### PR TITLE
docs: track implementation of system ntp threshold action

### DIFF
--- a/docs/next-features/ntp-threshold-action.md
+++ b/docs/next-features/ntp-threshold-action.md
@@ -1,0 +1,23 @@
+# Next Feature: `system ntp threshold <ms> action <accept|reject>`
+
+## Config Evidence
+- Present in `/home/ps/git/bpfrx/vsrx.conf:109` as `threshold 400 action accept;`
+
+## Current State
+- Parsed into `SystemConfig.NTPThreshold` and `NTPThresholdAction`: `pkg/config/compiler.go`
+- Runtime NTP apply only writes chrony server lines and reloads sources: `pkg/daemon/daemon.go` (`applySystemNTP`)
+- Threshold/action values are currently ignored
+
+## Problem
+Time discipline behavior differs from operator intent in configs that rely on explicit threshold policy. Failover and session-sync systems can be sensitive to clock behavior, so silently ignoring this knob is risky.
+
+## Proposed Implementation Scope
+1. Map threshold/action into chrony-compatible controls (or enforce in bpfrxd wrapper logic if chrony mapping is insufficient).
+2. Expose active threshold mode in operational output.
+3. Emit warning when configured value cannot be represented exactly.
+4. Add tests for accept/reject behaviors and config rendering.
+
+## Acceptance Criteria
+- Configured threshold/action changes runtime NTP behavior deterministically.
+- `show` output reflects effective threshold policy.
+- Unsupported combinations produce explicit warning, not silent ignore.


### PR DESCRIPTION
## Summary
- add next-feature spec for `system ntp threshold ... action ...` from `vsrx.conf`
- document current parser-only behavior and daemon gap
- define implementation scope and acceptance criteria

## Why
`vsrx.conf` configures NTP threshold action, but `applySystemNTP` currently ignores these fields and only configures servers.

## Testing
- docs-only change
