### PR TITLE
Improve command completion robustness and coverage

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -18,51 +18,10 @@ type completionCandidate struct {
 
 // completeFromTreeWithDesc mirrors completeFromTree but returns name+desc pairs.
 func completeFromTreeWithDesc(tree map[string]*completionNode, words []string, partial string, cfg *config.Config) []completionCandidate {
-	current := tree
-	var currentNode *completionNode
-	dynamicConsumed := false // true when last word was a dynamic value
-	for wi, w := range words {
-		dynamicConsumed = false
-		node, ok := current[w]
-		if !ok {
-			if currentNode != nil && currentNode.HasDynamic() {
-				dynamicConsumed = true
-				continue
-			}
-			return nil
-		}
-		currentNode = node
-		if node.Children == nil {
-			if node.HasDynamic() && wi < len(words)-1 {
-				dynamicConsumed = true
-				continue
-			}
-			if node.HasDynamic() && cfg != nil {
-				var candidates []completionCandidate
-				for _, name := range node.DynamicValues(cfg, words) {
-					if strings.HasPrefix(name, partial) {
-						candidates = append(candidates, completionCandidate{name: name, desc: "(configured)"})
-					}
-				}
-				return candidates
-			}
-			return nil
-		}
-		current = node.Children
-	}
-
-	var candidates []completionCandidate
-	for name, node := range current {
-		if strings.HasPrefix(name, partial) {
-			candidates = append(candidates, completionCandidate{name: name, desc: node.Desc})
-		}
-	}
-	if !dynamicConsumed && currentNode != nil && currentNode.HasDynamic() && cfg != nil {
-		for _, name := range currentNode.DynamicValues(cfg, words) {
-			if strings.HasPrefix(name, partial) {
-				candidates = append(candidates, completionCandidate{name: name, desc: "(configured)"})
-			}
-		}
+	treeCands := cmdtree.CompleteFromTreeWithDesc(tree, words, partial, cfg)
+	candidates := make([]completionCandidate, 0, len(treeCands))
+	for _, c := range treeCands {
+		candidates = append(candidates, completionCandidate{name: c.Name, desc: c.Desc})
 	}
 	return candidates
 }

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -60,22 +60,22 @@ var OperationalTree = map[string]*Node{
 	"show": {Desc: "Show system information", Children: map[string]*Node{
 		"chassis": {Desc: "Show chassis information", Children: map[string]*Node{
 			"cluster": {Desc: "Show cluster/HA status", Children: map[string]*Node{
-			"status":      {Desc: "Show cluster node status"},
-			"interfaces":  {Desc: "Show cluster interfaces"},
-			"information": {Desc: "Show cluster configuration details"},
-			"statistics":  {Desc: "Show cluster statistics"},
-			"control-plane": {Desc: "Show control-plane information", Children: map[string]*Node{
-				"statistics": {Desc: "Show control-plane statistics"},
+				"status":      {Desc: "Show cluster node status"},
+				"interfaces":  {Desc: "Show cluster interfaces"},
+				"information": {Desc: "Show cluster configuration details"},
+				"statistics":  {Desc: "Show cluster statistics"},
+				"control-plane": {Desc: "Show control-plane information", Children: map[string]*Node{
+					"statistics": {Desc: "Show control-plane statistics"},
+				}},
+				"data-plane": {Desc: "Show data-plane information", Children: map[string]*Node{
+					"statistics": {Desc: "Show data-plane statistics"},
+					"interfaces": {Desc: "Show data-plane interfaces"},
+				}},
+				"ip-monitoring": {Desc: "Show IP monitoring information", Children: map[string]*Node{
+					"status": {Desc: "Show IP monitoring status"},
+				}},
+				"fence-status": {Desc: "Show peer fencing configuration and history"},
 			}},
-			"data-plane": {Desc: "Show data-plane information", Children: map[string]*Node{
-				"statistics": {Desc: "Show data-plane statistics"},
-				"interfaces": {Desc: "Show data-plane interfaces"},
-			}},
-			"ip-monitoring": {Desc: "Show IP monitoring information", Children: map[string]*Node{
-				"status": {Desc: "Show IP monitoring status"},
-			}},
-			"fence-status": {Desc: "Show peer fencing configuration and history"},
-		}},
 			"alarms":         {Desc: "Show chassis alarm status"},
 			"environment":    {Desc: "Show chassis environment"},
 			"hardware":       {Desc: "Show installed hardware components"},
@@ -129,11 +129,23 @@ var OperationalTree = map[string]*Node{
 				"longer":   {Desc: "More-specific (longer) prefixes"},
 				"orlonger": {Desc: "Equal or more-specific prefixes"},
 			}},
-			"terse":         {Desc: "Display terse output"},
-			"detail":        {Desc: "Display detailed output"},
-			"summary":       {Desc: "Show routing table statistics"},
-			"table":         {Desc: "Show routes in named routing table"},
-			"protocol":      {Desc: "Show routes learned from named protocol"},
+			"terse":   {Desc: "Display terse output"},
+			"detail":  {Desc: "Display detailed output"},
+			"summary": {Desc: "Show routing table statistics"},
+			"table": {Desc: "Show routes in named routing table", DynamicFn: func(cfg *config.Config) []string {
+				if cfg == nil {
+					return []string{"inet.0", "inet6.0"}
+				}
+				// Include main tables plus per-instance tables.
+				names := []string{"inet.0", "inet6.0"}
+				for _, ri := range cfg.RoutingInstances {
+					names = append(names, ri.Name+".inet.0", ri.Name+".inet6.0")
+				}
+				return names
+			}},
+			"protocol": {Desc: "Show routes learned from named protocol", DynamicFn: func(_ *config.Config) []string {
+				return []string{"static", "direct", "local", "ospf", "bgp", "rip", "isis", "kernel", "connected"}
+			}},
 			"instance": {Desc: "Show routes for a routing instance", DynamicFn: func(cfg *config.Config) []string {
 				if cfg == nil {
 					return nil
@@ -162,9 +174,9 @@ var OperationalTree = map[string]*Node{
 			"policies": {Desc: "Show security firewall policies", Children: map[string]*Node{
 				"global":      {Desc: "Show global security policy information"},
 				"policy-name": {Desc: "Show policy matching a specific name"},
-				"brief":     {Desc: "Show brief policy summary"},
-				"detail":    {Desc: "Show detailed policy information"},
-				"hit-count": {Desc: "Show policy hit counters [from-zone X to-zone Y]"},
+				"brief":       {Desc: "Show brief policy summary"},
+				"detail":      {Desc: "Show detailed policy information"},
+				"hit-count":   {Desc: "Show policy hit counters [from-zone X to-zone Y]"},
 				"from-zone": {Desc: "Filter by source zone", DynamicFn: func(cfg *config.Config) []string {
 					if cfg == nil {
 						return nil
@@ -281,22 +293,22 @@ var OperationalTree = map[string]*Node{
 			}},
 			"nat": {Desc: "Show Network Address Translation information", Children: map[string]*Node{
 				"source": {Desc: "Show source NAT", Children: map[string]*Node{
-					"summary":              {Desc: "Show source NAT summary"},
-					"pool":                 {Desc: "Show source NAT pools"},
+					"summary": {Desc: "Show source NAT summary"},
+					"pool":    {Desc: "Show source NAT pools"},
 					"persistent-nat-table": {Desc: "Show persistent NAT bindings", Children: map[string]*Node{
 						"detail": {Desc: "Show detailed persistent NAT bindings"},
 					}},
 					"rule": {Desc: "Show source NAT rules", Children: map[string]*Node{
 						"detail": {Desc: "Show detailed source NAT rules"},
 					}},
-					"rule-set":             {Desc: "Show source NAT rule sets"},
+					"rule-set": {Desc: "Show source NAT rule sets"},
 					"deterministic-nat": {Desc: "Show deterministic NAT information", Children: map[string]*Node{
 						"nat-table": {Desc: "Show deterministic NAT mapping table"},
 					}},
 				}},
 				"destination": {Desc: "Show destination NAT", Children: map[string]*Node{
-					"summary":  {Desc: "Show destination NAT summary"},
-					"pool":     {Desc: "Show destination NAT pools"},
+					"summary": {Desc: "Show destination NAT summary"},
+					"pool":    {Desc: "Show destination NAT pools"},
 					"rule": {Desc: "Show destination NAT rules", Children: map[string]*Node{
 						"detail": {Desc: "Show detailed destination NAT rules"},
 					}},
@@ -366,17 +378,17 @@ var OperationalTree = map[string]*Node{
 				"routes":    {Desc: "Show OSPF routes"},
 			}},
 			"bgp": {Desc: "Show BGP information", Children: map[string]*Node{
-				"summary":  {Desc: "Show BGP peer summary"},
-				"routes":   {Desc: "Show BGP routes"},
+				"summary": {Desc: "Show BGP peer summary"},
+				"routes":  {Desc: "Show BGP routes"},
 				"neighbor": {Desc: "Show BGP neighbor details", Children: map[string]*Node{
-					"received-routes":  {Desc: "Show received routes from neighbor"},
+					"received-routes":   {Desc: "Show received routes from neighbor"},
 					"advertised-routes": {Desc: "Show advertised routes to neighbor"},
 				}},
 			}},
 			"bfd": {Desc: "Show BFD status", Children: map[string]*Node{
 				"peers": {Desc: "Show BFD peer status"},
 			}},
-			"rip":  {Desc: "Show RIP information"},
+			"rip": {Desc: "Show RIP information"},
 			"isis": {Desc: "Show IS-IS information", Children: map[string]*Node{
 				"adjacency": {Desc: "Show IS-IS adjacencies", Children: map[string]*Node{
 					"detail": {Desc: "Show detailed IS-IS adjacency information"},
@@ -389,8 +401,8 @@ var OperationalTree = map[string]*Node{
 			}},
 		}},
 		"bgp": {Desc: "Show BGP information (alias for show protocols bgp)", Children: map[string]*Node{
-			"summary":  {Desc: "Show BGP peer summary"},
-			"routes":   {Desc: "Show BGP routes"},
+			"summary": {Desc: "Show BGP peer summary"},
+			"routes":  {Desc: "Show BGP routes"},
 			"neighbor": {Desc: "Show BGP neighbor details", Children: map[string]*Node{
 				"received-routes":   {Desc: "Show received routes from neighbor"},
 				"advertised-routes": {Desc: "Show advertised routes to neighbor"},
@@ -403,8 +415,8 @@ var OperationalTree = map[string]*Node{
 			"neighbors":            {Desc: "Show IPv6 neighbor cache"},
 			"router-advertisement": {Desc: "Show Router Advertisement status"},
 		}},
-		"schedulers":        {Desc: "Show policy schedulers"},
-		"dhcp-relay":        {Desc: "Show DHCP relay status"},
+		"schedulers": {Desc: "Show policy schedulers"},
+		"dhcp-relay": {Desc: "Show DHCP relay status"},
 		"dhcp-server": {Desc: "Show DHCP server leases", Children: map[string]*Node{
 			"detail": {Desc: "Show detailed DHCP server information with pool utilization"},
 		}},
@@ -420,20 +432,20 @@ var OperationalTree = map[string]*Node{
 			"commit": {Desc: "Show pending and historical commit information", Children: map[string]*Node{
 				"history": {Desc: "Show recent commit log"},
 			}},
-			"connections":   {Desc: "Show system connection activity"},
-			"core-dumps":    {Desc: "Show system core dumps"},
+			"connections": {Desc: "Show system connection activity"},
+			"core-dumps":  {Desc: "Show system core dumps"},
 			"rollback": {Desc: "Show rolled back configuration", Children: map[string]*Node{
 				"compare": {Desc: "Compare rollback with active config"},
 			}},
-			"backup-router":      {Desc: "Show backup router configuration"},
+			"backup-router": {Desc: "Show backup router configuration"},
 			"buffers": {Desc: "Show buffer utilization", Children: map[string]*Node{
 				"detail": {Desc: "Show detailed per-map statistics"},
 			}},
-			"internet-options":   {Desc: "Show internet options"},
-			"license":            {Desc: "Show system license"},
-			"login":              {Desc: "Show login configuration"},
-			"memory":             {Desc: "Show system memory usage"},
-			"ntp":                {Desc: "Show NTP status"},
+			"internet-options": {Desc: "Show internet options"},
+			"license":          {Desc: "Show system license"},
+			"login":            {Desc: "Show login configuration"},
+			"memory":           {Desc: "Show system memory usage"},
+			"ntp":              {Desc: "Show NTP status"},
 			"processes": {Desc: "Show system process table", Children: map[string]*Node{
 				"summary": {Desc: "Show summary of system processes (top-like view)"},
 			}},
@@ -441,25 +453,25 @@ var OperationalTree = map[string]*Node{
 			"configuration": {Desc: "Show configuration info", Children: map[string]*Node{
 				"rescue": {Desc: "Show rescue configuration"},
 			}},
-			"services":           {Desc: "Show configured system services"},
-			"storage":            {Desc: "Show local filesystem usage"},
-			"syslog":             {Desc: "Show system syslog configuration"},
-			"uptime":             {Desc: "Show time since last reboot"},
-			"users":              {Desc: "Show configured login users"},
+			"services": {Desc: "Show configured system services"},
+			"storage":  {Desc: "Show local filesystem usage"},
+			"syslog":   {Desc: "Show system syslog configuration"},
+			"uptime":   {Desc: "Show time since last reboot"},
+			"users":    {Desc: "Show configured login users"},
 		}},
-		"task": {Desc: "Show daemon task/runtime information"},
-		"route-map":          {Desc: "Show route-map information"},
-		"routing-options":    {Desc: "Show routing options"},
+		"task":            {Desc: "Show daemon task/runtime information"},
+		"route-map":       {Desc: "Show route-map information"},
+		"routing-options": {Desc: "Show routing options"},
 		"routing-instances": {Desc: "Show routing instances", Children: map[string]*Node{
 			"detail": {Desc: "Show detailed routing instance information"},
 		}},
-		"policy-options":     {Desc: "Show policy options"},
-		"event-options":      {Desc: "Show event policies"},
+		"policy-options": {Desc: "Show policy options"},
+		"event-options":  {Desc: "Show event policies"},
 		"forwarding-options": {Desc: "Show forwarding options", Children: map[string]*Node{
 			"port-mirroring": {Desc: "Show port mirroring instances"},
 		}},
-		"vlans":              {Desc: "Show VLAN configuration"},
-		"version":            {Desc: "Show software process revision levels"},
+		"vlans":   {Desc: "Show VLAN configuration"},
+		"version": {Desc: "Show software process revision levels"},
 		"monitor": {Desc: "Show monitor information", Children: map[string]*Node{
 			"security": {Desc: "Show security monitor information", Children: map[string]*Node{
 				"flow": {Desc: "Show security flow monitor status"},
@@ -615,15 +627,50 @@ var OperationalTree = map[string]*Node{
 		"chassis": {Desc: "Perform chassis-specific operations", Children: map[string]*Node{
 			"cluster": {Desc: "Cluster operations", Children: map[string]*Node{
 				"failover": {Desc: "Trigger cluster failover", Children: map[string]*Node{
-					"redundancy-group": {Desc: "Failover a specific redundancy group"},
-					"reset":            {Desc: "Reset manual failover", Children: map[string]*Node{
-						"redundancy-group": {Desc: "Reset failover for a redundancy group"},
+					"redundancy-group": {Desc: "Failover a specific redundancy group", DynamicFn: func(cfg *config.Config) []string {
+						if cfg == nil || cfg.Chassis.Cluster == nil {
+							return nil
+						}
+						names := make([]string, 0, len(cfg.Chassis.Cluster.RedundancyGroups))
+						for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
+							names = append(names, fmt.Sprintf("%d", rg.ID))
+						}
+						return names
+					}, Children: map[string]*Node{
+						"node": {Desc: "Target node ID (local or peer)", DynamicFn: func(cfg *config.Config) []string {
+							if cfg == nil || cfg.Chassis.Cluster == nil {
+								return []string{"0", "1"}
+							}
+							// Cluster is currently 2-node only.
+							return []string{"0", "1"}
+						}},
+					}},
+					"reset": {Desc: "Reset manual failover", Children: map[string]*Node{
+						"redundancy-group": {Desc: "Reset failover for a redundancy group", DynamicFn: func(cfg *config.Config) []string {
+							if cfg == nil || cfg.Chassis.Cluster == nil {
+								return nil
+							}
+							names := make([]string, 0, len(cfg.Chassis.Cluster.RedundancyGroups))
+							for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
+								names = append(names, fmt.Sprintf("%d", rg.ID))
+							}
+							return names
+						}},
 					}},
 				}},
 			}},
 		}},
 		"dhcp": {Desc: "Perform DHCP operations", Children: map[string]*Node{
-			"renew": {Desc: "Renew DHCP lease on an interface"},
+			"renew": {Desc: "Renew DHCP lease on an interface", DynamicFn: func(cfg *config.Config) []string {
+				if cfg == nil || cfg.Interfaces.Interfaces == nil {
+					return nil
+				}
+				names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+				for name := range cfg.Interfaces.Interfaces {
+					names = append(names, name)
+				}
+				return names
+			}},
 		}},
 		"protocols": {Desc: "Protocol operations", Children: map[string]*Node{
 			"ospf": {Desc: "OSPF operations", Children: map[string]*Node{
@@ -715,10 +762,10 @@ var OperationalTree = map[string]*Node{
 		}},
 	}},
 	"ping": {Desc: "Ping remote host", Children: map[string]*Node{
-		"<host>":  {Desc: "Hostname or IP address of remote host"},
-		"count":   {Desc: "Number of ping requests to send"},
-		"source":  {Desc: "Source address to use"},
-		"size":    {Desc: "Request data size in bytes"},
+		"<host>": {Desc: "Hostname or IP address of remote host"},
+		"count":  {Desc: "Number of ping requests to send"},
+		"source": {Desc: "Source address to use"},
+		"size":   {Desc: "Request data size in bytes"},
 		"routing-instance": {Desc: "Routing instance for route lookup", DynamicFn: func(cfg *config.Config) []string {
 			if cfg == nil {
 				return nil
@@ -744,8 +791,8 @@ var OperationalTree = map[string]*Node{
 			return names
 		}},
 	}},
-	"quit":       {Desc: "Exit CLI"},
-	"exit":       {Desc: "Exit CLI"},
+	"quit": {Desc: "Exit CLI"},
+	"exit": {Desc: "Exit CLI"},
 }
 
 // ConfigTopLevel defines tab completion for config mode top-level commands.
@@ -828,8 +875,15 @@ func CompleteFromTree(tree map[string]*Node, words []string, partial string, cfg
 			}
 			// Check for placeholder node that consumes any value
 			if ph := findPlaceholder(current); ph != nil {
-				// Placeholder consumed this word; stay at same tree level
-				// so sibling options remain available for completion
+				// Placeholder consumed this word. If the placeholder has
+				// children, descend so follow-on keywords can complete
+				// (e.g. "show route <dest> exact"). Otherwise stay at this
+				// level so sibling options remain available (e.g. "ping
+				// <host> count").
+				if ph.Children != nil {
+					currentNode = ph
+					current = ph.Children
+				}
 				dynamicConsumed = true
 				continue
 			}
@@ -870,6 +924,10 @@ func CompleteFromTreeWithDesc(tree map[string]*Node, words []string, partial str
 			}
 			// Check for placeholder node that consumes any value
 			if ph := findPlaceholder(current); ph != nil {
+				if ph.Children != nil {
+					currentNode = ph
+					current = ph.Children
+				}
 				dynamicConsumed = true
 				continue
 			}
@@ -958,11 +1016,15 @@ func LookupDesc(words []string, name string, configMode bool) string {
 		node, ok := current[w]
 		if !ok {
 			// Dynamic value — skip but stay at same children level.
-			if currentNode != nil && currentNode.DynamicFn != nil {
+			if currentNode != nil && currentNode.HasDynamic() {
 				continue
 			}
 			// Placeholder node consumes any value.
-			if findPlaceholder(current) != nil {
+			if ph := findPlaceholder(current); ph != nil {
+				if ph.Children != nil {
+					currentNode = ph
+					current = ph.Children
+				}
 				continue
 			}
 			return ""

--- a/pkg/cmdtree/tree_test.go
+++ b/pkg/cmdtree/tree_test.go
@@ -1,0 +1,71 @@
+package cmdtree
+
+import (
+	"testing"
+
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompleteFromTree_PlaceholderWithChildrenDescends(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"show", "route", "10.0.0.1"}, "", nil)
+	if !contains(cands, "exact") || !contains(cands, "longer") || !contains(cands, "orlonger") {
+		t.Fatalf("expected destination modifiers after placeholder, got %v", cands)
+	}
+	if contains(cands, "summary") {
+		t.Fatalf("unexpected sibling completions after destination placeholder: %v", cands)
+	}
+}
+
+func TestCompleteFromTree_PlaceholderWithoutChildrenStaysLevel(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"ping", "8.8.8.8"}, "", nil)
+	if !contains(cands, "count") || !contains(cands, "source") || !contains(cands, "size") {
+		t.Fatalf("expected ping option completions after host placeholder, got %v", cands)
+	}
+}
+
+func TestCompleteFromTree_RequestFailoverSupportsNodeAfterRGValue(t *testing.T) {
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{
+			Cluster: &config.ClusterConfig{
+				RedundancyGroups: []*config.RedundancyGroup{
+					{ID: 1},
+				},
+			},
+		},
+	}
+
+	cands := CompleteFromTree(
+		OperationalTree,
+		[]string{"request", "chassis", "cluster", "failover", "redundancy-group", "1"},
+		"",
+		cfg,
+	)
+	if !contains(cands, "node") {
+		t.Fatalf("expected 'node' completion after redundancy-group value, got %v", cands)
+	}
+}
+
+func TestCompleteFromTree_ShowRouteTableDynamicNames(t *testing.T) {
+	cfg := &config.Config{
+		RoutingInstances: []*config.RoutingInstanceConfig{
+			{Name: "blue"},
+		},
+	}
+
+	cands := CompleteFromTree(OperationalTree, []string{"show", "route", "table"}, "", cfg)
+	if !contains(cands, "inet.0") || !contains(cands, "inet6.0") {
+		t.Fatalf("expected default table names, got %v", cands)
+	}
+	if !contains(cands, "blue.inet.0") || !contains(cands, "blue.inet6.0") {
+		t.Fatalf("expected per-instance table names, got %v", cands)
+	}
+}

--- a/pkg/grpcapi/completion_test.go
+++ b/pkg/grpcapi/completion_test.go
@@ -1,0 +1,28 @@
+package grpcapi
+
+import "testing"
+
+func hasPairName(pairs []completionPair, want string) bool {
+	for _, p := range pairs {
+		if p.name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompleteConfigPairsCommitReturnsAllMatches(t *testing.T) {
+	s := &Server{}
+	pairs := s.completeConfigPairs([]string{"commit"}, "")
+	if !hasPairName(pairs, "check") || !hasPairName(pairs, "confirmed") {
+		t.Fatalf("expected both commit completions, got %#v", pairs)
+	}
+}
+
+func TestCompleteConfigPairsLoadReturnsAllMatches(t *testing.T) {
+	s := &Server{}
+	pairs := s.completeConfigPairs([]string{"load"}, "")
+	if !hasPairName(pairs, "override") || !hasPairName(pairs, "merge") {
+		t.Fatalf("expected both load completions, got %#v", pairs)
+	}
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -40,59 +40,59 @@ import (
 	"github.com/psaab/bpfrx/pkg/frr"
 	pb "github.com/psaab/bpfrx/pkg/grpcapi/bpfrxv1"
 	"github.com/psaab/bpfrx/pkg/ipsec"
-	"github.com/psaab/bpfrx/pkg/logging"
-	"github.com/psaab/bpfrx/pkg/routing"
 	"github.com/psaab/bpfrx/pkg/lldp"
+	"github.com/psaab/bpfrx/pkg/logging"
 	"github.com/psaab/bpfrx/pkg/ra"
+	"github.com/psaab/bpfrx/pkg/routing"
 	"github.com/psaab/bpfrx/pkg/rpm"
 	"github.com/psaab/bpfrx/pkg/vrrp"
 )
 
 // Config configures the gRPC server.
 type Config struct {
-	Store    *configstore.Store
-	DP       dataplane.DataPlane
-	EventBuf *logging.EventBuffer
-	GC       *conntrack.GC
-	Routing  *routing.Manager
-	FRR      *frr.Manager
-	IPsec    *ipsec.Manager
-	Cluster  *cluster.Manager
-	DHCP         *dhcp.Manager
-	DHCPServer   *dhcpserver.Manager
-	RPMResultsFn    func() []*rpm.ProbeResult      // returns live RPM results
+	Store           *configstore.Store
+	DP              dataplane.DataPlane
+	EventBuf        *logging.EventBuffer
+	GC              *conntrack.GC
+	Routing         *routing.Manager
+	FRR             *frr.Manager
+	IPsec           *ipsec.Manager
+	Cluster         *cluster.Manager
+	DHCP            *dhcp.Manager
+	DHCPServer      *dhcpserver.Manager
+	RPMResultsFn    func() []*rpm.ProbeResult        // returns live RPM results
 	FeedsFn         func() map[string]feeds.FeedInfo // returns live feed status
-	LLDPNeighborsFn func() []*lldp.Neighbor         // returns live LLDP neighbors
+	LLDPNeighborsFn func() []*lldp.Neighbor          // returns live LLDP neighbors
 	ApplyFn         func(*config.Config)             // daemon's applyConfig callback
 	VRRPMgr         *vrrp.Manager                    // native VRRP manager
 	RAMgr           *ra.Manager                      // embedded RA sender manager
-	Version      string                    // software version string
-	FabricPeerAddrFn func() string          // returns peer fabric IP (empty if standalone)
-	FabricVRFDevice  string                 // VRF for fabric interface (e.g. "vrf-mgmt")
+	Version          string                           // software version string
+	FabricPeerAddrFn func() string                    // returns peer fabric IP (empty if standalone)
+	FabricVRFDevice  string                           // VRF for fabric interface (e.g. "vrf-mgmt")
 }
 
 // Server implements the BpfrxService gRPC service.
 type Server struct {
 	pb.UnimplementedBpfrxServiceServer
-	store        *configstore.Store
-	dp           dataplane.DataPlane
-	eventBuf     *logging.EventBuffer
-	gc           *conntrack.GC
-	routing      *routing.Manager
-	frr          *frr.Manager
-	ipsec        *ipsec.Manager
-	cluster      *cluster.Manager
-	dhcp         *dhcp.Manager
-	dhcpServer   *dhcpserver.Manager
+	store           *configstore.Store
+	dp              dataplane.DataPlane
+	eventBuf        *logging.EventBuffer
+	gc              *conntrack.GC
+	routing         *routing.Manager
+	frr             *frr.Manager
+	ipsec           *ipsec.Manager
+	cluster         *cluster.Manager
+	dhcp            *dhcp.Manager
+	dhcpServer      *dhcpserver.Manager
 	rpmResultsFn    func() []*rpm.ProbeResult
 	feedsFn         func() map[string]feeds.FeedInfo
 	lldpNeighborsFn func() []*lldp.Neighbor
 	applyFn         func(*config.Config)
 	vrrpMgr         *vrrp.Manager
 	raMgr           *ra.Manager
-	startTime    time.Time
-	addr         string
-	version      string
+	startTime        time.Time
+	addr             string
+	version          string
 	fabricPeerAddrFn func() string
 	fabricVRFDevice  string
 }
@@ -103,25 +103,25 @@ type Server struct {
 // gRPC is ever exposed on non-loopback addresses.
 func NewServer(addr string, cfg Config) *Server {
 	return &Server{
-		store:        cfg.Store,
-		dp:           cfg.DP,
-		eventBuf:     cfg.EventBuf,
-		gc:           cfg.GC,
-		routing:      cfg.Routing,
-		frr:          cfg.FRR,
-		ipsec:        cfg.IPsec,
-		cluster:      cfg.Cluster,
-		dhcp:         cfg.DHCP,
-		dhcpServer:   cfg.DHCPServer,
+		store:           cfg.Store,
+		dp:              cfg.DP,
+		eventBuf:        cfg.EventBuf,
+		gc:              cfg.GC,
+		routing:         cfg.Routing,
+		frr:             cfg.FRR,
+		ipsec:           cfg.IPsec,
+		cluster:         cfg.Cluster,
+		dhcp:            cfg.DHCP,
+		dhcpServer:      cfg.DHCPServer,
 		rpmResultsFn:    cfg.RPMResultsFn,
 		feedsFn:         cfg.FeedsFn,
 		lldpNeighborsFn: cfg.LLDPNeighborsFn,
 		applyFn:         cfg.ApplyFn,
 		vrrpMgr:         cfg.VRRPMgr,
 		raMgr:           cfg.RAMgr,
-		startTime:    time.Now(),
-		addr:         addr,
-		version:      cfg.Version,
+		startTime:        time.Now(),
+		addr:             addr,
+		version:          cfg.Version,
 		fabricPeerAddrFn: cfg.FabricPeerAddrFn,
 		fabricVRFDevice:  cfg.FabricVRFDevice,
 	}
@@ -585,19 +585,19 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 	}
 
 	return &pb.GetGlobalStatsResponse{
-		RxPackets:           readCounter(dataplane.GlobalCtrRxPackets),
-		TxPackets:           readCounter(dataplane.GlobalCtrTxPackets),
-		Drops:               readCounter(dataplane.GlobalCtrDrops),
-		SessionsCreated:     readCounter(dataplane.GlobalCtrSessionsNew),
-		SessionsClosed:      readCounter(dataplane.GlobalCtrSessionsClosed),
-		ScreenDrops:         readCounter(dataplane.GlobalCtrScreenDrops),
-		PolicyDenies:        readCounter(dataplane.GlobalCtrPolicyDeny),
-		NatAllocFailures:    readCounter(dataplane.GlobalCtrNATAllocFail),
-		HostInboundDenies:   readCounter(dataplane.GlobalCtrHostInboundDeny),
-		TcEgressPackets:     readCounter(dataplane.GlobalCtrTCEgressPackets),
-		Nat64Translations:   readCounter(dataplane.GlobalCtrNAT64Xlate),
-		HostInboundAllowed:  readCounter(dataplane.GlobalCtrHostInbound),
-		ScreenDropDetails:   screenDetails,
+		RxPackets:          readCounter(dataplane.GlobalCtrRxPackets),
+		TxPackets:          readCounter(dataplane.GlobalCtrTxPackets),
+		Drops:              readCounter(dataplane.GlobalCtrDrops),
+		SessionsCreated:    readCounter(dataplane.GlobalCtrSessionsNew),
+		SessionsClosed:     readCounter(dataplane.GlobalCtrSessionsClosed),
+		ScreenDrops:        readCounter(dataplane.GlobalCtrScreenDrops),
+		PolicyDenies:       readCounter(dataplane.GlobalCtrPolicyDeny),
+		NatAllocFailures:   readCounter(dataplane.GlobalCtrNATAllocFail),
+		HostInboundDenies:  readCounter(dataplane.GlobalCtrHostInboundDeny),
+		TcEgressPackets:    readCounter(dataplane.GlobalCtrTCEgressPackets),
+		Nat64Translations:  readCounter(dataplane.GlobalCtrNAT64Xlate),
+		HostInboundAllowed: readCounter(dataplane.GlobalCtrHostInbound),
+		ScreenDropDetails:  screenDetails,
 	}, nil
 }
 
@@ -1517,8 +1517,8 @@ func (s *Server) showInterfacesTerse(cfg *config.Config, filterName string) (*pb
 	// Add peer node interfaces (cluster mode).
 	// Peer interfaces don't exist locally — compile the peer's config from the
 	// raw tree and extract interfaces not in our compiled config.
-	peerIfaces := make(map[string]bool)    // peer-only interface names
-	peerLinkUp := make(map[string]bool)    // peer interface link status from heartbeat
+	peerIfaces := make(map[string]bool) // peer-only interface names
+	peerLinkUp := make(map[string]bool) // peer interface link status from heartbeat
 	if s.cluster != nil {
 		// Determine peer node ID.
 		peerNodeID := -1
@@ -2632,16 +2632,20 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 		return pairs
 	case "commit":
 		if len(words) == 1 {
+			var pairs []completionPair
 			for _, name := range cmdtree.FilterPrefix([]string{"check", "confirmed"}, partial) {
-				return []completionPair{{name: name}}
+				pairs = append(pairs, completionPair{name: name})
 			}
+			return pairs
 		}
 		return nil
 	case "load":
 		if len(words) == 1 {
+			var pairs []completionPair
 			for _, name := range cmdtree.FilterPrefix([]string{"override", "merge"}, partial) {
-				return []completionPair{{name: name}}
+				pairs = append(pairs, completionPair{name: name})
 			}
+			return pairs
 		}
 		return nil
 	default:
@@ -2909,11 +2913,11 @@ func sessionEntryV4(key dataplane.SessionKey, val dataplane.SessionValue, now ui
 		EgressZone:      uint32(val.EgressZone),
 		IngressZoneName: zoneNames[val.IngressZone],
 		EgressZoneName:  zoneNames[val.EgressZone],
-		FwdPackets:     val.FwdPackets,
-		FwdBytes:       val.FwdBytes,
-		RevPackets:     val.RevPackets,
-		RevBytes:       val.RevBytes,
-		TimeoutSeconds: val.Timeout,
+		FwdPackets:      val.FwdPackets,
+		FwdBytes:        val.FwdBytes,
+		RevPackets:      val.RevPackets,
+		RevBytes:        val.RevBytes,
+		TimeoutSeconds:  val.Timeout,
 	}
 	if val.Created > 0 && now > val.Created {
 		se.AgeSeconds = int64(now - val.Created)
@@ -2944,11 +2948,11 @@ func sessionEntryV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, no
 		EgressZone:      uint32(val.EgressZone),
 		IngressZoneName: zoneNames[val.IngressZone],
 		EgressZoneName:  zoneNames[val.EgressZone],
-		FwdPackets:     val.FwdPackets,
-		FwdBytes:       val.FwdBytes,
-		RevPackets:     val.RevPackets,
-		RevBytes:       val.RevBytes,
-		TimeoutSeconds: val.Timeout,
+		FwdPackets:      val.FwdPackets,
+		FwdBytes:        val.FwdBytes,
+		RevPackets:      val.RevPackets,
+		RevBytes:        val.RevBytes,
+		TimeoutSeconds:  val.Timeout,
 	}
 	if val.Created > 0 && now > val.Created {
 		se.AgeSeconds = int64(now - val.Created)


### PR DESCRIPTION
## Summary
- unify local CLI completion to use canonical `cmdtree` completion logic so local CLI and gRPC CLI stay in sync
- fix placeholder traversal so placeholders with child nodes descend correctly (for example, `show route <destination> exact|longer|orlonger`)
- add dynamic completions for:
  - `show route table <name>` (includes `inet.0`, `inet6.0`, and per-instance tables)
  - `request chassis cluster failover redundancy-group <id> [node <id>]`
  - `request dhcp renew <interface>`
- fix gRPC config-mode completion bug where `commit`/`load` returned only the first matching candidate
- add regression tests for cmdtree completion behavior and gRPC completion candidate sets

## Testing
- `go test ./pkg/cmdtree ./pkg/grpcapi ./pkg/cli ./cmd/cli`
