### PR TITLE
vrrp: prevent preempt-before-sync on startup/rejoin

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -235,6 +235,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if err := d.vrrpMgr.Start(context.Background()); err != nil {
 		slog.Warn("failed to start VRRP manager", "err", err)
 	}
+	// On fresh cluster daemon start, suppress VRRP preemption until session
+	// bulk sync completes (or timeout) to avoid preempt-before-sync outages.
+	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
+		cc := cfg.Chassis.Cluster
+		if cc.FabricInterface != "" && cc.FabricPeerAddress != "" {
+			d.vrrpMgr.SetSyncHold(30 * time.Second)
+		}
+	}
 
 	// Create dataplane backend (unless in config-only mode)
 	if !d.opts.NoDataplane {
@@ -3522,14 +3530,6 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				}
 				slog.Info("cluster: pushing config to reconnected peer")
 				d.pushConfigToPeer()
-			}
-
-			// Enable VRRP sync hold on fresh daemon start: suppress preemption
-			// until bulk session sync completes from the peer. This prevents
-			// the returning high-priority node from preempting before it has
-			// session state, which would break all existing connections.
-			if time.Since(d.startTime) < 30*time.Second {
-				d.vrrpMgr.SetSyncHold(30 * time.Second)
 			}
 
 			d.sessionSync.OnBulkSyncReceived = func() {

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -197,6 +197,22 @@ func (vi *vrrpInstance) updateConfig(cfg Instance) {
 	vi.mu.Unlock()
 }
 
+// suppressPreempt forces effective preempt to false while preserving the
+// configured desiredPreempt value for later restore.
+func (vi *vrrpInstance) suppressPreempt() {
+	vi.mu.Lock()
+	vi.cfg.Preempt = false
+	vi.mu.Unlock()
+}
+
+// setDesiredPreempt updates the configured preempt value that should be
+// restored when sync hold is released.
+func (vi *vrrpInstance) setDesiredPreempt(preempt bool) {
+	vi.mu.Lock()
+	vi.desiredPreempt = preempt
+	vi.mu.Unlock()
+}
+
 // restorePreempt sets cfg.Preempt to the configured (desired) value.
 // Called when sync hold is released to re-enable preemption.
 func (vi *vrrpInstance) restorePreempt() {

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -87,8 +87,21 @@ func (m *Manager) Stop() {
 func (m *Manager) SetSyncHold(timeout time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	if m.syncHoldTimer != nil {
+		m.syncHoldTimer.Stop()
+		m.syncHoldTimer = nil
+	}
+	wasHeld := m.syncHold
 	m.syncHold = true
 	m.syncHoldReason = ""
+	if !wasHeld {
+		for _, vi := range m.instances {
+			vi.suppressPreempt()
+		}
+	}
 	m.syncHoldTimer = time.AfterFunc(timeout, func() {
 		slog.Warn("vrrp: sync-hold timeout: bulk sync did not complete within timeout, releasing in degraded mode",
 			"timeout", timeout)
@@ -116,6 +129,7 @@ func (m *Manager) releaseSyncHoldWithReason(reason string) {
 	m.syncHoldReason = reason
 	if m.syncHoldTimer != nil {
 		m.syncHoldTimer.Stop()
+		m.syncHoldTimer = nil
 	}
 	for _, vi := range m.instances {
 		vi.restorePreempt()
@@ -176,7 +190,14 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 			if vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
 				slog.Info("vrrp: priority update", "key", existing.key(),
 					"old_pri", existing.cfg.Priority, "new_pri", inst.Priority)
-				existing.updateConfig(*inst)
+				instCfg := *inst
+				if m.syncHold {
+					instCfg.Preempt = false
+				}
+				existing.updateConfig(instCfg)
+				if m.syncHold {
+					existing.setDesiredPreempt(inst.Preempt)
+				}
 				continue
 			}
 			// VIPs changed — must restart instance.

--- a/pkg/vrrp/vrrp_test.go
+++ b/pkg/vrrp/vrrp_test.go
@@ -547,6 +547,129 @@ func TestSyncHold_SuppressesPreempt(t *testing.T) {
 	}
 }
 
+func TestSyncHold_AppliesToExistingInstances(t *testing.T) {
+	m := NewManager()
+
+	vi := newInstance(Instance{
+		Interface: "eth0",
+		GroupID:   101,
+		Priority:  200,
+		Preempt:   true,
+	}, &net.Interface{Name: "eth0"}, m.eventCh, nil)
+
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{
+		{iface: "eth0", groupID: 101}: vi,
+	}
+	m.mu.Unlock()
+
+	m.SetSyncHold(5 * time.Second)
+	defer m.ReleaseSyncHold()
+
+	if vi.getPreempt() {
+		t.Error("expected existing instance preempt to be suppressed during sync hold")
+	}
+	vi.mu.RLock()
+	dp := vi.desiredPreempt
+	vi.mu.RUnlock()
+	if !dp {
+		t.Error("expected desiredPreempt to remain true while hold is active")
+	}
+}
+
+func TestUpdateInstances_PreservesSyncHoldForExistingInstances(t *testing.T) {
+	m := NewManager()
+
+	vi := newInstance(Instance{
+		Interface: "eth0",
+		GroupID:   101,
+		Priority:  200,
+		Preempt:   true,
+	}, &net.Interface{Name: "eth0"}, m.eventCh, nil)
+
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{
+		{iface: "eth0", groupID: 101}: vi,
+	}
+	m.mu.Unlock()
+
+	m.SetSyncHold(5 * time.Second)
+	defer m.ReleaseSyncHold()
+
+	desired := []*Instance{
+		{
+			Interface: "eth0",
+			GroupID:   101,
+			Priority:  150,
+			Preempt:   true,
+		},
+	}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances failed: %v", err)
+	}
+
+	if vi.getPreempt() {
+		t.Error("expected sync hold to keep preempt disabled on updated instance")
+	}
+	if got := vi.getPriority(); got != 150 {
+		t.Errorf("priority = %d, want 150", got)
+	}
+	vi.mu.RLock()
+	dp := vi.desiredPreempt
+	vi.mu.RUnlock()
+	if !dp {
+		t.Error("expected desiredPreempt to track configured preempt during hold")
+	}
+}
+
+func TestSyncHold_RearmStopsPreviousTimer(t *testing.T) {
+	m := NewManager()
+	vi := newInstance(Instance{
+		Interface: "eth0",
+		GroupID:   101,
+		Priority:  200,
+		Preempt:   true,
+	}, &net.Interface{Name: "eth0"}, m.eventCh, nil)
+
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{
+		{iface: "eth0", groupID: 101}: vi,
+	}
+	m.mu.Unlock()
+
+	m.SetSyncHold(30 * time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
+	m.SetSyncHold(120 * time.Millisecond)
+	defer m.ReleaseSyncHold()
+
+	time.Sleep(60 * time.Millisecond)
+
+	m.mu.RLock()
+	held := m.syncHold
+	m.mu.RUnlock()
+	if !held {
+		t.Fatal("expected sync hold to remain active after timer re-arm")
+	}
+	if reason := m.SyncHoldReason(); reason != "" {
+		t.Fatalf("expected empty sync hold reason while hold active, got %q", reason)
+	}
+
+	time.Sleep(90 * time.Millisecond)
+
+	m.mu.RLock()
+	held = m.syncHold
+	m.mu.RUnlock()
+	if held {
+		t.Fatal("expected sync hold to release after re-armed timeout")
+	}
+	if reason := m.SyncHoldReason(); reason != "timeout-degraded" {
+		t.Fatalf("expected timeout-degraded reason after timeout, got %q", reason)
+	}
+	if !vi.getPreempt() {
+		t.Fatal("expected preempt to be restored after timeout release")
+	}
+}
+
 func TestSyncHold_ReleaseTwiceIsNoop(t *testing.T) {
 	m := NewManager()
 	m.SetSyncHold(5 * time.Second)


### PR DESCRIPTION
## Summary
This fixes a VRRP sync-hold race during node restart/rejoin where a returning node could preempt before session sync was complete.

Fixes #96.

## What changed
- Enable VRRP sync hold at daemon startup (cluster+fabric mode) before initial config apply, so first `UpdateInstances()` already sees hold active.
- Make `SetSyncHold()` apply preempt suppression to already-running instances.
- Make `SetSyncHold()` stop/replace any prior timer when re-armed.
- Ensure `UpdateInstances()` keeps effective `preempt=false` while hold is active for in-place updates, while preserving configured `desiredPreempt` for later restore.
- Added regression tests for:
  - hold applies to existing instances
  - in-place updates preserve hold
  - timer re-arm does not early-release hold

## Validation
- `go test ./pkg/vrrp`
- `go test ./pkg/daemon`
