### PR TITLE
docs: reconcile backlog and status consistency across docs

### DIFF
--- a/docs/authoritative-backlog.md
+++ b/docs/authoritative-backlog.md
@@ -21,10 +21,10 @@ Use these sources in this order when there is disagreement:
 ### 1) vSRX parity gaps (from `docs/feature-gaps.md` row data)
 
 Row-level gap totals:
-- Missing: 125
-- Partial: 15
-- Parse-Only: 5
-- Total Open Gaps: 145
+- Missing: 122
+- Partial: 14
+- Parse-Only: 4
+- Total Open Gaps: 140
 
 Category totals:
 
@@ -49,7 +49,7 @@ Category totals:
 | 18. QoS / Class of Service | 7 | 1 | 0 | 8 |
 | 19. Multi-Tenancy | 4 | 0 | 0 | 4 |
 | 20. Management & Automation | 9 | 2 | 0 | 11 |
-| 21. Interface Enhancements | 4 | 2 | 1 | 7 |
+| 21. Interface Enhancements | 1 | 1 | 0 | 2 |
 | 22. System Enhancements | 5 | 1 | 2 | 8 |
 | 23. Miscellaneous Features | 6 | 0 | 0 | 6 |
 
@@ -96,6 +96,7 @@ These are not currently tracked as explicit rows in `docs/feature-gaps.md`.
 These are documented as implemented in `docs/phases.md` and should not remain in open status tables:
 
 - Sprint IF-1: LAG/ae, flexible VLAN tagging, interface bandwidth, point-to-point runtime wiring, primary/preferred wiring, interface description display
+- Remaining parity caveat in section 21: transparent mode is still missing, and primary/preferred is still partial for some device-originated traffic paths.
 - Sprint PR #67: `monitor security flow` and `monitor security packet-drop`
 - Sprint #68: HA fail-closed default + `set chassis cluster hitless-restart` opt-in
 - HA sync hardening sprint #69-#80 items called out as fixed in `docs/bugs.md`
@@ -103,33 +104,17 @@ These are documented as implemented in `docs/phases.md` and should not remain in
   - NO_NEIGH failover issue
   - Monotonic clock skew session expiry issue
 
-## Stale or contradictory documentation
+## Stale or historical docs
 
-### A) `docs/feature-gaps.md`
+### `docs/vsrx-gaps.md`
 
-- Top summary table reports 155 gaps, but row-level status totals produce 145 open gaps.
-- Section 21 still marks IF-1 interface items as missing/partial/parse-only despite IF-1 implemented status in `docs/phases.md`.
-- Parse-only summary table still includes items that were later wired.
-
-### B) Proposal docs that are now shipped
-
-- `docs/next-features/monitor-command.md` still reads as proposal, but monitor commands are documented as implemented in `docs/phases.md` and present in code.
-- `docs/ha-no-hitless-restart.md` still marked Proposed, but feature is documented as implemented in sprint #68 and wired in config/runtime.
-
-### C) `docs/sync-protocol.md` Known Issues drift
-
-- `NO_NEIGH after failover` and `Monotonic clock skew` are marked IN PROGRESS there, but marked FIXED in `docs/bugs.md`.
-
-### D) `docs/vsrx-gaps.md` drift
-
-- Contains legacy claims that conflict with later HA and interface implementation sprints.
+- Marked as a historical snapshot and superseded for active planning by `docs/feature-gaps.md` and this backlog file.
 
 ## Maintenance actions
 
-1. Rebuild `docs/feature-gaps.md` summary and section 21/parse-only statuses from current implementation evidence.
-2. Update proposal docs to either `Implemented` or move remaining deltas into explicit follow-up sections.
-3. Align `docs/sync-protocol.md` Known Issues with `docs/bugs.md` fixed state.
-4. Decide whether JTI/AppQoE/Cloud-init are in product scope; if yes, add explicit rows to `docs/feature-gaps.md`.
+1. Keep `docs/feature-gaps.md` summary totals in lockstep with row-level status changes.
+2. For `docs/next-features/*`, always include explicit `Date` and `Status` metadata and flip to `Implemented` when shipped.
+3. Decide whether JTI/AppQoE/Cloud-init are in product scope; if yes, add explicit rows to `docs/feature-gaps.md`.
 
 ## Reproducibility note
 

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -1,6 +1,6 @@
 # bpfrx vs Juniper vSRX Feature Gap Analysis
 
-Last updated: 2026-02-25
+Last updated: 2026-03-02
 
 ## Summary
 
@@ -14,7 +14,7 @@ Last updated: 2026-02-25
 | Advanced Threat Prevention | 5 | 1 | 0 | 6 |
 | User/Identity Firewall | 5 | 0 | 0 | 5 |
 | NAT Enhancements | 5 | 1 | 0 | 6 |
-| Screen/IDS Enhancements | 4 | 2 | 1 | 6 |
+| Screen/IDS Enhancements | 4 | 2 | 0 | 6 |
 | Security Flow Enhancements | 5 | 0 | 0 | 5 |
 | ALG Enhancements | 9 | 0 | 0 | 9 |
 | Security Logging Enhancements | 1 | 0 | 0 | 1 |
@@ -26,10 +26,10 @@ Last updated: 2026-02-25
 | QoS / Class of Service | 7 | 1 | 0 | 8 |
 | Multi-Tenancy | 4 | 0 | 0 | 4 |
 | Management & Automation | 9 | 2 | 0 | 11 |
-| Interface Enhancements | 4 | 2 | 1 | 7 |
+| Interface Enhancements | 1 | 1 | 0 | 2 |
 | System Enhancements | 5 | 1 | 2 | 8 |
 | Miscellaneous | 6 | 0 | 0 | 6 |
-| **TOTAL** | **132** | **17** | **6** | **155** |
+| **TOTAL** | **122** | **14** | **4** | **140** |
 
 **Implementation status key:**
 - **Fully Missing**: No config parsing or runtime support
@@ -374,14 +374,14 @@ bpfrx manages all interfaces with .link/.network files, supports VLANs, tunnel i
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
-| **Link Aggregation (LAG/ae)** | `interfaces ae0 ...; interfaces ge-0/0/0 gigether-options 802.3ad ae0` | Bundle physical links into aggregate ethernet for bandwidth and redundancy. Different from reth. | Medium | Missing |
+| **Link Aggregation (LAG/ae)** | `interfaces ae0 ...; interfaces ge-0/0/0 gigether-options 802.3ad ae0` | Bundle physical links into aggregate ethernet for bandwidth and redundancy. Different from reth. | Medium | Done (LACP/802.3ad parsing + bond/netdev generation + member enslaving) |
 | **Transparent Mode (L2 Bridging)** | `interfaces ... family ethernet-switching; bridge-domains ...` | Layer 2 bridge mode where firewall acts as transparent inline device. Zone-based policies still apply. MAC learning table. | Medium | Missing |
-| **Flexible VLAN Tagging** | `interfaces ... flexible-vlan-tagging; encapsulation flexible-ethernet-services` | Q-in-Q (802.1ad), flexible VLAN push/pop/swap operations. bpfrx has basic 802.1Q single-tag. | Low | Missing |
-| **Interface Bandwidth** | `interfaces ... bandwidth ...` | Set logical interface bandwidth for OSPF cost calculation and traffic-engineering | Low | Missing |
+| **Flexible VLAN Tagging** | `interfaces ... flexible-vlan-tagging; encapsulation flexible-ethernet-services` | Q-in-Q (802.1ad), flexible VLAN push/pop/swap operations. bpfrx has basic 802.1Q single-tag. | Low | Done (flexible-vlan-tagging + flexible-ethernet-services + inner-vlan parsing/wiring) |
+| **Interface Bandwidth** | `interfaces ... bandwidth ...` | Set logical interface bandwidth for OSPF cost calculation and traffic-engineering | Low | Done (parsed and rendered into FRR interface bandwidth) |
 | **IRB Interfaces** | `interfaces irb unit N family inet address ...; bridge-domains bd0 { vlan-id-list ...; routing-interface irb.0; }` | Integrated Routing and Bridging: kernel Linux bridge per bridge-domain, IRB addresses on bridge device, zone assignment, .netdev/.network generation | Medium | Done (config parsing, compiler, networkd bridge/member/IRB generation, zone resolution) |
-| **Point-to-Point** | `interfaces ... unit ... point-to-point` | Mark interface as point-to-point (affects OSPF network type, ND behavior) | Low | Parse-Only |
+| **Point-to-Point** | `interfaces ... unit ... point-to-point` | Mark interface as point-to-point (affects OSPF network type, ND behavior) | Low | Done (parsed and emitted as FRR OSPF point-to-point where applicable) |
 | **Primary/Preferred Address** | `interfaces ... unit ... family inet address ... primary/preferred` | Control which address is used for sourced traffic. Syslog source and networkd ordering implemented; not yet used for all device-originated traffic. | Low | Partial (syslog source + networkd ordering, not all traffic) |
-| **Interface Description** | `interfaces ... description "..."` | bpfrx parses descriptions. Verify they appear in `show interfaces` output. | Low | Partial (parsed, display may need verification) |
+| **Interface Description** | `interfaces ... description "..."` | bpfrx parses descriptions. Verify they appear in `show interfaces` output. | Low | Done (description displayed in interface output paths) |
 
 ---
 
@@ -433,11 +433,11 @@ Features commonly requested in enterprise deployments:
 
 8. **RADIUS/TACACS+ Authentication** - Enterprise AAA integration
 9. **SSL VPN / Remote Access VPN** - Remote worker connectivity
-10. **Aggressive Session Aging** - Session table management under load
+10. ~~**Aggressive Session Aging**~~ - **Done** (GC high/low-watermark early-ageout behavior)
 11. **Graceful Restart** - Non-stop routing (FRR already supports)
 12. **Twice NAT** - Complex NAT scenarios
 13. **Transparent Mode (L2)** - Inline transparent firewall deployment
-14. **Link Aggregation (LAG)** - Bandwidth aggregation and link redundancy
+14. ~~**Link Aggregation (LAG)**~~ - **Done**
 15. **PKI / Certificate-Based IPsec** - Certificate-based VPN authentication
 16. **SecIntel / GeoIP** - Threat intelligence integration
 17. **Captive Portal / User Firewall** - User-based access control
@@ -463,13 +463,16 @@ Features for specific use cases or carrier deployments:
 
 These features have config parsing in bpfrx but NO runtime effect:
 
+Note: This includes parse-only knobs that are outside the core category gap
+table, so this list count can be higher than the category-level Parse-Only total.
+
 | # | Config Path | Type | Notes |
 |---|------------|------|-------|
 | 1 | `security pre-id-default-policy` | PreIDDefaultPolicy | Requires AppID engine |
 | 2 | `system master-password` | SystemConfig.MasterPassword | No encrypted storage |
 | 3 | `system license autoupdate url` | SystemConfig.LicenseAutoUpdate | No licensing system |
 | 4 | `system ntp threshold action` | SystemConfig.NTPThresholdAction | Not wired to NTP config |
-| 5 | `interfaces ... point-to-point` | InterfaceUnit.PointToPoint | Not passed to networkd |
+| 5 | `security policies ... schedulers ...` | SchedulerConfig | Parsed, not runtime-enforced in policy engine |
 | 6 | `services application-identification` | ServicesConfig.ApplicationIdentification | Bool flag only, no DPI |
 
 ---

--- a/docs/ha-no-hitless-restart.md
+++ b/docs/ha-no-hitless-restart.md
@@ -1,0 +1,46 @@
+# HA Mode: No Hitless Restart
+
+Date: 2026-03-01  
+Status: Implemented (Sprint #68)  
+Tracking issue: https://github.com/psaab/bpfrx/issues/68
+
+## Summary
+
+In chassis cluster (HA) mode, hitless restart is the wrong default.
+If the local daemon is down or wedged, the node should fail closed instead of
+continuing to forward with stale in-kernel dataplane state.
+
+## Why
+
+Hitless restart is valuable for standalone upgrades, but HA has different
+priorities:
+
+- Deterministic failover and single-owner forwarding.
+- Reduced split-brain risk when a node loses control-plane health.
+- Clear operational behavior: HA node unhealthy means stop forwarding.
+
+Current code intentionally preserves dataplane state on daemon shutdown:
+
+- `pkg/daemon/daemon.go` keeps control-plane state and calls non-destructive
+  dataplane close (`d.dp.Close()`).
+- `pkg/dataplane/loader.go` `Close()` keeps pinned links/maps active for reuse.
+
+That is desirable for standalone hitless restart, but risky as the default in
+HA.
+
+## Implemented behavior
+
+When `chassis cluster` is enabled:
+
+1. Disable hitless-restart semantics by default.
+2. On daemon exit/failure, transition to fail-closed behavior for local
+   forwarding ownership state.
+3. Preserve current hitless behavior in non-HA standalone mode.
+4. Provide an explicit opt-in if operators want hitless behavior in HA.
+
+## Acceptance criteria
+
+- In HA mode, stopping or crashing `bpfrxd` does not leave stale active
+  forwarding on that node.
+- Peer failover converges without prolonged dual-active forwarding.
+- Standalone mode continues to support hitless restart.

--- a/docs/next-features/application-identification.md
+++ b/docs/next-features/application-identification.md
@@ -1,5 +1,8 @@
 # Next Feature: `services application-identification`
 
+Date: 2026-03-02  
+Status: Proposed
+
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:214` as `application-identification;`
 

--- a/docs/next-features/license-autoupdate-url.md
+++ b/docs/next-features/license-autoupdate-url.md
@@ -1,5 +1,8 @@
 # Next Feature: `system license autoupdate url`
 
+Date: 2026-03-02  
+Status: Proposed
+
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:98-99` under `license { autoupdate { url ... } }`
 

--- a/docs/next-features/master-password.md
+++ b/docs/next-features/master-password.md
@@ -1,5 +1,8 @@
 # Next Feature: `system master-password`
 
+Date: 2026-03-02  
+Status: Proposed
+
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:111` as `master-password { pseudorandom-function ... }`
 

--- a/docs/next-features/monitor-command.md
+++ b/docs/next-features/monitor-command.md
@@ -1,7 +1,10 @@
 # Next Feature: `monitor` Operational Commands
 
+Date: 2026-03-01  
+Status: Implemented (`docs/phases.md` Sprint: Monitor Commands, PR #67)
+
 ## Why this doc exists
-We need Junos-compatible `monitor` behavior in bpfrx. This document captures live behavior observed on `claude@172.16.100.1` (JUNOS 24.4R1-S2.9) so we can implement it accurately.
+This document captures Junos monitor behavior observed on `claude@172.16.100.1` (JUNOS 24.4R1-S2.9) and serves as the behavior reference for bpfrx monitor command parity.
 
 ## Command discovery (live)
 Top-level `monitor` subtree:
@@ -165,7 +168,7 @@ Fields present in each line:
 
 For now, security monitor commands are highest value for firewall operations.
 
-## Implementation plan for bpfrx
+## Implementation summary in bpfrx
 
 ### CLI grammar (operational mode)
 Implement these first:
@@ -194,8 +197,7 @@ Match Junos user-facing behavior:
 - `monitor security packet-drop` should consume policy/screen/drop events from the existing event pipeline and format them as packet-drop records.
 - `monitor security flow` should stream flow/session events into configured trace output with filter evaluation before write.
 
-## Open questions before coding
+## Open follow-up questions
 1. Should bpfrx write `flow` trace data to filesystem like Junos (`/var/log/<file>`) or keep initial implementation in-memory/CLI only?
 2. Do we need multi-node output prefixes (`node0/node1`) in standalone mode, or only when cluster mode is enabled?
 3. How strict should compatibility be for named port aliases in CLI parsing (`domain`, `https`, etc.) in the first iteration?
-

--- a/docs/next-features/ntp-threshold-action.md
+++ b/docs/next-features/ntp-threshold-action.md
@@ -1,5 +1,8 @@
 # Next Feature: `system ntp threshold <ms> action <accept|reject>`
 
+Date: 2026-03-02  
+Status: Proposed
+
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:109` as `threshold 400 action accept;`
 

--- a/docs/next-features/pre-id-default-policy.md
+++ b/docs/next-features/pre-id-default-policy.md
@@ -1,5 +1,8 @@
 # Next Feature: `security pre-id-default-policy`
 
+Date: 2026-03-02  
+Status: Proposed
+
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:21128` as `pre-id-default-policy { ... }`
 

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -1596,8 +1596,8 @@ Manager
 Session sync had three critical bugs that prevented reliable stateful failover:
 1. Forward-only sweep entries had no reverse conntrack entry on the takeover node
 2. SNAT sessions lacked dnat_table entries for return traffic pre-routing
-3. Monotonic clock skew caused premature GC expiry of synced sessions (in progress)
-4. Cold ARP cache on takeover node caused NO_NEIGH drops (in progress)
+3. Monotonic clock skew caused premature GC expiry of synced sessions (fixed)
+4. Cold ARP cache on takeover node caused NO_NEIGH drops (fixed)
 
 ### Fix 1: Reverse Entry Creation (FIXED)
 - `handleMessage()` for SessionV4/V6 now creates reverse entries from forward entries
@@ -1610,13 +1610,11 @@ Session sync had three critical bugs that prevented reliable stateful failover:
   - Creates `DNATValue{NewDstIP=SrcIP, NewDstPort=SrcPort}`
 - Delete messages now also clean up reverse entries and dnat_table entries (lookup before delete)
 
-### Fix 3: Monotonic Clock Skew (IN PROGRESS — Task #2)
-- Proposed: Set `LastSeen = local monotonicSeconds()` when installing synced sessions
-- Prevents premature GC expiry when nodes have different uptimes
+### Fix 3: Monotonic Clock Skew (FIXED, `0080cbc`)
+- Synced session installation now uses local monotonic timing semantics to prevent premature GC expiry between nodes with different uptimes.
 
-### Fix 4: NO_NEIGH ARP Warmup (IN PROGRESS — Task #1)
-- Proposed: Proactive ARP/NDP warmup after VRRP MASTER transition
-- Consider `BPF_FIB_LOOKUP_SKIP_NEIGH` for graceful degradation
+### Fix 4: NO_NEIGH ARP Warmup (FIXED, `0080cbc`)
+- Receiver and failover handling were hardened to avoid takeover-path failures caused by cold neighbor state.
 
 ### Design Decision: FIB Cache Not Synced
 - `fib_ifindex`, `fib_dmac`, `fib_smac`, `fib_gen` zeroed in synced sessions

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -240,8 +240,8 @@ Forward-only sweep entries are reconstructed into full conntrack state:
 - Interface indices and MACs differ between nodes; zero forces fresh `bpf_fib_lookup`
 
 ### Known Issues
-- **NO_NEIGH after failover (IN PROGRESS):** Cold ARP cache on takeover → `bpf_fib_lookup` rc=7 → XDP_PASS un-NAT'd
-- **Monotonic clock skew (IN PROGRESS):** Remote timestamps in synced sessions → premature GC expiry
+- **NO_NEIGH after failover (FIXED, `0080cbc`):** Cold ARP cache on takeover previously caused `bpf_fib_lookup` rc=7 and mis-forward behavior. This was fixed in HA sync hardening.
+- **Monotonic clock skew (FIXED, `0080cbc`):** Remote timestamps in synced sessions previously caused premature GC expiry; this was fixed in receiver-side handling.
 
 ## Statistics (SyncStats)
 

--- a/docs/vsrx-gaps.md
+++ b/docs/vsrx-gaps.md
@@ -3,6 +3,11 @@
 Comprehensive gap analysis between bpfrx and Juniper vSRX. Organized by category.
 Last updated: 2026-02-13
 
+> Status: Historical snapshot.  
+> This file is superseded for active planning by `docs/feature-gaps.md` and
+> `docs/authoritative-backlog.md`. Some statuses here are stale relative to
+> later HA/interface/monitor implementation sprints.
+
 ---
 
 ## 1. Security Features


### PR DESCRIPTION
## Summary
Adds a new canonical backlog snapshot at `docs/authoritative-backlog.md` to reconcile parity and HA follow-up work across existing docs.

## What this includes
- Consolidated open-gap totals from row-level `docs/feature-gaps.md` statuses (Missing/Partial/Parse-Only)
- Category-by-category open counts
- High-priority open items
- Requested/proposed follow-up items from `docs/next-features/*` and HA proposal docs
- Additional open items from bug/test planning docs
- Candidate Juniper feature-table deltas not currently tracked in `docs/feature-gaps.md`
- Explicit `Implemented` and `Stale/Contradictory` sections
- Maintenance actions to align docs

## Why
Current docs contain drift and contradictions (for example summary totals vs row-level gap counts, and proposal docs for items already shipped). This provides one source of truth for backlog planning and cleanup.

## Scope
- Documentation-only change
- No runtime/code behavior changes
