### PR TITLE
docs: capture vSRX fab0/fab1 HA syntax-compat architecture

### DIFF
--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -158,7 +158,7 @@ bpfrx has SNAT (interface + pool, address-persistent), DNAT (with pools, hit cou
 | **DNS ALG with NAT** | `security alg dns enable` | DNS payload rewriting when NAT changes embedded IP addresses (A/AAAA record doctoring) | Medium | Missing |
 | **Overflow Pool** | `security nat source pool ... overflow-pool ...` | Fallback to interface NAT or another pool when primary SNAT pool is exhausted | Low | Missing |
 | **Address Pooling (paired/no-paired)** | `security nat source pool ... address-pooling paired` | Per-pool override of global address-persistent: paired ensures same source always maps to same pool address; no-paired allows round-robin | Low | Missing |
-| **Port Randomization Control** | `security nat source pool ... port-randomization disable` | Disable random port selection in SNAT (use sequential instead). Enabled by default. | Low | Missing |
+| **Port Randomization Control** | `security nat source pool ... port-randomization disable` | Disable random port selection in SNAT (use sequential instead). Enabled by default. | Low | **Done** -- `port-randomization disable` now compiles for source pools and is enforced in both XDP and DPDK SNAT allocators. |
 | **Deterministic NAT (Port Block Allocation)** | `security nat source pool ... port deterministic ...` | Predictable port mapping for logging compliance. Each source gets fixed port block. | Low | **Done** (`74e1d17`, `439cd3f`) -- IPv4 CGNAT + IPv6 NAPT64 deterministic allocation, address ranges, pool-utilization-alarm, Prometheus gauge |
 
 ---
@@ -289,7 +289,7 @@ bpfrx has IPsec via strongSwan with IKE proposals, gateways, VPNs, XFRM interfac
 
 ## 16. HA Enhancements
 
-bpfrx has a full chassis cluster implementation with redundancy groups, RETH (VRRP-backed, virtual MAC), heartbeat, GARP, weight-based failover, session sync (RTO, per-RG aware), config sync, IP monitoring, election logic, VRRP, active/active per-RG service management, fabric bond redundancy, embedded ICMP fabric redirect (mtr/traceroute through secondary), and ISSU. All HA features are now implemented.
+bpfrx has a broad chassis cluster implementation with redundancy groups, RETH (VRRP-backed, virtual MAC), heartbeat, GARP, weight-based failover, session sync (RTO, per-RG aware), config sync, IP monitoring, election logic, VRRP, active/active per-RG service management, fabric forwarding, and ISSU. Remaining gaps are tracked below.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
@@ -299,7 +299,8 @@ bpfrx has a full chassis cluster implementation with redundancy groups, RETH (VR
 | **Active/Active Mode** | `chassis cluster redundancy-group N node 0 priority N node 1 priority N` (both nonzero) | Both nodes forward traffic simultaneously for different RGs. Per-RG VRRP service management, per-RG session sync with zone→RG mapping. | Medium | Done (per-RG service mgmt, per-RG session sync, per-RG election all implemented and tested) |
 | **Redundant Ethernet (reth) Runtime** | `interfaces reth0 redundant-ether-options ...` | Bondless RETH via VRRP on physical member interfaces, virtual MAC per node (`02:bf:72:CC:RR:NN`), programRethMAC, VIP reconciliation, fabric forwarding (including embedded ICMP redirect for mtr/traceroute through secondary), `.link` files with OriginalName matching, session sync across nodes | Medium | Done (fully implemented and validated in cluster testing) |
 | **Primary/Preferred Address per Interface** | `interfaces ... unit ... family inet address ... primary/preferred` | Select which address is used as source for traffic originated by the device. Syslog source address prefers PrimaryAddress, networkd orders primary first. | Low | Done (syslog source address + networkd ordering) |
-| **Fabric Link Redundancy** | `chassis cluster ... fabric-options member-interfaces` | Multiple fabric links between cluster nodes for data forwarding resilience. Linux bond (active-backup) with MII monitoring. | Low | Done (systemd-networkd bond generation with active-backup mode, transparent to BPF/sync) |
+| **vSRX Dual Fabric Syntax Compatibility (`fab0` + `fab1`)** | `interfaces fab0/fab1 fabric-options member-interfaces ...` | Native vSRX HA syntax models two fabric links. Requires multi-fabric transport/data-plane (not single `fabric-interface`). | High | Missing (current core HA transport/data-plane still single-fabric) |
+| **Fabric Link Redundancy** | `chassis cluster ... fabric-options member-interfaces` | Multiple fabric links between cluster nodes for data forwarding resilience. Linux bond/failover behavior should be consistent across runtime and networkd. | Low | Partial (networkd generation and runtime bond mode are inconsistent) |
 
 ---
 

--- a/docs/next-features/vsrx-fabric-fab0-fab1-syntax-compat.md
+++ b/docs/next-features/vsrx-fabric-fab0-fab1-syntax-compat.md
@@ -1,0 +1,80 @@
+# vSRX HA Fabric Syntax Compatibility (`fab0` + `fab1`)
+
+## Problem
+
+`vsrx.conf` defines two fabric interfaces:
+
+- `interfaces fab0 { fabric-options { member-interfaces { ge-0/0/7; } } }`
+- `interfaces fab1 { fabric-options { member-interfaces { ge-7/0/7; } } }`
+
+The current bpfrx HA architecture is still single-fabric in core transport/data-plane wiring, so syntax compatibility is partial.
+
+## Current Gaps (Code-Level)
+
+- Cluster config model is single-fabric:
+  - `pkg/config/types.go` has `FabricInterface string` and `FabricPeerAddress string`.
+- Chassis compiler only reads one fabric interface/peer:
+  - `pkg/config/compiler.go` reads one `fabric-interface` and one `fabric-peer-address`.
+- Runtime HA comms is single endpoint:
+  - `pkg/daemon/daemon.go` starts session sync/gRPC fabric listener/fabric_fwd from one `cc.FabricInterface`.
+  - `clusterTransportKey` tracks only one fabric interface/peer tuple.
+- Cluster CLI display model is single-fabric:
+  - `pkg/cluster/cluster.go` `InterfacesInput` has `FabricInterface string`.
+  - `pkg/cli/cli.go` and `pkg/grpcapi/server.go` populate a single fabric field.
+- eBPF fabric forwarding state is single-entry:
+  - `bpf/headers/bpfrx_maps.h` `fabric_fwd` map has `max_entries = 1`.
+- DPDK parity is single-fabric:
+  - `dpdk_worker/shared_mem.h` has one `fabric_port_id`.
+  - `pkg/dataplane/dpdk/dpdk_cgo.go` updates a single `fabric_port_id`.
+- Bond behavior is inconsistent:
+  - networkd generation uses `active-backup` in `pkg/dataplane/compiler.go`.
+  - netlink runtime bond creation uses `802.3ad` in `pkg/routing/routing.go`.
+
+## Architectural Changes Required
+
+### 1) Config/Data Model
+
+- Introduce multi-fabric cluster transport model (list of links), not single string fields.
+- Keep legacy `fabric-interface`/`fabric-peer-address` as backward-compatible shorthand that maps to one link.
+- Parse/compile `fab0` and `fab1` as first-class cluster fabric links.
+
+### 2) HA Transport Manager
+
+- Replace single `SessionSync(local, peer)` wiring with a fabric transport manager that:
+  - tracks both links (`fab0`, `fab1`),
+  - selects active link by health,
+  - fails over sync/config-channel transport between links without restarting cluster state.
+- Track per-link health/counters and expose active link state.
+
+### 3) Dataplane Fabric Forwarding
+
+- Replace single `fabric_fwd` state with multi-link state:
+  - eBPF map keyed per fabric link (or keyed by ifindex),
+  - anti-loop validation accepts known fabric ingress set, not one ifindex.
+- DPDK shared memory should hold multiple fabric ports (array/bitmap), not one `fabric_port_id`.
+
+### 4) CLI/Operational Parity
+
+- Update `show chassis cluster interfaces` to display both `fab0` and `fab1` rows with child interfaces.
+- Show active/standby fabric transport and per-link health.
+
+### 5) Bond Semantics
+
+- Standardize fabric bond mode for HA semantics (active-backup default unless explicitly configured otherwise).
+- Make networkd and netlink runtime bond mode consistent.
+
+### 6) Validation and Migration
+
+- Add validation:
+  - if `fab0`/`fab1` are configured, require usable member-interface mapping for this node.
+  - reject ambiguous multi-link configs that still rely on single-link-only fields without explicit mapping.
+- Migration behavior:
+  - single-link legacy config keeps working unchanged,
+  - dual-link syntax auto-enables multi-fabric transport path.
+
+## Acceptance Criteria
+
+- A `vsrx.conf`-style HA config with both `fab0` and `fab1` parses and compiles without custom-only transport fields.
+- Session/config sync survives loss of one fabric link with no cluster split.
+- `show chassis cluster interfaces` shows both fabric links and correct link status.
+- eBPF and DPDK both validate/redirect using either fabric link.


### PR DESCRIPTION
## Summary

Document vSRX HA dual-fabric (`fab0` + `fab1`) syntax-compatibility gap and required architecture changes.

- add design note: `docs/next-features/vsrx-fabric-fab0-fab1-syntax-compat.md`
- update HA section in `docs/feature-gaps.md` to track this as a missing high-priority gap

## Why

`vsrx.conf` defines both `fab0` and `fab1` in HA setups. bpfrx currently has single-fabric assumptions in cluster transport and fabric forwarding wiring, so syntax compatibility is incomplete.

## Cross-reference

Refs #107
