### PR TITLE
docs: control-link-only RETH ownership plan (fxp1 election authority)

### DIFF
--- a/docs/next-features/control-link-only-reth-ownership.md
+++ b/docs/next-features/control-link-only-reth-ownership.md
@@ -10,7 +10,7 @@ Can we stop running VRRP advertisements on LAN/WAN RETH interfaces and do HA ele
 Short answer: **mostly yes**. Election is already over the private control link.  
 The part still running on data interfaces is the VRRP VIP ownership/advertisement layer.
 
-## Per-RETH Election Over Private Fabric Link
+## Per-RETH Election Over Private Control Link
 
 Yes, there is a viable path.
 


### PR DESCRIPTION
## Summary
- add a next-feature design doc for removing data-plane VRRP chatter from RETH interfaces
- document a per-RG/per-RETH ownership model driven by private-link election (lease/epoch)
- make `control-interface` (prefer `fxp1`) the recommended election/control authority
- keep `fab0/fab1` scoped to sync and fabric-forwarding roles

## Why
- captures a concrete path to move ownership election off LAN/WAN VRRP multicast
- aligns HA control-plane traffic with dedicated control interface usage
- records risks, gaps, phased implementation plan, and issue-ready acceptance criteria

## Files
- docs/next-features/control-link-only-reth-ownership.md
