### PR TITLE
perf: reduce flow export allocations and preserve source-address collectors

### DIFF
--- a/pkg/flowexport/exporter.go
+++ b/pkg/flowexport/exporter.go
@@ -118,8 +118,9 @@ func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsC
 	seen := make(map[string]bool)
 	deduped := ec.Collectors[:0]
 	for _, c := range ec.Collectors {
-		if !seen[c.Address] {
-			seen[c.Address] = true
+		key := collectorKey(c)
+		if !seen[key] {
+			seen[key] = true
 			deduped = append(deduped, c)
 		}
 	}
@@ -208,9 +209,14 @@ func parseIfaceRef(ref string) (string, int) {
 
 // Exporter sends NetFlow v9 packets to configured collectors.
 type Exporter struct {
-	cfg      ExportConfig
-	bootTime time.Time
-	sourceID uint32
+	cfg             ExportConfig
+	bootTime        time.Time
+	sourceID        uint32
+	fieldsV4        []templateField
+	fieldsV6        []templateField
+	recSizeV4       int
+	recSizeV6       int
+	templateFlowSet []byte
 
 	mu    sync.Mutex
 	seq   uint32
@@ -232,7 +238,12 @@ func NewExporter(cfg ExportConfig) (*Exporter, error) {
 		cfg:      cfg,
 		bootTime: time.Now(),
 		sourceID: 1,
+		fieldsV4: buildTemplateFieldsV4(cfg.V9TemplateOpts),
+		fieldsV6: buildTemplateFieldsV6(cfg.V9TemplateOpts),
 	}
+	e.recSizeV4 = recordSize(e.fieldsV4)
+	e.recSizeV6 = recordSize(e.fieldsV6)
+	e.templateFlowSet = encodeTemplateFlowSet(cfg.V9TemplateOpts)
 
 	for _, cc := range cfg.Collectors {
 		var conn net.Conn
@@ -332,8 +343,6 @@ func (e *Exporter) Close() {
 }
 
 func (e *Exporter) sendTemplates() {
-	tmplFS := encodeTemplateFlowSet(e.cfg.V9TemplateOpts)
-
 	e.mu.Lock()
 	seq := e.seq
 	e.seq++
@@ -349,7 +358,9 @@ func (e *Exporter) sendTemplates() {
 		SourceID:  e.sourceID,
 	}
 
-	pkt := append(encodeHeader(hdr), tmplFS...)
+	pkt := make([]byte, 20+len(e.templateFlowSet))
+	encodeHeaderInto(pkt[:20], hdr)
+	copy(pkt[20:], e.templateFlowSet)
 	for _, c := range e.conns {
 		if _, err := c.Write(pkt); err != nil {
 			slog.Debug("netflow template send failed", "err", err)
@@ -378,15 +389,21 @@ func (e *Exporter) sendRecords(records []FlowRecord) {
 		return
 	}
 
-	opts := e.cfg.V9TemplateOpts
 	isV6 := records[0].IsIPv6
-	var fields []templateField
+	var (
+		fields  []templateField
+		recSize int
+		tmplID  uint16
+	)
 	if isV6 {
-		fields = buildTemplateFieldsV6(opts)
+		fields = e.fieldsV6
+		recSize = e.recSizeV6
+		tmplID = templateIDv6
 	} else {
-		fields = buildTemplateFieldsV4(opts)
+		fields = e.fieldsV4
+		recSize = e.recSizeV4
+		tmplID = templateIDv4
 	}
-	recSize := recordSize(fields)
 
 	// Split into chunks that fit in maxPayload
 	// Reserve 20 bytes for header + 4 bytes for flowset header
@@ -401,11 +418,7 @@ func (e *Exporter) sendRecords(records []FlowRecord) {
 			end = len(records)
 		}
 		batch := records[i:end]
-
-		dataFS := encodeDataFlowSet(batch, e.bootTime, opts)
-		if dataFS == nil {
-			continue
-		}
+		dataLen := dataFlowSetLen(len(batch), recSize)
 
 		e.mu.Lock()
 		seq := e.seq
@@ -422,7 +435,10 @@ func (e *Exporter) sendRecords(records []FlowRecord) {
 			SourceID:  e.sourceID,
 		}
 
-		pkt := append(encodeHeader(hdr), dataFS...)
+		pkt := make([]byte, 20+dataLen)
+		encodeHeaderInto(pkt[:20], hdr)
+		encodeDataFlowSetInto(pkt[20:], batch, e.bootTime,
+			tmplID, fields, recSize)
 		for _, c := range e.conns {
 			if _, err := c.Write(pkt); err != nil {
 				slog.Debug("netflow data send failed", "err", err)
@@ -445,4 +461,8 @@ func estimateSessionDuration(pkts uint64, proto uint8) time.Duration {
 		return time.Duration(pkts) * 100 * time.Millisecond
 	}
 	return time.Duration(pkts) * 50 * time.Millisecond
+}
+
+func collectorKey(c CollectorConfig) string {
+	return c.Address + "\x00" + c.SourceAddress
 }

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -97,7 +97,7 @@ func TestShouldExport(t *testing.T) {
 	ec := &ExportConfig{
 		SamplingZones: map[uint16]SamplingDir{
 			2: {Input: true, Output: true},  // trust
-			3: {Input: true, Output: false},  // untrust
+			3: {Input: true, Output: false}, // untrust
 		},
 	}
 
@@ -169,6 +169,38 @@ func TestBuildExportConfig_FlowServerSourceAddressTakesPrecedence(t *testing.T) 
 	}
 	if ec.Collectors[0].SourceAddress != "10.0.1.20" {
 		t.Errorf("SourceAddress = %q, want flow-server source-address %q", ec.Collectors[0].SourceAddress, "10.0.1.20")
+	}
+}
+
+func TestBuildExportConfig_DistinctSourceAddressesAreNotDeduped(t *testing.T) {
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"test": {
+					Name: "test",
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055},
+						},
+						SourceAddress: "10.0.1.10",
+					},
+					FamilyInet6: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055},
+						},
+						SourceAddress: "10.0.1.11",
+					},
+				},
+			},
+		},
+	}
+
+	ec := BuildExportConfig(nil, fo)
+	if ec == nil {
+		t.Fatal("expected non-nil ExportConfig")
+	}
+	if len(ec.Collectors) != 2 {
+		t.Fatalf("expected 2 collectors, got %d", len(ec.Collectors))
 	}
 }
 
@@ -367,6 +399,47 @@ func TestBuildIPFIXExportConfig_NilIPFIX(t *testing.T) {
 	ec := BuildIPFIXExportConfig(svc, fo)
 	if ec != nil {
 		t.Error("expected nil ExportConfig when VersionIPFIX is not set")
+	}
+}
+
+func TestBuildIPFIXExportConfig_DistinctSourceAddressesAreNotDeduped(t *testing.T) {
+	svc := &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			VersionIPFIX: &config.NetFlowIPFIXConfig{
+				Templates: map[string]*config.NetFlowIPFIXTemplate{
+					"tmpl": {Name: "tmpl"},
+				},
+			},
+		},
+	}
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"test": {
+					Name: "test",
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055},
+						},
+						SourceAddress: "10.0.1.10",
+					},
+					FamilyInet6: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055},
+						},
+						SourceAddress: "10.0.1.11",
+					},
+				},
+			},
+		},
+	}
+
+	ec := BuildIPFIXExportConfig(svc, fo)
+	if ec == nil {
+		t.Fatal("expected non-nil ExportConfig")
+	}
+	if len(ec.Collectors) != 2 {
+		t.Fatalf("expected 2 collectors, got %d", len(ec.Collectors))
 	}
 }
 

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -17,23 +17,23 @@ import (
 
 // IPFIX field Information Element IDs (IANA-assigned, RFC 5102).
 const (
-	ipfixOctetDeltaCount        = 1
-	ipfixPacketDeltaCount       = 2
-	ipfixProtocolIdentifier     = 4
-	ipfixIpClassOfService       = 5
-	ipfixTcpControlBits         = 6
-	ipfixSourceTransportPort    = 7
-	ipfixSourceIPv4Address      = 8
+	ipfixOctetDeltaCount          = 1
+	ipfixPacketDeltaCount         = 2
+	ipfixProtocolIdentifier       = 4
+	ipfixIpClassOfService         = 5
+	ipfixTcpControlBits           = 6
+	ipfixSourceTransportPort      = 7
+	ipfixSourceIPv4Address        = 8
 	ipfixDestinationTransportPort = 11
-	ipfixDestinationIPv4Address = 12
-	ipfixIngressInterface       = 10
-	ipfixEgressInterface        = 14
-	ipfixSourceIPv6Address      = 27
-	ipfixDestinationIPv6Address = 28
-	ipfixFlowDirection          = 61
-	ipfixApplicationId          = 95
-	ipfixFlowStartMilliseconds  = 152
-	ipfixFlowEndMilliseconds    = 153
+	ipfixDestinationIPv4Address   = 12
+	ipfixIngressInterface         = 10
+	ipfixEgressInterface          = 14
+	ipfixSourceIPv6Address        = 27
+	ipfixDestinationIPv6Address   = 28
+	ipfixFlowDirection            = 61
+	ipfixApplicationId            = 95
+	ipfixFlowStartMilliseconds    = 152
+	ipfixFlowEndMilliseconds      = 153
 )
 
 // IPFIX Set IDs (RFC 7011 Section 3.3.2).
@@ -110,12 +110,16 @@ type ipfixHeader struct {
 
 func encodeIPFIXHeader(h ipfixHeader) []byte {
 	b := make([]byte, 16)
+	encodeIPFIXHeaderInto(b, h)
+	return b
+}
+
+func encodeIPFIXHeaderInto(b []byte, h ipfixHeader) {
 	binary.BigEndian.PutUint16(b[0:2], h.Version)
 	binary.BigEndian.PutUint16(b[2:4], h.Length)
 	binary.BigEndian.PutUint32(b[4:8], h.ExportTime)
 	binary.BigEndian.PutUint32(b[8:12], h.SequenceNumber)
 	binary.BigEndian.PutUint32(b[12:16], h.ObservationID)
-	return b
 }
 
 // encodeIPFIXTemplateSet builds an IPFIX template set containing v4 and v6 templates.
@@ -172,17 +176,25 @@ func encodeIPFIXDataSet(records []FlowRecord) []byte {
 		recSize = ipfixRecordSizeV4
 	}
 
-	// Set header (4 bytes) + records
-	totalLen := 4 + len(records)*recSize
-
+	totalLen := ipfixDataSetLen(len(records), recSize)
 	b := make([]byte, totalLen)
-	off := 0
+	encodeIPFIXDataSetInto(b, records, tmplID, recSize)
+	return b
+}
 
-	// Set header: Set ID = template ID, Length
-	binary.BigEndian.PutUint16(b[off:off+2], tmplID)
-	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(totalLen))
-	off += 4
+func ipfixDataSetLen(recordCount, recSize int) int {
+	return 4 + recordCount*recSize
+}
 
+func encodeIPFIXDataSetInto(b []byte, records []FlowRecord, tmplID uint16, recSize int) {
+	if len(records) == 0 {
+		return
+	}
+	totalLen := ipfixDataSetLen(len(records), recSize)
+	binary.BigEndian.PutUint16(b[0:2], tmplID)
+	binary.BigEndian.PutUint16(b[2:4], uint16(totalLen))
+	off := 4
+	isV6 := records[0].IsIPv6
 	for _, r := range records {
 		if isV6 {
 			off = encodeIPFIXRecordV6(b, off, r)
@@ -190,8 +202,7 @@ func encodeIPFIXDataSet(records []FlowRecord) []byte {
 			off = encodeIPFIXRecordV4(b, off, r)
 		}
 	}
-
-	return b
+	clear(b[off:totalLen])
 }
 
 func encodeIPFIXRecordV4(b []byte, off int, r FlowRecord) int {
@@ -276,8 +287,9 @@ func encodeIPFIXRecordV6(b []byte, off int, r FlowRecord) int {
 
 // IPFIXExporter sends IPFIX (NetFlow v10) messages to configured collectors.
 type IPFIXExporter struct {
-	cfg      ExportConfig
-	sourceID uint32
+	cfg         ExportConfig
+	sourceID    uint32
+	templateSet []byte
 
 	mu    sync.Mutex
 	seq   uint32 // cumulative data record count
@@ -294,8 +306,9 @@ type IPFIXExporter struct {
 // NewIPFIXExporter creates a new IPFIX exporter.
 func NewIPFIXExporter(cfg ExportConfig) (*IPFIXExporter, error) {
 	e := &IPFIXExporter{
-		cfg:      cfg,
-		sourceID: 1,
+		cfg:         cfg,
+		sourceID:    1,
+		templateSet: encodeIPFIXTemplateSet(),
 	}
 
 	for _, cc := range cfg.Collectors {
@@ -383,18 +396,18 @@ func (e *IPFIXExporter) Close() {
 }
 
 func (e *IPFIXExporter) sendTemplates() {
-	tmplSet := encodeIPFIXTemplateSet()
-
 	now := time.Now()
 	hdr := ipfixHeader{
 		Version:        10,
-		Length:         uint16(16 + len(tmplSet)),
+		Length:         uint16(16 + len(e.templateSet)),
 		ExportTime:     uint32(now.Unix()),
 		SequenceNumber: 0, // template-only messages use seq=0 per convention
 		ObservationID:  e.sourceID,
 	}
 
-	pkt := append(encodeIPFIXHeader(hdr), tmplSet...)
+	pkt := make([]byte, 16+len(e.templateSet))
+	encodeIPFIXHeaderInto(pkt[:16], hdr)
+	copy(pkt[16:], e.templateSet)
 	for _, c := range e.conns {
 		if _, err := c.Write(pkt); err != nil {
 			slog.Debug("ipfix template send failed", "err", err)
@@ -424,11 +437,16 @@ func (e *IPFIXExporter) sendRecords(records []FlowRecord) {
 	}
 
 	isV6 := records[0].IsIPv6
-	var recSize int
+	var (
+		recSize int
+		tmplID  uint16
+	)
 	if isV6 {
 		recSize = ipfixRecordSizeV6
+		tmplID = ipfixTemplateIDv6
 	} else {
 		recSize = ipfixRecordSizeV4
+		tmplID = ipfixTemplateIDv4
 	}
 
 	// Reserve 16 bytes for IPFIX header + 4 bytes for set header
@@ -443,11 +461,7 @@ func (e *IPFIXExporter) sendRecords(records []FlowRecord) {
 			end = len(records)
 		}
 		batch := records[i:end]
-
-		dataSet := encodeIPFIXDataSet(batch)
-		if dataSet == nil {
-			continue
-		}
+		dataLen := ipfixDataSetLen(len(batch), recSize)
 
 		e.mu.Lock()
 		seq := e.seq
@@ -457,13 +471,15 @@ func (e *IPFIXExporter) sendRecords(records []FlowRecord) {
 		now := time.Now()
 		hdr := ipfixHeader{
 			Version:        10,
-			Length:         uint16(16 + len(dataSet)),
+			Length:         uint16(16 + dataLen),
 			ExportTime:     uint32(now.Unix()),
 			SequenceNumber: seq,
 			ObservationID:  e.sourceID,
 		}
 
-		pkt := append(encodeIPFIXHeader(hdr), dataSet...)
+		pkt := make([]byte, 16+dataLen)
+		encodeIPFIXHeaderInto(pkt[:16], hdr)
+		encodeIPFIXDataSetInto(pkt[16:], batch, tmplID, recSize)
 		for _, c := range e.conns {
 			if _, err := c.Write(pkt); err != nil {
 				slog.Debug("ipfix data send failed", "err", err)
@@ -547,8 +563,9 @@ func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOpt
 	seen := make(map[string]bool)
 	deduped := ec.Collectors[:0]
 	for _, c := range ec.Collectors {
-		if !seen[c.Address] {
-			seen[c.Address] = true
+		key := collectorKey(c)
+		if !seen[key] {
+			seen[key] = true
 			deduped = append(deduped, c)
 		}
 	}

--- a/pkg/flowexport/netflow9.go
+++ b/pkg/flowexport/netflow9.go
@@ -55,14 +55,8 @@ type V9TemplateOptions struct {
 	IncludeFlowDir bool // include fieldDirection (export-extension flow-dir)
 }
 
-// DefaultV9TemplateOptions returns options with all extensions enabled (backward compat).
-func DefaultV9TemplateOptions() V9TemplateOptions {
-	return V9TemplateOptions{IncludeFlowDir: true}
-}
-
-// buildTemplateFieldsV4 returns the IPv4 template fields based on options.
-func buildTemplateFieldsV4(opts V9TemplateOptions) []templateField {
-	fields := []templateField{
+var (
+	netflowTemplateFieldsV4 = []templateField{
 		{fieldIPv4SrcAddr, 4},
 		{fieldIPv4DstAddr, 4},
 		{fieldL4SrcPort, 2},
@@ -70,36 +64,34 @@ func buildTemplateFieldsV4(opts V9TemplateOptions) []templateField {
 		{fieldProtocol, 1},
 		{fieldSrcTos, 1},
 		{fieldTCPFlags, 1},
+		{fieldDirection, 1},
+		{fieldInputSNMP, 4},
+		{fieldOutputSNMP, 4},
+		{fieldInPkts, 8},
+		{fieldInBytes, 8},
+		{fieldFirstSwitched, 4},
+		{fieldLastSwitched, 4},
+		{fieldSrcMask, 1},
+		{fieldDstMask, 1},
 	}
-	if opts.IncludeFlowDir {
-		fields = append(fields, templateField{fieldDirection, 1})
-	} else {
-		// 1 byte padding to maintain alignment after tcp_flags
-		fields = append(fields, templateField{0, 0}) // placeholder, not emitted
+	netflowTemplateFieldsV4NoDir = []templateField{
+		{fieldIPv4SrcAddr, 4},
+		{fieldIPv4DstAddr, 4},
+		{fieldL4SrcPort, 2},
+		{fieldL4DstPort, 2},
+		{fieldProtocol, 1},
+		{fieldSrcTos, 1},
+		{fieldTCPFlags, 1},
+		{fieldInputSNMP, 4},
+		{fieldOutputSNMP, 4},
+		{fieldInPkts, 8},
+		{fieldInBytes, 8},
+		{fieldFirstSwitched, 4},
+		{fieldLastSwitched, 4},
+		{fieldSrcMask, 1},
+		{fieldDstMask, 1},
 	}
-	fields = append(fields,
-		templateField{fieldInputSNMP, 4},
-		templateField{fieldOutputSNMP, 4},
-		templateField{fieldInPkts, 8},
-		templateField{fieldInBytes, 8},
-		templateField{fieldFirstSwitched, 4},
-		templateField{fieldLastSwitched, 4},
-		templateField{fieldSrcMask, 1},
-		templateField{fieldDstMask, 1},
-	)
-	// Filter out zero-type placeholders
-	var result []templateField
-	for _, f := range fields {
-		if f.fieldType != 0 || f.fieldLen != 0 {
-			result = append(result, f)
-		}
-	}
-	return result
-}
-
-// buildTemplateFieldsV6 returns the IPv6 template fields based on options.
-func buildTemplateFieldsV6(opts V9TemplateOptions) []templateField {
-	fields := []templateField{
+	netflowTemplateFieldsV6 = []templateField{
 		{fieldIPv6SrcAddr, 16},
 		{fieldIPv6DstAddr, 16},
 		{fieldL4SrcPort, 2},
@@ -107,21 +99,54 @@ func buildTemplateFieldsV6(opts V9TemplateOptions) []templateField {
 		{fieldProtocol, 1},
 		{fieldSrcTos, 1},
 		{fieldTCPFlags, 1},
+		{fieldDirection, 1},
+		{fieldInputSNMP, 4},
+		{fieldOutputSNMP, 4},
+		{fieldInPkts, 8},
+		{fieldInBytes, 8},
+		{fieldFirstSwitched, 4},
+		{fieldLastSwitched, 4},
+		{fieldIPv6SrcMask, 1},
+		{fieldIPv6DstMask, 1},
 	}
+	netflowTemplateFieldsV6NoDir = []templateField{
+		{fieldIPv6SrcAddr, 16},
+		{fieldIPv6DstAddr, 16},
+		{fieldL4SrcPort, 2},
+		{fieldL4DstPort, 2},
+		{fieldProtocol, 1},
+		{fieldSrcTos, 1},
+		{fieldTCPFlags, 1},
+		{fieldInputSNMP, 4},
+		{fieldOutputSNMP, 4},
+		{fieldInPkts, 8},
+		{fieldInBytes, 8},
+		{fieldFirstSwitched, 4},
+		{fieldLastSwitched, 4},
+		{fieldIPv6SrcMask, 1},
+		{fieldIPv6DstMask, 1},
+	}
+)
+
+// DefaultV9TemplateOptions returns options with all extensions enabled (backward compat).
+func DefaultV9TemplateOptions() V9TemplateOptions {
+	return V9TemplateOptions{IncludeFlowDir: true}
+}
+
+// buildTemplateFieldsV4 returns the IPv4 template fields based on options.
+func buildTemplateFieldsV4(opts V9TemplateOptions) []templateField {
 	if opts.IncludeFlowDir {
-		fields = append(fields, templateField{fieldDirection, 1})
+		return netflowTemplateFieldsV4
 	}
-	fields = append(fields,
-		templateField{fieldInputSNMP, 4},
-		templateField{fieldOutputSNMP, 4},
-		templateField{fieldInPkts, 8},
-		templateField{fieldInBytes, 8},
-		templateField{fieldFirstSwitched, 4},
-		templateField{fieldLastSwitched, 4},
-		templateField{fieldIPv6SrcMask, 1},
-		templateField{fieldIPv6DstMask, 1},
-	)
-	return fields
+	return netflowTemplateFieldsV4NoDir
+}
+
+// buildTemplateFieldsV6 returns the IPv6 template fields based on options.
+func buildTemplateFieldsV6(opts V9TemplateOptions) []templateField {
+	if opts.IncludeFlowDir {
+		return netflowTemplateFieldsV6
+	}
+	return netflowTemplateFieldsV6NoDir
 }
 
 // recordSize computes the data record size from template fields, padded to 4 bytes.
@@ -166,14 +191,18 @@ type nfHeader struct {
 	SourceID  uint32
 }
 
-func encodeHeader(h nfHeader) []byte {
-	b := make([]byte, 20)
+func encodeHeaderInto(b []byte, h nfHeader) {
 	binary.BigEndian.PutUint16(b[0:2], h.Version)
 	binary.BigEndian.PutUint16(b[2:4], h.Count)
 	binary.BigEndian.PutUint32(b[4:8], h.SysUptime)
 	binary.BigEndian.PutUint32(b[8:12], h.UnixSecs)
 	binary.BigEndian.PutUint32(b[12:16], h.SeqNumber)
 	binary.BigEndian.PutUint32(b[16:20], h.SourceID)
+}
+
+func encodeHeader(h nfHeader) []byte {
+	b := make([]byte, 20)
+	encodeHeaderInto(b, h)
 	return b
 }
 
@@ -222,44 +251,64 @@ func encodeDataFlowSet(records []FlowRecord, bootTime time.Time, opts V9Template
 	if len(records) == 0 {
 		return nil
 	}
-	isV6 := records[0].IsIPv6
-	var tmplID uint16
-	var fields []templateField
-	if isV6 {
-		tmplID = templateIDv6
-		fields = buildTemplateFieldsV6(opts)
-	} else {
-		tmplID = templateIDv4
-		fields = buildTemplateFieldsV4(opts)
-	}
-	recSize := recordSize(fields)
-
-	// FlowSet header (4 bytes) + records
-	totalLen := 4 + len(records)*recSize
-	// Pad to 4-byte boundary
-	pad := (4 - totalLen%4) % 4
-	totalLen += pad
-
+	tmplID, fields, recSize := netflowTemplateConfig(records[0].IsIPv6, opts)
+	totalLen := dataFlowSetLen(len(records), recSize)
 	b := make([]byte, totalLen)
-	off := 0
-
-	// FlowSet header
-	binary.BigEndian.PutUint16(b[off:off+2], tmplID)
-	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(totalLen))
-	off += 4
-
-	for _, r := range records {
-		if isV6 {
-			off = encodeRecordV6(b, off, r, bootTime, opts)
-		} else {
-			off = encodeRecordV4(b, off, r, bootTime, opts)
-		}
-	}
-
+	encodeDataFlowSetInto(b, records, bootTime, tmplID, fields, recSize)
 	return b
 }
 
-func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9TemplateOptions) int {
+func netflowTemplateConfig(isV6 bool, opts V9TemplateOptions) (uint16, []templateField, int) {
+	if isV6 {
+		fields := buildTemplateFieldsV6(opts)
+		return templateIDv6, fields, recordSize(fields)
+	}
+	fields := buildTemplateFieldsV4(opts)
+	return templateIDv4, fields, recordSize(fields)
+}
+
+func dataFlowSetLen(recordCount, recSize int) int {
+	totalLen := 4 + recordCount*recSize
+	pad := (4 - totalLen%4) % 4
+	return totalLen + pad
+}
+
+func encodeDataFlowSetInto(b []byte, records []FlowRecord, bootTime time.Time,
+	tmplID uint16, fields []templateField, recSize int,
+) {
+	if len(records) == 0 {
+		return
+	}
+	totalLen := dataFlowSetLen(len(records), recSize)
+	binary.BigEndian.PutUint16(b[0:2], tmplID)
+	binary.BigEndian.PutUint16(b[2:4], uint16(totalLen))
+	off := 4
+	isV6 := records[0].IsIPv6
+	includeFlowDir := fieldSetIncludesFlowDir(fields)
+	for _, r := range records {
+		if isV6 {
+			off = encodeRecordV6(b, off, r, bootTime,
+				includeFlowDir, recSize)
+		} else {
+			off = encodeRecordV4(b, off, r, bootTime,
+				includeFlowDir, recSize)
+		}
+	}
+	clear(b[off:totalLen])
+}
+
+func fieldSetIncludesFlowDir(fields []templateField) bool {
+	for _, f := range fields {
+		if f.fieldType == fieldDirection {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time,
+	includeFlowDir bool, recSize int,
+) int {
 	startOff := off
 	src4 := r.SrcIP.To4()
 	dst4 := r.DstIP.To4()
@@ -283,7 +332,7 @@ func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9
 	off++
 	b[off] = r.TCPFlags
 	off++
-	if opts.IncludeFlowDir {
+	if includeFlowDir {
 		b[off] = r.Direction
 		off++
 	}
@@ -303,12 +352,12 @@ func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9
 	off++
 	b[off] = r.DstMask
 	off++
-	// Advance to padded record boundary
-	recSize := recordSize(buildTemplateFieldsV4(opts))
 	return startOff + recSize
 }
 
-func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9TemplateOptions) int {
+func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time,
+	includeFlowDir bool, recSize int,
+) int {
 	startOff := off
 	src16 := r.SrcIP.To16()
 	dst16 := r.DstIP.To16()
@@ -332,7 +381,7 @@ func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9
 	off++
 	b[off] = r.TCPFlags
 	off++
-	if opts.IncludeFlowDir {
+	if includeFlowDir {
 		b[off] = r.Direction
 		off++
 	}
@@ -352,8 +401,6 @@ func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time, opts V9
 	off++
 	b[off] = r.DstMask
 	off++
-	// Advance to padded record boundary
-	recSize := recordSize(buildTemplateFieldsV6(opts))
 	return startOff + recSize
 }
 


### PR DESCRIPTION
## Summary
- precompute template metadata and build NetFlow/IPFIX packets in a single buffer instead of allocating header and payload slices separately
- cache template payloads on exporter startup instead of rebuilding them on every timer tick
- dedupe collectors by address plus source-address so distinct exporters are not collapsed together
- add tests covering the source-address collector case

## Testing
- GOCACHE=/tmp/go-build go test ./pkg/flowexport/...
