### PR TITLE
vpn: improve Junos IKE/IPsec compatibility

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -2957,7 +2957,7 @@ func (c *CLI) applyToDataplane(cfg *config.Config) error {
 
 	// 5. Apply IPsec config
 	if c.ipsec != nil {
-		if err := c.ipsec.Apply(&cfg.Security.IPsec); err != nil {
+		if err := c.ipsec.Apply(ipsec.PrepareConfig(cfg)); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: IPsec apply failed: %v\n", err)
 		}
 	}
@@ -6105,11 +6105,25 @@ func (c *CLI) showIPsec(args []string) error {
 		if vpn.IPsecPolicy != "" {
 			fmt.Printf("  IPsec policy: %s\n", vpn.IPsecPolicy)
 		}
+		if vpn.BindInterface != "" {
+			fmt.Printf("  Bind interface: %s\n", vpn.BindInterface)
+		}
 		if vpn.LocalID != "" {
 			fmt.Printf("  Local identity: %s\n", vpn.LocalID)
 		}
 		if vpn.RemoteID != "" {
 			fmt.Printf("  Remote identity: %s\n", vpn.RemoteID)
+		}
+		if len(vpn.TrafficSelectors) > 0 {
+			names := make([]string, 0, len(vpn.TrafficSelectors))
+			for tsName := range vpn.TrafficSelectors {
+				names = append(names, tsName)
+			}
+			sort.Strings(names)
+			for _, tsName := range names {
+				ts := vpn.TrafficSelectors[tsName]
+				fmt.Printf("  Traffic selector %s: %s -> %s\n", tsName, ts.LocalIP, ts.RemoteIP)
+			}
 		}
 		fmt.Println()
 	}
@@ -6224,6 +6238,9 @@ func (c *CLI) showIKE(args []string) error {
 		if gw.ExternalIface != "" {
 			fmt.Printf("  External interface: %s\n", gw.ExternalIface)
 		}
+		if gw.LocalCertificate != "" {
+			fmt.Printf("  Local certificate:  %s\n", gw.LocalCertificate)
+		}
 		if gw.IKEPolicy != "" {
 			fmt.Printf("  IKE policy:         %s\n", gw.IKEPolicy)
 			if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
@@ -6238,9 +6255,19 @@ func (c *CLI) showIKE(args []string) error {
 		fmt.Printf("  IKE version:        %s\n", ver)
 		if gw.DeadPeerDetect != "" {
 			fmt.Printf("  DPD:                %s\n", gw.DeadPeerDetect)
+			if gw.DPDInterval > 0 {
+				fmt.Printf("  DPD interval:       %ds\n", gw.DPDInterval)
+			}
+			if gw.DPDThreshold > 0 {
+				fmt.Printf("  DPD threshold:      %d\n", gw.DPDThreshold)
+			}
 		}
 		if gw.NoNATTraversal {
 			fmt.Printf("  NAT-T:              disabled\n")
+		} else if gw.NATTraversal == "force" {
+			fmt.Printf("  NAT-T:              force\n")
+		} else if gw.NATTraversal == "enable" {
+			fmt.Printf("  NAT-T:              enabled\n")
 		}
 		if gw.LocalIDValue != "" {
 			fmt.Printf("  Local identity:     %s %s\n", gw.LocalIDType, gw.LocalIDValue)

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -896,8 +896,8 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"description": {args: 1, children: nil},
 					"match": {children: map[string]*schemaNode{
 						"source-address":      {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
-						"destination-address":  {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
-						"application":          {args: 1, multi: true, valueHint: ValueHintPolicyApp, children: nil},
+						"destination-address": {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
+						"application":         {args: 1, multi: true, valueHint: ValueHintPolicyApp, children: nil},
 					}},
 					"then": {children: map[string]*schemaNode{
 						"log": {children: nil},
@@ -910,8 +910,8 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"description": {args: 1, children: nil},
 					"match": {children: map[string]*schemaNode{
 						"source-address":      {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
-						"destination-address":  {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
-						"application":          {args: 1, multi: true, valueHint: ValueHintPolicyApp, children: nil},
+						"destination-address": {args: 1, multi: true, valueHint: ValueHintPolicyAddress, children: nil},
+						"application":         {args: 1, multi: true, valueHint: ValueHintPolicyApp, children: nil},
 					}},
 					"then": {children: map[string]*schemaNode{
 						"log": {children: nil},
@@ -923,8 +923,8 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"ids-option": {args: 1, valueHint: ValueHintScreenProfile, children: map[string]*schemaNode{
 				"icmp": {children: nil},
 				"tcp": {children: map[string]*schemaNode{
-					"syn-flood":  {children: nil},
-					"port-scan":  {children: nil},
+					"syn-flood": {children: nil},
+					"port-scan": {children: nil},
 					// land, winnuke, syn-frag -> leaf
 				}},
 				"ip": {children: map[string]*schemaNode{
@@ -940,7 +940,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		}},
 		"nat": {children: map[string]*schemaNode{
 			"source": {children: map[string]*schemaNode{
-				"pool":              {args: 1, valueHint: ValueHintPoolName, children: nil},
+				"pool":               {args: 1, valueHint: ValueHintPoolName, children: nil},
 				"address-persistent": {children: nil},
 				"rule-set": {args: 1, children: map[string]*schemaNode{
 					"from": {children: map[string]*schemaNode{
@@ -952,9 +952,9 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"rule": {args: 1, children: map[string]*schemaNode{
 						"match": {children: map[string]*schemaNode{
 							"source-address":      {args: 1, multi: true, children: nil},
-							"destination-address":  {args: 1, multi: true, children: nil},
-							"destination-port":     {args: 1, multi: true, children: nil},
-							"application":          {args: 1, multi: true, children: nil},
+							"destination-address": {args: 1, multi: true, children: nil},
+							"destination-port":    {args: 1, multi: true, children: nil},
+							"application":         {args: 1, multi: true, children: nil},
 						}},
 						"then": {children: map[string]*schemaNode{
 							"source-nat": {children: map[string]*schemaNode{
@@ -977,12 +977,12 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					}},
 					"rule": {args: 1, children: map[string]*schemaNode{
 						"match": {children: map[string]*schemaNode{
-							"source-address":       {args: 1, multi: true, children: nil},
-							"source-address-name":  {args: 1, multi: true, children: nil},
-							"destination-address":  {args: 1, multi: true, children: nil},
-							"destination-port":     {args: 1, multi: true, children: nil},
-							"protocol":             {args: 1, multi: true, children: nil},
-							"application":          {args: 1, multi: true, children: nil},
+							"source-address":      {args: 1, multi: true, children: nil},
+							"source-address-name": {args: 1, multi: true, children: nil},
+							"destination-address": {args: 1, multi: true, children: nil},
+							"destination-port":    {args: 1, multi: true, children: nil},
+							"protocol":            {args: 1, multi: true, children: nil},
+							"application":         {args: 1, multi: true, children: nil},
 						}},
 						"then": {children: map[string]*schemaNode{
 							"destination-nat": {children: map[string]*schemaNode{
@@ -996,7 +996,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"rule-set": {args: 1, children: map[string]*schemaNode{
 					"rule": {args: 1, children: map[string]*schemaNode{
 						"match": {children: nil},
-						"then":  {children: map[string]*schemaNode{
+						"then": {children: map[string]*schemaNode{
 							"static-nat": {children: nil},
 						}},
 					}},
@@ -1052,8 +1052,8 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"gre-performance-acceleration": {children: nil},
 			"power-mode-disable":           {children: nil},
 			"traceoptions": {children: map[string]*schemaNode{
-				"file":          {args: 1, children: nil},
-				"flag":          {args: 1, children: nil},
+				"file": {args: 1, children: nil},
+				"flag": {args: 1, children: nil},
 				"packet-filter": {args: 1, children: map[string]*schemaNode{
 					"source-prefix":      {args: 1, children: nil},
 					"destination-prefix": {args: 1, children: nil},
@@ -1074,17 +1074,24 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"pre-shared-key": {children: nil},
 			}},
 			"gateway": {args: 1, children: map[string]*schemaNode{
-				"address":              {args: 1, children: nil},
-				"local-address":        {args: 1, children: nil},
-				"ike-policy":           {args: 1, children: nil},
-				"external-interface":   {args: 1, children: nil},
-				"version":              {args: 1, children: nil},
-				"no-nat-traversal":     {children: nil},
-				"nat-traversal":        {args: 1, children: nil},
-				"dead-peer-detection":  {args: 1, children: nil},
-				"local-identity":       {children: nil},
-				"remote-identity":      {children: nil},
-				"dynamic":              {children: nil},
+				"address":            {args: 1, children: nil},
+				"local-address":      {args: 1, children: nil},
+				"ike-policy":         {args: 1, children: nil},
+				"external-interface": {args: 1, children: nil},
+				"local-certificate":  {args: 1, children: nil},
+				"version":            {args: 1, children: nil},
+				"no-nat-traversal":   {children: nil},
+				"nat-traversal":      {args: 1, children: nil},
+				"dead-peer-detection": {children: map[string]*schemaNode{
+					"always-send":       {children: nil},
+					"optimized":         {children: nil},
+					"probe-idle-tunnel": {children: nil},
+					"interval":          {args: 1, children: nil},
+					"threshold":         {args: 1, children: nil},
+				}},
+				"local-identity":  {children: nil},
+				"remote-identity": {children: nil},
+				"dynamic":         {children: nil},
 			}},
 		}},
 		"ipsec": {children: map[string]*schemaNode{
@@ -1094,22 +1101,37 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"proposals":               {args: 1, children: nil},
 			}},
 			"gateway": {args: 1, children: map[string]*schemaNode{
-				"address":              {args: 1, children: nil},
-				"local-address":        {args: 1, children: nil},
-				"ike-policy":           {args: 1, children: nil},
-				"external-interface":   {args: 1, children: nil},
-				"version":              {args: 1, children: nil},
-				"no-nat-traversal":     {children: nil},
-				"nat-traversal":        {args: 1, children: nil},
-				"dead-peer-detection":  {args: 1, children: nil},
-				"local-identity":       {children: nil},
-				"remote-identity":      {children: nil},
-				"dynamic":              {children: nil},
+				"address":            {args: 1, children: nil},
+				"local-address":      {args: 1, children: nil},
+				"ike-policy":         {args: 1, children: nil},
+				"external-interface": {args: 1, children: nil},
+				"local-certificate":  {args: 1, children: nil},
+				"version":            {args: 1, children: nil},
+				"no-nat-traversal":   {children: nil},
+				"nat-traversal":      {args: 1, children: nil},
+				"dead-peer-detection": {children: map[string]*schemaNode{
+					"always-send":       {children: nil},
+					"optimized":         {children: nil},
+					"probe-idle-tunnel": {children: nil},
+					"interval":          {args: 1, children: nil},
+					"threshold":         {args: 1, children: nil},
+				}},
+				"local-identity":  {children: nil},
+				"remote-identity": {children: nil},
+				"dynamic":         {children: nil},
 			}},
 			"vpn": {args: 1, children: map[string]*schemaNode{
 				"bind-interface":    {args: 1, children: nil},
-				"df-bit":           {args: 1, children: nil},
+				"df-bit":            {args: 1, children: nil},
 				"establish-tunnels": {args: 1, children: nil},
+				"local-identity":    {args: 1, children: nil},
+				"remote-identity":   {args: 1, children: nil},
+				"pre-shared-key":    {args: 1, children: nil},
+				"local-address":     {args: 1, children: nil},
+				"traffic-selector": {args: 1, children: map[string]*schemaNode{
+					"local-ip":  {args: 1, children: nil},
+					"remote-ip": {args: 1, children: nil},
+				}},
 				"ike": {children: map[string]*schemaNode{
 					"gateway":      {args: 1, children: nil},
 					"ipsec-policy": {args: 1, children: nil},
@@ -1122,7 +1144,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"hostname":        {args: 1, children: nil},
 				"update-interval": {args: 1, children: nil},
 				"hold-interval":   {args: 1, children: nil},
-				"feed-name":       {args: 1, children: map[string]*schemaNode{
+				"feed-name": {args: 1, children: map[string]*schemaNode{
 					"path": {args: 1, children: nil},
 				}},
 			}},
@@ -1148,23 +1170,23 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		}},
 	}},
 	"interfaces": {desc: "Interface configuration", wildcard: &schemaNode{valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
-		"description":            {desc: "Text description of interface", args: 1, children: nil},
-		"mtu":                    {desc: "Maximum transmit packet size", args: 1, children: nil},
-		"speed":                  {desc: "Link speed", args: 1, children: nil},
-		"duplex":                 {desc: "Link duplex mode", args: 1, children: nil},
-		"bandwidth":              {desc: "Interface bandwidth", args: 1, children: nil},
-		"disable":                {desc: "Disable this interface", children: nil},
-		"vlan-tagging":           {desc: "Enable 802.1Q VLAN tagging", children: nil},
-		"flexible-vlan-tagging":  {desc: "Enable flexible 802.1Q VLAN tagging (QinQ)", children: nil},
-		"encapsulation":          {desc: "Physical link-layer encapsulation", args: 1, children: nil},
+		"description":           {desc: "Text description of interface", args: 1, children: nil},
+		"mtu":                   {desc: "Maximum transmit packet size", args: 1, children: nil},
+		"speed":                 {desc: "Link speed", args: 1, children: nil},
+		"duplex":                {desc: "Link duplex mode", args: 1, children: nil},
+		"bandwidth":             {desc: "Interface bandwidth", args: 1, children: nil},
+		"disable":               {desc: "Disable this interface", children: nil},
+		"vlan-tagging":          {desc: "Enable 802.1Q VLAN tagging", children: nil},
+		"flexible-vlan-tagging": {desc: "Enable flexible 802.1Q VLAN tagging (QinQ)", children: nil},
+		"encapsulation":         {desc: "Physical link-layer encapsulation", args: 1, children: nil},
 		"gigether-options": {desc: "Gigabit Ethernet interface options", children: map[string]*schemaNode{
 			"redundant-parent": {desc: "Parent of this redundant interface", args: 1, children: nil},
 			"802.3ad":          {desc: "Link aggregation group", args: 1, children: nil},
 		}},
 		"aggregated-ether-options": {desc: "Aggregated Ethernet interface options", children: map[string]*schemaNode{
 			"lacp": {desc: "LACP parameters", children: map[string]*schemaNode{
-				"active":  {desc: "Active LACP mode", children: nil},
-				"passive": {desc: "Passive LACP mode", children: nil},
+				"active":   {desc: "Active LACP mode", children: nil},
+				"passive":  {desc: "Passive LACP mode", children: nil},
 				"periodic": {desc: "LACP timer period", args: 1, children: nil},
 			}},
 			"link-speed":    {desc: "Member link speed", args: 1, children: nil},
@@ -1177,11 +1199,11 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"member-interfaces": {desc: "Member interfaces", children: nil},
 		}},
 		"tunnel": {desc: "Tunnel parameters", children: map[string]*schemaNode{
-			"source":      {desc: "Tunnel source address", args: 1, children: nil},
-			"destination": {desc: "Tunnel destination address", args: 1, children: nil},
-			"mode":        {desc: "Tunnel mode", args: 1, children: nil},
-			"key":         {desc: "Tunnel key", args: 1, children: nil},
-			"ttl":         {desc: "Time to live", args: 1, children: nil},
+			"source":          {desc: "Tunnel source address", args: 1, children: nil},
+			"destination":     {desc: "Tunnel destination address", args: 1, children: nil},
+			"mode":            {desc: "Tunnel mode", args: 1, children: nil},
+			"key":             {desc: "Tunnel key", args: 1, children: nil},
+			"ttl":             {desc: "Time to live", args: 1, children: nil},
 			"keepalive":       {desc: "Keepalive interval", args: 1, children: nil},
 			"keepalive-retry": {desc: "Keepalive retry count", args: 1, children: nil},
 			"routing-instance": {desc: "Routing instance", children: map[string]*schemaNode{
@@ -1194,11 +1216,11 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"vlan-id":        {args: 1, children: nil},
 			"inner-vlan-id":  {args: 1, children: nil},
 			"tunnel": {desc: "Tunnel parameters", children: map[string]*schemaNode{
-				"source":      {desc: "Tunnel source address", args: 1, children: nil},
-				"destination": {desc: "Tunnel destination address", args: 1, children: nil},
-				"mode":        {desc: "Tunnel mode", args: 1, children: nil},
-				"key":         {desc: "Tunnel key", args: 1, children: nil},
-				"ttl":         {desc: "Time to live", args: 1, children: nil},
+				"source":          {desc: "Tunnel source address", args: 1, children: nil},
+				"destination":     {desc: "Tunnel destination address", args: 1, children: nil},
+				"mode":            {desc: "Tunnel mode", args: 1, children: nil},
+				"key":             {desc: "Tunnel key", args: 1, children: nil},
+				"ttl":             {desc: "Time to live", args: 1, children: nil},
 				"keepalive":       {desc: "Keepalive interval", args: 1, children: nil},
 				"keepalive-retry": {desc: "Keepalive retry count", args: 1, children: nil},
 				"routing-instance": {desc: "Routing instance", children: map[string]*schemaNode{
@@ -1207,7 +1229,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			}},
 			"family": {children: map[string]*schemaNode{
 				"inet": {children: map[string]*schemaNode{
-					"mtu":     {args: 1, children: nil},
+					"mtu": {args: 1, children: nil},
 					"address": {args: 1, children: map[string]*schemaNode{
 						"primary":   {children: nil},
 						"preferred": {children: nil},
@@ -1230,7 +1252,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"inet6": {children: map[string]*schemaNode{
 					"mtu":         {args: 1, children: nil},
 					"dad-disable": {children: nil},
-					"address":     {args: 1, children: map[string]*schemaNode{
+					"address": {args: 1, children: map[string]*schemaNode{
 						"primary":   {children: nil},
 						"preferred": {children: nil},
 					}},
@@ -1399,11 +1421,11 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			}},
 		}},
 		"bgp": {children: map[string]*schemaNode{
-			"local-as":        {args: 1, children: nil},
-			"router-id":       {args: 1, children: nil},
-			"cluster-id":      {args: 1, children: nil},
+			"local-as":         {args: 1, children: nil},
+			"router-id":        {args: 1, children: nil},
+			"cluster-id":       {args: 1, children: nil},
 			"graceful-restart": {children: nil},
-			"log-updown":      {children: nil},
+			"log-updown":       {children: nil},
 			"multipath": {children: map[string]*schemaNode{
 				"multiple-as": {children: nil},
 			}},
@@ -1413,7 +1435,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"suppress":     {args: 1, children: nil},
 				"max-suppress": {args: 1, children: nil},
 			}},
-			"export":          {args: 1, multi: true, children: nil},
+			"export": {args: 1, multi: true, children: nil},
 			"group": {args: 1, children: map[string]*schemaNode{
 				"peer-as":            {args: 1, children: nil},
 				"description":        {args: 1, children: nil},
@@ -1445,9 +1467,9 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				}},
 				"neighbor": {args: 1, children: map[string]*schemaNode{
 					"description":            {args: 1, children: nil},
-					"peer-as":               {args: 1, children: nil},
-					"multihop":              {args: 1, children: nil},
-					"authentication-key":    {args: 1, children: nil},
+					"peer-as":                {args: 1, children: nil},
+					"multihop":               {args: 1, children: nil},
+					"authentication-key":     {args: 1, children: nil},
 					"route-reflector-client": {children: nil},
 					"default-originate":      {children: nil},
 					"loops":                  {args: 1, children: nil},
@@ -1484,10 +1506,10 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"authentication-type": {args: 1, children: nil},
 		}},
 		"isis": {children: map[string]*schemaNode{
-			"net":                 {args: 1, children: nil},
-			"level":              {args: 1, children: nil},
-			"is-type":            {args: 1, children: nil},
-			"export":             {args: 1, multi: true, children: nil},
+			"net":     {args: 1, children: nil},
+			"level":   {args: 1, children: nil},
+			"is-type": {args: 1, children: nil},
+			"export":  {args: 1, multi: true, children: nil},
 			"interface": {args: 1, valueHint: ValueHintInterfaceName, children: map[string]*schemaNode{
 				"level":               {args: 1, children: nil},
 				"passive":             {children: nil},
@@ -1508,7 +1530,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"interface": {args: 1, valueHint: ValueHintInterfaceName, children: map[string]*schemaNode{
 				"prefix":     {args: 1, children: nil}, // prefix <prefix/len>
 				"preference": {args: 1, children: nil},
-				"nat-prefix":   {args: 1, children: map[string]*schemaNode{
+				"nat-prefix": {args: 1, children: map[string]*schemaNode{
 					"lifetime": {args: 1, children: nil},
 				}},
 				"nat64prefix": {args: 1, children: map[string]*schemaNode{
@@ -1541,24 +1563,24 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 	}},
 	"chassis": {children: map[string]*schemaNode{
 		"cluster": {children: map[string]*schemaNode{
-			"cluster-id":           {args: 1, children: nil},
-			"node":                 {args: 1, children: nil},
-			"reth-count":           {args: 1, children: nil},
-			"heartbeat-interval":   {args: 1, children: nil},
-			"heartbeat-threshold":  {args: 1, children: nil},
+			"cluster-id":            {args: 1, children: nil},
+			"node":                  {args: 1, children: nil},
+			"reth-count":            {args: 1, children: nil},
+			"heartbeat-interval":    {args: 1, children: nil},
+			"heartbeat-threshold":   {args: 1, children: nil},
 			"control-link-recovery": {children: nil},
 			"control-ports": {children: map[string]*schemaNode{
 				"fpc": {args: 1, children: map[string]*schemaNode{
 					"port": {args: 1, children: nil},
 				}},
 			}},
-			"control-interface":          {args: 1, children: nil},
-			"peer-address":              {args: 1, children: nil},
-			"fabric-interface":          {args: 1, children: nil},
-			"fabric-peer-address":       {args: 1, children: nil},
-			"configuration-synchronize":      {children: nil},
-			"nat-state-synchronization":      {children: nil},
-			"ipsec-session-synchronization":  {children: nil},
+			"control-interface":             {args: 1, children: nil},
+			"peer-address":                  {args: 1, children: nil},
+			"fabric-interface":              {args: 1, children: nil},
+			"fabric-peer-address":           {args: 1, children: nil},
+			"configuration-synchronize":     {children: nil},
+			"nat-state-synchronization":     {children: nil},
+			"ipsec-session-synchronization": {children: nil},
 			"reth-advertise-interval":       {args: 1, children: nil},
 			"hitless-restart":               {children: nil},
 			"peer-fencing":                  {args: 1, children: nil},
@@ -1587,8 +1609,8 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 	"firewall": {children: map[string]*schemaNode{
 		"policer": {args: 1, multi: true, children: map[string]*schemaNode{
 			"if-exceeding": {children: map[string]*schemaNode{
-				"bandwidth-limit":   {args: 1, children: nil},
-				"burst-size-limit":  {args: 1, children: nil},
+				"bandwidth-limit":  {args: 1, children: nil},
+				"burst-size-limit": {args: 1, children: nil},
 			}},
 			"logical-interface-policer": {children: nil},
 			"then": {children: map[string]*schemaNode{
@@ -1598,19 +1620,19 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		}},
 		"three-color-policer": {args: 1, multi: true, children: map[string]*schemaNode{
 			"single-rate": {children: map[string]*schemaNode{
-				"color-blind":                  {children: nil},
-				"color-aware":                  {children: nil},
-				"committed-information-rate":    {args: 1, children: nil},
-				"committed-burst-size":          {args: 1, children: nil},
-				"excess-burst-size":             {args: 1, children: nil},
+				"color-blind":                {children: nil},
+				"color-aware":                {children: nil},
+				"committed-information-rate": {args: 1, children: nil},
+				"committed-burst-size":       {args: 1, children: nil},
+				"excess-burst-size":          {args: 1, children: nil},
 			}},
 			"two-rate": {children: map[string]*schemaNode{
-				"color-blind":                  {children: nil},
-				"color-aware":                  {children: nil},
-				"committed-information-rate":    {args: 1, children: nil},
-				"committed-burst-size":          {args: 1, children: nil},
-				"peak-information-rate":         {args: 1, children: nil},
-				"peak-burst-size":               {args: 1, children: nil},
+				"color-blind":                {children: nil},
+				"color-aware":                {children: nil},
+				"committed-information-rate": {args: 1, children: nil},
+				"committed-burst-size":       {args: 1, children: nil},
+				"peak-information-rate":      {args: 1, children: nil},
+				"peak-burst-size":            {args: 1, children: nil},
 			}},
 			"then": {children: map[string]*schemaNode{
 				"discard":       {children: nil},
@@ -1636,12 +1658,12 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 							"is-fragment":             {children: nil},
 							"flexible-match-range": {children: map[string]*schemaNode{
 								"range": {args: 1, children: map[string]*schemaNode{
-									"match-start":  {args: 1, children: nil},
-									"byte-offset":  {args: 1, children: nil},
-									"bit-length":   {args: 1, children: nil},
-									"range":        {args: 1, children: nil},
-									"match-value":  {args: 1, children: nil},
-									"match-mask":   {args: 1, children: nil},
+									"match-start": {args: 1, children: nil},
+									"byte-offset": {args: 1, children: nil},
+									"bit-length":  {args: 1, children: nil},
+									"range":       {args: 1, children: nil},
+									"match-value": {args: 1, children: nil},
+									"match-mask":  {args: 1, children: nil},
 								}},
 							}},
 						}},
@@ -1680,12 +1702,12 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 							"is-fragment":             {children: nil},
 							"flexible-match-range": {children: map[string]*schemaNode{
 								"range": {args: 1, children: map[string]*schemaNode{
-									"match-start":  {args: 1, children: nil},
-									"byte-offset":  {args: 1, children: nil},
-									"bit-length":   {args: 1, children: nil},
-									"range":        {args: 1, children: nil},
-									"match-value":  {args: 1, children: nil},
-									"match-mask":   {args: 1, children: nil},
+									"match-start": {args: 1, children: nil},
+									"byte-offset": {args: 1, children: nil},
+									"bit-length":  {args: 1, children: nil},
+									"range":       {args: 1, children: nil},
+									"match-value": {args: 1, children: nil},
+									"match-mask":  {args: 1, children: nil},
 								}},
 							}},
 						}},
@@ -1795,7 +1817,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"api-key": {args: 1, children: nil},
 				}},
 			}},
-			"dns":               {children: nil},
+			"dns": {children: nil},
 			"dhcp-local-server": {children: map[string]*schemaNode{
 				"group": {args: 1, children: map[string]*schemaNode{
 					"pool": {args: 1, children: nil},
@@ -1822,7 +1844,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		"flow-monitoring": {children: map[string]*schemaNode{
 			"version9": {children: map[string]*schemaNode{
 				"template": {args: 1, children: map[string]*schemaNode{
-					"flow-active-timeout":  {args: 1, children: nil},
+					"flow-active-timeout":   {args: 1, children: nil},
 					"flow-inactive-timeout": {args: 1, children: nil},
 					"template-refresh-rate": {children: map[string]*schemaNode{
 						"seconds": {args: 1, children: nil},
@@ -1831,7 +1853,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			}},
 			"version-ipfix": {children: map[string]*schemaNode{
 				"template": {args: 1, children: map[string]*schemaNode{
-					"flow-active-timeout":  {args: 1, children: nil},
+					"flow-active-timeout":   {args: 1, children: nil},
 					"flow-inactive-timeout": {args: 1, children: nil},
 					"template-refresh-rate": {children: map[string]*schemaNode{
 						"seconds": {args: 1, children: nil},
@@ -1859,13 +1881,13 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"family": {children: map[string]*schemaNode{
 					"inet": {children: map[string]*schemaNode{
 						"output": {children: map[string]*schemaNode{
-							"flow-server": {args: 1, children: nil},
+							"flow-server":  {args: 1, children: nil},
 							"inline-jflow": {children: nil},
 						}},
 					}},
 					"inet6": {children: map[string]*schemaNode{
 						"output": {children: map[string]*schemaNode{
-							"flow-server": {args: 1, children: nil},
+							"flow-server":  {args: 1, children: nil},
 							"inline-jflow": {children: nil},
 						}},
 					}},
@@ -1957,13 +1979,13 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"suppress":     {args: 1, children: nil},
 					"max-suppress": {args: 1, children: nil},
 				}},
-				"group":            {args: 1, children: nil},
+				"group": {args: 1, children: nil},
 			}},
 			"isis": {children: map[string]*schemaNode{
-				"net":                 {args: 1, children: nil},
-				"level":              {args: 1, children: nil},
-				"is-type":            {args: 1, children: nil},
-				"export":             {args: 1, multi: true, children: nil},
+				"net":     {args: 1, children: nil},
+				"level":   {args: 1, children: nil},
+				"is-type": {args: 1, children: nil},
+				"export":  {args: 1, multi: true, children: nil},
 				"interface": {args: 1, valueHint: ValueHintInterfaceName, children: map[string]*schemaNode{
 					"level":               {args: 1, children: nil},
 					"passive":             {children: nil},

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -4098,6 +4098,10 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 				if v != "" {
 					gw.ExternalIface = v
 				}
+			case "local-certificate":
+				if v != "" {
+					gw.LocalCertificate = v
+				}
 			case "version":
 				if v != "" {
 					gw.Version = v
@@ -4113,11 +4117,7 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 					gw.NoNATTraversal = true
 				}
 			case "dead-peer-detection":
-				if v != "" {
-					gw.DeadPeerDetect = v
-				} else {
-					gw.DeadPeerDetect = "always-send"
-				}
+				parseDeadPeerDetectionNode(p, gw)
 			case "local-identity":
 				if len(p.Keys) >= 3 {
 					gw.LocalIDType = p.Keys[1]
@@ -4155,6 +4155,35 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 	}
 
 	return nil
+}
+
+func parseDeadPeerDetectionNode(node *Node, gw *IPsecGateway) {
+	if gw == nil || node == nil {
+		return
+	}
+
+	if v := nodeVal(node); v != "" {
+		gw.DeadPeerDetect = v
+	}
+
+	for _, c := range node.Children {
+		switch c.Name() {
+		case "always-send", "optimized", "probe-idle-tunnel":
+			gw.DeadPeerDetect = c.Name()
+		case "interval":
+			if n, err := strconv.Atoi(nodeVal(c)); err == nil {
+				gw.DPDInterval = n
+			}
+		case "threshold":
+			if n, err := strconv.Atoi(nodeVal(c)); err == nil {
+				gw.DPDThreshold = n
+			}
+		}
+	}
+
+	if gw.DeadPeerDetect == "" && (len(node.Children) > 0 || len(node.Keys) > 1) {
+		gw.DeadPeerDetect = "always-send"
+	}
 }
 
 func compileIPsec(node *Node, sec *SecurityConfig) error {
@@ -4243,6 +4272,10 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 				if v != "" {
 					gw.ExternalIface = v
 				}
+			case "local-certificate":
+				if v != "" {
+					gw.LocalCertificate = v
+				}
 			case "version":
 				if v != "" {
 					gw.Version = v
@@ -4258,11 +4291,7 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 					gw.NoNATTraversal = true
 				}
 			case "dead-peer-detection":
-				if v != "" {
-					gw.DeadPeerDetect = v
-				} else {
-					gw.DeadPeerDetect = "always-send"
-				}
+				parseDeadPeerDetectionNode(p, gw)
 			case "local-identity":
 				if len(p.Keys) >= 3 {
 					gw.LocalIDType = p.Keys[1]
@@ -4334,6 +4363,21 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 			case "local-address":
 				vpn.LocalAddr = v
 			}
+		}
+		for _, tsInst := range namedInstances(inst.node.FindChildren("traffic-selector")) {
+			if vpn.TrafficSelectors == nil {
+				vpn.TrafficSelectors = make(map[string]*IPsecTrafficSelector)
+			}
+			ts := &IPsecTrafficSelector{Name: tsInst.name}
+			for _, p := range tsInst.node.Children {
+				switch p.Name() {
+				case "local-ip":
+					ts.LocalIP = nodeVal(p)
+				case "remote-ip":
+					ts.RemoteIP = nodeVal(p)
+				}
+			}
+			vpn.TrafficSelectors[ts.Name] = ts
 		}
 		sec.IPsec.VPNs[vpn.Name] = vpn
 	}

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -4543,6 +4543,138 @@ func TestIKEAdvancedFeatures(t *testing.T) {
 	}
 }
 
+func TestIKEGatewayLocalCertificateAndDPD(t *testing.T) {
+	input := `security {
+    ike {
+        gateway remote-gw {
+            ike-policy ike-pol;
+            address 203.0.113.1;
+            local-certificate gw-cert.pem;
+            dead-peer-detection {
+                optimized;
+                interval 7;
+                threshold 3;
+            }
+            external-interface wan0;
+        }
+    }
+}`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	gw := cfg.Security.IPsec.Gateways["remote-gw"]
+	if gw == nil {
+		t.Fatal("missing gateway remote-gw")
+	}
+	if gw.LocalCertificate != "gw-cert.pem" {
+		t.Fatalf("local-certificate = %q, want gw-cert.pem", gw.LocalCertificate)
+	}
+	if gw.DeadPeerDetect != "optimized" {
+		t.Fatalf("dead-peer-detection = %q, want optimized", gw.DeadPeerDetect)
+	}
+	if gw.DPDInterval != 7 {
+		t.Fatalf("dpd interval = %d, want 7", gw.DPDInterval)
+	}
+	if gw.DPDThreshold != 3 {
+		t.Fatalf("dpd threshold = %d, want 3", gw.DPDThreshold)
+	}
+}
+
+func TestIPsecTrafficSelectorSyntax(t *testing.T) {
+	input := `security {
+    ipsec {
+        vpn site-a {
+            bind-interface st0.0;
+            traffic-selector corp-a {
+                local-ip 10.0.1.0/24;
+                remote-ip 10.10.1.0/24;
+            }
+            traffic-selector corp-b {
+                local-ip 10.0.2.0/24;
+                remote-ip 10.10.2.0/24;
+            }
+        }
+    }
+}`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	vpn := cfg.Security.IPsec.VPNs["site-a"]
+	if vpn == nil {
+		t.Fatal("missing VPN site-a")
+	}
+	if len(vpn.TrafficSelectors) != 2 {
+		t.Fatalf("expected 2 traffic selectors, got %d", len(vpn.TrafficSelectors))
+	}
+	if vpn.TrafficSelectors["corp-a"].LocalIP != "10.0.1.0/24" {
+		t.Fatalf("corp-a local-ip = %q", vpn.TrafficSelectors["corp-a"].LocalIP)
+	}
+	if vpn.TrafficSelectors["corp-b"].RemoteIP != "10.10.2.0/24" {
+		t.Fatalf("corp-b remote-ip = %q", vpn.TrafficSelectors["corp-b"].RemoteIP)
+	}
+}
+
+func TestIKEGatewayLocalCertificateAndTrafficSelectorSetSyntax(t *testing.T) {
+	setCommands := []string{
+		`set security ike gateway gw1 address 203.0.113.1`,
+		`set security ike gateway gw1 local-certificate gw-cert.pem`,
+		`set security ike gateway gw1 dead-peer-detection optimized`,
+		`set security ike gateway gw1 dead-peer-detection interval 7`,
+		`set security ike gateway gw1 dead-peer-detection threshold 3`,
+		`set security ipsec vpn site-a bind-interface st0.0`,
+		`set security ipsec vpn site-a traffic-selector corp-a local-ip 10.0.1.0/24`,
+		`set security ipsec vpn site-a traffic-selector corp-a remote-ip 10.10.1.0/24`,
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	gw := cfg.Security.IPsec.Gateways["gw1"]
+	if gw == nil {
+		t.Fatal("missing gateway gw1")
+	}
+	if gw.LocalCertificate != "gw-cert.pem" {
+		t.Fatalf("local-certificate = %q", gw.LocalCertificate)
+	}
+	if gw.DeadPeerDetect != "optimized" || gw.DPDInterval != 7 || gw.DPDThreshold != 3 {
+		t.Fatalf("unexpected DPD config: %+v", gw)
+	}
+
+	vpn := cfg.Security.IPsec.VPNs["site-a"]
+	if vpn == nil || vpn.TrafficSelectors["corp-a"] == nil {
+		t.Fatal("missing traffic-selector corp-a")
+	}
+	if vpn.TrafficSelectors["corp-a"].LocalIP != "10.0.1.0/24" {
+		t.Fatalf("corp-a local-ip = %q", vpn.TrafficSelectors["corp-a"].LocalIP)
+	}
+}
+
 func TestIKEAdvancedSetSyntax(t *testing.T) {
 	setCommands := []string{
 		`set security ike proposal ike-p1 authentication-method pre-shared-keys`,
@@ -15666,9 +15798,9 @@ func TestValidateFabric1MissingPeerAddress(t *testing.T) {
 		},
 		Chassis: ChassisConfig{
 			Cluster: &ClusterConfig{
-				FabricInterface:    "fab0",
-				FabricPeerAddress:  "10.99.1.2",
-				Fabric1Interface:   "fab1",
+				FabricInterface:   "fab0",
+				FabricPeerAddress: "10.99.1.2",
+				Fabric1Interface:  "fab1",
 				// Missing Fabric1PeerAddress
 			},
 		},
@@ -15812,9 +15944,9 @@ func TestPeerFromPointToPoint(t *testing.T) {
 		{"10.99.2.2/30", "10.99.2.1"},
 		{"192.168.0.1/31", "192.168.0.0"},
 		{"192.168.0.0/31", "192.168.0.1"},
-		{"10.0.0.0/30", ""},  // network address
-		{"10.0.0.3/30", ""},  // broadcast
-		{"10.0.0.1/24", ""},  // not point-to-point
+		{"10.0.0.0/30", ""}, // network address
+		{"10.0.0.3/30", ""}, // broadcast
+		{"10.0.0.1/24", ""}, // not point-to-point
 		{"invalid", ""},
 		{"", ""},
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -124,10 +124,10 @@ type RedundancyGroup struct {
 	ID                 int
 	NodePriorities     map[int]int // node-id -> priority
 	GratuitousARPCount int
-	Preempt              bool
-	StrictVIPOwnership   bool
-	InterfaceMonitors    []*InterfaceMonitor
-	IPMonitoring         *IPMonitoring
+	Preempt            bool
+	StrictVIPOwnership bool
+	InterfaceMonitors  []*InterfaceMonitor
+	IPMonitoring       *IPMonitoring
 }
 
 // InterfaceMonitor defines an interface health monitor within a redundancy group.
@@ -709,11 +709,11 @@ type DynamicAddressConfig struct {
 // FeedServer defines a remote address feed source with optional per-feed paths.
 type FeedServer struct {
 	Name           string
-	URL            string // explicit url (takes precedence)
-	Hostname       string // hostname for building URLs with per-feed paths
-	UpdateInterval int    // seconds (0 = default 3600)
-	HoldInterval   int    // seconds (0 = default 7200)
-	FeedName       string // single feed-name (backward compat, no path)
+	URL            string      // explicit url (takes precedence)
+	Hostname       string      // hostname for building URLs with per-feed paths
+	UpdateInterval int         // seconds (0 = default 3600)
+	HoldInterval   int         // seconds (0 = default 7200)
+	FeedName       string      // single feed-name (backward compat, no path)
 	FeedEntries    []FeedEntry // named feeds with per-feed paths
 }
 
@@ -1533,20 +1533,29 @@ type IPsecPolicyDef struct {
 
 // IPsecGateway defines a remote IKE gateway.
 type IPsecGateway struct {
-	Name            string
-	Address         string // remote gateway IP
-	DynamicHostname string // dynamic peer hostname (DNS-resolved)
-	LocalAddress    string // local IP
-	IKEPolicy       string // IKE policy reference
-	ExternalIface   string // external-facing interface
-	Version         string // "v1-only", "v2-only" (empty = both)
-	NoNATTraversal  bool   // disable NAT-T (legacy, use NATTraversal)
-	NATTraversal    string // "enable" (default), "disable", "force"
-	DeadPeerDetect  string // "always-send", "optimized", "probe-idle"
-	LocalIDType     string // "hostname", "inet", "fqdn"
-	LocalIDValue    string // identity value
-	RemoteIDType    string // "hostname", "inet", "fqdn"
-	RemoteIDValue   string // identity value
+	Name             string
+	Address          string // remote gateway IP
+	DynamicHostname  string // dynamic peer hostname (DNS-resolved)
+	LocalAddress     string // local IP
+	IKEPolicy        string // IKE policy reference
+	ExternalIface    string // external-facing interface
+	LocalCertificate string // local certificate name for pubkey auth
+	Version          string // "v1-only", "v2-only" (empty = both)
+	NoNATTraversal   bool   // disable NAT-T (legacy, use NATTraversal)
+	NATTraversal     string // "enable" (default), "disable", "force"
+	DeadPeerDetect   string // "always-send", "optimized", "probe-idle"
+	DPDInterval      int    // seconds
+	DPDThreshold     int    // retry count before peer is considered dead
+	LocalIDType      string // "hostname", "inet", "fqdn"
+	LocalIDValue     string // identity value
+	RemoteIDType     string // "hostname", "inet", "fqdn"
+	RemoteIDValue    string // identity value
+}
+
+type IPsecTrafficSelector struct {
+	Name     string
+	LocalIP  string
+	RemoteIP string
 }
 
 // IPsecVPN defines an IPsec VPN tunnel.
@@ -1561,6 +1570,7 @@ type IPsecVPN struct {
 	BindInterface    string // tunnel interface (e.g. "st0.0") — creates xfrmi with if_id
 	DFBit            string // "copy", "set", "clear"
 	EstablishTunnels string // "immediately", "on-traffic"
+	TrafficSelectors map[string]*IPsecTrafficSelector
 }
 
 // RoutingInstanceConfig represents a VRF-based routing instance.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1874,7 +1874,7 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 	// Always call Apply so stale swanctl config is removed when VPNs are
 	// deleted from config.
 	if d.ipsec != nil {
-		if err := d.ipsec.Apply(&cfg.Security.IPsec); err != nil {
+		if err := d.ipsec.Apply(ipsec.PrepareConfig(cfg)); err != nil {
 			slog.Warn("failed to apply IPsec config", "err", err)
 		}
 	}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -51,46 +51,46 @@ import (
 
 // Config configures the gRPC server.
 type Config struct {
-	Store           *configstore.Store
-	DP              dataplane.DataPlane
-	EventBuf        *logging.EventBuffer
-	GC              *conntrack.GC
-	Routing         *routing.Manager
-	FRR             *frr.Manager
-	IPsec           *ipsec.Manager
-	Cluster         *cluster.Manager
-	DHCP            *dhcp.Manager
-	DHCPServer      *dhcpserver.Manager
-	RPMResultsFn    func() []*rpm.ProbeResult        // returns live RPM results
-	FeedsFn         func() map[string]feeds.FeedInfo // returns live feed status
-	LLDPNeighborsFn func() []*lldp.Neighbor          // returns live LLDP neighbors
-	ApplyFn         func(*config.Config)             // daemon's applyConfig callback
-	VRRPMgr         *vrrp.Manager                    // native VRRP manager
-	RAMgr           *ra.Manager                      // embedded RA sender manager
+	Store            *configstore.Store
+	DP               dataplane.DataPlane
+	EventBuf         *logging.EventBuffer
+	GC               *conntrack.GC
+	Routing          *routing.Manager
+	FRR              *frr.Manager
+	IPsec            *ipsec.Manager
+	Cluster          *cluster.Manager
+	DHCP             *dhcp.Manager
+	DHCPServer       *dhcpserver.Manager
+	RPMResultsFn     func() []*rpm.ProbeResult        // returns live RPM results
+	FeedsFn          func() map[string]feeds.FeedInfo // returns live feed status
+	LLDPNeighborsFn  func() []*lldp.Neighbor          // returns live LLDP neighbors
+	ApplyFn          func(*config.Config)             // daemon's applyConfig callback
+	VRRPMgr          *vrrp.Manager                    // native VRRP manager
+	RAMgr            *ra.Manager                      // embedded RA sender manager
 	Version          string                           // software version string
-	FabricPeerAddrFn func() []string                   // returns peer fabric IPs (fab0, fab1; empty if standalone)
+	FabricPeerAddrFn func() []string                  // returns peer fabric IPs (fab0, fab1; empty if standalone)
 	FabricVRFDevice  string                           // VRF for fabric interface (e.g. "vrf-mgmt")
 }
 
 // Server implements the BpfrxService gRPC service.
 type Server struct {
 	pb.UnimplementedBpfrxServiceServer
-	store           *configstore.Store
-	dp              dataplane.DataPlane
-	eventBuf        *logging.EventBuffer
-	gc              *conntrack.GC
-	routing         *routing.Manager
-	frr             *frr.Manager
-	ipsec           *ipsec.Manager
-	cluster         *cluster.Manager
-	dhcp            *dhcp.Manager
-	dhcpServer      *dhcpserver.Manager
-	rpmResultsFn    func() []*rpm.ProbeResult
-	feedsFn         func() map[string]feeds.FeedInfo
-	lldpNeighborsFn func() []*lldp.Neighbor
-	applyFn         func(*config.Config)
-	vrrpMgr         *vrrp.Manager
-	raMgr           *ra.Manager
+	store            *configstore.Store
+	dp               dataplane.DataPlane
+	eventBuf         *logging.EventBuffer
+	gc               *conntrack.GC
+	routing          *routing.Manager
+	frr              *frr.Manager
+	ipsec            *ipsec.Manager
+	cluster          *cluster.Manager
+	dhcp             *dhcp.Manager
+	dhcpServer       *dhcpserver.Manager
+	rpmResultsFn     func() []*rpm.ProbeResult
+	feedsFn          func() map[string]feeds.FeedInfo
+	lldpNeighborsFn  func() []*lldp.Neighbor
+	applyFn          func(*config.Config)
+	vrrpMgr          *vrrp.Manager
+	raMgr            *ra.Manager
 	startTime        time.Time
 	addr             string
 	version          string
@@ -104,22 +104,22 @@ type Server struct {
 // gRPC is ever exposed on non-loopback addresses.
 func NewServer(addr string, cfg Config) *Server {
 	return &Server{
-		store:           cfg.Store,
-		dp:              cfg.DP,
-		eventBuf:        cfg.EventBuf,
-		gc:              cfg.GC,
-		routing:         cfg.Routing,
-		frr:             cfg.FRR,
-		ipsec:           cfg.IPsec,
-		cluster:         cfg.Cluster,
-		dhcp:            cfg.DHCP,
-		dhcpServer:      cfg.DHCPServer,
-		rpmResultsFn:    cfg.RPMResultsFn,
-		feedsFn:         cfg.FeedsFn,
-		lldpNeighborsFn: cfg.LLDPNeighborsFn,
-		applyFn:         cfg.ApplyFn,
-		vrrpMgr:         cfg.VRRPMgr,
-		raMgr:           cfg.RAMgr,
+		store:            cfg.Store,
+		dp:               cfg.DP,
+		eventBuf:         cfg.EventBuf,
+		gc:               cfg.GC,
+		routing:          cfg.Routing,
+		frr:              cfg.FRR,
+		ipsec:            cfg.IPsec,
+		cluster:          cfg.Cluster,
+		dhcp:             cfg.DHCP,
+		dhcpServer:       cfg.DHCPServer,
+		rpmResultsFn:     cfg.RPMResultsFn,
+		feedsFn:          cfg.FeedsFn,
+		lldpNeighborsFn:  cfg.LLDPNeighborsFn,
+		applyFn:          cfg.ApplyFn,
+		vrrpMgr:          cfg.VRRPMgr,
+		raMgr:            cfg.RAMgr,
 		startTime:        time.Now(),
 		addr:             addr,
 		version:          cfg.Version,
@@ -6765,6 +6765,9 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 				if gw.ExternalIface != "" {
 					fmt.Fprintf(&buf, "  External interface: %s\n", gw.ExternalIface)
 				}
+				if gw.LocalCertificate != "" {
+					fmt.Fprintf(&buf, "  Local certificate:  %s\n", gw.LocalCertificate)
+				}
 				if gw.IKEPolicy != "" {
 					fmt.Fprintf(&buf, "  IKE policy:         %s\n", gw.IKEPolicy)
 					if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
@@ -6779,9 +6782,19 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 				fmt.Fprintf(&buf, "  IKE version:        %s\n", ver)
 				if gw.DeadPeerDetect != "" {
 					fmt.Fprintf(&buf, "  DPD:                %s\n", gw.DeadPeerDetect)
+					if gw.DPDInterval > 0 {
+						fmt.Fprintf(&buf, "  DPD interval:       %ds\n", gw.DPDInterval)
+					}
+					if gw.DPDThreshold > 0 {
+						fmt.Fprintf(&buf, "  DPD threshold:      %d\n", gw.DPDThreshold)
+					}
 				}
 				if gw.NoNATTraversal {
 					buf.WriteString("  NAT-T:              disabled\n")
+				} else if gw.NATTraversal == "force" {
+					buf.WriteString("  NAT-T:              force\n")
+				} else if gw.NATTraversal == "enable" {
+					buf.WriteString("  NAT-T:              enabled\n")
 				}
 				if gw.LocalIDValue != "" {
 					fmt.Fprintf(&buf, "  Local identity:     %s %s\n", gw.LocalIDType, gw.LocalIDValue)
@@ -8701,10 +8714,10 @@ func (s *Server) MonitorInterface(req *pb.MonitorInterfaceRequest, stream grpc.S
 
 	// Helper: read interface counters.
 	type ifSnap struct {
-		rxBytes, txBytes, rxPkts, txPkts         uint64
-		rxErrors, txErrors, rxDrops, txDrops      uint64
-		rxFrame, txCarrier, collisions             uint64
-		ts                                         time.Time
+		rxBytes, txBytes, rxPkts, txPkts     uint64
+		rxErrors, txErrors, rxDrops, txDrops uint64
+		rxFrame, txCarrier, collisions       uint64
+		ts                                   time.Time
 	}
 	readSnap := func(name string) *ifSnap {
 		iface, err := net.InterfaceByName(name)

--- a/pkg/ipsec/ipsec.go
+++ b/pkg/ipsec/ipsec.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/psaab/bpfrx/pkg/config"
@@ -41,7 +42,10 @@ func (m *Manager) Apply(ipsecCfg *config.IPsecConfig) error {
 		return m.Clear()
 	}
 
-	cfg := m.generateConfig(ipsecCfg)
+	cfg, err := m.renderConfig(ipsecCfg)
+	if err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(m.configDir, 0755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
@@ -71,13 +75,19 @@ func (m *Manager) Clear() error {
 }
 
 func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
+	cfg, _ := m.renderConfig(ipsecCfg)
+	return cfg
+}
+
+func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	var b strings.Builder
 
 	b.WriteString("# bpfrx managed config - do not edit\n\n")
 
 	// Connections
 	b.WriteString("connections {\n")
-	for name, vpn := range ipsecCfg.VPNs {
+	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
+		vpn := ipsecCfg.VPNs[name]
 		fmt.Fprintf(&b, "  %s {\n", name)
 
 		// Resolve gateway reference
@@ -95,6 +105,12 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 				localAddr = gw.LocalAddress
 			}
 		}
+		authMethod, ikeProposals, ikeLifetime, aggressive, err := resolveIKESettings(ipsecCfg, gw)
+		if err != nil {
+			return "", fmt.Errorf("vpn %s: %w", name, err)
+		}
+		espProposals, espLifetime := resolveESPSettings(ipsecCfg, vpn)
+		dpd := deriveDPD(gw, vpn)
 
 		// IKE version
 		if gw != nil && gw.Version == "v2-only" {
@@ -103,13 +119,8 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 			b.WriteString("    version = 1\n")
 		}
 
-		// Aggressive mode: resolve IKE policy mode through gateway -> ike-policy chain
-		if gw != nil && gw.IKEPolicy != "" {
-			if ikePol, ok := ipsecCfg.IKEPolicies[gw.IKEPolicy]; ok {
-				if ikePol.Mode == "aggressive" {
-					b.WriteString("    aggressive = yes\n")
-				}
-			}
+		if aggressive {
+			b.WriteString("    aggressive = yes\n")
 		}
 
 		if localAddr != "" {
@@ -135,14 +146,19 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 			}
 		}
 
-		// DPD
-		if gw != nil && gw.DeadPeerDetect != "" {
-			b.WriteString("    dpd_delay = 10s\n")
+		if dpd.Delay > 0 {
+			fmt.Fprintf(&b, "    dpd_delay = %ds\n", dpd.Delay)
+		}
+		if dpd.Timeout > 0 {
+			fmt.Fprintf(&b, "    dpd_timeout = %ds\n", dpd.Timeout)
 		}
 
 		// Local auth section
 		b.WriteString("    local {\n")
-		b.WriteString("      auth = psk\n")
+		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
+		if gw != nil && gw.LocalCertificate != "" {
+			fmt.Fprintf(&b, "      certs = %s\n", gw.LocalCertificate)
+		}
 		if gw != nil && gw.LocalIDValue != "" {
 			fmt.Fprintf(&b, "      id = %s\n", formatIdentity(gw.LocalIDType, gw.LocalIDValue))
 		}
@@ -150,44 +166,18 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 
 		// Remote auth section
 		b.WriteString("    remote {\n")
-		b.WriteString("      auth = psk\n")
+		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
 		if gw != nil && gw.RemoteIDValue != "" {
 			fmt.Fprintf(&b, "      id = %s\n", formatIdentity(gw.RemoteIDType, gw.RemoteIDValue))
 		}
 		b.WriteString("    }\n")
 
-		// Build IKE proposals: gateway.IKEPolicy -> IKEPolicy -> IKEProposal
-		if gw != nil && gw.IKEPolicy != "" {
-			if ikePol, ok := ipsecCfg.IKEPolicies[gw.IKEPolicy]; ok {
-				if ikeProp, ok := ipsecCfg.IKEProposals[ikePol.Proposals]; ok {
-					fmt.Fprintf(&b, "    proposals = %s\n", buildIKEProposalFromIKE(ikeProp))
-				}
-			}
-			// Fallback: try IPsec proposals directly (legacy config)
-			if !hasIKEChain(ipsecCfg, gw.IKEPolicy) {
-				if prop, ok := ipsecCfg.Proposals[gw.IKEPolicy]; ok {
-					fmt.Fprintf(&b, "    proposals = %s\n", buildIKEProposal(prop))
-				}
-			}
+		if ikeProposals != "" {
+			fmt.Fprintf(&b, "    proposals = %s\n", ikeProposals)
 		}
-
-		// Build ESP proposals: vpn.IPsecPolicy -> IPsecPolicyDef -> IPsecProposal
-		espProposals := "default"
-		pfsGroup := 0
-		if vpn.IPsecPolicy != "" {
-			if ipsecPol, ok := ipsecCfg.Policies[vpn.IPsecPolicy]; ok {
-				pfsGroup = ipsecPol.PFSGroup
-				propRef := ipsecPol.Proposals
-				if propRef == "" {
-					propRef = vpn.IPsecPolicy
-				}
-				if prop, ok := ipsecCfg.Proposals[propRef]; ok {
-					espProposals = buildESPProposal(prop, pfsGroup)
-				}
-			} else if prop, ok := ipsecCfg.Proposals[vpn.IPsecPolicy]; ok {
-				// Fallback: direct proposal reference (legacy)
-				espProposals = buildESPProposal(prop, 0)
-			}
+		if ikeLifetime > 0 {
+			fmt.Fprintf(&b, "    rekey_time = %ds\n", ikeLifetime)
+			b.WriteString("    rand_time = 0s\n")
 		}
 
 		// Start immediately?
@@ -199,27 +189,36 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 		ifID := xfrmiIfID(vpn.BindInterface)
 
 		fmt.Fprintf(&b, "    children {\n")
-		fmt.Fprintf(&b, "      %s {\n", name)
-		if vpn.LocalID != "" {
-			fmt.Fprintf(&b, "        local_ts = %s\n", vpn.LocalID)
+		for _, child := range effectiveTrafficSelectors(name, vpn) {
+			fmt.Fprintf(&b, "      %s {\n", child.Name)
+			if child.LocalTS != "" {
+				fmt.Fprintf(&b, "        local_ts = %s\n", child.LocalTS)
+			}
+			if child.RemoteTS != "" {
+				fmt.Fprintf(&b, "        remote_ts = %s\n", child.RemoteTS)
+			}
+			fmt.Fprintf(&b, "        esp_proposals = %s\n", espProposals)
+			if espLifetime > 0 {
+				fmt.Fprintf(&b, "        rekey_time = %ds\n", espLifetime)
+				b.WriteString("        rand_time = 0s\n")
+			}
+			if vpn.DFBit == "copy" {
+				fmt.Fprintf(&b, "        copy_df = yes\n")
+			} else if vpn.DFBit == "set" {
+				fmt.Fprintf(&b, "        copy_df = no\n")
+			}
+			if vpn.EstablishTunnels == "immediately" {
+				fmt.Fprintf(&b, "        start_action = start\n")
+			}
+			if dpd.Action != "" {
+				fmt.Fprintf(&b, "        dpd_action = %s\n", dpd.Action)
+			}
+			if ifID > 0 {
+				fmt.Fprintf(&b, "        if_id_in = %d\n", ifID)
+				fmt.Fprintf(&b, "        if_id_out = %d\n", ifID)
+			}
+			fmt.Fprintf(&b, "      }\n")
 		}
-		if vpn.RemoteID != "" {
-			fmt.Fprintf(&b, "        remote_ts = %s\n", vpn.RemoteID)
-		}
-		fmt.Fprintf(&b, "        esp_proposals = %s\n", espProposals)
-		if vpn.DFBit == "copy" {
-			fmt.Fprintf(&b, "        copy_df = yes\n")
-		} else if vpn.DFBit == "set" {
-			fmt.Fprintf(&b, "        copy_df = no\n")
-		}
-		if vpn.EstablishTunnels == "immediately" {
-			fmt.Fprintf(&b, "        start_action = start\n")
-		}
-		if ifID > 0 {
-			fmt.Fprintf(&b, "        if_id_in = %d\n", ifID)
-			fmt.Fprintf(&b, "        if_id_out = %d\n", ifID)
-		}
-		fmt.Fprintf(&b, "      }\n")
 		fmt.Fprintf(&b, "    }\n")
 
 		fmt.Fprintf(&b, "  }\n")
@@ -228,7 +227,8 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 
 	// Secrets — resolve PSK from IKE policy chain
 	b.WriteString("secrets {\n")
-	for name, vpn := range ipsecCfg.VPNs {
+	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
+		vpn := ipsecCfg.VPNs[name]
 		secret := vpn.PSK
 		// Resolve PSK from IKE policy chain: VPN -> gateway -> IKE policy -> PSK
 		if secret == "" {
@@ -239,14 +239,163 @@ func (m *Manager) generateConfig(ipsecCfg *config.IPsecConfig) string {
 			}
 		}
 		if secret != "" {
+			decoded, err := normalizePSK(secret)
+			if err != nil {
+				return "", fmt.Errorf("vpn %s: %w", name, err)
+			}
 			fmt.Fprintf(&b, "  ike-%s {\n", name)
-			fmt.Fprintf(&b, "    secret = \"%s\"\n", secret)
+			fmt.Fprintf(&b, "    secret = \"%s\"\n", decoded)
 			fmt.Fprintf(&b, "  }\n")
 		}
 	}
 	b.WriteString("}\n")
 
-	return b.String()
+	return b.String(), nil
+}
+
+type childSelector struct {
+	Name     string
+	LocalTS  string
+	RemoteTS string
+}
+
+type dpdSettings struct {
+	Delay   int
+	Timeout int
+	Action  string
+}
+
+func sortedVPNNames(vpns map[string]*config.IPsecVPN) []string {
+	names := make([]string, 0, len(vpns))
+	for name := range vpns {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authMethod, proposals string, lifetime int, aggressive bool, err error) {
+	authMethod = "psk"
+	if gw == nil || gw.IKEPolicy == "" {
+		return authMethod, "", 0, false, nil
+	}
+
+	if ikePol, ok := cfg.IKEPolicies[gw.IKEPolicy]; ok {
+		aggressive = ikePol.Mode == "aggressive"
+		if ikeProp, ok := cfg.IKEProposals[ikePol.Proposals]; ok {
+			authMethod, err = authMethodToSwan(ikeProp.AuthMethod)
+			if err != nil {
+				return "", "", 0, false, err
+			}
+			return authMethod, buildIKEProposalFromIKE(ikeProp), ikeProp.LifetimeSeconds, aggressive, nil
+		}
+	}
+
+	if !hasIKEChain(cfg, gw.IKEPolicy) {
+		if prop, ok := cfg.Proposals[gw.IKEPolicy]; ok {
+			return authMethod, buildIKEProposal(prop), prop.LifetimeSeconds, aggressive, nil
+		}
+	}
+
+	return authMethod, "", 0, aggressive, nil
+}
+
+func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, int) {
+	espProposals := "default"
+	pfsGroup := 0
+	if vpn.IPsecPolicy != "" {
+		if ipsecPol, ok := cfg.Policies[vpn.IPsecPolicy]; ok {
+			pfsGroup = ipsecPol.PFSGroup
+			propRef := ipsecPol.Proposals
+			if propRef == "" {
+				propRef = vpn.IPsecPolicy
+			}
+			if prop, ok := cfg.Proposals[propRef]; ok {
+				return buildESPProposal(prop, pfsGroup), prop.LifetimeSeconds
+			}
+		} else if prop, ok := cfg.Proposals[vpn.IPsecPolicy]; ok {
+			return buildESPProposal(prop, 0), prop.LifetimeSeconds
+		}
+	}
+	return espProposals, 0
+}
+
+func deriveDPD(gw *config.IPsecGateway, vpn *config.IPsecVPN) dpdSettings {
+	if gw == nil || gw.DeadPeerDetect == "" {
+		return dpdSettings{}
+	}
+
+	delay := gw.DPDInterval
+	if delay <= 0 {
+		delay = 10
+	}
+	threshold := gw.DPDThreshold
+	if threshold <= 0 {
+		threshold = 5
+	}
+
+	action := ""
+	switch gw.DeadPeerDetect {
+	case "always-send":
+		action = "restart"
+	case "optimized":
+		if vpn != nil && vpn.EstablishTunnels == "immediately" {
+			action = "restart"
+		} else {
+			action = "clear"
+		}
+	case "probe-idle-tunnel":
+		if vpn != nil && vpn.EstablishTunnels == "immediately" {
+			action = "restart"
+		} else {
+			action = "trap"
+		}
+	default:
+		if vpn != nil && vpn.EstablishTunnels == "immediately" {
+			action = "restart"
+		}
+	}
+
+	return dpdSettings{
+		Delay:   delay,
+		Timeout: delay * threshold,
+		Action:  action,
+	}
+}
+
+func effectiveTrafficSelectors(connName string, vpn *config.IPsecVPN) []childSelector {
+	if vpn == nil || len(vpn.TrafficSelectors) == 0 {
+		return []childSelector{{
+			Name:     connName,
+			LocalTS:  vpn.LocalID,
+			RemoteTS: vpn.RemoteID,
+		}}
+	}
+
+	names := make([]string, 0, len(vpn.TrafficSelectors))
+	for name := range vpn.TrafficSelectors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	children := make([]childSelector, 0, len(names))
+	for _, name := range names {
+		ts := vpn.TrafficSelectors[name]
+		localTS := vpn.LocalID
+		remoteTS := vpn.RemoteID
+		if ts.LocalIP != "" {
+			localTS = ts.LocalIP
+		}
+		if ts.RemoteIP != "" {
+			remoteTS = ts.RemoteIP
+		}
+		children = append(children, childSelector{
+			Name:     connName + "-" + sanitizeChildName(name),
+			LocalTS:  localTS,
+			RemoteTS: remoteTS,
+		})
+	}
+	return children
 }
 
 // hasIKEChain checks if the IKE policy -> IKE proposal chain is available.
@@ -402,14 +551,15 @@ func (m *Manager) reload() error {
 
 // SAStatus represents an IPsec Security Association.
 type SAStatus struct {
-	Name       string
-	LocalAddr  string
-	RemoteAddr string
-	State      string
-	LocalTS    string
-	RemoteTS   string
-	InBytes    string
-	OutBytes   string
+	Name           string
+	ConnectionName string
+	LocalAddr      string
+	RemoteAddr     string
+	State          string
+	LocalTS        string
+	RemoteTS       string
+	InBytes        string
+	OutBytes       string
 }
 
 // TerminateAllSAs terminates all active IKE SAs via swanctl.
@@ -419,10 +569,19 @@ func (m *Manager) TerminateAllSAs() (int, error) {
 		return 0, err
 	}
 	count := 0
+	seen := make(map[string]bool)
 	for _, sa := range sas {
-		cmd := exec.Command("swanctl", "--terminate", "--ike", sa.Name)
+		ikeName := sa.ConnectionName
+		if ikeName == "" {
+			ikeName = sa.Name
+		}
+		if ikeName == "" || seen[ikeName] {
+			continue
+		}
+		seen[ikeName] = true
+		cmd := exec.Command("swanctl", "--terminate", "--ike", ikeName)
 		if out, err := cmd.CombinedOutput(); err != nil {
-			slog.Warn("swanctl terminate failed", "ike", sa.Name, "err", err, "output", string(out))
+			slog.Warn("swanctl terminate failed", "ike", ikeName, "err", err, "output", string(out))
 		} else {
 			count++
 		}
@@ -437,8 +596,10 @@ func (m *Manager) ActiveConnectionNames() ([]string, error) {
 		return nil, err
 	}
 	names := make([]string, 0, len(sas))
+	seen := make(map[string]bool)
 	for _, sa := range sas {
-		if sa.Name != "" {
+		if sa.Name != "" && !seen[sa.Name] {
+			seen[sa.Name] = true
 			names = append(names, sa.Name)
 		}
 	}
@@ -469,44 +630,81 @@ func (m *Manager) GetSAStatus() ([]SAStatus, error) {
 
 func parseSAOutput(output string) []SAStatus {
 	var sas []SAStatus
-	var current *SAStatus
+	var currentConn *SAStatus
+	var currentChild *SAStatus
+	connHasChild := false
 
 	for _, line := range strings.Split(output, "\n") {
 		trimmed := strings.TrimSpace(line)
 
 		// Connection name line (no leading whitespace = new SA)
 		if len(line) > 0 && line[0] != ' ' && strings.Contains(line, ":") {
-			if current != nil {
-				sas = append(sas, *current)
+			if currentChild != nil {
+				sas = append(sas, *currentChild)
+				currentChild = nil
+			}
+			if currentConn != nil && !connHasChild {
+				sas = append(sas, *currentConn)
 			}
 			name := strings.TrimSuffix(strings.Fields(trimmed)[0], ":")
-			current = &SAStatus{Name: name}
+			currentConn = &SAStatus{Name: name, ConnectionName: name}
+			connHasChild = false
 			// Extract state from the connection name line (e.g. "site-a: #1, ESTABLISHED")
 			for _, word := range []string{"ESTABLISHED", "CONNECTING", "INSTALLED", "REKEYING"} {
 				if strings.Contains(trimmed, word) {
-					current.State = word
+					currentConn.State = word
 					break
 				}
 			}
 			continue
 		}
 
-		if current == nil {
+		if currentConn == nil {
 			continue
+		}
+
+		if strings.Contains(trimmed, ", reqid ") && strings.Contains(trimmed, ":") {
+			if currentChild != nil {
+				sas = append(sas, *currentChild)
+			}
+			childName := strings.TrimSuffix(strings.Fields(trimmed)[0], ":")
+			currentChild = &SAStatus{
+				Name:           childName,
+				ConnectionName: currentConn.Name,
+				LocalAddr:      currentConn.LocalAddr,
+				RemoteAddr:     currentConn.RemoteAddr,
+			}
+			connHasChild = true
+			for _, word := range []string{"ESTABLISHED", "CONNECTING", "INSTALLED", "REKEYING"} {
+				if strings.Contains(trimmed, word) {
+					currentChild.State = word
+					break
+				}
+			}
+			continue
+		}
+
+		target := currentConn
+		if currentChild != nil {
+			target = currentChild
 		}
 
 		if strings.Contains(trimmed, "local") && strings.Contains(trimmed, "===") {
 			parts := strings.Split(trimmed, "===")
 			if len(parts) >= 2 {
-				current.LocalAddr = strings.TrimSpace(strings.TrimPrefix(parts[0], "local:"))
-				current.RemoteAddr = strings.TrimSpace(parts[1])
+				currentConn.LocalAddr = strings.TrimSpace(strings.TrimPrefix(parts[0], "local:"))
+				currentConn.RemoteAddr = strings.TrimSpace(parts[1])
+				if currentChild != nil {
+					currentChild.LocalAddr = currentConn.LocalAddr
+					currentChild.RemoteAddr = currentConn.RemoteAddr
+				}
 			}
 		}
 
 		if strings.Contains(trimmed, "ESTABLISHED") || strings.Contains(trimmed, "CONNECTING") {
 			for _, word := range []string{"ESTABLISHED", "CONNECTING", "INSTALLED", "REKEYING"} {
 				if strings.Contains(trimmed, word) {
-					current.State = word
+					target.State = word
 					break
 				}
 			}
@@ -514,30 +712,32 @@ func parseSAOutput(output string) []SAStatus {
 
 		if strings.Contains(trimmed, "local_ts") {
 			if idx := strings.Index(trimmed, "="); idx >= 0 {
-				current.LocalTS = strings.TrimSpace(trimmed[idx+1:])
+				target.LocalTS = strings.TrimSpace(trimmed[idx+1:])
 			}
 		}
 		if strings.Contains(trimmed, "remote_ts") {
 			if idx := strings.Index(trimmed, "="); idx >= 0 {
-				current.RemoteTS = strings.TrimSpace(trimmed[idx+1:])
+				target.RemoteTS = strings.TrimSpace(trimmed[idx+1:])
 			}
 		}
 		if strings.HasPrefix(trimmed, "bytes_in") || strings.Contains(trimmed, " bytes_in") {
 			for _, field := range strings.Fields(trimmed) {
 				if strings.HasPrefix(field, "bytes_in=") {
-					current.InBytes = strings.TrimPrefix(field, "bytes_in=")
-					current.InBytes = strings.TrimRight(current.InBytes, ",")
+					target.InBytes = strings.TrimPrefix(field, "bytes_in=")
+					target.InBytes = strings.TrimRight(target.InBytes, ",")
 				}
 				if strings.HasPrefix(field, "bytes_out=") {
-					current.OutBytes = strings.TrimPrefix(field, "bytes_out=")
-					current.OutBytes = strings.TrimRight(current.OutBytes, ",")
+					target.OutBytes = strings.TrimPrefix(field, "bytes_out=")
+					target.OutBytes = strings.TrimRight(target.OutBytes, ",")
 				}
 			}
 		}
 	}
 
-	if current != nil {
-		sas = append(sas, *current)
+	if currentChild != nil {
+		sas = append(sas, *currentChild)
+	} else if currentConn != nil && !connHasChild {
+		sas = append(sas, *currentConn)
 	}
 
 	return sas

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -210,6 +210,28 @@ func TestParseSAOutput(t *testing.T) {
 	}
 }
 
+func TestParseSAOutput_MultiChild(t *testing.T) {
+	output := `site-a: #1, ESTABLISHED
+  local: 10.0.1.1 === 10.0.2.1
+  site-a-ts1: #1, reqid 1, INSTALLED
+    local_ts = 10.0.1.0/24
+    remote_ts = 10.0.2.0/24
+  site-a-ts2: #2, reqid 2, INSTALLED
+    local_ts = 10.0.3.0/24
+    remote_ts = 10.0.4.0/24
+`
+	sas := parseSAOutput(output)
+	if len(sas) != 2 {
+		t.Fatalf("expected 2 child SAs, got %d", len(sas))
+	}
+	if sas[0].Name != "site-a-ts1" || sas[0].ConnectionName != "site-a" {
+		t.Fatalf("unexpected first child: %+v", sas[0])
+	}
+	if sas[1].Name != "site-a-ts2" || sas[1].ConnectionName != "site-a" {
+		t.Fatalf("unexpected second child: %+v", sas[1])
+	}
+}
+
 func TestGenerateConfig_GatewayReference(t *testing.T) {
 	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
 	cfg := &config.IPsecConfig{
@@ -412,12 +434,14 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 		{"remote addr", "remote_addrs = 203.0.113.1"},
 		{"no NAT-T", "encap = no"},
 		{"DPD", "dpd_delay = 10s"},
+		{"DPD timeout", "dpd_timeout = 50s"},
 		{"local identity", "id = @vpn.example.com"},
 		{"remote identity", "id = 203.0.113.1"},
 		{"IKE proposal", "proposals = aes256-sha256-modp2048"},
 		{"ESP proposal", "esp_proposals = aes256-sha256128-modp2048"},
 		{"copy DF", "copy_df = yes"},
 		{"start action", "start_action = start"},
+		{"DPD action", "dpd_action = restart"},
 		{"XFRM if_id", "if_id_in = 1"},
 		{"PSK from IKE policy", `secret = "secret123"`},
 	}
@@ -425,9 +449,6 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 		if !strings.Contains(got, c.want) {
 			t.Errorf("%s: missing %q in:\n%s", c.name, c.want, got)
 		}
-	}
-	if strings.Contains(got, "dpd_action = restart") {
-		t.Errorf("PFS must not inject dpd_action into child config: %s", got)
 	}
 }
 
@@ -689,5 +710,205 @@ func TestGenerateConfig_EstablishTunnels(t *testing.T) {
 	got = m.generateConfig(cfg)
 	if strings.Contains(got, "start_action") {
 		t.Errorf("on-traffic should not produce start_action: %s", got)
+	}
+}
+
+func TestGenerateConfig_IKELifetime(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {
+				Name:            "ike-p1",
+				AuthMethod:      "pre-shared-keys",
+				EncryptionAlg:   "aes-256-cbc",
+				AuthAlg:         "sha-256",
+				DHGroup:         14,
+				LifetimeSeconds: 28800,
+			},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"pol1": {Name: "pol1", Proposals: "ike-p1", PSK: "secret"},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {Name: "gw", Address: "203.0.113.1", IKEPolicy: "pol1"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "gw"},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "rekey_time = 28800s") {
+		t.Fatalf("expected IKE rekey_time from lifetime-seconds: %s", got)
+	}
+	if !strings.Contains(got, "rand_time = 0s") {
+		t.Fatalf("expected deterministic IKE rand_time: %s", got)
+	}
+}
+
+func TestGenerateConfig_ESPLifetime(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-p2": {
+				Name:            "esp-p2",
+				EncryptionAlg:   "aes-256-cbc",
+				AuthAlg:         "hmac-sha-256-128",
+				LifetimeSeconds: 3600,
+			},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: "esp-p2"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "203.0.113.1", IPsecPolicy: "ipsec-pol"},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "rekey_time = 3600s") {
+		t.Fatalf("expected child rekey_time from ESP lifetime-seconds: %s", got)
+	}
+}
+
+func TestGenerateConfig_DPDModes(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {
+				Name:           "gw",
+				Address:        "10.0.0.1",
+				DeadPeerDetect: "probe-idle-tunnel",
+				DPDInterval:    7,
+				DPDThreshold:   3,
+			},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "gw", EstablishTunnels: "on-traffic"},
+		},
+	}
+	got := m.generateConfig(cfg)
+	for _, want := range []string{"dpd_delay = 7s", "dpd_timeout = 21s", "dpd_action = trap"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateConfig_JunosObfuscatedPSK(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "10.0.0.1", PSK: "$9$SpRrMLYgaZDirexdwgUDzFn9uO1RhlKW"},
+		},
+	}
+	got, err := m.renderConfig(cfg)
+	if err != nil {
+		t.Fatalf("renderConfig() error = %v", err)
+	}
+	if !strings.Contains(got, `secret = "QZ1agnL21L"`) {
+		t.Fatalf("expected decoded Junos secret, got:\n%s", got)
+	}
+}
+
+func TestGenerateConfig_PubkeyAuth(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {
+				Name:          "ike-p1",
+				AuthMethod:    "rsa-signatures",
+				EncryptionAlg: "aes-256-cbc",
+				AuthAlg:       "sha-256",
+				DHGroup:       14,
+			},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {
+				Name:             "gw",
+				Address:          "203.0.113.1",
+				IKEPolicy:        "pol1",
+				LocalCertificate: "gw-cert.pem",
+			},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "gw"},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "auth = pubkey") {
+		t.Fatalf("expected pubkey auth, got:\n%s", got)
+	}
+	if !strings.Contains(got, "certs = gw-cert.pem") {
+		t.Fatalf("expected local certificate, got:\n%s", got)
+	}
+	if strings.Contains(got, "secret = ") {
+		t.Fatalf("pubkey auth should not emit PSK secrets:\n%s", got)
+	}
+}
+
+func TestGenerateConfig_TrafficSelectors(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/bpfrx.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {
+				Gateway: "10.0.0.1",
+				TrafficSelectors: map[string]*config.IPsecTrafficSelector{
+					"corp-a": {Name: "corp-a", LocalIP: "10.0.1.0/24", RemoteIP: "10.10.1.0/24"},
+					"corp-b": {Name: "corp-b", LocalIP: "10.0.2.0/24", RemoteIP: "10.10.2.0/24"},
+				},
+			},
+		},
+	}
+	got := m.generateConfig(cfg)
+	for _, want := range []string{
+		"tun-corp-a {",
+		"local_ts = 10.0.1.0/24",
+		"remote_ts = 10.10.1.0/24",
+		"tun-corp-b {",
+		"local_ts = 10.0.2.0/24",
+		"remote_ts = 10.10.2.0/24",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrepareConfig_ExternalInterfaceLocalAddress(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"wan0": {
+					Name: "wan0",
+					Units: map[int]*config.InterfaceUnit{
+						0: {
+							PrimaryAddress: "198.51.100.1/24",
+							Addresses:      []string{"198.51.100.1/24"},
+						},
+					},
+				},
+			},
+		},
+		Security: config.SecurityConfig{
+			IPsec: config.IPsecConfig{
+				Gateways: map[string]*config.IPsecGateway{
+					"gw": {
+						Name:          "gw",
+						Address:       "203.0.113.1",
+						ExternalIface: "wan0.0",
+					},
+				},
+				VPNs: map[string]*config.IPsecVPN{
+					"tun": {Gateway: "gw"},
+				},
+			},
+		},
+	}
+
+	prepared := PrepareConfig(cfg)
+	if prepared.Gateways["gw"].LocalAddress != "198.51.100.1" {
+		t.Fatalf("resolved local-address = %q, want 198.51.100.1", prepared.Gateways["gw"].LocalAddress)
 	}
 }

--- a/pkg/ipsec/junos_secret.go
+++ b/pkg/ipsec/junos_secret.go
@@ -1,0 +1,169 @@
+package ipsec
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Portions of the $9$ decoder in this file are adapted from the MIT-licensed
+// github.com/nadddy/jcrypt project:
+//
+// MIT License
+// Copyright (c) 2020 nadddy
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const junosSecretMagic = "$9$"
+
+var errInvalidJunosSecret = errors.New("invalid Junos $9$ secret")
+
+var junosNumAlpha = []byte{}
+var junosExtraNum = make([]int, 256)
+var junosAlphaNum = make([]int, 256)
+var junosEncoding = [][]int{{1, 4, 32}, {1, 16, 32}, {1, 8, 32}, {1, 64}, {1, 32}, {1, 4, 16, 128}, {1, 32, 64}}
+
+func init() {
+	family := [][]byte{
+		[]byte("QzF3n6/9CAtpu0O"),
+		[]byte("B1IREhcSyrleKvMW8LXx"),
+		[]byte("7N-dVbwsY2g4oaJZGUDj"),
+		[]byte("iHkq.mPf5T"),
+	}
+	offset := 0
+	for i, bs := range family {
+		junosNumAlpha = append(junosNumAlpha, bs...)
+		for j, b := range bs {
+			junosAlphaNum[b] = offset + j
+			junosExtraNum[b] = 3 - i
+		}
+		offset += len(bs)
+	}
+}
+
+func normalizePSK(secret string) (string, error) {
+	if strings.HasPrefix(secret, junosSecretMagic) {
+		return decodeJunosSecret(secret)
+	}
+	return secret, nil
+}
+
+func decodeJunosSecret(secret string) (string, error) {
+	if !strings.HasPrefix(secret, junosSecretMagic) {
+		return "", errInvalidJunosSecret
+	}
+
+	rest := []byte(secret[len(junosSecretMagic):])
+	if len(rest) == 0 {
+		return "", errInvalidJunosSecret
+	}
+
+	first := rest[:1]
+	rest = rest[1:]
+
+	skip := junosExtraNum[first[0]]
+	if skip > len(rest) {
+		return "", errInvalidJunosSecret
+	}
+	rest = rest[skip:]
+	prev := first[0]
+
+	out := make([]byte, 0, len(rest))
+	for len(rest) > 0 {
+		decode := junosEncoding[len(out)%len(junosEncoding)]
+		if len(rest) < len(decode) {
+			return "", errInvalidJunosSecret
+		}
+		nibble := rest[:len(decode)]
+		rest = rest[len(decode):]
+
+		gaps := make([]byte, 0, len(nibble))
+		for _, nb := range nibble {
+			gap, err := junosGap(prev, nb)
+			if err != nil {
+				return "", err
+			}
+			prev = nb
+			gaps = append(gaps, gap)
+		}
+		out = append(out, junosGapDecode(gaps, decode))
+	}
+
+	return string(out), nil
+}
+
+func junosGap(prev, next byte) (byte, error) {
+	if int(prev) >= len(junosAlphaNum) || int(next) >= len(junosAlphaNum) {
+		return 0, errInvalidJunosSecret
+	}
+	if !bytes.Contains(junosNumAlpha, []byte{prev}) || !bytes.Contains(junosNumAlpha, []byte{next}) {
+		return 0, errInvalidJunosSecret
+	}
+	gap := (junosAlphaNum[next]-junosAlphaNum[prev])%len(junosNumAlpha) - 1
+	if gap < 0 {
+		gap += len(junosNumAlpha)
+	}
+	return byte(gap), nil
+}
+
+func junosGapDecode(gaps []byte, decode []int) byte {
+	num := 0
+	for i := range gaps {
+		num += int(gaps[i]) * decode[i]
+	}
+	return byte(num % 256)
+}
+
+func sanitizeChildName(name string) string {
+	if name == "" {
+		return "traffic-selector"
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "traffic-selector"
+	}
+	return out
+}
+
+func authMethodToSwan(method string) (string, error) {
+	switch method {
+	case "", "pre-shared-keys":
+		return "psk", nil
+	case "rsa-signatures", "ecdsa-signatures":
+		return "pubkey", nil
+	default:
+		return "", fmt.Errorf("unsupported IKE authentication-method %q", method)
+	}
+}

--- a/pkg/ipsec/prepare.go
+++ b/pkg/ipsec/prepare.go
@@ -1,0 +1,203 @@
+package ipsec
+
+import (
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+// PrepareConfig resolves runtime-only IPsec values from the full config.
+// The returned config is a deep copy that can be safely mutated by the IPsec
+// runtime without affecting the active config tree.
+func PrepareConfig(cfg *config.Config) *config.IPsecConfig {
+	if cfg == nil {
+		return nil
+	}
+
+	src := &cfg.Security.IPsec
+	out := &config.IPsecConfig{
+		IKEProposals: make(map[string]*config.IKEProposal, len(src.IKEProposals)),
+		IKEPolicies:  make(map[string]*config.IKEPolicy, len(src.IKEPolicies)),
+		Gateways:     make(map[string]*config.IPsecGateway, len(src.Gateways)),
+		Proposals:    make(map[string]*config.IPsecProposal, len(src.Proposals)),
+		Policies:     make(map[string]*config.IPsecPolicyDef, len(src.Policies)),
+		VPNs:         make(map[string]*config.IPsecVPN, len(src.VPNs)),
+	}
+
+	for name, prop := range src.IKEProposals {
+		cp := *prop
+		out.IKEProposals[name] = &cp
+	}
+	for name, pol := range src.IKEPolicies {
+		cp := *pol
+		out.IKEPolicies[name] = &cp
+	}
+	for name, gw := range src.Gateways {
+		cp := *gw
+		if cp.LocalAddress == "" && cp.ExternalIface != "" {
+			cp.LocalAddress = resolveInterfaceAddress(cfg, cp.ExternalIface, cp.Address)
+		}
+		out.Gateways[name] = &cp
+	}
+	for name, prop := range src.Proposals {
+		cp := *prop
+		out.Proposals[name] = &cp
+	}
+	for name, pol := range src.Policies {
+		cp := *pol
+		out.Policies[name] = &cp
+	}
+	for name, vpn := range src.VPNs {
+		cp := *vpn
+		if vpn.TrafficSelectors != nil {
+			cp.TrafficSelectors = make(map[string]*config.IPsecTrafficSelector, len(vpn.TrafficSelectors))
+			for tsName, ts := range vpn.TrafficSelectors {
+				tsCopy := *ts
+				cp.TrafficSelectors[tsName] = &tsCopy
+			}
+		}
+		out.VPNs[name] = &cp
+	}
+
+	return out
+}
+
+func resolveInterfaceAddress(cfg *config.Config, ifaceRef, remoteAddr string) string {
+	family := addressFamilyHint(remoteAddr)
+	if addr := resolveConfiguredInterfaceAddress(cfg, ifaceRef, family); addr != "" {
+		return addr
+	}
+
+	resolvedRef := cfg.ResolveReth(ifaceRef)
+	for _, name := range []string{
+		config.LinuxIfName(resolvedRef),
+		config.LinuxIfName(ifaceRef),
+	} {
+		if addr := resolveKernelInterfaceAddress(name, family); addr != "" {
+			return addr
+		}
+	}
+
+	return ""
+}
+
+func resolveConfiguredInterfaceAddress(cfg *config.Config, ifaceRef string, family int) string {
+	parts := strings.SplitN(ifaceRef, ".", 2)
+	base := parts[0]
+	unitNum := 0
+	if len(parts) == 2 {
+		if n, err := strconv.Atoi(parts[1]); err == nil {
+			unitNum = n
+		}
+	}
+
+	ifc, ok := cfg.Interfaces.Interfaces[base]
+	if !ok {
+		return ""
+	}
+
+	if unit, ok := ifc.Units[unitNum]; ok {
+		if addr := selectUnitAddress(unit, family); addr != "" {
+			return addr
+		}
+	}
+
+	if len(parts) == 1 && len(ifc.Units) > 0 {
+		unitIDs := make([]int, 0, len(ifc.Units))
+		for id := range ifc.Units {
+			unitIDs = append(unitIDs, id)
+		}
+		sort.Ints(unitIDs)
+		for _, id := range unitIDs {
+			if addr := selectUnitAddress(ifc.Units[id], family); addr != "" {
+				return addr
+			}
+		}
+	}
+
+	return ""
+}
+
+func selectUnitAddress(unit *config.InterfaceUnit, family int) string {
+	if unit == nil {
+		return ""
+	}
+
+	for _, candidate := range []string{unit.PrimaryAddress, unit.PreferredAddress} {
+		if addr := bareIP(candidate, family); addr != "" {
+			return addr
+		}
+	}
+	for _, candidate := range unit.Addresses {
+		if addr := bareIP(candidate, family); addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
+func resolveKernelInterfaceAddress(ifaceName string, family int) string {
+	if ifaceName == "" {
+		return ""
+	}
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return ""
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		if ip := bareIP(addr.String(), family); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func bareIP(addr string, family int) string {
+	if addr == "" {
+		return ""
+	}
+	if ip, _, err := net.ParseCIDR(addr); err == nil {
+		return matchFamily(ip, family)
+	}
+	if ip := net.ParseIP(addr); ip != nil {
+		return matchFamily(ip, family)
+	}
+	return ""
+}
+
+func addressFamilyHint(addr string) int {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return 0
+	}
+	if ip.To4() != nil {
+		return 4
+	}
+	return 6
+}
+
+func matchFamily(ip net.IP, family int) string {
+	if ip == nil || !ip.IsGlobalUnicast() {
+		return ""
+	}
+	switch family {
+	case 4:
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	case 6:
+		if ip.To4() == nil {
+			return ip.String()
+		}
+	default:
+		return ip.String()
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- resolve runtime IPsec local-address from the configured external-interface when needed
- support Junos-oriented IKE/IPsec semantics for local certificates, proposal lifetimes, DPD settings, auth method selection, and traffic selectors
- decode Junos `$9$` obfuscated PSKs before generating `swanctl.conf`
- expose the added IKE/IPsec fields in CLI/gRPC output and keep apply paths using the prepared runtime config
- harden SA parsing for multi-child traffic-selector output

## Issues
- Closes #154
- Closes #155
- Closes #156
- Closes #157
- Closes #158
- Closes #159

## Testing
- `GOCACHE=/tmp/go-build go test ./pkg/ipsec ./pkg/config ./pkg/daemon ./pkg/cli ./pkg/grpcapi ./pkg/cluster`
- `GOCACHE=/tmp/go-build go test ./...`
