### PR TITLE
system: wire NTP threshold action via chrony

### DIFF
--- a/docs/authoritative-backlog.md
+++ b/docs/authoritative-backlog.md
@@ -23,8 +23,8 @@ Use these sources in this order when there is disagreement:
 Row-level gap totals:
 - Missing: 120
 - Partial: 12
-- Parse-Only: 4
-- Total Open Gaps: 136
+- Parse-Only: 3
+- Total Open Gaps: 135
 
 Category totals:
 
@@ -50,7 +50,7 @@ Category totals:
 | 19. Multi-Tenancy | 4 | 0 | 0 | 4 |
 | 20. Management & Automation | 9 | 2 | 0 | 11 |
 | 21. Interface Enhancements | 1 | 1 | 0 | 2 |
-| 22. System Enhancements | 5 | 0 | 2 | 7 |
+| 22. System Enhancements | 5 | 0 | 1 | 6 |
 | 23. Miscellaneous Features | 6 | 0 | 0 | 6 |
 
 High-priority open items:
@@ -72,7 +72,6 @@ From `docs/next-features` and HA proposal docs:
 - Runtime wiring for `security pre-id-default-policy`
 - Runtime behavior for `system master-password`
 - Runtime behavior for `system license autoupdate url`
-- Runtime behavior for `system ntp threshold ... action ...`
 
 ### 3) Additional open items from bug/test planning docs
 
@@ -100,6 +99,7 @@ These are documented as implemented in `docs/phases.md` and should not remain in
 - Sprint PR #67: `monitor security flow` and `monitor security packet-drop`
 - Sprint #68: HA fail-closed default + `set chassis cluster hitless-restart` opt-in
 - HA sync hardening sprint #69-#80 items called out as fixed in `docs/bugs.md`
+- System NTP threshold action runtime wiring (`accept`/`reject`) via chrony
 - Sprint CC-18: Junos IKE/IPsec compatibility items now merged on `master`:
   - gateway `local-certificate` / pubkey auth generation
   - `traffic-selector` support

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -27,9 +27,9 @@ Last updated: 2026-03-06
 | Multi-Tenancy | 4 | 0 | 0 | 4 |
 | Management & Automation | 9 | 2 | 0 | 11 |
 | Interface Enhancements | 1 | 1 | 0 | 2 |
-| System Enhancements | 5 | 0 | 2 | 7 |
+| System Enhancements | 5 | 0 | 1 | 6 |
 | Miscellaneous | 6 | 0 | 0 | 6 |
-| **TOTAL** | **120** | **12** | **4** | **136** |
+| **TOTAL** | **120** | **12** | **3** | **135** |
 
 **Implementation status key:**
 - **Fully Missing**: No config parsing or runtime support
@@ -397,7 +397,7 @@ bpfrx has hostname, domain-name, domain-search, timezone, name-servers, NTP, ser
 | **Authentication Order** | `system authentication-order [radius tacplus password]` | Control order of authentication methods for management access | Medium | Missing |
 | **Auto-Image Upgrade** | `system autoinstallation ...` | Zero-touch provisioning for initial deployment | Low | Missing |
 | **Time Zone (wired)** | `system time-zone ...` | bpfrx applies the configured timezone to the system runtime | Low | Done (daemon updates `/etc/localtime` and `/etc/timezone`) |
-| **NTP Threshold Action** | `system ntp threshold ... action ...` | Action when NTP offset exceeds threshold (accept or reject large time jumps) | Low | Parse-Only |
+| **NTP Threshold Action** | `system ntp threshold ... action ...` | Action when NTP offset exceeds threshold (accept or reject large time jumps) | Low | Done (maps to chrony `logchange` for `accept` and `logchange` + `maxchange` for `reject`, and is shown in operational output) |
 | **Master Password** | `system master-password ...` | Encrypted password storage with master key for config secrets | Low | Parse-Only |
 | **DNS Proxy** | `system services dns dns-proxy ...` | DNS proxy/caching server on firewall for client DNS resolution | Low | Missing |
 
@@ -472,9 +472,8 @@ table, so this list count can be higher than the category-level Parse-Only total
 | 1 | `security pre-id-default-policy` | PreIDDefaultPolicy | Requires AppID engine |
 | 2 | `system master-password` | SystemConfig.MasterPassword | No encrypted storage |
 | 3 | `system license autoupdate url` | SystemConfig.LicenseAutoUpdate | No licensing system |
-| 4 | `system ntp threshold action` | SystemConfig.NTPThresholdAction | Not wired to NTP config |
-| 5 | `security policies ... schedulers ...` | SchedulerConfig | Parsed, not runtime-enforced in policy engine |
-| 6 | `services application-identification` | ServicesConfig.ApplicationIdentification | Bool flag only, no DPI |
+| 4 | `security policies ... schedulers ...` | SchedulerConfig | Parsed, not runtime-enforced in policy engine |
+| 5 | `services application-identification` | ServicesConfig.ApplicationIdentification | Bool flag only, no DPI |
 
 ---
 

--- a/docs/next-features/ntp-threshold-action.md
+++ b/docs/next-features/ntp-threshold-action.md
@@ -1,26 +1,20 @@
-# Next Feature: `system ntp threshold <ms> action <accept|reject>`
+# Next Feature: `system ntp threshold <seconds> action <accept|reject>`
 
-Date: 2026-03-02  
-Status: Proposed
+Date: 2026-03-06
+Status: Implemented
 
 ## Config Evidence
 - Present in `/home/ps/git/bpfrx/vsrx.conf:109` as `threshold 400 action accept;`
 
-## Current State
-- Parsed into `SystemConfig.NTPThreshold` and `NTPThresholdAction`: `pkg/config/compiler.go`
-- Runtime NTP apply only writes chrony server lines and reloads sources: `pkg/daemon/daemon.go` (`applySystemNTP`)
-- Threshold/action values are currently ignored
+## Implemented Behavior
+1. `system ntp threshold <seconds> action accept` writes chrony `logchange <seconds>` so large offsets are logged while remaining acceptable.
+2. `system ntp threshold <seconds> action reject` writes `logchange <seconds>` and `maxchange <seconds> 1 -1` so large post-startup corrections are rejected.
+3. `show ntp` and system summary output display the configured threshold mode.
+4. Threshold config is reconciled through a managed chrony drop-in file alongside the existing managed source list.
 
-## Problem
-Time discipline behavior differs from operator intent in configs that rely on explicit threshold policy. Failover and session-sync systems can be sensitive to clock behavior, so silently ignoring this knob is risky.
+## Notes
+- This maps the Junos operator intent onto chrony primitives rather than re-implementing NTP discipline in bpfrxd.
+- The value is treated as seconds, matching Junos documentation and chrony directive units.
 
-## Proposed Implementation Scope
-1. Map threshold/action into chrony-compatible controls (or enforce in bpfrxd wrapper logic if chrony mapping is insufficient).
-2. Expose active threshold mode in operational output.
-3. Emit warning when configured value cannot be represented exactly.
-4. Add tests for accept/reject behaviors and config rendering.
-
-## Acceptance Criteria
-- Configured threshold/action changes runtime NTP behavior deterministically.
-- `show` output reflects effective threshold policy.
-- Unsupported combinations produce explicit warning, not silent ignore.
+## Validation
+- Unit tests cover chrony source rendering, threshold rendering for `accept` and `reject`, and managed file reconciliation.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7891,6 +7891,9 @@ func (c *CLI) showSystemNTP() error {
 	for _, server := range cfg.System.NTPServers {
 		fmt.Printf("  %s\n", server)
 	}
+	if cfg.System.NTPThreshold > 0 && cfg.System.NTPThresholdAction != "" {
+		fmt.Printf("  Threshold: %d seconds (%s)\n", cfg.System.NTPThreshold, cfg.System.NTPThresholdAction)
+	}
 
 	// Try chronyc tracking for detailed sync status
 	if out, err := exec.Command("chronyc", "tracking").CombinedOutput(); err == nil {
@@ -8017,6 +8020,9 @@ func (c *CLI) showSystemServices() error {
 	// NTP
 	if len(cfg.System.NTPServers) > 0 {
 		fmt.Printf("  NTP servers:    %s\n", strings.Join(cfg.System.NTPServers, ", "))
+		if cfg.System.NTPThreshold > 0 && cfg.System.NTPThresholdAction != "" {
+			fmt.Printf("  NTP threshold:  %d seconds (%s)\n", cfg.System.NTPThreshold, cfg.System.NTPThresholdAction)
+		}
 	}
 
 	// Syslog

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -261,7 +261,7 @@ type SystemConfig struct {
 	TimeZone           string
 	NameServers        []string // DNS server addresses
 	NTPServers         []string // NTP server addresses
-	NTPThreshold       int      // NTP threshold in milliseconds (0 = default)
+	NTPThreshold       int      // NTP threshold in seconds (0 = default)
 	NTPThresholdAction string   // "accept" or "reject"
 	NoRedirects        bool     // disable ICMP redirects
 	BackupRouter       string   // backup default gateway IP

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3021,40 +3021,126 @@ func restartResolved() {
 	}
 }
 
-// applySystemNTP configures chrony from system { ntp } config.
-// Writes per-server source lines to /etc/chrony/sources.d/bpfrx.sources
-// and reloads chrony to pick up changes.
-func (d *Daemon) applySystemNTP(cfg *config.Config) {
-	if len(cfg.System.NTPServers) == 0 || isProcessDisabled(cfg, "ntp") {
-		return
-	}
+const (
+	chronySourcesPath   = "/etc/chrony/sources.d/bpfrx.sources"
+	chronyThresholdPath = "/etc/chrony/conf.d/bpfrx-threshold.conf"
+)
 
+func renderChronySources(servers []string) string {
 	var b strings.Builder
-	for _, server := range cfg.System.NTPServers {
-		// Use "pool" directive for hostnames (multiple IPs), "server" for explicit IPs
+	for _, server := range servers {
+		// Use "pool" for hostnames and "server" for literal IPs.
 		directive := "pool"
 		if net.ParseIP(server) != nil {
 			directive = "server"
 		}
 		fmt.Fprintf(&b, "%s %s iburst\n", directive, server)
 	}
-	content := b.String()
-	confPath := "/etc/chrony/sources.d/bpfrx.sources"
+	return b.String()
+}
 
-	current, _ := os.ReadFile(confPath)
-	if string(current) == content {
-		return // no change
+func renderChronyThreshold(threshold int, action string) string {
+	if threshold <= 0 || action == "" {
+		return ""
 	}
 
-	os.MkdirAll("/etc/chrony/sources.d", 0755)
-	if err := os.WriteFile(confPath, []byte(content), 0644); err != nil {
-		slog.Warn("failed to write chrony sources", "err", err)
+	// Junos NTP threshold is configured in seconds; chrony directives use
+	// seconds as well. "accept" logs offsets beyond the threshold while
+	// allowing correction, and "reject" additionally refuses large changes
+	// after the initial update.
+	var b strings.Builder
+	fmt.Fprintf(&b, "logchange %d\n", threshold)
+	if action == "reject" {
+		fmt.Fprintf(&b, "maxchange %d 1 -1\n", threshold)
+	}
+	return b.String()
+}
+
+func reconcileManagedFile(path, content string) (bool, error) {
+	current, err := os.ReadFile(path)
+	if err == nil && string(current) == content {
+		return false, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	if content == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("remove %s: %w", path, err)
+		}
+		return !os.IsNotExist(err), nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return false, fmt.Errorf("create dir for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func reloadChronyRuntime(sourcesChanged, thresholdChanged bool) {
+	if sourcesChanged {
+		if out, err := exec.Command("chronyc", "reload", "sources").CombinedOutput(); err != nil {
+			slog.Warn("failed to reload chrony sources", "err", err, "output", string(out))
+		}
+	}
+
+	if !thresholdChanged {
 		return
 	}
 
-	// Reload chrony to pick up new sources
-	exec.Command("chronyc", "reload", "sources").Run()
-	slog.Info("NTP config applied via chrony", "servers", cfg.System.NTPServers)
+	commands := [][]string{
+		{"systemctl", "reload", "chrony"},
+		{"systemctl", "reload", "chronyd"},
+		{"systemctl", "restart", "chrony"},
+		{"systemctl", "restart", "chronyd"},
+	}
+	for _, cmd := range commands {
+		if out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput(); err == nil {
+			return
+		} else {
+			slog.Debug("chrony config reload attempt failed", "cmd", strings.Join(cmd, " "), "err", err, "output", string(out))
+		}
+	}
+	slog.Warn("failed to reload chrony threshold config; change will apply on next chronyd restart")
+}
+
+// applySystemNTP configures chrony from system { ntp } config.
+// Writes per-server source lines to /etc/chrony/sources.d/bpfrx.sources and
+// optional threshold directives to /etc/chrony/conf.d/bpfrx-threshold.conf.
+func (d *Daemon) applySystemNTP(cfg *config.Config) {
+	if isProcessDisabled(cfg, "ntp") {
+		if _, err := reconcileManagedFile(chronySourcesPath, ""); err != nil {
+			slog.Warn("failed to remove chrony sources", "err", err)
+		}
+		if _, err := reconcileManagedFile(chronyThresholdPath, ""); err != nil {
+			slog.Warn("failed to remove chrony threshold config", "err", err)
+		}
+		return
+	}
+
+	sourcesChanged, err := reconcileManagedFile(chronySourcesPath, renderChronySources(cfg.System.NTPServers))
+	if err != nil {
+		slog.Warn("failed to reconcile chrony sources", "err", err)
+		return
+	}
+	thresholdChanged, err := reconcileManagedFile(chronyThresholdPath, renderChronyThreshold(cfg.System.NTPThreshold, cfg.System.NTPThresholdAction))
+	if err != nil {
+		slog.Warn("failed to reconcile chrony threshold config", "err", err)
+		return
+	}
+	if !sourcesChanged && !thresholdChanged {
+		return
+	}
+
+	reloadChronyRuntime(sourcesChanged, thresholdChanged)
+	slog.Info("NTP config applied via chrony",
+		"servers", cfg.System.NTPServers,
+		"threshold", cfg.System.NTPThreshold,
+		"action", cfg.System.NTPThresholdAction)
 }
 
 // applyDNSService manages systemd-resolved based on system { services { dns } }.

--- a/pkg/daemon/ntp_test.go
+++ b/pkg/daemon/ntp_test.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRenderChronySources(t *testing.T) {
+	got := renderChronySources([]string{"10.0.0.1", "pool.example.net"})
+	want := "server 10.0.0.1 iburst\npool pool.example.net iburst\n"
+	if got != want {
+		t.Fatalf("renderChronySources() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderChronyThresholdAccept(t *testing.T) {
+	got := renderChronyThreshold(400, "accept")
+	want := "logchange 400\n"
+	if got != want {
+		t.Fatalf("renderChronyThreshold(accept) = %q, want %q", got, want)
+	}
+}
+
+func TestRenderChronyThresholdReject(t *testing.T) {
+	got := renderChronyThreshold(400, "reject")
+	want := "logchange 400\nmaxchange 400 1 -1\n"
+	if got != want {
+		t.Fatalf("renderChronyThreshold(reject) = %q, want %q", got, want)
+	}
+}
+
+func TestReconcileManagedFileWriteAndRemove(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.conf")
+
+	changed, err := reconcileManagedFile(path, "hello\n")
+	if err != nil {
+		t.Fatalf("reconcile write: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected initial write to report change")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "hello\n" {
+		t.Fatalf("file contents = %q, want %q", string(data), "hello\n")
+	}
+
+	changed, err = reconcileManagedFile(path, "hello\n")
+	if err != nil {
+		t.Fatalf("reconcile unchanged: %v", err)
+	}
+	if changed {
+		t.Fatal("expected unchanged content to report no change")
+	}
+
+	changed, err = reconcileManagedFile(path, "")
+	if err != nil {
+		t.Fatalf("reconcile remove: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected removal to report change")
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file to be removed, stat err = %v", err)
+	}
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -6570,6 +6570,9 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 		}
 		if len(cfg.System.NTPServers) > 0 {
 			fmt.Fprintf(&buf, "  NTP servers:    %s\n", strings.Join(cfg.System.NTPServers, ", "))
+			if cfg.System.NTPThreshold > 0 && cfg.System.NTPThresholdAction != "" {
+				fmt.Fprintf(&buf, "  NTP threshold:  %d seconds (%s)\n", cfg.System.NTPThreshold, cfg.System.NTPThresholdAction)
+			}
 		}
 		if cfg.Security.Log.Mode != "" {
 			fmt.Fprintf(&buf, "  Security log:   mode %s\n", cfg.Security.Log.Mode)
@@ -6607,6 +6610,9 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 		fmt.Fprintln(&buf, "NTP servers:")
 		for _, server := range cfg.System.NTPServers {
 			fmt.Fprintf(&buf, "  %s\n", server)
+		}
+		if cfg.System.NTPThreshold > 0 && cfg.System.NTPThresholdAction != "" {
+			fmt.Fprintf(&buf, "  Threshold: %d seconds (%s)\n", cfg.System.NTPThreshold, cfg.System.NTPThresholdAction)
 		}
 		if out, err := exec.Command("chronyc", "tracking").CombinedOutput(); err == nil {
 			writeChronyTracking(&buf, string(out))


### PR DESCRIPTION
## Summary
- map `system ntp threshold <seconds> action accept|reject` to chrony runtime/config behavior
- show the configured NTP threshold/action in CLI and gRPC output
- update the parity docs and backlog to mark the NTP threshold gap closed
- add unit tests for chrony rendering and managed file reconciliation

## Details
This maps Junos intent to chrony as follows:
- `accept` -> `logchange <threshold>`
- `reject` -> `logchange <threshold>` + `maxchange <threshold> 1 -1`

It also reconciles a managed threshold drop-in file and reloads chrony when the threshold config changes.

## Validation
- `GOCACHE=/tmp/go-build go test ./pkg/daemon ./pkg/config ./pkg/cli ./pkg/grpcapi`
- `GOCACHE=/tmp/go-build go test ./...`
- `git diff --check`

## Scope note
This PR does not claim to solve `services application-identification`, `security pre-id-default-policy`, or `system master-password`. Those still require real subsystem work rather than plumbing.
