### PR TITLE
fix: clear shared sessions on Coordinator stop

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -209,6 +209,12 @@ impl Coordinator {
         if let Ok(mut neighbors) = self.dynamic_neighbors.lock() {
             neighbors.clear();
         }
+        if let Ok(mut sessions) = self.shared_sessions.lock() {
+            sessions.clear();
+        }
+        if let Ok(mut nat_sessions) = self.shared_nat_sessions.lock() {
+            nat_sessions.clear();
+        }
         if let Ok(mut recent) = self.recent_exceptions.lock() {
             recent.clear();
         }


### PR DESCRIPTION
## Summary
- Clear `shared_sessions` and `shared_nat_sessions` in `Coordinator::stop()`, which previously neglected these maps while clearing all other state (workers, identities, live, dynamic_neighbors, recent_exceptions, etc.)
- Prevents stale session data from persisting across stop/start cycles

Fixes #204

## Test plan
- [ ] Verify `stop()` clears both `shared_sessions` and `shared_nat_sessions`
- [ ] Verify no stale sessions remain after a stop/start cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)