### PR TITLE
fix: remove unnecessary unsafe mutable borrow in TX validation

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -3762,17 +3762,12 @@ fn transmit_prepared_batch(
         return Ok((0, 0));
     }
     for req in &binding.scratch_prepared_tx {
-        let Some(frame) = (unsafe {
-            binding
-                .umem
-                .area
-                .slice_mut_unchecked(req.offset as usize, req.len as usize)
-        }) else {
+        if binding.umem.area.slice(req.offset as usize, req.len as usize).is_none() {
             return Err(TxError::Drop(format!(
                 "prepared tx frame slice out of range: offset={} len={}",
                 req.offset, req.len
             )));
-        };
+        }
     }
 
     let mut writer = binding


### PR DESCRIPTION
## Summary
- Replace `unsafe { slice_mut_unchecked() }` with safe `slice()` in `transmit_prepared_batch()` validation loop
- The mutable slice was bound but never read or written -- only used to check existence
- Eliminates an unnecessary `unsafe` block and unused `frame` variable binding

Fixes #206

## Test plan
- [ ] Verify `cargo check` shows no new errors (pre-existing WIP errors on this branch are unrelated)
- [ ] Confirm validation still correctly rejects out-of-range frame offsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)