### PR TITLE
fix: recycle UMEM frames on TxError::Drop in transmit_prepared_batch

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -3750,6 +3750,14 @@ fn transmit_prepared_batch(
             break;
         };
         if req.len as usize > tx_frame_capacity() {
+            // Recycle the oversized req that triggered the drop, plus
+            // everything already popped into scratch, so UMEM frames
+            // are returned to the free pool instead of being orphaned.
+            let orphaned: Vec<_> = binding.scratch_prepared_tx.drain(..).collect();
+            recycle_cancelled_prepared(binding, &req);
+            for r in &orphaned {
+                recycle_cancelled_prepared(binding, r);
+            }
             return Err(TxError::Drop(format!(
                 "prepared tx frame exceeds UMEM frame capacity: len={} cap={}",
                 req.len,
@@ -3768,9 +3776,18 @@ fn transmit_prepared_batch(
                 .area
                 .slice_mut_unchecked(req.offset as usize, req.len as usize)
         }) else {
+            // Capture error values before draining the scratch buffer.
+            let err_offset = req.offset;
+            let err_len = req.len;
+            // Recycle all frames in scratch before returning error so
+            // UMEM frames are not permanently orphaned.
+            let orphaned: Vec<_> = binding.scratch_prepared_tx.drain(..).collect();
+            for r in &orphaned {
+                recycle_cancelled_prepared(binding, r);
+            }
             return Err(TxError::Drop(format!(
                 "prepared tx frame slice out of range: offset={} len={}",
-                req.offset, req.len
+                err_offset, err_len
             )));
         };
     }


### PR DESCRIPTION
## Summary
- Fix UMEM frame leak when `TxError::Drop` is returned from `transmit_prepared_batch()` in `userspace-dp/src/afxdp.rs`
- Frames popped from `pending_tx_prepared` into `scratch_prepared_tx` were orphaned on both Drop paths (oversized frame and slice-out-of-range), never returned to the free pool
- Both paths now drain `scratch_prepared_tx` and recycle every frame via `recycle_cancelled_prepared()` before returning the error

Fixes #203

## Test plan
- [ ] Verify `cargo check` passes (only pre-existing E0609 WIP errors remain, none in the changed function)
- [ ] Run traffic workload that triggers oversized frames or invalid offsets and confirm UMEM frame count stays stable
- [ ] Monitor `debug_free_tx_frames` / `debug_pending_fill_frames` counters under sustained forwarding to confirm no leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)