### PR TITLE
fix: RX throttle under TX backpressure to prevent UMEM exhaustion

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -1704,6 +1704,15 @@ fn poll_binding(
     let fill_work = drain_pending_fill(binding, now_ns);
     let mut did_work = tx_work || fill_work;
     for _ in 0..MAX_RX_BATCHES_PER_POLL {
+        // Backpressure: skip RX when TX queues are heavily loaded to prevent
+        // fill ring exhaustion. The NIC holds packets until we refill (#201).
+        let tx_backlog = binding.pending_tx_local.len() + binding.pending_tx_prepared.len();
+        if tx_backlog >= binding.max_pending_tx {
+            // Try to drain TX first — completions free frames for both TX and fill.
+            let _ = drain_pending_tx(binding, now_ns, shared_recycles);
+            return did_work;
+        }
+
         let available = binding.rx.available().min(RX_BATCH_SIZE);
         if available == 0 {
             maybe_wake_rx(binding, false, now_ns);
@@ -2436,6 +2445,7 @@ fn enqueue_pending_forwards(
                         flow_key: request.flow_key.clone(),
                     });
                     bound_pending_tx_local(target_binding);
+                    bound_pending_tx_prepared(target_binding);
                 }
                 copied_source_frame = true;
                 if target_binding.pending_tx_local.len() >= TX_BATCH_SIZE {
@@ -2473,6 +2483,7 @@ fn enqueue_pending_forwards(
                                     expected_protocol: request.meta.protocol,
                                     flow_key: request.flow_key.clone(),
                                 });
+                            bound_pending_tx_prepared(target_binding);
                             target_binding.live.in_place_tx_packets.fetch_add(1, Ordering::Relaxed);
                             retained_source_frame = true;
                         }
@@ -2527,6 +2538,7 @@ fn enqueue_pending_forwards(
                                     flow_key: request.flow_key.clone(),
                                 });
                                 bound_pending_tx_local(target_binding);
+                                bound_pending_tx_prepared(target_binding);
                             }
                             None => {
                                 build_failed = true;
@@ -2586,6 +2598,7 @@ fn enqueue_pending_forwards(
                                 flow_key: request.flow_key.clone(),
                             });
                             bound_pending_tx_local(target_binding);
+                            bound_pending_tx_prepared(target_binding);
                         }
                         None => {
                             build_failed = true;
@@ -3546,6 +3559,19 @@ fn bound_pending_tx_local(binding: &mut BindingWorker) {
     }
 }
 
+fn bound_pending_tx_prepared(binding: &mut BindingWorker) {
+    let limit = binding.max_pending_tx;
+    while binding.pending_tx_prepared.len() > limit {
+        if let Some(req) = binding.pending_tx_prepared.pop_front() {
+            recycle_cancelled_prepared(binding, &req);
+            binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
+            binding
+                .live
+                .set_error(format!("pending TX prepared overflow on slot {}", binding.slot));
+        }
+    }
+}
+
 fn drain_pending_tx(
     binding: &mut BindingWorker,
     now_ns: u64,
@@ -3630,6 +3656,7 @@ fn drain_pending_tx(
         binding.pending_tx_local = retry;
         bound_pending_tx_local(binding);
     }
+    bound_pending_tx_prepared(binding);
     update_binding_debug_state(binding);
     did_work
         || !binding.pending_tx_prepared.is_empty()


### PR DESCRIPTION
## Summary
- **RX throttle**: Skip RX batch processing when `pending_tx_local + pending_tx_prepared >= max_pending_tx`, preventing fill ring frame exhaustion under TX backpressure. The NIC holds packets until frames are freed.
- **`bound_pending_tx_prepared()`**: New bounding function for the prepared TX queue that properly recycles UMEM frames via `recycle_cancelled_prepared()`, preventing frame leaks when dropping overflow entries.
- **Comprehensive bounding**: `bound_pending_tx_prepared()` called at all `bound_pending_tx_local()` call sites plus after in-place TX push_back, ensuring both TX queues are bounded with proper frame accounting.

Fixes #201

## Test plan
- [ ] Verify under sustained TX backpressure (slow egress NIC, fast ingress) that RX does not stall
- [ ] Confirm fill ring frames are returned when prepared TX overflow is trimmed
- [ ] Check `tx_errors` counter increments when overflow bounding triggers
- [ ] Validate no UMEM frame leaks under prolonged backpressure (frame count stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)