### PR TITLE
docs: sync userspace dataplane docs with master

### DIFF
--- a/.codex/skills/userspace-ha-validation/SKILL.md
+++ b/.codex/skills/userspace-ha-validation/SKILL.md
@@ -20,8 +20,8 @@ Workflow:
 1. After each userspace dataplane phase, run the phase-cycle script from the repo root.
 2. The phase-cycle script pushes the current branch, deploys `bpfrx-userspace-fw0/1`, and then runs the validation script.
 3. Use `--perf` when the phase needs fresh `perf` profiles on whichever userspace firewall is active after deploy.
-4. Treat the validator threshold as the target for the branch, not as proof that the
-   current branch head already meets it.
+4. Treat the validator threshold as the target for the current tree, not as proof that the
+   current tree state already meets it.
 
 Commands:
 
@@ -47,14 +47,14 @@ What the script enforces:
 
 Use `scripts/userspace-ha-validation.sh` directly only when you are debugging the validator itself.
 
-Use `scripts/userspace-perf-compare.sh` when validation is failing or when you need fresh IPv4/IPv6 hotspot data without the validator's throughput gates. Read [docs/userspace-perf-compare.md](/home/ps/git/codex-bpfrx-userspace-wip/docs/userspace-perf-compare.md) for the exact artifact layout and interpretation.
+Use `scripts/userspace-perf-compare.sh` when validation is failing or when you need fresh IPv4/IPv6 hotspot data without the validator's throughput gates. Read [docs/userspace-perf-compare.md](/home/ps/git/codex-bpfrx/docs/userspace-perf-compare.md) for the exact artifact layout and interpretation.
 
-The current branch reality is:
+The current tree reality is:
 
 - the Rust userspace dataplane is real and deployed on the isolated `loss` userspace lab
 - the validator must distinguish between intentional fallback and real userspace forwarding
 - the legacy XDP dataplane is still the correctness and performance reference
-- `22-23 Gbps` is the target, not the guaranteed result of every current branch head
+- `22-23 Gbps` is the target, not the guaranteed result of every current tree state
 
 If the script fails on IPv6 route state:
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,21 @@ TC Egress:   main → screen_egress → conntrack → nat → forward
 
 ### Userspace Dataplane
 
-An alternative Rust-based forwarding engine that receives packets via AF_XDP sockets and processes them in userspace. A minimal XDP shim steers transit traffic to userspace while unsupported traffic falls back to the kernel BPF pipeline.
+An alternative Rust-based forwarding engine that receives packets via AF_XDP sockets and processes them in userspace. A Rust XDP shim stamps metadata, redirects transit traffic into AF_XDP, and still hands kernel-owned or unsupported traffic back to the kernel/BPF path when needed.
 
 ```
-NIC → XDP Shim (session-gated redirect) → AF_XDP socket
+NIC → XDP shim (live-session + new-flow redirect, kernel pass-through, explicit fallback)
+    → AF_XDP socket
     → Rust worker thread (session → policy → NAT → FIB → TX)
     → AF_XDP TX ring → NIC
 ```
 
-- **23+ Gbps** on 25G mlx5 ConnectX-5 (93% line rate)
-- **Per-worker architecture**: one thread per RSS queue, lock-free forwarding
-- **Zero-copy AF_XDP** with cpumap redirect for kernel pass-through
-- **Automatic fallback**: unsupported features cause transparent fallback to the eBPF dataplane
-- **Best for**: high-throughput transit forwarding with stateful NAT (SNAT, static 1:1, NAT64) and zone policy
-- **See**: [`docs/userspace-dataplane-architecture.md`](docs/userspace-dataplane-architecture.md) for full design details
+- **Per-worker architecture**: one worker per queue shard, with session/NAT/policy/FIB handled in Rust
+- **AF_XDP fast path**: current code supports both copy and zero-copy modes depending on driver/path behavior
+- **Kernel pass-through**: cpumap-assisted delivery keeps local/kernel-owned traffic out of the AF_XDP fast path
+- **Automatic fallback**: unsupported configs and explicit error paths still fall back to the legacy eBPF dataplane
+- **Best for**: active development of the Rust forwarding path and high-throughput transit forwarding on supported configs
+- **See**: [`docs/userspace-dataplane-architecture.md`](docs/userspace-dataplane-architecture.md) for the current architecture and [`docs/userspace-debug-map.md`](docs/userspace-debug-map.md) for the active debugging map
 
 **To select the userspace dataplane:**
 
@@ -58,23 +59,23 @@ system {
 | Stateful forwarding | Yes | Yes |
 | Zone + global policies | Yes | Yes |
 | Application matching | Yes | Yes |
-| Source NAT (interface + pool) | Yes | Yes |
+| Source NAT (interface + pool) | Yes | Interface mode yes; pool mode still gated |
 | Destination NAT | Yes | Yes |
 | Static NAT (1:1) | Yes | Yes |
 | NAT64 (IPv6↔IPv4) | Yes | Yes |
 | NPTv6 (RFC 6296) | Yes | Yes |
-| Screen/IDS (11 checks) | Yes | Yes |
-| Firewall filters + policers | Yes | Yes |
+| Screen/IDS (11 checks) | Yes | Most checks yes; SYN-cookie behavior falls back |
+| Firewall filters + policers | Yes | Filters yes; three-color policers still gated |
 | TCP MSS clamping | Yes | Yes |
 | GRE tunnel transit | Yes | Yes (passthrough) |
 | IPsec / XFRM | Yes | Yes (passthrough) |
 | VLANs (802.1Q) | Yes | Yes |
 | Flow export (NetFlow v9) | Yes | Yes |
-| HA cluster + session sync | Yes | Yes |
+| HA cluster + session sync | Yes | Integrated, but still under active hardening |
 | SYN cookie flood protection | Yes | No (fallback) |
-| Throughput (25G mlx5) | 22+ Gbps | 23+ Gbps |
+| Throughput (25G mlx5) | 22+ Gbps | See validation/perf docs for current results |
 
-The only remaining eBPF fallback is SYN cookie flood protection, which requires kernel-level TCP state. All other features are handled natively by the userspace dataplane. See [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md) for details.
+The userspace dataplane now covers most of the transit feature set in native Rust, but it is not "fallback-free". Current explicit gates in code still include pool-mode SNAT admission, SYN-cookie-dependent screen behavior, three-color policers, and port mirroring. The exact admission boundary is documented in [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
 
 ## Architecture
 
@@ -222,10 +223,10 @@ set security policies from-zone trust to-zone untrust policy allow-all then perm
   - **~60ms cluster failover** (30ms VRRP, ~97ms masterDown interval)
   - **Near-instant planned shutdown** (priority-0 burst, peer takes over in ~1ms)
 - **Userspace dataplane**
-  - **23+ Gbps** on 25G mlx5 ConnectX-5 with 6 workers (93% line rate)
-  - **Zero-copy AF_XDP** with cpumap redirect for XDP_PASS paths
-  - **Lock-free forwarding**: no mutexes on per-packet hot path
-  - **HA cluster support**: session sync, fabric redirect, ~60ms failover
+  - **AF_XDP-based forwarding** with per-worker Rust session/NAT/policy/FIB processing
+  - **Copy or zero-copy mode** depending on NIC driver/path behavior
+  - **Kernel pass-through via cpumap** for local and other kernel-owned traffic
+  - **See** [`docs/userspace-ha-validation.md`](docs/userspace-ha-validation.md) and [`docs/userspace-perf-compare.md`](docs/userspace-perf-compare.md) for current validation and profiling workflow
 
 ## Test Environment
 
@@ -329,6 +330,7 @@ See `docs/` for detailed design documents:
 - `test_env.md` — Test topology and validation steps
 - `feature-gaps.md` — vSRX feature parity tracking
 - `userspace-dataplane-architecture.md` — Comprehensive userspace AF_XDP dataplane architecture
+- `userspace-debug-map.md` — Active file/function map for userspace forwarding and debugging
 - `xdp-io-uring-userspace-dataplane.md` — Original userspace dataplane design document
 - `shared-umem-plan.md` — Shared UMEM investigation (cross-NIC infeasibility analysis)
 - `userspace-ha-validation.md` — HA failover validation procedures

--- a/docs/userspace-afxdp-idle-softirq-starvation.md
+++ b/docs/userspace-afxdp-idle-softirq-starvation.md
@@ -52,7 +52,7 @@ Implemented in commit `aefed32`:
   - spare fill frames
 - stopped treating a temporary zero insert as a hard runtime error
 
-Code: [userspace-dp/src/afxdp.rs](/home/ps/git/codex-bpfrx-userspace-wip/userspace-dp/src/afxdp.rs)
+Code: [userspace-dp/src/afxdp.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs)
 
 ### Shared-UMEM ring-size fix
 
@@ -61,7 +61,7 @@ Implemented in commit `5086741`:
 - rounded shared UMEM `fill_size` / `complete_size` to a power of two before `fq_cq()` creation
 - kept the spare-frame design without breaking AF_XDP bring-up on mlx5
 
-Code: [userspace-dp/src/afxdp.rs](/home/ps/git/codex-bpfrx-userspace-wip/userspace-dp/src/afxdp.rs)
+Code: [userspace-dp/src/afxdp.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs)
 
 ## Verification
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -8,6 +8,12 @@ networking stack for stateful firewall processing. It runs alongside
 the existing BPF XDP pipeline as a parallel forwarding path optimized
 for high-throughput TCP/UDP forwarding.
 
+This document tracks the current `master` architecture. It is not a claim
+that every supported configuration already reaches feature or performance
+parity with the legacy eBPF dataplane. For the exact admission gate, use
+[`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md). For active
+debugging entry points, use [`userspace-debug-map.md`](userspace-debug-map.md).
+
 ```
                         ┌─────────────────────────────────┐
                         │          bpfrxd (Go)             │
@@ -59,19 +65,20 @@ Packet arrives at NIC
   ├─ Non-IP (ARP, etc.) ──────────────────► cpumap → kernel stack
   ├─ Multicast / broadcast ────────────────► cpumap → kernel stack
   ├─ Local destination ────────────────────► cpumap → kernel stack
+  ├─ GRE / ESP / explicit fallback cases ──► tail-call → legacy XDP pipeline
   │
   ├─ Has active session in BPF map? ───YES─► XDP_REDIRECT → XSK socket
   │
-  ├─ Connection-initiating (SYN/new)? ─YES─► XDP_REDIRECT → XSK socket
+  ├─ Session miss but still transit traffic ─► XDP_REDIRECT → XSK socket
   │
-  └─ Non-initiating without session ───────► DROP (TCP retransmit recovers)
+  └─ Binding/heartbeat failure on DP-managed interface ─► DROP or explicit fallback
 ```
 
 **Key design decisions:**
 
-- **Session-gated redirect**: Only redirects packets when the userspace
-  session table has an entry. Prevents packet black holes during startup
-  and graceful degradation when userspace is restarting.
+- **Session-aware, not session-only redirect**: live sessions skip extra
+  local/interface-NAT checks, but transit session misses are still redirected
+  so the Rust dataplane can perform first-packet policy/NAT/FIB evaluation.
 
 - **cpumap for kernel pass-through**: In AF_XDP zero-copy mode, XDP_PASS
   permanently consumes UMEM frames (the kernel holds them in SKBs). The
@@ -79,10 +86,10 @@ Packet arrives at NIC
   frees the XSK frame while still delivering the packet to the kernel
   networking stack.
 
-- **Connection-init filtering**: Non-SYN TCP packets without a session
-  are dropped rather than redirected. The sender will retransmit, and
-  by then the session will exist. This prevents userspace from needing
-  to handle mid-stream TCP.
+- **Fail closed on dead bindings**: if a binding is missing, not ready, or
+  its heartbeat is stale on a userspace-managed interface, the shim drops
+  rather than blindly passing packets into the kernel path and creating
+  spurious RST/black-hole behavior.
 
 - **Heartbeat watchdog**: Each worker writes a timestamp to a BPF array
   map every 250ms. The shim checks freshness (5s timeout) and refuses
@@ -147,8 +154,8 @@ RX from AF_XDP ring (up to 256 frames per batch, 4 batches per poll)
   ├─ Build egress frame (MAC rewrite, VLAN tag)
   │
   └─ TX submission
-      ├─ Same binding: in-place UMEM rewrite (zero copy)
-      └─ Cross binding: memcpy to target UMEM frame
+      ├─ Same binding: in-place UMEM rewrite when possible
+      └─ Cross binding: copy into target binding UMEM on the common path
 ```
 
 #### AF_XDP Ring Management
@@ -191,9 +198,10 @@ Each binding manages four rings:
 
 **Zero-copy vs copy mode:**
 - Zero-copy: NIC DMA writes directly into UMEM. No kernel memcpy.
-  Requires driver support (mlx5). XDP_PASS leaks frames (hence cpumap).
-- Copy mode: Kernel copies packet data into UMEM. Works with any NIC.
-  Fallback when zero-copy bind fails.
+  Requires driver support and safe kernel-pass handling.
+- Copy mode: Kernel copies packet data into UMEM. The current tree still
+  contains mlx5/copy-mode mitigations and debugging around fill-ring pressure,
+  so do not read "AF_XDP" as meaning "always zero-copy" on current `master`.
 
 #### Session Table (`session.rs`)
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -1,126 +1,97 @@
-# Userspace Dataplane: Feature Gap Analysis
+# Userspace Dataplane: Current Capability Gate
 
-Comprehensive comparison between the eBPF dataplane (full feature set) and the Rust AF_XDP userspace dataplane. When the userspace dataplane encounters unsupported configuration, it transparently falls back to the eBPF pipeline via the XDP shim.
+This document tracks the current admission boundary on `master` for the Rust
+AF_XDP userspace dataplane. It is not a full bug tracker and it is not a
+historical branch plan. For active debugging entry points, use
+[`userspace-debug-map.md`](userspace-debug-map.md).
 
 Last updated: 2026-03-14
 
-## Implemented Features
+## Implemented In The Current Runtime
 
-These features work natively in the userspace dataplane:
+These capabilities exist in the current Rust userspace dataplane code path:
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Stateful forwarding | Full | Per-worker session tables, forward + reverse entries |
-| Zone-based policies | Full | Zone-pair matching with permit/deny actions |
-| Application matching | Full | Protocol + port range terms, multi-term apps (pre-expanded by daemon) |
-| Source NAT (interface mode) | Full | IPv4 and IPv6, egress interface address |
-| Static NAT (1:1 bidirectional) | Full | O(1) hash lookup, zone-aware, pre-routing DNAT + post-routing SNAT |
-| NAT64 (IPv6↔IPv4) | Full | Header translation, ICMPv6↔ICMP mapping, checksum recomputation, pool allocation |
-| VLANs (802.1Q) | Full | Ingress VLAN tracking, egress VLAN tagging, VLAN sub-interfaces |
-| HA cluster | Full | Session sync, fabric redirect, VRRP integration, ~60ms failover |
-| Session sync | Full | Incremental sync, GC delete callbacks, peer session replication |
-| allow-dns-reply | Full | Unsolicited DNS reply bypass for session-miss path |
-| Address books | Full | Pre-expanded to CIDRs by daemon before snapshot delivery |
-| Neighbor resolution | Full | Dynamic ARP/NDP tracking, proactive resolution |
-| FIB lookup | Full | Per-table IPv4/IPv6 route lookup with longest-prefix match |
+| Feature | Current state | Notes |
+|---------|---------------|-------|
+| Stateful forwarding | Implemented | Per-worker sessions plus shared session tables |
+| Zone + global policies | Implemented | Address and application terms are pre-expanded by the daemon |
+| Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
+| Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
+| Destination NAT | Implemented | Pre-expanded tuple snapshots from Go |
+| Static NAT | Implemented | Bidirectional 1:1 translation |
+| NAT64 | Implemented | Forward and reverse translation with reverse-session state |
+| NPTv6 | Implemented | Stateless prefix translation |
+| Firewall filters | Implemented | Filter snapshots and evaluation in Rust |
+| Flow export | Implemented | Userspace flow export snapshot and runtime |
+| TCP MSS clamping | Implemented | Flow snapshot fields are delivered and used in Rust |
+| Embedded ICMP NAT reversal | Implemented | Includes reverse-session repair paths |
+| Configurable session timeouts | Implemented | Snapshot-driven timeouts in `session.rs` |
+| VLAN handling | Implemented | Ingress VLAN tracking and egress tagging |
+| Route and neighbor lookup | Implemented | Per-table routes, neighbor cache, next-table support |
+| HA state ingestion | Implemented | Helper receives RG active/watchdog state |
+| Session delta export | Implemented | Rust helper exports open/close deltas back to Go |
 
-## Not Implemented (Fallback to eBPF)
+## Still Gated By `deriveUserspaceCapabilities()`
 
-These features cause the userspace dataplane to defer packets to the kernel eBPF pipeline. The `deriveUserspaceCapabilities()` function in `manager.go` detects these and marks forwarding as unsupported for affected traffic.
+These are the remaining explicit configuration gates in
+[`pkg/dataplane/userspace/manager.go`](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go):
 
-### NAT
+| Feature/config shape | Gate status | Reason |
+|----------------------|-------------|--------|
+| Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
+| Source NAT (pool mode) | Gated | Capability check still rejects non-interface SNAT rules |
+| Screen behavior requiring SYN cookies | Gated | SYN-cookie behavior remains a legacy eBPF capability |
+| Three-color policers | Gated | Simple filters are supported; three-color policers are not |
+| Port mirroring | Gated | No userspace mirroring path |
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| Source NAT (pool mode) | No address pool allocation, no port translation | Medium |
-| Destination NAT | Being implemented — plan at `docs/userspace-dnat-plan.md` | Medium |
-| NPTv6 (RFC 6296) | No stateless IPv6 prefix translation | Low |
+## Features That Still Use A Mixed Boundary
 
-### Security
+These are not "missing", but they are not pure userspace forwarding either:
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| Screen/IDS (all 11 checks) | No land, SYN flood, ping-of-death, teardrop, SYN-FIN, no-flag, winnuke, FIN-no-ACK, rate-limiting | High |
-| SYN cookie flood protection | No XDP-generated SYN-ACK cookies | High |
-| Global policies | `junos-global` zone pair not matched | Low |
-| Firewall filters | No port-range filters, hit counters, logging, DSCP rewrite, policer, lo0 filter | High |
+| Area | Current boundary |
+|------|------------------|
+| SYN cookie flood protection | Legacy eBPF fallback |
+| Kernel-owned traffic (ARP, local delivery, management, some non-IP) | cpumap or kernel pass-through from XDP |
+| GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
+| IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 
-### Flow Processing
+## What This Document Does Not Mean
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| TCP MSS clamping | No ingress/egress MSS adjustment (including GRE gre-in/gre-out) | Medium |
-| ALG control | No application layer gateway support | High |
-| allow-embedded-icmp | Field tracked but not actively enforced | Low |
-| Per-application timeouts | Static timeouts only (TCP 300s, UDP 60s, ICMP 15s) | Low |
-| Embedded ICMP error NAT reversal | Partial — reverse DNAT exists but incomplete inner-packet analysis | Medium |
-| TTL check / ICMP Time Exceeded | TTL checked and decremented; no ICMP TE generated (packet dropped) | Medium |
+A feature being "implemented" here means the runtime has code for it. It does
+not guarantee:
 
-### Routing
+- that every configuration shape using the feature is currently admitted
+- that every path is already hardened for HA failover
+- that current performance is at parity with the legacy dataplane
+- that there are no active correctness bugs in the forwarding path
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| Policy-based routing (PBR) | No `ip rule` integration, no routing-instance action | Medium |
-| ECMP multipath | Routes loaded but no equal-cost tie-breaking / load balancing | Medium |
-| VRF enforcement | Routes per-table but no full per-VRF policy isolation | Medium |
-| GRE tunnel transit | No POINTOPOINT detection, no pseudo-Ethernet header | High |
-| IPsec / XFRM interfaces | No strongSwan integration, no XFRM support | High |
+Those are separate questions. Use:
 
-### Observability
+- [`userspace-ha-validation.md`](userspace-ha-validation.md)
+- [`userspace-perf-compare.md`](userspace-perf-compare.md)
+- [`userspace-debug-map.md`](userspace-debug-map.md)
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| Syslog (per-packet) | No RT_FLOW structured logging, no facility/severity filtering | Medium |
-| NetFlow v9 export | No 1-in-N sampling or flow export | Medium |
-| SNMP counters | No ifTable MIB integration | Low |
+## Actual Fallback Mechanisms
 
-### Session Management
+There are two distinct fallback boundaries:
 
-| Feature | Gap | Complexity |
-|---------|-----|------------|
-| Filtered session clearing | Sessions can be deleted but not filtered by criteria | Low |
-| Session idle time display | No per-session idle time tracking for CLI display | Low |
+1. **Compile-time / reconcile-time gate**
+   - The Go manager chooses `xdp_userspace_prog` or `xdp_main_prog`
+     depending on `deriveUserspaceCapabilities()`.
 
-### Control Plane Features (Not Applicable)
+2. **Runtime XDP decision**
+   - Even when `xdp_userspace_prog` is active, the XDP shim can still:
+     - redirect to AF_XDP
+     - send kernel-owned traffic to cpumap / kernel
+     - tail-call back into the legacy XDP pipeline for explicit fallback reasons
+     - drop on dead/missing userspace bindings to fail closed
 
-These features are handled by the Go daemon, not the dataplane. They work regardless of which dataplane is active:
+## Priority Work
 
-- DHCP relay (Option 82)
-- DHCP server (Kea integration)
-- RPM probes
-- Dynamic address feeds
-- LLDP
-- Router Advertisements (RA)
-- FRR routing protocol integration
-- Config management (candidate/active/rollback)
-- CLI / gRPC / REST APIs
-- Event engine
+The highest-value remaining work on current `master` is:
 
-## Fallback Mechanism
-
-When any unsupported feature is detected in the active configuration, the Go manager (`pkg/dataplane/userspace/manager.go`) calls `deriveUserspaceCapabilities()` which checks for:
-
-1. Firewall filters or policers configured
-2. TCP MSS clamping enabled
-3. Screen profiles assigned to zones
-4. IPsec gateways, VPNs, or policies
-5. Tunnel interfaces (GRE, ip6gre)
-6. Per-application session timeouts
-7. Global policies
-8. NetFlow/flow monitoring
-9. Destination NAT rules (being implemented)
-
-If any are found, `ForwardingSupported` is set to `false` with reasons logged. The XDP shim then passes all transit packets to the kernel eBPF pipeline instead of AF_XDP sockets.
-
-## Priority Roadmap
-
-Based on real-world usage patterns, suggested implementation priority:
-
-1. **Destination NAT** — in progress, plan at `docs/userspace-dnat-plan.md`
-2. **Source NAT (pool mode)** — common in enterprise configs
-3. **Global policies** — trivial to add (treat `junos-global` as wildcard zone)
-4. **Per-application timeouts** — low effort, high value
-5. **TCP MSS clamping** — important for tunnel/VPN environments
-6. **Screen/IDS** — SYN flood protection is the highest priority check
-7. **PBR** — needed for multi-VRF deployments
-8. **Firewall filters** — complex but needed for advanced deployments
+1. admit pool-mode SNAT cleanly through the capability gate
+2. close the remaining SYN-cookie-dependent screen gap
+3. implement three-color policer support
+4. implement port mirroring
+5. continue correctness and performance hardening on the active AF_XDP fast path

--- a/docs/userspace-debug-map.md
+++ b/docs/userspace-debug-map.md
@@ -1,0 +1,128 @@
+# Userspace Dataplane Debug Map
+
+This is the compact file/function map for active debugging on current `master`.
+Use it when forwarding is broken, throughput collapses after startup, or the
+XDP shim and Rust helper disagree about who owns the packet.
+
+## 1. Start Here
+
+- XDP redirect and fallback decisions:
+  - [userspace-xdp/src/lib.rs](/home/ps/git/codex-bpfrx/userspace-xdp/src/lib.rs)
+- Go lifecycle, capability gate, and helper control:
+  - [pkg/dataplane/userspace/manager.go](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go)
+- Rust control loop and worker bring-up:
+  - [userspace-dp/src/main.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/main.rs)
+- Rust AF_XDP forwarding hot path:
+  - [userspace-dp/src/afxdp.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs)
+- Session installation and NAT reverse lookup:
+  - [userspace-dp/src/session.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/session.rs)
+  - [userspace-dp/src/nat.rs](/home/ps/git/codex-bpfrx/userspace-dp/src/nat.rs)
+- Go-side HA/session-sync bridge:
+  - [pkg/daemon/daemon.go](/home/ps/git/codex-bpfrx/pkg/daemon/daemon.go)
+
+## 2. Symptom To File Map
+
+### Packets never reach `bpfrx-userspace-dp`
+
+Look at:
+- [manager.go#L98](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go#L98)
+- [manager.go#L202](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go#L202)
+- [lib.rs#L279](/home/ps/git/codex-bpfrx/userspace-xdp/src/lib.rs#L279)
+- [lib.rs#L526](/home/ps/git/codex-bpfrx/userspace-xdp/src/lib.rs#L526)
+
+Questions:
+- Did Go choose `xdp_userspace_prog` or `xdp_main_prog`?
+- Is the capability gate forcing legacy fallback?
+- Is the XDP shim redirecting, cpumap-passing, tail-calling, or dropping?
+
+### Helper is up but bindings never become live
+
+Look at:
+- [manager.go#L2202](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go#L2202)
+- [main.rs#L1228](/home/ps/git/codex-bpfrx/userspace-dp/src/main.rs#L1228)
+- [main.rs#L1405](/home/ps/git/codex-bpfrx/userspace-dp/src/main.rs#L1405)
+- [afxdp.rs#L1862](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L1862)
+
+Questions:
+- Did bootstrap maps get programmed correctly?
+- Did the helper apply the snapshot and arm forwarding?
+- Did AF_XDP bind or rebind fail after a link cycle?
+
+### Session opens but reply traffic dies
+
+Look at:
+- [afxdp.rs#L4204](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L4204)
+- [afxdp.rs#L3421](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L3421)
+- [session.rs#L246](/home/ps/git/codex-bpfrx/userspace-dp/src/session.rs#L246)
+- [nat.rs#L23](/home/ps/git/codex-bpfrx/userspace-dp/src/nat.rs#L23)
+
+Questions:
+- Is the helper parsing the authoritative 5-tuple from metadata or from the mutated frame?
+- Is reverse NAT lookup hitting `nat_reverse_index`?
+- Are rebuilt L4 ports coming from the session tuple or from stale frame bytes?
+
+### Throughput starts high then falls to zero
+
+Look at:
+- [afxdp.rs#L1862](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L1862)
+- [afxdp.rs#L1978](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L1978)
+- [afxdp.rs#L5147](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L5147)
+- [docs/afxdp-packet-processing.md](/home/ps/git/codex-bpfrx/docs/afxdp-packet-processing.md)
+
+Questions:
+- Is TX backpressure starving RX fill-ring replenishment?
+- Are `pending_tx_local` or `pending_tx_prepared` growing without draining?
+- Are completions being reaped fast enough to recycle frames?
+
+### Idle softirq burn or AF_XDP stall
+
+Look at:
+- [docs/userspace-afxdp-idle-softirq-starvation.md](/home/ps/git/codex-bpfrx/docs/userspace-afxdp-idle-softirq-starvation.md)
+- [afxdp.rs#L1978](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L1978)
+- [afxdp.rs#L5014](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L5014)
+
+Questions:
+- Is the fill ring draining to zero?
+- Are AF_XDP RX buffer allocation errors climbing?
+- Are we spinning in backpressure without refilling?
+
+### HA/session-sync looks wrong
+
+Look at:
+- [manager.go#L2127](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go#L2127)
+- [daemon.go#L2798](/home/ps/git/codex-bpfrx/pkg/daemon/daemon.go#L2798)
+- [daemon.go#L3002](/home/ps/git/codex-bpfrx/pkg/daemon/daemon.go#L3002)
+
+Questions:
+- Is forwarding armed on the actual primary?
+- Are session deltas being drained from Rust and mirrored into Go/cluster sync?
+- Is owner RG being preserved or falling back to zone-based sync?
+
+## 3. Short Packet-Path Checklist
+
+1. Did Go arm userspace forwarding?
+   - [manager.go#L2127](/home/ps/git/codex-bpfrx/pkg/dataplane/userspace/manager.go#L2127)
+2. Did the XDP shim redirect this packet to AF_XDP?
+   - [lib.rs#L279](/home/ps/git/codex-bpfrx/userspace-xdp/src/lib.rs#L279)
+3. Did the Rust worker parse the expected tuple?
+   - [afxdp.rs#L4204](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L4204)
+4. Was there a session hit, shared hit, or NAT-reverse hit?
+   - [session.rs#L213](/home/ps/git/codex-bpfrx/userspace-dp/src/session.rs#L213)
+   - [session.rs#L246](/home/ps/git/codex-bpfrx/userspace-dp/src/session.rs#L246)
+5. Did NAT and FIB resolution produce a valid egress?
+   - [nat.rs#L211](/home/ps/git/codex-bpfrx/userspace-dp/src/nat.rs#L211)
+6. Did TX enqueue and drain without starving fill-ring recycle?
+   - [afxdp.rs#L5147](/home/ps/git/codex-bpfrx/userspace-dp/src/afxdp.rs#L5147)
+
+## 4. Validation And Capture Workflow
+
+Use:
+- [userspace-ha-validation.md](/home/ps/git/codex-bpfrx/docs/userspace-ha-validation.md)
+- [userspace-perf-compare.md](/home/ps/git/codex-bpfrx/docs/userspace-perf-compare.md)
+- [.codex/skills/iperf-grpc-tcpdump/SKILL.md](/home/ps/git/codex-bpfrx/.codex/skills/iperf-grpc-tcpdump/SKILL.md)
+
+That workflow gives you:
+- runtime mode detection
+- sustained-throughput detection
+- perf capture on the active userspace firewall
+- synchronized firewall-side and server-side tcpdump when `iperf3` collapses

--- a/docs/userspace-ha-validation.md
+++ b/docs/userspace-ha-validation.md
@@ -1,6 +1,6 @@
 # Userspace HA Validation
 
-Date: 2026-03-09
+Date: 2026-03-14
 
 This document captures the current repeatable validation path for the isolated
 userspace cluster on `loss`:
@@ -10,11 +10,11 @@ userspace cluster on `loss`:
 - `loss:cluster-userspace-host`
 
 Tracked inputs:
-- env: [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx-userspace-wip/test/incus/loss-userspace-cluster.env)
-- config: [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx-userspace-wip/docs/ha-cluster-userspace.conf)
-- validator: [userspace-ha-validation.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-ha-validation.sh)
-- phase cycle: [userspace-phase-cycle.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-phase-cycle.sh)
-- perf compare: [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-perf-compare.sh)
+- env: [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx/test/incus/loss-userspace-cluster.env)
+- config: [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx/docs/ha-cluster-userspace.conf)
+- validator: [userspace-ha-validation.sh](/home/ps/git/codex-bpfrx/scripts/userspace-ha-validation.sh)
+- phase cycle: [userspace-phase-cycle.sh](/home/ps/git/codex-bpfrx/scripts/userspace-phase-cycle.sh)
+- perf compare: [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx/scripts/userspace-perf-compare.sh)
 
 ## Current Model
 
@@ -74,7 +74,7 @@ This is the required sequence after each userspace dataplane phase:
 
 If the validation script is failing and you still need current performance data,
 run the perf-compare workflow next. It captures IPv4/IPv6 `iperf3` and `perf`
-artifacts without treating the current branch instability as a hard blocker.
+artifacts without treating current tree instability as a hard blocker.
 
 ## What The Validator Enforces
 
@@ -95,28 +95,31 @@ The validator does this in order:
 
 ## Target And Interpretation
 
-Validation target for this branch:
+Validation target for the active userspace forwarding path:
 
 - IPv4 `iperf3 -P 4 -t 5`: `22-23 Gbps`
 - IPv6 `iperf3 -P 4 -t 5`: `22-23 Gbps`
 - Retransmits: `0`
 - Sustained transfer: no “fast first second, then collapse to 0 bps” interval pattern
 
-That is the target, not a guarantee of the current branch head.
+That is the target, not a guarantee of the current tree state.
 
-Current branch reality:
+Current `master` reality:
 
-- the isolated HA/fabric lab currently validates the safe fallback path, not Rust
-  userspace forwarding for real traffic
-- the branch is still under active forwarding-correctness and performance work on
-  supported userspace-forwarding paths
+- the isolated HA lab is used for both active userspace-forwarding work and
+  safe fallback verification, depending on the active config and runtime gate
+- the validator must therefore first determine whether the node settled into:
+  - active userspace forwarding, or
+  - legacy eBPF fallback
+- the tree is still under active forwarding-correctness and performance work on
+  the AF_XDP fast path
 - it is normal for the validator to fail while a phase is in progress
 - a failing validation run is signal; do not “fix” it by lowering the threshold
 
-Use [userspace-perf-compare.md](/home/ps/git/codex-bpfrx-userspace-wip/docs/userspace-perf-compare.md)
+Use [userspace-perf-compare.md](/home/ps/git/codex-bpfrx/docs/userspace-perf-compare.md)
 for the current measured numbers and current hot-path deltas. This document defines
 the required workflow and the target, not the current performance claim for every
-branch head.
+tree state.
 
 The validator now treats interval collapse as a separate failure mode from average
 Gbps. A run that peaks high and then drops near zero is a failure even if the short
@@ -128,11 +131,11 @@ route state before throughput checks.
 
 ## Operational Rule
 
-For the isolated userspace cluster, do not use `/tmp/bpfrx-loss-userspace.env`
-or `/tmp/ha-cluster-userspace.conf` as the source of truth.
+For the isolated userspace cluster, do not use `/tmp` cluster env/config files
+as the source of truth.
 
 Use:
 
-- [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx-userspace-wip/test/incus/loss-userspace-cluster.env)
-- [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx-userspace-wip/docs/ha-cluster-userspace.conf)
-- [userspace-phase-cycle.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-phase-cycle.sh)
+- [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx/test/incus/loss-userspace-cluster.env)
+- [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx/docs/ha-cluster-userspace.conf)
+- [userspace-phase-cycle.sh](/home/ps/git/codex-bpfrx/scripts/userspace-phase-cycle.sh)

--- a/docs/userspace-perf-compare.md
+++ b/docs/userspace-perf-compare.md
@@ -1,22 +1,22 @@
 # Userspace Perf Compare
 
-Use [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-perf-compare.sh) when you need a repeatable IPv4/IPv6 performance capture on the isolated userspace cluster without coupling the result to the pass/fail thresholds in `userspace-ha-validation.sh`.
+Use [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx/scripts/userspace-perf-compare.sh) when you need a repeatable IPv4/IPv6 performance capture on the isolated userspace cluster without coupling the result to the pass/fail thresholds in `userspace-ha-validation.sh`.
 
-This is the authoritative workflow for current branch measurements. During active
+This is the authoritative workflow for current-tree measurements. During active
 performance work, do not cite the validation doc’s `22-23 Gbps` target as if it
-describes the current branch head. Use this workflow and the saved artifacts instead.
+describes the current tree state. Use this workflow and the saved artifacts instead.
 
 This is the right tool when:
-- the branch is still unstable and validation fails at a reachability or throughput gate
+- the current tree is still unstable and validation fails at a reachability or throughput gate
 - you still need current `perf` data from `bpfrx-userspace-fw0/1`
 - you want a side-by-side IPv4/IPv6 hotspot comparison with saved artifacts
 - you need to confirm whether a run is truly sustained or only bursts in the first second
 
 Inputs:
-- env: [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx-userspace-wip/test/incus/loss-userspace-cluster.env)
-- isolated config: [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx-userspace-wip/docs/ha-cluster-userspace.conf)
-- validator: [userspace-ha-validation.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-ha-validation.sh)
-- compare script: [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx-userspace-wip/scripts/userspace-perf-compare.sh)
+- env: [loss-userspace-cluster.env](/home/ps/git/codex-bpfrx/test/incus/loss-userspace-cluster.env)
+- isolated config: [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx/docs/ha-cluster-userspace.conf)
+- validator: [userspace-ha-validation.sh](/home/ps/git/codex-bpfrx/scripts/userspace-ha-validation.sh)
+- compare script: [userspace-perf-compare.sh](/home/ps/git/codex-bpfrx/scripts/userspace-perf-compare.sh)
 
 Run:
 

--- a/docs/userspace-vlan80-regression.md
+++ b/docs/userspace-vlan80-regression.md
@@ -10,7 +10,7 @@ Environment:
 - test host:
   - `loss:cluster-userspace-host`
 - tracked config:
-  - [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx-userspace-wip/docs/ha-cluster-userspace.conf)
+  - [ha-cluster-userspace.conf](/home/ps/git/codex-bpfrx/docs/ha-cluster-userspace.conf)
 
 This file is historical. It captures a closed lab regression and should not be read
 as the explanation for current userspace forwarding bugs on this branch.
@@ -202,4 +202,4 @@ Current remaining userspace work is in the forwarding path itself:
 - closing the gap to the `22-23 Gbps` target on the isolated lab
 
 Current repeatable validation is documented in
-[userspace-ha-validation.md](/home/ps/git/codex-bpfrx-userspace-wip/docs/userspace-ha-validation.md).
+[userspace-ha-validation.md](/home/ps/git/codex-bpfrx/docs/userspace-ha-validation.md).

--- a/docs/xdp-io-uring-userspace-dataplane.md
+++ b/docs/xdp-io-uring-userspace-dataplane.md
@@ -5,17 +5,17 @@ Date: 2026-03-06
 Note: This is an architecture exploration document. It is intentionally grounded in
 bpfrx's current XDP/TC, HA, and `pkg/dataplane.DataPlane` model.
 
-This file now serves two purposes:
+This file is now best read as a design and migration-history document.
 
-- the target design for the userspace dataplane
-- the current branch status on `userspace-dataplane-rust-wip`
+For current `master` behavior, use:
 
-Those are not the same thing. The branch has real Rust AF_XDP forwarding and real
-lab validation on supported non-HA paths, but it is still experimental, incomplete
-for full HA/policy parity, and not yet at performance parity with the legacy XDP/TC
-dataplane. The current isolated HA/fabric cluster on `loss` is intentionally gated
-back to legacy XDP for real traffic until HA ownership and fabric redirect are
-implemented in the Rust dataplane.
+- [`userspace-dataplane-architecture.md`](userspace-dataplane-architecture.md) for the current architecture
+- [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md) for the current admission boundary
+- the current code in `pkg/dataplane/userspace/`, `userspace-xdp/`, and `userspace-dp/`
+
+Some historical branch-status notes remain below because they explain design
+tradeoffs and fallback boundaries, but they should not be treated as the
+authoritative runtime status for `master`.
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary
- sync the userspace dataplane docs with current `master` behavior
- remove stale `userspace-wip` references and branch-specific wording
- add a compact userspace debug map for XDP redirect, AF_XDP forwarding, session/NAT, and HA/session-sync debugging

## Included
- README userspace dataplane summary updated to match current code paths and capability gate
- userspace architecture and gaps docs updated to reflect current `master`
- validation/perf docs updated to point at repo-local files and current-tree workflow
- new `docs/userspace-debug-map.md` for active forwarding/debug work

## Notes
- documentation-only change
- no runtime code changes