### PR TITLE
test: harden userspace validation harness

### DIFF
--- a/.codex/skills/userspace-ha-validation/SKILL.md
+++ b/.codex/skills/userspace-ha-validation/SKILL.md
@@ -42,17 +42,24 @@ What the script enforces:
 - deterministic TTL-expired probes must work to:
   - `1.1.1.1`
   - `2607:f8b0:4005:814::200e`
+  - `ping` exit status `1` is expected for these probes if the returned output
+    contains the native time-exceeded response
 - one-cycle `mtr` reports to those two targets must show:
   - a resolved first hop
   - a resolved destination hop
 - one unmeasured warm-up `iperf3` pass is run for each address family
 - repeated IPv4 `iperf3` to `172.16.80.200` must stay above threshold
 - repeated IPv6 `iperf3` to `2001:559:8585:80::200` must stay above threshold
-- per-interval `iperf3 -J` output is parsed and a run fails if it starts fast and then collapses
+- per-interval `iperf3 -J` output is copied back to the repo host, parsed
+  locally, and a run fails if it starts fast and then collapses
 - one marginal near-threshold miss is retried once before the run is treated as failed
 - optional `perf` capture runs on the active userspace firewall, not a hardcoded node
 
 Use `scripts/userspace-ha-validation.sh` directly only when you are debugging the validator itself.
+
+`cluster-userspace-host` only needs `ping`, `mtr`, and `iperf3`. The JSON
+interval analysis runs on the repo host with `scripts/iperf-json-metrics.py`,
+so do not assume `python3` exists on the test host.
 
 Use `scripts/userspace-perf-compare.sh` when validation is failing or when you need fresh IPv4/IPv6 hotspot data without the validator's throughput gates. Read [docs/userspace-perf-compare.md](/home/ps/git/codex-bpfrx/docs/userspace-perf-compare.md) for the exact artifact layout and interpretation.
 

--- a/docs/userspace-dataplane-cleanup-plan.md
+++ b/docs/userspace-dataplane-cleanup-plan.md
@@ -21,7 +21,8 @@ Current execution state as of 2026-03-15:
 2. Phase 2 is complete and merged on `master` via PR `#225`.
 3. Phase 3 is complete on the current branch via PR `#228`.
 4. Phase 4 is complete on the current branch and ready for PR review.
-5. Phase 5 is partially complete on `master` via PR `#221`.
+5. Phase 5 is in progress on the current branch and is partially complete on
+   `master` via PR `#221`.
 6. Phase 6 has not started as a formal cleanup phase yet.
 
 Latest status-sync update for this document:
@@ -72,10 +73,9 @@ Completed under this plan:
 
 Still left to do at a high level:
 
-1. Finish hardening validation coverage in Phase 5.
-2. Fix the userspace validation shell harness so TTL / hop-limit probes are
-   treated as success when they return the expected native time-exceeded reply.
-3. Only then do the serious sustained-throughput optimization work in Phase 6.
+1. Finish the remaining regression hardening in Phase 5 beyond the TTL /
+   hop-limit shell-harness fix.
+2. Only then do the serious sustained-throughput optimization work in Phase 6.
 
 ## Current Baseline
 
@@ -410,7 +410,7 @@ Phase 4 result:
 
 ## Phase 5: Validation And Regression Hardening
 
-Status: Partially Complete
+Status: In Progress
 
 Completed so far:
 
@@ -420,6 +420,11 @@ Completed so far:
    to `2607:f8b0:4005:814::200e`.
 3. Sustained-throughput collapse detection was already added before this plan
    and remains part of the normal workflow.
+4. On the current branch, the shell harness now accepts TTL / hop-limit probe
+   exit status `1` when the captured output contains the expected native
+   time-exceeded response.
+5. On the current branch, `iperf3 -J` output is now analyzed on the repo host
+   instead of assuming `python3` exists on `cluster-userspace-host`.
 
 Delivered in:
 
@@ -429,13 +434,10 @@ Delivered in:
 
 Still left:
 
-1. Fix the shell harness so TTL / hop-limit probes do not fail the validation
-   script when they return the expected time-exceeded reply with non-zero exit
-   status.
-2. Add more direct regression coverage for tuple authority and embedded ICMP
+1. Add more direct regression coverage for tuple authority and embedded ICMP
    corner cases.
-3. Add coverage for AF_XDP build-failure fallback behavior.
-4. Keep synchronized capture workflows available as diagnosis tools, not first
+2. Add coverage for AF_XDP build-failure fallback behavior.
+3. Keep synchronized capture workflows available as diagnosis tools, not first
    line validation.
 
 ### Purpose

--- a/docs/userspace-ha-validation.md
+++ b/docs/userspace-ha-validation.md
@@ -90,12 +90,15 @@ The validator does this in order:
 8. runs deterministic TTL-expired probes to:
    - IPv4 `1.1.1.1`
    - IPv6 `2607:f8b0:4005:814::200e`
+   - the validator treats `ping` exit status `1` as expected for these probes
+     when the returned output contains the native time-exceeded response
 9. records one-cycle `mtr` reports to those same public IPv4/IPv6 targets
 10. fails if the first hop is unresolved or the destination hop is unresolved
 11. runs one unmeasured warm-up `iperf3` pass for IPv4 and IPv6
 12. runs repeated IPv4 `iperf3` to `172.16.80.200`
 13. runs repeated IPv6 `iperf3` to `2001:559:8585:80::200`
-14. parses per-interval `iperf3 -J` output and fails if throughput cliffs after startup
+14. pulls `iperf3 -J` JSON back to the repo host, parses it locally, and fails
+    if throughput cliffs after startup
 15. retries one marginal near-threshold miss once
 16. optionally records `perf` data on the active firewall
 
@@ -139,12 +142,29 @@ It does not require every internet hop to answer. It does require:
   - `1.1.1.1`
   - `2607:f8b0:4005:814::200e`
 
+For the TTL / hop-limit probes, a non-zero `ping` exit code is not itself a
+failure. The validator accepts the probe when the returned output contains the
+expected native time-exceeded text from the userspace firewall.
+
 Artifacts kept on `cluster-userspace-host`:
 
 - `/tmp/userspace-ttl-v4.txt`
 - `/tmp/userspace-ttl-v6.txt`
 - `/tmp/userspace-mtr-v4.txt`
 - `/tmp/userspace-mtr-v6.txt`
+- `/tmp/ipv4-*.json`
+- `/tmp/ipv6-*.json`
+
+The `cluster-userspace-host` only needs the runtime tools used to generate the
+artifacts:
+
+- `ping`
+- `mtr`
+- `iperf3`
+
+The interval-collapse analysis runs on the repo host using
+[iperf-json-metrics.py](/home/ps/git/codex-bpfrx/scripts/iperf-json-metrics.py),
+so the cluster test host does not need `python3`.
 
 Short-lived outliers can still happen immediately after rolling deploy while HA
 ownership and RA converge. That is why the validator explicitly waits for IPv6

--- a/scripts/userspace-ha-validation.sh
+++ b/scripts/userspace-ha-validation.sh
@@ -271,9 +271,9 @@ run_ttl_probe() {
 	local family="$1" target="$2" outfile="$3"
 	local cmd
 	if [[ "$family" == "6" ]]; then
-		cmd="ping -6 -c 1 -W 2 -t 1 ${target} > ${outfile}"
+		cmd="rm -f ${outfile}; if ping -6 -c 1 -W 2 -t 1 ${target} > ${outfile} 2>&1; then :; else rc=\$?; if [[ \$rc -gt 1 ]]; then echo \"ping exited with status \$rc\" >> ${outfile}; exit \$rc; fi; fi"
 	else
-		cmd="ping -c 1 -W 2 -t 1 ${target} > ${outfile}"
+		cmd="rm -f ${outfile}; if ping -c 1 -W 2 -t 1 ${target} > ${outfile} 2>&1; then :; else rc=\$?; if [[ \$rc -gt 1 ]]; then echo \"ping exited with status \$rc\" >> ${outfile}; exit \$rc; fi; fi"
 	fi
 	run_host "$cmd"
 }
@@ -391,18 +391,18 @@ run_iperf_json() {
 }
 
 parse_gbps() {
-	local path="$1"
-	local metrics
-	metrics="$(iperf_metrics "$path")"
+	local metrics="$1"
 	if [[ "$metrics" == ERROR:* ]]; then
 		printf '%s\n' "$metrics"
 		return 0
 	fi
-	python3 -c 'import json,sys; print(f"{json.load(sys.stdin)[\"avg_gbps\"]:.3f}")' <<<"$metrics"
+	python3 -c 'import json,sys; print("{:.3f}".format(json.load(sys.stdin)["avg_gbps"]))' <<<"$metrics"
 }
 
 iperf_metrics() {
 	local path="$1"
+	local local_json
+	local metrics
 	if ! run_host "[ -s ${path} ]" >/dev/null 2>&1; then
 		local err
 		err="$(run_host "cat ${path}.err 2>/dev/null || true")"
@@ -412,7 +412,24 @@ iperf_metrics() {
 		printf 'ERROR:%s\n' "$err"
 		return 0
 	fi
-	run_host "python3 ${IPERF_METRICS} ${path} --tail-window ${IPERF_TAIL_WINDOW} --min-peak-gbps ${IPERF_MIN_PEAK_GBPS} --min-tail-ratio ${IPERF_MIN_TAIL_RATIO} --zero-gbps ${IPERF_ZERO_GBPS} --stall-gbps ${IPERF_STALL_GBPS}"
+	local_json="$(mktemp)"
+	if ! run_host "cat ${path}" >"${local_json}"; then
+		rm -f "${local_json}"
+		printf 'ERROR:failed to fetch iperf3 JSON output from cluster host\n'
+		return 0
+	fi
+	if ! metrics="$(python3 "${IPERF_METRICS}" "${local_json}" \
+		--tail-window "${IPERF_TAIL_WINDOW}" \
+		--min-peak-gbps "${IPERF_MIN_PEAK_GBPS}" \
+		--min-tail-ratio "${IPERF_MIN_TAIL_RATIO}" \
+		--zero-gbps "${IPERF_ZERO_GBPS}" \
+		--stall-gbps "${IPERF_STALL_GBPS}")"; then
+		rm -f "${local_json}"
+		printf 'ERROR:failed to summarize iperf3 JSON output\n'
+		return 0
+	fi
+	rm -f "${local_json}"
+	printf '%s\n' "${metrics}"
 }
 
 validate_sustained_iperf() {
@@ -485,7 +502,7 @@ validate_family() {
 			if [[ "$metrics" == ERROR:* ]]; then
 				die "${label} iperf failed: ${metrics#ERROR:}"
 			fi
-			gbps="$(parse_gbps "$json")"
+			gbps="$(parse_gbps "$metrics")"
 			metrics_line="$(format_metrics_line "$metrics")"
 			validate_sustained_iperf "$label" "$i" "$metrics"
 			if python3 - <<'PY' "$gbps" "$min_gbps" "$MARGINAL_GBPS_EPSILON"


### PR DESCRIPTION
## Summary
- accept the expected non-zero `ping` exit status for TTL / hop-limit probes and validate success from the returned time-exceeded text
- analyze `iperf3 -J` output on the repo host instead of assuming `python3` exists on `cluster-userspace-host`
- update the userspace validation docs, skill, and cleanup plan to reflect the current Phase 5 state

## Validation
- `bash -n scripts/userspace-ha-validation.sh`
- `python3 -m py_compile scripts/iperf-json-metrics.py`
- `RUNS=1 DURATION=3 PARALLEL=1 MIN_GBPS_V4=1 MIN_GBPS_V6=1 ./scripts/userspace-ha-validation.sh --env test/incus/loss-userspace-cluster.env`
