### PR TITLE
userspace: cut direct enqueue control overhead

### DIFF
--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -134,13 +134,14 @@ pub(super) fn enqueue_pending_forwards(
         };
         let expected_ports = request.expected_ports;
         let ingress_umem_ptr = ingress_binding.umem.allocation_ptr();
-        let Some(target_binding) = find_target_binding_mut(
+        let Some(target_binding) = resolve_pending_forward_target_binding(
             left,
             ingress_index,
             ingress_binding,
             request.ingress_queue_id,
             right,
             binding_lookup,
+            request.target_binding_index,
             request.target_ifindex,
         ) else {
             // No XSK binding for the target interface.  Normally fabric
@@ -594,14 +595,16 @@ pub(super) fn enqueue_pending_forwards(
                 let _ = drain_pending_tx(target_binding, now_ns, &mut post_recycles);
             }
         }
-        apply_shared_recycles(
-            left,
-            ingress_index,
-            ingress_binding,
-            right,
-            binding_lookup,
-            &mut post_recycles,
-        );
+        if !post_recycles.is_empty() {
+            apply_shared_recycles(
+                left,
+                ingress_index,
+                ingress_binding,
+                right,
+                binding_lookup,
+                &mut post_recycles,
+            );
+        }
         update_binding_debug_state(ingress_binding);
         if build_failed {
             handle_forward_build_failure(


### PR DESCRIPTION
## Summary
- use the cached `target_binding_index` for normal direct enqueue paths
- skip shared-recycle application when there are no shared recycles to apply

## Why
The current direct path already caches `target_binding_index` when building a forward request, but `enqueue_pending_forwards()` was still re-running target-binding lookup on the hot path. This change uses the cached index for normal forwards and trims an avoidable empty shared-recycle call.

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_live_forward_request_caches_target_binding_index -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_forwarded_frame_into_keeps_ipv6_tcp_ports_after_vlan_snat -- --nocapture`
- live deploy to `bpfrx-userspace-fw0/1`
- manual IPv4 transit samples:
  - `18.95 Gbps`
  - `19.14 Gbps`
- `./scripts/userspace-ha-validation.sh --env test/incus/loss-userspace-cluster.env`
- `./scripts/userspace-ha-failover-validation.sh --env test/incus/loss-userspace-cluster.env --duration 30 --parallel 4`