### PR TITLE
userspace: select XSK bind mode from XDP attach mode

### DIFF
--- a/userspace-dp/src/afxdp/bind.rs
+++ b/userspace-dp/src/afxdp/bind.rs
@@ -151,7 +151,11 @@ fn interface_uses_generic_xdp(ifindex: u32) -> bool {
     };
     let rc = unsafe { libbpf_sys::bpf_xdp_query(ifindex as c_int, 0, &mut opts) };
     if rc != 0 {
-        return false;
+        eprintln!(
+            "bpfrx-userspace-dp: bpf_xdp_query(ifindex={}) failed rc={} — assuming generic XDP",
+            ifindex, rc
+        );
+        return true;
     }
     opts.attach_mode == libbpf_sys::XDP_ATTACHED_SKB as u8
 }


### PR DESCRIPTION
## Summary
- select AF_XDP bind flags from the interface's actual XDP attach mode
- keep generic `virtio_net` bindings on auto mode, but force copy for generic non-virtio interfaces
- avoid taking zerocopy on `mlx5` interfaces when the compiler has already downgraded the box to generic XDP

## Why
Issue #294.

On the userspace cluster, a native attach failure on `ifindex=4` downgrades all interfaces to `xdpgeneric`. Before this change the helper still chose zerocopy for non-`virtio_net` NICs based only on driver name, which broke steady-state forwarding to `.200`.

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `make build-userspace-dp`
- deployed helper-only build to `loss-userspace-cluster`
- observed bind logs on `fw1`:
  - generic `virtio_net`: `mode=Copy flags=0x0000`
  - generic `mlx5`: `mode=Copy flags=0x000a`
- connectivity after warm-up:
  - `cluster-userspace-host -> 172.16.80.200` ping: pass
  - TCP connect to `172.16.80.200:5201`: pass
  - `iperf3 -c 172.16.80.200 -P 4 -t 3`: ~`9.27 Gbps`

## Notes
- this fixes the helper-side bind selection bug
- it does not address the separate global generic fallback issue tracked in #293
