### PR TITLE
ha: gate takeover on userspace dataplane readiness

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -95,3 +95,7 @@
 - **Timestamp**: 2026-04-02T06:00:00Z
   - **Action**: Merged PR #357 (flow cache simplification refactors). Implemented phases 3+4 from docs/flow-cache-simplification.md — explicit is_cacheable() + 10 unit tests (624a1f83)
   - **File(s)**: userspace-dp/src/afxdp/types.rs, docs/flow-cache-simplification.md
+
+- **Timestamp**: 2026-04-02T12:30:00Z
+  - **Action**: Gate HA takeover on proven userspace dataplane readiness and remove activation-time NAPI bootstrap from `UpdateRGActive()` (#391)
+  - **File(s)**: pkg/dataplane/userspace/manager_ha.go, pkg/dataplane/userspace/manager_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/vip_readiness_test.go

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -2870,13 +2870,15 @@ func (d *Daemon) reconcileRGState() {
 			} else {
 				vrrpReady = true // no VRRP = always ready
 			}
-			ready := ifReady && vrrpReady && fabricReady
+			userspaceReady, userspaceReasons := d.checkUserspaceTakeoverReadiness(rgID)
+			ready := ifReady && vrrpReady && fabricReady && userspaceReady
 			var reasons []string
 			reasons = append(reasons, ifReasons...)
 			reasons = append(reasons, vrrpReasons...)
 			if !fabricReady {
 				reasons = append(reasons, "fabric forwarding path not ready")
 			}
+			reasons = append(reasons, userspaceReasons...)
 			d.cluster.SetRGReady(rgID, ready, reasons)
 		}
 	}
@@ -3556,6 +3558,30 @@ func checkVIPReadinessForConfig(cfg *config.Config, rgID int, linkByName func(st
 		}
 	}
 	return len(reasons) == 0, reasons
+}
+
+func userspaceRGConfigured(cfg *config.Config, rgID int) bool {
+	if cfg == nil || cfg.System.DataplaneType != dataplane.TypeUserspace || rgID <= 0 {
+		return false
+	}
+	for _, ifc := range cfg.Interfaces.Interfaces {
+		if ifc != nil && ifc.RedundancyGroup == rgID {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Daemon) checkUserspaceTakeoverReadiness(rgID int) (bool, []string) {
+	cfg := d.store.ActiveConfig()
+	if !userspaceRGConfigured(cfg, rgID) {
+		return true, nil
+	}
+	um, ok := d.dp.(*dpuserspace.Manager)
+	if !ok {
+		return true, nil
+	}
+	return um.TakeoverReady()
 }
 
 // isNoRethVRRP returns true when no-reth-vrrp is explicitly configured,

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -214,3 +214,38 @@ func TestCheckVIPReadiness_InterfaceUpViaFlags(t *testing.T) {
 		t.Errorf("should be ready with FlagUp, got reasons: %v", reasons)
 	}
 }
+
+func TestUserspaceRGConfigured(t *testing.T) {
+	cfg := &config.Config{
+		System: config.SystemConfig{
+			DataplaneType: "userspace",
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name:            "reth0",
+					RedundancyGroup: 1,
+				},
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 2,
+				},
+			},
+		},
+	}
+
+	if !userspaceRGConfigured(cfg, 1) {
+		t.Fatal("userspaceRGConfigured(cfg, 1) = false, want true")
+	}
+	if userspaceRGConfigured(cfg, 0) {
+		t.Fatal("userspaceRGConfigured(cfg, 0) = true, want false for RG0")
+	}
+	if userspaceRGConfigured(cfg, 3) {
+		t.Fatal("userspaceRGConfigured(cfg, 3) = true, want false for missing RG")
+	}
+
+	cfg.System.DataplaneType = ""
+	if userspaceRGConfigured(cfg, 1) {
+		t.Fatal("userspaceRGConfigured(non-userspace, 1) = true, want false")
+	}
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -217,6 +217,46 @@ func (m *Manager) desiredForwardingArmedLocked() bool {
 	return false
 }
 
+// TakeoverReady reports whether the userspace dataplane is already in a state
+// where an HA ownership move can rely on it for forwarding immediately.
+// This intentionally rejects "startup-like" states so HA cutover does not
+// begin queue bring-up work during UpdateRGActive().
+func (m *Manager) TakeoverReady() (bool, []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.takeoverReadyLocked()
+}
+
+func (m *Manager) takeoverReadyLocked() (bool, []string) {
+	var reasons []string
+	if m.proc == nil || m.proc.Process == nil {
+		reasons = append(reasons, "userspace helper not running")
+	}
+	if !m.lastStatus.Enabled {
+		reasons = append(reasons, "userspace helper not enabled")
+	}
+	if !m.lastStatus.Capabilities.ForwardingSupported {
+		if len(m.lastStatus.Capabilities.UnsupportedReasons) > 0 {
+			reasons = append(reasons, m.lastStatus.Capabilities.UnsupportedReasons...)
+		} else {
+			reasons = append(reasons, "userspace forwarding unsupported")
+		}
+	}
+	if !m.lastStatus.ForwardingArmed {
+		reasons = append(reasons, "userspace forwarding not armed")
+	}
+	if m.mode == ModeEBPFOnly {
+		reasons = append(reasons, "userspace dataplane not active")
+	}
+	if m.xskLivenessFailed {
+		reasons = append(reasons, "userspace XSK liveness failed")
+	}
+	if !m.xskLivenessProven {
+		reasons = append(reasons, "userspace XSK liveness not proven")
+	}
+	return len(reasons) == 0, reasons
+}
+
 func (m *Manager) hasActiveDataRGLocked() bool {
 	for _, group := range m.haGroups {
 		if group.RGID > 0 && group.Active {
@@ -298,7 +338,6 @@ func (m *Manager) UpdateRGActive(rgID int, active bool) error {
 		"rg", rgID, "active", active)
 
 	if active {
-		m.bootstrapNAPIQueuesAsyncLocked("ha-update-active")
 		m.proactiveNeighborResolveAsyncLocked()
 	}
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -3,6 +3,8 @@ package userspace
 import (
 	"encoding/binary"
 	"net"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -223,6 +225,68 @@ func TestBuildSessionSyncRequestV4PreservesTunnelEndpointIdentity(t *testing.T) 
 	}
 	if req.NeighborMAC != "" || req.SrcMAC != "" {
 		t.Fatalf("unexpected tunnel L2 metadata: %+v", req)
+	}
+}
+
+func TestTakeoverReadyRequiresProvenUserspacePath(t *testing.T) {
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			Enabled:         true,
+			ForwardingArmed: true,
+			Capabilities: UserspaceCapabilities{
+				ForwardingSupported: true,
+			},
+		},
+		mode: ModeUserspaceCompat,
+	}
+
+	ready, reasons := m.TakeoverReady()
+	if ready {
+		t.Fatal("TakeoverReady() = true, want false without XSK liveness proof")
+	}
+	if len(reasons) != 1 || reasons[0] != "userspace XSK liveness not proven" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+
+	m.xskLivenessProven = true
+	ready, reasons = m.TakeoverReady()
+	if !ready {
+		t.Fatalf("TakeoverReady() = false, want true; reasons=%v", reasons)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("unexpected ready reasons: %v", reasons)
+	}
+}
+
+func TestTakeoverReadyRejectsEBPFOnlyAndFailedLiveness(t *testing.T) {
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			Enabled:         true,
+			ForwardingArmed: true,
+			Capabilities: UserspaceCapabilities{
+				ForwardingSupported: true,
+			},
+		},
+		mode:              ModeEBPFOnly,
+		xskLivenessFailed: true,
+	}
+
+	ready, reasons := m.TakeoverReady()
+	if ready {
+		t.Fatal("TakeoverReady() = true, want false")
+	}
+	want := map[string]bool{
+		"userspace dataplane not active":    true,
+		"userspace XSK liveness failed":     true,
+		"userspace XSK liveness not proven": true,
+	}
+	for _, reason := range reasons {
+		delete(want, reason)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing expected reasons, remaining=%v got=%v", want, reasons)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a userspace dataplane takeover-readiness check to the manager
- gate RG takeover readiness on that userspace signal for userspace data RGs
- remove activation-time NAPI bootstrap from `UpdateRGActive()` and record the work in `_Log.md`

## Why
Failover should not start queue bring-up work during ownership transfer. If the standby is not already RX-ready, it should not be takeover-ready. This is the first concrete cut toward issue #391 and the failover implementation plan.

## Testing
- `go test ./pkg/dataplane/userspace ./pkg/daemon/...`
