### PR TITLE
cluster: use explicit transfer state for manual failover

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -76,6 +76,10 @@
 
 ## 2026-04-02
 
+- **Timestamp**: 2026-04-02T12:30:00Z
+  - **Action**: First #390 slice — replace weight-zero manual failover with explicit secondary-hold transfer-out state, keep ForceSecondary on zero-weight drain semantics, and teach election to promote on peer transfer-out without mutating monitor weight
+  - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/election.go, pkg/cluster/cluster_test.go, pkg/cluster/election_test.go, pkg/cluster/sync.go
+
 - **Timestamp**: 2026-04-02T01:30:00Z
   - **Action**: Merged PR #337 (HA simple failover design doc). Fixed copilot review — issue reference swap in phases 3/5/6.
   - **File(s)**: docs/ha-simple-failover-design.md

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -615,7 +615,10 @@ func (m *Manager) IsLocalPrimaryAny() bool {
 	return false
 }
 
-// ManualFailover forces a redundancy group to failover.
+// ManualFailover forces a redundancy group to transfer out of primary.
+// Unlike ForceSecondary, this preserves the group's monitor-derived weight
+// and advertises an explicit transfer-out state so the peer can claim
+// primary without relying on weight-zero election semantics.
 func (m *Manager) ManualFailover(rgID int) error {
 	m.mu.Lock()
 	rg, ok := m.groups[rgID]
@@ -667,8 +670,7 @@ func (m *Manager) ManualFailover(rgID int) error {
 	oldState := rg.State
 	rg.ManualFailover = true
 	rg.ManualFailoverAt = time.Now()
-	rg.Weight = 0 // zero weight so peer election sees "Peer weight 0" → becomes primary
-	rg.State = StateSecondary
+	rg.State = StateSecondaryHold
 	rg.FailoverCount++
 	if oldState != rg.State {
 		m.sendEvent(rg.GroupID, oldState, rg.State, "Manual failover")
@@ -1117,8 +1119,8 @@ func (m *Manager) handlePeerTimeout() {
 
 	// Clear ManualFailover on all RGs: the peer is dead, so the surviving
 	// node MUST be able to take over. Without this, a previous manual
-	// failover (which set Weight=0) prevents electSingleNode from
-	// promoting this node to primary.
+	// transfer-out would keep the local node parked in secondary-hold even
+	// though there is no longer a peer to hand ownership to.
 	for _, rg := range m.groups {
 		if rg.ManualFailover {
 			slog.Info("cluster: clearing manual failover (peer lost)", "rg", rg.GroupID)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -127,8 +127,8 @@ func TestUpdateConfig_PreservesState(t *testing.T) {
 	if !states[0].ManualFailover {
 		t.Error("RG 0 manual failover should be preserved")
 	}
-	if states[0].State != StateSecondary {
-		t.Errorf("RG 0 state = %s, want secondary (manual failover)", states[0].State)
+	if states[0].State != StateSecondaryHold {
+		t.Errorf("RG 0 state = %s, want secondary-hold (manual failover)", states[0].State)
 	}
 	if !states[0].Preempt {
 		t.Error("RG 0 preempt should be updated to true")
@@ -274,8 +274,8 @@ func TestManualFailover(t *testing.T) {
 	}
 
 	states := m.GroupStates()
-	if states[0].State != StateSecondary {
-		t.Errorf("state = %s, want secondary after failover", states[0].State)
+	if states[0].State != StateSecondaryHold {
+		t.Errorf("state = %s, want secondary-hold after failover", states[0].State)
 	}
 	if !states[0].ManualFailover {
 		t.Error("ManualFailover should be true")
@@ -283,16 +283,17 @@ func TestManualFailover(t *testing.T) {
 	if states[0].FailoverCount != 1 {
 		t.Errorf("failover count = %d, want 1", states[0].FailoverCount)
 	}
-	// Weight must be 0 so peer election sees "Peer weight 0" and elects itself primary.
-	if states[0].Weight != 0 {
-		t.Errorf("weight = %d, want 0 after manual failover", states[0].Weight)
+	// Weight stays monitor-derived; the peer now sees an explicit
+	// transfer-out state instead of relying on weight=0.
+	if states[0].Weight != 255 {
+		t.Errorf("weight = %d, want 255 after manual failover", states[0].Weight)
 	}
 
 	// Failover event should be emitted.
 	select {
 	case ev := <-m.Events():
-		if ev.OldState != StatePrimary || ev.NewState != StateSecondary {
-			t.Errorf("event = %v->%v, want primary->secondary", ev.OldState, ev.NewState)
+		if ev.OldState != StatePrimary || ev.NewState != StateSecondaryHold {
+			t.Errorf("event = %v->%v, want primary->secondary-hold", ev.OldState, ev.NewState)
 		}
 	default:
 		t.Error("expected failover event")
@@ -372,8 +373,8 @@ func TestManualFailover_RetryablePreHookRetriesThenSucceeds(t *testing.T) {
 		t.Fatalf("attempts = %d, want 3", attempts)
 	}
 	states := m.GroupStates()
-	if states[0].State != StateSecondary {
-		t.Fatalf("state = %s, want secondary after manual failover", states[0].State)
+	if states[0].State != StateSecondaryHold {
+		t.Fatalf("state = %s, want secondary-hold after manual failover", states[0].State)
 	}
 	if !states[0].ManualFailover {
 		t.Fatal("manual failover should be set after successful retry")

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -20,7 +20,7 @@ func EffectivePriority(basePriority, weight int) int {
 type electionResult int
 
 const (
-	electLocalPrimary  electionResult = iota // local node should be primary
+	electLocalPrimary   electionResult = iota // local node should be primary
 	electLocalSecondary                       // local node should be secondary
 	electNoChange                             // no state change needed
 )
@@ -38,29 +38,33 @@ func (m *Manager) electRG(rg *RedundancyGroupState, peerGroup *PeerGroupState) (
 		return electNoChange, ""
 	}
 
-	// ManualFailover normally blocks election (stays secondary until reset).
-	// Exception: if the peer has also resigned (weight 0), both nodes are
-	// secondary and neither can serve traffic. Clear ManualFailover and
-	// restore weight to allow election, avoiding a dual-secondary deadlock
-	// during rapid failover cycles where one node resigns before the
-	// previous cycle's ManualFailover flag is cleared.
+	clearedManualFailover := false
+
+	// ManualFailover normally blocks election (stays secondary-hold until
+	// reset). Exception: if the peer has also explicitly transferred out or
+	// already resigned with weight 0, both nodes can end up parked as
+	// non-owners. Clear ManualFailover and restore normal election after a
+	// short guard window so one node can reclaim primary.
 	//
 	// Time guard: only clear after 2s to prevent re-promoting a node that
-	// JUST resigned. Without this, the resigned node sees stale peer
-	// weight=0 (from a previous cycle) and immediately re-elects itself
-	// as primary, defeating the resignation.
+	// JUST transferred out. Without this, the resigned node sees stale peer
+	// transfer-out or weight=0 state and immediately re-elects itself as
+	// primary, defeating the handoff.
 	if rg.ManualFailover {
-		if peerGroup == nil || peerGroup.Weight > 0 {
+		peerResigned := peerGroup != nil && peerGroup.Weight <= 0
+		peerTransferOut := peerGroup != nil && peerGroup.State == StateSecondaryHold
+		if !peerResigned && !peerTransferOut {
 			return electNoChange, ""
 		}
 		if time.Since(rg.ManualFailoverAt) < 2*time.Second {
 			return electNoChange, ""
 		}
-		// Peer weight 0 for >2s — both nodes resigned. Clear
-		// ManualFailover and restore weight so election can promote
-		// one of them.
-		slog.Info("cluster: clearing manual failover (peer also resigned)",
-			"rg", rg.GroupID)
+		// The peer has also yielded for >2s. Clear manual failover and
+		// restore weight so normal election can promote one node.
+		slog.Info("cluster: clearing manual failover (peer also yielded)",
+			"rg", rg.GroupID,
+			"peer_state", peerGroup.State.String(),
+			"peer_weight", peerGroup.Weight)
 		rg.ManualFailover = false
 		rg.ManualFailoverAt = time.Time{}
 		// Recalculate weight inline (recalcWeight calls runElection
@@ -74,6 +78,7 @@ func (m *Manager) electRG(rg *RedundancyGroupState, peerGroup *PeerGroupState) (
 		if rg.Weight < 0 {
 			rg.Weight = 0
 		}
+		clearedManualFailover = true
 	}
 
 	localWeight := rg.Weight
@@ -122,6 +127,18 @@ func (m *Manager) electRG(rg *RedundancyGroupState, peerGroup *PeerGroupState) (
 	if peerWeight <= 0 {
 		if rg.State != StatePrimary {
 			return electLocalPrimary, "Peer weight 0"
+		}
+		return electNoChange, ""
+	}
+
+	// An explicit peer transfer-out should hand ownership to us without
+	// mutating the peer's monitor-derived weight. If both sides had been in
+	// manual transfer-out and we just cleared our own guard, fall through to
+	// normal priority/tie-break election instead of unconditionally claiming
+	// primary on both nodes.
+	if peerGroup.State == StateSecondaryHold && !clearedManualFailover {
+		if rg.State != StatePrimary {
+			return electLocalPrimary, "Peer transfer out"
 		}
 		return electNoChange, ""
 	}

--- a/pkg/cluster/election_test.go
+++ b/pkg/cluster/election_test.go
@@ -12,13 +12,13 @@ func TestEffectivePriority(t *testing.T) {
 	tests := []struct {
 		base, weight, want int
 	}{
-		{200, 255, 200},   // full weight
-		{200, 0, 0},       // zero weight
-		{200, 128, 100},   // half weight (200*128/255 = 100)
-		{100, 255, 100},   // full weight, lower priority
-		{255, 255, 255},   // max everything
-		{0, 255, 0},       // zero priority
-		{200, -1, 0},      // negative weight → 0
+		{200, 255, 200}, // full weight
+		{200, 0, 0},     // zero weight
+		{200, 128, 100}, // half weight (200*128/255 = 100)
+		{100, 255, 100}, // full weight, lower priority
+		{255, 255, 255}, // max everything
+		{0, 255, 0},     // zero priority
+		{200, -1, 0},    // negative weight → 0
 	}
 	for _, tt := range tests {
 		got := EffectivePriority(tt.base, tt.weight)
@@ -240,29 +240,54 @@ func TestElection_ManualFailover_Preserved(t *testing.T) {
 	}
 }
 
+func TestElection_PeerSecondaryHold_BecomesPrimary(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.mu.Lock()
+	m.groups[0].State = StateSecondary
+	m.mu.Unlock()
+
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 100, Weight: 255, State: uint8(StateSecondaryHold)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+
+	if !m.IsLocalPrimary(0) {
+		t.Error("should become primary when peer explicitly transfers out")
+	}
+}
+
 func TestElection_DualResign_TimeGuard(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
 	m.UpdateConfig(cfg)
 	<-m.Events()
 
-	// Manual failover — just set, should NOT clear even if peer weight=0.
+	// Manual failover — just set, should NOT clear even if peer is also in
+	// transfer-out state.
 	m.ManualFailover(0)
 	drainEvents(m, 1)
 
-	// Peer also resigned (weight 0).
+	// Peer also transferred out.
 	pkt := &HeartbeatPacket{
 		NodeID:    1,
 		ClusterID: 1,
 		Groups: []HeartbeatGroup{
-			{GroupID: 0, Priority: 100, Weight: 0, State: uint8(StateSecondary)},
+			{GroupID: 0, Priority: 100, Weight: 255, State: uint8(StateSecondaryHold)},
 		},
 	}
 	m.handlePeerHeartbeat(pkt)
 
 	// Within 2s time guard — should stay secondary.
 	if m.IsLocalPrimary(0) {
-		t.Error("should stay secondary within time guard (just resigned)")
+		t.Error("should stay secondary within time guard (just transferred out)")
 	}
 
 	// Backdate the ManualFailoverAt to simulate >2s elapsed.
@@ -273,9 +298,10 @@ func TestElection_DualResign_TimeGuard(t *testing.T) {
 	// Now re-trigger election via heartbeat.
 	m.handlePeerHeartbeat(pkt)
 
-	// After time guard, dual-resign should clear ManualFailover → primary.
+	// After time guard, dual transfer-out should clear ManualFailover and
+	// fall back to normal election.
 	if !m.IsLocalPrimary(0) {
-		t.Error("should become primary after time guard expires (dual-resign deadlock recovery)")
+		t.Error("should become primary after time guard expires (dual transfer-out recovery)")
 	}
 }
 
@@ -678,8 +704,8 @@ func TestRGInterfaceReady(t *testing.T) {
 		{
 			ID: 0,
 			InterfaceMonitors: []*config.InterfaceMonitor{
-				{Interface: "ge-0/0/0", Weight: 255},  // local (slot 0 → node 0)
-				{Interface: "ge-7/0/0", Weight: 128},  // peer  (slot 7 → node 1)
+				{Interface: "ge-0/0/0", Weight: 255}, // local (slot 0 → node 0)
+				{Interface: "ge-7/0/0", Weight: 128}, // peer  (slot 7 → node 1)
 			},
 		},
 	}
@@ -759,7 +785,7 @@ func TestElection_NonPreemptDualActive_LowerPriorityYields(t *testing.T) {
 func TestElection_NonPreemptDualActive_TieBreakNodeID(t *testing.T) {
 	// Both primary, same priority, non-preempt.
 	// Higher node ID must yield.
-	m := NewManager(1, 1) // We are node 1 (higher)
+	m := NewManager(1, 1)                                    // We are node 1 (higher)
 	cfg := makeConfig(makeRG(0, false, map[int]int{1: 200})) // non-preempt
 	m.UpdateConfig(cfg)
 	<-m.Events()
@@ -817,7 +843,7 @@ func TestElection_NonPreemptDualActive_WinnerStays(t *testing.T) {
 func TestElection_NonPreemptDualActive_PreemptSelfResolves(t *testing.T) {
 	// Regression guard: preempt mode already handles dual-active via
 	// priority comparison — ensure it still works.
-	m := NewManager(1, 1) // We are node 1 (higher)
+	m := NewManager(1, 1)                                   // We are node 1 (higher)
 	cfg := makeConfig(makeRG(0, true, map[int]int{1: 100})) // preempt enabled
 	m.UpdateConfig(cfg)
 	<-m.Events()

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -147,9 +147,10 @@ type SessionSync struct {
 	// On failover, the new primary calls swanctl --initiate for each connection name.
 	OnIPsecSAReceived func(connectionNames []string)
 
-	// OnRemoteFailover is called when the peer requests us to failover an RG.
-	// The callback receives the redundancy group ID. The receiver should call
-	// ManualFailover(rgID) to give up primary for that RG.
+	// OnRemoteFailover is called when the peer requests us to transfer an RG
+	// out of primary. The callback receives the redundancy group ID. The
+	// receiver should call ManualFailover(rgID) to advertise secondary-hold
+	// for that RG and let the peer claim ownership.
 	OnRemoteFailover func(rgID int)
 
 	// OnFenceReceived is called when the peer sends a fence message, requesting
@@ -1604,7 +1605,6 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		s.completeBarrierWait(seq)
 	}
 }
-
 
 func (s *SessionSync) WaitForIdle(timeout time.Duration, stableSamples int, sampleInterval time.Duration) error {
 	if stableSamples <= 0 {


### PR DESCRIPTION
## Summary
- stop expressing ordinary manual failover as `Weight=0`
- advertise `secondary-hold` as an explicit RG transfer-out state
- promote on peer transfer-out in election while keeping `ForceSecondary()` on zero-weight drain semantics

## Details
- `ManualFailover()` now preserves monitor-derived weight and moves the RG into `StateSecondaryHold`
- election now treats peer `StateSecondaryHold` as an explicit ownership handoff
- the dual-resign guard now keys off peer transfer-out or peer weight-zero instead of only peer weight-zero
- added cluster tests for peer transfer-out and updated manual failover expectations
- updated `_Log.md`

## Testing
- `go test ./pkg/cluster/...`
- `go test ./pkg/daemon/... ./pkg/cli/...`