### PR TITLE
docs: validate manual failover transfer commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -76,6 +76,10 @@
 
 ## 2026-04-02
 
+- **Timestamp**: 2026-04-02T16:45:00Z
+  - **Action**: Validate `#397` on `loss-userspace-cluster` — settled RG0 manual failover now completes on explicit failover ack + commit ack instead of heartbeat observation; filed residual issue `#398` for failover admission while requester is still in bulk receive
+  - **File(s)**: testing-docs/manual-failover-transfer-commit-validation.md, testing-docs/README.md
+
 - **Timestamp**: 2026-04-02T13:15:00Z
   - **Action**: Second #390 slice — add explicit sync-channel failover ack handshake so manual RG transfer returns applied/rejected instead of inferring success from send-only behavior
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_test.go, pkg/cluster/cluster.go, pkg/daemon/daemon_ha.go, pkg/cli/cli.go

--- a/testing-docs/README.md
+++ b/testing-docs/README.md
@@ -11,6 +11,7 @@ dataplane and the userspace AF_XDP dataplane.
 | [standalone-vm.md](standalone-vm.md) | Single-VM forwarding, NAT, policy | `make test-deploy` |
 | [ha-cluster.md](ha-cluster.md) | HA failover, crash recovery, session sync | `make test-failover` |
 | [failover-testing.md](failover-testing.md) | End-to-end failover-only runbook across userspace and eBPF HA clusters | Manual + scripts |
+| [manual-failover-transfer-commit-validation.md](manual-failover-transfer-commit-validation.md) | Live validation of sync-channel manual failover completion after `#397` | Manual |
 | [userspace-fabric-failover.md](userspace-fabric-failover.md) | Userspace RG move across fabric, failover hardening, artifact interpretation | `scripts/userspace-ha-failover-validation.sh` |
 | [userspace-dataplane.md](userspace-dataplane.md) | AF_XDP forwarding, cold start, neighbor resolution | Manual + scripts |
 | [native-gre.md](native-gre.md) | Native GRE transit, failover, host-origin validation | `scripts/userspace-native-gre-validation.sh` |

--- a/testing-docs/manual-failover-transfer-commit-validation.md
+++ b/testing-docs/manual-failover-transfer-commit-validation.md
@@ -1,0 +1,163 @@
+# Manual Failover Transfer-Commit Validation
+
+Date: 2026-04-02
+
+Validated commit:
+
+- `310a2399` `cluster: preserve transfer-out override until commit`
+
+Related PRs:
+
+- `#396` manual failover request/ack handshake
+- `#397` manual failover transfer commit
+
+Related issue:
+
+- `#398` manual failover still times out while requester is in bulk sync receive
+
+## Goal
+
+Validate that manual redundancy-group moves no longer depend on heartbeat
+observation for completion after `#397`.
+
+## Environment
+
+- env: `test/incus/loss-userspace-cluster.env`
+- cluster: `bpfrx-userspace-fw0` / `bpfrx-userspace-fw1`
+- branch under test: `origin/master`
+- requester / target commands run with local `cli`
+
+## What Was Tested
+
+### 1. Initial live attempt while requester was still in bulk receive
+
+Command:
+
+```bash
+incus exec loss:bpfrx-userspace-fw0 -- \
+  cli -c 'request chassis cluster failover redundancy-group 0 node 0'
+```
+
+Result:
+
+- failed
+- requester returned:
+  - `rpc error: code = FailedPrecondition desc = timed out waiting for peer failover ack for redundancy group 0`
+
+Why it failed:
+
+- the requester (`fw0`) was still in reconnect bulk receive
+- the peer (`fw1`) kept retrying pre-failover admission
+- each retry failed on the session-sync barrier because the requester did not
+  answer barrier acks during that bulk window
+
+Representative logs:
+
+- requester `fw0`:
+  - `cluster sync: bulk receive progress epoch=4 sessions=64`
+  - `cluster sync: bulk receive progress epoch=4 sessions=128`
+  - `cluster sync: bulk receive progress epoch=4 sessions=192`
+- responder `fw1`:
+  - `cluster: bulk sync not acked yet, verifying peer readiness via barrier`
+  - `cluster: waiting to admit manual failover ... err="session sync not ready before demotion: peer not responding to barrier: timed out waiting for session sync barrier ack ..."`
+
+This is a separate residual problem and is tracked in `#398`.
+
+Artifacts:
+
+- `/tmp/rg0-transfer-commit-validation-20260402-093415`
+- `/tmp/rg0-transfer-commit-validation-rerun-20260402-093552`
+
+### 2. Settled-cluster RG0 move from `node1 -> node0`
+
+Precondition:
+
+- `fw0` takeover-ready `yes`
+- `fw1` primary for `RG0`
+- bulk receive complete on `fw0`
+
+Command:
+
+```bash
+incus exec loss:bpfrx-userspace-fw0 -- \
+  cli -c 'request chassis cluster failover redundancy-group 0 node 0'
+```
+
+Result:
+
+- success
+- command output:
+  - `Manual failover completed for redundancy group 0 (transfer committed)`
+- post-state:
+  - `fw0` primary for `RG0`
+  - `fw1` secondary for `RG0`
+
+Runtime proof that this did not wait for heartbeat observation:
+
+- on `fw0` the logs show, in the same second:
+  - `cluster sync: failover ack received ... status=0`
+  - `cluster: primary transition rg=0`
+  - `cluster sync: failover commit sent to peer`
+  - `cluster sync: failover commit ack received ... status=0`
+- on `fw1` the logs show:
+  - `cluster sync: remote failover request received rg=0 req_id=3`
+  - `cluster: manual failover rg=0`
+  - `cluster sync: failover result sent ... status=0`
+  - `cluster sync: remote failover commit received rg=0 req_id=3`
+  - `cluster sync: failover result sent ... msg_type=18 ... status=0`
+
+That is the new request/ack/commit/commit-ack protocol doing the completion,
+not delayed heartbeat re-evaluation.
+
+Artifact:
+
+- `/tmp/rg0-transfer-commit-validation-settled-rerun-20260402-093809`
+
+### 3. Reverse settled-cluster RG0 move from `node0 -> node1`
+
+Command:
+
+```bash
+incus exec loss:bpfrx-userspace-fw1 -- \
+  cli -c 'request chassis cluster failover redundancy-group 0 node 1'
+```
+
+Result:
+
+- success
+- command output:
+  - `Manual failover completed for redundancy group 0 (transfer committed)`
+- post-state:
+  - `fw1` primary for `RG0`
+  - `fw0` secondary for `RG0`
+
+This confirmed the new transfer-commit path works in both directions and left
+the cluster back on the original `RG0` owner.
+
+Artifact:
+
+- `/tmp/rg0-transfer-commit-validation-reverse-20260402-093830`
+
+## Conclusion
+
+`#397` does what it was supposed to do on a settled cluster:
+
+1. manual RG moves no longer complete by waiting for heartbeat observation
+2. completion happens on explicit sync-channel failover ack and failover
+   commit ack
+3. both directions succeed immediately for `RG0`
+
+What is still not fixed:
+
+1. manual failover can still be rejected before the new transfer protocol runs
+2. the blocker is the pre-failover admission path while the requester is in
+   active reconnect bulk receive
+3. that residual gap is tracked in `#398`
+
+## Practical reading of the result
+
+The new transfer-commit design is valid.
+
+The remaining failure mode is no longer "manual failover depends on heartbeat
+timing". The remaining failure mode is "manual failover admission still depends
+on session-sync bootstrap state".


### PR DESCRIPTION
## Summary
- document live validation of the manual failover transfer-commit path from `#397`
- record that settled RG0 moves now complete on explicit failover ack + commit ack, not heartbeat observation
- capture the residual bulk-sync admission failure and link `#398`

## Validation
- deployed `origin/master` (`310a2399`) to `loss-userspace-cluster`
- verified settled `RG0` manual failover `node1 -> node0`
- verified settled `RG0` manual failover `node0 -> node1`
- captured the initial failed attempt while requester was still in bulk receive

## Runtime result
- settled cluster: pass
- both directions returned `Manual failover completed for redundancy group 0 (transfer committed)`
- logs showed `failover ack -> primary transition -> failover commit sent -> failover commit ack received` in the same second
- residual issue: manual failover still times out if requested while the requester is in active bulk receive (`#398`)
