### PR TITLE
cluster: fast-fail manual failover on unsettled sync state

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -76,6 +76,10 @@
 
 ## 2026-04-02
 
+- **Timestamp**: 2026-04-02T17:20:00Z
+  - **Action**: Start `#398` fix — add explicit session-sync transfer-readiness snapshot and fast-fail manual failover demotion when bulk receive or pending bulk ack proves the sync path is not settled; filed `#400` for exposing transfer readiness separately from takeover readiness
+  - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
+
 - **Timestamp**: 2026-04-02T16:45:00Z
   - **Action**: Validate `#397` on `loss-userspace-cluster` — settled RG0 manual failover now completes on explicit failover ack + commit ack instead of heartbeat observation; filed residual issue `#398` for failover admission while requester is still in bulk receive
   - **File(s)**: testing-docs/manual-failover-transfer-commit-validation.md, testing-docs/README.md

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -122,6 +122,47 @@ type SyncStatsSnapshot struct {
 	LastFenceAckAt int64 // UnixNano (0 = never)
 }
 
+// TransferReadinessSnapshot captures session-sync state that determines
+// whether manual failover can proceed without depending on bootstrap timing.
+type TransferReadinessSnapshot struct {
+	Connected             bool
+	PendingBulkAckEpoch   uint64
+	PendingBulkAckAge     time.Duration
+	BulkReceiveInProgress bool
+	BulkReceiveEpoch      uint64
+	BulkReceiveSessions   int
+}
+
+// ReadyForManualFailover reports whether the sync path is settled enough to
+// use as a manual-failover transport without waiting for bootstrap work.
+func (s TransferReadinessSnapshot) ReadyForManualFailover() bool {
+	return s.PendingBulkAckEpoch == 0 && !s.BulkReceiveInProgress
+}
+
+// Reason explains the current transfer-readiness blocker, if any.
+func (s TransferReadinessSnapshot) Reason() string {
+	switch {
+	case s.PendingBulkAckEpoch != 0:
+		age := s.PendingBulkAckAge
+		if age < 0 {
+			age = 0
+		}
+		return fmt.Sprintf(
+			"peer still receiving outbound bulk epoch=%d age=%s",
+			s.PendingBulkAckEpoch,
+			age.Round(100*time.Millisecond),
+		)
+	case s.BulkReceiveInProgress:
+		return fmt.Sprintf(
+			"local bulk receive still in progress epoch=%d sessions=%d",
+			s.BulkReceiveEpoch,
+			s.BulkReceiveSessions,
+		)
+	default:
+		return ""
+	}
+}
+
 // SessionSync manages TCP-based session state replication between cluster peers.
 type SessionSync struct {
 	localAddr  string // local listen address (e.g. ":4785")

--- a/pkg/cluster/sync_bulk.go
+++ b/pkg/cluster/sync_bulk.go
@@ -152,6 +152,24 @@ func (s *SessionSync) PendingBulkAck() (epoch uint64, age time.Duration, ok bool
 	return epoch, age, true
 }
 
+// TransferReadiness snapshots the sync state that makes manual failover
+// timing-sensitive: an unacked outbound bulk or an in-progress inbound bulk.
+func (s *SessionSync) TransferReadiness() TransferReadinessSnapshot {
+	snap := TransferReadinessSnapshot{
+		Connected: s.stats.Connected.Load(),
+	}
+	if epoch, age, ok := s.PendingBulkAck(); ok {
+		snap.PendingBulkAckEpoch = epoch
+		snap.PendingBulkAckAge = age
+	}
+	s.bulkMu.Lock()
+	snap.BulkReceiveInProgress = s.bulkInProgress
+	snap.BulkReceiveEpoch = s.bulkRecvEpoch
+	snap.BulkReceiveSessions = len(s.bulkRecvV4) + len(s.bulkRecvV6)
+	s.bulkMu.Unlock()
+	return snap
+}
+
 func (s *SessionSync) sendBarrierAck(conn net.Conn, seq uint64) {
 	// Queue the barrier ack through sendCh so it goes through the
 	// sendLoop in order with session messages. Direct writeMu access

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -1940,6 +1940,49 @@ func TestPendingBulkAckClearedOnDisconnect(t *testing.T) {
 	}
 }
 
+func TestTransferReadinessReportsPendingBulkAckAndBulkReceive(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.stats.Connected.Store(true)
+	ss.pendingBulkAckEpoch.Store(9)
+	ss.pendingBulkAckSince.Store(time.Now().Add(-1500 * time.Millisecond).UnixNano())
+	ss.bulkMu.Lock()
+	ss.bulkInProgress = true
+	ss.bulkRecvEpoch = 4
+	ss.bulkRecvV4 = map[dataplane.SessionKey]struct{}{
+		{}: {},
+	}
+	ss.bulkRecvV6 = map[dataplane.SessionKeyV6]struct{}{
+		{}: {},
+	}
+	ss.bulkMu.Unlock()
+
+	state := ss.TransferReadiness()
+	if !state.Connected {
+		t.Fatal("expected connected transfer state")
+	}
+	if state.PendingBulkAckEpoch != 9 {
+		t.Fatalf("pending bulk ack epoch = %d, want 9", state.PendingBulkAckEpoch)
+	}
+	if state.PendingBulkAckAge <= 0 {
+		t.Fatalf("pending bulk ack age = %v, want > 0", state.PendingBulkAckAge)
+	}
+	if !state.BulkReceiveInProgress {
+		t.Fatal("expected bulk receive in progress")
+	}
+	if state.BulkReceiveEpoch != 4 {
+		t.Fatalf("bulk receive epoch = %d, want 4", state.BulkReceiveEpoch)
+	}
+	if state.BulkReceiveSessions != 2 {
+		t.Fatalf("bulk receive sessions = %d, want 2", state.BulkReceiveSessions)
+	}
+	if state.ReadyForManualFailover() {
+		t.Fatal("expected transfer state to block manual failover")
+	}
+	if got := state.Reason(); !strings.Contains(got, "peer still receiving outbound bulk epoch=9") {
+		t.Fatalf("unexpected reason: %q", got)
+	}
+}
+
 func TestHandleNewConnectionStartsBulkSyncWhenConnectionBecomesActive(t *testing.T) {
 	dp := &mockSweepDP{
 		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1068,6 +1068,16 @@ func wrapUserspaceManualFailoverPrepareError(err error) error {
 	return err
 }
 
+func userspaceManualFailoverTransferReadinessError(state cluster.TransferReadinessSnapshot) error {
+	if state.ReadyForManualFailover() {
+		return nil
+	}
+	if reason := state.Reason(); reason != "" {
+		return fmt.Errorf("session sync transfer not ready before demotion: %s", reason)
+	}
+	return nil
+}
+
 func (d *Daemon) prepareUserspaceManualFailover(rgID int) error {
 	return wrapUserspaceManualFailoverPrepareError(
 		d.prepareUserspaceRGDemotionWithTimeout(rgID, 15*time.Second),
@@ -1091,6 +1101,9 @@ func (d *Daemon) prepareUserspaceRGDemotionWithTimeout(rgID int, barrierTimeout 
 		d.releaseUserspaceRGDemotionPrep(rgID)
 		success = true
 		return nil
+	}
+	if err := userspaceManualFailoverTransferReadinessError(d.sessionSync.TransferReadiness()); err != nil {
+		return err
 	}
 
 	// Verify the peer is caught up by sending a barrier. Incremental sync

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -124,6 +124,45 @@ func TestWrapUserspaceManualFailoverPrepareErrorMarksRetryableBulkSyncNotReady(t
 	}
 }
 
+func TestWrapUserspaceManualFailoverPrepareErrorLeavesTransferNotReadyFatal(t *testing.T) {
+	src := errors.New("session sync transfer not ready before demotion: peer still receiving outbound bulk epoch=4 age=3s")
+	err := wrapUserspaceManualFailoverPrepareError(
+		src,
+	)
+	if err != src {
+		t.Fatalf("expected original fatal error to be preserved, got %v", err)
+	}
+}
+
+func TestUserspaceManualFailoverTransferReadinessErrorPendingBulkAck(t *testing.T) {
+	err := userspaceManualFailoverTransferReadinessError(cluster.TransferReadinessSnapshot{
+		Connected:           true,
+		PendingBulkAckEpoch: 4,
+		PendingBulkAckAge:   3 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected transfer readiness error")
+	}
+	if got := err.Error(); got != "session sync transfer not ready before demotion: peer still receiving outbound bulk epoch=4 age=3s" {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestUserspaceManualFailoverTransferReadinessErrorBulkReceive(t *testing.T) {
+	err := userspaceManualFailoverTransferReadinessError(cluster.TransferReadinessSnapshot{
+		Connected:             true,
+		BulkReceiveInProgress: true,
+		BulkReceiveEpoch:      7,
+		BulkReceiveSessions:   128,
+	})
+	if err == nil {
+		t.Fatal("expected transfer readiness error")
+	}
+	if got := err.Error(); got != "session sync transfer not ready before demotion: local bulk receive still in progress epoch=7 sessions=128" {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
 func TestUserspaceSessionFromDeltaV4CarriesTunnelEndpointMetadata(t *testing.T) {
 	zoneIDs := map[string]uint16{"lan": 1, "sfmix": 2}
 	delta := dpuserspace.SessionDeltaInfo{
@@ -530,23 +569,23 @@ func TestDrainUserspaceSessionDeltasWithConfigDrainsPreparedBatches(t *testing.T
 func TestExportUserspaceOwnerRGSessionsWithConfigQueuesForwardWireAlias(t *testing.T) {
 	exporter := &fakeUserspaceSessionExporter{
 		deltas: []dpuserspace.SessionDeltaInfo{{
-			Event:         "open",
-			AddrFamily:    dataplane.AFInet,
-			Protocol:      6,
-			SrcIP:         "10.0.61.102",
-			DstIP:         "172.16.80.200",
-			SrcPort:       39906,
-			DstPort:       5201,
-			IngressZone:   "lan",
-			EgressZone:    "wan",
-			OwnerRGID:     1,
-			EgressIfindex: 12,
-			TXIfindex:     11,
-			TXVLANID:      80,
-			NeighborMAC:   "aa:bb:cc:dd:ee:ff",
-			SrcMAC:        "02:bf:72:00:50:08",
-			NATSrcIP:      "172.16.80.8",
-			NATSrcPort:    39906,
+			Event:          "open",
+			AddrFamily:     dataplane.AFInet,
+			Protocol:       6,
+			SrcIP:          "10.0.61.102",
+			DstIP:          "172.16.80.200",
+			SrcPort:        39906,
+			DstPort:        5201,
+			IngressZone:    "lan",
+			EgressZone:     "wan",
+			OwnerRGID:      1,
+			EgressIfindex:  12,
+			TXIfindex:      11,
+			TXVLANID:       80,
+			NeighborMAC:    "aa:bb:cc:dd:ee:ff",
+			SrcMAC:         "02:bf:72:00:50:08",
+			NATSrcIP:       "172.16.80.8",
+			NATSrcPort:     39906,
 			FabricRedirect: true,
 		}},
 	}


### PR DESCRIPTION
## Summary
- add an explicit session-sync transfer-readiness snapshot for manual failover
- reject manual failover demotion immediately when bulk sync is visibly unsettled instead of discovering that via barrier retries
- add tests for transfer-readiness state and error handling

## Why
This takes a direct slice at `#398`.

The current manual-failover path was still timing-sensitive because it used session-sync barriers to discover states that were already obvious:
- peer still receiving our outbound bulk
- local bulk receive still in progress

That produced long retry loops and eventual requester-side timeout even though the real answer should have been an immediate "not transfer-ready yet" rejection.

## Changes
- `pkg/cluster/sync.go`
  - add `TransferReadinessSnapshot`
- `pkg/cluster/sync_bulk.go`
  - add `SessionSync.TransferReadiness()`
- `pkg/daemon/daemon_ha.go`
  - fail fast on explicit transfer-readiness blockers before barrier probing
  - keep barrier retries for the older barrier/quiescence cases only
- tests in:
  - `pkg/cluster/sync_test.go`
  - `pkg/daemon/userspace_sync_test.go`
- update `_Log.md`

## Validation
- `go test ./pkg/cluster/... ./pkg/daemon/...`

## Notes
- I also filed `#400` for the adjacent operator gap: takeover readiness and transfer readiness are still surfaced separately/inconsistently.
- I exercised the live cluster enough to confirm the new explicit transfer-readiness reason surfaces during the bulk-receive scenario, but the cluster was not stable enough in this pass to claim a clean final end-to-end runtime proof after the fatal/retryable adjustment.
