### PR TITLE
cluster: surface manual failover transfer readiness

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -76,6 +76,10 @@
 
 ## 2026-04-02
 
+- **Timestamp**: 2026-04-02T18:05:00Z
+  - **Action**: Start `#400` — separate transfer readiness from takeover readiness in cluster status and explicit peer-failover admission, with daemon wiring for session-sync transfer-readiness reasons
+  - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
+
 - **Timestamp**: 2026-04-02T17:20:00Z
   - **Action**: Start `#398` fix — add explicit session-sync transfer-readiness snapshot and fast-fail manual failover demotion when bulk receive or pending bulk ack proves the sync path is not settled; filed `#400` for exposing transfer readiness separately from takeover readiness
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -63,6 +63,12 @@ type RedundancyGroupState struct {
 	ReadySince       time.Time   // when Ready transitioned to true (zero if not ready)
 	ReadinessReasons []string    // reasons why not ready (empty when ready)
 	holdTimer        *time.Timer // fires at ReadySince+holdTime to re-trigger election
+
+	// Transfer readiness is the stricter explicit-manual-failover readiness.
+	// It intentionally stays separate from takeover readiness so operators can
+	// distinguish election readiness from transfer protocol readiness.
+	TransferReady            bool
+	TransferReadinessReasons []string
 }
 
 // IsReadyForTakeover returns true if the RG has been ready for at least
@@ -159,6 +165,9 @@ type Manager struct {
 	// The daemon uses this to pre-stage userspace continuity before
 	// weight/state changes let the peer take over.
 	preManualFailoverFn func(rgID int) error
+	// transferReadinessFn reports whether explicit manual failover can be
+	// attempted for the local RG right now and, if not, why.
+	transferReadinessFn func(rgID int) (bool, []string)
 	// Retry policy for transient pre-failover prepare failures.
 	preManualFailoverRetryTimeout  time.Duration
 	preManualFailoverRetryInterval time.Duration
@@ -560,8 +569,6 @@ func (m *Manager) recalcWeight(rg *RedundancyGroupState) {
 // GroupStates returns a snapshot of all redundancy group states.
 func (m *Manager) GroupStates() []RedundancyGroupState {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	states := make([]RedundancyGroupState, 0, len(m.groups))
 	for _, rg := range m.groups {
 		cp := *rg
@@ -575,6 +582,23 @@ func (m *Manager) GroupStates() []RedundancyGroupState {
 		}
 		states = append(states, cp)
 	}
+	fn := m.transferReadinessFn
+	m.mu.RUnlock()
+
+	if fn != nil {
+		for i := range states {
+			ready, reasons := fn(states[i].GroupID)
+			states[i].TransferReady = ready
+			if len(reasons) > 0 {
+				states[i].TransferReadinessReasons = append([]string(nil), reasons...)
+			}
+		}
+	} else {
+		for i := range states {
+			states[i].TransferReady = true
+		}
+	}
+
 	sort.Slice(states, func(i, j int) bool {
 		return states[i].GroupID < states[j].GroupID
 	})
@@ -584,9 +608,9 @@ func (m *Manager) GroupStates() []RedundancyGroupState {
 // GroupState returns the state for a specific redundancy group, or nil if not found.
 func (m *Manager) GroupState(rgID int) *RedundancyGroupState {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	rg, ok := m.groups[rgID]
 	if !ok {
+		m.mu.RUnlock()
 		return nil
 	}
 	cp := *rg
@@ -597,6 +621,16 @@ func (m *Manager) GroupState(rgID int) *RedundancyGroupState {
 	if len(rg.ReadinessReasons) > 0 {
 		cp.ReadinessReasons = make([]string, len(rg.ReadinessReasons))
 		copy(cp.ReadinessReasons, rg.ReadinessReasons)
+	}
+	fn := m.transferReadinessFn
+	m.mu.RUnlock()
+	if fn != nil {
+		cp.TransferReady, cp.TransferReadinessReasons = fn(rgID)
+		if len(cp.TransferReadinessReasons) > 0 {
+			cp.TransferReadinessReasons = append([]string(nil), cp.TransferReadinessReasons...)
+		}
+	} else {
+		cp.TransferReady = true
 	}
 	return &cp
 }
@@ -695,6 +729,14 @@ func (m *Manager) SetPreManualFailoverHook(fn func(rgID int) error) {
 	m.preManualFailoverFn = fn
 }
 
+// SetTransferReadinessFunc sets the callback used to report whether a local
+// redundancy group is ready for explicit transfer-based manual failover.
+func (m *Manager) SetTransferReadinessFunc(fn func(rgID int) (bool, []string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.transferReadinessFn = fn
+}
+
 // SetPeerFailoverFunc sets the callback used to send remote failover requests
 // to the peer via the fabric sync connection.
 func (m *Manager) SetPeerFailoverFunc(fn func(rgID int) (uint64, error)) {
@@ -771,6 +813,7 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	}
 	fn := m.peerFailoverFn
 	commitFn := m.peerFailoverCommitFn
+	transferReadyFn := m.transferReadinessFn
 
 	// Clear local ManualFailover and restore weight so election can
 	// promote us once the peer transfers out.
@@ -785,6 +828,16 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	}
 	if commitFn == nil {
 		return fmt.Errorf("peer failover commit not available (sync not connected)")
+	}
+	if transferReadyFn != nil {
+		ready, reasons := transferReadyFn(rgID)
+		if !ready {
+			return fmt.Errorf(
+				"local redundancy group %d not transfer-ready for explicit failover reasons=%v",
+				rgID,
+				append([]string(nil), reasons...),
+			)
+		}
 	}
 	reqID, err := fn(rgID)
 	if err != nil {
@@ -1459,11 +1512,19 @@ func (m *Manager) FormatStatus() string {
 				readyStr = "no (" + strings.Join(rg.ReadinessReasons, ", ") + ")"
 			}
 		}
+		transferReadyStr := "yes"
+		if !rg.TransferReady {
+			transferReadyStr = "no"
+			if len(rg.TransferReadinessReasons) > 0 {
+				transferReadyStr = "no (" + strings.Join(rg.TransferReadinessReasons, ", ") + ")"
+			}
+		}
 		// Local node line.
 		fmt.Fprintf(&b, "%-6s %-8d %-14s %-8s %-8s %s\n",
 			fmt.Sprintf("node%d", m.nodeID),
 			rg.LocalPriority, rg.State, preempt, manual, monFails)
 		fmt.Fprintf(&b, "  Takeover ready: %s\n", readyStr)
+		fmt.Fprintf(&b, "  Transfer ready: %s\n", transferReadyStr)
 		// Peer node line (if alive).
 		if peerAlive {
 			if pg, ok := peerGroups[rg.GroupID]; ok {
@@ -1561,6 +1622,15 @@ func (m *Manager) FormatInformation() string {
 				reasons = strings.Join(rg.ReadinessReasons, ", ")
 			}
 			fmt.Fprintf(&b, "  Takeover ready: no (%s)\n", reasons)
+		}
+		if rg.TransferReady {
+			fmt.Fprintf(&b, "  Transfer ready: yes\n")
+		} else {
+			reasons := "none"
+			if len(rg.TransferReadinessReasons) > 0 {
+				reasons = strings.Join(rg.TransferReadinessReasons, ", ")
+			}
+			fmt.Fprintf(&b, "  Transfer ready: no (%s)\n", reasons)
 		}
 		if len(rg.MonitorFails) > 0 {
 			fmt.Fprintf(&b, "  Monitor failures: %s\n", strings.Join(rg.MonitorFails, ", "))

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -505,6 +505,50 @@ func TestRequestPeerFailoverRequiresLocalReadiness(t *testing.T) {
 	}
 }
 
+func TestRequestPeerFailoverRequiresLocalTransferReadiness(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	called := false
+	m.SetTransferReadinessFunc(func(rgID int) (bool, []string) {
+		return false, []string{"local bulk receive still in progress epoch=7 sessions=128"}
+	})
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		called = true
+		return 0, nil
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error { return nil })
+
+	err := m.RequestPeerFailover(0)
+	if err == nil {
+		t.Fatal("expected local transfer readiness error")
+	}
+	if !strings.Contains(err.Error(), "not transfer-ready for explicit failover") {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "local bulk receive still in progress epoch=7 sessions=128") {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if called {
+		t.Fatal("peer failover request should not be sent while transfer readiness is false")
+	}
+}
+
 func TestFinalizePeerTransferOutClearsSecondaryHold(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
@@ -567,6 +611,36 @@ func TestPeerTransferOutOverrideSurvivesHeartbeatRefreshUntilCommit(t *testing.T
 	}
 	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
 		t.Fatalf("peer state = %s, want secondary-hold while transfer commit in flight", peer.State)
+	}
+}
+
+func TestFormatStatusShowsSeparateTransferReadiness(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+	m.SetTransferReadinessFunc(func(rgID int) (bool, []string) {
+		return false, []string{"peer still receiving outbound bulk epoch=7 age=25.7s"}
+	})
+
+	out := m.FormatStatus()
+	if !strings.Contains(out, "Takeover ready: yes") {
+		t.Fatalf("status missing takeover readiness: %s", out)
+	}
+	if !strings.Contains(out, "Transfer ready: no (peer still receiving outbound bulk epoch=7 age=25.7s)") {
+		t.Fatalf("status missing transfer readiness: %s", out)
 	}
 }
 

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1078,6 +1078,20 @@ func userspaceManualFailoverTransferReadinessError(state cluster.TransferReadine
 	return nil
 }
 
+func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
+	if d.sessionSync == nil || !d.sessionSync.IsConnected() || !d.syncPeerConnected.Load() {
+		return false, []string{"session sync disconnected"}
+	}
+	state := d.sessionSync.TransferReadiness()
+	if state.ReadyForManualFailover() {
+		return true, nil
+	}
+	if reason := state.Reason(); reason != "" {
+		return false, []string{reason}
+	}
+	return true, nil
+}
+
 func (d *Daemon) prepareUserspaceManualFailover(rgID int) error {
 	return wrapUserspaceManualFailoverPrepareError(
 		d.prepareUserspaceRGDemotionWithTimeout(rgID, 15*time.Second),
@@ -1479,6 +1493,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFailoverFunc(d.sessionSync.SendFailover)
 			d.cluster.SetPeerFailoverCommitFunc(d.sessionSync.SendFailoverCommit)
 			d.cluster.SetPreManualFailoverHook(d.prepareUserspaceManualFailover)
+			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)
 
 			// Wire peer fencing: on heartbeat timeout, cluster sends

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -163,6 +163,17 @@ func TestUserspaceManualFailoverTransferReadinessErrorBulkReceive(t *testing.T) 
 	}
 }
 
+func TestUserspaceTransferReadinessDisconnected(t *testing.T) {
+	d := &Daemon{}
+	ready, reasons := d.userspaceTransferReadiness(0)
+	if ready {
+		t.Fatal("expected disconnected transfer readiness to be false")
+	}
+	if len(reasons) != 1 || reasons[0] != "session sync disconnected" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
 func TestUserspaceSessionFromDeltaV4CarriesTunnelEndpointMetadata(t *testing.T) {
 	zoneIDs := map[string]uint16{"lan": 1, "sfmix": 2}
 	delta := dpuserspace.SessionDeltaInfo{


### PR DESCRIPTION
## Summary
- surface transfer readiness separately from takeover readiness in cluster status
- use the same transfer-readiness signal to fail explicit peer failover earlier on the local node
- wire daemon session-sync transfer readiness into the cluster manager

## Why
This addresses `#400`.

Takeover readiness and transfer readiness are not the same thing:
- takeover readiness answers whether election can promote the RG
- transfer readiness answers whether explicit manual failover can use the current session-sync transport without bootstrap-related failure

The code already had a transfer-readiness concept from `#401`, but operators still only saw `Takeover ready`.

## Changes
- add `TransferReady` and `TransferReadinessReasons` to cluster RG state snapshots
- add a manager transfer-readiness callback
- show `Transfer ready: ...` in cluster status and information output
- make `RequestPeerFailover()` reject locally when transfer readiness is false
- wire daemon session-sync transfer readiness into the cluster manager
- add cluster and daemon tests
- update `_Log.md`

## Validation
- `go test ./pkg/cluster/... ./pkg/daemon/...`

## Stack
- base PR: `#401`
