### PR TITLE
userspace: index worker HA sessions by owner RG

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -151,3 +151,7 @@
 - **Timestamp**: 2026-04-03T01:01:45Z
   - **Action**: Final #389 slice — index worker-local sessions by owner RG and use those indexes for export, demotion, and activation refresh so helper HA apply no longer scans the full live session table
   - **File(s)**: userspace-dp/src/session.rs, userspace-dp/src/afxdp/session_glue.rs, _Log.md
+
+- **Timestamp**: 2026-04-03T03:00:15Z
+  - **Action**: Applied Copilot review fixes for stacked #389 PRs — make reverse-prewarm owner-RG index updates lock once per refresh, restore derived indexes on rejected session updates, and remove unnecessary hot-path clones
+  - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/session.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp.rs, _Log.md

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -2644,7 +2644,7 @@ fn poll_binding(
                                     if sessions.install_with_protocol_with_origin(
                                         flow.forward_key.clone(),
                                         fabric_return_decision,
-                                        fabric_return_metadata.clone(),
+                                        fabric_return_metadata,
                                         SessionOrigin::ReverseFlow,
                                         now_ns,
                                         meta.protocol,

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -389,12 +389,10 @@ pub(super) fn apply_worker_commands(
                 }
             }
             WorkerCommand::UpsertLocal(entry) => {
-                let key = entry.key.clone();
-                let metadata = entry.metadata.clone();
                 sessions.install_with_protocol_with_origin(
-                    key.clone(),
+                    entry.key,
                     entry.decision,
-                    metadata.clone(),
+                    entry.metadata,
                     entry.origin,
                     now_ns,
                     entry.protocol,

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -537,11 +537,11 @@ impl SessionTable {
                 // Peer-synced entry being promoted by local traffic — allow
             } else if entry.origin.is_peer_synced() && origin.is_peer_synced() {
                 // Both peer-synced: reject (refresh_local on synced entry)
-                self.sessions.insert(key.clone(), entry);
+                self.restore_entry(key.clone(), entry);
                 return false;
             } else if !entry.origin.is_peer_synced() && origin.is_peer_synced() {
                 // Local entry: reject peer data trying to overwrite
-                self.sessions.insert(key.clone(), entry);
+                self.restore_entry(key.clone(), entry);
                 return false;
             }
             // Both local: allow (local refresh of local entry)
@@ -554,8 +554,7 @@ impl SessionTable {
         entry.last_seen_ns = now_ns;
         entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
         entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0;
-        self.sessions.insert(key.clone(), entry);
-        self.index_forward_nat_key(key, decision, &metadata);
+        self.restore_entry(key.clone(), entry);
         // Emit open delta when promoting a peer-synced entry to local
         if was_peer_synced && !origin.is_peer_synced() && !metadata.is_reverse {
             self.push_delta(SessionDelta {
@@ -781,6 +780,11 @@ impl SessionTable {
         self.remove_forward_nat_index(key, entry.decision, &entry.metadata);
         remove_owner_rg_index_entry(&mut self.owner_rg_sessions, entry.metadata.owner_rg_id, key);
         Some(entry)
+    }
+
+    fn restore_entry(&mut self, key: SessionKey, entry: SessionEntry) -> Option<SessionEntry> {
+        self.index_forward_nat_key(&key, entry.decision, &entry.metadata);
+        self.sessions.insert(key, entry)
     }
 
     fn index_forward_nat_key(
@@ -2118,6 +2122,7 @@ mod tests {
             2_000_000,
             0x10,
         ));
+        assert_eq!(table.owner_rg_session_keys(&[1]), vec![key.clone()]);
         // session should still have original decision
         let lookup = table.lookup(&key, 3_000_000, 0x10).expect("session");
         assert_ne!(lookup.decision.resolution.egress_ifindex, 99);


### PR DESCRIPTION
## Summary
- add owner-RG indexes to the worker-local `SessionTable`
- use those indexes for owner-RG export, demotion, and activation refresh
- update `_Log.md` with the final `#389` slice

## Why
`#404` removed the shared-map HA scans and `#405` removed the shared forward-map scan for reverse prewarm, but the worker-local HA apply path was still doing O(all live sessions) work. This slice removes the remaining owner-RG full-table scans from helper HA apply.

Shared split-RG reverse-prewarm stays in `#405`. The worker-local apply path only needs the current owner-RG index because live reverse sessions already carry their local owner RG, while missing reverse companions are handled by shared prewarm.

## Validation
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml demote_owner_rg_marks_forward_and_reverse_entries_synced -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml owner_rg_session_keys_track_insert_update_and_delete -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml publish_and_remove_shared_session_tracks_owner_rg_indexes -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_demotes_local_sessions_for_owner_rg -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_demoted_owner_rg_republishes_forward_sessions -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_exports_owner_rg_forward_sessions_without_teardown -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml demote_shared_owner_rgs_preserves_reverse_entries_and_marks_all_synced -- --nocapture`
- `~/.cargo/bin/cargo test --manifest-path userspace-dp/Cargo.toml prewarm_reverse_synced_sessions_recomputes_when_reverse_owner_rg_activates -- --nocapture`

Fixes #389