### PR TITLE
docs: snapshot publish redesign — separate config from FIB state

### DIFF
--- a/docs/snapshot-publish-redesign.md
+++ b/docs/snapshot-publish-redesign.md
@@ -19,7 +19,8 @@ Observed symptoms during OSPF/BGP convergence on an HA cluster:
   are starved by continuous snapshot publishes
 - **Dozens of full snapshot rebuilds per second** during FRR route convergence —
   each `BumpFIBGeneration()` (`manager.go:378`) calls `buildSnapshot()` which
-  reads all kernel routes/neighbors and serializes the entire config
+  derives route snapshots from config/static routes and connected prefixes,
+  reads kernel ARP/NDP neighbors, and serializes the entire config
 
 Root cause: every `Compile()` call triggers `BumpFIBGeneration()` which rebuilds
 and publishes a complete snapshot (config + route snapshots from config + kernel


### PR DESCRIPTION
## Summary
- Design document for fixing control socket contention that causes 42s barrier ack delays
- Root cause: full snapshot rebuild on every route change during FRR convergence starves HA session installs
- Four-phase migration plan:
  1. Content-hash dedup (quick win, no protocol changes)
  2. FIB deltas instead of full rebuilds
  3. Separate session channel for HA installs
  4. Async snapshot publish (if needed)

## Test plan
- [ ] Review design with team
- [ ] Phase 1 implementation validates barrier ack drops to <15s
- [ ] Phase 3 implementation validates barrier ack drops to <5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)