### PR TITLE
fix: warm ARP cache on standby nodes for static route next-hops

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-05
 
+- **Timestamp**: 2026-04-05T12:00:00Z
+  - **Action**: Fix TCP stream death on failback due to cold ARP cache on standby node. Root cause: `resolveNeighborsInner()` used `netlink.RouteGet()` to find the outgoing interface for static route next-hops, but on standby nodes the kernel route doesn't exist (FRR only installs it on the active). Added `addByIPOrConfig()` fallback that resolves the outgoing interface from config by matching the next-hop IP against configured interface subnets when the kernel FIB lookup fails.
+  - **File(s)**: pkg/daemon/daemon.go
+
 - **Timestamp**: 2026-04-05T10:00:00Z
   - **Action**: Issue #475 — Fix 0 throughput on pre-existing TCP streams after failover+failback. Root cause: `prewarm_reverse_synced_sessions_for_owner_rgs` published USERSPACE_SESSIONS BPF map entries for reverse sessions but not forward sessions during RG activation. Forward sessions relied on async worker processing, creating a window where the XDP shim had no REDIRECT entry. Added synchronous BPF map publishing for forward sessions in prewarm, plus a comprehensive `republish_bpf_session_entries_for_owner_rgs` that iterates ALL sessions in the `sessions` owner-RG index (not just the `reverse_prewarm` subset) to ensure no session is missed.
   - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/session_glue.rs

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2629,7 +2629,53 @@ func (d *Daemon) resolveNeighborsInner(cfg *config.Config, waitForReplies bool) 
 		addByLink(ip, link.Attrs().Index)
 	}
 
-	// 1. Static route next-hops (resolve interface via FIB if not specified)
+	// addByIPOrConfig first tries the kernel FIB (addByIP). If the kernel
+	// has no route (e.g. standby node where FRR hasn't installed the route),
+	// fall back to finding the outgoing interface from the config by matching
+	// the next-hop IP against configured interface subnets. This keeps ARP
+	// warm on standby nodes so failback doesn't lose packets to ARP delay.
+	addByIPOrConfig := func(ipStr string) {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return
+		}
+		// Try kernel FIB first — this is the fast/common path on active nodes.
+		routes, err := netlink.RouteGet(ip)
+		if err == nil && len(routes) > 0 {
+			neighborIP := ip
+			if gw := routes[0].Gw; gw != nil && !gw.IsUnspecified() {
+				neighborIP = gw
+			}
+			addByLink(neighborIP, routes[0].LinkIndex)
+			return
+		}
+		// Kernel has no route — find the interface from config by subnet match.
+		for _, ifc := range cfg.Interfaces.Interfaces {
+			for _, unit := range ifc.Units {
+				for _, addrStr := range unit.Addresses {
+					_, ipNet, err := net.ParseCIDR(addrStr)
+					if err != nil {
+						continue
+					}
+					if ipNet.Contains(ip) {
+						linuxName := resolveJunosIfName(cfg, ifc.Name)
+						link, err := netlink.LinkByName(linuxName)
+						if err != nil {
+							continue
+						}
+						slog.Debug("neighbor warmup: resolved next-hop via config subnet",
+							"nexthop", ipStr, "iface", linuxName, "subnet", addrStr)
+						addByLink(ip, link.Attrs().Index)
+						return
+					}
+				}
+			}
+		}
+	}
+
+	// 1. Static route next-hops (resolve interface via FIB if not specified).
+	// Uses addByIPOrConfig so standby nodes without the kernel route still
+	// resolve next-hops via config subnet matching (keeps ARP cache warm).
 	allStaticRoutes := append(cfg.RoutingOptions.StaticRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
 	for _, sr := range allStaticRoutes {
 		if sr.Discard {
@@ -2642,12 +2688,12 @@ func (d *Daemon) resolveNeighborsInner(cfg *config.Config, waitForReplies bool) 
 			if nh.Interface != "" {
 				addByName(nh.Address, nh.Interface)
 			} else {
-				addByIP(nh.Address)
+				addByIPOrConfig(nh.Address)
 			}
 		}
 	}
 	for _, ri := range cfg.RoutingInstances {
-		for _, sr := range ri.StaticRoutes {
+		for _, sr := range append(ri.StaticRoutes, ri.Inet6StaticRoutes...) {
 			if sr.Discard {
 				continue
 			}
@@ -2658,7 +2704,7 @@ func (d *Daemon) resolveNeighborsInner(cfg *config.Config, waitForReplies bool) 
 				if nh.Interface != "" {
 					addByName(nh.Address, nh.Interface)
 				} else {
-					addByIP(nh.Address)
+					addByIPOrConfig(nh.Address)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- TCP streams die on HA failback because the standby node's ARP cache is cold for WAN gateway next-hops
- Root cause: `resolveNeighborsInner()` uses `netlink.RouteGet()` to find outgoing interfaces for static route next-hops, but on standby nodes FRR hasn't installed the route so `RouteGet` fails silently
- Added `addByIPOrConfig()` fallback: tries kernel FIB first (fast path), then matches next-hop IP against configured interface subnets to find the outgoing interface from config
- Covers both global `routing-options` and per-`routing-instance` static routes (IPv4 + IPv6)

## Test plan
- [ ] `make build` passes (verified: `CGO_ENABLED=0 go build -o /dev/null ./cmd/bpfrxd/`)
- [ ] `make cluster-deploy` to both HA nodes
- [ ] Verify standby node's ARP cache has WAN gateway entry (`ip neigh show dev ge-0-0-3` on standby)
- [ ] `make test-failover` — TCP stream survives failover+failback with 0 packet loss
- [ ] Check logs for `"neighbor warmup: resolved next-hop via config subnet"` on standby node

🤖 Generated with [Claude Code](https://claude.com/claude-code)