### PR TITLE
fix: serialize per-RG ManualFailover to prevent barrier crash

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-05
 
+- **Timestamp**: 2026-04-05T15:00:00Z
+  - **Action**: Issue #481 — Serialize per-RG ManualFailover to prevent back-to-back failover/failback from racing. Added `failoverInProgress` map to cluster Manager; ManualFailover rejects a second request for the same RG while one is in progress (including during the preHook barrier wait). The flag is cleared atomically under the same lock as the state change, whether the failover succeeds or fails. Different RGs can still failover concurrently.
+  - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go
+
 - **Timestamp**: 2026-04-05T12:00:00Z
   - **Action**: Fix TCP stream death on failback due to cold ARP cache on standby node. Root cause: `resolveNeighborsInner()` used `netlink.RouteGet()` to find the outgoing interface for static route next-hops, but on standby nodes the kernel route doesn't exist (FRR only installs it on the active). Added `addByIPOrConfig()` fallback that resolves the outgoing interface from config by matching the next-hop IP against configured interface subnets when the kernel FIB lookup fails.
   - **File(s)**: pkg/daemon/daemon.go

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -191,6 +191,13 @@ type Manager struct {
 	// syncTransport records whether session sync uses "fabric" or
 	// "control-link" transport. Displayed in CLI status.
 	syncTransport string
+
+	// failoverInProgress tracks per-RG failover serialization. When a
+	// ManualFailover is in progress for an RG (including the preHook
+	// barrier wait), a second request for the same RG is rejected
+	// immediately. This prevents back-to-back failover/failback from
+	// racing and hitting "session sync disconnected during barrier wait".
+	failoverInProgress map[int]bool
 }
 
 // DefaultTakeoverHoldTime is the default duration an RG must be ready
@@ -216,6 +223,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		takeoverHoldTime:               DefaultTakeoverHoldTime,
 		preManualFailoverRetryTimeout:  DefaultPreManualFailoverRetryTimeout,
 		preManualFailoverRetryInterval: DefaultPreManualFailoverRetryInterval,
+		failoverInProgress:             make(map[int]bool),
 	}
 }
 
@@ -668,21 +676,29 @@ func (m *Manager) ManualFailover(rgID int) error {
 		m.mu.Unlock()
 		return fmt.Errorf("redundancy group %d not found", rgID)
 	}
+	if m.failoverInProgress[rgID] {
+		m.mu.Unlock()
+		return fmt.Errorf("failover already in progress for redundancy group %d, please wait", rgID)
+	}
+	m.failoverInProgress[rgID] = true
 	preHook := m.preManualFailoverFn
 	retryTimeout := m.preManualFailoverRetryTimeout
 	retryInterval := m.preManualFailoverRetryInterval
 	m.mu.Unlock()
 
+	var preHookErr error
 	if preHook != nil {
 		deadline := time.Now().Add(retryTimeout)
 		for attempts := 1; ; attempts++ {
 			if err := preHook(rgID); err != nil {
 				if !IsRetryablePreFailoverError(err) {
-					return fmt.Errorf("pre-failover prepare for redundancy group %d: %w", rgID, err)
+					preHookErr = fmt.Errorf("pre-failover prepare for redundancy group %d: %w", rgID, err)
+					break
 				}
 				remaining := time.Until(deadline)
 				if remaining <= 0 {
-					return fmt.Errorf("pre-failover prepare for redundancy group %d: %w", rgID, err)
+					preHookErr = fmt.Errorf("pre-failover prepare for redundancy group %d: %w", rgID, err)
+					break
 				}
 				sleep := retryInterval
 				if sleep <= 0 {
@@ -705,6 +721,16 @@ func (m *Manager) ManualFailover(rgID int) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Always clear the in-progress flag under the same lock acquisition
+	// that performs the state change, so there is no window where another
+	// caller can slip in between flag-clear and state-commit.
+	defer delete(m.failoverInProgress, rgID)
+
+	if preHookErr != nil {
+		return preHookErr
+	}
+
 	rg, ok = m.groups[rgID]
 	if !ok {
 		return fmt.Errorf("redundancy group %d not found", rgID)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -419,6 +419,115 @@ func TestManualFailover_UnknownRG(t *testing.T) {
 	}
 }
 
+func TestManualFailover_RejectsBackToBack(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	// Pre-hook blocks until released, simulating a long barrier wait.
+	hookStarted := make(chan struct{})
+	hookRelease := make(chan struct{})
+	m.SetPreManualFailoverHook(func(rgID int) error {
+		close(hookStarted)
+		<-hookRelease
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- m.ManualFailover(0)
+	}()
+
+	// Wait for the first failover to enter the pre-hook.
+	<-hookStarted
+
+	// Second failover for the same RG should be rejected immediately.
+	err := m.ManualFailover(0)
+	if err == nil {
+		t.Fatal("expected error for back-to-back failover on same RG")
+	}
+	if !strings.Contains(err.Error(), "failover already in progress") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Release the first failover and verify it completes.
+	close(hookRelease)
+	if err := <-errCh; err != nil {
+		t.Fatalf("first failover should succeed: %v", err)
+	}
+
+	states := m.GroupStates()
+	if states[0].State != StateSecondaryHold {
+		t.Fatalf("state = %s, want secondary-hold", states[0].State)
+	}
+}
+
+func TestManualFailover_DifferentRGsAllowed(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200}),
+		makeRG(1, false, map[int]int{0: 200}),
+	)
+	m.UpdateConfig(cfg)
+	// Drain both RG events.
+	<-m.Events()
+	<-m.Events()
+
+	// Pre-hook blocks for RG 0 but not RG 1.
+	hookStarted := make(chan struct{})
+	hookRelease := make(chan struct{})
+	m.SetPreManualFailoverHook(func(rgID int) error {
+		if rgID == 0 {
+			close(hookStarted)
+			<-hookRelease
+		}
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- m.ManualFailover(0)
+	}()
+
+	<-hookStarted
+
+	// RG 1 failover should succeed even though RG 0 is in progress.
+	if err := m.ManualFailover(1); err != nil {
+		t.Fatalf("failover for different RG should succeed: %v", err)
+	}
+
+	close(hookRelease)
+	if err := <-errCh; err != nil {
+		t.Fatalf("RG 0 failover should succeed: %v", err)
+	}
+}
+
+func TestManualFailover_InProgressClearedOnPreHookError(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.SetPreManualFailoverHook(func(rgID int) error {
+		return fmt.Errorf("fatal hook error")
+	})
+
+	// First attempt fails.
+	if err := m.ManualFailover(0); err == nil {
+		t.Fatal("expected pre-hook error")
+	}
+
+	// Second attempt should NOT be rejected as "in progress" — the flag
+	// must have been cleared by the failed first attempt.
+	m.SetPreManualFailoverHook(func(rgID int) error {
+		return nil
+	})
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("retry after failed failover should succeed: %v", err)
+	}
+}
+
 func TestRequestPeerFailoverCommitsLocalPrimaryWithoutHeartbeatObservation(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))


### PR DESCRIPTION
## Summary
- Adds per-RG `failoverInProgress` gate to `ManualFailover()` in the cluster Manager
- When failover/failback are issued back-to-back with no delay, the second request is rejected immediately with "failover already in progress for redundancy group N, please wait" instead of racing the first request's barrier wait
- Different RGs can still failover concurrently; the flag is cleared atomically under the same lock as the state change

## Root Cause
The failback triggers a new HA state transition on the peer, which tears down and reconnects the sync connection. The barrier from the first failover is still waiting for an ack when the connection drops, causing "session sync disconnected during barrier wait".

## Test plan
- [x] `TestManualFailover_RejectsBackToBack` — concurrent failover for same RG is rejected
- [x] `TestManualFailover_DifferentRGsAllowed` — concurrent failover for different RGs succeeds
- [x] `TestManualFailover_InProgressClearedOnPreHookError` — flag is cleared on preHook failure, retry succeeds
- [x] All existing cluster tests pass (3.6s)
- [x] `go build ./cmd/bpfrxd/` clean
- [ ] `make test-failover` on cluster

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)