### PR TITLE
daemon: remove dead demotion-prep journal branch

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -218,20 +218,8 @@ type Daemon struct {
 	eventStreamConnected atomic.Bool
 
 	// userspaceDeltaSyncMu serializes helper delta draining between the
-	// periodic background sync loop and the RG demotion prepare path.
-	// Demotion prepare must drain and barrier its continuity-critical
-	// republish deltas itself; otherwise the background loop can consume
-	// them first and let demotion proceed without peer ack.
+	// event-stream fallback loop and the background polling loop.
 	userspaceDeltaSyncMu sync.Mutex
-	// userspaceDemotionPrepDepth pauses background incremental session-sync
-	// producers while demotion prep stages continuity-critical republish.
-	userspaceDemotionPrepDepth atomic.Int32
-	// demotionKernelJournal buffers kernel SESSION_OPEN events that arrive
-	// during demotion prep. Instead of dropping them, they are flushed to
-	// the peer before the final barrier.
-	demotionKernelJournalMu sync.Mutex
-	demotionKernelJournalV4 []journaledSessionV4
-	demotionKernelJournalV6 []journaledSessionV6
 	// userspaceDemotionPrepUntil suppresses duplicate demotion prep for the
 	// same RG during a single failover transition. Manual failover can now
 	// stage prep before ownership changes; the later cluster/VRRP edges must
@@ -498,8 +486,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// Deletes are synced if this node is primary for any RG — the peer
 		// ignores deletes for sessions it doesn't have.
 		gc.OnDeleteV4 = func(key dataplane.SessionKey) {
-			// Always sync deletes, even during demotion prep. Dropping
-			// deletes leaves stale sessions on the peer indefinitely.
+			// Always sync deletes. Dropping deletes leaves stale sessions
+			// on the peer indefinitely.
 			if d.cluster != nil && d.cluster.IsLocalPrimaryAny() && d.sessionSync != nil {
 				d.sessionSync.QueueDeleteV4(key)
 			}
@@ -546,8 +534,6 @@ func (d *Daemon) Run(ctx context.Context) error {
 					}
 					proto := raw[53]
 					af := raw[55]
-					demotionActive := d.userspaceDemotionPrepActive()
-
 					if af == dataplane.AFInet6 {
 						var key dataplane.SessionKeyV6
 						copy(key.SrcIP[:], raw[8:24])
@@ -557,11 +543,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.Protocol = proto
 						if val, err := d.dp.GetSessionV6(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
-								if demotionActive {
-									d.journalKernelSessionV6(key, val)
-								} else {
-									d.sessionSync.QueueSessionV6(key, val)
-								}
+								d.sessionSync.QueueSessionV6(key, val)
 							}
 						}
 					} else {
@@ -573,11 +555,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.Protocol = proto
 						if val, err := d.dp.GetSessionV4(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
-								if demotionActive {
-									d.journalKernelSessionV4(key, val)
-								} else {
-									d.sessionSync.QueueSessionV4(key, val)
-								}
+								d.sessionSync.QueueSessionV4(key, val)
 							}
 						}
 					}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -720,10 +720,6 @@ func (d *Daemon) syncUserspaceSessionDeltas(ctx context.Context) {
 		if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
 			continue
 		}
-		if d.userspaceDemotionPrepActive() {
-			continue
-		}
-
 		cfg := d.store.ActiveConfig()
 		if cfg == nil {
 			continue
@@ -792,11 +788,6 @@ func (d *Daemon) handleEventStreamDelta(eventType uint8, delta dpuserspace.Sessi
 		slog.Debug("userspace delta: dropped (sync not connected)", "type", eventType)
 		return
 	}
-	if d.userspaceDemotionPrepActive() {
-		slog.Debug("userspace delta: dropped (demotion prep active)", "type", eventType)
-		return
-	}
-
 	cfg := d.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -896,9 +887,6 @@ func (d *Daemon) eventStreamFallbackLoop(ctx context.Context, provider userspace
 			if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
 				continue
 			}
-			if d.userspaceDemotionPrepActive() {
-				continue
-			}
 			cfg := d.store.ActiveConfig()
 			if cfg == nil {
 				continue
@@ -922,9 +910,6 @@ func (d *Daemon) eventStreamFallbackLoop(ctx context.Context, provider userspace
 		if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
 			continue
 		}
-		if d.userspaceDemotionPrepActive() {
-			continue
-		}
 		cfg := d.store.ActiveConfig()
 		if cfg == nil {
 			continue
@@ -933,32 +918,6 @@ func (d *Daemon) eventStreamFallbackLoop(ctx context.Context, provider userspace
 		_, _ = d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
 		d.userspaceDeltaSyncMu.Unlock()
 	}
-}
-
-type journaledSessionV4 struct {
-	Key dataplane.SessionKey
-	Val dataplane.SessionValue
-}
-type journaledSessionV6 struct {
-	Key dataplane.SessionKeyV6
-	Val dataplane.SessionValueV6
-}
-
-func (d *Daemon) userspaceDemotionPrepActive() bool {
-	return d.userspaceDemotionPrepDepth.Load() > 0
-}
-
-// journalKernelSessionV4 buffers a kernel session event during demotion prep.
-func (d *Daemon) journalKernelSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) {
-	d.demotionKernelJournalMu.Lock()
-	d.demotionKernelJournalV4 = append(d.demotionKernelJournalV4, journaledSessionV4{key, val})
-	d.demotionKernelJournalMu.Unlock()
-}
-
-func (d *Daemon) journalKernelSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) {
-	d.demotionKernelJournalMu.Lock()
-	d.demotionKernelJournalV6 = append(d.demotionKernelJournalV6, journaledSessionV6{key, val})
-	d.demotionKernelJournalMu.Unlock()
 }
 
 func (d *Daemon) queueUserspaceSessionDeltas(

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -653,32 +653,6 @@ func TestHandleEventStreamDeltaSkipsWhenNoCluster(t *testing.T) {
 	d.handleEventStreamDelta(dpuserspace.EventTypeSessionOpen, delta)
 }
 
-// TestHandleEventStreamDeltaSkipsDemotionPrep verifies that events are
-// skipped when demotion prep is active.
-func TestHandleEventStreamDeltaSkipsDemotionPrep(t *testing.T) {
-	d := &Daemon{
-		sessionSync: &cluster.SessionSync{
-			IsPrimaryFn:      func() bool { return true },
-			IsPrimaryForRGFn: func(rgID int) bool { return true },
-		},
-	}
-
-	// Simulate demotion prep active — should return early without panic.
-	d.userspaceDemotionPrepDepth.Store(1)
-
-	delta := dpuserspace.SessionDeltaInfo{
-		AddrFamily: dataplane.AFInet,
-		Protocol:   6,
-		SrcIP:      "10.0.1.102",
-		DstIP:      "172.16.80.200",
-		SrcPort:    12345,
-		DstPort:    443,
-		OwnerRGID:  1,
-	}
-
-	d.handleEventStreamDelta(dpuserspace.EventTypeSessionOpen, delta)
-}
-
 // TestHandleEventStreamDeltaMapsEventTypes verifies event type to string mapping
 // doesn't panic for all supported types.
 func TestHandleEventStreamDeltaMapsEventTypes(t *testing.T) {


### PR DESCRIPTION
Closes #492.

## Summary
- remove the unused userspace demotion-prep producer pause/journal state
- stop dropping event-stream and polling deltas behind a test-only depth bit
- keep the real demotion-prep suppression/barrier path, but delete the dead branch around it

## Testing
- go test ./pkg/daemon ./pkg/cluster
