### PR TITLE
daemon: default to strict VIP ownership in VRRP mode

### DIFF
--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1385,8 +1385,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 
 	// In VRRP mode, make strict VIP ownership the runtime default so
 	// rg_active follows VIP/MAC ownership rather than cluster-primary
-	// intent. Direct/no-reth-vrrp mode still uses cluster state because
-	// there are no VRRP instances to gate on.
+	// intent. Direct/no-reth-vrrp mode and private-rg-election mode
+	// still use cluster state because there are no VRRP instances to
+	// gate on.
 	d.syncRGStrictVIPOwnershipMode(cc)
 
 	// Start heartbeat if control-interface and peer-address are configured.

--- a/pkg/daemon/per_rg_test.go
+++ b/pkg/daemon/per_rg_test.go
@@ -133,6 +133,20 @@ func TestSyncRGStrictVIPOwnershipMode_DisabledInNoRethVRRPMode(t *testing.T) {
 	}
 }
 
+func TestSyncRGStrictVIPOwnershipMode_DisabledInPrivateRGElectionMode(t *testing.T) {
+	d := newTestDaemon()
+	cc := &config.ClusterConfig{
+		PrivateRGElection: true,
+		RedundancyGroups:  []*config.RedundancyGroup{{ID: 1}},
+	}
+
+	d.syncRGStrictVIPOwnershipMode(cc)
+
+	if d.getOrCreateRGState(1).IsStrictVIPOwnership() {
+		t.Fatal("expected strict VIP ownership to stay off in private-rg-election mode")
+	}
+}
+
 func TestSnapshotRethMasterState(t *testing.T) {
 	d := newTestDaemon()
 


### PR DESCRIPTION
Closes #493.

## Summary
- make strict VIP ownership the runtime default whenever VRRP-backed RETH ownership is in use
- keep direct/no-reth-vrrp mode on cluster-state activation since there are no VRRP instances to gate on
- add daemon-level regression tests for the new default and the no-reth-vrrp exception

## Testing
- go test ./pkg/daemon
