### PR TITLE
daemon: drop no-reth sync-ready takeover gate

### DIFF
--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -2942,28 +2942,7 @@ func (d *Daemon) reconcileRGState() {
 	if mon := d.cluster.Monitor(); mon != nil {
 		for _, rgID := range rgIDs {
 			ifReady, ifReasons := mon.RGInterfaceReady(rgID)
-			var vrrpReady bool
-			var vrrpReasons []string
-				if noRethVRRP {
-					// In direct/no-RETH mode there is no VRRP preemption gate.
-					// Promotion readiness is just whether VIP ownership can be
-					// established on the local node.
-					vrrpReady, vrrpReasons = d.checkNoRethTakeoverReadiness(rgID)
-				} else if d.vrrpMgr != nil {
-					hasRETH := rgHasRETH(d.store.ActiveConfig(), rgID)
-					vrrpReady, vrrpReasons = d.vrrpMgr.RGVRRPReady(rgID, hasRETH)
-			} else {
-				vrrpReady = true // no VRRP = always ready
-			}
-			userspaceReady, userspaceReasons := d.checkUserspaceTakeoverReadiness(rgID)
-			ready := ifReady && vrrpReady && fabricReady && userspaceReady
-			var reasons []string
-			reasons = append(reasons, ifReasons...)
-			reasons = append(reasons, vrrpReasons...)
-			if !fabricReady {
-				reasons = append(reasons, "fabric forwarding path not ready")
-			}
-			reasons = append(reasons, userspaceReasons...)
+			ready, reasons := d.takeoverReadinessForRG(rgID, ifReady, ifReasons, fabricReady, noRethVRRP)
 			d.cluster.SetRGReady(rgID, ready, reasons)
 		}
 	}
@@ -3621,15 +3600,34 @@ func (d *Daemon) checkVIPReadiness(rgID int) (bool, []string) {
 }
 
 func (d *Daemon) checkNoRethTakeoverReadiness(rgID int) (bool, []string) {
-	cfg := d.store.ActiveConfig()
-	if cfg == nil {
-		return true, nil
+	return d.checkVIPReadiness(rgID)
+}
+
+func (d *Daemon) takeoverReadinessForRG(rgID int, ifReady bool, ifReasons []string, fabricReady, noRethVRRP bool) (bool, []string) {
+	var takeoverGateReady bool
+	var takeoverGateReasons []string
+	if noRethVRRP {
+		// This reduces the no-RETH VRRP/takeover gate component to
+		// whether VIP ownership can be established on the local node.
+		takeoverGateReady, takeoverGateReasons = d.checkNoRethTakeoverReadiness(rgID)
+	} else if d.vrrpMgr != nil {
+		hasRETH := rgHasRETH(d.store.ActiveConfig(), rgID)
+		takeoverGateReady, takeoverGateReasons = d.vrrpMgr.RGVRRPReady(rgID, hasRETH)
+	} else {
+		takeoverGateReady = true // no VRRP = always ready
 	}
-	linkByName := d.linkByNameFn
-	if linkByName == nil {
-		linkByName = netlink.LinkByName
+
+	userspaceReady, userspaceReasons := d.checkUserspaceTakeoverReadiness(rgID)
+	ready := ifReady && takeoverGateReady && fabricReady && userspaceReady
+
+	var reasons []string
+	reasons = append(reasons, ifReasons...)
+	reasons = append(reasons, takeoverGateReasons...)
+	if !fabricReady {
+		reasons = append(reasons, "fabric forwarding path not ready")
 	}
-	return checkNoRethTakeoverReadinessForConfig(cfg, rgID, linkByName)
+	reasons = append(reasons, userspaceReasons...)
+	return ready, reasons
 }
 
 // checkVIPReadinessForConfig verifies that RETH interfaces for the given RG
@@ -3653,10 +3651,6 @@ func checkVIPReadinessForConfig(cfg *config.Config, rgID int, linkByName func(st
 		}
 	}
 	return len(reasons) == 0, reasons
-}
-
-func checkNoRethTakeoverReadinessForConfig(cfg *config.Config, rgID int, linkByName func(string) (netlink.Link, error)) (bool, []string) {
-	return checkVIPReadinessForConfig(cfg, rgID, linkByName)
 }
 
 func userspaceRGConfigured(cfg *config.Config, rgID int) bool {

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -1,15 +1,20 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/psaab/bpfrx/pkg/cluster"
 	"github.com/psaab/bpfrx/pkg/dataplane"
 	"github.com/vishvananda/netlink"
 
 	"github.com/psaab/bpfrx/pkg/config"
+	"github.com/psaab/bpfrx/pkg/configstore"
+	"github.com/psaab/bpfrx/pkg/vrrp"
 )
 
 // testLink implements netlink.Link for testing.
@@ -239,12 +244,73 @@ func TestCheckNoRethTakeoverReadiness_UsesVIPReadinessOnly(t *testing.T) {
 		"ge-0-0-0": newTestLink("ge-0-0-0", true),
 	}
 
-	ready, reasons := checkNoRethTakeoverReadinessForConfig(cfg, 0, mockLinkByName(links))
+	ready, reasons := checkVIPReadinessForConfig(cfg, 0, mockLinkByName(links))
 	if !ready {
 		t.Fatalf("should be ready, got reasons: %v", reasons)
 	}
 	if len(reasons) != 0 {
 		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
+func testStoreWithSetConfig(t *testing.T, lines []string) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "config"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(lines, "\n")); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return store
+}
+
+func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster no-reth-vrrp",
+		"set chassis cluster redundancy-group 0 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 0",
+		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+	})
+
+	cm := cluster.NewManager(0, 1)
+	cm.UpdateConfig(store.ActiveConfig().Chassis.Cluster)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cm.Start(ctx)
+
+	d := &Daemon{
+		rgStates:     make(map[int]*rgStateMachine),
+		cluster:      cm,
+		store:        store,
+		vrrpMgr:      vrrp.NewManager(),
+		linkByNameFn: mockLinkByName(map[string]*testLink{"ge-0-0-0": newTestLink("ge-0-0-0", true)}),
+	}
+
+	if d.cluster.IsSyncReady() {
+		t.Fatal("sync should start not ready for this regression test")
+	}
+
+	d.reconcileRGState()
+
+	state := d.cluster.GroupState(0)
+	if state == nil {
+		t.Fatal("expected RG 0 state")
+	}
+	if !state.Ready {
+		t.Fatalf("expected RG 0 ready, got reasons: %v", state.ReadinessReasons)
+	}
+	for _, reason := range state.ReadinessReasons {
+		if strings.Contains(reason, "session sync not ready") {
+			t.Fatalf("unexpected session sync gating reason: %v", state.ReadinessReasons)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop blocking no-reth/direct HA promotion on cluster sync-ready state
- treat direct-mode takeover readiness as VIP ownership readiness only
- add regression coverage for the direct-mode readiness helper

## Testing
- go test ./pkg/daemon

Closes #502
