### PR TITLE
userspace: stop snapshot churn on HA rg transitions

### DIFF
--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -362,7 +362,8 @@ func (m *Manager) UpdateRGActive(rgID int, active bool) error {
 	// Sync HA state DIRECTLY to helper without re-reading from BPF maps.
 	// The periodic status poll also reads rg_active and syncs to the helper,
 	// racing with us. If the poll syncs first, our syncHAStateLocked
-	// sends the same state → no delta detected → no FlushFlowCaches.
+	// sends the same state → no delta detected → no new RG-epoch bump or
+	// helper-side HA transition handling.
 	// By sending directly with the groups we already have, we guarantee
 	// the helper sees the transition.
 	//


### PR DESCRIPTION
## Summary
- stop double FIB generation bumps during `UpdateRGActive()`
- stop rebuilding and republishing a snapshot after every HA RG transition
- leave HA transition invalidation to the helper's RG epoch and HA-state path

## Testing
- go test ./pkg/dataplane/userspace ./pkg/daemon

Refs #499
