### PR TITLE
userspace: stop worker session scans on ha apply

### DIFF
--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -55,6 +55,7 @@ impl super::Coordinator {
             }
         }
         self.ha_state.store(Arc::new(state));
+        let mut ha_state_changed = false;
         if !demoted_rgs.is_empty() {
             demote_shared_owner_rgs(
                 &self.shared_sessions,
@@ -71,7 +72,7 @@ impl super::Coordinator {
                     self.rg_epochs[idx].fetch_add(1, Ordering::Release);
                 }
             }
-            self.enqueue_apply_ha_state(&[], &demoted_rgs);
+            ha_state_changed = true;
             // Record cache flush timestamp for observability (#312).
             self.last_cache_flush_at.store(now_secs, Ordering::Relaxed);
         }
@@ -90,11 +91,10 @@ impl super::Coordinator {
                     self.rg_epochs[idx].fetch_add(1, Ordering::Release);
                 }
             }
-            // Standby workers already keep session redirect keys programmed.
-            // Activation only needs an in-place refresh of the local session
-            // tables so previously demoted fabric redirects resolve back to
-            // local forwarding.
-            self.enqueue_apply_ha_state(&activated_rgs, &[]);
+            ha_state_changed = true;
+        }
+        if ha_state_changed {
+            self.enqueue_apply_ha_state();
         }
         Ok(())
     }
@@ -128,7 +128,7 @@ impl super::Coordinator {
         self.ha_state.store(Arc::new(state));
     }
 
-    fn enqueue_apply_ha_state(&self, refresh_owner_rgs: &[i32], demote_owner_rgs: &[i32]) {
+    fn enqueue_apply_ha_state(&self) {
         if self.workers.is_empty() {
             return;
         }
@@ -138,11 +138,7 @@ impl super::Coordinator {
             .saturating_add(1);
         for (worker_id, handle) in &self.workers {
             if let Ok(mut pending) = handle.commands.lock() {
-                pending.push_back(WorkerCommand::ApplyHAState {
-                    sequence,
-                    refresh_owner_rgs: refresh_owner_rgs.to_vec(),
-                    demote_owner_rgs: demote_owner_rgs.to_vec(),
-                });
+                pending.push_back(WorkerCommand::ApplyHAState { sequence });
             } else {
                 eprintln!(
                     "bpfrx-ha: worker-{} command mutex poisoned during HA state apply",

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -250,7 +250,7 @@ pub(super) fn apply_worker_commands(
     };
     let now_ns = monotonic_nanos();
     let now_secs = now_ns / 1_000_000_000;
-    let mut cancelled_keys = Vec::new();
+    let cancelled_keys: Vec<SessionKey> = Vec::new();
     let mut applied_sequences = Vec::new();
     let mut exported_sequences = Vec::new();
     for cmd in pending {
@@ -262,56 +262,10 @@ pub(super) fn apply_worker_commands(
                 export_forward_sessions_for_owner_rgs(sessions, &owner_rgs);
                 exported_sequences.push(sequence);
             }
-            WorkerCommand::ApplyHAState {
-                sequence,
-                refresh_owner_rgs,
-                demote_owner_rgs,
-            } => {
-                let mut affected_owner_rgs = refresh_owner_rgs.clone();
-                for rg_id in &demote_owner_rgs {
-                    if !affected_owner_rgs.contains(rg_id) {
-                        affected_owner_rgs.push(*rg_id);
-                    }
-                }
-                // Flow cache invalidation is handled by epoch-based check
-                // in FlowCache::lookup() — no per-entry scan needed here.
-                if !refresh_owner_rgs.is_empty() || !demote_owner_rgs.is_empty() {
-                    let refreshed = refresh_live_reverse_sessions_for_owner_rgs(
-                        sessions,
-                        session_map_fd,
-                        forwarding,
-                        ha_state,
-                        dynamic_neighbors,
-                        &affected_owner_rgs,
-                        now_ns,
-                        now_secs,
-                        !demote_owner_rgs.is_empty(),
-                    );
-                    // Collect refreshed keys as cancelled so queued TX
-                    // packets with stale resolution get dropped. Keys from
-                    // demoted RGs are added by the demote loop below, so
-                    // deduplicate to avoid double-cancel.
-                    cancelled_keys.extend(refreshed);
-                }
-                for owner_rg_id in demote_owner_rgs {
-                    eprintln!(
-                        "bpfrx-ha: DemoteOwnerRG {} worker sessions: total={}",
-                        owner_rg_id,
-                        sessions.len(),
-                    );
-                    // Mark sessions as synced in-place. Their decisions were
-                    // already refreshed above, so demoted flows stay redirect-
-                    // ready on the standby without tearing down the live BPF
-                    // keys that activation would otherwise need to rebuild.
-                    let demoted = sessions.demote_owner_rg(owner_rg_id);
-                    eprintln!(
-                        "bpfrx-ha: DemoteOwnerRG {} demoted_sessions={} remaining={}",
-                        owner_rg_id,
-                        demoted.len(),
-                        sessions.len(),
-                    );
-                    cancelled_keys.extend(demoted);
-                }
+            WorkerCommand::ApplyHAState { sequence } => {
+                // Worker-local session repair is no longer part of the HA
+                // transition path. Flow cache epoch invalidation and shared
+                // session lookup handle continuity without an owner-RG walk.
                 applied_sequences.push(sequence);
             }
             WorkerCommand::UpsertSynced(mut entry) => {
@@ -412,12 +366,6 @@ pub(super) fn apply_worker_commands(
             }
         }
     }
-    // Deduplicate: refresh and demote paths may both collect the same key.
-    {
-        let mut seen =
-            super::FastSet::with_capacity_and_hasher(cancelled_keys.len(), Default::default());
-        cancelled_keys.retain(|k| seen.insert(k.clone()));
-    }
     WorkerCommandResults {
         cancelled_keys,
         applied_sequences,
@@ -448,6 +396,7 @@ pub(super) fn replicate_session_delete(
     }
 }
 
+#[allow(dead_code)]
 pub(super) fn refresh_live_reverse_sessions_for_owner_rgs(
     sessions: &mut SessionTable,
     session_map_fd: c_int,
@@ -2315,7 +2264,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_worker_commands_demotes_local_sessions_for_owner_rg() {
+    fn apply_worker_commands_records_demotion_sequence_without_mutating_local_sessions() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let mut sessions = SessionTable::new();
         let key = test_key();
@@ -2332,11 +2281,7 @@ mod tests {
         commands
             .lock()
             .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 3,
-                refresh_owner_rgs: Vec::new(),
-                demote_owner_rgs: vec![1],
-            });
+            .push_back(WorkerCommand::ApplyHAState { sequence: 3 });
         let forwarding = test_forwarding_state();
         let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
         let results = apply_worker_commands(
@@ -2349,10 +2294,18 @@ mod tests {
             &BTreeMap::new(),
             &dynamic_neighbors,
         );
-        assert_eq!(results.cancelled_keys, vec![key.clone()]);
+        assert!(results.cancelled_keys.is_empty());
         assert_eq!(results.applied_sequences, vec![3]);
 
-        let _hit = sessions.lookup(&key, 2_000_000, 0x10).expect("demoted hit");
+        let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("local hit");
+        assert_eq!(
+            hit.decision.resolution.disposition,
+            test_decision().resolution.disposition
+        );
+        let (_, _, origin) = sessions
+            .entry_with_origin(&key)
+            .expect("local session origin");
+        assert_eq!(origin, SessionOrigin::ForwardFlow);
     }
 
     #[test]
@@ -2497,7 +2450,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_worker_commands_marks_reverse_local_sessions_synced_for_owner_rg() {
+    fn apply_worker_commands_leaves_reverse_local_sessions_unchanged() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let mut sessions = SessionTable::new();
         let mut key = test_key();
@@ -2517,11 +2470,7 @@ mod tests {
         commands
             .lock()
             .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 5,
-                refresh_owner_rgs: Vec::new(),
-                demote_owner_rgs: vec![1],
-            });
+            .push_back(WorkerCommand::ApplyHAState { sequence: 5 });
         let forwarding = test_forwarding_state();
         let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
         apply_worker_commands(
@@ -2535,94 +2484,21 @@ mod tests {
             &dynamic_neighbors,
         );
 
-        let _hit = sessions
-            .lookup(&key, 2_000_000, 0x10)
-            .expect("demoted reverse hit");
-    }
-
-    #[test]
-    fn apply_worker_commands_demoted_owner_rg_refreshes_reverse_sessions_to_fabric_redirect() {
-        let commands = Arc::new(Mutex::new(VecDeque::new()));
-        let mut sessions = SessionTable::new();
-        let key = SessionKey {
-            addr_family: libc::AF_INET as u8,
-            protocol: PROTO_TCP,
-            src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
-            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
-            src_port: 5201,
-            dst_port: 42424,
-        };
-        let decision = SessionDecision {
-            resolution: ForwardingResolution {
-                disposition: ForwardingDisposition::ForwardCandidate,
-                local_ifindex: 0,
-                egress_ifindex: 6,
-                tx_ifindex: 6,
-                tunnel_endpoint_id: 0,
-                next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
-                neighbor_mac: Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
-                src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
-                tx_vlan_id: 0,
-            },
-            nat: NatDecision::default(),
-        };
-        let metadata = SessionMetadata {
-            ingress_zone: Arc::<str>::from("wan"),
-            egress_zone: Arc::<str>::from("lan"),
-            owner_rg_id: 1,
-            fabric_ingress: false,
-            is_reverse: true,
-            nat64_reverse: None,
-        };
-        assert!(sessions.install_with_protocol(
-            key.clone(),
-            decision,
-            metadata,
-            1_000_000,
-            PROTO_TCP,
-            0x10,
-        ));
-        commands
-            .lock()
-            .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 6,
-                refresh_owner_rgs: Vec::new(),
-                demote_owner_rgs: vec![1],
-            });
-        let forwarding = test_forwarding_state_with_fabric();
-        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
-        let mut ha_state = BTreeMap::new();
-        ha_state.insert(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000));
-        apply_worker_commands(
-            &commands,
-            &mut sessions,
-            -1,
-            -1,
-            -1,
-            &forwarding,
-            &ha_state,
-            &dynamic_neighbors,
-        );
-
         let hit = sessions
             .lookup(&key, 2_000_000, 0x10)
-            .expect("demoted reverse hit");
-
-        assert_eq!(hit.metadata.owner_rg_id, 1);
+            .expect("reverse hit");
         assert_eq!(
             hit.decision.resolution.disposition,
-            ForwardingDisposition::FabricRedirect
+            test_decision().resolution.disposition
         );
-        assert_eq!(hit.decision.resolution.egress_ifindex, 21);
-        assert_eq!(
-            hit.decision.resolution.src_mac,
-            Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, 0x03])
-        );
+        let (_, _, origin) = sessions
+            .entry_with_origin(&key)
+            .expect("reverse session origin");
+        assert_eq!(origin, SessionOrigin::ForwardFlow);
     }
 
     #[test]
-    fn apply_worker_commands_demoted_owner_rg_republishes_forward_sessions() {
+    fn apply_worker_commands_demotion_no_longer_republishes_forward_sessions() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let mut sessions = SessionTable::new();
         let key = test_key();
@@ -2649,16 +2525,12 @@ mod tests {
         commands
             .lock()
             .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 7,
-                refresh_owner_rgs: Vec::new(),
-                demote_owner_rgs: vec![1],
-            });
+            .push_back(WorkerCommand::ApplyHAState { sequence: 7 });
         let forwarding = test_forwarding_state_with_fabric();
         let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
         let mut ha_state = BTreeMap::new();
         ha_state.insert(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000));
-        apply_worker_commands(
+        let results = apply_worker_commands(
             &commands,
             &mut sessions,
             -1,
@@ -2669,31 +2541,25 @@ mod tests {
             &dynamic_neighbors,
         );
 
+        assert_eq!(results.cancelled_keys, Vec::<SessionKey>::new());
+        assert_eq!(results.applied_sequences, vec![7]);
         let hit = sessions
             .lookup(&key, 2_000_000, 0x10)
-            .expect("demoted forward hit");
+            .expect("forward hit");
 
         assert_eq!(
             hit.decision.resolution.disposition,
-            ForwardingDisposition::FabricRedirect
-        );
-        let deltas = sessions.drain_deltas(16);
-        assert_eq!(deltas.len(), 1, "demotion should republish forward session");
-        assert_eq!(deltas[0].kind, SessionDeltaKind::Open);
-        assert_eq!(deltas[0].key, key);
-        assert_eq!(
-            deltas[0].decision.resolution.disposition,
             ForwardingDisposition::ForwardCandidate
         );
-        assert_eq!(
-            deltas[0].decision.nat.rewrite_src,
-            Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)))
+        let deltas = sessions.drain_deltas(16);
+        assert!(
+            deltas.is_empty(),
+            "demotion sequencing should not republish forward sessions"
         );
-        assert!(deltas[0].fabric_redirect_sync);
     }
 
     #[test]
-    fn apply_worker_commands_refreshes_activated_owner_rg_without_republish() {
+    fn apply_worker_commands_activation_no_longer_refreshes_local_sessions() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let mut sessions = SessionTable::new();
         let key = test_key();
@@ -2720,11 +2586,7 @@ mod tests {
         commands
             .lock()
             .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 7,
-                refresh_owner_rgs: vec![1],
-                demote_owner_rgs: Vec::new(),
-            });
+            .push_back(WorkerCommand::ApplyHAState { sequence: 7 });
         let forwarding = test_forwarding_state_with_fabric();
         let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
         let mut ha_state = BTreeMap::new();
@@ -2740,11 +2602,9 @@ mod tests {
             &dynamic_neighbors,
         );
 
-        assert_eq!(results.cancelled_keys, vec![key.clone()]);
+        assert!(results.cancelled_keys.is_empty());
         assert_eq!(results.applied_sequences, vec![7]);
-        let hit = sessions
-            .lookup(&key, 2_000_000, 0x10)
-            .expect("prepared forward hit");
+        let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("forward hit");
 
         assert_eq!(
             hit.decision.resolution.disposition,
@@ -2827,11 +2687,7 @@ mod tests {
         commands
             .lock()
             .expect("commands lock")
-            .push_back(WorkerCommand::ApplyHAState {
-                sequence: 7,
-                refresh_owner_rgs: Vec::new(),
-                demote_owner_rgs: Vec::new(),
-            });
+            .push_back(WorkerCommand::ApplyHAState { sequence: 7 });
         let forwarding = test_forwarding_state();
         let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
         let ha_state = BTreeMap::new();

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -555,8 +555,6 @@ pub(super) enum WorkerCommand {
     },
     ApplyHAState {
         sequence: u64,
-        refresh_owner_rgs: Vec<i32>,
-        demote_owner_rgs: Vec<i32>,
     },
 }
 


### PR DESCRIPTION
## Summary
- remove owner-RG session refresh/demotion walks from worker `ApplyHAState`
- shrink `ApplyHAState` to a pure sequence/ack command
- update HA/session regressions to assert that worker-local sessions are no longer rewritten during transitions

## Testing
- cargo test --manifest-path userspace-dp/Cargo.toml session_glue::tests -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml afxdp::ha::tests -- --nocapture

Refs #500
