### PR TITLE
daemon: keep blackholes until strict VIP ownership activates

### DIFF
--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -2585,11 +2585,13 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 						s.ApplyIfCurrent(tr)
 					}
 				}
-				// Then remove blackhole routes — steady-state neighbor
-				// maintenance keeps next-hop resolution warm in the
-				// background, so activation no longer depends on a
-				// one-shot neighbor warmup here.
-				d.removeBlackholeRoutes(ev.GroupID)
+				// Only remove blackholes once this node's desired state is
+				// actually active. In strict VIP ownership mode, a cluster
+				// primary event alone does not activate the RG until VRRP
+				// ownership has moved as well.
+				if shouldRemoveBlackholesOnClusterPrimary(s) {
+					d.removeBlackholeRoutes(ev.GroupID)
+				}
 
 				// VRRP priority + ForceRGMaster AFTER rg_active and
 				// blackhole removal (#485).
@@ -2839,6 +2841,11 @@ func (d *Daemon) triggerReconcile() {
 	case d.reconcileNowCh <- struct{}{}:
 	default:
 	}
+}
+
+func shouldRemoveBlackholesOnClusterPrimary(s *rgStateMachine) bool {
+	active, _ := s.CurrentDesired()
+	return active
 }
 
 func (d *Daemon) reconcileRGState() {

--- a/pkg/daemon/rg_state_test.go
+++ b/pkg/daemon/rg_state_test.go
@@ -349,7 +349,7 @@ func TestRGStateMachine_CurrentDesired(t *testing.T) {
 	}
 
 	// Interleaved: VRRP goes MASTER then BACKUP while we hold stale active=true.
-	s.SetVRRP("reth0", true) // epoch 2
+	s.SetVRRP("reth0", true)  // epoch 2
 	s.SetVRRP("reth0", false) // epoch 3, still active via cluster
 
 	active, epoch = s.CurrentDesired()
@@ -768,6 +768,30 @@ func TestStrictVIPOwnershipDualInactiveWindowPrevention(t *testing.T) {
 	tr = s.SetVRRP("reth0", false)
 	if !tr.Changed || tr.Active {
 		t.Error("strict: should deactivate when VRRP goes BACKUP")
+	}
+}
+
+func TestShouldRemoveBlackholesOnClusterPrimary_DefaultMode(t *testing.T) {
+	s := newRGStateMachine()
+	s.SetCluster(true)
+
+	if !shouldRemoveBlackholesOnClusterPrimary(s) {
+		t.Fatal("default mode should remove blackholes once cluster primary activates the RG")
+	}
+}
+
+func TestShouldRemoveBlackholesOnClusterPrimary_StrictVIPOwnership(t *testing.T) {
+	s := newRGStateMachine()
+	s.SetStrictVIPOwnership(true)
+	s.SetCluster(true)
+
+	if shouldRemoveBlackholesOnClusterPrimary(s) {
+		t.Fatal("strict VIP ownership should keep blackholes until VRRP ownership is active")
+	}
+
+	s.SetVRRP("reth0", true)
+	if !shouldRemoveBlackholesOnClusterPrimary(s) {
+		t.Fatal("strict VIP ownership should remove blackholes after VRRP ownership activates the RG")
 	}
 }
 


### PR DESCRIPTION
Closes #511.

## Summary
- keep blackholes in place on the cluster-primary path until the RG's desired state is actually active
- avoid removing the inactive-node safeguard during the strict-VIP window before VRRP ownership moves
- add regressions for default and strict VIP ownership behavior

## Testing
- go test ./pkg/daemon
