### PR TITLE
fix: skip reverse helper mirror for synced sessions

### DIFF
--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -545,7 +545,7 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := m.syncSessionV4Locked("upsert", key, &val); err != nil {
+	if err := m.syncSessionV4Locked("upsert", key, &installVal); err != nil {
 		slog.Debug("userspace: session mirror failed", "err", err)
 	}
 	return nil
@@ -596,7 +596,7 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := m.syncSessionV6Locked("upsert", key, &val); err != nil {
+	if err := m.syncSessionV6Locked("upsert", key, &installVal); err != nil {
 		slog.Debug("userspace: session mirror failed", "err", err)
 	}
 	return nil

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os/exec"
 	"path/filepath"
@@ -26,12 +27,40 @@ func hostToNetwork16(v uint16) uint16 {
 
 func injectInnerMap(t *testing.T, inner *dataplane.Manager, name string, m *ebpf.Map) {
 	t.Helper()
-	rv := reflect.ValueOf(inner).Elem().FieldByName("maps")
+	if inner == nil {
+		t.Fatal("injectInnerMap: inner manager is nil")
+	}
+	managerValue := reflect.ValueOf(inner)
+	if managerValue.Kind() != reflect.Ptr || managerValue.IsNil() {
+		t.Fatalf("injectInnerMap: expected non-nil pointer to dataplane.Manager, got %T", inner)
+	}
+	managerElem := managerValue.Elem()
+	if !managerElem.IsValid() || managerElem.Kind() != reflect.Struct {
+		t.Fatalf("injectInnerMap: expected dataplane.Manager struct, got kind %s", managerElem.Kind())
+	}
+	rv := managerElem.FieldByName("maps")
+	if !rv.IsValid() {
+		t.Fatal("injectInnerMap: dataplane.Manager has no field named \"maps\"")
+	}
+	if !rv.CanAddr() {
+		t.Fatal("injectInnerMap: dataplane.Manager.maps is not addressable")
+	}
+	if rv.Kind() != reflect.Map {
+		t.Fatalf("injectInnerMap: dataplane.Manager.maps has kind %s, want map", rv.Kind())
+	}
 	rm := reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem()
 	if rm.IsNil() {
 		rm.Set(reflect.MakeMap(rv.Type()))
 	}
-	rm.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(m))
+	key := reflect.ValueOf(name)
+	value := reflect.ValueOf(m)
+	if !key.Type().AssignableTo(rv.Type().Key()) {
+		t.Fatalf("injectInnerMap: cannot use key type %s for map key type %s", key.Type(), rv.Type().Key())
+	}
+	if !value.Type().AssignableTo(rv.Type().Elem()) {
+		t.Fatalf("injectInnerMap: cannot use value type %s for map element type %s", value.Type(), rv.Type().Elem())
+	}
+	rm.SetMapIndex(key, value)
 }
 
 func TestFindUserspaceEgressInterfaceSnapshotPrefersVLANUnit(t *testing.T) {
@@ -359,18 +388,29 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 	}
 	defer ln.Close()
 
-	gotReq := make(chan ControlRequest, 1)
+	unexpectedConn := make(chan string, 4)
 	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case unexpectedConn <- "unexpected helper session socket connection for reverse cluster session":
+			default:
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err == nil {
+					select {
+					case unexpectedConn <- fmt.Sprintf("unexpected helper mirror request for reverse cluster session: %+v", req):
+					default:
+					}
+				}
+				_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
+			}()
 		}
-		defer conn.Close()
-		var req ControlRequest
-		if err := json.NewDecoder(conn).Decode(&req); err == nil {
-			gotReq <- req
-		}
-		_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
 	}()
 
 	m := New()
@@ -387,6 +427,17 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 	}
 	defer sessionsMap.Close()
 	injectInnerMap(t, m.inner, "sessions", sessionsMap)
+	sessionsMapV6, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKeyV6{})),
+		ValueSize:  uint32(unsafe.Sizeof(dataplane.SessionValueV6{})),
+		MaxEntries: 1024,
+	})
+	if err != nil {
+		t.Fatalf("new sessions_v6 map: %v", err)
+	}
+	defer sessionsMapV6.Close()
+	injectInnerMap(t, m.inner, "sessions_v6", sessionsMapV6)
 
 	key := dataplane.SessionKey{
 		SrcIP:    [4]byte{172, 16, 80, 200},
@@ -411,8 +462,40 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 	}
 
 	select {
-	case req := <-gotReq:
-		t.Fatalf("unexpected helper mirror request for reverse cluster session: %+v", req)
+	case msg := <-unexpectedConn:
+		t.Fatal(msg)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	var srcIPv6, dstIPv6, natSrcIPv6 [16]byte
+	copy(srcIPv6[:], net.ParseIP("2001:db8:1::200").To16())
+	copy(dstIPv6[:], net.ParseIP("2001:db8:2::8").To16())
+	copy(natSrcIPv6[:], net.ParseIP("2001:db8:2::8").To16())
+	keyV6 := dataplane.SessionKeyV6{
+		SrcIP:    srcIPv6,
+		DstIP:    dstIPv6,
+		SrcPort:  hostToNetwork16(5201),
+		DstPort:  hostToNetwork16(55340),
+		Protocol: 6,
+	}
+	valV6 := dataplane.SessionValueV6{
+		IsReverse:   1,
+		IngressZone: 2,
+		EgressZone:  1,
+		Flags:       dataplane.SessFlagSNAT,
+		FibIfindex:  6,
+		FibVlanID:   80,
+		NATSrcIP:    natSrcIPv6,
+		NATSrcPort:  hostToNetwork16(55340),
+	}
+
+	if err := m.SetClusterSyncedSessionV6(keyV6, valV6); err != nil {
+		t.Fatalf("SetClusterSyncedSessionV6: %v", err)
+	}
+
+	select {
+	case msg := <-unexpectedConn:
+		t.Fatal(msg)
 	case <-time.After(200 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
Fixes #518.

## Summary
- stop mirroring explicit reverse cluster-synced sessions into the userspace helper
- keep mirroring forward cluster-synced sessions so the helper can synthesize the correct reverse companion locally
- add a regression that proves reverse cluster updates do not hit the helper session socket

## Testing
- go test ./pkg/dataplane/userspace -run 'Test(ShouldMirrorUserspaceSessionSkipsReverseEntries|SetClusterSyncedSessionV4SkipsReverseHelperMirror)' -count=1
- go test ./pkg/dataplane/userspace -count=1
