### PR TITLE
fix: select usable cluster bind addresses

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1487,6 +1487,88 @@ func resolveInterfaceAddr(ifname, fallback string) string {
 	return fallback
 }
 
+func parseLiteralIP(addr string) net.IP {
+	if addr == "" {
+		return nil
+	}
+	if ip := net.ParseIP(addr); ip != nil {
+		return ip
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil
+	}
+	return net.ParseIP(host)
+}
+
+func selectClusterBindAddr(addrs []net.Addr, peerAddr, fallback string) string {
+	var ipv4Candidates []string
+	var globalIPv6Candidates []string
+	peerIP := parseLiteralIP(peerAddr)
+	peerWantsIPv4 := peerIP != nil && peerIP.To4() != nil
+	peerWantsIPv6 := peerIP != nil && peerIP.To4() == nil
+
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip4 := ipNet.IP.To4(); ip4 != nil {
+			ipv4Candidates = append(ipv4Candidates, ip4.String())
+			continue
+		}
+		// Cluster control/fabric transports do not support binding to bare
+		// link-local IPv6 addresses because the resulting listen address lacks
+		// an interface zone. Treat them as unusable so startup waits for the
+		// configured control/fabric address family instead of racing on fe80::.
+		if ipNet.IP.IsLinkLocalUnicast() {
+			continue
+		}
+		globalIPv6Candidates = append(globalIPv6Candidates, ipNet.IP.String())
+	}
+
+	switch {
+	case peerWantsIPv4:
+		if len(ipv4Candidates) > 0 {
+			return ipv4Candidates[0]
+		}
+	case peerWantsIPv6:
+		if len(globalIPv6Candidates) > 0 {
+			return globalIPv6Candidates[0]
+		}
+	default:
+		if len(ipv4Candidates) > 0 {
+			return ipv4Candidates[0]
+		}
+		if len(globalIPv6Candidates) > 0 {
+			return globalIPv6Candidates[0]
+		}
+	}
+
+	return fallback
+}
+
+// resolveClusterInterfaceAddr returns a usable control/fabric bind address for
+// the named interface. It prefers the same address family as the configured
+// peer and skips unscoped link-local IPv6 addresses.
+func resolveClusterInterfaceAddr(ifname, peerAddr, fallback string) string {
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		slog.Warn("cluster interface not found, using fallback", "interface", ifname, "fallback", fallback)
+		return fallback
+	}
+	addrs, err := iface.Addrs()
+	if err != nil || len(addrs) == 0 {
+		slog.Warn("cluster interface has no addresses, using fallback", "interface", ifname, "fallback", fallback)
+		return fallback
+	}
+	addr := selectClusterBindAddr(addrs, peerAddr, fallback)
+	if addr == "" {
+		slog.Info("cluster interface has no usable bind address yet", "interface", ifname, "peer", peerAddr)
+	}
+	return addr
+}
+
 // applyConfig applies a compiled config in the correct order:
 // 0. Create VRF devices and bind interfaces (routing instances)
 // bootstrapFromFile reads the text Junos config file and imports it as the

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1306,10 +1306,10 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	if cc.ControlInterface != "" && cc.PeerAddress != "" {
 		go func() {
 			for i := 0; i < 30; i++ {
-				localIP := resolveInterfaceAddr(cc.ControlInterface, "")
+				localIP := resolveClusterInterfaceAddr(cc.ControlInterface, cc.PeerAddress, "")
 				if localIP == "" {
 					if i == 0 {
-						slog.Info("cluster: control interface has no IPv4 address yet, waiting",
+						slog.Info("cluster: control interface has no usable address yet, waiting",
 							"interface", cc.ControlInterface)
 					}
 					time.Sleep(2 * time.Second)
@@ -1348,12 +1348,12 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 		go func() {
 			var syncIP string
 			for i := 0; i < 30; i++ {
-				syncIP = resolveInterfaceAddr(syncIface, "")
+				syncIP = resolveClusterInterfaceAddr(syncIface, syncPeerAddr, "")
 				if syncIP != "" {
 					break
 				}
 				if i == 0 {
-					slog.Info("cluster: sync interface has no IPv4 address yet, waiting",
+					slog.Info("cluster: sync interface has no usable address yet, waiting",
 						"interface", syncIface, "transport", syncTransport)
 				}
 				select {
@@ -1368,8 +1368,8 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				return
 			}
 
-			syncLocal := fmt.Sprintf("%s:4785", syncIP)
-			syncPeer := fmt.Sprintf("%s:4785", syncPeerAddr)
+			syncLocal := net.JoinHostPort(syncIP, "4785")
+			syncPeer := net.JoinHostPort(syncPeerAddr, "4785")
 			slog.Info("cluster: session sync transport", "mode", syncTransport,
 				"local", syncLocal, "peer", syncPeer)
 
@@ -1379,12 +1379,12 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			if syncTransport == "fabric" && cc.Fabric1Interface != "" && cc.Fabric1PeerAddress != "" {
 				var fab1IP string
 				for i := 0; i < 15; i++ {
-					fab1IP = resolveInterfaceAddr(cc.Fabric1Interface, "")
+					fab1IP = resolveClusterInterfaceAddr(cc.Fabric1Interface, cc.Fabric1PeerAddress, "")
 					if fab1IP != "" {
 						break
 					}
 					if i == 0 {
-						slog.Info("cluster: fabric1 interface has no IPv4 address yet, waiting",
+						slog.Info("cluster: fabric1 interface has no usable address yet, waiting",
 							"interface", cc.Fabric1Interface)
 					}
 					select {
@@ -1394,8 +1394,8 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					}
 				}
 				if fab1IP != "" {
-					syncLocal1 = fmt.Sprintf("%s:4785", fab1IP)
-					syncPeer1 = fmt.Sprintf("%s:4785", cc.Fabric1PeerAddress)
+					syncLocal1 = net.JoinHostPort(fab1IP, "4785")
+					syncPeer1 = net.JoinHostPort(cc.Fabric1PeerAddress, "4785")
 					slog.Info("cluster: dual fabric transport configured",
 						"fab0_local", syncLocal, "fab1_local", syncLocal1)
 				} else {

--- a/pkg/daemon/interface_addr_test.go
+++ b/pkg/daemon/interface_addr_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+)
+
+func mustIPNet(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", cidr, err)
+	}
+	ipNet.IP = ip
+	return ipNet
+}
+
+func TestSelectClusterBindAddr(t *testing.T) {
+	addrs := []net.Addr{
+		mustIPNet(t, "fe80::1266:6aff:fe30:ad1c/64"),
+		mustIPNet(t, "10.99.12.1/30"),
+		mustIPNet(t, "2001:db8::1/64"),
+	}
+
+	tests := []struct {
+		name     string
+		peerAddr string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "ipv4 peer waits for ipv4 instead of link local",
+			peerAddr: "10.99.12.2",
+			want:     "10.99.12.1",
+		},
+		{
+			name:     "ipv6 peer prefers global ipv6",
+			peerAddr: "2001:db8::2",
+			want:     "2001:db8::1",
+		},
+		{
+			name:     "unknown peer prefers ipv4 then global ipv6",
+			peerAddr: "",
+			want:     "10.99.12.1",
+		},
+		{
+			name:     "hostport peer is parsed",
+			peerAddr: "[2001:db8::2]:4785",
+			want:     "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectClusterBindAddr(addrs, tt.peerAddr, tt.fallback); got != tt.want {
+				t.Fatalf("selectClusterBindAddr(%q) = %q, want %q", tt.peerAddr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectClusterBindAddrSkipsLinkLocalIPv6Fallback(t *testing.T) {
+	addrs := []net.Addr{
+		mustIPNet(t, "fe80::1266:6aff:fe30:ad1c/64"),
+	}
+	if got := selectClusterBindAddr(addrs, "10.99.12.2", ""); got != "" {
+		t.Fatalf("selectClusterBindAddr returned %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
## Summary
- prefer cluster heartbeat/session-sync bind addresses that match the configured peer family
- skip bare link-local IPv6 addresses that cannot be listened on without a zone
- use `net.JoinHostPort` so IPv6 sync/control endpoints are formatted correctly
- add regression coverage for IPv4, IPv6, host:port peers, and link-local-only interfaces

## Testing
- `go test ./pkg/daemon -run 'TestSelectClusterBindAddr|TestSessionSync|TestSelectClusterBindAddrSkipsLinkLocalIPv6Fallback' -count=1`\n