### PR TITLE
fix: harden local HA handoff against old-owner resets

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -127,6 +127,7 @@ type Manager struct {
 	// transfer-out across heartbeat refreshes until the transfer is either
 	// committed or aborted locally.
 	peerTransferOutOverride map[int]uint64
+	peerTransferOutPrevious map[int]peerGroupSnapshot
 	peerMonitors            []InterfaceMonitorInfo
 
 	// Heartbeat goroutines (nil when not started).
@@ -215,6 +216,11 @@ type Manager struct {
 	failoverInProgress map[int]bool
 }
 
+type peerGroupSnapshot struct {
+	state   PeerGroupState
+	present bool
+}
+
 // DefaultTakeoverHoldTime is the default additional delay after an RG becomes
 // ready before election promotes it to primary. Zero means promote as soon as
 // readiness is established.
@@ -233,6 +239,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		garpCounts:                     make(map[int]int),
 		peerGroups:                     make(map[int]PeerGroupState),
 		peerTransferOutOverride:        make(map[int]uint64),
+		peerTransferOutPrevious:        make(map[int]peerGroupSnapshot),
 		hbInterval:                     DefaultHeartbeatInterval,
 		hbThreshold:                    DefaultHeartbeatThreshold,
 		history:                        NewEventHistory(64),
@@ -241,6 +248,50 @@ func NewManager(nodeID, clusterID int) *Manager {
 		preManualFailoverRetryInterval: DefaultPreManualFailoverRetryInterval,
 		failoverInProgress:             make(map[int]bool),
 	}
+}
+
+func (m *Manager) applyPeerTransferOutOverrideLocked(rgID int, reqID uint64) {
+	previous, ok := m.peerGroups[rgID]
+	m.peerTransferOutOverride[rgID] = reqID
+	m.peerTransferOutPrevious[rgID] = peerGroupSnapshot{
+		state:   previous,
+		present: ok,
+	}
+	peerGroup := previous
+	peerGroup.GroupID = rgID
+	peerGroup.State = StateSecondaryHold
+	m.peerGroups[rgID] = peerGroup
+	if rg := m.groups[rgID]; rg != nil {
+		rg.PeerPriority = peerGroup.Priority
+	}
+}
+
+func (m *Manager) clearPeerTransferOutOverrideLocked(rgID int) {
+	delete(m.peerTransferOutOverride, rgID)
+	delete(m.peerTransferOutPrevious, rgID)
+}
+
+func (m *Manager) restorePeerTransferOutOverrideLocked(rgID int, reqID uint64) bool {
+	currentReqID, ok := m.peerTransferOutOverride[rgID]
+	if !ok || currentReqID != reqID {
+		return false
+	}
+	delete(m.peerTransferOutOverride, rgID)
+	snapshot, hadSnapshot := m.peerTransferOutPrevious[rgID]
+	delete(m.peerTransferOutPrevious, rgID)
+	if hadSnapshot && snapshot.present {
+		m.peerGroups[rgID] = snapshot.state
+	} else {
+		delete(m.peerGroups, rgID)
+	}
+	if rg := m.groups[rgID]; rg != nil {
+		if snapshot.present {
+			rg.PeerPriority = snapshot.state.Priority
+		} else {
+			rg.PeerPriority = 0
+		}
+	}
+	return true
 }
 
 // NodeID returns the local node ID.
@@ -981,12 +1032,8 @@ func (m *Manager) commitRequestedPeerFailover(rgID int, reqID uint64) error {
 		)
 	}
 
-	m.peerTransferOutOverride[rgID] = reqID
+	m.applyPeerTransferOutOverrideLocked(rgID, reqID)
 	peerGroup := m.peerGroups[rgID]
-	peerGroup.GroupID = rgID
-	peerGroup.State = StateSecondaryHold
-	m.peerGroups[rgID] = peerGroup
-	rg.PeerPriority = peerGroup.Priority
 
 	m.runElection()
 	if rg.State != StatePrimary {
@@ -1006,10 +1053,9 @@ func (m *Manager) abortRequestedPeerFailover(rgID int, reqID uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if currentReqID, ok := m.peerTransferOutOverride[rgID]; !ok || currentReqID != reqID {
+	if !m.restorePeerTransferOutOverrideLocked(rgID, reqID) {
 		return
 	}
-	delete(m.peerTransferOutOverride, rgID)
 	m.runElection()
 }
 
@@ -1017,7 +1063,7 @@ func (m *Manager) notePeerTransferCommitted(rgID int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.peerTransferOutOverride, rgID)
+	m.clearPeerTransferOutOverrideLocked(rgID)
 	peerGroup, ok := m.peerGroups[rgID]
 	if !ok {
 		return

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -176,6 +176,12 @@ type Manager struct {
 	// transferReadinessFn reports whether explicit manual failover can be
 	// attempted for the local RG right now and, if not, why.
 	transferReadinessFn func(rgID int) (bool, []string)
+	// localTransferCommitReadyFn runs on the requesting node after local
+	// ownership has been committed but before the final peer-demotion
+	// commit is sent. The daemon uses this to ensure the target node has
+	// actually applied its local failover side effects before the old
+	// owner is told to stand down.
+	localTransferCommitReadyFn func(rgIDs []int) error
 	// Retry policy for transient pre-failover prepare failures.
 	preManualFailoverRetryTimeout  time.Duration
 	preManualFailoverRetryInterval time.Duration
@@ -796,6 +802,15 @@ func (m *Manager) SetTransferReadinessFunc(fn func(rgID int) (bool, []string)) {
 	m.transferReadinessFn = fn
 }
 
+// SetLocalTransferCommitReadyHook registers a callback that runs on the
+// requesting node after local ownership is committed and before the final
+// peer-demotion commit is sent.
+func (m *Manager) SetLocalTransferCommitReadyHook(fn func(rgIDs []int) error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.localTransferCommitReadyFn = fn
+}
+
 // SetPeerFailoverFunc sets the callback used to send remote failover requests
 // to the peer via the fabric sync connection.
 func (m *Manager) SetPeerFailoverFunc(fn func(rgID int) (uint64, error)) {
@@ -889,6 +904,7 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	fn := m.peerFailoverFn
 	commitFn := m.peerFailoverCommitFn
 	transferReadyFn := m.transferReadinessFn
+	localCommitReadyFn := m.localTransferCommitReadyFn
 	m.mu.Unlock()
 
 	if fn == nil {
@@ -928,6 +944,12 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	m.mu.Unlock()
 	if err := m.commitRequestedPeerFailover(rgID, reqID); err != nil {
 		return err
+	}
+	if localCommitReadyFn != nil {
+		if err := localCommitReadyFn([]int{rgID}); err != nil {
+			m.abortRequestedPeerFailover(rgID, reqID)
+			return err
+		}
 	}
 	if err := commitFn(rgID, reqID); err != nil {
 		m.abortRequestedPeerFailover(rgID, reqID)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -633,6 +633,103 @@ func TestRequestPeerFailoverBatchCommitsLocalPrimaryTogether(t *testing.T) {
 	}
 }
 
+func TestRequestPeerFailoverWaitsForLocalCommitReadyHookBeforePeerCommit(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	var order []string
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		return 77, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		order = append(order, "ready")
+		if len(rgIDs) != 1 || rgIDs[0] != 0 {
+			t.Fatalf("local commit ready rgIDs = %v, want [0]", rgIDs)
+		}
+		if !m.IsLocalPrimary(0) {
+			t.Fatal("local node should already be primary before local commit ready hook runs")
+		}
+		return nil
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error {
+		order = append(order, "commit")
+		return nil
+	})
+
+	if err := m.RequestPeerFailover(0); err != nil {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if len(order) != 2 || order[0] != "ready" || order[1] != "commit" {
+		t.Fatalf("call order = %v, want [ready commit]", order)
+	}
+}
+
+func TestRequestPeerFailoverBatchAbortsWhenLocalCommitReadyHookFails(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(1, true, map[int]int{0: 100}),
+		makeRG(2, true, map[int]int{0: 100}),
+	)
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 1, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+			{GroupID: 2, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	for _, rgID := range []int{1, 2} {
+		m.groups[rgID].Ready = true
+		m.groups[rgID].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+		m.groups[rgID].ReadinessReasons = nil
+	}
+	m.mu.Unlock()
+
+	m.SetPeerFailoverBatchFunc(func(rgIDs []int) (uint64, error) {
+		return 88, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		return fmt.Errorf("local activation not settled")
+	})
+	m.SetPeerFailoverCommitBatchFunc(func(rgIDs []int, reqID uint64) error {
+		t.Fatal("peer failover batch commit should not run when local commit ready hook fails")
+		return nil
+	})
+
+	err := m.RequestPeerFailoverBatch([]int{1, 2})
+	if err == nil {
+		t.Fatal("expected local commit ready error")
+	}
+	if !strings.Contains(err.Error(), "local activation not settled") {
+		t.Fatalf("RequestPeerFailoverBatch() error = %v", err)
+	}
+	for _, rgID := range []int{1, 2} {
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondaryHold {
+			t.Fatalf("peer state for rg %d = %s, want secondary-hold after local commit ready abort", rgID, peer.State)
+		}
+	}
+}
+
 func TestRequestPeerFailoverRequiresLocalReadiness(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -679,6 +679,51 @@ func TestRequestPeerFailoverWaitsForLocalCommitReadyHookBeforePeerCommit(t *test
 	}
 }
 
+func TestRequestPeerFailoverAbortsToPriorPeerStateWhenLocalCommitReadyHookFails(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		return 77, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		return fmt.Errorf("local activation not settled")
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error {
+		t.Fatal("peer failover commit should not run when local commit ready hook fails")
+		return nil
+	})
+
+	err := m.RequestPeerFailover(0)
+	if err == nil {
+		t.Fatal("expected local commit ready error")
+	}
+	if !strings.Contains(err.Error(), "local activation not settled") {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("local node should not remain primary after abort")
+	}
+	if peer := m.PeerGroupStates()[0]; peer.State != StatePrimary {
+		t.Fatalf("peer state = %s, want primary after abort", peer.State)
+	}
+}
+
 func TestRequestPeerFailoverBatchAbortsWhenLocalCommitReadyHookFails(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(
@@ -724,8 +769,11 @@ func TestRequestPeerFailoverBatchAbortsWhenLocalCommitReadyHookFails(t *testing.
 		t.Fatalf("RequestPeerFailoverBatch() error = %v", err)
 	}
 	for _, rgID := range []int{1, 2} {
-		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondaryHold {
-			t.Fatalf("peer state for rg %d = %s, want secondary-hold after local commit ready abort", rgID, peer.State)
+		if m.IsLocalPrimary(rgID) {
+			t.Fatalf("local node should not remain primary for rg %d after abort", rgID)
+		}
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StatePrimary {
+			t.Fatalf("peer state for rg %d = %s, want primary after local commit ready abort", rgID, peer.State)
 		}
 	}
 }

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -185,6 +185,7 @@ func (m *Manager) RequestPeerFailoverBatch(rgIDs []int) error {
 	fn := m.peerFailoverBatchFn
 	commitFn := m.peerFailoverCommitBatchFn
 	transferReadyFn := m.transferReadinessFn
+	localCommitReadyFn := m.localTransferCommitReadyFn
 	m.mu.Unlock()
 
 	if fn == nil {
@@ -225,6 +226,12 @@ func (m *Manager) RequestPeerFailoverBatch(rgIDs []int) error {
 	if err := m.commitRequestedPeerFailoverBatch(ids, reqID); err != nil {
 		m.abortRequestedPeerFailoverBatch(ids, reqID)
 		return err
+	}
+	if localCommitReadyFn != nil {
+		if err := localCommitReadyFn(ids); err != nil {
+			m.abortRequestedPeerFailoverBatch(ids, reqID)
+			return err
+		}
 	}
 	if err := commitFn(ids, reqID); err != nil {
 		m.abortRequestedPeerFailoverBatch(ids, reqID)

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -266,14 +266,7 @@ func (m *Manager) commitRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) er
 	}
 
 	for _, rgID := range rgIDs {
-		m.peerTransferOutOverride[rgID] = reqID
-		peerGroup := m.peerGroups[rgID]
-		peerGroup.GroupID = rgID
-		peerGroup.State = StateSecondaryHold
-		m.peerGroups[rgID] = peerGroup
-		if rg := m.groups[rgID]; rg != nil {
-			rg.PeerPriority = peerGroup.Priority
-		}
+		m.applyPeerTransferOutOverrideLocked(rgID, reqID)
 	}
 
 	m.runElection()
@@ -301,9 +294,7 @@ func (m *Manager) abortRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) {
 	defer m.mu.Unlock()
 
 	for _, rgID := range rgIDs {
-		if currentReqID, ok := m.peerTransferOutOverride[rgID]; ok && currentReqID == reqID {
-			delete(m.peerTransferOutOverride, rgID)
-		}
+		m.restorePeerTransferOutOverrideLocked(rgID, reqID)
 	}
 	m.runElection()
 }
@@ -313,7 +304,7 @@ func (m *Manager) notePeerTransferCommittedBatch(rgIDs []int) {
 	defer m.mu.Unlock()
 
 	for _, rgID := range rgIDs {
-		delete(m.peerTransferOutOverride, rgID)
+		m.clearPeerTransferOutOverrideLocked(rgID)
 		peerGroup, ok := m.peerGroups[rgID]
 		if !ok {
 			continue

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -208,6 +208,15 @@ type Daemon struct {
 	// VIP presence/removal idempotently every pass.
 	directVIPMu    sync.Mutex
 	directVIPOwned map[int]bool
+	// localFailoverCommitReady tracks whether this node has already
+	// applied the local side of a freshly committed transfer request for
+	// each RG. The cluster manager waits on this before telling the peer
+	// to finalize demotion, so the old owner does not stand down before
+	// the target daemon has processed the promotion edge.
+	localFailoverCommitMu      sync.Mutex
+	localFailoverCommitReady   map[int]bool
+	localFailoverCommitTimeout time.Duration
+	localFailoverCommitDelay   time.Duration
 	// Test hooks for direct-mode VIP ownership reconciliation.
 	directAddVIPsFn        func(int) int
 	directRemoveVIPsFn     func(int) int
@@ -270,6 +279,9 @@ func New(opts Options) *Daemon {
 		linkByNameFn:               netlink.LinkByName,
 		directAnnounceSchedule:     []time.Duration{0, 250 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 6 * time.Second},
 		directVIPOwned:             make(map[int]bool),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: time.Second,
+		localFailoverCommitDelay:   200 * time.Millisecond,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 	}
 }

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -56,6 +56,61 @@ func (d *Daemon) armSyncReadyTimer() {
 	})
 }
 
+func (d *Daemon) setLocalFailoverCommitReady(rgID int, ready bool) {
+	d.localFailoverCommitMu.Lock()
+	defer d.localFailoverCommitMu.Unlock()
+	if d.localFailoverCommitReady == nil {
+		d.localFailoverCommitReady = make(map[int]bool)
+	}
+	d.localFailoverCommitReady[rgID] = ready
+}
+
+func (d *Daemon) localFailoverCommitIsReady(rgID int) bool {
+	d.localFailoverCommitMu.Lock()
+	defer d.localFailoverCommitMu.Unlock()
+	if d.localFailoverCommitReady == nil {
+		return false
+	}
+	return d.localFailoverCommitReady[rgID]
+}
+
+func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
+	if len(rgIDs) == 0 {
+		return nil
+	}
+	timeout := d.localFailoverCommitTimeout
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	delay := d.localFailoverCommitDelay
+	deadline := time.Now().Add(timeout)
+	dwelled := false
+	for {
+		ready := true
+		for _, rgID := range rgIDs {
+			if d.cluster != nil && !d.cluster.IsLocalPrimary(rgID) {
+				return fmt.Errorf("local redundancy group %d lost primary before peer demotion commit", rgID)
+			}
+			if !d.localFailoverCommitIsReady(rgID) {
+				ready = false
+				break
+			}
+		}
+		if ready {
+			if !dwelled && delay > 0 {
+				dwelled = true
+				time.Sleep(delay)
+				continue
+			}
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for local failover activation settle for redundancy groups %v", rgIDs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func (d *Daemon) onSessionSyncPeerConnected() {
 	d.syncPeerConnected.Store(true)
 	d.hbSuppressStart.Store(0) // fresh connection → reset suppression cap
@@ -1536,6 +1591,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFailoverCommitBatchFunc(d.sessionSync.SendFailoverCommitBatch)
 			d.cluster.SetPreManualFailoverHook(d.prepareUserspaceManualFailover)
 			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
+			d.cluster.SetLocalTransferCommitReadyHook(d.waitLocalFailoverCommitReady)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)
 
 			// Wire peer fencing: on heartbeat timeout, cluster sends
@@ -2605,6 +2661,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 			//   add blackholes, then clear rg_active (#485)
 			isPrimary := ev.NewState == cluster.StatePrimary
 			clusterDemotionEdge := ev.OldState == cluster.StatePrimary && !isPrimary
+			d.setLocalFailoverCommitReady(ev.GroupID, false)
 			s := d.getOrCreateRGState(ev.GroupID)
 			tr := s.SetCluster(isPrimary)
 			if isPrimary {
@@ -2651,6 +2708,9 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				if noRethVRRP {
 					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-primary")
 					go d.RefreshFabricFwd()
+				}
+				if noRethVRRP && (d.dp == nil || !s.NeedsApply()) {
+					d.setLocalFailoverCommitReady(ev.GroupID, true)
 				}
 			} else {
 				// Demotion: run preflight and resign VRRP BEFORE
@@ -2814,10 +2874,16 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 					d.addStableRethLinkLocal(rgID)
 					d.applyRethServicesForRG(rgID)
 				}
+				if d.cluster != nil && d.cluster.IsLocalPrimary(rgID) && s.AllVRRPMaster() {
+					d.setLocalFailoverCommitReady(rgID, true)
+				}
 			}
 			if ev.State == vrrp.StateBackup {
 				s := d.getOrCreateRGState(rgID)
 				tr := s.SetVRRP(ev.Interface, false)
+				if !s.AllVRRPMaster() {
+					d.setLocalFailoverCommitReady(rgID, false)
+				}
 				if tr.Changed && !tr.Active {
 					// Deactivation order: inject blackhole routes FIRST,
 					// then clear rg_active. Re-read desired state to
@@ -4014,8 +4080,20 @@ func (d *Daemon) scheduleDirectAnnounce(rgID int, reason string) {
 		sendFn = d.directSendGARPs
 	}
 	slog.Info("direct-mode re-announce scheduled", "rg", rgID, "reason", reason, "bursts", len(schedule))
+	start := time.Now()
+	burstOffset := 0
+	if len(schedule) > 0 && schedule[0] == 0 {
+		if d.directAnnounceActive(rgID, seq) {
+			sendFn(rgID)
+			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", 1, "total", len(schedule))
+		}
+		schedule = schedule[1:]
+		burstOffset = 1
+	}
+	if len(schedule) == 0 {
+		return
+	}
 	go func() {
-		start := time.Now()
 		for idx, at := range schedule {
 			if wait := time.Until(start.Add(at)); wait > 0 {
 				timer := time.NewTimer(wait)
@@ -4025,7 +4103,7 @@ func (d *Daemon) scheduleDirectAnnounce(rgID int, reason string) {
 				return
 			}
 			sendFn(rgID)
-			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", idx+1, "total", len(schedule))
+			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", idx+1+burstOffset, "total", len(schedule)+burstOffset)
 		}
 	}()
 }

--- a/pkg/daemon/direct_announce_test.go
+++ b/pkg/daemon/direct_announce_test.go
@@ -35,6 +35,31 @@ func TestScheduleDirectAnnounceRepeatsWhileRGActive(t *testing.T) {
 	}
 }
 
+func TestScheduleDirectAnnounceSendsImmediateBurstInline(t *testing.T) {
+	state := newRGStateMachine()
+	state.SetCluster(true)
+	d := &Daemon{
+		rgStates:               map[int]*rgStateMachine{1: state},
+		directAnnounceSchedule: []time.Duration{0, 25 * time.Millisecond},
+	}
+
+	calls := make(chan int, 4)
+	d.directSendGARPsFn = func(rgID int) {
+		calls <- rgID
+	}
+
+	d.scheduleDirectAnnounce(1, "test")
+
+	select {
+	case rgID := <-calls:
+		if rgID != 1 {
+			t.Fatalf("unexpected rg id: %d", rgID)
+		}
+	default:
+		t.Fatal("expected immediate announce burst before scheduleDirectAnnounce returns")
+	}
+}
+
 func TestCancelDirectAnnounceStopsFutureBursts(t *testing.T) {
 	state := newRGStateMachine()
 	state.SetCluster(true)

--- a/pkg/daemon/failover_commit_ready_test.go
+++ b/pkg/daemon/failover_commit_ready_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitLocalFailoverCommitReadyWaitsForPromotionSettle(t *testing.T) {
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 200 * time.Millisecond,
+		localFailoverCommitDelay:   0,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.waitLocalFailoverCommitReady([]int{0})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	d.setLocalFailoverCommitReady(0, true)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("waitLocalFailoverCommitReady() error = %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for failover commit settle")
+	}
+}
+
+func TestWaitLocalFailoverCommitReadyTimesOutWithoutPromotionSettle(t *testing.T) {
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 30 * time.Millisecond,
+		localFailoverCommitDelay:   0,
+	}
+
+	err := d.waitLocalFailoverCommitReady([]int{0})
+	if err == nil {
+		t.Fatal("expected timeout waiting for failover commit settle")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for local failover activation settle") {
+		t.Fatalf("waitLocalFailoverCommitReady() error = %v", err)
+	}
+}

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -345,10 +345,10 @@ pub(super) struct ConntrackCtx<'a> {
 #[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct BpfSessionKeyV4 {
-    src_ip: [u8; 4],   // __be32, network byte order
-    dst_ip: [u8; 4],   // __be32, network byte order
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_ip: [u8; 4], // __be32, network byte order
+    dst_ip: [u8; 4], // __be32, network byte order
+    src_port: u16,   // __be16, network byte order
+    dst_port: u16,   // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -369,10 +369,10 @@ struct BpfSessionValueV4 {
     policy_id: u32,
     ingress_zone: u16,
     egress_zone: u16,
-    nat_src_ip: u32,    // __be32, native endian for BPF
-    nat_dst_ip: u32,    // __be32, native endian for BPF
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_ip: u32,   // __be32, native endian for BPF
+    nat_dst_ip: u32,   // __be32, native endian for BPF
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -394,8 +394,8 @@ struct BpfSessionValueV4 {
 struct BpfSessionKeyV6 {
     src_ip: [u8; 16],
     dst_ip: [u8; 16],
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_port: u16, // __be16, network byte order
+    dst_port: u16, // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -418,8 +418,8 @@ struct BpfSessionValueV6 {
     egress_zone: u16,
     nat_src_ip: [u8; 16],
     nat_dst_ip: [u8; 16],
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -812,7 +812,9 @@ pub(super) fn publish_session_map_entry_for_session_with_origin(
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) -> io::Result<()> {
-    publish_session_map_entry_for_session_with_conntrack(map_fd, key, decision, metadata, origin, None)
+    publish_session_map_entry_for_session_with_conntrack(
+        map_fd, key, decision, metadata, origin, None,
+    )
 }
 
 pub(super) fn publish_session_map_entry_for_session_with_conntrack(
@@ -838,14 +840,28 @@ pub(super) fn publish_session_map_entry_for_session_with_conntrack(
         }
         // Also mirror to conntrack for session display.
         if let Some(ctx) = ct {
-            publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+            publish_bpf_conntrack_entry(
+                ctx.v4_fd,
+                ctx.v6_fd,
+                key,
+                decision,
+                metadata,
+                ctx.zone_name_to_id,
+            );
         }
         return Ok(());
     }
     let result = publish_live_session_entry(map_fd, key, decision.nat, metadata.is_reverse);
     // Mirror to conntrack for session display.
     if let Some(ctx) = ct {
-        publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+        publish_bpf_conntrack_entry(
+            ctx.v4_fd,
+            ctx.v6_fd,
+            key,
+            decision,
+            metadata,
+            ctx.zone_name_to_id,
+        );
     }
     result
 }
@@ -1089,7 +1105,13 @@ pub(super) fn delete_session_map_entry_for_removed_session(
     // Default to SyncImport for backwards-compatible callers where
     // the session being deleted is always from a sync path.
     delete_session_map_entry_for_removed_session_with_origin(
-        map_fd, key, decision, metadata, SessionOrigin::SyncImport, -1, -1,
+        map_fd,
+        key,
+        decision,
+        metadata,
+        SessionOrigin::SyncImport,
+        -1,
+        -1,
     );
 }
 
@@ -1226,8 +1248,7 @@ mod tests {
         // The packed struct bytes at the port offsets must be big-endian:
         // port 80 = 0x0050 -> bytes [0x00, 0x50]
         // port 443 = 0x01BB -> bytes [0x01, 0xBB]
-        let bytes: [u8; 16] =
-            unsafe { core::mem::transmute(bpf_key) };
+        let bytes: [u8; 16] = unsafe { core::mem::transmute(bpf_key) };
         assert_eq!(bytes[8], 0x00, "src_port high byte");
         assert_eq!(bytes[9], 0x50, "src_port low byte");
         assert_eq!(bytes[10], 0x01, "dst_port high byte");

--- a/userspace-dp/src/afxdp/forwarding.rs
+++ b/userspace-dp/src/afxdp/forwarding.rs
@@ -427,8 +427,13 @@ pub(super) fn enforce_ha_resolution_snapshot(
 ) -> ForwardingResolution {
     if !matches!(
         resolution.disposition,
-        ForwardingDisposition::ForwardCandidate | ForwardingDisposition::MissingNeighbor
+        ForwardingDisposition::ForwardCandidate
+            | ForwardingDisposition::MissingNeighbor
+            | ForwardingDisposition::LocalDelivery
     ) {
+        return resolution;
+    }
+    if resolution.disposition == ForwardingDisposition::LocalDelivery && ha_state.is_empty() {
         return resolution;
     }
     let owner_rg_id = owner_rg_for_resolution(forwarding, resolution);
@@ -438,7 +443,10 @@ pub(super) fn enforce_ha_resolution_snapshot(
         // Treat as invalid (force re-resolution through the slow path) rather
         // than "always active" which would let stale cached entries bypass
         // HA checks after RG failover.
-        if !ha_state.is_empty() && resolution.egress_ifindex > 0 {
+        if resolution.disposition != ForwardingDisposition::LocalDelivery
+            && !ha_state.is_empty()
+            && resolution.egress_ifindex > 0
+        {
             return ForwardingResolution {
                 disposition: ForwardingDisposition::HAInactive,
                 ..resolution
@@ -1655,6 +1663,23 @@ mod tests {
     }
 
     #[test]
+    fn cached_local_delivery_decision_invalidates_when_owner_rg_is_demoted() {
+        let state = build_forwarding_state(&nat_snapshot());
+        let active = BTreeMap::from([(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let demoted = BTreeMap::from([(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let resolution = interface_nat_local_resolution(&state, "172.16.80.8".parse().expect("v4"))
+            .expect("interface nat local delivery");
+        let now_secs = monotonic_nanos() / 1_000_000_000;
+
+        assert!(cached_flow_decision_valid(
+            &state, &active, now_secs, resolution
+        ));
+        assert!(!cached_flow_decision_valid(
+            &state, &demoted, now_secs, resolution
+        ));
+    }
+
+    #[test]
     fn inactive_owner_rg_redirects_established_session_to_fabric() {
         let state = build_forwarding_state(&nat_snapshot_with_fabric());
         let ha_state = Arc::new(ArcSwap::from_pointee(BTreeMap::from([(
@@ -2305,6 +2330,29 @@ mod tests {
     }
 
     #[test]
+    fn reverse_session_blocks_inactive_interface_snat_ipv4_local_delivery() {
+        let state = build_forwarding_state(&nat_snapshot());
+        let ha_state =
+            BTreeMap::from([(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+
+        let resolved = reverse_resolution_for_session(
+            &state,
+            &ha_state,
+            &dynamic_neighbors,
+            IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            "wan",
+            false,
+            monotonic_nanos() / 1_000_000_000,
+            false,
+        );
+
+        assert_eq!(resolved.disposition, ForwardingDisposition::HAInactive);
+        assert_eq!(resolved.local_ifindex, 12);
+        assert_eq!(resolved.egress_ifindex, 12);
+    }
+
+    #[test]
     fn reverse_session_prefers_interface_snat_ipv6_local_delivery() {
         let state = build_forwarding_state(&nat_snapshot());
         let ha_state = BTreeMap::new();
@@ -2354,6 +2402,45 @@ mod tests {
 
         assert_eq!(resolved.disposition, ForwardingDisposition::LocalDelivery);
         assert_eq!(resolved.local_ifindex, 12);
+    }
+
+    #[test]
+    fn inactive_interface_snat_session_hit_redirects_to_fabric() {
+        let state = build_forwarding_state(&nat_snapshot_with_fabric());
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let ha_state = Arc::new(ArcSwap::from_pointee(BTreeMap::from([(
+            1,
+            inactive_ha_runtime(monotonic_nanos() / 1_000_000_000),
+        )])));
+        let flow = SessionFlow {
+            src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+                src_port: 5201,
+                dst_port: 43600,
+            },
+        };
+        let decision = SessionDecision {
+            resolution: interface_nat_local_resolution(&state, flow.dst_ip)
+                .expect("interface nat local delivery"),
+            nat: NatDecision::default(),
+        };
+
+        let looked_up =
+            lookup_forwarding_resolution_for_session(&state, &dynamic_neighbors, &flow, decision);
+        let blocked = enforce_ha_resolution(&state, &ha_state, looked_up);
+        let redirected = redirect_via_fabric_if_needed(&state, blocked, 12);
+
+        assert_eq!(
+            redirected.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(redirected.egress_ifindex, 21);
+        assert_eq!(redirected.tx_ifindex, 21);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -1103,10 +1103,8 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                             _ => 0,
                         };
                         if csum_off > 0 && packet.len() > csum_off + 1 {
-                            let current = u16::from_be_bytes([
-                                packet[csum_off],
-                                packet[csum_off + 1],
-                            ]);
+                            let current =
+                                u16::from_be_bytes([packet[csum_off], packet[csum_off + 1]]);
                             let mut updated = checksum16_adjust(
                                 current,
                                 &ipv4_words(Ipv4Addr::from(pre_src_ip)),
@@ -1118,18 +1116,12 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                                 &ipv4_words(Ipv4Addr::from(post_dst_ip)),
                             );
                             if pre_src_port != post_src_port {
-                                updated = checksum16_adjust(
-                                    updated,
-                                    &[pre_src_port],
-                                    &[post_src_port],
-                                );
+                                updated =
+                                    checksum16_adjust(updated, &[pre_src_port], &[post_src_port]);
                             }
                             if pre_dst_port != post_dst_port {
-                                updated = checksum16_adjust(
-                                    updated,
-                                    &[pre_dst_port],
-                                    &[post_dst_port],
-                                );
+                                updated =
+                                    checksum16_adjust(updated, &[pre_dst_port], &[post_dst_port]);
                             }
                             if matches!(meta.protocol, PROTO_UDP) && updated == 0 {
                                 updated = 0xffff;
@@ -1142,12 +1134,7 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                 } else {
                     // Full L4 checksum recompute when enforce_expected_ports
                     // may have modified ports and adjusted the checksum.
-                    recompute_l4_checksum_ipv4(
-                        packet,
-                        ip_header_len,
-                        meta.protocol,
-                        false,
-                    )?;
+                    recompute_l4_checksum_ipv4(packet, ip_header_len, meta.protocol, false)?;
                 }
             }
             libc::AF_INET6 => {

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -55,6 +55,13 @@ impl super::Coordinator {
             }
             // Record cache flush timestamp for observability (#312).
             self.last_cache_flush_at.store(now_secs, Ordering::Relaxed);
+            for handle in self.workers.values() {
+                if let Ok(mut pending) = handle.commands.lock() {
+                    pending.push_back(WorkerCommand::DemoteOwnerRGSessions {
+                        owner_rgs: demoted_rgs.clone(),
+                    });
+                }
+            }
         }
         if !activated_rgs.is_empty() {
             eprintln!(

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -208,6 +208,38 @@ pub(super) struct WorkerCommandResults {
     pub exported_sequences: Vec<u64>,
 }
 
+fn force_live_redirect_for_worker_synced_entry(
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+    standby_owner: bool,
+) -> bool {
+    standby_owner
+        && origin.is_peer_synced()
+        && !metadata.is_reverse
+        && decision.resolution.disposition == ForwardingDisposition::LocalDelivery
+        && decision.resolution.tunnel_endpoint_id == 0
+}
+
+fn publish_worker_session_map_entry(
+    session_map_fd: c_int,
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+    standby_owner: bool,
+) {
+    if session_map_fd < 0 {
+        return;
+    }
+    let _ =
+        if force_live_redirect_for_worker_synced_entry(decision, metadata, origin, standby_owner) {
+            publish_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse)
+        } else {
+            publish_session_map_entry_for_session(session_map_fd, key, decision, metadata)
+        };
+}
+
 fn export_forward_sessions_for_owner_rgs(sessions: &mut SessionTable, owner_rgs: &[i32]) {
     if owner_rgs.is_empty() {
         return;
@@ -269,6 +301,28 @@ pub(super) fn apply_worker_commands(
     let mut exported_sequences = Vec::new();
     for cmd in pending {
         match cmd {
+            WorkerCommand::DemoteOwnerRGSessions { owner_rgs } => {
+                for owner_rg in owner_rgs {
+                    for key in sessions.demote_owner_rg(owner_rg) {
+                        let Some((decision, metadata, origin)) = sessions.entry_with_origin(&key)
+                        else {
+                            continue;
+                        };
+                        publish_worker_session_map_entry(
+                            session_map_fd,
+                            &key,
+                            decision,
+                            &metadata,
+                            origin,
+                            synced_entry_allows_local_replace(
+                                ha_state,
+                                metadata.owner_rg_id,
+                                now_secs,
+                            ),
+                        );
+                    }
+                }
+            }
             WorkerCommand::ExportOwnerRGSessions {
                 sequence,
                 owner_rgs,
@@ -336,11 +390,13 @@ pub(super) fn apply_worker_commands(
                     entry.tcp_flags,
                     allow_replace_local,
                 ) {
-                    let _ = publish_session_map_entry_for_session(
+                    publish_worker_session_map_entry(
                         session_map_fd,
                         &key,
                         entry.decision,
                         &metadata,
+                        entry.origin,
+                        allow_replace_local,
                     );
                 }
             }
@@ -1021,6 +1077,23 @@ mod tests {
     fn test_decision() -> SessionDecision {
         SessionDecision {
             resolution: test_resolution(),
+            nat: NatDecision::default(),
+        }
+    }
+
+    fn test_local_delivery_decision() -> SessionDecision {
+        SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::LocalDelivery,
+                local_ifindex: 12,
+                egress_ifindex: 12,
+                tx_ifindex: 12,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
             nat: NatDecision::default(),
         }
     }
@@ -2183,6 +2256,26 @@ mod tests {
     }
 
     #[test]
+    fn worker_synced_local_delivery_forces_live_redirect_on_standby() {
+        assert!(force_live_redirect_for_worker_synced_entry(
+            test_local_delivery_decision(),
+            &test_metadata(),
+            SessionOrigin::SyncImport,
+            true,
+        ));
+    }
+
+    #[test]
+    fn worker_synced_local_delivery_keeps_default_publish_on_active_owner() {
+        assert!(!force_live_redirect_for_worker_synced_entry(
+            test_local_delivery_decision(),
+            &test_metadata(),
+            SessionOrigin::SyncImport,
+            false,
+        ));
+    }
+
+    #[test]
     fn apply_worker_commands_preserves_local_session_for_active_owner_rg() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let mut sessions = SessionTable::new();
@@ -2234,6 +2327,118 @@ mod tests {
         let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("live hit");
         assert_eq!(hit.metadata, live_metadata);
         assert_eq!(hit.decision, live_decision);
+    }
+
+    #[test]
+    fn apply_worker_commands_demotes_local_owner_rg_sessions_to_sync_import() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        assert!(sessions.install_with_protocol(
+            key.clone(),
+            test_decision(),
+            test_metadata(),
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::DemoteOwnerRGSessions { owner_rgs: vec![1] });
+        let forwarding = test_forwarding_state();
+        let ha_state = BTreeMap::from([(1, inactive_ha_runtime(0))]);
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+
+        apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+        );
+
+        let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
+            panic!("demoted session missing");
+        };
+        assert_eq!(origin, SessionOrigin::SyncImport);
+    }
+
+    #[test]
+    fn demoted_local_session_promotes_as_synced_on_failback_lookup() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = test_decision();
+        let metadata = test_metadata();
+        assert!(sessions.install_with_protocol(
+            key.clone(),
+            decision,
+            metadata.clone(),
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::DemoteOwnerRGSessions { owner_rgs: vec![1] });
+        let forwarding = test_forwarding_state();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let inactive_state = BTreeMap::from([(1, inactive_ha_runtime(0))]);
+
+        apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &inactive_state,
+            &dynamic_neighbors,
+        );
+
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+        let active_state = BTreeMap::from([(1, active_ha_runtime(1))]);
+        let flow = SessionFlow {
+            src_ip: key.src_ip,
+            dst_ip: key.dst_ip,
+            forward_key: key.clone(),
+        };
+
+        let resolved = resolve_flow_session_decision(
+            &mut sessions,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &active_state,
+            &dynamic_neighbors,
+            &flow,
+            2_000_000,
+            2,
+            PROTO_TCP,
+            0x10,
+            6,
+            0,
+        )
+        .expect("resolved demoted session");
+
+        assert!(!resolved.created);
+        let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
+            panic!("promoted session missing");
+        };
+        assert_eq!(origin, SessionOrigin::SharedPromote);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -456,15 +456,15 @@ pub(super) fn reverse_resolution_for_session(
     now_secs: u64,
     allow_unseeded_tunnel_local: bool,
 ) -> ForwardingResolution {
-    if let Some(local) = super::interface_nat_local_resolution(forwarding, target_ip) {
-        return local;
-    }
     let resolved =
-        lookup_forwarding_resolution_with_dynamic(forwarding, dynamic_neighbors, target_ip);
+        super::interface_nat_local_resolution(forwarding, target_ip).unwrap_or_else(|| {
+            lookup_forwarding_resolution_with_dynamic(forwarding, dynamic_neighbors, target_ip)
+        });
+    let owner_rg_id = owner_rg_for_resolution(forwarding, resolved);
     if fabric_ingress
-        && owner_rg_for_resolution(forwarding, resolved) > 0
+        && owner_rg_id > 0
         && !matches!(
-            ha_state.get(&owner_rg_for_resolution(forwarding, resolved)),
+            ha_state.get(&owner_rg_id),
             Some(group) if group.is_forwarding_active(now_secs)
         )
         && let Some(redirect) = resolve_zone_encoded_fabric_redirect(forwarding, ingress_zone)

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -549,6 +549,7 @@ pub(super) enum WorkerCommand {
     UpsertSynced(SyncedSessionEntry),
     UpsertLocal(SyncedSessionEntry),
     DeleteSynced(SessionKey),
+    DemoteOwnerRGSessions { owner_rgs: Vec<i32> },
     ExportOwnerRGSessions { sequence: u64, owner_rgs: Vec<i32> },
 }
 

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -4,7 +4,7 @@
 //! happens on a stack-allocated `[u8; 256]` buffer.
 
 use crate::afxdp::ForwardingDisposition;
-use crate::session::{SessionDelta, SessionDecision, SessionKey, SessionMetadata};
+use crate::session::{SessionDecision, SessionDelta, SessionKey, SessionMetadata};
 use rustc_hash::FxHashMap;
 use std::net::IpAddr;
 
@@ -86,18 +86,15 @@ impl EventFrame {
 
         // [6:8] NATSrcPort LE
         let nat = &decision.nat;
-        buf[pos..pos + 2]
-            .copy_from_slice(&nat.rewrite_src_port.unwrap_or(0).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&nat.rewrite_src_port.unwrap_or(0).to_le_bytes());
         pos += 2;
 
         // [8:10] NATDstPort LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&nat.rewrite_dst_port.unwrap_or(0).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&nat.rewrite_dst_port.unwrap_or(0).to_le_bytes());
         pos += 2;
 
         // [10:12] OwnerRGID i16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&(metadata.owner_rg_id as i16).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&(metadata.owner_rg_id as i16).to_le_bytes());
         pos += 2;
 
         // [12:14] EgressIfindex i16 LE
@@ -106,18 +103,15 @@ impl EventFrame {
         pos += 2;
 
         // [14:16] TXIfindex i16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&(decision.resolution.tx_ifindex as i16).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&(decision.resolution.tx_ifindex as i16).to_le_bytes());
         pos += 2;
 
         // [16:18] TunnelEndpointID u16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&decision.resolution.tunnel_endpoint_id.to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&decision.resolution.tunnel_endpoint_id.to_le_bytes());
         pos += 2;
 
         // [18:20] TXVLANID u16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&decision.resolution.tx_vlan_id.to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&decision.resolution.tx_vlan_id.to_le_bytes());
         pos += 2;
 
         // [20] Flags
@@ -533,14 +527,23 @@ mod tests {
 
     #[test]
     fn test_disposition_encoding() {
-        assert_eq!(encode_disposition(ForwardingDisposition::ForwardCandidate), 0);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::ForwardCandidate),
+            0
+        );
         assert_eq!(encode_disposition(ForwardingDisposition::LocalDelivery), 1);
         assert_eq!(encode_disposition(ForwardingDisposition::FabricRedirect), 2);
         assert_eq!(encode_disposition(ForwardingDisposition::PolicyDenied), 3);
         assert_eq!(encode_disposition(ForwardingDisposition::NoRoute), 4);
-        assert_eq!(encode_disposition(ForwardingDisposition::MissingNeighbor), 5);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::MissingNeighbor),
+            5
+        );
         assert_eq!(encode_disposition(ForwardingDisposition::HAInactive), 6);
         assert_eq!(encode_disposition(ForwardingDisposition::DiscardRoute), 7);
-        assert_eq!(encode_disposition(ForwardingDisposition::NextTableUnsupported), 8);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::NextTableUnsupported),
+            8
+        );
     }
 }

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -11,7 +11,7 @@
 
 pub(crate) mod codec;
 
-pub(crate) use codec::{close_flags, EventFrame};
+pub(crate) use codec::{EventFrame, close_flags};
 
 use crate::session::{SessionDelta, SessionDeltaKind};
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
@@ -19,9 +19,9 @@ use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::io;
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TryRecvError};
-use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -649,17 +649,15 @@ fn handle_stream(
                     }
                 }
             }
-            "export_all_sessions" => {
-                match guard.afxdp.export_all_sessions_to_event_stream() {
-                    Ok(_count) => {
-                        refresh_status(&mut guard);
-                    }
-                    Err(err) => {
-                        response.ok = false;
-                        response.error = err;
-                    }
+            "export_all_sessions" => match guard.afxdp.export_all_sessions_to_event_stream() {
+                Ok(_count) => {
+                    refresh_status(&mut guard);
                 }
-            }
+                Err(err) => {
+                    response.ok = false;
+                    response.error = err;
+                }
+            },
             "rebind" => {
                 // After a link DOWN/UP cycle (e.g. RETH MAC programming),
                 // the kernel destroys the XSK receive queue.  Stop all

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -731,7 +731,11 @@ pub(crate) struct HAGroupStatus {
     pub watchdog_timestamp: u64,
     #[serde(rename = "forwarding_active", default)]
     pub forwarding_active: bool,
-    #[serde(rename = "lease_state", default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        rename = "lease_state",
+        default,
+        skip_serializing_if = "String::is_empty"
+    )]
     pub lease_state: String,
     #[serde(rename = "lease_until", default, skip_serializing_if = "u64_is_zero")]
     pub lease_until: u64,


### PR DESCRIPTION
## Summary
- wait for the local side of a batched/manual transfer to settle before the peer finalizes demotion
- keep demoted peer-synced local-delivery sessions on XSK redirect instead of republishing them as kernel-local on the old owner
- send the first direct-mode VIP/MAC announce synchronously before the transfer is considered settled

## Root cause
Issue #536 was actually two coupled bugs:
1. On demotion, worker-side `DemoteOwnerRGSessions` republished peer-synced `LocalDelivery` sessions through the generic session-map writer. That could emit `PASS_TO_KERNEL` on the old owner, and the old owner's kernel would answer stray packets with RSTs.
2. In direct mode, the target node could report the local transfer as ready before it had emitted the first GARP/NA burst. That let the peer finish demotion before the MAC/VIP move had actually been announced.

## Validation
- `go test ./pkg/cluster ./pkg/daemon -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml session_glue::tests -- --nocapture`
- `go test ./pkg/daemon -run 'TestScheduleDirectAnnounce|TestWaitLocalFailoverCommitReady' -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml worker_synced_local_delivery_ -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_demotes_local_owner_rg_sessions_to_sync_import -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml reverse_session_blocks_inactive_interface_snat_ipv4_local_delivery -- --nocapture`

## Live loss validation
Deployed the dirty branch to `loss` and ran repeated direct `data node1 -> node0` failover/failback under 30s one-stream `iperf3` load.

Before the fixes, repeated runs still produced zero-throughput collapse after failback and captured old-owner RSTs.

After the fixes:
- `/tmp/issue536-rerun-20260406-224125`: `avg 9.85 Gbps`, `zero_intervals 0`, `retransmits 400`
- `/tmp/issue536-repeat-announcefix-20260406-224751/run1`: `zero_intervals 0`
- `/tmp/issue536-repeat-announcefix-20260406-224751/run2`: `zero_intervals 0`
- `/tmp/issue536-repeat-announcefix-20260406-224751/run3`: `zero_intervals 0`

The remaining behavior is a brief throughput dip at failover/failback, but the long failback-to-zero collapse no longer reproduced on the announce-ordered build.
