### PR TITLE
fix: drain session deltas on standby to unblock failover validator

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-04-07
+
+- **Timestamp**: 2026-04-07T06:10:00Z
+  - **Action**: Issue #533 — Fix failover validator idle gate blocked by "Session delta drained" staying at 0 on standby. Root cause: `eventStreamFallbackLoop` and `syncUserspaceSessionDeltas` both gated `DrainSessionDeltas` calls behind `IsLocalPrimaryAny()`, so the standby never drained deltas from the Rust helper. Added `discardUserspaceSessionDeltas()` that drains without queuing for sync, called on standby/disconnected nodes. Added unit test.
+  - **File(s)**: pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
+
 ## 2026-04-05
 
 - **Timestamp**: 2026-04-05T22:00:00Z

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -717,19 +717,24 @@ func (d *Daemon) syncUserspaceSessionDeltas(ctx context.Context) {
 		if d.cluster == nil || d.sessionSync == nil {
 			return
 		}
-		if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
-			continue
-		}
+		isPrimary := d.cluster.IsLocalPrimaryAny()
+		syncConnected := d.sessionSync.IsConnected()
 		cfg := d.store.ActiveConfig()
 		if cfg == nil {
 			continue
 		}
 		d.userspaceDeltaSyncMu.Lock()
-		_, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
-		d.userspaceDeltaSyncMu.Unlock()
-		if err != nil {
-			slog.Debug("userspace session delta drain failed", "err", err)
+		if isPrimary && syncConnected {
+			_, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
+			if err != nil {
+				slog.Debug("userspace session delta drain failed", "err", err)
+			}
+		} else {
+			// Standby or sync disconnected: drain deltas to advance the
+			// helper counter but discard them (don't queue for sync).
+			d.discardUserspaceSessionDeltas(drainer)
 		}
+		d.userspaceDeltaSyncMu.Unlock()
 	}
 }
 
@@ -875,47 +880,46 @@ func (d *Daemon) eventStreamFallbackLoop(ctx context.Context, provider userspace
 			}
 		}
 
-		if connected {
-			// Stream is live — run reconciliation drain to catch any
-			// missed events, but at the slow 5s cadence.
-			if !hasDrainer {
-				continue
-			}
-			if d.cluster == nil || d.sessionSync == nil {
-				return
-			}
-			if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
-				continue
-			}
-			cfg := d.store.ActiveConfig()
-			if cfg == nil {
-				continue
-			}
-			d.userspaceDeltaSyncMu.Lock()
-			n, _ := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
-			d.userspaceDeltaSyncMu.Unlock()
-			if n > 0 {
-				slog.Info("userspace: reconciliation drain caught missed deltas", "count", n)
-			}
-			continue
-		}
-
-		// Stream disconnected — fall back to fast polling.
 		if !hasDrainer {
 			continue
 		}
 		if d.cluster == nil || d.sessionSync == nil {
 			return
 		}
-		if !d.cluster.IsLocalPrimaryAny() || !d.sessionSync.IsConnected() {
+		isPrimary := d.cluster.IsLocalPrimaryAny()
+		syncConnected := d.sessionSync.IsConnected()
+
+		if connected {
+			// Stream is live — run reconciliation drain to catch any
+			// missed events, but at the slow 5s cadence.
+			cfg := d.store.ActiveConfig()
+			if cfg == nil {
+				continue
+			}
+			d.userspaceDeltaSyncMu.Lock()
+			if isPrimary && syncConnected {
+				n, _ := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
+				if n > 0 {
+					slog.Info("userspace: reconciliation drain caught missed deltas", "count", n)
+				}
+			} else {
+				d.discardUserspaceSessionDeltas(drainer)
+			}
+			d.userspaceDeltaSyncMu.Unlock()
 			continue
 		}
+
+		// Stream disconnected — fall back to fast polling.
 		cfg := d.store.ActiveConfig()
 		if cfg == nil {
 			continue
 		}
 		d.userspaceDeltaSyncMu.Lock()
-		_, _ = d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
+		if isPrimary && syncConnected {
+			_, _ = d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
+		} else {
+			d.discardUserspaceSessionDeltas(drainer)
+		}
 		d.userspaceDeltaSyncMu.Unlock()
 	}
 }
@@ -1022,6 +1026,25 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 		}
 	}
 	return total, nil
+}
+
+// discardUserspaceSessionDeltas drains pending deltas from the Rust helper
+// without queuing them for sync. This advances the helper's "session delta
+// drained" counter on the standby node where deltas are generated (by
+// incoming session sync installs) but must not be sent back to the primary.
+func (d *Daemon) discardUserspaceSessionDeltas(drainer userspaceSessionDeltaDrainer) {
+	if drainer == nil {
+		return
+	}
+	for {
+		deltas, _, err := drainer.DrainSessionDeltas(256)
+		if err != nil || len(deltas) == 0 {
+			return
+		}
+		if len(deltas) < 256 {
+			return
+		}
+	}
 }
 
 func (d *Daemon) exportUserspaceOwnerRGSessionsWithConfig(

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -24,6 +24,11 @@ import (
 	"github.com/psaab/bpfrx/pkg/vrrp"
 )
 
+const (
+	userspaceSessionDeltaBatchSize = 256
+	userspaceDiscardSessionBatches = 16
+)
+
 func (d *Daemon) stopSyncReadyTimer() {
 	d.syncReadyTimerMu.Lock()
 	defer d.syncReadyTimerMu.Unlock()
@@ -719,22 +724,24 @@ func (d *Daemon) syncUserspaceSessionDeltas(ctx context.Context) {
 		}
 		isPrimary := d.cluster.IsLocalPrimaryAny()
 		syncConnected := d.sessionSync.IsConnected()
-		cfg := d.store.ActiveConfig()
-		if cfg == nil {
-			continue
-		}
-		d.userspaceDeltaSyncMu.Lock()
 		if isPrimary && syncConnected {
-			_, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
+			cfg := d.store.ActiveConfig()
+			if cfg == nil {
+				continue
+			}
+			d.userspaceDeltaSyncMu.Lock()
+			_, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1, userspaceSessionDeltaBatchSize)
+			d.userspaceDeltaSyncMu.Unlock()
 			if err != nil {
 				slog.Debug("userspace session delta drain failed", "err", err)
 			}
 		} else {
 			// Standby or sync disconnected: drain deltas to advance the
 			// helper counter but discard them (don't queue for sync).
-			d.discardUserspaceSessionDeltas(drainer)
+			d.userspaceDeltaSyncMu.Lock()
+			d.discardUserspaceSessionDeltas(drainer, userspaceSessionDeltaBatchSize, userspaceDiscardSessionBatches)
+			d.userspaceDeltaSyncMu.Unlock()
 		}
-		d.userspaceDeltaSyncMu.Unlock()
 	}
 }
 
@@ -892,35 +899,39 @@ func (d *Daemon) eventStreamFallbackLoop(ctx context.Context, provider userspace
 		if connected {
 			// Stream is live — run reconciliation drain to catch any
 			// missed events, but at the slow 5s cadence.
+			if isPrimary && syncConnected {
+				cfg := d.store.ActiveConfig()
+				if cfg == nil {
+					continue
+				}
+				d.userspaceDeltaSyncMu.Lock()
+				n, _ := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1, userspaceSessionDeltaBatchSize)
+				d.userspaceDeltaSyncMu.Unlock()
+				if n > 0 {
+					slog.Info("userspace: reconciliation drain caught missed deltas", "count", n)
+				}
+			} else {
+				d.userspaceDeltaSyncMu.Lock()
+				d.discardUserspaceSessionDeltas(drainer, userspaceSessionDeltaBatchSize, userspaceDiscardSessionBatches)
+				d.userspaceDeltaSyncMu.Unlock()
+			}
+			continue
+		}
+
+		// Stream disconnected — fall back to fast polling.
+		if isPrimary && syncConnected {
 			cfg := d.store.ActiveConfig()
 			if cfg == nil {
 				continue
 			}
 			d.userspaceDeltaSyncMu.Lock()
-			if isPrimary && syncConnected {
-				n, _ := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
-				if n > 0 {
-					slog.Info("userspace: reconciliation drain caught missed deltas", "count", n)
-				}
-			} else {
-				d.discardUserspaceSessionDeltas(drainer)
-			}
+			_, _ = d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1, userspaceSessionDeltaBatchSize)
 			d.userspaceDeltaSyncMu.Unlock()
-			continue
-		}
-
-		// Stream disconnected — fall back to fast polling.
-		cfg := d.store.ActiveConfig()
-		if cfg == nil {
-			continue
-		}
-		d.userspaceDeltaSyncMu.Lock()
-		if isPrimary && syncConnected {
-			_, _ = d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 1)
 		} else {
-			d.discardUserspaceSessionDeltas(drainer)
+			d.userspaceDeltaSyncMu.Lock()
+			d.discardUserspaceSessionDeltas(drainer, userspaceSessionDeltaBatchSize, userspaceDiscardSessionBatches)
+			d.userspaceDeltaSyncMu.Unlock()
 		}
-		d.userspaceDeltaSyncMu.Unlock()
 	}
 }
 
@@ -1006,14 +1017,15 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 	drainer userspaceSessionDeltaDrainer,
 	cfg *config.Config,
 	maxBatches int,
+	batchSize uint32,
 ) (int, error) {
-	if drainer == nil || cfg == nil || maxBatches <= 0 {
+	if drainer == nil || cfg == nil || maxBatches <= 0 || batchSize == 0 {
 		return 0, nil
 	}
 	zoneIDs := buildZoneIDs(cfg)
 	total := 0
 	for batch := 0; batch < maxBatches; batch++ {
-		deltas, _, err := drainer.DrainSessionDeltas(256)
+		deltas, _, err := drainer.DrainSessionDeltas(batchSize)
 		if err != nil {
 			return total, err
 		}
@@ -1021,7 +1033,7 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 			break
 		}
 		total += d.queueUserspaceSessionDeltas(zoneIDs, deltas)
-		if len(deltas) < 256 {
+		if len(deltas) < int(batchSize) {
 			break
 		}
 	}
@@ -1032,16 +1044,20 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 // without queuing them for sync. This advances the helper's "session delta
 // drained" counter on the standby node where deltas are generated (by
 // incoming session sync installs) but must not be sent back to the primary.
-func (d *Daemon) discardUserspaceSessionDeltas(drainer userspaceSessionDeltaDrainer) {
-	if drainer == nil {
+func (d *Daemon) discardUserspaceSessionDeltas(
+	drainer userspaceSessionDeltaDrainer,
+	batchSize uint32,
+	maxBatches int,
+) {
+	if drainer == nil || batchSize == 0 || maxBatches <= 0 {
 		return
 	}
-	for {
-		deltas, _, err := drainer.DrainSessionDeltas(256)
+	for batch := 0; batch < maxBatches; batch++ {
+		deltas, _, err := drainer.DrainSessionDeltas(batchSize)
 		if err != nil || len(deltas) == 0 {
 			return
 		}
-		if len(deltas) < 256 {
+		if len(deltas) < int(batchSize) {
 			return
 		}
 	}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -565,7 +565,7 @@ func TestDrainUserspaceSessionDeltasWithConfigDrainsPreparedBatches(t *testing.T
 		"wan": {Name: "wan"},
 	}
 
-	queued, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 8)
+	queued, err := d.drainUserspaceSessionDeltasWithConfig(drainer, cfg, 8, userspaceSessionDeltaBatchSize)
 	if err != nil {
 		t.Fatalf("drainUserspaceSessionDeltasWithConfig() error = %v", err)
 	}
@@ -604,7 +604,7 @@ func TestDiscardUserspaceSessionDeltasDrainsWithoutQueuing(t *testing.T) {
 	}
 	d := &Daemon{}
 
-	d.discardUserspaceSessionDeltas(drainer)
+	d.discardUserspaceSessionDeltas(drainer, userspaceSessionDeltaBatchSize, userspaceDiscardSessionBatches)
 
 	// Should have drained both batches (first was full 256, so loop continued;
 	// second was <256, so loop stopped).
@@ -614,6 +614,36 @@ func TestDiscardUserspaceSessionDeltasDrainsWithoutQueuing(t *testing.T) {
 	// No batches left.
 	if len(drainer.batches) != 0 {
 		t.Fatalf("remaining batches = %d, want 0", len(drainer.batches))
+	}
+}
+
+func TestDiscardUserspaceSessionDeltasStopsAtBatchBudget(t *testing.T) {
+	fullBatch := make([]dpuserspace.SessionDeltaInfo, userspaceSessionDeltaBatchSize)
+	for i := range fullBatch {
+		fullBatch[i] = dpuserspace.SessionDeltaInfo{
+			Event:      "open",
+			AddrFamily: dataplane.AFInet,
+			Protocol:   6,
+			SrcIP:      "10.0.1.1",
+			DstIP:      "10.0.2.1",
+			SrcPort:    uint16(10000 + i),
+			DstPort:    80,
+		}
+	}
+	batches := make([][]dpuserspace.SessionDeltaInfo, userspaceDiscardSessionBatches+2)
+	for i := range batches {
+		batches[i] = append([]dpuserspace.SessionDeltaInfo(nil), fullBatch...)
+	}
+	drainer := &fakeUserspaceDeltaDrainer{batches: batches}
+	d := &Daemon{}
+
+	d.discardUserspaceSessionDeltas(drainer, userspaceSessionDeltaBatchSize, userspaceDiscardSessionBatches)
+
+	if drainer.calls != userspaceDiscardSessionBatches {
+		t.Fatalf("drain calls = %d, want %d", drainer.calls, userspaceDiscardSessionBatches)
+	}
+	if want := 2; len(drainer.batches) != want {
+		t.Fatalf("remaining batches = %d, want %d", len(drainer.batches), want)
 	}
 }
 

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -577,6 +577,46 @@ func TestDrainUserspaceSessionDeltasWithConfigDrainsPreparedBatches(t *testing.T
 	}
 }
 
+func TestDiscardUserspaceSessionDeltasDrainsWithoutQueuing(t *testing.T) {
+	firstBatch := make([]dpuserspace.SessionDeltaInfo, 256)
+	for i := range firstBatch {
+		firstBatch[i] = dpuserspace.SessionDeltaInfo{
+			Event:      "open",
+			AddrFamily: dataplane.AFInet,
+			Protocol:   6,
+			SrcIP:      "10.0.1.1",
+			DstIP:      "10.0.2.1",
+			SrcPort:    uint16(10000 + i),
+			DstPort:    80,
+		}
+	}
+	secondBatch := []dpuserspace.SessionDeltaInfo{{
+		Event:      "open",
+		AddrFamily: dataplane.AFInet,
+		Protocol:   6,
+		SrcIP:      "10.0.1.1",
+		DstIP:      "10.0.2.1",
+		SrcPort:    20001,
+		DstPort:    80,
+	}}
+	drainer := &fakeUserspaceDeltaDrainer{
+		batches: [][]dpuserspace.SessionDeltaInfo{firstBatch, secondBatch},
+	}
+	d := &Daemon{}
+
+	d.discardUserspaceSessionDeltas(drainer)
+
+	// Should have drained both batches (first was full 256, so loop continued;
+	// second was <256, so loop stopped).
+	if drainer.calls != 2 {
+		t.Fatalf("drain calls = %d, want 2", drainer.calls)
+	}
+	// No batches left.
+	if len(drainer.batches) != 0 {
+		t.Fatalf("remaining batches = %d, want 0", len(drainer.batches))
+	}
+}
+
 func TestExportUserspaceOwnerRGSessionsWithConfigQueuesForwardWireAlias(t *testing.T) {
 	exporter := &fakeUserspaceSessionExporter{
 		deltas: []dpuserspace.SessionDeltaInfo{{


### PR DESCRIPTION
## Summary
- The failover validator's `wait_for_session_sync_idle` gate checks "Session delta drained" on the standby node, but the counter stayed at 0 because all three delta drain sites (`syncUserspaceSessionDeltas`, `eventStreamFallbackLoop` connected path, and disconnected path) were gated behind `IsLocalPrimaryAny()` — the standby never drained deltas from the Rust helper.
- Added `discardUserspaceSessionDeltas()` which drains deltas without queuing them for sync, preventing a feedback loop where synced sessions would generate deltas sent back to the primary.
- All drain code paths now call `discardUserspaceSessionDeltas` on standby/disconnected nodes instead of skipping entirely.

## Test plan
- [x] `go build` passes
- [x] `go test ./pkg/daemon/` passes (including new `TestDiscardUserspaceSessionDeltasDrainsWithoutQueuing`)
- [ ] `make cluster-deploy` and verify "Session delta drained" counter advances on standby node via `cli -c "show chassis cluster data-plane statistics"`
- [ ] `make test-failover` passes (validator idle gate no longer blocks)

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)