### PR TITLE
fix: generate ICMP Time Exceeded on session-hit and flow-cache-hit paths

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-04-07
+
+- **Timestamp**: 2026-04-07T00:00:00Z
+  - **Action**: Issue #532 — Fix IPv6 TTL-expired (hop limit exceeded) probe responses not being returned in userspace dataplane. Added TTL/hop-limit check with ICMP Time Exceeded generation to both session-hit and flow-cache-hit paths. Previously only the session-miss path generated TE responses; subsequent packets hitting an existing session or flow cache were silently dropped when TTL<=1 because the rewrite functions returned None without generating a response.
+  - **File(s)**: userspace-dp/src/afxdp.rs
+
 ## 2026-04-05
 
 - **Timestamp**: 2026-04-05T22:00:00Z

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -2498,6 +2498,31 @@ fn poll_binding(
                                     ForwardingDisposition::ForwardCandidate
                                         | ForwardingDisposition::FabricRedirect
                                 ) {
+                                    // TTL/hop-limit check on flow cache hit path:
+                                    // generate ICMP Time Exceeded for packets that
+                                    // would expire after decrement.
+                                    let local_icmp_te = unsafe { &*area }
+                                        .slice(desc.addr as usize, desc.len as usize)
+                                        .and_then(|frame| {
+                                            build_local_time_exceeded_request(
+                                                frame,
+                                                desc,
+                                                meta,
+                                                &ident,
+                                                flow,
+                                                forwarding,
+                                                dynamic_neighbors,
+                                                ha_state,
+                                                now_secs,
+                                            )
+                                        });
+                                    if let Some(request) = local_icmp_te {
+                                        binding.scratch_forwards.push(request);
+                                        // Don't recycle here — enqueue_pending_forwards
+                                        // returns the frame via pending_fill_frames
+                                        // when processing the prebuilt TE response.
+                                        continue;
+                                    }
                                     counters.forward_candidate_packets += 1;
                                     if cached_decision.nat.rewrite_src.is_some() {
                                         counters.snat_packets += 1;
@@ -2680,6 +2705,39 @@ fn poll_binding(
                             }
                             session_ingress_zone = Some(resolved.metadata.ingress_zone.clone());
                             apply_nat_on_fabric = true;
+                            // TTL/hop-limit check on session-hit path: generate
+                            // ICMP Time Exceeded for packets that would expire
+                            // after decrement. The session-miss path handles this
+                            // in build_local_time_exceeded_request(); the session-
+                            // hit path previously silently dropped these packets
+                            // (the rewrite functions return None for TTL<=1).
+                            if matches!(
+                                resolved.decision.resolution.disposition,
+                                ForwardingDisposition::ForwardCandidate
+                            ) {
+                                let local_icmp_te = unsafe { &*area }
+                                    .slice(desc.addr as usize, desc.len as usize)
+                                    .and_then(|frame| {
+                                        build_local_time_exceeded_request(
+                                            frame,
+                                            desc,
+                                            meta,
+                                            &ident,
+                                            flow,
+                                            forwarding,
+                                            dynamic_neighbors,
+                                            ha_state,
+                                            now_secs,
+                                        )
+                                    });
+                                if let Some(request) = local_icmp_te {
+                                    binding.scratch_forwards.push(request);
+                                    // Don't recycle: the TE response references
+                                    // the original frame via desc in its source_offset.
+                                    // The continue skips recycle_now handling.
+                                    continue;
+                                }
+                            }
                             resolved.decision
                         } else {
                             counters.session_misses += 1;


### PR DESCRIPTION
## Summary
- Add TTL/hop-limit expiry check with ICMPv6/ICMP Time Exceeded generation to **session-hit** and **flow-cache-hit** paths in the userspace dataplane
- Previously only the session-miss path (new flows) generated TE responses via `build_local_time_exceeded_request()`; packets hitting an existing session or flow cache entry with TTL/hop_limit<=1 were silently dropped because the frame rewrite functions (`apply_rewrite_descriptor`, `rewrite_forwarded_frame_in_place`, `build_forwarded_frame`) return `None` for expired TTL without generating a response
- This matches the BPF pipeline behavior where `xdp_forward` and `xdp_nat` check TTL and `XDP_PASS` to the kernel for Time Exceeded generation

## Test plan
- [x] `cargo build --release` passes (0 new warnings)
- [x] `cargo test --release` passes (435/435 tests)
- [ ] Deploy to test VM and verify `ping6 -t 1 <external_addr>` returns ICMPv6 Time Exceeded
- [ ] Verify IPv4 `ping -t 1 <external_addr>` still returns ICMP Time Exceeded
- [ ] Verify normal forwarding (TTL>1) is not affected by the new check

Fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)