### PR TITLE
fix: keep missing-neighbor seeds out of HA sync

### DIFF
--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -18,7 +18,6 @@ import (
 	dpuserspace "github.com/psaab/bpfrx/pkg/dataplane/userspace"
 )
 
-
 // buildZoneIDs replicates the deterministic zone ID assignment from the
 // dataplane compiler (sorted zone names, 1-based sequential IDs).
 func buildZoneIDs(cfg *config.Config) map[string]uint16 {
@@ -339,6 +338,10 @@ func (d *Daemon) shouldSyncUserspaceDelta(delta dpuserspace.SessionDeltaInfo, in
 	// See #315 for discussion.
 	if strings.EqualFold(delta.Disposition, "local_delivery") {
 		slog.Debug("userspace delta: filtered (local_delivery)", "src", delta.SrcIP, "dst", delta.DstIP)
+		return false
+	}
+	if strings.EqualFold(delta.Origin, "missing_neighbor_seed") {
+		slog.Debug("userspace delta: filtered (missing_neighbor_seed)", "src", delta.SrcIP, "dst", delta.DstIP)
 		return false
 	}
 	if delta.FabricRedirect && !delta.FabricIngress {

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -482,6 +482,18 @@ func TestShouldSyncUserspaceDeltaSkipsLocalDelivery(t *testing.T) {
 	}
 }
 
+func TestShouldSyncUserspaceDeltaSkipsMissingNeighborSeed(t *testing.T) {
+	d := &Daemon{
+		sessionSync: &cluster.SessionSync{
+			IsPrimaryFn:      func() bool { return true },
+			IsPrimaryForRGFn: func(rgID int) bool { return true },
+		},
+	}
+	if d.shouldSyncUserspaceDelta(dpuserspace.SessionDeltaInfo{Origin: "missing_neighbor_seed"}, 1) {
+		t.Fatal("expected transient missing-neighbor seed deltas to stay out of session sync")
+	}
+}
+
 func TestShouldSyncUserspaceDeltaAllowsStaleOwnerFabricRedirect(t *testing.T) {
 	ss := &cluster.SessionSync{
 		IsPrimaryFn:      func() bool { return false },

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -217,7 +217,11 @@ fn export_forward_sessions_for_owner_rgs(sessions: &mut SessionTable, owner_rgs:
         let Some((decision, metadata, origin)) = sessions.entry_with_origin(&key) else {
             continue;
         };
-        if metadata.is_reverse || origin.is_peer_synced() || metadata.fabric_ingress {
+        if metadata.is_reverse
+            || origin.is_peer_synced()
+            || origin.is_transient_local_seed()
+            || metadata.fabric_ingress
+        {
             continue;
         }
         if !matches!(
@@ -2438,6 +2442,58 @@ mod tests {
         assert_eq!(deltas.len(), 1, "export should republish forward session");
         assert_eq!(deltas[0].kind, SessionDeltaKind::Open);
         assert!(deltas[0].fabric_redirect_sync);
+    }
+
+    #[test]
+    fn apply_worker_commands_does_not_export_missing_neighbor_seed_sessions() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let metadata = SessionMetadata {
+            owner_rg_id: 1,
+            ..test_metadata()
+        };
+        assert!(sessions.install_with_protocol_with_origin(
+            key,
+            test_decision(),
+            metadata,
+            SessionOrigin::MissingNeighborSeed,
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        assert!(
+            sessions.drain_deltas(16).is_empty(),
+            "missing-neighbor seed install should not emit open deltas"
+        );
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::ExportOwnerRGSessions {
+                sequence: 10,
+                owner_rgs: vec![1],
+            });
+        let forwarding = test_forwarding_state_with_fabric();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let mut ha_state = BTreeMap::new();
+        ha_state.insert(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000));
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        assert_eq!(results.exported_sequences, vec![10]);
+        assert!(
+            sessions.drain_deltas(16).is_empty(),
+            "missing-neighbor seed sessions must not be exported as HA deltas"
+        );
     }
 
     #[test]

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -286,7 +286,10 @@ impl SessionTable {
                         decision.nat.rewrite_dst,
                     );
                 }
-                if !metadata.is_reverse && !entry.origin.is_peer_synced() {
+                if !metadata.is_reverse
+                    && !entry.origin.is_peer_synced()
+                    && !entry.origin.is_transient_local_seed()
+                {
                     self.push_delta(SessionDelta {
                         kind: SessionDeltaKind::Close,
                         key: key.clone(),
@@ -1141,6 +1144,28 @@ mod tests {
             table.drain_deltas(8).is_empty(),
             "transient missing-neighbor seeds must stay local"
         );
+    }
+
+    #[test]
+    fn missing_neighbor_seed_expire_stays_out_of_delta_stream() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let then = 1_000_000_000u64;
+        assert!(table.install_with_protocol_with_origin(
+            key.clone(),
+            decision(),
+            metadata(),
+            SessionOrigin::MissingNeighborSeed,
+            then,
+            PROTO_TCP,
+            0x10
+        ));
+        assert!(table.drain_deltas(8).is_empty());
+        table.last_gc_ns = then + 301_000_000_000;
+        let expired = table.expire_stale_entries(then + 302_000_000_000);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].key, key);
+        assert!(table.drain_deltas(8).is_empty());
     }
 
     #[test]

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -159,6 +159,10 @@ impl SessionOrigin {
             Self::SyncImport | Self::SharedMaterialize | Self::WorkerLocalImport
         )
     }
+
+    pub(crate) fn is_transient_local_seed(self) -> bool {
+        matches!(self, Self::MissingNeighborSeed)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -460,7 +464,7 @@ impl SessionTable {
             },
         );
         self.index_forward_nat_key(&key, decision, &metadata);
-        if !metadata.is_reverse && !origin.is_peer_synced() {
+        if !metadata.is_reverse && !origin.is_peer_synced() && !origin.is_transient_local_seed() {
             self.push_delta(SessionDelta {
                 kind: SessionDeltaKind::Open,
                 key,
@@ -1118,6 +1122,25 @@ mod tests {
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].kind, SessionDeltaKind::Open);
         assert_eq!(deltas[0].key, key);
+    }
+
+    #[test]
+    fn missing_neighbor_seed_install_stays_out_of_delta_stream() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        assert!(table.install_with_protocol_with_origin(
+            key,
+            decision(),
+            metadata(),
+            SessionOrigin::MissingNeighborSeed,
+            1_000_000_000,
+            PROTO_TCP,
+            0x10
+        ));
+        assert!(
+            table.drain_deltas(8).is_empty(),
+            "transient missing-neighbor seeds must stay local"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep transient `MissingNeighborSeed` sessions out of the helper delta stream
- skip them during owner-RG export and on the daemon-side userspace sync filter
- add targeted helper and daemon regressions

## Why
On `loss`, stock RG1 failover/failback on clean `master` can leave long-lived TCP streams stuck at `0`. The concrete root cause is that transient neighbor-repair seed sessions were still being treated like authoritative HA session state and could leak across failover.

Closes #562.

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml missing_neighbor_seed_install_stays_out_of_delta_stream -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_does_not_export_missing_neighbor_seed_sessions -- --nocapture`
- `go test ./pkg/daemon -run 'TestShouldSyncUserspaceDelta(SkipsMissingNeighborSeed|SkipsLocalDelivery|PrefersOwnerRG|FallsBackToZone|AllowsStaleOwnerFabricRedirect|DoesNotBypassFabricIngress)$' -count=1`
