### PR TITLE
fix: settle idle standby XSK liveness without incidental traffic

### DIFF
--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -2915,7 +2915,17 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 					m.xskProbeStart = time.Now()
 					slog.Info("userspace: starting XSK liveness probe")
 				} else if time.Now().After(m.xskProbeStart.Add(10 * time.Second)) {
-					if m.shouldExtendXSKLivenessIdleLocked(currentRX, allBindingsBound) {
+					if m.shouldAutoProveIdleStandbyXSKLocked(currentRX, allBindingsBound) {
+						m.xskLivenessProven = true
+						m.xskProbeStart = time.Time{}
+						if m.inner.XDPEntryProg != "xdp_userspace_prog" {
+							if err := m.inner.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
+								slog.Warn("userspace: failed to restore XDP shim after idle standby liveness success", "err", err)
+							}
+						}
+						slog.Info("userspace: XSK liveness proven on idle standby")
+						goto ctrlReady
+					} else if m.shouldExtendXSKLivenessIdleLocked(currentRX, allBindingsBound) {
 						m.xskProbeStart = time.Now()
 						slog.Info("userspace: extending XSK liveness probe while idle")
 						goto ctrlReady

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -301,10 +301,17 @@ func (m *Manager) shouldExtendXSKLivenessIdleLocked(currentRX uint64, allBinding
 	if currentRX != 0 {
 		return false
 	}
+	if m.shouldAutoProveIdleStandbyXSKLocked(currentRX, allBindingsBound) {
+		return false
+	}
 	if allBindingsBound {
 		return true
 	}
 	return !m.hasActiveDataRGLocked()
+}
+
+func (m *Manager) shouldAutoProveIdleStandbyXSKLocked(currentRX uint64, allBindingsBound bool) bool {
+	return currentRX == 0 && allBindingsBound && !m.hasActiveDataRGLocked()
 }
 
 func (m *Manager) configHasDataRGLocked() bool {

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1470,15 +1470,39 @@ func TestShouldExtendXSKLivenessIdleLocked(t *testing.T) {
 	if !m.shouldExtendXSKLivenessIdleLocked(0, false) {
 		t.Fatal("shouldExtendXSKLivenessIdleLocked(0) = false, want true with no active data RG")
 	}
-	m.haGroups[1] = HAGroupStatus{RGID: 1, Active: true}
-	if !m.shouldExtendXSKLivenessIdleLocked(0, true) {
-		t.Fatal("shouldExtendXSKLivenessIdleLocked(0, true) = false, want true when all bindings are bound")
+	if m.shouldExtendXSKLivenessIdleLocked(0, true) {
+		t.Fatal("shouldExtendXSKLivenessIdleLocked(0, true) = true, want false when idle standby should auto-prove")
 	}
+	m.haGroups[1] = HAGroupStatus{RGID: 1, Active: true}
 	if m.shouldExtendXSKLivenessIdleLocked(0, false) {
 		t.Fatal("shouldExtendXSKLivenessIdleLocked(0) = true, want false with active data RG")
 	}
+	if !m.shouldExtendXSKLivenessIdleLocked(0, true) {
+		t.Fatal("shouldExtendXSKLivenessIdleLocked(0, true) = false, want true when active dataplane is fully bound but still idle")
+	}
 	if m.shouldExtendXSKLivenessIdleLocked(42, true) {
 		t.Fatal("shouldExtendXSKLivenessIdleLocked(42) = true, want false when RX is already live")
+	}
+}
+
+func TestShouldAutoProveIdleStandbyXSKLocked(t *testing.T) {
+	m := &Manager{
+		haGroups: map[int]HAGroupStatus{
+			0: {RGID: 0, Active: true},
+		},
+	}
+	if !m.shouldAutoProveIdleStandbyXSKLocked(0, true) {
+		t.Fatal("shouldAutoProveIdleStandbyXSKLocked(0, true) = false, want true on fully bound idle standby")
+	}
+	if m.shouldAutoProveIdleStandbyXSKLocked(0, false) {
+		t.Fatal("shouldAutoProveIdleStandbyXSKLocked(0, false) = true, want false when bindings are not fully bound")
+	}
+	m.haGroups[1] = HAGroupStatus{RGID: 1, Active: true}
+	if m.shouldAutoProveIdleStandbyXSKLocked(0, true) {
+		t.Fatal("shouldAutoProveIdleStandbyXSKLocked(0, true) = true, want false when a data RG is active")
+	}
+	if m.shouldAutoProveIdleStandbyXSKLocked(42, true) {
+		t.Fatal("shouldAutoProveIdleStandbyXSKLocked(42, true) = true, want false when RX is already live")
 	}
 }
 


### PR DESCRIPTION
## Summary
- auto-prove XSK liveness on a fully bound idle standby instead of extending the idle probe forever
- restore the userspace XDP shim and exit the probe-timeout path cleanly on idle-standby success
- add readiness regressions for idle standby auto-prove versus real active-data-RG idle cases

Closes #564.

## Testing
- go test ./pkg/dataplane/userspace -run 'Test(ShouldExtendXSKLivenessIdleLocked|ShouldAutoProveIdleStandbyXSKLocked|TakeoverReadyReportsSessionMirrorFailure)$' -count=1
