### PR TITLE
fix: keep HA standby neighbor resolution warm

### DIFF
--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -67,37 +67,38 @@ type Manager struct {
 	dataplane.DataPlane
 	inner *dataplane.Manager
 
-	mu                  sync.Mutex
-	sessionMu           sync.Mutex // separate lock for session sync requests (Phase 3)
-	proc                *exec.Cmd
-	cfg                 config.UserspaceConfig
-	clusterHA           bool
-	generation          uint64
-	syncCancel          context.CancelFunc
-	lastStatus          ProcessStatus
-	lastSnapshot        *ConfigSnapshot
-	haGroups            map[int]HAGroupStatus
-	lastIngressIfaces   []uint32
-	lastRSTv4           []netip.Addr
-	lastRSTv6           []netip.Addr
-	lastSnapshotHash    [32]byte // content hash of last published snapshot (excludes volatile fields)
-	lastBindingIndices  []uint32
-	neighborsPrewarmed  bool
-	ctrlEnableAt        time.Time
-	ctrlWasEnabled      bool
-	ctrlDisabledAt      uint64    // monotonic ktime_ns when ctrl was last disabled
-	lastDemotionTime    time.Time // wall clock when last RG demotion occurred
-	xskLivenessFailed   bool
-	xskLivenessProven   bool
-	xskProbeStart       time.Time
-	lastXSKRX           uint64
-	lastNAPIBootstrap   time.Time
-	publishedSnapshot   uint64
-	publishedPlanKey    string
-	sessionMirrorFailed bool
-	sessionMirrorErr    string
-	deferWorkers        bool // skip worker spawn until NotifyLinkCycle
-	xskBoundNotified    bool // OnXSKBound fired at most once
+	mu                      sync.Mutex
+	sessionMu               sync.Mutex // separate lock for session sync requests (Phase 3)
+	proc                    *exec.Cmd
+	cfg                     config.UserspaceConfig
+	clusterHA               bool
+	generation              uint64
+	syncCancel              context.CancelFunc
+	lastStatus              ProcessStatus
+	lastSnapshot            *ConfigSnapshot
+	haGroups                map[int]HAGroupStatus
+	lastIngressIfaces       []uint32
+	lastRSTv4               []netip.Addr
+	lastRSTv6               []netip.Addr
+	lastSnapshotHash        [32]byte // content hash of last published snapshot (excludes volatile fields)
+	lastBindingIndices      []uint32
+	neighborsPrewarmed      bool
+	ctrlEnableAt            time.Time
+	ctrlWasEnabled          bool
+	ctrlDisabledAt          uint64    // monotonic ktime_ns when ctrl was last disabled
+	lastDemotionTime        time.Time // wall clock when last RG demotion occurred
+	xskLivenessFailed       bool
+	xskLivenessProven       bool
+	xskProbeStart           time.Time
+	lastXSKRX               uint64
+	lastNAPIBootstrap       time.Time
+	lastStandbyNeighResolve time.Time
+	publishedSnapshot       uint64
+	publishedPlanKey        string
+	sessionMirrorFailed     bool
+	sessionMirrorErr        string
+	deferWorkers            bool // skip worker spawn until NotifyLinkCycle
+	xskBoundNotified        bool // OnXSKBound fired at most once
 
 	mode               DataplaneMode // current active runtime mode
 	configuredMode     DataplaneMode // user-configured desired mode (from config)
@@ -4154,15 +4155,39 @@ func (m *Manager) statusLoop(ctx context.Context) {
 			} else {
 				slog.Warn("userspace dataplane status poll failed", "err", err)
 			}
-			// Keep the targeted kernel prewarm during initial startup, but
-			// let the helper own neighbor-table sync via its own dump+subscribe
-			// netlink path instead of pushing periodic manager snapshots.
-			if time.Since(startTime) < 60*time.Second && m.lastSnapshot != nil && m.lastSnapshot.Config != nil {
+			// Keep the targeted kernel prewarm during initial startup. After
+			// startup, continue a throttled standby-only neighbor prewarm so HA
+			// standby nodes already have WAN next-hop resolution before the
+			// first redirected packets arrive.
+			now := time.Now()
+			if now.Sub(startTime) < 60*time.Second && m.lastSnapshot != nil && m.lastSnapshot.Config != nil {
+				m.proactiveNeighborResolveAsyncLocked()
+			} else if m.shouldStandbyNeighborPrewarmLocked(now) {
+				m.lastStandbyNeighResolve = now
 				m.proactiveNeighborResolveAsyncLocked()
 			}
 			m.mu.Unlock()
 		}
 	}
+}
+
+func (m *Manager) shouldStandbyNeighborPrewarmLocked(now time.Time) bool {
+	if m.lastSnapshot == nil || m.lastSnapshot.Config == nil {
+		return false
+	}
+	if !m.clusterHA || !m.configHasDataRGLocked() || m.hasActiveDataRGLocked() {
+		return false
+	}
+	if m.proc == nil || m.proc.Process == nil {
+		return false
+	}
+	if !m.lastStatus.Enabled || !m.lastStatus.ForwardingArmed || !m.lastStatus.Capabilities.ForwardingSupported {
+		return false
+	}
+	if !m.lastStandbyNeighResolve.IsZero() && now.Sub(m.lastStandbyNeighResolve) < 10*time.Second {
+		return false
+	}
+	return true
 }
 
 func (m *Manager) bootstrapNAPIQueuesAsyncLocked(reason string) {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -4261,6 +4261,7 @@ func (m *Manager) stopLocked() {
 	m.xskProbeStart = time.Time{}
 	m.lastXSKRX = 0
 	m.lastNAPIBootstrap = time.Time{}
+	m.lastStandbyNeighResolve = time.Time{}
 	m.publishedSnapshot = 0
 	m.publishedPlanKey = ""
 	m.sessionMirrorFailed = false
@@ -4517,10 +4518,20 @@ func (m *Manager) proactiveNeighborResolveAsyncLocked() {
 	if m.lastSnapshot == nil || m.lastSnapshot.Config == nil {
 		return
 	}
+	cfg := m.lastSnapshot.Config
+	go proactiveNeighborResolveAsync(cfg)
+}
+
+type neighborProbeTarget struct {
+	iface string
+	ip    string
+}
+
+func proactiveNeighborResolveAsync(cfg *config.Config) {
 	seen := make(map[string]bool)
 	targetSet := make(map[string]struct{})
-	var targets []struct{ iface, ip string }
-	for ifName, ifc := range m.lastSnapshot.Config.Interfaces.Interfaces {
+	var targets []neighborProbeTarget
+	for ifName, ifc := range cfg.Interfaces.Interfaces {
 		base := config.LinuxIfName(ifName)
 		seen[base] = true // include base interface for route-GW probing
 		for _, unit := range ifc.Units {
@@ -4549,7 +4560,7 @@ func (m *Manager) proactiveNeighborResolveAsyncLocked() {
 							continue
 						}
 						targetSet[key] = struct{}{}
-						targets = append(targets, struct{ iface, ip string }{linuxName, n.IP.String()})
+						targets = append(targets, neighborProbeTarget{iface: linuxName, ip: n.IP.String()})
 					}
 				}
 			}
@@ -4585,7 +4596,7 @@ func (m *Manager) proactiveNeighborResolveAsyncLocked() {
 			continue
 		}
 		targetSet[key] = struct{}{}
-		targets = append(targets, struct{ iface, ip string }{ifName, r.Gw.String()})
+		targets = append(targets, neighborProbeTarget{iface: ifName, ip: r.Gw.String()})
 	}
 	for _, t := range targets {
 		go func(iface, ip string) {

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -632,6 +632,59 @@ func TestTakeoverReadyReportsSessionMirrorFailure(t *testing.T) {
 	}
 }
 
+func testStandbyNeighborPrewarmManager() *Manager {
+	return &Manager{
+		proc:      &exec.Cmd{Process: &os.Process{Pid: 1}},
+		clusterHA: true,
+		lastStatus: ProcessStatus{
+			Enabled:         true,
+			ForwardingArmed: true,
+			Capabilities: UserspaceCapabilities{
+				ForwardingSupported: true,
+			},
+		},
+		lastSnapshot: &ConfigSnapshot{
+			Config: &config.Config{
+				Chassis: config.ChassisConfig{
+					Cluster: &config.ClusterConfig{
+						RedundancyGroups: []*config.RedundancyGroup{
+							{ID: 0},
+							{ID: 1},
+						},
+					},
+				},
+			},
+		},
+		haGroups: map[int]HAGroupStatus{
+			1: {RGID: 1, Active: false},
+		},
+	}
+}
+
+func TestShouldStandbyNeighborPrewarmLocked(t *testing.T) {
+	m := testStandbyNeighborPrewarmManager()
+	if !m.shouldStandbyNeighborPrewarmLocked(time.Now()) {
+		t.Fatal("shouldStandbyNeighborPrewarmLocked() = false, want true")
+	}
+}
+
+func TestShouldStandbyNeighborPrewarmLockedRejectsActiveOwner(t *testing.T) {
+	m := testStandbyNeighborPrewarmManager()
+	m.haGroups[1] = HAGroupStatus{RGID: 1, Active: true}
+	if m.shouldStandbyNeighborPrewarmLocked(time.Now()) {
+		t.Fatal("shouldStandbyNeighborPrewarmLocked() = true, want false for active owner")
+	}
+}
+
+func TestShouldStandbyNeighborPrewarmLockedThrottlesRecentRun(t *testing.T) {
+	m := testStandbyNeighborPrewarmManager()
+	now := time.Now()
+	m.lastStandbyNeighResolve = now.Add(-5 * time.Second)
+	if m.shouldStandbyNeighborPrewarmLocked(now) {
+		t.Fatal("shouldStandbyNeighborPrewarmLocked() = true, want false during throttle window")
+	}
+}
+
 func TestMergeHAStateFromMaps(t *testing.T) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		t.Skipf("RemoveMemlock: %v", err)


### PR DESCRIPTION
## Summary
- keep a throttled standby-only neighbor prewarm running after helper startup
- only do this while the node is an armed HA standby with data RGs configured
- add focused manager tests for the standby prewarm gate

## Why
Fixes #572. After the stale-owner forwarding fixes, the remaining failover loss on  was promoted-node  on the first translated WAN packets. The manager had stopped doing any neighbor prewarm after the helper's first 60 seconds, so a long-idle standby could still report takeover-ready while its WAN next-hop was cold.

## Testing
- ok  	github.com/psaab/bpfrx/pkg/dataplane/userspace	0.784s