### PR TITLE
fix: infer on-link interfaces for ipv6 static next-hops

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1205,8 +1205,10 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
 		}
 	}
 
+	addRoutes(cfg.RoutingOptions.StaticRoutes)
 	addRoutes(cfg.RoutingOptions.Inet6StaticRoutes)
 	for _, ri := range cfg.RoutingInstances {
+		addRoutes(ri.StaticRoutes)
 		addRoutes(ri.Inet6StaticRoutes)
 	}
 	return resolved

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1145,6 +1145,73 @@ func enableForwarding() {
 	slog.Info("IP forwarding enabled, RA acceptance disabled")
 }
 
+func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
+	type connectedPrefix struct {
+		net    *net.IPNet
+		ifName string
+		bits   int
+	}
+
+	var connected []connectedPrefix
+	for ifName, ifc := range cfg.Interfaces.Interfaces {
+		base := config.LinuxIfName(ifName)
+		for unitNum, unit := range ifc.Units {
+			logical := base
+			if unitNum != 0 {
+				logical = fmt.Sprintf("%s.%d", base, unitNum)
+			}
+			for _, addr := range unit.Addresses {
+				ip, ipNet, err := net.ParseCIDR(addr)
+				if err != nil || ip == nil || ip.To4() != nil {
+					continue
+				}
+				bits, _ := ipNet.Mask.Size()
+				connected = append(connected, connectedPrefix{
+					net:    ipNet,
+					ifName: logical,
+					bits:   bits,
+				})
+			}
+		}
+	}
+
+	resolve := func(addr string) string {
+		ip := net.ParseIP(addr)
+		if ip == nil || ip.To4() != nil {
+			return ""
+		}
+		bestIf := ""
+		bestBits := -1
+		for _, candidate := range connected {
+			if candidate.net.Contains(ip) && candidate.bits > bestBits {
+				bestIf = candidate.ifName
+				bestBits = candidate.bits
+			}
+		}
+		return bestIf
+	}
+
+	resolved := make(map[string]string)
+	addRoutes := func(routes []*config.StaticRoute) {
+		for _, sr := range routes {
+			for _, nh := range sr.NextHops {
+				if nh.Interface != "" || nh.Address == "" || !strings.Contains(nh.Address, ":") {
+					continue
+				}
+				if ifName := resolve(nh.Address); ifName != "" {
+					resolved[nh.Address] = ifName
+				}
+			}
+		}
+	}
+
+	addRoutes(cfg.RoutingOptions.Inet6StaticRoutes)
+	for _, ri := range cfg.RoutingInstances {
+		addRoutes(ri.Inet6StaticRoutes)
+	}
+	return resolved
+}
+
 // fixRethLinkFile rewrites the .link file for a RETH member to use
 // OriginalName= (the kernel name) instead of MACAddress= for matching.
 // This ensures the .link works on reboot when the MAC reverts to physical.
@@ -2176,6 +2243,7 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 			InterfaceBandwidths:   ifaceBandwidths,
 			InterfacePointToPoint: ifaceP2P,
 			RethMap:               cfg.RethToPhysical(),
+			IPv6NextHopInterfaces: inferIPv6StaticNextHopInterfaces(cfg),
 			ClusterMode:           d.cluster != nil,
 		}
 		for _, ri := range cfg.RoutingInstances {

--- a/pkg/daemon/ipv6_static_nexthop_test.go
+++ b/pkg/daemon/ipv6_static_nexthop_test.go
@@ -24,7 +24,7 @@ func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
 			},
 		},
 		RoutingOptions: config.RoutingOptionsConfig{
-			Inet6StaticRoutes: []*config.StaticRoute{
+			StaticRoutes: []*config.StaticRoute{
 				{
 					Destination: "::/0",
 					NextHops: []config.NextHopEntry{
@@ -38,6 +38,14 @@ func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
 					},
 				},
 			},
+			Inet6StaticRoutes: []*config.StaticRoute{
+				{
+					Destination: "2001:db8:ffff::/48",
+					NextHops: []config.NextHopEntry{
+						{Address: "2001:559:8585:ef00::2"},
+					},
+				},
+			},
 		},
 	}
 
@@ -47,5 +55,8 @@ func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
 	}
 	if got["2001:559:8585:80::1"] != "reth0.80" {
 		t.Fatalf("gre route next-hop interface = %q, want reth0.80", got["2001:559:8585:80::1"])
+	}
+	if got["2001:559:8585:ef00::2"] != "reth1" {
+		t.Fatalf("inet6 static route next-hop interface = %q, want reth1", got["2001:559:8585:ef00::2"])
 	}
 }

--- a/pkg/daemon/ipv6_static_nexthop_test.go
+++ b/pkg/daemon/ipv6_static_nexthop_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Units: map[int]*config.InterfaceUnit{
+						50: {Addresses: []string{"2001:559:8585:50::8/64"}},
+						80: {Addresses: []string{"2001:559:8585:80::8/64"}},
+					},
+				},
+				"reth1": {
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"2001:559:8585:ef00::1/64"}},
+					},
+				},
+			},
+		},
+		RoutingOptions: config.RoutingOptionsConfig{
+			Inet6StaticRoutes: []*config.StaticRoute{
+				{
+					Destination: "::/0",
+					NextHops: []config.NextHopEntry{
+						{Address: "2001:559:8585:50::1"},
+					},
+				},
+				{
+					Destination: "2602:ffd3:0:2::/64",
+					NextHops: []config.NextHopEntry{
+						{Address: "2001:559:8585:80::1"},
+					},
+				},
+			},
+		},
+	}
+
+	got := inferIPv6StaticNextHopInterfaces(cfg)
+	if got["2001:559:8585:50::1"] != "reth0.50" {
+		t.Fatalf("default route next-hop interface = %q, want reth0.50", got["2001:559:8585:50::1"])
+	}
+	if got["2001:559:8585:80::1"] != "reth0.80" {
+		t.Fatalf("gre route next-hop interface = %q, want reth0.80", got["2001:559:8585:80::1"])
+	}
+}

--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -90,8 +90,11 @@ type FullConfig struct {
 	// Used to translate RETH interface names in static routes to kernel names.
 	RethMap map[string]string
 
-	// IPv6NextHopInterfaces resolves global IPv6 next-hops to their on-link
-	// kernel interface name when the config omits an explicit interface.
+	// IPv6NextHopInterfaces maps IPv6 next-hops used by global and per-instance
+	// static routes to the interface to use when the route omits an explicit
+	// interface. Values may still be logical interface names (for example,
+	// "reth0.50"); any later translation to kernel/physical names is handled
+	// separately via RethMap.
 	IPv6NextHopInterfaces map[string]string
 
 	// ConsistentHash is set when the forwarding-table export policy uses

--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -58,11 +58,11 @@ type DHCPRoute struct {
 
 // FullConfig holds the complete routing config for a single FRR apply.
 type FullConfig struct {
-	OSPF          *config.OSPFConfig
-	OSPFv3        *config.OSPFv3Config
-	BGP           *config.BGPConfig
-	RIP           *config.RIPConfig
-	ISIS          *config.ISISConfig
+	OSPF              *config.OSPFConfig
+	OSPFv3            *config.OSPFv3Config
+	BGP               *config.BGPConfig
+	RIP               *config.RIPConfig
+	ISIS              *config.ISISConfig
 	StaticRoutes      []*config.StaticRoute
 	Inet6StaticRoutes []*config.StaticRoute // rib inet6.0 static routes
 	GenerateRoutes    []*config.GenerateRoute
@@ -89,6 +89,10 @@ type FullConfig struct {
 	// RethMap maps reth name → physical member name (e.g. "reth0" → "ge-0-0-1").
 	// Used to translate RETH interface names in static routes to kernel names.
 	RethMap map[string]string
+
+	// IPv6NextHopInterfaces resolves global IPv6 next-hops to their on-link
+	// kernel interface name when the config omits an explicit interface.
+	IPv6NextHopInterfaces map[string]string
 
 	// ConsistentHash is set when the forwarding-table export policy uses
 	// "load-balance consistent-hash". The daemon should set
@@ -124,9 +128,9 @@ func (m *Manager) ApplyWithInstances(ospf *config.OSPFConfig, bgp *config.BGPCon
 
 // RIPRouteEntry represents a RIP route.
 type RIPRouteEntry struct {
-	Network  string
-	NextHop  string
-	Metric   string
+	Network   string
+	NextHop   string
+	Metric    string
 	Interface string
 }
 
@@ -248,7 +252,7 @@ func (m *Manager) ApplyFull(fc *FullConfig) error {
 	// Global static routes
 	if len(fc.StaticRoutes) > 0 {
 		for _, sr := range fc.StaticRoutes {
-			b.WriteString(m.generateStaticRoute(sr, "", fc.RethMap))
+			b.WriteString(m.generateStaticRoute(sr, "", fc.RethMap, fc.IPv6NextHopInterfaces))
 		}
 		b.WriteString("!\n")
 	}
@@ -268,7 +272,7 @@ func (m *Manager) ApplyFull(fc *FullConfig) error {
 	// IPv6 RIB static routes (rib inet6.0)
 	if len(fc.Inet6StaticRoutes) > 0 {
 		for _, sr := range fc.Inet6StaticRoutes {
-			b.WriteString(m.generateStaticRoute(sr, "", fc.RethMap))
+			b.WriteString(m.generateStaticRoute(sr, "", fc.RethMap, fc.IPv6NextHopInterfaces))
 		}
 		b.WriteString("!\n")
 	}
@@ -344,10 +348,10 @@ func (m *Manager) ApplyFull(fc *FullConfig) error {
 	for _, inst := range fc.Instances {
 		if len(inst.StaticRoutes) > 0 || len(inst.Inet6StaticRoutes) > 0 {
 			for _, sr := range inst.StaticRoutes {
-				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, fc.RethMap))
+				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, fc.RethMap, fc.IPv6NextHopInterfaces))
 			}
 			for _, sr := range inst.Inet6StaticRoutes {
-				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, fc.RethMap))
+				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, fc.RethMap, fc.IPv6NextHopInterfaces))
 			}
 			b.WriteString("!\n")
 		}
@@ -469,7 +473,7 @@ func (m *Manager) generateInterfaceSettings(fc *FullConfig) string {
 // generateStaticRoute produces FRR static route commands.
 // Multiple next-hops produce one line each (FRR creates ECMP).
 // Routes with NextTable are handled via ip rule (policy routing), not FRR.
-func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, rethMap map[string]string) string {
+func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, rethMap map[string]string, ipv6NextHopInterfaces map[string]string) string {
 	if sr.NextTable != "" {
 		return "" // handled via ip rule in routing package
 	}
@@ -500,6 +504,9 @@ func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, re
 		// kernel names. VLAN suffixes like ".50" in "wan0.50" are real kernel
 		// interface names and must NOT be stripped.
 		ifName := nh.Interface
+		if isV6 && ifName == "" && nh.Address != "" {
+			ifName = ipv6NextHopInterfaces[nh.Address]
+		}
 		if strings.HasSuffix(ifName, ".0") {
 			ifName = ifName[:len(ifName)-2]
 		}
@@ -1441,24 +1448,24 @@ type FRRRouteDetail struct {
 
 // FRRNextHop holds next-hop detail from FRR JSON.
 type FRRNextHop struct {
-	IP               string
-	Interface        string
+	IP                string
+	Interface         string
 	DirectlyConnected bool
-	Active           bool
-	FIB              bool
-	Recursive        bool
+	Active            bool
+	FIB               bool
+	Recursive         bool
 }
 
 // frrRouteJSON maps the JSON output of "show ip route json".
 type frrRouteJSON struct {
-	Prefix    string          `json:"prefix"`
-	Protocol  string          `json:"protocol"`
-	Selected  bool            `json:"selected"`
-	Installed bool            `json:"installed"`
-	Distance  int             `json:"distance"`
-	Metric    int             `json:"metric"`
-	Uptime    string          `json:"uptime"`
-	Table     int             `json:"table"`
+	Prefix    string           `json:"prefix"`
+	Protocol  string           `json:"protocol"`
+	Selected  bool             `json:"selected"`
+	Installed bool             `json:"installed"`
+	Distance  int              `json:"distance"`
+	Metric    int              `json:"metric"`
+	Uptime    string           `json:"uptime"`
+	Table     int              `json:"table"`
 	NextHops  []frrNextHopJSON `json:"nexthops"`
 }
 

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -15,7 +15,7 @@ func TestGenerateStaticRoute_SingleNextHop(t *testing.T) {
 		Destination: "10.0.0.0/8",
 		NextHops:    []config.NextHopEntry{{Address: "192.168.1.1"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ip route 10.0.0.0/8 192.168.1.1\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -31,7 +31,7 @@ func TestGenerateStaticRoute_ECMP(t *testing.T) {
 			{Address: "192.168.2.1"},
 		},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	if !strings.Contains(got, "ip route 10.0.0.0/8 192.168.1.1\n") {
 		t.Errorf("missing first next-hop: %q", got)
 	}
@@ -46,7 +46,7 @@ func TestGenerateStaticRoute_Discard(t *testing.T) {
 		Destination: "10.0.99.0/24",
 		Discard:     true,
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ip route 10.0.99.0/24 Null0\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -60,7 +60,7 @@ func TestGenerateStaticRoute_Preference(t *testing.T) {
 		NextHops:    []config.NextHopEntry{{Address: "192.168.1.1"}},
 		Preference:  100,
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ip route 10.0.0.0/8 192.168.1.1 100\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -73,7 +73,7 @@ func TestGenerateStaticRoute_VRF(t *testing.T) {
 		Destination: "172.16.0.0/12",
 		NextHops:    []config.NextHopEntry{{Address: "10.0.1.1"}},
 	}
-	got := m.generateStaticRoute(sr, "customer-a", nil)
+	got := m.generateStaticRoute(sr, "customer-a", nil, nil)
 	want := "ip route 172.16.0.0/12 10.0.1.1 vrf customer-a\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -86,7 +86,7 @@ func TestGenerateStaticRoute_IPv6(t *testing.T) {
 		Destination: "2001:db8::/32",
 		NextHops:    []config.NextHopEntry{{Address: "fe80::1", Interface: "trust0"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ipv6 route 2001:db8::/32 fe80::1 trust0\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -99,7 +99,7 @@ func TestGenerateStaticRoute_InterfaceOnly(t *testing.T) {
 		Destination: "10.0.0.0/8",
 		NextHops:    []config.NextHopEntry{{Interface: "tunnel0"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ip route 10.0.0.0/8 tunnel0\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -112,7 +112,7 @@ func TestGenerateStaticRoute_NextTable(t *testing.T) {
 		Destination: "0.0.0.0/0",
 		NextTable:   "Comcast-GigabitPro",
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	if got != "" {
 		t.Errorf("next-table route should produce empty FRR output, got %q", got)
 	}
@@ -504,7 +504,7 @@ func TestBGPAddressFamily(t *testing.T) {
 				PeerAS:      65909,
 				FamilyInet:  true,
 				FamilyInet6: true,
-				Export:       []string{"to_BV-FIREHOUSE"},
+				Export:      []string{"to_BV-FIREHOUSE"},
 			},
 			{
 				Address:    "10.0.0.2",
@@ -652,13 +652,13 @@ func TestFRRMultiVRF(t *testing.T) {
 	var b strings.Builder
 	b.WriteString("! bpfrx managed config - do not edit\n!\n")
 	for _, sr := range fc.StaticRoutes {
-		b.WriteString(m.generateStaticRoute(sr, "", nil))
+		b.WriteString(m.generateStaticRoute(sr, "", nil, nil))
 	}
 	b.WriteString("!\n")
 	for _, inst := range fc.Instances {
 		if len(inst.StaticRoutes) > 0 {
 			for _, sr := range inst.StaticRoutes {
-				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, nil))
+				b.WriteString(m.generateStaticRoute(sr, inst.VRFName, nil, nil))
 			}
 			b.WriteString("!\n")
 		}
@@ -722,7 +722,7 @@ func TestFRRForwardingInstance(t *testing.T) {
 	var b strings.Builder
 	for _, inst := range fc.Instances {
 		for _, sr := range inst.StaticRoutes {
-			b.WriteString(m.generateStaticRoute(sr, inst.VRFName, nil))
+			b.WriteString(m.generateStaticRoute(sr, inst.VRFName, nil, nil))
 		}
 	}
 	got := b.String()
@@ -771,7 +771,7 @@ func TestGenerateStaticRoute_QualifiedNextHopLinkLocal(t *testing.T) {
 			{Address: "fe80::2d0:f6ff:feda:c180", Interface: "wan0.0"},
 		},
 	}
-	got := m.generateStaticRoute(sr, "ATT", nil)
+	got := m.generateStaticRoute(sr, "ATT", nil, nil)
 	want := "ipv6 route ::/0 fe80::2d0:f6ff:feda:c180 wan0 vrf ATT\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -784,7 +784,7 @@ func TestGenerateStaticRoute_UnitSuffixStripped(t *testing.T) {
 		Destination: "10.0.0.0/8",
 		NextHops:    []config.NextHopEntry{{Interface: "tunnel0.0"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ip route 10.0.0.0/8 tunnel0\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -797,7 +797,7 @@ func TestGenerateStaticRoute_NoUnitNoStrip(t *testing.T) {
 		Destination: "2001:db8::/32",
 		NextHops:    []config.NextHopEntry{{Address: "fe80::1", Interface: "trust0"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	want := "ipv6 route 2001:db8::/32 fe80::1 trust0\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -810,7 +810,7 @@ func TestGenerateStaticRoute_VLANSuffixNotStripped(t *testing.T) {
 		Destination: "::/0",
 		NextHops:    []config.NextHopEntry{{Address: "fe80::50", Interface: "wan0.50"}},
 	}
-	got := m.generateStaticRoute(sr, "", nil)
+	got := m.generateStaticRoute(sr, "", nil, nil)
 	// VLAN sub-interface "wan0.50" must NOT be stripped — it's a real kernel name
 	want := "ipv6 route ::/0 fe80::50 wan0.50\n"
 	if got != want {
@@ -828,7 +828,7 @@ func TestGenerateStaticRoute_RethResolution(t *testing.T) {
 		Destination: "::/0",
 		NextHops:    []config.NextHopEntry{{Address: "fe80::50", Interface: "reth0.50"}},
 	}
-	got := m.generateStaticRoute(sr, "", rethMap)
+	got := m.generateStaticRoute(sr, "", rethMap, nil)
 	want := "ipv6 route ::/0 fe80::50 ge-0-0-1.50\n"
 	if got != want {
 		t.Errorf("reth VLAN: got %q, want %q", got, want)
@@ -839,7 +839,7 @@ func TestGenerateStaticRoute_RethResolution(t *testing.T) {
 		Destination: "10.0.0.0/8",
 		NextHops:    []config.NextHopEntry{{Interface: "reth0"}},
 	}
-	got2 := m.generateStaticRoute(sr2, "", rethMap)
+	got2 := m.generateStaticRoute(sr2, "", rethMap, nil)
 	want2 := "ip route 10.0.0.0/8 ge-0-0-1\n"
 	if got2 != want2 {
 		t.Errorf("reth bare: got %q, want %q", got2, want2)
@@ -850,10 +850,28 @@ func TestGenerateStaticRoute_RethResolution(t *testing.T) {
 		Destination: "10.0.0.0/8",
 		NextHops:    []config.NextHopEntry{{Interface: "trust0"}},
 	}
-	got3 := m.generateStaticRoute(sr3, "", rethMap)
+	got3 := m.generateStaticRoute(sr3, "", rethMap, nil)
 	want3 := "ip route 10.0.0.0/8 trust0\n"
 	if got3 != want3 {
 		t.Errorf("non-reth: got %q, want %q", got3, want3)
+	}
+}
+
+func TestGenerateStaticRoute_InferredIPv6NextHopInterface(t *testing.T) {
+	m := New()
+	rethMap := map[string]string{"reth0": "ge-0/0/2"}
+	sr := &config.StaticRoute{
+		Destination: "::/0",
+		NextHops: []config.NextHopEntry{
+			{Address: "2001:559:8585:50::1"},
+		},
+	}
+	got := m.generateStaticRoute(sr, "", rethMap, map[string]string{
+		"2001:559:8585:50::1": "reth0.50",
+	})
+	want := "ipv6 route ::/0 2001:559:8585:50::1 ge-0-0-2.50\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
@@ -1952,9 +1970,9 @@ func TestGenerateProtocols_OSPFVirtualLinkCustomTransitArea(t *testing.T) {
 func TestNextHopPeerAddress(t *testing.T) {
 	m := New()
 	po := &config.PolicyOptionsConfig{
-		PrefixLists:      make(map[string]*config.PrefixList),
-		Communities:      make(map[string]*config.CommunityDef),
-		ASPaths:          make(map[string]*config.ASPathDef),
+		PrefixLists: make(map[string]*config.PrefixList),
+		Communities: make(map[string]*config.CommunityDef),
+		ASPaths:     make(map[string]*config.ASPathDef),
 		PolicyStatements: map[string]*config.PolicyStatement{
 			"to-vpn-mesh": {
 				Name: "to-vpn-mesh",
@@ -1995,9 +2013,9 @@ func TestNextHopPeerAddress(t *testing.T) {
 
 	// Verify "next-hop self" does NOT generate "set ip next-hop peer-address"
 	po2 := &config.PolicyOptionsConfig{
-		PrefixLists:      make(map[string]*config.PrefixList),
-		Communities:      make(map[string]*config.CommunityDef),
-		ASPaths:          make(map[string]*config.ASPathDef),
+		PrefixLists: make(map[string]*config.PrefixList),
+		Communities: make(map[string]*config.CommunityDef),
+		ASPaths:     make(map[string]*config.ASPathDef),
 		PolicyStatements: map[string]*config.PolicyStatement{
 			"self-policy": {
 				Name: "self-policy",
@@ -2020,9 +2038,9 @@ func TestNextHopPeerAddress(t *testing.T) {
 func TestRouteFilterExactFRR(t *testing.T) {
 	m := New()
 	po := &config.PolicyOptionsConfig{
-		PrefixLists:      make(map[string]*config.PrefixList),
-		Communities:      make(map[string]*config.CommunityDef),
-		ASPaths:          make(map[string]*config.ASPathDef),
+		PrefixLists: make(map[string]*config.PrefixList),
+		Communities: make(map[string]*config.CommunityDef),
+		ASPaths:     make(map[string]*config.ASPathDef),
 		PolicyStatements: map[string]*config.PolicyStatement{
 			"to-firewall": {
 				Name: "to-firewall",
@@ -2233,7 +2251,7 @@ func TestDHCPRoutesIPv6SuppressedByStaticDefault(t *testing.T) {
 			{Destination: "::/0", NextHops: []config.NextHopEntry{{Address: "fe80::1", Interface: "wan0"}}},
 		},
 		DHCPRoutes: []DHCPRoute{
-			{Gateway: "10.0.100.1"},                              // IPv4 — should remain
+			{Gateway: "10.0.100.1"},                                // IPv4 — should remain
 			{Gateway: "fe80::gw", Interface: "eth0", IsIPv6: true}, // IPv6 — should be suppressed
 		},
 	}


### PR DESCRIPTION
## Summary
- infer on-link interfaces for configured IPv6 static next-hops when config only provides the IPv6 next-hop address
- pass the inferred interface map into FRR static route generation so IPv6 routes render with the correct egress interface
- add daemon and FRR regression coverage for inferred IPv6 next-hop interface selection

## Validation
- `go test ./pkg/frr ./pkg/daemon`
- live evidence from `loss`: `/tmp/ipv6-rg1-repro-20260407-090657`
