### PR TITLE
fix: clear demoted session redirect aliases

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -5335,6 +5335,19 @@ fn worker_loop(
                 for binding in bindings.iter_mut() {
                     cancel_queued_flow_on_binding(binding, key, key);
                 }
+                if let Some((decision, metadata, origin)) = sessions.entry_with_origin(key) {
+                    // Demotion keeps the session in the standby table, but the
+                    // stale owner must stop advertising local XSK redirect
+                    // aliases immediately or XDP will keep steering packets to
+                    // the old node after RG handoff.
+                    delete_session_map_redirect_for_session(
+                        session_map_fd,
+                        key,
+                        decision,
+                        &metadata,
+                        origin,
+                    );
+                }
             }
         }
         heartbeat.store(loop_now_ns, Ordering::Relaxed);

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -1080,6 +1080,51 @@ pub(super) fn delete_live_session_entry(
     }
 }
 
+fn session_map_redirect_keys_for_session(
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+) -> Vec<SessionKey> {
+    let mut keys = vec![key.clone()];
+    if uses_kernel_local_session_map_entry(decision, metadata, origin) {
+        if decision.nat.rewrite_src.is_some() {
+            let reverse_wire = reverse_session_key(key, decision.nat);
+            if reverse_wire != *key {
+                keys.push(reverse_wire);
+            }
+        }
+        return keys;
+    }
+    if !metadata.is_reverse {
+        let wire_key = forward_wire_key(key, decision.nat);
+        if wire_key != *key {
+            keys.push(wire_key);
+        }
+        let reverse_wire = reverse_session_key(key, decision.nat);
+        if reverse_wire != *key {
+            keys.push(reverse_wire.clone());
+        }
+        let reverse_canonical = reverse_canonical_key(key, decision.nat);
+        if reverse_canonical != *key && reverse_canonical != reverse_wire {
+            keys.push(reverse_canonical);
+        }
+    }
+    keys
+}
+
+pub(super) fn delete_session_map_redirect_for_session(
+    map_fd: c_int,
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+) {
+    for redirect_key in session_map_redirect_keys_for_session(key, decision, metadata, origin) {
+        delete_live_session_key(map_fd, &redirect_key);
+    }
+}
+
 pub(super) fn delete_session_map_entry_for_removed_session(
     map_fd: c_int,
     key: &SessionKey,
@@ -1102,20 +1147,11 @@ pub(super) fn delete_session_map_entry_for_removed_session_with_origin(
     conntrack_v4_fd: c_int,
     conntrack_v6_fd: c_int,
 ) {
+    delete_session_map_redirect_for_session(map_fd, key, decision, metadata, origin);
     if uses_kernel_local_session_map_entry(decision, metadata, origin) {
-        delete_live_session_key(map_fd, key);
-        // Also delete the reverse-wire alias published for SNATed
-        // kernel-local sessions (see publish_session_map_entry_for_session).
-        if decision.nat.rewrite_src.is_some() {
-            let reverse_wire = reverse_session_key(key, decision.nat);
-            if reverse_wire != *key {
-                delete_live_session_key(map_fd, &reverse_wire);
-            }
-        }
         delete_bpf_conntrack_entry(conntrack_v4_fd, conntrack_v6_fd, key);
         return;
     }
-    delete_live_session_entry(map_fd, key, decision.nat, metadata.is_reverse);
     delete_bpf_conntrack_entry(conntrack_v4_fd, conntrack_v6_fd, key);
 }
 
@@ -1206,6 +1242,96 @@ mod tests {
         assert_eq!(core::mem::size_of::<BpfSessionValueV4>(), 128);
         assert_eq!(core::mem::size_of::<BpfSessionKeyV6>(), 40);
         assert_eq!(core::mem::size_of::<BpfSessionValueV6>(), 176);
+    }
+
+    #[test]
+    fn session_map_redirect_keys_for_forward_session_include_nat_aliases() {
+        let key = SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 6,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 41086,
+            dst_port: 5201,
+        };
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 0,
+                egress_ifindex: 14,
+                tx_ifindex: 14,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                ..NatDecision::default()
+            },
+        };
+        let metadata = SessionMetadata {
+            ingress_zone: Arc::<str>::from("lan"),
+            egress_zone: Arc::<str>::from("wan"),
+            owner_rg_id: 1,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+        };
+
+        let keys = session_map_redirect_keys_for_session(
+            &key,
+            decision,
+            &metadata,
+            SessionOrigin::SharedPromote,
+        );
+
+        assert!(keys.contains(&key));
+        assert!(keys.contains(&forward_wire_key(&key, decision.nat)));
+        assert!(keys.contains(&reverse_session_key(&key, decision.nat)));
+        assert!(keys.contains(&reverse_canonical_key(&key, decision.nat)));
+    }
+
+    #[test]
+    fn session_map_redirect_keys_for_kernel_local_synced_session_skip_forward_aliases() {
+        let key = SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 1,
+            src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            src_port: 0,
+            dst_port: 0,
+        };
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::LocalDelivery,
+                local_ifindex: 14,
+                egress_ifindex: 14,
+                tx_ifindex: 14,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                ..NatDecision::default()
+            },
+        };
+        let metadata = synced_forward_metadata();
+
+        let keys = session_map_redirect_keys_for_session(
+            &key,
+            decision,
+            &metadata,
+            SessionOrigin::SyncImport,
+        );
+
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&key));
+        assert!(keys.contains(&reverse_session_key(&key, decision.nat)));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -345,10 +345,10 @@ pub(super) struct ConntrackCtx<'a> {
 #[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct BpfSessionKeyV4 {
-    src_ip: [u8; 4],   // __be32, network byte order
-    dst_ip: [u8; 4],   // __be32, network byte order
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_ip: [u8; 4], // __be32, network byte order
+    dst_ip: [u8; 4], // __be32, network byte order
+    src_port: u16,   // __be16, network byte order
+    dst_port: u16,   // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -369,10 +369,10 @@ struct BpfSessionValueV4 {
     policy_id: u32,
     ingress_zone: u16,
     egress_zone: u16,
-    nat_src_ip: u32,    // __be32, native endian for BPF
-    nat_dst_ip: u32,    // __be32, native endian for BPF
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_ip: u32,   // __be32, native endian for BPF
+    nat_dst_ip: u32,   // __be32, native endian for BPF
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -394,8 +394,8 @@ struct BpfSessionValueV4 {
 struct BpfSessionKeyV6 {
     src_ip: [u8; 16],
     dst_ip: [u8; 16],
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_port: u16, // __be16, network byte order
+    dst_port: u16, // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -418,8 +418,8 @@ struct BpfSessionValueV6 {
     egress_zone: u16,
     nat_src_ip: [u8; 16],
     nat_dst_ip: [u8; 16],
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -812,7 +812,9 @@ pub(super) fn publish_session_map_entry_for_session_with_origin(
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) -> io::Result<()> {
-    publish_session_map_entry_for_session_with_conntrack(map_fd, key, decision, metadata, origin, None)
+    publish_session_map_entry_for_session_with_conntrack(
+        map_fd, key, decision, metadata, origin, None,
+    )
 }
 
 pub(super) fn publish_session_map_entry_for_session_with_conntrack(
@@ -838,14 +840,28 @@ pub(super) fn publish_session_map_entry_for_session_with_conntrack(
         }
         // Also mirror to conntrack for session display.
         if let Some(ctx) = ct {
-            publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+            publish_bpf_conntrack_entry(
+                ctx.v4_fd,
+                ctx.v6_fd,
+                key,
+                decision,
+                metadata,
+                ctx.zone_name_to_id,
+            );
         }
         return Ok(());
     }
     let result = publish_live_session_entry(map_fd, key, decision.nat, metadata.is_reverse);
     // Mirror to conntrack for session display.
     if let Some(ctx) = ct {
-        publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+        publish_bpf_conntrack_entry(
+            ctx.v4_fd,
+            ctx.v6_fd,
+            key,
+            decision,
+            metadata,
+            ctx.zone_name_to_id,
+        );
     }
     result
 }
@@ -1080,36 +1096,43 @@ pub(super) fn delete_live_session_entry(
     }
 }
 
+fn for_each_session_map_redirect_key<F>(
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    _origin: SessionOrigin,
+    mut f: F,
+) where
+    F: FnMut(SessionKey),
+{
+    f(key.clone());
+    if !metadata.is_reverse {
+        let wire_key = forward_wire_key(key, decision.nat);
+        if wire_key != *key {
+            f(wire_key);
+        }
+        let reverse_wire = reverse_session_key(key, decision.nat);
+        if reverse_wire != *key {
+            f(reverse_wire.clone());
+        }
+        let reverse_canonical = reverse_canonical_key(key, decision.nat);
+        if reverse_canonical != *key && reverse_canonical != reverse_wire {
+            f(reverse_canonical);
+        }
+    }
+}
+
+#[cfg(test)]
 fn session_map_redirect_keys_for_session(
     key: &SessionKey,
     decision: SessionDecision,
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) -> Vec<SessionKey> {
-    let mut keys = vec![key.clone()];
-    if uses_kernel_local_session_map_entry(decision, metadata, origin) {
-        if decision.nat.rewrite_src.is_some() {
-            let reverse_wire = reverse_session_key(key, decision.nat);
-            if reverse_wire != *key {
-                keys.push(reverse_wire);
-            }
-        }
-        return keys;
-    }
-    if !metadata.is_reverse {
-        let wire_key = forward_wire_key(key, decision.nat);
-        if wire_key != *key {
-            keys.push(wire_key);
-        }
-        let reverse_wire = reverse_session_key(key, decision.nat);
-        if reverse_wire != *key {
-            keys.push(reverse_wire.clone());
-        }
-        let reverse_canonical = reverse_canonical_key(key, decision.nat);
-        if reverse_canonical != *key && reverse_canonical != reverse_wire {
-            keys.push(reverse_canonical);
-        }
-    }
+    let mut keys = Vec::with_capacity(4);
+    for_each_session_map_redirect_key(key, decision, metadata, origin, |redirect_key| {
+        keys.push(redirect_key);
+    });
     keys
 }
 
@@ -1120,9 +1143,9 @@ pub(super) fn delete_session_map_redirect_for_session(
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) {
-    for redirect_key in session_map_redirect_keys_for_session(key, decision, metadata, origin) {
+    for_each_session_map_redirect_key(key, decision, metadata, origin, |redirect_key| {
         delete_live_session_key(map_fd, &redirect_key);
-    }
+    });
 }
 
 pub(super) fn delete_session_map_entry_for_removed_session(
@@ -1134,7 +1157,13 @@ pub(super) fn delete_session_map_entry_for_removed_session(
     // Default to SyncImport for backwards-compatible callers where
     // the session being deleted is always from a sync path.
     delete_session_map_entry_for_removed_session_with_origin(
-        map_fd, key, decision, metadata, SessionOrigin::SyncImport, -1, -1,
+        map_fd,
+        key,
+        decision,
+        metadata,
+        SessionOrigin::SyncImport,
+        -1,
+        -1,
     );
 }
 
@@ -1294,7 +1323,7 @@ mod tests {
     }
 
     #[test]
-    fn session_map_redirect_keys_for_kernel_local_synced_session_skip_forward_aliases() {
+    fn session_map_redirect_keys_for_kernel_local_synced_session_delete_superset() {
         let key = SessionKey {
             addr_family: libc::AF_INET as u8,
             protocol: 1,
@@ -1329,9 +1358,11 @@ mod tests {
             SessionOrigin::SyncImport,
         );
 
-        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.len(), 4);
         assert!(keys.contains(&key));
+        assert!(keys.contains(&forward_wire_key(&key, decision.nat)));
         assert!(keys.contains(&reverse_session_key(&key, decision.nat)));
+        assert!(keys.contains(&reverse_canonical_key(&key, decision.nat)));
     }
 
     #[test]
@@ -1352,8 +1383,7 @@ mod tests {
         // The packed struct bytes at the port offsets must be big-endian:
         // port 80 = 0x0050 -> bytes [0x00, 0x50]
         // port 443 = 0x01BB -> bytes [0x01, 0xBB]
-        let bytes: [u8; 16] =
-            unsafe { core::mem::transmute(bpf_key) };
+        let bytes: [u8; 16] = unsafe { core::mem::transmute(bpf_key) };
         assert_eq!(bytes[8], 0x00, "src_port high byte");
         assert_eq!(bytes[9], 0x50, "src_port low byte");
         assert_eq!(bytes[10], 0x01, "dst_port high byte");

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -2652,6 +2652,48 @@ mod tests {
     }
 
     #[test]
+    fn apply_worker_commands_demote_owner_rg_returns_cancelled_keys() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        assert!(sessions.install_with_protocol_with_origin(
+            key.clone(),
+            test_decision(),
+            test_metadata(),
+            SessionOrigin::ForwardFlow,
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::DemoteOwnerRGS {
+                owner_rgs: vec![1, 1],
+            });
+
+        let forwarding = test_forwarding_state_with_fabric();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let mut ha_state = BTreeMap::new();
+        ha_state.insert(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000));
+
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+        );
+
+        assert_eq!(results.exported_sequences, Vec::<u64>::new());
+        assert_eq!(results.cancelled_keys.len(), 1);
+        assert!(results.cancelled_keys.iter().any(|k| k == &key));
+    }
+
+    #[test]
     fn demote_shared_owner_rgs_preserves_reverse_entries_and_marks_all_synced() {
         let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
         let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));


### PR DESCRIPTION
## Summary
- clear demoted `USERSPACE_SESSIONS` redirect aliases immediately when a session is demoted
- make session-map demotion cleanup remove both redirect keys and queued TX state
- add regression coverage for demotion clearing redirect aliases

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml session_map_redirect_keys_for_ -- --nocapture`
- live `loss` RG1 failover validation artifact: `/tmp/userspace-ha-failover-rg1-20260407-085805`
