### PR TITLE
fix: choose HA owner in userspace validation

### DIFF
--- a/scripts/userspace-ha-validation.sh
+++ b/scripts/userspace-ha-validation.sh
@@ -194,13 +194,12 @@ ensure_preferred_active_node() {
 wait_for_active_supported_runtime() {
 	local tries=30
 	while (( tries > 0 )); do
-		local vm
-		for vm in "$FW0" "$FW1"; do
-			if enabled_userspace_vm "$vm" >/dev/null 2>&1; then
-				printf '%s\n' "$vm"
-				return 0
-			fi
-		done
+		local owner
+		owner="$(active_owner_vm || true)"
+		if [[ -n "$owner" ]] && enabled_userspace_vm "$owner" >/dev/null 2>&1; then
+			printf '%s\n' "$owner"
+			return 0
+		fi
 		sleep 1
 		tries=$((tries - 1))
 	done


### PR DESCRIPTION
## Summary
- choose the HA owner first when determining the active userspace firewall in the HA validator
- stop treating the first `Enabled:true` helper node as active when all HA groups on that node are still `active=false`
- keep the validator aligned with real RG ownership before it tries WAN-neighbor checks

## Validation
- `bash -n scripts/userspace-ha-validation.sh`
- `BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env RUNS=1 DURATION=5 PARALLEL=4 PREFERRED_ACTIVE_NODE=1 PREFERRED_ACTIVE_RGS='1 2' scripts/userspace-ha-validation.sh`
  - this now selects `loss:bpfrx-userspace-fw1` as the active userspace firewall and gets past the old bogus `unable to detect WAN test interface for loss:bpfrx-userspace-fw0` failure
