### PR TITLE
userspace: keep standby HA readiness when bindings are already ready

### DIFF
--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -268,7 +268,7 @@ func (m *Manager) takeoverReadyLocked() (bool, []string) {
 	if m.xskLivenessFailed {
 		reasons = append(reasons, "userspace XSK liveness failed")
 	}
-	if !m.xskLivenessProven {
+	if !m.xskLivenessProven && !m.standbyBindingsReadyLocked() {
 		reasons = append(reasons, "userspace XSK liveness not proven")
 	}
 	if m.sessionMirrorFailed {
@@ -279,6 +279,26 @@ func (m *Manager) takeoverReadyLocked() (bool, []string) {
 		reasons = append(reasons, reason)
 	}
 	return len(reasons) == 0, reasons
+}
+
+func (m *Manager) standbyBindingsReadyLocked() bool {
+	if m.hasActiveDataRGLocked() {
+		return false
+	}
+	if len(m.lastStatus.Bindings) == 0 || len(m.lastStatus.Queues) == 0 {
+		return false
+	}
+	for _, q := range m.lastStatus.Queues {
+		if !q.Armed || !q.Ready {
+			return false
+		}
+	}
+	for _, b := range m.lastStatus.Bindings {
+		if !b.Armed || !b.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *Manager) recordSessionMirrorFailureLocked(err error) {

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -685,6 +685,93 @@ func TestShouldStandbyNeighborPrewarmLockedThrottlesRecentRun(t *testing.T) {
 	}
 }
 
+func TestTakeoverReadyAllowsStandbyWithReadyBindingsWithoutLivenessProof(t *testing.T) {
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			Enabled:         true,
+			ForwardingArmed: true,
+			Capabilities: UserspaceCapabilities{
+				ForwardingSupported: true,
+			},
+			Queues: []QueueStatus{
+				{QueueID: 0, WorkerID: 0, Registered: true, Armed: true, Ready: true},
+			},
+			Bindings: []BindingStatus{
+				{
+					Slot:          0,
+					QueueID:       0,
+					WorkerID:      0,
+					Ifindex:       5,
+					Registered:    true,
+					Armed:         true,
+					Ready:         true,
+					Bound:         true,
+					XSKRegistered: true,
+				},
+			},
+		},
+		mode: ModeUserspaceCompat,
+		haGroups: map[int]HAGroupStatus{
+			1: {RGID: 1, Active: false},
+			2: {RGID: 2, Active: false},
+		},
+	}
+
+	ready, reasons := m.TakeoverReady()
+	if !ready {
+		t.Fatalf("TakeoverReady() = false, want true, reasons=%v", reasons)
+	}
+}
+
+func TestTakeoverReadyRequiresLivenessProofOnActiveNode(t *testing.T) {
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			Enabled:         true,
+			ForwardingArmed: true,
+			Capabilities: UserspaceCapabilities{
+				ForwardingSupported: true,
+			},
+			Queues: []QueueStatus{
+				{QueueID: 0, WorkerID: 0, Registered: true, Armed: true, Ready: true},
+			},
+			Bindings: []BindingStatus{
+				{
+					Slot:          0,
+					QueueID:       0,
+					WorkerID:      0,
+					Ifindex:       5,
+					Registered:    true,
+					Armed:         true,
+					Ready:         true,
+					Bound:         true,
+					XSKRegistered: true,
+				},
+			},
+		},
+		mode: ModeUserspaceCompat,
+		haGroups: map[int]HAGroupStatus{
+			1: {RGID: 1, Active: true},
+		},
+	}
+
+	ready, reasons := m.TakeoverReady()
+	if ready {
+		t.Fatal("TakeoverReady() = true, want false without active-node liveness proof")
+	}
+	found := false
+	for _, reason := range reasons {
+		if reason == "userspace XSK liveness not proven" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected XSK liveness reason, got %v", reasons)
+	}
+}
+
 func TestMergeHAStateFromMaps(t *testing.T) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		t.Skipf("RemoveMemlock: %v", err)


### PR DESCRIPTION
Closes #582

## Summary
- allow standby takeover readiness when all helper queues and bindings are already registered, armed, bound, and ready
- keep active-node readiness gated on real XSK liveness proof
- add focused takeover readiness regressions for standby vs active nodes

## Testing
- go test ./pkg/dataplane/userspace -run 'TestTakeoverReady(AllowsStandbyWithReadyBindingsWithoutLivenessProof|RequiresLivenessProofOnActiveNode|ReportsSessionMirrorFailure)' -count=1