### PR TITLE
userspace: demote worker sessions on rg handoff

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -3302,10 +3302,10 @@ fn poll_binding(
                                                         forwarding,
                                                         &from_zone,
                                                         &to_zone,
-                                                    decision.resolution.egress_ifindex,
-                                                    flow,
-                                                )
-                                            })
+                                                        decision.resolution.egress_ifindex,
+                                                        flow,
+                                                    )
+                                                })
                                                 .unwrap_or_default();
                                         } else {
                                             let snat_decision = forwarding

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn uses_kernel_local_session_map_entry(
+pub(super) fn uses_kernel_local_session_map_entry(
     decision: SessionDecision,
     metadata: &SessionMetadata,
     origin: SessionOrigin,
@@ -345,10 +345,10 @@ pub(super) struct ConntrackCtx<'a> {
 #[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct BpfSessionKeyV4 {
-    src_ip: [u8; 4],   // __be32, network byte order
-    dst_ip: [u8; 4],   // __be32, network byte order
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_ip: [u8; 4], // __be32, network byte order
+    dst_ip: [u8; 4], // __be32, network byte order
+    src_port: u16,   // __be16, network byte order
+    dst_port: u16,   // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -369,10 +369,10 @@ struct BpfSessionValueV4 {
     policy_id: u32,
     ingress_zone: u16,
     egress_zone: u16,
-    nat_src_ip: u32,    // __be32, native endian for BPF
-    nat_dst_ip: u32,    // __be32, native endian for BPF
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_ip: u32,   // __be32, native endian for BPF
+    nat_dst_ip: u32,   // __be32, native endian for BPF
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -394,8 +394,8 @@ struct BpfSessionValueV4 {
 struct BpfSessionKeyV6 {
     src_ip: [u8; 16],
     dst_ip: [u8; 16],
-    src_port: u16,      // __be16, network byte order
-    dst_port: u16,      // __be16, network byte order
+    src_port: u16, // __be16, network byte order
+    dst_port: u16, // __be16, network byte order
     protocol: u8,
     pad: [u8; 3],
 }
@@ -418,8 +418,8 @@ struct BpfSessionValueV6 {
     egress_zone: u16,
     nat_src_ip: [u8; 16],
     nat_dst_ip: [u8; 16],
-    nat_src_port: u16,  // __be16, network byte order
-    nat_dst_port: u16,  // __be16, network byte order
+    nat_src_port: u16, // __be16, network byte order
+    nat_dst_port: u16, // __be16, network byte order
     fwd_packets: u64,
     fwd_bytes: u64,
     rev_packets: u64,
@@ -812,7 +812,9 @@ pub(super) fn publish_session_map_entry_for_session_with_origin(
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) -> io::Result<()> {
-    publish_session_map_entry_for_session_with_conntrack(map_fd, key, decision, metadata, origin, None)
+    publish_session_map_entry_for_session_with_conntrack(
+        map_fd, key, decision, metadata, origin, None,
+    )
 }
 
 pub(super) fn publish_session_map_entry_for_session_with_conntrack(
@@ -838,14 +840,28 @@ pub(super) fn publish_session_map_entry_for_session_with_conntrack(
         }
         // Also mirror to conntrack for session display.
         if let Some(ctx) = ct {
-            publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+            publish_bpf_conntrack_entry(
+                ctx.v4_fd,
+                ctx.v6_fd,
+                key,
+                decision,
+                metadata,
+                ctx.zone_name_to_id,
+            );
         }
         return Ok(());
     }
     let result = publish_live_session_entry(map_fd, key, decision.nat, metadata.is_reverse);
     // Mirror to conntrack for session display.
     if let Some(ctx) = ct {
-        publish_bpf_conntrack_entry(ctx.v4_fd, ctx.v6_fd, key, decision, metadata, ctx.zone_name_to_id);
+        publish_bpf_conntrack_entry(
+            ctx.v4_fd,
+            ctx.v6_fd,
+            key,
+            decision,
+            metadata,
+            ctx.zone_name_to_id,
+        );
     }
     result
 }
@@ -1089,7 +1105,13 @@ pub(super) fn delete_session_map_entry_for_removed_session(
     // Default to SyncImport for backwards-compatible callers where
     // the session being deleted is always from a sync path.
     delete_session_map_entry_for_removed_session_with_origin(
-        map_fd, key, decision, metadata, SessionOrigin::SyncImport, -1, -1,
+        map_fd,
+        key,
+        decision,
+        metadata,
+        SessionOrigin::SyncImport,
+        -1,
+        -1,
     );
 }
 
@@ -1226,8 +1248,7 @@ mod tests {
         // The packed struct bytes at the port offsets must be big-endian:
         // port 80 = 0x0050 -> bytes [0x00, 0x50]
         // port 443 = 0x01BB -> bytes [0x01, 0xBB]
-        let bytes: [u8; 16] =
-            unsafe { core::mem::transmute(bpf_key) };
+        let bytes: [u8; 16] = unsafe { core::mem::transmute(bpf_key) };
         assert_eq!(bytes[8], 0x00, "src_port high byte");
         assert_eq!(bytes[9], 0x50, "src_port low byte");
         assert_eq!(bytes[10], 0x01, "dst_port high byte");

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -208,6 +208,48 @@ pub(super) struct WorkerCommandResults {
     pub exported_sequences: Vec<u64>,
 }
 
+fn force_live_redirect_for_worker_synced_entry(
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+    allow_replace_local: bool,
+) -> bool {
+    allow_replace_local && uses_kernel_local_session_map_entry(decision, metadata, origin)
+}
+
+fn publish_worker_session_map_entry(
+    session_map_fd: c_int,
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+    allow_replace_local: bool,
+) {
+    if session_map_fd < 0 {
+        return;
+    }
+    let uses_kernel_local = uses_kernel_local_session_map_entry(decision, metadata, origin);
+    let _ = if force_live_redirect_for_worker_synced_entry(
+        decision,
+        metadata,
+        origin,
+        allow_replace_local,
+    ) {
+        publish_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse)
+    } else {
+        if uses_kernel_local {
+            delete_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse);
+        }
+        publish_session_map_entry_for_session_with_origin(
+            session_map_fd,
+            key,
+            decision,
+            metadata,
+            origin,
+        )
+    };
+}
+
 fn export_forward_sessions_for_owner_rgs(sessions: &mut SessionTable, owner_rgs: &[i32]) {
     if owner_rgs.is_empty() {
         return;
@@ -280,6 +322,23 @@ pub(super) fn apply_worker_commands(
                         continue;
                     }
                     for demoted_key in sessions.demote_owner_rg(owner_rg_id) {
+                        let Some((decision, metadata, origin)) =
+                            sessions.entry_with_origin(&demoted_key)
+                        else {
+                            continue;
+                        };
+                        publish_worker_session_map_entry(
+                            session_map_fd,
+                            &demoted_key,
+                            decision,
+                            &metadata,
+                            origin,
+                            synced_entry_allows_local_replace(
+                                ha_state,
+                                metadata.owner_rg_id,
+                                now_secs,
+                            ),
+                        );
                         if !cancelled_keys.iter().any(|key| key == &demoted_key) {
                             cancelled_keys.push(demoted_key);
                         }
@@ -353,11 +412,13 @@ pub(super) fn apply_worker_commands(
                     entry.tcp_flags,
                     allow_replace_local,
                 ) {
-                    let _ = publish_session_map_entry_for_session(
+                    publish_worker_session_map_entry(
                         session_map_fd,
                         &key,
                         entry.decision,
                         &metadata,
+                        entry.origin,
+                        allow_replace_local,
                     );
                 }
             }
@@ -1070,6 +1131,23 @@ mod tests {
             },
         );
         forwarding
+    }
+
+    fn test_local_delivery_decision() -> SessionDecision {
+        SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::LocalDelivery,
+                local_ifindex: 12,
+                egress_ifindex: 12,
+                tx_ifindex: 12,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        }
     }
 
     fn test_forwarding_state_with_fabric() -> ForwardingState {
@@ -2393,6 +2471,138 @@ mod tests {
         let hit = sessions.lookup(&key, 2_000_000, 0x10).expect("live hit");
         assert_eq!(hit.metadata, live_metadata);
         assert_eq!(hit.decision, live_decision);
+    }
+
+    #[test]
+    fn worker_synced_local_delivery_forces_live_redirect_on_standby() {
+        assert!(force_live_redirect_for_worker_synced_entry(
+            test_local_delivery_decision(),
+            &test_metadata(),
+            SessionOrigin::SyncImport,
+            true,
+        ));
+    }
+
+    #[test]
+    fn worker_synced_local_delivery_keeps_default_publish_on_active_owner() {
+        assert!(!force_live_redirect_for_worker_synced_entry(
+            test_local_delivery_decision(),
+            &test_metadata(),
+            SessionOrigin::SyncImport,
+            false,
+        ));
+    }
+
+    #[test]
+    fn apply_worker_commands_demotes_local_owner_rg_sessions_to_sync_import() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        assert!(sessions.install_with_protocol(
+            key.clone(),
+            test_decision(),
+            test_metadata(),
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![1] });
+        let forwarding = test_forwarding_state();
+        let ha_state = BTreeMap::from([(1, inactive_ha_runtime(0))]);
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+
+        apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+        );
+
+        let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
+            panic!("demoted session missing");
+        };
+        assert_eq!(origin, SessionOrigin::SyncImport);
+    }
+
+    #[test]
+    fn demoted_local_session_promotes_as_synced_on_failback_lookup() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = test_decision();
+        let metadata = test_metadata();
+        assert!(sessions.install_with_protocol(
+            key.clone(),
+            decision,
+            metadata.clone(),
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        commands
+            .lock()
+            .expect("commands lock")
+            .push_back(WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![1] });
+        let forwarding = test_forwarding_state();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let inactive_state = BTreeMap::from([(1, inactive_ha_runtime(0))]);
+
+        apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &forwarding,
+            &inactive_state,
+            &dynamic_neighbors,
+        );
+
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+        let active_state = BTreeMap::from([(1, active_ha_runtime(1))]);
+        let flow = SessionFlow {
+            src_ip: key.src_ip,
+            dst_ip: key.dst_ip,
+            forward_key: key.clone(),
+        };
+
+        let resolved = resolve_flow_session_decision(
+            &mut sessions,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &active_state,
+            &dynamic_neighbors,
+            &flow,
+            2_000_000,
+            2,
+            PROTO_TCP,
+            0x10,
+            6,
+            0,
+        )
+        .expect("resolved demoted session");
+
+        assert!(!resolved.created);
+        let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
+            panic!("promoted session missing");
+        };
+        assert_eq!(origin, SessionOrigin::SharedPromote);
     }
 
     #[test]


### PR DESCRIPTION
Closes #584

## Summary
- demote worker-local sessions for demoted owner RGs instead of only demoting shared replicas
- republish worker session-map entries under the demoted ownership rules
- add regressions for worker demotion and failback promotion behavior

## Testing
- cargo test --manifest-path userspace-dp/Cargo.toml afxdp::session_glue::tests:: -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml afxdp::ha::tests:: -- --nocapture