### PR TITLE
ha: refresh standby neighbors when synced sessions arrive

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -231,6 +231,12 @@ type SessionSync struct {
 	// bpf_fib_lookup succeeds for the first packet after VRRP MASTER (#485).
 	OnPrepareActivation func(rgID int)
 
+	// OnForwardSessionInstalled is called when a forward cluster-synced
+	// session has been successfully installed into the local dataplane.
+	// The daemon uses this as a low-latency signal to refresh standby
+	// neighbor state without waiting for the periodic sweep interval.
+	OnForwardSessionInstalled func()
+
 	// OnBulkSyncReceived is called when a bulk sync transfer completes
 	// (syncMsgBulkEnd received). The secondary uses this to release VRRP
 	// sync hold after session state has been installed.
@@ -1921,6 +1927,9 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 					if err := installer.SetClusterSyncedSessionV4(key, val); err == nil {
 						s.stats.SessionsInstalled.Add(1)
 						s.noteHelperMirrorResult("v4", &s.sessionMirrorWarnedV4, nil)
+						if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
+							s.OnForwardSessionInstalled()
+						}
 					} else {
 						s.noteHelperMirrorResult("v4", &s.sessionMirrorWarnedV4, err)
 					}
@@ -1935,6 +1944,9 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 					val.FibGen = 0
 					if err := s.dp.SetSessionV4(key, val); err == nil {
 						s.stats.SessionsInstalled.Add(1)
+						if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
+							s.OnForwardSessionInstalled()
+						}
 					}
 				}
 				// Create reverse session entry from forward entries so return
@@ -2020,6 +2032,9 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 					if err := installer.SetClusterSyncedSessionV6(key, val); err == nil {
 						s.stats.SessionsInstalled.Add(1)
 						s.noteHelperMirrorResult("v6", &s.sessionMirrorWarnedV6, nil)
+						if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
+							s.OnForwardSessionInstalled()
+						}
 					} else {
 						s.noteHelperMirrorResult("v6", &s.sessionMirrorWarnedV6, err)
 					}
@@ -2032,6 +2047,9 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 					val.FibGen = 0
 					if err := s.dp.SetSessionV6(key, val); err == nil {
 						s.stats.SessionsInstalled.Add(1)
+						if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
+							s.OnForwardSessionInstalled()
+						}
 					}
 				}
 				if val.IsReverse == 0 && val.ReverseKey.Protocol != 0 {

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -201,6 +201,39 @@ func TestPeerHealthyRequiresRecentInboundAfterHeartbeatAck(t *testing.T) {
 	}
 }
 
+func TestForwardSessionInstalledCallbackFiresOnlyForForwardSessions(t *testing.T) {
+	dp := &mockSweepDP{}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	calls := 0
+	ss.OnForwardSessionInstalled = func() {
+		calls++
+	}
+
+	key := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 0, 1},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  12345,
+		DstPort:  5201,
+		Protocol: 6,
+	}
+	val := dataplane.SessionValue{
+		State:       dataplane.SessStateEstablished,
+		IngressZone: 1,
+		EgressZone:  2,
+	}
+
+	ss.handleMessage(nil, syncMsgSessionV4, encodeSessionV4(key, val)[syncHeaderSize:])
+	if got := calls; got != 1 {
+		t.Fatalf("forward callback calls = %d, want 1", got)
+	}
+
+	val.IsReverse = 1
+	ss.handleMessage(nil, syncMsgSessionV4, encodeSessionV4(key, val)[syncHeaderSize:])
+	if got := calls; got != 1 {
+		t.Fatalf("reverse callback calls = %d, want 1", got)
+	}
+}
+
 func TestSyncStatsInit(t *testing.T) {
 	ss := NewSessionSync(":4785", "10.0.0.2:4785", nil)
 	stats := ss.Stats()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -69,48 +69,49 @@ const nodeIDFile = "/etc/bpfrx/node-id"
 
 // Daemon is the main bpfrx daemon.
 type Daemon struct {
-	opts               Options
-	store              *configstore.Store
-	dp                 dataplane.DataPlane
-	networkd           *networkd.Manager
-	routing            *routing.Manager
-	frr                *frr.Manager
-	ipsec              *ipsec.Manager
-	ra                 *ra.Manager
-	dhcp               *dhcp.Manager
-	dhcpServer         *dhcpserver.Manager
-	feeds              *feeds.Manager
-	rpm                *rpm.Manager
-	flowExporter       *flowexport.Exporter
-	flowCancel         context.CancelFunc
-	flowWg             sync.WaitGroup
-	ipfixExporter      *flowexport.IPFIXExporter
-	ipfixCancel        context.CancelFunc
-	ipfixWg            sync.WaitGroup
-	dhcpRelay          *dhcprelay.Manager
-	snmpAgent          *snmp.Agent
-	lldpMgr            *lldp.Manager
-	scheduler          *scheduler.Scheduler
-	cluster            *cluster.Manager
-	sessionSync        *cluster.SessionSync
-	syncBulkPrimed     atomic.Bool
-	syncPeerBulkPrimed atomic.Bool
-	syncPeerConnected  atomic.Bool
-	hbSuppressStart    atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
-	syncPrimeRetryGen  atomic.Uint64
-	syncReadyTimerGen  atomic.Uint64
-	syncReadyTimerMu   sync.Mutex
-	syncReadyTimer     *time.Timer
-	syncReadyTimeout   time.Duration
-	slogHandler        *logging.SyslogSlogHandler
-	traceWriter        *logging.TraceWriter
-	eventReader        *logging.EventReader
-	eventEngine        *eventengine.Engine
-	aggregator         *logging.SessionAggregator
-	aggCancel          context.CancelFunc
-	vrrpMgr            *vrrp.Manager
-	gc                 *conntrack.GC
-	startTime          time.Time // daemon start time; used to suppress stale config sync
+	opts                       Options
+	store                      *configstore.Store
+	dp                         dataplane.DataPlane
+	networkd                   *networkd.Manager
+	routing                    *routing.Manager
+	frr                        *frr.Manager
+	ipsec                      *ipsec.Manager
+	ra                         *ra.Manager
+	dhcp                       *dhcp.Manager
+	dhcpServer                 *dhcpserver.Manager
+	feeds                      *feeds.Manager
+	rpm                        *rpm.Manager
+	flowExporter               *flowexport.Exporter
+	flowCancel                 context.CancelFunc
+	flowWg                     sync.WaitGroup
+	ipfixExporter              *flowexport.IPFIXExporter
+	ipfixCancel                context.CancelFunc
+	ipfixWg                    sync.WaitGroup
+	dhcpRelay                  *dhcprelay.Manager
+	snmpAgent                  *snmp.Agent
+	lldpMgr                    *lldp.Manager
+	scheduler                  *scheduler.Scheduler
+	cluster                    *cluster.Manager
+	sessionSync                *cluster.SessionSync
+	syncBulkPrimed             atomic.Bool
+	syncPeerBulkPrimed         atomic.Bool
+	syncPeerConnected          atomic.Bool
+	lastStandbyNeighborRefresh atomic.Int64
+	hbSuppressStart            atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
+	syncPrimeRetryGen          atomic.Uint64
+	syncReadyTimerGen          atomic.Uint64
+	syncReadyTimerMu           sync.Mutex
+	syncReadyTimer             *time.Timer
+	syncReadyTimeout           time.Duration
+	slogHandler                *logging.SyslogSlogHandler
+	traceWriter                *logging.TraceWriter
+	eventReader                *logging.EventReader
+	eventEngine                *eventengine.Engine
+	aggregator                 *logging.SessionAggregator
+	aggCancel                  context.CancelFunc
+	vrrpMgr                    *vrrp.Manager
+	gc                         *conntrack.GC
+	startTime                  time.Time // daemon start time; used to suppress stale config sync
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
@@ -237,6 +238,34 @@ type Daemon struct {
 	// not rerun the same barrier sequence immediately afterward.
 	userspaceDemotionPrepMu    sync.Mutex
 	userspaceDemotionPrepUntil map[int]time.Time
+}
+
+const standbyNeighborRefreshMinInterval = time.Second
+
+func (d *Daemon) shouldScheduleStandbyNeighborRefresh(now time.Time) bool {
+	nowUnix := now.UnixNano()
+	last := d.lastStandbyNeighborRefresh.Load()
+	if last != 0 && nowUnix-last < int64(standbyNeighborRefreshMinInterval) {
+		return false
+	}
+	return d.lastStandbyNeighborRefresh.CompareAndSwap(last, nowUnix)
+}
+
+func (d *Daemon) scheduleStandbyNeighborRefresh() {
+	if d.cluster == nil || d.dp == nil {
+		return
+	}
+	if !d.shouldScheduleStandbyNeighborRefresh(time.Now()) {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	go func(cfg *config.Config) {
+		d.resolveNeighborsInner(cfg, false)
+		d.maintainClusterNeighborReadiness()
+	}(cfg)
 }
 
 // New creates a new Daemon.

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -13,7 +13,6 @@ import (
 	"github.com/psaab/bpfrx/pkg/config"
 )
 
-
 func (d *Daemon) stopSyncReadyTimer() {
 	d.syncReadyTimerMu.Lock()
 	defer d.syncReadyTimerMu.Unlock()
@@ -586,6 +585,10 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.sessionSync.OnBulkSyncAckReceived = func() {
 				d.cluster.RecordEvent(cluster.EventColdSync, -1, "Bulk sync acknowledged by peer")
 				d.onSessionSyncBulkAckReceived()
+			}
+
+			d.sessionSync.OnForwardSessionInstalled = func() {
+				d.scheduleStandbyNeighborRefresh()
 			}
 
 			// Wire bulk sync override: use event stream export (fast path)

--- a/pkg/daemon/resolve_neighbor_test.go
+++ b/pkg/daemon/resolve_neighbor_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	"github.com/psaab/bpfrx/pkg/config"
 )
@@ -40,5 +41,19 @@ func TestResolveJunosIfName(t *testing.T) {
 				t.Errorf("resolveJunosIfName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestShouldScheduleStandbyNeighborRefresh(t *testing.T) {
+	var d Daemon
+	base := time.Unix(100, 0)
+	if !d.shouldScheduleStandbyNeighborRefresh(base) {
+		t.Fatal("first standby neighbor refresh should schedule")
+	}
+	if d.shouldScheduleStandbyNeighborRefresh(base.Add(500 * time.Millisecond)) {
+		t.Fatal("refresh inside debounce interval should not schedule")
+	}
+	if !d.shouldScheduleStandbyNeighborRefresh(base.Add(standbyNeighborRefreshMinInterval + time.Millisecond)) {
+		t.Fatal("refresh after debounce interval should schedule")
 	}
 }


### PR DESCRIPTION
Closes #587.

This wires a low-latency signal from session sync into the daemon when a forward synced session is installed, then debounces a standby neighbor refresh so the promoted owner does not wait for the periodic sweep before it can resolve WAN next hops.

What changed:
- add `OnForwardSessionInstalled` to `SessionSync`
- fire it only for forward session installs
- debounce standby neighbor refreshes to 1s in the daemon
- reuse existing neighbor maintenance instead of adding a separate warmup path

Validation:
- `go test ./pkg/cluster ./pkg/daemon -count=1`
- live loss artifact: `/tmp/userspace-ha-failover-rg1-20260407-103004`

Impact:
- fixes the external IPv4 reachability loss during `RG1 node0 -> node1` failover on loss
- leaves the remaining session-miss / throughput-tail issue tracked separately in #590