### PR TITLE
fix: scope inferred ipv6 next-hop interfaces by vrf

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1174,7 +1174,7 @@ func enableForwarding() {
 	slog.Info("IP forwarding enabled, RA acceptance disabled")
 }
 
-func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
+func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]string {
 	type connectedPrefix struct {
 		net    *net.IPNet
 		ifName string
@@ -1182,9 +1182,21 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
 	}
 
 	var connected []connectedPrefix
-	for ifName, ifc := range cfg.Interfaces.Interfaces {
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for ifName := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, ifName)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
 		base := config.LinuxIfName(ifName)
-		for unitNum, unit := range ifc.Units {
+		unitNums := make([]int, 0, len(ifc.Units))
+		for unitNum := range ifc.Units {
+			unitNums = append(unitNums, unitNum)
+		}
+		sort.Ints(unitNums)
+		for _, unitNum := range unitNums {
+			unit := ifc.Units[unitNum]
 			logical := base
 			if unitNum != 0 {
 				logical = fmt.Sprintf("%s.%d", base, unitNum)
@@ -1212,7 +1224,10 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
 		bestIf := ""
 		bestBits := -1
 		for _, candidate := range connected {
-			if candidate.net.Contains(ip) && candidate.bits > bestBits {
+			if !candidate.net.Contains(ip) {
+				continue
+			}
+			if candidate.bits > bestBits || (candidate.bits == bestBits && (bestIf == "" || candidate.ifName < bestIf)) {
 				bestIf = candidate.ifName
 				bestBits = candidate.bits
 			}
@@ -1220,25 +1235,40 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]string {
 		return bestIf
 	}
 
-	resolved := make(map[string]string)
-	addRoutes := func(routes []*config.StaticRoute) {
+	resolved := make(map[string]map[string]string)
+	setResolved := func(vrfName, nextHop, ifName string) {
+		if ifName == "" {
+			return
+		}
+		vrfMap, ok := resolved[vrfName]
+		if !ok {
+			vrfMap = make(map[string]string)
+			resolved[vrfName] = vrfMap
+		}
+		if existing, ok := vrfMap[nextHop]; !ok || ifName < existing {
+			vrfMap[nextHop] = ifName
+		}
+	}
+	addRoutes := func(vrfName string, routes []*config.StaticRoute) {
 		for _, sr := range routes {
 			for _, nh := range sr.NextHops {
 				if nh.Interface != "" || nh.Address == "" || !strings.Contains(nh.Address, ":") {
 					continue
 				}
-				if ifName := resolve(nh.Address); ifName != "" {
-					resolved[nh.Address] = ifName
-				}
+				setResolved(vrfName, nh.Address, resolve(nh.Address))
 			}
 		}
 	}
 
-	addRoutes(cfg.RoutingOptions.StaticRoutes)
-	addRoutes(cfg.RoutingOptions.Inet6StaticRoutes)
+	addRoutes("", cfg.RoutingOptions.StaticRoutes)
+	addRoutes("", cfg.RoutingOptions.Inet6StaticRoutes)
 	for _, ri := range cfg.RoutingInstances {
-		addRoutes(ri.StaticRoutes)
-		addRoutes(ri.Inet6StaticRoutes)
+		vrfName := "vrf-" + ri.Name
+		if ri.InstanceType == "forwarding" {
+			vrfName = ""
+		}
+		addRoutes(vrfName, ri.StaticRoutes)
+		addRoutes(vrfName, ri.Inet6StaticRoutes)
 	}
 	return resolved
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1182,6 +1182,7 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 	}
 
 	var connected []connectedPrefix
+	connectedByLogical := make(map[string][]connectedPrefix)
 	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
 	for ifName := range cfg.Interfaces.Interfaces {
 		ifNames = append(ifNames, ifName)
@@ -1207,23 +1208,25 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 					continue
 				}
 				bits, _ := ipNet.Mask.Size()
-				connected = append(connected, connectedPrefix{
+				prefix := connectedPrefix{
 					net:    ipNet,
 					ifName: logical,
 					bits:   bits,
-				})
+				}
+				connected = append(connected, prefix)
+				connectedByLogical[logical] = append(connectedByLogical[logical], prefix)
 			}
 		}
 	}
 
-	resolve := func(addr string) string {
+	resolve := func(candidates []connectedPrefix, addr string) string {
 		ip := net.ParseIP(addr)
 		if ip == nil || ip.To4() != nil {
 			return ""
 		}
 		bestIf := ""
 		bestBits := -1
-		for _, candidate := range connected {
+		for _, candidate := range candidates {
 			if !candidate.net.Contains(ip) {
 				continue
 			}
@@ -1235,7 +1238,31 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 		return bestIf
 	}
 
+	collectPrefixesForInterface := func(ifName string) []connectedPrefix {
+		normalized := config.LinuxIfName(ifName)
+		var prefixes []connectedPrefix
+		if entries, ok := connectedByLogical[normalized]; ok {
+			prefixes = append(prefixes, entries...)
+		}
+		if !strings.Contains(normalized, ".") {
+			prefixNames := make([]string, 0, len(connectedByLogical))
+			for logical := range connectedByLogical {
+				if strings.HasPrefix(logical, normalized+".") {
+					prefixNames = append(prefixNames, logical)
+				}
+			}
+			sort.Strings(prefixNames)
+			for _, logical := range prefixNames {
+				prefixes = append(prefixes, connectedByLogical[logical]...)
+			}
+		}
+		return prefixes
+	}
+
 	resolved := make(map[string]map[string]string)
+	connectedByVRF := map[string][]connectedPrefix{
+		"": append([]connectedPrefix(nil), connected...),
+	}
 	setResolved := func(vrfName, nextHop, ifName string) {
 		if ifName == "" {
 			return
@@ -1250,14 +1277,51 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 		}
 	}
 	addRoutes := func(vrfName string, routes []*config.StaticRoute) {
+		candidates := connectedByVRF[vrfName]
 		for _, sr := range routes {
 			for _, nh := range sr.NextHops {
 				if nh.Interface != "" || nh.Address == "" || !strings.Contains(nh.Address, ":") {
 					continue
 				}
-				setResolved(vrfName, nh.Address, resolve(nh.Address))
+				setResolved(vrfName, nh.Address, resolve(candidates, nh.Address))
 			}
 		}
+	}
+
+	claimedByVRF := make(map[string]struct{})
+	for _, ri := range cfg.RoutingInstances {
+		vrfName := "vrf-" + ri.Name
+		if ri.InstanceType == "forwarding" {
+			vrfName = ""
+		}
+		for _, ifName := range ri.Interfaces {
+			prefixes := collectPrefixesForInterface(ifName)
+			if len(prefixes) == 0 {
+				continue
+			}
+			connectedByVRF[vrfName] = append(connectedByVRF[vrfName], prefixes...)
+			if vrfName != "" {
+				normalized := config.LinuxIfName(ifName)
+				claimedByVRF[normalized] = struct{}{}
+			}
+		}
+	}
+	if len(claimedByVRF) > 0 {
+		filtered := connectedByVRF[""][:0]
+		for _, prefix := range connectedByVRF[""] {
+			base := prefix.ifName
+			if idx := strings.IndexByte(base, '.'); idx >= 0 {
+				base = base[:idx]
+			}
+			if _, claimed := claimedByVRF[prefix.ifName]; claimed {
+				continue
+			}
+			if _, claimed := claimedByVRF[base]; claimed {
+				continue
+			}
+			filtered = append(filtered, prefix)
+		}
+		connectedByVRF[""] = filtered
 	}
 
 	addRoutes("", cfg.RoutingOptions.StaticRoutes)

--- a/pkg/daemon/ipv6_static_nexthop_test.go
+++ b/pkg/daemon/ipv6_static_nexthop_test.go
@@ -89,6 +89,7 @@ func TestInferIPv6StaticNextHopInterfaces_ByVRFAndDeterministicTieBreak(t *testi
 			{
 				Name:         "BLUE",
 				InstanceType: "vrf",
+				Interfaces:   []string{"reth1.10"},
 				Inet6StaticRoutes: []*config.StaticRoute{
 					{
 						Destination: "2001:db8:ffff::/48",
@@ -103,7 +104,7 @@ func TestInferIPv6StaticNextHopInterfaces_ByVRFAndDeterministicTieBreak(t *testi
 	if got[""]["2001:db8:1::100"] != "reth0.10" {
 		t.Fatalf("global tie-break interface = %q, want reth0.10", got[""]["2001:db8:1::100"])
 	}
-	if got["vrf-BLUE"]["2001:db8:1::100"] != "reth0.10" {
-		t.Fatalf("vrf tie-break interface = %q, want reth0.10", got["vrf-BLUE"]["2001:db8:1::100"])
+	if got["vrf-BLUE"]["2001:db8:1::100"] != "reth1.10" {
+		t.Fatalf("vrf-scoped interface = %q, want reth1.10", got["vrf-BLUE"]["2001:db8:1::100"])
 	}
 }

--- a/pkg/daemon/ipv6_static_nexthop_test.go
+++ b/pkg/daemon/ipv6_static_nexthop_test.go
@@ -50,13 +50,60 @@ func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
 	}
 
 	got := inferIPv6StaticNextHopInterfaces(cfg)
-	if got["2001:559:8585:50::1"] != "reth0.50" {
-		t.Fatalf("default route next-hop interface = %q, want reth0.50", got["2001:559:8585:50::1"])
+	if got[""]["2001:559:8585:50::1"] != "reth0.50" {
+		t.Fatalf("default route next-hop interface = %q, want reth0.50", got[""]["2001:559:8585:50::1"])
 	}
-	if got["2001:559:8585:80::1"] != "reth0.80" {
-		t.Fatalf("gre route next-hop interface = %q, want reth0.80", got["2001:559:8585:80::1"])
+	if got[""]["2001:559:8585:80::1"] != "reth0.80" {
+		t.Fatalf("gre route next-hop interface = %q, want reth0.80", got[""]["2001:559:8585:80::1"])
 	}
-	if got["2001:559:8585:ef00::2"] != "reth1" {
-		t.Fatalf("inet6 static route next-hop interface = %q, want reth1", got["2001:559:8585:ef00::2"])
+	if got[""]["2001:559:8585:ef00::2"] != "reth1" {
+		t.Fatalf("inet6 static route next-hop interface = %q, want reth1", got[""]["2001:559:8585:ef00::2"])
+	}
+}
+
+func TestInferIPv6StaticNextHopInterfaces_ByVRFAndDeterministicTieBreak(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Units: map[int]*config.InterfaceUnit{
+						10: {Addresses: []string{"2001:db8:1::1/64"}},
+					},
+				},
+				"reth0": {
+					Units: map[int]*config.InterfaceUnit{
+						10: {Addresses: []string{"2001:db8:1::2/64"}},
+					},
+				},
+			},
+		},
+		RoutingOptions: config.RoutingOptionsConfig{
+			Inet6StaticRoutes: []*config.StaticRoute{
+				{
+					Destination: "::/0",
+					NextHops:    []config.NextHopEntry{{Address: "2001:db8:1::100"}},
+				},
+			},
+		},
+		RoutingInstances: []*config.RoutingInstanceConfig{
+			{
+				Name:         "BLUE",
+				InstanceType: "vrf",
+				Inet6StaticRoutes: []*config.StaticRoute{
+					{
+						Destination: "2001:db8:ffff::/48",
+						NextHops:    []config.NextHopEntry{{Address: "2001:db8:1::100"}},
+					},
+				},
+			},
+		},
+	}
+
+	got := inferIPv6StaticNextHopInterfaces(cfg)
+	if got[""]["2001:db8:1::100"] != "reth0.10" {
+		t.Fatalf("global tie-break interface = %q, want reth0.10", got[""]["2001:db8:1::100"])
+	}
+	if got["vrf-BLUE"]["2001:db8:1::100"] != "reth0.10" {
+		t.Fatalf("vrf tie-break interface = %q, want reth0.10", got["vrf-BLUE"]["2001:db8:1::100"])
 	}
 }

--- a/pkg/frr/frr.go
+++ b/pkg/frr/frr.go
@@ -90,12 +90,12 @@ type FullConfig struct {
 	// Used to translate RETH interface names in static routes to kernel names.
 	RethMap map[string]string
 
-	// IPv6NextHopInterfaces maps IPv6 next-hops used by global and per-instance
-	// static routes to the interface to use when the route omits an explicit
-	// interface. Values may still be logical interface names (for example,
-	// "reth0.50"); any later translation to kernel/physical names is handled
-	// separately via RethMap.
-	IPv6NextHopInterfaces map[string]string
+	// IPv6NextHopInterfaces maps VRF name -> IPv6 next-hop -> interface for
+	// global and per-instance static routes that omit an explicit interface.
+	// Values may still be logical interface names (for example, "reth0.50");
+	// any later translation to kernel/physical names is handled separately via
+	// RethMap. The global table uses the empty-string VRF key.
+	IPv6NextHopInterfaces map[string]map[string]string
 
 	// ConsistentHash is set when the forwarding-table export policy uses
 	// "load-balance consistent-hash". The daemon should set
@@ -476,7 +476,7 @@ func (m *Manager) generateInterfaceSettings(fc *FullConfig) string {
 // generateStaticRoute produces FRR static route commands.
 // Multiple next-hops produce one line each (FRR creates ECMP).
 // Routes with NextTable are handled via ip rule (policy routing), not FRR.
-func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, rethMap map[string]string, ipv6NextHopInterfaces map[string]string) string {
+func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, rethMap map[string]string, ipv6NextHopInterfaces map[string]map[string]string) string {
 	if sr.NextTable != "" {
 		return "" // handled via ip rule in routing package
 	}
@@ -508,7 +508,7 @@ func (m *Manager) generateStaticRoute(sr *config.StaticRoute, vrfName string, re
 		// interface names and must NOT be stripped.
 		ifName := nh.Interface
 		if isV6 && ifName == "" && nh.Address != "" {
-			ifName = ipv6NextHopInterfaces[nh.Address]
+			ifName = ipv6NextHopInterfaces[vrfName][nh.Address]
 		}
 		if strings.HasSuffix(ifName, ".0") {
 			ifName = ifName[:len(ifName)-2]

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -866,10 +866,29 @@ func TestGenerateStaticRoute_InferredIPv6NextHopInterface(t *testing.T) {
 			{Address: "2001:559:8585:50::1"},
 		},
 	}
-	got := m.generateStaticRoute(sr, "", rethMap, map[string]string{
-		"2001:559:8585:50::1": "reth0.50",
+	got := m.generateStaticRoute(sr, "", rethMap, map[string]map[string]string{
+		"": {"2001:559:8585:50::1": "reth0.50"},
 	})
 	want := "ipv6 route ::/0 2001:559:8585:50::1 ge-0-0-2.50\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateStaticRoute_InferredIPv6NextHopInterfaceByVRF(t *testing.T) {
+	m := New()
+	rethMap := map[string]string{"reth0": "ge-0/0/2", "reth1": "ge-0/0/3"}
+	sr := &config.StaticRoute{
+		Destination: "2001:db8:ffff::/48",
+		NextHops: []config.NextHopEntry{
+			{Address: "2001:db8:1::100"},
+		},
+	}
+	got := m.generateStaticRoute(sr, "BLUE", rethMap, map[string]map[string]string{
+		"":     {"2001:db8:1::100": "reth0.10"},
+		"BLUE": {"2001:db8:1::100": "reth1.20"},
+	})
+	want := "ipv6 route 2001:db8:ffff::/48 2001:db8:1::100 ge-0-0-3.20 vrf BLUE\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -884,11 +884,11 @@ func TestGenerateStaticRoute_InferredIPv6NextHopInterfaceByVRF(t *testing.T) {
 			{Address: "2001:db8:1::100"},
 		},
 	}
-	got := m.generateStaticRoute(sr, "BLUE", rethMap, map[string]map[string]string{
-		"":     {"2001:db8:1::100": "reth0.10"},
-		"BLUE": {"2001:db8:1::100": "reth1.20"},
+	got := m.generateStaticRoute(sr, "vrf-BLUE", rethMap, map[string]map[string]string{
+		"":         {"2001:db8:1::100": "reth0.10"},
+		"vrf-BLUE": {"2001:db8:1::100": "reth1.20"},
 	})
-	want := "ipv6 route 2001:db8:ffff::/48 2001:db8:1::100 ge-0-0-3.20 vrf BLUE\n"
+	want := "ipv6 route 2001:db8:ffff::/48 2001:db8:1::100 ge-0-0-3.20 vrf vrf-BLUE\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
Follow-up to merged PR #577.

This closes the remaining Copilot findings from that branch:
- scope inferred IPv6 next-hop interface resolution by VRF instead of a single global next-hop map
- make inference deterministic by iterating interfaces/units in sorted order and using a stable lexical tie-break for equal prefix lengths

Validation:
- `go test ./pkg/frr ./pkg/daemon -count=1`