### PR TITLE
ha: harden standby neighbor refresh scheduling

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -244,7 +244,10 @@ type Daemon struct {
 const standbyNeighborRefreshMinInterval = time.Second
 
 func (d *Daemon) shouldScheduleStandbyNeighborRefresh(now time.Time) bool {
-	elapsed := now.Sub(d.startTime).Nanoseconds()
+	elapsed := now.Sub(d.startTime).Nanoseconds() + 1
+	if elapsed < 1 {
+		elapsed = 1
+	}
 	last := d.lastStandbyNeighborRefresh.Load()
 	if last != 0 && elapsed >= last && elapsed-last < int64(standbyNeighborRefreshMinInterval) {
 		return false

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -97,6 +97,7 @@ type Daemon struct {
 	syncPeerBulkPrimed         atomic.Bool
 	syncPeerConnected          atomic.Bool
 	lastStandbyNeighborRefresh atomic.Int64
+	neighborWarmupInFlight     atomic.Bool
 	hbSuppressStart            atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
 	syncPrimeRetryGen          atomic.Uint64
 	syncReadyTimerGen          atomic.Uint64
@@ -243,23 +244,23 @@ type Daemon struct {
 const standbyNeighborRefreshMinInterval = time.Second
 
 func (d *Daemon) shouldScheduleStandbyNeighborRefresh(now time.Time) bool {
-	nowUnix := now.UnixNano()
+	elapsed := now.Sub(d.startTime).Nanoseconds()
 	last := d.lastStandbyNeighborRefresh.Load()
-	if last != 0 && nowUnix-last < int64(standbyNeighborRefreshMinInterval) {
+	if last != 0 && elapsed >= last && elapsed-last < int64(standbyNeighborRefreshMinInterval) {
 		return false
 	}
-	return d.lastStandbyNeighborRefresh.CompareAndSwap(last, nowUnix)
+	return d.lastStandbyNeighborRefresh.CompareAndSwap(last, elapsed)
 }
 
 func (d *Daemon) scheduleStandbyNeighborRefresh() {
 	if d.cluster == nil || d.dp == nil {
 		return
 	}
-	if !d.shouldScheduleStandbyNeighborRefresh(time.Now()) {
-		return
-	}
 	cfg := d.store.ActiveConfig()
 	if cfg == nil {
+		return
+	}
+	if !d.shouldScheduleStandbyNeighborRefresh(time.Now()) {
 		return
 	}
 	go func(cfg *config.Config) {
@@ -3173,7 +3174,13 @@ func (d *Daemon) maintainClusterNeighborReadiness() {
 		return
 	}
 	d.preinstallSnapshotNeighbors()
-	go d.warmNeighborCache()
+	if !d.neighborWarmupInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer d.neighborWarmupInFlight.Store(false)
+		d.warmNeighborCache()
+	}()
 }
 
 // collectDHCPRoutes builds FRR DHCPRoute entries from active DHCP leases.

--- a/pkg/daemon/resolve_neighbor_test.go
+++ b/pkg/daemon/resolve_neighbor_test.go
@@ -47,6 +47,14 @@ func TestResolveJunosIfName(t *testing.T) {
 func TestShouldScheduleStandbyNeighborRefresh(t *testing.T) {
 	base := time.Unix(100, 0)
 	d := Daemon{startTime: base}
+	if !d.shouldScheduleStandbyNeighborRefresh(base) {
+		t.Fatal("first refresh at daemon start should schedule")
+	}
+	if d.shouldScheduleStandbyNeighborRefresh(base) {
+		t.Fatal("second refresh at daemon start should be debounced")
+	}
+
+	d = Daemon{startTime: base}
 	first := base.Add(10 * time.Second)
 	if !d.shouldScheduleStandbyNeighborRefresh(first) {
 		t.Fatal("first standby neighbor refresh should schedule")

--- a/pkg/daemon/resolve_neighbor_test.go
+++ b/pkg/daemon/resolve_neighbor_test.go
@@ -45,15 +45,19 @@ func TestResolveJunosIfName(t *testing.T) {
 }
 
 func TestShouldScheduleStandbyNeighborRefresh(t *testing.T) {
-	var d Daemon
 	base := time.Unix(100, 0)
-	if !d.shouldScheduleStandbyNeighborRefresh(base) {
+	d := Daemon{startTime: base}
+	first := base.Add(10 * time.Second)
+	if !d.shouldScheduleStandbyNeighborRefresh(first) {
 		t.Fatal("first standby neighbor refresh should schedule")
 	}
-	if d.shouldScheduleStandbyNeighborRefresh(base.Add(500 * time.Millisecond)) {
+	if d.shouldScheduleStandbyNeighborRefresh(first.Add(500 * time.Millisecond)) {
 		t.Fatal("refresh inside debounce interval should not schedule")
 	}
-	if !d.shouldScheduleStandbyNeighborRefresh(base.Add(standbyNeighborRefreshMinInterval + time.Millisecond)) {
+	if !d.shouldScheduleStandbyNeighborRefresh(first.Add(standbyNeighborRefreshMinInterval + time.Millisecond)) {
 		t.Fatal("refresh after debounce interval should schedule")
+	}
+	if !d.shouldScheduleStandbyNeighborRefresh(first.Add(-time.Second)) {
+		t.Fatal("clock step backwards should not suppress refresh scheduling")
 	}
 }


### PR DESCRIPTION
Follow-up to merged PR #591.

This closes the remaining Copilot findings from that branch:
- use monotonic debounce accounting for standby neighbor refresh scheduling
- avoid consuming the debounce window when there is no active config
- prevent overlapping expensive neighbor warmup runs while still allowing cheap preinstall refreshes

Validation:
- `go test ./pkg/daemon -count=1`