### PR TITLE
fix: reconnect half-open session sync after ack timeout

### DIFF
--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -289,7 +289,6 @@ type SessionSync struct {
 	deleteJournal        [][]byte // ring buffer of encoded delete messages
 	deleteJournalCap     int      // max entries (default 10000)
 	lastPeerRxUnix       atomic.Int64
-	peerHeartbeatAck     atomic.Bool
 	peerHeartbeatAckEver atomic.Bool
 	readDeadline         time.Duration
 	peerSilenceLimit     time.Duration
@@ -771,9 +770,6 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 	}
 	s.stats.Connected.Store(true)
 	s.lastPeerRxUnix.Store(time.Now().UnixNano())
-	if wasDisconnected {
-		s.peerHeartbeatAck.Store(false)
-	}
 	s.mu.Unlock()
 	becameActive := activeAfter == fabricIdx
 
@@ -2236,7 +2232,6 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		}
 
 	case syncMsgHeartbeatAck:
-		s.peerHeartbeatAck.Store(true)
 		s.peerHeartbeatAckEver.Store(true)
 
 	case syncMsgConfig:
@@ -2867,7 +2862,6 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 	connected := s.conn0 != nil || s.conn1 != nil
 	s.stats.Connected.Store(connected)
 	if !connected {
-		s.peerHeartbeatAck.Store(false)
 		pendingBarriers := s.barrierSeq.Load()
 		ackedBarriers := s.barrierAckSeq.Load()
 		// Do NOT reset barrierSeq — the monotonic counter must keep

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -285,13 +285,14 @@ type SessionSync struct {
 	// Delete journal: bounded ring buffer for delete messages during disconnect.
 	// Deletes are journaled when queueMessage fails (disconnect), then flushed
 	// on reconnect before normal sync resumes.
-	deleteJournalMu  sync.Mutex
-	deleteJournal    [][]byte // ring buffer of encoded delete messages
-	deleteJournalCap int      // max entries (default 10000)
-	lastPeerRxUnix   atomic.Int64
-	peerHeartbeatAck atomic.Bool
-	readDeadline     time.Duration
-	peerSilenceLimit time.Duration
+	deleteJournalMu      sync.Mutex
+	deleteJournal        [][]byte // ring buffer of encoded delete messages
+	deleteJournalCap     int      // max entries (default 10000)
+	lastPeerRxUnix       atomic.Int64
+	peerHeartbeatAck     atomic.Bool
+	peerHeartbeatAckEver atomic.Bool
+	readDeadline         time.Duration
+	peerSilenceLimit     time.Duration
 
 	// bulkSendMu serializes entire BulkSync() calls so two concurrent
 	// callers (e.g. acceptLoop and connectLoop) cannot interleave.
@@ -645,14 +646,15 @@ func (s *SessionSync) PeerRecentlyActive(maxAge time.Duration) bool {
 }
 
 // PeerHealthy reports whether the sync connection is established and, once the
-// peer proves heartbeat-ack support, has been observed on the protocol within
-// the expected silence window. Before that capability is observed we fall back
-// to plain connection state so rolling upgrades do not flap readiness.
+// peer has ever proved heartbeat-ack support, has been observed on the
+// protocol within the expected silence window. Before that capability is ever
+// observed we fall back to plain connection state so rolling upgrades do not
+// flap readiness.
 func (s *SessionSync) PeerHealthy() bool {
 	if !s.stats.Connected.Load() {
 		return false
 	}
-	if !s.peerHeartbeatAck.Load() {
+	if !s.peerHeartbeatAckEver.Load() {
 		return true
 	}
 	return s.PeerRecentlyActive(s.peerSilenceDuration())
@@ -1835,7 +1837,7 @@ func (s *SessionSync) receiveLoop(ctx context.Context, conn net.Conn) {
 				return
 			}
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				if s.peerHeartbeatAck.Load() {
+				if s.peerHeartbeatAckEver.Load() {
 					missedHeartbeats++
 				}
 				if missedHeartbeats >= 2 {
@@ -2235,6 +2237,7 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 
 	case syncMsgHeartbeatAck:
 		s.peerHeartbeatAck.Store(true)
+		s.peerHeartbeatAckEver.Store(true)
 
 	case syncMsgConfig:
 		s.stats.ConfigsReceived.Add(1)

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -3355,8 +3355,13 @@ func TestReceiveLoopKeepsConnectionAliveWithoutHeartbeatAckSupport(t *testing.T)
 
 	cancel()
 	serverConn.Close()
-	if err := <-serverDone; err != nil && !errors.Is(err, net.ErrClosed) && !strings.Contains(err.Error(), "use of closed network connection") && !strings.Contains(err.Error(), "EOF") {
-		t.Fatalf("server loop failed: %v", err)
+	select {
+	case err := <-serverDone:
+		if err != nil && !errors.Is(err, net.ErrClosed) && !strings.Contains(err.Error(), "use of closed network connection") && !strings.Contains(err.Error(), "EOF") {
+			t.Fatalf("server loop failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server loop to exit")
 	}
 }
 

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -178,7 +178,7 @@ func TestPeerRecentlyActive(t *testing.T) {
 	}
 }
 
-func TestPeerHealthyRequiresRecentInboundAfterHeartbeatAck(t *testing.T) {
+func TestPeerHealthyRequiresRecentInboundAfterHeartbeatAckCapability(t *testing.T) {
 	s := &SessionSync{}
 	if s.PeerHealthy() {
 		t.Fatal("expected disconnected session sync to be unhealthy")
@@ -189,7 +189,7 @@ func TestPeerHealthyRequiresRecentInboundAfterHeartbeatAck(t *testing.T) {
 		t.Fatal("expected connected pre-capability session sync to be healthy")
 	}
 
-	s.peerHeartbeatAck.Store(true)
+	s.peerHeartbeatAckEver.Store(true)
 	s.lastPeerRxUnix.Store(time.Now().UnixNano())
 	if !s.PeerHealthy() {
 		t.Fatal("expected recent peer activity to be healthy")
@@ -3355,6 +3355,116 @@ func TestReceiveLoopKeepsConnectionAliveWithoutHeartbeatAckSupport(t *testing.T)
 
 	cancel()
 	serverConn.Close()
+	if err := <-serverDone; err != nil && !errors.Is(err, net.ErrClosed) && !strings.Contains(err.Error(), "use of closed network connection") && !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("server loop failed: %v", err)
+	}
+}
+
+func TestReceiveLoopDisconnectsSilentConnectionAfterAckCapableReconnect(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverConnCh := make(chan net.Conn, 1)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		serverConnCh <- conn
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	var serverConn net.Conn
+	select {
+	case err := <-serverErrCh:
+		t.Fatalf("accept: %v", err)
+	case serverConn = <-serverConnCh:
+	}
+	defer serverConn.Close()
+
+	heartbeatSeen := make(chan struct{}, 1)
+	serverDone := make(chan error, 1)
+	go func() {
+		for {
+			var hdr [syncHeaderSize]byte
+			if err := serverConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+				serverDone <- err
+				return
+			}
+			if _, err := io.ReadFull(serverConn, hdr[:]); err != nil {
+				serverDone <- err
+				return
+			}
+			if string(hdr[0:4]) != "BPSY" {
+				serverDone <- fmt.Errorf("bad sync magic: %q", hdr[0:4])
+				return
+			}
+			payloadLen := binary.LittleEndian.Uint32(hdr[8:12])
+			if payloadLen > 0 {
+				payload := make([]byte, payloadLen)
+				if _, err := io.ReadFull(serverConn, payload); err != nil {
+					serverDone <- err
+					return
+				}
+			}
+			if hdr[4] == syncMsgHeartbeat {
+				select {
+				case heartbeatSeen <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	ss := NewSessionSync(":0", ln.Addr().String(), nil)
+	ss.bulkEverCompleted.Store(true)
+	ss.readDeadline = 100 * time.Millisecond
+	ss.peerSilenceLimit = 300 * time.Millisecond
+	ss.peerHeartbeatAckEver.Store(true)
+
+	disconnected := make(chan struct{}, 1)
+	ss.OnPeerDisconnected = func() {
+		select {
+		case disconnected <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ss.handleNewConnection(ctx, 0, clientConn)
+
+	select {
+	case <-heartbeatSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for heartbeat request")
+	}
+
+	select {
+	case <-disconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for silent reconnect disconnect")
+	}
+
+	if ss.IsConnected() {
+		t.Fatal("expected ack-capable silent reconnect to be marked disconnected")
+	}
+	if ss.PeerHealthy() {
+		t.Fatal("expected peer health to be false after silent reconnect disconnect")
+	}
+	if got := ss.getActiveConn(); got != nil {
+		t.Fatalf("expected active conn to be cleared, got %v", got)
+	}
 	if err := <-serverDone; err != nil && !errors.Is(err, net.ErrClosed) && !strings.Contains(err.Error(), "use of closed network connection") && !strings.Contains(err.Error(), "EOF") {
 		t.Fatalf("server loop failed: %v", err)
 	}


### PR DESCRIPTION
Closes #588

## Summary
- remember heartbeat-ack capability across reconnects so silent stale sockets are still considered ack-capable
- tear down silent reconnects even before a fresh ack arrives on the new connection
- add regressions for reconnects after an ack-capable peer has already been observed

## Testing
- go test ./pkg/cluster -run 'TestReceiveLoop(DisconnectsSilentConnectionAfterHeartbeatAck|KeepsConnectionAliveWithoutHeartbeatAckSupport|DisconnectsSilentConnectionAfterAckCapableReconnect|KeepsConnectionAliveWithHeartbeatAck)' -count=1\n- go test ./pkg/cluster ./pkg/daemon -count=1