### PR TITLE
fix: auto-rebind standby XSK busy wedge

### DIFF
--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -3803,6 +3803,9 @@ func (m *Manager) hasBusyBindingsWedgeLocked(repaired bool) bool {
 	ready := 0
 	busyErr := false
 	for _, binding := range bindings {
+		if binding.Ifindex <= 0 {
+			continue
+		}
 		if binding.Registered && binding.Armed {
 			registeredArmed++
 		}
@@ -4312,6 +4315,8 @@ func (m *Manager) stopLocked() {
 	}
 	if m.proc == nil {
 		m.lastStatus = ProcessStatus{}
+		m.bindingsBusySince = time.Time{}
+		m.lastBindingsAutoRebind = time.Time{}
 		m.sessionMirrorFailed = false
 		m.sessionMirrorErr = ""
 		return
@@ -4352,6 +4357,8 @@ func (m *Manager) stopLocked() {
 	m.lastXSKRX = 0
 	m.lastNAPIBootstrap = time.Time{}
 	m.lastStandbyNeighResolve = time.Time{}
+	m.bindingsBusySince = time.Time{}
+	m.lastBindingsAutoRebind = time.Time{}
 	m.publishedSnapshot = 0
 	m.publishedPlanKey = ""
 	m.sessionMirrorFailed = false

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -93,6 +93,8 @@ type Manager struct {
 	lastXSKRX               uint64
 	lastNAPIBootstrap       time.Time
 	lastStandbyNeighResolve time.Time
+	bindingsBusySince       time.Time
+	lastBindingsAutoRebind  time.Time
 	publishedSnapshot       uint64
 	publishedPlanKey        string
 	sessionMirrorFailed     bool
@@ -3782,6 +3784,83 @@ func (m *Manager) verifyBindingsMapLocked() bool {
 	return repaired > 0
 }
 
+func (m *Manager) hasBusyBindingsWedgeLocked(repaired bool) bool {
+	if m.proc == nil || m.proc.Process == nil {
+		return false
+	}
+	if !m.lastStatus.ForwardingArmed || m.deferWorkers {
+		return false
+	}
+	if m.xskLivenessProven || m.xskLivenessFailed {
+		return false
+	}
+	bindings := m.lastStatus.Bindings
+	if len(bindings) == 0 {
+		return false
+	}
+	registeredArmed := 0
+	bound := 0
+	ready := 0
+	busyErr := false
+	for _, binding := range bindings {
+		if binding.Registered && binding.Armed {
+			registeredArmed++
+		}
+		if binding.Bound {
+			bound++
+		}
+		if binding.Ready {
+			ready++
+		}
+		if strings.Contains(strings.ToLower(binding.LastError), "resource busy") {
+			busyErr = true
+		}
+	}
+	return registeredArmed > 0 && bound == 0 && ready == 0 && (busyErr || repaired)
+}
+
+func (m *Manager) shouldAutoRebindBusyBindingsLocked(now time.Time, repaired bool) bool {
+	if !m.hasBusyBindingsWedgeLocked(repaired) {
+		m.bindingsBusySince = time.Time{}
+		return false
+	}
+	if m.bindingsBusySince.IsZero() {
+		m.bindingsBusySince = now
+		return false
+	}
+	if now.Sub(m.bindingsBusySince) < 5*time.Second {
+		return false
+	}
+	if !m.lastBindingsAutoRebind.IsZero() && now.Sub(m.lastBindingsAutoRebind) < 15*time.Second {
+		return false
+	}
+	m.lastBindingsAutoRebind = now
+	return true
+}
+
+func (m *Manager) maybeAutoRebindBusyBindingsLocked(now time.Time, repaired bool) {
+	if !m.shouldAutoRebindBusyBindingsLocked(now, repaired) {
+		return
+	}
+	var status ProcessStatus
+	m.neighborsPrewarmed = false
+	m.xskLivenessProven = false
+	m.xskLivenessFailed = false
+	m.xskProbeStart = time.Time{}
+	m.lastXSKRX = 0
+	if err := m.requestLocked(ControlRequest{Type: "rebind"}, &status); err != nil {
+		slog.Warn("userspace: auto-rebind for stuck XSK bindings failed", "err", err)
+		return
+	}
+	if err := m.applyHelperStatusLocked(&status); err != nil {
+		slog.Warn("userspace: auto-rebind status sync failed", "err", err)
+	}
+	slog.Warn("userspace: auto-rebind initiated for stuck XSK bindings",
+		"bindings", len(status.Bindings),
+		"forwarding_armed", status.ForwardingArmed)
+	m.bootstrapNAPIQueuesAsyncLocked("busy-xsk-wedge")
+}
+
 type userspaceLocalV6Key struct {
 	Addr [16]byte
 }
@@ -4122,7 +4201,8 @@ func (m *Manager) statusLoop(ctx context.Context) {
 					// the helper's reported state. Only run after a successful
 					// status update — stale m.lastStatus could cause incorrect
 					// repairs.
-					m.verifyBindingsMapLocked()
+					repaired := m.verifyBindingsMapLocked()
+					m.maybeAutoRebindBusyBindingsLocked(time.Now(), repaired)
 				}
 				if m.lastSnapshot != nil && m.publishedSnapshot < m.lastSnapshot.Generation {
 					if err := m.syncSnapshotLocked(); err != nil {

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1653,6 +1653,8 @@ func TestHasBusyBindingsWedgeLocked(t *testing.T) {
 			ForwardingArmed: true,
 			Bindings: []BindingStatus{
 				{
+					Ifindex:    6,
+					QueueID:    0,
 					Registered: true,
 					Armed:      true,
 					Ready:      false,
@@ -1679,6 +1681,8 @@ func TestShouldAutoRebindBusyBindingsLockedDebounces(t *testing.T) {
 			ForwardingArmed: true,
 			Bindings: []BindingStatus{
 				{
+					Ifindex:    6,
+					QueueID:    0,
 					Registered: true,
 					Armed:      true,
 					LastError:  "Device or resource busy",
@@ -1701,6 +1705,22 @@ func TestShouldAutoRebindBusyBindingsLockedDebounces(t *testing.T) {
 	m.lastStatus.Bindings[0].Bound = true
 	if m.shouldAutoRebindBusyBindingsLocked(now.Add(30*time.Second), false) {
 		t.Fatal("shouldAutoRebindBusyBindingsLocked() = true, want false once wedge clears")
+	}
+}
+
+func TestStopLockedResetsBusyBindingsAutoRebindState(t *testing.T) {
+	m := &Manager{
+		bindingsBusySince:      time.Now().Add(-30 * time.Second),
+		lastBindingsAutoRebind: time.Now().Add(-10 * time.Second),
+	}
+
+	m.stopLocked()
+
+	if !m.bindingsBusySince.IsZero() {
+		t.Fatal("bindingsBusySince not reset by stopLocked()")
+	}
+	if !m.lastBindingsAutoRebind.IsZero() {
+		t.Fatal("lastBindingsAutoRebind not reset by stopLocked()")
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1646,6 +1646,64 @@ func TestShouldAutoProveIdleStandbyXSKLocked(t *testing.T) {
 	}
 }
 
+func TestHasBusyBindingsWedgeLocked(t *testing.T) {
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			ForwardingArmed: true,
+			Bindings: []BindingStatus{
+				{
+					Registered: true,
+					Armed:      true,
+					Ready:      false,
+					Bound:      false,
+					LastError:  "libxdp xsk_socket__create_shared: Device or resource busy",
+				},
+			},
+		},
+	}
+	if !m.hasBusyBindingsWedgeLocked(false) {
+		t.Fatal("hasBusyBindingsWedgeLocked(false) = false, want true for busy unbound wedge")
+	}
+	m.lastStatus.Bindings[0].Bound = true
+	if m.hasBusyBindingsWedgeLocked(false) {
+		t.Fatal("hasBusyBindingsWedgeLocked(false) = true, want false once any binding is bound")
+	}
+}
+
+func TestShouldAutoRebindBusyBindingsLockedDebounces(t *testing.T) {
+	now := time.Now()
+	m := &Manager{
+		proc: &exec.Cmd{Process: &os.Process{Pid: 1}},
+		lastStatus: ProcessStatus{
+			ForwardingArmed: true,
+			Bindings: []BindingStatus{
+				{
+					Registered: true,
+					Armed:      true,
+					LastError:  "Device or resource busy",
+				},
+			},
+		},
+	}
+	if m.shouldAutoRebindBusyBindingsLocked(now, false) {
+		t.Fatal("first shouldAutoRebindBusyBindingsLocked() = true, want false while starting debounce")
+	}
+	if m.shouldAutoRebindBusyBindingsLocked(now.Add(4*time.Second), false) {
+		t.Fatal("shouldAutoRebindBusyBindingsLocked() = true before busy debounce window elapsed")
+	}
+	if !m.shouldAutoRebindBusyBindingsLocked(now.Add(6*time.Second), false) {
+		t.Fatal("shouldAutoRebindBusyBindingsLocked() = false, want true after busy debounce window")
+	}
+	if m.shouldAutoRebindBusyBindingsLocked(now.Add(10*time.Second), false) {
+		t.Fatal("shouldAutoRebindBusyBindingsLocked() = true, want false during rebind throttle")
+	}
+	m.lastStatus.Bindings[0].Bound = true
+	if m.shouldAutoRebindBusyBindingsLocked(now.Add(30*time.Second), false) {
+		t.Fatal("shouldAutoRebindBusyBindingsLocked() = true, want false once wedge clears")
+	}
+}
+
 func TestDesiredForwardingArmedDefaultsOnStandalone(t *testing.T) {
 	m := &Manager{
 		clusterHA: false,


### PR DESCRIPTION
Closes #580

## Summary
- detect the standby helper wedge where bindings stay armed but never bind and stale map repair keeps firing
- debounce and throttle an automatic helper rebind instead of waiting forever for takeover readiness
- add unit coverage for the wedge detector and auto-rebind debounce behavior

## Testing
- go test ./pkg/dataplane/userspace -run 'Test(HasBusyBindingsWedgeLocked|ShouldAutoRebindBusyBindingsLockedDebounces|ShouldAutoProveIdleStandbyXSKLocked|ShouldExtendXSKLivenessIdleLocked)' -count=1\n- go test ./pkg/dataplane/userspace ./pkg/daemon -count=1