### PR TITLE
fix: retry userspace RST suppression install

### DIFF
--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -80,6 +80,8 @@ type Manager struct {
 	lastIngressIfaces       []uint32
 	lastRSTv4               []netip.Addr
 	lastRSTv6               []netip.Addr
+	lastRSTAttempt          time.Time
+	lastRSTInstallOK        bool
 	lastSnapshotHash        [32]byte // content hash of last published snapshot (excludes volatile fields)
 	lastBindingIndices      []uint32
 	neighborsPrewarmed      bool
@@ -120,6 +122,29 @@ type Manager struct {
 	// Used by the daemon to defer IPVLAN creation until after XSK
 	// binds in zerocopy mode on fabric parents.
 	OnXSKBound func()
+}
+
+const rstSuppressionRetryBackoff = 5 * time.Second
+
+func shouldAttemptRSTSuppression(
+	now time.Time,
+	desiredV4 []netip.Addr,
+	desiredV6 []netip.Addr,
+	appliedV4 []netip.Addr,
+	appliedV6 []netip.Addr,
+	lastAttempt time.Time,
+	lastInstallOK bool,
+) bool {
+	if lastAttempt.IsZero() {
+		return true
+	}
+	if !slices.Equal(desiredV4, appliedV4) || !slices.Equal(desiredV6, appliedV6) {
+		return true
+	}
+	if lastInstallOK {
+		return false
+	}
+	return now.Sub(lastAttempt) >= rstSuppressionRetryBackoff
 }
 
 func New() *Manager {
@@ -3416,18 +3441,28 @@ func (m *Manager) syncInterfaceNATAddressMapsLocked(snapshot *ConfigSnapshot) er
 	}
 	slices.SortFunc(rstV4, netip.Addr.Compare)
 	slices.SortFunc(rstV6, netip.Addr.Compare)
-	// Install RST suppression rules. Skip if addresses haven't changed
-	// (dedup) to avoid hammering a broken nftables subsystem on every
-	// compile cycle. On first call (lastRSTv4 nil) always try.
-	if m.lastRSTv4 == nil || !slices.Equal(rstV4, m.lastRSTv4) || !slices.Equal(rstV6, m.lastRSTv6) {
+	// Install RST suppression rules. Retry immediately on address changes,
+	// and periodically retry unchanged failed installs so a transient
+	// startup failure does not leave the node permanently unprotected.
+	now := time.Now()
+	if shouldAttemptRSTSuppression(
+		now,
+		rstV4,
+		rstV6,
+		m.lastRSTv4,
+		m.lastRSTv6,
+		m.lastRSTAttempt,
+		m.lastRSTInstallOK,
+	) {
 		if err := bpfrxnft.InstallRSTSuppression(rstV4, rstV6); err != nil {
-			// Log once, don't retry until addresses change.
-			if m.lastRSTv4 == nil {
-				slog.Warn("userspace: RST suppression unavailable (nftables error, non-fatal)", "err", err)
-			}
+			slog.Warn("userspace: RST suppression unavailable (nftables error, non-fatal)", "err", err)
+			m.lastRSTInstallOK = false
+		} else {
+			m.lastRSTInstallOK = true
 		}
-		m.lastRSTv4 = rstV4
-		m.lastRSTv6 = rstV6
+		m.lastRSTAttempt = now
+		m.lastRSTv4 = slices.Clone(rstV4)
+		m.lastRSTv6 = slices.Clone(rstV6)
 	}
 	return nil
 }

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,27 @@ import (
 	"github.com/psaab/bpfrx/pkg/dataplane"
 	"github.com/vishvananda/netlink"
 )
+
+func TestShouldAttemptRSTSuppression(t *testing.T) {
+	now := time.Unix(100, 0)
+	addrV4 := []netip.Addr{netip.MustParseAddr("172.16.80.8")}
+
+	if !shouldAttemptRSTSuppression(now, addrV4, nil, nil, nil, time.Time{}, false) {
+		t.Fatal("shouldAttemptRSTSuppression() = false on first attempt, want true")
+	}
+	if shouldAttemptRSTSuppression(now, addrV4, nil, addrV4, nil, now, true) {
+		t.Fatal("shouldAttemptRSTSuppression() = true for unchanged successful install, want false")
+	}
+	if !shouldAttemptRSTSuppression(now, addrV4, nil, nil, nil, now, true) {
+		t.Fatal("shouldAttemptRSTSuppression() = false for address change, want true")
+	}
+	if shouldAttemptRSTSuppression(now, addrV4, nil, addrV4, nil, now.Add(-rstSuppressionRetryBackoff+time.Second), false) {
+		t.Fatal("shouldAttemptRSTSuppression() = true before failure retry backoff, want false")
+	}
+	if !shouldAttemptRSTSuppression(now, addrV4, nil, addrV4, nil, now.Add(-rstSuppressionRetryBackoff), false) {
+		t.Fatal("shouldAttemptRSTSuppression() = false at failure retry backoff, want true")
+	}
+}
 
 func hostToNetwork16(v uint16) uint16 {
 	var raw [2]byte

--- a/pkg/nftables/rst_suppress.go
+++ b/pkg/nftables/rst_suppress.go
@@ -3,10 +3,12 @@
 package nftables
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
+	"slices"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
@@ -15,56 +17,34 @@ import (
 
 const rstTableName = "bpfrx_dp_rst"
 
+type rstSuppressionPlan struct {
+	deleteTable bool
+	v4Addrs     []netip.Addr
+	v6Addrs     []netip.Addr
+}
+
 // InstallRSTSuppression creates nftables rules to DROP outgoing TCP RSTs
 // from interface-NAT (SNAT) addresses. These addresses are owned by the
 // userspace dataplane; the kernel has no sockets for them and should never
 // emit RSTs.
 //
-// The delete + create is performed in a single atomic netlink batch to
-// eliminate the race window where no rules exist between the old table
-// deletion and new table creation. This is critical for HA failover:
-// during the microseconds of RG demotion, the kernel may generate RSTs
-// for connections it doesn't own (#450).
+// When the table already exists, delete + create is performed in a single
+// atomic netlink batch to eliminate the race window where no rules exist
+// between the old table deletion and new table creation. This is critical
+// for HA failover: during the microseconds of RG demotion, the kernel may
+// generate RSTs for connections it doesn't own (#450).
 func InstallRSTSuppression(v4Addrs []netip.Addr, v6Addrs []netip.Addr) error {
 	c, err := nftables.New()
 	if err != nil {
 		return fmt.Errorf("nftables conn: %w", err)
 	}
-
-	// Delete + create in a single atomic flush. The kernel applies the
-	// entire netlink batch atomically, so the RST suppression rules are
-	// never absent — the old table is replaced by the new one in one shot.
-	// On fresh boot the table doesn't exist yet; the kernel silently
-	// ignores the delete for non-existent tables in a batch.
-	removeRSTTable(c)
-
-	if len(v4Addrs) == 0 && len(v6Addrs) == 0 {
-		// Flush the delete only — no rules needed.
-		if err := c.Flush(); err != nil {
-			return fmt.Errorf("nftables flush (delete-only): %w", err)
-		}
+	tableExists, err := rstTableExists(c)
+	if err != nil {
+		return err
+	}
+	plan := buildRSTSuppressionPlan(tableExists, v4Addrs, v6Addrs)
+	if !queueRSTSuppression(c, plan) {
 		return nil
-	}
-
-	table := c.AddTable(&nftables.Table{
-		Family: nftables.TableFamilyINet,
-		Name:   rstTableName,
-	})
-
-	chain := c.AddChain(&nftables.Chain{
-		Name:     "output",
-		Table:    table,
-		Type:     nftables.ChainTypeFilter,
-		Hooknum:  nftables.ChainHookOutput,
-		Priority: nftables.ChainPriorityFilter,
-		Policy:   ptrPolicy(nftables.ChainPolicyAccept),
-	})
-
-	for _, addr := range v4Addrs {
-		addRSTDropRuleV4(c, table, chain, addr.As4())
-	}
-	for _, addr := range v6Addrs {
-		addRSTDropRuleV6(c, table, chain, addr.As16())
 	}
 
 	if err := c.Flush(); err != nil {
@@ -82,6 +62,10 @@ func RemoveRSTSuppression() {
 	if err != nil {
 		return
 	}
+	tableExists, err := rstTableExists(c)
+	if err != nil || !tableExists {
+		return
+	}
 	removeRSTTable(c)
 	_ = c.Flush()
 }
@@ -91,6 +75,61 @@ func removeRSTTable(c *nftables.Conn) {
 		Family: nftables.TableFamilyINet,
 		Name:   rstTableName,
 	})
+}
+
+func rstTableExists(c *nftables.Conn) (bool, error) {
+	tables, err := c.ListTablesOfFamily(nftables.TableFamilyINet)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return false, nil
+		}
+		return false, fmt.Errorf("nftables list tables: %w", err)
+	}
+	for _, table := range tables {
+		if table != nil && table.Name == rstTableName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func buildRSTSuppressionPlan(tableExists bool, v4Addrs []netip.Addr, v6Addrs []netip.Addr) rstSuppressionPlan {
+	return rstSuppressionPlan{
+		deleteTable: tableExists,
+		v4Addrs:     slices.Clone(v4Addrs),
+		v6Addrs:     slices.Clone(v6Addrs),
+	}
+}
+
+func queueRSTSuppression(c *nftables.Conn, plan rstSuppressionPlan) bool {
+	if plan.deleteTable {
+		removeRSTTable(c)
+	}
+	if len(plan.v4Addrs) == 0 && len(plan.v6Addrs) == 0 {
+		return plan.deleteTable
+	}
+
+	table := c.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   rstTableName,
+	})
+
+	chain := c.AddChain(&nftables.Chain{
+		Name:     "output",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityFilter,
+		Policy:   ptrPolicy(nftables.ChainPolicyAccept),
+	})
+
+	for _, addr := range plan.v4Addrs {
+		addRSTDropRuleV4(c, table, chain, addr.As4())
+	}
+	for _, addr := range plan.v6Addrs {
+		addRSTDropRuleV6(c, table, chain, addr.As16())
+	}
+	return true
 }
 
 func addRSTDropRuleV4(c *nftables.Conn, table *nftables.Table, chain *nftables.Chain, addr [4]byte) {

--- a/pkg/nftables/rst_suppress_test.go
+++ b/pkg/nftables/rst_suppress_test.go
@@ -1,0 +1,37 @@
+package nftables
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestBuildRSTSuppressionPlanSkipsDeleteWhenTableMissing(t *testing.T) {
+	plan := buildRSTSuppressionPlan(false, []netip.Addr{netip.MustParseAddr("172.16.80.8")}, nil)
+	if plan.deleteTable {
+		t.Fatal("plan.deleteTable = true, want false")
+	}
+	if len(plan.v4Addrs) != 1 {
+		t.Fatalf("len(plan.v4Addrs) = %d, want 1", len(plan.v4Addrs))
+	}
+	if len(plan.v6Addrs) != 0 {
+		t.Fatalf("len(plan.v6Addrs) = %d, want 0", len(plan.v6Addrs))
+	}
+}
+
+func TestBuildRSTSuppressionPlanDeleteOnlyRequiresExistingTable(t *testing.T) {
+	plan := buildRSTSuppressionPlan(false, nil, nil)
+	if plan.deleteTable {
+		t.Fatal("plan.deleteTable = true for missing table, want false")
+	}
+	if len(plan.v4Addrs) != 0 || len(plan.v6Addrs) != 0 {
+		t.Fatalf("unexpected addresses in empty missing-table plan: %+v", plan)
+	}
+
+	plan = buildRSTSuppressionPlan(true, nil, nil)
+	if !plan.deleteTable {
+		t.Fatal("plan.deleteTable = false for existing table, want true")
+	}
+	if len(plan.v4Addrs) != 0 || len(plan.v6Addrs) != 0 {
+		t.Fatalf("unexpected addresses in delete-only plan: %+v", plan)
+	}
+}


### PR DESCRIPTION
Fixes #596

This change makes userspace RST suppression install safely when the `inet bpfrx_dp_rst` table does not already exist, and retries failed installs on a backoff instead of caching the failure forever.

Validation:
- `go test ./pkg/nftables ./pkg/dataplane/userspace -count=1`
- live loss deploy: verified `RST suppression: installed nftables rules via netlink` on both firewalls and verified the `inet bpfrx_dp_rst` table exists on fw0 after deploy
- live failover/failback debugging before this fix showed old-owner WAN-side TCP RSTs; those RSTs no longer appeared after the install/retry fix
