### PR TITLE
fix: allow explicit failback when sync is healthy

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -867,10 +867,6 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 		m.mu.Unlock()
 		return fmt.Errorf("node is already primary for redundancy group %d", rgID)
 	}
-	if !m.peerAlive {
-		m.mu.Unlock()
-		return fmt.Errorf("peer not alive — cannot request failover")
-	}
 	if !rg.IsReadyForTakeover(m.takeoverHoldTime) {
 		readySince := "<zero>"
 		if !rg.ReadySince.IsZero() {
@@ -889,12 +885,19 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	fn := m.peerFailoverFn
 	commitFn := m.peerFailoverCommitFn
 	transferReadyFn := m.transferReadinessFn
+	peerAlive := m.peerAlive
 	m.mu.Unlock()
 
 	if fn == nil {
+		if !peerAlive {
+			return fmt.Errorf("peer not alive — cannot request failover")
+		}
 		return fmt.Errorf("peer failover not available (sync not connected)")
 	}
 	if commitFn == nil {
+		if !peerAlive {
+			return fmt.Errorf("peer not alive — cannot request failover")
+		}
 		return fmt.Errorf("peer failover commit not available (sync not connected)")
 	}
 	if transferReadyFn != nil {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -576,6 +577,52 @@ func TestRequestPeerFailoverCommitsLocalPrimaryWithoutHeartbeatObservation(t *te
 	}
 }
 
+func TestRequestPeerFailoverAllowsTransferWithSyncWhenHeartbeatLost(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.mu.Lock()
+	m.peerEverSeen = true
+	m.peerAlive = false
+	m.peerGroups[0] = PeerGroupState{
+		GroupID:  0,
+		Priority: 200,
+		Weight:   255,
+		State:    StatePrimary,
+	}
+	m.groups[0].State = StateSecondary
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	var committedRG int
+	var committedReqID uint64
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		return 91, nil
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error {
+		committedRG = rgID
+		committedReqID = reqID
+		return nil
+	})
+
+	if err := m.RequestPeerFailover(0); err != nil {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("should be primary after explicit transfer commit with sync-connected peer")
+	}
+	if committedRG != 0 || committedReqID != 91 {
+		t.Fatalf("commit = rg %d req %d, want rg 0 req 91", committedRG, committedReqID)
+	}
+	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondary {
+		t.Fatalf("peer state = %s, want secondary after commit", peer.State)
+	}
+}
+
 func TestRequestPeerFailoverBatchCommitsLocalPrimaryTogether(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(
@@ -627,6 +674,63 @@ func TestRequestPeerFailoverBatchCommitsLocalPrimaryTogether(t *testing.T) {
 		t.Fatalf("committed rgs = %v, want [1 2]", committedRGs)
 	}
 	for _, rgID := range []int{1, 2} {
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondary {
+			t.Fatalf("peer state for rg %d = %s, want secondary after commit", rgID, peer.State)
+		}
+	}
+}
+
+func TestRequestPeerFailoverBatchAllowsTransferWithSyncWhenHeartbeatLost(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(1, true, map[int]int{0: 100}),
+		makeRG(2, true, map[int]int{0: 100}),
+	)
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	<-m.Events()
+
+	m.mu.Lock()
+	m.peerEverSeen = true
+	m.peerAlive = false
+	for _, rgID := range []int{1, 2} {
+		m.peerGroups[rgID] = PeerGroupState{
+			GroupID:  rgID,
+			Priority: 200,
+			Weight:   255,
+			State:    StatePrimary,
+		}
+		m.groups[rgID].State = StateSecondary
+		m.groups[rgID].Ready = true
+		m.groups[rgID].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+		m.groups[rgID].ReadinessReasons = nil
+	}
+	m.mu.Unlock()
+
+	var committedRGs []int
+	var committedReqID uint64
+	m.SetPeerFailoverBatchFunc(func(rgIDs []int) (uint64, error) {
+		committedRGs = append([]int(nil), rgIDs...)
+		return 92, nil
+	})
+	m.SetPeerFailoverCommitBatchFunc(func(rgIDs []int, reqID uint64) error {
+		committedReqID = reqID
+		return nil
+	})
+
+	if err := m.RequestPeerFailoverBatch([]int{2, 1}); err != nil {
+		t.Fatalf("RequestPeerFailoverBatch() error = %v", err)
+	}
+	if committedReqID != 92 {
+		t.Fatalf("commit req id = %d, want 92", committedReqID)
+	}
+	if !reflect.DeepEqual(committedRGs, []int{1, 2}) {
+		t.Fatalf("requested rg IDs = %v, want [1 2]", committedRGs)
+	}
+	for _, rgID := range []int{1, 2} {
+		if !m.IsLocalPrimary(rgID) {
+			t.Fatalf("rg %d should be primary after explicit batch transfer commit", rgID)
+		}
 		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondary {
 			t.Fatalf("peer state for rg %d = %s, want secondary after commit", rgID, peer.State)
 		}

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -178,19 +178,22 @@ func (m *Manager) RequestPeerFailoverBatch(rgIDs []int) error {
 			)
 		}
 	}
-	if !m.peerAlive {
-		m.mu.Unlock()
-		return fmt.Errorf("peer not alive — cannot request failover")
-	}
 	fn := m.peerFailoverBatchFn
 	commitFn := m.peerFailoverCommitBatchFn
 	transferReadyFn := m.transferReadinessFn
+	peerAlive := m.peerAlive
 	m.mu.Unlock()
 
 	if fn == nil {
+		if !peerAlive {
+			return fmt.Errorf("peer not alive — cannot request failover")
+		}
 		return fmt.Errorf("peer batch failover not available (sync not connected)")
 	}
 	if commitFn == nil {
+		if !peerAlive {
+			return fmt.Errorf("peer not alive — cannot request failover")
+		}
 		return fmt.Errorf("peer batch failover commit not available (sync not connected)")
 	}
 	if transferReadyFn != nil {


### PR DESCRIPTION
Fixes #597

This change stops treating UDP heartbeat `peerAlive` as a hard prerequisite for explicit RG transfer requests when the explicit peer-transfer RPC/commit path is still available. In the asymmetric lab state where session sync and transfer readiness stay healthy but one node drops heartbeat observation, operator failback can still commit instead of getting stuck behind `peer not alive`.

Validation:
- `go test ./pkg/cluster ./pkg/daemon -count=1`
- added regressions for single-RG and batched explicit transfer while heartbeat is lost but sync-backed transfer callbacks are still available

Live note:
- this was derived from a live loss reproduction where `request chassis cluster failover redundancy-group 1 node 0` started failing with `peer not alive — cannot request failover` after RG1 moved to node1, while cluster status still showed `Transfer ready: yes`
