### PR TITLE
fix: resolve standby warmup neighbors on unit interfaces

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2812,6 +2812,37 @@ func resolveJunosIfName(cfg *config.Config, ifName string) string {
 	return config.LinuxIfName(cfg.ResolveReth(ifName))
 }
 
+func resolveConfigSubnetLinuxName(cfg *config.Config, ip net.IP) (string, string, bool) {
+	if cfg == nil || ip == nil {
+		return "", "", false
+	}
+	for _, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
+		for unitNum, unit := range ifc.Units {
+			if unit == nil {
+				continue
+			}
+			for _, addrStr := range unit.Addresses {
+				_, ipNet, err := net.ParseCIDR(addrStr)
+				if err != nil {
+					continue
+				}
+				if !ipNet.Contains(ip) {
+					continue
+				}
+				ifName := ifc.Name
+				if unitNum != 0 {
+					ifName = fmt.Sprintf("%s.%d", ifc.Name, unitNum)
+				}
+				return resolveJunosIfName(cfg, ifName), addrStr, true
+			}
+		}
+	}
+	return "", "", false
+}
+
 // stripCIDR removes the /prefix from a CIDR string, returning just the IP.
 func stripCIDR(s string) string {
 	ip, _, err := net.ParseCIDR(s)
@@ -3005,26 +3036,15 @@ func (d *Daemon) resolveNeighborsInner(cfg *config.Config, waitForReplies bool) 
 			return
 		}
 		// Kernel has no route — find the interface from config by subnet match.
-		for _, ifc := range cfg.Interfaces.Interfaces {
-			for _, unit := range ifc.Units {
-				for _, addrStr := range unit.Addresses {
-					_, ipNet, err := net.ParseCIDR(addrStr)
-					if err != nil {
-						continue
-					}
-					if ipNet.Contains(ip) {
-						linuxName := resolveJunosIfName(cfg, ifc.Name)
-						link, err := netlink.LinkByName(linuxName)
-						if err != nil {
-							continue
-						}
-						slog.Debug("neighbor warmup: resolved next-hop via config subnet",
-							"nexthop", ipStr, "iface", linuxName, "subnet", addrStr)
-						addByLink(ip, link.Attrs().Index)
-						return
-					}
-				}
+		linuxName, subnet, ok := resolveConfigSubnetLinuxName(cfg, ip)
+		if ok {
+			link, err := netlink.LinkByName(linuxName)
+			if err != nil {
+				return
 			}
+			slog.Debug("neighbor warmup: resolved next-hop via config subnet",
+				"nexthop", ipStr, "iface", linuxName, "subnet", subnet)
+			addByLink(ip, link.Attrs().Index)
 		}
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2832,11 +2832,13 @@ func resolveConfigSubnetLinuxName(cfg *config.Config, ip net.IP) (string, string
 				if !ipNet.Contains(ip) {
 					continue
 				}
-				ifName := ifc.Name
-				if unitNum != 0 {
-					ifName = fmt.Sprintf("%s.%d", ifc.Name, unitNum)
+				ifName := resolveJunosIfName(cfg, ifc.Name)
+				if unit.VlanID > 0 {
+					ifName = fmt.Sprintf("%s.%d", ifName, unit.VlanID)
+				} else if unitNum != 0 {
+					ifName = fmt.Sprintf("%s.%d", ifName, unitNum)
 				}
-				return resolveJunosIfName(cfg, ifName), addrStr, true
+				return ifName, addrStr, true
 			}
 		}
 	}
@@ -3036,15 +3038,37 @@ func (d *Daemon) resolveNeighborsInner(cfg *config.Config, waitForReplies bool) 
 			return
 		}
 		// Kernel has no route — find the interface from config by subnet match.
-		linuxName, subnet, ok := resolveConfigSubnetLinuxName(cfg, ip)
-		if ok {
-			link, err := netlink.LinkByName(linuxName)
-			if err != nil {
-				return
+		for name, ifc := range cfg.Interfaces.Interfaces {
+			if ifc == nil {
+				continue
 			}
-			slog.Debug("neighbor warmup: resolved next-hop via config subnet",
-				"nexthop", ipStr, "iface", linuxName, "subnet", subnet)
-			addByLink(ip, link.Attrs().Index)
+			for unitNum, unit := range ifc.Units {
+				if unit == nil {
+					continue
+				}
+				for _, addrStr := range unit.Addresses {
+					_, ipNet, err := net.ParseCIDR(addrStr)
+					if err != nil || !ipNet.Contains(ip) {
+						continue
+					}
+					linuxName := resolveJunosIfName(cfg, name)
+					if unit.VlanID > 0 {
+						linuxName = fmt.Sprintf("%s.%d", linuxName, unit.VlanID)
+					} else if unitNum != 0 {
+						linuxName = fmt.Sprintf("%s.%d", linuxName, unitNum)
+					}
+					link, err := netlink.LinkByName(linuxName)
+					if err != nil {
+						slog.Debug("neighbor warmup: config subnet match could not be resolved to a linux link",
+							"nexthop", ipStr, "iface", linuxName, "subnet", addrStr, "err", err)
+						continue
+					}
+					slog.Debug("neighbor warmup: resolved next-hop via config subnet",
+						"nexthop", ipStr, "iface", linuxName, "subnet", addrStr)
+					addByLink(ip, link.Attrs().Index)
+					return
+				}
+			}
 		}
 	}
 

--- a/pkg/daemon/resolve_neighbor_test.go
+++ b/pkg/daemon/resolve_neighbor_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -41,6 +42,32 @@ func TestResolveJunosIfName(t *testing.T) {
 				t.Errorf("resolveJunosIfName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveConfigSubnetLinuxNameUsesUnitInterface(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name:            "reth0",
+					RedundancyGroup: 1,
+					Units:           map[int]*config.InterfaceUnit{80: {Number: 80, Addresses: []string{"172.16.80.8/24"}}},
+				},
+				"ge-0/0/0": {Name: "ge-0/0/0", RedundantParent: "reth0"},
+			},
+		},
+	}
+
+	got, subnet, ok := resolveConfigSubnetLinuxName(cfg, net.ParseIP("172.16.80.200"))
+	if !ok {
+		t.Fatal("resolveConfigSubnetLinuxName() = !ok, want ok")
+	}
+	if got != "ge-0-0-0.80" {
+		t.Fatalf("resolveConfigSubnetLinuxName() linuxName = %q, want %q", got, "ge-0-0-0.80")
+	}
+	if subnet != "172.16.80.8/24" {
+		t.Fatalf("resolveConfigSubnetLinuxName() subnet = %q, want %q", subnet, "172.16.80.8/24")
 	}
 }
 

--- a/pkg/daemon/resolve_neighbor_test.go
+++ b/pkg/daemon/resolve_neighbor_test.go
@@ -52,7 +52,9 @@ func TestResolveConfigSubnetLinuxNameUsesUnitInterface(t *testing.T) {
 				"reth0": {
 					Name:            "reth0",
 					RedundancyGroup: 1,
-					Units:           map[int]*config.InterfaceUnit{80: {Number: 80, Addresses: []string{"172.16.80.8/24"}}},
+					Units: map[int]*config.InterfaceUnit{
+						80: {Number: 80, VlanID: 180, Addresses: []string{"172.16.80.8/24"}},
+					},
 				},
 				"ge-0/0/0": {Name: "ge-0/0/0", RedundantParent: "reth0"},
 			},
@@ -63,8 +65,8 @@ func TestResolveConfigSubnetLinuxNameUsesUnitInterface(t *testing.T) {
 	if !ok {
 		t.Fatal("resolveConfigSubnetLinuxName() = !ok, want ok")
 	}
-	if got != "ge-0-0-0.80" {
-		t.Fatalf("resolveConfigSubnetLinuxName() linuxName = %q, want %q", got, "ge-0-0-0.80")
+	if got != "ge-0-0-0.180" {
+		t.Fatalf("resolveConfigSubnetLinuxName() linuxName = %q, want %q", got, "ge-0-0-0.180")
 	}
 	if subnet != "172.16.80.8/24" {
 		t.Fatalf("resolveConfigSubnetLinuxName() subnet = %q, want %q", subnet, "172.16.80.8/24")


### PR DESCRIPTION
Fixes #598

This change makes standby neighbor warmup resolve config-subnet fallback matches to the actual Linux unit/VLAN interface name instead of the parent/base interface. That keeps split-RG warmup and standby forwarding prep aimed at the real neighbor table used by the configured subnet.

Validation:
- `go test ./pkg/daemon -count=1`
- added regression coverage for `reth` unit fallback resolving to the concrete unit interface name
