### PR TITLE
fix: surface HA software version mismatch

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -123,6 +123,9 @@ type Manager struct {
 	peerEverSeen bool // true once first heartbeat received; distinguishes "never heard" from "lost"
 	peerNodeID   int
 	peerGroups   map[int]PeerGroupState
+	// Optional software version metadata advertised via heartbeat.
+	localSoftwareVersion string
+	peerSoftwareVersion  string
 	// peerTransferOutOverride preserves an explicitly acknowledged peer
 	// transfer-out across heartbeat refreshes until the transfer is either
 	// committed or aborted locally.
@@ -380,6 +383,33 @@ func (m *Manager) PeerGroupStates() map[int]PeerGroupState {
 		cp[k] = v
 	}
 	return cp
+}
+
+// SetSoftwareVersion records the local software version advertised to the peer.
+func (m *Manager) SetSoftwareVersion(version string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(version) > maxHeartbeatSoftwareVersionSize {
+		version = version[:maxHeartbeatSoftwareVersionSize]
+	}
+	m.localSoftwareVersion = version
+}
+
+// SoftwareVersions returns the currently known local and peer software versions.
+func (m *Manager) SoftwareVersions() (local, peer string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.localSoftwareVersion, m.peerSoftwareVersion
+}
+
+// SoftwareVersionMismatch reports whether both sides advertised different versions.
+func (m *Manager) SoftwareVersionMismatch() (bool, string, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.localSoftwareVersion == "" || m.peerSoftwareVersion == "" {
+		return false, m.localSoftwareVersion, m.peerSoftwareVersion
+	}
+	return m.localSoftwareVersion != m.peerSoftwareVersion, m.localSoftwareVersion, m.peerSoftwareVersion
 }
 
 // PeerMonitorStatuses returns the peer's interface monitor states from heartbeat.
@@ -1289,8 +1319,9 @@ func (m *Manager) buildHeartbeat() *HeartbeatPacket {
 	defer m.mu.RUnlock()
 
 	pkt := &HeartbeatPacket{
-		NodeID:    uint8(m.nodeID),
-		ClusterID: uint16(m.clusterID),
+		NodeID:          uint8(m.nodeID),
+		ClusterID:       uint16(m.clusterID),
+		SoftwareVersion: m.localSoftwareVersion,
 	}
 	for _, rg := range m.groups {
 		pkt.Groups = append(pkt.Groups, HeartbeatGroup{
@@ -1322,6 +1353,7 @@ func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 	m.peerAlive = true
 	m.peerEverSeen = true
 	m.peerNodeID = int(pkt.NodeID)
+	m.peerSoftwareVersion = pkt.SoftwareVersion
 
 	// Rebuild peer group states from scratch — prunes stale RGs that
 	// the peer no longer reports (fix #92).
@@ -1399,6 +1431,7 @@ func (m *Manager) handlePeerTimeout() {
 	m.peerAlive = false
 	m.peerGroups = make(map[int]PeerGroupState)
 	m.peerMonitors = nil
+	m.peerSoftwareVersion = ""
 	slog.Warn("cluster: peer heartbeat timeout, marking peer lost")
 	m.history.Record(EventHeartbeat, -1, "Peer heartbeat timeout")
 
@@ -1558,6 +1591,8 @@ func (m *Manager) FormatStatus() string {
 	m.mu.RLock()
 	peerAlive := m.peerAlive
 	peerNodeID := m.peerNodeID
+	localVersion := m.localSoftwareVersion
+	peerVersion := m.peerSoftwareVersion
 	peerGroups := make(map[int]PeerGroupState, len(m.peerGroups))
 	for k, v := range m.peerGroups {
 		peerGroups[k] = v
@@ -1572,6 +1607,18 @@ func (m *Manager) FormatStatus() string {
 	fmt.Fprintln(&b)
 	fmt.Fprintf(&b, "Cluster ID: %d\n", m.clusterID)
 	fmt.Fprintf(&b, "Node name: node%d\n\n", m.nodeID)
+	if localVersion != "" {
+		fmt.Fprintf(&b, "Software version: %s\n", localVersion)
+	}
+	if peerAlive {
+		if peerVersion == "" {
+			peerVersion = "unknown"
+		}
+		fmt.Fprintf(&b, "Peer software version: %s\n", peerVersion)
+	}
+	if localVersion != "" || peerAlive {
+		fmt.Fprintln(&b)
+	}
 	fmt.Fprintf(&b, "%-6s %-8s %-14s %-8s %-8s %s\n",
 		"Node", "Priority", "Status", "Preempt", "Manual", "Monitor-failures")
 	fmt.Fprintln(&b)
@@ -1629,6 +1676,8 @@ func (m *Manager) FormatInformation() string {
 	m.mu.RLock()
 	peerAlive := m.peerAlive
 	peerNodeID := m.peerNodeID
+	localVersion := m.localSoftwareVersion
+	peerVersion := m.peerSoftwareVersion
 	interval := m.hbInterval
 	threshold := m.hbThreshold
 	controlIface := m.controlInterface
@@ -1665,6 +1714,12 @@ func (m *Manager) FormatInformation() string {
 	fmt.Fprintf(&b, "  Heartbeat threshold: %d\n", threshold)
 	if controlIface != "" {
 		fmt.Fprintf(&b, "  Control interface: %s\n", controlIface)
+	}
+	if localVersion != "" {
+		fmt.Fprintf(&b, "  Software version: %s\n", localVersion)
+	}
+	if peerAlive && peerVersion != "" {
+		fmt.Fprintf(&b, "  Peer software version: %s\n", peerVersion)
 	}
 	fmt.Fprintf(&b, "  Sync transport: %s\n", m.SyncTransport())
 	fmt.Fprintln(&b)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1718,7 +1718,10 @@ func (m *Manager) FormatInformation() string {
 	if localVersion != "" {
 		fmt.Fprintf(&b, "  Software version: %s\n", localVersion)
 	}
-	if peerAlive && peerVersion != "" {
+	if peerAlive {
+		if peerVersion == "" {
+			peerVersion = "unknown"
+		}
 		fmt.Fprintf(&b, "  Peer software version: %s\n", peerVersion)
 	}
 	fmt.Fprintf(&b, "  Sync transport: %s\n", m.SyncTransport())

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1066,6 +1066,26 @@ func TestFormatStatusShowsSoftwareVersions(t *testing.T) {
 	}
 }
 
+func TestFormatInformationShowsUnknownPeerSoftwareVersion(t *testing.T) {
+	m := NewManager(0, 1)
+	m.SetSoftwareVersion("local-build")
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+
+	out := m.FormatInformation()
+	if !strings.Contains(out, "Peer software version: unknown") {
+		t.Fatalf("information missing unknown peer software version: %s", out)
+	}
+}
+
 func TestResetFailover(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1042,6 +1042,30 @@ func TestFormatStatusShowsSeparateTransferReadiness(t *testing.T) {
 	}
 }
 
+func TestFormatStatusShowsSoftwareVersions(t *testing.T) {
+	m := NewManager(0, 1)
+	m.SetSoftwareVersion("local-build")
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:          1,
+		ClusterID:       1,
+		SoftwareVersion: "peer-build",
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+
+	out := m.FormatStatus()
+	if !strings.Contains(out, "Software version: local-build") {
+		t.Fatalf("status missing local software version: %s", out)
+	}
+	if !strings.Contains(out, "Peer software version: peer-build") {
+		t.Fatalf("status missing peer software version: %s", out)
+	}
+}
+
 func TestResetFailover(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -52,6 +52,13 @@ const (
 //	    [2] Weight
 //	    [3] NameLen
 //	    [4..4+NameLen] Interface name
+//	After monitors:
+//	  Optional SoftwareVersion:
+//	    [0] VersionLen
+//	    [1..1+VersionLen] Version bytes
+//
+// The trailing software-version field is optional; packets may end after the
+// monitor section, or may include the length-prefixed version bytes.
 type HeartbeatPacket struct {
 	NodeID          uint8
 	ClusterID       uint16
@@ -86,9 +93,10 @@ const maxHeartbeatSoftwareVersionSize = 255
 
 // MarshalHeartbeat encodes a heartbeat packet to wire format.
 // The output is capped at maxHeartbeatSize. RG group entries are always
-// included (they are critical for election). If monitors would cause the
-// packet to exceed the limit, the monitor section is truncated — as many
-// monitors as fit are included.
+// included (they are critical for election). When SoftwareVersion is present,
+// space for it is reserved first so monitor truncation never drops version
+// metadata. If monitors would cause the packet to exceed the limit, the monitor
+// section is truncated and the version field is preserved.
 func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 	buf := make([]byte, maxHeartbeatSize)
 	copy(buf[0:4], heartbeatMagic)
@@ -106,6 +114,20 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		off += heartbeatGroupSize
 	}
 
+	var version []byte
+	versionReserve := 0
+	if pkt.SoftwareVersion != "" {
+		version = []byte(pkt.SoftwareVersion)
+		if len(version) > maxHeartbeatSoftwareVersionSize {
+			version = version[:maxHeartbeatSoftwareVersionSize]
+		}
+		if off+1+len(version) <= maxHeartbeatSize {
+			versionReserve = 1 + len(version)
+		} else {
+			version = nil
+		}
+	}
+
 	// Append monitor section, fitting as many monitors as possible.
 	monCountOff := off // remember offset of NumMonitors byte
 	buf[off] = 0       // NumMonitors — updated below
@@ -114,7 +136,7 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 	for _, mon := range pkt.Monitors {
 		nameBytes := []byte(mon.Interface)
 		entrySize := 4 + len(nameBytes) // RGID + Flags + Weight + NameLen + name
-		if off+entrySize > maxHeartbeatSize {
+		if off+entrySize > maxHeartbeatSize-versionReserve {
 			break
 		}
 		buf[off] = mon.RGID
@@ -131,17 +153,11 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		numMon++
 	}
 	buf[monCountOff] = uint8(numMon)
-	if pkt.SoftwareVersion != "" {
-		version := []byte(pkt.SoftwareVersion)
-		if len(version) > maxHeartbeatSoftwareVersionSize {
-			version = version[:maxHeartbeatSoftwareVersionSize]
-		}
-		if off+1+len(version) <= maxHeartbeatSize {
-			buf[off] = uint8(len(version))
-			off++
-			copy(buf[off:off+len(version)], version)
-			off += len(version)
-		}
+	if len(version) > 0 {
+		buf[off] = uint8(len(version))
+		off++
+		copy(buf[off:off+len(version)], version)
+		off += len(version)
 	}
 	return buf[:off]
 }
@@ -186,11 +202,13 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 	// is truncated (sender capped at maxHeartbeatSize), return whatever
 	// monitors were successfully parsed rather than erroring — RG state
 	// (already parsed above) is the critical data.
+	monitorSectionComplete := true
 	if off < len(data) {
 		numMonitors := int(data[off])
 		off++
 		for i := 0; i < numMonitors; i++ {
 			if off+4 > len(data) {
+				monitorSectionComplete = false
 				break // truncated — return what we have
 			}
 			rgID := data[off]
@@ -199,6 +217,7 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 			nameLen := int(data[off+3])
 			off += 4
 			if off+nameLen > len(data) {
+				monitorSectionComplete = false
 				break // truncated name — return what we have
 			}
 			name := string(data[off : off+nameLen])
@@ -211,7 +230,7 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 			})
 		}
 	}
-	if off < len(data) {
+	if monitorSectionComplete && off < len(data) {
 		versionLen := int(data[off])
 		off++
 		if off+versionLen <= len(data) {

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -53,10 +53,11 @@ const (
 //	    [3] NameLen
 //	    [4..4+NameLen] Interface name
 type HeartbeatPacket struct {
-	NodeID    uint8
-	ClusterID uint16
-	Groups    []HeartbeatGroup
-	Monitors  []HeartbeatMonitor
+	NodeID          uint8
+	ClusterID       uint16
+	Groups          []HeartbeatGroup
+	Monitors        []HeartbeatMonitor
+	SoftwareVersion string
 }
 
 // HeartbeatGroup is a per-RG entry in the heartbeat.
@@ -80,6 +81,8 @@ const heartbeatHeaderSize = 9
 
 // heartbeatGroupSize is GroupID(1) + Priority(2) + Weight(1) + State(1).
 const heartbeatGroupSize = 5
+
+const maxHeartbeatSoftwareVersionSize = 255
 
 // MarshalHeartbeat encodes a heartbeat packet to wire format.
 // The output is capped at maxHeartbeatSize. RG group entries are always
@@ -128,6 +131,18 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		numMon++
 	}
 	buf[monCountOff] = uint8(numMon)
+	if pkt.SoftwareVersion != "" {
+		version := []byte(pkt.SoftwareVersion)
+		if len(version) > maxHeartbeatSoftwareVersionSize {
+			version = version[:maxHeartbeatSoftwareVersionSize]
+		}
+		if off+1+len(version) <= maxHeartbeatSize {
+			buf[off] = uint8(len(version))
+			off++
+			copy(buf[off:off+len(version)], version)
+			off += len(version)
+		}
+	}
 	return buf[:off]
 }
 
@@ -194,6 +209,13 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 				Up:        up,
 				Interface: name,
 			})
+		}
+	}
+	if off < len(data) {
+		versionLen := int(data[off])
+		off++
+		if off+versionLen <= len(data) {
+			pkt.SoftwareVersion = string(data[off : off+versionLen])
 		}
 	}
 

--- a/pkg/cluster/heartbeat_test.go
+++ b/pkg/cluster/heartbeat_test.go
@@ -7,8 +7,9 @@ import (
 
 func TestMarshalUnmarshalHeartbeat(t *testing.T) {
 	pkt := &HeartbeatPacket{
-		NodeID:    1,
-		ClusterID: 42,
+		NodeID:          1,
+		ClusterID:       42,
+		SoftwareVersion: "bpfrx-test-1",
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
 			{GroupID: 1, Priority: 150, Weight: 100, State: uint8(StateSecondary)},
@@ -41,6 +42,9 @@ func TestMarshalUnmarshalHeartbeat(t *testing.T) {
 	}
 	if got.Groups[1].State != uint8(StateSecondary) {
 		t.Errorf("group 1 state = %d, want %d", got.Groups[1].State, StateSecondary)
+	}
+	if got.SoftwareVersion != "bpfrx-test-1" {
+		t.Errorf("software version = %q, want bpfrx-test-1", got.SoftwareVersion)
 	}
 }
 
@@ -120,6 +124,7 @@ func TestMarshalHeartbeat_Size(t *testing.T) {
 
 func TestHandlePeerHeartbeat(t *testing.T) {
 	m := NewManager(0, 1)
+	m.SetSoftwareVersion("local-test")
 	cfg := makeConfig(
 		makeRG(0, true, map[int]int{0: 200, 1: 100}),
 	)
@@ -129,8 +134,9 @@ func TestHandlePeerHeartbeat(t *testing.T) {
 
 	// Simulate peer heartbeat.
 	pkt := &HeartbeatPacket{
-		NodeID:    1,
-		ClusterID: 1,
+		NodeID:          1,
+		ClusterID:       1,
+		SoftwareVersion: "peer-test",
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 100, Weight: 255, State: uint8(StateSecondary)},
 		},
@@ -149,6 +155,9 @@ func TestHandlePeerHeartbeat(t *testing.T) {
 		t.Error("peer group 0 not found")
 	} else if pg.Priority != 100 {
 		t.Errorf("peer group 0 priority = %d, want 100", pg.Priority)
+	}
+	if mismatch, local, peer := m.SoftwareVersionMismatch(); !mismatch || local != "local-test" || peer != "peer-test" {
+		t.Fatalf("software mismatch = %v local=%q peer=%q, want true/local-test/peer-test", mismatch, local, peer)
 	}
 }
 
@@ -261,6 +270,9 @@ func TestMarshalUnmarshalHeartbeat_NoMonitors_BackwardsCompat(t *testing.T) {
 	}
 	if len(got2.Groups) != 1 {
 		t.Errorf("groups from old format = %d, want 1", len(got2.Groups))
+	}
+	if got2.SoftwareVersion != "" {
+		t.Errorf("software version from old format = %q, want empty", got2.SoftwareVersion)
 	}
 }
 

--- a/pkg/cluster/heartbeat_test.go
+++ b/pkg/cluster/heartbeat_test.go
@@ -278,8 +278,9 @@ func TestMarshalUnmarshalHeartbeat_NoMonitors_BackwardsCompat(t *testing.T) {
 
 func TestUnmarshalHeartbeat_TruncatedMonitor(t *testing.T) {
 	pkt := &HeartbeatPacket{
-		NodeID:    0,
-		ClusterID: 1,
+		NodeID:          0,
+		ClusterID:       1,
+		SoftwareVersion: "peer-build",
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
 		},
@@ -311,6 +312,9 @@ func TestUnmarshalHeartbeat_TruncatedMonitor(t *testing.T) {
 	if len(got.Monitors) > 0 && got.Monitors[0].Interface != "ge-0/0/0" {
 		t.Errorf("monitor 0 interface = %q, want ge-0/0/0", got.Monitors[0].Interface)
 	}
+	if got.SoftwareVersion != "" {
+		t.Errorf("software version = %q, want empty after truncated monitor section", got.SoftwareVersion)
+	}
 }
 
 func TestUnmarshalHeartbeat_TruncatedMonitorName(t *testing.T) {
@@ -337,8 +341,9 @@ func TestMarshalHeartbeat_LargeMonitorPayload_RGPreserved(t *testing.T) {
 	// Build a packet with many monitors that would exceed the old 512-byte
 	// limit. RG group state must always be preserved.
 	pkt := &HeartbeatPacket{
-		NodeID:    0,
-		ClusterID: 1,
+		NodeID:          0,
+		ClusterID:       1,
+		SoftwareVersion: "peer-build",
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
 			{GroupID: 1, Priority: 150, Weight: 100, State: uint8(StateSecondary)},
@@ -358,10 +363,12 @@ func TestMarshalHeartbeat_LargeMonitorPayload_RGPreserved(t *testing.T) {
 	if len(data) > maxHeartbeatSize {
 		t.Fatalf("marshal produced %d bytes, exceeds maxHeartbeatSize %d", len(data), maxHeartbeatSize)
 	}
-
 	got, err := UnmarshalHeartbeat(data)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.SoftwareVersion != "peer-build" {
+		t.Fatalf("software version = %q, want peer-build", got.SoftwareVersion)
 	}
 
 	// RG groups must be intact.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -394,6 +394,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
 		cc := cfg.Chassis.Cluster
 		d.cluster = cluster.NewManager(cc.NodeID, cc.ClusterID)
+		d.cluster.SetSoftwareVersion(d.opts.Version)
 		d.cluster.UpdateConfig(cc)
 		d.cluster.Start(ctx)
 		// Wire event-drop callback: on dropped cluster events, trigger

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -831,7 +831,7 @@ func userspaceSoftwareVersionMismatchReason(provider userspaceSoftwareVersionMis
 		return nil
 	}
 	if mismatch, local, peer := provider.SoftwareVersionMismatch(); mismatch {
-		return []string{fmt.Sprintf("software version mismatch local=%s peer=%s", local, peer)}
+		return []string{fmt.Sprintf("software version mismatch local=%q peer=%q", local, peer)}
 	}
 	return nil
 }

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -822,7 +822,26 @@ func userspaceManualFailoverTransferReadinessError(state cluster.TransferReadine
 	return nil
 }
 
+type userspaceSoftwareVersionMismatchProvider interface {
+	SoftwareVersionMismatch() (bool, string, string)
+}
+
+func userspaceSoftwareVersionMismatchReason(provider userspaceSoftwareVersionMismatchProvider) []string {
+	if provider == nil {
+		return nil
+	}
+	if mismatch, local, peer := provider.SoftwareVersionMismatch(); mismatch {
+		return []string{fmt.Sprintf("software version mismatch local=%s peer=%s", local, peer)}
+	}
+	return nil
+}
+
 func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
+	if d.cluster != nil {
+		if reasons := userspaceSoftwareVersionMismatchReason(d.cluster); len(reasons) > 0 {
+			return false, reasons
+		}
+	}
 	if d.sessionSync == nil || !d.sessionSync.IsConnected() || !d.sessionSync.PeerHealthy() || !d.syncPeerConnected.Load() {
 		return false, []string{"session sync disconnected"}
 	}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -174,6 +174,27 @@ func TestUserspaceTransferReadinessDisconnected(t *testing.T) {
 	}
 }
 
+type fakeUserspaceSoftwareVersionMismatchProvider struct {
+	mismatch bool
+	local    string
+	peer     string
+}
+
+func (f fakeUserspaceSoftwareVersionMismatchProvider) SoftwareVersionMismatch() (bool, string, string) {
+	return f.mismatch, f.local, f.peer
+}
+
+func TestUserspaceSoftwareVersionMismatchReason(t *testing.T) {
+	reasons := userspaceSoftwareVersionMismatchReason(fakeUserspaceSoftwareVersionMismatchProvider{
+		mismatch: true,
+		local:    "local-build",
+		peer:     "peer-build",
+	})
+	if len(reasons) != 1 || reasons[0] != "software version mismatch local=local-build peer=peer-build" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
 func TestUserspaceSessionFromDeltaV4CarriesTunnelEndpointMetadata(t *testing.T) {
 	zoneIDs := map[string]uint16{"lan": 1, "sfmix": 2}
 	delta := dpuserspace.SessionDeltaInfo{

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -187,10 +187,10 @@ func (f fakeUserspaceSoftwareVersionMismatchProvider) SoftwareVersionMismatch() 
 func TestUserspaceSoftwareVersionMismatchReason(t *testing.T) {
 	reasons := userspaceSoftwareVersionMismatchReason(fakeUserspaceSoftwareVersionMismatchProvider{
 		mismatch: true,
-		local:    "local-build",
-		peer:     "peer-build",
+		local:    "local build",
+		peer:     "peer build",
 	})
-	if len(reasons) != 1 || reasons[0] != "software version mismatch local=local-build peer=peer-build" {
+	if len(reasons) != 1 || reasons[0] != `software version mismatch local="local build" peer="peer build"` {
 		t.Fatalf("unexpected reasons: %v", reasons)
 	}
 }


### PR DESCRIPTION
Closes #603.

## What this changes

- carries local software version in cluster heartbeats
- stores peer software version in the cluster manager
- exposes local/peer software versions in cluster status/information output
- makes userspace transfer readiness prefer an explicit version-mismatch reason over the generic `session sync disconnected`

## Why

On `loss`, the reported session-sync disconnect was reproduced with mixed node builds:

- `fw0`: `...-ga2f53a50-dirty`
- `fw1`: `...-gd6a538e1`

After both nodes were redeployed to the same clean `origin/master` build (`g51fc6996`), session sync recovered and both nodes returned to `Transfer ready: yes`.

So the product gap here is operator-facing diagnosis/readiness: version skew looked like a transport failure.

## Verification

- `go test ./pkg/cluster ./pkg/daemon -count=1`
