### PR TITLE
fix: skip identical config sync apply on standby

### DIFF
--- a/pkg/daemon/config_sync_test.go
+++ b/pkg/daemon/config_sync_test.go
@@ -86,6 +86,7 @@ func TestHandleConfigSync_SkipsWhenConfigAlreadyMatchesActive(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 	active := store.ShowActive()
+	historyLen := len(store.ListHistory())
 
 	d := &Daemon{
 		cluster: newClusterManager(false),
@@ -99,6 +100,9 @@ func TestHandleConfigSync_SkipsWhenConfigAlreadyMatchesActive(t *testing.T) {
 	}
 	if got := store.ActiveConfig(); got == nil || got.System.HostName != "sync-test" {
 		t.Fatalf("expected unchanged compiled config, got %#v", got)
+	}
+	if got := len(store.ListHistory()); got != historyLen {
+		t.Fatalf("expected identical config sync to skip history mutation, want %d entries got %d", historyLen, got)
 	}
 }
 

--- a/pkg/daemon/config_sync_test.go
+++ b/pkg/daemon/config_sync_test.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/psaab/bpfrx/pkg/cluster"
 	"github.com/psaab/bpfrx/pkg/config"
+	"github.com/psaab/bpfrx/pkg/configstore"
 )
 
 // newClusterManager creates a cluster.Manager where node 0 is primary or
@@ -70,6 +72,34 @@ func TestHandleConfigSync_AcceptsWhenNoCluster(t *testing.T) {
 		}
 	}()
 	d.handleConfigSync("set system host-name standalone")
+}
+
+func TestHandleConfigSync_SkipsWhenConfigAlreadyMatchesActive(t *testing.T) {
+	store := configstore.New(filepath.Join(t.TempDir(), "config"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.SetFromInput("system host-name sync-test"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	active := store.ShowActive()
+
+	d := &Daemon{
+		cluster: newClusterManager(false),
+		store:   store,
+	}
+
+	d.handleConfigSync(active + "\n")
+
+	if got := store.ShowActive(); got != active {
+		t.Fatalf("active config changed on identical sync:\nwant:\n%s\n\ngot:\n%s", active, got)
+	}
+	if got := store.ActiveConfig(); got == nil || got.System.HostName != "sync-test" {
+		t.Fatalf("expected unchanged compiled config, got %#v", got)
+	}
 }
 
 // TestOnPeerConnected_PrimaryPushesConfig verifies that an RG0 primary with

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -326,6 +327,15 @@ func (d *Daemon) handleConfigSync(configText string) {
 	if d.cluster != nil && d.cluster.IsLocalPrimary(0) {
 		slog.Warn("cluster: rejecting config sync (this node is RG0 primary)")
 		return
+	}
+	if d.store != nil {
+		activeText := strings.TrimSpace(d.store.ShowActive())
+		incomingText := strings.TrimSpace(configText)
+		if activeText == incomingText {
+			slog.Info("cluster: skipping config sync apply (config already matches active)",
+				"size", len(configText))
+			return
+		}
 	}
 	slog.Info("cluster: accepting config sync from peer", "size", len(configText))
 


### PR DESCRIPTION
## Summary
- skip standby config sync apply when the incoming config already matches the active config
- avoid reconnect-time no-op recompiles/rebinds during session sync recovery
- add a daemon regression test for the identical-config path

## Testing
- `go test ./pkg/daemon -run 'TestHandleConfigSync_(RejectsWhenPrimary|AcceptsWhenSecondary|AcceptsWhenNoCluster|SkipsWhenConfigAlreadyMatchesActive)' -count=1`
- `go test ./pkg/cluster ./pkg/daemon -count=1`
- live on `loss`: deploy branch, restart `bpfrxd` on `bpfrx-userspace-fw1`, confirm both nodes return to `Transfer ready: yes`
- live on `loss`: standby journal shows `cluster: skipping config sync apply (config already matches active)` and does not log `restarting heartbeat after VRF rebind` for that reconnect

Fixes #606
