### PR TITLE
fix HA handoff regressions during rapid RG movement

### DIFF
--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -15,7 +15,6 @@ import (
 	"github.com/psaab/bpfrx/pkg/dataplane"
 )
 
-
 // ensureFabricIPVLAN creates an IPVLAN L2 interface on top of parent for
 // fabric IP addressing. The parent keeps its ge-X-0-Y name (XDP/TC attaches
 // there); the IPVLAN carries the fabric IP used for session sync.
@@ -348,6 +347,45 @@ func (d *Daemon) logFabricRefreshFailure(slot int, msg string, args ...any) {
 	slog.Info(msg, args...)
 }
 
+func (d *Daemon) fabricEntryPopulated(slot int) bool {
+	d.fabricMu.RLock()
+	defer d.fabricMu.RUnlock()
+	if slot == 1 {
+		return d.fabric1Populated
+	}
+	return d.fabricPopulated
+}
+
+func (d *Daemon) retainFabricFwdOnNeighborMiss(slot int, peerIP net.IP, overlay string, logWaiting bool) bool {
+	if !d.fabricEntryPopulated(slot) {
+		if logWaiting {
+			if slot == 1 {
+				slog.Info("cluster: waiting for fabric1 peer neighbor entry",
+					"peer", peerIP, "overlay", overlay)
+			} else {
+				slog.Info("cluster: waiting for fabric peer neighbor entry",
+					"peer", peerIP, "overlay", overlay)
+			}
+		} else if slot == 1 {
+			d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (missing peer neighbor)",
+				"peer", peerIP, "overlay", overlay)
+		} else {
+			d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (missing peer neighbor)",
+				"peer", peerIP, "overlay", overlay)
+		}
+		return false
+	}
+
+	if slot == 1 {
+		d.logFabricRefreshFailure(1, "cluster: retaining fabric1_fwd despite missing peer neighbor",
+			"peer", peerIP, "overlay", overlay)
+	} else {
+		d.logFabricRefreshFailure(0, "cluster: retaining fabric_fwd despite missing peer neighbor",
+			"peer", peerIP, "overlay", overlay)
+	}
+	return true
+}
+
 // refreshFabricFwd resolves fabric link/neighbor state and updates the
 // fabric_fwd BPF map. Returns true on success. Called during initial
 // population and periodic drift correction.
@@ -460,12 +498,8 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	}
 
 	if peerMAC == nil {
-		if logWaiting {
-			slog.Info("cluster: waiting for fabric peer neighbor entry",
-				"peer", peerIP, "overlay", overlay)
-		} else {
-			d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (missing peer neighbor)",
-				"peer", peerIP, "overlay", overlay)
+		if d.retainFabricFwdOnNeighborMiss(0, peerIP, overlay, logWaiting) {
+			return true
 		}
 		d.clearFabricFwd0()
 		return false
@@ -656,12 +690,8 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 		}
 	}
 	if peerMAC == nil {
-		if logWaiting {
-			slog.Info("cluster: waiting for fabric1 peer neighbor entry",
-				"peer", peerIP, "overlay", overlay)
-		} else {
-			d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (missing peer neighbor)",
-				"peer", peerIP, "overlay", overlay)
+		if d.retainFabricFwdOnNeighborMiss(1, peerIP, overlay, logWaiting) {
+			return true
 		}
 		d.clearFabricFwd1()
 		return false

--- a/pkg/daemon/daemon_ha_fabric_test.go
+++ b/pkg/daemon/daemon_ha_fabric_test.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+)
+
+func TestRetainFabricFwdOnNeighborMissWithoutCachedEntry(t *testing.T) {
+	d := &Daemon{}
+	if d.retainFabricFwdOnNeighborMiss(0, net.ParseIP("10.99.13.2"), "fab0", false) {
+		t.Fatal("expected missing neighbor without cached fabric state to remain not ready")
+	}
+	if d.fabricEntryPopulated(0) {
+		t.Fatal("fabric entry should not become populated")
+	}
+}
+
+func TestRetainFabricFwdOnNeighborMissWithCachedEntry(t *testing.T) {
+	d := &Daemon{}
+	d.fabricMu.Lock()
+	d.fabricPopulated = true
+	d.fabricMu.Unlock()
+
+	if !d.retainFabricFwdOnNeighborMiss(0, net.ParseIP("10.99.13.2"), "fab0", false) {
+		t.Fatal("expected cached fabric entry to survive a transient neighbor miss")
+	}
+	if !d.fabricEntryPopulated(0) {
+		t.Fatal("cached fabric entry should remain populated")
+	}
+}
+
+func TestRetainFabricFwdOnNeighborMissWithCachedSecondaryEntry(t *testing.T) {
+	d := &Daemon{}
+	d.fabricMu.Lock()
+	d.fabric1Populated = true
+	d.fabricMu.Unlock()
+
+	if !d.retainFabricFwdOnNeighborMiss(1, net.ParseIP("10.99.13.1"), "fab1", false) {
+		t.Fatal("expected cached secondary fabric entry to survive a transient neighbor miss")
+	}
+	if !d.fabricEntryPopulated(1) {
+		t.Fatal("cached secondary fabric entry should remain populated")
+	}
+}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -87,6 +87,7 @@ type Manager struct {
 	neighborsPrewarmed      bool
 	ctrlEnableAt            time.Time
 	ctrlWasEnabled          bool
+	initialCtrlCleanupDone  bool
 	ctrlDisabledAt          uint64    // monotonic ktime_ns when ctrl was last disabled
 	lastDemotionTime        time.Time // wall clock when last RG demotion occurred
 	xskLivenessFailed       bool
@@ -3003,10 +3004,11 @@ ctrlReady:
 	// SessionTable + shared_sessions) holds the authoritative synced
 	// sessions — BPF conntrack must be empty when ctrl re-enables.
 	// Only flush stale BPF sessions on the very first ctrl enable after
-	// daemon startup. During HA transitions, ctrl may briefly disable and
-	// re-enable (rgTransitionInFlight); flushing then destroys synced
-	// sessions that the peer just published, killing TCP streams (#475).
-	if ctrl.Enabled == 1 && !m.ctrlWasEnabled && m.publishedSnapshot <= 1 {
+	// daemon startup. Snapshot generation is not a reliable proxy for
+	// "startup" on long-lived HA nodes because a steady appliance can stay
+	// at generation 1 indefinitely; later ctrl re-enables during RG moves
+	// would then retrigger the startup flush and destroy synced sessions.
+	if ctrl.Enabled == 1 && !m.ctrlWasEnabled && !m.initialCtrlCleanupDone {
 		if usMap := m.inner.Map("userspace_sessions"); usMap != nil {
 			var key, nextKey []byte
 			key = make([]byte, usMap.KeySize())
@@ -3082,6 +3084,7 @@ ctrlReady:
 				}
 			}
 		}
+		m.initialCtrlCleanupDone = true
 	}
 	if ctrl.Enabled == 0 && m.ctrlWasEnabled {
 		m.ctrlDisabledAt = m.bpfKtimeNs()
@@ -4388,6 +4391,7 @@ func (m *Manager) stopLocked() {
 	m.ctrlEnableAt = time.Time{}
 	m.xskLivenessProven = false
 	m.xskLivenessFailed = false
+	m.initialCtrlCleanupDone = false
 	m.xskProbeStart = time.Time{}
 	m.lastXSKRX = 0
 	m.lastNAPIBootstrap = time.Time{}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -440,6 +440,12 @@ func (m *Manager) UpdateRGActive(rgID int, active bool) error {
 	if err := m.requestLocked(req, &status); err != nil {
 		return err
 	}
+	if active {
+		// The helper has already acknowledged the RG activation update.
+		// Clear the transition guard before applying the returned status so
+		// the acked activation does not force one global ctrl-disabled cycle.
+		m.rgTransitionInFlight.Store(false)
+	}
 	m.lastRGActivateTime = time.Now()
 	if err := m.applyHelperStatusLocked(&status); err != nil {
 		return err

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -111,6 +112,50 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 	}
 	t.Cleanup(func() { sessionsMapV6.Close() })
 	injectInnerMap(t, m.inner, "sessions_v6", sessionsMapV6)
+}
+
+func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
+	t.Helper()
+	ctrlMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  uint32(unsafe.Sizeof(userspaceCtrlValue{})),
+		MaxEntries: 16,
+	})
+	if err != nil {
+		t.Fatalf("new userspace_ctrl map: %v", err)
+	}
+	t.Cleanup(func() { ctrlMap.Close() })
+	injectInnerMap(t, m.inner, "userspace_ctrl", ctrlMap)
+
+	bindingsMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  uint32(unsafe.Sizeof(userspaceBindingValue{})),
+		MaxEntries: 256,
+	})
+	if err != nil {
+		t.Fatalf("new userspace_bindings map: %v", err)
+	}
+	t.Cleanup(func() { bindingsMap.Close() })
+	injectInnerMap(t, m.inner, "userspace_bindings", bindingsMap)
+	return ctrlMap, bindingsMap
+}
+
+func injectUserspaceSessionMap(t *testing.T, m *Manager) *ebpf.Map {
+	t.Helper()
+	usMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 256,
+	})
+	if err != nil {
+		t.Fatalf("new userspace_sessions map: %v", err)
+	}
+	t.Cleanup(func() { usMap.Close() })
+	injectInnerMap(t, m.inner, "userspace_sessions", usMap)
+	return usMap
 }
 
 func TestFindUserspaceEgressInterfaceSnapshotPrefersVLANUnit(t *testing.T) {
@@ -791,6 +836,166 @@ func TestTakeoverReadyRequiresLivenessProofOnActiveNode(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected XSK liveness reason, got %v", reasons)
+	}
+}
+
+func TestApplyHelperStatusInitialCtrlCleanupRunsOnlyOnce(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	m := New()
+	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	injectCtrlAndBindingMaps(t, m)
+	usMap := injectUserspaceSessionMap(t, m)
+	m.neighborsPrewarmed = true
+	m.xskLivenessProven = true
+	m.publishedSnapshot = 1
+
+	status := ProcessStatus{
+		Enabled:                true,
+		Workers:                1,
+		LastSnapshotGeneration: 1,
+		NeighborGeneration:     1,
+		Capabilities: UserspaceCapabilities{
+			ForwardingSupported: true,
+		},
+		Bindings: []BindingStatus{{
+			Slot:       1,
+			QueueID:    0,
+			Ifindex:    5,
+			Registered: true,
+			Armed:      true,
+			Bound:      true,
+		}},
+	}
+
+	key := uint32(1)
+	value := uint64(1)
+	if err := usMap.Update(key, value, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed userspace_sessions: %v", err)
+	}
+	if err := m.applyHelperStatusLocked(&status); err != nil {
+		t.Fatalf("first applyHelperStatusLocked: %v", err)
+	}
+	if !m.initialCtrlCleanupDone {
+		t.Fatal("initialCtrlCleanupDone = false, want true after first ctrl enable")
+	}
+	var got uint64
+	if err := usMap.Lookup(key, &got); !errors.Is(err, ebpf.ErrKeyNotExist) {
+		t.Fatalf("userspace_sessions entry survived first ctrl enable cleanup: err=%v got=%d", err, got)
+	}
+
+	if err := usMap.Update(key, value, ebpf.UpdateAny); err != nil {
+		t.Fatalf("reseed userspace_sessions: %v", err)
+	}
+	m.ctrlWasEnabled = false
+	if err := m.applyHelperStatusLocked(&status); err != nil {
+		t.Fatalf("second applyHelperStatusLocked: %v", err)
+	}
+	if err := usMap.Lookup(key, &got); err != nil {
+		t.Fatalf("later ctrl re-enable reran startup cleanup: %v", err)
+	}
+}
+
+func TestUpdateRGActiveActivationKeepsCtrlEnabledAfterAckedStatus(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	status := ProcessStatus{
+		Enabled:                true,
+		Workers:                1,
+		LastSnapshotGeneration: 2,
+		NeighborGeneration:     1,
+		Capabilities: UserspaceCapabilities{
+			ForwardingSupported: true,
+		},
+		Bindings: []BindingStatus{{
+			Slot:       1,
+			QueueID:    0,
+			Ifindex:    5,
+			Registered: true,
+			Armed:      true,
+			Bound:      true,
+		}},
+	}
+	reqDone := make(chan struct{}, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req ControlRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			return
+		}
+		if req.Type != "update_ha_state" {
+			return
+		}
+		_ = json.NewEncoder(conn).Encode(ControlResponse{
+			OK:     true,
+			Status: &status,
+		})
+		reqDone <- struct{}{}
+	}()
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+	m.cfg.ControlSocket = controlSock
+	m.clusterHA = true
+	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.neighborsPrewarmed = true
+	m.xskLivenessProven = true
+	m.ctrlWasEnabled = true
+	m.haGroups = map[int]HAGroupStatus{
+		0: {RGID: 0, Active: true},
+		1: {RGID: 1, Active: false},
+		2: {RGID: 2, Active: true},
+	}
+
+	ctrlMap, _ := injectCtrlAndBindingMaps(t, m)
+	rgMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  1,
+		MaxEntries: 16,
+	})
+	if err != nil {
+		t.Fatalf("new rg_active map: %v", err)
+	}
+	t.Cleanup(func() { rgMap.Close() })
+	injectInnerMap(t, m.inner, "rg_active", rgMap)
+
+	if err := m.UpdateRGActive(1, true); err != nil {
+		t.Fatalf("UpdateRGActive: %v", err)
+	}
+	select {
+	case <-reqDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for update_ha_state request")
+	}
+
+	var zero uint32
+	var ctrl userspaceCtrlValue
+	if err := ctrlMap.Lookup(zero, &ctrl); err != nil {
+		t.Fatalf("lookup userspace_ctrl: %v", err)
+	}
+	if ctrl.Enabled != 1 {
+		t.Fatalf("userspace_ctrl.Enabled = %d, want 1 after acked activation", ctrl.Enabled)
+	}
+	if m.mode != ModeUserspaceCompat {
+		t.Fatalf("mode = %s, want %s", m.mode, ModeUserspaceCompat)
+	}
+	if m.rgTransitionInFlight.Load() {
+		t.Fatal("rgTransitionInFlight = true after UpdateRGActive")
 	}
 }
 

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -2377,12 +2377,12 @@ fn poll_binding(
                         meta,
                         forwarding,
                     );
+                    let packet_fabric_ingress = ingress_zone_override.is_some()
+                        || ingress_is_fabric_overlay(forwarding, meta.ingress_ifindex as i32);
                     // Flag fabric-ingress packets so rewrite functions skip TTL
                     // decrement. The sending peer already decremented TTL when
                     // it forwarded the packet across the fabric link.
-                    if ingress_zone_override.is_some()
-                        || ingress_is_fabric(forwarding, meta.ingress_ifindex as i32)
-                    {
+                    if packet_fabric_ingress {
                         meta.meta_flags |= FABRIC_INGRESS_FLAG;
                     }
                     // Screen/IDS check — runs BEFORE session lookup.
@@ -2661,6 +2661,7 @@ fn poll_binding(
                             meta.protocol,
                             meta.tcp_flags,
                             meta.ingress_ifindex as i32,
+                            packet_fabric_ingress,
                             ha_startup_grace_until_secs,
                         ) {
                             counters.session_hits += 1;
@@ -2922,8 +2923,7 @@ fn poll_binding(
                                     )
                                 })
                             };
-                            let fabric_ingress =
-                                ingress_is_fabric(forwarding, meta.ingress_ifindex as i32);
+                            let fabric_ingress = packet_fabric_ingress;
                             let resolution = prefer_local_forward_candidate_for_fabric_ingress(
                                 forwarding,
                                 ha_state,
@@ -2957,6 +2957,7 @@ fn poll_binding(
                                 ha_state,
                                 now_secs,
                                 decision.resolution,
+                                packet_fabric_ingress,
                                 meta.ingress_ifindex as i32,
                                 from_zone_arc.as_ref(),
                                 ha_startup_grace_until_secs,
@@ -3620,7 +3621,7 @@ fn poll_binding(
                                 }
                             } else if decision.resolution.disposition
                                 == ForwardingDisposition::HAInactive
-                                && !ingress_is_fabric(forwarding, meta.ingress_ifindex as i32)
+                                && !packet_fabric_ingress
                             {
                                 // New flow to inactive RG: fabric-redirect to the peer
                                 // that owns the egress RG.  Use from_zone_arc directly
@@ -3654,7 +3655,7 @@ fn poll_binding(
                         // redirect when the egress RG is inactive.
                         let final_resolution = if non_flow_resolution.disposition
                             == ForwardingDisposition::HAInactive
-                            && !ingress_is_fabric(forwarding, meta.ingress_ifindex as i32)
+                            && !packet_fabric_ingress
                         {
                             resolve_fabric_redirect(forwarding).unwrap_or(non_flow_resolution)
                         } else {
@@ -3678,7 +3679,7 @@ fn poll_binding(
                     let egress_rg = owner_rg_for_resolution(forwarding, decision.resolution);
                     if decision.resolution.disposition == ForwardingDisposition::HAInactive
                         && egress_rg > 0
-                        && !ingress_is_fabric(forwarding, meta.ingress_ifindex as i32)
+                        && !packet_fabric_ingress
                     {
                         let zone_name = session_ingress_zone
                             .as_deref()
@@ -4169,7 +4170,7 @@ fn poll_binding(
                                         forwarding,
                                         &from_zone_arc,
                                         &to_zone_arc,
-                                        meta.ingress_ifindex as i32,
+                                        packet_fabric_ingress,
                                         pending_decision,
                                     );
                                     if sessions.install_with_protocol_with_origin(
@@ -4677,14 +4678,14 @@ fn build_missing_neighbor_session_metadata(
     forwarding: &ForwardingState,
     ingress_zone: &Arc<str>,
     egress_zone: &Arc<str>,
-    ingress_ifindex: i32,
+    fabric_ingress: bool,
     decision: SessionDecision,
 ) -> SessionMetadata {
     SessionMetadata {
         ingress_zone: ingress_zone.clone(),
         egress_zone: egress_zone.clone(),
         owner_rg_id: owner_rg_for_resolution(forwarding, decision.resolution),
-        fabric_ingress: ingress_is_fabric(forwarding, ingress_ifindex),
+        fabric_ingress,
         is_reverse: false,
         nat64_reverse: None,
     }
@@ -6241,7 +6242,7 @@ mod tests {
     }
 
     #[test]
-    fn synced_replica_entry_marks_replica_synced() {
+    fn synced_replica_entry_keeps_peer_synced_entries_promotable() {
         let entry = SyncedSessionEntry {
             key: SessionKey {
                 addr_family: libc::AF_INET as u8,
@@ -6275,6 +6276,48 @@ mod tests {
         };
         let replica = synced_replica_entry(&entry);
         assert!(replica.origin.is_peer_synced());
+        assert!(replica.origin.is_promotable_synced());
+        assert_eq!(replica.key, entry.key);
+        assert_eq!(replica.decision, entry.decision);
+    }
+
+    #[test]
+    fn synced_replica_entry_marks_local_entries_worker_local() {
+        let entry = SyncedSessionEntry {
+            key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 5201,
+            },
+            decision: SessionDecision {
+                resolution: lookup_forwarding_resolution(
+                    &build_forwarding_state(&nat_snapshot()),
+                    IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                ),
+                nat: NatDecision {
+                    rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                    ..NatDecision::default()
+                },
+            },
+            metadata: SessionMetadata {
+                ingress_zone: Arc::<str>::from("lan"),
+                egress_zone: Arc::<str>::from("wan"),
+                owner_rg_id: 1,
+                fabric_ingress: false,
+                is_reverse: false,
+                nat64_reverse: None,
+            },
+            origin: SessionOrigin::ForwardFlow,
+            protocol: PROTO_TCP,
+            tcp_flags: 0,
+        };
+        let replica = synced_replica_entry(&entry);
+        assert_eq!(replica.origin, SessionOrigin::WorkerLocalImport);
+        assert!(replica.origin.is_peer_synced());
+        assert!(!replica.origin.is_promotable_synced());
         assert_eq!(replica.key, entry.key);
         assert_eq!(replica.decision, entry.decision);
     }

--- a/userspace-dp/src/afxdp/forwarding.rs
+++ b/userspace-dp/src/afxdp/forwarding.rs
@@ -186,6 +186,16 @@ pub(super) fn ingress_is_fabric(forwarding: &ForwardingState, ingress_ifindex: i
     })
 }
 
+pub(super) fn ingress_is_fabric_overlay(
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+) -> bool {
+    forwarding
+        .fabrics
+        .iter()
+        .any(|fabric| fabric.overlay_ifindex == ingress_ifindex)
+}
+
 pub(super) fn resolve_fabric_links_from_snapshots(
     snapshots: &[crate::FabricSnapshot],
     egress: &FastMap<i32, EgressInterface>,
@@ -475,21 +485,26 @@ pub(super) fn finalize_new_flow_ha_resolution(
     ha_state: &BTreeMap<i32, HAGroupRuntime>,
     now_secs: u64,
     resolution: ForwardingResolution,
+    fabric_ingress: bool,
     ingress_ifindex: i32,
     ingress_zone: &str,
     ha_startup_grace_until_secs: u64,
 ) -> ForwardingResolution {
+    let enforced = super::session_glue::enforce_session_ha_resolution(
+        forwarding,
+        ha_state,
+        now_secs,
+        resolution,
+        ingress_ifindex,
+        ha_startup_grace_until_secs,
+    );
+    if fabric_ingress && enforced.disposition == ForwardingDisposition::HAInactive {
+        return resolution;
+    }
     super::session_glue::redirect_session_via_fabric_if_needed(
         forwarding,
-        super::session_glue::enforce_session_ha_resolution(
-            forwarding,
-            ha_state,
-            now_secs,
-            resolution,
-            ingress_ifindex,
-            ha_startup_grace_until_secs,
-        ),
-        ingress_ifindex,
+        enforced,
+        fabric_ingress,
         ingress_zone,
     )
 }
@@ -2044,13 +2059,7 @@ mod tests {
         let routed = lookup_forwarding_resolution(&state, IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
         let (from_zone, _) = zone_pair_for_flow(&state, 24, routed.egress_ifindex);
         let redirected = finalize_new_flow_ha_resolution(
-            &state,
-            &ha_state,
-            now_secs,
-            routed,
-            24,
-            &from_zone,
-            0,
+            &state, &ha_state, now_secs, routed, false, 24, &from_zone, 0,
         );
         assert_eq!(
             redirected.disposition,
@@ -2069,13 +2078,7 @@ mod tests {
         let ha_state = BTreeMap::from([(1, inactive_ha_runtime(now_secs))]);
         let routed = lookup_forwarding_resolution(&state, IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
         let resolved = finalize_new_flow_ha_resolution(
-            &state,
-            &ha_state,
-            now_secs,
-            routed,
-            21,
-            "lan",
-            0,
+            &state, &ha_state, now_secs, routed, true, 21, "lan", 0,
         );
         assert_eq!(
             resolved.disposition,
@@ -2317,7 +2320,7 @@ mod tests {
             &state,
             &ingress_zone,
             &egress_zone,
-            4,
+            true,
             decision,
         );
 

--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -1103,10 +1103,8 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                             _ => 0,
                         };
                         if csum_off > 0 && packet.len() > csum_off + 1 {
-                            let current = u16::from_be_bytes([
-                                packet[csum_off],
-                                packet[csum_off + 1],
-                            ]);
+                            let current =
+                                u16::from_be_bytes([packet[csum_off], packet[csum_off + 1]]);
                             let mut updated = checksum16_adjust(
                                 current,
                                 &ipv4_words(Ipv4Addr::from(pre_src_ip)),
@@ -1118,18 +1116,12 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                                 &ipv4_words(Ipv4Addr::from(post_dst_ip)),
                             );
                             if pre_src_port != post_src_port {
-                                updated = checksum16_adjust(
-                                    updated,
-                                    &[pre_src_port],
-                                    &[post_src_port],
-                                );
+                                updated =
+                                    checksum16_adjust(updated, &[pre_src_port], &[post_src_port]);
                             }
                             if pre_dst_port != post_dst_port {
-                                updated = checksum16_adjust(
-                                    updated,
-                                    &[pre_dst_port],
-                                    &[post_dst_port],
-                                );
+                                updated =
+                                    checksum16_adjust(updated, &[pre_dst_port], &[post_dst_port]);
                             }
                             if matches!(meta.protocol, PROTO_UDP) && updated == 0 {
                                 updated = 0xffff;
@@ -1142,12 +1134,7 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
                 } else {
                     // Full L4 checksum recompute when enforce_expected_ports
                     // may have modified ports and adjusted the checksum.
-                    recompute_l4_checksum_ipv4(
-                        packet,
-                        ip_header_len,
-                        meta.protocol,
-                        false,
-                    )?;
+                    recompute_l4_checksum_ipv4(packet, ip_header_len, meta.protocol, false)?;
                 }
             }
             libc::AF_INET6 => {

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -672,7 +672,7 @@ fn materialize_shared_session_hit(
             replica.key.clone(),
             replica.decision,
             replica.metadata.clone(),
-            SessionOrigin::SharedMaterialize,
+            shared.origin.materialized_shared_hit_origin(),
             now_ns,
             replica.protocol,
             tcp_flags,
@@ -699,12 +699,12 @@ fn maybe_promote_synced_session(
     decision: SessionDecision,
     metadata: SessionMetadata,
     origin: SessionOrigin,
-    ingress_ifindex: i32,
+    fabric_ingress: bool,
     now_ns: u64,
     protocol: u8,
     tcp_flags: u8,
 ) -> SessionMetadata {
-    if !origin.is_peer_synced()
+    if !origin.is_promotable_synced()
         || decision.resolution.disposition != ForwardingDisposition::ForwardCandidate
     {
         return metadata;
@@ -714,7 +714,7 @@ fn maybe_promote_synced_session(
     if promoted.owner_rg_id <= 0 {
         promoted.owner_rg_id = owner_rg_for_resolution(forwarding, decision.resolution);
     }
-    if ingress_is_fabric(forwarding, ingress_ifindex) {
+    if fabric_ingress {
         promoted.fabric_ingress = true;
     }
     if sessions.promote_synced_with_origin(
@@ -814,6 +814,7 @@ pub(super) fn resolve_flow_session_decision(
     protocol: u8,
     tcp_flags: u8,
     ingress_ifindex: i32,
+    fabric_ingress: bool,
     ha_startup_grace_until_secs: u64,
 ) -> Option<ResolvedFlowSessionDecision> {
     if let Some(mut hit) = lookup_session_across_scopes(
@@ -869,7 +870,7 @@ pub(super) fn resolve_flow_session_decision(
             ha_state,
             dynamic_neighbors,
             now_secs,
-            ingress_is_fabric(forwarding, ingress_ifindex),
+            fabric_ingress,
             resolution_target,
             looked_up_resolution,
         );
@@ -884,7 +885,7 @@ pub(super) fn resolve_flow_session_decision(
         decision.resolution = redirect_session_via_fabric_if_needed(
             forwarding,
             enforced_resolution,
-            ingress_ifindex,
+            fabric_ingress,
             resolved.metadata.ingress_zone.as_ref(),
         );
         let metadata = if keep_transient {
@@ -903,7 +904,7 @@ pub(super) fn resolve_flow_session_decision(
                 decision,
                 resolved.metadata,
                 hit_origin,
-                ingress_ifindex,
+                fabric_ingress,
                 now_ns,
                 protocol,
                 tcp_flags,
@@ -947,7 +948,7 @@ pub(super) fn resolve_flow_session_decision(
         ha_state,
         dynamic_neighbors,
         now_secs,
-        ingress_is_fabric(forwarding, ingress_ifindex),
+        fabric_ingress,
         resolution_target,
         looked_up_resolution,
     );
@@ -962,7 +963,7 @@ pub(super) fn resolve_flow_session_decision(
     decision.resolution = redirect_session_via_fabric_if_needed(
         forwarding,
         enforced_resolution,
-        ingress_ifindex,
+        fabric_ingress,
         resolved.metadata.ingress_zone.as_ref(),
     );
     // Reverse sessions created from forward NAT matches are locally
@@ -980,7 +981,7 @@ pub(super) fn resolve_flow_session_decision(
         decision,
         resolved.metadata,
         SessionOrigin::ReverseFlow,
-        ingress_ifindex,
+        fabric_ingress,
         now_ns,
         protocol,
         tcp_flags,
@@ -995,13 +996,13 @@ pub(super) fn resolve_flow_session_decision(
 pub(super) fn redirect_session_via_fabric_if_needed(
     forwarding: &ForwardingState,
     resolution: ForwardingResolution,
-    ingress_ifindex: i32,
+    fabric_ingress: bool,
     ingress_zone: &str,
 ) -> ForwardingResolution {
     if resolution.disposition != ForwardingDisposition::HAInactive {
         return resolution;
     }
-    if ingress_is_fabric(forwarding, ingress_ifindex) {
+    if fabric_ingress {
         return resolution;
     }
     resolve_zone_encoded_fabric_redirect(forwarding, ingress_zone)
@@ -1018,11 +1019,6 @@ pub(super) fn enforce_session_ha_resolution(
     ha_startup_grace_until_secs: u64,
 ) -> ForwardingResolution {
     let enforced = enforce_ha_resolution_snapshot(forwarding, ha_state, now_secs, resolution);
-    if enforced.disposition == ForwardingDisposition::HAInactive
-        && ingress_is_fabric(forwarding, ingress_ifindex)
-    {
-        return resolution;
-    }
     if enforced.disposition == ForwardingDisposition::HAInactive
         && should_bypass_unseeded_tunnel_ha(
             forwarding,
@@ -1237,13 +1233,63 @@ mod tests {
             decision,
             metadata,
             SessionOrigin::SyncImport,
-            21,
+            true,
             2_000_000,
             PROTO_TCP,
             0x10,
         );
 
         assert!(promoted.fabric_ingress);
+    }
+
+    #[test]
+    fn maybe_promote_synced_session_skips_worker_local_import() {
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = test_decision();
+        let metadata = test_metadata();
+        assert!(sessions.install_with_protocol_with_origin(
+            key.clone(),
+            decision,
+            metadata.clone(),
+            SessionOrigin::WorkerLocalImport,
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+        let forwarding = test_forwarding_state_with_fabric();
+
+        let promoted = maybe_promote_synced_session(
+            &mut sessions,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &key,
+            decision,
+            metadata.clone(),
+            SessionOrigin::WorkerLocalImport,
+            false,
+            2_000_000,
+            PROTO_TCP,
+            0x10,
+        );
+
+        assert_eq!(promoted, metadata);
+        let Some((_decision, _metadata, origin)) = sessions.entry_with_origin(&key) else {
+            panic!("worker-local session missing");
+        };
+        assert_eq!(origin, SessionOrigin::WorkerLocalImport);
+        assert!(shared_sessions.lock().expect("shared sessions").is_empty());
     }
 
     #[test]
@@ -1320,6 +1366,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             21,
+            true,
             0,
         )
         .expect("resolved");
@@ -1929,6 +1976,7 @@ mod tests {
             PROTO_TCP,
             0x10,
             0,
+            false,
             0,
         )
         .expect("translated forward hit should resolve");
@@ -2015,6 +2063,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             21,
+            true,
             0,
         )
         .expect("translated shared hit should resolve");
@@ -2106,6 +2155,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             21,
+            true,
             0,
         )
         .expect("translated local hit should resolve");
@@ -2195,6 +2245,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             21,
+            true,
             0,
         )
         .expect("translated shared hit should resolve");
@@ -2275,6 +2326,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             12,
+            false,
             0,
         )
         .expect("translated shared hit should resolve");
@@ -2349,6 +2401,7 @@ mod tests {
             PROTO_TCP,
             0x18,
             12,
+            false,
             0,
         )
         .expect("translated local hit should resolve");
@@ -2594,6 +2647,7 @@ mod tests {
             PROTO_TCP,
             0x10,
             6,
+            false,
             0,
         )
         .expect("resolved demoted session");
@@ -3171,7 +3225,7 @@ mod tests {
                 src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
                 tx_vlan_id: 0,
             },
-            362,
+            false,
             "sfmix",
         );
         assert_eq!(
@@ -3187,7 +3241,29 @@ mod tests {
     }
 
     #[test]
-    fn fabric_ingress_session_hit_bypasses_ha_inactive_gate() {
+    fn session_hit_ha_inactive_does_not_redirect_actual_fabric_ingress() {
+        let forwarding = test_forwarding_state_with_fabric();
+        let resolved = redirect_session_via_fabric_if_needed(
+            &forwarding,
+            ForwardingResolution {
+                disposition: ForwardingDisposition::HAInactive,
+                local_ifindex: 0,
+                egress_ifindex: 6,
+                tx_ifindex: 6,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                neighbor_mac: Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+                src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
+                tx_vlan_id: 0,
+            },
+            true,
+            "sfmix",
+        );
+        assert_eq!(resolved.disposition, ForwardingDisposition::HAInactive);
+    }
+
+    #[test]
+    fn fabric_ingress_session_hit_obeys_ha_inactive_gate() {
         let forwarding = test_forwarding_state_with_fabric();
         let ha_state = BTreeMap::from([(1, inactive_ha_runtime(1))]);
         let resolved = enforce_session_ha_resolution(
@@ -3208,10 +3284,7 @@ mod tests {
             21,
             0,
         );
-        assert_eq!(
-            resolved.disposition,
-            ForwardingDisposition::ForwardCandidate
-        );
+        assert_eq!(resolved.disposition, ForwardingDisposition::HAInactive);
         assert_eq!(resolved.egress_ifindex, 6);
     }
 

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -36,7 +36,7 @@ pub(super) fn demote_shared_owner_rgs(
 
 pub(super) fn synced_replica_entry(entry: &SyncedSessionEntry) -> SyncedSessionEntry {
     let mut replica = entry.clone();
-    replica.origin = SessionOrigin::SyncImport;
+    replica.origin = entry.origin.worker_replica_origin();
     replica
 }
 

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -439,31 +439,31 @@ mod tests {
 
     #[test]
     fn local_tunnel_io_error_is_fatal_for_permanent_tunnel_fd_errors() {
-        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
-            libc::EINVAL,
-        )));
-        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
-            libc::EBADF,
-        )));
-        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
-            libc::EBADFD,
-        )));
-        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
-            libc::ENODEV,
-        )));
-        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
-            libc::ENXIO,
-        )));
+        assert!(local_tunnel_io_error_is_fatal(
+            &io::Error::from_raw_os_error(libc::EINVAL,)
+        ));
+        assert!(local_tunnel_io_error_is_fatal(
+            &io::Error::from_raw_os_error(libc::EBADF,)
+        ));
+        assert!(local_tunnel_io_error_is_fatal(
+            &io::Error::from_raw_os_error(libc::EBADFD,)
+        ));
+        assert!(local_tunnel_io_error_is_fatal(
+            &io::Error::from_raw_os_error(libc::ENODEV,)
+        ));
+        assert!(local_tunnel_io_error_is_fatal(
+            &io::Error::from_raw_os_error(libc::ENXIO,)
+        ));
     }
 
     #[test]
     fn local_tunnel_io_error_is_not_fatal_for_retryable_io() {
-        assert!(!local_tunnel_io_error_is_fatal(
-            &io::Error::from(io::ErrorKind::WouldBlock),
-        ));
-        assert!(!local_tunnel_io_error_is_fatal(
-            &io::Error::from(io::ErrorKind::Interrupted),
-        ));
+        assert!(!local_tunnel_io_error_is_fatal(&io::Error::from(
+            io::ErrorKind::WouldBlock
+        ),));
+        assert!(!local_tunnel_io_error_is_fatal(&io::Error::from(
+            io::ErrorKind::Interrupted
+        ),));
         assert!(!local_tunnel_io_error_is_fatal(
             &io::Error::from_raw_os_error(libc::ETIMEDOUT),
         ));

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -439,31 +439,31 @@ mod tests {
 
     #[test]
     fn local_tunnel_io_error_is_fatal_for_permanent_tunnel_fd_errors() {
-        assert!(local_tunnel_io_error_is_fatal(
-            &io::Error::from_raw_os_error(libc::EINVAL,)
-        ));
-        assert!(local_tunnel_io_error_is_fatal(
-            &io::Error::from_raw_os_error(libc::EBADF,)
-        ));
-        assert!(local_tunnel_io_error_is_fatal(
-            &io::Error::from_raw_os_error(libc::EBADFD,)
-        ));
-        assert!(local_tunnel_io_error_is_fatal(
-            &io::Error::from_raw_os_error(libc::ENODEV,)
-        ));
-        assert!(local_tunnel_io_error_is_fatal(
-            &io::Error::from_raw_os_error(libc::ENXIO,)
-        ));
+        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
+            libc::EINVAL,
+        )));
+        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
+            libc::EBADF,
+        )));
+        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
+            libc::EBADFD,
+        )));
+        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
+            libc::ENODEV,
+        )));
+        assert!(local_tunnel_io_error_is_fatal(&io::Error::from_raw_os_error(
+            libc::ENXIO,
+        )));
     }
 
     #[test]
     fn local_tunnel_io_error_is_not_fatal_for_retryable_io() {
-        assert!(!local_tunnel_io_error_is_fatal(&io::Error::from(
-            io::ErrorKind::WouldBlock
-        ),));
-        assert!(!local_tunnel_io_error_is_fatal(&io::Error::from(
-            io::ErrorKind::Interrupted
-        ),));
+        assert!(!local_tunnel_io_error_is_fatal(
+            &io::Error::from(io::ErrorKind::WouldBlock),
+        ));
+        assert!(!local_tunnel_io_error_is_fatal(
+            &io::Error::from(io::ErrorKind::Interrupted),
+        ));
         assert!(!local_tunnel_io_error_is_fatal(
             &io::Error::from_raw_os_error(libc::ETIMEDOUT),
         ));

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -4,7 +4,7 @@
 //! happens on a stack-allocated `[u8; 256]` buffer.
 
 use crate::afxdp::ForwardingDisposition;
-use crate::session::{SessionDelta, SessionDecision, SessionKey, SessionMetadata};
+use crate::session::{SessionDecision, SessionDelta, SessionKey, SessionMetadata};
 use rustc_hash::FxHashMap;
 use std::net::IpAddr;
 
@@ -86,18 +86,15 @@ impl EventFrame {
 
         // [6:8] NATSrcPort LE
         let nat = &decision.nat;
-        buf[pos..pos + 2]
-            .copy_from_slice(&nat.rewrite_src_port.unwrap_or(0).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&nat.rewrite_src_port.unwrap_or(0).to_le_bytes());
         pos += 2;
 
         // [8:10] NATDstPort LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&nat.rewrite_dst_port.unwrap_or(0).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&nat.rewrite_dst_port.unwrap_or(0).to_le_bytes());
         pos += 2;
 
         // [10:12] OwnerRGID i16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&(metadata.owner_rg_id as i16).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&(metadata.owner_rg_id as i16).to_le_bytes());
         pos += 2;
 
         // [12:14] EgressIfindex i16 LE
@@ -106,18 +103,15 @@ impl EventFrame {
         pos += 2;
 
         // [14:16] TXIfindex i16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&(decision.resolution.tx_ifindex as i16).to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&(decision.resolution.tx_ifindex as i16).to_le_bytes());
         pos += 2;
 
         // [16:18] TunnelEndpointID u16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&decision.resolution.tunnel_endpoint_id.to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&decision.resolution.tunnel_endpoint_id.to_le_bytes());
         pos += 2;
 
         // [18:20] TXVLANID u16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&decision.resolution.tx_vlan_id.to_le_bytes());
+        buf[pos..pos + 2].copy_from_slice(&decision.resolution.tx_vlan_id.to_le_bytes());
         pos += 2;
 
         // [20] Flags
@@ -533,14 +527,23 @@ mod tests {
 
     #[test]
     fn test_disposition_encoding() {
-        assert_eq!(encode_disposition(ForwardingDisposition::ForwardCandidate), 0);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::ForwardCandidate),
+            0
+        );
         assert_eq!(encode_disposition(ForwardingDisposition::LocalDelivery), 1);
         assert_eq!(encode_disposition(ForwardingDisposition::FabricRedirect), 2);
         assert_eq!(encode_disposition(ForwardingDisposition::PolicyDenied), 3);
         assert_eq!(encode_disposition(ForwardingDisposition::NoRoute), 4);
-        assert_eq!(encode_disposition(ForwardingDisposition::MissingNeighbor), 5);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::MissingNeighbor),
+            5
+        );
         assert_eq!(encode_disposition(ForwardingDisposition::HAInactive), 6);
         assert_eq!(encode_disposition(ForwardingDisposition::DiscardRoute), 7);
-        assert_eq!(encode_disposition(ForwardingDisposition::NextTableUnsupported), 8);
+        assert_eq!(
+            encode_disposition(ForwardingDisposition::NextTableUnsupported),
+            8
+        );
     }
 }

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -11,7 +11,7 @@
 
 pub(crate) mod codec;
 
-pub(crate) use codec::{close_flags, EventFrame};
+pub(crate) use codec::{EventFrame, close_flags};
 
 use crate::session::{SessionDelta, SessionDeltaKind};
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
@@ -19,9 +19,9 @@ use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::io;
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TryRecvError};
-use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -649,17 +649,15 @@ fn handle_stream(
                     }
                 }
             }
-            "export_all_sessions" => {
-                match guard.afxdp.export_all_sessions_to_event_stream() {
-                    Ok(_count) => {
-                        refresh_status(&mut guard);
-                    }
-                    Err(err) => {
-                        response.ok = false;
-                        response.error = err;
-                    }
+            "export_all_sessions" => match guard.afxdp.export_all_sessions_to_event_stream() {
+                Ok(_count) => {
+                    refresh_status(&mut guard);
                 }
-            }
+                Err(err) => {
+                    response.ok = false;
+                    response.error = err;
+                }
+            },
             "rebind" => {
                 // After a link DOWN/UP cycle (e.g. RETH MAC programming),
                 // the kernel destroys the XSK receive queue.  Stop all

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -731,7 +731,11 @@ pub(crate) struct HAGroupStatus {
     pub watchdog_timestamp: u64,
     #[serde(rename = "forwarding_active", default)]
     pub forwarding_active: bool,
-    #[serde(rename = "lease_state", default, skip_serializing_if = "String::is_empty")]
+    #[serde(
+        rename = "lease_state",
+        default,
+        skip_serializing_if = "String::is_empty"
+    )]
     pub lease_state: String,
     #[serde(rename = "lease_until", default, skip_serializing_if = "u64_is_zero")]
     pub lease_until: u64,

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -160,6 +160,26 @@ impl SessionOrigin {
         )
     }
 
+    pub(crate) fn is_promotable_synced(self) -> bool {
+        matches!(self, Self::SyncImport | Self::SharedMaterialize)
+    }
+
+    pub(crate) fn worker_replica_origin(self) -> Self {
+        if self.is_promotable_synced() {
+            Self::SyncImport
+        } else {
+            Self::WorkerLocalImport
+        }
+    }
+
+    pub(crate) fn materialized_shared_hit_origin(self) -> Self {
+        if self.is_promotable_synced() {
+            Self::SharedMaterialize
+        } else {
+            Self::WorkerLocalImport
+        }
+    }
+
     pub(crate) fn is_transient_local_seed(self) -> bool {
         matches!(self, Self::MissingNeighborSeed)
     }


### PR DESCRIPTION
Closes #608.

This bundles the repo-level HA handoff fixes that came out of the repeated RG movement debugging:

- retain a populated `fabric_fwd` entry across transient neighbor misses instead of clearing it immediately
- avoid an extra ctrl-disable cycle after RG activation has already been acked
- distinguish actual fabric-ingress packets from ordinary packets arriving on the fabric parent NIC, so stale traffic on the old owner can still be redirected to the active peer instead of getting dropped as `ha_inactive`
- preserve synced-session ownership/materialization semantics needed for that standby redirect path

Validation:
- `go test ./pkg/dataplane/userspace ./pkg/daemon -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::session_glue::tests -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::forwarding::tests -- --nocapture`

Live notes:
- on the patched build, the old `ha_inactive` standby-drop symptom is no longer visible on the new owner during the RG1 IPv6 repro
- the separate remaining first-failover throughput collapse is tracked in #609
- the later VM panic remains the known kernel/driver issue in #472
