### PR TITLE
cluster: preserve committed reverse failovers through heartbeat gaps

### DIFF
--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -190,10 +190,16 @@ TOTAL_CYCLES=12 CYCLE_INTERVAL=5 \
 scripts/userspace-ha-failover-validation.sh --duration 600 --parallel 8
 ```
 
+```bash
+# Reverse-path coverage is also required. The validator currently exercises the
+# source-sending path, so run a matching reverse iperf after the forward pass.
+iperf3 -c 172.16.80.200 -P 8 -t 600 -R
+```
+
 ### Manual CLI test
 
 ```bash
-# Start long-running traffic and keep all per-stream lines visible.
+# Start long-running forward traffic and keep all per-stream lines visible.
 iperf3 -c 172.16.80.200 -P 8 -t 600
 
 # Rapidly move RG1 between fw0 and fw1 while traffic is active.
@@ -210,12 +216,26 @@ cli -c "request chassis cluster failover redundancy-group 1 node 0"
 cli -c "show chassis cluster data-plane statistics" | grep SNAT
 ```
 
+```bash
+# Repeat the same RG movement under reverse traffic. This exercises the return
+# path ownership and catches failovers that only work when the host is sending.
+iperf3 -c 172.16.80.200 -P 8 -t 600 -R
+
+cli -c "request chassis cluster failover redundancy-group 1 node 1"
+sleep 5
+cli -c "request chassis cluster failover redundancy-group 1 node 0"
+sleep 5
+cli -c "request chassis cluster failover redundancy-group 1 node 1"
+sleep 5
+cli -c "request chassis cluster failover redundancy-group 1 node 0"
+```
+
 ### Pass criteria
 
-- All 8 iperf3 streams survive every RG move
-- Zero per-stream zero-throughput intervals
-- Zero aggregate zero-throughput intervals
-- No permanently wedged stream after failback
+- All 8 iperf3 streams survive every RG move in both forward and reverse runs
+- Zero per-stream zero-throughput intervals in both directions
+- Zero aggregate zero-throughput intervals in both directions
+- No permanently wedged stream after failback in either direction
 - SNAT packets > 0 on new owner
 - Session misses < 1000 on new owner
 - RG moves to the requested node

--- a/docs/userspace-ha-validation.md
+++ b/docs/userspace-ha-validation.md
@@ -156,6 +156,7 @@ For standard HA failover stress on `loss`, use:
 - `CYCLE_INTERVAL=5`
 - `--duration 600`
 - `--parallel 8`
+- one forward run and one reverse `iperf3 -R` run
 
 That is the preferred repro shape for the remaining "first failover degrades,
 failback wedges one stream" class because it exercises:
@@ -163,6 +164,7 @@ failback wedges one stream" class because it exercises:
 - longer-lived inherited flows
 - repeated ownership changes in both directions
 - per-stream survival, not just aggregate throughput
+- both traffic ownership directions, not only the host-sending path
 
 This matters because a split-RG fabric-path bug can kill streams before the
 first failover. That must fail as a fabric regression, not be misclassified as
@@ -201,8 +203,13 @@ Gbps. A run that peaks high and then drops near zero is a failure even if the sh
 overall average still looks superficially acceptable.
 
 For the dedicated failover workflow, the operator should watch all eight stream
-lines, not only the `[SUM]` line. A run is still a failure if aggregate traffic
-recovers but one stream remains pinned at `0.00 bits/sec` after failback.
+lines, not only the `[SUM]` line, for both:
+
+- forward `iperf3 -c ...`
+- reverse `iperf3 -c ... -R`
+
+A run is still a failure if aggregate traffic recovers but one stream remains
+pinned at `0.00 bits/sec` after failback, or if only one direction recovers.
 
 The validator also treats traceroute visibility as a standard correctness gate.
 It does not require every internet hop to answer. It does require:

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1415,7 +1415,10 @@ func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 		}
 	}
 	for rgID := range m.peerTransferOutOverride {
-		peerGroup := newPeerGroups[rgID]
+		peerGroup, ok := newPeerGroups[rgID]
+		if !ok {
+			continue
+		}
 		peerGroup.GroupID = rgID
 		peerGroup.State = StateSecondaryHold
 		newPeerGroups[rgID] = peerGroup
@@ -1425,7 +1428,10 @@ func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 			delete(m.peerTransferCommitGraceUntil, rgID)
 			continue
 		}
-		peerGroup := newPeerGroups[rgID]
+		peerGroup, ok := newPeerGroups[rgID]
+		if !ok {
+			continue
+		}
 		peerGroup.GroupID = rgID
 		peerGroup.State = StateSecondaryHold
 		newPeerGroups[rgID] = peerGroup
@@ -1477,7 +1483,7 @@ func (m *Manager) handlePeerTimeout() {
 	}
 	if suppress, reason := m.suppressPeerTimeoutForTransferCommitLocked(time.Now()); suppress {
 		m.mu.Unlock()
-		slog.Info("cluster: suppressing peer heartbeat timeout", "reason", reason)
+		slog.Debug("cluster: suppressing peer heartbeat timeout", "reason", reason)
 		return
 	}
 	guard := m.peerTimeoutGuardFn
@@ -1485,7 +1491,7 @@ func (m *Manager) handlePeerTimeout() {
 
 	if guard != nil {
 		if suppress, reason := guard(); suppress {
-			slog.Info("cluster: suppressing peer heartbeat timeout", "reason", reason)
+			slog.Debug("cluster: suppressing peer heartbeat timeout", "reason", reason)
 			return
 		}
 	}
@@ -1496,7 +1502,7 @@ func (m *Manager) handlePeerTimeout() {
 		return // already marked lost while guard ran
 	}
 	if suppress, reason := m.suppressPeerTimeoutForTransferCommitLocked(time.Now()); suppress {
-		slog.Info("cluster: suppressing peer heartbeat timeout", "reason", reason)
+		slog.Debug("cluster: suppressing peer heartbeat timeout", "reason", reason)
 		return
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -130,7 +130,15 @@ type Manager struct {
 	// transfer-out across heartbeat refreshes until the transfer is either
 	// committed or aborted locally.
 	peerTransferOutOverride map[int]uint64
-	peerMonitors            []InterfaceMonitorInfo
+	// peerTransferCommitGraceUntil keeps the peer in secondary-hold for a
+	// short window after a transfer commit so a transient stale heartbeat
+	// cannot immediately steal the RG back from the new primary.
+	peerTransferCommitGraceUntil map[int]time.Time
+	// localTransferOutHoldUntil keeps a just-demoted local RG parked in
+	// secondary during the same window so a transient heartbeat gap cannot
+	// immediately re-promote the old primary.
+	localTransferOutHoldUntil map[int]time.Time
+	peerMonitors              []InterfaceMonitorInfo
 
 	// Heartbeat goroutines (nil when not started).
 	hbSender   *heartbeatSender
@@ -218,6 +226,8 @@ type Manager struct {
 const DefaultTakeoverHoldTime = 0
 const DefaultPreManualFailoverRetryTimeout = 5 * time.Second
 const DefaultPreManualFailoverRetryInterval = 500 * time.Millisecond
+const minTransferCommitGracePeriod = 10 * time.Second
+const transferCommitHeartbeatSlack = 5 * time.Second
 
 // NewManager creates a new cluster manager.
 func NewManager(nodeID, clusterID int) *Manager {
@@ -230,6 +240,8 @@ func NewManager(nodeID, clusterID int) *Manager {
 		garpCounts:                     make(map[int]int),
 		peerGroups:                     make(map[int]PeerGroupState),
 		peerTransferOutOverride:        make(map[int]uint64),
+		peerTransferCommitGraceUntil:   make(map[int]time.Time),
+		localTransferOutHoldUntil:      make(map[int]time.Time),
 		hbInterval:                     DefaultHeartbeatInterval,
 		hbThreshold:                    DefaultHeartbeatThreshold,
 		history:                        NewEventHistory(64),
@@ -874,6 +886,30 @@ func (m *Manager) SetPeerTimeoutGuard(fn func() (bool, string)) {
 	m.peerTimeoutGuardFn = fn
 }
 
+func (m *Manager) transferCommitGracePeriodLocked() time.Duration {
+	grace := 2*time.Duration(m.hbThreshold)*m.hbInterval + transferCommitHeartbeatSlack
+	if grace < minTransferCommitGracePeriod {
+		grace = minTransferCommitGracePeriod
+	}
+	return grace
+}
+
+func (m *Manager) suppressPeerTimeoutForTransferCommitLocked(now time.Time) (bool, string) {
+	activeRGs := make([]int, 0, len(m.localTransferOutHoldUntil))
+	for rgID, until := range m.localTransferOutHoldUntil {
+		if now.Before(until) {
+			activeRGs = append(activeRGs, rgID)
+			continue
+		}
+		delete(m.localTransferOutHoldUntil, rgID)
+	}
+	if len(activeRGs) == 0 {
+		return false, ""
+	}
+	sort.Ints(activeRGs)
+	return true, fmt.Sprintf("recent transfer commit grace active rgs=%v", activeRGs)
+}
+
 // FenceStatus returns the configured fencing action and history of fence events.
 func (m *Manager) FenceStatus() (action string, events []HistoryEvent) {
 	m.mu.RLock()
@@ -993,6 +1029,8 @@ func (m *Manager) commitRequestedPeerFailover(rgID int, reqID uint64) error {
 	}
 
 	m.peerTransferOutOverride[rgID] = reqID
+	delete(m.peerTransferCommitGraceUntil, rgID)
+	delete(m.localTransferOutHoldUntil, rgID)
 	peerGroup := m.peerGroups[rgID]
 	peerGroup.GroupID = rgID
 	peerGroup.State = StateSecondaryHold
@@ -1021,6 +1059,7 @@ func (m *Manager) abortRequestedPeerFailover(rgID int, reqID uint64) {
 		return
 	}
 	delete(m.peerTransferOutOverride, rgID)
+	delete(m.peerTransferCommitGraceUntil, rgID)
 	m.runElection()
 }
 
@@ -1029,11 +1068,12 @@ func (m *Manager) notePeerTransferCommitted(rgID int) {
 	defer m.mu.Unlock()
 
 	delete(m.peerTransferOutOverride, rgID)
+	m.peerTransferCommitGraceUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 	peerGroup, ok := m.peerGroups[rgID]
 	if !ok {
 		return
 	}
-	peerGroup.State = StateSecondary
+	peerGroup.State = StateSecondaryHold
 	m.peerGroups[rgID] = peerGroup
 }
 
@@ -1058,6 +1098,7 @@ func (m *Manager) FinalizePeerTransferOut(rgID int) error {
 	rg.ManualFailover = false
 	rg.ManualFailoverAt = time.Time{}
 	rg.State = StateSecondary
+	m.localTransferOutHoldUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 	if oldState != rg.State {
 		m.sendEvent(rg.GroupID, oldState, rg.State, "Peer transfer committed")
 	}
@@ -1348,6 +1389,7 @@ func (m *Manager) buildHeartbeat() *HeartbeatPacket {
 func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	now := time.Now()
 
 	wasAlive := m.peerAlive
 	m.peerAlive = true
@@ -1371,6 +1413,21 @@ func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 		peerGroup.GroupID = rgID
 		peerGroup.State = StateSecondaryHold
 		newPeerGroups[rgID] = peerGroup
+	}
+	for rgID, until := range m.peerTransferCommitGraceUntil {
+		if !now.Before(until) {
+			delete(m.peerTransferCommitGraceUntil, rgID)
+			continue
+		}
+		peerGroup := newPeerGroups[rgID]
+		peerGroup.GroupID = rgID
+		peerGroup.State = StateSecondaryHold
+		newPeerGroups[rgID] = peerGroup
+	}
+	for rgID, until := range m.localTransferOutHoldUntil {
+		if !now.Before(until) {
+			delete(m.localTransferOutHoldUntil, rgID)
+		}
 	}
 	m.peerGroups = newPeerGroups
 
@@ -1412,6 +1469,11 @@ func (m *Manager) handlePeerTimeout() {
 		m.mu.Unlock()
 		return // already marked lost
 	}
+	if suppress, reason := m.suppressPeerTimeoutForTransferCommitLocked(time.Now()); suppress {
+		m.mu.Unlock()
+		slog.Info("cluster: suppressing peer heartbeat timeout", "reason", reason)
+		return
+	}
 	guard := m.peerTimeoutGuardFn
 	m.mu.Unlock()
 
@@ -1426,6 +1488,10 @@ func (m *Manager) handlePeerTimeout() {
 	defer m.mu.Unlock()
 	if !m.peerAlive {
 		return // already marked lost while guard ran
+	}
+	if suppress, reason := m.suppressPeerTimeoutForTransferCommitLocked(time.Now()); suppress {
+		slog.Info("cluster: suppressing peer heartbeat timeout", "reason", reason)
+		return
 	}
 
 	m.peerAlive = false

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1098,6 +1098,12 @@ func (m *Manager) FinalizePeerTransferOut(rgID int) error {
 	rg.ManualFailover = false
 	rg.ManualFailoverAt = time.Time{}
 	rg.State = StateSecondary
+	// A completed transfer-out invalidates any stale inbound-transfer view
+	// from the previous owner direction. If we keep forcing the peer into
+	// secondary-hold here, the next heartbeat can immediately re-elect the
+	// old owner during rapid failback/failover sequences.
+	delete(m.peerTransferOutOverride, rgID)
+	delete(m.peerTransferCommitGraceUntil, rgID)
 	m.localTransferOutHoldUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 	if oldState != rg.State {
 		m.sendEvent(rg.GroupID, oldState, rg.State, "Peer transfer committed")

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1062,6 +1062,28 @@ func TestNotePeerTransferCommittedPreservesPeerTransferOutDuringGrace(t *testing
 	}
 }
 
+func TestHandlePeerHeartbeatSkipsTransferOverridesForAbsentRG(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.mu.Lock()
+	m.peerTransferOutOverride[0] = 77
+	m.peerTransferCommitGraceUntil[0] = time.Now().Add(time.Second)
+	m.mu.Unlock()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups:    nil,
+	})
+
+	if got := len(m.PeerGroupStates()); got != 0 {
+		t.Fatalf("peer groups = %d, want 0 when heartbeat omits overridden RG", got)
+	}
+}
+
 func TestHandlePeerTimeoutSuppressedDuringRecentTransferCommitGrace(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -572,8 +572,8 @@ func TestRequestPeerFailoverCommitsLocalPrimaryWithoutHeartbeatObservation(t *te
 	if committedRG != 0 || committedReqID != 77 {
 		t.Fatalf("commit = rg %d req %d, want rg 0 req 77", committedRG, committedReqID)
 	}
-	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondary {
-		t.Fatalf("peer state = %s, want secondary after commit", peer.State)
+	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
+		t.Fatalf("peer state = %s, want secondary-hold during post-commit grace", peer.State)
 	}
 }
 
@@ -618,8 +618,8 @@ func TestRequestPeerFailoverAllowsTransferWithSyncWhenHeartbeatLost(t *testing.T
 	if committedRG != 0 || committedReqID != 91 {
 		t.Fatalf("commit = rg %d req %d, want rg 0 req 91", committedRG, committedReqID)
 	}
-	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondary {
-		t.Fatalf("peer state = %s, want secondary after commit", peer.State)
+	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
+		t.Fatalf("peer state = %s, want secondary-hold during post-commit grace", peer.State)
 	}
 }
 
@@ -674,8 +674,8 @@ func TestRequestPeerFailoverBatchCommitsLocalPrimaryTogether(t *testing.T) {
 		t.Fatalf("committed rgs = %v, want [1 2]", committedRGs)
 	}
 	for _, rgID := range []int{1, 2} {
-		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondary {
-			t.Fatalf("peer state for rg %d = %s, want secondary after commit", rgID, peer.State)
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondaryHold {
+			t.Fatalf("peer state for rg %d = %s, want secondary-hold during post-commit grace", rgID, peer.State)
 		}
 	}
 }
@@ -731,8 +731,8 @@ func TestRequestPeerFailoverBatchAllowsTransferWithSyncWhenHeartbeatLost(t *test
 		if !m.IsLocalPrimary(rgID) {
 			t.Fatalf("rg %d should be primary after explicit batch transfer commit", rgID)
 		}
-		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondary {
-			t.Fatalf("peer state for rg %d = %s, want secondary after commit", rgID, peer.State)
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StateSecondaryHold {
+			t.Fatalf("peer state for rg %d = %s, want secondary-hold during post-commit grace", rgID, peer.State)
 		}
 	}
 }
@@ -1009,6 +1009,101 @@ func TestPeerTransferOutOverrideSurvivesHeartbeatRefreshUntilCommit(t *testing.T
 	}
 	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
 		t.Fatalf("peer state = %s, want secondary-hold while transfer commit in flight", peer.State)
+	}
+}
+
+func TestNotePeerTransferCommittedPreservesPeerTransferOutDuringGrace(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	if err := m.commitRequestedPeerFailover(0, 77); err != nil {
+		t.Fatalf("commitRequestedPeerFailover() error = %v", err)
+	}
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("should be primary after local transfer commit")
+	}
+
+	m.notePeerTransferCommitted(0)
+	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
+		t.Fatalf("peer state = %s, want secondary-hold during post-commit grace", peer.State)
+	}
+
+	m.handlePeerHeartbeat(pkt)
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("stale peer-primary heartbeat should not clobber committed ownership during grace")
+	}
+	if peer := m.PeerGroupStates()[0]; peer.State != StateSecondaryHold {
+		t.Fatalf("peer state = %s, want secondary-hold during post-commit grace", peer.State)
+	}
+
+	m.mu.Lock()
+	m.peerTransferCommitGraceUntil[0] = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+
+	m.handlePeerHeartbeat(pkt)
+	if m.IsLocalPrimary(0) {
+		t.Fatal("should yield after post-commit grace expires and peer still advertises primary")
+	}
+}
+
+func TestHandlePeerTimeoutSuppressedDuringRecentTransferCommitGrace(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	m.peerNodeID = 1
+	m.peerGroups = map[int]PeerGroupState{
+		0: {GroupID: 0, Priority: 100, Weight: 255, State: StateSecondaryHold},
+	}
+	m.mu.Unlock()
+	if err := m.FinalizePeerTransferOut(0); err != nil {
+		t.Fatalf("FinalizePeerTransferOut() error = %v", err)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("should remain secondary immediately after peer transfer commit")
+	}
+
+	m.handlePeerTimeout()
+	if !m.PeerAlive() {
+		t.Fatal("peer should remain alive while recent transfer-commit grace is active")
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("old primary should stay secondary while transfer-commit grace is active")
+	}
+
+	m.mu.Lock()
+	m.localTransferOutHoldUntil[0] = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+
+	m.handlePeerTimeout()
+	if m.PeerAlive() {
+		t.Fatal("peer should be marked lost after transfer-commit grace expires")
+	}
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("old primary should reclaim ownership after grace expires and peer times out")
 	}
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1107,6 +1107,109 @@ func TestHandlePeerTimeoutSuppressedDuringRecentTransferCommitGrace(t *testing.T
 	}
 }
 
+func TestFinalizePeerTransferOutClearsStaleInboundTransferGrace(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	if err := m.commitRequestedPeerFailover(0, 77); err != nil {
+		t.Fatalf("commitRequestedPeerFailover() error = %v", err)
+	}
+	m.notePeerTransferCommitted(0)
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("should be primary after local transfer commit")
+	}
+
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	if err := m.FinalizePeerTransferOut(0); err != nil {
+		t.Fatalf("FinalizePeerTransferOut() error = %v", err)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("should be secondary after peer transfer commit")
+	}
+
+	m.handlePeerHeartbeat(pkt)
+	if m.IsLocalPrimary(0) {
+		t.Fatal("stale inbound transfer grace should not re-promote the old primary after direction change")
+	}
+	if peer := m.PeerGroupStates()[0]; peer.State != StatePrimary {
+		t.Fatalf("peer state = %s, want primary after direction change heartbeat", peer.State)
+	}
+}
+
+func TestFinalizePeerTransferOutBatchClearsStaleInboundTransferGrace(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(1, true, map[int]int{0: 100}),
+		makeRG(2, true, map[int]int{0: 100}),
+	)
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	<-m.Events()
+
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 1, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+			{GroupID: 2, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+	m.mu.Lock()
+	for _, rgID := range []int{1, 2} {
+		m.groups[rgID].Ready = true
+		m.groups[rgID].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+		m.groups[rgID].ReadinessReasons = nil
+	}
+	m.mu.Unlock()
+
+	if err := m.commitRequestedPeerFailoverBatch([]int{1, 2}, 88); err != nil {
+		t.Fatalf("commitRequestedPeerFailoverBatch() error = %v", err)
+	}
+	m.notePeerTransferCommittedBatch([]int{1, 2})
+	if !m.IsLocalPrimary(1) || !m.IsLocalPrimary(2) {
+		t.Fatal("both redundancy groups should be primary after local batch transfer commit")
+	}
+
+	if err := m.ManualFailoverBatch([]int{1, 2}); err != nil {
+		t.Fatalf("ManualFailoverBatch() error = %v", err)
+	}
+	if err := m.FinalizePeerTransferOutBatch([]int{1, 2}); err != nil {
+		t.Fatalf("FinalizePeerTransferOutBatch() error = %v", err)
+	}
+	if m.IsLocalPrimary(1) || m.IsLocalPrimary(2) {
+		t.Fatal("both redundancy groups should be secondary after peer batch transfer commit")
+	}
+
+	m.handlePeerHeartbeat(pkt)
+	if m.IsLocalPrimary(1) || m.IsLocalPrimary(2) {
+		t.Fatal("stale inbound batch transfer grace should not re-promote the old primary after direction change")
+	}
+	for _, rgID := range []int{1, 2} {
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StatePrimary {
+			t.Fatalf("peer state for rg %d = %s, want primary after direction change heartbeat", rgID, peer.State)
+		}
+	}
+}
+
 func TestFormatStatusShowsSeparateTransferReadiness(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -356,6 +356,12 @@ func (m *Manager) FinalizePeerTransferOutBatch(rgIDs []int) error {
 		rg.ManualFailover = false
 		rg.ManualFailoverAt = time.Time{}
 		rg.State = StateSecondary
+		// Clear stale inbound-transfer markers from the previous direction
+		// before we park this node as the old owner. Otherwise the next peer
+		// heartbeat can still force the peer into secondary-hold and snap the
+		// RG back during rapid alternating moves.
+		delete(m.peerTransferOutOverride, rgID)
+		delete(m.peerTransferCommitGraceUntil, rgID)
 		m.localTransferOutHoldUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 		if oldState != rg.State {
 			m.sendEvent(rg.GroupID, oldState, rg.State, "Peer transfer committed batch")

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -263,6 +263,8 @@ func (m *Manager) commitRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) er
 
 	for _, rgID := range rgIDs {
 		m.peerTransferOutOverride[rgID] = reqID
+		delete(m.peerTransferCommitGraceUntil, rgID)
+		delete(m.localTransferOutHoldUntil, rgID)
 		peerGroup := m.peerGroups[rgID]
 		peerGroup.GroupID = rgID
 		peerGroup.State = StateSecondaryHold
@@ -300,6 +302,7 @@ func (m *Manager) abortRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) {
 		if currentReqID, ok := m.peerTransferOutOverride[rgID]; ok && currentReqID == reqID {
 			delete(m.peerTransferOutOverride, rgID)
 		}
+		delete(m.peerTransferCommitGraceUntil, rgID)
 	}
 	m.runElection()
 }
@@ -310,11 +313,12 @@ func (m *Manager) notePeerTransferCommittedBatch(rgIDs []int) {
 
 	for _, rgID := range rgIDs {
 		delete(m.peerTransferOutOverride, rgID)
+		m.peerTransferCommitGraceUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 		peerGroup, ok := m.peerGroups[rgID]
 		if !ok {
 			continue
 		}
-		peerGroup.State = StateSecondary
+		peerGroup.State = StateSecondaryHold
 		m.peerGroups[rgID] = peerGroup
 	}
 }
@@ -352,6 +356,7 @@ func (m *Manager) FinalizePeerTransferOutBatch(rgIDs []int) error {
 		rg.ManualFailover = false
 		rg.ManualFailoverAt = time.Time{}
 		rg.State = StateSecondary
+		m.localTransferOutHoldUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 		if oldState != rg.State {
 			m.sendEvent(rg.GroupID, oldState, rg.State, "Peer transfer committed batch")
 		}

--- a/testing-docs/failover-testing.md
+++ b/testing-docs/failover-testing.md
@@ -215,6 +215,15 @@ TOTAL_CYCLES=3 CYCLE_INTERVAL=10 \
 scripts/userspace-ha-failover-validation.sh --duration 90 --parallel 4
 ```
 
+Reverse-path follow-up:
+
+```bash
+# The validator currently exercises the source-sending path. Run a matching
+# reverse iperf after the forward pass so failover is validated in both
+# ownership directions.
+iperf3 -c 172.16.80.200 -P 4 -t 90 -R
+```
+
 Useful knobs:
 
 - `SOURCE_NODE`
@@ -233,6 +242,7 @@ Pass:
 - RG ownership moves to the requested node
 - immediate target reachability returns quickly after each phase
 - no sustained zero-throughput collapse
+- both forward and reverse traffic recover after each move
 - retransmits stay bounded
 - old-owner fabric TX proves stale-owner redirect actually happened
 - standby WAN TX stays flat while redirect is expected
@@ -257,6 +267,12 @@ Start traffic from the host:
 iperf3 -c 172.16.80.200 -P 8 -t 120
 ```
 
+Then repeat the same test in reverse mode:
+
+```bash
+iperf3 -c 172.16.80.200 -P 8 -t 120 -R
+```
+
 Move the RG from the current primary:
 
 ```bash
@@ -271,8 +287,9 @@ cli -c "request chassis cluster failover redundancy-group 1 node 0"
 
 Pass:
 
-- throughput may dip, but recovers quickly and stays relatively flat
+- throughput may dip, but recovers quickly and stays relatively flat in both directions
 - new connections succeed immediately after the move
+- reverse `iperf3 -R` does not wedge at `0.00 bits/sec`
 - the moved RG remains on the requested node
 
 Required live checks during manual RG move:
@@ -322,13 +339,14 @@ Purpose:
 
 After the crashed node rejoins:
 
-1. start a fresh `iperf3 -P 8`
-2. move the RG again with CLI failover
-3. verify flows still recover and stay flat
+1. start a fresh forward `iperf3 -P 8`
+2. start a fresh reverse `iperf3 -P 8 -R`
+3. move the RG again with CLI failover
+4. verify flows still recover and stay flat in both directions
 
 Pass:
 
-- no new collapse introduced by the rejoined node
+- no new collapse introduced by the rejoined node in either direction
 - takeover readiness returns on both nodes
 
 ### 6. Split-RG active/active validation
@@ -512,13 +530,14 @@ Use this order when validating HA/failover for a serious userspace change.
 
 1. `scripts/userspace-ha-validation.sh`
 2. one-cycle `scripts/userspace-ha-failover-validation.sh`
-3. manual CLI RG move under `iperf3 -P 8`
-4. hard crash of the active primary with traffic running
-5. rebooted-node rejoin validation
-6. another manual RG move after rejoin
-7. split-RG placement validation
-8. split-RG crash in both directions
-9. multi-cycle failover stress
+3. manual CLI RG move under forward `iperf3 -P 8`
+4. manual CLI RG move under reverse `iperf3 -P 8 -R`
+5. hard crash of the active primary with traffic running
+6. rebooted-node rejoin validation
+7. another manual RG move after rejoin
+8. split-RG placement validation
+9. split-RG crash in both directions
+10. multi-cycle failover stress
 
 If any earlier phase fails, stop and fix that first. Later failover tests are
 not trustworthy on top of a broken baseline.


### PR DESCRIPTION
## Summary
- preserve committed manual failovers through transient post-commit heartbeat gaps
- keep the new primary from self-demoting while the matching session-sync barrier ack is still in flight
- clear stale inbound transfer grace when RG ownership direction flips repeatedly
- update the HA failover docs to require reverse-path `iperf3 -R` validation, not only host-sending tests

## What changed
- add a transfer-commit grace window that keeps the peer in `secondary-hold` briefly after commit and suppresses old-primary heartbeat reclaim during that window
- apply the same grace handling to batch failovers
- clear stale `peerTransferOutOverride` / `peerTransferCommitGraceUntil` markers when finalizing a peer transfer-out, so the old owner cannot re-elect itself on the next heartbeat during rapid alternating moves
- add regression tests for:
  - post-commit heartbeat-gap handling
  - single-RG direction flips
  - batch direction flips
- document forward and reverse failover test requirements in:
  - `docs/ha-failover-status.md`
  - `docs/userspace-ha-validation.md`
  - `testing-docs/failover-testing.md`

## Verification
- `go test ./pkg/cluster ./pkg/daemon -count=1`
- `go test ./pkg/cluster -run 'TestFinalizePeerTransferOut(ClearsStaleInboundTransferGrace|BatchClearsStaleInboundTransferGrace)' -count=1`

## Live validation
- before this follow-up fix, alternating RG1 transfers could snap ownership back to the old owner a few seconds after a committed direction change
- after this fix, the old-owner snapback is gone, but the first reverse `-P 12` failover now cleanly exposes the remaining mlx5 kernel panic on the old owner

Closes #611
Closes #612
Closes #615

Related to #613
Related to #472
