### PR TITLE
userspace-dp: refresh synced reverse sessions on RG demotion

### DIFF
--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -3284,6 +3284,77 @@ mod tests {
     }
 
     #[test]
+    fn apply_worker_commands_demote_split_reverse_owner_rg_rewrites_to_fabric_redirect() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![2] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::ForwardCandidate,
+                    local_ifindex: 0,
+                    egress_ifindex: 6,
+                    tx_ifindex: 6,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                    neighbor_mac: Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 2,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SyncImport,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([(2, inactive_ha_runtime(now_ns / 1_000_000_000))]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert_eq!(results.cancelled_keys, vec![reverse_key.clone()]);
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("demoted reverse session");
+        assert!(origin.is_peer_synced());
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 21);
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
     fn export_owner_rg_sessions_skips_locally_demoted_entries() {
         let commands = Arc::new(Mutex::new(VecDeque::from([
             WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![1] },

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -775,10 +775,9 @@ impl SessionTable {
             let Some(entry) = self.sessions.get_mut(&key) else {
                 continue;
             };
-            if entry.origin.is_peer_synced() {
-                continue;
+            if !entry.origin.is_peer_synced() {
+                entry.origin = SessionOrigin::SyncImport;
             }
-            entry.origin = SessionOrigin::SyncImport;
             demoted_keys.push(key);
         }
         demoted_keys
@@ -1591,6 +1590,30 @@ mod tests {
                 .metadata,
             metadata_other
         );
+    }
+
+    #[test]
+    fn demote_owner_rg_returns_synced_entries_for_transition_refresh() {
+        let mut table = SessionTable::new();
+        let now = 1_000_000_000u64;
+        let key = key_v4();
+        let mut metadata = metadata();
+        metadata.owner_rg_id = 2;
+        assert!(table.install_with_protocol_with_origin(
+            key.clone(),
+            decision(),
+            metadata.clone(),
+            SessionOrigin::SyncImport,
+            now,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let demoted = table.demote_owner_rg(2);
+        assert_eq!(demoted, vec![key.clone()]);
+
+        let (_, _, origin) = table.entry_with_origin(&key).expect("session exists");
+        assert_eq!(origin, SessionOrigin::SyncImport);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- revisit all sessions owned by a demoting RG so synced reverse companions also get HA transition refresh
- preserve the existing origin conversion behavior for locally-owned sessions while still returning synced keys for worker-side re-resolution
- add regressions for synced owner-RG demotion and split-RG reverse rewrite to fabric redirect

## Testing
- cargo test --manifest-path userspace-dp/Cargo.toml demote_owner_rg -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml apply_worker_commands_demote_split_reverse_owner_rg_rewrites_to_fabric_redirect -- --nocapture

Related: #613