### PR TITLE
HA: wait for local failover settle before peer demotion

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -295,6 +295,9 @@ func (m *Manager) restorePeerTransferOutOverrideLocked(rgID int, reqID uint64) b
 	snapshot, hadSnapshot := m.peerTransferOutPrevious[rgID]
 	delete(m.peerTransferOutPrevious, rgID)
 	if hadSnapshot && snapshot.present {
+		// A fresh heartbeat can race this restore and overwrite peerGroups
+		// with newer live state. If that happens we may briefly put the older
+		// snapshot back here, but the next heartbeat corrects it again.
 		m.peerGroups[rgID] = snapshot.state
 	} else {
 		delete(m.peerGroups, rgID)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -138,7 +138,8 @@ type Manager struct {
 	// secondary during the same window so a transient heartbeat gap cannot
 	// immediately re-promote the old primary.
 	localTransferOutHoldUntil map[int]time.Time
-	peerMonitors              []InterfaceMonitorInfo
+	peerTransferOutPrevious map[int]peerGroupSnapshot
+	peerMonitors            []InterfaceMonitorInfo
 
 	// Heartbeat goroutines (nil when not started).
 	hbSender   *heartbeatSender
@@ -187,6 +188,12 @@ type Manager struct {
 	// transferReadinessFn reports whether explicit manual failover can be
 	// attempted for the local RG right now and, if not, why.
 	transferReadinessFn func(rgID int) (bool, []string)
+	// localTransferCommitReadyFn runs on the requesting node after local
+	// ownership has been committed but before the final peer-demotion
+	// commit is sent. The daemon uses this to ensure the target node has
+	// actually applied its local failover side effects before the old
+	// owner is told to stand down.
+	localTransferCommitReadyFn func(rgIDs []int) error
 	// Retry policy for transient pre-failover prepare failures.
 	preManualFailoverRetryTimeout  time.Duration
 	preManualFailoverRetryInterval time.Duration
@@ -220,6 +227,11 @@ type Manager struct {
 	failoverInProgress map[int]bool
 }
 
+type peerGroupSnapshot struct {
+	state   PeerGroupState
+	present bool
+}
+
 // DefaultTakeoverHoldTime is the default additional delay after an RG becomes
 // ready before election promotes it to primary. Zero means promote as soon as
 // readiness is established.
@@ -242,6 +254,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		peerTransferOutOverride:        make(map[int]uint64),
 		peerTransferCommitGraceUntil:   make(map[int]time.Time),
 		localTransferOutHoldUntil:      make(map[int]time.Time),
+		peerTransferOutPrevious:        make(map[int]peerGroupSnapshot),
 		hbInterval:                     DefaultHeartbeatInterval,
 		hbThreshold:                    DefaultHeartbeatThreshold,
 		history:                        NewEventHistory(64),
@@ -250,6 +263,50 @@ func NewManager(nodeID, clusterID int) *Manager {
 		preManualFailoverRetryInterval: DefaultPreManualFailoverRetryInterval,
 		failoverInProgress:             make(map[int]bool),
 	}
+}
+
+func (m *Manager) applyPeerTransferOutOverrideLocked(rgID int, reqID uint64) {
+	previous, ok := m.peerGroups[rgID]
+	m.peerTransferOutOverride[rgID] = reqID
+	m.peerTransferOutPrevious[rgID] = peerGroupSnapshot{
+		state:   previous,
+		present: ok,
+	}
+	peerGroup := previous
+	peerGroup.GroupID = rgID
+	peerGroup.State = StateSecondaryHold
+	m.peerGroups[rgID] = peerGroup
+	if rg := m.groups[rgID]; rg != nil {
+		rg.PeerPriority = peerGroup.Priority
+	}
+}
+
+func (m *Manager) clearPeerTransferOutOverrideLocked(rgID int) {
+	delete(m.peerTransferOutOverride, rgID)
+	delete(m.peerTransferOutPrevious, rgID)
+}
+
+func (m *Manager) restorePeerTransferOutOverrideLocked(rgID int, reqID uint64) bool {
+	currentReqID, ok := m.peerTransferOutOverride[rgID]
+	if !ok || currentReqID != reqID {
+		return false
+	}
+	delete(m.peerTransferOutOverride, rgID)
+	snapshot, hadSnapshot := m.peerTransferOutPrevious[rgID]
+	delete(m.peerTransferOutPrevious, rgID)
+	if hadSnapshot && snapshot.present {
+		m.peerGroups[rgID] = snapshot.state
+	} else {
+		delete(m.peerGroups, rgID)
+	}
+	if rg := m.groups[rgID]; rg != nil {
+		if snapshot.present {
+			rg.PeerPriority = snapshot.state.Priority
+		} else {
+			rg.PeerPriority = 0
+		}
+	}
+	return true
 }
 
 // NodeID returns the local node ID.
@@ -838,6 +895,15 @@ func (m *Manager) SetTransferReadinessFunc(fn func(rgID int) (bool, []string)) {
 	m.transferReadinessFn = fn
 }
 
+// SetLocalTransferCommitReadyHook registers a callback that runs on the
+// requesting node after local ownership is committed and before the final
+// peer-demotion commit is sent.
+func (m *Manager) SetLocalTransferCommitReadyHook(fn func(rgIDs []int) error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.localTransferCommitReadyFn = fn
+}
+
 // SetPeerFailoverFunc sets the callback used to send remote failover requests
 // to the peer via the fabric sync connection.
 func (m *Manager) SetPeerFailoverFunc(fn func(rgID int) (uint64, error)) {
@@ -952,6 +1018,7 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	commitFn := m.peerFailoverCommitFn
 	transferReadyFn := m.transferReadinessFn
 	peerAlive := m.peerAlive
+	localCommitReadyFn := m.localTransferCommitReadyFn
 	m.mu.Unlock()
 
 	if fn == nil {
@@ -998,6 +1065,12 @@ func (m *Manager) RequestPeerFailover(rgID int) error {
 	if err := m.commitRequestedPeerFailover(rgID, reqID); err != nil {
 		return err
 	}
+	if localCommitReadyFn != nil {
+		if err := localCommitReadyFn([]int{rgID}); err != nil {
+			m.abortRequestedPeerFailover(rgID, reqID)
+			return err
+		}
+	}
 	if err := commitFn(rgID, reqID); err != nil {
 		m.abortRequestedPeerFailover(rgID, reqID)
 		return err
@@ -1028,14 +1101,10 @@ func (m *Manager) commitRequestedPeerFailover(rgID int, reqID uint64) error {
 		)
 	}
 
-	m.peerTransferOutOverride[rgID] = reqID
+	m.applyPeerTransferOutOverrideLocked(rgID, reqID)
 	delete(m.peerTransferCommitGraceUntil, rgID)
 	delete(m.localTransferOutHoldUntil, rgID)
 	peerGroup := m.peerGroups[rgID]
-	peerGroup.GroupID = rgID
-	peerGroup.State = StateSecondaryHold
-	m.peerGroups[rgID] = peerGroup
-	rg.PeerPriority = peerGroup.Priority
 
 	m.runElection()
 	if rg.State != StatePrimary {
@@ -1055,10 +1124,9 @@ func (m *Manager) abortRequestedPeerFailover(rgID int, reqID uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if currentReqID, ok := m.peerTransferOutOverride[rgID]; !ok || currentReqID != reqID {
+	if !m.restorePeerTransferOutOverrideLocked(rgID, reqID) {
 		return
 	}
-	delete(m.peerTransferOutOverride, rgID)
 	delete(m.peerTransferCommitGraceUntil, rgID)
 	m.runElection()
 }
@@ -1067,7 +1135,7 @@ func (m *Manager) notePeerTransferCommitted(rgID int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.peerTransferOutOverride, rgID)
+	m.clearPeerTransferOutOverrideLocked(rgID)
 	m.peerTransferCommitGraceUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 	peerGroup, ok := m.peerGroups[rgID]
 	if !ok {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -737,6 +737,151 @@ func TestRequestPeerFailoverBatchAllowsTransferWithSyncWhenHeartbeatLost(t *test
 	}
 }
 
+func TestRequestPeerFailoverWaitsForLocalCommitReadyHookBeforePeerCommit(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	var order []string
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		return 77, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		order = append(order, "ready")
+		if len(rgIDs) != 1 || rgIDs[0] != 0 {
+			t.Fatalf("local commit ready rgIDs = %v, want [0]", rgIDs)
+		}
+		if !m.IsLocalPrimary(0) {
+			t.Fatal("local node should already be primary before local commit ready hook runs")
+		}
+		return nil
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error {
+		order = append(order, "commit")
+		return nil
+	})
+
+	if err := m.RequestPeerFailover(0); err != nil {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if len(order) != 2 || order[0] != "ready" || order[1] != "commit" {
+		t.Fatalf("call order = %v, want [ready commit]", order)
+	}
+}
+
+func TestRequestPeerFailoverAbortsToPriorPeerStateWhenLocalCommitReadyHookFails(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	m.SetPeerFailoverFunc(func(rgID int) (uint64, error) {
+		return 77, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		return fmt.Errorf("local activation not settled")
+	})
+	m.SetPeerFailoverCommitFunc(func(rgID int, reqID uint64) error {
+		t.Fatal("peer failover commit should not run when local commit ready hook fails")
+		return nil
+	})
+
+	err := m.RequestPeerFailover(0)
+	if err == nil {
+		t.Fatal("expected local commit ready error")
+	}
+	if !strings.Contains(err.Error(), "local activation not settled") {
+		t.Fatalf("RequestPeerFailover() error = %v", err)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("local node should not remain primary after abort")
+	}
+	if peer := m.PeerGroupStates()[0]; peer.State != StatePrimary {
+		t.Fatalf("peer state = %s, want primary after abort", peer.State)
+	}
+}
+
+func TestRequestPeerFailoverBatchAbortsWhenLocalCommitReadyHookFails(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(1, true, map[int]int{0: 100}),
+		makeRG(2, true, map[int]int{0: 100}),
+	)
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 1, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+			{GroupID: 2, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.mu.Lock()
+	for _, rgID := range []int{1, 2} {
+		m.groups[rgID].Ready = true
+		m.groups[rgID].ReadySince = time.Now().Add(-m.takeoverHoldTime - time.Second)
+		m.groups[rgID].ReadinessReasons = nil
+	}
+	m.mu.Unlock()
+
+	m.SetPeerFailoverBatchFunc(func(rgIDs []int) (uint64, error) {
+		return 88, nil
+	})
+	m.SetLocalTransferCommitReadyHook(func(rgIDs []int) error {
+		return fmt.Errorf("local activation not settled")
+	})
+	m.SetPeerFailoverCommitBatchFunc(func(rgIDs []int, reqID uint64) error {
+		t.Fatal("peer failover batch commit should not run when local commit ready hook fails")
+		return nil
+	})
+
+	err := m.RequestPeerFailoverBatch([]int{1, 2})
+	if err == nil {
+		t.Fatal("expected local commit ready error")
+	}
+	if !strings.Contains(err.Error(), "local activation not settled") {
+		t.Fatalf("RequestPeerFailoverBatch() error = %v", err)
+	}
+	for _, rgID := range []int{1, 2} {
+		if m.IsLocalPrimary(rgID) {
+			t.Fatalf("local node should not remain primary for rg %d after abort", rgID)
+		}
+		if peer := m.PeerGroupStates()[rgID]; peer.State != StatePrimary {
+			t.Fatalf("peer state for rg %d = %s, want primary after local commit ready abort", rgID, peer.State)
+		}
+	}
+}
+
 func TestRequestPeerFailoverRequiresLocalReadiness(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100}))

--- a/pkg/cluster/failover_batch.go
+++ b/pkg/cluster/failover_batch.go
@@ -182,6 +182,7 @@ func (m *Manager) RequestPeerFailoverBatch(rgIDs []int) error {
 	commitFn := m.peerFailoverCommitBatchFn
 	transferReadyFn := m.transferReadinessFn
 	peerAlive := m.peerAlive
+	localCommitReadyFn := m.localTransferCommitReadyFn
 	m.mu.Unlock()
 
 	if fn == nil {
@@ -229,6 +230,12 @@ func (m *Manager) RequestPeerFailoverBatch(rgIDs []int) error {
 		m.abortRequestedPeerFailoverBatch(ids, reqID)
 		return err
 	}
+	if localCommitReadyFn != nil {
+		if err := localCommitReadyFn(ids); err != nil {
+			m.abortRequestedPeerFailoverBatch(ids, reqID)
+			return err
+		}
+	}
 	if err := commitFn(ids, reqID); err != nil {
 		m.abortRequestedPeerFailoverBatch(ids, reqID)
 		return err
@@ -262,16 +269,9 @@ func (m *Manager) commitRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) er
 	}
 
 	for _, rgID := range rgIDs {
-		m.peerTransferOutOverride[rgID] = reqID
+		m.applyPeerTransferOutOverrideLocked(rgID, reqID)
 		delete(m.peerTransferCommitGraceUntil, rgID)
 		delete(m.localTransferOutHoldUntil, rgID)
-		peerGroup := m.peerGroups[rgID]
-		peerGroup.GroupID = rgID
-		peerGroup.State = StateSecondaryHold
-		m.peerGroups[rgID] = peerGroup
-		if rg := m.groups[rgID]; rg != nil {
-			rg.PeerPriority = peerGroup.Priority
-		}
 	}
 
 	m.runElection()
@@ -299,10 +299,8 @@ func (m *Manager) abortRequestedPeerFailoverBatch(rgIDs []int, reqID uint64) {
 	defer m.mu.Unlock()
 
 	for _, rgID := range rgIDs {
-		if currentReqID, ok := m.peerTransferOutOverride[rgID]; ok && currentReqID == reqID {
-			delete(m.peerTransferOutOverride, rgID)
-		}
 		delete(m.peerTransferCommitGraceUntil, rgID)
+		m.restorePeerTransferOutOverrideLocked(rgID, reqID)
 	}
 	m.runElection()
 }
@@ -312,7 +310,7 @@ func (m *Manager) notePeerTransferCommittedBatch(rgIDs []int) {
 	defer m.mu.Unlock()
 
 	for _, rgID := range rgIDs {
-		delete(m.peerTransferOutOverride, rgID)
+		m.clearPeerTransferOutOverrideLocked(rgID)
 		m.peerTransferCommitGraceUntil[rgID] = time.Now().Add(m.transferCommitGracePeriodLocked())
 		peerGroup, ok := m.peerGroups[rgID]
 		if !ok {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -313,7 +313,7 @@ func New(opts Options) *Daemon {
 		directAnnounceSchedule:     []time.Duration{0, 250 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 6 * time.Second},
 		directVIPOwned:             make(map[int]bool),
 		localFailoverCommitReady:   make(map[int]bool),
-		localFailoverCommitTimeout: time.Second,
+		localFailoverCommitTimeout: 3 * time.Second,
 		localFailoverCommitDelay:   200 * time.Millisecond,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -218,6 +218,9 @@ type Daemon struct {
 	localFailoverCommitMu      sync.Mutex
 	localFailoverCommitReady   map[int]bool
 	localFailoverCommitTimeout time.Duration
+	// localFailoverCommitDelay adds one short post-ready dwell after the
+	// readiness bit flips so the VRRP/direct-ownership side effects that set
+	// the bit have a chance to propagate before the peer finalizes demotion.
 	localFailoverCommitDelay   time.Duration
 	// Test hooks for direct-mode VIP ownership reconciliation.
 	directAddVIPsFn        func(int) int

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -210,6 +210,15 @@ type Daemon struct {
 	// VIP presence/removal idempotently every pass.
 	directVIPMu    sync.Mutex
 	directVIPOwned map[int]bool
+	// localFailoverCommitReady tracks whether this node has already
+	// applied the local side of a freshly committed transfer request for
+	// each RG. The cluster manager waits on this before telling the peer
+	// to finalize demotion, so the old owner does not stand down before
+	// the target daemon has processed the promotion edge.
+	localFailoverCommitMu      sync.Mutex
+	localFailoverCommitReady   map[int]bool
+	localFailoverCommitTimeout time.Duration
+	localFailoverCommitDelay   time.Duration
 	// Test hooks for direct-mode VIP ownership reconciliation.
 	directAddVIPsFn        func(int) int
 	directRemoveVIPsFn     func(int) int
@@ -303,6 +312,9 @@ func New(opts Options) *Daemon {
 		linkByNameFn:               netlink.LinkByName,
 		directAnnounceSchedule:     []time.Duration{0, 250 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 6 * time.Second},
 		directVIPOwned:             make(map[int]bool),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: time.Second,
+		localFailoverCommitDelay:   200 * time.Millisecond,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 	}
 }

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -19,7 +19,6 @@ import (
 	"github.com/psaab/bpfrx/pkg/vrrp"
 )
 
-
 // getOrCreateRGState returns the rgStateMachine for the given RG, creating
 // one if it doesn't exist yet.
 func (d *Daemon) getOrCreateRGState(rgID int) *rgStateMachine {
@@ -67,6 +66,61 @@ func strictVIPOwnershipByDefault(cc *config.ClusterConfig, cfg *config.Config) b
 	// for the VRRP MASTER event to derive rg_active leaves a cutover window
 	// where reply packets can hit the promoted node before userspace is active.
 	return cfg == nil || cfg.System.DataplaneType != dataplane.TypeUserspace
+}
+
+func (d *Daemon) setLocalFailoverCommitReady(rgID int, ready bool) {
+	d.localFailoverCommitMu.Lock()
+	defer d.localFailoverCommitMu.Unlock()
+	if d.localFailoverCommitReady == nil {
+		d.localFailoverCommitReady = make(map[int]bool)
+	}
+	d.localFailoverCommitReady[rgID] = ready
+}
+
+func (d *Daemon) localFailoverCommitIsReady(rgID int) bool {
+	d.localFailoverCommitMu.Lock()
+	defer d.localFailoverCommitMu.Unlock()
+	if d.localFailoverCommitReady == nil {
+		return false
+	}
+	return d.localFailoverCommitReady[rgID]
+}
+
+func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
+	if len(rgIDs) == 0 {
+		return nil
+	}
+	timeout := d.localFailoverCommitTimeout
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	delay := d.localFailoverCommitDelay
+	deadline := time.Now().Add(timeout)
+	dwelled := false
+	for {
+		ready := true
+		for _, rgID := range rgIDs {
+			if d.cluster != nil && !d.cluster.IsLocalPrimary(rgID) {
+				return fmt.Errorf("local redundancy group %d lost primary before peer demotion commit", rgID)
+			}
+			if !d.localFailoverCommitIsReady(rgID) {
+				ready = false
+				break
+			}
+		}
+		if ready {
+			if !dwelled && delay > 0 {
+				dwelled = true
+				time.Sleep(delay)
+				continue
+			}
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for local failover activation settle for redundancy groups %v", rgIDs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // isRethMasterState returns true when ALL VRRP instances for rgID are MASTER.
@@ -135,6 +189,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 			//   add blackholes, then clear rg_active (#485)
 			isPrimary := ev.NewState == cluster.StatePrimary
 			clusterDemotionEdge := ev.OldState == cluster.StatePrimary && !isPrimary
+			d.setLocalFailoverCommitReady(ev.GroupID, false)
 			s := d.getOrCreateRGState(ev.GroupID)
 			tr := s.SetCluster(isPrimary)
 			if isPrimary {
@@ -181,6 +236,9 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				if noRethVRRP {
 					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-primary")
 					go d.RefreshFabricFwd()
+				}
+				if noRethVRRP && (d.dp == nil || !s.NeedsApply()) {
+					d.setLocalFailoverCommitReady(ev.GroupID, true)
 				}
 			} else {
 				// Demotion: run preflight and resign VRRP BEFORE
@@ -344,10 +402,16 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 					d.addStableRethLinkLocal(rgID)
 					d.applyRethServicesForRG(rgID)
 				}
+				if d.cluster != nil && d.cluster.IsLocalPrimary(rgID) && s.AllVRRPMaster() {
+					d.setLocalFailoverCommitReady(rgID, true)
+				}
 			}
 			if ev.State == vrrp.StateBackup {
 				s := d.getOrCreateRGState(rgID)
 				tr := s.SetVRRP(ev.Interface, false)
+				if !s.AllVRRPMaster() {
+					d.setLocalFailoverCommitReady(rgID, false)
+				}
 				if tr.Changed && !tr.Active {
 					// Deactivation order: inject blackhole routes FIRST,
 					// then clear rg_active. Re-read desired state to
@@ -1143,4 +1207,3 @@ func resolveDHCPRethInterfaces(dhcpCfg *config.DHCPServerConfig, cfg *config.Con
 		resolve(dhcpCfg.DHCPv6LocalServer.Groups)
 	}
 }
-

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -657,6 +657,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFailoverBatchFunc(d.sessionSync.SendFailoverBatch)
 			d.cluster.SetPeerFailoverCommitBatchFunc(d.sessionSync.SendFailoverCommitBatch)
 			d.cluster.SetPreManualFailoverHook(d.prepareUserspaceManualFailover)
+			d.cluster.SetLocalTransferCommitReadyHook(d.waitLocalFailoverCommitReady)
 			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)
 

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -822,6 +822,12 @@ func userspaceManualFailoverTransferReadinessError(state cluster.TransferReadine
 	return nil
 }
 
+type userspaceTransferReadinessProvider interface {
+	IsConnected() bool
+	PeerHealthy() bool
+	TransferReadiness() cluster.TransferReadinessSnapshot
+}
+
 type userspaceSoftwareVersionMismatchProvider interface {
 	SoftwareVersionMismatch() (bool, string, string)
 }
@@ -836,16 +842,11 @@ func userspaceSoftwareVersionMismatchReason(provider userspaceSoftwareVersionMis
 	return nil
 }
 
-func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
-	if d.cluster != nil {
-		if reasons := userspaceSoftwareVersionMismatchReason(d.cluster); len(reasons) > 0 {
-			return false, reasons
-		}
-	}
-	if d.sessionSync == nil || !d.sessionSync.IsConnected() || !d.sessionSync.PeerHealthy() || !d.syncPeerConnected.Load() {
+func computeUserspaceTransferReadiness(sync userspaceTransferReadinessProvider, syncPeerConnected bool) (bool, []string) {
+	if !sync.IsConnected() || !sync.PeerHealthy() || !syncPeerConnected {
 		return false, []string{"session sync disconnected"}
 	}
-	state := d.sessionSync.TransferReadiness()
+	state := sync.TransferReadiness()
 	if state.ReadyForManualFailover() {
 		return true, nil
 	}
@@ -853,6 +854,18 @@ func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
 		return false, []string{reason}
 	}
 	return true, nil
+}
+
+func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
+	if d.cluster != nil {
+		if reasons := userspaceSoftwareVersionMismatchReason(d.cluster); len(reasons) > 0 {
+			return false, reasons
+		}
+	}
+	if d.sessionSync == nil {
+		return false, []string{"session sync disconnected"}
+	}
+	return computeUserspaceTransferReadiness(d.sessionSync, d.syncPeerConnected.Load())
 }
 
 func (d *Daemon) prepareUserspaceManualFailover(rgID int) error {

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -17,7 +17,6 @@ import (
 	"github.com/psaab/bpfrx/pkg/vrrp"
 )
 
-
 // checkVIPReadiness verifies that RETH interfaces for the given RG exist and
 // are operationally UP, so that VIPs can actually be added. Used in
 // private-rg-election mode where there are no VRRP instances to gate readiness.
@@ -439,8 +438,20 @@ func (d *Daemon) scheduleDirectAnnounce(rgID int, reason string) {
 		sendFn = d.directSendGARPs
 	}
 	slog.Info("direct-mode re-announce scheduled", "rg", rgID, "reason", reason, "bursts", len(schedule))
+	start := time.Now()
+	burstOffset := 0
+	if len(schedule) > 0 && schedule[0] == 0 {
+		if d.directAnnounceActive(rgID, seq) {
+			sendFn(rgID)
+			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", 1, "total", len(schedule))
+		}
+		schedule = schedule[1:]
+		burstOffset = 1
+	}
+	if len(schedule) == 0 {
+		return
+	}
 	go func() {
-		start := time.Now()
 		for idx, at := range schedule {
 			if wait := time.Until(start.Add(at)); wait > 0 {
 				timer := time.NewTimer(wait)
@@ -450,7 +461,7 @@ func (d *Daemon) scheduleDirectAnnounce(rgID int, reason string) {
 				return
 			}
 			sendFn(rgID)
-			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", idx+1, "total", len(schedule))
+			slog.Info("direct-mode re-announce sent", "rg", rgID, "reason", reason, "burst", idx+1+burstOffset, "total", len(schedule)+burstOffset)
 		}
 	}()
 }

--- a/pkg/daemon/direct_announce_test.go
+++ b/pkg/daemon/direct_announce_test.go
@@ -35,6 +35,31 @@ func TestScheduleDirectAnnounceRepeatsWhileRGActive(t *testing.T) {
 	}
 }
 
+func TestScheduleDirectAnnounceSendsImmediateBurstInline(t *testing.T) {
+	state := newRGStateMachine()
+	state.SetCluster(true)
+	d := &Daemon{
+		rgStates:               map[int]*rgStateMachine{1: state},
+		directAnnounceSchedule: []time.Duration{0, 25 * time.Millisecond},
+	}
+
+	calls := make(chan int, 4)
+	d.directSendGARPsFn = func(rgID int) {
+		calls <- rgID
+	}
+
+	d.scheduleDirectAnnounce(1, "test")
+
+	select {
+	case rgID := <-calls:
+		if rgID != 1 {
+			t.Fatalf("unexpected rg id: %d", rgID)
+		}
+	default:
+		t.Fatal("expected immediate announce burst before scheduleDirectAnnounce returns")
+	}
+}
+
 func TestCancelDirectAnnounceStopsFutureBursts(t *testing.T) {
 	state := newRGStateMachine()
 	state.SetCluster(true)

--- a/pkg/daemon/failover_commit_ready_test.go
+++ b/pkg/daemon/failover_commit_ready_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitLocalFailoverCommitReadyWaitsForPromotionSettle(t *testing.T) {
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 200 * time.Millisecond,
+		localFailoverCommitDelay:   0,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.waitLocalFailoverCommitReady([]int{0})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	d.setLocalFailoverCommitReady(0, true)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("waitLocalFailoverCommitReady() error = %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for failover commit settle")
+	}
+}
+
+func TestWaitLocalFailoverCommitReadyTimesOutWithoutPromotionSettle(t *testing.T) {
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 30 * time.Millisecond,
+		localFailoverCommitDelay:   0,
+	}
+
+	err := d.waitLocalFailoverCommitReady([]int{0})
+	if err == nil {
+		t.Fatal("expected timeout waiting for failover commit settle")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for local failover activation settle") {
+		t.Fatalf("waitLocalFailoverCommitReady() error = %v", err)
+	}
+}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -174,6 +174,56 @@ func TestUserspaceTransferReadinessDisconnected(t *testing.T) {
 	}
 }
 
+type fakeUserspaceTransferReadinessProvider struct {
+	connected bool
+	healthy   bool
+	state     cluster.TransferReadinessSnapshot
+}
+
+func (f fakeUserspaceTransferReadinessProvider) IsConnected() bool {
+	return f.connected
+}
+
+func (f fakeUserspaceTransferReadinessProvider) PeerHealthy() bool {
+	return f.healthy
+}
+
+func (f fakeUserspaceTransferReadinessProvider) TransferReadiness() cluster.TransferReadinessSnapshot {
+	return f.state
+}
+
+func TestComputeUserspaceTransferReadinessRequiresHealthyPeer(t *testing.T) {
+	ready, reasons := computeUserspaceTransferReadiness(fakeUserspaceTransferReadinessProvider{
+		connected: true,
+		healthy:   false,
+		state: cluster.TransferReadinessSnapshot{
+			Connected: true,
+		},
+	}, true)
+	if ready {
+		t.Fatal("expected unhealthy peer transfer readiness to be false")
+	}
+	if len(reasons) != 1 || reasons[0] != "session sync disconnected" {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+}
+
+func TestComputeUserspaceTransferReadinessReady(t *testing.T) {
+	ready, reasons := computeUserspaceTransferReadiness(fakeUserspaceTransferReadinessProvider{
+		connected: true,
+		healthy:   true,
+		state: cluster.TransferReadinessSnapshot{
+			Connected: true,
+		},
+	}, true)
+	if !ready {
+		t.Fatalf("expected ready transfer readiness, got reasons=%v", reasons)
+	}
+	if reasons != nil {
+		t.Fatalf("expected nil reasons, got %v", reasons)
+	}
+}
+
 type fakeUserspaceSoftwareVersionMismatchProvider struct {
 	mismatch bool
 	local    string

--- a/userspace-dp/src/afxdp/forwarding.rs
+++ b/userspace-dp/src/afxdp/forwarding.rs
@@ -437,8 +437,13 @@ pub(super) fn enforce_ha_resolution_snapshot(
 ) -> ForwardingResolution {
     if !matches!(
         resolution.disposition,
-        ForwardingDisposition::ForwardCandidate | ForwardingDisposition::MissingNeighbor
+        ForwardingDisposition::ForwardCandidate
+            | ForwardingDisposition::MissingNeighbor
+            | ForwardingDisposition::LocalDelivery
     ) {
+        return resolution;
+    }
+    if resolution.disposition == ForwardingDisposition::LocalDelivery && ha_state.is_empty() {
         return resolution;
     }
     let owner_rg_id = owner_rg_for_resolution(forwarding, resolution);
@@ -448,7 +453,10 @@ pub(super) fn enforce_ha_resolution_snapshot(
         // Treat as invalid (force re-resolution through the slow path) rather
         // than "always active" which would let stale cached entries bypass
         // HA checks after RG failover.
-        if !ha_state.is_empty() && resolution.egress_ifindex > 0 {
+        if resolution.disposition != ForwardingDisposition::LocalDelivery
+            && !ha_state.is_empty()
+            && resolution.egress_ifindex > 0
+        {
             return ForwardingResolution {
                 disposition: ForwardingDisposition::HAInactive,
                 ..resolution
@@ -1843,6 +1851,38 @@ mod tests {
     }
 
     #[test]
+    fn cached_local_delivery_decision_invalidates_when_owner_rg_is_demoted() {
+        let state = build_forwarding_state(&nat_snapshot());
+        let active = BTreeMap::from([(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let demoted = BTreeMap::from([(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let resolution = interface_nat_local_resolution(&state, "172.16.80.8".parse().expect("v4"))
+            .expect("interface nat local delivery");
+        let now_secs = monotonic_nanos() / 1_000_000_000;
+
+        assert!(cached_flow_decision_valid(
+            &state,
+            &active,
+            &dynamic_neighbors,
+            now_secs,
+            1,
+            false,
+            IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            resolution
+        ));
+        assert!(!cached_flow_decision_valid(
+            &state,
+            &demoted,
+            &dynamic_neighbors,
+            now_secs,
+            1,
+            false,
+            IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            resolution
+        ));
+    }
+
+    #[test]
     fn inactive_owner_rg_redirects_established_session_to_fabric() {
         let state = build_forwarding_state(&nat_snapshot_with_fabric());
         let ha_state = Arc::new(ArcSwap::from_pointee(BTreeMap::from([(
@@ -2503,6 +2543,29 @@ mod tests {
     }
 
     #[test]
+    fn reverse_session_blocks_inactive_interface_snat_ipv4_local_delivery() {
+        let state = build_forwarding_state(&nat_snapshot());
+        let ha_state =
+            BTreeMap::from([(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+
+        let resolved = reverse_resolution_for_session(
+            &state,
+            &ha_state,
+            &dynamic_neighbors,
+            IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            "wan",
+            false,
+            monotonic_nanos() / 1_000_000_000,
+            false,
+        );
+
+        assert_eq!(resolved.disposition, ForwardingDisposition::HAInactive);
+        assert_eq!(resolved.local_ifindex, 12);
+        assert_eq!(resolved.egress_ifindex, 12);
+    }
+
+    #[test]
     fn reverse_session_prefers_interface_snat_ipv6_local_delivery() {
         let state = build_forwarding_state(&nat_snapshot());
         let ha_state = BTreeMap::new();
@@ -2552,6 +2615,45 @@ mod tests {
 
         assert_eq!(resolved.disposition, ForwardingDisposition::LocalDelivery);
         assert_eq!(resolved.local_ifindex, 12);
+    }
+
+    #[test]
+    fn inactive_interface_snat_session_hit_redirects_to_fabric() {
+        let state = build_forwarding_state(&nat_snapshot_with_fabric());
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let ha_state = Arc::new(ArcSwap::from_pointee(BTreeMap::from([(
+            1,
+            inactive_ha_runtime(monotonic_nanos() / 1_000_000_000),
+        )])));
+        let flow = SessionFlow {
+            src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+                src_port: 5201,
+                dst_port: 43600,
+            },
+        };
+        let decision = SessionDecision {
+            resolution: interface_nat_local_resolution(&state, flow.dst_ip)
+                .expect("interface nat local delivery"),
+            nat: NatDecision::default(),
+        };
+
+        let looked_up =
+            lookup_forwarding_resolution_for_session(&state, &dynamic_neighbors, &flow, decision);
+        let blocked = enforce_ha_resolution(&state, &ha_state, looked_up);
+        let redirected = redirect_via_fabric_if_needed(&state, blocked, 12);
+
+        assert_eq!(
+            redirected.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(redirected.egress_ifindex, 21);
+        assert_eq!(redirected.tx_ifindex, 21);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -99,6 +99,13 @@ impl super::Coordinator {
             .values()
             .map(|handle| handle.commands.clone())
             .collect::<Vec<_>>();
+        for commands in &worker_commands {
+            if let Ok(mut pending) = commands.lock() {
+                pending.push_back(WorkerCommand::RefreshOwnerRGS {
+                    owner_rgs: activated_rgs.to_vec(),
+                });
+            }
+        }
         let current = self.ha_state.load();
         let session_map_fd = self.session_map_fd.as_ref().map(|fd| fd.fd).unwrap_or(-1);
 
@@ -732,6 +739,16 @@ mod tests {
             .expect("reverse entry");
         assert!(reverse.metadata.is_reverse);
         assert_eq!(reverse.metadata.owner_rg_id, 2);
-        assert_eq!(worker_commands.lock().expect("commands").len(), 2);
+        let commands = worker_commands.lock().expect("commands");
+        assert_eq!(commands.len(), 3);
+        assert!(matches!(
+            commands.front(),
+            Some(WorkerCommand::RefreshOwnerRGS { owner_rgs }) if owner_rgs == &vec![1]
+        ));
+        assert!(commands.iter().any(|command| matches!(
+            command,
+            WorkerCommand::UpsertSynced(session)
+                if session.metadata.is_reverse && session.metadata.owner_rg_id == 2
+        )));
     }
 }

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -100,11 +100,19 @@ impl super::Coordinator {
             .map(|handle| handle.commands.clone())
             .collect::<Vec<_>>();
         for commands in &worker_commands {
-            if let Ok(mut pending) = commands.lock() {
-                pending.push_back(WorkerCommand::RefreshOwnerRGS {
-                    owner_rgs: activated_rgs.to_vec(),
-                });
-            }
+            let mut pending = match commands.lock() {
+                Ok(pending) => pending,
+                Err(poisoned) => {
+                    eprintln!(
+                        "bpfrx-ha: worker command queue lock poisoned while refreshing activated RGs {:?}; recovering inner queue",
+                        activated_rgs
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            pending.push_back(WorkerCommand::RefreshOwnerRGS {
+                owner_rgs: activated_rgs.to_vec(),
+            });
         }
         let current = self.ha_state.load();
         let session_map_fd = self.session_map_fd.as_ref().map(|fd| fd.fd).unwrap_or(-1);

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -403,9 +403,22 @@ pub(super) fn apply_worker_commands(
                 }
             }
             WorkerCommand::RefreshOwnerRGS { owner_rgs } => {
-                if owner_rgs.is_empty() {
+                let activated_owner_rgs: std::collections::BTreeSet<_> = owner_rgs
+                    .into_iter()
+                    .filter(|owner_rg_id| *owner_rg_id > 0)
+                    .collect();
+                if activated_owner_rgs.is_empty() {
                     continue;
                 }
+                let locally_relevant_owner_rgs: std::collections::BTreeSet<_> = ha_state
+                    .iter()
+                    .filter_map(|(owner_rg_id, runtime)| {
+                        runtime
+                            .is_forwarding_active(now_secs)
+                            .then_some(*owner_rg_id)
+                    })
+                    .chain(activated_owner_rgs.iter().copied())
+                    .collect();
 
                 // Activation must re-evaluate all HA-managed worker sessions,
                 // not just those currently indexed under the activated RG.
@@ -413,7 +426,9 @@ pub(super) fn apply_worker_commands(
                 // move of RG1 changes whether they should locally forward or
                 // fabric-redirect. Activation is infrequent, so do the wider
                 // worker scan here instead of trusting potentially stale RG
-                // ownership buckets.
+                // ownership buckets. Still skip sessions whose current and
+                // recomputed owners are both purely remote, since a local RG
+                // move cannot affect them.
                 let mut refresh = Vec::new();
                 sessions.iter_with_origin(|key, decision, metadata, origin| {
                     if metadata.owner_rg_id <= 0 && !metadata.fabric_ingress {
@@ -461,6 +476,12 @@ pub(super) fn apply_worker_commands(
                         owner_rg_for_resolution(forwarding, refreshed_decision.resolution);
                     if refreshed_owner_rg > 0 {
                         refreshed_metadata.owner_rg_id = refreshed_owner_rg;
+                    }
+                    if !metadata.fabric_ingress
+                        && !locally_relevant_owner_rgs.contains(&metadata.owner_rg_id)
+                        && !locally_relevant_owner_rgs.contains(&refreshed_metadata.owner_rg_id)
+                    {
+                        return;
                     }
                     refresh.push((key.clone(), refreshed_decision, refreshed_metadata, origin));
                 });

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -402,6 +402,87 @@ pub(super) fn apply_worker_commands(
                     }
                 }
             }
+            WorkerCommand::RefreshOwnerRGS { owner_rgs } => {
+                if owner_rgs.is_empty() {
+                    continue;
+                }
+
+                // Activation must re-evaluate all HA-managed worker sessions,
+                // not just those currently indexed under the activated RG.
+                // Split-RG reverse companions can remain owned by RG2 while a
+                // move of RG1 changes whether they should locally forward or
+                // fabric-redirect. Activation is infrequent, so do the wider
+                // worker scan here instead of trusting potentially stale RG
+                // ownership buckets.
+                let mut refresh = Vec::new();
+                sessions.iter_with_origin(|key, decision, metadata, origin| {
+                    if metadata.owner_rg_id <= 0 && !metadata.fabric_ingress {
+                        return;
+                    }
+                    let flow = SessionFlow {
+                        src_ip: key.src_ip,
+                        dst_ip: key.dst_ip,
+                        forward_key: key.clone(),
+                    };
+                    let resolution_target = resolution_target_for_session(&flow, decision);
+                    let looked_up_resolution = lookup_forwarding_resolution_for_session(
+                        forwarding,
+                        dynamic_neighbors,
+                        &flow,
+                        decision,
+                    );
+                    let looked_up_resolution =
+                        super::prefer_local_forward_candidate_for_fabric_ingress(
+                            forwarding,
+                            ha_state,
+                            dynamic_neighbors,
+                            now_secs,
+                            metadata.fabric_ingress,
+                            resolution_target,
+                            looked_up_resolution,
+                        );
+                    let enforced_resolution = enforce_ha_resolution_snapshot(
+                        forwarding,
+                        ha_state,
+                        now_secs,
+                        looked_up_resolution,
+                    );
+                    let refreshed_decision = SessionDecision {
+                        resolution: redirect_session_via_fabric_if_needed(
+                            forwarding,
+                            enforced_resolution,
+                            metadata.fabric_ingress,
+                            metadata.ingress_zone.as_ref(),
+                        ),
+                        ..decision
+                    };
+                    let mut refreshed_metadata = metadata.clone();
+                    let refreshed_owner_rg =
+                        owner_rg_for_resolution(forwarding, refreshed_decision.resolution);
+                    if refreshed_owner_rg > 0 {
+                        refreshed_metadata.owner_rg_id = refreshed_owner_rg;
+                    }
+                    refresh.push((key.clone(), refreshed_decision, refreshed_metadata, origin));
+                });
+
+                for (key, refreshed_decision, refreshed_metadata, origin) in refresh {
+                    if sessions.refresh_for_ha_transition(
+                        &key,
+                        refreshed_decision,
+                        refreshed_metadata.clone(),
+                        now_ns,
+                    ) {
+                        publish_worker_session_map_entry(
+                            session_map_fd,
+                            &key,
+                            refreshed_decision,
+                            &refreshed_metadata,
+                            origin,
+                            false,
+                        );
+                    }
+                }
+            }
             WorkerCommand::ExportOwnerRGSessions {
                 sequence,
                 owner_rgs,
@@ -3350,6 +3431,240 @@ mod tests {
             ForwardingDisposition::FabricRedirect
         );
         assert_eq!(lookup.decision.resolution.egress_ifindex, 21);
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
+    fn apply_worker_commands_refresh_split_reverse_owner_rg_rewrites_to_forward_candidate() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![2] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::FabricRedirect,
+                    local_ifindex: 0,
+                    egress_ifindex: 21,
+                    tx_ifindex: 21,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                    neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 2,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SyncImport,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([(2, active_ha_runtime(now_ns / 1_000_000_000))]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("refreshed reverse session");
+        assert!(origin.is_peer_synced());
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::ForwardCandidate
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 6);
+        assert_eq!(lookup.decision.resolution.tx_ifindex, 6);
+        assert_eq!(
+            lookup.decision.resolution.next_hop,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)))
+        );
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
+    fn apply_worker_commands_refresh_split_reverse_owner_rg_updates_stale_indexed_session() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![2] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::FabricRedirect,
+                    local_ifindex: 0,
+                    egress_ifindex: 21,
+                    tx_ifindex: 21,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                    neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 1,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SyncImport,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([
+            (1, inactive_ha_runtime(now_ns / 1_000_000_000)),
+            (2, active_ha_runtime(now_ns / 1_000_000_000)),
+        ]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("refreshed reverse session");
+        assert!(origin.is_peer_synced());
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::ForwardCandidate
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 6);
+        assert_eq!(lookup.decision.resolution.tx_ifindex, 6);
+        assert_eq!(
+            lookup.decision.resolution.next_hop,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)))
+        );
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
+    fn apply_worker_commands_refresh_owner_rg_updates_reverse_session_owned_by_other_rg() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![1] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::FabricRedirect,
+                    local_ifindex: 0,
+                    egress_ifindex: 21,
+                    tx_ifindex: 21,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                    neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 2,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SharedPromote,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([
+            (1, active_ha_runtime(now_ns / 1_000_000_000)),
+            (2, active_ha_runtime(now_ns / 1_000_000_000)),
+        ]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("refreshed reverse session");
+        assert_eq!(origin, SessionOrigin::SharedPromote);
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::ForwardCandidate
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 6);
+        assert_eq!(lookup.decision.resolution.tx_ifindex, 6);
+        assert_eq!(
+            lookup.decision.resolution.next_hop,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)))
+        );
         assert_eq!(lookup.metadata.owner_rg_id, 2);
         assert!(lookup.metadata.is_reverse);
     }

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -470,15 +470,15 @@ pub(super) fn reverse_resolution_for_session(
     now_secs: u64,
     allow_unseeded_tunnel_local: bool,
 ) -> ForwardingResolution {
-    if let Some(local) = super::interface_nat_local_resolution(forwarding, target_ip) {
-        return local;
-    }
     let resolved =
-        lookup_forwarding_resolution_with_dynamic(forwarding, dynamic_neighbors, target_ip);
+        super::interface_nat_local_resolution(forwarding, target_ip).unwrap_or_else(|| {
+            lookup_forwarding_resolution_with_dynamic(forwarding, dynamic_neighbors, target_ip)
+        });
+    let owner_rg_id = owner_rg_for_resolution(forwarding, resolved);
     if fabric_ingress
-        && owner_rg_for_resolution(forwarding, resolved) > 0
+        && owner_rg_id > 0
         && !matches!(
-            ha_state.get(&owner_rg_for_resolution(forwarding, resolved)),
+            ha_state.get(&owner_rg_id),
             Some(group) if group.is_forwarding_active(now_secs)
         )
         && let Some(redirect) = resolve_zone_encoded_fabric_redirect(forwarding, ingress_zone)

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -550,6 +550,7 @@ pub(super) enum WorkerCommand {
     UpsertLocal(SyncedSessionEntry),
     DeleteSynced(SessionKey),
     DemoteOwnerRGS { owner_rgs: Vec<i32> },
+    RefreshOwnerRGS { owner_rgs: Vec<i32> },
     ExportOwnerRGSessions { sequence: u64, owner_rgs: Vec<i32> },
 }
 


### PR DESCRIPTION
## Summary
- restore the previous peer RG snapshot when a requested failover aborts after local promotion, instead of leaving the peer parked in synthetic `secondary-hold`
- wait for the target daemon to observe local promotion side effects before sending the peer-demotion commit
- tighten userspace transfer readiness and direct announce behavior during HA handoff
- treat interface-NAT local-delivery session decisions as HA-owned so standby cached/session-hit decisions invalidate or redirect correctly

## Validation
- `go test ./pkg/daemon ./pkg/cluster -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::forwarding::tests -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::session_glue::tests -- --nocapture`

## Live Smoke
Deployed the equivalent tree from `~/git/codex-bpfrx` to the isolated `loss` userspace HA cluster and ran:
- `iperf3 -c 172.16.80.200 -P 12 -t 32 -R -J`
- RG1 moves: `node1 -> node0 -> node1 -> node0`

The cluster recovered healthy after all four moves, but reverse traffic still showed multi-second blackout windows with several `0.0 Gbps` intervals. Artifact:
- `/tmp/reverse-rg1-smoke-local-20260409-145558.json`

This PR is draft because that repeated reverse-failover dataplane gap is still open.
