### PR TITLE
HA: stabilize repeated RG2 failover recovery

### DIFF
--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -283,7 +283,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
-						s.ApplyIfCurrent(tr)
+						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
 					}
 				}
 

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -86,6 +86,18 @@ func (d *Daemon) localFailoverCommitIsReady(rgID int) bool {
 	return d.localFailoverCommitReady[rgID]
 }
 
+func recordRGActiveAppliedIfCurrentOrStable(s *rgStateMachine, tr rgTransition, active bool) bool {
+	if s.ApplyIfCurrent(tr) {
+		return true
+	}
+	current, _ := s.CurrentDesired()
+	if current != active {
+		return false
+	}
+	s.MarkApplied(active)
+	return true
+}
+
 func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 	if len(rgIDs) == 0 {
 		return nil
@@ -203,7 +215,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
-						s.ApplyIfCurrent(tr)
+						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
 					}
 				}
 				// Only remove blackholes once this node's desired state is
@@ -237,7 +249,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-primary")
 					go d.RefreshFabricFwd()
 				}
-				if noRethVRRP && (d.dp == nil || !s.NeedsApply()) {
+				if noRethVRRP && d.cluster != nil && d.cluster.IsLocalPrimary(ev.GroupID) && (d.dp == nil || !s.NeedsApply()) {
 					d.setLocalFailoverCommitReady(ev.GroupID, true)
 				}
 			} else {
@@ -391,7 +403,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 					if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
 						slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 					} else {
-						s.ApplyIfCurrent(tr)
+						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
 					}
 					go d.RefreshFabricFwd()
 				}
@@ -425,7 +437,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 						if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
 							slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 						} else {
-							s.ApplyIfCurrent(tr)
+							recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
 						}
 						go d.RefreshFabricFwd()
 					}
@@ -572,6 +584,9 @@ func (d *Daemon) reconcileRGState() {
 						"rg", rgID, "active", true, "err", err)
 				} else {
 					s.MarkApplied(true)
+					if noRethVRRP && clusterPri && !s.NeedsApply() {
+						d.setLocalFailoverCommitReady(rgID, true)
+					}
 				}
 			} else {
 				// Deactivation ordering: blackholes FIRST, then
@@ -583,6 +598,7 @@ func (d *Daemon) reconcileRGState() {
 						"rg", rgID, "active", false, "err", err)
 				} else {
 					s.MarkApplied(false)
+					d.setLocalFailoverCommitReady(rgID, false)
 				}
 			}
 		}

--- a/pkg/daemon/failover_commit_ready_test.go
+++ b/pkg/daemon/failover_commit_ready_test.go
@@ -85,3 +85,25 @@ func TestRecordRGActiveAppliedIfCurrentOrStableRejectsChangedDesiredState(t *tes
 		t.Fatal("expected apply pending to remain set after rejected stale apply")
 	}
 }
+
+func TestRecordRGActiveAppliedIfCurrentOrStableClearsSameDesiredStaleDemotion(t *testing.T) {
+	s := newRGStateMachine()
+	s.SetCluster(true)
+	s.MarkApplied(true)
+
+	tr := s.SetCluster(false)
+	if !s.NeedsApply() {
+		t.Fatal("expected apply to be pending after cluster demotion")
+	}
+
+	// Simulate another goroutine advancing the epoch while keeping the same
+	// desired inactive state.
+	s.Reconcile(false, nil)
+
+	if !recordRGActiveAppliedIfCurrentOrStable(s, tr, false) {
+		t.Fatal("expected same-desired stale demotion to be accepted")
+	}
+	if s.NeedsApply() {
+		t.Fatal("expected apply pending to clear after same-desired stale demotion")
+	}
+}

--- a/pkg/daemon/failover_commit_ready_test.go
+++ b/pkg/daemon/failover_commit_ready_test.go
@@ -48,3 +48,40 @@ func TestWaitLocalFailoverCommitReadyTimesOutWithoutPromotionSettle(t *testing.T
 		t.Fatalf("waitLocalFailoverCommitReady() error = %v", err)
 	}
 }
+
+func TestRecordRGActiveAppliedIfCurrentOrStableClearsSameDesiredStaleEpoch(t *testing.T) {
+	s := newRGStateMachine()
+	tr := s.SetCluster(true)
+	if !s.NeedsApply() {
+		t.Fatal("expected apply to be pending after cluster promotion")
+	}
+
+	// Simulate the reconcile loop or another goroutine advancing the epoch
+	// without changing the desired active state.
+	s.Reconcile(true, nil)
+
+	if !recordRGActiveAppliedIfCurrentOrStable(s, tr, true) {
+		t.Fatal("expected same-desired stale transition to be accepted")
+	}
+	if s.NeedsApply() {
+		t.Fatal("expected apply pending to clear after same-desired stale transition")
+	}
+}
+
+func TestRecordRGActiveAppliedIfCurrentOrStableRejectsChangedDesiredState(t *testing.T) {
+	s := newRGStateMachine()
+	tr := s.SetCluster(true)
+	if !s.NeedsApply() {
+		t.Fatal("expected apply to be pending after cluster promotion")
+	}
+
+	// Change the desired state before recording the apply result.
+	s.SetCluster(false)
+
+	if recordRGActiveAppliedIfCurrentOrStable(s, tr, true) {
+		t.Fatal("expected changed desired state to reject stale apply result")
+	}
+	if !s.NeedsApply() {
+		t.Fatal("expected apply pending to remain set after rejected stale apply")
+	}
+}

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -1866,7 +1866,7 @@ impl BindingWorker {
 
 fn should_install_local_reverse_session(decision: SessionDecision, fabric_ingress: bool) -> bool {
     let fabric_wire_placeholder =
-        fabric_ingress && decision.nat.rewrite_src.is_some() && decision.nat.rewrite_dst.is_none();
+        shared_ops::is_fabric_wire_placeholder(fabric_ingress, false, decision);
     decision.resolution.disposition != ForwardingDisposition::FabricRedirect
         || (fabric_ingress && !fabric_wire_placeholder)
 }

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -1864,6 +1864,13 @@ impl BindingWorker {
     }
 }
 
+fn should_install_local_reverse_session(decision: SessionDecision, fabric_ingress: bool) -> bool {
+    let fabric_wire_placeholder =
+        fabric_ingress && decision.nat.rewrite_src.is_some() && decision.nat.rewrite_dst.is_none();
+    decision.resolution.disposition != ForwardingDisposition::FabricRedirect
+        || (fabric_ingress && !fabric_wire_placeholder)
+}
+
 fn poll_binding(
     binding_index: usize,
     bindings: &mut [BindingWorker],
@@ -3355,6 +3362,11 @@ fn poll_binding(
                                         let mut created = 0u64;
                                         let track_in_userspace = decision.resolution.disposition
                                             != ForwardingDisposition::LocalDelivery;
+                                        let install_local_reverse =
+                                            should_install_local_reverse_session(
+                                                decision,
+                                                fabric_ingress,
+                                            );
                                         let forward_metadata = SessionMetadata {
                                             ingress_zone: from_zone_arc.clone(),
                                             egress_zone: to_zone_arc.clone(),
@@ -3492,6 +3504,7 @@ fn poll_binding(
                                             nat64_reverse: nat64_info,
                                         };
                                         if track_in_userspace
+                                            && install_local_reverse
                                             && sessions.install_with_protocol_with_origin(
                                                 reverse_key.clone(),
                                                 reverse_decision,
@@ -6175,6 +6188,55 @@ mod tests {
             shared_umem_group_key_for_device(Some("mlx5_core"), None),
             None
         );
+    }
+
+    #[test]
+    fn split_owner_fabric_redirect_skips_local_reverse_placeholder() {
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::FabricRedirect,
+                local_ifindex: 0,
+                egress_ifindex: 21,
+                tx_ifindex: 21,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                src_mac: Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, 0x01]),
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                ..NatDecision::default()
+            },
+        };
+
+        assert!(!should_install_local_reverse_session(decision, true));
+        assert!(!should_install_local_reverse_session(decision, false));
+    }
+
+    #[test]
+    fn fabric_redirect_reply_from_real_fabric_ingress_keeps_local_reverse() {
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::FabricRedirect,
+                local_ifindex: 0,
+                egress_ifindex: 21,
+                tx_ifindex: 21,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                src_mac: Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, 0x01]),
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_dst: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                ..NatDecision::default()
+            },
+        };
+
+        assert!(should_install_local_reverse_session(decision, true));
+        assert!(!should_install_local_reverse_session(decision, false));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -97,6 +97,22 @@ pub(super) fn lookup_forwarding_resolution_for_session(
     flow: &SessionFlow,
     decision: SessionDecision,
 ) -> ForwardingResolution {
+    lookup_forwarding_resolution_for_session_with_cache(
+        forwarding,
+        dynamic_neighbors,
+        flow,
+        decision,
+        true,
+    )
+}
+
+fn lookup_forwarding_resolution_for_session_with_cache(
+    forwarding: &ForwardingState,
+    dynamic_neighbors: &Arc<Mutex<FastMap<(i32, IpAddr), NeighborEntry>>>,
+    flow: &SessionFlow,
+    decision: SessionDecision,
+    allow_cached_fast_path: bool,
+) -> ForwardingResolution {
     if decision.resolution.disposition == ForwardingDisposition::LocalDelivery {
         return decision.resolution;
     }
@@ -114,8 +130,10 @@ pub(super) fn lookup_forwarding_resolution_for_session(
             _ => resolved,
         };
     }
-    if let Some(cached) = cached_session_resolution(forwarding, decision.resolution) {
-        return cached;
+    if allow_cached_fast_path {
+        if let Some(cached) = cached_session_resolution(forwarding, decision.resolution) {
+            return cached;
+        }
     }
     let target = resolution_target_for_session(flow, decision);
     if let Some(local) = super::interface_nat_local_resolution(forwarding, target) {
@@ -128,6 +146,21 @@ pub(super) fn lookup_forwarding_resolution_for_session(
         }
         _ => resolved,
     }
+}
+
+fn lookup_forwarding_resolution_for_synced_session(
+    forwarding: &ForwardingState,
+    dynamic_neighbors: &Arc<Mutex<FastMap<(i32, IpAddr), NeighborEntry>>>,
+    flow: &SessionFlow,
+    decision: SessionDecision,
+) -> ForwardingResolution {
+    lookup_forwarding_resolution_for_session_with_cache(
+        forwarding,
+        dynamic_neighbors,
+        flow,
+        decision,
+        false,
+    )
 }
 
 pub(super) fn owner_rg_is_locally_active(
@@ -410,15 +443,6 @@ pub(super) fn apply_worker_commands(
                 if activated_owner_rgs.is_empty() {
                     continue;
                 }
-                let locally_relevant_owner_rgs: std::collections::BTreeSet<_> = ha_state
-                    .iter()
-                    .filter_map(|(owner_rg_id, runtime)| {
-                        runtime
-                            .is_forwarding_active(now_secs)
-                            .then_some(*owner_rg_id)
-                    })
-                    .chain(activated_owner_rgs.iter().copied())
-                    .collect();
 
                 // Activation must re-evaluate all HA-managed worker sessions,
                 // not just those currently indexed under the activated RG.
@@ -426,9 +450,7 @@ pub(super) fn apply_worker_commands(
                 // move of RG1 changes whether they should locally forward or
                 // fabric-redirect. Activation is infrequent, so do the wider
                 // worker scan here instead of trusting potentially stale RG
-                // ownership buckets. Still skip sessions whose current and
-                // recomputed owners are both purely remote, since a local RG
-                // move cannot affect them.
+                // ownership buckets.
                 let mut refresh = Vec::new();
                 sessions.iter_with_origin(|key, decision, metadata, origin| {
                     if metadata.owner_rg_id <= 0 && !metadata.fabric_ingress {
@@ -476,12 +498,6 @@ pub(super) fn apply_worker_commands(
                         owner_rg_for_resolution(forwarding, refreshed_decision.resolution);
                     if refreshed_owner_rg > 0 {
                         refreshed_metadata.owner_rg_id = refreshed_owner_rg;
-                    }
-                    if !metadata.fabric_ingress
-                        && !locally_relevant_owner_rgs.contains(&metadata.owner_rg_id)
-                        && !locally_relevant_owner_rgs.contains(&refreshed_metadata.owner_rg_id)
-                    {
-                        return;
                     }
                     refresh.push((key.clone(), refreshed_decision, refreshed_metadata, origin));
                 });
@@ -1022,8 +1038,16 @@ pub(super) fn resolve_flow_session_decision(
         let resolved_key = hit.key.as_ref(&flow.forward_key);
         let mut decision = resolved.decision;
         let resolution_target = resolution_target_for_session(flow, decision);
-        let looked_up_resolution =
-            lookup_forwarding_resolution_for_session(forwarding, dynamic_neighbors, flow, decision);
+        let looked_up_resolution = if hit_origin.is_peer_synced() {
+            lookup_forwarding_resolution_for_synced_session(
+                forwarding,
+                dynamic_neighbors,
+                flow,
+                decision,
+            )
+        } else {
+            lookup_forwarding_resolution_for_session(forwarding, dynamic_neighbors, flow, decision)
+        };
         let looked_up_resolution = super::prefer_local_forward_candidate_for_fabric_ingress(
             forwarding,
             ha_state,
@@ -1706,6 +1730,62 @@ mod tests {
     }
 
     #[test]
+    fn lookup_session_across_scopes_prefers_shared_entry_over_fabric_wire_placeholder() {
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = SessionDecision {
+            resolution: test_resolution(),
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_src_port: Some(key.src_port),
+                ..NatDecision::default()
+            },
+        };
+        let translated_key = forward_wire_key(&key, decision.nat);
+        assert!(sessions.install_with_protocol_with_origin(
+            translated_key.clone(),
+            decision,
+            SessionMetadata {
+                fabric_ingress: true,
+                ..test_metadata()
+            },
+            SessionOrigin::ForwardFlow,
+            1,
+            PROTO_TCP,
+            0,
+        ));
+        let shared_entry = SyncedSessionEntry {
+            key: key.clone(),
+            decision,
+            metadata: SessionMetadata { ..test_metadata() },
+            origin: SessionOrigin::SyncImport,
+            protocol: PROTO_TCP,
+            tcp_flags: 0,
+        };
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        shared_forward_wire_sessions
+            .lock()
+            .expect("shared forward-wire lock")
+            .insert(translated_key.clone(), shared_entry.clone());
+
+        let resolved = lookup_session_across_scopes(
+            &mut sessions,
+            &shared_sessions,
+            &shared_forward_wire_sessions,
+            &translated_key,
+            2,
+            0,
+        )
+        .expect("shared forward-wire hit");
+        assert!(resolved.shared_entry.is_some());
+        assert_eq!(resolved.key.as_ref(&translated_key), &key);
+        assert_eq!(resolved.lookup.decision, shared_entry.decision);
+        assert_eq!(resolved.lookup.metadata, shared_entry.metadata);
+        assert_eq!(resolved.origin, SessionOrigin::SyncImport);
+    }
+
+    #[test]
     fn lookup_forward_nat_across_scopes_returns_shared_nat_entry() {
         let sessions = SessionTable::new();
         let key = SessionKey {
@@ -1746,6 +1826,86 @@ mod tests {
         assert_eq!(hit.key, entry.key);
         assert_eq!(hit.decision, entry.decision);
         assert_eq!(hit.metadata, entry.metadata);
+    }
+
+    #[test]
+    fn lookup_forward_nat_across_scopes_prefers_shared_entry_over_fabric_wire_placeholder() {
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = SessionDecision {
+            resolution: test_resolution(),
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_src_port: Some(key.src_port),
+                ..NatDecision::default()
+            },
+        };
+        let translated_key = forward_wire_key(&key, decision.nat);
+        assert!(sessions.install_with_protocol_with_origin(
+            translated_key,
+            decision,
+            SessionMetadata {
+                fabric_ingress: true,
+                ..test_metadata()
+            },
+            SessionOrigin::ForwardFlow,
+            1,
+            PROTO_TCP,
+            0,
+        ));
+        let shared_entry = SyncedSessionEntry {
+            key: key.clone(),
+            decision,
+            metadata: SessionMetadata { ..test_metadata() },
+            origin: SessionOrigin::SyncImport,
+            protocol: PROTO_TCP,
+            tcp_flags: 0,
+        };
+        let reply_key = reverse_session_key(&key, decision.nat);
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        shared_nat_sessions
+            .lock()
+            .expect("shared nat lock")
+            .insert(reply_key.clone(), shared_entry.clone());
+
+        let hit = lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &reply_key)
+            .expect("shared nat hit");
+        assert_eq!(hit.key, shared_entry.key);
+        assert_eq!(hit.decision, shared_entry.decision);
+        assert_eq!(hit.metadata, shared_entry.metadata);
+    }
+
+    #[test]
+    fn lookup_forward_nat_across_scopes_ignores_fabric_wire_placeholder_without_shared_entry() {
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let decision = SessionDecision {
+            resolution: test_resolution(),
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_src_port: Some(key.src_port),
+                ..NatDecision::default()
+            },
+        };
+        let translated_key = forward_wire_key(&key, decision.nat);
+        assert!(sessions.install_with_protocol_with_origin(
+            translated_key,
+            decision,
+            SessionMetadata {
+                fabric_ingress: true,
+                ..test_metadata()
+            },
+            SessionOrigin::ForwardFlow,
+            1,
+            PROTO_TCP,
+            0,
+        ));
+        let reply_key = reverse_session_key(&key, decision.nat);
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+
+        assert!(
+            lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &reply_key).is_none()
+        );
     }
 
     #[test]
@@ -3691,6 +3851,154 @@ mod tests {
     }
 
     #[test]
+    fn apply_worker_commands_refresh_owner_rg_rewrites_remote_reverse_session_on_peer_move() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![1] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::ForwardCandidate,
+                    local_ifindex: 0,
+                    egress_ifindex: 6,
+                    tx_ifindex: 6,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                    neighbor_mac: Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 2,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SyncImport,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([
+            (1, active_ha_runtime(now_ns / 1_000_000_000)),
+            (2, inactive_ha_runtime(now_ns / 1_000_000_000)),
+        ]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("refreshed reverse session");
+        assert!(origin.is_peer_synced());
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 21);
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
+    fn apply_worker_commands_refresh_owner_rg_rewrites_shared_promote_reverse_on_peer_move() {
+        let commands = Arc::new(Mutex::new(VecDeque::from([
+            WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![1] },
+        ])));
+        let mut sessions = SessionTable::new();
+        let forward_key = test_key();
+        let reverse_key = reverse_session_key(&forward_key, test_decision().nat);
+        let now_ns = monotonic_nanos();
+
+        assert!(sessions.install_with_protocol_with_origin(
+            reverse_key.clone(),
+            SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::ForwardCandidate,
+                    local_ifindex: 0,
+                    egress_ifindex: 6,
+                    tx_ifindex: 6,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                    neighbor_mac: Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x61, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: test_decision().nat.reverse(
+                    forward_key.src_ip,
+                    forward_key.dst_ip,
+                    forward_key.src_port,
+                    forward_key.dst_port,
+                ),
+            },
+            SessionMetadata {
+                ingress_zone: Arc::<str>::from("wan"),
+                egress_zone: Arc::<str>::from("lan"),
+                owner_rg_id: 2,
+                fabric_ingress: false,
+                is_reverse: true,
+                nat64_reverse: None,
+            },
+            SessionOrigin::SharedPromote,
+            now_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+
+        let ha_state = BTreeMap::from([
+            (1, active_ha_runtime(now_ns / 1_000_000_000)),
+            (2, inactive_ha_runtime(now_ns / 1_000_000_000)),
+        ]);
+        let results = apply_worker_commands(
+            &commands,
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &test_forwarding_state_split_rgs(),
+            &ha_state,
+            &Arc::new(Mutex::new(FastMap::default())),
+        );
+
+        assert!(results.cancelled_keys.is_empty());
+        let (lookup, origin) = sessions
+            .lookup_with_origin(&reverse_key, now_ns, 0x10)
+            .expect("refreshed reverse session");
+        assert_eq!(origin, SessionOrigin::SharedPromote);
+        assert_eq!(
+            lookup.decision.resolution.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(lookup.decision.resolution.egress_ifindex, 21);
+        assert_eq!(lookup.metadata.owner_rg_id, 2);
+        assert!(lookup.metadata.is_reverse);
+    }
+
+    #[test]
     fn export_owner_rg_sessions_skips_locally_demoted_entries() {
         let commands = Arc::new(Mutex::new(VecDeque::from([
             WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![1] },
@@ -4062,6 +4370,84 @@ mod tests {
     }
 
     #[test]
+    fn prewarm_reverse_synced_sessions_for_owner_rgs_restores_shared_promote_forward_entry() {
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let worker_commands = vec![Arc::new(Mutex::new(VecDeque::new()))];
+        let forwarding = test_forwarding_state_split_rgs();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let mut ha_state = BTreeMap::new();
+        ha_state.insert(1, active_ha_runtime(1));
+        ha_state.insert(2, inactive_ha_runtime(1));
+        let mut metadata = test_metadata();
+        metadata.ingress_zone = Arc::<str>::from("lan");
+        metadata.egress_zone = Arc::<str>::from("wan");
+        metadata.fabric_ingress = false;
+        metadata.owner_rg_id = 1;
+        let entry = SyncedSessionEntry {
+            key: test_key(),
+            decision: test_decision(),
+            metadata,
+            origin: SessionOrigin::SharedPromote,
+            protocol: PROTO_TCP,
+            tcp_flags: 0x10,
+        };
+        publish_shared_session(
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &entry,
+        );
+
+        let prewarm_index = shared_owner_rg_indexes
+            .reverse_prewarm_sessions
+            .lock()
+            .expect("prewarm index");
+        assert!(
+            prewarm_index.get(&1).is_none() || !prewarm_index.get(&1).unwrap().contains(&entry.key)
+        );
+        drop(prewarm_index);
+
+        prewarm_reverse_synced_sessions_for_owner_rgs(
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &worker_commands,
+            -1,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+            &[1],
+            1,
+        );
+
+        let reverse_key = reverse_session_key(&entry.key, entry.decision.nat);
+        let reverse = shared_sessions
+            .lock()
+            .expect("shared sessions")
+            .get(&reverse_key)
+            .cloned()
+            .expect("reverse entry");
+        assert!(reverse.metadata.is_reverse);
+        assert_eq!(reverse.metadata.owner_rg_id, 2);
+        let commands = worker_commands[0].lock().expect("commands");
+        assert_eq!(commands.len(), 2);
+        assert!(matches!(
+            &commands[0],
+            WorkerCommand::UpsertSynced(session) if session.origin == SessionOrigin::SharedPromote
+        ));
+        assert!(matches!(
+            &commands[1],
+            WorkerCommand::UpsertSynced(session)
+                if session.metadata.is_reverse && session.metadata.owner_rg_id == 2
+        ));
+    }
+
+    #[test]
     fn prewarm_reverse_synced_sessions_recomputes_when_reverse_owner_rg_activates() {
         let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
         let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -4164,6 +4550,62 @@ mod tests {
     }
 
     #[test]
+    fn reverse_session_from_split_owner_fabric_redirect_uses_fabric_return_when_client_rg_inactive()
+    {
+        let forwarding = test_forwarding_state_split_rgs();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let ha_state = BTreeMap::from([(2, inactive_ha_runtime(1))]);
+        let reverse = build_reverse_session_from_forward_match(
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+            ForwardSessionMatch {
+                key: SessionKey {
+                    addr_family: libc::AF_INET as u8,
+                    protocol: PROTO_TCP,
+                    src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+                    dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                    src_port: 42424,
+                    dst_port: 5201,
+                },
+                decision: SessionDecision {
+                    resolution: ForwardingResolution {
+                        disposition: ForwardingDisposition::FabricRedirect,
+                        local_ifindex: 0,
+                        egress_ifindex: 21,
+                        tx_ifindex: 21,
+                        tunnel_endpoint_id: 0,
+                        next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                        neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                        src_mac: Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, 0x01]),
+                        tx_vlan_id: 0,
+                    },
+                    nat: NatDecision {
+                        rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                        ..NatDecision::default()
+                    },
+                },
+                metadata: SessionMetadata {
+                    ingress_zone: Arc::<str>::from("lan"),
+                    egress_zone: Arc::<str>::from("wan"),
+                    owner_rg_id: 1,
+                    fabric_ingress: false,
+                    is_reverse: false,
+                    nat64_reverse: None,
+                },
+            },
+            1,
+            0,
+        );
+        assert_eq!(
+            reverse.decision.resolution.disposition,
+            ForwardingDisposition::FabricRedirect
+        );
+        assert_eq!(reverse.decision.resolution.egress_ifindex, 21);
+        assert_eq!(reverse.decision.resolution.tx_ifindex, 21);
+    }
+
+    #[test]
     fn republish_bpf_session_entries_covers_all_sessions_in_owner_rg_index() {
         // Simulate the failover+failback scenario (#475):
         // A session is in the shared sessions table and the `sessions`
@@ -4234,5 +4676,101 @@ mod tests {
             &[2],
         );
         assert_eq!(count, 0, "should find 0 sessions for RG2");
+    }
+
+    #[test]
+    fn synced_session_hit_recomputes_local_resolution_after_failover() {
+        let mut sessions = SessionTable::new();
+        let key = test_key();
+        let mut forwarding = test_forwarding_state_with_fabric();
+        forwarding.connected_v4.push(ConnectedRouteV4 {
+            prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
+            ifindex: 12,
+            tunnel_endpoint_id: 0,
+        });
+        forwarding.neighbors.insert(
+            (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
+            NeighborEntry {
+                mac: [0x56, 0x4a, 0xe8, 0x1e, 0xa8, 0x32],
+            },
+        );
+        let stale_fabric_decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::FabricRedirect,
+                local_ifindex: 0,
+                egress_ifindex: 21,
+                tx_ifindex: 21,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                neighbor_mac: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+                src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        };
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        publish_shared_session(
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &SyncedSessionEntry {
+                key: key.clone(),
+                decision: stale_fabric_decision,
+                metadata: test_metadata(),
+                origin: SessionOrigin::SyncImport,
+                protocol: PROTO_TCP,
+                tcp_flags: 0x10,
+            },
+        );
+        let peer_worker_commands = Vec::new();
+        let dynamic_neighbors = Arc::new(Mutex::new(FastMap::default()));
+        let ha_state = BTreeMap::from([(
+            1,
+            HAGroupRuntime {
+                active: true,
+                watchdog_timestamp: monotonic_nanos() / 1_000_000_000,
+                lease: HAGroupRuntime::active_lease_until(
+                    monotonic_nanos() / 1_000_000_000,
+                    monotonic_nanos() / 1_000_000_000,
+                ),
+            },
+        )]);
+
+        let resolved = resolve_flow_session_decision(
+            &mut sessions,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+            &SessionFlow {
+                src_ip: key.src_ip,
+                dst_ip: key.dst_ip,
+                forward_key: key.clone(),
+            },
+            1_000_000,
+            monotonic_nanos() / 1_000_000_000,
+            PROTO_TCP,
+            0x10,
+            5,
+            false,
+            0,
+        )
+        .expect("synced session should resolve");
+
+        assert_eq!(
+            resolved.decision.resolution.disposition,
+            ForwardingDisposition::ForwardCandidate
+        );
+        assert_eq!(resolved.decision.resolution.egress_ifindex, 12);
+        assert_eq!(resolved.decision.resolution.tx_ifindex, 11);
     }
 }

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -436,11 +436,7 @@ pub(super) fn apply_worker_commands(
                 }
             }
             WorkerCommand::RefreshOwnerRGS { owner_rgs } => {
-                let activated_owner_rgs: std::collections::BTreeSet<_> = owner_rgs
-                    .into_iter()
-                    .filter(|owner_rg_id| *owner_rg_id > 0)
-                    .collect();
-                if activated_owner_rgs.is_empty() {
+                if !owner_rgs.iter().any(|owner_rg_id| *owner_rg_id > 0) {
                     continue;
                 }
 

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -357,11 +357,18 @@ pub(super) struct ResolvedFlowSessionDecision {
     pub(super) created: bool,
 }
 
-fn is_fabric_wire_placeholder(lookup: &SessionLookup) -> bool {
-    lookup.metadata.fabric_ingress
-        && !lookup.metadata.is_reverse
-        && lookup.decision.nat.rewrite_src.is_some()
-        && lookup.decision.nat.rewrite_dst.is_none()
+// Fabric-ingress SNAT-only forward entries are standby-side wire placeholders
+// in the split-RG topology: they should not win lookups over the real shared
+// session and should not synthesize a competing local reverse session.
+pub(super) fn is_fabric_wire_placeholder(
+    fabric_ingress: bool,
+    is_reverse: bool,
+    decision: SessionDecision,
+) -> bool {
+    fabric_ingress
+        && !is_reverse
+        && decision.nat.rewrite_src.is_some()
+        && decision.nat.rewrite_dst.is_none()
 }
 
 pub(super) fn lookup_session_across_scopes(
@@ -373,9 +380,12 @@ pub(super) fn lookup_session_across_scopes(
     tcp_flags: u8,
 ) -> Option<ResolvedSessionLookup> {
     if let Some((lookup, origin)) = sessions.lookup_with_origin(key, now_ns, tcp_flags) {
-        if is_fabric_wire_placeholder(&lookup)
-            && let Some(shared) =
-                lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
+        if is_fabric_wire_placeholder(
+            lookup.metadata.fabric_ingress,
+            lookup.metadata.is_reverse,
+            lookup.decision,
+        ) && let Some(shared) =
+            lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
         {
             return Some(ResolvedSessionLookup::shared(shared));
         }
@@ -386,9 +396,12 @@ pub(super) fn lookup_session_across_scopes(
             decision: matched.decision,
             metadata: matched.metadata,
         };
-        if is_fabric_wire_placeholder(&lookup)
-            && let Some(shared) =
-                lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
+        if is_fabric_wire_placeholder(
+            lookup.metadata.fabric_ingress,
+            lookup.metadata.is_reverse,
+            lookup.decision,
+        ) && let Some(shared) =
+            lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
         {
             return Some(ResolvedSessionLookup::shared(shared));
         }
@@ -408,10 +421,11 @@ pub(super) fn lookup_forward_nat_across_scopes(
     reply_key: &SessionKey,
 ) -> Option<ForwardSessionMatch> {
     if let Some(local) = sessions.find_forward_nat_match(reply_key) {
-        if is_fabric_wire_placeholder(&SessionLookup {
-            decision: local.decision,
-            metadata: local.metadata.clone(),
-        }) {
+        if is_fabric_wire_placeholder(
+            local.metadata.fabric_ingress,
+            local.metadata.is_reverse,
+            local.decision,
+        ) {
             return lookup_shared_forward_nat_match(shared_nat_sessions, reply_key).map(|entry| {
                 ForwardSessionMatch {
                     key: entry.key,

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -60,6 +60,15 @@ pub(super) fn synced_replica_entry(entry: &SyncedSessionEntry) -> SyncedSessionE
 /// pre-installs reverse entries via UpsertSynced. This function still runs
 /// at activation to re-resolve egress with local forwarding state (the
 /// pre-installed entries carry the peer's interface indices/MACs).
+///
+/// Use the union of the shared owner-RG session index and the narrower
+/// reverse-prewarm index here. Activation is infrequent, and locally promoted
+/// sessions can exist in the shared table without appearing in the
+/// reverse-prewarm subset, while split-RG reverse companions can still resolve
+/// to an activated RG even when the forward entry's current owner RG is
+/// different. Both cases need their forward entries restored to worker
+/// SessionTables and, when applicable, their reverse companions synthesized
+/// again on activation.
 pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
     shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
@@ -78,11 +87,21 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
     }
     let publish_session_map = session_map_fd >= 0;
     let owner_rg_set: std::collections::BTreeSet<i32> = owner_rgs.iter().copied().collect();
-    let candidate_keys = owner_rg_session_keys_serialized(
+    let mut candidate_keys = owner_rg_session_keys_serialized(
+        shared_sessions,
+        &shared_owner_rg_indexes.sessions,
+        owner_rgs,
+    );
+    let reverse_candidate_keys = owner_rg_session_keys_serialized(
         shared_sessions,
         &shared_owner_rg_indexes.reverse_prewarm_sessions,
         owner_rgs,
     );
+    for key in reverse_candidate_keys {
+        if !candidate_keys.contains(&key) {
+            candidate_keys.push(key);
+        }
+    }
     let (forward_entries, reverse_entries) = shared_sessions
         .lock()
         .map(|sessions| {
@@ -92,9 +111,11 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
                 let Some(entry) = sessions.get(&key) else {
                     continue;
                 };
-                if entry.metadata.is_reverse || !entry.origin.is_peer_synced() {
+                if entry.metadata.is_reverse {
                     continue;
                 }
+                let allow_reverse_prewarm = entry.origin.is_peer_synced()
+                    || matches!(entry.origin, SessionOrigin::SharedPromote);
                 let Some(reverse) = synthesized_synced_reverse_entry(
                     forwarding,
                     ha_state,
@@ -113,7 +134,9 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
                     || owner_rg_set.contains(&reverse.metadata.owner_rg_id)
                 {
                     forward_entries.push(entry.clone());
-                    reverse_entries.push(reverse);
+                    if allow_reverse_prewarm {
+                        reverse_entries.push(reverse);
+                    }
                 }
             }
             (forward_entries, reverse_entries)
@@ -334,6 +357,13 @@ pub(super) struct ResolvedFlowSessionDecision {
     pub(super) created: bool,
 }
 
+fn is_fabric_wire_placeholder(lookup: &SessionLookup) -> bool {
+    lookup.metadata.fabric_ingress
+        && !lookup.metadata.is_reverse
+        && lookup.decision.nat.rewrite_src.is_some()
+        && lookup.decision.nat.rewrite_dst.is_none()
+}
+
 pub(super) fn lookup_session_across_scopes(
     sessions: &mut SessionTable,
     shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
@@ -342,24 +372,30 @@ pub(super) fn lookup_session_across_scopes(
     now_ns: u64,
     tcp_flags: u8,
 ) -> Option<ResolvedSessionLookup> {
-    sessions
-        .lookup_with_origin(key, now_ns, tcp_flags)
-        .map(|(lookup, origin)| ResolvedSessionLookup::local_query(lookup, origin))
-        .or_else(|| {
-            sessions
-                .find_forward_wire_match_with_origin(key)
-                .map(|(matched, origin)| {
-                    ResolvedSessionLookup::local(
-                        matched.key,
-                        SessionLookup {
-                            decision: matched.decision,
-                            metadata: matched.metadata,
-                        },
-                        origin,
-                    )
-                })
-        })
-        .or_else(|| lookup_shared_session(shared_sessions, key).map(ResolvedSessionLookup::shared))
+    if let Some((lookup, origin)) = sessions.lookup_with_origin(key, now_ns, tcp_flags) {
+        if is_fabric_wire_placeholder(&lookup)
+            && let Some(shared) =
+                lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
+        {
+            return Some(ResolvedSessionLookup::shared(shared));
+        }
+        return Some(ResolvedSessionLookup::local_query(lookup, origin));
+    }
+    if let Some((matched, origin)) = sessions.find_forward_wire_match_with_origin(key) {
+        let lookup = SessionLookup {
+            decision: matched.decision,
+            metadata: matched.metadata,
+        };
+        if is_fabric_wire_placeholder(&lookup)
+            && let Some(shared) =
+                lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
+        {
+            return Some(ResolvedSessionLookup::shared(shared));
+        }
+        return Some(ResolvedSessionLookup::local(matched.key, lookup, origin));
+    }
+    lookup_shared_session(shared_sessions, key)
+        .map(ResolvedSessionLookup::shared)
         .or_else(|| {
             lookup_shared_forward_wire_match(shared_forward_wire_sessions, key)
                 .map(ResolvedSessionLookup::shared)
@@ -371,14 +407,27 @@ pub(super) fn lookup_forward_nat_across_scopes(
     shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     reply_key: &SessionKey,
 ) -> Option<ForwardSessionMatch> {
-    sessions.find_forward_nat_match(reply_key).or_else(|| {
-        lookup_shared_forward_nat_match(shared_nat_sessions, reply_key).map(|entry| {
-            ForwardSessionMatch {
-                key: entry.key,
-                decision: entry.decision,
-                metadata: entry.metadata,
-            }
-        })
+    if let Some(local) = sessions.find_forward_nat_match(reply_key) {
+        if is_fabric_wire_placeholder(&SessionLookup {
+            decision: local.decision,
+            metadata: local.metadata.clone(),
+        }) {
+            return lookup_shared_forward_nat_match(shared_nat_sessions, reply_key).map(|entry| {
+                ForwardSessionMatch {
+                    key: entry.key,
+                    decision: entry.decision,
+                    metadata: entry.metadata,
+                }
+            });
+        }
+        return Some(local);
+    }
+    lookup_shared_forward_nat_match(shared_nat_sessions, reply_key).map(|entry| {
+        ForwardSessionMatch {
+            key: entry.key,
+            decision: entry.decision,
+            metadata: entry.metadata,
+        }
     })
 }
 
@@ -390,13 +439,15 @@ pub(super) fn build_reverse_session_from_forward_match(
     now_secs: u64,
     ha_startup_grace_until_secs: u64,
 ) -> SessionLookup {
+    let requires_fabric_return = forward_match.metadata.fabric_ingress
+        || forward_match.decision.resolution.disposition == ForwardingDisposition::FabricRedirect;
     let resolution = reverse_resolution_for_session(
         forwarding,
         ha_state,
         dynamic_neighbors,
         forward_match.key.src_ip,
         forward_match.metadata.ingress_zone.as_ref(),
-        forward_match.metadata.fabric_ingress,
+        requires_fabric_return,
         now_secs,
         forward_match.decision.resolution.tunnel_endpoint_id != 0
             && now_secs <= ha_startup_grace_until_secs,


### PR DESCRIPTION
## Summary
- keep repeated RG activation bookkeeping from getting stuck behind stale rgStateMachine epochs
- republish and prewarm split-RG reverse sessions on owner-RG transitions in the userspace dataplane
- validate the clean origin/master-based deploy with repeated RG2 failovers on the isolated loss userspace HA cluster

## Validation
- `GOTOOLCHAIN=local go test ./pkg/daemon -run 'TestWaitLocalFailoverCommitReadyWaitsForPromotionSettle|TestWaitLocalFailoverCommitReadyTimesOutWithoutPromotionSettle|TestRecordRGActiveAppliedIfCurrentOrStableClearsSameDesiredStaleEpoch|TestRecordRGActiveAppliedIfCurrentOrStableRejectsChangedDesiredState' -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::ha::tests -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml prewarm_reverse_synced_sessions_after_demotion_recomputes_split_owner_reverse -- --nocapture`

## Live HA Validation
- clean rebooted/stabilized userspace HA boot before validation to avoid mlx/XSK guest-crash contamination
- 4-move 10s cadence artifact: `/tmp/narrow-short-4move-10s-fg-20260410-065125`
- 100-move 10s cadence artifact: `/tmp/narrow-long-100move-10s-fg-20260410-065357`
- `100/100` RG2 failover requests committed successfully
- `exact_zero_intervals=0`
- `exact_zero_streams=0`
- no mlx/XSK crash signatures captured on either userspace firewall console

## Note
The existing `scripts/iperf-json-metrics.py` zero counters are thresholded at `<= 50 Mbps`, not literal `0.0 bps`, so the soak still reports nonzero thresholded zero counters even though no stream hit an exact zero interval.