### PR TITLE
userspace: clarify standby forwarding status

### DIFF
--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -6,6 +6,21 @@ import (
 	"time"
 )
 
+func localHAForwardingRole(status ProcessStatus) string {
+	if len(status.HAGroups) == 0 {
+		return ""
+	}
+	for _, group := range status.HAGroups {
+		if group.Active {
+			return "active"
+		}
+	}
+	if status.ForwardingArmed {
+		return "standby (armed for failover)"
+	}
+	return "standby"
+}
+
 func FormatStatusSummary(status ProcessStatus) string {
 	var b strings.Builder
 	now := time.Now()
@@ -162,6 +177,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  Neighbor generation:       %d\n", status.NeighborGeneration)
 	fmt.Fprintf(&b, "  Route entries:             %d\n", status.RouteEntries)
 	if len(status.HAGroups) > 0 {
+		fmt.Fprintf(&b, "  Local HA forwarding role:  %s\n", localHAForwardingRole(status))
 		parts := make([]string, 0, len(status.HAGroups))
 		for _, group := range status.HAGroups {
 			parts = append(parts, fmt.Sprintf("rg%d active=%t watchdog=%d", group.RGID, group.Active, group.WatchdogTimestamp))

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -20,6 +20,11 @@ func TestFormatStatusSummary(t *testing.T) {
 		InterfaceAddresses:     6,
 		NeighborEntries:        9,
 		RouteEntries:           4,
+		HAGroups: []HAGroupStatus{
+			{RGID: 0, Active: true, WatchdogTimestamp: 100},
+			{RGID: 1, Active: false, WatchdogTimestamp: 0},
+			{RGID: 2, Active: false, WatchdogTimestamp: 0},
+		},
 		Fabrics: []FabricSnapshot{
 			{Name: "fab0", ParentLinuxName: "ge-0-0-0", ParentIfindex: 7, OverlayLinux: "fab0", OverlayIfindex: 17, RXQueues: 4, PeerAddress: "10.99.1.2"},
 		},
@@ -52,6 +57,8 @@ func TestFormatStatusSummary(t *testing.T) {
 		"Interface addresses:       6",
 		"Neighbor entries:          9",
 		"Route entries:             4",
+		"Local HA forwarding role:  active",
+		"HA groups:                 rg0 active=true watchdog=100; rg1 active=false watchdog=0; rg2 active=false watchdog=0",
 		"Fabric links:              fab0 parent=ge-0-0-0 peer=10.99.1.2",
 		"Last resolution:           forward_candidate egress-ifindex=11 next-hop=172.16.50.1 mac=00:10:db:ff:10:01",
 		"Bound bindings:            2/2",
@@ -89,6 +96,22 @@ func TestFormatStatusSummary(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("summary missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestFormatStatusSummaryReportsStandbyArmedRole(t *testing.T) {
+	status := ProcessStatus{
+		ForwardingArmed: true,
+		HAGroups: []HAGroupStatus{
+			{RGID: 0, Active: false, WatchdogTimestamp: 100},
+			{RGID: 1, Active: false, WatchdogTimestamp: 0},
+			{RGID: 2, Active: false, WatchdogTimestamp: 0},
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	if !strings.Contains(out, "Local HA forwarding role:  standby (armed for failover)") {
+		t.Fatalf("summary missing standby armed role:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an explicit local HA forwarding role line to userspace dataplane status
- distinguish active ownership from standby armed-for-failover state
- cover both active and standby-armed output in status formatter tests

## Validation
- go test ./pkg/dataplane/userspace -run 'TestFormatStatusSummary|TestFormatStatusSummaryReportsStandbyArmedRole|TestFormatBindings' -count=1
- live cluster check on 2026-04-10:
  - fw0 primary, fw1 secondary
  - fw1 had blackhole default routes and no service IPs on data interfaces
  - during iperf3 -c 172.16.80.200 -P 8 -t 10, fw0 dataplane counters advanced by ~19.9M RX packets while fw1 advanced by 1 RX / 1 TX packet
  - issue was misleading status wording, not real dual transit forwarding