### PR TITLE
userspace-dp: keep UMEM bounds at registered length

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -8402,8 +8402,7 @@ mod tests {
             nat: NatDecision::default(),
         };
 
-        // Addr beyond the mapped region forces an extract failure.
-        // MmapArea rounds up to 2 MB, so use an offset well beyond that.
+        // Addr beyond the registered UMEM length forces an extract failure.
         maybe_reinject_slow_path(
             &binding,
             &live,
@@ -8411,7 +8410,7 @@ mod tests {
             &local_tunnel_reinjectors,
             &area,
             XdpDesc {
-                addr: 4 * 1024 * 1024,
+                addr: 512,
                 len: 96,
                 options: 0,
             },

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -180,7 +180,7 @@ impl MmapArea {
 
     pub(super) fn slice(&self, offset: usize, len: usize) -> Option<&[u8]> {
         let end = offset.checked_add(len)?;
-        if end > self.mapped_len {
+        if end > self.len {
             return None;
         }
         Some(unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().add(offset), len) })
@@ -197,7 +197,7 @@ impl MmapArea {
         len: usize,
     ) -> Option<&mut [u8]> {
         let end = offset.checked_add(len)?;
-        if end > self.mapped_len {
+        if end > self.len {
             return None;
         }
         Some(unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().add(offset), len) })
@@ -207,6 +207,20 @@ impl MmapArea {
 impl Drop for MmapArea {
     fn drop(&mut self) {
         let _ = unsafe { libc::munmap(self.ptr.as_ptr().cast::<c_void>(), self.mapped_len) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MmapArea;
+
+    #[test]
+    fn mmap_area_rejects_access_beyond_registered_len_even_if_mapping_is_rounded() {
+        let area = MmapArea::new(128).expect("mmap");
+
+        assert!(area.slice(0, 128).is_some());
+        assert!(area.slice(128, 1).is_none());
+        assert!(area.slice(512, 1).is_none());
     }
 }
 


### PR DESCRIPTION
Fixes #625.

## Summary
- keep hugepage-backed UMEM allocation and rounded `munmap` length
- restore `MmapArea` slice bounds to the registered UMEM length
- add a regression test that rejects accesses into the rounded hugepage tail
- restore the small invalid-descriptor slow-path regression to the original past-the-end semantics

## Problem
Commit `136b9dbb64754723350a7f338f62fc4af22f965a` changed `MmapArea` access bounds from the registered UMEM length to the rounded mapping length. That made descriptors in the padded hugepage tail look valid to userspace parsing helpers even though those bytes are outside the UMEM region registered with XSK.

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml mmap_area_rejects_access_beyond_registered_len_even_if_mapping_is_rounded -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml maybe_reinject_slow_path_records_extract_failure_for_invalid_desc -- --nocapture