### PR TITLE
daemon: bind RETH RA to stable link-local

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2189,8 +2189,9 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 	raByIface := make(map[string]*config.RAInterfaceConfig)
 	var result []*config.RAInterfaceConfig
 	for _, ra := range cfg.Protocols.RouterAdvertisement {
-		raByIface[ra.Interface] = ra
-		result = append(result, ra)
+		clone := cloneRAInterfaceConfig(ra)
+		raByIface[clone.Interface] = clone
+		result = append(result, clone)
 	}
 
 	if d.dhcp != nil {
@@ -2269,6 +2270,28 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 	}
 
 	return result
+}
+
+func cloneRAInterfaceConfig(src *config.RAInterfaceConfig) *config.RAInterfaceConfig {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	if len(src.DNSServers) > 0 {
+		clone.DNSServers = append([]string(nil), src.DNSServers...)
+	}
+	if len(src.Prefixes) > 0 {
+		clone.Prefixes = make([]*config.RAPrefix, 0, len(src.Prefixes))
+		for _, pfx := range src.Prefixes {
+			if pfx == nil {
+				clone.Prefixes = append(clone.Prefixes, nil)
+				continue
+			}
+			pfxClone := *pfx
+			clone.Prefixes = append(clone.Prefixes, &pfxClone)
+		}
+	}
+	return &clone
 }
 
 // startDHCPClients iterates the config and starts DHCP/DHCPv6 clients

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2193,48 +2193,45 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 		result = append(result, ra)
 	}
 
-	// If no DHCP manager, return static only.
-	if d.dhcp == nil {
-		return result
-	}
-
-	// Merge PD-derived prefixes from DHCPv6 clients.
-	for _, mapping := range d.dhcp.DelegatedPrefixesForRA() {
-		subPrefix := dhcp.DeriveSubPrefix(mapping.Prefix, mapping.SubPrefLen)
-		if !subPrefix.IsValid() {
-			slog.Warn("DHCPv6 PD: invalid sub-prefix derivation",
-				"delegated", mapping.Prefix, "sub_len", mapping.SubPrefLen)
-			continue
-		}
-
-		pfx := &config.RAPrefix{
-			Prefix:     subPrefix.String(),
-			OnLink:     true,
-			Autonomous: true,
-		}
-		if mapping.ValidLifetime > 0 {
-			pfx.ValidLifetime = int(mapping.ValidLifetime.Seconds())
-		}
-		if mapping.PreferredLifetime > 0 {
-			pfx.PreferredLife = int(mapping.PreferredLifetime.Seconds())
-		}
-
-		if existing, ok := raByIface[mapping.RAIface]; ok {
-			// Append prefix to existing RA interface config.
-			existing.Prefixes = append(existing.Prefixes, pfx)
-		} else {
-			// Create a new RA interface config for this downstream interface.
-			ra := &config.RAInterfaceConfig{
-				Interface: mapping.RAIface,
-				Prefixes:  []*config.RAPrefix{pfx},
+	if d.dhcp != nil {
+		// Merge PD-derived prefixes from DHCPv6 clients.
+		for _, mapping := range d.dhcp.DelegatedPrefixesForRA() {
+			subPrefix := dhcp.DeriveSubPrefix(mapping.Prefix, mapping.SubPrefLen)
+			if !subPrefix.IsValid() {
+				slog.Warn("DHCPv6 PD: invalid sub-prefix derivation",
+					"delegated", mapping.Prefix, "sub_len", mapping.SubPrefLen)
+				continue
 			}
-			raByIface[mapping.RAIface] = ra
-			result = append(result, ra)
-		}
 
-		slog.Info("DHCPv6 PD: advertising prefix via RA",
-			"prefix", subPrefix, "interface", mapping.RAIface,
-			"delegated_from", mapping.Interface)
+			pfx := &config.RAPrefix{
+				Prefix:     subPrefix.String(),
+				OnLink:     true,
+				Autonomous: true,
+			}
+			if mapping.ValidLifetime > 0 {
+				pfx.ValidLifetime = int(mapping.ValidLifetime.Seconds())
+			}
+			if mapping.PreferredLifetime > 0 {
+				pfx.PreferredLife = int(mapping.PreferredLifetime.Seconds())
+			}
+
+			if existing, ok := raByIface[mapping.RAIface]; ok {
+				// Append prefix to existing RA interface config.
+				existing.Prefixes = append(existing.Prefixes, pfx)
+			} else {
+				// Create a new RA interface config for this downstream interface.
+				ra := &config.RAInterfaceConfig{
+					Interface: mapping.RAIface,
+					Prefixes:  []*config.RAPrefix{pfx},
+				}
+				raByIface[mapping.RAIface] = ra
+				result = append(result, ra)
+			}
+
+			slog.Info("DHCPv6 PD: advertising prefix via RA",
+				"prefix", subPrefix, "interface", mapping.RAIface,
+				"delegated_from", mapping.Interface)
+		}
 	}
 
 	// Detect explicitly configured link-local addresses on RA interfaces.
@@ -2253,6 +2250,15 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 						break
 					}
 				}
+			}
+			if ra.SourceLinkLocal == "" && cfg.Chassis.Cluster != nil && ifc.RedundancyGroup != 0 {
+				// RETH HA startup installs a stable router link-local on the active
+				// member. Bind RA to that address so the sender does not auto-pick a
+				// transient EUI-64 link-local which can later be removed by HA reconcile.
+				ra.SourceLinkLocal = cluster.StableRethLinkLocal(
+					cfg.Chassis.Cluster.ClusterID,
+					ifc.RedundancyGroup,
+				).String()
 			}
 		}
 	}

--- a/pkg/daemon/ra_source_test.go
+++ b/pkg/daemon/ra_source_test.go
@@ -74,3 +74,63 @@ func TestBuildRAConfigsPrefersExplicitLinkLocal(t *testing.T) {
 		t.Fatalf("SourceLinkLocal = %q, want fe80::face", ras[0].SourceLinkLocal)
 	}
 }
+
+func TestBuildRAConfigsDoesNotMutateConfiguredRAEntries(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{
+			Cluster: &config.ClusterConfig{ClusterID: 22},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 2,
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"2001:559:8585:ef00::1/64"}},
+					},
+				},
+				"ge-0/0/1": {
+					Name:            "ge-0/0/1",
+					RedundantParent: "reth1",
+				},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{
+					Interface:  "reth1",
+					DNSServers: []string{"2001:4860:4860::8888"},
+					Prefixes: []*config.RAPrefix{
+						{Prefix: "2001:559:8585:ef00::/64", OnLink: true, Autonomous: true},
+					},
+				},
+			},
+		},
+	}
+
+	ras := d.buildRAConfigs(cfg)
+	if len(ras) != 1 {
+		t.Fatalf("buildRAConfigs returned %d RAs, want 1", len(ras))
+	}
+	if ras[0].Interface != "ge-0-0-1" {
+		t.Fatalf("returned Interface = %q, want ge-0-0-1", ras[0].Interface)
+	}
+	if ras[0].SourceLinkLocal == "" {
+		t.Fatal("returned SourceLinkLocal is empty, want stable fallback")
+	}
+
+	gotCfg := cfg.Protocols.RouterAdvertisement[0]
+	if gotCfg.Interface != "reth1" {
+		t.Fatalf("configured Interface mutated to %q, want reth1", gotCfg.Interface)
+	}
+	if gotCfg.SourceLinkLocal != "" {
+		t.Fatalf("configured SourceLinkLocal mutated to %q, want empty", gotCfg.SourceLinkLocal)
+	}
+	if len(gotCfg.Prefixes) != 1 || gotCfg.Prefixes[0].Prefix != "2001:559:8585:ef00::/64" {
+		t.Fatalf("configured prefixes mutated to %#v", gotCfg.Prefixes)
+	}
+	if len(gotCfg.DNSServers) != 1 || gotCfg.DNSServers[0] != "2001:4860:4860::8888" {
+		t.Fatalf("configured DNSServers mutated to %#v", gotCfg.DNSServers)
+	}
+}

--- a/pkg/daemon/ra_source_test.go
+++ b/pkg/daemon/ra_source_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/bpfrx/pkg/cluster"
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+func TestBuildRAConfigsUsesStableRethLinkLocal(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{
+			Cluster: &config.ClusterConfig{ClusterID: 22},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 2,
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"2001:559:8585:ef00::1/64"}},
+					},
+				},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "reth1"},
+			},
+		},
+	}
+
+	ras := d.buildRAConfigs(cfg)
+	if len(ras) != 1 {
+		t.Fatalf("buildRAConfigs returned %d RAs, want 1", len(ras))
+	}
+
+	wantLL := cluster.StableRethLinkLocal(22, 2).String()
+	if ras[0].SourceLinkLocal != wantLL {
+		t.Fatalf("SourceLinkLocal = %q, want %q", ras[0].SourceLinkLocal, wantLL)
+	}
+}
+
+func TestBuildRAConfigsPrefersExplicitLinkLocal(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{
+			Cluster: &config.ClusterConfig{ClusterID: 22},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 2,
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"fe80::face/64", "2001:559:8585:ef00::1/64"}},
+					},
+				},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "reth1"},
+			},
+		},
+	}
+
+	ras := d.buildRAConfigs(cfg)
+	if len(ras) != 1 {
+		t.Fatalf("buildRAConfigs returned %d RAs, want 1", len(ras))
+	}
+	if ras[0].SourceLinkLocal != "fe80::face" {
+		t.Fatalf("SourceLinkLocal = %q, want fe80::face", ras[0].SourceLinkLocal)
+	}
+}


### PR DESCRIPTION
## Summary
- bind RA senders on HA RETH interfaces to the stable router link-local when no explicit RA source link-local is configured
- keep explicit configured link-local addresses taking precedence
- stop skipping RA source-link-local selection for static RA configs when DHCP-PD is not in use
- add daemon tests for both the stable-link-local and explicit-link-local cases

## Problem
On the `loss` userspace HA cluster, IPv6 could degrade after deploy even though policy/config looked unchanged. The active node logged repeated RA send failures like:

```
ra: failed to send RA ... fe80::bf:72ff:fe16:200%ge-0-0-1->ff02::1%ge-0-0-1: sendmsg: invalid argument
```

The root cause was that the RA sender auto-selected a transient EUI-64 link-local, while HA reconcile had already removed that address and installed the stable router link-local on the active RETH member. The sender then kept trying to transmit from an address the interface no longer owned.

## Validation
- `go test ./pkg/daemon -run 'TestBuildRAConfigsUsesStableRethLinkLocal|TestBuildRAConfigsPrefersExplicitLinkLocal|TestSelectClusterBindAddr|TestSelectClusterBindAddrSkipsLinkLocalIPv6Fallback' -count=1`
- `go test ./pkg/daemon -count=1`
- live deploy to `loss:bpfrx-userspace-fw0/1`
- post-deploy `show ipv6 router-advertisement` on `fw0` now reports source `fe80::bf72:16:2%ge-0-0-1`
- no new `ra: failed to send RA` warnings after deploy
- `cluster-userspace-host` recovered IPv6 default route via `fe80::bf72:16:2` and successful IPv6 ping to `2607:f8b0:4005:814::200e`
