### PR TITLE
test/incus: keep isolated LAN IPv6 off the host parent

### DIFF
--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -123,7 +123,13 @@ suppress_host_parent_ipv6_ra() {
 		"net.ipv6.conf.${parent}.accept_ra=0" \
 		"net.ipv6.conf.${parent}.autoconf=0" \
 		"net.ipv6.conf.${parent}.router_solicitations=0"
-	run_on_host sudo ip -6 addr flush dev "$parent" scope global dynamic || true
+	if ! run_on_host sudo ip -6 addr flush dev "$parent" scope global dynamic; then
+		warn "targeted IPv6 dynamic address flush failed on host parent $parent; falling back to broader global-address flush"
+		run_on_host sudo ip -6 addr flush dev "$parent" scope global ||
+			die "failed to clear learned IPv6 global addresses from host parent $parent"
+	fi
+	run_on_host sudo ip -6 route flush dev "$parent" proto ra ||
+		die "failed to clear RA-learned IPv6 routes from host parent $parent"
 }
 
 # Prefix instance name with remote if set: "loss:bpfrx-fw0" or "bpfrx-fw0"

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -100,6 +100,32 @@ die()   { echo "ERROR: $*" >&2; exit 1; }
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
+run_on_host() {
+	if [[ -n "${INCUS_REMOTE:-}" ]]; then
+		ssh "$INCUS_REMOTE" "$@"
+	else
+		"$@"
+	fi
+}
+
+suppress_host_parent_ipv6_ra() {
+	local parent="$1"
+
+	if [[ -z "$parent" ]]; then
+		return
+	fi
+
+	# The host-side SR-IOV LAN parent should never learn the isolated LAN
+	# prefix itself. If it accepts RAs, host traffic to the test LAN bypasses
+	# the firewall and tries to resolve the destination directly on-link.
+	info "Disabling IPv6 RA/autoconf on host parent $parent..."
+	run_on_host sudo sysctl -qw \
+		"net.ipv6.conf.${parent}.accept_ra=0" \
+		"net.ipv6.conf.${parent}.autoconf=0" \
+		"net.ipv6.conf.${parent}.router_solicitations=0"
+	run_on_host sudo ip -6 addr flush dev "$parent" scope global dynamic || true
+}
+
 # Prefix instance name with remote if set: "loss:bpfrx-fw0" or "bpfrx-fw0"
 r() {
 	echo "${INCUS_REMOTE:+${INCUS_REMOTE}:}$1"
@@ -212,6 +238,10 @@ devices:
 # ── Instance Management ──────────────────────────────────────────────
 
 cmd_create() {
+	if [[ -n "${SRIOV_LAN_PARENT:-}" ]]; then
+		suppress_host_parent_ipv6_ra "$SRIOV_LAN_PARENT"
+	fi
+
 	# Create both VMs
 	for idx in 0 1; do
 		create_vm "$idx"
@@ -502,6 +532,10 @@ cmd_destroy() {
 
 cmd_deploy() {
 	local target="${1:-all}"
+
+	if [[ -n "${SRIOV_LAN_PARENT:-}" ]]; then
+		suppress_host_parent_ipv6_ra "$SRIOV_LAN_PARENT"
+	fi
 
 	info "Building bpfrxd and cli..."
 	make -C "$PROJECT_ROOT" build build-ctl


### PR DESCRIPTION
## Summary
- disable IPv6 RA/autoconf on the host-side SR-IOV LAN parent before create/deploy
- flush any dynamic global IPv6 addresses learned on that parent
- prevent the host from installing an on-link route to the isolated LAN and bypassing the firewall

## Validation
- `bash -n test/incus/cluster-setup.sh`
- on `loss`, before the fix: `ip -6 route get 2001:559:8585:ef00:1266:6aff:fe0b:d017` resolved to `dev mlx1` and `ping -6` returned `Destination unreachable: Address unreachable`
- applied the runtime equivalent on `loss`: disabled `accept_ra`/`autoconf` on `mlx1` and flushed dynamic global IPv6 state
- after the fix on `loss`, the same route resolves via `fe80::100 dev ix0` and `ping -6 -c 5 2001:559:8585:ef00:1266:6aff:fe0b:d017` succeeds
