### PR TITLE
monitor: merge userspace XSK traffic into interface view

### DIFF
--- a/pkg/monitoriface/monitor.go
+++ b/pkg/monitoriface/monitor.go
@@ -96,7 +96,22 @@ type UserspaceSnapshot struct {
 	RecentExceptions                  []string
 }
 
-func mergedTrafficCounters(snap *Snapshot) trafficCounters {
+func hasUserspaceTrafficSource(snap *UserspaceSnapshot) bool {
+	if snap == nil {
+		return false
+	}
+	return snap.Bindings > 0 ||
+		snap.ReadyBindings > 0 ||
+		snap.BoundBindings > 0 ||
+		snap.XSKRegistered > 0 ||
+		snap.ZeroCopyBindings > 0 ||
+		snap.RxPackets > 0 ||
+		snap.RxBytes > 0 ||
+		snap.TxPackets > 0 ||
+		snap.TxBytes > 0
+}
+
+func displayTrafficCounters(snap *Snapshot) trafficCounters {
 	if snap == nil {
 		return trafficCounters{}
 	}
@@ -106,16 +121,32 @@ func mergedTrafficCounters(snap *Snapshot) trafficCounters {
 		rxPkts:  snap.RxPkts,
 		txPkts:  snap.TxPkts,
 	}
-	if snap.Userspace == nil {
+	if !hasUserspaceTrafficSource(snap.Userspace) {
 		return counters
 	}
-	// Userspace/XSK forwarding bypasses the normal per-interface BPF pipeline, so
-	// monitor output needs both sources to reflect actual interface traffic.
-	counters.rxBytes += snap.Userspace.RxBytes
+	// Userspace/XSK forwarding bypasses the normal egress accounting path, so
+	// monitor output needs helper TX counters merged into interface totals.
 	counters.txBytes += snap.Userspace.TxBytes
-	counters.rxPkts += snap.Userspace.RxPackets
 	counters.txPkts += snap.Userspace.TxPackets
 	return counters
+}
+
+func snapshotTrafficDeltas(curr, prev *Snapshot) (rxPktsDelta, txPktsDelta, rxBytesDelta, txBytesDelta uint64) {
+	if curr == nil || prev == nil {
+		return 0, 0, 0, 0
+	}
+
+	rxPktsDelta = deltaU64(curr.RxPkts, prev.RxPkts)
+	txPktsDelta = deltaU64(curr.TxPkts, prev.TxPkts)
+	rxBytesDelta = deltaU64(curr.RxBytes, prev.RxBytes)
+	txBytesDelta = deltaU64(curr.TxBytes, prev.TxBytes)
+
+	if hasUserspaceTrafficSource(curr.Userspace) && hasUserspaceTrafficSource(prev.Userspace) {
+		txPktsDelta += deltaU64(curr.Userspace.TxPackets, prev.Userspace.TxPackets)
+		txBytesDelta += deltaU64(curr.Userspace.TxBytes, prev.Userspace.TxBytes)
+	}
+
+	return rxPktsDelta, txPktsDelta, rxBytesDelta, txBytesDelta
 }
 
 func ResolvePhysicalParent(name string) string {
@@ -511,27 +542,21 @@ func RenderSingleInterface(w io.Writer, hostname, displayName, kernelName string
 	if prev != nil {
 		dt := snap.Timestamp.Sub(prev.Timestamp).Seconds()
 		if dt > 0 {
-			currCounters := mergedTrafficCounters(snap)
-			prevCounters := mergedTrafficCounters(prev)
-			rxBps = uint64(float64(deltaU64(currCounters.rxBytes, prevCounters.rxBytes)) * 8 / dt)
-			txBps = uint64(float64(deltaU64(currCounters.txBytes, prevCounters.txBytes)) * 8 / dt)
-			rxPps = uint64(float64(deltaU64(currCounters.rxPkts, prevCounters.rxPkts)) / dt)
-			txPps = uint64(float64(deltaU64(currCounters.txPkts, prevCounters.txPkts)) / dt)
+			rxPktsDelta, txPktsDelta, rxBytesDeltaStep, txBytesDeltaStep := snapshotTrafficDeltas(snap, prev)
+			rxBps = uint64(float64(rxBytesDeltaStep) * 8 / dt)
+			txBps = uint64(float64(txBytesDeltaStep) * 8 / dt)
+			rxPps = uint64(float64(rxPktsDelta) / dt)
+			txPps = uint64(float64(txPktsDelta) / dt)
 		}
 	}
 
 	var rxBytesDelta, txBytesDelta, rxPktsDelta, txPktsDelta uint64
 	if baseline != nil {
-		currCounters := mergedTrafficCounters(snap)
-		baseCounters := mergedTrafficCounters(baseline)
-		rxBytesDelta = deltaU64(currCounters.rxBytes, baseCounters.rxBytes)
-		txBytesDelta = deltaU64(currCounters.txBytes, baseCounters.txBytes)
-		rxPktsDelta = deltaU64(currCounters.rxPkts, baseCounters.rxPkts)
-		txPktsDelta = deltaU64(currCounters.txPkts, baseCounters.txPkts)
+		rxPktsDelta, txPktsDelta, rxBytesDelta, txBytesDelta = snapshotTrafficDeltas(snap, baseline)
 	}
-	currCounters := mergedTrafficCounters(snap)
+	currCounters := displayTrafficCounters(snap)
 
-	fmt.Fprintf(w, "Traffic statistics (merged interface + userspace XSK): Current delta\n")
+	fmt.Fprintf(w, "Traffic statistics (interface counters + userspace XSK TX): Current delta\n")
 	fmt.Fprintf(w, "  Input  bytes:         %20d (%d bps)    [%d]\n", currCounters.rxBytes, rxBps, rxBytesDelta)
 	fmt.Fprintf(w, "  Output bytes:         %20d (%d bps)    [%d]\n", currCounters.txBytes, txBps, txBytesDelta)
 	fmt.Fprintf(w, "  Input  packets:       %20d (%d pps)    [%d]\n", currCounters.rxPkts, rxPps, rxPktsDelta)
@@ -736,10 +761,7 @@ func RenderTrafficSummary(w io.Writer, hostname string, names []string, kernelNa
 			}
 			var rxDelta, txDelta uint64
 			if prev := prevSnaps[name]; prev != nil {
-				currCounters := mergedTrafficCounters(snap)
-				prevCounters := mergedTrafficCounters(prev)
-				rxDelta = deltaU64(currCounters.rxPkts, prevCounters.rxPkts)
-				txDelta = deltaU64(currCounters.txPkts, prevCounters.txPkts)
+				rxDelta, txDelta, _, _ = snapshotTrafficDeltas(snap, prev)
 			}
 			totalRxDelta += rxDelta
 			totalTxDelta += txDelta
@@ -828,12 +850,11 @@ func snapshotRates(curr, prev *Snapshot) (rxPps, txPps, rxBytesPerSec, txBytesPe
 	if dt <= 0 {
 		return 0, 0, 0, 0
 	}
-	currCounters := mergedTrafficCounters(curr)
-	prevCounters := mergedTrafficCounters(prev)
-	return uint64(float64(deltaU64(currCounters.rxPkts, prevCounters.rxPkts)) / dt),
-		uint64(float64(deltaU64(currCounters.txPkts, prevCounters.txPkts)) / dt),
-		uint64(float64(deltaU64(currCounters.rxBytes, prevCounters.rxBytes)) / dt),
-		uint64(float64(deltaU64(currCounters.txBytes, prevCounters.txBytes)) / dt)
+	rxPktsDelta, txPktsDelta, rxBytesDelta, txBytesDelta := snapshotTrafficDeltas(curr, prev)
+	return uint64(float64(rxPktsDelta) / dt),
+		uint64(float64(txPktsDelta) / dt),
+		uint64(float64(rxBytesDelta) / dt),
+		uint64(float64(txBytesDelta) / dt)
 }
 
 func deltaU64(curr, prev uint64) uint64 {

--- a/pkg/monitoriface/monitor.go
+++ b/pkg/monitoriface/monitor.go
@@ -43,6 +43,13 @@ type Snapshot struct {
 	Timestamp          time.Time
 }
 
+type trafficCounters struct {
+	rxBytes uint64
+	txBytes uint64
+	rxPkts  uint64
+	txPkts  uint64
+}
+
 type UserspaceSnapshot struct {
 	StatusNote                        string
 	HelperEnabled                     bool
@@ -87,6 +94,28 @@ type UserspaceSnapshot struct {
 	SlowPathForwardBuildPackets       uint64
 	LastErrors                        []string
 	RecentExceptions                  []string
+}
+
+func mergedTrafficCounters(snap *Snapshot) trafficCounters {
+	if snap == nil {
+		return trafficCounters{}
+	}
+	counters := trafficCounters{
+		rxBytes: snap.RxBytes,
+		txBytes: snap.TxBytes,
+		rxPkts:  snap.RxPkts,
+		txPkts:  snap.TxPkts,
+	}
+	if snap.Userspace == nil {
+		return counters
+	}
+	// Userspace/XSK forwarding bypasses the normal per-interface BPF pipeline, so
+	// monitor output needs both sources to reflect actual interface traffic.
+	counters.rxBytes += snap.Userspace.RxBytes
+	counters.txBytes += snap.Userspace.TxBytes
+	counters.rxPkts += snap.Userspace.RxPackets
+	counters.txPkts += snap.Userspace.TxPackets
+	return counters
 }
 
 func ResolvePhysicalParent(name string) string {
@@ -482,26 +511,31 @@ func RenderSingleInterface(w io.Writer, hostname, displayName, kernelName string
 	if prev != nil {
 		dt := snap.Timestamp.Sub(prev.Timestamp).Seconds()
 		if dt > 0 {
-			rxBps = uint64(float64(deltaU64(snap.RxBytes, prev.RxBytes)) * 8 / dt)
-			txBps = uint64(float64(deltaU64(snap.TxBytes, prev.TxBytes)) * 8 / dt)
-			rxPps = uint64(float64(deltaU64(snap.RxPkts, prev.RxPkts)) / dt)
-			txPps = uint64(float64(deltaU64(snap.TxPkts, prev.TxPkts)) / dt)
+			currCounters := mergedTrafficCounters(snap)
+			prevCounters := mergedTrafficCounters(prev)
+			rxBps = uint64(float64(deltaU64(currCounters.rxBytes, prevCounters.rxBytes)) * 8 / dt)
+			txBps = uint64(float64(deltaU64(currCounters.txBytes, prevCounters.txBytes)) * 8 / dt)
+			rxPps = uint64(float64(deltaU64(currCounters.rxPkts, prevCounters.rxPkts)) / dt)
+			txPps = uint64(float64(deltaU64(currCounters.txPkts, prevCounters.txPkts)) / dt)
 		}
 	}
 
 	var rxBytesDelta, txBytesDelta, rxPktsDelta, txPktsDelta uint64
 	if baseline != nil {
-		rxBytesDelta = deltaU64(snap.RxBytes, baseline.RxBytes)
-		txBytesDelta = deltaU64(snap.TxBytes, baseline.TxBytes)
-		rxPktsDelta = deltaU64(snap.RxPkts, baseline.RxPkts)
-		txPktsDelta = deltaU64(snap.TxPkts, baseline.TxPkts)
+		currCounters := mergedTrafficCounters(snap)
+		baseCounters := mergedTrafficCounters(baseline)
+		rxBytesDelta = deltaU64(currCounters.rxBytes, baseCounters.rxBytes)
+		txBytesDelta = deltaU64(currCounters.txBytes, baseCounters.txBytes)
+		rxPktsDelta = deltaU64(currCounters.rxPkts, baseCounters.rxPkts)
+		txPktsDelta = deltaU64(currCounters.txPkts, baseCounters.txPkts)
 	}
+	currCounters := mergedTrafficCounters(snap)
 
-	fmt.Fprintf(w, "Traffic statistics:                                Current delta\n")
-	fmt.Fprintf(w, "  Input  bytes:         %20d (%d bps)    [%d]\n", snap.RxBytes, rxBps, rxBytesDelta)
-	fmt.Fprintf(w, "  Output bytes:         %20d (%d bps)    [%d]\n", snap.TxBytes, txBps, txBytesDelta)
-	fmt.Fprintf(w, "  Input  packets:       %20d (%d pps)    [%d]\n", snap.RxPkts, rxPps, rxPktsDelta)
-	fmt.Fprintf(w, "  Output packets:       %20d (%d pps)    [%d]\n", snap.TxPkts, txPps, txPktsDelta)
+	fmt.Fprintf(w, "Traffic statistics (merged interface + userspace XSK): Current delta\n")
+	fmt.Fprintf(w, "  Input  bytes:         %20d (%d bps)    [%d]\n", currCounters.rxBytes, rxBps, rxBytesDelta)
+	fmt.Fprintf(w, "  Output bytes:         %20d (%d bps)    [%d]\n", currCounters.txBytes, txBps, txBytesDelta)
+	fmt.Fprintf(w, "  Input  packets:       %20d (%d pps)    [%d]\n", currCounters.rxPkts, rxPps, rxPktsDelta)
+	fmt.Fprintf(w, "  Output packets:       %20d (%d pps)    [%d]\n", currCounters.txPkts, txPps, txPktsDelta)
 	fmt.Fprintf(w, "\n")
 
 	var rxErrDelta, txErrDelta, rxDropDelta, txDropDelta, rxFrameDelta, txCarrierDelta, colDelta uint64
@@ -702,8 +736,10 @@ func RenderTrafficSummary(w io.Writer, hostname string, names []string, kernelNa
 			}
 			var rxDelta, txDelta uint64
 			if prev := prevSnaps[name]; prev != nil {
-				rxDelta = deltaU64(snap.RxPkts, prev.RxPkts)
-				txDelta = deltaU64(snap.TxPkts, prev.TxPkts)
+				currCounters := mergedTrafficCounters(snap)
+				prevCounters := mergedTrafficCounters(prev)
+				rxDelta = deltaU64(currCounters.rxPkts, prevCounters.rxPkts)
+				txDelta = deltaU64(currCounters.txPkts, prevCounters.txPkts)
 			}
 			totalRxDelta += rxDelta
 			totalTxDelta += txDelta
@@ -792,10 +828,12 @@ func snapshotRates(curr, prev *Snapshot) (rxPps, txPps, rxBytesPerSec, txBytesPe
 	if dt <= 0 {
 		return 0, 0, 0, 0
 	}
-	return uint64(float64(deltaU64(curr.RxPkts, prev.RxPkts)) / dt),
-		uint64(float64(deltaU64(curr.TxPkts, prev.TxPkts)) / dt),
-		uint64(float64(deltaU64(curr.RxBytes, prev.RxBytes)) / dt),
-		uint64(float64(deltaU64(curr.TxBytes, prev.TxBytes)) / dt)
+	currCounters := mergedTrafficCounters(curr)
+	prevCounters := mergedTrafficCounters(prev)
+	return uint64(float64(deltaU64(currCounters.rxPkts, prevCounters.rxPkts)) / dt),
+		uint64(float64(deltaU64(currCounters.txPkts, prevCounters.txPkts)) / dt),
+		uint64(float64(deltaU64(currCounters.rxBytes, prevCounters.rxBytes)) / dt),
+		uint64(float64(deltaU64(currCounters.txBytes, prevCounters.txBytes)) / dt)
 }
 
 func deltaU64(curr, prev uint64) uint64 {

--- a/pkg/monitoriface/monitor_test.go
+++ b/pkg/monitoriface/monitor_test.go
@@ -95,7 +95,7 @@ func TestRenderTrafficSummaryCombinedIncludesTotals(t *testing.T) {
 	}
 }
 
-func TestMergedTrafficCountersIncludeUserspaceXSK(t *testing.T) {
+func TestDisplayTrafficCountersIncludeUserspaceXSKTxOnly(t *testing.T) {
 	snap := &Snapshot{
 		RxBytes: 1000,
 		TxBytes: 2000,
@@ -109,9 +109,9 @@ func TestMergedTrafficCountersIncludeUserspaceXSK(t *testing.T) {
 		},
 	}
 
-	counters := mergedTrafficCounters(snap)
-	if counters.rxBytes != 4000 || counters.txBytes != 6000 || counters.rxPkts != 40 || counters.txPkts != 60 {
-		t.Fatalf("mergedTrafficCounters() = %+v, want rxBytes=4000 txBytes=6000 rxPkts=40 txPkts=60", counters)
+	counters := displayTrafficCounters(snap)
+	if counters.rxBytes != 1000 || counters.txBytes != 6000 || counters.rxPkts != 10 || counters.txPkts != 60 {
+		t.Fatalf("displayTrafficCounters() = %+v, want rxBytes=1000 txBytes=6000 rxPkts=10 txPkts=60", counters)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestSnapshotRatesCounterResetReturnsZero(t *testing.T) {
 	}
 }
 
-func TestSnapshotRatesIncludeUserspaceXSKCounters(t *testing.T) {
+func TestSnapshotRatesIncludeUserspaceXSKTxOnly(t *testing.T) {
 	now := time.Now()
 	rxPps, txPps, rxBps, txBps := snapshotRates(&Snapshot{
 		RxBytes:   1000,
@@ -162,12 +162,38 @@ func TestSnapshotRatesIncludeUserspaceXSKCounters(t *testing.T) {
 			TxPackets: 7,
 		},
 	})
-	if rxPps != 20 || txPps != 38 || rxBps != 2000 || txBps != 3800 {
-		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want 20/38/2000/3800", rxPps, txPps, rxBps, txBps)
+	if rxPps != 6 || txPps != 38 || rxBps != 600 || txBps != 3800 {
+		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want 6/38/600/3800", rxPps, txPps, rxBps, txBps)
 	}
 }
 
-func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTotals(t *testing.T) {
+func TestSnapshotRatesPreserveInterfaceDeltaWhenUserspaceDisappears(t *testing.T) {
+	now := time.Now()
+	rxPps, txPps, rxBps, txBps := snapshotRates(&Snapshot{
+		RxBytes:   2000,
+		TxBytes:   3000,
+		RxPkts:    20,
+		TxPkts:    30,
+		Timestamp: now,
+		Userspace: &UserspaceSnapshot{StatusNote: "userspace status unavailable"},
+	}, &Snapshot{
+		RxBytes:   1000,
+		TxBytes:   1500,
+		RxPkts:    10,
+		TxPkts:    15,
+		Timestamp: now.Add(-1 * time.Second),
+		Userspace: &UserspaceSnapshot{
+			TxBytes:   9000,
+			TxPackets: 90,
+			Bindings:  1,
+		},
+	})
+	if rxPps != 10 || txPps != 15 || rxBps != 1000 || txBps != 1500 {
+		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want interface-only 10/15/1000/1500 when userspace disappears", rxPps, txPps, rxBps, txBps)
+	}
+}
+
+func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTxTotals(t *testing.T) {
 	now := time.Now()
 	names := []string{"wan0"}
 	kernelNames := map[string]string{"wan0": "wan0"}
@@ -206,15 +232,15 @@ func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTotals(t *testing.T) {
 	RenderTrafficSummary(&buf, "bpfrx", names, kernelNames, snaps, prev, SummaryModeCombined, now.Add(-5*time.Second))
 	out := buf.String()
 	for _, needle := range []string{
-		"2.50 MB/s",
+		"500.00 KB/s",
 		"3.50 MB/s",
-		"6.00 MB/s",
-		"2.50K",
+		"4.00 MB/s",
+		"500.00",
 		"3.50K",
-		"6.00K",
+		"4.00K",
 	} {
 		if !strings.Contains(out, needle) {
-			t.Fatalf("combined summary missing merged userspace traffic %q\n%s", needle, out)
+			t.Fatalf("combined summary missing merged userspace TX traffic %q\n%s", needle, out)
 		}
 	}
 }

--- a/pkg/monitoriface/monitor_test.go
+++ b/pkg/monitoriface/monitor_test.go
@@ -95,6 +95,26 @@ func TestRenderTrafficSummaryCombinedIncludesTotals(t *testing.T) {
 	}
 }
 
+func TestMergedTrafficCountersIncludeUserspaceXSK(t *testing.T) {
+	snap := &Snapshot{
+		RxBytes: 1000,
+		TxBytes: 2000,
+		RxPkts:  10,
+		TxPkts:  20,
+		Userspace: &UserspaceSnapshot{
+			RxBytes:   3000,
+			TxBytes:   4000,
+			RxPackets: 30,
+			TxPackets: 40,
+		},
+	}
+
+	counters := mergedTrafficCounters(snap)
+	if counters.rxBytes != 4000 || counters.txBytes != 6000 || counters.rxPkts != 40 || counters.txPkts != 60 {
+		t.Fatalf("mergedTrafficCounters() = %+v, want rxBytes=4000 txBytes=6000 rxPkts=40 txPkts=60", counters)
+	}
+}
+
 func TestSnapshotRatesCounterResetReturnsZero(t *testing.T) {
 	now := time.Now()
 	rxPps, txPps, rxBps, txBps := snapshotRates(&Snapshot{
@@ -112,6 +132,90 @@ func TestSnapshotRatesCounterResetReturnsZero(t *testing.T) {
 	})
 	if rxPps != 0 || txPps != 0 || rxBps != 0 || txBps != 0 {
 		t.Fatalf("snapshotRates should clamp counter resets to zero, got rxPps=%d txPps=%d rxBps=%d txBps=%d", rxPps, txPps, rxBps, txBps)
+	}
+}
+
+func TestSnapshotRatesIncludeUserspaceXSKCounters(t *testing.T) {
+	now := time.Now()
+	rxPps, txPps, rxBps, txBps := snapshotRates(&Snapshot{
+		RxBytes:   1000,
+		TxBytes:   2000,
+		RxPkts:    10,
+		TxPkts:    20,
+		Timestamp: now,
+		Userspace: &UserspaceSnapshot{
+			RxBytes:   2000,
+			TxBytes:   3000,
+			RxPackets: 20,
+			TxPackets: 30,
+		},
+	}, &Snapshot{
+		RxBytes:   400,
+		TxBytes:   500,
+		RxPkts:    4,
+		TxPkts:    5,
+		Timestamp: now.Add(-1 * time.Second),
+		Userspace: &UserspaceSnapshot{
+			RxBytes:   600,
+			TxBytes:   700,
+			RxPackets: 6,
+			TxPackets: 7,
+		},
+	})
+	if rxPps != 20 || txPps != 38 || rxBps != 2000 || txBps != 3800 {
+		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want 20/38/2000/3800", rxPps, txPps, rxBps, txBps)
+	}
+}
+
+func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTotals(t *testing.T) {
+	now := time.Now()
+	names := []string{"wan0"}
+	kernelNames := map[string]string{"wan0": "wan0"}
+	snaps := map[string]*Snapshot{
+		"wan0": {
+			RxBytes:   1_000_000,
+			TxBytes:   2_000_000,
+			RxPkts:    1_000,
+			TxPkts:    2_000,
+			Timestamp: now,
+			Userspace: &UserspaceSnapshot{
+				RxBytes:   4_000_000,
+				TxBytes:   5_000_000,
+				RxPackets: 4_000,
+				TxPackets: 5_000,
+			},
+		},
+	}
+	prev := map[string]*Snapshot{
+		"wan0": {
+			RxBytes:   500_000,
+			TxBytes:   1_000_000,
+			RxPkts:    500,
+			TxPkts:    1_000,
+			Timestamp: now.Add(-1 * time.Second),
+			Userspace: &UserspaceSnapshot{
+				RxBytes:   2_000_000,
+				TxBytes:   2_500_000,
+				RxPackets: 2_000,
+				TxPackets: 2_500,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderTrafficSummary(&buf, "bpfrx", names, kernelNames, snaps, prev, SummaryModeCombined, now.Add(-5*time.Second))
+	out := buf.String()
+	for _, needle := range []string{
+		"2.50 MB/s",
+		"3.50 MB/s",
+		"6.00 MB/s",
+		"2.50K",
+		"3.50K",
+		"6.00K",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("combined summary missing merged userspace traffic %q\n%s", needle, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- merge userspace/XSK RX/TX counters into monitor interface traffic totals and rates
- keep kernel/interface error stats separate
- add monitor regression coverage for merged summary and rate calculations

## Why
`monitor interface traffic` was rendering from interface counters only. On the userspace dataplane that misses the XSK/helper path, so 10Gbps of forwarded traffic could look mostly idle.

## Validation
- `go test ./pkg/monitoriface ./pkg/cli -count=1`
