### PR TITLE
cli: fix command help and completion prefix handling

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -323,8 +323,10 @@ func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 		candidates = cc.cli.completeConfigWithDesc(words, partial)
 	} else {
 		// "show configuration <path>" — delegate sub-path to config schema
-		if len(words) >= 2 && words[0] == "show" && words[1] == "configuration" {
-			subPath := words[2:]
+		if subPath, ok := showConfigurationSubPath(words); ok {
+			if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(subPath); resolved {
+				subPath = resolvedPath
+			}
 			schemaCompletions := config.CompleteSetPathWithValues(subPath, cc.cli.valueProvider)
 			if schemaCompletions != nil {
 				for _, sc := range schemaCompletions {
@@ -367,18 +369,24 @@ func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 
 func (c *CLI) completeConfigWithDesc(words []string, partial string) []completionCandidate {
 	if len(words) == 0 {
-		var candidates []completionCandidate
-		for name, node := range configTopLevel {
-			if strings.HasPrefix(name, partial) {
-				candidates = append(candidates, completionCandidate{name: name, desc: node.Desc})
-			}
-		}
-		return candidates
+		return filterTreeCandidates(configTopLevel, partial)
 	}
 
-	switch words[0] {
+	resolvedTop, ok := resolveUniqueTreePrefix(configTopLevel, words[0])
+	if !ok {
+		if len(words) == 1 {
+			return filterTreeCandidates(configTopLevel, words[0])
+		}
+		return nil
+	}
+
+	switch resolvedTop {
 	case "set", "delete", "show", "edit":
-		schemaCompletions := config.CompleteSetPathWithValues(words[1:], c.valueProvider)
+		pathWords := words[1:]
+		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(pathWords); resolved {
+			pathWords = resolvedPath
+		}
+		schemaCompletions := config.CompleteSetPathWithValues(pathWords, c.valueProvider)
 		if schemaCompletions == nil {
 			return nil
 		}
@@ -395,7 +403,7 @@ func (c *CLI) completeConfigWithDesc(words []string, partial string) []completio
 
 	case "commit", "load":
 		if len(words) == 1 {
-			node := configTopLevel[words[0]]
+			node := configTopLevel[resolvedTop]
 			if node == nil || node.Children == nil {
 				return nil
 			}
@@ -509,8 +517,10 @@ func (c *CLI) Run() error {
 				candidates = c.completeConfigWithDesc(words, partial)
 			} else {
 				// "show configuration <path>" — delegate sub-path to config schema
-				if len(words) >= 2 && words[0] == "show" && words[1] == "configuration" {
-					subPath := words[2:]
+				if subPath, ok := showConfigurationSubPath(words); ok {
+					if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(subPath); resolved {
+						subPath = resolvedPath
+					}
 					schemaCompletions := config.CompleteSetPathWithValues(subPath, c.valueProvider)
 					if schemaCompletions != nil {
 						for _, sc := range schemaCompletions {

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -65,6 +65,39 @@ func treeHelpCandidates(tree map[string]*completionNode) []completionCandidate {
 	return candidates
 }
 
+func filterTreeCandidates(tree map[string]*completionNode, prefix string) []completionCandidate {
+	candidates := make([]completionCandidate, 0, len(tree))
+	for name, node := range tree {
+		if prefix == "" || strings.HasPrefix(name, prefix) {
+			candidates = append(candidates, completionCandidate{name: name, desc: node.Desc})
+		}
+	}
+	return candidates
+}
+
+func resolveUniqueTreePrefix(tree map[string]*completionNode, input string) (string, bool) {
+	return cmdtree.ResolveUniquePrefix(keysFromTree(tree), input)
+}
+
+func showConfigurationSubPath(words []string) ([]string, bool) {
+	if len(words) < 2 {
+		return nil, false
+	}
+	show, ok := resolveUniqueTreePrefix(operationalTree, words[0])
+	if !ok || show != "show" {
+		return nil, false
+	}
+	showNode := operationalTree[show]
+	if showNode == nil || showNode.Children == nil {
+		return nil, false
+	}
+	conf, ok := resolveUniqueTreePrefix(showNode.Children, words[1])
+	if !ok || conf != "configuration" {
+		return nil, false
+	}
+	return words[2:], true
+}
+
 // commonPrefix returns the longest shared prefix among the given strings.
 func commonPrefix(items []string) string {
 	return cmdtree.CommonPrefix(items)

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -924,6 +924,32 @@ func findPlaceholder(tree map[string]*Node) *Node {
 	return nil
 }
 
+// ResolveUniquePrefix returns the exact item, or a uniquely matching prefix.
+func ResolveUniquePrefix(items []string, input string) (string, bool) {
+	for _, item := range items {
+		if item == input {
+			return item, true
+		}
+	}
+	matches := FilterPrefix(items, input)
+	if len(matches) != 1 {
+		return "", false
+	}
+	return matches[0], true
+}
+
+func resolveTreeWord(tree map[string]*Node, word string) (string, *Node, []string, bool) {
+	if node, ok := tree[word]; ok {
+		return word, node, nil, true
+	}
+	matches := FilterPrefix(KeysOf(tree), word)
+	if len(matches) == 1 {
+		name := matches[0]
+		return name, tree[name], matches, true
+	}
+	return "", nil, matches, false
+}
+
 // CompleteFromTree walks the tree to find completion candidates for the given words and partial.
 func CompleteFromTree(tree map[string]*Node, words []string, partial string, cfg *config.Config) []string {
 	current := tree
@@ -931,7 +957,7 @@ func CompleteFromTree(tree map[string]*Node, words []string, partial string, cfg
 	dynamicConsumed := false
 	for wi, w := range words {
 		dynamicConsumed = false
-		node, ok := current[w]
+		_, node, matches, ok := resolveTreeWord(current, w)
 		if !ok {
 			if currentNode != nil && currentNode.HasDynamic() {
 				dynamicConsumed = true
@@ -950,6 +976,9 @@ func CompleteFromTree(tree map[string]*Node, words []string, partial string, cfg
 				}
 				dynamicConsumed = true
 				continue
+			}
+			if wi == len(words)-1 && len(matches) > 0 {
+				return matches
 			}
 			return nil
 		}
@@ -980,7 +1009,7 @@ func CompleteFromTreeWithDesc(tree map[string]*Node, words []string, partial str
 	dynamicConsumed := false
 	for wi, w := range words {
 		dynamicConsumed = false
-		node, ok := current[w]
+		_, node, matches, ok := resolveTreeWord(current, w)
 		if !ok {
 			if currentNode != nil && currentNode.HasDynamic() {
 				dynamicConsumed = true
@@ -994,6 +1023,13 @@ func CompleteFromTreeWithDesc(tree map[string]*Node, words []string, partial str
 				}
 				dynamicConsumed = true
 				continue
+			}
+			if wi == len(words)-1 && len(matches) > 0 {
+				var candidates []Candidate
+				for _, name := range matches {
+					candidates = append(candidates, Candidate{Name: name, Desc: current[name].Desc})
+				}
+				return candidates
 			}
 			return nil
 		}
@@ -1044,12 +1080,16 @@ func LookupDesc(words []string, name string, configMode bool) string {
 			}
 			return ""
 		}
-		if words[0] == "run" {
+		resolvedTop, ok := ResolveUniquePrefix(KeysFromTree(ConfigTopLevel), words[0])
+		if !ok {
+			return ""
+		}
+		if resolvedTop == "run" {
 			tree = OperationalTree
 			words = words[1:]
 		} else {
 			// Walk config top-level children (e.g. "commit" → "check")
-			node, ok := ConfigTopLevel[words[0]]
+			node, ok := ConfigTopLevel[resolvedTop]
 			if !ok {
 				return ""
 			}
@@ -1057,7 +1097,7 @@ func LookupDesc(words []string, name string, configMode bool) string {
 				if node.Children == nil {
 					return ""
 				}
-				node, ok = node.Children[w]
+				_, node, _, ok = resolveTreeWord(node.Children, w)
 				if !ok {
 					return ""
 				}
@@ -1077,7 +1117,7 @@ func LookupDesc(words []string, name string, configMode bool) string {
 	current := tree
 	var currentNode *Node
 	for _, w := range words {
-		node, ok := current[w]
+		_, node, _, ok := resolveTreeWord(current, w)
 		if !ok {
 			// Dynamic value — skip but stay at same children level.
 			if currentNode != nil && currentNode.HasDynamic() {

--- a/pkg/cmdtree/tree_test.go
+++ b/pkg/cmdtree/tree_test.go
@@ -69,3 +69,29 @@ func TestCompleteFromTree_ShowRouteTableDynamicNames(t *testing.T) {
 		t.Fatalf("expected per-instance table names, got %v", cands)
 	}
 }
+
+func TestCompleteFromTree_UniquePrefixWordsDescend(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"sh", "sec"}, "", nil)
+	if !contains(cands, "flow") || !contains(cands, "nat") {
+		t.Fatalf("expected security subtree completions after unique prefixes, got %v", cands)
+	}
+}
+
+func TestCompleteFromTree_AmbiguousLastConsumedPrefixReturnsMatches(t *testing.T) {
+	cands := CompleteFromTree(OperationalTree, []string{"show", "s"}, "", nil)
+	if !contains(cands, "security") || !contains(cands, "services") || !contains(cands, "system") {
+		t.Fatalf("expected ambiguous show subtree matches, got %v", cands)
+	}
+}
+
+func TestLookupDesc_ResolvesUniquePrefixWords(t *testing.T) {
+	if got := LookupDesc([]string{"show", "sec"}, "flow", false); got != "Show security flow information" {
+		t.Fatalf("LookupDesc() = %q, want %q", got, "Show security flow information")
+	}
+}
+
+func TestLookupDesc_ConfigModeResolvesUniquePrefixWords(t *testing.T) {
+	if got := LookupDesc([]string{"com"}, "confirmed", true); got != "Automatically rollback if not confirmed" {
+		t.Fatalf("LookupDesc() = %q, want %q", got, "Automatically rollback if not confirmed")
+	}
+}

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1599,9 +1599,27 @@ func CompleteSetPathWithValues(tokens []string, provider ValueProvider) []Schema
 
 		// Look up keyword in current schema level.
 		var childSchema *schemaNode
+		resolvedKeyword := keyword
 		if schema.children != nil {
 			if s, ok := schema.children[keyword]; ok {
 				childSchema = s
+			} else {
+				var matches []string
+				for name := range schema.children {
+					if strings.HasPrefix(name, keyword) {
+						matches = append(matches, name)
+					}
+				}
+				if len(matches) == 1 && i < len(tokens)-1 {
+					resolvedKeyword = matches[0]
+					childSchema = schema.children[resolvedKeyword]
+				} else if len(matches) > 0 && i == len(tokens)-1 {
+					var completions []SchemaCompletion
+					for _, name := range matches {
+						completions = append(completions, SchemaCompletion{Name: name, Desc: schema.children[name].desc})
+					}
+					return completions
+				}
 			}
 		}
 		if childSchema == nil && schema.wildcard != nil {
@@ -1629,7 +1647,10 @@ func CompleteSetPathWithValues(tokens []string, provider ValueProvider) []Schema
 		if end > len(tokens) {
 			end = len(tokens)
 		}
-		path = append(path, tokens[i:end]...)
+		path = append(path, resolvedKeyword)
+		if end-i > 1 {
+			path = append(path, tokens[i+1:end]...)
+		}
 		i += nodeKeyCount
 
 		// Compound key: consume child token as part of key.
@@ -1715,4 +1736,86 @@ func CompleteSetPathWithValues(tokens []string, provider ValueProvider) []Schema
 		return nil
 	}
 	return completions
+}
+
+// ResolveConsumedSetPathTokens expands uniquely matching keyword prefixes in a
+// token list that is already known to contain only consumed words, not the
+// current partial token being completed.
+func ResolveConsumedSetPathTokens(tokens []string) ([]string, bool) {
+	schema := setSchema
+	i := 0
+	var resolved []string
+
+	for i < len(tokens) {
+		if schema == nil {
+			return nil, false
+		}
+
+		keyword := tokens[i]
+		resolvedKeyword := keyword
+		var childSchema *schemaNode
+		if schema.children != nil {
+			if s, ok := schema.children[keyword]; ok {
+				childSchema = s
+			} else {
+				var matches []string
+				for name := range schema.children {
+					if strings.HasPrefix(name, keyword) {
+						matches = append(matches, name)
+					}
+				}
+				if len(matches) != 1 {
+					return nil, false
+				}
+				resolvedKeyword = matches[0]
+				childSchema = schema.children[resolvedKeyword]
+			}
+		}
+		if childSchema == nil && schema.wildcard != nil {
+			childSchema = schema.wildcard
+		}
+		if childSchema == nil {
+			return nil, false
+		}
+
+		resolved = append(resolved, resolvedKeyword)
+		nodeKeyCount := 1 + childSchema.args
+		end := i + nodeKeyCount
+		if end > len(tokens) {
+			return resolved, true
+		}
+		if end-i > 1 {
+			resolved = append(resolved, tokens[i+1:end]...)
+		}
+		i += nodeKeyCount
+
+		if childSchema.compoundKey && i < len(tokens) {
+			subKeyword := tokens[i]
+			if sub, ok := childSchema.children[subKeyword]; ok {
+				resolved = append(resolved, subKeyword)
+				i++
+				childSchema = sub
+			} else {
+				var matches []string
+				for name := range childSchema.children {
+					if strings.HasPrefix(name, subKeyword) {
+						matches = append(matches, name)
+					}
+				}
+				if len(matches) != 1 {
+					return nil, false
+				}
+				resolved = append(resolved, matches[0])
+				i++
+				childSchema = childSchema.children[matches[0]]
+			}
+		}
+
+		if childSchema.multi && childSchema.children == nil {
+			continue
+		}
+		schema = childSchema
+	}
+
+	return resolved, true
 }

--- a/pkg/config/completion_prefix_test.go
+++ b/pkg/config/completion_prefix_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+func completionNames(results []SchemaCompletion) []string {
+	names := make([]string, len(results))
+	for i, result := range results {
+		names[i] = result.Name
+	}
+	return names
+}
+
+func containsCompletionName(results []SchemaCompletion, want string) bool {
+	for _, result := range results {
+		if result.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestResolveConsumedSetPathTokensResolvesPrefixes(t *testing.T) {
+	resolved, ok := ResolveConsumedSetPathTokens([]string{"secu", "na", "sou"})
+	if !ok {
+		t.Fatal("ResolveConsumedSetPathTokens() returned false")
+	}
+	results := CompleteSetPathWithValues(resolved, nil)
+	if !containsCompletionName(results, "pool") || !containsCompletionName(results, "rule-set") {
+		t.Fatalf("expected source NAT subtree completions after consumed prefixes, got %v", completionNames(results))
+	}
+}
+
+func TestCompleteSetPathWithValuesReturnsAmbiguousLastPrefixMatches(t *testing.T) {
+	results := CompleteSetPathWithValues([]string{"security", "s"}, nil)
+	if !containsCompletionName(results, "screen") || !containsCompletionName(results, "ssh-known-hosts") {
+		t.Fatalf("expected ambiguous security subtree matches, got %v", completionNames(results))
+	}
+}

--- a/pkg/grpcapi/completion_test.go
+++ b/pkg/grpcapi/completion_test.go
@@ -14,15 +14,39 @@ func hasPairName(pairs []completionPair, want string) bool {
 func TestCompleteConfigPairsCommitReturnsAllMatches(t *testing.T) {
 	s := &Server{}
 	pairs := s.completeConfigPairs([]string{"commit"}, "")
-	if !hasPairName(pairs, "check") || !hasPairName(pairs, "confirmed") {
-		t.Fatalf("expected both commit completions, got %#v", pairs)
+	if !hasPairName(pairs, "check") || !hasPairName(pairs, "confirmed") || !hasPairName(pairs, "comment") {
+		t.Fatalf("expected all commit completions, got %#v", pairs)
 	}
 }
 
 func TestCompleteConfigPairsLoadReturnsAllMatches(t *testing.T) {
 	s := &Server{}
 	pairs := s.completeConfigPairs([]string{"load"}, "")
-	if !hasPairName(pairs, "override") || !hasPairName(pairs, "merge") {
-		t.Fatalf("expected both load completions, got %#v", pairs)
+	if !hasPairName(pairs, "override") || !hasPairName(pairs, "merge") || !hasPairName(pairs, "set") {
+		t.Fatalf("expected all load completions, got %#v", pairs)
+	}
+}
+
+func TestCompleteOperationalPairsShowConfigurationResolvesPrefixes(t *testing.T) {
+	s := &Server{}
+	pairs := s.completeOperationalPairs([]string{"show", "conf", "sec"}, "po")
+	if !hasPairName(pairs, "policies") {
+		t.Fatalf("expected policies completion for prefixed show configuration path, got %#v", pairs)
+	}
+}
+
+func TestCompleteConfigPairsUniquePrefixDescends(t *testing.T) {
+	s := &Server{}
+	pairs := s.completeConfigPairs([]string{"com"}, "")
+	if !hasPairName(pairs, "check") || !hasPairName(pairs, "confirmed") || !hasPairName(pairs, "comment") {
+		t.Fatalf("expected commit subtree completions after unique prefix, got %#v", pairs)
+	}
+}
+
+func TestCompleteConfigPairsAmbiguousPrefixReturnsMatches(t *testing.T) {
+	s := &Server{}
+	pairs := s.completeConfigPairs([]string{"co"}, "")
+	if !hasPairName(pairs, "commit") || !hasPairName(pairs, "copy") {
+		t.Fatalf("expected ambiguous top-level config matches, got %#v", pairs)
 	}
 }

--- a/pkg/grpcapi/completion_test.go
+++ b/pkg/grpcapi/completion_test.go
@@ -50,3 +50,8 @@ func TestCompleteConfigPairsAmbiguousPrefixReturnsMatches(t *testing.T) {
 		t.Fatalf("expected ambiguous top-level config matches, got %#v", pairs)
 	}
 }
+
+func TestCompleteConfigPairsDynamicPathWithoutStoreDoesNotPanic(t *testing.T) {
+	s := &Server{}
+	_ = s.completeConfigPairs([]string{"set", "security", "policies", "from-zone"}, "")
+}

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -508,13 +508,20 @@ func resolveShowConfigurationWords(words []string) ([]string, bool) {
 	return words[2:], true
 }
 
+func (s *Server) completionValueProvider() config.ValueProvider {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	return s.valueProvider
+}
+
 func (s *Server) completeOperationalPairs(words []string, partial string) []completionPair {
 	// "show configuration <path>" — delegate sub-path to config schema
 	if subPath, ok := resolveShowConfigurationWords(words); ok {
 		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(subPath); resolved {
 			subPath = resolvedPath
 		}
-		schemaCompletions := config.CompleteSetPathWithValues(subPath, s.valueProvider)
+		schemaCompletions := config.CompleteSetPathWithValues(subPath, s.completionValueProvider())
 		if schemaCompletions != nil {
 			var pairs []completionPair
 			for _, sc := range schemaCompletions {
@@ -558,7 +565,7 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(pathWords); resolved {
 			pathWords = resolvedPath
 		}
-		schemaCompletions := config.CompleteSetPathWithValues(pathWords, s.valueProvider)
+		schemaCompletions := config.CompleteSetPathWithValues(pathWords, s.completionValueProvider())
 		if schemaCompletions == nil {
 			return nil
 		}
@@ -601,6 +608,9 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 }
 
 func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.SchemaCompletion {
+	if s == nil || s.store == nil {
+		return nil
+	}
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
 		return nil

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -479,10 +479,41 @@ func (s *Server) completePipeFilter(text string) []string {
 	return candidates
 }
 
+func filterCompletionPairs(tree map[string]*cmdtree.Node, prefix string) []completionPair {
+	pairs := make([]completionPair, 0, len(tree))
+	for name, node := range tree {
+		if prefix == "" || strings.HasPrefix(name, prefix) {
+			pairs = append(pairs, completionPair{name: name, desc: node.Desc})
+		}
+	}
+	return pairs
+}
+
+func resolveShowConfigurationWords(words []string) ([]string, bool) {
+	if len(words) < 2 {
+		return nil, false
+	}
+	show, ok := cmdtree.ResolveUniquePrefix(cmdtree.KeysFromTree(cmdtree.OperationalTree), words[0])
+	if !ok || show != "show" {
+		return nil, false
+	}
+	showNode := cmdtree.OperationalTree[show]
+	if showNode == nil || showNode.Children == nil {
+		return nil, false
+	}
+	conf, ok := cmdtree.ResolveUniquePrefix(cmdtree.KeysFromTree(showNode.Children), words[1])
+	if !ok || conf != "configuration" {
+		return nil, false
+	}
+	return words[2:], true
+}
+
 func (s *Server) completeOperationalPairs(words []string, partial string) []completionPair {
 	// "show configuration <path>" — delegate sub-path to config schema
-	if len(words) >= 2 && words[0] == "show" && words[1] == "configuration" {
-		subPath := words[2:]
+	if subPath, ok := resolveShowConfigurationWords(words); ok {
+		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(subPath); resolved {
+			subPath = resolvedPath
+		}
 		schemaCompletions := config.CompleteSetPathWithValues(subPath, s.valueProvider)
 		if schemaCompletions != nil {
 			var pairs []completionPair
@@ -496,7 +527,10 @@ func (s *Server) completeOperationalPairs(words []string, partial string) []comp
 			}
 		}
 	}
-	cfg := s.store.ActiveConfig()
+	var cfg *config.Config
+	if s.store != nil {
+		cfg = s.store.ActiveConfig()
+	}
 	candidates := cmdtree.CompleteFromTreeWithDesc(cmdtree.OperationalTree, words, partial, cfg)
 	pairs := make([]completionPair, len(candidates))
 	for i, c := range candidates {
@@ -507,18 +541,24 @@ func (s *Server) completeOperationalPairs(words []string, partial string) []comp
 
 func (s *Server) completeConfigPairs(words []string, partial string) []completionPair {
 	if len(words) == 0 {
-		var pairs []completionPair
-		for name, node := range cmdtree.ConfigTopLevel {
-			if strings.HasPrefix(name, partial) {
-				pairs = append(pairs, completionPair{name: name, desc: node.Desc})
-			}
-		}
-		return pairs
+		return filterCompletionPairs(cmdtree.ConfigTopLevel, partial)
 	}
 
-	switch words[0] {
+	resolvedTop, ok := cmdtree.ResolveUniquePrefix(cmdtree.KeysFromTree(cmdtree.ConfigTopLevel), words[0])
+	if !ok {
+		if len(words) == 1 {
+			return filterCompletionPairs(cmdtree.ConfigTopLevel, words[0])
+		}
+		return nil
+	}
+
+	switch resolvedTop {
 	case "set", "delete", "show", "edit":
-		schemaCompletions := config.CompleteSetPathWithValues(words[1:], s.valueProvider)
+		pathWords := words[1:]
+		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(pathWords); resolved {
+			pathWords = resolvedPath
+		}
+		schemaCompletions := config.CompleteSetPathWithValues(pathWords, s.valueProvider)
 		if schemaCompletions == nil {
 			return nil
 		}
@@ -530,27 +570,27 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 		}
 		return pairs
 	case "run":
-		cfg := s.store.ActiveConfig()
+		var cfg *config.Config
+		if s.store != nil {
+			cfg = s.store.ActiveConfig()
+		}
 		names := cmdtree.CompleteFromTree(cmdtree.OperationalTree, words[1:], partial, cfg)
 		var pairs []completionPair
 		for _, name := range names {
 			pairs = append(pairs, completionPair{name: name})
 		}
 		return pairs
-	case "commit":
+	case "commit", "load":
 		if len(words) == 1 {
-			var pairs []completionPair
-			for _, name := range cmdtree.FilterPrefix([]string{"check", "confirmed"}, partial) {
-				pairs = append(pairs, completionPair{name: name})
+			node := cmdtree.ConfigTopLevel[resolvedTop]
+			if node == nil || node.Children == nil {
+				return nil
 			}
-			return pairs
-		}
-		return nil
-	case "load":
-		if len(words) == 1 {
 			var pairs []completionPair
-			for _, name := range cmdtree.FilterPrefix([]string{"override", "merge"}, partial) {
-				pairs = append(pairs, completionPair{name: name})
+			for name, child := range node.Children {
+				if strings.HasPrefix(name, partial) {
+					pairs = append(pairs, completionPair{name: name, desc: child.Desc})
+				}
 			}
 			return pairs
 		}


### PR DESCRIPTION
## Summary
- make command-tree completion and help resolve unique prefixes in already-typed words instead of requiring exact parent tokens
- normalize consumed config-path prefixes before schema completion so `show configuration` and config-mode completions work after abbreviated parents
- remove the stale hardcoded gRPC config completion lists so `commit comment` and `load set` show up again

## Validation
- go test ./pkg/cmdtree ./pkg/config ./pkg/grpcapi ./pkg/cli ./cmd/cli -count=1