### PR TITLE
monitor: include userspace ingress in interface traffic

### DIFF
--- a/pkg/monitoriface/monitor.go
+++ b/pkg/monitoriface/monitor.go
@@ -124,9 +124,12 @@ func displayTrafficCounters(snap *Snapshot) trafficCounters {
 	if !hasUserspaceTrafficSource(snap.Userspace) {
 		return counters
 	}
-	// Userspace/XSK forwarding bypasses the normal egress accounting path, so
-	// monitor output needs helper TX counters merged into interface totals.
+	// Userspace/XSK forwarding is accounted in the helper bindings rather than
+	// the kernel/BPF interface snapshots that back monitor output, so fold both
+	// directions into the displayed totals.
+	counters.rxBytes += snap.Userspace.RxBytes
 	counters.txBytes += snap.Userspace.TxBytes
+	counters.rxPkts += snap.Userspace.RxPackets
 	counters.txPkts += snap.Userspace.TxPackets
 	return counters
 }
@@ -142,7 +145,9 @@ func snapshotTrafficDeltas(curr, prev *Snapshot) (rxPktsDelta, txPktsDelta, rxBy
 	txBytesDelta = deltaU64(curr.TxBytes, prev.TxBytes)
 
 	if hasUserspaceTrafficSource(curr.Userspace) && hasUserspaceTrafficSource(prev.Userspace) {
+		rxPktsDelta += deltaU64(curr.Userspace.RxPackets, prev.Userspace.RxPackets)
 		txPktsDelta += deltaU64(curr.Userspace.TxPackets, prev.Userspace.TxPackets)
+		rxBytesDelta += deltaU64(curr.Userspace.RxBytes, prev.Userspace.RxBytes)
 		txBytesDelta += deltaU64(curr.Userspace.TxBytes, prev.Userspace.TxBytes)
 	}
 
@@ -556,7 +561,7 @@ func RenderSingleInterface(w io.Writer, hostname, displayName, kernelName string
 	}
 	currCounters := displayTrafficCounters(snap)
 
-	fmt.Fprintf(w, "Traffic statistics (interface counters + userspace XSK TX): Current delta\n")
+	fmt.Fprintf(w, "Traffic statistics (interface counters + userspace XSK traffic): Current delta\n")
 	fmt.Fprintf(w, "  Input  bytes:         %20d (%d bps)    [%d]\n", currCounters.rxBytes, rxBps, rxBytesDelta)
 	fmt.Fprintf(w, "  Output bytes:         %20d (%d bps)    [%d]\n", currCounters.txBytes, txBps, txBytesDelta)
 	fmt.Fprintf(w, "  Input  packets:       %20d (%d pps)    [%d]\n", currCounters.rxPkts, rxPps, rxPktsDelta)

--- a/pkg/monitoriface/monitor_test.go
+++ b/pkg/monitoriface/monitor_test.go
@@ -95,7 +95,7 @@ func TestRenderTrafficSummaryCombinedIncludesTotals(t *testing.T) {
 	}
 }
 
-func TestDisplayTrafficCountersIncludeUserspaceXSKTxOnly(t *testing.T) {
+func TestDisplayTrafficCountersIncludeUserspaceXSKTraffic(t *testing.T) {
 	snap := &Snapshot{
 		RxBytes: 1000,
 		TxBytes: 2000,
@@ -110,8 +110,8 @@ func TestDisplayTrafficCountersIncludeUserspaceXSKTxOnly(t *testing.T) {
 	}
 
 	counters := displayTrafficCounters(snap)
-	if counters.rxBytes != 1000 || counters.txBytes != 6000 || counters.rxPkts != 10 || counters.txPkts != 60 {
-		t.Fatalf("displayTrafficCounters() = %+v, want rxBytes=1000 txBytes=6000 rxPkts=10 txPkts=60", counters)
+	if counters.rxBytes != 4000 || counters.txBytes != 6000 || counters.rxPkts != 40 || counters.txPkts != 60 {
+		t.Fatalf("displayTrafficCounters() = %+v, want rxBytes=4000 txBytes=6000 rxPkts=40 txPkts=60", counters)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestSnapshotRatesCounterResetReturnsZero(t *testing.T) {
 	}
 }
 
-func TestSnapshotRatesIncludeUserspaceXSKTxOnly(t *testing.T) {
+func TestSnapshotRatesIncludeUserspaceXSKTraffic(t *testing.T) {
 	now := time.Now()
 	rxPps, txPps, rxBps, txBps := snapshotRates(&Snapshot{
 		RxBytes:   1000,
@@ -162,8 +162,8 @@ func TestSnapshotRatesIncludeUserspaceXSKTxOnly(t *testing.T) {
 			TxPackets: 7,
 		},
 	})
-	if rxPps != 6 || txPps != 38 || rxBps != 600 || txBps != 3800 {
-		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want 6/38/600/3800", rxPps, txPps, rxBps, txBps)
+	if rxPps != 20 || txPps != 38 || rxBps != 2000 || txBps != 3800 {
+		t.Fatalf("snapshotRates() = rxPps=%d txPps=%d rxBps=%d txBps=%d, want 20/38/2000/3800", rxPps, txPps, rxBps, txBps)
 	}
 }
 
@@ -193,7 +193,7 @@ func TestSnapshotRatesPreserveInterfaceDeltaWhenUserspaceDisappears(t *testing.T
 	}
 }
 
-func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTxTotals(t *testing.T) {
+func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTotals(t *testing.T) {
 	now := time.Now()
 	names := []string{"wan0"}
 	kernelNames := map[string]string{"wan0": "wan0"}
@@ -232,15 +232,72 @@ func TestRenderTrafficSummaryCombinedIncludesUserspaceXSKTxTotals(t *testing.T) 
 	RenderTrafficSummary(&buf, "bpfrx", names, kernelNames, snaps, prev, SummaryModeCombined, now.Add(-5*time.Second))
 	out := buf.String()
 	for _, needle := range []string{
-		"500.00 KB/s",
+		"2.50 MB/s",
 		"3.50 MB/s",
-		"4.00 MB/s",
-		"500.00",
+		"6.00 MB/s",
+		"2.50K",
 		"3.50K",
-		"4.00K",
+		"6.00K",
 	} {
 		if !strings.Contains(out, needle) {
-			t.Fatalf("combined summary missing merged userspace TX traffic %q\n%s", needle, out)
+			t.Fatalf("combined summary missing merged userspace traffic %q\n%s", needle, out)
+		}
+	}
+}
+
+func TestRenderTrafficSummaryCombinedShowsIngressAndEgressUserspaceRows(t *testing.T) {
+	now := time.Now()
+	names := []string{"reth0", "reth1"}
+	kernelNames := map[string]string{
+		"reth0": "ge-0-0-2",
+		"reth1": "ge-0-0-1",
+	}
+	snaps := map[string]*Snapshot{
+		"reth0": {
+			Timestamp: now,
+			Userspace: &UserspaceSnapshot{
+				TxBytes:   8_000_000,
+				TxPackets: 8_000,
+			},
+		},
+		"reth1": {
+			Timestamp: now,
+			Userspace: &UserspaceSnapshot{
+				RxBytes:   8_000_000,
+				RxPackets: 8_000,
+			},
+		},
+	}
+	prev := map[string]*Snapshot{
+		"reth0": {
+			Timestamp: now.Add(-1 * time.Second),
+			Userspace: &UserspaceSnapshot{
+				TxBytes:   3_000_000,
+				TxPackets: 3_000,
+			},
+		},
+		"reth1": {
+			Timestamp: now.Add(-1 * time.Second),
+			Userspace: &UserspaceSnapshot{
+				RxBytes:   3_000_000,
+				RxPackets: 3_000,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderTrafficSummary(&buf, "bpfrx", names, kernelNames, snaps, prev, SummaryModeCombined, now.Add(-5*time.Second))
+	out := buf.String()
+	for _, needle := range []string{
+		"reth0:",
+		"reth1:",
+		"5.00 MB/s",
+		"5.00K",
+		"10.00 MB/s",
+		"10.00K",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("combined summary missing ingress/egress userspace row data %q\n%s", needle, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- merge userspace RX as well as TX into monitor interface traffic counters
- keep per-interface delta/rate calculations aligned with the merged userspace view
- add regressions for ingress-only and egress-only userspace rows

## Validation
- go test ./pkg/monitoriface ./pkg/cli -count=1

## Root cause
Live userspace binding stats on `loss:bpfrx-userspace-fw0` showed `ge-0-0-1` carrying the ingress side and `ge-0-0-2` carrying the egress side, while the monitor summary only folded in helper TX counters. The interface/BPF counters for those rows remained tiny, so `reth1` stayed near zero even though XSK RX was busy.
