### PR TITLE
services: tighten rpm probe config support

### DIFF
--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -6,9 +6,51 @@ import (
 	"strings"
 	"time"
 
+	"github.com/psaab/bpfrx/pkg/config"
 	"github.com/psaab/bpfrx/pkg/dhcp"
 	"github.com/psaab/bpfrx/pkg/dhcpserver"
 )
+
+func sortedRPMProbeNames(probes map[string]*config.RPMProbe) []string {
+	names := make([]string, 0, len(probes))
+	for name := range probes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedRPMTestNames(tests map[string]*config.RPMTest) []string {
+	names := make([]string, 0, len(tests))
+	for name := range tests {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func showRPMConfiguredProbe(probeName, testName string, test *config.RPMTest) {
+	fmt.Printf("  Probe: %s, Test: %s\n", probeName, testName)
+	fmt.Printf("    Type: %s, Target: %s\n", test.EffectiveProbeType(), test.Target)
+	if test.SourceAddress != "" {
+		fmt.Printf("    Source: %s\n", test.SourceAddress)
+	}
+	if test.RoutingInstance != "" {
+		fmt.Printf("    Routing instance: %s\n", test.RoutingInstance)
+	}
+	fmt.Printf("    Probe interval: %ds\n", test.EffectiveProbeInterval())
+	fmt.Printf("    Probe count: %d\n", test.EffectiveProbeCount())
+	fmt.Printf("    Test interval: %ds\n", test.EffectiveTestInterval())
+	fmt.Printf("    Successive loss threshold: %d\n", test.EffectiveSuccessiveLossThreshold())
+	if test.ProbeLimit > 0 {
+		fmt.Printf("    Probe limit: %d\n", test.ProbeLimit)
+	} else {
+		fmt.Println("    Probe limit: unlimited")
+	}
+	if test.EffectiveProbeType() == "tcp-ping" || test.DestPort > 0 {
+		fmt.Printf("    Destination port: %d\n", test.EffectiveDestinationPort())
+	}
+}
 
 func (c *CLI) showDHCPLeases() error {
 	if c.dhcp == nil {
@@ -241,16 +283,11 @@ func (c *CLI) showRPMProbeResults() error {
 	}
 
 	fmt.Println("RPM Probe Configuration:")
-	for probeName, probe := range cfg.Services.RPM.Probes {
-		for testName, test := range probe.Tests {
-			fmt.Printf("  Probe: %s, Test: %s\n", probeName, testName)
-			fmt.Printf("    Type: %s, Target: %s\n", test.ProbeType, test.Target)
-			if test.SourceAddress != "" {
-				fmt.Printf("    Source: %s\n", test.SourceAddress)
-			}
-			if test.RoutingInstance != "" {
-				fmt.Printf("    Routing instance: %s\n", test.RoutingInstance)
-			}
+	for _, probeName := range sortedRPMProbeNames(cfg.Services.RPM.Probes) {
+		probe := cfg.Services.RPM.Probes[probeName]
+		for _, testName := range sortedRPMTestNames(probe.Tests) {
+			showRPMConfiguredProbe(probeName, testName, probe.Tests[testName])
+			fmt.Println()
 		}
 	}
 	return nil

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -2,55 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/psaab/bpfrx/pkg/config"
 	"github.com/psaab/bpfrx/pkg/dhcp"
 	"github.com/psaab/bpfrx/pkg/dhcpserver"
+	"github.com/psaab/bpfrx/pkg/rpm"
 )
-
-func sortedRPMProbeNames(probes map[string]*config.RPMProbe) []string {
-	names := make([]string, 0, len(probes))
-	for name := range probes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
-func sortedRPMTestNames(tests map[string]*config.RPMTest) []string {
-	names := make([]string, 0, len(tests))
-	for name := range tests {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
-func showRPMConfiguredProbe(probeName, testName string, test *config.RPMTest) {
-	fmt.Printf("  Probe: %s, Test: %s\n", probeName, testName)
-	fmt.Printf("    Type: %s, Target: %s\n", test.EffectiveProbeType(), test.Target)
-	if test.SourceAddress != "" {
-		fmt.Printf("    Source: %s\n", test.SourceAddress)
-	}
-	if test.RoutingInstance != "" {
-		fmt.Printf("    Routing instance: %s\n", test.RoutingInstance)
-	}
-	fmt.Printf("    Probe interval: %ds\n", test.EffectiveProbeInterval())
-	fmt.Printf("    Probe count: %d\n", test.EffectiveProbeCount())
-	fmt.Printf("    Test interval: %ds\n", test.EffectiveTestInterval())
-	fmt.Printf("    Successive loss threshold: %d\n", test.EffectiveSuccessiveLossThreshold())
-	if test.ProbeLimit > 0 {
-		fmt.Printf("    Probe limit: %d\n", test.ProbeLimit)
-	} else {
-		fmt.Println("    Probe limit: unlimited")
-	}
-	if test.EffectiveProbeType() == "tcp-ping" || test.DestPort > 0 {
-		fmt.Printf("    Destination port: %d\n", test.EffectiveDestinationPort())
-	}
-}
 
 func (c *CLI) showDHCPLeases() error {
 	if c.dhcp == nil {
@@ -245,48 +205,50 @@ func (c *CLI) showRPMProbeResults() error {
 	// Show live results if RPM manager is available
 	if c.rpmResultsFn != nil {
 		results := c.rpmResultsFn()
-		if len(results) == 0 {
-			fmt.Println("No RPM probes configured")
+		if len(results) > 0 {
+			fmt.Println("RPM Probe Results:")
+			for _, r := range results {
+				fmt.Printf("  Probe: %s, Test: %s\n", r.ProbeName, r.TestName)
+				fmt.Printf("    Type: %s, Target: %s\n", r.ProbeType, r.Target)
+				fmt.Printf("    Status: %s", r.LastStatus)
+				if r.LastRTT > 0 {
+					fmt.Printf(", RTT: %s", r.LastRTT)
+				}
+				fmt.Println()
+				if r.MinRTT > 0 {
+					fmt.Printf("    RTT: min %s, max %s, avg %s, jitter %s\n",
+						r.MinRTT, r.MaxRTT, r.AvgRTT, r.Jitter)
+				}
+				fmt.Printf("    Sent: %d, Received: %d", r.TotalSent, r.TotalRecv)
+				if r.TotalSent > 0 {
+					loss := float64(r.TotalSent-r.TotalRecv) / float64(r.TotalSent) * 100
+					fmt.Printf(", Loss: %.1f%%", loss)
+				}
+				fmt.Println()
+				if !r.LastProbeAt.IsZero() {
+					fmt.Printf("    Last probe: %s\n", r.LastProbeAt.Format("2006-01-02 15:04:05"))
+				}
+			}
 			return nil
 		}
-		fmt.Println("RPM Probe Results:")
-		for _, r := range results {
-			fmt.Printf("  Probe: %s, Test: %s\n", r.ProbeName, r.TestName)
-			fmt.Printf("    Type: %s, Target: %s\n", r.ProbeType, r.Target)
-			fmt.Printf("    Status: %s", r.LastStatus)
-			if r.LastRTT > 0 {
-				fmt.Printf(", RTT: %s", r.LastRTT)
-			}
-			fmt.Println()
-			if r.MinRTT > 0 {
-				fmt.Printf("    RTT: min %s, max %s, avg %s, jitter %s\n",
-					r.MinRTT, r.MaxRTT, r.AvgRTT, r.Jitter)
-			}
-			fmt.Printf("    Sent: %d, Received: %d", r.TotalSent, r.TotalRecv)
-			if r.TotalSent > 0 {
-				loss := float64(r.TotalSent-r.TotalRecv) / float64(r.TotalSent) * 100
-				fmt.Printf(", Loss: %.1f%%", loss)
-			}
-			fmt.Println()
-			if !r.LastProbeAt.IsZero() {
-				fmt.Printf("    Last probe: %s\n", r.LastProbeAt.Format("2006-01-02 15:04:05"))
-			}
-		}
-		return nil
 	}
 
 	// Fallback: show config only
 	cfg := c.store.ActiveConfig()
-	if cfg == nil || cfg.Services.RPM == nil || len(cfg.Services.RPM.Probes) == 0 {
+	if cfg == nil {
+		fmt.Println("No active configuration")
+		return nil
+	}
+	if cfg.Services.RPM == nil || len(cfg.Services.RPM.Probes) == 0 {
 		fmt.Println("No RPM probes configured")
 		return nil
 	}
 
 	fmt.Println("RPM Probe Configuration:")
-	for _, probeName := range sortedRPMProbeNames(cfg.Services.RPM.Probes) {
+	for _, probeName := range rpm.SortedProbeNames(cfg.Services.RPM.Probes) {
 		probe := cfg.Services.RPM.Probes[probeName]
-		for _, testName := range sortedRPMTestNames(probe.Tests) {
-			showRPMConfiguredProbe(probeName, testName, probe.Tests[testName])
+		for _, testName := range rpm.SortedTestNames(probe.Tests) {
+			rpm.WriteConfiguredTest(os.Stdout, probeName, testName, probe.Tests[testName])
 			fmt.Println()
 		}
 	}

--- a/pkg/cli/cli_show_services_test.go
+++ b/pkg/cli/cli_show_services_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/bpfrx/pkg/configstore"
+	"github.com/psaab/bpfrx/pkg/rpm"
+)
+
+func TestShowRPMProbeResultsFallsBackToConfigWhenLiveResultsEmpty(t *testing.T) {
+	store := configstore.New(filepath.Join(t.TempDir(), "config.conf"))
+	_, err := store.SyncApply(`services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                target 8.8.8.8;
+            }
+        }
+    }
+}
+`, nil)
+	if err != nil {
+		t.Fatalf("SyncApply() error = %v", err)
+	}
+
+	c := &CLI{
+		store: store,
+		rpmResultsFn: func() []*rpm.ProbeResult {
+			return []*rpm.ProbeResult{}
+		},
+	}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.showRPMProbeResults()
+	})
+	if callErr != nil {
+		t.Fatalf("showRPMProbeResults() error = %v", callErr)
+	}
+	if !strings.Contains(out, "RPM Probe Configuration:") {
+		t.Fatalf("stdout = %q, want config fallback output", out)
+	}
+	if !strings.Contains(out, "Probe interval: 5s") {
+		t.Fatalf("stdout = %q, want effective defaults in fallback output", out)
+	}
+}
+
+func TestShowRPMProbeResultsReportsNoActiveConfiguration(t *testing.T) {
+	c := &CLI{
+		store: configstore.New(filepath.Join(t.TempDir(), "config.conf")),
+		rpmResultsFn: func() []*rpm.ProbeResult {
+			return []*rpm.ProbeResult{}
+		},
+	}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.showRPMProbeResults()
+	})
+	if callErr != nil {
+		t.Fatalf("showRPMProbeResults() error = %v", callErr)
+	}
+	if strings.TrimSpace(out) != "No active configuration" {
+		t.Fatalf("stdout = %q, want %q", out, "No active configuration\n")
+	}
+}

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1362,13 +1362,21 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		}},
 	}},
 	"services": {children: map[string]*schemaNode{
-		"rpm": {children: map[string]*schemaNode{
-			"probe": {args: 1, children: map[string]*schemaNode{
-				"test": {args: 1, children: map[string]*schemaNode{
-					"probe-limit": {args: 1, children: nil},
-					"target": {children: map[string]*schemaNode{
-						"url": {args: 1, children: nil},
+		"rpm": {desc: "Real-time Performance Monitoring probes", children: map[string]*schemaNode{
+			"probe": {args: 1, desc: "RPM probe name", children: map[string]*schemaNode{
+				"test": {args: 1, desc: "RPM test name", children: map[string]*schemaNode{
+					"probe-type":       {args: 1, desc: "Probe type: icmp-ping, tcp-ping, or http-get", children: nil},
+					"target":           {desc: "Target IP, hostname, or URL", wildcard: &schemaNode{placeholder: "<target>", desc: "Target IP, hostname, or URL"}, children: map[string]*schemaNode{"url": {args: 1, desc: "HTTP target URL", children: nil}}},
+					"source-address":   {args: 1, desc: "Source address for the probe", children: nil},
+					"routing-instance": {args: 1, desc: "Routing instance / VRF for the probe", children: nil},
+					"probe-interval":   {args: 1, desc: "Seconds between probes within a test", children: nil},
+					"probe-count":      {args: 1, desc: "Number of probes per test cycle", children: nil},
+					"test-interval":    {args: 1, desc: "Seconds between test cycles", children: nil},
+					"thresholds": {desc: "Failure thresholds for the test", children: map[string]*schemaNode{
+						"successive-loss": {args: 1, desc: "Consecutive losses before marking the test failed", children: nil},
 					}},
+					"probe-limit":      {args: 1, desc: "Maximum failed probes before stopping the current test cycle", children: nil},
+					"destination-port": {args: 1, desc: "Destination TCP port for tcp-ping probes", children: nil},
 				}},
 			}},
 		}},

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1375,7 +1375,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"thresholds": {desc: "Failure thresholds for the test", children: map[string]*schemaNode{
 						"successive-loss": {args: 1, desc: "Consecutive losses before marking the test failed", children: nil},
 					}},
-					"probe-limit":      {args: 1, desc: "Maximum failed probes before stopping the current test cycle", children: nil},
+					"probe-limit":      {args: 1, desc: "Maximum consecutive failed probes before stopping the current test cycle", children: nil},
 					"destination-port": {args: 1, desc: "Destination TCP port for tcp-ping probes", children: nil},
 				}},
 			}},

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -6,6 +6,39 @@ import (
 	"strings"
 )
 
+var supportedRPMProbeTypes = map[string]struct{}{
+	DefaultRPMProbeType: {},
+	"tcp-ping":          {},
+	"http-get":          {},
+}
+
+func parseRPMPositiveInt(probeName, testName, field, raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("services rpm probe %q test %q %s: invalid integer %q", probeName, testName, field, raw)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("services rpm probe %q test %q %s: must be > 0", probeName, testName, field)
+	}
+	return n, nil
+}
+
+func validateRPMTest(probeName string, test *RPMTest) error {
+	if test.Target == "" {
+		return fmt.Errorf("services rpm probe %q test %q: target is required", probeName, test.Name)
+	}
+	if _, ok := supportedRPMProbeTypes[test.EffectiveProbeType()]; !ok {
+		return fmt.Errorf(
+			"services rpm probe %q test %q: unsupported probe-type %q (want icmp-ping, tcp-ping, or http-get)",
+			probeName, test.Name, test.ProbeType,
+		)
+	}
+	if test.DestPort < 0 || test.DestPort > 65535 {
+		return fmt.Errorf("services rpm probe %q test %q destination-port: must be 1-65535", probeName, test.Name)
+	}
+	return nil
+}
+
 func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error {
 	lsc := &DHCPLocalServerConfig{
 		Groups: make(map[string]*DHCPServerGroup),
@@ -181,45 +214,61 @@ func compileRPM(node *Node, svc *ServicesConfig) error {
 					test.RoutingInstance = nodeVal(prop)
 				case "probe-interval":
 					if v := nodeVal(prop); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							test.ProbeInterval = n
+						n, err := parseRPMPositiveInt(probe.Name, test.Name, "probe-interval", v)
+						if err != nil {
+							return err
 						}
+						test.ProbeInterval = n
 					}
 				case "probe-count":
 					if v := nodeVal(prop); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							test.ProbeCount = n
+						n, err := parseRPMPositiveInt(probe.Name, test.Name, "probe-count", v)
+						if err != nil {
+							return err
 						}
+						test.ProbeCount = n
 					}
 				case "test-interval":
 					if v := nodeVal(prop); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							test.TestInterval = n
+						n, err := parseRPMPositiveInt(probe.Name, test.Name, "test-interval", v)
+						if err != nil {
+							return err
 						}
+						test.TestInterval = n
 					}
 				case "thresholds":
 					for _, th := range prop.Children {
 						if th.Name() == "successive-loss" {
 							if v := nodeVal(th); v != "" {
-								if n, err := strconv.Atoi(v); err == nil {
-									test.ThresholdSuccessive = n
+								n, err := parseRPMPositiveInt(probe.Name, test.Name, "thresholds successive-loss", v)
+								if err != nil {
+									return err
 								}
+								test.ThresholdSuccessive = n
 							}
 						}
 					}
 				case "probe-limit":
 					if v := nodeVal(prop); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							test.ProbeLimit = n
+						n, err := parseRPMPositiveInt(probe.Name, test.Name, "probe-limit", v)
+						if err != nil {
+							return err
 						}
+						test.ProbeLimit = n
 					}
 				case "destination-port":
 					if v := nodeVal(prop); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							test.DestPort = n
+						n, err := parseRPMPositiveInt(probe.Name, test.Name, "destination-port", v)
+						if err != nil {
+							return err
 						}
+						test.DestPort = n
 					}
 				}
+			}
+
+			if err := validateRPMTest(probe.Name, test); err != nil {
+				return err
 			}
 
 			probe.Tests[test.Name] = test

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -33,7 +33,7 @@ func validateRPMTest(probeName string, test *RPMTest) error {
 			probeName, test.Name, test.ProbeType,
 		)
 	}
-	if test.DestPort < 0 || test.DestPort > 65535 {
+	if test.DestPort > 65535 {
 		return fmt.Errorf("services rpm probe %q test %q destination-port: must be 1-65535", probeName, test.Name)
 	}
 	return nil

--- a/pkg/config/completion_prefix_test.go
+++ b/pkg/config/completion_prefix_test.go
@@ -36,3 +36,15 @@ func TestCompleteSetPathWithValuesReturnsAmbiguousLastPrefixMatches(t *testing.T
 		t.Fatalf("expected ambiguous security subtree matches, got %v", completionNames(results))
 	}
 }
+
+func TestCompleteSetPathWithValuesReturnsRPMProbeCompletions(t *testing.T) {
+	results := CompleteSetPathWithValues([]string{"services", "rpm", "probe", "monitor", "test", "ping-test"}, nil)
+	if !containsCompletionName(results, "probe-type") || !containsCompletionName(results, "target") || !containsCompletionName(results, "thresholds") {
+		t.Fatalf("expected RPM test subtree completions, got %v", completionNames(results))
+	}
+
+	targetResults := CompleteSetPathWithValues([]string{"services", "rpm", "probe", "monitor", "test", "ping-test", "target"}, nil)
+	if !containsCompletionName(targetResults, "url") || !containsCompletionName(targetResults, "<target>") {
+		t.Fatalf("expected RPM target completions, got %v", completionNames(targetResults))
+	}
+}

--- a/pkg/config/parser_services_test.go
+++ b/pkg/config/parser_services_test.go
@@ -5,6 +5,155 @@ import (
 	"testing"
 )
 
+func TestRPMDefaultsAndValidation(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		input := `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                target 8.8.8.8;
+            }
+            test tcp-test {
+                probe-type tcp-ping;
+                target 1.1.1.1;
+            }
+        }
+    }
+}
+`
+		parser := NewParser(input)
+		tree, errs := parser.Parse()
+		if len(errs) > 0 {
+			t.Fatalf("parse errors: %v", errs)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+
+		pingTest := cfg.Services.RPM.Probes["monitor"].Tests["ping-test"]
+		if got := pingTest.EffectiveProbeType(); got != DefaultRPMProbeType {
+			t.Fatalf("EffectiveProbeType() = %q, want %q", got, DefaultRPMProbeType)
+		}
+		if got := pingTest.EffectiveProbeInterval(); got != DefaultRPMProbeIntervalSeconds {
+			t.Fatalf("EffectiveProbeInterval() = %d, want %d", got, DefaultRPMProbeIntervalSeconds)
+		}
+		if got := pingTest.EffectiveProbeCount(); got != DefaultRPMProbeCount {
+			t.Fatalf("EffectiveProbeCount() = %d, want %d", got, DefaultRPMProbeCount)
+		}
+		if got := pingTest.EffectiveTestInterval(); got != DefaultRPMTestIntervalSeconds {
+			t.Fatalf("EffectiveTestInterval() = %d, want %d", got, DefaultRPMTestIntervalSeconds)
+		}
+		if got := pingTest.EffectiveSuccessiveLossThreshold(); got != DefaultRPMSuccessiveLosses {
+			t.Fatalf("EffectiveSuccessiveLossThreshold() = %d, want %d", got, DefaultRPMSuccessiveLosses)
+		}
+
+		tcpTest := cfg.Services.RPM.Probes["monitor"].Tests["tcp-test"]
+		if got := tcpTest.EffectiveDestinationPort(); got != DefaultRPMTCPDestinationPort {
+			t.Fatalf("EffectiveDestinationPort() = %d, want %d", got, DefaultRPMTCPDestinationPort)
+		}
+	})
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "missing target",
+			input: `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                probe-type icmp-ping;
+            }
+        }
+    }
+}
+`,
+			wantErr: "target is required",
+		},
+		{
+			name: "unsupported probe type",
+			input: `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                probe-type udp-ping;
+                target 8.8.8.8;
+            }
+        }
+    }
+}
+`,
+			wantErr: "unsupported probe-type",
+		},
+		{
+			name: "invalid numeric value",
+			input: `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                target 8.8.8.8;
+                probe-count nope;
+            }
+        }
+    }
+}
+`,
+			wantErr: "invalid integer",
+		},
+		{
+			name: "zero probe limit rejected",
+			input: `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                target 8.8.8.8;
+                probe-limit 0;
+            }
+        }
+    }
+}
+`,
+			wantErr: "must be > 0",
+		},
+		{
+			name: "destination port range validated",
+			input: `services {
+    rpm {
+        probe monitor {
+            test ping-test {
+                probe-type tcp-ping;
+                target 8.8.8.8;
+                destination-port 70000;
+            }
+        }
+    }
+}
+`,
+			wantErr: "1-65535",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := NewParser(tc.input)
+			tree, errs := parser.Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse errors: %v", errs)
+			}
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatal("expected compile error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("CompileConfig() error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestDynamicAddressFeed(t *testing.T) {
 	input := `security {
     dynamic-address {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -352,13 +352,13 @@ type DPDKPort struct {
 
 // UserspaceConfig holds separate-process userspace dataplane configuration.
 type UserspaceConfig struct {
-	Binary        string `json:"binary"`                    // helper process path
-	ControlSocket string `json:"control_socket"`            // unix control socket path
-	EventSocket   string `json:"event_socket,omitempty"`    // event stream socket path (auto-derived if empty)
-	StateFile     string `json:"state_file"`                // helper state file path
-	Workers       int    `json:"workers"`                   // worker thread count
-	RingEntries   int    `json:"ring_entries"`              // planned AF_XDP ring entries
-	PollMode      string `json:"poll_mode"`                 // "busy-poll" (default) or "interrupt"
+	Binary        string `json:"binary"`                 // helper process path
+	ControlSocket string `json:"control_socket"`         // unix control socket path
+	EventSocket   string `json:"event_socket,omitempty"` // event stream socket path (auto-derived if empty)
+	StateFile     string `json:"state_file"`             // helper state file path
+	Workers       int    `json:"workers"`                // worker thread count
+	RingEntries   int    `json:"ring_entries"`           // planned AF_XDP ring entries
+	PollMode      string `json:"poll_mode"`              // "busy-poll" (default) or "interrupt"
 }
 
 // RootAuthConfig holds root-authentication settings.
@@ -530,6 +530,15 @@ type RPMProbe struct {
 	Tests map[string]*RPMTest
 }
 
+const (
+	DefaultRPMProbeType            = "icmp-ping"
+	DefaultRPMProbeIntervalSeconds = 5
+	DefaultRPMProbeCount           = 1
+	DefaultRPMTestIntervalSeconds  = 60
+	DefaultRPMSuccessiveLosses     = 3
+	DefaultRPMTCPDestinationPort   = 80
+)
+
 // RPMTest defines a test within an RPM probe.
 type RPMTest struct {
 	Name                string
@@ -543,6 +552,48 @@ type RPMTest struct {
 	ThresholdSuccessive int // successive failures before probe-fail (0 = default 3)
 	ProbeLimit          int // max consecutive failed probes before test is declared failed (0 = unlimited)
 	DestPort            int // for tcp-ping
+}
+
+func (t *RPMTest) EffectiveProbeType() string {
+	if t == nil || t.ProbeType == "" {
+		return DefaultRPMProbeType
+	}
+	return t.ProbeType
+}
+
+func (t *RPMTest) EffectiveProbeInterval() int {
+	if t == nil || t.ProbeInterval <= 0 {
+		return DefaultRPMProbeIntervalSeconds
+	}
+	return t.ProbeInterval
+}
+
+func (t *RPMTest) EffectiveProbeCount() int {
+	if t == nil || t.ProbeCount <= 0 {
+		return DefaultRPMProbeCount
+	}
+	return t.ProbeCount
+}
+
+func (t *RPMTest) EffectiveTestInterval() int {
+	if t == nil || t.TestInterval <= 0 {
+		return DefaultRPMTestIntervalSeconds
+	}
+	return t.TestInterval
+}
+
+func (t *RPMTest) EffectiveSuccessiveLossThreshold() int {
+	if t == nil || t.ThresholdSuccessive <= 0 {
+		return DefaultRPMSuccessiveLosses
+	}
+	return t.ThresholdSuccessive
+}
+
+func (t *RPMTest) EffectiveDestinationPort() int {
+	if t == nil || t.DestPort <= 0 {
+		return DefaultRPMTCPDestinationPort
+	}
+	return t.DestPort
 }
 
 // FlowMonitoringConfig holds flow monitoring configuration.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -550,7 +550,7 @@ type RPMTest struct {
 	ProbeCount          int // number of probes per test (0 = default 1)
 	TestInterval        int // seconds (0 = default 60)
 	ThresholdSuccessive int // successive failures before probe-fail (0 = default 3)
-	ProbeLimit          int // max consecutive failed probes before test is declared failed (0 = unlimited)
+	ProbeLimit          int // max consecutive failed probes before stopping the current test cycle (0 = unlimited)
 	DestPort            int // for tcp-ping
 }
 

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -31,6 +31,54 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func writeRPMConfig(buf *strings.Builder, cfg *config.Config) {
+	if cfg == nil || cfg.Services.RPM == nil || len(cfg.Services.RPM.Probes) == 0 {
+		buf.WriteString("No RPM probes configured\n")
+		return
+	}
+
+	buf.WriteString("RPM Probe Configuration:\n")
+	probeNames := make([]string, 0, len(cfg.Services.RPM.Probes))
+	for name := range cfg.Services.RPM.Probes {
+		probeNames = append(probeNames, name)
+	}
+	sort.Strings(probeNames)
+
+	for _, probeName := range probeNames {
+		probe := cfg.Services.RPM.Probes[probeName]
+		testNames := make([]string, 0, len(probe.Tests))
+		for name := range probe.Tests {
+			testNames = append(testNames, name)
+		}
+		sort.Strings(testNames)
+
+		for _, testName := range testNames {
+			test := probe.Tests[testName]
+			fmt.Fprintf(buf, "  Probe: %s, Test: %s\n", probeName, testName)
+			fmt.Fprintf(buf, "    Type: %s, Target: %s\n", test.EffectiveProbeType(), test.Target)
+			if test.SourceAddress != "" {
+				fmt.Fprintf(buf, "    Source: %s\n", test.SourceAddress)
+			}
+			if test.RoutingInstance != "" {
+				fmt.Fprintf(buf, "    Routing instance: %s\n", test.RoutingInstance)
+			}
+			fmt.Fprintf(buf, "    Probe interval: %ds\n", test.EffectiveProbeInterval())
+			fmt.Fprintf(buf, "    Probe count: %d\n", test.EffectiveProbeCount())
+			fmt.Fprintf(buf, "    Test interval: %ds\n", test.EffectiveTestInterval())
+			fmt.Fprintf(buf, "    Successive loss threshold: %d\n", test.EffectiveSuccessiveLossThreshold())
+			if test.ProbeLimit > 0 {
+				fmt.Fprintf(buf, "    Probe limit: %d\n", test.ProbeLimit)
+			} else {
+				buf.WriteString("    Probe limit: unlimited\n")
+			}
+			if test.EffectiveProbeType() == "tcp-ping" || test.DestPort > 0 {
+				fmt.Fprintf(buf, "    Destination port: %d\n", test.EffectiveDestinationPort())
+			}
+			buf.WriteString("\n")
+		}
+	}
+}
+
 // --- Operational show RPCs ---
 
 func (s *Server) GetStatus(_ context.Context, _ *pb.GetStatusRequest) (*pb.GetStatusResponse, error) {
@@ -3256,13 +3304,9 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 		}
 
 	case "rpm":
-		if s.rpmResultsFn == nil {
-			buf.WriteString("RPM probes not available\n")
-		} else {
+		if s.rpmResultsFn != nil {
 			results := s.rpmResultsFn()
-			if len(results) == 0 {
-				buf.WriteString("No RPM probes configured\n")
-			} else {
+			if len(results) > 0 {
 				buf.WriteString("RPM Probe Results:\n")
 				for _, r := range results {
 					fmt.Fprintf(&buf, "  Probe: %s, Test: %s\n", r.ProbeName, r.TestName)
@@ -3286,8 +3330,10 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 						fmt.Fprintf(&buf, "    Last probe: %s\n", r.LastProbeAt.Format("2006-01-02 15:04:05"))
 					}
 				}
+				break
 			}
 		}
+		writeRPMConfig(&buf, s.store.ActiveConfig())
 
 	case "version":
 		ver := s.version

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -25,6 +25,7 @@ import (
 	pb "github.com/psaab/bpfrx/pkg/grpcapi/bpfrxv1"
 	"github.com/psaab/bpfrx/pkg/logging"
 	"github.com/psaab/bpfrx/pkg/routing"
+	"github.com/psaab/bpfrx/pkg/rpm"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
@@ -32,48 +33,20 @@ import (
 )
 
 func writeRPMConfig(buf *strings.Builder, cfg *config.Config) {
-	if cfg == nil || cfg.Services.RPM == nil || len(cfg.Services.RPM.Probes) == 0 {
+	if cfg == nil {
+		buf.WriteString("No active configuration\n")
+		return
+	}
+	if cfg.Services.RPM == nil || len(cfg.Services.RPM.Probes) == 0 {
 		buf.WriteString("No RPM probes configured\n")
 		return
 	}
 
 	buf.WriteString("RPM Probe Configuration:\n")
-	probeNames := make([]string, 0, len(cfg.Services.RPM.Probes))
-	for name := range cfg.Services.RPM.Probes {
-		probeNames = append(probeNames, name)
-	}
-	sort.Strings(probeNames)
-
-	for _, probeName := range probeNames {
+	for _, probeName := range rpm.SortedProbeNames(cfg.Services.RPM.Probes) {
 		probe := cfg.Services.RPM.Probes[probeName]
-		testNames := make([]string, 0, len(probe.Tests))
-		for name := range probe.Tests {
-			testNames = append(testNames, name)
-		}
-		sort.Strings(testNames)
-
-		for _, testName := range testNames {
-			test := probe.Tests[testName]
-			fmt.Fprintf(buf, "  Probe: %s, Test: %s\n", probeName, testName)
-			fmt.Fprintf(buf, "    Type: %s, Target: %s\n", test.EffectiveProbeType(), test.Target)
-			if test.SourceAddress != "" {
-				fmt.Fprintf(buf, "    Source: %s\n", test.SourceAddress)
-			}
-			if test.RoutingInstance != "" {
-				fmt.Fprintf(buf, "    Routing instance: %s\n", test.RoutingInstance)
-			}
-			fmt.Fprintf(buf, "    Probe interval: %ds\n", test.EffectiveProbeInterval())
-			fmt.Fprintf(buf, "    Probe count: %d\n", test.EffectiveProbeCount())
-			fmt.Fprintf(buf, "    Test interval: %ds\n", test.EffectiveTestInterval())
-			fmt.Fprintf(buf, "    Successive loss threshold: %d\n", test.EffectiveSuccessiveLossThreshold())
-			if test.ProbeLimit > 0 {
-				fmt.Fprintf(buf, "    Probe limit: %d\n", test.ProbeLimit)
-			} else {
-				buf.WriteString("    Probe limit: unlimited\n")
-			}
-			if test.EffectiveProbeType() == "tcp-ping" || test.DestPort > 0 {
-				fmt.Fprintf(buf, "    Destination port: %d\n", test.EffectiveDestinationPort())
-			}
+		for _, testName := range rpm.SortedTestNames(probe.Tests) {
+			rpm.WriteConfiguredTest(buf, probeName, testName, probe.Tests[testName])
 			buf.WriteString("\n")
 		}
 	}
@@ -3330,10 +3303,12 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 						fmt.Fprintf(&buf, "    Last probe: %s\n", r.LastProbeAt.Format("2006-01-02 15:04:05"))
 					}
 				}
-				break
+			} else {
+				writeRPMConfig(&buf, s.store.ActiveConfig())
 			}
+		} else {
+			writeRPMConfig(&buf, s.store.ActiveConfig())
 		}
-		writeRPMConfig(&buf, s.store.ActiveConfig())
 
 	case "version":
 		ver := s.version

--- a/pkg/grpcapi/server_show_rpm_test.go
+++ b/pkg/grpcapi/server_show_rpm_test.go
@@ -1,0 +1,49 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+func TestWriteRPMConfigReportsNoActiveConfiguration(t *testing.T) {
+	var buf strings.Builder
+	writeRPMConfig(&buf, nil)
+	if got, want := buf.String(), "No active configuration\n"; got != want {
+		t.Fatalf("writeRPMConfig(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestWriteRPMConfigRendersEffectiveSettings(t *testing.T) {
+	cfg := &config.Config{
+		Services: config.ServicesConfig{
+			RPM: &config.RPMConfig{
+				Probes: map[string]*config.RPMProbe{
+					"monitor": {
+						Name: "monitor",
+						Tests: map[string]*config.RPMTest{
+							"ping-test": {
+								Name:   "ping-test",
+								Target: "8.8.8.8",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	writeRPMConfig(&buf, cfg)
+	out := buf.String()
+	if !strings.Contains(out, "RPM Probe Configuration:\n") {
+		t.Fatalf("writeRPMConfig() output = %q, want heading", out)
+	}
+	if !strings.Contains(out, "Probe interval: 5s") {
+		t.Fatalf("writeRPMConfig() output = %q, want effective default interval", out)
+	}
+	if !strings.Contains(out, "Probe limit: unlimited") {
+		t.Fatalf("writeRPMConfig() output = %q, want unlimited probe limit", out)
+	}
+}

--- a/pkg/rpm/display.go
+++ b/pkg/rpm/display.go
@@ -1,0 +1,53 @@
+package rpm
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/psaab/bpfrx/pkg/config"
+)
+
+// SortedProbeNames returns RPM probe names in deterministic order.
+func SortedProbeNames(probes map[string]*config.RPMProbe) []string {
+	names := make([]string, 0, len(probes))
+	for name := range probes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SortedTestNames returns RPM test names in deterministic order.
+func SortedTestNames(tests map[string]*config.RPMTest) []string {
+	names := make([]string, 0, len(tests))
+	for name := range tests {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// WriteConfiguredTest renders a single configured RPM test using effective defaults.
+func WriteConfiguredTest(w io.Writer, probeName, testName string, test *config.RPMTest) {
+	fmt.Fprintf(w, "  Probe: %s, Test: %s\n", probeName, testName)
+	fmt.Fprintf(w, "    Type: %s, Target: %s\n", test.EffectiveProbeType(), test.Target)
+	if test.SourceAddress != "" {
+		fmt.Fprintf(w, "    Source: %s\n", test.SourceAddress)
+	}
+	if test.RoutingInstance != "" {
+		fmt.Fprintf(w, "    Routing instance: %s\n", test.RoutingInstance)
+	}
+	fmt.Fprintf(w, "    Probe interval: %ds\n", test.EffectiveProbeInterval())
+	fmt.Fprintf(w, "    Probe count: %d\n", test.EffectiveProbeCount())
+	fmt.Fprintf(w, "    Test interval: %ds\n", test.EffectiveTestInterval())
+	fmt.Fprintf(w, "    Successive loss threshold: %d\n", test.EffectiveSuccessiveLossThreshold())
+	if test.ProbeLimit > 0 {
+		fmt.Fprintf(w, "    Probe limit: %d\n", test.ProbeLimit)
+	} else {
+		fmt.Fprintln(w, "    Probe limit: unlimited")
+	}
+	if test.EffectiveProbeType() == "tcp-ping" || test.DestPort > 0 {
+		fmt.Fprintf(w, "    Destination port: %d\n", test.EffectiveDestinationPort())
+	}
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -46,20 +46,20 @@ func vrfDeviceName(ri string) string {
 
 // ProbeResult holds the current state of a single RPM test.
 type ProbeResult struct {
-	ProbeName    string
-	TestName     string
-	ProbeType    string
-	Target       string
-	LastRTT      time.Duration
-	MinRTT       time.Duration
-	MaxRTT       time.Duration
-	AvgRTT       time.Duration
-	Jitter       time.Duration // running absolute deviation from average
-	LastStatus   string        // "pass" or "fail"
-	SuccFail     int           // consecutive failures
-	TotalSent    int64
-	TotalRecv    int64
-	LastProbeAt  time.Time
+	ProbeName   string
+	TestName    string
+	ProbeType   string
+	Target      string
+	LastRTT     time.Duration
+	MinRTT      time.Duration
+	MaxRTT      time.Duration
+	AvgRTT      time.Duration
+	Jitter      time.Duration // running absolute deviation from average
+	LastStatus  string        // "pass" or "fail"
+	SuccFail    int           // consecutive failures
+	TotalSent   int64
+	TotalRecv   int64
+	LastProbeAt time.Time
 }
 
 // Event represents an RPM event for event-options matching.
@@ -122,7 +122,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.RPMConfig) {
 			m.results[key] = &ProbeResult{
 				ProbeName:  probe.Name,
 				TestName:   test.Name,
-				ProbeType:  test.ProbeType,
+				ProbeType:  test.EffectiveProbeType(),
 				Target:     test.Target,
 				LastStatus: "unknown",
 			}
@@ -170,29 +170,14 @@ func (m *Manager) Results() []*ProbeResult {
 }
 
 func (m *Manager) runProbeLoop(ctx context.Context, probe *config.RPMProbe, test *config.RPMTest, key string) {
-	interval := time.Duration(test.TestInterval) * time.Second
-	if interval <= 0 {
-		interval = 60 * time.Second
-	}
-
-	probeInterval := time.Duration(test.ProbeInterval) * time.Second
-	if probeInterval <= 0 {
-		probeInterval = 5 * time.Second
-	}
-
-	probeCount := test.ProbeCount
-	if probeCount <= 0 {
-		probeCount = 1
-	}
-
-	threshold := test.ThresholdSuccessive
-	if threshold <= 0 {
-		threshold = 3
-	}
+	interval := time.Duration(test.EffectiveTestInterval()) * time.Second
+	probeInterval := time.Duration(test.EffectiveProbeInterval()) * time.Second
+	probeCount := test.EffectiveProbeCount()
+	threshold := test.EffectiveSuccessiveLossThreshold()
 
 	slog.Info("RPM probe started",
 		"probe", probe.Name, "test", test.Name,
-		"type", test.ProbeType, "target", test.Target,
+		"type", test.EffectiveProbeType(), "target", test.Target,
 		"interval", interval)
 
 	ticker := time.NewTicker(interval)
@@ -294,7 +279,7 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 }
 
 func (m *Manager) executeProbe(ctx context.Context, test *config.RPMTest) (time.Duration, error) {
-	switch test.ProbeType {
+	switch test.EffectiveProbeType() {
 	case "icmp-ping":
 		return m.probeICMP(ctx, test)
 	case "tcp-ping":
@@ -302,7 +287,7 @@ func (m *Manager) executeProbe(ctx context.Context, test *config.RPMTest) (time.
 	case "http-get":
 		return m.probeHTTP(ctx, test)
 	default:
-		return m.probeICMP(ctx, test) // default to ICMP
+		return m.probeICMP(ctx, test)
 	}
 }
 
@@ -328,10 +313,7 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest) (time.Dur
 }
 
 func (m *Manager) probeTCP(ctx context.Context, test *config.RPMTest) (time.Duration, error) {
-	port := test.DestPort
-	if port == 0 {
-		port = 80
-	}
+	port := test.EffectiveDestinationPort()
 	addr := net.JoinHostPort(test.Target, fmt.Sprintf("%d", port))
 	dialer := vrfDialer(5*time.Second, test.SourceAddress, vrfDeviceName(test.RoutingInstance))
 


### PR DESCRIPTION
## Summary
- expand the RPM schema/help tree to match the probe/test syntax the compiler already supports
- tighten RPM compile-time validation so missing targets, unsupported probe types, and bad numeric values fail early
- improve local and remote `show services rpm` config fallback so it shows the effective probe settings instead of a partial stub

## Details
- centralize RPM default handling on `RPMTest` helper methods and use those defaults in the runtime and operational output
- add explicit completion coverage for the RPM subtree
- add config tests for default behavior and validation failures
- keep the deeper vSRX parity gaps tracked separately in #648

## Validation
- `git diff --check`
- `go test ./pkg/config ./pkg/rpm ./pkg/cli ./pkg/grpcapi -count=1`
