### PR TITLE
services: inherit root rpm probe-limit

### DIFF
--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1363,6 +1363,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 	}},
 	"services": {children: map[string]*schemaNode{
 		"rpm": {desc: "Real-time Performance Monitoring probes", children: map[string]*schemaNode{
+			"probe-limit": {args: 1, desc: "Default maximum consecutive failed probes before stopping a test cycle", children: nil},
 			"probe": {args: 1, desc: "RPM probe name", children: map[string]*schemaNode{
 				"test": {args: 1, desc: "RPM test name", children: map[string]*schemaNode{
 					"probe-type":       {args: 1, desc: "Probe type: icmp-ping, tcp-ping, or http-get", children: nil},

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -185,6 +185,17 @@ func compileServices(node *Node, svc *ServicesConfig) error {
 
 func compileRPM(node *Node, svc *ServicesConfig) error {
 	rpmCfg := &RPMConfig{Probes: make(map[string]*RPMProbe)}
+	defaultProbeLimit := 0
+
+	if probeLimitNode := node.FindChild("probe-limit"); probeLimitNode != nil {
+		if v := nodeVal(probeLimitNode); v != "" {
+			n, err := parseRPMPositiveInt("rpm", "default", "probe-limit", v)
+			if err != nil {
+				return fmt.Errorf("services rpm probe-limit: %w", err)
+			}
+			defaultProbeLimit = n
+		}
+	}
 
 	for _, probeInst := range namedInstances(node.FindChildren("probe")) {
 		probe := &RPMProbe{
@@ -265,6 +276,10 @@ func compileRPM(node *Node, svc *ServicesConfig) error {
 						test.DestPort = n
 					}
 				}
+			}
+
+			if test.ProbeLimit == 0 && defaultProbeLimit > 0 {
+				test.ProbeLimit = defaultProbeLimit
 			}
 
 			if err := validateRPMTest(probe.Name, test); err != nil {

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -23,6 +23,17 @@ func parseRPMPositiveInt(probeName, testName, field, raw string) (int, error) {
 	return n, nil
 }
 
+func parseRPMRootPositiveInt(field, raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("services rpm %s: invalid integer %q", field, raw)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("services rpm %s: must be > 0", field)
+	}
+	return n, nil
+}
+
 func validateRPMTest(probeName string, test *RPMTest) error {
 	if test.Target == "" {
 		return fmt.Errorf("services rpm probe %q test %q: target is required", probeName, test.Name)
@@ -189,9 +200,9 @@ func compileRPM(node *Node, svc *ServicesConfig) error {
 
 	if probeLimitNode := node.FindChild("probe-limit"); probeLimitNode != nil {
 		if v := nodeVal(probeLimitNode); v != "" {
-			n, err := parseRPMPositiveInt("rpm", "default", "probe-limit", v)
+			n, err := parseRPMRootPositiveInt("probe-limit", v)
 			if err != nil {
-				return fmt.Errorf("services rpm probe-limit: %w", err)
+				return err
 			}
 			defaultProbeLimit = n
 		}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -1085,6 +1085,40 @@ func TestRPMTargetURLAndProbeLimit(t *testing.T) {
 	}
 }
 
+func TestRPMRootProbeLimitSetSyntax(t *testing.T) {
+	tree := &ConfigTree{}
+	setCommands := []string{
+		"set services rpm probe-limit 3",
+		"set services rpm probe web2 test inherited target 8.8.8.8",
+		"set services rpm probe web2 test explicit target 1.1.1.1",
+		"set services rpm probe web2 test explicit probe-limit 7",
+	}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("set-command compile error: %v", err)
+	}
+	probe := cfg.Services.RPM.Probes["web2"]
+	if probe == nil {
+		t.Fatal("expected probe web2")
+	}
+	if got := probe.Tests["inherited"].ProbeLimit; got != 3 {
+		t.Fatalf("inherited probe-limit = %d, want 3", got)
+	}
+	if got := probe.Tests["explicit"].ProbeLimit; got != 7 {
+		t.Fatalf("explicit probe-limit = %d, want 7", got)
+	}
+}
+
 func TestMultipleSNATRules(t *testing.T) {
 	input := `security {
     zones {

--- a/pkg/config/parser_services_test.go
+++ b/pkg/config/parser_services_test.go
@@ -54,11 +54,64 @@ func TestRPMDefaultsAndValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("root probe-limit inheritance", func(t *testing.T) {
+		input := `services {
+    rpm {
+        probe-limit 3;
+        probe monitor {
+            test inherited {
+                target 8.8.8.8;
+            }
+            test explicit {
+                target 1.1.1.1;
+                probe-limit 5;
+            }
+        }
+    }
+}
+`
+		parser := NewParser(input)
+		tree, errs := parser.Parse()
+		if len(errs) > 0 {
+			t.Fatalf("parse errors: %v", errs)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+
+		probe := cfg.Services.RPM.Probes["monitor"]
+		if probe == nil {
+			t.Fatal("expected probe monitor")
+		}
+		if got := probe.Tests["inherited"].ProbeLimit; got != 3 {
+			t.Fatalf("inherited ProbeLimit = %d, want 3", got)
+		}
+		if got := probe.Tests["explicit"].ProbeLimit; got != 5 {
+			t.Fatalf("explicit ProbeLimit = %d, want 5", got)
+		}
+	})
+
 	tests := []struct {
 		name    string
 		input   string
 		wantErr string
 	}{
+		{
+			name: "zero root probe limit rejected",
+			input: `services {
+    rpm {
+        probe-limit 0;
+        probe monitor {
+            test ping-test {
+                target 8.8.8.8;
+            }
+        }
+    }
+}
+`,
+			wantErr: "services rpm probe-limit",
+		},
 		{
 			name: "missing target",
 			input: `services {


### PR DESCRIPTION
Fixes #142\n\nThis wires top-level services rpm { probe-limit N; } into the existing per-test RPM behavior instead of silently dropping it. Tests without an explicit probe-limit now inherit the root value, while per-test overrides still win.\n\nValidation:\n- go test ./pkg/config ./pkg/grpcapi -count=1