### PR TITLE
config: reject persist-groups-inheritance

### DIFF
--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1,6 +1,9 @@
 package config
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 func compileSystem(node *Node, sys *SystemConfig) error {
 	for _, child := range node.Children {
@@ -110,6 +113,10 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			// Also check children for hierarchical format
 			if dstNode := child.FindChild("destination"); dstNode != nil && len(dstNode.Keys) >= 2 {
 				sys.BackupRouterDst = dstNode.Keys[1]
+			}
+		case "commit":
+			if child.FindChild("persist-groups-inheritance") != nil {
+				return fmt.Errorf("system commit persist-groups-inheritance: unsupported")
 			}
 		case "root-authentication":
 			sys.RootAuthentication = &RootAuthConfig{}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -115,6 +115,11 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 				sys.BackupRouterDst = dstNode.Keys[1]
 			}
 		case "commit":
+			for _, key := range child.Keys[1:] {
+				if key == "persist-groups-inheritance" {
+					return fmt.Errorf("system commit persist-groups-inheritance: unsupported")
+				}
+			}
 			if child.FindChild("persist-groups-inheritance") != nil {
 				return fmt.Errorf("system commit persist-groups-inheritance: unsupported")
 			}

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -969,22 +969,29 @@ func TestDNSServiceEnabled(t *testing.T) {
 }
 
 func TestCommitPersistGroupsInheritanceRejected(t *testing.T) {
-	input := `system {
+	tests := []string{
+		`system {
     commit {
         persist-groups-inheritance;
     }
-}`
-	p := NewParser(input)
-	tree, errs := p.Parse()
-	if errs != nil {
-		t.Fatal(errs)
+}`,
+		`system {
+    commit persist-groups-inheritance;
+}`,
 	}
-	_, err := CompileConfig(tree)
-	if err == nil {
-		t.Fatal("expected compile error")
-	}
-	if !strings.Contains(err.Error(), "persist-groups-inheritance") {
-		t.Fatalf("CompileConfig() error = %v, want persist-groups-inheritance", err)
+	for _, input := range tests {
+		p := NewParser(input)
+		tree, errs := p.Parse()
+		if errs != nil {
+			t.Fatal(errs)
+		}
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("expected compile error for %q", input)
+		}
+		if !strings.Contains(err.Error(), "persist-groups-inheritance") {
+			t.Fatalf("CompileConfig() error = %v, want persist-groups-inheritance", err)
+		}
 	}
 }
 

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -968,6 +968,26 @@ func TestDNSServiceEnabled(t *testing.T) {
 	}
 }
 
+func TestCommitPersistGroupsInheritanceRejected(t *testing.T) {
+	input := `system {
+    commit {
+        persist-groups-inheritance;
+    }
+}`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if errs != nil {
+		t.Fatal(errs)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected compile error")
+	}
+	if !strings.Contains(err.Error(), "persist-groups-inheritance") {
+		t.Fatalf("CompileConfig() error = %v, want persist-groups-inheritance", err)
+	}
+}
+
 func TestParseLoginClass(t *testing.T) {
 	input := `system {
     login {


### PR DESCRIPTION
Fixes #650\n\nThis stops silently dropping system commit persist-groups-inheritance. The compiler now fails explicitly when that Junos-only knob is present, which keeps imported configs honest instead of pretending the behavior exists.\n\nValidation:\n- go test ./pkg/config -count=1