### PR TITLE
config: reject unsupported flow export app-id

### DIFF
--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -514,28 +514,6 @@ func ValidateConfig(cfg *Config) []string {
 		warnings = append(warnings, "chassis cluster: no-reth-vrrp is redundant (private-rg-election is the default)")
 	}
 
-	// Warn about unsupported export-extension app-id in flow monitoring templates
-	if fm := cfg.Services.FlowMonitoring; fm != nil {
-		checkExtWarning := func(kind, name string, exts []string) {
-			for _, ext := range exts {
-				if ext == "app-id" {
-					warnings = append(warnings, fmt.Sprintf(
-						"flow-monitoring %s template %s: export-extension app-id configured but application data is not available in flow records", kind, name))
-				}
-			}
-		}
-		if fm.Version9 != nil {
-			for _, tmpl := range fm.Version9.Templates {
-				checkExtWarning("version9", tmpl.Name, tmpl.ExportExtensions)
-			}
-		}
-		if fm.VersionIPFIX != nil {
-			for _, tmpl := range fm.VersionIPFIX.Templates {
-				checkExtWarning("version-ipfix", tmpl.Name, tmpl.ExportExtensions)
-			}
-		}
-	}
-
 	return warnings
 }
 

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -321,6 +321,9 @@ func compileFlowMonitoring(node *Node, svc *ServicesConfig) error {
 					tmpl.ExportExtensions = append(tmpl.ExportExtensions, parseExportExtensions(prop)...)
 				}
 			}
+			if err := rejectUnsupportedFlowExportExtensions("version9", tmpl.Name, tmpl.ExportExtensions); err != nil {
+				return err
+			}
 			v9cfg.Templates[tmpl.Name] = tmpl
 		}
 		fm.Version9 = v9cfg
@@ -363,12 +366,24 @@ func compileFlowMonitoring(node *Node, svc *ServicesConfig) error {
 					tmpl.ExportExtensions = append(tmpl.ExportExtensions, parseExportExtensions(prop)...)
 				}
 			}
+			if err := rejectUnsupportedFlowExportExtensions("version-ipfix", tmpl.Name, tmpl.ExportExtensions); err != nil {
+				return err
+			}
 			ipfixCfg.Templates[tmpl.Name] = tmpl
 		}
 		fm.VersionIPFIX = ipfixCfg
 	}
 
 	svc.FlowMonitoring = fm
+	return nil
+}
+
+func rejectUnsupportedFlowExportExtensions(kind, name string, exts []string) error {
+	for _, ext := range exts {
+		if ext == "app-id" {
+			return fmt.Errorf("services flow-monitoring %s template %s: export-extension app-id unsupported", kind, name)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -381,7 +381,7 @@ func compileFlowMonitoring(node *Node, svc *ServicesConfig) error {
 func rejectUnsupportedFlowExportExtensions(kind, name string, exts []string) error {
 	for _, ext := range exts {
 		if ext == "app-id" {
-			return fmt.Errorf("services flow-monitoring %s template %s: export-extension app-id unsupported", kind, name)
+			return fmt.Errorf("services flow-monitoring %s template %q: export-extension app-id unsupported", kind, name)
 		}
 	}
 	return nil

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1006,38 +1006,8 @@ func TestV9ExportExtensions(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	if cfg.Services.FlowMonitoring == nil {
-		t.Fatal("expected FlowMonitoring to be non-nil")
-	}
-	v9 := cfg.Services.FlowMonitoring.Version9
-	if v9 == nil {
-		t.Fatal("expected Version9 to be non-nil")
-	}
-	tmpl := v9.Templates["v9-ext"]
-	if tmpl == nil {
-		t.Fatal("expected template v9-ext")
-	}
-	if len(tmpl.ExportExtensions) != 2 {
-		t.Fatalf("expected 2 export extensions, got %d: %v", len(tmpl.ExportExtensions), tmpl.ExportExtensions)
-	}
-	if tmpl.ExportExtensions[0] != "flow-dir" {
-		t.Errorf("ext[0] = %q, want flow-dir", tmpl.ExportExtensions[0])
-	}
-	if tmpl.ExportExtensions[1] != "app-id" {
-		t.Errorf("ext[1] = %q, want app-id", tmpl.ExportExtensions[1])
-	}
-	found := false
-	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "app-id") && strings.Contains(w, "v9-ext") {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected validation warning for app-id export-extension")
+	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "export-extension app-id unsupported") {
+		t.Fatalf("expected unsupported app-id error, got %v", err)
 	}
 	tree2 := &ConfigTree{}
 	setCommands := []string{"set services flow-monitoring version9 template v9-set2 flow-active-timeout 90", "set services flow-monitoring version9 template v9-set2 ipv4-template export-extension flow-dir", "set services flow-monitoring version9 template v9-set2 ipv6-template export-extension flow-dir"}
@@ -1060,6 +1030,29 @@ func TestV9ExportExtensions(t *testing.T) {
 	}
 	if len(tmpl2.ExportExtensions) != 2 {
 		t.Fatalf("set syntax: expected 2 extensions, got %d: %v", len(tmpl2.ExportExtensions), tmpl2.ExportExtensions)
+	}
+}
+
+func TestIPFIXExportExtensionsRejectUnsupportedAppID(t *testing.T) {
+	input := `services {
+    flow-monitoring {
+        version-ipfix {
+            template ipfix-ext {
+                flow-active-timeout 60;
+                ipv4-template {
+                    export-extension app-id;
+                }
+            }
+        }
+    }
+}`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "export-extension app-id unsupported") {
+		t.Fatalf("expected unsupported app-id error, got %v", err)
 	}
 }
 

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1031,6 +1031,9 @@ func TestV9ExportExtensions(t *testing.T) {
 	if len(tmpl2.ExportExtensions) != 2 {
 		t.Fatalf("set syntax: expected 2 extensions, got %d: %v", len(tmpl2.ExportExtensions), tmpl2.ExportExtensions)
 	}
+	if tmpl2.ExportExtensions[0] != "flow-dir" || tmpl2.ExportExtensions[1] != "flow-dir" {
+		t.Fatalf("set syntax: expected both extensions to be flow-dir, got %v", tmpl2.ExportExtensions)
+	}
 }
 
 func TestIPFIXExportExtensionsRejectUnsupportedAppID(t *testing.T) {


### PR DESCRIPTION
Fixes #144

This narrows flow-monitoring export-extension handling to what runtime actually supports. `flow-dir` remains supported; `app-id` is now rejected at compile time for both NetFlow v9 and IPFIX templates instead of compiling with a misleading warning.

Validation:
- go test ./pkg/config ./pkg/flowexport -count=1