### PR TITLE
config: reject unsupported dns-proxy subtree

### DIFF
--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -258,10 +258,13 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			if sys.Services == nil {
 				sys.Services = &SystemServicesConfig{}
 			}
-			if dnsNode.FindChild("dns-proxy") != nil {
+			if len(dnsNode.Keys) > 1 {
+				return fmt.Errorf("system services dns: unsupported arguments")
+			}
+			if hasDNSProxySubtree(dnsNode) {
 				return fmt.Errorf("system services dns dns-proxy: unsupported")
 			}
-			if len(dnsNode.Children) > 0 {
+			if !dnsNode.IsLeaf {
 				return fmt.Errorf("system services dns: subconfiguration unsupported")
 			}
 			sys.Services.DNSEnabled = true
@@ -313,6 +316,18 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	}
 
 	return nil
+}
+
+func hasDNSProxySubtree(node *Node) bool {
+	for _, child := range node.Children {
+		if child.Name() == "dns-proxy" {
+			return true
+		}
+		if len(child.Keys) >= 2 && child.Keys[0] == "inactive:" && child.Keys[1] == "dns-proxy" {
+			return true
+		}
+	}
+	return false
 }
 
 func compileDPDKDataplane(node *Node, cfg *DPDKConfig) error {

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1,6 +1,9 @@
 package config
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 func compileSystem(node *Node, sys *SystemConfig) error {
 	for _, child := range node.Children {
@@ -251,9 +254,15 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			}
 		}
 		// DNS service
-		if svcNode.FindChild("dns") != nil {
+		if dnsNode := svcNode.FindChild("dns"); dnsNode != nil {
 			if sys.Services == nil {
 				sys.Services = &SystemServicesConfig{}
+			}
+			if dnsNode.FindChild("dns-proxy") != nil {
+				return fmt.Errorf("system services dns dns-proxy: unsupported")
+			}
+			if len(dnsNode.Children) > 0 {
+				return fmt.Errorf("system services dns: subconfiguration unsupported")
 			}
 			sys.Services.DNSEnabled = true
 		}

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -968,6 +968,29 @@ func TestDNSServiceEnabled(t *testing.T) {
 	}
 }
 
+func TestDNSProxyRejected(t *testing.T) {
+	input := `system {
+    services {
+        dns {
+            dns-proxy {
+                default-domain *;
+                forwarders {
+                    1.1.1.1;
+                }
+            }
+        }
+    }
+}`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if errs != nil {
+		t.Fatal(errs)
+	}
+	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "system services dns dns-proxy: unsupported") {
+		t.Fatalf("expected dns-proxy unsupported error, got %v", err)
+	}
+}
+
 func TestParseLoginClass(t *testing.T) {
 	input := `system {
     login {

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -969,7 +969,14 @@ func TestDNSServiceEnabled(t *testing.T) {
 }
 
 func TestDNSProxyRejected(t *testing.T) {
-	input := `system {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "active dns-proxy subtree",
+			input: `system {
     services {
         dns {
             dns-proxy {
@@ -980,14 +987,53 @@ func TestDNSProxyRejected(t *testing.T) {
             }
         }
     }
-}`
-	p := NewParser(input)
-	tree, errs := p.Parse()
-	if errs != nil {
-		t.Fatal(errs)
+}`,
+			want: "system services dns dns-proxy: unsupported",
+		},
+		{
+			name: "inactive dns-proxy subtree",
+			input: `system {
+    services {
+        dns {
+            inactive: dns-proxy {
+                default-domain *;
+            }
+        }
+    }
+}`,
+			want: "system services dns dns-proxy: unsupported",
+		},
+		{
+			name: "empty dns block",
+			input: `system {
+    services {
+        dns {
+        }
+    }
+}`,
+			want: "system services dns: subconfiguration unsupported",
+		},
+		{
+			name: "dns arguments rejected",
+			input: `system {
+    services {
+        dns foo;
+    }
+}`,
+			want: "system services dns: unsupported arguments",
+		},
 	}
-	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "system services dns dns-proxy: unsupported") {
-		t.Fatalf("expected dns-proxy unsupported error, got %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			tree, errs := p.Parse()
+			if errs != nil {
+				t.Fatal(errs)
+			}
+			if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #652

This keeps `system services dns;` as the existing service toggle, but rejects `system services dns { dns-proxy { ... } }` explicitly so imported vSRX config cannot look supported when it is not.

Validation:
- go test ./pkg/config -count=1