### PR TITLE
config: accept unsupported vSRX syntax with warnings

### DIFF
--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -13,13 +13,29 @@ func CompileConfig(tree *ConfigTree) (*Config, error) {
 	// Clone the tree before expanding groups — the caller's tree must retain
 	// groups and apply-groups nodes for display (show configuration groups).
 	tree = tree.Clone()
+	usedNodeFallback := false
 
 	// Expand groups before compilation — resolve all apply-groups references.
 	if err := tree.ExpandGroups(); err != nil {
-		return nil, fmt.Errorf("apply-groups: %w", err)
+		if strings.Contains(err.Error(), `undefined group "${node}"`) {
+			vars := map[string]string{"node": "node0"}
+			if err2 := tree.ExpandGroupsWithVars(vars); err2 != nil {
+				return nil, fmt.Errorf("apply-groups: %w", err2)
+			}
+			usedNodeFallback = true
+		} else {
+			return nil, fmt.Errorf("apply-groups: %w", err)
+		}
 	}
 
-	return compileExpanded(tree)
+	cfg, err := compileExpanded(tree)
+	if err != nil {
+		return nil, err
+	}
+	if usedNodeFallback {
+		cfg.Warnings = append(cfg.Warnings, `apply-groups "${node}" resolved using default node0 context during generic compile`)
+	}
+	return cfg, nil
 }
 
 // CompileConfigForNode is like CompileConfig but resolves ${node} variables
@@ -512,6 +528,35 @@ func ValidateConfig(cfg *Config) []string {
 	// Warn if no-reth-vrrp set explicitly — redundant since private-rg-election is now default
 	if cc := cfg.Chassis.Cluster; cc != nil && cc.PrivateRGElection && cc.NoRethVRRP {
 		warnings = append(warnings, "chassis cluster: no-reth-vrrp is redundant (private-rg-election is the default)")
+	}
+
+	if cfg.System.PersistGroupsInheritance {
+		warnings = append(warnings, "system commit persist-groups-inheritance configured but group inheritance persistence is not implemented")
+	}
+
+	if cfg.System.Services != nil && cfg.System.Services.DNSProxyConfigured {
+		warnings = append(warnings, "system services dns dns-proxy configured but DNS proxy/forwarder runtime is not implemented")
+	}
+
+	if fm := cfg.Services.FlowMonitoring; fm != nil {
+		checkExtWarning := func(kind, name string, exts []string) {
+			for _, ext := range exts {
+				if ext == "app-id" {
+					warnings = append(warnings, fmt.Sprintf(
+						"flow-monitoring %s template %s: export-extension app-id configured but application data is not available in flow records", kind, name))
+				}
+			}
+		}
+		if fm.Version9 != nil {
+			for _, tmpl := range fm.Version9.Templates {
+				checkExtWarning("version9", tmpl.Name, tmpl.ExportExtensions)
+			}
+		}
+		if fm.VersionIPFIX != nil {
+			for _, tmpl := range fm.VersionIPFIX.Templates {
+				checkExtWarning("version-ipfix", tmpl.Name, tmpl.ExportExtensions)
+			}
+		}
 	}
 
 	return warnings

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -347,9 +347,6 @@ func compileFlowMonitoring(node *Node, svc *ServicesConfig) error {
 					tmpl.ExportExtensions = append(tmpl.ExportExtensions, parseExportExtensions(prop)...)
 				}
 			}
-			if err := rejectUnsupportedFlowExportExtensions("version9", tmpl.Name, tmpl.ExportExtensions); err != nil {
-				return err
-			}
 			v9cfg.Templates[tmpl.Name] = tmpl
 		}
 		fm.Version9 = v9cfg
@@ -392,24 +389,12 @@ func compileFlowMonitoring(node *Node, svc *ServicesConfig) error {
 					tmpl.ExportExtensions = append(tmpl.ExportExtensions, parseExportExtensions(prop)...)
 				}
 			}
-			if err := rejectUnsupportedFlowExportExtensions("version-ipfix", tmpl.Name, tmpl.ExportExtensions); err != nil {
-				return err
-			}
 			ipfixCfg.Templates[tmpl.Name] = tmpl
 		}
 		fm.VersionIPFIX = ipfixCfg
 	}
 
 	svc.FlowMonitoring = fm
-	return nil
-}
-
-func rejectUnsupportedFlowExportExtensions(kind, name string, exts []string) error {
-	for _, ext := range exts {
-		if ext == "app-id" {
-			return fmt.Errorf("services flow-monitoring %s template %q: export-extension app-id unsupported", kind, name)
-		}
-	}
 	return nil
 }
 

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1,9 +1,6 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 func compileSystem(node *Node, sys *SystemConfig) error {
 	for _, child := range node.Children {
@@ -117,11 +114,11 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 		case "commit":
 			for _, key := range child.Keys[1:] {
 				if key == "persist-groups-inheritance" {
-					return fmt.Errorf("system commit persist-groups-inheritance: unsupported")
+					sys.PersistGroupsInheritance = true
 				}
 			}
 			if child.FindChild("persist-groups-inheritance") != nil {
-				return fmt.Errorf("system commit persist-groups-inheritance: unsupported")
+				sys.PersistGroupsInheritance = true
 			}
 		case "root-authentication":
 			sys.RootAuthentication = &RootAuthConfig{}
@@ -263,11 +260,14 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			}
 		}
 		// DNS service
-		if svcNode.FindChild("dns") != nil {
+		if dnsNode := svcNode.FindChild("dns"); dnsNode != nil {
 			if sys.Services == nil {
 				sys.Services = &SystemServicesConfig{}
 			}
 			sys.Services.DNSEnabled = true
+			if hasDNSProxyChild(dnsNode) {
+				sys.Services.DNSProxyConfigured = true
+			}
 		}
 		// Web management
 		if wmNode := svcNode.FindChild("web-management"); wmNode != nil {
@@ -316,6 +316,15 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	}
 
 	return nil
+}
+
+func hasDNSProxyChild(node *Node) bool {
+	for _, child := range node.Children {
+		if child.Name() == "dns-proxy" {
+			return true
+		}
+	}
+	return false
 }
 
 func compileDPDKDataplane(node *Node, cfg *DPDKConfig) error {

--- a/pkg/config/lexer.go
+++ b/pkg/config/lexer.go
@@ -243,6 +243,7 @@ func isIdentChar(ch byte) bool {
 		(ch >= '0' && ch <= '9') ||
 		ch == '-' || ch == '_' || ch == '.' ||
 		ch == '/' || ch == ':' || ch == '*' || ch == '+' ||
+		ch == '=' || ch == ',' ||
 		ch == '<' || ch == '>'
 }
 
@@ -251,5 +252,6 @@ func IsIdentRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r) ||
 		r == '-' || r == '_' || r == '.' ||
 		r == '/' || r == ':' || r == '*' || r == '+' ||
+		r == '=' || r == ',' ||
 		r == '<' || r == '>'
 }

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -3232,12 +3232,21 @@ func TestCompileConfigForNodeBackwardCompat(t *testing.T) {
 			t.Fatalf("SetPath(%q): %v", cmd, err)
 		}
 	}
-	_, err := CompileConfig(tree)
-	if err == nil {
-		t.Fatal("expected error from CompileConfig with ${node} reference")
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig() unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), `"${node}"`) {
-		t.Errorf("error should mention ${node}, got: %v", err)
+	if cfg.System.HostName != "fw0" {
+		t.Fatalf("hostname = %q, want fw0", cfg.System.HostName)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, `"${node}"`) && strings.Contains(w, "node0") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected node placeholder warning, got %v", cfg.Warnings)
 	}
 }
 
@@ -3751,6 +3760,38 @@ func TestApplyGroupsVsrxHAConf(t *testing.T) {
 		t.Errorf("expected many policies from group expansion, got %d", totalPolicies)
 	}
 	t.Logf("compiled %d zone pairs with %d total policies", len(cfg.Security.Policies), totalPolicies)
+}
+
+func TestCompileLocalVsrxConf(t *testing.T) {
+	data, err := os.ReadFile("../../vsrx.conf")
+	if err != nil {
+		t.Skipf("vsrx.conf not found: %v", err)
+	}
+	tree, errs := NewParser(string(data)).Parse()
+	if len(errs) > 0 {
+		t.Logf("parse warnings (%d): %v", len(errs), errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile vsrx.conf: %v", err)
+	}
+	if len(cfg.Warnings) == 0 {
+		t.Log("compiled vsrx.conf with no warnings")
+	}
+}
+
+func TestParserAcceptsSSHKnownHostTokens(t *testing.T) {
+	input := `system {
+    ssh-known-hosts {
+        host skull.sf.saab.org,2001:559:8585:100::253 {
+            ecdsa-sha2-nistp256-key AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOzePLJ+YX/jjDmcAr2E4oB/RJ/6aCPsl39581dbjpCEDhdW6ahp+JDUUsHsHkYdJ0qw6cG8qlUbjezKfB3O4Rw=;
+        }
+    }
+}`
+	_, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
 }
 
 func TestAnnotationFormatText(t *testing.T) {

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1006,8 +1006,28 @@ func TestV9ExportExtensions(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "export-extension app-id unsupported") {
-		t.Fatalf("expected unsupported app-id error, got %v", err)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("unexpected compile error: %v", err)
+	}
+	if cfg.Services.FlowMonitoring == nil || cfg.Services.FlowMonitoring.Version9 == nil {
+		t.Fatal("expected Version9 to be non-nil")
+	}
+	tmpl := cfg.Services.FlowMonitoring.Version9.Templates["v9-ext"]
+	if tmpl == nil {
+		t.Fatal("expected template v9-ext")
+	}
+	if len(tmpl.ExportExtensions) != 2 {
+		t.Fatalf("expected 2 export extensions, got %d: %v", len(tmpl.ExportExtensions), tmpl.ExportExtensions)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "app-id") && strings.Contains(w, "v9-ext") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected app-id warning, got %v", cfg.Warnings)
 	}
 	tree2 := &ConfigTree{}
 	setCommands := []string{"set services flow-monitoring version9 template v9-set2 flow-active-timeout 90", "set services flow-monitoring version9 template v9-set2 ipv4-template export-extension flow-dir", "set services flow-monitoring version9 template v9-set2 ipv6-template export-extension flow-dir"}
@@ -1036,7 +1056,7 @@ func TestV9ExportExtensions(t *testing.T) {
 	}
 }
 
-func TestIPFIXExportExtensionsRejectUnsupportedAppID(t *testing.T) {
+func TestIPFIXExportExtensionsWarnUnsupportedAppID(t *testing.T) {
 	input := `services {
     flow-monitoring {
         version-ipfix {
@@ -1054,8 +1074,18 @@ func TestIPFIXExportExtensionsRejectUnsupportedAppID(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "export-extension app-id unsupported") {
-		t.Fatalf("expected unsupported app-id error, got %v", err)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("unexpected compile error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "app-id") && strings.Contains(w, "ipfix-ext") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected app-id warning, got %v", cfg.Warnings)
 	}
 }
 

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -968,7 +968,7 @@ func TestDNSServiceEnabled(t *testing.T) {
 	}
 }
 
-func TestCommitPersistGroupsInheritanceRejected(t *testing.T) {
+func TestCommitPersistGroupsInheritanceWarned(t *testing.T) {
 	tests := []string{
 		`system {
     commit {
@@ -985,13 +985,61 @@ func TestCommitPersistGroupsInheritanceRejected(t *testing.T) {
 		if errs != nil {
 			t.Fatal(errs)
 		}
-		_, err := CompileConfig(tree)
-		if err == nil {
-			t.Fatalf("expected compile error for %q", input)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("unexpected compile error for %q: %v", input, err)
 		}
-		if !strings.Contains(err.Error(), "persist-groups-inheritance") {
-			t.Fatalf("CompileConfig() error = %v, want persist-groups-inheritance", err)
+		if !cfg.System.PersistGroupsInheritance {
+			t.Fatalf("expected PersistGroupsInheritance to be recorded for %q", input)
 		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "persist-groups-inheritance") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected persist-groups-inheritance warning for %q, got %v", input, cfg.Warnings)
+		}
+	}
+}
+
+func TestDNSProxyWarned(t *testing.T) {
+	input := `system {
+    services {
+        dns {
+            dns-proxy {
+                default-domain *;
+                forwarders {
+                    1.1.1.1;
+                }
+            }
+        }
+    }
+}`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if errs != nil {
+		t.Fatal(errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("unexpected compile error: %v", err)
+	}
+	if cfg.System.Services == nil || !cfg.System.Services.DNSEnabled {
+		t.Fatal("expected DNS service to remain enabled")
+	}
+	if !cfg.System.Services.DNSProxyConfigured {
+		t.Fatal("expected DNSProxyConfigured to be recorded")
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "dns-proxy") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected dns-proxy warning, got %v", cfg.Warnings)
 	}
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -296,33 +296,34 @@ type SchedulerConfig struct {
 
 // SystemConfig holds system-level configuration.
 type SystemConfig struct {
-	HostName           string
-	DomainName         string   // system domain-name (e.g. "example.com")
-	DomainSearch       []string // system domain-search (search domains)
-	TimeZone           string
-	NameServers        []string // DNS server addresses
-	NTPServers         []string // NTP server addresses
-	NTPThreshold       int      // NTP threshold in seconds (0 = default)
-	NTPThresholdAction string   // "accept" or "reject"
-	NoRedirects        bool     // disable ICMP redirects
-	BackupRouter       string   // backup default gateway IP
-	BackupRouterDst    string   // backup router destination prefix
-	Lo0FilterInputV4   string   // lo0 unit 0 family inet filter input (host-bound filtering)
-	Lo0FilterInputV6   string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
-	DataplaneType      string   // "ebpf" (default), "dpdk", or "userspace"
-	DPDKDataplane      *DPDKConfig
-	UserspaceDataplane *UserspaceConfig
-	InternetOptions    *InternetOptionsConfig
-	Services           *SystemServicesConfig
-	Syslog             *SystemSyslogConfig
-	DHCPServer         DHCPServerConfig
-	SNMP               *SNMPConfig
-	Login              *LoginConfig
-	RootAuthentication *RootAuthConfig
-	Archival           *ArchivalConfig
-	MasterPassword     string   // pseudorandom-function value
-	LicenseAutoUpdate  string   // license autoupdate URL
-	DisabledProcesses  []string // processes marked "disable"
+	HostName                 string
+	DomainName               string   // system domain-name (e.g. "example.com")
+	DomainSearch             []string // system domain-search (search domains)
+	TimeZone                 string
+	NameServers              []string // DNS server addresses
+	NTPServers               []string // NTP server addresses
+	NTPThreshold             int      // NTP threshold in seconds (0 = default)
+	NTPThresholdAction       string   // "accept" or "reject"
+	NoRedirects              bool     // disable ICMP redirects
+	BackupRouter             string   // backup default gateway IP
+	BackupRouterDst          string   // backup router destination prefix
+	Lo0FilterInputV4         string   // lo0 unit 0 family inet filter input (host-bound filtering)
+	Lo0FilterInputV6         string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
+	DataplaneType            string   // "ebpf" (default), "dpdk", or "userspace"
+	DPDKDataplane            *DPDKConfig
+	UserspaceDataplane       *UserspaceConfig
+	InternetOptions          *InternetOptionsConfig
+	Services                 *SystemServicesConfig
+	Syslog                   *SystemSyslogConfig
+	DHCPServer               DHCPServerConfig
+	SNMP                     *SNMPConfig
+	Login                    *LoginConfig
+	RootAuthentication       *RootAuthConfig
+	Archival                 *ArchivalConfig
+	MasterPassword           string   // pseudorandom-function value
+	LicenseAutoUpdate        string   // license autoupdate URL
+	DisabledProcesses        []string // processes marked "disable"
+	PersistGroupsInheritance bool     // system commit persist-groups-inheritance (syntax accepted, runtime no-op)
 }
 
 // DPDKConfig holds DPDK dataplane-specific configuration.
@@ -383,9 +384,10 @@ type InternetOptionsConfig struct {
 
 // SystemServicesConfig holds system services (SSH, web-management).
 type SystemServicesConfig struct {
-	SSH           *SSHServiceConfig
-	WebManagement *WebManagementConfig
-	DNSEnabled    bool // system services dns
+	SSH                *SSHServiceConfig
+	WebManagement      *WebManagementConfig
+	DNSEnabled         bool // system services dns
+	DNSProxyConfigured bool // system services dns dns-proxy (syntax accepted, runtime no-op)
 }
 
 // SSHServiceConfig holds SSH service settings.


### PR DESCRIPTION
Fixes #650
Fixes #652

This follow-up changes the import-compatibility policy for vSRX config:
- accept unsupported vSRX syntax as compile-time no-op state instead of rejecting it
- emit explicit warnings so operators still see that behavior is not implemented

Included in this change:
- `system commit persist-groups-inheritance` compiles and warns instead of failing
- `system services dns dns-proxy` compiles and warns instead of failing
- `services flow-monitoring ... export-extension app-id` compiles and warns instead of failing
- generic `CompileConfig()` now falls back to `node0` for `apply-groups "${node}"` and warns
- lexer accepts the SSH/base64/comma tokens present in `vsrx.conf`

Validation:
- go test ./pkg/config -count=1
- go test ./pkg/config -run TestCompileLocalVsrxConf -count=1 -v

This supersedes the reject-based direction from #656 and #658 and aligns import behavior with the requirement that vSRX config should load even when some features are runtime no-ops.