### PR TITLE
cluster: gate HA transfer on protocol compatibility

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -496,12 +496,16 @@ func (m *Manager) HAProtocolVersions() (local, peer uint16) {
 }
 
 // HAProtocolVersionMismatch reports whether both sides advertised incompatible
-// HA/session-transfer versions. A missing peer field is interpreted as the
-// legacy compatibility version.
+// HA/session-transfer versions. When the peer is absent or has not yet
+// advertised a version, mismatch stays false so disconnect/readiness logic can
+// report the more accurate transport-state reason.
 func (m *Manager) HAProtocolVersionMismatch() (bool, uint16, uint16) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	local := normalizeHAProtocolVersion(m.localHAProtocolVersion)
+	if !m.peerAlive || m.peerHAProtocolVersion == 0 {
+		return false, local, 0
+	}
 	peer := normalizeHAProtocolVersion(m.peerHAProtocolVersion)
 	return local != peer, local, peer
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -126,6 +126,11 @@ type Manager struct {
 	// Optional software version metadata advertised via heartbeat.
 	localSoftwareVersion string
 	peerSoftwareVersion  string
+	// Explicit HA/session-transfer compatibility version carried in heartbeat.
+	// Unlike software version strings, this is a deliberate interoperability
+	// contract and is what userspace transfer readiness gates on.
+	localHAProtocolVersion uint16
+	peerHAProtocolVersion  uint16
 	// peerTransferOutOverride preserves an explicitly acknowledged peer
 	// transfer-out across heartbeat refreshes until the transfer is either
 	// committed or aborted locally.
@@ -138,8 +143,8 @@ type Manager struct {
 	// secondary during the same window so a transient heartbeat gap cannot
 	// immediately re-promote the old primary.
 	localTransferOutHoldUntil map[int]time.Time
-	peerTransferOutPrevious map[int]peerGroupSnapshot
-	peerMonitors            []InterfaceMonitorInfo
+	peerTransferOutPrevious   map[int]peerGroupSnapshot
+	peerMonitors              []InterfaceMonitorInfo
 
 	// Heartbeat goroutines (nil when not started).
 	hbSender   *heartbeatSender
@@ -255,6 +260,7 @@ func NewManager(nodeID, clusterID int) *Manager {
 		peerTransferCommitGraceUntil:   make(map[int]time.Time),
 		localTransferOutHoldUntil:      make(map[int]time.Time),
 		peerTransferOutPrevious:        make(map[int]peerGroupSnapshot),
+		localHAProtocolVersion:         CurrentHAProtocolVersion,
 		hbInterval:                     DefaultHeartbeatInterval,
 		hbThreshold:                    DefaultHeartbeatThreshold,
 		history:                        NewEventHistory(64),
@@ -474,14 +480,30 @@ func (m *Manager) SoftwareVersions() (local, peer string) {
 	return m.localSoftwareVersion, m.peerSoftwareVersion
 }
 
-// SoftwareVersionMismatch reports whether both sides advertised different versions.
-func (m *Manager) SoftwareVersionMismatch() (bool, string, string) {
+// SetHAProtocolVersion records the local HA compatibility version advertised to
+// the peer. Zero falls back to the legacy compatibility version.
+func (m *Manager) SetHAProtocolVersion(version uint16) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.localHAProtocolVersion = normalizeHAProtocolVersion(version)
+}
+
+// HAProtocolVersions returns the currently known local and peer HA protocol versions.
+func (m *Manager) HAProtocolVersions() (local, peer uint16) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if m.localSoftwareVersion == "" || m.peerSoftwareVersion == "" {
-		return false, m.localSoftwareVersion, m.peerSoftwareVersion
-	}
-	return m.localSoftwareVersion != m.peerSoftwareVersion, m.localSoftwareVersion, m.peerSoftwareVersion
+	return m.localHAProtocolVersion, m.peerHAProtocolVersion
+}
+
+// HAProtocolVersionMismatch reports whether both sides advertised incompatible
+// HA/session-transfer versions. A missing peer field is interpreted as the
+// legacy compatibility version.
+func (m *Manager) HAProtocolVersionMismatch() (bool, uint16, uint16) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	local := normalizeHAProtocolVersion(m.localHAProtocolVersion)
+	peer := normalizeHAProtocolVersion(m.peerHAProtocolVersion)
+	return local != peer, local, peer
 }
 
 // PeerMonitorStatuses returns the peer's interface monitor states from heartbeat.
@@ -1437,9 +1459,10 @@ func (m *Manager) buildHeartbeat() *HeartbeatPacket {
 	defer m.mu.RUnlock()
 
 	pkt := &HeartbeatPacket{
-		NodeID:          uint8(m.nodeID),
-		ClusterID:       uint16(m.clusterID),
-		SoftwareVersion: m.localSoftwareVersion,
+		NodeID:            uint8(m.nodeID),
+		ClusterID:         uint16(m.clusterID),
+		SoftwareVersion:   m.localSoftwareVersion,
+		HAProtocolVersion: m.localHAProtocolVersion,
 	}
 	for _, rg := range m.groups {
 		pkt.Groups = append(pkt.Groups, HeartbeatGroup{
@@ -1473,6 +1496,7 @@ func (m *Manager) handlePeerHeartbeat(pkt *HeartbeatPacket) {
 	m.peerEverSeen = true
 	m.peerNodeID = int(pkt.NodeID)
 	m.peerSoftwareVersion = pkt.SoftwareVersion
+	m.peerHAProtocolVersion = normalizeHAProtocolVersion(pkt.HAProtocolVersion)
 
 	// Rebuild peer group states from scratch — prunes stale RGs that
 	// the peer no longer reports (fix #92).
@@ -1581,6 +1605,7 @@ func (m *Manager) handlePeerTimeout() {
 	m.peerGroups = make(map[int]PeerGroupState)
 	m.peerMonitors = nil
 	m.peerSoftwareVersion = ""
+	m.peerHAProtocolVersion = 0
 	slog.Warn("cluster: peer heartbeat timeout, marking peer lost")
 	m.history.Record(EventHeartbeat, -1, "Peer heartbeat timeout")
 
@@ -1742,6 +1767,8 @@ func (m *Manager) FormatStatus() string {
 	peerNodeID := m.peerNodeID
 	localVersion := m.localSoftwareVersion
 	peerVersion := m.peerSoftwareVersion
+	localProtocol := normalizeHAProtocolVersion(m.localHAProtocolVersion)
+	peerProtocol := normalizeHAProtocolVersion(m.peerHAProtocolVersion)
 	peerGroups := make(map[int]PeerGroupState, len(m.peerGroups))
 	for k, v := range m.peerGroups {
 		peerGroups[k] = v
@@ -1759,15 +1786,15 @@ func (m *Manager) FormatStatus() string {
 	if localVersion != "" {
 		fmt.Fprintf(&b, "Software version: %s\n", localVersion)
 	}
+	fmt.Fprintf(&b, "HA protocol version: %d\n", localProtocol)
 	if peerAlive {
 		if peerVersion == "" {
 			peerVersion = "unknown"
 		}
 		fmt.Fprintf(&b, "Peer software version: %s\n", peerVersion)
+		fmt.Fprintf(&b, "Peer HA protocol version: %d\n", peerProtocol)
 	}
-	if localVersion != "" || peerAlive {
-		fmt.Fprintln(&b)
-	}
+	fmt.Fprintln(&b)
 	fmt.Fprintf(&b, "%-6s %-8s %-14s %-8s %-8s %s\n",
 		"Node", "Priority", "Status", "Preempt", "Manual", "Monitor-failures")
 	fmt.Fprintln(&b)
@@ -1827,6 +1854,8 @@ func (m *Manager) FormatInformation() string {
 	peerNodeID := m.peerNodeID
 	localVersion := m.localSoftwareVersion
 	peerVersion := m.peerSoftwareVersion
+	localProtocol := normalizeHAProtocolVersion(m.localHAProtocolVersion)
+	peerProtocol := normalizeHAProtocolVersion(m.peerHAProtocolVersion)
 	interval := m.hbInterval
 	threshold := m.hbThreshold
 	controlIface := m.controlInterface
@@ -1867,11 +1896,13 @@ func (m *Manager) FormatInformation() string {
 	if localVersion != "" {
 		fmt.Fprintf(&b, "  Software version: %s\n", localVersion)
 	}
+	fmt.Fprintf(&b, "  HA protocol version: %d\n", localProtocol)
 	if peerAlive {
 		if peerVersion == "" {
 			peerVersion = "unknown"
 		}
 		fmt.Fprintf(&b, "  Peer software version: %s\n", peerVersion)
+		fmt.Fprintf(&b, "  Peer HA protocol version: %d\n", peerProtocol)
 	}
 	fmt.Fprintf(&b, "  Sync transport: %s\n", m.SyncTransport())
 	fmt.Fprintln(&b)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1426,8 +1426,14 @@ func TestFormatStatusShowsSoftwareVersions(t *testing.T) {
 	if !strings.Contains(out, "Software version: local-build") {
 		t.Fatalf("status missing local software version: %s", out)
 	}
+	if !strings.Contains(out, "HA protocol version: 1") {
+		t.Fatalf("status missing local ha protocol version: %s", out)
+	}
 	if !strings.Contains(out, "Peer software version: peer-build") {
 		t.Fatalf("status missing peer software version: %s", out)
+	}
+	if !strings.Contains(out, "Peer HA protocol version: 1") {
+		t.Fatalf("status missing peer ha protocol version: %s", out)
 	}
 }
 
@@ -1448,6 +1454,12 @@ func TestFormatInformationShowsUnknownPeerSoftwareVersion(t *testing.T) {
 	out := m.FormatInformation()
 	if !strings.Contains(out, "Peer software version: unknown") {
 		t.Fatalf("information missing unknown peer software version: %s", out)
+	}
+	if !strings.Contains(out, "HA protocol version: 1") {
+		t.Fatalf("information missing local ha protocol version: %s", out)
+	}
+	if !strings.Contains(out, "Peer HA protocol version: 1") {
+		t.Fatalf("information missing peer ha protocol version: %s", out)
 	}
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1463,6 +1463,32 @@ func TestFormatInformationShowsUnknownPeerSoftwareVersion(t *testing.T) {
 	}
 }
 
+func TestHAProtocolVersionMismatchIgnoresUnknownPeerAfterTimeout(t *testing.T) {
+	m := NewManager(0, 1)
+	m.SetHAProtocolVersion(2)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100, 1: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:            1,
+		ClusterID:         1,
+		HAProtocolVersion: 2,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+	m.handlePeerTimeout()
+
+	mismatch, local, peer := m.HAProtocolVersionMismatch()
+	if mismatch {
+		t.Fatalf("unexpected mismatch after peer timeout: local=%d peer=%d", local, peer)
+	}
+	if local != 2 || peer != 0 {
+		t.Fatalf("unexpected versions after peer timeout: local=%d peer=%d", local, peer)
+	}
+}
+
 func TestResetFailover(t *testing.T) {
 	m := NewManager(0, 1)
 	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -63,17 +63,17 @@ const (
 //	    [3] NameLen
 //	    [4..4+NameLen] Interface name
 //	After monitors:
-//	  Optional SoftwareVersion:
+//	  Optional VersionTrailer:
 //	    [0] VersionLen
-//	    [1..1+VersionLen] Version bytes
-//	  Optional HAProtocolVersion:
-//	    [0:2] uint16 little-endian
+//	    [1..1+VersionLen] SoftwareVersion bytes
+//	    [..] uint16 little-endian HAProtocolVersion
 //
-// The trailing software-version field is optional; packets may end after the
-// monitor section, or may include the length-prefixed version bytes. Newer
-// packets may also append a trailing HA protocol version; older readers ignore
-// those extra bytes, and newer readers treat a missing field as the legacy
-// protocol version.
+// The trailing version trailer is optional; packets may end after the monitor
+// section. When present, the trailer always starts with a length byte, even if
+// the software version string is empty, so newer readers can unambiguously find
+// the HA protocol version. Older readers ignore any bytes after the optional
+// software-version field, and newer readers treat a missing trailer as the
+// legacy protocol version.
 type HeartbeatPacket struct {
 	NodeID            uint8
 	ClusterID         uint16
@@ -138,14 +138,15 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 	}
 
 	var version []byte
-	versionReserve := 2 // preserve room for HA protocol version
+	const heartbeatVersionTrailerSize = 1 + 2 // version length byte + HA protocol version
+	versionReserve := heartbeatVersionTrailerSize
 	if pkt.SoftwareVersion != "" {
 		version = []byte(pkt.SoftwareVersion)
 		if len(version) > maxHeartbeatSoftwareVersionSize {
 			version = version[:maxHeartbeatSoftwareVersionSize]
 		}
-		if off+1+len(version)+versionReserve <= maxHeartbeatSize {
-			versionReserve += 1 + len(version)
+		if off+heartbeatVersionTrailerSize+len(version) <= maxHeartbeatSize {
+			versionReserve = heartbeatVersionTrailerSize + len(version)
 		} else {
 			version = nil
 		}
@@ -176,14 +177,16 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		numMon++
 	}
 	buf[monCountOff] = uint8(numMon)
-	if len(version) > 0 {
+	if off+versionReserve <= maxHeartbeatSize {
 		buf[off] = uint8(len(version))
 		off++
-		copy(buf[off:off+len(version)], version)
-		off += len(version)
+		if len(version) > 0 {
+			copy(buf[off:off+len(version)], version)
+			off += len(version)
+		}
+		binary.LittleEndian.PutUint16(buf[off:off+2], normalizeHAProtocolVersion(pkt.HAProtocolVersion))
+		off += 2
 	}
-	binary.LittleEndian.PutUint16(buf[off:off+2], normalizeHAProtocolVersion(pkt.HAProtocolVersion))
-	off += 2
 	return buf[:off]
 }
 
@@ -256,15 +259,19 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 			})
 		}
 	}
+	versionSectionComplete := false
 	if monitorSectionComplete && off < len(data) {
 		versionLen := int(data[off])
 		off++
 		if off+versionLen <= len(data) {
 			pkt.SoftwareVersion = string(data[off : off+versionLen])
 			off += versionLen
+			versionSectionComplete = true
+		} else {
+			return pkt, nil
 		}
 	}
-	if off+2 <= len(data) {
+	if monitorSectionComplete && versionSectionComplete && off+2 <= len(data) {
 		pkt.HAProtocolVersion = normalizeHAProtocolVersion(binary.LittleEndian.Uint16(data[off : off+2]))
 	}
 

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -20,6 +20,16 @@ const (
 	// heartbeatVersion is the current protocol version.
 	heartbeatVersion = 1
 
+	// LegacyHAProtocolVersion is the compatibility version implicitly used by
+	// older heartbeats that predate explicit HA protocol advertisement.
+	LegacyHAProtocolVersion uint16 = 1
+
+	// CurrentHAProtocolVersion is the HA/session-transfer compatibility version
+	// used to decide whether mixed software builds can still hand off RGs. Bump
+	// this only when heartbeat/session-sync/failover wire semantics change in a
+	// way that breaks mixed-version interoperability.
+	CurrentHAProtocolVersion = LegacyHAProtocolVersion
+
 	// maxHeartbeatSize is the max packet size we'll read/write.
 	// 1472 = 1500 MTU - 20 IP header - 8 UDP header.
 	maxHeartbeatSize = 1472
@@ -56,15 +66,21 @@ const (
 //	  Optional SoftwareVersion:
 //	    [0] VersionLen
 //	    [1..1+VersionLen] Version bytes
+//	  Optional HAProtocolVersion:
+//	    [0:2] uint16 little-endian
 //
 // The trailing software-version field is optional; packets may end after the
-// monitor section, or may include the length-prefixed version bytes.
+// monitor section, or may include the length-prefixed version bytes. Newer
+// packets may also append a trailing HA protocol version; older readers ignore
+// those extra bytes, and newer readers treat a missing field as the legacy
+// protocol version.
 type HeartbeatPacket struct {
-	NodeID          uint8
-	ClusterID       uint16
-	Groups          []HeartbeatGroup
-	Monitors        []HeartbeatMonitor
-	SoftwareVersion string
+	NodeID            uint8
+	ClusterID         uint16
+	Groups            []HeartbeatGroup
+	Monitors          []HeartbeatMonitor
+	SoftwareVersion   string
+	HAProtocolVersion uint16
 }
 
 // HeartbeatGroup is a per-RG entry in the heartbeat.
@@ -91,6 +107,13 @@ const heartbeatGroupSize = 5
 
 const maxHeartbeatSoftwareVersionSize = 255
 
+func normalizeHAProtocolVersion(version uint16) uint16 {
+	if version == 0 {
+		return LegacyHAProtocolVersion
+	}
+	return version
+}
+
 // MarshalHeartbeat encodes a heartbeat packet to wire format.
 // The output is capped at maxHeartbeatSize. RG group entries are always
 // included (they are critical for election). When SoftwareVersion is present,
@@ -115,14 +138,14 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 	}
 
 	var version []byte
-	versionReserve := 0
+	versionReserve := 2 // preserve room for HA protocol version
 	if pkt.SoftwareVersion != "" {
 		version = []byte(pkt.SoftwareVersion)
 		if len(version) > maxHeartbeatSoftwareVersionSize {
 			version = version[:maxHeartbeatSoftwareVersionSize]
 		}
-		if off+1+len(version) <= maxHeartbeatSize {
-			versionReserve = 1 + len(version)
+		if off+1+len(version)+versionReserve <= maxHeartbeatSize {
+			versionReserve += 1 + len(version)
 		} else {
 			version = nil
 		}
@@ -159,6 +182,8 @@ func MarshalHeartbeat(pkt *HeartbeatPacket) []byte {
 		copy(buf[off:off+len(version)], version)
 		off += len(version)
 	}
+	binary.LittleEndian.PutUint16(buf[off:off+2], normalizeHAProtocolVersion(pkt.HAProtocolVersion))
+	off += 2
 	return buf[:off]
 }
 
@@ -175,8 +200,9 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 	}
 
 	pkt := &HeartbeatPacket{
-		NodeID:    data[5],
-		ClusterID: binary.LittleEndian.Uint16(data[6:8]),
+		NodeID:            data[5],
+		ClusterID:         binary.LittleEndian.Uint16(data[6:8]),
+		HAProtocolVersion: LegacyHAProtocolVersion,
 	}
 
 	numGroups := int(data[8])
@@ -235,7 +261,11 @@ func UnmarshalHeartbeat(data []byte) (*HeartbeatPacket, error) {
 		off++
 		if off+versionLen <= len(data) {
 			pkt.SoftwareVersion = string(data[off : off+versionLen])
+			off += versionLen
 		}
+	}
+	if off+2 <= len(data) {
+		pkt.HAProtocolVersion = normalizeHAProtocolVersion(binary.LittleEndian.Uint16(data[off : off+2]))
 	}
 
 	return pkt, nil

--- a/pkg/cluster/heartbeat_test.go
+++ b/pkg/cluster/heartbeat_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestMarshalUnmarshalHeartbeat(t *testing.T) {
 	pkt := &HeartbeatPacket{
-		NodeID:          1,
-		ClusterID:       42,
-		SoftwareVersion: "bpfrx-test-1",
+		NodeID:            1,
+		ClusterID:         42,
+		SoftwareVersion:   "bpfrx-test-1",
+		HAProtocolVersion: CurrentHAProtocolVersion,
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
 			{GroupID: 1, Priority: 150, Weight: 100, State: uint8(StateSecondary)},
@@ -46,6 +47,9 @@ func TestMarshalUnmarshalHeartbeat(t *testing.T) {
 	if got.SoftwareVersion != "bpfrx-test-1" {
 		t.Errorf("software version = %q, want bpfrx-test-1", got.SoftwareVersion)
 	}
+	if got.HAProtocolVersion != CurrentHAProtocolVersion {
+		t.Errorf("ha protocol version = %d, want %d", got.HAProtocolVersion, CurrentHAProtocolVersion)
+	}
 }
 
 func TestMarshalUnmarshalHeartbeat_NoGroups(t *testing.T) {
@@ -60,6 +64,9 @@ func TestMarshalUnmarshalHeartbeat_NoGroups(t *testing.T) {
 	}
 	if len(got.Groups) != 0 {
 		t.Errorf("groups = %d, want 0", len(got.Groups))
+	}
+	if got.HAProtocolVersion != LegacyHAProtocolVersion {
+		t.Errorf("ha protocol version = %d, want legacy %d", got.HAProtocolVersion, LegacyHAProtocolVersion)
 	}
 }
 
@@ -116,7 +123,7 @@ func TestMarshalHeartbeat_Size(t *testing.T) {
 		},
 	}
 	data := MarshalHeartbeat(pkt)
-	expected := heartbeatHeaderSize + 2*heartbeatGroupSize + 1 // +1 for NumMonitors byte
+	expected := heartbeatHeaderSize + 2*heartbeatGroupSize + 1 + 2 // +1 NumMonitors, +2 HA protocol version
 	if len(data) != expected {
 		t.Errorf("size = %d, want %d", len(data), expected)
 	}
@@ -134,9 +141,10 @@ func TestHandlePeerHeartbeat(t *testing.T) {
 
 	// Simulate peer heartbeat.
 	pkt := &HeartbeatPacket{
-		NodeID:          1,
-		ClusterID:       1,
-		SoftwareVersion: "peer-test",
+		NodeID:            1,
+		ClusterID:         1,
+		SoftwareVersion:   "peer-test",
+		HAProtocolVersion: CurrentHAProtocolVersion,
 		Groups: []HeartbeatGroup{
 			{GroupID: 0, Priority: 100, Weight: 255, State: uint8(StateSecondary)},
 		},
@@ -156,8 +164,8 @@ func TestHandlePeerHeartbeat(t *testing.T) {
 	} else if pg.Priority != 100 {
 		t.Errorf("peer group 0 priority = %d, want 100", pg.Priority)
 	}
-	if mismatch, local, peer := m.SoftwareVersionMismatch(); !mismatch || local != "local-test" || peer != "peer-test" {
-		t.Fatalf("software mismatch = %v local=%q peer=%q, want true/local-test/peer-test", mismatch, local, peer)
+	if mismatch, local, peer := m.HAProtocolVersionMismatch(); mismatch || local != CurrentHAProtocolVersion || peer != CurrentHAProtocolVersion {
+		t.Fatalf("ha protocol mismatch = %v local=%d peer=%d, want false/%d/%d", mismatch, local, peer, CurrentHAProtocolVersion, CurrentHAProtocolVersion)
 	}
 }
 
@@ -274,6 +282,9 @@ func TestMarshalUnmarshalHeartbeat_NoMonitors_BackwardsCompat(t *testing.T) {
 	if got2.SoftwareVersion != "" {
 		t.Errorf("software version from old format = %q, want empty", got2.SoftwareVersion)
 	}
+	if got2.HAProtocolVersion != LegacyHAProtocolVersion {
+		t.Errorf("ha protocol version from old format = %d, want %d", got2.HAProtocolVersion, LegacyHAProtocolVersion)
+	}
 }
 
 func TestUnmarshalHeartbeat_TruncatedMonitor(t *testing.T) {
@@ -369,6 +380,9 @@ func TestMarshalHeartbeat_LargeMonitorPayload_RGPreserved(t *testing.T) {
 	}
 	if got.SoftwareVersion != "peer-build" {
 		t.Fatalf("software version = %q, want peer-build", got.SoftwareVersion)
+	}
+	if got.HAProtocolVersion != LegacyHAProtocolVersion {
+		t.Fatalf("ha protocol version = %d, want %d", got.HAProtocolVersion, LegacyHAProtocolVersion)
 	}
 
 	// RG groups must be intact.
@@ -470,7 +484,29 @@ func TestBuildHeartbeat(t *testing.T) {
 	if pkt.ClusterID != 1 {
 		t.Errorf("ClusterID = %d, want 1", pkt.ClusterID)
 	}
+	if pkt.HAProtocolVersion != CurrentHAProtocolVersion {
+		t.Errorf("HAProtocolVersion = %d, want %d", pkt.HAProtocolVersion, CurrentHAProtocolVersion)
+	}
 	if len(pkt.Groups) != 2 {
 		t.Fatalf("groups = %d, want 2", len(pkt.Groups))
+	}
+}
+
+func TestHandlePeerHeartbeat_LegacyHeartbeatDefaultsProtocolCompatibility(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, true, map[int]int{0: 100, 1: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	m.handlePeerHeartbeat(&HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 200, Weight: 255, State: uint8(StatePrimary)},
+		},
+	})
+
+	if mismatch, local, peer := m.HAProtocolVersionMismatch(); mismatch || local != CurrentHAProtocolVersion || peer != LegacyHAProtocolVersion {
+		t.Fatalf("ha protocol mismatch = %v local=%d peer=%d, want false/%d/%d", mismatch, local, peer, CurrentHAProtocolVersion, LegacyHAProtocolVersion)
 	}
 }

--- a/pkg/cluster/heartbeat_test.go
+++ b/pkg/cluster/heartbeat_test.go
@@ -123,7 +123,7 @@ func TestMarshalHeartbeat_Size(t *testing.T) {
 		},
 	}
 	data := MarshalHeartbeat(pkt)
-	expected := heartbeatHeaderSize + 2*heartbeatGroupSize + 1 + 2 // +1 NumMonitors, +2 HA protocol version
+	expected := heartbeatHeaderSize + 2*heartbeatGroupSize + 1 + 1 + 2 // +1 NumMonitors, +1 version length, +2 HA protocol version
 	if len(data) != expected {
 		t.Errorf("size = %d, want %d", len(data), expected)
 	}
@@ -506,7 +506,39 @@ func TestHandlePeerHeartbeat_LegacyHeartbeatDefaultsProtocolCompatibility(t *tes
 		},
 	})
 
-	if mismatch, local, peer := m.HAProtocolVersionMismatch(); mismatch || local != CurrentHAProtocolVersion || peer != LegacyHAProtocolVersion {
-		t.Fatalf("ha protocol mismatch = %v local=%d peer=%d, want false/%d/%d", mismatch, local, peer, CurrentHAProtocolVersion, LegacyHAProtocolVersion)
+	mismatch, local, peer := m.HAProtocolVersionMismatch()
+	if local != CurrentHAProtocolVersion {
+		t.Fatalf("local ha protocol version = %d, want %d", local, CurrentHAProtocolVersion)
+	}
+	if peer != LegacyHAProtocolVersion {
+		t.Fatalf("peer ha protocol version = %d, want %d", peer, LegacyHAProtocolVersion)
+	}
+	wantMismatch := CurrentHAProtocolVersion != LegacyHAProtocolVersion
+	if mismatch != wantMismatch {
+		t.Fatalf("ha protocol mismatch = %v, want %v (local=%d peer=%d)", mismatch, wantMismatch, local, peer)
+	}
+}
+
+func TestUnmarshalHeartbeat_TruncatedVersionTrailerDoesNotParseHAProtocol(t *testing.T) {
+	pkt := &HeartbeatPacket{
+		NodeID:            1,
+		ClusterID:         5,
+		HAProtocolVersion: CurrentHAProtocolVersion,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 100, Weight: 200, State: uint8(StateSecondary)},
+		},
+	}
+	data := MarshalHeartbeat(pkt)
+
+	// Remove the last HA protocol byte so the version trailer is incomplete.
+	got, err := UnmarshalHeartbeat(data[:len(data)-1])
+	if err != nil {
+		t.Fatalf("unmarshal truncated trailer: %v", err)
+	}
+	if got.SoftwareVersion != "" {
+		t.Fatalf("software version = %q, want empty", got.SoftwareVersion)
+	}
+	if got.HAProtocolVersion != LegacyHAProtocolVersion {
+		t.Fatalf("ha protocol version = %d, want legacy default %d", got.HAProtocolVersion, LegacyHAProtocolVersion)
 	}
 }

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -828,16 +828,16 @@ type userspaceTransferReadinessProvider interface {
 	TransferReadiness() cluster.TransferReadinessSnapshot
 }
 
-type userspaceSoftwareVersionMismatchProvider interface {
-	SoftwareVersionMismatch() (bool, string, string)
+type userspaceHAProtocolMismatchProvider interface {
+	HAProtocolVersionMismatch() (bool, uint16, uint16)
 }
 
-func userspaceSoftwareVersionMismatchReason(provider userspaceSoftwareVersionMismatchProvider) []string {
+func userspaceHAProtocolMismatchReason(provider userspaceHAProtocolMismatchProvider) []string {
 	if provider == nil {
 		return nil
 	}
-	if mismatch, local, peer := provider.SoftwareVersionMismatch(); mismatch {
-		return []string{fmt.Sprintf("software version mismatch local=%q peer=%q", local, peer)}
+	if mismatch, local, peer := provider.HAProtocolVersionMismatch(); mismatch {
+		return []string{fmt.Sprintf("ha protocol mismatch local=%d peer=%d", local, peer)}
 	}
 	return nil
 }
@@ -858,7 +858,7 @@ func computeUserspaceTransferReadiness(sync userspaceTransferReadinessProvider, 
 
 func (d *Daemon) userspaceTransferReadiness(rgID int) (bool, []string) {
 	if d.cluster != nil {
-		if reasons := userspaceSoftwareVersionMismatchReason(d.cluster); len(reasons) > 0 {
+		if reasons := userspaceHAProtocolMismatchReason(d.cluster); len(reasons) > 0 {
 			return false, reasons
 		}
 	}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -224,23 +224,23 @@ func TestComputeUserspaceTransferReadinessReady(t *testing.T) {
 	}
 }
 
-type fakeUserspaceSoftwareVersionMismatchProvider struct {
+type fakeUserspaceHAProtocolMismatchProvider struct {
 	mismatch bool
-	local    string
-	peer     string
+	local    uint16
+	peer     uint16
 }
 
-func (f fakeUserspaceSoftwareVersionMismatchProvider) SoftwareVersionMismatch() (bool, string, string) {
+func (f fakeUserspaceHAProtocolMismatchProvider) HAProtocolVersionMismatch() (bool, uint16, uint16) {
 	return f.mismatch, f.local, f.peer
 }
 
-func TestUserspaceSoftwareVersionMismatchReason(t *testing.T) {
-	reasons := userspaceSoftwareVersionMismatchReason(fakeUserspaceSoftwareVersionMismatchProvider{
+func TestUserspaceHAProtocolMismatchReason(t *testing.T) {
+	reasons := userspaceHAProtocolMismatchReason(fakeUserspaceHAProtocolMismatchProvider{
 		mismatch: true,
-		local:    "local build",
-		peer:     "peer build",
+		local:    1,
+		peer:     2,
 	})
-	if len(reasons) != 1 || reasons[0] != `software version mismatch local="local build" peer="peer build"` {
+	if len(reasons) != 1 || reasons[0] != `ha protocol mismatch local=1 peer=2` {
 		t.Fatalf("unexpected reasons: %v", reasons)
 	}
 }


### PR DESCRIPTION
Fixes #641

## Summary
- advertise an explicit HA protocol compatibility version in cluster heartbeat
- gate userspace transfer readiness on HA protocol compatibility instead of software build string equality
- keep software version strings as status/information metadata only
- treat heartbeats from older daemons that do not advertise the field as the legacy compatibility version

## Why
Rolling upgrades were blocked by `Transfer ready: no (software version mismatch ...)` even when heartbeat/session-sync/failover wire behavior had not changed. The readiness contract should follow protocol compatibility, not build-label drift.

## Implementation
- add `HAProtocolVersion` to the optional heartbeat trailer without changing the existing heartbeat wire version byte
- reserve space for the field during marshal so monitor truncation does not drop compatibility metadata
- default missing peer values to `LegacyHAProtocolVersion` for backward compatibility with older heartbeats
- surface local/peer HA protocol versions in cluster status/information output
- switch userspace transfer readiness mismatch reporting to `ha protocol mismatch local=X peer=Y`

## Validation
- `go test ./pkg/cluster ./pkg/daemon -count=1`
