### PR TITLE
userspace-dp: classify CoS queues from egress filters

### DIFF
--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -767,8 +767,9 @@ actually honors today for a simple outbound `iperf3` check from the LAN side.
 Important current behavior:
 
 - shaping is enforced on the **egress** interface
-- queue selection is still driven by the **ingress interface input filter**
-- interface **output** filters do not currently drive CoS queue selection
+- queue selection prefers the shaped interface **egress output filter**
+- if no egress CoS filter is configured, queue selection falls back to the
+  current **ingress interface input filter**
 - `per-unit-scheduler` is not implemented
 - `transmit-rate exact` is not implemented yet
 
@@ -795,37 +796,36 @@ set class-of-service scheduler-maps bandwidth-limit forwarding-class bandwidth-5
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 15m
 
-delete firewall family inet filter sfmix-pbr term default
-set firewall family inet filter sfmix-pbr term cos-10m from destination-port 80
-set firewall family inet filter sfmix-pbr term cos-10m from destination-port 5201
-set firewall family inet filter sfmix-pbr term cos-10m then count input-10m
-set firewall family inet filter sfmix-pbr term cos-10m then forwarding-class bandwidth-10mb
-set firewall family inet filter sfmix-pbr term cos-10m then accept
-set firewall family inet filter sfmix-pbr term default then count input-5m
-set firewall family inet filter sfmix-pbr term default then forwarding-class bandwidth-5mb
-set firewall family inet filter sfmix-pbr term default then accept
+set firewall family inet filter bandwidth-output term 0 from destination-port 80
+set firewall family inet filter bandwidth-output term 0 from destination-port 5201
+set firewall family inet filter bandwidth-output term 0 then count output-10m
+set firewall family inet filter bandwidth-output term 0 then forwarding-class bandwidth-10mb
+set firewall family inet filter bandwidth-output term 0 then accept
+set firewall family inet filter bandwidth-output term 1 then count output-5m
+set firewall family inet filter bandwidth-output term 1 then forwarding-class bandwidth-5mb
+set firewall family inet filter bandwidth-output term 1 then accept
 
-set interfaces reth1 unit 0 family inet filter input sfmix-pbr
+set interfaces reth0 unit 80 family inet filter output bandwidth-output
 ```
 
 Notes for this specific test:
 
-- keep the existing `sfmix-route` term ahead of the CoS terms so routing-instance
-  steering still happens first
 - match `destination-port 5201` for client-to-server `iperf3` traffic; matching
   `source-port 5201` classifies the reverse direction instead
-- shape `reth0.80`, not `reth0.0`, because the WAN test traffic in this lab
-  leaves via `reth0.80`
+- shape and classify on `reth0.80`, not `reth0.0`, because the WAN test
+  traffic in this lab leaves via `reth0.80`
 - define an explicit `best-effort` queue so unmatched traffic does not depend
   on whatever queue happens to be first in the scheduler map
+- keep ingress `input` filter classification only as a compatibility fallback
+  for existing configs that do not yet attach an egress CoS filter
 
 Suggested verification commands:
 
 ```text
 show configuration class-of-service | display set
-show configuration firewall family inet filter sfmix-pbr | display set
+show configuration firewall family inet filter bandwidth-output | display set
 show class-of-service interface reth0.80
-show firewall filter sfmix-pbr
+show firewall filter bandwidth-output
 monitor interface traffic
 ```
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2612,6 +2612,47 @@ func TestBuildInterfaceSnapshotSetsTunnelFlag(t *testing.T) {
 	}
 }
 
+func TestBuildInterfaceSnapshotIncludesInputAndOutputFilters(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {
+			Name: "ge-0-0-0",
+			Units: map[int]*config.InterfaceUnit{
+				0: {
+					FilterInputV4:  "ingress-v4",
+					FilterOutputV4: "egress-v4",
+					FilterInputV6:  "ingress-v6",
+					FilterOutputV6: "egress-v6",
+				},
+			},
+		},
+	}
+
+	snaps := buildInterfaceSnapshots(cfg)
+	var unitSnap *InterfaceSnapshot
+	for i := range snaps {
+		if snaps[i].Name == "ge-0-0-0.0" {
+			unitSnap = &snaps[i]
+			break
+		}
+	}
+	if unitSnap == nil {
+		t.Fatal("ge-0-0-0.0 snapshot not found")
+	}
+	if unitSnap.FilterInputV4 != "ingress-v4" {
+		t.Fatalf("FilterInputV4 = %q, want ingress-v4", unitSnap.FilterInputV4)
+	}
+	if unitSnap.FilterOutputV4 != "egress-v4" {
+		t.Fatalf("FilterOutputV4 = %q, want egress-v4", unitSnap.FilterOutputV4)
+	}
+	if unitSnap.FilterInputV6 != "ingress-v6" {
+		t.Fatalf("FilterInputV6 = %q, want ingress-v6", unitSnap.FilterInputV6)
+	}
+	if unitSnap.FilterOutputV6 != "egress-v6" {
+		t.Fatalf("FilterOutputV6 = %q, want egress-v6", unitSnap.FilterOutputV6)
+	}
+}
+
 func TestBuildScreenSnapshotsIncludesAdvancedFields(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.Zones = map[string]*config.ZoneConfig{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -99,26 +99,28 @@ type ZoneSnapshot struct {
 }
 
 type InterfaceSnapshot struct {
-	Name            string                     `json:"name"`
-	Zone            string                     `json:"zone,omitempty"`
-	LinuxName       string                     `json:"linux_name,omitempty"`
-	ParentLinuxName string                     `json:"parent_linux_name,omitempty"`
-	Ifindex         int                        `json:"ifindex,omitempty"`
-	ParentIfindex   int                        `json:"parent_ifindex,omitempty"`
-	RXQueues        int                        `json:"rx_queues,omitempty"`
-	VLANID          int                        `json:"vlan_id,omitempty"`
-	LocalFabric     string                     `json:"local_fabric_member,omitempty"`
-	RedundancyGroup int                        `json:"redundancy_group,omitempty"`
-	UnitCount       int                        `json:"unit_count"`
-	Tunnel          bool                       `json:"tunnel"`
-	MTU             int                        `json:"mtu,omitempty"`
-	HardwareAddr    string                     `json:"hardware_addr,omitempty"`
-	Addresses       []InterfaceAddressSnapshot `json:"addresses,omitempty"`
-	FilterInputV4   string                     `json:"filter_input_v4,omitempty"`
-	FilterInputV6   string                     `json:"filter_input_v6,omitempty"`
+	Name                      string                     `json:"name"`
+	Zone                      string                     `json:"zone,omitempty"`
+	LinuxName                 string                     `json:"linux_name,omitempty"`
+	ParentLinuxName           string                     `json:"parent_linux_name,omitempty"`
+	Ifindex                   int                        `json:"ifindex,omitempty"`
+	ParentIfindex             int                        `json:"parent_ifindex,omitempty"`
+	RXQueues                  int                        `json:"rx_queues,omitempty"`
+	VLANID                    int                        `json:"vlan_id,omitempty"`
+	LocalFabric               string                     `json:"local_fabric_member,omitempty"`
+	RedundancyGroup           int                        `json:"redundancy_group,omitempty"`
+	UnitCount                 int                        `json:"unit_count"`
+	Tunnel                    bool                       `json:"tunnel"`
+	MTU                       int                        `json:"mtu,omitempty"`
+	HardwareAddr              string                     `json:"hardware_addr,omitempty"`
+	Addresses                 []InterfaceAddressSnapshot `json:"addresses,omitempty"`
+	FilterInputV4             string                     `json:"filter_input_v4,omitempty"`
+	FilterOutputV4            string                     `json:"filter_output_v4,omitempty"`
+	FilterInputV6             string                     `json:"filter_input_v6,omitempty"`
+	FilterOutputV6            string                     `json:"filter_output_v6,omitempty"`
 	CoSShapingRateBytesPerSec uint64                     `json:"cos_shaping_rate_bytes_per_sec,omitempty"`
-	CoSBurstSize             uint64                     `json:"cos_shaping_burst_bytes,omitempty"`
-	CoSSchedulerMap          string                     `json:"cos_scheduler_map,omitempty"`
+	CoSBurstSize              uint64                     `json:"cos_shaping_burst_bytes,omitempty"`
+	CoSSchedulerMap           string                     `json:"cos_scheduler_map,omitempty"`
 }
 
 type ClassOfServiceSnapshot struct {

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -305,26 +305,28 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxUnit)
 			addresses = mergeInterfaceAddressSnapshots(addresses, buildConfiguredAddressSnapshots(unit.Addresses))
 			out = append(out, InterfaceSnapshot{
-				Name:            unitName,
-				Zone:            zoneByInterface[unitName],
-				LinuxName:       linuxUnit,
-				ParentLinuxName: parentLinux,
-				Ifindex:         ifindex,
-				ParentIfindex:   parentIfindex,
-				RXQueues:        userspaceRXQueueCount(linuxUnit),
-				VLANID:          unit.VlanID,
-				LocalFabric:     iface.LocalFabricMember,
-				RedundancyGroup: rg, // inherit resolved RG (RETH parent or own)
-				UnitCount:       0,
-				Tunnel:          iface.Tunnel != nil || unit.Tunnel != nil,
-				MTU:             mtu,
-				HardwareAddr:    hardwareAddr,
-				Addresses:       addresses,
-				FilterInputV4:   unit.FilterInputV4,
-				FilterInputV6:   unit.FilterInputV6,
+				Name:                      unitName,
+				Zone:                      zoneByInterface[unitName],
+				LinuxName:                 linuxUnit,
+				ParentLinuxName:           parentLinux,
+				Ifindex:                   ifindex,
+				ParentIfindex:             parentIfindex,
+				RXQueues:                  userspaceRXQueueCount(linuxUnit),
+				VLANID:                    unit.VlanID,
+				LocalFabric:               iface.LocalFabricMember,
+				RedundancyGroup:           rg, // inherit resolved RG (RETH parent or own)
+				UnitCount:                 0,
+				Tunnel:                    iface.Tunnel != nil || unit.Tunnel != nil,
+				MTU:                       mtu,
+				HardwareAddr:              hardwareAddr,
+				Addresses:                 addresses,
+				FilterInputV4:             unit.FilterInputV4,
+				FilterOutputV4:            unit.FilterOutputV4,
+				FilterInputV6:             unit.FilterInputV6,
+				FilterOutputV6:            unit.FilterOutputV6,
 				CoSShapingRateBytesPerSec: coSUnitShapingRate(cosUnit),
-				CoSBurstSize:             coSUnitBurstSize(cosUnit),
-				CoSSchedulerMap:          coSUnitSchedulerMap(cosUnit),
+				CoSBurstSize:              coSUnitBurstSize(cosUnit),
+				CoSSchedulerMap:           coSUnitSchedulerMap(cosUnit),
 			})
 		}
 	}

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -330,7 +330,8 @@ fn drain_shaped_tx(
     }
     let start = binding.cos_interface_rr % binding.cos_interface_order.len();
     for offset in 0..binding.cos_interface_order.len() {
-        let root_ifindex = binding.cos_interface_order[(start + offset) % binding.cos_interface_order.len()];
+        let root_ifindex =
+            binding.cos_interface_order[(start + offset) % binding.cos_interface_order.len()];
         let Some(root) = binding.cos_interfaces.get(&root_ifindex) else {
             continue;
         };
@@ -369,7 +370,8 @@ fn build_cos_batch(
             }
             let start = root.rr_index_by_priority[priority] % indices_len;
             for offset in 0..indices_len {
-                let queue_idx = root.queue_indices_by_priority[priority][(start + offset) % indices_len];
+                let queue_idx =
+                    root.queue_indices_by_priority[priority][(start + offset) % indices_len];
                 let queue = &mut root.queues[queue_idx];
                 if queue.items.is_empty() || !queue.runnable {
                     continue;
@@ -664,9 +666,8 @@ fn advance_cos_timer_wheel(root: &mut CoSInterfaceRuntime, now_ns: u64) {
 }
 
 fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {
-    let slot =
-        ((root.timer_wheel.current_tick / COS_TIMER_WHEEL_L0_SLOTS as u64) % COS_TIMER_WHEEL_L1_SLOTS as u64)
-            as usize;
+    let slot = ((root.timer_wheel.current_tick / COS_TIMER_WHEEL_L0_SLOTS as u64)
+        % COS_TIMER_WHEEL_L1_SLOTS as u64) as usize;
     let queued = core::mem::take(&mut root.timer_wheel.level1[slot]);
     let mut rearm = Vec::with_capacity(queued.len());
     for queue_idx in queued {
@@ -719,24 +720,48 @@ pub(super) fn resolve_cos_queue_id(
     let Some(flow_key) = flow_key else {
         return Some(iface.default_queue);
     };
-    let ingress_ifindex = resolve_ingress_logical_ifindex(
-        forwarding,
-        meta.ingress_ifindex as i32,
-        meta.ingress_vlan_id,
-    )
-    .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
-    let result = crate::filter::evaluate_interface_filter(
-        &forwarding.filter_state,
-        ingress_ifindex,
-        is_v6,
-        flow_key.src_ip,
-        flow_key.dst_ip,
-        flow_key.protocol,
-        flow_key.src_port,
-        flow_key.dst_port,
-        meta.dscp,
-    );
+    let result = if if is_v6 {
+        forwarding
+            .filter_state
+            .iface_filter_out_v6
+            .contains_key(&egress_ifindex)
+    } else {
+        forwarding
+            .filter_state
+            .iface_filter_out_v4
+            .contains_key(&egress_ifindex)
+    } {
+        crate::filter::evaluate_interface_output_filter(
+            &forwarding.filter_state,
+            egress_ifindex,
+            is_v6,
+            flow_key.src_ip,
+            flow_key.dst_ip,
+            flow_key.protocol,
+            flow_key.src_port,
+            flow_key.dst_port,
+            meta.dscp,
+        )
+    } else {
+        let ingress_ifindex = resolve_ingress_logical_ifindex(
+            forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        crate::filter::evaluate_interface_filter(
+            &forwarding.filter_state,
+            ingress_ifindex,
+            is_v6,
+            flow_key.src_ip,
+            flow_key.dst_ip,
+            flow_key.protocol,
+            flow_key.src_port,
+            flow_key.dst_port,
+            meta.dscp,
+        )
+    };
     if !result.forwarding_class.is_empty() {
         if let Some(queue_id) = iface
             .queue_by_forwarding_class
@@ -1621,7 +1646,123 @@ mod tests {
     }
 
     #[test]
-    fn resolve_cos_queue_id_uses_filter_forwarding_class() {
+    fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![
+                InterfaceSnapshot {
+                    name: "reth1.0".into(),
+                    ifindex: 101,
+                    parent_ifindex: 5,
+                    vlan_id: 0,
+                    hardware_addr: "02:bf:72:00:61:01".into(),
+                    filter_input_v4: "cos-classify".into(),
+                    ..Default::default()
+                },
+                InterfaceSnapshot {
+                    name: "reth0.0".into(),
+                    ifindex: 202,
+                    hardware_addr: "02:bf:72:00:80:08".into(),
+                    filter_output_v4: "wan-classify".into(),
+                    cos_shaping_rate_bytes_per_sec: 10_000_000,
+                    cos_shaping_burst_bytes: 256_000,
+                    cos_scheduler_map: "wan-map".into(),
+                    ..Default::default()
+                },
+            ],
+            filters: vec![
+                FirewallFilterSnapshot {
+                    name: "cos-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "voice".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        forwarding_class: "best-effort".into(),
+                        ..Default::default()
+                    }],
+                },
+                FirewallFilterSnapshot {
+                    name: "wan-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "voice".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        forwarding_class: "expedited-forwarding".into(),
+                        ..Default::default()
+                    }],
+                },
+            ],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![
+                    CoSForwardingClassSnapshot {
+                        name: "best-effort".into(),
+                        queue: 0,
+                    },
+                    CoSForwardingClassSnapshot {
+                        name: "expedited-forwarding".into(),
+                        queue: 1,
+                    },
+                ],
+                schedulers: vec![
+                    CoSSchedulerSnapshot {
+                        name: "be-sched".into(),
+                        transmit_rate_bytes: 4_000_000,
+                        priority: "low".into(),
+                        buffer_size_bytes: 128_000,
+                    },
+                    CoSSchedulerSnapshot {
+                        name: "ef-sched".into(),
+                        transmit_rate_bytes: 6_000_000,
+                        priority: "strict-high".into(),
+                        buffer_size_bytes: 64_000,
+                    },
+                ],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "best-effort".into(),
+                            scheduler: "be-sched".into(),
+                        },
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "expedited-forwarding".into(),
+                            scheduler: "ef-sched".into(),
+                        },
+                    ],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let queue_id = resolve_cos_queue_id(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(queue_id, Some(1));
+    }
+
+    #[test]
+    fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists() {
         let snapshot = ConfigSnapshot {
             interfaces: vec![
                 InterfaceSnapshot {
@@ -1769,6 +1910,121 @@ mod tests {
         assert_eq!(queue_id, Some(7));
     }
 
+    #[test]
+    fn resolve_cos_queue_id_defaults_when_output_filter_has_no_forwarding_class() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![
+                InterfaceSnapshot {
+                    name: "reth1.0".into(),
+                    ifindex: 101,
+                    parent_ifindex: 5,
+                    vlan_id: 0,
+                    hardware_addr: "02:bf:72:00:61:01".into(),
+                    filter_input_v4: "cos-classify".into(),
+                    ..Default::default()
+                },
+                InterfaceSnapshot {
+                    name: "reth0.0".into(),
+                    ifindex: 202,
+                    hardware_addr: "02:bf:72:00:80:08".into(),
+                    filter_output_v4: "wan-classify".into(),
+                    cos_shaping_rate_bytes_per_sec: 10_000_000,
+                    cos_shaping_burst_bytes: 256_000,
+                    cos_scheduler_map: "wan-map".into(),
+                    ..Default::default()
+                },
+            ],
+            filters: vec![
+                FirewallFilterSnapshot {
+                    name: "cos-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "voice".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        forwarding_class: "expedited-forwarding".into(),
+                        ..Default::default()
+                    }],
+                },
+                FirewallFilterSnapshot {
+                    name: "wan-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "allow".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        ..Default::default()
+                    }],
+                },
+            ],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![
+                    CoSForwardingClassSnapshot {
+                        name: "best-effort".into(),
+                        queue: 7,
+                    },
+                    CoSForwardingClassSnapshot {
+                        name: "expedited-forwarding".into(),
+                        queue: 1,
+                    },
+                ],
+                schedulers: vec![
+                    CoSSchedulerSnapshot {
+                        name: "be-sched".into(),
+                        transmit_rate_bytes: 10_000_000,
+                        priority: "low".into(),
+                        buffer_size_bytes: 128_000,
+                    },
+                    CoSSchedulerSnapshot {
+                        name: "ef-sched".into(),
+                        transmit_rate_bytes: 10_000_000,
+                        priority: "strict-high".into(),
+                        buffer_size_bytes: 128_000,
+                    },
+                ],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "best-effort".into(),
+                            scheduler: "be-sched".into(),
+                        },
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "expedited-forwarding".into(),
+                            scheduler: "ef-sched".into(),
+                        },
+                    ],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let queue_id = resolve_cos_queue_id(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(queue_id, Some(7));
+    }
+
     fn test_cos_interface_runtime(now_ns: u64) -> CoSInterfaceRuntime {
         build_cos_interface_runtime(
             &CoSInterfaceConfig {
@@ -1859,10 +2115,7 @@ mod tests {
         assert_eq!(root.queues[0].wheel_level, 1);
         assert!(root.queues[0].parked);
 
-        advance_cos_timer_wheel(
-            &mut root,
-            (wake_tick - 1) * COS_TIMER_WHEEL_TICK_NS,
-        );
+        advance_cos_timer_wheel(&mut root, (wake_tick - 1) * COS_TIMER_WHEEL_TICK_NS);
         assert!(root.queues[0].parked);
         assert!(!root.queues[0].runnable);
 

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -721,7 +721,7 @@ pub(super) fn resolve_cos_queue_id(
         return Some(iface.default_queue);
     };
     let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
-    let result = if if is_v6 {
+    let has_output_filter = if is_v6 {
         forwarding
             .filter_state
             .iface_filter_out_v6
@@ -731,7 +731,8 @@ pub(super) fn resolve_cos_queue_id(
             .filter_state
             .iface_filter_out_v4
             .contains_key(&egress_ifindex)
-    } {
+    };
+    let result = if has_output_filter {
         crate::filter::evaluate_interface_output_filter(
             &forwarding.filter_state,
             egress_ifindex,

--- a/userspace-dp/src/filter.rs
+++ b/userspace-dp/src/filter.rs
@@ -146,6 +146,10 @@ pub(crate) struct FilterState {
     pub(crate) iface_filter_v4: rustc_hash::FxHashMap<i32, String>,
     /// Per-interface (ifindex) input filter name for inet6.
     pub(crate) iface_filter_v6: rustc_hash::FxHashMap<i32, String>,
+    /// Per-interface (ifindex) output filter name for inet.
+    pub(crate) iface_filter_out_v4: rustc_hash::FxHashMap<i32, String>,
+    /// Per-interface (ifindex) output filter name for inet6.
+    pub(crate) iface_filter_out_v6: rustc_hash::FxHashMap<i32, String>,
     /// lo0 inet input filter name.
     pub(crate) lo0_filter_v4: String,
     /// lo0 inet6 input filter name.
@@ -251,6 +255,36 @@ pub(crate) fn evaluate_interface_filter(
         state.iface_filter_v6.get(&ifindex)
     } else {
         state.iface_filter_v4.get(&ifindex)
+    };
+    let Some(filter_name) = filter_name else {
+        return FilterResult::default();
+    };
+    if filter_name.is_empty() {
+        return FilterResult::default();
+    }
+    let family = if is_v6 { "inet6" } else { "inet" };
+    let key = format!("{family}:{filter_name}");
+    evaluate_filter(
+        state, &key, src_ip, dst_ip, protocol, src_port, dst_port, dscp,
+    )
+}
+
+/// Evaluate the per-interface output filter for a given address family.
+pub(crate) fn evaluate_interface_output_filter(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> FilterResult {
+    let filter_name = if is_v6 {
+        state.iface_filter_out_v6.get(&ifindex)
+    } else {
+        state.iface_filter_out_v4.get(&ifindex)
     };
     let Some(filter_name) = filter_name else {
         return FilterResult::default();
@@ -375,10 +409,20 @@ pub(crate) fn parse_filter_state(
                 .iface_filter_v4
                 .insert(iface.ifindex, iface.filter_input_v4.clone());
         }
+        if !iface.filter_output_v4.is_empty() {
+            state
+                .iface_filter_out_v4
+                .insert(iface.ifindex, iface.filter_output_v4.clone());
+        }
         if !iface.filter_input_v6.is_empty() {
             state
                 .iface_filter_v6
                 .insert(iface.ifindex, iface.filter_input_v6.clone());
+        }
+        if !iface.filter_output_v6.is_empty() {
+            state
+                .iface_filter_out_v6
+                .insert(iface.ifindex, iface.filter_output_v6.clone());
         }
     }
 
@@ -905,6 +949,8 @@ mod tests {
             ifindex: 5,
             filter_input_v4: "protect-RE".into(),
             filter_input_v6: "protect-RE-v6".into(),
+            filter_output_v4: "egress-v4".into(),
+            filter_output_v6: "egress-v6".into(),
             ..Default::default()
         }];
         let state = parse_filter_state(
@@ -924,6 +970,30 @@ mod tests {
                     terms: vec![FirewallTermSnapshot {
                         name: "deny-all".into(),
                         action: "discard".into(),
+                        ..Default::default()
+                    }],
+                },
+                FirewallFilterSnapshot {
+                    name: "egress-v4".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "classify".into(),
+                        action: "accept".into(),
+                        forwarding_class: "bandwidth-10mb".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["5201".into()],
+                        ..Default::default()
+                    }],
+                },
+                FirewallFilterSnapshot {
+                    name: "egress-v6".into(),
+                    family: "inet6".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "classify".into(),
+                        action: "accept".into(),
+                        forwarding_class: "bandwidth-10mb".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["5201".into()],
                         ..Default::default()
                     }],
                 },
@@ -960,6 +1030,19 @@ mod tests {
             0,
         );
         assert_eq!(result.action, FilterAction::Accept);
+
+        let result = evaluate_interface_output_filter(
+            &state,
+            5,
+            false,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            PROTO_TCP,
+            1234,
+            5201,
+            0,
+        );
+        assert_eq!(result.forwarding_class.as_ref(), "bandwidth-10mb");
     }
 
     #[test]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -62,8 +62,12 @@ pub(crate) struct InterfaceSnapshot {
     pub addresses: Vec<InterfaceAddressSnapshot>,
     #[serde(rename = "filter_input_v4", default)]
     pub filter_input_v4: String,
+    #[serde(rename = "filter_output_v4", default)]
+    pub filter_output_v4: String,
     #[serde(rename = "filter_input_v6", default)]
     pub filter_input_v6: String,
+    #[serde(rename = "filter_output_v6", default)]
+    pub filter_output_v6: String,
     #[serde(
         rename = "cos_shaping_rate_bytes_per_sec",
         alias = "cos_shaping_rate_bps",


### PR DESCRIPTION
## Summary
- teach the userspace snapshot/protocol to carry per-interface output filters
- make CoS queue selection prefer the shaped egress output filter with ingress-input fallback
- update the CoS test recipe docs and add Go/Rust regressions

## Validation
- go test ./pkg/dataplane/userspace -count=1
- cargo test --manifest-path userspace-dp/Cargo.toml interface_filter_assignment -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml resolve_cos_queue_id_ -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture
- git diff --check