### PR TITLE
userspace-dp: add CoS guarantee and surplus scheduling

### DIFF
--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -770,8 +770,10 @@ Important current behavior:
 - queue selection prefers the shaped interface **egress output filter**
 - if no egress CoS filter is configured, queue selection falls back to the
   current **ingress interface input filter**
+- non-`exact` scheduler `transmit-rate` values act as guarantees and may borrow
+  surplus bandwidth up to the root shaper
+- `transmit-rate exact` prevents that queue from borrowing surplus
 - `per-unit-scheduler` is not implemented
-- `transmit-rate exact` is not implemented yet
 
 For the `loss` userspace lab, the relevant path is:
 
@@ -818,6 +820,8 @@ Notes for this specific test:
   on whatever queue happens to be first in the scheduler map
 - keep ingress `input` filter classification only as a compatibility fallback
   for existing configs that do not yet attach an egress CoS filter
+- use `set class-of-service schedulers <name> transmit-rate <rate> exact` for
+  queues that must stay capped at their guarantee instead of borrowing surplus
 
 Suggested verification commands:
 

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -322,17 +322,17 @@ xpf has firewall filters with source/dest addresses, prefix-lists (with except),
 
 ## 18. QoS / Class of Service
 
-Note: The vSRX deployment guide markets CoS as part of the standard feature set, but the user guide also calls out important CoS limitations on vSRX, such as the lack of high-priority SPC queue support. xpf now has a userspace-only Phase 1 CoS path with forwarding-class parsing, scheduler-map binding, interface shaping, and FIFO-per-class scheduling, but it is still materially narrower than Junos CoS.
+Note: The vSRX deployment guide markets CoS as part of the standard feature set, but the user guide also calls out important CoS limitations on vSRX, such as the lack of high-priority SPC queue support. xpf now has a userspace-only CoS path with forwarding-class parsing, scheduler-map binding, egress shaping, timer-wheel deferred eligibility, and guarantee/surplus queue scheduling, but it is still materially narrower than Junos CoS.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **Forwarding Classes** | `class-of-service forwarding-classes queue <num> <name>;` | Define custom forwarding class names mapped to queue numbers | Low | Done |
 | **Scheduler Maps** | `class-of-service scheduler-maps ...` | Associate forwarding classes with schedulers (bandwidth %, priority, buffer) | Low | Done |
-| **Schedulers** | `class-of-service schedulers ...` | Define per-queue scheduling parameters (transmit rate, priority, drop profile) | Low | Partial (userspace Phase 1 supports transmit-rate, priority, and buffer-size, but not the fuller Junos scheduler/drop-profile model) |
+| **Schedulers** | `class-of-service schedulers ...` | Define per-queue scheduling parameters (transmit rate, priority, drop profile) | Low | Partial (userspace supports transmit-rate, `transmit-rate exact`, priority, and buffer-size, but not the fuller Junos scheduler/drop-profile model) |
 | **BA Classifiers** | `class-of-service classifiers dscp ...` | Classify incoming traffic by DSCP/802.1p into forwarding classes and loss priorities | Low | Missing |
 | **Rewrite Rules** | `class-of-service rewrite-rules dscp ...` | Rewrite outgoing DSCP/802.1p values. xpf has filter-based DSCP rewrite. | Low | Partial (via firewall filter forwarding-class action) |
 | **WRED Drop Profiles** | `class-of-service drop-profiles ...` | Weighted Random Early Detection congestion avoidance per queue | Low | Missing |
-| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only Phase 1 egress shaping with FIFO-per-class queues and timer-wheel deferred eligibility; not full Junos CoS parity) |
+| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only egress shaping with queue guarantees, non-`exact` surplus borrowing, and timer-wheel deferred eligibility; not full Junos CoS parity) |
 | **Interface CoS Binding** | `class-of-service interfaces ... scheduler-map ...` | Bind scheduler-map and classifiers to specific interfaces | Low | Partial (scheduler-map binding works on userspace interfaces, but BA classifiers and broader CoS attachment semantics are still missing) |
 
 ---

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1136,9 +1136,11 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 			"queue": {args: 2, multi: true, children: nil},
 		}},
 		"schedulers": {args: 1, multi: true, children: map[string]*schemaNode{
-			"transmit-rate": {args: 1, children: nil},
-			"priority":      {args: 1, children: nil},
-			"buffer-size":   {args: 1, children: nil},
+			"transmit-rate": {args: 1, children: map[string]*schemaNode{
+				"exact": {children: nil},
+			}},
+			"priority":    {args: 1, children: nil},
+			"buffer-size": {args: 1, children: nil},
 		}},
 		"scheduler-maps": {args: 1, multi: true, children: map[string]*schemaNode{
 			"forwarding-class": {args: 1, multi: true, children: map[string]*schemaNode{

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -41,9 +41,11 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 		for _, child := range inst.node.Children {
 			switch child.Name() {
 			case "transmit-rate":
-				if v := nodeVal(child); v != "" {
-					sched.TransmitRateBytes = parseBandwidthLimit(v)
+				rate, exact := parseCoSTransmitRate(child)
+				if rate > 0 {
+					sched.TransmitRateBytes = rate
 				}
+				sched.TransmitRateExact = sched.TransmitRateExact || exact
 			case "priority":
 				sched.Priority = nodeVal(child)
 			case "buffer-size":
@@ -116,4 +118,22 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	}
 
 	return nil
+}
+
+func parseCoSTransmitRate(node *Node) (uint64, bool) {
+	var rate uint64
+	exact := false
+	for _, key := range node.Keys[1:] {
+		if key == "exact" {
+			exact = true
+			continue
+		}
+		if parsed := parseBandwidthLimit(key); parsed > 0 {
+			rate = parsed
+		}
+	}
+	if node.FindChild("exact") != nil {
+		exact = true
+	}
+	return rate, exact
 }

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -88,6 +88,7 @@ func TestCompileClassOfServiceSetSyntax(t *testing.T) {
 	lines := []string{
 		"set class-of-service forwarding-classes queue 0 best-effort",
 		"set class-of-service schedulers be-sched transmit-rate 5g",
+		"set class-of-service schedulers be-sched transmit-rate exact",
 		"set class-of-service schedulers be-sched priority low",
 		"set class-of-service schedulers be-sched buffer-size 8m",
 		"set class-of-service scheduler-maps edge-map forwarding-class best-effort scheduler be-sched",
@@ -119,6 +120,41 @@ func TestCompileClassOfServiceSetSyntax(t *testing.T) {
 	}
 	if got := unit.SchedulerMap; got != "edge-map" {
 		t.Fatalf("scheduler-map = %q, want edge-map", got)
+	}
+	if !cfg.ClassOfService.Schedulers["be-sched"].TransmitRateExact {
+		t.Fatal("expected be-sched transmit-rate exact")
+	}
+}
+
+func TestCompileClassOfServiceInlineTransmitRateExactSyntax(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service schedulers be-sched transmit-rate 5g exact",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	sched := cfg.ClassOfService.Schedulers["be-sched"]
+	if sched == nil {
+		t.Fatal("expected be-sched scheduler")
+	}
+	if got := sched.TransmitRateBytes; got != parseBandwidthLimit("5g") {
+		t.Fatalf("transmit-rate = %d, want %d", got, parseBandwidthLimit("5g"))
+	}
+	if !sched.TransmitRateExact {
+		t.Fatal("expected inline transmit-rate exact")
 	}
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -314,6 +314,7 @@ type CoSForwardingClass struct {
 type CoSScheduler struct {
 	Name              string
 	TransmitRateBytes uint64
+	TransmitRateExact bool
 	Priority          string
 	BufferSizeBytes   uint64
 }

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2653,6 +2653,36 @@ func TestBuildInterfaceSnapshotIncludesInputAndOutputFilters(t *testing.T) {
 	}
 }
 
+func TestBuildClassOfServiceSnapshotIncludesTransmitRateExact(t *testing.T) {
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			Schedulers: map[string]*config.CoSScheduler{
+				"exact-sched": {
+					Name:              "exact-sched",
+					TransmitRateBytes: 1_250_000,
+					TransmitRateExact: true,
+					Priority:          "strict-high",
+					BufferSizeBytes:   64_000,
+				},
+			},
+		},
+	}
+
+	snap := buildClassOfServiceSnapshot(cfg)
+	if snap == nil {
+		t.Fatal("expected non-nil class-of-service snapshot")
+	}
+	if len(snap.Schedulers) != 1 {
+		t.Fatalf("Schedulers len = %d, want 1", len(snap.Schedulers))
+	}
+	if !snap.Schedulers[0].TransmitRateExact {
+		t.Fatal("expected transmit_rate_exact in class-of-service snapshot")
+	}
+	if got := snap.Schedulers[0].TransmitRateBytes; got != 1_250_000 {
+		t.Fatalf("TransmitRateBytes = %d, want 1250000", got)
+	}
+}
+
 func TestBuildScreenSnapshotsIncludesAdvancedFields(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.Zones = map[string]*config.ZoneConfig{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -137,6 +137,7 @@ type CoSForwardingClassSnapshot struct {
 type CoSSchedulerSnapshot struct {
 	Name              string `json:"name"`
 	TransmitRateBytes uint64 `json:"transmit_rate_bytes,omitempty"`
+	TransmitRateExact bool   `json:"transmit_rate_exact,omitempty"`
 	Priority          string `json:"priority,omitempty"`
 	BufferSizeBytes   uint64 `json:"buffer_size_bytes,omitempty"`
 }

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -1462,6 +1462,7 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 			snap.Schedulers = append(snap.Schedulers, CoSSchedulerSnapshot{
 				Name:              sched.Name,
 				TransmitRateBytes: sched.TransmitRateBytes,
+				TransmitRateExact: sched.TransmitRateExact,
 				Priority:          sched.Priority,
 				BufferSizeBytes:   sched.BufferSizeBytes,
 			})

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -471,6 +471,10 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                     continue;
                 };
                 let scheduler = schedulers.get(&entry.scheduler).copied();
+                let transmit_rate_bytes = scheduler
+                    .map(|sched| sched.transmit_rate_bytes)
+                    .filter(|rate| *rate > 0)
+                    .unwrap_or(iface.cos_shaping_rate_bytes_per_sec);
                 queues.push(CoSQueueConfig {
                     queue_id,
                     forwarding_class: entry.forwarding_class.clone(),
@@ -479,21 +483,14 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                             .map(|sched| sched.priority.as_str())
                             .unwrap_or("low"),
                     ),
-                    transmit_rate_bytes: scheduler
-                        .map(|sched| sched.transmit_rate_bytes)
-                        .filter(|rate| *rate > 0)
-                        .unwrap_or(iface.cos_shaping_rate_bytes_per_sec),
+                    transmit_rate_bytes,
                     exact: scheduler
                         .map(|sched| sched.transmit_rate_exact)
                         .unwrap_or(false),
-                    surplus_weight: scheduler
-                        .map(|sched| {
-                            cos_surplus_weight(
-                                sched.transmit_rate_bytes.max(1),
-                                iface.cos_shaping_rate_bytes_per_sec,
-                            )
-                        })
-                        .unwrap_or(1),
+                    surplus_weight: cos_surplus_weight(
+                        transmit_rate_bytes.max(1),
+                        iface.cos_shaping_rate_bytes_per_sec,
+                    ),
                     buffer_bytes: scheduler
                         .map(|sched| sched.buffer_size_bytes)
                         .filter(|size| *size > 0)
@@ -680,6 +677,45 @@ mod tests {
             iface.queues[0].buffer_bytes,
             default_cos_burst_bytes(1_000_000)
         );
+    }
+
+    #[test]
+    fn build_cos_state_uses_effective_transmit_rate_for_surplus_weight() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                ifindex: 9,
+                cos_shaping_rate_bytes_per_sec: 1_000_000,
+                cos_scheduler_map: "test-map".into(),
+                ..Default::default()
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                }],
+                schedulers: vec![CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 0,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 0,
+                }],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "test-map".into(),
+                    entries: vec![CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    }],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let state = build_cos_state(&snapshot);
+        let iface = state.interfaces.get(&9).expect("missing CoS interface");
+        assert_eq!(iface.queues.len(), 1);
+        assert_eq!(iface.queues[0].transmit_rate_bytes, 1_000_000);
+        assert_eq!(iface.queues[0].surplus_weight, 16);
     }
 }
 

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -483,6 +483,17 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                         .map(|sched| sched.transmit_rate_bytes)
                         .filter(|rate| *rate > 0)
                         .unwrap_or(iface.cos_shaping_rate_bytes_per_sec),
+                    exact: scheduler
+                        .map(|sched| sched.transmit_rate_exact)
+                        .unwrap_or(false),
+                    surplus_weight: scheduler
+                        .map(|sched| {
+                            cos_surplus_weight(
+                                sched.transmit_rate_bytes.max(1),
+                                iface.cos_shaping_rate_bytes_per_sec,
+                            )
+                        })
+                        .unwrap_or(1),
                     buffer_bytes: scheduler
                         .map(|sched| sched.buffer_size_bytes)
                         .filter(|size| *size > 0)
@@ -496,6 +507,8 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                 forwarding_class: "best-effort".to_string(),
                 priority: cos_priority_rank("low"),
                 transmit_rate_bytes: iface.cos_shaping_rate_bytes_per_sec,
+                exact: false,
+                surplus_weight: 1,
                 buffer_bytes: burst_bytes,
             });
         }
@@ -529,6 +542,15 @@ fn default_cos_burst_bytes(rate_bytes: u64) -> u64 {
         .checked_div(100)
         .unwrap_or_default()
         .max(64 * 1500)
+}
+
+fn cos_surplus_weight(rate_bytes: u64, root_rate_bytes: u64) -> u32 {
+    if rate_bytes == 0 || root_rate_bytes == 0 {
+        return 1;
+    }
+    ((rate_bytes as u128) * 16)
+        .div_ceil(root_rate_bytes as u128)
+        .clamp(1, 16) as u32
 }
 
 fn cos_priority_rank(priority: &str) -> u8 {
@@ -575,12 +597,14 @@ mod tests {
                     CoSSchedulerSnapshot {
                         name: "be-sched".into(),
                         transmit_rate_bytes: 3_000_000,
+                        transmit_rate_exact: false,
                         priority: "low".into(),
                         buffer_size_bytes: 128_000,
                     },
                     CoSSchedulerSnapshot {
                         name: "ef-sched".into(),
                         transmit_rate_bytes: 7_000_000,
+                        transmit_rate_exact: true,
                         priority: "strict-high".into(),
                         buffer_size_bytes: 64_000,
                     },
@@ -612,11 +636,15 @@ mod tests {
         assert_eq!(iface.queues[0].forwarding_class, "best-effort");
         assert_eq!(iface.queues[0].priority, 5);
         assert_eq!(iface.queues[0].transmit_rate_bytes, 3_000_000);
+        assert!(!iface.queues[0].exact);
+        assert_eq!(iface.queues[0].surplus_weight, 5);
         assert_eq!(iface.queues[0].buffer_bytes, 128_000);
         assert_eq!(iface.queues[1].queue_id, 1);
         assert_eq!(iface.queues[1].forwarding_class, "expedited-forwarding");
         assert_eq!(iface.queues[1].priority, 0);
         assert_eq!(iface.queues[1].transmit_rate_bytes, 7_000_000);
+        assert!(iface.queues[1].exact);
+        assert_eq!(iface.queues[1].surplus_weight, 12);
         assert_eq!(iface.queues[1].buffer_bytes, 64_000);
     }
 
@@ -646,6 +674,8 @@ mod tests {
         assert_eq!(iface.queues[0].forwarding_class, "best-effort");
         assert_eq!(iface.queues[0].priority, 5);
         assert_eq!(iface.queues[0].transmit_rate_bytes, 1_000_000);
+        assert!(!iface.queues[0].exact);
+        assert_eq!(iface.queues[0].surplus_weight, 1);
         assert_eq!(
             iface.queues[0].buffer_bytes,
             default_cos_burst_bytes(1_000_000)

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -409,7 +409,7 @@ fn select_cos_guarantee_batch(root: &mut CoSInterfaceRuntime, now_ns: u64) -> Op
                 queue.transmit_rate_bytes,
                 head_len,
                 now_ns,
-                true,
+                queue.exact,
             ) {
                 park_cos_queue(root, queue_idx, wake_tick);
             }
@@ -2309,6 +2309,24 @@ mod tests {
 
         assert!(select_cos_guarantee_batch(&mut root, 1).is_none());
         assert!(select_cos_surplus_batch(&mut root, 1).is_none());
+    }
+
+    #[test]
+    fn guarantee_phase_parks_non_exact_queue_on_root_only_wakeup() {
+        let mut root = test_cos_runtime_with_exact(false);
+        root.last_refill_ns = 1;
+        root.tokens = 0;
+        root.queues[0].last_refill_ns = 1;
+        root.queues[0].tokens = 0;
+        root.queues[0].items.push_back(test_cos_item(1500));
+        root.queues[0].queued_bytes = 1500;
+        root.queues[0].runnable = true;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+
+        assert!(select_cos_guarantee_batch(&mut root, 1).is_none());
+        assert!(root.queues[0].parked);
+        assert_eq!(root.queues[0].next_wakeup_tick, 30);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -271,13 +271,21 @@ pub(super) enum TxError {
     Drop(String),
 }
 
+#[derive(Clone, Copy)]
+enum CoSServicePhase {
+    Guarantee,
+    Surplus,
+}
+
 enum CoSBatch {
     Local {
         queue_idx: usize,
+        phase: CoSServicePhase,
         items: VecDeque<TxRequest>,
     },
     Prepared {
         queue_idx: usize,
+        phase: CoSServicePhase,
         items: VecDeque<PreparedTxRequest>,
     },
 }
@@ -352,8 +360,7 @@ fn build_cos_batch(
     root_ifindex: i32,
     now_ns: u64,
 ) -> Option<CoSBatch> {
-    let mut selected = None;
-    {
+    let selected = {
         let root = binding.cos_interfaces.get_mut(&root_ifindex)?;
         advance_cos_timer_wheel(root, now_ns);
         refill_cos_tokens(
@@ -363,116 +370,218 @@ fn build_cos_batch(
             &mut root.last_refill_ns,
             now_ns,
         );
-        for priority in 0..COS_PRIORITY_LEVELS {
-            let indices_len = root.queue_indices_by_priority[priority].len();
-            if indices_len == 0 {
-                continue;
-            }
-            let start = root.rr_index_by_priority[priority] % indices_len;
-            for offset in 0..indices_len {
-                let queue_idx =
-                    root.queue_indices_by_priority[priority][(start + offset) % indices_len];
-                let queue = &mut root.queues[queue_idx];
-                if queue.items.is_empty() || !queue.runnable {
-                    continue;
-                }
-                refill_cos_tokens(
-                    &mut queue.tokens,
-                    queue.transmit_rate_bytes,
-                    queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
-                    &mut queue.last_refill_ns,
-                    now_ns,
-                );
-                let Some(head) = queue.items.front() else {
-                    continue;
-                };
-                let head_len = cos_item_len(head);
-                if root.tokens < head_len || queue.tokens < head_len {
-                    if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
-                        root.tokens,
-                        root.shaping_rate_bytes,
-                        queue.tokens,
-                        queue.transmit_rate_bytes,
-                        head_len,
-                        now_ns,
-                    ) {
-                        park_cos_queue(root, queue_idx, wake_tick);
-                    }
-                    continue;
-                }
-                root.rr_index_by_priority[priority] = (start + offset + 1) % indices_len;
-                let mut remaining_root = root.tokens;
-                let mut remaining_queue = queue.tokens;
-                match head {
-                    CoSPendingTxItem::Local(_) => {
-                        let mut items = VecDeque::new();
-                        while items.len() < TX_BATCH_SIZE {
-                            let Some(front) = queue.items.front() else {
-                                break;
-                            };
-                            let len = cos_item_len(front);
-                            if !matches!(front, CoSPendingTxItem::Local(_))
-                                || remaining_root < len
-                                || remaining_queue < len
-                            {
-                                break;
-                            }
-                            remaining_root = remaining_root.saturating_sub(len);
-                            remaining_queue = remaining_queue.saturating_sub(len);
-                            match queue.items.pop_front() {
-                                Some(CoSPendingTxItem::Local(req)) => items.push_back(req),
-                                Some(other) => {
-                                    queue.items.push_front(other);
-                                    break;
-                                }
-                                None => break,
-                            }
-                        }
-                        if !items.is_empty() {
-                            selected = Some(CoSBatch::Local { queue_idx, items });
-                            break;
-                        }
-                    }
-                    CoSPendingTxItem::Prepared(_) => {
-                        let mut items = VecDeque::new();
-                        while items.len() < TX_BATCH_SIZE {
-                            let Some(front) = queue.items.front() else {
-                                break;
-                            };
-                            let len = cos_item_len(front);
-                            if !matches!(front, CoSPendingTxItem::Prepared(_))
-                                || remaining_root < len
-                                || remaining_queue < len
-                            {
-                                break;
-                            }
-                            remaining_root = remaining_root.saturating_sub(len);
-                            remaining_queue = remaining_queue.saturating_sub(len);
-                            match queue.items.pop_front() {
-                                Some(CoSPendingTxItem::Prepared(req)) => items.push_back(req),
-                                Some(other) => {
-                                    queue.items.push_front(other);
-                                    break;
-                                }
-                                None => break,
-                            }
-                        }
-                        if !items.is_empty() {
-                            selected = Some(CoSBatch::Prepared { queue_idx, items });
-                            break;
-                        }
-                    }
-                }
-            }
-            if selected.is_some() {
-                break;
-            }
-        }
-    }
+        select_cos_guarantee_batch(root, now_ns).or_else(|| select_cos_surplus_batch(root, now_ns))
+    };
     if selected.is_some() {
         refresh_cos_interface_activity(binding, root_ifindex);
     }
     selected
+}
+
+fn select_cos_guarantee_batch(root: &mut CoSInterfaceRuntime, now_ns: u64) -> Option<CoSBatch> {
+    let queue_count = root.queues.len();
+    if queue_count == 0 {
+        return None;
+    }
+    let start = root.guarantee_rr % queue_count;
+    for offset in 0..queue_count {
+        let queue_idx = (start + offset) % queue_count;
+        let queue = &mut root.queues[queue_idx];
+        if queue.items.is_empty() || !queue.runnable {
+            continue;
+        }
+        refill_cos_tokens(
+            &mut queue.tokens,
+            queue.transmit_rate_bytes,
+            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+            &mut queue.last_refill_ns,
+            now_ns,
+        );
+        let Some(head) = queue.items.front() else {
+            continue;
+        };
+        let head_len = cos_item_len(head);
+        if root.tokens < head_len {
+            if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
+                root.tokens,
+                root.shaping_rate_bytes,
+                queue.tokens,
+                queue.transmit_rate_bytes,
+                head_len,
+                now_ns,
+                true,
+            ) {
+                park_cos_queue(root, queue_idx, wake_tick);
+            }
+            continue;
+        }
+        if queue.tokens < head_len {
+            if queue.exact {
+                if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
+                    root.tokens,
+                    root.shaping_rate_bytes,
+                    queue.tokens,
+                    queue.transmit_rate_bytes,
+                    head_len,
+                    now_ns,
+                    true,
+                ) {
+                    park_cos_queue(root, queue_idx, wake_tick);
+                }
+            }
+            continue;
+        }
+        root.guarantee_rr = (start + offset + 1) % queue_count;
+        if let Some(batch) = build_cos_batch_from_queue(
+            queue,
+            queue_idx,
+            root.tokens,
+            queue.tokens,
+            CoSServicePhase::Guarantee,
+        ) {
+            return Some(batch);
+        }
+    }
+    None
+}
+
+fn select_cos_surplus_batch(root: &mut CoSInterfaceRuntime, now_ns: u64) -> Option<CoSBatch> {
+    for priority in 0..COS_PRIORITY_LEVELS {
+        let indices_len = root.queue_indices_by_priority[priority].len();
+        if indices_len == 0 {
+            continue;
+        }
+        let start = root.rr_index_by_priority[priority] % indices_len;
+        for offset in 0..indices_len {
+            let queue_idx =
+                root.queue_indices_by_priority[priority][(start + offset) % indices_len];
+            let queue = &mut root.queues[queue_idx];
+            if queue.items.is_empty() || !queue.runnable || queue.exact {
+                continue;
+            }
+            let Some(head) = queue.items.front() else {
+                continue;
+            };
+            let head_len = cos_item_len(head);
+            if root.tokens < head_len {
+                if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
+                    root.tokens,
+                    root.shaping_rate_bytes,
+                    queue.tokens,
+                    queue.transmit_rate_bytes,
+                    head_len,
+                    now_ns,
+                    false,
+                ) {
+                    park_cos_queue(root, queue_idx, wake_tick);
+                }
+                continue;
+            }
+            if queue.surplus_deficit < head_len {
+                queue.surplus_deficit = queue
+                    .surplus_deficit
+                    .saturating_add(cos_surplus_quantum_bytes(queue));
+                if queue.surplus_deficit < head_len {
+                    continue;
+                }
+            }
+            root.rr_index_by_priority[priority] = (start + offset + 1) % indices_len;
+            if let Some(batch) = build_cos_batch_from_queue(
+                queue,
+                queue_idx,
+                root.tokens,
+                queue.surplus_deficit,
+                CoSServicePhase::Surplus,
+            ) {
+                return Some(batch);
+            }
+        }
+    }
+    None
+}
+
+fn build_cos_batch_from_queue(
+    queue: &mut CoSQueueRuntime,
+    queue_idx: usize,
+    root_budget: u64,
+    secondary_budget: u64,
+    phase: CoSServicePhase,
+) -> Option<CoSBatch> {
+    let head = queue.items.front()?;
+    match head {
+        CoSPendingTxItem::Local(_) => {
+            let mut items = VecDeque::new();
+            let mut remaining_root = root_budget;
+            let mut remaining_secondary = secondary_budget;
+            while items.len() < TX_BATCH_SIZE {
+                let Some(front) = queue.items.front() else {
+                    break;
+                };
+                let len = cos_item_len(front);
+                if !matches!(front, CoSPendingTxItem::Local(_))
+                    || remaining_root < len
+                    || remaining_secondary < len
+                {
+                    break;
+                }
+                remaining_root = remaining_root.saturating_sub(len);
+                remaining_secondary = remaining_secondary.saturating_sub(len);
+                match queue.items.pop_front() {
+                    Some(CoSPendingTxItem::Local(req)) => items.push_back(req),
+                    Some(other) => {
+                        queue.items.push_front(other);
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            if items.is_empty() {
+                None
+            } else {
+                Some(CoSBatch::Local {
+                    queue_idx,
+                    phase,
+                    items,
+                })
+            }
+        }
+        CoSPendingTxItem::Prepared(_) => {
+            let mut items = VecDeque::new();
+            let mut remaining_root = root_budget;
+            let mut remaining_secondary = secondary_budget;
+            while items.len() < TX_BATCH_SIZE {
+                let Some(front) = queue.items.front() else {
+                    break;
+                };
+                let len = cos_item_len(front);
+                if !matches!(front, CoSPendingTxItem::Prepared(_))
+                    || remaining_root < len
+                    || remaining_secondary < len
+                {
+                    break;
+                }
+                remaining_root = remaining_root.saturating_sub(len);
+                remaining_secondary = remaining_secondary.saturating_sub(len);
+                match queue.items.pop_front() {
+                    Some(CoSPendingTxItem::Prepared(req)) => items.push_back(req),
+                    Some(other) => {
+                        queue.items.push_front(other);
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            if items.is_empty() {
+                None
+            } else {
+                Some(CoSBatch::Prepared {
+                    queue_idx,
+                    phase,
+                    items,
+                })
+            }
+        }
+    }
 }
 
 fn submit_cos_batch(
@@ -485,10 +594,11 @@ fn submit_cos_batch(
     match batch {
         CoSBatch::Local {
             queue_idx,
+            phase,
             mut items,
         } => match transmit_batch(binding, &mut items, now_ns, shared_recycles) {
             Ok((packets, bytes)) => {
-                apply_cos_send_result(binding, root_ifindex, queue_idx, bytes, items);
+                apply_cos_send_result(binding, root_ifindex, queue_idx, phase, bytes, items);
                 if packets > 0 {
                     binding
                         .live
@@ -512,10 +622,11 @@ fn submit_cos_batch(
         },
         CoSBatch::Prepared {
             queue_idx,
+            phase,
             mut items,
         } => match transmit_prepared_queue(binding, &mut items, now_ns) {
             Ok((packets, bytes)) => {
-                apply_cos_prepared_result(binding, root_ifindex, queue_idx, bytes, items);
+                apply_cos_prepared_result(binding, root_ifindex, queue_idx, phase, bytes, items);
                 if packets > 0 {
                     binding
                         .live
@@ -542,6 +653,7 @@ fn submit_cos_batch(
 
 const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
 const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
+const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
 fn refill_cos_tokens(
@@ -599,6 +711,10 @@ fn cos_refill_ns_until(tokens: u64, need: u64, rate_bytes_per_sec: u64) -> Optio
     Some(deficit.saturating_mul(1_000_000_000u128).div_ceil(rate) as u64)
 }
 
+fn cos_surplus_quantum_bytes(queue: &CoSQueueRuntime) -> u64 {
+    COS_SURPLUS_ROUND_QUANTUM_BYTES.saturating_mul(u64::from(queue.surplus_weight.max(1)))
+}
+
 fn estimate_cos_queue_wakeup_tick(
     root_tokens: u64,
     root_rate_bytes: u64,
@@ -606,9 +722,14 @@ fn estimate_cos_queue_wakeup_tick(
     queue_rate_bytes: u64,
     need_bytes: u64,
     now_ns: u64,
+    require_queue_tokens: bool,
 ) -> Option<u64> {
     let root_refill_ns = cos_refill_ns_until(root_tokens, need_bytes, root_rate_bytes)?;
-    let queue_refill_ns = cos_refill_ns_until(queue_tokens, need_bytes, queue_rate_bytes)?;
+    let queue_refill_ns = if require_queue_tokens {
+        cos_refill_ns_until(queue_tokens, need_bytes, queue_rate_bytes)?
+    } else {
+        0
+    };
     let wake_ns = now_ns.saturating_add(root_refill_ns.max(queue_refill_ns));
     Some(cos_tick_for_ns(wake_ns).max(cos_tick_for_ns(now_ns).saturating_add(1)))
 }
@@ -859,6 +980,7 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
         default_queue: config.default_queue,
         nonempty_queues: 0,
         runnable_queues: 0,
+        guarantee_rr: 0,
         queues: config
             .queues
             .iter()
@@ -866,6 +988,9 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 queue_id: queue.queue_id,
                 priority: queue.priority,
                 transmit_rate_bytes: queue.transmit_rate_bytes,
+                exact: queue.exact,
+                surplus_weight: queue.surplus_weight,
+                surplus_deficit: 0,
                 buffer_bytes: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
                 tokens: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
                 last_refill_ns: now_ns,
@@ -982,6 +1107,7 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
                 queue.runnable = false;
                 queue.parked = false;
                 queue.next_wakeup_tick = 0;
+                queue.surplus_deficit = 0;
                 continue;
             }
             new_nonempty = new_nonempty.saturating_add(1);
@@ -1010,6 +1136,7 @@ fn apply_cos_send_result(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
+    phase: CoSServicePhase,
     sent_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
@@ -1020,7 +1147,14 @@ fn apply_cos_send_result(
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             restore_cos_local_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
-            queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+            match phase {
+                CoSServicePhase::Guarantee => {
+                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+                }
+                CoSServicePhase::Surplus => {
+                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
+                }
+            }
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
@@ -1031,6 +1165,7 @@ fn apply_cos_prepared_result(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
+    phase: CoSServicePhase,
     sent_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
@@ -1041,7 +1176,14 @@ fn apply_cos_prepared_result(
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             restore_cos_prepared_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
-            queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+            match phase {
+                CoSServicePhase::Guarantee => {
+                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+                }
+                CoSServicePhase::Surplus => {
+                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
+                }
+            }
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
@@ -1711,12 +1853,14 @@ mod tests {
                     CoSSchedulerSnapshot {
                         name: "be-sched".into(),
                         transmit_rate_bytes: 4_000_000,
+                        transmit_rate_exact: false,
                         priority: "low".into(),
                         buffer_size_bytes: 128_000,
                     },
                     CoSSchedulerSnapshot {
                         name: "ef-sched".into(),
                         transmit_rate_bytes: 6_000_000,
+                        transmit_rate_exact: false,
                         priority: "strict-high".into(),
                         buffer_size_bytes: 64_000,
                     },
@@ -1812,12 +1956,14 @@ mod tests {
                     CoSSchedulerSnapshot {
                         name: "be-sched".into(),
                         transmit_rate_bytes: 4_000_000,
+                        transmit_rate_exact: false,
                         priority: "low".into(),
                         buffer_size_bytes: 128_000,
                     },
                     CoSSchedulerSnapshot {
                         name: "ef-sched".into(),
                         transmit_rate_bytes: 6_000_000,
+                        transmit_rate_exact: false,
                         priority: "strict-high".into(),
                         buffer_size_bytes: 64_000,
                     },
@@ -1881,6 +2027,7 @@ mod tests {
                 schedulers: vec![CoSSchedulerSnapshot {
                     name: "be-sched".into(),
                     transmit_rate_bytes: 10_000_000,
+                    transmit_rate_exact: false,
                     priority: "low".into(),
                     buffer_size_bytes: 128_000,
                 }],
@@ -1975,12 +2122,14 @@ mod tests {
                     CoSSchedulerSnapshot {
                         name: "be-sched".into(),
                         transmit_rate_bytes: 10_000_000,
+                        transmit_rate_exact: false,
                         priority: "low".into(),
                         buffer_size_bytes: 128_000,
                     },
                     CoSSchedulerSnapshot {
                         name: "ef-sched".into(),
                         transmit_rate_bytes: 10_000_000,
+                        transmit_rate_exact: false,
                         priority: "strict-high".into(),
                         buffer_size_bytes: 128_000,
                     },
@@ -2038,10 +2187,33 @@ mod tests {
                     forwarding_class: "best-effort".into(),
                     priority: 5,
                     transmit_rate_bytes: 1_000_000,
+                    exact: false,
+                    surplus_weight: 1,
                     buffer_bytes: COS_MIN_BURST_BYTES,
                 }],
             },
             now_ns,
+        )
+    }
+
+    fn test_cos_runtime_with_exact(exact: bool) -> CoSInterfaceRuntime {
+        build_cos_interface_runtime(
+            &CoSInterfaceConfig {
+                shaping_rate_bytes: 1_000_000,
+                burst_bytes: COS_MIN_BURST_BYTES,
+                default_queue: 0,
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 0,
+                    forwarding_class: "best-effort".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 500_000,
+                    exact,
+                    surplus_weight: 1,
+                    buffer_bytes: COS_MIN_BURST_BYTES,
+                }],
+            },
+            0,
         )
     }
 
@@ -2070,10 +2242,73 @@ mod tests {
             root.queues[0].transmit_rate_bytes,
             1500,
             0,
+            true,
         )
         .expect("wake tick");
 
         assert_eq!(wake_tick, 30);
+    }
+
+    #[test]
+    fn estimate_cos_queue_wakeup_tick_ignores_queue_deficit_for_surplus() {
+        let mut root = test_cos_interface_runtime(0);
+        root.tokens = 0;
+        root.queues[0].tokens = 0;
+
+        let wake_tick = estimate_cos_queue_wakeup_tick(
+            root.tokens,
+            root.shaping_rate_bytes,
+            root.queues[0].tokens,
+            root.queues[0].transmit_rate_bytes,
+            1500,
+            0,
+            false,
+        )
+        .expect("wake tick");
+
+        assert_eq!(wake_tick, 30);
+    }
+
+    #[test]
+    fn surplus_phase_selects_non_exact_queue_without_guarantee_tokens() {
+        let mut root = test_cos_runtime_with_exact(false);
+        root.last_refill_ns = 1;
+        root.tokens = 1500;
+        root.queues[0].last_refill_ns = 1;
+        root.queues[0].tokens = 0;
+        root.queues[0].items.push_back(test_cos_item(1500));
+        root.queues[0].queued_bytes = 1500;
+        root.queues[0].runnable = true;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+
+        assert!(select_cos_guarantee_batch(&mut root, 1).is_none());
+        let batch = select_cos_surplus_batch(&mut root, 1);
+
+        assert!(matches!(
+            batch,
+            Some(CoSBatch::Local {
+                phase: CoSServicePhase::Surplus,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn surplus_phase_skips_exact_queue_without_guarantee_tokens() {
+        let mut root = test_cos_runtime_with_exact(true);
+        root.last_refill_ns = 1;
+        root.tokens = 1500;
+        root.queues[0].last_refill_ns = 1;
+        root.queues[0].tokens = 0;
+        root.queues[0].items.push_back(test_cos_item(1500));
+        root.queues[0].queued_bytes = 1500;
+        root.queues[0].runnable = true;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+
+        assert!(select_cos_guarantee_batch(&mut root, 1).is_none());
+        assert!(select_cos_surplus_batch(&mut root, 1).is_none());
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -188,6 +188,8 @@ pub(super) struct CoSQueueConfig {
     pub(super) forwarding_class: String,
     pub(super) priority: u8,
     pub(super) transmit_rate_bytes: u64,
+    pub(super) exact: bool,
+    pub(super) surplus_weight: u32,
     pub(super) buffer_bytes: u64,
 }
 
@@ -569,6 +571,7 @@ pub(super) struct CoSInterfaceRuntime {
     pub(super) default_queue: u8,
     pub(super) nonempty_queues: usize,
     pub(super) runnable_queues: usize,
+    pub(super) guarantee_rr: usize,
     pub(super) queues: Vec<CoSQueueRuntime>,
     pub(super) queue_indices_by_priority: [Vec<usize>; COS_PRIORITY_LEVELS],
     pub(super) rr_index_by_priority: [usize; COS_PRIORITY_LEVELS],
@@ -579,6 +582,9 @@ pub(super) struct CoSQueueRuntime {
     pub(super) queue_id: u8,
     pub(super) priority: u8,
     pub(super) transmit_rate_bytes: u64,
+    pub(super) exact: bool,
+    pub(super) surplus_weight: u32,
+    pub(super) surplus_deficit: u64,
     pub(super) buffer_bytes: u64,
     pub(super) tokens: u64,
     pub(super) last_refill_ns: u64,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -102,6 +102,8 @@ pub(crate) struct CoSSchedulerSnapshot {
     pub name: String,
     #[serde(rename = "transmit_rate_bytes", default)]
     pub transmit_rate_bytes: u64,
+    #[serde(rename = "transmit_rate_exact", default)]
+    pub transmit_rate_exact: bool,
     #[serde(default)]
     pub priority: String,
     #[serde(rename = "buffer_size_bytes", default)]


### PR DESCRIPTION
## Summary
- carry `transmit-rate exact` from config into the userspace CoS snapshot
- treat ordinary `transmit-rate` as a guarantee and add a surplus-borrow phase for non-`exact` queues
- update CoS docs and feature-gap notes to match the new userspace behavior

## Validation
- `go test ./pkg/config ./pkg/dataplane/userspace -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml resolve_cos_queue_id_ -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml surplus_phase_ -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml estimate_cos_queue_wakeup_tick_ -- --nocapture`
- `git diff --check`