### PR TITLE
userspace: add CoS interface runtime observability

### DIFF
--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -109,7 +109,11 @@ func (c *ctl) handleShow(args []string) error {
 
 	case "class-of-service":
 		if len(args) >= 2 && args[1] == "interface" {
-			return c.showText("class-of-service")
+			topic := "class-of-service"
+			if len(args) >= 3 {
+				topic += ":" + args[2]
+			}
+			return c.showText(topic)
 		}
 		printRemoteTreeHelp("show class-of-service:", "show", "class-of-service")
 		return nil

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -846,6 +846,18 @@ Required views:
 - container state
 - shard state for many-core debugging
 
+Currently implemented:
+
+- `show class-of-service interface [IFACE[.UNIT]]`
+- prints configured shaping rate, scheduler-map, attached CoS filters, and the
+  live userspace queue/runtime state that is currently exported by the helper
+
+Still planned:
+
+- reservation detail views
+- container detail views
+- shard detail views
+
 Examples:
 
 ```text

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -2562,7 +2562,11 @@ func (c *CLI) handleShowClassOfService(args []string) error {
 		cmdtree.PrintTreeHelp("show class-of-service:", operationalTree, "show", "class-of-service")
 		return nil
 	}
-	return c.showClassOfServiceInterface()
+	selector := ""
+	if len(args) > 1 {
+		selector = args[1]
+	}
+	return c.showClassOfServiceInterface(selector)
 }
 
 func (c *CLI) handleShowServices(args []string) error {

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/rpm"
@@ -97,107 +97,13 @@ func (c *CLI) showDHCPClientIdentifier() error {
 	return nil
 }
 
-func (c *CLI) showClassOfServiceInterface() error {
+func (c *CLI) showClassOfServiceInterface(selector string) error {
 	cfg := c.store.ActiveConfig()
-	if cfg == nil {
-		fmt.Println("No active configuration")
-		return nil
+	var status *dpuserspace.ProcessStatus
+	if userspaceStatus, err := c.userspaceDataplaneStatus(); err == nil {
+		status = &userspaceStatus
 	}
-
-	// Collect interfaces with filter bindings
-	type ifBinding struct {
-		name     string
-		inputV4  string
-		outputV4 string
-		inputV6  string
-		outputV6 string
-	}
-	var bindings []ifBinding
-	for _, ifc := range cfg.Interfaces.Interfaces {
-		for _, unit := range ifc.Units {
-			b := ifBinding{name: ifc.Name}
-			b.inputV4 = unit.FilterInputV4
-			b.outputV4 = unit.FilterOutputV4
-			b.inputV6 = unit.FilterInputV6
-			b.outputV6 = unit.FilterOutputV6
-			if b.inputV4 != "" || b.outputV4 != "" || b.inputV6 != "" || b.outputV6 != "" {
-				bindings = append(bindings, b)
-			}
-		}
-	}
-
-	if len(bindings) == 0 {
-		fmt.Println("No interfaces with class-of-service configuration")
-		return nil
-	}
-
-	sort.Slice(bindings, func(i, j int) bool { return bindings[i].name < bindings[j].name })
-
-	for _, b := range bindings {
-		fmt.Printf("Interface: %s\n", b.name)
-		printFilterBinding := func(dir, family, filterName string) {
-			filters := cfg.Firewall.FiltersInet
-			if family == "inet6" {
-				filters = cfg.Firewall.FiltersInet6
-			}
-			f, ok := filters[filterName]
-			if !ok {
-				fmt.Printf("  %s filter (%s): %s (not found)\n", dir, family, filterName)
-				return
-			}
-			fmt.Printf("  %s filter (%s): %s\n", dir, family, filterName)
-			for _, term := range f.Terms {
-				var matchParts []string
-				if term.DSCP != "" {
-					matchParts = append(matchParts, "dscp "+term.DSCP)
-				}
-				if term.Protocol != "" {
-					matchParts = append(matchParts, "protocol "+term.Protocol)
-				}
-				if len(term.DestinationPorts) > 0 {
-					matchParts = append(matchParts, "port "+strings.Join(term.DestinationPorts, ","))
-				}
-				if term.ICMPType >= 0 {
-					matchParts = append(matchParts, fmt.Sprintf("icmp-type %d", term.ICMPType))
-				}
-				if term.ICMPCode >= 0 {
-					matchParts = append(matchParts, fmt.Sprintf("icmp-code %d", term.ICMPCode))
-				}
-				matchStr := "any"
-				if len(matchParts) > 0 {
-					matchStr = strings.Join(matchParts, " ")
-				}
-				action := term.Action
-				if action == "" {
-					action = "accept"
-				}
-				extras := ""
-				if term.ForwardingClass != "" {
-					extras += " forwarding-class " + term.ForwardingClass
-				}
-				if term.DSCPRewrite != "" {
-					extras += " dscp " + term.DSCPRewrite
-				}
-				if term.Log {
-					extras += " log"
-				}
-				fmt.Printf("    Term %s: match %s -> %s%s\n", term.Name, matchStr, action, extras)
-			}
-		}
-		if b.inputV4 != "" {
-			printFilterBinding("Input", "inet", b.inputV4)
-		}
-		if b.outputV4 != "" {
-			printFilterBinding("Output", "inet", b.outputV4)
-		}
-		if b.inputV6 != "" {
-			printFilterBinding("Input", "inet6", b.inputV6)
-		}
-		if b.outputV6 != "" {
-			printFilterBinding("Output", "inet6", b.outputV6)
-		}
-		fmt.Println()
-	}
+	fmt.Print(dpuserspace.FormatCoSInterfaceSummary(cfg, status, selector))
 	return nil
 }
 

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -1,0 +1,263 @@
+package userspace
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+type cosInterfaceView struct {
+	name           string
+	unit           int
+	cosUnit        *config.CoSInterfaceUnit
+	interfaceUnit  *config.InterfaceUnit
+	interfaceState *CoSInterfaceStatus
+}
+
+type cosQueueView struct {
+	queueID         int
+	forwardingClass string
+	priority        string
+	exact           bool
+	transmitRate    uint64
+	bufferBytes     uint64
+	queuedPackets   uint64
+	queuedBytes     uint64
+	runnable        int
+	parked          int
+	nextWakeupTick  uint64
+	surplusDeficit  uint64
+}
+
+func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
+	if cfg == nil {
+		return "No active configuration\n"
+	}
+	if cfg.ClassOfService == nil || len(cfg.ClassOfService.Interfaces) == 0 {
+		return "No class-of-service interfaces configured\n"
+	}
+
+	views := configuredCoSInterfaceViews(cfg, status, selector)
+	if len(views) == 0 {
+		if selector == "" {
+			return "No class-of-service interfaces configured\n"
+		}
+		return fmt.Sprintf("No class-of-service interface matches %s\n", selector)
+	}
+
+	var b strings.Builder
+	for idx, view := range views {
+		if idx > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "Interface: %s\n", view.name)
+		if view.cosUnit != nil {
+			fmt.Fprintf(&b, "  Scheduler map:            %s\n", emptyDash(view.cosUnit.SchedulerMap))
+			fmt.Fprintf(&b, "  Shaping rate:             %s\n", formatCoSRate(view.cosUnit.ShapingRateBytes))
+			fmt.Fprintf(&b, "  Burst size:               %s\n", formatCoSBytes(view.cosUnit.BurstSizeBytes))
+		}
+		if view.interfaceUnit != nil {
+			if view.interfaceUnit.FilterInputV4 != "" {
+				fmt.Fprintf(&b, "  Input filter (inet):      %s\n", view.interfaceUnit.FilterInputV4)
+			}
+			if view.interfaceUnit.FilterOutputV4 != "" {
+				fmt.Fprintf(&b, "  Output filter (inet):     %s\n", view.interfaceUnit.FilterOutputV4)
+			}
+			if view.interfaceUnit.FilterInputV6 != "" {
+				fmt.Fprintf(&b, "  Input filter (inet6):     %s\n", view.interfaceUnit.FilterInputV6)
+			}
+			if view.interfaceUnit.FilterOutputV6 != "" {
+				fmt.Fprintf(&b, "  Output filter (inet6):    %s\n", view.interfaceUnit.FilterOutputV6)
+			}
+		}
+		if view.interfaceState == nil {
+			b.WriteString("  Runtime:                  unavailable\n")
+		} else {
+			fmt.Fprintf(&b, "  Runtime workers:          %d\n", view.interfaceState.WorkerInstances)
+			fmt.Fprintf(&b, "  Runtime queues:           nonempty=%d runnable=%d\n",
+				view.interfaceState.NonemptyQueues,
+				view.interfaceState.RunnableQueues)
+			fmt.Fprintf(&b, "  Timer wheel sleepers:     level0=%d level1=%d\n",
+				view.interfaceState.TimerLevel0Sleepers,
+				view.interfaceState.TimerLevel1Sleepers)
+		}
+		queues := buildCoSQueueViews(cfg, view)
+		if len(queues) == 0 {
+			b.WriteString("  Queues:                   none\n")
+			continue
+		}
+		b.WriteString("  Queues:\n")
+		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "    Queue\tClass\tPriority\tExact\tTransmit rate\tBuffer\tQueued pkts\tQueued bytes\tRunnable\tParked\tNext wake\tSurplus deficit")
+		for _, queue := range queues {
+			fmt.Fprintf(tw, "    %d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%d\t%d\t%s\t%s\n",
+				queue.queueID,
+				emptyDash(queue.forwardingClass),
+				queue.priority,
+				yesNo(queue.exact),
+				formatCoSRate(queue.transmitRate),
+				formatCoSBytes(queue.bufferBytes),
+				queue.queuedPackets,
+				formatCoSBytes(queue.queuedBytes),
+				queue.runnable,
+				queue.parked,
+				formatWakeTick(queue.nextWakeupTick),
+				formatCoSBytes(queue.surplusDeficit),
+			)
+		}
+		_ = tw.Flush()
+	}
+	return b.String()
+}
+
+func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, selector string) []cosInterfaceView {
+	runtimeByName := make(map[string]*CoSInterfaceStatus)
+	if status != nil {
+		for i := range status.CoSInterfaces {
+			iface := &status.CoSInterfaces[i]
+			runtimeByName[iface.InterfaceName] = iface
+		}
+	}
+	selector = strings.TrimSpace(selector)
+	views := make([]cosInterfaceView, 0)
+	for ifName, iface := range cfg.ClassOfService.Interfaces {
+		for unitNum, cosUnit := range iface.Units {
+			logicalName := fmt.Sprintf("%s.%d", ifName, unitNum)
+			if selector != "" && selector != ifName && selector != logicalName {
+				continue
+			}
+			var interfaceUnit *config.InterfaceUnit
+			if cfg.Interfaces.Interfaces != nil {
+				if intf := cfg.Interfaces.Interfaces[ifName]; intf != nil && intf.Units != nil {
+					interfaceUnit = intf.Units[unitNum]
+				}
+			}
+			views = append(views, cosInterfaceView{
+				name:           logicalName,
+				unit:           unitNum,
+				cosUnit:        cosUnit,
+				interfaceUnit:  interfaceUnit,
+				interfaceState: runtimeByName[logicalName],
+			})
+		}
+	}
+	sort.Slice(views, func(i, j int) bool {
+		if views[i].name == views[j].name {
+			return views[i].unit < views[j].unit
+		}
+		return views[i].name < views[j].name
+	})
+	return views
+}
+
+func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueView {
+	queueViews := make(map[int]cosQueueView)
+	if cfg.ClassOfService != nil && view.cosUnit != nil {
+		schedulerMap := cfg.ClassOfService.SchedulerMaps[view.cosUnit.SchedulerMap]
+		if schedulerMap != nil {
+			for className, entry := range schedulerMap.Entries {
+				class := cfg.ClassOfService.ForwardingClasses[className]
+				if class == nil {
+					continue
+				}
+				qv := queueViews[class.Queue]
+				qv.queueID = class.Queue
+				qv.forwardingClass = className
+				if sched := cfg.ClassOfService.Schedulers[entry.Scheduler]; sched != nil {
+					qv.exact = sched.TransmitRateExact
+					qv.transmitRate = sched.TransmitRateBytes
+					qv.bufferBytes = sched.BufferSizeBytes
+					if sched.Priority != "" {
+						qv.priority = sched.Priority
+					}
+				}
+				queueViews[class.Queue] = qv
+			}
+		}
+	}
+	if view.interfaceState != nil {
+		for _, runtimeQueue := range view.interfaceState.Queues {
+			qv := queueViews[int(runtimeQueue.QueueID)]
+			qv.queueID = int(runtimeQueue.QueueID)
+			if runtimeQueue.ForwardingClass != "" {
+				qv.forwardingClass = runtimeQueue.ForwardingClass
+			}
+			qv.priority = fmt.Sprintf("%d", runtimeQueue.Priority)
+			qv.exact = runtimeQueue.Exact
+			if runtimeQueue.TransmitRateBytes > 0 {
+				qv.transmitRate = runtimeQueue.TransmitRateBytes
+			}
+			if runtimeQueue.BufferBytes > 0 {
+				qv.bufferBytes = runtimeQueue.BufferBytes
+			}
+			qv.queuedPackets = runtimeQueue.QueuedPackets
+			qv.queuedBytes = runtimeQueue.QueuedBytes
+			qv.runnable = runtimeQueue.RunnableInstances
+			qv.parked = runtimeQueue.ParkedInstances
+			qv.nextWakeupTick = runtimeQueue.NextWakeupTick
+			qv.surplusDeficit = runtimeQueue.SurplusDeficitBytes
+			queueViews[qv.queueID] = qv
+		}
+	}
+	out := make([]cosQueueView, 0, len(queueViews))
+	for _, queue := range queueViews {
+		if queue.priority == "" {
+			queue.priority = "-"
+		}
+		out = append(out, queue)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].queueID < out[j].queueID })
+	return out
+}
+
+func formatCoSRate(bytesPerSecond uint64) string {
+	if bytesPerSecond == 0 {
+		return "-"
+	}
+	bitsPerSecond := float64(bytesPerSecond) * 8
+	units := []string{"b/s", "Kb/s", "Mb/s", "Gb/s", "Tb/s"}
+	unitIdx := 0
+	for bitsPerSecond >= 1000 && unitIdx < len(units)-1 {
+		bitsPerSecond /= 1000
+		unitIdx++
+	}
+	return fmt.Sprintf("%.2f %s", bitsPerSecond, units[unitIdx])
+}
+
+func formatCoSBytes(bytes uint64) string {
+	if bytes == 0 {
+		return "-"
+	}
+	value := float64(bytes)
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
+	unitIdx := 0
+	for value >= 1024 && unitIdx < len(units)-1 {
+		value /= 1024
+		unitIdx++
+	}
+	return fmt.Sprintf("%.2f %s", value, units[unitIdx])
+}
+
+func formatWakeTick(tick uint64) string {
+	if tick == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", tick)
+}
+
+func emptyDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -144,12 +144,7 @@ func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, sele
 			})
 		}
 	}
-	sort.Slice(views, func(i, j int) bool {
-		if views[i].name == views[j].name {
-			return views[i].unit < views[j].unit
-		}
-		return views[i].name < views[j].name
-	})
+	sort.Slice(views, func(i, j int) bool { return views[i].name < views[j].name })
 	return views
 }
 

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -1,0 +1,130 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func testCoSConfig() *config.Config {
+	return &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			ForwardingClasses: map[string]*config.CoSForwardingClass{
+				"best-effort":    {Name: "best-effort", Queue: 0},
+				"bandwidth-10mb": {Name: "bandwidth-10mb", Queue: 4},
+			},
+			Schedulers: map[string]*config.CoSScheduler{
+				"be":   {Name: "be", TransmitRateBytes: 1_875_000},
+				"10mb": {Name: "10mb", TransmitRateBytes: 1_250_000, TransmitRateExact: true},
+			},
+			SchedulerMaps: map[string]*config.CoSSchedulerMap{
+				"bandwidth-limit": {
+					Name: "bandwidth-limit",
+					Entries: map[string]*config.CoSSchedulerMapEntry{
+						"best-effort":    {ForwardingClass: "best-effort", Scheduler: "be"},
+						"bandwidth-10mb": {ForwardingClass: "bandwidth-10mb", Scheduler: "10mb"},
+					},
+				},
+			},
+			Interfaces: map[string]*config.CoSInterface{
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.CoSInterfaceUnit{
+						80: {
+							Unit:             80,
+							ShapingRateBytes: 1_875_000,
+							BurstSizeBytes:   65_536,
+							SchedulerMap:     "bandwidth-limit",
+						},
+					},
+				},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.InterfaceUnit{
+						80: {
+							Number:         80,
+							FilterOutputV4: "bandwidth-output",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestFormatCoSInterfaceSummaryShowsConfigOnlyInterface(t *testing.T) {
+	out := FormatCoSInterfaceSummary(testCoSConfig(), nil, "reth0.80")
+	for _, want := range []string{
+		"Interface: reth0.80",
+		"Scheduler map:            bandwidth-limit",
+		"Output filter (inet):     bandwidth-output",
+		"Runtime:                  unavailable",
+		"best-effort",
+		"bandwidth-10mb",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:       "reth0.80",
+				WorkerInstances:     2,
+				NonemptyQueues:      1,
+				RunnableQueues:      1,
+				TimerLevel0Sleepers: 1,
+				TimerLevel1Sleepers: 0,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:             4,
+						ForwardingClass:     "bandwidth-10mb",
+						Priority:            1,
+						Exact:               true,
+						TransmitRateBytes:   1_250_000,
+						BufferBytes:         32 * 1024,
+						QueuedPackets:       3,
+						QueuedBytes:         4096,
+						RunnableInstances:   1,
+						ParkedInstances:     1,
+						NextWakeupTick:      77,
+						SurplusDeficitBytes: 2048,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "")
+	for _, want := range []string{
+		"Runtime workers:          2",
+		"Runtime queues:           nonempty=1 runnable=1",
+		"Timer wheel sleepers:     level0=1 level1=0",
+		"bandwidth-10mb",
+		"\t", // ensure tabwriter path generated a table row before flush normalization
+	} {
+		if want == "\t" {
+			continue
+		}
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "77") || !strings.Contains(out, "4.00 KiB") {
+		t.Fatalf("expected runtime queue metrics in output:\n%s", out)
+	}
+}
+
+func TestFormatCoSInterfaceSummaryFiltersByBaseInterface(t *testing.T) {
+	out := FormatCoSInterfaceSummary(testCoSConfig(), nil, "reth0")
+	if !strings.Contains(out, "Interface: reth0.80") {
+		t.Fatalf("expected base selector to include logical unit:\n%s", out)
+	}
+}

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -107,12 +107,9 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 		"Runtime workers:          2",
 		"Runtime queues:           nonempty=1 runnable=1",
 		"Timer wheel sleepers:     level0=1 level1=0",
+		"Queue  Class           Priority",
 		"bandwidth-10mb",
-		"\t", // ensure tabwriter path generated a table row before flush normalization
 	} {
-		if want == "\t" {
-			continue
-		}
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in output:\n%s", want, out)
 		}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -386,6 +386,7 @@ type ProcessStatus struct {
 	Bindings               []BindingStatus       `json:"bindings,omitempty"`
 	RecentSessionDeltas    []SessionDeltaInfo    `json:"recent_session_deltas,omitempty"`
 	RecentExceptions       []ExceptionStatus     `json:"recent_exceptions,omitempty"`
+	CoSInterfaces          []CoSInterfaceStatus  `json:"cos_interfaces,omitempty"`
 	LastResolution         *PacketResolution     `json:"last_resolution,omitempty"`
 	SlowPath               SlowPathStatus        `json:"slow_path,omitempty"`
 	LastCacheFlushAt       uint64                `json:"last_cache_flush_at,omitempty"` // monotonic secs (#312)
@@ -393,6 +394,35 @@ type ProcessStatus struct {
 	ConfiguredMode         string                `json:"configured_mode,omitempty"`     // Desired mode from config
 	EntryPrograms          map[int]string        `json:"entry_programs,omitempty"`      // ifindex -> attached XDP program name
 	FallbackCounters       map[string]uint64     `json:"fallback_counters,omitempty"`   // reason_name -> count
+}
+
+type CoSInterfaceStatus struct {
+	Ifindex             int              `json:"ifindex,omitempty"`
+	InterfaceName       string           `json:"interface_name,omitempty"`
+	ShapingRateBytes    uint64           `json:"shaping_rate_bytes,omitempty"`
+	BurstBytes          uint64           `json:"burst_bytes,omitempty"`
+	WorkerInstances     int              `json:"worker_instances,omitempty"`
+	NonemptyQueues      int              `json:"nonempty_queues,omitempty"`
+	RunnableQueues      int              `json:"runnable_queues,omitempty"`
+	TimerLevel0Sleepers int              `json:"timer_level0_sleepers,omitempty"`
+	TimerLevel1Sleepers int              `json:"timer_level1_sleepers,omitempty"`
+	Queues              []CoSQueueStatus `json:"queues,omitempty"`
+}
+
+type CoSQueueStatus struct {
+	QueueID             int    `json:"queue_id,omitempty"`
+	ForwardingClass     string `json:"forwarding_class,omitempty"`
+	Priority            int    `json:"priority,omitempty"`
+	Exact               bool   `json:"exact,omitempty"`
+	TransmitRateBytes   uint64 `json:"transmit_rate_bytes,omitempty"`
+	BufferBytes         uint64 `json:"buffer_bytes,omitempty"`
+	WorkerInstances     int    `json:"worker_instances,omitempty"`
+	QueuedPackets       uint64 `json:"queued_packets,omitempty"`
+	QueuedBytes         uint64 `json:"queued_bytes,omitempty"`
+	RunnableInstances   int    `json:"runnable_instances,omitempty"`
+	ParkedInstances     int    `json:"parked_instances,omitempty"`
+	NextWakeupTick      uint64 `json:"next_wakeup_tick,omitempty"`
+	SurplusDeficitBytes uint64 `json:"surplus_deficit_bytes,omitempty"`
 }
 
 type HAStateUpdateRequest struct {

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -1314,6 +1314,19 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 		return &pb.ShowTextResponse{Output: buf.String()}, nil
 	}
 
+	if req.Topic == "class-of-service" || strings.HasPrefix(req.Topic, "class-of-service:") {
+		selector := ""
+		if strings.HasPrefix(req.Topic, "class-of-service:") {
+			selector = strings.TrimPrefix(req.Topic, "class-of-service:")
+		}
+		var status *dpuserspace.ProcessStatus
+		if userspaceStatus, err := s.userspaceDataplaneStatus(); err == nil {
+			status = &userspaceStatus
+		}
+		buf.WriteString(dpuserspace.FormatCoSInterfaceSummary(cfg, status, selector))
+		return &pb.ShowTextResponse{Output: buf.String()}, nil
+	}
+
 	if strings.HasPrefix(req.Topic, "screen-ids-option:") {
 		profileName := strings.TrimPrefix(req.Topic, "screen-ids-option:")
 		if cfg == nil || len(cfg.Security.Screen) == 0 {
@@ -2093,102 +2106,6 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 			}
 			if cfg != nil && len(cfg.Security.IPsec.VPNs) > 0 {
 				fmt.Fprintf(&buf, "\n  Configured VPNs: %d\n", len(cfg.Security.IPsec.VPNs))
-			}
-		}
-
-	case "class-of-service":
-		if cfg == nil {
-			buf.WriteString("No active configuration\n")
-		} else {
-			type ifBinding struct {
-				name     string
-				inputV4  string
-				outputV4 string
-				inputV6  string
-				outputV6 string
-			}
-			var bindings []ifBinding
-			for _, ifc := range cfg.Interfaces.Interfaces {
-				for _, unit := range ifc.Units {
-					b := ifBinding{name: ifc.Name}
-					b.inputV4 = unit.FilterInputV4
-					b.outputV4 = unit.FilterOutputV4
-					b.inputV6 = unit.FilterInputV6
-					b.outputV6 = unit.FilterOutputV6
-					if b.inputV4 != "" || b.outputV4 != "" || b.inputV6 != "" || b.outputV6 != "" {
-						bindings = append(bindings, b)
-					}
-				}
-			}
-			if len(bindings) == 0 {
-				buf.WriteString("No interfaces with class-of-service configuration\n")
-			} else {
-				sort.Slice(bindings, func(i, j int) bool { return bindings[i].name < bindings[j].name })
-				printBinding := func(dir, family, filterName string) {
-					filters := cfg.Firewall.FiltersInet
-					if family == "inet6" {
-						filters = cfg.Firewall.FiltersInet6
-					}
-					f, ok := filters[filterName]
-					if !ok {
-						fmt.Fprintf(&buf, "  %s filter (%s): %s (not found)\n", dir, family, filterName)
-						return
-					}
-					fmt.Fprintf(&buf, "  %s filter (%s): %s\n", dir, family, filterName)
-					for _, term := range f.Terms {
-						var matchParts []string
-						if term.DSCP != "" {
-							matchParts = append(matchParts, "dscp "+term.DSCP)
-						}
-						if term.Protocol != "" {
-							matchParts = append(matchParts, "protocol "+term.Protocol)
-						}
-						if len(term.DestinationPorts) > 0 {
-							matchParts = append(matchParts, "port "+strings.Join(term.DestinationPorts, ","))
-						}
-						if term.ICMPType >= 0 {
-							matchParts = append(matchParts, fmt.Sprintf("icmp-type %d", term.ICMPType))
-						}
-						if term.ICMPCode >= 0 {
-							matchParts = append(matchParts, fmt.Sprintf("icmp-code %d", term.ICMPCode))
-						}
-						matchStr := "any"
-						if len(matchParts) > 0 {
-							matchStr = strings.Join(matchParts, " ")
-						}
-						action := term.Action
-						if action == "" {
-							action = "accept"
-						}
-						extras := ""
-						if term.ForwardingClass != "" {
-							extras += " forwarding-class " + term.ForwardingClass
-						}
-						if term.DSCPRewrite != "" {
-							extras += " dscp " + term.DSCPRewrite
-						}
-						if term.Log {
-							extras += " log"
-						}
-						fmt.Fprintf(&buf, "    Term %s: match %s -> %s%s\n", term.Name, matchStr, action, extras)
-					}
-				}
-				for _, b := range bindings {
-					fmt.Fprintf(&buf, "Interface: %s\n", b.name)
-					if b.inputV4 != "" {
-						printBinding("Input", "inet", b.inputV4)
-					}
-					if b.outputV4 != "" {
-						printBinding("Output", "inet", b.outputV4)
-					}
-					if b.inputV6 != "" {
-						printBinding("Input", "inet6", b.inputV6)
-					}
-					if b.outputV6 != "" {
-						printBinding("Output", "inet6", b.outputV6)
-					}
-					buf.WriteString("\n")
-				}
 			}
 		}
 

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -867,9 +867,10 @@ impl Coordinator {
                     if q.forwarding_class.is_empty() {
                         q.forwarding_class = queue.forwarding_class.clone();
                     }
-                    q.priority = q.priority.min(queue.priority);
                     if q.worker_instances == 0 {
                         q.priority = queue.priority;
+                    } else {
+                        q.priority = q.priority.min(queue.priority);
                     }
                     q.exact = queue.exact;
                     q.transmit_rate_bytes = q.transmit_rate_bytes.max(queue.transmit_rate_bytes);

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -595,6 +595,7 @@ impl Coordinator {
             let stop = Arc::new(AtomicBool::new(false));
             let heartbeat = Arc::new(AtomicU64::new(monotonic_nanos()));
             let session_export_ack = Arc::new(AtomicU64::new(0));
+            let cos_status = Arc::new(ArcSwap::from_pointee(Vec::new()));
             let commands = worker_command_queues
                 .get(&worker_id)
                 .cloned()
@@ -625,6 +626,7 @@ impl Coordinator {
             let shared_fabrics = self.shared_fabrics.clone();
             let rg_epochs = self.rg_epochs.clone();
             let event_stream_handle = self.event_stream_worker_handle();
+            let cos_status_clone = cos_status.clone();
             let join = thread::Builder::new()
                 .name(format!("xpf-userspace-worker-{worker_id}"))
                 .spawn(move || {
@@ -654,6 +656,7 @@ impl Coordinator {
                         shared_fabrics,
                         event_stream_handle,
                         rg_epochs,
+                        cos_status_clone,
                     );
                 });
             match join {
@@ -669,6 +672,7 @@ impl Coordinator {
                             heartbeat,
                             commands,
                             session_export_ack,
+                            cos_status,
                             join: Some(join),
                         },
                     );
@@ -832,6 +836,86 @@ impl Coordinator {
             .as_ref()
             .map(|slow| slow.status())
             .unwrap_or_else(|| self.last_slow_path_status.clone())
+    }
+
+    pub fn cos_statuses(&self) -> Vec<crate::protocol::CoSInterfaceStatus> {
+        let mut interfaces = BTreeMap::<i32, crate::protocol::CoSInterfaceStatus>::new();
+        let mut queue_maps = BTreeMap::<i32, BTreeMap<u8, crate::protocol::CoSQueueStatus>>::new();
+        for worker in self.workers.values() {
+            let snapshot = worker.cos_status.load();
+            for iface in snapshot.iter() {
+                let entry = interfaces.entry(iface.ifindex).or_default();
+                entry.ifindex = iface.ifindex;
+                if entry.interface_name.is_empty() {
+                    entry.interface_name = iface.interface_name.clone();
+                }
+                entry.shaping_rate_bytes = entry.shaping_rate_bytes.max(iface.shaping_rate_bytes);
+                entry.burst_bytes = entry.burst_bytes.max(iface.burst_bytes);
+                entry.worker_instances = entry
+                    .worker_instances
+                    .saturating_add(iface.worker_instances);
+                entry.timer_level0_sleepers = entry
+                    .timer_level0_sleepers
+                    .saturating_add(iface.timer_level0_sleepers);
+                entry.timer_level1_sleepers = entry
+                    .timer_level1_sleepers
+                    .saturating_add(iface.timer_level1_sleepers);
+                let queue_map = queue_maps.entry(iface.ifindex).or_default();
+                for queue in &iface.queues {
+                    let q = queue_map.entry(queue.queue_id).or_default();
+                    q.queue_id = queue.queue_id;
+                    if q.forwarding_class.is_empty() {
+                        q.forwarding_class = queue.forwarding_class.clone();
+                    }
+                    q.priority = q.priority.min(queue.priority);
+                    if q.worker_instances == 0 {
+                        q.priority = queue.priority;
+                    }
+                    q.exact = queue.exact;
+                    q.transmit_rate_bytes = q.transmit_rate_bytes.max(queue.transmit_rate_bytes);
+                    q.buffer_bytes = q.buffer_bytes.max(queue.buffer_bytes);
+                    q.worker_instances = q.worker_instances.saturating_add(queue.worker_instances);
+                    q.queued_packets = q.queued_packets.saturating_add(queue.queued_packets);
+                    q.queued_bytes = q.queued_bytes.saturating_add(queue.queued_bytes);
+                    q.runnable_instances = q
+                        .runnable_instances
+                        .saturating_add(queue.runnable_instances);
+                    q.parked_instances = q.parked_instances.saturating_add(queue.parked_instances);
+                    if q.next_wakeup_tick == 0
+                        || (queue.next_wakeup_tick > 0
+                            && queue.next_wakeup_tick < q.next_wakeup_tick)
+                    {
+                        q.next_wakeup_tick = queue.next_wakeup_tick;
+                    }
+                    q.surplus_deficit_bytes = q
+                        .surplus_deficit_bytes
+                        .saturating_add(queue.surplus_deficit_bytes);
+                }
+            }
+        }
+        let mut out = Vec::with_capacity(interfaces.len());
+        for (ifindex, mut iface) in interfaces {
+            if let Some(queue_map) = queue_maps.remove(&ifindex) {
+                iface.queues = queue_map.into_values().collect();
+                iface.nonempty_queues = iface
+                    .queues
+                    .iter()
+                    .filter(|queue| queue.queued_packets > 0 || queue.queued_bytes > 0)
+                    .count();
+                iface.runnable_queues = iface
+                    .queues
+                    .iter()
+                    .filter(|queue| queue.runnable_instances > 0)
+                    .count();
+            }
+            out.push(iface);
+        }
+        out.sort_by(|a, b| {
+            a.interface_name
+                .cmp(&b.interface_name)
+                .then(a.ifindex.cmp(&b.ifindex))
+        });
+        out
     }
 
     pub fn drain_session_deltas(&self, max: usize) -> Vec<SessionDeltaInfo> {

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -95,6 +95,9 @@ pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingSta
             iface.linux_name.clone()
         };
         state.ifindex_to_name.insert(iface.ifindex, label);
+        state
+            .ifindex_to_config_name
+            .insert(iface.ifindex, iface.name.clone());
         name_to_ifindex.insert(iface.name.clone(), iface.ifindex);
         if !iface.linux_name.is_empty() {
             linux_to_ifindex.insert(iface.linux_name.clone(), iface.ifindex);

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -679,6 +679,7 @@ mod tests {
                 heartbeat: Arc::new(AtomicU64::new(0)),
                 commands: worker_commands.clone(),
                 session_export_ack: Arc::new(AtomicU64::new(0)),
+                cos_status: Arc::new(ArcSwap::from_pointee(Vec::new())),
                 join: None,
             },
         );

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -90,6 +90,7 @@ pub(super) struct WorkerHandle {
     pub(super) heartbeat: Arc<AtomicU64>,
     pub(super) commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
     pub(super) session_export_ack: Arc<AtomicU64>,
+    pub(super) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
     pub(super) join: Option<JoinHandle<()>>,
 }
 
@@ -141,6 +142,7 @@ pub(super) struct ForwardingState {
     pub(super) tunnel_endpoint_by_ifindex: FastMap<i32, u16>,
     pub(super) neighbors: FastMap<(i32, IpAddr), NeighborEntry>,
     pub(super) ifindex_to_name: FastMap<i32, String>,
+    pub(super) ifindex_to_config_name: FastMap<i32, String>,
     pub(super) ifindex_to_zone: FastMap<i32, String>,
     pub(super) zone_name_to_id: FastMap<String, u16>,
     pub(super) zone_id_to_name: FastMap<u16, String>,

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1339,22 +1339,16 @@ where
                     .map(std::vec::Vec::len)
                     .sum::<usize>(),
             );
-            let queue_config_by_id = forwarding
-                .cos
-                .interfaces
-                .get(&ifindex)
-                .map(|cfg| {
-                    cfg.queues
-                        .iter()
-                        .map(|queue| (queue.queue_id, queue))
-                        .collect::<BTreeMap<_, _>>()
-                })
-                .unwrap_or_default();
+            let interface_config = forwarding.cos.interfaces.get(&ifindex);
             let queue_map = queue_maps.entry(ifindex).or_default();
             for queue in &root.queues {
                 let status = queue_map.entry(queue.queue_id).or_default();
                 status.queue_id = queue.queue_id;
-                if let Some(config) = queue_config_by_id.get(&queue.queue_id) {
+                if let Some(config) = interface_config.and_then(|cfg| {
+                    cfg.queues
+                        .iter()
+                        .find(|config| config.queue_id == queue.queue_id)
+                }) {
                     if status.forwarding_class.is_empty() {
                         status.forwarding_class = config.forwarding_class.clone();
                     }

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -399,8 +399,10 @@ pub(crate) fn worker_loop(
     shared_fabrics: Arc<ArcSwap<Vec<FabricLink>>>,
     event_stream: Option<crate::event_stream::EventStreamWorkerHandle>,
     rg_epochs: Arc<[AtomicU32; MAX_RG_EPOCHS]>,
+    cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
 ) {
     pin_current_thread(worker_id);
+    const COS_STATUS_INTERVAL_NS: u64 = 100_000_000;
     let ha_startup_grace_until_secs =
         (monotonic_nanos() / 1_000_000_000).saturating_add(TUNNEL_HA_STARTUP_GRACE_SECS);
     let mut validation = **shared_validation.load();
@@ -565,6 +567,11 @@ pub(crate) fn worker_loop(
         .map(|binding| binding.conntrack_v6_fd)
         .unwrap_or(-1);
     let mut last_ct_refresh_ns: u64 = 0;
+    cos_status.store(Arc::new(build_worker_cos_statuses(
+        &bindings,
+        forwarding.as_ref(),
+    )));
+    let mut last_cos_status_ns = monotonic_nanos();
     while !stop.load(Ordering::Relaxed) {
         let loop_now_ns = monotonic_nanos();
         let loop_now_secs = loop_now_ns / 1_000_000_000;
@@ -767,6 +774,13 @@ pub(crate) fn worker_loop(
         }
         if !bindings.is_empty() {
             poll_start = (poll_start + 1) % bindings.len();
+        }
+        if loop_now_ns.saturating_sub(last_cos_status_ns) >= COS_STATUS_INTERVAL_NS {
+            cos_status.store(Arc::new(build_worker_cos_statuses(
+                &bindings,
+                forwarding.as_ref(),
+            )));
+            last_cos_status_ns = loop_now_ns;
         }
         if !command_results.exported_sequences.is_empty() {
             while sessions.has_pending_deltas() {
@@ -1270,7 +1284,238 @@ pub(crate) fn worker_loop(
             }
         }
     }
+    cos_status.store(Arc::new(build_worker_cos_statuses(
+        &bindings,
+        forwarding.as_ref(),
+    )));
     heartbeat.store(monotonic_nanos(), Ordering::Relaxed);
+}
+
+fn build_worker_cos_statuses(
+    bindings: &[BindingWorker],
+    forwarding: &ForwardingState,
+) -> Vec<crate::protocol::CoSInterfaceStatus> {
+    build_worker_cos_statuses_from_maps(
+        bindings.iter().map(|binding| &binding.cos_interfaces),
+        forwarding,
+    )
+}
+
+fn build_worker_cos_statuses_from_maps<'a, I>(
+    cos_maps: I,
+    forwarding: &ForwardingState,
+) -> Vec<crate::protocol::CoSInterfaceStatus>
+where
+    I: IntoIterator<Item = &'a FastMap<i32, CoSInterfaceRuntime>>,
+{
+    let mut interfaces = BTreeMap::<i32, crate::protocol::CoSInterfaceStatus>::new();
+    let mut queue_maps = BTreeMap::<i32, BTreeMap<u8, crate::protocol::CoSQueueStatus>>::new();
+    for cos_map in cos_maps {
+        for (&ifindex, root) in cos_map {
+            let entry = interfaces.entry(ifindex).or_default();
+            entry.ifindex = ifindex;
+            if entry.interface_name.is_empty() {
+                entry.interface_name = forwarding
+                    .ifindex_to_config_name
+                    .get(&ifindex)
+                    .cloned()
+                    .or_else(|| forwarding.ifindex_to_name.get(&ifindex).cloned())
+                    .unwrap_or_else(|| format!("ifindex-{ifindex}"));
+            }
+            entry.shaping_rate_bytes = entry.shaping_rate_bytes.max(root.shaping_rate_bytes);
+            entry.burst_bytes = entry.burst_bytes.max(root.burst_bytes);
+            entry.worker_instances = entry.worker_instances.saturating_add(1);
+            entry.timer_level0_sleepers = entry.timer_level0_sleepers.saturating_add(
+                root.timer_wheel
+                    .level0
+                    .iter()
+                    .map(std::vec::Vec::len)
+                    .sum::<usize>(),
+            );
+            entry.timer_level1_sleepers = entry.timer_level1_sleepers.saturating_add(
+                root.timer_wheel
+                    .level1
+                    .iter()
+                    .map(std::vec::Vec::len)
+                    .sum::<usize>(),
+            );
+            let queue_config_by_id = forwarding
+                .cos
+                .interfaces
+                .get(&ifindex)
+                .map(|cfg| {
+                    cfg.queues
+                        .iter()
+                        .map(|queue| (queue.queue_id, queue))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            let queue_map = queue_maps.entry(ifindex).or_default();
+            for queue in &root.queues {
+                let status = queue_map.entry(queue.queue_id).or_default();
+                status.queue_id = queue.queue_id;
+                if let Some(config) = queue_config_by_id.get(&queue.queue_id) {
+                    if status.forwarding_class.is_empty() {
+                        status.forwarding_class = config.forwarding_class.clone();
+                    }
+                }
+                if status.worker_instances == 0 {
+                    status.priority = queue.priority;
+                }
+                status.exact = queue.exact;
+                status.transmit_rate_bytes =
+                    status.transmit_rate_bytes.max(queue.transmit_rate_bytes);
+                status.buffer_bytes = status.buffer_bytes.max(queue.buffer_bytes);
+                status.worker_instances = status.worker_instances.saturating_add(1);
+                status.queued_packets = status
+                    .queued_packets
+                    .saturating_add(queue.items.len() as u64);
+                status.queued_bytes = status.queued_bytes.saturating_add(queue.queued_bytes);
+                if queue.runnable {
+                    status.runnable_instances = status.runnable_instances.saturating_add(1);
+                }
+                if queue.parked {
+                    status.parked_instances = status.parked_instances.saturating_add(1);
+                }
+                if status.next_wakeup_tick == 0
+                    || (queue.next_wakeup_tick > 0
+                        && queue.next_wakeup_tick < status.next_wakeup_tick)
+                {
+                    status.next_wakeup_tick = queue.next_wakeup_tick;
+                }
+                status.surplus_deficit_bytes = status
+                    .surplus_deficit_bytes
+                    .saturating_add(queue.surplus_deficit);
+            }
+        }
+    }
+    let mut out = Vec::with_capacity(interfaces.len());
+    for (ifindex, mut iface) in interfaces {
+        if let Some(queue_map) = queue_maps.remove(&ifindex) {
+            iface.queues = queue_map.into_values().collect();
+            iface.nonempty_queues = iface
+                .queues
+                .iter()
+                .filter(|queue| queue.queued_packets > 0 || queue.queued_bytes > 0)
+                .count();
+            iface.runnable_queues = iface
+                .queues
+                .iter()
+                .filter(|queue| queue.runnable_instances > 0)
+                .count();
+        }
+        out.push(iface);
+    }
+    out.sort_by(|a, b| {
+        a.interface_name
+            .cmp(&b.interface_name)
+            .then(a.ifindex.cmp(&b.ifindex))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_tx_request(ifindex: i32) -> TxRequest {
+        TxRequest {
+            bytes: vec![0; 128],
+            expected_ports: None,
+            expected_addr_family: 0,
+            expected_protocol: 0,
+            flow_key: None,
+            egress_ifindex: ifindex,
+            cos_queue_id: Some(4),
+        }
+    }
+
+    #[test]
+    fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
+        let mut forwarding = ForwardingState::default();
+        forwarding
+            .ifindex_to_config_name
+            .insert(80, "reth0.80".to_string());
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 1_875_000,
+                burst_bytes: 64 * 1024,
+                default_queue: 0,
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 4,
+                    forwarding_class: "bandwidth-10mb".to_string(),
+                    priority: 1,
+                    transmit_rate_bytes: 1_250_000,
+                    exact: false,
+                    surplus_weight: 1,
+                    buffer_bytes: 32 * 1024,
+                }],
+            },
+        );
+
+        let make_root = |queued_bytes, runnable, parked, wake_tick| CoSInterfaceRuntime {
+            shaping_rate_bytes: 1_875_000,
+            burst_bytes: 64 * 1024,
+            tokens: 0,
+            last_refill_ns: 0,
+            default_queue: 0,
+            nonempty_queues: 1,
+            runnable_queues: usize::from(runnable),
+            guarantee_rr: 0,
+            queues: vec![CoSQueueRuntime {
+                queue_id: 4,
+                priority: 1,
+                transmit_rate_bytes: 1_250_000,
+                exact: false,
+                surplus_weight: 1,
+                surplus_deficit: 512,
+                buffer_bytes: 32 * 1024,
+                tokens: 0,
+                last_refill_ns: 0,
+                queued_bytes,
+                runnable,
+                parked,
+                next_wakeup_tick: wake_tick,
+                wheel_level: 0,
+                wheel_slot: 0,
+                items: VecDeque::from([CoSPendingTxItem::Local(test_tx_request(80))]),
+            }],
+            queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
+            rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
+            timer_wheel: CoSTimerWheelRuntime {
+                current_tick: 0,
+                level0: std::array::from_fn(|idx| if idx == 3 { vec![0] } else { Vec::new() }),
+                level1: std::array::from_fn(|idx| if idx == 1 { vec![0] } else { Vec::new() }),
+            },
+        };
+
+        let mut first = FastMap::default();
+        first.insert(80, make_root(1024, true, false, 0));
+        let mut second = FastMap::default();
+        second.insert(80, make_root(2048, false, true, 77));
+
+        let statuses = build_worker_cos_statuses_from_maps([&first, &second], &forwarding);
+        assert_eq!(statuses.len(), 1);
+        let iface = &statuses[0];
+        assert_eq!(iface.interface_name, "reth0.80");
+        assert_eq!(iface.worker_instances, 2);
+        assert_eq!(iface.timer_level0_sleepers, 2);
+        assert_eq!(iface.timer_level1_sleepers, 2);
+        assert_eq!(iface.nonempty_queues, 1);
+        assert_eq!(iface.runnable_queues, 1);
+        assert_eq!(iface.queues.len(), 1);
+        let queue = &iface.queues[0];
+        assert_eq!(queue.queue_id, 4);
+        assert_eq!(queue.forwarding_class, "bandwidth-10mb");
+        assert_eq!(queue.queued_packets, 2);
+        assert_eq!(queue.queued_bytes, 3072);
+        assert_eq!(queue.runnable_instances, 1);
+        assert_eq!(queue.parked_instances, 1);
+        assert_eq!(queue.next_wakeup_tick, 77);
+        assert_eq!(queue.surplus_deficit_bytes, 1024);
+    }
 }
 
 pub(crate) fn push_recent_exception(

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -156,6 +156,7 @@ fn run() -> Result<(), String> {
             bindings: Vec::new(),
             recent_session_deltas: Vec::new(),
             recent_exceptions: Vec::new(),
+            cos_interfaces: Vec::new(),
             last_resolution: None,
             slow_path: SlowPathStatus::default(),
             debug_worker_threads: 0,
@@ -790,6 +791,7 @@ fn refresh_status(state: &mut ServerState) {
     state.status.queues = summarize_queues(&state.status.bindings);
     state.status.recent_session_deltas = state.afxdp.recent_session_deltas();
     state.status.recent_exceptions = state.afxdp.recent_exceptions();
+    state.status.cos_interfaces = state.afxdp.cos_statuses();
     state.status.last_resolution = state.afxdp.last_resolution();
     state.status.slow_path = state.afxdp.slow_path_status().into();
     if let Some(es_stats) = state.afxdp.event_stream_stats() {

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -648,6 +648,8 @@ pub(crate) struct ProcessStatus {
     pub recent_session_deltas: Vec<SessionDeltaInfo>,
     #[serde(rename = "recent_exceptions", default)]
     pub recent_exceptions: Vec<ExceptionStatus>,
+    #[serde(rename = "cos_interfaces", default)]
+    pub cos_interfaces: Vec<CoSInterfaceStatus>,
     #[serde(rename = "last_resolution", skip_serializing_if = "Option::is_none")]
     pub last_resolution: Option<PacketResolution>,
     #[serde(rename = "slow_path", default)]
@@ -679,6 +681,60 @@ pub(crate) struct ProcessStatus {
     /// Monotonic timestamp (secs) of the last HA flow cache flush (#312).
     #[serde(rename = "last_cache_flush_at", default)]
     pub last_cache_flush_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct CoSInterfaceStatus {
+    #[serde(default)]
+    pub ifindex: i32,
+    #[serde(rename = "interface_name", default)]
+    pub interface_name: String,
+    #[serde(rename = "shaping_rate_bytes", default)]
+    pub shaping_rate_bytes: u64,
+    #[serde(rename = "burst_bytes", default)]
+    pub burst_bytes: u64,
+    #[serde(rename = "worker_instances", default)]
+    pub worker_instances: usize,
+    #[serde(rename = "nonempty_queues", default)]
+    pub nonempty_queues: usize,
+    #[serde(rename = "runnable_queues", default)]
+    pub runnable_queues: usize,
+    #[serde(rename = "timer_level0_sleepers", default)]
+    pub timer_level0_sleepers: usize,
+    #[serde(rename = "timer_level1_sleepers", default)]
+    pub timer_level1_sleepers: usize,
+    #[serde(default)]
+    pub queues: Vec<CoSQueueStatus>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct CoSQueueStatus {
+    #[serde(rename = "queue_id", default)]
+    pub queue_id: u8,
+    #[serde(rename = "forwarding_class", default)]
+    pub forwarding_class: String,
+    #[serde(default)]
+    pub priority: u8,
+    #[serde(default)]
+    pub exact: bool,
+    #[serde(rename = "transmit_rate_bytes", default)]
+    pub transmit_rate_bytes: u64,
+    #[serde(rename = "buffer_bytes", default)]
+    pub buffer_bytes: u64,
+    #[serde(rename = "worker_instances", default)]
+    pub worker_instances: usize,
+    #[serde(rename = "queued_packets", default)]
+    pub queued_packets: u64,
+    #[serde(rename = "queued_bytes", default)]
+    pub queued_bytes: u64,
+    #[serde(rename = "runnable_instances", default)]
+    pub runnable_instances: usize,
+    #[serde(rename = "parked_instances", default)]
+    pub parked_instances: usize,
+    #[serde(rename = "next_wakeup_tick", default)]
+    pub next_wakeup_tick: u64,
+    #[serde(rename = "surplus_deficit_bytes", default)]
+    pub surplus_deficit_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- export worker-local CoS queue runtime into helper status snapshots
- replace the old class-of-service filter dump with a shared local/remote formatter
- support `show class-of-service interface [IFACE[.UNIT]]` with config plus live userspace queue state

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml resolve_cos_queue_id_ -- --nocapture`
- `go test ./pkg/dataplane/userspace ./pkg/cli ./pkg/grpcapi ./cmd/cli -count=1`
- `git diff --check`