### PR TITLE
userspace: add CoS owner-worker handoff

### DIFF
--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -851,6 +851,10 @@ Currently implemented:
 - `show class-of-service interface [IFACE[.UNIT]]`
 - prints configured shaping rate, scheduler-map, attached CoS filters, and the
   live userspace queue/runtime state that is currently exported by the helper
+- shaped egress interfaces now have a static userspace scheduler owner worker;
+  non-owner workers hand shaped traffic to that owner before CoS queue
+  admission so one interface does not silently get independent queue state on
+  every worker
 
 Still planned:
 
@@ -916,6 +920,8 @@ At minimum:
 ### Phase 4: Many-Core Ownership and Leasing
 
 - static reservation/container ownership by scheduler shard
+- first userspace slice is implemented as one owner worker per shaped egress
+  interface with cross-worker handoff before CoS enqueue
 - internal enqueue to the owning shard
 - shared parent budgets plus shard-local leases
 - cache-line isolation for shared pools

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -332,7 +332,7 @@ Note: The vSRX deployment guide markets CoS as part of the standard feature set,
 | **BA Classifiers** | `class-of-service classifiers dscp ...` | Classify incoming traffic by DSCP/802.1p into forwarding classes and loss priorities | Low | Missing |
 | **Rewrite Rules** | `class-of-service rewrite-rules dscp ...` | Rewrite outgoing DSCP/802.1p values. xpf has filter-based DSCP rewrite. | Low | Partial (via firewall filter forwarding-class action) |
 | **WRED Drop Profiles** | `class-of-service drop-profiles ...` | Weighted Random Early Detection congestion avoidance per queue | Low | Missing |
-| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only egress shaping with queue guarantees, non-`exact` surplus borrowing, and timer-wheel deferred eligibility; not full Junos CoS parity) |
+| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only egress shaping with queue guarantees, non-`exact` surplus borrowing, timer-wheel deferred eligibility, and one owner worker per shaped egress interface; not full Junos CoS parity) |
 | **Interface CoS Binding** | `class-of-service interfaces ... scheduler-map ...` | Bind scheduler-map and classifiers to specific interfaces | Low | Partial (scheduler-map binding works on userspace interfaces, but BA classifiers and broader CoS attachment semantics are still missing) |
 
 ---

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -265,12 +265,15 @@ fn poll_binding(
     _recent_session_deltas: &Arc<Mutex<VecDeque<SessionDeltaInfo>>>,
     last_resolution: &Arc<Mutex<Option<PacketResolution>>>,
     peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     shared_recycles: &mut Vec<(u32, u64)>,
     dnat_fds: &DnatTableFds,
     conntrack_v4_fd: c_int,
     conntrack_v6_fd: c_int,
     dbg: &mut DebugPollCounters,
     rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
 ) -> bool {
     #[derive(Default)]
     struct BatchCounters {
@@ -363,7 +366,15 @@ fn poll_binding(
     };
     let area = binding.umem.area() as *const MmapArea;
     maybe_touch_heartbeat(binding, now_ns);
-    let tx_work = drain_pending_tx(binding, now_ns, shared_recycles, forwarding);
+    let tx_work = drain_pending_tx(
+        binding,
+        now_ns,
+        shared_recycles,
+        forwarding,
+        worker_id,
+        worker_commands_by_id,
+        cos_owner_worker_by_ifindex,
+    );
     apply_shared_recycles(
         left,
         binding_index,
@@ -384,7 +395,15 @@ fn poll_binding(
         if tx_backlog >= binding.max_pending_tx {
             binding.dbg_backpressure += 1;
             // Try to drain TX first — completions free frames for both TX and fill.
-            let _ = drain_pending_tx(binding, now_ns, shared_recycles, forwarding);
+            let _ = drain_pending_tx(
+                binding,
+                now_ns,
+                shared_recycles,
+                forwarding,
+                worker_id,
+                worker_commands_by_id,
+                cos_owner_worker_by_ifindex,
+            );
             apply_shared_recycles(
                 left,
                 binding_index,

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -2797,6 +2797,9 @@ fn poll_binding(
             local_tunnel_deliveries,
             recent_exceptions,
             dbg,
+            worker_id,
+            worker_commands_by_id,
+            cos_owner_worker_by_ifindex,
         );
         binding.scratch_post_recycles = scratch_post_recycles;
         binding.scratch_forwards = pending_forwards;

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -573,14 +573,21 @@ impl Coordinator {
         self.conntrack_v6_fd = conntrack_v6_fd;
         self.dnat_table_fd = dnat_table_fd;
         self.dnat_table_v6_fd = dnat_table_v6_fd;
-        let worker_command_queues: BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>> = workers
-            .keys()
-            .copied()
-            .map(|worker_id| (worker_id, Arc::new(Mutex::new(VecDeque::new()))))
-            .collect();
+        let cos_owner_worker_by_ifindex = Arc::new(build_cos_owner_worker_by_ifindex(
+            &self.forwarding,
+            &workers,
+        ));
+        let worker_command_queues: Arc<BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>> =
+            Arc::new(
+                workers
+                    .keys()
+                    .copied()
+                    .map(|worker_id| (worker_id, Arc::new(Mutex::new(VecDeque::new()))))
+                    .collect(),
+            );
         let replayed_synced_sessions = self.replay_synced_sessions(
             &preserved_synced_sessions,
-            &worker_command_queues,
+            worker_command_queues.as_ref(),
             session_map_raw_fd,
         );
         if replayed_synced_sessions > 0 {
@@ -620,6 +627,7 @@ impl Coordinator {
                 .filter(|(id, _)| **id != worker_id)
                 .map(|(_, queue)| queue.clone())
                 .collect::<Vec<_>>();
+            let worker_commands_by_id = worker_command_queues.clone();
             let ha_state = self.ha_state.clone();
             let dynamic_neighbors = self.dynamic_neighbors.clone();
             let worker_poll_mode = self.poll_mode;
@@ -627,6 +635,7 @@ impl Coordinator {
             let rg_epochs = self.rg_epochs.clone();
             let event_stream_handle = self.event_stream_worker_handle();
             let cos_status_clone = cos_status.clone();
+            let cos_owner_worker_by_ifindex = cos_owner_worker_by_ifindex.clone();
             let join = thread::Builder::new()
                 .name(format!("xpf-userspace-worker-{worker_id}"))
                 .spawn(move || {
@@ -648,6 +657,7 @@ impl Coordinator {
                         last_resolution,
                         commands_clone,
                         peer_commands_clone,
+                        worker_commands_by_id,
                         stop_clone,
                         heartbeat_clone,
                         session_export_ack_clone,
@@ -656,6 +666,7 @@ impl Coordinator {
                         shared_fabrics,
                         event_stream_handle,
                         rg_epochs,
+                        cos_owner_worker_by_ifindex,
                         cos_status_clone,
                     );
                 });
@@ -1361,5 +1372,85 @@ impl Coordinator {
                 binding.ready = false;
             }
         }
+    }
+}
+
+fn build_cos_owner_worker_by_ifindex(
+    forwarding: &ForwardingState,
+    workers: &BTreeMap<u32, Vec<BindingPlan>>,
+) -> BTreeMap<i32, u32> {
+    let worker_binding_ifindexes = workers
+        .iter()
+        .map(|(worker_id, binding_plans)| {
+            (
+                *worker_id,
+                binding_plans
+                    .iter()
+                    .map(|plan| plan.status.ifindex)
+                    .collect::<std::collections::BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    build_cos_owner_worker_by_ifindex_from_binding_ifindexes(forwarding, &worker_binding_ifindexes)
+}
+
+fn build_cos_owner_worker_by_ifindex_from_binding_ifindexes(
+    forwarding: &ForwardingState,
+    worker_binding_ifindexes: &BTreeMap<u32, std::collections::BTreeSet<i32>>,
+) -> BTreeMap<i32, u32> {
+    let mut owner_by_ifindex = BTreeMap::new();
+    for egress_ifindex in forwarding.cos.interfaces.keys().copied() {
+        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
+        for (worker_id, ifindexes) in worker_binding_ifindexes {
+            if ifindexes.contains(&tx_ifindex) {
+                owner_by_ifindex.insert(egress_ifindex, *worker_id);
+                break;
+            }
+        }
+    }
+    owner_by_ifindex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_cos_owner_worker_by_ifindex_prefers_lowest_worker_with_tx_binding() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 1_000_000,
+                burst_bytes: 64 * 1024,
+                default_queue: 0,
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![],
+            },
+        );
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 12,
+                vlan_id: 0,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone: "wan".to_string(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+        let worker_binding_ifindexes = BTreeMap::from([
+            (2, std::collections::BTreeSet::from([12])),
+            (7, std::collections::BTreeSet::from([12, 13])),
+        ]);
+
+        let owner_by_ifindex = build_cos_owner_worker_by_ifindex_from_binding_ifindexes(
+            &forwarding,
+            &worker_binding_ifindexes,
+        );
+
+        assert_eq!(owner_by_ifindex.get(&80), Some(&2));
     }
 }

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -170,7 +170,12 @@ pub(super) fn enqueue_pending_forwards(
                 }
                 copied_source_frame = true;
                 if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE {
-                    let _ = drain_pending_tx(target_binding, now_ns, post_recycles, forwarding);
+                    let _ = drain_pending_tx_local_owner(
+                        target_binding,
+                        now_ns,
+                        post_recycles,
+                        forwarding,
+                    );
                 }
             } else if let Some(segmented) = segment_forwarded_tcp_frames_from_frame(
                 source_frame,
@@ -228,7 +233,12 @@ pub(super) fn enqueue_pending_forwards(
                 }
                 copied_source_frame = true;
                 if target_binding.pending_tx_local.len() >= TX_BATCH_SIZE {
-                    let _ = drain_pending_tx(target_binding, now_ns, post_recycles, forwarding);
+                    let _ = drain_pending_tx_local_owner(
+                        target_binding,
+                        now_ns,
+                        post_recycles,
+                        forwarding,
+                    );
                 }
             }
             // Track when segmentation was needed but returned None
@@ -404,7 +414,12 @@ pub(super) fn enqueue_pending_forwards(
                             || !target_binding.pending_tx_prepared.is_empty()
                             || !target_binding.pending_tx_local.is_empty())
                     {
-                        let _ = drain_pending_tx(target_binding, now_ns, post_recycles, forwarding);
+                        let _ = drain_pending_tx_local_owner(
+                            target_binding,
+                            now_ns,
+                            post_recycles,
+                            forwarding,
+                        );
                         direct_tx_offset = target_binding.free_tx_frames.pop_front();
                     }
                     let mut direct_tx_fallback_reason = None;
@@ -625,7 +640,8 @@ pub(super) fn enqueue_pending_forwards(
             if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE
                 || target_binding.pending_tx_local.len() >= TX_BATCH_SIZE
             {
-                let _ = drain_pending_tx(target_binding, now_ns, post_recycles, forwarding);
+                let _ =
+                    drain_pending_tx_local_owner(target_binding, now_ns, post_recycles, forwarding);
             }
         }
         if !post_recycles.is_empty() {
@@ -1069,7 +1085,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
             || !target_binding.pending_tx_prepared.is_empty()
             || !target_binding.pending_tx_local.is_empty())
     {
-        let _ = drain_pending_tx(target_binding, now_ns, post_recycles, forwarding);
+        let _ = drain_pending_tx_local_owner(target_binding, now_ns, post_recycles, forwarding);
     }
     if target_binding.free_tx_frames.len() < segment_count {
         return None;

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -16,6 +16,9 @@ pub(super) fn enqueue_pending_forwards(
     local_tunnel_deliveries: &Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
     recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
     dbg: &mut DebugPollCounters,
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
 ) {
     let ingress_area = ingress_binding.umem.area() as *const MmapArea;
     post_recycles.clear();
@@ -160,6 +163,9 @@ pub(super) fn enqueue_pending_forwards(
                 request.cos_queue_id,
                 now_ns,
                 post_recycles,
+                worker_id,
+                worker_commands_by_id,
+                cos_owner_worker_by_ifindex,
             ) {
                 dbg.enqueue_ok += segments as u64;
                 dbg.enqueue_direct += segments as u64;
@@ -175,6 +181,9 @@ pub(super) fn enqueue_pending_forwards(
                         now_ns,
                         post_recycles,
                         forwarding,
+                        worker_id,
+                        worker_commands_by_id,
+                        cos_owner_worker_by_ifindex,
                     );
                 }
             } else if let Some(segmented) = segment_forwarded_tcp_frames_from_frame(
@@ -238,6 +247,9 @@ pub(super) fn enqueue_pending_forwards(
                         now_ns,
                         post_recycles,
                         forwarding,
+                        worker_id,
+                        worker_commands_by_id,
+                        cos_owner_worker_by_ifindex,
                     );
                 }
             }
@@ -419,6 +431,9 @@ pub(super) fn enqueue_pending_forwards(
                             now_ns,
                             post_recycles,
                             forwarding,
+                            worker_id,
+                            worker_commands_by_id,
+                            cos_owner_worker_by_ifindex,
                         );
                         direct_tx_offset = target_binding.free_tx_frames.pop_front();
                     }
@@ -640,8 +655,15 @@ pub(super) fn enqueue_pending_forwards(
             if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE
                 || target_binding.pending_tx_local.len() >= TX_BATCH_SIZE
             {
-                let _ =
-                    drain_pending_tx_local_owner(target_binding, now_ns, post_recycles, forwarding);
+                let _ = drain_pending_tx_local_owner(
+                    target_binding,
+                    now_ns,
+                    post_recycles,
+                    forwarding,
+                    worker_id,
+                    worker_commands_by_id,
+                    cos_owner_worker_by_ifindex,
+                );
             }
         }
         if !post_recycles.is_empty() {
@@ -1018,6 +1040,9 @@ fn segment_forwarded_tcp_frames_into_prepared(
     cos_queue_id: Option<u8>,
     now_ns: u64,
     post_recycles: &mut Vec<(u32, u64)>,
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
 ) -> Option<(u32, u64, u32)> {
     if meta.protocol != PROTO_TCP || decision.resolution.tunnel_endpoint_id != 0 {
         return None;
@@ -1085,7 +1110,15 @@ fn segment_forwarded_tcp_frames_into_prepared(
             || !target_binding.pending_tx_prepared.is_empty()
             || !target_binding.pending_tx_local.is_empty())
     {
-        let _ = drain_pending_tx_local_owner(target_binding, now_ns, post_recycles, forwarding);
+        let _ = drain_pending_tx_local_owner(
+            target_binding,
+            now_ns,
+            post_recycles,
+            forwarding,
+            worker_id,
+            worker_commands_by_id,
+            cos_owner_worker_by_ifindex,
+        );
     }
     if target_binding.free_tx_frames.len() < segment_count {
         return None;

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -239,6 +239,7 @@ fn should_bypass_unseeded_tunnel_ha(
 pub(super) struct WorkerCommandResults {
     pub cancelled_keys: Vec<SessionKey>,
     pub exported_sequences: Vec<u64>,
+    pub shaped_tx_requests: Vec<TxRequest>,
 }
 
 fn force_live_redirect_for_worker_synced_entry(
@@ -331,6 +332,7 @@ pub(super) fn apply_worker_commands(
                 return WorkerCommandResults {
                     cancelled_keys: Vec::new(),
                     exported_sequences: Vec::new(),
+                    shaped_tx_requests: Vec::new(),
                 };
             }
             core::mem::take(&mut *pending)
@@ -339,6 +341,7 @@ pub(super) fn apply_worker_commands(
             return WorkerCommandResults {
                 cancelled_keys: Vec::new(),
                 exported_sequences: Vec::new(),
+                shaped_tx_requests: Vec::new(),
             };
         }
     };
@@ -346,6 +349,7 @@ pub(super) fn apply_worker_commands(
     let now_secs = now_ns / 1_000_000_000;
     let mut cancelled_keys: Vec<SessionKey> = Vec::new();
     let mut exported_sequences = Vec::new();
+    let mut shaped_tx_requests = Vec::new();
     for cmd in pending {
         match cmd {
             WorkerCommand::DemoteOwnerRGS { owner_rgs } => {
@@ -618,11 +622,13 @@ pub(super) fn apply_worker_commands(
                     delete_live_session_key(session_map_fd, &key);
                 }
             }
+            WorkerCommand::EnqueueShapedLocal(req) => shaped_tx_requests.push(req),
         }
     }
     WorkerCommandResults {
         cancelled_keys,
         exported_sequences,
+        shaped_tx_requests,
     }
 }
 

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -184,6 +184,9 @@ pub(super) fn drain_pending_tx(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
     forwarding: &ForwardingState,
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
 ) -> bool {
     if !binding_has_pending_tx_work(binding) {
         return false;
@@ -198,7 +201,14 @@ pub(super) fn drain_pending_tx(
     {
         maybe_wake_tx(binding, false, now_ns);
     }
-    ingest_cos_pending_tx(binding, forwarding, now_ns);
+    ingest_cos_pending_tx(
+        binding,
+        forwarding,
+        now_ns,
+        worker_id,
+        worker_commands_by_id,
+        cos_owner_worker_by_ifindex,
+    );
     while drain_shaped_tx(binding, now_ns, shared_recycles) {
         did_work = true;
     }
@@ -298,7 +308,33 @@ fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
         || binding.cos_nonempty_interfaces > 0
 }
 
-fn ingest_cos_pending_tx(binding: &mut BindingWorker, forwarding: &ForwardingState, now_ns: u64) {
+pub(super) fn drain_pending_tx_local_owner(
+    binding: &mut BindingWorker,
+    now_ns: u64,
+    shared_recycles: &mut Vec<(u32, u64)>,
+    forwarding: &ForwardingState,
+) -> bool {
+    let empty_worker_commands = BTreeMap::new();
+    let empty_owner_by_ifindex = BTreeMap::new();
+    drain_pending_tx(
+        binding,
+        now_ns,
+        shared_recycles,
+        forwarding,
+        binding.worker_id,
+        &empty_worker_commands,
+        &empty_owner_by_ifindex,
+    )
+}
+
+fn ingest_cos_pending_tx(
+    binding: &mut BindingWorker,
+    forwarding: &ForwardingState,
+    now_ns: u64,
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
+) {
     if forwarding.cos.interfaces.is_empty() {
         return;
     }
@@ -306,6 +342,16 @@ fn ingest_cos_pending_tx(binding: &mut BindingWorker, forwarding: &ForwardingSta
     if !binding.pending_tx_prepared.is_empty() {
         let mut kept = VecDeque::with_capacity(binding.pending_tx_prepared.len());
         while let Some(req) = binding.pending_tx_prepared.pop_front() {
+            let req = match redirect_prepared_cos_request_to_owner(
+                binding,
+                req,
+                worker_id,
+                worker_commands_by_id,
+                cos_owner_worker_by_ifindex,
+            ) {
+                Ok(()) => continue,
+                Err(req) => req,
+            };
             match enqueue_prepared_into_cos(binding, forwarding, req, now_ns) {
                 Ok(()) => {}
                 Err(req) => kept.push_back(req),
@@ -319,6 +365,15 @@ fn ingest_cos_pending_tx(binding: &mut BindingWorker, forwarding: &ForwardingSta
     let mut pending = merge_pending_tx_requests(local, shared);
     let mut kept = VecDeque::with_capacity(pending.len());
     while let Some(req) = pending.pop_front() {
+        let req = match redirect_local_cos_request_to_owner(
+            req,
+            worker_id,
+            worker_commands_by_id,
+            cos_owner_worker_by_ifindex,
+        ) {
+            Ok(()) => continue,
+            Err(req) => req,
+        };
         match enqueue_local_into_cos(binding, forwarding, req, now_ns) {
             Ok(()) => {}
             Err(req) => kept.push_back(req),
@@ -326,6 +381,87 @@ fn ingest_cos_pending_tx(binding: &mut BindingWorker, forwarding: &ForwardingSta
     }
     binding.pending_tx_local = kept;
     bound_pending_tx_local(binding);
+}
+
+fn cos_owner_worker_for_egress_ifindex(
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
+    egress_ifindex: i32,
+    current_worker_id: u32,
+) -> u32 {
+    cos_owner_worker_by_ifindex
+        .get(&egress_ifindex)
+        .copied()
+        .unwrap_or(current_worker_id)
+}
+
+fn redirect_local_cos_request_to_owner(
+    req: TxRequest,
+    current_worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
+) -> Result<(), TxRequest> {
+    let owner_worker_id = cos_owner_worker_for_egress_ifindex(
+        cos_owner_worker_by_ifindex,
+        req.egress_ifindex,
+        current_worker_id,
+    );
+    if owner_worker_id == current_worker_id {
+        return Err(req);
+    }
+    let Some(commands) = worker_commands_by_id.get(&owner_worker_id) else {
+        return Err(req);
+    };
+    if let Ok(mut pending) = commands.lock() {
+        pending.push_back(WorkerCommand::EnqueueShapedLocal(req));
+        return Ok(());
+    }
+    Err(req)
+}
+
+fn redirect_prepared_cos_request_to_owner(
+    binding: &mut BindingWorker,
+    req: PreparedTxRequest,
+    current_worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
+) -> Result<(), PreparedTxRequest> {
+    let owner_worker_id = cos_owner_worker_for_egress_ifindex(
+        cos_owner_worker_by_ifindex,
+        req.egress_ifindex,
+        current_worker_id,
+    );
+    if owner_worker_id == current_worker_id {
+        return Err(req);
+    }
+    let Some(frame) = binding
+        .umem
+        .area()
+        .slice(req.offset as usize, req.len as usize)
+        .map(|frame| frame.to_vec())
+    else {
+        return Err(req);
+    };
+    let local_req = TxRequest {
+        bytes: frame,
+        expected_ports: req.expected_ports,
+        expected_addr_family: req.expected_addr_family,
+        expected_protocol: req.expected_protocol,
+        flow_key: req.flow_key.clone(),
+        egress_ifindex: req.egress_ifindex,
+        cos_queue_id: req.cos_queue_id,
+    };
+    if redirect_local_cos_request_to_owner(
+        local_req,
+        current_worker_id,
+        worker_commands_by_id,
+        cos_owner_worker_by_ifindex,
+    )
+    .is_ok()
+    {
+        recycle_prepared_immediately(binding, &req);
+        return Ok(());
+    }
+    Err(req)
 }
 
 fn drain_shaped_tx(
@@ -895,7 +1031,7 @@ pub(super) fn resolve_cos_queue_id(
     Some(iface.default_queue)
 }
 
-fn enqueue_local_into_cos(
+pub(super) fn enqueue_local_into_cos(
     binding: &mut BindingWorker,
     forwarding: &ForwardingState,
     req: TxRequest,
@@ -1723,6 +1859,40 @@ mod tests {
         let merged = merge_pending_tx_requests(VecDeque::new(), shared);
         let bytes: Vec<Vec<u8>> = merged.into_iter().map(|req| req.bytes).collect();
         assert_eq!(bytes, vec![vec![9]]);
+    }
+
+    #[test]
+    fn redirect_local_cos_request_to_owner_pushes_worker_command() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+        let cos_owner_worker_by_ifindex = BTreeMap::from([(80, 7)]);
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+        };
+
+        let redirected = redirect_local_cos_request_to_owner(
+            req,
+            2,
+            &worker_commands_by_id,
+            &cos_owner_worker_by_ifindex,
+        );
+
+        assert!(redirected.is_ok());
+        let pending = commands.lock().unwrap();
+        assert_eq!(pending.len(), 1);
+        match pending.front() {
+            Some(WorkerCommand::EnqueueShapedLocal(req)) => {
+                assert_eq!(req.egress_ifindex, 80);
+                assert_eq!(req.cos_queue_id, Some(4));
+            }
+            other => panic!("unexpected command queued: {other:?}"),
+        }
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -313,17 +313,18 @@ pub(super) fn drain_pending_tx_local_owner(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
     forwarding: &ForwardingState,
+    worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    cos_owner_worker_by_ifindex: &BTreeMap<i32, u32>,
 ) -> bool {
-    let empty_worker_commands = BTreeMap::new();
-    let empty_owner_by_ifindex = BTreeMap::new();
     drain_pending_tx(
         binding,
         now_ns,
         shared_recycles,
         forwarding,
-        binding.worker_id,
-        &empty_worker_commands,
-        &empty_owner_by_ifindex,
+        worker_id,
+        worker_commands_by_id,
+        cos_owner_worker_by_ifindex,
     )
 }
 

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -644,6 +644,7 @@ pub(super) enum WorkerCommand {
     DemoteOwnerRGS { owner_rgs: Vec<i32> },
     RefreshOwnerRGS { owner_rgs: Vec<i32> },
     ExportOwnerRGSessions { sequence: u64, owner_rgs: Vec<i32> },
+    EnqueueShapedLocal(TxRequest),
 }
 
 #[derive(Default)]

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -391,6 +391,7 @@ pub(crate) fn worker_loop(
     last_resolution: Arc<Mutex<Option<PacketResolution>>>,
     commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
     peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>>,
+    worker_commands_by_id: Arc<BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>>,
     stop: Arc<AtomicBool>,
     heartbeat: Arc<AtomicU64>,
     session_export_ack: Arc<AtomicU64>,
@@ -399,6 +400,7 @@ pub(crate) fn worker_loop(
     shared_fabrics: Arc<ArcSwap<Vec<FabricLink>>>,
     event_stream: Option<crate::event_stream::EventStreamWorkerHandle>,
     rg_epochs: Arc<[AtomicU32; MAX_RG_EPOCHS]>,
+    cos_owner_worker_by_ifindex: Arc<BTreeMap<i32, u32>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
 ) {
     pin_current_thread(worker_id);
@@ -604,10 +606,24 @@ pub(crate) fn worker_loop(
             WorkerCommandResults {
                 cancelled_keys: Vec::new(),
                 exported_sequences: Vec::new(),
+                shaped_tx_requests: Vec::new(),
             }
         };
-        if !command_results.cancelled_keys.is_empty() {
-            for key in &command_results.cancelled_keys {
+        let WorkerCommandResults {
+            cancelled_keys,
+            exported_sequences,
+            shaped_tx_requests,
+        } = command_results;
+        if !shaped_tx_requests.is_empty() {
+            apply_worker_shaped_tx_requests(
+                &mut bindings,
+                forwarding.as_ref(),
+                loop_now_ns,
+                shaped_tx_requests,
+            );
+        }
+        if !cancelled_keys.is_empty() {
+            for key in &cancelled_keys {
                 for binding in bindings.iter_mut() {
                     cancel_queued_flow_on_binding(binding, key, key);
                 }
@@ -702,12 +718,15 @@ pub(crate) fn worker_loop(
                 &recent_session_deltas,
                 &last_resolution,
                 &peer_worker_commands,
+                worker_id,
+                worker_commands_by_id.as_ref(),
                 &mut shared_recycles,
                 &dnat_fds,
                 conntrack_v4_fd,
                 conntrack_v6_fd,
                 &mut dbg_poll,
                 &rg_epochs,
+                cos_owner_worker_by_ifindex.as_ref(),
             ) {
                 did_work = true;
             }
@@ -782,7 +801,7 @@ pub(crate) fn worker_loop(
             )));
             last_cos_status_ns = loop_now_ns;
         }
-        if !command_results.exported_sequences.is_empty() {
+        if !exported_sequences.is_empty() {
             while sessions.has_pending_deltas() {
                 let deltas = sessions.drain_deltas(256);
                 purge_queued_flows_for_closed_deltas(&mut bindings, &deltas);
@@ -806,7 +825,7 @@ pub(crate) fn worker_loop(
                     );
                 }
             }
-            if let Some(sequence) = command_results.exported_sequences.iter().copied().max() {
+            if let Some(sequence) = exported_sequences.iter().copied().max() {
                 session_export_ack.store(sequence, Ordering::Release);
             }
         } else if sessions.has_pending_deltas() {
@@ -1289,6 +1308,30 @@ pub(crate) fn worker_loop(
         forwarding.as_ref(),
     )));
     heartbeat.store(monotonic_nanos(), Ordering::Relaxed);
+}
+
+fn apply_worker_shaped_tx_requests(
+    bindings: &mut [BindingWorker],
+    forwarding: &ForwardingState,
+    now_ns: u64,
+    requests: Vec<TxRequest>,
+) {
+    for req in requests {
+        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
+        let Some(binding) = bindings
+            .iter_mut()
+            .find(|binding| binding.ifindex == tx_ifindex)
+        else {
+            continue;
+        };
+        match enqueue_local_into_cos(binding, forwarding, req, now_ns) {
+            Ok(()) => {}
+            Err(req) => {
+                binding.pending_tx_local.push_back(req);
+                bound_pending_tx_local(binding);
+            }
+        }
+    }
 }
 
 fn build_worker_cos_statuses(

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1322,6 +1322,16 @@ fn apply_worker_shaped_tx_requests(
             .iter_mut()
             .find(|binding| binding.ifindex == tx_ifindex)
         else {
+            if let Some(binding) = bindings.first_mut() {
+                binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
+            }
+            if cfg!(feature = "debug-log") {
+                debug_log!(
+                    "DBG COS_OWNER_MISSING_BINDING: egress_ifindex={} tx_ifindex={}",
+                    req.egress_ifindex,
+                    tx_ifindex,
+                );
+            }
             continue;
         };
         match enqueue_local_into_cos(binding, forwarding, req, now_ns) {


### PR DESCRIPTION
## Summary
- add a first Phase 4 CoS slice: one static owner worker per shaped egress interface
- hand shaped traffic from non-owner workers to the owner before CoS queue admission
- update CoS docs/gap notes to reflect the implemented owner-worker model

## Details
This does not attempt full many-core leasing yet. It implements the first concrete step from the CoS plan:
- the coordinator derives an owner worker for each shaped egress interface from the TX binding map
- non-owner workers redirect shaped `TxRequest`s to that owner worker
- prepared shaped frames on a non-owner worker are copied back into a local `TxRequest`, redirected, and the original prepared frame is recycled locally
- owner workers enqueue the handed-off traffic into the existing CoS queueing/scheduling path

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_owner_worker_by_ifindex_prefers_lowest_worker_with_tx_binding -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml redirect_local_cos_request_to_owner_pushes_worker_command -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue -- --nocapture`
- `go test ./pkg/dataplane/userspace ./pkg/cli ./pkg/grpcapi ./cmd/cli -count=1`
- `git diff --check`
