### PR TITLE
userspace: spread static CoS owners across workers

### DIFF
--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -855,6 +855,8 @@ Currently implemented:
   non-owner workers hand shaped traffic to that owner before CoS queue
   admission so one interface does not silently get independent queue state on
   every worker
+- ownership is now spread deterministically across eligible workers when
+  multiple shaped egress interfaces share the same TX path
 
 Still planned:
 
@@ -922,6 +924,8 @@ At minimum:
 - static reservation/container ownership by scheduler shard
 - first userspace slice is implemented as one owner worker per shaped egress
   interface with cross-worker handoff before CoS enqueue
+- static ownership is now spread deterministically across eligible workers for
+  multiple shaped egress interfaces on the same TX path
 - internal enqueue to the owning shard
 - shared parent budgets plus shard-local leases
 - cache-line isolation for shared pools

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -332,7 +332,7 @@ Note: The vSRX deployment guide markets CoS as part of the standard feature set,
 | **BA Classifiers** | `class-of-service classifiers dscp ...` | Classify incoming traffic by DSCP/802.1p into forwarding classes and loss priorities | Low | Missing |
 | **Rewrite Rules** | `class-of-service rewrite-rules dscp ...` | Rewrite outgoing DSCP/802.1p values. xpf has filter-based DSCP rewrite. | Low | Partial (via firewall filter forwarding-class action) |
 | **WRED Drop Profiles** | `class-of-service drop-profiles ...` | Weighted Random Early Detection congestion avoidance per queue | Low | Missing |
-| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only egress shaping with queue guarantees, non-`exact` surplus borrowing, timer-wheel deferred eligibility, and one owner worker per shaped egress interface; not full Junos CoS parity) |
+| **Traffic Shaping** | `class-of-service interfaces ... shaping-rate ...` | Per-interface output rate shaping | Low | Partial (userspace-only egress shaping with queue guarantees, non-`exact` surplus borrowing, timer-wheel deferred eligibility, and deterministic static owner-worker spreading across shaped egress interfaces; not full Junos CoS parity) |
 | **Interface CoS Binding** | `class-of-service interfaces ... scheduler-map ...` | Bind scheduler-map and classifiers to specific interfaces | Low | Partial (scheduler-map binding works on userspace interfaces, but BA classifiers and broader CoS attachment semantics are still missing) |
 
 ---

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -76,7 +76,7 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 		if view.interfaceState == nil {
 			b.WriteString("  Runtime:                  unavailable\n")
 		} else {
-			fmt.Fprintf(&b, "  Owner worker:             %d\n", view.interfaceState.OwnerWorkerID)
+			fmt.Fprintf(&b, "  Owner worker:             %s\n", formatOptionalWorkerID(view.interfaceState.OwnerWorkerID))
 			fmt.Fprintf(&b, "  Runtime workers:          %d\n", view.interfaceState.WorkerInstances)
 			fmt.Fprintf(&b, "  Runtime queues:           nonempty=%d runnable=%d\n",
 				view.interfaceState.NonemptyQueues,
@@ -221,6 +221,13 @@ func formatCoSRate(bytesPerSecond uint64) string {
 		unitIdx++
 	}
 	return fmt.Sprintf("%.2f %s", bitsPerSecond, units[unitIdx])
+}
+
+func formatOptionalWorkerID(workerID *uint32) string {
+	if workerID == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *workerID)
 }
 
 func formatCoSBytes(bytes uint64) string {

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -76,6 +76,7 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 		if view.interfaceState == nil {
 			b.WriteString("  Runtime:                  unavailable\n")
 		} else {
+			fmt.Fprintf(&b, "  Owner worker:             %d\n", view.interfaceState.OwnerWorkerID)
 			fmt.Fprintf(&b, "  Runtime workers:          %d\n", view.interfaceState.WorkerInstances)
 			fmt.Fprintf(&b, "  Runtime queues:           nonempty=%d runnable=%d\n",
 				view.interfaceState.NonemptyQueues,

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -78,6 +78,7 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 		CoSInterfaces: []CoSInterfaceStatus{
 			{
 				InterfaceName:       "reth0.80",
+				OwnerWorkerID:       7,
 				WorkerInstances:     2,
 				NonemptyQueues:      1,
 				RunnableQueues:      1,
@@ -104,6 +105,7 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 	}
 	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "")
 	for _, want := range []string{
+		"Owner worker:             7",
 		"Runtime workers:          2",
 		"Runtime queues:           nonempty=1 runnable=1",
 		"Timer wheel sleepers:     level0=1 level1=0",

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -74,11 +74,12 @@ func TestFormatCoSInterfaceSummaryShowsConfigOnlyInterface(t *testing.T) {
 }
 
 func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
+	owner := uint32(7)
 	status := &ProcessStatus{
 		CoSInterfaces: []CoSInterfaceStatus{
 			{
 				InterfaceName:       "reth0.80",
-				OwnerWorkerID:       7,
+				OwnerWorkerID:       &owner,
 				WorkerInstances:     2,
 				NonemptyQueues:      1,
 				RunnableQueues:      1,
@@ -118,6 +119,21 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 	}
 	if !strings.Contains(out, "77") || !strings.Contains(out, "4.00 KiB") {
 		t.Fatalf("expected runtime queue metrics in output:\n%s", out)
+	}
+}
+
+func TestFormatCoSInterfaceSummaryShowsUnknownOwnerAsDash(t *testing.T) {
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				WorkerInstances: 1,
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	if !strings.Contains(out, "Owner worker:             -") {
+		t.Fatalf("expected unknown owner to render as dash:\n%s", out)
 	}
 }
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -399,6 +399,7 @@ type ProcessStatus struct {
 type CoSInterfaceStatus struct {
 	Ifindex             int              `json:"ifindex,omitempty"`
 	InterfaceName       string           `json:"interface_name,omitempty"`
+	OwnerWorkerID       int              `json:"owner_worker_id,omitempty"`
 	ShapingRateBytes    uint64           `json:"shaping_rate_bytes,omitempty"`
 	BurstBytes          uint64           `json:"burst_bytes,omitempty"`
 	WorkerInstances     int              `json:"worker_instances,omitempty"`

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -399,7 +399,7 @@ type ProcessStatus struct {
 type CoSInterfaceStatus struct {
 	Ifindex             int              `json:"ifindex,omitempty"`
 	InterfaceName       string           `json:"interface_name,omitempty"`
-	OwnerWorkerID       int              `json:"owner_worker_id,omitempty"`
+	OwnerWorkerID       *uint32          `json:"owner_worker_id,omitempty"`
 	ShapingRateBytes    uint64           `json:"shaping_rate_bytes,omitempty"`
 	BurstBytes          uint64           `json:"burst_bytes,omitempty"`
 	WorkerInstances     int              `json:"worker_instances,omitempty"`

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -39,6 +39,7 @@ pub struct Coordinator {
     pub(crate) last_reconcile_stage: String,
     pub(crate) poll_mode: crate::PollMode,
     pub(crate) event_stream: Option<crate::event_stream::EventStreamSender>,
+    pub(crate) cos_owner_worker_by_ifindex: BTreeMap<i32, u32>,
     /// Monotonic timestamp (secs) of the last HA flow cache flush (#312).
     pub(crate) last_cache_flush_at: Arc<AtomicU64>,
     /// Per-RG epoch counters for O(1) flow cache invalidation on demotion.
@@ -89,6 +90,7 @@ impl Coordinator {
             last_reconcile_stage: "idle".to_string(),
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,
+            cos_owner_worker_by_ifindex: BTreeMap::new(),
             last_cache_flush_at: Arc::new(AtomicU64::new(0)),
             rg_epochs: Arc::new(std::array::from_fn(|_| AtomicU32::new(0))),
         }
@@ -577,6 +579,7 @@ impl Coordinator {
             &self.forwarding,
             &workers,
         ));
+        self.cos_owner_worker_by_ifindex = cos_owner_worker_by_ifindex.as_ref().clone();
         let worker_command_queues: Arc<BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>> =
             Arc::new(
                 workers
@@ -859,6 +862,12 @@ impl Coordinator {
                 entry.ifindex = iface.ifindex;
                 if entry.interface_name.is_empty() {
                     entry.interface_name = iface.interface_name.clone();
+                }
+                if entry.owner_worker_id == 0 {
+                    entry.owner_worker_id = *self
+                        .cos_owner_worker_by_ifindex
+                        .get(&iface.ifindex)
+                        .unwrap_or(&0) as usize;
                 }
                 entry.shaping_rate_bytes = entry.shaping_rate_bytes.max(iface.shaping_rate_bytes);
                 entry.burst_bytes = entry.burst_bytes.max(iface.burst_bytes);
@@ -1399,14 +1408,22 @@ fn build_cos_owner_worker_by_ifindex_from_binding_ifindexes(
     worker_binding_ifindexes: &BTreeMap<u32, std::collections::BTreeSet<i32>>,
 ) -> BTreeMap<i32, u32> {
     let mut owner_by_ifindex = BTreeMap::new();
+    let mut next_owner_slot_by_tx_ifindex = BTreeMap::<i32, usize>::new();
     for egress_ifindex in forwarding.cos.interfaces.keys().copied() {
         let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
-        for (worker_id, ifindexes) in worker_binding_ifindexes {
-            if ifindexes.contains(&tx_ifindex) {
-                owner_by_ifindex.insert(egress_ifindex, *worker_id);
-                break;
-            }
+        let eligible_workers = worker_binding_ifindexes
+            .iter()
+            .filter_map(|(worker_id, ifindexes)| {
+                ifindexes.contains(&tx_ifindex).then_some(*worker_id)
+            })
+            .collect::<Vec<_>>();
+        if eligible_workers.is_empty() {
+            continue;
         }
+        let next_slot = next_owner_slot_by_tx_ifindex.entry(tx_ifindex).or_default();
+        let owner_worker_id = eligible_workers[*next_slot % eligible_workers.len()];
+        *next_slot += 1;
+        owner_by_ifindex.insert(egress_ifindex, owner_worker_id);
     }
     owner_by_ifindex
 }
@@ -1452,5 +1469,48 @@ mod tests {
         );
 
         assert_eq!(owner_by_ifindex.get(&80), Some(&2));
+    }
+
+    #[test]
+    fn build_cos_owner_worker_by_ifindex_spreads_interfaces_across_eligible_workers() {
+        let mut forwarding = ForwardingState::default();
+        for ifindex in [80, 81, 82] {
+            forwarding.cos.interfaces.insert(
+                ifindex,
+                CoSInterfaceConfig {
+                    shaping_rate_bytes: 1_000_000,
+                    burst_bytes: 64 * 1024,
+                    default_queue: 0,
+                    queue_by_forwarding_class: FastMap::default(),
+                    queues: vec![],
+                },
+            );
+            forwarding.egress.insert(
+                ifindex,
+                EgressInterface {
+                    bind_ifindex: 12,
+                    vlan_id: 0,
+                    mtu: 1500,
+                    src_mac: [0; 6],
+                    zone: "wan".to_string(),
+                    redundancy_group: 0,
+                    primary_v4: None,
+                    primary_v6: None,
+                },
+            );
+        }
+        let worker_binding_ifindexes = BTreeMap::from([
+            (2, std::collections::BTreeSet::from([12])),
+            (7, std::collections::BTreeSet::from([12])),
+        ]);
+
+        let owner_by_ifindex = build_cos_owner_worker_by_ifindex_from_binding_ifindexes(
+            &forwarding,
+            &worker_binding_ifindexes,
+        );
+
+        assert_eq!(owner_by_ifindex.get(&80), Some(&2));
+        assert_eq!(owner_by_ifindex.get(&81), Some(&7));
+        assert_eq!(owner_by_ifindex.get(&82), Some(&2));
     }
 }

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -228,6 +228,7 @@ impl Coordinator {
         self.workers.clear();
         self.identities.clear();
         self.live.clear();
+        self.cos_owner_worker_by_ifindex.clear();
         self.last_slow_path_status = self
             .slow_path
             .as_ref()
@@ -863,11 +864,11 @@ impl Coordinator {
                 if entry.interface_name.is_empty() {
                     entry.interface_name = iface.interface_name.clone();
                 }
-                if entry.owner_worker_id == 0 {
-                    entry.owner_worker_id = *self
+                if entry.owner_worker_id.is_none() {
+                    entry.owner_worker_id = self
                         .cos_owner_worker_by_ifindex
                         .get(&iface.ifindex)
-                        .unwrap_or(&0) as usize;
+                        .copied();
                 }
                 entry.shaping_rate_bytes = entry.shaping_rate_bytes.max(iface.shaping_rate_bytes);
                 entry.burst_bytes = entry.burst_bytes.max(iface.burst_bytes);
@@ -1409,7 +1410,14 @@ fn build_cos_owner_worker_by_ifindex_from_binding_ifindexes(
 ) -> BTreeMap<i32, u32> {
     let mut owner_by_ifindex = BTreeMap::new();
     let mut next_owner_slot_by_tx_ifindex = BTreeMap::<i32, usize>::new();
-    for egress_ifindex in forwarding.cos.interfaces.keys().copied() {
+    let mut egress_ifindexes = forwarding
+        .cos
+        .interfaces
+        .keys()
+        .copied()
+        .collect::<Vec<_>>();
+    egress_ifindexes.sort_unstable();
+    for egress_ifindex in egress_ifindexes {
         let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
         let eligible_workers = worker_binding_ifindexes
             .iter()
@@ -1474,7 +1482,7 @@ mod tests {
     #[test]
     fn build_cos_owner_worker_by_ifindex_spreads_interfaces_across_eligible_workers() {
         let mut forwarding = ForwardingState::default();
-        for ifindex in [80, 81, 82] {
+        for ifindex in [82, 80, 81] {
             forwarding.cos.interfaces.insert(
                 ifindex,
                 CoSInterfaceConfig {

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -689,8 +689,12 @@ pub(crate) struct CoSInterfaceStatus {
     pub ifindex: i32,
     #[serde(rename = "interface_name", default)]
     pub interface_name: String,
-    #[serde(rename = "owner_worker_id", default)]
-    pub owner_worker_id: usize,
+    #[serde(
+        rename = "owner_worker_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub owner_worker_id: Option<u32>,
     #[serde(rename = "shaping_rate_bytes", default)]
     pub shaping_rate_bytes: u64,
     #[serde(rename = "burst_bytes", default)]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -689,6 +689,8 @@ pub(crate) struct CoSInterfaceStatus {
     pub ifindex: i32,
     #[serde(rename = "interface_name", default)]
     pub interface_name: String,
+    #[serde(rename = "owner_worker_id", default)]
+    pub owner_worker_id: usize,
     #[serde(rename = "shaping_rate_bytes", default)]
     pub shaping_rate_bytes: u64,
     #[serde(rename = "burst_bytes", default)]


### PR DESCRIPTION
## Summary
- spread static CoS interface ownership across eligible workers on the same TX path
- expose the chosen owner worker in `show class-of-service interface`
- update the CoS docs/gap note to reflect the stronger static ownership model

## Details
This is still the static-ownership part of Phase 4, not shared-budget leasing.

The coordinator now assigns shaped egress interfaces deterministically across the workers that can transmit on the resolved TX binding, instead of always pinning every such interface to the lowest worker. That keeps one owner per shaped interface, but avoids piling every shaped interface on the same worker when several share the same TX path.

The merged CoS runtime status now includes `owner_worker_id`, and the CLI summary shows it so the static ownership decision is visible during testing.

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_owner_worker_by_ifindex_ -- --nocapture`
- `go test ./pkg/dataplane/userspace ./pkg/cli ./pkg/grpcapi ./cmd/cli -count=1`
- `git diff --check`
