### PR TITLE
userspace-dp: cut hot-path CPU overhead

### DIFF
--- a/docs/userspace-dataplane-perf-hotspots.md
+++ b/docs/userspace-dataplane-perf-hotspots.md
@@ -1,0 +1,91 @@
+## Userspace Dataplane Perf Hotspots
+
+Date: 2026-04-15
+
+This note captures the current userspace dataplane CPU-cut work that restored post-CoS throughput, the validation used for it, and the remaining hotspots that still need targeted work.
+
+Follow-up tracker: `#678`
+
+### Validation Baseline
+
+Validation command:
+
+```bash
+./scripts/userspace-perf-compare.sh --duration 8 --parallel 12
+```
+
+Validated live on the `loss` HA userspace cluster with binary-only helper rollouts that preserved `/etc/xpf/xpf.conf` and `/etc/xpf/.configdb`.
+
+Current measured result on the validated helper build:
+
+- IPv4: about `23.0 Gbps`
+- IPv6: about `22.8 Gbps`
+
+Representative steady-state sample:
+
+- IPv4 intervals: `22.82, 23.34, 23.12, 23.01, 23.01, 23.12, 22.87, 22.86`
+- IPv6 intervals: `21.21, 22.82, 23.03, 22.96, 23.14, 23.09, 23.04, 22.87`
+
+### What This Perf Slice Changed
+
+These cuts are all aimed at keeping the no-CoS and lightly-classified fast path close to the earlier userspace forwarding baseline.
+
+- prequalified interface and `lo0` filter references so the packet hot path no longer pays per-packet string lookup overhead
+- replaced linear protocol/DSCP matching with bitmap checks
+- replaced generic port-range vector scans with specialized `any` / single-port / single-range / compact-set matchers
+- precomputed ingress logical-interface resolution so packet forwarding no longer scans interfaces to map `(bind_ifindex, vlan)` to the logical unit
+- skipped CoS TX-selection evaluation entirely when neither CoS nor TX-selection-capable filters are present for the packet family
+- skipped ingress TX-selection reevaluation when the ingress filter cannot influence `forwarding-class` or `dscp_rewrite`
+- reduced pending-forward request overhead by collapsing mutually exclusive frame payload storage
+- removed duplicate `expected_ports` / `target_binding_index` recomputation on the flow-cache fast-path fallback into `PendingForwardRequest`
+- optimized the common IPv6 single-address NAT checksum-adjust path to avoid repeated word-array materialization
+- kept direct-TX as the dominant forwarded path, with copy-path fallback remaining at zero in the validated steady state
+
+### Current Hotspots
+
+These are the remaining first-order symbols from the validated steady-state perf sample.
+
+IPv4:
+
+- `poll_binding`: about `13.4%`
+- `enqueue_pending_forwards`: about `4.3%`
+- `mlx5e_xsk_skb_from_cqe_linear`: about `4.6%`
+
+IPv6:
+
+- `poll_binding`: about `13.3%`
+- `enqueue_pending_forwards`: about `3.7%`
+- `apply_nat_ipv6`: about `3.2%`
+
+Interpretation:
+
+- `poll_binding` is still the largest userspace bucket and is now the main place to keep cutting CPU.
+- `enqueue_pending_forwards` is smaller than before, but it is still materially visible and still worth tightening.
+- `apply_nat_ipv6` is no longer catastrophic, but it is still one of the remaining IPv6-specific costs.
+
+### What Looks Left
+
+The next work should stay narrow and perf-driven.
+
+1. Split `poll_binding` into a colder orchestration shell and a smaller packet hot path.
+2. Reduce request-build work that still happens before a frame is known to need the generic pending-forward path.
+3. Keep shrinking `enqueue_pending_forwards`, especially the generic cross-binding and fallback work that still executes before direct-TX enqueue.
+4. Continue cutting IPv6 NAT overhead only behind live perf confirmation.
+
+More concrete next steps:
+
+- move more one-time per-binding/per-family decisions out of `poll_binding`
+- reduce temporary object construction on the session-hit and flow-cache-hit paths
+- continue pushing more packets into the direct descriptor/in-place rewrite path before they ever become generic pending-forward requests
+- revisit IPv6 NAT checksum and address rewrite work with targeted microbench plus live cluster perf, not speculative rewrites
+
+### Rejected Or Rolled Back Experiments
+
+These were tested and intentionally not kept.
+
+- `RUSTFLAGS='-C target-cpu=native'` helper builds: hurt live throughput badly on the validated cluster
+- adaptive idle-binding poll skipping: did not reduce the real `poll_binding` cost enough and hurt measured throughput
+- over-aggressive `authoritative_forward_ports()` shortcutting: reduced the symbol share but hurt effective IPv4 throughput
+- one direct-index `apply_nat_ipv6()` rewrite attempt: built and ran, but lowered IPv6 throughput and was rolled back
+
+The rule for the remaining work should stay the same: keep only changes that survive live HA-cluster validation, not just local benchmarks or cleaner-looking code.

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -274,6 +274,7 @@ fn poll_binding(
     dbg: &mut DebugPollCounters,
     rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> bool {
     #[derive(Default)]
     struct BatchCounters {
@@ -374,6 +375,7 @@ fn poll_binding(
         worker_id,
         worker_commands_by_id,
         cos_owner_worker_by_queue,
+        cos_owner_live_by_queue,
     );
     apply_shared_recycles(
         left,
@@ -403,6 +405,7 @@ fn poll_binding(
                 worker_id,
                 worker_commands_by_id,
                 cos_owner_worker_by_queue,
+                cos_owner_live_by_queue,
             );
             apply_shared_recycles(
                 left,
@@ -2838,6 +2841,7 @@ fn poll_binding(
                 worker_id,
                 worker_commands_by_id,
                 cos_owner_worker_by_queue,
+                cos_owner_live_by_queue,
             );
             binding.scratch_post_recycles = scratch_post_recycles;
         }

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -887,8 +887,16 @@ fn poll_binding(
                                 // HA resolution → fabric redirect.
                             } else {
                                 let cached_decision = cached.decision;
-                                let cached_descriptor = cached.descriptor;
-                                let cached_metadata = cached.metadata.clone();
+                                let cached_descriptor = &cached.descriptor;
+                                let cached_metadata = &cached.metadata;
+                                if let Some(counter) =
+                                    cached_descriptor.tx_selection.filter_counter.as_ref()
+                                {
+                                    crate::filter::record_filter_counter(
+                                        counter,
+                                        meta.pkt_len as u64,
+                                    );
+                                }
                                 // Amortize session timestamp touch — every 64 cache hits.
                                 binding.flow_cache_session_touch += 1;
                                 if binding.flow_cache_session_touch & 63 == 0 {
@@ -945,21 +953,28 @@ fn poll_binding(
                                         };
                                     let expected_ports =
                                         authoritative_forward_ports(packet_frame, meta, Some(flow));
-                                    let target_bi = if cached_decision.resolution.disposition
-                                        == ForwardingDisposition::FabricRedirect
-                                    {
-                                        binding_lookup.fabric_target_index(
-                                            target_ifindex,
-                                            fabric_queue_hash(Some(flow), expected_ports, meta),
-                                        )
-                                    } else {
-                                        binding_lookup.target_index(
-                                            binding_index,
-                                            ident.ifindex,
-                                            ident.queue_id,
-                                            target_ifindex,
-                                        )
-                                    };
+                                    let target_bi =
+                                        cached_descriptor.target_binding_index.or_else(|| {
+                                            if cached_decision.resolution.disposition
+                                                == ForwardingDisposition::FabricRedirect
+                                            {
+                                                binding_lookup.fabric_target_index(
+                                                    target_ifindex,
+                                                    fabric_queue_hash(
+                                                        Some(flow),
+                                                        expected_ports,
+                                                        meta,
+                                                    ),
+                                                )
+                                            } else {
+                                                binding_lookup.target_index(
+                                                    binding_index,
+                                                    ident.ifindex,
+                                                    ident.queue_id,
+                                                    target_ifindex,
+                                                )
+                                            }
+                                        });
                                     // Check if target is same binding (hairpin) or same-UMEM.
                                     // For simplicity, only do in-place fast path when target == self.
                                     let is_self_target = target_bi == Some(binding_index);
@@ -987,12 +1002,6 @@ fn poll_binding(
                                             )
                                         });
                                         if let Some(frame_len) = frame_len {
-                                            let cos = resolve_cos_tx_selection(
-                                                forwarding,
-                                                cached_decision.resolution.egress_ifindex,
-                                                meta,
-                                                Some(&flow.forward_key),
-                                            );
                                             binding.pending_tx_prepared.push_back(
                                                 PreparedTxRequest {
                                                     offset: desc.addr,
@@ -1007,8 +1016,12 @@ fn poll_binding(
                                                     egress_ifindex: cached_decision
                                                         .resolution
                                                         .egress_ifindex,
-                                                    cos_queue_id: cos.queue_id,
-                                                    dscp_rewrite: cos.dscp_rewrite,
+                                                    cos_queue_id: cached_descriptor
+                                                        .tx_selection
+                                                        .queue_id,
+                                                    dscp_rewrite: cached_descriptor
+                                                        .tx_selection
+                                                        .dscp_rewrite,
                                                 },
                                             );
                                             binding.pending_in_place_tx_packets += 1;
@@ -1032,9 +1045,17 @@ fn poll_binding(
                                                 Some(flow),
                                                 Some(&cached_metadata.ingress_zone),
                                                 cached_descriptor.apply_nat_on_fabric,
+                                                Some(PendingForwardHints {
+                                                    expected_ports,
+                                                    target_binding_index: target_bi,
+                                                }),
+                                                Some(&cached_descriptor.tx_selection),
                                             )
                                         {
-                                            request.source_frame = owned_packet_frame.take();
+                                            request.frame = owned_packet_frame
+                                                .take()
+                                                .map(PendingForwardFrame::Owned)
+                                                .unwrap_or(PendingForwardFrame::Live);
                                             dbg.forward += 1;
                                             dbg.tx += 1;
                                             binding.scratch_forwards.push(request);
@@ -1148,7 +1169,7 @@ fn poll_binding(
                                 if let Some(request) = local_icmp_te {
                                     binding.scratch_forwards.push(request);
                                     // Don't recycle: the TE response references
-                                    // the original frame via desc in its source_offset.
+                                    // the original frame via desc.addr on the request.
                                     // The continue skips recycle_now handling.
                                     continue;
                                 }
@@ -1195,8 +1216,13 @@ fn poll_binding(
                                     Some(flow),
                                     None,
                                     false,
+                                    None,
+                                    None,
                                 ) {
-                                    request.source_frame = owned_packet_frame.take();
+                                    request.frame = owned_packet_frame
+                                        .take()
+                                        .map(PendingForwardFrame::Owned)
+                                        .unwrap_or(PendingForwardFrame::Live);
                                     if sessions.install_with_protocol_with_origin(
                                         flow.forward_key.clone(),
                                         fabric_return_decision,
@@ -1591,16 +1617,16 @@ fn poll_binding(
                                                     target_ifindex,
                                                 ),
                                                 ingress_queue_id: ident.queue_id,
-                                                source_offset: desc.addr,
                                                 desc,
-                                                source_frame: None,
-                                                meta,
+                                                frame: PendingForwardFrame::Prebuilt(
+                                                    rewritten_frame,
+                                                ),
+                                                meta: meta.into(),
                                                 decision: icmp_decision,
                                                 apply_nat_on_fabric: false,
                                                 expected_ports: None,
                                                 flow_key: None,
                                                 nat64_reverse: None,
-                                                prebuilt_frame: Some(rewritten_frame),
                                                 cos_queue_id: cos.queue_id,
                                                 dscp_rewrite: cos.dscp_rewrite,
                                             });
@@ -2383,8 +2409,13 @@ fn poll_binding(
                             flow.as_ref(),
                             session_ingress_zone.as_ref(),
                             apply_nat_on_fabric,
+                            None,
+                            None,
                         ) {
-                            request.source_frame = owned_packet_frame.take();
+                            request.frame = owned_packet_frame
+                                .take()
+                                .map(PendingForwardFrame::Owned)
+                                .unwrap_or(PendingForwardFrame::Live);
                             dbg.tx += 1; // track forward requests queued
                             if cfg!(feature = "debug-log") {
                                 if dbg.tx <= 5 {
@@ -2434,6 +2465,7 @@ fn poll_binding(
                                     );
                                 }
                             }
+                            let request_target_binding_index = request.target_binding_index;
                             binding.scratch_forwards.push(request);
                             recycle_now = false;
                             // ── Flow cache population ────────────────────
@@ -2447,6 +2479,7 @@ fn poll_binding(
                                     decision,
                                     flow_cache_owner_rg_id,
                                     session_ingress_zone.as_ref().cloned(),
+                                    request_target_binding_index,
                                     forwarding,
                                     ha_state,
                                     apply_nat_on_fabric,
@@ -2779,33 +2812,35 @@ fn poll_binding(
             );
         }
         binding.scratch_rst_teardowns = rst_teardowns;
-        // Use raw pointer to avoid Arc::clone (~5% CPU from lock incq).
-        // Safety: the Arc<BindingLiveState> outlives this function call;
-        // binding is borrowed mutably by enqueue_pending_forwards but
-        // ingress_live is only used for read-only error logging inside it.
-        let ingress_live: *const BindingLiveState = &*binding.live;
-        let mut scratch_post_recycles = core::mem::take(&mut binding.scratch_post_recycles);
-        enqueue_pending_forwards(
-            left,
-            binding_index,
-            binding,
-            right,
-            binding_lookup,
-            &mut pending_forwards,
-            &mut scratch_post_recycles,
-            now_ns,
-            forwarding,
-            &ident,
-            unsafe { &*ingress_live },
-            slow_path,
-            local_tunnel_deliveries,
-            recent_exceptions,
-            dbg,
-            worker_id,
-            worker_commands_by_id,
-            cos_owner_worker_by_queue,
-        );
-        binding.scratch_post_recycles = scratch_post_recycles;
+        if !pending_forwards.is_empty() {
+            // Use raw pointer to avoid Arc::clone (~5% CPU from lock incq).
+            // Safety: the Arc<BindingLiveState> outlives this function call;
+            // binding is borrowed mutably by enqueue_pending_forwards but
+            // ingress_live is only used for read-only error logging inside it.
+            let ingress_live: *const BindingLiveState = &*binding.live;
+            let mut scratch_post_recycles = core::mem::take(&mut binding.scratch_post_recycles);
+            enqueue_pending_forwards(
+                left,
+                binding_index,
+                binding,
+                right,
+                binding_lookup,
+                &mut pending_forwards,
+                &mut scratch_post_recycles,
+                now_ns,
+                forwarding,
+                &ident,
+                unsafe { &*ingress_live },
+                slow_path,
+                local_tunnel_deliveries,
+                recent_exceptions,
+                dbg,
+                worker_id,
+                worker_commands_by_id,
+                cos_owner_worker_by_queue,
+            );
+            binding.scratch_post_recycles = scratch_post_recycles;
+        }
         binding.scratch_forwards = pending_forwards;
         // Reserved: cross-binding in-place TX from flow cache fast path.
         // Currently only self-target (hairpin) uses the inline path;
@@ -2991,7 +3026,15 @@ fn build_live_forward_request(
         flow,
         fabric_ingress_zone,
         apply_nat_on_fabric,
+        None,
+        None,
     )
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PendingForwardHints {
+    expected_ports: Option<(u16, u16)>,
+    target_binding_index: Option<usize>,
 }
 
 fn build_live_forward_request_from_frame(
@@ -3006,7 +3049,10 @@ fn build_live_forward_request_from_frame(
     flow: Option<&SessionFlow>,
     fabric_ingress_zone: Option<&Arc<str>>,
     apply_nat_on_fabric: bool,
+    hints: Option<PendingForwardHints>,
+    precomputed_tx_selection: Option<&CachedTxSelectionDescriptor>,
 ) -> Option<PendingForwardRequest> {
+    let hints = hints.unwrap_or_default();
     let target_ifindex = if decision.resolution.tx_ifindex > 0 {
         decision.resolution.tx_ifindex
     } else {
@@ -3015,8 +3061,10 @@ fn build_live_forward_request_from_frame(
     // Prefer session flow ports (set by conntrack, immune to DMA races),
     // then live frame ports (lazy — only parsed if session ports unavailable),
     // then metadata as last resort.
-    let expected_ports = authoritative_forward_ports(frame, meta, flow);
-    let target_binding_index =
+    let expected_ports = hints
+        .expected_ports
+        .or_else(|| authoritative_forward_ports(frame, meta, flow));
+    let target_binding_index = hints.target_binding_index.or_else(|| {
         if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
             binding_lookup.fabric_target_index(
                 target_ifindex,
@@ -3029,7 +3077,8 @@ fn build_live_forward_request_from_frame(
                 ingress_ident.queue_id,
                 target_ifindex,
             )
-        };
+        }
+    });
     let mut decision = *decision;
     if decision.resolution.disposition == ForwardingDisposition::FabricRedirect
         && let Some(ingress_zone) = fabric_ingress_zone
@@ -3038,26 +3087,31 @@ fn build_live_forward_request_from_frame(
     {
         decision.resolution.src_mac = zone_redirect.src_mac;
     }
-    let cos = resolve_cos_tx_selection(
-        forwarding,
-        decision.resolution.egress_ifindex,
-        meta,
-        flow.map(|flow| &flow.forward_key),
-    );
+    let cos = precomputed_tx_selection
+        .map(|selection| CoSTxSelection {
+            queue_id: selection.queue_id,
+            dscp_rewrite: selection.dscp_rewrite,
+        })
+        .unwrap_or_else(|| {
+            resolve_cos_tx_selection(
+                forwarding,
+                decision.resolution.egress_ifindex,
+                meta,
+                flow.map(|flow| &flow.forward_key),
+            )
+        });
     Some(PendingForwardRequest {
         target_ifindex,
         target_binding_index,
         ingress_queue_id: ingress_ident.queue_id,
-        source_offset: desc.addr,
         desc,
-        source_frame: None,
-        meta,
+        frame: PendingForwardFrame::Live,
+        meta: meta.into(),
         decision,
         apply_nat_on_fabric,
         expected_ports,
         flow_key: flow.map(|flow| flow.forward_key.clone()),
         nat64_reverse: None,
-        prebuilt_frame: None,
         cos_queue_id: cos.queue_id,
         dscp_rewrite: cos.dscp_rewrite,
     })

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -19,8 +19,7 @@ pub struct Coordinator {
     pub(crate) shared_cos_owner_live_by_queue:
         Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     pub(crate) shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
-    pub(crate) shared_cos_queue_leases:
-        Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
+    pub(crate) shared_cos_queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     pub(crate) shared_validation: Arc<ArcSwap<ValidationState>>,
     pub(crate) dynamic_neighbors: Arc<Mutex<FastMap<(i32, IpAddr), NeighborEntry>>>,
     pub(crate) neighbor_generation: Arc<AtomicU64>,
@@ -244,7 +243,8 @@ impl Coordinator {
         self.shared_cos_owner_live_by_queue
             .store(Arc::new(BTreeMap::new()));
         self.shared_cos_root_leases.store(Arc::new(BTreeMap::new()));
-        self.shared_cos_queue_leases.store(Arc::new(BTreeMap::new()));
+        self.shared_cos_queue_leases
+            .store(Arc::new(BTreeMap::new()));
         self.last_slow_path_status = self
             .slow_path
             .as_ref()
@@ -1195,7 +1195,8 @@ impl Coordinator {
             self.shared_cos_root_leases.store(Arc::new(next_leases));
         }
         if !shared_cos_queue_leases_match(current_queue_leases.as_ref(), &next_queue_leases) {
-            self.shared_cos_queue_leases.store(Arc::new(next_queue_leases));
+            self.shared_cos_queue_leases
+                .store(Arc::new(next_queue_leases));
         }
     }
 

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1645,6 +1645,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![CoSQueueConfig {
                     queue_id: 0,
@@ -1695,6 +1697,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![
                     CoSQueueConfig {
@@ -1769,6 +1773,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![
                     CoSQueueConfig {
@@ -1832,6 +1838,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![CoSQueueConfig {
                     queue_id: 0,
@@ -1988,6 +1996,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![
                     CoSQueueConfig {
@@ -2045,6 +2055,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![CoSQueueConfig {
                     queue_id: 0,
@@ -2081,6 +2093,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![
                     CoSQueueConfig {

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -19,6 +19,8 @@ pub struct Coordinator {
     pub(crate) shared_cos_owner_live_by_queue:
         Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     pub(crate) shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
+    pub(crate) shared_cos_queue_leases:
+        Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     pub(crate) shared_validation: Arc<ArcSwap<ValidationState>>,
     pub(crate) dynamic_neighbors: Arc<Mutex<FastMap<(i32, IpAddr), NeighborEntry>>>,
     pub(crate) neighbor_generation: Arc<AtomicU64>,
@@ -71,6 +73,7 @@ impl Coordinator {
             shared_cos_owner_worker_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             shared_cos_owner_live_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             shared_cos_root_leases: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
+            shared_cos_queue_leases: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             shared_validation: Arc::new(ArcSwap::from_pointee(ValidationState::default())),
             dynamic_neighbors: Arc::new(Mutex::new(FastMap::default())),
             neighbor_generation: Arc::new(AtomicU64::new(0)),
@@ -241,6 +244,7 @@ impl Coordinator {
         self.shared_cos_owner_live_by_queue
             .store(Arc::new(BTreeMap::new()));
         self.shared_cos_root_leases.store(Arc::new(BTreeMap::new()));
+        self.shared_cos_queue_leases.store(Arc::new(BTreeMap::new()));
         self.last_slow_path_status = self
             .slow_path
             .as_ref()
@@ -588,7 +592,26 @@ impl Coordinator {
         self.conntrack_v6_fd = conntrack_v6_fd;
         self.dnat_table_fd = dnat_table_fd;
         self.dnat_table_v6_fd = dnat_table_v6_fd;
-        self.refresh_cos_runtime_maps(build_cos_owner_worker_by_queue(&self.forwarding, &workers));
+        let worker_binding_ifindexes = workers
+            .iter()
+            .map(|(worker_id, binding_plans)| {
+                (
+                    *worker_id,
+                    binding_plans
+                        .iter()
+                        .map(|plan| plan.status.ifindex)
+                        .collect::<std::collections::BTreeSet<_>>(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let owner_map = build_cos_owner_worker_by_queue(&self.forwarding, &workers);
+        let active_shards_by_egress_ifindex =
+            build_cos_active_shards_by_egress_ifindex_with_fallback_ifindexes(
+                &self.forwarding,
+                &worker_binding_ifindexes,
+                &worker_binding_ifindexes,
+            );
+        self.refresh_cos_runtime_maps(owner_map, active_shards_by_egress_ifindex);
         let worker_command_queues: Arc<BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>> =
             Arc::new(
                 workers
@@ -650,6 +673,7 @@ impl Coordinator {
             let shared_cos_owner_worker_by_queue = self.shared_cos_owner_worker_by_queue.clone();
             let shared_cos_owner_live_by_queue = self.shared_cos_owner_live_by_queue.clone();
             let shared_cos_root_leases = self.shared_cos_root_leases.clone();
+            let shared_cos_queue_leases = self.shared_cos_queue_leases.clone();
             let join = thread::Builder::new()
                 .name(format!("xpf-userspace-worker-{worker_id}"))
                 .spawn(move || {
@@ -683,6 +707,7 @@ impl Coordinator {
                         shared_cos_owner_worker_by_queue,
                         shared_cos_owner_live_by_queue,
                         shared_cos_root_leases,
+                        shared_cos_queue_leases,
                         cos_status_clone,
                     );
                 });
@@ -1088,10 +1113,17 @@ impl Coordinator {
     fn refresh_cos_owner_worker_map_from_identities(&mut self) {
         let worker_binding_ifindexes =
             build_worker_binding_ifindexes_from_identities(&self.identities);
-        self.refresh_cos_runtime_maps(build_cos_owner_worker_by_queue_from_binding_ifindexes(
+        let owner_map = build_cos_owner_worker_by_queue_from_binding_ifindexes(
             &self.forwarding,
             &worker_binding_ifindexes,
-        ));
+        );
+        let active_shards_by_egress_ifindex =
+            build_cos_active_shards_by_egress_ifindex_with_fallback_ifindexes(
+                &self.forwarding,
+                &worker_binding_ifindexes,
+                &worker_binding_ifindexes,
+            );
+        self.refresh_cos_runtime_maps(owner_map, active_shards_by_egress_ifindex);
     }
 
     fn refresh_cos_owner_worker_map_from_binding_statuses(&mut self, bindings: &[BindingStatus]) {
@@ -1106,14 +1138,25 @@ impl Coordinator {
         );
         let fallback_worker_binding_ifindexes =
             build_worker_binding_ifindexes_from_identities(&self.identities);
-        self.refresh_cos_runtime_maps(build_cos_owner_worker_by_queue_with_fallback_ifindexes(
+        let owner_map = build_cos_owner_worker_by_queue_with_fallback_ifindexes(
             &self.forwarding,
             &ready_worker_binding_ifindexes,
             &fallback_worker_binding_ifindexes,
-        ));
+        );
+        let active_shards_by_egress_ifindex =
+            build_cos_active_shards_by_egress_ifindex_with_fallback_ifindexes(
+                &self.forwarding,
+                &ready_worker_binding_ifindexes,
+                &fallback_worker_binding_ifindexes,
+            );
+        self.refresh_cos_runtime_maps(owner_map, active_shards_by_egress_ifindex);
     }
 
-    fn refresh_cos_runtime_maps(&mut self, owner_map: BTreeMap<(i32, u8), u32>) {
+    fn refresh_cos_runtime_maps(
+        &mut self,
+        owner_map: BTreeMap<(i32, u8), u32>,
+        active_shards_by_egress_ifindex: BTreeMap<i32, usize>,
+    ) {
         let owner_changed = owner_map != self.cos_owner_worker_by_queue;
         let owner_map_for_runtime = if owner_changed {
             &owner_map
@@ -1130,8 +1173,14 @@ impl Coordinator {
         let current_leases = self.shared_cos_root_leases.load();
         let next_leases = build_shared_cos_root_leases_reusing_existing(
             &self.forwarding,
-            owner_map_for_runtime,
+            &active_shards_by_egress_ifindex,
             current_leases.as_ref(),
+        );
+        let current_queue_leases = self.shared_cos_queue_leases.load();
+        let next_queue_leases = build_shared_cos_queue_leases_reusing_existing(
+            &self.forwarding,
+            &active_shards_by_egress_ifindex,
+            current_queue_leases.as_ref(),
         );
         if owner_changed {
             self.cos_owner_worker_by_queue = owner_map.clone();
@@ -1144,6 +1193,9 @@ impl Coordinator {
         }
         if !shared_cos_root_leases_match(current_leases.as_ref(), &next_leases) {
             self.shared_cos_root_leases.store(Arc::new(next_leases));
+        }
+        if !shared_cos_queue_leases_match(current_queue_leases.as_ref(), &next_queue_leases) {
+            self.shared_cos_queue_leases.store(Arc::new(next_queue_leases));
         }
     }
 
@@ -1594,11 +1646,49 @@ fn build_cos_owner_worker_by_queue_with_fallback_ifindexes(
     owner_by_queue
 }
 
+fn build_cos_active_shards_by_egress_ifindex_with_fallback_ifindexes(
+    forwarding: &ForwardingState,
+    preferred_worker_binding_ifindexes: &BTreeMap<u32, std::collections::BTreeSet<i32>>,
+    fallback_worker_binding_ifindexes: &BTreeMap<u32, std::collections::BTreeSet<i32>>,
+) -> BTreeMap<i32, usize> {
+    let mut out = BTreeMap::new();
+    let mut egress_ifindexes = forwarding
+        .cos
+        .interfaces
+        .keys()
+        .copied()
+        .collect::<Vec<_>>();
+    egress_ifindexes.sort_unstable();
+    for egress_ifindex in egress_ifindexes {
+        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
+        let preferred_count = preferred_worker_binding_ifindexes
+            .values()
+            .filter(|ifindexes| ifindexes.contains(&tx_ifindex))
+            .count();
+        let fallback_count = fallback_worker_binding_ifindexes
+            .values()
+            .filter(|ifindexes| ifindexes.contains(&tx_ifindex))
+            .count();
+        let active_shards = if preferred_count > 0 {
+            preferred_count
+        } else {
+            fallback_count
+        }
+        .max(1);
+        out.insert(egress_ifindex, active_shards);
+    }
+    out
+}
+
 fn build_shared_cos_root_leases(
     forwarding: &ForwardingState,
-    owner_by_queue: &BTreeMap<(i32, u8), u32>,
+    active_shards_by_egress_ifindex: &BTreeMap<i32, usize>,
 ) -> BTreeMap<i32, Arc<SharedCoSRootLease>> {
-    build_shared_cos_root_leases_reusing_existing(forwarding, owner_by_queue, &BTreeMap::new())
+    build_shared_cos_root_leases_reusing_existing(
+        forwarding,
+        active_shards_by_egress_ifindex,
+        &BTreeMap::new(),
+    )
 }
 
 fn build_cos_owner_live_by_queue(
@@ -1630,17 +1720,15 @@ fn build_cos_owner_live_by_queue(
 
 fn build_shared_cos_root_leases_reusing_existing(
     forwarding: &ForwardingState,
-    owner_by_queue: &BTreeMap<(i32, u8), u32>,
+    active_shards_by_egress_ifindex: &BTreeMap<i32, usize>,
     existing: &BTreeMap<i32, Arc<SharedCoSRootLease>>,
 ) -> BTreeMap<i32, Arc<SharedCoSRootLease>> {
     let mut out = BTreeMap::new();
     for (&ifindex, iface) in &forwarding.cos.interfaces {
-        let active_shards = iface
-            .queues
-            .iter()
-            .filter_map(|queue| owner_by_queue.get(&(ifindex, queue.queue_id)).copied())
-            .collect::<std::collections::BTreeSet<_>>()
-            .len()
+        let active_shards = active_shards_by_egress_ifindex
+            .get(&ifindex)
+            .copied()
+            .unwrap_or(1)
             .max(1);
         let burst_bytes = iface.burst_bytes.max(64 * 1500);
         if let Some(lease) = existing.get(&ifindex).filter(|lease| {
@@ -1661,6 +1749,43 @@ fn build_shared_cos_root_leases_reusing_existing(
     out
 }
 
+fn build_shared_cos_queue_leases_reusing_existing(
+    forwarding: &ForwardingState,
+    active_shards_by_egress_ifindex: &BTreeMap<i32, usize>,
+    existing: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+) -> BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>> {
+    let mut out = BTreeMap::new();
+    for (&ifindex, iface) in &forwarding.cos.interfaces {
+        let active_shards = active_shards_by_egress_ifindex
+            .get(&ifindex)
+            .copied()
+            .unwrap_or(1)
+            .max(1);
+        for queue in &iface.queues {
+            if !queue.exact || queue.transmit_rate_bytes == 0 {
+                continue;
+            }
+            let burst_bytes = queue.buffer_bytes.max(64 * 1500);
+            let key = (ifindex, queue.queue_id);
+            if let Some(lease) = existing.get(&key).filter(|lease| {
+                lease.matches_config(queue.transmit_rate_bytes, burst_bytes, active_shards)
+            }) {
+                out.insert(key, lease.clone());
+                continue;
+            }
+            out.insert(
+                key,
+                Arc::new(SharedCoSQueueLease::new(
+                    queue.transmit_rate_bytes,
+                    burst_bytes,
+                    active_shards,
+                )),
+            );
+        }
+    }
+    out
+}
+
 fn shared_cos_root_leases_match(
     current: &BTreeMap<i32, Arc<SharedCoSRootLease>>,
     next: &BTreeMap<i32, Arc<SharedCoSRootLease>>,
@@ -1670,6 +1795,16 @@ fn shared_cos_root_leases_match(
             next.get(ifindex)
                 .is_some_and(|next| Arc::ptr_eq(lease, next))
         })
+}
+
+fn shared_cos_queue_leases_match(
+    current: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    next: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+) -> bool {
+    current.len() == next.len()
+        && current
+            .iter()
+            .all(|(key, lease)| next.get(key).is_some_and(|next| Arc::ptr_eq(lease, next)))
 }
 
 fn shared_cos_owner_live_by_queue_match(
@@ -2043,7 +2178,7 @@ mod tests {
     }
 
     #[test]
-    fn build_shared_cos_root_leases_uses_distinct_owner_workers_per_interface() {
+    fn build_shared_cos_root_leases_uses_active_workers_per_interface() {
         let mut forwarding = ForwardingState::default();
         forwarding.cos.interfaces.insert(
             80,
@@ -2080,9 +2215,9 @@ mod tests {
                 ],
             },
         );
-        let owner_by_queue = BTreeMap::from([((80, 0), 2), ((80, 1), 7)]);
+        let active_shards_by_egress_ifindex = BTreeMap::from([(80, 2usize)]);
 
-        let leases = build_shared_cos_root_leases(&forwarding, &owner_by_queue);
+        let leases = build_shared_cos_root_leases(&forwarding, &active_shards_by_egress_ifindex);
         let lease = leases.get(&80).expect("shared root lease");
 
         let first = lease.acquire(1, 2500);
@@ -2127,15 +2262,63 @@ mod tests {
                 }],
             },
         );
-        let owner_by_queue = BTreeMap::from([((80, 0), 2)]);
+        let active_shards_by_egress_ifindex = BTreeMap::from([(80, 1usize)]);
 
-        let existing = build_shared_cos_root_leases(&forwarding, &owner_by_queue);
-        let reused =
-            build_shared_cos_root_leases_reusing_existing(&forwarding, &owner_by_queue, &existing);
+        let existing = build_shared_cos_root_leases(&forwarding, &active_shards_by_egress_ifindex);
+        let reused = build_shared_cos_root_leases_reusing_existing(
+            &forwarding,
+            &active_shards_by_egress_ifindex,
+            &existing,
+        );
 
         assert!(Arc::ptr_eq(
             existing.get(&80).expect("existing lease"),
             reused.get(&80).expect("reused lease")
+        ));
+    }
+
+    #[test]
+    fn build_shared_cos_queue_leases_reuses_existing_matching_lease_arc() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 100_000_000,
+                burst_bytes: 256 * 1024,
+                default_queue: 0,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 4,
+                    forwarding_class: "iperf-b".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 50_000_000,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: 128 * 1024,
+                    dscp_rewrite: None,
+                }],
+            },
+        );
+        let active_shards_by_egress_ifindex = BTreeMap::from([(80, 2usize)]);
+
+        let existing = build_shared_cos_queue_leases_reusing_existing(
+            &forwarding,
+            &active_shards_by_egress_ifindex,
+            &BTreeMap::new(),
+        );
+        let reused = build_shared_cos_queue_leases_reusing_existing(
+            &forwarding,
+            &active_shards_by_egress_ifindex,
+            &existing,
+        );
+
+        assert!(Arc::ptr_eq(
+            existing.get(&(80, 4)).expect("existing queue lease"),
+            reused.get(&(80, 4)).expect("reused queue lease")
         ));
     }
 

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -16,6 +16,8 @@ pub struct Coordinator {
     pub(crate) shared_fabrics: Arc<ArcSwap<Vec<FabricLink>>>,
     pub(crate) shared_forwarding: Arc<ArcSwap<ForwardingState>>,
     pub(crate) shared_cos_owner_worker_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), u32>>>,
+    pub(crate) shared_cos_owner_live_by_queue:
+        Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     pub(crate) shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
     pub(crate) shared_validation: Arc<ArcSwap<ValidationState>>,
     pub(crate) dynamic_neighbors: Arc<Mutex<FastMap<(i32, IpAddr), NeighborEntry>>>,
@@ -67,6 +69,7 @@ impl Coordinator {
             shared_fabrics: Arc::new(ArcSwap::from_pointee(Vec::new())),
             shared_forwarding: Arc::new(ArcSwap::from_pointee(ForwardingState::default())),
             shared_cos_owner_worker_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
+            shared_cos_owner_live_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             shared_cos_root_leases: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             shared_validation: Arc::new(ArcSwap::from_pointee(ValidationState::default())),
             dynamic_neighbors: Arc::new(Mutex::new(FastMap::default())),
@@ -234,6 +237,8 @@ impl Coordinator {
         self.live.clear();
         self.cos_owner_worker_by_queue.clear();
         self.shared_cos_owner_worker_by_queue
+            .store(Arc::new(BTreeMap::new()));
+        self.shared_cos_owner_live_by_queue
             .store(Arc::new(BTreeMap::new()));
         self.shared_cos_root_leases.store(Arc::new(BTreeMap::new()));
         self.last_slow_path_status = self
@@ -643,6 +648,7 @@ impl Coordinator {
             let event_stream_handle = self.event_stream_worker_handle();
             let cos_status_clone = cos_status.clone();
             let shared_cos_owner_worker_by_queue = self.shared_cos_owner_worker_by_queue.clone();
+            let shared_cos_owner_live_by_queue = self.shared_cos_owner_live_by_queue.clone();
             let shared_cos_root_leases = self.shared_cos_root_leases.clone();
             let join = thread::Builder::new()
                 .name(format!("xpf-userspace-worker-{worker_id}"))
@@ -675,6 +681,7 @@ impl Coordinator {
                         event_stream_handle,
                         rg_epochs,
                         shared_cos_owner_worker_by_queue,
+                        shared_cos_owner_live_by_queue,
                         shared_cos_root_leases,
                         cos_status_clone,
                     );
@@ -1108,20 +1115,32 @@ impl Coordinator {
 
     fn refresh_cos_runtime_maps(&mut self, owner_map: BTreeMap<(i32, u8), u32>) {
         let owner_changed = owner_map != self.cos_owner_worker_by_queue;
+        let owner_map_for_runtime = if owner_changed {
+            &owner_map
+        } else {
+            &self.cos_owner_worker_by_queue
+        };
+        let current_owner_live = self.shared_cos_owner_live_by_queue.load();
+        let next_owner_live = build_cos_owner_live_by_queue(
+            &self.forwarding,
+            owner_map_for_runtime,
+            &self.identities,
+            &self.live,
+        );
         let current_leases = self.shared_cos_root_leases.load();
         let next_leases = build_shared_cos_root_leases_reusing_existing(
             &self.forwarding,
-            if owner_changed {
-                &owner_map
-            } else {
-                &self.cos_owner_worker_by_queue
-            },
+            owner_map_for_runtime,
             current_leases.as_ref(),
         );
         if owner_changed {
             self.cos_owner_worker_by_queue = owner_map.clone();
             self.shared_cos_owner_worker_by_queue
                 .store(Arc::new(owner_map));
+        }
+        if !shared_cos_owner_live_by_queue_match(current_owner_live.as_ref(), &next_owner_live) {
+            self.shared_cos_owner_live_by_queue
+                .store(Arc::new(next_owner_live));
         }
         if !shared_cos_root_leases_match(current_leases.as_ref(), &next_leases) {
             self.shared_cos_root_leases.store(Arc::new(next_leases));
@@ -1582,6 +1601,33 @@ fn build_shared_cos_root_leases(
     build_shared_cos_root_leases_reusing_existing(forwarding, owner_by_queue, &BTreeMap::new())
 }
 
+fn build_cos_owner_live_by_queue(
+    forwarding: &ForwardingState,
+    owner_by_queue: &BTreeMap<(i32, u8), u32>,
+    identities: &BTreeMap<u32, BindingIdentity>,
+    live: &BTreeMap<u32, Arc<BindingLiveState>>,
+) -> BTreeMap<(i32, u8), Arc<BindingLiveState>> {
+    let mut live_by_worker_ifindex = BTreeMap::<(u32, i32), Arc<BindingLiveState>>::new();
+    for (slot, ident) in identities {
+        let Some(binding_live) = live.get(slot) else {
+            continue;
+        };
+        live_by_worker_ifindex
+            .entry((ident.worker_id, ident.ifindex))
+            .or_insert_with(|| binding_live.clone());
+    }
+
+    let mut out = BTreeMap::new();
+    for (&(egress_ifindex, queue_id), &worker_id) in owner_by_queue {
+        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
+        let Some(owner_live) = live_by_worker_ifindex.get(&(worker_id, tx_ifindex)) else {
+            continue;
+        };
+        out.insert((egress_ifindex, queue_id), owner_live.clone());
+    }
+    out
+}
+
 fn build_shared_cos_root_leases_reusing_existing(
     forwarding: &ForwardingState,
     owner_by_queue: &BTreeMap<(i32, u8), u32>,
@@ -1623,6 +1669,17 @@ fn shared_cos_root_leases_match(
         && current.iter().all(|(ifindex, lease)| {
             next.get(ifindex)
                 .is_some_and(|next| Arc::ptr_eq(lease, next))
+        })
+}
+
+fn shared_cos_owner_live_by_queue_match(
+    current: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    next: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+) -> bool {
+    current.len() == next.len()
+        && current.iter().all(|(key, live)| {
+            next.get(key)
+                .is_some_and(|next_live| Arc::ptr_eq(live, next_live))
         })
 }
 

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
 
 const FLOW_CACHE_SIZE: usize = 4096;
@@ -7,10 +8,17 @@ const FLOW_CACHE_MASK: usize = FLOW_CACHE_SIZE - 1;
 /// Maximum number of redundancy groups for epoch-based cache invalidation.
 pub(super) const MAX_RG_EPOCHS: usize = 16;
 
+#[derive(Clone, Debug, Default)]
+pub(super) struct CachedTxSelectionDescriptor {
+    pub(super) queue_id: Option<u8>,
+    pub(super) dscp_rewrite: Option<u8>,
+    pub(super) filter_counter: Option<Arc<crate::filter::FilterTermCounter>>,
+}
+
 /// Precomputed rewrite descriptor for an established flow.
 /// All fields are constant for the lifetime of the session.
 /// Per-packet cost: write MACs + TTL-- + apply precomputed csum deltas.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct RewriteDescriptor {
     pub(super) dst_mac: [u8; 6],
     pub(super) src_mac: [u8; 6],
@@ -29,6 +37,7 @@ pub(super) struct RewriteDescriptor {
     pub(super) tx_ifindex: i32,
     #[allow(dead_code)] // populated for future flow-cache fast-path TX
     pub(super) target_binding_index: Option<usize>,
+    pub(super) tx_selection: CachedTxSelectionDescriptor,
     pub(super) nat64: bool,
     pub(super) nptv6: bool,
     #[allow(dead_code)] // populated for future flow-cache fast-path TX
@@ -126,6 +135,7 @@ impl FlowCacheEntry {
         decision: SessionDecision,
         flow_owner_rg_id: i32,
         ingress_zone: Option<Arc<str>>,
+        target_binding_index: Option<usize>,
         forwarding: &ForwardingState,
         ha_state: &BTreeMap<i32, HAGroupRuntime>,
         apply_nat_on_fabric: bool,
@@ -165,7 +175,13 @@ impl FlowCacheEntry {
                 l4_csum_delta: compute_l4_csum_delta(flow, &decision.nat),
                 egress_ifindex: decision.resolution.egress_ifindex,
                 tx_ifindex: decision.resolution.tx_ifindex,
-                target_binding_index: None,
+                target_binding_index,
+                tx_selection: resolve_cached_cos_tx_selection(
+                    forwarding,
+                    decision.resolution.egress_ifindex,
+                    meta,
+                    Some(&flow.forward_key),
+                ),
                 nat64: false,
                 nptv6: false,
                 apply_nat_on_fabric,
@@ -326,6 +342,7 @@ mod tests {
             egress_ifindex: 6,
             tx_ifindex: 6,
             target_binding_index: None,
+            tx_selection: CachedTxSelectionDescriptor::default(),
             nat64: false,
             nptv6: false,
             apply_nat_on_fabric: false,
@@ -729,6 +746,7 @@ mod tests {
             decision,
             1,
             ingress_zone.clone(),
+            Some(7),
             &forwarding,
             &BTreeMap::from([(
                 1,
@@ -762,6 +780,7 @@ mod tests {
         assert_eq!(entry.descriptor.tx_vlan_id, 50);
         assert_eq!(entry.descriptor.egress_ifindex, 6);
         assert_eq!(entry.descriptor.tx_ifindex, 6);
+        assert_eq!(entry.descriptor.target_binding_index, Some(7));
         assert_eq!(entry.descriptor.ether_type, 0x0800);
         assert_eq!(
             entry.descriptor.fabric_redirect,
@@ -821,6 +840,7 @@ mod tests {
             validation,
             decision,
             0,
+            None,
             None,
             &forwarding,
             &BTreeMap::new(),
@@ -888,6 +908,7 @@ mod tests {
             decision,
             2,
             Some(Arc::<str>::from("trust")),
+            Some(3),
             &forwarding,
             &BTreeMap::from([(
                 2,
@@ -905,5 +926,6 @@ mod tests {
         assert_eq!(entry.stamp.owner_rg_id, 2);
         assert_eq!(entry.metadata.owner_rg_id, 2);
         assert!(entry.descriptor.fabric_redirect);
+        assert_eq!(entry.descriptor.target_binding_index, Some(3));
     }
 }

--- a/userspace-dp/src/afxdp/forwarding.rs
+++ b/userspace-dp/src/afxdp/forwarding.rs
@@ -918,7 +918,14 @@ pub(super) fn ingress_route_table_override(
     )
     .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
-    let result = crate::filter::evaluate_interface_filter_counted(
+    if !crate::filter::interface_filter_affects_route_lookup(
+        &forwarding.filter_state,
+        ingress_ifindex,
+        is_v6,
+    ) {
+        return None;
+    }
+    let routing_instance = crate::filter::evaluate_interface_filter_routing_instance_counted(
         &forwarding.filter_state,
         ingress_ifindex,
         is_v6,
@@ -930,13 +937,11 @@ pub(super) fn ingress_route_table_override(
         meta.dscp,
         meta.pkt_len as u64,
     );
-    if result.routing_instance.is_empty() {
-        return None;
-    }
+    let routing_instance = routing_instance?;
     Some(if is_v6 {
-        format!("{}.inet6.0", result.routing_instance)
+        format!("{routing_instance}.inet6.0")
     } else {
-        format!("{}.inet.0", result.routing_instance)
+        format!("{routing_instance}.inet.0")
     })
 }
 

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -32,6 +32,40 @@ pub(super) fn build_screen_profiles(snapshot: &ConfigSnapshot) -> FxHashMap<Stri
     profiles
 }
 
+fn build_cos_dscp_queue_table(
+    classifier_name: &str,
+    classifiers: &FastMap<String, CoSDSCPClassifierConfig>,
+) -> [u8; 64] {
+    let mut table = [u8::MAX; 64];
+    if classifier_name.is_empty() {
+        return table;
+    }
+    if let Some(classifier) = classifiers.get(classifier_name) {
+        for (&dscp, &queue_id) in &classifier.queue_by_dscp {
+            let idx = usize::from(dscp & 0x3f);
+            table[idx] = queue_id;
+        }
+    }
+    table
+}
+
+fn build_cos_ieee8021_queue_table(
+    classifier_name: &str,
+    classifiers: &FastMap<String, CoSIEEE8021ClassifierConfig>,
+) -> [u8; 8] {
+    let mut table = [u8::MAX; 8];
+    if classifier_name.is_empty() {
+        return table;
+    }
+    if let Some(classifier) = classifiers.get(classifier_name) {
+        for (&pcp, &queue_id) in &classifier.queue_by_pcp {
+            let idx = usize::from(pcp.min(7));
+            table[idx] = queue_id;
+        }
+    }
+    table
+}
+
 pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingState {
     let mut state = ForwardingState::default();
     let mut name_to_ifindex = BTreeMap::new();
@@ -172,7 +206,9 @@ pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingSta
         };
         let ingress_key = (bind_ifindex, iface.vlan_id.max(0) as u16);
         if iface.parent_ifindex > 0 {
-            state.ingress_logical_ifindex.insert(ingress_key, iface.ifindex);
+            state
+                .ingress_logical_ifindex
+                .insert(ingress_key, iface.ifindex);
         } else {
             state
                 .ingress_logical_ifindex
@@ -323,6 +359,13 @@ pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingSta
         &snapshot.flow.lo0_filter_input_v6,
     );
     state.cos = build_cos_state(snapshot);
+    let has_cos_interfaces = !state.cos.interfaces.is_empty();
+    state.tx_selection_enabled_v4 = has_cos_interfaces
+        || state.filter_state.has_input_tx_selection_v4
+        || state.filter_state.has_output_tx_selection_v4;
+    state.tx_selection_enabled_v6 = has_cos_interfaces
+        || state.filter_state.has_input_tx_selection_v6
+        || state.filter_state.has_output_tx_selection_v6;
     // Build flow export config from snapshot
     state.flow_export_config = snapshot.flow_export.as_ref().and_then(|fe| {
         let addr = format!("{}:{}", fe.collector_address, fe.collector_port);
@@ -620,6 +663,14 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                 default_queue,
                 dscp_classifier: iface.cos_dscp_classifier.clone(),
                 ieee8021_classifier: iface.cos_ieee8021_classifier.clone(),
+                dscp_queue_by_dscp: build_cos_dscp_queue_table(
+                    &iface.cos_dscp_classifier,
+                    &dscp_classifiers,
+                ),
+                ieee8021_queue_by_pcp: build_cos_ieee8021_queue_table(
+                    &iface.cos_ieee8021_classifier,
+                    &ieee8021_classifiers,
+                ),
                 queue_by_forwarding_class,
                 queues,
             },
@@ -963,6 +1014,48 @@ mod tests {
 
         let state = build_forwarding_state(&snapshot);
         assert_eq!(state.ingress_logical_ifindex.get(&(10, 0)), Some(&11));
+    }
+    #[test]
+    fn build_forwarding_state_disables_tx_selection_when_no_cos_or_filters_exist() {
+        let state = build_forwarding_state(&ConfigSnapshot::default());
+        assert!(!state.tx_selection_enabled_v4);
+        assert!(!state.tx_selection_enabled_v6);
+    }
+
+    #[test]
+    fn build_forwarding_state_enables_tx_selection_when_cos_interfaces_exist() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                ifindex: 42,
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                }],
+                schedulers: vec![CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 10_000_000,
+                    ..Default::default()
+                }],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    }],
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let state = build_forwarding_state(&snapshot);
+        assert!(state.tx_selection_enabled_v4);
+        assert!(state.tx_selection_enabled_v6);
     }
 }
 

--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -9,20 +9,22 @@ pub(super) fn authoritative_forward_ports(
     if !matches!(meta.protocol, PROTO_TCP | PROTO_UDP) {
         return None;
     }
-    let flow_ports = flow.and_then(|flow| {
+    if let Some(flow_ports) = flow.and_then(|flow| {
         if flow.forward_key.src_port != 0 && flow.forward_key.dst_port != 0 {
             Some((flow.forward_key.src_port, flow.forward_key.dst_port))
         } else {
             None
         }
-    });
+    }) {
+        return Some(flow_ports);
+    }
     let meta_ports = if meta.flow_src_port != 0 && meta.flow_dst_port != 0 {
         Some((meta.flow_src_port, meta.flow_dst_port))
     } else {
         None
     };
-    let frame_ports = live_frame_ports_bytes(frame, meta.addr_family, meta.protocol);
-    flow_ports.or(frame_ports).or(meta_ports)
+    let frame_ports = live_frame_ports_from_meta_bytes(frame, meta);
+    frame_ports.or(meta_ports)
 }
 
 #[allow(dead_code)]
@@ -35,6 +37,24 @@ pub(super) fn live_frame_ports(
         return None;
     }
     let frame = area.slice(desc.addr as usize, desc.len as usize)?;
+    live_frame_ports_from_meta_bytes(frame, meta)
+}
+
+#[inline(always)]
+pub(super) fn live_frame_ports_from_meta_bytes(
+    frame: &[u8],
+    meta: impl Into<ForwardPacketMeta>,
+) -> Option<(u16, u16)> {
+    let meta = meta.into();
+    if !matches!(meta.protocol, PROTO_TCP | PROTO_UDP) {
+        return None;
+    }
+    let l4 = meta.l4_offset as usize;
+    if l4 != 0
+        && let Some(ports) = parse_flow_ports(frame, l4, meta.protocol)
+    {
+        return Some(ports);
+    }
     live_frame_ports_bytes(frame, meta.addr_family, meta.protocol)
 }
 
@@ -71,14 +91,15 @@ pub(super) fn parse_session_flow_from_bytes(
     frame: &[u8],
     meta: UserspaceDpMeta,
 ) -> Option<SessionFlow> {
+    let meta_flow = parse_session_flow_from_meta(meta);
     // Fast path: for TCP/UDP with complete metadata tuple, use meta directly
     // without parsing the frame. This avoids extra L3/L4 parsing for the
     // common established-flow case.
     if matches!(meta.protocol, PROTO_TCP | PROTO_UDP)
-        && let Some(meta_flow) = parse_session_flow_from_meta(meta)
-        && metadata_tuple_complete(meta, &meta_flow)
+        && let Some(meta_flow) = meta_flow.as_ref()
+        && metadata_tuple_complete(meta, meta_flow)
     {
-        return Some(meta_flow);
+        return Some(meta_flow.clone());
     }
 
     let frame_flow = if matches!(meta.addr_family as i32, libc::AF_INET) {
@@ -87,7 +108,7 @@ pub(super) fn parse_session_flow_from_bytes(
         parse_session_flow_from_frame(frame, meta)
     };
 
-    if let Some(meta_flow) = parse_session_flow_from_meta(meta)
+    if let Some(meta_flow) = meta_flow
         && metadata_tuple_complete(meta, &meta_flow)
     {
         if let Some(ref frame_flow) = frame_flow {
@@ -623,8 +644,22 @@ pub(super) fn parse_session_flow_from_frame(
     match meta.addr_family as i32 {
         libc::AF_INET => parse_ipv4_session_flow_from_frame(frame, meta),
         libc::AF_INET6 => {
-            let l3 = frame_l3_offset(frame)?;
-            let l4 = frame_l4_offset(frame, meta.addr_family)?;
+            let l3 = match meta.l3_offset {
+                14 | 18
+                    if frame
+                        .get(meta.l3_offset as usize)
+                        .is_some_and(|byte| (byte >> 4) == 6) =>
+                {
+                    meta.l3_offset as usize
+                }
+                _ => frame_l3_offset(frame)?,
+            };
+            let meta_rel = meta.l4_offset.wrapping_sub(meta.l3_offset) as usize;
+            let l4 = if meta_rel >= 40 && meta.l4_offset > meta.l3_offset {
+                l3.checked_add(meta_rel)?
+            } else {
+                frame_l4_offset(frame, meta.addr_family)?
+            };
             if frame.len() < l3 + 40 || frame.len() < l4 {
                 return None;
             }
@@ -689,19 +724,17 @@ pub(super) fn parse_ipv4_session_flow_from_frame(
     frame: &[u8],
     meta: UserspaceDpMeta,
 ) -> Option<SessionFlow> {
-    let mut l3 = 14usize;
-    if frame.len() < l3 {
-        return None;
-    }
-    let mut eth_proto = u16::from_be_bytes([*frame.get(12)?, *frame.get(13)?]);
-    if matches!(eth_proto, 0x8100 | 0x88a8) {
-        if frame.len() < l3 + 4 {
-            return None;
+    let l3 = match meta.l3_offset {
+        14 | 18
+            if frame
+                .get(meta.l3_offset as usize)
+                .is_some_and(|byte| (byte >> 4) == 4) =>
+        {
+            meta.l3_offset as usize
         }
-        eth_proto = u16::from_be_bytes([*frame.get(16)?, *frame.get(17)?]);
-        l3 += 4;
-    }
-    if eth_proto != 0x0800 || frame.len() < l3 + 20 {
+        _ => frame_l3_offset(frame)?,
+    };
+    if frame.len() < l3 + 20 {
         return None;
     }
     let ihl = usize::from(frame[l3] & 0x0f) * 4;
@@ -709,7 +742,15 @@ pub(super) fn parse_ipv4_session_flow_from_frame(
         return None;
     }
     let protocol = frame[l3 + 9];
-    let l4 = l3 + ihl;
+    let parsed_l4 = l3 + ihl;
+    let l4 = if meta.l4_offset > meta.l3_offset && meta.l4_offset as usize == parsed_l4 {
+        meta.l4_offset as usize
+    } else {
+        parsed_l4
+    };
+    if frame.len() < l4 {
+        return None;
+    }
     let src_ip = IpAddr::V4(Ipv4Addr::new(
         frame[l3 + 12],
         frame[l3 + 13],
@@ -839,10 +880,11 @@ pub(super) fn build_injected_packet(
 /// by 20). This always uses a copy path — in-place rewrite is not possible.
 pub(super) fn build_nat64_forwarded_frame(
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     nat64_reverse: Option<&Nat64ReverseInfo>,
 ) -> Option<Vec<u8>> {
+    let meta = meta.into();
     let dst_mac = decision.resolution.neighbor_mac?;
     let src_mac = decision.resolution.src_mac?;
     let vlan_id = decision.resolution.tx_vlan_id;
@@ -881,12 +923,13 @@ pub(super) fn build_nat64_forwarded_frame(
 
 pub(super) fn build_forwarded_frame_from_frame(
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     apply_nat_on_fabric: bool,
     expected_ports: Option<(u16, u16)>,
 ) -> Option<Vec<u8>> {
+    let meta = meta.into();
     let mut out = vec![0u8; frame.len().saturating_add(4)];
     let written = build_forwarded_frame_into_from_frame(
         &mut out,
@@ -906,12 +949,13 @@ pub(super) fn build_forwarded_frame_from_frame(
 
 pub(super) fn segment_forwarded_tcp_frames_from_frame(
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     apply_nat_on_fabric: bool,
     expected_ports: Option<(u16, u16)>,
 ) -> Option<Vec<Vec<u8>>> {
+    let meta = meta.into();
     if meta.protocol != PROTO_TCP {
         return None;
     }
@@ -1015,11 +1059,7 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
         *payload.get(tcp_offset + 6)?,
         *payload.get(tcp_offset + 7)?,
     ]);
-    let enforced_ports = expected_ports.or(live_frame_ports_bytes(
-        frame,
-        meta.addr_family,
-        meta.protocol,
-    ));
+    let enforced_ports = expected_ports.or(live_frame_ports_from_meta_bytes(frame, meta));
     let Some(tcp_header) = payload.get(tcp_offset..tcp_offset + tcp_header_len) else {
         return None;
     };
@@ -1218,12 +1258,13 @@ pub(super) fn segment_forwarded_tcp_frames_from_frame(
 pub(super) fn build_forwarded_frame_into_from_frame(
     out: &mut [u8],
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     apply_nat_on_fabric: bool,
     expected_ports: Option<(u16, u16)>,
 ) -> Option<usize> {
+    let meta = meta.into();
     let dst_mac = decision.resolution.neighbor_mac?;
     let enforced_ports = expected_ports;
     // Use meta L3 offset when it's a valid Ethernet header size (14 or 18),
@@ -1236,31 +1277,7 @@ pub(super) fn build_forwarded_frame_into_from_frame(
         return None;
     }
     let raw_payload = &frame[l3..];
-    // Trim Ethernet padding: use ip_total_len so we don't carry trailing
-    // pad bytes (small frames padded to 60/64 by hardware).
-    let payload = if raw_payload.len() >= 4 {
-        let ip_version = raw_payload[0] >> 4;
-        if ip_version == 4 {
-            let ip_total_len = u16::from_be_bytes([raw_payload[2], raw_payload[3]]) as usize;
-            if ip_total_len > 0 && ip_total_len < raw_payload.len() {
-                &raw_payload[..ip_total_len]
-            } else {
-                raw_payload
-            }
-        } else if ip_version == 6 && raw_payload.len() >= 40 {
-            let ipv6_payload_len = u16::from_be_bytes([raw_payload[4], raw_payload[5]]) as usize;
-            let ip6_total = 40 + ipv6_payload_len;
-            if ip6_total > 0 && ip6_total < raw_payload.len() {
-                &raw_payload[..ip6_total]
-            } else {
-                raw_payload
-            }
-        } else {
-            raw_payload
-        }
-    } else {
-        raw_payload
-    };
+    let payload = trim_l3_payload(raw_payload, meta);
     let (src_mac, vlan_id, apply_nat) =
         if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
             (
@@ -1513,7 +1530,7 @@ pub(super) fn build_forwarded_frame_into(
     out: &mut [u8],
     area: &MmapArea,
     desc: XdpDesc,
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     expected_ports: Option<(u16, u16)>,
@@ -1533,11 +1550,12 @@ pub(super) fn build_forwarded_frame_into(
 pub(super) fn rewrite_forwarded_frame_in_place(
     area: &MmapArea,
     desc: XdpDesc,
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     apply_nat_on_fabric: bool,
     expected_ports: Option<(u16, u16)>,
 ) -> Option<u32> {
+    let meta = meta.into();
     let dst_mac = decision.resolution.neighbor_mac?;
     let enforced_ports = expected_ports;
     let frame = unsafe { area.slice_mut_unchecked(desc.addr as usize, UMEM_FRAME_SIZE as usize)? };
@@ -1549,24 +1567,7 @@ pub(super) fn rewrite_forwarded_frame_in_place(
     if l3 >= current_len {
         return None;
     }
-    let mut payload_len = current_len.checked_sub(l3)?;
-    // Trim Ethernet padding: use ip_total_len when available so we don't
-    // carry trailing pad bytes (small frames padded to 60/64 by hardware).
-    if payload_len >= 4 {
-        let ip_version = frame[l3] >> 4;
-        if ip_version == 4 {
-            let ip_total_len = u16::from_be_bytes([frame[l3 + 2], frame[l3 + 3]]) as usize;
-            if ip_total_len > 0 && ip_total_len < payload_len {
-                payload_len = ip_total_len;
-            }
-        } else if ip_version == 6 && payload_len >= 40 {
-            let ipv6_payload_len = u16::from_be_bytes([frame[l3 + 4], frame[l3 + 5]]) as usize;
-            let ip6_total = 40 + ipv6_payload_len;
-            if ip6_total > 0 && ip6_total < payload_len {
-                payload_len = ip6_total;
-            }
-        }
-    }
+    let payload_len = trim_l3_payload(&frame[l3..current_len], meta).len();
     let (src_mac, vlan_id, apply_nat) =
         if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
             (
@@ -1718,6 +1719,51 @@ pub(super) fn rewrite_forwarded_frame_in_place(
         verify_built_frame_checksums(&packet[..frame_len]);
     }
     Some(frame_len as u32)
+}
+
+#[inline(always)]
+fn trim_l3_payload<'a>(raw_payload: &'a [u8], meta: impl Into<ForwardPacketMeta>) -> &'a [u8] {
+    let meta = meta.into();
+    let meta_len = meta.pkt_len as usize;
+    if meta_len >= 20 && meta_len <= raw_payload.len() {
+        return &raw_payload[..meta_len];
+    }
+    let meta_l3_len = match meta.l3_offset {
+        14 | 18 if meta_len > meta.l3_offset as usize => Some(meta_len - meta.l3_offset as usize),
+        _ => None,
+    };
+    if let Some(meta_l3_len) = meta_l3_len
+        && meta_l3_len >= 20
+        && meta_l3_len <= raw_payload.len()
+    {
+        return &raw_payload[..meta_l3_len];
+    }
+    // Fall back to parsing the IP header only when metadata does not carry a
+    // usable payload length. This preserves the padding-trim safety net for
+    // synthetic or incomplete metadata while keeping the hot path metadata-led.
+    if raw_payload.len() < 4 {
+        return raw_payload;
+    }
+    match raw_payload[0] >> 4 {
+        4 => {
+            let ip_total_len = u16::from_be_bytes([raw_payload[2], raw_payload[3]]) as usize;
+            if ip_total_len > 0 && ip_total_len < raw_payload.len() {
+                &raw_payload[..ip_total_len]
+            } else {
+                raw_payload
+            }
+        }
+        6 if raw_payload.len() >= 40 => {
+            let ipv6_payload_len = u16::from_be_bytes([raw_payload[4], raw_payload[5]]) as usize;
+            let ip6_total = 40 + ipv6_payload_len;
+            if ip6_total > 0 && ip6_total < raw_payload.len() {
+                &raw_payload[..ip6_total]
+            } else {
+                raw_payload
+            }
+        }
+        _ => raw_payload,
+    }
 }
 
 /// Straight-line frame rewrite using a precomputed `RewriteDescriptor`.
@@ -2083,19 +2129,17 @@ pub(super) fn apply_nat_ipv6(packet: &mut [u8], protocol: u8, nat: NatDecision) 
     let skip_l4_csum = nat.nptv6;
     if new_src.is_some() && new_dst.is_none() {
         let new_src = new_src?;
-        let old_src_words = ipv6_words_from_slice(packet.get(8..24)?)?;
+        let old_src: [u8; 16] = packet.get(8..24)?.try_into().ok()?;
         packet.get_mut(8..24)?.copy_from_slice(&new_src);
         if !skip_l4_csum {
-            let new_src_words = ipv6_words_from_octets(new_src);
-            adjust_l4_checksum_ipv6_words(packet, protocol, &old_src_words, &new_src_words)?;
+            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_src, &new_src)?;
         }
     } else if new_dst.is_some() && new_src.is_none() {
         let new_dst = new_dst?;
-        let old_dst_words = ipv6_words_from_slice(packet.get(24..40)?)?;
+        let old_dst: [u8; 16] = packet.get(24..40)?.try_into().ok()?;
         packet.get_mut(24..40)?.copy_from_slice(&new_dst);
         if !skip_l4_csum {
-            let new_dst_words = ipv6_words_from_octets(new_dst);
-            adjust_l4_checksum_ipv6_words(packet, protocol, &old_dst_words, &new_dst_words)?;
+            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_dst, &new_dst)?;
         }
     } else if new_src.is_some() || new_dst.is_some() {
         let old_src_words = ipv6_words_from_slice(packet.get(8..24)?)?;
@@ -2283,9 +2327,10 @@ pub(super) fn enforce_expected_ports_at(
 
 pub(super) fn restore_l4_tuple_from_meta(
     packet: &mut [u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     rel_l4: usize,
 ) -> Option<bool> {
+    let meta = meta.into();
     match meta.protocol {
         PROTO_TCP | PROTO_UDP => Some(false),
         PROTO_ICMP | PROTO_ICMPV6 => {
@@ -2486,6 +2531,24 @@ pub(super) fn checksum16_adjust(checksum: u16, old_words: &[u16], new_words: &[u
     }
     for word in new_words {
         sum += u32::from(*word);
+    }
+    checksum16_finish(sum)
+}
+
+#[inline(always)]
+fn checksum16_adjust_ipv6_addr_bytes(
+    checksum: u16,
+    old_addr: &[u8; 16],
+    new_addr: &[u8; 16],
+) -> u16 {
+    let mut sum = (!checksum as u32) & 0xffff;
+    let mut idx = 0usize;
+    while idx < 16 {
+        let old_word = u16::from_be_bytes([old_addr[idx], old_addr[idx + 1]]);
+        let new_word = u16::from_be_bytes([new_addr[idx], new_addr[idx + 1]]);
+        sum += (!u32::from(old_word)) & 0xffff;
+        sum += u32::from(new_word);
+        idx += 2;
     }
     checksum16_finish(sum)
 }
@@ -2728,6 +2791,33 @@ pub(super) fn adjust_l4_checksum_ipv6_words(
         *packet.get(checksum_offset + 1)?,
     ]);
     let mut updated = checksum16_adjust(current, old_words, new_words);
+    if matches!(protocol, PROTO_UDP | PROTO_ICMPV6) && updated == 0 {
+        updated = 0xffff;
+    }
+    packet
+        .get_mut(checksum_offset..checksum_offset + 2)?
+        .copy_from_slice(&updated.to_be_bytes());
+    Some(())
+}
+
+#[inline(always)]
+fn adjust_l4_checksum_ipv6_addr_bytes(
+    packet: &mut [u8],
+    protocol: u8,
+    old_addr: &[u8; 16],
+    new_addr: &[u8; 16],
+) -> Option<()> {
+    let checksum_offset = match protocol {
+        PROTO_TCP => 56usize,
+        PROTO_UDP => 46usize,
+        PROTO_ICMPV6 => 42usize,
+        _ => return Some(()),
+    };
+    let current = u16::from_be_bytes([
+        *packet.get(checksum_offset)?,
+        *packet.get(checksum_offset + 1)?,
+    ]);
+    let mut updated = checksum16_adjust_ipv6_addr_bytes(current, old_addr, new_addr);
     if matches!(protocol, PROTO_UDP | PROTO_ICMPV6) && updated == 0 {
         updated = 0xffff;
     }
@@ -3064,6 +3154,34 @@ mod tests {
         frame
     }
 
+    fn build_icmp_echo_frame_v4_vlan(
+        src: Ipv4Addr,
+        dst: Ipv4Addr,
+        ttl: u8,
+        vlan_id: u16,
+    ) -> Vec<u8> {
+        let mut frame = Vec::new();
+        write_eth_header(
+            &mut frame,
+            [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+            [0x00, 0x25, 0x90, 0x12, 0x34, 0x56],
+            vlan_id,
+            0x0800,
+        );
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x01, 0x00, 0x00, ttl, PROTO_ICMP, 0x00, 0x00,
+        ]);
+        frame.extend_from_slice(&src.octets());
+        frame.extend_from_slice(&dst.octets());
+        let ip_csum = checksum16(&frame[18..38]);
+        frame[28..30].copy_from_slice(&ip_csum.to_be_bytes());
+        let icmp_start = frame.len();
+        frame.extend_from_slice(&[8, 0, 0x00, 0x00, 0x12, 0x34, 0x00, 0x01]);
+        let icmp_csum = checksum16(&frame[icmp_start..]);
+        frame[icmp_start + 2..icmp_start + 4].copy_from_slice(&icmp_csum.to_be_bytes());
+        frame
+    }
+
     fn build_ipv6_gre_frame(
         inner_packet: &[u8],
         src: Ipv6Addr,
@@ -3101,6 +3219,47 @@ mod tests {
         }
         frame.extend_from_slice(inner_packet);
         frame
+    }
+
+    #[test]
+    fn trim_l3_payload_uses_frame_length_metadata_relative_to_l3_offset_without_parsing_header() {
+        let mut frame =
+            build_icmp_echo_frame_v4(Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2), 64);
+        let wire_len = frame.len();
+        frame[14] = 0;
+        frame.extend_from_slice(&[0u8; 8]);
+        let raw_payload = &frame[14..];
+        let meta = UserspaceDpMeta {
+            l3_offset: 14,
+            pkt_len: wire_len as u16,
+            addr_family: libc::AF_INET as u8,
+            ..UserspaceDpMeta::default()
+        };
+
+        assert_eq!(trim_l3_payload(raw_payload, meta).len(), wire_len - 14);
+    }
+
+    #[test]
+    fn trim_l3_payload_uses_vlan_frame_length_metadata_relative_to_l3_offset_without_parsing_header()
+     {
+        let mut frame = build_icmp_echo_frame_v4_vlan(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+            64,
+            80,
+        );
+        let wire_len = frame.len();
+        frame[18] = 0;
+        frame.extend_from_slice(&[0u8; 8]);
+        let raw_payload = &frame[18..];
+        let meta = UserspaceDpMeta {
+            l3_offset: 18,
+            pkt_len: wire_len as u16,
+            addr_family: libc::AF_INET as u8,
+            ..UserspaceDpMeta::default()
+        };
+
+        assert_eq!(trim_l3_payload(raw_payload, meta).len(), wire_len - 18);
     }
 
     fn native_gre_outer_meta() -> UserspaceDpMeta {
@@ -6583,6 +6742,7 @@ mod tests {
             egress_ifindex: decision.resolution.egress_ifindex,
             tx_ifindex: decision.resolution.tx_ifindex,
             target_binding_index: None,
+            tx_selection: CachedTxSelectionDescriptor::default(),
             nat64: false,
             nptv6: false,
             apply_nat_on_fabric: false,
@@ -7127,6 +7287,7 @@ mod tests {
             egress_ifindex: 0,
             tx_ifindex: 0,
             target_binding_index: None,
+            tx_selection: CachedTxSelectionDescriptor::default(),
             nat64: true,
             nptv6: false,
             apply_nat_on_fabric: false,

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -1,5 +1,44 @@
 use super::*;
 
+fn cos_owner_live_for_request(
+    forwarding: &ForwardingState,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    egress_ifindex: i32,
+    requested_queue_id: Option<u8>,
+) -> Option<Arc<BindingLiveState>> {
+    let effective_queue_id = requested_queue_id.or_else(|| {
+        forwarding
+            .cos
+            .interfaces
+            .get(&egress_ifindex)
+            .map(|iface| iface.default_queue)
+    });
+    effective_queue_id
+        .and_then(|queue_id| cos_owner_live_by_queue.get(&(egress_ifindex, queue_id)).cloned())
+}
+
+fn enqueue_local_request_to_target_or_owner(
+    target_binding: &mut BindingWorker,
+    forwarding: &ForwardingState,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    req: TxRequest,
+) -> Result<(), TxRequest> {
+    let owner_live = cos_owner_live_for_request(
+        forwarding,
+        cos_owner_live_by_queue,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    );
+    if let Some(owner_live) = owner_live {
+        if !Arc::ptr_eq(&owner_live, &target_binding.live) {
+            return owner_live.enqueue_tx_owned(req);
+        }
+    }
+    target_binding.pending_tx_local.push_back(req);
+    bound_pending_tx_local(target_binding);
+    Ok(())
+}
+
 #[inline]
 fn recycle_ingress_frame(
     ingress_binding: &mut BindingWorker,
@@ -34,6 +73,7 @@ pub(super) fn enqueue_pending_forwards(
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) {
     if pending_forwards.is_empty() {
         return;
@@ -91,7 +131,7 @@ pub(super) fn enqueue_pending_forwards(
                 continue;
             };
             let frame_len = prebuilt.len();
-            target_binding.pending_tx_local.push_back(TxRequest {
+            let req = TxRequest {
                 bytes: prebuilt,
                 expected_ports: None,
                 expected_addr_family: request.meta.addr_family,
@@ -100,8 +140,23 @@ pub(super) fn enqueue_pending_forwards(
                 egress_ifindex: request.decision.resolution.egress_ifindex,
                 cos_queue_id: request.cos_queue_id,
                 dscp_rewrite: request.dscp_rewrite,
-            });
-            bound_pending_tx_local(target_binding);
+            };
+            if enqueue_local_request_to_target_or_owner(
+                target_binding,
+                forwarding,
+                cos_owner_live_by_queue,
+                req,
+            )
+            .is_err()
+            {
+                recycle_ingress_frame(
+                    ingress_binding,
+                    source_offset,
+                    now_ns,
+                    &mut fill_drain_pending,
+                );
+                continue;
+            }
             dbg.enqueue_ok += 1;
             dbg.enqueue_copy += 1;
             target_binding.pending_copy_tx_packets += 1;
@@ -243,6 +298,7 @@ pub(super) fn enqueue_pending_forwards(
                         worker_id,
                         worker_commands_by_id,
                         cos_owner_worker_by_queue,
+                        cos_owner_live_by_queue,
                     )
                 {
                     dbg.enqueue_ok += segments as u64;
@@ -262,6 +318,7 @@ pub(super) fn enqueue_pending_forwards(
                             worker_id,
                             worker_commands_by_id,
                             cos_owner_worker_by_queue,
+                            cos_owner_live_by_queue,
                         );
                     }
                 } else if let Some(segmented) = segment_forwarded_tcp_frames_from_frame(
@@ -325,6 +382,7 @@ pub(super) fn enqueue_pending_forwards(
                             worker_id,
                             worker_commands_by_id,
                             cos_owner_worker_by_queue,
+                            cos_owner_live_by_queue,
                         );
                     }
                 }
@@ -360,6 +418,14 @@ pub(super) fn enqueue_pending_forwards(
                 // Always use copy path with NAT64-specific frame builder.
                 let is_nat64 = request.decision.nat.nat64;
                 let uses_native_tunnel = request.decision.resolution.tunnel_endpoint_id != 0;
+                let owner_matches_target = cos_owner_live_for_request(
+                    forwarding,
+                    cos_owner_live_by_queue,
+                    request.decision.resolution.egress_ifindex,
+                    request.cos_queue_id,
+                )
+                .as_ref()
+                .is_none_or(|live| Arc::ptr_eq(live, &target_binding.live));
 
                 /*
                  * In-place TX optimization: rewrite the ingress frame directly in UMEM
@@ -371,6 +437,7 @@ pub(super) fn enqueue_pending_forwards(
                 let can_rewrite_in_place = target_binding.umem.allocation_ptr() == ingress_umem_ptr
                     && !is_nat64
                     && !uses_native_tunnel
+                    && owner_matches_target
                     && matches!(request.frame, PendingForwardFrame::Live);
                 if can_rewrite_in_place {
                     match rewrite_forwarded_frame_in_place(
@@ -461,7 +528,7 @@ pub(super) fn enqueue_pending_forwards(
                                     );
                                     continue;
                                 }
-                                target_binding.pending_tx_local.push_back(TxRequest {
+                                let req = TxRequest {
                                     bytes: frame,
                                     expected_ports,
                                     expected_addr_family: request.meta.addr_family,
@@ -470,8 +537,19 @@ pub(super) fn enqueue_pending_forwards(
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
-                                });
-                                bound_pending_tx_local(target_binding);
+                                };
+                                if enqueue_local_request_to_target_or_owner(
+                                    target_binding,
+                                    forwarding,
+                                    cos_owner_live_by_queue,
+                                    req,
+                                )
+                                .is_err()
+                                {
+                                    build_failed = true;
+                                    fallback_to_slow_path = true;
+                                    continue;
+                                }
                                 dbg.enqueue_ok += 1;
                                 dbg.enqueue_copy += 1;
                                 target_binding.pending_copy_tx_packets += 1;
@@ -511,6 +589,7 @@ pub(super) fn enqueue_pending_forwards(
                             worker_id,
                             worker_commands_by_id,
                             cos_owner_worker_by_queue,
+                            cos_owner_live_by_queue,
                         );
                         direct_tx_offset = target_binding.free_tx_frames.pop_front();
                     }
@@ -520,6 +599,16 @@ pub(super) fn enqueue_pending_forwards(
                         if let Some(off) = direct_tx_offset {
                             target_binding.free_tx_frames.push_front(off);
                         }
+                        direct_tx_fallback_reason =
+                            Some(DirectTxFallbackReason::DisallowedByRewriteMode);
+                        false
+                    } else if !owner_matches_target {
+                        if let Some(off) = direct_tx_offset {
+                            target_binding.free_tx_frames.push_front(off);
+                        }
+                        // A prepared/direct frame on a non-owner binding would be
+                        // cloned back into a local Vec during CoS owner redirection.
+                        // Skip that waste and fall back to the single-copy local path.
                         direct_tx_fallback_reason =
                             Some(DirectTxFallbackReason::DisallowedByRewriteMode);
                         false
@@ -699,7 +788,7 @@ pub(super) fn enqueue_pending_forwards(
                                     );
                                     continue;
                                 }
-                                target_binding.pending_tx_local.push_back(TxRequest {
+                                let req = TxRequest {
                                     bytes: frame,
                                     expected_ports,
                                     expected_addr_family: request.meta.addr_family,
@@ -708,8 +797,19 @@ pub(super) fn enqueue_pending_forwards(
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
-                                });
-                                bound_pending_tx_local(target_binding);
+                                };
+                                if enqueue_local_request_to_target_or_owner(
+                                    target_binding,
+                                    forwarding,
+                                    cos_owner_live_by_queue,
+                                    req,
+                                )
+                                .is_err()
+                                {
+                                    build_failed = true;
+                                    fallback_to_slow_path = true;
+                                    continue;
+                                }
                                 dbg.enqueue_ok += 1;
                                 dbg.enqueue_copy += 1;
                                 target_binding.pending_copy_tx_packets += 1;
@@ -737,6 +837,7 @@ pub(super) fn enqueue_pending_forwards(
                     worker_id,
                     worker_commands_by_id,
                     cos_owner_worker_by_queue,
+                    cos_owner_live_by_queue,
                 );
             }
         }
@@ -1133,6 +1234,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Option<(u32, u64, u32)> {
     let meta = meta.into();
     if meta.protocol != PROTO_TCP || decision.resolution.tunnel_endpoint_id != 0 {
@@ -1209,6 +1311,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
             worker_id,
             worker_commands_by_id,
             cos_owner_worker_by_queue,
+            cos_owner_live_by_queue,
         );
     }
     if target_binding.free_tx_frames.len() < segment_count {
@@ -1449,7 +1552,6 @@ mod tests {
         );
         forwarding
     }
-
     fn test_decision() -> SessionDecision {
         SessionDecision {
             resolution: ForwardingResolution {

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -70,17 +70,10 @@ fn enqueue_local_request_to_target_or_owner(
 }
 
 #[inline]
-fn recycle_ingress_frame(
-    ingress_binding: &mut BindingWorker,
-    source_offset: u64,
-    now_ns: u64,
-    fill_drain_pending: &mut bool,
-) {
+fn recycle_ingress_frame(ingress_binding: &mut BindingWorker, source_offset: u64, now_ns: u64) {
     ingress_binding.pending_fill_frames.push_back(source_offset);
-    *fill_drain_pending = true;
     if ingress_binding.pending_fill_frames.len() >= FILL_BATCH_SIZE {
         let _ = drain_pending_fill(ingress_binding, now_ns);
-        *fill_drain_pending = false;
     }
 }
 
@@ -109,7 +102,6 @@ pub(super) fn enqueue_pending_forwards(
         return;
     }
     let ingress_area = ingress_binding.umem.area() as *const MmapArea;
-    let mut fill_drain_pending = false;
     let tx_selection_enabled_v4 = forwarding.tx_selection_enabled_v4;
     let tx_selection_enabled_v6 = forwarding.tx_selection_enabled_v6;
     post_recycles.clear();
@@ -141,7 +133,7 @@ pub(super) fn enqueue_pending_forwards(
 
         // Fast path: prebuilt frame (e.g. ICMP error NAT reversal).
         // The frame is already fully rewritten — just enqueue for TX.
-        if let PendingForwardFrame::Prebuilt(prebuilt) = core::mem::take(&mut request.frame) {
+        if let PendingForwardFrame::Prebuilt(prebuilt) = &mut request.frame {
             let Some(target_binding) = resolve_pending_forward_target_binding(
                 left,
                 ingress_index,
@@ -152,17 +144,12 @@ pub(super) fn enqueue_pending_forwards(
                 target_binding_index,
                 request.target_ifindex,
             ) else {
-                recycle_ingress_frame(
-                    ingress_binding,
-                    source_offset,
-                    now_ns,
-                    &mut fill_drain_pending,
-                );
+                recycle_ingress_frame(ingress_binding, source_offset, now_ns);
                 continue;
             };
             let frame_len = prebuilt.len();
             let req = TxRequest {
-                bytes: prebuilt,
+                bytes: core::mem::take(prebuilt),
                 expected_ports: None,
                 expected_addr_family: request.meta.addr_family,
                 expected_protocol: request.meta.protocol,
@@ -179,12 +166,7 @@ pub(super) fn enqueue_pending_forwards(
             )
             .is_err()
             {
-                recycle_ingress_frame(
-                    ingress_binding,
-                    source_offset,
-                    now_ns,
-                    &mut fill_drain_pending,
-                );
+                recycle_ingress_frame(ingress_binding, source_offset, now_ns);
                 continue;
             }
             dbg.enqueue_ok += 1;
@@ -194,12 +176,7 @@ pub(super) fn enqueue_pending_forwards(
             if (frame_len as u32) > dbg.tx_max_frame {
                 dbg.tx_max_frame = frame_len as u32;
             }
-            recycle_ingress_frame(
-                ingress_binding,
-                source_offset,
-                now_ns,
-                &mut fill_drain_pending,
-            );
+            recycle_ingress_frame(ingress_binding, source_offset, now_ns);
             continue;
         }
 
@@ -214,12 +191,7 @@ pub(super) fn enqueue_pending_forwards(
                 {
                     frame
                 } else {
-                    recycle_ingress_frame(
-                        ingress_binding,
-                        source_offset,
-                        now_ns,
-                        &mut fill_drain_pending,
-                    );
+                    recycle_ingress_frame(ingress_binding, source_offset, now_ns);
                     continue;
                 }
             }
@@ -266,12 +238,7 @@ pub(super) fn enqueue_pending_forwards(
                         recent_exceptions,
                     );
                 }
-                recycle_ingress_frame(
-                    ingress_binding,
-                    source_offset,
-                    now_ns,
-                    &mut fill_drain_pending,
-                );
+                recycle_ingress_frame(ingress_binding, source_offset, now_ns);
                 continue;
             }
             dbg.no_egress_binding += 1;
@@ -291,12 +258,7 @@ pub(super) fn enqueue_pending_forwards(
                 None,
                 None,
             );
-            recycle_ingress_frame(
-                ingress_binding,
-                source_offset,
-                now_ns,
-                &mut fill_drain_pending,
-            );
+            recycle_ingress_frame(ingress_binding, source_offset, now_ns);
             continue;
         };
         let mut build_failed = false;
@@ -902,26 +864,20 @@ pub(super) fn enqueue_pending_forwards(
                 fallback_to_slow_path,
             );
             if !retained_source_frame {
-                recycle_ingress_frame(
-                    ingress_binding,
-                    source_offset,
-                    now_ns,
-                    &mut fill_drain_pending,
-                );
+                recycle_ingress_frame(ingress_binding, source_offset, now_ns);
             }
             continue;
         }
         if !retained_source_frame {
-            recycle_ingress_frame(
-                ingress_binding,
-                source_offset,
-                now_ns,
-                &mut fill_drain_pending,
-            );
+            recycle_ingress_frame(ingress_binding, source_offset, now_ns);
         }
     }
-    if fill_drain_pending && !ingress_binding.pending_fill_frames.is_empty() {
+    while !ingress_binding.pending_fill_frames.is_empty() {
+        let pending_before = ingress_binding.pending_fill_frames.len();
         let _ = drain_pending_fill(ingress_binding, now_ns);
+        if ingress_binding.pending_fill_frames.len() >= pending_before {
+            break;
+        }
     }
     update_binding_debug_state(ingress_binding);
     pending_forwards.clear();
@@ -1553,9 +1509,6 @@ fn forwarded_tcp_may_need_segmentation(
         .map(|egress| egress.mtu)
         .unwrap_or_default()
         .max(1280);
-    if mtu == 0 {
-        return false;
-    }
     let l3 = match meta.l3_offset {
         14 | 18 => meta.l3_offset as usize,
         _ => match frame_l3_offset(frame) {

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -13,8 +13,11 @@ fn cos_owner_live_for_request(
             .get(&egress_ifindex)
             .map(|iface| iface.default_queue)
     });
-    effective_queue_id
-        .and_then(|queue_id| cos_owner_live_by_queue.get(&(egress_ifindex, queue_id)).cloned())
+    effective_queue_id.and_then(|queue_id| {
+        cos_owner_live_by_queue
+            .get(&(egress_ifindex, queue_id))
+            .cloned()
+    })
 }
 
 fn request_uses_shared_exact_queue_lease(
@@ -30,9 +33,8 @@ fn request_uses_shared_exact_queue_lease(
             .get(&egress_ifindex)
             .map(|iface| iface.default_queue)
     });
-    effective_queue_id.is_some_and(|queue_id| {
-        cos_shared_queue_leases.contains_key(&(egress_ifindex, queue_id))
-    })
+    effective_queue_id
+        .is_some_and(|queue_id| cos_shared_queue_leases.contains_key(&(egress_ifindex, queue_id)))
 }
 
 fn enqueue_local_request_to_target_or_owner(
@@ -1642,7 +1644,10 @@ mod tests {
     fn shared_exact_queue_lease_uses_requested_queue_id() {
         let forwarding = ForwardingState::default();
         let mut shared_queue_leases = BTreeMap::new();
-        shared_queue_leases.insert((80, 5), Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)));
+        shared_queue_leases.insert(
+            (80, 5),
+            Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)),
+        );
 
         assert!(request_uses_shared_exact_queue_lease(
             &shared_queue_leases,
@@ -1676,7 +1681,10 @@ mod tests {
             },
         );
         let mut shared_queue_leases = BTreeMap::new();
-        shared_queue_leases.insert((80, 5), Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)));
+        shared_queue_leases.insert(
+            (80, 5),
+            Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)),
+        );
 
         assert!(request_uses_shared_exact_queue_lease(
             &shared_queue_leases,

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+#[inline]
+fn recycle_ingress_frame(
+    ingress_binding: &mut BindingWorker,
+    source_offset: u64,
+    now_ns: u64,
+    fill_drain_pending: &mut bool,
+) {
+    ingress_binding.pending_fill_frames.push_back(source_offset);
+    *fill_drain_pending = true;
+    if ingress_binding.pending_fill_frames.len() >= FILL_BATCH_SIZE {
+        let _ = drain_pending_fill(ingress_binding, now_ns);
+        *fill_drain_pending = false;
+    }
+}
+
 pub(super) fn enqueue_pending_forwards(
     left: &mut [BindingWorker],
     ingress_index: usize,
@@ -20,20 +35,43 @@ pub(super) fn enqueue_pending_forwards(
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
 ) {
+    if pending_forwards.is_empty() {
+        return;
+    }
     let ingress_area = ingress_binding.umem.area() as *const MmapArea;
+    let mut fill_drain_pending = false;
+    let tx_selection_enabled_v4 = forwarding.tx_selection_enabled_v4;
+    let tx_selection_enabled_v6 = forwarding.tx_selection_enabled_v6;
     post_recycles.clear();
-    for mut request in pending_forwards.drain(..) {
-        let source_offset = request.source_offset;
+    // Walk the scratch vector in place. Moving large PendingForwardRequest
+    // values through the iterator path was still forcing per-request memcpy
+    // traffic before any forwarding work started.
+    for request in pending_forwards.iter_mut() {
+        let source_offset = request.desc.addr;
         let ingress_slot = ingress_binding.slot;
-        if request.cos_queue_id.is_none() && request.dscp_rewrite.is_none() {
+        let tx_selection_enabled = if request.meta.addr_family as i32 == libc::AF_INET6 {
+            tx_selection_enabled_v6
+        } else {
+            tx_selection_enabled_v4
+        };
+        if tx_selection_enabled && request.cos_queue_id.is_none() && request.dscp_rewrite.is_none()
+        {
             let cos = resolve_pending_forward_cos_tx_selection(forwarding, &request);
             request.cos_queue_id = cos.queue_id;
             request.dscp_rewrite = cos.dscp_rewrite;
         }
+        let target_binding_index = request.target_binding_index.or_else(|| {
+            binding_lookup.target_index(
+                ingress_index,
+                ingress_binding.ifindex,
+                request.ingress_queue_id,
+                request.target_ifindex,
+            )
+        });
 
         // Fast path: prebuilt frame (e.g. ICMP error NAT reversal).
         // The frame is already fully rewritten — just enqueue for TX.
-        if let Some(prebuilt) = request.prebuilt_frame {
+        if let PendingForwardFrame::Prebuilt(prebuilt) = core::mem::take(&mut request.frame) {
             let Some(target_binding) = resolve_pending_forward_target_binding(
                 left,
                 ingress_index,
@@ -41,10 +79,15 @@ pub(super) fn enqueue_pending_forwards(
                 request.ingress_queue_id,
                 right,
                 binding_lookup,
-                request.target_binding_index,
+                target_binding_index,
                 request.target_ifindex,
             ) else {
-                ingress_binding.pending_fill_frames.push_back(source_offset);
+                recycle_ingress_frame(
+                    ingress_binding,
+                    source_offset,
+                    now_ns,
+                    &mut fill_drain_pending,
+                );
                 continue;
             };
             let frame_len = prebuilt.len();
@@ -66,23 +109,36 @@ pub(super) fn enqueue_pending_forwards(
             if (frame_len as u32) > dbg.tx_max_frame {
                 dbg.tx_max_frame = frame_len as u32;
             }
-            ingress_binding.pending_fill_frames.push_back(source_offset);
+            recycle_ingress_frame(
+                ingress_binding,
+                source_offset,
+                now_ns,
+                &mut fill_drain_pending,
+            );
             continue;
         }
 
         // Read source frame directly from ingress UMEM — no heap copy needed.
         // The frame is safe to read: RX ring released but frame not yet returned
         // to fill ring (that happens after this function completes).
-        let owned_source_frame = request.source_frame.as_deref();
-        let source_frame = if let Some(frame) = owned_source_frame {
-            frame
-        } else if let Some(frame) = (unsafe { &*ingress_area })
-            .slice(request.source_offset as usize, request.desc.len as usize)
-        {
-            frame
-        } else {
-            ingress_binding.pending_fill_frames.push_back(source_offset);
-            continue;
+        let source_frame = match &request.frame {
+            PendingForwardFrame::Owned(frame) => frame.as_slice(),
+            PendingForwardFrame::Live => {
+                if let Some(frame) = (unsafe { &*ingress_area })
+                    .slice(request.desc.addr as usize, request.desc.len as usize)
+                {
+                    frame
+                } else {
+                    recycle_ingress_frame(
+                        ingress_binding,
+                        source_offset,
+                        now_ns,
+                        &mut fill_drain_pending,
+                    );
+                    continue;
+                }
+            }
+            PendingForwardFrame::Prebuilt(_) => unreachable!(),
         };
         let expected_ports = request.expected_ports;
         let ingress_umem_ptr = ingress_binding.umem.allocation_ptr();
@@ -93,14 +149,14 @@ pub(super) fn enqueue_pending_forwards(
             request.ingress_queue_id,
             right,
             binding_lookup,
-            request.target_binding_index,
+            target_binding_index,
             request.target_ifindex,
         ) else {
             // No XSK binding for the target interface.  Normally fabric
             // parents have bindings; this is a safety-net fallback in case
             // the binding is not yet ready or bind() failed.
             if request.decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
-                if request.source_frame.is_some() {
+                if matches!(request.frame, PendingForwardFrame::Owned(_)) {
                     maybe_reinject_slow_path_from_frame(
                         ingress_ident,
                         ingress_live,
@@ -125,7 +181,12 @@ pub(super) fn enqueue_pending_forwards(
                         recent_exceptions,
                     );
                 }
-                ingress_binding.pending_fill_frames.push_back(source_offset);
+                recycle_ingress_frame(
+                    ingress_binding,
+                    source_offset,
+                    now_ns,
+                    &mut fill_drain_pending,
+                );
                 continue;
             }
             dbg.no_egress_binding += 1;
@@ -145,117 +206,127 @@ pub(super) fn enqueue_pending_forwards(
                 None,
                 None,
             );
-            ingress_binding.pending_fill_frames.push_back(source_offset);
+            recycle_ingress_frame(
+                ingress_binding,
+                source_offset,
+                now_ns,
+                &mut fill_drain_pending,
+            );
             continue;
         };
-        post_recycles.clear();
         let mut build_failed = false;
         let mut fallback_to_slow_path = false;
         let mut copied_source_frame = false;
         let mut retained_source_frame = false;
+        let mut flow_key = request.flow_key.take();
         {
-            if let Some((segments, bytes, max_frame)) = segment_forwarded_tcp_frames_into_prepared(
-                target_binding,
+            if forwarded_tcp_may_need_segmentation(
                 source_frame,
                 request.meta,
                 &request.decision,
                 forwarding,
-                request.apply_nat_on_fabric,
-                expected_ports,
-                request.flow_key.clone(),
-                request.cos_queue_id,
-                request.dscp_rewrite,
-                now_ns,
-                post_recycles,
-                worker_id,
-                worker_commands_by_id,
-                cos_owner_worker_by_queue,
             ) {
-                dbg.enqueue_ok += segments as u64;
-                dbg.enqueue_direct += segments as u64;
-                target_binding.pending_direct_tx_packets += segments as u64;
-                dbg.tx_bytes_total += bytes;
-                if max_frame > dbg.tx_max_frame {
-                    dbg.tx_max_frame = max_frame;
-                }
-                copied_source_frame = true;
-                if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE {
-                    let _ = drain_pending_tx_local_owner(
+                if let Some((segments, bytes, max_frame)) =
+                    segment_forwarded_tcp_frames_into_prepared(
                         target_binding,
+                        source_frame,
+                        request.meta,
+                        &request.decision,
+                        forwarding,
+                        request.apply_nat_on_fabric,
+                        expected_ports,
+                        flow_key.clone(),
+                        request.cos_queue_id,
+                        request.dscp_rewrite,
                         now_ns,
                         post_recycles,
-                        forwarding,
                         worker_id,
                         worker_commands_by_id,
                         cos_owner_worker_by_queue,
-                    );
-                }
-            } else if let Some(segmented) = segment_forwarded_tcp_frames_from_frame(
-                source_frame,
-                request.meta,
-                &request.decision,
-                forwarding,
-                request.apply_nat_on_fabric,
-                expected_ports,
-            ) {
-                for frame in segmented {
-                    if cfg!(feature = "debug-log") {
-                        if let Some(reason) = forward_tuple_mismatch_reason(
-                            live_frame_ports_bytes(
-                                source_frame,
-                                request.meta.addr_family,
-                                request.meta.protocol,
-                            ),
+                    )
+                {
+                    dbg.enqueue_ok += segments as u64;
+                    dbg.enqueue_direct += segments as u64;
+                    target_binding.pending_direct_tx_packets += segments as u64;
+                    dbg.tx_bytes_total += bytes;
+                    if max_frame > dbg.tx_max_frame {
+                        dbg.tx_max_frame = max_frame;
+                    }
+                    copied_source_frame = true;
+                    if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE {
+                        let _ = drain_pending_tx_local_owner(
+                            target_binding,
+                            now_ns,
+                            post_recycles,
+                            forwarding,
+                            worker_id,
+                            worker_commands_by_id,
+                            cos_owner_worker_by_queue,
+                        );
+                    }
+                } else if let Some(segmented) = segment_forwarded_tcp_frames_from_frame(
+                    source_frame,
+                    request.meta,
+                    &request.decision,
+                    forwarding,
+                    request.apply_nat_on_fabric,
+                    expected_ports,
+                ) {
+                    for frame in segmented {
+                        if cfg!(feature = "debug-log") {
+                            if let Some(reason) = forward_tuple_mismatch_reason(
+                                live_frame_ports_from_meta_bytes(source_frame, request.meta),
+                                expected_ports,
+                                live_frame_ports_bytes(
+                                    &frame,
+                                    request.meta.addr_family,
+                                    request.meta.protocol,
+                                ),
+                            ) {
+                                record_exception(
+                                    recent_exceptions,
+                                    ingress_ident,
+                                    &reason,
+                                    frame.len() as u32,
+                                    Some(request.meta.into()),
+                                    None,
+                                );
+                                build_failed = true;
+                                break;
+                            }
+                        }
+                        let seg_frame_len = frame.len();
+                        target_binding.pending_tx_local.push_back(TxRequest {
+                            bytes: frame,
                             expected_ports,
-                            live_frame_ports_bytes(
-                                &frame,
-                                request.meta.addr_family,
-                                request.meta.protocol,
-                            ),
-                        ) {
-                            record_exception(
-                                recent_exceptions,
-                                ingress_ident,
-                                &reason,
-                                frame.len() as u32,
-                                Some(request.meta),
-                                None,
-                            );
-                            build_failed = true;
-                            break;
+                            expected_addr_family: request.meta.addr_family,
+                            expected_protocol: request.meta.protocol,
+                            flow_key: flow_key.clone(),
+                            egress_ifindex: request.decision.resolution.egress_ifindex,
+                            cos_queue_id: request.cos_queue_id,
+                            dscp_rewrite: request.dscp_rewrite,
+                        });
+                        bound_pending_tx_local(target_binding);
+                        dbg.enqueue_ok += 1;
+                        dbg.enqueue_copy += 1;
+                        target_binding.pending_copy_tx_packets += 1;
+                        dbg.tx_bytes_total += seg_frame_len as u64;
+                        if (seg_frame_len as u32) > dbg.tx_max_frame {
+                            dbg.tx_max_frame = seg_frame_len as u32;
                         }
                     }
-                    let seg_frame_len = frame.len();
-                    target_binding.pending_tx_local.push_back(TxRequest {
-                        bytes: frame,
-                        expected_ports,
-                        expected_addr_family: request.meta.addr_family,
-                        expected_protocol: request.meta.protocol,
-                        flow_key: request.flow_key.clone(),
-                        egress_ifindex: request.decision.resolution.egress_ifindex,
-                        cos_queue_id: request.cos_queue_id,
-                        dscp_rewrite: request.dscp_rewrite,
-                    });
-                    bound_pending_tx_local(target_binding);
-                    dbg.enqueue_ok += 1;
-                    dbg.enqueue_copy += 1;
-                    target_binding.pending_copy_tx_packets += 1;
-                    dbg.tx_bytes_total += seg_frame_len as u64;
-                    if (seg_frame_len as u32) > dbg.tx_max_frame {
-                        dbg.tx_max_frame = seg_frame_len as u32;
+                    copied_source_frame = true;
+                    if target_binding.pending_tx_local.len() >= TX_BATCH_SIZE {
+                        let _ = drain_pending_tx_local_owner(
+                            target_binding,
+                            now_ns,
+                            post_recycles,
+                            forwarding,
+                            worker_id,
+                            worker_commands_by_id,
+                            cos_owner_worker_by_queue,
+                        );
                     }
-                }
-                copied_source_frame = true;
-                if target_binding.pending_tx_local.len() >= TX_BATCH_SIZE {
-                    let _ = drain_pending_tx_local_owner(
-                        target_binding,
-                        now_ns,
-                        post_recycles,
-                        forwarding,
-                        worker_id,
-                        worker_commands_by_id,
-                        cos_owner_worker_by_queue,
-                    );
                 }
             }
             // Track when segmentation was needed but returned None
@@ -300,7 +371,7 @@ pub(super) fn enqueue_pending_forwards(
                 let can_rewrite_in_place = target_binding.umem.allocation_ptr() == ingress_umem_ptr
                     && !is_nat64
                     && !uses_native_tunnel
-                    && request.source_frame.is_none();
+                    && matches!(request.frame, PendingForwardFrame::Live);
                 if can_rewrite_in_place {
                     match rewrite_forwarded_frame_in_place(
                         unsafe { &*ingress_area },
@@ -320,7 +391,7 @@ pub(super) fn enqueue_pending_forwards(
                                     expected_ports,
                                     expected_addr_family: request.meta.addr_family,
                                     expected_protocol: request.meta.protocol,
-                                    flow_key: request.flow_key.clone(),
+                                    flow_key: flow_key.take(),
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
@@ -355,10 +426,9 @@ pub(super) fn enqueue_pending_forwards(
                             Some(frame) => {
                                 if cfg!(feature = "debug-log") {
                                     if let Some(reason) = forward_tuple_mismatch_reason(
-                                        live_frame_ports_bytes(
+                                        live_frame_ports_from_meta_bytes(
                                             source_frame,
-                                            request.meta.addr_family,
-                                            request.meta.protocol,
+                                            request.meta,
                                         ),
                                         expected_ports,
                                         live_frame_ports_bytes(
@@ -372,7 +442,7 @@ pub(super) fn enqueue_pending_forwards(
                                             ingress_ident,
                                             &reason,
                                             frame.len() as u32,
-                                            Some(request.meta),
+                                            Some(request.meta.into()),
                                             None,
                                         );
                                         // Don't continue — the frame was built successfully,
@@ -386,7 +456,7 @@ pub(super) fn enqueue_pending_forwards(
                                         ingress_ident,
                                         "oversized_forward_frame",
                                         cp1_len as u32,
-                                        Some(request.meta),
+                                        Some(request.meta.into()),
                                         None,
                                     );
                                     continue;
@@ -396,7 +466,7 @@ pub(super) fn enqueue_pending_forwards(
                                     expected_ports,
                                     expected_addr_family: request.meta.addr_family,
                                     expected_protocol: request.meta.protocol,
-                                    flow_key: request.flow_key.clone(),
+                                    flow_key: flow_key.take(),
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
@@ -495,11 +565,7 @@ pub(super) fn enqueue_pending_forwards(
                                     )
                                 });
                                 if let Some(reason) = forward_tuple_mismatch_reason(
-                                    live_frame_ports_bytes(
-                                        source_frame,
-                                        request.meta.addr_family,
-                                        request.meta.protocol,
-                                    ),
+                                    live_frame_ports_from_meta_bytes(source_frame, request.meta),
                                     expected_ports,
                                     built_ports,
                                 ) {
@@ -509,7 +575,7 @@ pub(super) fn enqueue_pending_forwards(
                                         ingress_ident,
                                         &reason,
                                         written as u32,
-                                        Some(request.meta),
+                                        Some(request.meta.into()),
                                         None,
                                     );
                                     build_failed = true;
@@ -525,7 +591,7 @@ pub(super) fn enqueue_pending_forwards(
                                     ingress_ident,
                                     "oversized_forward_frame",
                                     written as u32,
-                                    Some(request.meta),
+                                    Some(request.meta.into()),
                                     None,
                                 );
                                 true
@@ -539,7 +605,7 @@ pub(super) fn enqueue_pending_forwards(
                                         expected_ports,
                                         expected_addr_family: request.meta.addr_family,
                                         expected_protocol: request.meta.protocol,
-                                        flow_key: request.flow_key.clone(),
+                                        flow_key: flow_key.take(),
                                         egress_ifindex: request.decision.resolution.egress_ifindex,
                                         cos_queue_id: request.cos_queue_id,
                                         dscp_rewrite: request.dscp_rewrite,
@@ -598,10 +664,9 @@ pub(super) fn enqueue_pending_forwards(
                             Some(frame) => {
                                 if cfg!(feature = "debug-log") {
                                     if let Some(reason) = forward_tuple_mismatch_reason(
-                                        live_frame_ports_bytes(
+                                        live_frame_ports_from_meta_bytes(
                                             source_frame,
-                                            request.meta.addr_family,
-                                            request.meta.protocol,
+                                            request.meta,
                                         ),
                                         expected_ports,
                                         live_frame_ports_bytes(
@@ -615,7 +680,7 @@ pub(super) fn enqueue_pending_forwards(
                                             ingress_ident,
                                             &reason,
                                             frame.len() as u32,
-                                            Some(request.meta),
+                                            Some(request.meta.into()),
                                             None,
                                         );
                                         // Don't continue — the frame was built successfully,
@@ -629,7 +694,7 @@ pub(super) fn enqueue_pending_forwards(
                                         ingress_ident,
                                         "oversized_forward_frame",
                                         cp2_len as u32,
-                                        Some(request.meta),
+                                        Some(request.meta.into()),
                                         None,
                                     );
                                     continue;
@@ -639,7 +704,7 @@ pub(super) fn enqueue_pending_forwards(
                                     expected_ports,
                                     expected_addr_family: request.meta.addr_family,
                                     expected_protocol: request.meta.protocol,
-                                    flow_key: request.flow_key.clone(),
+                                    flow_key: flow_key.take(),
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
@@ -685,7 +750,6 @@ pub(super) fn enqueue_pending_forwards(
                 post_recycles,
             );
         }
-        update_binding_debug_state(ingress_binding);
         if build_failed {
             handle_forward_build_failure(
                 ingress_ident,
@@ -702,21 +766,29 @@ pub(super) fn enqueue_pending_forwards(
                 fallback_to_slow_path,
             );
             if !retained_source_frame {
-                ingress_binding.pending_fill_frames.push_back(source_offset);
+                recycle_ingress_frame(
+                    ingress_binding,
+                    source_offset,
+                    now_ns,
+                    &mut fill_drain_pending,
+                );
             }
             continue;
         }
         if !retained_source_frame {
-            ingress_binding.pending_fill_frames.push_back(source_offset);
+            recycle_ingress_frame(
+                ingress_binding,
+                source_offset,
+                now_ns,
+                &mut fill_drain_pending,
+            );
         }
-        // Always drain fill immediately — no watermark delay. In copy mode,
-        // the kernel queues packets in the socket buffer when the fill ring
-        // is low, causing latency spikes that stall TCP.
-        if !ingress_binding.pending_fill_frames.is_empty() {
-            let _ = drain_pending_fill(ingress_binding, now_ns);
-        }
-        update_binding_debug_state(ingress_binding);
     }
+    if fill_drain_pending && !ingress_binding.pending_fill_frames.is_empty() {
+        let _ = drain_pending_fill(ingress_binding, now_ns);
+    }
+    update_binding_debug_state(ingress_binding);
+    pending_forwards.clear();
 }
 
 fn resolve_pending_forward_target_binding<'a>(
@@ -753,10 +825,11 @@ pub(super) fn handle_forward_build_failure(
     _target_ifindex: i32,
     packet_length: u32,
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<UserspaceDpMeta>,
     decision: SessionDecision,
     fallback_to_slow_path: bool,
 ) {
+    let meta = meta.into();
     dbg.build_fail += 1;
     #[cfg(feature = "debug-log")]
     if dbg.build_fail <= 3 {
@@ -848,10 +921,11 @@ pub(super) fn maybe_reinject_slow_path(
     local_tunnel_deliveries: &Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
     area: &MmapArea,
     desc: XdpDesc,
-    meta: UserspaceDpMeta,
+    meta: impl Into<UserspaceDpMeta>,
     decision: SessionDecision,
     recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
 ) {
+    let meta = meta.into();
     if !matches!(
         decision.resolution.disposition,
         ForwardingDisposition::LocalDelivery
@@ -892,11 +966,12 @@ pub(super) fn maybe_reinject_slow_path_from_frame(
     slow_path: Option<&Arc<SlowPathReinjector>>,
     local_tunnel_deliveries: &Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<UserspaceDpMeta>,
     decision: SessionDecision,
     recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
     reason: &str,
 ) {
+    let meta = meta.into();
     let Some(packet) = extract_l3_packet_with_nat(frame, meta, decision.nat) else {
         live.slow_path_drops.fetch_add(1, Ordering::Relaxed);
         record_exception(
@@ -1015,7 +1090,11 @@ pub(super) fn extract_l3_packet(
     extract_l3_packet_from_frame(frame, meta)
 }
 
-pub(super) fn extract_l3_packet_from_frame(frame: &[u8], meta: UserspaceDpMeta) -> Option<Vec<u8>> {
+pub(super) fn extract_l3_packet_from_frame(
+    frame: &[u8],
+    meta: impl Into<ForwardPacketMeta>,
+) -> Option<Vec<u8>> {
+    let meta = meta.into();
     let l3 = meta.l3_offset as usize;
     if l3 >= frame.len() {
         return None;
@@ -1025,9 +1104,10 @@ pub(super) fn extract_l3_packet_from_frame(frame: &[u8], meta: UserspaceDpMeta) 
 
 pub(super) fn extract_l3_packet_with_nat(
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     nat: NatDecision,
 ) -> Option<Vec<u8>> {
+    let meta = meta.into();
     let mut packet = extract_l3_packet_from_frame(frame, meta)?;
     match meta.addr_family as i32 {
         libc::AF_INET => apply_nat_ipv4(&mut packet, meta.protocol, nat)?,
@@ -1040,7 +1120,7 @@ pub(super) fn extract_l3_packet_with_nat(
 fn segment_forwarded_tcp_frames_into_prepared(
     target_binding: &mut BindingWorker,
     frame: &[u8],
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     apply_nat_on_fabric: bool,
@@ -1054,6 +1134,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
 ) -> Option<(u32, u64, u32)> {
+    let meta = meta.into();
     if meta.protocol != PROTO_TCP || decision.resolution.tunnel_endpoint_id != 0 {
         return None;
     }
@@ -1161,11 +1242,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
         *payload.get(tcp_offset + 6)?,
         *payload.get(tcp_offset + 7)?,
     ]);
-    let enforced_ports = expected_ports.or(live_frame_ports_bytes(
-        frame,
-        meta.addr_family,
-        meta.protocol,
-    ));
+    let enforced_ports = expected_ports.or(live_frame_ports_from_meta_bytes(frame, meta));
     let tcp_header = payload.get(tcp_offset..tcp_offset + tcp_header_len)?;
     let ip_header = payload.get(..ip_header_len)?;
     let mut prepared: Vec<PreparedTxRequest> = Vec::with_capacity(segment_count);
@@ -1318,4 +1395,111 @@ fn segment_forwarded_tcp_frames_into_prepared(
     }
     bound_pending_tx_prepared(target_binding);
     Some((segment_count as u32, total_bytes, max_frame))
+}
+
+#[inline(always)]
+fn forwarded_tcp_may_need_segmentation(
+    frame: &[u8],
+    meta: impl Into<ForwardPacketMeta>,
+    decision: &SessionDecision,
+    forwarding: &ForwardingState,
+) -> bool {
+    let meta = meta.into();
+    if meta.protocol != PROTO_TCP || decision.resolution.tunnel_endpoint_id != 0 {
+        return false;
+    }
+    let mtu = forwarding
+        .egress
+        .get(&decision.resolution.egress_ifindex)
+        .or_else(|| forwarding.egress.get(&decision.resolution.tx_ifindex))
+        .map(|egress| egress.mtu)
+        .unwrap_or_default()
+        .max(1280);
+    if mtu == 0 {
+        return false;
+    }
+    let l3 = match meta.l3_offset {
+        14 | 18 => meta.l3_offset as usize,
+        _ => match frame_l3_offset(frame) {
+            Some(offset) => offset,
+            None => return false,
+        },
+    };
+    l3 < frame.len() && frame.len().saturating_sub(l3) > mtu
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_forwarding_with_egress_mtu(mtu: usize) -> ForwardingState {
+        let mut forwarding = ForwardingState::default();
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 11,
+                vlan_id: 80,
+                mtu,
+                src_mac: [0; 6],
+                zone: "wan".into(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+        forwarding
+    }
+
+    fn test_decision() -> SessionDecision {
+        SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 0,
+                egress_ifindex: 80,
+                tx_ifindex: 11,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 80,
+            },
+            nat: NatDecision::default(),
+        }
+    }
+
+    #[test]
+    fn forwarded_tcp_may_need_segmentation_skips_mtu_sized_frame() {
+        let forwarding = test_forwarding_with_egress_mtu(1500);
+        let meta = UserspaceDpMeta {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            l3_offset: 14,
+            ..UserspaceDpMeta::default()
+        };
+        let frame = vec![0u8; 14 + 1500];
+        assert!(!forwarded_tcp_may_need_segmentation(
+            &frame,
+            meta,
+            &test_decision(),
+            &forwarding,
+        ));
+    }
+
+    #[test]
+    fn forwarded_tcp_may_need_segmentation_flags_oversized_frame() {
+        let forwarding = test_forwarding_with_egress_mtu(1500);
+        let meta = UserspaceDpMeta {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            l3_offset: 14,
+            ..UserspaceDpMeta::default()
+        };
+        let frame = vec![0u8; 14 + 1600];
+        assert!(forwarded_tcp_may_need_segmentation(
+            &frame,
+            meta,
+            &test_decision(),
+            &forwarding,
+        ));
+    }
 }

--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -17,12 +17,40 @@ fn cos_owner_live_for_request(
         .and_then(|queue_id| cos_owner_live_by_queue.get(&(egress_ifindex, queue_id)).cloned())
 }
 
+fn request_uses_shared_exact_queue_lease(
+    cos_shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    requested_queue_id: Option<u8>,
+) -> bool {
+    let effective_queue_id = requested_queue_id.or_else(|| {
+        forwarding
+            .cos
+            .interfaces
+            .get(&egress_ifindex)
+            .map(|iface| iface.default_queue)
+    });
+    effective_queue_id.is_some_and(|queue_id| {
+        cos_shared_queue_leases.contains_key(&(egress_ifindex, queue_id))
+    })
+}
+
 fn enqueue_local_request_to_target_or_owner(
     target_binding: &mut BindingWorker,
     forwarding: &ForwardingState,
     cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
     req: TxRequest,
 ) -> Result<(), TxRequest> {
+    if request_uses_shared_exact_queue_lease(
+        &target_binding.cos_shared_queue_leases,
+        forwarding,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) {
+        target_binding.pending_tx_local.push_back(req);
+        bound_pending_tx_local(target_binding);
+        return Ok(());
+    }
     let owner_live = cos_owner_live_for_request(
         forwarding,
         cos_owner_live_by_queue,
@@ -418,7 +446,12 @@ pub(super) fn enqueue_pending_forwards(
                 // Always use copy path with NAT64-specific frame builder.
                 let is_nat64 = request.decision.nat.nat64;
                 let uses_native_tunnel = request.decision.resolution.tunnel_endpoint_id != 0;
-                let owner_matches_target = cos_owner_live_for_request(
+                let owner_matches_target = request_uses_shared_exact_queue_lease(
+                    &target_binding.cos_shared_queue_leases,
+                    forwarding,
+                    request.decision.resolution.egress_ifindex,
+                    request.cos_queue_id,
+                ) || cos_owner_live_for_request(
                     forwarding,
                     cos_owner_live_by_queue,
                     request.decision.resolution.egress_ifindex,
@@ -1602,6 +1635,54 @@ mod tests {
             meta,
             &test_decision(),
             &forwarding,
+        ));
+    }
+
+    #[test]
+    fn shared_exact_queue_lease_uses_requested_queue_id() {
+        let forwarding = ForwardingState::default();
+        let mut shared_queue_leases = BTreeMap::new();
+        shared_queue_leases.insert((80, 5), Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)));
+
+        assert!(request_uses_shared_exact_queue_lease(
+            &shared_queue_leases,
+            &forwarding,
+            80,
+            Some(5),
+        ));
+        assert!(!request_uses_shared_exact_queue_lease(
+            &shared_queue_leases,
+            &forwarding,
+            80,
+            Some(4),
+        ));
+    }
+
+    #[test]
+    fn shared_exact_queue_lease_uses_interface_default_queue() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 10_000_000_000u64 / 8,
+                burst_bytes: 256 * 1024,
+                default_queue: 5,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [0; 64],
+                ieee8021_queue_by_pcp: [0; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: Vec::new(),
+            },
+        );
+        let mut shared_queue_leases = BTreeMap::new();
+        shared_queue_leases.insert((80, 5), Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)));
+
+        assert!(request_uses_shared_exact_queue_lease(
+            &shared_queue_leases,
+            &forwarding,
+            80,
+            None,
         ));
     }
 }

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -296,10 +296,11 @@ pub(super) fn try_native_gre_decap_from_frame(
 
 pub(super) fn encapsulate_native_gre_frame(
     inner_frame: &[u8],
-    inner_meta: UserspaceDpMeta,
+    inner_meta: impl Into<ForwardPacketMeta>,
     decision: &SessionDecision,
     forwarding: &ForwardingState,
 ) -> Option<Vec<u8>> {
+    let inner_meta = inner_meta.into();
     let endpoint = forwarding
         .tunnel_endpoints
         .get(&decision.resolution.tunnel_endpoint_id)?;

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -53,10 +53,9 @@ pub(super) fn build_local_time_exceeded_request(
         target_ifindex,
         target_binding_index: None,
         ingress_queue_id: ingress_ident.queue_id,
-        source_offset: desc.addr,
         desc,
-        source_frame: None,
-        meta,
+        frame: PendingForwardFrame::Prebuilt(prebuilt_frame),
+        meta: meta.into(),
         decision: SessionDecision {
             resolution: ForwardingResolution {
                 disposition: ForwardingDisposition::ForwardCandidate,
@@ -75,7 +74,6 @@ pub(super) fn build_local_time_exceeded_request(
         expected_ports: None,
         flow_key: None,
         nat64_reverse: None,
-        prebuilt_frame: Some(prebuilt_frame),
         cos_queue_id: cos.queue_id,
         dscp_rewrite: cos.dscp_rewrite,
     })

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -786,7 +786,7 @@ pub(super) fn cancel_pending_forwards(
     let mut kept = Vec::with_capacity(pending_forwards.len());
     for req in pending_forwards.drain(..) {
         if pending_forward_matches_flow(&req, forward_key, reverse_key) {
-            binding.pending_fill_frames.push_back(req.source_offset);
+            binding.pending_fill_frames.push_back(req.desc.addr);
             continue;
         }
         kept.push(req);
@@ -3008,6 +3008,7 @@ mod tests {
                 egress_ifindex: 6,
                 tx_ifindex: 6,
                 target_binding_index: None,
+                tx_selection: CachedTxSelectionDescriptor::default(),
                 nat64: false,
                 nptv6: false,
                 apply_nat_on_fabric: false,
@@ -3086,6 +3087,7 @@ mod tests {
                 egress_ifindex: 6,
                 tx_ifindex: 6,
                 target_binding_index: None,
+                tx_selection: CachedTxSelectionDescriptor::default(),
                 nat64: false,
                 nptv6: false,
                 apply_nat_on_fabric: false,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -166,6 +166,70 @@ fn worker_binding_lookup_resolves_slot_index() {
 }
 
 #[test]
+fn build_live_forward_request_from_frame_uses_precomputed_hints() {
+    let lookup = WorkerBindingLookup::default();
+    let ingress_ident = BindingIdentity {
+        slot: 7,
+        queue_id: 3,
+        worker_id: 0,
+        interface: Arc::<str>::from("ge-0-0-1"),
+        ifindex: 10,
+    };
+    let desc = XdpDesc {
+        addr: 0,
+        len: 0,
+        options: 0,
+    };
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        ..UserspaceDpMeta::default()
+    };
+    let decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 80,
+        },
+        nat: NatDecision::default(),
+    };
+    let hints = PendingForwardHints {
+        expected_ports: Some((12345, 5201)),
+        target_binding_index: Some(9),
+    };
+
+    let req = build_live_forward_request_from_frame(
+        &lookup,
+        2,
+        &ingress_ident,
+        desc,
+        &[],
+        meta,
+        &decision,
+        &ForwardingState::default(),
+        None,
+        None,
+        false,
+        Some(hints),
+        None,
+    )
+    .expect("request");
+
+    assert_eq!(req.expected_ports, hints.expected_ports);
+    assert_eq!(req.target_binding_index, hints.target_binding_index);
+    assert_eq!(req.target_ifindex, 11);
+}
+
+#[test]
 fn icmp_reverse_key_keeps_identifier_position() {
     let flow = SessionFlow {
         src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
@@ -1093,8 +1157,8 @@ fn build_local_time_exceeded_request_returns_prebuilt_forward_for_ttl_expiry() {
 
     assert_eq!(request.target_ifindex, 5);
     assert_eq!(request.ingress_queue_id, ingress_ident.queue_id);
-    assert_eq!(request.source_offset, desc.addr);
-    assert!(request.prebuilt_frame.is_some());
+    assert_eq!(request.desc.addr, desc.addr);
+    assert!(matches!(request.frame, PendingForwardFrame::Prebuilt(_)));
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -489,8 +489,11 @@ fn ingest_cos_pending_tx(
                 Ok(()) => continue,
                 Err(req) => req,
             };
-            let req = match redirect_prepared_cos_request_to_owner_binding(binding, forwarding, req)
-            {
+            let req = match redirect_prepared_cos_request_to_owner_binding(
+                binding,
+                forwarding,
+                req,
+            ) {
                 Ok(()) => continue,
                 Err(req) => req,
             };
@@ -514,6 +517,7 @@ fn ingest_cos_pending_tx(
             worker_commands_by_id,
             cos_owner_worker_by_queue,
             cos_owner_live_by_queue,
+            &binding.cos_shared_queue_leases,
         ) {
             Ok(()) => continue,
             Err(req) => req,
@@ -523,6 +527,7 @@ fn ingest_cos_pending_tx(
             &binding.cos_owner_live_by_tx_ifindex,
             forwarding,
             req,
+            &binding.cos_shared_queue_leases,
         ) {
             Ok(()) => continue,
             Err(req) => req,
@@ -566,6 +571,16 @@ fn cos_owner_worker_for_cos_queue(
         .unwrap_or(current_worker_id)
 }
 
+fn cos_queue_uses_shared_exact_lease(
+    forwarding: &ForwardingState,
+    cos_shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    egress_ifindex: i32,
+    requested_queue_id: Option<u8>,
+) -> bool {
+    effective_cos_queue_id(forwarding, egress_ifindex, requested_queue_id)
+        .is_some_and(|queue_id| cos_shared_queue_leases.contains_key(&(egress_ifindex, queue_id)))
+}
+
 fn redirect_local_cos_request_to_owner(
     forwarding: &ForwardingState,
     req: TxRequest,
@@ -573,7 +588,16 @@ fn redirect_local_cos_request_to_owner(
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
     cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    cos_shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
 ) -> Result<(), TxRequest> {
+    if cos_queue_uses_shared_exact_lease(
+        forwarding,
+        cos_shared_queue_leases,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) {
+        return Err(req);
+    }
     let owner_worker_id = cos_owner_worker_for_cos_queue(
         forwarding,
         cos_owner_worker_by_queue,
@@ -606,7 +630,16 @@ fn redirect_local_cos_request_to_owner_binding(
     owner_live_by_tx_ifindex: &BTreeMap<i32, Arc<BindingLiveState>>,
     forwarding: &ForwardingState,
     req: TxRequest,
+    cos_shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
 ) -> Result<(), TxRequest> {
+    if cos_queue_uses_shared_exact_lease(
+        forwarding,
+        cos_shared_queue_leases,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) {
+        return Err(req);
+    }
     let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
     let Some(owner_live) = owner_live_by_tx_ifindex.get(&tx_ifindex) else {
         return Err(req);
@@ -626,6 +659,14 @@ fn redirect_prepared_cos_request_to_owner(
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
     cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Result<(), PreparedTxRequest> {
+    if cos_queue_uses_shared_exact_lease(
+        forwarding,
+        &binding.cos_shared_queue_leases,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) {
+        return Err(req);
+    }
     let owner_worker_id = cos_owner_worker_for_cos_queue(
         forwarding,
         cos_owner_worker_by_queue,
@@ -661,6 +702,7 @@ fn redirect_prepared_cos_request_to_owner(
         worker_commands_by_id,
         cos_owner_worker_by_queue,
         cos_owner_live_by_queue,
+        &binding.cos_shared_queue_leases,
     )
     .is_ok()
     {
@@ -675,6 +717,14 @@ fn redirect_prepared_cos_request_to_owner_binding(
     forwarding: &ForwardingState,
     req: PreparedTxRequest,
 ) -> Result<(), PreparedTxRequest> {
+    if cos_queue_uses_shared_exact_lease(
+        forwarding,
+        &binding.cos_shared_queue_leases,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) {
+        return Err(req);
+    }
     let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
     let Some(owner_live) = binding.cos_owner_live_by_tx_ifindex.get(&tx_ifindex) else {
         return Err(req);
@@ -746,6 +796,12 @@ fn build_cos_batch(
         if let Some(shared_root_lease) = shared_root_lease.as_ref() {
             maybe_top_up_cos_root_lease(root, shared_root_lease, now_ns);
         }
+        maybe_top_up_cos_exact_queue_leases(
+            root,
+            root_ifindex,
+            &binding.cos_shared_queue_leases,
+            now_ns,
+        );
         select_cos_guarantee_batch(root, now_ns).or_else(|| select_cos_surplus_batch(root, now_ns))
     };
     if selected.is_some() {
@@ -1082,6 +1138,35 @@ fn maybe_top_up_cos_root_lease(
         .tokens
         .saturating_add(grant)
         .min(root.burst_bytes.max(COS_MIN_BURST_BYTES));
+}
+
+fn maybe_top_up_cos_exact_queue_leases(
+    root: &mut CoSInterfaceRuntime,
+    root_ifindex: i32,
+    shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    now_ns: u64,
+) {
+    for queue in &mut root.queues {
+        if !queue.exact || queue.items.is_empty() {
+            continue;
+        }
+        let Some(shared_queue_lease) = shared_queue_leases.get(&(root_ifindex, queue.queue_id))
+        else {
+            continue;
+        };
+        let lease_bytes = shared_queue_lease
+            .lease_bytes()
+            .max(tx_frame_capacity() as u64)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        if queue.tokens >= lease_bytes {
+            continue;
+        }
+        let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
+        queue.tokens = queue
+            .tokens
+            .saturating_add(grant)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+    }
 }
 
 fn refill_cos_tokens(
@@ -1731,7 +1816,11 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 surplus_deficit: 0,
                 buffer_bytes: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
                 dscp_rewrite: queue.dscp_rewrite,
-                tokens: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+                tokens: if queue.exact {
+                    0
+                } else {
+                    queue.buffer_bytes.max(COS_MIN_BURST_BYTES)
+                },
                 last_refill_ns: now_ns,
                 queued_bytes: 0,
                 runnable: false,
@@ -1868,6 +1957,7 @@ fn enqueue_cos_item(
 fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32) {
     let mut new_nonempty = 0usize;
     let mut new_runnable = 0usize;
+    let mut released_queue_leases = Vec::<(u8, u64)>::new();
     let old_nonempty = binding
         .cos_interfaces
         .get(&root_ifindex)
@@ -1876,6 +1966,9 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
     if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
         for queue in &mut root.queues {
             normalize_cos_queue_state(queue);
+            if queue.items.is_empty() && queue.exact && queue.tokens > 0 {
+                released_queue_leases.push((queue.queue_id, core::mem::take(&mut queue.tokens)));
+            }
             if queue.items.is_empty() {
                 continue;
             }
@@ -1892,6 +1985,11 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
     } else if old_nonempty > 0 && new_nonempty == 0 {
         binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_sub(1);
         release_cos_root_lease(binding, root_ifindex);
+    }
+    for (queue_id, released) in released_queue_leases {
+        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+            shared_queue_lease.release_unused(released);
+        }
     }
 }
 
@@ -1916,6 +2014,37 @@ pub(super) fn release_all_cos_root_leases(binding: &mut BindingWorker) {
     }
 }
 
+pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
+    let queue_keys = binding
+        .cos_interfaces
+        .iter()
+        .flat_map(|(&root_ifindex, root)| {
+            root.queues
+                .iter()
+                .filter(|queue| queue.exact && queue.tokens > 0)
+                .map(move |queue| (root_ifindex, queue.queue_id))
+        })
+        .collect::<Vec<_>>();
+    for (root_ifindex, queue_id) in queue_keys {
+        let released = binding
+            .cos_interfaces
+            .get_mut(&root_ifindex)
+            .and_then(|root| {
+                root.queues
+                    .iter_mut()
+                    .find(|queue| queue.queue_id == queue_id)
+                    .map(|queue| core::mem::take(&mut queue.tokens))
+            })
+            .unwrap_or(0);
+        if released == 0 {
+            continue;
+        }
+        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+            shared_queue_lease.release_unused(released);
+        }
+    }
+}
+
 fn cos_item_len(item: &CoSPendingTxItem) -> u64 {
     match item {
         CoSPendingTxItem::Local(req) => req.bytes.len() as u64,
@@ -1931,11 +2060,15 @@ fn apply_cos_send_result(
     sent_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
+    let mut queue_key = None;
+    let mut exact_queue = false;
     {
         let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
+            queue_key = Some((root_ifindex, queue.queue_id));
+            exact_queue = queue.exact;
             restore_cos_local_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
             match phase {
@@ -1952,6 +2085,13 @@ fn apply_cos_send_result(
     if let Some(shared_root_lease) = binding.cos_shared_root_leases.get(&root_ifindex) {
         shared_root_lease.consume(sent_bytes);
     }
+    if exact_queue {
+        if let Some(queue_key) = queue_key {
+            if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&queue_key) {
+                shared_queue_lease.consume(sent_bytes);
+            }
+        }
+    }
     refresh_cos_interface_activity(binding, root_ifindex);
 }
 
@@ -1963,11 +2103,15 @@ fn apply_cos_prepared_result(
     sent_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
+    let mut queue_key = None;
+    let mut exact_queue = false;
     {
         let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
+            queue_key = Some((root_ifindex, queue.queue_id));
+            exact_queue = queue.exact;
             restore_cos_prepared_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
             match phase {
@@ -1983,6 +2127,13 @@ fn apply_cos_prepared_result(
     }
     if let Some(shared_root_lease) = binding.cos_shared_root_leases.get(&root_ifindex) {
         shared_root_lease.consume(sent_bytes);
+    }
+    if exact_queue {
+        if let Some(queue_key) = queue_key {
+            if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&queue_key) {
+                shared_queue_lease.consume(sent_bytes);
+            }
+        }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
 }
@@ -2614,6 +2765,7 @@ mod tests {
             &worker_commands_by_id,
             &cos_owner_worker_by_queue,
             &BTreeMap::new(),
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
@@ -2666,11 +2818,70 @@ mod tests {
             &worker_commands_by_id,
             &cos_owner_worker_by_queue,
             &BTreeMap::new(),
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
         let pending = commands.lock().unwrap();
         assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn redirect_local_exact_cos_request_to_owner_stays_local_with_shared_queue_lease() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 1_000_000,
+                burst_bytes: COS_MIN_BURST_BYTES,
+                default_queue: 4,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 4,
+                    forwarding_class: "iperf-b".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 1_000_000,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: COS_MIN_BURST_BYTES,
+                    dscp_rewrite: None,
+                }],
+            },
+        );
+        let cos_owner_worker_by_queue = BTreeMap::from([((80, 4), 7)]);
+        let cos_shared_queue_leases = BTreeMap::from([(
+            (80, 4),
+            Arc::new(SharedCoSQueueLease::new(1_000_000, COS_MIN_BURST_BYTES, 2)),
+        )]);
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+
+        let redirected = redirect_local_cos_request_to_owner(
+            &forwarding,
+            req,
+            2,
+            &worker_commands_by_id,
+            &cos_owner_worker_by_queue,
+            &BTreeMap::new(),
+            &cos_shared_queue_leases,
+        );
+
+        assert!(redirected.is_err());
+        assert!(commands.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -2739,6 +2950,46 @@ mod tests {
     }
 
     #[test]
+    fn maybe_top_up_cos_exact_queue_lease_unblocks_local_exact_queue_without_tokens() {
+        let mut root = test_cos_runtime_with_queues(
+            400_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 0,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 400_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.tokens = 1500;
+        root.queues[0].tokens = 0;
+        root.queues[0].items.push_back(test_cos_item(1500));
+        root.queues[0].queued_bytes = 1500;
+        root.queues[0].runnable = true;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+        let shared_queue_leases = BTreeMap::from([(
+            (42, 0),
+            Arc::new(SharedCoSQueueLease::new(
+                400_000_000 / 8,
+                COS_MIN_BURST_BYTES,
+                2,
+            )),
+        )]);
+
+        maybe_top_up_cos_exact_queue_leases(&mut root, 42, &shared_queue_leases, 1_000_000_000);
+
+        assert!(
+            root.queues[0].tokens >= 1500,
+            "shared exact queue lease must replenish local queue tokens"
+        );
+        assert!(select_cos_guarantee_batch(&mut root, 1_000_000_000).is_some());
+    }
+
+    #[test]
     fn redirect_local_cos_request_to_owner_binding_pushes_owner_live_queue() {
         let current_live = Arc::new(BindingLiveState::new());
         let owner_live = Arc::new(BindingLiveState::new());
@@ -2773,12 +3024,83 @@ mod tests {
             &owner_live_by_tx_ifindex,
             &forwarding,
             req,
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
         let queued = owner_live.take_pending_tx();
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
+        assert!(current_live.take_pending_tx().is_empty());
+    }
+
+    #[test]
+    fn redirect_local_exact_cos_request_to_owner_binding_stays_local_with_shared_queue_lease() {
+        let current_live = Arc::new(BindingLiveState::new());
+        let owner_live = Arc::new(BindingLiveState::new());
+        let owner_live_by_tx_ifindex = BTreeMap::from([(12, owner_live.clone())]);
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 1_000_000,
+                burst_bytes: COS_MIN_BURST_BYTES,
+                default_queue: 4,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 4,
+                    forwarding_class: "iperf-b".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 1_000_000,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: COS_MIN_BURST_BYTES,
+                    dscp_rewrite: None,
+                }],
+            },
+        );
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 12,
+                vlan_id: 80,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone: "wan".to_string(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+        let cos_shared_queue_leases = BTreeMap::from([(
+            (80, 4),
+            Arc::new(SharedCoSQueueLease::new(1_000_000, COS_MIN_BURST_BYTES, 2)),
+        )]);
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+
+        let redirected = redirect_local_cos_request_to_owner_binding(
+            &current_live,
+            &owner_live_by_tx_ifindex,
+            &forwarding,
+            req,
+            &cos_shared_queue_leases,
+        );
+
+        assert!(redirected.is_err());
+        assert!(owner_live.take_pending_tx().is_empty());
         assert!(current_live.take_pending_tx().is_empty());
     }
 
@@ -2822,6 +3144,7 @@ mod tests {
             &worker_commands_by_id,
             &cos_owner_worker_by_queue,
             &cos_owner_live_by_queue,
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -187,6 +187,7 @@ pub(super) fn drain_pending_tx(
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> bool {
     if !binding_has_pending_tx_work(binding) {
         return false;
@@ -208,6 +209,7 @@ pub(super) fn drain_pending_tx(
         worker_id,
         worker_commands_by_id,
         cos_owner_worker_by_queue,
+        cos_owner_live_by_queue,
     );
     // Only continue this loop while shaped service is making real forward
     // progress. A retrying CoS batch (for example, no free TX frame on the
@@ -445,6 +447,7 @@ pub(super) fn drain_pending_tx_local_owner(
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> bool {
     drain_pending_tx(
         binding,
@@ -454,6 +457,7 @@ pub(super) fn drain_pending_tx_local_owner(
         worker_id,
         worker_commands_by_id,
         cos_owner_worker_by_queue,
+        cos_owner_live_by_queue,
     )
 }
 
@@ -464,6 +468,7 @@ fn ingest_cos_pending_tx(
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) {
     if forwarding.cos.interfaces.is_empty() {
         return;
@@ -479,6 +484,7 @@ fn ingest_cos_pending_tx(
                 worker_id,
                 worker_commands_by_id,
                 cos_owner_worker_by_queue,
+                cos_owner_live_by_queue,
             ) {
                 Ok(()) => continue,
                 Err(req) => req,
@@ -507,6 +513,7 @@ fn ingest_cos_pending_tx(
             worker_id,
             worker_commands_by_id,
             cos_owner_worker_by_queue,
+            cos_owner_live_by_queue,
         ) {
             Ok(()) => continue,
             Err(req) => req,
@@ -565,6 +572,7 @@ fn redirect_local_cos_request_to_owner(
     current_worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Result<(), TxRequest> {
     let owner_worker_id = cos_owner_worker_for_cos_queue(
         forwarding,
@@ -575,6 +583,13 @@ fn redirect_local_cos_request_to_owner(
     );
     if owner_worker_id == current_worker_id {
         return Err(req);
+    }
+    let effective_queue_id =
+        effective_cos_queue_id(forwarding, req.egress_ifindex, req.cos_queue_id);
+    if let Some(owner_live) = effective_queue_id
+        .and_then(|queue_id| cos_owner_live_by_queue.get(&(req.egress_ifindex, queue_id)))
+    {
+        return owner_live.enqueue_tx_owned(req);
     }
     let Some(commands) = worker_commands_by_id.get(&owner_worker_id) else {
         return Err(req);
@@ -609,6 +624,7 @@ fn redirect_prepared_cos_request_to_owner(
     current_worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
     cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Result<(), PreparedTxRequest> {
     let owner_worker_id = cos_owner_worker_for_cos_queue(
         forwarding,
@@ -644,6 +660,7 @@ fn redirect_prepared_cos_request_to_owner(
         current_worker_id,
         worker_commands_by_id,
         cos_owner_worker_by_queue,
+        cos_owner_live_by_queue,
     )
     .is_ok()
     {
@@ -1039,9 +1056,9 @@ fn cos_batch_tx_made_progress(result: Result<(u64, u64), TxError>) -> bool {
 
 const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
 const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
-const COS_GUARANTEE_VISIT_NS: u64 = 100_000;
+const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
-const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 32 * 1024;
+const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
 const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
@@ -1464,6 +1481,68 @@ pub(super) fn enqueue_local_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
+    if binding
+        .cos_interfaces
+        .get(&egress_ifindex)
+        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
+    {
+        match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
+            Ok(prepared_req) => {
+                let item_len = prepared_req.len as u64;
+                match enqueue_cos_item(
+                    binding,
+                    egress_ifindex,
+                    prepared_req.cos_queue_id,
+                    item_len,
+                    CoSPendingTxItem::Prepared(prepared_req),
+                ) {
+                    Ok(()) => return Ok(()),
+                    Err(CoSPendingTxItem::Prepared(prepared_req)) => {
+                        let req =
+                            clone_prepared_request_for_cos(binding.umem.area(), &prepared_req)
+                                .expect("prepared CoS fallback clone");
+                        recycle_prepared_immediately(binding, &prepared_req);
+                        let item_len = req.bytes.len() as u64;
+                        return match enqueue_cos_item(
+                            binding,
+                            egress_ifindex,
+                            req.cos_queue_id,
+                            item_len,
+                            CoSPendingTxItem::Local(req),
+                        ) {
+                            Ok(()) => Ok(()),
+                            Err(CoSPendingTxItem::Local(req)) => Err(req),
+                            Err(CoSPendingTxItem::Prepared(_)) => {
+                                unreachable!("local request returned prepared item")
+                            }
+                        };
+                    }
+                    Err(CoSPendingTxItem::Local(_)) => {
+                        unreachable!("local request prepared into prepared item")
+                    }
+                }
+            }
+            Err(req) => {
+                // Fall through to the local CoS path when no TX frame is
+                // available or the request cannot be materialized safely.
+                let req = req;
+                let item_len = req.bytes.len() as u64;
+                return match enqueue_cos_item(
+                    binding,
+                    egress_ifindex,
+                    req.cos_queue_id,
+                    item_len,
+                    CoSPendingTxItem::Local(req),
+                ) {
+                    Ok(()) => Ok(()),
+                    Err(CoSPendingTxItem::Local(req)) => Err(req),
+                    Err(CoSPendingTxItem::Prepared(_)) => {
+                        unreachable!("local request returned prepared item")
+                    }
+                };
+            }
+        }
+    }
     let item_len = req.bytes.len() as u64;
     match enqueue_cos_item(
         binding,
@@ -1478,6 +1557,37 @@ pub(super) fn enqueue_local_into_cos(
     }
 }
 
+fn prepare_local_request_for_cos(
+    area: &MmapArea,
+    free_tx_frames: &mut VecDeque<u64>,
+    req: TxRequest,
+) -> Result<PreparedTxRequest, TxRequest> {
+    if req.bytes.len() > tx_frame_capacity() {
+        return Err(req);
+    }
+    let Some(offset) = free_tx_frames.pop_front() else {
+        return Err(req);
+    };
+    let Some(frame) = (unsafe { area.slice_mut_unchecked(offset as usize, req.bytes.len()) })
+    else {
+        free_tx_frames.push_front(offset);
+        return Err(req);
+    };
+    frame.copy_from_slice(&req.bytes);
+    Ok(PreparedTxRequest {
+        offset,
+        len: req.bytes.len() as u32,
+        recycle: PreparedTxRecycle::FreeTxFrame,
+        expected_ports: req.expected_ports,
+        expected_addr_family: req.expected_addr_family,
+        expected_protocol: req.expected_protocol,
+        flow_key: req.flow_key,
+        egress_ifindex: req.egress_ifindex,
+        cos_queue_id: req.cos_queue_id,
+        dscp_rewrite: req.dscp_rewrite,
+    })
+}
+
 fn enqueue_prepared_into_cos(
     binding: &mut BindingWorker,
     forwarding: &ForwardingState,
@@ -1488,13 +1598,33 @@ fn enqueue_prepared_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
+    if binding
+        .cos_interfaces
+        .get(&egress_ifindex)
+        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
+    {
+        let item_len = req.len as u64;
+        match enqueue_cos_item(
+            binding,
+            egress_ifindex,
+            req.cos_queue_id,
+            item_len,
+            CoSPendingTxItem::Prepared(req),
+        ) {
+            Ok(()) => return Ok(()),
+            Err(CoSPendingTxItem::Prepared(req)) => return Err(req),
+            Err(CoSPendingTxItem::Local(_)) => unreachable!("prepared request returned local item"),
+        }
+    }
+
     let Some(local_req) = clone_prepared_request_for_cos(binding.umem.area(), &req) else {
         return Err(req);
     };
-    // Once shaped traffic is queued behind the CoS scheduler, it must not keep holding
-    // owner TX frames. Otherwise a local item can reach the head of the same queue while
-    // all free frames are trapped inside queued prepared items, leading to a persistent
-    // "no free TX frame available" livelock.
+    // Keep prepared/direct frames in CoS while a queue stays prepared-only.
+    // Once any copied local item enters that queue, later prepared frames must
+    // fall back to local copies until the queue drains empty again; otherwise a
+    // local head item can block behind prepared frames that are holding every
+    // free TX frame on the owner binding.
     let item_len = local_req.bytes.len() as u64;
     match enqueue_cos_item(
         binding,
@@ -1526,6 +1656,30 @@ fn clone_prepared_request_for_cos(area: &MmapArea, req: &PreparedTxRequest) -> O
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
     })
+}
+
+fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> bool {
+    if root.queues.is_empty() {
+        return false;
+    }
+    let target_queue = requested_queue.unwrap_or(root.default_queue);
+    let queue_idx = root
+        .queues
+        .iter()
+        .position(|queue| queue.queue_id == target_queue)
+        .or_else(|| {
+            root.queues
+                .iter()
+                .position(|queue| queue.queue_id == root.default_queue)
+        })
+        .unwrap_or(0);
+    let Some(queue) = root.queues.get(queue_idx) else {
+        return false;
+    };
+    !queue
+        .items
+        .iter()
+        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
 }
 
 fn ensure_cos_interface_runtime(
@@ -1948,7 +2102,7 @@ fn recycle_completed_tx_offset(
     }
 }
 
-fn recycle_prepared_immediately(binding: &mut BindingWorker, req: &PreparedTxRequest) {
+pub(super) fn recycle_prepared_immediately(binding: &mut BindingWorker, req: &PreparedTxRequest) {
     recycle_cancelled_prepared(binding, req);
 }
 
@@ -2459,6 +2613,7 @@ mod tests {
             2,
             &worker_commands_by_id,
             &cos_owner_worker_by_queue,
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
@@ -2510,6 +2665,7 @@ mod tests {
             2,
             &worker_commands_by_id,
             &cos_owner_worker_by_queue,
+            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
@@ -2624,6 +2780,56 @@ mod tests {
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
         assert!(current_live.take_pending_tx().is_empty());
+    }
+
+    #[test]
+    fn redirect_local_cos_request_to_owner_uses_owner_live_queue_when_available() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 1_000_000,
+                burst_bytes: COS_MIN_BURST_BYTES,
+                default_queue: 4,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: Vec::new(),
+            },
+        );
+        let owner_live = Arc::new(BindingLiveState::new());
+        let cos_owner_worker_by_queue = BTreeMap::from([((80, 4), 7)]);
+        let cos_owner_live_by_queue = BTreeMap::from([((80, 4), owner_live.clone())]);
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+
+        let redirected = redirect_local_cos_request_to_owner(
+            &forwarding,
+            req,
+            2,
+            &worker_commands_by_id,
+            &cos_owner_worker_by_queue,
+            &cos_owner_live_by_queue,
+        );
+
+        assert!(redirected.is_ok());
+        assert!(commands.lock().unwrap().is_empty());
+        let queued = owner_live.take_pending_tx();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
+        assert_eq!(queued.front().map(|req| req.cos_queue_id), Some(Some(4)));
     }
 
     #[test]
@@ -2753,6 +2959,144 @@ mod tests {
         };
 
         assert!(clone_prepared_request_for_cos(&area, &req).is_none());
+    }
+
+    #[test]
+    fn prepare_local_request_for_cos_materializes_prepared_frame() {
+        let area = MmapArea::new(4096).expect("mmap");
+        let mut free_tx_frames = VecDeque::from([128]);
+        let req = TxRequest {
+            bytes: vec![0xde, 0xad, 0xbe, 0xef],
+            expected_ports: Some((1111, 2222)),
+            expected_addr_family: libc::AF_INET6 as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: Some(SessionKey {
+                addr_family: libc::AF_INET6 as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                dst_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+                src_port: 1111,
+                dst_port: 2222,
+            }),
+            egress_ifindex: 80,
+            cos_queue_id: Some(5),
+            dscp_rewrite: Some(46),
+        };
+
+        let prepared =
+            prepare_local_request_for_cos(&area, &mut free_tx_frames, req).expect("prepared");
+
+        assert_eq!(prepared.offset, 128);
+        assert_eq!(prepared.len, 4);
+        assert_eq!(prepared.recycle, PreparedTxRecycle::FreeTxFrame);
+        assert_eq!(prepared.expected_ports, Some((1111, 2222)));
+        assert_eq!(prepared.egress_ifindex, 80);
+        assert_eq!(prepared.cos_queue_id, Some(5));
+        assert_eq!(prepared.dscp_rewrite, Some(46));
+        assert!(free_tx_frames.is_empty());
+        assert_eq!(area.slice(128, 4).expect("slice"), [0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn prepare_local_request_for_cos_falls_back_when_no_free_tx_frame_exists() {
+        let area = MmapArea::new(4096).expect("mmap");
+        let mut free_tx_frames = VecDeque::new();
+        let req = TxRequest {
+            bytes: vec![1, 2, 3, 4],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(5),
+            dscp_rewrite: None,
+        };
+
+        let req = match prepare_local_request_for_cos(&area, &mut free_tx_frames, req) {
+            Ok(_) => panic!("must fall back to local"),
+            Err(req) => req,
+        };
+
+        assert_eq!(req.bytes, [1, 2, 3, 4]);
+        assert!(free_tx_frames.is_empty());
+    }
+
+    #[test]
+    fn cos_queue_accepts_prepared_when_queue_is_prepared_only() {
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
+                offset: 64,
+                len: 1500,
+                recycle: PreparedTxRecycle::FreeTxFrame,
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+
+        assert!(cos_queue_accepts_prepared(&root, Some(5)));
+    }
+
+    #[test]
+    fn cos_queue_rejects_prepared_once_local_items_enter_queue() {
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
+                offset: 64,
+                len: 1500,
+                recycle: PreparedTxRecycle::FreeTxFrame,
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Local(TxRequest {
+                bytes: vec![0; 1500],
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+
+        assert!(!cos_queue_accepts_prepared(&root, Some(5)));
     }
 
     #[test]
@@ -4238,6 +4582,39 @@ mod tests {
             CoSBatch::Prepared { .. } => panic!("expected local batch"),
         }
         assert_eq!(root.queues[0].items.len(), 3);
+    }
+
+    #[test]
+    fn guarantee_phase_allows_larger_high_rate_visit_quantum() {
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000u64 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 0,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000u64 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 256 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        root.tokens = 256 * 1024;
+        root.queues[0].tokens = 256 * 1024;
+        root.queues[0].runnable = true;
+        for _ in 0..200 {
+            root.queues[0].items.push_back(test_cos_item(1500));
+        }
+        root.queues[0].queued_bytes = 200 * 1500;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+
+        let batch = select_cos_guarantee_batch(&mut root, 1).expect("guarantee batch");
+        match batch {
+            CoSBatch::Local { items, .. } => assert_eq!(items.len(), 166),
+            CoSBatch::Prepared { .. } => panic!("expected local batch"),
+        }
+        assert_eq!(root.queues[0].items.len(), 34);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -489,8 +489,11 @@ fn ingest_cos_pending_tx(
                 Ok(()) => continue,
                 Err(req) => req,
             };
-            let req = match redirect_prepared_cos_request_to_owner_binding(binding, forwarding, req)
-            {
+            let req = match redirect_prepared_cos_request_to_owner_binding(
+                binding,
+                forwarding,
+                req,
+            ) {
                 Ok(()) => continue,
                 Err(req) => req,
             };
@@ -1563,57 +1566,79 @@ pub(super) fn enqueue_local_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
-    match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
-        Ok(prepared_req) => {
-            let item_len = prepared_req.len as u64;
-            match enqueue_cos_item(
-                binding,
-                egress_ifindex,
-                prepared_req.cos_queue_id,
-                item_len,
-                CoSPendingTxItem::Prepared(prepared_req),
-            ) {
-                Ok(()) => Ok(()),
-                Err(CoSPendingTxItem::Prepared(prepared_req)) => {
-                    let req = clone_prepared_request_for_cos(binding.umem.area(), &prepared_req)
-                        .expect("prepared CoS fallback clone");
-                    recycle_prepared_immediately(binding, &prepared_req);
-                    let item_len = req.bytes.len() as u64;
-                    match enqueue_cos_item(
-                        binding,
-                        egress_ifindex,
-                        req.cos_queue_id,
-                        item_len,
-                        CoSPendingTxItem::Local(req),
-                    ) {
-                        Ok(()) => Ok(()),
-                        Err(CoSPendingTxItem::Local(req)) => Err(req),
-                        Err(CoSPendingTxItem::Prepared(_)) => {
-                            unreachable!("local request returned prepared item")
-                        }
+    if binding
+        .cos_interfaces
+        .get(&egress_ifindex)
+        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
+    {
+        match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
+            Ok(prepared_req) => {
+                let item_len = prepared_req.len as u64;
+                match enqueue_cos_item(
+                    binding,
+                    egress_ifindex,
+                    prepared_req.cos_queue_id,
+                    item_len,
+                    CoSPendingTxItem::Prepared(prepared_req),
+                ) {
+                    Ok(()) => return Ok(()),
+                    Err(CoSPendingTxItem::Prepared(prepared_req)) => {
+                        let req =
+                            clone_prepared_request_for_cos(binding.umem.area(), &prepared_req)
+                                .expect("prepared CoS fallback clone");
+                        recycle_prepared_immediately(binding, &prepared_req);
+                        let item_len = req.bytes.len() as u64;
+                        return match enqueue_cos_item(
+                            binding,
+                            egress_ifindex,
+                            req.cos_queue_id,
+                            item_len,
+                            CoSPendingTxItem::Local(req),
+                        ) {
+                            Ok(()) => Ok(()),
+                            Err(CoSPendingTxItem::Local(req)) => Err(req),
+                            Err(CoSPendingTxItem::Prepared(_)) => {
+                                unreachable!("local request returned prepared item")
+                            }
+                        };
+                    }
+                    Err(CoSPendingTxItem::Local(_)) => {
+                        unreachable!("local request prepared into prepared item")
                     }
                 }
-                Err(CoSPendingTxItem::Local(_)) => {
-                    unreachable!("local request prepared into prepared item")
-                }
+            }
+            Err(req) => {
+                // Fall through to the local CoS path when no TX frame is
+                // available or the request cannot be materialized safely.
+                let req = req;
+                let item_len = req.bytes.len() as u64;
+                return match enqueue_cos_item(
+                    binding,
+                    egress_ifindex,
+                    req.cos_queue_id,
+                    item_len,
+                    CoSPendingTxItem::Local(req),
+                ) {
+                    Ok(()) => Ok(()),
+                    Err(CoSPendingTxItem::Local(req)) => Err(req),
+                    Err(CoSPendingTxItem::Prepared(_)) => {
+                        unreachable!("local request returned prepared item")
+                    }
+                };
             }
         }
-        Err(req) => {
-            let item_len = req.bytes.len() as u64;
-            match enqueue_cos_item(
-                binding,
-                egress_ifindex,
-                req.cos_queue_id,
-                item_len,
-                CoSPendingTxItem::Local(req),
-            ) {
-                Ok(()) => Ok(()),
-                Err(CoSPendingTxItem::Local(req)) => Err(req),
-                Err(CoSPendingTxItem::Prepared(_)) => {
-                    unreachable!("local request returned prepared item")
-                }
-            }
-        }
+    }
+    let item_len = req.bytes.len() as u64;
+    match enqueue_cos_item(
+        binding,
+        egress_ifindex,
+        req.cos_queue_id,
+        item_len,
+        CoSPendingTxItem::Local(req),
+    ) {
+        Ok(()) => Ok(()),
+        Err(CoSPendingTxItem::Local(req)) => Err(req),
+        Err(CoSPendingTxItem::Prepared(_)) => unreachable!("local request returned prepared item"),
     }
 }
 
@@ -1658,17 +1683,49 @@ fn enqueue_prepared_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
-    let item_len = req.len as u64;
+    if binding
+        .cos_interfaces
+        .get(&egress_ifindex)
+        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
+    {
+        let item_len = req.len as u64;
+        match enqueue_cos_item(
+            binding,
+            egress_ifindex,
+            req.cos_queue_id,
+            item_len,
+            CoSPendingTxItem::Prepared(req),
+        ) {
+            Ok(()) => return Ok(()),
+            Err(CoSPendingTxItem::Prepared(req)) => return Err(req),
+            Err(CoSPendingTxItem::Local(_)) => unreachable!("prepared request returned local item"),
+        }
+    }
+
+    let Some(local_req) = clone_prepared_request_for_cos(binding.umem.area(), &req) else {
+        return Err(req);
+    };
+    // Keep prepared/direct frames in CoS while a queue stays prepared-only.
+    // Once any copied local item enters that queue, later prepared frames must
+    // fall back to local copies until the queue drains empty again; otherwise a
+    // local head item can block behind prepared frames that are holding every
+    // free TX frame on the owner binding.
+    let item_len = local_req.bytes.len() as u64;
     match enqueue_cos_item(
         binding,
         egress_ifindex,
-        req.cos_queue_id,
+        local_req.cos_queue_id,
         item_len,
-        CoSPendingTxItem::Prepared(req),
+        CoSPendingTxItem::Local(local_req),
     ) {
-        Ok(()) => Ok(()),
-        Err(CoSPendingTxItem::Prepared(req)) => Err(req),
-        Err(CoSPendingTxItem::Local(_)) => unreachable!("prepared request returned local item"),
+        Ok(()) => {
+            recycle_prepared_immediately(binding, &req);
+            Ok(())
+        }
+        Err(CoSPendingTxItem::Local(_)) => Err(req),
+        Err(CoSPendingTxItem::Prepared(_)) => {
+            unreachable!("prepared queueing converted to local request")
+        }
     }
 }
 
@@ -1684,6 +1741,30 @@ fn clone_prepared_request_for_cos(area: &MmapArea, req: &PreparedTxRequest) -> O
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
     })
+}
+
+fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> bool {
+    if root.queues.is_empty() {
+        return false;
+    }
+    let target_queue = requested_queue.unwrap_or(root.default_queue);
+    let queue_idx = root
+        .queues
+        .iter()
+        .position(|queue| queue.queue_id == target_queue)
+        .or_else(|| {
+            root.queues
+                .iter()
+                .position(|queue| queue.queue_id == root.default_queue)
+        })
+        .unwrap_or(0);
+    let Some(queue) = root.queues.get(queue_idx) else {
+        return false;
+    };
+    !queue
+        .items
+        .iter()
+        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
 }
 
 fn ensure_cos_interface_runtime(
@@ -1906,10 +1987,7 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
         release_cos_root_lease(binding, root_ifindex);
     }
     for (queue_id, released) in released_queue_leases {
-        if let Some(shared_queue_lease) = binding
-            .cos_shared_queue_leases
-            .get(&(root_ifindex, queue_id))
-        {
+        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -1961,10 +2039,7 @@ pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
         if released == 0 {
             continue;
         }
-        if let Some(shared_queue_lease) = binding
-            .cos_shared_queue_leases
-            .get(&(root_ifindex, queue_id))
-        {
+        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -3270,7 +3345,7 @@ mod tests {
     }
 
     #[test]
-    fn mixed_cos_queue_preserves_prepared_batches_after_local_fallback() {
+    fn cos_queue_accepts_prepared_when_queue_is_prepared_only() {
         let mut root = test_cos_runtime_with_queues(
             10_000_000_000 / 8,
             vec![CoSQueueConfig {
@@ -3284,8 +3359,7 @@ mod tests {
                 dscp_rewrite: None,
             }],
         );
-        let queue = &mut root.queues[0];
-        queue
+        root.queues[0]
             .items
             .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
                 offset: 64,
@@ -3299,20 +3373,29 @@ mod tests {
                 cos_queue_id: Some(5),
                 dscp_rewrite: None,
             }));
-        queue.items.push_back(CoSPendingTxItem::Local(TxRequest {
-            bytes: vec![0; 1500],
-            expected_ports: None,
-            expected_addr_family: libc::AF_INET6 as u8,
-            expected_protocol: PROTO_TCP,
-            flow_key: None,
-            egress_ifindex: 80,
-            cos_queue_id: Some(5),
-            dscp_rewrite: None,
-        }));
-        queue
+
+        assert!(cos_queue_accepts_prepared(&root, Some(5)));
+    }
+
+    #[test]
+    fn cos_queue_rejects_prepared_once_local_items_enter_queue() {
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.queues[0]
             .items
             .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
-                offset: 128,
+                offset: 64,
                 len: 1500,
                 recycle: PreparedTxRecycle::FreeTxFrame,
                 expected_ports: None,
@@ -3323,29 +3406,20 @@ mod tests {
                 cos_queue_id: Some(5),
                 dscp_rewrite: None,
             }));
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Local(TxRequest {
+                bytes: vec![0; 1500],
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
 
-        let first =
-            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
-                .expect("first queue batch");
-        let second =
-            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
-                .expect("second queue batch");
-        let third =
-            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
-                .expect("third queue batch");
-
-        match first {
-            CoSBatch::Prepared { items, .. } => assert_eq!(items.len(), 1),
-            CoSBatch::Local { .. } => panic!("first batch should stay prepared"),
-        }
-        match second {
-            CoSBatch::Local { items, .. } => assert_eq!(items.len(), 1),
-            CoSBatch::Prepared { .. } => panic!("second batch should drain the local fallback"),
-        }
-        match third {
-            CoSBatch::Prepared { items, .. } => assert_eq!(items.len(), 1),
-            CoSBatch::Local { .. } => panic!("third batch should return to prepared"),
-        }
+        assert!(!cos_queue_accepts_prepared(&root, Some(5)));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -332,14 +332,17 @@ pub(super) fn resolve_cached_cos_tx_selection(
     };
 
     let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
-    let has_output_tx_selection =
-        crate::filter::filter_state_has_output_tx_selection(&forwarding.filter_state, is_v6);
+    let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
+        &forwarding.filter_state,
+        egress_ifindex,
+        is_v6,
+    );
     let has_input_tx_selection =
         crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
-    if iface.is_none() && !has_output_tx_selection && !has_input_tx_selection {
+    if iface.is_none() && !has_output_tx_eval && !has_input_tx_selection {
         return CachedTxSelectionDescriptor::default();
     }
-    let output_filter = if has_output_tx_selection {
+    let output_filter = if has_output_tx_eval {
         if is_v6 {
             forwarding
                 .filter_state
@@ -357,7 +360,7 @@ pub(super) fn resolve_cached_cos_tx_selection(
         None
     };
     let output_result = output_filter
-        .filter(|filter| filter.affects_tx_selection)
+        .filter(|filter| filter.affects_tx_selection || filter.has_counter_terms)
         .map(|filter| {
             crate::filter::evaluate_filter_ref_tx_selection_cached(
                 filter,
@@ -1406,17 +1409,20 @@ pub(super) fn resolve_cos_tx_selection(
         };
     };
     let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
-    let has_output_tx_selection =
-        crate::filter::filter_state_has_output_tx_selection(&forwarding.filter_state, is_v6);
+    let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
+        &forwarding.filter_state,
+        egress_ifindex,
+        is_v6,
+    );
     let has_input_tx_selection =
         crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
-    if iface.is_none() && !has_output_tx_selection && !has_input_tx_selection {
+    if iface.is_none() && !has_output_tx_eval && !has_input_tx_selection {
         return CoSTxSelection {
             queue_id: None,
             dscp_rewrite: None,
         };
     }
-    let output_filter = if has_output_tx_selection {
+    let output_filter = if has_output_tx_eval {
         if is_v6 {
             forwarding
                 .filter_state
@@ -1461,21 +1467,22 @@ pub(super) fn resolve_cos_tx_selection(
     } else {
         None
     };
-    let output_result =
-        if let Some(output_filter) = output_filter.filter(|filter| filter.affects_tx_selection) {
-            crate::filter::evaluate_filter_ref_tx_selection_counted(
-                output_filter,
-                flow_key.src_ip,
-                flow_key.dst_ip,
-                flow_key.protocol,
-                flow_key.src_port,
-                flow_key.dst_port,
-                meta.dscp,
-                meta.pkt_len as u64,
-            )
-        } else {
-            crate::filter::TxSelectionFilterResult::default()
-        };
+    let output_result = if let Some(output_filter) =
+        output_filter.filter(|filter| filter.affects_tx_selection || filter.has_counter_terms)
+    {
+        crate::filter::evaluate_filter_ref_tx_selection_counted(
+            output_filter,
+            flow_key.src_ip,
+            flow_key.dst_ip,
+            flow_key.protocol,
+            flow_key.src_port,
+            flow_key.dst_port,
+            meta.dscp,
+            meta.pkt_len as u64,
+        )
+    } else {
+        crate::filter::TxSelectionFilterResult::default()
+    };
     let mut effective_dscp_rewrite = output_result.dscp_rewrite;
     let mut ingress_forwarding_class = None;
     if let Some(ingress_filter) = ingress_filter.filter(|filter| filter.affects_tx_selection) {
@@ -4108,6 +4115,169 @@ mod tests {
         assert_eq!(cached.queue_id, Some(1));
         assert_eq!(cached.dscp_rewrite, None);
         assert!(cached.filter_counter.is_some());
+    }
+
+    #[test]
+    fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                filter_output_v4: "wan-count".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            }],
+            filters: vec![FirewallFilterSnapshot {
+                name: "wan-count".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "count-only".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "accept".into(),
+                    count: "wan-hits".into(),
+                    ..Default::default()
+                }],
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                }],
+                dscp_classifiers: vec![],
+                ieee8021_classifiers: vec![],
+                dscp_rewrite_rules: vec![],
+                schedulers: vec![CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 128_000,
+                }],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    }],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let cached = resolve_cached_cos_tx_selection(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(cached.queue_id, Some(0));
+        assert_eq!(cached.dscp_rewrite, None);
+        assert!(cached.filter_counter.is_some());
+    }
+
+    #[test]
+    fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                filter_output_v4: "wan-count".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            }],
+            filters: vec![FirewallFilterSnapshot {
+                name: "wan-count".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "count-only".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "accept".into(),
+                    count: "wan-hits".into(),
+                    ..Default::default()
+                }],
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                }],
+                dscp_classifiers: vec![],
+                ieee8021_classifiers: vec![],
+                dscp_rewrite_rules: vec![],
+                schedulers: vec![CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 128_000,
+                }],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    }],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let selection = resolve_cos_tx_selection(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                pkt_len: 1514,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(selection.queue_id, Some(0));
+        assert_eq!(selection.dscp_rewrite, None);
+
+        let filter = forwarding
+            .filter_state
+            .filters
+            .get("inet:wan-count")
+            .expect("inet output filter");
+        let term = filter.terms.first().expect("first term");
+        assert_eq!(term.counter.packets.load(Ordering::Relaxed), 1);
+        assert_eq!(term.counter.bytes.load(Ordering::Relaxed), 1514);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -489,11 +489,8 @@ fn ingest_cos_pending_tx(
                 Ok(()) => continue,
                 Err(req) => req,
             };
-            let req = match redirect_prepared_cos_request_to_owner_binding(
-                binding,
-                forwarding,
-                req,
-            ) {
+            let req = match redirect_prepared_cos_request_to_owner_binding(binding, forwarding, req)
+            {
                 Ok(()) => continue,
                 Err(req) => req,
             };
@@ -1566,79 +1563,57 @@ pub(super) fn enqueue_local_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
-    if binding
-        .cos_interfaces
-        .get(&egress_ifindex)
-        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
-    {
-        match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
-            Ok(prepared_req) => {
-                let item_len = prepared_req.len as u64;
-                match enqueue_cos_item(
-                    binding,
-                    egress_ifindex,
-                    prepared_req.cos_queue_id,
-                    item_len,
-                    CoSPendingTxItem::Prepared(prepared_req),
-                ) {
-                    Ok(()) => return Ok(()),
-                    Err(CoSPendingTxItem::Prepared(prepared_req)) => {
-                        let req =
-                            clone_prepared_request_for_cos(binding.umem.area(), &prepared_req)
-                                .expect("prepared CoS fallback clone");
-                        recycle_prepared_immediately(binding, &prepared_req);
-                        let item_len = req.bytes.len() as u64;
-                        return match enqueue_cos_item(
-                            binding,
-                            egress_ifindex,
-                            req.cos_queue_id,
-                            item_len,
-                            CoSPendingTxItem::Local(req),
-                        ) {
-                            Ok(()) => Ok(()),
-                            Err(CoSPendingTxItem::Local(req)) => Err(req),
-                            Err(CoSPendingTxItem::Prepared(_)) => {
-                                unreachable!("local request returned prepared item")
-                            }
-                        };
-                    }
-                    Err(CoSPendingTxItem::Local(_)) => {
-                        unreachable!("local request prepared into prepared item")
+    match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
+        Ok(prepared_req) => {
+            let item_len = prepared_req.len as u64;
+            match enqueue_cos_item(
+                binding,
+                egress_ifindex,
+                prepared_req.cos_queue_id,
+                item_len,
+                CoSPendingTxItem::Prepared(prepared_req),
+            ) {
+                Ok(()) => Ok(()),
+                Err(CoSPendingTxItem::Prepared(prepared_req)) => {
+                    let req = clone_prepared_request_for_cos(binding.umem.area(), &prepared_req)
+                        .expect("prepared CoS fallback clone");
+                    recycle_prepared_immediately(binding, &prepared_req);
+                    let item_len = req.bytes.len() as u64;
+                    match enqueue_cos_item(
+                        binding,
+                        egress_ifindex,
+                        req.cos_queue_id,
+                        item_len,
+                        CoSPendingTxItem::Local(req),
+                    ) {
+                        Ok(()) => Ok(()),
+                        Err(CoSPendingTxItem::Local(req)) => Err(req),
+                        Err(CoSPendingTxItem::Prepared(_)) => {
+                            unreachable!("local request returned prepared item")
+                        }
                     }
                 }
-            }
-            Err(req) => {
-                // Fall through to the local CoS path when no TX frame is
-                // available or the request cannot be materialized safely.
-                let req = req;
-                let item_len = req.bytes.len() as u64;
-                return match enqueue_cos_item(
-                    binding,
-                    egress_ifindex,
-                    req.cos_queue_id,
-                    item_len,
-                    CoSPendingTxItem::Local(req),
-                ) {
-                    Ok(()) => Ok(()),
-                    Err(CoSPendingTxItem::Local(req)) => Err(req),
-                    Err(CoSPendingTxItem::Prepared(_)) => {
-                        unreachable!("local request returned prepared item")
-                    }
-                };
+                Err(CoSPendingTxItem::Local(_)) => {
+                    unreachable!("local request prepared into prepared item")
+                }
             }
         }
-    }
-    let item_len = req.bytes.len() as u64;
-    match enqueue_cos_item(
-        binding,
-        egress_ifindex,
-        req.cos_queue_id,
-        item_len,
-        CoSPendingTxItem::Local(req),
-    ) {
-        Ok(()) => Ok(()),
-        Err(CoSPendingTxItem::Local(req)) => Err(req),
-        Err(CoSPendingTxItem::Prepared(_)) => unreachable!("local request returned prepared item"),
+        Err(req) => {
+            let item_len = req.bytes.len() as u64;
+            match enqueue_cos_item(
+                binding,
+                egress_ifindex,
+                req.cos_queue_id,
+                item_len,
+                CoSPendingTxItem::Local(req),
+            ) {
+                Ok(()) => Ok(()),
+                Err(CoSPendingTxItem::Local(req)) => Err(req),
+                Err(CoSPendingTxItem::Prepared(_)) => {
+                    unreachable!("local request returned prepared item")
+                }
+            }
+        }
     }
 }
 
@@ -1683,49 +1658,17 @@ fn enqueue_prepared_into_cos(
     if !ensure_cos_interface_runtime(binding, forwarding, egress_ifindex, now_ns) {
         return Err(req);
     }
-    if binding
-        .cos_interfaces
-        .get(&egress_ifindex)
-        .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
-    {
-        let item_len = req.len as u64;
-        match enqueue_cos_item(
-            binding,
-            egress_ifindex,
-            req.cos_queue_id,
-            item_len,
-            CoSPendingTxItem::Prepared(req),
-        ) {
-            Ok(()) => return Ok(()),
-            Err(CoSPendingTxItem::Prepared(req)) => return Err(req),
-            Err(CoSPendingTxItem::Local(_)) => unreachable!("prepared request returned local item"),
-        }
-    }
-
-    let Some(local_req) = clone_prepared_request_for_cos(binding.umem.area(), &req) else {
-        return Err(req);
-    };
-    // Keep prepared/direct frames in CoS while a queue stays prepared-only.
-    // Once any copied local item enters that queue, later prepared frames must
-    // fall back to local copies until the queue drains empty again; otherwise a
-    // local head item can block behind prepared frames that are holding every
-    // free TX frame on the owner binding.
-    let item_len = local_req.bytes.len() as u64;
+    let item_len = req.len as u64;
     match enqueue_cos_item(
         binding,
         egress_ifindex,
-        local_req.cos_queue_id,
+        req.cos_queue_id,
         item_len,
-        CoSPendingTxItem::Local(local_req),
+        CoSPendingTxItem::Prepared(req),
     ) {
-        Ok(()) => {
-            recycle_prepared_immediately(binding, &req);
-            Ok(())
-        }
-        Err(CoSPendingTxItem::Local(_)) => Err(req),
-        Err(CoSPendingTxItem::Prepared(_)) => {
-            unreachable!("prepared queueing converted to local request")
-        }
+        Ok(()) => Ok(()),
+        Err(CoSPendingTxItem::Prepared(req)) => Err(req),
+        Err(CoSPendingTxItem::Local(_)) => unreachable!("prepared request returned local item"),
     }
 }
 
@@ -1741,30 +1684,6 @@ fn clone_prepared_request_for_cos(area: &MmapArea, req: &PreparedTxRequest) -> O
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
     })
-}
-
-fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> bool {
-    if root.queues.is_empty() {
-        return false;
-    }
-    let target_queue = requested_queue.unwrap_or(root.default_queue);
-    let queue_idx = root
-        .queues
-        .iter()
-        .position(|queue| queue.queue_id == target_queue)
-        .or_else(|| {
-            root.queues
-                .iter()
-                .position(|queue| queue.queue_id == root.default_queue)
-        })
-        .unwrap_or(0);
-    let Some(queue) = root.queues.get(queue_idx) else {
-        return false;
-    };
-    !queue
-        .items
-        .iter()
-        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
 }
 
 fn ensure_cos_interface_runtime(
@@ -1987,7 +1906,10 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
         release_cos_root_lease(binding, root_ifindex);
     }
     for (queue_id, released) in released_queue_leases {
-        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+        if let Some(shared_queue_lease) = binding
+            .cos_shared_queue_leases
+            .get(&(root_ifindex, queue_id))
+        {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -2039,7 +1961,10 @@ pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
         if released == 0 {
             continue;
         }
-        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+        if let Some(shared_queue_lease) = binding
+            .cos_shared_queue_leases
+            .get(&(root_ifindex, queue_id))
+        {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -3345,7 +3270,7 @@ mod tests {
     }
 
     #[test]
-    fn cos_queue_accepts_prepared_when_queue_is_prepared_only() {
+    fn mixed_cos_queue_preserves_prepared_batches_after_local_fallback() {
         let mut root = test_cos_runtime_with_queues(
             10_000_000_000 / 8,
             vec![CoSQueueConfig {
@@ -3359,7 +3284,8 @@ mod tests {
                 dscp_rewrite: None,
             }],
         );
-        root.queues[0]
+        let queue = &mut root.queues[0];
+        queue
             .items
             .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
                 offset: 64,
@@ -3373,29 +3299,20 @@ mod tests {
                 cos_queue_id: Some(5),
                 dscp_rewrite: None,
             }));
-
-        assert!(cos_queue_accepts_prepared(&root, Some(5)));
-    }
-
-    #[test]
-    fn cos_queue_rejects_prepared_once_local_items_enter_queue() {
-        let mut root = test_cos_runtime_with_queues(
-            10_000_000_000 / 8,
-            vec![CoSQueueConfig {
-                queue_id: 5,
-                forwarding_class: "iperf-b".into(),
-                priority: 5,
-                transmit_rate_bytes: 10_000_000_000 / 8,
-                exact: true,
-                surplus_weight: 1,
-                buffer_bytes: COS_MIN_BURST_BYTES,
-                dscp_rewrite: None,
-            }],
-        );
-        root.queues[0]
+        queue.items.push_back(CoSPendingTxItem::Local(TxRequest {
+            bytes: vec![0; 1500],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET6 as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(5),
+            dscp_rewrite: None,
+        }));
+        queue
             .items
             .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
-                offset: 64,
+                offset: 128,
                 len: 1500,
                 recycle: PreparedTxRecycle::FreeTxFrame,
                 expected_ports: None,
@@ -3406,20 +3323,29 @@ mod tests {
                 cos_queue_id: Some(5),
                 dscp_rewrite: None,
             }));
-        root.queues[0]
-            .items
-            .push_back(CoSPendingTxItem::Local(TxRequest {
-                bytes: vec![0; 1500],
-                expected_ports: None,
-                expected_addr_family: libc::AF_INET6 as u8,
-                expected_protocol: PROTO_TCP,
-                flow_key: None,
-                egress_ifindex: 80,
-                cos_queue_id: Some(5),
-                dscp_rewrite: None,
-            }));
 
-        assert!(!cos_queue_accepts_prepared(&root, Some(5)));
+        let first =
+            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
+                .expect("first queue batch");
+        let second =
+            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
+                .expect("second queue batch");
+        let third =
+            build_cos_batch_from_queue(queue, 0, 64 * 1024, 64 * 1024, CoSServicePhase::Guarantee)
+                .expect("third queue batch");
+
+        match first {
+            CoSBatch::Prepared { items, .. } => assert_eq!(items.len(), 1),
+            CoSBatch::Local { .. } => panic!("first batch should stay prepared"),
+        }
+        match second {
+            CoSBatch::Local { items, .. } => assert_eq!(items.len(), 1),
+            CoSBatch::Prepared { .. } => panic!("second batch should drain the local fallback"),
+        }
+        match third {
+            CoSBatch::Prepared { items, .. } => assert_eq!(items.len(), 1),
+            CoSBatch::Local { .. } => panic!("third batch should return to prepared"),
+        }
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -489,11 +489,8 @@ fn ingest_cos_pending_tx(
                 Ok(()) => continue,
                 Err(req) => req,
             };
-            let req = match redirect_prepared_cos_request_to_owner_binding(
-                binding,
-                forwarding,
-                req,
-            ) {
+            let req = match redirect_prepared_cos_request_to_owner_binding(binding, forwarding, req)
+            {
                 Ok(()) => continue,
                 Err(req) => req,
             };
@@ -1610,6 +1607,18 @@ pub(super) fn enqueue_local_into_cos(
             Err(req) => {
                 // Fall through to the local CoS path when no TX frame is
                 // available or the request cannot be materialized safely.
+                let area = binding.umem.area();
+                let slot = binding.slot;
+                if let Some(root) = binding.cos_interfaces.get_mut(&egress_ifindex) {
+                    let _ = demote_prepared_cos_queue_to_local(
+                        area,
+                        &mut binding.free_tx_frames,
+                        &mut binding.pending_fill_frames,
+                        slot,
+                        root,
+                        req.cos_queue_id,
+                    );
+                }
                 let req = req;
                 let item_len = req.bytes.len() as u64;
                 return match enqueue_cos_item(
@@ -1743,13 +1752,12 @@ fn clone_prepared_request_for_cos(area: &MmapArea, req: &PreparedTxRequest) -> O
     })
 }
 
-fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> bool {
+fn resolve_cos_queue_idx(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> Option<usize> {
     if root.queues.is_empty() {
-        return false;
+        return None;
     }
     let target_queue = requested_queue.unwrap_or(root.default_queue);
-    let queue_idx = root
-        .queues
+    root.queues
         .iter()
         .position(|queue| queue.queue_id == target_queue)
         .or_else(|| {
@@ -1757,7 +1765,82 @@ fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Optio
                 .iter()
                 .position(|queue| queue.queue_id == root.default_queue)
         })
-        .unwrap_or(0);
+        .or(Some(0))
+}
+
+fn recycle_cancelled_prepared_offset(
+    free_tx_frames: &mut VecDeque<u64>,
+    pending_fill_frames: &mut VecDeque<u64>,
+    slot: u32,
+    recycle: PreparedTxRecycle,
+    offset: u64,
+) {
+    match recycle {
+        PreparedTxRecycle::FreeTxFrame => free_tx_frames.push_back(offset),
+        PreparedTxRecycle::FillOnSlot(fill_slot) if fill_slot == slot => {
+            pending_fill_frames.push_back(offset);
+        }
+        PreparedTxRecycle::FillOnSlot(_) => free_tx_frames.push_back(offset),
+    }
+}
+
+fn demote_prepared_cos_queue_to_local(
+    area: &MmapArea,
+    free_tx_frames: &mut VecDeque<u64>,
+    pending_fill_frames: &mut VecDeque<u64>,
+    slot: u32,
+    root: &mut CoSInterfaceRuntime,
+    requested_queue: Option<u8>,
+) -> bool {
+    let Some(queue_idx) = resolve_cos_queue_idx(root, requested_queue) else {
+        return false;
+    };
+    let Some(queue) = root.queues.get(queue_idx) else {
+        return false;
+    };
+    if !queue.exact || queue.items.is_empty() {
+        return false;
+    }
+    if queue
+        .items
+        .iter()
+        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
+    {
+        return false;
+    }
+
+    let mut local_items = VecDeque::with_capacity(queue.items.len());
+    let mut recycles = Vec::with_capacity(queue.items.len());
+    for item in queue.items.iter() {
+        let CoSPendingTxItem::Prepared(req) = item else {
+            return false;
+        };
+        let Some(local_req) = clone_prepared_request_for_cos(area, req) else {
+            return false;
+        };
+        local_items.push_back(CoSPendingTxItem::Local(local_req));
+        recycles.push((req.recycle, req.offset));
+    }
+
+    if let Some(queue) = root.queues.get_mut(queue_idx) {
+        queue.items = local_items;
+    }
+    for (recycle, offset) in recycles {
+        recycle_cancelled_prepared_offset(
+            free_tx_frames,
+            pending_fill_frames,
+            slot,
+            recycle,
+            offset,
+        );
+    }
+    true
+}
+
+fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Option<u8>) -> bool {
+    let Some(queue_idx) = resolve_cos_queue_idx(root, requested_queue) else {
+        return false;
+    };
     let Some(queue) = root.queues.get(queue_idx) else {
         return false;
     };
@@ -1987,7 +2070,10 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
         release_cos_root_lease(binding, root_ifindex);
     }
     for (queue_id, released) in released_queue_leases {
-        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+        if let Some(shared_queue_lease) = binding
+            .cos_shared_queue_leases
+            .get(&(root_ifindex, queue_id))
+        {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -2039,7 +2125,10 @@ pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
         if released == 0 {
             continue;
         }
-        if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&(root_ifindex, queue_id)) {
+        if let Some(shared_queue_lease) = binding
+            .cos_shared_queue_leases
+            .get(&(root_ifindex, queue_id))
+        {
             shared_queue_lease.release_unused(released);
         }
     }
@@ -2254,7 +2343,13 @@ fn recycle_completed_tx_offset(
 }
 
 pub(super) fn recycle_prepared_immediately(binding: &mut BindingWorker, req: &PreparedTxRequest) {
-    recycle_cancelled_prepared(binding, req);
+    recycle_cancelled_prepared_offset(
+        &mut binding.free_tx_frames,
+        &mut binding.pending_fill_frames,
+        binding.slot,
+        req.recycle,
+        req.offset,
+    );
 }
 
 fn remember_prepared_recycle(
@@ -3420,6 +3515,139 @@ mod tests {
             }));
 
         assert!(!cos_queue_accepts_prepared(&root, Some(5)));
+    }
+
+    #[test]
+    fn demote_prepared_cos_queue_to_local_recycles_frames_and_blocks_prepared_appends() {
+        let area = MmapArea::new(4096).expect("mmap");
+        unsafe { area.slice_mut_unchecked(64, 4) }
+            .expect("frame")
+            .copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        unsafe { area.slice_mut_unchecked(128, 4) }
+            .expect("frame")
+            .copy_from_slice(&[0xca, 0xfe, 0xba, 0xbe]);
+
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
+                offset: 64,
+                len: 4,
+                recycle: PreparedTxRecycle::FreeTxFrame,
+                expected_ports: Some((1111, 5202)),
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
+                offset: 128,
+                len: 4,
+                recycle: PreparedTxRecycle::FillOnSlot(7),
+                expected_ports: Some((1112, 5202)),
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+
+        let mut free_tx_frames = VecDeque::from([512]);
+        let mut pending_fill_frames = VecDeque::new();
+        assert!(demote_prepared_cos_queue_to_local(
+            &area,
+            &mut free_tx_frames,
+            &mut pending_fill_frames,
+            7,
+            &mut root,
+            Some(5),
+        ));
+
+        let items = root.queues[0]
+            .items
+            .iter()
+            .map(|item| match item {
+                CoSPendingTxItem::Local(req) => req.bytes.clone(),
+                CoSPendingTxItem::Prepared(_) => panic!("prepared item should be demoted"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            items,
+            vec![vec![0xde, 0xad, 0xbe, 0xef], vec![0xca, 0xfe, 0xba, 0xbe]]
+        );
+        assert_eq!(free_tx_frames, VecDeque::from([512, 64]));
+        assert_eq!(pending_fill_frames, VecDeque::from([128]));
+        assert!(!cos_queue_accepts_prepared(&root, Some(5)));
+    }
+
+    #[test]
+    fn demote_prepared_cos_queue_to_local_skips_non_exact_queue() {
+        let area = MmapArea::new(4096).expect("mmap");
+        unsafe { area.slice_mut_unchecked(64, 4) }
+            .expect("frame")
+            .copy_from_slice(&[1, 2, 3, 4]);
+
+        let mut root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: false,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+        root.queues[0]
+            .items
+            .push_back(CoSPendingTxItem::Prepared(PreparedTxRequest {
+                offset: 64,
+                len: 4,
+                recycle: PreparedTxRecycle::FreeTxFrame,
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET6 as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 80,
+                cos_queue_id: Some(5),
+                dscp_rewrite: None,
+            }));
+
+        let mut free_tx_frames = VecDeque::new();
+        let mut pending_fill_frames = VecDeque::new();
+        assert!(!demote_prepared_cos_queue_to_local(
+            &area,
+            &mut free_tx_frames,
+            &mut pending_fill_frames,
+            7,
+            &mut root,
+            Some(5),
+        ));
+        assert!(matches!(
+            root.queues[0].items.front(),
+            Some(CoSPendingTxItem::Prepared(_))
+        ));
+        assert!(free_tx_frames.is_empty());
+        assert!(pending_fill_frames.is_empty());
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -307,6 +307,128 @@ pub(super) struct CoSTxSelection {
     pub(super) dscp_rewrite: Option<u8>,
 }
 
+fn map_cached_forwarding_class_queue(
+    iface: &CoSInterfaceConfig,
+    forwarding_class: Option<&Arc<str>>,
+) -> Option<u8> {
+    forwarding_class.and_then(|class| iface.queue_by_forwarding_class.get(class.as_ref()).copied())
+}
+
+pub(super) fn resolve_cached_cos_tx_selection(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    meta: UserspaceDpMeta,
+    flow_key: Option<&SessionKey>,
+) -> CachedTxSelectionDescriptor {
+    let iface = forwarding.cos.interfaces.get(&egress_ifindex);
+    let Some(flow_key) = flow_key else {
+        return CachedTxSelectionDescriptor {
+            queue_id: iface.map(|iface| iface.default_queue),
+            dscp_rewrite: None,
+            filter_counter: None,
+        };
+    };
+
+    let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
+    let has_output_tx_selection =
+        crate::filter::filter_state_has_output_tx_selection(&forwarding.filter_state, is_v6);
+    let has_input_tx_selection =
+        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
+    if iface.is_none() && !has_output_tx_selection && !has_input_tx_selection {
+        return CachedTxSelectionDescriptor::default();
+    }
+    let output_filter = if has_output_tx_selection {
+        if is_v6 {
+            forwarding
+                .filter_state
+                .iface_filter_out_v6_fast
+                .get(&egress_ifindex)
+                .map(Arc::as_ref)
+        } else {
+            forwarding
+                .filter_state
+                .iface_filter_out_v4_fast
+                .get(&egress_ifindex)
+                .map(Arc::as_ref)
+        }
+    } else {
+        None
+    };
+    let output_result = output_filter
+        .filter(|filter| filter.affects_tx_selection)
+        .map(|filter| {
+            crate::filter::evaluate_filter_ref_tx_selection_cached(
+                filter,
+                flow_key.src_ip,
+                flow_key.dst_ip,
+                flow_key.protocol,
+                flow_key.src_port,
+                flow_key.dst_port,
+                meta.dscp,
+            )
+        })
+        .unwrap_or_default();
+
+    let mut effective_dscp_rewrite = output_result.dscp_rewrite;
+    let mut forwarding_class = output_result.forwarding_class.clone();
+    let mut filter_counter = output_result.counter.clone();
+
+    if output_filter.is_none() && has_input_tx_selection {
+        let ingress_ifindex = resolve_ingress_logical_ifindex(
+            forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        let ingress_filter = if is_v6 {
+            forwarding
+                .filter_state
+                .iface_filter_v6_fast
+                .get(&ingress_ifindex)
+                .map(Arc::as_ref)
+        } else {
+            forwarding
+                .filter_state
+                .iface_filter_v4_fast
+                .get(&ingress_ifindex)
+                .map(Arc::as_ref)
+        };
+        if let Some(ingress_filter) = ingress_filter.filter(|filter| filter.affects_tx_selection) {
+            let ingress_result = crate::filter::evaluate_filter_ref_tx_selection_cached(
+                ingress_filter,
+                flow_key.src_ip,
+                flow_key.dst_ip,
+                flow_key.protocol,
+                flow_key.src_port,
+                flow_key.dst_port,
+                meta.dscp,
+            );
+            effective_dscp_rewrite = effective_dscp_rewrite.or(ingress_result.dscp_rewrite);
+            forwarding_class = ingress_result.forwarding_class;
+            filter_counter = ingress_result.counter;
+        }
+    }
+
+    let queue_id = iface.and_then(|iface| {
+        map_cached_forwarding_class_queue(iface, forwarding_class.as_ref())
+            .or_else(|| resolve_cos_dscp_classifier_queue_id(iface, meta.dscp))
+            .or_else(|| {
+                resolve_cos_ieee8021_classifier_queue_id(
+                    iface,
+                    meta.ingress_pcp,
+                    meta.ingress_vlan_present != 0,
+                )
+            })
+            .or(Some(iface.default_queue))
+    });
+
+    CachedTxSelectionDescriptor {
+        queue_id,
+        dscp_rewrite: effective_dscp_rewrite,
+        filter_counter,
+    }
+}
+
 fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
     binding.outstanding_tx > 0
         || !binding.pending_tx_prepared.is_empty()
@@ -1156,7 +1278,7 @@ fn wake_due_cos_timer_slot(root: &mut CoSInterfaceRuntime) {
 pub(super) fn resolve_cos_queue_id(
     forwarding: &ForwardingState,
     egress_ifindex: i32,
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
 ) -> Option<u8> {
     resolve_cos_tx_selection(forwarding, egress_ifindex, meta, flow_key).queue_id
@@ -1165,9 +1287,18 @@ pub(super) fn resolve_cos_queue_id(
 pub(super) fn resolve_cos_tx_selection(
     forwarding: &ForwardingState,
     egress_ifindex: i32,
-    meta: UserspaceDpMeta,
+    meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
 ) -> CoSTxSelection {
+    let meta = meta.into();
+    let tx_selection_enabled = if meta.addr_family as i32 == libc::AF_INET6 {
+        forwarding.tx_selection_enabled_v6
+    } else {
+        forwarding.tx_selection_enabled_v4
+    };
+    if !tx_selection_enabled {
+        return CoSTxSelection::default();
+    }
     let iface = forwarding.cos.interfaces.get(&egress_ifindex);
     let Some(flow_key) = flow_key else {
         return CoSTxSelection {
@@ -1176,18 +1307,35 @@ pub(super) fn resolve_cos_tx_selection(
         };
     };
     let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
-    let has_output_filter = if is_v6 {
-        forwarding
-            .filter_state
-            .iface_filter_out_v6
-            .contains_key(&egress_ifindex)
+    let has_output_tx_selection =
+        crate::filter::filter_state_has_output_tx_selection(&forwarding.filter_state, is_v6);
+    let has_input_tx_selection =
+        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
+    if iface.is_none() && !has_output_tx_selection && !has_input_tx_selection {
+        return CoSTxSelection {
+            queue_id: None,
+            dscp_rewrite: None,
+        };
+    }
+    let output_filter = if has_output_tx_selection {
+        if is_v6 {
+            forwarding
+                .filter_state
+                .iface_filter_out_v6_fast
+                .get(&egress_ifindex)
+                .map(Arc::as_ref)
+        } else {
+            forwarding
+                .filter_state
+                .iface_filter_out_v4_fast
+                .get(&egress_ifindex)
+                .map(Arc::as_ref)
+        }
     } else {
-        forwarding
-            .filter_state
-            .iface_filter_out_v4
-            .contains_key(&egress_ifindex)
+        None
     };
-    let ingress_ifindex = if !has_output_filter {
+    let has_output_filter = output_filter.is_some();
+    let ingress_ifindex = if !has_output_filter && has_input_tx_selection {
         resolve_ingress_logical_ifindex(
             forwarding,
             meta.ingress_ifindex as i32,
@@ -1197,41 +1345,43 @@ pub(super) fn resolve_cos_tx_selection(
     } else {
         0
     };
-    let ingress_filter_affects_tx_selection = !has_output_filter
-        && crate::filter::interface_filter_affects_tx_selection(
-            &forwarding.filter_state,
-            ingress_ifindex,
-            is_v6,
-        );
-    if iface.is_none() && !has_output_filter && !ingress_filter_affects_tx_selection {
-        return CoSTxSelection {
-            queue_id: None,
-            dscp_rewrite: None,
-        };
-    }
-    let output_result = if has_output_filter {
-        crate::filter::evaluate_interface_output_filter_counted(
-            &forwarding.filter_state,
-            egress_ifindex,
-            is_v6,
-            flow_key.src_ip,
-            flow_key.dst_ip,
-            flow_key.protocol,
-            flow_key.src_port,
-            flow_key.dst_port,
-            meta.dscp,
-            meta.pkt_len as u64,
-        )
+    let ingress_filter = if !has_output_filter && has_input_tx_selection {
+        if is_v6 {
+            forwarding
+                .filter_state
+                .iface_filter_v6_fast
+                .get(&ingress_ifindex)
+                .map(Arc::as_ref)
+        } else {
+            forwarding
+                .filter_state
+                .iface_filter_v4_fast
+                .get(&ingress_ifindex)
+                .map(Arc::as_ref)
+        }
     } else {
-        crate::filter::FilterResult::default()
+        None
     };
+    let output_result =
+        if let Some(output_filter) = output_filter.filter(|filter| filter.affects_tx_selection) {
+            crate::filter::evaluate_filter_ref_tx_selection_counted(
+                output_filter,
+                flow_key.src_ip,
+                flow_key.dst_ip,
+                flow_key.protocol,
+                flow_key.src_port,
+                flow_key.dst_port,
+                meta.dscp,
+                meta.pkt_len as u64,
+            )
+        } else {
+            crate::filter::TxSelectionFilterResult::default()
+        };
     let mut effective_dscp_rewrite = output_result.dscp_rewrite;
-    let mut ingress_forwarding_class = Arc::<str>::from("");
-    if ingress_filter_affects_tx_selection {
-        let ingress_result = crate::filter::evaluate_interface_filter_counted(
-            &forwarding.filter_state,
-            ingress_ifindex,
-            is_v6,
+    let mut ingress_forwarding_class = None;
+    if let Some(ingress_filter) = ingress_filter.filter(|filter| filter.affects_tx_selection) {
+        let ingress_result = crate::filter::evaluate_filter_ref_tx_selection_counted(
+            ingress_filter,
             flow_key.src_ip,
             flow_key.dst_ip,
             flow_key.protocol,
@@ -1249,36 +1399,29 @@ pub(super) fn resolve_cos_tx_selection(
             dscp_rewrite: effective_dscp_rewrite,
         };
     };
-    if !output_result.forwarding_class.is_empty() {
-        if let Some(queue_id) = iface
-            .queue_by_forwarding_class
-            .get(output_result.forwarding_class.as_ref())
-        {
+    if let Some(forwarding_class) = output_result.forwarding_class {
+        if let Some(queue_id) = iface.queue_by_forwarding_class.get(forwarding_class) {
             return CoSTxSelection {
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
             };
         }
     }
-    if !ingress_forwarding_class.is_empty() {
-        if let Some(queue_id) = iface
-            .queue_by_forwarding_class
-            .get(ingress_forwarding_class.as_ref())
-        {
+    if let Some(forwarding_class) = ingress_forwarding_class {
+        if let Some(queue_id) = iface.queue_by_forwarding_class.get(forwarding_class) {
             return CoSTxSelection {
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
             };
         }
     }
-    if let Some(queue_id) = resolve_cos_dscp_classifier_queue_id(forwarding, iface, meta.dscp) {
+    if let Some(queue_id) = resolve_cos_dscp_classifier_queue_id(iface, meta.dscp) {
         return CoSTxSelection {
             queue_id: Some(queue_id),
             dscp_rewrite: effective_dscp_rewrite,
         };
     }
     if let Some(queue_id) = resolve_cos_ieee8021_classifier_queue_id(
-        forwarding,
         iface,
         meta.ingress_pcp,
         meta.ingress_vlan_present != 0,
@@ -1294,35 +1437,21 @@ pub(super) fn resolve_cos_tx_selection(
     }
 }
 
-fn resolve_cos_dscp_classifier_queue_id(
-    forwarding: &ForwardingState,
-    iface: &CoSInterfaceConfig,
-    dscp: u8,
-) -> Option<u8> {
-    if iface.dscp_classifier.is_empty() {
-        return None;
-    }
-    forwarding
-        .cos
-        .dscp_classifiers
-        .get(&iface.dscp_classifier)
-        .and_then(|classifier| classifier.queue_by_dscp.get(&dscp).copied())
+fn resolve_cos_dscp_classifier_queue_id(iface: &CoSInterfaceConfig, dscp: u8) -> Option<u8> {
+    let queue_id = iface.dscp_queue_by_dscp[usize::from(dscp & 0x3f)];
+    (queue_id != u8::MAX).then_some(queue_id)
 }
 
 fn resolve_cos_ieee8021_classifier_queue_id(
-    forwarding: &ForwardingState,
     iface: &CoSInterfaceConfig,
     pcp: u8,
     vlan_present: bool,
 ) -> Option<u8> {
-    if iface.ieee8021_classifier.is_empty() || !vlan_present {
+    if !vlan_present {
         return None;
     }
-    forwarding
-        .cos
-        .ieee8021_classifiers
-        .get(&iface.ieee8021_classifier)
-        .and_then(|classifier| classifier.queue_by_pcp.get(&pcp).copied())
+    let queue_id = iface.ieee8021_queue_by_pcp[usize::from(pcp.min(7))];
+    (queue_id != u8::MAX).then_some(queue_id)
 }
 
 pub(super) fn enqueue_local_into_cos(
@@ -2306,6 +2435,8 @@ mod tests {
                 default_queue: 4,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: Vec::new(),
             },
@@ -2355,6 +2486,8 @@ mod tests {
                 default_queue: 5,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: Vec::new(),
             },
@@ -2744,6 +2877,130 @@ mod tests {
     }
 
     #[test]
+    fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counter() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![
+                InterfaceSnapshot {
+                    name: "reth1.0".into(),
+                    ifindex: 101,
+                    parent_ifindex: 5,
+                    vlan_id: 0,
+                    hardware_addr: "02:bf:72:00:61:01".into(),
+                    filter_input_v4: "cos-classify".into(),
+                    ..Default::default()
+                },
+                InterfaceSnapshot {
+                    name: "reth0.0".into(),
+                    ifindex: 202,
+                    hardware_addr: "02:bf:72:00:80:08".into(),
+                    filter_output_v4: "wan-classify".into(),
+                    cos_shaping_rate_bytes_per_sec: 10_000_000,
+                    cos_shaping_burst_bytes: 256_000,
+                    cos_scheduler_map: "wan-map".into(),
+                    ..Default::default()
+                },
+            ],
+            filters: vec![
+                FirewallFilterSnapshot {
+                    name: "cos-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "voice".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        forwarding_class: "best-effort".into(),
+                        ..Default::default()
+                    }],
+                },
+                FirewallFilterSnapshot {
+                    name: "wan-classify".into(),
+                    family: "inet".into(),
+                    terms: vec![FirewallTermSnapshot {
+                        name: "voice".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["443".into()],
+                        action: "accept".into(),
+                        count: "wan-hits".into(),
+                        forwarding_class: "expedited-forwarding".into(),
+                        ..Default::default()
+                    }],
+                },
+            ],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![
+                    CoSForwardingClassSnapshot {
+                        name: "best-effort".into(),
+                        queue: 0,
+                    },
+                    CoSForwardingClassSnapshot {
+                        name: "expedited-forwarding".into(),
+                        queue: 1,
+                    },
+                ],
+                schedulers: vec![
+                    CoSSchedulerSnapshot {
+                        name: "be-sched".into(),
+                        transmit_rate_bytes: 4_000_000,
+                        transmit_rate_exact: false,
+                        priority: "low".into(),
+                        buffer_size_bytes: 128_000,
+                    },
+                    CoSSchedulerSnapshot {
+                        name: "ef-sched".into(),
+                        transmit_rate_bytes: 6_000_000,
+                        transmit_rate_exact: false,
+                        priority: "strict-high".into(),
+                        buffer_size_bytes: 64_000,
+                    },
+                ],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "best-effort".into(),
+                            scheduler: "be-sched".into(),
+                        },
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "expedited-forwarding".into(),
+                            scheduler: "ef-sched".into(),
+                        },
+                    ],
+                }],
+                dscp_classifiers: vec![],
+                ieee8021_classifiers: vec![],
+                dscp_rewrite_rules: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let cached = resolve_cached_cos_tx_selection(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(cached.queue_id, Some(1));
+        assert_eq!(cached.dscp_rewrite, None);
+        assert!(cached.filter_counter.is_some());
+    }
+
+    #[test]
     fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists() {
         let snapshot = ConfigSnapshot {
             interfaces: vec![
@@ -2847,6 +3104,115 @@ mod tests {
         );
 
         assert_eq!(queue_id, Some(1));
+    }
+
+    #[test]
+    fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exists() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![
+                InterfaceSnapshot {
+                    name: "reth1.0".into(),
+                    ifindex: 101,
+                    parent_ifindex: 5,
+                    vlan_id: 0,
+                    hardware_addr: "02:bf:72:00:61:01".into(),
+                    filter_input_v4: "cos-classify".into(),
+                    ..Default::default()
+                },
+                InterfaceSnapshot {
+                    name: "reth0.0".into(),
+                    ifindex: 202,
+                    hardware_addr: "02:bf:72:00:80:08".into(),
+                    cos_shaping_rate_bytes_per_sec: 10_000_000,
+                    cos_shaping_burst_bytes: 256_000,
+                    cos_scheduler_map: "wan-map".into(),
+                    ..Default::default()
+                },
+            ],
+            filters: vec![FirewallFilterSnapshot {
+                name: "cos-classify".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "voice".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "accept".into(),
+                    count: "lan-hits".into(),
+                    forwarding_class: "expedited-forwarding".into(),
+                    ..Default::default()
+                }],
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![
+                    CoSForwardingClassSnapshot {
+                        name: "best-effort".into(),
+                        queue: 0,
+                    },
+                    CoSForwardingClassSnapshot {
+                        name: "expedited-forwarding".into(),
+                        queue: 1,
+                    },
+                ],
+                dscp_classifiers: vec![],
+                ieee8021_classifiers: vec![],
+                dscp_rewrite_rules: vec![],
+                schedulers: vec![
+                    CoSSchedulerSnapshot {
+                        name: "be-sched".into(),
+                        transmit_rate_bytes: 4_000_000,
+                        transmit_rate_exact: false,
+                        priority: "low".into(),
+                        buffer_size_bytes: 128_000,
+                    },
+                    CoSSchedulerSnapshot {
+                        name: "ef-sched".into(),
+                        transmit_rate_bytes: 6_000_000,
+                        transmit_rate_exact: false,
+                        priority: "strict-high".into(),
+                        buffer_size_bytes: 64_000,
+                    },
+                ],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "best-effort".into(),
+                            scheduler: "be-sched".into(),
+                        },
+                        CoSSchedulerMapEntrySnapshot {
+                            forwarding_class: "expedited-forwarding".into(),
+                            scheduler: "ef-sched".into(),
+                        },
+                    ],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let cached = resolve_cached_cos_tx_selection(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(cached.queue_id, Some(1));
+        assert_eq!(cached.dscp_rewrite, None);
+        assert!(cached.filter_counter.is_some());
     }
 
     #[test]
@@ -3042,6 +3408,72 @@ mod tests {
         );
 
         assert_eq!(selection.queue_id, Some(7));
+        assert_eq!(selection.dscp_rewrite, None);
+        let filter = forwarding
+            .filter_state
+            .filters
+            .get("inet:sfmix-pbr")
+            .expect("filter");
+        assert_eq!(
+            filter.terms[0]
+                .counter
+                .packets
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[test]
+    fn resolve_cos_tx_selection_returns_none_when_no_cos_or_tx_selection_filters_exist() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                name: "reth1.0".into(),
+                ifindex: 101,
+                parent_ifindex: 5,
+                vlan_id: 0,
+                hardware_addr: "02:bf:72:00:61:01".into(),
+                filter_input_v4: "sfmix-pbr".into(),
+                ..Default::default()
+            }],
+            filters: vec![FirewallFilterSnapshot {
+                name: "sfmix-pbr".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "sfmix-route".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "accept".into(),
+                    count: "tx-duplicate".into(),
+                    routing_instance: "sfmix".into(),
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        };
+
+        let forwarding = build_forwarding_state(&snapshot);
+        let selection = resolve_cos_tx_selection(
+            &forwarding,
+            202,
+            UserspaceDpMeta {
+                ingress_ifindex: 5,
+                ingress_vlan_id: 0,
+                addr_family: libc::AF_INET as u8,
+                dscp: 0,
+                pkt_len: 1500,
+                ..Default::default()
+            },
+            Some(&SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+                dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+                src_port: 12345,
+                dst_port: 443,
+            }),
+        );
+
+        assert_eq!(selection.queue_id, None);
         assert_eq!(selection.dscp_rewrite, None);
         let filter = forwarding
             .filter_state
@@ -3611,6 +4043,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![CoSQueueConfig {
                     queue_id: 0,
@@ -3654,6 +4088,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues,
             },

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -92,6 +92,82 @@ const _: [(); 40] = [(); std::mem::offset_of!(UserspaceDpMeta, dscp)];
 const _: [(); 80] = [(); std::mem::offset_of!(UserspaceDpMeta, config_generation)];
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct ForwardPacketMeta {
+    pub(super) ingress_ifindex: u32,
+    pub(super) ingress_vlan_id: u16,
+    pub(super) ingress_pcp: u8,
+    pub(super) ingress_vlan_present: u8,
+    pub(super) l3_offset: u16,
+    pub(super) l4_offset: u16,
+    pub(super) payload_offset: u16,
+    pub(super) pkt_len: u16,
+    pub(super) addr_family: u8,
+    pub(super) protocol: u8,
+    pub(super) tcp_flags: u8,
+    pub(super) meta_flags: u8,
+    pub(super) dscp: u8,
+    pub(super) flow_src_port: u16,
+    pub(super) flow_dst_port: u16,
+}
+
+impl From<UserspaceDpMeta> for ForwardPacketMeta {
+    fn from(meta: UserspaceDpMeta) -> Self {
+        Self {
+            ingress_ifindex: meta.ingress_ifindex,
+            ingress_vlan_id: meta.ingress_vlan_id,
+            ingress_pcp: meta.ingress_pcp,
+            ingress_vlan_present: meta.ingress_vlan_present,
+            l3_offset: meta.l3_offset,
+            l4_offset: meta.l4_offset,
+            payload_offset: meta.payload_offset,
+            pkt_len: meta.pkt_len,
+            addr_family: meta.addr_family,
+            protocol: meta.protocol,
+            tcp_flags: meta.tcp_flags,
+            meta_flags: meta.meta_flags,
+            dscp: meta.dscp,
+            flow_src_port: meta.flow_src_port,
+            flow_dst_port: meta.flow_dst_port,
+        }
+    }
+}
+
+impl From<ForwardPacketMeta> for UserspaceDpMeta {
+    fn from(meta: ForwardPacketMeta) -> Self {
+        Self {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            ingress_ifindex: meta.ingress_ifindex,
+            rx_queue_index: 0,
+            ingress_vlan_id: meta.ingress_vlan_id,
+            ingress_pcp: meta.ingress_pcp,
+            ingress_vlan_present: meta.ingress_vlan_present,
+            ingress_zone: 0,
+            routing_table: 0,
+            l3_offset: meta.l3_offset,
+            l4_offset: meta.l4_offset,
+            payload_offset: meta.payload_offset,
+            pkt_len: meta.pkt_len,
+            addr_family: meta.addr_family,
+            protocol: meta.protocol,
+            tcp_flags: meta.tcp_flags,
+            meta_flags: meta.meta_flags,
+            dscp: meta.dscp,
+            dscp_rewrite: 0,
+            reserved: 0,
+            flow_src_port: meta.flow_src_port,
+            flow_dst_port: meta.flow_dst_port,
+            flow_src_addr: [0; 16],
+            flow_dst_addr: [0; 16],
+            config_generation: 0,
+            fib_generation: 0,
+            reserved2: 0,
+        }
+    }
+}
+#[repr(C)]
 pub(super) struct XdpOptions {
     pub(super) flags: u32,
 }
@@ -173,6 +249,8 @@ pub(super) struct ForwardingState {
     pub(super) tunnel_interfaces: FastSet<i32>,
     pub(super) filter_state: crate::filter::FilterState,
     pub(super) cos: CoSState,
+    pub(super) tx_selection_enabled_v4: bool,
+    pub(super) tx_selection_enabled_v6: bool,
     #[allow(dead_code)]
     pub(super) gre_acceleration: bool,
     pub(super) flow_export_config: Option<crate::flowexport::FlowExportConfig>,
@@ -197,6 +275,8 @@ pub(super) struct CoSInterfaceConfig {
     pub(super) default_queue: u8,
     pub(super) dscp_classifier: String,
     pub(super) ieee8021_classifier: String,
+    pub(super) dscp_queue_by_dscp: [u8; 64],
+    pub(super) ieee8021_queue_by_pcp: [u8; 8],
     pub(super) queue_by_forwarding_class: FastMap<String, u8>,
     pub(super) queues: Vec<CoSQueueConfig>,
 }
@@ -567,20 +647,30 @@ pub(super) struct TxRequest {
     pub(super) dscp_rewrite: Option<u8>,
 }
 
+pub(super) enum PendingForwardFrame {
+    Live,
+    Owned(Vec<u8>),
+    Prebuilt(Vec<u8>),
+}
+
+impl Default for PendingForwardFrame {
+    fn default() -> Self {
+        Self::Live
+    }
+}
+
 pub(super) struct PendingForwardRequest {
     pub(super) target_ifindex: i32,
     pub(super) target_binding_index: Option<usize>,
     pub(super) ingress_queue_id: u32,
-    pub(super) source_offset: u64,
     pub(super) desc: XdpDesc,
-    pub(super) source_frame: Option<Vec<u8>>,
-    pub(super) meta: UserspaceDpMeta,
+    pub(super) frame: PendingForwardFrame,
+    pub(super) meta: ForwardPacketMeta,
     pub(super) decision: SessionDecision,
     pub(super) apply_nat_on_fabric: bool,
     pub(super) expected_ports: Option<(u16, u16)>,
     pub(super) flow_key: Option<SessionKey>,
     pub(super) nat64_reverse: Option<Nat64ReverseInfo>,
-    pub(super) prebuilt_frame: Option<Vec<u8>>,
     pub(super) cos_queue_id: Option<u8>,
     pub(super) dscp_rewrite: Option<u8>,
 }

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -732,14 +732,20 @@ pub(super) struct CoSTimerWheelRuntime {
 }
 
 #[repr(align(64))]
+pub(super) struct SharedCoSQueueLease {
+    config: SharedCoSLeaseConfig,
+    state: Mutex<SharedCoSLeaseState>,
+}
+
+#[repr(align(64))]
 pub(super) struct SharedCoSRootLease {
-    config: SharedCoSRootLeaseConfig,
-    state: Mutex<SharedCoSRootLeaseState>,
+    config: SharedCoSLeaseConfig,
+    state: Mutex<SharedCoSLeaseState>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct SharedCoSRootLeaseConfig {
-    shaping_rate_bytes: u64,
+struct SharedCoSLeaseConfig {
+    rate_bytes: u64,
     burst_bytes: u64,
     lease_bytes: u64,
     max_total_leased: u64,
@@ -747,7 +753,7 @@ struct SharedCoSRootLeaseConfig {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-struct SharedCoSRootLeaseState {
+struct SharedCoSLeaseState {
     available_tokens: u64,
     outstanding_leased_tokens: u64,
     last_refill_ns: u64,
@@ -757,41 +763,157 @@ const COS_ROOT_LEASE_TARGET_US: u64 = 200;
 const COS_ROOT_LEASE_MIN_BYTES: u64 = 1500;
 const COS_ROOT_LEASE_MAX_BYTES: u64 = 512 * 1024;
 
-impl SharedCoSRootLease {
-    fn compute_config(
-        shaping_rate_bytes: u64,
-        burst_bytes: u64,
-        active_shards: usize,
-    ) -> SharedCoSRootLeaseConfig {
-        let burst_bytes = burst_bytes.max(COS_ROOT_LEASE_MIN_BYTES);
-        let active_shards = active_shards.max(1);
-        let target_lease_bytes = ((shaping_rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128)
-            / 1_000_000u128) as u64;
-        let lease_ceiling = burst_bytes
-            .saturating_div(8)
-            .min(COS_ROOT_LEASE_MAX_BYTES)
-            .max(COS_ROOT_LEASE_MIN_BYTES);
-        let lease_bytes = target_lease_bytes
-            .max(COS_ROOT_LEASE_MIN_BYTES)
-            .min(lease_ceiling);
-        let max_frame_lease_bytes = lease_bytes.max(tx_frame_capacity() as u64);
-        let max_total_leased = burst_bytes
-            .saturating_div(4)
-            .min(max_frame_lease_bytes.saturating_mul(active_shards as u64));
-        SharedCoSRootLeaseConfig {
-            shaping_rate_bytes,
-            burst_bytes,
-            lease_bytes,
-            max_total_leased,
-            active_shards,
+fn compute_shared_cos_lease_config(
+    rate_bytes: u64,
+    burst_bytes: u64,
+    active_shards: usize,
+) -> SharedCoSLeaseConfig {
+    let burst_bytes = burst_bytes.max(COS_ROOT_LEASE_MIN_BYTES);
+    let active_shards = active_shards.max(1);
+    let target_lease_bytes = ((rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128)
+        / 1_000_000u128) as u64;
+    let lease_ceiling = burst_bytes
+        .saturating_div(8)
+        .min(COS_ROOT_LEASE_MAX_BYTES)
+        .max(COS_ROOT_LEASE_MIN_BYTES);
+    let lease_bytes = target_lease_bytes
+        .max(COS_ROOT_LEASE_MIN_BYTES)
+        .min(lease_ceiling);
+    let max_frame_lease_bytes = lease_bytes.max(tx_frame_capacity() as u64);
+    let max_total_leased = burst_bytes
+        .saturating_div(4)
+        .min(max_frame_lease_bytes.saturating_mul(active_shards as u64));
+    SharedCoSLeaseConfig {
+        rate_bytes,
+        burst_bytes,
+        lease_bytes,
+        max_total_leased,
+        active_shards,
+    }
+}
+
+fn shared_cos_lease_acquire(
+    config: SharedCoSLeaseConfig,
+    state: &Mutex<SharedCoSLeaseState>,
+    now_ns: u64,
+    requested: u64,
+) -> u64 {
+    let Ok(mut state) = state.lock() else {
+        return 0;
+    };
+    refill_shared_cos_lease_locked(config, &mut state, now_ns);
+    let lease_headroom = config
+        .max_total_leased
+        .saturating_sub(state.outstanding_leased_tokens);
+    if lease_headroom == 0 || state.available_tokens == 0 {
+        return 0;
+    }
+    let granted = requested.min(state.available_tokens).min(lease_headroom);
+    state.available_tokens = state.available_tokens.saturating_sub(granted);
+    state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_add(granted);
+    granted
+}
+
+fn shared_cos_lease_consume(state: &Mutex<SharedCoSLeaseState>, bytes: u64) {
+    if bytes == 0 {
+        return;
+    }
+    if let Ok(mut state) = state.lock() {
+        state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
+    }
+}
+
+fn shared_cos_lease_release_unused(
+    config: SharedCoSLeaseConfig,
+    state: &Mutex<SharedCoSLeaseState>,
+    bytes: u64,
+) {
+    if bytes == 0 {
+        return;
+    }
+    if let Ok(mut state) = state.lock() {
+        state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
+        state.available_tokens = state
+            .available_tokens
+            .saturating_add(bytes)
+            .min(config.burst_bytes);
+    }
+}
+
+fn refill_shared_cos_lease_locked(
+    config: SharedCoSLeaseConfig,
+    state: &mut SharedCoSLeaseState,
+    now_ns: u64,
+) {
+    if config.burst_bytes == 0 {
+        return;
+    }
+    if state.last_refill_ns == 0 {
+        state.available_tokens = config.burst_bytes;
+        state.last_refill_ns = now_ns;
+        return;
+    }
+    if now_ns <= state.last_refill_ns || config.rate_bytes == 0 {
+        return;
+    }
+    let elapsed_ns = now_ns - state.last_refill_ns;
+    let added = ((elapsed_ns as u128) * (config.rate_bytes as u128) / 1_000_000_000u128) as u64;
+    if added == 0 {
+        return;
+    }
+    state.available_tokens = state
+        .available_tokens
+        .saturating_add(added)
+        .min(config.burst_bytes);
+    state.last_refill_ns = now_ns;
+}
+
+impl SharedCoSQueueLease {
+    pub(super) fn new(rate_bytes: u64, burst_bytes: u64, active_shards: usize) -> Self {
+        let config = compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards);
+        Self {
+            config,
+            state: Mutex::new(SharedCoSLeaseState {
+                available_tokens: config.burst_bytes,
+                outstanding_leased_tokens: 0,
+                last_refill_ns: 0,
+            }),
         }
     }
 
+    pub(super) fn lease_bytes(&self) -> u64 {
+        self.config.lease_bytes
+    }
+
+    pub(super) fn matches_config(
+        &self,
+        rate_bytes: u64,
+        burst_bytes: u64,
+        active_shards: usize,
+    ) -> bool {
+        self.config == compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards)
+    }
+
+    pub(super) fn acquire(&self, now_ns: u64, requested: u64) -> u64 {
+        shared_cos_lease_acquire(self.config, &self.state, now_ns, requested)
+    }
+
+    pub(super) fn consume(&self, bytes: u64) {
+        shared_cos_lease_consume(&self.state, bytes);
+    }
+
+    pub(super) fn release_unused(&self, bytes: u64) {
+        shared_cos_lease_release_unused(self.config, &self.state, bytes);
+    }
+}
+
+impl SharedCoSRootLease {
     pub(super) fn new(shaping_rate_bytes: u64, burst_bytes: u64, active_shards: usize) -> Self {
-        let config = Self::compute_config(shaping_rate_bytes, burst_bytes, active_shards);
+        let config =
+            compute_shared_cos_lease_config(shaping_rate_bytes, burst_bytes, active_shards);
         Self {
             config,
-            state: Mutex::new(SharedCoSRootLeaseState {
+            state: Mutex::new(SharedCoSLeaseState {
                 available_tokens: config.burst_bytes,
                 outstanding_leased_tokens: 0,
                 last_refill_ns: 0,
@@ -809,72 +931,20 @@ impl SharedCoSRootLease {
         burst_bytes: u64,
         active_shards: usize,
     ) -> bool {
-        self.config == Self::compute_config(shaping_rate_bytes, burst_bytes, active_shards)
+        self.config
+            == compute_shared_cos_lease_config(shaping_rate_bytes, burst_bytes, active_shards)
     }
 
     pub(super) fn acquire(&self, now_ns: u64, requested: u64) -> u64 {
-        let Ok(mut state) = self.state.lock() else {
-            return 0;
-        };
-        self.refill_locked(&mut state, now_ns);
-        let lease_headroom = self
-            .config
-            .max_total_leased
-            .saturating_sub(state.outstanding_leased_tokens);
-        if lease_headroom == 0 || state.available_tokens == 0 {
-            return 0;
-        }
-        let granted = requested.min(state.available_tokens).min(lease_headroom);
-        state.available_tokens = state.available_tokens.saturating_sub(granted);
-        state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_add(granted);
-        granted
+        shared_cos_lease_acquire(self.config, &self.state, now_ns, requested)
     }
 
     pub(super) fn consume(&self, bytes: u64) {
-        if bytes == 0 {
-            return;
-        }
-        if let Ok(mut state) = self.state.lock() {
-            state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
-        }
+        shared_cos_lease_consume(&self.state, bytes);
     }
 
     pub(super) fn release_unused(&self, bytes: u64) {
-        if bytes == 0 {
-            return;
-        }
-        if let Ok(mut state) = self.state.lock() {
-            state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
-            state.available_tokens = state
-                .available_tokens
-                .saturating_add(bytes)
-                .min(self.config.burst_bytes);
-        }
-    }
-
-    fn refill_locked(&self, state: &mut SharedCoSRootLeaseState, now_ns: u64) {
-        if self.config.burst_bytes == 0 {
-            return;
-        }
-        if state.last_refill_ns == 0 {
-            state.available_tokens = self.config.burst_bytes;
-            state.last_refill_ns = now_ns;
-            return;
-        }
-        if now_ns <= state.last_refill_ns || self.config.shaping_rate_bytes == 0 {
-            return;
-        }
-        let elapsed_ns = now_ns - state.last_refill_ns;
-        let added = ((elapsed_ns as u128) * (self.config.shaping_rate_bytes as u128)
-            / 1_000_000_000u128) as u64;
-        if added == 0 {
-            return;
-        }
-        state.available_tokens = state
-            .available_tokens
-            .saturating_add(added)
-            .min(self.config.burst_bytes);
-        state.last_refill_ns = now_ns;
+        shared_cos_lease_release_unused(self.config, &self.state, bytes);
     }
 }
 

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -823,6 +823,14 @@ fn shared_cos_lease_consume(state: &Mutex<SharedCoSLeaseState>, bytes: u64) {
     }
 }
 
+#[inline(always)]
+fn shared_cos_lease_available_cap(
+    config: SharedCoSLeaseConfig,
+    outstanding_leased_tokens: u64,
+) -> u64 {
+    config.burst_bytes.saturating_sub(outstanding_leased_tokens)
+}
+
 fn shared_cos_lease_release_unused(
     config: SharedCoSLeaseConfig,
     state: &Mutex<SharedCoSLeaseState>,
@@ -833,10 +841,14 @@ fn shared_cos_lease_release_unused(
     }
     if let Ok(mut state) = state.lock() {
         state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
-        state.available_tokens = state
-            .available_tokens
-            .saturating_add(bytes)
-            .min(config.burst_bytes);
+        state.available_tokens =
+            state
+                .available_tokens
+                .saturating_add(bytes)
+                .min(shared_cos_lease_available_cap(
+                    config,
+                    state.outstanding_leased_tokens,
+                ));
     }
 }
 
@@ -849,7 +861,8 @@ fn refill_shared_cos_lease_locked(
         return;
     }
     if state.last_refill_ns == 0 {
-        state.available_tokens = config.burst_bytes;
+        state.available_tokens =
+            shared_cos_lease_available_cap(config, state.outstanding_leased_tokens);
         state.last_refill_ns = now_ns;
         return;
     }
@@ -861,10 +874,14 @@ fn refill_shared_cos_lease_locked(
     if added == 0 {
         return;
     }
-    state.available_tokens = state
-        .available_tokens
-        .saturating_add(added)
-        .min(config.burst_bytes);
+    state.available_tokens =
+        state
+            .available_tokens
+            .saturating_add(added)
+            .min(shared_cos_lease_available_cap(
+                config,
+                state.outstanding_leased_tokens,
+            ));
     state.last_refill_ns = now_ns;
 }
 
@@ -945,6 +962,45 @@ impl SharedCoSRootLease {
 
     pub(super) fn release_unused(&self, bytes: u64) {
         shared_cos_lease_release_unused(self.config, &self.state, bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_cos_root_lease_refill_respects_outstanding_burst_credit() {
+        let lease = SharedCoSRootLease::new(10_000_000, 16_000, 1);
+        let mut state = lease.state.lock().unwrap();
+        state.available_tokens = 0;
+        state.outstanding_leased_tokens = 4_000;
+        state.last_refill_ns = 1;
+
+        refill_shared_cos_lease_locked(lease.config, &mut state, 1_000_000_001);
+
+        assert_eq!(
+            state.available_tokens,
+            lease.config.burst_bytes - state.outstanding_leased_tokens
+        );
+    }
+
+    #[test]
+    fn shared_cos_root_lease_release_unused_preserves_total_burst_bound() {
+        let lease = SharedCoSRootLease::new(10_000_000, 16_000, 1);
+        {
+            let mut state = lease.state.lock().unwrap();
+            state.available_tokens = lease.config.burst_bytes;
+            state.outstanding_leased_tokens = 4_000;
+        }
+
+        lease.release_unused(1_500);
+
+        let state = lease.state.lock().unwrap();
+        assert_eq!(
+            state.available_tokens + state.outstanding_leased_tokens,
+            lease.config.burst_bytes
+        );
     }
 }
 

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -260,7 +260,7 @@ pub(super) struct ForwardingState {
     pub(super) tcp_mss_gre_out: u16,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct CoSState {
     pub(super) interfaces: FastMap<i32, CoSInterfaceConfig>,
     pub(super) dscp_classifiers: FastMap<String, CoSDSCPClassifierConfig>,
@@ -268,7 +268,7 @@ pub(super) struct CoSState {
     pub(super) dscp_rewrite_rules: FastMap<String, CoSDSCPRewriteRuleConfig>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct CoSInterfaceConfig {
     pub(super) shaping_rate_bytes: u64,
     pub(super) burst_bytes: u64,
@@ -281,22 +281,22 @@ pub(super) struct CoSInterfaceConfig {
     pub(super) queues: Vec<CoSQueueConfig>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct CoSDSCPClassifierConfig {
     pub(super) queue_by_dscp: FastMap<u8, u8>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct CoSIEEE8021ClassifierConfig {
     pub(super) queue_by_pcp: FastMap<u8, u8>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct CoSDSCPRewriteRuleConfig {
     pub(super) dscp_by_forwarding_class: FastMap<String, u8>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct CoSQueueConfig {
     pub(super) queue_id: u8,
     pub(super) forwarding_class: String,
@@ -753,9 +753,9 @@ struct SharedCoSRootLeaseState {
     last_refill_ns: u64,
 }
 
-const COS_ROOT_LEASE_TARGET_US: u64 = 25;
+const COS_ROOT_LEASE_TARGET_US: u64 = 200;
 const COS_ROOT_LEASE_MIN_BYTES: u64 = 1500;
-const COS_ROOT_LEASE_MAX_BYTES: u64 = 64 * 1024;
+const COS_ROOT_LEASE_MAX_BYTES: u64 = 512 * 1024;
 
 impl SharedCoSRootLease {
     fn compute_config(

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -770,8 +770,8 @@ fn compute_shared_cos_lease_config(
 ) -> SharedCoSLeaseConfig {
     let burst_bytes = burst_bytes.max(COS_ROOT_LEASE_MIN_BYTES);
     let active_shards = active_shards.max(1);
-    let target_lease_bytes = ((rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128)
-        / 1_000_000u128) as u64;
+    let target_lease_bytes =
+        ((rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128) / 1_000_000u128) as u64;
     let lease_ceiling = burst_bytes
         .saturating_div(8)
         .min(COS_ROOT_LEASE_MAX_BYTES)

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1363,6 +1363,7 @@ pub(crate) fn worker_loop(
             }
         }
     }
+    crate::filter::flush_recorded_filter_counters();
     for binding in bindings.iter_mut() {
         release_all_cos_root_leases(binding);
         release_all_cos_queue_leases(binding);

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -761,6 +761,7 @@ pub(crate) fn worker_loop(
                 did_work = true;
             }
         }
+        crate::filter::flush_recorded_filter_counters();
         dbg_rx_total += dbg_poll.rx;
         #[cfg(feature = "debug-log")]
         {
@@ -1536,6 +1537,8 @@ mod tests {
                 default_queue: 0,
                 dscp_classifier: String::new(),
                 ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
                 queue_by_forwarding_class: FastMap::default(),
                 queues: vec![CoSQueueConfig {
                     queue_id: 4,

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -19,6 +19,7 @@ pub(crate) struct BindingWorker {
     pub(crate) max_pending_tx: usize,
     pub(crate) cos_owner_live_by_tx_ifindex: BTreeMap<i32, Arc<BindingLiveState>>,
     pub(crate) cos_shared_root_leases: BTreeMap<i32, Arc<SharedCoSRootLease>>,
+    pub(crate) cos_shared_queue_leases: BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
     pub(crate) cos_interfaces: FastMap<i32, CoSInterfaceRuntime>,
     pub(crate) cos_interface_order: Vec<i32>,
     pub(crate) cos_interface_rr: usize,
@@ -295,6 +296,7 @@ impl BindingWorker {
             max_pending_tx,
             cos_owner_live_by_tx_ifindex: BTreeMap::new(),
             cos_shared_root_leases: BTreeMap::new(),
+            cos_shared_queue_leases: BTreeMap::new(),
             cos_interfaces: FastMap::default(),
             cos_interface_order: Vec::new(),
             cos_interface_rr: 0,
@@ -407,6 +409,7 @@ pub(crate) fn worker_loop(
     shared_cos_owner_worker_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), u32>>>,
     shared_cos_owner_live_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
+    shared_cos_queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
 ) {
     pin_current_thread(worker_id);
@@ -418,6 +421,7 @@ pub(crate) fn worker_loop(
     let mut cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
     let mut cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
     let mut cos_shared_root_leases = shared_cos_root_leases.load_full();
+    let mut cos_shared_queue_leases = shared_cos_queue_leases.load_full();
     let mut sessions = SessionTable::new();
     let mut screen_state = ScreenState::new();
     screen_state.update_profiles(forwarding.screen_profiles.clone());
@@ -464,6 +468,7 @@ pub(crate) fn worker_loop(
     for binding in bindings.iter_mut() {
         binding.cos_owner_live_by_tx_ifindex = cos_owner_live_by_tx_ifindex.clone();
         binding.cos_shared_root_leases = cos_shared_root_leases.as_ref().clone();
+        binding.cos_shared_queue_leases = cos_shared_queue_leases.as_ref().clone();
     }
     let mut interrupt_poll_fds = if poll_mode == crate::PollMode::Interrupt {
         bindings
@@ -622,10 +627,21 @@ pub(crate) fn worker_loop(
         if !Arc::ptr_eq(&cos_shared_root_leases, &live_cos_shared_root_leases) {
             for binding in bindings.iter_mut() {
                 release_all_cos_root_leases(binding);
+                release_all_cos_queue_leases(binding);
             }
             cos_shared_root_leases = live_cos_shared_root_leases;
             for binding in bindings.iter_mut() {
                 binding.cos_shared_root_leases = cos_shared_root_leases.as_ref().clone();
+            }
+        }
+        let live_cos_shared_queue_leases = shared_cos_queue_leases.load_full();
+        if !Arc::ptr_eq(&cos_shared_queue_leases, &live_cos_shared_queue_leases) {
+            for binding in bindings.iter_mut() {
+                release_all_cos_queue_leases(binding);
+            }
+            cos_shared_queue_leases = live_cos_shared_queue_leases;
+            for binding in bindings.iter_mut() {
+                binding.cos_shared_queue_leases = cos_shared_queue_leases.as_ref().clone();
             }
         }
         let ha_runtime = ha_state.load();
@@ -1349,6 +1365,7 @@ pub(crate) fn worker_loop(
     }
     for binding in bindings.iter_mut() {
         release_all_cos_root_leases(binding);
+        release_all_cos_queue_leases(binding);
     }
     cos_status.store(Arc::new(build_worker_cos_statuses(
         &bindings,
@@ -1418,6 +1435,8 @@ fn cos_runtime_config_changed(current: &ForwardingState, next: &ForwardingState)
 }
 
 fn reset_binding_cos_runtime(binding: &mut BindingWorker) {
+    release_all_cos_root_leases(binding);
+    release_all_cos_queue_leases(binding);
     let mut dropped_local = 0u64;
     let mut dropped_prepared = Vec::new();
     for root in binding.cos_interfaces.values_mut() {

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -405,6 +405,7 @@ pub(crate) fn worker_loop(
     event_stream: Option<crate::event_stream::EventStreamWorkerHandle>,
     rg_epochs: Arc<[AtomicU32; MAX_RG_EPOCHS]>,
     shared_cos_owner_worker_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), u32>>>,
+    shared_cos_owner_live_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
 ) {
@@ -415,6 +416,7 @@ pub(crate) fn worker_loop(
     let mut validation = **shared_validation.load();
     let mut forwarding = shared_forwarding.load_full();
     let mut cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
+    let mut cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
     let mut cos_shared_root_leases = shared_cos_root_leases.load_full();
     let mut sessions = SessionTable::new();
     let mut screen_state = ScreenState::new();
@@ -599,13 +601,22 @@ pub(crate) fn worker_loop(
         }
         let live_forwarding = shared_forwarding.load_full();
         if !Arc::ptr_eq(&forwarding, &live_forwarding) {
+            let cos_changed =
+                cos_runtime_config_changed(forwarding.as_ref(), live_forwarding.as_ref());
             forwarding = live_forwarding;
             screen_state.update_profiles(forwarding.screen_profiles.clone());
             sessions.set_timeouts(forwarding.session_timeouts);
+            if cos_changed {
+                reset_worker_cos_runtimes(&mut bindings);
+            }
         }
         let live_cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
         if !Arc::ptr_eq(&cos_owner_worker_by_queue, &live_cos_owner_worker_by_queue) {
             cos_owner_worker_by_queue = live_cos_owner_worker_by_queue;
+        }
+        let live_cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
+        if !Arc::ptr_eq(&cos_owner_live_by_queue, &live_cos_owner_live_by_queue) {
+            cos_owner_live_by_queue = live_cos_owner_live_by_queue;
         }
         let live_cos_shared_root_leases = shared_cos_root_leases.load_full();
         if !Arc::ptr_eq(&cos_shared_root_leases, &live_cos_shared_root_leases) {
@@ -649,6 +660,7 @@ pub(crate) fn worker_loop(
                 &mut bindings,
                 forwarding.as_ref(),
                 loop_now_ns,
+                cos_owner_live_by_queue.as_ref(),
                 shaped_tx_requests,
             );
         }
@@ -757,6 +769,7 @@ pub(crate) fn worker_loop(
                 &mut dbg_poll,
                 &rg_epochs,
                 cos_owner_worker_by_queue.as_ref(),
+                cos_owner_live_by_queue.as_ref(),
             ) {
                 did_work = true;
             }
@@ -1348,6 +1361,7 @@ fn apply_worker_shaped_tx_requests(
     bindings: &mut [BindingWorker],
     forwarding: &ForwardingState,
     now_ns: u64,
+    _cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
     requests: Vec<TxRequest>,
 ) {
     for req in requests {
@@ -1397,6 +1411,54 @@ fn build_worker_cos_statuses(
         bindings.iter().map(|binding| &binding.cos_interfaces),
         forwarding,
     )
+}
+
+fn cos_runtime_config_changed(current: &ForwardingState, next: &ForwardingState) -> bool {
+    current.cos != next.cos
+}
+
+fn reset_binding_cos_runtime(binding: &mut BindingWorker) {
+    let mut dropped_local = 0u64;
+    let mut dropped_prepared = Vec::new();
+    for root in binding.cos_interfaces.values_mut() {
+        for queue in &mut root.queues {
+            while let Some(item) = queue.items.pop_front() {
+                match item {
+                    CoSPendingTxItem::Local(_) => {
+                        dropped_local = dropped_local.saturating_add(1);
+                    }
+                    CoSPendingTxItem::Prepared(req) => dropped_prepared.push(req),
+                }
+            }
+            queue.queued_bytes = 0;
+            queue.runnable = false;
+            queue.parked = false;
+            queue.next_wakeup_tick = 0;
+        }
+        root.nonempty_queues = 0;
+        root.runnable_queues = 0;
+    }
+    binding.cos_interfaces.clear();
+    binding.cos_interface_order.clear();
+    binding.cos_interface_rr = 0;
+    binding.cos_nonempty_interfaces = 0;
+
+    let dropped_total = dropped_local.saturating_add(dropped_prepared.len() as u64);
+    if dropped_total > 0 {
+        binding
+            .live
+            .tx_errors
+            .fetch_add(dropped_total, Ordering::Relaxed);
+    }
+    for req in dropped_prepared {
+        recycle_prepared_immediately(binding, &req);
+    }
+}
+
+fn reset_worker_cos_runtimes(bindings: &mut [BindingWorker]) {
+    for binding in bindings {
+        reset_binding_cos_runtime(binding);
+    }
 }
 
 fn build_worker_cos_statuses_from_maps<'a, I>(
@@ -1628,6 +1690,43 @@ mod tests {
 
         assert!(Arc::ptr_eq(owners.get(&12).unwrap(), &live_a));
         assert!(Arc::ptr_eq(owners.get(&13).unwrap(), &live_c));
+    }
+
+    #[test]
+    fn cos_runtime_config_changed_detects_queue_rate_change() {
+        let iface = CoSInterfaceConfig {
+            shaping_rate_bytes: 1_250_000_000,
+            burst_bytes: 1_000_000,
+            default_queue: 0,
+            dscp_classifier: String::new(),
+            ieee8021_classifier: String::new(),
+            dscp_queue_by_dscp: [u8::MAX; 64],
+            ieee8021_queue_by_pcp: [u8::MAX; 8],
+            queue_by_forwarding_class: [("iperf-b".to_string(), 5)].into_iter().collect(),
+            queues: vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_250_000_000,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 1_000_000,
+                dscp_rewrite: None,
+            }],
+        };
+        let mut current = ForwardingState::default();
+        current.cos.interfaces.insert(12, iface.clone());
+
+        let mut next = current.clone();
+        next.cos
+            .interfaces
+            .get_mut(&12)
+            .expect("cos interface")
+            .queues[0]
+            .transmit_rate_bytes = 1_875_000_000;
+
+        assert!(cos_runtime_config_changed(&current, &next));
+        assert!(!cos_runtime_config_changed(&current, &current));
     }
 }
 

--- a/userspace-dp/src/filter.rs
+++ b/userspace-dp/src/filter.rs
@@ -10,6 +10,8 @@
 
 use crate::prefix::{PrefixV4, PrefixV6};
 use ipnet::IpNet;
+#[cfg(not(test))]
+use std::cell::RefCell;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -42,12 +44,15 @@ pub(crate) struct FilterTerm {
     pub(crate) source_v6: Vec<PrefixV6>,
     pub(crate) dest_v4: Vec<PrefixV4>,
     pub(crate) dest_v6: Vec<PrefixV6>,
-    pub(crate) protocols: Vec<u8>,
-    pub(crate) source_ports: Vec<PortRange>,
-    pub(crate) dest_ports: Vec<PortRange>,
-    pub(crate) dscp_values: Vec<u8>,
+    pub(crate) protocol_bitmap: [u64; 4],
+    pub(crate) protocol_match_enabled: bool,
+    pub(crate) source_ports: PortMatcher,
+    pub(crate) dest_ports: PortMatcher,
+    pub(crate) dscp_bitmap: u64,
+    pub(crate) dscp_match_enabled: bool,
     pub(crate) action: FilterAction,
     pub(crate) count: String,
+    pub(crate) has_count: bool,
     pub(crate) log: bool,
     pub(crate) policer_name: String,
     pub(crate) routing_instance: String,
@@ -63,6 +68,28 @@ pub(crate) struct PortRange {
     pub(crate) high: u16,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PortMatcher {
+    Any,
+    Single(u16),
+    Range(PortRange),
+    Set(Box<[PortRange]>),
+}
+
+impl PortMatcher {
+    #[inline(always)]
+    fn matches(&self, port: u16) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Single(expected) => port == *expected,
+            Self::Range(range) => port >= range.low && port <= range.high,
+            Self::Set(ranges) => ranges
+                .iter()
+                .any(|range| port >= range.low && port <= range.high),
+        }
+    }
+}
+
 /// A compiled firewall filter (ordered list of terms).
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
@@ -71,6 +98,8 @@ pub(crate) struct Filter {
     pub(crate) family: String,
     pub(crate) terms: Vec<FilterTerm>,
     pub(crate) affects_tx_selection: bool,
+    pub(crate) affects_route_lookup: bool,
+    pub(crate) has_counter_terms: bool,
 }
 
 #[derive(Debug, Default)]
@@ -80,11 +109,80 @@ pub(crate) struct FilterTermCounter {
 }
 
 impl FilterTermCounter {
-    fn record(&self, packet_bytes: u64) {
+    pub(crate) fn record(&self, packet_bytes: u64) {
         self.packets.fetch_add(1, Ordering::Relaxed);
         self.bytes.fetch_add(packet_bytes, Ordering::Relaxed);
     }
 }
+
+#[cfg(not(test))]
+#[derive(Default)]
+struct PendingFilterCounterRecord {
+    counter: Option<Arc<FilterTermCounter>>,
+    packets: u64,
+    bytes: u64,
+}
+
+#[cfg(not(test))]
+const FILTER_COUNTER_FLUSH_PACKETS: u64 = 64;
+
+#[cfg(not(test))]
+thread_local! {
+    static PENDING_FILTER_COUNTER_RECORD: RefCell<PendingFilterCounterRecord> =
+        RefCell::new(PendingFilterCounterRecord::default());
+}
+
+#[cfg(not(test))]
+#[inline(always)]
+fn flush_pending_filter_counter_record(record: &mut PendingFilterCounterRecord) {
+    let Some(counter) = record.counter.take() else {
+        return;
+    };
+    counter.packets.fetch_add(record.packets, Ordering::Relaxed);
+    counter.bytes.fetch_add(record.bytes, Ordering::Relaxed);
+    record.packets = 0;
+    record.bytes = 0;
+}
+
+#[cfg(not(test))]
+#[inline(always)]
+pub(crate) fn record_filter_counter(counter: &Arc<FilterTermCounter>, packet_bytes: u64) {
+    PENDING_FILTER_COUNTER_RECORD.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending
+            .counter
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, counter))
+        {
+            pending.packets = pending.packets.saturating_add(1);
+            pending.bytes = pending.bytes.saturating_add(packet_bytes);
+        } else {
+            flush_pending_filter_counter_record(&mut pending);
+            pending.counter = Some(counter.clone());
+            pending.packets = 1;
+            pending.bytes = packet_bytes;
+        }
+        if pending.packets >= FILTER_COUNTER_FLUSH_PACKETS {
+            flush_pending_filter_counter_record(&mut pending);
+        }
+    });
+}
+
+#[cfg(test)]
+#[inline(always)]
+pub(crate) fn record_filter_counter(counter: &Arc<FilterTermCounter>, packet_bytes: u64) {
+    counter.record(packet_bytes);
+}
+
+#[cfg(not(test))]
+pub(crate) fn flush_recorded_filter_counters() {
+    PENDING_FILTER_COUNTER_RECORD.with(|pending| {
+        flush_pending_filter_counter_record(&mut pending.borrow_mut());
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn flush_recorded_filter_counters() {}
 
 /// Token-bucket policer state.
 #[allow(dead_code)]
@@ -155,25 +253,53 @@ impl PolicerState {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct FilterState {
     /// Named filters keyed by "family:name" (e.g. "inet:protect-RE").
-    pub(crate) filters: rustc_hash::FxHashMap<String, Filter>,
+    pub(crate) filters: rustc_hash::FxHashMap<String, Arc<Filter>>,
     /// Named policer states keyed by policer name.
     pub(crate) policers: rustc_hash::FxHashMap<String, PolicerState>,
     /// Per-interface (ifindex) input filter key for inet.
     pub(crate) iface_filter_v4: rustc_hash::FxHashMap<i32, String>,
+    /// Direct per-interface inet filter reference for packet hot-path evaluation.
+    pub(crate) iface_filter_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
     /// Per-interface inet input filters that can affect CoS TX selection.
     pub(crate) iface_filter_v4_affects_tx_selection: rustc_hash::FxHashSet<i32>,
+    /// Whether any inet input filter can affect CoS TX selection.
+    pub(crate) has_input_tx_selection_v4: bool,
+    /// Per-interface inet input filters that can affect route-table selection.
+    pub(crate) iface_filter_v4_affects_route_lookup: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) input filter key for inet6.
     pub(crate) iface_filter_v6: rustc_hash::FxHashMap<i32, String>,
+    /// Direct per-interface inet6 filter reference for packet hot-path evaluation.
+    pub(crate) iface_filter_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
     /// Per-interface inet6 input filters that can affect CoS TX selection.
     pub(crate) iface_filter_v6_affects_tx_selection: rustc_hash::FxHashSet<i32>,
+    /// Whether any inet6 input filter can affect CoS TX selection.
+    pub(crate) has_input_tx_selection_v6: bool,
+    /// Per-interface inet6 input filters that can affect route-table selection.
+    pub(crate) iface_filter_v6_affects_route_lookup: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) output filter key for inet.
     pub(crate) iface_filter_out_v4: rustc_hash::FxHashMap<i32, String>,
+    /// Direct per-interface inet output filter reference for packet hot-path evaluation.
+    pub(crate) iface_filter_out_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
+    /// Per-interface inet output filters that must still be evaluated in the TX path.
+    pub(crate) iface_filter_out_v4_needs_tx_eval: rustc_hash::FxHashSet<i32>,
+    /// Whether any inet output filter can affect CoS TX selection.
+    pub(crate) has_output_tx_selection_v4: bool,
     /// Per-interface (ifindex) output filter key for inet6.
     pub(crate) iface_filter_out_v6: rustc_hash::FxHashMap<i32, String>,
+    /// Direct per-interface inet6 output filter reference for packet hot-path evaluation.
+    pub(crate) iface_filter_out_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
+    /// Per-interface inet6 output filters that must still be evaluated in the TX path.
+    pub(crate) iface_filter_out_v6_needs_tx_eval: rustc_hash::FxHashSet<i32>,
+    /// Whether any inet6 output filter can affect CoS TX selection.
+    pub(crate) has_output_tx_selection_v6: bool,
     /// lo0 inet input filter key.
     pub(crate) lo0_filter_v4: String,
+    /// Direct lo0 inet filter reference for packet hot-path evaluation.
+    pub(crate) lo0_filter_v4_fast: Option<Arc<Filter>>,
     /// lo0 inet6 input filter key.
     pub(crate) lo0_filter_v6: String,
+    /// Direct lo0 inet6 filter reference for packet hot-path evaluation.
+    pub(crate) lo0_filter_v6_fast: Option<Arc<Filter>>,
 }
 
 /// Result of filter evaluation.
@@ -185,6 +311,19 @@ pub(crate) struct FilterResult {
     pub(crate) routing_instance: String,
     pub(crate) forwarding_class: Arc<str>,
     pub(crate) log: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TxSelectionFilterResult<'a> {
+    pub(crate) forwarding_class: Option<&'a str>,
+    pub(crate) dscp_rewrite: Option<u8>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CachedTxSelectionFilterResult {
+    pub(crate) forwarding_class: Option<Arc<str>>,
+    pub(crate) dscp_rewrite: Option<u8>,
+    pub(crate) counter: Option<Arc<FilterTermCounter>>,
 }
 
 impl Default for FilterResult {
@@ -231,12 +370,127 @@ pub(crate) fn evaluate_filter_counted(
     let Some(filter) = state.filters.get(filter_key) else {
         return FilterResult::default();
     };
+    evaluate_filter_ref_counted(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        packet_bytes,
+    )
+}
+
+#[inline]
+fn evaluate_filter_ref_counted(
+    filter: &Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> FilterResult {
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_counted_v4(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_counted_v6(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        _ => FilterResult::default(),
+    }
+}
+
+#[inline]
+pub(crate) fn evaluate_filter_ref_tx_selection_counted<'a>(
+    filter: &'a Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_tx_selection_counted_v4(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_tx_selection_counted_v6(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        _ => TxSelectionFilterResult::default(),
+    }
+}
+
+pub(crate) fn evaluate_filter_ref_tx_selection_cached(
+    filter: &Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> CachedTxSelectionFilterResult {
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_tx_selection_cached_v4(
+            filter, src, dst, protocol, src_port, dst_port, dscp,
+        ),
+        (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_tx_selection_cached_v6(
+            filter, src, dst, protocol, src_port, dst_port, dscp,
+        ),
+        _ => CachedTxSelectionFilterResult::default(),
+    }
+}
+
+#[inline]
+fn evaluate_filter_ref_counted_v4(
+    filter: &Filter,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> FilterResult {
     for term in &filter.terms {
-        if !term_matches(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
             continue;
         }
-        if !term.count.is_empty() {
-            term.counter.record(packet_bytes);
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
         }
         return FilterResult {
             action: term.action.clone(),
@@ -247,8 +501,183 @@ pub(crate) fn evaluate_filter_counted(
             log: term.log,
         };
     }
-    // No matching term — implicit accept
     FilterResult::default()
+}
+
+#[inline]
+fn evaluate_filter_ref_counted_v6(
+    filter: &Filter,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> FilterResult {
+    for term in &filter.terms {
+        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        return FilterResult {
+            action: term.action.clone(),
+            dscp_rewrite: term.dscp_rewrite,
+            policer_name: term.policer_name.clone(),
+            routing_instance: term.routing_instance.clone(),
+            forwarding_class: term.forwarding_class.clone(),
+            log: term.log,
+        };
+    }
+    FilterResult::default()
+}
+
+#[inline]
+fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
+    filter: &'a Filter,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    for term in &filter.terms {
+        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        return TxSelectionFilterResult {
+            forwarding_class: (!term.forwarding_class.is_empty())
+                .then_some(term.forwarding_class.as_ref()),
+            dscp_rewrite: term.dscp_rewrite,
+        };
+    }
+    TxSelectionFilterResult::default()
+}
+
+#[inline]
+fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
+    filter: &'a Filter,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    for term in &filter.terms {
+        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        return TxSelectionFilterResult {
+            forwarding_class: (!term.forwarding_class.is_empty())
+                .then_some(term.forwarding_class.as_ref()),
+            dscp_rewrite: term.dscp_rewrite,
+        };
+    }
+    TxSelectionFilterResult::default()
+}
+
+fn evaluate_filter_ref_tx_selection_cached_v4(
+    filter: &Filter,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> CachedTxSelectionFilterResult {
+    for term in &filter.terms {
+        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        return CachedTxSelectionFilterResult {
+            forwarding_class: (!term.forwarding_class.is_empty())
+                .then(|| term.forwarding_class.clone()),
+            dscp_rewrite: term.dscp_rewrite,
+            counter: term.has_count.then(|| term.counter.clone()),
+        };
+    }
+    CachedTxSelectionFilterResult::default()
+}
+
+fn evaluate_filter_ref_tx_selection_cached_v6(
+    filter: &Filter,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> CachedTxSelectionFilterResult {
+    for term in &filter.terms {
+        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        return CachedTxSelectionFilterResult {
+            forwarding_class: (!term.forwarding_class.is_empty())
+                .then(|| term.forwarding_class.clone()),
+            dscp_rewrite: term.dscp_rewrite,
+            counter: term.has_count.then(|| term.counter.clone()),
+        };
+    }
+    CachedTxSelectionFilterResult::default()
+}
+
+#[inline]
+fn evaluate_filter_ref_routing_instance_counted_v4<'a>(
+    filter: &'a Filter,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> Option<&'a str> {
+    for term in &filter.terms {
+        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        return (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str());
+    }
+    None
+}
+
+#[inline]
+fn evaluate_filter_ref_routing_instance_counted_v6<'a>(
+    filter: &'a Filter,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> Option<&'a str> {
+    for term in &filter.terms {
+        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        return (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str());
+    }
+    None
 }
 
 /// Evaluate the lo0 (host-bound) filter for a given address family.
@@ -279,17 +708,16 @@ pub(crate) fn evaluate_lo0_filter_counted(
     dscp: u8,
     packet_bytes: u64,
 ) -> FilterResult {
-    let filter_name = if is_v6 {
-        &state.lo0_filter_v6
+    let filter = if is_v6 {
+        state.lo0_filter_v6_fast.as_deref()
     } else {
-        &state.lo0_filter_v4
+        state.lo0_filter_v4_fast.as_deref()
     };
-    if filter_name.is_empty() {
+    let Some(filter) = filter else {
         return FilterResult::default();
-    }
-    evaluate_filter_counted(
-        state,
-        filter_name,
+    };
+    evaluate_filter_ref_counted(
+        filter,
         src_ip,
         dst_ip,
         protocol,
@@ -329,20 +757,16 @@ pub(crate) fn evaluate_interface_filter_counted(
     dscp: u8,
     packet_bytes: u64,
 ) -> FilterResult {
-    let filter_name = if is_v6 {
-        state.iface_filter_v6.get(&ifindex)
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex).map(Arc::as_ref)
     } else {
-        state.iface_filter_v4.get(&ifindex)
+        state.iface_filter_v4_fast.get(&ifindex).map(Arc::as_ref)
     };
-    let Some(filter_name) = filter_name else {
+    let Some(filter) = filter else {
         return FilterResult::default();
     };
-    if filter_name.is_empty() {
-        return FilterResult::default();
-    }
-    evaluate_filter_counted(
-        state,
-        filter_name,
+    evaluate_filter_ref_counted(
+        filter,
         src_ip,
         dst_ip,
         protocol,
@@ -351,6 +775,83 @@ pub(crate) fn evaluate_interface_filter_counted(
         dscp,
         packet_bytes,
     )
+}
+
+pub(crate) fn evaluate_interface_filter_tx_selection_counted<'a>(
+    state: &'a FilterState,
+    ifindex: i32,
+    is_v6: bool,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex).map(Arc::as_ref)
+    } else {
+        state.iface_filter_v4_fast.get(&ifindex).map(Arc::as_ref)
+    };
+    let Some(filter) = filter else {
+        return TxSelectionFilterResult::default();
+    };
+    evaluate_filter_ref_tx_selection_counted(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        packet_bytes,
+    )
+}
+
+pub(crate) fn evaluate_interface_filter_routing_instance_counted<'a>(
+    state: &'a FilterState,
+    ifindex: i32,
+    is_v6: bool,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> Option<&'a str> {
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex).map(Arc::as_ref)
+    } else {
+        state.iface_filter_v4_fast.get(&ifindex).map(Arc::as_ref)
+    };
+    let Some(filter) = filter else {
+        return None;
+    };
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_routing_instance_counted_v4(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_routing_instance_counted_v6(
+            filter,
+            src,
+            dst,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            packet_bytes,
+        ),
+        _ => None,
+    }
 }
 
 /// Evaluate the per-interface output filter for a given address family.
@@ -382,20 +883,60 @@ pub(crate) fn evaluate_interface_output_filter_counted(
     dscp: u8,
     packet_bytes: u64,
 ) -> FilterResult {
-    let filter_name = if is_v6 {
-        state.iface_filter_out_v6.get(&ifindex)
+    let filter = if is_v6 {
+        state
+            .iface_filter_out_v6_fast
+            .get(&ifindex)
+            .map(Arc::as_ref)
     } else {
-        state.iface_filter_out_v4.get(&ifindex)
+        state
+            .iface_filter_out_v4_fast
+            .get(&ifindex)
+            .map(Arc::as_ref)
     };
-    let Some(filter_name) = filter_name else {
+    let Some(filter) = filter else {
         return FilterResult::default();
     };
-    if filter_name.is_empty() {
-        return FilterResult::default();
-    }
-    evaluate_filter_counted(
-        state,
-        filter_name,
+    evaluate_filter_ref_counted(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        packet_bytes,
+    )
+}
+
+pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
+    state: &'a FilterState,
+    ifindex: i32,
+    is_v6: bool,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    packet_bytes: u64,
+) -> TxSelectionFilterResult<'a> {
+    let filter = if is_v6 {
+        state
+            .iface_filter_out_v6_fast
+            .get(&ifindex)
+            .map(Arc::as_ref)
+    } else {
+        state
+            .iface_filter_out_v4_fast
+            .get(&ifindex)
+            .map(Arc::as_ref)
+    };
+    let Some(filter) = filter else {
+        return TxSelectionFilterResult::default();
+    };
+    evaluate_filter_ref_tx_selection_counted(
+        filter,
         src_ip,
         dst_ip,
         protocol,
@@ -412,22 +953,65 @@ pub(crate) fn interface_filter_affects_tx_selection(
     is_v6: bool,
 ) -> bool {
     if is_v6 {
-        state.iface_filter_v6_affects_tx_selection.contains(&ifindex)
+        state
+            .iface_filter_v6_affects_tx_selection
+            .contains(&ifindex)
     } else {
-        state.iface_filter_v4_affects_tx_selection.contains(&ifindex)
+        state
+            .iface_filter_v4_affects_tx_selection
+            .contains(&ifindex)
     }
 }
 
-fn filter_key_affects_tx_selection(state: &FilterState, filter_key: &str) -> bool {
-    state
-        .filters
-        .get(filter_key)
-        .map(|filter| filter.affects_tx_selection)
-        .unwrap_or(false)
+pub(crate) fn interface_filter_affects_route_lookup(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    if is_v6 {
+        state
+            .iface_filter_v6_affects_route_lookup
+            .contains(&ifindex)
+    } else {
+        state
+            .iface_filter_v4_affects_route_lookup
+            .contains(&ifindex)
+    }
+}
+
+pub(crate) fn interface_output_filter_needs_tx_eval(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    if is_v6 {
+        state.iface_filter_out_v6_needs_tx_eval.contains(&ifindex)
+    } else {
+        state.iface_filter_out_v4_needs_tx_eval.contains(&ifindex)
+    }
+}
+
+#[inline]
+pub(crate) fn filter_state_has_input_tx_selection(state: &FilterState, is_v6: bool) -> bool {
+    if is_v6 {
+        state.has_input_tx_selection_v6
+    } else {
+        state.has_input_tx_selection_v4
+    }
+}
+
+#[inline]
+pub(crate) fn filter_state_has_output_tx_selection(state: &FilterState, is_v6: bool) -> bool {
+    if is_v6 {
+        state.has_output_tx_selection_v6
+    } else {
+        state.has_output_tx_selection_v4
+    }
 }
 
 /// Check whether a single filter term matches the given packet fields.
 /// All specified criteria must match (AND logic). Empty criteria = match any.
+#[inline(always)]
 fn term_matches(
     term: &FilterTerm,
     src_ip: IpAddr,
@@ -437,55 +1021,81 @@ fn term_matches(
     dst_port: u16,
     dscp: u8,
 ) -> bool {
-    // Protocol match
-    if !term.protocols.is_empty() && !term.protocols.contains(&protocol) {
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            term_matches_v4(term, src, dst, protocol, src_port, dst_port, dscp)
+        }
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            term_matches_v6(term, src, dst, protocol, src_port, dst_port, dscp)
+        }
+        _ => false,
+    }
+}
+
+#[inline(always)]
+fn term_matches_v4(
+    term: &FilterTerm,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> bool {
+    if term.protocol_match_enabled
+        && (term.protocol_bitmap[(protocol / 64) as usize] & (1u64 << (protocol % 64))) == 0
+    {
         return false;
     }
-    // Source address match
-    if !address_matches(&term.source_v4, &term.source_v6, src_ip) {
+    if !term.source_v4.is_empty() && !term.source_v4.iter().any(|net| net.contains(src_ip)) {
         return false;
     }
-    // Destination address match
-    if !address_matches(&term.dest_v4, &term.dest_v6, dst_ip) {
+    if !term.dest_v4.is_empty() && !term.dest_v4.iter().any(|net| net.contains(dst_ip)) {
         return false;
     }
-    // Source port match
-    if !port_ranges_match(&term.source_ports, src_port) {
+    if !term.source_ports.matches(src_port) {
         return false;
     }
-    // Destination port match
-    if !port_ranges_match(&term.dest_ports, dst_port) {
+    if !term.dest_ports.matches(dst_port) {
         return false;
     }
-    // DSCP match
-    if !term.dscp_values.is_empty() && !term.dscp_values.contains(&dscp) {
+    if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
         return false;
     }
     true
 }
 
-fn address_matches(v4: &[PrefixV4], v6: &[PrefixV6], ip: IpAddr) -> bool {
-    if v4.is_empty() && v6.is_empty() {
-        return true; // no constraint
+#[inline(always)]
+fn term_matches_v6(
+    term: &FilterTerm,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+) -> bool {
+    if term.protocol_match_enabled
+        && (term.protocol_bitmap[(protocol / 64) as usize] & (1u64 << (protocol % 64))) == 0
+    {
+        return false;
     }
-    match ip {
-        IpAddr::V4(addr) => {
-            if v4.is_empty() {
-                return true; // no v4 constraint
-            }
-            v4.iter().any(|net| net.contains(addr))
-        }
-        IpAddr::V6(addr) => {
-            if v6.is_empty() {
-                return true; // no v6 constraint
-            }
-            v6.iter().any(|net| net.contains(addr))
-        }
+    if !term.source_v6.is_empty() && !term.source_v6.iter().any(|net| net.contains(src_ip)) {
+        return false;
     }
-}
-
-fn port_ranges_match(ranges: &[PortRange], port: u16) -> bool {
-    ranges.is_empty() || ranges.iter().any(|r| port >= r.low && port <= r.high)
+    if !term.dest_v6.is_empty() && !term.dest_v6.iter().any(|net| net.contains(dst_ip)) {
+        return false;
+    }
+    if !term.source_ports.matches(src_port) {
+        return false;
+    }
+    if !term.dest_ports.matches(dst_port) {
+        return false;
+    }
+    if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
+        return false;
+    }
+    true
 }
 
 // ----- Snapshot parsing -----
@@ -513,8 +1123,13 @@ pub(crate) fn parse_filter_state(
                 .terms
                 .iter()
                 .any(|term| !term.forwarding_class.is_empty() || term.dscp_rewrite.is_some()),
+            affects_route_lookup: snap
+                .terms
+                .iter()
+                .any(|term| !term.routing_instance.is_empty()),
+            has_counter_terms: snap.terms.iter().any(|term| !term.count.is_empty()),
         };
-        state.filters.insert(key, filter);
+        state.filters.insert(key, Arc::new(filter));
     }
 
     // Parse policers
@@ -537,27 +1152,77 @@ pub(crate) fn parse_filter_state(
         }
         if !iface.filter_input_v4.is_empty() {
             let key = qualify_filter_key("inet", &iface.filter_input_v4);
-            if filter_key_affects_tx_selection(&state, &key) {
-                state.iface_filter_v4_affects_tx_selection.insert(iface.ifindex);
+            if let Some(filter) = state.filters.get(&key) {
+                if filter.affects_tx_selection {
+                    state
+                        .iface_filter_v4_affects_tx_selection
+                        .insert(iface.ifindex);
+                    state.has_input_tx_selection_v4 = true;
+                }
+                if filter.affects_route_lookup {
+                    state
+                        .iface_filter_v4_affects_route_lookup
+                        .insert(iface.ifindex);
+                }
+                state
+                    .iface_filter_v4_fast
+                    .insert(iface.ifindex, filter.clone());
             }
             state.iface_filter_v4.insert(iface.ifindex, key);
         }
         if !iface.filter_output_v4.is_empty() {
-            state
-                .iface_filter_out_v4
-                .insert(iface.ifindex, qualify_filter_key("inet", &iface.filter_output_v4));
+            let key = qualify_filter_key("inet", &iface.filter_output_v4);
+            if let Some(filter) = state.filters.get(&key) {
+                if filter.affects_tx_selection || filter.has_counter_terms {
+                    state
+                        .iface_filter_out_v4_needs_tx_eval
+                        .insert(iface.ifindex);
+                }
+                if filter.affects_tx_selection {
+                    state.has_output_tx_selection_v4 = true;
+                }
+                state
+                    .iface_filter_out_v4_fast
+                    .insert(iface.ifindex, filter.clone());
+            }
+            state.iface_filter_out_v4.insert(iface.ifindex, key);
         }
         if !iface.filter_input_v6.is_empty() {
             let key = qualify_filter_key("inet6", &iface.filter_input_v6);
-            if filter_key_affects_tx_selection(&state, &key) {
-                state.iface_filter_v6_affects_tx_selection.insert(iface.ifindex);
+            if let Some(filter) = state.filters.get(&key) {
+                if filter.affects_tx_selection {
+                    state
+                        .iface_filter_v6_affects_tx_selection
+                        .insert(iface.ifindex);
+                    state.has_input_tx_selection_v6 = true;
+                }
+                if filter.affects_route_lookup {
+                    state
+                        .iface_filter_v6_affects_route_lookup
+                        .insert(iface.ifindex);
+                }
+                state
+                    .iface_filter_v6_fast
+                    .insert(iface.ifindex, filter.clone());
             }
             state.iface_filter_v6.insert(iface.ifindex, key);
         }
         if !iface.filter_output_v6.is_empty() {
-            state
-                .iface_filter_out_v6
-                .insert(iface.ifindex, qualify_filter_key("inet6", &iface.filter_output_v6));
+            let key = qualify_filter_key("inet6", &iface.filter_output_v6);
+            if let Some(filter) = state.filters.get(&key) {
+                if filter.affects_tx_selection || filter.has_counter_terms {
+                    state
+                        .iface_filter_out_v6_needs_tx_eval
+                        .insert(iface.ifindex);
+                }
+                if filter.affects_tx_selection {
+                    state.has_output_tx_selection_v6 = true;
+                }
+                state
+                    .iface_filter_out_v6_fast
+                    .insert(iface.ifindex, filter.clone());
+            }
+            state.iface_filter_out_v6.insert(iface.ifindex, key);
         }
     }
 
@@ -566,11 +1231,13 @@ pub(crate) fn parse_filter_state(
     } else {
         qualify_filter_key("inet", lo0_filter_v4)
     };
+    state.lo0_filter_v4_fast = state.filters.get(&state.lo0_filter_v4).cloned();
     state.lo0_filter_v6 = if lo0_filter_v6.is_empty() {
         String::new()
     } else {
         qualify_filter_key("inet6", lo0_filter_v6)
     };
+    state.lo0_filter_v6_fast = state.filters.get(&state.lo0_filter_v6).cloned();
 
     state
 }
@@ -621,12 +1288,15 @@ fn parse_term(snap: &FirewallTermSnapshot) -> FilterTerm {
         source_v6,
         dest_v4,
         dest_v6,
-        protocols,
-        source_ports,
-        dest_ports,
-        dscp_values: snap.dscp_values.clone(),
+        protocol_bitmap: build_u8_match_bitmap(&protocols),
+        protocol_match_enabled: !protocols.is_empty(),
+        source_ports: build_port_matcher(source_ports),
+        dest_ports: build_port_matcher(dest_ports),
+        dscp_bitmap: build_u6_match_bitmap(&snap.dscp_values),
+        dscp_match_enabled: !snap.dscp_values.is_empty(),
         action,
         count: snap.count.clone(),
+        has_count: !snap.count.is_empty(),
         log: snap.log,
         policer_name: snap.policer.clone(),
         routing_instance: snap.routing_instance.clone(),
@@ -709,6 +1379,39 @@ fn parse_port_spec(spec: &str) -> Option<Vec<PortRange>> {
         low: port,
         high: port,
     }])
+}
+
+fn build_port_matcher(mut ranges: Vec<PortRange>) -> PortMatcher {
+    match ranges.len() {
+        0 => PortMatcher::Any,
+        1 => {
+            let range = ranges.pop().expect("single range");
+            if range.low == range.high {
+                PortMatcher::Single(range.low)
+            } else {
+                PortMatcher::Range(range)
+            }
+        }
+        _ => PortMatcher::Set(ranges.into_boxed_slice()),
+    }
+}
+
+fn build_u8_match_bitmap(values: &[u8]) -> [u64; 4] {
+    let mut bitmap = [0u64; 4];
+    for value in values {
+        bitmap[(value / 64) as usize] |= 1u64 << (value % 64);
+    }
+    bitmap
+}
+
+fn build_u6_match_bitmap(values: &[u8]) -> u64 {
+    let mut bitmap = 0u64;
+    for value in values {
+        if *value < 64 {
+            bitmap |= 1u64 << value;
+        }
+    }
+    bitmap
 }
 
 #[cfg(test)]
@@ -1245,6 +1948,7 @@ mod tests {
                     terms: vec![FirewallTermSnapshot {
                         name: "tx-select".into(),
                         forwarding_class: "best-effort".into(),
+                        routing_instance: "sfmix".into(),
                         ..Default::default()
                     }],
                 },
@@ -1274,12 +1978,102 @@ mod tests {
             Some("inet:ingress-v4")
         );
         assert!(state.iface_filter_v4_affects_tx_selection.contains(&7));
+        assert!(state.has_input_tx_selection_v4);
+        assert!(state.iface_filter_v4_affects_route_lookup.contains(&7));
+        assert!(!state.iface_filter_out_v4_needs_tx_eval.contains(&7));
+        assert!(!state.iface_filter_out_v6_needs_tx_eval.contains(&7));
+        assert!(!state.has_output_tx_selection_v4);
+        assert!(!state.has_output_tx_selection_v6);
         assert_eq!(
             state.iface_filter_out_v6.get(&7).map(String::as_str),
             Some("inet6:egress-v6")
         );
         assert_eq!(state.lo0_filter_v4, "inet:protect-re");
         assert_eq!(state.lo0_filter_v6, "inet6:protect-re-v6");
+    }
+
+    #[test]
+    fn accept_only_output_filter_does_not_need_tx_eval() {
+        let ifaces = vec![crate::InterfaceSnapshot {
+            name: "reth0.80".into(),
+            ifindex: 7,
+            filter_output_v4: "wan-allow".into(),
+            ..Default::default()
+        }];
+        let state = parse_filter_state(
+            &[FirewallFilterSnapshot {
+                name: "wan-allow".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "allow".into(),
+                    action: "accept".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    ..Default::default()
+                }],
+            }],
+            &[],
+            &ifaces,
+            "",
+            "",
+        );
+
+        assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
+        assert!(!filter_state_has_output_tx_selection(&state, false));
+    }
+
+    #[test]
+    fn interface_filter_routing_instance_counted_returns_matching_override() {
+        let ifaces = vec![crate::InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: 11,
+            filter_input_v6: "sfmix-pbr".into(),
+            ..Default::default()
+        }];
+        let state = parse_filter_state(
+            &[FirewallFilterSnapshot {
+                name: "sfmix-pbr".into(),
+                family: "inet6".into(),
+                terms: vec![
+                    FirewallTermSnapshot {
+                        name: "match-iperf".into(),
+                        action: "accept".into(),
+                        count: "iperf-v6".into(),
+                        protocols: vec!["tcp".into()],
+                        destination_ports: vec!["5201".into()],
+                        routing_instance: "sfmix".into(),
+                        ..Default::default()
+                    },
+                    FirewallTermSnapshot {
+                        name: "default".into(),
+                        action: "accept".into(),
+                        ..Default::default()
+                    },
+                ],
+            }],
+            &[],
+            &ifaces,
+            "",
+            "",
+        );
+
+        assert!(interface_filter_affects_route_lookup(&state, 11, true));
+        let routing_instance = evaluate_interface_filter_routing_instance_counted(
+            &state,
+            11,
+            true,
+            IpAddr::V6("2001:db8::10".parse().unwrap()),
+            IpAddr::V6("2001:db8::200".parse().unwrap()),
+            PROTO_TCP,
+            12345,
+            5201,
+            0,
+            1500,
+        );
+        assert_eq!(routing_instance, Some("sfmix"));
+        let filter = state.iface_filter_v6_fast.get(&11).expect("input filter");
+        assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 1);
+        assert_eq!(filter.terms[0].counter.bytes.load(Ordering::Relaxed), 1500);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR cuts the hot-path CPU overhead that showed up after the recent userspace dataplane CoS work and restores the no-CoS fast path to the expected throughput band.

It includes:

- hot-path filter lookup and match reductions
- precomputed ingress logical-interface lookup
- reduced TX-selection work when CoS / filter state cannot affect the packet
- lower-overhead pending-forward request handling
- smaller flow-cache fallback overhead by reusing precomputed `expected_ports` and `target_binding_index`
- exact CoS queue correctness hardening: when an exact queue first falls back to a local item, already-queued prepared items are demoted to local and their TX frames are recycled immediately
- an engineering note in `docs/userspace-dataplane-perf-hotspots.md`

Remaining perf tail work is tracked separately in `#678`.

## Validation

Local:

- `cargo test --manifest-path userspace-dp/Cargo.toml build_live_forward_request_from_frame_uses_precomputed_hints -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml demote_prepared_cos_queue_to_local_ -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml cos_queue_accepts_prepared_ -- --nocapture`
- `make build-userspace-dp`
- `git diff --check`

Live on the `loss` userspace HA cluster with helper-only rollouts preserving `/etc/xpf/xpf.conf` and `/etc/xpf/.configdb`:

- `./scripts/userspace-perf-compare.sh --duration 8 --parallel 12`
- IPv4: `23.02 Gbps`
- IPv6: `22.77 Gbps`
- helper hash on `xpf-userspace-fw0/1`: `8ec95142d5093be59558a035947f71b2dbb2301fff8f724d6234c7361582f88c`
- `iperf3 -c 2001:559:8585:80::200 -t 20 -P 12 -p 5202`
- exact `5202` queue completed cleanly at `9.45 Gbits/sec`; the earlier zero-throughput hang is fixed, but throughput is still capped well below the desired `10g exact` target

Representative remaining hot symbols after the perf slice:

- IPv4: `poll_binding` ~13.4%, `enqueue_pending_forwards` ~4.3%
- IPv6: `poll_binding` ~13.3%, `enqueue_pending_forwards` ~3.7%, `apply_nat_ipv6` ~3.2%

Remaining exact-queue work is architectural rather than another small fast-path tweak: the current exact queue service still behaves like a single-owner / single-frame-pool design.
