### PR TITLE
userspace-dp: flatten exact CoS hot path

### DIFF
--- a/userspace-dp/src/afxdp/frame_tx.rs
+++ b/userspace-dp/src/afxdp/frame_tx.rs
@@ -1,51 +1,38 @@
 use super::*;
 
+fn cos_queue_fast_path_for_request<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
+    egress_ifindex: i32,
+    requested_queue_id: Option<u8>,
+) -> Option<&'a WorkerCoSQueueFastPath> {
+    let iface = cos_fast_interfaces.get(&egress_ifindex)?;
+    iface.queue_fast_path(requested_queue_id)
+}
+
 fn cos_owner_live_for_request(
-    forwarding: &ForwardingState,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
     egress_ifindex: i32,
     requested_queue_id: Option<u8>,
 ) -> Option<Arc<BindingLiveState>> {
-    let effective_queue_id = requested_queue_id.or_else(|| {
-        forwarding
-            .cos
-            .interfaces
-            .get(&egress_ifindex)
-            .map(|iface| iface.default_queue)
-    });
-    effective_queue_id.and_then(|queue_id| {
-        cos_owner_live_by_queue
-            .get(&(egress_ifindex, queue_id))
-            .cloned()
-    })
+    cos_queue_fast_path_for_request(cos_fast_interfaces, egress_ifindex, requested_queue_id)
+        .and_then(|queue_fast| queue_fast.owner_live.clone())
 }
 
 fn request_uses_shared_exact_queue_lease(
-    cos_shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
-    forwarding: &ForwardingState,
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
     egress_ifindex: i32,
     requested_queue_id: Option<u8>,
 ) -> bool {
-    let effective_queue_id = requested_queue_id.or_else(|| {
-        forwarding
-            .cos
-            .interfaces
-            .get(&egress_ifindex)
-            .map(|iface| iface.default_queue)
-    });
-    effective_queue_id
-        .is_some_and(|queue_id| cos_shared_queue_leases.contains_key(&(egress_ifindex, queue_id)))
+    cos_queue_fast_path_for_request(cos_fast_interfaces, egress_ifindex, requested_queue_id)
+        .is_some_and(|queue_fast| queue_fast.shared_queue_lease.is_some())
 }
 
 fn enqueue_local_request_to_target_or_owner(
     target_binding: &mut BindingWorker,
-    forwarding: &ForwardingState,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
     req: TxRequest,
 ) -> Result<(), TxRequest> {
     if request_uses_shared_exact_queue_lease(
-        &target_binding.cos_shared_queue_leases,
-        forwarding,
+        &target_binding.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     ) {
@@ -54,8 +41,7 @@ fn enqueue_local_request_to_target_or_owner(
         return Ok(());
     }
     let owner_live = cos_owner_live_for_request(
-        forwarding,
-        cos_owner_live_by_queue,
+        &target_binding.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     );
@@ -158,14 +144,7 @@ pub(super) fn enqueue_pending_forwards(
                 cos_queue_id: request.cos_queue_id,
                 dscp_rewrite: request.dscp_rewrite,
             };
-            if enqueue_local_request_to_target_or_owner(
-                target_binding,
-                forwarding,
-                cos_owner_live_by_queue,
-                req,
-            )
-            .is_err()
-            {
+            if enqueue_local_request_to_target_or_owner(target_binding, req).is_err() {
                 recycle_ingress_frame(ingress_binding, source_offset, now_ns);
                 continue;
             }
@@ -411,13 +390,11 @@ pub(super) fn enqueue_pending_forwards(
                 let is_nat64 = request.decision.nat.nat64;
                 let uses_native_tunnel = request.decision.resolution.tunnel_endpoint_id != 0;
                 let owner_matches_target = request_uses_shared_exact_queue_lease(
-                    &target_binding.cos_shared_queue_leases,
-                    forwarding,
+                    &target_binding.cos_fast_interfaces,
                     request.decision.resolution.egress_ifindex,
                     request.cos_queue_id,
                 ) || cos_owner_live_for_request(
-                    forwarding,
-                    cos_owner_live_by_queue,
+                    &target_binding.cos_fast_interfaces,
                     request.decision.resolution.egress_ifindex,
                     request.cos_queue_id,
                 )
@@ -535,13 +512,8 @@ pub(super) fn enqueue_pending_forwards(
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
                                 };
-                                if enqueue_local_request_to_target_or_owner(
-                                    target_binding,
-                                    forwarding,
-                                    cos_owner_live_by_queue,
-                                    req,
-                                )
-                                .is_err()
+                                if enqueue_local_request_to_target_or_owner(target_binding, req)
+                                    .is_err()
                                 {
                                     build_failed = true;
                                     fallback_to_slow_path = true;
@@ -795,13 +767,8 @@ pub(super) fn enqueue_pending_forwards(
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
                                 };
-                                if enqueue_local_request_to_target_or_owner(
-                                    target_binding,
-                                    forwarding,
-                                    cos_owner_live_by_queue,
-                                    req,
-                                )
-                                .is_err()
+                                if enqueue_local_request_to_target_or_owner(target_binding, req)
+                                    .is_err()
                                 {
                                     build_failed = true;
                                     fallback_to_slow_path = true;
@@ -1557,6 +1524,38 @@ mod tests {
         }
     }
 
+    fn test_cos_fast_interfaces(
+        egress_ifindex: i32,
+        default_queue: u8,
+        shared_exact_queues: &[(u8, bool)],
+    ) -> FastMap<i32, WorkerCoSInterfaceFastPath> {
+        let mut queue_index_by_id = [COS_FAST_QUEUE_INDEX_MISS; 256];
+        let mut queue_fast_path = Vec::new();
+        for (idx, (queue_id, shared_exact)) in shared_exact_queues.iter().copied().enumerate() {
+            queue_index_by_id[usize::from(queue_id)] = idx as u16;
+            queue_fast_path.push(WorkerCoSQueueFastPath {
+                shared_exact,
+                owner_worker_id: 0,
+                owner_live: None,
+                shared_queue_lease: shared_exact
+                    .then(|| Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2))),
+            });
+        }
+        let mut interfaces = FastMap::default();
+        interfaces.insert(
+            egress_ifindex,
+            WorkerCoSInterfaceFastPath {
+                tx_ifindex: 11,
+                default_queue_index: queue_index_by_id[usize::from(default_queue)] as usize,
+                queue_index_by_id,
+                tx_owner_live: None,
+                shared_root_lease: None,
+                queue_fast_path,
+            },
+        );
+        interfaces
+    }
+
     #[test]
     fn forwarded_tcp_may_need_segmentation_skips_mtu_sized_frame() {
         let forwarding = test_forwarding_with_egress_mtu(1500);
@@ -1595,22 +1594,15 @@ mod tests {
 
     #[test]
     fn shared_exact_queue_lease_uses_requested_queue_id() {
-        let forwarding = ForwardingState::default();
-        let mut shared_queue_leases = BTreeMap::new();
-        shared_queue_leases.insert(
-            (80, 5),
-            Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)),
-        );
+        let cos_fast_interfaces = test_cos_fast_interfaces(80, 5, &[(5, true)]);
 
         assert!(request_uses_shared_exact_queue_lease(
-            &shared_queue_leases,
-            &forwarding,
+            &cos_fast_interfaces,
             80,
             Some(5),
         ));
         assert!(!request_uses_shared_exact_queue_lease(
-            &shared_queue_leases,
-            &forwarding,
+            &cos_fast_interfaces,
             80,
             Some(4),
         ));
@@ -1618,30 +1610,10 @@ mod tests {
 
     #[test]
     fn shared_exact_queue_lease_uses_interface_default_queue() {
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
-            80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 10_000_000_000u64 / 8,
-                burst_bytes: 256 * 1024,
-                default_queue: 5,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [0; 64],
-                ieee8021_queue_by_pcp: [0; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: Vec::new(),
-            },
-        );
-        let mut shared_queue_leases = BTreeMap::new();
-        shared_queue_leases.insert(
-            (80, 5),
-            Arc::new(SharedCoSQueueLease::new(1_250_000_000, 256 * 1024, 2)),
-        );
+        let cos_fast_interfaces = test_cos_fast_interfaces(80, 5, &[(5, true)]);
 
         assert!(request_uses_shared_exact_queue_lease(
-            &shared_queue_leases,
-            &forwarding,
+            &cos_fast_interfaces,
             80,
             None,
         ));

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -292,11 +292,13 @@ enum CoSBatch {
     Local {
         queue_idx: usize,
         phase: CoSServicePhase,
+        batch_bytes: u64,
         items: VecDeque<TxRequest>,
     },
     Prepared {
         queue_idx: usize,
         phase: CoSServicePhase,
+        batch_bytes: u64,
         items: VecDeque<PreparedTxRequest>,
     },
 }
@@ -474,41 +476,40 @@ fn ingest_cos_pending_tx(
     }
 
     if !binding.pending_tx_prepared.is_empty() {
-        let mut kept = VecDeque::with_capacity(binding.pending_tx_prepared.len());
-        while let Some(req) = binding.pending_tx_prepared.pop_front() {
+        let mut pending = core::mem::take(&mut binding.pending_tx_prepared);
+        process_pending_queue_in_place(&mut pending, |req| {
             let req = match redirect_prepared_cos_request_to_owner(
                 binding,
                 req,
                 worker_id,
                 worker_commands_by_id,
             ) {
-                Ok(()) => continue,
+                Ok(()) => return Ok(()),
                 Err(req) => req,
             };
             let req = match redirect_prepared_cos_request_to_owner_binding(binding, req) {
-                Ok(()) => continue,
+                Ok(()) => return Ok(()),
                 Err(req) => req,
             };
             match enqueue_prepared_into_cos(binding, forwarding, req, now_ns) {
-                Ok(()) => {}
-                Err(req) => kept.push_back(req),
+                Ok(()) => Ok(()),
+                Err(req) => Err(req),
             }
-        }
-        binding.pending_tx_prepared = kept;
+        });
+        binding.pending_tx_prepared = pending;
     }
 
-    let local = core::mem::take(&mut binding.pending_tx_local);
-    let shared = binding.live.take_pending_tx();
-    let mut pending = merge_pending_tx_requests(local, shared);
-    let mut kept = VecDeque::with_capacity(pending.len());
-    while let Some(req) = pending.pop_front() {
+    let mut pending = core::mem::take(&mut binding.pending_tx_local);
+    let mut shared = binding.live.take_pending_tx();
+    append_pending_queue(&mut pending, &mut shared);
+    process_pending_queue_in_place(&mut pending, |req| {
         let req = match redirect_local_cos_request_to_owner(
             &binding.cos_fast_interfaces,
             req,
             worker_id,
             worker_commands_by_id,
         ) {
-            Ok(()) => continue,
+            Ok(()) => return Ok(()),
             Err(req) => req,
         };
         let req = match redirect_local_cos_request_to_owner_binding(
@@ -516,15 +517,15 @@ fn ingest_cos_pending_tx(
             &binding.cos_fast_interfaces,
             req,
         ) {
-            Ok(()) => continue,
+            Ok(()) => return Ok(()),
             Err(req) => req,
         };
         match enqueue_local_into_cos(binding, forwarding, req, now_ns) {
-            Ok(()) => {}
-            Err(req) => kept.push_back(req),
+            Ok(()) => Ok(()),
+            Err(req) => Err(req),
         }
-    }
-    binding.pending_tx_local = kept;
+    });
+    binding.pending_tx_local = pending;
     bound_pending_tx_local(binding);
 }
 
@@ -915,6 +916,7 @@ fn build_cos_batch_from_queue(
             let mut items = VecDeque::new();
             let mut remaining_root = root_budget;
             let mut remaining_secondary = secondary_budget;
+            let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
                 let Some(front) = queue.items.front() else {
                     break;
@@ -929,7 +931,10 @@ fn build_cos_batch_from_queue(
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
                 match queue.items.pop_front() {
-                    Some(CoSPendingTxItem::Local(req)) => items.push_back(req),
+                    Some(CoSPendingTxItem::Local(req)) => {
+                        batch_bytes = batch_bytes.saturating_add(len);
+                        items.push_back(req);
+                    }
                     Some(other) => {
                         queue.items.push_front(other);
                         break;
@@ -943,6 +948,7 @@ fn build_cos_batch_from_queue(
                 Some(CoSBatch::Local {
                     queue_idx,
                     phase,
+                    batch_bytes,
                     items,
                 })
             }
@@ -951,6 +957,7 @@ fn build_cos_batch_from_queue(
             let mut items = VecDeque::new();
             let mut remaining_root = root_budget;
             let mut remaining_secondary = secondary_budget;
+            let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
                 let Some(front) = queue.items.front() else {
                     break;
@@ -965,7 +972,10 @@ fn build_cos_batch_from_queue(
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
                 match queue.items.pop_front() {
-                    Some(CoSPendingTxItem::Prepared(req)) => items.push_back(req),
+                    Some(CoSPendingTxItem::Prepared(req)) => {
+                        batch_bytes = batch_bytes.saturating_add(len);
+                        items.push_back(req);
+                    }
                     Some(other) => {
                         queue.items.push_front(other);
                         break;
@@ -979,6 +989,7 @@ fn build_cos_batch_from_queue(
                 Some(CoSBatch::Prepared {
                     queue_idx,
                     phase,
+                    batch_bytes,
                     items,
                 })
             }
@@ -997,6 +1008,7 @@ fn submit_cos_batch(
         CoSBatch::Local {
             queue_idx,
             phase,
+            batch_bytes,
             mut items,
         } => {
             assign_local_dscp_rewrite(
@@ -1005,45 +1017,12 @@ fn submit_cos_batch(
             );
             match transmit_batch(binding, &mut items, now_ns, shared_recycles) {
                 Ok((packets, bytes)) => {
-                    apply_cos_send_result(binding, root_ifindex, queue_idx, phase, bytes, items);
-                    if packets > 0 {
-                        binding
-                            .live
-                            .tx_packets
-                            .fetch_add(packets, Ordering::Relaxed);
-                        binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
-                    }
-                    cos_batch_tx_made_progress(Ok((packets, bytes)))
-                }
-                Err(TxError::Retry(err)) => {
-                    binding.live.set_error(err);
-                    restore_cos_local_items(binding, root_ifindex, queue_idx, items);
-                    cos_batch_tx_made_progress(Err(TxError::Retry(String::new())))
-                }
-                Err(TxError::Drop(err)) => {
-                    binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
-                    binding.live.set_error(err);
-                    restore_cos_local_items(binding, root_ifindex, queue_idx, items);
-                    cos_batch_tx_made_progress(Err(TxError::Drop(String::new())))
-                }
-            }
-        }
-        CoSBatch::Prepared {
-            queue_idx,
-            phase,
-            mut items,
-        } => {
-            assign_prepared_dscp_rewrite(
-                &mut items,
-                cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx),
-            );
-            match transmit_prepared_queue(binding, &mut items, now_ns) {
-                Ok((packets, bytes)) => {
-                    apply_cos_prepared_result(
+                    apply_cos_send_result(
                         binding,
                         root_ifindex,
                         queue_idx,
                         phase,
+                        batch_bytes,
                         bytes,
                         items,
                     );
@@ -1058,13 +1037,68 @@ fn submit_cos_batch(
                 }
                 Err(TxError::Retry(err)) => {
                     binding.live.set_error(err);
-                    restore_cos_prepared_items(binding, root_ifindex, queue_idx, items);
+                    restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
                     cos_batch_tx_made_progress(Err(TxError::Retry(String::new())))
                 }
                 Err(TxError::Drop(err)) => {
                     binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
                     binding.live.set_error(err);
-                    restore_cos_prepared_items(binding, root_ifindex, queue_idx, items);
+                    restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
+                    cos_batch_tx_made_progress(Err(TxError::Drop(String::new())))
+                }
+            }
+        }
+        CoSBatch::Prepared {
+            queue_idx,
+            phase,
+            batch_bytes,
+            mut items,
+        } => {
+            assign_prepared_dscp_rewrite(
+                &mut items,
+                cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx),
+            );
+            match transmit_prepared_queue(binding, &mut items, now_ns) {
+                Ok((packets, bytes)) => {
+                    apply_cos_prepared_result(
+                        binding,
+                        root_ifindex,
+                        queue_idx,
+                        phase,
+                        batch_bytes,
+                        bytes,
+                        items,
+                    );
+                    if packets > 0 {
+                        binding
+                            .live
+                            .tx_packets
+                            .fetch_add(packets, Ordering::Relaxed);
+                        binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
+                    }
+                    cos_batch_tx_made_progress(Ok((packets, bytes)))
+                }
+                Err(TxError::Retry(err)) => {
+                    binding.live.set_error(err);
+                    restore_cos_prepared_items(
+                        binding,
+                        root_ifindex,
+                        queue_idx,
+                        batch_bytes,
+                        items,
+                    );
+                    cos_batch_tx_made_progress(Err(TxError::Retry(String::new())))
+                }
+                Err(TxError::Drop(err)) => {
+                    binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
+                    binding.live.set_error(err);
+                    restore_cos_prepared_items(
+                        binding,
+                        root_ifindex,
+                        queue_idx,
+                        batch_bytes,
+                        items,
+                    );
                     cos_batch_tx_made_progress(Err(TxError::Drop(String::new())))
                 }
             }
@@ -1730,16 +1764,16 @@ fn resolve_cos_queue_idx(root: &CoSInterfaceRuntime, requested_queue: Option<u8>
     if root.queues.is_empty() {
         return None;
     }
-    let target_queue = requested_queue.unwrap_or(root.default_queue);
+    if let Some(queue_id) = requested_queue {
+        return root
+            .queues
+            .iter()
+            .position(|queue| queue.queue_id == queue_id);
+    }
     root.queues
         .iter()
-        .position(|queue| queue.queue_id == target_queue)
-        .or_else(|| {
-            root.queues
-                .iter()
-                .position(|queue| queue.queue_id == root.default_queue)
-        })
-        .or(Some(0))
+        .position(|queue| queue.queue_id == root.default_queue)
+        .or_else(|| (!root.queues.is_empty()).then_some(0))
 }
 
 fn recycle_cancelled_prepared_offset(
@@ -1946,21 +1980,9 @@ fn enqueue_cos_item(
         let Some(root) = binding.cos_interfaces.get_mut(&egress_ifindex) else {
             return Err(item);
         };
-        if root.queues.is_empty() {
+        let Some(mut queue_idx) = resolve_cos_queue_idx(root, requested_queue) else {
             return Err(item);
-        }
-        let target_queue = requested_queue.unwrap_or(root.default_queue);
-        let default_queue = root.default_queue;
-        let mut queue_idx = root
-            .queues
-            .iter()
-            .position(|queue| queue.queue_id == target_queue)
-            .or_else(|| {
-                root.queues
-                    .iter()
-                    .position(|queue| queue.queue_id == default_queue)
-            })
-            .unwrap_or(0);
+        };
         if queue_idx >= root.queues.len() {
             queue_idx = 0;
         }
@@ -2129,6 +2151,7 @@ fn apply_cos_send_result(
     root_ifindex: i32,
     queue_idx: usize,
     phase: CoSServicePhase,
+    batch_bytes: u64,
     sent_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
@@ -2139,8 +2162,11 @@ fn apply_cos_send_result(
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.exact.then_some(queue_idx);
-            restore_cos_local_items_inner(queue, retry);
-            queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
+            let retry_bytes = restore_cos_local_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
             match phase {
                 CoSServicePhase::Guarantee => {
                     queue.tokens = queue.tokens.saturating_sub(sent_bytes);
@@ -2177,6 +2203,7 @@ fn apply_cos_prepared_result(
     root_ifindex: i32,
     queue_idx: usize,
     phase: CoSServicePhase,
+    batch_bytes: u64,
     sent_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
@@ -2187,8 +2214,11 @@ fn apply_cos_prepared_result(
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.exact.then_some(queue_idx);
-            restore_cos_prepared_items_inner(queue, retry);
-            queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
+            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
             match phase {
                 CoSServicePhase::Guarantee => {
                     queue.tokens = queue.tokens.saturating_sub(sent_bytes);
@@ -2224,6 +2254,7 @@ fn restore_cos_local_items(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
+    batch_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
     {
@@ -2231,8 +2262,11 @@ fn restore_cos_local_items(
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            restore_cos_local_items_inner(queue, retry);
-            queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
+            let retry_bytes = restore_cos_local_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
@@ -2242,6 +2276,7 @@ fn restore_cos_prepared_items(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
+    batch_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
     {
@@ -2249,36 +2284,44 @@ fn restore_cos_prepared_items(
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            restore_cos_prepared_items_inner(queue, retry);
-            queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
+            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
 }
 
-fn restore_cos_local_items_inner(queue: &mut CoSQueueRuntime, mut retry: VecDeque<TxRequest>) {
+fn restore_cos_local_items_inner(
+    queue: &mut CoSQueueRuntime,
+    mut retry: VecDeque<TxRequest>,
+) -> u64 {
+    let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {
+        retry_bytes = retry_bytes.saturating_add(req.bytes.len() as u64);
         queue.items.push_front(CoSPendingTxItem::Local(req));
     }
     if !queue.items.is_empty() {
         mark_cos_queue_runnable(queue);
     }
+    retry_bytes
 }
 
 fn restore_cos_prepared_items_inner(
     queue: &mut CoSQueueRuntime,
     mut retry: VecDeque<PreparedTxRequest>,
-) {
+) -> u64 {
+    let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {
+        retry_bytes = retry_bytes.saturating_add(req.len as u64);
         queue.items.push_front(CoSPendingTxItem::Prepared(req));
     }
     if !queue.items.is_empty() {
         mark_cos_queue_runnable(queue);
     }
-}
-
-fn recompute_cos_queue_bytes(queue: &VecDeque<CoSPendingTxItem>) -> u64 {
-    queue.iter().map(cos_item_len).sum()
+    retry_bytes
 }
 
 fn merge_pending_tx_requests(
@@ -2292,6 +2335,29 @@ fn merge_pending_tx_requests(
         local.append(&mut shared);
     }
     local
+}
+
+fn append_pending_queue<T>(pending: &mut VecDeque<T>, shared: &mut VecDeque<T>) {
+    if pending.is_empty() {
+        *pending = core::mem::take(shared);
+    } else if !shared.is_empty() {
+        pending.append(shared);
+    }
+}
+
+fn process_pending_queue_in_place<T, F>(pending: &mut VecDeque<T>, mut f: F)
+where
+    F: FnMut(T) -> Result<(), T>,
+{
+    let initial_len = pending.len();
+    for _ in 0..initial_len {
+        let Some(item) = pending.pop_front() else {
+            break;
+        };
+        if let Err(item) = f(item) {
+            pending.push_back(item);
+        }
+    }
 }
 
 fn take_pending_tx_requests(binding: &mut BindingWorker) -> VecDeque<TxRequest> {
@@ -2846,6 +2912,29 @@ mod tests {
     }
 
     #[test]
+    fn append_pending_queue_moves_shared_into_empty_pending() {
+        let mut pending = VecDeque::new();
+        let mut shared = VecDeque::from([1u8, 2, 3]);
+
+        append_pending_queue(&mut pending, &mut shared);
+
+        assert!(shared.is_empty());
+        assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn process_pending_queue_in_place_preserves_failed_item_order() {
+        let mut pending = VecDeque::from([1u8, 2, 3, 4]);
+
+        process_pending_queue_in_place(&mut pending, |item| match item {
+            1 | 3 => Ok(()),
+            other => Err(other),
+        });
+
+        assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![2, 4]);
+    }
+
+    #[test]
     fn cos_batch_tx_made_progress_requires_real_send_progress() {
         assert!(!cos_batch_tx_made_progress(Ok((0, 0))));
         assert!(cos_batch_tx_made_progress(Ok((1, 0))));
@@ -2937,6 +3026,60 @@ mod tests {
         assert!(redirected.is_ok());
         let pending = commands.lock().unwrap();
         assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn redirect_local_cos_request_to_owner_rejects_explicit_queue_miss() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+        let cos_fast_interfaces = test_cos_fast_interfaces(
+            80,
+            12,
+            5,
+            vec![(5, test_queue_fast_path(false, 7, None, None))],
+            None,
+            None,
+        );
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+
+        let redirected = redirect_local_cos_request_to_owner(
+            &cos_fast_interfaces,
+            req,
+            2,
+            &worker_commands_by_id,
+        );
+
+        assert!(redirected.is_err());
+        assert!(commands.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn resolve_cos_queue_idx_rejects_explicit_queue_miss() {
+        let root = test_cos_runtime_with_queues(
+            10_000_000,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "best-effort".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000,
+                exact: false,
+                surplus_weight: 1,
+                buffer_bytes: COS_MIN_BURST_BYTES,
+                dscp_rewrite: None,
+            }],
+        );
+
+        assert_eq!(resolve_cos_queue_idx(&root, Some(4)), None);
+        assert_eq!(resolve_cos_queue_idx(&root, None), Some(0));
     }
 
     #[test]
@@ -5679,9 +5822,10 @@ mod tests {
             dscp_rewrite: None,
         }]);
 
-        restore_cos_local_items_inner(&mut queue, retry);
+        let retry_bytes = restore_cos_local_items_inner(&mut queue, retry);
 
         assert_eq!(queue.items.len(), 1);
+        assert_eq!(retry_bytes, 1500);
         assert!(queue.runnable);
         assert!(!queue.parked);
     }
@@ -5720,9 +5864,10 @@ mod tests {
             dscp_rewrite: None,
         }]);
 
-        restore_cos_prepared_items_inner(&mut queue, retry);
+        let retry_bytes = restore_cos_prepared_items_inner(&mut queue, retry);
 
         assert_eq!(queue.items.len(), 1);
+        assert_eq!(retry_bytes, 1500);
         assert!(queue.runnable);
         assert!(!queue.parked);
     }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -186,8 +186,8 @@ pub(super) fn drain_pending_tx(
     forwarding: &ForwardingState,
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-    cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    _cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    _cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> bool {
     if !binding_has_pending_tx_work(binding) {
         return false;
@@ -208,8 +208,6 @@ pub(super) fn drain_pending_tx(
         now_ns,
         worker_id,
         worker_commands_by_id,
-        cos_owner_worker_by_queue,
-        cos_owner_live_by_queue,
     );
     // Only continue this loop while shaped service is making real forward
     // progress. A retrying CoS batch (for example, no free TX frame on the
@@ -470,8 +468,6 @@ fn ingest_cos_pending_tx(
     now_ns: u64,
     worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-    cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) {
     if forwarding.cos.interfaces.is_empty() {
         return;
@@ -482,18 +478,14 @@ fn ingest_cos_pending_tx(
         while let Some(req) = binding.pending_tx_prepared.pop_front() {
             let req = match redirect_prepared_cos_request_to_owner(
                 binding,
-                forwarding,
                 req,
                 worker_id,
                 worker_commands_by_id,
-                cos_owner_worker_by_queue,
-                cos_owner_live_by_queue,
             ) {
                 Ok(()) => continue,
                 Err(req) => req,
             };
-            let req = match redirect_prepared_cos_request_to_owner_binding(binding, forwarding, req)
-            {
+            let req = match redirect_prepared_cos_request_to_owner_binding(binding, req) {
                 Ok(()) => continue,
                 Err(req) => req,
             };
@@ -511,21 +503,17 @@ fn ingest_cos_pending_tx(
     let mut kept = VecDeque::with_capacity(pending.len());
     while let Some(req) = pending.pop_front() {
         let req = match redirect_local_cos_request_to_owner(
-            &binding.cos_owner_live_by_tx_ifindex,
-            forwarding,
+            &binding.cos_fast_interfaces,
             req,
             worker_id,
             worker_commands_by_id,
-            cos_owner_worker_by_queue,
-            cos_owner_live_by_queue,
         ) {
             Ok(()) => continue,
             Err(req) => req,
         };
         let req = match redirect_local_cos_request_to_owner_binding(
             &binding.live,
-            &binding.cos_owner_live_by_tx_ifindex,
-            forwarding,
+            &binding.cos_fast_interfaces,
             req,
         ) {
             Ok(()) => continue,
@@ -540,103 +528,44 @@ fn ingest_cos_pending_tx(
     bound_pending_tx_local(binding);
 }
 
-fn effective_cos_queue_id(
-    forwarding: &ForwardingState,
+#[inline]
+fn cos_fast_interface<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
     egress_ifindex: i32,
-    requested_queue_id: Option<u8>,
-) -> Option<u8> {
-    requested_queue_id.or_else(|| {
-        forwarding
-            .cos
-            .interfaces
-            .get(&egress_ifindex)
-            .map(|iface| iface.default_queue)
-    })
+) -> Option<&'a WorkerCoSInterfaceFastPath> {
+    cos_fast_interfaces.get(&egress_ifindex)
 }
 
-fn effective_cos_queue_config<'a>(
-    forwarding: &'a ForwardingState,
+#[inline]
+fn cos_fast_queue<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
     egress_ifindex: i32,
     requested_queue_id: Option<u8>,
-) -> Option<&'a CoSQueueConfig> {
-    let iface = forwarding.cos.interfaces.get(&egress_ifindex)?;
-    let queue_id = effective_cos_queue_id(forwarding, egress_ifindex, requested_queue_id)
-        .unwrap_or(iface.default_queue);
-    iface
-        .queues
-        .iter()
-        .find(|queue| queue.queue_id == queue_id)
-        .or_else(|| {
-            iface
-                .queues
-                .iter()
-                .find(|queue| queue.queue_id == iface.default_queue)
-        })
-        .or_else(|| iface.queues.first())
-}
-
-fn cos_queue_uses_shared_exact_execution(
-    forwarding: &ForwardingState,
-    egress_ifindex: i32,
-    requested_queue_id: Option<u8>,
-) -> bool {
-    effective_cos_queue_config(forwarding, egress_ifindex, requested_queue_id)
-        .is_some_and(|queue| queue.exact)
-}
-
-fn worker_has_local_cos_tx_path(
-    owner_live_by_tx_ifindex: &BTreeMap<i32, Arc<BindingLiveState>>,
-    forwarding: &ForwardingState,
-    egress_ifindex: i32,
-) -> bool {
-    owner_live_by_tx_ifindex.contains_key(&resolve_tx_binding_ifindex(forwarding, egress_ifindex))
-}
-
-fn cos_owner_worker_for_cos_queue(
-    forwarding: &ForwardingState,
-    cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
-    egress_ifindex: i32,
-    requested_queue_id: Option<u8>,
-    current_worker_id: u32,
-) -> u32 {
-    effective_cos_queue_id(forwarding, egress_ifindex, requested_queue_id)
-        .and_then(|queue_id| {
-            cos_owner_worker_by_queue
-                .get(&(egress_ifindex, queue_id))
-                .copied()
-        })
-        .unwrap_or(current_worker_id)
+) -> Option<(&'a WorkerCoSInterfaceFastPath, &'a WorkerCoSQueueFastPath)> {
+    let iface = cos_fast_interface(cos_fast_interfaces, egress_ifindex)?;
+    let queue = iface.queue_fast_path(requested_queue_id)?;
+    Some((iface, queue))
 }
 
 fn redirect_local_cos_request_to_owner(
-    owner_live_by_tx_ifindex: &BTreeMap<i32, Arc<BindingLiveState>>,
-    forwarding: &ForwardingState,
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
     req: TxRequest,
     current_worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-    cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Result<(), TxRequest> {
-    if cos_queue_uses_shared_exact_execution(forwarding, req.egress_ifindex, req.cos_queue_id)
-        && worker_has_local_cos_tx_path(owner_live_by_tx_ifindex, forwarding, req.egress_ifindex)
-    {
+    let Some((iface_fast, queue_fast)) =
+        cos_fast_queue(cos_fast_interfaces, req.egress_ifindex, req.cos_queue_id)
+    else {
+        return Err(req);
+    };
+    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
         return Err(req);
     }
-    let owner_worker_id = cos_owner_worker_for_cos_queue(
-        forwarding,
-        cos_owner_worker_by_queue,
-        req.egress_ifindex,
-        req.cos_queue_id,
-        current_worker_id,
-    );
+    let owner_worker_id = queue_fast.owner_worker_id;
     if owner_worker_id == current_worker_id {
         return Err(req);
     }
-    let effective_queue_id =
-        effective_cos_queue_id(forwarding, req.egress_ifindex, req.cos_queue_id);
-    if let Some(owner_live) = effective_queue_id
-        .and_then(|queue_id| cos_owner_live_by_queue.get(&(req.egress_ifindex, queue_id)))
-    {
+    if let Some(owner_live) = queue_fast.owner_live.as_ref() {
         return owner_live.enqueue_tx_owned(req);
     }
     let Some(commands) = worker_commands_by_id.get(&owner_worker_id) else {
@@ -651,14 +580,15 @@ fn redirect_local_cos_request_to_owner(
 
 fn redirect_local_cos_request_to_owner_binding(
     current_live: &Arc<BindingLiveState>,
-    owner_live_by_tx_ifindex: &BTreeMap<i32, Arc<BindingLiveState>>,
-    forwarding: &ForwardingState,
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
     req: TxRequest,
 ) -> Result<(), TxRequest> {
     // Caller ordering matters: shared exact queues that already have a local TX
     // path were filtered out in redirect_local_cos_request_to_owner().
-    let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
-    let Some(owner_live) = owner_live_by_tx_ifindex.get(&tx_ifindex) else {
+    let Some(iface_fast) = cos_fast_interface(cos_fast_interfaces, req.egress_ifindex) else {
+        return Err(req);
+    };
+    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
         return Err(req);
     };
     if Arc::ptr_eq(owner_live, current_live) {
@@ -670,39 +600,29 @@ fn redirect_local_cos_request_to_owner_binding(
 #[inline]
 fn prepared_cos_request_stays_on_current_tx_binding(
     binding_ifindex: i32,
-    tx_ifindex: i32,
-    forwarding: &ForwardingState,
-    req: &PreparedTxRequest,
+    iface_fast: &WorkerCoSInterfaceFastPath,
+    queue_fast: &WorkerCoSQueueFastPath,
 ) -> bool {
-    binding_ifindex == tx_ifindex
-        && cos_queue_uses_shared_exact_execution(forwarding, req.egress_ifindex, req.cos_queue_id)
+    binding_ifindex == iface_fast.tx_ifindex && queue_fast.shared_exact
 }
 
 fn redirect_prepared_cos_request_to_owner(
     binding: &mut BindingWorker,
-    forwarding: &ForwardingState,
     req: PreparedTxRequest,
     current_worker_id: u32,
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-    cos_owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
-    cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
 ) -> Result<(), PreparedTxRequest> {
-    if cos_queue_uses_shared_exact_execution(forwarding, req.egress_ifindex, req.cos_queue_id)
-        && worker_has_local_cos_tx_path(
-            &binding.cos_owner_live_by_tx_ifindex,
-            forwarding,
-            req.egress_ifindex,
-        )
-    {
-        return Err(req);
-    }
-    let owner_worker_id = cos_owner_worker_for_cos_queue(
-        forwarding,
-        cos_owner_worker_by_queue,
+    let Some((iface_fast, queue_fast)) = cos_fast_queue(
+        &binding.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
-        current_worker_id,
-    );
+    ) else {
+        return Err(req);
+    };
+    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
+        return Err(req);
+    }
+    let owner_worker_id = queue_fast.owner_worker_id;
     if owner_worker_id == current_worker_id {
         return Err(req);
     }
@@ -725,13 +645,10 @@ fn redirect_prepared_cos_request_to_owner(
         dscp_rewrite: req.dscp_rewrite,
     };
     if redirect_local_cos_request_to_owner(
-        &binding.cos_owner_live_by_tx_ifindex,
-        forwarding,
+        &binding.cos_fast_interfaces,
         local_req,
         current_worker_id,
         worker_commands_by_id,
-        cos_owner_worker_by_queue,
-        cos_owner_live_by_queue,
     )
     .is_ok()
     {
@@ -743,22 +660,22 @@ fn redirect_prepared_cos_request_to_owner(
 
 fn redirect_prepared_cos_request_to_owner_binding(
     binding: &mut BindingWorker,
-    forwarding: &ForwardingState,
     req: PreparedTxRequest,
 ) -> Result<(), PreparedTxRequest> {
-    let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
+    let Some((iface_fast, queue_fast)) = cos_fast_queue(
+        &binding.cos_fast_interfaces,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) else {
+        return Err(req);
+    };
     // Keep shared exact traffic on the current binding when it already sits on
     // the resolved TX path; redirecting it sideways would force a copy back
     // into local TX instead of preserving the prepared path.
-    if prepared_cos_request_stays_on_current_tx_binding(
-        binding.ifindex,
-        tx_ifindex,
-        forwarding,
-        &req,
-    ) {
+    if prepared_cos_request_stays_on_current_tx_binding(binding.ifindex, iface_fast, queue_fast) {
         return Err(req);
     }
-    let Some(owner_live) = binding.cos_owner_live_by_tx_ifindex.get(&tx_ifindex) else {
+    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
         return Err(req);
     };
     if Arc::ptr_eq(owner_live, &binding.live) {
@@ -821,20 +738,19 @@ fn build_cos_batch(
     root_ifindex: i32,
     now_ns: u64,
 ) -> Option<CoSBatch> {
-    let shared_root_lease = binding.cos_shared_root_leases.get(&root_ifindex).cloned();
+    let (cos_fast_interfaces, cos_interfaces) =
+        (&binding.cos_fast_interfaces, &mut binding.cos_interfaces);
+    let iface_fast = cos_fast_interfaces.get(&root_ifindex)?;
+    let shared_root_lease = iface_fast.shared_root_lease.clone();
+    let queue_fast_path = iface_fast.queue_fast_path.as_slice();
     let selected = {
-        let root = binding.cos_interfaces.get_mut(&root_ifindex)?;
+        let root = cos_interfaces.get_mut(&root_ifindex)?;
         advance_cos_timer_wheel(root, now_ns);
         if let Some(shared_root_lease) = shared_root_lease.as_ref() {
             maybe_top_up_cos_root_lease(root, shared_root_lease, now_ns);
         }
-        select_cos_guarantee_batch_with_shared_leases(
-            root,
-            root_ifindex,
-            &binding.cos_shared_queue_leases,
-            now_ns,
-        )
-        .or_else(|| select_cos_surplus_batch(root, now_ns))
+        select_cos_guarantee_batch_with_fast_path(root, queue_fast_path, now_ns)
+            .or_else(|| select_cos_surplus_batch(root, now_ns))
     };
     if selected.is_some() {
         refresh_cos_interface_activity(binding, root_ifindex);
@@ -843,14 +759,12 @@ fn build_cos_batch(
 }
 
 fn select_cos_guarantee_batch(root: &mut CoSInterfaceRuntime, now_ns: u64) -> Option<CoSBatch> {
-    let shared_queue_leases = BTreeMap::new();
-    select_cos_guarantee_batch_with_shared_leases(root, 0, &shared_queue_leases, now_ns)
+    select_cos_guarantee_batch_with_fast_path(root, &[], now_ns)
 }
 
-fn select_cos_guarantee_batch_with_shared_leases(
+fn select_cos_guarantee_batch_with_fast_path(
     root: &mut CoSInterfaceRuntime,
-    root_ifindex: i32,
-    shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
     now_ns: u64,
 ) -> Option<CoSBatch> {
     let queue_count = root.queues.len();
@@ -867,7 +781,9 @@ fn select_cos_guarantee_batch_with_shared_leases(
         if queue.exact {
             maybe_top_up_cos_queue_lease(
                 queue,
-                shared_queue_leases.get(&(root_ifindex, queue.queue_id)),
+                queue_fast_path
+                    .get(queue_idx)
+                    .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref()),
                 now_ns,
             );
         } else {
@@ -1920,6 +1836,9 @@ fn ensure_cos_interface_runtime(
     let Some(config) = forwarding.cos.interfaces.get(&egress_ifindex) else {
         return false;
     };
+    if !binding.cos_fast_interfaces.contains_key(&egress_ifindex) {
+        return false;
+    }
     if !binding.cos_interfaces.contains_key(&egress_ifindex) {
         binding
             .cos_interfaces
@@ -2098,17 +2017,17 @@ fn enqueue_cos_item(
 fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32) {
     let mut new_nonempty = 0usize;
     let mut new_runnable = 0usize;
-    let mut released_queue_leases = Vec::<(u8, u64)>::new();
+    let mut released_queue_leases = Vec::<(usize, u64)>::new();
     let old_nonempty = binding
         .cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.nonempty_queues)
         .unwrap_or(0);
     if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
-        for queue in &mut root.queues {
+        for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
             normalize_cos_queue_state(queue);
             if queue.items.is_empty() && queue.exact && queue.tokens > 0 {
-                released_queue_leases.push((queue.queue_id, core::mem::take(&mut queue.tokens)));
+                released_queue_leases.push((queue_idx, core::mem::take(&mut queue.tokens)));
             }
             if queue.items.is_empty() {
                 continue;
@@ -2127,12 +2046,15 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
         binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_sub(1);
         release_cos_root_lease(binding, root_ifindex);
     }
-    for (queue_id, released) in released_queue_leases {
-        if let Some(shared_queue_lease) = binding
-            .cos_shared_queue_leases
-            .get(&(root_ifindex, queue_id))
-        {
-            shared_queue_lease.release_unused(released);
+    if let Some(iface_fast) = binding.cos_fast_interfaces.get(&root_ifindex) {
+        for (queue_idx, released) in released_queue_leases {
+            if let Some(shared_queue_lease) = iface_fast
+                .queue_fast_path
+                .get(queue_idx)
+                .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+            {
+                shared_queue_lease.release_unused(released);
+            }
         }
     }
 }
@@ -2146,7 +2068,11 @@ fn release_cos_root_lease(binding: &mut BindingWorker, root_ifindex: i32) {
     if released == 0 {
         return;
     }
-    if let Some(shared_root_lease) = binding.cos_shared_root_leases.get(&root_ifindex) {
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
         shared_root_lease.release_unused(released);
     }
 }
@@ -2165,27 +2091,26 @@ pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
         .flat_map(|(&root_ifindex, root)| {
             root.queues
                 .iter()
-                .filter(|queue| queue.exact && queue.tokens > 0)
-                .map(move |queue| (root_ifindex, queue.queue_id))
+                .enumerate()
+                .filter(|(_, queue)| queue.exact && queue.tokens > 0)
+                .map(move |(queue_idx, _)| (root_ifindex, queue_idx))
         })
         .collect::<Vec<_>>();
-    for (root_ifindex, queue_id) in queue_keys {
+    for (root_ifindex, queue_idx) in queue_keys {
         let released = binding
             .cos_interfaces
             .get_mut(&root_ifindex)
-            .and_then(|root| {
-                root.queues
-                    .iter_mut()
-                    .find(|queue| queue.queue_id == queue_id)
-                    .map(|queue| core::mem::take(&mut queue.tokens))
-            })
+            .and_then(|root| root.queues.get_mut(queue_idx))
+            .map(|queue| core::mem::take(&mut queue.tokens))
             .unwrap_or(0);
         if released == 0 {
             continue;
         }
         if let Some(shared_queue_lease) = binding
-            .cos_shared_queue_leases
-            .get(&(root_ifindex, queue_id))
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
         {
             shared_queue_lease.release_unused(released);
         }
@@ -2207,15 +2132,13 @@ fn apply_cos_send_result(
     sent_bytes: u64,
     retry: VecDeque<TxRequest>,
 ) {
-    let mut queue_key = None;
-    let mut exact_queue = false;
+    let mut exact_queue_idx = None;
     {
         let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            queue_key = Some((root_ifindex, queue.queue_id));
-            exact_queue = queue.exact;
+            exact_queue_idx = queue.exact.then_some(queue_idx);
             restore_cos_local_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
             match phase {
@@ -2229,14 +2152,21 @@ fn apply_cos_send_result(
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
-    if let Some(shared_root_lease) = binding.cos_shared_root_leases.get(&root_ifindex) {
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
         shared_root_lease.consume(sent_bytes);
     }
-    if exact_queue {
-        if let Some(queue_key) = queue_key {
-            if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&queue_key) {
-                shared_queue_lease.consume(sent_bytes);
-            }
+    if let Some(queue_idx) = exact_queue_idx {
+        if let Some(shared_queue_lease) = binding
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+        {
+            shared_queue_lease.consume(sent_bytes);
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
@@ -2250,15 +2180,13 @@ fn apply_cos_prepared_result(
     sent_bytes: u64,
     retry: VecDeque<PreparedTxRequest>,
 ) {
-    let mut queue_key = None;
-    let mut exact_queue = false;
+    let mut exact_queue_idx = None;
     {
         let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            queue_key = Some((root_ifindex, queue.queue_id));
-            exact_queue = queue.exact;
+            exact_queue_idx = queue.exact.then_some(queue_idx);
             restore_cos_prepared_items_inner(queue, retry);
             queue.queued_bytes = recompute_cos_queue_bytes(&queue.items);
             match phase {
@@ -2272,14 +2200,21 @@ fn apply_cos_prepared_result(
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
-    if let Some(shared_root_lease) = binding.cos_shared_root_leases.get(&root_ifindex) {
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
         shared_root_lease.consume(sent_bytes);
     }
-    if exact_queue {
-        if let Some(queue_key) = queue_key {
-            if let Some(shared_queue_lease) = binding.cos_shared_queue_leases.get(&queue_key) {
-                shared_queue_lease.consume(sent_bytes);
-            }
+    if let Some(queue_idx) = exact_queue_idx {
+        if let Some(shared_queue_lease) = binding
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+        {
+            shared_queue_lease.consume(sent_bytes);
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
@@ -2805,6 +2740,53 @@ mod tests {
         CoSSchedulerSnapshot, FirewallFilterSnapshot, FirewallTermSnapshot,
     };
 
+    fn test_queue_fast_path(
+        shared_exact: bool,
+        owner_worker_id: u32,
+        owner_live: Option<Arc<BindingLiveState>>,
+        shared_queue_lease: Option<Arc<SharedCoSQueueLease>>,
+    ) -> WorkerCoSQueueFastPath {
+        WorkerCoSQueueFastPath {
+            shared_exact,
+            owner_worker_id,
+            owner_live,
+            shared_queue_lease,
+        }
+    }
+
+    fn test_cos_fast_interfaces(
+        egress_ifindex: i32,
+        tx_ifindex: i32,
+        default_queue: u8,
+        queue_entries: Vec<(u8, WorkerCoSQueueFastPath)>,
+        tx_owner_live: Option<Arc<BindingLiveState>>,
+        shared_root_lease: Option<Arc<SharedCoSRootLease>>,
+    ) -> FastMap<i32, WorkerCoSInterfaceFastPath> {
+        let mut queue_index_by_id = [COS_FAST_QUEUE_INDEX_MISS; 256];
+        let mut queue_fast_path = Vec::with_capacity(queue_entries.len());
+        for (idx, (queue_id, queue)) in queue_entries.into_iter().enumerate() {
+            queue_index_by_id[usize::from(queue_id)] = idx as u16;
+            queue_fast_path.push(queue);
+        }
+        let default_queue_index = match queue_index_by_id[usize::from(default_queue)] {
+            COS_FAST_QUEUE_INDEX_MISS => panic!("missing default queue {default_queue}"),
+            idx => idx as usize,
+        };
+        let mut interfaces = FastMap::default();
+        interfaces.insert(
+            egress_ifindex,
+            WorkerCoSInterfaceFastPath {
+                tx_ifindex,
+                default_queue_index,
+                queue_index_by_id,
+                tx_owner_live,
+                shared_root_lease,
+                queue_fast_path,
+            },
+        );
+        interfaces
+    }
+
     #[test]
     fn merge_pending_tx_requests_appends_shared_after_local() {
         let local = VecDeque::from(vec![
@@ -2884,23 +2866,14 @@ mod tests {
     fn redirect_local_cos_request_to_owner_pushes_worker_command() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
-        let owner_live_by_tx_ifindex = BTreeMap::new();
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 4,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: Vec::new(),
-            },
+            12,
+            4,
+            vec![(4, test_queue_fast_path(false, 7, None, None))],
+            None,
+            None,
         );
-        let cos_owner_worker_by_queue = BTreeMap::from([((80, 4), 7)]);
         let req = TxRequest {
             bytes: vec![1, 2, 3],
             expected_ports: None,
@@ -2913,13 +2886,10 @@ mod tests {
         };
 
         let redirected = redirect_local_cos_request_to_owner(
-            &owner_live_by_tx_ifindex,
-            &forwarding,
+            &cos_fast_interfaces,
             req,
             2,
             &worker_commands_by_id,
-            &cos_owner_worker_by_queue,
-            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
@@ -2938,23 +2908,14 @@ mod tests {
     fn redirect_local_cos_request_to_owner_uses_interface_default_queue_owner_when_unset() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
-        let owner_live_by_tx_ifindex = BTreeMap::new();
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 5,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: Vec::new(),
-            },
+            12,
+            5,
+            vec![(5, test_queue_fast_path(false, 7, None, None))],
+            None,
+            None,
         );
-        let cos_owner_worker_by_queue = BTreeMap::from([((80, 5), 7)]);
         let req = TxRequest {
             bytes: vec![1, 2, 3],
             expected_ports: None,
@@ -2967,13 +2928,10 @@ mod tests {
         };
 
         let redirected = redirect_local_cos_request_to_owner(
-            &owner_live_by_tx_ifindex,
-            &forwarding,
+            &cos_fast_interfaces,
             req,
             2,
             &worker_commands_by_id,
-            &cos_owner_worker_by_queue,
-            &BTreeMap::new(),
         );
 
         assert!(redirected.is_ok());
@@ -2985,45 +2943,27 @@ mod tests {
     fn redirect_local_cos_request_to_owner_keeps_exact_queue_on_eligible_worker() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
-        let owner_live_by_tx_ifindex = BTreeMap::from([(12, Arc::new(BindingLiveState::new()))]);
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let tx_owner_live = Arc::new(BindingLiveState::new());
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 4,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: vec![CoSQueueConfig {
-                    queue_id: 4,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 1_000_000,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                }],
-            },
+            12,
+            4,
+            vec![(
+                4,
+                test_queue_fast_path(
+                    true,
+                    7,
+                    None,
+                    Some(Arc::new(SharedCoSQueueLease::new(
+                        1_000_000,
+                        COS_MIN_BURST_BYTES,
+                        2,
+                    ))),
+                ),
+            )],
+            Some(tx_owner_live),
+            None,
         );
-        forwarding.egress.insert(
-            80,
-            EgressInterface {
-                bind_ifindex: 12,
-                vlan_id: 80,
-                mtu: 1500,
-                src_mac: [0; 6],
-                zone: "wan".to_string(),
-                redundancy_group: 0,
-                primary_v4: None,
-                primary_v6: None,
-            },
-        );
-        let cos_owner_worker_by_queue = BTreeMap::from([((80, 4), 7)]);
         let req = TxRequest {
             bytes: vec![1, 2, 3],
             expected_ports: None,
@@ -3036,13 +2976,10 @@ mod tests {
         };
 
         let redirected = redirect_local_cos_request_to_owner(
-            &owner_live_by_tx_ifindex,
-            &forwarding,
+            &cos_fast_interfaces,
             req,
             2,
             &worker_commands_by_id,
-            &cos_owner_worker_by_queue,
-            &BTreeMap::new(),
         );
 
         assert!(redirected.is_err());
@@ -3161,18 +3098,21 @@ mod tests {
         root.queues[0].runnable = true;
         root.nonempty_queues = 1;
         root.runnable_queues = 1;
-        let shared_queue_leases = BTreeMap::from([(
-            (42, 0),
-            Arc::new(SharedCoSQueueLease::new(
-                400_000_000 / 8,
-                COS_MIN_BURST_BYTES,
-                2,
-            )),
-        )]);
+        let shared_queue_lease = Arc::new(SharedCoSQueueLease::new(
+            400_000_000 / 8,
+            COS_MIN_BURST_BYTES,
+            2,
+        ));
+        let queue_fast_path = vec![test_queue_fast_path(
+            true,
+            0,
+            None,
+            Some(shared_queue_lease.clone()),
+        )];
 
         maybe_top_up_cos_queue_lease(
             &mut root.queues[0],
-            shared_queue_leases.get(&(42, 0)),
+            Some(&shared_queue_lease),
             1_000_000_000,
         );
 
@@ -3181,13 +3121,8 @@ mod tests {
             "shared exact queue lease must replenish local queue tokens"
         );
         assert!(
-            select_cos_guarantee_batch_with_shared_leases(
-                &mut root,
-                42,
-                &shared_queue_leases,
-                1_000_000_000,
-            )
-            .is_some()
+            select_cos_guarantee_batch_with_fast_path(&mut root, &queue_fast_path, 1_000_000_000,)
+                .is_some()
         );
     }
 
@@ -3225,20 +3160,13 @@ mod tests {
     fn redirect_local_cos_request_to_owner_binding_pushes_owner_live_queue() {
         let current_live = Arc::new(BindingLiveState::new());
         let owner_live = Arc::new(BindingLiveState::new());
-        let owner_live_by_tx_ifindex = BTreeMap::from([(12, owner_live.clone())]);
-        let mut forwarding = ForwardingState::default();
-        forwarding.egress.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            EgressInterface {
-                bind_ifindex: 12,
-                vlan_id: 80,
-                mtu: 1500,
-                src_mac: [0; 6],
-                zone: "wan".to_string(),
-                redundancy_group: 0,
-                primary_v4: None,
-                primary_v6: None,
-            },
+            12,
+            4,
+            vec![(4, test_queue_fast_path(false, 7, None, None))],
+            Some(owner_live.clone()),
+            None,
         );
         let req = TxRequest {
             bytes: vec![1, 2, 3],
@@ -3251,12 +3179,8 @@ mod tests {
             dscp_rewrite: None,
         };
 
-        let redirected = redirect_local_cos_request_to_owner_binding(
-            &current_live,
-            &owner_live_by_tx_ifindex,
-            &forwarding,
-            req,
-        );
+        let redirected =
+            redirect_local_cos_request_to_owner_binding(&current_live, &cos_fast_interfaces, req);
 
         assert!(redirected.is_ok());
         let queued = owner_live.take_pending_tx();
@@ -3269,43 +3193,25 @@ mod tests {
     fn redirect_local_exact_cos_request_to_owner_binding_pushes_owner_live_queue() {
         let current_live = Arc::new(BindingLiveState::new());
         let owner_live = Arc::new(BindingLiveState::new());
-        let owner_live_by_tx_ifindex = BTreeMap::from([(12, owner_live.clone())]);
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 4,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: vec![CoSQueueConfig {
-                    queue_id: 4,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 1_000_000,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                }],
-            },
-        );
-        forwarding.egress.insert(
-            80,
-            EgressInterface {
-                bind_ifindex: 12,
-                vlan_id: 80,
-                mtu: 1500,
-                src_mac: [0; 6],
-                zone: "wan".to_string(),
-                redundancy_group: 0,
-                primary_v4: None,
-                primary_v6: None,
-            },
+            12,
+            4,
+            vec![(
+                4,
+                test_queue_fast_path(
+                    true,
+                    7,
+                    None,
+                    Some(Arc::new(SharedCoSQueueLease::new(
+                        1_000_000,
+                        COS_MIN_BURST_BYTES,
+                        2,
+                    ))),
+                ),
+            )],
+            Some(owner_live.clone()),
+            None,
         );
         let req = TxRequest {
             bytes: vec![1, 2, 3],
@@ -3318,12 +3224,8 @@ mod tests {
             dscp_rewrite: None,
         };
 
-        let redirected = redirect_local_cos_request_to_owner_binding(
-            &current_live,
-            &owner_live_by_tx_ifindex,
-            &forwarding,
-            req,
-        );
+        let redirected =
+            redirect_local_cos_request_to_owner_binding(&current_live, &cos_fast_interfaces, req);
 
         assert!(redirected.is_ok());
         let queued = owner_live.take_pending_tx();
@@ -3334,127 +3236,52 @@ mod tests {
 
     #[test]
     fn prepared_cos_request_stays_on_current_tx_binding_for_exact_queue() {
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 5,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: vec![CoSQueueConfig {
-                    queue_id: 5,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 1_000_000,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                }],
-            },
+            12,
+            5,
+            vec![(
+                5,
+                test_queue_fast_path(
+                    true,
+                    7,
+                    None,
+                    Some(Arc::new(SharedCoSQueueLease::new(
+                        1_000_000,
+                        COS_MIN_BURST_BYTES,
+                        2,
+                    ))),
+                ),
+            )],
+            Some(Arc::new(BindingLiveState::new())),
+            None,
         );
-        forwarding.egress.insert(
-            80,
-            EgressInterface {
-                bind_ifindex: 12,
-                vlan_id: 80,
-                mtu: 1500,
-                src_mac: [0; 6],
-                zone: "wan".to_string(),
-                redundancy_group: 0,
-                primary_v4: None,
-                primary_v6: None,
-            },
-        );
-        let req = PreparedTxRequest {
-            offset: 64,
-            len: 1500,
-            recycle: PreparedTxRecycle::FreeTxFrame,
-            expected_ports: None,
-            expected_addr_family: libc::AF_INET6 as u8,
-            expected_protocol: PROTO_TCP,
-            flow_key: None,
-            egress_ifindex: 80,
-            cos_queue_id: Some(5),
-            dscp_rewrite: None,
-        };
+        let iface_fast = cos_fast_interfaces.get(&80).unwrap();
+        let queue_fast = iface_fast.queue_fast_path(Some(5)).unwrap();
 
         assert!(prepared_cos_request_stays_on_current_tx_binding(
-            12,
-            12,
-            &forwarding,
-            &req,
+            12, iface_fast, queue_fast,
         ));
         assert!(!prepared_cos_request_stays_on_current_tx_binding(
-            13,
-            12,
-            &forwarding,
-            &req,
+            13, iface_fast, queue_fast,
         ));
     }
 
     #[test]
     fn prepared_cos_request_stays_on_current_tx_binding_only_for_exact_queue() {
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
+        let cos_fast_interfaces = test_cos_fast_interfaces(
             80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 5,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: vec![CoSQueueConfig {
-                    queue_id: 5,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 1_000_000,
-                    exact: false,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                }],
-            },
+            12,
+            5,
+            vec![(5, test_queue_fast_path(false, 7, None, None))],
+            Some(Arc::new(BindingLiveState::new())),
+            None,
         );
-        forwarding.egress.insert(
-            80,
-            EgressInterface {
-                bind_ifindex: 12,
-                vlan_id: 80,
-                mtu: 1500,
-                src_mac: [0; 6],
-                zone: "wan".to_string(),
-                redundancy_group: 0,
-                primary_v4: None,
-                primary_v6: None,
-            },
-        );
-        let req = PreparedTxRequest {
-            offset: 64,
-            len: 1500,
-            recycle: PreparedTxRecycle::FreeTxFrame,
-            expected_ports: None,
-            expected_addr_family: libc::AF_INET6 as u8,
-            expected_protocol: PROTO_TCP,
-            flow_key: None,
-            egress_ifindex: 80,
-            cos_queue_id: Some(5),
-            dscp_rewrite: None,
-        };
+        let iface_fast = cos_fast_interfaces.get(&80).unwrap();
+        let queue_fast = iface_fast.queue_fast_path(Some(5)).unwrap();
 
         assert!(!prepared_cos_request_stays_on_current_tx_binding(
-            12,
-            12,
-            &forwarding,
-            &req,
+            12, iface_fast, queue_fast,
         ));
     }
 
@@ -3462,24 +3289,18 @@ mod tests {
     fn redirect_local_cos_request_to_owner_uses_owner_live_queue_when_available() {
         let commands = Arc::new(Mutex::new(VecDeque::new()));
         let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
-        let mut forwarding = ForwardingState::default();
-        forwarding.cos.interfaces.insert(
-            80,
-            CoSInterfaceConfig {
-                shaping_rate_bytes: 1_000_000,
-                burst_bytes: COS_MIN_BURST_BYTES,
-                default_queue: 4,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: Vec::new(),
-            },
-        );
         let owner_live = Arc::new(BindingLiveState::new());
-        let cos_owner_worker_by_queue = BTreeMap::from([((80, 4), 7)]);
-        let cos_owner_live_by_queue = BTreeMap::from([((80, 4), owner_live.clone())]);
+        let cos_fast_interfaces = test_cos_fast_interfaces(
+            80,
+            12,
+            4,
+            vec![(
+                4,
+                test_queue_fast_path(false, 7, Some(owner_live.clone()), None),
+            )],
+            None,
+            None,
+        );
         let req = TxRequest {
             bytes: vec![1, 2, 3],
             expected_ports: None,
@@ -3492,13 +3313,10 @@ mod tests {
         };
 
         let redirected = redirect_local_cos_request_to_owner(
-            &BTreeMap::new(),
-            &forwarding,
+            &cos_fast_interfaces,
             req,
             2,
             &worker_commands_by_id,
-            &cos_owner_worker_by_queue,
-            &cos_owner_live_by_queue,
         );
 
         assert!(redirected.is_ok());

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(super) type FastMap<K, V> = FxHashMap<K, V>;
 pub(super) type FastSet<T> = FxHashSet<T>;
@@ -584,6 +585,52 @@ impl WorkerBindingLookup {
     }
 }
 
+pub(super) const COS_FAST_QUEUE_INDEX_MISS: u16 = u16::MAX;
+
+#[derive(Clone)]
+pub(super) struct WorkerCoSQueueFastPath {
+    pub(super) shared_exact: bool,
+    pub(super) owner_worker_id: u32,
+    pub(super) owner_live: Option<Arc<BindingLiveState>>,
+    pub(super) shared_queue_lease: Option<Arc<SharedCoSQueueLease>>,
+}
+
+#[derive(Clone)]
+pub(super) struct WorkerCoSInterfaceFastPath {
+    pub(super) tx_ifindex: i32,
+    pub(super) default_queue_index: usize,
+    pub(super) queue_index_by_id: [u16; 256],
+    pub(super) tx_owner_live: Option<Arc<BindingLiveState>>,
+    pub(super) shared_root_lease: Option<Arc<SharedCoSRootLease>>,
+    pub(super) queue_fast_path: Vec<WorkerCoSQueueFastPath>,
+}
+
+impl WorkerCoSInterfaceFastPath {
+    #[inline]
+    pub(super) fn effective_queue_index(&self, requested_queue_id: Option<u8>) -> Option<usize> {
+        if let Some(queue_id) = requested_queue_id {
+            let idx = self.queue_index_by_id[usize::from(queue_id)];
+            if idx != COS_FAST_QUEUE_INDEX_MISS {
+                return Some(idx as usize);
+            }
+            return None;
+        }
+        (!self.queue_fast_path.is_empty()).then_some(
+            self.default_queue_index
+                .min(self.queue_fast_path.len().saturating_sub(1)),
+        )
+    }
+
+    #[inline]
+    pub(super) fn queue_fast_path(
+        &self,
+        requested_queue_id: Option<u8>,
+    ) -> Option<&WorkerCoSQueueFastPath> {
+        self.effective_queue_index(requested_queue_id)
+            .and_then(|idx| self.queue_fast_path.get(idx))
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct SessionFlow {
     pub(super) src_ip: IpAddr,
@@ -734,13 +781,13 @@ pub(super) struct CoSTimerWheelRuntime {
 #[repr(align(64))]
 pub(super) struct SharedCoSQueueLease {
     config: SharedCoSLeaseConfig,
-    state: Mutex<SharedCoSLeaseState>,
+    state: SharedCoSLeaseState,
 }
 
 #[repr(align(64))]
 pub(super) struct SharedCoSRootLease {
     config: SharedCoSLeaseConfig,
-    state: Mutex<SharedCoSLeaseState>,
+    state: SharedCoSLeaseState,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -752,11 +799,10 @@ struct SharedCoSLeaseConfig {
     active_shards: usize,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Debug)]
 struct SharedCoSLeaseState {
-    available_tokens: u64,
-    outstanding_leased_tokens: u64,
-    last_refill_ns: u64,
+    credits: AtomicU64,
+    last_refill_ns: AtomicU64,
 }
 
 const COS_ROOT_LEASE_TARGET_US: u64 = 200;
@@ -769,6 +815,11 @@ fn compute_shared_cos_lease_config(
     active_shards: usize,
 ) -> SharedCoSLeaseConfig {
     let burst_bytes = burst_bytes.max(COS_ROOT_LEASE_MIN_BYTES);
+    assert!(
+        burst_bytes <= u32::MAX as u64,
+        "shared CoS burst exceeds packed lease range: {}",
+        burst_bytes
+    );
     let active_shards = active_shards.max(1);
     let target_lease_bytes =
         ((rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128) / 1_000_000u128) as u64;
@@ -783,6 +834,7 @@ fn compute_shared_cos_lease_config(
     let max_total_leased = burst_bytes
         .saturating_div(4)
         .min(max_frame_lease_bytes.saturating_mul(active_shards as u64));
+    debug_assert!(max_total_leased <= u32::MAX as u64);
     SharedCoSLeaseConfig {
         rate_bytes,
         burst_bytes,
@@ -792,34 +844,72 @@ fn compute_shared_cos_lease_config(
     }
 }
 
+#[inline(always)]
+fn pack_shared_cos_lease_credits(available_tokens: u64, outstanding_leased_tokens: u64) -> u64 {
+    debug_assert!(available_tokens <= u32::MAX as u64);
+    debug_assert!(outstanding_leased_tokens <= u32::MAX as u64);
+    (available_tokens << 32) | outstanding_leased_tokens
+}
+
+#[inline(always)]
+fn unpack_shared_cos_lease_credits(credits: u64) -> (u64, u64) {
+    ((credits >> 32) as u64, (credits as u32) as u64)
+}
+
 fn shared_cos_lease_acquire(
     config: SharedCoSLeaseConfig,
-    state: &Mutex<SharedCoSLeaseState>,
+    state: &SharedCoSLeaseState,
     now_ns: u64,
     requested: u64,
 ) -> u64 {
-    let Ok(mut state) = state.lock() else {
-        return 0;
-    };
-    refill_shared_cos_lease_locked(config, &mut state, now_ns);
-    let lease_headroom = config
-        .max_total_leased
-        .saturating_sub(state.outstanding_leased_tokens);
-    if lease_headroom == 0 || state.available_tokens == 0 {
+    if requested == 0 {
         return 0;
     }
-    let granted = requested.min(state.available_tokens).min(lease_headroom);
-    state.available_tokens = state.available_tokens.saturating_sub(granted);
-    state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_add(granted);
-    granted
+    refill_shared_cos_lease_state(config, state, now_ns);
+    loop {
+        let credits = state.credits.load(Ordering::Acquire);
+        let (available_tokens, outstanding_leased_tokens) =
+            unpack_shared_cos_lease_credits(credits);
+        let lease_headroom = config
+            .max_total_leased
+            .saturating_sub(outstanding_leased_tokens);
+        let granted = requested.min(available_tokens).min(lease_headroom);
+        if granted == 0 {
+            return 0;
+        }
+        let new_credits = pack_shared_cos_lease_credits(
+            available_tokens.saturating_sub(granted),
+            outstanding_leased_tokens.saturating_add(granted),
+        );
+        if state
+            .credits
+            .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return granted;
+        }
+    }
 }
 
-fn shared_cos_lease_consume(state: &Mutex<SharedCoSLeaseState>, bytes: u64) {
+fn shared_cos_lease_consume(state: &SharedCoSLeaseState, bytes: u64) {
     if bytes == 0 {
         return;
     }
-    if let Ok(mut state) = state.lock() {
-        state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
+    loop {
+        let credits = state.credits.load(Ordering::Acquire);
+        let (available_tokens, outstanding_leased_tokens) =
+            unpack_shared_cos_lease_credits(credits);
+        let new_credits = pack_shared_cos_lease_credits(
+            available_tokens,
+            outstanding_leased_tokens.saturating_sub(bytes),
+        );
+        if state
+            .credits
+            .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return;
+        }
     }
 }
 
@@ -833,56 +923,88 @@ fn shared_cos_lease_available_cap(
 
 fn shared_cos_lease_release_unused(
     config: SharedCoSLeaseConfig,
-    state: &Mutex<SharedCoSLeaseState>,
+    state: &SharedCoSLeaseState,
     bytes: u64,
 ) {
     if bytes == 0 {
         return;
     }
-    if let Ok(mut state) = state.lock() {
-        state.outstanding_leased_tokens = state.outstanding_leased_tokens.saturating_sub(bytes);
-        state.available_tokens =
-            state
-                .available_tokens
-                .saturating_add(bytes)
-                .min(shared_cos_lease_available_cap(
-                    config,
-                    state.outstanding_leased_tokens,
-                ));
+    loop {
+        let credits = state.credits.load(Ordering::Acquire);
+        let (available_tokens, outstanding_leased_tokens) =
+            unpack_shared_cos_lease_credits(credits);
+        let new_outstanding = outstanding_leased_tokens.saturating_sub(bytes);
+        let new_available = available_tokens
+            .saturating_add(bytes)
+            .min(shared_cos_lease_available_cap(config, new_outstanding));
+        let new_credits = pack_shared_cos_lease_credits(new_available, new_outstanding);
+        if state
+            .credits
+            .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return;
+        }
     }
 }
 
-fn refill_shared_cos_lease_locked(
+fn refill_shared_cos_lease_state(
     config: SharedCoSLeaseConfig,
-    state: &mut SharedCoSLeaseState,
+    state: &SharedCoSLeaseState,
     now_ns: u64,
 ) {
     if config.burst_bytes == 0 {
         return;
     }
-    if state.last_refill_ns == 0 {
-        state.available_tokens =
-            shared_cos_lease_available_cap(config, state.outstanding_leased_tokens);
-        state.last_refill_ns = now_ns;
-        return;
+    loop {
+        let last_refill_ns = state.last_refill_ns.load(Ordering::Acquire);
+        if last_refill_ns == 0 {
+            if state
+                .last_refill_ns
+                .compare_exchange(0, now_ns, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
+            }
+            continue;
+        }
+        if now_ns <= last_refill_ns || config.rate_bytes == 0 {
+            return;
+        }
+        let elapsed_ns = now_ns - last_refill_ns;
+        let added = ((elapsed_ns as u128) * (config.rate_bytes as u128) / 1_000_000_000u128) as u64;
+        if added == 0 {
+            return;
+        }
+        if state
+            .last_refill_ns
+            .compare_exchange(last_refill_ns, now_ns, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            continue;
+        }
+        loop {
+            let credits = state.credits.load(Ordering::Acquire);
+            let (available_tokens, outstanding_leased_tokens) =
+                unpack_shared_cos_lease_credits(credits);
+            let new_available =
+                available_tokens
+                    .saturating_add(added)
+                    .min(shared_cos_lease_available_cap(
+                        config,
+                        outstanding_leased_tokens,
+                    ));
+            let new_credits =
+                pack_shared_cos_lease_credits(new_available, outstanding_leased_tokens);
+            if state
+                .credits
+                .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
+            }
+        }
     }
-    if now_ns <= state.last_refill_ns || config.rate_bytes == 0 {
-        return;
-    }
-    let elapsed_ns = now_ns - state.last_refill_ns;
-    let added = ((elapsed_ns as u128) * (config.rate_bytes as u128) / 1_000_000_000u128) as u64;
-    if added == 0 {
-        return;
-    }
-    state.available_tokens =
-        state
-            .available_tokens
-            .saturating_add(added)
-            .min(shared_cos_lease_available_cap(
-                config,
-                state.outstanding_leased_tokens,
-            ));
-    state.last_refill_ns = now_ns;
 }
 
 impl SharedCoSQueueLease {
@@ -890,11 +1012,10 @@ impl SharedCoSQueueLease {
         let config = compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards);
         Self {
             config,
-            state: Mutex::new(SharedCoSLeaseState {
-                available_tokens: config.burst_bytes,
-                outstanding_leased_tokens: 0,
-                last_refill_ns: 0,
-            }),
+            state: SharedCoSLeaseState {
+                credits: AtomicU64::new(pack_shared_cos_lease_credits(config.burst_bytes, 0)),
+                last_refill_ns: AtomicU64::new(0),
+            },
         }
     }
 
@@ -930,11 +1051,10 @@ impl SharedCoSRootLease {
             compute_shared_cos_lease_config(shaping_rate_bytes, burst_bytes, active_shards);
         Self {
             config,
-            state: Mutex::new(SharedCoSLeaseState {
-                available_tokens: config.burst_bytes,
-                outstanding_leased_tokens: 0,
-                last_refill_ns: 0,
-            }),
+            state: SharedCoSLeaseState {
+                credits: AtomicU64::new(pack_shared_cos_lease_credits(config.burst_bytes, 0)),
+                last_refill_ns: AtomicU64::new(0),
+            },
         }
     }
 
@@ -969,36 +1089,44 @@ impl SharedCoSRootLease {
 mod tests {
     use super::*;
 
+    fn shared_cos_lease_snapshot(lease: &SharedCoSRootLease) -> (u64, u64, u64) {
+        let (available_tokens, outstanding_leased_tokens) =
+            unpack_shared_cos_lease_credits(lease.state.credits.load(Ordering::Relaxed));
+        let last_refill_ns = lease.state.last_refill_ns.load(Ordering::Relaxed);
+        (available_tokens, outstanding_leased_tokens, last_refill_ns)
+    }
+
     #[test]
     fn shared_cos_root_lease_refill_respects_outstanding_burst_credit() {
         let lease = SharedCoSRootLease::new(10_000_000, 16_000, 1);
-        let mut state = lease.state.lock().unwrap();
-        state.available_tokens = 0;
-        state.outstanding_leased_tokens = 4_000;
-        state.last_refill_ns = 1;
+        lease
+            .state
+            .credits
+            .store(pack_shared_cos_lease_credits(0, 4_000), Ordering::Relaxed);
+        lease.state.last_refill_ns.store(1, Ordering::Relaxed);
 
-        refill_shared_cos_lease_locked(lease.config, &mut state, 1_000_000_001);
+        refill_shared_cos_lease_state(lease.config, &lease.state, 1_000_000_001);
 
+        let (available_tokens, outstanding_leased_tokens, _) = shared_cos_lease_snapshot(&lease);
         assert_eq!(
-            state.available_tokens,
-            lease.config.burst_bytes - state.outstanding_leased_tokens
+            available_tokens,
+            lease.config.burst_bytes - outstanding_leased_tokens
         );
     }
 
     #[test]
     fn shared_cos_root_lease_release_unused_preserves_total_burst_bound() {
         let lease = SharedCoSRootLease::new(10_000_000, 16_000, 1);
-        {
-            let mut state = lease.state.lock().unwrap();
-            state.available_tokens = lease.config.burst_bytes;
-            state.outstanding_leased_tokens = 4_000;
-        }
+        lease.state.credits.store(
+            pack_shared_cos_lease_credits(lease.config.burst_bytes, 4_000),
+            Ordering::Relaxed,
+        );
 
         lease.release_unused(1_500);
 
-        let state = lease.state.lock().unwrap();
+        let (available_tokens, outstanding_leased_tokens, _) = shared_cos_lease_snapshot(&lease);
         assert_eq!(
-            state.available_tokens + state.outstanding_leased_tokens,
+            available_tokens + outstanding_leased_tokens,
             lease.config.burst_bytes
         );
     }

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -778,13 +778,11 @@ pub(super) struct CoSTimerWheelRuntime {
     pub(super) level1: [Vec<usize>; COS_TIMER_WHEEL_L1_SLOTS],
 }
 
-#[repr(align(64))]
 pub(super) struct SharedCoSQueueLease {
     config: SharedCoSLeaseConfig,
     state: SharedCoSLeaseState,
 }
 
-#[repr(align(64))]
 pub(super) struct SharedCoSRootLease {
     config: SharedCoSLeaseConfig,
     state: SharedCoSLeaseState,
@@ -799,6 +797,7 @@ struct SharedCoSLeaseConfig {
     active_shards: usize,
 }
 
+#[repr(align(64))]
 #[derive(Debug)]
 struct SharedCoSLeaseState {
     credits: AtomicU64,
@@ -814,12 +813,9 @@ fn compute_shared_cos_lease_config(
     burst_bytes: u64,
     active_shards: usize,
 ) -> SharedCoSLeaseConfig {
-    let burst_bytes = burst_bytes.max(COS_ROOT_LEASE_MIN_BYTES);
-    assert!(
-        burst_bytes <= u32::MAX as u64,
-        "shared CoS burst exceeds packed lease range: {}",
-        burst_bytes
-    );
+    let burst_bytes = burst_bytes
+        .max(COS_ROOT_LEASE_MIN_BYTES)
+        .min(u32::MAX as u64);
     let active_shards = active_shards.max(1);
     let target_lease_bytes =
         ((rate_bytes as u128) * (COS_ROOT_LEASE_TARGET_US as u128) / 1_000_000u128) as u64;
@@ -1088,6 +1084,7 @@ impl SharedCoSRootLease {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::align_of;
 
     fn shared_cos_lease_snapshot(lease: &SharedCoSRootLease) -> (u64, u64, u64) {
         let (available_tokens, outstanding_leased_tokens) =
@@ -1129,6 +1126,17 @@ mod tests {
             available_tokens + outstanding_leased_tokens,
             lease.config.burst_bytes
         );
+    }
+
+    #[test]
+    fn shared_cos_lease_state_is_cacheline_aligned() {
+        assert_eq!(align_of::<SharedCoSLeaseState>(), 64);
+    }
+
+    #[test]
+    fn shared_cos_lease_config_clamps_burst_to_packed_range() {
+        let lease = SharedCoSRootLease::new(10_000_000, u64::MAX, 1);
+        assert_eq!(lease.config.burst_bytes, u32::MAX as u64);
     }
 }
 

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -17,9 +17,7 @@ pub(crate) struct BindingWorker {
     pub(crate) pending_tx_prepared: VecDeque<PreparedTxRequest>,
     pub(crate) pending_tx_local: VecDeque<TxRequest>,
     pub(crate) max_pending_tx: usize,
-    pub(crate) cos_owner_live_by_tx_ifindex: BTreeMap<i32, Arc<BindingLiveState>>,
-    pub(crate) cos_shared_root_leases: BTreeMap<i32, Arc<SharedCoSRootLease>>,
-    pub(crate) cos_shared_queue_leases: BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+    pub(crate) cos_fast_interfaces: FastMap<i32, WorkerCoSInterfaceFastPath>,
     pub(crate) cos_interfaces: FastMap<i32, CoSInterfaceRuntime>,
     pub(crate) cos_interface_order: Vec<i32>,
     pub(crate) cos_interface_rr: usize,
@@ -294,9 +292,7 @@ impl BindingWorker {
             pending_tx_prepared: VecDeque::new(),
             pending_tx_local: VecDeque::new(),
             max_pending_tx,
-            cos_owner_live_by_tx_ifindex: BTreeMap::new(),
-            cos_shared_root_leases: BTreeMap::new(),
-            cos_shared_queue_leases: BTreeMap::new(),
+            cos_fast_interfaces: FastMap::default(),
             cos_interfaces: FastMap::default(),
             cos_interface_order: Vec::new(),
             cos_interface_rr: 0,
@@ -465,10 +461,17 @@ pub(crate) fn worker_loop(
             .iter()
             .map(|binding| (binding.ifindex, binding.live.clone())),
     );
+    let cos_fast_interfaces = build_worker_cos_fast_interfaces(
+        forwarding.as_ref(),
+        worker_id,
+        &cos_owner_live_by_tx_ifindex,
+        cos_owner_worker_by_queue.as_ref(),
+        cos_owner_live_by_queue.as_ref(),
+        cos_shared_root_leases.as_ref(),
+        cos_shared_queue_leases.as_ref(),
+    );
     for binding in bindings.iter_mut() {
-        binding.cos_owner_live_by_tx_ifindex = cos_owner_live_by_tx_ifindex.clone();
-        binding.cos_shared_root_leases = cos_shared_root_leases.as_ref().clone();
-        binding.cos_shared_queue_leases = cos_shared_queue_leases.as_ref().clone();
+        binding.cos_fast_interfaces = cos_fast_interfaces.clone();
     }
     let mut interrupt_poll_fds = if poll_mode == crate::PollMode::Interrupt {
         bindings
@@ -605,6 +608,7 @@ pub(crate) fn worker_loop(
             validation = **live_validation;
         }
         let live_forwarding = shared_forwarding.load_full();
+        let mut rebuild_cos_fast_interfaces = false;
         if !Arc::ptr_eq(&forwarding, &live_forwarding) {
             let cos_changed =
                 cos_runtime_config_changed(forwarding.as_ref(), live_forwarding.as_ref());
@@ -613,15 +617,18 @@ pub(crate) fn worker_loop(
             sessions.set_timeouts(forwarding.session_timeouts);
             if cos_changed {
                 reset_worker_cos_runtimes(&mut bindings);
+                rebuild_cos_fast_interfaces = true;
             }
         }
         let live_cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
         if !Arc::ptr_eq(&cos_owner_worker_by_queue, &live_cos_owner_worker_by_queue) {
             cos_owner_worker_by_queue = live_cos_owner_worker_by_queue;
+            rebuild_cos_fast_interfaces = true;
         }
         let live_cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
         if !Arc::ptr_eq(&cos_owner_live_by_queue, &live_cos_owner_live_by_queue) {
             cos_owner_live_by_queue = live_cos_owner_live_by_queue;
+            rebuild_cos_fast_interfaces = true;
         }
         let live_cos_shared_root_leases = shared_cos_root_leases.load_full();
         if !Arc::ptr_eq(&cos_shared_root_leases, &live_cos_shared_root_leases) {
@@ -630,9 +637,7 @@ pub(crate) fn worker_loop(
                 release_all_cos_queue_leases(binding);
             }
             cos_shared_root_leases = live_cos_shared_root_leases;
-            for binding in bindings.iter_mut() {
-                binding.cos_shared_root_leases = cos_shared_root_leases.as_ref().clone();
-            }
+            rebuild_cos_fast_interfaces = true;
         }
         let live_cos_shared_queue_leases = shared_cos_queue_leases.load_full();
         if !Arc::ptr_eq(&cos_shared_queue_leases, &live_cos_shared_queue_leases) {
@@ -640,8 +645,25 @@ pub(crate) fn worker_loop(
                 release_all_cos_queue_leases(binding);
             }
             cos_shared_queue_leases = live_cos_shared_queue_leases;
+            rebuild_cos_fast_interfaces = true;
+        }
+        if rebuild_cos_fast_interfaces {
+            let cos_owner_live_by_tx_ifindex = build_worker_cos_owner_live_by_tx_ifindex(
+                bindings
+                    .iter()
+                    .map(|binding| (binding.ifindex, binding.live.clone())),
+            );
+            let cos_fast_interfaces = build_worker_cos_fast_interfaces(
+                forwarding.as_ref(),
+                worker_id,
+                &cos_owner_live_by_tx_ifindex,
+                cos_owner_worker_by_queue.as_ref(),
+                cos_owner_live_by_queue.as_ref(),
+                cos_shared_root_leases.as_ref(),
+                cos_shared_queue_leases.as_ref(),
+            );
             for binding in bindings.iter_mut() {
-                binding.cos_shared_queue_leases = cos_shared_queue_leases.as_ref().clone();
+                binding.cos_fast_interfaces = cos_fast_interfaces.clone();
             }
         }
         let ha_runtime = ha_state.load();
@@ -675,8 +697,8 @@ pub(crate) fn worker_loop(
             apply_worker_shaped_tx_requests(
                 &mut bindings,
                 forwarding.as_ref(),
+                &binding_lookup,
                 loop_now_ns,
-                cos_owner_live_by_queue.as_ref(),
                 shaped_tx_requests,
             );
         }
@@ -1378,24 +1400,32 @@ pub(crate) fn worker_loop(
 fn apply_worker_shaped_tx_requests(
     bindings: &mut [BindingWorker],
     forwarding: &ForwardingState,
+    binding_lookup: &WorkerBindingLookup,
     now_ns: u64,
-    _cos_owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
     requests: Vec<TxRequest>,
 ) {
     for req in requests {
-        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
-        let Some(binding) = bindings
-            .iter_mut()
-            .find(|binding| binding.ifindex == tx_ifindex)
-        else {
+        let binding_index = bindings
+            .first()
+            .and_then(|binding| binding.cos_fast_interfaces.get(&req.egress_ifindex))
+            .and_then(|iface_fast| {
+                binding_lookup
+                    .first_by_if
+                    .get(&iface_fast.tx_ifindex)
+                    .copied()
+            })
+            .or_else(|| {
+                let tx_ifindex = resolve_tx_binding_ifindex(forwarding, req.egress_ifindex);
+                binding_lookup.first_by_if.get(&tx_ifindex).copied()
+            });
+        let Some(binding) = binding_index.and_then(|idx| bindings.get_mut(idx)) else {
             if let Some(binding) = bindings.first_mut() {
                 binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
             }
             if cfg!(feature = "debug-log") {
                 debug_log!(
-                    "DBG COS_OWNER_MISSING_BINDING: egress_ifindex={} tx_ifindex={}",
+                    "DBG COS_OWNER_MISSING_BINDING: egress_ifindex={}",
                     req.egress_ifindex,
-                    tx_ifindex,
                 );
             }
             continue;
@@ -1410,13 +1440,62 @@ fn apply_worker_shaped_tx_requests(
     }
 }
 
-fn build_worker_cos_owner_live_by_tx_ifindex<I>(bindings: I) -> BTreeMap<i32, Arc<BindingLiveState>>
+fn build_worker_cos_owner_live_by_tx_ifindex<I>(bindings: I) -> FastMap<i32, Arc<BindingLiveState>>
 where
     I: IntoIterator<Item = (i32, Arc<BindingLiveState>)>,
 {
-    let mut out = BTreeMap::new();
+    let mut out = FastMap::default();
     for (ifindex, live) in bindings {
         out.entry(ifindex).or_insert(live);
+    }
+    out
+}
+
+fn build_worker_cos_fast_interfaces(
+    forwarding: &ForwardingState,
+    current_worker_id: u32,
+    tx_owner_live_by_tx_ifindex: &FastMap<i32, Arc<BindingLiveState>>,
+    owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
+    owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
+    shared_root_leases: &BTreeMap<i32, Arc<SharedCoSRootLease>>,
+    shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
+) -> FastMap<i32, WorkerCoSInterfaceFastPath> {
+    let mut out = FastMap::default();
+    for (&egress_ifindex, iface) in &forwarding.cos.interfaces {
+        let tx_ifindex = resolve_tx_binding_ifindex(forwarding, egress_ifindex);
+        let mut queue_index_by_id = [COS_FAST_QUEUE_INDEX_MISS; 256];
+        let mut queue_fast_path = Vec::with_capacity(iface.queues.len());
+        for (queue_idx, queue) in iface.queues.iter().enumerate() {
+            queue_index_by_id[usize::from(queue.queue_id)] = queue_idx as u16;
+            let queue_key = (egress_ifindex, queue.queue_id);
+            queue_fast_path.push(WorkerCoSQueueFastPath {
+                shared_exact: queue.exact,
+                owner_worker_id: owner_worker_by_queue
+                    .get(&queue_key)
+                    .copied()
+                    .unwrap_or(current_worker_id),
+                owner_live: owner_live_by_queue.get(&queue_key).cloned(),
+                shared_queue_lease: queue
+                    .exact
+                    .then(|| shared_queue_leases.get(&queue_key).cloned())
+                    .flatten(),
+            });
+        }
+        let default_queue_index = match queue_index_by_id[usize::from(iface.default_queue)] {
+            COS_FAST_QUEUE_INDEX_MISS => 0,
+            idx => idx as usize,
+        };
+        out.insert(
+            egress_ifindex,
+            WorkerCoSInterfaceFastPath {
+                tx_ifindex,
+                default_queue_index,
+                queue_index_by_id,
+                tx_owner_live: tx_owner_live_by_tx_ifindex.get(&tx_ifindex).cloned(),
+                shared_root_lease: shared_root_leases.get(&egress_ifindex).cloned(),
+                queue_fast_path,
+            },
+        );
     }
     out
 }
@@ -1710,6 +1789,117 @@ mod tests {
 
         assert!(Arc::ptr_eq(owners.get(&12).unwrap(), &live_a));
         assert!(Arc::ptr_eq(owners.get(&13).unwrap(), &live_c));
+    }
+
+    #[test]
+    fn build_worker_cos_fast_interfaces_flattens_owner_and_lease_state() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 25_000_000,
+                burst_bytes: 256 * 1024,
+                default_queue: 5,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![
+                    CoSQueueConfig {
+                        queue_id: 4,
+                        forwarding_class: "best-effort".into(),
+                        priority: 5,
+                        transmit_rate_bytes: 1_000_000,
+                        exact: false,
+                        surplus_weight: 1,
+                        buffer_bytes: 64 * 1024,
+                        dscp_rewrite: None,
+                    },
+                    CoSQueueConfig {
+                        queue_id: 5,
+                        forwarding_class: "iperf-b".into(),
+                        priority: 5,
+                        transmit_rate_bytes: 10_000_000,
+                        exact: true,
+                        surplus_weight: 1,
+                        buffer_bytes: 128 * 1024,
+                        dscp_rewrite: None,
+                    },
+                ],
+            },
+        );
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 12,
+                vlan_id: 80,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone: "wan".into(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+
+        let tx_owner_live = Arc::new(BindingLiveState::new());
+        let queue_owner_live = Arc::new(BindingLiveState::new());
+        let root_lease = Arc::new(SharedCoSRootLease::new(25_000_000, 256 * 1024, 4));
+        let queue_lease = Arc::new(SharedCoSQueueLease::new(10_000_000, 128 * 1024, 4));
+
+        let tx_owner_live_by_tx_ifindex = FastMap::from_iter([(12, tx_owner_live.clone())]);
+        let owner_worker_by_queue = BTreeMap::from([((80, 5), 7)]);
+        let owner_live_by_queue = BTreeMap::from([((80, 5), queue_owner_live.clone())]);
+        let shared_root_leases = BTreeMap::from([(80, root_lease.clone())]);
+        let shared_queue_leases = BTreeMap::from([((80, 5), queue_lease.clone())]);
+
+        let fast = build_worker_cos_fast_interfaces(
+            &forwarding,
+            3,
+            &tx_owner_live_by_tx_ifindex,
+            &owner_worker_by_queue,
+            &owner_live_by_queue,
+            &shared_root_leases,
+            &shared_queue_leases,
+        );
+
+        let iface = fast.get(&80).expect("fast cos interface");
+        assert_eq!(iface.tx_ifindex, 12);
+        assert_eq!(iface.default_queue_index, 1);
+        assert!(Arc::ptr_eq(
+            iface.tx_owner_live.as_ref().expect("tx owner live"),
+            &tx_owner_live
+        ));
+        assert!(Arc::ptr_eq(
+            iface.shared_root_lease.as_ref().expect("shared root lease"),
+            &root_lease
+        ));
+
+        let queue4 = iface.queue_fast_path(Some(4)).expect("queue 4");
+        assert!(!queue4.shared_exact);
+        assert_eq!(queue4.owner_worker_id, 3);
+        assert!(queue4.owner_live.is_none());
+        assert!(queue4.shared_queue_lease.is_none());
+
+        let queue5 = iface.queue_fast_path(Some(5)).expect("queue 5");
+        assert!(queue5.shared_exact);
+        assert_eq!(queue5.owner_worker_id, 7);
+        assert!(Arc::ptr_eq(
+            queue5.owner_live.as_ref().expect("queue owner live"),
+            &queue_owner_live
+        ));
+        assert!(Arc::ptr_eq(
+            queue5
+                .shared_queue_lease
+                .as_ref()
+                .expect("shared queue lease"),
+            &queue_lease
+        ));
+        assert!(std::ptr::eq(
+            iface.queue_fast_path(None).expect("default queue"),
+            queue5
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace mutex-backed shared exact CoS lease state with packed atomic lease state
- publish worker-local flattened CoS fast-path metadata for queue owner/live/root lease lookups
- rewire exact CoS redirect, scheduler, and shaped-worker enqueue paths to use the flattened metadata instead of tree lookups
- preserve explicit queue-id semantics by treating an explicit queue miss as a miss, not a default-queue fallback

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml --no-run
- cargo test --manifest-path userspace-dp/Cargo.toml shared_cos_root_lease_ -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml redirect_local_cos_request_to_owner_ -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml build_worker_cos_fast_interfaces_flattens_owner_and_lease_state -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml maybe_top_up_cos_queue_lease_unblocks_local_exact_queue_without_tokens -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml shared_exact_queue_lease_uses_ -- --nocapture
- cargo fmt --manifest-path userspace-dp/Cargo.toml
- git diff --check

Closes #683