### PR TITLE
userspace-dp: make exact CoS queue enforcement authoritative

### DIFF
--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -839,7 +839,7 @@ mod tests {
         let snapshot = ConfigSnapshot {
             interfaces: vec![InterfaceSnapshot {
                 ifindex: 42,
-                cos_shaping_rate_bytes_per_sec: 25_000_000 / 8,
+                cos_shaping_rate_bytes_per_sec: 25_000_000_000 / 8,
                 cos_scheduler_map: "wan-map".into(),
                 ..Default::default()
             }],
@@ -872,10 +872,10 @@ mod tests {
         let state = build_cos_state(&snapshot);
         let iface = state.interfaces.get(&42).expect("missing CoS interface");
 
-        assert_eq!(iface.shaping_rate_bytes, 25_000_000 / 8);
+        assert_eq!(iface.shaping_rate_bytes, 25_000_000_000 / 8);
         assert_eq!(
             iface.burst_bytes,
-            default_cos_burst_bytes(25_000_000 / 8),
+            default_cos_burst_bytes(25_000_000_000 / 8),
             "interface burst should still derive from the parent shaper"
         );
         assert_eq!(iface.queues.len(), 1);
@@ -884,7 +884,7 @@ mod tests {
         assert_eq!(
             iface.queues[0].buffer_bytes,
             default_cos_burst_bytes(100_000_000 / 8),
-            "exact queue burst must derive from the scheduler rate, not the 25g parent shaper"
+            "exact queue burst must derive from the scheduler rate, not the 25 Gb/s parent shaper"
         );
     }
 

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -619,7 +619,7 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                     buffer_bytes: scheduler
                         .map(|sched| sched.buffer_size_bytes)
                         .filter(|size| *size > 0)
-                        .unwrap_or(burst_bytes),
+                        .unwrap_or_else(|| default_cos_burst_bytes(transmit_rate_bytes)),
                     dscp_rewrite: dscp_rewrite_rule.and_then(|rewrite_rule| {
                         rewrite_rule
                             .dscp_by_forwarding_class
@@ -831,6 +831,60 @@ mod tests {
         assert_eq!(
             iface.queues[0].buffer_bytes,
             default_cos_burst_bytes(1_000_000)
+        );
+    }
+
+    #[test]
+    fn build_cos_state_derives_exact_queue_default_burst_from_queue_rate() {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![InterfaceSnapshot {
+                ifindex: 42,
+                cos_shaping_rate_bytes_per_sec: 25_000_000 / 8,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            }],
+            class_of_service: Some(ClassOfServiceSnapshot {
+                forwarding_classes: vec![CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                }],
+                schedulers: vec![CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 100_000_000 / 8,
+                    transmit_rate_exact: true,
+                    priority: "low".into(),
+                    buffer_size_bytes: 0,
+                }],
+                scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                    name: "wan-map".into(),
+                    entries: vec![CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    }],
+                }],
+                dscp_classifiers: vec![],
+                ieee8021_classifiers: vec![],
+                dscp_rewrite_rules: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let state = build_cos_state(&snapshot);
+        let iface = state.interfaces.get(&42).expect("missing CoS interface");
+
+        assert_eq!(iface.shaping_rate_bytes, 25_000_000 / 8);
+        assert_eq!(
+            iface.burst_bytes,
+            default_cos_burst_bytes(25_000_000 / 8),
+            "interface burst should still derive from the parent shaper"
+        );
+        assert_eq!(iface.queues.len(), 1);
+        assert_eq!(iface.queues[0].transmit_rate_bytes, 100_000_000 / 8);
+        assert!(iface.queues[0].exact);
+        assert_eq!(
+            iface.queues[0].buffer_bytes,
+            default_cos_burst_bytes(100_000_000 / 8),
+            "exact queue burst must derive from the scheduler rate, not the 25g parent shaper"
         );
     }
 

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -1145,6 +1145,25 @@ fn maybe_top_up_cos_queue_lease(
     shared_queue_lease: Option<&Arc<SharedCoSQueueLease>>,
     now_ns: u64,
 ) {
+    if queue.exact {
+        let Some(shared_queue_lease) = shared_queue_lease else {
+            return;
+        };
+        let lease_bytes = shared_queue_lease
+            .lease_bytes()
+            .max(tx_frame_capacity() as u64)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        if queue.tokens >= lease_bytes {
+            return;
+        }
+        let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
+        queue.tokens = queue
+            .tokens
+            .saturating_add(grant)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        queue.last_refill_ns = now_ns;
+        return;
+    }
     let Some(shared_queue_lease) = shared_queue_lease else {
         refill_cos_tokens(
             &mut queue.tokens,
@@ -3267,6 +3286,41 @@ mod tests {
             select_cos_guarantee_batch_with_fast_path(&mut root, &queue_fast_path, 1_000_000_000,)
                 .is_some()
         );
+    }
+
+    #[test]
+    fn exact_queue_without_shared_lease_does_not_locally_refill() {
+        let mut root = test_cos_runtime_with_queues(
+            400_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 0,
+                forwarding_class: "best-effort".into(),
+                priority: 5,
+                transmit_rate_bytes: 100_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 125_000,
+                dscp_rewrite: None,
+            }],
+        );
+        root.tokens = 1500;
+        root.queues[0].tokens = 0;
+        root.queues[0].items.push_back(test_cos_item(1500));
+        root.queues[0].queued_bytes = 1500;
+        root.queues[0].runnable = true;
+        root.nonempty_queues = 1;
+        root.runnable_queues = 1;
+        let queue_fast_path = vec![test_queue_fast_path(true, 0, None, None)];
+
+        let batch =
+            select_cos_guarantee_batch_with_fast_path(&mut root, &queue_fast_path, 1_000_000_000);
+
+        assert!(
+            batch.is_none(),
+            "exact queues must not locally refill when the shared queue lease is unavailable"
+        );
+        assert_eq!(root.queues[0].tokens, 0);
+        assert_eq!(root.queues[0].last_refill_ns, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive default exact queue burst from the scheduler queue rate instead of inheriting the parent interface shaper burst
- stop exact queues from silently falling back to local per-runtime token refill when the shared queue lease is unavailable
- add focused regressions for scheduler-rate-derived exact burst sizing and for exact queues refusing local refill without a shared lease

Closes #681.

## Why
The old behavior had two semantic problems:
- an exact queue with no explicit buffer inherited the interface shaper burst, which let a low-rate exact queue start with a budget sized for the much larger parent shaper
- exact queue service could still degrade into local refill if the shared lease was absent, which breaks the idea that exact queue rate is authoritative and shared

This slice makes the queue contract tighter:
- exact queue default burst now tracks queue rate
- exact queue refill is authoritative through the shared queue lease path only

## Files
- `userspace-dp/src/afxdp/forwarding_build.rs`
- `userspace-dp/src/afxdp/tx.rs`

## Focused tests
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state_derives_exact_queue_default_burst_from_queue_rate -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml exact_queue_without_shared_lease_does_not_locally_refill -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml maybe_top_up_cos_queue_lease_unblocks_local_exact_queue_without_tokens -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml build_cos_state -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml shared_cos_queue_lease_ -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml redirect_local_cos_request_to_owner_keeps_exact_queue_on_eligible_worker -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `cargo fmt --manifest-path userspace-dp/Cargo.toml`
- `git diff --check`

## Live rollout
Helper-only rollout to the isolated loss userspace HA cluster:
- deployed `/usr/local/sbin/xpf-userspace-dp` only
- preserved `/etc/xpf/xpf.conf`
- preserved `/etc/xpf/.configdb`
- restarted secondary first, then primary
- deployed helper SHA: `d4c9306c14688dc1f62379c0d2709a3713475635eda632cd47fa332b4704a676`

## Live validation
Configured CoS contract on `reth0.80`:
- `5201` -> `iperf-a` -> `1g exact`
- `5202` -> `iperf-b` -> `10g exact`
- `5203` -> `best-effort` -> `100m exact`

Runtime CoS state after rollout:
- queue 0 buffer: `122.07 KiB` at `100 Mb/s`
- queue 4 buffer: `1.19 MiB` at `1 Gb/s`
- queue 5 buffer: `11.92 MiB` at `10 Gb/s`

Parallel iperf validation was run by separate agents on IPv4 and IPv6, while the coordinator handled interpretation and follow-up:

IPv4:
- `iperf3 -c 172.16.80.200 -P 2 -t 5 -p 5201`: `955 Mbit/s` sender, `945 Mbit/s` receiver
- `iperf3 -c 172.16.80.200 -P 12 -t 10 -p 5202`: `9.67 Gbit/s` sender, `9.64 Gbit/s` receiver
- `iperf3 -c 172.16.80.200 -P 2 -t 5 -p 5203`: `97.5 Mbit/s` sender, `95.3 Mbit/s` receiver
- `iperf3 -c 172.16.80.200 -P 2 -t 30 -p 5203`: `90.3 Mbit/s` sender, `90.0 Mbit/s` receiver

IPv6:
- `iperf3 -c 2001:559:8585:80::200 -P 2 -t 5 -p 5201`: `953 Mbit/s` sender, `943 Mbit/s` receiver
- `iperf3 -c 2001:559:8585:80::200 -P 12 -t 10 -p 5202`: `9.51 Gbit/s` sender, `9.48 Gbit/s` receiver
- `iperf3 -c 2001:559:8585:80::200 -P 2 -t 5 -p 5203`: `94.3 Mbit/s` sender, `94.0 Mbit/s` receiver
- `iperf3 -c 2001:559:8585:80::200 -P 2 -t 30 -p 5203`: `94.3 Mbit/s` sender, `94.0 Mbit/s` receiver

Coordinator-side profiled exact-path runs:
- IPv4 `5202`: `9.61 Gbit/s` sender, `9.57 Gbit/s` receiver
- IPv6 `5202`: `9.58 Gbit/s` sender, `9.54 Gbit/s` receiver

## Perf
Top symbols on the active firewall during profiled exact `5202` runs:

IPv4 exact `5202`:
- `xpf_userspace_dp::afxdp::tx::drain_pending_tx` `27.33%`
- `__memmove_evex_unaligned_erms` `13.47%`
- `xpf_userspace_dp::afxdp::poll_binding` `8.20%`

IPv6 exact `5202`:
- `__memmove_evex_unaligned_erms` `16.33%`
- `xpf_userspace_dp::afxdp::tx::drain_pending_tx` `11.54%`
- `xpf_userspace_dp::afxdp::poll_binding` `9.32%`

## Follow-on
This PR is the exact enforcement semantics slice. The next performance slice remains `#685`, which is about cutting `drain_pending_tx` / `memmove` overhead now that exact rate semantics are behaving correctly.
