### PR TITLE
userspace-dp: add fair service for low-rate exact CoS queues

### DIFF
--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -845,7 +845,7 @@ fn select_cos_guarantee_batch_with_fast_path(
     for offset in 0..queue_count {
         let queue_idx = (start + offset) % queue_count;
         let queue = &mut root.queues[queue_idx];
-        if queue.items.is_empty() || !queue.runnable {
+        if cos_queue_is_empty(queue) || !queue.runnable {
             continue;
         }
         if queue.exact {
@@ -865,7 +865,7 @@ fn select_cos_guarantee_batch_with_fast_path(
                 now_ns,
             );
         }
-        let Some(head) = queue.items.front() else {
+        let Some(head) = cos_queue_front(queue) else {
             continue;
         };
         let head_len = cos_item_len(head);
@@ -930,7 +930,7 @@ fn select_exact_cos_guarantee_queue_with_fast_path(
     for offset in 0..queue_count {
         let queue_idx = (start + offset) % queue_count;
         let queue = &mut root.queues[queue_idx];
-        if queue.items.is_empty() || !queue.runnable || !queue.exact {
+        if cos_queue_is_empty(queue) || !queue.runnable || !queue.exact {
             continue;
         }
         maybe_top_up_cos_queue_lease(
@@ -940,7 +940,7 @@ fn select_exact_cos_guarantee_queue_with_fast_path(
                 .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref()),
             now_ns,
         );
-        let Some(head) = queue.items.front() else {
+        let Some(head) = cos_queue_front(queue) else {
             continue;
         };
         let head_len = cos_item_len(head);
@@ -1002,7 +1002,7 @@ fn select_nonexact_cos_guarantee_batch(
     for offset in 0..queue_count {
         let queue_idx = (start + offset) % queue_count;
         let queue = &mut root.queues[queue_idx];
-        if queue.items.is_empty() || !queue.runnable || queue.exact {
+        if cos_queue_is_empty(queue) || !queue.runnable || queue.exact {
             continue;
         }
         refill_cos_tokens(
@@ -1012,7 +1012,7 @@ fn select_nonexact_cos_guarantee_batch(
             &mut queue.last_refill_ns,
             now_ns,
         );
-        let Some(head) = queue.items.front() else {
+        let Some(head) = cos_queue_front(queue) else {
             continue;
         };
         let head_len = cos_item_len(head);
@@ -1062,10 +1062,10 @@ fn select_cos_surplus_batch(root: &mut CoSInterfaceRuntime, now_ns: u64) -> Opti
             let queue_idx =
                 root.queue_indices_by_priority[priority][(start + offset) % indices_len];
             let queue = &mut root.queues[queue_idx];
-            if queue.items.is_empty() || !queue.runnable || queue.exact {
+            if cos_queue_is_empty(queue) || !queue.runnable || queue.exact {
                 continue;
             }
-            let Some(head) = queue.items.front() else {
+            let Some(head) = cos_queue_front(queue) else {
                 continue;
             };
             let head_len = cos_item_len(head);
@@ -1356,7 +1356,7 @@ fn drain_exact_local_items_to_scratch(
         if free_tx_frames.is_empty() {
             break;
         }
-        let Some(front) = queue.items.front() else {
+        let Some(front) = cos_queue_front(queue) else {
             break;
         };
         let len = match front {
@@ -1366,7 +1366,7 @@ fn drain_exact_local_items_to_scratch(
         if remaining_root < len || remaining_secondary < len {
             break;
         }
-        let Some(CoSPendingTxItem::Local(mut req)) = queue.items.pop_front() else {
+        let Some(CoSPendingTxItem::Local(mut req)) = cos_queue_pop_front(queue) else {
             break;
         };
         remaining_root = remaining_root.saturating_sub(len);
@@ -1389,7 +1389,7 @@ fn drain_exact_local_items_to_scratch(
             };
         }
         let Some(offset) = free_tx_frames.pop_front() else {
-            queue.items.push_front(CoSPendingTxItem::Local(req));
+            cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
             break;
         };
         let Some(frame) = (unsafe { area.slice_mut_unchecked(offset as usize, req.bytes.len()) })
@@ -1425,7 +1425,7 @@ fn drain_exact_prepared_items_to_scratch(
     let mut remaining_secondary = secondary_budget;
 
     while scratch_prepared_tx.len() < TX_BATCH_SIZE {
-        let Some(front) = queue.items.front() else {
+        let Some(front) = cos_queue_front(queue) else {
             break;
         };
         let len = match front {
@@ -1435,7 +1435,7 @@ fn drain_exact_prepared_items_to_scratch(
         if remaining_root < len || remaining_secondary < len {
             break;
         }
-        let Some(CoSPendingTxItem::Prepared(mut req)) = queue.items.pop_front() else {
+        let Some(CoSPendingTxItem::Prepared(mut req)) = cos_queue_pop_front(queue) else {
             break;
         };
         remaining_root = remaining_root.saturating_sub(len);
@@ -1505,7 +1505,7 @@ fn restore_exact_local_scratch_to_queue_head(
     };
     while let Some((offset, req)) = scratch_local_tx.pop() {
         free_tx_frames.push_front(offset);
-        queue.items.push_front(CoSPendingTxItem::Local(req));
+        cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
     }
 }
 
@@ -1518,7 +1518,7 @@ fn restore_exact_prepared_scratch_to_queue_head(
         return;
     };
     while let Some(req) = scratch_prepared_tx.pop() {
-        queue.items.push_front(CoSPendingTxItem::Prepared(req));
+        cos_queue_push_front(queue, CoSPendingTxItem::Prepared(req));
     }
 }
 
@@ -1537,7 +1537,7 @@ fn settle_exact_local_scratch_submission(
     while let Some((offset, req)) = scratch_local_tx.pop() {
         if scratch_local_tx.len() >= inserted {
             free_tx_frames.push_front(offset);
-            queue.items.push_front(CoSPendingTxItem::Local(req));
+            cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
         } else {
             sent_packets += 1;
             sent_bytes += req.bytes.len() as u64;
@@ -1560,7 +1560,7 @@ fn settle_exact_prepared_scratch_submission(
     let mut sent_bytes = 0u64;
     while let Some(req) = scratch_prepared_tx.pop() {
         if scratch_prepared_tx.len() >= inserted {
-            queue.items.push_front(CoSPendingTxItem::Prepared(req));
+            cos_queue_push_front(queue, CoSPendingTxItem::Prepared(req));
         } else {
             remember_prepared_recycle(in_flight_prepared_recycles, &req);
             sent_packets += 1;
@@ -1637,7 +1637,7 @@ fn build_cos_batch_from_queue(
     secondary_budget: u64,
     phase: CoSServicePhase,
 ) -> Option<CoSBatch> {
-    let head = queue.items.front()?;
+    let head = cos_queue_front(queue)?;
     match head {
         CoSPendingTxItem::Local(_) => {
             let mut items = VecDeque::new();
@@ -1645,7 +1645,7 @@ fn build_cos_batch_from_queue(
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
-                let Some(front) = queue.items.front() else {
+                let Some(front) = cos_queue_front(queue) else {
                     break;
                 };
                 let len = cos_item_len(front);
@@ -1657,13 +1657,13 @@ fn build_cos_batch_from_queue(
                 }
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
-                match queue.items.pop_front() {
+                match cos_queue_pop_front(queue) {
                     Some(CoSPendingTxItem::Local(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
                         items.push_back(req);
                     }
                     Some(other) => {
-                        queue.items.push_front(other);
+                        cos_queue_push_front(queue, other);
                         break;
                     }
                     None => break,
@@ -1686,7 +1686,7 @@ fn build_cos_batch_from_queue(
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
-                let Some(front) = queue.items.front() else {
+                let Some(front) = cos_queue_front(queue) else {
                     break;
                 };
                 let len = cos_item_len(front);
@@ -1698,13 +1698,13 @@ fn build_cos_batch_from_queue(
                 }
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
-                match queue.items.pop_front() {
+                match cos_queue_pop_front(queue) {
                     Some(CoSPendingTxItem::Prepared(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
                         items.push_back(req);
                     }
                     Some(other) => {
-                        queue.items.push_front(other);
+                        cos_queue_push_front(queue, other);
                         break;
                     }
                     None => break,
@@ -1842,6 +1842,7 @@ const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
 const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
 const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
+const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 4 * 1500;
 const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
@@ -1984,6 +1985,205 @@ fn cos_guarantee_quantum_bytes(queue: &CoSQueueRuntime) -> u64 {
     )
 }
 
+#[inline(always)]
+fn mix_cos_flow_bucket(seed: &mut u64, value: u64) {
+    *seed ^= value
+        .wrapping_add(0x9e3779b97f4a7c15)
+        .wrapping_add(*seed << 6)
+        .wrapping_add(*seed >> 2);
+}
+
+#[inline(always)]
+fn exact_cos_flow_bucket(flow_key: Option<&SessionKey>) -> u8 {
+    let Some(flow_key) = flow_key else {
+        return 0;
+    };
+    let mut seed = flow_key.protocol as u64 ^ ((flow_key.addr_family as u64) << 8);
+    match flow_key.src_ip {
+        IpAddr::V4(ip) => mix_cos_flow_bucket(&mut seed, u32::from(ip) as u64),
+        IpAddr::V6(ip) => {
+            for chunk in ip.octets().chunks_exact(8) {
+                mix_cos_flow_bucket(&mut seed, u64::from_be_bytes(chunk.try_into().unwrap()));
+            }
+        }
+    }
+    match flow_key.dst_ip {
+        IpAddr::V4(ip) => mix_cos_flow_bucket(&mut seed, u32::from(ip) as u64),
+        IpAddr::V6(ip) => {
+            for chunk in ip.octets().chunks_exact(8) {
+                mix_cos_flow_bucket(&mut seed, u64::from_be_bytes(chunk.try_into().unwrap()));
+            }
+        }
+    }
+    mix_cos_flow_bucket(&mut seed, flow_key.src_port as u64);
+    mix_cos_flow_bucket(&mut seed, flow_key.dst_port as u64);
+    seed as u8
+}
+
+#[inline]
+fn cos_item_flow_key(item: &CoSPendingTxItem) -> Option<&SessionKey> {
+    match item {
+        CoSPendingTxItem::Local(req) => req.flow_key.as_ref(),
+        CoSPendingTxItem::Prepared(req) => req.flow_key.as_ref(),
+    }
+}
+
+#[inline(always)]
+fn cos_flow_bucket_index(flow_key: Option<&SessionKey>) -> usize {
+    usize::from(exact_cos_flow_bucket(flow_key)) & (COS_FLOW_FAIR_BUCKETS - 1)
+}
+
+#[inline]
+fn cos_queue_flow_share_limit(
+    queue: &CoSQueueRuntime,
+    buffer_limit: u64,
+    flow_bucket: usize,
+) -> u64 {
+    if !queue.flow_fair {
+        return buffer_limit;
+    }
+    let prospective_active = u64::from(queue.active_flow_buckets)
+        .saturating_add(u64::from(queue.flow_bucket_bytes[flow_bucket] == 0))
+        .max(1);
+    buffer_limit
+        .div_ceil(prospective_active)
+        .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
+}
+
+#[inline]
+fn account_cos_queue_flow_enqueue(
+    queue: &mut CoSQueueRuntime,
+    flow_key: Option<&SessionKey>,
+    item_len: u64,
+) {
+    if !queue.flow_fair || item_len == 0 {
+        return;
+    }
+    let bucket = cos_flow_bucket_index(flow_key);
+    if queue.flow_bucket_bytes[bucket] == 0 {
+        queue.active_flow_buckets = queue.active_flow_buckets.saturating_add(1);
+    }
+    queue.flow_bucket_bytes[bucket] = queue.flow_bucket_bytes[bucket].saturating_add(item_len);
+}
+
+#[inline]
+fn account_cos_queue_flow_dequeue(
+    queue: &mut CoSQueueRuntime,
+    flow_key: Option<&SessionKey>,
+    item_len: u64,
+) {
+    if !queue.flow_fair || item_len == 0 {
+        return;
+    }
+    let bucket = cos_flow_bucket_index(flow_key);
+    let remaining = queue.flow_bucket_bytes[bucket].saturating_sub(item_len);
+    if queue.flow_bucket_bytes[bucket] > 0 && remaining == 0 {
+        queue.active_flow_buckets = queue.active_flow_buckets.saturating_sub(1);
+    }
+    queue.flow_bucket_bytes[bucket] = remaining;
+}
+
+#[inline]
+pub(super) fn cos_queue_is_empty(queue: &CoSQueueRuntime) -> bool {
+    if !queue.flow_fair {
+        return queue.items.is_empty();
+    }
+    queue.flow_rr_buckets.is_empty()
+}
+
+#[inline]
+pub(super) fn cos_queue_len(queue: &CoSQueueRuntime) -> usize {
+    if !queue.flow_fair {
+        return queue.items.len();
+    }
+    queue
+        .flow_rr_buckets
+        .iter()
+        .map(|bucket| queue.flow_bucket_items[usize::from(*bucket)].len())
+        .sum()
+}
+
+#[inline]
+pub(super) fn cos_queue_front(queue: &CoSQueueRuntime) -> Option<&CoSPendingTxItem> {
+    if !queue.flow_fair {
+        return queue.items.front();
+    }
+    let bucket = usize::from(*queue.flow_rr_buckets.front()?);
+    queue.flow_bucket_items[bucket].front()
+}
+
+#[inline]
+pub(super) fn cos_queue_push_back(queue: &mut CoSQueueRuntime, item: CoSPendingTxItem) {
+    let item_len = cos_item_len(&item);
+    let flow_key = cos_item_flow_key(&item);
+    account_cos_queue_flow_enqueue(queue, flow_key, item_len);
+    if !queue.flow_fair {
+        queue.items.push_back(item);
+        return;
+    }
+    let bucket = cos_flow_bucket_index(flow_key);
+    let bucket_queue = &mut queue.flow_bucket_items[bucket];
+    let was_empty = bucket_queue.is_empty();
+    bucket_queue.push_back(item);
+    if was_empty {
+        queue.flow_rr_buckets.push_back(bucket as u8);
+    }
+}
+
+#[inline]
+pub(super) fn cos_queue_push_front(queue: &mut CoSQueueRuntime, item: CoSPendingTxItem) {
+    let item_len = cos_item_len(&item);
+    let flow_key = cos_item_flow_key(&item);
+    account_cos_queue_flow_enqueue(queue, flow_key, item_len);
+    if !queue.flow_fair {
+        queue.items.push_front(item);
+        return;
+    }
+    let bucket = cos_flow_bucket_index(flow_key);
+    let bucket_queue = &mut queue.flow_bucket_items[bucket];
+    let was_empty = bucket_queue.is_empty();
+    bucket_queue.push_front(item);
+    if was_empty {
+        queue.flow_rr_buckets.push_front(bucket as u8);
+    }
+}
+
+#[inline]
+pub(super) fn cos_queue_pop_front(queue: &mut CoSQueueRuntime) -> Option<CoSPendingTxItem> {
+    let item = if !queue.flow_fair {
+        queue.items.pop_front()?
+    } else {
+        let bucket = usize::from(*queue.flow_rr_buckets.front()?);
+        let item = queue.flow_bucket_items[bucket].pop_front()?;
+        let active = queue
+            .flow_rr_buckets
+            .pop_front()
+            .expect("active flow bucket must exist");
+        if !queue.flow_bucket_items[bucket].is_empty() {
+            queue.flow_rr_buckets.push_back(active);
+        }
+        item
+    };
+    let item_len = cos_item_len(&item);
+    let flow_key = cos_item_flow_key(&item);
+    account_cos_queue_flow_dequeue(queue, flow_key, item_len);
+    Some(item)
+}
+
+fn cos_queue_drain_all(queue: &mut CoSQueueRuntime) -> VecDeque<CoSPendingTxItem> {
+    let mut items = VecDeque::new();
+    while let Some(item) = cos_queue_pop_front(queue) {
+        items.push_back(item);
+    }
+    items
+}
+
+fn cos_queue_restore_front(queue: &mut CoSQueueRuntime, mut items: VecDeque<CoSPendingTxItem>) {
+    while let Some(item) = items.pop_back() {
+        cos_queue_push_front(queue, item);
+    }
+}
+
 fn estimate_cos_queue_wakeup_tick(
     root_tokens: u64,
     root_rate_bytes: u64,
@@ -2007,7 +2207,7 @@ fn wake_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize) {
     let Some(queue) = root.queues.get_mut(queue_idx) else {
         return;
     };
-    if queue.items.is_empty() {
+    if cos_queue_is_empty(queue) {
         queue.runnable = false;
         queue.parked = false;
         queue.next_wakeup_tick = 0;
@@ -2050,7 +2250,7 @@ fn mark_cos_queue_runnable(queue: &mut CoSQueueRuntime) {
 }
 
 fn normalize_cos_queue_state(queue: &mut CoSQueueRuntime) {
-    if queue.items.is_empty() {
+    if cos_queue_is_empty(queue) {
         queue.runnable = false;
         queue.parked = false;
         queue.next_wakeup_tick = 0;
@@ -2549,35 +2749,29 @@ fn demote_prepared_cos_queue_to_local(
     let Some(queue_idx) = resolve_cos_queue_idx(root, requested_queue) else {
         return false;
     };
-    let Some(queue) = root.queues.get(queue_idx) else {
+    let Some(queue) = root.queues.get_mut(queue_idx) else {
         return false;
     };
-    if !queue.exact || queue.items.is_empty() {
+    if !queue.exact || cos_queue_is_empty(queue) {
         return false;
     }
-    if queue
-        .items
-        .iter()
-        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
-    {
-        return false;
-    }
-
-    let mut local_items = VecDeque::with_capacity(queue.items.len());
-    let mut recycles = Vec::with_capacity(queue.items.len());
-    for item in queue.items.iter() {
+    let drained = cos_queue_drain_all(queue);
+    let mut local_items = VecDeque::with_capacity(drained.len());
+    let mut recycles = Vec::with_capacity(drained.len());
+    for item in &drained {
         let CoSPendingTxItem::Prepared(req) = item else {
+            cos_queue_restore_front(queue, drained);
             return false;
         };
         let Some(local_req) = clone_prepared_request_for_cos(area, req) else {
+            cos_queue_restore_front(queue, drained);
             return false;
         };
         local_items.push_back(CoSPendingTxItem::Local(local_req));
         recycles.push((req.recycle, req.offset));
     }
-
-    if let Some(queue) = root.queues.get_mut(queue_idx) {
-        queue.items = local_items;
+    for item in local_items {
+        cos_queue_push_back(queue, item);
     }
     for (recycle, offset) in recycles {
         recycle_cancelled_prepared_offset(
@@ -2598,10 +2792,17 @@ fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Optio
     let Some(queue) = root.queues.get(queue_idx) else {
         return false;
     };
-    !queue
-        .items
-        .iter()
-        .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
+    if !queue.flow_fair {
+        return !queue
+            .items
+            .iter()
+            .any(|item| matches!(item, CoSPendingTxItem::Local(_)));
+    }
+    !queue.flow_rr_buckets.iter().any(|bucket| {
+        queue.flow_bucket_items[usize::from(*bucket)]
+            .iter()
+            .any(|item| matches!(item, CoSPendingTxItem::Local(_)))
+    })
 }
 
 fn ensure_cos_interface_runtime(
@@ -2620,9 +2821,13 @@ fn ensure_cos_interface_runtime(
         return false;
     }
     if !binding.cos_interfaces.contains_key(&egress_ifindex) {
-        binding
-            .cos_interfaces
-            .insert(egress_ifindex, build_cos_interface_runtime(config, now_ns));
+        let mut runtime = build_cos_interface_runtime(config, now_ns);
+        if let Some(iface_fast) = binding.cos_fast_interfaces.get(&egress_ifindex) {
+            for (queue, queue_fast) in runtime.queues.iter_mut().zip(&iface_fast.queue_fast_path) {
+                queue.flow_fair = queue.exact && !queue_fast.shared_exact;
+            }
+        }
+        binding.cos_interfaces.insert(egress_ifindex, runtime);
         binding.cos_interface_order.push(egress_ifindex);
         binding.cos_interface_order.sort_unstable();
     }
@@ -2652,6 +2857,7 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 priority: queue.priority,
                 transmit_rate_bytes: queue.transmit_rate_bytes,
                 exact: queue.exact,
+                flow_fair: false,
                 surplus_weight: queue.surplus_weight,
                 surplus_deficit: 0,
                 buffer_bytes: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
@@ -2663,6 +2869,10 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 },
                 last_refill_ns: if queue.exact { 0 } else { now_ns },
                 queued_bytes: 0,
+                active_flow_buckets: 0,
+                flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+                flow_rr_buckets: VecDeque::new(),
+                flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
                 runnable: false,
                 parked: false,
                 next_wakeup_tick: 0,
@@ -2735,16 +2945,23 @@ fn enqueue_cos_item(
         let root_was_empty = root.nonempty_queues == 0;
         let queue = &mut root.queues[queue_idx];
         let buffer_limit = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
-        if queue.queued_bytes.saturating_add(item_len) > buffer_limit {
+        let flow_share_exceeded = if queue.flow_fair {
+            let flow_bucket = cos_flow_bucket_index(cos_item_flow_key(&item));
+            queue.flow_bucket_bytes[flow_bucket].saturating_add(item_len)
+                > cos_queue_flow_share_limit(queue, buffer_limit, flow_bucket)
+        } else {
+            false
+        };
+        if flow_share_exceeded || queue.queued_bytes.saturating_add(item_len) > buffer_limit {
             let recycle = match &item {
                 CoSPendingTxItem::Prepared(req) => Some((req.recycle, req.offset)),
                 CoSPendingTxItem::Local(_) => None,
             };
             (false, queue.queue_id, recycle)
         } else {
-            let queue_was_empty = queue.items.is_empty();
+            let queue_was_empty = cos_queue_is_empty(queue);
             queue.queued_bytes = queue.queued_bytes.saturating_add(item_len);
-            queue.items.push_back(item);
+            cos_queue_push_back(queue, item);
             if queue_was_empty {
                 root.nonempty_queues = root.nonempty_queues.saturating_add(1);
                 root_became_nonempty = root_was_empty;
@@ -2794,10 +3011,10 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
     if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
         for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
             normalize_cos_queue_state(queue);
-            if queue.items.is_empty() && queue.exact && queue.tokens > 0 {
+            if cos_queue_is_empty(queue) && queue.exact && queue.tokens > 0 {
                 released_queue_leases.push((queue_idx, core::mem::take(&mut queue.tokens)));
             }
-            if queue.items.is_empty() {
+            if cos_queue_is_empty(queue) {
                 continue;
             }
             new_nonempty = new_nonempty.saturating_add(1);
@@ -3047,9 +3264,9 @@ fn restore_cos_local_items_inner(
     let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {
         retry_bytes = retry_bytes.saturating_add(req.bytes.len() as u64);
-        queue.items.push_front(CoSPendingTxItem::Local(req));
+        cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
     }
-    if !queue.items.is_empty() {
+    if !cos_queue_is_empty(queue) {
         mark_cos_queue_runnable(queue);
     }
     retry_bytes
@@ -3062,9 +3279,9 @@ fn restore_cos_prepared_items_inner(
     let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {
         retry_bytes = retry_bytes.saturating_add(req.len as u64);
-        queue.items.push_front(CoSPendingTxItem::Prepared(req));
+        cos_queue_push_front(queue, CoSPendingTxItem::Prepared(req));
     }
-    if !queue.items.is_empty() {
+    if !cos_queue_is_empty(queue) {
         mark_cos_queue_runnable(queue);
     }
     retry_bytes
@@ -4249,6 +4466,60 @@ mod tests {
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
         assert_eq!(queued.front().map(|req| req.cos_queue_id), Some(Some(4)));
+    }
+
+    #[test]
+    fn redirect_local_cos_request_to_owner_redirects_low_rate_exact_queue() {
+        let commands = Arc::new(Mutex::new(VecDeque::new()));
+        let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+        let cos_fast_interfaces = test_cos_fast_interfaces(
+            80,
+            12,
+            4,
+            vec![(
+                4,
+                test_queue_fast_path(
+                    false,
+                    7,
+                    None,
+                    Some(Arc::new(SharedCoSQueueLease::new(
+                        1_000_000_000 / 8,
+                        COS_MIN_BURST_BYTES,
+                        4,
+                    ))),
+                ),
+            )],
+            Some(Arc::new(BindingLiveState::new())),
+            None,
+        );
+        let req = TxRequest {
+            bytes: vec![1, 2, 3],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+
+        let redirected = redirect_local_cos_request_to_owner(
+            &cos_fast_interfaces,
+            req,
+            2,
+            &worker_commands_by_id,
+        );
+
+        assert!(redirected.is_ok());
+        let pending = commands.lock().unwrap();
+        assert_eq!(pending.len(), 1);
+        match pending.front() {
+            Some(WorkerCommand::EnqueueShapedLocal(req)) => {
+                assert_eq!(req.egress_ifindex, 80);
+                assert_eq!(req.cos_queue_id, Some(4));
+            }
+            other => panic!("unexpected command queued: {other:?}"),
+        }
     }
 
     #[test]
@@ -6469,6 +6740,213 @@ mod tests {
         })
     }
 
+    fn test_flow_cos_item(src_port: u16, len: usize) -> CoSPendingTxItem {
+        CoSPendingTxItem::Local(TxRequest {
+            bytes: vec![0; len],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: Some(test_session_key(src_port, 5201)),
+            egress_ifindex: 42,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        })
+    }
+
+    fn test_flow_prepared_cos_item(src_port: u16, len: u32, offset: u64) -> CoSPendingTxItem {
+        CoSPendingTxItem::Prepared(PreparedTxRequest {
+            offset,
+            len,
+            recycle: PreparedTxRecycle::FreeTxFrame,
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: Some(test_session_key(src_port, 5201)),
+            egress_ifindex: 42,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        })
+    }
+
+    fn test_session_key(src_port: u16, dst_port: u16) -> SessionKey {
+        SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, (src_port & 0xff) as u8)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port,
+            dst_port,
+        }
+    }
+
+    #[test]
+    fn flow_fair_exact_queue_limits_dominant_flow_share() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        let buffer_limit = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
+        let flow_a = test_session_key(1111, 5201);
+        let flow_b = test_session_key(1112, 5201);
+        let bucket_a = cos_flow_bucket_index(Some(&flow_a));
+        let bucket_b = cos_flow_bucket_index(Some(&flow_b));
+        assert_ne!(bucket_a, bucket_b);
+
+        assert_eq!(
+            cos_queue_flow_share_limit(queue, buffer_limit, bucket_a),
+            buffer_limit
+        );
+        account_cos_queue_flow_enqueue(queue, Some(&flow_a), 64 * 1024);
+        account_cos_queue_flow_enqueue(queue, Some(&flow_a), 32 * 1024);
+        assert_eq!(queue.active_flow_buckets, 1);
+        assert_eq!(queue.flow_bucket_bytes[bucket_a], 96 * 1024);
+
+        account_cos_queue_flow_enqueue(queue, Some(&flow_b), 16 * 1024);
+        assert_eq!(queue.active_flow_buckets, 2);
+        assert_eq!(queue.flow_bucket_bytes[bucket_b], 16 * 1024);
+
+        let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, bucket_a);
+        assert_eq!(share_cap, buffer_limit / 2);
+        assert!(queue.flow_bucket_bytes[bucket_a].saturating_add(16 * 1024) > share_cap);
+
+        account_cos_queue_flow_dequeue(queue, Some(&flow_b), 16 * 1024);
+        assert_eq!(queue.active_flow_buckets, 1);
+        assert_eq!(queue.flow_bucket_bytes[bucket_b], 0);
+    }
+
+    #[test]
+    fn cos_queue_push_and_pop_track_flow_bucket_bytes() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        let req_a = TxRequest {
+            bytes: vec![0; 1500],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: Some(test_session_key(1111, 5201)),
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+        let req_b = TxRequest {
+            bytes: vec![0; 1500],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: Some(test_session_key(1112, 5201)),
+            egress_ifindex: 80,
+            cos_queue_id: Some(4),
+            dscp_rewrite: None,
+        };
+        let bucket_a = cos_flow_bucket_index(req_a.flow_key.as_ref());
+        let bucket_b = cos_flow_bucket_index(req_b.flow_key.as_ref());
+        assert_ne!(bucket_a, bucket_b);
+
+        cos_queue_push_back(queue, CoSPendingTxItem::Local(req_a));
+        cos_queue_push_back(queue, CoSPendingTxItem::Local(req_b));
+        assert_eq!(queue.active_flow_buckets, 2);
+        assert_eq!(queue.flow_bucket_bytes[bucket_a], 1500);
+        assert_eq!(queue.flow_bucket_bytes[bucket_b], 1500);
+
+        let Some(CoSPendingTxItem::Local(req)) = cos_queue_pop_front(queue) else {
+            panic!("expected first queued local request");
+        };
+        assert_eq!(req.flow_key.as_ref().map(|flow| flow.src_port), Some(1111));
+        assert_eq!(queue.active_flow_buckets, 1);
+        assert_eq!(queue.flow_bucket_bytes[bucket_a], 0);
+        assert_eq!(queue.flow_bucket_bytes[bucket_b], 1500);
+    }
+
+    #[test]
+    fn flow_fair_queue_round_robins_distinct_local_flows() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        cos_queue_push_back(queue, test_flow_cos_item(1111, 1500));
+        cos_queue_push_back(queue, test_flow_cos_item(1111, 1500));
+        cos_queue_push_back(queue, test_flow_cos_item(1112, 1500));
+        cos_queue_push_back(queue, test_flow_cos_item(1113, 1500));
+
+        let mut order = Vec::new();
+        while let Some(CoSPendingTxItem::Local(req)) = cos_queue_pop_front(queue) {
+            order.push(req.flow_key.expect("flow key").src_port);
+        }
+
+        assert_eq!(order, vec![1111, 1112, 1113, 1111]);
+        assert_eq!(queue.active_flow_buckets, 0);
+        assert!(queue.flow_rr_buckets.is_empty());
+    }
+
+    #[test]
+    fn flow_fair_queue_round_robins_distinct_prepared_flows() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        cos_queue_push_back(queue, test_flow_prepared_cos_item(1111, 1500, 64));
+        cos_queue_push_back(queue, test_flow_prepared_cos_item(1111, 1500, 128));
+        cos_queue_push_back(queue, test_flow_prepared_cos_item(1112, 1500, 192));
+
+        let mut order = Vec::new();
+        while let Some(CoSPendingTxItem::Prepared(req)) = cos_queue_pop_front(queue) {
+            order.push(req.flow_key.expect("flow key").src_port);
+        }
+
+        assert_eq!(order, vec![1111, 1112, 1111]);
+        assert_eq!(queue.active_flow_buckets, 0);
+        assert!(queue.flow_rr_buckets.is_empty());
+    }
+
     #[test]
     fn estimate_cos_queue_wakeup_tick_uses_token_deficits() {
         let mut root = test_cos_interface_runtime(0);
@@ -6849,6 +7327,7 @@ mod tests {
             priority: 5,
             transmit_rate_bytes: 11_000_000_000 / 8,
             exact: true,
+            flow_fair: false,
             surplus_weight: 1,
             surplus_deficit: 0,
             buffer_bytes: COS_MIN_BURST_BYTES,
@@ -6856,6 +7335,10 @@ mod tests {
             tokens: 0,
             last_refill_ns: 0,
             queued_bytes: 1500,
+            active_flow_buckets: 0,
+            flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            flow_rr_buckets: VecDeque::new(),
+            flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
             parked: false,
             next_wakeup_tick: 0,
@@ -6878,6 +7361,7 @@ mod tests {
             priority: 5,
             transmit_rate_bytes: 11_000_000_000 / 8,
             exact: true,
+            flow_fair: false,
             surplus_weight: 1,
             surplus_deficit: 0,
             buffer_bytes: COS_MIN_BURST_BYTES,
@@ -6885,6 +7369,10 @@ mod tests {
             tokens: 0,
             last_refill_ns: 0,
             queued_bytes: 0,
+            active_flow_buckets: 0,
+            flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            flow_rr_buckets: VecDeque::new(),
+            flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
             parked: false,
             next_wakeup_tick: 0,
@@ -6918,6 +7406,7 @@ mod tests {
             priority: 5,
             transmit_rate_bytes: 11_000_000_000 / 8,
             exact: true,
+            flow_fair: false,
             surplus_weight: 1,
             surplus_deficit: 0,
             buffer_bytes: COS_MIN_BURST_BYTES,
@@ -6925,6 +7414,10 @@ mod tests {
             tokens: 0,
             last_refill_ns: 0,
             queued_bytes: 0,
+            active_flow_buckets: 0,
+            flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            flow_rr_buckets: VecDeque::new(),
+            flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
             parked: false,
             next_wakeup_tick: 0,

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -586,6 +586,7 @@ impl WorkerBindingLookup {
 }
 
 pub(super) const COS_FAST_QUEUE_INDEX_MISS: u16 = u16::MAX;
+pub(super) const COS_FLOW_FAIR_BUCKETS: usize = 64;
 
 #[derive(Clone)]
 pub(super) struct WorkerCoSQueueFastPath {
@@ -757,6 +758,7 @@ pub(super) struct CoSQueueRuntime {
     pub(super) priority: u8,
     pub(super) transmit_rate_bytes: u64,
     pub(super) exact: bool,
+    pub(super) flow_fair: bool,
     pub(super) surplus_weight: u32,
     pub(super) surplus_deficit: u64,
     pub(super) buffer_bytes: u64,
@@ -764,6 +766,10 @@ pub(super) struct CoSQueueRuntime {
     pub(super) tokens: u64,
     pub(super) last_refill_ns: u64,
     pub(super) queued_bytes: u64,
+    pub(super) active_flow_buckets: u16,
+    pub(super) flow_bucket_bytes: [u64; COS_FLOW_FAIR_BUCKETS],
+    pub(super) flow_rr_buckets: VecDeque<u8>,
+    pub(super) flow_bucket_items: [VecDeque<CoSPendingTxItem>; COS_FLOW_FAIR_BUCKETS],
     pub(super) runnable: bool,
     pub(super) parked: bool,
     pub(super) next_wakeup_tick: u64,

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1451,6 +1451,23 @@ where
     out
 }
 
+const COS_SHARED_EXACT_MIN_RATE_BYTES: u64 = 2_500_000_000 / 8;
+
+#[inline]
+fn queue_uses_shared_exact_service(iface: &CoSInterfaceConfig, queue: &CoSQueueConfig) -> bool {
+    if !queue.exact {
+        return false;
+    }
+    // Low-rate exact queues care more about deterministic single-queue arbitration
+    // than shared-worker throughput. Only shard exact service once the queue rate is
+    // high enough that a single worker is no longer the clear fast path.
+    let shared_threshold = iface
+        .shaping_rate_bytes
+        .saturating_div(4)
+        .max(COS_SHARED_EXACT_MIN_RATE_BYTES);
+    queue.transmit_rate_bytes >= shared_threshold
+}
+
 fn build_worker_cos_fast_interfaces(
     forwarding: &ForwardingState,
     current_worker_id: u32,
@@ -1468,8 +1485,9 @@ fn build_worker_cos_fast_interfaces(
         for (queue_idx, queue) in iface.queues.iter().enumerate() {
             queue_index_by_id[usize::from(queue.queue_id)] = queue_idx as u16;
             let queue_key = (egress_ifindex, queue.queue_id);
+            let shared_exact = queue_uses_shared_exact_service(iface, queue);
             queue_fast_path.push(WorkerCoSQueueFastPath {
-                shared_exact: queue.exact,
+                shared_exact,
                 owner_worker_id: owner_worker_by_queue
                     .get(&queue_key)
                     .copied()
@@ -1521,7 +1539,7 @@ fn reset_binding_cos_runtime(binding: &mut BindingWorker) {
     let mut dropped_prepared = Vec::new();
     for root in binding.cos_interfaces.values_mut() {
         for queue in &mut root.queues {
-            while let Some(item) = queue.items.pop_front() {
+            while let Some(item) = cos_queue_pop_front(queue) {
                 match item {
                     CoSPendingTxItem::Local(_) => {
                         dropped_local = dropped_local.saturating_add(1);
@@ -1622,7 +1640,7 @@ where
                 status.worker_instances = status.worker_instances.saturating_add(1);
                 status.queued_packets = status
                     .queued_packets
-                    .saturating_add(queue.items.len() as u64);
+                    .saturating_add(cos_queue_len(queue) as u64);
                 status.queued_bytes = status.queued_bytes.saturating_add(queue.queued_bytes);
                 if queue.runnable {
                     status.runnable_instances = status.runnable_instances.saturating_add(1);
@@ -1727,6 +1745,7 @@ mod tests {
                 priority: 1,
                 transmit_rate_bytes: 1_250_000,
                 exact: false,
+                flow_fair: false,
                 surplus_weight: 1,
                 surplus_deficit: 512,
                 buffer_bytes: 32 * 1024,
@@ -1734,6 +1753,10 @@ mod tests {
                 tokens: 0,
                 last_refill_ns: 0,
                 queued_bytes,
+                active_flow_buckets: 0,
+                flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+                flow_rr_buckets: VecDeque::new(),
+                flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
                 runnable,
                 parked,
                 next_wakeup_tick: wake_tick,
@@ -1797,7 +1820,7 @@ mod tests {
         forwarding.cos.interfaces.insert(
             80,
             CoSInterfaceConfig {
-                shaping_rate_bytes: 25_000_000,
+                shaping_rate_bytes: 25_000_000_000 / 8,
                 burst_bytes: 256 * 1024,
                 default_queue: 5,
                 dscp_classifier: String::new(),
@@ -1810,7 +1833,7 @@ mod tests {
                         queue_id: 4,
                         forwarding_class: "best-effort".into(),
                         priority: 5,
-                        transmit_rate_bytes: 1_000_000,
+                        transmit_rate_bytes: 1_000_000_000 / 8,
                         exact: false,
                         surplus_weight: 1,
                         buffer_bytes: 64 * 1024,
@@ -1820,7 +1843,7 @@ mod tests {
                         queue_id: 5,
                         forwarding_class: "iperf-b".into(),
                         priority: 5,
-                        transmit_rate_bytes: 10_000_000,
+                        transmit_rate_bytes: 10_000_000_000 / 8,
                         exact: true,
                         surplus_weight: 1,
                         buffer_bytes: 128 * 1024,
@@ -1845,8 +1868,8 @@ mod tests {
 
         let tx_owner_live = Arc::new(BindingLiveState::new());
         let queue_owner_live = Arc::new(BindingLiveState::new());
-        let root_lease = Arc::new(SharedCoSRootLease::new(25_000_000, 256 * 1024, 4));
-        let queue_lease = Arc::new(SharedCoSQueueLease::new(10_000_000, 128 * 1024, 4));
+        let root_lease = Arc::new(SharedCoSRootLease::new(25_000_000_000 / 8, 256 * 1024, 4));
+        let queue_lease = Arc::new(SharedCoSQueueLease::new(10_000_000_000 / 8, 128 * 1024, 4));
 
         let tx_owner_live_by_tx_ifindex = FastMap::from_iter([(12, tx_owner_live.clone())]);
         let owner_worker_by_queue = BTreeMap::from([((80, 5), 7)]);
@@ -1900,6 +1923,103 @@ mod tests {
             iface.queue_fast_path(None).expect("default queue"),
             queue5
         ));
+    }
+
+    #[test]
+    fn build_worker_cos_fast_interfaces_keeps_low_rate_exact_queue_owner_local() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 25_000_000_000 / 8,
+                burst_bytes: 256 * 1024,
+                default_queue: 4,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![
+                    CoSQueueConfig {
+                        queue_id: 4,
+                        forwarding_class: "iperf-a".into(),
+                        priority: 5,
+                        transmit_rate_bytes: 1_000_000_000 / 8,
+                        exact: true,
+                        surplus_weight: 1,
+                        buffer_bytes: 128 * 1024,
+                        dscp_rewrite: None,
+                    },
+                    CoSQueueConfig {
+                        queue_id: 5,
+                        forwarding_class: "iperf-b".into(),
+                        priority: 5,
+                        transmit_rate_bytes: 10_000_000_000 / 8,
+                        exact: true,
+                        surplus_weight: 1,
+                        buffer_bytes: 128 * 1024,
+                        dscp_rewrite: None,
+                    },
+                ],
+            },
+        );
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 12,
+                vlan_id: 80,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone: "wan".into(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+
+        let queue4_owner_live = Arc::new(BindingLiveState::new());
+        let queue5_owner_live = Arc::new(BindingLiveState::new());
+        let tx_owner_live_by_tx_ifindex = FastMap::from_iter([(12, queue4_owner_live.clone())]);
+        let owner_worker_by_queue = BTreeMap::from([((80, 4), 4), ((80, 5), 7)]);
+        let owner_live_by_queue = BTreeMap::from([
+            ((80, 4), queue4_owner_live.clone()),
+            ((80, 5), queue5_owner_live.clone()),
+        ]);
+        let shared_root_leases = BTreeMap::from([(
+            80,
+            Arc::new(SharedCoSRootLease::new(25_000_000_000 / 8, 256 * 1024, 4)),
+        )]);
+        let shared_queue_leases = BTreeMap::from([
+            (
+                (80, 4),
+                Arc::new(SharedCoSQueueLease::new(1_000_000_000 / 8, 128 * 1024, 4)),
+            ),
+            (
+                (80, 5),
+                Arc::new(SharedCoSQueueLease::new(10_000_000_000 / 8, 128 * 1024, 4)),
+            ),
+        ]);
+
+        let fast = build_worker_cos_fast_interfaces(
+            &forwarding,
+            3,
+            &tx_owner_live_by_tx_ifindex,
+            &owner_worker_by_queue,
+            &owner_live_by_queue,
+            &shared_root_leases,
+            &shared_queue_leases,
+        );
+
+        let iface = fast.get(&80).expect("fast cos interface");
+        let queue4 = iface.queue_fast_path(Some(4)).expect("queue 4");
+        assert!(!queue4.shared_exact);
+        assert_eq!(queue4.owner_worker_id, 4);
+        assert!(queue4.shared_queue_lease.is_some());
+
+        let queue5 = iface.queue_fast_path(Some(5)).expect("queue 5");
+        assert!(queue5.shared_exact);
+        assert_eq!(queue5.owner_worker_id, 7);
+        assert!(queue5.shared_queue_lease.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add hashed per-flow round-robin service for low-rate owner-local exact CoS queues
- keep the earlier per-flow backlog admission guard, but stop treating the queue as a single FIFO once packets are admitted
- leave the high-rate shared exact path unchanged so `5202` stays on the existing fast path

## Root Cause
`5201` was still using a single FIFO inside the low-rate exact queue. Even after fixing rate enforcement and owner-local placement, one flow could occupy the head of the queue for too long and the rest of the TCP fanout would only see tail-drop fairness, not service fairness.

That showed up live as:
- IPv4 `5201`: `1.019 / 1.015 Gbit/s`, retrans `88549`, per-stream `min/max/avg 0.032/0.235/0.085`, ratio `7.283`

The correct fix was not another token tweak. The queue discipline itself needed to become flow-aware on the low-rate owner-local exact path.

## Implementation
- extend `CoSQueueRuntime` with hashed flow buckets and a round-robin bucket ring
- use the existing flow key to map packets into per-flow buckets
- preserve FIFO inside each flow bucket
- dequeue low-rate exact work in bucket round-robin order
- keep the flow-share admission guard so one bucket cannot consume the whole queue backlog
- keep high-rate shared exact queues on the existing queue structure and fast path
- update reset/status/demotion paths so they operate correctly on both FIFO and fair-bucket queues

## Validation
Unit / build:
- `cargo test --manifest-path userspace-dp/Cargo.toml flow_fair_queue_round_robins_distinct_local_flows -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml flow_fair_queue_round_robins_distinct_prepared_flows -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml flow_fair_exact_queue_limits_dominant_flow_share -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml cos_queue_push_and_pop_track_flow_bucket_bytes -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml drain_exact_local_items_to_scratch_stops_before_prepared_tail -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml --no-run`
- `cargo fmt --manifest-path userspace-dp/Cargo.toml`
- `git diff --check`
- `make build-userspace-dp`

Live rollout:
- helper-only rollout to `xpf-userspace-fw1` then `xpf-userspace-fw0`
- config preserved on both nodes
- helper SHA `b1e2d993ec10c4c44c8f0536f4adaff392816ce1d1e07d2044a71a7597c44431`

Live port matrix:
- IPv4 `5201`: `1.036 / 1.034 Gbit/s`, retrans `148560`, per-stream `min/max/avg 0.050/0.103/0.086`, ratio `2.057`
- IPv4 `5202`: `9.533 / 9.518 Gbit/s`, retrans `43012`
- IPv4 `5203`: `0.103 / 0.103 Gbit/s`, retrans `14416`
- IPv6 `5201` repeat: `1.042 / 1.041 Gbit/s`, retrans `213359`, per-stream `min/max/avg 0.073/0.098/0.087`, ratio `1.34`
- IPv6 `5202`: `9.388 / 9.372 Gbit/s`, retrans `68831`
- IPv6 `5203`: `0.098 / 0.098 Gbit/s`, retrans `7356`

Perf samples after the slice:
- IPv4 `5201`: `worker_loop 24.37%`, `poll_binding 13.31%`, `drain_pending_tx 2.23%`
- IPv4 `5202`: `memmove 14.54%`, `drain_pending_tx 11.41%`, `poll_binding 9.36%`, `drain_shaped_tx 4.06%`

## Notes
- this is intentionally scoped to low-rate owner-local exact fairness
- the next performance slice is still `#688` (`drain_pending_tx` / `memmove`), not more low-rate queue lookup work
- implements `#691`
