### PR TITLE
userspace-dp: drop iface_rate/4 term from shared-exact threshold (#697)

### DIFF
--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1458,10 +1458,11 @@ where
 // Empirical per-worker sustained exact throughput ceiling in bytes/sec. A
 // single owner worker can reliably drive an exact queue up to about this rate
 // before the drain loop backs up and throughput collapses (the collapse case
-// motivated shared-worker execution in PR #680). This constant is the
-// absolute floor component of the shared-exact threshold:
-// `shared_threshold = max(iface_rate / 4, COS_SHARED_EXACT_MIN_RATE_BYTES)`.
-// Exact queues are sharded only once they reach that computed threshold.
+// that motivated shared-worker execution in PR #680). This is the sole
+// shared-exact threshold: a queue at or above this rate shards across every
+// eligible worker; a queue below it runs under a single owner. The ceiling
+// is a property of the drain loop and the TX ring, not a function of the
+// interface shaper — it does not scale with iface rate.
 const COS_SHARED_EXACT_MIN_RATE_BYTES: u64 = 2_500_000_000 / 8;
 
 /// Decide whether an exact queue runs under shared-worker execution.
@@ -1469,38 +1470,34 @@ const COS_SHARED_EXACT_MIN_RATE_BYTES: u64 = 2_500_000_000 / 8;
 /// Policy:
 /// - Non-exact queues are never shared (they run through the non-exact
 ///   guarantee batch path regardless).
-/// - Exact queues below `shared_threshold` route to a single owner worker
-///   (one FIFO arbitration domain, SFQ inside). See issue #690 for why
-///   low-rate exact queues want one arbitration domain rather than N
-///   racing worker-local FIFOs.
-/// - Exact queues at or above `shared_threshold` run sharded across every
+/// - Exact queues below `COS_SHARED_EXACT_MIN_RATE_BYTES` route to a single
+///   owner worker (one FIFO arbitration domain, SFQ inside). See issue
+///   #690 for why low-rate exact queues want one arbitration domain rather
+///   than N racing worker-local FIFOs.
+/// - Exact queues at or above the threshold run sharded across every
 ///   eligible worker with shared root/queue leases, avoiding the single-
 ///   worker throughput collapse from PR #680.
 ///
-/// `shared_threshold = max(iface_rate / 4, COS_SHARED_EXACT_MIN_RATE_BYTES)`.
-/// `COS_SHARED_EXACT_MIN_RATE_BYTES` provides an absolute floor, while
-/// `iface_rate / 4` is the iface-rate-relative term and becomes the
-/// effective gate on faster interfaces, keeping very-small queues
-/// single-owner there.
+/// Before PR #697 the threshold was `max(iface_rate / 4, MIN)`. That scaled
+/// the threshold up with iface rate, which is the wrong direction: the
+/// single-worker drain ceiling is an absolute property of the loop, not a
+/// fraction of the iface. On a 25g or 100g iface the `iface_rate / 4` term
+/// dominated and would classify a genuinely high-rate queue (e.g. a 10g
+/// exact queue on a 100g iface) as single-owner — routing it straight back
+/// into the PR #680 collapse shape. The `/ 4` term is now gone; the
+/// threshold is just the absolute per-worker ceiling.
 ///
-/// Known rough edge (#690 follow-on): at iface rates well above 10g the
-/// `/4` component dominates `MIN` and will classify a genuinely high-rate
-/// queue (e.g. 10g exact on a 100g iface) as single-owner, regressing to
-/// PR #680's throughput collapse shape. Current lab runs 10g interfaces
-/// where `/4 == MIN`, so this is latent; the test
-/// `queue_uses_shared_exact_service_high_iface_rate_keeps_large_queues_single_owner`
-/// pins the current behavior so a future fix is an explicit policy change
-/// rather than a silent drift.
+/// On the current 10g-iface lab the new threshold equals the old threshold
+/// (`max(2.5g, 2.5g) == 2.5g`), so 5201 / 5202 / 5203 classification is
+/// byte-identical. The change only affects lab configs running on faster
+/// interfaces, which is why #697 notes "live validation requires a >10g
+/// iface" before closing the loop.
 #[inline]
-fn queue_uses_shared_exact_service(iface: &CoSInterfaceConfig, queue: &CoSQueueConfig) -> bool {
+fn queue_uses_shared_exact_service(_iface: &CoSInterfaceConfig, queue: &CoSQueueConfig) -> bool {
     if !queue.exact {
         return false;
     }
-    let shared_threshold = iface
-        .shaping_rate_bytes
-        .saturating_div(4)
-        .max(COS_SHARED_EXACT_MIN_RATE_BYTES);
-    queue.transmit_rate_bytes >= shared_threshold
+    queue.transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES
 }
 
 fn build_worker_cos_fast_interfaces(
@@ -2100,7 +2097,7 @@ mod tests {
         //   best-effort 100m exact  -> single owner
         //   iperf-a     1.0g exact  -> single owner  (this is 5201)
         //   iperf-b     10.0g exact -> shared
-        // Threshold on a 10g iface = max(10g/4, 2.5g) = 2.5g.
+        // Threshold is the absolute per-worker ceiling (2.5g) on any iface.
         let iface = test_cos_iface_with_rate(10_000_000_000);
         let be = test_exact_queue_at_rate(0, 100_000_000);
         let iperf_a = test_exact_queue_at_rate(4, 1_000_000_000);
@@ -2111,26 +2108,36 @@ mod tests {
     }
 
     #[test]
-    fn queue_uses_shared_exact_service_10g_iface_threshold_is_exactly_inclusive() {
-        // Threshold = 2.5 Gbps = 312_500_000 bytes/s. Exactly at threshold
-        // selects the shared path; one byte below stays single-owner. The
-        // boundary must be deterministic — a fairness fix that accidentally
-        // flips classification for a queue at the stated threshold will
-        // silently regress 5201 or 5202.
-        let iface = test_cos_iface_with_rate(10_000_000_000);
-        let mut q = test_exact_queue_at_rate(4, 0);
-        q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES - 1;
-        assert!(!queue_uses_shared_exact_service(&iface, &q));
-        q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES;
-        assert!(queue_uses_shared_exact_service(&iface, &q));
+    fn queue_uses_shared_exact_service_threshold_is_exactly_inclusive() {
+        // Threshold = COS_SHARED_EXACT_MIN_RATE_BYTES (2.5 Gbps =
+        // 312_500_000 bytes/s). Exactly at threshold selects the shared
+        // path; one byte below stays single-owner. The boundary must be
+        // deterministic — a fairness fix that accidentally flips
+        // classification for a queue at the stated threshold will silently
+        // regress 5201 or 5202. Pinned across a slow and a fast iface so
+        // the boundary cannot re-gain an iface-dependent term without
+        // being caught.
+        for iface_bits in [1_000_000_000u64, 10_000_000_000, 100_000_000_000] {
+            let iface = test_cos_iface_with_rate(iface_bits);
+            let mut q = test_exact_queue_at_rate(4, 0);
+            q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES - 1;
+            assert!(
+                !queue_uses_shared_exact_service(&iface, &q),
+                "iface {iface_bits}: one byte below threshold must stay single-owner"
+            );
+            q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES;
+            assert!(
+                queue_uses_shared_exact_service(&iface, &q),
+                "iface {iface_bits}: at threshold must be shared"
+            );
+        }
     }
 
     #[test]
-    fn queue_uses_shared_exact_service_slow_iface_absolute_floor_applies() {
-        // 1g iface -> /4 = 250m; MIN = 2.5g dominates. Every exact queue
-        // on a 1g iface is at or below 1g, which is below the 2.5g floor,
-        // so all of them run single-owner. This documents the slow-iface
-        // case where the absolute MIN term is what matters.
+    fn queue_uses_shared_exact_service_slow_iface_below_threshold_is_single_owner() {
+        // 1g iface, every exact queue is below the 2.5g ceiling → single
+        // owner. Documents that the predicate does not depend on the
+        // queue/iface ratio, only on the queue's absolute rate.
         let iface = test_cos_iface_with_rate(1_000_000_000);
         let q_100m = test_exact_queue_at_rate(0, 100_000_000);
         let q_1g = test_exact_queue_at_rate(4, 1_000_000_000);
@@ -2139,31 +2146,12 @@ mod tests {
     }
 
     #[test]
-    fn queue_uses_shared_exact_service_iface_rate_gate_boundary_is_byte_precise() {
-        // On a 100g iface the iface_rate/4 term is the active gate
-        // (25 Gbps = 3_125_000_000 bytes/s, well above the 2.5 Gbps MIN).
-        // Pin the inclusive boundary on the iface_rate/4 axis specifically
-        // so a future policy change to that term is an explicit assertion
-        // edit, not a silent flip. The 10g-iface "exactly_inclusive" test
-        // cannot distinguish MIN from iface_rate/4 because they coincide
-        // at exactly 2.5 Gbps there.
-        let iface = test_cos_iface_with_rate(100_000_000_000);
-        let expected_threshold_bytes = iface.shaping_rate_bytes / 4;
-        assert!(expected_threshold_bytes > COS_SHARED_EXACT_MIN_RATE_BYTES);
-        let mut q = test_exact_queue_at_rate(4, 0);
-        q.transmit_rate_bytes = expected_threshold_bytes - 1;
-        assert!(!queue_uses_shared_exact_service(&iface, &q));
-        q.transmit_rate_bytes = expected_threshold_bytes;
-        assert!(queue_uses_shared_exact_service(&iface, &q));
-    }
-
-    #[test]
     fn queue_uses_shared_exact_service_zero_rate_exact_queue_is_single_owner() {
         // Config validation should normally reject a 0-rate exact queue,
         // but if one ever reaches the predicate (race during reload, test
         // fixture, malformed journal replay) the policy is "single owner":
         // a queue with no budget cannot justify burning a shared-lease
-        // slot, and the threshold is strictly positive on every iface.
+        // slot, and the threshold is strictly positive.
         let iface_10g = test_cos_iface_with_rate(10_000_000_000);
         let iface_100g = test_cos_iface_with_rate(100_000_000_000);
         let mut q = test_exact_queue_at_rate(4, 0);
@@ -2173,35 +2161,51 @@ mod tests {
     }
 
     #[test]
-    fn queue_uses_shared_exact_service_high_iface_rate_keeps_large_queues_single_owner() {
-        // KNOWN ROUGH EDGE (#690 follow-on). On a 100g iface the /4 term
-        // dominates: threshold = max(25g, 2.5g) = 25g. A 10g or 20g exact
-        // queue is classified as single-owner, even though a single worker
-        // cannot sustain 10g exact throughput (the collapse case from
-        // PR #680). The policy scales UP with iface rate, which is the
-        // wrong direction relative to per-worker capacity.
-        //
-        // This test asserts the CURRENT behavior on purpose so a future
-        // policy fix is an explicit decision rather than a silent flip.
-        // Do not change these assertions without a corresponding live
-        // validation on a >10g iface that the change does not regress
-        // 5202-class throughput.
-        let iface = test_cos_iface_with_rate(100_000_000_000);
+    fn queue_uses_shared_exact_service_threshold_does_not_scale_with_iface_rate() {
+        // #697: the pre-fix policy was `max(iface_rate / 4, MIN)` which
+        // scaled the threshold up with iface rate. A 10g exact queue on a
+        // 100g iface got classified as single-owner (threshold was 25g),
+        // routing a genuinely high-rate queue straight into PR #680's
+        // throughput-collapse shape. The fix removes the `/ 4` term; the
+        // threshold is now the absolute per-worker ceiling regardless of
+        // iface rate. Exercise that: a 10g exact queue must be shared on
+        // every realistic iface rate, not just on a 10g iface.
         let q_10g = test_exact_queue_at_rate(5, 10_000_000_000);
-        let q_20g = test_exact_queue_at_rate(6, 20_000_000_000);
-        let q_25g = test_exact_queue_at_rate(7, 25_000_000_000);
-        assert!(!queue_uses_shared_exact_service(&iface, &q_10g));
-        assert!(!queue_uses_shared_exact_service(&iface, &q_20g));
-        assert!(queue_uses_shared_exact_service(&iface, &q_25g));
+        for iface_bits in [10u64, 25, 40, 50, 100, 200, 400].map(|g| g * 1_000_000_000) {
+            let iface = test_cos_iface_with_rate(iface_bits);
+            assert!(
+                queue_uses_shared_exact_service(&iface, &q_10g),
+                "iface {iface_bits}: 10g exact queue must be shared — single-owner would \
+                 reintroduce the PR #680 throughput collapse"
+            );
+        }
     }
 
     #[test]
-    fn queue_uses_shared_exact_service_zero_iface_rate_falls_back_to_absolute_floor() {
+    fn queue_uses_shared_exact_service_high_iface_rate_shards_mid_rate_queues() {
+        // Same shape as the scale-invariance test but pinned byte-precise
+        // at the threshold for a specific fast iface. On a 100g iface a
+        // 2.5g exact queue must shard (it crosses the per-worker ceiling),
+        // and a 2.5g-minus-one-byte queue must not. Under the pre-fix
+        // policy this iface had threshold 25g and both of these would have
+        // been single-owner.
+        let iface = test_cos_iface_with_rate(100_000_000_000);
+        let mut q = test_exact_queue_at_rate(4, 0);
+        q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES - 1;
+        assert!(!queue_uses_shared_exact_service(&iface, &q));
+        q.transmit_rate_bytes = COS_SHARED_EXACT_MIN_RATE_BYTES;
+        assert!(queue_uses_shared_exact_service(&iface, &q));
+        q.transmit_rate_bytes = 5_000_000_000 / 8; // 5 Gbps
+        assert!(queue_uses_shared_exact_service(&iface, &q));
+    }
+
+    #[test]
+    fn queue_uses_shared_exact_service_zero_iface_rate_uses_absolute_threshold() {
         // Bootstrap / pathological case: iface shaper is 0 (unconfigured).
-        // saturating_div(4) == 0, MIN dominates, behavior is the absolute
-        // 2.5g floor. Verifies there is no divide-by-zero or underflow path
-        // and that a brand-new iface at startup does not accidentally mark
-        // every exact queue as shared.
+        // Predicate is iface-rate-independent, so this is just the absolute
+        // threshold applied to the queue rate. Verifies there is no
+        // divide-by-zero or underflow on any code path the previous
+        // `saturating_div(4)` branch used to guard.
         let iface = test_cos_iface_with_rate(0);
         let q_2g = test_exact_queue_at_rate(4, 2_000_000_000);
         let q_3g = test_exact_queue_at_rate(5, 3_000_000_000);

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1481,17 +1481,17 @@ const COS_SHARED_EXACT_MIN_RATE_BYTES: u64 = 2_500_000_000 / 8;
 /// Before PR #697 the threshold was `max(iface_rate / 4, MIN)`. That scaled
 /// the threshold up with iface rate, which is the wrong direction: the
 /// single-worker drain ceiling is an absolute property of the loop, not a
-/// fraction of the iface. On a 25g or 100g iface the `iface_rate / 4` term
-/// dominated and would classify a genuinely high-rate queue (e.g. a 10g
-/// exact queue on a 100g iface) as single-owner — routing it straight back
-/// into the PR #680 collapse shape. The `/ 4` term is now gone; the
-/// threshold is just the absolute per-worker ceiling.
+/// fraction of the iface. Once `iface_rate / 4` exceeded `MIN`, the policy
+/// would classify a genuinely high-rate queue (e.g. a 10g exact queue on a
+/// 100g iface) as single-owner — routing it straight back into the PR #680
+/// collapse shape. The `/ 4` term is now gone; the threshold is just the
+/// absolute per-worker ceiling.
 ///
-/// On the current 10g-iface lab the new threshold equals the old threshold
-/// (`max(2.5g, 2.5g) == 2.5g`), so 5201 / 5202 / 5203 classification is
-/// byte-identical. The change only affects lab configs running on faster
-/// interfaces, which is why #697 notes "live validation requires a >10g
-/// iface" before closing the loop.
+/// The old and new policies classify queues identically whenever
+/// `iface_rate / 4 <= COS_SHARED_EXACT_MIN_RATE_BYTES` (both evaluate to
+/// `MIN`). Behavior diverges only in the `iface_rate / 4 > MIN` regime,
+/// which is the regime that previously mis-classified mid/high-rate exact
+/// queues as single-owner.
 #[inline]
 fn queue_uses_shared_exact_service(_iface: &CoSInterfaceConfig, queue: &CoSQueueConfig) -> bool {
     if !queue.exact {
@@ -2053,6 +2053,101 @@ mod tests {
         assert!(queue5.shared_exact);
         assert_eq!(queue5.owner_worker_id, 7);
         assert!(queue5.shared_queue_lease.is_some());
+    }
+
+    #[test]
+    fn build_worker_cos_fast_interfaces_high_iface_rate_shards_mid_rate_exact_queue() {
+        // #697 regression: a mid-rate exact queue on a >10g iface must end
+        // up on the shared-worker path end-to-end. The helper predicate is
+        // tested directly elsewhere in this module, but the runtime effect
+        // of this PR lands in `build_worker_cos_fast_interfaces` and is
+        // later consumed by `ensure_cos_interface_runtime` to set
+        // `flow_fair` and by the dispatch path to pick shared vs owner-
+        // local service. Pin the assembled output for the new regime
+        // (`iface_rate / 4 > MIN`) so a future refactor of either the
+        // predicate or the assembly cannot quietly re-introduce the
+        // PR #680 collapse shape.
+        //
+        // Shape: 100g iface, 5g exact queue on queue_id=6. Under the
+        // pre-fix policy the threshold was 25g and a 5g exact queue would
+        // have assembled with `shared_exact=false` and `shared_queue_lease
+        // = None`. Under the fix the 5g queue crosses the 2.5g absolute
+        // floor and assembles as shared.
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 100_000_000_000 / 8,
+                burst_bytes: 1 * 1024 * 1024,
+                default_queue: 6,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 6,
+                    forwarding_class: "mid-rate".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 5_000_000_000 / 8,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: 256 * 1024,
+                    dscp_rewrite: None,
+                }],
+            },
+        );
+        forwarding.egress.insert(
+            80,
+            EgressInterface {
+                bind_ifindex: 12,
+                vlan_id: 80,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone: "wan".into(),
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+
+        let queue_owner_live = Arc::new(BindingLiveState::new());
+        let tx_owner_live = Arc::new(BindingLiveState::new());
+        let tx_owner_live_by_tx_ifindex = FastMap::from_iter([(12, tx_owner_live.clone())]);
+        let owner_worker_by_queue = BTreeMap::from([((80, 6), 5)]);
+        let owner_live_by_queue = BTreeMap::from([((80, 6), queue_owner_live.clone())]);
+        let shared_root_leases = BTreeMap::from([(
+            80,
+            Arc::new(SharedCoSRootLease::new(
+                100_000_000_000 / 8,
+                1 * 1024 * 1024,
+                4,
+            )),
+        )]);
+        let queue_lease = Arc::new(SharedCoSQueueLease::new(5_000_000_000 / 8, 256 * 1024, 4));
+        let shared_queue_leases = BTreeMap::from([((80, 6), queue_lease.clone())]);
+
+        let fast = build_worker_cos_fast_interfaces(
+            &forwarding,
+            3,
+            &tx_owner_live_by_tx_ifindex,
+            &owner_worker_by_queue,
+            &owner_live_by_queue,
+            &shared_root_leases,
+            &shared_queue_leases,
+        );
+
+        let iface = fast.get(&80).expect("fast cos interface");
+        let queue6 = iface.queue_fast_path(Some(6)).expect("queue 6");
+        assert!(
+            queue6.shared_exact,
+            "5g exact queue on 100g iface must be classified as shared after #697"
+        );
+        assert!(
+            queue6.shared_queue_lease.is_some(),
+            "shared queue lease must be wired up for a sharded exact queue"
+        );
+        assert_eq!(queue6.owner_worker_id, 5);
     }
 
     fn test_cos_iface_with_rate(shaping_bits: u64) -> CoSInterfaceConfig {


### PR DESCRIPTION
## Summary
- replace `max(iface_rate / 4, MIN)` with just `COS_SHARED_EXACT_MIN_RATE_BYTES`
- fixes the shared-exact policy inversion at >10g iface rates where the old threshold scaled UP with iface rate and mis-classified high-rate queues as single-owner, routing them into the PR #680 throughput-collapse shape
- byte-identical behavior on the 10g loss HA lab (where `iface_rate / 4 == MIN == 2.5g`)
- closes #697

## Why
The old policy treated the shared-exact cutoff as a fraction of the interface shaper. That was backwards. A single worker's sustained exact drain throughput is an absolute property of the drain loop and the TX ring — it does not scale with iface rate. The `/ 4` term meant:

| iface | old threshold | 10g exact queue gets |
|-------|---------------|---------------------|
| 10g   | max(2.5g, 2.5g) = 2.5g | **shared** (correct) |
| 25g   | max(6.25g, 2.5g) = 6.25g | **single-owner** (collapse) |
| 100g  | max(25g, 2.5g) = 25g | **single-owner** (collapse) |

At 25g+ a 10g exact queue would have been routed to one owner worker that cannot sustain 10g exact — exactly PR #680's failure mode.

## Implementation

One line in `userspace-dp/src/afxdp/worker.rs`:

```rust
fn queue_uses_shared_exact_service(_iface: &CoSInterfaceConfig, queue: &CoSQueueConfig) -> bool {
    if !queue.exact { return false; }
    queue.transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES
}
```

The `iface` parameter is retained so call sites do not churn; it is no longer consulted. Rustdoc updated to document the policy and name #697 / PR #680 as the rationale.

## Test diff

**Removed:**
- `queue_uses_shared_exact_service_high_iface_rate_keeps_large_queues_single_owner` — this test explicitly pinned the BUG (a 10g exact queue on a 100g iface asserted as single-owner). Its job was done the moment the policy change landed.
- `queue_uses_shared_exact_service_iface_rate_gate_boundary_is_byte_precise` — the iface-rate gate no longer exists, so this test asserts a code path that does not run.

**Added:**
- `queue_uses_shared_exact_service_threshold_does_not_scale_with_iface_rate` — iterates iface rates {10, 25, 40, 50, 100, 200, 400 Gbps} and asserts a 10g exact queue shards on every one. This is the correctness property #697 asked for.
- `queue_uses_shared_exact_service_high_iface_rate_shards_mid_rate_queues` — byte-precise boundary at a 100g iface. Under the old policy a 2.5g exact queue on a 100g iface would have been single-owner (threshold was 25g); under the fix it shards.

**Tightened:**
- `queue_uses_shared_exact_service_threshold_is_exactly_inclusive` — now iterates iface rates {1g, 10g, 100g} and asserts the byte-precise boundary holds on all three. Pins that the threshold cannot re-gain an iface-dependent term without the test failing loudly.
- `queue_uses_shared_exact_service_slow_iface_below_threshold_is_single_owner` — renamed and re-documented; no longer talks about MIN "dominating" `/ 4` since `/ 4` is gone.
- `queue_uses_shared_exact_service_zero_iface_rate_uses_absolute_threshold` — retained as a bootstrap sanity check (no divide-by-zero etc).

## Live validation

Helper SHA `b4c8bfa9e56e399b63c3261b2455eabd73cb8a9c1b44eb2b616781f6b8c8043a` rolled out to `xpf-userspace-fw0` and `xpf-userspace-fw1`; xpfd restarted on both nodes.

12-stream iperf3, 20–30s:

| | IPv4 | IPv6 |
|-|------|------|
| **5201** (1g exact, single-owner) | 1.076 / 1.069 Gbit/s, ratio 1.68 (rerun 2.34) | 1.122 / 1.117 Gbit/s, ratio 1.25 |
| **5202** (10g exact, shared)      | 9.554 / 9.537 Gbit/s, retrans 8.2K | 9.386 / 9.368 Gbit/s, retrans 76K |
| **5203** (100m exact, single-owner) | 0.096 / 0.095 Gbit/s | 0.095 / 0.094 Gbit/s |

- **5202** within ±2% of PR #692 baseline (9.533 / 9.388 Gbit/s). ✓
- **5203** within ±3% of 100 Mbps. ✓
- **5201** aggregate at 1.07–1.12 Gbit/s. Per-flow ratio varies 1.25–2.34 run-to-run; this is the SFQ bucket-collision dependency on the randomized seed (PR #699), not a regression from this change. The 5201 code path is byte-identical pre- and post-fix on 10g iface — the predicate returns the same bit for every queue in the current live config. PR #692's original 5201 baseline was 2.057 IPv4 / 1.34 IPv6.

## What this PR cannot validate

The fix's *new* behavior — a mid-rate exact queue on a >10g iface going to shared instead of single-owner — is not live-validated. The loss lab runs 10g interfaces where the old and new threshold coincide. Unit tests pin the policy at 25g, 40g, 50g, 100g, 200g, 400g; a live run on a faster NIC is the next step when hardware is available, tracked separately.

The fix is **safe to land** on 10g because the threshold math is identical there by construction — any behavior change would be a bug in the new tests, not in the runtime.

## Not in this PR
- Empirical derivation of the 2.5 Gbps `COS_SHARED_EXACT_MIN_RATE_BYTES` constant (#698).
- End-to-end dispatch test covering the three-queue lab shape (#698).
- SFQ RR-ring fixed-capacity rewrite (#694).
- Further `drain_pending_tx` / `poll_binding` cuts (#678).

🤖 Generated with [Claude Code](https://claude.com/claude-code)