### PR TITLE
userspace-dp: fix three pre-existing CoS test failures

### DIFF
--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -2221,20 +2221,29 @@ mod tests {
         let leases = build_shared_cos_root_leases(&forwarding, &active_shards_by_egress_ifindex);
         let lease = leases.get(&80).expect("shared root lease");
 
-        let first = lease.acquire(1, 2500);
-        let second = lease.acquire(1, 2500);
-        let third = lease.acquire(1, 2500);
-        let fourth = lease.acquire(1, 2500);
-        let fifth = lease.acquire(1, 1);
-
-        assert_eq!(first, 2500);
-        assert_eq!(second, 2500);
-        assert_eq!(third, 2500);
+        // The root lease budget should scale with active_shards: at lease_bytes = 20 000 bytes and
+        // active_shards = 2, per-lease-config budget is lease_bytes * active_shards = 40 000 bytes.
+        // That is what this test pins — drain the budget with fixed-size requests and assert the
+        // cumulative grant equals lease_bytes * active_shards and that further acquires return 0.
+        let lease_bytes = lease.lease_bytes();
+        let per_request = 2500u64;
+        let expected_total = lease_bytes * 2;
         assert_eq!(
-            first + second + third + fourth,
-            (tx_frame_capacity() as u64) * 2
+            expected_total % per_request,
+            0,
+            "test assumes budget divides evenly into request size"
         );
-        assert_eq!(fifth, 0);
+        let request_count = (expected_total / per_request) as usize;
+
+        let mut total = 0u64;
+        for _ in 0..request_count {
+            let granted = lease.acquire(1, per_request);
+            assert_eq!(granted, per_request);
+            total += granted;
+        }
+        assert_eq!(total, expected_total);
+        let overflow = lease.acquire(1, 1);
+        assert_eq!(overflow, 0);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -2221,29 +2221,39 @@ mod tests {
         let leases = build_shared_cos_root_leases(&forwarding, &active_shards_by_egress_ifindex);
         let lease = leases.get(&80).expect("shared root lease");
 
-        // The root lease budget should scale with active_shards: at lease_bytes = 20 000 bytes and
-        // active_shards = 2, per-lease-config budget is lease_bytes * active_shards = 40 000 bytes.
-        // That is what this test pins — drain the budget with fixed-size requests and assert the
-        // cumulative grant equals lease_bytes * active_shards and that further acquires return 0.
+        // The root lease budget must scale with active_shards: total
+        // grantable = lease_bytes * active_shards. That is the actual
+        // invariant this test pins. Drive it by reading active_shards
+        // from the fixture (so the assertion does not silently decouple
+        // from the setup) and drain the budget with fixed-size requests
+        // plus a tail remainder for whatever the budget does not cleanly
+        // divide by — lease_bytes is a function of shaping rate and
+        // COS_ROOT_LEASE_TARGET_US, both of which are tuning knobs, so
+        // an exact-divisibility assertion would make this test brittle
+        // against legitimate scheduler tuning.
+        let active_shards = *active_shards_by_egress_ifindex
+            .get(&80)
+            .expect("active shards configured for egress ifindex 80")
+            as u64;
         let lease_bytes = lease.lease_bytes();
+        let expected_total = lease_bytes * active_shards;
         let per_request = 2500u64;
-        let expected_total = lease_bytes * 2;
-        assert_eq!(
-            expected_total % per_request,
-            0,
-            "test assumes budget divides evenly into request size"
-        );
-        let request_count = (expected_total / per_request) as usize;
 
+        let mut remaining = expected_total;
         let mut total = 0u64;
-        for _ in 0..request_count {
-            let granted = lease.acquire(1, per_request);
-            assert_eq!(granted, per_request);
+        while remaining > 0 {
+            let req = remaining.min(per_request);
+            let granted = lease.acquire(1, req);
+            assert_eq!(
+                granted, req,
+                "root lease must grant the full request while budget remains",
+            );
             total += granted;
+            remaining -= granted;
         }
         assert_eq!(total, expected_total);
-        let overflow = lease.acquire(1, 1);
-        assert_eq!(overflow, 0);
+        // Budget fully drained — any further acquire must return 0.
+        assert_eq!(lease.acquire(1, 1), 0);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -4733,22 +4733,25 @@ mod tests {
 
     #[test]
     fn maybe_top_up_cos_root_lease_unblocks_large_frame_exceeding_lease_bytes() {
-        // At 400 Mbps / 256 KB burst / 1 shard, lease_bytes() == 1500, which is less than
-        // tx_frame_capacity() == 4096.  Without the .max(tx_frame_capacity()) fix, root.tokens
+        // Pick a shaping rate low enough that lease_bytes() floors to COS_ROOT_LEASE_MIN_BYTES
+        // (1500) and stays below tx_frame_capacity() (4096).  At 50 Mbps / 256 KB burst / 1 shard
+        // the raw target lease is rate*TARGET_US/1e6 = 1250 bytes, which floors up to 1500.
+        // Without the .max(tx_frame_capacity()) fix in maybe_top_up_cos_root_lease, root.tokens
         // could never exceed 1500 and any frame with len > 1500 would deadlock the CoS queue.
-        let lease = Arc::new(SharedCoSRootLease::new(400_000_000 / 8, 256 * 1024, 1));
+        let rate_bytes = 50_000_000u64 / 8;
+        let lease = Arc::new(SharedCoSRootLease::new(rate_bytes, 256 * 1024, 1));
         assert!(
             lease.lease_bytes() < tx_frame_capacity() as u64,
             "precondition: lease_bytes must be below tx_frame_capacity for this regression"
         );
 
         let mut root = test_cos_runtime_with_queues(
-            400_000_000 / 8,
+            rate_bytes,
             vec![CoSQueueConfig {
                 queue_id: 0,
                 forwarding_class: "best-effort".into(),
                 priority: 5,
-                transmit_rate_bytes: 400_000_000 / 8,
+                transmit_rate_bytes: rate_bytes,
                 exact: false,
                 surplus_weight: 1,
                 buffer_bytes: COS_MIN_BURST_BYTES,
@@ -7421,6 +7424,14 @@ mod tests {
         assert_eq!(queue_id, Some(0));
     }
 
+    // Note on invariant change (replaces the pre-a15a6120 "defaults to iface default" behavior):
+    // The original shape of this test asserted that an output filter with NO tx-side effect (no
+    // forwarding_class, no counter) would still shadow the ingress input filter's classification
+    // and leave egress at the interface default queue.  Commit a15a6120 changed the gating so the
+    // output filter is skipped entirely when it has neither forwarding_class, dscp_rewrite, nor
+    // counter terms — matching Junos semantics, where a classify-only output filter that does not
+    // classify does not clobber upstream classification.  The new invariant asserted below: when
+    // the output filter has no tx-side effect, ingress input-filter classification is preserved.
     #[test]
     fn resolve_cos_queue_id_defaults_when_output_filter_has_no_forwarding_class() {
         let snapshot = ConfigSnapshot {
@@ -7538,7 +7549,12 @@ mod tests {
             }),
         );
 
-        assert_eq!(queue_id, Some(7));
+        // cos-classify on reth1.0 maps expedited-forwarding -> queue 1.  The output filter
+        // wan-classify on reth0.0 has no tx-side effect (no forwarding_class, no dscp_rewrite,
+        // no counter), so post-a15a6120 it is bypassed and the ingress classification is
+        // preserved.  Pre-a15a6120 this was expected to fall through to the iface default queue
+        // (best-effort = 7); that contract no longer holds and is captured by this test.
+        assert_eq!(queue_id, Some(1));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -7433,7 +7433,8 @@ mod tests {
     // classify does not clobber upstream classification.  The new invariant asserted below: when
     // the output filter has no tx-side effect, ingress input-filter classification is preserved.
     #[test]
-    fn resolve_cos_queue_id_defaults_when_output_filter_has_no_forwarding_class() {
+    fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_no_forwarding_class()
+     {
         let snapshot = ConfigSnapshot {
             interfaces: vec![
                 InterfaceSnapshot {


### PR DESCRIPTION
Three CoS tests were asserting stale invariants and failing on master. Fix each:

**build_shared_cos_root_leases_uses_active_workers_per_interface** (coordinator.rs)
Root cause: assertion `first+second+third+fourth == tx_frame_capacity()*2` (8192) was copy-pasted from the sibling queue-lease test. For this test's config (100 Mbps / 256 KB / 2 shards) `lease_bytes=20 000` and `max_total_leased = lease_bytes * active_shards = 40 000`, not 8192.
Fix: rewrite to drain the full budget and pin the real invariant — root budget scales with `active_shards`.

**maybe_top_up_cos_root_lease_unblocks_large_frame_exceeding_lease_bytes** (tx.rs)
Root cause: precondition `lease_bytes() < tx_frame_capacity()` was valid when `COS_ROOT_LEASE_TARGET_US=25`. Commit e4ae9eeb bumped it to 200, so at 400 Mbps lease_bytes is now 10 000 (> 4096) and the precondition trips.
Fix: drop rate to 50 Mbps so the raw target (1250) floors up to `COS_ROOT_LEASE_MIN_BYTES=1500` < 4096, exercising the same regression path.

**resolve_cos_queue_id_defaults_when_output_filter_has_no_forwarding_class** (tx.rs)
Root cause: test expected an assigned but no-op output filter to shadow ingress classification and fall back to default queue. Commit a15a6120 intentionally changed the gating (`interface_output_filter_needs_tx_eval`) to skip the output filter entirely when it has no `forwarding_class`, `dscp_rewrite`, or counter term — matching Junos semantics.
Fix: update assertion to the new invariant (ingress classification is preserved) and leave a comment above the test explaining the contract change.

## Validation
- `cargo test --manifest-path userspace-dp/Cargo.toml` — 620 pass, 0 fail
- `cargo fmt --manifest-path userspace-dp/Cargo.toml`
- `git diff --check`