### PR TITLE
userspace-dp: lock-free redirect inbox eliminates cross-producer mutex (#706)

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -65,6 +65,8 @@ mod forwarding_build;
 mod frame;
 #[path = "afxdp/frame_tx.rs"]
 mod frame_tx;
+#[path = "afxdp/mpsc_inbox.rs"]
+mod mpsc_inbox;
 #[path = "afxdp/gre.rs"]
 mod gre;
 #[path = "afxdp/ha.rs"]
@@ -134,6 +136,7 @@ use self::rst::*;
 use self::session_glue::*;
 use self::shared_ops::*;
 use self::tunnel::*;
+use self::mpsc_inbox::MpscInbox;
 use self::tx::*;
 use self::types::*;
 pub(crate) use self::types::{ForwardingDisposition, ForwardingResolution, NeighborEntry};

--- a/userspace-dp/src/afxdp/mpsc_inbox.rs
+++ b/userspace-dp/src/afxdp/mpsc_inbox.rs
@@ -30,15 +30,26 @@ struct Slot<T> {
     val: UnsafeCell<MaybeUninit<T>>,
 }
 
+/// Force a field onto its own 64-byte cache line. Producers CAS `head`
+/// while the owner worker advances `tail`; without this padding the two
+/// atomics would share a line and every producer operation would
+/// invalidate the consumer's cached view of `tail` (and vice versa),
+/// which re-introduces exactly the kind of cross-core coherence traffic
+/// the lock-free conversion is trying to eliminate.
+#[repr(align(64))]
+struct CachePadded<T>(T);
+
 pub(super) struct MpscInbox<T> {
     slots: Box<[Slot<T>]>,
     mask: usize,
-    /// Producer cursor. Advanced via CAS by any pushing thread.
-    head: AtomicUsize,
+    /// Producer cursor. Advanced via CAS by any pushing thread. On its
+    /// own cache line to avoid false sharing with `tail`.
+    head: CachePadded<AtomicUsize>,
     /// Consumer cursor. Advanced only by the single consumer (the owner
     /// worker for this binding). Exposed atomically so producers and the
-    /// `is_empty` / `len` helpers can observe it.
-    tail: AtomicUsize,
+    /// `is_empty` / `len` helpers can observe it. On its own cache line
+    /// to avoid false sharing with `head`.
+    tail: CachePadded<AtomicUsize>,
 }
 
 // Safety: the queue is designed to be shared across producer threads and
@@ -62,8 +73,8 @@ impl<T> MpscInbox<T> {
         Self {
             slots,
             mask: cap - 1,
-            head: AtomicUsize::new(0),
-            tail: AtomicUsize::new(0),
+            head: CachePadded(AtomicUsize::new(0)),
+            tail: CachePadded(AtomicUsize::new(0)),
         }
     }
 
@@ -78,19 +89,19 @@ impl<T> MpscInbox<T> {
     /// the updated `tail`. Safe for observability and soft-cap gating.
     #[inline]
     pub(super) fn len(&self) -> usize {
-        let head = self.head.load(Ordering::Relaxed);
-        let tail = self.tail.load(Ordering::Relaxed);
+        let head = self.head.0.load(Ordering::Relaxed);
+        let tail = self.tail.0.load(Ordering::Relaxed);
         head.wrapping_sub(tail)
     }
 
     #[inline]
     pub(super) fn is_empty(&self) -> bool {
-        self.head.load(Ordering::Relaxed) == self.tail.load(Ordering::Relaxed)
+        self.head.0.load(Ordering::Relaxed) == self.tail.0.load(Ordering::Relaxed)
     }
 
     /// Multi-producer push. Returns `Err(val)` when the ring is full.
     pub(super) fn push(&self, val: T) -> Result<(), T> {
-        let mut pos = self.head.load(Ordering::Relaxed);
+        let mut pos = self.head.0.load(Ordering::Relaxed);
         loop {
             // SAFETY: `pos & mask` is in range because `mask = cap - 1`
             // and `cap = slots.len()`.
@@ -99,7 +110,7 @@ impl<T> MpscInbox<T> {
             let diff = (seq as isize).wrapping_sub(pos as isize);
             if diff == 0 {
                 // Slot ready for this producer at `pos`. Try to claim.
-                match self.head.compare_exchange_weak(
+                match self.head.0.compare_exchange_weak(
                     pos,
                     pos.wrapping_add(1),
                     Ordering::Relaxed,
@@ -124,7 +135,7 @@ impl<T> MpscInbox<T> {
                 return Err(val);
             } else {
                 // Another producer claimed this slot first; refresh and retry.
-                pos = self.head.load(Ordering::Relaxed);
+                pos = self.head.0.load(Ordering::Relaxed);
             }
         }
     }
@@ -135,7 +146,7 @@ impl<T> MpscInbox<T> {
     /// contract is that only the owner worker for a binding pops from its
     /// inbox.
     pub(super) unsafe fn pop(&self) -> Option<T> {
-        let pos = self.tail.load(Ordering::Relaxed);
+        let pos = self.tail.0.load(Ordering::Relaxed);
         // SAFETY: `pos & mask` is in range.
         let slot = unsafe { self.slots.get_unchecked(pos & self.mask) };
         let seq = slot.seq.load(Ordering::Acquire);
@@ -154,6 +165,7 @@ impl<T> MpscInbox<T> {
                 Ordering::Release,
             );
             self.tail
+                .0
                 .store(pos.wrapping_add(1), Ordering::Release);
             Some(val)
         } else {

--- a/userspace-dp/src/afxdp/mpsc_inbox.rs
+++ b/userspace-dp/src/afxdp/mpsc_inbox.rs
@@ -1,0 +1,355 @@
+//! Bounded lock-free MPMC queue, safe for MPSC use.
+//!
+//! Backs the per-binding redirect inbox on `BindingLiveState` (see `umem.rs`):
+//! N producer workers push redirected `TxRequest`s; the owner worker drains.
+//! Prior to #706 this was a `Mutex<VecDeque<TxRequest>>` which serialised
+//! every producer against every other producer *and* against the owner's
+//! drain; the contention injected µs-scale jitter into TCP inter-arrival
+//! timing on redirected flows and drove the bimodal cwnd pattern in #704.
+//!
+//! Algorithm: Dmitry Vyukov's bounded MPMC with per-slot sequence numbers
+//! (<https://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue>).
+//! We only take the MPSC subset — all `pop` callers must be the owner worker
+//! — so correctness needs only the weaker single-consumer invariant. Using
+//! the MPMC algorithm keeps the push side trivially lock-free with one CAS
+//! per slot acquire.
+//!
+//! Overflow semantics: `push` returns `Err(val)` when the ring is full. The
+//! caller in `BindingLiveState` treats that as drop-newest and bumps the
+//! `redirect_inbox_overflow_drops` / `tx_errors` counters. This replaces the
+//! prior drop-oldest (pop-front-then-push-back) behaviour; drop-newest is
+//! preferable under contention because older queued packets are closer to
+//! being serviced by the owner and evicting them extends tail latency.
+
+use std::cell::UnsafeCell;
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Slot<T> {
+    seq: AtomicUsize,
+    val: UnsafeCell<MaybeUninit<T>>,
+}
+
+pub(super) struct MpscInbox<T> {
+    slots: Box<[Slot<T>]>,
+    mask: usize,
+    /// Producer cursor. Advanced via CAS by any pushing thread.
+    head: AtomicUsize,
+    /// Consumer cursor. Advanced only by the single consumer (the owner
+    /// worker for this binding). Exposed atomically so producers and the
+    /// `is_empty` / `len` helpers can observe it.
+    tail: AtomicUsize,
+}
+
+// Safety: the queue is designed to be shared across producer threads and
+// the consumer thread. `T: Send` is sufficient — values transit between
+// threads but each value is owned by exactly one thread at a time via
+// the head/tail sequencing.
+unsafe impl<T: Send> Send for MpscInbox<T> {}
+unsafe impl<T: Send> Sync for MpscInbox<T> {}
+
+impl<T> MpscInbox<T> {
+    /// Create a queue with capacity rounded up to the next power of two
+    /// (minimum 2 slots).
+    pub(super) fn new(capacity_hint: usize) -> Self {
+        let cap = capacity_hint.max(2).next_power_of_two();
+        let slots = (0..cap)
+            .map(|i| Slot {
+                seq: AtomicUsize::new(i),
+                val: UnsafeCell::new(MaybeUninit::uninit()),
+            })
+            .collect::<Box<[_]>>();
+        Self {
+            slots,
+            mask: cap - 1,
+            head: AtomicUsize::new(0),
+            tail: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    pub(super) fn capacity(&self) -> usize {
+        self.mask + 1
+    }
+
+    /// Approximate occupancy. Non-linearisable: producers may have
+    /// claimed a slot (advanced `head`) without yet publishing a value,
+    /// and the consumer may have consumed a value without readers seeing
+    /// the updated `tail`. Safe for observability and soft-cap gating.
+    #[inline]
+    pub(super) fn len(&self) -> usize {
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Relaxed);
+        head.wrapping_sub(tail)
+    }
+
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.head.load(Ordering::Relaxed) == self.tail.load(Ordering::Relaxed)
+    }
+
+    /// Multi-producer push. Returns `Err(val)` when the ring is full.
+    pub(super) fn push(&self, val: T) -> Result<(), T> {
+        let mut pos = self.head.load(Ordering::Relaxed);
+        loop {
+            // SAFETY: `pos & mask` is in range because `mask = cap - 1`
+            // and `cap = slots.len()`.
+            let slot = unsafe { self.slots.get_unchecked(pos & self.mask) };
+            let seq = slot.seq.load(Ordering::Acquire);
+            let diff = (seq as isize).wrapping_sub(pos as isize);
+            if diff == 0 {
+                // Slot ready for this producer at `pos`. Try to claim.
+                match self.head.compare_exchange_weak(
+                    pos,
+                    pos.wrapping_add(1),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        // SAFETY: we own the slot until we publish via
+                        // `seq.store(pos+1, Release)`; no other thread
+                        // can read or write the value until then.
+                        unsafe {
+                            (*slot.val.get()).write(val);
+                        }
+                        slot.seq
+                            .store(pos.wrapping_add(1), Ordering::Release);
+                        return Ok(());
+                    }
+                    Err(actual) => pos = actual,
+                }
+            } else if diff < 0 {
+                // seq is behind pos — consumer hasn't finished with the
+                // slot that currently lives at `pos & mask`. Queue full.
+                return Err(val);
+            } else {
+                // Another producer claimed this slot first; refresh and retry.
+                pos = self.head.load(Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Single-consumer pop.
+    ///
+    /// SAFETY: must not be called concurrently with itself. The helper's
+    /// contract is that only the owner worker for a binding pops from its
+    /// inbox.
+    pub(super) unsafe fn pop(&self) -> Option<T> {
+        let pos = self.tail.load(Ordering::Relaxed);
+        // SAFETY: `pos & mask` is in range.
+        let slot = unsafe { self.slots.get_unchecked(pos & self.mask) };
+        let seq = slot.seq.load(Ordering::Acquire);
+        let diff = (seq as isize).wrapping_sub(pos.wrapping_add(1) as isize);
+        if diff == 0 {
+            // Slot holds a value published at sequence `pos+1`.
+            // SAFETY: by the single-consumer invariant we are the only
+            // reader, and the producer already wrote the value before
+            // releasing the slot via `seq.store(pos+1, Release)`.
+            let val = unsafe { (*slot.val.get()).assume_init_read() };
+            // Republish slot for the next pass: producer looking at this
+            // slot at position `pos + cap` will see `seq == pos + cap`
+            // and be cleared to claim it.
+            slot.seq.store(
+                pos.wrapping_add(self.mask).wrapping_add(1),
+                Ordering::Release,
+            );
+            self.tail
+                .store(pos.wrapping_add(1), Ordering::Release);
+            Some(val)
+        } else {
+            // seq behind pos+1: no value yet at this tail position.
+            None
+        }
+    }
+}
+
+impl<T> Drop for MpscInbox<T> {
+    fn drop(&mut self) {
+        // SAFETY: &mut self gives us exclusive access, so the single-
+        // consumer invariant holds trivially.
+        while unsafe { self.pop() }.is_some() {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    #[test]
+    fn push_and_pop_in_order_for_single_producer() {
+        let q = MpscInbox::<u32>::new(4);
+        assert_eq!(q.capacity(), 4);
+        assert!(q.is_empty());
+        for i in 0..4 {
+            q.push(i).expect("push");
+        }
+        assert!(!q.is_empty());
+        assert_eq!(q.len(), 4);
+        for expected in 0..4 {
+            let got = unsafe { q.pop() }.expect("pop");
+            assert_eq!(got, expected);
+        }
+        assert!(q.is_empty());
+        assert!(unsafe { q.pop() }.is_none());
+    }
+
+    #[test]
+    fn push_returns_err_when_ring_is_full() {
+        let q = MpscInbox::<u32>::new(2);
+        q.push(10).unwrap();
+        q.push(11).unwrap();
+        match q.push(12) {
+            Err(v) => assert_eq!(v, 12),
+            Ok(()) => panic!("push should have failed on full ring"),
+        }
+        // After draining one slot, push should succeed again.
+        assert_eq!(unsafe { q.pop() }, Some(10));
+        q.push(13).expect("push after drain");
+        assert_eq!(unsafe { q.pop() }, Some(11));
+        assert_eq!(unsafe { q.pop() }, Some(13));
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn capacity_hint_rounds_up_to_power_of_two() {
+        assert_eq!(MpscInbox::<u32>::new(3).capacity(), 4);
+        assert_eq!(MpscInbox::<u32>::new(5).capacity(), 8);
+        assert_eq!(MpscInbox::<u32>::new(1).capacity(), 2);
+        assert_eq!(MpscInbox::<u32>::new(0).capacity(), 2);
+    }
+
+    #[test]
+    fn concurrent_producers_do_not_lose_items_below_capacity() {
+        // N producers each push P items; hard cap is large enough that
+        // no push should fail. Consumer drains and we verify the sum.
+        const PRODUCERS: usize = 4;
+        const PER_PRODUCER: usize = 1024;
+        let q = Arc::new(MpscInbox::<u32>::new(PRODUCERS * PER_PRODUCER));
+        let consumed = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..PRODUCERS)
+            .map(|p| {
+                let q = Arc::clone(&q);
+                thread::spawn(move || {
+                    for i in 0..PER_PRODUCER {
+                        let v = (p * PER_PRODUCER + i) as u32;
+                        q.push(v).expect("no overflow at below-cap");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Drain on the main (consumer) thread — the single consumer.
+        let mut sum: u64 = 0;
+        while let Some(v) = unsafe { q.pop() } {
+            sum += v as u64;
+            consumed.fetch_add(1, Ordering::Relaxed);
+        }
+        let expected_sum: u64 = (0..(PRODUCERS * PER_PRODUCER) as u64).sum();
+        assert_eq!(sum, expected_sum, "lost items across concurrent producers");
+        assert_eq!(consumed.load(Ordering::Relaxed), PRODUCERS * PER_PRODUCER);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn concurrent_producers_over_capacity_drop_exactly_the_overflow() {
+        // N producers each try to push P items into a ring smaller than
+        // N*P. We count push failures (Err) and pop successes (Ok) and
+        // verify no item is leaked or duplicated. With a concurrent
+        // consumer, `pushed == popped + failed`.
+        const PRODUCERS: usize = 4;
+        const PER_PRODUCER: usize = 4096;
+        const CAP: usize = 1024;
+        let q = Arc::new(MpscInbox::<u32>::new(CAP));
+        let pushed_ok = Arc::new(AtomicUsize::new(0));
+        let pushed_err = Arc::new(AtomicUsize::new(0));
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|p| {
+                let q = Arc::clone(&q);
+                let ok = Arc::clone(&pushed_ok);
+                let err = Arc::clone(&pushed_err);
+                thread::spawn(move || {
+                    for i in 0..PER_PRODUCER {
+                        let v = (p * PER_PRODUCER + i) as u32;
+                        match q.push(v) {
+                            Ok(()) => {
+                                ok.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Err(_) => {
+                                err.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        // Consumer runs concurrently with producers.
+        let q_c = Arc::clone(&q);
+        let consumer = thread::spawn(move || {
+            let mut popped = 0usize;
+            let mut idle_spins = 0usize;
+            loop {
+                if let Some(_v) = unsafe { q_c.pop() } {
+                    popped += 1;
+                    idle_spins = 0;
+                } else {
+                    idle_spins += 1;
+                    if idle_spins > 1_000_000 {
+                        break;
+                    }
+                    std::hint::spin_loop();
+                }
+            }
+            popped
+        });
+
+        for h in producers {
+            h.join().unwrap();
+        }
+        let popped_mid = consumer.join().unwrap();
+        // Drain anything the consumer's timeout missed.
+        let mut popped_tail = 0;
+        while let Some(_v) = unsafe { q.pop() } {
+            popped_tail += 1;
+        }
+        let popped = popped_mid + popped_tail;
+
+        let ok = pushed_ok.load(Ordering::Relaxed);
+        let err = pushed_err.load(Ordering::Relaxed);
+        assert_eq!(ok + err, PRODUCERS * PER_PRODUCER);
+        assert_eq!(
+            popped, ok,
+            "every successful push should be popped exactly once \
+             (popped={popped}, pushed_ok={ok}, pushed_err={err})"
+        );
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn drop_runs_for_remaining_values() {
+        use std::sync::atomic::AtomicUsize;
+        struct DropCount<'a>(&'a AtomicUsize);
+        impl<'a> Drop for DropCount<'a> {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let counter = AtomicUsize::new(0);
+        {
+            let q = MpscInbox::<DropCount<'_>>::new(8);
+            q.push(DropCount(&counter)).ok().unwrap();
+            q.push(DropCount(&counter)).ok().unwrap();
+            q.push(DropCount(&counter)).ok().unwrap();
+            // Drop the queue without popping: all three values must Drop.
+        }
+        assert_eq!(counter.load(Ordering::Relaxed), 3);
+    }
+}

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -759,20 +759,18 @@ pub(super) fn cancel_queued_flow_on_binding(
     }
     binding.pending_tx_prepared = kept_prepared;
 
-    if let Ok(mut pending) = binding.live.pending_tx.lock() {
-        let mut kept_shared = VecDeque::with_capacity(pending.len());
-        while let Some(req) = pending.pop_front() {
-            if tx_request_matches_flow(&req, forward_key, reverse_key) {
-                continue;
-            }
-            kept_shared.push_back(req);
-        }
-        binding
-            .live
-            .pending_tx_len
-            .store(kept_shared.len() as u32, Ordering::Relaxed);
-        *pending = kept_shared;
-    }
+    // #706: the cross-worker redirect inbox (`binding.live.pending_tx`) is
+    // now a lock-free MPSC ring (`MpscInbox`). In-place filtering from an
+    // arbitrary thread is not safe on that structure — only the owner
+    // worker may drain it. We accept that packets already sitting in the
+    // redirect inbox for a now-canceled flow will drain out on the next
+    // owner poll and hit the wire; the peer already saw a RST, so the
+    // extra late packets are ignored (or provoke a benign RST-for-RST
+    // response) rather than causing protocol harm. This trade is
+    // documented in #706's fix notes. The worker-owned `pending_tx_local`
+    // and `pending_tx_prepared` queues above are still filtered because
+    // they are never touched by another thread.
+    let _ = (forward_key, reverse_key);
 
     update_binding_debug_state(binding);
 }

--- a/userspace-dp/src/afxdp/session_glue.rs
+++ b/userspace-dp/src/afxdp/session_glue.rs
@@ -766,11 +766,9 @@ pub(super) fn cancel_queued_flow_on_binding(
     // redirect inbox for a now-canceled flow will drain out on the next
     // owner poll and hit the wire; the peer already saw a RST, so the
     // extra late packets are ignored (or provoke a benign RST-for-RST
-    // response) rather than causing protocol harm. This trade is
-    // documented in #706's fix notes. The worker-owned `pending_tx_local`
-    // and `pending_tx_prepared` queues above are still filtered because
-    // they are never touched by another thread.
-    let _ = (forward_key, reverse_key);
+    // response) rather than causing protocol harm. The worker-owned
+    // `pending_tx_local` and `pending_tx_prepared` queues above are still
+    // filtered because they are never touched by another thread.
 
     update_binding_debug_state(binding);
 }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -539,8 +539,7 @@ fn ingest_cos_pending_tx(
     }
 
     let mut pending = core::mem::take(&mut binding.pending_tx_local);
-    let mut shared = binding.live.take_pending_tx();
-    append_pending_queue(&mut pending, &mut shared);
+    binding.live.take_pending_tx_into(&mut pending);
     process_pending_queue_in_place(&mut pending, |req| {
         let req = match redirect_local_cos_request_to_owner(
             &binding.cos_fast_interfaces,
@@ -4066,27 +4065,6 @@ fn restore_cos_prepared_items_inner(
     retry_bytes
 }
 
-fn merge_pending_tx_requests(
-    mut local: VecDeque<TxRequest>,
-    mut shared: VecDeque<TxRequest>,
-) -> VecDeque<TxRequest> {
-    if local.is_empty() {
-        return shared;
-    }
-    if !shared.is_empty() {
-        local.append(&mut shared);
-    }
-    local
-}
-
-fn append_pending_queue<T>(pending: &mut VecDeque<T>, shared: &mut VecDeque<T>) {
-    if pending.is_empty() {
-        *pending = core::mem::take(shared);
-    } else if !shared.is_empty() {
-        pending.append(shared);
-    }
-}
-
 fn process_pending_queue_in_place<T, F>(pending: &mut VecDeque<T>, mut f: F)
 where
     F: FnMut(T) -> Result<(), T>,
@@ -4103,9 +4081,13 @@ where
 }
 
 fn take_pending_tx_requests(binding: &mut BindingWorker) -> VecDeque<TxRequest> {
-    let local = core::mem::take(&mut binding.pending_tx_local);
-    let shared = binding.live.take_pending_tx();
-    merge_pending_tx_requests(local, shared)
+    // Reuse the worker-owned `pending_tx_local` buffer as the drain
+    // target so the owner-worker hot path stays allocation-free. `pop`
+    // from the lock-free inbox appends into the same buffer without a
+    // queue-to-queue copy.
+    let mut out = core::mem::take(&mut binding.pending_tx_local);
+    binding.live.take_pending_tx_into(&mut out);
+    out
 }
 
 fn restore_pending_tx_requests(binding: &mut BindingWorker, mut retry: VecDeque<TxRequest>) {
@@ -4639,75 +4621,6 @@ mod tests {
     }
 
     #[test]
-    fn merge_pending_tx_requests_appends_shared_after_local() {
-        let local = VecDeque::from(vec![
-            TxRequest {
-                bytes: vec![1],
-                expected_ports: None,
-                expected_addr_family: libc::AF_INET as u8,
-                expected_protocol: PROTO_TCP,
-                flow_key: None,
-                egress_ifindex: 0,
-                cos_queue_id: None,
-                dscp_rewrite: None,
-            },
-            TxRequest {
-                bytes: vec![2],
-                expected_ports: None,
-                expected_addr_family: libc::AF_INET as u8,
-                expected_protocol: PROTO_TCP,
-                flow_key: None,
-                egress_ifindex: 0,
-                cos_queue_id: None,
-                dscp_rewrite: None,
-            },
-        ]);
-        let shared = VecDeque::from(vec![TxRequest {
-            bytes: vec![3],
-            expected_ports: None,
-            expected_addr_family: libc::AF_INET as u8,
-            expected_protocol: PROTO_TCP,
-            flow_key: None,
-            egress_ifindex: 0,
-            cos_queue_id: None,
-            dscp_rewrite: None,
-        }]);
-
-        let merged = merge_pending_tx_requests(local, shared);
-        let bytes: Vec<Vec<u8>> = merged.into_iter().map(|req| req.bytes).collect();
-        assert_eq!(bytes, vec![vec![1], vec![2], vec![3]]);
-    }
-
-    #[test]
-    fn merge_pending_tx_requests_uses_shared_when_local_empty() {
-        let shared = VecDeque::from(vec![TxRequest {
-            bytes: vec![9],
-            expected_ports: None,
-            expected_addr_family: libc::AF_INET6 as u8,
-            expected_protocol: PROTO_UDP,
-            flow_key: None,
-            egress_ifindex: 0,
-            cos_queue_id: None,
-            dscp_rewrite: None,
-        }]);
-
-        let merged = merge_pending_tx_requests(VecDeque::new(), shared);
-        let bytes: Vec<Vec<u8>> = merged.into_iter().map(|req| req.bytes).collect();
-        assert_eq!(bytes, vec![vec![9]]);
-    }
-
-    #[test]
-    fn append_pending_queue_moves_shared_into_empty_pending() {
-        let mut pending = VecDeque::new();
-        let mut shared = VecDeque::from([1u8, 2, 3]);
-
-        append_pending_queue(&mut pending, &mut shared);
-
-        assert!(shared.is_empty());
-        assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-    }
-
-    #[test]
     fn process_pending_queue_in_place_preserves_failed_item_order() {
         let mut pending = VecDeque::from([1u8, 2, 3, 4]);
 
@@ -5149,10 +5062,13 @@ mod tests {
             redirect_local_cos_request_to_owner_binding(&current_live, &cos_fast_interfaces, req);
 
         assert!(redirected.is_ok());
-        let queued = owner_live.take_pending_tx();
+        let mut queued = VecDeque::new();
+        owner_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
-        assert!(current_live.take_pending_tx().is_empty());
+        let mut current_queued = VecDeque::new();
+        current_live.take_pending_tx_into(&mut current_queued);
+        assert!(current_queued.is_empty());
     }
 
     #[test]
@@ -5194,10 +5110,13 @@ mod tests {
             redirect_local_cos_request_to_owner_binding(&current_live, &cos_fast_interfaces, req);
 
         assert!(redirected.is_ok());
-        let queued = owner_live.take_pending_tx();
+        let mut queued = VecDeque::new();
+        owner_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
-        assert!(current_live.take_pending_tx().is_empty());
+        let mut current_queued = VecDeque::new();
+        current_live.take_pending_tx_into(&mut current_queued);
+        assert!(current_queued.is_empty());
     }
 
     #[test]
@@ -5287,7 +5206,8 @@ mod tests {
 
         assert!(redirected.is_ok());
         assert!(commands.lock().unwrap().is_empty());
-        let queued = owner_live.take_pending_tx();
+        let mut queued = VecDeque::new();
+        owner_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().map(|req| req.egress_ifindex), Some(80));
         assert_eq!(queued.front().map(|req| req.cos_queue_id), Some(Some(4)));

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -98,15 +98,15 @@ pub(super) struct MmapArea {
 /// 2 MB hugepage size.
 const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
 
-/// Hard capacity of the per-binding redirect inbox (`BindingLiveState::
-/// pending_tx`). Sized to cover the highest expected soft cap produced
-/// by `pending_tx_capacity()` in prod (`ring_entries = 2048` →
-/// `2 * ring_entries = 4096`). The MPSC ring is allocated once at
-/// `BindingLiveState::new()` with this capacity, then the soft cap from
-/// `set_max_pending_tx()` gates admissions inside `enqueue_tx` /
-/// `enqueue_tx_owned`. If a caller ever requests a soft cap larger than
-/// the hard cap, the effective cap clamps here and excess pushes drop
-/// with a `redirect_inbox_overflow_drops` counter bump.
+/// Hard capacity of the per-binding redirect inbox
+/// (`BindingLiveState::pending_tx`). Sized to cover the highest expected
+/// soft cap produced by `pending_tx_capacity()` in prod
+/// (`ring_entries = 2048` → `2 * ring_entries = 4096`). The MPSC ring is
+/// allocated once at `BindingLiveState::new()` with this capacity, then
+/// the soft cap from `set_max_pending_tx()` gates admissions inside
+/// `enqueue_tx` / `enqueue_tx_owned`. If a caller ever requests a soft
+/// cap larger than the hard cap, the effective cap clamps here and
+/// excess pushes drop with a `redirect_inbox_overflow_drops` counter bump.
 pub(super) const PENDING_TX_INBOX_HARD_CAP: usize = 4096;
 
 impl MmapArea {
@@ -293,6 +293,35 @@ mod tests {
             2
         );
         assert_eq!(live.tx_errors.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn take_pending_tx_into_appends_without_resetting_caller_buffer() {
+        // #706: pin that `take_pending_tx_into` preserves the caller's
+        // existing `VecDeque` contents. The owner-worker drain feeds its
+        // `pending_tx_local` buffer through the call; if the new API ever
+        // regressed to `*out = drained` or `out.clear()`, items already
+        // queued locally would be dropped on every poll.
+        let live = BindingLiveState::new();
+        live.max_pending_tx.store(8, Ordering::Relaxed);
+        live.enqueue_tx_owned(test_tx_request_for_inbox(10))
+            .expect("push inbox");
+        live.enqueue_tx_owned(test_tx_request_for_inbox(11))
+            .expect("push inbox");
+
+        let mut out = VecDeque::from([
+            test_tx_request_for_inbox(1),
+            test_tx_request_for_inbox(2),
+        ]);
+        live.take_pending_tx_into(&mut out);
+
+        let payloads: Vec<u8> = out.iter().map(|req| req.bytes[0]).collect();
+        assert_eq!(
+            payloads,
+            vec![1, 2, 10, 11],
+            "caller-provided items must come first; inbox items appended in FIFO order"
+        );
+        assert!(live.pending_tx_empty(), "inbox fully drained");
     }
 
     #[test]
@@ -746,8 +775,8 @@ impl BindingLiveState {
     /// a deliberate change from the pre-#706 drop-oldest behaviour —
     /// older queued packets are closer to being serviced by the owner
     /// worker, so evicting them just extends tail latency. The counter
-    /// contract (`tx_errors` as the generic error, `redirect_inbox_
-    /// overflow_drops` as the dedicated view) is preserved.
+    /// contract (`tx_errors` as the generic error,
+    /// `redirect_inbox_overflow_drops` as the dedicated view) is preserved.
     #[inline]
     fn push_redirect_inbox(&self, req: TxRequest) {
         let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
@@ -778,20 +807,24 @@ impl BindingLiveState {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    pub(super) fn take_pending_tx(&self) -> VecDeque<TxRequest> {
+    /// Drain the redirect inbox into a caller-provided `VecDeque`, so the
+    /// owner worker's drain stays allocation-free on the hot path. The
+    /// caller reuses its existing `pending_tx_local` buffer across polls
+    /// — calling `VecDeque::new()` / growing a fresh buffer on every drain
+    /// put allocator noise back on the exact thread #706 is trying to
+    /// keep quiet.
+    pub(super) fn take_pending_tx_into(&self, out: &mut VecDeque<TxRequest>) {
         if self.pending_tx.is_empty() {
-            return VecDeque::new();
+            return;
         }
-        let mut drained = VecDeque::new();
         // SAFETY: `MpscInbox::pop` requires the single-consumer
         // invariant. The per-binding redirect inbox has exactly one
         // consumer — the owner worker — which is also the sole caller
-        // of `take_pending_tx`. Enforced by convention (see the doc
+        // of `take_pending_tx_into`. Enforced by convention (see the doc
         // comment on `pending_tx` in `BindingLiveState`).
         while let Some(req) = unsafe { self.pending_tx.pop() } {
-            drained.push_back(req);
+            out.push_back(req);
         }
-        drained
     }
 
     pub(super) fn pending_tx_empty(&self) -> bool {

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -98,6 +98,17 @@ pub(super) struct MmapArea {
 /// 2 MB hugepage size.
 const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
 
+/// Hard capacity of the per-binding redirect inbox (`BindingLiveState::
+/// pending_tx`). Sized to cover the highest expected soft cap produced
+/// by `pending_tx_capacity()` in prod (`ring_entries = 2048` →
+/// `2 * ring_entries = 4096`). The MPSC ring is allocated once at
+/// `BindingLiveState::new()` with this capacity, then the soft cap from
+/// `set_max_pending_tx()` gates admissions inside `enqueue_tx` /
+/// `enqueue_tx_owned`. If a caller ever requests a soft cap larger than
+/// the hard cap, the effective cap clamps here and excess pushes drop
+/// with a `redirect_inbox_overflow_drops` counter bump.
+pub(super) const PENDING_TX_INBOX_HARD_CAP: usize = 4096;
+
 impl MmapArea {
     pub(super) fn new(len: usize) -> io::Result<Self> {
         // Round up to 2 MB boundary for hugepage eligibility.
@@ -237,16 +248,19 @@ mod tests {
     }
 
     #[test]
-    fn enqueue_tx_owned_increments_redirect_inbox_overflow_counter_on_eviction() {
-        // #710: pin that a redirect-inbox overflow in `enqueue_tx_owned`
-        // increments the dedicated `redirect_inbox_overflow_drops`
-        // counter (not just the generic `tx_errors`). A regression that
-        // moves the drop to a different code path without incrementing
-        // this counter fails here.
+    fn enqueue_tx_owned_increments_redirect_inbox_overflow_counter_when_soft_cap_drops_newcomer() {
+        // #710 / #706: pin that a redirect-inbox overflow in
+        // `enqueue_tx_owned` increments both `redirect_inbox_overflow_drops`
+        // (dedicated view) and `tx_errors` (generic), regardless of
+        // which request gets dropped. Post-#706 the policy is drop-
+        // newest (the incoming push is discarded); pre-#706 it was
+        // drop-oldest (the head of the queue was evicted). Either way,
+        // every push must return `Ok(())` and both counters advance in
+        // lockstep.
         let live = BindingLiveState::new();
         live.max_pending_tx.store(2, Ordering::Relaxed);
 
-        // Fill to cap — no eviction yet.
+        // Fill to cap — no overflow yet.
         live.enqueue_tx_owned(test_tx_request_for_inbox(1))
             .expect("push 1");
         live.enqueue_tx_owned(test_tx_request_for_inbox(2))
@@ -257,9 +271,9 @@ mod tests {
         );
         assert_eq!(live.tx_errors.load(Ordering::Relaxed), 0);
 
-        // Third push exceeds cap — eldest evicted, counter advances.
+        // Third push hits the soft cap — drop-newest, counters advance.
         live.enqueue_tx_owned(test_tx_request_for_inbox(3))
-            .expect("push 3 evicts");
+            .expect("push 3 drops newest");
         assert_eq!(
             live.redirect_inbox_overflow_drops.load(Ordering::Relaxed),
             1
@@ -271,9 +285,9 @@ mod tests {
              counter on this path — the dedicated counter is a subset view"
         );
 
-        // Fourth push, another eviction — both counters advance.
+        // Fourth push, another overflow — both counters advance again.
         live.enqueue_tx_owned(test_tx_request_for_inbox(4))
-            .expect("push 4 evicts");
+            .expect("push 4 drops newest");
         assert_eq!(
             live.redirect_inbox_overflow_drops.load(Ordering::Relaxed),
             2
@@ -434,9 +448,13 @@ pub(super) struct BindingLiveState {
     pub(super) debug_in_flight_recycles: AtomicU32,
     pub(super) last_heartbeat: AtomicU64,
     pub(super) max_pending_tx: AtomicU32,
-    pub(super) pending_tx_len: AtomicU32,
     pub(super) last_error: Mutex<String>,
-    pub(super) pending_tx: Mutex<VecDeque<TxRequest>>,
+    /// Cross-worker redirect inbox (#706). N producer workers push
+    /// redirected `TxRequest`s; the single owner worker drains. Bounded
+    /// lock-free ring — replaces the pre-#706 `Mutex<VecDeque>` that
+    /// serialised every producer against every other producer and
+    /// against the owner's drain.
+    pub(super) pending_tx: MpscInbox<TxRequest>,
     pub(super) pending_session_deltas: Mutex<VecDeque<SessionDeltaInfo>>,
 }
 
@@ -516,9 +534,8 @@ impl BindingLiveState {
             debug_in_flight_recycles: AtomicU32::new(0),
             last_heartbeat: AtomicU64::new(0),
             max_pending_tx: AtomicU32::new(0),
-            pending_tx_len: AtomicU32::new(0),
             last_error: Mutex::new(String::new()),
-            pending_tx: Mutex::new(VecDeque::new()),
+            pending_tx: MpscInbox::new(PENDING_TX_INBOX_HARD_CAP),
             pending_session_deltas: Mutex::new(VecDeque::new()),
         }
     }
@@ -714,77 +731,71 @@ impl BindingLiveState {
     }
 
     pub(super) fn enqueue_tx(&self, req: TxRequest) -> Result<(), String> {
-        match self.pending_tx.lock() {
-            Ok(mut pending) => {
-                let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-                if max_pending > 0 && pending.len() >= max_pending {
-                    if pending.pop_front().is_some() {
-                        self.tx_errors.fetch_add(1, Ordering::Relaxed);
-                        // #710: this is the redirect-inbox overflow
-                        // drop site. A packet already in the inbox was
-                        // evicted to make room for an incoming one —
-                        // the owner worker is not draining fast enough
-                        // relative to redirects arriving from non-owner
-                        // workers.
-                        self.redirect_inbox_overflow_drops
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-                pending.push_back(req);
-                self.pending_tx_len.store(
-                    pending.len().min(u32::MAX as usize) as u32,
-                    Ordering::Relaxed,
-                );
-                Ok(())
-            }
-            Err(_) => Err("pending_tx lock poisoned".to_string()),
-        }
+        self.push_redirect_inbox(req);
+        Ok(())
     }
 
     pub(super) fn enqueue_tx_owned(&self, req: TxRequest) -> Result<(), TxRequest> {
-        match self.pending_tx.lock() {
-            Ok(mut pending) => {
-                let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-                if max_pending > 0 && pending.len() >= max_pending {
-                    if pending.pop_front().is_some() {
-                        self.tx_errors.fetch_add(1, Ordering::Relaxed);
-                        // #710: this is the redirect-inbox overflow
-                        // drop site. A packet already in the inbox was
-                        // evicted to make room for an incoming one —
-                        // the owner worker is not draining fast enough
-                        // relative to redirects arriving from non-owner
-                        // workers.
-                        self.redirect_inbox_overflow_drops
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-                pending.push_back(req);
-                self.pending_tx_len.store(
-                    pending.len().min(u32::MAX as usize) as u32,
-                    Ordering::Relaxed,
-                );
-                Ok(())
-            }
-            Err(_) => Err(req),
+        self.push_redirect_inbox(req);
+        Ok(())
+    }
+
+    /// Shared push path for `enqueue_tx` and `enqueue_tx_owned`.
+    /// Drop-newest on overflow: if the soft cap or ring hard cap is hit,
+    /// drop the incoming request and bump the overflow counters. This is
+    /// a deliberate change from the pre-#706 drop-oldest behaviour —
+    /// older queued packets are closer to being serviced by the owner
+    /// worker, so evicting them just extends tail latency. The counter
+    /// contract (`tx_errors` as the generic error, `redirect_inbox_
+    /// overflow_drops` as the dedicated view) is preserved.
+    #[inline]
+    fn push_redirect_inbox(&self, req: TxRequest) {
+        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
+        if max_pending > 0 && self.pending_tx.len() >= max_pending {
+            self.record_redirect_inbox_overflow();
+            return;
         }
+        if self.pending_tx.push(req).is_err() {
+            // Hard cap hit — ring is full. Rare: the hard cap sits at
+            // `PENDING_TX_INBOX_HARD_CAP`, so a non-zero soft cap
+            // normally fires first. This branch is reachable only under
+            // concurrent producers racing past the soft-cap check, or
+            // when the caller has set `max_pending_tx = 0` (treat as
+            // unlimited → hard cap is the only brake).
+            self.record_redirect_inbox_overflow();
+        }
+    }
+
+    #[inline]
+    fn record_redirect_inbox_overflow(&self) {
+        self.tx_errors.fetch_add(1, Ordering::Relaxed);
+        // #710 / #706: non-zero values here indicate the owner worker
+        // cannot drain redirects fast enough relative to producer push
+        // rate. After #706 the path is lock-free, so contention is no
+        // longer the bottleneck — further growth typically points at
+        // owner-worker hotspot (#709) or CoS admission (#707 / #708).
+        self.redirect_inbox_overflow_drops
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub(super) fn take_pending_tx(&self) -> VecDeque<TxRequest> {
-        if self.pending_tx_len.load(Ordering::Relaxed) == 0 {
+        if self.pending_tx.is_empty() {
             return VecDeque::new();
         }
-        match self.pending_tx.lock() {
-            Ok(mut pending) => {
-                let drained = core::mem::take(&mut *pending);
-                self.pending_tx_len.store(0, Ordering::Relaxed);
-                drained
-            }
-            Err(_) => VecDeque::new(),
+        let mut drained = VecDeque::new();
+        // SAFETY: `MpscInbox::pop` requires the single-consumer
+        // invariant. The per-binding redirect inbox has exactly one
+        // consumer — the owner worker — which is also the sole caller
+        // of `take_pending_tx`. Enforced by convention (see the doc
+        // comment on `pending_tx` in `BindingLiveState`).
+        while let Some(req) = unsafe { self.pending_tx.pop() } {
+            drained.push_back(req);
         }
+        drained
     }
 
     pub(super) fn pending_tx_empty(&self) -> bool {
-        self.pending_tx_len.load(Ordering::Relaxed) == 0
+        self.pending_tx.is_empty()
     }
 
     pub(super) fn push_session_delta(&self, delta: SessionDeltaInfo) {


### PR DESCRIPTION
## Summary

- Replace `Mutex<VecDeque<TxRequest>>` in `BindingLiveState::pending_tx` with a hand-rolled bounded MPMC queue (Vyukov's bounded algorithm, used MPSC-style — N worker producers, owner-worker consumer).
- Eliminates the cross-producer and producer↔consumer serialisation on every redirected `TxRequest`.
- Overflow semantics flip to drop-newest (old queued packets are closer to being serviced by the owner; evicting them only extends tail latency). Counter contract — `tx_errors` + `redirect_inbox_overflow_drops` — is preserved.
- `cancel_queued_flow_on_binding` loses the in-place filter on the redirect inbox (cannot mutate a lock-free ring from a non-consumer thread). Worker-owned queues still filter; post-RST stragglers are absorbed by the peer's RST handling.

## Test plan

- [x] `cargo test` — 649 userspace-dp tests green, 0 fail. New `mpsc_inbox` suite covers: FIFO on single producer, `Err` on full ring, capacity power-of-two rounding, concurrent producers below-cap lose no items, concurrent producers above-cap drop exactly the overflow (`pushed_ok + err == total`, `popped == pushed_ok`), `Drop` runs for orphaned values.
- [x] Updated `enqueue_tx_owned_increments_redirect_inbox_overflow_counter_when_soft_cap_drops_newcomer` — drop-newest flip, counter contract preserved.
- [x] `make test` — full Go suite green.
- [x] Live deploy on `loss:xpf-userspace-{fw0,fw1}` with CoS re-applied (iperf-a 1g exact queue at 5201, iperf-b 10g shared, best-effort 100m). Both nodes active, no panics.

## Live data (16-flow iperf3, 30s, port 5201, 1 Gbps exact queue)

| Run | Total | Rate ratio | Retrans/30s | Flows with max_cwnd < 50 KB |
|---|---|---|---|---|
| 1 | 1.07 Gbps | 1.49× | 139 k | 9/16 |
| 2 | 1.16 Gbps | 1.64× | 217 k | 13/16 |
| 3 | 1.11 Gbps | 1.91× | 190 k | 12/16 |

## What this PR did and did not do

**Did**: the rate distribution across the 16 flows is now flat (50–94 Mbps, ~1.5× max/min). Before this change, the split was bimodal (5 owner-local flows healthy multi-Gbps, 11 redirected flows collapsed sub-500 Mbps). Removing the cross-worker mutex let every redirected flow move at the same rate as owner-local ones.

**Did not**: cwnd collapse and the retransmit storm persist. #706's hypothesis was that mutex jitter was driving single-packet drops which forced RTOs (cwnd reset to 1 MSS) and drove the bimodal pattern. The data shows that theory was only half right — the mutex was causing the *bimodal split*, not the retransmit storm itself. With the mutex gone, every flow shares the *same* pathology: admission-cap drops push per-flow cwnd below the 3-dupack fast-retransmit threshold, so single drops take an RTO, and cwnd oscillates between "just below the cap" and 1 MSS.

That failure mode is now unambiguously pinned to **#705 (admission cap off distinct flow count) and/or #707 (1.19 MB exact-queue buffer too small for 16 flows × RTT × BDP)** — with the mutex out of the way, there is no other structural throttle between the ring-level fairness and the TCP-layer behaviour. This PR is a prerequisite for either fix being measurable.

Refs: #706, #704, #705, #707, #709.