### PR TITLE
userspace-dp: flow-aware CoS admission buffer + 16 MSS fast-retransmit floor (#707)

### DIFF
--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Re-apply the CoS iperf test config (cos-iperf-config.set) to a cluster
+# VM after a deploy that wiped it. Usage:
+#
+#   ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+#   ./test/incus/apply-cos-config.sh                     # defaults to xpf-userspace-fw0
+#
+# Only the RG0 primary needs the config applied — it replicates to the
+# secondary via config sync. Run against the primary.
+#
+# The config file starts with three `delete` lines so it can be applied
+# idempotently to a VM that already has a previous CoS config loaded.
+# On a fresh post-deploy apply those paths don't exist, so the deletes
+# would abort `load merge` and leave the candidate empty. Work around
+# by splitting the file into its delete and set halves, running deletes
+# in their own session with `|| true`, then merging the sets. Single
+# atomic commit at the end is fine because the deletes are no-ops on a
+# fresh apply (and the sets are the whole desired state).
+#
+set -euo pipefail
+
+TARGET="${1:-loss:xpf-userspace-fw0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/cos-iperf-config.set"
+REMOTE_SETS="/tmp/cos-iperf-sets.set"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+	echo "error: cannot find $CONFIG_FILE" >&2
+	exit 1
+fi
+
+# Temp file with only the set lines (comments + blanks stripped too).
+SETS_TMP="$(mktemp)"
+trap "rm -f '$SETS_TMP'" EXIT
+grep -E '^(set |$|#)' "$CONFIG_FILE" | grep -v '^$\|^#' > "$SETS_TMP"
+
+# Push sets-only file to the VM.
+incus file push "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
+
+# Drive one interactive CLI session:
+#   1. Enter configure mode (candidate created).
+#   2. Explicitly delete any pre-existing state for the three top-level
+#      paths this config owns. Each `delete` is followed by `|| true` in
+#      spirit — we achieve the same effect by running each delete in the
+#      same configure session; the one that targets a missing path is
+#      rejected, but `configure`-mode-rejection leaves the other deletes
+#      already-applied in the candidate. We redirect stderr on the per-
+#      line deletes so the transcript stays readable.
+#   3. `load merge` the sets-only file (clean: no deletes inside it).
+#   4. `commit` atomically.
+#
+# Lines prefixed with `#` in the heredoc are bash comments; the CLI
+# never sees them. Each subsequent line is a command to the CLI.
+incus exec "$TARGET" -- /usr/local/sbin/cli <<EOF || true
+configure
+delete class-of-service
+delete firewall family inet filter bandwidth-output
+delete interfaces reth0 unit 80 family inet filter output
+load merge ${REMOTE_SETS}
+commit
+exit
+quit
+EOF
+
+# Verify the exact queue landed.
+incus exec "$TARGET" -- /usr/local/sbin/cli -c "show class-of-service interface"

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -9,14 +9,12 @@
 # Only the RG0 primary needs the config applied — it replicates to the
 # secondary via config sync. Run against the primary.
 #
-# The config file starts with three `delete` lines so it can be applied
+# The config file starts with `delete` lines so it can be reapplied
 # idempotently to a VM that already has a previous CoS config loaded.
-# On a fresh post-deploy apply those paths don't exist, so the deletes
-# would abort `load merge` and leave the candidate empty. Work around
-# by splitting the file into its delete and set halves, running deletes
-# in their own session with `|| true`, then merging the sets. Single
-# atomic commit at the end is fine because the deletes are no-ops on a
-# fresh apply (and the sets are the whole desired state).
+# On a fresh post-deploy apply those paths do not exist, so load merge
+# would abort on the first `delete`. Running the deletes in a separate
+# best-effort session sidesteps that, while the merge/commit session
+# stays strict so validation failures are not masked.
 #
 set -euo pipefail
 
@@ -30,38 +28,40 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 	exit 1
 fi
 
-# Temp file with only the set lines (comments + blanks stripped too).
+# Strip `delete` and blank/comment lines out of the merge input so the
+# strict session (below) cannot abort on a missing path.
 SETS_TMP="$(mktemp)"
 trap "rm -f '$SETS_TMP'" EXIT
-grep -E '^(set |$|#)' "$CONFIG_FILE" | grep -v '^$\|^#' > "$SETS_TMP"
+grep -E '^set ' "$CONFIG_FILE" > "$SETS_TMP"
 
-# Push sets-only file to the VM.
-incus file push "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
+incus file push --mode 0644 "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
 
-# Drive one interactive CLI session:
-#   1. Enter configure mode (candidate created).
-#   2. Explicitly delete any pre-existing state for the three top-level
-#      paths this config owns. Each `delete` is followed by `|| true` in
-#      spirit — we achieve the same effect by running each delete in the
-#      same configure session; the one that targets a missing path is
-#      rejected, but `configure`-mode-rejection leaves the other deletes
-#      already-applied in the candidate. We redirect stderr on the per-
-#      line deletes so the transcript stays readable.
-#   3. `load merge` the sets-only file (clean: no deletes inside it).
-#   4. `commit` atomically.
-#
-# Lines prefixed with `#` in the heredoc are bash comments; the CLI
-# never sees them. Each subsequent line is a command to the CLI.
+# ---- Phase 1: best-effort deletes ----
+# These target paths that may or may not exist depending on whether this
+# is a fresh post-deploy apply or a re-apply. `|| true` is scoped here
+# only — we do NOT tolerate a bad merge/commit in phase 2.
 incus exec "$TARGET" -- /usr/local/sbin/cli <<EOF || true
 configure
 delete class-of-service
 delete firewall family inet filter bandwidth-output
 delete interfaces reth0 unit 80 family inet filter output
+delete firewall family inet6 filter bandwidth-output
+delete interfaces reth0 unit 80 family inet6 filter output
+commit
+exit
+quit
+EOF
+
+# ---- Phase 2: strict merge + commit ----
+# A bad load merge, a syntax drift in the fixture, or a failed commit
+# must fail the script. `set -e` is in effect; no `|| true` here.
+incus exec "$TARGET" -- /usr/local/sbin/cli <<EOF
+configure
 load merge ${REMOTE_SETS}
 commit
 exit
 quit
 EOF
 
-# Verify the exact queue landed.
+# ---- Phase 3: verify ----
 incus exec "$TARGET" -- /usr/local/sbin/cli -c "show class-of-service interface"

--- a/test/incus/cos-iperf-config.set
+++ b/test/incus/cos-iperf-config.set
@@ -1,0 +1,38 @@
+delete class-of-service
+delete firewall family inet filter bandwidth-output
+delete interfaces reth0 unit 80 family inet filter output
+
+set class-of-service forwarding-classes queue 0 best-effort
+set class-of-service forwarding-classes queue 4 iperf-a
+set class-of-service forwarding-classes queue 5 iperf-b
+
+set class-of-service schedulers scheduler-be transmit-rate 100m
+set class-of-service schedulers scheduler-be transmit-rate exact
+
+set class-of-service schedulers scheduler-iperf-a transmit-rate 1.0g
+set class-of-service schedulers scheduler-iperf-a transmit-rate exact
+
+set class-of-service schedulers scheduler-iperf-b transmit-rate 10.0g
+set class-of-service schedulers scheduler-iperf-b transmit-rate exact
+
+set class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
+
+set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
+set class-of-service interfaces reth0 unit 80 shaping-rate 25g
+
+set firewall family inet filter bandwidth-output term 0 from destination-port 5201
+set firewall family inet filter bandwidth-output term 0 then forwarding-class iperf-a
+set firewall family inet filter bandwidth-output term 0 then count iperf-a
+set firewall family inet filter bandwidth-output term 0 then accept
+
+set firewall family inet filter bandwidth-output term 1 from destination-port 5202
+set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-b
+set firewall family inet filter bandwidth-output term 1 then count iperf-b
+set firewall family inet filter bandwidth-output term 1 then accept
+
+set firewall family inet filter bandwidth-output term 2 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output term 2 then accept
+
+set interfaces reth0 unit 80 family inet filter output bandwidth-output

--- a/test/incus/cos-iperf-config.set
+++ b/test/incus/cos-iperf-config.set
@@ -1,6 +1,8 @@
 delete class-of-service
 delete firewall family inet filter bandwidth-output
 delete interfaces reth0 unit 80 family inet filter output
+delete firewall family inet6 filter bandwidth-output
+delete interfaces reth0 unit 80 family inet6 filter output
 
 set class-of-service forwarding-classes queue 0 best-effort
 set class-of-service forwarding-classes queue 4 iperf-a
@@ -36,3 +38,18 @@ set firewall family inet filter bandwidth-output term 2 then forwarding-class be
 set firewall family inet filter bandwidth-output term 2 then accept
 
 set interfaces reth0 unit 80 family inet filter output bandwidth-output
+
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 5201
+set firewall family inet6 filter bandwidth-output term 0 then forwarding-class iperf-a
+set firewall family inet6 filter bandwidth-output term 0 then count iperf-a
+set firewall family inet6 filter bandwidth-output term 0 then accept
+
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 5202
+set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-b
+set firewall family inet6 filter bandwidth-output term 1 then count iperf-b
+set firewall family inet6 filter bandwidth-output term 1 then accept
+
+set firewall family inet6 filter bandwidth-output term 2 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output term 2 then accept
+
+set interfaces reth0 unit 80 family inet6 filter output bandwidth-output

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -2448,12 +2448,22 @@ const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
 /// Minimum per-flow admission share. Sized so TCP fast-retransmit can
 /// trigger reliably on a single-packet drop:
 /// - 3 dupacks to trigger fast-retransmit (Linux `tcp_reordering = 3`)
-/// - headroom for in-flight reordering up to ~13 MSS
-/// - 16 MSS total = 24 KB
+/// - headroom for in-flight reordering up to ~13 MTU-sized packets
+/// - 16 MTU-sized (1500 B) packets total = 24 KB
 /// Below this, a single drop produces < 3 dupacks before cwnd is drained,
 /// forcing an RTO with cwnd reset to 1 MSS and starting the oscillation
 /// observed in #704 / #707 at high flow counts on low-rate exact queues.
+/// 1500 matches the default MTU and is a conservative proxy for TCP
+/// payload size; actual MSS (1460 v4 / 1440 v6) is smaller, so 16 × 1500
+/// is a safe over-count of the "packets needed for fast-retransmit".
 const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
+
+// Compile-time pin so the floor cannot silently drift below the
+// fast-retransmit-safe threshold on a rebase/refactor. Parallels the
+// `const _: () = assert!` invariants in `types.rs`. Lives here (at the
+// constant) rather than in `tests/` so `cargo build` enforces it, not
+// just `cargo test`.
+const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
 const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
@@ -2735,15 +2745,19 @@ fn cos_queue_flow_share_limit(
         .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
 }
 
-/// Effective buffer cap for the admission check. Grows with the observed
-/// distinct-flow count so the total admission threshold never drops
-/// below `active × COS_FLOW_FAIR_MIN_SHARE_BYTES` — without this, the
-/// per-flow clamp inside `cos_queue_flow_share_limit` can raise each
-/// flow's share to the fast-retransmit floor, but the aggregate
-/// `queue.queued_bytes > buffer_limit` check trips first and drops the
-/// packet anyway (the exact pathology driving #704 / #707 at 16 flows
-/// on the 1 Gbps exact queue: `buffer 125 KB / 16 flows = 7.8 KB` per
-/// share, well below the 16 MSS floor).
+/// Effective buffer cap for the admission check. Grows with the
+/// *prospective* distinct-flow count — same denominator that
+/// `cos_queue_flow_share_limit` uses — so the aggregate admission
+/// threshold never drops below `prospective_active ×
+/// COS_FLOW_FAIR_MIN_SHARE_BYTES`.
+///
+/// Why "prospective" and not current `active_flow_buckets`: the per-
+/// flow clamp already adds `+1` when the target bucket is empty, so it
+/// reserves headroom for a newly arriving flow. If the aggregate cap
+/// uses the *current* count it asymmetrically excludes that same new
+/// flow and the first packet of every new flow can get rejected right
+/// at the boundary even though the per-flow path was trying to admit
+/// it. Matching the two denominators removes that off-by-one window.
 ///
 /// Non-flow-fair queues (e.g. best-effort or pure rate-limited) bypass
 /// this scaling; their admission is buffer-bound by the operator's
@@ -2751,16 +2765,22 @@ fn cos_queue_flow_share_limit(
 ///
 /// This is a logical threshold only. The backing `VecDeque` storage is
 /// dynamic, so raising the cap costs nothing until traffic actually
-/// fills it; at peak 16-flow steady state the extra committed memory is
-/// `16 × 24 KB − 125 KB ≈ 259 KB` per exact queue.
+/// fills it. The cap is currently uncapped on the high side: at
+/// `COS_FLOW_FAIR_BUCKETS = 1024` active flows it can reach `~24 MB`,
+/// which on a 1 Gbps queue is `~190 ms` of queue residence time — an
+/// operator-visible latency envelope concern flagged in the #716
+/// review. A derived max-queue-delay clamp belongs in a follow-up
+/// change alongside the queueing-budget policy discussion.
 #[inline]
-fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime) -> u64 {
+fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime, flow_bucket: usize) -> u64 {
     let base = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
     if !queue.flow_fair {
         return base;
     }
-    let active = u64::from(queue.active_flow_buckets).max(1);
-    base.max(active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
+    let prospective_active = u64::from(queue.active_flow_buckets)
+        .saturating_add(u64::from(queue.flow_bucket_bytes[flow_bucket] == 0))
+        .max(1);
+    base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
 }
 
 #[inline]
@@ -3741,12 +3761,20 @@ fn enqueue_cos_item(
         }
         let root_was_empty = root.nonempty_queues == 0;
         let queue = &mut root.queues[queue_idx];
-        // #707: `buffer_limit` scales with active flow count so the per-
-        // flow fast-retransmit floor (`COS_FLOW_FAIR_MIN_SHARE_BYTES`)
-        // can actually be satisfied without tripping the aggregate cap.
-        let buffer_limit = cos_flow_aware_buffer_limit(queue);
+        // #707: aggregate cap scales with prospective-active flow count
+        // so the per-flow fast-retransmit floor can be satisfied, and
+        // the aggregate gate uses the same denominator as the per-flow
+        // clamp — otherwise the first packet of a new flow can get
+        // stuck at the boundary even when the per-flow path is trying
+        // to admit it. Compute `flow_bucket` once so both gates key off
+        // the same queue state snapshot.
+        let flow_bucket = if queue.flow_fair {
+            cos_flow_bucket_index(queue.flow_hash_seed, cos_item_flow_key(&item))
+        } else {
+            0
+        };
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, flow_bucket);
         let flow_share_exceeded = if queue.flow_fair {
-            let flow_bucket = cos_flow_bucket_index(queue.flow_hash_seed, cos_item_flow_key(&item));
             queue.flow_bucket_bytes[flow_bucket].saturating_add(item_len)
                 > cos_queue_flow_share_limit(queue, buffer_limit, flow_bucket)
         } else {
@@ -8011,13 +8039,16 @@ mod tests {
     }
 
     #[test]
-    fn cos_flow_aware_buffer_limit_scales_with_active_flow_buckets() {
-        // #707: at the 1 Gbps/16-flow workload a fixed 125 KB buffer
-        // divided across 16 flows gives each flow a 7.8 KB share,
-        // below the TCP fast-retransmit floor of 16 MSS = 24 KB. The
-        // flow-aware buffer limit grows the aggregate cap so the per-
-        // flow floor can be honoured without the buffer-cap tripping
-        // first.
+    fn cos_flow_aware_buffer_limit_scales_with_prospective_active_flow_count() {
+        // #707 + #716 review: at the 1 Gbps/16-flow workload a fixed
+        // 125 KB buffer divided across 16 flows gives each flow a 7.8
+        // KB share, below the TCP fast-retransmit floor of 16 MSS =
+        // 24 KB. The flow-aware buffer limit grows the aggregate cap
+        // so the per-flow floor can be honoured. "Prospective" count
+        // means the same denominator the per-flow clamp uses: current
+        // `active_flow_buckets + (target bucket empty ? 1 : 0)`, so
+        // the two gates never disagree about whether a new flow's
+        // first packet has room.
         let mut root = test_cos_runtime_with_queues(
             25_000_000_000 / 8,
             vec![CoSQueueConfig {
@@ -8034,26 +8065,85 @@ mod tests {
         let queue = &mut root.queues[0];
         queue.flow_fair = true;
 
-        // Base floor wins when the flow count × min share is small.
+        // Base floor wins when prospective flow count × min share is
+        // small. `flow_bucket = 0` is empty → prospective_active += 1.
         queue.active_flow_buckets = 0;
         assert_eq!(
-            cos_flow_aware_buffer_limit(queue),
+            cos_flow_aware_buffer_limit(queue, 0),
             queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
-            "zero active flows must collapse to the operator-configured base cap"
+            "zero active (+1 prospective) flows must stay at the operator-configured base"
         );
         queue.active_flow_buckets = 2;
         assert_eq!(
-            cos_flow_aware_buffer_limit(queue),
+            cos_flow_aware_buffer_limit(queue, 0),
             queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
-            "2 × 24 KB = 48 KB stays below the 125 KB configured base, so base wins"
+            "3 prospective × 24 KB = 72 KB stays below the 125 KB configured base, so base wins"
         );
 
-        // Flow-aware floor wins past the break-even point.
+        // Flow-aware floor wins past the break-even point. Now mark 16
+        // buckets populated so prospective = 16 (target bucket already
+        // non-empty).
         queue.active_flow_buckets = 16;
+        for bucket in 0..16 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
         assert_eq!(
-            cos_flow_aware_buffer_limit(queue),
+            cos_flow_aware_buffer_limit(queue, 0),
             16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
             "16 × 24 KB = 384 KB exceeds the 125 KB base and becomes the cap"
+        );
+    }
+
+    #[test]
+    fn cos_flow_aware_buffer_limit_matches_share_limit_at_new_flow_boundary() {
+        // #716 review: the aggregate cap and the per-flow clamp must
+        // use the SAME denominator. Before the review fix the
+        // aggregate cap used the current `active_flow_buckets` while
+        // the per-flow clamp used `active + (target bucket empty ? 1 :
+        // 0)`, so the first packet of a newly arriving flow could
+        // pass the per-flow gate and fail the aggregate one right at
+        // the boundary. This test pins the fix by driving exactly that
+        // case.
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 125 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        // 15 active flows, target bucket empty → prospective = 16.
+        // Both caps must key off 16, not 15.
+        queue.active_flow_buckets = 15;
+        for bucket in 0..15 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+        let new_flow_bucket = 100;
+        assert_eq!(queue.flow_bucket_bytes[new_flow_bucket], 0);
+
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, new_flow_bucket);
+        let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, new_flow_bucket);
+
+        // 16 × 24 KB = 384 KB aggregate; 384 KB / 16 = 24 KB per-flow.
+        assert_eq!(buffer_limit, 16 * COS_FLOW_FAIR_MIN_SHARE_BYTES);
+        assert_eq!(share_cap, COS_FLOW_FAIR_MIN_SHARE_BYTES);
+        // A single MTU-sized packet for the new flow must fit under
+        // BOTH caps simultaneously — this is the regression guard.
+        assert!(
+            queue.flow_bucket_bytes[new_flow_bucket].saturating_add(1500) <= share_cap,
+            "per-flow share must admit the new flow's first packet"
+        );
+        assert!(
+            queue.queued_bytes.saturating_add(1500) <= buffer_limit,
+            "aggregate cap must also admit the new flow's first packet at the boundary"
         );
     }
 
@@ -8079,8 +8169,9 @@ mod tests {
         queue.flow_fair = false;
         queue.active_flow_buckets = 64; // should be ignored
 
+        // `flow_bucket` argument is irrelevant when flow_fair=false; use 0.
         assert_eq!(
-            cos_flow_aware_buffer_limit(queue),
+            cos_flow_aware_buffer_limit(queue, 0),
             queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
             "flow_fair=false must bypass the flow-count multiplier"
         );
@@ -8091,7 +8182,7 @@ mod tests {
         // At 16 flows with a 125 KB buffer, the naive arithmetic share
         // is 7.8 KB — a single packet drop yields < 3 dupacks, forcing
         // RTO. The clamp to `COS_FLOW_FAIR_MIN_SHARE_BYTES` must hold
-        // the per-flow cap at 16 MSS = 24 KB no matter the denominator.
+        // the per-flow cap at 24 KB no matter the denominator.
         let mut root = test_cos_runtime_with_queues(
             25_000_000_000 / 8,
             vec![CoSQueueConfig {
@@ -8114,7 +8205,7 @@ mod tests {
             queue.flow_bucket_bytes[bucket] = 1_000;
         }
 
-        let buffer_limit = cos_flow_aware_buffer_limit(queue);
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
         assert_eq!(
             buffer_limit,
             16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
@@ -8124,21 +8215,12 @@ mod tests {
         let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
         assert!(
             share >= COS_FLOW_FAIR_MIN_SHARE_BYTES,
-            "per-flow cap ({share}) must stay ≥ {COS_FLOW_FAIR_MIN_SHARE_BYTES} (16 MSS)"
+            "per-flow cap ({share}) must stay ≥ {COS_FLOW_FAIR_MIN_SHARE_BYTES} (16 MTU-sized packets)"
         );
         assert_eq!(
             share, COS_FLOW_FAIR_MIN_SHARE_BYTES,
             "with buffer_limit == active × min-share, per-flow cap equals the floor"
         );
-    }
-
-    #[test]
-    fn cos_flow_fair_min_share_is_sized_for_tcp_fast_retransmit() {
-        // Compile-time pin: the floor must stay at or above 16 MSS so
-        // TCP fast-retransmit has headroom for 3 dupacks plus reorder.
-        // Lowering this is a behaviour change that warrants explicit
-        // review; the const should not drift silently.
-        const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -2445,7 +2445,15 @@ const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
 const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
 const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
-const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 4 * 1500;
+/// Minimum per-flow admission share. Sized so TCP fast-retransmit can
+/// trigger reliably on a single-packet drop:
+/// - 3 dupacks to trigger fast-retransmit (Linux `tcp_reordering = 3`)
+/// - headroom for in-flight reordering up to ~13 MSS
+/// - 16 MSS total = 24 KB
+/// Below this, a single drop produces < 3 dupacks before cwnd is drained,
+/// forcing an RTO with cwnd reset to 1 MSS and starting the oscillation
+/// observed in #704 / #707 at high flow counts on low-rate exact queues.
+const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
 const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
@@ -2725,6 +2733,34 @@ fn cos_queue_flow_share_limit(
     buffer_limit
         .div_ceil(prospective_active)
         .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
+}
+
+/// Effective buffer cap for the admission check. Grows with the observed
+/// distinct-flow count so the total admission threshold never drops
+/// below `active × COS_FLOW_FAIR_MIN_SHARE_BYTES` — without this, the
+/// per-flow clamp inside `cos_queue_flow_share_limit` can raise each
+/// flow's share to the fast-retransmit floor, but the aggregate
+/// `queue.queued_bytes > buffer_limit` check trips first and drops the
+/// packet anyway (the exact pathology driving #704 / #707 at 16 flows
+/// on the 1 Gbps exact queue: `buffer 125 KB / 16 flows = 7.8 KB` per
+/// share, well below the 16 MSS floor).
+///
+/// Non-flow-fair queues (e.g. best-effort or pure rate-limited) bypass
+/// this scaling; their admission is buffer-bound by the operator's
+/// configured `buffer-size` alone.
+///
+/// This is a logical threshold only. The backing `VecDeque` storage is
+/// dynamic, so raising the cap costs nothing until traffic actually
+/// fills it; at peak 16-flow steady state the extra committed memory is
+/// `16 × 24 KB − 125 KB ≈ 259 KB` per exact queue.
+#[inline]
+fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime) -> u64 {
+    let base = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
+    if !queue.flow_fair {
+        return base;
+    }
+    let active = u64::from(queue.active_flow_buckets).max(1);
+    base.max(active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
 }
 
 #[inline]
@@ -3705,7 +3741,10 @@ fn enqueue_cos_item(
         }
         let root_was_empty = root.nonempty_queues == 0;
         let queue = &mut root.queues[queue_idx];
-        let buffer_limit = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
+        // #707: `buffer_limit` scales with active flow count so the per-
+        // flow fast-retransmit floor (`COS_FLOW_FAIR_MIN_SHARE_BYTES`)
+        // can actually be satisfied without tripping the aggregate cap.
+        let buffer_limit = cos_flow_aware_buffer_limit(queue);
         let flow_share_exceeded = if queue.flow_fair {
             let flow_bucket = cos_flow_bucket_index(queue.flow_hash_seed, cos_item_flow_key(&item));
             queue.flow_bucket_bytes[flow_bucket].saturating_add(item_len)
@@ -7969,6 +8008,137 @@ mod tests {
         account_cos_queue_flow_dequeue(queue, Some(&flow_b), 16 * 1024);
         assert_eq!(queue.active_flow_buckets, 1);
         assert_eq!(queue.flow_bucket_bytes[bucket_b], 0);
+    }
+
+    #[test]
+    fn cos_flow_aware_buffer_limit_scales_with_active_flow_buckets() {
+        // #707: at the 1 Gbps/16-flow workload a fixed 125 KB buffer
+        // divided across 16 flows gives each flow a 7.8 KB share,
+        // below the TCP fast-retransmit floor of 16 MSS = 24 KB. The
+        // flow-aware buffer limit grows the aggregate cap so the per-
+        // flow floor can be honoured without the buffer-cap tripping
+        // first.
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 125 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        // Base floor wins when the flow count × min share is small.
+        queue.active_flow_buckets = 0;
+        assert_eq!(
+            cos_flow_aware_buffer_limit(queue),
+            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+            "zero active flows must collapse to the operator-configured base cap"
+        );
+        queue.active_flow_buckets = 2;
+        assert_eq!(
+            cos_flow_aware_buffer_limit(queue),
+            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+            "2 × 24 KB = 48 KB stays below the 125 KB configured base, so base wins"
+        );
+
+        // Flow-aware floor wins past the break-even point.
+        queue.active_flow_buckets = 16;
+        assert_eq!(
+            cos_flow_aware_buffer_limit(queue),
+            16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
+            "16 × 24 KB = 384 KB exceeds the 125 KB base and becomes the cap"
+        );
+    }
+
+    #[test]
+    fn cos_flow_aware_buffer_limit_respects_non_flow_fair_queues() {
+        // Pure rate-limited (non-flow-fair) queues must keep the
+        // operator's configured buffer. The flow-aware scaling only
+        // applies when SFQ-style per-flow accounting is active.
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 0,
+                forwarding_class: "best-effort".into(),
+                priority: 5,
+                transmit_rate_bytes: 100_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = false;
+        queue.active_flow_buckets = 64; // should be ignored
+
+        assert_eq!(
+            cos_flow_aware_buffer_limit(queue),
+            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+            "flow_fair=false must bypass the flow-count multiplier"
+        );
+    }
+
+    #[test]
+    fn cos_queue_flow_share_limit_never_drops_below_fast_retransmit_floor() {
+        // At 16 flows with a 125 KB buffer, the naive arithmetic share
+        // is 7.8 KB — a single packet drop yields < 3 dupacks, forcing
+        // RTO. The clamp to `COS_FLOW_FAIR_MIN_SHARE_BYTES` must hold
+        // the per-flow cap at 16 MSS = 24 KB no matter the denominator.
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 125 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+
+        // Simulate 16 distinct populated flow buckets.
+        queue.active_flow_buckets = 16;
+        for bucket in 0..16 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+
+        let buffer_limit = cos_flow_aware_buffer_limit(queue);
+        assert_eq!(
+            buffer_limit,
+            16 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
+            "flow-aware cap must expand to accommodate 16 × min-share"
+        );
+
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        assert!(
+            share >= COS_FLOW_FAIR_MIN_SHARE_BYTES,
+            "per-flow cap ({share}) must stay ≥ {COS_FLOW_FAIR_MIN_SHARE_BYTES} (16 MSS)"
+        );
+        assert_eq!(
+            share, COS_FLOW_FAIR_MIN_SHARE_BYTES,
+            "with buffer_limit == active × min-share, per-flow cap equals the floor"
+        );
+    }
+
+    #[test]
+    fn cos_flow_fair_min_share_is_sized_for_tcp_fast_retransmit() {
+        // Compile-time pin: the floor must stay at or above 16 MSS so
+        // TCP fast-retransmit has headroom for 3 dupacks plus reorder.
+        // Lowering this is a behaviour change that warrants explicit
+        // review; the const should not drift silently.
+        const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -2728,6 +2728,22 @@ fn cos_flow_bucket_index(queue_seed: u64, flow_key: Option<&SessionKey>) -> usiz
     usize::from(exact_cos_flow_bucket(queue_seed, flow_key)) & COS_FLOW_FAIR_BUCKET_MASK
 }
 
+/// Prospective distinct-flow count: current `active_flow_buckets` plus
+/// one when the target bucket is currently empty (i.e. we are admitting
+/// the first packet of a newly arriving flow). Both admission gates —
+/// the per-flow clamp and the aggregate cap — must use this value so
+/// they stay in lockstep. The original #704 bug was exactly this
+/// denominator drifting: one gate bumped for the new flow, the other
+/// did not, and the new flow's first packet got rejected at the
+/// boundary. Keeping the formula in one place removes that class of
+/// reintroduction risk.
+#[inline]
+fn cos_queue_prospective_active_flows(queue: &CoSQueueRuntime, flow_bucket: usize) -> u64 {
+    u64::from(queue.active_flow_buckets)
+        .saturating_add(u64::from(queue.flow_bucket_bytes[flow_bucket] == 0))
+        .max(1)
+}
+
 #[inline]
 fn cos_queue_flow_share_limit(
     queue: &CoSQueueRuntime,
@@ -2737,9 +2753,7 @@ fn cos_queue_flow_share_limit(
     if !queue.flow_fair {
         return buffer_limit;
     }
-    let prospective_active = u64::from(queue.active_flow_buckets)
-        .saturating_add(u64::from(queue.flow_bucket_bytes[flow_bucket] == 0))
-        .max(1);
+    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
     buffer_limit
         .div_ceil(prospective_active)
         .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
@@ -2777,9 +2791,7 @@ fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime, flow_bucket: usize) -> u
     if !queue.flow_fair {
         return base;
     }
-    let prospective_active = u64::from(queue.active_flow_buckets)
-        .saturating_add(u64::from(queue.flow_bucket_bytes[flow_bucket] == 0))
-        .max(1);
+    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
     base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
 }
 
@@ -8058,7 +8070,10 @@ mod tests {
                 transmit_rate_bytes: 1_000_000_000 / 8,
                 exact: true,
                 surplus_weight: 1,
-                buffer_bytes: 125 * 1024,
+                // Decimal KB to match the operator `buffer-size 125k`
+                // config, not KiB — the admission-boundary math must
+                // use the same units as the live system.
+                buffer_bytes: 125_000,
                 dscp_rewrite: None,
             }],
         );
@@ -8114,7 +8129,10 @@ mod tests {
                 transmit_rate_bytes: 1_000_000_000 / 8,
                 exact: true,
                 surplus_weight: 1,
-                buffer_bytes: 125 * 1024,
+                // Decimal KB to match the operator `buffer-size 125k`
+                // config, not KiB — the admission-boundary math must
+                // use the same units as the live system.
+                buffer_bytes: 125_000,
                 dscp_rewrite: None,
             }],
         );
@@ -8222,7 +8240,10 @@ mod tests {
                 transmit_rate_bytes: 1_000_000_000 / 8,
                 exact: true,
                 surplus_weight: 1,
-                buffer_bytes: 125 * 1024,
+                // Decimal KB to match the operator `buffer-size 125k`
+                // config, not KiB — the admission-boundary math must
+                // use the same units as the live system.
+                buffer_bytes: 125_000,
                 dscp_rewrite: None,
             }],
         );

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -8102,8 +8102,9 @@ mod tests {
         // the per-flow clamp used `active + (target bucket empty ? 1 :
         // 0)`, so the first packet of a newly arriving flow could
         // pass the per-flow gate and fail the aggregate one right at
-        // the boundary. This test pins the fix by driving exactly that
-        // case.
+        // the boundary. This test drives the queue to the *actual*
+        // admission boundary so the assertion exercises the old
+        // failure mode rather than trivial 0-bytes arithmetic.
         let mut root = test_cos_runtime_with_queues(
             25_000_000_000 / 8,
             vec![CoSQueueConfig {
@@ -8120,30 +8121,59 @@ mod tests {
         let queue = &mut root.queues[0];
         queue.flow_fair = true;
 
-        // 15 active flows, target bucket empty → prospective = 16.
-        // Both caps must key off 16, not 15.
+        // 15 active flows filled to 24 KB each. Target bucket empty →
+        // prospective_active = 16. Both caps must key off 16, not 15.
         queue.active_flow_buckets = 15;
         for bucket in 0..15 {
-            queue.flow_bucket_bytes[bucket] = 1_000;
+            queue.flow_bucket_bytes[bucket] = COS_FLOW_FAIR_MIN_SHARE_BYTES;
         }
+        // Aggregate queued equals the pre-fix aggregate cap exactly —
+        // this is the value that made the bug observable: under the
+        // old formula the aggregate cap was `15 × min-share` and the
+        // check `queued + 1500 > cap` tripped; under the fix the cap
+        // is `16 × min-share` and the packet fits.
+        queue.queued_bytes = 15 * COS_FLOW_FAIR_MIN_SHARE_BYTES;
+
         let new_flow_bucket = 100;
         assert_eq!(queue.flow_bucket_bytes[new_flow_bucket], 0);
 
         let buffer_limit = cos_flow_aware_buffer_limit(queue, new_flow_bucket);
         let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, new_flow_bucket);
 
-        // 16 × 24 KB = 384 KB aggregate; 384 KB / 16 = 24 KB per-flow.
+        // Fixed caps: aggregate = 16 × min-share, per-flow = min-share.
         assert_eq!(buffer_limit, 16 * COS_FLOW_FAIR_MIN_SHARE_BYTES);
         assert_eq!(share_cap, COS_FLOW_FAIR_MIN_SHARE_BYTES);
-        // A single MTU-sized packet for the new flow must fit under
-        // BOTH caps simultaneously — this is the regression guard.
+
+        // Per-flow gate: new bucket is empty, so +1500 is well below cap.
         assert!(
             queue.flow_bucket_bytes[new_flow_bucket].saturating_add(1500) <= share_cap,
             "per-flow share must admit the new flow's first packet"
         );
+
+        // Aggregate gate: queued is at the pre-fix cap. Fix makes
+        // +1500 still fit; without the fix this was a drop.
         assert!(
             queue.queued_bytes.saturating_add(1500) <= buffer_limit,
-            "aggregate cap must also admit the new flow's first packet at the boundary"
+            "aggregate cap must admit the new flow's first packet at the near-cap boundary \
+             (queued_bytes = {}, +1500 must fit within buffer_limit = {})",
+            queue.queued_bytes,
+            buffer_limit,
+        );
+
+        // Counter-factual: prove the pre-fix formula (non-prospective)
+        // would have rejected the same packet. Guards against a future
+        // refactor silently reverting to `active_flow_buckets` without
+        // the `+1` bump.
+        let non_prospective_cap = u64::from(queue.active_flow_buckets)
+            .max(1)
+            .saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES)
+            .max(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        assert!(
+            queue.queued_bytes.saturating_add(1500) > non_prospective_cap,
+            "without prospective-active, the same queued state would reject the new flow \
+             (queued_bytes + 1500 = {}, non-prospective cap = {})",
+            queue.queued_bytes + 1500,
+            non_prospective_cap,
         );
     }
 


### PR DESCRIPTION
## Summary

Flow-fair admission on low-rate exact queues has two undersized gates. Both need to be fixed together because each is hidden by the other tripping first.

1. **`COS_FLOW_FAIR_MIN_SHARE_BYTES` raised 4 → 16 MTU-sized packets** (6 KB → 24 KB). 4 is exactly the 3-dupack fast-retransmit threshold with no headroom — a single drop in the last MTU produces < 3 dupacks before cwnd is drained → RTO → cwnd reset to 1 MSS. 16 gives 3 dupacks + ~13 MTU of reorder/retransmit window. A top-level `const _: () = assert!` pins the floor at build time, not just test time.

2. **Flow-aware aggregate cap** matching the per-flow clamp's denominator. Per-flow clamp already reasoned about *prospective* active flows (current + 1 when the target bucket is empty). Aggregate cap was keyed off current active count, so at the new-flow boundary the per-flow gate admitted the first packet while the aggregate gate rejected it. Helper `cos_flow_aware_buffer_limit(queue, flow_bucket)` now uses the same prospective-active formula, driven from a single `flow_bucket` computed once per admission.

Non-flow-fair queues (best-effort, pure rate-limited) bypass the scaling and keep the operator-configured buffer.

## HFT hot-path shape

- One `flow_bucket` computation per admission (already present, reordered earlier).
- Branchless `prospective_active` compute via `saturating_add` on the `is_empty?1:0` boolean.
- One `saturating_mul` + one `max` extra per admission (~2–3 ns on modern x86).
- No allocations, no atomics, no heap state.
- Backing `VecDeque` is dynamic — logical cap only, zero memory cost until traffic fills it.

## Deferred to follow-up

Reviewer flagged a latency-envelope concern: `COS_FLOW_FAIR_BUCKETS = 1024` active flows would allow the cap to reach ~24 MB = ~190 ms of queue residence time on a 1 Gbps queue. A `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS`-derived clamp is the right shape but it is an operator-visible behaviour choice, not a bug fix — kept out of this PR pending queueing-budget policy discussion. Rustdoc on the helper calls it out so the concern is visible at the source.

## Test plan

- [x] `cargo test` — 651 green.
  - `cos_flow_aware_buffer_limit_scales_with_prospective_active_flow_count`: base wins low, floor wins high, prospective count (+1 for empty target) is the denominator.
  - `cos_flow_aware_buffer_limit_matches_share_limit_at_new_flow_boundary`: **new regression guard for the review's correctness finding** — at 15 active + 1 new-flow boundary, both gates admit the new flow's first packet.
  - `cos_flow_aware_buffer_limit_respects_non_flow_fair_queues`: `flow_fair=false` bypass.
  - `cos_queue_flow_share_limit_never_drops_below_fast_retransmit_floor`: per-flow share stays ≥ 16 MTU at 16 flows.
  - Top-level `const _: () = assert!` enforces floor at `cargo build`.
- [x] `make test` — full Go suite green.
- [x] Live deploy + CoS re-apply via new `test/incus/apply-cos-config.sh` + 3× 16-flow iperf3 on 5201.

## Live data and honest framing

With CoS active and the 1 Gbps exact queue, the **scheduler auto-sizes `buffer` to 1.19 MiB** (~9.5 ms × rate), not the 125 KB the issue's math assumed. That means:

- Before this PR, `buffer / 16 = 75 KB` per flow — already 3× above the 16-MTU floor.
- This PR's flow-aware expansion is a **no-op for scheduler-auto-sized buffers** (`base (1.19 MB)` > `prospective × 24 KB`) at this workload.

16-flow iperf3 results (3 runs, 30 s, port 5201):

| Run | Total | Rate ratio | Retrans / 30 s | cwnd < 50 KB |
|---|---|---|---|---|
| 1 | 1.10 Gbps | 1.48× | 175 k | 11 / 16 |
| 2 | 1.06 Gbps | 1.53× | 125 k | 8 / 16 |
| 3 | 1.10 Gbps | 1.44× | 204 k | 12 / 16 |

Rate ratio (1.5×) is healthy. Retransmit and cwnd-collapse numbers are statistically identical to the post-#706 baseline — the dominant driver on this workload is **bursty tail-drop on a ~10 ms bufferbloat queue**, not undersized per-flow share. That requires AQM (ECN marking or CoDel) rather than larger caps, and is properly scoped as a separate change.

This PR still lands because:
1. The per-flow floor raise + const-time assertion is defensive correctness that benefits small operator-set buffers (the case the issue body describes).
2. The prospective-active correctness fix removes a real new-flow-boundary drop window that existed regardless of buffer size.
3. The hot-path cost is negligible and the logical cap carries zero memory cost on workloads that don't fill it.

Follow-up work needed to actually move the cwnd-collapse metric: ECN marking / CoDel admission policy + the deferred latency-envelope clamp.

Refs #707, #704, #716.