### PR TITLE
docs: engineering-style.md — coding and review discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,12 @@
 - Keep solutions simple and direct.
 - When working with many teams, don't let the context windows get too large.
 
+**Read `docs/engineering-style.md` before writing non-trivial code or
+reviewing a PR.** It encodes the coding and review discipline this
+project has settled on — hot-path allocation rules, review severity,
+compile-time invariants, PR discipline, and the project-specific
+gotchas that repeatedly bite (deploy wipes CoS, iperf3 target, etc.).
+
 ## Logging Rules
 - Maintain a log of all major actions in `_Log.md`.
 - Use YAML or Markdown bullet points for structure:

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -1,0 +1,223 @@
+# Engineering style for xpf
+
+This file describes the coding and review personality the project has
+settled on. It is checked into the repo so new contributors — human or
+agent — internalise it before touching code or reviews. It is terser and
+more opinionated than `CLAUDE.md`; keep it that way.
+
+Read this file in full before:
+
+- writing non-trivial code in `userspace-dp/` or any hot path
+- reviewing a PR
+- opening a PR that claims a performance improvement
+
+## First principles
+
+1. **Latency is sacred.** Memory is cheap. Microseconds on the packet
+   path are not. When two approaches trade bytes for branches, take the
+   one that's branchless at the hot path.
+
+2. **Correctness first, performance second, convenience last.**
+   Defensive code that catches a class of bugs at build time beats tests
+   that catch one instance. Favour `const _: () = assert!(...)` over
+   `#[test]` pins for invariants that must not drift.
+
+3. **One source of truth for every formula.** If two code paths compute
+   the same denominator, they WILL drift. Centralise via a helper the
+   first time you notice the duplication. The #704 bug was two gates
+   computing "active flow count" differently.
+
+4. **Honest framing always.** If live data doesn't support the PR's
+   hypothesis, update the PR body. Don't bury it in a changelog. Don't
+   hide behind "tests pass".
+
+5. **Narrow scope.** Bug fix and behaviour choice do not ride in the
+   same PR. If a reviewer flags a "maybe we should also" concern, file
+   a tracking issue and cross-reference it. Don't silently expand
+   scope.
+
+## Hot-path coding discipline
+
+### Allocations
+
+- **Never allocate per packet.** `Vec::push` that may grow, `VecDeque`
+  that returns from a function, `Box::new` inside a `while let Some`
+  loop — all land on the allocator.
+- **Drain into caller-provided buffers.** Prefer
+  `drain_into(&mut out: VecDeque<T>)` over `drain() -> VecDeque<T>`.
+  Caller reuses its buffer across polls.
+- **Pre-size everything.** `VecDeque::with_capacity(expected)` at
+  construction. Fixed-cap rings (`[T; N]`) where the upper bound is
+  known statically.
+- **Drop policy on full: drop-newest.** Dropping the head of a queue
+  evicts a packet that was already close to being serviced and
+  extends tail latency. Dropping the incoming packet loses a packet
+  that has travelled zero further than the sender. Prefer drop-newest
+  unless there's a specific reason otherwise, and document the
+  rationale at the drop site.
+
+### Atomics
+
+- **Pick orderings deliberately.** `Relaxed` for counters. `Acquire` /
+  `Release` for publish/subscribe slot patterns. `AcqRel` only when
+  both sides of a CAS need ordering. If you're reaching for
+  `SeqCst` — stop and re-read the algorithm.
+- **No `Mutex<VecDeque>` on the hot path.** Use lock-free primitives
+  (Vyukov bounded MPMC, SPSC ring, or hand-rolled MPSC). If a mutex
+  is unavoidable, isolate it to a slow path.
+- **Cache-pad cross-core atomics.** Producer CAS on `head` + consumer
+  store on `tail` share a cache line → every op invalidates the
+  other core. Split into `#[repr(align(64))] CachePadded<T>` for
+  primitives whose job is cross-core coordination.
+
+### Branches
+
+- **Prefer branchless arithmetic.** `saturating_add`,
+  `saturating_mul`, `.max()`, `.min()`, `.clamp()`, and
+  `bool as u64` conversions generate predictable code.
+- **Make hot-path branches predictable.** Config-time booleans
+  (`flow_fair`, `exact`) that don't change at runtime give the
+  branch predictor a free win. Lift them to early returns at the
+  top of hot functions.
+- **Don't early-return on rare errors; account for them.** Error
+  paths should bump a counter and continue, not unwind. TCP doesn't
+  stop because one packet didn't fit; the scheduler shouldn't
+  either.
+
+### Compile-time guards
+
+- `const _: () = assert!(condition)` at module level is free. Use
+  it for structural invariants: power-of-two sizes, fast-retransmit
+  floors, maximum values that fit in a narrower type.
+- A `#[test]` that asserts `CONST >= N` runs only on `cargo test`.
+  A `const _: () = assert!` runs on every `cargo build`. Prefer
+  the latter for values that must not drift.
+
+## API shape discipline
+
+- **Signatures encode contracts.** If a function must not reallocate,
+  take `&mut VecDeque<T>` not `-> VecDeque<T>`. If a function expects
+  the consumer to hold the "SC" half of an MPSC invariant, mark it
+  `unsafe` and document the invariant at the call site.
+- **Helpers over duplication, always.** The moment you write the same
+  formula in two places, even if they look right today, extract it.
+  This is a future-correctness guarantee, not a style choice.
+- **Operator-visible units match operator config.** Tests that exercise
+  admission boundaries use the same units the operator types. If the
+  operator writes `buffer-size 125k` and that parses to 125000 bytes,
+  the fixture is `buffer_bytes: 125_000`, not `125 * 1024`. Don't mix
+  KB and KiB.
+
+## Overflow / failure policy
+
+| Scenario | Policy |
+|---|---|
+| Bounded queue, producer push on full | Return `Err(T)` so the caller can decide. In the admission-path wrapper, drop-newest + bump overflow counter. |
+| Bounded queue, consumer drain | Never fails. Loop until `pop()` returns `None`. |
+| Invariant violation at config time | `panic!` with context. Not recoverable; crash-start is safer than running with a wrong invariant. |
+| Invariant violation at runtime (rare, driver bug) | Bump a dedicated counter, continue. Crashing the dataplane on a single misbehaved packet punishes every other flow. |
+| "Path not found" at config apply | Warn + continue if the path is a best-effort cleanup; fail hard if the path is load-bearing. Don't let `|| true` mask the load-bearing case. |
+
+## Review discipline
+
+### Reviewing (adversarial by design)
+
+- **Be antagonistic in service of quality.** Reviewers who default to
+  "LGTM" let regressions land. The architect/reviewer role exists to
+  hold a deliberately high bar.
+- **Separate severity from style.** Correctness bugs, perf cliffs, and
+  API contract issues are Medium+. Terminology drift, rustdoc rendering,
+  redundant no-ops are Low. Call the severity explicitly; it tells the
+  author what to do first.
+- **Concrete code shape, not vague complaints.** "Consider centralising
+  the formula" is less useful than a five-line snippet showing the
+  exact helper signature. If you want a specific change, show it.
+- **Test strength matters.** A regression test that leaves state at
+  `0` before the final assertion is an arithmetic-consistency check,
+  not a regression guard. Tests must recreate the failure mode.
+  Counter-factual assertions that reconstruct the pre-fix formula and
+  prove it *would* fail are the strongest pin.
+- **Split behaviour choices out of bug fixes.** If a reviewer spots
+  "while you're here, we should also clamp...", that's a separate PR
+  or a follow-up issue. Don't let scope creep hide behind
+  "review feedback".
+- **Trust but verify.** An agent's commit summary describes what it
+  intended. Read the diff. Re-run the tests on the updated head before
+  approving.
+
+### Responding to review (as author)
+
+- **Apply review items by severity, fastest first.** Cleanup-level
+  items (docs, naming) land in the same push. Medium items get their
+  own commit if they're substantive. Design questions get a reply
+  asking for the decision before coding.
+- **Don't silently defer.** If a reviewer raises a concern you don't
+  act on, reply with why, and file a tracking issue. The next
+  reviewer should not have to re-discover the concern.
+- **Update the PR body when live data disagrees.** If the hypothesis
+  turns out to be partly wrong, rewrite the summary. Keep both the
+  before data and the after data visible. Future readers need the
+  honest picture.
+
+## PR discipline
+
+### Title
+
+- Imperative. `userspace-dp: lock-free redirect inbox eliminates cross-
+  producer mutex (#706)`, not "Removed mutex".
+- Issue reference in parentheses at the end. Multiple if the PR closes
+  multiple.
+
+### Body
+
+- **Summary**: 3–6 bullets. What changed and why.
+- **Hot-path shape** (for perf PRs): explicit about added instructions,
+  allocations, atomics. "One `saturating_mul` + one `max` per
+  admission (~2–3 ns)" is the right specificity.
+- **Test plan**: checkbox list. What tests were added, what was run.
+- **Live data** (for PRs that claim to move a metric): before/after
+  table. If the metric doesn't move, say so.
+- **Deferred**: named follow-ups with tracking issue numbers. Not
+  "TODO later".
+- **Refs**: every related issue.
+
+### Commit messages
+
+- Same shape as PR titles. Imperative, prefixed with the subsystem.
+- Body paragraphs explain *why*, not *what*. The diff shows what.
+- No emoji. No marketing. No "Makes the code better".
+
+### Merging
+
+- Squash-merge, single commit per PR on master. Commit message is the
+  PR title.
+- Do not merge with failing tests. Do not `--no-verify` to skip hooks.
+- Close referenced issues with a pointer to the merge commit and the
+  specific follow-up issues if any part was deferred.
+
+## Project-specific reminders
+
+These are not "style" but are worth keeping next to the rest because
+they repeatedly bite:
+
+- **Deploy wipes CoS config.** After `cluster-setup.sh deploy`, re-run
+  `./test/incus/apply-cos-config.sh <target>` before running iperf3
+  for any #706 / #707 / #708 / #709 / #718 validation.
+- **Always `source ~/.sshrc` before `git push`.** The user's SSH agent
+  config lives there.
+- **172.16.80.200 is the iperf3 test endpoint.** Not 172.16.50.x.
+- **Use `cli`, not `xpfctl`.** The remote CLI binary is `cli`.
+- **Primary is fw0 on RG0 in the loss userspace cluster.** Apply config
+  changes to the primary; sync takes care of the secondary.
+
+## Tone signals (patterns that have worked)
+
+- "The honest fix is..." → frame the real engineering tradeoff, not
+  the easy one.
+- "I would either ... or ..." → offer options in reviews, don't
+  dictate.
+- "I would not silently land ..." → insist on explicit agreement for
+  operator-visible changes.
+- "Behaviour choice, not a bug fix" → scope discipline in one phrase.
+- "Does not recreate the old failure mode" → test-strength review in
+  one phrase.


### PR DESCRIPTION
## Summary

Distill the coding / review personality that has emerged across the recent CoS work (#714, #715, #716) into a checked-in file that future sessions always load.

- **New**: `docs/engineering-style.md` — terse, opinionated, meant to be read once in full before touching hot-path code or reviewing a PR.
- **Updated**: `CLAUDE.md` now points at the style doc in the *Working Style* section, so agent sessions load it automatically alongside the project facts.

## What it covers

- First principles (latency > memory, correctness > perf > convenience, one source of truth per formula, honest framing, narrow scope).
- Hot-path coding rules: allocation, atomic orderings, cache-padding cross-core atomics, branchless arithmetic, `const _: () = assert!` vs `#[test]` pins.
- API shape discipline: drain-into-buffer signatures, `unsafe` fn for SC invariants, operator-visible units match live config.
- Overflow / failure policy matrix (drop-newest vs drop-oldest, return Err vs panic vs counter-bump).
- Review discipline: adversarial by design, severity tags, concrete code shape in comments, test-strength standards with counter-factual assertions.
- PR discipline: title/body/commit/merge conventions.
- Project-specific gotchas that repeatedly bite (CoS wipe on deploy, iperf3 endpoint, `cli` not `xpfctl`, `source ~/.sshrc`).
- Tone signals from reviews that worked (`"I would either ... or ..."`, `"behaviour choice, not a bug fix"`, `"does not recreate the old failure mode"`).

## Test plan

- [x] Docs-only change.
- [x] Links verified, no dangling file refs.

Since the file prescribes the *taste* of the codebase, please review the prescriptions themselves — not just the prose. Anything I got wrong, overclaimed, or missed from what you actually want the personality to be is worth calling out before merge.