### PR TITLE
cos: surface admission drop counters in show class-of-service interface

### DIFF
--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -31,6 +31,14 @@ type cosQueueView struct {
 	parked          int
 	nextWakeupTick  uint64
 	surplusDeficit  uint64
+	// #710/#718: admission-path counters sourced from runtime. Zero values
+	// are still rendered — operators need to see the counter exists.
+	admissionFlowShareDrops uint64
+	admissionBufferDrops    uint64
+	admissionEcnMarked      uint64
+	// hasRuntime is true when the queue view was populated from a runtime
+	// snapshot. Config-only queues (no runtime yet) skip the Drops line.
+	hasRuntime bool
 }
 
 func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
@@ -95,7 +103,14 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 			continue
 		}
 		b.WriteString("  Queues:\n")
-		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		// Render queue rows via tabwriter into a local buffer so columns
+		// align across ALL queues. Then walk the rendered lines and
+		// interleave the per-queue Drops line. Emitting Drops directly
+		// into the tabwriter breaks column alignment — a line without
+		// tabs restarts tabwriter's contiguous-column grouping — so we
+		// keep the Drops line outside the aligned grid (#710, #718).
+		var tableBuf strings.Builder
+		tw := tabwriter.NewWriter(&tableBuf, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(tw, "    Queue\tOwner\tClass\tPriority\tExact\tTransmit rate\tBuffer\tQueued pkts\tQueued bytes\tRunnable\tParked\tNext wake\tSurplus deficit")
 		for _, queue := range queues {
 			fmt.Fprintf(tw, "    %d\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%d\t%d\t%s\t%s\n",
@@ -115,6 +130,32 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 			)
 		}
 		_ = tw.Flush()
+		// First rendered line is the header; subsequent lines map 1:1 to
+		// queues in order. Re-emit into the main builder, appending a
+		// Drops line under each queue data row. Zero-valued counters are
+		// still printed so operators can confirm the counter is wired.
+		tableLines := strings.Split(strings.TrimRight(tableBuf.String(), "\n"), "\n")
+		for i, line := range tableLines {
+			b.WriteString(line)
+			b.WriteByte('\n')
+			if i == 0 {
+				// header — no drops line
+				continue
+			}
+			queueIdx := i - 1
+			if queueIdx >= len(queues) {
+				continue
+			}
+			queue := queues[queueIdx]
+			if !queue.hasRuntime {
+				continue
+			}
+			fmt.Fprintf(&b, "           Drops: flow_share=%d  buffer=%d  ecn_marked=%d\n",
+				queue.admissionFlowShareDrops,
+				queue.admissionBufferDrops,
+				queue.admissionEcnMarked,
+			)
+		}
 	}
 	return b.String()
 }
@@ -201,6 +242,10 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.parked = runtimeQueue.ParkedInstances
 			qv.nextWakeupTick = runtimeQueue.NextWakeupTick
 			qv.surplusDeficit = runtimeQueue.SurplusDeficitBytes
+			qv.admissionFlowShareDrops = runtimeQueue.AdmissionFlowShareDrops
+			qv.admissionBufferDrops = runtimeQueue.AdmissionBufferDrops
+			qv.admissionEcnMarked = runtimeQueue.AdmissionEcnMarked
+			qv.hasRuntime = true
 			queueViews[qv.queueID] = qv
 		}
 	}

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -149,3 +149,68 @@ func TestFormatCoSInterfaceSummaryFiltersByBaseInterface(t *testing.T) {
 		t.Fatalf("expected base selector to include logical unit:\n%s", out)
 	}
 }
+
+// #710/#718: admission-drop counters must render under each queue row
+// with real values. Without this line, operators debugging the
+// admission path (SFQ flow-share cap, buffer cap, ECN threshold) have
+// no way to tell which admission decision is firing on the live system.
+func TestFormatCoSInterfaceSummaryRendersAdmissionDropCounters(t *testing.T) {
+	owner := uint32(1)
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:                 4,
+						OwnerWorkerID:           &owner,
+						ForwardingClass:         "bandwidth-10mb",
+						Priority:                5,
+						Exact:                   true,
+						TransmitRateBytes:       1_250_000,
+						BufferBytes:             32 * 1024,
+						AdmissionFlowShareDrops: 12345,
+						AdmissionBufferDrops:    0,
+						AdmissionEcnMarked:      4567,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	want := "Drops: flow_share=12345  buffer=0  ecn_marked=4567"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in output:\n%s", want, out)
+	}
+}
+
+// Zero-valued counters MUST still render — operators need to see the
+// counter is wired, otherwise "no output" is indistinguishable from
+// "counter missing from the pipeline" when chasing #718 / #722.
+func TestFormatCoSInterfaceSummaryRendersZeroAdmissionCounters(t *testing.T) {
+	owner := uint32(1)
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:         4,
+						OwnerWorkerID:   &owner,
+						ForwardingClass: "bandwidth-10mb",
+						// all admission counters default to 0
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	want := "Drops: flow_share=0  buffer=0  ecn_marked=0"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in output (zero-valued drops must still render):\n%s", want, out)
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -465,6 +465,12 @@ type CoSQueueStatus struct {
 	ParkedInstances     int     `json:"parked_instances,omitempty"`
 	NextWakeupTick      uint64  `json:"next_wakeup_tick,omitempty"`
 	SurplusDeficitBytes uint64  `json:"surplus_deficit_bytes,omitempty"`
+	// #710/#718: per-queue admission-path counters aggregated across
+	// worker instances by the Rust coordinator. JSON tags MUST match the
+	// Rust serde rename(...) exactly — the wire format is the contract.
+	AdmissionFlowShareDrops uint64 `json:"admission_flow_share_drops,omitempty"`
+	AdmissionBufferDrops    uint64 `json:"admission_buffer_drops,omitempty"`
+	AdmissionEcnMarked      uint64 `json:"admission_ecn_marked,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {


### PR DESCRIPTION
## Summary

- Three per-queue admission counters — `admission_flow_share_drops`, `admission_buffer_drops`, `admission_ecn_marked` — already exist in the Rust dataplane (`CoSQueueDropCounters` in `userspace-dp/src/afxdp/types.rs`), are already aggregated across workers in `coordinator.rs`, and are already serialised on the wire in `userspace-dp/src/protocol.rs`.
- The Go `CoSQueueStatus` never had matching fields, and `FormatCoSInterfaceSummary` never rendered them. Operators had **no** way to see which admission decision was firing on the live system.
- This PR surfaces the existing counters. No new counters, no behaviour changes, no new `show` subcommand.

## Before / After

**Before** (`show class-of-service interface`):

```
    Queue  Owner  Class        Priority  Exact  Transmit rate  Buffer       Queued pkts  Queued bytes  Runnable  Parked  Next wake   Surplus deficit
    4      1      iperf-a      5         yes    1.00 Gb/s      1.19 MiB     255          378.02 KiB    0         1       6053592261  -
```

**After**:

```
    Queue  Owner  Class        Priority  Exact  Transmit rate  Buffer       Queued pkts  Queued bytes  Runnable  Parked  Next wake   Surplus deficit
    4      1      iperf-a      5         yes    1.00 Gb/s      1.19 MiB     255          378.02 KiB    0         1       6053592261  -
           Drops: flow_share=12345  buffer=0  ecn_marked=4567
```

Column alignment across queue rows is preserved (a naive tabwriter interleave breaks it; see the implementation note in `cosfmt.go`). Zero-valued counters are still rendered — operators need to SEE the zero to confirm the counter is wired end-to-end.

## Why this matters

We have been iterating on CoS admission-path fixes across #706 / #707 / #708 / #709 / #711 / #718 / #722. Without live operator visibility into which admission counter is incrementing, there is no way to confirm on the running system whether e.g. #722's per-flow ECN threshold is firing or whether flow-share drops dominate instead. Log scraping is not a substitute; a per-queue counter summary is what operators need at the CLI.

## Hot-path impact

None. `FormatCoSInterfaceSummary` is display-path code on the status poll; it runs once per CLI invocation, not per packet.

## Scope discipline

- The JSON tags on the new Go struct fields match the Rust `serde(rename = ...)` names exactly. They are the wire contract.
- No change to admission decision logic (`tx.rs`), no new counters, no renames.
- Extends the existing rendering; no new `show class-of-service interface extensive` subcommand.

## Test plan

- [x] `go test ./pkg/dataplane/userspace/...` — 6 of 6 format tests pass, including two new ones covering the non-zero and all-zero render paths.
- [x] `go test ./pkg/cli/... ./pkg/grpcapi/...` — green.
- [x] `cargo test --manifest-path userspace-dp/Cargo.toml` — 671 passed, 1 ignored, 0 failed. Test count unchanged because no Rust code was modified.

## Refs

- #718 — ECN CE marking at CoS admission (the counter this PR exposes)
- #722 — per-flow ECN threshold (pending; this PR unblocks live validation of #722 by making the counter visible)