### PR TITLE
docs+cos: validation methodology + #725 findings + interface-level drops gate

### DIFF
--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -1,0 +1,137 @@
+# CoS admission validation — methodology and current limitations
+
+This file documents how to validate changes to the userspace-dp CoS admission path
+(anything that touches `cos_flow_aware_buffer_limit`,
+`cos_queue_flow_share_limit`, `apply_cos_admission_ecn_policy`, or the
+admission block in `enqueue_cos_item`). Read it before opening a PR that
+claims to move TCP fairness, retransmit count, or cwnd-collapse numbers on
+the 16-flow iperf3 workload — otherwise you are likely to repeat the
+mistake described in #725.
+
+## How to read admission drop counters live
+
+Since #724, `show class-of-service interface` renders three per-queue
+counters on an indented `Drops:` line:
+
+```
+Queue  Owner  Class    ...  Buffer     Queued pkts  Queued bytes  ...
+4      1      iperf-a  ...  1.19 MiB   299          443.24 KiB    ...
+       Drops: flow_share=1923  buffer=0  ecn_marked=0
+```
+
+Definitions (from `CoSQueueDropCounters` in `userspace-dp/src/afxdp/types.rs`):
+
+- `flow_share` — packets dropped because a single flow's bucket already holds
+  its entire `share_cap` worth of bytes. The dominant failure mode on
+  flow-fair exact queues under multi-flow load.
+- `buffer` — packets dropped because aggregate queue depth exceeded
+  `buffer_limit`. Usually zero because #716 + #720 keep the aggregate
+  nowhere near the cap.
+- `ecn_marked` — count of successful ECN CE marks. Zero when either
+  (a) the threshold never trips, or (b) no ECT packets reach the
+  firewall. Look at both before drawing a conclusion.
+
+Zero-valued counters are still printed. That is deliberate: an operator
+needs to see the zero to confirm the counter is wired and the drop path
+simply is not firing, versus the telemetry being broken.
+
+### Reading them during an iperf3 run
+
+```bash
+# 16-flow iperf3 in background
+incus exec loss:cluster-userspace-host -- \
+  iperf3 -c 172.16.80.200 -P 16 -t 30 -p 5201 -i 0 >/dev/null 2>&1 &
+
+sleep 10   # let the queue fill and the counters move
+
+# Read the live counters mid-test
+incus exec loss:xpf-userspace-fw0 -- \
+  /usr/local/sbin/cli -c "show class-of-service interface"
+
+wait   # let iperf3 finish
+```
+
+The counters are monotonic from process start. For a delta over a run,
+snapshot before and after and subtract.
+
+## Current test-env limitation: ECN never negotiated
+
+The iperf3 server at `172.16.80.200` is not on any VM in the
+`loss:xpf-userspace-*` project — it lives on bare metal (or an
+unreachable network segment) and does **not** negotiate ECN. That
+means, regardless of `net.ipv4.tcp_ecn` settings on the client and
+firewalls:
+
+- Every packet arrives at the firewall with `tos 0x0` (NOT-ECT).
+- `maybe_mark_ecn_ce` correctly early-returns per RFC 3168 §6.1.1.1
+  (the firewall must not unilaterally force ECN on a flow that did not
+  opt in).
+- `ecn_marked` stays at zero for the life of the connection.
+
+**Implication**: #721 (aggregate ECN threshold) and #722 (per-flow
+ECN threshold) are structurally correct but dormant on this workload.
+They would fire as designed if packets were ECT.
+
+To validate ECN-path changes end-to-end:
+
+1. Run an iperf3 server on a VM where both endpoints can set
+   `tcp_ecn=1` (e.g., reuse `cluster-userspace-host` as the server
+   and point a second client at it through the firewall, or add a new
+   VM on the WAN side).
+2. Verify ECT bits show up on the wire with tcpdump:
+   ```bash
+   incus exec <client> -- tcpdump -v -c 4 -n 'tcp port 5201'
+   # expect tos != 0x0 on both directions after the SYN exchange
+   ```
+3. Re-run the iperf3 load and watch `ecn_marked` bump during the run.
+
+## Current dominant failure mode on this workload
+
+With #716/#717/#720 landed, the 16-flow / 1 Gbps exact queue workload
+sits at ~31% aggregate buffer utilisation (~378 KB of a 1.19 MiB
+buffer) during steady state. The dominant drop source is:
+
+- `flow_share_drops`: ~190/sec on queue 4.
+- `buffer_drops`: 0.
+- `ecn_marked`: 0 (see above).
+
+190 drops/sec × 30 s run × 16 flows ≈ per-flow drop every 1–2 s.
+Because these drops cluster (tail-drop on microbursts), many do not
+produce the 3 dupacks required for TCP fast-retransmit, so the flow
+takes RTO instead, collapsing cwnd to 1 MSS. That is the
+10–15/16-flows-collapsed pattern in #704/#722.
+
+## Choosing a fix path
+
+When the counters show something different from "`flow_share` dominant, `buffer` zero, `ecn_marked` zero", the pathology and the right fix may be different. The decision tree:
+
+| `flow_share` | `buffer` | `ecn_marked` | Interpretation | Likely fix |
+|---|---|---|---|---|
+| high | low | 0 | Per-flow cap too tight; no ECN to soften it | ECN end-to-end (test-env fix), or CoDel (non-ECN AQM), or relax per-flow cap |
+| high | low | high | ECN fires but TCP still drops — ECN signal not enough | Lower ECN threshold, or combine with rate-based pacing |
+| low | high | any | Aggregate cap tripping — bufferbloat | Revisit #720 clamp; look at operator `buffer-size` setting |
+| 0 | 0 | 0 | Nothing is dropping; problem is elsewhere | Look at #709 (owner worker), #712 (CPU pinning), or network-layer loss |
+
+## Gotchas the deploy wipes
+
+Per `feedback_cos_deploy_config.md` (auto-memory): the cluster deploy path
+wipes the CoS config. After every `cluster-setup.sh deploy`, re-apply
+the config:
+
+```bash
+./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+```
+
+The loader is intentionally strict on `load merge` / `commit` since
+#716 — if you see a validation error, stop and investigate rather than
+re-running.
+
+## Refs
+
+- #704 — umbrella cwnd-collapse symptom
+- #716 — flow-aware admission cap
+- #720 — latency-envelope clamp
+- #721 — ECN CE marking at CoS admission
+- #722 — per-flow ECN mark threshold
+- #724 — surface admission drop counters (unblocked this methodology)
+- #725 — validation-pipeline gap findings (live data + path forward)

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -56,11 +56,14 @@ snapshot before and after and subtract.
 
 ## Current test-env limitation: ECN never negotiated
 
-The iperf3 server at `172.16.80.200` is not on any VM in the
-`loss:xpf-userspace-*` project — it lives on bare metal (or an
-unreachable network segment) and does **not** negotiate ECN. That
-means, regardless of `net.ipv4.tcp_ecn` settings on the client and
-firewalls:
+**Observed state 2026-04-17** — this is not timeless methodology, it
+is a lab-setup snapshot that will rot as endpoints, kernels, and
+network segments change. Re-run the verification commands below before
+trusting anything in this section.
+
+The iperf3 server at `172.16.80.200` (at time of writing) does not
+respond with ECN-negotiated SYN-ACKs. That means, regardless of
+`net.ipv4.tcp_ecn` settings on the client and firewalls:
 
 - Every packet arrives at the firewall with `tos 0x0` (NOT-ECT).
 - `maybe_mark_ecn_ce` correctly early-returns per RFC 3168 §6.1.1.1
@@ -72,32 +75,47 @@ firewalls:
 ECN threshold) are structurally correct but dormant on this workload.
 They would fire as designed if packets were ECT.
 
-To validate ECN-path changes end-to-end:
+### Verify the current state
+
+```bash
+# Capture 4 packets from an in-progress iperf3 run and look at tos.
+# tos 0x0 on both directions == no ECN negotiation == ECN-path code dormant.
+incus exec <client> -- tcpdump -v -c 4 -n 'tcp port 5201'
+```
+
+If the verification shows `tos != 0x0` on both directions, ECN is
+live and this section is stale — update it.
+
+### Controlling the endpoint for ECN validation
+
+To exercise #721/#722 end-to-end, stand up a controllable iperf3
+server:
 
 1. Run an iperf3 server on a VM where both endpoints can set
    `tcp_ecn=1` (e.g., reuse `cluster-userspace-host` as the server
    and point a second client at it through the firewall, or add a new
    VM on the WAN side).
-2. Verify ECT bits show up on the wire with tcpdump:
-   ```bash
-   incus exec <client> -- tcpdump -v -c 4 -n 'tcp port 5201'
-   # expect tos != 0x0 on both directions after the SYN exchange
-   ```
+2. Verify ECT bits show up on the wire with the tcpdump above.
 3. Re-run the iperf3 load and watch `ecn_marked` bump during the run.
 
 ## Current dominant failure mode on this workload
 
-With #716/#717/#720 landed, the 16-flow / 1 Gbps exact queue workload
-sits at ~31% aggregate buffer utilisation (~378 KB of a 1.19 MiB
-buffer) during steady state. The dominant drop source is:
+With #716 and #720 (latency clamp from issue #717) landed, the
+16-flow / 1 Gbps exact queue workload sits at ~31% aggregate buffer
+utilisation (~378 KB of a 1.19 MiB buffer) during steady state. The
+dominant drop source is:
 
 - `flow_share_drops`: ~190/sec on queue 4.
 - `buffer_drops`: 0.
 - `ecn_marked`: 0 (see above).
 
-190 drops/sec × 30 s run × 16 flows ≈ per-flow drop every 1–2 s.
-Because these drops cluster (tail-drop on microbursts), many do not
-produce the 3 dupacks required for TCP fast-retransmit, so the flow
+At 190 drops/sec distributed across 16 flows, each flow sees
+~12 drops/sec on average — one drop every ~80 ms. That is much
+faster than the 1–2 s this file previously claimed. At ~80 ms
+between drops the flow never gets a clean RTT to re-open cwnd
+past ~5–6 MSS before the next drop lands; drops also arrive in
+bursts (tail-drop on microbursts), so many of the 12/sec do not
+produce the 3 dupacks needed for TCP fast-retransmit and the flow
 takes RTO instead, collapsing cwnd to 1 MSS. That is the
 10–15/16-flows-collapsed pattern in #704/#722.
 
@@ -114,17 +132,23 @@ When the counters show something different from "`flow_share` dominant, `buffer`
 
 ## Gotchas the deploy wipes
 
-Per `feedback_cos_deploy_config.md` (auto-memory): the cluster deploy path
-wipes the CoS config. After every `cluster-setup.sh deploy`, re-apply
-the config:
+The cluster deploy path (`cluster-setup.sh deploy`) wipes the CoS
+config every run — the bootstrapped `xpf.conf` does not carry the
+iperf CoS fixture. After every deploy, re-apply:
 
 ```bash
 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 ```
 
-The loader is intentionally strict on `load merge` / `commit` since
-#716 — if you see a validation error, stop and investigate rather than
-re-running.
+The loader script lives at `test/incus/apply-cos-config.sh` and is
+documented inline. It is intentionally strict on `load merge` / `commit`
+since #716 — if you see a validation error, stop and investigate rather
+than re-running. The accompanying fixture at
+`test/incus/cos-iperf-config.set` covers both `family inet` and
+`family inet6` classifier state.
+
+See also the "CoS deploy preserves config" bullet in
+[`engineering-style.md`](engineering-style.md#project-specific-reminders).
 
 ## Refs
 

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -209,6 +209,15 @@ they repeatedly bite:
 - **Use `cli`, not `xpfctl`.** The remote CLI binary is `cli`.
 - **Primary is fw0 on RG0 in the loss userspace cluster.** Apply config
   changes to the primary; sync takes care of the secondary.
+- **Before claiming a CoS admission-path PR moves a metric, read the
+  counters.** `show class-of-service interface` surfaces `flow_share`,
+  `buffer`, and `ecn_marked` drop counts per queue since #724. See
+  [`cos-validation-notes.md`](cos-validation-notes.md) for the
+  methodology, the decision tree mapping counter patterns to fixes,
+  and the current test-env limitation that blocks ECN end-to-end
+  validation. Iterating on admission logic without reading these
+  counters is how #721/#722 landed dormant on the live workload
+  (#725).
 
 ## Tone signals (patterns that have worked)
 

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -36,9 +36,6 @@ type cosQueueView struct {
 	admissionFlowShareDrops uint64
 	admissionBufferDrops    uint64
 	admissionEcnMarked      uint64
-	// hasRuntime is true when the queue view was populated from a runtime
-	// snapshot. Config-only queues (no runtime yet) skip the Drops line.
-	hasRuntime bool
 }
 
 func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
@@ -132,8 +129,19 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 		_ = tw.Flush()
 		// First rendered line is the header; subsequent lines map 1:1 to
 		// queues in order. Re-emit into the main builder, appending a
-		// Drops line under each queue data row. Zero-valued counters are
-		// still printed so operators can confirm the counter is wired.
+		// Drops line under each queue data row.
+		//
+		// The Drops line is gated on **interface** runtime (not per-queue
+		// runtime): once an interface reports runtime state, every
+		// configured queue on it emits a Drops line with whatever counts
+		// are exported, defaulting to zero for queues not yet materialised
+		// in the runtime snapshot. This avoids the "wired-but-silent vs
+		// missing-from-export" ambiguity — an operator seeing `flow_share=0
+		// buffer=0 ecn_marked=0` now unambiguously means the counter path
+		// is live and nothing is tripping, whereas a missing Drops line
+		// means the interface itself is not yet exported (see
+		// cos-validation-notes.md "Reading the counters live").
+		interfaceHasRuntime := view.interfaceState != nil
 		tableLines := strings.Split(strings.TrimRight(tableBuf.String(), "\n"), "\n")
 		for i, line := range tableLines {
 			b.WriteString(line)
@@ -146,10 +154,10 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 			if queueIdx >= len(queues) {
 				continue
 			}
-			queue := queues[queueIdx]
-			if !queue.hasRuntime {
+			if !interfaceHasRuntime {
 				continue
 			}
+			queue := queues[queueIdx]
 			fmt.Fprintf(&b, "           Drops: flow_share=%d  buffer=%d  ecn_marked=%d\n",
 				queue.admissionFlowShareDrops,
 				queue.admissionBufferDrops,
@@ -245,7 +253,6 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.admissionFlowShareDrops = runtimeQueue.AdmissionFlowShareDrops
 			qv.admissionBufferDrops = runtimeQueue.AdmissionBufferDrops
 			qv.admissionEcnMarked = runtimeQueue.AdmissionEcnMarked
-			qv.hasRuntime = true
 			queueViews[qv.queueID] = qv
 		}
 	}

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -186,6 +186,88 @@ func TestFormatCoSInterfaceSummaryRendersAdmissionDropCounters(t *testing.T) {
 	}
 }
 
+// The formatter renders queues via tabwriter into a scratch buffer and
+// interleaves the per-queue Drops line on a second pass. That second
+// pass relies on a strict 1:1 mapping between the i-th table data line
+// and the i-th element of `queues` (sorted by queue_id ascending).
+// This test pins that invariant — a future refactor that, say, adds a
+// blank separator line, re-orders queues, or attaches one queue's
+// Drops row under another's data row would break this assertion while
+// the single-queue tests above would still pass.
+func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) {
+	owner := uint32(1)
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:                 0,
+						OwnerWorkerID:           &owner,
+						ForwardingClass:         "best-effort",
+						Priority:                5,
+						Exact:                   true,
+						TransmitRateBytes:       1_875_000,
+						BufferBytes:             16 * 1024,
+						AdmissionFlowShareDrops: 11,
+						AdmissionBufferDrops:    22,
+						AdmissionEcnMarked:      33,
+					},
+					{
+						QueueID:                 4,
+						OwnerWorkerID:           &owner,
+						ForwardingClass:         "bandwidth-10mb",
+						Priority:                5,
+						Exact:                   true,
+						TransmitRateBytes:       1_250_000,
+						BufferBytes:             32 * 1024,
+						AdmissionFlowShareDrops: 44,
+						AdmissionBufferDrops:    55,
+						AdmissionEcnMarked:      66,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+
+	// Use content-unique markers rather than full row-text substrings
+	// because tabwriter's column widths depend on cell content across
+	// all rows — a new queue with a longer forwarding-class name in
+	// the fixture would shift spacing and break a literal-row match
+	// without actually breaking the invariant this test pins.
+	//
+	// The invariant: queue rows emit in queue_id ascending order, and
+	// each queue's Drops line sits directly under its own data row
+	// (not under the next queue's). We pin that with unique counter
+	// values per queue (33 vs 66) so a misaligned interleave would be
+	// detectable.
+	q0Drops := "Drops: flow_share=11  buffer=22  ecn_marked=33"
+	q4Drops := "Drops: flow_share=44  buffer=55  ecn_marked=66"
+	// The word "best-effort" anchors queue 0's row. "bandwidth-10mb"
+	// anchors queue 4's. Both strings appear exactly once in the
+	// output (once in the data row).
+	q0RowIdx := strings.Index(out, "best-effort")
+	q0DropsIdx := strings.Index(out, q0Drops)
+	q4RowIdx := strings.Index(out, "bandwidth-10mb")
+	q4DropsIdx := strings.Index(out, q4Drops)
+
+	if q0RowIdx < 0 || q0DropsIdx < 0 || q4RowIdx < 0 || q4DropsIdx < 0 {
+		t.Fatalf("missing queue row anchor or drops line:\n%s", out)
+	}
+	// Strict order: q0 row, q0 drops, q4 row, q4 drops. A swap would
+	// mean queue 0's row is followed by queue 4's Drops line (or
+	// similar) — exactly the pathology this test guards against.
+	if !(q0RowIdx < q0DropsIdx && q0DropsIdx < q4RowIdx && q4RowIdx < q4DropsIdx) {
+		t.Fatalf(
+			"drops-line interleave broken: q0Row=%d q0Drops=%d q4Row=%d q4Drops=%d\n%s",
+			q0RowIdx, q0DropsIdx, q4RowIdx, q4DropsIdx, out,
+		)
+	}
+}
+
 // Zero-valued counters MUST still render — operators need to see the
 // counter is wired, otherwise "no output" is indistinguishable from
 // "counter missing from the pipeline" when chasing #718 / #722.


### PR DESCRIPTION
## Summary

Originally a docs-only follow-up to #725. Review surfaced a real correctness issue in the render path from #724 (per-queue gate suppresses the Drops line in exactly the \`wired-but-silent\` case operators care about), so this PR now carries both:

**Docs** (\`docs/cos-validation-notes.md\`): how to read the CoS admission drop counters surfaced in #724, a decision tree mapping \`(flow_share, buffer, ecn_marked)\` patterns to fixes, and the current (dated, verifiable) test-env limitation that blocks ECN end-to-end validation.

**Code** (\`pkg/dataplane/userspace/cosfmt.go\`, \`cosfmt_test.go\`): Drops-line suppression keyed on **interface** runtime, not per-queue runtime. New multi-queue regression test pinning the queue-row → drops-row interleave invariant.

Updated: \`docs/engineering-style.md\` cross-links the validation methodology so future sessions hit it before writing admission-path code.

## Review findings applied

- **psaab / cosfmt.go:150** — interface-level gate, not per-queue. Removed \`cosQueueView.hasRuntime\`; gate is \`view.interfaceState != nil\`. Zero-valued counters now render on every configured queue of a runtime-visible interface, preserving the \`zero means wired-and-quiet\` contract.
- **psaab / cosfmt_test.go** — new \`TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder\` with distinct counter tuples per queue. Uses class-name anchors so tabwriter column-width changes don't make it fragile.
- **psaab / cos-validation-notes.md:61** — ECN-never-negotiated section now stamped \`Observed state 2026-04-17\` with a tcpdump verification command operators can re-run.
- **Copilot / cos-validation-notes.md:92** — clarified #717 (tracking issue) vs #720 (the PR that landed the latency clamp).
- **Copilot / cos-validation-notes.md:103** — corrected per-flow drop-rate math: 190/sec / 16 flows ≈ 12 drops/sec per flow (one every ~80 ms), not one every 1–2 s.
- **Copilot / cos-validation-notes.md:123** — replaced dead \`feedback_cos_deploy_config.md\` reference with real paths (\`test/incus/apply-cos-config.sh\` + cross-link to engineering-style.md).
- **Copilot / PR description** — PR body/title updated to reflect both docs and code changes.

## Test plan

- [x] \`go test ./pkg/dataplane/userspace/... ./pkg/cli/... ./pkg/grpcapi/...\` green (+1 new test).
- [x] \`cargo test --manifest-path userspace-dp/Cargo.toml\` unchanged (no Rust source changes in this PR).
- [x] Links verified, no dangling refs in docs.

Refs: #725, #724, #722, #721, #720, #716, #704.