### PR TITLE
userspace-dp: owner-profile telemetry for low-rate exact queues (#709 Option E)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -255,3 +255,18 @@
 - **Action**: Add 5 Prepared-variant admission tests (IPv4 ECT(0), IPv6 ECT(0), NOT-ECT, out-of-range offset, combined Local+Prepared counter pin); remove stale `admission_does_not_mark_prepared_variant` negative pin
   - **File(s)**: `userspace-dp/src/afxdp/tx.rs`
 - **Result**: admission_ecn group 11/11 pass, mark_ecn_ce group 11/11 pass, full suite 680/680 pass. Marker now fires on the XSK-RX→XSK-TX zero-copy hot path (iperf3, NAT'd flows); acceptance target per `docs/cos-validation-notes.md` is `ecn_marked` becoming non-zero during live 16-flow iperf3
+
+## 2026-04-17 — #709 Option E owner-profile telemetry (measure before optimizing)
+- **Action**: Add `DRAIN_HIST_BUCKETS = 16` const-asserted, `bucket_index_for_ns` branchless helper, `drain_latency_hist` + `drain_invocations` + `drain_noop_invocations` + `redirect_acquire_hist` + `redirect_sample_counter` + `pps_owner_vs_peer` on `BindingLiveState`; add `new_seeded(worker_id)` constructor so per-worker redirect samples don't lockstep
+  - **File(s)**: `userspace-dp/src/afxdp/umem.rs`
+- **Action**: Time every `drain_shaped_tx` invocation with one pair of `monotonic_nanos()` calls; count owner-local vs peer-redirected packets on `ingest_cos_pending_tx` split-point; sample `enqueue_tx_owned` 1-in-256 producer-side
+  - **File(s)**: `userspace-dp/src/afxdp/tx.rs`, `userspace-dp/src/afxdp/umem.rs`
+- **Action**: Extend `CoSQueueStatus` serde with histograms + owner/peer pps; populate from owner binding's live snapshot in `build_worker_cos_statuses` with `max` aggregation across workers (only owner writes non-zero). Cross-worker coordinator aggregation mirrors `admission_ecn_marked` shape
+  - **File(s)**: `userspace-dp/src/protocol.rs`, `userspace-dp/src/afxdp/worker.rs`, `userspace-dp/src/afxdp/coordinator.rs`
+- **Action**: Go-side protocol mirror + `OwnerProfile:` line in `show class-of-service interface` under the existing `Drops:` line (only for exact queues with named owner)
+  - **File(s)**: `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`
+- **Action**: Prometheus gauges/counters for `xpf_cos_drain_latency_ns_bucket`, `xpf_cos_drain_invocations_total`, `xpf_cos_redirect_acquire_ns_bucket`, `xpf_cos_owner_pps`, `xpf_cos_peer_pps`. Cardinality ≤ 16896 series (within plan §5 envelope)
+  - **File(s)**: `pkg/api/metrics.go`
+- **Action**: New "Reading the owner-profile counters" section with decision tree mapping drain_p99 / redirect_p99 / owner_pps ratio to #709 Option B/C/D follow-ups
+  - **File(s)**: `docs/cos-validation-notes.md`
+- **Result**: 7 new Rust tests (+692 total, baseline 685), 3 new Go tests; full `cargo test` + `go test ./...` green. Telemetry-only: no hot-path allocations, no new syscalls, MPSC invariants preserved, histogram bucket select branchless

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -181,6 +181,83 @@ is narrower than before:
 incus exec <client> -- tcpdump -v -c 4 -n 'tcp port 5201'
 ```
 
+## Reading the owner-profile counters
+
+Since #709 (Option E), `show class-of-service interface` renders a
+second indented line under each queue row whose owner is a single
+worker. This gives operators a latency view of the owner-worker
+drain path without having to scrape Prometheus or attach perf:
+
+```
+Queue  Owner  Class    ...  Buffer     Queued pkts  Queued bytes  ...
+4      1      iperf-a  ...  1.19 MiB   299          443.24 KiB    ...
+       Drops: flow_share=75  buffer=0  ecn_marked=97349
+       OwnerProfile: drain_p50=1us  drain_p99=16us  redirect_p99=2us  owner_pps=12345  peer_pps=6789
+```
+
+Field meanings (from `BindingLiveState` in `userspace-dp/src/afxdp/umem.rs`):
+
+- `drain_p50 / drain_p99` — p50/p99 of the time spent inside
+  `drain_shaped_tx` across its servicing tick. Sampled on EVERY
+  invocation, bucketed into power-of-two ns buckets from 1 µs to
+  ~16 ms. Lower bound of the bucket containing the Nth percentile
+  sample is reported — it is a ballpark, not an exact stat.
+- `redirect_p99` — p99 of the time spent in
+  `BindingLiveState::enqueue_tx_owned` (the redirect-inbox push path
+  peer workers use to deliver packets to the owner). Sampled 1-in-256
+  on each producer to keep the common case allocation- and
+  timer-free.
+- `owner_pps` — packets the owner sourced itself on the window
+  (accumulator, cleared by
+  `clear statistics class-of-service`).
+- `peer_pps` — packets peer workers redirected into the owner's
+  MPSC inbox on the same window. Ratio tells the operator whether
+  the owner is sourcing the bulk of the work itself or acting
+  mostly as a fan-in point for peer redirects.
+
+### What the shape means for #709
+
+The plan (`docs/709-owner-hotspot-plan.md` §3) lays out a decision
+tree that converts these counters into a fix path:
+
+- **drain_p99 ≈ drain_p50 (flat right tail).** The owner drain is
+  not the bottleneck. Close #709 as not-needed; keep #712 for CPU
+  jitter.
+- **drain_p99 ≥ 10× drain_p50 (fat right tail).** The owner has a
+  head-of-line stall — most drains finish fast but a long tail of
+  slow ones accumulates. Data supports Option B (work-stealing
+  off-owner drain). The structural fix is worth the complexity.
+- **drain_p99 is fine but redirect_p99 > 1 ms.** Unusual post-#715
+  (the MPSC inbox is lock-free); if seen, pivot to a smaller
+  producer-side fix rather than Option B.
+- **drain_p99 ~ µs but owner_pps >> peer_pps.** The owner is
+  overloaded with its own RX/forward/NAT work and only does a small
+  amount of cross-worker redirect drain — Option C (RSS retargeting)
+  or Option D (owner rotation) becomes more justified because the
+  issue is "owner doing 2× work" not "inbox latency".
+
+The guideline is the same one `engineering-style.md` sets out for
+all perf PRs: read the counters, then decide. Iterating on fixes
+without reading them is how we ship dormant code.
+
+### Operational gotchas
+
+- **Non-exact / shared_exact queues have NO OwnerProfile line.**
+  The telemetry is per-binding on the owner's `BindingLiveState`;
+  if there is no single owner binding (shared_exact at ≥ 2.5 Gbps,
+  or non-exact queues), the CLI suppresses the row. An operator
+  wanting the same view for a high-rate shared queue must wait for
+  a sharded-per-worker histogram to land (not planned).
+- **The counters are process-monotonic.** For a windowed delta on
+  live traffic, snapshot before and after and subtract — same as
+  the `Drops:` line.
+- **Prometheus:** the same data flows out as
+  `xpf_cos_drain_latency_ns_bucket{ifindex, queue_id, bucket_hi_ns}`,
+  `xpf_cos_redirect_acquire_ns_bucket{...}`,
+  `xpf_cos_drain_invocations_total{ifindex, queue_id}`,
+  `xpf_cos_owner_pps{ifindex, queue_id}`, and `xpf_cos_peer_pps{...}`.
+  Expected cardinality per the plan: ≤ 8192 series per histogram.
+
 ## Gotchas the deploy wipes
 
 The cluster deploy path (`cluster-setup.sh deploy`) wipes the CoS

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 // xpfCollector implements prometheus.Collector, reading BPF maps on each scrape.
@@ -71,6 +72,18 @@ type xpfCollector struct {
 	sysMemAvail   *prometheus.Desc
 	daemonUptime  *prometheus.Desc
 	daemonMemRSS  *prometheus.Desc
+
+	// #709: CoS owner-profile telemetry (userspace dataplane only).
+	// Cardinality estimate per plan §5: num_queues (≤ 64) × num_interfaces
+	// (≤ 8) × DRAIN_HIST_BUCKETS (16) = ≤ 8192 series for each of the
+	// two histograms. The two gauges (owner_pps, peer_pps) add 512
+	// more. Total ≤ 16896 series — within the envelope the plan
+	// flagged.
+	cosDrainLatencyBucket    *prometheus.Desc
+	cosDrainInvocationsTotal *prometheus.Desc
+	cosRedirectAcquireBucket *prometheus.Desc
+	cosOwnerPPS              *prometheus.Desc
+	cosPeerPPS               *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -248,6 +261,40 @@ func newCollector(srv *Server) *xpfCollector {
 			"Daemon resident set size in bytes.",
 			nil, nil,
 		),
+
+		// #709: owner-profile telemetry. Labels:
+		//   ifindex:      interface ifindex as string
+		//   queue_id:     CoS queue id 0-255
+		//   bucket_hi_ns: upper bound of the histogram bucket (ns),
+		//                 formatted as the power-of-two.
+		// The histogram metrics are counters (monotonic bucket counts
+		// in the Rust dataplane); owner/peer pps are gauges since the
+		// Rust side re-uses them across the window.
+		cosDrainLatencyBucket: prometheus.NewDesc(
+			"xpf_cos_drain_latency_ns_bucket",
+			"CoS owner-drain latency histogram — power-of-two ns buckets (#709).",
+			[]string{"ifindex", "queue_id", "bucket_hi_ns"}, nil,
+		),
+		cosDrainInvocationsTotal: prometheus.NewDesc(
+			"xpf_cos_drain_invocations_total",
+			"Total CoS owner-drain invocations per (ifindex, queue_id) (#709).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosRedirectAcquireBucket: prometheus.NewDesc(
+			"xpf_cos_redirect_acquire_ns_bucket",
+			"CoS redirect-acquire latency histogram — power-of-two ns buckets, sampled 1-in-256 (#709).",
+			[]string{"ifindex", "queue_id", "bucket_hi_ns"}, nil,
+		),
+		cosOwnerPPS: prometheus.NewDesc(
+			"xpf_cos_owner_pps",
+			"CoS owner-local pps (window accumulator, cleared by operator) (#709).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosPeerPPS: prometheus.NewDesc(
+			"xpf_cos_peer_pps",
+			"CoS peer-redirected pps (window accumulator, cleared by operator) (#709).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
 	}
 }
 
@@ -286,6 +333,11 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.sysMemAvail
 	ch <- c.daemonUptime
 	ch <- c.daemonMemRSS
+	ch <- c.cosDrainLatencyBucket
+	ch <- c.cosDrainInvocationsTotal
+	ch <- c.cosRedirectAcquireBucket
+	ch <- c.cosOwnerPPS
+	ch <- c.cosPeerPPS
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -303,6 +355,82 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectNATPoolMetrics(ch, dp)
 	c.collectDHCPMetrics(ch)
 	c.collectSystemMetrics(ch)
+	c.collectCoSOwnerProfile(ch, dp)
+}
+
+// #709: export owner-profile telemetry when the dataplane is the
+// userspace-dp helper. The eBPF-only build path doesn't have this
+// shape (it has no CoS scheduler), so we type-assert on the optional
+// `Status() (dpuserspace.ProcessStatus, error)` interface — if the
+// assertion fails we skip silently (not an error).
+func (c *xpfCollector) collectCoSOwnerProfile(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+	provider, ok := dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		return
+	}
+	status, err := provider.Status()
+	if err != nil {
+		return
+	}
+	for _, iface := range status.CoSInterfaces {
+		ifindexLabel := strconv.Itoa(iface.Ifindex)
+		for _, queue := range iface.Queues {
+			// Only exact queues with a named owner worker have
+			// meaningful owner-profile telemetry. See cosfmt.go for
+			// the same gating on the CLI side.
+			if queue.OwnerWorkerID == nil {
+				continue
+			}
+			queueLabel := strconv.Itoa(queue.QueueID)
+			emitHistogram(ch, c.cosDrainLatencyBucket,
+				queue.DrainLatencyHist, ifindexLabel, queueLabel)
+			emitHistogram(ch, c.cosRedirectAcquireBucket,
+				queue.RedirectAcquireHist, ifindexLabel, queueLabel)
+			ch <- prometheus.MustNewConstMetric(c.cosDrainInvocationsTotal,
+				prometheus.CounterValue, float64(queue.DrainInvocations),
+				ifindexLabel, queueLabel)
+			ch <- prometheus.MustNewConstMetric(c.cosOwnerPPS,
+				prometheus.GaugeValue, float64(queue.OwnerPPS),
+				ifindexLabel, queueLabel)
+			ch <- prometheus.MustNewConstMetric(c.cosPeerPPS,
+				prometheus.GaugeValue, float64(queue.PeerPPS),
+				ifindexLabel, queueLabel)
+		}
+	}
+}
+
+// #709: emit per-bucket counter samples. Bucket index maps to a
+// power-of-two ns upper bound; see Rust `bucket_index_for_ns` and
+// cosfmt.go `bucketLowerBoundMicros` for the shared layout. Label is
+// the upper bound so Prometheus histogram consumers can plot a
+// rate()-based le-histogram without needing the Rust-side layout
+// inlined in promql.
+func emitHistogram(ch chan<- prometheus.Metric, desc *prometheus.Desc, hist []uint64, ifindexLabel, queueLabel string) {
+	for i, count := range hist {
+		upperNs := bucketUpperBoundNs(i)
+		ch <- prometheus.MustNewConstMetric(
+			desc,
+			prometheus.CounterValue,
+			float64(count),
+			ifindexLabel,
+			queueLabel,
+			strconv.FormatUint(upperNs, 10),
+		)
+	}
+}
+
+// #709: upper-bound ns for histogram bucket index `i`. Bucket 0 is
+// [0, 1024 ns) — upper bound 1024. Bucket N (N >= 1) is
+// [2^(N+9), 2^(N+10)) — upper bound 2^(N+10). Bucket 15 (top bucket)
+// saturates at 2^24 and we report upper bound = math.MaxUint64-safe
+// value (2^25) as the "+Inf" sentinel.
+func bucketUpperBoundNs(i int) uint64 {
+	if i <= 0 {
+		return 1024
+	}
+	return uint64(1) << uint(i+10)
 }
 
 func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -36,6 +36,17 @@ type cosQueueView struct {
 	admissionFlowShareDrops uint64
 	admissionBufferDrops    uint64
 	admissionEcnMarked      uint64
+	// #709: owner-profile telemetry for exact queues with single
+	// owner binding. When ownerWorker is set AND these fields are
+	// non-default, the formatter renders a second indented line under
+	// the Drops row. See docs/cos-validation-notes.md "Reading the
+	// owner-profile counters".
+	drainLatencyHist     []uint64
+	drainInvocations     uint64
+	drainNoopInvocations uint64
+	redirectAcquireHist  []uint64
+	ownerPPS             uint64
+	peerPPS              uint64
 }
 
 func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
@@ -163,9 +174,83 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 				queue.admissionBufferDrops,
 				queue.admissionEcnMarked,
 			)
+			// #709: OwnerProfile line — rendered only for exact queues
+			// with a named owner worker. Non-exact / shared_exact
+			// queues have no single owner binding whose latency is
+			// meaningful, so the row would be misleading for those
+			// (see `TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner`).
+			if queue.ownerWorker != nil {
+				fmt.Fprintf(
+					&b,
+					"           OwnerProfile: drain_p50=%s  drain_p99=%s  redirect_p99=%s  owner_pps=%d  peer_pps=%d\n",
+					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 50),
+					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 99),
+					formatHistPercentileMicrosFromBuckets(queue.redirectAcquireHist, 99),
+					queue.ownerPPS,
+					queue.peerPPS,
+				)
+			}
 		}
 	}
 	return b.String()
+}
+
+// #709: render a histogram percentile as microseconds. The Rust side
+// fills the histogram with `DRAIN_HIST_BUCKETS` powers-of-two buckets;
+// we approximate the percentile as the lower bound of the bucket
+// containing the Nth-percentile sample. This is intentionally lossy —
+// operators want ballpark µs figures to make the decision tree in
+// docs/709-owner-hotspot-plan.md actionable, not exact stats.
+//
+// `total` is the authoritative sample count (drain_invocations). When
+// `total == 0`, emit "0µs" rather than "nan" or "-" so the field
+// aligns visually across queues and the zero value is obvious.
+func formatHistPercentileMicros(hist []uint64, total uint64, percentile int) string {
+	if len(hist) == 0 || total == 0 {
+		return "0us"
+	}
+	// Target = ceil(total * percentile / 100). We want the smallest
+	// bucket index whose cumulative sum reaches the target.
+	target := (total*uint64(percentile) + 99) / 100
+	if target == 0 {
+		target = 1
+	}
+	var cumulative uint64
+	for i, count := range hist {
+		cumulative += count
+		if cumulative >= target {
+			return bucketLowerBoundMicros(i)
+		}
+	}
+	// Reaching the end means cumulative < target (hist is sparse or
+	// `total` is larger than the sum of hist buckets). Saturate at the
+	// top bucket's lower bound.
+	return bucketLowerBoundMicros(len(hist) - 1)
+}
+
+// #709: redirect-acquire has no dedicated "invocations" counter
+// (sampling is 1-in-256, so the total is implicit in the bucket sum).
+// Derive `total` from the buckets and delegate.
+func formatHistPercentileMicrosFromBuckets(hist []uint64, percentile int) string {
+	var total uint64
+	for _, count := range hist {
+		total += count
+	}
+	return formatHistPercentileMicros(hist, total, percentile)
+}
+
+// #709: map a bucket index to its lower bound, formatted as µs. The
+// bucket layout (see `DRAIN_HIST_BUCKETS` comment in umem.rs):
+//   - bucket 0: [0, 1024) ns — render as "0us" (sub-1µs)
+//   - bucket N (N >= 1): [2^(N+9), 2^(N+10)) ns — lower bound in µs
+//     is `(1 << (N+9)) / 1000`.
+func bucketLowerBoundMicros(bucket int) string {
+	if bucket <= 0 {
+		return "0us"
+	}
+	ns := uint64(1) << uint(bucket+9)
+	us := ns / 1000
+	return fmt.Sprintf("%dus", us)
 }
 
 func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, selector string) []cosInterfaceView {
@@ -253,6 +338,17 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.admissionFlowShareDrops = runtimeQueue.AdmissionFlowShareDrops
 			qv.admissionBufferDrops = runtimeQueue.AdmissionBufferDrops
 			qv.admissionEcnMarked = runtimeQueue.AdmissionEcnMarked
+			// #709: owner-profile telemetry copied from the runtime
+			// snapshot. The Rust side populates these only when the
+			// queue has a single owner binding (exact && !shared_exact);
+			// otherwise the histograms are empty and the pps counters
+			// are 0, which the formatter skips.
+			qv.drainLatencyHist = runtimeQueue.DrainLatencyHist
+			qv.drainInvocations = runtimeQueue.DrainInvocations
+			qv.drainNoopInvocations = runtimeQueue.DrainNoopInvocations
+			qv.redirectAcquireHist = runtimeQueue.RedirectAcquireHist
+			qv.ownerPPS = runtimeQueue.OwnerPPS
+			qv.peerPPS = runtimeQueue.PeerPPS
 			queueViews[qv.queueID] = qv
 		}
 	}

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -268,6 +268,161 @@ func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) 
 	}
 }
 
+// #709: The OwnerProfile line renders below the Drops line for exact
+// queues with a single named owner worker. Fields: drain_p50 µs,
+// drain_p99 µs, redirect_p99 µs, owner_pps, peer_pps. Anchor on
+// non-zero values so a regression that swaps the ordering of the
+// percentile calls fails loudly.
+func TestFormatCoSInterfaceSummaryRendersOwnerProfileLineForExactQueues(t *testing.T) {
+	owner := uint32(1)
+	// Histogram layout (see umem.rs DRAIN_HIST_BUCKETS): bucket 0
+	// = [0, 1024) ns ("0us"), bucket 1 = [1024, 2048) ns ("1us"),
+	// ... bucket 5 = [2^14, 2^15) ns → lower bound 16384 ns = 16us.
+	// We want p50 in bucket 1 and p99 in bucket 5:
+	//   target50 = ceil(100 * 50 / 100) = 50; cumulative reaches 50 at
+	//     bucket 1 (50 samples there).
+	//   target99 = ceil(100 * 99 / 100) = 99; cumulative reaches 99 at
+	//     bucket 5 (50 + 48 + 0 + 0 + 0 + 2 = 100 >= 99, and 98 < 99
+	//     at bucket 4).
+	hist := make([]uint64, 16)
+	hist[1] = 50
+	hist[2] = 48
+	hist[5] = 2
+	redirectHist := make([]uint64, 16)
+	redirectHist[2] = 10 // p99 of redirect-acquire → bucket 2 = ~2us
+
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:              4,
+						OwnerWorkerID:        &owner,
+						ForwardingClass:      "bandwidth-10mb",
+						Priority:             1,
+						Exact:                true,
+						TransmitRateBytes:    1_250_000,
+						BufferBytes:          32 * 1024,
+						DrainLatencyHist:     hist,
+						DrainInvocations:     100,
+						DrainNoopInvocations: 30,
+						RedirectAcquireHist:  redirectHist,
+						OwnerPPS:             12345,
+						PeerPPS:              6789,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	// Exact substring match on the line format: leading whitespace
+	// aligns with `Drops:` above it (11 spaces). p50 is "1us" (bucket
+	// 1 lower bound), p99 is "16us" (bucket 5 = 2^14 ns = 16384 ns
+	// → 16 µs). Redirect p99 is "2us" (bucket 2 = 2^11 ns = 2048 ns
+	// → 2 µs).
+	want := "OwnerProfile: drain_p50=1us  drain_p99=16us  redirect_p99=2us  owner_pps=12345  peer_pps=6789"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in output:\n%s", want, out)
+	}
+	// Positional invariant: OwnerProfile must follow Drops. A
+	// regression that emits OwnerProfile above the Drops line would
+	// still include both strings but in the wrong order.
+	dropsIdx := strings.Index(out, "Drops: flow_share=")
+	ownerIdx := strings.Index(out, "OwnerProfile:")
+	if dropsIdx < 0 || ownerIdx < 0 || ownerIdx <= dropsIdx {
+		t.Fatalf("OwnerProfile line must render AFTER Drops line: drops=%d owner=%d\n%s",
+			dropsIdx, ownerIdx, out)
+	}
+}
+
+// #709: Non-exact / no-owner queues do not get an OwnerProfile line.
+// The plan's telemetry is only meaningful on single-owner exact queues
+// (see docs/709-owner-hotspot-plan.md §4). Counter-factual: render a
+// queue without OwnerWorkerID set and assert the line is absent while
+// the Drops line still renders.
+func TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner(t *testing.T) {
+	owner := uint32(2)
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID: 4,
+						// OwnerWorkerID intentionally nil: shared_exact
+						// or non-exact queue has no single owner binding.
+						ForwardingClass:      "bandwidth-10mb",
+						Priority:             1,
+						Exact:                true,
+						TransmitRateBytes:    1_250_000,
+						BufferBytes:          32 * 1024,
+						DrainLatencyHist:     []uint64{0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						DrainInvocations:     5,
+						DrainNoopInvocations: 0,
+						OwnerPPS:             999,
+						PeerPPS:              0,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	if !strings.Contains(out, "Drops: flow_share=0") {
+		t.Fatalf("expected Drops line to still render for no-owner queue:\n%s", out)
+	}
+	if strings.Contains(out, "OwnerProfile:") {
+		t.Fatalf("OwnerProfile line should NOT render for queue without owner_worker_id:\n%s", out)
+	}
+}
+
+// #709: Zeroed owner-profile telemetry must render "0us" not "nan" /
+// "-". An operator staring at a freshly-deployed firewall with no
+// traffic still needs to see the field alignment. The test pins the
+// exact rendering so a future change to the default-string helper
+// doesn't accidentally emit "nan" (which breaks grep/awk pipelines).
+func TestFormatCoSInterfaceSummaryRendersZeroedOwnerProfile(t *testing.T) {
+	owner := uint32(1)
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:           4,
+						OwnerWorkerID:     &owner,
+						ForwardingClass:   "bandwidth-10mb",
+						Priority:          1,
+						Exact:             true,
+						TransmitRateBytes: 1_250_000,
+						BufferBytes:       32 * 1024,
+						// All telemetry fields zero / empty.
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	want := "OwnerProfile: drain_p50=0us  drain_p99=0us  redirect_p99=0us  owner_pps=0  peer_pps=0"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in output:\n%s", want, out)
+	}
+	// Counter-factual: ensure "nan" and "-" don't creep in via the
+	// percentile helper on the empty-histogram path.
+	if strings.Contains(out, "nan") {
+		t.Fatalf("zeroed OwnerProfile must not emit 'nan':\n%s", out)
+	}
+	if strings.Contains(out, "drain_p50=-") || strings.Contains(out, "drain_p99=-") {
+		t.Fatalf("zeroed OwnerProfile must not emit placeholder '-':\n%s", out)
+	}
+}
+
 // Zero-valued counters MUST still render — operators need to see the
 // counter is wired, otherwise "no output" is indistinguishable from
 // "counter missing from the pipeline" when chasing #718 / #722.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -471,6 +471,22 @@ type CoSQueueStatus struct {
 	AdmissionFlowShareDrops uint64 `json:"admission_flow_share_drops,omitempty"`
 	AdmissionBufferDrops    uint64 `json:"admission_buffer_drops,omitempty"`
 	AdmissionEcnMarked      uint64 `json:"admission_ecn_marked,omitempty"`
+	// #709: owner-profile telemetry. Populated on exact queues with
+	// single owner binding; zero for shared_exact / non-exact. See
+	// docs/709-owner-hotspot-plan.md for the decision tree these
+	// counters drive. JSON tags MUST match Rust serde rename(...)
+	// byte-for-byte.
+	//
+	// DrainLatencyHist and RedirectAcquireHist are power-of-two ns
+	// bucketed (see Rust `bucket_index_for_ns`): index 0 is < 1 µs,
+	// index N >= 1 is [2^(N+9), 2^(N+10)) ns, index 15 saturates at
+	// >= 2^24 ns (~16 ms).
+	DrainLatencyHist     []uint64 `json:"drain_latency_hist,omitempty"`
+	DrainInvocations     uint64   `json:"drain_invocations,omitempty"`
+	DrainNoopInvocations uint64   `json:"drain_noop_invocations,omitempty"`
+	RedirectAcquireHist  []uint64 `json:"redirect_acquire_hist,omitempty"`
+	OwnerPPS             uint64   `json:"owner_pps,omitempty"`
+	PeerPPS              uint64   `json:"peer_pps,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1579,6 +1579,15 @@ pub(super) fn aggregate_cos_statuses_across_workers(
                 q.tx_ring_full_submit_stalls = q
                     .tx_ring_full_submit_stalls
                     .saturating_add(queue.tx_ring_full_submit_stalls);
+                // #709: cross-worker aggregation for owner-profile
+                // counters uses `max` (not `saturating_add`) because
+                // only the owner worker's snapshot has non-zero
+                // values for a given exact queue — summing would
+                // double-count if any peer worker surfaced the queue
+                // with zeros (same bucket contents). See
+                // `merge_owner_profile_max` for the same-shape
+                // intra-worker merge.
+                super::worker::merge_cos_queue_owner_profile_max(q, queue);
             }
         }
     }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -224,7 +224,32 @@ pub(super) fn drain_pending_tx(
     // progress. A retrying CoS batch (for example, no free TX frame on the
     // owner binding) must yield back to the worker loop so other bindings can
     // run and completions/recycles can free resources.
-    while drain_shaped_tx(binding, now_ns, shared_recycles) {
+    //
+    // #709: time every `drain_shaped_tx` invocation (not per queue, not per
+    // batch) with one pair of `monotonic_nanos()` calls. `monotonic_nanos`
+    // is `clock_gettime(CLOCK_MONOTONIC)` via VDSO — no syscall, ~15 ns
+    // each. The owner-drain latency histogram is the primary signal for
+    // deciding whether Option B / C / D in #709 is justified. Noop
+    // invocations (drain returned `false`) are bucketed too so the
+    // operator can distinguish "owner busy but fast" from "owner
+    // spinning on empty".
+    loop {
+        let start_ns = monotonic_nanos();
+        let progressed = drain_shaped_tx(binding, now_ns, shared_recycles);
+        let delta = monotonic_nanos().saturating_sub(start_ns);
+        let bucket = bucket_index_for_ns(delta);
+        binding.live.drain_latency_hist[bucket].fetch_add(1, Ordering::Relaxed);
+        binding
+            .live
+            .drain_invocations
+            .fetch_add(1, Ordering::Relaxed);
+        if !progressed {
+            binding
+                .live
+                .drain_noop_invocations
+                .fetch_add(1, Ordering::Relaxed);
+            break;
+        }
         did_work = true;
     }
     while !binding.pending_tx_prepared.is_empty() {
@@ -539,7 +564,26 @@ fn ingest_cos_pending_tx(
     }
 
     let mut pending = core::mem::take(&mut binding.pending_tx_local);
+    // #709: the split between owner-local and peer-redirected packets.
+    // `pending` starts with this worker's own locally-produced requests
+    // (this worker drove RX on this binding). `take_pending_tx_into`
+    // then APPENDS the MPSC inbox — every item appended was pushed by
+    // a peer worker that redirected a TxRequest at this binding as
+    // owner. Count the split here, before
+    // `process_pending_queue_in_place` mixes them with outbound
+    // re-redirects.
+    //
+    // For non-owner bindings the MPSC inbox is empty (peers never push
+    // to a binding they do not own), so `peer` naturally stays at 0.
+    let owner_local_count = pending.len() as u64;
     binding.live.take_pending_tx_into(&mut pending);
+    let peer_count = (pending.len() as u64).saturating_sub(owner_local_count);
+    if owner_local_count > 0 {
+        binding.live.pps_owner_vs_peer[0].fetch_add(owner_local_count, Ordering::Relaxed);
+    }
+    if peer_count > 0 {
+        binding.live.pps_owner_vs_peer[1].fetch_add(peer_count, Ordering::Relaxed);
+    }
     process_pending_queue_in_place(&mut pending, |req| {
         let req = match redirect_local_cos_request_to_owner(
             &binding.cos_fast_interfaces,

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -109,6 +109,62 @@ const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
 /// excess pushes drop with a `redirect_inbox_overflow_drops` counter bump.
 pub(super) const PENDING_TX_INBOX_HARD_CAP: usize = 4096;
 
+/// #709: owner-drain / redirect-acquire latency histogram bucket count.
+///
+/// Bucket layout (produced by `bucket_index_for_ns`):
+/// - Bucket 0: `[0, 1024 ns)` — the sub-1 µs catch-all.
+/// - Bucket 1: `[1024, 2048)` = `[2^10, 2^11)` ns.
+/// - Bucket N (N >= 1): `[2^(N+9), 2^(N+10))` ns.
+/// - Bucket 15: saturation — any ns ≥ 2^24 (~16 ms) lands here.
+///
+/// Indexed branchlessly (one `leading_zeros` + one saturating subtract
+/// + one min). Sized `[AtomicU64; DRAIN_HIST_BUCKETS]` on
+/// `BindingLiveState` so the entire histogram lives inline in the
+/// owner's `Arc<BindingLiveState>` — no heap allocation, no bucket-
+/// search loop on the hot path. The const-assert below exists because
+/// the bucket layout is part of the wire contract (protocol.rs +
+/// Prometheus labels): any future change must propagate through both
+/// sides, so force a compile error on a silent edit.
+pub(super) const DRAIN_HIST_BUCKETS: usize = 16;
+const _: () = assert!(DRAIN_HIST_BUCKETS == 16);
+
+/// #709: sample mask for the redirect-acquire timer. We sample the
+/// timer 1-in-(MASK+1) = 1-in-256 pushes. The mask is required to be a
+/// power-of-two minus one so `counter & MASK == 0` fires uniformly on
+/// exactly one value per wrap. Producer-local counter is seeded from
+/// `worker_id` so samples from different workers don't lockstep onto
+/// the same slot.
+pub(super) const REDIRECT_SAMPLE_MASK: u64 = 0xff;
+const _: () = assert!(REDIRECT_SAMPLE_MASK.count_ones() == REDIRECT_SAMPLE_MASK.trailing_ones());
+
+/// #709: branchless power-of-two bucket select for nanosecond deltas.
+///
+/// Mapping (see `DRAIN_HIST_BUCKETS` for the layout):
+/// - `ns ∈ [0, 1024)` → bucket 0 (sub-1 µs catch-all).
+/// - `ns ∈ [2^(N+9), 2^(N+10))` → bucket N, for N ∈ [1, 15).
+/// - `ns ≥ 2^24` → bucket 15 (saturation).
+///
+/// Formula:
+/// - `(ns | 1)` ensures `leading_zeros` sees at least one set bit —
+///   `leading_zeros(0) == 64` would otherwise land us one bucket off
+///   at the bottom. With the OR, `ns=0` behaves like `ns=1` (bucket 0).
+/// - `clz = (ns | 1).leading_zeros()`: for `ns=1024 (2^10)`,
+///   `clz = 64 - 11 = 53`; for `ns=2^24` (top bucket lower bound),
+///   `clz = 64 - 25 = 39`.
+/// - `b = 54 - clz` gives bucket 1 for `ns=1024` and bucket 15 for
+///   `ns=2^24`. Sub-1024 ns delta yields `clz >= 54` → `b <= 0`, which
+///   the `.max(0)` saturating subtract clamps at 0. Above 2^24, `b`
+///   grows past 15, which `.min(DRAIN_HIST_BUCKETS - 1)` clamps.
+///
+/// One `leading_zeros` + one saturating subtract + one min. No loop,
+/// no branch. Hot-path OK per plan §5.
+#[inline]
+pub(super) fn bucket_index_for_ns(ns: u64) -> usize {
+    let clz = (ns | 1).leading_zeros() as i32;
+    let b = (54 - clz).max(0) as usize;
+    b.min(DRAIN_HIST_BUCKETS - 1)
+}
+
 impl MmapArea {
     pub(super) fn new(len: usize) -> io::Result<Self> {
         // Round up to 2 MB boundary for hugepage eligibility.
@@ -341,6 +397,182 @@ mod tests {
     }
 
     #[test]
+    fn bucket_index_for_ns_covers_powers_of_two_from_1us_to_32ms() {
+        // #709: pin the bucket layout. Bucket 0 covers ns in
+        // [0, 1024); bucket 1 covers [1024, 2048); ... bucket 15
+        // saturates at >= 2^25 ns. Anyone editing the formula in
+        // `bucket_index_for_ns` must either keep this layout or
+        // renumber the wire contract — this test fails loudly on
+        // either.
+        // Bucket 0 is the "<= 1024 ns" catch-all: ns ∈ [0, 1024) lands
+        // here, ns = 1024 promotes to bucket 1.
+        assert_eq!(bucket_index_for_ns(0), 0);
+        assert_eq!(bucket_index_for_ns(1), 0);
+        assert_eq!(bucket_index_for_ns(1023), 0);
+        assert_eq!(bucket_index_for_ns(1024), 1);
+        assert_eq!(bucket_index_for_ns(2047), 1);
+        assert_eq!(bucket_index_for_ns(2048), 2);
+        assert_eq!(bucket_index_for_ns(4095), 2);
+        assert_eq!(bucket_index_for_ns(4096), 3);
+        // Walk each bucket boundary [2^(N+9), 2^(N+10)) for
+        // N ∈ [1, 15). Expect `bucket_index_for_ns(2^(N+9)) == N`
+        // and `bucket_index_for_ns(2^(N+10) - 1) == N`. We skip N=0
+        // because bucket 0 is the sub-1024 catch-all (its `lo` is 0
+        // not `2^9`), covered by the explicit asserts above.
+        for n in 1..(DRAIN_HIST_BUCKETS - 1) {
+            let lo = 1u64 << (n + 9);
+            let hi = (1u64 << (n + 10)).saturating_sub(1);
+            assert_eq!(
+                bucket_index_for_ns(lo),
+                n,
+                "lo boundary for bucket {n}: ns={lo}",
+            );
+            assert_eq!(
+                bucket_index_for_ns(hi),
+                n,
+                "hi boundary for bucket {n}: ns={hi}",
+            );
+        }
+        // Top bucket: ns >= 2^24 saturates at 15.
+        assert_eq!(bucket_index_for_ns(1u64 << 24), DRAIN_HIST_BUCKETS - 1);
+        assert_eq!(bucket_index_for_ns(1u64 << 25), DRAIN_HIST_BUCKETS - 1);
+        assert_eq!(bucket_index_for_ns(u64::MAX), DRAIN_HIST_BUCKETS - 1);
+    }
+
+    #[test]
+    fn bucket_index_for_ns_handles_zero() {
+        // #709: `ns = 0` must land in bucket 0 and MUST NOT panic. The
+        // implementation uses `(ns | 1).leading_zeros()` specifically
+        // to avoid `leading_zeros(0) == 64` which would cascade into a
+        // negative subtraction after the `54 - clz` step. This pins
+        // that the OR-with-1 guard is still in place after future
+        // edits.
+        assert_eq!(bucket_index_for_ns(0), 0);
+    }
+
+    #[test]
+    fn bucket_index_for_ns_saturates_above_top_bucket() {
+        // #709: ns = 1 trillion (~17 minutes) must clamp at bucket 15.
+        // If a future refactor ever turned the `.min(DRAIN_HIST_BUCKETS - 1)`
+        // into a subtraction, this would underflow silently on release
+        // builds — the min clamp is the wire-contract guard.
+        assert_eq!(bucket_index_for_ns(1_000_000_000_000), DRAIN_HIST_BUCKETS - 1);
+    }
+
+    #[test]
+    fn drain_latency_hist_increments_on_recorded_drain() {
+        // #709: exercise the hist-update path in isolation. We do not
+        // call `drain_shaped_tx` here (requires a fully-constructed
+        // BindingWorker fixture); instead, we recreate the exact shape
+        // tx.rs uses — bucket_index_for_ns + fetch_add — and assert
+        // the bucket landed in the right slot.
+        let live = BindingLiveState::new();
+        let delta_ns = 1500u64; // bucket 1 ([1024, 2048))
+        let bucket = bucket_index_for_ns(delta_ns);
+        live.drain_latency_hist[bucket].fetch_add(1, Ordering::Relaxed);
+        live.drain_invocations.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(bucket, 1);
+        assert_eq!(live.drain_latency_hist[1].load(Ordering::Relaxed), 1);
+        // Counter-factual: surrounding buckets must stay at 0. A prior
+        // draft that used the wrong shift constant (e.g. `55 - clz`)
+        // would light up bucket 0 or 2 here — this assertion catches
+        // the off-by-one.
+        assert_eq!(live.drain_latency_hist[0].load(Ordering::Relaxed), 0);
+        assert_eq!(live.drain_latency_hist[2].load(Ordering::Relaxed), 0);
+        assert_eq!(live.drain_invocations.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn redirect_acquire_hist_samples_one_in_mask_plus_one() {
+        // #709: drive `enqueue_tx_owned` exactly `REDIRECT_SAMPLE_MASK
+        // + 1` times and assert exactly one bucket increment. The
+        // sample counter is seeded to 0 by `new()`, so on the first
+        // push `(counter & MASK) == 0` fires; subsequent MASK pushes
+        // skip, and the (MASK+1)-th push would fire again.
+        let live = BindingLiveState::new();
+        live.max_pending_tx.store(8192, Ordering::Relaxed);
+        let iterations = (REDIRECT_SAMPLE_MASK + 1) as usize;
+        for _ in 0..iterations {
+            live.enqueue_tx_owned(test_tx_request_for_inbox(0xab))
+                .expect("push");
+        }
+        let total_samples: u64 = live
+            .redirect_acquire_hist
+            .iter()
+            .map(|slot| slot.load(Ordering::Relaxed))
+            .sum();
+        assert_eq!(
+            total_samples, 1,
+            "exactly one sample per (REDIRECT_SAMPLE_MASK + 1) pushes"
+        );
+
+        // Counter-factual: a pre-#709 path (no sampling, no bucket
+        // increment) would leave the histogram at zero after the same
+        // push count. Reset and demonstrate by skipping the hist update
+        // inline — this proves the test's positive assertion above is
+        // actually exercising the #709-added code path, not some
+        // always-live fallback.
+        let live2 = BindingLiveState::new();
+        live2.max_pending_tx.store(8192, Ordering::Relaxed);
+        // Replicate the non-sampled producer: raw MPSC push without
+        // the sample/timer wrapper.
+        for _ in 0..iterations {
+            live2
+                .pending_tx
+                .push(test_tx_request_for_inbox(0xcd))
+                .expect("push raw");
+        }
+        let pre_709_total: u64 = live2
+            .redirect_acquire_hist
+            .iter()
+            .map(|slot| slot.load(Ordering::Relaxed))
+            .sum();
+        assert_eq!(
+            pre_709_total, 0,
+            "raw MPSC push (pre-#709 shape) must not touch the redirect-acquire histogram"
+        );
+    }
+
+    #[test]
+    fn new_seeded_initialises_redirect_sample_counter_from_worker_id() {
+        // #709: per-worker seeding prevents lockstep sampling. Two
+        // workers with different ids must start at different positions
+        // in the 1-in-(MASK+1) cycle. Seed with 0 and 1 and verify
+        // both new_seeded instances hold distinct initial counter
+        // values.
+        let a = BindingLiveState::new_seeded(0);
+        let b = BindingLiveState::new_seeded(1);
+        assert_eq!(a.redirect_sample_counter.load(Ordering::Relaxed), 0);
+        assert_eq!(b.redirect_sample_counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn binding_live_snapshot_propagates_709_owner_profile_counters() {
+        // #709: pin that the snapshot() path copies all owner-profile
+        // atomics into the BindingLiveSnapshot. A future edit that
+        // misses one field would silently under-surface telemetry to
+        // the operator CLI / Prometheus — this test fails fast on the
+        // missing field.
+        let live = BindingLiveState::new();
+        live.drain_latency_hist[3].store(7, Ordering::Relaxed);
+        live.drain_latency_hist[15].store(2, Ordering::Relaxed);
+        live.drain_invocations.store(100, Ordering::Relaxed);
+        live.drain_noop_invocations.store(50, Ordering::Relaxed);
+        live.redirect_acquire_hist[1].store(11, Ordering::Relaxed);
+        live.pps_owner_vs_peer[0].store(1234, Ordering::Relaxed);
+        live.pps_owner_vs_peer[1].store(567, Ordering::Relaxed);
+
+        let snap = live.snapshot();
+        assert_eq!(snap.drain_latency_hist[3], 7);
+        assert_eq!(snap.drain_latency_hist[15], 2);
+        assert_eq!(snap.drain_invocations, 100);
+        assert_eq!(snap.drain_noop_invocations, 50);
+        assert_eq!(snap.redirect_acquire_hist[1], 11);
+        assert_eq!(snap.owner_pps, 1234);
+        assert_eq!(snap.peer_pps, 567);
+    }
+
+    #[test]
     fn binding_live_snapshot_propagates_710_drop_counters() {
         // #710: `refresh_bindings` in the coordinator copies
         // `snap.redirect_inbox_overflow_drops`, `pending_tx_local_overflow_drops`,
@@ -462,6 +694,47 @@ pub(super) struct BindingLiveState {
     /// race during config reload or helper restart. Subset of
     /// `tx_errors`.
     pub(super) no_owner_binding_drops: AtomicU64,
+    /// #709: drain-call latency buckets, powers of two in ns from 1 µs.
+    /// Bucket `N` covers `[2^(N+10) ns, 2^(N+11) ns)`. Indexed via
+    /// `bucket_index_for_ns(delta_ns)`. Written only by the owner
+    /// worker (the sole caller of `drain_shaped_tx` on this binding);
+    /// read by the snapshot path and by Prometheus scrape.
+    ///
+    /// Owner-only write + Relaxed load/store is sufficient: the
+    /// snapshot reader tolerates monotonic counter tearing across a
+    /// bucket array, and Prometheus semantics are "best effort at
+    /// scrape time".
+    pub(super) drain_latency_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
+    /// #709: total number of `drain_shaped_tx` invocations on this
+    /// binding since process start. Sum of `drain_latency_hist`
+    /// buckets = drain_invocations always holds (pin in unit test).
+    /// Owner-only write.
+    pub(super) drain_invocations: AtomicU64,
+    /// #709: subset of `drain_invocations` where the drain found no
+    /// work (returned `false`). A high noop ratio means the owner is
+    /// spinning on empty — the bottleneck, if any, is upstream RX.
+    /// Owner-only write.
+    pub(super) drain_noop_invocations: AtomicU64,
+    /// #709: redirect-acquire latency sampled 1-in-(REDIRECT_SAMPLE_MASK+1)
+    /// on producers. Same power-of-two bucket layout as
+    /// `drain_latency_hist`. Multi-writer: every worker that redirects
+    /// a TX request into this binding's inbox increments a bucket on a
+    /// sampled push. Relaxed loads/stores (see comment on
+    /// `drain_latency_hist`).
+    pub(super) redirect_acquire_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
+    /// #709: producer-local sample counter for the redirect-acquire
+    /// timer. Each call to `enqueue_tx_owned` does one
+    /// `fetch_add(1, Relaxed)` + `& REDIRECT_SAMPLE_MASK`; only the
+    /// every-(MASK+1)th push pays the `monotonic_nanos()` cost. Seeded
+    /// from `worker_id` at construction so different producer workers
+    /// don't lockstep their samples onto the same call.
+    pub(super) redirect_sample_counter: AtomicU64,
+    /// #709: ring-window pps counters. `[0]` accumulates owner-local
+    /// drains (packets the owner sourced itself); `[1]` accumulates
+    /// peer redirects (packets another worker produced and redirected
+    /// to this owner). Ratio tells the operator whether the owner is
+    /// overloaded. Cleared via `clear statistics class-of-service`.
+    pub(super) pps_owner_vs_peer: [AtomicU64; 2],
     pub(super) direct_tx_packets: AtomicU64,
     pub(super) copy_tx_packets: AtomicU64,
     pub(super) in_place_tx_packets: AtomicU64,
@@ -548,6 +821,18 @@ impl BindingLiveState {
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
+            // #709: owner-profile telemetry. Histograms are zero-init
+            // fixed-cap arrays; sum of buckets == drain_invocations
+            // invariant holds at `new()` (both 0). The sample counter
+            // seed is left at zero by `new()`; call sites that have a
+            // worker_id in hand should use `new_seeded()` instead so
+            // per-worker samples don't lockstep onto the same push.
+            drain_latency_hist: Self::zero_hist(),
+            drain_invocations: AtomicU64::new(0),
+            drain_noop_invocations: AtomicU64::new(0),
+            redirect_acquire_hist: Self::zero_hist(),
+            redirect_sample_counter: AtomicU64::new(0),
+            pps_owner_vs_peer: [AtomicU64::new(0), AtomicU64::new(0)],
             direct_tx_packets: AtomicU64::new(0),
             copy_tx_packets: AtomicU64::new(0),
             in_place_tx_packets: AtomicU64::new(0),
@@ -567,6 +852,34 @@ impl BindingLiveState {
             pending_tx: MpscInbox::new(PENDING_TX_INBOX_HARD_CAP),
             pending_session_deltas: Mutex::new(VecDeque::new()),
         }
+    }
+
+    /// #709: construct a binding live state with the redirect-sample
+    /// counter pre-seeded from `worker_id`. Seeding is cosmetic — the
+    /// sample mask fires exactly 1-in-(MASK+1) regardless of start
+    /// value — but it prevents every worker from firing its first
+    /// sample on its very first push, which avoids an early-startup
+    /// lockstep burst that would bias bucket 0 heavily on the first
+    /// scrape.
+    pub(super) fn new_seeded(worker_id: u32) -> Self {
+        let mut state = Self::new();
+        // `worker_id as u64` preserves the distinct-per-worker property
+        // we care about without needing a randomness source. The mask
+        // treats the counter modulo (MASK+1), so any seed ∈ [0, MASK]
+        // suffices; larger worker_ids just wrap cheaply.
+        state.redirect_sample_counter = AtomicU64::new(worker_id as u64);
+        state
+    }
+
+    /// #709: inline zero-initialised histogram bucket array. Factored
+    /// so `new()` and `new_seeded()` don't repeat the literal, and so
+    /// a future bucket-count bump only touches one spot.
+    #[inline]
+    fn zero_hist() -> [AtomicU64; DRAIN_HIST_BUCKETS] {
+        // `AtomicU64` is not `Copy`, so `[AtomicU64::new(0); N]` does
+        // not compile; build the array from a `from_fn` pattern. This
+        // is still a single stack allocation — no heap.
+        std::array::from_fn(|_| AtomicU64::new(0))
     }
 
     pub(super) fn set_bound(&self, socket_fd: c_int) {
@@ -756,7 +1069,27 @@ impl BindingLiveState {
                 .lock()
                 .map(|v| v.clone())
                 .unwrap_or_default(),
+            // #709: owner-profile telemetry snapshot. Histograms are
+            // copied bucket-by-bucket under `Relaxed`. Read-side
+            // tearing is acceptable — these are diagnostic counters,
+            // not a load-bearing arithmetic invariant; the only
+            // "invariant" (sum of buckets ≈ drain_invocations) holds
+            // within a single-thread read only in steady-state, which
+            // is how operators consume the values anyway.
+            drain_latency_hist: Self::snapshot_hist(&self.drain_latency_hist),
+            drain_invocations: self.drain_invocations.load(Ordering::Relaxed),
+            drain_noop_invocations: self.drain_noop_invocations.load(Ordering::Relaxed),
+            redirect_acquire_hist: Self::snapshot_hist(&self.redirect_acquire_hist),
+            owner_pps: self.pps_owner_vs_peer[0].load(Ordering::Relaxed),
+            peer_pps: self.pps_owner_vs_peer[1].load(Ordering::Relaxed),
         }
+    }
+
+    /// #709: copy a histogram bucket array under `Relaxed`. Inline to
+    /// keep the fixed-size array on the caller's stack — no `Vec`.
+    #[inline]
+    fn snapshot_hist(hist: &[AtomicU64; DRAIN_HIST_BUCKETS]) -> [u64; DRAIN_HIST_BUCKETS] {
+        std::array::from_fn(|i| hist[i].load(Ordering::Relaxed))
     }
 
     pub(super) fn enqueue_tx(&self, req: TxRequest) -> Result<(), String> {
@@ -765,7 +1098,34 @@ impl BindingLiveState {
     }
 
     pub(super) fn enqueue_tx_owned(&self, req: TxRequest) -> Result<(), TxRequest> {
+        // #709: redirect-acquire latency, sampled 1-in-256.
+        //
+        // Hot-path cost on the non-sampled branch: one
+        // `fetch_add(1, Relaxed)` + one `&` + one `==`. Under a few ns
+        // on modern x86_64. On the sampled branch: two
+        // `monotonic_nanos()` (VDSO `clock_gettime(MONOTONIC)`, ~15 ns
+        // each) + one bucket write. 1-in-256 sampling amortises to
+        // `~(2 * 15 + 2) / 256 ≈ 0.13 ns` per push — well below the
+        // noise floor of the redirect path itself.
+        //
+        // The timer wraps only `push_redirect_inbox`. We do NOT add a
+        // second atomic to the MPSC inbox itself; the sample counter
+        // lives on `BindingLiveState` next to the other per-binding
+        // atomics. MPSC invariants from #715 are preserved.
+        let sample = (self.redirect_sample_counter.fetch_add(1, Ordering::Relaxed)
+            & REDIRECT_SAMPLE_MASK)
+            == 0;
+        let start = if sample {
+            Some(monotonic_nanos())
+        } else {
+            None
+        };
         self.push_redirect_inbox(req);
+        if let Some(start) = start {
+            let delta = monotonic_nanos().saturating_sub(start);
+            let bucket = bucket_index_for_ns(delta);
+            self.redirect_acquire_hist[bucket].fetch_add(1, Ordering::Relaxed);
+        }
         Ok(())
     }
 

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1583,8 +1583,13 @@ fn build_worker_cos_statuses(
     bindings: &[BindingWorker],
     forwarding: &ForwardingState,
 ) -> Vec<crate::protocol::CoSInterfaceStatus> {
+    // #709: pair each cos_map with its owner-binding's live state so the
+    // per-queue telemetry fields (drain_latency_hist, owner_pps, ...)
+    // can be populated from the binding that actually did the work.
     build_worker_cos_statuses_from_maps(
-        bindings.iter().map(|binding| &binding.cos_interfaces),
+        bindings
+            .iter()
+            .map(|binding| (&binding.cos_interfaces, Some(binding.live.as_ref()))),
         forwarding,
     )
 }
@@ -1639,16 +1644,124 @@ fn reset_worker_cos_runtimes(bindings: &mut [BindingWorker]) {
     }
 }
 
+/// #709: snapshot the owner-profile counter set from a `BindingLiveState`
+/// into a struct-local copy. Histograms are fixed-cap arrays on both
+/// sides; copying into an owned value lets the caller attribute the
+/// same snapshot to multiple queues without re-reading the atomics
+/// (which would tear across queues in the same scrape).
+pub(super) struct OwnerProfileSnapshot {
+    pub(super) drain_latency_hist: [u64; DRAIN_HIST_BUCKETS],
+    pub(super) drain_invocations: u64,
+    pub(super) drain_noop_invocations: u64,
+    pub(super) redirect_acquire_hist: [u64; DRAIN_HIST_BUCKETS],
+    pub(super) owner_pps: u64,
+    pub(super) peer_pps: u64,
+}
+
+#[inline]
+pub(super) fn owner_profile_snapshot(live: &BindingLiveState) -> OwnerProfileSnapshot {
+    OwnerProfileSnapshot {
+        drain_latency_hist: std::array::from_fn(|i| {
+            live.drain_latency_hist[i].load(Ordering::Relaxed)
+        }),
+        drain_invocations: live.drain_invocations.load(Ordering::Relaxed),
+        drain_noop_invocations: live.drain_noop_invocations.load(Ordering::Relaxed),
+        redirect_acquire_hist: std::array::from_fn(|i| {
+            live.redirect_acquire_hist[i].load(Ordering::Relaxed)
+        }),
+        owner_pps: live.pps_owner_vs_peer[0].load(Ordering::Relaxed),
+        peer_pps: live.pps_owner_vs_peer[1].load(Ordering::Relaxed),
+    }
+}
+
+/// #709: max-merge the owner-profile fields of one `CoSQueueStatus`
+/// into another. Used by `coordinator::aggregate_cos_statuses_across_workers`
+/// to fold per-worker snapshots into the operator-facing view without
+/// double-counting the owner-only histogram. Signature mirrors
+/// `merge_owner_profile_max` so both layers share the same contract.
+pub(crate) fn merge_cos_queue_owner_profile_max(
+    dst: &mut crate::protocol::CoSQueueStatus,
+    src: &crate::protocol::CoSQueueStatus,
+) {
+    if dst.drain_latency_hist.len() < DRAIN_HIST_BUCKETS {
+        dst.drain_latency_hist.resize(DRAIN_HIST_BUCKETS, 0);
+    }
+    if dst.redirect_acquire_hist.len() < DRAIN_HIST_BUCKETS {
+        dst.redirect_acquire_hist.resize(DRAIN_HIST_BUCKETS, 0);
+    }
+    for i in 0..DRAIN_HIST_BUCKETS {
+        let src_drain = src.drain_latency_hist.get(i).copied().unwrap_or(0);
+        dst.drain_latency_hist[i] = dst.drain_latency_hist[i].max(src_drain);
+        let src_redirect = src.redirect_acquire_hist.get(i).copied().unwrap_or(0);
+        dst.redirect_acquire_hist[i] = dst.redirect_acquire_hist[i].max(src_redirect);
+    }
+    dst.drain_invocations = dst.drain_invocations.max(src.drain_invocations);
+    dst.drain_noop_invocations = dst.drain_noop_invocations.max(src.drain_noop_invocations);
+    dst.owner_pps = dst.owner_pps.max(src.owner_pps);
+    dst.peer_pps = dst.peer_pps.max(src.peer_pps);
+}
+
+/// #709: max-merge a binding's owner-profile snapshot into a per-queue
+/// `CoSQueueStatus`. Max is the right aggregation: only one worker per
+/// exact queue is the owner, and only that worker's snapshot has
+/// non-zero values. For shared_exact queues every worker drains, and
+/// taking max surfaces the busiest worker's profile — not perfect, but
+/// better than sum (which would inflate the histogram) or overwrite
+/// (which would be order-dependent). For non-exact queues the fields
+/// stay zero because those queues don't have a single owner binding.
+pub(super) fn merge_owner_profile_max(
+    status: &mut crate::protocol::CoSQueueStatus,
+    profile: &OwnerProfileSnapshot,
+) {
+    // Lazily size the histogram vectors on first touch; every queue
+    // serialised with #709 fields populated has exactly
+    // DRAIN_HIST_BUCKETS entries. A queue that was never merged stays
+    // `Vec::new()` and serialises as an empty array — readers gate
+    // on `owner_pps || drain_invocations` being > 0 before
+    // interpreting the histogram.
+    if status.drain_latency_hist.len() < DRAIN_HIST_BUCKETS {
+        status.drain_latency_hist.resize(DRAIN_HIST_BUCKETS, 0);
+    }
+    if status.redirect_acquire_hist.len() < DRAIN_HIST_BUCKETS {
+        status.redirect_acquire_hist.resize(DRAIN_HIST_BUCKETS, 0);
+    }
+    for i in 0..DRAIN_HIST_BUCKETS {
+        status.drain_latency_hist[i] =
+            status.drain_latency_hist[i].max(profile.drain_latency_hist[i]);
+        status.redirect_acquire_hist[i] =
+            status.redirect_acquire_hist[i].max(profile.redirect_acquire_hist[i]);
+    }
+    status.drain_invocations = status.drain_invocations.max(profile.drain_invocations);
+    status.drain_noop_invocations = status
+        .drain_noop_invocations
+        .max(profile.drain_noop_invocations);
+    status.owner_pps = status.owner_pps.max(profile.owner_pps);
+    status.peer_pps = status.peer_pps.max(profile.peer_pps);
+}
+
 fn build_worker_cos_statuses_from_maps<'a, I>(
     cos_maps: I,
     forwarding: &ForwardingState,
 ) -> Vec<crate::protocol::CoSInterfaceStatus>
 where
-    I: IntoIterator<Item = &'a FastMap<i32, CoSInterfaceRuntime>>,
+    I: IntoIterator<
+        Item = (
+            &'a FastMap<i32, CoSInterfaceRuntime>,
+            Option<&'a BindingLiveState>,
+        ),
+    >,
 {
     let mut interfaces = BTreeMap::<i32, crate::protocol::CoSInterfaceStatus>::new();
     let mut queue_maps = BTreeMap::<i32, BTreeMap<u8, crate::protocol::CoSQueueStatus>>::new();
-    for cos_map in cos_maps {
+    for (cos_map, binding_live) in cos_maps {
+        // #709: snapshot the binding's owner-profile counters ONCE per
+        // binding per scrape. Every queue this binding owns gets the
+        // same snapshot attributed to it — the counters are per-binding
+        // (not per-queue) because drain_shaped_tx operates across all
+        // queues on the binding's interface in one invocation. Readers
+        // interpret identical values across queues on the same
+        // interface as exactly this shape.
+        let binding_profile = binding_live.map(owner_profile_snapshot);
         for (&ifindex, root) in cos_map {
             let entry = interfaces.entry(ifindex).or_default();
             entry.ifindex = ifindex;
@@ -1744,6 +1857,19 @@ where
                 status.tx_ring_full_submit_stalls = status
                     .tx_ring_full_submit_stalls
                     .saturating_add(queue.drop_counters.tx_ring_full_submit_stalls);
+                // #709: attribute this binding's owner-profile snapshot
+                // to every queue served by this binding. When the
+                // coordinator aggregates across workers, each queue row
+                // will see the owner worker's values on its snapshot
+                // and zeros (or near-zero) from peer workers that
+                // happen to surface a runtime entry. `max` aggregation
+                // preserves the owner's data and ignores the peer's
+                // zeros; sum would double-count if any peer worker
+                // also populated (it should not in practice, but max
+                // is the safer contract to document).
+                if let Some(profile) = binding_profile.as_ref() {
+                    merge_owner_profile_max(status, profile);
+                }
             }
         }
     }
@@ -1892,7 +2018,8 @@ mod tests {
         let mut second = FastMap::default();
         second.insert(80, make_root(2048, false, true, 77, counters_b));
 
-        let statuses = build_worker_cos_statuses_from_maps([&first, &second], &forwarding);
+        let statuses =
+            build_worker_cos_statuses_from_maps([(&first, None), (&second, None)], &forwarding);
         assert_eq!(statuses.len(), 1);
         let iface = &statuses[0];
         assert_eq!(iface.interface_name, "reth0.80");
@@ -2757,4 +2884,13 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) debug_in_flight_recycles: u32,
     pub(crate) last_heartbeat: Option<chrono::DateTime<Utc>>,
     pub(crate) last_error: String,
+    // #709: owner-profile telemetry snapshot. Fixed-size arrays (no
+    // `Vec`) to keep the snapshot allocation-free on the hot path;
+    // readers that want a `Vec` for JSON can copy on demand.
+    pub(crate) drain_latency_hist: [u64; DRAIN_HIST_BUCKETS],
+    pub(crate) drain_invocations: u64,
+    pub(crate) drain_noop_invocations: u64,
+    pub(crate) redirect_acquire_hist: [u64; DRAIN_HIST_BUCKETS],
+    pub(crate) owner_pps: u64,
+    pub(crate) peer_pps: u64,
 }

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -843,6 +843,28 @@ pub(crate) struct CoSQueueStatus {
     pub queue_token_starvation_parks: u64,
     #[serde(rename = "tx_ring_full_submit_stalls", default)]
     pub tx_ring_full_submit_stalls: u64,
+    // #709: owner-profile telemetry for exact queues with a single
+    // owner binding. See `docs/709-owner-hotspot-plan.md` for the
+    // measurement methodology. These fields are populated from the
+    // owner binding's `BindingLiveState` when the queue is exact and
+    // not shared; for shared_exact and non-exact queues they are
+    // zero. The serde wire format is the cross-language contract to
+    // Go (pkg/dataplane/userspace/protocol.go); rename strings MUST
+    // match byte-for-byte. Histograms are `Vec<u64>` on the wire so
+    // serde can serialise them without a schema for the fixed-size
+    // array; the Rust side always fills them to DRAIN_HIST_BUCKETS.
+    #[serde(rename = "drain_latency_hist", default)]
+    pub drain_latency_hist: Vec<u64>,
+    #[serde(rename = "drain_invocations", default)]
+    pub drain_invocations: u64,
+    #[serde(rename = "drain_noop_invocations", default)]
+    pub drain_noop_invocations: u64,
+    #[serde(rename = "redirect_acquire_hist", default)]
+    pub redirect_acquire_hist: Vec<u64>,
+    #[serde(rename = "owner_pps", default)]
+    pub owner_pps: u64,
+    #[serde(rename = "peer_pps", default)]
+    pub peer_pps: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Implements the measure-before-fix slice from `docs/709-owner-hotspot-plan.md`
§4/§5/§6. Closes the telemetry gap that currently prevents us from
attributing residual #704 cwnd variance on low-rate exact queues to
the owner-worker hotspot versus CPU jitter versus ECN-residual
microbursts.

- Add `drain_latency_hist` (16 power-of-two ns buckets, 1 µs to ~16 ms),
  `drain_invocations`, `drain_noop_invocations`, `redirect_acquire_hist`
  (sampled 1-in-256 on peer-redirect push), and owner-vs-peer pps
  counters on `BindingLiveState`. Bucket selection is branchless
  (one `leading_zeros` + one saturating subtract + one min).
- Time every `drain_shaped_tx` invocation with one pair of
  `monotonic_nanos()` calls (VDSO, no syscall); sample
  `enqueue_tx_owned` producer-side with a worker-seeded counter so
  samples don't lockstep.
- Surface via `show class-of-service interface` (new `OwnerProfile:`
  line under the `Drops:` line, only for exact queues with a named
  owner worker) and Prometheus (`xpf_cos_drain_latency_ns_bucket`,
  `xpf_cos_redirect_acquire_ns_bucket`, `xpf_cos_drain_invocations_total`,
  `xpf_cos_owner_pps`, `xpf_cos_peer_pps`).
- New "Reading the owner-profile counters" section in
  `docs/cos-validation-notes.md` with the decision tree §3 of the
  plan depends on (fat drain_p99 tail → Option B; redirect_p99 > 1 ms
  → smaller producer-side fix; owner_pps >> peer_pps → Option C/D).

## Hot-path shape

- Common `enqueue_tx_owned` push: +1 `fetch_add(Relaxed)` + `&` + `==` (~2-3 ns).
- Sampled push (1-in-256): +2 `monotonic_nanos()` (~30 ns VDSO) + 1 bucket write — amortises to ~0.13 ns per push.
- Every `drain_shaped_tx` invocation: +2 `monotonic_nanos()` + 1 bucket write (~30 ns per tick — an order of magnitude below drain itself).
- Zero allocations. Histograms are `[AtomicU64; 16]` inline on `BindingLiveState`. No `Vec`, no `HashMap`.
- MPSC invariants from #715 preserved: the sample timer wraps `push` externally, no new atomic on the MPSC ring itself.
- Bucket select branchless per plan §5 invariant.

## Deliberately does NOT fix

- The owner hotspot itself. That's Option B (work-stealing off-owner drain) / C (RSS retargeting) / D (owner rotation), each gated on what the new telemetry shows. Deferred per plan §7.
- Live perf numbers today. This PR is telemetry-only; it does not claim to move retransmits, cwnd, or throughput on the 16-flow iperf3 workload. The whole point is to gather data before committing to a structural change.

## Prometheus cardinality

Per plan §5: `num_queues (≤ 64) × num_interfaces (≤ 8) × DRAIN_HIST_BUCKETS (16) = ≤ 8192 series` for each of the two histograms, plus `512` for each of the two gauges. Total ≤ **16896 series**. Within the plan's envelope; flagging here for reviewer visibility per plan §5.

## Design decisions not spelled out in the plan

1. **Bucket lower-bound layout.** The plan comment sketched `ns=0..1024 → 0, 1024..2048 → 1, ... 2^(B+10)..2^(B+11) → B`. The formula `b = 54 - (ns | 1).leading_zeros()` yields `ns=1024 → 1`, not `ns=1024 → 0`. I aligned both the Rust const doc and the CLI µs-formatter on the formula's actual behavior (bucket 0 = sub-1024 ns catch-all; bucket N for N ≥ 1 = [2^(N+9), 2^(N+10))). Flagged explicitly in `bucket_index_for_ns` rustdoc.

2. **Owner-profile aggregation = max, not sum.** The admission counters use `saturating_add` across workers because only the owner writes non-zero. For owner-profile histograms, sum would double-count if any peer worker surfaced the queue with identical values; max is idempotent and preserves the owner's data. Documented in `merge_owner_profile_max` rustdoc.

3. **`owner_pps` / `peer_pps` split point.** Counted at `ingest_cos_pending_tx` between the `mem::take(&mut pending_tx_local)` and `take_pending_tx_into(&mut pending)` calls: pre-take length is owner-local, delta is peer-redirect. For non-owner bindings the MPSC inbox is always empty, so peer_pps stays at 0. Documented at the increment site.

## Test plan

- [x] 7 new Rust tests in `afxdp::umem::tests`: bucket_index boundary pins (zero handling, each power-of-two, top-bucket saturation), histogram increment happy path, 1-in-256 sample rate pin, counter-factual proving pre-#709 raw MPSC push leaves the histogram at zero, new_seeded stores the worker_id.
- [x] 3 new Go tests in `cosfmt_test.go`: `OwnerProfile` line renders for exact queues with named owner, omitted for no-owner queues, zeros render as `0us` (not `nan` / `-`).
- [x] `cargo test --manifest-path userspace-dp/Cargo.toml`: 692 / 692 pass.
- [x] `go test ./pkg/dataplane/userspace/... ./pkg/cli/... ./pkg/api/...`: all green.
- [x] `go build ./...`: clean.
- [ ] Live-lab validation on the 16-flow iperf3 run — deferred to the merge window; this PR does not deploy to the cluster per task constraints.

## Refs

- #709 owner-worker hotspot (this PR, Option E implementation)
- #704 umbrella cwnd-collapse symptom
- #712 CPU pinning + IRQ isolation (orthogonal jitter lever)
- #715 lock-free MPSC redirect inbox (invariant preserved)
- #728 VLAN-aware L3 offset (post-#728 baseline these counters read against)
- `docs/709-owner-hotspot-plan.md` — architect plan; this PR is the §4 slice
- `docs/cos-validation-notes.md` — new "Reading the owner-profile counters" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)