### PR TITLE
Revert #734 pacing — burst cap too aggressive, doubles retrans; retry in #735

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,11 +1,5 @@
 # Action Log
 
-## 2026-04-17
-
-- **Timestamp**: 2026-04-17T17:00:00Z
-  - **Action**: Issue #708 Option B — Per-SFQ-bucket token-bucket pacing slice. Added `flow_bucket_tokens: [u64; 1024]` and `flow_bucket_last_refill_ns: [u64; 1024]` on CoSQueueRuntime, `admission_pacing_drops` counter on CoSQueueDropCounters, and a new helper `refill_cos_flow_bucket_tokens()` + `cos_flow_bucket_pacing_exceeded()` gate inline in `enqueue_cos_item`. Gate sits AFTER `apply_cos_admission_ecn_policy` to preserve #718's ECN ordering invariant. Drop-reason attribution order: flow_share > pacing > buffer. Lazy per-bucket refill strategy (O(1) hot path, 8 KB/queue overhead) vs plan §4's shared-timestamp O(1024) strategy. Added 7 Rust tests including a counter-factual pin for the ECN-ordering invariant. Extended Go cosfmt Drops line with `pacing=N` column and added `TestFormatCoSInterfaceSummaryRendersZeroPacingDropsExplicitly`. Added `xpf_cos_admission_pacing_drops_total` Prometheus counter. Updated cos-validation-notes.md decision tree with the new column.
-  - **File(s)**: userspace-dp/src/afxdp/types.rs, userspace-dp/src/afxdp/tx.rs, userspace-dp/src/afxdp/worker.rs, userspace-dp/src/afxdp/coordinator.rs, userspace-dp/src/protocol.rs, pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/cosfmt.go, pkg/dataplane/userspace/cosfmt_test.go, pkg/api/metrics.go, docs/cos-validation-notes.md
-
 ## 2026-04-03
 
 - **Timestamp**: 2026-04-03

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -10,14 +10,13 @@ mistake described in #725 or the VLAN-offset bug resolved in #728.
 
 ## How to read admission drop counters live
 
-Since #724, `show class-of-service interface` renders four per-queue
-counters on an indented `Drops:` line (the fourth, `pacing`, landed
-via #708):
+Since #724, `show class-of-service interface` renders three per-queue
+counters on an indented `Drops:` line:
 
 ```
 Queue  Owner  Class    ...  Buffer     Queued pkts  Queued bytes  ...
 4      1      iperf-a  ...  1.19 MiB   299          443.24 KiB    ...
-       Drops: flow_share=1923  buffer=0  ecn_marked=0  pacing=0
+       Drops: flow_share=1923  buffer=0  ecn_marked=0
 ```
 
 Definitions (from `CoSQueueDropCounters` in `userspace-dp/src/afxdp/types.rs`):
@@ -34,46 +33,6 @@ Definitions (from `CoSQueueDropCounters` in `userspace-dp/src/afxdp/types.rs`):
   firewall, or (c) the marker is reading the wrong byte (see #728 —
   the VLAN-offset bug made the marker dormant even with ECT(0)
   on the wire).
-- `pacing` — packets tail-dropped by the #708 per-SFQ-bucket pacing
-  gate because the bucket's token bucket had fewer tokens than the
-  packet's byte count. Sits **after** the ECN marker in the admission
-  pipeline so ECT packets above the ECN threshold get marked on the
-  previously-admitted packet AND tail-dropped here. A rising counter
-  with a steady `ecn_marked` means pacing is absorbing microbursts
-  the marker couldn't catch in time. Zero with rising `flow_share`
-  means the residual is not microburst-driven — per plan §3 that is
-  a valid "gate implemented, dormant on workload" outcome and closes
-  #708 as wontfix for the current baseline.
-
-### Interpreting `admission_pacing_drops`
-
-The pacing gate fires on flow-fair queues when the packet's target
-bucket has fewer pacing tokens than the packet's byte count. The
-refill rate is `queue.transmit_rate_bytes /
-cos_queue_prospective_active_flows()` (same denominator the per-flow
-share cap uses — centralised via #704's single-source-of-truth
-rule), clamped to a burst ceiling of `COS_FLOW_FAIR_MIN_SHARE_BYTES`
-so the gate cannot silently disable itself for a freshly-arriving
-flow. Expected signals at read time:
-
-- **Non-zero `pacing`, non-zero `ecn_marked`, low `flow_share`** —
-  pacing is doing the microburst smoothing the plan predicted. ECN
-  still carries the fairness signal on slow-timescale buildup. This
-  is the "pacing absorbing residual" shape.
-- **Zero `pacing`, unchanged `flow_share` and `ecn_marked`** — the
-  residual is not microburst-driven. Per plan §3 this is a valid
-  close-as-not-needed outcome for #708. Redirect effort to #709
-  owner-hotspot or #712 CPU jitter instead.
-- **High `pacing`, rising `flow_share`** — pacing ran out of
-  resolution and per-bucket pacing is not enough. Open the deferred
-  #708 follow-up "per-flow token-bucket pacing with deferred-admit
-  timer wheel" (plan §7 Option A).
-- **Non-zero `pacing`, zero `ecn_marked`** — ordering broke. Should
-  never happen on a config where ECT packets reach the queue; see
-  the counter-factual pin
-  `pacing_gate_after_ecn_marker_ordering` in `tx.rs` tests and
-  #728 VLAN-offset for the class of bug that previously silenced the
-  marker.
 
 Zero-valued counters are still printed. That is deliberate: an operator
 needs to see the zero to confirm the counter is wired and the drop path
@@ -140,15 +99,13 @@ When the counters show something different from the current baseline
 (see below), the pathology and the right fix may be different. The
 decision tree:
 
-| `flow_share` | `buffer` | `ecn_marked` | `pacing` | Interpretation | Likely fix |
-|---|---|---|---|---|---|
-| low (~10s/flow/30s) | 0 | high (~100k/30s) | 0 | Current post-#728 baseline with #708 dormant. ECN holds cwnd at the knee; residual drops are microburst arrivals the marker couldn't catch in time, but pacing sees no token starvation — residual is not microburst-driven. | Close #708 as implemented-dormant. Redirect to #709 owner-worker hotspot / #712 CPU pinning. |
-| low | 0 | high | ≥ 50/30s | Post-#708 "pacing absorbing microbursts". ECN carries slow-timescale fairness, pacing absorbs fast-timescale arrivals. | Stable shape — monitor `pacing` vs `flow_share` ratio; if `pacing` dominates and `flow_share` stays low, the gate is doing its job. |
-| high | low | 0 | 0 | Per-flow cap too tight; no ECN to soften it. Before concluding "endpoint doesn't negotiate ECN", run a gRPC server-side capture (see above) — #728 was this symptom caused by a VLAN-offset bug, not by the endpoint. | Confirm ECT on the wire via gRPC capture, then: fix marker if ECT present; otherwise ECN end-to-end, or relax per-flow cap. |
-| high | low | high | 0 | ECN fires but TCP still drops — ECN signal not enough, and pacing is not the bottleneck. | Lower ECN threshold, or investigate non-ECN-aware flows. |
-| low | high | any | any | Aggregate cap tripping — bufferbloat | Revisit #720 clamp; look at operator `buffer-size` setting |
-| high | low | high | high (dominant) | Pacing ran out of resolution; per-bucket pacing not enough. | Open the deferred plan §7 follow-up: "userspace-dp: per-flow token-bucket pacing with deferred-admit timer wheel" (Option A). |
-| 0 | 0 | 0 | 0 | Nothing is dropping; problem is elsewhere | Look at #709 (owner worker), #712 (CPU pinning), or network-layer loss |
+| `flow_share` | `buffer` | `ecn_marked` | Interpretation | Likely fix |
+|---|---|---|---|---|
+| low (~10s/flow/30s) | 0 | high (~100k/30s) | Current post-#728 baseline. ECN holds cwnd at the knee; residual drops are microburst arrivals the marker couldn't catch in time. | #709 owner-worker hotspot / #718 Option B CoDel for the microburst residual. |
+| high | low | 0 | Per-flow cap too tight; no ECN to soften it. Before concluding "endpoint doesn't negotiate ECN", run a gRPC server-side capture (see above) — #728 was this symptom caused by a VLAN-offset bug, not by the endpoint. | Confirm ECT on the wire via gRPC capture, then: fix marker if ECT present; otherwise ECN end-to-end, or CoDel (non-ECN AQM), or relax per-flow cap. |
+| high | low | high | ECN fires but TCP still drops — ECN signal not enough | Lower ECN threshold, or combine with rate-based pacing |
+| low | high | any | Aggregate cap tripping — bufferbloat | Revisit #720 clamp; look at operator `buffer-size` setting |
+| 0 | 0 | 0 | Nothing is dropping; problem is elsewhere | Look at #709 (owner worker), #712 (CPU pinning), or network-layer loss |
 
 ## Current dominant failure mode on this workload
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -84,11 +84,6 @@ type xpfCollector struct {
 	cosRedirectAcquireBucket *prometheus.Desc
 	cosOwnerPPS              *prometheus.Desc
 	cosPeerPPS               *prometheus.Desc
-
-	// #708: per-SFQ-bucket pacing-gate drops, per (ifindex, queue_id).
-	// Cardinality: num_queues (≤ 64) × num_interfaces (≤ 8) ≤ 512
-	// series.
-	cosAdmissionPacingDrops *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -300,20 +295,6 @@ func newCollector(srv *Server) *xpfCollector {
 			"CoS peer-redirected pps (window accumulator, cleared by operator) (#709).",
 			[]string{"ifindex", "queue_id"}, nil,
 		),
-		// #708: per-SFQ-bucket pacing-gate drops. Monotonic counter —
-		// one increment per packet tail-dropped because its target
-		// bucket had fewer pacing tokens than the packet's byte count.
-		// Sits after the ECN marker in the admission pipeline, so a
-		// rising counter with a steady `admission_ecn_marked` means
-		// pacing is absorbing microbursts the marker couldn't catch in
-		// time. Zero with rising `admission_flow_share_drops` means
-		// the residual is not microburst-driven; per plan §3 that is a
-		// valid "gate implemented, dormant on workload" outcome.
-		cosAdmissionPacingDrops: prometheus.NewDesc(
-			"xpf_cos_admission_pacing_drops_total",
-			"Packets tail-dropped by the per-SFQ-bucket pacing gate at CoS admission (#708).",
-			[]string{"ifindex", "queue_id"}, nil,
-		),
 	}
 }
 
@@ -357,7 +338,6 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.cosRedirectAcquireBucket
 	ch <- c.cosOwnerPPS
 	ch <- c.cosPeerPPS
-	ch <- c.cosAdmissionPacingDrops
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -397,21 +377,13 @@ func (c *xpfCollector) collectCoSOwnerProfile(ch chan<- prometheus.Metric, dp da
 	for _, iface := range status.CoSInterfaces {
 		ifindexLabel := strconv.Itoa(iface.Ifindex)
 		for _, queue := range iface.Queues {
-			queueLabel := strconv.Itoa(queue.QueueID)
-			// #708: pacing-gate drop counter is NOT gated on
-			// OwnerWorkerID — it applies to every flow-fair queue
-			// regardless of owner-binding shape. Emit before the
-			// owner-profile gate so shared_exact / non-exact queues
-			// still surface pacing drops.
-			ch <- prometheus.MustNewConstMetric(c.cosAdmissionPacingDrops,
-				prometheus.CounterValue, float64(queue.AdmissionPacingDrops),
-				ifindexLabel, queueLabel)
 			// Only exact queues with a named owner worker have
 			// meaningful owner-profile telemetry. See cosfmt.go for
 			// the same gating on the CLI side.
 			if queue.OwnerWorkerID == nil {
 				continue
 			}
+			queueLabel := strconv.Itoa(queue.QueueID)
 			emitHistogram(ch, c.cosDrainLatencyBucket,
 				queue.DrainLatencyHist, ifindexLabel, queueLabel)
 			emitHistogram(ch, c.cosRedirectAcquireBucket,

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -31,14 +31,11 @@ type cosQueueView struct {
 	parked          int
 	nextWakeupTick  uint64
 	surplusDeficit  uint64
-	// #710/#718/#708: admission-path counters sourced from runtime.
-	// Zero values are still rendered — operators need to see the
-	// counter exists so they can distinguish "telemetry wired but
-	// nothing dropping" from "telemetry missing".
+	// #710/#718: admission-path counters sourced from runtime. Zero values
+	// are still rendered — operators need to see the counter exists.
 	admissionFlowShareDrops uint64
 	admissionBufferDrops    uint64
 	admissionEcnMarked      uint64
-	admissionPacingDrops    uint64
 	// #709: owner-profile telemetry for exact queues with single
 	// owner binding. When ownerWorker is set AND these fields are
 	// non-default, the formatter renders a second indented line under
@@ -172,11 +169,10 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 				continue
 			}
 			queue := queues[queueIdx]
-			fmt.Fprintf(&b, "           Drops: flow_share=%d  buffer=%d  ecn_marked=%d  pacing=%d\n",
+			fmt.Fprintf(&b, "           Drops: flow_share=%d  buffer=%d  ecn_marked=%d\n",
 				queue.admissionFlowShareDrops,
 				queue.admissionBufferDrops,
 				queue.admissionEcnMarked,
-				queue.admissionPacingDrops,
 			)
 			// #709: OwnerProfile line — rendered only for exact queues
 			// with a named owner worker. Non-exact / shared_exact
@@ -342,7 +338,6 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.admissionFlowShareDrops = runtimeQueue.AdmissionFlowShareDrops
 			qv.admissionBufferDrops = runtimeQueue.AdmissionBufferDrops
 			qv.admissionEcnMarked = runtimeQueue.AdmissionEcnMarked
-			qv.admissionPacingDrops = runtimeQueue.AdmissionPacingDrops
 			// #709: owner-profile telemetry copied from the runtime
 			// snapshot. The Rust side populates these only when the
 			// queue has a single owner binding (exact && !shared_exact);

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -174,14 +174,13 @@ func TestFormatCoSInterfaceSummaryRendersAdmissionDropCounters(t *testing.T) {
 						AdmissionFlowShareDrops: 12345,
 						AdmissionBufferDrops:    0,
 						AdmissionEcnMarked:      4567,
-						AdmissionPacingDrops:    890,
 					},
 				},
 			},
 		},
 	}
 	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
-	want := "Drops: flow_share=12345  buffer=0  ecn_marked=4567  pacing=890"
+	want := "Drops: flow_share=12345  buffer=0  ecn_marked=4567"
 	if !strings.Contains(out, want) {
 		t.Fatalf("missing %q in output:\n%s", want, out)
 	}
@@ -215,7 +214,6 @@ func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) 
 						AdmissionFlowShareDrops: 11,
 						AdmissionBufferDrops:    22,
 						AdmissionEcnMarked:      33,
-						AdmissionPacingDrops:    77,
 					},
 					{
 						QueueID:                 4,
@@ -228,7 +226,6 @@ func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) 
 						AdmissionFlowShareDrops: 44,
 						AdmissionBufferDrops:    55,
 						AdmissionEcnMarked:      66,
-						AdmissionPacingDrops:    99,
 					},
 				},
 			},
@@ -247,8 +244,8 @@ func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) 
 	// (not under the next queue's). We pin that with unique counter
 	// values per queue (33 vs 66) so a misaligned interleave would be
 	// detectable.
-	q0Drops := "Drops: flow_share=11  buffer=22  ecn_marked=33  pacing=77"
-	q4Drops := "Drops: flow_share=44  buffer=55  ecn_marked=66  pacing=99"
+	q0Drops := "Drops: flow_share=11  buffer=22  ecn_marked=33"
+	q4Drops := "Drops: flow_share=44  buffer=55  ecn_marked=66"
 	// The word "best-effort" anchors queue 0's row. "bandwidth-10mb"
 	// anchors queue 4's. Both strings appear exactly once in the
 	// output (once in the data row).
@@ -449,47 +446,8 @@ func TestFormatCoSInterfaceSummaryRendersZeroAdmissionCounters(t *testing.T) {
 		},
 	}
 	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
-	want := "Drops: flow_share=0  buffer=0  ecn_marked=0  pacing=0"
+	want := "Drops: flow_share=0  buffer=0  ecn_marked=0"
 	if !strings.Contains(out, want) {
 		t.Fatalf("missing %q in output (zero-valued drops must still render):\n%s", want, out)
-	}
-}
-
-// #708: The pacing= column MUST render explicitly at zero, not be
-// omitted when zero. Same zero-visibility invariant as #724 for the
-// other admission counters: an operator looking at the Drops line on
-// a freshly-deployed firewall needs to see every column wired so they
-// can tell "pacing never fired" apart from "pacing column was dropped
-// in a rebase". Counter-factual: if the renderer ever adds a
-// `omitEmpty`-style short-circuit for zero pacing drops, this test
-// fails while the non-zero tests above keep passing.
-func TestFormatCoSInterfaceSummaryRendersZeroPacingDropsExplicitly(t *testing.T) {
-	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
-			{
-				InterfaceName:   "reth0.80",
-				OwnerWorkerID:   &owner,
-				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
-					{
-						QueueID:                 4,
-						OwnerWorkerID:           &owner,
-						ForwardingClass:         "bandwidth-10mb",
-						AdmissionFlowShareDrops: 42,
-						AdmissionBufferDrops:    17,
-						AdmissionEcnMarked:      8,
-						// AdmissionPacingDrops intentionally zero — the
-						// column must still render as "pacing=0", not
-						// be omitted.
-					},
-				},
-			},
-		},
-	}
-	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
-	want := "Drops: flow_share=42  buffer=17  ecn_marked=8  pacing=0"
-	if !strings.Contains(out, want) {
-		t.Fatalf("missing %q in output (zero pacing column must render):\n%s", want, out)
 	}
 }

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -471,12 +471,6 @@ type CoSQueueStatus struct {
 	AdmissionFlowShareDrops uint64 `json:"admission_flow_share_drops,omitempty"`
 	AdmissionBufferDrops    uint64 `json:"admission_buffer_drops,omitempty"`
 	AdmissionEcnMarked      uint64 `json:"admission_ecn_marked,omitempty"`
-	// #708: per-SFQ-bucket pacing-gate drops. See Rust
-	// `CoSQueueStatus::admission_pacing_drops` for semantics — sits
-	// after the ECN marker in the admission pipeline so a non-zero
-	// pacing count WITH a steady ECN-marked count is the expected
-	// shape on the post-#728 baseline.
-	AdmissionPacingDrops uint64 `json:"admission_pacing_drops,omitempty"`
 	// #709: owner-profile telemetry. Populated on exact queues with
 	// single owner binding; zero for shared_exact / non-exact. See
 	// docs/709-owner-hotspot-plan.md for the decision tree these

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1570,11 +1570,6 @@ pub(super) fn aggregate_cos_statuses_across_workers(
                 q.admission_ecn_marked = q
                     .admission_ecn_marked
                     .saturating_add(queue.admission_ecn_marked);
-                // #708: cross-worker aggregation for the pacing-drop
-                // counter. Same shape as the ECN-marked counter.
-                q.admission_pacing_drops = q
-                    .admission_pacing_drops
-                    .saturating_add(queue.admission_pacing_drops);
                 q.root_token_starvation_parks = q
                     .root_token_starvation_parks
                     .saturating_add(queue.root_token_starvation_parks);
@@ -2535,7 +2530,6 @@ mod tests {
                 admission_flow_share_drops: 3,
                 admission_buffer_drops: 5,
                 admission_ecn_marked: 37,
-                admission_pacing_drops: 47,
                 root_token_starvation_parks: 7,
                 queue_token_starvation_parks: 11,
                 tx_ring_full_submit_stalls: 13,
@@ -2555,7 +2549,6 @@ mod tests {
                 admission_flow_share_drops: 17,
                 admission_buffer_drops: 19,
                 admission_ecn_marked: 41,
-                admission_pacing_drops: 53,
                 root_token_starvation_parks: 23,
                 queue_token_starvation_parks: 29,
                 tx_ring_full_submit_stalls: 31,
@@ -2579,10 +2572,6 @@ mod tests {
         assert_eq!(q.admission_flow_share_drops, 3 + 17);
         assert_eq!(q.admission_buffer_drops, 5 + 19);
         assert_eq!(q.admission_ecn_marked, 37 + 41);
-        // #708: cross-worker aggregation for pacing counter. Primes
-        // chosen coprime to the other counters so re-attribution fails
-        // this assertion.
-        assert_eq!(q.admission_pacing_drops, 47 + 53);
         assert_eq!(q.root_token_starvation_parks, 7 + 23);
         assert_eq!(q.queue_token_starvation_parks, 11 + 29);
         assert_eq!(q.tx_ring_full_submit_stalls, 13 + 31);

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -2860,94 +2860,6 @@ fn apply_cos_admission_ecn_policy(
     marked
 }
 
-/// #708: burst cap for the per-SFQ-bucket pacing token bucket. Capped
-/// at `COS_FLOW_FAIR_MIN_SHARE_BYTES` (the fast-retransmit floor, 16 ×
-/// MSS) so a bucket that sat idle through a long pause can still admit
-/// a full fast-retransmit window without the gate firing. Any larger
-/// cap would effectively disable pacing for a freshly-arriving flow —
-/// it would be allowed a microburst the same size as the flow-share
-/// limit, which is exactly what #708 is trying to smooth out.
-///
-/// Compile-time constant, not operator-configurable. If operators ever
-/// need this knob, file a follow-up issue; premature knob-exposure
-/// in the scheduler's microburst layer is how #710 / #716 grew teeth.
-const COS_FLOW_BUCKET_PACING_BURST_BYTES: u64 = COS_FLOW_FAIR_MIN_SHARE_BYTES;
-
-// #708 compile-time pin: the pacing burst cap must not exceed the
-// fast-retransmit floor. If it does, the gate would drop a packet
-// during the cwnd-halving recovery window — which is exactly the TCP
-// behaviour #711 / #716 were tuned to preserve. Keep the equality so a
-// future refactor cannot silently drift the burst cap off the floor.
-const _: () = assert!(COS_FLOW_BUCKET_PACING_BURST_BYTES == COS_FLOW_FAIR_MIN_SHARE_BYTES);
-
-/// #708: refill a single SFQ-bucket's pacing token bucket using the
-/// `elapsed_ns × per_bucket_rate / 1e9` primitive from
-/// `refill_cos_tokens`, keyed off this bucket's own
-/// `flow_bucket_last_refill_ns`. Lazy per-bucket refill (vs refilling
-/// all 1024 buckets on every admission) keeps the hot path O(1).
-///
-/// Hot-path shape: one load of `last_refill_ns[bucket]`, one
-/// `saturating_sub` for elapsed, one u128 multiply + divide for added
-/// tokens, one `saturating_add`, one `.min(burst_cap)`, one store each
-/// to `flow_bucket_tokens[bucket]` and `flow_bucket_last_refill_ns[bucket]`.
-/// No branches except the fast-path short-circuits (flow_fair off,
-/// rate 0, or cold first touch).
-///
-/// First-touch semantics match `refill_cos_tokens`: when
-/// `last_refill_ns[bucket] == 0`, prime the bucket to the full burst
-/// cap so a freshly arriving flow is not starved by a cold bucket.
-#[inline]
-fn refill_cos_flow_bucket_tokens(
-    queue: &mut CoSQueueRuntime,
-    flow_bucket: usize,
-    now_ns: u64,
-) {
-    if !queue.flow_fair || queue.transmit_rate_bytes == 0 {
-        return;
-    }
-    // #704 drift guard: reuse the exact denominator
-    // `cos_queue_flow_share_limit` / `cos_flow_aware_buffer_limit` use so
-    // the pacing rate cannot drift out of lockstep with the admission
-    // caps. That class of duplication caused #704.
-    let per_bucket_rate =
-        queue.transmit_rate_bytes / cos_queue_prospective_active_flows(queue, flow_bucket).max(1);
-    let last = queue.flow_bucket_last_refill_ns[flow_bucket];
-    if last == 0 {
-        queue.flow_bucket_tokens[flow_bucket] = COS_FLOW_BUCKET_PACING_BURST_BYTES;
-        queue.flow_bucket_last_refill_ns[flow_bucket] = now_ns;
-        return;
-    }
-    if now_ns <= last {
-        return;
-    }
-    let elapsed_ns = now_ns - last;
-    let added = ((elapsed_ns as u128) * (per_bucket_rate as u128) / 1_000_000_000u128) as u64;
-    if added == 0 {
-        return;
-    }
-    queue.flow_bucket_tokens[flow_bucket] = queue.flow_bucket_tokens[flow_bucket]
-        .saturating_add(added)
-        .min(COS_FLOW_BUCKET_PACING_BURST_BYTES);
-    queue.flow_bucket_last_refill_ns[flow_bucket] = now_ns;
-}
-
-/// #708: check whether the target bucket has at least `item_len` tokens
-/// available. Returns `true` iff the gate must drop the packet (i.e.
-/// tokens < item_len). Non-flow-fair queues degenerate to `false` —
-/// the gate is disabled and admission falls through to the existing
-/// capacity-based caps.
-#[inline]
-fn cos_flow_bucket_pacing_exceeded(
-    queue: &CoSQueueRuntime,
-    flow_bucket: usize,
-    item_len: u64,
-) -> bool {
-    if !queue.flow_fair {
-        return false;
-    }
-    queue.flow_bucket_tokens[flow_bucket] < item_len
-}
-
 fn maybe_top_up_cos_root_lease(
     root: &mut CoSInterfaceRuntime,
     shared_root_lease: &SharedCoSRootLease,
@@ -3837,7 +3749,6 @@ pub(super) fn enqueue_local_into_cos(
                     prepared_req.cos_queue_id,
                     item_len,
                     CoSPendingTxItem::Prepared(prepared_req),
-                    now_ns,
                 ) {
                     Ok(()) => return Ok(()),
                     Err(CoSPendingTxItem::Prepared(prepared_req)) => {
@@ -3852,7 +3763,6 @@ pub(super) fn enqueue_local_into_cos(
                             req.cos_queue_id,
                             item_len,
                             CoSPendingTxItem::Local(req),
-                            now_ns,
                         ) {
                             Ok(()) => Ok(()),
                             Err(CoSPendingTxItem::Local(req)) => Err(req),
@@ -3889,7 +3799,6 @@ pub(super) fn enqueue_local_into_cos(
                     req.cos_queue_id,
                     item_len,
                     CoSPendingTxItem::Local(req),
-                    now_ns,
                 ) {
                     Ok(()) => Ok(()),
                     Err(CoSPendingTxItem::Local(req)) => Err(req),
@@ -3907,7 +3816,6 @@ pub(super) fn enqueue_local_into_cos(
         req.cos_queue_id,
         item_len,
         CoSPendingTxItem::Local(req),
-        now_ns,
     ) {
         Ok(()) => Ok(()),
         Err(CoSPendingTxItem::Local(req)) => Err(req),
@@ -3968,7 +3876,6 @@ fn enqueue_prepared_into_cos(
             req.cos_queue_id,
             item_len,
             CoSPendingTxItem::Prepared(req),
-            now_ns,
         ) {
             Ok(()) => return Ok(()),
             Err(CoSPendingTxItem::Prepared(req)) => return Err(req),
@@ -3991,7 +3898,6 @@ fn enqueue_prepared_into_cos(
         local_req.cos_queue_id,
         item_len,
         CoSPendingTxItem::Local(local_req),
-        now_ns,
     ) {
         Ok(()) => {
             recycle_prepared_immediately(binding, &req);
@@ -4199,8 +4105,6 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 queued_bytes: 0,
                 active_flow_buckets: 0,
                 flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-                flow_bucket_tokens: [0; COS_FLOW_FAIR_BUCKETS],
-                flow_bucket_last_refill_ns: [0; COS_FLOW_FAIR_BUCKETS],
                 flow_rr_buckets: FlowRrRing::default(),
                 flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
                 runnable: false,
@@ -4261,7 +4165,6 @@ fn enqueue_cos_item(
     requested_queue: Option<u8>,
     item_len: u64,
     mut item: CoSPendingTxItem,
-    now_ns: u64,
 ) -> Result<(), CoSPendingTxItem> {
     let mut root_became_nonempty = false;
     let (accepted, queue_id, recycle) = {
@@ -4315,15 +4218,6 @@ fn enqueue_cos_item(
         // trying to steer. `flow_bucket` is the same index the
         // per-flow admission gate keyed off, so both gates see the
         // same queue snapshot.
-        //
-        // #708 ORDERING INVARIANT (load-bearing): the pacing gate runs
-        // strictly AFTER `apply_cos_admission_ecn_policy`. If pacing
-        // ran first and dropped the packet on token exhaustion, the ECN
-        // marker would never see it — ECN would go dormant and the
-        // fairness signal (~100k marks/30s on the post-#728 baseline)
-        // would disappear. Reversing these two lines reproduces the
-        // dead-code regression pinned by
-        // `pacing_gate_after_ecn_marker_ordering`.
         let _ = apply_cos_admission_ecn_policy(
             queue,
             buffer_limit,
@@ -4333,38 +4227,18 @@ fn enqueue_cos_item(
             &mut item,
             umem,
         );
-        // #708: refill this bucket's pacing tokens based on elapsed-ns
-        // since its last refill. Lazy per-bucket strategy keeps the hot
-        // path O(1) (one bucket, not 1024) at the cost of an extra
-        // 8 KB `flow_bucket_last_refill_ns` array per queue. No-op on
-        // non-flow-fair queues — the helper short-circuits.
-        refill_cos_flow_bucket_tokens(queue, flow_bucket, now_ns);
-        let pacing_exceeded = cos_flow_bucket_pacing_exceeded(queue, flow_bucket, item_len);
-        if flow_share_exceeded || pacing_exceeded || buffer_exceeded {
-            // #710 + #708: drop-reason attribution priority is
-            // `flow_share` > `pacing` > `buffer`. flow_share is root
-            // cause for SFQ bucket saturation (original #710 rule);
-            // pacing sits above buffer because pacing IS the root
-            // cause of buffer-side microbursts on flow-fair queues —
-            // buffer overflow is a symptom of admission outrunning
-            // drain on short timescales. Reordering without a separate
-            // PR is explicitly forbidden by plan §5.
+        if flow_share_exceeded || buffer_exceeded {
+            // #710: attribute the drop to the specific admission-path
+            // reason. `flow_share_exceeded` is checked first so that
+            // when both caps trip simultaneously, the root cause
+            // (per-flow bucket saturation under SFQ collision / cap
+            // undersizing) is counted rather than the buffer cap — the
+            // buffer-cap hit is a symptom downstream of flow-share
+            // admission failing to throttle the flow.
             if flow_share_exceeded {
                 queue.drop_counters.admission_flow_share_drops = queue
                     .drop_counters
                     .admission_flow_share_drops
-                    .wrapping_add(1);
-            } else if pacing_exceeded {
-                // Drop-newest policy: the packet that failed the token
-                // check is the one dropped, not the head of the
-                // bucket. Dropping the head would evict a packet that
-                // was already close to being serviced and extend tail
-                // latency; dropping the incoming packet loses one that
-                // has travelled zero further than the sender. See
-                // engineering-style.md "drop-newest".
-                queue.drop_counters.admission_pacing_drops = queue
-                    .drop_counters
-                    .admission_pacing_drops
                     .wrapping_add(1);
             } else {
                 queue.drop_counters.admission_buffer_drops =
@@ -4376,18 +4250,6 @@ fn enqueue_cos_item(
             };
             (false, queue.queue_id, recycle)
         } else {
-            // #708: consume `item_len` tokens on admit. Saturating so a
-            // cold first admission that finds the bucket primed to the
-            // burst cap doesn't underflow even with a >burst item_len;
-            // the next admission will just re-refill. Non-flow-fair
-            // queues have `flow_bucket_tokens[0]` staying at zero —
-            // harmless because the gate short-circuits out of
-            // `cos_flow_bucket_pacing_exceeded` for those queues.
-            if queue.flow_fair {
-                queue.flow_bucket_tokens[flow_bucket] = queue
-                    .flow_bucket_tokens[flow_bucket]
-                    .saturating_sub(item_len);
-            }
             let queue_was_empty = cos_queue_is_empty(queue);
             queue.queued_bytes = queue.queued_bytes.saturating_add(item_len);
             cos_queue_push_back(queue, item);
@@ -10244,8 +10106,6 @@ mod tests {
             queued_bytes: 1500,
             active_flow_buckets: 0,
             flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_tokens: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_last_refill_ns: [0; COS_FLOW_FAIR_BUCKETS],
             flow_rr_buckets: FlowRrRing::default(),
             flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
@@ -10282,8 +10142,6 @@ mod tests {
             queued_bytes: 0,
             active_flow_buckets: 0,
             flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_tokens: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_last_refill_ns: [0; COS_FLOW_FAIR_BUCKETS],
             flow_rr_buckets: FlowRrRing::default(),
             flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
@@ -10331,8 +10189,6 @@ mod tests {
             queued_bytes: 0,
             active_flow_buckets: 0,
             flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_tokens: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_last_refill_ns: [0; COS_FLOW_FAIR_BUCKETS],
             flow_rr_buckets: FlowRrRing::default(),
             flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
             runnable: false,
@@ -11848,294 +11704,6 @@ mod tests {
         assert_eq!(
             actual_csum, expected_csum,
             "incremental checksum update must match a from-scratch recomputation",
-        );
-    }
-
-    // ---------------------------------------------------------------------
-    // #708 per-SFQ-bucket pacing gate. Admission-time rate pacing that
-    // sits after the ECN marker and before the drop-reason attribution.
-    // Tests cover: refill math at the queue fair rate, drop on token
-    // starvation, admit + decrement on sufficient tokens, ECN ordering
-    // invariant, non-flow-fair bypass, burst-cap clamping at the
-    // fast-retransmit floor, and snapshot/aggregation plumbing.
-    // ---------------------------------------------------------------------
-
-    /// Helper: flow-fair exact queue with a concrete
-    /// `transmit_rate_bytes` the pacing math can be asserted against.
-    /// 1 Gbps = 125 MB/s. With 16 active buckets the per-bucket rate
-    /// is 125 MB/s / 16 = 7.8125 MB/s, so in 1 ms the bucket earns
-    /// 7_812 bytes. Assertions below key off these exact numbers.
-    fn test_pacing_flow_fair_queue() -> CoSInterfaceRuntime {
-        let mut root = test_flow_fair_exact_queue_16_flows();
-        let queue = &mut root.queues[0];
-        queue.active_flow_buckets = 16;
-        // Pre-empty the token bucket and timestamp so the first refill
-        // is driven by elapsed_ns, not the cold-touch primer branch.
-        queue.flow_bucket_tokens[0] = 0;
-        queue.flow_bucket_last_refill_ns[0] = 0;
-        root
-    }
-
-    #[test]
-    fn pacing_gate_refills_at_queue_fair_rate() {
-        // 1 Gbps queue with 16 active buckets, target bucket
-        // non-empty so `cos_queue_prospective_active_flows` returns
-        // 16 (not 16 + 1). Per-bucket rate = 1_000_000_000 / 8 / 16
-        // = 7_812_500 bytes/sec. 1 ms elapsed → 7_812_500 ×
-        // 1_000_000 / 1_000_000_000 = 7_812 bytes. The shape of the
-        // u128 math is identical to `refill_cos_tokens`, which is
-        // how the queue/root shapers land on the same number; if it
-        // drifts, the pacing rate has desynced from the shaper and
-        // #704 has reintroduced.
-        let mut root = test_pacing_flow_fair_queue();
-        let queue = &mut root.queues[0];
-        // Populate the target bucket so `prospective_active_flows`
-        // stays at 16 (empty bucket would bump it to 17 via the
-        // "reserve headroom for a new flow" rule in
-        // `cos_queue_prospective_active_flows`). This keeps the
-        // denominator aligned with the "16 flows already established"
-        // scenario — otherwise the refill math would drift by 1 flow.
-        queue.flow_bucket_bytes[0] = 1;
-        // Seed the timestamp so elapsed_ns is deterministic.
-        queue.flow_bucket_last_refill_ns[0] = 1_000_000_000;
-        queue.flow_bucket_tokens[0] = 0;
-        let now_ns = 1_001_000_000; // exactly +1 ms
-        refill_cos_flow_bucket_tokens(queue, 0, now_ns);
-        assert_eq!(
-            queue.flow_bucket_tokens[0], 7_812,
-            "per-bucket refill must equal elapsed_ns × rate / 1e9 at 1 Gbps / 16 flows / 1 ms",
-        );
-        assert_eq!(
-            queue.flow_bucket_last_refill_ns[0], now_ns,
-            "refill must advance last_refill_ns on success",
-        );
-    }
-
-    #[test]
-    fn pacing_gate_drops_packet_when_bucket_tokens_insufficient() {
-        // Seed one bucket with 100 tokens, try to admit a 1500-byte
-        // packet. Pacing must drop it; flow-share and buffer drops
-        // must NOT increment (no double-counting). Compare against a
-        // snapshot to catch any counter re-attribution.
-        let mut root = test_pacing_flow_fair_queue();
-        let queue = &mut root.queues[0];
-        queue.flow_bucket_tokens[0] = 100;
-        // Preserve the last_refill_ns so the refill helper doesn't
-        // cold-prime the bucket to the burst cap.
-        queue.flow_bucket_last_refill_ns[0] = 1_000_000_000;
-        let item_len = 1_500u64;
-        assert!(cos_flow_bucket_pacing_exceeded(queue, 0, item_len));
-
-        // Exercise the full admission attribution in-line so the
-        // invariant "pacing drop does not bump flow_share or buffer"
-        // is regression-pinned through the branching the real
-        // `enqueue_cos_item` takes.
-        let before = snapshot_counters(queue);
-        queue.drop_counters.admission_pacing_drops = queue
-            .drop_counters
-            .admission_pacing_drops
-            .wrapping_add(1);
-        let after = snapshot_counters(queue);
-        assert_eq!(
-            after.admission_pacing_drops,
-            before.admission_pacing_drops + 1,
-        );
-        assert_eq!(after.admission_flow_share_drops, before.admission_flow_share_drops);
-        assert_eq!(after.admission_buffer_drops, before.admission_buffer_drops);
-    }
-
-    #[test]
-    fn pacing_gate_admits_packet_when_bucket_tokens_sufficient() {
-        // Seed one bucket with 10 KB of tokens, admit a 1500-byte
-        // packet. Gate must NOT fire; on admit the tokens must
-        // decrement by exactly item_len. Saturating math means a
-        // later under-full packet still lands cleanly.
-        let mut root = test_pacing_flow_fair_queue();
-        let queue = &mut root.queues[0];
-        queue.flow_bucket_tokens[0] = 10_000;
-        queue.flow_bucket_last_refill_ns[0] = 1_000_000_000;
-        let item_len = 1_500u64;
-        assert!(
-            !cos_flow_bucket_pacing_exceeded(queue, 0, item_len),
-            "10 KB of tokens must be sufficient for a 1.5 KB admission",
-        );
-        // Emulate the admit path's saturating_sub.
-        queue.flow_bucket_tokens[0] = queue.flow_bucket_tokens[0].saturating_sub(item_len);
-        assert_eq!(queue.flow_bucket_tokens[0], 10_000 - 1_500);
-    }
-
-    #[test]
-    fn pacing_gate_after_ecn_marker_ordering() {
-        // ORDERING INVARIANT #1: ECN marker runs BEFORE pacing. This
-        // pin recreates the "ECT above threshold + pacing starved"
-        // scenario end-to-end through `enqueue_cos_item`'s call order.
-        //
-        // Counter-factual (reconstructing the pre-fix formula): if we
-        // ran pacing BEFORE the marker and the packet drops on
-        // pacing, the mark counter would never bump — ECN would be
-        // dead code on this path. We reproduce that below and assert
-        // the mark counter does NOT move, proving the ordering is
-        // load-bearing.
-        let mut root = test_flow_fair_exact_queue_16_flows();
-        let queue = &mut root.queues[0];
-        queue.active_flow_buckets = 16;
-        // Drive the queue into the ECN mark zone: set the target
-        // bucket well above the per-flow ECN threshold so
-        // `apply_cos_admission_ecn_policy` will mark an ECT packet.
-        let target = 0usize;
-        let queued = seed_sixteen_flow_buckets(queue, target, 15_000);
-        queue.queued_bytes = queued;
-        let buffer_limit = cos_flow_aware_buffer_limit(queue, target);
-        // Starve the pacing bucket so the gate fires.
-        queue.flow_bucket_tokens[target] = 0;
-        queue.flow_bucket_last_refill_ns[target] = 1_000_000_000; // non-zero so refill is rate-driven, not cold-primed
-
-        let before = snapshot_counters(queue);
-
-        // Step 1 (correct order): ECN marker runs first.
-        let mut item = test_local_ipv4_item(ECN_ECT_0);
-        let umem = test_admission_umem();
-        let marked =
-            apply_cos_admission_ecn_policy(queue, buffer_limit, target, false, false, &mut item, &umem);
-        assert!(marked, "ECT packet above per-flow threshold must be marked");
-
-        // Step 2: pacing gate sees starved bucket, drops.
-        let item_len = 1_500u64;
-        // With last_refill_ns = 1_000_000_000 and now_ns = 1_000_000_001 (+1 ns),
-        // the refill adds ~0 bytes — keeps the bucket starved.
-        refill_cos_flow_bucket_tokens(queue, target, 1_000_000_001);
-        assert!(cos_flow_bucket_pacing_exceeded(queue, target, item_len));
-        queue.drop_counters.admission_pacing_drops = queue
-            .drop_counters
-            .admission_pacing_drops
-            .wrapping_add(1);
-
-        let after = snapshot_counters(queue);
-        assert_eq!(
-            after.admission_ecn_marked,
-            before.admission_ecn_marked + 1,
-            "ECN marker must fire BEFORE pacing — reversing the order makes ECN dead code on this path",
-        );
-        assert_eq!(
-            after.admission_pacing_drops,
-            before.admission_pacing_drops + 1,
-            "pacing counter must bump on token-starved drop",
-        );
-
-        // --------- Counter-factual pin ---------
-        // Reconstruct the REVERSED order: pacing-drop-first, marker
-        // never runs on the dropped packet. Assert that in that
-        // (broken) ordering the mark counter would NOT have moved,
-        // which is exactly why #708 invariant #1 insists on the
-        // marker running first.
-        let mut root_rev = test_flow_fair_exact_queue_16_flows();
-        let queue_rev = &mut root_rev.queues[0];
-        queue_rev.active_flow_buckets = 16;
-        let queued_rev = seed_sixteen_flow_buckets(queue_rev, target, 15_000);
-        queue_rev.queued_bytes = queued_rev;
-        queue_rev.flow_bucket_tokens[target] = 0;
-        queue_rev.flow_bucket_last_refill_ns[target] = 1_000_000_000;
-        let before_rev = snapshot_counters(queue_rev);
-
-        // Pretend we ran pacing first and dropped — do NOT call the
-        // marker afterwards. In the real (correct) wiring the marker
-        // runs first and the counter bumps; in this counter-factual
-        // it does not.
-        queue_rev.drop_counters.admission_pacing_drops = queue_rev
-            .drop_counters
-            .admission_pacing_drops
-            .wrapping_add(1);
-
-        let after_rev = snapshot_counters(queue_rev);
-        assert_eq!(
-            after_rev.admission_ecn_marked, before_rev.admission_ecn_marked,
-            "counter-factual: pacing-before-marker leaves ECN counter at zero, proving ECN becomes dead code",
-        );
-    }
-
-    #[test]
-    fn pacing_gate_bypassed_on_non_flow_fair_queue() {
-        // flow_fair=false queues must short-circuit out of the pacing
-        // gate. Seed tokens=0 and assert the gate returns false
-        // (would-admit) regardless of item_len. Also assert that
-        // `refill_cos_flow_bucket_tokens` is a no-op on the non-flow-
-        // fair path — the tokens array must stay zero.
-        let mut root = test_cos_runtime_with_exact(true); // flow_fair defaults to false here
-        let queue = &mut root.queues[0];
-        assert!(!queue.flow_fair, "test fixture must start with flow_fair=false");
-        queue.flow_bucket_tokens[0] = 0;
-        queue.flow_bucket_last_refill_ns[0] = 0;
-
-        assert!(
-            !cos_flow_bucket_pacing_exceeded(queue, 0, 64 * 1024),
-            "non-flow-fair queue must bypass the pacing gate",
-        );
-        // Also assert the refill is a no-op on non-flow-fair.
-        refill_cos_flow_bucket_tokens(queue, 0, 1_000_000_000);
-        assert_eq!(
-            queue.flow_bucket_tokens[0], 0,
-            "refill must not touch tokens on a non-flow-fair queue",
-        );
-        assert_eq!(
-            queue.flow_bucket_last_refill_ns[0], 0,
-            "refill must not touch last_refill_ns on a non-flow-fair queue",
-        );
-    }
-
-    #[test]
-    fn pacing_burst_cap_at_fast_retransmit_floor() {
-        // A bucket that sat idle across a large elapsed_ns should NOT
-        // accumulate tokens past `COS_FLOW_BUCKET_PACING_BURST_BYTES`
-        // (= COS_FLOW_FAIR_MIN_SHARE_BYTES = 24 000). This is what
-        // prevents the gate from effectively disabling itself on a
-        // freshly-arriving flow.
-        let mut root = test_pacing_flow_fair_queue();
-        let queue = &mut root.queues[0];
-        queue.flow_bucket_last_refill_ns[0] = 1;
-        queue.flow_bucket_tokens[0] = 0;
-        // 10 seconds elapsed at 7_812_500 B/s = 78 MB of "potential"
-        // refill. Must clamp to 24 KB.
-        let now_ns = 10_000_000_001u64;
-        refill_cos_flow_bucket_tokens(queue, 0, now_ns);
-        assert_eq!(
-            queue.flow_bucket_tokens[0], COS_FLOW_BUCKET_PACING_BURST_BYTES,
-            "burst cap must clamp to fast-retransmit floor",
-        );
-        assert_eq!(
-            COS_FLOW_BUCKET_PACING_BURST_BYTES, COS_FLOW_FAIR_MIN_SHARE_BYTES,
-            "burst cap must equal the fast-retransmit floor — drift here couples with TCP recovery window",
-        );
-    }
-
-    #[test]
-    fn admission_pacing_drops_snapshot_propagates_to_status() {
-        // Mirror of `admission_ecn_marked_counter_snapshot` pattern:
-        // bump the drop counter on the runtime, build the worker-side
-        // CoS status view, and assert the new field reached the
-        // operator-facing struct. Without this pin a refactor that
-        // adds the counter to the runtime but forgets the aggregation
-        // path would leave CLI + Prometheus showing zero while the
-        // runtime counter ticks.
-        //
-        // The plumbing is exercised via direct assignment on the
-        // drop_counters struct + a manual build of the status; the
-        // real path goes
-        // `CoSQueueDropCounters → worker::build_worker_cos_statuses →
-        // coordinator::aggregate_cos_statuses_across_workers`, both
-        // layers of which are pinned by the existing `admission_ecn`
-        // aggregation tests (now extended to cover pacing).
-        let mut root = test_pacing_flow_fair_queue();
-        let queue = &mut root.queues[0];
-        let before = snapshot_counters(queue);
-        queue.drop_counters.admission_pacing_drops = queue
-            .drop_counters
-            .admission_pacing_drops
-            .wrapping_add(17);
-        let after = snapshot_counters(queue);
-        assert_eq!(
-            after.admission_pacing_drops,
-            before.admission_pacing_drops + 17,
-            "drop_counters.admission_pacing_drops must be single-writer incrementable",
         );
     }
 }

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -618,20 +618,6 @@ pub(super) const COS_FLOW_FAIR_BUCKETS: usize = 1024;
 const _: () = assert!(COS_FLOW_FAIR_BUCKETS.is_power_of_two());
 const _: () = assert!(COS_FLOW_FAIR_BUCKETS <= u16::MAX as usize);
 
-// #708: the pacing gate indexes `flow_bucket_tokens` /
-// `flow_bucket_last_refill_ns` with the same bucket id that indexes
-// `flow_bucket_bytes`. A refactor that changed one array length without
-// the others would silently desync the gate. Pin all three to the same
-// constant at build time.
-const _: () = assert!({
-    let _bytes: [u64; COS_FLOW_FAIR_BUCKETS] = [0; COS_FLOW_FAIR_BUCKETS];
-    let _tokens: [u64; COS_FLOW_FAIR_BUCKETS] = [0; COS_FLOW_FAIR_BUCKETS];
-    let _refill: [u64; COS_FLOW_FAIR_BUCKETS] = [0; COS_FLOW_FAIR_BUCKETS];
-    COS_FLOW_FAIR_BUCKETS == _bytes.len()
-        && _bytes.len() == _tokens.len()
-        && _tokens.len() == _refill.len()
-});
-
 /// Pre-computed mask for `COS_FLOW_FAIR_BUCKETS`-modulo on the hot
 /// path. Using a mask (rather than `%`) gives deterministic codegen
 /// independent of the optimizer proving the power-of-two property at
@@ -995,22 +981,6 @@ pub(super) struct CoSQueueRuntime {
     pub(super) queued_bytes: u64,
     pub(super) active_flow_buckets: u16,
     pub(super) flow_bucket_bytes: [u64; COS_FLOW_FAIR_BUCKETS],
-    /// #708: per-SFQ-bucket token-bucket for enqueue-side pacing. Lives
-    /// alongside `flow_bucket_bytes` so the admission gate keys off the
-    /// same index with no extra hash. Bytes, not packets — same unit
-    /// `transmit_rate_bytes` is in so the refill primitive from
-    /// `refill_cos_tokens` reuses without a conversion. Initialised to 0;
-    /// the first admission on an empty queue primes the bucket via
-    /// `refill_cos_flow_bucket_tokens`. Cold on non-flow-fair queues
-    /// (the gate short-circuits on `!queue.flow_fair`).
-    pub(super) flow_bucket_tokens: [u64; COS_FLOW_FAIR_BUCKETS],
-    /// #708: per-bucket monotonic ns timestamp of the last refill. One
-    /// u64 per bucket so the pacing gate does O(1) work on admission
-    /// (refill only the target bucket) rather than O(1024) scanning
-    /// every bucket on every admission. Costs 8 KB per queue versus
-    /// the `single shared last_refill_ns` that plan §4 originally
-    /// scoped; accepted in exchange for hot-path O(1) refill.
-    pub(super) flow_bucket_last_refill_ns: [u64; COS_FLOW_FAIR_BUCKETS],
     pub(super) flow_rr_buckets: FlowRrRing,
     pub(super) flow_bucket_items: [VecDeque<CoSPendingTxItem>; COS_FLOW_FAIR_BUCKETS],
     pub(super) runnable: bool,
@@ -1047,19 +1017,6 @@ pub(super) struct CoSQueueDropCounters {
     /// path and are counted under the respective drop-reason field.
     /// See #718.
     pub(super) admission_ecn_marked: u64,
-    /// #708: packets tail-dropped because the per-SFQ-bucket pacing
-    /// token bucket had fewer tokens than the packet's byte count. Sits
-    /// *after* the ECN marker in `enqueue_cos_item` so that ECT packets
-    /// above the mark threshold get marked on the previously-admitted
-    /// packet AND tail-dropped here — the sender sees consistent
-    /// signals (CE mark + tail drop) rather than pacing silencing the
-    /// ECN path. Counter-factual: put pacing before the marker and ECN
-    /// becomes dead code. The gate is engaged only on `flow_fair=true`
-    /// queues; non-flow-fair queues bypass with zero tokens accounted.
-    /// Distinct from `admission_flow_share_drops` /
-    /// `admission_buffer_drops` — those count capacity caps, this
-    /// counts rate pacing.
-    pub(super) admission_pacing_drops: u64,
     /// Queue parked because the interface shaping-rate token bucket is
     /// empty. Not a drop — the queue will be woken on timer-wheel tick.
     /// High count relative to serviced-batches indicates the root

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1848,11 +1848,6 @@ where
                 status.admission_ecn_marked = status
                     .admission_ecn_marked
                     .saturating_add(queue.drop_counters.admission_ecn_marked);
-                // #708: aggregate pacing-drop counter across workers.
-                // Same shape as `admission_ecn_marked`.
-                status.admission_pacing_drops = status
-                    .admission_pacing_drops
-                    .saturating_add(queue.drop_counters.admission_pacing_drops);
                 status.root_token_starvation_parks = status
                     .root_token_starvation_parks
                     .saturating_add(queue.drop_counters.root_token_starvation_parks);
@@ -1978,8 +1973,6 @@ mod tests {
                     queued_bytes,
                     active_flow_buckets: 0,
                     flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-                    flow_bucket_tokens: [0; COS_FLOW_FAIR_BUCKETS],
-                    flow_bucket_last_refill_ns: [0; COS_FLOW_FAIR_BUCKETS],
                     flow_rr_buckets: FlowRrRing::default(),
                     flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
                     runnable,
@@ -2007,7 +2000,6 @@ mod tests {
             admission_flow_share_drops: 3,
             admission_buffer_drops: 1,
             admission_ecn_marked: 37,
-            admission_pacing_drops: 47,
             root_token_starvation_parks: 5,
             queue_token_starvation_parks: 7,
             tx_ring_full_submit_stalls: 11,
@@ -2016,7 +2008,6 @@ mod tests {
             admission_flow_share_drops: 13,
             admission_buffer_drops: 17,
             admission_ecn_marked: 41,
-            admission_pacing_drops: 53,
             root_token_starvation_parks: 19,
             queue_token_starvation_parks: 23,
             tx_ring_full_submit_stalls: 29,
@@ -2052,11 +2043,6 @@ mod tests {
         assert_eq!(queue.admission_flow_share_drops, 3 + 13);
         assert_eq!(queue.admission_buffer_drops, 1 + 17);
         assert_eq!(queue.admission_ecn_marked, 37 + 41);
-        // #708: pacing counter follows the same cross-worker aggregation
-        // shape as the ECN counter. Non-coprime-prime values on either
-        // side so re-attribution to a neighbouring counter would fail
-        // this assertion.
-        assert_eq!(queue.admission_pacing_drops, 47 + 53);
         assert_eq!(queue.root_token_starvation_parks, 5 + 19);
         assert_eq!(queue.queue_token_starvation_parks, 7 + 23);
         assert_eq!(queue.tx_ring_full_submit_stalls, 11 + 29);

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -837,19 +837,6 @@ pub(crate) struct CoSQueueStatus {
     /// per-queue retrans rates fall while this increments.
     #[serde(rename = "admission_ecn_marked", default)]
     pub admission_ecn_marked: u64,
-    /// #708: packets tail-dropped by the per-SFQ-bucket pacing gate
-    /// because the target bucket had fewer pacing tokens than the
-    /// packet's byte count. Sits *after* the ECN marker in
-    /// `enqueue_cos_item` so ECT packets above the ECN threshold get
-    /// marked on the previously-admitted packet AND tail-dropped
-    /// here — consistent signals for the sender. A non-zero value
-    /// with a steady `admission_ecn_marked` means pacing is absorbing
-    /// microbursts the ECN marker couldn't catch in time.
-    /// Zero with a steady `admission_flow_share_drops` means the
-    /// residual is not microburst-driven; per plan §3 that is a valid
-    /// "gate implemented, dormant on workload" outcome.
-    #[serde(rename = "admission_pacing_drops", default)]
-    pub admission_pacing_drops: u64,
     #[serde(rename = "root_token_starvation_parks", default)]
     pub root_token_starvation_parks: u64,
     #[serde(rename = "queue_token_starvation_parks", default)]


### PR DESCRIPTION
## Why revert

Live validation of #734 on the 16-flow / 1 Gbps exact queue workload showed net regression on the primary jitter metrics:

| Metric | pre-#708 | post-#708 | Δ |
|---|---|---|---|
| `flow_share_drops` / 30s | 75–156 | **0** | −100% |
| `ecn_marked` / 30s | 97–101 k | 27 k | −73% |
| `admission_pacing_drops` / 30s | — | **23 k** (firing heavily) | new |
| iperf3 retransmits / 30s | 114–136 k | **260 k** | **+100%** |
| Rate ratio | 1.24–1.28× | **1.55×** | degraded |

Pacing absorbed all flow-share drops (good), but converted ECN marks into tail-drops (bad), doubling sender-side retrans.

## Root cause

Architect plan §5 chose burst cap = `COS_FLOW_FAIR_MIN_SHARE_BYTES = 24 KB` (the fast-retransmit floor). TCP cubic at steady state runs cwnd > 24 KB routinely during burst transmission — normal behaviour, not a microburst. Pacing drops those legitimate bursts.

The ordering invariant ("ECN first, pacing second") prevents ECN becoming dead code but doesn't protect against a marked packet ALSO being dropped by pacing on a later admission: sender sees CE + drop, weights the drop heavier, ECN's smooth-backoff benefit is lost.

## Next step

Retry tracked in #735 with burst cap = `share_cap` (~76 KB at 16 flows on 1 Gbps) instead of `MIN_SHARE_BYTES` (24 KB). Expected to keep the flow_share-drops improvement while not converting ECN signals into drops. Re-measure before re-merging.

## Test plan

- [x] `cargo test` — 692 green (same as pre-#734).
- [x] `go test ./pkg/dataplane/userspace/...` — green.
- [ ] Re-deploy + re-validate post-revert restores 1.24× ratio / 114k retrans.

Refs: #708, #734, #735, #733 (plan that needs a §5 update before retry).