### PR TITLE
test/incus: pin xpfd workers to dedicated CPUs (#712 Option A)

### DIFF
--- a/docs/712-cpu-pinning-recipe.md
+++ b/docs/712-cpu-pinning-recipe.md
@@ -1,0 +1,204 @@
+# CPU pinning + IRQ isolation recipe for xpfd (#712 Option A)
+
+This doc is operator-facing. It describes the CPU layout xpfd expects on
+hosts of 2, 4, 6, and 8+ cores — specifically which CPUs carry NIC
+hardware interrupts, which carry kernel housekeeping, and which run the
+userspace-dp workers. It also spells out what is **not** in the recipe:
+those are either deferred to a separate option in #712 or out of scope.
+
+Read `docs/cos-validation-notes.md` §"CPU pinning layout for the loss
+lab" before applying this recipe — the loss userspace lab measurement
+found that `CPUAffinity=` alone is a no-op on that hardware because
+userspace-dp re-pins its workers internally. The recipe below is
+written assuming that ceiling is eventually lifted (either by Option B
+kernel cmdline, by a cgroup cpuset under Option D, or by a worker-pin
+fix in #742). Until then, treat the recipe as design intent rather than
+as something to cargo-cult onto a running firewall.
+
+## What the recipe covers
+
+| Layer | Where it is set | Knob |
+|---|---|---|
+| xpfd systemd unit CPU mask | `test/incus/xpfd.service` `[Service] CPUAffinity=` | Moves Go main + dp auxiliary threads off the NIC-IRQ CPUs. Does **not** move userspace-dp workers today. |
+| NIC IRQ affinity | `/proc/irq/<n>/smp_affinity_list` at boot | Writes `0` (or `0-1`) into every mlx5/virtio-net completion IRQ so the kernel does not deliver them to worker CPUs. |
+| Housekeeping CPU set | Implicit: the complement of `CPUAffinity=` | `ksoftirqd`, `kworker`, `chrony`, `sshd`, `systemd-journald`, and most other non-xpfd processes remain free to use the non-worker CPUs. |
+
+## What the recipe does NOT cover
+
+The following are **explicitly out of scope** for the recipe and belong
+to either later options in #712 or to a future follow-up issue. Do not
+add them as a "while we're here" change.
+
+- `isolcpus=`, `nohz_full=`, `rcu_nocbs=` on the kernel cmdline. That is
+  Option B (#712 retry or follow-up). It requires a kernel cmdline
+  change and a reboot, so deployment shape has to be opted in.
+- `SCHED_FIFO` / `chrt` on worker threads. That is Option C. It needs a
+  watchdog story before it is safe to ship.
+- cgroup v2 `cpuset.cpus` / `cpu.max`. That is Option D. Softer than
+  isolcpus but still needs a deployment decision about which cpuset
+  holds which process.
+- `ethtool --set-rxfh-indir …` or `ethtool -L` to reshape RSS. That is
+  orthogonal and affects where NIC IRQs fire on the hot path. Worth a
+  separate issue if the NIC-IRQ → worker-CPU collision matters after
+  Option A / B / D lands.
+
+If you think you need one of these levers to make Option A stick, file
+a new issue and cite this doc. Don't silently widen scope.
+
+## Layout per CPU budget
+
+The constants in the "Used by" column match the current userspace-dp
+default (`--workers 4`, see `test/incus/cluster-setup.sh` → each VM
+launches xpf-userspace-dp with 4 workers). Adjust if you change
+`--workers`.
+
+### 2-core host
+
+Does not fit the recipe. xpfd needs at least one CPU for its Go
+controller and one for the dataplane worker; reserving even one CPU for
+IRQ + housekeeping leaves zero for the worker. Run without pinning and
+accept the jitter. Consider scaling the host up.
+
+### 4-core host (CPUs 0..3)
+
+| CPU | Role | Who runs there |
+|---|---|---|
+| 0 | NIC IRQ + housekeeping | mlx5/virtio-net completion IRQs, `ksoftirqd/0`, `kworker/0:*`, systemd, journal, chrony |
+| 1 | xpfd control plane | Go daemon main + ancillary goroutines (config reader, gRPC, CLI), xpf-userspace-dp aux threads (state-writer, event-stream, slowpath, neigh-monitor) |
+| 2 | dp worker 0 | `xpf-userspace-w0` |
+| 3 | dp worker 1 | `xpf-userspace-w1` |
+
+With 4 userspace-dp workers, two workers share CPUs 2-3. Set
+`--workers 2` if the hot-path latency of sharing a CPU is worse than
+parallelism lost.
+
+Unit directive:
+```
+CPUAffinity=1 2 3
+```
+
+IRQ pin (run at boot or via `ExecStartPre=`):
+```
+for irq in $(grep -E 'mlx|virtio.*-input|virtio.*-output' /proc/interrupts | awk -F: '{print $1}'); do
+  echo 0 > /proc/irq/$irq/smp_affinity_list
+done
+```
+
+### 6-core host (CPUs 0..5) — the loss userspace lab
+
+| CPU | Role | Who runs there |
+|---|---|---|
+| 0 | NIC IRQ + housekeeping | Heaviest mlx5_comp* RX IRQ (comp0 at ~800 M over the run); ksoftirqd/0 |
+| 1 | NIC IRQ + housekeeping | Second-heaviest mlx5 comp IRQ (comp1 at ~900 M); ksoftirqd/1; chrony; systemd |
+| 2 | xpfd control + worker 0 | xpfd Go main + aux; `xpf-userspace-w0` |
+| 3 | worker 1 | `xpf-userspace-w1` |
+| 4 | worker 2 | `xpf-userspace-w2` |
+| 5 | worker 3 | `xpf-userspace-w3` |
+
+Unit directive:
+```
+CPUAffinity=2 3 4 5
+```
+
+IRQ pin at boot: pin NIC completion IRQs to CPUs 0-1:
+```
+for irq in $(grep -E 'mlx|virtio.*-input|virtio.*-output' /proc/interrupts | awk -F: '{print $1}'); do
+  echo 0-1 > /proc/irq/$irq/smp_affinity_list
+done
+```
+
+**Measured effect on the loss lab:** no-op, see
+`cos-validation-notes.md` §"CPU pinning layout for the loss lab". The
+recipe is the right layout for the hardware; the userspace-dp worker-pin
+logic needs to honour the inherited affinity (new follow-up issue) or
+the kernel cmdline needs isolcpus (Option B, also a follow-up) before
+the layout lands as a win.
+
+### 8-core host (CPUs 0..7)
+
+| CPU | Role | Who runs there |
+|---|---|---|
+| 0-1 | NIC IRQ + housekeeping | All mlx5/virtio completion IRQs; ksoftirqd/0-1; systemd; chrony |
+| 2 | xpfd control plane | Go daemon main + gRPC + dp aux threads |
+| 3 | reserve / BGP | BGP / FRR / DHCP listener; no hot-path worker |
+| 4-7 | dp workers 0-3 | One worker per CPU, 1:1 |
+
+Unit directive:
+```
+CPUAffinity=2 3 4 5 6 7
+```
+
+IRQ pin at boot:
+```
+for irq in $(grep -E 'mlx|virtio.*-input|virtio.*-output' /proc/interrupts | awk -F: '{print $1}'); do
+  echo 0-1 > /proc/irq/$irq/smp_affinity_list
+done
+```
+
+## Verification
+
+After applying the recipe, verify the mask made it through systemd:
+
+```
+# Process-level affinity mask (hex: 0x3c = CPUs 2-5, 0xfc = CPUs 2-7)
+taskset -p $(pgrep -x xpfd)
+taskset -p $(pgrep -f xpf-userspace-dp)
+
+# Per-thread allowed CPU list
+for tid in $(ls /proc/$(pgrep -f xpf-userspace-dp | head -1)/task); do
+  comm=$(cat /proc/$(pgrep -f xpf-userspace-dp | head -1)/task/$tid/comm)
+  aff=$(awk '/Cpus_allowed_list/ {print $2}' \
+            /proc/$(pgrep -f xpf-userspace-dp | head -1)/task/$tid/status)
+  echo "  $tid $comm cpus_allowed=$aff"
+done
+
+# Which CPU each thread is currently executing on
+ps -eTo pid,tid,comm,psr,pcpu | grep -E 'xpfd|xpf-userspace|ksoftirq'
+
+# NIC IRQ → CPU map
+grep -E 'mlx|virtio.*input|virtio.*output' /proc/interrupts
+```
+
+Expected after a fresh apply on a 6-core host:
+- `taskset -p` of xpfd → mask `0x3c` (CPUs 2-5)
+- Per-thread `cpus_allowed`: all xpfd + dp aux threads show `2-5`
+- Per-thread `cpus_allowed` for `xpf-userspace-w[0-3]`: **today** shows
+  `0 / 1 / 2 / 3` because of the worker-pin logic in
+  `userspace-dp/src/afxdp/neighbor.rs::pin_current_thread()`. After that
+  logic is fixed, expect `2 / 3 / 4 / 5`.
+- `psr` under load: non-worker threads on 2-5; workers on 0-3 today, on
+  2-5 after the fix.
+
+## Known blocker: worker-pin logic overrides systemd CPUAffinity
+
+`pin_current_thread(worker_id)` in
+`userspace-dp/src/afxdp/neighbor.rs` calls
+`sched_setaffinity(0, … CPU_SET(worker_id % nproc))`. On a process
+whose `CPUAffinity=` is `2 3 4 5`, `available_parallelism()` reports 4
+(correct), but the loop pins to absolute CPU `worker_id % 4` — i.e.
+CPU 0, 1, 2, 3 — not to the 0th, 1st, 2nd, 3rd CPU of the allowed set.
+The result: the hot-path workers ignore systemd's mask.
+
+Recipe options until that logic is fixed:
+
+- **Leave `CPUAffinity=` unset.** This is what
+  `test/incus/xpfd.service` ships today (see `#712 Option A` comment
+  in the unit file). The recipe is design intent, not live policy.
+- **Set `CPUAffinity=` anyway and pay the cost.** Non-worker threads
+  move off the NIC-IRQ CPUs; workers stay put. On the loss lab this
+  was measured as no better than unpinned (slightly worse within
+  noise); on larger hosts with more CPUs the non-worker-thread share
+  is small enough that the cost is invisible but so is the win.
+- **Wait for the follow-up that fixes `pin_current_thread` to pick the
+  Nth allowed CPU.** That is a one-line change to the helper; it is
+  called out as a blocker here rather than folded silently into this
+  recipe because it widens the scope beyond a systemd unit edit.
+
+## Refs
+
+- #712 — umbrella CPU pinning issue. This recipe implements Option A.
+- `docs/cos-validation-notes.md` — measurement methodology and the
+  no-op finding on the loss lab.
+- `userspace-dp/src/afxdp/neighbor.rs::pin_current_thread` — the
+  worker-pin call site that blocks Option A landing as a
+  measurable win.

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -258,6 +258,85 @@ without reading them is how we ship dormant code.
   `xpf_cos_owner_pps{ifindex, queue_id}`, and `xpf_cos_peer_pps{...}`.
   Expected cardinality per the plan: ≤ 8192 series per histogram.
 
+## CPU pinning layout for the loss lab
+
+**Measured 2026-04-17 for #712 Option A.** Conclusion: the
+`CPUAffinity=` directive on `xpfd.service` is a no-op on the 6-core
+loss userspace lab because `userspace-dp` re-pins its workers inside
+the process after systemd's mask is applied. Keep this section dated;
+re-measure if any of the three blockers below move.
+
+### Intended layout on the 6-core lab
+
+The host is a 6-CPU VM. NIC IRQ distribution on fw0 under 16-flow
+iperf3 load, sampled from `/proc/interrupts`:
+
+- mlx5_comp0 (WAN VF RX q0) → CPU 0, ~800 M interrupts
+- mlx5_comp1 (WAN VF RX q1) → CPU 1, ~900 M interrupts
+- mlx5_comp2..5 (WAN VF RX q2..5) → CPUs 2..5, ~500-900 M each
+- virtio-input/output q0..5 → pinned 1-per-CPU across CPUs 0..5
+
+Each CPU carries NIC IRQ load; CPUs 0-1 are the hottest. The recipe in
+`docs/712-cpu-pinning-recipe.md` §"6-core host" reserves CPUs 0-1 for
+IRQ + housekeeping and gives xpfd and its four dp workers CPUs 2-5:
+
+```
+[Service]
+CPUAffinity=2 3 4 5
+```
+
+### Why that recipe is a no-op today
+
+`xpf-userspace-dp` calls `pin_current_thread(worker_id)` in
+`userspace-dp/src/afxdp/neighbor.rs`, which issues
+`sched_setaffinity(0, CPU_SET(worker_id % nproc))` per worker **after**
+systemd has installed the unit mask. `nproc` (via
+`std::thread::available_parallelism()`) correctly reports 4 when the
+process is launched with `CPUAffinity=2 3 4 5`, but the call pins each
+worker to absolute CPU `worker_id % 4` — i.e. CPU 0, 1, 2, 3 — not to
+the 0th..3rd CPU of the allowed set. Result: the four hot-path workers
+land on CPUs 0-3 regardless, colliding with `mlx5_comp0` and
+`mlx5_comp1`. The Go main and the dp aux threads (state-writer,
+event-stream, slowpath, neigh-monitor) do honour the mask and run on
+CPUs 2-5.
+
+### Measurement
+
+16-flow iperf3 × 30 s × 3 runs, client
+`cluster-userspace-host`, target `172.16.80.200`, CoS fixture
+`test/incus/cos-iperf-config.set` applied, fw0 primary. Computed with
+`/tmp/712-pinning/analyze.py` (iperf3 `-J` on the client; per-flow CoV
+is the standard deviation of the per-second bps samples on each stream,
+divided by that stream's mean).
+
+| Metric | Pre-pin mean | Post-pin mean | Δ |
+|---|---|---|---|
+| Rate ratio (max/min per-flow) | 1.39× | 1.45× | +4% (worse) |
+| Retransmits / 30 s | 181 k | 204 k | +13% (worse) |
+| Per-flow CoV mean | 14.3% | 15.9% | +1.6 pp (worse) |
+| Per-flow CoV max | 25.4% | 26.4% | +1.0 pp (flat) |
+
+All deltas within run-to-run noise. No metric moved in a good
+direction. Acceptance criterion from #712 — per-flow stdev/mean ≤ 10% —
+was not met pre-pin (~14%) and not closer post-pin. Per
+`engineering-style.md` §"Hot-path coding discipline", the directive
+was reverted in the same PR; the recipe doc lives on as design intent.
+
+### Blockers before Option A can land as a win
+
+1. `pin_current_thread` must pick the Nth allowed CPU, not absolute
+   CPU N. One-line follow-up in `userspace-dp/src/afxdp/neighbor.rs`.
+2. Option B (kernel cmdline `isolcpus=`+`nohz_full=`) would remove
+   kernel timers and RCU callbacks from worker CPUs entirely. It
+   requires a cmdline edit and reboot, so deployment shape has to opt
+   in. Tracked as a follow-up to #712.
+3. Option D (cgroup cpuset) is softer and does not require a cmdline
+   change but needs operator decisions about which cpuset holds which
+   non-xpfd process. Tracked as a follow-up to #712.
+
+Until one of these lands, the 14% per-flow CoV on this lab is the
+floor — Option A alone does not move it.
+
 ## Gotchas the deploy wipes
 
 The cluster deploy path (`cluster-setup.sh deploy`) wipes the CoS
@@ -291,3 +370,4 @@ See also the "CoS deploy preserves config" bullet in
 - #725 — validation-pipeline gap findings (live data + path forward)
 - #727 — ECN marking on Prepared CoS variant (closed the Local-only gap)
 - #728 — VLAN-aware L3 offset + threshold tune (resolved the dormant-marker symptom)
+- #712 — CPU pinning + IRQ isolation (Option A measured no-op on this lab; see "CPU pinning layout for the loss lab")

--- a/test/incus/xpfd.service
+++ b/test/incus/xpfd.service
@@ -14,5 +14,17 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=xpfd
 
+# #712 Option A (CPUAffinity=) was measured on the 6-core loss userspace
+# lab and did not move per-flow jitter, retransmits, or rate ratio on
+# this hardware; no directive is added here. The cause is that the
+# userspace-dp helper calls sched_setaffinity per worker (see
+# pin_current_thread() in userspace-dp/src/afxdp/neighbor.rs) and that
+# call runs AFTER systemd's CPUAffinity= is applied, so the hot-path
+# workers land on CPUs 0..N-1 regardless of the unit-level mask. Only
+# the Go daemon and the dp auxiliary threads honoured CPUAffinity=.
+# See docs/712-cpu-pinning-recipe.md for the per-CPU-budget recipe
+# (which is still useful on hosts where the worker count is ≤ the
+# budget) and the measured-no-op finding that blocks it on 6-core.
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Attempts #712 Option A (systemd \`CPUAffinity=\`) on the 6-core loss userspace lab, measures no-op, records the finding, and ships the recipe doc the issue's acceptance criteria call for.
- Commits **no** live \`CPUAffinity=\` directive. The recipe lands as design intent with the one-sentence blocker: \`userspace-dp\` re-pins each worker via \`sched_setaffinity\` after systemd's mask is applied, so the hot-path workers ignore \`CPUAffinity=\` regardless of what the operator writes.
- Files two follow-ups (#738 worker-pin fix, #739 Option B cmdline) rather than widening scope here.

## Measurement

16-flow iperf3 × 30 s × 3 runs, client \`cluster-userspace-host\`, target \`172.16.80.200\`, CoS fixture \`test/incus/cos-iperf-config.set\` applied, fw0 primary. Per-flow CoV = per-second bps stdev / mean per stream, averaged over streams. Analyser: \`iperf3 -J\` + Python stats.

| Metric | Pre-pin (mean of 3) | Post-pin \`CPUAffinity=2 3 4 5\` (mean of 3) | Δ |
|---|---|---|---|
| Rate ratio (max/min per-flow) | **1.39×** (1.302 / 1.510 / 1.352) | **1.45×** (1.343 / 1.411 / 1.589) | +4% worse |
| Retransmits / 30 s | **181 k** (234k / 184k / 126k) | **204 k** (170k / 209k / 233k) | +13% worse |
| Per-flow CoV mean | **14.3%** (15.1 / 14.9 / 13.0) | **15.9%** (13.9 / 16.9 / 16.8) | +1.6 pp worse |
| Per-flow CoV max | **25.4%** (23.4 / 25.1 / 27.8) | **26.4%** (25.7 / 28.4 / 25.2) | ≈ flat |

All deltas within run-to-run noise. No metric moved in a good direction.

**Decision: revert the directive, ship the recipe + measurement.** Per \`engineering-style.md\` §"Reviewing (adversarial by design)" and the rule "performance PRs must present before/after numbers. If the numbers don't move, the PR doesn't land" — the directive does not land; the data + recipe do.

## Root cause of the no-op

\`pin_current_thread(worker_id)\` in \`userspace-dp/src/afxdp/neighbor.rs\`:

\`\`\`rust
let cpus = thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
let cpu = (worker_id as usize) % cpus.max(1);
let mut set: libc::cpu_set_t = core::mem::zeroed();
libc::CPU_ZERO(&mut set);
libc::CPU_SET(cpu, &mut set);
let _ = libc::sched_setaffinity(0, ..., &set);
\`\`\`

Launched with \`CPUAffinity=2 3 4 5\`, \`available_parallelism()\` correctly reports 4 (it honours the inherited mask), but \`CPU_SET(worker_id % 4)\` pins to **absolute** CPU 0/1/2/3, not the 0th..3rd CPU of the allowed set. The kernel accepts the call (it is not blocked by the cpuset because \`CPUAffinity=\` uses plain \`sched_setaffinity\` not cgroup cpuset), and each worker lands on an absolute CPU outside the unit-level mask. Only the Go main and the dp auxiliary threads (state-writer, event-stream, slowpath, neigh-monitor) actually honour the mask.

Verified live post-pin with \`/proc/<tid>/status\`:

\`\`\`
xpf-userspace-w cpus_allowed=0
xpf-userspace-w cpus_allowed=1
xpf-userspace-w cpus_allowed=2
xpf-userspace-w cpus_allowed=3
xpf-slowpath    cpus_allowed=2-5
xpf-state-write cpus_allowed=2-5
\`\`\`

Fix tracked at **#738**.

## CPU layout designed (and ignored)

| CPU | Role | Who runs there |
|---|---|---|
| 0 | NIC IRQ + housekeeping | mlx5_comp0 (~800 M IRQs on the run), virtio inputs 0, ksoftirqd/0 |
| 1 | NIC IRQ + housekeeping | mlx5_comp1 (~900 M IRQs), virtio inputs 1, ksoftirqd/1, chrony |
| 2 | xpfd control + worker 0 | Go main + aux; intended \`xpf-userspace-w0\` |
| 3 | worker 1 | intended \`xpf-userspace-w1\` |
| 4 | worker 2 | intended \`xpf-userspace-w2\` |
| 5 | worker 3 | intended \`xpf-userspace-w3\` |

Non-worker xpfd threads moved to CPUs 2-5 as expected. Workers stayed on 0-3, colliding with comp0 / comp1 exactly as the issue described.

## What lands

- \`test/incus/xpfd.service\`: explanatory comment, **no \`CPUAffinity=\` directive**.
- \`docs/712-cpu-pinning-recipe.md\` (new): operator-facing layouts for 2 / 4 / 6 / 8-core hosts, with explicit non-goals (isolcpus/nohz_full = Option B (#739); SCHED_FIFO = Option C; cgroup cpuset = Option D; ethtool RSS reshape = separate issue). Verification commands. Calls out the worker-pin blocker at #738.
- \`docs/cos-validation-notes.md\`: new "CPU pinning layout for the loss lab" section with the dated measurement + blockers + the three follow-up options.

## IRQ affinity

Not touched. Per the task brief this is a post-boot operation and should only be added if Phase 1 showed worker CPUs getting NIC IRQ traffic. They do (comp2-5 distribute across CPUs 2-5), but reshaping NIC IRQ placement without also reshaping RSS via \`ethtool --set-rxfh-indir\` will not move traffic off those CPUs — RSS hash picks the queue, the queue's MSI-X vector's affinity picks the CPU, and rewriting \`/proc/irq/*/smp_affinity_list\` alone just lets the kernel pick any allowed CPU round-robin per interrupt. That's a strictly larger scope than Option A; defer.

## Test plan

- [x] Phase 1: 3 × 30s × 16-flow iperf3 baseline captured on fw0-primary loss userspace cluster, CoS fixture applied, client \`cluster-userspace-host\`. CPU-thread snapshot captured mid-run.
- [x] Unit pushed with \`CPUAffinity=2 3 4 5\`, verified \`taskset -p\` returns mask \`0x3c\` (CPUs 2-5) for xpfd + xpf-userspace-dp.
- [x] Per-thread verification via \`/proc/<tid>/status\` — confirms aux threads on 2-5, workers on 0-3 (documents the root cause).
- [x] Phase 4: 3 × 30s × 16-flow iperf3 post-pin. All metrics captured.
- [x] Reverted \`CPUAffinity=\` from the unit after measurement, pushed empty unit back to both VMs, cluster status confirmed (node0 primary / node1 secondary).
- [x] No Rust or Go changes; no BPF changes; no CLI/API surface changes.

## Deferred

- **#738** — fix \`pin_current_thread\` in \`userspace-dp/src/afxdp/neighbor.rs\` to select the Nth CPU of the inherited mask rather than absolute CPU N. One-line follow-up.
- **#739** — #712 Option B kernel cmdline \`isolcpus=\` / \`nohz_full=\` / \`rcu_nocbs=\`. Requires cmdline change + reboot; depends on #738.
- #712 Option C (SCHED_FIFO), Option D (cgroup cpuset), Option E (busy-poll) — not addressed here.

## Refs

- #712 — umbrella CPU pinning + IRQ isolation (this PR is Option A)
- #738 — worker-pin logic fix (blocker for Option A)
- #739 — Option B kernel cmdline follow-up
- #704 — per-flow jitter umbrella (one of the symptoms #712 targets)