### PR TITLE
test/incus: retry #712 Option A after #740 fix — still no-op on loss lab

### DIFF
--- a/docs/712-cpu-pinning-recipe.md
+++ b/docs/712-cpu-pinning-recipe.md
@@ -7,13 +7,18 @@ userspace-dp workers. It also spells out what is **not** in the recipe:
 those are either deferred to a separate option in #712 or out of scope.
 
 Read `docs/cos-validation-notes.md` §"CPU pinning layout for the loss
-lab" before applying this recipe — the loss userspace lab measurement
-found that `CPUAffinity=` alone is a no-op on that hardware because
-userspace-dp re-pins its workers internally. The recipe below is
-written assuming that ceiling is eventually lifted (either by Option B
-kernel cmdline, by a cgroup cpuset under Option D, or by a worker-pin
-fix in #742). Until then, treat the recipe as design intent rather than
-as something to cargo-cult onto a running firewall.
+lab" and §"CPU pinning retry post-#740" before applying this recipe.
+
+The first attempt (#737) measured `CPUAffinity=` as a no-op because
+userspace-dp re-pinned its workers to absolute CPUs 0..N-1 via
+`sched_setaffinity`. That was fixed in #740; workers now pick the Nth
+entry of the inherited mask. The retry (#741) re-ran the measurement
+with the fix in place and confirmed that workers land on the intended
+CPUs 2-5 — but no aggregate metric moved by the #712 thresholds on the
+6-core loss lab. The recipe below is kept as design intent; it is
+validated as correctly applied, not as a measurable win on this
+hardware. The next lever is Option B (kernel cmdline `isolcpus=` +
+`nohz_full=`, tracked at #739).
 
 ## What the recipe covers
 
@@ -107,12 +112,28 @@ for irq in $(grep -E 'mlx|virtio.*-input|virtio.*-output' /proc/interrupts | awk
 done
 ```
 
-**Measured effect on the loss lab:** no-op, see
-`cos-validation-notes.md` §"CPU pinning layout for the loss lab". The
-recipe is the right layout for the hardware; the userspace-dp worker-pin
-logic needs to honour the inherited affinity (new follow-up issue) or
-the kernel cmdline needs isolcpus (Option B, also a follow-up) before
-the layout lands as a win.
+**Measured effect on the loss lab:** no-op, in both phases.
+
+- **First attempt (#737):** workers ignored the mask via
+  `pin_current_thread`'s absolute-CPU bug; the measured deltas
+  confirmed the bug rather than the pinning.
+- **Retry (#741) after #740 fix:** workers correctly pin to CPUs 2-5
+  (`taskset -p` reports `0x3c`, per-thread `Cpus_allowed_list=2-5`,
+  `psr` under load ∈ {2,3,4,5}). Rerun of the 3 × 30 s × 16-flow iperf3
+  fixture still showed no aggregate metric moving by the #712
+  thresholds. Rate ratio went from 1.37× → 1.40× (+2%, within noise),
+  retrans 210 k → 234 k (+11%, within noise), per-flow CoV mean
+  16.8% → 16.2% (-0.6 pp, within noise), CoV max 26.8% → 28.5%
+  (+1.7 pp, within noise). Per #712's keep/revert/defer table the
+  directive was reverted.
+
+The recipe is the right layout for the hardware; on a 6-core VM where
+every CPU already carries NIC IRQ load (comp0..5 spread 1-per-CPU on
+both mlx5 and virtio queues), moving workers to a subset of CPUs that
+still share IRQ load with the kernel does not reduce jitter. The next
+lever is Option B (kernel cmdline `isolcpus=` + `nohz_full=`) which
+removes kernel timer + softirq work from the worker CPUs entirely —
+tracked at #739.
 
 ### 8-core host (CPUs 0..7)
 
@@ -159,46 +180,52 @@ ps -eTo pid,tid,comm,psr,pcpu | grep -E 'xpfd|xpf-userspace|ksoftirq'
 grep -E 'mlx|virtio.*input|virtio.*output' /proc/interrupts
 ```
 
-Expected after a fresh apply on a 6-core host:
+Expected after a fresh apply on a 6-core host, post-#740:
 - `taskset -p` of xpfd → mask `0x3c` (CPUs 2-5)
 - Per-thread `cpus_allowed`: all xpfd + dp aux threads show `2-5`
-- Per-thread `cpus_allowed` for `xpf-userspace-w[0-3]`: **today** shows
-  `0 / 1 / 2 / 3` because of the worker-pin logic in
-  `userspace-dp/src/afxdp/neighbor.rs::pin_current_thread()`. After that
-  logic is fixed, expect `2 / 3 / 4 / 5`.
-- `psr` under load: non-worker threads on 2-5; workers on 0-3 today, on
-  2-5 after the fix.
+- Per-thread `cpus_allowed` for `xpf-userspace-w[0-3]`: shows
+  `2 / 3 / 4 / 5` — the #740 fix makes `pin_current_thread` pick the
+  Nth entry of the allowed mask, so workers land inside the unit-level
+  mask.
+- `psr` under load: all non-worker threads on 2-5; workers on 2/3/4/5
+  one-to-one.
+- Verified live on 2026-04-17 during the #741 retry.
 
-## Known blocker: worker-pin logic overrides systemd CPUAffinity
+## Historical blocker: worker-pin logic overrode systemd CPUAffinity
 
-`pin_current_thread(worker_id)` in
-`userspace-dp/src/afxdp/neighbor.rs` calls
+Before #740, `pin_current_thread(worker_id)` in
+`userspace-dp/src/afxdp/neighbor.rs` called
 `sched_setaffinity(0, … CPU_SET(worker_id % nproc))`. On a process
-whose `CPUAffinity=` is `2 3 4 5`, `available_parallelism()` reports 4
-(correct), but the loop pins to absolute CPU `worker_id % 4` — i.e.
-CPU 0, 1, 2, 3 — not to the 0th, 1st, 2nd, 3rd CPU of the allowed set.
-The result: the hot-path workers ignore systemd's mask.
+whose `CPUAffinity=` was `2 3 4 5`, `available_parallelism()` reported
+4 correctly, but the loop pinned to absolute CPU `worker_id % 4` —
+i.e. CPU 0, 1, 2, 3 — not to the 0th, 1st, 2nd, 3rd CPU of the allowed
+set. The result: hot-path workers ignored systemd's mask.
 
-Recipe options until that logic is fixed:
+**Fixed in #740.** `pin_current_thread` now calls `sched_getaffinity`,
+enumerates the allowed CPUs, and pins to `allowed[worker_id % count]`.
+Verified live during the #741 retry — workers report
+`cpus_allowed_list=2-5` and `psr ∈ {2,3,4,5}` under load.
 
-- **Leave `CPUAffinity=` unset.** This is what
-  `test/incus/xpfd.service` ships today (see `#712 Option A` comment
-  in the unit file). The recipe is design intent, not live policy.
-- **Set `CPUAffinity=` anyway and pay the cost.** Non-worker threads
-  move off the NIC-IRQ CPUs; workers stay put. On the loss lab this
-  was measured as no better than unpinned (slightly worse within
-  noise); on larger hosts with more CPUs the non-worker-thread share
-  is small enough that the cost is invisible but so is the win.
-- **Wait for the follow-up that fixes `pin_current_thread` to pick the
-  Nth allowed CPU.** That is a one-line change to the helper; it is
-  called out as a blocker here rather than folded silently into this
-  recipe because it widens the scope beyond a systemd unit edit.
+The blocker is not on the layout any more; it is on the hardware.
+On a 6-core VM where NIC IRQs distribute one-per-CPU across all 6
+CPUs (mlx5_comp0..5 and virtio-input.0..5 each carry hundreds of
+millions of interrupts per run), moving workers onto a subset of
+CPUs that still share IRQ load with the kernel does not reduce
+jitter. The layout is correct; the hardware needs a stronger lever
+to surface the improvement — see #739 for Option B kernel cmdline
+(`isolcpus=` / `nohz_full=` / `rcu_nocbs=`) which actually evicts
+timers and RCU callbacks from worker CPUs.
 
 ## Refs
 
 - #712 — umbrella CPU pinning issue. This recipe implements Option A.
 - `docs/cos-validation-notes.md` — measurement methodology and the
-  no-op finding on the loss lab.
-- `userspace-dp/src/afxdp/neighbor.rs::pin_current_thread` — the
-  worker-pin call site that blocks Option A landing as a
-  measurable win.
+  no-op finding on the loss lab (both attempts).
+- #737 — first attempt at Option A; measured no-op because of the
+  worker-pin bug.
+- #740 — fix for `pin_current_thread` to pick the Nth entry of the
+  allowed mask.
+- #741 — retry of Option A after #740; measured no-op on aggregate
+  metrics despite workers now landing on CPUs 2-5 as intended.
+- #739 — Option B kernel cmdline (`isolcpus=` + `nohz_full=`), the
+  next lever to try on this hardware.

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -324,18 +324,122 @@ was reverted in the same PR; the recipe doc lives on as design intent.
 
 ### Blockers before Option A can land as a win
 
-1. `pin_current_thread` must pick the Nth allowed CPU, not absolute
-   CPU N. One-line follow-up in `userspace-dp/src/afxdp/neighbor.rs`.
+1. ~~`pin_current_thread` must pick the Nth allowed CPU, not absolute
+   CPU N.~~ **Fixed in #740.** Workers correctly honour the inherited
+   mask as of master `b5e7fc2f`. Verified during the #741 retry below.
 2. Option B (kernel cmdline `isolcpus=`+`nohz_full=`) would remove
    kernel timers and RCU callbacks from worker CPUs entirely. It
    requires a cmdline edit and reboot, so deployment shape has to opt
-   in. Tracked as a follow-up to #712.
+   in. Tracked as a follow-up to #712 (#739). After the #741 retry
+   this is the next lever to try on this hardware.
 3. Option D (cgroup cpuset) is softer and does not require a cmdline
    change but needs operator decisions about which cpuset holds which
    non-xpfd process. Tracked as a follow-up to #712.
 
-Until one of these lands, the 14% per-flow CoV on this lab is the
-floor — Option A alone does not move it.
+## CPU pinning retry post-#740
+
+**Measured 2026-04-17 for #712 Option A retry (#741).** Conclusion:
+with the #740 fix in place, workers correctly pin to CPUs 2-5 — but
+the aggregate iperf3 metrics still do not move by the #712 thresholds
+on this hardware. The layout is verified as applied; the 6-core lab
+does not benefit from systemd-level pinning alone.
+
+### Verification (Phase 3)
+
+Taken live with `CPUAffinity=2 3 4 5` loaded, xpfd running, before
+the Phase 4 iperf3 runs:
+
+```
+pid 65616's current affinity mask: 3c
+
+65619 ctrl-c         cpus_allowed=2-5 psr=3
+65620 iou-wrk-...    cpus_allowed=2-5 psr=5
+65628 neigh-monitor  cpus_allowed=2-5 psr=2
+65621 session-socket cpus_allowed=2-5 psr=2
+65618 xpf-event-strea cpus_allowed=2-5 psr=2
+65622 xpf-slowpath   cpus_allowed=2-5 psr=3
+65617 xpf-state-write cpus_allowed=2-5 psr=4
+65616 xpf-userspace-d cpus_allowed=2-5 psr=5
+65624 xpf-userspace-w cpus_allowed=2   psr=2
+65625 xpf-userspace-w cpus_allowed=3   psr=3
+65626 xpf-userspace-w cpus_allowed=4   psr=4
+65627 xpf-userspace-w cpus_allowed=5   psr=5
+```
+
+Every worker on its own CPU in {2,3,4,5}; `psr` matches
+`cpus_allowed` one-to-one. No worker lands on CPU 0 or 1. The
+pre-#740 failure mode — workers on CPUs 0-3 regardless of the unit
+mask — does not recur.
+
+### Phase 4 measurement
+
+Same fixture as #737: 3 × 30 s × 16-flow iperf3, client
+`cluster-userspace-host`, target `172.16.80.200`, CoS fixture
+`test/incus/cos-iperf-config.set` applied, fw0 primary,
+`net.ipv4.tcp_ecn=1` end-to-end. Per-flow CoV = per-second bps
+stdev / mean per stream, mean across streams (16 streams per run).
+
+Per-run raw values:
+
+| Run | Ratio | Retrans / 30 s | CoV mean | CoV max |
+|---|---|---|---|---|
+| Pre  1 | 1.370× | 198,317 | 16.3% | 26.4% |
+| Pre  2 | 1.365× | 186,389 | 15.3% | 26.9% |
+| Pre  3 | 1.383× | 245,724 | 18.9% | 27.0% |
+| Post 1 | 1.288× | 264,493 | 17.4% | 27.6% |
+| Post 2 | 1.492× | 179,843 | 16.7% | 32.5% |
+| Post 3 | 1.419× | 257,562 | 14.6% | 25.4% |
+
+Aggregate:
+
+| Metric | Pre-pin mean | Post-pin mean | Δ |
+|---|---|---|---|
+| Rate ratio (max/min per-flow) | 1.373× | 1.400× | +2% (worse, within noise) |
+| Retransmits / 30 s | 210 k | 234 k | +11% (worse, within noise) |
+| Per-flow CoV mean | 16.8% | 16.2% | -0.6 pp (better, within noise) |
+| Per-flow CoV max | 26.8% | 28.5% | +1.7 pp (worse, within noise) |
+
+### Decision
+
+Per #712's keep/revert/defer thresholds (also cited verbatim in the
+#741 task brief):
+
+- **Keep** requires: ratio improves ≥ 5%, OR per-flow CoV mean drops
+  ≥ 3 pp on 2+ runs, OR retrans drops ≥ 15%. **None satisfied.**
+- **Revert** if no metric moves above thresholds. Three of four
+  metrics moved in the *worse* direction within noise; CoV mean
+  improved 0.6 pp, far below the 3 pp threshold.
+- **Defer** is for "small movement without any metric going worse".
+  That condition is not met either — ratio + retrans + CoV max all
+  regressed.
+
+**Decision: revert the directive.** Same engineering outcome as #737,
+different mechanism. #737 revert was forced by the pin logic bug;
+#741 revert is forced by the hardware. The recipe lives on as design
+intent; the next lever is #739 (kernel cmdline isolcpus/nohz_full).
+
+### Why the pin doesn't help on this lab
+
+IRQ layout sampled mid-run (abbreviated from `/proc/interrupts`):
+
+- `virtio11-input.0..5` (one of the NICs) — each pinned to its own
+  CPU across CPUs 0-5, each carrying tens of thousands of interrupts
+  per run.
+- `virtio12-input.0..5` — same 1-per-CPU spread, hundreds of
+  thousands of interrupts per CPU per run (LAN-side).
+- `virtio5-virtqueues` → CPU 2, 65 k interrupts.
+
+CPUs 2-5 carry virtio RX interrupts for four of the six virtio
+queues; moving xpfd workers onto those CPUs collides with the same
+softirq work that was running there before. The pin moves the
+workload alongside its IRQs rather than away from them. To actually
+separate the worker from kernel timer + softirq preemption you need
+either (a) `isolcpus=2-5` on the cmdline (Option B, #739), or (b)
+`ethtool`-level RSS reshape to park the RX queues on CPUs 0-1 so
+CPUs 2-5 are truly quiet (out of scope per the recipe).
+
+Until one of those lands, the 14-18% per-flow CoV on this lab is the
+floor for `CPUAffinity=` alone.
 
 ## Gotchas the deploy wipes
 

--- a/test/incus/xpfd.service
+++ b/test/incus/xpfd.service
@@ -14,17 +14,16 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=xpfd
 
-# #712 Option A (CPUAffinity=) was measured on the 6-core loss userspace
-# lab and did not move per-flow jitter, retransmits, or rate ratio on
-# this hardware; no directive is added here. The cause is that the
-# userspace-dp helper calls sched_setaffinity per worker (see
-# pin_current_thread() in userspace-dp/src/afxdp/neighbor.rs) and that
-# call runs AFTER systemd's CPUAffinity= is applied, so the hot-path
-# workers land on CPUs 0..N-1 regardless of the unit-level mask. Only
-# the Go daemon and the dp auxiliary threads honoured CPUAffinity=.
-# See docs/712-cpu-pinning-recipe.md for the per-CPU-budget recipe
-# (which is still useful on hosts where the worker count is ≤ the
-# budget) and the measured-no-op finding that blocks it on 6-core.
+# #712 Option A retry (after #740 fix): measured on the 6-core loss
+# userspace lab with workers correctly pinned to CPUs 2-5 via
+# CPUAffinity=2 3 4 5 — no metric moved by the #712 thresholds
+# (rate ratio +2%, retrans +11%, per-flow CoV mean -0.6 pp, per-flow
+# CoV max +1.7 pp; all within run-to-run noise). The directive is
+# NOT shipped. See docs/cos-validation-notes.md §"CPU pinning retry
+# post-#740" for the dated measurement, docs/712-cpu-pinning-recipe.md
+# for the recipe (kept as design intent), and #739 for the kernel
+# cmdline (isolcpus/nohz_full) follow-up which is now the next lever
+# to try on this hardware.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Re-runs #712 Option A (systemd `CPUAffinity=2 3 4 5`) on the 6-core loss userspace lab now that #740 fixed `pin_current_thread` to pick the Nth entry of the inherited mask. Phase 3 verification confirms workers land on CPUs 2-5 as intended — the pre-#740 absolute-CPU-0..3 bug does not recur.
- Phase 4 measurement shows no aggregate metric moved by the #712 keep/revert/defer thresholds. Deltas vs. pre-pin are within run-to-run noise; ratio + retrans + CoV-max moved slightly *worse*, CoV-mean moved -0.6 pp better (far below the 3 pp threshold).
- Decision per the brief: **revert the directive**, ship the measurement. The recipe stays in place as design intent; the next hardware lever is #739 (kernel cmdline `isolcpus=` / `nohz_full=`). No Rust or Go code changes.

## Phase 1: pre-pin baseline (3 × 30 s × 16-flow iperf3)

Unit shipped without `CPUAffinity=`. Client `cluster-userspace-host`, target `172.16.80.200`, CoS fixture `test/incus/cos-iperf-config.set` applied, fw0 primary, `tcp_ecn=1` end-to-end.

| Run | Ratio | Retrans / 30 s | CoV mean | CoV max |
|---|---|---|---|---|
| 1 | 1.370× | 198,317 | 16.3% | 26.4% |
| 2 | 1.365× | 186,389 | 15.3% | 26.9% |
| 3 | 1.383× | 245,724 | 18.9% | 27.0% |
| **mean** | **1.373×** | **210 k** | **16.8%** | **26.8%** |

Pre-pin thread snapshot (confirms unpinned state): workers on CPUs 0/1/2/3 via `pin_current_thread`'s `allowed[worker_id % count]` landing on the first 4 of the 0-15 allowed mask. `xpf-userspace-w cpus_allowed=0/1/2/3 psr=0/1/2/3`.

IRQ layout sampled mid-run: virtio11-input.0..5 each pinned to its own CPU across CPUs 0-5 (tens of thousands of interrupts per CPU per run); virtio12-input.0..5 same 1-per-CPU spread at hundreds of thousands of interrupts per CPU per run. Every CPU carries NIC RX softirq load.

## Phase 3: verification (live, post-deploy, before iperf3)

```
pid 65616's current affinity mask: 3c

65619 ctrl-c           cpus_allowed=2-5 psr=3
65620 iou-wrk-...      cpus_allowed=2-5 psr=5
65628 neigh-monitor    cpus_allowed=2-5 psr=2
65621 session-socket   cpus_allowed=2-5 psr=2
65618 xpf-event-strea  cpus_allowed=2-5 psr=2
65622 xpf-slowpath     cpus_allowed=2-5 psr=3
65617 xpf-state-write  cpus_allowed=2-5 psr=4
65616 xpf-userspace-d  cpus_allowed=2-5 psr=5
65624 xpf-userspace-w  cpus_allowed=2   psr=2
65625 xpf-userspace-w  cpus_allowed=3   psr=3
65626 xpf-userspace-w  cpus_allowed=4   psr=4
65627 xpf-userspace-w  cpus_allowed=5   psr=5
```

Every worker on its own CPU in {2,3,4,5}; `psr` matches `cpus_allowed` one-to-one. No worker on CPU 0 or 1. The #737 failure mode does not recur — #740 landed as advertised. Phase 4 is therefore measuring pinning, not the bug.

## Phase 4: post-pin measurement (3 × 30 s × 16-flow iperf3)

Same fixture, `CPUAffinity=2 3 4 5` loaded.

| Run | Ratio | Retrans / 30 s | CoV mean | CoV max |
|---|---|---|---|---|
| 1 | 1.288× | 264,493 | 17.4% | 27.6% |
| 2 | 1.492× | 179,843 | 16.7% | 32.5% |
| 3 | 1.419× | 257,562 | 14.6% | 25.4% |
| **mean** | **1.400×** | **234 k** | **16.2%** | **28.5%** |

## Pre vs. post deltas

| Metric | Pre | Post | Δ |
|---|---|---|---|
| Rate ratio (max/min per-flow) | 1.373× | 1.400× | +2% (worse, within noise) |
| Retransmits / 30 s | 210 k | 234 k | +11% (worse, within noise) |
| Per-flow CoV mean | 16.8% | 16.2% | -0.6 pp (better, within noise) |
| Per-flow CoV max | 26.8% | 28.5% | +1.7 pp (worse, within noise) |

## Decision (explicit against the thresholds)

Per the task brief's keep/revert/defer table:

- **Keep** requires: rate ratio ≥ 5% improvement, OR per-flow CoV mean drops ≥ 3 pp on 2+ runs, OR retrans drops ≥ 15%. **None satisfied.** CoV mean improved 0.6 pp, retrans + ratio + CoV max all regressed.
- **Revert** if no metric moves by those thresholds. Satisfied.
- **Defer** applies only when the movement is small *and any metric is in the better direction without any going worse*. Three of four metrics moved worse — defer does not apply.

**Outcome: revert.** Same engineering outcome as #737, different mechanism: #737 revert was forced by the pin logic bug (#738 → #740); #741 revert is forced by the 6-core hardware. Directive is not shipped.

## Why the pin doesn't help on this lab

NIC RX IRQs are pinned one-per-CPU across all six CPUs on both virtio NICs. Moving xpfd workers onto CPUs 2-5 colocates them with the same softirq work that was running there before the pin. To actually separate workers from kernel softirq preemption on this hardware you need:

- **Option B (#739)** — `isolcpus=2-5` + `nohz_full=2-5` + `rcu_nocbs=2-5` on the kernel cmdline. Requires a cmdline edit and a reboot. Now the next lever to try.
- **ethtool RSS reshape** — park RX queues on CPUs 0-1 so CPUs 2-5 are truly quiet. Strictly larger scope than Option A; out of scope per the recipe's non-goals.

Until one lands, the 14-18% per-flow CoV on this lab is the floor for `CPUAffinity=` alone.

## What lands

- `test/incus/xpfd.service` — updated comment block documenting the retry and the revert; no `CPUAffinity=` directive shipped.
- `docs/712-cpu-pinning-recipe.md` — loss-lab section updated with the retry outcome, historical-blocker section updated to mark #740 as fixed, verification section updated with the post-retry evidence, refs include #740 and #741.
- `docs/cos-validation-notes.md` — new "CPU pinning retry post-#740" section with the Phase 3 verification + Phase 4 metrics + decision. Old "blockers" section updated to strike the worker-pin blocker (now fixed).

No Rust changes. No Go changes. No BPF changes.

## Test plan

- [x] Phase 1: 3 × 30 s × 16-flow iperf3 baseline captured, analyser output in the table above.
- [x] Phase 2: `CPUAffinity=2 3 4 5` added to `test/incus/xpfd.service`, rolling deploy to both loss-cluster VMs, `systemctl show xpfd -p CPUAffinity` returns `CPUAffinity=2-5`.
- [x] **Phase 3 verification** — per-thread `/proc/<tid>/status` + `psr` snapshot captured pre-Phase-4. All 12 threads on CPUs 2-5; workers one-to-one on 2/3/4/5. Output embedded above.
- [x] Phase 4: 3 × 30 s × 16-flow iperf3 post-pin, metrics in the table above.
- [x] Reverted `CPUAffinity=` on both VMs; `taskset -p` returns mask `0x3f` (CPUs 0-5) post-revert.
- [x] CoS config re-applied to fw0 post-revert deploy so the lab stays in the expected state for future measurements.

## Deferred

- **#739** — Option B kernel cmdline (`isolcpus=` / `nohz_full=` / `rcu_nocbs=`). Now the next lever on this hardware. Requires cmdline + reboot.
- #712 Option C (SCHED_FIFO), Option D (cgroup cpuset), Option E (busy-poll) — unchanged from #737.

## Refs

- #712 — umbrella CPU pinning + IRQ isolation (Option A second attempt)
- #737 — first attempt, reverted because of `pin_current_thread` absolute-CPU bug
- #740 — fix for `pin_current_thread` (merged as `b5e7fc2f`) that made this retry meaningful
- #739 — Option B kernel cmdline follow-up, now the next lever

🤖 Generated with [Claude Code](https://claude.com/claude-code)