### PR TITLE
docs: codify "all code changes land via PR" as a first principle

### DIFF
--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -36,6 +36,16 @@ Read this file in full before:
    a tracking issue and cross-reference it. Don't silently expand
    scope.
 
+6. **All code changes go through a PR.** No direct pushes to `master`
+   for code — not for one-line fixes, not for hotfixes, not for revert
+   commits. The PR flow is where reviewers catch what tests miss,
+   where live data gets contrasted against the hypothesis, and where
+   the commit message and PR body become the permanent record of why
+   the change was made. Skipping it to "save time" is how regressions
+   land. Docs-only maintenance skills that explicitly direct-push
+   (e.g. `/sync-history`) are the only exception and must be declared
+   in their `SKILL.md`.
+
 ## Hot-path coding discipline
 
 ### Allocations
@@ -189,6 +199,11 @@ Read this file in full before:
 
 ### Merging
 
+- **Every code change lands via PR.** Even revert commits. Even
+  "obviously right" one-line fixes. Even cherry-picks from someone
+  else's branch. If you find yourself typing `git push origin master`
+  for anything except a docs-only maintenance skill that explicitly
+  does that (see first principle #6), stop — open a PR.
 - Squash-merge, single commit per PR on master. Commit message is the
   PR title.
 - Do not merge with failing tests. Do not `--no-verify` to skip hooks.


### PR DESCRIPTION
## Summary

Codify the PR-discipline rule the project has been following implicitly. No direct pushes to `master` for code changes — the PR flow is where reviewers catch what tests miss, where live data gets contrasted against the hypothesis, and where the commit message / PR body becomes the permanent record.

## What changes in `docs/engineering-style.md`

- **New first principle #6**: "All code changes go through a PR." Spells out that the rule covers one-liners, hotfixes, and revert commits. Single documented exception: docs-only maintenance skills like `/sync-history` that explicitly direct-push and declare so in their `SKILL.md`.
- **Merging subsection** now leads with an unambiguous bullet naming the specific ways a direct-push can sneak in (revert commits, "obvious" one-line fixes, cherry-picks) — so a future session can't rationalise any of them.

## Test plan

- [x] Docs-only.
- [x] Links / cross-refs unchanged.
- [x] The rule is self-applying: this PR itself is a code-discipline change landing via PR rather than a direct push to master.

Refs: style-doc lineage #719, #726, #729.