### PR TITLE
userspace-dp: isolate owner-profile telemetry on its own cachelines (#746)

### DIFF
--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -238,14 +238,17 @@ pub(super) fn drain_pending_tx(
         let progressed = drain_shaped_tx(binding, now_ns, shared_recycles);
         let delta = monotonic_nanos().saturating_sub(start_ns);
         let bucket = bucket_index_for_ns(delta);
-        binding.live.drain_latency_hist[bucket].fetch_add(1, Ordering::Relaxed);
+        binding.live.owner_profile_owner.drain_latency_hist[bucket]
+            .fetch_add(1, Ordering::Relaxed);
         binding
             .live
+            .owner_profile_owner
             .drain_invocations
             .fetch_add(1, Ordering::Relaxed);
         if !progressed {
             binding
                 .live
+                .owner_profile_owner
                 .drain_noop_invocations
                 .fetch_add(1, Ordering::Relaxed);
             break;
@@ -579,10 +582,18 @@ fn ingest_cos_pending_tx(
     binding.live.take_pending_tx_into(&mut pending);
     let peer_count = (pending.len() as u64).saturating_sub(owner_local_count);
     if owner_local_count > 0 {
-        binding.live.pps_owner_vs_peer[0].fetch_add(owner_local_count, Ordering::Relaxed);
+        binding
+            .live
+            .owner_profile_owner
+            .owner_pps
+            .fetch_add(owner_local_count, Ordering::Relaxed);
     }
     if peer_count > 0 {
-        binding.live.pps_owner_vs_peer[1].fetch_add(peer_count, Ordering::Relaxed);
+        binding
+            .live
+            .owner_profile_peer
+            .peer_pps
+            .fetch_add(peer_count, Ordering::Relaxed);
     }
     process_pending_queue_in_place(&mut pending, |req| {
         let req = match redirect_local_cos_request_to_owner(

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -165,6 +165,94 @@ pub(super) fn bucket_index_for_ns(ns: u64) -> usize {
     b.min(DRAIN_HIST_BUCKETS - 1)
 }
 
+/// #746: owner-worker-written owner-profile telemetry. The owner of a
+/// binding is the sole writer of these atomics (the single drain caller
+/// for this binding); peer workers only read via `snapshot()`. Isolated
+/// onto its own 64-byte cacheline so owner writes do not invalidate
+/// peer-writer cachelines (see `OwnerProfilePeerWrites`) and so
+/// telemetry updates do not ping-pong unrelated `BindingLiveState`
+/// fields.
+///
+/// Matches the in-repo `#[repr(align(64))]` idiom established in
+/// `mpsc_inbox.rs::CachePadded` (#715). We use a freestanding struct
+/// here instead of wrapping each atomic individually because the
+/// grouped atomics are updated together on one code path — isolating
+/// the whole group on one line is the alignment contract that matters.
+///
+/// Counter semantics are unchanged from #709 / #731 (`drain_latency_hist`
+/// buckets sum to `drain_invocations`; `drain_noop_invocations` is a
+/// subset counter). See `BindingLiveState::snapshot()` for how these
+/// values flow into `BindingLiveSnapshot`.
+#[repr(align(64))]
+pub(super) struct OwnerProfileOwnerWrites {
+    pub(super) drain_latency_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
+    pub(super) drain_invocations: AtomicU64,
+    pub(super) drain_noop_invocations: AtomicU64,
+    /// #709: owner-local pps window. Formerly `pps_owner_vs_peer[0]`;
+    /// split by writer for cacheline isolation (#746). The owner is
+    /// the only writer; peers read through `snapshot()`.
+    pub(super) owner_pps: AtomicU64,
+}
+
+/// #746: peer-worker-written owner-profile telemetry. Every redirecting
+/// worker is a writer of these atomics. Isolated onto its own 64-byte
+/// cacheline so peer writes do not invalidate the owner's cacheline
+/// (see `OwnerProfileOwnerWrites`) and so the redirect-sample counter
+/// churn does not ping-pong unrelated `BindingLiveState` fields.
+///
+/// The owner reads the peer-written counters only via `snapshot()`;
+/// there is no owner-write path into this struct.
+#[repr(align(64))]
+pub(super) struct OwnerProfilePeerWrites {
+    pub(super) redirect_acquire_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
+    pub(super) redirect_sample_counter: AtomicU64,
+    /// #709: peer-redirect pps window. Formerly `pps_owner_vs_peer[1]`;
+    /// split by writer for cacheline isolation (#746). Any worker that
+    /// redirects into this binding is a writer; the owner reads via
+    /// `snapshot()`.
+    pub(super) peer_pps: AtomicU64,
+}
+
+// #746: compile-time layout enforcement. A silent drop of the
+// `#[repr(align(64))]` attribute — or a future refactor that inlines
+// a packed neighbor — is caught at build time, not at runtime.
+const _: () = assert!(core::mem::align_of::<OwnerProfileOwnerWrites>() == 64);
+const _: () = assert!(core::mem::align_of::<OwnerProfilePeerWrites>() == 64);
+// Size ceiling: owner struct is 16 hist + 3 scalar AtomicU64 = 152 B,
+// padded to 192 B (3 cachelines) at 64-B alignment. Peer struct is
+// 16 hist + 2 scalar AtomicU64 = 144 B, padded to 192 B. Allow up to
+// 5 cachelines (320 B) so a follow-up can add one or two atomics
+// without this assert breaking — but if someone drops a giant field
+// in here, the build fails loudly and forces a reshape decision.
+const _: () = assert!(core::mem::size_of::<OwnerProfileOwnerWrites>() <= 320);
+const _: () = assert!(core::mem::size_of::<OwnerProfilePeerWrites>() <= 320);
+
+impl OwnerProfileOwnerWrites {
+    /// Inline zero-init. `AtomicU64` is not `Copy`, so `[AtomicU64::new(0); N]`
+    /// does not compile; `from_fn` builds the array inline on the caller's
+    /// stack — no heap.
+    #[inline]
+    fn new() -> Self {
+        Self {
+            drain_latency_hist: std::array::from_fn(|_| AtomicU64::new(0)),
+            drain_invocations: AtomicU64::new(0),
+            drain_noop_invocations: AtomicU64::new(0),
+            owner_pps: AtomicU64::new(0),
+        }
+    }
+}
+
+impl OwnerProfilePeerWrites {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            redirect_acquire_hist: std::array::from_fn(|_| AtomicU64::new(0)),
+            redirect_sample_counter: AtomicU64::new(0),
+            peer_pps: AtomicU64::new(0),
+        }
+    }
+}
+
 impl MmapArea {
     pub(super) fn new(len: usize) -> io::Result<Self> {
         // Round up to 2 MB boundary for hugepage eligibility.
@@ -469,17 +557,33 @@ mod tests {
         let live = BindingLiveState::new();
         let delta_ns = 1500u64; // bucket 1 ([1024, 2048))
         let bucket = bucket_index_for_ns(delta_ns);
-        live.drain_latency_hist[bucket].fetch_add(1, Ordering::Relaxed);
-        live.drain_invocations.fetch_add(1, Ordering::Relaxed);
+        live.owner_profile_owner.drain_latency_hist[bucket].fetch_add(1, Ordering::Relaxed);
+        live.owner_profile_owner
+            .drain_invocations
+            .fetch_add(1, Ordering::Relaxed);
         assert_eq!(bucket, 1);
-        assert_eq!(live.drain_latency_hist[1].load(Ordering::Relaxed), 1);
+        assert_eq!(
+            live.owner_profile_owner.drain_latency_hist[1].load(Ordering::Relaxed),
+            1
+        );
         // Counter-factual: surrounding buckets must stay at 0. A prior
         // draft that used the wrong shift constant (e.g. `55 - clz`)
         // would light up bucket 0 or 2 here — this assertion catches
         // the off-by-one.
-        assert_eq!(live.drain_latency_hist[0].load(Ordering::Relaxed), 0);
-        assert_eq!(live.drain_latency_hist[2].load(Ordering::Relaxed), 0);
-        assert_eq!(live.drain_invocations.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            live.owner_profile_owner.drain_latency_hist[0].load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            live.owner_profile_owner.drain_latency_hist[2].load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            live.owner_profile_owner
+                .drain_invocations
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]
@@ -497,6 +601,7 @@ mod tests {
                 .expect("push");
         }
         let total_samples: u64 = live
+            .owner_profile_peer
             .redirect_acquire_hist
             .iter()
             .map(|slot| slot.load(Ordering::Relaxed))
@@ -523,6 +628,7 @@ mod tests {
                 .expect("push raw");
         }
         let pre_709_total: u64 = live2
+            .owner_profile_peer
             .redirect_acquire_hist
             .iter()
             .map(|slot| slot.load(Ordering::Relaxed))
@@ -542,8 +648,18 @@ mod tests {
         // values.
         let a = BindingLiveState::new_seeded(0);
         let b = BindingLiveState::new_seeded(1);
-        assert_eq!(a.redirect_sample_counter.load(Ordering::Relaxed), 0);
-        assert_eq!(b.redirect_sample_counter.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            a.owner_profile_peer
+                .redirect_sample_counter
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            b.owner_profile_peer
+                .redirect_sample_counter
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]
@@ -554,13 +670,21 @@ mod tests {
         // the operator CLI / Prometheus — this test fails fast on the
         // missing field.
         let live = BindingLiveState::new();
-        live.drain_latency_hist[3].store(7, Ordering::Relaxed);
-        live.drain_latency_hist[15].store(2, Ordering::Relaxed);
-        live.drain_invocations.store(100, Ordering::Relaxed);
-        live.drain_noop_invocations.store(50, Ordering::Relaxed);
-        live.redirect_acquire_hist[1].store(11, Ordering::Relaxed);
-        live.pps_owner_vs_peer[0].store(1234, Ordering::Relaxed);
-        live.pps_owner_vs_peer[1].store(567, Ordering::Relaxed);
+        live.owner_profile_owner.drain_latency_hist[3].store(7, Ordering::Relaxed);
+        live.owner_profile_owner.drain_latency_hist[15].store(2, Ordering::Relaxed);
+        live.owner_profile_owner
+            .drain_invocations
+            .store(100, Ordering::Relaxed);
+        live.owner_profile_owner
+            .drain_noop_invocations
+            .store(50, Ordering::Relaxed);
+        live.owner_profile_peer.redirect_acquire_hist[1].store(11, Ordering::Relaxed);
+        live.owner_profile_owner
+            .owner_pps
+            .store(1234, Ordering::Relaxed);
+        live.owner_profile_peer
+            .peer_pps
+            .store(567, Ordering::Relaxed);
 
         let snap = live.snapshot();
         assert_eq!(snap.drain_latency_hist[3], 7);
@@ -570,6 +694,52 @@ mod tests {
         assert_eq!(snap.redirect_acquire_hist[1], 11);
         assert_eq!(snap.owner_pps, 1234);
         assert_eq!(snap.peer_pps, 567);
+    }
+
+    #[test]
+    fn owner_profile_telemetry_is_cacheline_isolated_from_binding_live_state() {
+        // #746: pin the alignment invariant this PR is buying. If a
+        // future refactor silently drops the `#[repr(align(64))]`
+        // attribute on either of the owner-profile structs — or
+        // reshuffles `BindingLiveState` fields so the two groups
+        // land on the same cacheline as their neighbor — this test
+        // fails loudly.
+        //
+        // The two assertions are complementary: alignment on the
+        // struct types alone is not enough if the containing
+        // `BindingLiveState` somehow mis-places them, and field-offset
+        // alignment alone is not enough if the struct itself lost its
+        // `#[repr(align(64))]`.
+        use core::mem::{align_of, offset_of, size_of};
+
+        assert_eq!(align_of::<OwnerProfileOwnerWrites>(), 64);
+        assert_eq!(align_of::<OwnerProfilePeerWrites>(), 64);
+
+        let owner_off = offset_of!(BindingLiveState, owner_profile_owner);
+        let peer_off = offset_of!(BindingLiveState, owner_profile_peer);
+        assert_eq!(
+            owner_off % 64,
+            0,
+            "owner_profile_owner must sit on a 64-byte cacheline boundary",
+        );
+        assert_eq!(
+            peer_off % 64,
+            0,
+            "owner_profile_peer must sit on a 64-byte cacheline boundary",
+        );
+
+        // The two profile structs must NOT share a cacheline: their
+        // offset difference must be at least the larger struct size
+        // (both are padded to 64-B alignment, so this also implies
+        // rounded-up cacheline distance).
+        let gap = peer_off.abs_diff(owner_off);
+        assert!(
+            gap >= size_of::<OwnerProfileOwnerWrites>().max(size_of::<OwnerProfilePeerWrites>()),
+            "owner and peer profile structs must not share a cacheline (gap={gap}, \
+             owner_size={}, peer_size={})",
+            size_of::<OwnerProfileOwnerWrites>(),
+            size_of::<OwnerProfilePeerWrites>(),
+        );
     }
 
     #[test]
@@ -694,47 +864,31 @@ pub(super) struct BindingLiveState {
     /// race during config reload or helper restart. Subset of
     /// `tx_errors`.
     pub(super) no_owner_binding_drops: AtomicU64,
-    /// #709: drain-call latency buckets, powers of two in ns from 1 µs.
-    /// Bucket `N` covers `[2^(N+10) ns, 2^(N+11) ns)`. Indexed via
-    /// `bucket_index_for_ns(delta_ns)`. Written only by the owner
-    /// worker (the sole caller of `drain_shaped_tx` on this binding);
-    /// read by the snapshot path and by Prometheus scrape.
+    /// #709 / #746: owner-written telemetry, cacheline-isolated.
+    /// `drain_latency_hist` buckets sum to `drain_invocations` (pinned
+    /// in unit tests); `drain_noop_invocations` is a subset counter
+    /// (drains that returned `false`). `owner_pps` is the owner-local
+    /// pps window.
     ///
-    /// Owner-only write + Relaxed load/store is sufficient: the
-    /// snapshot reader tolerates monotonic counter tearing across a
-    /// bucket array, and Prometheus semantics are "best effort at
-    /// scrape time".
-    pub(super) drain_latency_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
-    /// #709: total number of `drain_shaped_tx` invocations on this
-    /// binding since process start. Sum of `drain_latency_hist`
-    /// buckets = drain_invocations always holds (pin in unit test).
-    /// Owner-only write.
-    pub(super) drain_invocations: AtomicU64,
-    /// #709: subset of `drain_invocations` where the drain found no
-    /// work (returned `false`). A high noop ratio means the owner is
-    /// spinning on empty — the bottleneck, if any, is upstream RX.
-    /// Owner-only write.
-    pub(super) drain_noop_invocations: AtomicU64,
-    /// #709: redirect-acquire latency sampled 1-in-(REDIRECT_SAMPLE_MASK+1)
-    /// on producers. Same power-of-two bucket layout as
-    /// `drain_latency_hist`. Multi-writer: every worker that redirects
-    /// a TX request into this binding's inbox increments a bucket on a
-    /// sampled push. Relaxed loads/stores (see comment on
-    /// `drain_latency_hist`).
-    pub(super) redirect_acquire_hist: [AtomicU64; DRAIN_HIST_BUCKETS],
-    /// #709: producer-local sample counter for the redirect-acquire
-    /// timer. Each call to `enqueue_tx_owned` does one
-    /// `fetch_add(1, Relaxed)` + `& REDIRECT_SAMPLE_MASK`; only the
-    /// every-(MASK+1)th push pays the `monotonic_nanos()` cost. Seeded
-    /// from `worker_id` at construction so different producer workers
-    /// don't lockstep their samples onto the same call.
-    pub(super) redirect_sample_counter: AtomicU64,
-    /// #709: ring-window pps counters. `[0]` accumulates owner-local
-    /// drains (packets the owner sourced itself); `[1]` accumulates
-    /// peer redirects (packets another worker produced and redirected
-    /// to this owner). Ratio tells the operator whether the owner is
-    /// overloaded. Cleared via `clear statistics class-of-service`.
-    pub(super) pps_owner_vs_peer: [AtomicU64; 2],
+    /// Written only by the owner worker (the sole caller of
+    /// `drain_shaped_tx` on this binding); read by the snapshot path
+    /// and by Prometheus scrape. Owner-only write + Relaxed load/store
+    /// is sufficient: the snapshot reader tolerates monotonic counter
+    /// tearing across a bucket array, and Prometheus semantics are
+    /// "best effort at scrape time".
+    pub(super) owner_profile_owner: OwnerProfileOwnerWrites,
+    /// #709 / #746: peer-written telemetry, cacheline-isolated.
+    /// `redirect_acquire_hist` is the redirect-acquire latency
+    /// histogram, sampled 1-in-(`REDIRECT_SAMPLE_MASK`+1) on
+    /// producers. `redirect_sample_counter` is the producer-local
+    /// sample counter; seeded from `worker_id` at construction so
+    /// different producer workers don't lockstep their samples onto
+    /// the same call. `peer_pps` is the peer-redirect pps window.
+    ///
+    /// Multi-writer: every worker that redirects a TX request into
+    /// this binding's inbox increments a bucket on a sampled push.
+    /// The owner reads via `snapshot()`.
+    pub(super) owner_profile_peer: OwnerProfilePeerWrites,
     pub(super) direct_tx_packets: AtomicU64,
     pub(super) copy_tx_packets: AtomicU64,
     pub(super) in_place_tx_packets: AtomicU64,
@@ -821,18 +975,15 @@ impl BindingLiveState {
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
-            // #709: owner-profile telemetry. Histograms are zero-init
-            // fixed-cap arrays; sum of buckets == drain_invocations
-            // invariant holds at `new()` (both 0). The sample counter
-            // seed is left at zero by `new()`; call sites that have a
-            // worker_id in hand should use `new_seeded()` instead so
-            // per-worker samples don't lockstep onto the same push.
-            drain_latency_hist: Self::zero_hist(),
-            drain_invocations: AtomicU64::new(0),
-            drain_noop_invocations: AtomicU64::new(0),
-            redirect_acquire_hist: Self::zero_hist(),
-            redirect_sample_counter: AtomicU64::new(0),
-            pps_owner_vs_peer: [AtomicU64::new(0), AtomicU64::new(0)],
+            // #709 / #746: owner-profile telemetry, split by writer
+            // into two cacheline-isolated groups. Histograms are zero-
+            // init fixed-cap arrays; sum of buckets == drain_invocations
+            // invariant holds at `new()` (both 0). The redirect-sample
+            // counter seed is left at zero by `new()`; call sites that
+            // have a worker_id in hand should use `new_seeded()` instead
+            // so per-worker samples don't lockstep onto the same push.
+            owner_profile_owner: OwnerProfileOwnerWrites::new(),
+            owner_profile_peer: OwnerProfilePeerWrites::new(),
             direct_tx_packets: AtomicU64::new(0),
             copy_tx_packets: AtomicU64::new(0),
             in_place_tx_packets: AtomicU64::new(0),
@@ -867,19 +1018,12 @@ impl BindingLiveState {
         // we care about without needing a randomness source. The mask
         // treats the counter modulo (MASK+1), so any seed ∈ [0, MASK]
         // suffices; larger worker_ids just wrap cheaply.
-        state.redirect_sample_counter = AtomicU64::new(worker_id as u64);
+        //
+        // #746: the sample counter moved into `owner_profile_peer`
+        // when the owner/peer split landed; seeding writes through the
+        // new nested path but the effect is identical.
+        state.owner_profile_peer.redirect_sample_counter = AtomicU64::new(worker_id as u64);
         state
-    }
-
-    /// #709: inline zero-initialised histogram bucket array. Factored
-    /// so `new()` and `new_seeded()` don't repeat the literal, and so
-    /// a future bucket-count bump only touches one spot.
-    #[inline]
-    fn zero_hist() -> [AtomicU64; DRAIN_HIST_BUCKETS] {
-        // `AtomicU64` is not `Copy`, so `[AtomicU64::new(0); N]` does
-        // not compile; build the array from a `from_fn` pattern. This
-        // is still a single stack allocation — no heap.
-        std::array::from_fn(|_| AtomicU64::new(0))
     }
 
     pub(super) fn set_bound(&self, socket_fd: c_int) {
@@ -1069,19 +1213,30 @@ impl BindingLiveState {
                 .lock()
                 .map(|v| v.clone())
                 .unwrap_or_default(),
-            // #709: owner-profile telemetry snapshot. Histograms are
-            // copied bucket-by-bucket under `Relaxed`. Read-side
-            // tearing is acceptable — these are diagnostic counters,
-            // not a load-bearing arithmetic invariant; the only
-            // "invariant" (sum of buckets ≈ drain_invocations) holds
-            // within a single-thread read only in steady-state, which
-            // is how operators consume the values anyway.
-            drain_latency_hist: Self::snapshot_hist(&self.drain_latency_hist),
-            drain_invocations: self.drain_invocations.load(Ordering::Relaxed),
-            drain_noop_invocations: self.drain_noop_invocations.load(Ordering::Relaxed),
-            redirect_acquire_hist: Self::snapshot_hist(&self.redirect_acquire_hist),
-            owner_pps: self.pps_owner_vs_peer[0].load(Ordering::Relaxed),
-            peer_pps: self.pps_owner_vs_peer[1].load(Ordering::Relaxed),
+            // #709 / #746: owner-profile telemetry snapshot.
+            // Histograms are copied bucket-by-bucket under `Relaxed`
+            // through the cacheline-isolated owner/peer structs.
+            // Read-side tearing is acceptable — these are diagnostic
+            // counters, not a load-bearing arithmetic invariant; the
+            // only "invariant" (sum of buckets ≈ drain_invocations)
+            // holds within a single-thread read only in steady-state,
+            // which is how operators consume the values anyway.
+            drain_latency_hist: Self::snapshot_hist(
+                &self.owner_profile_owner.drain_latency_hist,
+            ),
+            drain_invocations: self
+                .owner_profile_owner
+                .drain_invocations
+                .load(Ordering::Relaxed),
+            drain_noop_invocations: self
+                .owner_profile_owner
+                .drain_noop_invocations
+                .load(Ordering::Relaxed),
+            redirect_acquire_hist: Self::snapshot_hist(
+                &self.owner_profile_peer.redirect_acquire_hist,
+            ),
+            owner_pps: self.owner_profile_owner.owner_pps.load(Ordering::Relaxed),
+            peer_pps: self.owner_profile_peer.peer_pps.load(Ordering::Relaxed),
         }
     }
 
@@ -1112,7 +1267,10 @@ impl BindingLiveState {
         // second atomic to the MPSC inbox itself; the sample counter
         // lives on `BindingLiveState` next to the other per-binding
         // atomics. MPSC invariants from #715 are preserved.
-        let sample = (self.redirect_sample_counter.fetch_add(1, Ordering::Relaxed)
+        let sample = (self
+            .owner_profile_peer
+            .redirect_sample_counter
+            .fetch_add(1, Ordering::Relaxed)
             & REDIRECT_SAMPLE_MASK)
             == 0;
         let start = if sample {
@@ -1124,7 +1282,8 @@ impl BindingLiveState {
         if let Some(start) = start {
             let delta = monotonic_nanos().saturating_sub(start);
             let bucket = bucket_index_for_ns(delta);
-            self.redirect_acquire_hist[bucket].fetch_add(1, Ordering::Relaxed);
+            self.owner_profile_peer.redirect_acquire_hist[bucket]
+                .fetch_add(1, Ordering::Relaxed);
         }
         Ok(())
     }

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1660,17 +1660,26 @@ pub(super) struct OwnerProfileSnapshot {
 
 #[inline]
 pub(super) fn owner_profile_snapshot(live: &BindingLiveState) -> OwnerProfileSnapshot {
+    // #746: atomics now live on cacheline-isolated `owner_profile_owner`
+    // / `owner_profile_peer` nested structs. This snapshot reads from
+    // both but the shape it produces is byte-identical to pre-refactor.
     OwnerProfileSnapshot {
         drain_latency_hist: std::array::from_fn(|i| {
-            live.drain_latency_hist[i].load(Ordering::Relaxed)
+            live.owner_profile_owner.drain_latency_hist[i].load(Ordering::Relaxed)
         }),
-        drain_invocations: live.drain_invocations.load(Ordering::Relaxed),
-        drain_noop_invocations: live.drain_noop_invocations.load(Ordering::Relaxed),
+        drain_invocations: live
+            .owner_profile_owner
+            .drain_invocations
+            .load(Ordering::Relaxed),
+        drain_noop_invocations: live
+            .owner_profile_owner
+            .drain_noop_invocations
+            .load(Ordering::Relaxed),
         redirect_acquire_hist: std::array::from_fn(|i| {
-            live.redirect_acquire_hist[i].load(Ordering::Relaxed)
+            live.owner_profile_peer.redirect_acquire_hist[i].load(Ordering::Relaxed)
         }),
-        owner_pps: live.pps_owner_vs_peer[0].load(Ordering::Relaxed),
-        peer_pps: live.pps_owner_vs_peer[1].load(Ordering::Relaxed),
+        owner_pps: live.owner_profile_owner.owner_pps.load(Ordering::Relaxed),
+        peer_pps: live.owner_profile_peer.peer_pps.load(Ordering::Relaxed),
     }
 }
 
@@ -2139,20 +2148,44 @@ mod tests {
         };
 
         let live_a = BindingLiveState::new();
-        live_a.drain_latency_hist[0].store(5, Ordering::Relaxed);
-        live_a.redirect_acquire_hist[1].store(3, Ordering::Relaxed);
-        live_a.drain_invocations.store(5, Ordering::Relaxed);
-        live_a.drain_noop_invocations.store(1, Ordering::Relaxed);
-        live_a.pps_owner_vs_peer[0].store(100, Ordering::Relaxed);
-        live_a.pps_owner_vs_peer[1].store(40, Ordering::Relaxed);
+        live_a.owner_profile_owner.drain_latency_hist[0].store(5, Ordering::Relaxed);
+        live_a.owner_profile_peer.redirect_acquire_hist[1].store(3, Ordering::Relaxed);
+        live_a
+            .owner_profile_owner
+            .drain_invocations
+            .store(5, Ordering::Relaxed);
+        live_a
+            .owner_profile_owner
+            .drain_noop_invocations
+            .store(1, Ordering::Relaxed);
+        live_a
+            .owner_profile_owner
+            .owner_pps
+            .store(100, Ordering::Relaxed);
+        live_a
+            .owner_profile_peer
+            .peer_pps
+            .store(40, Ordering::Relaxed);
 
         let live_b = BindingLiveState::new();
-        live_b.drain_latency_hist[7].store(11, Ordering::Relaxed);
-        live_b.redirect_acquire_hist[2].store(13, Ordering::Relaxed);
-        live_b.drain_invocations.store(11, Ordering::Relaxed);
-        live_b.drain_noop_invocations.store(2, Ordering::Relaxed);
-        live_b.pps_owner_vs_peer[0].store(200, Ordering::Relaxed);
-        live_b.pps_owner_vs_peer[1].store(50, Ordering::Relaxed);
+        live_b.owner_profile_owner.drain_latency_hist[7].store(11, Ordering::Relaxed);
+        live_b.owner_profile_peer.redirect_acquire_hist[2].store(13, Ordering::Relaxed);
+        live_b
+            .owner_profile_owner
+            .drain_invocations
+            .store(11, Ordering::Relaxed);
+        live_b
+            .owner_profile_owner
+            .drain_noop_invocations
+            .store(2, Ordering::Relaxed);
+        live_b
+            .owner_profile_owner
+            .owner_pps
+            .store(200, Ordering::Relaxed);
+        live_b
+            .owner_profile_peer
+            .peer_pps
+            .store(50, Ordering::Relaxed);
 
         let mut first = FastMap::default();
         first.insert(80, make_root());


### PR DESCRIPTION
## Summary

- Split #709 / #731 owner-profile telemetry on `BindingLiveState` into two `#[repr(align(64))]` structs by writer: `OwnerProfileOwnerWrites` (drain_latency_hist / drain_invocations / drain_noop_invocations / owner_pps) and `OwnerProfilePeerWrites` (redirect_acquire_hist / redirect_sample_counter / peer_pps). Both 192 B = 3 cachelines, landing at 64 B-aligned offsets within `BindingLiveState`.
- Decomposed `pps_owner_vs_peer: [AtomicU64; 2]` along its true writer boundary — `[0]` → `owner_pps` on the owner struct, `[1]` → `peer_pps` on the peer struct. The array was a uniform-indexing concession at #731 time, not a design invariant.
- Compile-time layout guards (`const _: () = assert!(align_of == 64)`, `size_of <= 320`) pin the invariant so a silent `#[repr(align(64))]` drop or a future packed neighbor fails the build, not the next regression test.
- Matches the in-repo `CachePadded` idiom introduced in #715 (`mpsc_inbox.rs`).

## Hot-path shape

- No new atomics. No removed atomics. No changed orderings. All update sites keep the same `fetch_add(1, Ordering::Relaxed)` + bucket index they had pre-refactor; only the access path is longer by one field hop (`binding.live.drain_invocations` → `binding.live.owner_profile_owner.drain_invocations`). The nested struct is `#[repr(align(64))]` but otherwise has no indirection or vtable.
- Snapshot wire contract unchanged: `BindingLiveSnapshot` fields are byte-identical. `protocol.rs` untouched. Go side untouched. Prometheus surface untouched.
- Counter semantics unchanged. `drain_invocations` increments exactly the same way at the same call site. #748 coherence invariant (`sum(drain_latency_hist) == drain_invocations`) still holds — pinned in the retained tests.

## Layout sketch

```
BindingLiveState {
    ... [~56 flat AtomicU64 + Mutex + MpscInbox]
    owner_profile_owner: OwnerProfileOwnerWrites { align=64, size=192 }
    owner_profile_peer:  OwnerProfilePeerWrites  { align=64, size=192 }
    ... [MpscInbox + pending_session_deltas]
}

OwnerProfileOwnerWrites @ align 64:                   // owner-only writes
    drain_latency_hist:     [AtomicU64; 16]    128 B
    drain_invocations:      AtomicU64            8 B
    drain_noop_invocations: AtomicU64            8 B
    owner_pps:              AtomicU64            8 B
    (pad)                                       40 B  → 192 B / 3 lines

OwnerProfilePeerWrites @ align 64:                    // peer worker writes
    redirect_acquire_hist:   [AtomicU64; 16]   128 B
    redirect_sample_counter: AtomicU64           8 B
    peer_pps:                AtomicU64           8 B
    (pad)                                       48 B  → 192 B / 3 lines
```

## Test plan

- [x] `cargo test --manifest-path userspace-dp/Cargo.toml` — 699 passed, 0 failed, 1 ignored (baseline 698 + 1 new alignment test).
- [x] #748 coherence invariant pinned tests pass unchanged: `aggregate_cos_statuses_sums_owner_profile_across_workers_coherently`, `build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant`.
- [x] #731 snapshot test passes unchanged: `binding_live_snapshot_propagates_709_owner_profile_counters`.
- [x] New alignment test `owner_profile_telemetry_is_cacheline_isolated_from_binding_live_state` uses `core::mem::offset_of!` (stable 1.77) to assert both structs sit on 64 B boundaries within `BindingLiveState` and do not share a cacheline.
- [x] Cluster deploy (`loss:xpf-userspace-fw0` / `fw1`), CoS reapplied via `apply-cos-config.sh`, 3× `userspace-perf-compare.sh --duration 8 --parallel 12` runs before and after.

## Live data

3 runs before, 3 runs after, 12-parallel iperf3 via the `loss` userspace cluster, CoS enabled:

| Metric    | Baseline (3 runs)           | Refactor (3 runs)          | Mean Δ       |
|-----------|-----------------------------|----------------------------|--------------|
| IPv4 Gbps | 1.147 / 1.169 / 1.138       | 1.115 / 1.200 / 1.207      | +23 Mbps     |
| IPv6 Gbps | 1.102 / 1.109 / 1.087       | 1.049 / 1.080 / 1.144      | -8 Mbps      |

Both well inside the ±100 Mbps tolerance. Retransmits are noisy (50K–66K across runs) with no directional trend. No `owner_profile*` or `BindingLiveState` symbol appears in the top-160 perf output either before or after — below the noise floor at this traffic shape. That is the expected outcome: this PR repositions atomics, it does not add or remove hot-path work, and the lab's flow rate does not stress cross-core telemetry contention enough for the layout change to show up as a directional Gbps signal.

Post-refactor `show class-of-service interface reth0.80` on the live helper confirms counters still populate:

```
OwnerProfile: drain_p50=0us  drain_p99=8us  redirect_p99=0us
              owner_pps=0  peer_pps=3348236
```

drain_latency_hist is being written correctly on the owner cacheline; peer_pps is being written correctly on the peer cacheline; shape matches pre-refactor exactly.

## Deferred

- Other likely cacheline-isolation candidates on `BindingLiveState` (`redirect_inbox_overflow_drops`, `pending_tx_local_overflow_drops` from #710, the `pending_tx: MpscInbox` head/tail vs scalar counter neighborhood) — left intentionally out of scope per engineering-style.md first principle #5. Any follow-up should be filed as its own issue with its own layout rationale.

## Refs

- Closes #746
- Follows #709 / #731 (owner-profile telemetry introduction)
- Follows #748 (owner-profile telemetry aggregation correctness — pinned invariant preserved)
- Follows #715 (`CachePadded` idiom, `mpsc_inbox.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)