### PR TITLE
config: warn when `system processes X disable` names an unmanaged process (fixes #654)

### DIFF
--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -553,7 +553,7 @@ func ValidateConfig(cfg *Config) []string {
 	for _, proc := range cfg.System.DisabledProcesses {
 		if !isKnownProcessName(proc) {
 			warnings = append(warnings, fmt.Sprintf(
-				"system processes %s disable: bpfrx does not manage %q; setting has no runtime effect", proc, proc))
+				"system processes %q disable: bpfrx does not manage %q; setting has no runtime effect", proc, proc))
 		}
 	}
 
@@ -720,9 +720,13 @@ func ValidateConfig(cfg *Config) []string {
 
 // knownManagedProcessNames is the set of Junos process names that bpfrx
 // actually honours when `system processes X disable` is configured.
-// See pkg/daemon/daemon.go (snmpd) and daemon_system.go (ntp) for the
-// runtime sites that consult this list. Extending the set requires both
-// updating this map AND adding the gating logic at the runtime site.
+// The runtime sites hard-code their process name (not a table lookup):
+//   - pkg/daemon/daemon.go ~:715 — `isProcessDisabled(cfg, "snmpd")`
+//   - pkg/daemon/daemon_system.go ~:383 — `isProcessDisabled(cfg, "ntp")`
+// This table mirrors those hard-codes for the purpose of the #654
+// validation warning. Any addition here MUST be paired with a matching
+// runtime gating site, or the warning will go quiet while the knob
+// remains a no-op.
 var knownManagedProcessNames = map[string]struct{}{
 	"snmpd": {},
 	"ntp":   {},

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -546,6 +546,17 @@ func ValidateConfig(cfg *Config) []string {
 		warnings = append(warnings, "system commit persist-groups-inheritance configured but group inheritance persistence is not implemented")
 	}
 
+	// #654: warn on `system processes X disable` for a process that
+	// bpfrx does not actually manage. Silently accepting the knob (as
+	// used to happen with e.g. `utmd disable` on vSRX) means the
+	// operator gets no signal that the setting is a no-op.
+	for _, proc := range cfg.System.DisabledProcesses {
+		if !isKnownProcessName(proc) {
+			warnings = append(warnings, fmt.Sprintf(
+				"system processes %s disable: bpfrx does not manage %q; setting has no runtime effect", proc, proc))
+		}
+	}
+
 	if cfg.System.Services != nil && cfg.System.Services.DNSProxyConfigured {
 		warnings = append(warnings, "system services dns dns-proxy configured but DNS proxy/forwarder runtime is not implemented")
 	}
@@ -705,6 +716,21 @@ func ValidateConfig(cfg *Config) []string {
 	}
 
 	return warnings
+}
+
+// knownManagedProcessNames is the set of Junos process names that bpfrx
+// actually honours when `system processes X disable` is configured.
+// See pkg/daemon/daemon.go (snmpd) and daemon_system.go (ntp) for the
+// runtime sites that consult this list. Extending the set requires both
+// updating this map AND adding the gating logic at the runtime site.
+var knownManagedProcessNames = map[string]struct{}{
+	"snmpd": {},
+	"ntp":   {},
+}
+
+func isKnownProcessName(name string) bool {
+	_, ok := knownManagedProcessNames[name]
+	return ok
 }
 
 func compileApplications(node *Node, apps *ApplicationsConfig) error {

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -3876,6 +3876,52 @@ func TestValidateConfigApplicationPorts(t *testing.T) {
 	}
 }
 
+// TestValidateConfig_DisabledProcessWarnsOnUnknown pins #654: `system
+// processes <X> disable` must WARN when bpfrx does not actually manage
+// <X>. Silently accepting it (as `utmd disable` did) gave operators no
+// signal that the knob is a no-op. Known-managed processes (snmpd, ntp)
+// must NOT produce the warning.
+func TestValidateConfig_DisabledProcessWarnsOnUnknown(t *testing.T) {
+	cfg := &Config{}
+	cfg.Applications.Applications = map[string]*Application{}
+	cfg.Applications.ApplicationSets = map[string]*ApplicationSet{}
+	cfg.Security.Zones = map[string]*ZoneConfig{}
+	cfg.System.DisabledProcesses = []string{"utmd", "snmpd", "ntp", "idpd"}
+
+	warnings := ValidateConfig(cfg)
+
+	sawUtmdWarn := false
+	sawIdpdWarn := false
+	sawSnmpdWarn := false
+	sawNtpWarn := false
+	for _, w := range warnings {
+		if strings.Contains(w, "utmd") && strings.Contains(w, "no runtime effect") {
+			sawUtmdWarn = true
+		}
+		if strings.Contains(w, "idpd") && strings.Contains(w, "no runtime effect") {
+			sawIdpdWarn = true
+		}
+		if strings.Contains(w, "\"snmpd\"") && strings.Contains(w, "no runtime effect") {
+			sawSnmpdWarn = true
+		}
+		if strings.Contains(w, "\"ntp\"") && strings.Contains(w, "no runtime effect") {
+			sawNtpWarn = true
+		}
+	}
+	if !sawUtmdWarn {
+		t.Error("expected warning for utmd disable (not managed by bpfrx)")
+	}
+	if !sawIdpdWarn {
+		t.Error("expected warning for idpd disable (not managed by bpfrx)")
+	}
+	if sawSnmpdWarn {
+		t.Error("snmpd is managed by bpfrx; should not warn")
+	}
+	if sawNtpWarn {
+		t.Error("ntp is managed by bpfrx; should not warn")
+	}
+}
+
 func TestLo0FilterExtraction(t *testing.T) {
 	input := `interfaces {
     lo0 {


### PR DESCRIPTION
## Summary

\`vsrx.conf\` ships with \`system processes { utmd disable; }\`. On vSRX that disables the UTM daemon. bpfrx has no UTM subsystem, so the knob is silently accepted with no runtime effect. Operators importing vSRX configs get no signal that the setting is a no-op.

Emit a validation warning for any disabled process name that is not in the allowlist of processes bpfrx actually gates.

## Changes

- \`pkg/config/compiler.go\` (\`ValidateConfig\`): iterate \`cfg.System.DisabledProcesses\`; warn on any name not in \`knownManagedProcessNames\`.
- \`pkg/config/compiler.go\` (new helper): \`knownManagedProcessNames\` map + \`isKnownProcessName\`. Centralizing it means extending the set requires both updating the map AND adding the runtime gating logic.

Current set: \`snmpd\` (daemon.go:715 — gates SNMP agent startup), \`ntp\` (daemon_system.go:383 — gates NTP setup). Any other name warns.

## Test plan

- [x] \`TestValidateConfig_DisabledProcessWarnsOnUnknown\` — pins \`utmd\` and \`idpd\` warn with \"no runtime effect\", \`snmpd\` and \`ntp\` stay silent.
- [x] \`make test\` — all Go tests pass.

## Scope

Narrow. The warning makes an existing silent no-op visible. Generalizing \`system processes X disable\` to actually reject/honour arbitrary process names is a behaviour choice and belongs in its own issue/PR.

## Refs

Fixes #654
Related: #762 (meta tracker), #651, #653 (other vSRX config parity gaps)