### PR TITLE
daemon + api: surface compile-fail state via /health (fixes #758)

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -34,8 +34,30 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, Response{Success: false, Error: msg})
 }
 
+// healthHandler surfaces dataplane compile health (#758) alongside the
+// simple "ok" probe. When the dataplane compile has failed and has
+// never succeeded since startup, return 503 with a structured "status:
+// degraded" payload so operators scanning a probe can distinguish the
+// catastrophic-silent-fail case from a healthy daemon.
 func (s *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
-	writeOK(w, map[string]string{"status": "ok"})
+	payload := map[string]any{"status": "ok"}
+	if s.compileHealthFn != nil {
+		h := s.compileHealthFn()
+		payload["compile_ever_succeeded"] = h.EverSucceeded
+		payload["compile_failure_count"] = h.FailureCount
+		if h.LastError != "" {
+			payload["compile_last_error"] = h.LastError
+		}
+		if h.LastErrorUnixSec != 0 {
+			payload["compile_last_error_unix"] = h.LastErrorUnixSec
+		}
+		if !h.EverSucceeded && h.FailureCount > 0 {
+			payload["status"] = "degraded"
+			writeJSON(w, http.StatusServiceUnavailable, Response{Success: false, Data: payload, Error: "dataplane compile has never succeeded"})
+			return
+		}
+	}
+	writeOK(w, payload)
 }
 
 func (s *Server) statusHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHealthHandler_DegradedWhenCompileNeverSucceeded pins #758: when
+// the daemon's dataplane compile has failed and never succeeded, /health
+// must return 503 with status="degraded", not 200 with status="ok". A
+// probe reading the old 200-and-opaque response alongside a single WARN
+// in the journal gave operators no signal that forwarding was broken.
+func TestHealthHandler_DegradedWhenCompileNeverSucceeded(t *testing.T) {
+	s := &Server{
+		compileHealthFn: func() CompileHealthSnapshot {
+			return CompileHealthSnapshot{
+				EverSucceeded:    false,
+				FailureCount:     3,
+				LastError:        "compile zones: add tx port fab0: key too big for map",
+				LastErrorUnixSec: 1_700_000_000,
+			}
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/health", nil)
+	s.healthHandler(rr, req)
+
+	if rr.Code != 503 {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Success {
+		t.Error("success must be false for degraded health")
+	}
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data = %T, want map", resp.Data)
+	}
+	if s, _ := data["status"].(string); s != "degraded" {
+		t.Errorf("status = %q, want \"degraded\"", s)
+	}
+	if ever, _ := data["compile_ever_succeeded"].(bool); ever {
+		t.Error("compile_ever_succeeded should be false")
+	}
+	if msg, _ := data["compile_last_error"].(string); msg == "" {
+		t.Error("compile_last_error should be populated")
+	}
+}
+
+// TestHealthHandler_OKAfterCompileSucceeds pins the complementary
+// half: once compile has succeeded, /health returns 200/ok regardless
+// of how many failures happened before. The counter stays visible for
+// observability but no longer gates the probe.
+func TestHealthHandler_OKAfterCompileSucceeds(t *testing.T) {
+	s := &Server{
+		compileHealthFn: func() CompileHealthSnapshot {
+			return CompileHealthSnapshot{
+				EverSucceeded: true,
+				FailureCount:  2,
+				LastError:     "",
+			}
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/health", nil)
+	s.healthHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if s, _ := data["status"].(string); s != "ok" {
+		t.Errorf("status = %q, want \"ok\"", s)
+	}
+	// Counter still visible so operators can tell the daemon had
+	// transient issues even after recovery.
+	if fc, ok := data["compile_failure_count"].(float64); !ok || fc != 2 {
+		t.Errorf("compile_failure_count = %v, want 2", data["compile_failure_count"])
+	}
+}
+
+// TestHealthHandler_NoCompileFnKeepsLegacyBehaviour pins backwards
+// compatibility: callers that do not wire CompileHealthFn (tests,
+// embeddings) must keep the pre-#758 200/ok behaviour.
+func TestHealthHandler_NoCompileFnKeepsLegacyBehaviour(t *testing.T) {
+	s := &Server{} // compileHealthFn intentionally nil
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/health", nil)
+	s.healthHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Errorf("status = %d, want 200 (legacy)", rr.Code)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -30,6 +30,16 @@ import (
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
+// CompileHealthSnapshot mirrors daemon.CompileHealth without the import.
+// Keeping pkg/api -> pkg/daemon free of a back-edge preserves the layered
+// build shape; the daemon injects a callback that returns this struct.
+type CompileHealthSnapshot struct {
+	EverSucceeded    bool
+	FailureCount     uint64
+	LastError        string
+	LastErrorUnixSec int64
+}
+
 // Config configures the API server.
 type Config struct {
 	Addr      string
@@ -46,6 +56,12 @@ type Config struct {
 	DHCP      *dhcp.Manager
 	VRRPMgr   *vrrp.Manager       // native VRRP manager
 	ApplyFn   func(*config.Config) // daemon's applyConfig callback
+	// CompileHealthFn surfaces dataplane compile state via /health (#758).
+	// Returning a snapshot with EverSucceeded=false and FailureCount>0
+	// makes /health return 503 so operators see the degraded state
+	// instead of reading "status: ok" alongside a one-shot WARN in the
+	// journal. Optional; if nil, /health keeps the pre-#758 behaviour.
+	CompileHealthFn func() CompileHealthSnapshot
 }
 
 // Server is the HTTP API server.
@@ -60,9 +76,10 @@ type Server struct {
 	frr         *frr.Manager
 	ipsec       *ipsec.Manager
 	dhcp        *dhcp.Manager
-	vrrpMgr     *vrrp.Manager
-	applyFn     func(*config.Config)
-	startTime   time.Time
+	vrrpMgr         *vrrp.Manager
+	applyFn         func(*config.Config)
+	compileHealthFn func() CompileHealthSnapshot
+	startTime       time.Time
 }
 
 // NewServer creates a new API server.
@@ -76,9 +93,10 @@ func NewServer(cfg Config) *Server {
 		frr:       cfg.FRR,
 		ipsec:     cfg.IPsec,
 		dhcp:      cfg.DHCP,
-		vrrpMgr:   cfg.VRRPMgr,
-		applyFn:   cfg.ApplyFn,
-		startTime: time.Now(),
+		vrrpMgr:         cfg.VRRPMgr,
+		applyFn:         cfg.ApplyFn,
+		compileHealthFn: cfg.CompileHealthFn,
+		startTime:       time.Now(),
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/daemon/compile_health_test.go
+++ b/pkg/daemon/compile_health_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestCompileHealth_RecordFailure pins the #758 state transitions:
+// - recordCompileFailure increments the counter and captures the error
+// - recordCompileSuccess flips EverSucceeded and clears LastError, but
+//   preserves the failure count so operators can see past transience
+// - counter-factual: before recording any failure, the snapshot shows
+//   EverSucceeded=false with FailureCount=0 — /health treats this as
+//   healthy (the "never tried" case matches the "succeeded once" path
+//   rather than the "persistent failure" path).
+func TestCompileHealth_RecordFailure(t *testing.T) {
+	d := &Daemon{}
+
+	// Initial: zero state. /health must treat this as healthy (not
+	// degraded) — the gate fires only on FailureCount > 0.
+	s := d.CompileHealthSnapshot()
+	if s.EverSucceeded || s.FailureCount != 0 || s.LastError != "" {
+		t.Errorf("initial snapshot = %+v, want zero value", s)
+	}
+
+	// Record a failure. The counter increments; LastError carries
+	// through verbatim; EverSucceeded stays false.
+	d.recordCompileFailure(errors.New("compile zones: add tx port fab0: key too big for map"))
+	s = d.CompileHealthSnapshot()
+	if s.EverSucceeded {
+		t.Error("EverSucceeded must stay false before any success")
+	}
+	if s.FailureCount != 1 {
+		t.Errorf("FailureCount = %d, want 1", s.FailureCount)
+	}
+	if s.LastError == "" {
+		t.Error("LastError must be populated on failure")
+	}
+
+	// Second failure with a different error: counter advances,
+	// LastError rewrites to the latest message.
+	d.recordCompileFailure(errors.New("different compile failure"))
+	s = d.CompileHealthSnapshot()
+	if s.FailureCount != 2 {
+		t.Errorf("FailureCount after second failure = %d, want 2", s.FailureCount)
+	}
+	if s.LastError != "different compile failure" {
+		t.Errorf("LastError = %q, want the most recent error text", s.LastError)
+	}
+
+	// Success flips EverSucceeded and clears LastError but preserves
+	// the failure count (monotonic observability counter).
+	d.recordCompileSuccess()
+	s = d.CompileHealthSnapshot()
+	if !s.EverSucceeded {
+		t.Error("EverSucceeded must be true after a success")
+	}
+	if s.LastError != "" {
+		t.Errorf("LastError = %q, want empty after success", s.LastError)
+	}
+	if s.FailureCount != 2 {
+		t.Errorf("FailureCount after success = %d, want 2 (preserved)", s.FailureCount)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -250,6 +250,76 @@ type Daemon struct {
 	// not rerun the same barrier sequence immediately afterward.
 	userspaceDemotionPrepMu    sync.Mutex
 	userspaceDemotionPrepUntil map[int]time.Time
+
+	// Compile health (#758). If dataplane compile fails and never
+	// succeeds, the daemon is in a degraded state: config is accepted
+	// but the forwarding path may be partial or absent. Track this so
+	// /health can surface it and operators aren't left staring at a
+	// single pre-existing WARN line with no other signal.
+	compileHealthMu         sync.Mutex
+	compileFailureCount     uint64 // total failed compiles since daemon start
+	compileEverSucceeded    bool   // true once any compile completed cleanly
+	compileLastError        string // text of the most recent compile error
+	compileLastErrorUnixSec int64  // timestamp of the most recent compile error
+}
+
+// CompileHealth is a snapshot of dataplane compile health (#758).
+// Consumed by /health to surface a degraded state instead of returning
+// OK when the dataplane never compiled successfully.
+type CompileHealth struct {
+	EverSucceeded    bool
+	FailureCount     uint64
+	LastError        string
+	LastErrorUnixSec int64
+}
+
+// recordCompileFailure tracks a dataplane compile failure and emits an
+// escalating log (#758). The first failure remains a single WARN;
+// every Nth repeat re-emits at ERROR level so an operator tailing the
+// journal sees the degraded state without needing to know the original
+// failure text. A success clears the counter via recordCompileSuccess.
+func (d *Daemon) recordCompileFailure(err error) {
+	d.compileHealthMu.Lock()
+	d.compileFailureCount++
+	d.compileLastError = err.Error()
+	d.compileLastErrorUnixSec = time.Now().Unix()
+	count := d.compileFailureCount
+	everOk := d.compileEverSucceeded
+	d.compileHealthMu.Unlock()
+
+	// First WARN fires on every failure — matches pre-#758 behaviour.
+	// Escalate to ERROR on the 5th consecutive failure with no prior
+	// success, and again every 10 failures thereafter, so a persistent
+	// degraded state stays visible in the log without flooding.
+	slog.Warn("failed to compile dataplane", "err", err, "attempt", count, "ever_ok", everOk)
+	if !everOk && (count == 5 || (count > 5 && count%10 == 0)) {
+		slog.Error("dataplane compile has failed repeatedly; forwarding path is degraded",
+			"attempt", count, "err", err)
+	}
+}
+
+// recordCompileSuccess clears compile failure state. The failure count
+// is intentionally preserved as a monotonic "have we ever hit this"
+// counter (exported via CompileHealthSnapshot), but the "ever ok" flag
+// flips true so /health goes back to healthy.
+func (d *Daemon) recordCompileSuccess() {
+	d.compileHealthMu.Lock()
+	d.compileEverSucceeded = true
+	d.compileLastError = ""
+	d.compileHealthMu.Unlock()
+}
+
+// CompileHealthSnapshot returns the current compile health for /health
+// and operator-facing RPCs. Safe to call concurrently.
+func (d *Daemon) CompileHealthSnapshot() CompileHealth {
+	d.compileHealthMu.Lock()
+	defer d.compileHealthMu.Unlock()
+	return CompileHealth{
+		EverSucceeded:    d.compileEverSucceeded,
+		FailureCount:     d.compileFailureCount,
+		LastError:        d.compileLastError,
+		LastErrorUnixSec: d.compileLastErrorUnixSec,
+	}
 }
 
 const standbyNeighborRefreshMinInterval = time.Second
@@ -845,6 +915,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 			DHCP:     d.dhcp,
 			VRRPMgr:  d.vrrpMgr,
 			ApplyFn:  d.applyConfig,
+			// #758: surface compile state so /health returns 503
+			// when the dataplane has never compiled successfully.
+			CompileHealthFn: func() api.CompileHealthSnapshot {
+				h := d.CompileHealthSnapshot()
+				return api.CompileHealthSnapshot{
+					EverSucceeded:    h.EverSucceeded,
+					FailureCount:     h.FailureCount,
+					LastError:        h.LastError,
+					LastErrorUnixSec: h.LastErrorUnixSec,
+				}
+			},
 		}
 		// Resolve interface bindings from web-management config
 		if cfg := d.store.ActiveConfig(); cfg != nil && cfg.System.Services != nil &&
@@ -1642,7 +1723,9 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 	if d.dp != nil {
 		var err error
 		if compileResult, err = d.dp.Compile(cfg); err != nil {
-			slog.Warn("failed to compile dataplane", "err", err)
+			d.recordCompileFailure(err)
+		} else {
+			d.recordCompileSuccess()
 		}
 	}
 


### PR DESCRIPTION
## Summary

When \`Compile()\` failed (e.g. the ifindex > cap case fixed in #756/#759), the daemon logged a single WARN and then silently kept running with a partially- or entirely-broken forwarding path. /health kept returning 200 \"ok\". Operators and probes had no signal.

Track compile health on the daemon and surface it in /health.

## Changes

- **\`pkg/daemon/daemon.go\`**: add \`compileEverSucceeded\` / \`compileFailureCount\` / \`compileLastError*\` state under a mutex. Replace the single WARN with \`recordCompileFailure(err)\` — still WARN per attempt, escalates to ERROR on the 5th consecutive failure and every 10th thereafter so a persistent degraded state stays visible without flooding.
- **\`pkg/api/Config\`**: new optional \`CompileHealthFn func() CompileHealthSnapshot\`. When wired, \`/health\` returns \`503 {\"status\":\"degraded\", ...}\` whenever \`!EverSucceeded && FailureCount > 0\`. The snapshot carries the failure count, last error text, and timestamp into the response either way so /health is useful for observability even when healthy.
- **Legacy preserved**: if \`CompileHealthFn\` is nil, \`/health\` keeps the pre-#758 200/ok behaviour.
- **Daemon wiring**: \`applyConfig\` now calls \`recordCompileFailure\` / \`recordCompileSuccess\` around the existing \`d.dp.Compile(cfg)\` call, and the \`api.Config\` builder injects the callback.

## Scope

Narrow. The PR surfaces the state; exponential-backoff retry of Compile itself (so transient races self-heal without a new commit) is a natural follow-up but not required to stop the silent-fail.

## Test plan

- [x] \`TestHealthHandler_DegradedWhenCompileNeverSucceeded\` — 503 + \"degraded\".
- [x] \`TestHealthHandler_OKAfterCompileSucceeds\` — 200 + counter preserved.
- [x] \`TestHealthHandler_NoCompileFnKeepsLegacyBehaviour\` — legacy 200/ok.
- [x] \`TestCompileHealth_RecordFailure\` — failure/success transitions, counter-factual on initial zero state, LastError clearing on success.
- [x] \`make test\` — all Go tests pass.
- [x] \`make build\` — OK.

## Refs

Fixes #758
Related: #762 (meta), #756 (original trigger), #757 (sibling: reconcile log flood when helper is down)