### PR TITLE
userspace-dp: move drain telemetry per-queue; render binding-scoped fields once per interface (fixes #751, #732)

### DIFF
--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -105,6 +105,14 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 				view.interfaceState.TimerLevel0Sleepers,
 				view.interfaceState.TimerLevel1Sleepers)
 		}
+		// #732 / #751: binding-scoped telemetry rendered once per
+		// interface instead of under every queue row. owner_pps /
+		// peer_pps / redirect_p99 describe binding-wide arrivals
+		// and redirects; producers don't know a target queue at
+		// redirect time so these values are inherently per-binding.
+		// Pre-#751 each queue row reported the same values, which
+		// was the #732 symptom.
+		renderBindingScopedTelemetry(&b, cfg, view)
 		queues := buildCoSQueueViews(cfg, view)
 		if len(queues) == 0 {
 			b.WriteString("  Queues:                   none\n")
@@ -174,20 +182,22 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 				queue.admissionBufferDrops,
 				queue.admissionEcnMarked,
 			)
-			// #709: OwnerProfile line — rendered only for exact queues
-			// with a named owner worker. Non-exact / shared_exact
-			// queues have no single owner binding whose latency is
-			// meaningful, so the row would be misleading for those
-			// (see `TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner`).
-			if queue.ownerWorker != nil {
+			// #709 / #751: per-queue OwnerProfile line renders only
+			// the queue-scoped drain percentiles. The binding-scoped
+			// fields (redirect_p99 / owner_pps / peer_pps) moved to
+			// the interface header via renderBindingScopedTelemetry
+			// so they are no longer repeated under every queue row
+			// (#732). Non-exact / shared_exact queues keep an empty
+			// per-queue hist post-#751 because the drain path only
+			// writes the atomics when it services them, so
+			// drainInvocations==0 correctly suppresses the row.
+			if queue.ownerWorker != nil && queue.drainInvocations > 0 {
 				fmt.Fprintf(
 					&b,
-					"           OwnerProfile: drain_p50=%s  drain_p99=%s  redirect_p99=%s  owner_pps=%d  peer_pps=%d\n",
+					"           OwnerProfile: drain_p50=%s  drain_p99=%s  drain_invocations=%d\n",
 					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 50),
 					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 99),
-					formatHistPercentileMicrosFromBuckets(queue.redirectAcquireHist, 99),
-					queue.ownerPPS,
-					queue.peerPPS,
+					queue.drainInvocations,
 				)
 			}
 		}
@@ -237,6 +247,50 @@ func formatHistPercentileMicrosFromBuckets(hist []uint64, percentile int) string
 		total += count
 	}
 	return formatHistPercentileMicros(hist, total, percentile)
+}
+
+// #732 / #751: render a single "Binding telemetry" line per interface
+// carrying the values that are inherently binding-scoped (producers do
+// not know the target queue at redirect time). Rust's snapshot path
+// attributes these to the sole unambiguous owner-local exact queue row,
+// or leaves them at zero when the shape is ambiguous. We gather them
+// from whichever queue carries non-zero values and render once at the
+// interface level, replacing the pre-#751 per-queue repetition.
+//
+// Zero-in-all-fields is suppressed so interfaces with no exact queue
+// or ambiguous shape don't get a noise line.
+func renderBindingScopedTelemetry(b *strings.Builder, cfg *config.Config, view cosInterfaceView) {
+	if view.interfaceState == nil {
+		return
+	}
+	queues := buildCoSQueueViews(cfg, view)
+	var (
+		ownerPPS       uint64
+		peerPPS        uint64
+		redirectHist   []uint64
+	)
+	for _, q := range queues {
+		if q.ownerPPS > ownerPPS {
+			ownerPPS = q.ownerPPS
+		}
+		if q.peerPPS > peerPPS {
+			peerPPS = q.peerPPS
+		}
+		if redirectHist == nil && len(q.redirectAcquireHist) > 0 {
+			redirectHist = q.redirectAcquireHist
+		}
+	}
+	// Gate: nothing meaningful to render.
+	if ownerPPS == 0 && peerPPS == 0 && len(redirectHist) == 0 {
+		return
+	}
+	fmt.Fprintf(
+		b,
+		"  Binding telemetry:        redirect_p99=%s  owner_pps=%d  peer_pps=%d\n",
+		formatHistPercentileMicrosFromBuckets(redirectHist, 99),
+		ownerPPS,
+		peerPPS,
+	)
 }
 
 // #709: map a bucket index to its lower bound, formatted as µs. The

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -105,6 +105,14 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 				view.interfaceState.TimerLevel0Sleepers,
 				view.interfaceState.TimerLevel1Sleepers)
 		}
+		// Build queue views once per interface and share the slice
+		// between the binding-scoped telemetry render and the main
+		// queue table below. Copilot flagged that the first rev of
+		// this PR invoked buildCoSQueueViews twice — once inside
+		// renderBindingScopedTelemetry, again here — which doubled
+		// work and risked drift if buildCoSQueueViews filter/order
+		// ever changed.
+		queues := buildCoSQueueViews(cfg, view)
 		// #732 / #751: binding-scoped telemetry rendered once per
 		// interface instead of under every queue row. owner_pps /
 		// peer_pps / redirect_p99 describe binding-wide arrivals
@@ -112,8 +120,7 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 		// redirect time so these values are inherently per-binding.
 		// Pre-#751 each queue row reported the same values, which
 		// was the #732 symptom.
-		renderBindingScopedTelemetry(&b, cfg, view)
-		queues := buildCoSQueueViews(cfg, view)
+		renderBindingScopedTelemetry(&b, view, queues)
 		if len(queues) == 0 {
 			b.WriteString("  Queues:                   none\n")
 			continue
@@ -250,38 +257,56 @@ func formatHistPercentileMicrosFromBuckets(hist []uint64, percentile int) string
 }
 
 // #732 / #751: render a single "Binding telemetry" line per interface
-// carrying the values that are inherently binding-scoped (producers do
-// not know the target queue at redirect time). Rust's snapshot path
-// attributes these to the sole unambiguous owner-local exact queue row,
-// or leaves them at zero when the shape is ambiguous. We gather them
-// from whichever queue carries non-zero values and render once at the
-// interface level, replacing the pre-#751 per-queue repetition.
+// carrying the values that are inherently binding-scoped (producers
+// do not know the target queue at redirect time). Rust's snapshot
+// path attributes these to the sole unambiguous owner-local exact
+// queue row, or leaves them at zero when the shape is ambiguous.
+//
+// Copilot-review-driven design notes:
+//   - We SUM across queues instead of MAX. Rust populates the fields
+//     on at most one queue per binding in the normal case, so sum and
+//     max are equivalent — except if a bug or mixed-version mismatch
+//     ever puts non-zero values on multiple queue rows, the sum makes
+//     that divergence visible (inflated value in the output) instead
+//     of silently hiding it like max would.
+//   - The redirect-acquire histogram gate checks for at least one
+//     non-zero bucket, not just a non-empty slice. Rust resizes the
+//     vector to DRAIN_HIST_BUCKETS on the eligible row even when
+//     every sample is 0, so a length-only gate would render a noisy
+//     "redirect_p99=0us" line on ambiguous bindings.
+//   - The `queues` slice is built once by the caller so the binding-
+//     scoped line and the per-queue table see exactly the same data.
 //
 // Zero-in-all-fields is suppressed so interfaces with no exact queue
 // or ambiguous shape don't get a noise line.
-func renderBindingScopedTelemetry(b *strings.Builder, cfg *config.Config, view cosInterfaceView) {
+func renderBindingScopedTelemetry(b *strings.Builder, view cosInterfaceView, queues []cosQueueView) {
 	if view.interfaceState == nil {
 		return
 	}
-	queues := buildCoSQueueViews(cfg, view)
 	var (
-		ownerPPS       uint64
-		peerPPS        uint64
-		redirectHist   []uint64
+		ownerPPS     uint64
+		peerPPS      uint64
+		redirectHist []uint64
 	)
 	for _, q := range queues {
-		if q.ownerPPS > ownerPPS {
-			ownerPPS = q.ownerPPS
-		}
-		if q.peerPPS > peerPPS {
-			peerPPS = q.peerPPS
-		}
-		if redirectHist == nil && len(q.redirectAcquireHist) > 0 {
-			redirectHist = q.redirectAcquireHist
+		ownerPPS = saturatingAddU64(ownerPPS, q.ownerPPS)
+		peerPPS = saturatingAddU64(peerPPS, q.peerPPS)
+		// Fold histograms element-wise; unset-slice queues are
+		// skipped so we don't allocate for queues that reported
+		// no samples.
+		for i, count := range q.redirectAcquireHist {
+			if count == 0 {
+				continue
+			}
+			if len(redirectHist) < len(q.redirectAcquireHist) {
+				resized := make([]uint64, len(q.redirectAcquireHist))
+				copy(resized, redirectHist)
+				redirectHist = resized
+			}
+			redirectHist[i] = saturatingAddU64(redirectHist[i], count)
 		}
 	}
-	// Gate: nothing meaningful to render.
-	if ownerPPS == 0 && peerPPS == 0 && len(redirectHist) == 0 {
+	if ownerPPS == 0 && peerPPS == 0 && !histHasSample(redirectHist) {
 		return
 	}
 	fmt.Fprintf(
@@ -291,6 +316,28 @@ func renderBindingScopedTelemetry(b *strings.Builder, cfg *config.Config, view c
 		ownerPPS,
 		peerPPS,
 	)
+}
+
+// saturatingAddU64 avoids silent wraparound in the telemetry render.
+// Hot-path this is not (called once per interface at scrape cadence)
+// but honesty-of-summation matters more here than the cycle cost —
+// an overflow under adversarial input is a visible ceiling, not a
+// reset to zero.
+func saturatingAddU64(a, b uint64) uint64 {
+	sum := a + b
+	if sum < a {
+		return ^uint64(0)
+	}
+	return sum
+}
+
+func histHasSample(hist []uint64) bool {
+	for _, count := range hist {
+		if count > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // #709: map a bucket index to its lower bound, formatted as µs. The

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -318,23 +318,102 @@ func TestFormatCoSInterfaceSummaryRendersOwnerProfileLineForExactQueues(t *testi
 		},
 	}
 	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
-	// Exact substring match on the line format: leading whitespace
-	// aligns with `Drops:` above it (11 spaces). p50 is "1us" (bucket
-	// 1 lower bound), p99 is "16us" (bucket 5 = 2^14 ns = 16384 ns
-	// → 16 µs). Redirect p99 is "2us" (bucket 2 = 2^11 ns = 2048 ns
-	// → 2 µs).
-	want := "OwnerProfile: drain_p50=1us  drain_p99=16us  redirect_p99=2us  owner_pps=12345  peer_pps=6789"
-	if !strings.Contains(out, want) {
-		t.Fatalf("missing %q in output:\n%s", want, out)
+	// #751: per-queue OwnerProfile line now renders only the
+	// queue-scoped fields (drain_p50, drain_p99, drain_invocations).
+	// p50 is "1us" (bucket 1 lower bound), p99 is "16us" (bucket 5 =
+	// 2^14 ns = 16384 ns → 16µs).
+	wantQueue := "OwnerProfile: drain_p50=1us  drain_p99=16us  drain_invocations=100"
+	if !strings.Contains(out, wantQueue) {
+		t.Fatalf("missing queue-scoped OwnerProfile line %q in output:\n%s", wantQueue, out)
 	}
-	// Positional invariant: OwnerProfile must follow Drops. A
-	// regression that emits OwnerProfile above the Drops line would
-	// still include both strings but in the wrong order.
+	// #732: binding-scoped fields now render once at the interface
+	// level instead of being repeated under every queue row. p99 of
+	// redirect-acquire is "2us" (bucket 2 = 2^11 ns = 2048 ns → 2µs).
+	wantBinding := "Binding telemetry:        redirect_p99=2us  owner_pps=12345  peer_pps=6789"
+	if !strings.Contains(out, wantBinding) {
+		t.Fatalf("missing binding-scoped telemetry line %q in output:\n%s", wantBinding, out)
+	}
+	// Positional invariant: per-queue OwnerProfile must follow Drops
+	// on the same queue row. Binding telemetry must appear ABOVE
+	// the Queues table (it's an interface-level summary).
 	dropsIdx := strings.Index(out, "Drops: flow_share=")
 	ownerIdx := strings.Index(out, "OwnerProfile:")
+	queuesIdx := strings.Index(out, "Queues:")
+	bindingIdx := strings.Index(out, "Binding telemetry:")
 	if dropsIdx < 0 || ownerIdx < 0 || ownerIdx <= dropsIdx {
 		t.Fatalf("OwnerProfile line must render AFTER Drops line: drops=%d owner=%d\n%s",
 			dropsIdx, ownerIdx, out)
+	}
+	if bindingIdx < 0 || queuesIdx < 0 || bindingIdx >= queuesIdx {
+		t.Fatalf("Binding telemetry must render ABOVE the Queues table: binding=%d queues=%d\n%s",
+			bindingIdx, queuesIdx, out)
+	}
+}
+
+// #751 / #732: pin that two exact queues on the same interface with
+// distinct drain profiles render distinct per-queue OwnerProfile
+// lines. Pre-#751 the hist was sourced from a binding-wide rollup and
+// both queues carried identical values (#732 symptom).
+//
+// Counter-factual: the two queues are seeded with DISJOINT bucket
+// sets (q4 at bucket 1 = "1us", q6 at bucket 5 = "16us"). If the
+// render collapsed them to a single distribution — the pre-#751
+// behaviour — the formatted line for each queue would show the
+// same p50/p99 and the distinct-percentile assertion would fail.
+func TestFormatCoSInterfaceSummaryRendersDistinctPerQueueOwnerProfiles(t *testing.T) {
+	owner := uint32(1)
+	q4Hist := make([]uint64, 16)
+	q4Hist[1] = 100 // p50 & p99 in bucket 1 → "1us"
+	q6Hist := make([]uint64, 16)
+	q6Hist[5] = 200 // p50 & p99 in bucket 5 → "16us"
+
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				OwnerWorkerID:   &owner,
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:           4,
+						OwnerWorkerID:     &owner,
+						ForwardingClass:   "bandwidth-10mb",
+						Priority:          1,
+						Exact:             true,
+						TransmitRateBytes: 1_250_000,
+						BufferBytes:       32 * 1024,
+						DrainLatencyHist:  q4Hist,
+						DrainInvocations:  100,
+					},
+					{
+						QueueID:           6,
+						OwnerWorkerID:     &owner,
+						ForwardingClass:   "bandwidth-iperf-c",
+						Priority:          1,
+						Exact:             true,
+						TransmitRateBytes: 625_000,
+						BufferBytes:       32 * 1024,
+						DrainLatencyHist:  q6Hist,
+						DrainInvocations:  200,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	wantQ4 := "OwnerProfile: drain_p50=1us  drain_p99=1us  drain_invocations=100"
+	wantQ6 := "OwnerProfile: drain_p50=16us  drain_p99=16us  drain_invocations=200"
+	if !strings.Contains(out, wantQ4) {
+		t.Fatalf("missing q4 per-queue OwnerProfile %q:\n%s", wantQ4, out)
+	}
+	if !strings.Contains(out, wantQ6) {
+		t.Fatalf("missing q6 per-queue OwnerProfile %q:\n%s", wantQ6, out)
+	}
+	// Counter-factual: the pre-#751 regression would produce identical
+	// lines for both queues (both showing the same p50/p99). Pin that
+	// the two OwnerProfile strings are actually distinct in the output.
+	if strings.Count(out, wantQ4) != 1 || strings.Count(out, wantQ6) != 1 {
+		t.Fatalf("expected exactly one per-queue OwnerProfile per queue; got:\n%s", out)
 	}
 }
 
@@ -380,12 +459,20 @@ func TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner(t *test
 	}
 }
 
-// #709: Zeroed owner-profile telemetry must render "0us" not "nan" /
-// "-". An operator staring at a freshly-deployed firewall with no
-// traffic still needs to see the field alignment. The test pins the
-// exact rendering so a future change to the default-string helper
-// doesn't accidentally emit "nan" (which breaks grep/awk pipelines).
-func TestFormatCoSInterfaceSummaryRendersZeroedOwnerProfile(t *testing.T) {
+// #751: zeroed owner-profile telemetry now SUPPRESSES the per-queue
+// OwnerProfile line entirely (drainInvocations == 0 ⇒ nothing to
+// report). Same for the interface-level Binding telemetry line:
+// when all three fields are zero there's nothing meaningful to show.
+// This keeps "show class-of-service interface" tight on a freshly-
+// deployed firewall with no traffic instead of surfacing rows of
+// "0us 0us 0us 0 0" noise that operators learn to skip over and
+// that dilute the signal when a real non-zero does appear.
+//
+// Counter-factual pin: if a future change started emitting the
+// OwnerProfile line on zero-invocation queues, it would produce
+// "drain_p50=0us" somewhere in the output and this test would
+// catch it.
+func TestFormatCoSInterfaceSummarySuppressesZeroedOwnerProfile(t *testing.T) {
 	owner := uint32(1)
 	status := &ProcessStatus{
 		CoSInterfaces: []CoSInterfaceStatus{
@@ -409,17 +496,18 @@ func TestFormatCoSInterfaceSummaryRendersZeroedOwnerProfile(t *testing.T) {
 		},
 	}
 	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
-	want := "OwnerProfile: drain_p50=0us  drain_p99=0us  redirect_p99=0us  owner_pps=0  peer_pps=0"
-	if !strings.Contains(out, want) {
-		t.Fatalf("missing %q in output:\n%s", want, out)
+	if strings.Contains(out, "OwnerProfile:") {
+		t.Fatalf("OwnerProfile line must not render for zeroed queue:\n%s", out)
 	}
-	// Counter-factual: ensure "nan" and "-" don't creep in via the
-	// percentile helper on the empty-histogram path.
-	if strings.Contains(out, "nan") {
-		t.Fatalf("zeroed OwnerProfile must not emit 'nan':\n%s", out)
+	if strings.Contains(out, "Binding telemetry:") {
+		t.Fatalf("Binding telemetry line must not render when all fields are zero:\n%s", out)
 	}
-	if strings.Contains(out, "drain_p50=-") || strings.Contains(out, "drain_p99=-") {
-		t.Fatalf("zeroed OwnerProfile must not emit placeholder '-':\n%s", out)
+	// The Drops line MUST still render — zero-valued admission
+	// counters are the signal that the counter path is wired; see
+	// TestFormatCoSInterfaceSummaryRendersZeroAdmissionCounters
+	// below for the same invariant documented there.
+	if !strings.Contains(out, "Drops: flow_share=0") {
+		t.Fatalf("Drops line must still render even with zeroed telemetry:\n%s", out)
 	}
 }
 

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -225,17 +225,25 @@ pub(super) fn drain_pending_tx(
     // owner binding) must yield back to the worker loop so other bindings can
     // run and completions/recycles can free resources.
     //
-    // #709: time every `drain_shaped_tx` invocation (not per queue, not per
-    // batch) with one pair of `monotonic_nanos()` calls. `monotonic_nanos`
-    // is `clock_gettime(CLOCK_MONOTONIC)` via VDSO — no syscall, ~15 ns
-    // each. The owner-drain latency histogram is the primary signal for
-    // deciding whether Option B / C / D in #709 is justified. Noop
-    // invocations (drain returned `false`) are bucketed too so the
-    // operator can distinguish "owner busy but fast" from "owner
-    // spinning on empty".
+    // #709: time every `drain_shaped_tx` invocation with one pair of
+    // `monotonic_nanos()` calls. `monotonic_nanos` is
+    // `clock_gettime(CLOCK_MONOTONIC)` via VDSO — no syscall, ~15 ns
+    // each. The owner-drain latency histogram is the primary signal
+    // for deciding whether Option B / C / D in #709 is justified.
+    //
+    // #751: attribute the measured latency to the specific queue
+    // that was serviced on this drain pass, not to a binding-wide
+    // rollup. Producers don't know the target queue at redirect time
+    // so peer-side telemetry (redirect_acquire_hist, peer_pps) stays
+    // binding-scoped; only the owner-side drain stats move per-queue.
+    //
+    // Noop invocations (drain returned `None` — no queue made
+    // progress) keep binding-wide attribution on BindingLiveState so
+    // the operator can still tell "owner busy but fast" from "owner
+    // spinning on empty" as a binding-wide property.
     loop {
         let start_ns = monotonic_nanos();
-        let progressed = drain_shaped_tx(binding, now_ns, shared_recycles);
+        let serviced = drain_shaped_tx(binding, now_ns, shared_recycles);
         let delta = monotonic_nanos().saturating_sub(start_ns);
         let bucket = bucket_index_for_ns(delta);
         binding.live.owner_profile_owner.drain_latency_hist[bucket]
@@ -245,7 +253,23 @@ pub(super) fn drain_pending_tx(
             .owner_profile_owner
             .drain_invocations
             .fetch_add(1, Ordering::Relaxed);
-        if !progressed {
+        if let Some(serviced) = serviced.as_ref() {
+            if let Some(root) = binding.cos_interfaces.get(&serviced.root_ifindex) {
+                if let Some(queue) = root
+                    .queues
+                    .iter()
+                    .find(|q| q.queue_id == serviced.queue_id)
+                {
+                    queue.owner_profile.drain_latency_hist[bucket]
+                        .fetch_add(1, Ordering::Relaxed);
+                    queue
+                        .owner_profile
+                        .drain_invocations
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        if serviced.is_none() {
             binding
                 .live
                 .owner_profile_owner
@@ -800,13 +824,25 @@ fn redirect_prepared_cos_request_to_owner_binding(
     Err(req)
 }
 
+/// #751: one drain pass through the binding's CoS interfaces. Returns
+/// the (root_ifindex, queue_id) that was actually serviced so the
+/// caller can attribute the drain latency to the specific queue
+/// instead of into a binding-wide rollup.
+///
+/// `Some((ifindex, qid))` — a batch from this queue was submitted.
+/// `None` — no progress on any queue.
+pub(super) struct DrainedQueueRef {
+    pub(super) root_ifindex: i32,
+    pub(super) queue_id: u8,
+}
+
 fn drain_shaped_tx(
     binding: &mut BindingWorker,
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
-) -> bool {
+) -> Option<DrainedQueueRef> {
     if binding.cos_nonempty_interfaces == 0 || binding.cos_interface_order.is_empty() {
-        return false;
+        return None;
     }
     let start = binding.cos_interface_rr % binding.cos_interface_order.len();
     for offset in 0..binding.cos_interface_order.len() {
@@ -821,19 +857,44 @@ fn drain_shaped_tx(
         if !prime_cos_root_for_service(binding, root_ifindex, now_ns) {
             continue;
         }
-        if let Some(progress) =
-            service_exact_guarantee_queue_direct(binding, root_ifindex, now_ns, shared_recycles)
-        {
+        if let Some(serviced) = service_exact_guarantee_queue_direct_with_info(
+            binding,
+            root_ifindex,
+            now_ns,
+            shared_recycles,
+        ) {
             binding.cos_interface_rr = (start + offset + 1) % binding.cos_interface_order.len();
-            return progress;
+            return serviced;
         }
         let Some(batch) = build_nonexact_cos_batch(binding, root_ifindex, now_ns) else {
             continue;
         };
+        let queue_id = cos_batch_queue_id(binding, root_ifindex, &batch);
         binding.cos_interface_rr = (start + offset + 1) % binding.cos_interface_order.len();
-        return submit_cos_batch(binding, root_ifindex, batch, now_ns, shared_recycles);
+        if submit_cos_batch(binding, root_ifindex, batch, now_ns, shared_recycles) {
+            return queue_id.map(|queue_id| DrainedQueueRef {
+                root_ifindex,
+                queue_id,
+            });
+        }
+        return None;
     }
-    false
+    None
+}
+
+fn cos_batch_queue_id(
+    binding: &BindingWorker,
+    root_ifindex: i32,
+    batch: &CoSBatch,
+) -> Option<u8> {
+    let queue_idx = match batch {
+        CoSBatch::Local { queue_idx, .. } | CoSBatch::Prepared { queue_idx, .. } => *queue_idx,
+    };
+    binding
+        .cos_interfaces
+        .get(&root_ifindex)
+        .and_then(|root| root.queues.get(queue_idx))
+        .map(|queue| queue.queue_id)
 }
 
 fn prime_cos_root_for_service(binding: &mut BindingWorker, root_ifindex: i32, now_ns: u64) -> bool {
@@ -873,6 +934,30 @@ fn service_exact_guarantee_queue_direct(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> Option<bool> {
+    service_exact_guarantee_queue_direct_with_info(
+        binding,
+        root_ifindex,
+        now_ns,
+        shared_recycles,
+    )
+    .map(|slot| slot.is_some())
+}
+
+/// #751: variant that additionally reports which queue was actually
+/// serviced so the caller can attribute per-queue drain latency.
+/// Returns:
+///   * `Some(Some(ref))` — exact-guarantee selection fired, batch
+///     service progressed on `ref`.
+///   * `Some(None)` — exact-guarantee selection fired but the service
+///     call made no progress (batch build declined / TX ring refused).
+///   * `None` — no exact-guarantee selection; caller falls through
+///     to the non-exact path.
+fn service_exact_guarantee_queue_direct_with_info(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    now_ns: u64,
+    shared_recycles: &mut Vec<(u32, u64)>,
+) -> Option<Option<DrainedQueueRef>> {
     let queue_fast_path = binding
         .cos_fast_interfaces
         .get(&root_ifindex)?
@@ -882,6 +967,12 @@ fn service_exact_guarantee_queue_direct(
         let root = binding.cos_interfaces.get_mut(&root_ifindex)?;
         select_exact_cos_guarantee_queue_with_fast_path(root, queue_fast_path, now_ns)?
     };
+
+    let queue_id = binding
+        .cos_interfaces
+        .get(&root_ifindex)
+        .and_then(|root| root.queues.get(selection.queue_idx))
+        .map(|queue| queue.queue_id);
 
     let progress = match selection.kind {
         ExactCoSQueueKind::Local => service_exact_local_queue_direct(
@@ -900,7 +991,15 @@ fn service_exact_guarantee_queue_direct(
             now_ns,
         ),
     };
-    Some(progress)
+
+    Some(if progress {
+        queue_id.map(|queue_id| DrainedQueueRef {
+            root_ifindex,
+            queue_id,
+        })
+    } else {
+        None
+    })
 }
 
 #[cfg(test)]
@@ -4133,6 +4232,7 @@ fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSI
                 wheel_slot: 0,
                 items: VecDeque::new(),
                 drop_counters: CoSQueueDropCounters::default(),
+                owner_profile: CoSQueueOwnerProfile::new(),
             })
             .collect(),
         queue_indices_by_priority,
@@ -10134,6 +10234,7 @@ mod tests {
             wheel_slot: 0,
             items: VecDeque::from([test_cos_item(1500)]),
             drop_counters: CoSQueueDropCounters::default(),
+            owner_profile: CoSQueueOwnerProfile::new(),
         };
 
         normalize_cos_queue_state(&mut queue);
@@ -10170,6 +10271,7 @@ mod tests {
             wheel_slot: 0,
             items: VecDeque::new(),
             drop_counters: CoSQueueDropCounters::default(),
+            owner_profile: CoSQueueOwnerProfile::new(),
         };
         let retry = VecDeque::from([TxRequest {
             bytes: vec![0; 1500],
@@ -10217,6 +10319,7 @@ mod tests {
             wheel_slot: 0,
             items: VecDeque::new(),
             drop_counters: CoSQueueDropCounters::default(),
+            owner_profile: CoSQueueOwnerProfile::new(),
         };
         let retry = VecDeque::from([PreparedTxRequest {
             offset: 64,

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -225,51 +225,59 @@ pub(super) fn drain_pending_tx(
     // owner binding) must yield back to the worker loop so other bindings can
     // run and completions/recycles can free resources.
     //
-    // #709: time every `drain_shaped_tx` invocation with one pair of
-    // `monotonic_nanos()` calls. `monotonic_nanos` is
+    // #709 / #751: time every `drain_shaped_tx` invocation with one
+    // pair of `monotonic_nanos()` calls. `monotonic_nanos` is
     // `clock_gettime(CLOCK_MONOTONIC)` via VDSO — no syscall, ~15 ns
-    // each. The owner-drain latency histogram is the primary signal
-    // for deciding whether Option B / C / D in #709 is justified.
+    // each.
     //
-    // #751: attribute the measured latency to the specific queue
-    // that was serviced on this drain pass, not to a binding-wide
-    // rollup. Producers don't know the target queue at redirect time
-    // so peer-side telemetry (redirect_acquire_hist, peer_pps) stays
-    // binding-scoped; only the owner-side drain stats move per-queue.
+    // Attribution split:
+    //   * A serviced drain (Some) attributes latency + invocation
+    //     to the specific queue's per-queue atomics via indexed
+    //     access (queue_idx is captured by drain_shaped_tx at
+    //     selection time so we avoid a linear scan here — see
+    //     Copilot review on the initial revision of this PR).
+    //   * A no-op drain (None — nothing ran on any queue) bumps
+    //     the binding-wide drain_noop_invocations counter. That
+    //     field stays binding-scoped because there is no queue
+    //     context to attribute it to.
     //
-    // Noop invocations (drain returned `None` — no queue made
-    // progress) keep binding-wide attribution on BindingLiveState so
-    // the operator can still tell "owner busy but fast" from "owner
-    // spinning on empty" as a binding-wide property.
+    // Pre-#751 also wrote the drain latency + invocations into the
+    // binding-wide `owner_profile_owner` atomics unconditionally.
+    // Those writes are dead post-#751 — the snapshot path reads
+    // drain stats from per-queue atomics and
+    // `merge_binding_scoped_owner_profile` no longer touches them —
+    // so removing the writes reclaims the fetch_add cost on the
+    // hot path and keeps BindingLiveState's drain fields as a pure
+    // noop accounting slot.
     loop {
         let start_ns = monotonic_nanos();
         let serviced = drain_shaped_tx(binding, now_ns, shared_recycles);
-        let delta = monotonic_nanos().saturating_sub(start_ns);
-        let bucket = bucket_index_for_ns(delta);
-        binding.live.owner_profile_owner.drain_latency_hist[bucket]
-            .fetch_add(1, Ordering::Relaxed);
-        binding
-            .live
-            .owner_profile_owner
-            .drain_invocations
-            .fetch_add(1, Ordering::Relaxed);
         if let Some(serviced) = serviced.as_ref() {
+            let delta = monotonic_nanos().saturating_sub(start_ns);
+            let bucket = bucket_index_for_ns(delta);
             if let Some(root) = binding.cos_interfaces.get(&serviced.root_ifindex) {
-                if let Some(queue) = root
-                    .queues
-                    .iter()
-                    .find(|q| q.queue_id == serviced.queue_id)
-                {
-                    queue.owner_profile.drain_latency_hist[bucket]
-                        .fetch_add(1, Ordering::Relaxed);
-                    queue
-                        .owner_profile
-                        .drain_invocations
-                        .fetch_add(1, Ordering::Relaxed);
+                if let Some(queue) = root.queues.get(serviced.queue_idx) {
+                    // queue_idx + queue_id are captured at selection
+                    // time inside drain_shaped_tx. `root.queues` is
+                    // not reshaped during a single drain pass, so
+                    // the indexed access is safe and O(1). The id
+                    // recheck guards against a future refactor that
+                    // swaps queue positions between selection and
+                    // attribution — the miss path just skips the
+                    // write rather than poisoning another queue's
+                    // counters.
+                    if queue.queue_id == serviced.queue_id {
+                        queue.owner_profile.drain_latency_hist[bucket]
+                            .fetch_add(1, Ordering::Relaxed);
+                        queue
+                            .owner_profile
+                            .drain_invocations
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
-        }
-        if serviced.is_none() {
+            did_work = true;
+        } else {
             binding
                 .live
                 .owner_profile_owner
@@ -277,7 +285,6 @@ pub(super) fn drain_pending_tx(
                 .fetch_add(1, Ordering::Relaxed);
             break;
         }
-        did_work = true;
     }
     while !binding.pending_tx_prepared.is_empty() {
         match transmit_prepared_batch(binding, now_ns) {
@@ -825,14 +832,24 @@ fn redirect_prepared_cos_request_to_owner_binding(
 }
 
 /// #751: one drain pass through the binding's CoS interfaces. Returns
-/// the (root_ifindex, queue_id) that was actually serviced so the
-/// caller can attribute the drain latency to the specific queue
-/// instead of into a binding-wide rollup.
+/// the (root_ifindex, queue_idx, queue_id) that was actually serviced
+/// so the caller can attribute the drain latency to the specific
+/// queue's per-queue atomics without walking the queues vec a second
+/// time.
 ///
-/// `Some((ifindex, qid))` — a batch from this queue was submitted.
-/// `None` — no progress on any queue.
+/// `queue_idx` is the stable position within `root.queues` captured
+/// at selection time. The drain path mutates queue state (tokens,
+/// queued_bytes) but does not reorder or reshape `root.queues`
+/// within a single drain pass, so using the idx for direct indexed
+/// access is safe and avoids the O(#queues) linear scan by
+/// `queue_id` that the first revision of this PR used (Copilot
+/// review, tx.rs:262).
+///
+/// `queue_id` is retained as a stable 8-bit identifier for the
+/// snapshot and telemetry paths which key on id, not idx.
 pub(super) struct DrainedQueueRef {
     pub(super) root_ifindex: i32,
+    pub(super) queue_idx: usize,
     pub(super) queue_id: u8,
 }
 
@@ -869,11 +886,18 @@ fn drain_shaped_tx(
         let Some(batch) = build_nonexact_cos_batch(binding, root_ifindex, now_ns) else {
             continue;
         };
-        let queue_id = cos_batch_queue_id(binding, root_ifindex, &batch);
+        // #751: capture both queue_idx (stable Vec position) and
+        // queue_id (stable u8 identifier) BEFORE submit_cos_batch
+        // takes ownership of the batch. Pre-Copilot-review this
+        // resolved only queue_id and the outer loop did a linear
+        // scan by id; now we carry the idx through for direct
+        // indexed access.
+        let located = cos_batch_queue_ref(binding, root_ifindex, &batch);
         binding.cos_interface_rr = (start + offset + 1) % binding.cos_interface_order.len();
         if submit_cos_batch(binding, root_ifindex, batch, now_ns, shared_recycles) {
-            return queue_id.map(|queue_id| DrainedQueueRef {
+            return located.map(|(queue_idx, queue_id)| DrainedQueueRef {
                 root_ifindex,
+                queue_idx,
                 queue_id,
             });
         }
@@ -882,11 +906,11 @@ fn drain_shaped_tx(
     None
 }
 
-fn cos_batch_queue_id(
+fn cos_batch_queue_ref(
     binding: &BindingWorker,
     root_ifindex: i32,
     batch: &CoSBatch,
-) -> Option<u8> {
+) -> Option<(usize, u8)> {
     let queue_idx = match batch {
         CoSBatch::Local { queue_idx, .. } | CoSBatch::Prepared { queue_idx, .. } => *queue_idx,
     };
@@ -894,7 +918,7 @@ fn cos_batch_queue_id(
         .cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(queue_idx))
-        .map(|queue| queue.queue_id)
+        .map(|queue| (queue_idx, queue.queue_id))
 }
 
 fn prime_cos_root_for_service(binding: &mut BindingWorker, root_ifindex: i32, now_ns: u64) -> bool {
@@ -995,6 +1019,7 @@ fn service_exact_guarantee_queue_direct_with_info(
     Some(if progress {
         queue_id.map(|queue_id| DrainedQueueRef {
             root_ifindex,
+            queue_idx: selection.queue_idx,
             queue_id,
         })
     } else {

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -997,6 +997,21 @@ pub(super) struct CoSQueueRuntime {
     // via `ArcSwap`, so reads are consistent without ordering discipline
     // here.
     pub(super) drop_counters: CoSQueueDropCounters,
+    // #751: per-queue owner-side drain telemetry. Lives inline on the
+    // queue runtime so each queue's drain_latency + drain_invocations
+    // are genuinely per-queue rather than a binding-wide rollup
+    // surfaced under every queue row (#732). Single-writer on the
+    // owner worker thread; atomic because the snapshot path reads
+    // from a different thread.
+    //
+    // Cross-core ping-pong: this lives on the owner worker's hot
+    // data, so it shares cache lines with the surrounding queue
+    // state (tokens, queued_bytes, etc.). Owner-only writes to all
+    // of them, so false-sharing risk is internal to the worker and
+    // already accepted by the design. The #709 cache-pad isolation
+    // on BindingLiveState was specifically for owner/peer split;
+    // here both are owner-side so no separate pad is needed.
+    pub(super) owner_profile: CoSQueueOwnerProfile,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1044,6 +1059,45 @@ pub(super) struct CoSTimerWheelRuntime {
     pub(super) current_tick: u64,
     pub(super) level0: [Vec<usize>; COS_TIMER_WHEEL_L0_SLOTS],
     pub(super) level1: [Vec<usize>; COS_TIMER_WHEEL_L1_SLOTS],
+}
+
+/// #751: per-queue owner-side drain telemetry. Written by the owner
+/// worker when a drain cycle services this specific queue (see
+/// `drain_shaped_tx`'s per-queue return signal in tx.rs); read via
+/// the snapshot path published through ArcSwap to Prometheus and to
+/// `show class-of-service interface`.
+///
+/// Buckets sum to `drain_invocations` modulo the reader's scrape
+/// window, pinned in
+/// `queue_owner_profile_buckets_sum_to_drain_invocations`.
+///
+/// Single-writer. Relaxed is sufficient:
+///   - The snapshot reader tolerates monotonic counter tearing
+///     across the bucket array (same tolerance the BindingLiveState
+///     owner_profile_owner already assumed).
+///   - Prometheus scrape semantics are "best effort at scrape time".
+///   - No happens-before requirement between the buckets themselves
+///     or between `drain_latency_hist` and `drain_invocations` —
+///     readers compute percentiles independently and a brief skew
+///     just rounds the p50/p99 into an adjacent bucket.
+pub(super) struct CoSQueueOwnerProfile {
+    pub(super) drain_latency_hist: [AtomicU64; super::umem::DRAIN_HIST_BUCKETS],
+    pub(super) drain_invocations: AtomicU64,
+}
+
+impl CoSQueueOwnerProfile {
+    pub(super) fn new() -> Self {
+        Self {
+            drain_latency_hist: std::array::from_fn(|_| AtomicU64::new(0)),
+            drain_invocations: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Default for CoSQueueOwnerProfile {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 pub(super) struct SharedCoSQueueLease {

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1789,6 +1789,15 @@ pub(crate) fn merge_cos_queue_owner_profile_sum(
 /// summation preserves a coherent aggregate distribution and keeps
 /// `sum(histogram) == invocations` intact. A per-bucket `max` breaks
 /// that invariant and can manufacture an impossible mixed profile.
+///
+/// Post-#751: this still merges the full owner profile into the
+/// destination status. It's retained for call sites that snapshot a
+/// binding wholesale (tests, the coordinator fold-across-workers path).
+/// Production `build_worker_cos_statuses_from_maps` no longer uses this
+/// for drain_latency_hist / drain_invocations — those are now populated
+/// per-queue from the per-queue atomics — but it still applies to the
+/// binding-scoped fields (owner_pps, peer_pps, redirect_acquire_hist,
+/// drain_noop_invocations) via `merge_binding_scoped_owner_profile`.
 pub(super) fn merge_owner_profile_sum(
     status: &mut crate::protocol::CoSQueueStatus,
     profile: &OwnerProfileSnapshot,
@@ -1802,18 +1811,40 @@ pub(super) fn merge_owner_profile_sum(
     if status.drain_latency_hist.len() < DRAIN_HIST_BUCKETS {
         status.drain_latency_hist.resize(DRAIN_HIST_BUCKETS, 0);
     }
-    if status.redirect_acquire_hist.len() < DRAIN_HIST_BUCKETS {
-        status.redirect_acquire_hist.resize(DRAIN_HIST_BUCKETS, 0);
-    }
     for i in 0..DRAIN_HIST_BUCKETS {
         status.drain_latency_hist[i] =
             status.drain_latency_hist[i].saturating_add(profile.drain_latency_hist[i]);
-        status.redirect_acquire_hist[i] =
-            status.redirect_acquire_hist[i].saturating_add(profile.redirect_acquire_hist[i]);
     }
     status.drain_invocations = status
         .drain_invocations
         .saturating_add(profile.drain_invocations);
+    merge_binding_scoped_owner_profile(status, profile);
+}
+
+/// #751: merge only the binding-scoped fields from a binding's
+/// owner-profile snapshot into a per-queue status. The fields
+/// covered — `redirect_acquire_hist`, `owner_pps`, `peer_pps`,
+/// `drain_noop_invocations` — are inherently per-binding: producers
+/// do not know the target queue at redirect time (so
+/// `redirect_acquire_hist` and `peer_pps` cannot be queue-scoped),
+/// `owner_pps` measures binding-wide TX arrivals, and
+/// `drain_noop_invocations` counts drain calls that made no
+/// progress on *any* queue (so no queue to attribute them to).
+///
+/// The per-queue drain fields (`drain_latency_hist`,
+/// `drain_invocations`) are populated separately from the queue's
+/// own atomics — see `build_worker_cos_statuses_from_maps`.
+pub(super) fn merge_binding_scoped_owner_profile(
+    status: &mut crate::protocol::CoSQueueStatus,
+    profile: &OwnerProfileSnapshot,
+) {
+    if status.redirect_acquire_hist.len() < DRAIN_HIST_BUCKETS {
+        status.redirect_acquire_hist.resize(DRAIN_HIST_BUCKETS, 0);
+    }
+    for i in 0..DRAIN_HIST_BUCKETS {
+        status.redirect_acquire_hist[i] =
+            status.redirect_acquire_hist[i].saturating_add(profile.redirect_acquire_hist[i]);
+    }
     status.drain_noop_invocations = status
         .drain_noop_invocations
         .saturating_add(profile.drain_noop_invocations);
@@ -1941,15 +1972,71 @@ where
                 status.tx_ring_full_submit_stalls = status
                     .tx_ring_full_submit_stalls
                     .saturating_add(queue.drop_counters.tx_ring_full_submit_stalls);
-                // #709 / #748 / #751: owner-profile export is valid only
-                // for the single unambiguous owner-local exact queue row
-                // on the whole binding. Shared, non-exact, and ambiguous
-                // multi-owner-local shapes (whether within one interface
-                // or spread across interfaces on the same binding) stay
-                // zero rather than surfacing a binding-wide mixed profile.
+                // #751: the owner-side drain telemetry
+                // (drain_latency_hist + drain_invocations) now lives
+                // per-queue on CoSQueueRuntime.owner_profile — each
+                // exact queue gets its OWN histogram populated
+                // directly from its own atomics, with no eligibility
+                // gate. Pre-#751 these came from a binding-wide
+                // rollup that was only surfaced on the single
+                // "unambiguous owner-local exact queue" row; as a
+                // result #732 showed every queue row of a
+                // multi-queue binding with identical values.
+                //
+                // HFT notes on the atomic loads below:
+                //   * Single-writer (owner worker thread) + cross-
+                //     thread read (snapshot path). Relaxed is the
+                //     correct ordering: the reader tolerates ~1
+                //     count of tearing between the hist buckets
+                //     and drain_invocations, and Prometheus scrape
+                //     semantics are "best effort at scrape time".
+                //   * The owner_profile atomics sit alongside the
+                //     plain u64 fields in CoSQueueRuntime that the
+                //     same owner also mutates each tick, so there is
+                //     no false-sharing cost internal to the worker.
+                //     The snapshot reader pulls the cache line
+                //     once per scrape — negligible.
+                //   * Load invocations first so an untouched queue
+                //     (zero counter) skips the histogram walk and
+                //     keeps the on-wire status vector empty — saves
+                //     the resize + 16 bucket copies plus the 128
+                //     bytes of serde overhead on queues that never
+                //     drained. The writer always bumps both hist and
+                //     invocations under Relaxed, so
+                //     invocations==0 ⇒ all buckets are zero; the
+                //     reverse may briefly be false due to tearing,
+                //     but a ~1-count under-report from a single
+                //     reader is within the tolerance documented on
+                //     CoSQueueOwnerProfile.
+                let queue_invocations =
+                    queue.owner_profile.drain_invocations.load(Ordering::Relaxed);
+                if queue_invocations > 0 {
+                    if status.drain_latency_hist.len() < DRAIN_HIST_BUCKETS {
+                        status.drain_latency_hist.resize(DRAIN_HIST_BUCKETS, 0);
+                    }
+                    for i in 0..DRAIN_HIST_BUCKETS {
+                        let bucket_count =
+                            queue.owner_profile.drain_latency_hist[i].load(Ordering::Relaxed);
+                        status.drain_latency_hist[i] =
+                            status.drain_latency_hist[i].saturating_add(bucket_count);
+                    }
+                    status.drain_invocations =
+                        status.drain_invocations.saturating_add(queue_invocations);
+                }
+
+                // #709 / #748 / #751: the *binding-scoped* fields
+                // (redirect_acquire_hist, owner_pps, peer_pps,
+                // drain_noop_invocations) are surfaced only on the
+                // single unambiguous owner-local exact queue row on
+                // the whole binding. Producers don't know the target
+                // queue at redirect time so these fields cannot be
+                // queue-scoped and still stay truthful; any
+                // shared-exact, non-exact, or multi-owner-local
+                // shape keeps them at zero rather than surfacing a
+                // binding-wide mixed profile under an arbitrary row.
                 if owner_profile_row == Some((ifindex, queue.queue_id)) {
                     if let Some(profile) = binding_profile.as_ref() {
-                        merge_owner_profile_sum(status, profile);
+                        merge_binding_scoped_owner_profile(status, profile);
                     }
                 }
             }
@@ -2073,6 +2160,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::from([CoSPendingTxItem::Local(test_tx_request(80))]),
                     drop_counters,
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 }],
                 queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
                 rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
@@ -2205,6 +2293,7 @@ mod tests {
                 wheel_slot: 0,
                 items: VecDeque::new(),
                 drop_counters: CoSQueueDropCounters::default(),
+                owner_profile: CoSQueueOwnerProfile::new(),
             }],
             queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
             rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
@@ -2216,12 +2305,9 @@ mod tests {
         };
 
         let live_a = BindingLiveState::new();
-        live_a.owner_profile_owner.drain_latency_hist[0].store(5, Ordering::Relaxed);
+        // binding-scoped fields (unchanged by #751): redirect_acquire
+        // histogram, owner_pps, peer_pps, drain_noop_invocations.
         live_a.owner_profile_peer.redirect_acquire_hist[1].store(3, Ordering::Relaxed);
-        live_a
-            .owner_profile_owner
-            .drain_invocations
-            .store(5, Ordering::Relaxed);
         live_a
             .owner_profile_owner
             .drain_noop_invocations
@@ -2236,12 +2322,7 @@ mod tests {
             .store(40, Ordering::Relaxed);
 
         let live_b = BindingLiveState::new();
-        live_b.owner_profile_owner.drain_latency_hist[7].store(11, Ordering::Relaxed);
         live_b.owner_profile_peer.redirect_acquire_hist[2].store(13, Ordering::Relaxed);
-        live_b
-            .owner_profile_owner
-            .drain_invocations
-            .store(11, Ordering::Relaxed);
         live_b
             .owner_profile_owner
             .drain_noop_invocations
@@ -2257,8 +2338,41 @@ mod tests {
 
         let mut first = FastMap::default();
         first.insert(80, make_root());
+        // #751: seed per-queue drain stats directly on the first
+        // worker's queue runtime. This is what the TX drain loop
+        // writes in production (tx.rs line ~250); tests pin the
+        // aggregated value rather than the old binding-wide rollup.
+        first
+            .get_mut(&80)
+            .unwrap()
+            .queues[0]
+            .owner_profile
+            .drain_latency_hist[0]
+            .store(5, Ordering::Relaxed);
+        first
+            .get_mut(&80)
+            .unwrap()
+            .queues[0]
+            .owner_profile
+            .drain_invocations
+            .store(5, Ordering::Relaxed);
+
         let mut second = FastMap::default();
         second.insert(80, make_root());
+        second
+            .get_mut(&80)
+            .unwrap()
+            .queues[0]
+            .owner_profile
+            .drain_latency_hist[7]
+            .store(11, Ordering::Relaxed);
+        second
+            .get_mut(&80)
+            .unwrap()
+            .queues[0]
+            .owner_profile
+            .drain_invocations
+            .store(11, Ordering::Relaxed);
 
         let statuses = build_worker_cos_statuses_from_maps(
             [(&first, Some(&live_a)), (&second, Some(&live_b))],
@@ -2266,19 +2380,26 @@ mod tests {
         );
         let queue = &statuses[0].queues[0];
 
+        // #751: drain_latency_hist + drain_invocations come from
+        // per-queue atomics, summed across workers servicing the
+        // same (ifindex, queue_id).
         assert_eq!(queue.drain_latency_hist[0], 5);
         assert_eq!(queue.drain_latency_hist[7], 11);
-        assert_eq!(queue.redirect_acquire_hist[1], 3);
-        assert_eq!(queue.redirect_acquire_hist[2], 13);
         assert_eq!(queue.drain_invocations, 16);
-        assert_eq!(queue.drain_noop_invocations, 3);
-        assert_eq!(queue.owner_pps, 300);
-        assert_eq!(queue.peer_pps, 90);
         assert_eq!(
             queue.drain_latency_hist.iter().copied().sum::<u64>(),
             queue.drain_invocations,
-            "aggregated histogram must stay coherent with invocation count",
+            "per-queue histogram must stay coherent with invocation count",
         );
+
+        // Binding-scoped fields still attributed to the eligible
+        // queue (there's only one in this fixture) and summed
+        // across workers.
+        assert_eq!(queue.redirect_acquire_hist[1], 3);
+        assert_eq!(queue.redirect_acquire_hist[2], 13);
+        assert_eq!(queue.drain_noop_invocations, 3);
+        assert_eq!(queue.owner_pps, 300);
+        assert_eq!(queue.peer_pps, 90);
     }
 
     #[test]
@@ -2371,6 +2492,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::new(),
                     drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 },
                 CoSQueueRuntime {
                     queue_id: 4,
@@ -2397,6 +2519,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::new(),
                     drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 },
                 CoSQueueRuntime {
                     queue_id: 5,
@@ -2423,6 +2546,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::new(),
                     drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 },
             ],
             queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
@@ -2435,10 +2559,7 @@ mod tests {
         };
 
         let live = BindingLiveState::new();
-        live.owner_profile_owner.drain_latency_hist[2].store(9, Ordering::Relaxed);
-        live.owner_profile_owner
-            .drain_invocations
-            .store(9, Ordering::Relaxed);
+        // Binding-scoped fields (unchanged by #751).
         live.owner_profile_owner
             .drain_noop_invocations
             .store(1, Ordering::Relaxed);
@@ -2452,6 +2573,20 @@ mod tests {
 
         let mut cos_map = FastMap::default();
         cos_map.insert(80, root);
+        // #751: seed per-queue drain stats on queue_id=4 only
+        // (the owner-local exact queue in this fixture).
+        {
+            let runtime = cos_map.get_mut(&80).unwrap();
+            let q4 = runtime
+                .queues
+                .iter_mut()
+                .find(|q| q.queue_id == 4)
+                .unwrap();
+            q4.owner_profile.drain_latency_hist[2].store(9, Ordering::Relaxed);
+            q4.owner_profile
+                .drain_invocations
+                .store(9, Ordering::Relaxed);
+        }
 
         let statuses = build_worker_cos_statuses_from_maps([(&cos_map, Some(&live))], &forwarding);
         let queues = &statuses[0].queues;
@@ -2459,18 +2594,26 @@ mod tests {
         let q4 = queues.iter().find(|q| q.queue_id == 4).unwrap();
         let q5 = queues.iter().find(|q| q.queue_id == 5).unwrap();
 
+        // q0 is non-exact: no per-queue drain stats seeded and not
+        // the eligible row for binding-scoped fields.
         assert_eq!(q0.drain_invocations, 0);
-        assert!(q0.drain_latency_hist.is_empty());
         assert_eq!(q0.owner_pps, 0);
 
+        // q4 is the owner-local exact queue: it gets BOTH its own
+        // per-queue drain stats (seeded on the runtime) AND the
+        // binding-scoped fields (redirect_acquire, owner_pps,
+        // peer_pps, drain_noop) because it's the unambiguous row.
         assert_eq!(q4.drain_latency_hist[2], 9);
-        assert_eq!(q4.redirect_acquire_hist[4], 7);
         assert_eq!(q4.drain_invocations, 9);
+        assert_eq!(q4.redirect_acquire_hist[4], 7);
         assert_eq!(q4.owner_pps, 123);
         assert_eq!(q4.peer_pps, 45);
+        assert_eq!(q4.drain_noop_invocations, 1);
 
+        // q5 is shared-exact (via SHARED_EXACT_RATE fixture): no
+        // per-queue drain stats seeded, and it's not the eligible
+        // row for binding-scoped fields.
         assert_eq!(q5.drain_invocations, 0);
-        assert!(q5.drain_latency_hist.is_empty());
         assert_eq!(q5.owner_pps, 0);
     }
 
@@ -2555,6 +2698,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::new(),
                     drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 },
                 CoSQueueRuntime {
                     queue_id: 6,
@@ -2581,6 +2725,7 @@ mod tests {
                     wheel_slot: 0,
                     items: VecDeque::new(),
                     drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
                 },
             ],
             queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
@@ -2697,6 +2842,7 @@ mod tests {
                 wheel_slot: 0,
                 items: VecDeque::new(),
                 drop_counters: CoSQueueDropCounters::default(),
+                owner_profile: CoSQueueOwnerProfile::new(),
             }],
             queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
             rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
@@ -2753,6 +2899,210 @@ mod tests {
              multiple owner-local exact queues across interfaces; got {:?}",
             row
         );
+    }
+
+    /// #751 / #732: per-queue drain telemetry.
+    ///
+    /// Pre-#751 (symptom of #732): the same drain_latency_hist /
+    /// drain_invocations read from BindingLiveState and stamped under
+    /// every queue row of a multi-queue binding. The on-wire status
+    /// repeated identical values on each queue even when the owner
+    /// worker was draining two queues with wildly different latency
+    /// profiles — e.g. a low-rate "iperf-a" queue with ~8 µs drains
+    /// and a high-rate "iperf-b" queue with ~1 µs drains collapsed
+    /// into a single flat shape.
+    ///
+    /// Post-#751: each queue carries its own per-queue atomics
+    /// (CoSQueueRuntime::owner_profile). The snapshot reads from the
+    /// queue itself; distinct queues report distinct distributions.
+    ///
+    /// This test pins that behaviour by seeding two owner-local
+    /// exact queues on the same binding with disjoint latency
+    /// histograms (non-overlapping bucket sets) and invocation
+    /// counts, running the snapshot path, and asserting the two
+    /// on-wire queue rows carry different values. The counter-factual
+    /// pre-#751 behaviour (both queues showing the same profile)
+    /// would fail the disjoint-bucket assertion loudly.
+    #[test]
+    fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
+        let mut forwarding = ForwardingState::default();
+        forwarding
+            .ifindex_to_config_name
+            .insert(80, "reth0.80".to_string());
+        forwarding.cos.interfaces.insert(
+            80,
+            CoSInterfaceConfig {
+                shaping_rate_bytes: 10_000_000_000 / 8,
+                burst_bytes: 256 * 1024,
+                default_queue: 0,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![
+                    CoSQueueConfig {
+                        queue_id: 4,
+                        forwarding_class: "iperf-a".into(),
+                        priority: 1,
+                        transmit_rate_bytes: OWNER_LOCAL_EXACT_RATE,
+                        exact: true,
+                        surplus_weight: 1,
+                        buffer_bytes: 64 * 1024,
+                        dscp_rewrite: None,
+                    },
+                    CoSQueueConfig {
+                        queue_id: 6,
+                        forwarding_class: "iperf-c".into(),
+                        priority: 1,
+                        // Also owner-local-exact — same shape as the
+                        // ambiguous-multi-exact fixture above.
+                        transmit_rate_bytes: OWNER_LOCAL_EXACT_RATE / 2,
+                        exact: true,
+                        surplus_weight: 1,
+                        buffer_bytes: 64 * 1024,
+                        dscp_rewrite: None,
+                    },
+                ],
+            },
+        );
+
+        let mut root = CoSInterfaceRuntime {
+            shaping_rate_bytes: 10_000_000_000 / 8,
+            burst_bytes: 256 * 1024,
+            tokens: 0,
+            default_queue: 0,
+            nonempty_queues: 0,
+            runnable_queues: 0,
+            exact_guarantee_rr: 0,
+            nonexact_guarantee_rr: 0,
+            #[cfg(test)]
+            legacy_guarantee_rr: 0,
+            queues: vec![
+                CoSQueueRuntime {
+                    queue_id: 4,
+                    priority: 1,
+                    transmit_rate_bytes: OWNER_LOCAL_EXACT_RATE,
+                    exact: true,
+                    flow_fair: false,
+                    flow_hash_seed: 0,
+                    surplus_weight: 1,
+                    surplus_deficit: 0,
+                    buffer_bytes: 64 * 1024,
+                    dscp_rewrite: None,
+                    tokens: 0,
+                    last_refill_ns: 0,
+                    queued_bytes: 0,
+                    active_flow_buckets: 0,
+                    flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+                    flow_rr_buckets: FlowRrRing::default(),
+                    flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
+                    runnable: false,
+                    parked: false,
+                    next_wakeup_tick: 0,
+                    wheel_level: 0,
+                    wheel_slot: 0,
+                    items: VecDeque::new(),
+                    drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
+                },
+                CoSQueueRuntime {
+                    queue_id: 6,
+                    priority: 1,
+                    transmit_rate_bytes: OWNER_LOCAL_EXACT_RATE / 2,
+                    exact: true,
+                    flow_fair: false,
+                    flow_hash_seed: 0,
+                    surplus_weight: 1,
+                    surplus_deficit: 0,
+                    buffer_bytes: 64 * 1024,
+                    dscp_rewrite: None,
+                    tokens: 0,
+                    last_refill_ns: 0,
+                    queued_bytes: 0,
+                    active_flow_buckets: 0,
+                    flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+                    flow_rr_buckets: FlowRrRing::default(),
+                    flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
+                    runnable: false,
+                    parked: false,
+                    next_wakeup_tick: 0,
+                    wheel_level: 0,
+                    wheel_slot: 0,
+                    items: VecDeque::new(),
+                    drop_counters: CoSQueueDropCounters::default(),
+                    owner_profile: CoSQueueOwnerProfile::new(),
+                },
+            ],
+            queue_indices_by_priority: std::array::from_fn(|_| Vec::new()),
+            rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
+            timer_wheel: CoSTimerWheelRuntime {
+                current_tick: 0,
+                level0: std::array::from_fn(|_| Vec::new()),
+                level1: std::array::from_fn(|_| Vec::new()),
+            },
+        };
+
+        // Queue 4: "slow drain" profile — landings in high bucket.
+        {
+            let q = root.queues.iter_mut().find(|q| q.queue_id == 4).unwrap();
+            q.owner_profile.drain_latency_hist[12].store(7, Ordering::Relaxed);
+            q.owner_profile
+                .drain_invocations
+                .store(7, Ordering::Relaxed);
+        }
+        // Queue 6: "fast drain" profile — landings in low bucket.
+        // Disjoint from queue 4's bucket so a regression that collapses
+        // to a single profile fails the per-queue distinctness check.
+        {
+            let q = root.queues.iter_mut().find(|q| q.queue_id == 6).unwrap();
+            q.owner_profile.drain_latency_hist[2].store(23, Ordering::Relaxed);
+            q.owner_profile
+                .drain_invocations
+                .store(23, Ordering::Relaxed);
+        }
+
+        // Binding-scoped fields: ambiguous shape (two owner-local
+        // exact queues), so these stay at zero on all queues
+        // regardless of what we seed — the test does NOT seed
+        // BindingLiveState to make that invariant explicit.
+        let live = BindingLiveState::new();
+        let mut cos_map = FastMap::default();
+        cos_map.insert(80, root);
+
+        let statuses =
+            build_worker_cos_statuses_from_maps([(&cos_map, Some(&live))], &forwarding);
+        let queues = &statuses[0].queues;
+        let q4 = queues.iter().find(|q| q.queue_id == 4).unwrap();
+        let q6 = queues.iter().find(|q| q.queue_id == 6).unwrap();
+
+        // Per-queue distinctness.
+        assert_eq!(q4.drain_invocations, 7);
+        assert_eq!(q4.drain_latency_hist[12], 7);
+        assert_eq!(q4.drain_latency_hist[2], 0);
+
+        assert_eq!(q6.drain_invocations, 23);
+        assert_eq!(q6.drain_latency_hist[2], 23);
+        assert_eq!(q6.drain_latency_hist[12], 0);
+
+        // Counter-factual: if the snapshot collapsed both queues to
+        // a shared profile (the pre-#751 / #732 behaviour), q4 would
+        // carry q6's bucket[2] count and vice versa. Assert both
+        // hists are disjoint in their non-zero buckets.
+        assert!(
+            q4.drain_latency_hist[12] > 0 && q4.drain_latency_hist[2] == 0
+                && q6.drain_latency_hist[2] > 0 && q6.drain_latency_hist[12] == 0,
+            "queues must surface their own per-queue hist, not share a \
+             binding-wide rollup (pre-#751 regression)",
+        );
+
+        // Binding-scoped fields stay at zero on ambiguous shapes.
+        assert_eq!(q4.owner_pps, 0);
+        assert_eq!(q6.owner_pps, 0);
+        assert_eq!(q4.peer_pps, 0);
+        assert_eq!(q6.peer_pps, 0);
+        assert_eq!(q4.drain_noop_invocations, 0);
+        assert_eq!(q6.drain_noop_invocations, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

\`BindingLiveState.owner_profile_owner\` was binding-scoped for all of its fields, but only some are inherently binding-scoped. \`drain_latency_hist\` + \`drain_invocations\` are attributable to the specific queue the owner worker just serviced; lumping them into a single binding-wide rollup and then stamping that rollup under every queue row of a multi-queue binding was the **#732** symptom — two queues with different latency profiles collapsed into identical display rows.

This PR splits the scope honestly:

- **Per-queue**: \`drain_latency_hist\`, \`drain_invocations\` — moved onto \`CoSQueueRuntime.owner_profile\`.
- **Binding-scoped** (unchanged): \`redirect_acquire_hist\`, \`peer_pps\` (producers don't know target queue at redirect time), \`owner_pps\` (binding-wide TX arrivals), \`drain_noop_invocations\` (drain calls with no queue to attribute to).
- **Display**: per-queue row shows per-queue drain stats only; binding-scoped fields moved to a new \`Binding telemetry:\` line once per interface instead of repeated under every queue row.

## Hot-path shape (HFT lens)

- New per-queue atomics: single-writer (owner worker) + cross-thread read (snapshot path). Relaxed ordering — reader tolerates ~1 count of tearing between hist buckets and \`drain_invocations\`; Prometheus scrape semantics are "best effort at scrape time." Documented on \`CoSQueueOwnerProfile\`.
- The atomics sit alongside existing plain-u64 fields on the same owner-mutated runtime, so no new cache-line sharing cost internal to the worker. Snapshot reader pulls the lines at scrape cadence.
- Per drain pass on a queue that services work: one extra \`AtomicU64::fetch_add(Relaxed)\` on a hist bucket + one on \`drain_invocations\`. No allocation, no syscall.
- Snapshot reader guards on \`drain_invocations > 0\` before walking the hist array so an idle queue costs one atomic load, zero allocations, zero Vec resize.
- Wire format: idle queues stay empty \`Vec<u64>\` on the wire (preserved).

## Display (post-#732)

Before:
\`\`\`
OwnerProfile: drain_p50=0us  drain_p99=8us  redirect_p99=0us  owner_pps=0  peer_pps=2441382
OwnerProfile: drain_p50=0us  drain_p99=8us  redirect_p99=0us  owner_pps=0  peer_pps=2441382
OwnerProfile: drain_p50=0us  drain_p99=8us  redirect_p99=0us  owner_pps=0  peer_pps=2441382
\`\`\`

After (two exact queues with distinct drain profiles, one binding-scoped set):
\`\`\`
  Binding telemetry:        redirect_p99=2us  owner_pps=12345  peer_pps=6789
  Queues:
    Queue  ...
    0      ...
           Drops: flow_share=0  buffer=0  ecn_marked=0
    4      ...
           Drops: flow_share=0  buffer=0  ecn_marked=0
           OwnerProfile: drain_p50=1us  drain_p99=1us  drain_invocations=100
    6      ...
           Drops: flow_share=0  buffer=0  ecn_marked=0
           OwnerProfile: drain_p50=16us  drain_p99=16us  drain_invocations=200
\`\`\`

## Test plan

- [x] Rust: 703 pass, 0 fail. Existing \`owner_profile*\` worker tests updated to seed per-queue atomics; binding-scoped eligibility invariants preserved. New \`build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry\` pins disjoint-bucket distinctness with an explicit counter-factual.
- [x] Go: all pass. Existing renderer test updated to assert the new shape and positional invariants. Renamed/rewrote the zeroed-telemetry test to pin suppression. New \`TestFormatCoSInterfaceSummaryRendersDistinctPerQueueOwnerProfiles\` end-to-end pins two queues → two distinct rendered OwnerProfile lines.
- [x] \`make test\` clean.
- [x] \`cargo test --release\` clean.

## Refs

Fixes #751 (queue-scoped owner-profile)
Fixes #732 (cosmetic per-queue repetition)
Related: #709 (original binding-wide telemetry), #746 (cacheline isolation), #762 (meta).