### PR TITLE
userspace-dp: instrument drain cap bypass for #760 (investigation branch)

### DIFF
--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -47,6 +47,14 @@ type cosQueueView struct {
 	redirectAcquireHist  []uint64
 	ownerPPS             uint64
 	peerPPS              uint64
+	// #760 overshoot-hunt instrumentation. drainSentBytes /
+	// drainParkRootTokens / drainParkQueueTokens are queue-scoped.
+	// postDrainBackupBytes is binding-scoped (one-per-binding Rust
+	// attribution; summed across queues here for rendering).
+	drainSentBytes        uint64
+	drainParkRootTokens   uint64
+	drainParkQueueTokens  uint64
+	postDrainBackupBytes  uint64
 }
 
 func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
@@ -206,6 +214,19 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 99),
 					queue.drainInvocations,
 				)
+				// #760 overshoot-hunt row. Sibling of the OwnerProfile
+				// line so operators can correlate drain-latency with
+				// the rate the queue actually shaped out and the two
+				// gate-park counters. Only rendered when the queue has
+				// been drained at least once — a never-drained queue's
+				// zeros carry no signal.
+				fmt.Fprintf(
+					&b,
+					"           DrainShape:   sent_bytes=%d  park_root=%d  park_queue=%d\n",
+					queue.drainSentBytes,
+					queue.drainParkRootTokens,
+					queue.drainParkQueueTokens,
+				)
 			}
 		}
 	}
@@ -284,13 +305,15 @@ func renderBindingScopedTelemetry(b *strings.Builder, view cosInterfaceView, que
 		return
 	}
 	var (
-		ownerPPS     uint64
-		peerPPS      uint64
-		redirectHist []uint64
+		ownerPPS      uint64
+		peerPPS       uint64
+		redirectHist  []uint64
+		backupBytes   uint64
 	)
 	for _, q := range queues {
 		ownerPPS = saturatingAddU64(ownerPPS, q.ownerPPS)
 		peerPPS = saturatingAddU64(peerPPS, q.peerPPS)
+		backupBytes = saturatingAddU64(backupBytes, q.postDrainBackupBytes)
 		// Fold histograms element-wise; unset-slice queues are
 		// skipped so we don't allocate for queues that reported
 		// no samples.
@@ -306,15 +329,16 @@ func renderBindingScopedTelemetry(b *strings.Builder, view cosInterfaceView, que
 			redirectHist[i] = saturatingAddU64(redirectHist[i], count)
 		}
 	}
-	if ownerPPS == 0 && peerPPS == 0 && !histHasSample(redirectHist) {
+	if ownerPPS == 0 && peerPPS == 0 && !histHasSample(redirectHist) && backupBytes == 0 {
 		return
 	}
 	fmt.Fprintf(
 		b,
-		"  Binding telemetry:        redirect_p99=%s  owner_pps=%d  peer_pps=%d\n",
+		"  Binding telemetry:        redirect_p99=%s  owner_pps=%d  peer_pps=%d  post_drain_backup_bytes=%d\n",
 		formatHistPercentileMicrosFromBuckets(redirectHist, 99),
 		ownerPPS,
 		peerPPS,
+		backupBytes,
 	)
 }
 
@@ -450,6 +474,14 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.redirectAcquireHist = runtimeQueue.RedirectAcquireHist
 			qv.ownerPPS = runtimeQueue.OwnerPPS
 			qv.peerPPS = runtimeQueue.PeerPPS
+			// #760 copy-through. See field comments on cosQueueView
+			// and on the Rust CoSQueueStatus. A queue that never got
+			// drained leaves these at zero; the renderer gates on
+			// drainInvocations > 0 so a silent queue stays silent.
+			qv.drainSentBytes = runtimeQueue.DrainSentBytes
+			qv.drainParkRootTokens = runtimeQueue.DrainParkRootTokens
+			qv.drainParkQueueTokens = runtimeQueue.DrainParkQueueTokens
+			qv.postDrainBackupBytes = runtimeQueue.PostDrainBackupBytes
 			queueViews[qv.queueID] = qv
 		}
 	}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -488,6 +488,15 @@ type CoSQueueStatus struct {
 	RedirectAcquireHist  []uint64 `json:"redirect_acquire_hist,omitempty"`
 	OwnerPPS             uint64   `json:"owner_pps,omitempty"`
 	PeerPPS              uint64   `json:"peer_pps,omitempty"`
+	// #760 overshoot-hunt instrumentation. DrainSentBytes /
+	// DrainParkRootTokens / DrainParkQueueTokens are queue-scoped.
+	// PostDrainBackupBytes is binding-scoped (same row as
+	// OwnerPPS/PeerPPS). See Rust `CoSQueueStatus` for field
+	// semantics and write-site locations.
+	DrainSentBytes        uint64 `json:"drain_sent_bytes,omitempty"`
+	DrainParkRootTokens   uint64 `json:"drain_park_root_tokens,omitempty"`
+	DrainParkQueueTokens  uint64 `json:"drain_park_queue_tokens,omitempty"`
+	PostDrainBackupBytes  uint64 `json:"post_drain_backup_bytes,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -496,7 +496,8 @@ type CoSQueueStatus struct {
 	DrainSentBytes        uint64 `json:"drain_sent_bytes,omitempty"`
 	DrainParkRootTokens   uint64 `json:"drain_park_root_tokens,omitempty"`
 	DrainParkQueueTokens  uint64 `json:"drain_park_queue_tokens,omitempty"`
-	PostDrainBackupBytes  uint64 `json:"post_drain_backup_bytes,omitempty"`
+	PostDrainBackupBytes                uint64 `json:"post_drain_backup_bytes,omitempty"`
+	DrainSentBytesShapedUnconditional   uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1385,6 +1385,9 @@ impl Coordinator {
                 binding.redirect_inbox_overflow_drops = snap.redirect_inbox_overflow_drops;
                 binding.pending_tx_local_overflow_drops = snap.pending_tx_local_overflow_drops;
                 binding.tx_submit_error_drops = snap.tx_submit_error_drops;
+                binding.post_drain_backup_bytes = snap.post_drain_backup_bytes;
+                binding.drain_sent_bytes_shaped_unconditional =
+                    snap.drain_sent_bytes_shaped_unconditional;
                 // #710: `snap.no_owner_binding_drops` is not copied into
                 // per-binding status — it is summed across all bindings
                 // into `ProcessStatus::cos_no_owner_binding_drops_total`
@@ -1467,6 +1470,8 @@ impl Coordinator {
                 binding.tx_bytes = 0;
                 binding.tx_completions = 0;
                 binding.tx_errors = 0;
+                binding.post_drain_backup_bytes = 0;
+                binding.drain_sent_bytes_shaped_unconditional = 0;
                 binding.direct_tx_packets = 0;
                 binding.copy_tx_packets = 0;
                 binding.in_place_tx_packets = 0;

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -4679,6 +4679,19 @@ fn apply_cos_prepared_result(
                     queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
                 }
             }
+            // #760 instrumentation, the FOURTH apply_* site. This is
+            // the prepared-batch path (CoSBatch::Prepared, in-place
+            // rewrite — the common case for forwarded traffic). The
+            // initial instrumentation commit missed this site; the
+            // first 120 s iperf3 measurement showed only ~987 Mbps
+            // on drain_sent_bytes while the receiver reported 1.55
+            // Gbps, leaving ~563 Mbps unaccounted — all of it
+            // flowing through this path. Same Relaxed semantics as
+            // the other three apply_* sites.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -298,6 +298,15 @@ pub(super) fn drain_pending_tx(
                     .tx_packets
                     .fetch_add(packets, Ordering::Relaxed);
                 binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
+                // #760 instrumentation: these bytes went out via
+                // the post-CoS backup path in drain_pending_tx —
+                // they did NOT pass through any queue's token gate.
+                // Non-zero here is the direct fingerprint of the
+                // cap bypass we're hunting.
+                binding
+                    .live
+                    .post_drain_backup_bytes
+                    .fetch_add(bytes, Ordering::Relaxed);
             }
             Err(TxError::Retry(err)) => {
                 binding.live.set_error(err);
@@ -336,6 +345,15 @@ pub(super) fn drain_pending_tx(
                             .tx_packets
                             .fetch_add(packets, Ordering::Relaxed);
                         binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
+                        // #760 instrumentation: bytes that left via
+                        // the fallback transmit_batch WITHOUT going
+                        // through any CoS queue's token gate. See
+                        // the post_drain_backup_bytes field comment
+                        // for why this is the #760 smoking gun.
+                        binding
+                            .live
+                            .post_drain_backup_bytes
+                            .fetch_add(bytes, Ordering::Relaxed);
                     }
                 }
                 Err(TxError::Retry(err)) => {
@@ -1161,6 +1179,16 @@ fn select_exact_cos_guarantee_queue_with_fast_path(
         };
         let head_len = cos_item_len(head);
         if root.tokens < head_len {
+            // #760 instrumentation: record the per-queue observation
+            // that the interface shaper held it back. Written
+            // regardless of whether the wakeup-tick estimator
+            // succeeds in parking it, because "gate fired" is the
+            // signal we care about, not "queue successfully
+            // scheduled". Same Relaxed reasoning as drain_invocations.
+            queue
+                .owner_profile
+                .drain_park_root_tokens
+                .fetch_add(1, Ordering::Relaxed);
             if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
                 root.tokens,
                 root.shaping_rate_bytes,
@@ -1176,6 +1204,14 @@ fn select_exact_cos_guarantee_queue_with_fast_path(
             continue;
         }
         if queue.tokens < head_len {
+            // #760 instrumentation: the per-queue token gate held
+            // this queue back. A queue that sustains throughput
+            // above its configured rate with this counter near zero
+            // is direct evidence the gate never fired.
+            queue
+                .owner_profile
+                .drain_park_queue_tokens
+                .fetch_add(1, Ordering::Relaxed);
             if let Some(wake_tick) = estimate_cos_queue_wakeup_tick(
                 root.tokens,
                 root.shaping_rate_bytes,
@@ -2369,6 +2405,15 @@ fn apply_direct_exact_send_result(
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             queue.queued_bytes = queue.queued_bytes.saturating_sub(sent_bytes);
             queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+            // #760 instrumentation: record the exact-owner-local
+            // send at the same place the token bucket decrements.
+            // Divide by a scrape window to get an observed per-queue
+            // drain rate and compare against
+            // `queue.transmit_rate_bytes` to detect a cap bypass.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
@@ -4573,6 +4618,15 @@ fn apply_cos_send_result(
                     queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
                 }
             }
+            // #760 instrumentation: record non-exact / surplus /
+            // shared-exact sends at the same site the queue's token
+            // or surplus accounting is debited. Paired with the
+            // apply_direct_exact_send_result write so the sum across
+            // all sites equals the bytes the CoS scheduler accounted.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -2442,6 +2442,14 @@ fn apply_direct_exact_send_result(
             .live
             .tx_bytes
             .fetch_add(sent_bytes, Ordering::Relaxed);
+        // #760 instrumentation, exact-owner-local path. Paired with
+        // tx_bytes unconditionally — if the per-queue drain_sent_bytes
+        // above (guarded by `if let Some(queue)`) ever undercounts
+        // this, the gap is an `apply_*` early-return / queue-miss.
+        binding
+            .live
+            .drain_sent_bytes_shaped_unconditional
+            .fetch_add(sent_bytes, Ordering::Relaxed);
     }
 }
 
@@ -2574,6 +2582,12 @@ fn submit_cos_batch(
                             .tx_packets
                             .fetch_add(packets, Ordering::Relaxed);
                         binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
+                        // #760 instrumentation, non-exact / shared-exact
+                        // Local path. See umem.rs field comment.
+                        binding
+                            .live
+                            .drain_sent_bytes_shaped_unconditional
+                            .fetch_add(bytes, Ordering::Relaxed);
                     }
                     cos_batch_tx_made_progress(Ok((packets, bytes)))
                 }
@@ -2625,6 +2639,13 @@ fn submit_cos_batch(
                             .tx_packets
                             .fetch_add(packets, Ordering::Relaxed);
                         binding.live.tx_bytes.fetch_add(bytes, Ordering::Relaxed);
+                        // #760 instrumentation, Prepared path (the
+                        // in-place-rewrite hot path). See umem.rs
+                        // field comment.
+                        binding
+                            .live
+                            .drain_sent_bytes_shaped_unconditional
+                            .fetch_add(bytes, Ordering::Relaxed);
                     }
                     cos_batch_tx_made_progress(Ok((packets, bytes)))
                 }

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -1083,6 +1083,24 @@ pub(super) struct CoSTimerWheelRuntime {
 pub(super) struct CoSQueueOwnerProfile {
     pub(super) drain_latency_hist: [AtomicU64; super::umem::DRAIN_HIST_BUCKETS],
     pub(super) drain_invocations: AtomicU64,
+    /// #760 instrumentation. Bytes the shaped drain actually
+    /// submitted on behalf of this queue. Divide by a scrape window
+    /// to get an observed drain rate and compare against
+    /// `queue.transmit_rate_bytes`. Writer = owner worker on the
+    /// single site that also decrements `queue.tokens` after a send
+    /// (apply_direct_exact_send_result for exact-owner-local,
+    /// apply_cos_send_result for the non-exact / shared-exact paths).
+    pub(super) drain_sent_bytes: AtomicU64,
+    /// #760 instrumentation. Count of drain iterations where the
+    /// root token gate fired (root.tokens < head_len) and the queue
+    /// got parked waiting for the interface shaper to refill.
+    pub(super) drain_park_root_tokens: AtomicU64,
+    /// #760 instrumentation. Count of drain iterations where the
+    /// per-queue token gate fired (queue.tokens < head_len) and the
+    /// queue got parked waiting for its own refill. A queue that
+    /// sustains throughput above its configured rate with this near
+    /// zero is a direct signal the gate never fired.
+    pub(super) drain_park_queue_tokens: AtomicU64,
 }
 
 impl CoSQueueOwnerProfile {
@@ -1090,6 +1108,9 @@ impl CoSQueueOwnerProfile {
         Self {
             drain_latency_hist: std::array::from_fn(|_| AtomicU64::new(0)),
             drain_invocations: AtomicU64::new(0),
+            drain_sent_bytes: AtomicU64::new(0),
+            drain_park_root_tokens: AtomicU64::new(0),
+            drain_park_queue_tokens: AtomicU64::new(0),
         }
     }
 }

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -856,6 +856,15 @@ pub(super) struct BindingLiveState {
     /// non-zero value usually indicates a frame-building bug upstream
     /// or a legitimate oversize packet. Subset of `tx_errors`.
     pub(super) tx_submit_error_drops: AtomicU64,
+    /// #760 instrumentation. Bytes delivered by the post-CoS backup
+    /// transmit paths in `drain_pending_tx` (transmit_prepared_batch
+    /// + transmit_batch calls at tx.rs:289/330). These sites bypass
+    /// the CoS token gate entirely — anything non-zero here means
+    /// packets are leaving the binding without being rate-limited
+    /// by any queue's admission, which is the most likely bypass
+    /// path for #760's observed 57% overshoot on single-flow
+    /// exact-queue workloads.
+    pub(super) post_drain_backup_bytes: AtomicU64,
     /// #710: packets dropped in `apply_worker_shaped_tx_requests`
     /// because the worker could not locate any binding for the
     /// request's egress_ifindex. Happens when a cross-worker CoS
@@ -974,6 +983,7 @@ impl BindingLiveState {
             redirect_inbox_overflow_drops: AtomicU64::new(0),
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
+            post_drain_backup_bytes: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
             // #709 / #746: owner-profile telemetry, split by writer
             // into two cacheline-isolated groups. Histograms are zero-

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -856,6 +856,16 @@ pub(super) struct BindingLiveState {
     /// non-zero value usually indicates a frame-building bug upstream
     /// or a legitimate oversize packet. Subset of `tx_errors`.
     pub(super) tx_submit_error_drops: AtomicU64,
+    /// #760 instrumentation. Bytes the three `apply_*` sites
+    /// observed in `sent_bytes`, incremented WITHOUT the
+    /// `if let Some(queue)` guard the per-queue
+    /// `CoSQueueOwnerProfile::drain_sent_bytes` write uses. The sum
+    /// of this plus `post_drain_backup_bytes` equals `tx_bytes` on
+    /// the shaped path. Per-queue `drain_sent_bytes` can undercount
+    /// vs this one; the gap reveals how much shaped traffic is
+    /// leaving the binding via `apply_*`'s early-return / queue-miss
+    /// branches. Not a user-facing metric — purely for #760 triage.
+    pub(super) drain_sent_bytes_shaped_unconditional: AtomicU64,
     /// #760 instrumentation. Bytes delivered by the post-CoS backup
     /// transmit paths in `drain_pending_tx` (transmit_prepared_batch
     /// + transmit_batch calls at tx.rs:289/330). These sites bypass
@@ -984,6 +994,7 @@ impl BindingLiveState {
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
             post_drain_backup_bytes: AtomicU64::new(0),
+            drain_sent_bytes_shaped_unconditional: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
             // #709 / #746: owner-profile telemetry, split by writer
             // into two cacheline-isolated groups. Histograms are zero-

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -1202,6 +1202,10 @@ impl BindingLiveState {
                 .pending_tx_local_overflow_drops
                 .load(Ordering::Relaxed),
             tx_submit_error_drops: self.tx_submit_error_drops.load(Ordering::Relaxed),
+            post_drain_backup_bytes: self.post_drain_backup_bytes.load(Ordering::Relaxed),
+            drain_sent_bytes_shaped_unconditional: self
+                .drain_sent_bytes_shaped_unconditional
+                .load(Ordering::Relaxed),
             // `no_owner_binding_drops` is read directly from the atomic
             // by `Coordinator::cos_no_owner_binding_drops_total()` — not
             // snapshotted here because it is not exposed per-binding.

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -3993,6 +3993,10 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) redirect_inbox_overflow_drops: u64,
     pub(crate) pending_tx_local_overflow_drops: u64,
     pub(crate) tx_submit_error_drops: u64,
+    // #760 triage: surfaced on BindingStatus so operators can
+    // compare binding-level vs per-queue drain accounting.
+    pub(crate) post_drain_backup_bytes: u64,
+    pub(crate) drain_sent_bytes_shaped_unconditional: u64,
     // #710: `no_owner_binding_drops` is intentionally NOT snapshotted
     // per-binding. The atomic on `BindingLiveState` accumulates drops
     // for mechanical accounting (the increment site can only write to

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1716,6 +1716,12 @@ pub(super) struct OwnerProfileSnapshot {
     pub(super) redirect_acquire_hist: [u64; DRAIN_HIST_BUCKETS],
     pub(super) owner_pps: u64,
     pub(super) peer_pps: u64,
+    /// #760 instrumentation, binding-scoped. Bytes delivered via
+    /// the post-CoS backup transmit paths in `drain_pending_tx`
+    /// — these never passed a queue's token gate. Surfaced on
+    /// the same "unambiguous owner-local exact queue" row the
+    /// other binding-scoped fields use.
+    pub(super) post_drain_backup_bytes: u64,
 }
 
 #[inline]
@@ -1740,6 +1746,7 @@ pub(super) fn owner_profile_snapshot(live: &BindingLiveState) -> OwnerProfileSna
         }),
         owner_pps: live.owner_profile_owner.owner_pps.load(Ordering::Relaxed),
         peer_pps: live.owner_profile_peer.peer_pps.load(Ordering::Relaxed),
+        post_drain_backup_bytes: live.post_drain_backup_bytes.load(Ordering::Relaxed),
     }
 }
 
@@ -1778,6 +1785,22 @@ pub(crate) fn merge_cos_queue_owner_profile_sum(
         .saturating_add(src.drain_noop_invocations);
     dst.owner_pps = dst.owner_pps.saturating_add(src.owner_pps);
     dst.peer_pps = dst.peer_pps.saturating_add(src.peer_pps);
+    // #760 sum-merge the new per-queue + binding-scoped counters
+    // across workers. Same saturating-add discipline as the rest of
+    // this function — a single queue can be owned by at most one
+    // worker per scrape, so cross-worker aggregation is almost
+    // always sum-of-single-non-zero, but saturating_add keeps us
+    // safe if the ownership ever shifts mid-scrape.
+    dst.drain_sent_bytes = dst.drain_sent_bytes.saturating_add(src.drain_sent_bytes);
+    dst.drain_park_root_tokens = dst
+        .drain_park_root_tokens
+        .saturating_add(src.drain_park_root_tokens);
+    dst.drain_park_queue_tokens = dst
+        .drain_park_queue_tokens
+        .saturating_add(src.drain_park_queue_tokens);
+    dst.post_drain_backup_bytes = dst
+        .post_drain_backup_bytes
+        .saturating_add(src.post_drain_backup_bytes);
 }
 
 /// #709: sum-merge a binding's owner-profile snapshot into a per-queue
@@ -1850,6 +1873,14 @@ pub(super) fn merge_binding_scoped_owner_profile(
         .saturating_add(profile.drain_noop_invocations);
     status.owner_pps = status.owner_pps.saturating_add(profile.owner_pps);
     status.peer_pps = status.peer_pps.saturating_add(profile.peer_pps);
+    // #760 smoking gun. Surfaced once per binding on the same
+    // unambiguous owner-local exact queue row the other
+    // binding-scoped fields ride on, so we don't multiply-count
+    // the same binding-wide atomic across several queues of a
+    // shared-exact shape.
+    status.post_drain_backup_bytes = status
+        .post_drain_backup_bytes
+        .saturating_add(profile.post_drain_backup_bytes);
 }
 
 fn build_worker_cos_statuses_from_maps<'a, I>(
@@ -2023,6 +2054,35 @@ where
                     status.drain_invocations =
                         status.drain_invocations.saturating_add(queue_invocations);
                 }
+                // #760 overshoot-hunt instrumentation. Same Relaxed
+                // load pattern as drain_invocations — single writer
+                // (owner worker, at the queue-token decrement sites
+                // in tx.rs) + single reader (this snapshot path).
+                // drain_sent_bytes is the authoritative per-queue
+                // "bytes the scheduler actually shaped out"; pair it
+                // with `queue.transmit_rate_bytes` over a scrape
+                // window to detect a direct cap bypass on this row.
+                // drain_park_root_tokens / drain_park_queue_tokens
+                // both rising with drain_sent_bytes sustaining above
+                // configured rate would mean the gate fires but the
+                // refill/accounting is wrong; both near zero with
+                // drain_sent_bytes above rate means the gate never
+                // ran for this queue.
+                status.drain_sent_bytes = status.drain_sent_bytes.saturating_add(
+                    queue.owner_profile.drain_sent_bytes.load(Ordering::Relaxed),
+                );
+                status.drain_park_root_tokens = status.drain_park_root_tokens.saturating_add(
+                    queue
+                        .owner_profile
+                        .drain_park_root_tokens
+                        .load(Ordering::Relaxed),
+                );
+                status.drain_park_queue_tokens = status.drain_park_queue_tokens.saturating_add(
+                    queue
+                        .owner_profile
+                        .drain_park_queue_tokens
+                        .load(Ordering::Relaxed),
+                );
 
                 // #709 / #748 / #751: the *binding-scoped* fields
                 // (redirect_acquire_hist, owner_pps, peer_pps,

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1722,6 +1722,12 @@ pub(super) struct OwnerProfileSnapshot {
     /// the same "unambiguous owner-local exact queue" row the
     /// other binding-scoped fields use.
     pub(super) post_drain_backup_bytes: u64,
+    /// #760 instrumentation, binding-scoped. Bytes observed at the
+    /// three `apply_*` tx_bytes sites, incremented unconditionally.
+    /// Compare against the sum of per-queue `drain_sent_bytes`; any
+    /// gap is shaped traffic that bypassed the per-queue write via
+    /// an `apply_*` early-return.
+    pub(super) drain_sent_bytes_shaped_unconditional: u64,
 }
 
 #[inline]
@@ -1747,6 +1753,9 @@ pub(super) fn owner_profile_snapshot(live: &BindingLiveState) -> OwnerProfileSna
         owner_pps: live.owner_profile_owner.owner_pps.load(Ordering::Relaxed),
         peer_pps: live.owner_profile_peer.peer_pps.load(Ordering::Relaxed),
         post_drain_backup_bytes: live.post_drain_backup_bytes.load(Ordering::Relaxed),
+        drain_sent_bytes_shaped_unconditional: live
+            .drain_sent_bytes_shaped_unconditional
+            .load(Ordering::Relaxed),
     }
 }
 
@@ -1801,6 +1810,9 @@ pub(crate) fn merge_cos_queue_owner_profile_sum(
     dst.post_drain_backup_bytes = dst
         .post_drain_backup_bytes
         .saturating_add(src.post_drain_backup_bytes);
+    dst.drain_sent_bytes_shaped_unconditional = dst
+        .drain_sent_bytes_shaped_unconditional
+        .saturating_add(src.drain_sent_bytes_shaped_unconditional);
 }
 
 /// #709: sum-merge a binding's owner-profile snapshot into a per-queue
@@ -1881,6 +1893,9 @@ pub(super) fn merge_binding_scoped_owner_profile(
     status.post_drain_backup_bytes = status
         .post_drain_backup_bytes
         .saturating_add(profile.post_drain_backup_bytes);
+    status.drain_sent_bytes_shaped_unconditional = status
+        .drain_sent_bytes_shaped_unconditional
+        .saturating_add(profile.drain_sent_bytes_shaped_unconditional);
 }
 
 fn build_worker_cos_statuses_from_maps<'a, I>(

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1209,6 +1209,18 @@ pub(crate) struct BindingStatus {
     // the flow-fair admission / redirect-inbox / pending-FIFO drops.
     #[serde(rename = "tx_submit_error_drops", default)]
     pub tx_submit_error_drops: u64,
+    // #760 instrumentation: post-CoS backup transmit bytes
+    // (drain_pending_tx fallbacks at tx.rs:289/330) that bypass
+    // any CoS queue's token gate.
+    #[serde(rename = "post_drain_backup_bytes", default)]
+    pub post_drain_backup_bytes: u64,
+    // #760 instrumentation: binding-scoped bytes observed at the
+    // three apply_* tx_bytes sites, written unconditionally. Gap
+    // vs the sum of per-queue drain_sent_bytes attributes shaped
+    // traffic that bypassed the per-queue write via an apply_*
+    // early-return / queue miss.
+    #[serde(rename = "drain_sent_bytes_shaped_unconditional", default)]
+    pub drain_sent_bytes_shaped_unconditional: u64,
     // #710 attribution note: cross-worker CoS "no-owner-binding" drops
     // are exposed at the `ProcessStatus::cos_no_owner_binding_drops_total`
     // top-level field, not per binding. The increment mechanically lands

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -866,6 +866,22 @@ pub(crate) struct CoSQueueStatus {
     pub owner_pps: u64,
     #[serde(rename = "peer_pps", default)]
     pub peer_pps: u64,
+    // #760 overshoot-hunt instrumentation. Read at the same
+    // cadence as the other owner-profile fields; zeroed for
+    // queues without a single unambiguous owner-local binding.
+    #[serde(rename = "drain_sent_bytes", default)]
+    pub drain_sent_bytes: u64,
+    #[serde(rename = "drain_park_root_tokens", default)]
+    pub drain_park_root_tokens: u64,
+    #[serde(rename = "drain_park_queue_tokens", default)]
+    pub drain_park_queue_tokens: u64,
+    // #760 binding-scoped: non-zero means the post-CoS backup
+    // transmit path (drain_pending_tx) sent bytes without
+    // going through any queue's token gate. Same value is
+    // broadcast on every queue status belonging to the
+    // binding — the Go renderer shows it once per interface.
+    #[serde(rename = "post_drain_backup_bytes", default)]
+    pub post_drain_backup_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -882,6 +882,13 @@ pub(crate) struct CoSQueueStatus {
     // binding — the Go renderer shows it once per interface.
     #[serde(rename = "post_drain_backup_bytes", default)]
     pub post_drain_backup_bytes: u64,
+    /// #760 triage. Binding-scoped bytes observed at the three
+    /// `apply_*` tx_bytes sites, written unconditionally. Compare
+    /// against the sum of `drain_sent_bytes` across all queues —
+    /// any gap attributes shaped traffic that bypassed the
+    /// per-queue write via an `apply_*` early-return / queue miss.
+    #[serde(rename = "drain_sent_bytes_shaped_unconditional", default)]
+    pub drain_sent_bytes_shaped_unconditional: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
Wire 4 atomics through the snapshot path to identify which transmit
site is letting the CoS cap slip when iperf3 -P 1 overshoots the
1 Gbps iperf-a guarantee. Investigation branch — merging this only
once the root cause is understood, but the telemetry stands on its own
for ongoing diagnostics.

## New counters
Per-queue atomics (owner worker, Relaxed):
  - \`drain_sent_bytes\` at the queue.tokens decrement sites
    (both exact-owner-local and non-exact/shared paths)
  - \`drain_park_root_tokens\` (root-token gate fired in exact selector)
  - \`drain_park_queue_tokens\` (per-queue token gate fired)

Binding-scoped atomic (smoking gun, surfaced on binding telemetry row):
  - \`post_drain_backup_bytes\` — bytes delivered via the post-CoS
    backup transmit paths in \`drain_pending_tx\`
    (transmit_prepared_batch + transmit_batch calls). These sites
    bypass the CoS token gate entirely.

## Render
\`show class-of-service interface <if>\` gains per-queue
\`DrainShape: sent_bytes=… park_root=… park_queue=…\` under the
existing OwnerProfile line, plus a \`post_drain_backup_bytes\` on the
\`Binding telemetry\` row.

## Deploy + measure — first findings
Deployed to \`loss:xpf-userspace-fw0/fw1\`.

30 s \`iperf3 -c 172.16.80.200 -P 1 -t 30 -p 5201\`:
- Result: 955 Mbps at the receiver — UNDER the 1 Gbps cap
- \`drain_sent_bytes\` delta ≈ 987 Mbps (matches cap)
- \`post_drain_backup_bytes\` = 0

120 s run:
- Result: **1.55 Gbps at receiver — +55% over cap**, 919K retransmits
- \`drain_sent_bytes\` delta = 14.8 GB / 120 s = **987 Mbps wire** (tracks cap exactly)
- \`drain_park_queue_tokens\` delta = 1.69M gate-fires
- \`drain_park_root_tokens\` delta = 0 (interface shaper idle, 25 Gbps)
- \`post_drain_backup_bytes\` = 0 — **drain backup is NOT the leak**
- Firewall filter counter (\`iperf-a\`) delta ≈ 23 GB wire = 1.53 Gbps

## Interpretation
- CoS gate is working exactly as designed on queue 4
- Something is delivering an additional ~560 Mbps of classified
  iperf-a traffic to the wire that does NOT pass through either the
  shaped drain path OR the post-drain backup path
- The leak is time-dependent: absent on 30 s, present on 120 s

Next diagnostic: cross-check \`BindingLiveState.tx_bytes\` against
\`sum(drain_sent_bytes + post_drain_backup_bytes)\`. If tx_bytes is
larger, we have an un-instrumented TX site. If equal, the extra
bytes are going through some other binding entirely (cross-binding /
cross-worker TX ring).

Refs #760

## Test plan
- [x] \`cargo test\` passes (703 tests, 0 failures)
- [x] \`go test ./...\` passes  
- [x] Deployed to loss:xpf-userspace-fw0/fw1
- [x] Counters render via \`show class-of-service interface reth0.80\`
- [ ] Identify bypass path and fix