### PR TITLE
config: reject duplicate forwarding-class-to-queue mappings

### DIFF
--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -32,6 +33,34 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	}
 
 	if fcNode := node.FindChild("forwarding-classes"); fcNode != nil {
+		// Track which FC owns each queue so we can reject
+		// duplicate-FC-per-queue configs with a clear error.
+		//
+		// Junos semantics give each queue ID one forwarding class
+		// (schedulers attach to an FC, so two FCs with different
+		// schedulers on the same queue contradict each other on
+		// rate). The userspace dataplane's compile path
+		// (forwarding_build.rs) iterates the scheduler-map and
+		// creates ONE CoSQueueConfig per FC; when two FCs map to
+		// the same queue_id the result is two runtime entries
+		// that share queue_id but carry different transmit rates
+		// and forwarding-class names. Downstream:
+		//
+		//   * `resolve_cos_queue_idx` returns the first match by
+		//     queue_id, so packets go to one of the two duplicates
+		//     at random (depends on scheduler-map iteration order).
+		//   * The shared-queue lease gets its rate from yet
+		//     another code path, so the live shaper rate can be a
+		//     third value distinct from both queue entries.
+		//   * `show class-of-service interface` displays one
+		//     forwarding-class name alongside a rate that belongs
+		//     to the OTHER FC on the same queue — a
+		//     debugger-hostile mismatch.
+		//
+		// Surfaced during #785 investigation when a user config
+		// mapped iperf-b (scheduler 10g) AND iperf-c (scheduler
+		// 25g) to queue 5 simultaneously.
+		queueOwner := make(map[int]string)
 		for _, queueNode := range fcNode.FindChildren("queue") {
 			if len(queueNode.Keys) < 3 {
 				continue
@@ -41,6 +70,18 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 				continue
 			}
 			name := queueNode.Keys[2]
+			if existing, claimed := queueOwner[queue]; claimed && existing != name {
+				return fmt.Errorf(
+					"class-of-service forwarding-classes queue %d: "+
+						"forwarding-class %q conflicts with %q "+
+						"(a queue can only be owned by one "+
+						"forwarding-class; schedulers attach to an "+
+						"FC, so two FCs on one queue give the queue "+
+						"two conflicting scheduler rates)",
+					queue, name, existing,
+				)
+			}
+			queueOwner[queue] = name
 			cos.ForwardingClasses[name] = &CoSForwardingClass{
 				Name:  name,
 				Queue: queue,

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -33,34 +33,51 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	}
 
 	if fcNode := node.FindChild("forwarding-classes"); fcNode != nil {
-		// Track which FC owns each queue so we can reject
-		// duplicate-FC-per-queue configs with a clear error.
+		// Enforce the FC ↔ queue bijection. Junos semantics give
+		// each queue ID one forwarding class, and each FC one
+		// queue — schedulers attach to an FC, so two FCs on one
+		// queue give the queue two conflicting rate targets, and
+		// one FC on two queues leaves classifier / scheduler-map
+		// references ambiguous.
 		//
-		// Junos semantics give each queue ID one forwarding class
-		// (schedulers attach to an FC, so two FCs with different
-		// schedulers on the same queue contradict each other on
-		// rate). The userspace dataplane's compile path
-		// (forwarding_build.rs) iterates the scheduler-map and
-		// creates ONE CoSQueueConfig per FC; when two FCs map to
-		// the same queue_id the result is two runtime entries
-		// that share queue_id but carry different transmit rates
-		// and forwarding-class names. Downstream:
+		// The userspace dataplane's compile path
+		// (`forwarding_build.rs`) iterates the scheduler-map and
+		// creates ONE `CoSQueueConfig` per FC. Without this guard
+		// either direction of a bijection violation produces
+		// inconsistent runtime state that downstream code
+		// silently disambiguates three different ways:
 		//
 		//   * `resolve_cos_queue_idx` returns the first match by
-		//     queue_id, so packets go to one of the two duplicates
-		//     at random (depends on scheduler-map iteration order).
-		//   * The shared-queue lease gets its rate from yet
-		//     another code path, so the live shaper rate can be a
-		//     third value distinct from both queue entries.
+		//     queue_id, so packets for an ambiguous queue go to
+		//     whichever duplicate the scheduler-map produced
+		//     first.
+		//   * The shared-queue lease derives its rate from a
+		//     separate path, which can land on yet another value.
 		//   * `show class-of-service interface` displays one
-		//     forwarding-class name alongside a rate that belongs
-		//     to the OTHER FC on the same queue — a
-		//     debugger-hostile mismatch.
+		//     entry's FC name alongside a different entry's rate
+		//     — a debugger-hostile mismatch on live output.
 		//
-		// Surfaced during #785 investigation when a user config
-		// mapped iperf-b (scheduler 10g) AND iperf-c (scheduler
-		// 25g) to queue 5 simultaneously.
-		queueOwner := make(map[int]string)
+		// Both directions are rejected:
+		//
+		//   * queue N → two different FCs (`queue 5 iperf-b`
+		//     followed by `queue 5 iperf-c`) surfaced during the
+		//     #785 investigation; the scheduler-map would attach
+		//     both schedulers to queue 5 at conflicting rates.
+		//   * FC X → two different queue numbers (`queue 4 iperf-a`
+		//     followed by `queue 5 iperf-a`) — the second silently
+		//     overwrote `ForwardingClasses[X].Queue`, leaving any
+		//     `classifier`/`scheduler-map` reference to FC X
+		//     resolving to the wrong queue at runtime.
+		//     (Flagged by Codex review of PR #787; can arise from
+		//     `apply-groups` / `${node}` expansion producing
+		//     unintended duplicate entries in a user's config.)
+		//
+		// Idempotent reassignment of the SAME FC to the SAME
+		// queue is explicitly allowed so `load merge` /
+		// `load override` paths that re-apply the same line
+		// remain clean.
+		queueOwner := make(map[int]string) // queue_id → FC name
+		fcQueue := make(map[string]int)    // FC name → queue_id
 		for _, queueNode := range fcNode.FindChildren("queue") {
 			if len(queueNode.Keys) < 3 {
 				continue
@@ -81,7 +98,19 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					queue, name, existing,
 				)
 			}
+			if existingQueue, claimed := fcQueue[name]; claimed && existingQueue != queue {
+				return fmt.Errorf(
+					"class-of-service forwarding-classes "+
+						"forwarding-class %q: queue %d conflicts with "+
+						"queue %d (an FC can only be assigned to one "+
+						"queue; classifier and scheduler-map "+
+						"references to %q would otherwise resolve to "+
+						"different queues depending on evaluation order)",
+					name, queue, existingQueue, name,
+				)
+			}
 			queueOwner[queue] = name
+			fcQueue[name] = queue
 			cos.ForwardingClasses[name] = &CoSForwardingClass{
 				Name:  name,
 				Queue: queue,

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -533,3 +533,100 @@ system {
 		t.Fatalf("expected queue range warning, got: %s", warnings)
 	}
 }
+
+// TestCompileClassOfServiceRejectsDuplicateFCPerQueue pins the validation
+// added for the #785 follow-up: two forwarding classes assigned to the
+// same queue ID must cause `CompileConfig` to return an error, not a
+// silent warning.
+//
+// Before the fix, a config like the one below silently compiled into two
+// CoSQueueConfig entries sharing `queue_id=5` with different transmit
+// rates, which the userspace dataplane then resolved inconsistently
+// across three code paths (runtime queue transmit_rate, shared-lease
+// rate, and display) — the discovery that pre-empted the #785 cross-
+// worker investigation's throughput-vs-fairness analysis. Rejection at
+// compile time prevents the inconsistency from ever reaching the
+// dataplane.
+func TestCompileClassOfServiceRejectsDuplicateFCPerQueue(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service forwarding-classes queue 5 iperf-b",
+		"set class-of-service forwarding-classes queue 5 iperf-c", // conflict
+		"set class-of-service schedulers scheduler-iperf-b transmit-rate 10g",
+		"set class-of-service schedulers scheduler-iperf-b transmit-rate exact",
+		"set class-of-service schedulers scheduler-iperf-c transmit-rate 25g",
+		"set class-of-service schedulers scheduler-iperf-c transmit-rate exact",
+		"set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b",
+		"set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c",
+		"set class-of-service interfaces reth0 unit 80 shaping-rate 25g",
+		"set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal(
+			"expected CompileConfig to REJECT a config with two " +
+				"forwarding-classes on the same queue; got no error. " +
+				"Regression re-introduces the three-way runtime " +
+				"inconsistency that bit the #785 investigation.",
+		)
+	}
+	msg := err.Error()
+	// The error must name the offending queue and BOTH FCs so the
+	// operator can fix the config without having to diff the whole
+	// forwarding-classes block.
+	if !strings.Contains(msg, "queue 5") {
+		t.Errorf("error message must identify the conflicting queue ID 5, got: %s", msg)
+	}
+	if !strings.Contains(msg, "iperf-b") {
+		t.Errorf("error message must identify first FC iperf-b, got: %s", msg)
+	}
+	if !strings.Contains(msg, "iperf-c") {
+		t.Errorf("error message must identify second FC iperf-c, got: %s", msg)
+	}
+}
+
+// TestCompileClassOfServiceAllowsIdempotentReassignment pins that
+// setting the SAME FC-to-queue mapping twice does NOT produce an
+// error — reconciliation paths (e.g. `load merge`, `load override`,
+// or applying a set script that re-runs the same assignment) must
+// remain idempotent.
+func TestCompileClassOfServiceAllowsIdempotentReassignment(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service forwarding-classes queue 5 iperf-c",
+		"set class-of-service forwarding-classes queue 5 iperf-c", // same, not duplicate
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("idempotent reassignment must compile cleanly: %v", err)
+	}
+	fc := cfg.ClassOfService.ForwardingClasses["iperf-c"]
+	if fc == nil {
+		t.Fatal("expected iperf-c forwarding class")
+	}
+	if fc.Queue != 5 {
+		t.Fatalf("iperf-c queue = %d, want 5", fc.Queue)
+	}
+}

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -630,3 +630,88 @@ func TestCompileClassOfServiceAllowsIdempotentReassignment(t *testing.T) {
 		t.Fatalf("iperf-c queue = %d, want 5", fc.Queue)
 	}
 }
+
+// TestCompileClassOfServiceRejectsSameFCOnDifferentQueues pins the
+// second direction of the FC ↔ queue bijection: one forwarding class
+// cannot be assigned to two different queue numbers.
+//
+// This path can arise organically from `apply-groups` / `${node}`
+// expansion producing duplicate entries in an operator's config.
+// Pre-fix the second assignment silently overwrote
+// `ForwardingClasses[name].Queue`, so classifier + scheduler-map
+// references to that FC would resolve to the wrong queue depending
+// on the compile-time iteration order — a silent runtime-routing
+// bug with no warning surface. (Flagged by Codex review of the
+// initial PR #787 revision; that revision guarded only the
+// queue-ID → FC-name direction.)
+func TestCompileClassOfServiceRejectsSameFCOnDifferentQueues(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service forwarding-classes queue 4 iperf-a",
+		"set class-of-service forwarding-classes queue 5 iperf-a", // conflict
+		"set class-of-service schedulers scheduler-iperf-a transmit-rate 1g",
+		"set class-of-service schedulers scheduler-iperf-a transmit-rate exact",
+		"set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal(
+			"expected CompileConfig to REJECT a config that assigns " +
+				"the same forwarding-class to two different queues; got " +
+				"no error. Regression silently overwrites the FC→queue " +
+				"map and mis-routes classifier / scheduler-map references.",
+		)
+	}
+	msg := err.Error()
+	// Error must name the FC and BOTH conflicting queue numbers.
+	if !strings.Contains(msg, "iperf-a") {
+		t.Errorf("error message must name the conflicting FC iperf-a, got: %s", msg)
+	}
+	if !strings.Contains(msg, "queue 4") {
+		t.Errorf("error message must name first queue 4, got: %s", msg)
+	}
+	if !strings.Contains(msg, "queue 5") {
+		t.Errorf("error message must name second queue 5, got: %s", msg)
+	}
+}
+
+// TestCompileClassOfServiceRejectsThreeFCsOnOneQueue pins that the
+// duplicate detection fires on the SECOND collision regardless of
+// how many FCs pile up on one queue — the error catches the
+// earliest conflict in iteration order, not the last.
+func TestCompileClassOfServiceRejectsThreeFCsOnOneQueue(t *testing.T) {
+	lines := []string{
+		"set class-of-service forwarding-classes queue 5 iperf-a",
+		"set class-of-service forwarding-classes queue 5 iperf-b",
+		"set class-of-service forwarding-classes queue 5 iperf-c",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected three FCs on one queue to be rejected at compile time")
+	}
+	if !strings.Contains(err.Error(), "queue 5") {
+		t.Errorf("error must reference queue 5, got: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- A CoS config that assigns two forwarding classes to the same queue ID silently compiled before this fix, producing inconsistent runtime state across three independent code paths. `CompileConfig` now returns a hard error naming the offending queue and both conflicting FCs.
- Idempotent reassignment (same FC listed twice on the same queue) is explicitly allowed so `load merge` / `load override` reconciliation paths stay clean.
- Two new unit tests pin both the rejection and the idempotent-allow behavior.

## How the bug surfaces

Config shape that triggers it (the exact config that bit the #785 investigation):

```
set class-of-service forwarding-classes queue 5 iperf-b
set class-of-service forwarding-classes queue 5 iperf-c
set class-of-service schedulers scheduler-iperf-b transmit-rate 10g
set class-of-service schedulers scheduler-iperf-c transmit-rate 25g
set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c
```

Before: silently compiled. `show class-of-service interface` displayed one FC's name next to another FC's transmit rate. `queue.transmit_rate_bytes` on the runtime queue was one value; the shared-lease rate was a different value; the display was a third.

After: `CompileConfig` fails with

> class-of-service forwarding-classes queue 5: forwarding-class "iperf-c" conflicts with "iperf-b" (a queue can only be owned by one forwarding-class; schedulers attach to an FC, so two FCs on one queue give the queue two conflicting scheduler rates)

## Why hard-reject

Junos semantics: each queue has one scheduler via the scheduler-map. Two FCs on the same queue with different schedulers give the queue two conflicting rate targets — the compile pipeline cannot represent this unambiguously regardless of disambiguation policy. Warning-and-accepting lets the mismatch reach the shaper; error-and-reject forces the operator to fix the config.

## Test plan

- [x] `go test ./pkg/config/` — new `TestCompileClassOfServiceRejectsDuplicateFCPerQueue` and `TestCompileClassOfServiceAllowsIdempotentReassignment` pass; all existing CoS tests still pass.
- [x] `go test ./...` — all 29 packages pass.
- [ ] Manual: load the bug-trigger config via `cli` / `load merge` on a test VM, confirm commit fails with the expected error and the config stays pre-commit.

## Follow-up (not in this PR)

The Rust forwarding-state builder at `userspace-dp/src/afxdp/forwarding_build.rs:603-629` still accepts the duplicate-queue shape silently. Adding a `debug_assert!` there would fail loudly if any other surface (snapshot replay, test fixture, future FC synthesis) re-introduces a duplicate, even though the Go compile path now rejects it upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)