### PR TITLE
userspace-dp: #802 expose per-binding ring-pressure counters in flow_steer_snapshot

### DIFF
--- a/docs/802-pr-review-rust.md
+++ b/docs/802-pr-review-rust.md
@@ -1,0 +1,190 @@
+# PR #804 — Rust-quality review (per-binding ring-pressure counters)
+
+Branch: `pr/802-ring-counter-instrumentation`
+Reviewer focus: Rust idioms, types, test quality, plumbing cleanliness.
+(Correctness of aggregation semantics is the Codex reviewer's lane; I
+agree at a glance but do not deep-dive it here.)
+
+**ROUND 1 verdict: merge-ready with minor polish.** No blockers. A
+handful of LOW/INFO polish items and one MEDIUM-quality observation
+about test coverage. Listed below in severity order.
+
+---
+
+## MEDIUM — Wire-shape test is a substring check, not a cross-language pin
+
+- **Summary**: `binding_counters_snapshot_serializes_with_expected_wire_keys`
+  asserts keys via `json.contains(&format!("\"{}\"", key))`. Substring
+  matching on the whole serialized blob passes even if a key is nested
+  inside a different field name (e.g. a hypothetical
+  `"foo_outstanding_tx"` field would still make the test think
+  `outstanding_tx` is present). It also does not cover the real failure
+  mode the comment warns about — "the daemon's poll path parses these
+  JSON keys" — because the daemon is Go, not Rust.
+- **Citation**: `userspace-dp/src/main.rs:1782-1824`
+  ```rust
+  let json = serde_json::to_string(&snap).expect("serialize snapshot");
+  for key in [ "worker_id", "ifindex", /* ... */ ] {
+      assert!(
+          json.contains(&format!("\"{}\"", key)),
+          "wire key `{key}` missing from snapshot JSON: {json}"
+      );
+  }
+  ```
+- **Mitigation** (pick one):
+  1. Parse into `serde_json::Value`, then assert keys exist at the
+     top level (`v.as_object().unwrap().contains_key(key)`). That's the
+     robust version of what this test is trying to say.
+  2. Add a Go-side test in `pkg/dataplane/userspace/protocol_test.go`
+     that decodes a canned JSON sample (the exact one the Rust side
+     would produce) into `BindingCountersSnapshot` and asserts every
+     field populates correctly. That's the real cross-binding pin.
+  3. Keep the substring check but also round-trip through the Go
+     struct via `encoding/json` in a Go test — the only way to catch
+     silent Rust↔Go drift is to exercise both sides.
+  The test comment explicitly names the daemon as the consumer, so a
+  Go-side decode test is the right level.
+
+## LOW — `BindingCountersSnapshot::ifindex` lacks the explicit `rename`
+
+- **Summary**: Every other field in `BindingCountersSnapshot` has an
+  explicit `#[serde(rename = "...", default)]` even when the rename
+  would be a no-op (e.g. `dbg_tx_ring_full`). `ifindex` alone uses
+  `#[serde(default)]` without `rename`. Harmless — serde defaults the
+  name to the field ident — but the inconsistency reads as an
+  oversight.
+- **Citation**: `userspace-dp/src/protocol.rs:1345-1347`
+  ```rust
+  #[serde(default)]
+  pub ifindex: i32,
+  ```
+- **Mitigation**: either add `#[serde(rename = "ifindex", default)]`
+  for consistency with the rest of the struct, or drop the redundant
+  renames from the other fields (they're all already snake_case
+  Rust idents). The existing `BindingStatus` struct uses explicit
+  renames on every field; mirror that.
+
+## LOW — Go-side casing inconsistency within `BindingCountersSnapshot`
+
+- **Summary**: The new Go struct mixes `TX` and `Tx` casing for TX
+  acronyms: `TXErrors`, `OutstandingTX` (uppercase) vs
+  `TxSubmitErrorDrops`, `PendingTxLocalOverflowDrops`,
+  `DbgTxRingFull`, `RxFillRingEmptyDescs` (mixed-case). The existing
+  `BindingStatus` is not itself consistent (`DebugPendingTXLocal`,
+  `DebugOutstandingTX`, `TXErrors` — all uppercase `TX`), so this PR
+  introduces a new divergence within one type.
+- **Citation**: `pkg/dataplane/userspace/protocol.go:678-690`
+- **Mitigation**: pick a rule and stick to it. Go convention per
+  Effective Go / Uber style is to uppercase acronyms (`TX`, `RX`,
+  `ID`), so `TXSubmitErrorDrops`, `PendingTXLocalOverflowDrops`,
+  `DbgTXRingFull`, `RXFillRingEmptyDescs` would match the
+  adjacent `TXErrors` / `OutstandingTX`. JSON tags are the load-bearing
+  wire contract — renaming Go field idents is cheap.
+
+## LOW — `BindingCountersSnapshot::from_binding_status` would read more
+idiomatically as `From<&BindingStatus>`
+
+- **Summary**: A named constructor `from_binding_status(&BindingStatus)`
+  is fine but `impl From<&BindingStatus> for BindingCountersSnapshot`
+  is the idiomatic Rust shape, and lets callers use
+  `.map(Into::into)` on the iterator chain in `refresh_status`.
+- **Citation**: `userspace-dp/src/protocol.rs:1366-1385`,
+  `userspace-dp/src/main.rs:803-807`
+  ```rust
+  state.status.per_binding = state
+      .status
+      .bindings
+      .iter()
+      .map(BindingCountersSnapshot::from_binding_status)
+      .collect();
+  ```
+- **Mitigation**: replace with `impl From<&BindingStatus> for
+  BindingCountersSnapshot`, then the call site becomes
+  `.map(BindingCountersSnapshot::from)` or `.map(Into::into)`. Purely
+  idiomatic, no functional change.
+
+## LOW — New `pub(super)` atomics are exposed cross-module via snapshot,
+which is the existing convention (note only)
+
+- **Summary**: `BindingLiveState` adds four new `pub(super) AtomicU64`
+  fields. Consistent with the rest of the struct; `pub(super)` is used
+  throughout and crossed through `BindingLiveSnapshot` into
+  `coordinator.rs`. No leak of `pub(super)` to `pub`. Public API
+  surface growth is limited to the two new `pub(crate)` types
+  (`BindingCountersSnapshot` at struct level, and the new serde fields
+  on `BindingStatus` / `ProcessStatus`).
+- **Citation**: `userspace-dp/src/afxdp/umem.rs:944-961`
+- **Mitigation**: none — this is the existing convention. Flagged so
+  the reviewer can confirm intent.
+
+## INFO — Pre-existing bug silently fixed: `debug_outstanding_tx` was
+never published by the worker before this PR
+
+- **Summary**: The new `b.live.debug_outstanding_tx.store(...)` in
+  the worker's per-second tick is the first writer to this atomic.
+  Every other site (`new()`, `snapshot()`, coordinator read) treats it
+  as a value that someone else populates, but before this PR no code
+  path actually wrote it. So the operator-facing
+  `BindingStatus.debug_outstanding_tx` was always zero, and the new
+  `BindingStatus.outstanding_tx` (aliased from it) is the value the
+  old field was supposed to have shown. Worth calling out in the PR
+  description or a follow-up note, because it changes observed field
+  behavior for anyone already consuming `debug_outstanding_tx`.
+- **Citation**:
+  - Old read path: `userspace-dp/src/afxdp/coordinator.rs:1411`
+  - New writer: `userspace-dp/src/afxdp/worker.rs:1368-1370`
+  - No other writer in the tree (verified via grep for
+    `debug_outstanding_tx.store`/`.fetch_add`).
+- **Mitigation**: none needed for this PR (the fix is strictly
+  better), but flag it in the commit message so consumers don't think
+  something changed semantics.
+
+## INFO — Double `statistics_v2()` syscall per binding per tick
+
+- **Summary**: The debug-summary block at
+  `userspace-dp/src/afxdp/worker.rs:952` calls `statistics_v2()` to
+  build a log string (log text is cfg-gated under `debug-log`, but the
+  syscall itself is unconditional). The new publish path at line 1358
+  calls `statistics_v2()` a second time. Both are per-tick (~1 Hz),
+  so the cost is negligible, but it's a pointless duplicate.
+- **Citation**:
+  - `userspace-dp/src/afxdp/worker.rs:952` (existing)
+  - `userspace-dp/src/afxdp/worker.rs:1358-1362` (new)
+- **Mitigation**: capture the `Result<XdpStatistics, _>` once at the
+  top of the per-binding loop, reuse it for both the log-formatting
+  path and the atomic publish. Or leave it — 1 Hz syscall is free.
+
+## INFO — `ring_pressure_counters_round_trip_through_snapshot` is
+strictly a publish-contract test, not a round-trip
+
+- **Summary**: The test name says "round_trip_through_snapshot" but it
+  only exercises `BindingLiveState::snapshot()` — no serialize, no
+  deserialize, no projection into `BindingCountersSnapshot`. The
+  other two tests cover those paths. Misleading name.
+- **Citation**: `userspace-dp/src/afxdp/coordinator.rs:2720-2739`
+- **Mitigation**: rename to something like
+  `snapshot_surfaces_ring_pressure_atomics` or
+  `ring_pressure_atomics_publish_via_snapshot`. One-liner.
+
+---
+
+## Summary
+
+- No blocker, no data-race concern, no public-API leak.
+- Atomic ordering choices (`fetch_add` for worker-local cumulative
+  deltas, `store` for kernel-absolute / gauge values) are correct and
+  the code comments explain the decision.
+- The `skip_serializing_if = "Vec::is_empty"` on `ProcessStatus::per_binding`
+  pairs cleanly with the Go `omitempty` tag — backward-compat on the
+  wire.
+- Go struct naming within `BindingCountersSnapshot` is internally
+  inconsistent (`TX`/`Tx`/`Rx`) and warrants a cleanup pass before
+  other consumers copy the style.
+- The most useful additional test would be a Go-side decode of a
+  canned JSON blob, which is the only way to catch silent wire-shape
+  drift between the two bindings.
+
+MERGE: **YES**, land after addressing the MEDIUM test-quality point
+(either upgrade the substring check to a `serde_json::Value` key check
+or add a Go-side decode test). LOW items are polish; can ride a
+follow-up.

--- a/docs/802-pr-review-rust.md
+++ b/docs/802-pr-review-rust.md
@@ -1,5 +1,9 @@
 # PR #804 — Rust-quality review (per-binding ring-pressure counters)
 
+**ROUND 2: merge-ready YES**
+
+
+
 Branch: `pr/802-ring-counter-instrumentation`
 Reviewer focus: Rust idioms, types, test quality, plumbing cleanliness.
 (Correctness of aggregation semantics is the Codex reviewer's lane; I
@@ -188,3 +192,50 @@ MERGE: **YES**, land after addressing the MEDIUM test-quality point
 (either upgrade the substring check to a `serde_json::Value` key check
 or add a Go-side decode test). LOW items are polish; can ride a
 follow-up.
+
+---
+
+## Round 2 verification
+
+Re-reviewed against commits `3008a833` (split + Rust nits) and
+`75a90298` (Go decode mirror) on `pr/802-ring-counter-instrumentation`.
+All round-1 items CLOSED.
+
+- **MEDIUM (substring → JSON-object key check): CLOSED.** `main.rs:1790`
+  `binding_counters_snapshot_serializes_with_expected_wire_keys` now
+  goes through `serde_json::to_value(&snap).as_object()` and asserts
+  each expected key via `obj.contains_key(key)`
+  (`main.rs:1815-1836`). Bonus negative assertion at
+  `main.rs:1839-1842` — `!obj.contains_key("dbg_pending_overflow")`
+  pins that the pre-split wire key is gone, which is the exact
+  contract the Codex split relies on for non-silent re-attribution.
+  Substring false-positive class eliminated.
+
+- **LOW (explicit `#[serde(rename = "ifindex")]`): CLOSED.**
+  `protocol.rs:1375` — `#[serde(rename = "ifindex", default)]` on
+  `BindingCountersSnapshot::ifindex`. Matches the other renamed
+  fields on the struct; defensive comment at `protocol.rs:1370-1374`
+  documents the rationale (identity-today, protect against a future
+  Rust-field rename silently renaming the wire key).
+
+- **LOW (`impl From<&BindingStatus>` replaces `from_binding_status`):
+  CLOSED.** `protocol.rs:1406-1423` — `impl
+  From<&BindingStatus> for BindingCountersSnapshot` with full field
+  projection including both split fields
+  (`dbg_bound_pending_overflow`, `dbg_cos_queue_overflow`). Comment at
+  `protocol.rs:1402-1405` references #804 and notes the composition
+  win with `.map(BindingCountersSnapshot::from)`.
+
+- **NEW test `binding_counters_snapshot_tolerates_pre_split_wire`:
+  PRESENT.** `main.rs:1851-1883`. Decodes a hand-written legacy JSON
+  blob that carries `"dbg_pending_overflow": 99` (the pre-split key)
+  and asserts both new fields deserialize to `0` via
+  `serde(default)`, with the round-tripped fields
+  (`worker_id`, `dbg_tx_ring_full`, `rx_fill_ring_empty_descs`)
+  intact. Pins the Rust-side of the cross-boundary compat contract
+  that `75a90298` mirrors on the Go decode path (Go u64 zero-value
+  via `encoding/json`, confirmed in the commit message and
+  `pkg/dataplane/userspace/protocol.go` diff).
+
+Nothing else regressed. Rust-side test surface expanded, idioms
+tightened, wire contract pinned in both directions. Merge-ready.

--- a/docs/802-pr-review.md
+++ b/docs/802-pr-review.md
@@ -1,3 +1,14 @@
+ROUND 2: merge-ready YES
+## Round 2 verification
+PASS — all four claims below validated.
+
+1. `BindingLiveState` has both new counters, `dbg_bound_pending_overflow` and `dbg_cos_queue_overflow`, in `userspace-dp/src/afxdp/umem.rs:954-968`.
+2. Increment attribution is split: `bound_pending_tx_local` and `bound_pending_tx_prepared` increment only `binding.dbg_bound_pending_overflow` (`userspace-dp/src/afxdp/tx.rs:160, 182`) while `enqueue_cos_item` increments only `binding.dbg_cos_queue_overflow` (`userspace-dp/src/afxdp/tx.rs:5406-5412`).
+3. Wire-key hygiene is correct: split keys exist as `dbg_bound_pending_overflow` and `dbg_cos_queue_overflow` in Rust wire structs (`userspace-dp/src/protocol.rs:1316-1319`, `1360-1365`, `1386-1389`), and `dbg_pending_overflow` is no longer present in serde/json tags there.
+4. Go consumer decodes both counters via `ControlResponse/ProcessStatus` JSON decode (`pkg/dataplane/userspace/process.go:185-200`) into fields that are present in Go structs (`pkg/dataplane/userspace/protocol.go:668-671`, `700-701`), with comments documenting pre-#804 zero-value compatibility (`pkg/dataplane/userspace/protocol.go:659-667`, `692-699`).
+
+Blocking issues: none.
+
 ROUND 1: NOT merge-ready
 
 ## Hot-path discipline

--- a/docs/802-pr-review.md
+++ b/docs/802-pr-review.md
@@ -1,0 +1,19 @@
+ROUND 1: NOT merge-ready
+
+## Hot-path discipline
+Clean.
+
+## Counter aggregation timing
+Clean.
+
+## Overflow semantics
+Clean.
+
+## outstanding_tx proxy quality
+Clean.
+
+## Wire-key backward compatibility
+Clean.
+
+## dbg_pending_overflow semantic (the PARTIAL finding) — does the counter name match what it counts?
+MAJOR | `dbg_pending_overflow` is published as “bound_pending” FIFO overflow while the increment site in the TX enqueue path also increments it for CoS queue overflow, so the operator-facing counter conflates two different saturation paths in one metric and can mislead root-cause triage | `userspace-dp/src/protocol.rs:1329-1330`, `userspace-dp/src/afxdp/tx.rs:157`, `userspace-dp/src/afxdp/tx.rs:176`, `userspace-dp/src/afxdp/tx.rs:5400` | Split the telemetry into distinct counters (or rename/clarify the field and docs) so `bound_pending` and CoS-queue admission overflow are not indistinguishable in the API payload.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -656,11 +656,19 @@ type BindingStatus struct {
 	DebugPendingTXLocal               uint32    `json:"debug_pending_tx_local,omitempty"`
 	DebugOutstandingTX                uint32    `json:"debug_outstanding_tx,omitempty"`
 	DebugInFlightRecycles             uint32    `json:"debug_in_flight_recycles,omitempty"`
-	// #802: ring-pressure instrumentation mirror fields. See the Rust
-	// `BindingStatus` for semantics and write sites.
+	// #802/#804: ring-pressure instrumentation mirror fields. See the
+	// Rust `BindingStatus` for semantics and write sites. The #804
+	// split replaces the pre-#804 `dbg_pending_overflow` field with
+	// two distinct wire keys — `dbg_bound_pending_overflow` for the
+	// `bound_pending` FIFO evict sites in `tx.rs`, and
+	// `dbg_cos_queue_overflow` for the class-of-service admission
+	// overflow in `enqueue_cos_item`. A snapshot from a pre-#804
+	// helper deserializes both as 0 (standard Go json zero-value),
+	// which is the right backward-compat behavior.
 	DbgTxRingFull                     uint64    `json:"dbg_tx_ring_full,omitempty"`
 	DbgSendtoENOBUFS                  uint64    `json:"dbg_sendto_enobufs,omitempty"`
-	DbgPendingOverflow                uint64    `json:"dbg_pending_overflow,omitempty"`
+	DbgBoundPendingOverflow           uint64    `json:"dbg_bound_pending_overflow,omitempty"`
+	DbgCoSQueueOverflow               uint64    `json:"dbg_cos_queue_overflow,omitempty"`
 	RxFillRingEmptyDescs              uint64    `json:"rx_fill_ring_empty_descs,omitempty"`
 	OutstandingTX                     uint32    `json:"outstanding_tx,omitempty"`
 	LastHeartbeat                     time.Time `json:"last_heartbeat,omitempty"`
@@ -676,17 +684,26 @@ type BindingStatus struct {
 //
 // #802.
 type BindingCountersSnapshot struct {
-	WorkerID                       uint32 `json:"worker_id"`
-	Ifindex                        int    `json:"ifindex,omitempty"`
-	QueueID                        uint32 `json:"queue_id"`
-	DbgTxRingFull                  uint64 `json:"dbg_tx_ring_full,omitempty"`
-	DbgSendtoENOBUFS               uint64 `json:"dbg_sendto_enobufs,omitempty"`
-	DbgPendingOverflow             uint64 `json:"dbg_pending_overflow,omitempty"`
-	RxFillRingEmptyDescs           uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
-	OutstandingTX                  uint32 `json:"outstanding_tx,omitempty"`
-	TXErrors                       uint64 `json:"tx_errors,omitempty"`
-	TxSubmitErrorDrops             uint64 `json:"tx_submit_error_drops,omitempty"`
-	PendingTxLocalOverflowDrops    uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
+	WorkerID uint32 `json:"worker_id"`
+	Ifindex  int    `json:"ifindex,omitempty"`
+	QueueID  uint32 `json:"queue_id"`
+	DbgTxRingFull    uint64 `json:"dbg_tx_ring_full,omitempty"`
+	DbgSendtoENOBUFS uint64 `json:"dbg_sendto_enobufs,omitempty"`
+	// #804: split from the pre-#804 `dbg_pending_overflow` field. Two
+	// distinct increment sites (bound-pending FIFO evict in tx.rs vs
+	// CoS queue admission in enqueue_cos_item) now publish two
+	// distinct wire keys so operators can disambiguate. A snapshot
+	// from a pre-#804 helper will leave both fields at the Go
+	// zero-value — there is no silent re-attribution of the legacy
+	// counter. Consumers that want a total across either path should
+	// sum these two explicitly.
+	DbgBoundPendingOverflow     uint64 `json:"dbg_bound_pending_overflow,omitempty"`
+	DbgCoSQueueOverflow         uint64 `json:"dbg_cos_queue_overflow,omitempty"`
+	RxFillRingEmptyDescs        uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
+	OutstandingTX               uint32 `json:"outstanding_tx,omitempty"`
+	TXErrors                    uint64 `json:"tx_errors,omitempty"`
+	TxSubmitErrorDrops          uint64 `json:"tx_submit_error_drops,omitempty"`
+	PendingTxLocalOverflowDrops uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
 }
 
 type ExceptionStatus struct {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -423,6 +423,9 @@ type ProcessStatus struct {
 	Fabrics                []FabricSnapshot                  `json:"fabrics,omitempty"`
 	Queues                 []QueueStatus                     `json:"queues,omitempty"`
 	Bindings               []BindingStatus                   `json:"bindings,omitempty"`
+	// #802: focused per-binding ring-pressure view. Projected from
+	// Bindings by the Rust helper; parallel rather than replacement.
+	PerBinding             []BindingCountersSnapshot         `json:"per_binding,omitempty"`
 	RecentSessionDeltas    []SessionDeltaInfo                `json:"recent_session_deltas,omitempty"`
 	RecentExceptions       []ExceptionStatus                 `json:"recent_exceptions,omitempty"`
 	CoSInterfaces          []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
@@ -653,9 +656,37 @@ type BindingStatus struct {
 	DebugPendingTXLocal               uint32    `json:"debug_pending_tx_local,omitempty"`
 	DebugOutstandingTX                uint32    `json:"debug_outstanding_tx,omitempty"`
 	DebugInFlightRecycles             uint32    `json:"debug_in_flight_recycles,omitempty"`
+	// #802: ring-pressure instrumentation mirror fields. See the Rust
+	// `BindingStatus` for semantics and write sites.
+	DbgTxRingFull                     uint64    `json:"dbg_tx_ring_full,omitempty"`
+	DbgSendtoENOBUFS                  uint64    `json:"dbg_sendto_enobufs,omitempty"`
+	DbgPendingOverflow                uint64    `json:"dbg_pending_overflow,omitempty"`
+	RxFillRingEmptyDescs              uint64    `json:"rx_fill_ring_empty_descs,omitempty"`
+	OutstandingTX                     uint32    `json:"outstanding_tx,omitempty"`
 	LastHeartbeat                     time.Time `json:"last_heartbeat,omitempty"`
 	LastError                         string    `json:"last_error,omitempty"`
 	LastChange                        time.Time `json:"last_change,omitempty"`
+}
+
+// BindingCountersSnapshot is the focused per-binding ring-pressure view
+// surfaced on ProcessStatus.PerBinding. It is a strict subset of
+// BindingStatus, emitted by the Rust helper so the daemon's poll path
+// can deserialize only the triage counters when that's all it needs.
+// See the Rust `BindingCountersSnapshot` definition for semantics.
+//
+// #802.
+type BindingCountersSnapshot struct {
+	WorkerID                       uint32 `json:"worker_id"`
+	Ifindex                        int    `json:"ifindex,omitempty"`
+	QueueID                        uint32 `json:"queue_id"`
+	DbgTxRingFull                  uint64 `json:"dbg_tx_ring_full,omitempty"`
+	DbgSendtoENOBUFS               uint64 `json:"dbg_sendto_enobufs,omitempty"`
+	DbgPendingOverflow             uint64 `json:"dbg_pending_overflow,omitempty"`
+	RxFillRingEmptyDescs           uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
+	OutstandingTX                  uint32 `json:"outstanding_tx,omitempty"`
+	TXErrors                       uint64 `json:"tx_errors,omitempty"`
+	TxSubmitErrorDrops             uint64 `json:"tx_submit_error_drops,omitempty"`
+	PendingTxLocalOverflowDrops    uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
 }
 
 type ExceptionStatus struct {

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1416,7 +1416,12 @@ impl Coordinator {
                 // `debug_outstanding_tx` for the operator-facing name.
                 binding.dbg_tx_ring_full = snap.dbg_tx_ring_full;
                 binding.dbg_sendto_enobufs = snap.dbg_sendto_enobufs;
-                binding.dbg_pending_overflow = snap.dbg_pending_overflow;
+                // #804: split counters — bound-pending FIFO vs CoS
+                // queue admission. Pre-#804 a single `dbg_pending_overflow`
+                // was published; the wire name was removed because
+                // the semantics were ambiguous for operators.
+                binding.dbg_bound_pending_overflow = snap.dbg_bound_pending_overflow;
+                binding.dbg_cos_queue_overflow = snap.dbg_cos_queue_overflow;
                 binding.rx_fill_ring_empty_descs = snap.rx_fill_ring_empty_descs;
                 binding.outstanding_tx = snap.debug_outstanding_tx;
                 binding.last_heartbeat = snap.last_heartbeat;
@@ -1502,7 +1507,8 @@ impl Coordinator {
                 // has no live state (unregistered slot).
                 binding.dbg_tx_ring_full = 0;
                 binding.dbg_sendto_enobufs = 0;
-                binding.dbg_pending_overflow = 0;
+                binding.dbg_bound_pending_overflow = 0;
+                binding.dbg_cos_queue_overflow = 0;
                 binding.rx_fill_ring_empty_descs = 0;
                 binding.outstanding_tx = 0;
                 binding.last_heartbeat = None;
@@ -2727,13 +2733,18 @@ mod tests {
         let live = BindingLiveState::new();
         live.dbg_tx_ring_full.store(11, Ordering::Relaxed);
         live.dbg_sendto_enobufs.store(13, Ordering::Relaxed);
-        live.dbg_pending_overflow.store(17, Ordering::Relaxed);
+        // #804: two distinct counters — bound-pending FIFO overflow
+        // (17) and CoS queue admission overflow (41). Non-coprime-prime
+        // per field so an accidental swap across the two is caught.
+        live.dbg_bound_pending_overflow.store(17, Ordering::Relaxed);
+        live.dbg_cos_queue_overflow.store(41, Ordering::Relaxed);
         live.rx_fill_ring_empty_descs.store(19, Ordering::Relaxed);
         live.debug_outstanding_tx.store(23, Ordering::Relaxed);
         let snap = live.snapshot();
         assert_eq!(snap.dbg_tx_ring_full, 11);
         assert_eq!(snap.dbg_sendto_enobufs, 13);
-        assert_eq!(snap.dbg_pending_overflow, 17);
+        assert_eq!(snap.dbg_bound_pending_overflow, 17);
+        assert_eq!(snap.dbg_cos_queue_overflow, 41);
         assert_eq!(snap.rx_fill_ring_empty_descs, 19);
         assert_eq!(snap.debug_outstanding_tx, 23);
     }

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -1410,6 +1410,15 @@ impl Coordinator {
                 binding.debug_pending_tx_local = snap.debug_pending_tx_local;
                 binding.debug_outstanding_tx = snap.debug_outstanding_tx;
                 binding.debug_in_flight_recycles = snap.debug_in_flight_recycles;
+                // #802: ring-pressure counters — atomic mirrors of
+                // worker-local counters, published on the worker's
+                // per-second debug tick. `outstanding_tx` aliases
+                // `debug_outstanding_tx` for the operator-facing name.
+                binding.dbg_tx_ring_full = snap.dbg_tx_ring_full;
+                binding.dbg_sendto_enobufs = snap.dbg_sendto_enobufs;
+                binding.dbg_pending_overflow = snap.dbg_pending_overflow;
+                binding.rx_fill_ring_empty_descs = snap.rx_fill_ring_empty_descs;
+                binding.outstanding_tx = snap.debug_outstanding_tx;
                 binding.last_heartbeat = snap.last_heartbeat;
                 binding.last_error = snap.last_error;
                 binding.ready = binding.registered
@@ -1489,6 +1498,13 @@ impl Coordinator {
                 binding.debug_pending_tx_local = 0;
                 binding.debug_outstanding_tx = 0;
                 binding.debug_in_flight_recycles = 0;
+                // #802: ring-pressure counters — zero when the binding
+                // has no live state (unregistered slot).
+                binding.dbg_tx_ring_full = 0;
+                binding.dbg_sendto_enobufs = 0;
+                binding.dbg_pending_overflow = 0;
+                binding.rx_fill_ring_empty_descs = 0;
+                binding.outstanding_tx = 0;
                 binding.last_heartbeat = None;
                 binding.last_error.clear();
                 binding.ready = false;
@@ -2699,5 +2715,26 @@ mod tests {
             })
             .sum();
         assert_eq!(total, 15);
+    }
+
+    #[test]
+    fn ring_pressure_counters_round_trip_through_snapshot() {
+        // #802: verify that the new ring-pressure atomics on
+        // BindingLiveState are surfaced via `snapshot()`. Without this
+        // pin, a refactor that drops the new fields from `snapshot()`
+        // would silently zero the operator-facing counters.
+        use std::sync::atomic::Ordering;
+        let live = BindingLiveState::new();
+        live.dbg_tx_ring_full.store(11, Ordering::Relaxed);
+        live.dbg_sendto_enobufs.store(13, Ordering::Relaxed);
+        live.dbg_pending_overflow.store(17, Ordering::Relaxed);
+        live.rx_fill_ring_empty_descs.store(19, Ordering::Relaxed);
+        live.debug_outstanding_tx.store(23, Ordering::Relaxed);
+        let snap = live.snapshot();
+        assert_eq!(snap.dbg_tx_ring_full, 11);
+        assert_eq!(snap.dbg_sendto_enobufs, 13);
+        assert_eq!(snap.dbg_pending_overflow, 17);
+        assert_eq!(snap.rx_fill_ring_empty_descs, 19);
+        assert_eq!(snap.debug_outstanding_tx, 23);
     }
 }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -154,7 +154,10 @@ pub(super) fn pending_tx_capacity(ring_entries: u32) -> usize {
 pub(super) fn bound_pending_tx_local(binding: &mut BindingWorker) {
     while binding.pending_tx_local.len() > binding.max_pending_tx {
         if binding.pending_tx_local.pop_front().is_some() {
-            binding.dbg_pending_overflow += 1;
+            // #804: bound-pending FIFO overflow — distinct from the CoS
+            // queue admission overflow counter. Keep this attribution
+            // precise so operators can tell which path is dropping.
+            binding.dbg_bound_pending_overflow += 1;
             binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
             // #710: dedicated drop-reason counter. Subset of tx_errors.
             binding
@@ -173,7 +176,10 @@ pub(super) fn bound_pending_tx_prepared(binding: &mut BindingWorker) {
     let limit = binding.max_pending_tx;
     while binding.pending_tx_prepared.len() > limit {
         if let Some(req) = binding.pending_tx_prepared.pop_front() {
-            binding.dbg_pending_overflow += 1;
+            // #804: bound-pending FIFO overflow (prepared side). Same
+            // semantic bucket as `bound_pending_tx_local` — internal
+            // prepared/local distinction is irrelevant to operators.
+            binding.dbg_bound_pending_overflow += 1;
             recycle_prepared_immediately(binding, &req);
             binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
             // #710: same drop category — prepared vs local FIFO is an
@@ -5397,7 +5403,12 @@ fn enqueue_cos_item(
             PreparedTxRecycle::FillOnSlot(_) => binding.free_tx_frames.push_back(offset),
         }
     }
-    binding.dbg_pending_overflow += 1;
+    // #804: CoS admission overflow — NOT bound-pending. Pre-#804 this
+    // site incremented `dbg_pending_overflow` which conflated it with
+    // the bound-pending FIFO evict sites; the two are now tracked on
+    // separate counters so operators can disambiguate CoS shaping
+    // pressure from bound-pending pressure.
+    binding.dbg_cos_queue_overflow += 1;
     binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
     binding.live.set_error(format!(
         "class-of-service queue overflow on ifindex {} queue {}",

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -941,6 +941,24 @@ pub(super) struct BindingLiveState {
     pub(super) debug_pending_tx_local: AtomicU32,
     pub(super) debug_outstanding_tx: AtomicU32,
     pub(super) debug_in_flight_recycles: AtomicU32,
+    /// #802: ring-pressure instrumentation. Cumulative monotonic counters
+    /// mirrored from the worker-local `BindingWorker` fields of the same
+    /// name. Worker increments `b.dbg_tx_ring_full += 1` (etc.) on the hot
+    /// path; the published value here is updated via `fetch_add(delta)`
+    /// at the existing ~1s debug-report tick, BEFORE the local counter is
+    /// reset for the next window. The control-socket snapshot reads from
+    /// these atomics. No hot-path code is touched — this is purely a new
+    /// read-side publish sink.
+    pub(super) dbg_tx_ring_full: AtomicU64,
+    pub(super) dbg_sendto_enobufs: AtomicU64,
+    pub(super) dbg_pending_overflow: AtomicU64,
+    /// #802: kernel XDP statistics v2 `rx_fill_ring_empty_descs` — the
+    /// kernel's native cumulative counter of RX fill-ring starvation
+    /// events. Published via `store()` (not fetch_add) because the
+    /// kernel-side value is already absolute. Sampled from
+    /// `device.statistics_v2()` at the same ~1s debug-report tick as
+    /// the local counters above.
+    pub(super) rx_fill_ring_empty_descs: AtomicU64,
     pub(super) last_heartbeat: AtomicU64,
     pub(super) max_pending_tx: AtomicU32,
     pub(super) last_error: Mutex<String>,
@@ -1036,6 +1054,12 @@ impl BindingLiveState {
             debug_pending_tx_local: AtomicU32::new(0),
             debug_outstanding_tx: AtomicU32::new(0),
             debug_in_flight_recycles: AtomicU32::new(0),
+            // #802: ring-pressure instrumentation sinks. Zero-init;
+            // published by the worker's per-second debug tick.
+            dbg_tx_ring_full: AtomicU64::new(0),
+            dbg_sendto_enobufs: AtomicU64::new(0),
+            dbg_pending_overflow: AtomicU64::new(0),
+            rx_fill_ring_empty_descs: AtomicU64::new(0),
             last_heartbeat: AtomicU64::new(0),
             max_pending_tx: AtomicU32::new(0),
             last_error: Mutex::new(String::new()),
@@ -1261,6 +1285,14 @@ impl BindingLiveState {
             debug_pending_tx_local: self.debug_pending_tx_local.load(Ordering::Relaxed),
             debug_outstanding_tx: self.debug_outstanding_tx.load(Ordering::Relaxed),
             debug_in_flight_recycles: self.debug_in_flight_recycles.load(Ordering::Relaxed),
+            // #802: ring-pressure counters published from the worker's
+            // periodic debug tick. Relaxed load is sufficient — these
+            // are monotonic diagnostic counters, not part of any
+            // load-bearing synchronization.
+            dbg_tx_ring_full: self.dbg_tx_ring_full.load(Ordering::Relaxed),
+            dbg_sendto_enobufs: self.dbg_sendto_enobufs.load(Ordering::Relaxed),
+            dbg_pending_overflow: self.dbg_pending_overflow.load(Ordering::Relaxed),
+            rx_fill_ring_empty_descs: self.rx_fill_ring_empty_descs.load(Ordering::Relaxed),
             last_heartbeat: monotonic_timestamp_to_datetime(
                 self.last_heartbeat.load(Ordering::Relaxed),
                 now_mono,

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -951,7 +951,21 @@ pub(super) struct BindingLiveState {
     /// read-side publish sink.
     pub(super) dbg_tx_ring_full: AtomicU64,
     pub(super) dbg_sendto_enobufs: AtomicU64,
-    pub(super) dbg_pending_overflow: AtomicU64,
+    /// #802/#804: per-binding `bound_pending` FIFO overflow counter —
+    /// incremented when `bound_pending_tx_local`/`bound_pending_tx_prepared`
+    /// evict an item because the FIFO is above `max_pending_tx`. This is
+    /// strictly the bound-pending path; the class-of-service admission
+    /// overflow has its own counter below. Pre-#804 builds published a
+    /// single `dbg_pending_overflow` that conflated the two sites; that
+    /// wire key was removed in #804 in favor of the split names.
+    pub(super) dbg_bound_pending_overflow: AtomicU64,
+    /// #804: class-of-service queue admission overflow counter —
+    /// incremented in `enqueue_cos_item()` when the CoS admission gate
+    /// rejects the item (flow-share cap + buffer cap exhausted) but the
+    /// caller still needs to account the drop. Separate from
+    /// `dbg_bound_pending_overflow` so operators can disambiguate
+    /// bound-pending pressure from CoS shaping pressure at triage time.
+    pub(super) dbg_cos_queue_overflow: AtomicU64,
     /// #802: kernel XDP statistics v2 `rx_fill_ring_empty_descs` — the
     /// kernel's native cumulative counter of RX fill-ring starvation
     /// events. Published via `store()` (not fetch_add) because the
@@ -1058,7 +1072,8 @@ impl BindingLiveState {
             // published by the worker's per-second debug tick.
             dbg_tx_ring_full: AtomicU64::new(0),
             dbg_sendto_enobufs: AtomicU64::new(0),
-            dbg_pending_overflow: AtomicU64::new(0),
+            dbg_bound_pending_overflow: AtomicU64::new(0),
+            dbg_cos_queue_overflow: AtomicU64::new(0),
             rx_fill_ring_empty_descs: AtomicU64::new(0),
             last_heartbeat: AtomicU64::new(0),
             max_pending_tx: AtomicU32::new(0),
@@ -1291,7 +1306,8 @@ impl BindingLiveState {
             // load-bearing synchronization.
             dbg_tx_ring_full: self.dbg_tx_ring_full.load(Ordering::Relaxed),
             dbg_sendto_enobufs: self.dbg_sendto_enobufs.load(Ordering::Relaxed),
-            dbg_pending_overflow: self.dbg_pending_overflow.load(Ordering::Relaxed),
+            dbg_bound_pending_overflow: self.dbg_bound_pending_overflow.load(Ordering::Relaxed),
+            dbg_cos_queue_overflow: self.dbg_cos_queue_overflow.load(Ordering::Relaxed),
             rx_fill_ring_empty_descs: self.rx_fill_ring_empty_descs.load(Ordering::Relaxed),
             last_heartbeat: monotonic_timestamp_to_datetime(
                 self.last_heartbeat.load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1327,6 +1327,48 @@ pub(crate) fn worker_loop(
                     dbg_fwd_tcp_zero_window = 0;
                 }
                 for b in bindings.iter_mut() {
+                    // #802: publish ring-pressure counters into BindingLiveState
+                    // BEFORE resetting the worker-local window. The worker-local
+                    // counters (b.dbg_tx_ring_full, etc.) are accumulated by the
+                    // hot path and reset each ~1s debug tick; without this
+                    // publish they'd never be visible outside the worker thread.
+                    // fetch_add is used because the atomic holds the cumulative
+                    // total while the local counter holds only the current
+                    // window. Relaxed is sufficient — diagnostic counters, no
+                    // synchronization contract.
+                    if b.dbg_tx_ring_full != 0 {
+                        b.live
+                            .dbg_tx_ring_full
+                            .fetch_add(b.dbg_tx_ring_full, Ordering::Relaxed);
+                    }
+                    if b.dbg_sendto_enobufs != 0 {
+                        b.live
+                            .dbg_sendto_enobufs
+                            .fetch_add(b.dbg_sendto_enobufs, Ordering::Relaxed);
+                    }
+                    if b.dbg_pending_overflow != 0 {
+                        b.live
+                            .dbg_pending_overflow
+                            .fetch_add(b.dbg_pending_overflow, Ordering::Relaxed);
+                    }
+                    // #802: kernel xdp_statistics.rx_fill_ring_empty_descs is
+                    // already absolute (kernel-cumulative), so publish with
+                    // store() not fetch_add. Sampling failures are silently
+                    // ignored — the atomic simply retains its last good value.
+                    if let Ok(stats) = b.device.statistics_v2() {
+                        b.live
+                            .rx_fill_ring_empty_descs
+                            .store(stats.rx_fill_ring_empty_descs, Ordering::Relaxed);
+                    }
+                    // #802: outstanding_tx is a transient gauge on BindingWorker
+                    // (current in-flight TX). Publish to the existing atomic
+                    // mirror on BindingLiveState so the snapshot reader sees
+                    // a recent value. store() because it's a gauge, not a
+                    // counter.
+                    b.live
+                        .debug_outstanding_tx
+                        .store(b.outstanding_tx, Ordering::Relaxed);
+
                     b.dbg_fill_submitted = 0;
                     b.dbg_fill_failed = 0;
                     b.dbg_poll_cycles = 0;
@@ -4118,6 +4160,12 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) debug_pending_tx_local: u32,
     pub(crate) debug_outstanding_tx: u32,
     pub(crate) debug_in_flight_recycles: u32,
+    // #802: ring-pressure snapshot fields. Mirrored from BindingLiveState
+    // atomics that are published by the worker's per-second debug tick.
+    pub(crate) dbg_tx_ring_full: u64,
+    pub(crate) dbg_sendto_enobufs: u64,
+    pub(crate) dbg_pending_overflow: u64,
+    pub(crate) rx_fill_ring_empty_descs: u64,
     pub(crate) last_heartbeat: Option<chrono::DateTime<Utc>>,
     pub(crate) last_error: String,
     // #709: owner-profile telemetry snapshot. Fixed-size arrays (no

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -67,7 +67,17 @@ pub(crate) struct BindingWorker {
     pub(crate) dbg_sendto_err: u64,        // sendto returned error (non-EAGAIN/ENOBUFS)
     pub(crate) dbg_sendto_eagain: u64,     // sendto returned EAGAIN/EWOULDBLOCK
     pub(crate) dbg_sendto_enobufs: u64,    // sendto returned ENOBUFS (kernel TX drop)
-    pub(crate) dbg_pending_overflow: u64,  // drops from bound_pending overflow
+    // #802/#804: per-binding bound-pending FIFO overflow — incremented at
+    // the `bound_pending_tx_local`/`bound_pending_tx_prepared` evict
+    // sites only. Pre-#804 this counter was named `dbg_pending_overflow`
+    // and also doubled as the CoS admission overflow accumulator; the
+    // two semantics are now tracked on separate fields so operators can
+    // tell which path is dropping.
+    pub(crate) dbg_bound_pending_overflow: u64,
+    // #804: per-binding class-of-service queue admission overflow —
+    // incremented in `enqueue_cos_item()` when the CoS admission gate
+    // rejects the item.
+    pub(crate) dbg_cos_queue_overflow: u64,
     pub(crate) dbg_tx_tcp_rst: u64,        // TCP RST packets transmitted
     // Ring diagnostics — raw values from xsk_ffi API
     pub(crate) dbg_rx_avail_nonzero: u64, // times rx.available() > 0
@@ -337,7 +347,8 @@ impl BindingWorker {
             dbg_sendto_err: 0,
             dbg_sendto_eagain: 0,
             dbg_sendto_enobufs: 0,
-            dbg_pending_overflow: 0,
+            dbg_bound_pending_overflow: 0,
+            dbg_cos_queue_overflow: 0,
             dbg_tx_tcp_rst: 0,
             dbg_rx_avail_nonzero: 0,
             dbg_rx_avail_max: 0,
@@ -993,7 +1004,7 @@ pub(crate) fn worker_loop(
                     }
                     let _ = write!(
                         binding_summary,
-                        " TX:ring_sub={}/ring_full={}/compl={}/sendto={}/err={}/eagain={}/enobufs={}/overflow={}",
+                        " TX:ring_sub={}/ring_full={}/compl={}/sendto={}/err={}/eagain={}/enobufs={}/bp_overflow={}/cos_overflow={}",
                         b.dbg_tx_ring_submitted,
                         b.dbg_tx_ring_full,
                         b.dbg_completions_reaped,
@@ -1001,7 +1012,8 @@ pub(crate) fn worker_loop(
                         b.dbg_sendto_err,
                         b.dbg_sendto_eagain,
                         b.dbg_sendto_enobufs,
-                        b.dbg_pending_overflow,
+                        b.dbg_bound_pending_overflow,
+                        b.dbg_cos_queue_overflow,
                     );
                     #[cfg(feature = "debug-log")]
                     let _ = write!(binding_summary, "/rst={}", b.dbg_tx_tcp_rst);
@@ -1346,10 +1358,15 @@ pub(crate) fn worker_loop(
                             .dbg_sendto_enobufs
                             .fetch_add(b.dbg_sendto_enobufs, Ordering::Relaxed);
                     }
-                    if b.dbg_pending_overflow != 0 {
+                    if b.dbg_bound_pending_overflow != 0 {
                         b.live
-                            .dbg_pending_overflow
-                            .fetch_add(b.dbg_pending_overflow, Ordering::Relaxed);
+                            .dbg_bound_pending_overflow
+                            .fetch_add(b.dbg_bound_pending_overflow, Ordering::Relaxed);
+                    }
+                    if b.dbg_cos_queue_overflow != 0 {
+                        b.live
+                            .dbg_cos_queue_overflow
+                            .fetch_add(b.dbg_cos_queue_overflow, Ordering::Relaxed);
                     }
                     // #802: kernel xdp_statistics.rx_fill_ring_empty_descs is
                     // already absolute (kernel-cumulative), so publish with
@@ -1382,7 +1399,8 @@ pub(crate) fn worker_loop(
                     b.dbg_sendto_err = 0;
                     b.dbg_sendto_eagain = 0;
                     b.dbg_sendto_enobufs = 0;
-                    b.dbg_pending_overflow = 0;
+                    b.dbg_bound_pending_overflow = 0;
+                    b.dbg_cos_queue_overflow = 0;
                     #[cfg(feature = "debug-log")]
                     {
                         b.dbg_tx_tcp_rst = 0;
@@ -4164,7 +4182,9 @@ pub(crate) struct BindingLiveSnapshot {
     // atomics that are published by the worker's per-second debug tick.
     pub(crate) dbg_tx_ring_full: u64,
     pub(crate) dbg_sendto_enobufs: u64,
-    pub(crate) dbg_pending_overflow: u64,
+    // #802/#804: split — see `BindingLiveState` for write-site semantics.
+    pub(crate) dbg_bound_pending_overflow: u64,
+    pub(crate) dbg_cos_queue_overflow: u64,
     pub(crate) rx_fill_ring_empty_descs: u64,
     pub(crate) last_heartbeat: Option<chrono::DateTime<Utc>>,
     pub(crate) last_error: String,

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -803,7 +803,7 @@ fn refresh_status(state: &mut ServerState) {
         .status
         .bindings
         .iter()
-        .map(BindingCountersSnapshot::from_binding_status)
+        .map(BindingCountersSnapshot::from)
         .collect();
     state.status.recent_session_deltas = state.afxdp.recent_session_deltas();
     state.status.recent_exceptions = state.afxdp.recent_exceptions();
@@ -1745,10 +1745,11 @@ mod tests {
 
     #[test]
     fn binding_counters_snapshot_projects_ring_pressure_fields() {
-        // #802: verify projection from BindingStatus into the focused
-        // BindingCountersSnapshot carries every ring-pressure field,
-        // plus the operator-facing TX drop trio re-surfaced for
-        // triage. Non-coprime-prime per field so an accidental
+        // #802/#804: verify projection from BindingStatus into the
+        // focused BindingCountersSnapshot carries every ring-pressure
+        // field (with the #804 split of bound-pending vs CoS queue
+        // overflow), plus the operator-facing TX drop trio re-surfaced
+        // for triage. Non-coprime-prime per field so an accidental
         // re-attribution across fields is caught.
         let binding = BindingStatus {
             slot: 0,
@@ -1757,7 +1758,8 @@ mod tests {
             ifindex: 12,
             dbg_tx_ring_full: 11,
             dbg_sendto_enobufs: 13,
-            dbg_pending_overflow: 17,
+            dbg_bound_pending_overflow: 17,
+            dbg_cos_queue_overflow: 41,
             rx_fill_ring_empty_descs: 19,
             outstanding_tx: 23,
             tx_errors: 29,
@@ -1765,13 +1767,18 @@ mod tests {
             pending_tx_local_overflow_drops: 37,
             ..Default::default()
         };
-        let snap = BindingCountersSnapshot::from_binding_status(&binding);
+        // #804: exercise the `impl From<&BindingStatus>` path. The old
+        // named `from_binding_status` was renamed to the idiomatic
+        // `From` impl so iterator adaptors and `into()` callsites get
+        // the conversion for free.
+        let snap = BindingCountersSnapshot::from(&binding);
         assert_eq!(snap.worker_id, 7);
         assert_eq!(snap.ifindex, 12);
         assert_eq!(snap.queue_id, 4);
         assert_eq!(snap.dbg_tx_ring_full, 11);
         assert_eq!(snap.dbg_sendto_enobufs, 13);
-        assert_eq!(snap.dbg_pending_overflow, 17);
+        assert_eq!(snap.dbg_bound_pending_overflow, 17);
+        assert_eq!(snap.dbg_cos_queue_overflow, 41);
         assert_eq!(snap.rx_fill_ring_empty_descs, 19);
         assert_eq!(snap.outstanding_tx, 23);
         assert_eq!(snap.tx_errors, 29);
@@ -1781,30 +1788,41 @@ mod tests {
 
     #[test]
     fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
-        // #802: the daemon's poll path parses these JSON keys. Pin the
-        // wire names so a rename that breaks the consumer is caught at
-        // CI, not in the field.
+        // #802/#804: the daemon's poll path parses these JSON keys. Pin
+        // the wire names so a rename that breaks the consumer is caught
+        // at CI, not in the field. Uses `serde_json::Value` key
+        // introspection rather than substring matching so a key that
+        // happens to appear inside another field's string value does
+        // not accidentally pass the assertion (the original #802 test
+        // was flagged in round-1 review as brittle for exactly this
+        // reason).
         let snap = BindingCountersSnapshot {
             worker_id: 1,
             ifindex: 2,
             queue_id: 3,
             dbg_tx_ring_full: 4,
             dbg_sendto_enobufs: 5,
-            dbg_pending_overflow: 6,
+            dbg_bound_pending_overflow: 6,
+            dbg_cos_queue_overflow: 12,
             rx_fill_ring_empty_descs: 7,
             outstanding_tx: 8,
             tx_errors: 9,
             tx_submit_error_drops: 10,
             pending_tx_local_overflow_drops: 11,
         };
-        let json = serde_json::to_string(&snap).expect("serialize snapshot");
+        let value: serde_json::Value =
+            serde_json::to_value(&snap).expect("serialize snapshot to Value");
+        let obj = value
+            .as_object()
+            .expect("snapshot serializes as a JSON object");
         for key in [
             "worker_id",
             "ifindex",
             "queue_id",
             "dbg_tx_ring_full",
             "dbg_sendto_enobufs",
-            "dbg_pending_overflow",
+            "dbg_bound_pending_overflow",
+            "dbg_cos_queue_overflow",
             "rx_fill_ring_empty_descs",
             "outstanding_tx",
             "tx_errors",
@@ -1812,14 +1830,55 @@ mod tests {
             "pending_tx_local_overflow_drops",
         ] {
             assert!(
-                json.contains(&format!("\"{}\"", key)),
-                "wire key `{key}` missing from snapshot JSON: {json}"
+                obj.contains_key(key),
+                "wire key `{key}` missing from snapshot JSON object: {value}"
             );
         }
+        // #804: the pre-split `dbg_pending_overflow` wire key must not
+        // reappear — that was the conflation the split removed.
+        assert!(
+            !obj.contains_key("dbg_pending_overflow"),
+            "pre-split wire key `dbg_pending_overflow` unexpectedly present: {value}"
+        );
         // Round-trip: the daemon's JSON → Rust decode path must be
         // symmetric with the Rust encode path.
+        let json = serde_json::to_string(&snap).expect("serialize snapshot");
         let round: BindingCountersSnapshot =
             serde_json::from_str(&json).expect("deserialize snapshot");
         assert_eq!(round, snap);
+    }
+
+    #[test]
+    fn binding_counters_snapshot_tolerates_pre_split_wire() {
+        // #804: a helper snapshot that pre-dates the
+        // dbg_pending_overflow → {dbg_bound_pending_overflow,
+        // dbg_cos_queue_overflow} split must still deserialize — the
+        // two new fields should default to 0 rather than the decode
+        // failing. This is the compat contract the split relies on.
+        let legacy_json = r#"{
+            "worker_id": 1,
+            "ifindex": 2,
+            "queue_id": 3,
+            "dbg_tx_ring_full": 4,
+            "dbg_sendto_enobufs": 5,
+            "dbg_pending_overflow": 99,
+            "rx_fill_ring_empty_descs": 7,
+            "outstanding_tx": 8,
+            "tx_errors": 9,
+            "tx_submit_error_drops": 10,
+            "pending_tx_local_overflow_drops": 11
+        }"#;
+        let snap: BindingCountersSnapshot =
+            serde_json::from_str(legacy_json).expect("legacy snapshot decodes");
+        // The unknown legacy field is discarded; the two new fields
+        // default to 0 via `serde(default)`. Callers that need a total
+        // across either path must sum the two explicitly — there is no
+        // silent re-attribution of the legacy number to one bucket.
+        assert_eq!(snap.dbg_bound_pending_overflow, 0);
+        assert_eq!(snap.dbg_cos_queue_overflow, 0);
+        // Everything else round-trips as expected.
+        assert_eq!(snap.worker_id, 1);
+        assert_eq!(snap.dbg_tx_ring_full, 4);
+        assert_eq!(snap.rx_fill_ring_empty_descs, 7);
     }
 }

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -151,6 +151,7 @@ fn run() -> Result<(), String> {
             route_entries: 0,
             worker_heartbeats: Vec::new(),
             cos_no_owner_binding_drops_total: 0,
+            per_binding: Vec::new(),
             ha_groups: Vec::new(),
             fabrics: Vec::new(),
             queues: Vec::new(),
@@ -795,6 +796,15 @@ fn refresh_status(state: &mut ServerState) {
             .iter()
             .all(|b| b.registered && b.armed);
     state.status.queues = summarize_queues(&state.status.bindings);
+    // #802: focused per-binding ring-pressure snapshot. Projected from
+    // the freshly-refreshed BindingStatus entries so this field tracks
+    // the same data source the richer `bindings[]` view exposes.
+    state.status.per_binding = state
+        .status
+        .bindings
+        .iter()
+        .map(BindingCountersSnapshot::from_binding_status)
+        .collect();
     state.status.recent_session_deltas = state.afxdp.recent_session_deltas();
     state.status.recent_exceptions = state.afxdp.recent_exceptions();
     state.status.cos_interfaces = state.afxdp.cos_statuses();
@@ -1731,5 +1741,85 @@ mod tests {
         set_bindings_forwarding_armed(&mut status, false);
         assert!(!status.bindings[0].armed);
         assert!(!status.bindings[1].armed);
+    }
+
+    #[test]
+    fn binding_counters_snapshot_projects_ring_pressure_fields() {
+        // #802: verify projection from BindingStatus into the focused
+        // BindingCountersSnapshot carries every ring-pressure field,
+        // plus the operator-facing TX drop trio re-surfaced for
+        // triage. Non-coprime-prime per field so an accidental
+        // re-attribution across fields is caught.
+        let binding = BindingStatus {
+            slot: 0,
+            queue_id: 4,
+            worker_id: 7,
+            ifindex: 12,
+            dbg_tx_ring_full: 11,
+            dbg_sendto_enobufs: 13,
+            dbg_pending_overflow: 17,
+            rx_fill_ring_empty_descs: 19,
+            outstanding_tx: 23,
+            tx_errors: 29,
+            tx_submit_error_drops: 31,
+            pending_tx_local_overflow_drops: 37,
+            ..Default::default()
+        };
+        let snap = BindingCountersSnapshot::from_binding_status(&binding);
+        assert_eq!(snap.worker_id, 7);
+        assert_eq!(snap.ifindex, 12);
+        assert_eq!(snap.queue_id, 4);
+        assert_eq!(snap.dbg_tx_ring_full, 11);
+        assert_eq!(snap.dbg_sendto_enobufs, 13);
+        assert_eq!(snap.dbg_pending_overflow, 17);
+        assert_eq!(snap.rx_fill_ring_empty_descs, 19);
+        assert_eq!(snap.outstanding_tx, 23);
+        assert_eq!(snap.tx_errors, 29);
+        assert_eq!(snap.tx_submit_error_drops, 31);
+        assert_eq!(snap.pending_tx_local_overflow_drops, 37);
+    }
+
+    #[test]
+    fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
+        // #802: the daemon's poll path parses these JSON keys. Pin the
+        // wire names so a rename that breaks the consumer is caught at
+        // CI, not in the field.
+        let snap = BindingCountersSnapshot {
+            worker_id: 1,
+            ifindex: 2,
+            queue_id: 3,
+            dbg_tx_ring_full: 4,
+            dbg_sendto_enobufs: 5,
+            dbg_pending_overflow: 6,
+            rx_fill_ring_empty_descs: 7,
+            outstanding_tx: 8,
+            tx_errors: 9,
+            tx_submit_error_drops: 10,
+            pending_tx_local_overflow_drops: 11,
+        };
+        let json = serde_json::to_string(&snap).expect("serialize snapshot");
+        for key in [
+            "worker_id",
+            "ifindex",
+            "queue_id",
+            "dbg_tx_ring_full",
+            "dbg_sendto_enobufs",
+            "dbg_pending_overflow",
+            "rx_fill_ring_empty_descs",
+            "outstanding_tx",
+            "tx_errors",
+            "tx_submit_error_drops",
+            "pending_tx_local_overflow_drops",
+        ] {
+            assert!(
+                json.contains(&format!("\"{}\"", key)),
+                "wire key `{key}` missing from snapshot JSON: {json}"
+            );
+        }
+        // Round-trip: the daemon's JSON → Rust decode path must be
+        // symmetric with the Rust encode path.
+        let round: BindingCountersSnapshot =
+            serde_json::from_str(&json).expect("deserialize snapshot");
+        assert_eq!(round, snap);
     }
 }

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -708,6 +708,16 @@ pub(crate) struct ProcessStatus {
     // is the operator-facing number.
     #[serde(rename = "cos_no_owner_binding_drops_total", default)]
     pub cos_no_owner_binding_drops_total: u64,
+    /// #802: focused per-binding ring-pressure view. Projected from the
+    /// same `BindingLiveState` atomics that back `Self::bindings` — a
+    /// compact snapshot of the counters an operator looks at first when
+    /// triaging XSK ring saturation (TX full, sendto ENOBUFS, pending-
+    /// overflow, fill-ring empty descs, outstanding-tx gauge). Keeping
+    /// it as a parallel field (rather than only embedded in
+    /// `bindings[].*`) lets the daemon pull just the triage counters on
+    /// its poll path without deserializing every field on `BindingStatus`.
+    #[serde(rename = "per_binding", default, skip_serializing_if = "Vec::is_empty")]
+    pub per_binding: Vec<BindingCountersSnapshot>,
     #[serde(rename = "ha_groups", default)]
     pub ha_groups: Vec<HAGroupStatus>,
     #[serde(default)]
@@ -1287,10 +1297,92 @@ pub(crate) struct BindingStatus {
     pub debug_outstanding_tx: u32,
     #[serde(rename = "debug_in_flight_recycles", default)]
     pub debug_in_flight_recycles: u32,
+    // #802: ring-pressure instrumentation. Operator-facing cumulative
+    // counters for XSK ring saturation diagnosis. See the
+    // `line-rate-investigation-plan.md` "DEFERRED-INSTRUMENTATION" rows
+    // for semantics. `outstanding_tx` is a gauge (current value) that
+    // serves as a proxy for `completion_reap_max_batch`; the real
+    // completion-reap-batch histogram is accept-proxy per that plan.
+    #[serde(rename = "dbg_tx_ring_full", default)]
+    pub dbg_tx_ring_full: u64,
+    #[serde(rename = "dbg_sendto_enobufs", default)]
+    pub dbg_sendto_enobufs: u64,
+    #[serde(rename = "dbg_pending_overflow", default)]
+    pub dbg_pending_overflow: u64,
+    #[serde(rename = "rx_fill_ring_empty_descs", default)]
+    pub rx_fill_ring_empty_descs: u64,
+    #[serde(rename = "outstanding_tx", default)]
+    pub outstanding_tx: u32,
     #[serde(rename = "last_error", default)]
     pub last_error: String,
     #[serde(rename = "last_change", skip_serializing_if = "Option::is_none")]
     pub last_change: Option<DateTime<Utc>>,
+}
+
+/// #802: focused per-binding ring-pressure snapshot surfaced on
+/// `ProcessStatus::per_binding`.
+///
+/// Fields (see `docs/line-rate-investigation-plan.md` lines 703-724 for
+/// the full operator rationale):
+/// - `dbg_tx_ring_full`: times the XSK TX ring producer returned 0 slots.
+/// - `dbg_sendto_enobufs`: kernel-side TX drop — TX kick returned ENOBUFS.
+/// - `dbg_pending_overflow`: drops from the `bound_pending` FIFO
+///   overflowing its soft cap.
+/// - `rx_fill_ring_empty_descs`: kernel `xdp_statistics_v2` counter of
+///   RX fill-ring starvation events.
+/// - `outstanding_tx`: accept-proxy for `completion_reap_max_batch` per
+///   the investigation plan's disposition. Snapshot of the worker's
+///   current in-flight TX gauge at the last publish tick.
+/// - `tx_errors`, `tx_submit_error_drops`,
+///   `pending_tx_local_overflow_drops`: operator-facing aggregate TX
+///   drop attribution, re-surfaced here so the triage view does not
+///   require a second join against `BindingStatus`.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct BindingCountersSnapshot {
+    #[serde(rename = "worker_id")]
+    pub worker_id: u32,
+    #[serde(default)]
+    pub ifindex: i32,
+    #[serde(rename = "queue_id")]
+    pub queue_id: u32,
+    #[serde(rename = "dbg_tx_ring_full", default)]
+    pub dbg_tx_ring_full: u64,
+    #[serde(rename = "dbg_sendto_enobufs", default)]
+    pub dbg_sendto_enobufs: u64,
+    #[serde(rename = "dbg_pending_overflow", default)]
+    pub dbg_pending_overflow: u64,
+    #[serde(rename = "rx_fill_ring_empty_descs", default)]
+    pub rx_fill_ring_empty_descs: u64,
+    #[serde(rename = "outstanding_tx", default)]
+    pub outstanding_tx: u32,
+    #[serde(rename = "tx_errors", default)]
+    pub tx_errors: u64,
+    #[serde(rename = "tx_submit_error_drops", default)]
+    pub tx_submit_error_drops: u64,
+    #[serde(rename = "pending_tx_local_overflow_drops", default)]
+    pub pending_tx_local_overflow_drops: u64,
+}
+
+impl BindingCountersSnapshot {
+    /// #802: projection from a full `BindingStatus` into the focused
+    /// ring-pressure view. Used by `refresh_status` so the daemon's
+    /// poll path can pick up the triage counters without re-scanning
+    /// every field of `BindingStatus`.
+    pub(crate) fn from_binding_status(b: &BindingStatus) -> Self {
+        Self {
+            worker_id: b.worker_id,
+            ifindex: b.ifindex,
+            queue_id: b.queue_id,
+            dbg_tx_ring_full: b.dbg_tx_ring_full,
+            dbg_sendto_enobufs: b.dbg_sendto_enobufs,
+            dbg_pending_overflow: b.dbg_pending_overflow,
+            rx_fill_ring_empty_descs: b.rx_fill_ring_empty_descs,
+            outstanding_tx: b.outstanding_tx,
+            tx_errors: b.tx_errors,
+            tx_submit_error_drops: b.tx_submit_error_drops,
+            pending_tx_local_overflow_drops: b.pending_tx_local_overflow_drops,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1307,8 +1307,16 @@ pub(crate) struct BindingStatus {
     pub dbg_tx_ring_full: u64,
     #[serde(rename = "dbg_sendto_enobufs", default)]
     pub dbg_sendto_enobufs: u64,
-    #[serde(rename = "dbg_pending_overflow", default)]
-    pub dbg_pending_overflow: u64,
+    // #804: split from the old conflated `dbg_pending_overflow`. Two
+    // distinct write-sites, two distinct wire keys. Pre-#804 snapshots
+    // will deserialize both as 0 (`default`), which is the right
+    // backward-compat behavior — the old field is no longer present on
+    // the wire and consumers that want totals across either path should
+    // sum the two explicitly.
+    #[serde(rename = "dbg_bound_pending_overflow", default)]
+    pub dbg_bound_pending_overflow: u64,
+    #[serde(rename = "dbg_cos_queue_overflow", default)]
+    pub dbg_cos_queue_overflow: u64,
     #[serde(rename = "rx_fill_ring_empty_descs", default)]
     pub rx_fill_ring_empty_descs: u64,
     #[serde(rename = "outstanding_tx", default)]
@@ -1326,8 +1334,16 @@ pub(crate) struct BindingStatus {
 /// the full operator rationale):
 /// - `dbg_tx_ring_full`: times the XSK TX ring producer returned 0 slots.
 /// - `dbg_sendto_enobufs`: kernel-side TX drop — TX kick returned ENOBUFS.
-/// - `dbg_pending_overflow`: drops from the `bound_pending` FIFO
-///   overflowing its soft cap.
+/// - `dbg_bound_pending_overflow` (#804): drops from the per-binding
+///   `bound_pending` FIFO (`pending_tx_local` / `pending_tx_prepared`)
+///   overflowing its soft cap. **This does not include CoS admission
+///   overflow** — those are counted separately below.
+/// - `dbg_cos_queue_overflow` (#804): drops from the class-of-service
+///   queue admission gate (`enqueue_cos_item`) when the CoS shaping
+///   path rejects the item. Pre-#804 builds conflated this with
+///   `bound_pending` overflow under the old `dbg_pending_overflow` wire
+///   key; the counter was split so operators can disambiguate shaping
+///   pressure from bound-pending pressure.
 /// - `rx_fill_ring_empty_descs`: kernel `xdp_statistics_v2` counter of
 ///   RX fill-ring starvation events.
 /// - `outstanding_tx`: accept-proxy for `completion_reap_max_batch` per
@@ -1337,11 +1353,26 @@ pub(crate) struct BindingStatus {
 ///   `pending_tx_local_overflow_drops`: operator-facing aggregate TX
 ///   drop attribution, re-surfaced here so the triage view does not
 ///   require a second join against `BindingStatus`.
+///
+/// ## Wire-compat
+///
+/// The split is not wire-compatible on the daemon→operator boundary —
+/// we removed the old `dbg_pending_overflow` wire key rather than keep
+/// it aliased, because the whole point of the split is to stop
+/// operators reading a conflated number. On the helper→daemon boundary
+/// both new fields carry `serde(default)` so a helper that pre-dates
+/// this split (no fields present) deserializes as zero rather than
+/// refusing the message.
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub(crate) struct BindingCountersSnapshot {
     #[serde(rename = "worker_id")]
     pub worker_id: u32,
-    #[serde(default)]
+    // #804: explicit rename matches the other fields on this struct
+    // (defensive — default serde field→key mapping is identity, but
+    // making it explicit here prevents a rename of the Rust field name
+    // from silently renaming the wire key and breaking the Go
+    // consumer).
+    #[serde(rename = "ifindex", default)]
     pub ifindex: i32,
     #[serde(rename = "queue_id")]
     pub queue_id: u32,
@@ -1349,8 +1380,13 @@ pub(crate) struct BindingCountersSnapshot {
     pub dbg_tx_ring_full: u64,
     #[serde(rename = "dbg_sendto_enobufs", default)]
     pub dbg_sendto_enobufs: u64,
-    #[serde(rename = "dbg_pending_overflow", default)]
-    pub dbg_pending_overflow: u64,
+    // #804: split wire keys — `default` on both so a helper snapshot
+    // that pre-dates the split (field absent on the wire) deserializes
+    // as 0 rather than failing.
+    #[serde(rename = "dbg_bound_pending_overflow", default)]
+    pub dbg_bound_pending_overflow: u64,
+    #[serde(rename = "dbg_cos_queue_overflow", default)]
+    pub dbg_cos_queue_overflow: u64,
     #[serde(rename = "rx_fill_ring_empty_descs", default)]
     pub rx_fill_ring_empty_descs: u64,
     #[serde(rename = "outstanding_tx", default)]
@@ -1363,19 +1399,20 @@ pub(crate) struct BindingCountersSnapshot {
     pub pending_tx_local_overflow_drops: u64,
 }
 
-impl BindingCountersSnapshot {
-    /// #802: projection from a full `BindingStatus` into the focused
-    /// ring-pressure view. Used by `refresh_status` so the daemon's
-    /// poll path can pick up the triage counters without re-scanning
-    /// every field of `BindingStatus`.
-    pub(crate) fn from_binding_status(b: &BindingStatus) -> Self {
+// #804: was `impl BindingCountersSnapshot { fn from_binding_status(...) }`.
+// Switched to the idiomatic `From` impl so the projection composes with
+// iterator adaptors (`.map(BindingCountersSnapshot::from)`) and any
+// future `into()` callsites get the conversion for free.
+impl From<&BindingStatus> for BindingCountersSnapshot {
+    fn from(b: &BindingStatus) -> Self {
         Self {
             worker_id: b.worker_id,
             ifindex: b.ifindex,
             queue_id: b.queue_id,
             dbg_tx_ring_full: b.dbg_tx_ring_full,
             dbg_sendto_enobufs: b.dbg_sendto_enobufs,
-            dbg_pending_overflow: b.dbg_pending_overflow,
+            dbg_bound_pending_overflow: b.dbg_bound_pending_overflow,
+            dbg_cos_queue_overflow: b.dbg_cos_queue_overflow,
             rx_fill_ring_empty_descs: b.rx_fill_ring_empty_descs,
             outstanding_tx: b.outstanding_tx,
             tx_errors: b.tx_errors,


### PR DESCRIPTION
Closes #802. Part of #798 (line-rate investigation Phase B Step 1 pre-req).

## Summary

Per-binding ring-pressure counters were tracked on `BindingWorker` (hot-path, worker-local) but never surfaced to operators. Investigation plan (`docs/line-rate-investigation-plan.md` Step 0.4 table) marked 6 counter rows as DEFERRED-INSTRUMENTATION. This PR exposes the four that exist today via the existing `flow_steer_snapshot` control-socket handler.

## What's exposed

On each `per_binding` entry + `BindingStatus`:
- `dbg_tx_ring_full`
- `dbg_sendto_enobufs`
- `dbg_bound_pending_overflow` — the per-binding `bound_pending` FIFO evict counter (`tx.rs` `bound_pending_tx_local`/`bound_pending_tx_prepared`)
- `dbg_cos_queue_overflow` — the class-of-service admission overflow counter (`tx.rs::enqueue_cos_item`)
- `rx_fill_ring_empty_descs` (kernel `xdp_statistics_v2`)
- `outstanding_tx` (ACCEPT-PROXY for `completion_reap_max_batch` per plan)
- `tx_errors`, `tx_submit_error_drops`, `pending_tx_local_overflow_drops` (re-surfaced)

`fill_batch_starved` and `completion_reap_max_batch` remain DEFERRED-INSTRUMENTATION per the plan's ACCEPT-PROXY disposition.

## #804 — Codex round-1 fix: split `dbg_pending_overflow`

The pre-split `dbg_pending_overflow` was incremented from two structurally different failure paths: the documented bound-pending FIFO evict at `tx.rs:157`/`tx.rs:176`, AND an undocumented CoS admission overflow at `tx.rs:5400` (now renamed `tx.rs:5405` after the comment). Operators reading the conflated counter during triage could not tell shaping pressure from bound-pending pressure. Split into two counters — each with its own atomic on `BindingLiveState`, its own worker-local mirror, its own publish at the ~1s debug tick, and its own wire key. Pre-#804 `dbg_pending_overflow` wire key removed (not aliased — the whole point of the split is to stop operators reading a conflated number); the `BindingCountersSnapshot` deserializer tolerates its absence via `serde(default)`, pinned by the new `binding_counters_snapshot_tolerates_pre_split_wire` test.

## Hot-path discipline

No hot-path code modified. Counter increments stay worker-local where they were; the split touched only the destination field name at each increment site. New atomics on `BindingLiveState` are written only at the existing per-second debug-report tick (read-side context) immediately before window reset.

## Sample snapshot output

```json
{
  "worker_id": 0,
  "ifindex": 6,
  "queue_id": 0,
  "dbg_tx_ring_full": 0,
  "dbg_sendto_enobufs": 0,
  "dbg_bound_pending_overflow": 0,
  "dbg_cos_queue_overflow": 0,
  "rx_fill_ring_empty_descs": 1,
  "outstanding_tx": 0,
  "tx_errors": 0,
  "tx_submit_error_drops": 0,
  "pending_tx_local_overflow_drops": 0
}
```

## Test plan

- [x] 739 Rust tests pass (4 new — updated `binding_counters_snapshot_projects_ring_pressure_fields`, `binding_counters_snapshot_serializes_with_expected_wire_keys` (now `serde_json::Value` key check, not substring), `ring_pressure_counters_round_trip_through_snapshot`, and new `binding_counters_snapshot_tolerates_pre_split_wire` for decode backward-compat)
- [x] `make test` passes (30 Go packages green)
- [x] Deployed to loss-userspace cluster; snapshot shows populated fields with BOTH `dbg_bound_pending_overflow` and `dbg_cos_queue_overflow` present, old `dbg_pending_overflow` absent
- [x] Smoke `iperf3 -P 4 -t 5 -p 5201` = 18.2 Gbps / 0 retransmits
- [ ] Adversarial review round 2 (Codex + Rust reviewer)