### PR TITLE
#869 userspace-dp: per-worker busy/idle runtime telemetry

### DIFF
--- a/docs/pr/869-worker-runtime/plan.md
+++ b/docs/pr/869-worker-runtime/plan.md
@@ -1,0 +1,41 @@
+# PR: #869 userspace-dp worker runtime telemetry
+
+## Goal
+Expose per-worker busy/idle time + thread CPU time + loop counts so
+operators can tell apart: compute saturation vs idle spin vs real
+idle headroom vs VM scheduling loss vs per-worker imbalance.
+
+## Design
+Loop-top accounting: attribute `now - last_loop_ns` delta to the
+PREVIOUS loop's classified state (Active / IdleSpin / IdleBlock).
+Worker-local u64 math; no per-packet atomics.  Publish to
+cacheline-isolated atomics on ~1s cadence, same time `clock_gettime
+CLOCK_THREAD_CPUTIME_ID` is sampled.
+
+## Files
+- `userspace-dp/src/afxdp/worker_runtime.rs` (new): state enum, local
+  counters struct, `WorkerRuntimeAtomics` publish struct, tid + cpu
+  samplers, unit tests.
+- `userspace-dp/src/afxdp/worker.rs`: loop-top delta accounting,
+  classification at `did_work`/spin/block sites, 1s publish cadence.
+- `userspace-dp/src/afxdp/coordinator.rs`: `Arc<WorkerRuntimeAtomics>`
+  per worker, `worker_runtime_snapshots()` accessor.
+- `userspace-dp/src/afxdp/types.rs`: `WorkerHandle.runtime_atomics`.
+- `userspace-dp/src/afxdp.rs`: expose `worker_runtime` module.
+- `userspace-dp/src/protocol.rs`: `WorkerRuntimeStatus` struct,
+  `StatusSnapshot.worker_runtime`.
+- `userspace-dp/src/main.rs`: populate status field on each snapshot.
+- `pkg/dataplane/userspace/protocol.go`: Go mirror struct + field.
+- `pkg/dataplane/userspace/statusfmt.go`: compact worker-runtime table
+  in status output.
+- `pkg/api/metrics.go`: 7 Prometheus counters, `collectWorkerRuntime`
+  helper.
+
+## Risk
+- Hot path gets 1 `monotonic_nanos()` + small arithmetic per loop
+  (worker was already taking that timestamp at loop top; we added a
+  `saturating_sub` + `match` + 1-2 add/store).  No atomics, no
+  allocs, no syscalls on hot path.
+- `clock_gettime` once per second per worker — negligible.
+- JSON wire format is additive with `serde(default)` for
+  compatibility with older daemons.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -84,6 +84,14 @@ type xpfCollector struct {
 	cosRedirectAcquireBucket *prometheus.Desc
 	cosOwnerPPS              *prometheus.Desc
 	cosPeerPPS               *prometheus.Desc
+	// #869: per-worker busy/idle runtime counters.
+	workerWallSecs      *prometheus.Desc
+	workerActiveSecs    *prometheus.Desc
+	workerIdleSpinSecs  *prometheus.Desc
+	workerIdleBlockSecs *prometheus.Desc
+	workerThreadCPUSecs *prometheus.Desc
+	workerWorkLoops     *prometheus.Desc
+	workerIdleLoops     *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -295,6 +303,42 @@ func newCollector(srv *Server) *xpfCollector {
 			"CoS peer-redirected pps (window accumulator, cleared by operator) (#709).",
 			[]string{"ifindex", "queue_id"}, nil,
 		),
+		// #869: per-worker busy/idle runtime counters.
+		workerWallSecs: prometheus.NewDesc(
+			"xpf_userspace_worker_wall_seconds_total",
+			"Monotonic wall seconds observed by the userspace-dp worker loop (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerActiveSecs: prometheus.NewDesc(
+			"xpf_userspace_worker_active_seconds_total",
+			"Seconds the userspace-dp worker spent processing packets (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerIdleSpinSecs: prometheus.NewDesc(
+			"xpf_userspace_worker_idle_spin_seconds_total",
+			"Seconds the userspace-dp worker spent idle-spinning on empty rings (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerIdleBlockSecs: prometheus.NewDesc(
+			"xpf_userspace_worker_idle_block_seconds_total",
+			"Seconds the userspace-dp worker spent blocked in poll()/sleep (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerThreadCPUSecs: prometheus.NewDesc(
+			"xpf_userspace_worker_thread_cpu_seconds_total",
+			"CLOCK_THREAD_CPUTIME_ID sample for the userspace-dp worker thread (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerWorkLoops: prometheus.NewDesc(
+			"xpf_userspace_worker_work_loops_total",
+			"Worker-loop iterations that did useful packet/ring work (#869).",
+			[]string{"worker_id"}, nil,
+		),
+		workerIdleLoops: prometheus.NewDesc(
+			"xpf_userspace_worker_idle_loops_total",
+			"Worker-loop iterations with no useful work (#869).",
+			[]string{"worker_id"}, nil,
+		),
 	}
 }
 
@@ -338,6 +382,13 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.cosRedirectAcquireBucket
 	ch <- c.cosOwnerPPS
 	ch <- c.cosPeerPPS
+	ch <- c.workerWallSecs
+	ch <- c.workerActiveSecs
+	ch <- c.workerIdleSpinSecs
+	ch <- c.workerIdleBlockSecs
+	ch <- c.workerThreadCPUSecs
+	ch <- c.workerWorkLoops
+	ch <- c.workerIdleLoops
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -355,15 +406,14 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectNATPoolMetrics(ch, dp)
 	c.collectDHCPMetrics(ch)
 	c.collectSystemMetrics(ch)
-	c.collectCoSOwnerProfile(ch, dp)
+	c.collectUserspaceStatus(ch, dp)
 }
 
-// #709: export owner-profile telemetry when the dataplane is the
-// userspace-dp helper. The eBPF-only build path doesn't have this
-// shape (it has no CoS scheduler), so we type-assert on the optional
-// `Status() (dpuserspace.ProcessStatus, error)` interface — if the
-// assertion fails we skip silently (not an error).
-func (c *xpfCollector) collectCoSOwnerProfile(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+// #709 + #869: single Status() call per scrape, then dispatch to
+// CoS owner profile + worker runtime collectors.  Both features need
+// the same ProcessStatus; calling Status() twice per scrape is
+// wasteful on the userspace-dp control socket.
+func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
 	provider, ok := dp.(interface {
 		Status() (dpuserspace.ProcessStatus, error)
 	})
@@ -374,6 +424,39 @@ func (c *xpfCollector) collectCoSOwnerProfile(ch chan<- prometheus.Metric, dp da
 	if err != nil {
 		return
 	}
+	c.emitCoSOwnerProfile(ch, status)
+	c.emitWorkerRuntime(ch, status)
+}
+
+// #869: emit per-worker busy/idle runtime counters from a cached
+// ProcessStatus snapshot.
+func (c *xpfCollector) emitWorkerRuntime(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, w := range status.WorkerRuntime {
+		label := strconv.FormatUint(uint64(w.WorkerID), 10)
+		toSecs := func(ns uint64) float64 { return float64(ns) / 1e9 }
+		ch <- prometheus.MustNewConstMetric(c.workerWallSecs,
+			prometheus.CounterValue, toSecs(w.WallNS), label)
+		ch <- prometheus.MustNewConstMetric(c.workerActiveSecs,
+			prometheus.CounterValue, toSecs(w.ActiveNS), label)
+		ch <- prometheus.MustNewConstMetric(c.workerIdleSpinSecs,
+			prometheus.CounterValue, toSecs(w.IdleSpinNS), label)
+		ch <- prometheus.MustNewConstMetric(c.workerIdleBlockSecs,
+			prometheus.CounterValue, toSecs(w.IdleBlockNS), label)
+		ch <- prometheus.MustNewConstMetric(c.workerThreadCPUSecs,
+			prometheus.CounterValue, toSecs(w.ThreadCPUNS), label)
+		ch <- prometheus.MustNewConstMetric(c.workerWorkLoops,
+			prometheus.CounterValue, float64(w.WorkLoops), label)
+		ch <- prometheus.MustNewConstMetric(c.workerIdleLoops,
+			prometheus.CounterValue, float64(w.IdleLoops), label)
+	}
+}
+
+// #709: export owner-profile telemetry when the dataplane is the
+// userspace-dp helper. The eBPF-only build path doesn't have this
+// shape (it has no CoS scheduler), so we type-assert on the optional
+// `Status() (dpuserspace.ProcessStatus, error)` interface — if the
+// assertion fails we skip silently (not an error).
+func (c *xpfCollector) emitCoSOwnerProfile(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
 	for _, iface := range status.CoSInterfaces {
 		ifindexLabel := strconv.Itoa(iface.Ifindex)
 		for _, queue := range iface.Queues {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -419,6 +419,8 @@ type ProcessStatus struct {
 	NeighborGeneration     uint64                            `json:"neighbor_generation,omitempty"`
 	RouteEntries           int                               `json:"route_entries,omitempty"`
 	WorkerHeartbeats       []time.Time                       `json:"worker_heartbeats,omitempty"`
+	// #869: per-worker busy/idle runtime telemetry.
+	WorkerRuntime          []WorkerRuntimeStatus             `json:"worker_runtime,omitempty"`
 	HAGroups               []HAGroupStatus                   `json:"ha_groups,omitempty"`
 	Fabrics                []FabricSnapshot                  `json:"fabrics,omitempty"`
 	Queues                 []QueueStatus                     `json:"queues,omitempty"`
@@ -517,6 +519,22 @@ type FirewallFilterTermCounterStatus struct {
 
 type HAStateUpdateRequest struct {
 	Groups []HAGroupStatus `json:"groups,omitempty"`
+}
+
+// #869: WorkerRuntimeStatus mirrors the Rust WorkerRuntimeStatus;
+// each entry is one AF_XDP worker thread's cumulative runtime counters,
+// refreshed on the worker's ~1s publish cadence.  All fields omit when
+// zero so older daemons parse correctly.
+type WorkerRuntimeStatus struct {
+	WorkerID     uint32 `json:"worker_id,omitempty"`
+	TID          uint64 `json:"tid,omitempty"`
+	WallNS       uint64 `json:"wall_ns,omitempty"`
+	ActiveNS     uint64 `json:"active_ns,omitempty"`
+	IdleSpinNS   uint64 `json:"idle_spin_ns,omitempty"`
+	IdleBlockNS  uint64 `json:"idle_block_ns,omitempty"`
+	ThreadCPUNS  uint64 `json:"thread_cpu_ns,omitempty"`
+	WorkLoops    uint64 `json:"work_loops,omitempty"`
+	IdleLoops    uint64 `json:"idle_loops,omitempty"`
 }
 
 type HAGroupStatus struct {

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -304,6 +304,29 @@ func FormatStatusSummary(status ProcessStatus) string {
 		}
 		fmt.Fprintf(&b, "  Worker %d heartbeat age:    %s\n", i, formatStatusAge(now.Sub(hb)))
 	}
+	// #869: worker runtime table.  Percentages are cumulative since
+	// process start — operators derive live rates with Prometheus
+	// counters via rate().
+	if len(status.WorkerRuntime) > 0 {
+		fmt.Fprintln(&b, "Worker runtime (cumulative since worker start):")
+		fmt.Fprintf(&b, "  %-6s %-8s %-8s %-10s %-11s %-8s %-12s %-12s\n",
+			"Worker", "TID", "Active%", "SpinIdle%", "BlockIdle%", "CPU%", "WorkLoops", "IdleLoops")
+		for _, w := range status.WorkerRuntime {
+			wall := float64(w.WallNS)
+			if wall <= 0 {
+				fmt.Fprintf(&b, "  %-6d %-8d    -        -          -        -   %-12d %-12d\n",
+					w.WorkerID, w.TID, w.WorkLoops, w.IdleLoops)
+				continue
+			}
+			activePct := 100.0 * float64(w.ActiveNS) / wall
+			spinPct := 100.0 * float64(w.IdleSpinNS) / wall
+			blockPct := 100.0 * float64(w.IdleBlockNS) / wall
+			cpuPct := 100.0 * float64(w.ThreadCPUNS) / wall
+			fmt.Fprintf(&b, "  %-6d %-8d %-8.1f %-8.1f %-10.1f %-8.1f %-12d %-12d\n",
+				w.WorkerID, w.TID, activePct, spinPct, blockPct, cpuPct,
+				w.WorkLoops, w.IdleLoops)
+		}
+	}
 	return b.String()
 }
 

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -240,6 +240,8 @@ mod coordinator;
 mod tests;
 #[path = "afxdp/worker.rs"]
 mod worker;
+#[path = "afxdp/worker_runtime.rs"]
+mod worker_runtime;
 pub use self::coordinator::Coordinator;
 pub(crate) use self::worker::{
     BindingLiveSnapshot, BindingWorker, SyncedSessionEntry, XskBindMode, fabric_queue_hash,

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -690,6 +690,9 @@ impl Coordinator {
             let shared_cos_owner_live_by_queue = self.shared_cos_owner_live_by_queue.clone();
             let shared_cos_root_leases = self.shared_cos_root_leases.clone();
             let shared_cos_queue_leases = self.shared_cos_queue_leases.clone();
+            let runtime_atomics =
+                std::sync::Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new());
+            let runtime_atomics_clone = runtime_atomics.clone();
             let join = thread::Builder::new()
                 .name(format!("xpf-userspace-worker-{worker_id}"))
                 .spawn(move || {
@@ -725,6 +728,7 @@ impl Coordinator {
                         shared_cos_root_leases,
                         shared_cos_queue_leases,
                         cos_status_clone,
+                        runtime_atomics_clone,
                     );
                 });
             match join {
@@ -741,6 +745,7 @@ impl Coordinator {
                             commands,
                             session_export_ack,
                             cos_status,
+                            runtime_atomics,
                             join: Some(join),
                         },
                     );
@@ -1162,6 +1167,29 @@ impl Coordinator {
 
     pub fn worker_count(&self) -> usize {
         self.workers.len()
+    }
+
+    /// #869: snapshot per-worker busy/idle runtime counters.  Each row is
+    /// the current `WorkerRuntimeAtomics` publish, most recently written
+    /// on the worker's ~1s publish cadence.
+    pub fn worker_runtime_snapshots(&self) -> Vec<crate::protocol::WorkerRuntimeStatus> {
+        self.workers
+            .iter()
+            .map(|(worker_id, handle)| {
+                let s = handle.runtime_atomics.snapshot();
+                crate::protocol::WorkerRuntimeStatus {
+                    worker_id: *worker_id,
+                    tid: handle.runtime_atomics.tid(),
+                    wall_ns: s.wall_ns,
+                    active_ns: s.active_ns,
+                    idle_spin_ns: s.idle_spin_ns,
+                    idle_block_ns: s.idle_block_ns,
+                    thread_cpu_ns: s.thread_cpu_ns,
+                    work_loops: s.work_loops,
+                    idle_loops: s.idle_loops,
+                }
+            })
+            .collect()
     }
 
     pub fn identity_count(&self) -> usize {

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -680,6 +680,9 @@ mod tests {
                 commands: worker_commands.clone(),
                 session_export_ack: Arc::new(AtomicU64::new(0)),
                 cos_status: Arc::new(ArcSwap::from_pointee(Vec::new())),
+                runtime_atomics: Arc::new(
+                    super::worker_runtime::WorkerRuntimeAtomics::new(),
+                ),
                 join: None,
             },
         );

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -179,6 +179,8 @@ pub(super) struct WorkerHandle {
     pub(super) commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
     pub(super) session_export_ack: Arc<AtomicU64>,
     pub(super) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
+    // #869: per-worker busy/idle runtime telemetry publish slot.
+    pub(super) runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
     pub(super) join: Option<JoinHandle<()>>,
 }
 

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -462,6 +462,9 @@ pub(crate) fn worker_loop(
     shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
     shared_cos_queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
+    // #869: worker-runtime telemetry publish slot.  Worker writes its
+    // local counters here on a ~1s cadence; coordinator reads for status.
+    runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
 ) {
     pin_current_thread(worker_id);
     const COS_STATUS_INTERVAL_NS: u64 = 100_000_000;
@@ -655,8 +658,41 @@ pub(crate) fn worker_loop(
         forwarding.as_ref(),
     )));
     let mut last_cos_status_ns = monotonic_nanos();
+    // #869: worker-runtime telemetry.  Local counters, published to
+    // `runtime_atomics` on the ~1s cadence below.
+    use super::worker_runtime::{
+        WorkerRuntimeCounters, WorkerRuntimeState, current_tid, sample_thread_cpu_ns,
+    };
+    let mut wr_counters = WorkerRuntimeCounters::default();
+    let mut wr_state = WorkerRuntimeState::IdleBlock;
+    let mut wr_last_loop_ns = monotonic_nanos();
+    let mut wr_last_publish_ns = wr_last_loop_ns;
+    const WR_PUBLISH_INTERVAL_NS: u64 = 1_000_000_000;
+    runtime_atomics.set_tid(current_tid());
     while !stop.load(Ordering::Relaxed) {
         let loop_now_ns = monotonic_nanos();
+        // #869: attribute elapsed delta to the previous loop's state.
+        {
+            let delta = loop_now_ns.saturating_sub(wr_last_loop_ns);
+            wr_counters.wall_ns = wr_counters.wall_ns.wrapping_add(delta);
+            match wr_state {
+                WorkerRuntimeState::Active => {
+                    wr_counters.active_ns = wr_counters.active_ns.wrapping_add(delta);
+                }
+                WorkerRuntimeState::IdleSpin => {
+                    wr_counters.idle_spin_ns = wr_counters.idle_spin_ns.wrapping_add(delta);
+                }
+                WorkerRuntimeState::IdleBlock => {
+                    wr_counters.idle_block_ns = wr_counters.idle_block_ns.wrapping_add(delta);
+                }
+            }
+            wr_last_loop_ns = loop_now_ns;
+            if loop_now_ns.saturating_sub(wr_last_publish_ns) >= WR_PUBLISH_INTERVAL_NS {
+                wr_counters.thread_cpu_ns = sample_thread_cpu_ns();
+                runtime_atomics.publish(&wr_counters);
+                wr_last_publish_ns = loop_now_ns;
+            }
+        }
         let loop_now_secs = loop_now_ns / 1_000_000_000;
         let live_validation = shared_validation.load();
         if **live_validation != validation {
@@ -1455,14 +1491,20 @@ pub(crate) fn worker_loop(
         }
         if did_work {
             idle_iters = 0;
+            // #869: classify this iteration for next-loop-top accounting.
+            wr_state = WorkerRuntimeState::Active;
+            wr_counters.work_loops = wr_counters.work_loops.wrapping_add(1);
             continue;
         }
         idle_iters = idle_iters.saturating_add(1);
+        wr_counters.idle_loops = wr_counters.idle_loops.wrapping_add(1);
         match poll_mode {
             crate::PollMode::BusyPoll => {
                 if idle_iters <= IDLE_SPIN_ITERS {
+                    wr_state = WorkerRuntimeState::IdleSpin;
                     std::hint::spin_loop();
                 } else {
+                    wr_state = WorkerRuntimeState::IdleBlock;
                     thread::sleep(Duration::from_micros(IDLE_SLEEP_US));
                 }
             }
@@ -1471,8 +1513,10 @@ pub(crate) fn worker_loop(
                 // Firewall-local TCP flows are ACK-latency-sensitive; blocking
                 // immediately on the first empty poll collapses cwnd badly.
                 if idle_iters <= IDLE_SPIN_ITERS {
+                    wr_state = WorkerRuntimeState::IdleSpin;
                     std::hint::spin_loop();
                 } else if !interrupt_poll_fds.is_empty() {
+                    wr_state = WorkerRuntimeState::IdleBlock;
                     for pfd in &mut interrupt_poll_fds {
                         pfd.revents = 0;
                     }
@@ -1484,6 +1528,7 @@ pub(crate) fn worker_loop(
                         );
                     }
                 } else {
+                    wr_state = WorkerRuntimeState::IdleBlock;
                     thread::sleep(Duration::from_millis(INTERRUPT_POLL_TIMEOUT_MS as u64));
                 }
             }

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -688,7 +688,14 @@ pub(crate) fn worker_loop(
             }
             wr_last_loop_ns = loop_now_ns;
             if loop_now_ns.saturating_sub(wr_last_publish_ns) >= WR_PUBLISH_INTERVAL_NS {
-                wr_counters.thread_cpu_ns = sample_thread_cpu_ns();
+                // Skip on transient clock_gettime failure (sample == 0):
+                // overwriting a previously-published nonzero value with 0
+                // would make the Prometheus counter go backwards and
+                // break `rate()` queries.
+                let sampled_cpu_ns = sample_thread_cpu_ns();
+                if sampled_cpu_ns != 0 {
+                    wr_counters.thread_cpu_ns = sampled_cpu_ns;
+                }
                 runtime_atomics.publish(&wr_counters);
                 wr_last_publish_ns = loop_now_ns;
             }

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -148,9 +148,15 @@ pub(crate) fn sample_thread_cpu_ns() -> u64 {
 
 /// Return the calling thread's kernel TID (`gettid`) as u64.  Used in
 /// status output so operators can correlate telemetry with `top -H`.
+/// Returns 0 on syscall failure so a wrapped -1 sentinel never escapes
+/// to Prometheus or the CLI.
 pub(crate) fn current_tid() -> u64 {
     // SAFETY: gettid is a pure syscall with no arguments.
-    unsafe { libc::syscall(libc::SYS_gettid) as u64 }
+    let tid = unsafe { libc::syscall(libc::SYS_gettid) };
+    if tid < 0 {
+        return 0;
+    }
+    tid as u64
 }
 
 #[cfg(test)]
@@ -202,8 +208,9 @@ mod tests {
             _acc = _acc.wrapping_add(1);
         }
         let b = sample_thread_cpu_ns();
-        // Either both zero (syscall failed), or b >= a.
-        if a != 0 || b != 0 {
+        // Zero is the syscall-failure sentinel; only assert monotonicity
+        // when both samples succeeded.
+        if a != 0 && b != 0 {
             assert!(b >= a, "thread cpu time must be monotonic: a={a} b={b}");
         }
     }

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -1,0 +1,210 @@
+// #869: per-worker busy/idle runtime accounting.
+//
+// The AF_XDP worker loop publishes cumulative time spent in three states
+// (Active, IdleSpin, IdleBlock) plus loop counts and sampled thread CPU
+// time.  Operators use this to tell compute saturation apart from spin
+// waste apart from genuine idle headroom apart from VM-scheduling loss.
+//
+// Hot-path design:
+//
+//   1. At each loop iteration's top the worker computes
+//      `delta = now - last_loop_ns` and attributes the delta to the
+//      PREVIOUS loop's classified state.  No per-packet work.
+//
+//   2. After `did_work` is known and the worker has decided whether it
+//      will take the active / spin / block branch, the state for the
+//      next iteration is set.
+//
+//   3. Worker-local counters are pure u64 math.  They are copied into a
+//      cacheline-isolated atomic struct only on a ~1s cadence (same
+//      cadence as existing worker_heartbeats).  `CLOCK_THREAD_CPUTIME_ID`
+//      is sampled on the same cadence, NOT per iteration.
+//
+//   4. All atomics use Ordering::Relaxed — these are diagnostic monotonic
+//      counters, not synchronization primitives.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Classification applied to the previous worker-loop iteration.
+/// Determines which counter the elapsed delta is added to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WorkerRuntimeState {
+    /// `did_work` returned true — the loop processed at least one ring
+    /// or packet.
+    Active,
+    /// No useful work this iteration; worker stayed in the short-spin
+    /// path (idle_iters <= IDLE_SPIN_ITERS).
+    IdleSpin,
+    /// No useful work this iteration; worker entered interrupt-mode
+    /// `poll()` or `sleep()`.
+    IdleBlock,
+}
+
+/// Per-worker cumulative counters, owned exclusively by the worker
+/// thread.  No atomics here — the worker only contends with itself.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct WorkerRuntimeCounters {
+    pub wall_ns: u64,
+    pub active_ns: u64,
+    pub idle_spin_ns: u64,
+    pub idle_block_ns: u64,
+    pub thread_cpu_ns: u64,
+    pub work_loops: u64,
+    pub idle_loops: u64,
+}
+
+/// Cacheline-isolated atomic publish slot.  The worker copies its local
+/// counters here on a ~1s cadence; the coordinator (or any status reader)
+/// snapshots with `Ordering::Relaxed`.  One Atomic per field keeps
+/// snapshots consistent within a field — cross-field tearing is
+/// acceptable for diagnostic counters.
+#[repr(align(64))]
+pub(crate) struct WorkerRuntimeAtomics {
+    pub wall_ns: AtomicU64,
+    pub active_ns: AtomicU64,
+    pub idle_spin_ns: AtomicU64,
+    pub idle_block_ns: AtomicU64,
+    pub thread_cpu_ns: AtomicU64,
+    pub work_loops: AtomicU64,
+    pub idle_loops: AtomicU64,
+    pub tid: AtomicU64,
+    /// Cacheline padding after the atomics so that adjacent workers in
+    /// a `Vec<WorkerRuntimeAtomics>` don't false-share.
+    _pad: [u8; 0],
+}
+
+impl WorkerRuntimeAtomics {
+    pub fn new() -> Self {
+        Self {
+            wall_ns: AtomicU64::new(0),
+            active_ns: AtomicU64::new(0),
+            idle_spin_ns: AtomicU64::new(0),
+            idle_block_ns: AtomicU64::new(0),
+            thread_cpu_ns: AtomicU64::new(0),
+            work_loops: AtomicU64::new(0),
+            idle_loops: AtomicU64::new(0),
+            tid: AtomicU64::new(0),
+            _pad: [],
+        }
+    }
+
+    /// Publish a full snapshot of the worker's local counters.  Called
+    /// on the ~1s publish cadence; NOT called per iteration.
+    pub fn publish(&self, c: &WorkerRuntimeCounters) {
+        self.wall_ns.store(c.wall_ns, Ordering::Relaxed);
+        self.active_ns.store(c.active_ns, Ordering::Relaxed);
+        self.idle_spin_ns.store(c.idle_spin_ns, Ordering::Relaxed);
+        self.idle_block_ns.store(c.idle_block_ns, Ordering::Relaxed);
+        self.thread_cpu_ns.store(c.thread_cpu_ns, Ordering::Relaxed);
+        self.work_loops.store(c.work_loops, Ordering::Relaxed);
+        self.idle_loops.store(c.idle_loops, Ordering::Relaxed);
+    }
+
+    /// Snapshot for status readers.  Not atomic across fields — each
+    /// field is `Relaxed`-loaded individually.
+    pub fn snapshot(&self) -> WorkerRuntimeCounters {
+        WorkerRuntimeCounters {
+            wall_ns: self.wall_ns.load(Ordering::Relaxed),
+            active_ns: self.active_ns.load(Ordering::Relaxed),
+            idle_spin_ns: self.idle_spin_ns.load(Ordering::Relaxed),
+            idle_block_ns: self.idle_block_ns.load(Ordering::Relaxed),
+            thread_cpu_ns: self.thread_cpu_ns.load(Ordering::Relaxed),
+            work_loops: self.work_loops.load(Ordering::Relaxed),
+            idle_loops: self.idle_loops.load(Ordering::Relaxed),
+        }
+    }
+
+    pub fn set_tid(&self, tid: u64) {
+        self.tid.store(tid, Ordering::Relaxed);
+    }
+
+    pub fn tid(&self) -> u64 {
+        self.tid.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for WorkerRuntimeAtomics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sample CLOCK_THREAD_CPUTIME_ID for the calling thread.  Returns 0 on
+/// syscall failure — diagnostic counters treat that as "no sample this
+/// cadence" rather than propagating the error.
+pub(crate) fn sample_thread_cpu_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: clock_gettime with a valid clock id + writable timespec
+    // is defined behavior.
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+    if rc != 0 {
+        return 0;
+    }
+    (ts.tv_sec as u64).saturating_mul(1_000_000_000) + (ts.tv_nsec as u64)
+}
+
+/// Return the calling thread's kernel TID (`gettid`) as u64.  Used in
+/// status output so operators can correlate telemetry with `top -H`.
+pub(crate) fn current_tid() -> u64 {
+    // SAFETY: gettid is a pure syscall with no arguments.
+    unsafe { libc::syscall(libc::SYS_gettid) as u64 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_roundtrip() {
+        let atomics = WorkerRuntimeAtomics::new();
+        let c = WorkerRuntimeCounters {
+            wall_ns: 10_000_000_000,
+            active_ns: 9_700_000_000,
+            idle_spin_ns: 250_000_000,
+            idle_block_ns: 50_000_000,
+            thread_cpu_ns: 9_950_000_000,
+            work_loops: 1_234_567,
+            idle_loops: 1_234,
+        };
+        atomics.publish(&c);
+        let s = atomics.snapshot();
+        assert_eq!(s.wall_ns, c.wall_ns);
+        assert_eq!(s.active_ns, c.active_ns);
+        assert_eq!(s.idle_spin_ns, c.idle_spin_ns);
+        assert_eq!(s.idle_block_ns, c.idle_block_ns);
+        assert_eq!(s.thread_cpu_ns, c.thread_cpu_ns);
+        assert_eq!(s.work_loops, c.work_loops);
+        assert_eq!(s.idle_loops, c.idle_loops);
+    }
+
+    #[test]
+    fn counters_default_zero() {
+        let c: WorkerRuntimeCounters = Default::default();
+        assert_eq!(c.wall_ns, 0);
+        assert_eq!(c.active_ns, 0);
+        assert_eq!(c.idle_spin_ns, 0);
+        assert_eq!(c.idle_block_ns, 0);
+        assert_eq!(c.thread_cpu_ns, 0);
+        assert_eq!(c.work_loops, 0);
+        assert_eq!(c.idle_loops, 0);
+    }
+
+    #[test]
+    fn cpu_sample_is_monotonic_or_zero() {
+        let a = sample_thread_cpu_ns();
+        // busy wait briefly
+        let until = std::time::Instant::now() + std::time::Duration::from_millis(5);
+        let mut _acc = 0u64;
+        while std::time::Instant::now() < until {
+            _acc = _acc.wrapping_add(1);
+        }
+        let b = sample_thread_cpu_ns();
+        // Either both zero (syscall failed), or b >= a.
+        if a != 0 || b != 0 {
+            assert!(b >= a, "thread cpu time must be monotonic: a={a} b={b}");
+        }
+    }
+}

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -150,6 +150,7 @@ fn run() -> Result<(), String> {
             neighbor_generation: 0,
             route_entries: 0,
             worker_heartbeats: Vec::new(),
+            worker_runtime: Vec::new(),
             cos_no_owner_binding_drops_total: 0,
             per_binding: Vec::new(),
             ha_groups: Vec::new(),
@@ -770,6 +771,8 @@ fn refresh_status(state: &mut ServerState) {
         .map(|s| s.fabrics.clone())
         .unwrap_or_default();
     state.status.worker_heartbeats = state.afxdp.worker_heartbeats();
+    // #869: per-worker busy/idle runtime telemetry.
+    state.status.worker_runtime = state.afxdp.worker_runtime_snapshots();
     state.status.debug_worker_threads = state.afxdp.worker_count();
     state.status.debug_identity_slots = state.afxdp.identity_count();
     state.status.debug_live_slots = state.afxdp.live_count();

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -699,6 +699,11 @@ pub(crate) struct ProcessStatus {
     pub route_entries: usize,
     #[serde(rename = "worker_heartbeats", default)]
     pub worker_heartbeats: Vec<DateTime<Utc>>,
+    /// #869: per-worker busy/idle runtime telemetry.  Empty on
+    /// dataplanes that don't publish.  Additive / defaulted for
+    /// backward compatibility with older daemon builds.
+    #[serde(rename = "worker_runtime", default)]
+    pub worker_runtime: Vec<WorkerRuntimeStatus>,
     // #710: cluster-wide aggregate of cross-worker CoS redirects that
     // could not locate a binding for their target egress on the landing
     // worker. Summed across all bindings in `refresh_status` — the
@@ -1028,6 +1033,32 @@ pub(crate) struct ForwardingControlRequest {
 pub(crate) struct HAStateUpdateRequest {
     #[serde(default)]
     pub groups: Vec<HAGroupStatus>,
+}
+
+/// #869: per-worker busy/idle runtime telemetry, published on the
+/// worker's ~1s cadence.  See `userspace-dp/src/afxdp/worker_runtime.rs`.
+/// All fields default to 0 for backward compatibility with daemons that
+/// predate this instrumentation.
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct WorkerRuntimeStatus {
+    #[serde(rename = "worker_id", default)]
+    pub worker_id: u32,
+    #[serde(default)]
+    pub tid: u64,
+    #[serde(rename = "wall_ns", default)]
+    pub wall_ns: u64,
+    #[serde(rename = "active_ns", default)]
+    pub active_ns: u64,
+    #[serde(rename = "idle_spin_ns", default)]
+    pub idle_spin_ns: u64,
+    #[serde(rename = "idle_block_ns", default)]
+    pub idle_block_ns: u64,
+    #[serde(rename = "thread_cpu_ns", default)]
+    pub thread_cpu_ns: u64,
+    #[serde(rename = "work_loops", default)]
+    pub work_loops: u64,
+    #[serde(rename = "idle_loops", default)]
+    pub idle_loops: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- Per-worker cumulative busy/idle accounting in the AF_XDP runtime: `wall_ns`, `active_ns`, `idle_spin_ns`, `idle_block_ns`, `thread_cpu_ns`, `work_loops`, `idle_loops`, plus `tid`.
- Published 1/s via cacheline-isolated `WorkerRuntimeAtomics` (`#[repr(align(64))]` AtomicU64 fields); workers own local counters and `wrapping_add` state-attributed deltas on each loop iter.
- Wired through the status protocol (`WorkerRuntimeStatus` in `protocol.rs` / `protocol.go`), surfaced in `show system status` via a new "Worker runtime (cumulative since worker start)" table, and exported as 7 Prometheus counters (`xpf_userspace_worker_{wall,active,idle_spin,idle_block,thread_cpu}_seconds_total`, `work_loops_total`, `idle_loops_total`) with a `worker_id` label.
- Metrics collector refactored to a single `Status()` call per scrape (`collectUserspaceStatus` → `emitCoSOwnerProfile` + `emitWorkerRuntime`) so both profiles share one snapshot.

## Test plan
- [x] `cargo test -p userspace-dp worker_runtime` — 3 unit tests (snapshot roundtrip, zero default, CPU monotonic)
- [x] `make build` + `cargo build --release`
- [x] `./test/incus/cluster-setup.sh deploy all` onto loss userspace HA cluster
- [x] Verified `show system status`: all 3 RGs `Transfer ready: yes`, worker runtime table populated
- [x] Forwarding: `cluster-userspace-host → 172.16.80.200` 4/4 ping, 0% loss
- [x] Perf: `iperf3 -P 16 -p 5203 -t 30` → **23.5 Gbit/s** (sender + receiver), matches 25G-shaped baseline
- [x] Codex hostile review: **MERGE YES**, 3 LOWs addressed (CLI label clarified, single-Status scrape, early-run CPU% skew accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)