### PR TITLE
#881 show chassis forwarding: 5s / 1m / 5m CPU windows

### DIFF
--- a/docs/pr/881-cpu-windows/plan.md
+++ b/docs/pr/881-cpu-windows/plan.md
@@ -1,25 +1,45 @@
-# PR: #881 show chassis forwarding — 5s / 1m / 5m CPU windows + honest worker activity
+# PR: #881 show chassis forwarding — 5s / 1m / 5m CPU windows
 
 ## Goal
 
 Replace the cumulative-since-start CPU% on the `Daemon CPU utilization`
 and `Worker threads CPU utilization` rows with three Junos-style
-sliding windows (5s / 1m / 5m), and fix the worker row to measure
-**dataplane activity** rather than OS thread CPU time.
+sliding windows (5s / 1m / 5m). Cumulative hides current load — a
+daemon that burned 100% for 10s three days ago reads ~0% today.
+Operators diagnose live load, not lifetime averages.
 
-Two problems with the shipped-in-#880 rows:
+## History — worker-row semantic change reverted
 
-1. **Cumulative hides current load.** A daemon that burned 100% for
-   10s three days ago reads ~0% today. Operators diagnose live load,
-   not lifetime averages.
+An earlier iteration of this PR also proposed switching the worker row
+from OS thread CPU (`thread_cpu_ns / wall_ns`) to dataplane activity
+(`Σactive_ns / Σwall_ns` from #869 telemetry). **Empirical validation
+killed that change.** At 25 Gbps iperf3 load on
+`loss:xpf-userspace-fw0`, the activity signal read **0%** per worker
+while `top` and `thread_cpu/wall` showed ~5-10% per worker. Two
+follow-up issues came out of that investigation:
 
-2. **Worker row is dishonest on userspace-dp.** It reports
-   `thread_cpu_ns / wall_ns` (`CLOCK_THREAD_CPUTIME_ID`). In busy-poll
-   mode, a worker spinning on an empty AF_XDP rx-ring shows 100% OS
-   CPU even when forwarding 0 pps. Operators can't distinguish "fully
-   saturated" from "idle-spinning". The #869 telemetry already carries
-   `active_ns` (time in `did_work=true` iterations) — that's the
-   honest forwarding-activity signal.
+- **#883 (P0)** — iperf3 at 25 Gbps entirely bypasses the userspace
+  workers. `ethtool -S ge-0-0-2 | grep rx_xdp_redirect` = **1** over
+  20+ minutes. The XDP shim is attached and configured correctly but
+  packets take `XDP_PASS` to the kernel stack instead of XSK/CPUMAP
+  redirect. Until this lands, workers genuinely see no forwarding
+  traffic.
+- **#884** — `active_ns` accounting in the worker loop undercounts:
+  idle-branch ring-poll CPU (~84s over 1604s) gets bucketed into
+  `idle_block_ns` instead of a poll-CPU bucket. Even if workers did
+  see traffic, the activity signal would be near-zero because all the
+  poll-loop CPU is misclassified.
+
+Both upstream issues defeat `active_ns / wall_ns` as an operator
+signal today. Until #883 + #884 land, the honest default is to keep
+the worker row on `thread_cpu_ns / wall_ns` — the same semantics #880
+shipped. The busy-poll-100% false-positive I was worried about is a
+smaller lie than showing 0% at 25 Gbps.
+
+This PR therefore ships the **windows only**, not the worker-row
+semantic change. Worker row stays on `thread_cpu_ns / wall_ns` with
+the #880 label ("Worker threads CPU utilization"). When #883 and
+#884 are resolved, a follow-up PR can swap to activity-based semantics.
 
 ## Approach — two signals, three windows
 

--- a/docs/pr/881-cpu-windows/plan.md
+++ b/docs/pr/881-cpu-windows/plan.md
@@ -189,7 +189,7 @@ Daemon CPU utilization         4% / - / -     (5s / 1m / 5m)
 
 
 - New package file `pkg/fwdstatus/sampler.go`:
-  - `type Sampler struct { mu, ring, head, count, dp, proc, cancel }`
+  - `type Sampler struct { mu, ring, head, count, dp, proc }` (lifetime tied to the ctx passed to Start; no cancel field)
   - `NewSampler(dp DataPlaneAccessor, proc ProcReader) *Sampler`
   - `(s *Sampler) Start(ctx context.Context)` — primes one sample
     synchronously, then launches the 1s-tick goroutine.

--- a/docs/pr/881-cpu-windows/plan.md
+++ b/docs/pr/881-cpu-windows/plan.md
@@ -1,0 +1,282 @@
+# PR: #881 show chassis forwarding — 5s / 1m / 5m CPU windows + honest worker activity
+
+## Goal
+
+Replace the cumulative-since-start CPU% on the `Daemon CPU utilization`
+and `Worker threads CPU utilization` rows with three Junos-style
+sliding windows (5s / 1m / 5m), and fix the worker row to measure
+**dataplane activity** rather than OS thread CPU time.
+
+Two problems with the shipped-in-#880 rows:
+
+1. **Cumulative hides current load.** A daemon that burned 100% for
+   10s three days ago reads ~0% today. Operators diagnose live load,
+   not lifetime averages.
+
+2. **Worker row is dishonest on userspace-dp.** It reports
+   `thread_cpu_ns / wall_ns` (`CLOCK_THREAD_CPUTIME_ID`). In busy-poll
+   mode, a worker spinning on an empty AF_XDP rx-ring shows 100% OS
+   CPU even when forwarding 0 pps. Operators can't distinguish "fully
+   saturated" from "idle-spinning". The #869 telemetry already carries
+   `active_ns` (time in `did_work=true` iterations) — that's the
+   honest forwarding-activity signal.
+
+## Approach — two signals, three windows
+
+Two rows tell different, complementary stories:
+
+- **Daemon CPU utilization** — `/proc/self/stat` utime+stime. Total
+  process CPU as per-core percent; can exceed 100% on multi-core
+  (200% = 2 cores). Useful for capacity planning.
+- **Worker threads utilization** (note: label drops "CPU" to avoid
+  the OS-CPU connotation) — `Σ(active_ns) / Σ(wall_ns) × 100` across
+  all workers. A 0-100% time-weighted per-worker-average activity
+  fraction. Matches the operator intent of Junos vSRX "Real-time
+  threads CPU utilization" — "how loaded is the forwarding plane?"
+  — without the busy-poll false-positive of raw OS CPU. On eBPF,
+  workers don't exist so this row renders `N/A — eBPF path has no
+  worker threads` as in #880.
+
+Each row renders three windows: 5s / 1m / 5m.
+
+### Data flow
+
+```
+   ┌───────────────┐  1s tick   ┌─────────────────┐   Build()   ┌──────────────┐
+   │  sampler      │──────────▶ │  cpuRing        │ ──────────▶ │  Format()    │
+   │  goroutine    │            │  (360 samples)  │             │  3 columns   │
+   └───────────────┘            └─────────────────┘             └──────────────┘
+```
+
+- **Sampler goroutine** owned by `pkg/fwdstatus`. Launched from the
+  daemon at startup via a new `NewSampler(dp, proc)` + `Start(ctx)`.
+  Stops on context cancel.
+- **Cadence: 1s**. Matches existing #869 `WorkerRuntimeStatus`
+  publish cadence.
+- **Each sample captures three cumulative monotonic counters**:
+  - `wall_ns` — monotonic clock at sample time.
+  - `daemon_cpu_ns` — from `/proc/self/stat` (utime+stime, in ticks
+    → ns via userHZ=100).
+  - `worker_active_ns` — `Σ WorkerRuntimeStatus.active_ns` across all
+    workers at sample time. Zero on eBPF path (type assertion fails).
+  - `worker_wall_ns` — `Σ WorkerRuntimeStatus.wall_ns` across all
+    workers. Used as denominator for the worker row. Zero on eBPF.
+- **Ring**: `[360]cpuSample` circular buffer — sized for the longest
+  window (5m at 1s = 300) plus a 1m headroom to tolerate: (a) missed
+  samples (skipped on /proc read errors) and (b) the fact that
+  looking up `newest.wall_ns − 5m` after 300 samples requires the
+  ring still hold a sample ≥ 300s old. With a 360-slot ring and 1s
+  cadence, the oldest retained sample is ~360s old at steady state,
+  comfortably satisfying the 5m window. Mutex around writer + reader.
+- **Build() query**: take a `SamplerSnapshot` (see test interface
+  below). Pick newest sample and the sample at or before
+  (newest.wall − W) for each W in {5s, 1m, 5m}.
+  - Daemon %: `(newest.daemon_cpu_ns − then.daemon_cpu_ns) /
+    (newest.wall_ns − then.wall_ns) × 100` → per-core %.
+  - Worker %: `(newest.worker_active_ns − then.worker_active_ns) /
+    (newest.worker_wall_ns − then.worker_wall_ns) × 100`. Because
+    each worker's `wall_ns` advances at real time, `Σ wall_ns` over
+    N workers and a time interval Δt equals N·Δt, and `Σ active_ns`
+    is bounded by `Σ wall_ns`. The ratio is therefore a
+    **time-weighted per-worker-average activity fraction in [0, 100]**
+    — not a pool aggregate. The row answers "on average, what
+    fraction of a worker's time was spent doing useful work in this
+    window?".
+  - If no sample ≥ W ago, that column is marked invalid and the
+    formatter prints `-`.
+
+### Struct changes
+
+```go
+// In pkg/fwdstatus/fwdstatus.go
+
+type ForwardingStatus struct {
+    // existing fields (State, Heap%, Buffer%, Uptime, ClusterMode)...
+
+    // New: 5s / 1m / 5m columns.  Index with CPUWindow* constants.
+    // DaemonCPU = process-wide /proc/self/stat rate.
+    // WorkerCPU = Σ(active_ns) / Σ(wall_ns) × 100 — dataplane
+    //            activity fraction, not OS thread CPU.
+    DaemonCPUWindows      [3]float64
+    WorkerCPUWindows      [3]float64
+    DaemonCPUWindowValid  [3]bool
+    WorkerCPUWindowValid  [3]bool
+
+    // WorkerCPUMode is retained from #880. When it equals
+    // CPUModeEBPFNoWorkers, the worker row prints the explicit "N/A
+    // — eBPF path has no worker threads" label regardless of
+    // WorkerCPUWindowValid — so eBPF's all-invalid state is
+    // distinguishable from userspace's "short uptime" state.
+    WorkerCPUMode         CPUMode
+
+    // (Removed: DaemonCPUPercent, WorkerCPUPercent — cumulative
+    // values are no longer displayed.)
+}
+
+const (
+    CPUWindow5s = iota
+    CPUWindow1m
+    CPUWindow5m
+)
+```
+
+### Formatter changes
+
+`Format()` renders the two CPU rows as:
+
+```
+Daemon CPU utilization         4% / 3% / 2%   (5s / 1m / 5m)
+Worker threads utilization     42% / 38% / 35% (5s / 1m / 5m)
+```
+
+Short uptime renders `-` per invalid column:
+
+```
+Daemon CPU utilization         4% / - / -     (5s / 1m / 5m)
+```
+
+### Sampling precision and first-tick behavior
+
+- **Window granularity is ±1 sample.** With a 1s cadence and a
+  `sample at or before (now − W)` lookup, the 5s column actually
+  covers a 5–6s interval. Junos's literal-5s semantics has the same
+  ±1s slop. Noted so operators don't chase ghost differences.
+- **First-tick off-by-one.** `Start()` takes an initial sample
+  before returning so the ring is never empty when Build() runs.
+  Subsequent samples arrive at t=1, t=2, … With a sample at t=0
+  (prime) and another at t=5, the 5s column becomes valid at t≈5
+  (five ticks after prime). For the 1m / 5m columns, the validity
+  threshold is ≥ N ticks since prime where N = window_seconds.
+  Short-uptime behavior: the validity flag is set purely on "does a
+  sample ≥ W old exist in the ring", not on a separate uptime
+  clock — this makes the condition self-consistent with what
+  Build() actually needs.
+
+### Error handling during sampling
+
+- **`/proc/self/stat` read failure**: the sample is **skipped**
+  (ring head does not advance). Skipping ensures counter monotonicity
+  across samples — a zero-insert would create a non-monotonic series
+  that produces a negative rate on the next Build(). A skip merely
+  widens the window's effective time range by 1s, which is benign
+  and already tolerated by the ±1s slop above.
+- **Worker telemetry read failure** (e.g. `Status()` returns an
+  error on userspace-dp): record the sample with `worker_active_ns`
+  and `worker_wall_ns` frozen at the previous sample's values.
+  Build() therefore reads the rate as zero for that interval, which
+  is honest — we didn't observe any worker activity.
+
+
+
+- New package file `pkg/fwdstatus/sampler.go`:
+  - `type Sampler struct { mu, ring, head, count, dp, proc, cancel }`
+  - `NewSampler(dp DataPlaneAccessor, proc ProcReader) *Sampler`
+  - `(s *Sampler) Start(ctx context.Context)` — primes one sample
+    synchronously, then launches the 1s-tick goroutine.
+  - `(s *Sampler) Snapshot() SamplerSnapshot` — returns a
+    copy-on-read view of the ring for `Build()`.
+  - `(s *Sampler) sample()` — one iteration of the loop.
+- **Test interface**: `Build()` takes `SamplerSnapshot` directly
+  (not `*Sampler`), so tests construct `SamplerSnapshot` literals
+  with canned values without touching the Sampler goroutine.
+  `SamplerSnapshot` is a small value-type:
+  ```go
+  type SamplerSnapshot struct {
+      Samples []cpuSample    // copied from ring, newest last
+      Now     time.Time      // captured when Snapshot() was called
+  }
+  ```
+  Call sites (grpcapi handler, local TTY handler) do
+  `Build(dp, proc, startTime, clusterMode, s.sampler.Snapshot())`.
+  Zero-value `SamplerSnapshot{}` (empty slice) → all windows
+  invalid, preserving behavior when no sampler is plumbed.
+- Daemon wiring: new field on `grpcapi.Server` for the `*Sampler`;
+  constructed in `pkg/daemon/daemon.go` alongside the existing
+  dataplane/gRPC setup, started with the daemon context.
+
+### Thread safety
+
+- `Sampler` holds three fields under `mu`: the ring (`[360]cpuSample`),
+  a write index `head` (wraps 0..359), and a monotonic `count` of
+  samples ever written (does NOT wrap). `head` is the next write
+  slot; `count` tracks population history so rollover doesn't lose
+  track of how many samples have actually been taken.
+- `Snapshot()` takes `mu`, copies `ring[]` to a fresh slice ordered
+  oldest-first (newest last — whichever order Build() expects), sets
+  `Now = time.Now()`, releases the lock. If `count < 360`, only the
+  first `count` entries are populated — the returned slice is sized
+  to `min(count, 360)`. Build reads off-lock.
+- Samples are 32 bytes × 360 = 11.5 KB. Copy is cheap.
+
+### Short-uptime handling
+
+A column is valid iff the snapshot contains a sample with
+`wall_ns ≤ newest.wall_ns − W`. This is purely a content check, not a
+head/count check — Build only needs to know whether a sufficiently-old
+sample is present in the copied slice. At boot, with a 1s sampler
+cadence and a synchronous prime at `Start()`:
+
+- 5s column: valid once a sample ≥ 5s old is in the ring (≈5s after
+  prime).
+- 1m column: valid at ≈60s post-prime.
+- 5m column: valid at ≈300s post-prime.
+
+Before those thresholds, the corresponding `*WindowValid[i]` stays
+`false` and the formatter renders `-`. Ring rollover at count ≥ 360
+does not affect this: once the 5m column is valid, it stays valid,
+because the oldest retained sample is always ~6m old by construction
+(the ring holds 360s of history, comfortably past the 5m lookup).
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `pkg/fwdstatus/sampler.go` (new) | `Sampler` type, ring, goroutine, `Snapshot`. |
+| `pkg/fwdstatus/sampler_test.go` (new) | Fill, rollover, window lookup with exact / approximate / short-uptime cases. |
+| `pkg/fwdstatus/fwdstatus.go` | Add `DaemonCPUWindows`/`WorkerCPUWindows` + valid flags to `ForwardingStatus`; remove `DaemonCPUPercent`/`WorkerCPUPercent` (cumulative values) but retain `WorkerCPUMode` for eBPF N/A label distinction. Update `Format()`. |
+| `pkg/fwdstatus/builder.go` | Drop the per-call `/proc/self/stat` CPU math. Take a `SamplerSnapshot` (value type); populate windows by computing rates from the snapshot's `Samples` slice. |
+| `pkg/fwdstatus/fwdstatus_test.go` | Replace cumulative-CPU tests with window tests. Tests construct `SamplerSnapshot` literals directly — no need to instantiate or drive the Sampler goroutine. |
+| `pkg/grpcapi/server.go` + `server_show.go` | Store `*Sampler` on `Server`; call `s.sampler.Snapshot()` and pass the result to `fwdstatus.Build`. |
+| `pkg/cli/cli_show_chassis.go` | Accept `*Sampler` (new field on CLI struct) + call `Snapshot()` and pass result to Build. |
+| `pkg/cli/cli.go` | Add `*fwdstatus.Sampler` field + setter. |
+| `pkg/daemon/daemon.go` | Construct the sampler at startup; pass to gRPC server + CLI. |
+
+### Test strategy
+
+1. **Sampler unit test**: seed with synthetic timestamps, write N
+   samples, assert `Snapshot` returns correct ordering, rollover,
+   and window lookups for all three windows.
+2. **Insufficient-history test**: sampler with 3 samples (3s
+   uptime) → 5s and longer windows flagged invalid.
+3. **Build + format integration**: fake sampler returns canned
+   windows; formatter renders correct three-column output; invalid
+   columns render `-`.
+4. **Deploy + load test**: on `loss:xpf-userspace-fw0`, run iperf3
+   to saturate one core briefly, run `show chassis forwarding`
+   during and after. Expect 5s to spike and decay first, 1m to
+   track more slowly, 5m to stay low.
+
+### Follow-ups not in this PR
+
+- Exposing windows as Prometheus gauges (separate issue if asked).
+- Adding more windows (15m, 1h) — not requested, not doing.
+
+## Alternatives rejected
+
+1. **Keep cumulative + add windowed rows**. Rejected: cumulative is
+   not useful information for an operator diagnosing live load; it
+   only dilutes the display. If some operator wants it, it can come
+   back as a `show chassis forwarding extensive` follow-up.
+
+2. **Per-CLI-invocation two-sample 1s sleep**. Already rejected in
+   #877 plan alt 2. Blocks scripts.
+
+3. **Sliding mean via decay instead of ring**. Cheap storage-wise
+   (just 3 floats + EMA constants) but loses the ability to
+   compute arbitrary windows later and produces a different
+   (exponentially decayed) value than what operators expect from
+   Junos's "last 5 seconds" literal-average semantics.
+
+## Refs
+
+Closes #881. Builds on #877/#880 (ForwardingStatus + formatter).

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
+	"github.com/psaab/xpf/pkg/fwdstatus"
 	"github.com/psaab/xpf/pkg/vrrp"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -65,6 +66,11 @@ type CLI struct {
 	startTime       time.Time
 
 	vrrpMgr *vrrp.Manager
+
+	// fwdSampler supplies 5s/1m/5m CPU windows to
+	// `show chassis forwarding` (#881).  Nil when no sampler is
+	// wired — Build() falls back to all-invalid windows.
+	fwdSampler *fwdstatus.Sampler
 
 	// applyConfigFn is the daemon's full reconcile callback. When set,
 	// local CLI commits invoke this (the single source of truth used by
@@ -117,6 +123,14 @@ func New(store *configstore.Store, dp dataplane.DataPlane, eventBuf *logging.Eve
 }
 
 // SetRPMResultsFn sets a callback for retrieving live RPM probe results.
+// SetForwardingSampler wires the pkg/fwdstatus Sampler into the CLI
+// so `show chassis forwarding` can read 5s/1m/5m CPU windows.
+// Pass nil to disable windowed CPU display (Build falls back to
+// all-invalid columns and the formatter prints `-`).
+func (c *CLI) SetForwardingSampler(s *fwdstatus.Sampler) {
+	c.fwdSampler = s
+}
+
 func (c *CLI) SetRPMResultsFn(fn func() []*rpm.ProbeResult) {
 	c.rpmResultsFn = fn
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -122,7 +122,6 @@ func New(store *configstore.Store, dp dataplane.DataPlane, eventBuf *logging.Eve
 	}
 }
 
-// SetRPMResultsFn sets a callback for retrieving live RPM probe results.
 // SetForwardingSampler wires the pkg/fwdstatus Sampler into the CLI
 // so `show chassis forwarding` can read 5s/1m/5m CPU windows.
 // Pass nil to disable windowed CPU display (Build falls back to
@@ -131,6 +130,7 @@ func (c *CLI) SetForwardingSampler(s *fwdstatus.Sampler) {
 	c.fwdSampler = s
 }
 
+// SetRPMResultsFn sets a callback for retrieving live RPM probe results.
 func (c *CLI) SetRPMResultsFn(fn func() []*rpm.ProbeResult) {
 	c.rpmResultsFn = fn
 }

--- a/pkg/cli/cli_show_chassis.go
+++ b/pkg/cli/cli_show_chassis.go
@@ -13,11 +13,16 @@ import (
 // #877: local-node MVP.  Cluster peer rendering is stubbed via
 // fwdstatus.ClusterPeerFollowup.
 func (c *CLI) showChassisForwarding() error {
+	var snap fwdstatus.SamplerSnapshot
+	if c.fwdSampler != nil {
+		snap = c.fwdSampler.Snapshot()
+	}
 	fs, err := fwdstatus.Build(
 		c.dp,
 		fwdstatus.OSProcReader{},
 		c.startTime,
 		c.cluster != nil,
+		snap,
 	)
 	if err != nil {
 		return fmt.Errorf("build forwarding status: %w", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"github.com/psaab/xpf/pkg/feeds"
 	"github.com/psaab/xpf/pkg/flowexport"
 	"github.com/psaab/xpf/pkg/frr"
+	"github.com/psaab/xpf/pkg/fwdstatus"
 	"github.com/psaab/xpf/pkg/grpcapi"
 	"github.com/psaab/xpf/pkg/ipsec"
 	"github.com/psaab/xpf/pkg/lldp"
@@ -1047,6 +1048,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		slog.Info("HTTP API server started", "addr", d.opts.APIAddr)
 	}
 
+	// #881: forwarding-daemon CPU sampler (5s/1m/5m windows for
+	// `show chassis forwarding`).  Shared between the gRPC server
+	// and the local CLI; both paths call Snapshot() at query time.
+	// Started here so the ring is populated before the first CLI.
+	fwdSampler := fwdstatus.NewSampler(d.dp, fwdstatus.OSProcReader{})
+	fwdSampler.Start(ctx)
+
 	// Start gRPC API server.
 	{
 		// Wrap applyConfig to also sync config to cluster peer after commit.
@@ -1118,6 +1126,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return ""
 			}(),
+			FwdSampler: fwdSampler,
 		})
 		d.grpcSrv = grpcSrv
 		wg.Add(1)
@@ -1135,6 +1144,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if isInteractive() {
 		shell := cli.New(d.store, d.dp, eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
 		shell.SetVersion(d.opts.Version)
+		shell.SetForwardingSampler(fwdSampler)
 		// #797 H2: route in-process CLI commits through the daemon's
 		// full reconcile (same path gRPC/HTTP use via ApplyFn) so D3
 		// RSS indirection reapply, cluster/VRRP, DHCP etc. converge

--- a/pkg/fwdstatus/builder.go
+++ b/pkg/fwdstatus/builder.go
@@ -46,12 +46,14 @@ type DataPlaneAccessor interface {
 // `proc` must be non-nil; callers that want to bypass /proc should
 // pass a stub implementation that returns os.ErrNotExist — Build
 // maps that into State=Unknown with uptime falling back to
-// `startTime`.
+// `startTime`.  `snap` carries the 5s/1m/5m CPU history; an empty
+// snapshot renders all window columns as invalid (`-`).
 func Build(
 	dp DataPlaneAccessor,
 	proc ProcReader,
 	startTime time.Time,
 	clusterMode bool,
+	snap SamplerSnapshot,
 ) (*ForwardingStatus, error) {
 	fs := &ForwardingStatus{
 		State:              StateUnknown,
@@ -62,7 +64,7 @@ func Build(
 		ClusterFollowupRef: followupClusterPeer,
 	}
 
-	// --- Uptime + Daemon CPU %: shared PID-start anchor ------------
+	// --- Uptime: shared PID-start anchor ---------------------------
 	selfStat, statErr := proc.ReadSelfStat()
 	stat, btimeErr := proc.ReadStat()
 	hasProcStat := statErr == nil && btimeErr == nil
@@ -70,22 +72,19 @@ func Build(
 	if hasProcStat {
 		pidStart := time.Unix(int64(stat.BootTime)+int64(selfStat.StartTimeTicks)/userHZ, 0)
 		fs.Uptime = time.Since(pidStart)
-
-		wallNs := fs.Uptime.Nanoseconds()
-		if wallNs > 0 {
-			// Per-core percent: 100% = one core fully saturated;
-			// a daemon using 2 cores sustained reports 200%.  This
-			// matches `top` and is honest on CPU-pinned deployments
-			// where normalizing by NumCPU() would under-report load.
-			cpuNs := ticksToNanos(selfStat.UtimeTicks + selfStat.StimeTicks)
-			fs.DaemonCPUPercent = float64(cpuNs) * 100.0 / float64(wallNs)
-		}
 	} else {
 		// Fallback: in-memory daemon start time.  Differs from true
 		// PID-start by ms at most.  State stays Unknown below because
 		// /proc/self/stat was unreadable.
 		fs.Uptime = time.Since(startTime)
 	}
+
+	// --- CPU windows (5s / 1m / 5m) --------------------------------
+	// Populated from the sampler's cumulative-counter ring.  An
+	// empty snap (no sampler wired, or zero samples yet) leaves all
+	// windows invalid — formatter renders `-`.
+	fs.DaemonCPUWindows, fs.WorkerCPUWindows,
+		fs.DaemonCPUWindowValid, fs.WorkerCPUWindowValid = computeCPUWindows(snap)
 
 	// --- Heap % --------------------------------------------------
 	selfStatm, statmErr := proc.ReadSelfStatm()
@@ -145,7 +144,10 @@ func Build(
 		fs.BufferKnown = true
 	}
 
-	// --- Worker CPU % (userspace-dp only) ------------------------
+	// --- Worker path detection (for State + Mode) ----------------
+	// Worker CPU values come from the sampler (above); here we only
+	// need to know whether we're on the userspace path and whether
+	// Status() currently returns an error, for State classification.
 	var usStatus userspace.ProcessStatus
 	var usErr error
 	if dp != nil && isUserspace {
@@ -157,7 +159,6 @@ func Build(
 	}
 	if isUserspace && usErr == nil {
 		fs.WorkerCPUMode = CPUModeWorkers
-		fs.WorkerCPUPercent = sumWorkerCPUPercent(usStatus)
 	}
 
 	// --- State ---------------------------------------------------
@@ -179,21 +180,6 @@ func Build(
 
 func ticksToNanos(ticks uint64) uint64 {
 	return ticks * 1_000_000_000 / userHZ
-}
-
-// sumWorkerCPUPercent returns the cumulative summed CPU% across all
-// workers in the given status.  Each worker contributes
-// thread_cpu_ns / wall_ns * 100; summing yields aggregate daemon
-// worker load (can exceed 100 on multi-core).
-func sumWorkerCPUPercent(st userspace.ProcessStatus) float64 {
-	total := 0.0
-	for _, w := range st.WorkerRuntime {
-		if w.WallNS == 0 {
-			continue
-		}
-		total += float64(w.ThreadCPUNS) * 100.0 / float64(w.WallNS)
-	}
-	return total
 }
 
 // allHeartbeatsFresh returns true iff every heartbeat is within

--- a/pkg/fwdstatus/fwdstatus.go
+++ b/pkg/fwdstatus/fwdstatus.go
@@ -75,19 +75,20 @@ func Format(fs *ForwardingStatus) string {
 	writeRow(&b, "State", string(fs.State))
 	// CPU rows: three sliding windows (5s / 1m / 5m).  Daemon row
 	// is /proc/self/stat per-core % (can exceed 100 on multi-core;
-	// no upper clamp).  Worker row is per-worker-average activity
-	// fraction in [0, 100]: Σactive_ns / Σwall_ns across workers —
-	// honest "dataplane busy" signal, not OS thread CPU time.
-	// Columns with insufficient history (uptime < window) render
-	// `-`.  On eBPF, the worker row prints the N/A label.
+	// no upper clamp).  Worker row is Σ(thread_cpu_ns) / Σ(wall_ns)
+	// from CLOCK_THREAD_CPUTIME_ID — OS thread CPU, not dataplane
+	// activity (see #883/#884; activity-based signal was tried and
+	// empirically found broken at 25 Gbps).  Columns with insufficient
+	// history (uptime < window) render `-`.  On eBPF, the worker row
+	// prints the N/A label.
 	writeRow(&b, "Daemon CPU utilization",
 		formatWindowRow(fs.DaemonCPUWindows, fs.DaemonCPUWindowValid))
 
 	if fs.WorkerCPUMode == CPUModeEBPFNoWorkers {
-		writeRow(&b, "Worker threads utilization",
+		writeRow(&b, "Worker threads CPU utilization",
 			"N/A — eBPF path has no worker threads")
 	} else {
-		writeRow(&b, "Worker threads utilization",
+		writeRow(&b, "Worker threads CPU utilization",
 			formatWindowRow(fs.WorkerCPUWindows, fs.WorkerCPUWindowValid))
 	}
 

--- a/pkg/fwdstatus/fwdstatus.go
+++ b/pkg/fwdstatus/fwdstatus.go
@@ -37,18 +37,32 @@ const (
 // are computed by Build; Format does not read /proc or call into the
 // dataplane.
 type ForwardingStatus struct {
-	State             State
-	DaemonCPUPercent  float64
-	WorkerCPUMode     CPUMode
-	WorkerCPUPercent  float64
-	HeapPercent       float64
-	BufferPercent     float64 // Only valid if BufferKnown.
-	BufferKnown       bool    // False on userspace-dp until UMEM telemetry lands.
-	BufferFollowupRef int     // GitHub issue number printed in place of buffer %.
-	Uptime            time.Duration
+	State State
 
-	// ClusterMode = true causes Format to append a deferred-peer note.
-	ClusterMode       bool
+	// CPU windows (5s / 1m / 5m) — indexed by CPUWindow* constants.
+	// DaemonCPUWindows is /proc/self/stat per-core % (can exceed
+	// 100 on multi-core).  WorkerCPUWindows is per-worker-average
+	// activity fraction in [0, 100] — time-weighted Σactive_ns /
+	// Σwall_ns across all workers.  Parallel *Valid flags are
+	// false when the ring doesn't have a sample ≥ W old yet
+	// (short uptime); the formatter renders `-` for invalid cols.
+	DaemonCPUWindows     [numCPUWindows]float64
+	WorkerCPUWindows     [numCPUWindows]float64
+	DaemonCPUWindowValid [numCPUWindows]bool
+	WorkerCPUWindowValid [numCPUWindows]bool
+
+	// WorkerCPUMode distinguishes the eBPF "no workers" path from
+	// the userspace path — on eBPF the worker row prints the
+	// explicit N/A label instead of window values, regardless of
+	// WorkerCPUWindowValid.
+	WorkerCPUMode CPUMode
+
+	HeapPercent        float64
+	BufferPercent      float64 // Only valid if BufferKnown.
+	BufferKnown        bool    // False on userspace-dp until UMEM telemetry lands.
+	BufferFollowupRef  int     // GitHub issue number printed in place of buffer %.
+	Uptime             time.Duration
+	ClusterMode        bool
 	ClusterFollowupRef int
 }
 
@@ -59,20 +73,22 @@ func Format(fs *ForwardingStatus) string {
 	var b strings.Builder
 	b.WriteString("FWDD status:\n")
 	writeRow(&b, "State", string(fs.State))
-	// CPU rows are per-core: 100 percent = one core saturated; a
-	// multi-threaded daemon legitimately shows >100% (e.g. 250%
-	// = 2.5 cores).  Do not clamp — suppressing >100% would hide
-	// real load.  Clamp to a non-negative floor only.
+	// CPU rows: three sliding windows (5s / 1m / 5m).  Daemon row
+	// is /proc/self/stat per-core % (can exceed 100 on multi-core;
+	// no upper clamp).  Worker row is per-worker-average activity
+	// fraction in [0, 100]: Σactive_ns / Σwall_ns across workers —
+	// honest "dataplane busy" signal, not OS thread CPU time.
+	// Columns with insufficient history (uptime < window) render
+	// `-`.  On eBPF, the worker row prints the N/A label.
 	writeRow(&b, "Daemon CPU utilization",
-		fmt.Sprintf("%.0f percent (cumulative since start)", floorZero(fs.DaemonCPUPercent)))
+		formatWindowRow(fs.DaemonCPUWindows, fs.DaemonCPUWindowValid))
 
-	switch fs.WorkerCPUMode {
-	case CPUModeEBPFNoWorkers:
-		writeRow(&b, "Worker threads CPU utilization",
-			"0 percent (N/A — eBPF path has no worker threads)")
-	default:
-		writeRow(&b, "Worker threads CPU utilization",
-			fmt.Sprintf("%.0f percent (cumulative since start)", floorZero(fs.WorkerCPUPercent)))
+	if fs.WorkerCPUMode == CPUModeEBPFNoWorkers {
+		writeRow(&b, "Worker threads utilization",
+			"N/A — eBPF path has no worker threads")
+	} else {
+		writeRow(&b, "Worker threads utilization",
+			formatWindowRow(fs.WorkerCPUWindows, fs.WorkerCPUWindowValid))
 	}
 
 	writeRow(&b, "Heap utilization",
@@ -125,6 +141,20 @@ func floorZero(p float64) float64 {
 		return 0
 	}
 	return p
+}
+
+// formatWindowRow renders three windows as
+// `NN% / NN% / NN%   (5s / 1m / 5m)`.  Invalid columns render `-`.
+func formatWindowRow(pct [numCPUWindows]float64, valid [numCPUWindows]bool) string {
+	cols := [numCPUWindows]string{}
+	for i := 0; i < numCPUWindows; i++ {
+		if valid[i] {
+			cols[i] = fmt.Sprintf("%.0f%%", floorZero(pct[i]))
+		} else {
+			cols[i] = "-"
+		}
+	}
+	return fmt.Sprintf("%-5s / %-5s / %-5s   (5s / 1m / 5m)", cols[0], cols[1], cols[2])
 }
 
 // formatUptime renders a duration as "N days, N hours, N minutes,

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -16,19 +16,20 @@ import (
 
 func TestFormat_LabelsAndOrderEBPF(t *testing.T) {
 	fs := &ForwardingStatus{
-		State:             StateOnline,
-		DaemonCPUPercent:  3.7,
-		WorkerCPUMode:     CPUModeEBPFNoWorkers,
-		HeapPercent:       72.0,
-		BufferPercent:     83.0,
-		BufferKnown:       true,
-		Uptime:            474635 * time.Second,
+		State: StateOnline,
+		DaemonCPUWindows: [numCPUWindows]float64{4, 3, 2},
+		DaemonCPUWindowValid: [numCPUWindows]bool{true, true, true},
+		WorkerCPUMode:  CPUModeEBPFNoWorkers,
+		HeapPercent:    72.0,
+		BufferPercent:  83.0,
+		BufferKnown:    true,
+		Uptime:         474635 * time.Second,
 	}
 	out := Format(fs)
 	wantLabelsInOrder := []string{
 		"State",
 		"Daemon CPU utilization",
-		"Worker threads CPU utilization",
+		"Worker threads utilization",
 		"Heap utilization",
 		"Buffer utilization",
 		"Uptime:",
@@ -51,18 +52,19 @@ func TestFormat_LabelsAndOrderEBPF(t *testing.T) {
 	if !strings.Contains(out, "N/A") {
 		t.Errorf("eBPF worker row should mention N/A: %s", out)
 	}
-	if !regexp.MustCompile(`\d+ percent`).MatchString(out) {
+	if !regexp.MustCompile(`\d+%`).MatchString(out) {
 		t.Errorf("expected percentage: %s", out)
 	}
 }
 
 func TestFormat_BufferUnknownUserspace(t *testing.T) {
 	fs := &ForwardingStatus{
-		State:             StateOnline,
-		WorkerCPUMode:     CPUModeWorkers,
-		WorkerCPUPercent:  45.0,
-		BufferKnown:       false,
-		BufferFollowupRef: 878,
+		State:              StateOnline,
+		WorkerCPUMode:      CPUModeWorkers,
+		WorkerCPUWindows:   [numCPUWindows]float64{45, 40, 35},
+		WorkerCPUWindowValid: [numCPUWindows]bool{true, true, true},
+		BufferKnown:        false,
+		BufferFollowupRef:  878,
 	}
 	out := Format(fs)
 	if !strings.Contains(out, "unknown (see #878)") {
@@ -123,20 +125,22 @@ func TestFormat_UptimeShape(t *testing.T) {
 
 func TestFormat_HeapAndBufferClampButCPUDoesNot(t *testing.T) {
 	fs := &ForwardingStatus{
-		DaemonCPUPercent: 230.4, // multi-core daemon, legitimately >100
-		WorkerCPUMode:    CPUModeWorkers,
-		WorkerCPUPercent: -3.0, // negative is a bug; floor to 0
-		HeapPercent:      150.0,
-		BufferKnown:      true,
-		BufferPercent:    -5.0,
+		DaemonCPUWindows:     [numCPUWindows]float64{230.4, 230.4, 230.4}, // multi-core >100
+		DaemonCPUWindowValid: [numCPUWindows]bool{true, true, true},
+		WorkerCPUMode:        CPUModeWorkers,
+		WorkerCPUWindows:     [numCPUWindows]float64{-3.0, -3.0, -3.0}, // negatives floor to 0
+		WorkerCPUWindowValid: [numCPUWindows]bool{true, true, true},
+		HeapPercent:          150.0,
+		BufferKnown:          true,
+		BufferPercent:        -5.0,
 	}
 	out := Format(fs)
 	// 230% is honest per-core utilization — must not clamp
-	if !regexp.MustCompile(`Daemon CPU utilization\s+230 percent`).MatchString(out) {
+	if !regexp.MustCompile(`Daemon CPU utilization\s+230%\s*/\s*230%\s*/\s*230%`).MatchString(out) {
 		t.Errorf("daemon CPU must not clamp to 100 (per-core): %s", out)
 	}
 	// negative worker CPU floors to 0
-	if !regexp.MustCompile(`Worker threads CPU utilization\s+0 percent`).MatchString(out) {
+	if !regexp.MustCompile(`Worker threads utilization\s+0%\s*/\s*0%\s*/\s*0%`).MatchString(out) {
 		t.Errorf("expected worker CPU floored to 0: %s", out)
 	}
 	// 150% heap clamps to 100
@@ -221,7 +225,7 @@ func TestBuild_Online_eBPF(t *testing.T) {
 	dp := &fakeDP{loaded: true, mapStats: []dataplane.MapStats{
 		{Name: "sessions", MaxEntries: 100, UsedCount: 30},
 	}}
-	fs, err := Build(dp, freshProcReader(), time.Now(), false)
+	fs, err := Build(dp, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +244,7 @@ func TestBuild_Online_eBPF(t *testing.T) {
 }
 
 func TestBuild_Unknown_DpNil(t *testing.T) {
-	fs, _ := Build(nil, freshProcReader(), time.Now(), false)
+	fs, _ := Build(nil, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateUnknown {
 		t.Errorf("dp==nil: state %q, want Unknown", fs.State)
 	}
@@ -248,7 +252,7 @@ func TestBuild_Unknown_DpNil(t *testing.T) {
 
 func TestBuild_Unknown_NotLoaded(t *testing.T) {
 	dp := &fakeDP{loaded: false}
-	fs, _ := Build(dp, freshProcReader(), time.Now(), false)
+	fs, _ := Build(dp, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateUnknown {
 		t.Errorf("!IsLoaded: state %q, want Unknown", fs.State)
 	}
@@ -258,7 +262,7 @@ func TestBuild_Unknown_SelfStatErr(t *testing.T) {
 	dp := &fakeDP{loaded: true}
 	proc := freshProcReader()
 	proc.selfStatErr = os.ErrNotExist
-	fs, _ := Build(dp, proc, time.Now(), false)
+	fs, _ := Build(dp, proc, time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateUnknown {
 		t.Errorf("selfStat err: state %q, want Unknown", fs.State)
 	}
@@ -268,7 +272,7 @@ func TestBuild_Unknown_StatmErr(t *testing.T) {
 	dp := &fakeDP{loaded: true}
 	proc := freshProcReader()
 	proc.selfStatmErr = os.ErrNotExist
-	fs, _ := Build(dp, proc, time.Now(), false)
+	fs, _ := Build(dp, proc, time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateUnknown {
 		t.Errorf("statm err: state %q, want Unknown", fs.State)
 	}
@@ -279,7 +283,7 @@ func TestBuild_Unknown_UserspaceStatusErr(t *testing.T) {
 		fakeDP: fakeDP{loaded: true},
 		err:    errors.New("status unavailable"),
 	}
-	fs, _ := Build(dp, freshProcReader(), time.Now(), false)
+	fs, _ := Build(dp, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateUnknown {
 		t.Errorf("userspace Status err: state %q, want Unknown", fs.State)
 	}
@@ -296,7 +300,7 @@ func TestBuild_Degraded_StaleHeartbeat(t *testing.T) {
 			},
 		},
 	}
-	fs, _ := Build(dp, freshProcReader(), time.Now(), false)
+	fs, _ := Build(dp, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateDegraded {
 		t.Errorf("stale hb: state %q, want Degraded", fs.State)
 	}
@@ -317,16 +321,20 @@ func TestBuild_Online_UserspaceFreshHeartbeats(t *testing.T) {
 			},
 		},
 	}
-	fs, _ := Build(dp, freshProcReader(), time.Now(), false)
+	fs, _ := Build(dp, freshProcReader(), time.Now(), false, SamplerSnapshot{})
 	if fs.State != StateOnline {
 		t.Errorf("fresh hb: state %q, want Online", fs.State)
 	}
 	if fs.WorkerCPUMode != CPUModeWorkers {
 		t.Error("userspace should set CPUModeWorkers")
 	}
-	// (30% + 20%) = 50
-	if fs.WorkerCPUPercent < 49 || fs.WorkerCPUPercent > 51 {
-		t.Errorf("worker CPU%%: got %v, want ~50", fs.WorkerCPUPercent)
+	// Worker CPU values now come from the sampler, not sum of
+	// cumulative thread_cpu_ns at Build time. With an empty
+	// SamplerSnapshot, all windows should be invalid.
+	for i, v := range fs.WorkerCPUWindowValid {
+		if v {
+			t.Errorf("empty snapshot: WorkerCPUWindowValid[%d] should be false", i)
+		}
 	}
 	if fs.BufferKnown {
 		t.Error("userspace-dp Buffer should be unknown")
@@ -338,7 +346,7 @@ func TestBuild_Online_UserspaceFreshHeartbeats(t *testing.T) {
 
 func TestBuild_ClusterMode(t *testing.T) {
 	dp := &fakeDP{loaded: true}
-	fs, _ := Build(dp, freshProcReader(), time.Now(), true)
+	fs, _ := Build(dp, freshProcReader(), time.Now(), true, SamplerSnapshot{})
 	if !fs.ClusterMode {
 		t.Error("ClusterMode should be true")
 	}

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -29,7 +29,7 @@ func TestFormat_LabelsAndOrderEBPF(t *testing.T) {
 	wantLabelsInOrder := []string{
 		"State",
 		"Daemon CPU utilization",
-		"Worker threads utilization",
+		"Worker threads CPU utilization",
 		"Heap utilization",
 		"Buffer utilization",
 		"Uptime:",
@@ -140,7 +140,7 @@ func TestFormat_HeapAndBufferClampButCPUDoesNot(t *testing.T) {
 		t.Errorf("daemon CPU must not clamp to 100 (per-core): %s", out)
 	}
 	// negative worker CPU floors to 0
-	if !regexp.MustCompile(`Worker threads utilization\s+0%\s*/\s*0%\s*/\s*0%`).MatchString(out) {
+	if !regexp.MustCompile(`Worker threads CPU utilization\s+0%\s*/\s*0%\s*/\s*0%`).MatchString(out) {
 		t.Errorf("expected worker CPU floored to 0: %s", out)
 	}
 	// 150% heap clamps to 100

--- a/pkg/fwdstatus/sampler.go
+++ b/pkg/fwdstatus/sampler.go
@@ -195,13 +195,23 @@ func computeCPUWindows(snap SamplerSnapshot) (
 		if wallDelta <= 0 {
 			continue
 		}
+		// Guard against non-monotonic counters.  A userspace-dp
+		// restart or a brief Status() miscarriage can reset the
+		// cumulative series; an unchecked subtract on uint64 would
+		// underflow to a huge value and pass the clamp-on-display
+		// path, reporting a bogus 9e20%.  Mark the window invalid
+		// in that case so the operator sees `-` until fresh samples
+		// accumulate.
 		wallNs := uint64(wallDelta.Nanoseconds())
-		daemonDelta := newest.daemonCPUNs - then.daemonCPUNs
-		daemonPct[i] = float64(daemonDelta) * 100.0 / float64(wallNs)
-		daemonValid[i] = true
+		if newest.daemonCPUNs >= then.daemonCPUNs {
+			daemonDelta := newest.daemonCPUNs - then.daemonCPUNs
+			daemonPct[i] = float64(daemonDelta) * 100.0 / float64(wallNs)
+			daemonValid[i] = true
+		}
 
-		workerWallDelta := newest.workerWallNs - then.workerWallNs
-		if workerWallDelta > 0 {
+		if newest.workerWallNs > then.workerWallNs &&
+			newest.workerThreadNs >= then.workerThreadNs {
+			workerWallDelta := newest.workerWallNs - then.workerWallNs
 			workerThreadDelta := newest.workerThreadNs - then.workerThreadNs
 			workerPct[i] = float64(workerThreadDelta) * 100.0 /
 				float64(workerWallDelta)

--- a/pkg/fwdstatus/sampler.go
+++ b/pkg/fwdstatus/sampler.go
@@ -1,0 +1,220 @@
+package fwdstatus
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// ringSize is the sampler ring capacity.  At 1s cadence it holds 6m
+// of history — comfortably past the 5m window lookup, with headroom
+// for occasional missed samples.
+const ringSize = 360
+
+// SampleInterval is the sampler cadence.
+const SampleInterval = 1 * time.Second
+
+// CPU window indices.
+const (
+	CPUWindow5s = iota
+	CPUWindow1m
+	CPUWindow5m
+	numCPUWindows
+)
+
+// cpuSample is one tick of the cumulative-counter ring.  All
+// counters are monotonic nanoseconds.
+type cpuSample struct {
+	wall           time.Time
+	daemonCPUNs    uint64 // /proc/self/stat utime+stime, converted to ns
+	workerActiveNs uint64 // Σ WorkerRuntimeStatus.active_ns across workers
+	workerWallNs   uint64 // Σ WorkerRuntimeStatus.wall_ns across workers
+}
+
+// Sampler maintains a ring of cumulative CPU counters.  One
+// instance per daemon, started at boot.  Snapshot() returns a
+// read-only copy safe to hand to Build() off-lock.
+type Sampler struct {
+	mu    sync.Mutex
+	ring  [ringSize]cpuSample
+	head  int    // next write index, wraps 0..ringSize-1
+	count uint64 // monotonic count of samples ever taken (no wrap)
+
+	dp   DataPlaneAccessor
+	proc ProcReader
+
+	// Snapshot of the last successfully-read worker telemetry.
+	// On a failed Status() call the sampler reuses these values so
+	// the counter series stays monotonic (see plan §Error handling).
+	lastWorkerActive uint64
+	lastWorkerWall   uint64
+}
+
+// NewSampler constructs a Sampler.  The sampler is not running
+// until Start() is called.
+func NewSampler(dp DataPlaneAccessor, proc ProcReader) *Sampler {
+	return &Sampler{dp: dp, proc: proc}
+}
+
+// Start primes one sample synchronously, then launches a goroutine
+// that samples every SampleInterval until ctx is canceled.
+// Returns immediately after priming.
+func (s *Sampler) Start(ctx context.Context) {
+	s.sample(time.Now())
+	go s.loop(ctx)
+}
+
+func (s *Sampler) loop(ctx context.Context) {
+	t := time.NewTicker(SampleInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			s.sample(now)
+		}
+	}
+}
+
+// sample captures one row and appends it to the ring.  On
+// /proc/self/stat read failure the sample is dropped entirely —
+// skipping preserves monotonicity of daemonCPUNs.  On worker
+// telemetry failure the worker counters are held at their
+// previous values (honest zero-rate for that interval).
+func (s *Sampler) sample(now time.Time) {
+	selfStat, statErr := s.proc.ReadSelfStat()
+	if statErr != nil {
+		return
+	}
+	daemonNs := ticksToNanos(selfStat.UtimeTicks + selfStat.StimeTicks)
+
+	// Worker counters — userspace-dp only.
+	workerActive, workerWall := s.lastWorkerActive, s.lastWorkerWall
+	if s.dp != nil {
+		if us, ok := s.dp.(interface {
+			Status() (userspace.ProcessStatus, error)
+		}); ok {
+			if st, err := us.Status(); err == nil {
+				var a, w uint64
+				for _, wr := range st.WorkerRuntime {
+					a += wr.ActiveNS
+					w += wr.WallNS
+				}
+				workerActive, workerWall = a, w
+			}
+		}
+	}
+
+	s.mu.Lock()
+	s.ring[s.head] = cpuSample{
+		wall:           now,
+		daemonCPUNs:    daemonNs,
+		workerActiveNs: workerActive,
+		workerWallNs:   workerWall,
+	}
+	s.head = (s.head + 1) % ringSize
+	s.count++
+	s.lastWorkerActive = workerActive
+	s.lastWorkerWall = workerWall
+	s.mu.Unlock()
+}
+
+// SamplerSnapshot is a value-type view of the ring passed to
+// Build().  Samples is ordered oldest-first, newest-last.  Empty
+// snapshot renders as all-windows-invalid in Build().
+type SamplerSnapshot struct {
+	Samples []cpuSample
+	Now     time.Time
+}
+
+// Snapshot copies the ring under lock and returns it.  Always
+// ordered oldest-first.
+func (s *Sampler) Snapshot() SamplerSnapshot {
+	s.mu.Lock()
+	n := int(s.count)
+	if n > ringSize {
+		n = ringSize
+	}
+	out := make([]cpuSample, n)
+	if s.count <= ringSize {
+		// Ring has not yet rolled over; entries 0..count-1 are in
+		// chronological order.
+		copy(out, s.ring[:n])
+	} else {
+		// Ring has rolled over; oldest entry is at head.
+		tail := ringSize - s.head
+		copy(out[:tail], s.ring[s.head:])
+		copy(out[tail:], s.ring[:s.head])
+	}
+	s.mu.Unlock()
+	return SamplerSnapshot{Samples: out, Now: time.Now()}
+}
+
+// computeCPUWindows returns per-core Daemon CPU% and per-worker-average
+// Worker activity% for the three windows, plus parallel validity
+// flags.  A window is valid iff the snapshot contains a sample with
+// wall ≤ newest.wall − W.
+//
+// Daemon %: (Δdaemon_cpu_ns / Δwall_ns) × 100 — per-core percent;
+//          can exceed 100% on multi-core.
+// Worker %: (Δworker_active_ns / Δworker_wall_ns) × 100 — fraction
+//          of per-worker wall time spent in did_work=true iterations,
+//          in [0, 100].  Zero when worker_wall didn't advance (eBPF
+//          path or no workers).
+func computeCPUWindows(snap SamplerSnapshot) (
+	daemonPct, workerPct [numCPUWindows]float64,
+	daemonValid, workerValid [numCPUWindows]bool,
+) {
+	if len(snap.Samples) < 2 {
+		return
+	}
+	newest := snap.Samples[len(snap.Samples)-1]
+	windows := [numCPUWindows]time.Duration{
+		5 * time.Second,
+		1 * time.Minute,
+		5 * time.Minute,
+	}
+	for i, w := range windows {
+		target := newest.wall.Add(-w)
+		idx := findSampleAtOrBefore(snap.Samples, target)
+		if idx < 0 {
+			continue
+		}
+		then := snap.Samples[idx]
+		wallDelta := newest.wall.Sub(then.wall)
+		if wallDelta <= 0 {
+			continue
+		}
+		wallNs := uint64(wallDelta.Nanoseconds())
+		daemonDelta := newest.daemonCPUNs - then.daemonCPUNs
+		daemonPct[i] = float64(daemonDelta) * 100.0 / float64(wallNs)
+		daemonValid[i] = true
+
+		workerWallDelta := newest.workerWallNs - then.workerWallNs
+		if workerWallDelta > 0 {
+			workerActiveDelta := newest.workerActiveNs - then.workerActiveNs
+			workerPct[i] = float64(workerActiveDelta) * 100.0 /
+				float64(workerWallDelta)
+			workerValid[i] = true
+		}
+	}
+	return
+}
+
+// findSampleAtOrBefore returns the index of the sample with the
+// largest wall ≤ target, or -1 if none.  Samples is ordered
+// oldest-first so we scan forward and return the last element
+// that satisfies the predicate.
+func findSampleAtOrBefore(samples []cpuSample, target time.Time) int {
+	idx := -1
+	for i := range samples {
+		if samples[i].wall.After(target) {
+			break
+		}
+		idx = i
+	}
+	return idx
+}

--- a/pkg/fwdstatus/sampler.go
+++ b/pkg/fwdstatus/sampler.go
@@ -27,10 +27,10 @@ const (
 // cpuSample is one tick of the cumulative-counter ring.  All
 // counters are monotonic nanoseconds.
 type cpuSample struct {
-	wall           time.Time
-	daemonCPUNs    uint64 // /proc/self/stat utime+stime, converted to ns
-	workerActiveNs uint64 // Σ WorkerRuntimeStatus.active_ns across workers
-	workerWallNs   uint64 // Σ WorkerRuntimeStatus.wall_ns across workers
+	wall            time.Time
+	daemonCPUNs     uint64 // /proc/self/stat utime+stime, converted to ns
+	workerThreadNs  uint64 // Σ WorkerRuntimeStatus.thread_cpu_ns across workers
+	workerWallNs    uint64 // Σ WorkerRuntimeStatus.wall_ns across workers
 }
 
 // Sampler maintains a ring of cumulative CPU counters.  One
@@ -48,7 +48,7 @@ type Sampler struct {
 	// Snapshot of the last successfully-read worker telemetry.
 	// On a failed Status() call the sampler reuses these values so
 	// the counter series stays monotonic (see plan §Error handling).
-	lastWorkerActive uint64
+	lastWorkerThread uint64
 	lastWorkerWall   uint64
 }
 
@@ -84,6 +84,11 @@ func (s *Sampler) loop(ctx context.Context) {
 // skipping preserves monotonicity of daemonCPUNs.  On worker
 // telemetry failure the worker counters are held at their
 // previous values (honest zero-rate for that interval).
+//
+// Worker CPU comes from Σthread_cpu_ns (OS thread CPU via
+// CLOCK_THREAD_CPUTIME_ID) divided by Σwall_ns.  NOT Σactive_ns —
+// that was tried and reverted: see #883 (workers bypassed under
+// load) and #884 (active_ns idle-poll undercounting).
 func (s *Sampler) sample(now time.Time) {
 	selfStat, statErr := s.proc.ReadSelfStat()
 	if statErr != nil {
@@ -92,18 +97,18 @@ func (s *Sampler) sample(now time.Time) {
 	daemonNs := ticksToNanos(selfStat.UtimeTicks + selfStat.StimeTicks)
 
 	// Worker counters — userspace-dp only.
-	workerActive, workerWall := s.lastWorkerActive, s.lastWorkerWall
+	workerThread, workerWall := s.lastWorkerThread, s.lastWorkerWall
 	if s.dp != nil {
 		if us, ok := s.dp.(interface {
 			Status() (userspace.ProcessStatus, error)
 		}); ok {
 			if st, err := us.Status(); err == nil {
-				var a, w uint64
+				var tc, w uint64
 				for _, wr := range st.WorkerRuntime {
-					a += wr.ActiveNS
+					tc += wr.ThreadCPUNS
 					w += wr.WallNS
 				}
-				workerActive, workerWall = a, w
+				workerThread, workerWall = tc, w
 			}
 		}
 	}
@@ -112,12 +117,12 @@ func (s *Sampler) sample(now time.Time) {
 	s.ring[s.head] = cpuSample{
 		wall:           now,
 		daemonCPUNs:    daemonNs,
-		workerActiveNs: workerActive,
+		workerThreadNs: workerThread,
 		workerWallNs:   workerWall,
 	}
 	s.head = (s.head + 1) % ringSize
 	s.count++
-	s.lastWorkerActive = workerActive
+	s.lastWorkerThread = workerThread
 	s.lastWorkerWall = workerWall
 	s.mu.Unlock()
 }
@@ -154,16 +159,18 @@ func (s *Sampler) Snapshot() SamplerSnapshot {
 }
 
 // computeCPUWindows returns per-core Daemon CPU% and per-worker-average
-// Worker activity% for the three windows, plus parallel validity
+// Worker thread CPU% for the three windows, plus parallel validity
 // flags.  A window is valid iff the snapshot contains a sample with
 // wall ≤ newest.wall − W.
 //
 // Daemon %: (Δdaemon_cpu_ns / Δwall_ns) × 100 — per-core percent;
 //          can exceed 100% on multi-core.
-// Worker %: (Δworker_active_ns / Δworker_wall_ns) × 100 — fraction
-//          of per-worker wall time spent in did_work=true iterations,
-//          in [0, 100].  Zero when worker_wall didn't advance (eBPF
-//          path or no workers).
+// Worker %: (Δworker_thread_cpu_ns / Δworker_wall_ns) × 100 —
+//          per-worker-average OS thread CPU via CLOCK_THREAD_CPUTIME_ID,
+//          summed across workers.  Busy-poll mode shows ~100% regardless
+//          of traffic (known false-positive); eBPF path has no workers
+//          so Δworker_wall_ns stays 0 and the window flags as invalid.
+//          See #883 / #884 for why we don't use active_ns here.
 func computeCPUWindows(snap SamplerSnapshot) (
 	daemonPct, workerPct [numCPUWindows]float64,
 	daemonValid, workerValid [numCPUWindows]bool,
@@ -195,8 +202,8 @@ func computeCPUWindows(snap SamplerSnapshot) (
 
 		workerWallDelta := newest.workerWallNs - then.workerWallNs
 		if workerWallDelta > 0 {
-			workerActiveDelta := newest.workerActiveNs - then.workerActiveNs
-			workerPct[i] = float64(workerActiveDelta) * 100.0 /
+			workerThreadDelta := newest.workerThreadNs - then.workerThreadNs
+			workerPct[i] = float64(workerThreadDelta) * 100.0 /
 				float64(workerWallDelta)
 			workerValid[i] = true
 		}

--- a/pkg/fwdstatus/sampler_test.go
+++ b/pkg/fwdstatus/sampler_test.go
@@ -117,6 +117,39 @@ func TestComputeCPUWindows_WorkerWallFlat(t *testing.T) {
 	}
 }
 
+// Counter decrease (e.g. userspace-dp restart reset the cumulative
+// series) must not produce a bogus % — both windows should mark
+// invalid instead of underflowing uint64.
+func TestComputeCPUWindows_NonMonotonicCounters(t *testing.T) {
+	now := time.Now()
+	// 10 samples, normal ramp-up, then the newest sample has SMALLER
+	// cumulative counters than the target lookup sample.
+	samples := make([]cpuSample, 10)
+	for i := 0; i < 9; i++ {
+		samples[i] = cpuSample{
+			wall:           now.Add(-time.Duration(9-i) * time.Second),
+			daemonCPUNs:    uint64(i+1) * 100_000_000,
+			workerThreadNs: uint64(i+1) * 200_000_000,
+			workerWallNs:   uint64(i+1) * 1_000_000_000,
+		}
+	}
+	// Newest sample: wall advanced, but cumulative counters reset.
+	samples[9] = cpuSample{
+		wall:           now,
+		daemonCPUNs:    50_000_000, // < samples[4].daemonCPUNs
+		workerThreadNs: 50_000_000, // < samples[4].workerThreadNs
+		workerWallNs:   500_000_000,
+	}
+	snap := SamplerSnapshot{Samples: samples, Now: now}
+	dPct, wPct, dValid, wValid := computeCPUWindows(snap)
+	if dValid[CPUWindow5s] {
+		t.Errorf("daemon 5s should be invalid after counter decrease, got %.1f%%", dPct[CPUWindow5s])
+	}
+	if wValid[CPUWindow5s] {
+		t.Errorf("worker 5s should be invalid after counter decrease, got %.1f%%", wPct[CPUWindow5s])
+	}
+}
+
 // findSampleAtOrBefore edge cases.
 func TestFindSampleAtOrBefore(t *testing.T) {
 	base := time.Unix(1000, 0)

--- a/pkg/fwdstatus/sampler_test.go
+++ b/pkg/fwdstatus/sampler_test.go
@@ -17,7 +17,7 @@ func buildSnapshot(now time.Time, count int, daemonRate, activeRate, numWorkers 
 		samples[i] = cpuSample{
 			wall:           now.Add(-time.Duration(count-1-i) * time.Second),
 			daemonCPUNs:    uint64(i) * daemonRate,
-			workerActiveNs: uint64(i) * activeRate,
+			workerThreadNs: uint64(i) * activeRate,
 			workerWallNs:   uint64(i) * numWorkers * 1_000_000_000,
 		}
 	}

--- a/pkg/fwdstatus/sampler_test.go
+++ b/pkg/fwdstatus/sampler_test.go
@@ -1,0 +1,206 @@
+package fwdstatus
+
+import (
+	"testing"
+	"time"
+)
+
+// buildSnapshot constructs a deterministic snapshot for testing
+// window lookups. Samples are 1s apart ending at `now`.
+// daemonCPUNs advances by daemonRatePerSec ns per second.
+// workerActive advances by activeRatePerSec per total worker
+// wall; each sample's worker_wall advances by numWorkers·1e9 ns
+// per second (N workers each accumulate 1s of wall per real second).
+func buildSnapshot(now time.Time, count int, daemonRate, activeRate, numWorkers uint64) SamplerSnapshot {
+	samples := make([]cpuSample, count)
+	for i := 0; i < count; i++ {
+		samples[i] = cpuSample{
+			wall:           now.Add(-time.Duration(count-1-i) * time.Second),
+			daemonCPUNs:    uint64(i) * daemonRate,
+			workerActiveNs: uint64(i) * activeRate,
+			workerWallNs:   uint64(i) * numWorkers * 1_000_000_000,
+		}
+	}
+	return SamplerSnapshot{Samples: samples, Now: now}
+}
+
+// Compute windows for a populated snapshot and assert values.
+func TestComputeCPUWindows_Populated(t *testing.T) {
+	// 400 samples covers all three windows comfortably.
+	// Daemon: 500 Mns CPU per 1s wall = 50% per-core.
+	// Worker: 2 workers; active = 400 Mns per worker-second = 40%.
+	now := time.Now()
+	snap := buildSnapshot(now, 400,
+		500_000_000,          // daemonRate: 500 Mns per sec = 50%/core
+		800_000_000,          // activeRate: 800 Mns/total-sec → per 2 workers = 400 Mns/worker/sec = 40%
+		2)
+
+	dPct, wPct, dValid, wValid := computeCPUWindows(snap)
+	for i, label := range []string{"5s", "1m", "5m"} {
+		if !dValid[i] {
+			t.Errorf("daemon %s should be valid", label)
+			continue
+		}
+		if !wValid[i] {
+			t.Errorf("worker %s should be valid", label)
+			continue
+		}
+		if dPct[i] < 49 || dPct[i] > 51 {
+			t.Errorf("daemon %s: got %.1f, want ~50", label, dPct[i])
+		}
+		if wPct[i] < 39 || wPct[i] > 41 {
+			t.Errorf("worker %s: got %.1f, want ~40", label, wPct[i])
+		}
+	}
+}
+
+// Short uptime: only 10 samples (≈10s). 5s window valid; 1m and 5m invalid.
+func TestComputeCPUWindows_ShortUptime(t *testing.T) {
+	now := time.Now()
+	snap := buildSnapshot(now, 10, 100_000_000, 500_000_000, 1)
+	_, _, dValid, wValid := computeCPUWindows(snap)
+	if !dValid[CPUWindow5s] {
+		t.Error("5s should be valid at 10 samples")
+	}
+	if !wValid[CPUWindow5s] {
+		t.Error("worker 5s should be valid at 10 samples")
+	}
+	if dValid[CPUWindow1m] {
+		t.Error("1m should NOT be valid at 10 samples")
+	}
+	if dValid[CPUWindow5m] {
+		t.Error("5m should NOT be valid at 10 samples")
+	}
+}
+
+// Empty snapshot → everything invalid.
+func TestComputeCPUWindows_Empty(t *testing.T) {
+	_, _, dValid, wValid := computeCPUWindows(SamplerSnapshot{})
+	for i := 0; i < numCPUWindows; i++ {
+		if dValid[i] {
+			t.Errorf("empty: daemon[%d] should be invalid", i)
+		}
+		if wValid[i] {
+			t.Errorf("empty: worker[%d] should be invalid", i)
+		}
+	}
+}
+
+// Single sample is not enough for rate computation.
+func TestComputeCPUWindows_OneSample(t *testing.T) {
+	now := time.Now()
+	snap := buildSnapshot(now, 1, 100_000_000, 500_000_000, 1)
+	_, _, dValid, wValid := computeCPUWindows(snap)
+	for i := 0; i < numCPUWindows; i++ {
+		if dValid[i] {
+			t.Errorf("1-sample: daemon[%d] should be invalid", i)
+		}
+		if wValid[i] {
+			t.Errorf("1-sample: worker[%d] should be invalid", i)
+		}
+	}
+}
+
+// Worker path inactive (userspace_wall doesn't advance) → worker
+// windows stay invalid even when daemon windows are valid.
+func TestComputeCPUWindows_WorkerWallFlat(t *testing.T) {
+	now := time.Now()
+	snap := buildSnapshot(now, 400, 100_000_000, 0, 0)
+	_, _, dValid, wValid := computeCPUWindows(snap)
+	for i, label := range []string{"5s", "1m", "5m"} {
+		if !dValid[i] {
+			t.Errorf("daemon %s should be valid", label)
+		}
+		if wValid[i] {
+			t.Errorf("worker %s should be invalid (no worker wall advance)", label)
+		}
+	}
+}
+
+// findSampleAtOrBefore edge cases.
+func TestFindSampleAtOrBefore(t *testing.T) {
+	base := time.Unix(1000, 0)
+	samples := []cpuSample{
+		{wall: base.Add(0 * time.Second)},
+		{wall: base.Add(1 * time.Second)},
+		{wall: base.Add(2 * time.Second)},
+		{wall: base.Add(3 * time.Second)},
+	}
+	cases := []struct {
+		target time.Time
+		want   int
+	}{
+		{base.Add(-1 * time.Second), -1}, // before all
+		{base.Add(0 * time.Second), 0},   // exact oldest
+		{base.Add(1500 * time.Millisecond), 1},
+		{base.Add(3 * time.Second), 3}, // exact newest
+		{base.Add(10 * time.Second), 3}, // after all → newest
+	}
+	for _, c := range cases {
+		got := findSampleAtOrBefore(samples, c.target)
+		if got != c.want {
+			t.Errorf("target=%v: got %d, want %d", c.target, got, c.want)
+		}
+	}
+}
+
+// Format exercise: three valid windows render as three percentages.
+func TestFormat_ThreeValidWindows(t *testing.T) {
+	fs := &ForwardingStatus{
+		State:                StateOnline,
+		DaemonCPUWindows:     [numCPUWindows]float64{4, 3, 2},
+		DaemonCPUWindowValid: [numCPUWindows]bool{true, true, true},
+		WorkerCPUMode:        CPUModeWorkers,
+		WorkerCPUWindows:     [numCPUWindows]float64{42, 38, 35},
+		WorkerCPUWindowValid: [numCPUWindows]bool{true, true, true},
+	}
+	out := Format(fs)
+	for _, want := range []string{"4%", "3%", "2%", "42%", "38%", "35%", "5s / 1m / 5m"} {
+		if !contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// Format exercise: short-uptime renders `-` for invalid columns.
+func TestFormat_ShortUptimeRendersDash(t *testing.T) {
+	fs := &ForwardingStatus{
+		State:                StateOnline,
+		DaemonCPUWindows:     [numCPUWindows]float64{5, 0, 0},
+		DaemonCPUWindowValid: [numCPUWindows]bool{true, false, false},
+		WorkerCPUMode:        CPUModeWorkers,
+		WorkerCPUWindows:     [numCPUWindows]float64{0, 0, 0},
+		WorkerCPUWindowValid: [numCPUWindows]bool{false, false, false},
+	}
+	out := Format(fs)
+	// Daemon: 5% / - / -
+	if !contains(out, "5%") {
+		t.Errorf("missing 5%% daemon value: %s", out)
+	}
+	// We expect at least 5 occurrences of "-" (three daemon invalid
+	// columns would be 2 of them; worker has all three invalid = 3).
+	// Actually: daemon has 1 valid + 2 invalid; worker has 3 invalid.
+	// So 5 "-" total.
+	dashes := 0
+	for _, r := range out {
+		if r == '-' {
+			dashes++
+		}
+	}
+	if dashes < 5 {
+		t.Errorf("expected ≥ 5 `-` chars (invalid columns), got %d in:\n%s", dashes, out)
+	}
+}
+
+// contains is strings.Contains — kept local to avoid an extra import.
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/psaab/xpf/pkg/ipsec"
 	"github.com/psaab/xpf/pkg/lldp"
 	"github.com/psaab/xpf/pkg/logging"
+	"github.com/psaab/xpf/pkg/fwdstatus"
 	"github.com/psaab/xpf/pkg/ra"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
@@ -54,6 +55,7 @@ type Config struct {
 	Version          string                           // software version string
 	FabricPeerAddrFn func() []string                  // returns peer fabric IPs (fab0, fab1; empty if standalone)
 	FabricVRFDevice  string                           // VRF for fabric interface (e.g. "vrf-mgmt")
+	FwdSampler       *fwdstatus.Sampler               // #881: 5s/1m/5m CPU windows for `show chassis forwarding`
 }
 
 // Server implements the BpfrxService gRPC service.
@@ -75,6 +77,7 @@ type Server struct {
 	applyFn            func(*config.Config)
 	vrrpMgr            *vrrp.Manager
 	raMgr              *ra.Manager
+	fwdSampler         *fwdstatus.Sampler
 	startTime          time.Time
 	addr               string
 	version            string
@@ -135,6 +138,7 @@ func NewServer(addr string, cfg Config) *Server {
 		applyFn:          cfg.ApplyFn,
 		vrrpMgr:          cfg.VRRPMgr,
 		raMgr:            cfg.RAMgr,
+		fwdSampler:       cfg.FwdSampler,
 		startTime:        time.Now(),
 		addr:             addr,
 		version:          cfg.Version,

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -3991,11 +3991,17 @@ func (s *Server) ShowText(_ context.Context, req *pb.ShowTextRequest) (*pb.ShowT
 
 	case "chassis-forwarding":
 		// #877: Junos-style forwarding-daemon health view.
+		// #881: CPU rows are 5s/1m/5m windows from s.fwdSampler.
+		var snap fwdstatus.SamplerSnapshot
+		if s.fwdSampler != nil {
+			snap = s.fwdSampler.Snapshot()
+		}
 		fs, err := fwdstatus.Build(
 			s.dp,
 			fwdstatus.OSProcReader{},
 			s.startTime,
 			s.cluster != nil,
+			snap,
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "build forwarding status: %v", err)


### PR DESCRIPTION
## Summary

Replaces cumulative-since-start CPU% from #880 with three sliding windows (5s / 1m / 5m). Cumulative hides current load — a daemon that burned 100% for 10s three days ago reads ~0% today.

**Worker row semantics**: stayed on \`thread_cpu_ns / wall_ns\` (the #880 behavior). An earlier iteration of this PR switched to \`Σactive_ns / Σwall_ns\` for a more honest "dataplane busy" signal. That change was reverted after empirical validation — see History below.

## Output

Under active iperf3 on \`loss:xpf-userspace-fw0\`:
```
Daemon CPU utilization         10%   / 10%   / -    (5s / 1m / 5m)
Worker threads CPU utilization 5%    / 5%    / -    (5s / 1m / 5m)
```

Short uptime renders \`-\` for windows wider than uptime.

## History — activity-based worker row reverted

Earlier iteration switched the worker row from OS thread CPU (\`thread_cpu_ns/wall_ns\`) to dataplane activity (\`Σactive_ns/Σwall_ns\` from #869). At 25 Gbps iperf3 the activity signal read **0% per worker** while \`top\` showed 5-10%. Two follow-up issues identified:

- **#883 (P0)** — 25 Gbps iperf3 bypasses the userspace-dp entirely. \`rx_xdp_redirect=1\` on ge-0-0-2 over 20+ minutes despite ctrl.enabled=1 and ready bindings. Packets XDP_PASS to the kernel stack instead of reaching workers.
- **#884** — even when workers see traffic, idle-branch ring-poll CPU (~84s over 1604s) gets misattributed to \`idle_block_ns\` instead of \`active_ns\`.

Until #883 + #884 land, \`thread_cpu_ns/wall_ns\` is the least-bad signal. Busy-poll workers showing ~100% is a smaller lie than showing 0% at line rate.

## Design

- New \`Sampler\` in \`pkg/fwdstatus/\`: 1s-tick goroutine captures \`/proc/self/stat\` + \`Σthread_cpu_ns + Σwall_ns\` from \`WorkerRuntimeStatus\` into a 360-slot ring (6m history).
- \`Build()\` takes a \`SamplerSnapshot\` (value type). Empty snapshot → all windows invalid → formatter prints \`-\`.
- Short uptime: column valid iff the ring has a sample ≥ W old. Transitions to values naturally as the ring fills.
- Daemon wires sampler into both gRPC server and local TTY CLI at startup.

## Test plan

- [x] \`go test ./pkg/fwdstatus/\` — 22 tests covering sampler ring, window lookups, short-uptime, format, state transitions
- [x] \`make test\` — full suite green
- [x] Deployed to \`loss:xpf-userspace-fw0\`
- [x] At uptime=28s: 5s column valid (14% daemon, 4% worker); 1m/5m show \`-\`
- [x] At uptime=88s: 5s + 1m valid (10% / 5%); 5m still \`-\`
- [x] Transition from \`-\` to values happens naturally as ring fills

## Follow-ups

- **#883** (P0): XDP shim redirect blackhole at 25 Gbps.
- **#884**: worker \`active_ns\` undercounting.
- When both resolved: follow-up PR to swap worker row to \`active_ns/wall_ns\` for the honest activity signal.

Closes #881. Builds on #877/#880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)