### PR TITLE
#846 atomic commit+apply via shared semaphore

### DIFF
--- a/docs/pr/846-apply-config-serialize/plan.md
+++ b/docs/pr/846-apply-config-serialize/plan.md
@@ -1,0 +1,272 @@
+# PR: #846 applyConfig serialization with daemon-level mutex
+
+## Goal
+
+Eliminate the cross-step interleaving race in `applyConfig` by holding
+a single `applyMu sync.Mutex` for the entire call. Two concurrent
+callers no longer overlap across VRF / tunnel / FRR-reload steps.
+
+## Context
+
+`applyConfig` (`pkg/daemon/daemon.go:1569`) is invoked from at least
+9 distinct entry points (HTTP / gRPC commits, cluster sync recv,
+DHCP callbacks, config-poll, dynamic-feed callbacks, event-engine,
+in-process CLI commits, CLI auto-rollback). All of them call
+`d.applyConfig(cfg)` directly, with no synchronization.
+
+#844 added `d.vrfsMu` covering only the VRF reconcile phase.
+That's a strict subset. This PR adds the broader lock.
+
+## Approach
+
+### Scope
+
+Add a single `applyMu sync.Mutex` to the `Daemon` struct. The lock is
+acquired at the top of `applyConfig` and held until the function
+returns. All entry points call `applyConfig` unchanged; the mutex is
+internal.
+
+### Implementation
+
+(Codex round-1 BLOCKER 8: plain `Lock()` ignores caller context. An
+HTTP client that times out still queues an apply forever. Use a
+context-aware acquire pattern with explicit upstream propagation.)
+
+The cleanest pattern: keep `applyConfig(cfg)` as the synchronous
+entry signature for compatibility (DHCP / cluster sync goroutines
+don't have a request context), but add a context-aware sibling
+`applyConfigCtx(ctx, cfg)` that the HTTP and gRPC handlers use:
+
+```go
+type Daemon struct {
+    // ... existing fields ...
+    applyMu sync.Mutex
+}
+
+// applyConfig — backwards-compatible synchronous entry. Callers
+// without a request context (DHCP, cluster sync goroutine, event
+// engine, CLI auto-rollback) use this. They block until the lock
+// is released.
+func (d *Daemon) applyConfig(cfg *config.Config) {
+    d.applyMu.Lock()
+    defer d.applyMu.Unlock()
+    d.applyConfigLocked(cfg)
+}
+
+// applyConfigCtx — context-aware entry for HTTP/gRPC commit
+// handlers. If the caller's context is canceled before we can
+// acquire the lock, returns ErrApplyCanceled without queuing the
+// apply. Body is identical otherwise.
+func (d *Daemon) applyConfigCtx(ctx context.Context, cfg *config.Config) error {
+    if !d.tryLockCtx(ctx, &d.applyMu) {
+        return ErrApplyCanceled
+    }
+    defer d.applyMu.Unlock()
+    d.applyConfigLocked(cfg)
+    return nil
+}
+
+func (d *Daemon) tryLockCtx(ctx context.Context, mu *sync.Mutex) bool {
+    acquired := make(chan struct{})
+    go func() {
+        mu.Lock()
+        close(acquired)
+    }()
+    select {
+    case <-acquired:
+        return true
+    case <-ctx.Done():
+        // Lock is being acquired in a goroutine; it'll release
+        // when applyConfig finishes. Caller bails out.
+        go func() {
+            <-acquired
+            mu.Unlock()
+        }()
+        return false
+    }
+}
+
+// applyConfigLocked — the existing applyConfig body, unchanged.
+// Only callable with d.applyMu held.
+func (d *Daemon) applyConfigLocked(cfg *config.Config) {
+    // ... existing body of applyConfig() moves here ...
+}
+```
+
+HTTP and gRPC handlers switch from `d.applyConfig(cfg)` to
+`d.applyConfigCtx(ctx, cfg)`, propagating their request context.
+Other callers (DHCP, cluster sync goroutine, event engine, CLI
+auto-rollback) continue using `applyConfig(cfg)` — they're not
+context-bound.
+
+The `tryLockCtx` helper spawns a goroutine that will eventually
+acquire the lock if the caller cancels — but that goroutine does NOT
+run the apply body. It only acquires-then-releases the lock to keep
+the mutex's invariant balanced. The canceled caller's apply is
+DROPPED ON THE FLOOR. See the explicit "tryLockCtx semantics"
+section below for the full contract.
+
+### Why this is safe
+
+- `applyConfig` is already low-frequency: config commits, DHCP
+  events, peer config sync, feed callbacks, etc. — none are hot
+  paths. Lock contention is negligible.
+- Lock-held duration: a typical apply is ~50–500 ms (FRR reload is
+  the dominant cost). Two concurrent commits queue rather than
+  interleave; the operator-visible effect is "second commit waits"
+  instead of "second commit corrupts kernel state."
+- No callbacks INSIDE applyConfig re-enter applyConfig:
+  - DHCP callbacks call applyConfig from goroutines, never from
+    inside applyConfig. Verify by reading the call sites.
+  - Cluster-sync receive runs in a separate goroutine.
+  - Event engine triggers from a goroutine.
+  Verify by grep: any function that holds applyMu must not call
+  back into applyConfig synchronously. If found, the inner caller
+  must drop the lock.
+
+### Reentrancy verification
+
+Search before coding:
+
+```bash
+grep -rn "applyConfig\|d\.applyMu" pkg/daemon/ pkg/cli/ pkg/api/ pkg/grpcapi/ pkg/cluster/ pkg/eventengine/
+```
+
+Walk every callsite and confirm none calls `applyConfig` from inside
+the lock-held region. If a re-entry is found, the plan adjusts (e.g.
+release lock around the inner call, or change the caller to async).
+
+The issue body lists 9 entry points; expect them all to be top-level.
+
+### Files touched
+
+(Codex round-2 fix: full handler + wiring chain enumerated.)
+
+| File | Change |
+|---|---|
+| `pkg/daemon/daemon.go` | Add `applyMu sync.Mutex`. Split `applyConfig(cfg)` into `applyConfig(cfg)` (sync wrapper) + `applyConfigCtx(ctx, cfg) error` (context-aware) + `applyConfigLocked(cfg)` (the existing body). New `tryLockCtx` helper. New `ErrApplyCanceled`. |
+| `pkg/daemon/daemon_ha_sync.go` | Cluster sync receive uses sync `applyConfig` (no caller context). No change beyond verification. |
+| `pkg/grpcapi/server.go` | `Config.ApplyFn` signature changes to `func(context.Context, *config.Config) error`. Daemon wires `applyConfigCtx` here. |
+| `pkg/grpcapi/server_config.go` | Commit handler propagates the request `ctx` to ApplyFn; on `ErrApplyCanceled`, return gRPC `codes.Canceled` (or `codes.DeadlineExceeded` if `ctx.Err() == DeadlineExceeded`) so the client sees a clean reject rather than a hang. |
+| `pkg/api/server.go` | Same Config-level signature change. |
+| `pkg/api/handlers.go` | Commit handler propagates `r.Context()` to ApplyFn; on `ErrApplyCanceled`, return HTTP 503 (or 408 on deadline). |
+| `pkg/cli/cli.go` | In-process CLI uses `d.applyConfig(cfg)` — no context, no behavior change. |
+| `pkg/eventengine/engine.go` | Event engine fires from a goroutine — uses sync `applyConfig`. No context, no change. |
+
+### tryLockCtx semantics — explicit
+
+(Codex round-2 fix: clarify the "what happens on cancel" path.)
+
+When `applyConfigCtx(ctx, cfg)` returns `ErrApplyCanceled`, the
+canceled caller's apply **never runs**. The body of `applyConfig`
+is NOT executed for that caller. Only the apply that already held
+the lock at cancel time continues to completion (it cannot be
+cancelled mid-stride because the body of applyConfig is not
+cancellation-safe — kernel route writes, FRR reload, etc.).
+
+The `tryLockCtx` goroutine that "eventually acquires and releases
+the lock" only does so to keep the mutex's invariant (lock count
+matched). It does NOT run the apply body. The cancel goroutine
+just acquires-then-releases to give back the slot:
+
+```go
+case <-ctx.Done():
+    go func() {
+        <-acquired
+        mu.Unlock()  // release the slot we caused to be held
+    }()
+    return false
+```
+
+Net effect: a context-cancelled commit is observably equivalent to
+"the commit never happened" — the canceled config is dropped on the
+floor. The operator sees an explicit error and knows to re-issue.
+
+### Test strategy
+
+(Codex round-1 BLOCKER 5: instrumenting `applyConfigLocked` directly
+doesn't catch caller-driven deadlocks. Add a real-caller-driven test
+in addition to the sentinel.)
+
+1. **Sentinel test (mutex correctness)**: instrument
+   `applyConfigLocked` body with an atomic in-progress counter.
+   Run with `-race`. Assert max-concurrent observed == 1.
+2. **Real-caller deadlock test**: spin up an in-process daemon test
+   harness that exposes both the HTTP and gRPC commit handlers.
+   Fire 5 concurrent commits via the HTTP handler + 5 via the gRPC
+   handler with subtly different configs. Assert each returns
+   within 30s (no deadlock), each completes either successfully or
+   with `ErrApplyCanceled`, and the post-commit state matches the
+   last successful caller's config.
+3. **Context-cancel test**: HTTP caller posts a commit with a
+   context canceled after 100ms while another commit is in
+   progress (5s applyConfig blocked on FRR reload). Assert the
+   second caller gets `ErrApplyCanceled` quickly and the in-flight
+   first apply still completes.
+4. **Existing test suite**: `make test` — no regressions.
+5. **Failover-during-commit**: `make test-failover` (cluster) +
+   trigger a CLI commit during the failover window — peer-config-
+   sync receive should queue behind any in-progress local apply.
+
+### Forwarding validation
+
+(Codex round-1 BLOCKER 7: applyConfig recompiles dataplane, RETH
+state, FRR rules, ip rules. Forwarding IS at risk during the lock
+window.)
+
+- **Pre/post commit**: deploy on `bpfrx-fw` (standalone), run a
+  benign commit (whitespace-only config change), verify ping and
+  iperf3 (`-t 5`, ≥18 Gbps) still pass post-commit.
+- **Concurrent apply + iperf3**: start a 30s iperf3, mid-stream
+  trigger 3 concurrent CLI commits. Verify iperf3 completes
+  without TCP retransmits going crazy (acceptable: a few hundred
+  retransmits during the apply window; unacceptable: TCP flows
+  collapse).
+- **FRR reload tail**: a long apply (FRR reload up to 15s) holds
+  the mutex. Verify forwarding sessions remain stable across the
+  whole window.
+
+### Race-test design
+
+```go
+func TestApplyConfigSerialized(t *testing.T) {
+    d := newTestDaemon(t)
+    var wg sync.WaitGroup
+    var concurrent int32
+    var maxConcurrent int32
+    for i := 0; i < 10; i++ {
+        wg.Add(1)
+        go func(i int) {
+            defer wg.Done()
+            // Hijack one step of applyConfig to assert no overlap.
+            // Easier: instrument applyConfig with a sentinel that
+            // increments on enter, decrements on exit, atomically
+            // tracks max concurrent. After the test, max must be 1.
+            d.applyConfig(testConfigVariant(i))
+        }(i)
+    }
+    wg.Wait()
+    if atomic.LoadInt32(&maxConcurrent) > 1 {
+        t.Errorf("applyConfig was reentered: max concurrent = %d", maxConcurrent)
+    }
+}
+```
+
+Implementation note: the sentinel goes in a test-only build-tag-gated
+file or behind a debug counter that's exposed only in tests.
+
+## Alternatives considered
+
+1. **Worker goroutine + channel**: serialize via a queue rather than
+   a mutex. More invasive (changes the call shape from sync to
+   request-then-wait). Rejected unless the simple mutex turns out to
+   create deadlocks during reentrancy review.
+2. **Per-step locks (vrfMu, frrMu, ipsecMu, etc.)**: finer-grained
+   but doesn't fix the cross-step interleave the issue describes.
+   Rejected.
+3. **Defer lock until inner critical sections**: doesn't prevent
+   interleave; rejected.
+
+## Refs
+
+Closes #846. Identified during #844/#845 (`vrfsMu`) review.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
+	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.40.0
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
@@ -32,7 +33,6 @@ require (
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda // indirect
 )

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1515,7 +1515,7 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
-func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) configCommitHandler(w http.ResponseWriter, _ *http.Request) {
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -1530,18 +1530,7 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// #846: prefer context-aware ApplyFnCtx so a client cancel/timeout
-	// doesn't queue an apply behind a long FRR reload.
-	if s.applyFnCtx != nil {
-		if err := s.applyFnCtx(r.Context(), compiled); err != nil {
-			if r.Context().Err() == context.DeadlineExceeded {
-				writeError(w, http.StatusRequestTimeout, "apply: "+err.Error())
-				return
-			}
-			writeError(w, http.StatusServiceUnavailable, "apply: "+err.Error())
-			return
-		}
-	} else if s.applyFn != nil {
+	if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -1699,16 +1688,7 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if s.applyFnCtx != nil {
-		if err := s.applyFnCtx(r.Context(), compiled); err != nil {
-			if r.Context().Err() == context.DeadlineExceeded {
-				writeError(w, http.StatusRequestTimeout, "apply: "+err.Error())
-				return
-			}
-			writeError(w, http.StatusServiceUnavailable, "apply: "+err.Error())
-			return
-		}
-	} else if s.applyFn != nil {
+	if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	writeOK(w, map[string]string{"status": "ok"})

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1515,7 +1515,7 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
-func (s *Server) configCommitHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -1530,7 +1530,18 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, _ *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if s.applyFn != nil {
+	// #846: prefer context-aware ApplyFnCtx so a client cancel/timeout
+	// doesn't queue an apply behind a long FRR reload.
+	if s.applyFnCtx != nil {
+		if err := s.applyFnCtx(r.Context(), compiled); err != nil {
+			if r.Context().Err() == context.DeadlineExceeded {
+				writeError(w, http.StatusRequestTimeout, "apply: "+err.Error())
+				return
+			}
+			writeError(w, http.StatusServiceUnavailable, "apply: "+err.Error())
+			return
+		}
+	} else if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -1688,7 +1699,16 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if s.applyFn != nil {
+	if s.applyFnCtx != nil {
+		if err := s.applyFnCtx(r.Context(), compiled); err != nil {
+			if r.Context().Err() == context.DeadlineExceeded {
+				writeError(w, http.StatusRequestTimeout, "apply: "+err.Error())
+				return
+			}
+			writeError(w, http.StatusServiceUnavailable, "apply: "+err.Error())
+			return
+		}
+	} else if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	writeOK(w, map[string]string{"status": "ok"})

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1515,7 +1516,7 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
-func (s *Server) configCommitHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -1525,13 +1526,18 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	compiled, err := s.store.Commit()
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if s.commitFn == nil {
+		writeError(w, http.StatusInternalServerError, "commit handler not wired")
 		return
 	}
-	if s.applyFn != nil {
-		s.applyFn(compiled)
+	if _, err := s.commitFn(r.Context(), ""); err != nil {
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			writeError(w, http.StatusServiceUnavailable, "commit busy: "+err.Error())
+		default:
+			writeError(w, http.StatusBadRequest, err.Error())
+		}
+		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
 }
@@ -1682,14 +1688,18 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-
-	compiled, err := s.store.CommitConfirmed(req.Minutes)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if s.commitConfirmedFn == nil {
+		writeError(w, http.StatusInternalServerError, "commit-confirmed handler not wired")
 		return
 	}
-	if s.applyFn != nil {
-		s.applyFn(compiled)
+	if _, err := s.commitConfirmedFn(r.Context(), req.Minutes); err != nil {
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			writeError(w, http.StatusServiceUnavailable, "commit busy: "+err.Error())
+		default:
+			writeError(w, http.StatusBadRequest, err.Error())
+		}
+		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -55,7 +55,8 @@ type Config struct {
 	IPsec     *ipsec.Manager
 	DHCP      *dhcp.Manager
 	VRRPMgr   *vrrp.Manager       // native VRRP manager
-	ApplyFn   func(*config.Config) // daemon's applyConfig callback
+	ApplyFn    func(*config.Config)                        // daemon's applyConfig callback (sync)
+	ApplyFnCtx func(context.Context, *config.Config) error // #846: context-aware variant for HTTP commit handlers
 	// CompileHealthFn surfaces dataplane compile state via /health (#758).
 	// Returning a snapshot with EverSucceeded=false and FailureCount>0
 	// makes /health return 503 so operators see the degraded state
@@ -78,6 +79,7 @@ type Server struct {
 	dhcp        *dhcp.Manager
 	vrrpMgr         *vrrp.Manager
 	applyFn         func(*config.Config)
+	applyFnCtx      func(context.Context, *config.Config) error
 	compileHealthFn func() CompileHealthSnapshot
 	startTime       time.Time
 }
@@ -95,6 +97,7 @@ func NewServer(cfg Config) *Server {
 		dhcp:      cfg.DHCP,
 		vrrpMgr:         cfg.VRRPMgr,
 		applyFn:         cfg.ApplyFn,
+		applyFnCtx:      cfg.ApplyFnCtx,
 		compileHealthFn: cfg.CompileHealthFn,
 		startTime:       time.Now(),
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -54,8 +54,14 @@ type Config struct {
 	FRR       *frr.Manager
 	IPsec     *ipsec.Manager
 	DHCP      *dhcp.Manager
-	VRRPMgr   *vrrp.Manager       // native VRRP manager
-	ApplyFn   func(*config.Config) // daemon's applyConfig callback
+	VRRPMgr *vrrp.Manager // native VRRP manager
+	// #846: atomic commit+apply callbacks. The daemon holds its
+	// apply semaphore across configstore.Commit and applyConfig, so
+	// two concurrent committers can't interleave their commit→apply
+	// pairs. Returns ctx.Err() if the request is canceled before the
+	// semaphore is acquired (handlers translate to 408/503).
+	CommitFn          func(ctx context.Context, comment string) (*config.Config, error)
+	CommitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
 	// CompileHealthFn surfaces dataplane compile state via /health (#758).
 	// Returning a snapshot with EverSucceeded=false and FailureCount>0
 	// makes /health return 503 so operators see the degraded state
@@ -76,10 +82,11 @@ type Server struct {
 	frr         *frr.Manager
 	ipsec       *ipsec.Manager
 	dhcp        *dhcp.Manager
-	vrrpMgr         *vrrp.Manager
-	applyFn         func(*config.Config)
-	compileHealthFn func() CompileHealthSnapshot
-	startTime       time.Time
+	vrrpMgr           *vrrp.Manager
+	commitFn          func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
+	compileHealthFn   func() CompileHealthSnapshot
+	startTime         time.Time
 }
 
 // NewServer creates a new API server.
@@ -93,10 +100,11 @@ func NewServer(cfg Config) *Server {
 		frr:       cfg.FRR,
 		ipsec:     cfg.IPsec,
 		dhcp:      cfg.DHCP,
-		vrrpMgr:         cfg.VRRPMgr,
-		applyFn:         cfg.ApplyFn,
-		compileHealthFn: cfg.CompileHealthFn,
-		startTime:       time.Now(),
+		vrrpMgr:           cfg.VRRPMgr,
+		commitFn:          cfg.CommitFn,
+		commitConfirmedFn: cfg.CommitConfirmedFn,
+		compileHealthFn:   cfg.CompileHealthFn,
+		startTime:         time.Now(),
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -55,8 +55,7 @@ type Config struct {
 	IPsec     *ipsec.Manager
 	DHCP      *dhcp.Manager
 	VRRPMgr   *vrrp.Manager       // native VRRP manager
-	ApplyFn    func(*config.Config)                        // daemon's applyConfig callback (sync)
-	ApplyFnCtx func(context.Context, *config.Config) error // #846: context-aware variant for HTTP commit handlers
+	ApplyFn   func(*config.Config) // daemon's applyConfig callback
 	// CompileHealthFn surfaces dataplane compile state via /health (#758).
 	// Returning a snapshot with EverSucceeded=false and FailureCount>0
 	// makes /health return 503 so operators see the degraded state
@@ -79,7 +78,6 @@ type Server struct {
 	dhcp        *dhcp.Manager
 	vrrpMgr         *vrrp.Manager
 	applyFn         func(*config.Config)
-	applyFnCtx      func(context.Context, *config.Config) error
 	compileHealthFn func() CompileHealthSnapshot
 	startTime       time.Time
 }
@@ -97,7 +95,6 @@ func NewServer(cfg Config) *Server {
 		dhcp:      cfg.DHCP,
 		vrrpMgr:         cfg.VRRPMgr,
 		applyFn:         cfg.ApplyFn,
-		applyFnCtx:      cfg.ApplyFnCtx,
 		compileHealthFn: cfg.CompileHealthFn,
 		startTime:       time.Now(),
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -96,8 +96,12 @@ type CLI struct {
 	monitorFlow *monitorFlowState
 
 	// Command cancellation: Ctrl-C during a running external command cancels it.
-	cmdMu     sync.Mutex
-	cmdCancel context.CancelFunc
+	// commitCancel is a SEPARATE slot used by handleCommit so an
+	// external-command cancel and a commit cancel can never displace
+	// each other (the slots are single-writer per call site).
+	cmdMu        sync.Mutex
+	cmdCancel    context.CancelFunc
+	commitCancel context.CancelFunc
 }
 
 // New creates a new CLI.
@@ -631,12 +635,21 @@ func (c *CLI) Run() error {
 	go func() {
 		var lastInterrupt time.Time
 		for range sigCh {
-			// If an external command is running, cancel it.
+			// If a commit or an external command is running, cancel
+			// it. commitCancel takes priority because a commit
+			// hanging on the apply semaphore is the only path that
+			// actually needs ctx-aware cancellation; external
+			// commands fall back if no commit is in flight.
 			c.cmdMu.Lock()
-			cancel := c.cmdCancel
+			commitCancel := c.commitCancel
+			cmdCancel := c.cmdCancel
 			c.cmdMu.Unlock()
-			if cancel != nil {
-				cancel()
+			if commitCancel != nil {
+				commitCancel()
+				continue
+			}
+			if cmdCancel != nil {
+				cmdCancel()
 				continue
 			}
 			now := time.Now()

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -72,14 +72,20 @@ type CLI struct {
 	// wired — Build() falls back to all-invalid windows.
 	fwdSampler *fwdstatus.Sampler
 
-	// applyConfigFn is the daemon's full reconcile callback. When set,
-	// local CLI commits invoke this (the single source of truth used by
-	// gRPC/HTTP commits via ApplyFn) so every commit path runs through
-	// the same reconcile — including D3 RSS indirection reapply (#797
-	// H2). When nil (not wired), the CLI falls back to the legacy
-	// applyToDataplane() which covers dataplane/FRR/IPsec but misses
-	// daemon-level steps like D3 and cluster/VRRP reconcile.
+	// applyConfigFn is the daemon's full reconcile callback used by
+	// non-commit paths (e.g. confirm/rollback). For commits, the CLI
+	// prefers commitFn / commitConfirmedFn so the commit→apply pair
+	// is atomic under the daemon's apply semaphore (#846). When
+	// commitFn is nil (CLI spawned outside daemon), the CLI falls
+	// back to store.Commit() + applyConfigFn, and ultimately to
+	// applyToDataplane when neither is wired.
 	applyConfigFn func(*config.Config)
+	// #846: atomic commit+apply callbacks. When set, handleCommit
+	// routes through these instead of calling store.Commit directly.
+	// Same callback the HTTP/gRPC handlers use, so commits from all
+	// three paths serialize against each other.
+	commitFn          func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
 
 	// Fabric peer dialing for cluster-wide queries (fab0 + optional fab1).
 	fabricPeerAddrFn   func() []string
@@ -168,6 +174,18 @@ func (c *CLI) SetVRRPManager(m *vrrp.Manager) {
 // applyToDataplane() path.
 func (c *CLI) SetApplyConfigFn(fn func(*config.Config)) {
 	c.applyConfigFn = fn
+}
+
+// SetCommitFns wires the daemon's atomic commit+apply callbacks
+// (#846). When set, handleCommit routes through these instead of
+// calling store.Commit directly so the commit→apply pair is atomic
+// against HTTP/gRPC/event-engine commits.
+func (c *CLI) SetCommitFns(
+	commitFn func(ctx context.Context, comment string) (*config.Config, error),
+	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error),
+) {
+	c.commitFn = commitFn
+	c.commitConfirmedFn = commitConfirmedFn
 }
 
 // SetFabricPeer configures fabric peer dialing for cluster-wide queries.

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -303,22 +303,19 @@ func (c *CLI) runCommitConfirmed(minutes int) (*config.Config, error) {
 }
 
 // commitCtx returns a cancellable context registered with the CLI's
-// Ctrl-C handler (cmdCancel). The returned `done` cleans up the
-// registration; callers MUST defer it. Used by runCommit /
-// runCommitConfirmed so an operator can interrupt a commit that's
-// hung waiting for the daemon's apply semaphore.
+// Ctrl-C handler via the dedicated commitCancel slot (separate from
+// cmdCancel which is used by external commands). Single-writer per
+// call site means the cleanup can clear unconditionally — the slot
+// is only ever set/cleared by a runCommit pair. The returned `done`
+// MUST be deferred by the caller.
 func (c *CLI) commitCtx() (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cmdMu.Lock()
-	c.cmdCancel = cancel
+	c.commitCancel = cancel
 	c.cmdMu.Unlock()
 	return ctx, func() {
 		c.cmdMu.Lock()
-		if c.cmdCancel != nil {
-			// only clear if still ours (a nested handler hasn't
-			// already replaced it).
-			c.cmdCancel = nil
-		}
+		c.commitCancel = nil
 		c.cmdMu.Unlock()
 		cancel()
 	}

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -262,9 +262,16 @@ func (c *CLI) handleCommit(args []string) error {
 // commitApply (the legacy path used by standalone CLI without a
 // daemon). The atomic path serializes against HTTP/gRPC/event-engine
 // commits via d.applySem.
+//
+// Uses a cancellable context registered with the CLI's Ctrl-C
+// handler so an operator can interrupt a commit that's hung
+// waiting for the apply lock (e.g. a long-running peer-sync apply
+// holding it).
 func (c *CLI) runCommit(comment string) (*config.Config, error) {
 	if c.commitFn != nil {
-		return c.commitFn(context.Background(), comment)
+		ctx, done := c.commitCtx()
+		defer done()
+		return c.commitFn(ctx, comment)
 	}
 	var compiled *config.Config
 	var err error
@@ -283,7 +290,9 @@ func (c *CLI) runCommit(comment string) (*config.Config, error) {
 // runCommitConfirmed is the commit-confirmed analogue of runCommit.
 func (c *CLI) runCommitConfirmed(minutes int) (*config.Config, error) {
 	if c.commitConfirmedFn != nil {
-		return c.commitConfirmedFn(context.Background(), minutes)
+		ctx, done := c.commitCtx()
+		defer done()
+		return c.commitConfirmedFn(ctx, minutes)
 	}
 	compiled, err := c.store.CommitConfirmed(minutes)
 	if err != nil {
@@ -291,4 +300,26 @@ func (c *CLI) runCommitConfirmed(minutes int) (*config.Config, error) {
 	}
 	c.commitApply(compiled)
 	return compiled, nil
+}
+
+// commitCtx returns a cancellable context registered with the CLI's
+// Ctrl-C handler (cmdCancel). The returned `done` cleans up the
+// registration; callers MUST defer it. Used by runCommit /
+// runCommitConfirmed so an operator can interrupt a commit that's
+// hung waiting for the daemon's apply semaphore.
+func (c *CLI) commitCtx() (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cmdMu.Lock()
+	c.cmdCancel = cancel
+	c.cmdMu.Unlock()
+	return ctx, func() {
+		c.cmdMu.Lock()
+		if c.cmdCancel != nil {
+			// only clear if still ours (a nested handler hasn't
+			// already replaced it).
+			c.cmdCancel = nil
+		}
+		c.cmdMu.Unlock()
+		cancel()
+	}
 }

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -191,12 +192,11 @@ func (c *CLI) handleCommit(args []string) error {
 
 		diffSummary := c.store.CommitDiffSummary()
 
-		compiled, err := c.store.CommitWithDescription(desc)
+		compiled, err := c.runCommit(desc)
 		if err != nil {
 			return fmt.Errorf("commit failed: %w", err)
 		}
 
-		c.commitApply(compiled)
 		c.reloadSyslog(compiled)
 		c.refreshPrompt()
 
@@ -216,13 +216,11 @@ func (c *CLI) handleCommit(args []string) error {
 			}
 		}
 
-		compiled, err := c.store.CommitConfirmed(minutes)
+		compiled, err := c.runCommitConfirmed(minutes)
 		if err != nil {
 			return fmt.Errorf("commit confirmed failed: %w", err)
 		}
 
-		// Apply to dataplane (daemon full reconcile when wired).
-		c.commitApply(compiled)
 		c.reloadSyslog(compiled)
 		c.refreshPrompt()
 
@@ -242,13 +240,10 @@ func (c *CLI) handleCommit(args []string) error {
 	// Capture diff summary before commit (active will change)
 	diffSummary := c.store.CommitDiffSummary()
 
-	compiled, err := c.store.Commit()
+	compiled, err := c.runCommit("")
 	if err != nil {
 		return fmt.Errorf("commit failed: %w", err)
 	}
-
-	// Apply to dataplane (daemon full reconcile when wired).
-	c.commitApply(compiled)
 
 	// Hot-reload syslog clients
 	c.reloadSyslog(compiled)
@@ -260,4 +255,40 @@ func (c *CLI) handleCommit(args []string) error {
 		fmt.Println("commit complete")
 	}
 	return nil
+}
+
+// runCommit dispatches to the daemon's atomic commit+apply when
+// wired (#846); otherwise falls back to store.Commit followed by
+// commitApply (the legacy path used by standalone CLI without a
+// daemon). The atomic path serializes against HTTP/gRPC/event-engine
+// commits via d.applySem.
+func (c *CLI) runCommit(comment string) (*config.Config, error) {
+	if c.commitFn != nil {
+		return c.commitFn(context.Background(), comment)
+	}
+	var compiled *config.Config
+	var err error
+	if comment != "" {
+		compiled, err = c.store.CommitWithDescription(comment)
+	} else {
+		compiled, err = c.store.Commit()
+	}
+	if err != nil {
+		return nil, err
+	}
+	c.commitApply(compiled)
+	return compiled, nil
+}
+
+// runCommitConfirmed is the commit-confirmed analogue of runCommit.
+func (c *CLI) runCommitConfirmed(minutes int) (*config.Config, error) {
+	if c.commitConfirmedFn != nil {
+		return c.commitConfirmedFn(context.Background(), minutes)
+	}
+	compiled, err := c.store.CommitConfirmed(minutes)
+	if err != nil {
+		return nil, err
+	}
+	c.commitApply(compiled)
+	return compiled, nil
 }

--- a/pkg/daemon/apply_serialize_test.go
+++ b/pkg/daemon/apply_serialize_test.go
@@ -1,0 +1,58 @@
+// #846: Serialization contract for applyMu.
+//
+// applyConfig() is invoked from many entry points (HTTP/gRPC commits,
+// cluster sync recv, DHCP callbacks, config-poll, dynamic feeds, event
+// engine, in-process CLI commits, CLI auto-rollback). Before #846 these
+// could interleave across VRF/tunnel/FRR-reload steps and leave the
+// kernel inconsistent with the configstore's "active" config.
+//
+// Calling the real applyConfig in a unit test isn't practical — it
+// touches the dataplane, FRR, IPsec, and netlink. This test instead
+// pins the contract that the mutex itself provides: two goroutines
+// that take applyMu around their critical section never overlap. If a
+// future refactor moves the lock acquisition out of applyConfig (or
+// replaces it with a non-blocking variant), this test fails.
+package daemon
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestApplyMuSerializesConcurrentCallers(t *testing.T) {
+	d := &Daemon{}
+
+	var (
+		inFlight int32
+		maxSeen  int32
+		wg       sync.WaitGroup
+	)
+
+	const callers = 8
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			d.applyMu.Lock()
+			n := atomic.AddInt32(&inFlight, 1)
+			for {
+				cur := atomic.LoadInt32(&maxSeen)
+				if n <= cur || atomic.CompareAndSwapInt32(&maxSeen, cur, n) {
+					break
+				}
+			}
+			// Hold long enough that any missing serialization would
+			// be visible as inFlight > 1.
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddInt32(&inFlight, -1)
+			d.applyMu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxSeen); got != 1 {
+		t.Fatalf("applyMu must serialize callers; saw %d concurrent holders", got)
+	}
+}

--- a/pkg/daemon/apply_serialize_test.go
+++ b/pkg/daemon/apply_serialize_test.go
@@ -1,58 +1,96 @@
-// #846: Serialization contract for applyMu.
+// #846: Serialization contract for the apply semaphore.
 //
-// applyConfig() is invoked from many entry points (HTTP/gRPC commits,
-// cluster sync recv, DHCP callbacks, config-poll, dynamic feeds, event
-// engine, in-process CLI commits, CLI auto-rollback). Before #846 these
-// could interleave across VRF/tunnel/FRR-reload steps and leave the
-// kernel inconsistent with the configstore's "active" config.
+// applyConfig + commitAndApply + commitConfirmedAndApply all share
+// d.applySem so that two concurrent callers can never interleave
+// across VRF/tunnel/FRR-reload steps and so the commit→apply pair
+// is atomic per caller. These tests exercise the public API
+// (applyConfig directly; commit*AndApply via context-respecting
+// Acquire) and would fail if a future refactor:
 //
-// Calling the real applyConfig in a unit test isn't practical — it
-// touches the dataplane, FRR, IPsec, and netlink. This test instead
-// pins the contract that the mutex itself provides: two goroutines
-// that take applyMu around their critical section never overlap. If a
-// future refactor moves the lock acquisition out of applyConfig (or
-// replaces it with a non-blocking variant), this test fails.
+//   - Removed Acquire from applyConfig (TestApplyConfigSerializes
+//     would see >1 concurrent body invocation).
+//   - Removed Acquire from commitAndApply / commitConfirmedAndApply,
+//     or moved Commit() before Acquire (the held-semaphore test
+//     would not see a context.DeadlineExceeded — instead the call
+//     would panic on the nil store).
 package daemon
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
-func TestApplyMuSerializesConcurrentCallers(t *testing.T) {
-	d := &Daemon{}
+// applyConfig must serialize concurrent callers via d.applySem.
+// Uses applyBodyForTest as a seam so the body of applyConfigLocked
+// (which would otherwise touch d.dp / d.routing / d.frr) is replaced
+// with a counter that records the maximum concurrent invocations.
+func TestApplyConfigSerializes(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
 
 	var (
 		inFlight int32
 		maxSeen  int32
-		wg       sync.WaitGroup
 	)
+	d.applyBodyForTest = func(_ *config.Config) {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			cur := atomic.LoadInt32(&maxSeen)
+			if n <= cur || atomic.CompareAndSwapInt32(&maxSeen, cur, n) {
+				break
+			}
+		}
+		// Hold long enough that any missing serialization would
+		// be visible as inFlight > 1.
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+	}
 
 	const callers = 8
+	var wg sync.WaitGroup
 	wg.Add(callers)
 	for i := 0; i < callers; i++ {
 		go func() {
 			defer wg.Done()
-			d.applyMu.Lock()
-			n := atomic.AddInt32(&inFlight, 1)
-			for {
-				cur := atomic.LoadInt32(&maxSeen)
-				if n <= cur || atomic.CompareAndSwapInt32(&maxSeen, cur, n) {
-					break
-				}
-			}
-			// Hold long enough that any missing serialization would
-			// be visible as inFlight > 1.
-			time.Sleep(5 * time.Millisecond)
-			atomic.AddInt32(&inFlight, -1)
-			d.applyMu.Unlock()
+			d.applyConfig(nil)
 		}()
 	}
 	wg.Wait()
 
 	if got := atomic.LoadInt32(&maxSeen); got != 1 {
-		t.Fatalf("applyMu must serialize callers; saw %d concurrent holders", got)
+		t.Fatalf("applyConfig must serialize via applySem; saw %d concurrent body invocations", got)
+	}
+}
+
+// commitAndApply must Acquire the semaphore BEFORE calling
+// store.Commit. We hold the semaphore externally and run
+// commitAndApply with a tight deadline; the expected outcome is
+// context.DeadlineExceeded (proves Acquire blocked). If a future
+// refactor moved Commit() before Acquire, the call would either
+// panic on the nil store or succeed without ctx.Err.
+func TestCommitAndApplyRespectsSemaphore(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("setup acquire: %v", err)
+	}
+	defer d.applySem.Release(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := d.commitAndApply(ctx, "", false); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("commitAndApply must surface ctx err while semaphore is held; got %v", err)
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	if _, err := d.commitConfirmedAndApply(ctx2, 1, false); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("commitConfirmedAndApply must surface ctx err while semaphore is held; got %v", err)
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -994,11 +993,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 			GC:       d.gc,
 			Routing:  d.routing,
 			FRR:      d.frr,
-			IPsec:      d.ipsec,
-			DHCP:       d.dhcp,
-			VRRPMgr:    d.vrrpMgr,
-			ApplyFn:    d.applyConfig,
-			ApplyFnCtx: d.applyConfigCtx,
+			IPsec:    d.ipsec,
+			DHCP:     d.dhcp,
+			VRRPMgr:  d.vrrpMgr,
+			ApplyFn:  d.applyConfig,
 			// #758: surface compile state so /health returns 503
 			// when the dataplane has never compiled successfully.
 			CompileHealthFn: func() api.CompileHealthSnapshot {
@@ -1072,16 +1070,6 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.applyConfig(cfg)
 			d.syncConfigToPeer()
 		}
-		// #846: context-aware variant for gRPC commit handlers.
-		// Returns ErrApplyCanceled if the client cancels before the
-		// apply lock is acquired; otherwise behaves identically.
-		applyAndSyncCtx := func(ctx context.Context, cfg *config.Config) error {
-			if err := d.applyConfigCtx(ctx, cfg); err != nil {
-				return err
-			}
-			d.syncConfigToPeer()
-			return nil
-		}
 		grpcSrv := grpcapi.NewServer(d.opts.GRPCAddr, grpcapi.Config{
 			Store:      d.store,
 			DP:         d.dp,
@@ -1111,8 +1099,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return nil
 			},
-			ApplyFn:    applyAndSync,
-			ApplyFnCtx: applyAndSyncCtx,
+			ApplyFn: applyAndSync,
 			VRRPMgr: d.vrrpMgr,
 			RAMgr:   d.ra,
 			Version: d.opts.Version,
@@ -1552,8 +1539,6 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 	return resolved
 }
 
-// applyConfig applies a compiled config in the correct order:
-// 0. Create VRF devices and bind interfaces (routing instances)
 // bootstrapFromFile reads the text Junos config file and imports it as the
 // initial active configuration. This is called on first start when the DB
 // has no active config yet.
@@ -1582,79 +1567,24 @@ func (d *Daemon) bootstrapFromFile() error {
 	return nil
 }
 
+// applyConfig applies a compiled config in the correct order:
+// 0. Create VRF devices and bind interfaces (routing instances)
 // 1. Create tunnels (so interfaces exist for zone binding)
 // 2. Compile eBPF (attaches XDP/TC to interfaces including tunnels)
 // 3. Install static routes (global + per-instance)
 // 4. Apply FRR config (OSPF/BGP, global + per-VRF)
 // 5. Apply IPsec config (strongSwan)
 //
-// #846: applyConfig is the synchronous entry point. Holds applyMu
-// for the full call to serialize across all entry points. Callers
-// without a request context (DHCP, cluster sync goroutine, event
-// engine, CLI auto-rollback, in-process CLI) use this and block
-// until the lock is released.
+// #846: applyConfig holds applyMu for the full call. All entry
+// points — HTTP/gRPC commits, cluster sync recv, DHCP callbacks,
+// config-poll, dynamic feeds, event engine, in-process CLI commits,
+// CLI auto-rollback — serialize end-to-end through this mutex.
+// Two concurrent commits queue rather than interleave; the
+// operator-visible effect is "second commit waits" instead of
+// "second commit corrupts kernel state".
 func (d *Daemon) applyConfig(cfg *config.Config) {
 	d.applyMu.Lock()
 	defer d.applyMu.Unlock()
-	d.applyConfigLocked(cfg)
-}
-
-// ErrApplyCanceled is returned by applyConfigCtx when the caller's
-// context is canceled before the lock can be acquired. The canceled
-// caller's apply NEVER runs — the configured Config is dropped on
-// the floor. Only an apply that already held the lock at cancel
-// time continues to completion (it cannot be interrupted because
-// the body of applyConfig is not cancellation-safe — kernel route
-// writes, FRR reload, etc.).
-var ErrApplyCanceled = errors.New("applyConfig canceled before lock acquisition")
-
-// applyConfigCtx is the context-aware entry point used by HTTP and
-// gRPC commit handlers. If the caller's context is canceled before
-// we acquire applyMu, returns ErrApplyCanceled and the apply is
-// dropped. The body is identical otherwise.
-//
-// Implementation note: tryLockCtx spawns a goroutine that will
-// eventually acquire+release the lock to keep the mutex's invariant
-// balanced. That goroutine does NOT run the apply body — only the
-// canceling caller's slot is given back; the canceled config is
-// dropped.
-func (d *Daemon) applyConfigCtx(ctx context.Context, cfg *config.Config) error {
-	if !d.tryLockCtx(ctx, &d.applyMu) {
-		return ErrApplyCanceled
-	}
-	defer d.applyMu.Unlock()
-	d.applyConfigLocked(cfg)
-	return nil
-}
-
-// tryLockCtx acquires mu unless ctx is canceled first. On
-// cancellation, returns false but leaves a goroutine running that
-// will acquire-then-release the mutex when it eventually becomes
-// available. This goroutine does NOT execute any caller-visible
-// work — its sole purpose is to balance the lock count for the
-// abandoned acquisition attempt.
-func (d *Daemon) tryLockCtx(ctx context.Context, mu *sync.Mutex) bool {
-	acquired := make(chan struct{})
-	go func() {
-		mu.Lock()
-		close(acquired)
-	}()
-	select {
-	case <-acquired:
-		return true
-	case <-ctx.Done():
-		go func() {
-			<-acquired
-			mu.Unlock()
-		}()
-		return false
-	}
-}
-
-// applyConfigLocked is the existing applyConfig body. Callable
-// only with d.applyMu held — both applyConfig() and applyConfigCtx()
-// route through here.
-func (d *Daemon) applyConfigLocked(cfg *config.Config) {
 	// Reset VIP warning suppression so new config gets fresh warnings.
 	d.vipWarnedIfaces = nil
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1659,6 +1659,27 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bo
 	return compiled, nil
 }
 
+// syncAndApply is the cluster-sync-recv analogue of commitAndApply.
+// Holds applySem across configstore.SyncApply (peer-driven active
+// promotion) + applyConfigLocked, so a peer-sync can't interleave
+// between a local committer's Commit and applyConfig (which would
+// briefly leave store=peer-config but kernel=local-config).
+func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPreserve func(*config.ConfigTree)) (*config.Config, error) {
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer d.applySem.Release(1)
+
+	compiled, err := d.store.SyncApply(configText, chassisPreserve)
+	if err != nil {
+		return nil, err
+	}
+	if compiled != nil {
+		d.applyConfigLocked(compiled)
+	}
+	return compiled, nil
+}
+
 // commitConfirmedAndApply is the commit-confirmed analogue of
 // commitAndApply. Same atomicity guarantees.
 func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncPeer bool) (*config.Config, error) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -113,6 +114,14 @@ type Daemon struct {
 	vrrpMgr                    *vrrp.Manager
 	gc                         *conntrack.GC
 	startTime                  time.Time // daemon start time; used to suppress stale config sync
+
+	// #846: applyMu serializes applyConfig() across all entry points
+	// (HTTP/gRPC commits, cluster sync recv, DHCP callbacks, config-
+	// poll, dynamic feeds, event engine, in-process CLI commits, CLI
+	// auto-rollback). Without this, two concurrent callers can
+	// interleave across VRF/tunnel/FRR-reload steps and leave the
+	// kernel state inconsistent with the active config.
+	applyMu sync.Mutex
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
@@ -985,10 +994,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			GC:       d.gc,
 			Routing:  d.routing,
 			FRR:      d.frr,
-			IPsec:    d.ipsec,
-			DHCP:     d.dhcp,
-			VRRPMgr:  d.vrrpMgr,
-			ApplyFn:  d.applyConfig,
+			IPsec:      d.ipsec,
+			DHCP:       d.dhcp,
+			VRRPMgr:    d.vrrpMgr,
+			ApplyFn:    d.applyConfig,
+			ApplyFnCtx: d.applyConfigCtx,
 			// #758: surface compile state so /health returns 503
 			// when the dataplane has never compiled successfully.
 			CompileHealthFn: func() api.CompileHealthSnapshot {
@@ -1062,6 +1072,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.applyConfig(cfg)
 			d.syncConfigToPeer()
 		}
+		// #846: context-aware variant for gRPC commit handlers.
+		// Returns ErrApplyCanceled if the client cancels before the
+		// apply lock is acquired; otherwise behaves identically.
+		applyAndSyncCtx := func(ctx context.Context, cfg *config.Config) error {
+			if err := d.applyConfigCtx(ctx, cfg); err != nil {
+				return err
+			}
+			d.syncConfigToPeer()
+			return nil
+		}
 		grpcSrv := grpcapi.NewServer(d.opts.GRPCAddr, grpcapi.Config{
 			Store:      d.store,
 			DP:         d.dp,
@@ -1091,7 +1111,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return nil
 			},
-			ApplyFn: applyAndSync,
+			ApplyFn:    applyAndSync,
+			ApplyFnCtx: applyAndSyncCtx,
 			VRRPMgr: d.vrrpMgr,
 			RAMgr:   d.ra,
 			Version: d.opts.Version,
@@ -1566,7 +1587,74 @@ func (d *Daemon) bootstrapFromFile() error {
 // 3. Install static routes (global + per-instance)
 // 4. Apply FRR config (OSPF/BGP, global + per-VRF)
 // 5. Apply IPsec config (strongSwan)
+//
+// #846: applyConfig is the synchronous entry point. Holds applyMu
+// for the full call to serialize across all entry points. Callers
+// without a request context (DHCP, cluster sync goroutine, event
+// engine, CLI auto-rollback, in-process CLI) use this and block
+// until the lock is released.
 func (d *Daemon) applyConfig(cfg *config.Config) {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	d.applyConfigLocked(cfg)
+}
+
+// ErrApplyCanceled is returned by applyConfigCtx when the caller's
+// context is canceled before the lock can be acquired. The canceled
+// caller's apply NEVER runs — the configured Config is dropped on
+// the floor. Only an apply that already held the lock at cancel
+// time continues to completion (it cannot be interrupted because
+// the body of applyConfig is not cancellation-safe — kernel route
+// writes, FRR reload, etc.).
+var ErrApplyCanceled = errors.New("applyConfig canceled before lock acquisition")
+
+// applyConfigCtx is the context-aware entry point used by HTTP and
+// gRPC commit handlers. If the caller's context is canceled before
+// we acquire applyMu, returns ErrApplyCanceled and the apply is
+// dropped. The body is identical otherwise.
+//
+// Implementation note: tryLockCtx spawns a goroutine that will
+// eventually acquire+release the lock to keep the mutex's invariant
+// balanced. That goroutine does NOT run the apply body — only the
+// canceling caller's slot is given back; the canceled config is
+// dropped.
+func (d *Daemon) applyConfigCtx(ctx context.Context, cfg *config.Config) error {
+	if !d.tryLockCtx(ctx, &d.applyMu) {
+		return ErrApplyCanceled
+	}
+	defer d.applyMu.Unlock()
+	d.applyConfigLocked(cfg)
+	return nil
+}
+
+// tryLockCtx acquires mu unless ctx is canceled first. On
+// cancellation, returns false but leaves a goroutine running that
+// will acquire-then-release the mutex when it eventually becomes
+// available. This goroutine does NOT execute any caller-visible
+// work — its sole purpose is to balance the lock count for the
+// abandoned acquisition attempt.
+func (d *Daemon) tryLockCtx(ctx context.Context, mu *sync.Mutex) bool {
+	acquired := make(chan struct{})
+	go func() {
+		mu.Lock()
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		return true
+	case <-ctx.Done():
+		go func() {
+			<-acquired
+			mu.Unlock()
+		}()
+		return false
+	}
+}
+
+// applyConfigLocked is the existing applyConfig body. Callable
+// only with d.applyMu held — both applyConfig() and applyConfigCtx()
+// route through here.
+func (d *Daemon) applyConfigLocked(cfg *config.Config) {
 	// Reset VIP warning suppression so new config gets fresh warnings.
 	d.vipWarnedIfaces = nil
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/psaab/xpf/pkg/api"
 	"github.com/psaab/xpf/pkg/cli"
@@ -114,13 +115,23 @@ type Daemon struct {
 	gc                         *conntrack.GC
 	startTime                  time.Time // daemon start time; used to suppress stale config sync
 
-	// #846: applyMu serializes applyConfig() across all entry points
-	// (HTTP/gRPC commits, cluster sync recv, DHCP callbacks, config-
-	// poll, dynamic feeds, event engine, in-process CLI commits, CLI
-	// auto-rollback). Without this, two concurrent callers can
-	// interleave across VRF/tunnel/FRR-reload steps and leave the
-	// kernel state inconsistent with the active config.
-	applyMu sync.Mutex
+	// #846: applySem (capacity 1) serializes applyConfig + the
+	// commit→apply pair across all entry points (HTTP/gRPC commits,
+	// cluster sync recv, DHCP callbacks, config-poll, dynamic feeds,
+	// event engine, in-process CLI commits, CLI auto-rollback).
+	// Without this, two concurrent callers can interleave across
+	// VRF/tunnel/FRR-reload steps, or one caller's commit can
+	// interleave between another's commit and apply, leaving
+	// configstore/kernel divergent. Used as a semaphore (not a
+	// sync.Mutex) so handlers can Acquire(ctx, 1) and surface a 503
+	// to the client when the lock holder is slow, instead of
+	// hanging the request indefinitely.
+	applySem *semaphore.Weighted
+	// applyBodyForTest, when non-nil, replaces applyConfigLocked's
+	// body. Test-only seam used by apply_serialize_test.go to
+	// exercise the semaphore contract through the real applyConfig
+	// / commitAndApply paths without standing up the full dataplane.
+	applyBodyForTest func(*config.Config)
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
@@ -407,6 +418,7 @@ func New(opts Options) *Daemon {
 		localFailoverCommitTimeout: 3 * time.Second,
 		localFailoverCommitDelay:   200 * time.Millisecond,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
+		applySem:                   semaphore.NewWeighted(1),
 	}
 }
 
@@ -996,7 +1008,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 			IPsec:    d.ipsec,
 			DHCP:     d.dhcp,
 			VRRPMgr:  d.vrrpMgr,
-			ApplyFn:  d.applyConfig,
+			// HTTP commits don't sync to peer (preserves prior
+			// behavior; see #846 for follow-up).
+			CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
+				return d.commitAndApply(ctx, comment, false)
+			},
+			CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
+				return d.commitConfirmedAndApply(ctx, minutes, false)
+			},
 			// #758: surface compile state so /health returns 503
 			// when the dataplane has never compiled successfully.
 			CompileHealthFn: func() api.CompileHealthSnapshot {
@@ -1065,11 +1084,6 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	// Start gRPC API server.
 	{
-		// Wrap applyConfig to also sync config to cluster peer after commit.
-		applyAndSync := func(cfg *config.Config) {
-			d.applyConfig(cfg)
-			d.syncConfigToPeer()
-		}
 		grpcSrv := grpcapi.NewServer(d.opts.GRPCAddr, grpcapi.Config{
 			Store:      d.store,
 			DP:         d.dp,
@@ -1099,7 +1113,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return nil
 			},
-			ApplyFn: applyAndSync,
+			// gRPC commits sync to cluster peer atomically inside
+			// the apply lock so the peer can never observe an apply
+			// that hasn't yet been propagated.
+			CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
+				return d.commitAndApply(ctx, comment, true)
+			},
+			CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
+				return d.commitConfirmedAndApply(ctx, minutes, true)
+			},
 			VRRPMgr: d.vrrpMgr,
 			RAMgr:   d.ra,
 			Version: d.opts.Version,
@@ -1154,9 +1176,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		shell.SetVersion(d.opts.Version)
 		shell.SetForwardingSampler(fwdSampler)
 		// #797 H2: route in-process CLI commits through the daemon's
-		// full reconcile (same path gRPC/HTTP use via ApplyFn) so D3
-		// RSS indirection reapply, cluster/VRRP, DHCP etc. converge
-		// on every commit — not only the subset applyToDataplane() did.
+		// full reconcile so D3 RSS indirection reapply, cluster/VRRP,
+		// DHCP etc. converge on every commit — not only the subset
+		// applyToDataplane() did. Same path gRPC/HTTP commits take
+		// via commitAndApply (which calls applyConfig under
+		// d.applySem).
 		shell.SetApplyConfigFn(d.applyConfig)
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
@@ -1567,24 +1591,84 @@ func (d *Daemon) bootstrapFromFile() error {
 	return nil
 }
 
-// applyConfig applies a compiled config in the correct order:
-// 0. Create VRF devices and bind interfaces (routing instances)
-// 1. Create tunnels (so interfaces exist for zone binding)
-// 2. Compile eBPF (attaches XDP/TC to interfaces including tunnels)
-// 3. Install static routes (global + per-instance)
-// 4. Apply FRR config (OSPF/BGP, global + per-VRF)
-// 5. Apply IPsec config (strongSwan)
+// applyConfig applies a compiled config to the dataplane / kernel.
+// Wraps applyConfigLocked under the apply semaphore for non-context
+// callers (DHCP callbacks, config-poll, dynamic feeds, event engine,
+// in-process CLI commits, CLI auto-rollback, cluster sync recv).
+// Always succeeds in acquiring the lock because Background never
+// cancels.
 //
-// #846: applyConfig holds applyMu for the full call. All entry
-// points — HTTP/gRPC commits, cluster sync recv, DHCP callbacks,
-// config-poll, dynamic feeds, event engine, in-process CLI commits,
-// CLI auto-rollback — serialize end-to-end through this mutex.
-// Two concurrent commits queue rather than interleave; the
-// operator-visible effect is "second commit waits" instead of
-// "second commit corrupts kernel state".
+// #846: HTTP/gRPC commit handlers go through commitAndApply /
+// commitConfirmedAndApply instead, which take the same semaphore
+// with a request-bound context so a slow lock holder surfaces 503
+// to the client rather than hanging the request.
 func (d *Daemon) applyConfig(cfg *config.Config) {
-	d.applyMu.Lock()
-	defer d.applyMu.Unlock()
+	_ = d.applySem.Acquire(context.Background(), 1)
+	defer d.applySem.Release(1)
+	d.applyConfigLocked(cfg)
+}
+
+// commitAndApply atomically promotes the candidate config and
+// applies it. Holds applySem across configstore.Commit and
+// applyConfigLocked so two concurrent committers can't interleave
+// their commit→apply pairs (which would let kernel state lag store
+// state). Optionally syncs to the cluster peer inside the lock.
+//
+// If ctx is canceled before the semaphore is acquired, returns
+// ctx.Err() and NEITHER commit nor apply runs — no divergence. Once
+// the semaphore is held, commit and apply run to completion;
+// cancellation past that point is ignored (applyConfigLocked is not
+// safe to interrupt mid-stream — kernel route writes, FRR reload,
+// etc.).
+func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bool) (*config.Config, error) {
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer d.applySem.Release(1)
+
+	var compiled *config.Config
+	var err error
+	if comment != "" {
+		compiled, err = d.store.CommitWithDescription(comment)
+	} else {
+		compiled, err = d.store.Commit()
+	}
+	if err != nil {
+		return nil, err
+	}
+	d.applyConfigLocked(compiled)
+	if syncPeer {
+		d.syncConfigToPeer()
+	}
+	return compiled, nil
+}
+
+// commitConfirmedAndApply is the commit-confirmed analogue of
+// commitAndApply. Same atomicity guarantees.
+func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncPeer bool) (*config.Config, error) {
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer d.applySem.Release(1)
+
+	compiled, err := d.store.CommitConfirmed(minutes)
+	if err != nil {
+		return nil, err
+	}
+	d.applyConfigLocked(compiled)
+	if syncPeer {
+		d.syncConfigToPeer()
+	}
+	return compiled, nil
+}
+
+// applyConfigLocked runs the actual reconcile pipeline. MUST be
+// called with d.applySem held.
+func (d *Daemon) applyConfigLocked(cfg *config.Config) {
+	if d.applyBodyForTest != nil {
+		d.applyBodyForTest(cfg)
+		return
+	}
 	// Reset VIP warning suppression so new config gets fresh warnings.
 	d.vipWarnedIfaces = nil
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -854,7 +854,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	// Start event-options engine if configured.
 	if cfg := d.store.ActiveConfig(); cfg != nil && len(cfg.EventOptions) > 0 {
-		d.eventEngine = eventengine.New(d.store, d.applyConfig)
+		// #846: route through commitAndApply so the engine's commit
+		// serializes with HTTP/gRPC commits under d.applySem.
+		// Event-options changes don't sync to peer (the engine fires
+		// independently on each node based on local RPM events).
+		d.eventEngine = eventengine.New(d.store, func(ctx context.Context, comment string) (*config.Config, error) {
+			return d.commitAndApply(ctx, comment, false)
+		})
 		d.eventEngine.Apply(cfg.EventOptions)
 		if d.rpm != nil {
 			d.rpm.SetEventCallback(d.eventEngine.HandleEvent)
@@ -1175,13 +1181,23 @@ func (d *Daemon) Run(ctx context.Context) error {
 		shell := cli.New(d.store, d.dp, eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
 		shell.SetVersion(d.opts.Version)
 		shell.SetForwardingSampler(fwdSampler)
-		// #797 H2: route in-process CLI commits through the daemon's
-		// full reconcile so D3 RSS indirection reapply, cluster/VRRP,
-		// DHCP etc. converge on every commit — not only the subset
-		// applyToDataplane() did. Same path gRPC/HTTP commits take
-		// via commitAndApply (which calls applyConfig under
-		// d.applySem).
+		// #797 H2 / #846: route in-process CLI commits through the
+		// daemon's atomic commit+apply so they serialize against
+		// HTTP/gRPC/event-engine commits under d.applySem.
+		// applyConfigFn stays wired for non-commit paths (rollback,
+		// confirm) that still need the full reconcile.
 		shell.SetApplyConfigFn(d.applyConfig)
+		shell.SetCommitFns(
+			func(ctx context.Context, comment string) (*config.Config, error) {
+				// In-process CLI commits don't sync to peer (the
+				// CLI is local; preserves prior per-transport
+				// behavior, same as HTTP).
+				return d.commitAndApply(ctx, comment, false)
+			},
+			func(ctx context.Context, minutes int) (*config.Config, error) {
+				return d.commitConfirmedAndApply(ctx, minutes, false)
+			},
+		)
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -339,15 +339,14 @@ func (d *Daemon) handleConfigSync(configText string) {
 	}
 	slog.Info("cluster: accepting config sync from peer", "size", len(configText))
 
-	compiled, err := d.store.SyncApply(configText, nil)
-	if err != nil {
+	// #846: route through syncAndApply so the peer's
+	// SyncApply(active promotion) + applyConfig run atomically
+	// under d.applySem. Without this, a local commitAndApply could
+	// interleave between the two and briefly leave store and kernel
+	// disagreeing.
+	if _, err := d.syncAndApply(context.Background(), configText, nil); err != nil {
 		slog.Error("cluster: config sync apply failed", "err", err)
 		return
-	}
-
-	// Apply the compiled config to the dataplane.
-	if compiled != nil {
-		d.applyConfig(compiled)
 	}
 	slog.Info("cluster: config sync applied successfully")
 }

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -3,6 +3,7 @@
 package eventengine
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,15 +15,18 @@ import (
 	"github.com/psaab/xpf/pkg/rpm"
 )
 
-// ApplyFn is called after a successful commit to apply the new configuration.
-type ApplyFn func(*config.Config)
+// CommitFn atomically promotes the candidate to active and applies
+// it to the dataplane. The daemon's commitAndApply implementation
+// holds the apply semaphore across both steps so the engine's
+// commit can't interleave with another caller's commit/apply pair.
+type CommitFn func(ctx context.Context, comment string) (*config.Config, error)
 
 // Engine evaluates event-options policies against RPM events.
 type Engine struct {
 	mu       sync.Mutex
 	policies []*config.EventPolicy
 	store    *configstore.Store
-	applyFn  ApplyFn
+	commitFn CommitFn
 
 	// Temporal tracking: policy name → event name → sliding window of timestamps
 	windows map[string]map[string][]time.Time
@@ -34,11 +38,14 @@ type Engine struct {
 // Minimum time between successive triggers of the same policy.
 const policyCooldown = 30 * time.Second
 
-// New creates an event engine.
-func New(store *configstore.Store, applyFn ApplyFn) *Engine {
+// New creates an event engine. commitFn is the daemon's atomic
+// commit+apply callback (see #846); when non-nil, the engine routes
+// its committed configs through it so they serialize with HTTP/gRPC
+// commits. When nil (tests), commits succeed but no apply runs.
+func New(store *configstore.Store, commitFn CommitFn) *Engine {
 	return &Engine{
 		store:       store,
-		applyFn:     applyFn,
+		commitFn:    commitFn,
 		windows:     make(map[string]map[string][]time.Time),
 		lastTrigger: make(map[string]time.Time),
 	}
@@ -281,23 +288,26 @@ func (e *Engine) executeCommands(pol *config.EventPolicy) {
 		}
 	}
 
-	// Commit
-	compiled, err := e.store.Commit()
-	if err != nil {
+	// #846: route through the daemon's atomic commit+apply so this
+	// commit serializes with HTTP/gRPC commits. Without this, the
+	// engine's store.Commit could interleave between another caller's
+	// commit and apply, leaving configstore/kernel divergent.
+	if e.commitFn == nil {
+		// Standalone (tests): just commit; no apply.
+		if _, err := e.store.Commit(); err != nil {
+			slog.Warn("event-options: commit failed", "policy", pol.Name, "err", err)
+		}
+		e.store.ExitConfigure()
+		return
+	}
+	if _, err := e.commitFn(context.Background(), ""); err != nil {
 		slog.Warn("event-options: commit failed", "policy", pol.Name, "err", err)
 		e.store.ExitConfigure()
 		return
 	}
-
-	// Exit configure mode to release the lock
 	e.store.ExitConfigure()
 
 	slog.Info("event-options: configuration committed",
 		"policy", pol.Name,
 		"commands", fmt.Sprintf("%d", len(pol.ThenCommands)))
-
-	// Apply the new configuration
-	if e.applyFn != nil && compiled != nil {
-		e.applyFn(compiled)
-	}
 }

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -49,7 +49,8 @@ type Config struct {
 	RPMResultsFn     func() []*rpm.ProbeResult        // returns live RPM results
 	FeedsFn          func() map[string]feeds.FeedInfo // returns live feed status
 	LLDPNeighborsFn  func() []*lldp.Neighbor          // returns live LLDP neighbors
-	ApplyFn          func(*config.Config)             // daemon's applyConfig callback
+	ApplyFn          func(*config.Config)             // daemon's applyConfig callback (sync)
+	ApplyFnCtx       func(context.Context, *config.Config) error // #846: context-aware variant; commit handlers propagate request ctx so client cancel/timeout doesn't queue forever
 	VRRPMgr          *vrrp.Manager                    // native VRRP manager
 	RAMgr            *ra.Manager                      // embedded RA sender manager
 	Version          string                           // software version string
@@ -75,6 +76,7 @@ type Server struct {
 	feedsFn            func() map[string]feeds.FeedInfo
 	lldpNeighborsFn    func() []*lldp.Neighbor
 	applyFn            func(*config.Config)
+	applyFnCtx         func(context.Context, *config.Config) error
 	vrrpMgr            *vrrp.Manager
 	raMgr              *ra.Manager
 	fwdSampler         *fwdstatus.Sampler
@@ -136,6 +138,7 @@ func NewServer(addr string, cfg Config) *Server {
 		feedsFn:          cfg.FeedsFn,
 		lldpNeighborsFn:  cfg.LLDPNeighborsFn,
 		applyFn:          cfg.ApplyFn,
+		applyFnCtx:       cfg.ApplyFnCtx,
 		vrrpMgr:          cfg.VRRPMgr,
 		raMgr:            cfg.RAMgr,
 		fwdSampler:       cfg.FwdSampler,

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -49,8 +49,7 @@ type Config struct {
 	RPMResultsFn     func() []*rpm.ProbeResult        // returns live RPM results
 	FeedsFn          func() map[string]feeds.FeedInfo // returns live feed status
 	LLDPNeighborsFn  func() []*lldp.Neighbor          // returns live LLDP neighbors
-	ApplyFn          func(*config.Config)             // daemon's applyConfig callback (sync)
-	ApplyFnCtx       func(context.Context, *config.Config) error // #846: context-aware variant; commit handlers propagate request ctx so client cancel/timeout doesn't queue forever
+	ApplyFn          func(*config.Config)             // daemon's applyConfig callback
 	VRRPMgr          *vrrp.Manager                    // native VRRP manager
 	RAMgr            *ra.Manager                      // embedded RA sender manager
 	Version          string                           // software version string
@@ -76,7 +75,6 @@ type Server struct {
 	feedsFn            func() map[string]feeds.FeedInfo
 	lldpNeighborsFn    func() []*lldp.Neighbor
 	applyFn            func(*config.Config)
-	applyFnCtx         func(context.Context, *config.Config) error
 	vrrpMgr            *vrrp.Manager
 	raMgr              *ra.Manager
 	fwdSampler         *fwdstatus.Sampler
@@ -138,7 +136,6 @@ func NewServer(addr string, cfg Config) *Server {
 		feedsFn:          cfg.FeedsFn,
 		lldpNeighborsFn:  cfg.LLDPNeighborsFn,
 		applyFn:          cfg.ApplyFn,
-		applyFnCtx:       cfg.ApplyFnCtx,
 		vrrpMgr:          cfg.VRRPMgr,
 		raMgr:            cfg.RAMgr,
 		fwdSampler:       cfg.FwdSampler,

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -49,7 +49,14 @@ type Config struct {
 	RPMResultsFn     func() []*rpm.ProbeResult        // returns live RPM results
 	FeedsFn          func() map[string]feeds.FeedInfo // returns live feed status
 	LLDPNeighborsFn  func() []*lldp.Neighbor          // returns live LLDP neighbors
-	ApplyFn          func(*config.Config)             // daemon's applyConfig callback
+	// #846: atomic commit+apply callbacks. The daemon holds its
+	// apply semaphore across configstore.Commit, applyConfig, and
+	// (for gRPC) syncConfigToPeer, so two concurrent committers
+	// can't interleave their commit→apply pairs. Returns ctx.Err()
+	// if the request is canceled before the semaphore is acquired
+	// (handlers translate to DeadlineExceeded/Canceled).
+	CommitFn          func(ctx context.Context, comment string) (*config.Config, error)
+	CommitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
 	VRRPMgr          *vrrp.Manager                    // native VRRP manager
 	RAMgr            *ra.Manager                      // embedded RA sender manager
 	Version          string                           // software version string
@@ -74,7 +81,8 @@ type Server struct {
 	rpmResultsFn       func() []*rpm.ProbeResult
 	feedsFn            func() map[string]feeds.FeedInfo
 	lldpNeighborsFn    func() []*lldp.Neighbor
-	applyFn            func(*config.Config)
+	commitFn           func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn  func(ctx context.Context, minutes int) (*config.Config, error)
 	vrrpMgr            *vrrp.Manager
 	raMgr              *ra.Manager
 	fwdSampler         *fwdstatus.Sampler
@@ -133,9 +141,10 @@ func NewServer(addr string, cfg Config) *Server {
 		dhcp:             cfg.DHCP,
 		dhcpServer:       cfg.DHCPServer,
 		rpmResultsFn:     cfg.RPMResultsFn,
-		feedsFn:          cfg.FeedsFn,
-		lldpNeighborsFn:  cfg.LLDPNeighborsFn,
-		applyFn:          cfg.ApplyFn,
+		feedsFn:           cfg.FeedsFn,
+		lldpNeighborsFn:   cfg.LLDPNeighborsFn,
+		commitFn:          cfg.CommitFn,
+		commitConfirmedFn: cfg.CommitConfirmedFn,
 		vrrpMgr:          cfg.VRRPMgr,
 		raMgr:            cfg.RAMgr,
 		fwdSampler:       cfg.FwdSampler,

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -140,7 +140,7 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 	return &pb.LoadResponse{}, nil
 }
 
-func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
+func (s *Server) Commit(_ context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
 	// If a confirmed commit is pending, confirm it
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
@@ -162,16 +162,7 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	// #846: prefer context-aware ApplyFnCtx when available so client
-	// cancel/timeout doesn't queue an apply behind a long FRR reload.
-	if s.applyFnCtx != nil {
-		if err := s.applyFnCtx(ctx, compiled); err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				return nil, status.Errorf(codes.DeadlineExceeded, "apply: %v", err)
-			}
-			return nil, status.Errorf(codes.Canceled, "apply: %v", err)
-		}
-	} else if s.applyFn != nil {
+	if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	return &pb.CommitResponse{Summary: summary}, nil
@@ -184,19 +175,12 @@ func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.C
 	return &pb.CommitCheckResponse{}, nil
 }
 
-func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
+func (s *Server) CommitConfirmed(_ context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
 	compiled, err := s.store.CommitConfirmed(int(req.Minutes))
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if s.applyFnCtx != nil {
-		if err := s.applyFnCtx(ctx, compiled); err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				return nil, status.Errorf(codes.DeadlineExceeded, "apply: %v", err)
-			}
-			return nil, status.Errorf(codes.Canceled, "apply: %v", err)
-		}
-	} else if s.applyFn != nil {
+	if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	return &pb.CommitConfirmedResponse{}, nil

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -2,9 +2,9 @@ package grpcapi
 
 import (
 	"context"
+	"errors"
 	"strings"
 
-	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -140,7 +140,7 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 	return &pb.LoadResponse{}, nil
 }
 
-func (s *Server) Commit(_ context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
+func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
 	// If a confirmed commit is pending, confirm it
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
@@ -152,18 +152,18 @@ func (s *Server) Commit(_ context.Context, req *pb.CommitRequest) (*pb.CommitRes
 	// Capture diff summary before commit (active will change)
 	summary := s.store.CommitDiffSummary()
 
-	var compiled *config.Config
-	var err error
-	if req.Comment != "" {
-		compiled, err = s.store.CommitWithDescription(req.Comment)
-	} else {
-		compiled, err = s.store.Commit()
+	if s.commitFn == nil {
+		return nil, status.Errorf(codes.Internal, "commit handler not wired")
 	}
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if s.applyFn != nil {
-		s.applyFn(compiled)
+	if _, err := s.commitFn(ctx, req.Comment); err != nil {
+		switch {
+		case errors.Is(err, context.Canceled):
+			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
+		case errors.Is(err, context.DeadlineExceeded):
+			return nil, status.Errorf(codes.DeadlineExceeded, "commit busy: %v", err)
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
 	}
 	return &pb.CommitResponse{Summary: summary}, nil
 }
@@ -175,13 +175,19 @@ func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.C
 	return &pb.CommitCheckResponse{}, nil
 }
 
-func (s *Server) CommitConfirmed(_ context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
-	compiled, err := s.store.CommitConfirmed(int(req.Minutes))
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
+	if s.commitConfirmedFn == nil {
+		return nil, status.Errorf(codes.Internal, "commit-confirmed handler not wired")
 	}
-	if s.applyFn != nil {
-		s.applyFn(compiled)
+	if _, err := s.commitConfirmedFn(ctx, int(req.Minutes)); err != nil {
+		switch {
+		case errors.Is(err, context.Canceled):
+			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
+		case errors.Is(err, context.DeadlineExceeded):
+			return nil, status.Errorf(codes.DeadlineExceeded, "commit busy: %v", err)
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
 	}
 	return &pb.CommitConfirmedResponse{}, nil
 }

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -140,7 +140,7 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 	return &pb.LoadResponse{}, nil
 }
 
-func (s *Server) Commit(_ context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
+func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitResponse, error) {
 	// If a confirmed commit is pending, confirm it
 	if s.store.IsConfirmPending() {
 		if err := s.store.ConfirmCommit(); err != nil {
@@ -162,7 +162,16 @@ func (s *Server) Commit(_ context.Context, req *pb.CommitRequest) (*pb.CommitRes
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if s.applyFn != nil {
+	// #846: prefer context-aware ApplyFnCtx when available so client
+	// cancel/timeout doesn't queue an apply behind a long FRR reload.
+	if s.applyFnCtx != nil {
+		if err := s.applyFnCtx(ctx, compiled); err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, status.Errorf(codes.DeadlineExceeded, "apply: %v", err)
+			}
+			return nil, status.Errorf(codes.Canceled, "apply: %v", err)
+		}
+	} else if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	return &pb.CommitResponse{Summary: summary}, nil
@@ -175,12 +184,19 @@ func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.C
 	return &pb.CommitCheckResponse{}, nil
 }
 
-func (s *Server) CommitConfirmed(_ context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
+func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
 	compiled, err := s.store.CommitConfirmed(int(req.Minutes))
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if s.applyFn != nil {
+	if s.applyFnCtx != nil {
+		if err := s.applyFnCtx(ctx, compiled); err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, status.Errorf(codes.DeadlineExceeded, "apply: %v", err)
+			}
+			return nil, status.Errorf(codes.Canceled, "apply: %v", err)
+		}
+	} else if s.applyFn != nil {
 		s.applyFn(compiled)
 	}
 	return &pb.CommitConfirmedResponse{}, nil


### PR DESCRIPTION
## Summary

Adds `applySem *semaphore.Weighted` (capacity 1) on the daemon and serializes the **commit→apply pair** under it, not just `applyConfig`'s body.

Two new daemon methods:

- `commitAndApply(ctx, comment, syncPeer)`
- `commitConfirmedAndApply(ctx, minutes, syncPeer)`

Both `Acquire(ctx, 1)` first, then call `configstore.Commit{,WithDescription,Confirmed}`, then `applyConfigLocked`, then optionally `syncConfigToPeer` — all under one semaphore hold. HTTP wires `syncPeer=false`, gRPC wires `syncPeer=true` (preserves existing per-transport behavior).

## Why

Codex hostile review of the simpler "mutex around `applyConfig`" form found three real blockers:

1. **`configstore.Commit()` ran in handlers BEFORE `applyFn(compiled)`.** A second caller's commit could interleave between the first caller's commit and apply. Final state could be store=B, kernel=A — divergent.
2. **HTTP/gRPC handlers ignored request context entirely.** Clients hung indefinitely when apply was slow with no error surfaced.
3. **The previous serialization test locked `applyMu` directly and never called `applyConfig`** — a future refactor that removed the lock from `applyConfig` would still pass.

This refactor addresses all three:

- Commit and apply both happen under the same lock acquisition → atomic.
- `Acquire(ctx, 1)` respects the request context → handlers translate `ctx.Err()` into HTTP 503 / gRPC `DeadlineExceeded`/`Canceled`.
- Tests now exercise the public API (`applyConfig`, `commitAndApply`, `commitConfirmedAndApply`) and pin the semaphore contract via a test seam.

## Field changes

- `api.Config.ApplyFn` removed → replaced with `CommitFn` + `CommitConfirmedFn`.
- `grpcapi.Config.ApplyFn` removed → replaced with `CommitFn` + `CommitConfirmedFn`.
- `daemon.applyMu sync.Mutex` removed → replaced with `applySem *semaphore.Weighted`.
- `daemon` gains `applyBodyForTest` (test-only seam, nil in production).

## Cancellation semantics

If `ctx` cancels **before** `Acquire` succeeds: `commitAndApply` returns `ctx.Err()` and **neither commit nor apply runs** — no divergence.

Once the semaphore is held, the commit→apply pair runs to completion. Cancellation past that point is ignored — `applyConfigLocked` is not safe to interrupt mid-stream (kernel route writes, FRR reload, IPsec etc.).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/daemon/ ./pkg/api/ ./pkg/grpcapi/ ./pkg/configstore/ ./pkg/cli/` clean
- [x] New `TestApplyConfigSerializes` — 8 goroutines call `applyConfig`; max concurrent body invocations must be 1
- [x] New `TestCommitAndApplyRespectsSemaphore` — externally hold semaphore, call `commitAndApply` / `commitConfirmedAndApply` with tight deadline; expect `context.DeadlineExceeded` (proves `Acquire` runs before `store.Commit` — otherwise the call would panic on the nil store)
- [ ] `make cluster-deploy` to userspace cluster, verify daemon starts and config commits work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)