### PR TITLE
#848 routing.Manager: protect tunnels/xfrmis/bonds with ifaceMu

### DIFF
--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -42,11 +42,18 @@ type InterfaceMonitorStatus struct {
 // Manager handles tunnel and VRF lifecycle.
 type Manager struct {
 	nlHandle   *netlink.Handle
-	tunnels    []string                    // currently created tunnel interface names
-	xfrmis     []string                    // currently created xfrmi interface names
-	bonds      []string                    // currently created bond interface names
-	reths      []string                    // currently created RETH interface names
 	keepalives map[string]*keepaliveRunner // tunnel name -> runner
+
+	// #848: ifaceMu serializes all reads and writes of the
+	// tunnels/xfrmis/bonds slices. ApplyTunnels/ApplyXfrmi/
+	// ApplyBonds and their Clear counterparts hold it for the full
+	// duration including netlink calls; GetTunnelStatus snapshots
+	// the slice under the lock and iterates lock-free so a long
+	// gRPC read can't block applyConfig.
+	ifaceMu sync.Mutex
+	tunnels []string // currently created tunnel interface names
+	xfrmis  []string // currently created xfrmi interface names
+	bonds   []string // currently created bond interface names
 
 	// vrfsMu serializes all reads and writes of vrfs, and is held for
 	// the full duration of ReconcileVRFs/CreateVRF including the
@@ -422,7 +429,9 @@ func routeToEntry(m *Manager, r netlink.Route, family int) RouteEntry {
 // Previous tunnels are removed first. Starts keepalive probes for tunnels that have
 // keepalive configured.
 func (m *Manager) ApplyTunnels(tunnels []*config.TunnelConfig) error {
-	if err := m.ClearTunnels(); err != nil {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	if err := m.clearTunnelsLocked(); err != nil {
 		slog.Warn("failed to clear previous tunnels", "err", err)
 	}
 
@@ -735,6 +744,15 @@ func (m *Manager) GetKeepaliveState(tunnelName string) *KeepaliveState {
 
 // ClearTunnels removes all previously created tunnel interfaces.
 func (m *Manager) ClearTunnels() error {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	return m.clearTunnelsLocked()
+}
+
+// clearTunnelsLocked is the lock-free body of ClearTunnels. Caller
+// must hold ifaceMu. Used internally by ApplyTunnels which already
+// holds the lock.
+func (m *Manager) clearTunnelsLocked() error {
 	m.stopAllKeepalives()
 	for _, name := range m.tunnels {
 		link, err := m.nlHandle.LinkByName(name)
@@ -755,7 +773,9 @@ func (m *Manager) ClearTunnels() error {
 // Each VPN with a BindInterface (e.g. "st0.0") gets a unit-specific xfrmi
 // device and a stable XFRM interface ID derived from the st/unit pair.
 func (m *Manager) ApplyXfrmi(vpns map[string]*config.IPsecVPN) error {
-	if err := m.ClearXfrmi(); err != nil {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	if err := m.clearXfrmiLocked(); err != nil {
 		slog.Warn("failed to clear previous xfrmi interfaces", "err", err)
 	}
 
@@ -824,6 +844,14 @@ func (m *Manager) ApplyXfrmi(vpns map[string]*config.IPsecVPN) error {
 
 // ClearXfrmi removes all previously created xfrmi interfaces.
 func (m *Manager) ClearXfrmi() error {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	return m.clearXfrmiLocked()
+}
+
+// clearXfrmiLocked is the lock-free body of ClearXfrmi. Caller must
+// hold ifaceMu. Used internally by ApplyXfrmi.
+func (m *Manager) clearXfrmiLocked() error {
 	for _, name := range m.xfrmis {
 		link, err := m.nlHandle.LinkByName(name)
 		if err != nil {
@@ -852,8 +880,14 @@ type TunnelStatus struct {
 
 // GetTunnelStatus returns the status of managed tunnel interfaces.
 func (m *Manager) GetTunnelStatus() ([]TunnelStatus, error) {
+	// #848: snapshot tunnel names under ifaceMu, then iterate
+	// without the lock so a long netlink probe can't block applyConfig.
+	m.ifaceMu.Lock()
+	names := append([]string(nil), m.tunnels...)
+	m.ifaceMu.Unlock()
+
 	var result []TunnelStatus
-	for _, name := range m.tunnels {
+	for _, name := range names {
 		ts := TunnelStatus{Name: name, State: "down"}
 
 		link, err := m.nlHandle.LinkByName(name)
@@ -1764,8 +1798,9 @@ func resolveRibTable(ribName string, tableIDs map[string]int) int {
 // member-interfaces configured. Uses the bond mode from InterfaceConfig.BondMode
 // (active-backup for fabric bonds, 802.3ad for ae interfaces).
 func (m *Manager) ApplyBonds(interfaces []*config.InterfaceConfig) error {
-	// Clear previous bonds first
-	if err := m.ClearBonds(); err != nil {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	if err := m.clearBondsLocked(); err != nil {
 		slog.Warn("failed to clear previous bonds", "err", err)
 	}
 
@@ -1845,6 +1880,14 @@ func (m *Manager) ApplyBonds(interfaces []*config.InterfaceConfig) error {
 
 // ClearBonds removes all previously created bond devices.
 func (m *Manager) ClearBonds() error {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
+	return m.clearBondsLocked()
+}
+
+// clearBondsLocked is the lock-free body of ClearBonds. Caller must
+// hold ifaceMu. Used internally by ApplyBonds.
+func (m *Manager) clearBondsLocked() error {
 	for _, name := range m.bonds {
 		link, err := m.nlHandle.LinkByName(name)
 		if err != nil {
@@ -1870,9 +1913,6 @@ func (m *Manager) ApplyRethInterfaces(interfaces map[string]*config.InterfaceCon
 // It scans for any existing reth* bond devices (including stale ones from
 // previous binary versions) and deletes them.
 func (m *Manager) ClearRethInterfaces() error {
-	// First, clear any tracked names from this session.
-	m.reths = nil
-
 	// Scan all links for reth* bond devices left from previous deploys.
 	links, err := m.nlHandle.LinkList()
 	if err != nil {

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -93,7 +93,9 @@ func New() (*Manager, error) {
 
 // Close releases the netlink handle and stops all keepalive probes.
 func (m *Manager) Close() error {
+	m.ifaceMu.Lock()
 	m.stopAllKeepalives()
+	m.ifaceMu.Unlock()
 	if m.nlHandle != nil {
 		m.nlHandle.Close()
 	}
@@ -733,8 +735,17 @@ func probeICMP(addr string) bool {
 	return true
 }
 
-// GetKeepaliveState returns the keepalive state for a tunnel, or nil if no keepalive is configured.
+// GetKeepaliveState returns the keepalive state for a tunnel, or nil
+// if no keepalive is configured.
+//
+// #848: ifaceMu protects the keepalives map against concurrent
+// startKeepalive / stopAllKeepalives mutations from ApplyTunnels /
+// ClearTunnels. The returned *KeepaliveState pointer is safe to
+// dereference outside the lock — Go GC keeps the value alive even
+// if a subsequent stopAllKeepalives removes it from the map.
 func (m *Manager) GetKeepaliveState(tunnelName string) *KeepaliveState {
+	m.ifaceMu.Lock()
+	defer m.ifaceMu.Unlock()
 	runner, ok := m.keepalives[tunnelName]
 	if !ok {
 		return nil

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -74,9 +74,15 @@ type VRFSpec struct {
 }
 
 // keepaliveRunner manages the goroutine for a single tunnel's keepalive.
+//
+// #848: `done` is closed by keepaliveLoop just before it returns.
+// Close() / stopAllKeepalives drain on this channel so the netlink
+// handle is not closed while a keepalive goroutine is still in
+// flight (use-after-close on m.nlHandle).
 type keepaliveRunner struct {
 	cancel context.CancelFunc
 	state  *KeepaliveState
+	done   chan struct{}
 }
 
 // New creates a new routing Manager.
@@ -624,20 +630,32 @@ func closeTuntapFiles(files []*os.File) {
 	}
 }
 
-// stopAllKeepalives cancels all running keepalive goroutines.
+// stopAllKeepalives cancels all running keepalive goroutines and
+// waits for them to exit. Caller MUST hold ifaceMu.
+//
+// #848: draining (not just cancelling) is required because
+// keepaliveLoop touches m.nlHandle on bring-up/down. Close() then
+// closes nlHandle, so any in-flight tick that hadn't yet checked
+// ctx.Done() would use-after-close. The done channel makes the
+// drain explicit.
 func (m *Manager) stopAllKeepalives() {
-	for name, runner := range m.keepalives {
+	runners := m.keepalives
+	m.keepalives = make(map[string]*keepaliveRunner)
+	for name, runner := range runners {
 		runner.cancel()
+		<-runner.done
 		slog.Debug("stopped keepalive", "tunnel", name)
 	}
-	m.keepalives = make(map[string]*keepaliveRunner)
 }
 
 // startKeepalive starts a keepalive probe goroutine for a tunnel.
+// Caller MUST hold ifaceMu.
 func (m *Manager) startKeepalive(tunnelName, remoteAddr string, interval, maxRetries int) {
-	// Stop existing keepalive for this tunnel if any
+	// Stop existing keepalive for this tunnel if any. Drain on done
+	// so the replacement doesn't race the old goroutine on m.nlHandle.
 	if runner, ok := m.keepalives[tunnelName]; ok {
 		runner.cancel()
+		<-runner.done
 	}
 
 	if maxRetries <= 0 {
@@ -652,18 +670,22 @@ func (m *Manager) startKeepalive(tunnelName, remoteAddr string, interval, maxRet
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	m.keepalives[tunnelName] = &keepaliveRunner{
 		cancel: cancel,
 		state:  state,
+		done:   done,
 	}
 
-	go m.keepaliveLoop(ctx, tunnelName, state)
+	go m.keepaliveLoop(ctx, done, tunnelName, state)
 	slog.Info("started keepalive", "tunnel", tunnelName,
 		"remote", remoteAddr, "interval", interval, "retries", maxRetries)
 }
 
 // keepaliveLoop runs periodic ICMP probes to the tunnel remote endpoint.
-func (m *Manager) keepaliveLoop(ctx context.Context, tunnelName string, state *KeepaliveState) {
+// Closes `done` when it returns so stopAllKeepalives can drain.
+func (m *Manager) keepaliveLoop(ctx context.Context, done chan struct{}, tunnelName string, state *KeepaliveState) {
+	defer close(done)
 	ticker := time.NewTicker(time.Duration(state.Interval) * time.Second)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Summary

Adds \`ifaceMu sync.Mutex\` to \`routing.Manager\` covering the \`tunnels\`, \`xfrmis\`, and \`bonds\` slices.

## Why

#846 serialized \`applyConfig\` end-to-end, but \`GetTunnelStatus\` runs from gRPC handlers that don't hold the apply semaphore. Writers (via applyConfig → ApplyTunnels) can race readers (via gRPC → GetTunnelStatus) on the underlying slice header. Race is rare in practice but real.

## Design

- \`ApplyTunnels\` / \`ApplyXfrmi\` / \`ApplyBonds\` and their \`Clear*\` counterparts hold \`ifaceMu\` for the full body — matches the \`vrfsMu\` pattern from #844.
- Internal Apply→Clear re-entrance broken via \`clearTunnelsLocked\` / \`clearXfrmiLocked\` / \`clearBondsLocked\` helpers (no lock).
- \`GetTunnelStatus\` snapshots the tunnel-name slice under \`ifaceMu\` then iterates lock-free — keeps a long netlink probe from blocking applyConfig.
- Removes dead \`reths\` field (RETH bonds aren't created anymore; VRRP runs directly on physical members).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/routing/ ./pkg/daemon/\` clean
- [ ] \`make cluster-deploy\` to verify daemon still creates tunnels/xfrmi/bonds and \`show interfaces tunnels\` works

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)