### PR TITLE
docs: add Copilot review as a distinct step in the engineering workflow

### DIFF
--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -105,10 +105,38 @@ the mechanics, so this section is sequencing only.
    explicitly in the PR body with the reason. Never claim success for
    a check that wasn't executed.
 
-9. **PR open + review + merge** — see "PR discipline" and "Merging"
-   below for the body template and mechanics. At this stage: Copilot
-   and Codex review; every comment gets a disposition reply; squash
-   merge once CI is green and findings are resolved.
+9. **PR open + Copilot review + Codex re-review + merge** — see
+   "PR discipline" and "Merging" below for the body template and
+   mechanics. Two distinct review surfaces:
+
+   - **GitHub Copilot** auto-posts an inline review on every push to
+     a PR (~30s after `git push`). It catches a different class of
+     issues than Codex: stale comments, unwired fields, accidentally-
+     ignored errors, missing tests. **Always fetch and triage Copilot
+     comments before requesting human review** — pretend they're
+     from a thoughtful but pedantic colleague. Real ones get fixed
+     in the same branch; non-issues get a short reply explaining
+     why.
+
+     Standard fetch:
+     ```
+     gh api repos/<owner>/<repo>/pulls/<N>/comments | \
+       jq -r '.[] | select(.user.login | startswith("copilot")) |
+              "\(.path):\(.line // .original_line) — \(.body)"'
+     ```
+
+   - **Codex hostile code review** runs separately via the
+     `codex-rescue` agent. Same terminal rule as the plan review:
+     Codex returns `MERGE YES` AND every finding has a written
+     disposition. Codex sees the diff with eyes that have not seen
+     Copilot's findings — keep the two reviews independent so they
+     can disagree productively.
+
+   Iterate until BOTH reviewers are clean (or have explicit-with-
+   reason dispositions). Squash merge once CI is green and findings
+   are resolved. If the diff grows in response to review, push and
+   request a re-review — both Copilot and Codex re-fire on the new
+   HEAD.
 
 ## Hot-path coding discipline
 
@@ -218,6 +246,13 @@ the mechanics, so this section is sequencing only.
 - **Trust but verify.** An agent's commit summary describes what it
   intended. Read the diff. Re-run the tests on the updated head before
   approving.
+- **Two independent review surfaces.** Codex (hostile, design-level)
+  and Copilot (inline, mechanical-detail) catch different classes of
+  bugs. Treat them as separate passes; do not skip either. Codex
+  often misses the unwired-field or stale-comment bug that Copilot
+  spots; Copilot often misses the architectural concern that Codex
+  flags. The combined coverage is the point — losing one halves
+  the review.
 
 ### Responding to review (as author)
 


### PR DESCRIPTION
## Summary

Updates \`docs/engineering-style.md\` step 9 (PR open + review + merge) to pin GitHub Copilot review as a distinct workflow step, alongside the existing Codex hostile code review.

## Why

Yesterday's three-track parallel work (PRs #889 / #890 / #891) exposed a process gap: I drove Codex through multiple rounds on each PR but didn't fetch Copilot's inline comments until prompted. Copilot caught real issues Codex missed — stale doc comments, accidentally-ignored \`Update\` errors, loose \"anyKnown\" gates, missing tests.

The two reviewers cover different bug classes. Codex is hostile and design-level; Copilot is inline and mechanical-detail. Losing either halves the review.

## Changes

- Step 9 now spells out: Copilot auto-runs on push, must be fetched and triaged before merge, with the standard \`gh api + jq\` fetch command.
- Step 9 also keeps Codex hostile code review as the separate pass.
- New bullet in \"Reviewing (adversarial by design)\" pinning the two-surface contract.

## Test plan

- [x] Doc-only change; no code touched.
- [ ] Future PRs follow the updated workflow (validation is in the next round of merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)