### PR TITLE
#805 D3 RSS indirection refresh on workers↔queues transition

### DIFF
--- a/docs/pr/805-rss-refresh/plan.md
+++ b/docs/pr/805-rss-refresh/plan.md
@@ -183,7 +183,11 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
     if queueCount <= 0 {
         return false
     }
-    sawAnyRow := false  // R2#2: prevent vacuously-true on empty/unparseable output
+    // R2#2 + R3 LOW: prevent vacuously-true on empty,
+    // unparseable, or value-less ("0:" with no queue tokens)
+    // output. Set the flag only after at least one queue value
+    // has been successfully parsed and verified.
+    sawAnyEntry := false
     for _, line := range bytes.Split(output, []byte{'\n'}) {
         trimmed := bytes.TrimSpace(line)
         if len(trimmed) == 0 {
@@ -197,7 +201,6 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
         if err != nil {
             continue
         }
-        sawAnyRow = true
         for j, tok := range bytes.Fields(trimmed[colon+1:]) {
             q, err := strconv.Atoi(string(tok))
             if err != nil {
@@ -207,9 +210,10 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
             if q != expected {
                 return false
             }
+            sawAnyEntry = true
         }
     }
-    return sawAnyRow
+    return sawAnyEntry
 }
 ```
 
@@ -269,9 +273,15 @@ locking (none) preserved.
     but in non-round-robin order. Asserts the stricter check.
     (R1 MED #3.)
 11. `TestIndirectionTableIsDefault_EmptyOutput_False`: pure parser
-    test on empty / unparseable output (e.g. from a failed `ethtool
-    -x` that returned 0 bytes). Asserts `sawAnyRow` guard prevents
-    vacuously-true return. (R2 MED #2.)
+    test on empty / unparseable / value-less inputs. Three
+    sub-cases:
+    - empty `[]byte{}` → false (no rows seen)
+    - non-row text only (e.g. just the "RX flow hash..." header)
+      → false (no rows seen)
+    - row index with no queue tokens (e.g. `"0:\n"`) → false
+      (R3 LOW: sawAnyEntry guard, not just sawAnyRow)
+    Asserts the parser distinguishes "no entries parsed" from
+    "all entries match expected pattern".
 12. `TestApplyRSSIndirectionOne_BootSequence_4then6_RestoresDefault`:
     multi-cycle test simulating the actual operator scenario.
     Step 1: workers=4, queues=6, default round-robin live table —
@@ -354,3 +364,9 @@ path) must still pass unchanged.
 | 3 | MED | Runtime queue-count-only changes       | §12 explicit out-of-scope: operator changing `ethtool -L` without config commit is not auto-handled; netlink-watch for ringparam is separate scope |
 | 4 | LOW | Test fixture path unpinned             | §9 test #8 specifies inline-string-literal in the test (small enough to embed, keeps test self-contained) |
 | 5 | LOW | Multi-cycle boot scenario untested     | §9 test #12 added: `BootSequence_4then6_RestoresDefault` covers the full transition end-to-end |
+
+### Round 3 (1 finding)
+
+| # | Sev | Topic                                  | Resolution |
+|---|-----|----------------------------------------|------------|
+| 1 | LOW | sawAnyRow set before queue tokens parsed | Renamed `sawAnyRow` → `sawAnyEntry`, set inside the inner field loop after a value has been parsed AND verified. Test #11 expanded to cover the value-less row case (`"0:\n"`) explicitly |

--- a/docs/pr/805-rss-refresh/plan.md
+++ b/docs/pr/805-rss-refresh/plan.md
@@ -46,9 +46,15 @@ reverted. The fix here MUST work against this simpler contract:
 
 - No locking required: there is no concurrent writer of the RSS
   indirection table in master. The only callers are
-  daemon-startup (`linksetup.go:113`) and reconcile-on-commit
-  (`daemon.go:2566`); both are serialized by the daemon's
-  config-apply semaphore.
+  daemon-startup (`linksetup.go:113`, runs from
+  `enumerateAndRenameInterfaces` BEFORE the API / gRPC / CLI
+  commit paths are wired up) and reconcile-on-commit
+  (`daemon.go:2566`, runs under the config-apply path which the
+  daemon enforces serially). Startup-vs-reconcile serialization
+  is **lifecycle ordering** (R2#1: not the apply semaphore as a
+  prior revision incorrectly claimed), but the practical
+  outcome is the same: no two RSS-indirection writers ever run
+  concurrently in master.
 - No bool return: `applyRSSIndirectionOne` stays void. The
   caller is unaware whether a write happened.
 - No epoch bump: not present in master.
@@ -177,6 +183,7 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
     if queueCount <= 0 {
         return false
     }
+    sawAnyRow := false  // R2#2: prevent vacuously-true on empty/unparseable output
     for _, line := range bytes.Split(output, []byte{'\n'}) {
         trimmed := bytes.TrimSpace(line)
         if len(trimmed) == 0 {
@@ -190,6 +197,7 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
         if err != nil {
             continue
         }
+        sawAnyRow = true
         for j, tok := range bytes.Fields(trimmed[colon+1:]) {
             q, err := strconv.Atoi(string(tok))
             if err != nil {
@@ -201,7 +209,7 @@ func indirectionTableIsDefault(output []byte, queueCount int) bool {
             }
         }
     }
-    return true
+    return sawAnyRow
 }
 ```
 
@@ -250,13 +258,27 @@ locking (none) preserved.
    MED #6.)
 8. `TestIndirectionTableIsDefault_RoundRobin_True`: pure-parser
    test using the captured `ethtool -x` output from
-   `loss:xpf-userspace-fw0/ge-0-0-2` (committed as a fixture).
+   `loss:xpf-userspace-fw0/ge-0-0-2`. Fixture is **inline
+   string literal** in the test (R2#4: pinned — small enough
+   to embed, keeps the test self-contained without a
+   `testdata/` file).
 9. `TestIndirectionTableIsDefault_Concentrated_False`: pure
    parser test on the `[1,1,1,1,0,0]` shape.
 10. `TestIndirectionTableIsDefault_EveryQueueOnceButNonRoundRobin_False`:
     pure parser test on a hand-built table that uses every queue
     but in non-round-robin order. Asserts the stricter check.
     (R1 MED #3.)
+11. `TestIndirectionTableIsDefault_EmptyOutput_False`: pure parser
+    test on empty / unparseable output (e.g. from a failed `ethtool
+    -x` that returned 0 bytes). Asserts `sawAnyRow` guard prevents
+    vacuously-true return. (R2 MED #2.)
+12. `TestApplyRSSIndirectionOne_BootSequence_4then6_RestoresDefault`:
+    multi-cycle test simulating the actual operator scenario.
+    Step 1: workers=4, queues=6, default round-robin live table —
+    expect concentrated `[1,1,1,1,0,0]` write. Step 2: same iface,
+    workers=6, queues=6, live table now constrained — expect
+    `ethtool -X iface default` write. Asserts the full transition
+    behavior end-to-end. (R2 LOW #5.)
 
 Existing `TestApplyRSSIndirectionOne_*` tests (workers < queues
 path) must still pass unchanged.
@@ -298,6 +320,16 @@ path) must still pass unchanged.
 - General `ethtool -X` state-machine refactor.
 - D3 enable on non-mlx5 NICs.
 - Re-introduction of the #840 lock/epoch infrastructure.
+- **Runtime queue-count changes without a config commit** (R2#3):
+  if the operator runs `ethtool -L iface combined N` to change
+  the NIC's queue count without bumping `system dataplane
+  workers` afterwards, the daemon won't notice and the live
+  indirection table may reference non-existent queues until the
+  next config commit triggers `reapplyRSSIndirection`. Operators
+  changing queue counts are expected to follow up with a config
+  commit (or restart the daemon). This change does NOT add a
+  netlink-watch loop for ringparam changes — that's a separate
+  scope of work.
 
 ## 13. Codex round-1 review responses
 
@@ -312,3 +344,13 @@ path) must still pass unchanged.
 | 7 | MED | Missing tests: queueCount=0, workers>queues | §9 tests #2 (workers>queues) and #6 (queueCount=0) |
 | 8 | LOW | Missing regression: workers∈{0,1}     | §9 tests #4 and #5 |
 | 9 | LOW | `make test-failover` overbroad         | §10: demoted to optional defense, not a merge blocker |
+
+### Round 2 (5 findings)
+
+| # | Sev | Topic                                  | Resolution |
+|---|-----|----------------------------------------|------------|
+| 1 | LOW | §3 wrongly cited apply semaphore       | §3 reworded: serialization is lifecycle ordering (startup runs from enumerateAndRenameInterfaces before API/CLI are wired up), not the apply semaphore |
+| 2 | MED | indirectionTableIsDefault vacuously true | §7 added `sawAnyRow` guard (mirrors existing `indirectionTableMatches` shape); §9 test #11 pins empty-output behavior |
+| 3 | MED | Runtime queue-count-only changes       | §12 explicit out-of-scope: operator changing `ethtool -L` without config commit is not auto-handled; netlink-watch for ringparam is separate scope |
+| 4 | LOW | Test fixture path unpinned             | §9 test #8 specifies inline-string-literal in the test (small enough to embed, keeps test self-contained) |
+| 5 | LOW | Multi-cycle boot scenario untested     | §9 test #12 added: `BootSequence_4then6_RestoresDefault` covers the full transition end-to-end |

--- a/docs/pr/805-rss-refresh/plan.md
+++ b/docs/pr/805-rss-refresh/plan.md
@@ -10,18 +10,19 @@ though they now host worker-bound AF_XDP sockets.
 
 Concrete symptom (from #800 investigation, doc preserved on
 closed branch `pr/800-workers-queues-alignment`):
-- Pre-change: workers=4, queues=6 → table `[1,1,1,1,0,0]`.
-- Post-change: workers=6, queues=6 → expected default round-
-  robin table; observed: still `[1,1,1,1,0,0]`. Queues 4 and 5
-  receive 0 traffic via RSS, the dataplane workers bound there
-  starve.
+- Pre-change: workers=4, queues=6 → table written
+  `[1,1,1,1,0,0]` so the indirection only references queues 0-3.
+- Post-change: workers=6, queues=6 → expected default
+  round-robin table; observed: still references only queues 0-3.
+  Queues 4 and 5 receive 0 traffic via RSS, the dataplane
+  workers bound there starve.
 
 ## 2. Root cause
 
 `pkg/daemon/rss_indirection.go:applyRSSIndirectionOne()` calls
 `computeWeightVector(workers, queues)`. When `workers >= queues`
 that function returns `nil, "workers (N) >= queues (M)"`. The
-caller treats nil as "skip" and **does not** touch the live
+caller treats nil as "skip" and does not touch the live
 table. The configured-from-previous-workers state persists.
 
 The skip is correct for "fresh install with workers >= queues"
@@ -30,119 +31,284 @@ The skip is correct for "fresh install with workers >= queues"
 previously-written constrained table is now wrong and must be
 reset to default).
 
-## 3. Fix
+## 3. Master-state contract (Codex R1 HIGH 1+2 grounding)
 
-Smallest correct change: in `applyRSSIndirectionOne`, when
-`computeWeightVector` returns nil because `workers >= queues`
-(specifically, NOT because of misconfig like workers <= 0 or
-workers == 1), inspect the live indirection table; if it is
-not the default round-robin shape (i.e., some queue index
-≥ active count appears as 0 weight in concentrated form), run
-`ethtool -X <iface> default` to restore.
+The current call chain in master is:
 
-The decision to restore-default-on-skip is gated on:
-
-- `workers >= queues > 1` (the transition case)
-- `live table != default` (otherwise no-op)
-
-Other skip reasons (`workers <= 0`, `workers == 1`) leave the
-table alone — those are bring-up / single-worker paths where
-no prior workers<queues state could exist for this iface.
-
-## 4. Detection of "live table != default"
-
-Default RSS layout from `ethtool -X iface default` is
-round-robin over all queues: indices map to `q = i mod
-queue_count`. The current `indirectionTableMatches(out,
-weights)` helper checks for "table only uses queues
-0..(activeCount-1)". For the "is default?" question we need
-the inverse: "does the table use queues 0..queue_count-1
-(all of them)?".
-
-Add a sibling helper:
-
-```go
-// indirectionTableIsDefault reports true if the live ethtool
-// -x output describes a table that uses every queue index in
-// 0..queueCount-1 at least once.
-func indirectionTableIsDefault(output []byte, queueCount int) bool { ... }
+```
+reapplyRSSIndirectionWith → applyRSSIndirection → applyRSSIndirectionOne
 ```
 
-If `false` and `workers >= queues`, fire `ethtool -X iface
-default`. Caller applies same lock + bump semantics as the
-existing apply path (rssWriteMu held by parent
-`applyRSSIndirectionLocked`; epoch bump on successful write).
+All three return **void**. There is no `rssWriteMu`, no
+`applyRSSIndirectionLocked` split, no epoch counter — those were
+introduced in #840 (Slice D rebalance) and removed when #840 was
+reverted. The fix here MUST work against this simpler contract:
 
-## 5. Implementation
+- No locking required: there is no concurrent writer of the RSS
+  indirection table in master. The only callers are
+  daemon-startup (`linksetup.go:113`) and reconcile-on-commit
+  (`daemon.go:2566`); both are serialized by the daemon's
+  config-apply semaphore.
+- No bool return: `applyRSSIndirectionOne` stays void. The
+  caller is unaware whether a write happened.
+- No epoch bump: not present in master.
+
+The fix is purely additive within `applyRSSIndirectionOne`'s
+existing void-returning shape.
+
+## 4. Default-table shape (empirical, Codex R1 MED #4 closure)
+
+`ethtool -X iface default` on mlx5 produces a 128-entry
+indirection table where `entry[i] = i mod queue_count`, exactly.
+Verified live on `loss:xpf-userspace-fw0/ge-0-0-2` with 6 RX
+queues:
+
+```
+    0:      0     1     2     3     4     5     0     1
+    8:      2     3     4     5     0     1     2     3
+   16:      4     5     0     1     2     3     4     5
+   24:      0     1     2     3     4     5     0     1
+   ...
+```
+
+So "is default" detection can be exact:
+```
+for each row in `ethtool -x` output:
+    parse <row-index>: <q0> <q1> ... <q7>
+    for col j in 0..7:
+        if int(q[j]) != (row_index + j) % queue_count:
+            return false
+return true
+```
+
+This is strictly tighter than "uses every queue index at least
+once" (Codex MED #3): a custom table that hits every queue once
+in non-round-robin order would fail this check, so the daemon
+would correctly reset it to true round-robin on the next apply.
+
+## 5. Skip-reason discrimination (Codex R1 MED #5 fix)
+
+Don't parse the human string from `computeWeightVector`. The
+caller already knows `workers` and `queues`; check the structured
+condition directly:
+
+```go
+queues := execer.readQueueCount(iface)
+if queues <= 0 {
+    slog.Debug("rss indirection: queue count unknown, skipping",
+        "iface", iface)
+    return  // unchanged: nothing we can do without queue count
+}
+weights, _ := computeWeightVector(workers, queues)
+if weights == nil {
+    // computeWeightVector skipped. Distinguish:
+    //   workers <= 0 / workers == 1 → leave table alone
+    //   workers >= queues > 1 → maybe restore default if the
+    //                            live table is configured-stale
+    if workers > 1 && workers >= queues {
+        maybeRestoreDefault(iface, queues, execer)
+    }
+    return
+}
+// existing path for workers < queues — write `weights`
+...
+```
+
+The `workers > 1 && workers >= queues` condition is unambiguous,
+deterministic, and decoupled from any reason-string text.
+
+## 6. maybeRestoreDefault behavior (Codex R1 MED #6 fix)
+
+```go
+func maybeRestoreDefault(iface string, queues int, execer rssExecutor) {
+    out, err := execer.runEthtool("-x", iface)
+    if err != nil {
+        // Same probe-failure behavior as the existing apply path:
+        //   ErrNotFound → log Warn, return
+        //   other error → log Warn with output, return
+        // No write attempted on probe failure.
+        if isExecNotFound(err) {
+            slog.Warn("rss indirection: ethtool not found, cannot probe for default",
+                "iface", iface)
+            return
+        }
+        slog.Warn("rss indirection: ethtool -x failed, cannot probe for default",
+            "iface", iface, "err", err,
+            "output", strings.TrimSpace(string(out)))
+        return
+    }
+    if indirectionTableIsDefault(out, queues) {
+        slog.Debug("rss indirection: already default, no restore needed",
+            "iface", iface)
+        return
+    }
+    if _, err := execer.runEthtool("-X", iface, "default"); err != nil {
+        if isExecNotFound(err) {
+            slog.Warn("rss indirection: ethtool not found, cannot restore default",
+                "iface", iface)
+            return
+        }
+        slog.Warn("rss indirection: ethtool -X default failed",
+            "iface", iface, "err", err)
+        return
+    }
+    slog.Info("rss indirection: restored default round-robin",
+        "iface", iface, "reason", "workers>=queues with stale constrained table")
+}
+```
+
+Probe-failure handling explicitly mirrors the existing
+`applyRSSIndirectionOne` apply-path failure handling (Codex R1
+MED #6 fix).
+
+## 7. indirectionTableIsDefault helper
+
+```go
+// indirectionTableIsDefault reports true iff the live ethtool -x
+// output describes a round-robin indirection table where
+// entry[i] == i mod queueCount. This is the exact shape mlx5
+// produces on `ethtool -X iface default` (verified live on the
+// loss:xpf-userspace-fw0 cluster, 6-queue ge-0-0-2).
+//
+// Stricter than indirectionTableMatches: rejects any custom
+// table that happens to use every queue at least once but
+// doesn't match the round-robin pattern.
+func indirectionTableIsDefault(output []byte, queueCount int) bool {
+    if queueCount <= 0 {
+        return false
+    }
+    for _, line := range bytes.Split(output, []byte{'\n'}) {
+        trimmed := bytes.TrimSpace(line)
+        if len(trimmed) == 0 {
+            continue
+        }
+        colon := bytes.IndexByte(trimmed, ':')
+        if colon <= 0 {
+            continue
+        }
+        rowIdx, err := strconv.Atoi(string(trimmed[:colon]))
+        if err != nil {
+            continue
+        }
+        for j, tok := range bytes.Fields(trimmed[colon+1:]) {
+            q, err := strconv.Atoi(string(tok))
+            if err != nil {
+                return false
+            }
+            expected := (rowIdx + j) % queueCount
+            if q != expected {
+                return false
+            }
+        }
+    }
+    return true
+}
+```
+
+## 8. Implementation footprint
 
 Single-file change in `pkg/daemon/rss_indirection.go`:
 
-1. Add `indirectionTableIsDefault(output []byte, queueCount
-   int) bool` helper.
-2. In `applyRSSIndirectionOne`, after `computeWeightVector`
-   returns nil, branch on the reason:
-   - `workers >= queues > 1`: read live table; if not default,
-     run `ethtool -X iface default`. Return whether a write
-     happened (matches the existing bool return contract).
-   - Other reasons: return false unchanged.
+1. Add `indirectionTableIsDefault(output []byte, queueCount int) bool`.
+2. Add `maybeRestoreDefault(iface string, queues int, execer rssExecutor)`.
+3. Modify `applyRSSIndirectionOne`: read `queues` BEFORE
+   `computeWeightVector`; on nil-weights with the
+   `workers > 1 && workers >= queues` structured condition,
+   call `maybeRestoreDefault`.
 
-Because `applyRSSIndirectionOne` already returns `bool`, the
-caller (`applyRSSIndirectionLocked`) bumps the epoch via the
-existing path. No new plumbing needed.
+Existing `applyRSSIndirectionOne` signature (void) and
+locking (none) preserved.
 
-## 6. Tests
+## 9. Tests (Codex R1 MED #7+#8, LOW #8 fixes)
 
 `pkg/daemon/rss_indirection_test.go`:
 
-1. `TestApplyRSSIndirectionOne_WorkersBecomeEqualQueues_RestoresDefault`:
-   stub returns a live table with concentrated layout (uses
-   only queues 0..3 of 6). Call with workers=6, queues=6.
-   Expect: `ethtool -X iface default` invocation, function
-   returns true.
-2. `TestApplyRSSIndirectionOne_WorkersBecomeGreaterThanQueues_NoOpIfDefault`:
-   stub returns default round-robin layout. Call with
-   workers=8, queues=6. Expect: no ethtool write, function
-   returns false.
-3. `TestIndirectionTableIsDefault_RoundRobin_True`: pure
-   parser test on canned default output.
-4. `TestIndirectionTableIsDefault_Concentrated_False`: pure
-   parser test on canned `[1,1,1,1,0,0]` output.
-5. Regression: existing `TestApplyRSSIndirectionOne_*` tests
-   still pass (workers < queues path unchanged).
+1. `TestApplyRSSIndirectionOne_WorkersEqualsQueues_StaleTable_RestoresDefault`:
+   stub returns concentrated `[0,1,2,3]`-only table for a 6-queue
+   iface. Call with workers=6. Expect: `ethtool -X iface default`
+   invocation.
+2. `TestApplyRSSIndirectionOne_WorkersGreaterThanQueues_StaleTable_RestoresDefault`:
+   stub returns concentrated table; workers=8, queues=6. Expect:
+   restore call. (R1 MED #7 — covers `workers > queues`, not
+   just `==`.)
+3. `TestApplyRSSIndirectionOne_WorkersGreaterEqualQueues_DefaultTable_NoOp`:
+   stub returns true round-robin table. Call with workers=6,
+   queues=6. Expect: probe call only, no `ethtool -X` write.
+4. `TestApplyRSSIndirectionOne_WorkersIsOne_StaleTable_NotTouched`:
+   stub returns concentrated table. Call with workers=1, queues=6.
+   Expect: zero ethtool calls. (R1 LOW #8 — workers==1
+   regression guard.)
+5. `TestApplyRSSIndirectionOne_WorkersIsZero_StaleTable_NotTouched`:
+   stub returns concentrated table. Call with workers=0, queues=6.
+   Expect: zero ethtool calls. (R1 LOW #8.)
+6. `TestApplyRSSIndirectionOne_QueueCountZero_NoOp`:
+   stub `readQueueCount` returns 0 for the iface. Expect: zero
+   ethtool calls. (R1 MED #7 — defensive against sysfs failure.)
+7. `TestApplyRSSIndirectionOne_RestoreEthtoolXProbeMissing_LogAndSkip`:
+   stub `ethtool -x` returns ErrNotFound on the restore-default
+   probe. Expect: warning logged, no `-X default` write. (R1
+   MED #6.)
+8. `TestIndirectionTableIsDefault_RoundRobin_True`: pure-parser
+   test using the captured `ethtool -x` output from
+   `loss:xpf-userspace-fw0/ge-0-0-2` (committed as a fixture).
+9. `TestIndirectionTableIsDefault_Concentrated_False`: pure
+   parser test on the `[1,1,1,1,0,0]` shape.
+10. `TestIndirectionTableIsDefault_EveryQueueOnceButNonRoundRobin_False`:
+    pure parser test on a hand-built table that uses every queue
+    but in non-round-robin order. Asserts the stricter check.
+    (R1 MED #3.)
 
-## 7. Acceptance
+Existing `TestApplyRSSIndirectionOne_*` tests (workers < queues
+path) must still pass unchanged.
+
+## 10. Acceptance
 
 - All 880+ existing Go tests pass.
 - New tests pass.
 - `go test ./pkg/daemon/` clean.
 - Live deploy on `loss:xpf-userspace-fw0` (RG0 primary):
-  - Set workers=4, observe table `[1,1,1,1,0,0]` via
+  - Build with the change.
+  - Set workers=4, observe table with concentrated layout via
     `ethtool -x ge-0-0-2`.
   - Bump to workers=6 via cli commit.
   - Confirm table reverts to round-robin default.
 - Codex hostile review: at least 1 round, MERGE YES.
 - Copilot inline review: addressed.
-- `make test-failover`: pass (defense — touching RSS indirection
-  near HA boundary).
+- `make test-failover` is **NOT** a merge blocker (Codex R1
+  LOW #9 — this change is a per-iface RSS-indirection concern
+  that doesn't intersect HA except via the existing serialized
+  apply path). Run as optional defense-in-depth if convenient.
 
-## 8. Risks
+## 11. Risks
 
-- **Race with #840-style rebalance loop**: the rebalance loop
-  was reverted in #840, so no live concurrent writer. If a
-  future re-introduction lands, this path interacts via the
-  existing `rssWriteMu` (already in place from #785 / #840
-  partial state).
-- **False-positive default detection**: a future operator who
-  manually wrote a custom table via `ethtool -X` would have it
-  reverted by the daemon. Acceptable — the daemon claims D3
+- **False-positive default detection**: tightened (§4 + §7) to
+  exact round-robin `entry[i] == i mod queue_count`. A future
+  operator who manually wrote a custom table via `ethtool -X`
+  on a managed mlx5 iface would have it reverted by the daemon
+  on the next reconcile. Acceptable — the daemon claims D3
   ownership of the indirection table on managed mlx5 ifaces.
-- **Boot ordering**: this change runs in the same path that
-  D3 already runs in (linksetup at startup, applyConfig on
-  reconcile). No new ordering concern.
+- **Boot ordering**: at startup the live table is whatever the
+  kernel left it (likely default — most systems boot with
+  default RSS). The fix's "if not default, restore" logic is a
+  no-op on default. No new boot-ordering concern. Probe-error
+  handling explicit per §6.
 
-## 9. Out of scope
+## 12. Out of scope
 
 - General `ethtool -X` state-machine refactor.
 - D3 enable on non-mlx5 NICs.
-- Workers count NOT changing (the no-op case is preserved by
-  `indirectionTableIsDefault` early-returning true).
+- Re-introduction of the #840 lock/epoch infrastructure.
+
+## 13. Codex round-1 review responses
+
+| # | Sev | Topic                                  | Resolution |
+|---|-----|----------------------------------------|------------|
+| 1 | HIGH| `rssWriteMu` claim wrong               | §3: dropped — those came from #840 (reverted). Fix works against current void-returning master contract |
+| 2 | HIGH| Bool return contract claim wrong       | §3: dropped — `applyRSSIndirectionOne` stays void; `maybeRestoreDefault` is also void |
+| 3 | MED | Default-detection too loose            | §4 + §7: tightened to exact round-robin `entry[i] == i mod queue_count` |
+| 4 | MED | Default-table shape unverified         | §4: empirically captured on `loss:xpf-userspace-fw0/ge-0-0-2` |
+| 5 | MED | Skip-reason string parsing fragile     | §5: structured `workers > 1 && workers >= queues` condition |
+| 6 | MED | Boot-time probe-error unspecified      | §6: explicit ErrNotFound + generic err handling, mirrors existing apply path |
+| 7 | MED | Missing tests: queueCount=0, workers>queues | §9 tests #2 (workers>queues) and #6 (queueCount=0) |
+| 8 | LOW | Missing regression: workers∈{0,1}     | §9 tests #4 and #5 |
+| 9 | LOW | `make test-failover` overbroad         | §10: demoted to optional defense, not a merge blocker |

--- a/docs/pr/805-rss-refresh/plan.md
+++ b/docs/pr/805-rss-refresh/plan.md
@@ -1,0 +1,148 @@
+# #805 — D3 RSS indirection refresh on workers ↔ queues transition
+
+## 1. Bug
+
+When `system dataplane workers` is bumped from a value below the
+NIC RX-queue count to a value at-or-above it (e.g. 4 → 6 on a
+6-queue mlx5), the D3 RSS indirection table from the previous
+workers-count stays live: queues 4 and 5 keep weight 0 even
+though they now host worker-bound AF_XDP sockets.
+
+Concrete symptom (from #800 investigation, doc preserved on
+closed branch `pr/800-workers-queues-alignment`):
+- Pre-change: workers=4, queues=6 → table `[1,1,1,1,0,0]`.
+- Post-change: workers=6, queues=6 → expected default round-
+  robin table; observed: still `[1,1,1,1,0,0]`. Queues 4 and 5
+  receive 0 traffic via RSS, the dataplane workers bound there
+  starve.
+
+## 2. Root cause
+
+`pkg/daemon/rss_indirection.go:applyRSSIndirectionOne()` calls
+`computeWeightVector(workers, queues)`. When `workers >= queues`
+that function returns `nil, "workers (N) >= queues (M)"`. The
+caller treats nil as "skip" and **does not** touch the live
+table. The configured-from-previous-workers state persists.
+
+The skip is correct for "fresh install with workers >= queues"
+(default table is fine, no write needed) but incorrect for
+"transition from workers < queues to workers >= queues" (the
+previously-written constrained table is now wrong and must be
+reset to default).
+
+## 3. Fix
+
+Smallest correct change: in `applyRSSIndirectionOne`, when
+`computeWeightVector` returns nil because `workers >= queues`
+(specifically, NOT because of misconfig like workers <= 0 or
+workers == 1), inspect the live indirection table; if it is
+not the default round-robin shape (i.e., some queue index
+≥ active count appears as 0 weight in concentrated form), run
+`ethtool -X <iface> default` to restore.
+
+The decision to restore-default-on-skip is gated on:
+
+- `workers >= queues > 1` (the transition case)
+- `live table != default` (otherwise no-op)
+
+Other skip reasons (`workers <= 0`, `workers == 1`) leave the
+table alone — those are bring-up / single-worker paths where
+no prior workers<queues state could exist for this iface.
+
+## 4. Detection of "live table != default"
+
+Default RSS layout from `ethtool -X iface default` is
+round-robin over all queues: indices map to `q = i mod
+queue_count`. The current `indirectionTableMatches(out,
+weights)` helper checks for "table only uses queues
+0..(activeCount-1)". For the "is default?" question we need
+the inverse: "does the table use queues 0..queue_count-1
+(all of them)?".
+
+Add a sibling helper:
+
+```go
+// indirectionTableIsDefault reports true if the live ethtool
+// -x output describes a table that uses every queue index in
+// 0..queueCount-1 at least once.
+func indirectionTableIsDefault(output []byte, queueCount int) bool { ... }
+```
+
+If `false` and `workers >= queues`, fire `ethtool -X iface
+default`. Caller applies same lock + bump semantics as the
+existing apply path (rssWriteMu held by parent
+`applyRSSIndirectionLocked`; epoch bump on successful write).
+
+## 5. Implementation
+
+Single-file change in `pkg/daemon/rss_indirection.go`:
+
+1. Add `indirectionTableIsDefault(output []byte, queueCount
+   int) bool` helper.
+2. In `applyRSSIndirectionOne`, after `computeWeightVector`
+   returns nil, branch on the reason:
+   - `workers >= queues > 1`: read live table; if not default,
+     run `ethtool -X iface default`. Return whether a write
+     happened (matches the existing bool return contract).
+   - Other reasons: return false unchanged.
+
+Because `applyRSSIndirectionOne` already returns `bool`, the
+caller (`applyRSSIndirectionLocked`) bumps the epoch via the
+existing path. No new plumbing needed.
+
+## 6. Tests
+
+`pkg/daemon/rss_indirection_test.go`:
+
+1. `TestApplyRSSIndirectionOne_WorkersBecomeEqualQueues_RestoresDefault`:
+   stub returns a live table with concentrated layout (uses
+   only queues 0..3 of 6). Call with workers=6, queues=6.
+   Expect: `ethtool -X iface default` invocation, function
+   returns true.
+2. `TestApplyRSSIndirectionOne_WorkersBecomeGreaterThanQueues_NoOpIfDefault`:
+   stub returns default round-robin layout. Call with
+   workers=8, queues=6. Expect: no ethtool write, function
+   returns false.
+3. `TestIndirectionTableIsDefault_RoundRobin_True`: pure
+   parser test on canned default output.
+4. `TestIndirectionTableIsDefault_Concentrated_False`: pure
+   parser test on canned `[1,1,1,1,0,0]` output.
+5. Regression: existing `TestApplyRSSIndirectionOne_*` tests
+   still pass (workers < queues path unchanged).
+
+## 7. Acceptance
+
+- All 880+ existing Go tests pass.
+- New tests pass.
+- `go test ./pkg/daemon/` clean.
+- Live deploy on `loss:xpf-userspace-fw0` (RG0 primary):
+  - Set workers=4, observe table `[1,1,1,1,0,0]` via
+    `ethtool -x ge-0-0-2`.
+  - Bump to workers=6 via cli commit.
+  - Confirm table reverts to round-robin default.
+- Codex hostile review: at least 1 round, MERGE YES.
+- Copilot inline review: addressed.
+- `make test-failover`: pass (defense — touching RSS indirection
+  near HA boundary).
+
+## 8. Risks
+
+- **Race with #840-style rebalance loop**: the rebalance loop
+  was reverted in #840, so no live concurrent writer. If a
+  future re-introduction lands, this path interacts via the
+  existing `rssWriteMu` (already in place from #785 / #840
+  partial state).
+- **False-positive default detection**: a future operator who
+  manually wrote a custom table via `ethtool -X` would have it
+  reverted by the daemon. Acceptable — the daemon claims D3
+  ownership of the indirection table on managed mlx5 ifaces.
+- **Boot ordering**: this change runs in the same path that
+  D3 already runs in (linksetup at startup, applyConfig on
+  reconcile). No new ordering concern.
+
+## 9. Out of scope
+
+- General `ethtool -X` state-machine refactor.
+- D3 enable on non-mlx5 NICs.
+- Workers count NOT changing (the no-op case is preserved by
+  `indirectionTableIsDefault` early-returning true).

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -239,6 +239,18 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 	if weights == nil {
 		slog.Info("linksetup: rss indirection skipped", "iface", iface,
 			"workers", workers, "queues", queues, "reason", reason)
+		// #805: When workers >= queues > 1 we previously left the
+		// indirection table alone. That's correct on a fresh install
+		// (kernel default is round-robin = what we want) but wrong on
+		// the workers<queues → workers>=queues transition, where a
+		// concentrated `[1,...,1,0,...,0]` table written by an earlier
+		// applyRSSIndirectionOne for the prior worker count stays live
+		// and starves queues that now host worker-bound AF_XDP sockets.
+		// Inspect the live table; if it isn't the round-robin default,
+		// restore it.
+		if workers > 1 && workers >= queues && queues > 0 {
+			maybeRestoreDefault(iface, queues, execer)
+		}
 		return
 	}
 
@@ -281,6 +293,96 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 	slog.Info("linksetup: applied rss indirection",
 		"iface", iface, "workers", workers, "queues", len(weights),
 		"weights", weights)
+}
+
+// maybeRestoreDefault reads the live RSS indirection table and, if it
+// is not the kernel's default round-robin shape, runs
+// `ethtool -X <iface> default` to restore it. Used on the
+// workers >= queues skip path (#805) to undo a concentrated table
+// left behind by a prior workers < queues apply when the operator
+// has since increased the worker count to match queue count.
+//
+// Best-effort: ethtool probe failures are logged and skipped without
+// attempting a write, mirroring the apply path's error handling.
+func maybeRestoreDefault(iface string, queues int, execer rssExecutor) {
+	out, err := execer.runEthtool("-x", iface)
+	if err != nil {
+		if isExecNotFound(err) {
+			slog.Warn("linksetup: ethtool binary not found, cannot probe for default rss indirection",
+				"iface", iface)
+			return
+		}
+		slog.Warn("linksetup: ethtool -x failed, cannot probe for default rss indirection",
+			"iface", iface, "err", err,
+			"output", strings.TrimSpace(string(out)))
+		return
+	}
+	if indirectionTableIsDefault(out, queues) {
+		slog.Debug("linksetup: rss indirection already default, no restore needed",
+			"iface", iface)
+		return
+	}
+	if out, err := execer.runEthtool("-X", iface, "default"); err != nil {
+		if isExecNotFound(err) {
+			slog.Warn("linksetup: ethtool binary not found, cannot restore default rss indirection",
+				"iface", iface)
+			return
+		}
+		slog.Warn("linksetup: ethtool -X default failed",
+			"iface", iface, "err", err,
+			"output", strings.TrimSpace(string(out)))
+		return
+	}
+	slog.Info("linksetup: restored default round-robin rss indirection",
+		"iface", iface,
+		"reason", "workers>=queues with stale constrained table")
+}
+
+// indirectionTableIsDefault reports true iff the live `ethtool -x`
+// output describes a round-robin indirection table where
+// entry[i] == i mod queueCount. This is the exact shape mlx5
+// produces on `ethtool -X iface default` (verified live on the
+// loss:xpf-userspace-fw0 cluster, 6-queue ge-0-0-2).
+//
+// Stricter than indirectionTableMatches: rejects any custom table
+// that uses every queue at least once but doesn't match the
+// round-robin pattern.
+//
+// Returns false on empty/unparseable input, or on any row whose
+// entries don't all match the expected (rowIdx + j) % queueCount
+// position. Returns true only when at least one entry has been
+// successfully parsed AND verified.
+func indirectionTableIsDefault(output []byte, queueCount int) bool {
+	if queueCount <= 0 {
+		return false
+	}
+	sawAnyEntry := false
+	for _, line := range bytes.Split(output, []byte{'\n'}) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		colon := bytes.IndexByte(trimmed, ':')
+		if colon <= 0 {
+			continue
+		}
+		rowIdx, err := strconv.Atoi(string(trimmed[:colon]))
+		if err != nil {
+			continue
+		}
+		for j, tok := range bytes.Fields(trimmed[colon+1:]) {
+			q, err := strconv.Atoi(string(tok))
+			if err != nil {
+				return false
+			}
+			expected := (rowIdx + j) % queueCount
+			if q != expected {
+				return false
+			}
+			sawAnyEntry = true
+		}
+	}
+	return sawAnyEntry
 }
 
 // computeWeightVector returns the weight vector for the given worker and

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -239,7 +239,7 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 	queues := execer.readQueueCount(iface)
 	weights, reason := computeWeightVector(workers, queues)
 	if weights == nil {
-		slog.Info("linksetup: rss indirection skipped", "iface", iface,
+		slog.Info("linksetup: rss weight reshaping skipped", "iface", iface,
 			"workers", workers, "queues", queues, "reason", reason)
 		// #805: When workers >= queues > 1 we previously left the
 		// indirection table alone. That's correct on a fresh install

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -129,8 +129,10 @@ func (realRSSExecutor) listInterfaces() []string {
 //   - workers == 1 is skipped (single worker benefits from default RSS
 //     spreading across all HW queues / IRQ lines; weight-pinning to a
 //     single queue would serialize the worker on one IRQ — reviewer #L1).
-//   - workers >= queue_count is skipped (default table already delivers
-//     traffic to every queue; reshaping does nothing useful).
+//   - workers >= queue_count: weight reshaping is skipped (default
+//     table already delivers to every queue), BUT the live table is
+//     probed and reset to default if it carries a stale concentrated
+//     layout left over from a prior workers < queue_count apply (#805).
 //   - Idempotent: if the live indirection table already matches the
 //     computed layout, no write is issued.
 //   - Never returns a non-nil error — D3 regressions must not break

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -250,7 +250,11 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 		// and starves queues that now host worker-bound AF_XDP sockets.
 		// Inspect the live table; if it isn't the round-robin default,
 		// restore it.
-		if workers > 1 && workers >= queues && queues > 0 {
+		//
+		// Guard requires queues > 1: with a single-queue NIC there is
+		// no possible concentration to undo (the default and any
+		// "configured" layout both have entry[i] == 0 for every i).
+		if workers > 1 && workers >= queues && queues > 1 {
 			maybeRestoreDefault(iface, queues, execer)
 		}
 		return

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -16,6 +16,7 @@ import (
 	"io/fs"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -37,12 +38,37 @@ type fakeRSSExecutor struct {
 	ethtoolC map[string][]byte
 	// Recorded argvs, in call order. `{"-X", "eth0", "weight", "1", "1", "0", "0"}`, etc.
 	calls [][]string
+	// argvErr returns a scripted (output, error) for an exact argv
+	// prefix match. Used by tests that need to exercise the
+	// generic-error branches in maybeRestoreDefault. Key matches via
+	// strings.HasPrefix on a space-joined argv. For example, key
+	// "-X eth0 default" makes the `ethtool -X eth0 default` invocation
+	// return the scripted error. Checked AFTER the per-iface ethtoolX
+	// / ethtoolC path so test fixtures keep working unchanged.
+	argvErr map[string]argvErrSpec
+}
+
+// argvErrSpec scripts a (combinedOutput, error) tuple for an argv match.
+type argvErrSpec struct {
+	out []byte
+	err error
 }
 
 func (f *fakeRSSExecutor) runEthtool(args ...string) ([]byte, error) {
 	cp := make([]string, len(args))
 	copy(cp, args)
 	f.calls = append(f.calls, cp)
+	// Argv-keyed scripted errors (Codex code-review LOW #2) take
+	// precedence so tests can override default behavior for a
+	// specific invocation.
+	if f.argvErr != nil {
+		joined := strings.Join(args, " ")
+		for prefix, spec := range f.argvErr {
+			if strings.HasPrefix(joined, prefix) {
+				return spec.out, spec.err
+			}
+		}
+	}
 	if len(args) >= 2 && args[0] == "-x" {
 		if out, ok := f.ethtoolX[args[1]]; ok {
 			return out, nil
@@ -729,6 +755,89 @@ func TestApplyRSSIndirectionOne_BootSequence_4then6_RestoresDefault(t *testing.T
 	if !sawRestore {
 		t.Fatalf("step 2 (workers=6): expected -X default restore, got %v",
 			f.calls[step1Calls:])
+	}
+}
+
+// #805 test 13 (Codex LOW #2): generic -x probe error suppresses
+// the -X default call. The probe itself fails with a non-ErrNotFound
+// error; maybeRestoreDefault must log Warn and return without
+// attempting -X default.
+func TestApplyRSSIndirectionOne_RestoreEthtoolXProbeGenericError_LogAndSkip(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+		argvErr: map[string]argvErrSpec{
+			"-x eth0": {out: []byte("ethtool: bad request"), err: errors.New("exit status 1")},
+		},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	for _, c := range f.calls {
+		if len(c) >= 1 && c[0] == "-X" {
+			t.Errorf("generic probe failure → must not invoke -X, got %v", c)
+		}
+	}
+}
+
+// #805 test 14 (Codex LOW #2): generic -X default error is logged
+// and swallowed (D3 is best-effort). Ensures the function returns
+// normally without panicking or propagating.
+func TestApplyRSSIndirectionOne_RestoreEthtoolXDefaultGenericError_LoggedAndSwallowed(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+		argvErr: map[string]argvErrSpec{
+			"-X eth0 default": {out: []byte("ethtool: kernel rejected"), err: errors.New("exit status 1")},
+		},
+	}
+	// Should not panic. Both the -x probe and the failed -X default
+	// should be recorded; the function returns normally.
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 2 {
+		t.Fatalf("want 2 calls (probe + failed -X default), got %d: %v",
+			len(f.calls), f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[0], []string{"-x", "eth0"}) {
+		t.Errorf("call 0: want probe, got %v", f.calls[0])
+	}
+	if !reflect.DeepEqual(f.calls[1], []string{"-X", "eth0", "default"}) {
+		t.Errorf("call 1: want -X default, got %v", f.calls[1])
+	}
+}
+
+// #805 test 15 (Codex LOW #3): non-mlx5 driver on the new branch.
+// applyRSSIndirectionOne's first check is the driver guard; it must
+// short-circuit BEFORE the new restore-default logic.
+func TestApplyRSSIndirectionOne_NonMlxDriver_WorkersEqualsQueues_NotTouched(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": "virtio_net"},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("non-mlx5 driver on workers>=queues path → zero ethtool calls, got %v",
+			f.calls)
+	}
+}
+
+// #805 test 16 (Codex LOW #3): empty driver string (sysfs unreadable
+// for that iface). Same expectation as non-mlx5: short-circuit.
+func TestApplyRSSIndirectionOne_EmptyDriver_WorkersEqualsQueues_NotTouched(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{}, // readDriver returns ""
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("empty driver on workers>=queues path → zero ethtool calls, got %v",
+			f.calls)
 	}
 }
 

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -825,6 +825,22 @@ func TestApplyRSSIndirectionOne_NonMlxDriver_WorkersEqualsQueues_NotTouched(t *t
 	}
 }
 
+// #805 test 17 (Copilot inline #1): queueCount==1 short-circuit.
+// On a single-queue NIC there's no possible concentration to undo;
+// the guard `queues > 1` ensures we don't probe in that case.
+func TestApplyRSSIndirectionOne_QueueCountOne_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 1},
+		ethtoolX: map[string][]byte{"eth0": []byte("RX flow hash indirection table for eth0 with 1 RX ring(s):\n    0:      0     0     0     0\n")},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("queueCount=1 must short-circuit before maybeRestoreDefault, got %v", f.calls)
+	}
+}
+
 // #805 test 16 (Codex LOW #3): empty driver string (sysfs unreadable
 // for that iface). Same expectation as non-mlx5: short-circuit.
 func TestApplyRSSIndirectionOne_EmptyDriver_WorkersEqualsQueues_NotTouched(t *testing.T) {

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -486,6 +486,252 @@ func TestReapplyRSSIndirection_EndToEndWritesWeights(t *testing.T) {
 	}
 }
 
+// ─── #805: workers≥queues stale-table refresh ────────────────────────
+
+// staleTable6q4w: indirection layout left behind by an
+// applyRSSIndirectionOne run with workers=4, queues=6 — the
+// ethtool-style "uses only queues 0..3" output that
+// indirectionTableMatches([1,1,1,1,0,0]) returns true on but
+// indirectionTableIsDefault(_, 6) must return false on.
+const staleTable6q4w = `RX flow hash indirection table for eth0 with 6 RX ring(s):
+    0:      0     1     2     3     0     1
+    8:      2     3     0     1     2     3
+   16:      0     1     2     3     0     1
+`
+
+// defaultTable6q: kernel default round-robin layout for queueCount=6,
+// captured live from loss:xpf-userspace-fw0/ge-0-0-2 via
+// `ethtool -X iface default; ethtool -x iface`.
+const defaultTable6q = `RX flow hash indirection table for eth0 with 6 RX ring(s):
+    0:      0     1     2     3     4     5     0     1
+    8:      2     3     4     5     0     1     2     3
+   16:      4     5     0     1     2     3     4     5
+   24:      0     1     2     3     4     5     0     1
+`
+
+// defaultTable4q: round-robin layout for queueCount=4 (synthesized from
+// the formula entry[i] == i mod queueCount, the same shape mlx5
+// produces).
+const defaultTable4q = `RX flow hash indirection table for eth0 with 4 RX ring(s):
+    0:      0     1     2     3     0     1     2     3
+    8:      0     1     2     3     0     1     2     3
+`
+
+// #805 test 1: workers==queues, live table is from the prior
+// workers<queues apply (stale concentrated). maybeRestoreDefault must
+// fire `ethtool -X iface default`.
+func TestApplyRSSIndirectionOne_WorkersEqualsQueues_StaleTable_RestoresDefault(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 2 {
+		t.Fatalf("expected 2 ethtool calls (probe + restore), got %d: %v",
+			len(f.calls), f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[0], []string{"-x", "eth0"}) {
+		t.Errorf("call 0: want probe, got %v", f.calls[0])
+	}
+	if !reflect.DeepEqual(f.calls[1], []string{"-X", "eth0", "default"}) {
+		t.Errorf("call 1: want -X default, got %v", f.calls[1])
+	}
+}
+
+// #805 test 2: workers > queues (e.g. operator over-allocated workers).
+// Same restore-default behavior as workers==queues case.
+func TestApplyRSSIndirectionOne_WorkersGreaterThanQueues_StaleTable_RestoresDefault(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 8, f)
+
+	sawRestore := false
+	for _, c := range f.calls {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "default" {
+			sawRestore = true
+		}
+	}
+	if !sawRestore {
+		t.Fatalf("expected ethtool -X default invocation, got %v", f.calls)
+	}
+}
+
+// #805 test 3: workers >= queues but live table IS default. No write.
+func TestApplyRSSIndirectionOne_WorkersGreaterEqualQueues_DefaultTable_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(defaultTable6q)},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	for _, c := range f.calls {
+		if len(c) >= 1 && c[0] == "-X" {
+			t.Errorf("default table → must not invoke -X, got %v", c)
+		}
+	}
+}
+
+// #805 test 4: workers == 1 with stale table — must NOT touch.
+// Single-worker deploys keep default RSS regardless of stale state;
+// "stale" is only meaningful when transitioning from workers<queues
+// where some prior apply wrote concentrated weights.
+func TestApplyRSSIndirectionOne_WorkersIsOne_StaleTable_NotTouched(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 1, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("workers=1 must issue zero ethtool calls, got %v", f.calls)
+	}
+}
+
+// #805 test 5: workers == 0 with stale table — must NOT touch.
+func TestApplyRSSIndirectionOne_WorkersIsZero_StaleTable_NotTouched(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 0, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("workers=0 must issue zero ethtool calls, got %v", f.calls)
+	}
+}
+
+// #805 test 6: queueCount==0 (sysfs read failed). The
+// workers>=queues>0 guard must short-circuit.
+func TestApplyRSSIndirectionOne_QueueCountZero_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 0},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("queueCount=0 must issue zero ethtool calls, got %v", f.calls)
+	}
+}
+
+// #805 test 7: ethtool -x probe returns ErrNotFound on the
+// restore-default path. Must log warning, NOT attempt -X default.
+func TestApplyRSSIndirectionOne_RestoreEthtoolXProbeMissing_LogAndSkip(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers: map[string]string{"eth0": mlx5Driver},
+		queues:  map[string]int{"eth0": 6},
+		// No ethtoolX entry → fakeRSSExecutor returns ErrNotFound on -x.
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	for _, c := range f.calls {
+		if len(c) >= 1 && c[0] == "-X" {
+			t.Errorf("probe failure → must not invoke -X, got %v", c)
+		}
+	}
+}
+
+// #805 test 8: parser — true round-robin for the given queueCount.
+func TestIndirectionTableIsDefault_RoundRobin_True(t *testing.T) {
+	if !indirectionTableIsDefault([]byte(defaultTable6q), 6) {
+		t.Error("captured ge-0-0-2 default table must parse as default")
+	}
+	if !indirectionTableIsDefault([]byte(defaultTable4q), 4) {
+		t.Error("synthetic 4-queue default must parse as default")
+	}
+}
+
+// #805 test 9: parser — concentrated [1,1,1,1,0,0]-style table is NOT
+// default.
+func TestIndirectionTableIsDefault_Concentrated_False(t *testing.T) {
+	if indirectionTableIsDefault([]byte(staleTable6q4w), 6) {
+		t.Error("stale concentrated table must NOT parse as default")
+	}
+}
+
+// #805 test 10: parser — table that uses every queue at least once but
+// in non-round-robin order is NOT default. Tightens R2 #3.
+func TestIndirectionTableIsDefault_EveryQueueOnceButNonRoundRobin_False(t *testing.T) {
+	custom := []byte(`RX flow hash indirection table for eth0 with 6 RX ring(s):
+    0:      5     4     3     2     1     0     5     4
+    8:      3     2     1     0     5     4     3     2
+`)
+	if indirectionTableIsDefault(custom, 6) {
+		t.Error("non-round-robin table that uses every queue must NOT parse as default")
+	}
+}
+
+// #805 test 11: parser — empty / unparseable / value-less inputs all
+// return false. The R3 sawAnyEntry guard must reject "row index with
+// no values".
+func TestIndirectionTableIsDefault_EmptyOutput_False(t *testing.T) {
+	if indirectionTableIsDefault([]byte(""), 6) {
+		t.Error("empty output must NOT be default")
+	}
+	headerOnly := []byte("RX flow hash indirection table for eth0 with 6 RX ring(s):\nRSS hash key:\n  0a:1b:2c:3d:4e\n")
+	if indirectionTableIsDefault(headerOnly, 6) {
+		t.Error("header-only output (no row data) must NOT be default")
+	}
+	emptyRow := []byte("    0:\n")
+	if indirectionTableIsDefault(emptyRow, 6) {
+		t.Error("row index with no values must NOT be default (sawAnyEntry guard)")
+	}
+}
+
+// #805 test 12: full end-to-end transition. Step 1: workers=4, queues=6
+// with a default starting table → write concentrated. Step 2: same
+// iface, workers=6, queues=6 with the now-stale concentrated table →
+// restore default.
+func TestApplyRSSIndirectionOne_BootSequence_4then6_RestoresDefault(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(defaultTable6q)},
+	}
+
+	// Step 1: workers=4. computeWeightVector → [1,1,1,1,0,0]. Live
+	// table is default (doesn't match [1,1,1,1,0,0]) so a write fires.
+	applyRSSIndirectionOne("eth0", 4, f)
+	step1Calls := len(f.calls)
+	sawWeight := false
+	for _, c := range f.calls {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "weight" {
+			sawWeight = true
+		}
+	}
+	if !sawWeight {
+		t.Fatalf("step 1 (workers=4): expected -X weight write, got %v", f.calls)
+	}
+
+	// Simulate the kernel-side outcome: live table is now the stale
+	// concentrated layout.
+	f.ethtoolX["eth0"] = []byte(staleTable6q4w)
+
+	// Step 2: workers=6. computeWeightVector returns nil; the new
+	// maybeRestoreDefault path must detect the stale table and fire
+	// `ethtool -X eth0 default`.
+	applyRSSIndirectionOne("eth0", 6, f)
+	sawRestore := false
+	for _, c := range f.calls[step1Calls:] {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "default" {
+			sawRestore = true
+		}
+	}
+	if !sawRestore {
+		t.Fatalf("step 2 (workers=6): expected -X default restore, got %v",
+			f.calls[step1Calls:])
+	}
+}
+
 // Sanity: the production isExecNotFound detects the stable sentinel that
 // `exec.Command("missing").CombinedOutput()` wraps, without substring
 // matching (Go MEDIUM #1).

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -38,13 +38,13 @@ type fakeRSSExecutor struct {
 	ethtoolC map[string][]byte
 	// Recorded argvs, in call order. `{"-X", "eth0", "weight", "1", "1", "0", "0"}`, etc.
 	calls [][]string
-	// argvErr returns a scripted (output, error) for an exact argv
-	// prefix match. Used by tests that need to exercise the
-	// generic-error branches in maybeRestoreDefault. Key matches via
-	// strings.HasPrefix on a space-joined argv. For example, key
-	// "-X eth0 default" makes the `ethtool -X eth0 default` invocation
-	// return the scripted error. Checked AFTER the per-iface ethtoolX
-	// / ethtoolC path so test fixtures keep working unchanged.
+	// argvErr returns a scripted (output, error) for an argv-prefix
+	// match. Used by tests that need to exercise the generic-error
+	// branches in maybeRestoreDefault. Key matches via strings.HasPrefix
+	// on a space-joined argv (longest matching prefix wins, for
+	// determinism — see runEthtool). Checked BEFORE the per-iface
+	// ethtoolX / ethtoolC path so a test can override default behavior
+	// for a specific invocation.
 	argvErr map[string]argvErrSpec
 }
 
@@ -62,11 +62,23 @@ func (f *fakeRSSExecutor) runEthtool(args ...string) ([]byte, error) {
 	// precedence so tests can override default behavior for a
 	// specific invocation.
 	if f.argvErr != nil {
+		// Longest-prefix-wins for determinism — Go map iteration
+		// is randomized, so without this two overlapping prefix
+		// keys (e.g. "-X eth0" and "-X eth0 default") would
+		// produce flaky tests.
 		joined := strings.Join(args, " ")
+		var bestPrefix string
+		var bestSpec argvErrSpec
+		matched := false
 		for prefix, spec := range f.argvErr {
-			if strings.HasPrefix(joined, prefix) {
-				return spec.out, spec.err
+			if strings.HasPrefix(joined, prefix) && len(prefix) >= len(bestPrefix) {
+				bestPrefix = prefix
+				bestSpec = spec
+				matched = true
 			}
+		}
+		if matched {
+			return bestSpec.out, bestSpec.err
 		}
 	}
 	if len(args) >= 2 && args[0] == "-x" {
@@ -825,22 +837,6 @@ func TestApplyRSSIndirectionOne_NonMlxDriver_WorkersEqualsQueues_NotTouched(t *t
 	}
 }
 
-// #805 test 17 (Copilot inline #1): queueCount==1 short-circuit.
-// On a single-queue NIC there's no possible concentration to undo;
-// the guard `queues > 1` ensures we don't probe in that case.
-func TestApplyRSSIndirectionOne_QueueCountOne_NoOp(t *testing.T) {
-	f := &fakeRSSExecutor{
-		drivers:  map[string]string{"eth0": mlx5Driver},
-		queues:   map[string]int{"eth0": 1},
-		ethtoolX: map[string][]byte{"eth0": []byte("RX flow hash indirection table for eth0 with 1 RX ring(s):\n    0:      0     0     0     0\n")},
-	}
-	applyRSSIndirectionOne("eth0", 6, f)
-
-	if len(f.calls) != 0 {
-		t.Errorf("queueCount=1 must short-circuit before maybeRestoreDefault, got %v", f.calls)
-	}
-}
-
 // #805 test 16 (Codex LOW #3): empty driver string (sysfs unreadable
 // for that iface). Same expectation as non-mlx5: short-circuit.
 func TestApplyRSSIndirectionOne_EmptyDriver_WorkersEqualsQueues_NotTouched(t *testing.T) {
@@ -854,6 +850,22 @@ func TestApplyRSSIndirectionOne_EmptyDriver_WorkersEqualsQueues_NotTouched(t *te
 	if len(f.calls) != 0 {
 		t.Errorf("empty driver on workers>=queues path → zero ethtool calls, got %v",
 			f.calls)
+	}
+}
+
+// #805 test 17 (Copilot inline #1): queueCount==1 short-circuit.
+// On a single-queue NIC there's no possible concentration to undo;
+// the guard `queues > 1` ensures we don't probe in that case.
+func TestApplyRSSIndirectionOne_QueueCountOne_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 1},
+		ethtoolX: map[string][]byte{"eth0": []byte("RX flow hash indirection table for eth0 with 1 RX ring(s):\n    0:      0     0     0     0\n")},
+	}
+	applyRSSIndirectionOne("eth0", 6, f)
+
+	if len(f.calls) != 0 {
+		t.Errorf("queueCount=1 must short-circuit before maybeRestoreDefault, got %v", f.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #805 — when `system dataplane workers` is bumped from `< queue_count` to `>= queue_count` (e.g. 4→6 on a 6-queue mlx5), the previously-written constrained `[1,1,1,1,0,0]` indirection table stays live. Queues 4-5 now host worker-bound AF_XDP sockets but receive no RSS traffic.

## Fix

On the `nil-weights` skip path of `applyRSSIndirectionOne`, when `workers > 1 && workers >= queues > 0`, inspect the live indirection table. If it isn't the kernel's default round-robin shape (`entry[i] == i mod queueCount`), run `ethtool -X iface default` to restore.

Helpers added:
- `indirectionTableIsDefault(output, queueCount)` — strict round-robin check, validated empirically against live mlx5 default on `loss:xpf-userspace-fw0/ge-0-0-2`.
- `maybeRestoreDefault(iface, queues, execer)` — runs the probe + restore, mirroring the existing apply-path's failure handling.

Other skip paths (`workers <= 0`, `workers == 1`) preserved unchanged — bring-up / single-worker cases have no prior state to undo.

## Tests (12 new in `pkg/daemon/rss_indirection_test.go`)

- 7 behavioral: workers=queues stale → restore; workers>queues stale → restore; workers≥queues default → no-op; workers∈{0,1} stale → preserved; queueCount=0 → short-circuit; probe-failure → log+skip
- 4 parser: round-robin true; concentrated false; every-queue-but-non-round-robin false; empty/unparseable/value-less false
- 1 end-to-end: `BootSequence_4then6_RestoresDefault` covers the full operator workflow

## Review history

- Plan with 4 Codex review rounds at `docs/pr/805-rss-refresh/plan.md`. R1 found 2 HIGH (false rssWriteMu/bool-return claims from #840-reverted), R2 found 1 MED (vacuously-true parser bug), R3 found 1 LOW (sawAnyRow set before queue token verified), R4: PLAN-READY YES.
- Empirical mlx5 default table captured live before implementation.

## Test plan

- [x] `go test ./pkg/daemon/` — all tests pass including new 12
- [x] `go test ./pkg/...` — full suite clean
- [ ] Codex code review against the plan
- [ ] Copilot inline review
- [ ] Live deploy on `loss:xpf-userspace-fw0` — verify workers=4→6 commit restores default
- [ ] `make test-failover` — optional defense (per plan §10, not a merge blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)