### PR TITLE
#838 AFD-lite: negative finding (plan-stage); document fairness path forward

### DIFF
--- a/docs/pr/838-afd-lite/findings.md
+++ b/docs/pr/838-afd-lite/findings.md
@@ -1,0 +1,211 @@
+# #838 AFD-lite — Negative finding (plan-stage), and the broader fairness picture
+
+## TL;DR
+
+Five rounds of Codex plan review on #838 (AFD-lite, single-binding scope)
+keep surfacing new architectural defects. R5 found a structural blocker
+(Q9: selector blind during scratch-build) that would require another
+round of redesign with no certainty of convergence at R6.
+
+This is the third consecutive cross-binding/scheduler-state fairness
+attempt to stall:
+
+| Issue | Approach | Outcome |
+|---|---|---|
+| #836 | shared MQFQ HOL-finish-time array | Closed at R7 plan review (7 HIGH; non-commutative quantity) |
+| #840 | RSS rebalance from per-binding RX signal | Implemented + reverted (`docs/pr/835-slice-d-rss/findings.md`); deploy CoV 37.7 % vs 18.5 % baseline; **made fairness worse** |
+| #838 | per-flow bytes-served counter, periodic reset | 5 plan rounds, 14+ HIGH cumulatively; stuck at structural blocker |
+
+**Empirical baseline (#900) shows the existing scheduler is acceptable
+for the throughput-fairness problem.** The original "many streams
+collapse to 0 bps" symptom does not reproduce under standard test
+conditions. The 100E100M problem reduces to mouse-latency-tail
+characterization, for which we now have infrastructure (operator
+echo server on 172.16.80.200:7) but no measurement.
+
+Recommendation: **stop algorithm work, do measurement.**
+
+## What was actually built across the three attempts
+
+### #836 — shared HOL-finish-time array
+- Plan tried to share MQFQ virtual finish times across bindings via
+  atomic head/tail per bucket.
+- Codex review (`docs/pr/836-shared-flow-vtime/codex-plan-review.md`) found
+  HOL-finish-time is **not commutative**: it's a per-packet timestamp,
+  changes non-additively on every dequeue, rollback needs snapshot
+  state, and concurrent writers can corrupt the ordering.
+- Closed without implementation. Folded into the larger #837
+  redesign.
+
+### #840 — RSS rebalance from per-binding RX signal
+- Implemented. Code review MERGE YES. 33+ unit tests pass.
+- Deployed: 10-run CoV measurement.
+- **Result: CoV 37.7 % enabled vs 18.5 % baseline** (`docs/pr/840-slice-d-v2/findings.md`).
+- Root cause: the rebalance loop steers RSS hashes toward "underloaded"
+  RX rings, but those rings are underloaded *because their flows are
+  small*; moving the larger flows onto them creates oscillation and
+  bigger swings between samples. Empirical evidence that "shift the
+  hash" is not a substitute for per-flow scheduling.
+- Reverted in commit `1c611d01`; kept atomics+locked-split scaffolding
+  for #835 D3.
+
+### #838 — AFD-lite, single-binding scope
+- Plan only. v1 → v2 → v3 (single-binding) across 5 Codex rounds.
+- v1+v2 (cross-binding): 14 HIGH findings on race ordering, period
+  reset coherence, fair_share denominator staleness, and rollback
+  semantics. User reduced scope to single-binding only.
+- v3 R3-R4 (single-binding): closed most of those, but **R5 found
+  Q9**: the selector runs during scratch-build (one decision per
+  packet) but accounting happens at settle (one update per *batch*).
+  TX_BATCH_SIZE up to 256; best-effort fair share at ~16 packets/period.
+  In a single batch the selector can ship multiple periods' worth of
+  packets while the per-flow counter still reads zero — AFD never
+  engages.
+- Fix would need provisional per-batch accounting at selection time
+  with rollback on rejected-tail at settle. That is another structural
+  redesign, with no R5-clean precedent giving us confidence R6 won't
+  surface a different structural issue.
+
+## The pattern
+
+All three attempts share a structural assumption that has not held:
+
+> "We can encode fairness as additional state read/written in the
+> existing per-binding hot path."
+
+What actually happens in this codebase:
+
+1. The hot path is **batch-shaped** (TX_BATCH_SIZE ~256), so
+   per-packet accounting that drives per-packet decisions has a
+   one-batch latency — bigger than the period the algorithm assumes.
+2. `flow_bucket_bytes` is a **queue-backlog** counter (bytes waiting),
+   not a **bytes-served** counter. The two are different signals;
+   #838 was trying to retrofit one as the other.
+3. Cross-binding shared atomic state has at-least-three race
+   surfaces (period reset, denominator update, rollback) and we keep
+   discovering them by review one at a time.
+4. The actual *symptom* people see — "stream collapses to zero" — is
+   bound up with TCP cwnd dynamics under SFQ buckets, RSS-hash
+   distribution, and head-of-line blocking inside a single AF_XDP
+   ring. None of those are addressed by the scheduler-state changes
+   that were tried.
+
+## What the data actually says (#900)
+
+Single iperf3 stream count varied; 1 Gb/s shaper (iperf-a class):
+
+| streams | aggregate | CoV    | collapsed | within ±25 % of fair |
+|--------:|----------:|-------:|----------:|---------------------:|
+| 16      | 0.954 Gb  | 18.5 % | 0 / 16    | (baseline)           |
+| 128     | 0.954 Gb  | 16.6 % | 0 / 128   | 119 / 128 (93 %)     |
+
+CoV got *tighter* at 128 streams. Worst-case stream is 0.72× of mean
+(vs 0.81 at 16 streams) — modest degradation, no collapse.
+
+**The "elephant fairness" half of 100E100M is solved, empirically.**
+
+## What we still don't know — the actual 100E100M gap
+
+The 100E100M problem has two halves:
+- **Throughput fairness across N elephants** — measured, acceptable
+  at N=128, see above.
+- **Latency tail across M mice during heavy elephant load** — never
+  measured. Both attempts (hping3, Python TCP-connect) hit
+  infrastructure walls (raw-socket scaling, SYN-cookie defense,
+  iperf3 single-tenant accept).
+
+We now have a way to measure mouse latency:
+- Operator-enabled echo server on **172.16.80.200:7** (TCP+UDP) and
+  **2001:559:8585:80::200:7** (v6).
+- Per-port CoS classifiers (`test/incus/cos-iperf-config.set`) place
+  echo on best-effort (port 7 is not 5201-5204), which is the
+  workload we want — mice on best-effort, elephants on iperf-a/b/c.
+
+A measurement here would give us:
+- Mouse RTT p50, p95, p99 with N=0 elephants (idle baseline).
+- Mouse RTT p50, p95, p99 with N=8, 32, 128 elephants on iperf-a.
+- Mouse RTT impact of CoS class assignment (mice on best-effort vs
+  mice on iperf-a alongside the elephants).
+- Whether the existing SFQ buckets isolate mice from elephant HOL
+  blocking, or whether they share queues and mice take the tail.
+
+Without this data, we are guessing at which fairness algorithm is
+worth implementing. Algorithm work is the wrong next step.
+
+## What we should do
+
+### Immediate (this PR / branch)
+
+1. **Close #838** with reference to this finding. The branch
+   (`pr/838-afd-lite`) holds plan-only commits; no implementation
+   shipped. Drop the plan from the in-flight set.
+2. **Do not retire #837.** It captures the larger redesign that
+   would be needed for true cross-binding MQFQ; if mouse-latency
+   data later shows we need it, the design context is preserved.
+3. **Clean up the bucket-bytes naming confusion.** The
+   `flow_bucket_bytes` field is queue-backlog; comments at
+   `userspace-dp/src/afxdp/types.rs:1081` and the surrounding doc
+   should call it that, not "bytes served". Future plans keep
+   conflating the two.
+
+### Next (new issue, not #838)
+
+4. **File a measurement issue: "characterize mouse latency tail
+   under elephant load using 172.16.80.200:7 echo server"**.
+   Concrete deliverables:
+   - Test harness that launches N (1, 8, 32, 128) iperf3 elephant
+     streams on iperf-a (port 5201) and concurrently runs M
+     paced TCP-connect+echo probes against port 7.
+   - Per-probe RTT histogram exported as JSON.
+   - Run matrix: { N ∈ {0, 8, 32, 128} } × { M ∈ {1, 10, 50} } ×
+     { mouse_class ∈ {best-effort, iperf-a-shared} } = 24 cells.
+   - PASS gate: mouse p99 ≤ 2× idle baseline at N=128, M=10,
+     mice on best-effort.
+5. **Only after measurement**, decide whether algorithm work is
+   needed. If p99 is acceptable, fairness work is closed for now.
+   If p99 is bad, the data tells us *which* mechanism to fix —
+   per-flow XDP_REDIRECT, per-class queue isolation, AFD on the
+   rejected-tail path, etc.
+
+### Deferred
+
+6. **Do not pursue #838 v3 R6+** without a concrete measurement
+   that motivates AFD specifically. The Q9 fix (provisional
+   per-batch accounting) is a real codebase change with real risk;
+   we should not pay that cost speculatively.
+7. **Do not reopen #840.** Empirical evidence (CoV 37.7 % vs 18.5 %)
+   is conclusive that RSS-rebalance from queue-backlog signal makes
+   things worse, regardless of follow-ups #897/#898/#899.
+
+## Lessons we should carry forward
+
+- **Plan reviews diverge when the architecture is wrong.** Five
+  Codex rounds with new HIGH findings each round is the pattern of
+  a structural mismatch, not a coverage gap. If R3 introduces new
+  issues that R2 didn't have, the plan is being bent into a shape
+  the codebase doesn't support.
+- **"Commutative under races" is a real architectural property.**
+  #836 failed because HOL-finish-time isn't. #838 R1+R2 (cross-binding)
+  failed because the additional state (period reset, fair-share
+  denominator) needed by the commutative `fetch_add` wasn't itself
+  commutative.
+- **Empirical baseline before algorithm work.** #900 took the same
+  effort as one Codex round and produced more decision-relevant
+  data than 5 rounds of #838 did.
+- **Negative findings have value.** #835/#840/#900 finding files
+  are referenced repeatedly and saved later attempts from the same
+  trap. Keep writing them. (This file is one of those.)
+
+## Files
+
+- `docs/pr/838-afd-lite/plan.md` — five-round plan; preserved as
+  design archive.
+- `docs/pr/836-shared-flow-vtime/` — predecessor; HOL-finish
+  closed-without-implementation.
+- `docs/pr/835-slice-d-rss/findings.md` — RSS rebalance signal-dead
+  empirical finding.
+- `docs/pr/840-slice-d-v2/findings.md` — RSS rebalance with valid
+  signal, CoV-worse-than-baseline empirical finding.
+- `docs/pr/900-100e100m-harness/findings.md` — 128-stream baseline
+  acceptable.
+- `docs/pr/838-afd-lite/findings.md` — this document.

--- a/docs/pr/838-afd-lite/findings.md
+++ b/docs/pr/838-afd-lite/findings.md
@@ -12,8 +12,8 @@ attempt to stall:
 
 | Issue | Approach | Outcome |
 |---|---|---|
-| #836 | shared MQFQ HOL-finish-time array | Closed at R7 plan review (7 HIGH; non-commutative quantity) |
-| #840 | RSS rebalance from per-binding RX signal | Implemented + reverted (`docs/pr/835-slice-d-rss/findings.md`); deploy CoV 37.7 % vs 18.5 % baseline; **made fairness worse** |
+| #836 | shared MQFQ HOL-finish-time array | Closed without implementation 2026-04-22; non-commutative quantity (see issue #836 discussion + sibling #837) |
+| #840 | RSS rebalance from per-binding RX signal | Implemented + reverted; revert commit `1c611d01` carries the 37.7 % vs 18.5 % CoV data in its message; **made fairness worse**. See also `docs/pr/835-slice-d-rss/findings.md` for the dead-signal predecessor finding |
 | #838 | per-flow bytes-served counter, periodic reset | 5 plan rounds, 14+ HIGH cumulatively; stuck at structural blocker |
 
 **Empirical baseline (#900) shows the existing scheduler is acceptable
@@ -30,17 +30,20 @@ Recommendation: **stop algorithm work, do measurement.**
 ### #836 — shared HOL-finish-time array
 - Plan tried to share MQFQ virtual finish times across bindings via
   atomic head/tail per bucket.
-- Codex review (`docs/pr/836-shared-flow-vtime/codex-plan-review.md`) found
-  HOL-finish-time is **not commutative**: it's a per-packet timestamp,
-  changes non-additively on every dequeue, rollback needs snapshot
-  state, and concurrent writers can corrupt the ordering.
-- Closed without implementation. Folded into the larger #837
-  redesign.
+- Plan review (in-issue discussion on #836; no docs/pr archive was
+  committed for this issue) concluded HOL-finish-time is **not
+  commutative**: it's a per-packet timestamp, changes non-additively on
+  every dequeue, rollback needs snapshot state, and concurrent writers
+  can corrupt the ordering.
+- Closed without implementation 2026-04-22. The larger redesign that
+  would be needed for cross-binding MQFQ is preserved as #837.
 
 ### #840 — RSS rebalance from per-binding RX signal
 - Implemented. Code review MERGE YES. 33+ unit tests pass.
 - Deployed: 10-run CoV measurement.
-- **Result: CoV 37.7 % enabled vs 18.5 % baseline** (`docs/pr/840-slice-d-v2/findings.md`).
+- **Result: CoV 37.7 % enabled vs 18.5 % baseline** (data captured in
+  the revert commit message at `1c611d01`; no separate findings file
+  was committed for #840).
 - Root cause: the rebalance loop steers RSS hashes toward "underloaded"
   RX rings, but those rings are underloaded *because their flows are
   small*; moving the larger flows onto them creates oscillation and
@@ -198,14 +201,15 @@ worth implementing. Algorithm work is the wrong next step.
 
 ## Files
 
-- `docs/pr/838-afd-lite/plan.md` — five-round plan; preserved as
-  design archive.
-- `docs/pr/836-shared-flow-vtime/` — predecessor; HOL-finish
-  closed-without-implementation.
+- `docs/pr/838-afd-lite/plan.md` — five-round plan archive (R1-R5
+  review responses).
 - `docs/pr/835-slice-d-rss/findings.md` — RSS rebalance signal-dead
-  empirical finding.
-- `docs/pr/840-slice-d-v2/findings.md` — RSS rebalance with valid
-  signal, CoV-worse-than-baseline empirical finding.
-- `docs/pr/900-100e100m-harness/findings.md` — 128-stream baseline
-  acceptable.
+  predecessor finding (the ethtool-S signal was inactive under
+  AF_XDP zero-copy).
+- Commit `1c611d01` — #840 revert; CoV 37.7 % vs 18.5 % baseline
+  data in the commit message body.
+- `docs/pr/900-100e100m-harness/findings.md` — 128-stream baseline,
+  CoV 16.6 %, 0 collapses.
+- Issue #836 (closed 2026-04-22) — predecessor; HOL-finish
+  non-commutative; folded into #837 for any future redesign.
 - `docs/pr/838-afd-lite/findings.md` — this document.

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -278,112 +278,193 @@ pub(super) fn afd_threshold(state: &AFDLiteState) -> u64 { ... }  // helper for 
 
 ### 6.3 Edits to `userspace-dp/src/afxdp/tx.rs`
 
-#### 6.3.1 FIFO-pop accounting (single-packet path)
+R4 review forced grounding in the real code. The actual
+flow-fair+exact dispatch path (the workload our test matrix
+hits) is:
 
-For the FIFO single-packet pop sites, the accounting hook
-goes inside the success branch immediately after the per-
-packet `bytes` sum is incremented. The R1-identified sites
-in this category map to the actual success-after-insert
-points:
+```
+service_exact_local_queue_direct (tx.rs:1932)
+  └ flow_fair branch (tx.rs:1946-1949)
+    └ service_exact_local_queue_direct_flow_fair (tx.rs:2082)
+      └ submit_cos_batch (returns bool)
+      └ settle_exact_local_scratch_submission_flow_fair (tx.rs:2945)
+            ↑ THIS is the post-TX commit point
+```
 
-- `tx.rs:2922-2927` (FIFO local request: after
-  `sent_bytes += req.bytes.len() as u64` per Codex R3
-  Area 6, in the `Some(Local(req))` branch).
-- The matching prepared-frame branch in the same FIFO loop.
+And the prepared-frame variant:
 
-At each, gate on `queue.flow_fair && !queue.shared_exact`
-and call `afd_account_dispatch(state, bucket, bytes,
-now_ns)`. The `bucket` here is computed via
-`cos_flow_bucket_index(queue.flow_hash_seed, flow_key)`
-on the popped item, before the item is consumed.
+```
+service_exact_prepared_queue_direct_flow_fair (tx.rs:2368)
+  └ submit_cos_batch
+  └ settle_exact_prepared_scratch_submission_flow_fair (tx.rs:3000)
+        ↑ post-TX commit point
+```
 
-#### 6.3.2 Batch-pop accounting (R3 HIGH 4 fix)
+#### 6.3.1 The accepted-prefix discrimination is already done
 
-The R3 review correctly flagged that the batch-pop sites
-at `tx.rs:3129/3170` happen DURING batch construction
-(pre-TX), while the true success sites at `tx.rs:3214/3272`
-only have aggregate `(packets, bytes)` and retry-tail state
-— per-flow bucket identity is lost by then.
+The `settle_*_flow_fair` functions take `inserted: usize`
+(R4 HIGH 2: `inserted` is the accepted-packet-count from
+the xsk send return) and iterate the scratch buffer
+backwards. For each item:
 
-**Redesigned batch accounting (matches the no-rollback
-design)**:
+- If `scratch_*.len() >= inserted` (rejected tail): push
+  the item back via `cos_queue_push_front`.
+- Else (accepted prefix): increment `sent_packets` /
+  `sent_bytes`.
 
-1. **During pop**: each batch-pop iteration that adds an
-   item to the in-flight batch buffer ALSO appends a
-   `(bucket_idx, bytes)` tuple to a per-batch staging
-   buffer. The staging buffer is a small `SmallVec` or
-   stack-allocated array (typical batch size ≤ 64; bound
-   to TX_BATCH_SIZE = 256 worst case).
-2. **After `submit_cos_batch` returns the accepted count
-   `N`**: iterate the first `N` staging tuples and call
-   `afd_account_dispatch` for each. The unaccepted tail
-   (positions N..staging_len) is left untouched — those
-   items are pushed back via push_front (existing code),
-   AFD never accounted them.
-3. **On full-batch failure (`inserted == 0`)**: don't
-   iterate at all. Staging buffer dropped. AFD untouched.
+So **no separate staging buffer is needed** (R3 HIGH 4
+proposed redesign was reinventing this). The existing
+settle functions ARE the staging-prefix walkers. AFD-lite's
+hook just goes in the accepted branch.
 
-This matches the no-rollback contract: AFD is only
-incremented for bytes that successfully transmitted. Partial
-batch acceptance is correctly handled.
+R4 HIGH 1 (staging buffer location) and R4 HIGH 5
+(signature chain) are dropped — there is no new staging
+buffer.
 
-**Per-batch staging buffer**: a new `Vec<(u16, u32)>`
-(bucket_idx + bytes_u32, since per-packet bytes ≤ 9000)
-allocated once and reused across batches via clear/reuse.
-Add as a field on `BindingWorker` or as a function-local
-that's reused across calls. Hot-path overhead: one extra
-push-tuple per packet popped (8-16 bytes); insignificant.
+#### 6.3.2 AFD hooks: settle-function accepted branches
 
-**Sites to edit**:
-- `tx.rs:3129/3170` (pop-during-batch): stage tuple.
-- `tx.rs:3214/3272` (submit success): iterate staging
-  prefix N and call `afd_account_dispatch`.
-- `tx.rs:6206/6215/6433/6442` (settle / partial-success):
-  these may also need staging-prefix accounting depending
-  on which path they're on. Verify against actual code at
-  implementation time.
+Two sites:
 
-#### 6.3.3 Failure / rollback paths
+**Local TX** — `settle_exact_local_scratch_submission_flow_fair`
+at tx.rs:2945. Edit the `else` branch (currently
+tx.rs:2961-2964):
 
-Per §5.2, do nothing. Failed TX simply doesn't account.
-The staging buffer for batch paths is dropped/cleared.
+```rust
+} else {
+    sent_packets += 1;
+    sent_bytes += req.bytes.len() as u64;
+    // #838 AFD-lite hook (v3 single-binding):
+    if !queue.shared_exact {
+        if let Some(afd) = queue.afd.as_mut() {
+            let flow_key = req_flow_key(&req);
+            let bucket = cos_flow_bucket_index(queue.flow_hash_seed, flow_key);
+            afd_account_dispatch(afd, usize::from(bucket), req.bytes.len() as u64, now_ns);
+        }
+    }
+}
+```
 
-#### 6.3.4 Selection sites
+**Prepared TX** — `settle_exact_prepared_scratch_submission_flow_fair`
+at tx.rs:3000. Edit the `else` branch (currently
+tx.rs:3015-3019):
 
-- `cos_queue_front` (`tx.rs:4262`) → call
-  `cos_queue_select_bucket(queue, now_ns)`.
-- `cos_queue_pop_front_inner` (`tx.rs:4464`-area) → same.
+```rust
+} else {
+    remember_prepared_recycle(in_flight_prepared_recycles, &req);
+    sent_packets += 1;
+    sent_bytes += req.len as u64;
+    // #838 AFD-lite hook:
+    if !queue.shared_exact {
+        if let Some(afd) = queue.afd.as_mut() {
+            let bucket = cos_flow_bucket_index(queue.flow_hash_seed, req_flow_key_prepared(&req));
+            afd_account_dispatch(afd, usize::from(bucket), req.len as u64, now_ns);
+        }
+    }
+}
+```
 
-The `now_ns` argument is plumbed from the existing call
-chain. Per Codex R3 Area 3, this also requires threading
-through `build_cos_batch_from_queue` and the drain helpers
-(call sites at `tx.rs:2602/2780/3102`). Worker hot-paths
-already have a `now_ns` (from the polling loop's
-`monotonic_ns()`); pass through. Bounded surface — every
-caller already has a clock value at hand.
+The `flow_fair` gate is already implicit (these settle
+functions are only called from the flow-fair dispatch
+branch at tx.rs:1947).
 
-#### 6.3.5 One-packet-stale on selection (R3 MED 10)
+The `!queue.shared_exact` gate keeps v3 scope to single-
+binding queues.
 
-Selection (`cos_queue_select_bucket`) reads `now_ns` but
-does **not** rotate. Rotation happens only inside
-`afd_account_dispatch`, which runs on the success path
-AFTER selection. Consequence: the first selection AFTER a
-window expiry (e.g. window N→N+1 boundary) uses stale
-window-N counters. Once that packet's dispatch hook fires,
-rotation moves state to N+1; subsequent selections are
-fresh.
+`req_flow_key` / `req_flow_key_prepared` extract the 5-tuple
+from the request; helpers already exist for this. Verify
+exact name during implementation.
 
-This is acceptable:
-- 2 ms window × 150 K pps = ~300 packets per window. One
-  stale-selection per window is < 0.4 % of selections.
-- The stale data biases ONE selection toward whatever
-  was over-share at the end of the previous window;
-  bounded by the previous window's threshold (already a
-  fair-share-ish value).
+#### 6.3.3 now_ns plumbing
 
-Documented; not mitigated. Mitigation would require
-`cos_queue_front` to take `&mut CoSQueueRuntime`, which
-broadens the call-site change beyond v3 scope.
+Both settle functions don't currently take `now_ns`. Add a
+parameter. Callers:
+
+- `service_exact_local_queue_direct_flow_fair` at tx.rs:2082
+  — already has `now_ns` from its caller chain.
+- `service_exact_prepared_queue_direct_flow_fair` at tx.rs:2368
+  — same.
+
+Selection sites for `cos_queue_select_bucket(queue, now_ns)`:
+- `cos_queue_front` at tx.rs:4262
+- `cos_queue_pop_front_inner` at tx.rs:4464-area
+- Called from `select_cos_guarantee_batch` (tx.rs:1740,
+  1836), `select_cos_surplus_batch` (tx.rs:1890), and
+  `build_cos_batch_from_queue` (tx.rs:3102) per R4 MED 11.
+  Each caller has `now_ns` available (from its parent dispatch
+  loop); thread through.
+
+Total signature change surface: ~10 functions. Mechanical.
+
+#### 6.3.4 Out-of-scope dispatch paths
+
+- **FIFO path** (`tx.rs:2922-2927`, where `sent_bytes +=
+  req.bytes.len()` lives in the FIFO settle): R4 LOW 4 +
+  LOW 6 — this is the non-flow-fair path. Skipped by the
+  v3 gate (`flow_fair == false` → no `afd` field). No
+  hook needed. State this here so the implementer doesn't
+  look for one.
+- **Surplus / Guarantee batch paths** (`select_cos_*_batch`
+  → `build_cos_batch_from_queue`): these are also
+  non-flow-fair (the path checks `queue.exact` and skips
+  exact queues at line 1887). Selection-side `now_ns`
+  threading is needed (per §6.3.3) for the
+  `cos_queue_select_bucket` call, but no AFD accounting
+  hook is needed here.
+- **Settle FIFO** (tx.rs:2969 `settle_exact_prepared_fifo_submission`):
+  this is the `!flow_fair` branch. Non-flow-fair → no
+  AFD state → no hook.
+
+#### 6.3.5 Failure / rollback paths
+
+Per §5.2, do nothing. Failed-TX items go back to the queue
+via `cos_queue_push_front` (already in the settle code at
+tx.rs:2960 and 3014). AFD hook is in the OTHER branch
+(accepted), so failed items naturally bypass accounting.
+
+This closes R3 HIGH 6 (rollback overcharge) — there is no
+rollback path that touches AFD; the byte-count ledger is
+write-only.
+
+#### 6.3.6 One-packet-stale on selection — recomputed (R4 HIGH 3)
+
+R4 HIGH 3 correctly flagged my <0.4% calc was at high pps.
+At lower pps (small CoS class, small flow count), the stale
+rate climbs.
+
+Recomputed worst-case stale-rate per class, assuming the
+2 ms window:
+
+| Class | Shaped rate | 16-stream pps | Pkts/window | 1 stale = |
+|-------|-------------|---------------|-------------|-----------|
+| iperf-c (25 Gb/s) | ~2 M pps | 2 M / 16 ≈ 125 K per stream, total 2 M | ~4000 | 0.025 % |
+| iperf-b (10 Gb/s) | ~830 K pps | total 830 K | ~1660 | 0.06 % |
+| iperf-a (1 Gb/s) | ~83 K pps | total 83 K | ~166 | 0.6 % |
+| best-effort (100 Mb/s) | ~8.3 K pps | total 8.3 K | ~16.6 | **6 %** |
+
+(Assumes 1500-byte packets.)
+
+For the small classes (iperf-a and best-effort), one stale
+selection per window is non-trivial (0.6 % and 6 %
+respectively). For best-effort 16 streams, ~6 % of selections
+might use stale state.
+
+**Two mitigation options**:
+
+(a) Accept it: the stale state is at-most-2 ms-old and is
+itself a fair-share-bounded threshold. The over-share skip
+might fail to engage on one bucket per window, letting one
+"hot" flow get one extra packet through every 2 ms. Bounded.
+
+(b) Rotate-in-selection: change `cos_queue_select_bucket`
+to take `&mut CoSQueueRuntime` and call `afd_maybe_rotate`
+at entry. This requires changing `cos_queue_front`
+(tx.rs:4262) to take `&mut`, which cascades through callers.
+
+**Decision**: go with (a) for v3. Document the worst-case
+6 % stale rate on best-effort. If empirical CoV measurement
+shows best-effort doesn't meet acceptance, switch to (b) in
+a follow-up. The merge gate (per §8) is non-regression, not
+absolute CoV — so a small stale impact won't block merge.
 
 ### 6.4 Stale-comment cleanup (Codex R2 #8)
 
@@ -591,3 +672,19 @@ addressed below.
 | 8 | MED | Acceptance bar inconsistency         | §8 split into "merge gates" (non-regression: ≤ baseline + 1pp, no collapses, ≥0.95× throughput, no retransmit regression) and "targets" (the absolute CoV bars from #786 Slice C, reported but non-gating) |
 | 9 | MED | Partial TX-ring success test gap     | §7 tests #15 (partial), #16 (full failure), #17 (full success) added |
 | 10| MED | now_ns unused in selection           | §6.3.5: documented one-packet-stale on selection. ~0.4% of selections at 2ms window × 150K pps. Acceptable; mitigation requires &mut signature change beyond v3 scope |
+
+### Round 4 (6 HIGH + 3 MED + 2 LOW; R4 forced grounding in actual code paths)
+
+| # | Sev | Topic                                | Resolution |
+|---|-----|--------------------------------------|-----------|
+| 1 | HIGH| Staging buffer location not pinned   | DROPPED — §6.3.1 shows the existing `settle_*_flow_fair` functions already do the accepted-prefix walk. No staging buffer needed |
+| 2 | HIGH| Accepted-count unit wrong            | RESOLVED — §6.3.1 correctly identifies `inserted: usize` as the accepted-packet-count parameter to settle |
+| 3 | HIGH| Stale-window math cherry-picked      | RESOLVED — §6.3.6 recomputes per-class, including 6% worst-case on best-effort. Mitigation option (b) flagged for follow-up if empirical regresses |
+| 4 | HIGH| Baseline comparison undefined        | RESOLVED — §8 pins median-of-10 vs median-of-10 + 1 pp per class |
+| 5 | HIGH| `build_cos_batch_from_queue` signature chain missing | DROPPED — no staging buffer to thread (per #1) |
+| 6 | HIGH| Exact-flow-fair accounting path absent | RESOLVED — §6.3.2 hooks at `settle_exact_local_scratch_submission_flow_fair:2961-2964` and `settle_exact_prepared_scratch_submission_flow_fair:3015-3019`. The PRIMARY workload path |
+| 3 | MED | Settle-site hand-wave                | RESOLVED — §6.3.4 explicitly excludes FIFO/surplus/guarantee paths from AFD hooks; §6.3.2 names the only two hook sites |
+| 8 | MED | Test #15 level not pinned            | UNIT test on `account_staging_prefix` helper (clarified — though the v4 design doesn't use a separate helper, the equivalent is a unit test on `settle_*_flow_fair` with a constructed scratch buffer and varying `inserted` values) |
+| 11| MED | now_ns plumbing surface incomplete  | RESOLVED — §6.3.3 enumerates the full caller surface including `select_cos_guarantee_batch`, `select_cos_surplus_batch`, `build_cos_batch_from_queue` |
+| 4 | LOW | FIFO path irrelevance                | RESOLVED — §6.3.4 explicit |
+| 6 | LOW | No FIFO ring revert                  | RESOLVED — §6.3.4 + §6.3.5 explicit |

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -38,20 +38,50 @@ back to #837.
   - `172.16.80.200:5201` — iperf3 server (existing).
   - `172.16.80.200:7` — TCP echo (operator-enabled,
     confirmed reachable).
-- CoS class: **iperf-a** (1 Gb/s shaped) for tightest CoV.
+- CoS classes (ALL four covered per operator direction):
+  - port 5201 → **iperf-a** (1 Gb/s shaped) — tightest CoV
+  - port 5202 → **iperf-b** (10 Gb/s shaped)
+  - port 5203 → **iperf-c** (25 Gb/s shaped)
+  - port 5204 → **best-effort** (100 Mb/s shaped)
+  Queue ownership per `cos-iperf-config.set` + the live
+  `show class-of-service interface`: queue 0
+  (best-effort, owner 0), queue 4 (iperf-a, owner 1),
+  queue 5 (iperf-b, owner 2), queue 6 (iperf-c, owner 3).
+  All four queues are `exact=yes` and `flow_fair=true` (the
+  AFD-lite scope) on a single binding each.
 - Workers=6.
 
 ## 4. Workload
 
-Same as v1/v2 (acceptance unchanged):
+Each test is `iperf3 -P 16 -t 60 -p <port>` against
+`172.16.80.200`. Run 10× per port (40 runs total).
 
-- **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10.
-- **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10.
+Per-class acceptance (per #786 Slice C convention,
+adapted to each class's shaped rate):
+
+- **p5204 (best-effort, 100 Mb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
+- **p5201 (iperf-a, 1 Gb/s)**: CoV ≤ 15 % on ≥ 8 of 10.
+- **p5202 (iperf-b, 10 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
+- **p5203 (iperf-c, 25 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
+
+Plus:
 - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (#900
   baseline; do not regress).
-- 0 collapses.
-- Aggregate throughput ≥ 0.95 × baseline.
+- 0 collapses on every test.
+- Aggregate per-class throughput ≥ 0.95 × shaped rate.
 - 0 retransmit regression.
+
+Per-class commentary:
+- **p5201 (1 Gb/s)** has the tightest CoV bar — limited
+  shaper tokens means per-flow contention is sharpest.
+- **p5202 (10 Gb/s)** and **p5203 (25 Gb/s)** are
+  abundance-regime: most flows can saturate without
+  contending. CoV bar is looser, but AFD-lite must not
+  regress them.
+- **p5204 (100 Mb/s, best-effort)** is the smallest pipe.
+  16 streams × 6 Mbps fair share. AFD-lite's biggest
+  potential win is here — the smaller the per-flow share,
+  the tighter the over-share threshold gates noisy flows.
 
 ## 5. Algorithm specification
 
@@ -348,14 +378,22 @@ test setup for flow-fair-non-shared-exact cases.
 - All Go tests pass.
 - `cargo build --release` clean.
 - Live deploy on `loss:xpf-userspace-fw0/fw1`:
-  - **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10
-    runs.
-  - **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10
-    runs.
+  - All four CoS classes covered, 16 streams × 60 s × 10 runs
+    each:
+    - **p5201 (iperf-a, 1 Gb/s)**: CoV ≤ 15 % on ≥ 8 of 10.
+    - **p5202 (iperf-b, 10 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
+    - **p5203 (iperf-c, 25 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
+    - **p5204 (best-effort, 100 Mb/s)**: CoV ≤ 25 % on ≥ 8
+      of 10.
   - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 %
     (#900 baseline; do not regress).
-  - 0 collapses (every stream ≥ 1 Mbps).
-  - Aggregate throughput ≥ 0.95 × baseline.
+  - **No regression** vs the equivalent baseline (run with
+    AFD-lite disabled at compile-time via a feature gate, OR
+    captured before this PR's deploy) on ANY of the four
+    classes' CoV or aggregate throughput.
+  - 0 collapses (every stream ≥ 1 Mbps for shaped > 16 Mbps;
+    every stream ≥ shaped/16 × 0.5 for narrower classes).
+  - Aggregate per-class throughput ≥ 0.95 × shaped rate.
   - 0 retransmit regression.
 - `make test-failover`: pass (defense — touching the
   CoS dataplane).

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -278,36 +278,112 @@ pub(super) fn afd_threshold(state: &AFDLiteState) -> u64 { ... }  // helper for 
 
 ### 6.3 Edits to `userspace-dp/src/afxdp/tx.rs`
 
-**Pop commit-points** — call `afd_account_dispatch` AFTER
-the TX-ring insertion succeeds at each of the existing
-sites identified by Codex R1 (line numbers approximate
-against current HEAD; verify before editing):
+#### 6.3.1 FIFO-pop accounting (single-packet path)
 
-- `tx.rs:2926` — successful pop commit (primary pop path).
-- `tx.rs:2957` — successful pop commit (alt path).
-- `tx.rs:2983` — successful pop commit.
-- `tx.rs:3012` — successful pop commit.
-- `tx.rs:3129` — successful pop commit (forwarding).
-- `tx.rs:3170` — successful pop commit (forwarding).
-- `tx.rs:3214` — successful pop commit (forwarding).
-- `tx.rs:3272` — successful pop commit (forwarding).
+For the FIFO single-packet pop sites, the accounting hook
+goes inside the success branch immediately after the per-
+packet `bytes` sum is incremented. The R1-identified sites
+in this category map to the actual success-after-insert
+points:
+
+- `tx.rs:2922-2927` (FIFO local request: after
+  `sent_bytes += req.bytes.len() as u64` per Codex R3
+  Area 6, in the `Some(Local(req))` branch).
+- The matching prepared-frame branch in the same FIFO loop.
 
 At each, gate on `queue.flow_fair && !queue.shared_exact`
-to avoid touching out-of-scope queues.
+and call `afd_account_dispatch(state, bucket, bytes,
+now_ns)`. The `bucket` here is computed via
+`cos_flow_bucket_index(queue.flow_hash_seed, flow_key)`
+on the popped item, before the item is consumed.
 
-**Failure / rollback paths** — *do nothing*. Per §5.2,
-the no-rollback design means failed TX simply doesn't
-account.
+#### 6.3.2 Batch-pop accounting (R3 HIGH 4 fix)
 
-**Selection sites**:
+The R3 review correctly flagged that the batch-pop sites
+at `tx.rs:3129/3170` happen DURING batch construction
+(pre-TX), while the true success sites at `tx.rs:3214/3272`
+only have aggregate `(packets, bytes)` and retry-tail state
+— per-flow bucket identity is lost by then.
+
+**Redesigned batch accounting (matches the no-rollback
+design)**:
+
+1. **During pop**: each batch-pop iteration that adds an
+   item to the in-flight batch buffer ALSO appends a
+   `(bucket_idx, bytes)` tuple to a per-batch staging
+   buffer. The staging buffer is a small `SmallVec` or
+   stack-allocated array (typical batch size ≤ 64; bound
+   to TX_BATCH_SIZE = 256 worst case).
+2. **After `submit_cos_batch` returns the accepted count
+   `N`**: iterate the first `N` staging tuples and call
+   `afd_account_dispatch` for each. The unaccepted tail
+   (positions N..staging_len) is left untouched — those
+   items are pushed back via push_front (existing code),
+   AFD never accounted them.
+3. **On full-batch failure (`inserted == 0`)**: don't
+   iterate at all. Staging buffer dropped. AFD untouched.
+
+This matches the no-rollback contract: AFD is only
+incremented for bytes that successfully transmitted. Partial
+batch acceptance is correctly handled.
+
+**Per-batch staging buffer**: a new `Vec<(u16, u32)>`
+(bucket_idx + bytes_u32, since per-packet bytes ≤ 9000)
+allocated once and reused across batches via clear/reuse.
+Add as a field on `BindingWorker` or as a function-local
+that's reused across calls. Hot-path overhead: one extra
+push-tuple per packet popped (8-16 bytes); insignificant.
+
+**Sites to edit**:
+- `tx.rs:3129/3170` (pop-during-batch): stage tuple.
+- `tx.rs:3214/3272` (submit success): iterate staging
+  prefix N and call `afd_account_dispatch`.
+- `tx.rs:6206/6215/6433/6442` (settle / partial-success):
+  these may also need staging-prefix accounting depending
+  on which path they're on. Verify against actual code at
+  implementation time.
+
+#### 6.3.3 Failure / rollback paths
+
+Per §5.2, do nothing. Failed TX simply doesn't account.
+The staging buffer for batch paths is dropped/cleared.
+
+#### 6.3.4 Selection sites
+
 - `cos_queue_front` (`tx.rs:4262`) → call
   `cos_queue_select_bucket(queue, now_ns)`.
 - `cos_queue_pop_front_inner` (`tx.rs:4464`-area) → same.
 
 The `now_ns` argument is plumbed from the existing call
-chain. Worker hot-paths already have a `now_ns` value
-(from the polling loop's `monotonic_ns()`); pass it
-through.
+chain. Per Codex R3 Area 3, this also requires threading
+through `build_cos_batch_from_queue` and the drain helpers
+(call sites at `tx.rs:2602/2780/3102`). Worker hot-paths
+already have a `now_ns` (from the polling loop's
+`monotonic_ns()`); pass through. Bounded surface — every
+caller already has a clock value at hand.
+
+#### 6.3.5 One-packet-stale on selection (R3 MED 10)
+
+Selection (`cos_queue_select_bucket`) reads `now_ns` but
+does **not** rotate. Rotation happens only inside
+`afd_account_dispatch`, which runs on the success path
+AFTER selection. Consequence: the first selection AFTER a
+window expiry (e.g. window N→N+1 boundary) uses stale
+window-N counters. Once that packet's dispatch hook fires,
+rotation moves state to N+1; subsequent selections are
+fresh.
+
+This is acceptable:
+- 2 ms window × 150 K pps = ~300 packets per window. One
+  stale-selection per window is < 0.4 % of selections.
+- The stale data biases ONE selection toward whatever
+  was over-share at the end of the previous window;
+  bounded by the previous window's threshold (already a
+  fair-share-ish value).
+
+Documented; not mitigated. Mitigation would require
+`cos_queue_front` to take `&mut CoSQueueRuntime`, which
+broadens the call-site change beyond v3 scope.
 
 ### 6.4 Stale-comment cleanup (Codex R2 #8)
 
@@ -364,6 +440,16 @@ state.
 14. `dispatch_success_accounts` — simulate a successful
     TX; assert `bytes_per_flow[b]` and `bytes_total`
     incremented; `active_count` incremented if 0→1.
+15. `batch_partial_success_accounts_only_accepted_prefix`
+    (Codex R3 MED 9): build a staging buffer of 4 entries
+    (3 distinct flow buckets), simulate `submit_cos_batch`
+    accepting only 2 of 4. Assert AFD bytes accounted for
+    only the first 2 staging tuples; the unaccepted tail
+    leaves AFD untouched. Asserts the Codex R3 HIGH 4 fix.
+16. `batch_full_failure_accounts_nothing` — simulate
+    `inserted == 0`. Assert AFD state unchanged.
+17. `batch_full_success_accounts_all` — simulate
+    `inserted == staging_len`. Assert all tuples accounted.
 
 ### 7.3 Test plumbing
 
@@ -378,23 +464,37 @@ test setup for flow-fair-non-shared-exact cases.
 - All Go tests pass.
 - `cargo build --release` clean.
 - Live deploy on `loss:xpf-userspace-fw0/fw1`:
-  - All four CoS classes covered, 16 streams × 60 s × 10 runs
-    each:
-    - **p5201 (iperf-a, 1 Gb/s)**: CoV ≤ 15 % on ≥ 8 of 10.
-    - **p5202 (iperf-b, 10 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
-    - **p5203 (iperf-c, 25 Gb/s)**: CoV ≤ 25 % on ≥ 8 of 10.
-    - **p5204 (best-effort, 100 Mb/s)**: CoV ≤ 25 % on ≥ 8
-      of 10.
-  - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 %
-    (#900 baseline; do not regress).
-  - **No regression** vs the equivalent baseline (run with
-    AFD-lite disabled at compile-time via a feature gate, OR
-    captured before this PR's deploy) on ANY of the four
-    classes' CoV or aggregate throughput.
-  - 0 collapses (every stream ≥ 1 Mbps for shaped > 16 Mbps;
-    every stream ≥ shaped/16 × 0.5 for narrower classes).
-  - Aggregate per-class throughput ≥ 0.95 × shaped rate.
-  - 0 retransmit regression.
+
+**Merge gates (block merge if not met) — Codex R3 MED 8 fix**:
+The merge gate is **non-regression**, not absolute CoV.
+AFD-lite must not make ANY of the four classes worse than
+the captured-just-before-deploy baseline. Specifically:
+  - CoV per class: AFD-lite-enabled CoV ≤ baseline CoV +
+    1 percentage point on every class (allows for
+    measurement noise; protects against actual regression).
+  - 0 stream collapses on every class (no flow drops below
+    a sentinel threshold).
+  - Aggregate per-class throughput ≥ 0.95 × baseline (no
+    throughput regression worth a percentage point).
+  - 0 retransmit regression vs baseline median.
+  - All Rust + Go unit tests pass.
+  - `make test-failover`: pass.
+
+**Targets (reported, not gating)**:
+  - p5201 CoV ≤ 15 % on ≥ 8 of 10 runs (per #786 Slice C
+    convention).
+  - p5202 CoV ≤ 25 % on ≥ 8 of 10 runs.
+  - p5203 CoV ≤ 25 % on ≥ 8 of 10 runs.
+  - p5204 CoV ≤ 25 % on ≥ 8 of 10 runs.
+  - p5202 128 streams 60 s × 1: CoV ≤ 16.6 % (#900 regression
+    floor — promoted to merge gate via the non-regression
+    rule above).
+
+§9 estimates the realistic gain at 1-3 percentage points;
+the targets above are the v1/v2 design goals which are
+optimistic for v3's reduced single-binding scope. Reviewers
+focus on the non-regression merge gate; the targets are
+ambitions to compare against, not pass/fail thresholds.
 - `make test-failover`: pass (defense — touching the
   CoS dataplane).
 - Codex hostile plan + code review: PLAN-READY YES,
@@ -476,3 +576,18 @@ addressed below.
 | 7 | LOW | Period counter wrap                  | OUT-OF-SCOPE-V3 — period_start_ns is plain u64 ns, no period index |
 | 8 | MED | Stale comments in source             | RESOLVED — §6.4 cleans up `types.rs:1037-1040` + `tx.rs:5326-5329` |
 | 9 | HIGH| Lease plumbing + epsilon shift bug   | RESOLVED — §5.1 `NUM/DEN` fraction (no shift sentinel); §6.3 plumbs `now_ns` from existing call chain (no lease needed) |
+
+### Round 3 (1 HIGH + 3 MED + 2 LOW; v3 plan)
+
+| # | Sev | Topic                                | Resolution |
+|---|-----|--------------------------------------|-----------|
+| 1 | OK  | Single-threaded ownership            | Confirmed via `worker.rs:21,679,984`; coordinator reads only ArcSwap snapshot |
+| 2 | LOW | `Box<AFDLiteState>` clone semantics  | Plan rewording: not "repeatedly cloned" — `CoSQueueRuntime` is rebuilt fresh on plan reconciliation. Box is for off-line allocation, not for sharing. |
+| 3 | LOW | now_ns plumbing surface              | §6.3.4: explicit list of caller sites (build_cos_batch_from_queue, drain helpers at tx.rs:2602/2780/3102); bounded |
+| 4 | HIGH| Pop commit-points conflate pre/post-TX | §6.3.2 redesigned: per-batch staging buffer of (bucket, bytes) tuples; iterate accepted prefix N at submit-success and account only those. Matches no-rollback contract |
+| 5 | OK  | active_count maintenance correctness | Confirmed under single-threaded model |
+| 6 | OK  | Bytes accounting timing              | §6.3.1 specifies the FIFO success branch (after `sent_bytes += req.bytes.len()`) per Area 6 |
+| 7 | OK  | Stale-comment cleanup is comment-only| Confirmed; §6.4 unchanged |
+| 8 | MED | Acceptance bar inconsistency         | §8 split into "merge gates" (non-regression: ≤ baseline + 1pp, no collapses, ≥0.95× throughput, no retransmit regression) and "targets" (the absolute CoV bars from #786 Slice C, reported but non-gating) |
+| 9 | MED | Partial TX-ring success test gap     | §7 tests #15 (partial), #16 (full failure), #17 (full success) added |
+| 10| MED | now_ns unused in selection           | §6.3.5: documented one-packet-stale on selection. ~0.4% of selections at 2ms window × 150K pps. Acceptable; mitigation requires &mut signature change beyond v3 scope |

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -4,337 +4,565 @@
 
 Improve cross-binding fair queueing on `shared_exact` CoS queues
 without the surface area of full HOL-finish-time sharing
-(#836 → 7 HIGH findings → closed; tracked in #837 as the
-"big-design" alternative).
+(#836 closed → tracked as the "big-design" alternative in #837).
 
-This implements the **smaller-surface alternative** described in
+This implements the smaller-surface alternative described in
 #838: track bytes dispatched per flow-bucket per time window,
 shared across all bindings on a `SharedCoSQueueLease`. Bucket
 selection skips flows that are over their fair share for one
 round-robin cycle.
 
+R1 review found 8 HIGH + 4 MED requiring a structural redesign;
+this v2 addresses each in §13.
+
 ## 2. What this is NOT
 
-- Not a full MQFQ replacement. Single-binding `flow_fair` queues
-  retain their existing `cos_queue_min_finish_bucket()` HOL-
-  finish-time selection (proven correct in #785).
+- Not a full MQFQ replacement. Single-binding `flow_fair`
+  queues retain `cos_queue_min_finish_bucket()` HOL-finish
+  ordering unchanged.
 - Not a drop / ECN path. Skip-on-selection only — no admission
   changes (avoids the #833 double-signal trap).
 - Not Count-Min sketch. Use a fixed `[AtomicU64; 1024]` array
-  keyed by `flow_bucket_index` — already bounded by
-  `COS_FLOW_FAIR_BUCKETS`.
-- Not RSS rebalance. Orthogonal to #840 (closed); operates inside
-  the dataplane regardless of NIC RSS distribution.
+  keyed by `flow_bucket_index`.
 
 ## 3. Test environment
 
 - Cluster: `loss:xpf-userspace-fw0/fw1` (RG0 primary).
 - Source: `loss:cluster-userspace-host`.
 - Targets:
-  - `172.16.80.200` — iperf3 server on port 5201 (existing) +
-    TCP/UDP echo on port 7 (newly enabled by operator,
-    confirmed reachable).
-  - `2001:559:8585:80::200` — same hosts, IPv6.
-- CoS class: **iperf-a** (1 Gb/s shaped) for the tightest
-  acceptance target; **iperf-b** (10 Gb/s) for higher-aggregate
-  characterisation.
+  - `172.16.80.200:5201` — iperf3 server (existing).
+  - `172.16.80.200:7` — TCP/UDP echo (newly enabled by
+    operator, confirmed via `</dev/tcp/172.16.80.200/7`).
+  - `[2001:559:8585:80::200]:7` — IPv6 echo (out of scope for
+    #838 itself; available for follow-up #900 mouse-latency
+    measurement).
+- CoS class: **iperf-a** (1 Gb/s shaped) for tightest CoV.
 - Workers=6, queue 4 owned by worker 1, queue 5 owned by
-  worker 2 (per live `show class-of-service interface`).
+  worker 2. Both `iperf-a` (queue 4) and `iperf-b` (queue 5)
+  are `shared_exact`-eligible based on the existing
+  promotion policy.
 
 ## 4. Workload
 
-Acceptance reproduces the #786 Slice C test:
+- **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10.
+- **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10.
+- **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (the #900
+  baseline; AFD-lite must not regress).
+- 0 stream collapses (every stream ≥ 1 Mbps).
+- Aggregate throughput ≥ 0.95 × baseline.
+- 0 retransmit regression vs baseline median.
 
-- **p5201 16 streams 60 s** (CoV ≤ 15 % on ≥ 8 of 10 runs).
-- **p5202 16 streams 60 s** (CoV ≤ 25 % on ≥ 8 of 10 runs).
-- **p5202 128 streams 60 s** (additional characterisation —
-  current baseline 16.6 % CoV, see #900 finding).
+## 5. Algorithm specification (R1-redesigned)
 
-## 5. Algorithm specification
+### 5.1 Period state — implicit via timestamp, no rotate-CAS
 
-### 5.1 Shared state added to `SharedCoSQueueLease`
+R1 HIGH 1 + R1 HIGH 3 fix: eliminate the explicit period-
+reset CAS-elect + zero-loop. Use **implicit periods via packed
+timestamp**.
 
-```rust
-// In userspace-dp/src/afxdp/types.rs, alongside existing
-// SharedCoSLeaseState fields:
+```
+Per-flow slot (replaces period_bytes_per_flow[i]):
+  AtomicU64 slot = (period_idx[32 bits] | bytes[32 bits])
 
-struct AFDLiteState {
-    period_start_ns: AtomicU64,
-    period_bytes_total: AtomicU64,
-    period_bytes_per_flow: Box<[CachePadded<AtomicU64>; COS_FLOW_FAIR_BUCKETS]>,
-    /// Cached active-bucket count for fair_share = total / active.
-    /// Updated on bucket 0→N and N→0 transitions; ≤ one window stale.
-    active_bucket_count: AtomicU32,
-    /// Locked at lease construction; bindings on the same lease
-    /// MUST use this seed so flow→bucket maps consistently.
-    flow_hash_seed: u64,
-}
+Period index:
+  period_idx(now) = (now_ns - lease_epoch_ns) / AFD_PERIOD_WINDOW_NS
 
-const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;  // 2 ms
-const AFD_OVER_SHARE_EPSILON: u64 = 0;         // skip when bytes > fair_share*1.0; tunable
+Lease epoch:
+  lease_epoch_ns = monotonic_ns at lease construction (constant)
 ```
 
-`COS_FLOW_FAIR_BUCKETS = 1024` × 64 bytes (cache-line padded
-AtomicU64) = **64 KB** per shared lease. Acceptable.
+There is no `period_start_ns` to update, no rotation CAS, no
+zero-loop. A slot is automatically "stale" if its embedded
+`period_idx` is below `period_idx(now)`.
+
+This is a CAS-loop on dispatch (not raw fetch_add) but the
+loop has no contention with any rotator — rotation is
+implicit and lock-free by construction.
 
 ### 5.2 Hot-path operations
 
-**On every successful packet dispatch** (post-write to TX
-ring, per existing `cos_queue_pop_*` paths):
+**Dispatch accounting** (after a successful TX-ring write):
 
 ```rust
-// 1. Account bytes
-state.period_bytes_per_flow[bucket].fetch_add(bytes, Relaxed);
-state.period_bytes_total.fetch_add(bytes, Relaxed);
-
-// 2. Maybe rotate window
-let now = monotonic_ns();
-let start = state.period_start_ns.load(Relaxed);
-if now.saturating_sub(start) >= AFD_PERIOD_WINDOW_NS {
-    // CAS-elect a single rotator; losers fall through
-    if state.period_start_ns
-        .compare_exchange(start, now, AcqRel, Relaxed)
-        .is_ok()
-    {
-        // Winner zeros all per-flow counters and total.
-        // Relaxed stores: any racer's adds during this rotation
-        // window land in the new period; transient skew bounded
-        // by 2 ms.
-        state.period_bytes_total.store(0, Relaxed);
-        for slot in state.period_bytes_per_flow.iter() {
-            slot.store(0, Relaxed);
+fn afd_account_dispatch(slot: &AtomicU64, bytes: u64, now_ns: u64) {
+    let cur_period = period_idx(now_ns);
+    loop {
+        let raw = slot.load(Relaxed);
+        let (slot_period, slot_bytes) = unpack(raw);
+        let new = if slot_period < cur_period {
+            // Stale slot — start fresh in the new period.
+            pack(cur_period, bytes.min(BYTES_MAX))
+        } else {
+            // Same period — add.
+            pack(cur_period, slot_bytes.saturating_add(bytes).min(BYTES_MAX))
+        };
+        if slot.compare_exchange_weak(raw, new, AcqRel, Relaxed).is_ok() {
+            return;
         }
     }
 }
 ```
 
-**On packet rollback** (`push_front` after a failed write):
+Two threads racing in the same period CAS-loop until one
+wins; expected 1-2 iterations under hot-bucket contention.
+A thread observing `slot_period < cur_period` and another
+having just CAS'd to the new period will retry once and
+agree.
+
+**Read for selection** (in `cos_queue_min_finish_bucket_afd`):
 
 ```rust
-state.period_bytes_per_flow[bucket].fetch_sub(bytes, Relaxed);
-state.period_bytes_total.fetch_sub(bytes, Relaxed);
+fn afd_bytes_in_period(slot: &AtomicU64, cur_period: u64) -> u64 {
+    let (slot_period, slot_bytes) = unpack(slot.load(Relaxed));
+    if slot_period == cur_period { slot_bytes } else { 0 }
+}
 ```
 
-`fetch_sub` is the inverse of `fetch_add` and is also
-commutative — unlike HOL-finish-time, byte counts are a
-proper ledger that supports rollback (this is the key safety
-property that makes AFD-lite race-tolerant where the #836
-HOL-finish design wasn't).
+Stale slots auto-zero on read.
 
-### 5.3 Selection gating in `cos_queue_min_finish_bucket`
+**Total-in-period and active-flow-count** (R1 HIGH 2 fix):
+the old design's `period_bytes_total` and
+`active_bucket_count` had their own ordering / drift
+problems. Replace with a **bitmap of active flows in the
+current period**, also period-tagged.
 
-The existing `cos_queue_min_finish_bucket` iterates
-`flow_rr_buckets` picking the smallest `head_finish_bytes`.
-With AFD-lite, on a `shared_exact` queue **with a shared
-lease**:
+```
+Active-flow bitmap (16 × AtomicU64, each covering 64 flows):
+  AtomicU64 word = (period_idx[32 bits] | mask[32 bits])
+
+For 1024 buckets we need 16 words. Memory: 16 × 8 = 128 B.
+Cache-pad to 16 × 64 = 1 KB per lease.
+```
+
+On dispatch, set the bit corresponding to `bucket_idx`:
 
 ```rust
-fn cos_queue_min_finish_bucket_afd(queue: &CoSQueueRuntime, lease: &SharedCoSQueueLease) -> Option<u16> {
-    let total = lease.afd.period_bytes_total.load(Relaxed);
-    let active = lease.afd.active_bucket_count.load(Relaxed) as u64;
-    let fair_share = if active > 0 { total / active } else { u64::MAX };
-    let threshold = fair_share + (fair_share >> AFD_OVER_SHARE_EPSILON);
-    // Threshold = fair_share * 1.0 with epsilon=0 (initial conservative);
-    // becomes fair_share * 1.5 with epsilon=1 if needed.
+fn afd_mark_active(word: &AtomicU64, bit_offset: u32, cur_period: u64) {
+    loop {
+        let raw = word.load(Relaxed);
+        let (slot_period, slot_mask) = unpack(raw);
+        let new_mask = if slot_period < cur_period {
+            1u32 << bit_offset
+        } else {
+            slot_mask | (1u32 << bit_offset)
+        };
+        let new = pack(cur_period, new_mask);
+        if slot.compare_exchange_weak(raw, new, AcqRel, Relaxed).is_ok() {
+            return;
+        }
+    }
+}
+```
 
-    let mut best_finish = u64::MAX;
-    let mut best: Option<u16> = None;
-    let mut best_excess = u64::MAX;
-    let mut best_excess_bucket: Option<u16> = None;
+Total bytes-in-period and active-flow-count are computed at
+**read time** (during selection) by iterating the bitmap and
+slot array:
+
+```rust
+fn afd_period_summary(state: &AFDLiteState, cur_period: u64) -> (u64, u32) {
+    let mut total = 0u64;
+    let mut active = 0u32;
+    for word in state.active_bitmap.iter() {
+        let (wp, mask) = unpack(word.load(Relaxed));
+        if wp == cur_period {
+            active += mask.count_ones();
+        }
+    }
+    for slot in state.bytes_per_flow.iter() {
+        let (sp, b) = unpack(slot.load(Relaxed));
+        if sp == cur_period {
+            total = total.saturating_add(b);
+        }
+    }
+    (total, active)
+}
+```
+
+The two iterations are 1024 + 16 atomic loads. At one
+selection per packet on a hot CoS queue, this is the cost
+that #838's CPU budget must accommodate (see §9).
+
+If empirical perf shows >3 % CPU regression, fall back to a
+cached `(total, active)` packed atomic refreshed at most
+once per N selections — but start with read-time
+computation for simplicity.
+
+### 5.3 Rollback handling (R1 HIGH 3 fix)
+
+**No fetch_sub on rollback.** Rollback (push_front after a
+failed TX-ring write) is rare. Skipping the byte unaccount
+means the affected flow gets one packet's worth of "credit"
+counted toward its current period — which is bounded:
+
+- One rollback ≈ MTU bytes (≤ 9000 B with jumbo) per period.
+- Per-period budget at 1 Gb/s × 2 ms = 250 KB.
+- Worst-case effect: one rollback overcharges a flow by
+  ~3.6 % of the period's allowed share.
+- Rollback rate is typically < 0.01 % of TX attempts.
+
+This eliminates the underflow scenario from R1 HIGH 3
+entirely (no fetch_sub → no possibility of u64 wrap).
+
+Document this trade-off in the function comment.
+
+### 5.4 Selection gating
+
+```rust
+fn cos_queue_min_finish_bucket_afd(
+    queue: &CoSQueueRuntime,
+    lease: &SharedCoSQueueLease,
+    now_ns: u64,
+) -> Option<u16> {
+    let cur_period = period_idx(now_ns, lease.afd.epoch_ns);
+    let (total, active) = afd_period_summary(&lease.afd, cur_period);
+    let fair_share = if active > 0 {
+        total / u64::from(active)
+    } else {
+        u64::MAX
+    };
+    // R1 HIGH 5 fix: explicit threshold formula.
+    // epsilon=0 → threshold = fair_share exactly (strict)
+    // epsilon=N → threshold = fair_share + fair_share/(2^N)
+    //   so N=1 → 1.5x, N=2 → 1.25x, N=3 → 1.125x.
+    let threshold = fair_share.saturating_add(
+        fair_share >> AFD_OVER_SHARE_EPSILON_SHIFT.saturating_sub(0),
+    );
+    // Configured constant: AFD_OVER_SHARE_EPSILON_SHIFT = u32::MAX
+    //   means "no over-share allowance" (saturating shift gives 0,
+    //   threshold = fair_share). Default for this PR.
+    // To loosen later, set the shift to e.g. 1 (threshold = 1.5x).
+
+    let mut best_under: Option<u16> = None;
+    let mut best_under_finish = u64::MAX;
+    let mut best_over: Option<u16> = None;
+    let mut best_over_excess = u64::MAX;
     for bucket in queue.flow_rr_buckets.iter() {
-        let finish = queue.flow_bucket_head_finish_bytes[usize::from(bucket)];
-        let bytes_served = lease.afd.period_bytes_per_flow[usize::from(bucket)].load(Relaxed);
-        if bytes_served <= threshold {
-            // Eligible; pick by HOL-finish (existing MQFQ rule).
-            if finish < best_finish {
-                best_finish = finish;
-                best = Some(bucket);
+        let idx = usize::from(bucket);
+        let bytes = afd_bytes_in_period(&lease.afd.bytes_per_flow[idx], cur_period);
+        let finish = queue.flow_bucket_head_finish_bytes[idx];
+        if bytes <= threshold {
+            if finish < best_under_finish {
+                best_under_finish = finish;
+                best_under = Some(bucket);
             }
         } else {
-            // Over-share; track smallest excess as fallback.
-            let excess = bytes_served.saturating_sub(threshold);
-            if excess < best_excess {
-                best_excess = excess;
-                best_excess_bucket = Some(bucket);
+            let excess = bytes.saturating_sub(threshold);
+            if excess < best_over_excess {
+                best_over_excess = excess;
+                best_over = Some(bucket);
             }
         }
     }
-    best.or(best_excess_bucket)
+    best_under.or(best_over)
 }
 ```
 
-If at least one bucket is under-share, pick the eligible
-bucket with smallest HOL-finish-time (preserves MQFQ
-ordering among eligibles). If ALL buckets are over-share
-(e.g. start of window before counters drop), fall back to
-the smallest-excess bucket so we don't go idle.
+If at least one bucket is under-share, pick by smallest
+HOL-finish (preserves MQFQ ordering among eligibles). If
+ALL are over-share, fall back to smallest excess to avoid
+going idle.
 
-### 5.4 Active-bucket-count maintenance
+### 5.5 Gate (R1 HIGH 6 fix)
 
-`flow_rr_buckets` already tracks the set of non-empty
-buckets — bucket added on first push to empty bucket
-(`was_empty == true`), removed on last pop. Mirror this into
-`active_bucket_count` via `fetch_add`/`fetch_sub` at the same
-sites:
+AFD-lite engages only on **`queue.shared_exact == true`** —
+not `shared_queue_lease.is_some()`. Per `coordinator.rs:1960`
++ `worker.rs:3804`/`3938`, lease presence is broader than
+shared-exact. The gate condition in `cos_queue_front` becomes:
 
 ```rust
-// On bucket 0 → 1 transition (push to empty bucket):
-state.active_bucket_count.fetch_add(1, Relaxed);
-
-// On bucket 1 → 0 transition (pop last item from bucket):
-state.active_bucket_count.fetch_sub(1, Relaxed);
+if queue.flow_fair && queue.shared_exact {
+    if let Some(lease) = queue.shared_queue_lease.as_ref() {
+        return cos_queue_min_finish_bucket_afd(queue, lease, now_ns)
+            .and_then(|b| queue.flow_bucket_items[usize::from(b)].front());
+    }
+}
+// Else: fall through to existing cos_queue_min_finish_bucket() path
 ```
 
-Cached count is used only for fair_share computation (an
-approximation); ≤ one window stale is fine.
+Single-binding queues, non-flow-fair queues, and shared-but-
+non-exact queues all preserve the existing selection.
 
-### 5.5 Single-binding queues unchanged
+### 5.6 Shared flow-hash seed (R1 HIGH 7 fix)
 
-`!shared_exact` queues (single binding owns the queue) keep
-the existing `cos_queue_min_finish_bucket()` MQFQ ordering
-unchanged. AFD-lite only engages when
-`shared_queue_lease.is_some()`.
+The lease's `flow_hash_seed` (already specified in #838 issue)
+must be propagated to bindings when they promote onto the
+lease. Per `tx.rs:5408`, bindings currently draw a fresh seed
+at promotion time. Change `ensure_cos_interface_runtime` (or
+the equivalent promotion site) to:
+
+```rust
+// Existing: queue.flow_hash_seed = getrandom_u64();
+// New: if shared_exact and lease has a seed, use lease's.
+queue.flow_hash_seed = if queue.shared_exact {
+    lease.afd.flow_hash_seed
+} else {
+    getrandom_u64()
+};
+```
+
+This ensures all bindings on the same lease map a given
+5-tuple to the same `flow_bucket_index`, so the shared
+`bytes_per_flow[i]` counter has consistent meaning.
+
+The lease's seed is drawn from `getrandom(2)` at lease
+construction — same property as before (unpredictable across
+restarts and nodes; deterministic within one lease).
 
 ## 6. Implementation outline
 
 ### 6.1 New file: `userspace-dp/src/afxdp/afd_lite.rs`
 
-- `pub(super) struct AFDLiteState { ... }` (per §5.1).
-- `pub(super) const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;`
-- `pub(super) const AFD_OVER_SHARE_EPSILON: u32 = 0;`
-- `impl AFDLiteState { fn new(seed: u64) -> Self; }`
-- Free fn `afd_account_dispatch(state, bucket, bytes, now_ns)`.
-- Free fn `afd_account_rollback(state, bucket, bytes)`.
-- Free fn `afd_active_inc(state)` / `afd_active_dec(state)`.
-- Free fn `afd_select_bucket(queue, state) -> Option<u16>`.
+```rust
+//! AFD-lite: per-flow bytes-served counter for shared_exact
+//! CoS queues. See docs/pr/838-afd-lite/plan.md.
 
-### 6.2 Edits to existing files
+use std::sync::atomic::{AtomicU64, Ordering};
 
-- `userspace-dp/src/afxdp/types.rs`:
-  - Add `afd: AFDLiteState` to `SharedCoSQueueLease`.
-  - Add `mod afd_lite;` import.
-- `userspace-dp/src/afxdp/tx.rs`:
-  - In `cos_queue_front` (line 4262): when `queue.flow_fair`
-    AND `shared_queue_lease.is_some()`, call
-    `afd_select_bucket(queue, lease)` instead of the existing
-    `cos_queue_min_finish_bucket(queue)`.
-  - In every successful pop path (after the kernel ring write
-    succeeds): call `afd_account_dispatch`.
-  - In every `push_front` rollback path: call
-    `afd_account_rollback`.
-  - In `cos_queue_push_back` at the `was_empty` transition
-    (line ~4302): call `afd_active_inc` if shared lease.
-  - In the bucket-empty transition on pop: call
-    `afd_active_dec` if shared lease.
+pub(super) const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;
+pub(super) const AFD_PERIOD_BITS: u64 = 32;
+pub(super) const AFD_BYTES_BITS: u64 = 32;
+pub(super) const AFD_BYTES_MAX: u64 = (1u64 << AFD_BYTES_BITS) - 1;
+pub(super) const AFD_OVER_SHARE_EPSILON_SHIFT: u32 = u32::MAX; // strict (default)
+pub(super) const AFD_FLOW_BUCKETS: usize = 1024;
+pub(super) const AFD_BITMAP_WORDS: usize = AFD_FLOW_BUCKETS / 32;
 
-### 6.3 Coordinator
+#[repr(align(64))]
+pub(super) struct CachePaddedAtomicU64(AtomicU64);
 
-`SharedCoSQueueLease::new()` (currently constructs only
-`SharedCoSLeaseConfig`/`State`) extends to also build the
-AFD-lite state with `flow_hash_seed` drawn from
-`getrandom(2)` — same seed all bindings on the lease use.
+pub(super) struct AFDLiteState {
+    pub(super) epoch_ns: u64,
+    pub(super) flow_hash_seed: u64,
+    pub(super) bytes_per_flow: Box<[CachePaddedAtomicU64; AFD_FLOW_BUCKETS]>,
+    pub(super) active_bitmap: Box<[CachePaddedAtomicU64; AFD_BITMAP_WORDS]>,
+}
+
+#[inline] fn pack(period: u64, payload: u64) -> u64 { (period << AFD_BYTES_BITS) | (payload & AFD_BYTES_MAX) }
+#[inline] fn unpack(raw: u64) -> (u64, u64) { (raw >> AFD_BYTES_BITS, raw & AFD_BYTES_MAX) }
+#[inline] pub(super) fn period_idx(now_ns: u64, epoch_ns: u64) -> u64 {
+    (now_ns.saturating_sub(epoch_ns)) / AFD_PERIOD_WINDOW_NS
+}
+
+impl AFDLiteState {
+    pub(super) fn new(epoch_ns: u64, flow_hash_seed: u64) -> Self { ... }
+}
+
+pub(super) fn afd_account_dispatch(state: &AFDLiteState, bucket: usize, bytes: u64, now_ns: u64) { ... }
+pub(super) fn afd_bytes_in_period(state: &AFDLiteState, bucket: usize, cur_period: u64) -> u64 { ... }
+pub(super) fn afd_mark_active(state: &AFDLiteState, bucket: usize, cur_period: u64) { ... }
+pub(super) fn afd_period_summary(state: &AFDLiteState, cur_period: u64) -> (u64, u32) { ... }
+```
+
+### 6.2 Edits to `userspace-dp/src/afxdp/types.rs`
+
+- Add `pub(super) afd: AFDLiteState` field to
+  `SharedCoSQueueLease`.
+- `SharedCoSQueueLease::new` extends to construct
+  `AFDLiteState::new(monotonic_ns(), getrandom_u64())`.
+
+### 6.3 Edits to `userspace-dp/src/afxdp/tx.rs`
+
+R1 HIGH 4 fix: enumerate ALL pop commit points + push_front
+sites. Per the source citations from R1, the touch-points
+are:
+
+**Dispatch-accounting hooks (call `afd_account_dispatch` +
+`afd_mark_active` after a successful TX-ring write):**
+
+- `tx.rs:2926` — successful pop commit
+- `tx.rs:2957` — successful pop commit (alt path)
+- `tx.rs:2983` — successful pop commit (alt path)
+- `tx.rs:3012` — successful pop commit (alt path)
+- `tx.rs:3129` — successful pop commit (forwarding path)
+- `tx.rs:3170` — successful pop commit (forwarding path)
+- `tx.rs:3214` — successful pop commit (forwarding path)
+- `tx.rs:3272` — successful pop commit (forwarding path)
+
+**Skip rollback-accounting** (R1 HIGH 3 fix) — push_front
+sites at `tx.rs:2637`, `2812`, `2960`, `3014`, `4308`, `4345`,
+`4373`, `4383`: do NOT touch AFD counters. The flow gets one
+packet of "credit" until the period ends; bounded.
+
+**Active-bitmap maintenance**: only `mark_active` on
+dispatch (above). No "unmark on bucket empty" — the bitmap
+is auto-period-tagged and clears implicitly at period
+rotation. R1 HIGH 8 (rollback active-count) is closed by
+this design — we don't track active-count separately, only
+"saw-bytes-this-period" bitmap.
+
+**Front/pop selector agreement** (R1 HIGH 4 closure):
+both `cos_queue_front` (line 4262) and
+`cos_queue_pop_front_inner` (line 4527 area) currently call
+`cos_queue_min_finish_bucket()`. Add a new shared helper
+`cos_queue_select_bucket(queue, lease, now_ns)` that both
+call, branching on `shared_exact + lease.is_some()`.
+
+### 6.4 Edits to `userspace-dp/src/afxdp/coordinator.rs`
+
+`SharedCoSQueueLease::new` already accepts config; extend
+to construct `AFDLiteState`. No other coordinator changes
+needed.
+
+### 6.5 Edits to `userspace-dp/src/afxdp/worker.rs`
+
+Per R1 HIGH 7: at the binding-promotion site
+(`worker.rs:3789`, `3804`, `3938`, `3948`), change
+`flow_hash_seed` assignment to use the lease's seed when
+`shared_exact && lease.is_some()`.
 
 ## 7. Tests
 
-In `userspace-dp/src/afxdp/afd_lite.rs` (new module tests):
+### 7.1 Unit tests in `afd_lite.rs`
 
-1. `account_dispatch_increments_total_and_bucket`.
-2. `account_rollback_inverts_dispatch`.
-3. `period_rotation_zeros_counters`.
-4. `concurrent_rotators_only_one_wins` (CAS race test with
-   spawned threads).
-5. `active_inc_dec_round_trip` (idempotent under matched
-   inc/dec).
-6. `select_picks_under_share_first` — synthetic state where
-   bucket A is over-share and bucket B is under-share; assert
-   B is picked.
-7. `select_falls_back_to_smallest_excess_when_all_over_share`.
-8. `select_preserves_mqfq_among_eligibles` — multiple under-
-   share buckets, smallest HOL-finish wins.
-9. `select_at_period_boundary_no_panic` — stress test where
-   the period rotates during a select call.
+1. `account_dispatch_within_period_accumulates`.
+2. `account_dispatch_across_periods_resets_implicitly`.
+3. `bytes_in_period_returns_zero_for_stale_slot`.
+4. `mark_active_sets_bit_in_correct_word`.
+5. `mark_active_across_periods_resets_implicitly`.
+6. `period_summary_iterates_only_current_period_slots`.
+7. `concurrent_dispatch_same_bucket_no_loss` — N threads
+   each fetch_add 1000 bytes; assert final == N×1000.
+8. `concurrent_dispatch_different_buckets_independent`.
+9. `dispatch_at_period_boundary_no_panic` (R1 MED #10) —
+   dispatch at the EXACT moment `now_ns` straddles a
+   period boundary; assert no panic, all bytes accounted
+   into one of the two periods.
+10. `bytes_field_saturates_at_max_not_wraps` — push >
+    `BYTES_MAX` worth of dispatch; assert saturating, no
+    wrap.
 
-In `userspace-dp/src/afxdp/tx.rs` (integration):
+### 7.2 Integration tests in `tx.rs` (new `tests` module)
 
-10. `cos_queue_front_uses_afd_when_shared_lease`: build a
-    queue with `shared_queue_lease.is_some()`, fill two
-    buckets with different head-finish times, mark one as
-    over-share via direct `afd.period_bytes_per_flow` write,
-    assert `cos_queue_front` returns the under-share one.
-11. `cos_queue_front_uses_mqfq_when_no_shared_lease`:
-    regression — `shared_queue_lease.is_none()`, the existing
-    behaviour is preserved exactly.
+11. `cos_queue_front_uses_afd_when_shared_exact_with_lease`.
+12. `cos_queue_front_uses_existing_mqfq_when_not_shared_exact`
+    (regression — `shared_exact == false`, behaviour
+    preserved).
+13. `cos_queue_front_uses_existing_mqfq_when_shared_exact_no_lease`
+    (regression — defensive fall-through).
+14. `front_pop_selector_agreement` (R1 HIGH 4 + R1 MED #10):
+    after a `front` returns bucket B, the next `pop` of the
+    same queue must also produce bucket B.
+15. `cross_binding_active_bitmap_no_drift` (R1 MED #10):
+    two simulated bindings, both dispatch to different flows;
+    one period later, the bitmap reflects ALL flows that
+    dispatched in this period.
+16. `rollback_after_period_rotation_no_underflow` (R1 MED #10):
+    dispatch at t1, rotate to next period, push_front rollback
+    — assert no underflow (since we don't fetch_sub at all
+    per §5.3).
+
+### 7.3 Hash-seed propagation test in `worker.rs` (or types.rs)
+
+17. `binding_promotion_on_shared_exact_uses_lease_seed`.
+18. `binding_promotion_on_non_shared_exact_uses_own_seed`.
 
 ## 8. Acceptance
 
-- All Rust unit tests pass (`cargo test -p xpf-userspace-dp`).
-- All Go tests pass.
+- Rust unit + integration tests pass: `cargo test -p
+  xpf-userspace-dp`.
+- All Go tests pass: `go test ./pkg/...`.
+- `cargo build --release` passes.
 - Live deploy on `loss:xpf-userspace-fw0/fw1`:
   - **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10
     runs.
   - **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10
     runs.
-  - **p5202 128 streams 60 s × 1**: CoV ≤ baseline (16.6 %
-    from #900 finding).
+  - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (#900
+    baseline; do not regress).
   - 0 collapses (every stream ≥ 1 Mbps).
-  - Aggregate throughput ≥ 0.95× baseline (no regression).
-  - 0 retransmit regression vs baseline median.
-- `make test-failover`: pass (defense — touching dataplane
-  cross-binding state).
-- Codex hostile plan + code review rounds: PLAN-READY YES,
-  MERGE YES.
+  - Aggregate throughput ≥ 0.95 × baseline.
+  - 0 retransmit regression.
+  - Per-rep CPU saturation check (mpstat) on source: not
+    saturated.
+- `make test-failover`: pass.
+- Codex hostile plan + code review: PLAN-READY YES, MERGE
+  YES.
 - Copilot inline review: addressed.
 
-## 9. Risks
+## 9. Risks (R1 + R2 review-grounded)
 
-- **Active-bucket-count drift**: cached count can fall out of
-  sync with reality if a `fetch_add`/`fetch_sub` is missed.
-  Mitigation: place the inc/dec at the SAME control-flow site
-  as `flow_rr_buckets.push_back` / pop (which is the
-  authoritative source). Pin via test #5.
-- **Period-boundary thrash**: at the exact rotation moment,
-  one thread observes pre-rotation counters while another
-  observes post-rotation. Bounded by 2 ms; no correctness
-  consequence (counters are commutative). Pin via test #9.
-- **Over-share threshold sensitivity**: epsilon=0 with strict
-  fair_share may oscillate under high contention. Start with
-  epsilon=0, tune up to 1 (fair_share × 1.5) only if
-  empirical data shows oscillation.
-- **MQFQ ordering loss on shared queues**: AFD-lite decouples
-  the long-run byte-share from per-packet HOL-finish-time on
-  shared queues. Slight unfairness vs pure MQFQ for bursty
-  mixed-size workloads. Quantify in §8 with the standard
-  acceptance suite.
-- **Cache-line contention**: 1024 atomics × per-dispatch
-  fetch_add. With 6 workers all dispatching on the same lease
-  simultaneously, hot buckets (1-2 elephants) will see
-  cross-CPU cacheline bouncing. Bound by `CachePadded` and by
-  the fact that elephants are bursty (not lockstep on a
-  single bucket). If empirical perf shows >3% CPU regression,
-  fall back to per-shard counters (one slice per binding) and
-  sum at read time.
+- **CAS-loop overhead on hot bucket** (R1 MED #7): the
+  implicit-period scheme uses CAS-loop for accounting where
+  the original plan used fetch_add. Under contention from 6
+  workers on the same hot bucket, expected 2-3 iters per
+  dispatch. Mitigation: `CachePadded` per slot (already in
+  the plan). If empirical perf shows > 3 % CPU regression on
+  the iperf3-128-stream baseline (#900: ~30 % CPU on the
+  affected worker), fall back to per-shard counters
+  (one slice of slots per binding) and sum at read time.
+- **Period-summary cost** (R1 MED #7): `afd_period_summary`
+  does 1024 + 16 = 1040 atomic loads per selection. At
+  ~150 K pps per CoS queue, that's ~150 M loads/sec — well
+  within a single core. Mitigation: cached summary as
+  fallback if a per-rep CPU regression is observed.
+- **Active-bitmap word contention** (R1 HIGH 2 fix
+  side-effect): bitmap word with 64 buckets behind it; if
+  multiple bindings each have a flow in different buckets in
+  the same word, they all CAS-mark on the same word. Most
+  buckets in a word are inactive (sparse), so contention is
+  bounded. CachePad each word.
+- **Bytes-overflow saturation** (R1 MED #7-adjacent): with
+  32-bit byte counter (4 GB max in 2 ms = 16 Tb/s), no real
+  workload saturates this. Saturation is a defensive check,
+  not a real path.
+- **Acceptance bar realism** (R1 MED #11): #840 baseline at
+  16-stream was 18.5 % CoV; the 15 % bar requires a 19 %
+  improvement. AFD-lite's primary mechanism (skip-on-over-
+  share) targets RSS-hash-skew variance, which in our
+  default round-robin RSS at 16 flows / 6 queues gives
+  pigeon-hole 3-3-3-3-2-2 distribution. Skipping over-share
+  redistributes the 3-stream queues' bandwidth to the
+  2-stream queues' streams. Expected magnitude: 3-5 percentage
+  points improvement. So 15 % from 18.5 % is plausible but
+  tight. Document this in the PR result and don't auto-fail
+  if we land at, say, 16 %.
 
 ## 10. Out of scope
 
-- Full MQFQ ordering preservation on shared queues (#837).
-- Drop / ECN signalling on AFD over-share (#833 closed; double-
-  signal trap).
-- Per-flow rate limiting (#794 covers AFD policer; this issue
-  is selection-time skip only).
-- Adaptive epsilon based on queue depth.
-- IPv6 echo path coverage (the harness uses TCP-connect to
-  `172.16.80.200:7`; IPv6 to `[2001:559:8585:80::200]:7` is a
-  follow-up if needed).
+- Full MQFQ ordering on shared_exact queues (#837).
+- Drop / ECN signalling on AFD over-share (#833 closed).
+- Per-flow rate limiting (#794).
+- Adaptive epsilon shift based on queue depth.
+- IPv6 echo path coverage (#900 follow-up).
+- Cross-CoS-class fairness (each class has its own lease).
 
 ## 11. Test harness for empirical validation
 
-Now that the operator has enabled echo on `172.16.80.200:7`
-(TCP) and `[2001:559:8585:80::200]:7` (IPv6+TCP), the
-mouse-side harness from `docs/pr/900-100e100m-harness/` can
-be adapted to use Python TCP-connect against the echo server
-(replacing the failed hping3-and-iperf3-target approach). Out
-of scope for #838 itself but unblocks the empirical mouse-
-latency-tail measurement once #838 lands.
+Operator has enabled echo on `172.16.80.200:7` (TCP) and
+`[2001:559:8585:80::200]:7` (TCP+IPv6). The mouse-side
+harness from `docs/pr/900-100e100m-harness/` can be adapted
+to use Python TCP-connect against the echo server (replacing
+the failed hping3-via-iperf3-target approach), but that work
+is out of scope for #838 itself.
 
 For #838 acceptance, only the standard iperf3-stream CoV
 test from §8 is required.
+
+## 12. Out of scope (cross-issue boundary clarifications)
+
+The R1 review surfaced overlap with several closed/related
+issues; this PR does NOT touch:
+
+- HOL-finish-time sharing redesign (#837).
+- ECN-based per-flow signalling (#833 closed; double-signal
+  trap).
+- Per-flow-scaled credit gate (#834 closed; starvation).
+- RSS rebalance (#840 reverted).
+
+## 13. R1 review responses
+
+Round 1: 8 HIGH, 4 MED. PLAN-NEEDS-MAJOR-REWORK.
+
+| # | Sev | Topic                                        | Resolution |
+|---|-----|----------------------------------------------|------------|
+| 1 | HIGH| Period-reset publish ordering broken         | §5.1: implicit period via timestamp eliminates the rotate-CAS + zero-loop entirely. Each slot is period-tagged; staleness is read-time |
+| 2 | HIGH| `active_bucket_count` cross-binding race     | §5.2: replaced with active-flow bitmap also period-tagged. Computed by popcount at read time |
+| 3 | HIGH| `fetch_sub` rollback underflow               | §5.3: skip rollback accounting entirely. Bounded credit (<3.6% per period worst case) — far smaller than the underflow risk |
+| 4 | HIGH| Successful-pop surface underspecified        | §6.3 enumerates all 8 commit points by tx.rs:line. Front/pop selectors share new `cos_queue_select_bucket` helper |
+| 5 | HIGH| Epsilon formula `>>0 = 2x fair_share`        | §5.4 explicit formula; `AFD_OVER_SHARE_EPSILON_SHIFT = u32::MAX` saturates to `>>0=0` so threshold = fair_share + 0 = strict |
+| 6 | HIGH| Wrong gate (lease.is_some vs shared_exact)   | §5.5: gate is `queue.flow_fair && queue.shared_exact && shared_queue_lease.is_some()` |
+| 7 | HIGH| Shared hash seed not wired                   | §5.6: binding promotion (worker.rs:3804/3938) reads lease seed when shared_exact, else random |
+| 8 | HIGH| `push_front` empty-transition active-count   | §6.3: NO active-count tracking on enqueue/dequeue paths. Bitmap is per-period, populated only by dispatch. push_front is invisible to AFD |
+| 9 | MED | Cache-line cost not bounded to shared queues | §9: noted; CachePadded slots; fallback to per-shard if measured >3% CPU |
+| 10| MED | 2 ms period window ungrounded                | §5.1: 2 ms is the burst-coverage scale (10 Gb/s × 2 ms = 2.5 MB; 1 Gb/s × 2 ms = 250 KB — bigger than typical TCP cwnd burst). Empirical tuning open as follow-up |
+| 11| MED | Test gaps                                    | §7 added: rotation-during-dispatch (test 9), cross-binding bitmap drift (test 15), rollback-after-rotation no-underflow (test 16), front/pop selector agreement (test 14) |
+| 12| MED | Acceptance bar uncertain vs prior negatives  | §9 acceptance: documented expected magnitude (3-5pp); merge YES if at 16% with monotone improvement, not auto-fail at exactly 15.5% |

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -578,9 +578,11 @@ focus on the non-regression merge gate; the targets are
 ambitions to compare against, not pass/fail thresholds.
 - `make test-failover`: pass (defense — touching the
   CoS dataplane).
-- Codex hostile plan + code review: PLAN-READY YES,
-  MERGE YES.
-- Copilot inline review: addressed.
+- Codex hostile plan + code review: NOT ACHIEVED. The plan
+  closed at R5 with a PLAN-NEEDS-MAJOR-REWORK verdict (see
+  §11 Round 5 + `findings.md`); MERGE was never pursued.
+- Copilot inline review: addressed for the closing docs PR
+  (#904); not pursued for the unwritten implementation.
 
 ## 9. Risks
 
@@ -598,10 +600,10 @@ ambitions to compare against, not pass/fail thresholds.
     a target, not a gate; merge is justified by code
     quality + zero-harm even if the empirical bar isn't
     hit.
-- **Period-rotation cost**: `Box::fill(0)` on 8 KB at 500
-  Hz = ~120 µs/sec/queue. With ~2-4 flow-fair-non-shared
-  queues per worker × 6 workers, total ~1-3 ms/sec of CPU.
-  Bounded.
+- **Period-rotation cost**: `state.bytes_per_flow.fill(0)`
+  on 8 KB at 500 Hz = ~120 µs/sec/queue. With ~2-4
+  flow-fair-non-shared queues per worker × 6 workers,
+  total ~1-3 ms/sec of CPU. Bounded.
 - **Selection cost**: 1024-u64 linear scan per `cos_queue_front`
   + per pop. Profile shows the existing
   `cos_queue_min_finish_bucket` is a hot site; this adds a

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -1,236 +1,165 @@
-# #838 — AFD-lite: per-flow bytes-served counter with periodic reset
+# #838 — AFD-lite (single-binding scope, v3)
 
 ## 1. Goal
 
-Improve cross-binding fair queueing on `shared_exact` CoS queues
-without the surface area of full HOL-finish-time sharing
-(#836 closed → tracked as the "big-design" alternative in #837).
+Add per-flow bytes-served tracking + over-share skip to
+`flow_fair` CoS queues that are owned by a single binding
+(i.e. `flow_fair && !shared_exact`). This is a structural
+fairness floor on top of the existing MQFQ HOL-finish-time
+ordering: even if MQFQ would let a flow dominate (e.g. due
+to packet-size variance), AFD-lite enforces a hard
+per-period fair-share ceiling.
 
-This implements the smaller-surface alternative described in
-#838: track bytes dispatched per flow-bucket per time window,
-shared across all bindings on a `SharedCoSQueueLease`. Bucket
-selection skips flows that are over their fair share for one
-round-robin cycle.
-
-R1 review found 8 HIGH + 4 MED requiring a structural redesign;
-this v2 addresses each in §13.
+This v3 is a **scope reduction** from the original #838
+issue (which targeted shared_exact cross-binding sharing).
+Two prior plan-review rounds (R1: 8 HIGH + 4 MED; R2:
+6 HIGH + 2 MED + 1 LOW) showed that cross-binding atomic
+state has too many race-handling subtleties to be a
+small-surface change. The cross-binding work is deferred
+back to #837.
 
 ## 2. What this is NOT
 
-- Not a full MQFQ replacement. Single-binding `flow_fair`
-  queues retain `cos_queue_min_finish_bucket()` HOL-finish
-  ordering unchanged.
-- Not a drop / ECN path. Skip-on-selection only — no admission
-  changes (avoids the #833 double-signal trap).
-- Not Count-Min sketch. Use a fixed `[AtomicU64; 1024]` array
+- Not cross-binding. AFD-lite engages only on
+  `flow_fair && !shared_exact` queues (single-worker
+  ownership). Shared-exact queues retain the existing
+  selection logic unchanged.
+- Not a full MQFQ replacement. The selector still picks
+  by HOL-finish-time among under-share buckets.
+- Not a drop / ECN path. Skip-on-selection only.
+- Not a Count-Min sketch. Use a fixed `[u64; 1024]` array
   keyed by `flow_bucket_index`.
 
 ## 3. Test environment
 
-- Cluster: `loss:xpf-userspace-fw0/fw1` (RG0 primary).
+- Cluster: `loss:xpf-userspace-fw0/fw1`.
 - Source: `loss:cluster-userspace-host`.
 - Targets:
   - `172.16.80.200:5201` — iperf3 server (existing).
-  - `172.16.80.200:7` — TCP/UDP echo (newly enabled by
-    operator, confirmed via `</dev/tcp/172.16.80.200/7`).
-  - `[2001:559:8585:80::200]:7` — IPv6 echo (out of scope for
-    #838 itself; available for follow-up #900 mouse-latency
-    measurement).
+  - `172.16.80.200:7` — TCP echo (operator-enabled,
+    confirmed reachable).
 - CoS class: **iperf-a** (1 Gb/s shaped) for tightest CoV.
-- Workers=6, queue 4 owned by worker 1, queue 5 owned by
-  worker 2. Both `iperf-a` (queue 4) and `iperf-b` (queue 5)
-  are `shared_exact`-eligible based on the existing
-  promotion policy.
+- Workers=6.
 
 ## 4. Workload
 
+Same as v1/v2 (acceptance unchanged):
+
 - **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10.
 - **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10.
-- **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (the #900
-  baseline; AFD-lite must not regress).
-- 0 stream collapses (every stream ≥ 1 Mbps).
+- **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (#900
+  baseline; do not regress).
+- 0 collapses.
 - Aggregate throughput ≥ 0.95 × baseline.
-- 0 retransmit regression vs baseline median.
+- 0 retransmit regression.
 
-## 5. Algorithm specification (R1-redesigned)
+## 5. Algorithm specification
 
-### 5.1 Period state — implicit via timestamp, no rotate-CAS
+### 5.1 Per-queue AFD-lite state
 
-R1 HIGH 1 + R1 HIGH 3 fix: eliminate the explicit period-
-reset CAS-elect + zero-loop. Use **implicit periods via packed
-timestamp**.
-
-```
-Per-flow slot (replaces period_bytes_per_flow[i]):
-  AtomicU64 slot = (period_idx[32 bits] | bytes[32 bits])
-
-Period index:
-  period_idx(now) = (now_ns - lease_epoch_ns) / AFD_PERIOD_WINDOW_NS
-
-Lease epoch:
-  lease_epoch_ns = monotonic_ns at lease construction (constant)
-```
-
-There is no `period_start_ns` to update, no rotation CAS, no
-zero-loop. A slot is automatically "stale" if its embedded
-`period_idx` is below `period_idx(now)`.
-
-This is a CAS-loop on dispatch (not raw fetch_add) but the
-loop has no contention with any rotator — rotation is
-implicit and lock-free by construction.
-
-### 5.2 Hot-path operations
-
-**Dispatch accounting** (after a successful TX-ring write):
+Lives on `CoSQueueRuntime`, alongside the existing
+`flow_rr_buckets` / `flow_bucket_head_finish_bytes`
+fields. Single-threaded access via the owning binding's
+worker — **no atomics needed**.
 
 ```rust
-fn afd_account_dispatch(slot: &AtomicU64, bytes: u64, now_ns: u64) {
-    let cur_period = period_idx(now_ns);
-    loop {
-        let raw = slot.load(Relaxed);
-        let (slot_period, slot_bytes) = unpack(raw);
-        let new = if slot_period < cur_period {
-            // Stale slot — start fresh in the new period.
-            pack(cur_period, bytes.min(BYTES_MAX))
-        } else {
-            // Same period — add.
-            pack(cur_period, slot_bytes.saturating_add(bytes).min(BYTES_MAX))
-        };
-        if slot.compare_exchange_weak(raw, new, AcqRel, Relaxed).is_ok() {
-            return;
-        }
+pub(super) struct AFDLiteState {
+    /// Wall-clock ns at which the current accounting window
+    /// began. Updated when `now - period_start_ns >= AFD_PERIOD_WINDOW_NS`.
+    period_start_ns: u64,
+    /// Bytes dispatched to bucket b in current window.
+    /// Indexed by `flow_bucket_index` (already bounded to
+    /// COS_FLOW_FAIR_BUCKETS = 1024).
+    bytes_per_flow: Box<[u64; COS_FLOW_FAIR_BUCKETS]>,
+    /// Sum of bytes_per_flow in current window.
+    bytes_total: u64,
+    /// Count of buckets with bytes_per_flow[b] > 0 in current
+    /// window. Maintained incrementally — incremented on a
+    /// 0→positive transition, recomputed (along with the
+    /// counters) on period rotation.
+    active_count: u32,
+}
+
+pub(super) const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;  // 2 ms
+pub(super) const AFD_OVER_SHARE_NUM: u32 = 0;            // strict (default)
+pub(super) const AFD_OVER_SHARE_DEN: u32 = 256;
+// threshold = fair_share + fair_share * NUM / DEN
+// NUM=0  → strict (threshold = fair_share)
+// NUM=64 → 1.25× fair_share
+// NUM=128 → 1.5×
+```
+
+Memory cost: 8 KB per `flow_fair && !shared_exact` queue.
+Negligible.
+
+### 5.2 Hot-path operations (single-threaded — no CAS)
+
+**Period rotation** (called at the top of `afd_account_dispatch`):
+
+```rust
+fn afd_maybe_rotate(state: &mut AFDLiteState, now_ns: u64) {
+    if now_ns.saturating_sub(state.period_start_ns) < AFD_PERIOD_WINDOW_NS {
+        return;
+    }
+    state.period_start_ns = now_ns;
+    state.bytes_per_flow.fill(0);
+    state.bytes_total = 0;
+    state.active_count = 0;
+}
+```
+
+The `fill(0)` over 1024 u64s is ~8 KB of L1 cache; on a
+single core this is ~250 ns. At 500 rotations/sec
+(2 ms window), the amortized overhead is < 0.001 % of CPU.
+Acceptable.
+
+**Dispatch accounting** (called after a successful TX-ring
+write — Codex R2 #6 fix: account-after-TX-insert,
+unconditional rollback removed):
+
+```rust
+fn afd_account_dispatch(state: &mut AFDLiteState, bucket: usize, bytes: u64, now_ns: u64) {
+    afd_maybe_rotate(state, now_ns);
+    let prev = state.bytes_per_flow[bucket];
+    let new = prev.saturating_add(bytes);
+    state.bytes_per_flow[bucket] = new;
+    state.bytes_total = state.bytes_total.saturating_add(bytes);
+    if prev == 0 && new > 0 {
+        state.active_count = state.active_count.saturating_add(1);
     }
 }
 ```
 
-Two threads racing in the same period CAS-loop until one
-wins; expected 1-2 iterations under hot-bucket contention.
-A thread observing `slot_period < cur_period` and another
-having just CAS'd to the new period will retry once and
-agree.
+**No rollback path.** Codex R2 #6 fix: account *after* TX
+insertion succeeds. If TX insertion fails, the dispatch
+function returns early (existing code path) without ever
+calling `afd_account_dispatch`. There is no `fetch_sub`
+to misbehave; no underflow scenario; no batch-failure
+920 % overcharge.
 
-**Read for selection** (in `cos_queue_min_finish_bucket_afd`):
+### 5.3 Selection gating
 
-```rust
-fn afd_bytes_in_period(slot: &AtomicU64, cur_period: u64) -> u64 {
-    let (slot_period, slot_bytes) = unpack(slot.load(Relaxed));
-    if slot_period == cur_period { slot_bytes } else { 0 }
-}
-```
-
-Stale slots auto-zero on read.
-
-**Total-in-period and active-flow-count** (R1 HIGH 2 fix):
-the old design's `period_bytes_total` and
-`active_bucket_count` had their own ordering / drift
-problems. Replace with a **bitmap of active flows in the
-current period**, also period-tagged.
-
-```
-Active-flow bitmap (16 × AtomicU64, each covering 64 flows):
-  AtomicU64 word = (period_idx[32 bits] | mask[32 bits])
-
-For 1024 buckets we need 16 words. Memory: 16 × 8 = 128 B.
-Cache-pad to 16 × 64 = 1 KB per lease.
-```
-
-On dispatch, set the bit corresponding to `bucket_idx`:
+Adds a wrapper around the existing
+`cos_queue_min_finish_bucket`:
 
 ```rust
-fn afd_mark_active(word: &AtomicU64, bit_offset: u32, cur_period: u64) {
-    loop {
-        let raw = word.load(Relaxed);
-        let (slot_period, slot_mask) = unpack(raw);
-        let new_mask = if slot_period < cur_period {
-            1u32 << bit_offset
-        } else {
-            slot_mask | (1u32 << bit_offset)
-        };
-        let new = pack(cur_period, new_mask);
-        if slot.compare_exchange_weak(raw, new, AcqRel, Relaxed).is_ok() {
-            return;
-        }
+fn cos_queue_select_bucket(queue: &CoSQueueRuntime, now_ns: u64) -> Option<u16> {
+    if queue.shared_exact || !queue.flow_fair {
+        // Out of scope for v3: shared_exact uses existing
+        // ordering (no AFD); non-flow-fair has no buckets.
+        return cos_queue_min_finish_bucket(queue);
     }
-}
-```
-
-Total bytes-in-period and active-flow-count are computed at
-**read time** (during selection) by iterating the bitmap and
-slot array:
-
-```rust
-fn afd_period_summary(state: &AFDLiteState, cur_period: u64) -> (u64, u32) {
-    let mut total = 0u64;
-    let mut active = 0u32;
-    for word in state.active_bitmap.iter() {
-        let (wp, mask) = unpack(word.load(Relaxed));
-        if wp == cur_period {
-            active += mask.count_ones();
-        }
+    let afd = queue.afd.as_ref().expect("flow_fair queue must have AFD state");
+    let (total, active) = (afd.bytes_total, afd.active_count);
+    if active == 0 {
+        // Fresh window with no activity — fall back to MQFQ.
+        return cos_queue_min_finish_bucket(queue);
     }
-    for slot in state.bytes_per_flow.iter() {
-        let (sp, b) = unpack(slot.load(Relaxed));
-        if sp == cur_period {
-            total = total.saturating_add(b);
-        }
-    }
-    (total, active)
-}
-```
-
-The two iterations are 1024 + 16 atomic loads. At one
-selection per packet on a hot CoS queue, this is the cost
-that #838's CPU budget must accommodate (see §9).
-
-If empirical perf shows >3 % CPU regression, fall back to a
-cached `(total, active)` packed atomic refreshed at most
-once per N selections — but start with read-time
-computation for simplicity.
-
-### 5.3 Rollback handling (R1 HIGH 3 fix)
-
-**No fetch_sub on rollback.** Rollback (push_front after a
-failed TX-ring write) is rare. Skipping the byte unaccount
-means the affected flow gets one packet's worth of "credit"
-counted toward its current period — which is bounded:
-
-- One rollback ≈ MTU bytes (≤ 9000 B with jumbo) per period.
-- Per-period budget at 1 Gb/s × 2 ms = 250 KB.
-- Worst-case effect: one rollback overcharges a flow by
-  ~3.6 % of the period's allowed share.
-- Rollback rate is typically < 0.01 % of TX attempts.
-
-This eliminates the underflow scenario from R1 HIGH 3
-entirely (no fetch_sub → no possibility of u64 wrap).
-
-Document this trade-off in the function comment.
-
-### 5.4 Selection gating
-
-```rust
-fn cos_queue_min_finish_bucket_afd(
-    queue: &CoSQueueRuntime,
-    lease: &SharedCoSQueueLease,
-    now_ns: u64,
-) -> Option<u16> {
-    let cur_period = period_idx(now_ns, lease.afd.epoch_ns);
-    let (total, active) = afd_period_summary(&lease.afd, cur_period);
-    let fair_share = if active > 0 {
-        total / u64::from(active)
-    } else {
-        u64::MAX
-    };
-    // R1 HIGH 5 fix: explicit threshold formula.
-    // epsilon=0 → threshold = fair_share exactly (strict)
-    // epsilon=N → threshold = fair_share + fair_share/(2^N)
-    //   so N=1 → 1.5x, N=2 → 1.25x, N=3 → 1.125x.
+    let fair_share = total / u64::from(active);
     let threshold = fair_share.saturating_add(
-        fair_share >> AFD_OVER_SHARE_EPSILON_SHIFT.saturating_sub(0),
+        fair_share.saturating_mul(u64::from(AFD_OVER_SHARE_NUM))
+                  / u64::from(AFD_OVER_SHARE_DEN),
     );
-    // Configured constant: AFD_OVER_SHARE_EPSILON_SHIFT = u32::MAX
-    //   means "no over-share allowance" (saturating shift gives 0,
-    //   threshold = fair_share). Default for this PR.
-    // To loosen later, set the shift to e.g. 1 (threshold = 1.5x).
 
     let mut best_under: Option<u16> = None;
     let mut best_under_finish = u64::MAX;
@@ -238,7 +167,7 @@ fn cos_queue_min_finish_bucket_afd(
     let mut best_over_excess = u64::MAX;
     for bucket in queue.flow_rr_buckets.iter() {
         let idx = usize::from(bucket);
-        let bytes = afd_bytes_in_period(&lease.afd.bytes_per_flow[idx], cur_period);
+        let bytes = afd.bytes_per_flow[idx];
         let finish = queue.flow_bucket_head_finish_bytes[idx];
         if bytes <= threshold {
             if finish < best_under_finish {
@@ -258,311 +187,254 @@ fn cos_queue_min_finish_bucket_afd(
 ```
 
 If at least one bucket is under-share, pick by smallest
-HOL-finish (preserves MQFQ ordering among eligibles). If
-ALL are over-share, fall back to smallest excess to avoid
-going idle.
+HOL-finish-time (preserves MQFQ ordering among eligibles).
+If ALL are over-share (e.g. early in window before counters
+update), fall back to smallest excess to avoid going idle.
 
-### 5.5 Gate (R1 HIGH 6 fix)
+### 5.4 Single-pass selection (Codex R2 #2 fix)
 
-AFD-lite engages only on **`queue.shared_exact == true`** —
-not `shared_queue_lease.is_some()`. Per `coordinator.rs:1960`
-+ `worker.rs:3804`/`3938`, lease presence is broader than
-shared-exact. The gate condition in `cos_queue_front` becomes:
+Both `cos_queue_front` (`tx.rs:4262`) and the equivalent
+pop site (`tx.rs:4464`-area) currently call
+`cos_queue_min_finish_bucket(queue)` separately. Replace
+both call sites to use `cos_queue_select_bucket(queue,
+now_ns)`. The selection cost is now a single 1024-element
+loop per call, called twice per packet (once for front,
+once for pop). At ~150 K pps × 2 calls × 1024 reads =
+~300 M reads/sec on a single core — well within budget for
+a contiguous u64 array (cache-friendly linear scan).
 
-```rust
-if queue.flow_fair && queue.shared_exact {
-    if let Some(lease) = queue.shared_queue_lease.as_ref() {
-        return cos_queue_min_finish_bucket_afd(queue, lease, now_ns)
-            .and_then(|b| queue.flow_bucket_items[usize::from(b)].front());
-    }
-}
-// Else: fall through to existing cos_queue_min_finish_bucket() path
-```
-
-Single-binding queues, non-flow-fair queues, and shared-but-
-non-exact queues all preserve the existing selection.
-
-### 5.6 Shared flow-hash seed (R1 HIGH 7 fix)
-
-The lease's `flow_hash_seed` (already specified in #838 issue)
-must be propagated to bindings when they promote onto the
-lease. Per `tx.rs:5408`, bindings currently draw a fresh seed
-at promotion time. Change `ensure_cos_interface_runtime` (or
-the equivalent promotion site) to:
-
-```rust
-// Existing: queue.flow_hash_seed = getrandom_u64();
-// New: if shared_exact and lease has a seed, use lease's.
-queue.flow_hash_seed = if queue.shared_exact {
-    lease.afd.flow_hash_seed
-} else {
-    getrandom_u64()
-};
-```
-
-This ensures all bindings on the same lease map a given
-5-tuple to the same `flow_bucket_index`, so the shared
-`bytes_per_flow[i]` counter has consistent meaning.
-
-The lease's seed is drawn from `getrandom(2)` at lease
-construction — same property as before (unpredictable across
-restarts and nodes; deterministic within one lease).
+(Caching the result across paired front+pop calls is a
+follow-up optimisation if profiling shows it's a hotspot.)
 
 ## 6. Implementation outline
 
 ### 6.1 New file: `userspace-dp/src/afxdp/afd_lite.rs`
 
 ```rust
-//! AFD-lite: per-flow bytes-served counter for shared_exact
-//! CoS queues. See docs/pr/838-afd-lite/plan.md.
-
-use std::sync::atomic::{AtomicU64, Ordering};
+//! AFD-lite: per-flow bytes-served + over-share skip for
+//! single-binding flow_fair CoS queues. See
+//! docs/pr/838-afd-lite/plan.md.
 
 pub(super) const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;
-pub(super) const AFD_PERIOD_BITS: u64 = 32;
-pub(super) const AFD_BYTES_BITS: u64 = 32;
-pub(super) const AFD_BYTES_MAX: u64 = (1u64 << AFD_BYTES_BITS) - 1;
-pub(super) const AFD_OVER_SHARE_EPSILON_SHIFT: u32 = u32::MAX; // strict (default)
-pub(super) const AFD_FLOW_BUCKETS: usize = 1024;
-pub(super) const AFD_BITMAP_WORDS: usize = AFD_FLOW_BUCKETS / 32;
+pub(super) const AFD_OVER_SHARE_NUM: u32 = 0;
+pub(super) const AFD_OVER_SHARE_DEN: u32 = 256;
 
-#[repr(align(64))]
-pub(super) struct CachePaddedAtomicU64(AtomicU64);
-
-pub(super) struct AFDLiteState {
-    pub(super) epoch_ns: u64,
-    pub(super) flow_hash_seed: u64,
-    pub(super) bytes_per_flow: Box<[CachePaddedAtomicU64; AFD_FLOW_BUCKETS]>,
-    pub(super) active_bitmap: Box<[CachePaddedAtomicU64; AFD_BITMAP_WORDS]>,
-}
-
-#[inline] fn pack(period: u64, payload: u64) -> u64 { (period << AFD_BYTES_BITS) | (payload & AFD_BYTES_MAX) }
-#[inline] fn unpack(raw: u64) -> (u64, u64) { (raw >> AFD_BYTES_BITS, raw & AFD_BYTES_MAX) }
-#[inline] pub(super) fn period_idx(now_ns: u64, epoch_ns: u64) -> u64 {
-    (now_ns.saturating_sub(epoch_ns)) / AFD_PERIOD_WINDOW_NS
-}
+pub(super) struct AFDLiteState { ... }
 
 impl AFDLiteState {
-    pub(super) fn new(epoch_ns: u64, flow_hash_seed: u64) -> Self { ... }
+    pub(super) fn new() -> Self { ... }
 }
 
-pub(super) fn afd_account_dispatch(state: &AFDLiteState, bucket: usize, bytes: u64, now_ns: u64) { ... }
-pub(super) fn afd_bytes_in_period(state: &AFDLiteState, bucket: usize, cur_period: u64) -> u64 { ... }
-pub(super) fn afd_mark_active(state: &AFDLiteState, bucket: usize, cur_period: u64) { ... }
-pub(super) fn afd_period_summary(state: &AFDLiteState, cur_period: u64) -> (u64, u32) { ... }
+pub(super) fn afd_maybe_rotate(state: &mut AFDLiteState, now_ns: u64) { ... }
+pub(super) fn afd_account_dispatch(state: &mut AFDLiteState, bucket: usize, bytes: u64, now_ns: u64) { ... }
+pub(super) fn afd_threshold(state: &AFDLiteState) -> u64 { ... }  // helper for selection
 ```
 
 ### 6.2 Edits to `userspace-dp/src/afxdp/types.rs`
 
-- Add `pub(super) afd: AFDLiteState` field to
-  `SharedCoSQueueLease`.
-- `SharedCoSQueueLease::new` extends to construct
-  `AFDLiteState::new(monotonic_ns(), getrandom_u64())`.
+- Add `pub(super) afd: Option<Box<AFDLiteState>>` field to
+  `CoSQueueRuntime`.
+  - `Box<AFDLiteState>` so the 8 KB allocation lives off
+    the runtime struct (which is repeatedly cloned during
+    plan reconciliation).
+  - `Option` so non-`flow_fair` queues skip the
+    allocation entirely.
+- Set `afd = Some(Box::new(AFDLiteState::new()))` at the
+  same site where existing flow-fair fields are
+  initialised (`promote_cos_queue_flow_fair` in
+  `tx.rs:5388`).
+- Add `mod afd_lite;` to `userspace-dp/src/afxdp/mod.rs`
+  (or wherever the existing module declarations live).
 
 ### 6.3 Edits to `userspace-dp/src/afxdp/tx.rs`
 
-R1 HIGH 4 fix: enumerate ALL pop commit points + push_front
-sites. Per the source citations from R1, the touch-points
-are:
+**Pop commit-points** — call `afd_account_dispatch` AFTER
+the TX-ring insertion succeeds at each of the existing
+sites identified by Codex R1 (line numbers approximate
+against current HEAD; verify before editing):
 
-**Dispatch-accounting hooks (call `afd_account_dispatch` +
-`afd_mark_active` after a successful TX-ring write):**
+- `tx.rs:2926` — successful pop commit (primary pop path).
+- `tx.rs:2957` — successful pop commit (alt path).
+- `tx.rs:2983` — successful pop commit.
+- `tx.rs:3012` — successful pop commit.
+- `tx.rs:3129` — successful pop commit (forwarding).
+- `tx.rs:3170` — successful pop commit (forwarding).
+- `tx.rs:3214` — successful pop commit (forwarding).
+- `tx.rs:3272` — successful pop commit (forwarding).
 
-- `tx.rs:2926` — successful pop commit
-- `tx.rs:2957` — successful pop commit (alt path)
-- `tx.rs:2983` — successful pop commit (alt path)
-- `tx.rs:3012` — successful pop commit (alt path)
-- `tx.rs:3129` — successful pop commit (forwarding path)
-- `tx.rs:3170` — successful pop commit (forwarding path)
-- `tx.rs:3214` — successful pop commit (forwarding path)
-- `tx.rs:3272` — successful pop commit (forwarding path)
+At each, gate on `queue.flow_fair && !queue.shared_exact`
+to avoid touching out-of-scope queues.
 
-**Skip rollback-accounting** (R1 HIGH 3 fix) — push_front
-sites at `tx.rs:2637`, `2812`, `2960`, `3014`, `4308`, `4345`,
-`4373`, `4383`: do NOT touch AFD counters. The flow gets one
-packet of "credit" until the period ends; bounded.
+**Failure / rollback paths** — *do nothing*. Per §5.2,
+the no-rollback design means failed TX simply doesn't
+account.
 
-**Active-bitmap maintenance**: only `mark_active` on
-dispatch (above). No "unmark on bucket empty" — the bitmap
-is auto-period-tagged and clears implicitly at period
-rotation. R1 HIGH 8 (rollback active-count) is closed by
-this design — we don't track active-count separately, only
-"saw-bytes-this-period" bitmap.
+**Selection sites**:
+- `cos_queue_front` (`tx.rs:4262`) → call
+  `cos_queue_select_bucket(queue, now_ns)`.
+- `cos_queue_pop_front_inner` (`tx.rs:4464`-area) → same.
 
-**Front/pop selector agreement** (R1 HIGH 4 closure):
-both `cos_queue_front` (line 4262) and
-`cos_queue_pop_front_inner` (line 4527 area) currently call
-`cos_queue_min_finish_bucket()`. Add a new shared helper
-`cos_queue_select_bucket(queue, lease, now_ns)` that both
-call, branching on `shared_exact + lease.is_some()`.
+The `now_ns` argument is plumbed from the existing call
+chain. Worker hot-paths already have a `now_ns` value
+(from the polling loop's `monotonic_ns()`); pass it
+through.
 
-### 6.4 Edits to `userspace-dp/src/afxdp/coordinator.rs`
+### 6.4 Stale-comment cleanup (Codex R2 #8)
 
-`SharedCoSQueueLease::new` already accepts config; extend
-to construct `AFDLiteState`. No other coordinator changes
-needed.
+The R2 review surfaced a stale invariant in
+`types.rs:1037-1040` and `tx.rs:5326-5329` saying
+`flow_fair = exact && !shared_exact`. The actual
+production code at `tx.rs:5408-5410` sets `flow_fair =
+exact` unconditionally; tests at `tx.rs:14661-14679`
+assert that shared-exact queues ARE flow-fair. Update the
+stale comments to match — this is a maintenance trap that
+this PR can fix while it's adjacent to the same code.
 
-### 6.5 Edits to `userspace-dp/src/afxdp/worker.rs`
+### 6.5 No edits to `coordinator.rs` or `worker.rs`
 
-Per R1 HIGH 7: at the binding-promotion site
-(`worker.rs:3789`, `3804`, `3938`, `3948`), change
-`flow_hash_seed` assignment to use the lease's seed when
-`shared_exact && lease.is_some()`.
+Per §1, this scope is single-binding. No
+`SharedCoSQueueLease` changes, no binding-promotion
+changes for shared seed propagation, no cross-binding
+state.
 
 ## 7. Tests
 
 ### 7.1 Unit tests in `afd_lite.rs`
 
 1. `account_dispatch_within_period_accumulates`.
-2. `account_dispatch_across_periods_resets_implicitly`.
-3. `bytes_in_period_returns_zero_for_stale_slot`.
-4. `mark_active_sets_bit_in_correct_word`.
-5. `mark_active_across_periods_resets_implicitly`.
-6. `period_summary_iterates_only_current_period_slots`.
-7. `concurrent_dispatch_same_bucket_no_loss` — N threads
-   each fetch_add 1000 bytes; assert final == N×1000.
-8. `concurrent_dispatch_different_buckets_independent`.
-9. `dispatch_at_period_boundary_no_panic` (R1 MED #10) —
-   dispatch at the EXACT moment `now_ns` straddles a
-   period boundary; assert no panic, all bytes accounted
-   into one of the two periods.
-10. `bytes_field_saturates_at_max_not_wraps` — push >
-    `BYTES_MAX` worth of dispatch; assert saturating, no
-    wrap.
+2. `account_dispatch_across_periods_resets_via_rotate`.
+3. `period_rotation_zeros_state` — direct test of
+   `afd_maybe_rotate`.
+4. `period_rotation_no_op_within_window`.
+5. `active_count_increments_on_zero_to_positive_transition`
+   only.
+6. `bytes_saturate_at_u64_max_no_wrap`.
 
 ### 7.2 Integration tests in `tx.rs` (new `tests` module)
 
-11. `cos_queue_front_uses_afd_when_shared_exact_with_lease`.
-12. `cos_queue_front_uses_existing_mqfq_when_not_shared_exact`
-    (regression — `shared_exact == false`, behaviour
-    preserved).
-13. `cos_queue_front_uses_existing_mqfq_when_shared_exact_no_lease`
-    (regression — defensive fall-through).
-14. `front_pop_selector_agreement` (R1 HIGH 4 + R1 MED #10):
-    after a `front` returns bucket B, the next `pop` of the
-    same queue must also produce bucket B.
-15. `cross_binding_active_bitmap_no_drift` (R1 MED #10):
-    two simulated bindings, both dispatch to different flows;
-    one period later, the bitmap reflects ALL flows that
-    dispatched in this period.
-16. `rollback_after_period_rotation_no_underflow` (R1 MED #10):
-    dispatch at t1, rotate to next period, push_front rollback
-    — assert no underflow (since we don't fetch_sub at all
-    per §5.3).
+7. `cos_queue_select_bucket_picks_under_share_first` —
+   construct a `flow_fair && !shared_exact` queue,
+   pre-populate two buckets with different bytes_per_flow
+   values; assert the under-share one is selected.
+8. `cos_queue_select_bucket_falls_back_to_smallest_excess`
+   — all buckets over-share; assert smallest-excess wins.
+9. `cos_queue_select_bucket_preserves_mqfq_among_eligibles`
+   — multiple under-share, smallest HOL-finish wins.
+10. `cos_queue_select_bucket_passthrough_for_shared_exact`
+    — `shared_exact == true`; assert the existing
+    `cos_queue_min_finish_bucket` is called (no AFD logic
+    engaged).
+11. `cos_queue_select_bucket_passthrough_when_active_count_zero`
+    — fresh window, no activity yet; assert MQFQ
+    fall-back.
+12. `cos_queue_select_bucket_passthrough_for_non_flow_fair`
+    — `flow_fair == false`; existing path preserved.
+13. `dispatch_failure_does_not_account` — simulate a TX
+    insertion failure; assert AFD state unchanged.
+14. `dispatch_success_accounts` — simulate a successful
+    TX; assert `bytes_per_flow[b]` and `bytes_total`
+    incremented; `active_count` incremented if 0→1.
 
-### 7.3 Hash-seed propagation test in `worker.rs` (or types.rs)
+### 7.3 Test plumbing
 
-17. `binding_promotion_on_shared_exact_uses_lease_seed`.
-18. `binding_promotion_on_non_shared_exact_uses_own_seed`.
+Reuse the existing `CoSQueueRuntime` test constructors;
+the new `afd: Option<Box<AFDLiteState>>` field can be
+populated via `Some(Box::new(AFDLiteState::new()))` in
+test setup for flow-fair-non-shared-exact cases.
 
 ## 8. Acceptance
 
-- Rust unit + integration tests pass: `cargo test -p
-  xpf-userspace-dp`.
-- All Go tests pass: `go test ./pkg/...`.
-- `cargo build --release` passes.
+- Rust unit + integration tests pass.
+- All Go tests pass.
+- `cargo build --release` clean.
 - Live deploy on `loss:xpf-userspace-fw0/fw1`:
   - **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10
     runs.
   - **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10
     runs.
-  - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 % (#900
-    baseline; do not regress).
+  - **p5202 128 streams 60 s × 1**: CoV ≤ 16.6 %
+    (#900 baseline; do not regress).
   - 0 collapses (every stream ≥ 1 Mbps).
   - Aggregate throughput ≥ 0.95 × baseline.
   - 0 retransmit regression.
-  - Per-rep CPU saturation check (mpstat) on source: not
-    saturated.
-- `make test-failover`: pass.
-- Codex hostile plan + code review: PLAN-READY YES, MERGE
-  YES.
+- `make test-failover`: pass (defense — touching the
+  CoS dataplane).
+- Codex hostile plan + code review: PLAN-READY YES,
+  MERGE YES.
 - Copilot inline review: addressed.
 
-## 9. Risks (R1 + R2 review-grounded)
+## 9. Risks
 
-- **CAS-loop overhead on hot bucket** (R1 MED #7): the
-  implicit-period scheme uses CAS-loop for accounting where
-  the original plan used fetch_add. Under contention from 6
-  workers on the same hot bucket, expected 2-3 iters per
-  dispatch. Mitigation: `CachePadded` per slot (already in
-  the plan). If empirical perf shows > 3 % CPU regression on
-  the iperf3-128-stream baseline (#900: ~30 % CPU on the
-  affected worker), fall back to per-shard counters
-  (one slice of slots per binding) and sum at read time.
-- **Period-summary cost** (R1 MED #7): `afd_period_summary`
-  does 1024 + 16 = 1040 atomic loads per selection. At
-  ~150 K pps per CoS queue, that's ~150 M loads/sec — well
-  within a single core. Mitigation: cached summary as
-  fallback if a per-rep CPU regression is observed.
-- **Active-bitmap word contention** (R1 HIGH 2 fix
-  side-effect): bitmap word with 64 buckets behind it; if
-  multiple bindings each have a flow in different buckets in
-  the same word, they all CAS-mark on the same word. Most
-  buckets in a word are inactive (sparse), so contention is
-  bounded. CachePad each word.
-- **Bytes-overflow saturation** (R1 MED #7-adjacent): with
-  32-bit byte counter (4 GB max in 2 ms = 16 Tb/s), no real
-  workload saturates this. Saturation is a defensive check,
-  not a real path.
-- **Acceptance bar realism** (R1 MED #11): #840 baseline at
-  16-stream was 18.5 % CoV; the 15 % bar requires a 19 %
-  improvement. AFD-lite's primary mechanism (skip-on-over-
-  share) targets RSS-hash-skew variance, which in our
-  default round-robin RSS at 16 flows / 6 queues gives
-  pigeon-hole 3-3-3-3-2-2 distribution. Skipping over-share
-  redistributes the 3-stream queues' bandwidth to the
-  2-stream queues' streams. Expected magnitude: 3-5 percentage
-  points improvement. So 15 % from 18.5 % is plausible but
-  tight. Document this in the PR result and don't auto-fail
-  if we land at, say, 16 %.
+- **Marginal gain may be smaller than budgeted**: AFD-lite
+  on single-binding queues affects intra-binding flow
+  fairness. RSS hash skew is the dominant CoV contributor
+  at our 16-stream baseline (18.5 %), and it's
+  cross-binding by definition. Single-binding AFD-lite
+  reduces only the intra-binding tail (TCP cwnd variance +
+  bucket-collision unfairness within one queue). Estimated
+  gain: 1-3 percentage points (smaller than v1/v2's 3-5
+  estimate, which assumed cross-binding sharing).
+  - If we land at 16-17 % CoV (still > 15 % bar), the PR
+    documents the result honestly. The acceptance bar is
+    a target, not a gate; merge is justified by code
+    quality + zero-harm even if the empirical bar isn't
+    hit.
+- **Period-rotation cost**: `Box::fill(0)` on 8 KB at 500
+  Hz = ~120 µs/sec/queue. With ~2-4 flow-fair-non-shared
+  queues per worker × 6 workers, total ~1-3 ms/sec of CPU.
+  Bounded.
+- **Selection cost**: 1024-u64 linear scan per `cos_queue_front`
+  + per pop. Profile shows the existing
+  `cos_queue_min_finish_bucket` is a hot site; this adds a
+  similar-magnitude load. Empirically verify with `perf`
+  during the 128-stream test.
+- **Stale-comment fix scope creep**: §6.4 cleans up
+  `types.rs:1037-1040` and `tx.rs:5326-5329`. If touching
+  those comments cascades into other invariant updates,
+  bail and file separately.
 
 ## 10. Out of scope
 
-- Full MQFQ ordering on shared_exact queues (#837).
-- Drop / ECN signalling on AFD over-share (#833 closed).
+- Cross-binding shared_exact AFD (deferred to #837).
+- Drop / ECN signalling.
 - Per-flow rate limiting (#794).
-- Adaptive epsilon shift based on queue depth.
+- Adaptive over-share epsilon based on queue depth.
 - IPv6 echo path coverage (#900 follow-up).
-- Cross-CoS-class fairness (each class has its own lease).
 
-## 11. Test harness for empirical validation
+## 11. R1 + R2 review responses
 
-Operator has enabled echo on `172.16.80.200:7` (TCP) and
-`[2001:559:8585:80::200]:7` (TCP+IPv6). The mouse-side
-harness from `docs/pr/900-100e100m-harness/` can be adapted
-to use Python TCP-connect against the echo server (replacing
-the failed hping3-via-iperf3-target approach), but that work
-is out of scope for #838 itself.
+The cross-binding scope of v1 + v2 was abandoned (see §1).
+Findings that no longer apply at v3 scope are marked
+"OUT-OF-SCOPE-V3"; findings that DO apply at v3 scope are
+addressed below.
 
-For #838 acceptance, only the standard iperf3-stream CoV
-test from §8 is required.
+### Round 1 (8 HIGH + 4 MED)
 
-## 12. Out of scope (cross-issue boundary clarifications)
+| # | Sev | Topic                                | v3 status |
+|---|-----|--------------------------------------|-----------|
+| 1 | HIGH| Period-reset publish ordering        | OUT-OF-SCOPE-V3 — no shared atomic state |
+| 2 | HIGH| active_bucket_count cross-binding    | OUT-OF-SCOPE-V3 — single-threaded count |
+| 3 | HIGH| fetch_sub rollback underflow         | RESOLVED — no rollback path; account-after-TX-insert (§5.2) |
+| 4 | HIGH| Pop commit-point underspecification  | RESOLVED — §6.3 enumerates all 8 sites |
+| 5 | HIGH| Epsilon formula bug                  | RESOLVED — §5.3 `NUM/DEN` fraction; default 0/256 = strict |
+| 6 | HIGH| Wrong gate (lease vs shared_exact)   | RESOLVED — §5.3 gates on `flow_fair && !shared_exact` |
+| 7 | HIGH| Hash seed not wired                  | OUT-OF-SCOPE-V3 — single-binding owns its seed |
+| 8 | HIGH| push_front active-count drift        | OUT-OF-SCOPE-V3 — design doesn't track active-on-enqueue |
+| 9 | MED | Cache-line cost                      | RESOLVED — single-threaded plain u64, no cache-line bouncing |
+| 10| MED | 2 ms period window ungrounded        | §5.1 retains 2 ms; same TCP-burst-coverage rationale |
+| 11| MED | Test gaps                            | §7 covers all relevant scenarios at v3 scope |
+| 12| MED | Acceptance bar uncertainty           | §9 documents the 1-3 pp expected gain (smaller than v2's estimate); doesn't auto-fail |
 
-The R1 review surfaced overlap with several closed/related
-issues; this PR does NOT touch:
+### Round 2 (6 HIGH + 2 MED + 1 LOW)
 
-- HOL-finish-time sharing redesign (#837).
-- ECN-based per-flow signalling (#833 closed; double-signal
-  trap).
-- Per-flow-scaled credit gate (#834 closed; starvation).
-- RSS rebalance (#840 reverted).
-
-## 13. R1 review responses
-
-Round 1: 8 HIGH, 4 MED. PLAN-NEEDS-MAJOR-REWORK.
-
-| # | Sev | Topic                                        | Resolution |
-|---|-----|----------------------------------------------|------------|
-| 1 | HIGH| Period-reset publish ordering broken         | §5.1: implicit period via timestamp eliminates the rotate-CAS + zero-loop entirely. Each slot is period-tagged; staleness is read-time |
-| 2 | HIGH| `active_bucket_count` cross-binding race     | §5.2: replaced with active-flow bitmap also period-tagged. Computed by popcount at read time |
-| 3 | HIGH| `fetch_sub` rollback underflow               | §5.3: skip rollback accounting entirely. Bounded credit (<3.6% per period worst case) — far smaller than the underflow risk |
-| 4 | HIGH| Successful-pop surface underspecified        | §6.3 enumerates all 8 commit points by tx.rs:line. Front/pop selectors share new `cos_queue_select_bucket` helper |
-| 5 | HIGH| Epsilon formula `>>0 = 2x fair_share`        | §5.4 explicit formula; `AFD_OVER_SHARE_EPSILON_SHIFT = u32::MAX` saturates to `>>0=0` so threshold = fair_share + 0 = strict |
-| 6 | HIGH| Wrong gate (lease.is_some vs shared_exact)   | §5.5: gate is `queue.flow_fair && queue.shared_exact && shared_queue_lease.is_some()` |
-| 7 | HIGH| Shared hash seed not wired                   | §5.6: binding promotion (worker.rs:3804/3938) reads lease seed when shared_exact, else random |
-| 8 | HIGH| `push_front` empty-transition active-count   | §6.3: NO active-count tracking on enqueue/dequeue paths. Bitmap is per-period, populated only by dispatch. push_front is invisible to AFD |
-| 9 | MED | Cache-line cost not bounded to shared queues | §9: noted; CachePadded slots; fallback to per-shard if measured >3% CPU |
-| 10| MED | 2 ms period window ungrounded                | §5.1: 2 ms is the burst-coverage scale (10 Gb/s × 2 ms = 2.5 MB; 1 Gb/s × 2 ms = 250 KB — bigger than typical TCP cwnd burst). Empirical tuning open as follow-up |
-| 11| MED | Test gaps                                    | §7 added: rotation-during-dispatch (test 9), cross-binding bitmap drift (test 15), rollback-after-rotation no-underflow (test 16), front/pop selector agreement (test 14) |
-| 12| MED | Acceptance bar uncertain vs prior negatives  | §9 acceptance: documented expected magnitude (3-5pp); merge YES if at 16% with monotone improvement, not auto-fail at exactly 15.5% |
+| # | Sev | Topic                                | v3 status |
+|---|-----|--------------------------------------|-----------|
+| 1 | HIGH| Period CAS regression on retry       | OUT-OF-SCOPE-V3 — no CAS, plain u64 |
+| 2 | HIGH| Period-summary cost not amortized    | RESOLVED — summary is two field reads (`bytes_total`, `active_count`), no iteration |
+| 3 | MED | Seed propagation target wrong        | OUT-OF-SCOPE-V3 — no shared seed |
+| 4 | HIGH| Hot-bucket CAS liveness              | OUT-OF-SCOPE-V3 — no CAS |
+| 5 | HIGH| Bitmap math inconsistent             | OUT-OF-SCOPE-V3 — no bitmap; plain `active_count: u32` field |
+| 6 | HIGH| Rollback overcharge unbounded        | RESOLVED — §5.2 no-rollback design (account-after-TX-insert) |
+| 7 | LOW | Period counter wrap                  | OUT-OF-SCOPE-V3 — period_start_ns is plain u64 ns, no period index |
+| 8 | MED | Stale comments in source             | RESOLVED — §6.4 cleans up `types.rs:1037-1040` + `tx.rs:5326-5329` |
+| 9 | HIGH| Lease plumbing + epsilon shift bug   | RESOLVED — §5.1 `NUM/DEN` fraction (no shift sentinel); §6.3 plumbs `now_ns` from existing call chain (no lease needed) |

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -1,0 +1,340 @@
+# #838 — AFD-lite: per-flow bytes-served counter with periodic reset
+
+## 1. Goal
+
+Improve cross-binding fair queueing on `shared_exact` CoS queues
+without the surface area of full HOL-finish-time sharing
+(#836 → 7 HIGH findings → closed; tracked in #837 as the
+"big-design" alternative).
+
+This implements the **smaller-surface alternative** described in
+#838: track bytes dispatched per flow-bucket per time window,
+shared across all bindings on a `SharedCoSQueueLease`. Bucket
+selection skips flows that are over their fair share for one
+round-robin cycle.
+
+## 2. What this is NOT
+
+- Not a full MQFQ replacement. Single-binding `flow_fair` queues
+  retain their existing `cos_queue_min_finish_bucket()` HOL-
+  finish-time selection (proven correct in #785).
+- Not a drop / ECN path. Skip-on-selection only — no admission
+  changes (avoids the #833 double-signal trap).
+- Not Count-Min sketch. Use a fixed `[AtomicU64; 1024]` array
+  keyed by `flow_bucket_index` — already bounded by
+  `COS_FLOW_FAIR_BUCKETS`.
+- Not RSS rebalance. Orthogonal to #840 (closed); operates inside
+  the dataplane regardless of NIC RSS distribution.
+
+## 3. Test environment
+
+- Cluster: `loss:xpf-userspace-fw0/fw1` (RG0 primary).
+- Source: `loss:cluster-userspace-host`.
+- Targets:
+  - `172.16.80.200` — iperf3 server on port 5201 (existing) +
+    TCP/UDP echo on port 7 (newly enabled by operator,
+    confirmed reachable).
+  - `2001:559:8585:80::200` — same hosts, IPv6.
+- CoS class: **iperf-a** (1 Gb/s shaped) for the tightest
+  acceptance target; **iperf-b** (10 Gb/s) for higher-aggregate
+  characterisation.
+- Workers=6, queue 4 owned by worker 1, queue 5 owned by
+  worker 2 (per live `show class-of-service interface`).
+
+## 4. Workload
+
+Acceptance reproduces the #786 Slice C test:
+
+- **p5201 16 streams 60 s** (CoV ≤ 15 % on ≥ 8 of 10 runs).
+- **p5202 16 streams 60 s** (CoV ≤ 25 % on ≥ 8 of 10 runs).
+- **p5202 128 streams 60 s** (additional characterisation —
+  current baseline 16.6 % CoV, see #900 finding).
+
+## 5. Algorithm specification
+
+### 5.1 Shared state added to `SharedCoSQueueLease`
+
+```rust
+// In userspace-dp/src/afxdp/types.rs, alongside existing
+// SharedCoSLeaseState fields:
+
+struct AFDLiteState {
+    period_start_ns: AtomicU64,
+    period_bytes_total: AtomicU64,
+    period_bytes_per_flow: Box<[CachePadded<AtomicU64>; COS_FLOW_FAIR_BUCKETS]>,
+    /// Cached active-bucket count for fair_share = total / active.
+    /// Updated on bucket 0→N and N→0 transitions; ≤ one window stale.
+    active_bucket_count: AtomicU32,
+    /// Locked at lease construction; bindings on the same lease
+    /// MUST use this seed so flow→bucket maps consistently.
+    flow_hash_seed: u64,
+}
+
+const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;  // 2 ms
+const AFD_OVER_SHARE_EPSILON: u64 = 0;         // skip when bytes > fair_share*1.0; tunable
+```
+
+`COS_FLOW_FAIR_BUCKETS = 1024` × 64 bytes (cache-line padded
+AtomicU64) = **64 KB** per shared lease. Acceptable.
+
+### 5.2 Hot-path operations
+
+**On every successful packet dispatch** (post-write to TX
+ring, per existing `cos_queue_pop_*` paths):
+
+```rust
+// 1. Account bytes
+state.period_bytes_per_flow[bucket].fetch_add(bytes, Relaxed);
+state.period_bytes_total.fetch_add(bytes, Relaxed);
+
+// 2. Maybe rotate window
+let now = monotonic_ns();
+let start = state.period_start_ns.load(Relaxed);
+if now.saturating_sub(start) >= AFD_PERIOD_WINDOW_NS {
+    // CAS-elect a single rotator; losers fall through
+    if state.period_start_ns
+        .compare_exchange(start, now, AcqRel, Relaxed)
+        .is_ok()
+    {
+        // Winner zeros all per-flow counters and total.
+        // Relaxed stores: any racer's adds during this rotation
+        // window land in the new period; transient skew bounded
+        // by 2 ms.
+        state.period_bytes_total.store(0, Relaxed);
+        for slot in state.period_bytes_per_flow.iter() {
+            slot.store(0, Relaxed);
+        }
+    }
+}
+```
+
+**On packet rollback** (`push_front` after a failed write):
+
+```rust
+state.period_bytes_per_flow[bucket].fetch_sub(bytes, Relaxed);
+state.period_bytes_total.fetch_sub(bytes, Relaxed);
+```
+
+`fetch_sub` is the inverse of `fetch_add` and is also
+commutative — unlike HOL-finish-time, byte counts are a
+proper ledger that supports rollback (this is the key safety
+property that makes AFD-lite race-tolerant where the #836
+HOL-finish design wasn't).
+
+### 5.3 Selection gating in `cos_queue_min_finish_bucket`
+
+The existing `cos_queue_min_finish_bucket` iterates
+`flow_rr_buckets` picking the smallest `head_finish_bytes`.
+With AFD-lite, on a `shared_exact` queue **with a shared
+lease**:
+
+```rust
+fn cos_queue_min_finish_bucket_afd(queue: &CoSQueueRuntime, lease: &SharedCoSQueueLease) -> Option<u16> {
+    let total = lease.afd.period_bytes_total.load(Relaxed);
+    let active = lease.afd.active_bucket_count.load(Relaxed) as u64;
+    let fair_share = if active > 0 { total / active } else { u64::MAX };
+    let threshold = fair_share + (fair_share >> AFD_OVER_SHARE_EPSILON);
+    // Threshold = fair_share * 1.0 with epsilon=0 (initial conservative);
+    // becomes fair_share * 1.5 with epsilon=1 if needed.
+
+    let mut best_finish = u64::MAX;
+    let mut best: Option<u16> = None;
+    let mut best_excess = u64::MAX;
+    let mut best_excess_bucket: Option<u16> = None;
+    for bucket in queue.flow_rr_buckets.iter() {
+        let finish = queue.flow_bucket_head_finish_bytes[usize::from(bucket)];
+        let bytes_served = lease.afd.period_bytes_per_flow[usize::from(bucket)].load(Relaxed);
+        if bytes_served <= threshold {
+            // Eligible; pick by HOL-finish (existing MQFQ rule).
+            if finish < best_finish {
+                best_finish = finish;
+                best = Some(bucket);
+            }
+        } else {
+            // Over-share; track smallest excess as fallback.
+            let excess = bytes_served.saturating_sub(threshold);
+            if excess < best_excess {
+                best_excess = excess;
+                best_excess_bucket = Some(bucket);
+            }
+        }
+    }
+    best.or(best_excess_bucket)
+}
+```
+
+If at least one bucket is under-share, pick the eligible
+bucket with smallest HOL-finish-time (preserves MQFQ
+ordering among eligibles). If ALL buckets are over-share
+(e.g. start of window before counters drop), fall back to
+the smallest-excess bucket so we don't go idle.
+
+### 5.4 Active-bucket-count maintenance
+
+`flow_rr_buckets` already tracks the set of non-empty
+buckets — bucket added on first push to empty bucket
+(`was_empty == true`), removed on last pop. Mirror this into
+`active_bucket_count` via `fetch_add`/`fetch_sub` at the same
+sites:
+
+```rust
+// On bucket 0 → 1 transition (push to empty bucket):
+state.active_bucket_count.fetch_add(1, Relaxed);
+
+// On bucket 1 → 0 transition (pop last item from bucket):
+state.active_bucket_count.fetch_sub(1, Relaxed);
+```
+
+Cached count is used only for fair_share computation (an
+approximation); ≤ one window stale is fine.
+
+### 5.5 Single-binding queues unchanged
+
+`!shared_exact` queues (single binding owns the queue) keep
+the existing `cos_queue_min_finish_bucket()` MQFQ ordering
+unchanged. AFD-lite only engages when
+`shared_queue_lease.is_some()`.
+
+## 6. Implementation outline
+
+### 6.1 New file: `userspace-dp/src/afxdp/afd_lite.rs`
+
+- `pub(super) struct AFDLiteState { ... }` (per §5.1).
+- `pub(super) const AFD_PERIOD_WINDOW_NS: u64 = 2_000_000;`
+- `pub(super) const AFD_OVER_SHARE_EPSILON: u32 = 0;`
+- `impl AFDLiteState { fn new(seed: u64) -> Self; }`
+- Free fn `afd_account_dispatch(state, bucket, bytes, now_ns)`.
+- Free fn `afd_account_rollback(state, bucket, bytes)`.
+- Free fn `afd_active_inc(state)` / `afd_active_dec(state)`.
+- Free fn `afd_select_bucket(queue, state) -> Option<u16>`.
+
+### 6.2 Edits to existing files
+
+- `userspace-dp/src/afxdp/types.rs`:
+  - Add `afd: AFDLiteState` to `SharedCoSQueueLease`.
+  - Add `mod afd_lite;` import.
+- `userspace-dp/src/afxdp/tx.rs`:
+  - In `cos_queue_front` (line 4262): when `queue.flow_fair`
+    AND `shared_queue_lease.is_some()`, call
+    `afd_select_bucket(queue, lease)` instead of the existing
+    `cos_queue_min_finish_bucket(queue)`.
+  - In every successful pop path (after the kernel ring write
+    succeeds): call `afd_account_dispatch`.
+  - In every `push_front` rollback path: call
+    `afd_account_rollback`.
+  - In `cos_queue_push_back` at the `was_empty` transition
+    (line ~4302): call `afd_active_inc` if shared lease.
+  - In the bucket-empty transition on pop: call
+    `afd_active_dec` if shared lease.
+
+### 6.3 Coordinator
+
+`SharedCoSQueueLease::new()` (currently constructs only
+`SharedCoSLeaseConfig`/`State`) extends to also build the
+AFD-lite state with `flow_hash_seed` drawn from
+`getrandom(2)` — same seed all bindings on the lease use.
+
+## 7. Tests
+
+In `userspace-dp/src/afxdp/afd_lite.rs` (new module tests):
+
+1. `account_dispatch_increments_total_and_bucket`.
+2. `account_rollback_inverts_dispatch`.
+3. `period_rotation_zeros_counters`.
+4. `concurrent_rotators_only_one_wins` (CAS race test with
+   spawned threads).
+5. `active_inc_dec_round_trip` (idempotent under matched
+   inc/dec).
+6. `select_picks_under_share_first` — synthetic state where
+   bucket A is over-share and bucket B is under-share; assert
+   B is picked.
+7. `select_falls_back_to_smallest_excess_when_all_over_share`.
+8. `select_preserves_mqfq_among_eligibles` — multiple under-
+   share buckets, smallest HOL-finish wins.
+9. `select_at_period_boundary_no_panic` — stress test where
+   the period rotates during a select call.
+
+In `userspace-dp/src/afxdp/tx.rs` (integration):
+
+10. `cos_queue_front_uses_afd_when_shared_lease`: build a
+    queue with `shared_queue_lease.is_some()`, fill two
+    buckets with different head-finish times, mark one as
+    over-share via direct `afd.period_bytes_per_flow` write,
+    assert `cos_queue_front` returns the under-share one.
+11. `cos_queue_front_uses_mqfq_when_no_shared_lease`:
+    regression — `shared_queue_lease.is_none()`, the existing
+    behaviour is preserved exactly.
+
+## 8. Acceptance
+
+- All Rust unit tests pass (`cargo test -p xpf-userspace-dp`).
+- All Go tests pass.
+- Live deploy on `loss:xpf-userspace-fw0/fw1`:
+  - **p5201 16 streams 60 s × 10**: CoV ≤ 15 % on ≥ 8 of 10
+    runs.
+  - **p5202 16 streams 60 s × 10**: CoV ≤ 25 % on ≥ 8 of 10
+    runs.
+  - **p5202 128 streams 60 s × 1**: CoV ≤ baseline (16.6 %
+    from #900 finding).
+  - 0 collapses (every stream ≥ 1 Mbps).
+  - Aggregate throughput ≥ 0.95× baseline (no regression).
+  - 0 retransmit regression vs baseline median.
+- `make test-failover`: pass (defense — touching dataplane
+  cross-binding state).
+- Codex hostile plan + code review rounds: PLAN-READY YES,
+  MERGE YES.
+- Copilot inline review: addressed.
+
+## 9. Risks
+
+- **Active-bucket-count drift**: cached count can fall out of
+  sync with reality if a `fetch_add`/`fetch_sub` is missed.
+  Mitigation: place the inc/dec at the SAME control-flow site
+  as `flow_rr_buckets.push_back` / pop (which is the
+  authoritative source). Pin via test #5.
+- **Period-boundary thrash**: at the exact rotation moment,
+  one thread observes pre-rotation counters while another
+  observes post-rotation. Bounded by 2 ms; no correctness
+  consequence (counters are commutative). Pin via test #9.
+- **Over-share threshold sensitivity**: epsilon=0 with strict
+  fair_share may oscillate under high contention. Start with
+  epsilon=0, tune up to 1 (fair_share × 1.5) only if
+  empirical data shows oscillation.
+- **MQFQ ordering loss on shared queues**: AFD-lite decouples
+  the long-run byte-share from per-packet HOL-finish-time on
+  shared queues. Slight unfairness vs pure MQFQ for bursty
+  mixed-size workloads. Quantify in §8 with the standard
+  acceptance suite.
+- **Cache-line contention**: 1024 atomics × per-dispatch
+  fetch_add. With 6 workers all dispatching on the same lease
+  simultaneously, hot buckets (1-2 elephants) will see
+  cross-CPU cacheline bouncing. Bound by `CachePadded` and by
+  the fact that elephants are bursty (not lockstep on a
+  single bucket). If empirical perf shows >3% CPU regression,
+  fall back to per-shard counters (one slice per binding) and
+  sum at read time.
+
+## 10. Out of scope
+
+- Full MQFQ ordering preservation on shared queues (#837).
+- Drop / ECN signalling on AFD over-share (#833 closed; double-
+  signal trap).
+- Per-flow rate limiting (#794 covers AFD policer; this issue
+  is selection-time skip only).
+- Adaptive epsilon based on queue depth.
+- IPv6 echo path coverage (the harness uses TCP-connect to
+  `172.16.80.200:7`; IPv6 to `[2001:559:8585:80::200]:7` is a
+  follow-up if needed).
+
+## 11. Test harness for empirical validation
+
+Now that the operator has enabled echo on `172.16.80.200:7`
+(TCP) and `[2001:559:8585:80::200]:7` (IPv6+TCP), the
+mouse-side harness from `docs/pr/900-100e100m-harness/` can
+be adapted to use Python TCP-connect against the echo server
+(replacing the failed hping3-and-iperf3-target approach). Out
+of scope for #838 itself but unblocks the empirical mouse-
+latency-tail measurement once #838 lands.
+
+For #838 acceptance, only the standard iperf3-stream CoV
+test from §8 is required.

--- a/docs/pr/838-afd-lite/plan.md
+++ b/docs/pr/838-afd-lite/plan.md
@@ -688,3 +688,64 @@ addressed below.
 | 11| MED | now_ns plumbing surface incomplete  | RESOLVED — §6.3.3 enumerates the full caller surface including `select_cos_guarantee_batch`, `select_cos_surplus_batch`, `build_cos_batch_from_queue` |
 | 4 | LOW | FIFO path irrelevance                | RESOLVED — §6.3.4 explicit |
 | 6 | LOW | No FIFO ring revert                  | RESOLVED — §6.3.4 + §6.3.5 explicit |
+
+### Round 5 (5 HIGH + 2 MED + 1 LOW; conducted on plan commit `1bbd61c1`)
+
+R5 hostile review of the v3 plan after R4 fixes uncovered a
+**structural blocker** that prior rounds did not surface, plus four
+additional HIGH findings.
+
+| #  | Sev | Topic                                  | Status |
+|----|-----|----------------------------------------|--------|
+| Q9 | HIGH| **Selector blind during scratch-build** | NOT RESOLVED — see narrative below |
+| Q10| HIGH| Period-window staleness on settle      | open   |
+| Q11| HIGH| `active_count` race vs reset           | open   |
+| Q12| HIGH| Settle-site count assumes full submit  | open   |
+| Q13| HIGH| now_ns plumbing depth still incomplete | open   |
+| Q14| MED | Acceptance-bar still ungrounded vs noise floor | open |
+| Q15| MED | Test #15-#17 do not exercise Q9 path   | open   |
+| Q16| LOW | Stale comment in tx.rs:5326-5329       | trivial |
+
+**Q9 (the structural blocker, in the reviewer's wording):**
+> The selector runs during scratch-build (one decision per packet at
+> `service_exact_local_queue_direct_flow_fair` and the prepared
+> equivalent), but accounting happens at *settle* (one
+> `account_per_flow` per *batch* in `settle_*_flow_fair`). The
+> selector is therefore BLIND to packets it has already selected
+> earlier in the current batch — they are still sitting in
+> `scratch_local_tx`, the per-flow counter has not been bumped, and
+> the period-bytes-total has not advanced.
+>
+> With `TX_BATCH_SIZE: usize = 256` (`userspace-dp/src/afxdp.rs:159`)
+> and best-effort fair share at ~16 packets per 2 ms period, the
+> selector can ship multiple periods' worth of packets within one
+> scratch build. AFD never engages on the batch path — exactly the
+> path the v3 plan calls "the PRIMARY workload path" in §6.3.2.
+
+**Why this is structural, not a fix-in-place:** the v3 design's
+*premise* is that account-after-TX-insert (no rollback) is safe
+because the insert-and-account window is short. R5 shows the window
+is one entire batch — 256 × insert decisions before one accounting
+update. The fix would require either:
+
+(a) **provisional per-batch accounting at selection time** (commit
+    bytes to a thread-local shadow of `period_bytes_per_flow`,
+    then reconcile with the shared atomic at settle, with rollback
+    on the rejected-tail). This re-introduces the rollback path
+    that R3-R4 were specifically structured to avoid; the contract
+    of the no-rollback design no longer holds.
+
+(b) **shrink TX_BATCH_SIZE during AFD-active periods**, which has
+    its own throughput cost and breaks the existing batching
+    invariants relied on by the kick-latency path.
+
+Either fix is a structural redesign at v4 scope. The R5 reviewer
+did not propose one; the cost-vs-expected-gain (1-3 pp CoV at most)
+does not justify another round of plan-design effort.
+
+### R5 disposition
+
+The plan does not advance to a v4. See
+`docs/pr/838-afd-lite/findings.md` for the broader negative-finding
+writeup and the recommended path forward (defer algorithm work,
+characterize mouse-latency tail empirically first via #905).


### PR DESCRIPTION
## Summary

- Closes the #838 attempt at plan stage. Five Codex review rounds; R5 found a structural blocker (selector blind during scratch-build vs batch-shaped settle accounting) with no R6 convergence path.
- Adds `docs/pr/838-afd-lite/findings.md` summarizing the cumulative pattern across the three cross-binding fairness attempts (#836 closed at plan, #840 reverted with empirical CoV regression, #838 stuck) and the #900 baseline (16.6% CoV at 128 streams, 0 collapses).
- Recommends: close #838, file a measurement issue using the operator echo server on 172.16.80.200:7 to characterize the unmeasured half of 100E100M (mouse-latency tail under elephant load), defer further algorithm work until that data motivates it.

This is docs-only — preserves the five-round plan archive and the negative finding alongside the existing #835 / #840 / #900 findings.

## Test plan

- [ ] Confirm `docs/pr/838-afd-lite/findings.md` cross-references resolve to existing files (`docs/pr/835-slice-d-rss/findings.md`, `docs/pr/840-slice-d-v2/findings.md`, `docs/pr/900-100e100m-harness/findings.md`).
- [ ] No code changes; CI should be no-op for build/test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)