### PR TITLE
#905 mouse-latency tail: harness for measurement-first 100E100M follow-up

### DIFF
--- a/docs/pr/905-mouse-latency/plan.md
+++ b/docs/pr/905-mouse-latency/plan.md
@@ -207,14 +207,14 @@ invalidate.
 
 ## 4. Harness design
 
-### 4.1 Probe driver — `test/incus/mouse-latency-probe.py`
+### 4.1 Probe driver — `test/incus/mouse_latency_probe.py`
 
 Python 3 script (no third-party deps; aggregator in §4.5 uses
 the stdlib `statistics` module — no `numpy`, R1 #13).
 
 Per-cell invocation contract:
 ```
-python3 test/incus/mouse-latency-probe.py \
+python3 test/incus/mouse_latency_probe.py \
     --target 172.16.80.200 --port 7 \
     --concurrency 10 \
     --duration 60 --payload-bytes 64 \
@@ -376,13 +376,20 @@ Steps per rep:
    re-attempt a port-7→best-effort dynamic assertion here —
    §3.3 v3 explicitly removed that check; the static config
    carries the assertion. Step 1 is fixture-apply only.)
-2. **Source-CPU sampling** (R1 #11): `mpstat 1 <duration+30>`
-   in background on `cluster-userspace-host`, output to
-   `<out_dir>/mpstat.txt`. If average user+sys > 80 % during
-   the probe window, mark rep as INVALID-client-saturated.
-3. **RG state polling** on both nodes — initial sample at
-   t=0, plus a background poll every 1 s for the duration of
-   the rep (R3 fresh #2 + R4 HIGH 1).
+2. **Source-CPU sampling** (R1 #11, Copilot R1 #3): launch
+   `mpstat 1 <duration>` on `cluster-userspace-host` JUST BEFORE
+   the probe (not at top-of-rep), so its count completes naturally
+   when the probe ends and the `Average:` summary row is emitted.
+   If `Average:` busy > 80 %, mark rep as INVALID-client-saturated;
+   if mpstat output is missing or unparseable, INVALIDATE rather
+   than silently passing.
+3. **RG state polling** — query the primary at 1 Hz (Copilot R1
+   #7: a single `cli -c "show chassis cluster status"` query
+   from the local node returns BOTH nodes' RG-state rows because
+   `Manager.FormatStatus` includes peer state in the same
+   output, so polling one node is sufficient to detect any
+   transition). Initial sample at t=0, plus continuous poll
+   throughout the rep (R3 fresh #2 + R4 HIGH 1).
 
    **CLI command pinned (R4 HIGH 1):**
    ```
@@ -525,7 +532,7 @@ reps are INSUFFICIENT-DATA.
 Before the matrix starts, a one-shot preflight:
 
 ```
-python3 test/incus/mouse-latency-probe.py \
+python3 test/incus/mouse_latency_probe.py \
     --target 172.16.80.200 --port 7 \
     --concurrency 1 --duration 5 \
     --out /tmp/preflight.json
@@ -579,7 +586,7 @@ M=10 cells (the gate's measurement cells), then the rest —
 so the gate-relevant data lands first and a wall-budget
 truncation degrades gracefully.
 
-## 5. Aggregator — `test/incus/mouse-latency-aggregate.py`
+## 5. Aggregator — `test/incus/mouse_latency_aggregate.py`
 
 Reads `<out_dir>/cell_N{n}_M{m}/`, picks median rep per cell
 (by p99), produces:
@@ -641,11 +648,16 @@ The 2× threshold is from the #905 issue body. It is a
   discovery to find anything).
 - Echo-server preflight succeeds (§4.6).
 - Smoke cell `N=0 M=1` runs end-to-end with valid output.
-- `findings.md` exists with the 12-cell table + decision verdict
-  (PASS / FAIL / INSUFFICIENT-DATA).
 - Codex hostile plan + code review: PLAN-READY YES + MERGE YES,
   every finding disposed.
 - Copilot inline review: addressed.
+
+The harness PR ships first; the matrix is run separately on the
+loss cluster and `findings.md` lands in a follow-up commit (or a
+follow-up PR) once the data is collected. Copilot R1 #2 correctly
+flagged that v4 had `findings.md exists` as a merge gate while
+the PR contained no findings file — the gate is dropped here in
+favor of "harness PR merges; findings PR adds the data".
 
 ### 7.2 Decision threshold (per #905; reported, not gating)
 
@@ -666,12 +678,12 @@ New files (planned deliverables):
 - `docs/pr/905-mouse-latency/plan.md` (this file)
 - `docs/pr/905-mouse-latency/findings.md` (post-data)
 - `docs/pr/905-mouse-latency/results/cell_N{n}_M{m}/...` (raw)
-- `test/incus/mouse-latency-probe.py`
-- `test/incus/mouse-latency-aggregate.py`
+- `test/incus/mouse_latency_probe.py`
+- `test/incus/mouse_latency_aggregate.py`
 - `test/incus/test-mouse-latency.sh`
 - `test/incus/test-mouse-latency-matrix.sh`
-- `test/incus/mouse-latency-probe_test.py`
-- `test/incus/mouse-latency-aggregate_test.py`
+- `test/incus/mouse_latency_probe_test.py`
+- `test/incus/mouse_latency_aggregate_test.py`
 - `test/incus/iperf3_sum_parse.py`
 - `test/incus/iperf3_sum_parse_test.py`
 - `test/incus/cluster_status_parse.py`
@@ -683,7 +695,7 @@ Modified files: none.
 
 ### 9.1 Unit tests (R1 #13)
 
-`mouse-latency-probe_test.py`:
+`mouse_latency_probe_test.py`:
 - Histogram bucket assignment correct at boundaries.
 - p99/p95/p50 from synthetic input matches `statistics.quantiles`
   output (no `numpy` dependency).
@@ -697,7 +709,7 @@ Modified files: none.
 - Achieved-RPS computation correct for synthetic input.
 - Duration-elapsed loop exit — no off-by-one.
 
-`mouse-latency-aggregate_test.py`:
+`mouse_latency_aggregate_test.py`:
 - Median-of-10 by p99 picks the 5th-or-6th rep, not the mean.
 - Decision-threshold computes correctly for synthetic inputs at
   PASS, FAIL, exactly-2.0× boundary.

--- a/docs/pr/905-mouse-latency/plan.md
+++ b/docs/pr/905-mouse-latency/plan.md
@@ -1,0 +1,893 @@
+# Plan: #905 — mouse-latency tail measurement (v4)
+
+Issue: #905
+Predecessor: #900 (`docs/pr/900-100e100m-harness/findings.md` —
+elephant-side answered; mouse-side not measured).
+Source of recommendation: `docs/pr/838-afd-lite/findings.md`.
+
+Plan revisions:
+- v1 → v2: incorporated Codex R1 (17 findings; PLAN-NEEDS-MAJOR).
+- v2 → v3: incorporated Codex R2 (3 HIGH + 2 MED + 2 LOW;
+  PLAN-NEEDS-MAJOR).
+- v3 → v3 (mid-rev): incorporated Codex R3 (2 HIGH-partial +
+  3 MED + 1 LOW; PLAN-NEEDS-MAJOR).
+- v3 → v4: incorporated Codex R4 (3 HIGH + 3 MED + 2 LOW;
+  PLAN-NEEDS-MAJOR).
+- v4 (revision): incorporated Codex R5 (4 MED + 1 LOW;
+  PLAN-NEEDS-MINOR).
+- v4 (revision): incorporated Codex R6 (2 MED + 1 LOW;
+  PLAN-NEEDS-MINOR).
+- v4 (revision): incorporated Codex R7 (2 MED;
+  PLAN-NEEDS-MINOR).
+
+Disposition tables at §11. Each round produced concrete
+file/line-grounded findings; each fix is anchored in §11.
+
+## 1. Goal
+
+Produce per-cell JSON RTT data for short TCP request/response
+"mice" running concurrently with a varying number of long-lived
+"elephant" iperf3 streams across the xpf-userspace HA cluster.
+Report:
+
+- p50, p95, p99 RTT per cell (p999 omitted: too few tail samples
+  even at the matrix-scaled run length to be robust — see §6.1).
+- Achieved per-coroutine RPS distribution (closed-loop semantics
+  hides degradation in absolute counts; achieved-RPS is the
+  co-metric — see §4.4).
+- IQR of p99 across reps as a noise-floor proxy.
+
+Concrete deliverable: a verdict against the **decision threshold**
+from #905:
+
+> Mouse p99 RTT at (N=128 elephants, M=10 mice, mouse_class =
+> best-effort) is ≤ 2 × the idle baseline (N=0, M=10, same class).
+
+This threshold is a **decision aid for whether to pursue further
+algorithm work**, not a product SLO. Product mouse-latency
+tolerance is a separate decision; #900 explicitly rejected uncited
+SLO numbers in its plan and this PR follows the same discipline
+(see §7.2).
+
+## 2. What this is NOT
+
+- Not an algorithm change. The deliverable is data + a verdict.
+- Not the 100E100M harness from #900 (which hit raw-socket and
+  iperf3-single-tenant walls). Smaller, scoped harness.
+- Not a HA failover test. RG state and journalctl VRRP events
+  are sampled across each rep; any rep with an in-window
+  state change is invalidated.
+- Not multi-mouse-class. Best-effort only; `iperf-a-shared`
+  dropped with the explicit caveat that this PR's verdict
+  cannot distinguish "cross-class isolation works" from "same
+  class doesn't HOL" — see §3.4.
+- Not v6. v4-only with the explicit caveat that the verdict
+  does not generalize to dual-stack — see §3.5.
+- Not a mechanism-attribution study. The plan's v1 claimed the
+  histogram could identify HOL/cross-class/SFQ as the failure
+  mechanism on FAIL; that requires daemon counters and CoS
+  deltas which this harness does not capture (R1 #12). On FAIL,
+  the deliverable is the latency tail + the follow-up file
+  `docs/pr/905-mouse-latency/findings.md` proposing a separate
+  mechanism issue.
+
+## 3. Test environment
+
+### 3.1 Cluster
+
+- `loss:xpf-userspace-fw0` (primary, weight 200) +
+  `loss:xpf-userspace-fw1` (secondary, weight 100).
+- **Source container** for mice + elephants:
+  `loss:cluster-userspace-host`. (R1 #8: this is the LAN-side
+  client container, not the firewall — `apply-cos-config.sh`
+  targets the firewall VM, not this host.)
+- Target: `172.16.80.200` (operator-managed):
+  - port 5201 → iperf3 server; CoS class `iperf-a`, 1 Gb/s
+    shaped (matches existing classifier term 0).
+  - port 7 (TCP) → echo; CoS class `best-effort` (no classifier
+    term matches, falls through to default queue, 100 Mb/s
+    shaped).
+
+### 3.2 CoS preconditions
+
+Before any run, apply the standard fixture on the primary using
+the qualified incus name (R1 #7):
+
+```
+./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+```
+
+(The script's default and usage line both use the `loss:` prefix;
+v1 dropped it and would have applied to a local instance.)
+
+### 3.3 Port-7 best-effort path verification (R1 #9, R2 F2)
+
+R1 asked for an active counter-delta assertion that port-7 traffic
+hits the best-effort queue. R2 (F2) correctly noted the daemon
+command shape this plan invented (`xpf-ctl status --json`) does
+not exist — the operational CLI is `cli`, the JSON status path
+doesn't expose per-queue tx counters keyed by class name, and the
+filter-term counters only fire when a classifier term matches
+(port 7 has no matching term, so it's an explicit fallthrough).
+
+v3 drops the daemon-counter-delta preflight. Two static facts and
+one dynamic check carry the assertion instead:
+
+1. **Static**: port 7 has no term in
+   `test/incus/cos-iperf-config.set` (terms 0-3 cover 5201-5204
+   only; verified by Codex R1 #9). Userspace dataplane default
+   queue selection for unmatched filter is the best-effort
+   queue per `userspace-dp/src/afxdp/forwarding_build.rs:653`
+   and `userspace-dp/src/afxdp/tx.rs:4937` (R4 LOW 7: v2 cited
+   `filter.rs:342-344` which is unmatched-filter accept
+   semantics, not queue selection).
+2. **Static**: best-effort scheduler is shaped at 100 Mb/s
+   (`cos-iperf-config.set:13-14`).
+3. **Dynamic preflight (§4.6)**: the echo-server preflight
+   issues real port-7 probes from the source through the
+   firewall. Reachability + echo-correctness is asserted
+   end-to-end.
+
+(R3 F2 corrected: v3's prior wording suggested the >100 Mb/s
+shaper would visibly engage and act as a sanity. That is
+wrong. Closed-loop probe traffic at M=50 is in the
+order-of-magnitude single-digit-megabit-per-second range —
+well below the 100 Mb/s shaper. (R4 L8 + R5 L8 residual: prior
+attempts at a precise byte-count derivation contradicted
+themselves; we drop the precise math and stick to the
+order-of-magnitude argument, which is what the conclusion
+actually requires.) The shaper-engages sanity is dead code;
+v3 drops it.)
+
+We do **not** dynamically assert "port-7 traffic landed in the
+best-effort queue" from outside the daemon. The static
+configuration above carries the assertion. If a future analysis
+finds port-7 traffic is NOT taking the best-effort path, that
+itself becomes a finding worth filing as a separate bug — but
+we don't synthesize a CLI command that doesn't exist to gate
+this PR's matrix on it.
+
+This is a real measurement-gap acknowledgement: we are
+assuming the dataplane behaves as the config implies. Adding
+a real per-queue tx-counter CLI is out of scope; tracked as
+follow-up if needed.
+
+### 3.4 Why best-effort only (rationale, R1 #15)
+
+#905 lists `mouse_class ∈ {best-effort, iperf-a-shared}`.
+`iperf-a-shared` requires reclassifying port 7 into iperf-a, which
+needs per-cell CoS-config edits.
+
+Best-effort is the **PASS gate cell**, so a best-effort verdict is
+sufficient to pursue the recommendation in `docs/pr/838-afd-lite/findings.md`
+(stop algorithm work if PASS).
+
+**Caveat (must appear in findings.md):** A best-effort PASS does
+NOT imply the dataplane has cross-class isolation; it only implies
+mice-on-best-effort survive elephant-on-iperf-a. The
+`iperf-a-shared` cell would be required to distinguish "cross-
+class isolation works" from "same-class HOL/SFQ doesn't degrade".
+A FAIL on best-effort already motivates further work without
+needing the shared cell.
+
+### 3.5 Why v4-only (rationale, R1 #14)
+
+#905 text says "v4 + v6"; #838 findings cites both echo addresses.
+The dataplane has separate v4/v6 TX selection paths
+(`userspace-dp/src/afxdp/tx.rs:4793-4797`), so a v4 PASS does
+not generalize.
+
+This PR is v4-only because:
+- The PASS-gate decision (stop further algorithm work?) is the
+  same on either family if v4 PASSes — v6 unfairness is its own
+  follow-up at most.
+- Doubling the matrix doubles wall time + harness surface.
+- A v6-only follow-up issue is small if v4 produces actionable
+  data.
+
+**Caveat (must appear in findings.md):** A v4 PASS does NOT
+generalize to v6.
+
+### 3.6 SYN-cookie state recorded, not assumed (R1 #10)
+
+The `screen syn-cookie` engagement threshold is referenced in
+`CLAUDE.md` and `docs/syn-cookie-flood-protection.md`, but the
+test cluster's HA config (`docs/ha-cluster-userspace.conf`) does
+not assign any screen profile to a security zone. Plan does not
+assume screen-cookie is active.
+
+Preflight step in §4.5: before each matrix, capture
+`show security screen statistics zone wan` (R4 MED 6:
+`docs/ha-cluster-userspace.conf:154` places the WAN-side
+zone as `wan`, not `untrust`; the v2 plan had the wrong
+zone name). Record the syn-flood counters at start + end.
+If they advance during the matrix, flag the cell as
+"screen-engaged" in manifest.json — analyst decides whether to
+invalidate.
+
+## 4. Harness design
+
+### 4.1 Probe driver — `test/incus/mouse-latency-probe.py`
+
+Python 3 script (no third-party deps; aggregator in §4.5 uses
+the stdlib `statistics` module — no `numpy`, R1 #13).
+
+Per-cell invocation contract:
+```
+python3 test/incus/mouse-latency-probe.py \
+    --target 172.16.80.200 --port 7 \
+    --concurrency 10 \
+    --duration 60 --payload-bytes 64 \
+    --out /tmp/probe.json
+```
+
+**Closed-loop semantics, no per-iteration sleep** (R1 #1, #2):
+
+The v1 plan tried to mix closed-loop coroutines with a
+`pace-ms / concurrency` inter-iteration sleep. That was wrong:
+M coroutines burst at startup and the sleep formula doesn't
+produce a bounded global rate. v2 drops the sleep entirely:
+
+1. Spawn `--concurrency` (= M) asyncio coroutines.
+2. Each coroutine, in a loop until `--duration` seconds elapse:
+   a. `t0 = time.monotonic_ns()`.
+   b. Open TCP socket to `(target, port)` with a 5 s connect
+      timeout.
+   c. Send `--payload-bytes` random bytes; flush.
+   d. Read back exactly `--payload-bytes`; on short-read or
+      timeout, count as error.
+   e. Close socket.
+   f. `t1 = time.monotonic_ns()`.
+   g. Append `t1 - t0` to its own RTT list. Increment its own
+      attempt counter.
+3. Each coroutine immediately starts its next probe — no sleep.
+
+This is canonical closed-loop "M concurrent mice". Achieved RPS
+falls if RTT rises; that drop IS data, not a bug.
+
+### 4.2 Achieved-RPS as co-metric (R1 #2, #3)
+
+Closed-loop semantics implies achieved RPS is workload-dependent.
+The harness reports it explicitly:
+
+- Per-coroutine: `attempts_per_coroutine[i]`.
+- Aggregate: `sum / duration`.
+- Median + IQR of `attempts_per_coroutine`.
+
+**Degenerate-coroutine guard (R1 #3):** if
+`min(attempts_per_coroutine) < 0.5 × median(attempts_per_coroutine)`,
+the cell is INVALIDATED — a coroutine has stalled (e.g. socket
+hang, server-side per-IP cap), so the histogram excludes its
+slow region and `error_rate` alone would not catch it.
+
+**Per-rep validity:** in addition to the existing
+`error_rate < 0.01`:
+- `min(attempts_per_coroutine) >= 0.5 × median(attempts)`.
+- Total `attempts` minimum (R5 fresh #4: v3's
+  `100 × concurrency` floor was too loose for p99 robustness):
+  - **For M ≥ 10**: `attempts >= 5000` per rep
+    (yields ≥ 50 tail samples for p99 within the rep, the
+    minimum for the §6.1 robustness argument to hold).
+  - **For M = 1**: `attempts >= 500` per rep (single coroutine
+    can't reach 5000 in 60 s under typical RTT; the M=1 cells
+    tolerate looser p99 — which is also why M=1 cells are
+    excluded from the PASS-gate ratio in §7.2).
+
+### 4.3 JSON output schema
+
+```json
+{
+  "config": {
+    "target": "172.16.80.200", "port": 7,
+    "concurrency": 10,
+    "duration_s": 60, "payload_bytes": 64
+  },
+  "totals": {
+    "attempted": 12000, "completed": 11982, "errors": 18,
+    "error_rate": 0.0015,
+    "attempts_per_coroutine": [1198, 1199, 1201, 1198, 1200, 1199, 1202, 1198, 1203, 1184],
+    "achieved_rps_total": 199.7
+  },
+  "rtt_us": {
+    "p50": 250, "p95": 800, "p99": 1500,
+    "min": 80, "max": 18000, "mean": 320, "iqr": 92
+  },
+  "histogram_us": {
+    "buckets": [10, 20, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 100000],
+    "counts": [0, 12, 480, 8011, 2102, 587, 187, 14, 1, 0, 0, 0]
+  },
+  "validity": {
+    "ok": true, "reasons": []
+  }
+}
+```
+
+`p999` deliberately omitted (R1 #4).
+
+### 4.4 Elephant driver with cwnd-settle gate (R1 #5)
+
+v1 used `iperf3 -J` + a 2 s sleep. R1 #5 correctly flagged that
+this doesn't prove steady-state. v2 mirrors #900's approach:
+
+```
+iperf3 -c 172.16.80.200 -p 5201 -P <N> -t <iperf3_duration> -i 1 --forceflush
+```
+
+(R4 HIGH 3: `--forceflush` is required when stdout is
+redirected/tailed, otherwise iperf3 buffers and the live
+`[SUM]` parser sees nothing until the run ends, falsely
+tripping `INVALID-cwnd-not-settled`. Existing harnesses use
+the same flag, e.g. `test/incus/test-stress-failover.sh:159`.)
+
+`iperf3_duration` is computed by the orchestrator (R2 F3):
+`SETTLE_BUDGET (20s) + probe_duration (60s) + SLACK (10s) = 90s`
+for the 60s probe window. If `probe_duration` changes via flag,
+the orchestrator recomputes. The original v2 expression
+`duration+10` was structurally too short (60s + 10s = 70s
+versus 80s required) — iperf3 would exit during the probe
+window.
+
+Text mode (no `-J`), with `-i 1` for live per-second aggregate.
+The orchestrator (§4.5):
+
+1. Launches iperf3, redirects stdout to `<out_dir>/iperf3.txt`.
+2. Tails the output, parses each `[SUM]` row's Gbps.
+3. Waits for a "settled" condition: 3 consecutive `[SUM]` rows
+   each within ±15 % of each other AND ≥ 0.7 × class-shaper
+   (0.7 Gb/s for iperf-a). Timeout: `SETTLE_BUDGET = 20 s`. On
+   timeout, abort the rep as INVALID-cwnd-not-settled.
+4. Once settled, launches the probe driver with
+   `--duration 60`.
+5. Continues monitoring `[SUM]` during probe window. If any
+   `[SUM]` row drops below 0.5 × shaper for ≥ 3 consecutive
+   seconds, mark rep as INVALID-elephant-collapsed.
+6. After probe driver exits, waits for iperf3 to exit (or
+   kills with the remaining `SLACK = 10 s` timeout).
+7. Parses the final `[SUM]` totals into iperf3.json (a derived
+   file; the raw text is also kept).
+
+**`[SUM]` line format pin (R2 F5):** iperf3 in text mode emits
+per-interval lines of the shape
+`[SUM]   3.00-4.00   sec  118 MBytes  990 Mbits/sec  ...`. The
+parser (in the orchestrator + a small Python helper) anchors
+on `^\[SUM\]\s+\d+\.\d+-\d+\.\d+\s+sec\s+\S+\s+\S+\s+(\S+)\s+(\S+)/sec`
+and extracts (rate, unit). Unit is normalized to bits/sec via a
+unit table (Kbits, Mbits, Gbits). The same parser is used for
+the per-second monitoring in step 5 and the final-summary
+aggregation in step 7.
+
+The parser ships as `test/incus/iperf3_sum_parse.py` with unit
+tests in `iperf3_sum_parse_test.py` covering: per-second rows
+across all unit prefixes, the final summary line shape, and
+malformed input (empty, non-SUM, partial). Listed in §9.1.
+
+For N=0 (idle baseline), no iperf3 is launched.
+
+### 4.5 Run orchestrator — `test/incus/test-mouse-latency.sh`
+
+```
+./test/incus/test-mouse-latency.sh <N> <M> <duration> <out_dir>
+```
+
+Steps per rep:
+
+1. **CoS preflight** (§3.2): apply
+   `cos-iperf-config.set` to the primary. (R4 MED 4: do NOT
+   re-attempt a port-7→best-effort dynamic assertion here —
+   §3.3 v3 explicitly removed that check; the static config
+   carries the assertion. Step 1 is fixture-apply only.)
+2. **Source-CPU sampling** (R1 #11): `mpstat 1 <duration+30>`
+   in background on `cluster-userspace-host`, output to
+   `<out_dir>/mpstat.txt`. If average user+sys > 80 % during
+   the probe window, mark rep as INVALID-client-saturated.
+3. **RG state polling** on both nodes — initial sample at
+   t=0, plus a background poll every 1 s for the duration of
+   the rep (R3 fresh #2 + R4 HIGH 1).
+
+   **CLI command pinned (R4 HIGH 1):**
+   ```
+   incus exec loss:xpf-userspace-fw0 -- cli -c "show chassis cluster status"
+   ```
+   The output is text from
+   `pkg/cluster/cluster.go:1767-1830` (`Manager.FormatStatus`).
+   Relevant identity for "did the RG state change?" is the
+   FULL set of `(rg_id, node_id, state)` triples (R5 fresh
+   #3: capturing only `(rg_id, primary_node_id)` would miss a
+   secondary's drift through `hold`/`disabled`/`lost` states
+   that can also indicate cluster instability without a
+   primary change). Parser anchors:
+   - `^Redundancy group: (\d+)` introduces an RG block.
+   - `^node[01]\s+\d+\s+(primary|secondary|hold|disabled|lost)`
+     gives the per-node state row inside the block.
+   The orchestrator extracts, per sample, a sorted list of
+   `(rg_id, node_id, state)` triples and writes them to
+   `<out_dir>/rg-state-poll.txt` as
+   `<unix_ms>\trg=<id>\tnode=<id>\tstate=<state>` lines (one
+   line per (rg, node) tuple per sample).
+
+   Parser ships as `test/incus/cluster_status_parse.py` with
+   unit tests in `cluster_status_parse_test.py` (added to §8
+   and §9.1).
+
+   Continuous polling catches a complete failover+failback
+   cycle (same start and end state, but transient master
+   change in between) that start/end-only sampling would miss.
+4. **journalctl cursor capture on BOTH nodes** (R7 MED 2):
+   ```
+   for FW in xpf-userspace-fw0 xpf-userspace-fw1; do
+       incus exec loss:$FW -- journalctl --show-cursor -n 0 \
+           > <out_dir>/jc-cursor-$FW.txt
+   done
+   ```
+   Both fw0 and fw1 are captured because either node may be
+   the primary at the start of a rep, and a transition could
+   originate from either side.
+4a. **SYN-cookie counter snapshot on the current primary**
+    (R5 fresh #1, R7 MED 2: explicit incus invocation):
+    ```
+    incus exec loss:xpf-userspace-fw0 -- \
+        cli -c "show security screen statistics zone wan" \
+        > <out_dir>/screen-pre.txt
+    ```
+    fw0 is the standing primary in the test cluster; if a
+    transition happens during the rep, the post-snapshot at
+    step 9a is taken from whichever node is primary at that
+    point (orchestrator queries
+    `cli -c "show chassis cluster status"` first to find it).
+    Captured into the manifest. Delta written into
+    manifest.json under `screen_engaged: <bool>`.
+5. **Elephant launch + cwnd-settle gate** (§4.4) if N>0.
+6. **Probe driver** (§4.1) for `<duration>` seconds.
+7. **Source-CPU stop**, parse mpstat result.
+8. **Elephant stop** (R1 #5: invalidate if collapsed during
+   window).
+9a. **SYN-cookie counter post-snapshot** (R5 fresh #1):
+    ```
+    cli -c "show security screen statistics zone wan" \
+        > <out_dir>/screen-post.txt
+    ```
+    Diff with `screen-pre.txt` (step 4a); if any syn-flood
+    counter advanced, set `screen_engaged: true` in manifest.
+    Not auto-invalidating; analyst flag.
+9. **journalctl diff on BOTH nodes** (R1 #6, R2 F1, R7 MED 2):
+   ```
+   for FW in xpf-userspace-fw0 xpf-userspace-fw1; do
+       incus exec loss:$FW -- journalctl \
+           --after-cursor="$(cat <out_dir>/jc-cursor-$FW.txt)" \
+           -u xpfd | grep -iE '<HA_TRANSITION_REGEX>'
+   done
+   ```
+   The userspace cluster has `PrivateRGElection=true`
+   (`pkg/config/compiler_system.go:810`), which suppresses
+   RETH VRRP entirely — the dominant state-change log is
+   `cluster: primary transition` from `pkg/cluster/cluster.go:1671`.
+   For the remaining VRRP-on-non-RETH paths, the log shape is
+   `vrrp: transitioning to (MASTER|BACKUP|INIT)` from
+   `pkg/vrrp/instance.go:779,796`.
+
+   `HA_TRANSITION_REGEX` =
+   `cluster: primary transition|vrrp: transitioning to (MASTER|BACKUP)`
+
+   (R3 F1: dropped the `INIT` arm — `pkg/vrrp/instance.go` only
+   emits `transitioning to MASTER` and `transitioning to BACKUP`;
+   no `INIT` log string exists.)
+
+   **grep + journalctl exit-status handling (R3 fresh #1, R4
+   MED 5):** `grep` exits 1 when no lines match, which is the
+   *expected* clean case. `journalctl` exit code is captured
+   separately so an upstream journalctl failure (e.g. cursor
+   invalid, daemon log unavailable) is NOT silently treated as
+   "no matches".
+
+   ```
+   set +e; set -o pipefail
+   matches=$(journalctl --after-cursor="$cursor" -u xpfd \
+                 2> /tmp/jc-stderr; echo "JC_RC=$?")
+   jc_rc=$(echo "$matches" | sed -n 's/.*JC_RC=//p' | tail -1)
+   matches=$(echo "$matches" | sed '/JC_RC=/d' | grep -E "$RE")
+   gr_rc=$?; set -e
+   ```
+   - `jc_rc != 0` → harness failure, fail the rep with
+     "INVALID-jc-error" + capture stderr.
+   - `gr_rc == 1 && empty matches` → success (no transitions).
+   - `gr_rc == 0 && nonempty matches` → INVALID-ha-transition.
+   - `gr_rc > 1` → harness failure.
+
+   If any state-transition event appears in the rep window,
+   INVALIDATE the rep with
+   `<out_dir>/INVALID-ha-transition`.
+10. **RG state poll review**: stop the background poller from
+    step 3, scan `rg-state-poll.txt` for any state value that
+    differs from the t=0 sample. ANY mismatch — even one that
+    later returns to the original state — INVALIDATES the rep
+    with `<out_dir>/INVALID-rg-state-flap`. This catches the
+    full failover+failback cycle that journalctl grep can miss
+    if the daemon log rotates or the regex has a gap.
+11. **Manifest write**: `<out_dir>/manifest.json` with cell
+    parameters, RG samples, journalctl excerpt, mpstat
+    summary.
+
+If any step fails or marks INVALID, the rep counts toward the
+INVALID quota; matrix orchestrator schedules a replacement
+under the cell's overall rep cap (R6 NEW-LOW: clarifying the
+two limits' interaction).
+
+The cell's hard rep ceiling is **15** (matching §4.7's
+auto-extension), of which up to 5 may be retries. So a cell
+that hits 10 valid reps without retries is done at 10; a cell
+with retry-eligible failures gets up to 5 replacement reps,
+not exceeding 15 total. Cells with > 7 valid reps after 15
+are reported with the data they have; cells with < 7 valid
+reps are INSUFFICIENT-DATA.
+
+### 4.6 Echo-server preflight (R1 #17)
+
+Before the matrix starts, a one-shot preflight:
+
+```
+python3 test/incus/mouse-latency-probe.py \
+    --target 172.16.80.200 --port 7 \
+    --concurrency 1 --duration 5 \
+    --out /tmp/preflight.json
+```
+
+Required for matrix to proceed:
+- TCP connect succeeds.
+- Echo readback exactly matches sent payload bit-for-bit (the
+  probe driver's per-probe verification).
+- p99 RTT < 5 ms (sanity — idle path through firewall should
+  be <1 ms but we allow margin).
+- error_rate < 0.001.
+
+If preflight fails, matrix aborts with the preflight JSON +
+operator-actionable diagnosis. No partial data is collected.
+
+### 4.7 Matrix orchestrator — `test/incus/test-mouse-latency-matrix.sh`
+
+Iterates 12 cells (N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}).
+
+**Per-cell rep accounting (R7 MED 1, reconciles §4.5 retries
+with §4.7 auto-extension):**
+
+- Baseline: 10 reps scheduled.
+- Replacement reps (per §4.5: any rep that lands INVALID
+  triggers a replacement) and auto-extension reps (per §4.7:
+  triggered when INVALID rate > 30 % in the first 10) BOTH
+  count against the same 15-rep hard ceiling.
+- Order: any in-baseline INVALID schedules an immediate
+  replacement; if total reps reaches 10 with INVALID rate
+  > 30 %, additional reps are scheduled up to 15. Both
+  mechanisms are subordinate to the 15-rep ceiling.
+- Cell stops once 10 valid reps are collected, or 15 total
+  reps have run, whichever is first.
+- Cell is reported INSUFFICIENT-DATA if fewer than 7 valid
+  reps after the ceiling.
+
+**Wall-budget math (R2 F4):** per-rep total is iperf3
+lifetime + setup ≈ 90 s + ~15 s setup/teardown ≈ 105 s. Base
+matrix at 10 reps: 12 × 10 × 105 s ≈ 210 min (3.5 h). With
+auto-extension to 15 reps in the worst case (every cell hits
+the extension trigger): 12 × 15 × 105 s ≈ 315 min (5.25 h).
+
+Wall-budget cap: **6 hours**. v2's "4 h" was incorrect for the
+extension worst case; v3 raises the cap. If exceeded, the
+matrix runs as far as it can and the partial results are
+written; findings.md flags incomplete cells as
+INSUFFICIENT-DATA. Cells are run in order N=0 first (idle
+baseline = the gate's reference cell, must be present), then
+M=10 cells (the gate's measurement cells), then the rest —
+so the gate-relevant data lands first and a wall-budget
+truncation degrades gracefully.
+
+## 5. Aggregator — `test/incus/mouse-latency-aggregate.py`
+
+Reads `<out_dir>/cell_N{n}_M{m}/`, picks median rep per cell
+(by p99), produces:
+
+- `<out_dir>/summary.json` — per cell, the median rep's
+  **p50, p95, and p99 RTT** (R5 fresh #2: §1 promises all
+  three; v3's narrower "median p99 + IQR" was an output
+  contract gap), plus IQR of p99 across reps and the
+  achieved-RPS distribution.
+- Markdown table to stdout, suitable for findings.md.
+- The decision-threshold verdict (§7.2): PASS / FAIL /
+  INSUFFICIENT-DATA, naming the two reference cells.
+
+## 6. Statistical notes
+
+### 6.1 Why p999 is omitted (R1 #4)
+
+At M=10, achieved RPS is bounded by the probe path. From #900's
+data, idle p99 across the firewall is sub-millisecond, so closed-
+loop achieved RPS ≈ 200 RPS at M=10. Per-rep samples ≈ 200 × 60
+= 12000.
+
+The aggregator picks the **median rep by p99** (§5), not a pooled
+sample set across all 10 reps (R2 F6). So the reported p99 is
+estimated from a single rep's ~12000 samples — that's its
+sample count, ~120 tail samples for p99 within that one rep.
+
+p999 within a single rep ≈ 12 tail samples — too narrow for a
+robust point estimate. We deliberately omit p999 from the report.
+
+p99 with 120 tail samples per rep is the primary metric; p95
+(600 tail samples) is the secondary. Across-rep variance is
+captured by IQR of p99 over the 10 reps and reported alongside
+the median.
+
+### 6.2 Decision-threshold defense (R1 #16)
+
+The 2× threshold is from the #905 issue body. It is a
+**decision-aid heuristic**, not a product SLO. Specifically:
+
+- If p99 at (N=128, M=10) is ≤ 2× idle, the elephants are not
+  inflicting catastrophic mouse latency under best-effort
+  isolation — sufficient to defer further algorithm work and
+  pursue measurement-driven follow-ups.
+- If > 2×, the harness produced concrete data motivating a next
+  algorithm investigation; product can then decide what its
+  actual tolerance threshold is.
+- Either verdict is mergeable. The merge gate is "we collected
+  data and reported it honestly" (per §7.1).
+
+## 7. Acceptance / gates
+
+### 7.1 Merge gates (block merge if not met)
+
+- `python3 -m unittest discover -s test/incus/ -p '*_test.py'`
+  passes for the new test files (R4 HIGH 2: default discover
+  pattern is `test*.py`; our file-naming convention puts
+  `_test` as a suffix, so the explicit pattern is required for
+  discovery to find anything).
+- Echo-server preflight succeeds (§4.6).
+- Smoke cell `N=0 M=1` runs end-to-end with valid output.
+- `findings.md` exists with the 12-cell table + decision verdict
+  (PASS / FAIL / INSUFFICIENT-DATA).
+- Codex hostile plan + code review: PLAN-READY YES + MERGE YES,
+  every finding disposed.
+- Copilot inline review: addressed.
+
+### 7.2 Decision threshold (per #905; reported, not gating)
+
+Mouse p99 at (N=128, M=10, best-effort) ≤ 2 × idle baseline
+(N=0, M=10, best-effort).
+
+## 8. Files touched
+
+This is a plan; the files below are **deliverables**, not
+asserted-existing. The plan ships first (this commit), then
+the implementation commits add the rest. R3 reviewer briefly
+read this section as "v3 claims iperf3_sum_parse_test.py
+ships and it doesn't" — clarifying that plan.md is the
+specification and these files are written in the
+implementation phase.
+
+New files (planned deliverables):
+- `docs/pr/905-mouse-latency/plan.md` (this file)
+- `docs/pr/905-mouse-latency/findings.md` (post-data)
+- `docs/pr/905-mouse-latency/results/cell_N{n}_M{m}/...` (raw)
+- `test/incus/mouse-latency-probe.py`
+- `test/incus/mouse-latency-aggregate.py`
+- `test/incus/test-mouse-latency.sh`
+- `test/incus/test-mouse-latency-matrix.sh`
+- `test/incus/mouse-latency-probe_test.py`
+- `test/incus/mouse-latency-aggregate_test.py`
+- `test/incus/iperf3_sum_parse.py`
+- `test/incus/iperf3_sum_parse_test.py`
+- `test/incus/cluster_status_parse.py`
+- `test/incus/cluster_status_parse_test.py`
+
+Modified files: none.
+
+## 9. Test strategy
+
+### 9.1 Unit tests (R1 #13)
+
+`mouse-latency-probe_test.py`:
+- Histogram bucket assignment correct at boundaries.
+- p99/p95/p50 from synthetic input matches `statistics.quantiles`
+  output (no `numpy` dependency).
+- Error-rate >1 % marks rep INVALID.
+- Degenerate-coroutine guard (R1 #3): rep INVALID when one
+  coroutine completes < 0.5 × median.
+- Min-attempts gate (per §4.2 thresholds, R5 F4):
+  rep INVALID when M≥10 and total attempts < 5000, or M=1
+  and total attempts < 500. Test cases at the boundary
+  (4999 vs 5000 for M=10; 499 vs 500 for M=1).
+- Achieved-RPS computation correct for synthetic input.
+- Duration-elapsed loop exit — no off-by-one.
+
+`mouse-latency-aggregate_test.py`:
+- Median-of-10 by p99 picks the 5th-or-6th rep, not the mean.
+- Decision-threshold computes correctly for synthetic inputs at
+  PASS, FAIL, exactly-2.0× boundary.
+- INSUFFICIENT-DATA verdict when valid reps < 7.
+- INVALID cells excluded from median.
+
+`cluster_status_parse_test.py` (R4 HIGH 1, schema updated by
+R5 F3):
+- Single-RG canonical output → correct list of
+  `(rg_id, node_id, state)` triples (one triple per
+  (RG, node) pair).
+- Multi-RG output → list extraction with ordering stable
+  (sort by `(rg_id, node_id)` for deterministic comparison
+  across samples).
+- Output with peer-down state (no `node1` row) → triples
+  list contains only the local node's row; missing peer
+  is implicit, not an error.
+- Output with hold/disabled/lost states for either node
+  surfaces correctly in the `state` field.
+- Empty / malformed input returns empty list, no crash.
+
+`iperf3_sum_parse_test.py` (R2 F5):
+- `[SUM]` per-second rows parsed correctly across Kbits, Mbits,
+  Gbits unit prefixes; rate normalized to bits/sec.
+- Final summary line shape parsed correctly.
+- Malformed input (empty, non-SUM, partial line, line with
+  trailing per-stream rows like `[SUM-PER-STREAM]`) returns
+  None / no-match instead of garbage.
+- Anchored regex does not match per-stream `[N]` rows.
+
+`test-mouse-latency.sh`:
+- Smoke test only — argument parsing + invocation contract.
+  Full integration is the harness run itself.
+
+### 9.2 Smoke run
+
+Before the full matrix (R6 NEW-MED 2: smoke duration must
+satisfy the §4.2 M=1 min-attempts floor of 500):
+```
+./test/incus/test-mouse-latency.sh 0 1 60 /tmp/smoke
+```
+Verify ≥ 500 completed probes (matches the M=1 floor),
+error_rate < 0.01, validity OK, no journalctl HA transitions
+in the rep window. Wall time: ~75 s (60 s probe + ~15 s
+setup/teardown).
+
+### 9.3 Full matrix
+
+12 cells × 10 reps. Outputs land in
+`docs/pr/905-mouse-latency/results/`, committed alongside
+findings.md.
+
+### 9.4 Validation lane (per `docs/engineering-style.md` §8)
+
+- Standalone deploy + ping: N/A — this PR is harness-only,
+  no daemon code.
+- iperf3 -P 16 baseline: implicit in the elephant runs.
+- HA failover: not exercised; harness is read-only on the
+  dataplane. Per-rep journalctl + RG-state samples protect
+  against in-flight failover.
+
+## 10. Risks
+
+- **Echo-server capacity unknown.** §4.6 preflight catches
+  obvious failure, but at M=50 sustained for 60 s = up to
+  ~12 000 connection attempts; if the echo server has lower
+  per-IP concurrency caps that show up only at M=50, the
+  M=50 cells INVALIDATE via degenerate-coroutine guard.
+  Mitigation: drop to M=25 if M=50 fails consistently;
+  document in findings.md.
+
+- **Source-host TCP-stack contention.** Closed-loop M=50 may
+  exceed `cluster-userspace-host`'s socket-recv buffer. The
+  mpstat gate (§4.5 step 2) catches client saturation; data
+  from a saturated source is invalidated.
+
+- **64-byte payload tests connect path, not in-stream
+  queueing.** This is a known scope choice; the connect path
+  is the canonical mouse workload. If the verdict is FAIL, a
+  follow-up could test in-stream RTT at 8 KB.
+
+- **Cluster steady-state drift over 6-hour wall budget.**
+  Mitigated by per-rep validity gates + median-of-10. A
+  systemic drift (e.g. RSS table mutation between cells)
+  shows as monotonic trend in `summary.json`, surfaced in
+  findings.md analysis.
+
+- **journalctl cursor on busy daemon.** If xpfd produces
+  state-transition logs at high frequency (it shouldn't —
+  CLAUDE.md says HA transitions are state-changes only,
+  not per-tick), the journalctl-diff grep could miss
+  events. Mitigation: also check the RG-state-sample diff
+  in step 10.
+
+## 11. R1 disposition
+
+| #  | Sev  | Topic                                | v2 status |
+|----|------|--------------------------------------|-----------|
+| 1  | HIGH | Pacing math wrong                    | RESOLVED — §4.1: dropped per-iteration sleep, closed-loop only |
+| 2  | HIGH | Closed-loop hides overload           | RESOLVED — §4.2: achieved-RPS reported, IQR + per-coroutine distribution |
+| 3  | HIGH | Error-rate gate passes degenerate cell | RESOLVED — §4.2: degenerate-coroutine guard (min < 0.5×median), min-attempts gate |
+| 4  | HIGH | Three reps statistically weak        | RESOLVED — §4.7: 10 reps baseline, auto-extend to 15. §6.1: p999 dropped, p99/p95 retained |
+| 5  | HIGH | Elephant load not proved steady      | RESOLVED — §4.4: text-mode iperf3, cwnd-settle gate ≥0.7× shaper, in-window collapse check at <0.5× |
+| 6  | HIGH | HA contamination via in-cell failover | RESOLVED — §4.5 step 4 + 9: journalctl cursor + diff for VRRP transitions |
+| 7  | HIGH | CoS apply command wrong namespace    | RESOLVED — §3.2: `loss:xpf-userspace-fw0` qualified |
+| 8  | MED  | Source-host claim wrong              | RESOLVED — §3.1: clarified that `cluster-userspace-host` is LAN client, `apply-cos-config.sh` targets the firewall |
+| 9  | MED  | Port-7 best-effort live assertion    | SUPERSEDED by R2 F2 — see §3.3 v3: synthetic counter check dropped (no real CLI), replaced with static config + dynamic echo-preflight |
+| 10 | MED  | SYN-cookie unverified                | RESOLVED — §3.6: assumption dropped, screen counters recorded as analyst signal |
+| 11 | MED  | Client CPU bottleneck                | RESOLVED — §4.5 step 2: mpstat 1 with > 80 % invalidation |
+| 12 | MED  | Mechanism attribution overclaimed    | RESOLVED — §1, §2: scope reduced to data + verdict; mechanism is follow-up |
+| 13 | MED  | Unit tests miss risky behavior       | RESOLVED — §9.1: added pacing absence, achieved-RPS, degenerate-guard, min-attempts coverage; dropped numpy |
+| 14 | MED  | v6 omission rationale weak           | RESOLVED — §3.5: explicit caveat, narrowed PASS-gate scope, v6 = follow-up |
+| 15 | MED  | Dropping iperf-a-shared              | RESOLVED — §3.4: explicit caveat about cross-class diagnosis |
+| 16 | MED  | PASS threshold not defended as SLO   | RESOLVED — §6.2: 2× is a decision-aid, NOT a product SLO. Findings.md must repeat the caveat |
+| 17 | MED  | Echo-server preflight underspecified | RESOLVED — §4.6: explicit preflight (connect, echo readback, p99 < 5 ms, error_rate < 0.001) |
+
+### R2 disposition (after v2 → v3 fixes)
+
+| ID | Sev  | Topic                                | v3 status |
+|----|------|--------------------------------------|-----------|
+| F1 | HIGH | HA regex doesn't match real log      | RESOLVED — §4.5 step 9: regex now `cluster: primary transition\|vrrp: transitioning to (MASTER\|BACKUP\|INIT)` grounded in `pkg/cluster/cluster.go:1671` + `pkg/vrrp/instance.go:779,796` |
+| F2 | HIGH | `xpf-ctl status --json` does not exist | RESOLVED — §3.3 v3: synthetic-counter preflight dropped; static config + dynamic echo-preflight carry the assertion |
+| F3 | HIGH | Elephant iperf3 lifetime too short   | RESOLVED — §4.4: `iperf3_duration = SETTLE_BUDGET (20s) + probe_duration (60s) + SLACK (10s) = 90s` |
+| F4 | MED  | Wall-budget math ignores extension   | RESOLVED — §4.7 v3: cap raised to 6 h; cells run gate-relevant first so truncation degrades gracefully |
+| F5 | MED  | `[SUM]` parsing untested             | RESOLVED — §4.4: parser pinned with a regex; `iperf3_sum_parse_test.py` added; §9.1 lists tests |
+| F6 | LOW  | p99 sample-count claim overstated    | RESOLVED — §6.1: clarified that median-rep selection means p99 is from a single rep's samples, not pooled |
+| F7 | LOW  | bucket edges fine                    | NO-OP — concern was theoretical, not material |
+
+### R3 disposition (after v2 → v3 fixes)
+
+| ID | Sev  | Topic                                  | v3 status |
+|----|------|----------------------------------------|-----------|
+| F1 | HIGH (partial) | INIT regex arm ungrounded     | RESOLVED — §4.5 step 9: `INIT` removed; only `MASTER`/`BACKUP` arms remain, grounded in `pkg/vrrp/instance.go:781,798` |
+| F2 | HIGH (partial) | 100 Mb/s sanity is dead code  | RESOLVED — §3.3 v3: dead-code claim removed; explicit "we do not dynamically assert this; static config carries it; daemon-CLI follow-up if needed" |
+| F5 | MED (still-broken) | parser test file doesn't exist | CLARIFIED — §8: explicit "files below are deliverables, not asserted-existing"; Codex misread plan as implementation. No code change |
+| Fresh-1 | MED  | grep no-match exits 1                | RESOLVED — §4.5 step 9: explicit `set +e; rc==1 && empty` handling for clean case |
+| Fresh-2 | MED  | failover+failback returns same state | RESOLVED — §4.5 step 3 + 10: continuous 1 Hz RG-state polling during rep, ANY mismatch INVALIDATES |
+| Fresh-3 | LOW  | invocation path ambiguous            | RESOLVED — all `python3 test/incus/...` invocations qualified |
+
+### R4 disposition
+
+| ID | Sev  | Topic                                | v4 status |
+|----|------|--------------------------------------|-----------|
+| H1 | HIGH | RG state polling unspecified         | RESOLVED — §4.5 step 3: `cli -c "show chassis cluster status"` pinned, parser regex pinned, new `cluster_status_parse.py` + `_test.py` files |
+| H2 | HIGH | unittest discover discovers nothing  | RESOLVED — §7.1 + §10 acceptance: `discover -p '*_test.py'` flag added |
+| H3 | HIGH | iperf3 stdout buffering              | RESOLVED — §4.4: `--forceflush` added to iperf3 invocation |
+| M4 | MED  | §4.5 step 1 contradicted §3.3        | RESOLVED — §4.5 step 1 reduced to fixture-apply only |
+| M5 | MED  | journalctl exit code unchecked       | RESOLVED — §4.5 step 9: explicit `jc_rc` capture + branch |
+| M6 | MED  | SYN-cookie zone wrong (`untrust` → `wan`) | RESOLVED — §3.6: zone corrected per `docs/ha-cluster-userspace.conf:154` |
+| L7 | LOW  | filter.rs citation off               | RESOLVED — §3.3: cite `forwarding_build.rs:653` + `tx.rs:4937` |
+| L8 | LOW  | byte math off                        | RESOLVED — §3.3: derivation corrected to ~1.7 Mbps |
+
+### R5 disposition
+
+| ID | Sev  | Topic                                | v4 status |
+|----|------|--------------------------------------|-----------|
+| F1 | MED  | §3.6 SYN counter not wired into rep flow | RESOLVED — §4.5 step 4a + 9a: explicit pre/post snapshot, manifest delta |
+| F2 | MED  | §1 promises p50/p95/p99 but §5 only median p99 | RESOLVED — §5: aggregator outputs all three quantiles per cell |
+| F3 | MED  | RG poll schema too narrow            | RESOLVED — §4.5 step 3: `(rg_id, node_id, state)` triple, not `(rg_id, primary_node_id)` |
+| F4 | MED  | min-attempts floor too loose for p99 | RESOLVED — §4.2: ≥5000 for M≥10, ≥500 for M=1; M=1 excluded from PASS gate per §7.2 |
+| L8r| LOW  | byte math residual                   | RESOLVED — §3.3: dropped precise derivation, kept order-of-magnitude argument |
+
+### R6 disposition
+
+| ID  | Sev | Topic                                              | v4 status |
+|-----|-----|----------------------------------------------------|-----------|
+| NM1 | MED | §9.1 cluster_status_parse_test still primary-only  | RESOLVED — §9.1: triple-schema test contract |
+| NM2 | MED | §9.2 smoke probe count (~200) contradicts M=1 floor (500) | RESOLVED — §9.2: smoke duration bumped from 10 s to 60 s; expectation set to ≥ 500 probes |
+| NL1 | LOW | retry-cap (3) vs extension-cap (15) interaction unspecified | RESOLVED — §4.5: hard ceiling 15 reps total, up to 5 of which may be retries |
+
+### R7 disposition
+
+| ID | Sev | Topic                                              | v4 status |
+|----|-----|----------------------------------------------------|-----------|
+| M1 | MED | §4.5 retries vs §4.7 extension reconciliation      | RESOLVED — §4.7: explicit "both mechanisms subordinate to 15-rep ceiling; cell stops at 10 valid OR 15 total" |
+| M2 | MED | journalctl/SYN-counter both-node coverage ambiguous | RESOLVED — §4.5 step 4 + 4a + 9: explicit `incus exec loss:xpf-userspace-fw{0,1}` invocations; SYN snapshot tracks primary across in-rep transitions |
+
+## 12. Acceptance checklist
+
+- [ ] Plan reviewed by Codex (hostile); PLAN-READY YES.
+- [ ] Probe + aggregate Python implemented; unit tests green.
+- [ ] Orchestrator + matrix shell scripts implemented.
+- [ ] Smoke cell (N=0, M=1) runs on the loss cluster with
+      validity OK.
+- [ ] Echo-server preflight succeeds.
+- [ ] Full 12-cell matrix runs (10 reps each, auto-extend
+      to 15); results committed under
+      `docs/pr/905-mouse-latency/results/`.
+- [ ] `findings.md` written with the summary table, decision
+      verdict, AND the §3.4 / §3.5 / §6.2 caveats.
+- [ ] Codex hostile code review: MERGE YES.
+- [ ] Copilot inline review: addressed.
+- [ ] PR opened, CI green, both reviewers clean.

--- a/test/incus/cluster_status_parse.py
+++ b/test/incus/cluster_status_parse.py
@@ -1,0 +1,54 @@
+"""Parser for `cli -c "show chassis cluster status"` output.
+
+Extracts the list of (rg_id, node_id, state) triples per sample,
+keyed deterministically by (rg_id, node_id) for cross-sample
+comparison.
+
+Output format (one block per RG, see pkg/cluster/cluster.go:1767):
+
+    Redundancy group: 1 , Failover count: 0
+    Node    Priority  Status         ...
+    node0   200       primary        ...
+    node1   100       secondary      ...
+
+The local node always reports itself + the peer (when alive).
+"""
+
+import re
+from typing import List, Tuple
+
+# Public type alias for clarity.
+StateTriple = Tuple[int, int, str]  # (rg_id, node_id, state)
+
+_RG_HEADER_RE = re.compile(r"^Redundancy group:\s*(\d+)\s*,")
+# State strings emitted by `pkg/cluster/cluster.go:NodeState.String()`:
+# "primary", "secondary", "secondary-hold", "lost", "disabled". The regex
+# anchors with `\b` and captures hyphenated suffixes (R3 HIGH:
+# `secondary-hold` was previously truncated to `secondary`, masking the
+# state transition).
+_NODE_ROW_RE = re.compile(
+    r"^node(\d+)\s+\d+\s+(primary|secondary-hold|secondary|hold|disabled|lost)\b",
+    re.IGNORECASE,
+)
+
+
+def parse_cluster_status(text: str) -> List[StateTriple]:
+    """Parse the multi-line output, return sorted (rg_id, node_id, state)."""
+    if not text:
+        return []
+    triples: List[StateTriple] = []
+    current_rg: int | None = None
+    for line in text.splitlines():
+        m = _RG_HEADER_RE.match(line)
+        if m:
+            current_rg = int(m.group(1))
+            continue
+        if current_rg is None:
+            continue
+        m = _NODE_ROW_RE.match(line)
+        if m:
+            node_id = int(m.group(1))
+            state = m.group(2).lower()
+            triples.append((current_rg, node_id, state))
+    triples.sort(key=lambda t: (t[0], t[1]))
+    return triples

--- a/test/incus/cluster_status_parse_test.py
+++ b/test/incus/cluster_status_parse_test.py
@@ -1,0 +1,116 @@
+import unittest
+
+from cluster_status_parse import parse_cluster_status
+
+
+SINGLE_RG = """\
+Monitor Failure codes:
+    CS  Cold Sync monitoring        FL  Fabric Connection monitoring
+    IF  Interface monitoring        IP  IP monitoring
+    CF  Config Sync monitoring
+
+Cluster ID: 1
+Node name: node0
+
+Software version: 0.1.0
+HA protocol version: 4
+Peer software version: 0.1.0
+Peer HA protocol version: 4
+
+Node    Priority  Status         Preempt  Manual   Monitor-failures
+
+Redundancy group: 1 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+"""
+
+MULTI_RG = """\
+Redundancy group: 0 , Failover count: 1
+node0   200       secondary      no       no       None
+node1   100       primary        no       no       None
+
+Redundancy group: 1 , Failover count: 2
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+"""
+
+PEER_DOWN = """\
+Redundancy group: 1 , Failover count: 0
+node0   200       primary        no       no       None
+"""
+
+HOLD_AND_LOST = """\
+Redundancy group: 1 , Failover count: 4
+node0   200       hold           no       no       FL
+node1   100       lost           no       no       None
+"""
+
+SECONDARY_HOLD = """\
+Redundancy group: 1 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary-hold no       no       None
+"""
+
+
+class ParseClusterStatusTests(unittest.TestCase):
+    def test_single_rg_canonical(self):
+        triples = parse_cluster_status(SINGLE_RG)
+        self.assertEqual(
+            triples,
+            [(1, 0, "primary"), (1, 1, "secondary")],
+        )
+
+    def test_multi_rg_input_order(self):
+        triples = parse_cluster_status(MULTI_RG)
+        # Sorted by (rg_id, node_id):
+        self.assertEqual(
+            triples,
+            [
+                (0, 0, "secondary"),
+                (0, 1, "primary"),
+                (1, 0, "primary"),
+                (1, 1, "secondary"),
+            ],
+        )
+
+    def test_peer_down(self):
+        # When peer is absent, only the local node row appears.
+        triples = parse_cluster_status(PEER_DOWN)
+        self.assertEqual(triples, [(1, 0, "primary")])
+
+    def test_hold_and_lost(self):
+        triples = parse_cluster_status(HOLD_AND_LOST)
+        self.assertEqual(
+            triples,
+            [(1, 0, "hold"), (1, 1, "lost")],
+        )
+
+    def test_secondary_hold_is_distinct(self):
+        # R3 HIGH: `secondary-hold` was truncated to `secondary`,
+        # making secondary→secondary-hold transitions invisible.
+        triples = parse_cluster_status(SECONDARY_HOLD)
+        self.assertEqual(
+            triples,
+            [(1, 0, "primary"), (1, 1, "secondary-hold")],
+        )
+
+    def test_empty(self):
+        self.assertEqual(parse_cluster_status(""), [])
+
+    def test_malformed_no_rg_header(self):
+        # Node rows without an RG header are ignored.
+        text = "node0   200       primary        no       no       None\n"
+        self.assertEqual(parse_cluster_status(text), [])
+
+    def test_malformed_no_node_rows(self):
+        text = "Redundancy group: 1 , Failover count: 0\nNode    Priority\n"
+        self.assertEqual(parse_cluster_status(text), [])
+
+    def test_state_case_normalized(self):
+        # Defensive: even if formatter changes case in the future.
+        text = "Redundancy group: 1 , Failover count: 0\nnode0   200       PRIMARY        no       no       None\n"
+        self.assertEqual(parse_cluster_status(text), [(1, 0, "primary")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/iperf3_sum_parse.py
+++ b/test/incus/iperf3_sum_parse.py
@@ -1,0 +1,52 @@
+"""Parser for `iperf3 -i 1 --forceflush -P N` text-mode `[SUM]` lines.
+
+Per-second rows look like:
+    [SUM]   3.00-4.00   sec  118 MBytes  990 Mbits/sec   ...
+
+Final summary lines look like:
+    [SUM]   0.00-60.00  sec  6.96 GBytes  996 Mbits/sec   ...      receiver
+    [SUM]   0.00-60.00  sec  6.96 GBytes  996 Mbits/sec   ...      sender
+
+Per-stream lines start with `[N]` where N is a digit; they must NOT
+match. Anchored regex on `[SUM]` only.
+"""
+
+import re
+from typing import Optional, Tuple
+
+# Match `[SUM]   <start>-<end>   sec  <transferred> <unit>  <rate> <rate-unit>/sec`.
+# Capture (rate_value, rate_unit_prefix).
+_SUM_RE = re.compile(
+    r"^\[SUM\]\s+\d+(?:\.\d+)?-\d+(?:\.\d+)?\s+sec\s+\S+\s+\S+\s+(\S+)\s+([KMGT]?)bits/sec",
+    re.IGNORECASE,
+)
+
+_UNIT_MULTIPLIER = {
+    "": 1,
+    "K": 1_000,
+    "M": 1_000_000,
+    "G": 1_000_000_000,
+    "T": 1_000_000_000_000,
+}
+
+
+def parse_sum_line(line: str) -> Optional[Tuple[float, int]]:
+    """Return (rate_value, rate_bps) or None if not a [SUM] line."""
+    m = _SUM_RE.match(line)
+    if not m:
+        return None
+    try:
+        rate_value = float(m.group(1))
+    except ValueError:
+        return None
+    unit = m.group(2).upper()
+    multiplier = _UNIT_MULTIPLIER.get(unit)
+    if multiplier is None:
+        return None
+    return (rate_value, int(rate_value * multiplier))
+
+
+def parse_sum_bps(line: str) -> Optional[int]:
+    """Return rate in bits/sec, or None."""
+    parsed = parse_sum_line(line)
+    return None if parsed is None else parsed[1]

--- a/test/incus/iperf3_sum_parse_test.py
+++ b/test/incus/iperf3_sum_parse_test.py
@@ -1,0 +1,61 @@
+import unittest
+
+from iperf3_sum_parse import parse_sum_bps, parse_sum_line
+
+
+class ParseSumLineTests(unittest.TestCase):
+    def test_per_second_mbits(self):
+        line = "[SUM]   3.00-4.00   sec  118 MBytes  990 Mbits/sec                  "
+        self.assertEqual(parse_sum_bps(line), 990_000_000)
+
+    def test_per_second_gbits(self):
+        line = "[SUM]   0.00-1.00   sec  1.16 GBytes  9.95 Gbits/sec"
+        rate_v, rate_bps = parse_sum_line(line)
+        self.assertEqual(rate_v, 9.95)
+        self.assertEqual(rate_bps, 9_950_000_000)
+
+    def test_per_second_kbits(self):
+        line = "[SUM]   1.00-2.00   sec  20.0 KBytes  164 Kbits/sec"
+        self.assertEqual(parse_sum_bps(line), 164_000)
+
+    def test_final_summary_receiver(self):
+        line = "[SUM]   0.00-60.00  sec  6.96 GBytes   996 Mbits/sec                  receiver"
+        self.assertEqual(parse_sum_bps(line), 996_000_000)
+
+    def test_final_summary_sender(self):
+        line = "[SUM]   0.00-60.00  sec  6.96 GBytes   996 Mbits/sec    1234             sender"
+        self.assertEqual(parse_sum_bps(line), 996_000_000)
+
+    def test_per_stream_does_not_match(self):
+        line = "[  5]   3.00-4.00   sec  118 MBytes  990 Mbits/sec"
+        self.assertIsNone(parse_sum_bps(line))
+
+    def test_empty_line(self):
+        self.assertIsNone(parse_sum_bps(""))
+
+    def test_non_sum_text(self):
+        self.assertIsNone(parse_sum_bps("Connecting to host 172.16.80.200, port 5201"))
+
+    def test_partial_sum_line(self):
+        # Truncated mid-line should not produce garbage.
+        self.assertIsNone(parse_sum_bps("[SUM]   3.00-4.00   sec  118 MBytes"))
+
+    def test_unit_prefix_lowercase(self):
+        line = "[SUM]   1.00-2.00   sec  118 mbytes  990 mbits/sec"
+        # Regex is case-insensitive on the keyword, but unit prefix
+        # is uppercased internally — verify lowercase-m is treated
+        # as Mega.
+        self.assertEqual(parse_sum_bps(line), 990_000_000)
+
+    def test_bare_bits_per_sec(self):
+        # No unit prefix at all (bits/sec exact).
+        line = "[SUM]   1.00-2.00   sec  100 Bytes  800 bits/sec"
+        self.assertEqual(parse_sum_bps(line), 800)
+
+    def test_fractional_rate_value(self):
+        line = "[SUM]   1.00-2.00   sec  118 MBytes  9.95 Gbits/sec"
+        self.assertEqual(parse_sum_bps(line), 9_950_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -1,0 +1,240 @@
+"""Aggregate per-rep JSON outputs into a per-cell summary + verdict.
+
+Cell directory layout: <root>/cell_N{n}_M{m}/rep_{i}/probe.json
+Per-rep validity is read from probe.json["validity"]["ok"].
+
+For each cell, the median rep (by p99) of the valid reps is selected
+as the representative; its p50/p95/p99 + IQR-of-p99-across-reps +
+achieved-RPS summary populate summary.json.
+
+Decision threshold (#905, plan §7.2):
+- p99(N=128, M=10, best-effort) ≤ 2 × p99(N=0, M=10, best-effort)
+
+The harness only runs best-effort, so cells are keyed by (N, M).
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from typing import Dict, List, Optional, Tuple
+
+CellKey = Tuple[int, int]  # (N, M)
+
+
+def has_invalid_marker(rep_dir: str) -> bool:
+    """Return True if the orchestrator wrote an INVALID-* marker file."""
+    if not os.path.isdir(rep_dir):
+        return False
+    for entry in os.listdir(rep_dir):
+        if entry.startswith("INVALID-"):
+            return True
+    return False
+
+
+def load_cell_reps(cell_dir: str) -> List[dict]:
+    """Load all rep_*/probe.json, applying orchestrator INVALID markers."""
+    if not os.path.isdir(cell_dir):
+        return []
+    reps: List[dict] = []
+    for entry in sorted(os.listdir(cell_dir)):
+        if not entry.startswith("rep_"):
+            continue
+        rep_dir = os.path.join(cell_dir, entry)
+        probe_path = os.path.join(rep_dir, "probe.json")
+        # Always collect orchestrator INVALID-* marker reasons first,
+        # regardless of probe.json availability (R2 HIGH 1 partial).
+        marker_reasons = sorted(
+            f"orchestrator: {m}"
+            for m in os.listdir(rep_dir)
+            if m.startswith("INVALID-")
+        )
+        if not os.path.isfile(probe_path):
+            reasons = ["no-probe-json"] + marker_reasons
+            reps.append({
+                "validity": {"ok": False, "reasons": reasons},
+                "rtt_us": {},
+                "totals": {},
+            })
+            continue
+        with open(probe_path) as f:
+            try:
+                rep = json.load(f)
+            except json.JSONDecodeError:
+                reasons = ["bad-json"] + marker_reasons
+                reps.append({
+                    "validity": {"ok": False, "reasons": reasons},
+                    "rtt_us": {},
+                    "totals": {},
+                })
+                continue
+        if marker_reasons:
+            v = rep.setdefault("validity", {"ok": False, "reasons": []})
+            v["ok"] = False
+            v.setdefault("reasons", []).extend(marker_reasons)
+        reps.append(rep)
+    return reps
+
+
+def select_valid_reps(reps: List[dict]) -> List[dict]:
+    return [r for r in reps if r.get("validity", {}).get("ok")]
+
+
+def median_rep_by_p99(valid_reps: List[dict]) -> Optional[dict]:
+    """Return the rep at the median position of p99 across valid reps."""
+    if not valid_reps:
+        return None
+    sortable = sorted(
+        valid_reps,
+        key=lambda r: r.get("rtt_us", {}).get("p99") or 0,
+    )
+    return sortable[len(sortable) // 2]
+
+
+def summarize_cell(reps: List[dict]) -> dict:
+    """Produce the per-cell summary record."""
+    valid = select_valid_reps(reps)
+    summary: dict = {
+        "n_reps_total": len(reps),
+        "n_reps_valid": len(valid),
+        "median_rep": None,
+        "iqr_p99_across_reps": None,
+    }
+    if len(valid) < 7:
+        summary["status"] = "INSUFFICIENT-DATA"
+        return summary
+    median = median_rep_by_p99(valid)
+    p99s = sorted(
+        r.get("rtt_us", {}).get("p99") or 0 for r in valid
+    )
+    n = len(p99s)
+    if n >= 4:
+        q1 = p99s[n // 4]
+        q3 = p99s[(3 * n) // 4]
+        summary["iqr_p99_across_reps"] = q3 - q1
+    if median is not None:
+        rtt = median.get("rtt_us", {})
+        totals = median.get("totals", {})
+        summary["median_rep"] = {
+            "p50_us": rtt.get("p50"),
+            "p95_us": rtt.get("p95"),
+            "p99_us": rtt.get("p99"),
+            "achieved_rps_total": totals.get("achieved_rps_total"),
+            # R2 fresh MED 1: propagate per-coroutine RPS distribution
+            # to the summary so the diagnosis surface MED-4 promised
+            # actually reaches the report.
+            "achieved_rps_per_coroutine_median":
+                totals.get("achieved_rps_per_coroutine_median"),
+            "achieved_rps_per_coroutine_iqr":
+                totals.get("achieved_rps_per_coroutine_iqr"),
+            "attempts_per_coroutine": totals.get("attempts_per_coroutine"),
+        }
+    summary["status"] = "OK"
+    return summary
+
+
+def decide(summaries: Dict[CellKey, dict]) -> dict:
+    """Compute the decision-threshold verdict per #905 plan §7.2."""
+    gate_loaded = summaries.get((128, 10))
+    gate_idle = summaries.get((0, 10))
+    if gate_loaded is None or gate_idle is None:
+        return {"verdict": "INSUFFICIENT-DATA", "reason": "missing gate cell"}
+    if gate_loaded.get("status") != "OK" or gate_idle.get("status") != "OK":
+        return {
+            "verdict": "INSUFFICIENT-DATA",
+            "reason": (
+                f"gate cell status: loaded={gate_loaded.get('status')}, "
+                f"idle={gate_idle.get('status')}"
+            ),
+        }
+    p99_loaded = (gate_loaded.get("median_rep") or {}).get("p99_us")
+    p99_idle = (gate_idle.get("median_rep") or {}).get("p99_us")
+    if p99_loaded is None or p99_idle is None or p99_idle == 0:
+        return {"verdict": "INSUFFICIENT-DATA", "reason": "missing p99 in gate cell"}
+    ratio = p99_loaded / p99_idle
+    return {
+        "verdict": "PASS" if ratio <= 2.0 else "FAIL",
+        "ratio": ratio,
+        "p99_idle_us": p99_idle,
+        "p99_loaded_us": p99_loaded,
+        "threshold": 2.0,
+        "gate": "p99(N=128, M=10) <= 2 * p99(N=0, M=10)",
+    }
+
+
+def discover_cells(root: str) -> Dict[CellKey, List[dict]]:
+    """Find all cell_N{n}_M{m}/ directories under root and load reps."""
+    if not os.path.isdir(root):
+        return {}
+    out: Dict[CellKey, List[dict]] = {}
+    for entry in sorted(os.listdir(root)):
+        if not entry.startswith("cell_N"):
+            continue
+        try:
+            _, rest = entry.split("cell_N", 1)
+            n_str, m_part = rest.split("_M", 1)
+            n = int(n_str)
+            m = int(m_part)
+        except (ValueError, IndexError):
+            continue
+        out[(n, m)] = load_cell_reps(os.path.join(root, entry))
+    return out
+
+
+def render_markdown(summaries: Dict[CellKey, dict], verdict: dict) -> str:
+    lines: List[str] = []
+    lines.append("| N elephants | M mice | reps (valid/total) | p50 µs | p95 µs | p99 µs | RPS | status |")
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for key in sorted(summaries.keys()):
+        n, m = key
+        s = summaries[key]
+        median = s.get("median_rep") or {}
+        lines.append(
+            f"| {n} | {m} | {s['n_reps_valid']}/{s['n_reps_total']} "
+            f"| {median.get('p50_us', '-')} "
+            f"| {median.get('p95_us', '-')} "
+            f"| {median.get('p99_us', '-')} "
+            f"| {median.get('achieved_rps_total', '-')} "
+            f"| {s.get('status', '-')} |"
+        )
+    lines.append("")
+    lines.append(f"**Verdict:** {verdict.get('verdict')}")
+    if "ratio" in verdict:
+        lines.append(
+            f"  ratio = {verdict['ratio']:.2f} "
+            f"(p99 loaded {verdict['p99_loaded_us']} µs / "
+            f"p99 idle {verdict['p99_idle_us']} µs); "
+            f"threshold ≤ {verdict['threshold']}"
+        )
+    elif "reason" in verdict:
+        lines.append(f"  reason: {verdict['reason']}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", required=True)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    cells = discover_cells(args.root)
+    summaries = {key: summarize_cell(reps) for key, reps in cells.items()}
+    verdict = decide(summaries)
+
+    with open(args.out, "w") as f:
+        json.dump(
+            {
+                "summaries": {f"N{n}_M{m}": s for (n, m), s in summaries.items()},
+                "verdict": verdict,
+            },
+            f,
+            indent=2,
+        )
+
+    print(render_markdown(summaries, verdict))
+    return 0 if verdict["verdict"] in ("PASS", "FAIL") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -121,13 +121,15 @@ def summarize_cell(reps: List[dict]) -> dict:
             "p95_us": rtt.get("p95"),
             "p99_us": rtt.get("p99"),
             "achieved_rps_total": totals.get("achieved_rps_total"),
-            # R2 fresh MED 1: propagate per-coroutine RPS distribution
-            # to the summary so the diagnosis surface MED-4 promised
-            # actually reaches the report.
-            "achieved_rps_per_coroutine_median":
-                totals.get("achieved_rps_per_coroutine_median"),
-            "achieved_rps_per_coroutine_iqr":
-                totals.get("achieved_rps_per_coroutine_iqr"),
+            # R2 fresh MED 1: propagate per-coroutine attempt-rate
+            # distribution to the summary so the diagnosis surface
+            # MED-4 promised actually reaches the report. Field
+            # renamed (Copilot R1): per-coroutine values are
+            # workload-offered (attempts), not completion-rate.
+            "attempts_per_second_per_coroutine_median":
+                totals.get("attempts_per_second_per_coroutine_median"),
+            "attempts_per_second_per_coroutine_iqr":
+                totals.get("attempts_per_second_per_coroutine_iqr"),
             "attempts_per_coroutine": totals.get("attempts_per_coroutine"),
         }
     summary["status"] = "OK"

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -1,0 +1,176 @@
+import json
+import os
+import tempfile
+import unittest
+
+from mouse_latency_aggregate import (
+    decide,
+    has_invalid_marker,
+    load_cell_reps,
+    median_rep_by_p99,
+    select_valid_reps,
+    summarize_cell,
+)
+
+
+def _make_rep(p99: int, ok: bool = True, p50: int = 100, p95: int = 500, rps: float = 200.0) -> dict:
+    return {
+        "rtt_us": {"p50": p50, "p95": p95, "p99": p99},
+        "totals": {"achieved_rps_total": rps, "attempts_per_coroutine": [600] * 10},
+        "validity": {"ok": ok, "reasons": []},
+    }
+
+
+class SelectValidRepsTests(unittest.TestCase):
+    def test_filters_invalid(self):
+        reps = [_make_rep(100), _make_rep(200, ok=False), _make_rep(300)]
+        self.assertEqual(len(select_valid_reps(reps)), 2)
+
+
+class MedianByP99Tests(unittest.TestCase):
+    def test_median_of_10(self):
+        reps = [_make_rep(p99) for p99 in range(100, 200, 10)]
+        # p99 values 100..190; sorted center is at index 5 → value 150.
+        m = median_rep_by_p99(reps)
+        self.assertEqual(m["rtt_us"]["p99"], 150)
+
+    def test_median_of_3(self):
+        reps = [_make_rep(100), _make_rep(300), _make_rep(200)]
+        m = median_rep_by_p99(reps)
+        self.assertEqual(m["rtt_us"]["p99"], 200)
+
+    def test_empty(self):
+        self.assertIsNone(median_rep_by_p99([]))
+
+
+class SummarizeCellTests(unittest.TestCase):
+    def test_insufficient_valid_reps(self):
+        # Only 5 valid → INSUFFICIENT-DATA
+        reps = [_make_rep(100) for _ in range(5)]
+        s = summarize_cell(reps)
+        self.assertEqual(s["status"], "INSUFFICIENT-DATA")
+
+    def test_ok_with_10_valid(self):
+        reps = [_make_rep(p99=100 + 10 * i) for i in range(10)]
+        s = summarize_cell(reps)
+        self.assertEqual(s["status"], "OK")
+        self.assertIsNotNone(s["median_rep"])
+        self.assertIsNotNone(s["iqr_p99_across_reps"])
+
+    def test_excludes_invalid_from_median(self):
+        # 7 valid + 3 invalid; the invalid ones with extreme p99 must
+        # not contribute to the median.
+        valid = [_make_rep(p99=100 + 10 * i) for i in range(7)]
+        invalid = [_make_rep(p99=99999, ok=False) for _ in range(3)]
+        s = summarize_cell(valid + invalid)
+        self.assertEqual(s["status"], "OK")
+        # Median p99 of 100..160 is at index 3 → 130.
+        self.assertEqual(s["median_rep"]["p99_us"], 130)
+
+
+class DecideTests(unittest.TestCase):
+    def _gate_summaries(self, p99_idle: int, p99_loaded: int):
+        idle = summarize_cell([_make_rep(p99=p99_idle) for _ in range(10)])
+        loaded = summarize_cell([_make_rep(p99=p99_loaded) for _ in range(10)])
+        return {(0, 10): idle, (128, 10): loaded}
+
+    def test_pass_at_2x(self):
+        # p99 idle 100, loaded 200 → ratio 2.0 → PASS (≤ 2)
+        summaries = self._gate_summaries(100, 200)
+        v = decide(summaries)
+        self.assertEqual(v["verdict"], "PASS")
+        self.assertAlmostEqual(v["ratio"], 2.0)
+
+    def test_fail_above_2x(self):
+        summaries = self._gate_summaries(100, 250)
+        v = decide(summaries)
+        self.assertEqual(v["verdict"], "FAIL")
+        self.assertAlmostEqual(v["ratio"], 2.5)
+
+    def test_pass_well_under_2x(self):
+        summaries = self._gate_summaries(100, 150)
+        v = decide(summaries)
+        self.assertEqual(v["verdict"], "PASS")
+
+    def test_missing_gate_cell(self):
+        v = decide({(0, 10): summarize_cell([_make_rep(100)] * 10)})
+        self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
+
+    def test_insufficient_data_in_gate(self):
+        # Loaded gate cell has only 5 valid reps → INSUFFICIENT-DATA
+        idle = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        loaded = summarize_cell([_make_rep(p99=100) for _ in range(5)])
+        v = decide({(0, 10): idle, (128, 10): loaded})
+        self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
+
+
+class LoadCellRepsInvalidMarkerTests(unittest.TestCase):
+    def _setup_cell(self, tmpdir: str):
+        cell_dir = os.path.join(tmpdir, "cell_N0_M10")
+        os.makedirs(cell_dir)
+        return cell_dir
+
+    def _write_rep(self, cell_dir: str, idx: int, ok: bool = True, marker: str = ""):
+        rep_dir = os.path.join(cell_dir, f"rep_{idx:02d}")
+        os.makedirs(rep_dir)
+        with open(os.path.join(rep_dir, "probe.json"), "w") as f:
+            json.dump({
+                "rtt_us": {"p50": 100, "p95": 500, "p99": 1000},
+                "totals": {"achieved_rps_total": 200.0, "attempts_per_coroutine": [600] * 10},
+                "validity": {"ok": ok, "reasons": []},
+            }, f)
+        if marker:
+            open(os.path.join(rep_dir, f"INVALID-{marker}"), "w").close()
+        return rep_dir
+
+    def test_marker_overrides_probe_ok(self):
+        with tempfile.TemporaryDirectory() as t:
+            cell_dir = self._setup_cell(t)
+            self._write_rep(cell_dir, 0, ok=True, marker="ha-transition")
+            reps = load_cell_reps(cell_dir)
+            self.assertEqual(len(reps), 1)
+            self.assertFalse(reps[0]["validity"]["ok"])
+            self.assertTrue(any("ha-transition" in r for r in reps[0]["validity"]["reasons"]))
+
+    def test_no_marker_keeps_probe_ok(self):
+        with tempfile.TemporaryDirectory() as t:
+            cell_dir = self._setup_cell(t)
+            self._write_rep(cell_dir, 0, ok=True)
+            reps = load_cell_reps(cell_dir)
+            self.assertTrue(reps[0]["validity"]["ok"])
+
+    def test_missing_probe_json(self):
+        # Orchestrator died before probe ran or pull failed: synthesize invalid.
+        with tempfile.TemporaryDirectory() as t:
+            cell_dir = self._setup_cell(t)
+            os.makedirs(os.path.join(cell_dir, "rep_00"))
+            reps = load_cell_reps(cell_dir)
+            self.assertEqual(len(reps), 1)
+            self.assertFalse(reps[0]["validity"]["ok"])
+
+    def test_missing_probe_with_invalid_marker_keeps_marker(self):
+        # R2 HIGH 1 partial: when probe.json is missing AND there's an
+        # orchestrator INVALID-* marker (e.g. cwnd-not-settled), the
+        # marker reason must survive — otherwise we lose attribution.
+        with tempfile.TemporaryDirectory() as t:
+            cell_dir = self._setup_cell(t)
+            rep_dir = os.path.join(cell_dir, "rep_00")
+            os.makedirs(rep_dir)
+            open(os.path.join(rep_dir, "INVALID-cwnd-not-settled"), "w").close()
+            reps = load_cell_reps(cell_dir)
+            self.assertEqual(len(reps), 1)
+            reasons = reps[0]["validity"]["reasons"]
+            self.assertIn("no-probe-json", reasons)
+            self.assertTrue(any("cwnd-not-settled" in r for r in reasons))
+
+    def test_has_invalid_marker(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = os.path.join(t, "rep")
+            os.makedirs(d)
+            self.assertFalse(has_invalid_marker(d))
+            open(os.path.join(d, "INVALID-rg-state-flap"), "w").close()
+            self.assertTrue(has_invalid_marker(d))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -1,0 +1,168 @@
+"""Helper functions for the test-mouse-latency.sh orchestrator.
+
+Keeps complex logic out of shell heredocs (which get tangled with
+variable interpolation and quoting). Each function is invoked via
+`python3 mouse_latency_orchestrate.py <subcommand> ...`.
+
+Subcommands:
+- check-cwnd-settle: parse a (snapshot of) iperf3.txt, return 0 if
+  the last 3 [SUM] rows are within ±15 % AND ≥ 0.7 × shaper.
+- check-collapse: parse a final iperf3.txt, return 0 if any 3
+  consecutive [SUM] rows fell below 0.5 × shaper.
+- parse-cluster-state: read cluster-status text from stdin, print
+  one line per (rg, node, state) triple.
+- rg-state-flapped: read the rg-state-poll file, return 0 if any
+  triple drifted from the initial sample.
+"""
+
+import argparse
+import sys
+
+from cluster_status_parse import parse_cluster_status
+from iperf3_sum_parse import parse_sum_bps
+
+
+def _last_n_sum_bps(text: str, n: int) -> list:
+    out = []
+    for line in text.splitlines():
+        bps = parse_sum_bps(line)
+        if bps is not None:
+            out.append(bps)
+    return out[-n:]
+
+
+def cmd_check_cwnd_settle(args: argparse.Namespace) -> int:
+    """Exit 0 if cwnd is settled; non-zero otherwise."""
+    with open(args.iperf3_txt) as f:
+        text = f.read()
+    last3 = _last_n_sum_bps(text, 3)
+    if len(last3) < 3:
+        return 1
+    mn, mx = min(last3), max(last3)
+    if mx > 0 and (mx - mn) > 0.15 * mx:
+        return 1
+    if mn < 0.7 * args.shaper_bps:
+        return 1
+    return 0
+
+
+def cmd_check_collapse(args: argparse.Namespace) -> int:
+    """Exit 0 if collapse detected within the probe window; 1 if not.
+
+    R5 HIGH: window must anchor on PROBE START, not "last N rows" —
+    iperf3 runs SETTLE_BUDGET + DURATION + SLACK seconds, so "last
+    DURATION rows" loses the first DURATION seconds of probe and
+    gains SLACK seconds of post-probe teardown. Take rows
+    [skip_front : skip_front + n_rows] from the per-second prefix
+    instead.
+    """
+    threshold = args.shaper_bps * 0.5
+    rows = []
+    with open(args.iperf3_txt) as f:
+        for line in f:
+            bps = parse_sum_bps(line)
+            if bps is not None:
+                rows.append(bps)
+    # iperf3 writes 1-2 trailing [SUM] summary lines (sender +
+    # receiver) covering the full run. Drop the trailing rows whose
+    # cumulative behavior would mask per-second interval semantics —
+    # we use --n-rows from a known offset instead, so summary rows
+    # only intrude if the run finished early.
+    if args.n_rows > 0:
+        start = max(0, args.skip_front)
+        end = start + args.n_rows
+        rows = rows[start:end]
+    streak = 0
+    for bps in rows:
+        if bps < threshold:
+            streak += 1
+            if streak >= 3:
+                return 0
+        else:
+            streak = 0
+    return 1
+
+
+def cmd_parse_cluster_state(args: argparse.Namespace) -> int:
+    """Read cluster-status text from stdin, emit one line per triple."""
+    text = sys.stdin.read()
+    triples = parse_cluster_status(text)
+    ts_ms = args.ts_ms
+    for rg, node, state in triples:
+        print(f"{ts_ms}\trg={rg}\tnode={node}\tstate={state}")
+    return 0
+
+
+def cmd_rg_state_flapped(args: argparse.Namespace) -> int:
+    """Exit 0 if state drifted from initial; 1 if stable; 2 if no data.
+
+    R1 HIGH 5: an empty poll file means the orchestrator never got a
+    successful cli sample. Returning 1 ("stable") would silently pass
+    a contaminated rep. Return 2 instead so the orchestrator can
+    invalidate.
+    """
+    by_ts: "dict[str, set]" = {}
+    with open(args.poll_file) as f:
+        for line in f:
+            parts = line.strip().split("\t")
+            if len(parts) != 4:
+                continue
+            ts, rg_part, node_part, state_part = parts
+            triple = (rg_part, node_part, state_part)
+            by_ts.setdefault(ts, set()).add(triple)
+    if not by_ts:
+        print("no RG poll samples", file=sys.stderr)
+        return 2
+    samples = sorted(by_ts.items())
+    initial = samples[0][1]
+    if not initial:
+        # First sample collected an empty triple set (cli succeeded
+        # but parser found nothing). Treat as undetermined.
+        print("first RG sample is empty", file=sys.stderr)
+        return 2
+    for ts, triples in samples[1:]:
+        if triples != initial:
+            for t in triples - initial:
+                print(f"DRIFT at {ts}: appeared {t}")
+            for t in initial - triples:
+                print(f"DRIFT at {ts}: disappeared {t}")
+            return 0
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p1 = sub.add_parser("check-cwnd-settle")
+    p1.add_argument("iperf3_txt")
+    p1.add_argument("shaper_bps", type=int)
+    p1.set_defaults(func=cmd_check_cwnd_settle)
+
+    p2 = sub.add_parser("check-collapse")
+    p2.add_argument("iperf3_txt")
+    p2.add_argument("shaper_bps", type=int)
+    p2.add_argument(
+        "--n-rows", type=int, default=0,
+        help="Scan N [SUM] rows from --skip-front. 0 = full log.",
+    )
+    p2.add_argument(
+        "--skip-front", type=int, default=0,
+        help="Skip this many leading [SUM] rows (settle warmup) before scanning.",
+    )
+    p2.set_defaults(func=cmd_check_collapse)
+
+    p3 = sub.add_parser("parse-cluster-state")
+    p3.add_argument("ts_ms")
+    p3.set_defaults(func=cmd_parse_cluster_state)
+
+    p4 = sub.add_parser("rg-state-flapped")
+    p4.add_argument("poll_file")
+    p4.set_defaults(func=cmd_rg_state_flapped)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -1,0 +1,191 @@
+import os
+import tempfile
+import unittest
+
+import mouse_latency_orchestrate as orch
+
+
+def _write(tmpdir: str, name: str, content: str) -> str:
+    path = os.path.join(tmpdir, name)
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+class CheckCwndSettleTests(unittest.TestCase):
+    def _make_args(self, txt_path: str, shaper: int):
+        class A: pass
+        a = A()
+        a.iperf3_txt = txt_path
+        a.shaper_bps = shaper
+        return a
+
+    def test_settled(self):
+        with tempfile.TemporaryDirectory() as t:
+            txt = _write(t, "iperf3.txt", """\
+[SUM]   1.00-2.00   sec  118 MBytes  990 Mbits/sec
+[SUM]   2.00-3.00   sec  118 MBytes  995 Mbits/sec
+[SUM]   3.00-4.00   sec  118 MBytes  988 Mbits/sec
+""")
+            self.assertEqual(orch.cmd_check_cwnd_settle(self._make_args(txt, 1_000_000_000)), 0)
+
+    def test_not_settled_too_low(self):
+        with tempfile.TemporaryDirectory() as t:
+            txt = _write(t, "iperf3.txt", """\
+[SUM]   1.00-2.00   sec  118 MBytes  500 Mbits/sec
+[SUM]   2.00-3.00   sec  118 MBytes  600 Mbits/sec
+[SUM]   3.00-4.00   sec  118 MBytes  650 Mbits/sec
+""")
+            self.assertEqual(orch.cmd_check_cwnd_settle(self._make_args(txt, 1_000_000_000)), 1)
+
+    def test_not_settled_unstable(self):
+        with tempfile.TemporaryDirectory() as t:
+            txt = _write(t, "iperf3.txt", """\
+[SUM]   1.00-2.00   sec  118 MBytes  900 Mbits/sec
+[SUM]   2.00-3.00   sec  118 MBytes  990 Mbits/sec
+[SUM]   3.00-4.00   sec  118 MBytes  700 Mbits/sec
+""")
+            self.assertEqual(orch.cmd_check_cwnd_settle(self._make_args(txt, 1_000_000_000)), 1)
+
+    def test_no_sum_rows_yet(self):
+        with tempfile.TemporaryDirectory() as t:
+            txt = _write(t, "iperf3.txt", "Connecting to host 172.16.80.200, port 5201\n")
+            self.assertEqual(orch.cmd_check_cwnd_settle(self._make_args(txt, 1_000_000_000)), 1)
+
+
+class CheckCollapseTests(unittest.TestCase):
+    def _make_args(self, txt_path: str, shaper: int, n_rows: int = 0, skip_front: int = 0):
+        class A: pass
+        a = A()
+        a.iperf3_txt = txt_path
+        a.shaper_bps = shaper
+        a.n_rows = n_rows
+        a.skip_front = skip_front
+        return a
+
+    def test_settle_window_drops_ignored_with_skip_front(self):
+        # R5 HIGH: the window must anchor on probe-start (skip_front=20)
+        # not "last DURATION rows" (which would lose probe-start
+        # collapse and include post-probe slack).
+        with tempfile.TemporaryDirectory() as t:
+            lines = []
+            for i in range(20):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  20 MBytes  100 Mbits/sec")
+            for i in range(20, 80):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            for i in range(80, 90):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  20 MBytes  100 Mbits/sec")
+            txt = _write(t, "iperf3.txt", "\n".join(lines) + "\n")
+            # skip_front=20, n_rows=60 (probe window only) → no collapse
+            self.assertEqual(
+                orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000, 60, 20)), 1
+            )
+            # skip_front=0 (full log) → collapse from warmup
+            self.assertEqual(
+                orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000, 0, 0)), 0
+            )
+
+    def test_collapse_at_probe_start_caught_with_skip_front(self):
+        # Settle is steady, but a 3-row dip happens RIGHT at probe start.
+        # The R5 fix must not lose this.
+        with tempfile.TemporaryDirectory() as t:
+            lines = []
+            for i in range(20):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            for i in range(20, 23):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  20 MBytes  100 Mbits/sec")
+            for i in range(23, 80):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            for i in range(80, 90):
+                lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            txt = _write(t, "iperf3.txt", "\n".join(lines) + "\n")
+            self.assertEqual(
+                orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000, 60, 20)), 0
+            )
+
+    def test_steady_no_collapse(self):
+        with tempfile.TemporaryDirectory() as t:
+            lines = [f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec" for i in range(60)]
+            txt = _write(t, "iperf3.txt", "\n".join(lines) + "\n")
+            # Collapse detection returns 0 IF collapsed; 1 IF not.
+            self.assertEqual(orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000)), 1)
+
+    def test_3_consecutive_drops_collapse(self):
+        with tempfile.TemporaryDirectory() as t:
+            lines = []
+            for i in range(60):
+                if 30 <= i <= 32:
+                    lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  20 MBytes  100 Mbits/sec")
+                else:
+                    lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            txt = _write(t, "iperf3.txt", "\n".join(lines) + "\n")
+            self.assertEqual(orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000)), 0)
+
+    def test_2_drops_no_collapse(self):
+        with tempfile.TemporaryDirectory() as t:
+            lines = []
+            for i in range(60):
+                if 30 <= i <= 31:
+                    lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  20 MBytes  100 Mbits/sec")
+                else:
+                    lines.append(f"[SUM]   {i}.00-{i+1}.00   sec  118 MBytes  990 Mbits/sec")
+            txt = _write(t, "iperf3.txt", "\n".join(lines) + "\n")
+            self.assertEqual(orch.cmd_check_collapse(self._make_args(txt, 1_000_000_000)), 1)
+
+
+class RGStateFlappedTests(unittest.TestCase):
+    def _make_args(self, path: str):
+        class A: pass
+        a = A()
+        a.poll_file = path
+        return a
+
+    def test_stable(self):
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "1000\trg=1\tnode=1\tstate=secondary",
+                "2000\trg=1\tnode=0\tstate=primary",
+                "2000\trg=1\tnode=1\tstate=secondary",
+                "3000\trg=1\tnode=0\tstate=primary",
+                "3000\trg=1\tnode=1\tstate=secondary",
+            ]) + "\n"
+            poll = _write(t, "rg.txt", content)
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 1)
+
+    def test_flap_detected(self):
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "1000\trg=1\tnode=1\tstate=secondary",
+                "2000\trg=1\tnode=0\tstate=secondary",
+                "2000\trg=1\tnode=1\tstate=primary",
+            ]) + "\n"
+            poll = _write(t, "rg.txt", content)
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 0)
+
+    def test_failover_failback_returns_to_initial(self):
+        # 3 samples: initial → flapped → back to initial. ANY drift
+        # invalidates, even if the end matches the start.
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "1000\trg=1\tnode=1\tstate=secondary",
+                "2000\trg=1\tnode=0\tstate=secondary",
+                "2000\trg=1\tnode=1\tstate=primary",
+                "3000\trg=1\tnode=0\tstate=primary",
+                "3000\trg=1\tnode=1\tstate=secondary",
+            ]) + "\n"
+            poll = _write(t, "rg.txt", content)
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 0)
+
+    def test_empty_poll_file_returns_2(self):
+        # R1 HIGH 5: empty poll file is "no data", not "stable" — caller
+        # must invalidate, not pass.
+        with tempfile.TemporaryDirectory() as t:
+            poll = _write(t, "rg.txt", "")
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -7,18 +7,20 @@ per-coroutine attempt counts, and a validity verdict.
 
 Validity model (plan §4.2):
 - error_rate < 0.01.
-- min(attempts_per_coroutine) >= 0.5 × median(attempts).
-- M >= 10: total attempts >= 5000.
-- M == 1: total attempts >= 500.
+- min(attempts_per_coroutine) >= 0.5 × median(attempts) (only when M >= 2).
+- Min-attempts floor:
+    - M == 1:  total attempts >= 500.
+    - 2 <= M < 10:  total attempts >= 1000 (intermediate-concurrency
+      cells are not in the matrix; the 1000 floor is a defensive default
+      so a manual smoke run at e.g. M=5 still has a meaningful gate).
+    - M >= 10: total attempts >= 5000.
 """
 
 import argparse
 import asyncio
 import json
 import os
-import random
 import statistics
-import struct
 import sys
 import time
 from typing import List

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -1,0 +1,238 @@
+"""Mouse-latency probe driver — closed-loop TCP echo probes.
+
+Spawns M asyncio coroutines, each looping connect → send → recv-echo →
+close until --duration expires. No per-iteration sleep (closed-loop
+semantics; see plan §4.1). Writes a JSON file with histogram, percentiles,
+per-coroutine attempt counts, and a validity verdict.
+
+Validity model (plan §4.2):
+- error_rate < 0.01.
+- min(attempts_per_coroutine) >= 0.5 × median(attempts).
+- M >= 10: total attempts >= 5000.
+- M == 1: total attempts >= 500.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import statistics
+import struct
+import sys
+import time
+from typing import List
+
+
+# Histogram bucket upper bounds in microseconds (plan §4.3).
+HISTOGRAM_BUCKETS_US = [
+    10, 20, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 100000,
+]
+
+
+async def _run_probe_coro(
+    target: str,
+    port: int,
+    payload_bytes: int,
+    deadline: float,
+    rtts_us: List[int],
+    attempt_counter: List[int],
+    error_counter: List[int],
+) -> None:
+    """One coroutine: closed-loop probe loop until deadline."""
+    while time.monotonic() < deadline:
+        attempt_counter[0] += 1
+        payload = os.urandom(payload_bytes)
+        t0 = time.monotonic_ns()
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(target, port),
+                timeout=5.0,
+            )
+            try:
+                writer.write(payload)
+                await writer.drain()
+                data = await asyncio.wait_for(
+                    reader.readexactly(payload_bytes),
+                    timeout=5.0,
+                )
+                if data != payload:
+                    error_counter[0] += 1
+                    continue
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+        except (
+            asyncio.TimeoutError,
+            ConnectionRefusedError,
+            ConnectionResetError,
+            BrokenPipeError,
+            asyncio.IncompleteReadError,
+            OSError,
+        ):
+            error_counter[0] += 1
+            continue
+        t1 = time.monotonic_ns()
+        rtts_us.append((t1 - t0) // 1000)
+
+
+def _compute_histogram(rtts_us: List[int]) -> List[int]:
+    counts = [0] * len(HISTOGRAM_BUCKETS_US)
+    for rtt in rtts_us:
+        placed = False
+        for i, upper in enumerate(HISTOGRAM_BUCKETS_US):
+            if rtt <= upper:
+                counts[i] += 1
+                placed = True
+                break
+        if not placed:
+            counts[-1] += 1  # > 100 ms goes into the top bucket.
+    return counts
+
+
+def _compute_percentiles(rtts_us: List[int]) -> dict:
+    """Compute p50/p95/p99 + IQR via stdlib `statistics.quantiles`.
+
+    R1 MED 3: the plan calls for `statistics.quantiles` output, so
+    the implementation and the unit tests share an estimator. With
+    n=100 cut points (method="inclusive") we get p50=q[49], p95=q[94],
+    p99=q[98] (the 99 cut points between 100 quantiles, zero-indexed).
+    """
+    if not rtts_us:
+        return {
+            "p50": None, "p95": None, "p99": None,
+            "min": None, "max": None, "mean": None, "iqr": None,
+        }
+    s = sorted(rtts_us)
+    if len(s) < 2:
+        v = s[0]
+        return {
+            "p50": v, "p95": v, "p99": v,
+            "min": v, "max": v, "mean": v, "iqr": 0,
+        }
+    cuts_100 = statistics.quantiles(s, n=100, method="inclusive")
+    cuts_4 = statistics.quantiles(s, n=4, method="inclusive")
+    return {
+        "p50": int(round(cuts_100[49])),
+        "p95": int(round(cuts_100[94])),
+        "p99": int(round(cuts_100[98])),
+        "min": s[0],
+        "max": s[-1],
+        "mean": int(statistics.fmean(s)),
+        "iqr": int(round(cuts_4[2] - cuts_4[0])),
+    }
+
+
+def compute_validity(
+    concurrency: int,
+    attempts_per_coroutine: List[int],
+    completed: int,
+    errors: int,
+) -> dict:
+    """Apply the §4.2 validity gates. Pure function — easy to unit-test."""
+    reasons: List[str] = []
+    attempted = sum(attempts_per_coroutine)
+    error_rate = errors / max(1, attempted)
+    if error_rate >= 0.01:
+        reasons.append(f"error_rate={error_rate:.4f} >= 0.01")
+    if concurrency >= 2:
+        median_a = statistics.median(attempts_per_coroutine) if attempts_per_coroutine else 0
+        min_a = min(attempts_per_coroutine) if attempts_per_coroutine else 0
+        if median_a > 0 and min_a < 0.5 * median_a:
+            reasons.append(
+                f"degenerate-coroutine: min={min_a} < 0.5 * median={median_a}"
+            )
+    floor = 5000 if concurrency >= 10 else 500 if concurrency == 1 else 1000
+    if attempted < floor:
+        reasons.append(f"min-attempts: attempted={attempted} < floor={floor}")
+    return {"ok": not reasons, "reasons": reasons}
+
+
+async def _run(args: argparse.Namespace) -> dict:
+    rtts_per_coro: List[List[int]] = [[] for _ in range(args.concurrency)]
+    attempts_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
+    errors_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
+    deadline = time.monotonic() + args.duration
+    coros = [
+        _run_probe_coro(
+            args.target, args.port, args.payload_bytes, deadline,
+            rtts_per_coro[i], attempts_per_coro[i], errors_per_coro[i],
+        )
+        for i in range(args.concurrency)
+    ]
+    await asyncio.gather(*coros)
+
+    rtts_us: List[int] = []
+    for sublist in rtts_per_coro:
+        rtts_us.extend(sublist)
+    attempts = [c[0] for c in attempts_per_coro]
+    errors = sum(c[0] for c in errors_per_coro)
+
+    completed = len(rtts_us)
+    attempted = sum(attempts)
+    achieved_rps_total = completed / max(0.001, args.duration)
+
+    # R1 MED 4: report the distribution of achieved RPS across
+    # coroutines so closed-loop overload diagnosis can distinguish
+    # client-side saturation (uniform low RPS) from probe-path
+    # asymmetry (one slow coroutine).
+    per_coro_rps = [a / max(0.001, args.duration) for a in attempts]
+    if len(per_coro_rps) >= 2:
+        cuts4 = statistics.quantiles(per_coro_rps, n=4, method="inclusive")
+        per_coro_iqr = cuts4[2] - cuts4[0]
+        per_coro_median = statistics.median(per_coro_rps)
+    elif per_coro_rps:
+        per_coro_iqr = 0.0
+        per_coro_median = per_coro_rps[0]
+    else:
+        per_coro_iqr = 0.0
+        per_coro_median = 0.0
+
+    return {
+        "config": {
+            "target": args.target, "port": args.port,
+            "concurrency": args.concurrency,
+            "duration_s": args.duration,
+            "payload_bytes": args.payload_bytes,
+        },
+        "totals": {
+            "attempted": attempted,
+            "completed": completed,
+            "errors": errors,
+            "error_rate": errors / max(1, attempted),
+            "attempts_per_coroutine": attempts,
+            "achieved_rps_total": achieved_rps_total,
+            "achieved_rps_per_coroutine_median": per_coro_median,
+            "achieved_rps_per_coroutine_iqr": per_coro_iqr,
+        },
+        "rtt_us": _compute_percentiles(rtts_us),
+        "histogram_us": {
+            "buckets": HISTOGRAM_BUCKETS_US,
+            "counts": _compute_histogram(rtts_us),
+        },
+        "validity": compute_validity(
+            args.concurrency, attempts, completed, errors,
+        ),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--target", required=True)
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--concurrency", type=int, required=True)
+    p.add_argument("--duration", type=float, required=True)
+    p.add_argument("--payload-bytes", type=int, default=64)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+    result = asyncio.run(_run(args))
+    with open(args.out, "w") as f:
+        json.dump(result, f, indent=2)
+    return 0 if result["validity"]["ok"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -135,6 +135,18 @@ def compute_validity(
     """Apply the §4.2 validity gates. Pure function — easy to unit-test."""
     reasons: List[str] = []
     attempted = sum(attempts_per_coroutine)
+    # Internal consistency: each attempt is either completed or errored.
+    # Copilot R1: surface the bookkeeping invariant rather than letting
+    # `completed` go unused.
+    if completed > attempted:
+        reasons.append(
+            f"inconsistent-counts: completed={completed} > attempted={attempted}"
+        )
+    if completed + errors != attempted:
+        reasons.append(
+            "inconsistent-counts: "
+            f"completed+errors={completed + errors} != attempted={attempted}"
+        )
     error_rate = errors / max(1, attempted)
     if error_rate >= 0.01:
         reasons.append(f"error_rate={error_rate:.4f} >= 0.01")
@@ -175,18 +187,23 @@ async def _run(args: argparse.Namespace) -> dict:
     attempted = sum(attempts)
     achieved_rps_total = completed / max(0.001, args.duration)
 
-    # R1 MED 4: report the distribution of achieved RPS across
-    # coroutines so closed-loop overload diagnosis can distinguish
-    # client-side saturation (uniform low RPS) from probe-path
-    # asymmetry (one slow coroutine).
-    per_coro_rps = [a / max(0.001, args.duration) for a in attempts]
-    if len(per_coro_rps) >= 2:
-        cuts4 = statistics.quantiles(per_coro_rps, n=4, method="inclusive")
+    # R1 MED 4: report the distribution of achieved attempt-rate
+    # across coroutines so closed-loop overload diagnosis can
+    # distinguish client-side saturation (uniform low rate) from
+    # probe-path asymmetry (one slow coroutine).
+    #
+    # Copilot R1: name the field `attempts_per_second` so it doesn't
+    # get conflated with the completion-rate `achieved_rps_total`.
+    # An attempt counts whether or not the echo round-trip completed,
+    # so this is a workload-offered metric, not a completion metric.
+    per_coro_aps = [a / max(0.001, args.duration) for a in attempts]
+    if len(per_coro_aps) >= 2:
+        cuts4 = statistics.quantiles(per_coro_aps, n=4, method="inclusive")
         per_coro_iqr = cuts4[2] - cuts4[0]
-        per_coro_median = statistics.median(per_coro_rps)
-    elif per_coro_rps:
+        per_coro_median = statistics.median(per_coro_aps)
+    elif per_coro_aps:
         per_coro_iqr = 0.0
-        per_coro_median = per_coro_rps[0]
+        per_coro_median = per_coro_aps[0]
     else:
         per_coro_iqr = 0.0
         per_coro_median = 0.0
@@ -205,8 +222,8 @@ async def _run(args: argparse.Namespace) -> dict:
             "error_rate": errors / max(1, attempted),
             "attempts_per_coroutine": attempts,
             "achieved_rps_total": achieved_rps_total,
-            "achieved_rps_per_coroutine_median": per_coro_median,
-            "achieved_rps_per_coroutine_iqr": per_coro_iqr,
+            "attempts_per_second_per_coroutine_median": per_coro_median,
+            "attempts_per_second_per_coroutine_iqr": per_coro_iqr,
         },
         "rtt_us": _compute_percentiles(rtts_us),
         "histogram_us": {

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -41,22 +41,40 @@ async def _run_probe_coro(
     attempt_counter: List[int],
     error_counter: List[int],
 ) -> None:
-    """One coroutine: closed-loop probe loop until deadline."""
-    while time.monotonic() < deadline:
+    """One coroutine: closed-loop probe loop until deadline.
+
+    Copilot R3 #2: payload is generated once per coroutine — the
+    echo server is byte-stateless and we don't need uniqueness
+    across attempts; per-attempt `os.urandom` was avoidable CPU on
+    the source.
+
+    Copilot R3 #1: per-attempt connect/recv timeouts are bounded
+    by remaining time to the deadline so the probe runtime is
+    consistently ≤ duration + small constant, never the full 5s+5s
+    above deadline.
+    """
+    payload = os.urandom(payload_bytes)
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         attempt_counter[0] += 1
-        payload = os.urandom(payload_bytes)
         t0 = time.monotonic_ns()
         try:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(target, port),
-                timeout=5.0,
+                timeout=min(5.0, remaining),
             )
             try:
                 writer.write(payload)
                 await writer.drain()
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error_counter[0] += 1
+                    break
                 data = await asyncio.wait_for(
                     reader.readexactly(payload_bytes),
-                    timeout=5.0,
+                    timeout=min(5.0, remaining),
                 )
                 if data != payload:
                     error_counter[0] += 1

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -1,0 +1,128 @@
+import unittest
+
+from mouse_latency_probe import (
+    HISTOGRAM_BUCKETS_US,
+    _compute_histogram,
+    _compute_percentiles,
+    compute_validity,
+)
+
+
+class HistogramTests(unittest.TestCase):
+    def test_boundary_lower_bucket(self):
+        # Value exactly at boundary lands in that bucket (≤ upper).
+        counts = _compute_histogram([10])
+        self.assertEqual(counts[0], 1)
+        self.assertEqual(sum(counts), 1)
+
+    def test_boundary_upper_bucket(self):
+        counts = _compute_histogram([100000])
+        self.assertEqual(counts[-1], 1)
+
+    def test_overflow_goes_to_top_bucket(self):
+        counts = _compute_histogram([200000])
+        self.assertEqual(counts[-1], 1)
+
+    def test_distribution_across_buckets(self):
+        rtts = [5, 15, 30, 75, 200, 400, 800, 2000, 4000, 8000, 20000, 50000]
+        counts = _compute_histogram(rtts)
+        self.assertEqual(sum(counts), len(rtts))
+        # Each value falls in distinct bucket due to construction:
+        # 5≤10, 15≤20, 30≤50, 75≤100, 200≤250, 400≤500, 800≤1000,
+        # 2000≤2500, 4000≤5000, 8000≤10000, 20000≤25000, 50000≤100000
+        self.assertEqual(counts, [1] * len(HISTOGRAM_BUCKETS_US))
+
+    def test_empty(self):
+        counts = _compute_histogram([])
+        self.assertEqual(counts, [0] * len(HISTOGRAM_BUCKETS_US))
+
+
+class PercentileTests(unittest.TestCase):
+    def test_percentile_matches_statistics_quantiles(self):
+        # The implementation uses statistics.quantiles(n=100,
+        # method="inclusive"). Anchor the test to the same estimator
+        # so they cannot drift.
+        import statistics
+        rtts = list(range(1, 1001))  # 1..1000
+        p = _compute_percentiles(rtts)
+        cuts100 = statistics.quantiles(rtts, n=100, method="inclusive")
+        cuts4 = statistics.quantiles(rtts, n=4, method="inclusive")
+        self.assertEqual(p["p50"], int(round(cuts100[49])))
+        self.assertEqual(p["p95"], int(round(cuts100[94])))
+        self.assertEqual(p["p99"], int(round(cuts100[98])))
+        self.assertEqual(p["min"], 1)
+        self.assertEqual(p["max"], 1000)
+        self.assertEqual(p["iqr"], int(round(cuts4[2] - cuts4[0])))
+
+    def test_empty(self):
+        p = _compute_percentiles([])
+        self.assertIsNone(p["p99"])
+        self.assertIsNone(p["p50"])
+        self.assertIsNone(p["min"])
+
+    def test_single_sample(self):
+        p = _compute_percentiles([42])
+        self.assertEqual(p["p50"], 42)
+        self.assertEqual(p["p99"], 42)
+        self.assertEqual(p["iqr"], 0)
+
+
+class ValidityTests(unittest.TestCase):
+    def test_clean_high_concurrency(self):
+        attempts = [600] * 10  # 6000 total, M=10 floor=5000
+        v = compute_validity(10, attempts, completed=5970, errors=30)
+        self.assertTrue(v["ok"], v["reasons"])
+
+    def test_error_rate_too_high(self):
+        attempts = [600] * 10
+        # 200/6000 = 3.3% > 1%
+        v = compute_validity(10, attempts, completed=5800, errors=200)
+        self.assertFalse(v["ok"])
+        self.assertTrue(any("error_rate" in r for r in v["reasons"]))
+
+    def test_degenerate_coroutine_min_attempts(self):
+        # 9 coroutines did 600, one did 200; median=600, min=200 < 300
+        attempts = [600] * 9 + [200]
+        v = compute_validity(10, attempts, completed=5790, errors=10)
+        self.assertFalse(v["ok"])
+        self.assertTrue(any("degenerate-coroutine" in r for r in v["reasons"]))
+
+    def test_below_min_attempts_floor_m10(self):
+        attempts = [400] * 10  # 4000 total, M=10 floor=5000
+        v = compute_validity(10, attempts, completed=4000, errors=0)
+        self.assertFalse(v["ok"])
+        self.assertTrue(any("min-attempts" in r for r in v["reasons"]))
+
+    def test_min_attempts_floor_m1(self):
+        # M=1: floor=500
+        v_pass = compute_validity(1, [500], completed=500, errors=0)
+        self.assertTrue(v_pass["ok"], v_pass["reasons"])
+        v_fail = compute_validity(1, [499], completed=499, errors=0)
+        self.assertFalse(v_fail["ok"])
+        self.assertTrue(any("min-attempts" in r for r in v_fail["reasons"]))
+
+    def test_m1_skips_degenerate_check(self):
+        # Single coroutine cannot be "degenerate vs median" — gate
+        # is concurrency >= 2.
+        v = compute_validity(1, [600], completed=600, errors=0)
+        self.assertTrue(v["ok"])
+
+    def test_boundary_m10_exactly_5000(self):
+        attempts = [500] * 10  # exactly 5000
+        v = compute_validity(10, attempts, completed=5000, errors=0)
+        self.assertTrue(v["ok"], v["reasons"])
+
+    def test_boundary_m10_exactly_4999(self):
+        attempts = [500] * 9 + [499]
+        # min=499 vs median=500 → 499 >= 0.5*500=250 → not degenerate.
+        # Total=4999 < 5000 → fails min-attempts.
+        v = compute_validity(10, attempts, completed=4999, errors=0)
+        self.assertFalse(v["ok"])
+
+    def test_boundary_m1_exactly_500(self):
+        v = compute_validity(1, [500], completed=500, errors=0)
+        self.assertTrue(v["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -123,6 +123,19 @@ class ValidityTests(unittest.TestCase):
         v = compute_validity(1, [500], completed=500, errors=0)
         self.assertTrue(v["ok"])
 
+    def test_inconsistent_counts_completed_more_than_attempted(self):
+        # Copilot R1 #4: surface the bookkeeping invariant rather
+        # than letting completed go unused.
+        v = compute_validity(10, [600] * 10, completed=7000, errors=0)
+        self.assertFalse(v["ok"])
+        self.assertTrue(any("inconsistent-counts" in r for r in v["reasons"]))
+
+    def test_inconsistent_counts_completed_plus_errors_neq_attempted(self):
+        # 6000 attempts, 5500 completed, 100 errors → 5600 ≠ 6000
+        v = compute_validity(10, [600] * 10, completed=5500, errors=100)
+        self.assertFalse(v["ok"])
+        self.assertTrue(any("inconsistent-counts" in r for r in v["reasons"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -90,11 +90,15 @@ except Exception as e:
     sys.exit(0)
 rtt = d.get("rtt_us")
 totals = d.get("totals")
-validity = d.get("validity") or {}
+validity = d.get("validity")
 if not isinstance(rtt, dict):
     print("FAIL missing-field=rtt_us"); sys.exit(0)
 if not isinstance(totals, dict):
     print("FAIL missing-field=totals"); sys.exit(0)
+# Codex R9: validity may be missing or wrong-type from schema drift;
+# coerce to dict so the .get() calls below cannot stack-trace.
+if not isinstance(validity, dict):
+    validity = {}
 p = rtt.get("p99")
 err = totals.get("error_rate")
 v = validity.get("ok", False)

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Run the full 12-cell #905 mouse-latency matrix.
+#
+# Usage: test-mouse-latency-matrix.sh <out_root>
+#
+# 12 cells: N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}.
+# Per cell: 10 reps baseline, auto-extend to 15 if INVALID rate > 30%
+# in the first 10. Cell stops at 10 valid reps OR 15 total, whichever
+# is first.
+#
+# Cells run in PASS-gate-relevant order so a wall-budget truncation
+# degrades gracefully:
+#   1. (0, 10)   ← idle baseline of the gate
+#   2. (128, 10) ← loaded measurement of the gate
+#   then (8, 10), (32, 10), and the rest of the matrix.
+#
+# Run echo-server preflight first (plan §4.6); abort if it fails.
+#
+# Total wall budget cap: 6 hours (plan §4.7).
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <out_root>" >&2
+    exit 1
+fi
+
+OUT_ROOT="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DURATION=60          # per-rep probe seconds
+WALL_CAP=$((6*3600)) # seconds, plan §4.7
+
+mkdir -p "$OUT_ROOT"
+
+# Prioritized cell order: gate cells first, then remaining M=10 cells,
+# then everything else.
+CELLS=(
+    "0 10"
+    "128 10"
+    "8 10"
+    "32 10"
+    "0 1"
+    "8 1"
+    "32 1"
+    "128 1"
+    "0 50"
+    "8 50"
+    "32 50"
+    "128 50"
+)
+
+start_t=$(date +%s)
+
+# ---- echo-server preflight (plan §4.6)
+PREFLIGHT_DIR="${OUT_ROOT}/preflight"
+mkdir -p "$PREFLIGHT_DIR"
+echo "Running echo-server preflight..."
+"${SCRIPT_DIR}/test-mouse-latency.sh" 0 1 60 "$PREFLIGHT_DIR" || true
+
+# R2 fresh MED 2: orchestrator INVALIDates by writing a marker file
+# and exiting 0; preflight must check the marker file too, not just
+# the orchestrator exit code.
+if compgen -G "${PREFLIGHT_DIR}/INVALID-*" > /dev/null 2>&1; then
+    echo "preflight invalidated; aborting matrix" >&2
+    ls "$PREFLIGHT_DIR" >&2
+    exit 1
+fi
+if [[ ! -f "$PREFLIGHT_DIR/probe.json" ]]; then
+    echo "preflight produced no probe.json; aborting" >&2
+    exit 1
+fi
+preflight=$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+p = d["rtt_us"]["p99"]
+err = d["totals"]["error_rate"]
+v = d.get("validity", {}).get("ok", False)
+reasons = d.get("validity", {}).get("reasons", [])
+# R3 MED: also gate on the probes own validity verdict (e.g.
+# min-attempts floor, degenerate-coroutine), not just p99/error_rate.
+if not v:
+    print(f"FAIL validity={reasons}")
+elif p is None or p >= 5000:
+    print(f"FAIL p99={p}")
+elif err >= 0.001:
+    print(f"FAIL err={err}")
+else:
+    print("OK")
+' "$PREFLIGHT_DIR/probe.json")
+if [[ "$preflight" != "OK" ]]; then
+    echo "preflight failed: $preflight" >&2
+    exit 1
+fi
+echo "preflight OK"
+
+rep_is_valid() {
+    # Combine: probe.json validity AND no INVALID-* marker file (the
+    # orchestrator writes those for HA transitions, RG flaps, elephant
+    # collapse, client saturation, etc.).
+    local rep_dir="$1"
+    if compgen -G "${rep_dir}/INVALID-*" > /dev/null 2>&1; then
+        return 1
+    fi
+    if [[ ! -f "${rep_dir}/probe.json" ]]; then
+        return 1
+    fi
+    python3 -c 'import json,sys; sys.exit(0 if json.load(open(sys.argv[1]))["validity"]["ok"] else 1)' \
+        "${rep_dir}/probe.json"
+}
+
+run_cell() {
+    local N="$1" M="$2"
+    local cell_dir="${OUT_ROOT}/cell_N${N}_M${M}"
+    mkdir -p "$cell_dir"
+    local valid=0
+    local total=0
+    local hard_cap=15  # plan §4.7: 15-rep ceiling
+    # Per plan §4.7: keep going until 10 valid OR 15 total. Both
+    # ordinary replacements (any INVALID rep) AND auto-extension
+    # (the >30% rule) draw from the same ceiling. R1 HIGH 2.
+    while [[ $total -lt $hard_cap && $valid -lt 10 ]]; do
+        # Wall budget guard.
+        local now=$(date +%s)
+        if [[ $((now - start_t)) -gt $WALL_CAP ]]; then
+            echo "wall-budget cap reached, stopping matrix" >&2
+            return 0
+        fi
+        local rep_dir="${cell_dir}/rep_$(printf '%02d' $total)"
+        mkdir -p "$rep_dir"
+        echo "  cell N=$N M=$M rep=$total ..."
+        "${SCRIPT_DIR}/test-mouse-latency.sh" "$N" "$M" "$DURATION" "$rep_dir" || true
+        if rep_is_valid "$rep_dir"; then
+            valid=$((valid + 1))
+        fi
+        total=$((total + 1))
+    done
+
+    echo "  cell N=$N M=$M done: $valid valid / $total total"
+}
+
+for cell in "${CELLS[@]}"; do
+    read -r N M <<< "$cell"
+    run_cell "$N" "$M"
+done
+
+echo "Matrix complete; running aggregator..."
+python3 "${SCRIPT_DIR}/mouse_latency_aggregate.py" \
+    --root "$OUT_ROOT" \
+    --out "${OUT_ROOT}/summary.json"

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -79,17 +79,35 @@ if [[ ! -f "$PREFLIGHT_DIR/probe.json" ]]; then
 fi
 preflight=$(python3 -c '
 import json, sys
-with open(sys.argv[1]) as f:
-    d = json.load(f)
-p = d["rtt_us"]["p99"]
-err = d["totals"]["error_rate"]
-v = d.get("validity", {}).get("ok", False)
-reasons = d.get("validity", {}).get("reasons", [])
-# R3 MED: also gate on the probes own validity verdict (e.g.
-# min-attempts floor, degenerate-coroutine), not just p99/error_rate.
+# Copilot R2 #4: defensive JSON parsing — partial writes or schema
+# drift should produce an actionable preflight FAIL line, not a
+# stack trace that aborts the matrix.
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+except Exception as e:
+    print(f"FAIL invalid-json={e}")
+    sys.exit(0)
+rtt = d.get("rtt_us")
+totals = d.get("totals")
+validity = d.get("validity") or {}
+if not isinstance(rtt, dict):
+    print("FAIL missing-field=rtt_us"); sys.exit(0)
+if not isinstance(totals, dict):
+    print("FAIL missing-field=totals"); sys.exit(0)
+p = rtt.get("p99")
+err = totals.get("error_rate")
+v = validity.get("ok", False)
+reasons = validity.get("reasons", [])
+# R3 MED: gate on the probes own validity verdict (min-attempts
+# floor, degenerate-coroutine, etc.), not just p99/error_rate.
 if not v:
     print(f"FAIL validity={reasons}")
-elif p is None or p >= 5000:
+elif p is None:
+    print("FAIL missing-field=rtt_us.p99")
+elif err is None:
+    print("FAIL missing-field=totals.error_rate")
+elif p >= 5000:
     print(f"FAIL p99={p}")
 elif err >= 0.001:
     print(f"FAIL err={err}")

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -135,9 +135,18 @@ rep_is_valid() {
     if [[ ! -f "${rep_dir}/probe.json" ]]; then
         return 1
     fi
-    python3 -c 'import json,sys; sys.exit(0 if json.load(open(sys.argv[1]))["validity"]["ok"] else 1)' \
-        "${rep_dir}/probe.json"
+    # Copilot R3 #4: defensive parse — malformed JSON / schema drift
+    # treated as invalid instead of stack-tracing into the matrix log.
+    python3 -c 'import json,sys
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+    sys.exit(0 if d["validity"]["ok"] else 1)
+except Exception:
+    sys.exit(1)' "${rep_dir}/probe.json"
 }
+
+WALL_CAP_HIT=0
 
 run_cell() {
     local N="$1" M="$2"
@@ -150,10 +159,14 @@ run_cell() {
     # ordinary replacements (any INVALID rep) AND auto-extension
     # (the >30% rule) draw from the same ceiling. R1 HIGH 2.
     while [[ $total -lt $hard_cap && $valid -lt 10 ]]; do
-        # Wall budget guard.
+        # Wall budget guard. Copilot R3 #3: signal the outer cell
+        # loop via WALL_CAP_HIT so it stops scheduling additional
+        # cells; previously `return 0` only exited run_cell and the
+        # outer loop kept iterating, hitting the cap on each cell.
         local now=$(date +%s)
         if [[ $((now - start_t)) -gt $WALL_CAP ]]; then
             echo "wall-budget cap reached, stopping matrix" >&2
+            WALL_CAP_HIT=1
             return 0
         fi
         local rep_dir="${cell_dir}/rep_$(printf '%02d' $total)"
@@ -172,6 +185,10 @@ run_cell() {
 for cell in "${CELLS[@]}"; do
     read -r N M <<< "$cell"
     run_cell "$N" "$M"
+    if [[ $WALL_CAP_HIT -eq 1 ]]; then
+        echo "wall-budget cap hit; remaining cells skipped" >&2
+        break
+    fi
 done
 
 echo "Matrix complete; running aggregator..."

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -4,9 +4,12 @@
 # Usage: test-mouse-latency-matrix.sh <out_root>
 #
 # 12 cells: N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}.
-# Per cell: 10 reps baseline, auto-extend to 15 if INVALID rate > 30%
-# in the first 10. Cell stops at 10 valid reps OR 15 total, whichever
-# is first.
+# Per cell: run up to 15 total reps as needed to reach 10 valid reps.
+# Cell stops at 10 valid reps OR 15 total, whichever is first.
+# (Replacements + extensions both draw from the 15-rep ceiling per
+# plan §4.7; the >30% conditional was simplified out — we always
+# allow up to 15 since the 30% trigger doesn't help if a cell lands
+# 1-3 invalid reps and the conditional path was a footgun.)
 #
 # Cells run in PASS-gate-relevant order so a wall-budget truncation
 # degrades gracefully:
@@ -55,6 +58,11 @@ start_t=$(date +%s)
 PREFLIGHT_DIR="${OUT_ROOT}/preflight"
 mkdir -p "$PREFLIGHT_DIR"
 echo "Running echo-server preflight..."
+# Use a 60s probe to satisfy the M=1 min-attempts floor of 500
+# (plan §4.2). The plan §4.6 originally specified 5s, but with the
+# probe driver's M=1 floor that would always INVALIDATE on
+# min-attempts. 60s costs us 60s once, vs. losing the validity
+# verdict entirely.
 "${SCRIPT_DIR}/test-mouse-latency.sh" 0 1 60 "$PREFLIGHT_DIR" || true
 
 # R2 fresh MED 2: orchestrator INVALIDates by writing a marker file

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -202,9 +202,17 @@ if [[ "$N" -gt 0 ]]; then
     # cwnd-settle gate. (Live tailing inside incus exec is hard to
     # plumb reliably; the budget is the gate.)
     sleep "$SETTLE_BUDGET"
+    set +e
     incus_run file pull \
         "${INCUS_REMOTE}:${SOURCE}/tmp/iperf3-${REP_TAG}.txt" \
-        "${OUT_DIR}/iperf3-settle.txt" 2>/dev/null || true
+        "${OUT_DIR}/iperf3-settle.txt" 2>/dev/null
+    pull_rc=$?
+    set -e
+    # Distinguish pull failure from a real cwnd-not-settled (Copilot R2 #1):
+    # the cwnd-settle gate fires only when we actually have iperf3 output.
+    if [[ $pull_rc -ne 0 || ! -s "${OUT_DIR}/iperf3-settle.txt" ]]; then
+        invalidate "iperf3-settle-pull-failed"
+    fi
     if ! python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
             check-cwnd-settle "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS"; then
         invalidate "cwnd-not-settled"
@@ -228,9 +236,25 @@ incus_exec "$SOURCE" python3 /tmp/mouse_latency_probe.py \
     --payload-bytes 64 --out "/tmp/probe-${REP_TAG}.json" \
     > "${OUT_DIR}/probe-stdout.log" 2>&1 || true
 
+set +e
 incus_run file pull \
     "${INCUS_REMOTE}:${SOURCE}/tmp/probe-${REP_TAG}.json" \
-    "${OUT_DIR}/probe.json" 2>/dev/null || true
+    "${OUT_DIR}/probe.json" 2>/dev/null
+probe_pull_rc=$?
+set -e
+# Catch a missing/empty/malformed probe.json early (Copilot R2 #2)
+# instead of letting the matrix wrapper silently treat the absence
+# as "validity false" and lose attribution.
+if [[ $probe_pull_rc -ne 0 ]]; then
+    invalidate "probe-pull-failed"
+fi
+if [[ ! -s "${OUT_DIR}/probe.json" ]]; then
+    invalidate "probe-missing"
+fi
+if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' \
+        "${OUT_DIR}/probe.json" 2>/dev/null; then
+    invalidate "probe-invalid-json"
+fi
 
 # ---- step 8: elephant stop + collapse check
 if [[ -n "${IPERF_PID:-}" ]]; then
@@ -302,7 +326,7 @@ for FW in "$PRIMARY" "$SECONDARY"; do
         invalidate "jc-cursor-missing-${FW}"
     fi
     set +e
-    matches=$(incus_exec "$FW" journalctl --after-cursor="$cursor" -u xpfd 2>"/tmp/jc-stderr-${REP_TAG}-${FW}")
+    matches=$(incus_exec "$FW" journalctl --after-cursor="$cursor" -u xpfd 2>"${OUT_DIR}/jc-stderr-${FW}.txt")
     jc_rc=$?
     set -e
     if [[ $jc_rc -ne 0 ]]; then

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -57,6 +57,7 @@ rm -f "${OUT_DIR}"/probe.json \
       "${OUT_DIR}"/iperf3-settle.txt \
       "${OUT_DIR}"/mpstat.txt \
       "${OUT_DIR}"/screen-pre.txt \
+      "${OUT_DIR}"/screen-pre-fw.txt \
       "${OUT_DIR}"/screen-post.txt \
       "${OUT_DIR}"/rg-state-poll.txt \
       "${OUT_DIR}"/rg-state-initial.txt \
@@ -148,8 +149,13 @@ incus_exec "$SOURCE" sh -c \
 incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
     "${INCUS_REMOTE}:${SOURCE}/tmp/mouse_latency_probe.py"
 
-# ---- step 1: CoS preflight (fixture-apply only, plan §3.3 + R4 MED 4)
-"${SCRIPT_DIR}/apply-cos-config.sh" "${INCUS_REMOTE}:${PRIMARY}" \
+# ---- step 1: CoS preflight (fixture-apply only, plan §3.3 + R4 MED 4).
+# Copilot R3 #5: apply-cos-config replicates from primary to peer, so
+# it must run against the current RG0 primary. If the cluster has
+# already failed over before the rep starts, hard-coding fw0 would
+# attempt to apply on the secondary.
+PRE_PRIMARY=$(current_primary)
+"${SCRIPT_DIR}/apply-cos-config.sh" "${INCUS_REMOTE}:${PRE_PRIMARY}" \
     > "${OUT_DIR}/cos-apply.log" 2>&1
 
 # ---- step 3: RG state polling at 1 Hz (plan §4.5 step 3)
@@ -185,8 +191,14 @@ for FW in "$PRIMARY" "$SECONDARY"; do
     echo "$cursor" > "${OUT_DIR}/jc-cursor-${FW}.txt"
 done
 
-# ---- step 4a: SYN-cookie counter snapshot (pre)
-incus_exec "$PRIMARY" cli -c "show security screen statistics zone wan" \
+# ---- step 4a: SYN-cookie counter snapshot (pre).
+# Copilot R3 #6: capture from the same node identity the post-run
+# comparison will follow (current primary at the time of the snapshot).
+# Mismatch between pre (always fw0) and post (current_primary) made the
+# screen_engaged delta meaningless when fw0 wasn't primary.
+SCREEN_PRE_FW=$(current_primary)
+echo "$SCREEN_PRE_FW" > "${OUT_DIR}/screen-pre-fw.txt"
+incus_exec "$SCREEN_PRE_FW" cli -c "show security screen statistics zone wan" \
     > "${OUT_DIR}/screen-pre.txt" 2>/dev/null || true
 
 # ---- step 5: elephant launch (if N > 0). Background; let it run for

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -36,7 +36,14 @@ SETTLE_BUDGET=20
 SLACK=10
 
 mkdir -p "$OUT_DIR"
-REP_TAG="${OUT_DIR##*/}"
+# Include the cell name in REP_TAG so per-rep temp files on the
+# remote source container don't collide across cells (e.g.
+# cell_N0_M10/rep_00 vs cell_N128_M10/rep_00 — without the cell
+# prefix, both write to /tmp/probe-rep_00.json and a failed pull
+# in the second cell silently picks up the first cell's data).
+# Codex R6 HIGH.
+CELL_DIR="$(basename "$(dirname "$OUT_DIR")")"
+REP_TAG="${CELL_DIR}_${OUT_DIR##*/}"
 
 # `incus_run` wraps incus calls so they work both inside and outside
 # the incus-admin group. Only the user's own group needs to differ —
@@ -101,6 +108,16 @@ cleanup() {
     [[ -n "${MPSTAT_PID:-}" ]] && kill "$MPSTAT_PID" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Defense in depth: remove any stale per-rep temp files on the
+# remote source before this rep starts (Codex R6 HIGH: without
+# REP_TAG including the cell name, two cells with the same rep
+# index would collide; even with that fix, a failed pull
+# previously left a stale file behind that the next reuse with the
+# same tag would inherit. Belt-and-suspenders.)
+incus_exec "$SOURCE" sh -c \
+    "rm -f /tmp/probe-${REP_TAG}.json /tmp/mpstat-${REP_TAG}.txt /tmp/iperf3-${REP_TAG}.txt" \
+    < /dev/null > /dev/null 2>&1 || true
 
 # Push helper scripts to the source container (probe driver runs there).
 incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
@@ -298,9 +315,31 @@ if ! diff -q "${OUT_DIR}/screen-pre.txt" "${OUT_DIR}/screen-post.txt" \
     screen_engaged="true"
 fi
 
-# ---- step 10: RG state poll review
+# ---- step 10: RG state poll review.
 kill "$RG_POLL_PID" 2>/dev/null || true
 wait "$RG_POLL_PID" 2>/dev/null || true
+
+# Final RG state one-shot, compared to the initial snapshot from
+# step 3 (Codex R6 MED: catches an in-window state change that
+# slipped through gaps in the 1Hz polling — even if individual
+# `cli` calls failed during the rep, the initial vs final pair
+# is two extra independent samples).
+incus_exec "$PRIMARY" cli -c "show chassis cluster status" \
+    > "${OUT_DIR}/rg-state-final.txt" 2>/dev/null || true
+
+initial_triples=$(python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+    parse-cluster-state 0 < "${OUT_DIR}/rg-state-initial.txt" 2>/dev/null \
+    | sort -u || true)
+final_triples=$(python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+    parse-cluster-state 0 < "${OUT_DIR}/rg-state-final.txt" 2>/dev/null \
+    | sort -u || true)
+if [[ -n "$initial_triples" && "$initial_triples" != "$final_triples" ]]; then
+    {
+        echo "initial vs final RG state mismatch:"
+        diff <(echo "$initial_triples") <(echo "$final_triples") || true
+    } > "${OUT_DIR}/rg-state-final-diff.log"
+    invalidate "rg-state-initial-vs-final"
+fi
 
 # Exit codes: 0 = drift detected (INVALID), 1 = stable, 2 = no data (INVALID).
 set +e

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -67,6 +67,7 @@ rm -f "${OUT_DIR}"/probe.json \
       "${OUT_DIR}"/manifest.json \
       "${OUT_DIR}"/cos-apply.log \
       "${OUT_DIR}"/jc-cursor-* \
+      "${OUT_DIR}"/jc-stderr-*.txt \
       "${OUT_DIR}"/INVALID-*
 
 # `incus_run` wraps incus calls so they work both inside and outside

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# Run one rep of the #905 mouse-latency cell.
+#
+# Usage: test-mouse-latency.sh <N> <M> <duration_s> <out_dir>
+#   N: elephant streams against 172.16.80.200:5201 (iperf-a)
+#   M: concurrent mouse coroutines against 172.16.80.200:7 (best-effort)
+#   duration_s: probe duration in seconds (≥ 60 recommended)
+#   out_dir: per-rep output directory (created if missing)
+#
+# See docs/pr/905-mouse-latency/plan.md for the full spec. Heavy
+# parsing logic lives in mouse_latency_orchestrate.py.
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 <N> <M> <duration_s> <out_dir>" >&2
+    exit 1
+fi
+
+N="$1"
+M="$2"
+DURATION="$3"
+OUT_DIR="$4"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Constants from plan §3.1.
+INCUS_REMOTE="loss"
+PRIMARY="xpf-userspace-fw0"
+SECONDARY="xpf-userspace-fw1"
+SOURCE="cluster-userspace-host"
+TARGET_V4="172.16.80.200"
+ELEPHANT_PORT=5201
+MOUSE_PORT=7
+SHAPER_BPS=$((1 * 1000 * 1000 * 1000))  # 1 Gb/s for iperf-a
+SETTLE_BUDGET=20
+SLACK=10
+
+mkdir -p "$OUT_DIR"
+REP_TAG="${OUT_DIR##*/}"
+
+# `incus_run` wraps incus calls so they work both inside and outside
+# the incus-admin group. Only the user's own group needs to differ —
+# if the user isn't already in incus-admin, `sg` runs the command
+# under that group via a single shell invocation.
+#
+# R1 MED 1: `sg ... -c "incus $*"` collapses argv across word
+# boundaries. We use `printf '%q '` to safely re-quote each arg.
+incus_run() {
+    if id -nG "$USER" 2>/dev/null | grep -qw incus-admin; then
+        incus "$@"
+        return
+    fi
+    if command -v sg >/dev/null && getent group incus-admin >/dev/null 2>&1; then
+        local quoted
+        quoted=$(printf '%q ' "$@")
+        sg incus-admin -c "incus ${quoted}"
+        return
+    fi
+    incus "$@"
+}
+
+incus_exec() {
+    local target="$1"; shift
+    incus_run exec "${INCUS_REMOTE}:${target}" -- "$@"
+}
+
+# Discover which node is currently primary (R1 MED 2: post-rep SYN
+# snapshot must follow primary if a transition happened in-rep).
+current_primary() {
+    local out
+    out=$(incus_exec "$PRIMARY" cli -c "show chassis cluster status" 2>/dev/null) || out=""
+    local node
+    node=$(printf '%s' "$out" | python3 -c '
+import sys
+sys.path.insert(0, "'"${SCRIPT_DIR}"'")
+from cluster_status_parse import parse_cluster_status
+for rg, n, st in parse_cluster_status(sys.stdin.read()):
+    if rg == 0 and st == "primary":
+        print(f"xpf-userspace-fw{n}")
+        break
+') || node=""
+    if [[ -z "$node" ]]; then
+        node="$PRIMARY"
+    fi
+    echo "$node"
+}
+
+invalidate() {
+    local reason="$1"
+    : > "${OUT_DIR}/INVALID-${reason}"
+    echo "REP INVALID: $reason" >&2
+    exit 0
+}
+
+cleanup() {
+    # Best-effort kill on early exit. The MPSTAT_PID is started AFTER
+    # the probe is launched, so on early INVALID exit (e.g. during
+    # cwnd-settle gate or step 4 cursor capture) it isn't running yet.
+    [[ -n "${IPERF_PID:-}" ]] && kill "$IPERF_PID" 2>/dev/null || true
+    [[ -n "${RG_POLL_PID:-}" ]] && kill "$RG_POLL_PID" 2>/dev/null || true
+    [[ -n "${MPSTAT_PID:-}" ]] && kill "$MPSTAT_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Push helper scripts to the source container (probe driver runs there).
+incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
+    "${INCUS_REMOTE}:${SOURCE}/tmp/mouse_latency_probe.py"
+
+# ---- step 1: CoS preflight (fixture-apply only, plan §3.3 + R4 MED 4)
+"${SCRIPT_DIR}/apply-cos-config.sh" "${INCUS_REMOTE}:${PRIMARY}" \
+    > "${OUT_DIR}/cos-apply.log" 2>&1
+
+# ---- step 3: RG state polling at 1 Hz (plan §4.5 step 3)
+RG_POLL_FILE="${OUT_DIR}/rg-state-poll.txt"
+: > "$RG_POLL_FILE"
+(
+    end_t=$(($(date +%s) + DURATION + SETTLE_BUDGET + SLACK + 5))
+    while [[ $(date +%s) -lt $end_t ]]; do
+        ts=$(date +%s%3N)
+        incus_exec "$PRIMARY" cli -c "show chassis cluster status" 2>/dev/null \
+            | python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+                  parse-cluster-state "$ts" \
+            >> "$RG_POLL_FILE" 2>/dev/null || true
+        sleep 1
+    done
+) &
+RG_POLL_PID=$!
+
+# Initial RG state snapshot (one-shot).
+incus_exec "$PRIMARY" cli -c "show chassis cluster status" \
+    > "${OUT_DIR}/rg-state-initial.txt" 2>/dev/null || true
+
+# ---- step 4: journalctl cursor capture on BOTH nodes (plan §4.5 step 4).
+# Empty cursors lose HA coverage on that node; fail-fast if capture fails.
+for FW in "$PRIMARY" "$SECONDARY"; do
+    cursor_out=$(incus_exec "$FW" journalctl --show-cursor -n 0 2>/dev/null \
+                 | tail -1) || cursor_out=""
+    cursor=$(echo "$cursor_out" | sed -n 's/.*cursor: //p')
+    if [[ -z "$cursor" ]]; then
+        echo "journalctl cursor capture failed on $FW" >&2
+        invalidate "jc-cursor-capture-${FW}"
+    fi
+    echo "$cursor" > "${OUT_DIR}/jc-cursor-${FW}.txt"
+done
+
+# ---- step 4a: SYN-cookie counter snapshot (pre)
+incus_exec "$PRIMARY" cli -c "show security screen statistics zone wan" \
+    > "${OUT_DIR}/screen-pre.txt" 2>/dev/null || true
+
+# ---- step 5: elephant launch (if N > 0). Background; let it run for
+# SETTLE_BUDGET + DURATION + SLACK seconds total.
+IPERF_DURATION=$((SETTLE_BUDGET + DURATION + SLACK))
+
+if [[ "$N" -gt 0 ]]; then
+    incus_exec "$SOURCE" sh -c \
+        "iperf3 -c ${TARGET_V4} -p ${ELEPHANT_PORT} -P ${N} -t ${IPERF_DURATION} -i 1 --forceflush > /tmp/iperf3-${REP_TAG}.txt 2>&1" \
+        < /dev/null > /dev/null 2>&1 &
+    IPERF_PID=$!
+
+    # Wait the SETTLE_BUDGET, then snapshot iperf3.txt and run the
+    # cwnd-settle gate. (Live tailing inside incus exec is hard to
+    # plumb reliably; the budget is the gate.)
+    sleep "$SETTLE_BUDGET"
+    incus_run file pull \
+        "${INCUS_REMOTE}:${SOURCE}/tmp/iperf3-${REP_TAG}.txt" \
+        "${OUT_DIR}/iperf3-settle.txt" 2>/dev/null || true
+    if ! python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+            check-cwnd-settle "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS"; then
+        invalidate "cwnd-not-settled"
+    fi
+fi
+
+# ---- step 2 (deferred to here): start mpstat over the probe window only.
+# R2 HIGH 6 fix had the killer-before-Average regression: starting mpstat
+# at top-of-rep means we kill it before its `Average:` row prints. Now
+# mpstat's count == DURATION, so it exits naturally just as the probe
+# does and writes the Average: line.
+incus_exec "$SOURCE" sh -c \
+    "mpstat 1 ${DURATION} > /tmp/mpstat-${REP_TAG}.txt 2>&1" \
+    < /dev/null > /dev/null 2>&1 &
+MPSTAT_PID=$!
+
+# ---- step 6: probe driver (M coroutines, closed-loop)
+incus_exec "$SOURCE" python3 /tmp/mouse_latency_probe.py \
+    --target "$TARGET_V4" --port "$MOUSE_PORT" \
+    --concurrency "$M" --duration "$DURATION" \
+    --payload-bytes 64 --out "/tmp/probe-${REP_TAG}.json" \
+    > "${OUT_DIR}/probe-stdout.log" 2>&1 || true
+
+incus_run file pull \
+    "${INCUS_REMOTE}:${SOURCE}/tmp/probe-${REP_TAG}.json" \
+    "${OUT_DIR}/probe.json" 2>/dev/null || true
+
+# ---- step 8: elephant stop + collapse check
+if [[ -n "${IPERF_PID:-}" ]]; then
+    # Wait for iperf3 to finish naturally (it has a -t budget that
+    # already includes settle + probe + slack). Capture exit status.
+    set +e
+    wait "$IPERF_PID"
+    iperf_rc=$?
+    set -e
+    incus_run file pull \
+        "${INCUS_REMOTE}:${SOURCE}/tmp/iperf3-${REP_TAG}.txt" \
+        "${OUT_DIR}/iperf3.txt" 2>/dev/null || true
+    if [[ $iperf_rc -ne 0 ]]; then
+        echo "iperf3 exited rc=$iperf_rc" >&2
+        invalidate "iperf3-rc${iperf_rc}"
+    fi
+    if [[ ! -s "${OUT_DIR}/iperf3.txt" ]]; then
+        invalidate "iperf3-no-output"
+    fi
+    # Scope collapse detection to the probe window (R5 HIGH): rows
+    # [SETTLE_BUDGET : SETTLE_BUDGET + DURATION] are the probe
+    # period. Earlier rows are settle warmup; later rows are slack
+    # post-probe. Anchoring on probe-start (--skip-front) avoids
+    # the off-by-window error where "last N rows" would lose the
+    # first DURATION seconds of probe and include SLACK seconds
+    # of post-probe noise.
+    set +e
+    python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+        check-collapse --skip-front "$SETTLE_BUDGET" --n-rows "$DURATION" \
+        "${OUT_DIR}/iperf3.txt" "$SHAPER_BPS"
+    collapse_rc=$?
+    set -e
+    case "$collapse_rc" in
+        0) invalidate "elephant-collapsed" ;;
+        1) : ;;  # not collapsed, ok
+        *) invalidate "collapse-check-error-rc${collapse_rc}" ;;
+    esac
+fi
+
+# ---- step 7: wait for mpstat to finish on its own count (so it
+# writes an `Average:` row), then parse client-busy result.
+wait "$MPSTAT_PID" 2>/dev/null || true
+incus_run file pull "${INCUS_REMOTE}:${SOURCE}/tmp/mpstat-${REP_TAG}.txt" \
+    "${OUT_DIR}/mpstat.txt" 2>/dev/null || true
+# Missing or unparseable mpstat output → INVALID rather than silent
+# pass (R2 HIGH 6 partial: v1 treated 0% as "fine"; that hid mpstat
+# crashes / pull failures).
+if [[ ! -s "${OUT_DIR}/mpstat.txt" ]]; then
+    invalidate "mpstat-missing"
+fi
+mpstat_busy=$(awk '/^Average:.*all/ { print 100 - $NF; exit }' \
+    "${OUT_DIR}/mpstat.txt")
+if [[ -z "$mpstat_busy" ]]; then
+    invalidate "mpstat-unparseable"
+fi
+if python3 -c "import sys; sys.exit(0 if float('${mpstat_busy}') > 80 else 1)"; then
+    invalidate "client-saturated"
+fi
+
+# ---- step 9: journalctl HA-transition diff (plan §4.5 step 9).
+HA_RE='cluster: primary transition|vrrp: transitioning to (MASTER|BACKUP)'
+ha_seen=0
+for FW in "$PRIMARY" "$SECONDARY"; do
+    cursor=$(cat "${OUT_DIR}/jc-cursor-${FW}.txt" 2>/dev/null || true)
+    if [[ -z "$cursor" ]]; then
+        # Cursor was captured non-empty in step 4 (or we'd have
+        # invalidated then). An empty cursor here means the file
+        # got clobbered — treat as harness failure.
+        invalidate "jc-cursor-missing-${FW}"
+    fi
+    set +e
+    matches=$(incus_exec "$FW" journalctl --after-cursor="$cursor" -u xpfd 2>"/tmp/jc-stderr-${REP_TAG}-${FW}")
+    jc_rc=$?
+    set -e
+    if [[ $jc_rc -ne 0 ]]; then
+        echo "journalctl on $FW failed (rc=$jc_rc)" >&2
+        invalidate "jc-error"
+    fi
+    set +e
+    hit=$(echo "$matches" | grep -iE "$HA_RE")
+    gr_rc=$?
+    set -e
+    if [[ $gr_rc -gt 1 ]]; then
+        invalidate "jc-grep-error"
+    fi
+    if [[ -n "$hit" ]]; then
+        ha_seen=1
+        {
+            echo "HA transition on $FW:"
+            echo "$hit"
+        } >> "${OUT_DIR}/ha-transitions.log"
+    fi
+done
+[[ $ha_seen -eq 1 ]] && invalidate "ha-transition"
+
+# ---- step 9a: SYN-cookie counter snapshot (post). Follow whichever
+# node is currently primary — if a transition happened in-window we
+# already invalidated above, but for the no-transition case we want
+# the screen counters from the same node we sampled in step 4a.
+post_primary=$(current_primary)
+incus_exec "$post_primary" cli -c "show security screen statistics zone wan" \
+    > "${OUT_DIR}/screen-post.txt" 2>/dev/null || true
+screen_engaged="false"
+if ! diff -q "${OUT_DIR}/screen-pre.txt" "${OUT_DIR}/screen-post.txt" \
+        > /dev/null 2>&1; then
+    screen_engaged="true"
+fi
+
+# ---- step 10: RG state poll review
+kill "$RG_POLL_PID" 2>/dev/null || true
+wait "$RG_POLL_PID" 2>/dev/null || true
+
+# Exit codes: 0 = drift detected (INVALID), 1 = stable, 2 = no data (INVALID).
+set +e
+python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+    rg-state-flapped "$RG_POLL_FILE" \
+    > "${OUT_DIR}/rg-state-flap.log" 2>&1
+rg_rc=$?
+set -e
+case "$rg_rc" in
+    0) invalidate "rg-state-flap" ;;
+    1) : ;;  # stable, ok
+    2) invalidate "rg-poll-no-data" ;;
+    *) invalidate "rg-poll-error-rc${rg_rc}" ;;
+esac
+
+# ---- step 11: manifest write
+cat > "${OUT_DIR}/manifest.json" <<EOF
+{
+  "N": $N,
+  "M": $M,
+  "duration_s": $DURATION,
+  "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "screen_engaged": $screen_engaged,
+  "ha_transition_seen": $ha_seen,
+  "mpstat_avg_busy": "${mpstat_busy:-0}"
+}
+EOF
+
+echo "REP OK"

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -45,6 +45,30 @@ mkdir -p "$OUT_DIR"
 CELL_DIR="$(basename "$(dirname "$OUT_DIR")")"
 REP_TAG="${CELL_DIR}_${OUT_DIR##*/}"
 
+# Local-side stale-artifact guard (Codex R7 HIGH): if OUT_DIR is
+# reused (rerun into an existing rep dir) and the new probe run
+# fails before overwriting probe.json, the previous run's data
+# would silently masquerade as the current rep's result. Wipe
+# the artifacts at rep start; INVALID-* markers from a prior run
+# are also cleared so the new rep's verdict is clean.
+rm -f "${OUT_DIR}"/probe.json \
+      "${OUT_DIR}"/probe-stdout.log \
+      "${OUT_DIR}"/iperf3.txt \
+      "${OUT_DIR}"/iperf3-settle.txt \
+      "${OUT_DIR}"/mpstat.txt \
+      "${OUT_DIR}"/screen-pre.txt \
+      "${OUT_DIR}"/screen-post.txt \
+      "${OUT_DIR}"/rg-state-poll.txt \
+      "${OUT_DIR}"/rg-state-initial.txt \
+      "${OUT_DIR}"/rg-state-final.txt \
+      "${OUT_DIR}"/rg-state-flap.log \
+      "${OUT_DIR}"/rg-state-final-diff.log \
+      "${OUT_DIR}"/ha-transitions.log \
+      "${OUT_DIR}"/manifest.json \
+      "${OUT_DIR}"/cos-apply.log \
+      "${OUT_DIR}"/jc-cursor-* \
+      "${OUT_DIR}"/INVALID-*
+
 # `incus_run` wraps incus calls so they work both inside and outside
 # the incus-admin group. Only the user's own group needs to differ —
 # if the user isn't already in incus-admin, `sg` runs the command


### PR DESCRIPTION
## Summary

Adds the measurement harness specified in `docs/pr/905-mouse-latency/plan.md` for characterizing mouse-latency tail under elephant load via the operator-provisioned echo server on 172.16.80.200:7. Closes the loop on the recommendation in `docs/pr/838-afd-lite/findings.md` (PR #904) — measurement first, algorithm work only if the data motivates it.

12 new files under `test/incus/`:

- **Parsers**: `cluster_status_parse.py` (RG state triples), `iperf3_sum_parse.py` (`[SUM]` rows), `mouse_latency_orchestrate.py` (cwnd-settle / collapse / RG-flap helpers).
- **Probe driver**: `mouse_latency_probe.py` — closed-loop M asyncio coroutines, histogram + `statistics.quantiles` percentiles + per-coroutine RPS distribution + validity verdict.
- **Aggregator**: `mouse_latency_aggregate.py` — per-cell median-by-p99 + decision verdict against the 2× threshold from #905; honours orchestrator `INVALID-*` marker files.
- **Orchestrator + matrix wrapper**: `test-mouse-latency.sh` runs one rep with the full validity pipeline (CoS preflight, mpstat scoped to the probe window, dual-node journalctl HA-transition diff, 1Hz RG state polling, post-snapshot following the current primary). `test-mouse-latency-matrix.sh` runs the 12-cell matrix with preflight gating + 10/15-rep accounting per plan §4.7.
- **Unit tests** for each Python module (68 tests, all passing via `python3 -m unittest discover -s test/incus/ -p '*_test.py'`).

Plan iterated through 7 Codex hostile review rounds (R7: PLAN-NEEDS-MINOR). Implementation iterated through 5 Codex hostile code-review rounds; each round's findings are addressed inline with file:line citations in commit messages and code comments referencing the round.

Decision threshold (per #905, plan §6.2 / §7.2): mouse p99 at (N=128, M=10, best-effort) ≤ 2 × idle baseline (N=0, M=10, best-effort). If PASS, fairness algorithm work parks indefinitely. If FAIL, the histogram tells us which mechanism — that motivates the next concrete algorithm issue.

## Validation lanes

Per `docs/engineering-style.md` §8:

- **Standalone deploy + ping**: N/A — this PR adds no daemon code.
- **iperf3 -P 16 baseline**: implicit in the elephant runs.
- **HA failover (`make test-failover`)**: N/A — harness is read-only on the dataplane. Per-rep journalctl + 1Hz RG-state polling protect against in-flight failover.
- **Smoke run on loss cluster**: NOT YET EXECUTED. The harness is committed for review; the smoke cell `./test/incus/test-mouse-latency.sh 0 1 60 /tmp/smoke` should run before the full 12-cell matrix. Findings document at `docs/pr/905-mouse-latency/findings.md` will be appended after the run.

## Test plan

- [ ] `python3 -m unittest discover -s test/incus/ -p '*_test.py'` (68 tests; all green at HEAD).
- [ ] Smoke run on `loss:cluster-userspace-host` for cell `(N=0, M=1, duration=60s)` — verify `validity.ok=true`, ≥500 probes completed, no orchestrator `INVALID-*` markers.
- [ ] Echo-server preflight succeeds (the matrix wrapper's first step).
- [ ] Full 12-cell matrix produces `summary.json` + `findings.md` with the decision verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)