### PR TITLE
#914 rate-aware per-flow cap on shared_exact admission

### DIFF
--- a/docs/pr/914-rate-aware-admission/plan.md
+++ b/docs/pr/914-rate-aware-admission/plan.md
@@ -1,0 +1,361 @@
+# Plan: #914 — Rate-aware per-flow cap on shared_exact
+
+Issue: #914
+Umbrella: #911 (validates against #929 same-class harness)
+
+## 1. Problem
+
+`cos_queue_flow_share_limit` at `tx.rs:4075-4104` disables the
+per-flow admission cap on `shared_exact` queues:
+
+```rust
+if queue.shared_exact {
+    return buffer_limit;  // hole: full buffer to any single flow
+}
+```
+
+This was deliberate (#785 retrospective Attempt A: enabling the
+fixed 24 KB cap on shared_exact regressed iperf-c throughput from
+22.3 → 16.3 Gbps because the cap was rate-unaware — multi-Gbps
+flows hit the cap and tail-dropped).
+
+But the absence of any cap means a single elephant in a
+shared_exact queue can occupy 100% of the queue's buffer,
+starving every other flow in the same class. This is the
+admission-side companion to #911's MQFQ ordering issue — even
+with perfect MQFQ vtime ordering (#913 just shipped), if one
+flow has 10 MB queued and others have 24 KB, MQFQ still has to
+drain the 10 MB before it can finish that flow's contribution.
+
+## 2. Goal
+
+Re-enable per-flow admission on `shared_exact` queues with a
+**rate-aware** cap that scales with the queue's configured
+`transmit_rate_bytes` and the prospective distinct-flow count.
+The cap should be:
+
+- High enough to fit one BDP at the queue's configured rate (so
+  TCP can build cwnd to line rate without tail-drops).
+- Low enough to prevent one flow from occupying >> 1/N of the
+  buffer when N flows are active.
+
+## 3. Approach
+
+### 3.1 Rate-aware cap formula
+
+Replace the unconditional `return buffer_limit` for shared_exact
+with:
+
+```rust
+if queue.shared_exact {
+    // Rate-aware per-flow cap. Goal: each active flow can hold
+    // approximately one BDP worth of bytes at the queue's
+    // configured rate, while preventing a single flow from
+    // exceeding `1/N + headroom` of the aggregate buffer.
+    //
+    // BDP at queue rate, ~10ms RTT (typical loss-cluster RTT
+    // post-shaper) = transmit_rate_bytes × 0.010.
+    // For 25 Gbps queue: 25e9/8 × 0.010 = ~31 MB BDP — way more
+    // than the queue's typical buffer_limit, so we cap at
+    // `buffer_limit / max(prospective_active, 1)` plus a 2x
+    // headroom factor for transient bursts.
+    let prospective = cos_queue_prospective_active_flows(queue, flow_bucket).max(1);
+    // Per-flow share = aggregate / N, with 2× headroom.
+    let fair_share = buffer_limit / prospective;
+    // BDP-equivalent floor: each flow gets at least enough buffer
+    // for one RTT at queue rate / N flows.
+    let bdp_floor_per_flow = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
+    return (fair_share * 2)
+        .max(bdp_floor_per_flow)
+        .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
+}
+```
+
+Where `bdp_floor_bytes` is a new helper:
+
+```rust
+const RTT_TARGET_NS: u64 = 10_000_000; // 10 ms
+
+#[inline]
+fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
+    // Per-flow BDP at queue's rate / active_flows ≈ rate * RTT / N.
+    // rate is bytes/sec; convert to bytes-per-RTT.
+    let per_flow_rate = transmit_rate_bytes / active_flows;
+    (per_flow_rate * RTT_TARGET_NS) / 1_000_000_000
+}
+```
+
+### 3.2 What this gives at typical configurations
+
+**(Codex R1 caught arithmetic disagreement: my earlier examples
+used unrealistic 1 MB buffer values. Recomputed below using the
+actual `cos_flow_aware_buffer_limit` output, which expands the
+base buffer by `prospective_active` flows.)**
+
+The `buffer_limit` argument passed to
+`cos_queue_flow_share_limit` is the OUTPUT of
+`cos_flow_aware_buffer_limit` (`tx.rs:4140-4153`). For
+non-`flow_fair` queues it returns `base` immediately; otherwise
+it returns
+
+`base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
+ .min(delay_cap.max(base))`
+
+where `base = queue.buffer_bytes.max(COS_MIN_BURST_BYTES)` (96 KB
+floor) and `delay_cap = transmit_rate_bytes × 5 ms`
+(`COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` = 5 ms, NOT 10 ms — the
+per-flow `RTT_TARGET_NS` in this PR is a separate constant).
+Shared_exact queues are flow_fair, so the early return is not
+in play here.
+
+The cluster CoS config (`test/incus/cos-iperf-config.set`) does
+NOT set `buffer-size`, so `queue.buffer_bytes = 0` and `base =
+COS_MIN_BURST_BYTES = 96 KB`. The effective `buffer_limit`
+therefore grows with prospective flows up to `delay_cap`:
+
+- **iperf-b** (10 Gbps): `delay_cap = 1.25 GB/s × 5 ms = 6.25 MB`.
+- **iperf-c** (25 Gbps): `delay_cap = 3.125 GB/s × 5 ms = 15.6 MB`.
+
+Re-running the formula `max(fair_share*2, bdp_floor)
+.clamp(MIN, buffer_limit)`. Note the **upper clamp to
+`buffer_limit`** is load-bearing at low N: the `bdp_floor` can
+exceed `buffer_limit` at low active-flow counts, in which case
+the per-flow cap is the buffer_limit itself (i.e. the proposed
+formula degenerates to "let one flow have the whole queue" — the
+admission-side hole this PR is partially closing only kicks in
+once there are enough flows to grow `buffer_limit` past BDP):
+
+For each case, `bdp_floor` uses the formula
+`(transmit_rate_bytes / active_flows) × RTT_TARGET_NS / 1e9`
+with `RTT_TARGET_NS = 10 ms`:
+
+- **iperf-b, N=8**: per-flow rate = 156 MB/s; bdp_floor = 156
+  MB/s × 10 ms = **1.56 MB**. `buffer_limit = max(96 KB, 8 × 24
+  KB).min(max(6.25 MB, 96 KB)) = 192 KB`. `fair_share = 192 KB /
+  8 = 24 KB`, `fair_share*2 = 48 KB`. `max(48 KB, 1.56 MB) =
+  1.56 MB`, clamp to `buffer_limit = 192 KB` → **per-flow cap =
+  192 KB** (= buffer_limit; one elephant can still fill the
+  queue). At low N the bdp_floor exceeds buffer_limit, so the
+  formula degenerates to today's behavior. This regime relies on
+  `cos_flow_aware_buffer_limit` itself to grow the buffer.
+
+- **iperf-b, N=128**: per-flow rate = 9.77 MB/s; bdp_floor =
+  9.77 MB/s × 10 ms = **97.7 KB**.
+  `buffer_limit = max(96 KB, 128 × 24 KB).min(6.25 MB) = 3.07 MB`.
+  `fair_share = 3.07 MB / 128 = 24 KB`, `fair_share*2 = 48 KB`.
+  `max(48 KB, 97.7 KB) = 97.7 KB`, clamp ≥ 24 KB and ≤ 3.07 MB →
+  **per-flow cap = 97.7 KB**. ~3.2% of the buffer per flow;
+  cwnd builds to 1 BDP, no tail-drops at line rate.
+
+- **iperf-c, N=12**: per-flow rate = 260 MB/s; bdp_floor = 260
+  MB/s × 10 ms = **2.6 MB**. `buffer_limit = max(96 KB, 12 × 24
+  KB).min(15.6 MB) = 288 KB`. `fair_share = 288 KB / 12 = 24
+  KB`, `fair_share*2 = 48 KB`. `max(48 KB, 2.6 MB) = 2.6 MB`,
+  clamp to `buffer_limit = 288 KB` → **per-flow cap = 288 KB**
+  (= buffer_limit; same degeneration as iperf-b N=8). The
+  pre-existing buffer_limit ceiling is the binding constraint.
+
+- **iperf-c, N=128**: per-flow rate = 24.4 MB/s; bdp_floor =
+  24.4 MB/s × 10 ms = **244 KB**. `buffer_limit = 3.07 MB`.
+  `fair_share = 24 KB`, `fair_share*2 = 48 KB`. `max(48 KB, 244
+  KB) = 244 KB`, clamp ≥ 24 KB and ≤ 3.07 MB → **per-flow cap =
+  244 KB**.
+
+The 22.3→16.3 Gbps regression in #785 Attempt A was caused by
+the FIXED 24 KB cap that ignored both `transmit_rate_bytes` and
+`active_flows`. The rate-aware formula above keeps the cap above
+per-flow BDP at moderate-to-high N (the cap actively splits the
+buffer), while at low N the cap clamps to `buffer_limit` (no
+change vs today). The transition point is where `bdp_floor`
+crosses below `buffer_limit`. For iperf-b that occurs at N where
+`(1.25 GB/s / N) × 10 ms < N × 24 KB` — i.e. roughly
+`N > sqrt(1.25e9 × 0.010 / 24000) ≈ 23` flows. Below ~23 flows
+on a 10G shared_exact queue, this PR is a no-op; above, it
+divides the buffer.
+
+(If the operator raises `buffer-size` so that `buffer_limit`
+grows above per-flow BDP at low N, the formula stops degenerating
+and the cap actively splits the buffer. Same-class iperf-b
+validation on the loss cluster relies on the N=128 case to show
+the cap is doing work; N=8 is the negative control and is
+expected to match today's mouse-latency p99.)
+
+### 3.2.1 Numerical-overflow safety (Codex R1)
+
+`bdp_floor_bytes(rate, active)` does
+`(rate / active) * RTT_NS / 1e9`. At `rate = 25e9 / 8 = 3.125e9
+B/s` and `active = 1`, intermediate `3.125e9 * 10e6 = 3.125e16`
+fits in u64. At `rate = 100e9 / 8 = 1.25e10` and `active = 1`,
+intermediate `1.25e10 * 10e6 = 1.25e17` fits in u64
+(u64::MAX ≈ 1.8e19). For 100G+ deployments with long RTT
+(50ms), `1.25e10 * 50e6 = 6.25e17` still fits. Use saturating
+multiply as belt-and-suspenders:
+
+```rust
+#[inline]
+fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
+    let per_flow_rate = transmit_rate_bytes / active_flows.max(1);
+    per_flow_rate
+        .saturating_mul(RTT_TARGET_NS)
+        / 1_000_000_000
+}
+```
+
+### 3.2.2 RTT_TARGET scoping (Codex R1)
+
+`RTT_TARGET_NS = 10_000_000` (10ms) is defensible for the
+loss-cluster and similar low-RTT deployments (project memory:
+~5-7ms post-shaper RTT on the cluster; 10ms gives 1.5× headroom).
+
+For **WAN-scoped deployments** (50ms+ RTT), the cap is too
+tight: at 10G shared_exact / N=8, BDP at 50ms is 7.8 MB. With
+no operator buffer-size override the buffer_limit ceiling is
+192 KB (per §3.2 above), so the cap clamps to 192 KB which is
+~40× below the WAN BDP. TCP cwnd would collapse. Operators
+running in WAN mode must raise `buffer-size` AND raise the
+`RTT_TARGET_NS` (or this PR's cap) before relying on
+shared_exact admission.
+
+Plan: scope this PR to the cluster RTT envelope. Document in
+the issue / commit message: `RTT_TARGET_NS` is hardcoded for
+cluster-scale RTT; WAN deployments need a separate follow-up
+that either makes RTT a queue-config attribute or uses an
+adaptive measurement (sketch: track per-queue p99 ack-RTT via
+sk_buff timestamping; use that to size BDP). Track as #930
+(file at impl time).
+
+### 3.3 Per-flow cap interaction with the active-flow count
+
+The existing `cos_queue_prospective_active_flows()` helper
+returns `max(active_count + 1, 1)` for the inserting flow.
+Rate-aware cap calls this with the new flow's bucket, so the
+denominator is correct.
+
+If `active_flows = 1` (only this flow), the cap effectively
+becomes `buffer_limit` (whole buffer) which is the same as
+today's behavior. As more flows arrive, the cap shrinks
+proportionally — exactly the fairness we want.
+
+### 3.4 Existing aggregate cap at site
+
+`cos_queue_admit()` (the actual admission gate) reads the
+returned share cap and tail-drops on overflow. No change needed
+to the gate site itself; just the helper.
+
+### 3.5 Configuration knob: NONE in this PR
+
+The 10ms RTT target is hardcoded. Tuning it per-queue is a
+follow-up if measurements show different rates need different
+targets. Project policy is no new config knobs without a
+demonstrated need (per `engineering-style.md`).
+
+## 4. What this is NOT
+
+- Not a change to the dequeue (MQFQ) path — that's #913 (shipped).
+- Not a change to non-`shared_exact` queues (already have rate-
+  unaware cap; not touching that today).
+- Not a fix to #927 (was_empty restore) or #926 (demote
+  inflation) — those are documented as preexisting.
+- Not a fix to #918 (flow cache) — that's stream A, parallel.
+
+## 5. Files touched
+
+- `userspace-dp/src/afxdp/tx.rs`:
+  - `cos_queue_flow_share_limit` — new `shared_exact` branch with
+    rate-aware formula.
+  - New helper `bdp_floor_bytes`.
+  - Add `RTT_TARGET_NS` constant.
+- New unit tests:
+  - `flow_share_limit_shared_exact_scales_with_rate`
+  - `flow_share_limit_shared_exact_caps_at_aggregate_for_single_flow`
+  - `flow_share_limit_shared_exact_protects_against_dominant_flow`
+  - `flow_share_limit_owner_local_exact_unchanged`
+
+## 6. Test strategy
+
+### 6.1 Unit
+
+`cargo build --release` clean. Unit tests above pass.
+
+### 6.2 Cluster validation
+
+Required: #929 same-class harness deployed.
+
+Run same-class N=8 M=10 + N=128 M=10 at iperf-b. Compare:
+
+- BEFORE #914 (baseline): one elephant can occupy ~entire buffer
+  at any N; mice tail-drop or queue behind.
+- AFTER #914 (per §3.2): N=8 cap = buffer_limit (192 KB) — same
+  as baseline, since `bdp_floor` exceeds `buffer_limit` at low N.
+  N=128 cap = 97.7 KB — each flow gets ~3.2% of the buffer; mice
+  share the rest.
+
+Expected: mouse p99 drops materially **at N=128 same-class
+iperf-b** (the binding case). At N=8, this PR alone is not
+expected to move the needle — that case is dominated by
+`cos_flow_aware_buffer_limit`'s ceiling. The plan §6.3 of #913
+explicitly named #914 as the next candidate if iperf-b
+same-class still FAILs after #913.
+
+### 6.3 Throughput sanity
+
+Critical regression check: iperf3 -P 12 -t 60 -p 5203 (iperf-c):
+
+- Pre-#914: ~22 Gbps (per project memory).
+- Post-#914: target ≥ 22 Gbps. If <22 Gbps, the rate-aware cap
+  is too tight; revisit headroom factor.
+
+### 6.4 Edge cases
+
+- **Single flow** (N=1): `prospective_active = 1`, so
+  `buffer_limit = max(96 KB, 24 KB) = 96 KB` (or operator-set
+  base). `fair_share = buffer_limit`, `fair_share*2 = 2 ×
+  buffer_limit`, `bdp_floor = rate × 10 ms` (typically ≫
+  buffer_limit), final clamp to `buffer_limit` → cap =
+  buffer_limit. No regression vs current.
+- **Low flow count (iperf-b N=8)**: per §3.2, cap = buffer_limit
+  = 192 KB. The `bdp_floor` (1.56 MB) exceeds `buffer_limit`, so
+  the formula degenerates to "let one flow hold the whole queue"
+  — same admission behavior as today. The cap only starts
+  splitting the buffer once `bdp_floor` drops below
+  `buffer_limit` (around N ≈ 23 flows on a 10 G queue).
+- **High flow count (iperf-b N=128)**: per §3.2, `buffer_limit =
+  3.07 MB`, `fair_share*2 = 48 KB`, `bdp_floor = 97.7 KB` →
+  `max = 97.7 KB`, clamp ≥ MIN_SHARE 24 KB and ≤ buffer_limit →
+  cap = 97.7 KB per flow. Fairness preserved; saturation drops
+  any flow exceeding its share.
+
+## 7. Risks
+
+- **TCP cwnd collapse if cap is too tight.** This is what #785
+  Attempt A hit. Mitigation: rate-aware formula sized to fit
+  per-flow BDP at queue rate. RTT target of 10ms is conservative
+  for the loss-cluster setup (post-shaper RTT measured at ~5-7
+  ms, so 10 ms is 1.5x headroom).
+- **Burst tail-drops.** Short bursts that exceed the per-flow
+  cap will tail-drop. Mitigated by the 2× fair-share headroom
+  AND the BDP-equivalent floor.
+- **Hot-path cost.** New cap formula = 1 division + 1 mul + 1
+  comparison vs the current 0-cost return. Total ~3 ns. Lookup
+  is on admission (per packet), not the throughput-critical
+  dequeue. Negligible.
+- **Static RTT assumption.** 10 ms hardcoded. If the deployment
+  has 50 ms RTT, the cap is too tight. Mitigation: make the cap
+  ENABLE be queue-config-conditional in a future PR if observed.
+
+## 8. Acceptance
+
+- [ ] Plan reviewed by Codex (hostile); PLAN-READY YES.
+- [ ] Plan reviewed by Gemini (HPC + networking-protocols
+      expertise on TCP cwnd / BDP); MERGE YES.
+- [ ] Implemented; `cargo build --release` clean.
+- [ ] Unit tests pass.
+- [ ] Codex hostile code review: MERGE YES.
+- [ ] Gemini adversarial code review: MERGE YES.
+- [ ] Cluster validation: same-class N=128 mouse p99 drops
+      materially (the binding case per §3.2); same-class N=8
+      mouse p99 ≈ baseline (negative control per §3.2;
+      `bdp_floor > buffer_limit` so cap clamps to today's
+      behavior); iperf-c throughput ≥ 22 Gbps.
+- [ ] PR opened, Copilot review addressed.
+- [ ] Merged.

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -4083,10 +4083,27 @@ fn cos_queue_prospective_active_flows(queue: &CoSQueueRuntime, flow_bucket: usiz
 /// post-shaper; 10 ms gives ~1.5× headroom.
 const RTT_TARGET_NS: u64 = 10_000_000;
 
+/// Burst headroom multiplier applied to the per-flow `fair_share`
+/// inside `cos_queue_flow_share_limit` for shared_exact queues. Set
+/// to 2 to admit short bursts up to 2× the steady-state per-flow
+/// allocation without tail-drops. Only binding in the moderate-N
+/// regime where it exceeds `bdp_floor` and is below `buffer_limit`;
+/// at high N `bdp_floor` dominates and at low N `buffer_limit` clamps.
+const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
+
 /// Per-flow BDP at the queue's rate divided across `active_flows`.
 /// Used as a floor in the shared_exact rate-aware cap — TCP cwnd
 /// must reach approximately one BDP for the per-flow rate to fit
 /// the queue's transmit rate without tail-drops.
+///
+/// Truncation: result truncates to 0 when `per_flow_rate <
+/// 1e9 / RTT_TARGET_NS = 100 bytes/sec`. At cluster-scale rates
+/// (≥ 1 Gbps queues with ≤ 1024 flows → ≥ 122 KB/s/flow) this is
+/// far from the truncation floor. On user-configured low-rate
+/// queues (e.g., 64 kbps WAN class with 100+ flows) the BDP floor
+/// silently degenerates to 0 and the `MIN_SHARE` (24 KB) clamp
+/// becomes the effective floor. Acceptable because the MIN_SHARE
+/// floor still keeps TCP recoverable via fast-retransmit.
 #[inline]
 fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
     let per_flow_rate = transmit_rate_bytes / active_flows.max(1);
@@ -4137,7 +4154,7 @@ fn cos_queue_flow_share_limit(
         let fair_share = buffer_limit / prospective.max(1);
         let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
         return fair_share
-            .saturating_mul(2)
+            .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
             .max(bdp)
             .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
     }

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -4151,7 +4151,13 @@ fn cos_queue_flow_share_limit(
     // 24 KB MIN floor matches TCP cwnd at 77 Mbps/flow.
     if queue.shared_exact {
         let prospective = cos_queue_prospective_active_flows(queue, flow_bucket);
-        let fair_share = buffer_limit / prospective.max(1);
+        // Copilot C.2: use `div_ceil` to match the legacy owner-local
+        // path below. Truncating division systematically undersizes
+        // the per-flow cap by up to (prospective - 1) bytes when
+        // `buffer_limit` is not divisible by `prospective`, increasing
+        // boundary-condition tail-drops. The legacy path picked
+        // div_ceil for that reason; shared_exact should follow.
+        let fair_share = buffer_limit.div_ceil(prospective.max(1));
         let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
         return fair_share
             .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
@@ -5556,11 +5562,17 @@ fn apply_cos_queue_flow_fair_promotion(
 /// fast-path struct (e.g. a `min_local_flow_count` guarantee for
 /// the cross-worker DRR work) is automatically visible here.
 ///
-/// **Adversarial review posture (campaign #775 / issue #785):**
-/// reviewers MUST reject PRs that drop the `!shared_exact` clause
-/// without also landing a cross-worker fairness mechanism AND
-/// re-validating the CoV target. The `shared_exact` shadow cached
-/// onto `CoSQueueRuntime` is the hook a future fix will branch on.
+/// **Adversarial review posture (post-#914):** the historical
+/// `!shared_exact` gate is no longer in policy — `flow_fair =
+/// queue.exact` for both shared_exact and owner-local-exact. The
+/// `shared_exact` shadow cached onto `CoSQueueRuntime` is now the
+/// branch point used by `cos_queue_flow_share_limit` to apply the
+/// rate-aware admission cap (`max(fair_share*2, bdp_floor)`)
+/// instead of the legacy aggregate/N share cap. Reviewers should
+/// reject PRs that re-introduce the rate-unaware MIN-floor cap on
+/// shared_exact without also re-validating iperf-c P=12 ≥ 22 Gbps
+/// and the same-class iperf-b mouse-latency p99 (the regressions
+/// historical Attempts A and B hit).
 ///
 /// The SFQ salt is drawn only for queues that actually use the
 /// flow-fair path — non-flow-fair queues never consult the seed
@@ -15407,13 +15419,16 @@ mod tests {
     // steering (or a single shared SFQ across workers), tracked in
     // the follow-up issue.
     //
-    // Adversarial review posture (campaign #775 / issue #785):
-    // reviewers MUST reject PRs that drop the `!shared_exact` clause
-    // from `promote_cos_queue_flow_fair` without also landing a
-    // cross-worker fairness mechanism AND re-validating
-    // `iperf3 -P 12 -p 5203` at 25 Gbps (expect SUM ≥ 22 Gbps AND
-    // per-flow CoV ≤ 20 %). The tests below drive the full
-    // production promotion path (via
+    // Adversarial review posture (post-#914): the historical
+    // `!shared_exact` gate is no longer in policy. shared_exact
+    // now runs MQFQ flow-fair AND a rate-aware admission cap
+    // (`max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)` —
+    // see `cos_queue_flow_share_limit`). Reviewers should reject
+    // PRs that re-introduce the rate-unaware MIN-floor cap on
+    // shared_exact without also re-validating
+    // `iperf3 -P 12 -p 5203` ≥ 22 Gbps AND per-flow CoV ≤ 20 %
+    // (the regression Attempt A hit). The tests below drive the
+    // full production promotion path (via
     // `apply_cos_queue_flow_fair_promotion` with hand-authored
     // `WorkerCoSQueueFastPath` vectors) so breaking the zip alignment
     // at the `ensure_cos_interface_runtime` call site — or feeding

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3728,8 +3728,10 @@ fn apply_cos_admission_ecn_policy(
     //
     // #722: per-flow threshold derived from the same share cap
     // the admission gate uses. `cos_queue_flow_share_limit` is
-    // pure and inlined (saturating_add + max + div_ceil + clamp),
-    // ~5 ns.
+    // pure and inlined: ~5 ns on the legacy owner-local path
+    // (saturating_add + max + div_ceil + clamp); ~8 ns on the
+    // post-#914 shared_exact path (adds one division + multiply
+    // for `bdp_floor_bytes`).
     let aggregate_ecn_threshold = buffer_limit
         .saturating_mul(COS_ECN_MARK_THRESHOLD_NUM)
         / COS_ECN_MARK_THRESHOLD_DEN.max(1);
@@ -4071,6 +4073,26 @@ fn cos_queue_prospective_active_flows(queue: &CoSQueueRuntime, flow_bucket: usiz
         .max(1)
 }
 
+/// Per-flow BDP-equivalent floor used by `cos_queue_flow_share_limit`
+/// on `shared_exact` queues (#914). Computed against the cluster's
+/// post-shaper RTT envelope; intentionally larger than the
+/// `cos_flow_aware_buffer_limit`'s 5 ms `delay_cap` because they
+/// serve different purposes — the aggregate buffer ceiling targets
+/// queue-residence latency, the per-flow floor targets TCP cwnd
+/// build-up at queue rate. Project memory: cluster RTT 5-7 ms
+/// post-shaper; 10 ms gives ~1.5× headroom.
+const RTT_TARGET_NS: u64 = 10_000_000;
+
+/// Per-flow BDP at the queue's rate divided across `active_flows`.
+/// Used as a floor in the shared_exact rate-aware cap — TCP cwnd
+/// must reach approximately one BDP for the per-flow rate to fit
+/// the queue's transmit rate without tail-drops.
+#[inline]
+fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
+    let per_flow_rate = transmit_rate_bytes / active_flows.max(1);
+    per_flow_rate.saturating_mul(RTT_TARGET_NS) / 1_000_000_000
+}
+
 #[inline]
 fn cos_queue_flow_share_limit(
     queue: &CoSQueueRuntime,
@@ -4080,22 +4102,44 @@ fn cos_queue_flow_share_limit(
     if !queue.flow_fair {
         return buffer_limit;
     }
-    // #785 Phase 3: shared_exact queues enforce per-flow fairness via
-    // MQFQ virtual-finish-time ordering in the dequeue path
-    // (`cos_queue_pop_front`), NOT via the per-flow share cap. The
-    // share cap's `COS_FLOW_FAIR_MIN_SHARE_BYTES` floor (24 KB) is
-    // rate-unaware and tail-drops TCP at multi-Gbps per-flow rates on
-    // a 25 Gbps queue with 12 flows. Retrospective Attempt A
-    // measured 22.3 → 16.3 Gbps + 25k retrans when the cap was
-    // enforced on shared_exact.
+    // #914 (post-#785 Phase 3): shared_exact queues now enforce a
+    // RATE-AWARE per-flow cap rather than passing through buffer_limit
+    // unchanged. The previous unconditional return was correct as far
+    // as it preserved TCP cwnd build-up (Attempt A had regressed
+    // 22.3 → 16.3 Gbps + 25k retrans because the rate-unaware
+    // `COS_FLOW_FAIR_MIN_SHARE_BYTES` floor of 24 KB was used as the
+    // cap), but it allowed a single elephant to occupy the entire
+    // queue buffer, starving mice in the same shared_exact class.
     //
-    // Aggregate-only admission here keeps TCP able to build cwnd
-    // up to BDP while MQFQ ordering equalises per-flow byte rates.
+    // The new cap = `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`:
+    //
+    //   - `fair_share*2` = aggregate buffer split N ways with 2×
+    //     headroom for transient bursts.
+    //   - `bdp_floor` = per-flow BDP at queue rate / N flows; ensures
+    //     TCP cwnd can build to one BDP without tail-drops.
+    //   - Clamped above by `buffer_limit` so the per-flow allocation
+    //     never exceeds the aggregate; clamped below by MIN_SHARE
+    //     (24 KB) for the existing guarantee.
+    //
+    // Behavior at low N (where bdp_floor > buffer_limit): the cap
+    // clamps to buffer_limit, i.e. the formula degenerates to today's
+    // behavior. This is intentional — at low N the buffer_limit
+    // ceiling is the binding constraint anyway, and forcing a tighter
+    // cap would regress TCP cwnd. The cap actively splits the buffer
+    // only at moderate-to-high N (around N ≈ 23 flows on a 10 G
+    // shared_exact queue).
+    //
     // Owner-local-exact queues (low-rate, #784 workload) keep the
-    // per-flow cap — at 1 Gbps / 12 flows the 24 KB cap matches
-    // TCP cwnd at 77 Mbps/flow.
+    // legacy aggregate/N share cap — at 1 Gbps / 12 flows the
+    // 24 KB MIN floor matches TCP cwnd at 77 Mbps/flow.
     if queue.shared_exact {
-        return buffer_limit;
+        let prospective = cos_queue_prospective_active_flows(queue, flow_bucket);
+        let fair_share = buffer_limit / prospective.max(1);
+        let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
+        return fair_share
+            .saturating_mul(2)
+            .max(bdp)
+            .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
     }
     let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
     buffer_limit
@@ -5450,44 +5494,39 @@ fn apply_cos_queue_flow_fair_promotion(
 /// `shared_exact` signal onto the runtime so future work on this
 /// surface can branch on it without another iface_fast lookup.
 ///
-/// **Current policy:** `flow_fair = queue.exact && !shared_exact`.
-/// Only the owner-local-exact path runs SFQ today; shared_exact
-/// (high-rate, >= `COS_SHARED_EXACT_MIN_RATE_BYTES` = 2.5 Gbps)
-/// queues stay on the single-FIFO-per-worker drain.
+/// **Current policy (post-#785 Phase 3, post-#914):** `flow_fair =
+/// queue.exact` for both owner-local-exact AND shared_exact. The
+/// dequeue-ordering mechanism is MQFQ virtual-finish-time (#913 fixed
+/// the snapshot-rollback bug). The admission-side per-flow cap on
+/// shared_exact is RATE-AWARE (#914): `cos_queue_flow_share_limit`
+/// returns `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`
+/// rather than the rate-unaware MIN floor that regressed throughput
+/// in the historical attempts described below.
 ///
-/// **Why shared_exact is held back (issue #785):** two attempts
-/// have been made to enable SFQ on shared_exact queues and both
-/// were rolled back after empirical regression:
+/// **Historical retrospective (issue #785):** two earlier attempts
+/// to enable SFQ on shared_exact were rolled back:
 ///
 /// 1. Naïve flip (flow_fair=queue.exact, no admission change).
 ///    iperf3 -P 12 on the 25 Gbps iperf-c cap regressed from
 ///    22.3 Gbps / 0 retrans to 16.3 Gbps / 25 k+ retrans. Root
 ///    cause: the per-flow share cap (`cos_queue_flow_share_limit`
 ///    → floor `COS_FLOW_FAIR_MIN_SHARE_BYTES` = 24 KB) and the
-///    per-flow ECN arm (`apply_cos_admission_ecn_policy`) are
+///    per-flow ECN arm (`apply_cos_admission_ecn_policy`) were
 ///    rate-unaware; on a 25 Gbps queue with 12 flows the per-flow
-///    cap collapses to ~24 KB, far below the ~5 MB BDP a
+///    cap collapsed to ~24 KB, far below the ~5 MB BDP a
 ///    2 Gbps / 20 ms TCP flow needs, so admission drops and ECN
-///    marks fired on nearly every packet.
+///    marks fired on nearly every packet. **#914 fixes this** by
+///    making the cap rate-aware via `bdp_floor_bytes`.
 ///
 /// 2. SFQ + aggregate-only admission (flow_fair=queue.exact;
 ///    `cos_queue_flow_share_limit` returns `buffer_limit` on
-///    shared_exact; `apply_cos_admission_ecn_policy` uses the
-///    aggregate arm on shared_exact). Throughput preserved
-///    (22-23 Gbps) but per-flow CoV went UP from ~33 % to
-///    ~40-51 % over three runs. Root cause: per-worker SFQ DRR
-///    cannot equalise flows that are distributed unevenly across
-///    workers by NIC RSS — which is the dominant imbalance source
-///    at P=12 / 8 workers. The SFQ cycle also appears to cost
-///    batch-drain efficiency on the high-rate path (a tangible
-///    but unquantified secondary effect).
-///
-/// The architecturally-correct lever is cross-worker flow steering
-/// (or a single shared-SFQ across all workers), not within-worker
-/// SFQ. Follow-up issue tracks that work. Do not flip this gate
-/// again without landing the cross-worker fairness mechanism first
-/// and validating `iperf3 -P 12 -p 5203` at 25 Gbps produces
-/// SUM ≥ 22 Gbps AND per-flow CoV ≤ 20 %.
+///    shared_exact). Throughput preserved (22-23 Gbps) but per-flow
+///    CoV went UP from ~33 % to ~40-51 % over three runs because
+///    per-worker SFQ DRR cannot equalise flows that are distributed
+///    unevenly across workers by NIC RSS — the dominant imbalance
+///    source at P=12 / 8 workers. The DRR primitive was replaced
+///    with MQFQ (#913) which uses byte-rate fairness, the
+///    architecturally correct primitive for TCP under pacing.
 ///
 /// **Contract shape:** `queue_fast: &WorkerCoSQueueFastPath` is the
 /// live classifier output from `build_worker_cos_fast_interfaces`,
@@ -5526,12 +5565,14 @@ fn promote_cos_queue_flow_fair(
     // retrospective analysis, and `docs/785-perf-fairness-plan.md`
     // for the phased plan.
     //
-    // Admission gates downgrade to aggregate-only on shared_exact
-    // (see `cos_queue_flow_share_limit` and
-    // `apply_cos_admission_ecn_policy`) so the rate-unaware 24 KB
-    // per-flow share cap doesn't tail-drop TCP at multi-Gbps per-
-    // flow rates. Proven necessary by Attempt A in the retrospective
-    // (22.3 → 16.3 Gbps regression on the 24 KB cap).
+    // Admission gates: `cos_queue_flow_share_limit` is RATE-AWARE
+    // on shared_exact post-#914 — it returns
+    // `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)` so the
+    // per-flow cap follows BDP at queue rate / N flows rather than
+    // collapsing to the rate-unaware 24 KB MIN floor that caused the
+    // Attempt A regression (22.3 → 16.3 Gbps).
+    // `apply_cos_admission_ecn_policy` still uses the aggregate arm
+    // on shared_exact (per-flow ECN remains rate-unaware).
     queue.flow_fair = queue.exact;
     if queue.flow_fair {
         queue.flow_hash_seed = cos_flow_hash_seed_from_os();
@@ -10549,6 +10590,214 @@ mod tests {
             cos_flow_aware_buffer_limit(queue, 0),
             queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
             "flow_fair=false must bypass the flow-count multiplier"
+        );
+    }
+
+    /// #914: shared_exact rate-aware cap — verify the formula
+    /// `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`
+    /// scales correctly with `transmit_rate_bytes` and active flows
+    /// rather than collapsing to the rate-unaware MIN floor.
+    #[test]
+    fn flow_share_limit_shared_exact_scales_with_rate() {
+        // 10 Gbps shared_exact queue at N=128 → per_flow_rate = 9.77 MB/s,
+        // bdp_floor = 9.77 MB/s × 10 ms = 97.6 KB. Buffer_limit ≫ that,
+        // so the cap should follow bdp_floor.
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 0,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.shared_exact = true;
+        queue.active_flow_buckets = 128;
+        for bucket in 0..128 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        // bdp_floor = (1.25 GB/s / 128) × 10 ms = 97_656 bytes (rounded).
+        let expected_bdp = bdp_floor_bytes(queue.transmit_rate_bytes, 128);
+        assert_eq!(
+            share, expected_bdp,
+            "shared_exact cap should follow bdp_floor at N=128 (cap={share}, bdp={expected_bdp})"
+        );
+        assert!(
+            share > COS_FLOW_FAIR_MIN_SHARE_BYTES,
+            "rate-aware cap ({share}) must exceed the rate-unaware MIN floor ({COS_FLOW_FAIR_MIN_SHARE_BYTES})"
+        );
+        assert!(
+            share <= buffer_limit,
+            "cap ({share}) must not exceed buffer_limit ({buffer_limit})"
+        );
+    }
+
+    /// #914: at low N, `bdp_floor` exceeds `buffer_limit`; the formula
+    /// must clamp to buffer_limit and degenerate to today's behavior
+    /// rather than capping below per-flow BDP (which would collapse
+    /// TCP cwnd).
+    #[test]
+    fn flow_share_limit_shared_exact_caps_at_aggregate_for_single_flow() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 0,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.shared_exact = true;
+        queue.active_flow_buckets = 1;
+        queue.flow_bucket_bytes[0] = 1_000;
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        // At N=1 the bdp_floor (~12.5 MB) is way above buffer_limit,
+        // so we clamp to buffer_limit.
+        assert_eq!(
+            share, buffer_limit,
+            "single-flow shared_exact cap must clamp to buffer_limit (no regression vs current)"
+        );
+    }
+
+    /// #914 (Codex review): at moderate N where `bdp_floor` exceeds
+    /// `buffer_limit` (the degeneration regime per plan §3.2), the
+    /// cap must clamp to `buffer_limit` rather than below it. Pins
+    /// the low-N behavior so a future regression where the formula
+    /// caps below buffer_limit fails this test rather than slipping
+    /// through.
+    #[test]
+    fn flow_share_limit_shared_exact_clamps_to_buffer_at_low_n() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 0,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.shared_exact = true;
+        // N = 8: per-flow rate = 156 MB/s, bdp_floor = 1.56 MB,
+        // far above buffer_limit (which at default base = 96 KB and
+        // 8 × MIN_SHARE = 192 KB clamps to ~192 KB).
+        queue.active_flow_buckets = 8;
+        for bucket in 0..8 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
+        let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, 8);
+        assert!(
+            bdp > buffer_limit,
+            "test premise: bdp_floor ({bdp}) must exceed buffer_limit ({buffer_limit}) at N=8"
+        );
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        assert_eq!(
+            share, buffer_limit,
+            "low-N shared_exact must clamp to buffer_limit, not below"
+        );
+    }
+
+    /// #914: at high N where bdp_floor < buffer_limit, the cap is
+    /// active and protects mice from elephant starvation (the actual
+    /// design goal).
+    #[test]
+    fn flow_share_limit_shared_exact_protects_against_dominant_flow() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 5,
+                forwarding_class: "iperf-b".into(),
+                priority: 5,
+                transmit_rate_bytes: 10_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 0,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.shared_exact = true;
+        queue.active_flow_buckets = 128;
+        for bucket in 0..128 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        // The cap must be strictly less than buffer_limit at N=128 —
+        // i.e. one flow cannot fill the entire queue.
+        assert!(
+            share < buffer_limit,
+            "rate-aware cap ({share}) must split the buffer at N=128 (buffer_limit={buffer_limit})"
+        );
+        // And strictly greater than buffer_limit / N (the rate-unaware
+        // arithmetic share) because of the bdp_floor and 2× headroom.
+        assert!(
+            share >= buffer_limit / 128,
+            "cap ({share}) must be at least buffer_limit/N ({})",
+            buffer_limit / 128
+        );
+    }
+
+    /// #914: owner-local-exact queues (NOT shared_exact) keep the
+    /// legacy `buffer_limit / prospective_active` arithmetic share.
+    /// Verify the new shared_exact branch does not affect them.
+    #[test]
+    fn flow_share_limit_owner_local_exact_unchanged() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 125_000,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.shared_exact = false; // owner-local-exact
+        queue.active_flow_buckets = 12;
+        for bucket in 0..12 {
+            queue.flow_bucket_bytes[bucket] = 1_000;
+        }
+        let buffer_limit = cos_flow_aware_buffer_limit(queue, 0);
+        let share = cos_queue_flow_share_limit(queue, buffer_limit, 0);
+        // Legacy formula: buffer_limit / prospective_active, clamped to
+        // [MIN_SHARE, buffer_limit]. With 12 buckets and the prospective
+        // +1 for empty target bucket, the divisor is 13 (or 12 if the
+        // target bucket is non-empty).
+        let prospective = cos_queue_prospective_active_flows(queue, 0);
+        let expected = buffer_limit
+            .div_ceil(prospective)
+            .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
+        assert_eq!(
+            share, expected,
+            "owner-local-exact cap must use the legacy aggregate/N formula"
         );
     }
 


### PR DESCRIPTION
## Summary

- Re-enables the per-flow admission cap on `shared_exact` queues (which #785 Phase 3 had to disable because the rate-unaware 24 KB MIN floor caused 22.3 → 16.3 Gbps + 25k retrans on iperf-c).
- Replaces the unconditional `return buffer_limit` for shared_exact with a rate-aware formula: `cap = max(fair_share × 2, bdp_floor).clamp(MIN_SHARE, buffer_limit)` where `bdp_floor = (rate / N) × 10 ms`.
- At low N (where `bdp_floor` exceeds `buffer_limit`) the cap clamps to `buffer_limit` and degenerates to today's behavior — avoiding the rate-unaware regression. At high N the cap actively splits the buffer (~3% per flow at iperf-b N=128), preventing one elephant from starving mice in the same class.
- Updates the #785 retrospective comment block in `promote_cos_queue_flow_fair` and the `apply_cos_admission_ecn_policy` doc to reflect the new rate-aware shared_exact behavior.

Plan: [`docs/pr/914-rate-aware-admission/plan.md`](docs/pr/914-rate-aware-admission/plan.md). Cleared to PLAN-READY YES across multiple Codex+Gemini rounds (the arithmetic went through a NEEDS-MAJOR fix when I divided by N twice in the N=128 derivation — corrected to 97.7 KB cap, not 48 KB). Code review: Codex MERGE YES, Gemini MERGE YES with two minor follow-ups addressed inline.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` 765/765 pass; 5 new shared_exact unit tests cover: rate-aware scaling at high N, low-N clamp to buffer_limit (degeneration regime), high-N protection against dominant flow, single-flow no-regression, owner-local-exact path preserved
- [ ] Cluster validation: same-class N=8 / N=128 mouse-latency at iperf-b (gates against #911) — depends on #929 same-class harness landing first
- [ ] Throughput sanity: `iperf3 -P 12 -p 5203 -t 60` (iperf-c) ≥ 22 Gbps unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)