### PR TITLE
#929 same-class iperf-b mouse-latency harness

### DIFF
--- a/docs/pr/929-same-class-harness/findings.md
+++ b/docs/pr/929-same-class-harness/findings.md
@@ -1,0 +1,87 @@
+# #929 Same-class harness — cluster smoke findings
+
+Smoke + binding-case measurements taken on the loss userspace
+cluster (xpf-userspace-fw0/fw1, cluster-userspace-host source,
+172.16.80.200 target with port 7 TCP echo) on 2026-04-27.
+
+## Combined-branch deploy
+
+The harness was validated against a combined branch that merges
+all four 100E100M sprint streams (sprint/918-flow-cache-4way +
+sprint/920-batch-size-l1d + sprint/914-rate-aware +
+sprint/929-same-class-harness). `cargo test --release` passed
+778/778 tests.
+
+## Throughput sanity (#914 + #920 gates)
+
+- `iperf3 -c 172.16.80.200 -p 5203 -P 12 -t 30` (iperf-c
+  shared_exact, the rate-aware-cap path):
+  - **23.47 Gb/s sent / 23.46 Gb/s recv**
+  - 55 retransmits across 30 s × 12 streams
+  - Above the 22 Gbps gate from #914 acceptance ✓
+
+- `iperf3 -c 172.16.80.200 -p 5203 -P 128 -t 30` (high-stress,
+  100E equivalent):
+  - 16.84 Gb/s sent / 16.71 Gb/s recv
+  - 706 k retransmits
+  - Per-flow CoV: 12.4 % (median 0.128 Gb/s, max 0.188 Gb/s)
+  - Zero CoS admission drops in any queue (`drops:
+    flow_share=0 buffer=0 ecn_marked=0` on iperf-a/b/c). The
+    retransmits are external (NIC TX or wire-level), not
+    daemon-side.
+
+## Mouse-latency tail (#911 / #905 binding case)
+
+| Cell | p50 (ms) | p95 (ms) | p99 (ms) | completed | mpstat |
+|---|---|---|---|---|---|
+| Idle (N=0, M=10) | 2.56 | 3.34 | **5.87** | 2186 | n/a |
+| Cross-class iperf-a (N=128, M=10) | 2.21 | 5.30 | **203.75** | 2187 | n/a |
+| **Same-class iperf-b (N=128, M=10)** | 6.46 | 46.63 | **60.64** | 3359 | 53.83 % |
+
+The same-class case is the binding measurement for #911 — the
+HOL gate that #913 (shipped) and the four sprint PRs target.
+Combined-branch p99 of **60.64 ms** at same-class iperf-b N=128
+is **3.4× lower than the cross-class iperf-a N=128 baseline of
+203.75 ms** on the same combined binary.
+
+Pre-PR same-class baseline numbers are not in the #905 dataset
+(the existing harness only exercised cross-class); the
+comparison above is qualitative — same-class behaves
+materially better than cross-class once #913 + #918 + #914 +
+#920 are all in place. A direct same-class-vs-master comparison
+would require deploying master with the new harness for an
+A/B run.
+
+## Harness fixes caught during smoke
+
+Two issues required follow-on commits to #929 before the smoke
+could complete:
+
+1. **`nc` not in source container.** The v1 preflight used
+   `nc -zw1 ${TARGET_V4} ${MOUSE_PORT}` which exited 127
+   ("command not found") and aborted every rep before the
+   probe ran. v2 uses `bash /dev/tcp` (built-in to bash, works
+   in any container).
+
+2. **Echo listener on port 7, not 5212.** v1 of the plan
+   assumed the operator would stand up a separate listener
+   on 5212 specifically for same-class. The operator's actual
+   topology runs a single echo on port 7 for both cross- and
+   same-class. v2 same-class fixture overrides port 7's CoS
+   classification (best-effort → iperf-b) instead of routing
+   to a different port. No second listener required.
+
+Both fixes are in commit 2a0d1d0a.
+
+## Acceptance status
+
+- [x] Smoke (§6.1) produces valid same-class probe.json.
+- [x] Regression (§6.2) cross-class baseline unchanged
+      (203.75 ms p99 matches #905).
+- [ ] E2E matrix (§6.3) — single cell run; full 12-cell matrix
+      deferred to post-merge so each Rust stream can be
+      validated against the harness independently.
+- [x] Gate ratio computable from same-class data
+      (60.64 ms / 5.87 ms idle = 10.3× — well below the
+      cross-class 35× ratio).
+- [x] Documentation (this file).

--- a/docs/pr/929-same-class-harness/plan.md
+++ b/docs/pr/929-same-class-harness/plan.md
@@ -21,12 +21,20 @@ matrix without breaking the existing cross-class baseline:
 - Existing default invocation continues to produce cross-class
   data (no regression in the #905 dataset).
 - A new code path runs the matrix with elephants + mice both in
-  iperf-b at port 5202 (elephants) + port 5212 (mice), with a
-  CoS classifier term mapping 5212 → iperf-b.
-- The cluster-side TCP echo daemon listens on both port 7
-  (existing) and port 5212 (new). UDP echo on 5212 is OUT OF
-  SCOPE for this PR — `mouse_latency_probe.py` exercises TCP
-  only (per §3.3), so adding UDP would be unverified scope creep.
+  iperf-b: port 5202 (elephants) + port 7 (mice, hitting the
+  operator's existing echo daemon), with a CoS classifier term
+  that overrides port 7's default best-effort classification and
+  routes it to iperf-b instead.
+- **No new echo daemon required** — the port 7 listener that the
+  cross-class default already uses is reused. The cross-class
+  fixture leaves port 7 as best-effort; the same-class fixture
+  reclassifies it as iperf-b. Switch by re-applying the fixture.
+
+(Plan v1 specified a separate port 5212 listener that the
+operator would stand up. v2 simplified to reuse port 7 after
+the operator confirmed they only run a single echo. The CoS
+term still differentiates same-class from cross-class via the
+fixture being applied, not the destination port.)
 
 ## 3. Approach
 
@@ -68,20 +76,25 @@ Existing `cos-iperf-config.set` maps:
 - 5204 → best-effort
 
 New same-class file inherits everything from `cos-iperf-config.set`
-plus adds a term that maps the same-class mouse port (5212) to
-iperf-b. Choose 5212 (= 5202 + 10) so the mouse port is visually
-related to the elephant class but doesn't collide with iperf3's
-listener on 5202.
+plus adds a term that overrides port 7's default best-effort
+classification and routes it to iperf-b — putting mouse traffic
+into the same queue as the elephants on port 5202.
 
 ```text
 # Append to cos-iperf-same-class.set:
-set firewall family inet filter bandwidth-output term 4 from destination-port 5212
+set firewall family inet filter bandwidth-output term 4 from destination-port 7
 set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-b
 set firewall family inet filter bandwidth-output term 4 then count iperf-b-mouse
 set firewall family inet filter bandwidth-output term 4 then accept
 ```
 
 (Plus matching IPv6 term.)
+
+(v2 note: an earlier revision used port 5212 for the mouse so
+that port 7 would never be classified as iperf-b. v2 dropped
+that requirement — using port 7 means no second echo listener
+on 172.16.80.200, and the same-class-vs-cross-class distinction
+lives entirely in which CoS fixture is applied.)
 
 `apply-cos-config.sh` learns a `--same-class` flag that selects
 which file to apply. Default stays cross-class.
@@ -106,38 +119,20 @@ TARGET="${1:?target required}"
 Without explicit parsing, `--same-class` would be silently
 treated as the target hostname — easy to miss in CI logs.
 
-### 3.3 Echo daemon on 5212 — host correction (Codex R1)
+### 3.3 Echo daemon (no new listener required)
 
 `TARGET_V4=172.16.80.200` is the iperf3 target host (the
-operator's external echo server), NOT
-`cluster-userspace-host` (which is the SOURCE of the test
-traffic). Codex R1 caught my earlier confusion: the new echo
-listener for port 5212 must run on `172.16.80.200`, not on
-the source container.
+operator's external echo server), NOT `cluster-userspace-host`
+(which is the SOURCE of the test traffic).
 
-Plan A and B below both run on `172.16.80.200`. Decide at
-implementation time after operator confirms which method is
-preferred (the existing port-7 service may already be one of
-these patterns):
-
-- (A) **Extend the existing echo service** on 172.16.80.200 to
-  listen on multiple ports. If the existing service is
-  systemd-socket-activated, append a `ListenStream=5212` /
-  `ListenDatagram=5212` entry. If it's xinetd, add a port-7-
-  twin block for 5212.
-- (B) **Stand up a second echo daemon** on 172.16.80.200 via
-  `socat` or a small Rust echo binary as a systemd service.
+v2 design: the same-class wrapper reuses the existing port 7
+TCP echo daemon on 172.16.80.200 — no new listener required.
+Same-class vs cross-class is a CoS-fixture distinction, not a
+destination-port distinction.
 
 The probe currently exercises **TCP only** (per
-`mouse_latency_probe.py`). UDP echo on 5212 is a nice-to-have
-but NOT validated by the existing probe; document that TCP
-is the required path.
-
-If the operator can't or won't add port 5212 to 172.16.80.200,
-fallback option (C): out of scope for this PR (would require
-spawning a new `cluster-target-aux` container with separate
-network plumbing — separate work item to file if A and B both
-fail).
+`mouse_latency_probe.py`). UDP same-class is OUT OF SCOPE for
+this PR — there's no UDP echo path the probe would exercise.
 
 ### 3.4 New wrapper `test-mouse-latency-same-class.sh`
 
@@ -148,16 +143,16 @@ Wraps `test-mouse-latency-matrix.sh` with the right env:
 set -euo pipefail
 exec env \
     ELEPHANT_PORT=5202 \
-    MOUSE_PORT=5212 \
+    MOUSE_PORT=7 \
     MOUSE_CLASS=iperf-b \
     SHAPER_BPS=$((10 * 1000 * 1000 * 1000)) \
     "$(dirname "$0")/test-mouse-latency-matrix.sh" "$@"
 ```
 
 `apply-cos-config.sh` is invoked with the `--same-class` flag
-when `MOUSE_CLASS == iperf-b`. The target-side echo daemon is
-assumed already running on 172.16.80.200:5212 (verified via
-preflight, §3.5).
+when `MOUSE_CLASS == iperf-b`. The target-side echo daemon on
+172.16.80.200:7 is the same one the cross-class default uses
+(verified via preflight, §3.5).
 
 **CoS apply is per-rep** (per existing harness behavior at
 `test-mouse-latency.sh:157`). Switching `MOUSE_CLASS` between
@@ -189,11 +184,15 @@ double-runs fail loudly instead of silently interleaving.
 ### 3.5 Preflight check
 
 Add a preflight step in `test-mouse-latency.sh` that probes the
-mouse port:
+mouse port. Uses `bash /dev/tcp` rather than `nc -zw1` because
+the source container doesn't ship netcat by default (cluster
+smoke v2 caught this: the original `nc` form aborted every rep
+with "command not found"):
 
 ```bash
-incus_exec "$SOURCE" timeout 1 nc -zw1 "$TARGET_V4" "$MOUSE_PORT" \
-    < /dev/null > /dev/null 2>&1 \
+incus_exec "$SOURCE" timeout 2 bash -c \
+    "exec 3<>/dev/tcp/${TARGET_V4}/${MOUSE_PORT}" \
+    > /dev/null 2>&1 \
     || { echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}"; exit 1; }
 ```
 
@@ -215,10 +214,9 @@ Fails fast if echo daemon isn't up on the target port.
   terms.
 - `test/incus/test-mouse-latency-same-class.sh` — NEW; thin
   wrapper.
-- Echo daemon on **172.16.80.200** (the iperf-3 target host,
-  NOT cluster-userspace-host which is the source of test
-  traffic) — implementation approach decided at impl time
-  (option A vs B vs fallback C, see §3.3).
+- No new echo daemon required (v2 design): same-class wrapper
+  reuses the existing port 7 listener on 172.16.80.200 that the
+  cross-class default already exercises.
 - `docs/pr/929-same-class-harness/findings.md` — smoke results.
 
 ## 6. Test strategy
@@ -226,17 +224,18 @@ Fails fast if echo daemon isn't up on the target port.
 ### 6.1 Smoke
 
 ```bash
-MOUSE_PORT=5212 MOUSE_CLASS=iperf-b SHAPER_BPS=$((10*1000*1000*1000)) \
+ELEPHANT_PORT=5202 MOUSE_PORT=7 MOUSE_CLASS=iperf-b \
+SHAPER_BPS=$((10*1000*1000*1000)) \
     ./test/incus/test-mouse-latency.sh 0 1 60 /tmp/sm
 ```
 
 Asserts:
-- Preflight passes (echo reachable on 172.16.80.200:5212).
+- Preflight passes (echo reachable on 172.16.80.200:7).
 - `cos-apply.log` shows the same-class term applied.
 - **Firewall classifier verification (Codex R1)**: extract
   `show configuration | display set | match "filter
   bandwidth-output term 4"` from the post-apply config and
-  assert it contains `from destination-port 5212` and
+  assert it contains `from destination-port 7` and
   `forwarding-class iperf-b`. Don't rely on
   `show class-of-service interface` alone — that only verifies
   scheduler/shaper binding, not the firewall term ordering.
@@ -279,7 +278,7 @@ This dataset is the validation gate for #913/#918/#914/#920.
   **Verify post-apply by extracting the firewall config**:
   `show configuration | display set | match "filter
   bandwidth-output term 4"` and asserting it contains
-  `from destination-port 5212` and `forwarding-class iperf-b`
+  `from destination-port 7` and `forwarding-class iperf-b`
   (per §6.1). `show class-of-service interface` is supplemental
   only — it shows scheduler/shaper binding, not firewall term
   ordering.

--- a/docs/pr/929-same-class-harness/plan.md
+++ b/docs/pr/929-same-class-harness/plan.md
@@ -1,0 +1,302 @@
+# Plan: #929 — Same-class iperf-b mouse-latency harness
+
+Issue: #929
+Umbrella: #911 (gates the validation of #913/#918/#914/#920)
+Diagnosis: `docs/pr/905-mouse-latency/findings.md` + #911 issue body
+
+## 1. Problem
+
+`test/incus/test-mouse-latency.sh` hardcodes `ELEPHANT_PORT=5201`
+(iperf-a class) and `MOUSE_PORT=7` (best-effort class), exercising
+the CROSS-class case. The #911 failure mode is SAME-class — both
+elephants and mice in iperf-b — which the existing harness can't
+measure. Any fix to the same-class HOL gate (#913 already shipped,
+#918/#914/#920 next) lacks a validation gate without this harness.
+
+## 2. Goal
+
+Add same-class measurement capability to the mouse-latency test
+matrix without breaking the existing cross-class baseline:
+
+- Existing default invocation continues to produce cross-class
+  data (no regression in the #905 dataset).
+- A new code path runs the matrix with elephants + mice both in
+  iperf-b at port 5202 (elephants) + port 5212 (mice), with a
+  CoS classifier term mapping 5212 → iperf-b.
+- The cluster-side TCP echo daemon listens on both port 7
+  (existing) and port 5212 (new). UDP echo on 5212 is OUT OF
+  SCOPE for this PR — `mouse_latency_probe.py` exercises TCP
+  only (per §3.3), so adding UDP would be unverified scope creep.
+
+## 3. Approach
+
+Three changes in `test/incus/`:
+
+### 3.1 Parameterize `test-mouse-latency.sh`
+
+Replace the unconditional assignments
+
+```bash
+ELEPHANT_PORT=5201
+MOUSE_PORT=7
+SHAPER_BPS=$((1 * 1000 * 1000 * 1000))  # 1 Gb/s for iperf-a
+```
+
+with environment-overrideable defaults (Codex R1: `SHAPER_BPS`
+must move with `ELEPHANT_PORT` because the settle/collapse
+gates compare against it; same-class iperf-b is at 10 Gb/s):
+
+```bash
+ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
+MOUSE_PORT="${MOUSE_PORT:-7}"
+MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
+# Default 1 Gb/s for iperf-a; same-class iperf-b wrapper sets 10 Gb/s.
+SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"
+```
+
+Pass `MOUSE_CLASS` and `SHAPER_BPS` through to the per-cell
+metadata (manifest.json) so post-hoc analysis can distinguish
+same-class runs from cross-class and verify the gate threshold
+matches the configured shape.
+
+### 3.2 New CoS terms file `cos-iperf-same-class.set`
+
+Existing `cos-iperf-config.set` maps:
+- 5201 → iperf-a
+- 5202 → iperf-b
+- 5203 → iperf-c
+- 5204 → best-effort
+
+New same-class file inherits everything from `cos-iperf-config.set`
+plus adds a term that maps the same-class mouse port (5212) to
+iperf-b. Choose 5212 (= 5202 + 10) so the mouse port is visually
+related to the elephant class but doesn't collide with iperf3's
+listener on 5202.
+
+```text
+# Append to cos-iperf-same-class.set:
+set firewall family inet filter bandwidth-output term 4 from destination-port 5212
+set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-b
+set firewall family inet filter bandwidth-output term 4 then count iperf-b-mouse
+set firewall family inet filter bandwidth-output term 4 then accept
+```
+
+(Plus matching IPv6 term.)
+
+`apply-cos-config.sh` learns a `--same-class` flag that selects
+which file to apply. Default stays cross-class.
+
+**Flag parsing (Codex R3):** the existing script treats `$1` as
+`TARGET`, so `--same-class` must be parsed BEFORE positional
+arguments. Use a small while-getopts-style loop at the top of
+the script:
+
+```bash
+SAME_CLASS=0
+while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+        --same-class) SAME_CLASS=1; shift ;;
+        --) shift; break ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+TARGET="${1:?target required}"
+```
+
+Without explicit parsing, `--same-class` would be silently
+treated as the target hostname — easy to miss in CI logs.
+
+### 3.3 Echo daemon on 5212 — host correction (Codex R1)
+
+`TARGET_V4=172.16.80.200` is the iperf3 target host (the
+operator's external echo server), NOT
+`cluster-userspace-host` (which is the SOURCE of the test
+traffic). Codex R1 caught my earlier confusion: the new echo
+listener for port 5212 must run on `172.16.80.200`, not on
+the source container.
+
+Plan A and B below both run on `172.16.80.200`. Decide at
+implementation time after operator confirms which method is
+preferred (the existing port-7 service may already be one of
+these patterns):
+
+- (A) **Extend the existing echo service** on 172.16.80.200 to
+  listen on multiple ports. If the existing service is
+  systemd-socket-activated, append a `ListenStream=5212` /
+  `ListenDatagram=5212` entry. If it's xinetd, add a port-7-
+  twin block for 5212.
+- (B) **Stand up a second echo daemon** on 172.16.80.200 via
+  `socat` or a small Rust echo binary as a systemd service.
+
+The probe currently exercises **TCP only** (per
+`mouse_latency_probe.py`). UDP echo on 5212 is a nice-to-have
+but NOT validated by the existing probe; document that TCP
+is the required path.
+
+If the operator can't or won't add port 5212 to 172.16.80.200,
+fallback option (C): out of scope for this PR (would require
+spawning a new `cluster-target-aux` container with separate
+network plumbing — separate work item to file if A and B both
+fail).
+
+### 3.4 New wrapper `test-mouse-latency-same-class.sh`
+
+Wraps `test-mouse-latency-matrix.sh` with the right env:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+exec env \
+    ELEPHANT_PORT=5202 \
+    MOUSE_PORT=5212 \
+    MOUSE_CLASS=iperf-b \
+    SHAPER_BPS=$((10 * 1000 * 1000 * 1000)) \
+    "$(dirname "$0")/test-mouse-latency-matrix.sh" "$@"
+```
+
+`apply-cos-config.sh` is invoked with the `--same-class` flag
+when `MOUSE_CLASS == iperf-b`. The target-side echo daemon is
+assumed already running on 172.16.80.200:5212 (verified via
+preflight, §3.5).
+
+**CoS apply is per-rep** (per existing harness behavior at
+`test-mouse-latency.sh:157`). Switching `MOUSE_CLASS` between
+runs requires re-applying the matching CoS fixture before each
+rep — already handled because each rep calls
+`apply-cos-config.sh` and the wrapper sets `MOUSE_CLASS`
+end-to-end.
+
+**Concurrent matrices: enforced via flock (Gemini R2).** CoS is
+global mutable cluster state. Documentation alone is insufficient
+— overlapping invocations corrupt both datasets silently. Add a
+file-based lock at the top of `test-mouse-latency-matrix.sh`
+(and reuse it from the same-class wrapper, which calls into
+matrix.sh):
+
+```bash
+LOCK_FILE="${TMPDIR:-/tmp}/test-mouse-latency-matrix.lock"
+exec 9>"$LOCK_FILE"
+flock -n 9 || {
+    echo "ABORT: another mouse-latency matrix is already running" >&2
+    echo "       (lock held on $LOCK_FILE)" >&2
+    exit 1
+}
+```
+
+`flock -n` returns immediately if the lock is held, so accidental
+double-runs fail loudly instead of silently interleaving.
+
+### 3.5 Preflight check
+
+Add a preflight step in `test-mouse-latency.sh` that probes the
+mouse port:
+
+```bash
+incus_exec "$SOURCE" timeout 1 nc -zw1 "$TARGET_V4" "$MOUSE_PORT" \
+    < /dev/null > /dev/null 2>&1 \
+    || { echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}"; exit 1; }
+```
+
+Fails fast if echo daemon isn't up on the target port.
+
+## 4. What this is NOT
+
+- Not a change to MQFQ semantics (that's #913, shipped).
+- Not a change to flow cache or batch size (#918, #920).
+- Not a change to admission caps (#914).
+- Not a new metric — same `mouse_latency_probe.py` / matrix runner.
+
+## 5. Files touched
+
+- `test/incus/test-mouse-latency.sh` — env-var parameterization
+  + preflight + manifest.json metadata.
+- `test/incus/apply-cos-config.sh` — `--same-class` flag.
+- `test/incus/cos-iperf-same-class.set` — NEW; same-class CoS
+  terms.
+- `test/incus/test-mouse-latency-same-class.sh` — NEW; thin
+  wrapper.
+- Echo daemon on **172.16.80.200** (the iperf-3 target host,
+  NOT cluster-userspace-host which is the source of test
+  traffic) — implementation approach decided at impl time
+  (option A vs B vs fallback C, see §3.3).
+- `docs/pr/929-same-class-harness/findings.md` — smoke results.
+
+## 6. Test strategy
+
+### 6.1 Smoke
+
+```bash
+MOUSE_PORT=5212 MOUSE_CLASS=iperf-b SHAPER_BPS=$((10*1000*1000*1000)) \
+    ./test/incus/test-mouse-latency.sh 0 1 60 /tmp/sm
+```
+
+Asserts:
+- Preflight passes (echo reachable on 172.16.80.200:5212).
+- `cos-apply.log` shows the same-class term applied.
+- **Firewall classifier verification (Codex R1)**: extract
+  `show configuration | display set | match "filter
+  bandwidth-output term 4"` from the post-apply config and
+  assert it contains `from destination-port 5212` and
+  `forwarding-class iperf-b`. Don't rely on
+  `show class-of-service interface` alone — that only verifies
+  scheduler/shaper binding, not the firewall term ordering.
+- `probe.json` produced with non-zero `completed` count.
+- `manifest.json` has `mouse_class: "iperf-b"`,
+  `shaper_bps: 10000000000` fields.
+
+### 6.2 Regression
+
+Run the existing cross-class smoke (no env overrides) and
+verify nothing changed. Compare `probe.json` numbers to the
+last cross-class baseline run from #913 (~5ms p99 idle).
+
+### 6.3 End-to-end
+
+Run `test-mouse-latency-same-class.sh /tmp/sc` with the full
+12-cell matrix (~6 hours wall budget per #905 plan §4.7).
+Capture the gate ratios at iperf-b.
+
+This dataset is the validation gate for #913/#918/#914/#920.
+
+## 7. Acceptance
+
+- [ ] Smoke (§6.1) produces valid same-class probe.json.
+- [ ] Regression (§6.2) cross-class baseline unchanged.
+- [ ] E2E matrix (§6.3) completes within wall budget.
+- [ ] Gate ratio computable from same-class data.
+- [ ] Documentation in `findings.md`.
+
+## 8. Risks
+
+- **Echo daemon scope creep.** If the existing echo on port 7
+  is hardcoded to one port, adding a second port may require
+  cluster-side config change beyond this PR. Document the
+  choice in `findings.md`; fall back to a small Python
+  `socketserver` if needed.
+- **CoS classifier ordering.** The new firewall term must NOT
+  shadow existing terms. Plan: add as `term 4`, after the
+  existing `term 0..3` (5201/5202/5203/5204 → iperf-a/b/c/be).
+  **Verify post-apply by extracting the firewall config**:
+  `show configuration | display set | match "filter
+  bandwidth-output term 4"` and asserting it contains
+  `from destination-port 5212` and `forwarding-class iperf-b`
+  (per §6.1). `show class-of-service interface` is supplemental
+  only — it shows scheduler/shaper binding, not firewall term
+  ordering.
+- **Cluster-state contamination.** Running same-class
+  immediately after cross-class leaves the same-class CoS term
+  installed. Document that `apply-cos-config.sh` (no
+  `--same-class`) must run before any cross-class baseline run.
+- **Preflight false negative.** `nc -zw1` may fail under
+  transient network conditions; document that the operator
+  should retry the smoke once.
+
+## 9. Acceptance checklist
+
+- [ ] Plan reviewed by Codex (hostile); PLAN-READY YES.
+- [ ] Plan reviewed by Gemini (HPC + OS expert framing); MERGE YES.
+- [ ] Implemented; smoke passes.
+- [ ] Codex hostile code review: MERGE YES.
+- [ ] Gemini adversarial code review: MERGE YES.
+- [ ] PR opened, Copilot review addressed.
+- [ ] Merged.

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -27,9 +27,27 @@
 #
 set -euo pipefail
 
+# #929: --same-class flag selects the same-class iperf-b CoS
+# fixture (cos-iperf-same-class.set), which adds term 4 mapping
+# port 5212 → iperf-b. Default stays cross-class. Flag must be
+# parsed BEFORE the positional TARGET argument so it isn't
+# silently treated as a hostname.
+SAME_CLASS=0
+while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+        --same-class) SAME_CLASS=1; shift ;;
+        --) shift; break ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
 TARGET="${1:-loss:xpf-userspace-fw0}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONFIG_FILE="${SCRIPT_DIR}/cos-iperf-config.set"
+if [[ "$SAME_CLASS" -eq 1 ]]; then
+    CONFIG_FILE="${SCRIPT_DIR}/cos-iperf-same-class.set"
+else
+    CONFIG_FILE="${SCRIPT_DIR}/cos-iperf-config.set"
+fi
 REMOTE_SETS="/tmp/cos-iperf-sets.set"
 
 if [[ ! -f "$CONFIG_FILE" ]]; then

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -29,9 +29,10 @@ set -euo pipefail
 
 # #929: --same-class flag selects the same-class iperf-b CoS
 # fixture (cos-iperf-same-class.set), which adds term 4 mapping
-# port 5212 → iperf-b. Default stays cross-class. Flag must be
-# parsed BEFORE the positional TARGET argument so it isn't
-# silently treated as a hostname.
+# destination-port 7 → iperf-b (overriding port 7's default
+# best-effort classification). Default stays cross-class. Flag
+# must be parsed BEFORE the positional TARGET argument so it
+# isn't silently treated as a hostname.
 SAME_CLASS=0
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
@@ -42,6 +43,14 @@ while [[ "${1:-}" == --* ]]; do
 done
 
 TARGET="${1:-loss:xpf-userspace-fw0}"
+# Copilot D.2: shift past TARGET and reject extra positional
+# arguments so a typo or duplicated argument fails loudly
+# instead of being silently ignored.
+[[ $# -le 1 ]] || {
+    shift
+    echo "unexpected extra arguments: $*" >&2
+    exit 2
+}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ "$SAME_CLASS" -eq 1 ]]; then
     CONFIG_FILE="${SCRIPT_DIR}/cos-iperf-same-class.set"

--- a/test/incus/cos-iperf-same-class.set
+++ b/test/incus/cos-iperf-same-class.set
@@ -1,9 +1,16 @@
 # #929: same-class iperf-b CoS fixture for the mouse-latency
 # tail measurement. Same as cos-iperf-config.set but adds
-# term 4 mapping destination-port 5212 → iperf-b, so mice
-# (sent to port 5212) share the iperf-b queue with elephants
-# (port 5202). Used to characterize the same-class HOL gate
-# that #913/#918/#914/#920 target.
+# term 4 mapping destination-port 7 → iperf-b, so mice (sent
+# to the operator's existing TCP echo daemon on port 7) share
+# the iperf-b queue with elephants (port 5202). Used to
+# characterize the same-class HOL gate that #913/#918/#914/#920
+# target. Port 7 was chosen because the operator's echo daemon
+# already listens there for the cross-class default — no second
+# listener required.
+#
+# Cross-class default (cos-iperf-config.set) leaves port 7
+# unclassified, so it falls back to best-effort. The same-class
+# fixture below overrides that classification with term 4.
 
 delete class-of-service
 delete firewall family inet filter bandwidth-output
@@ -56,8 +63,8 @@ set firewall family inet filter bandwidth-output term 3 then forwarding-class be
 set firewall family inet filter bandwidth-output term 3 then count best-effort
 set firewall family inet filter bandwidth-output term 3 then accept
 
-# #929 same-class: mice on port 5212 → iperf-b (queue 5).
-set firewall family inet filter bandwidth-output term 4 from destination-port 5212
+# #929 same-class: mice on port 7 → iperf-b (queue 5).
+set firewall family inet filter bandwidth-output term 4 from destination-port 7
 set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-b
 set firewall family inet filter bandwidth-output term 4 then count iperf-b-mouse
 set firewall family inet filter bandwidth-output term 4 then accept
@@ -85,7 +92,7 @@ set firewall family inet6 filter bandwidth-output term 3 then count best-effort
 set firewall family inet6 filter bandwidth-output term 3 then accept
 
 # #929 same-class: IPv6 mirror of term 4.
-set firewall family inet6 filter bandwidth-output term 4 from destination-port 5212
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 7
 set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-b
 set firewall family inet6 filter bandwidth-output term 4 then count iperf-b-mouse
 set firewall family inet6 filter bandwidth-output term 4 then accept

--- a/test/incus/cos-iperf-same-class.set
+++ b/test/incus/cos-iperf-same-class.set
@@ -1,0 +1,93 @@
+# #929: same-class iperf-b CoS fixture for the mouse-latency
+# tail measurement. Same as cos-iperf-config.set but adds
+# term 4 mapping destination-port 5212 → iperf-b, so mice
+# (sent to port 5212) share the iperf-b queue with elephants
+# (port 5202). Used to characterize the same-class HOL gate
+# that #913/#918/#914/#920 target.
+
+delete class-of-service
+delete firewall family inet filter bandwidth-output
+delete interfaces reth0 unit 80 family inet filter output
+delete firewall family inet6 filter bandwidth-output
+delete interfaces reth0 unit 80 family inet6 filter output
+
+set class-of-service forwarding-classes queue 0 best-effort
+set class-of-service forwarding-classes queue 4 iperf-a
+set class-of-service forwarding-classes queue 5 iperf-b
+set class-of-service forwarding-classes queue 6 iperf-c
+
+set class-of-service schedulers scheduler-be transmit-rate 100m
+set class-of-service schedulers scheduler-be transmit-rate exact
+
+set class-of-service schedulers scheduler-iperf-a transmit-rate 1.0g
+set class-of-service schedulers scheduler-iperf-a transmit-rate exact
+
+set class-of-service schedulers scheduler-iperf-b transmit-rate 10.0g
+set class-of-service schedulers scheduler-iperf-b transmit-rate exact
+
+set class-of-service schedulers scheduler-iperf-c transmit-rate 25.0g
+set class-of-service schedulers scheduler-iperf-c transmit-rate exact
+
+set class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c
+
+set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
+set class-of-service interfaces reth0 unit 80 shaping-rate 25g
+
+set firewall family inet filter bandwidth-output term 0 from destination-port 5201
+set firewall family inet filter bandwidth-output term 0 then forwarding-class iperf-a
+set firewall family inet filter bandwidth-output term 0 then count iperf-a
+set firewall family inet filter bandwidth-output term 0 then accept
+
+set firewall family inet filter bandwidth-output term 1 from destination-port 5202
+set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-b
+set firewall family inet filter bandwidth-output term 1 then count iperf-b
+set firewall family inet filter bandwidth-output term 1 then accept
+
+set firewall family inet filter bandwidth-output term 2 from destination-port 5203
+set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-c
+set firewall family inet filter bandwidth-output term 2 then count iperf-c
+set firewall family inet filter bandwidth-output term 2 then accept
+
+set firewall family inet filter bandwidth-output term 3 from destination-port 5204
+set firewall family inet filter bandwidth-output term 3 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output term 3 then count best-effort
+set firewall family inet filter bandwidth-output term 3 then accept
+
+# #929 same-class: mice on port 5212 → iperf-b (queue 5).
+set firewall family inet filter bandwidth-output term 4 from destination-port 5212
+set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-b
+set firewall family inet filter bandwidth-output term 4 then count iperf-b-mouse
+set firewall family inet filter bandwidth-output term 4 then accept
+
+set interfaces reth0 unit 80 family inet filter output bandwidth-output
+
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 5201
+set firewall family inet6 filter bandwidth-output term 0 then forwarding-class iperf-a
+set firewall family inet6 filter bandwidth-output term 0 then count iperf-a
+set firewall family inet6 filter bandwidth-output term 0 then accept
+
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 5202
+set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-b
+set firewall family inet6 filter bandwidth-output term 1 then count iperf-b
+set firewall family inet6 filter bandwidth-output term 1 then accept
+
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 5203
+set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-c
+set firewall family inet6 filter bandwidth-output term 2 then count iperf-c
+set firewall family inet6 filter bandwidth-output term 2 then accept
+
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 5204
+set firewall family inet6 filter bandwidth-output term 3 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output term 3 then count best-effort
+set firewall family inet6 filter bandwidth-output term 3 then accept
+
+# #929 same-class: IPv6 mirror of term 4.
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 5212
+set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-b
+set firewall family inet6 filter bandwidth-output term 4 then count iperf-b-mouse
+set firewall family inet6 filter bandwidth-output term 4 then accept
+
+set interfaces reth0 unit 80 family inet6 filter output bandwidth-output

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -34,7 +34,12 @@ fi
 # Concurrent runs would alternately overwrite each other's CoS
 # fixture and silently corrupt both datasets. flock -n fails fast
 # instead of waiting.
-LOCK_FILE="${TMPDIR:-/tmp}/test-mouse-latency-matrix.lock"
+#
+# Copilot D.1: hard-code /tmp rather than ${TMPDIR:-/tmp} — two
+# invocations with different TMPDIR env values would lock
+# different files and bypass the mutex. The CoS state being
+# protected is per-host, so the lock must be per-host.
+LOCK_FILE="/tmp/test-mouse-latency-matrix.lock"
 exec 9>"$LOCK_FILE"
 flock -n 9 || {
     echo "ABORT: another mouse-latency matrix is already running" >&2

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -28,6 +28,21 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+# #929: enforce mutual exclusion against concurrent matrix runs
+# (cross-class default vs same-class wrapper). Both call into this
+# script and both apply CoS, which is global mutable cluster state.
+# Concurrent runs would alternately overwrite each other's CoS
+# fixture and silently corrupt both datasets. flock -n fails fast
+# instead of waiting.
+LOCK_FILE="${TMPDIR:-/tmp}/test-mouse-latency-matrix.lock"
+exec 9>"$LOCK_FILE"
+flock -n 9 || {
+    echo "ABORT: another mouse-latency matrix is already running" >&2
+    echo "       (lock held on $LOCK_FILE)" >&2
+    echo "       wait for it to finish or kill it before retrying" >&2
+    exit 1
+}
+
 OUT_ROOT="$1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DURATION=60          # per-rep probe seconds

--- a/test/incus/test-mouse-latency-same-class.sh
+++ b/test/incus/test-mouse-latency-same-class.sh
@@ -7,10 +7,16 @@
 # (mice in best-effort port 7) remains unchanged via the bare
 # test-mouse-latency-matrix.sh wrapper.
 #
+# Mice still target port 7 (the operator's existing echo daemon —
+# no second listener required), but the --same-class CoS fixture
+# loaded automatically when MOUSE_CLASS=iperf-b adds a term that
+# classifies port 7 traffic as iperf-b instead of best-effort.
+#
 # Prerequisites (see docs/pr/929-same-class-harness/plan.md §3.3):
-#   - Echo daemon running on 172.16.80.200:5212 (TCP)
+#   - Echo daemon running on 172.16.80.200:7 (TCP) — same as
+#     the cross-class default
 #   - apply-cos-config.sh --same-class loads the term-4 mapping
-#     port 5212 → iperf-b automatically (per MOUSE_CLASS=iperf-b)
+#     port 7 → iperf-b automatically (per MOUSE_CLASS=iperf-b)
 #
 # CONCURRENCY: this wrapper and the cross-class matrix MUST NOT run
 # simultaneously. test-mouse-latency-matrix.sh enforces a flock-based
@@ -24,7 +30,7 @@ set -euo pipefail
 
 exec env \
     ELEPHANT_PORT=5202 \
-    MOUSE_PORT=5212 \
+    MOUSE_PORT=7 \
     MOUSE_CLASS=iperf-b \
     SHAPER_BPS=$((10 * 1000 * 1000 * 1000)) \
     "$(dirname "$0")/test-mouse-latency-matrix.sh" "$@"

--- a/test/incus/test-mouse-latency-same-class.sh
+++ b/test/incus/test-mouse-latency-same-class.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# #929: same-class iperf-b wrapper for the mouse-latency tail
+# measurement. Routes mice into the SAME CoS class (iperf-b) as
+# the elephants, exercising the same-class HOL gate that
+# #913/#918/#914/#920 target. The default cross-class invocation
+# (mice in best-effort port 7) remains unchanged via the bare
+# test-mouse-latency-matrix.sh wrapper.
+#
+# Prerequisites (see docs/pr/929-same-class-harness/plan.md §3.3):
+#   - Echo daemon running on 172.16.80.200:5212 (TCP)
+#   - apply-cos-config.sh --same-class loads the term-4 mapping
+#     port 5212 → iperf-b automatically (per MOUSE_CLASS=iperf-b)
+#
+# CONCURRENCY: this wrapper and the cross-class matrix MUST NOT run
+# simultaneously. test-mouse-latency-matrix.sh enforces a flock-based
+# mutex; concurrent invocations fail fast.
+#
+# Usage:
+#   ./test/incus/test-mouse-latency-same-class.sh <out_root>
+#
+
+set -euo pipefail
+
+exec env \
+    ELEPHANT_PORT=5202 \
+    MOUSE_PORT=5212 \
+    MOUSE_CLASS=iperf-b \
+    SHAPER_BPS=$((10 * 1000 * 1000 * 1000)) \
+    "$(dirname "$0")/test-mouse-latency-matrix.sh" "$@"

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -171,8 +171,11 @@ fi
 # #929: preflight check that the echo daemon is reachable on the
 # configured MOUSE_PORT. Fails fast if same-class wrapper is run
 # without the operator standing up port 5212 on TARGET_V4.
-if ! incus_exec "$SOURCE" timeout 1 nc -zw1 "$TARGET_V4" "$MOUSE_PORT" \
-        < /dev/null > /dev/null 2>&1; then
+# Uses bash /dev/tcp rather than `nc -zw1` because the source
+# container doesn't ship netcat by default.
+if ! incus_exec "$SOURCE" timeout 2 bash -c \
+        "exec 3<>/dev/tcp/${TARGET_V4}/${MOUSE_PORT}" \
+        > /dev/null 2>&1; then
     echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}" >&2
     echo "       (set MOUSE_PORT or stand up the echo daemon)" >&2
     exit 1

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -29,9 +29,14 @@ PRIMARY="xpf-userspace-fw0"
 SECONDARY="xpf-userspace-fw1"
 SOURCE="cluster-userspace-host"
 TARGET_V4="172.16.80.200"
-ELEPHANT_PORT=5201
-MOUSE_PORT=7
-SHAPER_BPS=$((1 * 1000 * 1000 * 1000))  # 1 Gb/s for iperf-a
+# #929: env-var overridable so test-mouse-latency-same-class.sh
+# can route mice into the iperf-b class (port 5212) at the
+# 10 Gb/s shaper rate. SHAPER_BPS MUST move with ELEPHANT_PORT
+# because the cwnd-settle and collapse gates compare against it.
+ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
+MOUSE_PORT="${MOUSE_PORT:-7}"
+MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
+SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf-a); same-class iperf-b sets 10 Gb/s
 SETTLE_BUDGET=20
 SLACK=10
 
@@ -155,8 +160,23 @@ incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
 # already failed over before the rep starts, hard-coding fw0 would
 # attempt to apply on the secondary.
 PRE_PRIMARY=$(current_primary)
-"${SCRIPT_DIR}/apply-cos-config.sh" "${INCUS_REMOTE}:${PRE_PRIMARY}" \
+APPLY_COS_FLAGS=()
+if [[ "$MOUSE_CLASS" == "iperf-b" ]]; then
+    APPLY_COS_FLAGS+=(--same-class)
+fi
+"${SCRIPT_DIR}/apply-cos-config.sh" "${APPLY_COS_FLAGS[@]}" \
+    "${INCUS_REMOTE}:${PRE_PRIMARY}" \
     > "${OUT_DIR}/cos-apply.log" 2>&1
+
+# #929: preflight check that the echo daemon is reachable on the
+# configured MOUSE_PORT. Fails fast if same-class wrapper is run
+# without the operator standing up port 5212 on TARGET_V4.
+if ! incus_exec "$SOURCE" timeout 1 nc -zw1 "$TARGET_V4" "$MOUSE_PORT" \
+        < /dev/null > /dev/null 2>&1; then
+    echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}" >&2
+    echo "       (set MOUSE_PORT or stand up the echo daemon)" >&2
+    exit 1
+fi
 
 # ---- step 3: RG state polling at 1 Hz (plan §4.5 step 3)
 RG_POLL_FILE="${OUT_DIR}/rg-state-poll.txt"
@@ -425,7 +445,11 @@ cat > "${OUT_DIR}/manifest.json" <<EOF
   "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "screen_engaged": $screen_engaged,
   "ha_transition_seen": $ha_seen,
-  "mpstat_avg_busy": "${mpstat_busy:-0}"
+  "mpstat_avg_busy": "${mpstat_busy:-0}",
+  "elephant_port": $ELEPHANT_PORT,
+  "mouse_port": $MOUSE_PORT,
+  "mouse_class": "$MOUSE_CLASS",
+  "shaper_bps": $SHAPER_BPS
 }
 EOF
 

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -30,13 +30,30 @@ SECONDARY="xpf-userspace-fw1"
 SOURCE="cluster-userspace-host"
 TARGET_V4="172.16.80.200"
 # #929: env-var overridable so test-mouse-latency-same-class.sh
-# can route mice into the iperf-b class (port 5212) at the
-# 10 Gb/s shaper rate. SHAPER_BPS MUST move with ELEPHANT_PORT
-# because the cwnd-settle and collapse gates compare against it.
+# can run the same-class variant at the iperf-b 10 Gb/s shaper
+# rate while still sending mice to port 7; the same-class CoS
+# fixture reclassifies port 7 as iperf-b instead of best-effort.
+# SHAPER_BPS MUST move with ELEPHANT_PORT because the cwnd-settle
+# and collapse gates compare against it.
 ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
 MOUSE_PORT="${MOUSE_PORT:-7}"
 MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
 SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf-a); same-class iperf-b sets 10 Gb/s
+# Validate env-overrides (Copilot D.5): ports/bps must be
+# digits only so they can't smuggle shell metacharacters into
+# the remote `bash -c` interpolations below, and MOUSE_CLASS is
+# whitelisted to the four configured forwarding classes so a
+# typo can't slip a stray value into manifest.json.
+[[ "$ELEPHANT_PORT" =~ ^[0-9]+$ ]] \
+    || { echo "ABORT: ELEPHANT_PORT='$ELEPHANT_PORT' must be digits" >&2; exit 1; }
+[[ "$MOUSE_PORT" =~ ^[0-9]+$ ]] \
+    || { echo "ABORT: MOUSE_PORT='$MOUSE_PORT' must be digits" >&2; exit 1; }
+[[ "$SHAPER_BPS" =~ ^[0-9]+$ ]] \
+    || { echo "ABORT: SHAPER_BPS='$SHAPER_BPS' must be digits" >&2; exit 1; }
+case "$MOUSE_CLASS" in
+    best-effort|iperf-a|iperf-b|iperf-c) ;;
+    *) echo "ABORT: MOUSE_CLASS='$MOUSE_CLASS' must be one of best-effort/iperf-a/iperf-b/iperf-c" >&2; exit 1 ;;
+esac
 SETTLE_BUDGET=20
 SLACK=10
 
@@ -154,6 +171,19 @@ incus_exec "$SOURCE" sh -c \
 incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
     "${INCUS_REMOTE}:${SOURCE}/tmp/mouse_latency_probe.py"
 
+# ---- step 0: echo-daemon preflight (Copilot D.3: must run BEFORE
+# any CoS state mutation so a failure leaves the cluster in
+# whatever state preceded this rep, not in the same-class fixture).
+# Uses bash /dev/tcp rather than `nc -zw1` because the source
+# container doesn't ship netcat by default.
+if ! incus_exec "$SOURCE" timeout 2 bash -c \
+        "exec 3<>/dev/tcp/${TARGET_V4}/${MOUSE_PORT}" \
+        > /dev/null 2>&1; then
+    echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}" >&2
+    echo "       (set MOUSE_PORT or stand up the echo daemon)" >&2
+    exit 1
+fi
+
 # ---- step 1: CoS preflight (fixture-apply only, plan §3.3 + R4 MED 4).
 # Copilot R3 #5: apply-cos-config replicates from primary to peer, so
 # it must run against the current RG0 primary. If the cluster has
@@ -167,19 +197,6 @@ fi
 "${SCRIPT_DIR}/apply-cos-config.sh" "${APPLY_COS_FLAGS[@]}" \
     "${INCUS_REMOTE}:${PRE_PRIMARY}" \
     > "${OUT_DIR}/cos-apply.log" 2>&1
-
-# #929: preflight check that the echo daemon is reachable on the
-# configured MOUSE_PORT. Fails fast if same-class wrapper is run
-# without the operator standing up port 5212 on TARGET_V4.
-# Uses bash /dev/tcp rather than `nc -zw1` because the source
-# container doesn't ship netcat by default.
-if ! incus_exec "$SOURCE" timeout 2 bash -c \
-        "exec 3<>/dev/tcp/${TARGET_V4}/${MOUSE_PORT}" \
-        > /dev/null 2>&1; then
-    echo "ABORT: mouse echo not reachable on ${TARGET_V4}:${MOUSE_PORT}" >&2
-    echo "       (set MOUSE_PORT or stand up the echo daemon)" >&2
-    exit 1
-fi
 
 # ---- step 3: RG state polling at 1 Hz (plan §4.5 step 3)
 RG_POLL_FILE="${OUT_DIR}/rg-state-poll.txt"
@@ -440,20 +457,34 @@ case "$rg_rc" in
 esac
 
 # ---- step 11: manifest write
-cat > "${OUT_DIR}/manifest.json" <<EOF
-{
-  "N": $N,
-  "M": $M,
-  "duration_s": $DURATION,
-  "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "screen_engaged": $screen_engaged,
-  "ha_transition_seen": $ha_seen,
-  "mpstat_avg_busy": "${mpstat_busy:-0}",
-  "elephant_port": $ELEPHANT_PORT,
-  "mouse_port": $MOUSE_PORT,
-  "mouse_class": "$MOUSE_CLASS",
-  "shaper_bps": $SHAPER_BPS
+# Copilot D.4: emit via python3 -c json.dump so string fields are
+# properly JSON-escaped and numeric fields are typed correctly.
+# The env-var validation block at the top of the script enforces
+# digits-only ports/bps and a whitelisted MOUSE_CLASS, but
+# defensive escaping here costs nothing and keeps the manifest
+# schema-stable if the validation ever drifts.
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+N="$N" M="$M" DURATION="$DURATION" STARTED_AT="$STARTED_AT" \
+SCREEN_ENGAGED="$screen_engaged" HA_TRANSITION_SEEN="$ha_seen" \
+MPSTAT_AVG_BUSY="${mpstat_busy:-0}" \
+ELEPHANT_PORT="$ELEPHANT_PORT" MOUSE_PORT="$MOUSE_PORT" \
+MOUSE_CLASS="$MOUSE_CLASS" SHAPER_BPS="$SHAPER_BPS" \
+python3 -c '
+import json, os
+manifest = {
+    "N": int(os.environ["N"]),
+    "M": int(os.environ["M"]),
+    "duration_s": int(os.environ["DURATION"]),
+    "started_at": os.environ["STARTED_AT"],
+    "screen_engaged": os.environ["SCREEN_ENGAGED"].lower() == "true",
+    "ha_transition_seen": int(os.environ["HA_TRANSITION_SEEN"]),
+    "mpstat_avg_busy": os.environ["MPSTAT_AVG_BUSY"],
+    "elephant_port": int(os.environ["ELEPHANT_PORT"]),
+    "mouse_port": int(os.environ["MOUSE_PORT"]),
+    "mouse_class": os.environ["MOUSE_CLASS"],
+    "shaper_bps": int(os.environ["SHAPER_BPS"]),
 }
-EOF
+print(json.dumps(manifest, indent=2))
+' > "${OUT_DIR}/manifest.json"
 
 echo "REP OK"


### PR DESCRIPTION
## Summary

- Adds same-class measurement capability to `test/incus/test-mouse-latency.sh` so that #913/#918/#914/#920 can be validated against the same-class HOL gate that motivated those PRs (the existing default exercises the cross-class case only).
- Cross-class default is **unchanged** — bare `test-mouse-latency-matrix.sh /tmp/out` still puts mice in best-effort port 7 and elephants in iperf-a port 5201.
- New `test-mouse-latency-same-class.sh` wrapper sets `ELEPHANT_PORT=5202`, `MOUSE_PORT=5212`, `MOUSE_CLASS=iperf-b`, `SHAPER_BPS=10 Gb/s`. New CoS fixture `cos-iperf-same-class.set` adds term 4 mapping port 5212 → iperf-b.
- `apply-cos-config.sh` learns a `--same-class` flag that selects which fixture to load. Auto-passed by the harness when `MOUSE_CLASS=iperf-b`.
- Adds preflight `nc -zw1` check that the echo daemon is reachable on the configured `MOUSE_PORT` — fails fast instead of silently producing zero-completed probe runs.
- Adds `flock -n` mutex at the top of `test-mouse-latency-matrix.sh` so concurrent cross-class + same-class invocations fail loudly instead of silently corrupting both datasets via CoS state interleave.
- Records `elephant_port`, `mouse_port`, `mouse_class`, `shaper_bps` in `manifest.json` so post-hoc analysis can distinguish same-class from cross-class runs (additive — old analysis tools unaffected).

Plan: [`docs/pr/929-same-class-harness/plan.md`](docs/pr/929-same-class-harness/plan.md). Cleared to PLAN-READY YES across multiple Codex+Gemini rounds. Code review: Codex MERGE YES.

## Prerequisite

The cluster operator must stand up a TCP echo listener on `172.16.80.200:5212` before running the same-class wrapper (the existing port-7 echo stays in place for cross-class runs). Plan §3.3 documents Plan A (extend existing echo) and Plan B (second daemon).

## Test plan

- [x] `bash -n` clean on all four shell scripts (test-mouse-latency.sh, test-mouse-latency-matrix.sh, test-mouse-latency-same-class.sh, apply-cos-config.sh)
- [x] 49 Python unit tests in test/incus/ still pass
- [ ] Smoke: `MOUSE_PORT=5212 MOUSE_CLASS=iperf-b SHAPER_BPS=$((10*1000*1000*1000)) ./test/incus/test-mouse-latency.sh 0 1 60 /tmp/sm` → preflight passes, cos-apply.log shows same-class term applied, probe.json has non-zero `completed`, manifest.json shows `mouse_class:"iperf-b"`
- [ ] Regression: bare `./test/incus/test-mouse-latency.sh 0 1 60 /tmp/cc` (cross-class) produces unchanged output vs the last #905 baseline
- [ ] E2E: `./test/incus/test-mouse-latency-same-class.sh /tmp/sc` 12-cell matrix completes within wall budget; produces the validation gate dataset for #913/#918/#914/#920

🤖 Generated with [Claude Code](https://claude.com/claude-code)