### PR TITLE
#927 MQFQ drained-bucket orphan-cleanup preserves served_finish

### DIFF
--- a/docs/pr/926-demote-vtime-inflation/plan.md
+++ b/docs/pr/926-demote-vtime-inflation/plan.md
@@ -1,0 +1,183 @@
+# Plan: #926 — demote_prepared_cos_queue_to_local vtime preservation
+
+Issue: #926
+Predecessor: #913 (MQFQ vtime fix; this is the deferred-NEEDS-MAJOR
+follow-up Codex review-mogzqvpf-xojwmt flagged)
+Blocks: #917 (V_min sync runs against the corrected vtime signal)
+
+## 1. Problem
+
+(Full walkthrough in the issue body.)
+
+`demote_prepared_cos_queue_to_local` at `tx.rs:5303-5319`
+drains a flow-fair exact queue with `cos_queue_drain_all`
+(aggregate-bytes vtime advance per pop), then re-enqueues
+the converted Local items via `cos_queue_push_back` on the
+SUCCESS path. No bytes were transmitted, but `queue_vtime`
+gets inflated by the entire drained backlog.
+
+A new flow Y enqueued immediately after demotion can anchor
+at the inflated `queue_vtime` with a smaller finish time than
+the demoted backlog — recreating temporal-inversion HOL
+inversion (same class as #911 / #913).
+
+The failure-rollback path (`drain_all → restore_front`) DOES
+work correctly per #913 design — that path is round-trip
+neutral. The success path was never neutral and is the bug.
+
+## 2. Goal
+
+Preserve `queue_vtime` and `flow_bucket_*_finish_bytes` across
+the success path so that no new flow can jump ahead of the
+demoted backlog.
+
+## 3. Approach
+
+### 3.1 Decision: in-place conversion (Option 1 from issue)
+
+The issue body proposes two options:
+
+1. **In-place conversion**: walk `flow_bucket_items[bucket]`
+   for each active bucket; replace each
+   `CoSPendingTxItem::Prepared` with its `Local` equivalent.
+   No drain_all, no push_back, no vtime touch. Items keep
+   their position in the bucket's VecDeque.
+
+2. **Snapshot/restore**: save `queue_vtime` +
+   `flow_bucket_*_finish_bytes` + `flow_bucket_bytes` +
+   `active_flow_buckets` + `active_flow_buckets_peak` before
+   `cos_queue_drain_all`. Restore on success.
+
+**Pick Option 1 (in-place).** Cleaner, single-loop, no Vec
+clones, no risk of forgetting a field. The in-place path also
+preserves item ORDER within the bucket — important for MQFQ
+which serializes by VecDeque order within a flow's bucket.
+
+### 3.2 Implementation sketch
+
+```rust
+fn demote_prepared_cos_queue_to_local(
+    binding: &mut Binding,
+    queue: &mut CoSQueueRuntime,
+    forwarding: &ForwardingState,
+    /* ... existing params ... */
+) -> Result<(), DemoteError> {
+    // 1. Iterate every active bucket in this queue.
+    // 2. Walk that bucket's items VecDeque.
+    // 3. For each item: convert Prepared → Local (the same
+    //    conversion logic the failure-rollback path uses on
+    //    re-enqueue, without the re-enqueue).
+    // 4. Update tx-stat counters (Prepared count -- / Local count ++)
+    //    inline as items convert. No queued_bytes change.
+    // 5. queue_vtime, flow_bucket_*_finish_bytes,
+    //    active_flow_buckets all left untouched.
+    for (bucket_idx, items) in queue.flow_bucket_items.iter_mut().enumerate() {
+        // Skip buckets that don't have Prepared items for this binding.
+        for slot in items.iter_mut() {
+            match slot {
+                CoSPendingTxItem::Prepared(prep) => {
+                    // Convert via the same path drain_all → push_back used.
+                    let local = convert_prepared_to_local(prep, forwarding, binding)?;
+                    *slot = CoSPendingTxItem::Local(local);
+                    // Update binding-side tx counters.
+                    binding.dec_prepared_count();
+                    binding.inc_local_count();
+                }
+                CoSPendingTxItem::Local(_) => {
+                    // Should not occur on this queue type, but skip safely.
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+The exact `convert_prepared_to_local` body comes from the
+existing failure-rollback re-enqueue path. Refactor it into a
+shared helper if not already.
+
+### 3.3 Failure-path handling
+
+If `convert_prepared_to_local` fails partway through (e.g.,
+forwarding state changed), the queue is in a partial state:
+some items Local, some still Prepared. Two options:
+
+- **Two-pass with savepoint**: first pass validates all
+  conversions are feasible; second pass commits. Prevents
+  partial state but doubles iteration cost.
+- **Rollback on failure**: walk the slots already converted
+  and revert them to Prepared. Convert is reversible (Local
+  → Prepared just unsets the precomputed wire-side state).
+
+**Pick rollback-on-failure.** Cheaper than two-pass; matches
+the existing failure semantics that `drain_all → restore_front`
+already handled (drain side).
+
+### 3.4 What this is NOT
+
+- Not a change to `cos_queue_drain_all` or
+  `cos_queue_push_back`. The failure-rollback path still uses
+  them — that path is round-trip neutral and stays correct.
+- Not a change to the demote function's caller contract.
+  Same Result<(), DemoteError> shape, same observable
+  side-effects on success and failure.
+- Not a change to per-flow accounting. `queue.queued_bytes`,
+  `flow_bucket_bytes[]`, `active_flow_buckets` all unchanged
+  across the success path.
+
+## 4. Files touched
+
+- `userspace-dp/src/afxdp/tx.rs`: rewrite
+  `demote_prepared_cos_queue_to_local` to use in-place
+  conversion on the success path. Failure path unchanged
+  (still drain_all → restore_front).
+- New unit test:
+  `demote_prepared_to_local_preserves_queue_vtime` —
+  enqueue several Prepared items; capture pre-demote
+  `queue_vtime`/finish-times; demote; assert all preserved.
+- New unit test:
+  `demote_prepared_to_local_no_temporal_inversion` —
+  the issue body's walkthrough (Y can't jump ahead of
+  demoted backlog).
+
+## 5. Test strategy
+
+- Existing demote-path tests (failure rollback, partial-fail
+  recovery) must continue to pass.
+- New regression tests for the in-place success path.
+- `cargo test --release` 765+ pass.
+
+## 6. Risks
+
+- **Refactor scope**: extracting `convert_prepared_to_local`
+  as a shared helper might force changes in the failure
+  rollback re-enqueue path too. Keep the rollback path
+  semantically identical — only factoring shared code.
+- **Iterator invalidation**: walking `flow_bucket_items[bucket]`
+  with `iter_mut` and replacing slots in-place is safe in
+  Rust (no length change, no Vec mutation). Verify the
+  `binding.dec_prepared_count()` / `inc_local_count()` calls
+  don't reach back into `binding.flow_bucket_items` (they
+  shouldn't — they update counters on the binding struct, not
+  the queue runtime).
+- **Interaction with #927 (parallel work)**: #927 changes
+  `cos_queue_clear_orphan_snapshot_after_drop`. No file-line
+  conflict expected; both in `tx.rs` but different
+  functions.
+- **Telemetry**: per-binding Prepared-count and Local-count
+  drifts are visible via existing counters; no new telemetry
+  added.
+
+## 7. Acceptance
+
+- [ ] Plan reviewed by Codex (hostile); PLAN-READY YES.
+- [ ] Plan reviewed by Gemini (adversarial); MERGE YES.
+- [ ] Implemented; `cargo build --release` clean.
+- [ ] New regression tests pass.
+- [ ] Full `cargo test --release` 765+ pass.
+- [ ] Codex hostile code review: MERGE YES.
+- [ ] Gemini adversarial code review: MERGE YES.
+- [ ] PR opened, Copilot review addressed.
+- [ ] Merged.

--- a/docs/pr/927-mqfq-orphan-vtime/plan.md
+++ b/docs/pr/927-mqfq-orphan-vtime/plan.md
@@ -1,0 +1,165 @@
+# Plan: #927 — MQFQ drained-bucket vtime preservation
+
+Issue: #927
+Predecessor: #913 (MQFQ vtime fix; this is the deferred-NEEDS-MAJOR
+follow-up Codex review-moh12hph-w5ztyx flagged)
+Blocks: #917 (V_min sync runs against the corrected vtime signal)
+
+## 1. Problem
+
+(Full walkthrough in the issue body.)
+
+When the scratch-builder pops multiple items from the SAME bucket
+and the LAST item drains the bucket, then is DROPPED (frame too
+big, etc.), the surviving earlier item's restore via
+`cos_queue_push_front` takes the `was_empty` path. That path
+restores `head_finish` from `snap.pre_pop_head_finish` — losing
+the dropped item's "virtual service" advance (`served_finish`).
+A competing active bucket can then have its scheduling inverted.
+
+The arithmetic-based active-bucket restore (post-#913) is correct.
+The drained-bucket / snapshot-restore branch is the gap.
+
+## 2. Goal
+
+Preserve the dropped item's served-finish in the surviving
+older same-bucket snapshots, so that when those snapshots are
+later popped via `was_empty` restore, `head_finish` reflects
+the bytes that were dispatched (and dropped) on this bucket
+between the older snapshot and the orphaned snapshot.
+
+## 3. Approach
+
+### 3.1 Helper internals only — no signature change (Codex R1)
+
+v1 proposed adding `item_len: u64` so the helper could compute
+`dropped_served_finish = orphan.pre_pop_head_finish + item_len`.
+Codex R1 caught two issues:
+
+- The formula over-inflates. `served_finish` for the popped
+  item equals `pre_pop_head_finish` (per `tx.rs:4637-4639`,
+  served_finish is read FROM `flow_bucket_head_finish_bytes`
+  BEFORE the bucket head is updated). Adding `item_len` would
+  bump the snapshot frontier by an extra `item_len` bytes,
+  unfairly delaying any future flow that re-anchors to this
+  bucket.
+- The helper signature already has access to the orphan's
+  `bucket` field via `CoSQueuePopSnapshot::bucket` (per
+  `types.rs:1018-1042`). No caller change needed.
+
+**Decision: pure helper-internal change.** Same signature, no
+caller updates. Existing test sites at `tx.rs:11883` and
+`:12025` (which Codex R1 also flagged as missing from the v1
+plan) are untouched.
+
+### 3.2 Helper body change
+
+Inside `cos_queue_clear_orphan_snapshot_after_drop` at
+`tx.rs:4718`, after popping the orphan and the existing
+`pre_pop_queue_vtime` clamp loop, add a same-bucket finish-
+time clamp using the orphan's served_finish:
+
+```rust
+fn cos_queue_clear_orphan_snapshot_after_drop(queue: &mut CoSQueueRuntime) {
+    let Some(orphan) = queue.pop_snapshot_stack.pop() else { return };
+    let z_committed_vtime = queue.queue_vtime;
+    // Orphan's served_finish == its pre_pop_head_finish (the
+    // bucket's head_finish at the moment we popped the dropped
+    // item). #913 head/tail invariants guarantee any older
+    // same-bucket snapshot's frontier was ≤ this value at the
+    // time it was captured, so .max(...) only raises and never
+    // crosses an already-committed boundary.
+    let orphan_served_finish = orphan.pre_pop_head_finish;
+    for snap in queue.pop_snapshot_stack.iter_mut() {
+        if snap.pre_pop_queue_vtime < z_committed_vtime {
+            snap.pre_pop_queue_vtime = z_committed_vtime;
+        }
+        if snap.bucket == orphan.bucket {
+            snap.pre_pop_head_finish =
+                snap.pre_pop_head_finish.max(orphan_served_finish);
+            snap.pre_pop_tail_finish =
+                snap.pre_pop_tail_finish.max(orphan_served_finish);
+        }
+    }
+}
+```
+
+Note: merged into the existing clamp loop so the stack walks
+once, not twice.
+
+The `.max(...)` is monotone — older snapshots' finish-times
+already reflect committed pops up to that snapshot's pop-time
+frontier. Bumping to `orphan_served_finish` only raises them
+when the dropped item's served-finish exceeds what was already
+recorded. Never lowers, so no semantic regression on the
+restore path.
+
+### 3.3 Caller updates
+
+None. The four scratch-builder Drop sites at `tx.rs:2660`,
+`:2679`, `:2846`, `:2877` and the two test sites at
+`tx.rs:11883`, `:12025` continue to call the helper with the
+existing single `queue` argument.
+
+### 3.4 What this is NOT
+
+- Not a change to the active-bucket arithmetic restore path
+  (#913 site at `cos_queue_push_front` ~`tx.rs:4459-4500`).
+- Not a change to `was_empty` snapshot semantics — only the
+  signal feeding into them.
+- Not a change to per-flow accounting, bucket flags, or
+  active_flow_buckets count.
+
+## 4. Files touched
+
+- `userspace-dp/src/afxdp/tx.rs`: helper-internal change to
+  `cos_queue_clear_orphan_snapshot_after_drop` — same single-
+  argument signature, just adds the same-bucket finish-time
+  clamp inside the existing stack-walk loop using
+  `orphan.pre_pop_head_finish` (= the dropped item's
+  served_finish). No caller-site updates; no test-call-site
+  updates.
+- New unit test:
+  `mqfq_drained_bucket_orphan_drop_preserves_served_finish` —
+  exercises the scenario from the issue body's walkthrough
+  (A=[A1,A2], C=[C], pop A1+C+A2, drop A2, restore C and A1,
+  assert **A1.head > C.head strictly** so MQFQ pops C first.
+  Codex R1: strict `>` because `cos_queue_front` uses strict
+  `<` tie-break at `tx.rs:4336-4346`; equal head_finish
+  leaves ordering implementation-defined.
+
+## 5. Test strategy
+
+- Existing #913 tests (especially
+  `mqfq_same_bucket_multipop_drop_preserves_dropped_item_finish`)
+  must continue to pass — they cover the same-bucket-with-
+  successor case.
+- New regression test for the drained-bucket scenario.
+- `cargo test --release` 765+ pass.
+
+## 6. Risks
+
+- **Snapshot-stack walk cost.** Each orphan-cleanup now walks
+  the full stack (bounded by TX_BATCH_SIZE = 64 post-#920).
+  Worst case 64 comparisons + 0–2 writes per orphan. Orphan
+  cleanup itself is rare (only on drop). Negligible.
+- **No arithmetic overflow.** v2 reads
+  `orphan.pre_pop_head_finish` directly and clamps existing
+  snapshot fields with `.max(...)` — no addition, no overflow
+  surface. (v1's `+ item_len` was wrong on the merits per
+  §3.1; this risk no longer applies.)
+- **Interaction with #926 (parallel work).** #926 changes the
+  demote-path, not the orphan-cleanup. No file-line conflict
+  expected; both touch `tx.rs` but in different functions.
+
+## 7. Acceptance
+
+- [ ] Plan reviewed by Codex (hostile); PLAN-READY YES.
+- [ ] Plan reviewed by Gemini (adversarial); MERGE YES.
+- [ ] Implemented; `cargo build --release` clean.
+- [ ] New regression test passes.
+- [ ] Full `cargo test --release` 765+ pass.
+- [ ] Codex hostile code review: MERGE YES.
+- [ ] Gemini adversarial code review: MERGE YES.
+- [ ] PR opened, Copilot review addressed.
+- [ ] Merged.

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -12128,9 +12128,9 @@ mod tests {
         let popped_a1 = cos_queue_pop_front(queue).expect("pop A1");
         assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_a], 3000);
 
-        // Pop C: bucket C drains (A.head_finish=3000 < C=2500? No,
-        // 3000 > 2500 so MQFQ picks C next). After pop: C empty;
-        // C.head_finish reset to 0.
+        // Pop C: MQFQ picks min-finish-first; with A.head=3000
+        // and C.head=2500, C.head < A.head so C is the next pop.
+        // After pop: bucket C empty; C.head_finish reset to 0.
         let popped_c = cos_queue_pop_front(queue).expect("pop C");
         assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_c], 0);
 

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -4716,17 +4716,39 @@ fn cos_queue_pop_front_inner(
 /// vtime=3000. Restore A: vtime=3000. Z's vtime contribution
 /// preserved across the rollback.
 fn cos_queue_clear_orphan_snapshot_after_drop(queue: &mut CoSQueueRuntime) {
-    let popped = queue.pop_snapshot_stack.pop();
-    if popped.is_none() {
+    let Some(orphan) = queue.pop_snapshot_stack.pop() else {
         return;
-    }
+    };
     // queue.queue_vtime here reflects the dropped item's pop
     // advance (already applied in cos_queue_pop_front_inner).
     // Clamp remaining snapshots to preserve it across rollback.
     let z_committed_vtime = queue.queue_vtime;
+    // #927: also preserve the dropped item's bucket-frontier
+    // contribution. The dropped item's served_finish equals
+    // `orphan.pre_pop_head_finish` (served_finish is read from
+    // `flow_bucket_head_finish_bytes[bucket]` BEFORE the
+    // post-pop overwrite at the orphan's pop site, so it
+    // matches the snapshot's pre_pop_head_finish capture).
+    // Older same-bucket snapshots were captured before the
+    // dropped item's pop, so their pre_pop_head/tail_finish
+    // do not include the dropped item's frontier. When such a
+    // snapshot is later restored via the `was_empty` snapshot
+    // path in `cos_queue_push_front`, the bucket would be
+    // re-anchored at a stale (lower) finish-time — competing
+    // active buckets could be incorrectly scheduled before
+    // it. Bumping to `orphan_served_finish` via .max() is
+    // monotone (only raises) and never crosses a committed
+    // boundary, so it is safe across all rollback orderings.
+    let orphan_served_finish = orphan.pre_pop_head_finish;
     for snap in queue.pop_snapshot_stack.iter_mut() {
         if snap.pre_pop_queue_vtime < z_committed_vtime {
             snap.pre_pop_queue_vtime = z_committed_vtime;
+        }
+        if snap.bucket == orphan.bucket {
+            snap.pre_pop_head_finish =
+                snap.pre_pop_head_finish.max(orphan_served_finish);
+            snap.pre_pop_tail_finish =
+                snap.pre_pop_tail_finish.max(orphan_served_finish);
         }
     }
 }
@@ -12049,6 +12071,102 @@ mod tests {
              that were originally scheduled in the [3000, 4500) \
              window — exactly the temporal inversion #913 was \
              supposed to prevent."
+        );
+    }
+
+    /// #927: drained-bucket scenario. Bucket A holds [A1=1000B,
+    /// A2=2000B], bucket C holds [C=2500B]. Scratch builder pops
+    /// A1+C+A2 in that order. A2's pop drains bucket A (last item).
+    /// A2 is then dropped (frame too big, etc.). The orphan-cleanup
+    /// helper must preserve A2's served_finish = 3000 across the
+    /// restore so that A1's restored frontier is ≥ 3000. Otherwise
+    /// the `was_empty` snapshot path in `cos_queue_push_front`
+    /// would restore A.head=1000 (the snap_1.pre_pop_head_finish
+    /// captured before A2's pop), and MQFQ would pop A1 BEFORE
+    /// C — inverting their original scheduling order.
+    #[test]
+    fn mqfq_drained_bucket_orphan_drop_preserves_served_finish() {
+        let mut root = test_cos_runtime_with_queues(
+            25_000_000_000 / 8,
+            vec![CoSQueueConfig {
+                queue_id: 4,
+                forwarding_class: "iperf-a".into(),
+                priority: 5,
+                transmit_rate_bytes: 1_000_000_000 / 8,
+                exact: true,
+                surplus_weight: 1,
+                buffer_bytes: 128 * 1024,
+                dscp_rewrite: None,
+            }],
+        );
+        let queue = &mut root.queues[0];
+        queue.flow_fair = true;
+        queue.flow_hash_seed = 0;
+
+        // Bucket A: [A1=1000, A2=2000]. Bucket C: [C=2500].
+        // Two distinct flow keys so they hash to distinct buckets.
+        cos_queue_push_back(queue, test_flow_cos_item(8001, 1000));
+        cos_queue_push_back(queue, test_flow_cos_item(8001, 2000));
+        cos_queue_push_back(queue, test_flow_cos_item(8002, 2500));
+        let key_a = test_session_key(8001, 5201);
+        let key_c = test_session_key(8002, 5201);
+        let bucket_a = cos_flow_bucket_index(0, Some(&key_a));
+        let bucket_c = cos_flow_bucket_index(0, Some(&key_c));
+        assert_ne!(
+            bucket_a, bucket_c,
+            "test setup: ports 8001/8002 must hash to distinct buckets"
+        );
+
+        // Pre-pop frontier:
+        //   A.head=1000 (A1 finish), A.tail=3000 (A2 finish).
+        //   C.head=C.tail=2500.
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_a], 1000);
+        assert_eq!(queue.flow_bucket_tail_finish_bytes[bucket_a], 3000);
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_c], 2500);
+
+        // Pop A1: head_finish[A] advances to 3000 (A2 finish-time).
+        let popped_a1 = cos_queue_pop_front(queue).expect("pop A1");
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_a], 3000);
+
+        // Pop C: bucket C drains (A.head_finish=3000 < C=2500? No,
+        // 3000 > 2500 so MQFQ picks C next). After pop: C empty;
+        // C.head_finish reset to 0.
+        let popped_c = cos_queue_pop_front(queue).expect("pop C");
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_c], 0);
+
+        // Pop A2 (last in A): bucket A drains, A.head_finish reset
+        // to 0. queue_vtime reflects all three pops.
+        let _popped_a2 = cos_queue_pop_front(queue).expect("pop A2");
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_a], 0);
+        assert_eq!(queue.pop_snapshot_stack.len(), 3);
+
+        // Simulate A2 dropped (e.g., frame too big to transmit).
+        cos_queue_clear_orphan_snapshot_after_drop(queue);
+        assert_eq!(queue.pop_snapshot_stack.len(), 2);
+
+        // Restore C via push_front: bucket C is empty so the
+        // `was_empty` snapshot path applies. C.head should restore
+        // to snap_C.pre_pop_head_finish = 2500.
+        cos_queue_push_front(queue, popped_c);
+        assert_eq!(queue.flow_bucket_head_finish_bytes[bucket_c], 2500);
+
+        // Restore A1 via push_front: bucket A is empty so the
+        // `was_empty` snapshot path applies. WITHOUT #927, A.head
+        // would restore to snap_1.pre_pop_head_finish = 1000 —
+        // inverting MQFQ order vs C (1000 < 2500). WITH #927, the
+        // orphan-cleanup helper bumped snap_1.pre_pop_head_finish
+        // up to A2's served_finish = 3000, so the restored A.head
+        // = 3000 > C.head = 2500 — MQFQ correctly picks C first.
+        cos_queue_push_front(queue, popped_a1);
+        assert!(
+            queue.flow_bucket_head_finish_bytes[bucket_a]
+                > queue.flow_bucket_head_finish_bytes[bucket_c],
+            "#927 regression: A.head ({}) must be strictly greater than \
+             C.head ({}) so MQFQ picks C first. Without the orphan-cleanup \
+             same-bucket frontier bump, A.head would restore to 1000 and \
+             A1 would pop before C — inverting their original schedule.",
+            queue.flow_bucket_head_finish_bytes[bucket_a],
+            queue.flow_bucket_head_finish_bytes[bucket_c],
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes the multi-pop+tail-drop scenario where the dropped item's virtual service was lost on `was_empty` restore — competing active buckets had their scheduling inverted with the restored item.
- Helper-internal change: in `cos_queue_clear_orphan_snapshot_after_drop`, also bump older same-bucket snapshots' `pre_pop_head_finish` and `pre_pop_tail_finish` via `.max(orphan.pre_pop_head_finish)`. The orphan's served_finish equals its `pre_pop_head_finish` because `flow_bucket_head_finish_bytes[bucket]` is read BEFORE the post-pop overwrite at `tx.rs:4637`.
- Helper signature unchanged. No caller-site updates, no test-call-site updates.
- New regression test `mqfq_drained_bucket_orphan_drop_preserves_served_finish` exercises the issue body's walkthrough: A=[A1,A2] + C=[C], pop A1+C+A2, drop A2, restore C and A1. Asserts strict `A.head > C.head` so MQFQ picks C first (strict because `cos_queue_front` uses strict `<` tie-break at `tx.rs:4336`).

Plan: [`docs/pr/927-mqfq-orphan-vtime/plan.md`](docs/pr/927-mqfq-orphan-vtime/plan.md). Codex R1 NEEDS-MAJOR → R2/R3 PLAN-READY YES (caught the v1 `+ item_len` over-inflation; v2 reads `pre_pop_head_finish` directly). Gemini MERGE YES.

This unblocks #917 (MQFQ Phase 4 cross-worker V_min sync) — V_min will now be computed against a corrected vtime signal.

Closes #927.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` 779/779 pass; new regression test for the drained-bucket scenario
- [x] Existing `mqfq_same_bucket_multipop_drop_preserves_dropped_item_finish` (covers same-bucket-with-successor case) continues to pass
- [ ] Cluster smoke as part of #917 cluster validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)