### PR TITLE
#947: extract ARP/NDP parsing into parser.rs (mechanical, +11 unit tests)

### DIFF
--- a/docs/pr/947-arp-ndp-parser/smoke.md
+++ b/docs/pr/947-arp-ndp-parser/smoke.md
@@ -1,0 +1,45 @@
+# #947 cluster smoke
+
+Captured 2026-04-29 on `loss:xpf-userspace-fw0/fw1` userspace cluster
+after deploying commit `74d25948` (#947 ARP/NDP parser extraction).
+
+## Throughput gates (all clear)
+
+| Test | Gate | Result |
+|---|---|---|
+| iperf-c P=12 | ≥ 22 Gb/s | **23.4 Gb/s, 0 retx** ✓ |
+| iperf-c P=1  | ≥ 6 Gb/s  | **6.94 Gb/s, 0 retx** ✓ |
+| iperf-b P=12 | ≥ 9.5 Gb/s, 0 retx | **9.58 Gb/s, 0 retx** ✓ |
+
+## Test suite
+
+`cargo test --release`: **825 passed, 0 failed, 2 ignored.**
+- 814 prior tests unchanged.
+- 11 new unit tests in `parser.rs`.
+
+## Behavior preservation
+
+The classification enum (`ArpClassification::{NotArp, OtherArp,
+Reply}`) preserves the prior caller contract that ANY ARP frame is
+recycled (ARP doesn't transit through the firewall) but only replies
+update the dynamic neighbor cache + kernel neighbor table. Codex
+investigation flagged this as a swap-vulnerable area — the explicit
+enum makes the intent compiler-checked.
+
+The NDP NA path was simpler — fall through to normal IPv6 forwarding
+either way. The only behavior preserved is "if Target Link-Layer
+Address option is present, learn the MAC."
+
+## Test command transcripts
+
+```
+$ sg incus-admin -c "incus exec loss:cluster-userspace-host -- bash -c 'iperf3 -c 172.16.80.200 -p 5203 -P 12 -t 10'"
+[SUM]   0.00-10.00  sec  27.3 GBytes  23.5 Gbits/sec    0             sender
+[SUM]   0.00-10.01  sec  27.3 GBytes  23.4 Gbits/sec                  receiver
+
+$ sg incus-admin -c "incus exec loss:cluster-userspace-host -- bash -c 'iperf3 -c 172.16.80.200 -p 5203 -P 1 -t 5'"
+[  5]   0.00-5.00   sec  4.04 GBytes  6.94 Gbits/sec    0            sender
+
+$ sg incus-admin -c "incus exec loss:cluster-userspace-host -- bash -c 'iperf3 -c 172.16.80.200 -p 5202 -P 12 -t 10'"
+[SUM]   0.00-10.00  sec  11.2 GBytes  9.58 Gbits/sec    0             sender
+```

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -77,6 +77,8 @@ mod icmp;
 mod icmp_embed;
 #[path = "afxdp/neighbor.rs"]
 mod neighbor;
+#[path = "afxdp/parser.rs"]
+mod parser;
 #[path = "afxdp/rst.rs"]
 mod rst;
 #[path = "afxdp/sharded_neighbor.rs"]
@@ -891,127 +893,54 @@ fn poll_binding_process_descriptor(
                         binding.scratch_recycle.push(desc.addr);
                         continue;
                     };
-                    // Check for ARP reply (ethertype 0x0806, opcode 0x0002).
-                    // Parse it and update the dynamic neighbor cache.
-                    // Handles both untagged and VLAN-tagged (802.1Q) ARP frames.
-                    if raw_frame.len() >= 42 {
-                        let (arp_start, ethertype) = if raw_frame.len() >= 18
-                            && u16::from_be_bytes([raw_frame[12], raw_frame[13]]) == 0x8100
-                        {
-                            (18, u16::from_be_bytes([raw_frame[16], raw_frame[17]]))
-                        } else {
-                            (14, u16::from_be_bytes([raw_frame[12], raw_frame[13]]))
-                        };
-                        if ethertype == 0x0806 && raw_frame.len() >= arp_start + 28 {
-                            let opcode = u16::from_be_bytes([
-                                raw_frame[arp_start + 6],
-                                raw_frame[arp_start + 7],
-                            ]);
-                            if opcode == 2 {
-                                // ARP reply — extract sender MAC and IP
-                                let sender_mac = [
-                                    raw_frame[arp_start + 8],
-                                    raw_frame[arp_start + 9],
-                                    raw_frame[arp_start + 10],
-                                    raw_frame[arp_start + 11],
-                                    raw_frame[arp_start + 12],
-                                    raw_frame[arp_start + 13],
-                                ];
-                                let sender_ip = IpAddr::V4(Ipv4Addr::new(
-                                    raw_frame[arp_start + 14],
-                                    raw_frame[arp_start + 15],
-                                    raw_frame[arp_start + 16],
-                                    raw_frame[arp_start + 17],
-                                ));
-                                // Update dynamic neighbor cache
-                                worker_ctx.dynamic_neighbors.insert(
-                                    (meta.ingress_ifindex as i32, sender_ip),
-                                    NeighborEntry { mac: sender_mac },
-                                );
-                                // Add learned ARP entry to kernel neighbor table
-                                // via netlink. This keeps the kernel's ARP table
-                                // in sync (needed for XDP_PASS fallback and
-                                // kernel-originated traffic).
-                                let neigh_ifindex = resolve_ingress_logical_ifindex(
-                                    worker_ctx.forwarding,
-                                    meta.ingress_ifindex as i32,
-                                    meta.ingress_vlan_id,
-                                )
-                                .unwrap_or(meta.ingress_ifindex as i32);
-                                add_kernel_neighbor(neigh_ifindex, sender_ip, sender_mac);
-                            }
-                            // Recycle frame — ARP is not a transit packet
+                    // #947: ARP classification + reply parsing extracted to
+                    // `parser.rs`. Any ARP frame (request/reply/etc.) is
+                    // recycled — ARP does not transit the firewall. ARP
+                    // replies additionally update the dynamic neighbor cache
+                    // and the kernel's neighbor table.
+                    match parser::classify_arp(raw_frame) {
+                        parser::ArpClassification::Reply(arp) => {
+                            worker_ctx.dynamic_neighbors.insert(
+                                (meta.ingress_ifindex as i32, arp.sender_ip),
+                                NeighborEntry {
+                                    mac: arp.sender_mac,
+                                },
+                            );
+                            let neigh_ifindex = resolve_ingress_logical_ifindex(
+                                worker_ctx.forwarding,
+                                meta.ingress_ifindex as i32,
+                                meta.ingress_vlan_id,
+                            )
+                            .unwrap_or(meta.ingress_ifindex as i32);
+                            add_kernel_neighbor(neigh_ifindex, arp.sender_ip, arp.sender_mac);
                             binding.scratch_recycle.push(desc.addr);
                             continue;
                         }
-                    }
-                    // Check for ICMPv6 Neighbor Advertisement (type 136).
-                    // Parse the target address and target link-layer address option,
-                    // then update the dynamic neighbor cache.
-                    // Handles both untagged and VLAN-tagged (802.1Q) IPv6 frames.
-                    if raw_frame.len() >= 78 {
-                        let (l3_start, ethertype) = if raw_frame.len() >= 18
-                            && u16::from_be_bytes([raw_frame[12], raw_frame[13]]) == 0x8100
-                        {
-                            (18, u16::from_be_bytes([raw_frame[16], raw_frame[17]]))
-                        } else {
-                            (14, u16::from_be_bytes([raw_frame[12], raw_frame[13]]))
-                        };
-                        if ethertype == 0x86dd && raw_frame.len() >= l3_start + 40 {
-                            let next_header = raw_frame[l3_start + 6];
-                            let l4_start = l3_start + 40;
-                            // ICMPv6 NA: next_header=58, type=136, need at least 24 bytes of ICMPv6 body
-                            if next_header == 58
-                                && raw_frame.len() >= l4_start + 24
-                                && raw_frame[l4_start] == 136
-                            {
-                                // Target address at ICMPv6 offset + 8 (after type/code/checksum/flags)
-                                if let Ok(target_bytes) =
-                                    <[u8; 16]>::try_from(&raw_frame[l4_start + 8..l4_start + 24])
-                                {
-                                    let target_ip = IpAddr::V6(Ipv6Addr::from(target_bytes));
-                                    // Look for target link-layer address option (type 2)
-                                    let mut opt_off = l4_start + 24;
-                                    while opt_off + 2 <= raw_frame.len() {
-                                        let opt_type = raw_frame[opt_off];
-                                        let opt_len = raw_frame[opt_off + 1] as usize * 8;
-                                        if opt_len == 0 {
-                                            break;
-                                        }
-                                        if opt_type == 2
-                                            && opt_len >= 8
-                                            && opt_off + 8 <= raw_frame.len()
-                                        {
-                                            let mac = [
-                                                raw_frame[opt_off + 2],
-                                                raw_frame[opt_off + 3],
-                                                raw_frame[opt_off + 4],
-                                                raw_frame[opt_off + 5],
-                                                raw_frame[opt_off + 6],
-                                                raw_frame[opt_off + 7],
-                                            ];
-                                            worker_ctx.dynamic_neighbors.insert(
-                                                (meta.ingress_ifindex as i32, target_ip),
-                                                NeighborEntry { mac },
-                                            );
-                                            // Add to kernel neighbor table via netlink.
-                                            // Use the logical VLAN sub-interface ifindex
-                                            // so the kernel associates it correctly.
-                                            let neigh_ifindex = resolve_ingress_logical_ifindex(
-                                                worker_ctx.forwarding,
-                                                meta.ingress_ifindex as i32,
-                                                meta.ingress_vlan_id,
-                                            )
-                                            .unwrap_or(meta.ingress_ifindex as i32);
-                                            add_kernel_neighbor(neigh_ifindex, target_ip, mac);
-                                            break;
-                                        }
-                                        opt_off += opt_len;
-                                    }
-                                }
-                                // Also let the NA fall through to normal processing.
-                            }
+                        parser::ArpClassification::OtherArp => {
+                            binding.scratch_recycle.push(desc.addr);
+                            continue;
                         }
+                        parser::ArpClassification::NotArp => {}
+                    }
+                    // #947: NDP Neighbor Advertisement parsing extracted to
+                    // `parser.rs`. NA with a Target Link-Layer Address option
+                    // updates the dynamic neighbor cache and the kernel's
+                    // neighbor table. Unlike ARP, the NA frame falls through
+                    // to normal IPv6 forwarding processing afterward.
+                    if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
+                        && let Some(mac) = na.target_mac
+                    {
+                        worker_ctx.dynamic_neighbors.insert(
+                            (meta.ingress_ifindex as i32, na.target_ip),
+                            NeighborEntry { mac },
+                        );
+                        let neigh_ifindex = resolve_ingress_logical_ifindex(
+                            worker_ctx.forwarding,
+                            meta.ingress_ifindex as i32,
+                            meta.ingress_vlan_id,
+                        )
+                        .unwrap_or(meta.ingress_ifindex as i32);
+                        add_kernel_neighbor(neigh_ifindex, na.target_ip, mac);
                     }
                     let native_gre_packet =
                         try_native_gre_decap_from_frame(raw_frame, meta, worker_ctx.forwarding);

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -75,6 +75,8 @@ mod ha;
 mod icmp;
 #[path = "afxdp/icmp_embed.rs"]
 mod icmp_embed;
+#[path = "afxdp/ethernet.rs"]
+mod ethernet;
 #[path = "afxdp/neighbor.rs"]
 mod neighbor;
 #[path = "afxdp/parser.rs"]

--- a/userspace-dp/src/afxdp/ethernet.rs
+++ b/userspace-dp/src/afxdp/ethernet.rs
@@ -1,0 +1,21 @@
+//! Shared Ethernet / VLAN / EtherType constants.
+//!
+//! Single source of truth for L2 magic numbers used across the
+//! AF_XDP fast path. Previously these were defined privately in
+//! `tx.rs` (`ETH_HDR_LEN`, `VLAN_TAG_LEN`) and `parser.rs`
+//! (`ETHERTYPE_*`). Extracted per Gemini review of #947 to avoid
+//! drift between modules.
+//!
+//! These are `pub(super)` so any sibling submodule of `afxdp` can
+//! import via `use super::ethernet::*;` (or by-name).
+
+/// Size of a bare Ethernet header (6 dst MAC + 6 src MAC + 2 ethertype).
+pub(super) const ETH_HDR_LEN: usize = 14;
+
+/// Size of a single 802.1Q / 802.1ad VLAN tag (TPID + TCI).
+pub(super) const VLAN_TAG_LEN: usize = 4;
+
+/// EtherType constants.
+pub(super) const ETHERTYPE_ARP: u16 = 0x0806;
+pub(super) const ETHERTYPE_IPV6: u16 = 0x86DD;
+pub(super) const ETHERTYPE_VLAN: u16 = 0x8100;

--- a/userspace-dp/src/afxdp/parser.rs
+++ b/userspace-dp/src/afxdp/parser.rs
@@ -16,11 +16,8 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-const ETHERTYPE_ARP: u16 = 0x0806;
-const ETHERTYPE_IPV6: u16 = 0x86DD;
-const ETHERTYPE_VLAN: u16 = 0x8100;
-const VLAN_TAG_BYTES: usize = 4;
-const ETH_HDR_LEN: usize = 14;
+use super::ethernet::{ETH_HDR_LEN, ETHERTYPE_ARP, ETHERTYPE_IPV6, ETHERTYPE_VLAN, VLAN_TAG_LEN};
+
 const ARP_BODY_LEN: usize = 28;
 const IPV6_HDR_LEN: usize = 40;
 const ICMPV6_NA_HDR_LEN: usize = 24;
@@ -34,18 +31,18 @@ const NDP_OPT_TARGET_LL: u8 = 2;
 ///
 /// Returns `(l3_start, ethertype)` if the frame is large enough to
 /// contain the L2 header, otherwise `None`.
-#[inline]
+#[inline(always)]
 pub(super) fn parse_eth_offsets(raw_frame: &[u8]) -> Option<(usize, u16)> {
     if raw_frame.len() < ETH_HDR_LEN {
         return None;
     }
     let outer_ethertype = u16::from_be_bytes([raw_frame[12], raw_frame[13]]);
     if outer_ethertype == ETHERTYPE_VLAN {
-        if raw_frame.len() < ETH_HDR_LEN + VLAN_TAG_BYTES {
+        if raw_frame.len() < ETH_HDR_LEN + VLAN_TAG_LEN {
             return None;
         }
         let inner = u16::from_be_bytes([raw_frame[16], raw_frame[17]]);
-        Some((ETH_HDR_LEN + VLAN_TAG_BYTES, inner))
+        Some((ETH_HDR_LEN + VLAN_TAG_LEN, inner))
     } else {
         Some((ETH_HDR_LEN, outer_ethertype))
     }
@@ -79,7 +76,7 @@ pub(super) enum ArpClassification {
 /// (ARP does not transit); if it's specifically an ARP reply, also
 /// learn the neighbor entry. The enum captures both branches without
 /// re-parsing.
-#[inline]
+#[inline(always)]
 pub(super) fn classify_arp(raw_frame: &[u8]) -> ArpClassification {
     let Some((l3_start, ethertype)) = parse_eth_offsets(raw_frame) else {
         return ArpClassification::NotArp;
@@ -129,7 +126,7 @@ pub(super) struct NdpNeighborAdvert {
 /// is not an NA or is too short. Handles VLAN-tagged frames.
 ///
 /// Replaces the inline parser at `afxdp.rs:948-1014` (pre-#947).
-#[inline]
+#[inline(always)]
 pub(super) fn parse_ndp_neighbor_advert(raw_frame: &[u8]) -> Option<NdpNeighborAdvert> {
     let (l3_start, ethertype) = parse_eth_offsets(raw_frame)?;
     if ethertype != ETHERTYPE_IPV6 {

--- a/userspace-dp/src/afxdp/parser.rs
+++ b/userspace-dp/src/afxdp/parser.rs
@@ -1,0 +1,342 @@
+//! #947: pure parsers for ARP and IPv6 NDP packets, extracted from
+//! `poll_binding_process_descriptor` to make them testable in
+//! isolation and to declutter the main poll loop.
+//!
+//! These functions intentionally do NOT use trait objects (`dyn
+//! ProtocolParser`) — they are `#[inline]`-able free functions so the
+//! compiler can fold them into the caller. The original issue
+//! proposed a Strategy trait pattern, but trait-object dispatch on a
+//! per-packet path would regress IPC; generics with monomorphization
+//! (or, as here, simple `#[inline]` functions) are the correct shape.
+//!
+//! IPv4/IPv6/TCP/GRE parsing already lives in `frame.rs` and
+//! `gre.rs`; this module covers the two control-plane shapes (ARP
+//! reply and IPv6 neighbor advertisement) that were still inline in
+//! `afxdp.rs`.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+const ETHERTYPE_ARP: u16 = 0x0806;
+const ETHERTYPE_IPV6: u16 = 0x86DD;
+const ETHERTYPE_VLAN: u16 = 0x8100;
+const VLAN_TAG_BYTES: usize = 4;
+const ETH_HDR_LEN: usize = 14;
+const ARP_BODY_LEN: usize = 28;
+const IPV6_HDR_LEN: usize = 40;
+const ICMPV6_NA_HDR_LEN: usize = 24;
+const NEXT_HEADER_ICMPV6: u8 = 58;
+const ICMPV6_TYPE_NA: u8 = 136;
+const ARP_OP_REPLY: u16 = 2;
+const NDP_OPT_TARGET_LL: u8 = 2;
+
+/// Resolve the L3-header offset and the EtherType. Handles both
+/// untagged and 802.1Q VLAN-tagged frames.
+///
+/// Returns `(l3_start, ethertype)` if the frame is large enough to
+/// contain the L2 header, otherwise `None`.
+#[inline]
+pub(super) fn parse_eth_offsets(raw_frame: &[u8]) -> Option<(usize, u16)> {
+    if raw_frame.len() < ETH_HDR_LEN {
+        return None;
+    }
+    let outer_ethertype = u16::from_be_bytes([raw_frame[12], raw_frame[13]]);
+    if outer_ethertype == ETHERTYPE_VLAN {
+        if raw_frame.len() < ETH_HDR_LEN + VLAN_TAG_BYTES {
+            return None;
+        }
+        let inner = u16::from_be_bytes([raw_frame[16], raw_frame[17]]);
+        Some((ETH_HDR_LEN + VLAN_TAG_BYTES, inner))
+    } else {
+        Some((ETH_HDR_LEN, outer_ethertype))
+    }
+}
+
+/// Parsed ARP reply (sender MAC + sender IP).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ArpReply {
+    pub sender_mac: [u8; 6],
+    pub sender_ip: IpAddr,
+}
+
+/// Classification of an Ethernet frame as ARP-or-not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ArpClassification {
+    /// Frame is not ARP (or is too short to classify).
+    NotArp,
+    /// Frame is ARP but not a reply (e.g. request, RARP, gratuitous
+    /// announcement). Caller should recycle the frame — ARP does not
+    /// transit the firewall — but skip neighbor learning.
+    OtherArp,
+    /// Frame is an ARP reply with a parsed `(sender_mac, sender_ip)`.
+    Reply(ArpReply),
+}
+
+/// Classify an Ethernet frame as ARP / non-ARP / ARP reply. Handles
+/// untagged and VLAN-tagged frames.
+///
+/// Replaces the inline parser at `afxdp.rs:893-947` (pre-#947). The
+/// caller's contract was: if it's any kind of ARP, recycle the frame
+/// (ARP does not transit); if it's specifically an ARP reply, also
+/// learn the neighbor entry. The enum captures both branches without
+/// re-parsing.
+#[inline]
+pub(super) fn classify_arp(raw_frame: &[u8]) -> ArpClassification {
+    let Some((l3_start, ethertype)) = parse_eth_offsets(raw_frame) else {
+        return ArpClassification::NotArp;
+    };
+    if ethertype != ETHERTYPE_ARP {
+        return ArpClassification::NotArp;
+    }
+    if raw_frame.len() < l3_start + ARP_BODY_LEN {
+        return ArpClassification::NotArp;
+    }
+    let opcode = u16::from_be_bytes([raw_frame[l3_start + 6], raw_frame[l3_start + 7]]);
+    if opcode != ARP_OP_REPLY {
+        return ArpClassification::OtherArp;
+    }
+    let sender_mac = [
+        raw_frame[l3_start + 8],
+        raw_frame[l3_start + 9],
+        raw_frame[l3_start + 10],
+        raw_frame[l3_start + 11],
+        raw_frame[l3_start + 12],
+        raw_frame[l3_start + 13],
+    ];
+    let sender_ip = IpAddr::V4(Ipv4Addr::new(
+        raw_frame[l3_start + 14],
+        raw_frame[l3_start + 15],
+        raw_frame[l3_start + 16],
+        raw_frame[l3_start + 17],
+    ));
+    ArpClassification::Reply(ArpReply {
+        sender_mac,
+        sender_ip,
+    })
+}
+
+/// Parsed ICMPv6 Neighbor Advertisement (type 136).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct NdpNeighborAdvert {
+    pub target_ip: IpAddr,
+    /// Some(mac) iff the NA carries a Target Link-Layer Address option
+    /// (option type 2). NA without TLLA is valid (e.g. unsolicited NA
+    /// from a host whose router knows the LLA already), but we can't
+    /// learn a MAC from those.
+    pub target_mac: Option<[u8; 6]>,
+}
+
+/// Parse an IPv6 Neighbor Advertisement. Returns `None` if the frame
+/// is not an NA or is too short. Handles VLAN-tagged frames.
+///
+/// Replaces the inline parser at `afxdp.rs:948-1014` (pre-#947).
+#[inline]
+pub(super) fn parse_ndp_neighbor_advert(raw_frame: &[u8]) -> Option<NdpNeighborAdvert> {
+    let (l3_start, ethertype) = parse_eth_offsets(raw_frame)?;
+    if ethertype != ETHERTYPE_IPV6 {
+        return None;
+    }
+    if raw_frame.len() < l3_start + IPV6_HDR_LEN {
+        return None;
+    }
+    let next_header = raw_frame[l3_start + 6];
+    let l4_start = l3_start + IPV6_HDR_LEN;
+    if next_header != NEXT_HEADER_ICMPV6
+        || raw_frame.len() < l4_start + ICMPV6_NA_HDR_LEN
+        || raw_frame[l4_start] != ICMPV6_TYPE_NA
+    {
+        return None;
+    }
+    let target_bytes: [u8; 16] =
+        <[u8; 16]>::try_from(&raw_frame[l4_start + 8..l4_start + 24]).ok()?;
+    let target_ip = IpAddr::V6(Ipv6Addr::from(target_bytes));
+    // Walk the NDP options for a Target Link-Layer Address (type 2).
+    let mut target_mac: Option<[u8; 6]> = None;
+    let mut opt_off = l4_start + ICMPV6_NA_HDR_LEN;
+    while opt_off + 2 <= raw_frame.len() {
+        let opt_type = raw_frame[opt_off];
+        let opt_len = raw_frame[opt_off + 1] as usize * 8;
+        if opt_len == 0 {
+            break;
+        }
+        if opt_type == NDP_OPT_TARGET_LL && opt_len >= 8 && opt_off + 8 <= raw_frame.len() {
+            target_mac = Some([
+                raw_frame[opt_off + 2],
+                raw_frame[opt_off + 3],
+                raw_frame[opt_off + 4],
+                raw_frame[opt_off + 5],
+                raw_frame[opt_off + 6],
+                raw_frame[opt_off + 7],
+            ]);
+            break;
+        }
+        opt_off += opt_len;
+    }
+    Some(NdpNeighborAdvert {
+        target_ip,
+        target_mac,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_eth_arp_reply(vlan: bool) -> Vec<u8> {
+        let mut f = Vec::new();
+        // dst mac
+        f.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        // src mac
+        f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        if vlan {
+            // 802.1Q + VID 100
+            f.extend_from_slice(&[0x81, 0x00, 0x00, 0x64]);
+        }
+        // ethertype = ARP
+        f.extend_from_slice(&[0x08, 0x06]);
+        // ARP body: htype=1, ptype=0x0800, hlen=6, plen=4, op=2 (reply)
+        f.extend_from_slice(&[0x00, 0x01, 0x08, 0x00, 0x06, 0x04, 0x00, 0x02]);
+        // sender mac
+        f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        // sender ip 10.0.0.42
+        f.extend_from_slice(&[10, 0, 0, 42]);
+        // target mac (filled to 28-byte body)
+        f.extend_from_slice(&[0x00; 6]);
+        // target ip
+        f.extend_from_slice(&[10, 0, 0, 1]);
+        f
+    }
+
+    #[test]
+    fn classify_arp_reply_untagged() {
+        let f = build_eth_arp_reply(false);
+        match classify_arp(&f) {
+            ArpClassification::Reply(r) => {
+                assert_eq!(r.sender_mac, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+                assert_eq!(r.sender_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42)));
+            }
+            other => panic!("expected Reply, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_arp_reply_vlan_tagged() {
+        let f = build_eth_arp_reply(true);
+        match classify_arp(&f) {
+            ArpClassification::Reply(r) => {
+                assert_eq!(r.sender_mac, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+            }
+            other => panic!("expected Reply, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_arp_request_is_other_arp() {
+        let mut f = build_eth_arp_reply(false);
+        // flip op from 2 (reply) to 1 (request)
+        f[14 + 6] = 0x00;
+        f[14 + 7] = 0x01;
+        assert_eq!(classify_arp(&f), ArpClassification::OtherArp);
+    }
+
+    #[test]
+    fn classify_arp_rejects_non_arp_ethertype() {
+        let mut f = build_eth_arp_reply(false);
+        // change ethertype to IPv4
+        f[12] = 0x08;
+        f[13] = 0x00;
+        assert_eq!(classify_arp(&f), ArpClassification::NotArp);
+    }
+
+    #[test]
+    fn classify_arp_rejects_short_frame() {
+        let f = vec![0u8; 30];
+        assert_eq!(classify_arp(&f), ArpClassification::NotArp);
+    }
+
+    fn build_eth_ndp_na(vlan: bool, with_tlla: bool) -> Vec<u8> {
+        let mut f = Vec::new();
+        f.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        if vlan {
+            f.extend_from_slice(&[0x81, 0x00, 0x00, 0x64]);
+        }
+        // ethertype IPv6
+        f.extend_from_slice(&[0x86, 0xdd]);
+        // IPv6 header (40 bytes): version=6, payload-len=24+8 if TLLA else 24,
+        // next-header=58 ICMPv6, hop-limit=255
+        let payload_len = if with_tlla { 32u16 } else { 24u16 };
+        f.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]); // ver+tc+flow
+        f.extend_from_slice(&payload_len.to_be_bytes());
+        f.push(NEXT_HEADER_ICMPV6); // next header
+        f.push(255); // hop limit
+        // src ip
+        f.extend_from_slice(&[
+            0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x01,
+        ]);
+        // dst ip
+        f.extend_from_slice(&[0xff; 16]);
+        // ICMPv6 NA: type=136, code=0, checksum=0xffff, flags=0, target=fe80::abcd:ef01:0:42
+        f.push(ICMPV6_TYPE_NA);
+        f.push(0); // code
+        f.extend_from_slice(&[0xff, 0xff]); // checksum
+        f.extend_from_slice(&[0; 4]); // flags
+        // target address
+        f.extend_from_slice(&[
+            0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x42,
+        ]);
+        if with_tlla {
+            // option type=2 (TLLA), len=1 (×8 = 8 bytes), MAC
+            f.push(NDP_OPT_TARGET_LL);
+            f.push(1);
+            f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        }
+        f
+    }
+
+    #[test]
+    fn parse_ndp_na_with_tlla_untagged() {
+        let f = build_eth_ndp_na(false, true);
+        let r = parse_ndp_neighbor_advert(&f).expect("NA parses");
+        assert_eq!(
+            r.target_ip,
+            IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0xabcd, 0xef01, 0, 0x42)),
+        );
+        assert_eq!(r.target_mac, Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+    }
+
+    #[test]
+    fn parse_ndp_na_with_tlla_vlan() {
+        let f = build_eth_ndp_na(true, true);
+        let r = parse_ndp_neighbor_advert(&f).expect("VLAN NA parses");
+        assert_eq!(r.target_mac, Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+    }
+
+    #[test]
+    fn parse_ndp_na_without_tlla() {
+        let f = build_eth_ndp_na(false, false);
+        let r = parse_ndp_neighbor_advert(&f).expect("NA without TLLA still parses");
+        assert!(r.target_mac.is_none());
+    }
+
+    #[test]
+    fn parse_ndp_na_rejects_non_icmpv6_next_header() {
+        let mut f = build_eth_ndp_na(false, true);
+        // flip next-header from ICMPv6 (58) to UDP (17)
+        f[14 + 6] = 17;
+        assert!(parse_ndp_neighbor_advert(&f).is_none());
+    }
+
+    #[test]
+    fn parse_ndp_na_rejects_non_na_type() {
+        let mut f = build_eth_ndp_na(false, true);
+        // flip ICMPv6 type from 136 (NA) to 135 (NS)
+        f[14 + 40] = 135;
+        assert!(parse_ndp_neighbor_advert(&f).is_none());
+    }
+
+    #[test]
+    fn parse_eth_offsets_handles_short_frame() {
+        let f = vec![0u8; 12];
+        assert!(parse_eth_offsets(&f).is_none());
+    }
+}

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3545,10 +3545,7 @@ const ECN_ECT_0: u8 = 0b0000_0010;
 const ECN_ECT_1: u8 = 0b0000_0001;
 const ECN_CE: u8 = 0b0000_0011;
 
-/// Size of a bare Ethernet header (6 dst MAC + 6 src MAC + 2 ethertype).
-const ETH_HDR_LEN: usize = 14;
-/// Size of a single 802.1Q / 802.1ad VLAN tag (TPID + TCI).
-const VLAN_TAG_LEN: usize = 4;
+use super::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
 
 /// Parsed L3 discriminator + offset from a forwarded Ethernet frame.
 /// Carries both pieces together so the ECN mark path dispatches off the


### PR DESCRIPTION
## Summary
Extracts inline ARP-reply and IPv6 Neighbor Advertisement parsers from `poll_binding_process_descriptor` into a new `userspace-dp/src/afxdp/parser.rs` module with 11 unit tests.

## Honest scope correction
The original issue proposed a `Box<dyn ProtocolParser>` Strategy pattern. Codex investigation (task-moji1ueo-zy2b1h) found:
- **IPv4/IPv6/TCP/GRE parsing is already in helpers** (`frame.rs:90-790`, `gre.rs:113-267`). Only ARP and NDP were still inline.
- **Trait-object dispatch on a per-packet path would regress IPC.** Plain `#[inline]` free functions are the correct shape.

This PR is the focused extraction those findings recommend, not the original Strategy-pattern overhaul.

## Smoke (cluster)
- iperf-c P=12: 23.4 Gb/s, 0 retx (≥22 Gb/s gate ✓)
- iperf-c P=1: 6.94 Gb/s, 0 retx (≥6 Gb/s gate ✓)
- iperf-b P=12: 9.58 Gb/s, 0 retx (≥9.5 Gb/s gate ✓)
- 825 cargo tests pass (was 814; +11 parser tests)

## Behavior preservation
The `ArpClassification::{NotArp, OtherArp, Reply}` enum makes the prior caller contract explicit: ANY ARP frame is recycled (ARP doesn't transit), but only replies update the neighbor cache. The compiler now type-checks the intent.

## Plan + evidence
- `docs/pr/947-arp-ndp-parser/smoke.md`

## Test plan
- [x] `cargo test --release`: 825 pass / 0 fail
- [x] Cluster smoke (3 gates clean)
- [ ] Codex hostile review of impl
- [ ] Gemini adversarial review of impl

🤖 Generated with [Claude Code](https://claude.com/claude-code)