### PR TITLE
#925 Phase 1: worker supervisor (catch + report)

### DIFF
--- a/docs/pr/925-worker-supervisor/plan.md
+++ b/docs/pr/925-worker-supervisor/plan.md
@@ -1,6 +1,6 @@
 # #925: worker thread supervisor (Phase 1 — catch + report)
 
-Plan v3 — 2026-04-29. Addresses Codex round-2 review (task-mojk796g-0nm5pi): poison-safety overclaim narrowed, real spawn path identified, doc inconsistency fixed.
+Plan v4 — 2026-04-29. Addresses Gemini final-pass (task-mojkn285-83bz47): switch panic slots from Vec to BTreeMap<u32, ...> for stable worker_id mapping (Phase 2 respawn-friendly).
 
 ## Investigation findings (Claude, first-hand)
 
@@ -108,11 +108,18 @@ pub(crate) struct WorkerRuntimeAtomics {
 ### Panic message slot
 
 Stored on `Coordinator`, not on the per-worker atomics struct. One
-`Arc<Mutex<Option<String>>>` per worker, indexed by `worker_id`.
+`Arc<Mutex<Option<String>>>` per worker, **indexed by `worker_id`**.
+
+Per Gemini final-pass: use `BTreeMap<u32, ...>`, NOT `Vec`. With
+`Vec` the index is spawn-order, not `worker_id`. If `worker_id`s are
+non-contiguous, gappy (e.g. binding plan reduces from 8 → 4
+workers), or reused after a Phase 2 respawn, a `Vec` mapping
+diverges from `worker_id` semantics. `BTreeMap` is robust to all
+of these and adds negligible per-lookup cost (status poll is ~1 Hz).
 
 ```rust
 // In Coordinator:
-worker_panics: Vec<Arc<Mutex<Option<String>>>>,
+worker_panics: BTreeMap<u32, Arc<Mutex<Option<String>>>>,
 ```
 
 The `Mutex` is fine here because:
@@ -177,7 +184,7 @@ fine.
 
 ```rust
 let panic_slot = Arc::new(Mutex::new(None::<String>));
-self.worker_panics.push(panic_slot.clone());
+self.worker_panics.insert(worker_id, panic_slot.clone());
 let runtime_atomics_supervisor = runtime_atomics.clone();
 let worker_id_supervisor = worker_id;
 let join = thread::Builder::new()
@@ -298,7 +305,7 @@ Test for the fallback: panic with `i32`; assert message ==
 
 1. **Rust types**: add `dead: AtomicBool` to `WorkerRuntimeAtomics`
    (`worker_runtime.rs`).
-2. **Coordinator**: add `worker_panics: Vec<Arc<Mutex<Option<String>>>>`
+2. **Coordinator**: add `worker_panics: BTreeMap<u32, Arc<Mutex<Option<String>>>>`
    field. Push a slot per worker spawn.
 3. **Rust protocol**: add `dead` and `panic_message` to
    `WorkerRuntimeStatus` (`protocol.rs:1043`).

--- a/docs/pr/925-worker-supervisor/plan.md
+++ b/docs/pr/925-worker-supervisor/plan.md
@@ -1,6 +1,6 @@
 # #925: worker thread supervisor (Phase 1 — catch + report)
 
-Plan v1 — 2026-04-29.
+Plan v2 — 2026-04-29. Addresses Codex hostile review (task-mojjrq43-8h1u9c, NEEDS-REVISION).
 
 ## Investigation findings (Claude, first-hand)
 
@@ -9,144 +9,176 @@ The #925 issue body claims that the minimal supervisor (`catch_unwind`
 false.** Grepping `userspace-dp/src/`:
 
 - Zero `panic::catch_unwind` references in production code.
-- `sharded_neighbor.rs:20` has a doc-comment that says: "Workers
-  have no `catch_unwind` supervisor today (#925 deferred)."
-- `tx.rs:4554` has another doc-comment referencing the same gap.
+- `sharded_neighbor.rs:20` and `tx.rs:4553` have doc-comments that
+  explicitly say "Workers have no `catch_unwind` supervisor today
+  (#925 deferred)."
 
 So #925 starts from zero, not from a "minimal supervisor already in
 place; expand to respawn" baseline. This plan acknowledges that and
-scopes Phase 1 accordingly.
+scopes Phase 1 to **catch + report** only, with respawn / sticky-
+failure / HA-trigger explicitly deferred to follow-up phases.
 
 ## Spawn sites
 
-`userspace-dp/src/afxdp/coordinator.rs` has three `thread::Builder::spawn`
-sites that need supervision:
+`userspace-dp/src/afxdp/coordinator.rs` has three
+`thread::Builder::spawn` sites that need supervision:
 
 - **Line 716** — `worker_loop` per worker. The hot path. Highest
-  priority for catch+report.
-- **Line 807** — `neigh_monitor_thread` (netlink monitor). Different
-  failure profile; defer to Phase 2.
-- **Line 854** — `local_tunnel_source_loop` (per GRE tunnel). Defer
-  to Phase 2.
+  priority for catch+report. **This PR.**
+- **Line 807** — `neigh_monitor_thread`. Different failure profile;
+  discards the `JoinHandle` (`.spawn(...).ok()`). A panic dies
+  silently except for stderr. **Defer to Phase 2** — different code
+  shape, harmless to land separately.
+- **Line 854** — `local_tunnel_source_loop`. Stores a `JoinHandle`
+  in `endpoint` state but doesn't monitor it. **Defer to Phase 2.**
 
-This plan covers **the worker_loop site only**. The other two are
-follow-ups in #925's broader scope but separate PRs.
+This plan covers **the worker_loop site only**.
 
 ## Existing infrastructure
 
 - `WorkerRuntimeAtomics` (`worker_runtime.rs:62-90`) — cache-line
-  isolated atomic struct already plumbed per worker. Has `tid`,
-  `wall_ns`, `active_ns`, `work_loops`, `idle_loops`, etc. **The
-  natural home for a `dead` flag and a panic-message slot.**
-- `WorkerRuntimeStatus` (`protocol.rs:1043-1062`) — gRPC-published
-  per-worker status struct with `#[serde(default)]` on every field
-  for backward compat. Adding new fields is straightforward.
-- `coordinator.worker_runtime_snapshots()` (`coordinator.rs:1216`)
-  — already polls `WorkerRuntimeAtomics` and emits
-  `WorkerRuntimeStatus`. Adding two fields here lights up the gRPC
-  surface automatically.
+  aligned (`#[repr(align(64))]`) atomic struct. Currently exactly
+  8 × `AtomicU64` = 64 bytes.
+- `WorkerRuntimeStatus` (`protocol.rs:1043-1062`) — Rust JSON struct
+  emitted by the helper to the Go side. All fields use
+  `#[serde(rename = "..", default)]`.
+- Go-side mirror: `pkg/dataplane/userspace/protocol.go:528-538` —
+  `WorkerRuntimeStatus` Go struct with matching `json:"..,omitempty"`
+  tags. Decoded at `process.go:199` via `json.NewDecoder` (does NOT
+  use `DisallowUnknownFields`, so unknown fields are tolerated).
+- Display: `pkg/dataplane/userspace/statusfmt.go:307-329` — formats
+  the worker runtime table for `cli show chassis forwarding`.
 
 ## Phase 1 scope (this PR)
 
 Three deliverables:
 
 1. **Catch panics** in the worker_loop spawn closure.
-2. **Report dead workers** via gRPC `WorkerRuntimeStatus`.
-3. **Test coverage** with a panic-injection test.
+2. **Report dead workers** via JSON `WorkerRuntimeStatus` → Go-side
+   decode → CLI display.
+3. **Test coverage** with a `#[cfg(test)]` panic injection that
+   exercises the actual spawn / snapshot path (not just toy
+   closures).
 
 Phase 2 (separate PRs, separately tracked):
 
-- **Respawn**: detect dead worker, recreate BindingWorker state,
-  re-attach UMEM/XSK rings, re-bind queues. Non-trivial — UMEM
-  ownership and queue-binding mechanics need careful unwinding. Ship
-  Phase 1 first to learn whether respawn is ever actually needed in
-  practice.
-- **Sticky-failure detection**: don't infinite-respawn. Trivial once
-  Phase 2's respawn lands.
-- **HA failover trigger**: when a worker dies on the primary node,
-  optionally trigger chassis-cluster failover. Requires policy
-  decisions (does ANY worker death failover, or only N workers dead
-  on the primary?).
-- **Other spawn sites** (neigh_monitor, local_tunnel_source). Same
-  catch+report pattern; mechanical.
+- **Respawn** — recreate BindingWorker state, re-attach UMEM/XSK
+  rings, re-bind queues. State recreation is non-trivial.
+- **Sticky-failure detection** — don't infinite-respawn.
+- **HA failover trigger** on primary-node worker death.
+- **`neigh_monitor_thread` and `local_tunnel_source_loop`
+  supervision** — same `catch_unwind` pattern, mechanical, separate
+  PRs.
+
+## Honest framing: "detection only"
+
+This PR makes the daemon **detect** dead workers and **report**
+them. It does NOT recover forwarding for the dead worker's
+bindings, drain its command queue, trigger HA, or restart the
+worker. That is Phase 2. Operators learn a worker died via
+`cli show chassis forwarding`, then must manually restart the daemon
+to recover. This is **better than today** (silent thread death) but
+explicitly degraded vs full self-healing.
 
 ## Design
 
-### `WorkerRuntimeAtomics` additions
+### `WorkerRuntimeAtomics` size impact (corrected per Codex Q)
+
+Adding `dead: AtomicBool` to a `#[repr(align(64))]` struct that is
+currently exactly 64 bytes (8 × AtomicU64) makes the new size **128
+bytes**, not "unchanged" (v1's false claim). The struct-alignment
+rounds the total up to the next 64-byte multiple.
+
+Cost: 64 bytes per worker. With typical worker counts (4-12), this
+is 256-768 bytes total. Negligible.
 
 ```rust
 #[repr(align(64))]
 pub(crate) struct WorkerRuntimeAtomics {
-    // ... existing fields unchanged ...
+    // ... existing 8 AtomicU64 ...
     pub tid: AtomicU64,
-    /// #925 Phase 1: set to 1 when the worker_loop panics and is
-    /// caught by `catch_unwind`. Once set, never cleared in this
-    /// phase. Phase 2 (respawn) will clear it on successful relaunch.
+    /// #925 Phase 1: set to true on caught panic. Once set, never
+    /// cleared in this phase. Phase 2 (respawn) will clear on
+    /// successful relaunch.
     pub dead: AtomicBool,
     _pad: [u8; 0],
 }
 ```
 
-`AtomicBool` is 1 byte; with `#[repr(align(64))]` on the struct the
-total layout is unchanged (still 64-byte aligned, no inter-worker
-false sharing).
-
 ### Panic message slot
 
-The panic payload needs to live somewhere the coordinator can read.
-Options:
+Stored on `Coordinator`, not on the per-worker atomics struct. One
+`Arc<Mutex<Option<String>>>` per worker, indexed by `worker_id`.
 
-- **A.** `Arc<Mutex<Option<String>>>` per worker — heap, but only
-  written once per panic (worker is dead by then). Simple.
-- **B.** Lock-free SPSC queue — overkill for a one-shot event.
-- **C.** Fixed-size byte buffer atomically published — complex.
+```rust
+// In Coordinator:
+worker_panics: Vec<Arc<Mutex<Option<String>>>>,
+```
 
-Choosing **A**. The cost is paid only when a worker actually dies,
-which is rare. Field name: `last_panic: Arc<Mutex<Option<String>>>`.
-Lives outside `WorkerRuntimeAtomics` (it's a control-plane concept,
-not a per-tick atomic) — store on `Coordinator` as
-`worker_panics: Vec<Arc<Mutex<Option<String>>>>` indexed by worker
-ID.
+The `Mutex` is fine here because:
+- Written exactly once per worker (when the worker dies).
+- Read at most once per gRPC status poll (~1 Hz).
+- Not on the packet hot path.
 
-### `WorkerRuntimeStatus` additions
+### `WorkerRuntimeStatus` additions (Rust + Go)
+
+**Rust** (`userspace-dp/src/protocol.rs`):
 
 ```rust
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct WorkerRuntimeStatus {
-    // ... existing fields unchanged ...
-    /// #925: true if the worker thread panicked and was caught by
-    /// the supervisor. Once set, the worker is no longer processing
-    /// packets for its bound queues.
+    // ... existing fields ...
+    /// #925: true if the worker thread panicked and was caught.
     #[serde(rename = "dead", default)]
     pub dead: bool,
     /// #925: panic payload string (if any), for operator diagnosis.
-    /// Empty string when alive or when panic payload was non-string.
+    /// Empty string when alive or when the panic payload was not a
+    /// string-like type.
     #[serde(rename = "panic_message", default)]
     pub panic_message: String,
 }
 ```
 
-`#[serde(default)]` keeps wire compatibility with older daemons.
+**Go** (`pkg/dataplane/userspace/protocol.go`):
+
+```go
+type WorkerRuntimeStatus struct {
+    // ... existing fields ...
+    Dead         bool   `json:"dead,omitempty"`
+    PanicMessage string `json:"panic_message,omitempty"`
+}
+```
+
+**Display** (`pkg/dataplane/userspace/statusfmt.go:307-329`):
+
+When formatting the worker runtime table, prepend a "DEAD" marker
+in the worker column for any worker with `Dead == true`, and emit
+the panic message on a follow-up line.
+
+```go
+if w.Dead {
+    fmt.Fprintf(&b, "  %-6d %-8d   DEAD - panicked: %s\n",
+        w.WorkerID, w.TID, w.PanicMessage)
+    continue
+}
+```
+
+### Logging — use `eprintln!`, not slog (corrected per Codex Q)
+
+The codebase has no `slog` dependency. Per `CLAUDE.md`'s logging
+rules: `eprintln!("xpf-userspace-dp: ...")` writes to journald via
+stderr. A panic is a one-time event, so the eprintln! cadence is
+fine.
 
 ### Spawn closure rewrite
 
-Currently (`coordinator.rs:716-748`):
-
-```rust
-let join = thread::Builder::new()
-    .name(format!("xpf-userspace-worker-{worker_id}"))
-    .spawn(move || {
-        worker_loop(/* args */);
-    })
-    .expect("spawn worker");
-```
-
-After:
+`userspace-dp/src/afxdp/coordinator.rs:716-748`:
 
 ```rust
 let panic_slot = Arc::new(Mutex::new(None::<String>));
-let panic_slot_clone = panic_slot.clone();
+self.worker_panics.push(panic_slot.clone());
 let runtime_atomics_supervisor = runtime_atomics.clone();
+let worker_id_supervisor = worker_id;
 let join = thread::Builder::new()
     .name(format!("xpf-userspace-worker-{worker_id}"))
     .spawn(move || {
@@ -156,103 +188,167 @@ let join = thread::Builder::new()
             }),
         );
         if let Err(payload) = result {
-            // Extract a printable message from the panic payload.
             let msg = panic_payload_message(&payload);
-            slog::error!(slog_scope::logger(),
-                "userspace-dp worker_loop panicked";
-                "worker_id" => worker_id,
-                "message" => &msg,
+            eprintln!(
+                "xpf-userspace-dp: worker_loop panicked (worker_id={}): {}",
+                worker_id_supervisor, msg
             );
-            if let Ok(mut slot) = panic_slot_clone.lock() {
-                *slot = Some(msg);
+            // Publish the message via the panic slot. lock() may be
+            // poisoned if a future panic on the read side leaves it
+            // poisoned; use the same `into_inner` pattern as #949.
+            match panic_slot.lock() {
+                Ok(mut slot) => *slot = Some(msg),
+                Err(poisoned) => *poisoned.into_inner() = Some(msg),
             }
-            runtime_atomics_supervisor.dead.store(true, Ordering::Release);
+            // Mark dead. Relaxed is fine here — the panic_slot mutex
+            // publishes the message; the dead flag is a one-shot
+            // diagnostic, not a synchronization barrier.
+            runtime_atomics_supervisor
+                .dead
+                .store(true, Ordering::Relaxed);
         }
     })
     .expect("spawn worker");
-self.worker_panics.push(panic_slot);
 ```
 
-`AssertUnwindSafe` is required because `worker_loop` takes
-non-`UnwindSafe` types (raw fds, `&mut` borrows). This is sound
-because: on panic, those references are dropped; the supervisor
-doesn't reuse them.
+### `AssertUnwindSafe` rationale (corrected per Codex Q2)
 
-### `panic_payload_message` helper
+`worker_loop` does NOT take `&mut` parameters; it takes owned
+values and `Arc`s. After a panic:
+
+- **Owned values** (BindingPlan, atomics, etc.) are dropped on
+  unwind. Caller never observes them again — they were `move`d into
+  the closure.
+- **`Arc<Mutex<>>` shared state** (sessions, neighbors, etc.) MAY
+  become poisoned if `worker_loop` panicked while holding a lock.
+  This is acceptable per #949's poison policy: every shared mutex
+  read uses `lock().unwrap_or_else(|e| e.into_inner())`, ignoring
+  poison. The data may be in a partial-update state, but that's the
+  same hazard #949 already accepted.
+
+So `AssertUnwindSafe` is sound here for the specific reason
+"poison-tolerant shared state plus owned-value drop", NOT v1's
+incorrect "references are dropped" reasoning.
+
+### Shared-state invariant audit (Codex Q3)
+
+`publish_shared_session` updates the primary session map, owner
+index, NAT alias map, and forward-wire map in **separate** lock
+regions (`shared_ops.rs:620`). A panic between steps could leave
+map/index skew. **This pre-exists this PR.** The plan does not
+introduce new invariant hazards; it just reports the panic that
+caused them. Document this honestly: catching a panic does not
+imply recoverable-state semantics.
+
+### `panic_payload_message` helper (corrected per Codex Q6)
 
 ```rust
-fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s.to_string()
     } else if let Some(s) = payload.downcast_ref::<String>() {
         s.clone()
     } else {
-        format!("non-string panic payload of type {:?}",
-                std::any::type_name_of_val(payload))
+        // Generic fallback. We CANNOT reliably extract a concrete
+        // type name from `dyn Any` (type_name_of_val on a Box<dyn>
+        // gives the trait object's name, not the inner type), so do
+        // not pretend to.
+        String::from("non-string panic payload")
     }
 }
 ```
 
-### Coordinator status surfacing
-
-In `coordinator.worker_runtime_snapshots()`:
-
-```rust
-crate::protocol::WorkerRuntimeStatus {
-    worker_id: ...,
-    // ... existing fields ...
-    dead: atomics.dead.load(Ordering::Acquire),
-    panic_message: self.worker_panics
-        .get(worker_id as usize)
-        .and_then(|slot| slot.lock().ok().and_then(|g| g.clone()))
-        .unwrap_or_default(),
-}
-```
-
-## Memory ordering
-
-- `dead.store(true, Release)` on the panic-handler side.
-- `dead.load(Acquire)` in `worker_runtime_snapshots`.
-- The `Mutex`-protected panic message uses the mutex's
-  acquire/release semantics; no additional barriers needed.
+Test for the fallback: panic with `i32`; assert message ==
+"non-string panic payload" (NOT v1's false claim of "i32").
 
 ## Implementation steps
 
-1. Add `dead: AtomicBool` to `WorkerRuntimeAtomics` (`worker_runtime.rs`).
-2. Add `worker_panics: Vec<Arc<Mutex<Option<String>>>>` to
-   `Coordinator` (`coordinator.rs`).
-3. Add `dead: bool` and `panic_message: String` to
-   `WorkerRuntimeStatus` (`protocol.rs`).
-4. Add `panic_payload_message` helper (private, in `coordinator.rs`).
-5. Wrap the `worker_loop` spawn closure at `coordinator.rs:716` in
-   `catch_unwind` + on-Err mark-dead + log + slot publish.
-6. Update `worker_runtime_snapshots()` to surface the new fields.
-7. Unit tests (in `coordinator.rs::tests` or a new `supervisor.rs`):
-   - Spawn a closure that panics with a string; verify `dead == true`
-     after join.
-   - Spawn a closure that panics with `i32` (non-string); verify the
-     `panic_message` records "non-string panic payload of type i32".
-   - Spawn a closure that does not panic; verify `dead == false`.
-8. (Optional integration test) Inject a panic via a debug-only
-   `WorkerCommand::PanicInjection` that the test driver can fire,
-   then verify gRPC status reflects the dead worker. Defer to Phase 2
-   if the unit tests are sufficient.
+1. **Rust types**: add `dead: AtomicBool` to `WorkerRuntimeAtomics`
+   (`worker_runtime.rs`).
+2. **Coordinator**: add `worker_panics: Vec<Arc<Mutex<Option<String>>>>`
+   field. Push a slot per worker spawn.
+3. **Rust protocol**: add `dead` and `panic_message` to
+   `WorkerRuntimeStatus` (`protocol.rs:1043`).
+4. **`panic_payload_message`** helper (private, in `coordinator.rs`).
+5. **Spawn-closure rewrite** at `coordinator.rs:716` per the
+   pseudo-code above.
+6. **Update `coordinator.worker_runtime_snapshots()`** at
+   `coordinator.rs:1216` to surface `dead` and `panic_message`.
+7. **Go protocol**: add `Dead bool` and `PanicMessage string` to
+   `WorkerRuntimeStatus` in `pkg/dataplane/userspace/protocol.go:528`.
+8. **Go statusfmt**: update `pkg/dataplane/userspace/statusfmt.go:310`
+   to show DEAD marker + panic message.
+9. **Tests** (see below).
+
+## Tests
+
+### Real spawn-path test (Codex Q9)
+
+The plan adds a `#[cfg(test)]`-only `WorkerCommand::PanicInjection`
+variant. Production builds do not include this variant. The test
+spawns a worker through the actual `Coordinator::spawn_workers`
+path, sends a `PanicInjection` command, joins the thread, and
+asserts the dead flag is set + panic message is published via
+`worker_runtime_snapshots()`.
+
+```rust
+#[cfg(test)]
+#[test]
+fn worker_panic_is_caught_and_reported() {
+    let mut coordinator = Coordinator::new_minimal_for_test();
+    coordinator.spawn_workers(/* test config */);
+    coordinator.send_command_to_worker(0, WorkerCommand::PanicInjection);
+    coordinator.wait_for_worker_dead(0, Duration::from_secs(2));
+    let snapshots = coordinator.worker_runtime_snapshots();
+    assert!(snapshots[0].dead);
+    assert!(snapshots[0].panic_message.contains("PanicInjection"));
+}
+```
+
+### Unit tests for `panic_payload_message`
+
+```rust
+#[test]
+fn panic_payload_string_str() {
+    let r = std::panic::catch_unwind(|| panic!("hello"));
+    let payload = r.unwrap_err();
+    assert_eq!(panic_payload_message(&payload), "hello");
+}
+
+#[test]
+fn panic_payload_string_owned() {
+    let r = std::panic::catch_unwind(|| {
+        panic!("{}", String::from("world"))
+    });
+    let payload = r.unwrap_err();
+    assert_eq!(panic_payload_message(&payload), "world");
+}
+
+#[test]
+fn panic_payload_non_string_falls_back() {
+    let r = std::panic::catch_unwind(|| panic_any(42_i32));
+    let payload = r.unwrap_err();
+    assert_eq!(panic_payload_message(&payload), "non-string panic payload");
+}
+```
+
+(`panic_any` from `std::panic`.)
 
 ## Acceptance gates
 
 1. `cargo build --release` clean.
-2. `cargo test --release` ≥ 825 + 3 new = 828 / 828 pass.
-3. Cluster smoke (HARD): no regression — supervisor wrapping should
-   be zero-cost in the no-panic path.
+2. `cargo test --release` ≥ 825 + 4 = 829 / 829 pass (3 unit + 1
+   integration).
+3. Cluster smoke (HARD): no regression — `catch_unwind` is invoked
+   ONCE per spawn, not per packet, so cost is 0/packet.
    - iperf-c P=12 ≥ 22 Gb/s
    - iperf-c P=1 ≥ 6 Gb/s
    - iperf-b P=12 ≥ 9.5 Gb/s, 0 retx
-4. Manual injection (recommended, not gated): hot-patch a panic into
-   `worker_loop` (or use a feature-flagged `panic-injection-test`
-   build), restart the daemon, observe dead-worker status via
-   `cli show chassis forwarding workers` (or whatever surfaces
-   `WorkerRuntimeStatus`). Verify the daemon stays up and other
-   workers continue.
+4. **Manual injection (recommended, not gated)**: hot-patch a panic
+   into `worker_loop` (or use a feature-flagged build), restart the
+   daemon, observe `cli show chassis forwarding` showing the worker
+   as DEAD with the panic message. Verify the daemon stays up and
+   other workers continue.
 5. Codex hostile review: AGREE-TO-MERGE.
 6. Gemini adversarial review: AGREE-TO-MERGE.
 
@@ -261,21 +357,15 @@ crate::protocol::WorkerRuntimeStatus {
 **Medium-low.**
 
 - `catch_unwind` semantics are well-understood Rust stdlib.
-- `AssertUnwindSafe` is the only soundness footgun; the closure
-  doesn't share state with anyone after the panic, so it's correct
-  here.
-- Adding gRPC fields with `#[serde(default)]` is wire-compatible.
-- The hot path is unaffected — `catch_unwind` only intercepts
-  unwinding, not normal returns. There's literature claiming
-  ~5-10ns/call overhead even on the no-panic path due to landing-pad
-  setup, but `worker_loop` is called once per spawn, not per packet,
-  so the impact is "0 ns/packet."
-
-## Risk on hot path: zero
-
-`catch_unwind` is invoked ONCE per spawn (i.e., once per worker
-lifetime). The packet-processing loop inside `worker_loop` is
-unchanged. There is no per-packet or per-batch landing-pad cost.
+- `AssertUnwindSafe` rationale is honest (poison-tolerant shared
+  state, owned-value drop).
+- Wire compat: Go decoder doesn't use `DisallowUnknownFields`;
+  unknown fields ignored. `bool::default() = false` and
+  `String::default() = ""` are correct sentinels.
+- Hot path is unaffected — `catch_unwind` only intercepts
+  unwinding, not normal returns. Per-packet cost is zero (the
+  wrapper is around `worker_loop()` which runs for the entire
+  worker lifetime).
 
 ## Out of scope
 
@@ -284,7 +374,10 @@ unchanged. There is no per-packet or per-batch landing-pad cost.
 - HA failover trigger (Phase 4)
 - `neigh_monitor_thread` and `local_tunnel_source_loop` supervision
   (separate PRs, mechanical)
-- Panic injection as a production feature (only for tests)
+- Production debug `WorkerCommand::PanicInjection` (test-only;
+  `#[cfg(test)]`).
+- Improving `publish_shared_session` cross-map atomicity (pre-existing
+  hazard, separate concern).
 
 These all live under #925 in the issue tracker; this PR is
 **Phase 1: catch + report**, the foundation.

--- a/docs/pr/925-worker-supervisor/plan.md
+++ b/docs/pr/925-worker-supervisor/plan.md
@@ -1,0 +1,290 @@
+# #925: worker thread supervisor (Phase 1 — catch + report)
+
+Plan v1 — 2026-04-29.
+
+## Investigation findings (Claude, first-hand)
+
+The #925 issue body claims that the minimal supervisor (`catch_unwind`
++ mark-dead atomic) was already landed as part of #913. **This is
+false.** Grepping `userspace-dp/src/`:
+
+- Zero `panic::catch_unwind` references in production code.
+- `sharded_neighbor.rs:20` has a doc-comment that says: "Workers
+  have no `catch_unwind` supervisor today (#925 deferred)."
+- `tx.rs:4554` has another doc-comment referencing the same gap.
+
+So #925 starts from zero, not from a "minimal supervisor already in
+place; expand to respawn" baseline. This plan acknowledges that and
+scopes Phase 1 accordingly.
+
+## Spawn sites
+
+`userspace-dp/src/afxdp/coordinator.rs` has three `thread::Builder::spawn`
+sites that need supervision:
+
+- **Line 716** — `worker_loop` per worker. The hot path. Highest
+  priority for catch+report.
+- **Line 807** — `neigh_monitor_thread` (netlink monitor). Different
+  failure profile; defer to Phase 2.
+- **Line 854** — `local_tunnel_source_loop` (per GRE tunnel). Defer
+  to Phase 2.
+
+This plan covers **the worker_loop site only**. The other two are
+follow-ups in #925's broader scope but separate PRs.
+
+## Existing infrastructure
+
+- `WorkerRuntimeAtomics` (`worker_runtime.rs:62-90`) — cache-line
+  isolated atomic struct already plumbed per worker. Has `tid`,
+  `wall_ns`, `active_ns`, `work_loops`, `idle_loops`, etc. **The
+  natural home for a `dead` flag and a panic-message slot.**
+- `WorkerRuntimeStatus` (`protocol.rs:1043-1062`) — gRPC-published
+  per-worker status struct with `#[serde(default)]` on every field
+  for backward compat. Adding new fields is straightforward.
+- `coordinator.worker_runtime_snapshots()` (`coordinator.rs:1216`)
+  — already polls `WorkerRuntimeAtomics` and emits
+  `WorkerRuntimeStatus`. Adding two fields here lights up the gRPC
+  surface automatically.
+
+## Phase 1 scope (this PR)
+
+Three deliverables:
+
+1. **Catch panics** in the worker_loop spawn closure.
+2. **Report dead workers** via gRPC `WorkerRuntimeStatus`.
+3. **Test coverage** with a panic-injection test.
+
+Phase 2 (separate PRs, separately tracked):
+
+- **Respawn**: detect dead worker, recreate BindingWorker state,
+  re-attach UMEM/XSK rings, re-bind queues. Non-trivial — UMEM
+  ownership and queue-binding mechanics need careful unwinding. Ship
+  Phase 1 first to learn whether respawn is ever actually needed in
+  practice.
+- **Sticky-failure detection**: don't infinite-respawn. Trivial once
+  Phase 2's respawn lands.
+- **HA failover trigger**: when a worker dies on the primary node,
+  optionally trigger chassis-cluster failover. Requires policy
+  decisions (does ANY worker death failover, or only N workers dead
+  on the primary?).
+- **Other spawn sites** (neigh_monitor, local_tunnel_source). Same
+  catch+report pattern; mechanical.
+
+## Design
+
+### `WorkerRuntimeAtomics` additions
+
+```rust
+#[repr(align(64))]
+pub(crate) struct WorkerRuntimeAtomics {
+    // ... existing fields unchanged ...
+    pub tid: AtomicU64,
+    /// #925 Phase 1: set to 1 when the worker_loop panics and is
+    /// caught by `catch_unwind`. Once set, never cleared in this
+    /// phase. Phase 2 (respawn) will clear it on successful relaunch.
+    pub dead: AtomicBool,
+    _pad: [u8; 0],
+}
+```
+
+`AtomicBool` is 1 byte; with `#[repr(align(64))]` on the struct the
+total layout is unchanged (still 64-byte aligned, no inter-worker
+false sharing).
+
+### Panic message slot
+
+The panic payload needs to live somewhere the coordinator can read.
+Options:
+
+- **A.** `Arc<Mutex<Option<String>>>` per worker — heap, but only
+  written once per panic (worker is dead by then). Simple.
+- **B.** Lock-free SPSC queue — overkill for a one-shot event.
+- **C.** Fixed-size byte buffer atomically published — complex.
+
+Choosing **A**. The cost is paid only when a worker actually dies,
+which is rare. Field name: `last_panic: Arc<Mutex<Option<String>>>`.
+Lives outside `WorkerRuntimeAtomics` (it's a control-plane concept,
+not a per-tick atomic) — store on `Coordinator` as
+`worker_panics: Vec<Arc<Mutex<Option<String>>>>` indexed by worker
+ID.
+
+### `WorkerRuntimeStatus` additions
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct WorkerRuntimeStatus {
+    // ... existing fields unchanged ...
+    /// #925: true if the worker thread panicked and was caught by
+    /// the supervisor. Once set, the worker is no longer processing
+    /// packets for its bound queues.
+    #[serde(rename = "dead", default)]
+    pub dead: bool,
+    /// #925: panic payload string (if any), for operator diagnosis.
+    /// Empty string when alive or when panic payload was non-string.
+    #[serde(rename = "panic_message", default)]
+    pub panic_message: String,
+}
+```
+
+`#[serde(default)]` keeps wire compatibility with older daemons.
+
+### Spawn closure rewrite
+
+Currently (`coordinator.rs:716-748`):
+
+```rust
+let join = thread::Builder::new()
+    .name(format!("xpf-userspace-worker-{worker_id}"))
+    .spawn(move || {
+        worker_loop(/* args */);
+    })
+    .expect("spawn worker");
+```
+
+After:
+
+```rust
+let panic_slot = Arc::new(Mutex::new(None::<String>));
+let panic_slot_clone = panic_slot.clone();
+let runtime_atomics_supervisor = runtime_atomics.clone();
+let join = thread::Builder::new()
+    .name(format!("xpf-userspace-worker-{worker_id}"))
+    .spawn(move || {
+        let result = std::panic::catch_unwind(
+            std::panic::AssertUnwindSafe(|| {
+                worker_loop(/* same args */);
+            }),
+        );
+        if let Err(payload) = result {
+            // Extract a printable message from the panic payload.
+            let msg = panic_payload_message(&payload);
+            slog::error!(slog_scope::logger(),
+                "userspace-dp worker_loop panicked";
+                "worker_id" => worker_id,
+                "message" => &msg,
+            );
+            if let Ok(mut slot) = panic_slot_clone.lock() {
+                *slot = Some(msg);
+            }
+            runtime_atomics_supervisor.dead.store(true, Ordering::Release);
+        }
+    })
+    .expect("spawn worker");
+self.worker_panics.push(panic_slot);
+```
+
+`AssertUnwindSafe` is required because `worker_loop` takes
+non-`UnwindSafe` types (raw fds, `&mut` borrows). This is sound
+because: on panic, those references are dropped; the supervisor
+doesn't reuse them.
+
+### `panic_payload_message` helper
+
+```rust
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("non-string panic payload of type {:?}",
+                std::any::type_name_of_val(payload))
+    }
+}
+```
+
+### Coordinator status surfacing
+
+In `coordinator.worker_runtime_snapshots()`:
+
+```rust
+crate::protocol::WorkerRuntimeStatus {
+    worker_id: ...,
+    // ... existing fields ...
+    dead: atomics.dead.load(Ordering::Acquire),
+    panic_message: self.worker_panics
+        .get(worker_id as usize)
+        .and_then(|slot| slot.lock().ok().and_then(|g| g.clone()))
+        .unwrap_or_default(),
+}
+```
+
+## Memory ordering
+
+- `dead.store(true, Release)` on the panic-handler side.
+- `dead.load(Acquire)` in `worker_runtime_snapshots`.
+- The `Mutex`-protected panic message uses the mutex's
+  acquire/release semantics; no additional barriers needed.
+
+## Implementation steps
+
+1. Add `dead: AtomicBool` to `WorkerRuntimeAtomics` (`worker_runtime.rs`).
+2. Add `worker_panics: Vec<Arc<Mutex<Option<String>>>>` to
+   `Coordinator` (`coordinator.rs`).
+3. Add `dead: bool` and `panic_message: String` to
+   `WorkerRuntimeStatus` (`protocol.rs`).
+4. Add `panic_payload_message` helper (private, in `coordinator.rs`).
+5. Wrap the `worker_loop` spawn closure at `coordinator.rs:716` in
+   `catch_unwind` + on-Err mark-dead + log + slot publish.
+6. Update `worker_runtime_snapshots()` to surface the new fields.
+7. Unit tests (in `coordinator.rs::tests` or a new `supervisor.rs`):
+   - Spawn a closure that panics with a string; verify `dead == true`
+     after join.
+   - Spawn a closure that panics with `i32` (non-string); verify the
+     `panic_message` records "non-string panic payload of type i32".
+   - Spawn a closure that does not panic; verify `dead == false`.
+8. (Optional integration test) Inject a panic via a debug-only
+   `WorkerCommand::PanicInjection` that the test driver can fire,
+   then verify gRPC status reflects the dead worker. Defer to Phase 2
+   if the unit tests are sufficient.
+
+## Acceptance gates
+
+1. `cargo build --release` clean.
+2. `cargo test --release` ≥ 825 + 3 new = 828 / 828 pass.
+3. Cluster smoke (HARD): no regression — supervisor wrapping should
+   be zero-cost in the no-panic path.
+   - iperf-c P=12 ≥ 22 Gb/s
+   - iperf-c P=1 ≥ 6 Gb/s
+   - iperf-b P=12 ≥ 9.5 Gb/s, 0 retx
+4. Manual injection (recommended, not gated): hot-patch a panic into
+   `worker_loop` (or use a feature-flagged `panic-injection-test`
+   build), restart the daemon, observe dead-worker status via
+   `cli show chassis forwarding workers` (or whatever surfaces
+   `WorkerRuntimeStatus`). Verify the daemon stays up and other
+   workers continue.
+5. Codex hostile review: AGREE-TO-MERGE.
+6. Gemini adversarial review: AGREE-TO-MERGE.
+
+## Risk
+
+**Medium-low.**
+
+- `catch_unwind` semantics are well-understood Rust stdlib.
+- `AssertUnwindSafe` is the only soundness footgun; the closure
+  doesn't share state with anyone after the panic, so it's correct
+  here.
+- Adding gRPC fields with `#[serde(default)]` is wire-compatible.
+- The hot path is unaffected — `catch_unwind` only intercepts
+  unwinding, not normal returns. There's literature claiming
+  ~5-10ns/call overhead even on the no-panic path due to landing-pad
+  setup, but `worker_loop` is called once per spawn, not per packet,
+  so the impact is "0 ns/packet."
+
+## Risk on hot path: zero
+
+`catch_unwind` is invoked ONCE per spawn (i.e., once per worker
+lifetime). The packet-processing loop inside `worker_loop` is
+unchanged. There is no per-packet or per-batch landing-pad cost.
+
+## Out of scope
+
+- Respawn (Phase 2)
+- Sticky-failure detection (Phase 3)
+- HA failover trigger (Phase 4)
+- `neigh_monitor_thread` and `local_tunnel_source_loop` supervision
+  (separate PRs, mechanical)
+- Panic injection as a production feature (only for tests)
+
+These all live under #925 in the issue tracker; this PR is
+**Phase 1: catch + report**, the foundation.

--- a/docs/pr/925-worker-supervisor/plan.md
+++ b/docs/pr/925-worker-supervisor/plan.md
@@ -1,6 +1,6 @@
 # #925: worker thread supervisor (Phase 1 — catch + report)
 
-Plan v2 — 2026-04-29. Addresses Codex hostile review (task-mojjrq43-8h1u9c, NEEDS-REVISION).
+Plan v3 — 2026-04-29. Addresses Codex round-2 review (task-mojk796g-0nm5pi): poison-safety overclaim narrowed, real spawn path identified, doc inconsistency fixed.
 
 ## Investigation findings (Claude, first-hand)
 
@@ -211,7 +211,7 @@ let join = thread::Builder::new()
     .expect("spawn worker");
 ```
 
-### `AssertUnwindSafe` rationale (corrected per Codex Q2)
+### `AssertUnwindSafe` rationale (narrowed per Codex round-2)
 
 `worker_loop` does NOT take `&mut` parameters; it takes owned
 values and `Arc`s. After a panic:
@@ -221,24 +221,56 @@ values and `Arc`s. After a panic:
   the closure.
 - **`Arc<Mutex<>>` shared state** (sessions, neighbors, etc.) MAY
   become poisoned if `worker_loop` panicked while holding a lock.
-  This is acceptable per #949's poison policy: every shared mutex
-  read uses `lock().unwrap_or_else(|e| e.into_inner())`, ignoring
-  poison. The data may be in a partial-update state, but that's the
-  same hazard #949 already accepted.
 
-So `AssertUnwindSafe` is sound here for the specific reason
-"poison-tolerant shared state plus owned-value drop", NOT v1's
-incorrect "references are dropped" reasoning.
+**Important narrowing**: #949's `into_inner` poison policy is
+**scoped to `dynamic_neighbors` only**. Session maps
+(`shared_sessions`, `shared_nat_sessions`,
+`shared_forward_wire_sessions`) and worker command queues still
+use `if let Ok(mut g) = mutex.lock()` (e.g.
+`shared_ops.rs:627,639,665,689,718`). On poison those `if let`
+branches silently fail — subsequent operations on poisoned shared
+maps are skipped, not retried.
 
-### Shared-state invariant audit (Codex Q3)
+This means **a worker_loop panic that poisons a shared session
+mutex causes silent dropouts** in those maps until the daemon is
+restarted. This PR does NOT fix that. Phase 1 is "detection only":
+- Operator sees the dead worker via `cli show chassis forwarding`.
+- Operator restarts the daemon to recover.
+- HA peer continues serving traffic in the meantime.
+
+So `AssertUnwindSafe` is sound here in the narrow sense: "the
+panic is captured for diagnostics; full state recovery is NOT
+promised." Phase 2 (respawn) will need to either (a) extend the
+#949 `into_inner` policy to all shared mutexes, or (b) tear
+down and rebuild the shared state.
+
+The plan's promise is honest: catch + report + degraded operation,
+nothing more.
+
+### Shared-state invariant audit (Codex Q3 + round-2)
 
 `publish_shared_session` updates the primary session map, owner
 index, NAT alias map, and forward-wire map in **separate** lock
 regions (`shared_ops.rs:620`). A panic between steps could leave
 map/index skew. **This pre-exists this PR.** The plan does not
 introduce new invariant hazards; it just reports the panic that
-caused them. Document this honestly: catching a panic does not
-imply recoverable-state semantics.
+caused them.
+
+**Plan-1 scope of poison damage** (per Codex round-2 narrowing):
+
+| Mutex | Read pattern | What breaks on poison |
+|---|---|---|
+| `dynamic_neighbors` (sharded, #949) | `into_inner` recovery | Stale or partial MAC entries; next ARP/NA learn overwrites. Self-healing. |
+| `shared_sessions` | `if let Ok` skip-on-poison | Session inserts/lookups skipped on the affected shard. Manifests as policy re-evaluation per packet. |
+| `shared_nat_sessions` | `if let Ok` skip-on-poison | Same; NAT sessions silently leak. |
+| `shared_forward_wire_sessions` | `if let Ok` skip-on-poison | Same. |
+| `shared_owner_rg_indexes` | `if let Ok` skip-on-poison | HA index updates skipped on the affected shard. |
+| `worker_commands` (per-worker `VecDeque`) | `try_lock` then move/drain | Commands accumulate undrained; dead worker never processes them anyway. |
+
+In all "skip-on-poison" cases the daemon stays up but the affected
+shard becomes a black hole. **Operator action**: restart the
+daemon. The dead-worker indicator in `cli show chassis forwarding`
+is the trigger.
 
 ### `panic_payload_message` helper (corrected per Codex Q6)
 
@@ -282,28 +314,87 @@ Test for the fallback: panic with `i32`; assert message ==
 
 ## Tests
 
-### Real spawn-path test (Codex Q9)
+### Real spawn-path test (Codex round-2 — corrected)
 
-The plan adds a `#[cfg(test)]`-only `WorkerCommand::PanicInjection`
-variant. Production builds do not include this variant. The test
-spawns a worker through the actual `Coordinator::spawn_workers`
-path, sends a `PanicInjection` command, joins the thread, and
-asserts the dead flag is set + panic message is published via
-`worker_runtime_snapshots()`.
+Codex round-2 noted v2 referenced `Coordinator::spawn_workers`
+which doesn't exist. The actual spawn happens inside
+`Coordinator::reconcile` at `coordinator.rs:670-748`.
+
+The test exercises the same helper that production uses. Strategy:
+extract the spawn-closure body into a private helper
+`spawn_supervised_worker` so the test can call it directly with
+a no-op `worker_loop` substitute that panics on demand. This
+keeps the production spawn path intact (still called from
+`reconcile`) while making it testable.
 
 ```rust
-#[cfg(test)]
+// In coordinator.rs:
+fn spawn_supervised_worker<F: FnOnce() + Send + 'static>(
+    worker_id: u32,
+    runtime_atomics: Arc<WorkerRuntimeAtomics>,
+    panic_slot: Arc<Mutex<Option<String>>>,
+    body: F,
+) -> JoinHandle<()> {
+    thread::Builder::new()
+        .name(format!("xpf-userspace-worker-{worker_id}"))
+        .spawn(move || {
+            let result = std::panic::catch_unwind(
+                std::panic::AssertUnwindSafe(body),
+            );
+            if let Err(payload) = result {
+                let msg = panic_payload_message(&payload);
+                eprintln!(
+                    "xpf-userspace-dp: worker_loop panicked (worker_id={}): {}",
+                    worker_id, msg
+                );
+                match panic_slot.lock() {
+                    Ok(mut slot) => *slot = Some(msg),
+                    Err(poisoned) => *poisoned.into_inner() = Some(msg),
+                }
+                runtime_atomics.dead.store(true, Ordering::Relaxed);
+            }
+        })
+        .expect("spawn worker")
+}
+
+// In tests module:
 #[test]
-fn worker_panic_is_caught_and_reported() {
-    let mut coordinator = Coordinator::new_minimal_for_test();
-    coordinator.spawn_workers(/* test config */);
-    coordinator.send_command_to_worker(0, WorkerCommand::PanicInjection);
-    coordinator.wait_for_worker_dead(0, Duration::from_secs(2));
-    let snapshots = coordinator.worker_runtime_snapshots();
-    assert!(snapshots[0].dead);
-    assert!(snapshots[0].panic_message.contains("PanicInjection"));
+fn supervisor_catches_string_panic_and_marks_dead() {
+    let atomics = Arc::new(WorkerRuntimeAtomics::new());
+    let slot = Arc::new(Mutex::new(None));
+    let join = spawn_supervised_worker(
+        7,
+        atomics.clone(),
+        slot.clone(),
+        || panic!("intentional test panic"),
+    );
+    join.join().expect("supervisor must not propagate panic");
+    assert!(atomics.dead.load(Ordering::Relaxed));
+    let msg = slot.lock().unwrap().clone().unwrap_or_default();
+    assert_eq!(msg, "intentional test panic");
+}
+
+#[test]
+fn supervisor_catches_string_payload_panic() { /* String, not &str */ }
+
+#[test]
+fn supervisor_falls_back_for_non_string_panic() {
+    /* panic_any(42_i32); assert_eq!(msg, "non-string panic payload") */
 }
 ```
+
+Production usage in `reconcile` becomes:
+
+```rust
+let join = spawn_supervised_worker(
+    worker_id,
+    runtime_atomics.clone(),
+    panic_slot.clone(),
+    move || worker_loop(/* args */),
+);
+```
+
+The test exercises the same helper. No parallel-harness drift.
 
 ### Unit tests for `panic_payload_message`
 

--- a/docs/pr/925-worker-supervisor/plan.md
+++ b/docs/pr/925-worker-supervisor/plan.md
@@ -132,8 +132,9 @@ pub struct WorkerRuntimeStatus {
     #[serde(rename = "dead", default)]
     pub dead: bool,
     /// #925: panic payload string (if any), for operator diagnosis.
-    /// Empty string when alive or when the panic payload was not a
-    /// string-like type.
+    /// - String payload (`&str` / `String`): the panic argument.
+    /// - Non-string payload: literal "non-string panic payload".
+    /// - Worker alive (no panic): empty string.
     #[serde(rename = "panic_message", default)]
     pub panic_message: String,
 }

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -526,15 +526,21 @@ type HAStateUpdateRequest struct {
 // refreshed on the worker's ~1s publish cadence.  All fields omit when
 // zero so older daemons parse correctly.
 type WorkerRuntimeStatus struct {
-	WorkerID     uint32 `json:"worker_id,omitempty"`
-	TID          uint64 `json:"tid,omitempty"`
-	WallNS       uint64 `json:"wall_ns,omitempty"`
-	ActiveNS     uint64 `json:"active_ns,omitempty"`
-	IdleSpinNS   uint64 `json:"idle_spin_ns,omitempty"`
-	IdleBlockNS  uint64 `json:"idle_block_ns,omitempty"`
-	ThreadCPUNS  uint64 `json:"thread_cpu_ns,omitempty"`
-	WorkLoops    uint64 `json:"work_loops,omitempty"`
-	IdleLoops    uint64 `json:"idle_loops,omitempty"`
+	WorkerID    uint32 `json:"worker_id,omitempty"`
+	TID         uint64 `json:"tid,omitempty"`
+	WallNS      uint64 `json:"wall_ns,omitempty"`
+	ActiveNS    uint64 `json:"active_ns,omitempty"`
+	IdleSpinNS  uint64 `json:"idle_spin_ns,omitempty"`
+	IdleBlockNS uint64 `json:"idle_block_ns,omitempty"`
+	ThreadCPUNS uint64 `json:"thread_cpu_ns,omitempty"`
+	WorkLoops   uint64 `json:"work_loops,omitempty"`
+	IdleLoops   uint64 `json:"idle_loops,omitempty"`
+	// #925 Phase 1 (catch+report): Dead == true means the worker_loop
+	// panicked and the supervisor caught it. Cleared only by daemon
+	// restart in Phase 1; Phase 2 (respawn) will clear on relaunch.
+	// PanicMessage holds the rendered payload for operator diagnosis.
+	Dead         bool   `json:"dead,omitempty"`
+	PanicMessage string `json:"panic_message,omitempty"`
 }
 
 type HAGroupStatus struct {

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -312,6 +312,14 @@ func FormatStatusSummary(status ProcessStatus) string {
 		fmt.Fprintf(&b, "  %-6s %-8s %-8s %-10s %-11s %-8s %-12s %-12s\n",
 			"Worker", "TID", "Active%", "SpinIdle%", "BlockIdle%", "CPU%", "WorkLoops", "IdleLoops")
 		for _, w := range status.WorkerRuntime {
+			// #925 Phase 1: dead workers replace the runtime row with
+			// a DEAD marker + the rendered panic payload. Operator
+			// must restart the daemon to recover the worker's bindings.
+			if w.Dead {
+				fmt.Fprintf(&b, "  %-6d %-8d   DEAD - panicked: %s\n",
+					w.WorkerID, w.TID, w.PanicMessage)
+				continue
+			}
 			wall := float64(w.WallNS)
 			if wall <= 0 {
 				fmt.Fprintf(&b, "  %-6d %-8d    -        -          -        -   %-12d %-12d\n",

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -280,6 +280,10 @@ impl Coordinator {
         self.workers.clear();
         self.identities.clear();
         self.live.clear();
+        // #925 Phase 1: drop the per-worker panic slots alongside the
+        // workers themselves so a long-running daemon that reconciles
+        // through many worker-id sets doesn't accumulate stale slots.
+        self.worker_panics.clear();
         self.cos_owner_worker_by_queue.clear();
         self.shared_cos_owner_worker_by_queue
             .store(Arc::new(BTreeMap::new()));
@@ -797,6 +801,10 @@ impl Coordinator {
                         worker_id, err
                     );
                     self.last_reconcile_stage = format!("spawn_worker_failed:{worker_id}:{err}");
+                    // #925 Phase 1: the panic slot was inserted before
+                    // spawn; drop it now so a snapshot reader doesn't
+                    // see a phantom slot for a worker that never ran.
+                    self.worker_panics.remove(&worker_id);
                     if let Ok(mut recent) = self.recent_exceptions.lock() {
                         push_recent_exception(
                             &mut recent,

--- a/userspace-dp/src/afxdp/coordinator.rs
+++ b/userspace-dp/src/afxdp/coordinator.rs
@@ -58,6 +58,11 @@ pub struct Coordinator {
     /// Per-RG epoch counters for O(1) flow cache invalidation on demotion.
     /// Shared with all worker threads; bumped atomically on demotion/activation.
     pub(crate) rg_epochs: Arc<[AtomicU32; MAX_RG_EPOCHS]>,
+    /// #925 Phase 1: panic-payload slot per worker, keyed by `worker_id`.
+    /// `BTreeMap` (not `Vec`) so non-contiguous or reused worker IDs map
+    /// stably; written exactly once when the worker dies, read at most
+    /// once per gRPC status poll (~1 Hz). Not on the packet hot path.
+    pub(crate) worker_panics: BTreeMap<u32, Arc<Mutex<Option<String>>>>,
 }
 
 impl Coordinator {
@@ -111,6 +116,7 @@ impl Coordinator {
             cos_owner_worker_by_queue: BTreeMap::new(),
             last_cache_flush_at: Arc::new(AtomicU64::new(0)),
             rg_epochs: Arc::new(std::array::from_fn(|_| AtomicU32::new(0))),
+            worker_panics: BTreeMap::new(),
         }
     }
 
@@ -721,9 +727,14 @@ impl Coordinator {
             let runtime_atomics =
                 std::sync::Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new());
             let runtime_atomics_clone = runtime_atomics.clone();
-            let join = thread::Builder::new()
-                .name(format!("xpf-userspace-worker-{worker_id}"))
-                .spawn(move || {
+            // #925 Phase 1: per-worker panic slot, keyed by worker_id.
+            let panic_slot = Arc::new(Mutex::new(None::<String>));
+            self.worker_panics.insert(worker_id, panic_slot.clone());
+            let join = spawn_supervised_worker(
+                worker_id,
+                runtime_atomics.clone(),
+                panic_slot,
+                move || {
                     worker_loop(
                         worker_id,
                         binding_plans,
@@ -759,7 +770,8 @@ impl Coordinator {
                         cos_status_clone,
                         runtime_atomics_clone,
                     );
-                });
+                },
+            );
             match join {
                 Ok(join) => {
                     eprintln!(
@@ -1221,11 +1233,29 @@ impl Coordinator {
     /// #869: snapshot per-worker busy/idle runtime counters.  Each row is
     /// the current `WorkerRuntimeAtomics` publish, most recently written
     /// on the worker's ~1s publish cadence.
+    /// #925: also surfaces `dead` (one-shot AtomicBool set when the
+    /// supervisor catches a worker_loop panic) and the rendered panic
+    /// payload from the per-worker slot in `worker_panics`.
     pub fn worker_runtime_snapshots(&self) -> Vec<crate::protocol::WorkerRuntimeStatus> {
         self.workers
             .iter()
             .map(|(worker_id, handle)| {
                 let s = handle.runtime_atomics.snapshot();
+                let dead = handle
+                    .runtime_atomics
+                    .dead
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                let panic_message = if dead {
+                    self.worker_panics
+                        .get(worker_id)
+                        .and_then(|slot| match slot.lock() {
+                            Ok(g) => g.clone(),
+                            Err(poisoned) => poisoned.into_inner().clone(),
+                        })
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
                 crate::protocol::WorkerRuntimeStatus {
                     worker_id: *worker_id,
                     tid: handle.runtime_atomics.tid(),
@@ -1236,6 +1266,8 @@ impl Coordinator {
                     thread_cpu_ns: s.thread_cpu_ns,
                     work_loops: s.work_loops,
                     idle_loops: s.idle_loops,
+                    dead,
+                    panic_message,
                 }
             })
             .collect()
@@ -2121,6 +2153,71 @@ fn shared_cos_owner_live_by_queue_match(
         })
 }
 
+/// #925 Phase 1: render a panic payload as an operator-readable string.
+///
+/// Cases:
+/// - `&str` payload → the panic argument verbatim.
+/// - `String` payload → its content.
+/// - Anything else → literal `"non-string panic payload"`.
+///
+/// We deliberately do NOT try to extract a concrete type name from a
+/// `dyn Any` payload — `type_name_of_val` on a `Box<dyn Any>` returns
+/// the trait object's name, not the inner type, which would mislead.
+fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        String::from("non-string panic payload")
+    }
+}
+
+/// #925 Phase 1: spawn `body` on a named thread and wrap it with
+/// `catch_unwind`. On panic, mark `runtime_atomics.dead = true` and
+/// publish the rendered payload to `panic_slot`.
+///
+/// `AssertUnwindSafe` rationale (narrow): `worker_loop` takes owned
+/// values and `Arc`s — there are no `&mut` parameters to invalidate
+/// across an unwind. Owned values get dropped on unwind. Shared
+/// `Arc<Mutex<…>>` state MAY become poisoned; per #925's "detection
+/// only" framing this PR does not promise full state recovery — see
+/// `docs/pr/925-worker-supervisor/plan.md` §"AssertUnwindSafe rationale".
+fn spawn_supervised_worker<F>(
+    worker_id: u32,
+    runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
+    panic_slot: Arc<Mutex<Option<String>>>,
+    body: F,
+) -> std::io::Result<thread::JoinHandle<()>>
+where
+    F: FnOnce() + Send + 'static,
+{
+    thread::Builder::new()
+        .name(format!("xpf-userspace-worker-{worker_id}"))
+        .spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+            if let Err(payload) = result {
+                let msg = panic_payload_message(&payload);
+                eprintln!(
+                    "xpf-userspace-dp: worker_loop panicked (worker_id={worker_id}): {msg}",
+                );
+                // Write the message under the slot mutex; on poison
+                // (a prior panic during read), use into_inner — same
+                // pattern as #949's dynamic_neighbors policy.
+                match panic_slot.lock() {
+                    Ok(mut slot) => *slot = Some(msg),
+                    Err(poisoned) => *poisoned.into_inner() = Some(msg),
+                }
+                // Mark dead. Relaxed is fine — the panic_slot mutex
+                // publishes the message; the dead flag is a one-shot
+                // diagnostic, not a synchronization barrier.
+                runtime_atomics
+                    .dead
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2935,5 +3032,61 @@ mod tests {
         assert_eq!(snap.dbg_cos_queue_overflow, 41);
         assert_eq!(snap.rx_fill_ring_empty_descs, 19);
         assert_eq!(snap.debug_outstanding_tx, 23);
+    }
+
+    // -------------------------------------------------------------
+    // #925 Phase 1: worker supervisor catch_unwind tests.
+    // -------------------------------------------------------------
+
+    /// Helper: extract the message from a caught panic payload using
+    /// the same renderer the supervisor uses.
+    fn caught_message<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
+        let r = std::panic::catch_unwind(f);
+        let payload = r.unwrap_err();
+        super::panic_payload_message(&payload)
+    }
+
+    #[test]
+    fn panic_payload_message_renders_str_panic() {
+        assert_eq!(caught_message(|| panic!("hello world")), "hello world");
+    }
+
+    #[test]
+    fn panic_payload_message_renders_string_panic() {
+        let s = String::from("owned message");
+        assert_eq!(caught_message(move || panic!("{}", s)), "owned message");
+    }
+
+    #[test]
+    fn panic_payload_message_falls_back_for_non_string() {
+        // panic_any unwinds with a non-string payload (i32 here).
+        let msg = caught_message(|| std::panic::panic_any(42_i32));
+        assert_eq!(msg, "non-string panic payload");
+    }
+
+    /// Integration test against the same `spawn_supervised_worker`
+    /// production uses (the spawn-closure body is the only thing we
+    /// substitute — the supervisor wrapper is the real one).
+    #[test]
+    fn spawn_supervised_worker_catches_string_panic_and_marks_dead() {
+        use std::sync::atomic::Ordering;
+        let atomics = Arc::new(super::super::worker_runtime::WorkerRuntimeAtomics::new());
+        let slot = Arc::new(Mutex::new(None::<String>));
+        let join = super::spawn_supervised_worker(
+            7,
+            atomics.clone(),
+            slot.clone(),
+            || panic!("intentional test panic"),
+        )
+        .expect("spawn_supervised_worker");
+        // The supervisor must NOT propagate the panic to the joiner.
+        join.join().expect("supervisor must catch worker panic");
+        assert!(atomics.dead.load(Ordering::Relaxed));
+        let msg = slot
+            .lock()
+            .expect("panic slot lock")
+            .clone()
+            .expect("panic message published");
+        assert_eq!(msg, "intentional test panic");
     }
 }

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -23,7 +23,7 @@
 //   4. All atomics use Ordering::Relaxed — these are diagnostic monotonic
 //      counters, not synchronization primitives.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Classification applied to the previous worker-loop iteration.
 /// Determines which counter the elapsed delta is added to.
@@ -68,6 +68,13 @@ pub(crate) struct WorkerRuntimeAtomics {
     pub work_loops: AtomicU64,
     pub idle_loops: AtomicU64,
     pub tid: AtomicU64,
+    /// #925 Phase 1 (catch + report only): set to true exactly once when
+    /// the supervisor catches a worker_loop panic. Never cleared in
+    /// Phase 1; Phase 2 (respawn) will clear on successful relaunch.
+    /// Adding this flag pushes the struct from 64 B → 128 B due to
+    /// `#[repr(align(64))]` rounding; cost is negligible (a few hundred
+    /// bytes total across all workers).
+    pub dead: AtomicBool,
     /// Cacheline padding after the atomics so that adjacent workers in
     /// a `Vec<WorkerRuntimeAtomics>` don't false-share.
     _pad: [u8; 0],
@@ -84,6 +91,7 @@ impl WorkerRuntimeAtomics {
             work_loops: AtomicU64::new(0),
             idle_loops: AtomicU64::new(0),
             tid: AtomicU64::new(0),
+            dead: AtomicBool::new(false),
             _pad: [],
         }
     }

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1059,6 +1059,18 @@ pub struct WorkerRuntimeStatus {
     pub work_loops: u64,
     #[serde(rename = "idle_loops", default)]
     pub idle_loops: u64,
+    /// #925: true if the worker_loop thread panicked and the supervisor
+    /// caught it. Set once on first panic; never cleared in Phase 1.
+    /// Operators see DEAD in `cli show chassis forwarding` and must
+    /// restart the daemon for the dead worker's bindings to recover.
+    #[serde(rename = "dead", default)]
+    pub dead: bool,
+    /// #925: panic payload string for operator diagnosis.
+    /// Cases: `&str` payload → the argument; `String` payload → its
+    /// content; non-string payload → literal "non-string panic payload";
+    /// worker alive (no panic) → empty.
+    #[serde(rename = "panic_message", default)]
+    pub panic_message: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Wraps the `worker_loop` spawn closure with `std::panic::catch_unwind` so a panicking worker is detected and reported instead of dying silently. Phase 1 is **detection only** — operators see DEAD in `cli show chassis forwarding` and must restart the daemon to recover the dead worker's bindings. Respawn / sticky-failure / HA-trigger are explicitly Phase 2+.

### What lands

- `WorkerRuntimeAtomics` gains `dead: AtomicBool` (struct grows 64 → 128 B due to `#[repr(align(64))]` rounding; negligible at 4–12 workers).
- `Coordinator.worker_panics: BTreeMap<u32, Arc<Mutex<Option<String>>>>` — keyed by `worker_id` so the slot survives Phase 2 respawn (Vec wouldn't, per Gemini final-pass review of plan v4).
- `panic_payload_message` renders `&str` / `String` payloads literally; everything else falls back to `"non-string panic payload"` (no fake type-name extraction from `dyn Any`).
- `spawn_supervised_worker` helper wraps the body closure with `catch_unwind(AssertUnwindSafe(body))`. On panic: log via `eprintln!` (→ journald), publish the rendered message under the slot mutex (with `into_inner` poison handling matching #949), set `atomics.dead = Relaxed`. Production `reconcile` and the integration test both call this same helper.
- `WorkerRuntimeStatus` gains `dead: bool` and `panic_message: String` on both Rust (serde rename + default) and Go (`omitempty`) sides.
- `cli show chassis forwarding` displays `DEAD - panicked: <msg>` row in place of the runtime stats when the worker is dead.

### `AssertUnwindSafe` rationale (narrow)

`worker_loop` takes owned values + `Arc`s only — no `&mut` parameters that could leave invariants broken across an unwind (Codex confirmed worker-local `&mut` borrows don't escape the catch boundary). Shared `Arc<Mutex<…>>` state may become poisoned, but the codebase is already poison-tolerant: #949's `into_inner` policy covers `dynamic_neighbors`; session maps and worker command queues use `if let Ok` skip-on-poison and silently drop on poison. This PR does NOT fix that — it just reports the panic that caused it. Operators see DEAD and restart the daemon.

## Plan & Reviews

- **Plan**: `docs/pr/925-worker-supervisor/plan.md` v4. Codex iterated to PLAN-READY across 4 rounds; Gemini final-pass (`task-mojkxb1p-7irp0n`) returned no new issues at v4.
- **Implementation review**: Codex hostile review round-1 (`task-mojre973-yhl1lm`, 4m58s) returned **AGREE-TO-MERGE** with no blocking findings — only one minor doc-fact correction (`tid` field uses `#[serde(default)]` only, not `rename`; new fields still consistent and non-conflicting).
- **Gemini adversarial final-pass** (`task-mojrn2rr-01cd0c`): rate-limited (`gemini-2.5-flash`) at 5m38s. Per the operator's loop threshold, merging on Codex AGREE-only.

## Test plan

- [x] `cargo test --release` — **834 passed** (was 830), 0 failed, 2 ignored. New tests:
  - `panic_payload_message_renders_str_panic`
  - `panic_payload_message_renders_string_panic`
  - `panic_payload_message_falls_back_for_non_string`
  - `spawn_supervised_worker_catches_string_panic_and_marks_dead` (integration: same helper as production reconcile)
- [x] `cargo build --release` clean.
- [x] `go test ./pkg/dataplane/userspace/...` ok.
- [ ] Cluster smoke (P=12 ≥ 22 Gb/s, P=1 ≥ 6 Gb/s, iperf-b ≥ 9.5 Gb/s 0 retx) — to run after PR open. Per-packet cost is 0 (catch_unwind wrapper is around `worker_loop` itself, not the inner per-packet loop), so no expected regression.
- [ ] Optional manual injection: hot-patch a panic into `worker_loop`, restart, observe `cli show chassis forwarding` showing DEAD. Not gated.

## Out of scope (Phase 2+)

- Respawn (recreate BindingWorker state, re-attach UMEM/XSK rings).
- Sticky-failure detection (don't infinite-respawn).
- HA failover trigger on primary-node worker death.
- `neigh_monitor_thread` and `local_tunnel_source_loop` supervision (mechanical, separate PRs).
- Improving `publish_shared_session` cross-map atomicity (pre-existing hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)