### PR TITLE
#965 P1: bucketed timer-wheel session GC (replace O(N) scan)

### DIFF
--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,11 +1,19 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v4 — 2026-04-29. Addresses Codex round-3 (task-mojzzne7-vm90vz):
-two real bugs — bucket helper semantics inconsistent (relative vs
-absolute index), and a same-bucket-reinsert race during pop (drain
-takes the bucket, re-bucket push lands in the drained slot, then
-the empty `due` overwrites it). Alias pseudocode still pushed
-`SessionKey` instead of `WheelEntry`.
+Plan v6 — 2026-04-29. Addresses Codex round-5
+(task-mok0rvip-n6iba1): per-tick complexity model conflated
+"sessions / 256" with "live wheel entries / 256". Under sustained
+per-second touch the wheel can hold up to N × 256 entries (mostly
+stale duplicates), giving ~N entries per popped bucket — not N/256.
+Plan now distinguishes realistic-mixed vs. sustained-per-second-touch
+cost regimes, fixes the contradictory "low single-digit GB" claim
+against the 12.3 GB ceiling at 1M × per-second-touch, removes the
+residual ~30× slab claim, and adds an explicit acceptance gate for
+the sustained-per-second-touch worst-plausible hot-path workload.
+
+Earlier iterations (round 3 fixed the bucket-helper / pop race and
+the alias `WheelEntry` payload; round 4 fixed memory math and the
+alias borrow shape) remain in effect.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -251,8 +259,15 @@ accumulate over the full session lifetime.
 #964 (slot-handle compaction) replaces the 40-B `SessionKey` with a
 ~4-B slot index, taking `WheelEntry` from 48 B to ~16 B — roughly
 **3× smaller** (not 30×; the 30× figure assumed the 248-B miscount).
-That follow-up is still worth doing, but #965 alone keeps the
-absolute memory ceiling at low single-digit GB even at 1M sessions.
+That follow-up is meaningful at scale: at 1M sessions × per-second
+touch, 12.3 GB drops to ~4 GB. Active deletion (per Out of scope)
+takes that further by bounding live entries to N (one per
+session) — at 1M × 16 B = ~16 MB. Either follow-up is the right
+venue for solving the ceiling at the per-second-touch worst case;
+#965 alone delivers the realistic-deployment win and the
+per-tick-bound shape, with a documented memory ceiling that grows
+proportionally to N × WHEEL_BUCKETS under adversarial touch
+patterns.
 
 **Decision**: ship #965 with the corrected algorithm + this
 honest memory math. Document the "every-session-touched-every-tick
@@ -269,44 +284,112 @@ boundary all need explicit pseudocode.
 
 Decision per Codex finding #2: **no per-tick cap**. The cap was a
 flawed knob — at 5K/tick when due-rate is ≥5K/s the backlog grows
-unbounded. Two options remained:
+unbounded. We pay the bucket cost. Multi-level wheels and active
+deletion are deferred to follow-ups (see Out of scope).
 
-(a) Multi-level wheel — extra complexity and a follow-up.
-(b) Just pay the bucket cost. Under the assumption that scheduled
-    ticks are spread roughly uniformly across the wheel (the
-    typical case: sessions installed and touched at independent
-    times produce expirations spread across `WHEEL_BUCKETS`
-    distinct ticks), per-tick work is `O(N / WHEEL_BUCKETS)`. At
-    1M sessions / 256-tick wheel that's ~4K entries per bucket;
-    at ~1.7 µs per entry (HashMap lookup + state update) the
-    per-tick cost is **~7 ms under uniform distribution**, well
-    under sub-ms for realistic loads of ≤100K sessions.
+#### Per-tick cost model (corrected per Codex round-5 #1)
 
-We choose (b). Worst-case caveat: this is **average-case**, not
-absolute worst-case. Adversarial / synthetic workloads that bunch
-all installs into a single tick (all sessions installed at boot
-with identical timeouts, then idle) place every entry in one
-bucket. That bucket sees `O(N)` work at the moment the wheel sweep
-reaches it. We accept this because (i) it requires a synthetic
-load shape — real traffic does not install N sessions in one
-tick, (ii) the cost is paid exactly once per 256 s at most for
-that bucket, and (iii) the resulting latency spike (≈ same as
-today's StW for that one tick) is no worse than today's pre-#965
-behavior, and is dramatically better for the other 255 ticks.
+Per-tick work = `O(K)` where `K` is the number of `WheelEntry`s
+sitting in the popped bucket at that moment. Each entry costs:
 
-The plan is honest: this is *bounded per-bucket* work, not
-*fixed per-tick* work. The "Stop the World" #965 issue goes away
-because per-tick work is now `O(N / WHEEL_BUCKETS)` under uniform
-distribution instead of `O(N)` every tick.
+  - 1 FxHashMap lookup on `self.sessions[key]` (~80–150 ns)
+  - 1 tick-comparison branch (entry-gone / stale / expired / re-bucket)
+  - In the stale and gone cases: O(1) drop and continue
+  - In the expired case: 1 HashMap remove + delta push
+  - In the re-bucket case: 1 HashMap mut + 1 wheel push
 
-The acceptance-gate "mouse-latency" check (Acceptance gate §4
-below) installs sessions at a *uniform* rate over many ticks
-before triggering GC and asserts p99 GC-tick wall time ≤ 1 ms
-under a 50K-session synthetic load. That gate is explicit about
-the uniform-distribution shape; clustered-install adversarial
-shapes (every session installed in the same tick) are out of
-scope for #965 and tracked under #964 / multi-level wheel
-follow-up.
+Per-entry cost is dominated by the HashMap lookup. Realistic
+estimate: ~100 ns per stale/gone entry, ~300 ns per expired/re-
+bucketed entry.
+
+`K` is bounded by the number of pushes that landed in this bucket
+since it was last popped (one wheel rotation = 256 s ago) minus
+those popped at the start of this rotation. Push frequency per
+session is throttled to "1 per second-aligned `scheduled_tick`
+that the canonical `wheel_tick` advances onto". So under the
+**worst plausible hot-path workload — every session touched at
+least once per second**, each session contributes one push per
+second, and over a full 256-s rotation produces 256 entries (255
+of which are stale duplicates by the time their bucket is popped).
+
+Concretely:
+
+  total_wheel_entries ≤ Σ over sessions of
+                        (distinct `scheduled_tick`s pushed in last 256 s)
+                      ≤ N_sessions × min(touches_per_256s, 256)
+
+For a population with **uniform per-second touch on every session**:
+
+  total_wheel_entries ≈ N_sessions × 256
+  K (per bucket)      ≈ N_sessions
+  per-tick cost       ≈ N_sessions × 100 ns
+
+| N (sessions) | per-second touch | mostly idle (avg ≤5 active ticks/sess) |
+|---|---|---|
+| 10K | 1 ms | 200 µs |
+| 100K | **10 ms** | 2 ms |
+| 1M | **100 ms** | 20 ms |
+
+#### What this means for "Stop the World goes away"
+
+Today's StW does ~100 ms once per `SESSION_GC_INTERVAL_NS = 1 s`
+at 1M sessions. The wheel does **the same total work over the
+1 s window**, but spread across 256 ticks at the same per-second
+*shape* — so each tick still has to drain its bucket at full
+size. **The wheel does not dramatically reduce the worst-case
+tick wall-time under sustained per-second touch on every
+session**: at 1M sessions × per-second touch, both today's StW
+and the wheel produce ~100 ms of GC work per second, just paid in
+different shapes (one 100-ms blast vs. ~256 × ~0.4-ms drains —
+but each of those 256 drains visits a *different* bucket, and
+only ONE of them holds the per-second-touch crowd).
+
+The win, restated honestly:
+
+1. **Realistic mixed-traffic deployments** (most sessions idle,
+   some bursty): per-tick cost drops from O(N) to
+   O(N × distinct_active_ticks / 256), which at 100K sessions is
+   sub-ms — a **>50× improvement** in the typical case.
+
+2. **All-active per-second-touch on every session at 100K**:
+   per-tick cost is ~10 ms, vs. today's ~10 ms StW (same scale).
+   The win here is *not* a wall-time reduction; it's that the
+   work is bounded per-tick rather than appearing as a single
+   blocking call. Mouse-latency p99 stops correlating with the
+   GC interval.
+
+3. **All-active per-second-touch on every session at 1M**:
+   per-tick cost is ~100 ms. **This is the same wall time as
+   today's StW.** The wheel does not solve this case; it tracks
+   under "active deletion" and "multi-level wheel" follow-ups.
+   At this scale we recommend operators tune
+   `SESSION_GC_INTERVAL_NS` higher or land #964 first.
+
+4. **Same-bucket install bursts** (synthetic: all N sessions
+   installed in one tick, then idle): bucket sees O(N) work *once*
+   per 256 s, then idles. No worse than today's StW for that one
+   tick; better for the other 255 ticks.
+
+#### Acceptance gate (corrected per Codex round-5 #2)
+
+The mouse-latency gate (Acceptance gates §4) needs two distinct
+synthetic workloads:
+
+A. **Realistic mostly-idle**: 50K sessions, ~10% touched per
+   second (5K touches/s), the rest idle. Assert p99 GC-tick wall
+   time ≤ 1 ms. This is the realistic-deployment claim.
+
+B. **Sustained per-second touch (worst-plausible hot path)**:
+   100K sessions, EVERY session touched once per second for ≥
+   300 s before assertion. Assert p99 GC-tick wall time ≤ 15 ms
+   (matches the ~10 ms model + headroom). This proves the wheel
+   bounds per-tick work and prevents StW spikes even under the
+   worst sustained refresh pattern; it does NOT claim a
+   wall-time win at this load.
+
+Adversarial same-bucket install bursts are out of scope for #965
+and tracked under the active-deletion / multi-level-wheel follow-
+ups.
 
 ```rust
 pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
@@ -472,14 +555,16 @@ amortizes across the bucket lifetime (up to 256 ticks).
 
 Drop the "no allocations on the hot path" claim entirely. The
 honest phrasing is: "amortized O(1) push, occasional reallocation
-during bucket warmup". The expected number of bucket-reallocations
-across the wheel's first 256 ticks is `O(WHEEL_BUCKETS × log(B_avg))`
-≈ 256 × ~5 = ~1300 reallocations total during warm-up. Each is a
-VecDeque buffer copy of size ~B/2 — for B=3K that's 3K × 48 B =
-~144 KB per realloc × 1300 reallocs = ~180 MB of memory churn
-during warm-up. Spread over 256 ticks (256 s wall time), that's
-~720 KB/s of allocator traffic. Negligible vs the per-packet hot
-path.
+during bucket warmup". `VecDeque` doubles its backing buffer
+geometrically, so for a steady-state size of ~B entries it
+reallocates `~log2(B)` times during warm-up; each realloc copies
+*all* current elements (so the realloc just before reaching
+capacity B copies up to B−1 elements). For B=3K and B_avg ≈ B/2
+across the warm-up, the per-bucket warm-up moves ≈ B − 1 ≈ 3K
+elements total. Across 256 buckets that's 256 × 3K = ~768K
+element-moves during warm-up at 48 B each ≈ ~36 MB total. Spread
+over 256 ticks (256 s wall time), that's ~150 KB/s of allocator
+traffic. Negligible vs the per-packet hot path.
 
 After warm-up (after first wheel rotation), each bucket's VecDeque
 has settled at ~max-bucket-size capacity. New pushes don't grow.
@@ -543,6 +628,14 @@ buffers grow to fit avg load × geometric headroom. For typical
   sessions all with same expiration; advance time past expiration;
   verify expire_stale_entries returns all 50K in a single call
   (no per-tick cap; one tick = one bucket = O(B) work, not capped).
+- `wheel_per_second_touch_bound_per_tick_work` (Codex round-5 #2):
+  install N=10K sessions, then touch every session once per
+  second for 300 s of simulated time before measuring. After
+  warm-up, advance one tick and measure `wheel_pop_one_bucket`
+  wall time. Assert ≤ 5 ms (allows 2.5× headroom over the 100 ns
+  × 10K = 1 ms model). This catches regressions where a refactor
+  inadvertently makes `lookup_with_origin` or `update_session`
+  add multiple wheel pushes per touch.
 - `wheel_alias_lookup_does_not_double_borrow_self`: compile-time
   test that the alias path's `lookup_with_origin` body type-checks
   (i.e. the &mut self.sessions borrow is scoped before
@@ -559,16 +652,29 @@ continue to pass.
 ## Acceptance gates
 
 1. `cargo build --release` clean.
-2. `cargo test --release` ≥ baseline (851 post-#921) + 8 new = 859.
+2. `cargo test --release` ≥ baseline (851 post-#921) + 10 new = 861.
 3. Cluster smoke (HARD): no regression on the unloaded-session path.
    - iperf-c P=12 ≥ 22 Gb/s
    - iperf-c P=1 ≥ 6 Gb/s
-4. **Mouse-latency gate** (the actual #965 win): when the daemon
-   is loaded with ≥10K sessions and GC ticks fire under load, p99
-   mouse latency stays within ±5% of the unloaded baseline. Today
-   without this PR, p99 spikes correlate with GC ticks. Hard to
-   reproduce in a 30s smoke run; we'll instrument the GC-tick
-   wall time and assert ≤1 ms p99 under synthetic 50K-session load.
+4. **Mouse-latency gate** — TWO synthetic workloads (per Codex
+   round-5 #2):
+
+   4a. **Realistic mostly-idle**: 50K sessions, ~10% touched per
+       second (5K touches/s), the rest idle for ≥ 300 s before
+       measurement. Assert p99 GC-tick wall time ≤ 1 ms. This is
+       the typical-deployment win.
+
+   4b. **Sustained per-second touch**: 10K sessions, EVERY session
+       touched once per second for ≥ 300 s. Assert p99 GC-tick
+       wall time ≤ 5 ms (matches the 100 ns × 10K = 1 ms model
+       with 5× headroom). This proves the wheel keeps per-tick
+       work bounded under the hot-path refresh shape; it does NOT
+       claim a wall-time win at this load — see "Per-tick cost
+       model" in §Per-tick GC work.
+
+   Both gates must hold. Adversarial same-bucket install bursts
+   are out of scope for #965 and tracked under the active-
+   deletion / multi-level-wheel follow-ups (see Out of scope).
 5. Codex hostile review: AGREE-TO-MERGE.
 6. Gemini adversarial review: AGREE-TO-MERGE.
 
@@ -602,10 +708,18 @@ Risk areas:
   `WheelEntry { SessionKey, scheduled_tick }` as the bucket
   payload. After #964, the payload becomes
   `WheelEntry { SlotHandle, scheduled_tick }` — same structure,
-  ~30× smaller. The path between #965 and #964 is mechanical.
+  ~3× smaller (16 B vs 48 B). The path between #965 and #964 is
+  mechanical.
+- Active wheel-entry deletion (intrusive doubly-linked list per
+  bucket with back-reference in SessionEntry). Would bound live
+  wheel entries at exactly N (one per session) instead of up to
+  N × 256 under sustained per-tick touch. Significantly more code;
+  defer to a follow-up if the per-tick cost under adversarial
+  workloads becomes a problem.
 - Multi-level wheels (hashed timing wheels): the single wheel +
   re-bucket-on-still-alive is enough for the typical 100K-session
   / ≤300 s timeout case. Multi-level is a follow-up if profiling
-  shows the per-bucket spike (≤7 ms at 1M sessions) is an issue.
+  shows the per-bucket spike under sustained per-tick touch
+  (analyzed below) is an issue.
 - Per-protocol expire policy refactor: timeouts are still computed
   from `key.protocol` and `tcp_flags` at insert/update time.

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,0 +1,236 @@
+# #965: bucketed timer-wheel session GC (replace O(N) scan)
+
+Plan v1 — 2026-04-29.
+
+## Investigation findings (Claude, on commit 08ff1838)
+
+`SessionTable.expire_stale_entries` at `userspace-dp/src/session.rs:279-340`
+runs once per `SESSION_GC_INTERVAL_NS = 1s`. Inside that gate it does:
+
+```rust
+let stale = self.sessions.iter()
+    .filter_map(|(key, entry)| {
+        if now_ns.saturating_sub(entry.last_seen_ns) > entry.expires_after_ns {
+            Some(key.clone())
+        } else { None }
+    })
+    .collect::<Vec<_>>();
+// then iterate stale and remove each
+```
+
+This is O(N) over the entire `FxHashMap<SessionKey, SessionEntry>`
+every tick. At 1M concurrent sessions (a realistic 100G workload):
+
+- Hash-map iter + entry-tuple copy ≈ 100 ns/entry → ~100 ms per tick.
+- Two `Vec` allocations per tick (`stale`, `expired_entries`).
+- The hot worker thread BLOCKS for those 100 ms — every queue
+  starves, mouse-latency p99 jumps to >100 ms, and the XSK RX rings
+  back-pressure into the kernel.
+
+This is the "stop the world" GC pause #965 calls out.
+
+### Where last_seen / expires_after are written
+
+- `install_with_protocol` (L484) — initial insert.
+- `upsert_synced` (L554) — HA peer sync insert.
+- `update_session` (L612) — protocol-specific update.
+- `lookup_with_origin` (L390) — every read also touches last_seen
+  (this is the most frequent path; ~per session-miss-cached-hit).
+- `touch` (L274) — flow-cache amortized keepalive.
+- `refresh_local` / `refresh_for_ha_activation` /
+  `refresh_for_ha_transition` — HA state-machine paths.
+
+Any change to expiration management has to thread these write sites.
+
+## Approach
+
+Add a **bucketed timer wheel** that mirrors the `sessions` HashMap.
+On insert / touch / refresh, push the key into the bucket whose
+index = `(last_seen_ns + expires_after_ns) / TICK_NS` modulo the
+wheel size. On GC tick, pop one bucket and walk only those keys.
+
+The wheel is purely an *index*; the authoritative state still lives
+in `sessions: FxHashMap<SessionKey, SessionEntry>`. We do NOT
+require #964's slab + integer handle refactor for #965 to land.
+
+### Wheel shape
+
+```rust
+const WHEEL_TICK_NS: u64 = 1_000_000_000;        // 1 s
+const WHEEL_BUCKETS: usize = 256;                // covers 256 s window
+const WHEEL_TIMEOUT_CAP_NS: u64 =
+    WHEEL_TICK_NS * (WHEEL_BUCKETS as u64);      // 256 s
+
+pub(crate) struct SessionWheel {
+    /// 256 buckets indexed by `(expiration_ns / TICK_NS) & 0xFF`.
+    /// Each bucket holds the SessionKeys whose computed expiration
+    /// rounded down lands in that bucket.
+    buckets: Box<[VecDeque<SessionKey>; WHEEL_BUCKETS]>,
+    /// Anchor: the `expiration_tick` value of bucket index 0 in the
+    /// most recently rolled-over wheel cycle. Used to translate
+    /// absolute time → bucket index.
+    base_tick: u64,
+    /// Last tick processed by `pop_due()`. Bounded by current tick.
+    cursor_tick: u64,
+}
+```
+
+Coverage: with `WHEEL_TICK_NS = 1s` and 256 buckets, the wheel
+covers a 256-second timeout window. The longest session timeout
+today is `TCP_ESTABLISHED_TIMEOUT_NS` ≈ 7200 s — that exceeds the
+wheel. We handle long-timeout entries via a fallback:
+
+- If `expires_after_ns > WHEEL_TIMEOUT_CAP_NS`, push the key into
+  the bucket at `(base_tick + WHEEL_BUCKETS - 1) & WHEEL_MASK`
+  (the "far future" bucket). When that bucket is popped, re-check
+  the entry's actual `last_seen_ns + expires_after_ns`; if it's
+  still in the future, re-bucket it.
+
+This gives correctness for long sessions at the cost of one extra
+re-bucket every 256 s for each long-lived TCP session (a few
+microseconds per session — negligible at any realistic count).
+
+### Lazy delete on touch
+
+When `touch` / `lookup_with_origin` / `update_session` updates
+`last_seen_ns`, the old bucket entry becomes stale. Two options:
+
+A. **Eager remove + re-insert**: O(N_bucket) scan to find the old
+   key in its bucket, remove it, then push to the new bucket.
+   Per-touch cost: O(N_bucket) which can be thousands.
+
+B. **Lazy delete**: leave the stale entry in the old bucket. On
+   pop, re-check the entry's current `last_seen_ns + expires_after_ns`
+   against `now_ns`. If still in the future, the entry was touched
+   after we bucketed it; skip (don't remove from sessions, don't
+   emit expired). If `Some(entry)` not found in `sessions`, also
+   skip (already removed).
+
+Option B is dramatically simpler and faster on the hot path. Cost:
+the wheel can carry duplicate entries for a touched session (one
+in the old stale bucket, one in the new). Each pop visit to a
+stale entry is one HashMap lookup ≈ 100 ns and a comparison. For a
+session that's touched 10x over its lifetime, that's 10 stale
+bucket entries × 100 ns = 1 µs total over the session lifetime.
+
+We choose **B (lazy delete)**. The wheel is a *hint* about which
+keys *might* have expired, not authoritative state.
+
+### Per-tick GC work
+
+```rust
+pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
+    let now_tick = now_ns / WHEEL_TICK_NS;
+    if self.last_gc_ns != 0 && now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
+        return Vec::new();
+    }
+    self.last_gc_ns = now_ns;
+    let mut expired = Vec::new();
+    while self.wheel.cursor_tick < now_tick {
+        let bucket_idx = (self.wheel.cursor_tick & WHEEL_MASK) as usize;
+        let mut due = std::mem::take(&mut self.wheel.buckets[bucket_idx]);
+        for key in due.drain(..) {
+            // Lazy-delete: re-check current expiration against now_ns.
+            let Some(entry) = self.sessions.get(&key) else { continue };
+            let entry_expires_at = entry.last_seen_ns.saturating_add(entry.expires_after_ns);
+            if entry_expires_at > now_ns {
+                // Touched since this bucket was set — already
+                // re-bucketed at touch time. Drop this stale ref.
+                continue;
+            }
+            // Genuinely expired. Remove and emit.
+            if let Some(removed) = self.remove_entry(&key) {
+                // ... existing remove_entry path produces SessionDelta
+                // and ExpiredSession ...
+                expired.push(...);
+            }
+        }
+        self.wheel.cursor_tick += 1;
+    }
+    expired
+}
+```
+
+Per-tick work: O(B) where B is the average bucket size = N / T.
+For N=1M sessions across the 256-bucket wheel and average timeout
+30s, B = 1M / 30 ≈ 33,000 entries per bucket. Each entry is one
+HashMap lookup + one comparison ≈ 200 ns. Per-tick cost: ~6.6 ms.
+
+To bound the spike further (target: ≤1 ms per tick), we cap
+per-tick work to `MAX_GC_ENTRIES_PER_TICK = 5000`. If a bucket has
+more, defer the rest — push them back at the wheel's tail and they
+get processed next tick.
+
+That's still O(1) amortized: the wheel's total work over a full
+revolution is O(N), distributed across 256 ticks. With the cap,
+worst-case spike is 5000 × 200 ns = 1 ms.
+
+### Files touched
+
+- `userspace-dp/src/session.rs`: add `SessionWheel` (~150 LOC),
+  add wheel push at insert/touch/refresh sites, replace
+  `expire_stale_entries` body with wheel pop. ~250 LOC change.
+  Public API unchanged.
+
+### Tests
+
+- `wheel_pops_expired_entry_from_bucket`: insert one session, advance
+  time past its timeout, verify expire_stale_entries returns it.
+- `wheel_skips_touched_entry`: insert, touch (advances last_seen),
+  advance time past original bucket but before new bucket; verify
+  expire_stale_entries does NOT return it.
+- `wheel_handles_long_timeout_via_far_future_bucket`: insert with
+  timeout > 256s; verify entry doesn't expire prematurely; advance
+  past 256s; verify entry re-buckets and expires correctly later.
+- `wheel_per_tick_work_capped`: insert 50,000 sessions all with
+  same expiration tick; verify expire_stale_entries returns at
+  most MAX_GC_ENTRIES_PER_TICK; subsequent tick returns the rest.
+- `wheel_handles_concurrent_insert_and_pop`: not relevant
+  (SessionTable is not Send + Sync — owned by a single worker).
+
+Plus 4 existing GC tests (lines 2138, 2142, 2162, +1 more) must
+continue to pass.
+
+## Acceptance gates
+
+1. `cargo build --release` clean.
+2. `cargo test --release` ≥ baseline (851 post-#921) + 4 new = 855.
+3. Cluster smoke (HARD): no regression on the unloaded-session path.
+   - iperf-c P=12 ≥ 22 Gb/s
+   - iperf-c P=1 ≥ 6 Gb/s
+4. **Mouse-latency gate** (the actual #965 win): when the daemon
+   is loaded with ≥10K sessions and GC ticks fire under load, p99
+   mouse latency stays within ±5% of the unloaded baseline. Today
+   without this PR, p99 spikes correlate with GC ticks. Hard to
+   reproduce in a 30s smoke run; we'll instrument the GC-tick
+   wall time and assert ≤1 ms p99 under synthetic 50K-session load.
+5. Codex hostile review: AGREE-TO-MERGE.
+6. Gemini adversarial review: AGREE-TO-MERGE.
+
+## Risk
+
+**Medium-low.**
+
+- Wheel is purely an index; sessions HashMap is authoritative.
+- Lazy-delete is correct: we re-check actual expiration on pop.
+- Long-timeout fallback (re-bucket past the wheel cap) tested.
+- Per-tick cap bounds the spike.
+
+Risk areas:
+- `touch` / `lookup_with_origin` are hot — they currently just
+  update `last_seen_ns` in-place. After this PR they ALSO push to
+  a wheel bucket. The push is `VecDeque::push_back` on a
+  preallocated Box<[VecDeque; 256]>. No allocations on the hot
+  path (the VecDeques start empty and grow as needed; capacity
+  hints can avoid allocations under steady-state).
+
+## Out of scope
+
+- #964 (slab + integer handles): keep `sessions: FxHashMap<SessionKey, SessionEntry>`.
+  The wheel uses `SessionKey` as the bucket payload. After #964,
+  the wheel can switch to `SlotHandle` payload (smaller, faster).
+- Multi-level wheels (hashed timing wheels): single wheel + per-tick
+  cap is enough for the bounds we need. Multi-level is a follow-up
+  if profiling shows the cap deferral causes work pile-up.
+- Per-protocol expire policy refactor: timeouts are still computed
+  from `key.protocol` and `tcp_flags` at insert time.

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,6 +1,24 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v8 — 2026-04-29. Addresses Codex round-7 (task-mok1ojg3-0esulj):
+Plan v9 — 2026-04-29. Addresses Codex round-8 wording fixes
+(task-mok24765-mmf95n; no blocking findings, all substantive
+claims verified correct):
+
+a. Sub-tick lag wording now gives explicit absolute bounds
+   (today's gated scan ≤ 1 s; wheel ≤ 2 s) and frames the
+   wheel's contribution as "additional deviation < 1 wheel-tick"
+   instead of "same worst-case lag".
+
+b. Stale "Drain in place into a local Vec" comment replaced with
+   "Drain the bucket allocation-free" to match the v8 no-Vec
+   redesign.
+
+c. "Not popped during this call" tightened to "not popped during
+   this bucket drain" with an explicit note that re-pushes into
+   later buckets WILL be popped within the same multi-tick
+   catch-up call (intentional and correct).
+
+v8 — Addresses Codex round-7 (task-mok1ojg3-0esulj):
 
 1. Acceptance gate 4a workload was self-contradictory: "10 %
    touched per second" produces K ≈ 5K (every active session pushes
@@ -11,26 +29,22 @@ Plan v8 — 2026-04-29. Addresses Codex round-7 (task-mok1ojg3-0esulj):
 
 2. Per-second-touch test classification was wrong: under sustained
    per-second touch on every session, popped entries are ALL stale
-   duplicates (canonical wheel_tick has advanced beyond every
-   bucket's scheduled_tick by the time the bucket is popped). So
-   `entries_re_bucketed = 0`, not = N; `entries_dropped_stale ≈ K`,
-   not `≈ N × 255`. Test rewritten with the correct classification.
+   duplicates. So `entries_re_bucketed = 0`, not = N;
+   `entries_dropped_stale ≈ K`, not `≈ N × 255`. Test rewritten
+   with the correct classification.
 
 3. Drain pseudocode allocated `Vec::with_capacity(due_count)` per
    pop, contradicting the "no per-second Vec allocation" claim.
    Redesigned: snapshot bucket length, iterate via `pop_front`
    exactly that many times, no scratch buffer needed. Re-pushed
-   entries land at the back of the VecDeque and are NOT popped
-   during this call (next rotation handles them).
+   entries land at the back of the VecDeque and are not popped
+   during this BUCKET drain (the next wheel rotation handles
+   same-bucket re-pushes; re-pushes into later buckets are
+   processed within the same multi-tick catch-up call).
 
 4. "No production caller can observe the difference" softened to
-   "same worst-case bounded lag, slightly different GC-phase
-   alignment". The wheel preserves the existing 1-s lag bound but
-   may pick up an expiration up to 1 tick later than today's gated
-   scan does, depending on relative phase of `target_tick` vs.
-   wheel cursor at expiration time. Bounded above by
-   `WHEEL_TICK_NS`, strictly less than today's `SESSION_GC_INTERVAL_NS`,
-   no user-visible regression.
+   "additional deviation < 1 wheel-tick" with explicit absolute
+   bounds — see point (a) above for the corrected wording.
 
 Earlier rounds remain in effect: round-3 (bucket-helper / pop
 race + alias `WheelEntry`), round-4 (memory math + alias borrow
@@ -552,11 +566,18 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
                 // bucket at the new absolute target tick. The new
                 // bucket may be `bucket_idx` again (e.g. exactly
                 // 256s timeout repeats); that's fine because the
-                // outer `for _ in 0..due_count` loop iterates
+                // inner `for _ in 0..due_count` loop iterates
                 // exactly `due_count` times — re-pushed entries
-                // land at the back of the VecDeque and are NOT
-                // popped during this call. They get processed at
-                // the next wheel rotation.
+                // into THIS bucket land at the back of the
+                // VecDeque and are not popped during this BUCKET
+                // drain. They get processed at the next wheel
+                // rotation that visits this bucket. (Re-pushes
+                // into a LATER bucket — e.g. target_tick > current
+                // cursor + 1 — that the OUTER `while cursor_tick
+                // < now_tick` loop will visit in this same call
+                // ARE popped before the call returns; that case
+                // represents an entry re-bucketed forward into a
+                // tick that has already arrived.)
                 let new_target_tick = target_tick_for(
                     now_ns,
                     entry.last_seen_ns + entry.expires_after_ns,
@@ -795,19 +816,40 @@ continue to pass.
 3. Cluster smoke (HARD): no regression on the unloaded-session path.
    Run on `loss:xpf-userspace-fw0/fw1` (the userspace-dp HA cluster
    that is the default deploy target — NOT the legacy eBPF
-   `bpfrx-fw0/fw1` cluster) AND with CoS configured on every iperf3
-   forwarding-class. CoS state is wiped by `cluster-deploy`, so the
-   smoke runner must re-apply CoS classes before measurement.
-   - Apply CoS config covering all configured forwarding classes
-     (best-effort, expedited-forwarding, assured-forwarding, etc.)
-     before the first iperf3 run.
-   - iperf-c P=12 ≥ 22 Gb/s, repeated once per CoS class. Each run
-     must hit the gate independently.
-   - iperf-c P=1 ≥ 6 Gb/s, repeated once per CoS class.
-   - Verify `show class-of-service interface` reports the expected
-     class queues are non-zero on the egress side; an iperf3 run
-     that never lights up the queue counter is a config-misapplied
-     smoke that doesn't validate the CoS path.
+   `bpfrx-fw0/fw1` cluster) AND with CoS configured on every
+   iperf3 forwarding-class via `test/incus/cos-iperf-config.set`.
+   CoS state is wiped by `cluster-deploy`, so the smoke runner
+   must re-apply that fixture before measurement.
+
+   Per-class enumeration (matches the fixture's shaped rates,
+   ~10 % headroom for L2 overhead and TCP RTT variance):
+
+   | Class       | Port  | Shaped rate | P=12 gate     | P=1 gate     |
+   |-------------|-------|-------------|---------------|--------------|
+   | iperf-c     | 5203  | 25 g exact  | ≥ 22 Gb/s     | ≥ 6 Gb/s     |
+   | iperf-f     | 5206  | 19 g exact  | ≥ 17.1 Gb/s   | counter-only |
+   | iperf-e     | 5205  | 16 g exact  | ≥ 14.4 Gb/s   | counter-only |
+   | iperf-d     | 5204  | 13 g exact  | ≥ 11.7 Gb/s   | counter-only |
+   | iperf-b     | 5202  | 10 g exact  | ≥ 9.0 Gb/s    | counter-only |
+   | iperf-a     | 5201  | 1 g exact   | ≥ 0.9 Gb/s    | counter-only |
+   | best-effort | 5207  | 100 m exact | ≥ 90 Mb/s     | counter-only |
+
+   - "P=12 gate" runs `iperf3 -P 12 -p <port>` and asserts the
+     achieved Gb/s is ≥ the listed minimum. iperf-c is the
+     historical 22 Gb/s smoke; the others get a shaped-rate
+     gate scaled to their queue.
+   - "counter-only" rows still run an iperf3 P=1 against the
+     class but only assert that the egress class counter
+     (`show class-of-service interface reth0 unit 80`) lights
+     up by at least the iperf3 byte count. This validates the
+     classifier / queue path lit up without imposing a hard
+     throughput gate on classes whose shape would make a fixed
+     gate brittle.
+   - **Hard gate on iperf-c only.** The other rows are smoke for
+     "the queue path actually executed". A class whose iperf3
+     run lights up best-effort (queue 0) instead of the targeted
+     class is a config-misapplied smoke that does NOT validate
+     the refactor; treat it as a failure of step 3.
 4. **Mouse-latency gate** — TWO synthetic workloads (per Codex
    round-5 #2 + round-6 #4 / #5). The numbers below are the
    single source of truth; any other section that mentions "the

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,10 +1,11 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mojzpydq-t17ylf):
-algorithm bug — round-2 v2 pop dropped still-alive long-timeout
-entries from the wheel forever; bucket payload extended to
-`WheelEntry { key, scheduled_tick }` with explicit re-bucket-or-
-drop pop logic; memory math corrected; doc contradictions cleaned.
+Plan v4 — 2026-04-29. Addresses Codex round-3 (task-mojzzne7-vm90vz):
+two real bugs — bucket helper semantics inconsistent (relative vs
+absolute index), and a same-bucket-reinsert race during pop (drain
+takes the bucket, re-bucket push lands in the drained slot, then
+the empty `due` overwrites it). Alias pseudocode still pushed
+`SessionKey` instead of `WheelEntry`.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -117,29 +118,42 @@ Every public method that takes `now_ns` calls `wheel_observe(now_ns)`
 before any wheel push or pop. Test:
 `first_gc_with_large_monotonic_now_doesnt_walk_billions_of_buckets`.
 
-### Bucket-index calculation (Codex finding #4 — exact-256s trap)
+### Bucket-index calculation (Codex round-3 finding #1 — absolute, not relative)
+
+There is exactly ONE bucket helper. It takes an absolute target
+tick (the tick the entry should be checked at) and returns
+`(target_tick & WHEEL_MASK) as usize`. Both `push` and `pop` use
+the same formula.
 
 ```rust
 const FAR_FUTURE_OFFSET: u64 = WHEEL_BUCKETS as u64 - 1;
 
-fn bucket_for_expiration(&self, expiration_ns: u64, now_ns: u64) -> usize {
+#[inline]
+fn bucket_for_tick(tick: u64) -> usize {
+    (tick & WHEEL_MASK) as usize
+}
+
+/// Compute the absolute target tick at which an entry with the
+/// given expiration_ns should be checked, given the current
+/// `now_ns`. Returns `now_tick + delta.min(FAR_FUTURE_OFFSET)`.
+/// An entry with delta >= WHEEL_BUCKETS lands FAR_FUTURE_OFFSET
+/// ticks ahead and gets re-checked there (still-alive case
+/// triggers re-bucketing in pop).
+fn target_tick_for(now_ns: u64, expiration_ns: u64) -> u64 {
     let now_tick = now_ns / WHEEL_TICK_NS;
     let expiration_tick = expiration_ns / WHEEL_TICK_NS;
     let delta = expiration_tick.saturating_sub(now_tick);
-    // Cap at WHEEL_BUCKETS - 1 to make the "far future" bucket
-    // unambiguously distinct from the current bucket. An entry
-    // with delta >= WHEEL_BUCKETS lands in the far-future bucket
-    // and gets re-bucketed on pop. An entry with delta < WHEEL_BUCKETS
-    // lands at its precise position.
-    let offset = delta.min(FAR_FUTURE_OFFSET);
-    ((self.wheel.cursor_tick + offset) & WHEEL_MASK) as usize
+    now_tick + delta.min(FAR_FUTURE_OFFSET)
 }
 ```
 
-Use `>= WHEEL_BUCKETS` (i.e., `delta` clamped to FAR_FUTURE_OFFSET)
-not `> WHEEL_TIMEOUT_CAP_NS`. The clamping makes "exactly 256s"
-land at FAR_FUTURE_OFFSET ahead — distinct from the current bucket
-and correctly delayed. Test: `wheel_handles_exact_256s_timeout`.
+Use absolute target ticks throughout. The `target_tick` is what's
+written into `entry.wheel_tick` and `WheelEntry.scheduled_tick`.
+At pop time, `self.wheel.cursor_tick` advances absolutely; the
+bucket index is just `(cursor_tick & WHEEL_MASK)`. The
+"exactly 256s" case lands at `now_tick + 255`, which the wheel
+will revisit only after a full rotation — distinct from the
+current bucket. Test: `wheel_handles_exact_256s_timeout`.
 
 ### Coverage of long-lived TCP
 
@@ -157,11 +171,13 @@ When `install` / `upsert_synced` / `lookup_with_origin` / `update_session`
 need to add a wheel entry. To bound duplicates we throttle:
 
 ```rust
-let new_expiration_tick = (entry.last_seen_ns + entry.expires_after_ns)
-    / WHEEL_TICK_NS;
+let new_expiration_tick = target_tick_for(
+    now_ns,
+    entry.last_seen_ns + entry.expires_after_ns,
+);
 if new_expiration_tick != entry.wheel_tick {
     entry.wheel_tick = new_expiration_tick;
-    let bucket = self.bucket_for_tick(new_expiration_tick);
+    let bucket = bucket_for_tick(new_expiration_tick);
     self.wheel.buckets[bucket].push_back(WheelEntry {
         key: actual_key.clone(),
         scheduled_tick: new_expiration_tick,
@@ -244,49 +260,63 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
     // Cursor starts at the lazy-init now_tick, so the first call
     // after init is a no-op (loop body runs zero times).
     while self.wheel.cursor_tick < now_tick {
-        let bucket_idx = (self.wheel.cursor_tick & WHEEL_MASK) as usize;
-        // Take ownership of the bucket for the drain.
-        let mut due = std::mem::take(&mut self.wheel.buckets[bucket_idx]);
-        for WheelEntry { key, scheduled_tick } in due.drain(..) {
+        let bucket_idx = bucket_for_tick(self.wheel.cursor_tick);
+        // Drain in place into a local Vec, then process. We cannot
+        // hold a `&mut VecDeque` from the wheel and simultaneously
+        // call `self.wheel.buckets[new_bucket].push_back(...)` for
+        // a re-bucket whose target may equal `bucket_idx` — that
+        // would alias the same VecDeque mutably. Round-3 caught
+        // the v3 same-bucket-reinsert race that arose from
+        // `mem::take` followed by `buckets[idx] = due` overwriting
+        // re-bucketed entries. Drain → local Vec → free up the
+        // wheel reference → process from the local Vec.
+        let due_count = self.wheel.buckets[bucket_idx].len();
+        let mut due_buf: Vec<WheelEntry> = Vec::with_capacity(due_count);
+        while let Some(entry) = self.wheel.buckets[bucket_idx].pop_front() {
+            due_buf.push(entry);
+        }
+        for WheelEntry { key, scheduled_tick } in due_buf.drain(..) {
             let Some(entry) = self.sessions.get(&key) else {
                 // Already removed elsewhere — drop hint.
                 continue;
             };
             if entry.wheel_tick != scheduled_tick {
                 // Stale duplicate: the entry has been re-scheduled
-                // to a different tick (touched + tick changed).
-                // The new scheduled tick has its own wheel entry.
+                // to a different tick. The new tick has its own
+                // wheel entry already.
                 continue;
             }
-            // scheduled_tick matches the entry's recorded wheel_tick
-            // — this is the canonical scheduled-check entry. Now
-            // determine: actually expired vs. needs re-bucketing.
-            // Match today's strict `>` semantics (Codex finding #8).
+            // scheduled_tick matches entry.wheel_tick — this is the
+            // canonical scheduled-check entry. Match today's strict
+            // `>` semantics for "actually expired".
             if now_ns.saturating_sub(entry.last_seen_ns) > entry.expires_after_ns {
-                // Genuinely expired.
                 if let Some(removed) = self.remove_entry(&key) {
                     // ... emit SessionDelta + ExpiredSession ...
                     expired.push(...);
                 }
             } else {
-                // Still alive — happens for long-timeout sessions
-                // (>= 256s) and for sessions that were re-scheduled
-                // exactly back to this tick. Re-bucket at the new
-                // expiration tick.
-                let new_tick = (entry.last_seen_ns + entry.expires_after_ns)
-                    / WHEEL_TICK_NS;
-                let new_bucket = self.bucket_for_tick(new_tick);
+                // Still alive — long-timeout (>= 256s) case, or a
+                // session re-scheduled to exactly this tick. Re-
+                // bucket at the new absolute target tick. The new
+                // bucket may be `bucket_idx` again (e.g. exactly
+                // 256s timeout repeats); that's fine because the
+                // wheel's bucket VecDeque is now empty (we drained
+                // into due_buf above), so the push goes to the
+                // correct slot and is NOT overwritten on loop exit.
+                let new_target_tick = target_tick_for(
+                    now_ns,
+                    entry.last_seen_ns + entry.expires_after_ns,
+                );
+                let new_bucket = bucket_for_tick(new_target_tick);
                 let entry_mut = self.sessions.get_mut(&key)
                     .expect("entry was just read");
-                entry_mut.wheel_tick = new_tick;
+                entry_mut.wheel_tick = new_target_tick;
                 self.wheel.buckets[new_bucket].push_back(WheelEntry {
                     key,
-                    scheduled_tick: new_tick,
+                    scheduled_tick: new_target_tick,
                 });
             }
         }
-        // Return the (now-empty) VecDeque buffer for reuse.
-        self.wheel.buckets[bucket_idx] = due;
         self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
     }
     self.wheel.base_tick = now_tick;
@@ -322,13 +352,20 @@ let actual_key = if self.sessions.contains_key(key) {
 };
 self.sessions.get_mut(&actual_key).map(|entry| {
     // ... last_seen_ns / expires_after_ns updates ...
-    let new_expiration_tick = (entry.last_seen_ns + entry.expires_after_ns)
-        / WHEEL_TICK_NS;
+    let new_expiration_tick = target_tick_for(
+        now_ns,
+        entry.last_seen_ns + entry.expires_after_ns,
+    );
     if new_expiration_tick != entry.wheel_tick {
         entry.wheel_tick = new_expiration_tick;
-        // PUSH actual_key, not the alias `key`.
-        let bucket = self.wheel.bucket_for_tick(new_expiration_tick);
-        self.wheel.buckets[bucket].push_back(actual_key.clone());
+        // PUSH actual_key, not the alias `key`. Payload must be
+        // a WheelEntry carrying the canonical scheduled_tick so
+        // pop's lazy-delete discriminator can detect staleness.
+        let bucket = bucket_for_tick(new_expiration_tick);
+        self.wheel.buckets[bucket].push_back(WheelEntry {
+            key: actual_key.clone(),
+            scheduled_tick: new_expiration_tick,
+        });
     }
     // ... return SessionLookup ...
 })

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,6 +1,10 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v1 — 2026-04-29.
+Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mojzeozp-8bzfr7):
+8 blocking findings — cursor init, per-tick cap drainage,
+deferred-tail semantics, exact-256s correctness trap, alias
+lookup, hot-path allocation claim, duplicate-wheel-entry bound,
+expiry boundary off-by-1ns.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -57,113 +61,273 @@ require #964's slab + integer handle refactor for #965 to land.
 
 ```rust
 const WHEEL_TICK_NS: u64 = 1_000_000_000;        // 1 s
-const WHEEL_BUCKETS: usize = 256;                // covers 256 s window
-const WHEEL_TIMEOUT_CAP_NS: u64 =
-    WHEEL_TICK_NS * (WHEEL_BUCKETS as u64);      // 256 s
+const WHEEL_BUCKETS: usize = 256;                // 256 s window
+const WHEEL_MASK: u64 = (WHEEL_BUCKETS as u64) - 1; // 0xFF
 
 pub(crate) struct SessionWheel {
-    /// 256 buckets indexed by `(expiration_ns / TICK_NS) & 0xFF`.
-    /// Each bucket holds the SessionKeys whose computed expiration
-    /// rounded down lands in that bucket.
+    /// 256 buckets indexed by `expiration_tick & WHEEL_MASK`.
+    /// Each bucket holds keys whose computed `expiration_tick`
+    /// (= `(last_seen_ns + expires_after_ns) / WHEEL_TICK_NS`)
+    /// modulo 256 equals the bucket index.
     buckets: Box<[VecDeque<SessionKey>; WHEEL_BUCKETS]>,
-    /// Anchor: the `expiration_tick` value of bucket index 0 in the
-    /// most recently rolled-over wheel cycle. Used to translate
-    /// absolute time → bucket index.
+    /// Tick that bucket index 0 represents on the *current*
+    /// wheel revolution. Advanced lazily as `cursor_tick`
+    /// crosses bucket boundaries.
     base_tick: u64,
-    /// Last tick processed by `pop_due()`. Bounded by current tick.
+    /// Most-recent processed tick. Strictly < the live `now_tick`
+    /// once initialized. Initialized lazily on the first
+    /// insert/touch/expire that observes a `now_ns`.
     cursor_tick: u64,
+    /// `false` until the first observation of `now_ns`. Until then
+    /// every wheel mutation resets cursor/base from `now_ns`. This
+    /// avoids the catastrophe of `cursor_tick = 0` being many
+    /// years behind `now_tick = uptime_secs` on the first GC call.
+    initialized: bool,
 }
 ```
 
-Coverage: with `WHEEL_TICK_NS = 1s` and 256 buckets, the wheel
-covers a 256-second timeout window. The longest session timeout
-today is `TCP_ESTABLISHED_TIMEOUT_NS` ≈ 7200 s — that exceeds the
-wheel. We handle long-timeout entries via a fallback:
+### Cursor / base initialization (Codex finding #1)
 
-- If `expires_after_ns > WHEEL_TIMEOUT_CAP_NS`, push the key into
-  the bucket at `(base_tick + WHEEL_BUCKETS - 1) & WHEEL_MASK`
-  (the "far future" bucket). When that bucket is popped, re-check
-  the entry's actual `last_seen_ns + expires_after_ns`; if it's
-  still in the future, re-bucket it.
+`SessionTable::new()` does not have a `now_ns`. The wheel must be
+created in an "uninitialized" state and lazily initialize on the
+first observation of `now_ns` from any of the touch/insert/expire
+paths:
 
-This gives correctness for long sessions at the cost of one extra
-re-bucket every 256 s for each long-lived TCP session (a few
-microseconds per session — negligible at any realistic count).
+```rust
+fn wheel_observe(&mut self, now_ns: u64) {
+    if !self.wheel.initialized {
+        let now_tick = now_ns / WHEEL_TICK_NS;
+        self.wheel.base_tick = now_tick;
+        self.wheel.cursor_tick = now_tick;
+        self.wheel.initialized = true;
+    }
+}
+```
 
-### Lazy delete on touch
+Every public method that takes `now_ns` calls `wheel_observe(now_ns)`
+before any wheel push or pop. Test:
+`first_gc_with_large_monotonic_now_doesnt_walk_billions_of_buckets`.
+
+### Bucket-index calculation (Codex finding #4 — exact-256s trap)
+
+```rust
+const FAR_FUTURE_OFFSET: u64 = WHEEL_BUCKETS as u64 - 1;
+
+fn bucket_for_expiration(&self, expiration_ns: u64, now_ns: u64) -> usize {
+    let now_tick = now_ns / WHEEL_TICK_NS;
+    let expiration_tick = expiration_ns / WHEEL_TICK_NS;
+    let delta = expiration_tick.saturating_sub(now_tick);
+    // Cap at WHEEL_BUCKETS - 1 to make the "far future" bucket
+    // unambiguously distinct from the current bucket. An entry
+    // with delta >= WHEEL_BUCKETS lands in the far-future bucket
+    // and gets re-bucketed on pop. An entry with delta < WHEEL_BUCKETS
+    // lands at its precise position.
+    let offset = delta.min(FAR_FUTURE_OFFSET);
+    ((self.wheel.cursor_tick + offset) & WHEEL_MASK) as usize
+}
+```
+
+Use `>= WHEEL_BUCKETS` (i.e., `delta` clamped to FAR_FUTURE_OFFSET)
+not `> WHEEL_TIMEOUT_CAP_NS`. The clamping makes "exactly 256s"
+land at FAR_FUTURE_OFFSET ahead — distinct from the current bucket
+and correctly delayed. Test: `wheel_handles_exact_256s_timeout`.
+
+### Coverage of long-lived TCP
+
+`TCP_ESTABLISHED_TIMEOUT_NS` ≈ 7200 s exceeds the 256-s window.
+Such an entry lands in the far-future bucket. When that bucket is
+popped (256 s after insertion), `wheel_pop_one_bucket` re-checks
+the entry's actual `last_seen + expires_after` against `now_ns`,
+finds it still in the future, and re-buckets via the same logic.
+Cost: one HashMap lookup + one push per long session per 256 s.
+
+### Lazy delete on touch (Codex finding #7 — duplicate bound)
 
 When `touch` / `lookup_with_origin` / `update_session` updates
-`last_seen_ns`, the old bucket entry becomes stale. Two options:
+`last_seen_ns`, the old bucket entry becomes stale. We use **lazy
+delete**: leave the stale entry, push a new one, re-check on pop.
 
-A. **Eager remove + re-insert**: O(N_bucket) scan to find the old
-   key in its bucket, remove it, then push to the new bucket.
-   Per-touch cost: O(N_bucket) which can be thousands.
+The bound on duplicates per session matters because
+`lookup_with_origin` is called per session-cache-touch on the hot
+path. Without throttling, a session that's touched 1000 times
+during its lifetime would have 1000 stale wheel entries — that's
+240 KB of `SessionKey` (240 B each) per long session. At 1M
+sessions × 1000 touches that's 240 GB of stale wheel garbage.
 
-B. **Lazy delete**: leave the stale entry in the old bucket. On
-   pop, re-check the entry's current `last_seen_ns + expires_after_ns`
-   against `now_ns`. If still in the future, the entry was touched
-   after we bucketed it; skip (don't remove from sessions, don't
-   emit expired). If `Some(entry)` not found in `sessions`, also
-   skip (already removed).
+**Per-tick throttle**: only re-push to the wheel if the new
+expiration tick differs from the previously-recorded one. Embed a
+`wheel_tick: u64` field on SessionEntry (16 B added). On
+touch/lookup_with_origin/update_session/refresh_*:
 
-Option B is dramatically simpler and faster on the hot path. Cost:
-the wheel can carry duplicate entries for a touched session (one
-in the old stale bucket, one in the new). Each pop visit to a
-stale entry is one HashMap lookup ≈ 100 ns and a comparison. For a
-session that's touched 10x over its lifetime, that's 10 stale
-bucket entries × 100 ns = 1 µs total over the session lifetime.
+```rust
+let new_expiration_tick = (entry.last_seen_ns + entry.expires_after_ns)
+    / WHEEL_TICK_NS;
+if new_expiration_tick != entry.wheel_tick {
+    entry.wheel_tick = new_expiration_tick;
+    self.wheel.push(key.clone(), new_expiration_tick);
+}
+// Same-tick touches: no wheel push.
+```
 
-We choose **B (lazy delete)**. The wheel is a *hint* about which
-keys *might* have expired, not authoritative state.
+This bounds duplicates per session to:
+`(session_lifetime_secs / WHEEL_TICK_NS_secs) ≈ session_lifetime_secs`.
 
-### Per-tick GC work
+For a 30-second session: max 30 wheel duplicates. For a 7200-s TCP
+session: max 7200 entries (one per second the session is touched).
+At 1M long sessions × 7200 entries = 7.2B entries × 240 B/entry =
+1.7 TB worst case. That's still bad.
+
+**Tighter bound**: bucket the wheel at *touch granularity*, not
+expiration granularity. The wheel only cares about
+"approximately when this key SHOULD be checked again". Push at
+`expiration_tick` only when the key's next expiration is more
+than 1 tick away from its previously-recorded one. The 1-tick
+granularity is fine because GC pops one bucket = 1 tick of wall
+time anyway.
+
+This is the same algorithm as above, but the bound is now:
+`(session_lifetime_secs / 1 sec) = session_lifetime_secs`.
+
+For typical session lifetimes (≤300 s) and ≤1M sessions, that's
+1M × 300 = 300M entries × 240 B = 72 GB. Still bad for pathological
+workloads but realistic deployments stay well under.
+
+**Decision**: ship with the per-tick throttle. Document the
+"pathological worst case" honestly. The ultimate fix is the #964
+slab: SlotHandle is 8 B not 240 B (30× smaller), so 300M handles
+= 2.4 GB — same workload, manageable. #964 is the right place to
+solve the duplicate-storage problem; #965 ships with a usable
+bound and an explicit "pathological-only" caveat.
+
+### Per-tick GC work — the algorithm in full
+
+Per Codex findings #2/#3/#5/#8: cap-vs-uncapped, deferred-tail
+semantics, alias-key correctness, and the off-by-1-ns expiry
+boundary all need explicit pseudocode.
+
+Decision per Codex finding #2: **no per-tick cap**. The cap was a
+flawed knob — at 5K/tick when due-rate is ≥5K/s the backlog grows
+unbounded. Two options remained:
+
+(a) Multi-level wheel — extra complexity and a follow-up.
+(b) Just pay the bucket cost — ≤7 ms per tick at 1M sessions / 30s
+    timeouts in the worst case, but small (sub-ms) for realistic
+    loads. This still beats today's O(N) which is 100+ ms at the
+    same scale.
+
+We choose (b). The plan is honest: this is *bounded per-bucket*
+work, not *fixed per-tick* work. The "Stop the World" #965 issue
+goes away because per-tick work is now O(N/T) instead of O(N) —
+~30× lower at typical timeout/session-count ratios.
 
 ```rust
 pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
-    let now_tick = now_ns / WHEEL_TICK_NS;
     if self.last_gc_ns != 0 && now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
         return Vec::new();
     }
     self.last_gc_ns = now_ns;
+    self.wheel_observe(now_ns);  // lazy init if first call
+
+    let now_tick = now_ns / WHEEL_TICK_NS;
     let mut expired = Vec::new();
+    // Process every bucket from cursor_tick up to (but not including)
+    // now_tick. cursor_tick starts at the lazy-init now_tick, so the
+    // first call after init is a no-op (loop body runs zero times).
     while self.wheel.cursor_tick < now_tick {
         let bucket_idx = (self.wheel.cursor_tick & WHEEL_MASK) as usize;
+        // Take ownership of the bucket for the duration of this drain.
+        // Reusing `due` after the loop returns the buffer to the wheel,
+        // amortizing allocation.
         let mut due = std::mem::take(&mut self.wheel.buckets[bucket_idx]);
         for key in due.drain(..) {
-            // Lazy-delete: re-check current expiration against now_ns.
+            // Lookup + boundary check matches today's exact semantics
+            // (Codex finding #8): `now - last_seen > expires_after`
+            // (strict `>`), not `>=`.
             let Some(entry) = self.sessions.get(&key) else { continue };
-            let entry_expires_at = entry.last_seen_ns.saturating_add(entry.expires_after_ns);
-            if entry_expires_at > now_ns {
-                // Touched since this bucket was set — already
-                // re-bucketed at touch time. Drop this stale ref.
+            if now_ns.saturating_sub(entry.last_seen_ns) <= entry.expires_after_ns {
+                // Touched after bucketing — already re-bucketed in the
+                // new tick. Stale hint; drop.
                 continue;
             }
-            // Genuinely expired. Remove and emit.
             if let Some(removed) = self.remove_entry(&key) {
                 // ... existing remove_entry path produces SessionDelta
-                // and ExpiredSession ...
+                // and ExpiredSession; same logic as today's GC ...
                 expired.push(...);
             }
         }
-        self.wheel.cursor_tick += 1;
+        // Return the (now-empty) VecDeque buffer back to the wheel for reuse.
+        self.wheel.buckets[bucket_idx] = due;
+        self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
     }
+    self.wheel.base_tick = now_tick;  // for far-future bucket arithmetic
     expired
 }
 ```
 
-Per-tick work: O(B) where B is the average bucket size = N / T.
-For N=1M sessions across the 256-bucket wheel and average timeout
-30s, B = 1M / 30 ≈ 33,000 entries per bucket. Each entry is one
-HashMap lookup + one comparison ≈ 200 ns. Per-tick cost: ~6.6 ms.
+### Alias correctness in lookup_with_origin (Codex finding #5)
 
-To bound the spike further (target: ≤1 ms per tick), we cap
-per-tick work to `MAX_GC_ENTRIES_PER_TICK = 5000`. If a bucket has
-more, defer the rest — push them back at the wheel's tail and they
-get processed next tick.
+`lookup_with_origin` resolves NAT aliases via
+`reverse_translated_index`. The wheel push must use `actual_key`
+(the canonical key the entry is stored under), NOT the caller's
+alias key. Otherwise the wheel push goes to the wrong shard and
+the canonical entry never gets its expiration refreshed.
 
-That's still O(1) amortized: the wheel's total work over a full
-revolution is O(N), distributed across 256 ticks. With the cap,
-worst-case spike is 5000 × 200 ns = 1 ms.
+```rust
+let actual_key = if self.sessions.contains_key(key) {
+    key.clone()
+} else if let Some(alias) = self.reverse_translated_index.get(key) {
+    alias.clone()
+} else {
+    return None;
+};
+self.sessions.get_mut(&actual_key).map(|entry| {
+    // ... last_seen_ns / expires_after_ns updates ...
+    let new_expiration_tick = (entry.last_seen_ns + entry.expires_after_ns)
+        / WHEEL_TICK_NS;
+    if new_expiration_tick != entry.wheel_tick {
+        entry.wheel_tick = new_expiration_tick;
+        // PUSH actual_key, not the alias `key`.
+        let bucket = self.wheel.bucket_for_tick(new_expiration_tick);
+        self.wheel.buckets[bucket].push_back(actual_key.clone());
+    }
+    // ... return SessionLookup ...
+})
+```
+
+Test: `wheel_alias_lookup_refreshes_canonical_key`.
+
+### Hot-path allocation honesty (Codex finding #6)
+
+`Box<[VecDeque<SessionKey>; 256]>` preallocates the 256 VecDeque
+*headers* (24 B each = 6 KB total). Each VecDeque allocates its
+backing buffer on first `push_back`. To avoid per-tick allocation
+on the hot path, we pre-reserve `max_sessions / WHEEL_BUCKETS`
+slots per bucket at construction:
+
+```rust
+fn new_wheel(max_sessions: usize) -> SessionWheel {
+    let initial_cap = (max_sessions / WHEEL_BUCKETS).max(64);
+    let mut buckets: Vec<VecDeque<SessionKey>> = Vec::with_capacity(WHEEL_BUCKETS);
+    for _ in 0..WHEEL_BUCKETS {
+        buckets.push(VecDeque::with_capacity(initial_cap));
+    }
+    let buckets: Box<[VecDeque<SessionKey>; WHEEL_BUCKETS]> =
+        buckets.into_boxed_slice().try_into().expect("right size");
+    SessionWheel { buckets, base_tick: 0, cursor_tick: 0, initialized: false }
+}
+```
+
+For default `max_sessions = 1M`, that's 256 × 4096 SessionKeys =
+~250 MB of preallocated buffers. Drop to `max_sessions = 256K` for
+typical deployments and it's 64 MB. The `initial_cap` calc errs on
+the side of "no growth needed at steady state" — explicit
+`with_capacity` calls so the claim "no allocations on the hot path"
+is true at steady state, with a documented warm-up cost.
+
+Fallback: when bucket spikes past initial_cap (rare but possible
+if a config change creates many sessions with the same expiration
+bucket), `push_back` reallocates. This is rare enough that the
+"no allocations on hot path" claim is honest for the common case.
 
 ### Files touched
 
@@ -182,11 +346,33 @@ worst-case spike is 5000 × 200 ns = 1 ms.
 - `wheel_handles_long_timeout_via_far_future_bucket`: insert with
   timeout > 256s; verify entry doesn't expire prematurely; advance
   past 256s; verify entry re-buckets and expires correctly later.
-- `wheel_per_tick_work_capped`: insert 50,000 sessions all with
-  same expiration tick; verify expire_stale_entries returns at
-  most MAX_GC_ENTRIES_PER_TICK; subsequent tick returns the rest.
+- `wheel_handles_exact_256s_timeout` (Codex finding #4): insert
+  with `expires_after_ns == WHEEL_BUCKETS * WHEEL_TICK_NS`. Verify
+  the entry lands in the FAR_FUTURE bucket (not the current one)
+  and gets re-checked after the wheel rotation.
+- `wheel_alias_lookup_refreshes_canonical_key` (Codex finding #5):
+  install entry under canonical key K; lookup via NAT alias key A
+  (where reverse_translated_index[A] = K); verify the wheel push
+  goes to K's bucket, not A's.
+- `first_gc_with_large_monotonic_now_doesnt_walk_billions_of_buckets`
+  (Codex finding #1): construct fresh SessionTable; call
+  expire_stale_entries with `now_ns = 10^18` (wall-time-ish big);
+  verify it returns immediately (no infinite loop, no panic).
+- `expiry_boundary_strict_greater_than` (Codex finding #8): insert
+  entry with `expires_after_ns = 1_000_000_000`; advance to
+  exactly `last_seen + 1_000_000_000` (boundary); verify entry is
+  NOT expired (matches today's `>` semantics, not `>=`).
+- `wheel_duplicate_count_per_session_bounded` (Codex finding #7):
+  insert one session; touch it 100 times within the same tick;
+  count wheel entries for that key; assert ≤ 2 (the initial push
+  + at most one re-push if expiration tick changed).
+- `wheel_sustained_overload_drains_all_buckets`: insert 50K
+  sessions all with same expiration; advance time past expiration;
+  verify expire_stale_entries returns all 50K in a single call
+  (no per-tick cap; one tick = one bucket = O(B) work, not capped).
 - `wheel_handles_concurrent_insert_and_pop`: not relevant
-  (SessionTable is not Send + Sync — owned by a single worker).
+  (SessionTable is not Send + Sync — owned by a single worker;
+  Codex confirmed worker.rs:490 has `let mut sessions = ...`).
 
 Plus 4 existing GC tests (lines 2138, 2142, 2162, +1 more) must
 continue to pass.
@@ -194,7 +380,7 @@ continue to pass.
 ## Acceptance gates
 
 1. `cargo build --release` clean.
-2. `cargo test --release` ≥ baseline (851 post-#921) + 4 new = 855.
+2. `cargo test --release` ≥ baseline (851 post-#921) + 8 new = 859.
 3. Cluster smoke (HARD): no regression on the unloaded-session path.
    - iperf-c P=12 ≥ 22 Gb/s
    - iperf-c P=1 ≥ 6 Gb/s

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,19 +1,40 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v6 — 2026-04-29. Addresses Codex round-5
-(task-mok0rvip-n6iba1): per-tick complexity model conflated
-"sessions / 256" with "live wheel entries / 256". Under sustained
-per-second touch the wheel can hold up to N × 256 entries (mostly
-stale duplicates), giving ~N entries per popped bucket — not N/256.
-Plan now distinguishes realistic-mixed vs. sustained-per-second-touch
-cost regimes, fixes the contradictory "low single-digit GB" claim
-against the 12.3 GB ceiling at 1M × per-second-touch, removes the
-residual ~30× slab claim, and adds an explicit acceptance gate for
-the sustained-per-second-touch worst-plausible hot-path workload.
+Plan v7 — 2026-04-29. Addresses Codex round-6 (task-mok16mh6-7dzy54).
+Five fixes:
 
-Earlier iterations (round 3 fixed the bucket-helper / pop race and
-the alias `WheelEntry` payload; round 4 fixed memory math and the
-alias borrow shape) remain in effect.
+1. Sub-tick expiration lag (round-6 #1): documented the up-to-1-
+   wheel-tick lag introduced by `target_tick = floor(...)` + strict
+   `cursor < now_tick` pop. Production GC has the same lag (gated
+   to 1 s by `SESSION_GC_INTERVAL_NS`), so this is a non-regression
+   in deployed code. Added test `wheel_lags_today_subtick_by_at_most_one_tick`.
+
+2. Internal contradiction in the per-tick cost section (round-6 #2):
+   removed the "256 × ~0.4-ms drains, only ONE bucket holds the
+   per-second-touch crowd" wording — it conflicted with the K ≈ N
+   bound stated five lines above. Under sustained per-second touch
+   every bucket holds ~N entries after warm-up.
+
+3. Mostly-idle table miscalculated (round-6 #3): the column was
+   off by 10× because it failed to divide by 256. Fixed: 100K ×
+   T_active=5 → ~200 µs per tick, not 2 ms.
+
+4. Acceptance gate spec was duplicated with conflicting numbers
+   (round-6 #4): removed the duplicate inside §Per-tick GC work;
+   §Acceptance gates is now the single source of truth, with
+   workload sizes 50K (4a) and 10K (4b) and explicit K-bounds
+   plus wall-time targets.
+
+5. Unit test was wall-time-only (round-6 #5): rewrote
+   `wheel_per_second_touch_bounds_K_per_bucket` to assert K ≤ 12K
+   directly (catches a 2× duplicate-push regression that a 5×
+   wall-time bound would not), with wall-time as a separate
+   informational gate.
+
+Earlier rounds remain in effect: round-3 fixed bucket-helper /
+pop race and alias `WheelEntry` payload; round-4 fixed memory math
+and the alias borrow shape; round-5 fixed the per-tick cost model
+to use K = entries-per-bucket instead of N / 256.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -162,6 +183,49 @@ bucket index is just `(cursor_tick & WHEEL_MASK)`. The
 "exactly 256s" case lands at `now_tick + 255`, which the wheel
 will revisit only after a full rotation — distinct from the
 current bucket. Test: `wheel_handles_exact_256s_timeout`.
+
+#### Sub-tick expiration semantics (Codex round-6 #1)
+
+The pop loop is `while cursor_tick < now_tick { pop bucket; cursor++ }`,
+and `target_tick = floor((last_seen + expires_after) / WHEEL_TICK_NS)`.
+A session expiring at `last_seen + expires_after + 1ns` has
+`target_tick = (last_seen + expires_after) / TICK_NS` and
+`now_tick = (last_seen + expires_after + 1) / TICK_NS` —
+when the +1 ns does not cross a tick boundary, both are equal,
+so the bucket containing this entry is NOT popped on this call;
+it will be popped on the next tick (cursor_tick advances when
+now_tick advances by ≥ 1).
+
+So the wheel introduces **up to one wheel-tick (1 s) of lag**
+between the exact instant `last_seen + expires_after + 1 ns` and
+the wheel's detection of the expiration.
+
+Why this is a non-regression in production: the existing
+`expire_stale_entries` is gated by
+
+```rust
+if now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
+    return Vec::new();
+}
+```
+
+with `SESSION_GC_INTERVAL_NS = 1 s`, so today's scan also has
+a ~1 s expiration lag in production. The behavioral change is
+visible only in unit tests that bypass the gate by manipulating
+`last_gc_ns` directly, and only at sub-tick precision (the
+`+1 ns` case Codex flagged). No production caller can observe
+the difference.
+
+The existing `expiry_boundary_strict_greater_than` test asserts
+the exact-boundary case (`now == last_seen + expires_after`,
+which is NOT expired under either today's `>` semantics or the
+wheel). It continues to pass. A sibling test
+`wheel_lags_today_subtick_by_at_most_one_tick` asserts the
+documented bound: at `now == last_seen + expires_after + 1 ns`
+the wheel reports not-yet-expired, but at `now == last_seen +
+expires_after + WHEEL_TICK_NS + 1` (one tick past the expiration
+ceiling) the wheel does report expired. This guards the
+documented semantics from drifting silently.
 
 ### Coverage of long-lived sessions
 
@@ -318,78 +382,84 @@ Concretely:
                         (distinct `scheduled_tick`s pushed in last 256 s)
                       ≤ N_sessions × min(touches_per_256s, 256)
 
-For a population with **uniform per-second touch on every session**:
+For a population with **uniform per-second touch on every session**
+(each session touches at a different sub-tick offset within each
+1-second tick, so scheduled ticks spread roughly uniformly across
+the wheel after warm-up):
 
-  total_wheel_entries ≈ N_sessions × 256
-  K (per bucket)      ≈ N_sessions
+  total_wheel_entries ≈ N_sessions × 256        (1 push/sess/tick × 256 ticks)
+  K (per popped bucket) ≈ N_sessions            (entries spread evenly)
   per-tick cost       ≈ N_sessions × 100 ns
 
-| N (sessions) | per-second touch | mostly idle (avg ≤5 active ticks/sess) |
+For **mostly-idle** workloads where each session is touched in
+≈ T_active distinct ticks across the 256-tick window (T_active ≪ 256):
+
+  total_wheel_entries ≈ N_sessions × T_active
+  K (per popped bucket) ≈ N_sessions × T_active / 256
+  per-tick cost       ≈ (N_sessions × T_active / 256) × 100 ns
+
+Per-tick cost table (assuming 100 ns per stale/canonical entry):
+
+| N (sessions) | per-second touch (T_active=256, K=N) | mostly idle (T_active=5, K = N × 5/256) |
 |---|---|---|
-| 10K | 1 ms | 200 µs |
-| 100K | **10 ms** | 2 ms |
-| 1M | **100 ms** | 20 ms |
+| 10K | 1 ms (10K × 100 ns) | ~20 µs (~195 entries) |
+| 100K | **10 ms** (100K × 100 ns) | ~200 µs (~1.95K entries) |
+| 1M | **100 ms** (1M × 100 ns) | ~2 ms (~19.5K entries) |
 
 #### What this means for "Stop the World goes away"
 
-Today's StW does ~100 ms once per `SESSION_GC_INTERVAL_NS = 1 s`
-at 1M sessions. The wheel does **the same total work over the
-1 s window**, but spread across 256 ticks at the same per-second
-*shape* — so each tick still has to drain its bucket at full
-size. **The wheel does not dramatically reduce the worst-case
-tick wall-time under sustained per-second touch on every
-session**: at 1M sessions × per-second touch, both today's StW
-and the wheel produce ~100 ms of GC work per second, just paid in
-different shapes (one 100-ms blast vs. ~256 × ~0.4-ms drains —
-but each of those 256 drains visits a *different* bucket, and
-only ONE of them holds the per-second-touch crowd).
+Today's StW scans `self.sessions` (N entries) once per
+`SESSION_GC_INTERVAL_NS = 1 s`, producing one ~100 ms blocking
+call per second at 1M sessions. The wheel pops **one bucket per
+tick** (one per second, at the same cadence), so under the
+worst-plausible hot-path workload — sustained per-second touch
+on every session — each tick still pays K ≈ N work because
+every bucket is full of N entries (one per session, mostly
+stale duplicates) after warm-up.
+
+So the wheel does **NOT** reduce per-tick wall time under that
+workload; it preserves it (~100 ms per tick at 1M, ~10 ms per
+tick at 100K). What it changes is the *shape*: today's StW is a
+single blocking call inside `expire_stale_entries`; the wheel's
+work is paid as a steady drain on the same call, with no
+allocation of a Vec<SessionKey> for the candidate set. (The
+allocation savings are real but secondary.)
 
 The win, restated honestly:
 
 1. **Realistic mixed-traffic deployments** (most sessions idle,
-   some bursty): per-tick cost drops from O(N) to
-   O(N × distinct_active_ticks / 256), which at 100K sessions is
-   sub-ms — a **>50× improvement** in the typical case.
+   T_active ≈ 5): per-tick cost drops from O(N) to O(N × 5 / 256),
+   which at 100K sessions is ~200 µs vs. today's ~10 ms — a
+   **~50× improvement** in the typical case.
 
-2. **All-active per-second-touch on every session at 100K**:
-   per-tick cost is ~10 ms, vs. today's ~10 ms StW (same scale).
-   The win here is *not* a wall-time reduction; it's that the
-   work is bounded per-tick rather than appearing as a single
-   blocking call. Mouse-latency p99 stops correlating with the
-   GC interval.
+2. **All-active per-second-touch at 100K**: per-tick cost is
+   ~10 ms, same as today's ~10 ms StW. The wall-time at this
+   load is the same; the win is that work doesn't pile up into
+   an even larger periodic spike when GC is delayed.
 
-3. **All-active per-second-touch on every session at 1M**:
-   per-tick cost is ~100 ms. **This is the same wall time as
-   today's StW.** The wheel does not solve this case; it tracks
-   under "active deletion" and "multi-level wheel" follow-ups.
-   At this scale we recommend operators tune
-   `SESSION_GC_INTERVAL_NS` higher or land #964 first.
+3. **All-active per-second-touch at 1M**: per-tick cost is
+   ~100 ms — **the same wall time as today's StW.** The wheel
+   does not solve this case; it tracks under "active deletion"
+   and "multi-level wheel" follow-ups (see Out of scope). At
+   this scale we recommend operators tune `SESSION_GC_INTERVAL_NS`
+   higher or land #964 first.
 
 4. **Same-bucket install bursts** (synthetic: all N sessions
    installed in one tick, then idle): bucket sees O(N) work *once*
-   per 256 s, then idles. No worse than today's StW for that one
-   tick; better for the other 255 ticks.
+   per 256 s, then idles for 255 ticks. The other 255 ticks have
+   no GC work at all — strictly better than today's "100ms blast
+   every 1s".
 
-#### Acceptance gate (corrected per Codex round-5 #2)
+The single-line summary: **for realistic deployments the wheel
+delivers a ~50× per-tick latency win; for synthetic worst-case
+sustained-per-second-touch the wheel matches today's wall time
+but with bounded per-tick shape; for any workload this PR removes
+the per-second `Vec<SessionKey>` allocation that today's
+expire_stale_entries does inside its hot path.**
 
-The mouse-latency gate (Acceptance gates §4) needs two distinct
-synthetic workloads:
-
-A. **Realistic mostly-idle**: 50K sessions, ~10% touched per
-   second (5K touches/s), the rest idle. Assert p99 GC-tick wall
-   time ≤ 1 ms. This is the realistic-deployment claim.
-
-B. **Sustained per-second touch (worst-plausible hot path)**:
-   100K sessions, EVERY session touched once per second for ≥
-   300 s before assertion. Assert p99 GC-tick wall time ≤ 15 ms
-   (matches the ~10 ms model + headroom). This proves the wheel
-   bounds per-tick work and prevents StW spikes even under the
-   worst sustained refresh pattern; it does NOT claim a
-   wall-time win at this load.
-
-Adversarial same-bucket install bursts are out of scope for #965
-and tracked under the active-deletion / multi-level-wheel follow-
-ups.
+The acceptance-gate workloads, latency targets, and unit-test
+specifications live in §Acceptance gates below — that section is
+the single source of truth for what we will measure.
 
 ```rust
 pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
@@ -620,6 +690,16 @@ buffers grow to fit avg load × geometric headroom. For typical
   entry with `expires_after_ns = 1_000_000_000`; advance to
   exactly `last_seen + 1_000_000_000` (boundary); verify entry is
   NOT expired (matches today's `>` semantics, not `>=`).
+- `wheel_lags_today_subtick_by_at_most_one_tick` (Codex round-6
+  #1): bypass the gc-interval gate by setting `last_gc_ns`
+  directly. Insert entry with `expires_after_ns = 1_000_000_000`.
+  Call `expire_stale_entries(last_seen + 1_000_000_000 + 1)`
+  (one ns past expiration). Assert wheel returns it as NOT
+  expired (acceptable 1-tick lag vs today's hypothetical sub-
+  tick `>` scan). Then call `expire_stale_entries(last_seen +
+  1_000_000_000 + WHEEL_TICK_NS + 1)` (one tick past
+  expiration). Assert wheel returns it as EXPIRED. This guards
+  the documented bound from drifting.
 - `wheel_duplicate_count_per_session_bounded` (Codex finding #7):
   insert one session; touch it 100 times within the same tick;
   count wheel entries for that key; assert ≤ 2 (the initial push
@@ -628,14 +708,24 @@ buffers grow to fit avg load × geometric headroom. For typical
   sessions all with same expiration; advance time past expiration;
   verify expire_stale_entries returns all 50K in a single call
   (no per-tick cap; one tick = one bucket = O(B) work, not capped).
-- `wheel_per_second_touch_bound_per_tick_work` (Codex round-5 #2):
-  install N=10K sessions, then touch every session once per
-  second for 300 s of simulated time before measuring. After
-  warm-up, advance one tick and measure `wheel_pop_one_bucket`
-  wall time. Assert ≤ 5 ms (allows 2.5× headroom over the 100 ns
-  × 10K = 1 ms model). This catches regressions where a refactor
-  inadvertently makes `lookup_with_origin` or `update_session`
-  add multiple wheel pushes per touch.
+- `wheel_per_second_touch_bounds_K_per_bucket` (Codex round-5 #2,
+  hardened per round-6 #5): install N=10K sessions, then touch
+  every session once per second for 300 s of simulated time
+  before measuring. After warm-up, instrument the next pop to
+  count entries scanned (`K`) and entries dropped/expired/re-
+  bucketed. Assert:
+    * `K ≤ 12,000` (model says 10,000; 20 % headroom catches a
+      2× duplicate-push regression — a 5× wall-time bound would
+      not).
+    * `entries_re_bucketed = N` (the live canonical entry per
+      session lands in its new tick).
+    * `entries_dropped_stale ≈ N × (256 − 1)` summed across one
+      full wheel rotation (256 ticks). Assert
+      `total_dropped ∈ [0.9, 1.1] × N × 255` to catch leakage of
+      stale entries that the lazy-delete discriminator should
+      drop.
+  The point of the test is to bound *work shape*, not wall time;
+  wall-time perf is the §Acceptance gate 4b informational gate.
 - `wheel_alias_lookup_does_not_double_borrow_self`: compile-time
   test that the alias path's `lookup_with_origin` body type-checks
   (i.e. the &mut self.sessions borrow is scoped before
@@ -652,27 +742,47 @@ continue to pass.
 ## Acceptance gates
 
 1. `cargo build --release` clean.
-2. `cargo test --release` ≥ baseline (851 post-#921) + 10 new = 861.
+2. `cargo test --release` ≥ baseline (851 post-#921) + 11 new = 862.
 3. Cluster smoke (HARD): no regression on the unloaded-session path.
    - iperf-c P=12 ≥ 22 Gb/s
    - iperf-c P=1 ≥ 6 Gb/s
 4. **Mouse-latency gate** — TWO synthetic workloads (per Codex
-   round-5 #2):
+   round-5 #2 + round-6 #4 / #5). The numbers below are the
+   single source of truth; any other section that mentions "the
+   acceptance gate" defers to this list.
 
-   4a. **Realistic mostly-idle**: 50K sessions, ~10% touched per
-       second (5K touches/s), the rest idle for ≥ 300 s before
-       measurement. Assert p99 GC-tick wall time ≤ 1 ms. This is
-       the typical-deployment win.
+   4a. **Realistic mostly-idle workload**:
+       - N = 50K sessions installed.
+       - 10% (5K) of sessions touched once per second; the rest
+         idle for the duration of the measurement.
+       - Run for ≥ 300 s of simulated time before measuring (so
+         the wheel reaches steady state and any warm-up
+         allocations have settled).
+       - Assert: p99 GC-tick wall time ≤ 1 ms over a 60-s
+         measurement window.
+       - Assert: per-pop K (entries scanned per popped bucket)
+         ≤ 1500 (the model gives 50K × 5 / 256 = 977; 1500 is
+         ~50% headroom and catches a regression where touch
+         pushes more than one entry per tick-change).
 
-   4b. **Sustained per-second touch**: 10K sessions, EVERY session
-       touched once per second for ≥ 300 s. Assert p99 GC-tick
-       wall time ≤ 5 ms (matches the 100 ns × 10K = 1 ms model
-       with 5× headroom). This proves the wheel keeps per-tick
-       work bounded under the hot-path refresh shape; it does NOT
-       claim a wall-time win at this load — see "Per-tick cost
-       model" in §Per-tick GC work.
+   4b. **Sustained per-second touch** (worst-plausible hot path):
+       - N = 10K sessions installed.
+       - EVERY session touched once per second.
+       - Run for ≥ 300 s before measuring.
+       - Assert: per-pop K ≤ 12,000 (model gives 10K; 20%
+         headroom catches a 2× duplicate-push regression). This
+         is the **primary** correctness assertion — wall time is
+         a derivative of K and is hardware-dependent.
+       - Wall-time perf gate (informational, not blocking):
+         p99 GC-tick wall time ≤ 5 ms on the cluster test host
+         (model gives 10K × 100 ns = 1 ms; 5× margin allows for
+         alloc churn and HashMap probe variance). Failure here
+         flags a perf regression but does not block CI by itself
+         since wall time depends on the runner.
 
-   Both gates must hold. Adversarial same-bucket install bursts
+   Both correctness gates (4a and 4b K-bounds) must hold. The
+   wall-time gate at 4a must hold; the wall-time perf gate at
+   4b is informational. Adversarial same-bucket install bursts
    are out of scope for #965 and tracked under the active-
    deletion / multi-level-wheel follow-ups (see Out of scope).
 5. Codex hostile review: AGREE-TO-MERGE.

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,6 +1,31 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v9 — 2026-04-29. Addresses Codex round-8 wording fixes
+Plan v10 — 2026-04-29. Addresses Codex round-9 wording fixes
+(task-mok2wa0n-cvx3es):
+
+i. CoS smoke gate enumerated per-class against the actual
+   `test/incus/cos-iperf-config.set` fixture. Each iperf-{a,b,c,
+   d,e,f} class plus best-effort gets its own P=12 throughput
+   gate scaled to ≈ 90 % of its shape (iperf-c at 88 %, the
+   historical 25 g → 22 Gb/s smoke). All P=12 rows are blocking
+   gates; iperf-c also keeps the P=1 ≥ 6 Gb/s historical gate.
+   Other classes get a P=1 counter-only smoke (assert egress
+   queue counter increments by the iperf3 byte count) that
+   validates the classifier path lit up without imposing a
+   single-stream throughput gate.
+
+ii. v8 changelog header rewritten to reference the corrected
+   sub-tick lag bounds (today ≤ 1 s; wheel ≤ 2 s; additional
+   deviation < 1 wheel-tick) instead of the wrong "preserves
+   the existing 1-s lag bound" prose.
+
+iii. "Not popped during this call" wording tightened to "not
+   popped during this BUCKET drain" both in the inline drain
+   comment and the v8 changelog summary, with explicit note
+   that re-pushes into LATER buckets the outer multi-tick
+   catch-up loop visits ARE popped within the same call.
+
+v9 — Addresses Codex round-8 wording fixes
 (task-mok24765-mmf95n; no blocking findings, all substantive
 claims verified correct):
 
@@ -835,21 +860,23 @@ continue to pass.
    | best-effort | 5207  | 100 m exact | ≥ 90 Mb/s     | counter-only |
 
    - "P=12 gate" runs `iperf3 -P 12 -p <port>` and asserts the
-     achieved Gb/s is ≥ the listed minimum. iperf-c is the
-     historical 22 Gb/s smoke; the others get a shaped-rate
-     gate scaled to their queue.
-   - "counter-only" rows still run an iperf3 P=1 against the
-     class but only assert that the egress class counter
-     (`show class-of-service interface reth0 unit 80`) lights
-     up by at least the iperf3 byte count. This validates the
+     achieved Gb/s is ≥ the listed minimum. **Every P=12 row is
+     a blocking gate.** iperf-c is the historical 22 Gb/s smoke
+     (≈ 88 % of its 25 g shape); the others use ≈ 90 % of their
+     respective shapes (matches typical TCP/L2 overhead).
+   - "P=1 counter-only" rows run `iperf3 -P 1 -p <port>` against
+     the class and assert that the egress class counter
+     (`show class-of-service interface reth0 unit 80`) increments
+     by at least the iperf3 byte count. This validates the
      classifier / queue path lit up without imposing a hard
-     throughput gate on classes whose shape would make a fixed
-     gate brittle.
-   - **Hard gate on iperf-c only.** The other rows are smoke for
-     "the queue path actually executed". A class whose iperf3
-     run lights up best-effort (queue 0) instead of the targeted
-     class is a config-misapplied smoke that does NOT validate
-     the refactor; treat it as a failure of step 3.
+     throughput gate at single-stream P=1 (where small-packet
+     overhead can drag below the shape under noise). iperf-c is
+     the only class with a P=1 throughput gate (≥ 6 Gb/s) and
+     stays as the historical hard gate.
+   - A class whose iperf3 run lights up best-effort (queue 0)
+     instead of the targeted class is a config-misapplied smoke
+     that does NOT validate the refactor; treat it as a failure
+     of step 3 regardless of the iperf3 number.
 4. **Mouse-latency gate** — TWO synthetic workloads (per Codex
    round-5 #2 + round-6 #4 / #5). The numbers below are the
    single source of truth; any other section that mentions "the

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,18 +1,30 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v10 — 2026-04-29. Addresses Codex round-9 wording fixes
+Plan v11 — 2026-04-29. Addresses Codex round-10 wording fixes
+(task-mok33z3b-yg8x1d):
+
+α. CoS gate ambiguity resolved. The per-class table listed P=12
+   minimum throughput for every row, but the trailing prose said
+   "Hard gate on iperf-c only", which left CI behavior unclear.
+   Now: every P=12 row is a blocking gate (shaped-rate thresholds
+   at ≈ 90 % of each class's shape). P=1 stays as counter-only
+   smoke for non-iperf-c classes (single-stream variance makes a
+   hard P=1 throughput gate brittle for low-shape classes);
+   iperf-c keeps its historical P=1 ≥ 6 Gb/s hard gate.
+
+β. Stale top-of-doc version banner caught up with the round-9
+   work. The previous commit said "Plan v9 / round-8 fixes" while
+   the file already had v9-and-v10 changes; bumped to v11 with a
+   proper changelog stack.
+
+v10 — Addresses Codex round-9 wording fixes
 (task-mok2wa0n-cvx3es):
 
 i. CoS smoke gate enumerated per-class against the actual
    `test/incus/cos-iperf-config.set` fixture. Each iperf-{a,b,c,
    d,e,f} class plus best-effort gets its own P=12 throughput
    gate scaled to ≈ 90 % of its shape (iperf-c at 88 %, the
-   historical 25 g → 22 Gb/s smoke). All P=12 rows are blocking
-   gates; iperf-c also keeps the P=1 ≥ 6 Gb/s historical gate.
-   Other classes get a P=1 counter-only smoke (assert egress
-   queue counter increments by the iperf3 byte count) that
-   validates the classifier path lit up without imposing a
-   single-stream throughput gate.
+   historical 25 g → 22 Gb/s smoke).
 
 ii. v8 changelog header rewritten to reference the corrected
    sub-tick lag bounds (today ≤ 1 s; wheel ≤ 2 s; additional

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,40 +1,43 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v7 — 2026-04-29. Addresses Codex round-6 (task-mok16mh6-7dzy54).
-Five fixes:
+Plan v8 — 2026-04-29. Addresses Codex round-7 (task-mok1ojg3-0esulj):
 
-1. Sub-tick expiration lag (round-6 #1): documented the up-to-1-
-   wheel-tick lag introduced by `target_tick = floor(...)` + strict
-   `cursor < now_tick` pop. Production GC has the same lag (gated
-   to 1 s by `SESSION_GC_INTERVAL_NS`), so this is a non-regression
-   in deployed code. Added test `wheel_lags_today_subtick_by_at_most_one_tick`.
+1. Acceptance gate 4a workload was self-contradictory: "10 %
+   touched per second" produces K ≈ 5K (every active session pushes
+   to every bucket once per 256 s), not K ≈ 977. Redefined 4a as a
+   Poisson touch process tuned to T_active = 5 (~1000 touches/s
+   spread across 50K sessions), which actually matches the
+   N × T_active / 256 = 977 model and the K ≤ 1500 bound.
 
-2. Internal contradiction in the per-tick cost section (round-6 #2):
-   removed the "256 × ~0.4-ms drains, only ONE bucket holds the
-   per-second-touch crowd" wording — it conflicted with the K ≈ N
-   bound stated five lines above. Under sustained per-second touch
-   every bucket holds ~N entries after warm-up.
+2. Per-second-touch test classification was wrong: under sustained
+   per-second touch on every session, popped entries are ALL stale
+   duplicates (canonical wheel_tick has advanced beyond every
+   bucket's scheduled_tick by the time the bucket is popped). So
+   `entries_re_bucketed = 0`, not = N; `entries_dropped_stale ≈ K`,
+   not `≈ N × 255`. Test rewritten with the correct classification.
 
-3. Mostly-idle table miscalculated (round-6 #3): the column was
-   off by 10× because it failed to divide by 256. Fixed: 100K ×
-   T_active=5 → ~200 µs per tick, not 2 ms.
+3. Drain pseudocode allocated `Vec::with_capacity(due_count)` per
+   pop, contradicting the "no per-second Vec allocation" claim.
+   Redesigned: snapshot bucket length, iterate via `pop_front`
+   exactly that many times, no scratch buffer needed. Re-pushed
+   entries land at the back of the VecDeque and are NOT popped
+   during this call (next rotation handles them).
 
-4. Acceptance gate spec was duplicated with conflicting numbers
-   (round-6 #4): removed the duplicate inside §Per-tick GC work;
-   §Acceptance gates is now the single source of truth, with
-   workload sizes 50K (4a) and 10K (4b) and explicit K-bounds
-   plus wall-time targets.
+4. "No production caller can observe the difference" softened to
+   "same worst-case bounded lag, slightly different GC-phase
+   alignment". The wheel preserves the existing 1-s lag bound but
+   may pick up an expiration up to 1 tick later than today's gated
+   scan does, depending on relative phase of `target_tick` vs.
+   wheel cursor at expiration time. Bounded above by
+   `WHEEL_TICK_NS`, strictly less than today's `SESSION_GC_INTERVAL_NS`,
+   no user-visible regression.
 
-5. Unit test was wall-time-only (round-6 #5): rewrote
-   `wheel_per_second_touch_bounds_K_per_bucket` to assert K ≤ 12K
-   directly (catches a 2× duplicate-push regression that a 5×
-   wall-time bound would not), with wall-time as a separate
-   informational gate.
+Earlier rounds remain in effect: round-3 (bucket-helper / pop
+race + alias `WheelEntry`), round-4 (memory math + alias borrow
+shape), round-5 (per-tick cost model uses K not N/256), round-6
+(sub-tick lag documentation, mostly-idle table arithmetic, single
+acceptance-gate spec, K-bound assertions in unit test).
 
-Earlier rounds remain in effect: round-3 fixed bucket-helper /
-pop race and alias `WheelEntry` payload; round-4 fixed memory math
-and the alias borrow shape; round-5 fixed the per-tick cost model
-to use K = entries-per-bucket instead of N / 256.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -210,11 +213,19 @@ if now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
 ```
 
 with `SESSION_GC_INTERVAL_NS = 1 s`, so today's scan also has
-a ~1 s expiration lag in production. The behavioral change is
-visible only in unit tests that bypass the gate by manipulating
-`last_gc_ns` directly, and only at sub-tick precision (the
-`+1 ns` case Codex flagged). No production caller can observe
-the difference.
+a ~1 s expiration lag in production. Both the existing scan and
+the wheel are bounded by the same worst-case lag (one wheel-
+tick = one second). What CAN differ is the GC-phase alignment:
+today's scan picks an entry up the moment the gate releases
+after expiration, while the wheel picks it up at the next bucket
+visit, which can be up to one tick later depending on the
+relative phase of the entry's `target_tick` vs. the wheel cursor
+at expiration time. The honest claim is therefore "same worst-
+case bounded lag, slightly different phase alignment", not "no
+production caller can observe the difference". The behavioral
+deviation is bounded above by `WHEEL_TICK_NS = 1 s` and is
+strictly less than the existing GC interval's resolution, so no
+documented user-visible behavior changes.
 
 The existing `expiry_boundary_strict_greater_than` test asserts
 the exact-boundary case (`now == last_seen + expires_after`,
@@ -478,18 +489,28 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
         // Drain in place into a local Vec, then process. We cannot
         // hold a `&mut VecDeque` from the wheel and simultaneously
         // call `self.wheel.buckets[new_bucket].push_back(...)` for
-        // a re-bucket whose target may equal `bucket_idx` — that
-        // would alias the same VecDeque mutably. Round-3 caught
-        // the v3 same-bucket-reinsert race that arose from
+        // a re-bucket whose target may equal `bucket_idx`. Round-3
+        // caught the v3 same-bucket-reinsert race that arose from
         // `mem::take` followed by `buckets[idx] = due` overwriting
-        // re-bucketed entries. Drain → local Vec → free up the
-        // wheel reference → process from the local Vec.
+        // re-bucketed entries. Round-7 (#3) caught that the v4
+        // drain-into-Vec design re-introduced a per-pop allocation
+        // — `Vec::with_capacity(due_count)` once per popped bucket
+        // = once per tick, more than today's StW which allocates
+        // once per gc-interval.
+        //
+        // Allocation-free design: snapshot the bucket length BEFORE
+        // iterating, then `pop_front` exactly that many times. Any
+        // `push_back` re-bucket targeting this same bucket lands at
+        // the back of the VecDeque and is NOT popped during this
+        // call (we stop after `due_count` iterations). The next
+        // wheel rotation visits this bucket and processes the
+        // re-pushed entries normally.
         let due_count = self.wheel.buckets[bucket_idx].len();
-        let mut due_buf: Vec<WheelEntry> = Vec::with_capacity(due_count);
-        while let Some(entry) = self.wheel.buckets[bucket_idx].pop_front() {
-            due_buf.push(entry);
-        }
-        for WheelEntry { key, scheduled_tick } in due_buf.drain(..) {
+        for _ in 0..due_count {
+            let entry_snap = self.wheel.buckets[bucket_idx]
+                .pop_front()
+                .expect("len snapshot bounds the iteration");
+            let WheelEntry { key, scheduled_tick } = entry_snap;
             let Some(entry) = self.sessions.get(&key) else {
                 // Already removed elsewhere — drop hint.
                 continue;
@@ -514,9 +535,11 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
                 // bucket at the new absolute target tick. The new
                 // bucket may be `bucket_idx` again (e.g. exactly
                 // 256s timeout repeats); that's fine because the
-                // wheel's bucket VecDeque is now empty (we drained
-                // into due_buf above), so the push goes to the
-                // correct slot and is NOT overwritten on loop exit.
+                // outer `for _ in 0..due_count` loop iterates
+                // exactly `due_count` times — re-pushed entries
+                // land at the back of the VecDeque and are NOT
+                // popped during this call. They get processed at
+                // the next wheel rotation.
                 let new_target_tick = target_tick_for(
                     now_ns,
                     entry.last_seen_ns + entry.expires_after_ns,
@@ -709,21 +732,30 @@ buffers grow to fit avg load × geometric headroom. For typical
   verify expire_stale_entries returns all 50K in a single call
   (no per-tick cap; one tick = one bucket = O(B) work, not capped).
 - `wheel_per_second_touch_bounds_K_per_bucket` (Codex round-5 #2,
-  hardened per round-6 #5): install N=10K sessions, then touch
-  every session once per second for 300 s of simulated time
-  before measuring. After warm-up, instrument the next pop to
-  count entries scanned (`K`) and entries dropped/expired/re-
-  bucketed. Assert:
+  hardened per round-6 #5, classifications corrected per round-7
+  #2): install N=10K sessions, then touch every session once per
+  second for ≥ 300 s of simulated time before measuring. After
+  warm-up, instrument the next pop to count entries scanned (`K`)
+  and entries dropped/expired/re-bucketed. **Under sustained
+  per-second touch on every session, every entry in the popped
+  bucket is a stale duplicate** — the canonical `wheel_tick` for
+  every session has advanced beyond the bucket's `scheduled_tick`
+  because each session pushed a fresher entry every second since
+  the bucket was last popped. So:
     * `K ≤ 12,000` (model says 10,000; 20 % headroom catches a
       2× duplicate-push regression — a 5× wall-time bound would
       not).
-    * `entries_re_bucketed = N` (the live canonical entry per
-      session lands in its new tick).
-    * `entries_dropped_stale ≈ N × (256 − 1)` summed across one
-      full wheel rotation (256 ticks). Assert
-      `total_dropped ∈ [0.9, 1.1] × N × 255` to catch leakage of
-      stale entries that the lazy-delete discriminator should
-      drop.
+    * `entries_dropped_stale ≈ K` (every entry is dropped via
+      the `wheel_tick != scheduled_tick` discriminator).
+    * `entries_re_bucketed = 0` (no canonical entry expires in
+      this regime; sessions are kept alive by the per-second
+      touch).
+    * `entries_expired = 0` (same reason).
+    * Across a full 256-tick rotation: total entries scanned
+      ≈ 256 × K ≈ 256 × N. Assert
+      `total_scanned ∈ [0.9, 1.1] × 256 × N` to catch leakage
+      of stale entries the lazy-delete discriminator should
+      drop on visit but didn't.
   The point of the test is to bound *work shape*, not wall time;
   wall-time perf is the §Acceptance gate 4b informational gate.
 - `wheel_alias_lookup_does_not_double_borrow_self`: compile-time
@@ -753,17 +785,30 @@ continue to pass.
 
    4a. **Realistic mostly-idle workload**:
        - N = 50K sessions installed.
-       - 10% (5K) of sessions touched once per second; the rest
-         idle for the duration of the measurement.
+       - Touch rate calibrated so that each session contributes
+         ≈ T_active = 5 distinct expiration ticks over the 256-s
+         wheel window. Concretely: a Poisson touch process at
+         rate ~5/256 ≈ 0.02 per session per second, i.e. roughly
+         1000 touches/s spread across the 50K-session population.
        - Run for ≥ 300 s of simulated time before measuring (so
          the wheel reaches steady state and any warm-up
          allocations have settled).
-       - Assert: p99 GC-tick wall time ≤ 1 ms over a 60-s
-         measurement window.
        - Assert: per-pop K (entries scanned per popped bucket)
-         ≤ 1500 (the model gives 50K × 5 / 256 = 977; 1500 is
-         ~50% headroom and catches a regression where touch
-         pushes more than one entry per tick-change).
+         ≤ 1500 (the model gives N × T_active / 256 = 50K × 5 /
+         256 = 977; 1500 is ~50 % headroom and catches a
+         regression where touch pushes more than one entry per
+         tick-change).
+       - Assert: p99 GC-tick wall time ≤ 1 ms over a 60-s
+         measurement window (model: 977 × 100 ns = 98 µs; 10×
+         margin allows for HashMap probe variance and alloc
+         churn during warm-up).
+       - **NOT** a "10 % touched per second" workload — that
+         shape produces ≈ 5K active sessions each pushing once
+         per second, so K ≈ 5K, not 977. The two-rate framing
+         of T_active vs. per-second touch fraction was the
+         source of the round-6 → round-7 contradiction; the
+         spec above pins the rate to a Poisson process tuned to
+         T_active = 5.
 
    4b. **Sustained per-second touch** (worst-plausible hot path):
        - N = 10K sessions installed.

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -155,14 +155,18 @@ bucket index is just `(cursor_tick & WHEEL_MASK)`. The
 will revisit only after a full rotation — distinct from the
 current bucket. Test: `wheel_handles_exact_256s_timeout`.
 
-### Coverage of long-lived TCP
+### Coverage of long-lived sessions
 
-`TCP_ESTABLISHED_TIMEOUT_NS` ≈ 7200 s exceeds the 256-s window.
-Such an entry lands in the far-future bucket. When that bucket is
-popped (256 s after insertion), `wheel_pop_one_bucket` re-checks
-the entry's actual `last_seen + expires_after` against `now_ns`,
-finds it still in the future, and re-buckets via the same logic.
-Cost: one HashMap lookup + one push per long session per 256 s.
+The default established-TCP timeout in `userspace-dp/src/session.rs`
+is 300 s (`DEFAULT_TCP_SESSION_TIMEOUT_NS = 300_000_000_000`), which
+is already larger than the 256-s wheel window. Operators can set
+arbitrarily long per-protocol timeouts (Junos allows up to days).
+Any timeout that exceeds the 256-s window lands in the far-future
+bucket. When that bucket is popped (256 s after insertion),
+`wheel_pop_one_bucket` re-checks the entry's actual
+`last_seen + expires_after` against `now_ns`, finds it still in the
+future, and re-buckets via the same logic. Cost: one HashMap
+lookup + one push per long session per 256 s.
 
 ### Push-to-wheel: when, and the duplicate bound (Codex round-2 #2)
 
@@ -190,34 +194,65 @@ The wheel push happens only when the expiration TICK changes. A
 session touched 1000 times within the same second produces ZERO
 extra wheel entries.
 
-#### Memory math (corrected per Codex round-2 #2)
+Note: this snippet is the throttle *condition* in isolation. In a
+real call site (e.g. `update_session`, `lookup_with_origin`), the
+`&mut SessionEntry` borrow on `self.sessions` MUST be scoped to
+end before the `self.wheel.buckets[...]` push, or the borrow
+checker will reject the compound `&mut self` aliasing. See the
+alias correctness section below for the full borrow-scoped shape.
 
-Each push costs `WheelEntry` size = `SessionKey + u64` = ~248 B
-on 64-bit. The total live wheel-entry count is:
+#### Memory math (corrected per Codex rounds 2 + 4)
 
-  total_wheel_entries = sum over sessions of (distinct expiration ticks visited during the session's lifetime)
+Measured (`rustc 1.x`, 64-bit):
+- `size_of::<SessionKey>()` = **40 B** (u8 + u8 + 2×IpAddr(17 B) + u16 + u16, align 2)
+- `size_of::<WheelEntry>()` = **48 B** (40 B SessionKey + u64 + alignment padding to 8 B, align 8)
 
-For a session whose `last_seen_ns + expires_after_ns` shifts
-linearly with each touch (typical), every touch in a new second
-produces one push. Realistic touch-tick distributions:
+Live wheel storage is bounded by the wheel itself: the wheel only
+holds entries whose `scheduled_tick ∈ [cursor_tick, cursor_tick +
+FAR_FUTURE_OFFSET]`, i.e. at most 256 distinct future-tick slots.
+For each session, throttling caps push frequency at one push per
+TICK in which `(last_seen + expires_after)` produces a new
+`scheduled_tick`. Stale entries (where the canonical `wheel_tick`
+has moved on) are not deleted eagerly — they sit in the wheel until
+their bucket is popped, at which point the lazy-delete discriminator
+drops them in O(1).
 
-| Workload | Touches / sec | Lifetime | Pushes / session | Total at 100K sessions |
-|---|---|---|---|---|
-| Idle TCP keepalive (rare touch) | <0.1 | 7200s | ~1 | 100K (~24 MB) |
-| Mostly-idle session table | <1 | 300s | ~3 | 300K (~72 MB) |
-| Active TCP throughput | per-packet rate, but tick changes ≤1/s | 300s | ~300 | 30M (~7.2 GB) |
-| Pathological per-tick touch | 1/s | 300s | 300 | 30M (~7.2 GB) |
+Therefore:
 
-The worst case (every session active and touched per tick) is
-~7.2 GB at 100K sessions, growing linearly with N × lifetime_secs.
-For 1M × 300s × 248 B = ~72 GB — pathological territory.
+  live_wheel_entries ≤ Σ over live sessions of
+                       min(distinct_active_touch_ticks_in_last_256s, 256)
+                       + recently-superseded duplicates not yet drained
 
-This is honest: the wheel storage cost grows with the throughput
-of touch-tick changes. For typical deployments (most sessions
-mostly idle between brief activity bursts) it's well-bounded.
-For pathological dense-throughput workloads we hit a memory
-ceiling that #964's slab (8-B SlotHandle vs 248-B WheelEntry, ~30×
-smaller) is the right place to solve.
+The drain time of a stale duplicate is bounded by one wheel
+rotation: ≤ 256 s after it was superseded. So the steady-state
+upper bound is ≈ N_sessions × 256 entries (the absolute ceiling),
+and the realistic value is much smaller because most sessions are
+idle and touch in <<256 distinct ticks.
+
+| Workload | Active touch ticks / sess | Live entries at 100K sessions | Memory |
+|---|---|---|---|
+| Idle TCP keepalive (rare touch) | ~1 | ~100K | ~4.8 MB |
+| Mostly-idle session table | ~3–5 | ~300K–500K | ~14–24 MB |
+| Active TCP throughput (touch ≤1/s) | up to 256 | ≤25.6M | ≤1.2 GB |
+| Pathological (every session, every tick) | 256 | 25.6M | 1.2 GB |
+
+At 1M sessions × 256 × 48 B the absolute ceiling is **~12.3 GB**.
+That ceiling is reached only when every session is touched in 256
+distinct seconds inside a 256-s window, which already implies a 1M-
+session steady state with continuous activity. The realistic value
+is well under 100 MB.
+
+This is honest: the wheel storage cost is bounded by `N × WHEEL_BUCKETS`,
+not by session lifetime. The earlier draft's "linear with
+lifetime_secs" claim was wrong — once GC keeps up with the wheel
+rotation, stale duplicates are drained within 256 s and don't
+accumulate over the full session lifetime.
+
+#964 (slot-handle compaction) replaces the 40-B `SessionKey` with a
+~4-B slot index, taking `WheelEntry` from 48 B to ~16 B — roughly
+**3× smaller** (not 30×; the 30× figure assumed the 248-B miscount).
+That follow-up is still worth doing, but #965 alone keeps the
+absolute memory ceiling at low single-digit GB even at 1M sessions.
 
 **Decision**: ship #965 with the corrected algorithm + this
 honest memory math. Document the "every-session-touched-every-tick
@@ -237,15 +272,41 @@ flawed knob — at 5K/tick when due-rate is ≥5K/s the backlog grows
 unbounded. Two options remained:
 
 (a) Multi-level wheel — extra complexity and a follow-up.
-(b) Just pay the bucket cost — ≤7 ms per tick at 1M sessions / 30s
-    timeouts in the worst case, but small (sub-ms) for realistic
-    loads. This still beats today's O(N) which is 100+ ms at the
-    same scale.
+(b) Just pay the bucket cost. Under the assumption that scheduled
+    ticks are spread roughly uniformly across the wheel (the
+    typical case: sessions installed and touched at independent
+    times produce expirations spread across `WHEEL_BUCKETS`
+    distinct ticks), per-tick work is `O(N / WHEEL_BUCKETS)`. At
+    1M sessions / 256-tick wheel that's ~4K entries per bucket;
+    at ~1.7 µs per entry (HashMap lookup + state update) the
+    per-tick cost is **~7 ms under uniform distribution**, well
+    under sub-ms for realistic loads of ≤100K sessions.
 
-We choose (b). The plan is honest: this is *bounded per-bucket*
-work, not *fixed per-tick* work. The "Stop the World" #965 issue
-goes away because per-tick work is now O(N/T) instead of O(N) —
-~30× lower at typical timeout/session-count ratios.
+We choose (b). Worst-case caveat: this is **average-case**, not
+absolute worst-case. Adversarial / synthetic workloads that bunch
+all installs into a single tick (all sessions installed at boot
+with identical timeouts, then idle) place every entry in one
+bucket. That bucket sees `O(N)` work at the moment the wheel sweep
+reaches it. We accept this because (i) it requires a synthetic
+load shape — real traffic does not install N sessions in one
+tick, (ii) the cost is paid exactly once per 256 s at most for
+that bucket, and (iii) the resulting latency spike (≈ same as
+today's StW for that one tick) is no worse than today's pre-#965
+behavior, and is dramatically better for the other 255 ticks.
+
+The plan is honest: this is *bounded per-bucket* work, not
+*fixed per-tick* work. The "Stop the World" #965 issue goes away
+because per-tick work is now `O(N / WHEEL_BUCKETS)` under uniform
+distribution instead of `O(N)` every tick.
+
+The acceptance-gate "mouse-latency" check (Acceptance gate §4
+below) installs sessions at a *uniform* rate over many ticks
+before triggering GC and asserts p99 GC-tick wall time ≤ 1 ms
+under a 50K-session synthetic load. That gate is explicit about
+the uniform-distribution shape; clustered-install adversarial
+shapes (every session installed in the same tick) are out of
+scope for #965 and tracked under #964 / multi-level wheel
+follow-up.
 
 ```rust
 pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
@@ -350,7 +411,15 @@ let actual_key = if self.sessions.contains_key(key) {
 } else {
     return None;
 };
-self.sessions.get_mut(&actual_key).map(|entry| {
+
+// Scope the &mut self.sessions borrow so it ends BEFORE we touch
+// self.wheel. Without this scoping the closure form
+// `self.sessions.get_mut(...).map(|entry| { ... self.wheel ... })`
+// holds a mutable borrow on `self` (via `self.sessions`) and a
+// second mutable borrow on `self.wheel` simultaneously, which the
+// borrow checker rejects.
+let push_tick: Option<u64> = {
+    let entry = self.sessions.get_mut(&actual_key)?;
     // ... last_seen_ns / expires_after_ns updates ...
     let new_expiration_tick = target_tick_for(
         now_ns,
@@ -358,15 +427,26 @@ self.sessions.get_mut(&actual_key).map(|entry| {
     );
     if new_expiration_tick != entry.wheel_tick {
         entry.wheel_tick = new_expiration_tick;
-        // PUSH actual_key, not the alias `key`. Payload must be
-        // a WheelEntry carrying the canonical scheduled_tick so
-        // pop's lazy-delete discriminator can detect staleness.
-        let bucket = bucket_for_tick(new_expiration_tick);
-        self.wheel.buckets[bucket].push_back(WheelEntry {
-            key: actual_key.clone(),
-            scheduled_tick: new_expiration_tick,
-        });
+        Some(new_expiration_tick)
+    } else {
+        None
     }
+}; // <-- &mut self.sessions borrow ends here
+
+if let Some(tick) = push_tick {
+    // PUSH actual_key, not the alias `key`. Payload must be a
+    // WheelEntry carrying the canonical scheduled_tick so pop's
+    // lazy-delete discriminator can detect staleness.
+    let bucket = bucket_for_tick(tick);
+    self.wheel.buckets[bucket].push_back(WheelEntry {
+        key: actual_key.clone(),
+        scheduled_tick: tick,
+    });
+}
+
+// Build the SessionLookup return value via a fresh & immutable
+// borrow on self.sessions (the &mut borrow above has dropped).
+self.sessions.get(&actual_key).map(|entry| {
     // ... return SessionLookup ...
 })
 ```
@@ -395,10 +475,11 @@ honest phrasing is: "amortized O(1) push, occasional reallocation
 during bucket warmup". The expected number of bucket-reallocations
 across the wheel's first 256 ticks is `O(WHEEL_BUCKETS × log(B_avg))`
 ≈ 256 × ~5 = ~1300 reallocations total during warm-up. Each is a
-VecDeque buffer copy of size ~B/2 — for B=3K that's 3K × 248 B =
-~750 KB per realloc × 1300 reallocs = ~1 GB of memory churn during
-warm-up. Spread over 256 ticks (256 s wall time), that's ~4 MB/s of
-allocator traffic. Negligible vs the per-packet hot path.
+VecDeque buffer copy of size ~B/2 — for B=3K that's 3K × 48 B =
+~144 KB per realloc × 1300 reallocs = ~180 MB of memory churn
+during warm-up. Spread over 256 ticks (256 s wall time), that's
+~720 KB/s of allocator traffic. Negligible vs the per-packet hot
+path.
 
 After warm-up (after first wheel rotation), each bucket's VecDeque
 has settled at ~max-bucket-size capacity. New pushes don't grow.
@@ -418,7 +499,8 @@ fn new_wheel() -> SessionWheel {
 
 Construction memory cost: 256 × 24 B = 6 KB. Steady state: bucket
 buffers grow to fit avg load × geometric headroom. For typical
-100K × 30s workloads, ~30 active buckets × 3K × 248 B = ~22 MB.
+100K × 30s workloads, ~30 active buckets × ~3K entries × 48 B =
+~4.3 MB.
 
 ### Files touched
 
@@ -461,6 +543,12 @@ buffers grow to fit avg load × geometric headroom. For typical
   sessions all with same expiration; advance time past expiration;
   verify expire_stale_entries returns all 50K in a single call
   (no per-tick cap; one tick = one bucket = O(B) work, not capped).
+- `wheel_alias_lookup_does_not_double_borrow_self`: compile-time
+  test that the alias path's `lookup_with_origin` body type-checks
+  (i.e. the &mut self.sessions borrow is scoped before
+  self.wheel.buckets is touched). This is enforced by the borrow
+  checker; the test exists to guard against future refactors that
+  reintroduce a `.map(|entry| { ... self.wheel ... })` shape.
 - `wheel_handles_concurrent_insert_and_pop`: not relevant
   (SessionTable is not Send + Sync — owned by a single worker;
   Codex confirmed worker.rs:490 has `let mut sessions = ...`).

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -212,20 +212,27 @@ if now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
 }
 ```
 
-with `SESSION_GC_INTERVAL_NS = 1 s`, so today's scan also has
-a ~1 s expiration lag in production. Both the existing scan and
-the wheel are bounded by the same worst-case lag (one wheel-
-tick = one second). What CAN differ is the GC-phase alignment:
-today's scan picks an entry up the moment the gate releases
-after expiration, while the wheel picks it up at the next bucket
-visit, which can be up to one tick later depending on the
-relative phase of the entry's `target_tick` vs. the wheel cursor
-at expiration time. The honest claim is therefore "same worst-
-case bounded lag, slightly different phase alignment", not "no
-production caller can observe the difference". The behavioral
-deviation is bounded above by `WHEEL_TICK_NS = 1 s` and is
-strictly less than the existing GC interval's resolution, so no
-documented user-visible behavior changes.
+with `SESSION_GC_INTERVAL_NS = 1 s`, so today's scan already has
+up to ~1 s of lag in production. The wheel can add **up to one
+more tick** on top of that depending on the relative phase of
+the entry's `target_tick` vs. the wheel cursor at expiration
+time. So the honest bound is:
+
+  - Today's scan: absolute expiry-detection lag ≤ 1 s
+    (`SESSION_GC_INTERVAL_NS`).
+  - Wheel: absolute expiry-detection lag ≤ 2 s (existing 1 s
+    gate lag + up to one wheel-tick of phase deviation).
+  - Additional deviation introduced by the wheel vs. today:
+    **strictly less than one wheel-tick = 1 s.**
+
+That additional ≤1 s deviation is the only behavioral change
+the wheel introduces. No documented user-visible behavior is
+specified at sub-second precision (timeout knobs are second-
+granular in Junos config), so the deviation is below the
+resolution at which any operator can observe it; but the
+correct phrasing is "additional deviation < 1 tick" / "absolute
+expiry can approach 2 s in the worst phase", not "same worst-
+case lag".
 
 The existing `expiry_boundary_strict_greater_than` test asserts
 the exact-boundary case (`now == last_seen + expires_after`,
@@ -486,10 +493,10 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
     // after init is a no-op (loop body runs zero times).
     while self.wheel.cursor_tick < now_tick {
         let bucket_idx = bucket_for_tick(self.wheel.cursor_tick);
-        // Drain in place into a local Vec, then process. We cannot
-        // hold a `&mut VecDeque` from the wheel and simultaneously
-        // call `self.wheel.buckets[new_bucket].push_back(...)` for
-        // a re-bucket whose target may equal `bucket_idx`. Round-3
+        // Drain the bucket allocation-free. We cannot hold a
+        // `&mut VecDeque` from the wheel and simultaneously call
+        // `self.wheel.buckets[new_bucket].push_back(...)` for a
+        // re-bucket whose target may equal `bucket_idx`. Round-3
         // caught the v3 same-bucket-reinsert race that arose from
         // `mem::take` followed by `buckets[idx] = due` overwriting
         // re-bucketed entries. Round-7 (#3) caught that the v4
@@ -501,10 +508,20 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
         // Allocation-free design: snapshot the bucket length BEFORE
         // iterating, then `pop_front` exactly that many times. Any
         // `push_back` re-bucket targeting this same bucket lands at
-        // the back of the VecDeque and is NOT popped during this
-        // call (we stop after `due_count` iterations). The next
-        // wheel rotation visits this bucket and processes the
-        // re-pushed entries normally.
+        // the back of the VecDeque and is NOT popped during THIS
+        // BUCKET DRAIN (the inner `for _ in 0..due_count` loop
+        // stops after `due_count` iterations). The next wheel
+        // rotation that visits this bucket processes the re-pushed
+        // entries normally. NOTE: a single `expire_stale_entries`
+        // call may catch up multiple ticks (the outer `while
+        // cursor_tick < now_tick` advances the cursor across
+        // several buckets). A re-push from bucket A whose target
+        // lands in a later bucket B that the OUTER loop will visit
+        // in this same call IS popped before the call returns —
+        // that's intentional and correct (it represents an entry
+        // that was re-bucketed forward into a tick that has already
+        // arrived). Only same-bucket re-pushes are deferred to the
+        // next wheel rotation, by design.
         let due_count = self.wheel.buckets[bucket_idx].len();
         for _ in 0..due_count {
             let entry_snap = self.wheel.buckets[bucket_idx]

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -1,10 +1,10 @@
 # #965: bucketed timer-wheel session GC (replace O(N) scan)
 
-Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mojzeozp-8bzfr7):
-8 blocking findings — cursor init, per-tick cap drainage,
-deferred-tail semantics, exact-256s correctness trap, alias
-lookup, hot-path allocation claim, duplicate-wheel-entry bound,
-expiry boundary off-by-1ns.
+Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mojzpydq-t17ylf):
+algorithm bug — round-2 v2 pop dropped still-alive long-timeout
+entries from the wheel forever; bucket payload extended to
+`WheelEntry { key, scheduled_tick }` with explicit re-bucket-or-
+drop pop logic; memory math corrected; doc contradictions cleaned.
 
 ## Investigation findings (Claude, on commit 08ff1838)
 
@@ -64,12 +64,21 @@ const WHEEL_TICK_NS: u64 = 1_000_000_000;        // 1 s
 const WHEEL_BUCKETS: usize = 256;                // 256 s window
 const WHEEL_MASK: u64 = (WHEEL_BUCKETS as u64) - 1; // 0xFF
 
+/// What a wheel bucket holds. The `scheduled_tick` is the
+/// expiration tick at the moment of bucketing — used by `pop`
+/// to distinguish stale duplicates (`scheduled_tick !=
+/// entry.wheel_tick`) from genuinely-due entries
+/// (`scheduled_tick == entry.wheel_tick`).
+pub(crate) struct WheelEntry {
+    pub key: SessionKey,
+    pub scheduled_tick: u64,
+}
+
 pub(crate) struct SessionWheel {
     /// 256 buckets indexed by `expiration_tick & WHEEL_MASK`.
-    /// Each bucket holds keys whose computed `expiration_tick`
-    /// (= `(last_seen_ns + expires_after_ns) / WHEEL_TICK_NS`)
-    /// modulo 256 equals the bucket index.
-    buckets: Box<[VecDeque<SessionKey>; WHEEL_BUCKETS]>,
+    /// Each bucket holds entries whose `scheduled_tick` modulo
+    /// 256 equals the bucket index.
+    buckets: Box<[VecDeque<WheelEntry>; WHEEL_BUCKETS]>,
     /// Tick that bucket index 0 represents on the *current*
     /// wheel revolution. Advanced lazily as `cursor_tick`
     /// crosses bucket boundaries.
@@ -141,63 +150,65 @@ the entry's actual `last_seen + expires_after` against `now_ns`,
 finds it still in the future, and re-buckets via the same logic.
 Cost: one HashMap lookup + one push per long session per 256 s.
 
-### Lazy delete on touch (Codex finding #7 — duplicate bound)
+### Push-to-wheel: when, and the duplicate bound (Codex round-2 #2)
 
-When `touch` / `lookup_with_origin` / `update_session` updates
-`last_seen_ns`, the old bucket entry becomes stale. We use **lazy
-delete**: leave the stale entry, push a new one, re-check on pop.
-
-The bound on duplicates per session matters because
-`lookup_with_origin` is called per session-cache-touch on the hot
-path. Without throttling, a session that's touched 1000 times
-during its lifetime would have 1000 stale wheel entries — that's
-240 KB of `SessionKey` (240 B each) per long session. At 1M
-sessions × 1000 touches that's 240 GB of stale wheel garbage.
-
-**Per-tick throttle**: only re-push to the wheel if the new
-expiration tick differs from the previously-recorded one. Embed a
-`wheel_tick: u64` field on SessionEntry (16 B added). On
-touch/lookup_with_origin/update_session/refresh_*:
+When `install` / `upsert_synced` / `lookup_with_origin` / `update_session`
+/ `refresh_*` updates `last_seen_ns` or `expires_after_ns`, we may
+need to add a wheel entry. To bound duplicates we throttle:
 
 ```rust
 let new_expiration_tick = (entry.last_seen_ns + entry.expires_after_ns)
     / WHEEL_TICK_NS;
 if new_expiration_tick != entry.wheel_tick {
     entry.wheel_tick = new_expiration_tick;
-    self.wheel.push(key.clone(), new_expiration_tick);
+    let bucket = self.bucket_for_tick(new_expiration_tick);
+    self.wheel.buckets[bucket].push_back(WheelEntry {
+        key: actual_key.clone(),
+        scheduled_tick: new_expiration_tick,
+    });
 }
-// Same-tick touches: no wheel push.
+// Same-tick touches: no push.
 ```
 
-This bounds duplicates per session to:
-`(session_lifetime_secs / WHEEL_TICK_NS_secs) ≈ session_lifetime_secs`.
+The wheel push happens only when the expiration TICK changes. A
+session touched 1000 times within the same second produces ZERO
+extra wheel entries.
 
-For a 30-second session: max 30 wheel duplicates. For a 7200-s TCP
-session: max 7200 entries (one per second the session is touched).
-At 1M long sessions × 7200 entries = 7.2B entries × 240 B/entry =
-1.7 TB worst case. That's still bad.
+#### Memory math (corrected per Codex round-2 #2)
 
-**Tighter bound**: bucket the wheel at *touch granularity*, not
-expiration granularity. The wheel only cares about
-"approximately when this key SHOULD be checked again". Push at
-`expiration_tick` only when the key's next expiration is more
-than 1 tick away from its previously-recorded one. The 1-tick
-granularity is fine because GC pops one bucket = 1 tick of wall
-time anyway.
+Each push costs `WheelEntry` size = `SessionKey + u64` = ~248 B
+on 64-bit. The total live wheel-entry count is:
 
-This is the same algorithm as above, but the bound is now:
-`(session_lifetime_secs / 1 sec) = session_lifetime_secs`.
+  total_wheel_entries = sum over sessions of (distinct expiration ticks visited during the session's lifetime)
 
-For typical session lifetimes (≤300 s) and ≤1M sessions, that's
-1M × 300 = 300M entries × 240 B = 72 GB. Still bad for pathological
-workloads but realistic deployments stay well under.
+For a session whose `last_seen_ns + expires_after_ns` shifts
+linearly with each touch (typical), every touch in a new second
+produces one push. Realistic touch-tick distributions:
 
-**Decision**: ship with the per-tick throttle. Document the
-"pathological worst case" honestly. The ultimate fix is the #964
-slab: SlotHandle is 8 B not 240 B (30× smaller), so 300M handles
-= 2.4 GB — same workload, manageable. #964 is the right place to
-solve the duplicate-storage problem; #965 ships with a usable
-bound and an explicit "pathological-only" caveat.
+| Workload | Touches / sec | Lifetime | Pushes / session | Total at 100K sessions |
+|---|---|---|---|---|
+| Idle TCP keepalive (rare touch) | <0.1 | 7200s | ~1 | 100K (~24 MB) |
+| Mostly-idle session table | <1 | 300s | ~3 | 300K (~72 MB) |
+| Active TCP throughput | per-packet rate, but tick changes ≤1/s | 300s | ~300 | 30M (~7.2 GB) |
+| Pathological per-tick touch | 1/s | 300s | 300 | 30M (~7.2 GB) |
+
+The worst case (every session active and touched per tick) is
+~7.2 GB at 100K sessions, growing linearly with N × lifetime_secs.
+For 1M × 300s × 248 B = ~72 GB — pathological territory.
+
+This is honest: the wheel storage cost grows with the throughput
+of touch-tick changes. For typical deployments (most sessions
+mostly idle between brief activity bursts) it's well-bounded.
+For pathological dense-throughput workloads we hit a memory
+ceiling that #964's slab (8-B SlotHandle vs 248-B WheelEntry, ~30×
+smaller) is the right place to solve.
+
+**Decision**: ship #965 with the corrected algorithm + this
+honest memory math. Document the "every-session-touched-every-tick
+at 1M scale" worst case as the boundary. The bigger #964 slab
+refactor is the right venue for solving the duplicate-storage
+size; #965 alone delivers the "no Stop-the-World" win for the
+realistic case.
 
 ### Per-tick GC work — the algorithm in full
 
@@ -230,39 +241,68 @@ pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
 
     let now_tick = now_ns / WHEEL_TICK_NS;
     let mut expired = Vec::new();
-    // Process every bucket from cursor_tick up to (but not including)
-    // now_tick. cursor_tick starts at the lazy-init now_tick, so the
-    // first call after init is a no-op (loop body runs zero times).
+    // Cursor starts at the lazy-init now_tick, so the first call
+    // after init is a no-op (loop body runs zero times).
     while self.wheel.cursor_tick < now_tick {
         let bucket_idx = (self.wheel.cursor_tick & WHEEL_MASK) as usize;
-        // Take ownership of the bucket for the duration of this drain.
-        // Reusing `due` after the loop returns the buffer to the wheel,
-        // amortizing allocation.
+        // Take ownership of the bucket for the drain.
         let mut due = std::mem::take(&mut self.wheel.buckets[bucket_idx]);
-        for key in due.drain(..) {
-            // Lookup + boundary check matches today's exact semantics
-            // (Codex finding #8): `now - last_seen > expires_after`
-            // (strict `>`), not `>=`.
-            let Some(entry) = self.sessions.get(&key) else { continue };
-            if now_ns.saturating_sub(entry.last_seen_ns) <= entry.expires_after_ns {
-                // Touched after bucketing — already re-bucketed in the
-                // new tick. Stale hint; drop.
+        for WheelEntry { key, scheduled_tick } in due.drain(..) {
+            let Some(entry) = self.sessions.get(&key) else {
+                // Already removed elsewhere — drop hint.
+                continue;
+            };
+            if entry.wheel_tick != scheduled_tick {
+                // Stale duplicate: the entry has been re-scheduled
+                // to a different tick (touched + tick changed).
+                // The new scheduled tick has its own wheel entry.
                 continue;
             }
-            if let Some(removed) = self.remove_entry(&key) {
-                // ... existing remove_entry path produces SessionDelta
-                // and ExpiredSession; same logic as today's GC ...
-                expired.push(...);
+            // scheduled_tick matches the entry's recorded wheel_tick
+            // — this is the canonical scheduled-check entry. Now
+            // determine: actually expired vs. needs re-bucketing.
+            // Match today's strict `>` semantics (Codex finding #8).
+            if now_ns.saturating_sub(entry.last_seen_ns) > entry.expires_after_ns {
+                // Genuinely expired.
+                if let Some(removed) = self.remove_entry(&key) {
+                    // ... emit SessionDelta + ExpiredSession ...
+                    expired.push(...);
+                }
+            } else {
+                // Still alive — happens for long-timeout sessions
+                // (>= 256s) and for sessions that were re-scheduled
+                // exactly back to this tick. Re-bucket at the new
+                // expiration tick.
+                let new_tick = (entry.last_seen_ns + entry.expires_after_ns)
+                    / WHEEL_TICK_NS;
+                let new_bucket = self.bucket_for_tick(new_tick);
+                let entry_mut = self.sessions.get_mut(&key)
+                    .expect("entry was just read");
+                entry_mut.wheel_tick = new_tick;
+                self.wheel.buckets[new_bucket].push_back(WheelEntry {
+                    key,
+                    scheduled_tick: new_tick,
+                });
             }
         }
-        // Return the (now-empty) VecDeque buffer back to the wheel for reuse.
+        // Return the (now-empty) VecDeque buffer for reuse.
         self.wheel.buckets[bucket_idx] = due;
         self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
     }
-    self.wheel.base_tick = now_tick;  // for far-future bucket arithmetic
+    self.wheel.base_tick = now_tick;
     expired
 }
 ```
+
+This algorithm correctly handles four cases on pop:
+1. **Entry gone** (already removed by another path) — drop hint.
+2. **Stale duplicate** (`wheel_tick != scheduled_tick`) — drop, the
+   new scheduled tick has its own entry.
+3. **Actually expired** — remove, emit ExpiredSession + delta.
+4. **Still alive at the canonical scheduled tick** — long-timeout
+   case (e.g. 300s TCP-ESTABLISHED). Re-bucket at the new
+   expiration tick. This is the case that v2's pseudocode dropped
+   incorrectly (Codex round-2 finding #1).
 
 ### Alias correctness in lookup_with_origin (Codex finding #5)
 
@@ -296,38 +336,52 @@ self.sessions.get_mut(&actual_key).map(|entry| {
 
 Test: `wheel_alias_lookup_refreshes_canonical_key`.
 
-### Hot-path allocation honesty (Codex finding #6)
+### Hot-path allocation: lazy-grow with documented warm-up (Codex round-2 #3)
 
-`Box<[VecDeque<SessionKey>; 256]>` preallocates the 256 VecDeque
-*headers* (24 B each = 6 KB total). Each VecDeque allocates its
-backing buffer on first `push_back`. To avoid per-tick allocation
-on the hot path, we pre-reserve `max_sessions / WHEEL_BUCKETS`
-slots per bucket at construction:
+Round-1's `max_sessions / WHEEL_BUCKETS` reserve was wrong: short-
+timeout workloads concentrate sessions in a small number of "live"
+buckets (those between `cursor_tick` and `cursor_tick +
+typical_timeout_ticks`). For a 30s timeout × 100K sessions, only
+30 of 256 buckets see traffic at steady state, and each holds
+~3300 entries — far above the proposed 100K/256 = 390 reserve.
+Pre-reserving 390 per bucket means every active bucket reallocates
+2-3× as it grows.
+
+**Decision**: don't pre-reserve at all. Construct each VecDeque
+empty (24 B header). On the hot path, the FIRST `push_back` to
+each bucket allocates a small backing buffer; subsequent pushes
+amortize Vec-style geometric growth. Steady-state allocation
+amortizes across the bucket lifetime (up to 256 ticks).
+
+Drop the "no allocations on the hot path" claim entirely. The
+honest phrasing is: "amortized O(1) push, occasional reallocation
+during bucket warmup". The expected number of bucket-reallocations
+across the wheel's first 256 ticks is `O(WHEEL_BUCKETS × log(B_avg))`
+≈ 256 × ~5 = ~1300 reallocations total during warm-up. Each is a
+VecDeque buffer copy of size ~B/2 — for B=3K that's 3K × 248 B =
+~750 KB per realloc × 1300 reallocs = ~1 GB of memory churn during
+warm-up. Spread over 256 ticks (256 s wall time), that's ~4 MB/s of
+allocator traffic. Negligible vs the per-packet hot path.
+
+After warm-up (after first wheel rotation), each bucket's VecDeque
+has settled at ~max-bucket-size capacity. New pushes don't grow.
 
 ```rust
-fn new_wheel(max_sessions: usize) -> SessionWheel {
-    let initial_cap = (max_sessions / WHEEL_BUCKETS).max(64);
-    let mut buckets: Vec<VecDeque<SessionKey>> = Vec::with_capacity(WHEEL_BUCKETS);
+fn new_wheel() -> SessionWheel {
+    let mut buckets: Vec<VecDeque<WheelEntry>> = Vec::with_capacity(WHEEL_BUCKETS);
     for _ in 0..WHEEL_BUCKETS {
-        buckets.push(VecDeque::with_capacity(initial_cap));
+        // Lazy: first push allocates the backing buffer.
+        buckets.push(VecDeque::new());
     }
-    let buckets: Box<[VecDeque<SessionKey>; WHEEL_BUCKETS]> =
+    let buckets: Box<[VecDeque<WheelEntry>; WHEEL_BUCKETS]> =
         buckets.into_boxed_slice().try_into().expect("right size");
     SessionWheel { buckets, base_tick: 0, cursor_tick: 0, initialized: false }
 }
 ```
 
-For default `max_sessions = 1M`, that's 256 × 4096 SessionKeys =
-~250 MB of preallocated buffers. Drop to `max_sessions = 256K` for
-typical deployments and it's 64 MB. The `initial_cap` calc errs on
-the side of "no growth needed at steady state" — explicit
-`with_capacity` calls so the claim "no allocations on the hot path"
-is true at steady state, with a documented warm-up cost.
-
-Fallback: when bucket spikes past initial_cap (rare but possible
-if a config change creates many sessions with the same expiration
-bucket), `push_back` reallocates. This is rare enough that the
-"no allocations on hot path" claim is honest for the common case.
+Construction memory cost: 256 × 24 B = 6 KB. Steady state: bucket
+buffers grow to fit avg load × geometric headroom. For typical
+100K × 30s workloads, ~30 active buckets × 3K × 248 B = ~22 MB.
 
 ### Files touched
 
@@ -395,28 +449,38 @@ continue to pass.
 
 ## Risk
 
-**Medium-low.**
+**Medium.**
 
-- Wheel is purely an index; sessions HashMap is authoritative.
-- Lazy-delete is correct: we re-check actual expiration on pop.
-- Long-timeout fallback (re-bucket past the wheel cap) tested.
-- Per-tick cap bounds the spike.
+- Wheel is purely an index; `sessions` HashMap is authoritative
+  state.
+- Stale-duplicate vs. canonical pop is decided by
+  `entry.wheel_tick == scheduled_tick`. Long-timeout entries get
+  re-bucketed correctly per the algorithm in §"Per-tick GC work".
+- Memory growth scales with sessions × distinct expiration ticks
+  visited per session. For typical workloads that's ≤MB; for
+  pathological dense-throughput workloads it grows toward GB
+  scale. #964's slab is the right place to fix this; #965 ships
+  with this caveat documented.
+- `wheel_tick: u64` adds 8 B to `SessionEntry`. At 100K sessions
+  ≈ 800 KB. Acceptable.
 
 Risk areas:
-- `touch` / `lookup_with_origin` are hot — they currently just
-  update `last_seen_ns` in-place. After this PR they ALSO push to
-  a wheel bucket. The push is `VecDeque::push_back` on a
-  preallocated Box<[VecDeque; 256]>. No allocations on the hot
-  path (the VecDeques start empty and grow as needed; capacity
-  hints can avoid allocations under steady-state).
+- `touch` / `lookup_with_origin` add a wheel push when the
+  expiration tick changes. Same-tick touches are no-ops. The push
+  is amortized O(1) `VecDeque::push_back` with occasional
+  reallocation during bucket warm-up.
 
 ## Out of scope
 
-- #964 (slab + integer handles): keep `sessions: FxHashMap<SessionKey, SessionEntry>`.
-  The wheel uses `SessionKey` as the bucket payload. After #964,
-  the wheel can switch to `SlotHandle` payload (smaller, faster).
-- Multi-level wheels (hashed timing wheels): single wheel + per-tick
-  cap is enough for the bounds we need. Multi-level is a follow-up
-  if profiling shows the cap deferral causes work pile-up.
+- #964 (slab + integer handles): `sessions` stays as
+  `FxHashMap<SessionKey, SessionEntry>`. The wheel uses
+  `WheelEntry { SessionKey, scheduled_tick }` as the bucket
+  payload. After #964, the payload becomes
+  `WheelEntry { SlotHandle, scheduled_tick }` — same structure,
+  ~30× smaller. The path between #965 and #964 is mechanical.
+- Multi-level wheels (hashed timing wheels): the single wheel +
+  re-bucket-on-still-alive is enough for the typical 100K-session
+  / ≤300 s timeout case. Multi-level is a follow-up if profiling
+  shows the per-bucket spike (≤7 ms at 1M sessions) is an issue.
 - Per-protocol expire policy refactor: timeouts are still computed
-  from `key.protocol` and `tcp_flags` at insert time.
+  from `key.protocol` and `tcp_flags` at insert/update time.

--- a/docs/pr/965-session-gc-timer-wheel/plan.md
+++ b/docs/pr/965-session-gc-timer-wheel/plan.md
@@ -776,8 +776,21 @@ continue to pass.
 1. `cargo build --release` clean.
 2. `cargo test --release` ≥ baseline (851 post-#921) + 11 new = 862.
 3. Cluster smoke (HARD): no regression on the unloaded-session path.
-   - iperf-c P=12 ≥ 22 Gb/s
-   - iperf-c P=1 ≥ 6 Gb/s
+   Run on `loss:xpf-userspace-fw0/fw1` (the userspace-dp HA cluster
+   that is the default deploy target — NOT the legacy eBPF
+   `bpfrx-fw0/fw1` cluster) AND with CoS configured on every iperf3
+   forwarding-class. CoS state is wiped by `cluster-deploy`, so the
+   smoke runner must re-apply CoS classes before measurement.
+   - Apply CoS config covering all configured forwarding classes
+     (best-effort, expedited-forwarding, assured-forwarding, etc.)
+     before the first iperf3 run.
+   - iperf-c P=12 ≥ 22 Gb/s, repeated once per CoS class. Each run
+     must hit the gate independently.
+   - iperf-c P=1 ≥ 6 Gb/s, repeated once per CoS class.
+   - Verify `show class-of-service interface` reports the expected
+     class queues are non-zero on the egress side; an iperf3 run
+     that never lights up the queue counter is a config-misapplied
+     smoke that doesn't validate the CoS path.
 4. **Mouse-latency gate** — TWO synthetic workloads (per Codex
    round-5 #2 + round-6 #4 / #5). The numbers below are the
    single source of truth; any other section that mentions "the

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -20,8 +20,20 @@ const OTHER_SESSION_TIMEOUT_NS: u64 = 30_000_000_000;
 // pop; see plan docs/pr/965-session-gc-timer-wheel/plan.md.
 const WHEEL_BUCKETS: usize = 256;
 const WHEEL_MASK: u64 = (WHEEL_BUCKETS as u64) - 1;
-const WHEEL_TICK_NS: u64 = 1_000_000_000;
+// Wheel tick must equal the GC interval — `expire_stale_entries`
+// is gated by `SESSION_GC_INTERVAL_NS` and the cursor advances one
+// bucket per tick. If these diverge the cadence math gets silently
+// out of sync (Copilot review: bind WHEEL_TICK_NS to the gate).
+const WHEEL_TICK_NS: u64 = SESSION_GC_INTERVAL_NS;
 const FAR_FUTURE_OFFSET: u64 = (WHEEL_BUCKETS as u64) - 1;
+// Compile-time invariant: bucket_for_tick uses `tick & WHEEL_MASK`
+// which only computes `tick % WHEEL_BUCKETS` correctly when
+// WHEEL_BUCKETS is a power of two (Copilot review: footgun if
+// someone changes the bucket count without updating the helper).
+const _: () = assert!(
+    WHEEL_BUCKETS.is_power_of_two(),
+    "WHEEL_BUCKETS must be a power of two for the WHEEL_MASK trick to compute tick % WHEEL_BUCKETS",
+);
 
 #[inline]
 fn bucket_for_tick(tick: u64) -> usize {
@@ -50,7 +62,9 @@ struct WheelEntry {
 
 struct SessionWheel {
     buckets: Box<[VecDeque<WheelEntry>]>,
-    base_tick: u64,
+    /// Absolute tick of the next bucket to pop. Advances 1 per
+    /// elapsed wheel tick during `expire_stale_entries`. The bucket
+    /// index is `cursor_tick & WHEEL_MASK`.
     cursor_tick: u64,
     initialized: bool,
 }
@@ -63,7 +77,6 @@ impl SessionWheel {
         }
         Self {
             buckets: buckets.into_boxed_slice(),
-            base_tick: 0,
             cursor_tick: 0,
             initialized: false,
         }
@@ -363,9 +376,7 @@ impl SessionTable {
     #[inline]
     fn wheel_observe(&mut self, now_ns: u64) {
         if !self.wheel.initialized {
-            let now_tick = now_ns / WHEEL_TICK_NS;
-            self.wheel.base_tick = now_tick;
-            self.wheel.cursor_tick = now_tick;
+            self.wheel.cursor_tick = now_ns / WHEEL_TICK_NS;
             self.wheel.initialized = true;
         }
     }
@@ -533,15 +544,23 @@ impl SessionTable {
                 } else {
                     // Case 4: still alive — long-timeout (>= 256s) case
                     // or a session re-scheduled to exactly this tick.
-                    // Re-bucket at the new absolute target tick.
+                    // Re-bucket at the new absolute target tick. The
+                    // entry was just read via `self.sessions.get(&key)`
+                    // immediately above with no intervening mutation,
+                    // so `get_mut(&key)` is a hard invariant — use
+                    // `expect` instead of `if let Some` so an invariant
+                    // violation surfaces loudly instead of silently
+                    // pushing a stale-tick wheel entry (Copilot review).
                     let new_target_tick = target_tick_for(
                         now_ns,
                         entry.last_seen_ns.saturating_add(entry.expires_after_ns),
                     );
                     let new_bucket = bucket_for_tick(new_target_tick);
-                    if let Some(entry_mut) = self.sessions.get_mut(&key) {
-                        entry_mut.wheel_tick = new_target_tick;
-                    }
+                    let entry_mut = self
+                        .sessions
+                        .get_mut(&key)
+                        .expect("entry was just read via .get(); no concurrent mutation");
+                    entry_mut.wheel_tick = new_target_tick;
                     self.wheel.buckets[new_bucket].push_back(WheelEntry {
                         key,
                         scheduled_tick: new_target_tick,
@@ -551,7 +570,6 @@ impl SessionTable {
             }
             self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
         }
-        self.wheel.base_tick = now_tick;
         let expired = expired_entries.len() as u64;
         self.expired = self.expired.saturating_add(expired);
         expired_entries

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -14,6 +14,62 @@ const DEFAULT_UDP_SESSION_TIMEOUT_NS: u64 = 60_000_000_000;
 const DEFAULT_ICMP_SESSION_TIMEOUT_NS: u64 = 60_000_000_000;
 const OTHER_SESSION_TIMEOUT_NS: u64 = 30_000_000_000;
 
+// #965: bucketed timer-wheel session GC.
+// 256 buckets x 1-second ticks = 256-second window. Long-timeout
+// sessions (> 256 s) re-bucket via the FAR_FUTURE_OFFSET path on
+// pop; see plan docs/pr/965-session-gc-timer-wheel/plan.md.
+const WHEEL_BUCKETS: usize = 256;
+const WHEEL_MASK: u64 = (WHEEL_BUCKETS as u64) - 1;
+const WHEEL_TICK_NS: u64 = 1_000_000_000;
+const FAR_FUTURE_OFFSET: u64 = (WHEEL_BUCKETS as u64) - 1;
+
+#[inline]
+fn bucket_for_tick(tick: u64) -> usize {
+    (tick & WHEEL_MASK) as usize
+}
+
+/// Compute the absolute wheel tick at which an entry expiring at
+/// `expiration_ns` should be checked, given the current `now_ns`.
+/// Floors the expiration to a tick boundary; entries past their
+/// expiration land in the current tick (delta=0), entries in the
+/// far future are clamped to FAR_FUTURE_OFFSET ticks ahead and get
+/// re-checked there (still-alive case triggers re-bucketing in pop).
+#[inline]
+fn target_tick_for(now_ns: u64, expiration_ns: u64) -> u64 {
+    let now_tick = now_ns / WHEEL_TICK_NS;
+    let expiration_tick = expiration_ns / WHEEL_TICK_NS;
+    let delta = expiration_tick.saturating_sub(now_tick);
+    now_tick + delta.min(FAR_FUTURE_OFFSET)
+}
+
+#[derive(Clone, Debug)]
+struct WheelEntry {
+    key: SessionKey,
+    scheduled_tick: u64,
+}
+
+struct SessionWheel {
+    buckets: Box<[VecDeque<WheelEntry>]>,
+    base_tick: u64,
+    cursor_tick: u64,
+    initialized: bool,
+}
+
+impl SessionWheel {
+    fn new() -> Self {
+        let mut buckets: Vec<VecDeque<WheelEntry>> = Vec::with_capacity(WHEEL_BUCKETS);
+        for _ in 0..WHEEL_BUCKETS {
+            buckets.push(VecDeque::new());
+        }
+        Self {
+            buckets: buckets.into_boxed_slice(),
+            base_tick: 0,
+            cursor_tick: 0,
+            initialized: false,
+        }
+    }
+}
+
 /// Configurable session timeout values (in nanoseconds).
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SessionTimeouts {
@@ -90,6 +146,11 @@ struct SessionEntry {
     last_seen_ns: u64,
     expires_after_ns: u64,
     closing: bool,
+    /// #965: absolute wheel tick at which this session is scheduled to
+    /// be checked for expiration. Updated on every push to the wheel.
+    /// A WheelEntry whose `scheduled_tick != entry.wheel_tick` is a
+    /// stale duplicate (lazy-delete discriminator).
+    wheel_tick: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -231,6 +292,9 @@ pub(crate) struct SessionTable {
     create_drops: u64,
     delta_drops: u64,
     delta_drained: u64,
+    /// #965: bucketed timer wheel that mirrors `sessions`. Pop one
+    /// bucket per tick (1 s) instead of scanning the whole HashMap.
+    wheel: SessionWheel,
 }
 
 impl SessionTable {
@@ -250,6 +314,61 @@ impl SessionTable {
             create_drops: 0,
             delta_drops: 0,
             delta_drained: 0,
+            wheel: SessionWheel::new(),
+        }
+    }
+
+    /// #965: lazily initialize the wheel cursor to the first observed
+    /// `now_ns`. SessionTable::new() does not have a `now_ns`, so we
+    /// must initialize on the first call to any method that takes one.
+    /// Without this, `now_tick = now_ns / TICK_NS` can be billions
+    /// (monotonic time) and the pop loop would walk billions of empty
+    /// buckets on the first GC.
+    #[inline]
+    fn wheel_observe(&mut self, now_ns: u64) {
+        if !self.wheel.initialized {
+            let now_tick = now_ns / WHEEL_TICK_NS;
+            self.wheel.base_tick = now_tick;
+            self.wheel.cursor_tick = now_tick;
+            self.wheel.initialized = true;
+        }
+    }
+
+    /// #965: schedule (or re-schedule) `key` for an expiration check
+    /// at the tick implied by its `last_seen_ns + expires_after_ns`.
+    /// Throttled: only pushes when the canonical wheel tick changes,
+    /// so per-second touches within the same tick produce zero new
+    /// wheel entries.
+    ///
+    /// MUST be called only AFTER `last_seen_ns` / `expires_after_ns`
+    /// have been written and the &mut borrow on `self.sessions` has
+    /// dropped — otherwise the borrow checker will reject the
+    /// `self.wheel.buckets[bucket].push_back(...)` line because it
+    /// aliases `self` through both `self.sessions` and `self.wheel`.
+    #[inline]
+    fn push_to_wheel(&mut self, key: &SessionKey, now_ns: u64) {
+        self.wheel_observe(now_ns);
+        let new_tick = match self.sessions.get_mut(key) {
+            Some(entry) => {
+                let nt = target_tick_for(
+                    now_ns,
+                    entry.last_seen_ns.saturating_add(entry.expires_after_ns),
+                );
+                if nt != entry.wheel_tick {
+                    entry.wheel_tick = nt;
+                    Some(nt)
+                } else {
+                    None
+                }
+            }
+            None => return,
+        };
+        if let Some(tick) = new_tick {
+            let bucket = bucket_for_tick(tick);
+            self.wheel.buckets[bucket].push_back(WheelEntry {
+                key: key.clone(),
+                scheduled_tick: tick,
+            });
         }
     }
 
@@ -271,69 +390,123 @@ impl SessionTable {
     /// Used by the flow cache to amortize session keepalive.
     #[inline]
     pub fn touch(&mut self, key: &SessionKey, now_ns: u64) {
-        if let Some(entry) = self.sessions.get_mut(key) {
-            entry.last_seen_ns = now_ns;
+        if self.sessions.get_mut(key).is_some_and(|e| {
+            e.last_seen_ns = now_ns;
+            true
+        }) {
+            self.push_to_wheel(key, now_ns);
         }
     }
 
+    /// #965: GC pass over the timer wheel.
+    ///
+    /// Replaces the prior O(N) scan over `self.sessions` with a wheel
+    /// pop. For each tick that has elapsed since the last call (up to
+    /// `now_ns / WHEEL_TICK_NS`), drain the bucket at the current
+    /// cursor and process its entries via the lazy-delete discriminator:
+    ///
+    ///   1. Entry gone (HashMap miss) → drop.
+    ///   2. Stale duplicate (`wheel_tick != scheduled_tick`) → drop.
+    ///   3. Expired (`now > last_seen + expires_after`) → remove,
+    ///      emit delta + ExpiredSession.
+    ///   4. Still alive → re-bucket at the new absolute target tick.
+    ///
+    /// See docs/pr/965-session-gc-timer-wheel/plan.md for the full
+    /// algorithm and complexity analysis.
     pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
         if self.last_gc_ns != 0 && now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
             return Vec::new();
         }
         self.last_gc_ns = now_ns;
-        let stale = self
-            .sessions
-            .iter()
-            .filter_map(|(key, entry)| {
+        self.wheel_observe(now_ns);
+        let now_tick = now_ns / WHEEL_TICK_NS;
+        let mut expired_entries: Vec<ExpiredSession> = Vec::new();
+        while self.wheel.cursor_tick < now_tick {
+            let bucket_idx = bucket_for_tick(self.wheel.cursor_tick);
+            // Drain the bucket allocation-free: snapshot the length
+            // before iterating, then `pop_front` exactly that many
+            // times. Re-pushes targeting THIS bucket land at the back
+            // of the VecDeque and are not popped during this BUCKET
+            // drain (re-pushes into LATER buckets the outer loop
+            // visits will be popped within the same call — by design).
+            let due_count = self.wheel.buckets[bucket_idx].len();
+            for _ in 0..due_count {
+                let WheelEntry { key, scheduled_tick } = self.wheel.buckets[bucket_idx]
+                    .pop_front()
+                    .expect("len snapshot bounds the iteration");
+                // Case 1: entry already removed elsewhere — drop hint.
+                let Some(entry) = self.sessions.get(&key) else {
+                    continue;
+                };
+                // Case 2: stale duplicate — entry's canonical wheel_tick
+                // has advanced past this scheduled_tick, so the new tick
+                // already has its own wheel entry. Drop.
+                if entry.wheel_tick != scheduled_tick {
+                    continue;
+                }
+                // Case 3 vs 4: canonical entry. Match today's strict `>`
+                // expiration semantics.
                 if now_ns.saturating_sub(entry.last_seen_ns) > entry.expires_after_ns {
-                    Some(key.clone())
+                    if let Some(removed) = self.remove_entry(&key) {
+                        let decision = removed.decision;
+                        let metadata = removed.metadata;
+                        if key.protocol == PROTO_TCP {
+                            debug_log!(
+                                "SESS_EXPIRE: proto=TCP {}:{} -> {}:{} closing={} age_ns={} timeout_ns={} rev={} origin={} nat=({:?},{:?})",
+                                key.src_ip,
+                                key.src_port,
+                                key.dst_ip,
+                                key.dst_port,
+                                removed.closing,
+                                now_ns.saturating_sub(removed.last_seen_ns),
+                                removed.expires_after_ns,
+                                metadata.is_reverse,
+                                removed.origin.as_str(),
+                                decision.nat.rewrite_src,
+                                decision.nat.rewrite_dst,
+                            );
+                        }
+                        if !metadata.is_reverse
+                            && !removed.origin.is_peer_synced()
+                            && !removed.origin.is_transient_local_seed()
+                        {
+                            self.push_delta(SessionDelta {
+                                kind: SessionDeltaKind::Close,
+                                key: key.clone(),
+                                decision,
+                                metadata: metadata.clone(),
+                                origin: removed.origin,
+                                fabric_redirect_sync: false,
+                            });
+                        }
+                        expired_entries.push(ExpiredSession {
+                            key,
+                            decision,
+                            metadata,
+                            origin: removed.origin,
+                        });
+                    }
                 } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        let mut expired_entries = Vec::with_capacity(stale.len());
-        for key in &stale {
-            if let Some(entry) = self.remove_entry(key) {
-                let decision = entry.decision;
-                let metadata = entry.metadata;
-                if key.protocol == PROTO_TCP {
-                    debug_log!(
-                        "SESS_EXPIRE: proto=TCP {}:{} -> {}:{} closing={} age_ns={} timeout_ns={} rev={} origin={} nat=({:?},{:?})",
-                        key.src_ip,
-                        key.src_port,
-                        key.dst_ip,
-                        key.dst_port,
-                        entry.closing,
-                        now_ns.saturating_sub(entry.last_seen_ns),
-                        entry.expires_after_ns,
-                        metadata.is_reverse,
-                        entry.origin.as_str(),
-                        decision.nat.rewrite_src,
-                        decision.nat.rewrite_dst,
+                    // Case 4: still alive — long-timeout (>= 256s) case
+                    // or a session re-scheduled to exactly this tick.
+                    // Re-bucket at the new absolute target tick.
+                    let new_target_tick = target_tick_for(
+                        now_ns,
+                        entry.last_seen_ns.saturating_add(entry.expires_after_ns),
                     );
-                }
-                if !metadata.is_reverse
-                    && !entry.origin.is_peer_synced()
-                    && !entry.origin.is_transient_local_seed()
-                {
-                    self.push_delta(SessionDelta {
-                        kind: SessionDeltaKind::Close,
-                        key: key.clone(),
-                        decision,
-                        metadata: metadata.clone(),
-                        origin: entry.origin,
-                        fabric_redirect_sync: false,
+                    let new_bucket = bucket_for_tick(new_target_tick);
+                    if let Some(entry_mut) = self.sessions.get_mut(&key) {
+                        entry_mut.wheel_tick = new_target_tick;
+                    }
+                    self.wheel.buckets[new_bucket].push_back(WheelEntry {
+                        key,
+                        scheduled_tick: new_target_tick,
                     });
                 }
-                expired_entries.push(ExpiredSession {
-                    key: key.clone(),
-                    decision,
-                    metadata,
-                    origin: entry.origin,
-                });
             }
+            self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
         }
+        self.wheel.base_tick = now_tick;
         let expired = expired_entries.len() as u64;
         self.expired = self.expired.saturating_add(expired);
         expired_entries
@@ -367,7 +540,16 @@ impl SessionTable {
         } else {
             return None;
         };
-        self.sessions.get_mut(&actual_key).map(|entry| {
+        // Pre-compute the timeout before borrowing &mut self.sessions
+        // so the inner block doesn't need to access self.timeouts.
+        let timeouts = self.timeouts;
+        // Scope the &mut self.sessions borrow so it ends BEFORE we
+        // touch self.wheel via push_to_wheel. Without this scoping
+        // the closure form `self.sessions.get_mut(...).map(|entry| { ... })`
+        // would hold &mut self via self.sessions and conflict with
+        // a second &mut self via self.wheel.
+        let result = {
+            let entry = self.sessions.get_mut(&actual_key)?;
             if matches!(key.protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0 {
                 if !entry.closing {
                     debug_log!(
@@ -391,7 +573,7 @@ impl SessionTable {
             entry.expires_after_ns = if matches!(key.protocol, PROTO_TCP) && entry.closing {
                 TCP_CLOSING_TIMEOUT_NS
             } else {
-                session_timeout_ns(key.protocol, tcp_flags, &self.timeouts)
+                session_timeout_ns(key.protocol, tcp_flags, &timeouts)
             };
             (
                 SessionLookup {
@@ -400,7 +582,14 @@ impl SessionTable {
                 },
                 entry.origin,
             )
-        })
+        }; // <-- &mut self.sessions borrow ends here
+        // Push the canonical key (NOT the alias `key`) into the wheel.
+        // push_to_wheel re-reads the entry to compute the throttled
+        // target_tick, so a second HashMap lookup is needed; that
+        // matches the model in the plan (~100 ns per FxHashMap lookup
+        // on the hot path).
+        self.push_to_wheel(&actual_key, now_ns);
+        Some(result)
     }
 
     pub fn find_forward_nat_match(&self, reply_key: &SessionKey) -> Option<ForwardSessionMatch> {
@@ -491,9 +680,12 @@ impl SessionTable {
                 last_seen_ns: now_ns,
                 expires_after_ns: session_timeout_ns(protocol, tcp_flags, &self.timeouts),
                 closing: matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0,
+                wheel_tick: 0,
             },
         );
         self.index_forward_nat_key(&key, decision, &metadata);
+        // #965: schedule the new entry for expiration check.
+        self.push_to_wheel(&key, now_ns);
         if !metadata.is_reverse && !origin.is_peer_synced() && !origin.is_transient_local_seed() {
             self.push_delta(SessionDelta {
                 kind: SessionDeltaKind::Open,
@@ -561,9 +753,12 @@ impl SessionTable {
                 last_seen_ns: now_ns,
                 expires_after_ns: session_timeout_ns(protocol, tcp_flags, &self.timeouts),
                 closing: matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0,
+                wheel_tick: 0,
             },
         );
         self.index_forward_nat_key(&index_key, decision, &metadata);
+        // #965: schedule the synced entry for expiration check.
+        self.push_to_wheel(&index_key, now_ns);
         true
     }
 
@@ -613,6 +808,10 @@ impl SessionTable {
         entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
         entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0;
         self.restore_entry(key.clone(), entry);
+        // #965: schedule the refreshed entry. Last_seen / expires_after
+        // were rewritten above; push_to_wheel is throttled and will only
+        // emit a new wheel entry if the canonical tick changed.
+        self.push_to_wheel(key, now_ns);
         // Emit open delta when promoting a peer-synced entry to local
         if was_peer_synced && !origin.is_peer_synced() && !metadata.is_reverse {
             self.push_delta(SessionDelta {
@@ -699,6 +898,8 @@ impl SessionTable {
         entry.install_epoch = self.next_epoch();
         entry.last_seen_ns = now_ns;
         self.restore_entry(key.clone(), entry);
+        // #965: schedule the refreshed entry for expiration check.
+        self.push_to_wheel(key, now_ns);
         true
     }
 
@@ -1237,6 +1438,369 @@ mod tests {
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].kind, SessionDeltaKind::Close);
         assert_eq!(deltas[0].key, key);
+    }
+
+    // === #965 timer-wheel tests =================================
+
+    fn make_v4_key(src_octet: u8, port: u16) -> SessionKey {
+        SessionKey {
+            addr_family: 2,
+            protocol: PROTO_UDP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, src_octet)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            src_port: port,
+            dst_port: 53,
+        }
+    }
+
+    /// Wheel pop expires an entry whose bucket the cursor advances past.
+    #[test]
+    fn wheel_pops_expired_entry_from_bucket() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // UDP default timeout is 60 s. Advance past it; bypass GC gate.
+        let advance = install_ns + 65 * WHEEL_TICK_NS;
+        table.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(advance);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].key, key);
+        assert!(table.lookup(&key, advance + 1_000_000, 0).is_none());
+    }
+
+    /// A touched entry is not popped from the wheel — its canonical
+    /// wheel_tick advanced, so the old bucket entry is dropped as stale
+    /// and the new bucket holds the live entry.
+    #[test]
+    fn wheel_skips_touched_entry() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // Touch at install_ns + 30s — pushes the expiration target tick
+        // forward by 30 (from install+60 to install+90).
+        let touch_ns = install_ns + 30 * WHEEL_TICK_NS;
+        table.touch(&key, touch_ns);
+        // Advance past the ORIGINAL bucket (install+60) but not past
+        // the new one (install+90). Bypass GC gate.
+        let advance = install_ns + 65 * WHEEL_TICK_NS;
+        table.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(advance);
+        assert!(
+            expired.is_empty(),
+            "touched session should not expire yet; got {:?}",
+            expired
+        );
+        assert!(table.lookup(&key, advance + 1_000_000, 0).is_some());
+    }
+
+    /// A timeout > 256 s lands in the FAR_FUTURE bucket; when popped,
+    /// re-checks expiration and re-buckets if still alive.
+    #[test]
+    fn wheel_handles_long_timeout_via_far_future_bucket() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        // 7200 s timeout — far longer than the 256-s wheel.
+        let long_timeout_secs = 7200u64;
+        let mut t = SessionTimeouts::default();
+        t.udp_ns = long_timeout_secs * WHEEL_TICK_NS;
+        table.set_timeouts(t);
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // Advance 300 s — past one full rotation but well before the
+        // real timeout. Bypass GC gate at every check.
+        let advance = install_ns + 300 * WHEEL_TICK_NS;
+        table.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(advance);
+        assert!(
+            expired.is_empty(),
+            "long-timeout session must not expire prematurely"
+        );
+        // Advance past the real timeout — should now expire.
+        let final_advance = install_ns + (long_timeout_secs + 5) * WHEEL_TICK_NS;
+        table.last_gc_ns = final_advance - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(final_advance);
+        assert_eq!(expired.len(), 1);
+    }
+
+    /// Entry with `expires_after = WHEEL_BUCKETS * TICK_NS` lands in
+    /// the FAR_FUTURE bucket (now_tick + 255), not the current bucket.
+    #[test]
+    fn wheel_handles_exact_256s_timeout() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        let mut t = SessionTimeouts::default();
+        t.udp_ns = (WHEEL_BUCKETS as u64) * WHEEL_TICK_NS; // exactly 256 s
+        table.set_timeouts(t);
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // Verify the entry's wheel_tick is install_tick + 255, NOT
+        // install_tick (which would mean "current bucket").
+        let entry = table.sessions.get(&key).expect("entry");
+        let install_tick = install_ns / WHEEL_TICK_NS;
+        assert_eq!(
+            entry.wheel_tick,
+            install_tick + FAR_FUTURE_OFFSET,
+            "256-s timeout must land in FAR_FUTURE bucket, not current"
+        );
+    }
+
+    /// First GC with a large monotonic now_ns must not walk billions
+    /// of empty buckets — wheel_observe lazily initializes cursor_tick
+    /// to the first observed now_tick.
+    #[test]
+    fn first_gc_with_large_monotonic_now_doesnt_walk_billions_of_buckets() {
+        let mut table = SessionTable::new();
+        // 10^18 ns = a typical CLOCK_MONOTONIC value after ~31 years.
+        let huge_now = 1_000_000_000_000_000_000u64;
+        // Should return immediately, no panic, no infinite loop.
+        let expired = table.expire_stale_entries(huge_now);
+        assert!(expired.is_empty());
+        // Wheel should be initialized at the huge tick.
+        assert!(table.wheel.initialized);
+        assert_eq!(table.wheel.cursor_tick, huge_now / WHEEL_TICK_NS);
+    }
+
+    /// Sub-tick precision: at exactly `last_seen + expires_after`, the
+    /// session is NOT expired (matches today's strict `>` semantics).
+    /// This test exists in addition to the v8 sub-tick lag test.
+    #[test]
+    fn expiry_boundary_strict_greater_than() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        let mut t = SessionTimeouts::default();
+        t.udp_ns = 1_000_000_000; // 1 s
+        table.set_timeouts(t);
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // Exactly at last_seen + expires_after: NOT expired.
+        let at_boundary = install_ns + 1_000_000_000;
+        table.last_gc_ns = at_boundary - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(at_boundary);
+        assert!(
+            expired.is_empty(),
+            "exact-boundary entry must not expire under strict `>`"
+        );
+    }
+
+    /// Wheel adds at most one tick of additional lag vs today's
+    /// hypothetical sub-tick scan. At +1 ns the wheel reports
+    /// not-yet-expired; at +TICK_NS+1 it reports expired.
+    #[test]
+    fn wheel_lags_today_subtick_by_at_most_one_tick() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        let mut t = SessionTimeouts::default();
+        t.udp_ns = 1_000_000_000; // 1 s
+        table.set_timeouts(t);
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // +1 ns past expiration: wheel hasn't popped the bucket yet
+        // (cursor < now_tick is still false at this sub-tick offset).
+        let just_past = install_ns + 1_000_000_000 + 1;
+        table.last_gc_ns = just_past - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(just_past);
+        assert!(
+            expired.is_empty(),
+            "wheel may lag today's sub-tick scan by up to 1 tick"
+        );
+        // +1 wheel-tick + 1 ns past expiration: wheel MUST have caught
+        // it. The cursor advances when now_tick advances.
+        let one_tick_past = install_ns + 1_000_000_000 + WHEEL_TICK_NS + 1;
+        table.last_gc_ns = one_tick_past - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(one_tick_past);
+        assert_eq!(
+            expired.len(),
+            1,
+            "wheel must pop the entry once cursor advances one tick past target"
+        );
+    }
+
+    /// Session touched 100 times within a single tick produces at most
+    /// 2 wheel entries (the initial install push + at most one re-push
+    /// if the expiration tick changed). Throttle bounds duplicates.
+    #[test]
+    fn wheel_duplicate_count_per_session_bounded() {
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let install_ns = 1_000_000_000u64;
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_ns,
+            PROTO_UDP,
+            0
+        ));
+        // Touch 100 times within the same wheel tick (sub-second).
+        for i in 0..100u64 {
+            table.touch(&key, install_ns + i * 1_000_000); // 1 ms steps
+        }
+        // Count wheel entries for this key.
+        let count: usize = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.iter().filter(|e| e.key == key).count())
+            .sum();
+        assert!(
+            count <= 2,
+            "same-tick touches should produce <=2 wheel entries; got {}",
+            count
+        );
+    }
+
+    /// 50K sessions all expiring at the same tick: a single GC call
+    /// drains all of them from the popped bucket. No per-tick cap.
+    #[test]
+    fn wheel_sustained_overload_drains_all_buckets() {
+        let mut table = SessionTable::new();
+        let install_ns = 1_000_000_000u64;
+        // Use 5K (not 50K) to keep test runtime sub-second; the
+        // assertion is about behavior shape, not absolute capacity.
+        const N: usize = 5000;
+        // Default UDP timeout is 60s. Install all sessions at the
+        // same install_ns so they share an expiration tick.
+        for i in 0..N {
+            let k = make_v4_key((i % 250) as u8, 1024 + (i / 250) as u16);
+            assert!(table.install_with_protocol(
+                k,
+                decision(),
+                metadata(),
+                install_ns,
+                PROTO_UDP,
+                0
+            ));
+        }
+        let advance = install_ns + 65 * WHEEL_TICK_NS;
+        table.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+        let expired = table.expire_stale_entries(advance);
+        assert_eq!(expired.len(), N, "all sessions must drain in one call");
+        assert_eq!(table.len(), 0);
+    }
+
+    /// Compile-only test: ensure the alias path's `lookup_with_origin`
+    /// body type-checks (the &mut self.sessions borrow is scoped before
+    /// self.wheel.buckets is touched). Codex round-3/4 caught the
+    /// `.map(|entry| { ... self.wheel ... })` shape that wouldn't
+    /// compile. This test exists to guard against future refactors
+    /// that reintroduce that shape — failure is a compile-time error
+    /// not a runtime assertion.
+    #[test]
+    fn wheel_alias_lookup_does_not_double_borrow_self() {
+        // The body of lookup_with_origin compiles iff the &mut
+        // self.sessions borrow is dropped before push_to_wheel.
+        // Existence of this test = the file compiled with the correct
+        // borrow shape.
+        let mut table = SessionTable::new();
+        let key = key_v4();
+        let now = 1_000_000_000u64;
+        // The actual lookup does the alias resolution + wheel push.
+        let _ = table.lookup_with_origin(&key, now, 0);
+    }
+
+    /// Sustained per-second touch on every session: K (entries scanned
+    /// per popped bucket) is bounded. Catches a regression where touch
+    /// inadvertently adds multiple wheel entries per call.
+    ///
+    /// This is the per-second-touch K-bound from §Acceptance gate 4b.
+    #[test]
+    fn wheel_per_second_touch_bounds_k_per_bucket() {
+        let mut table = SessionTable::new();
+        const N: usize = 1000;
+        let install_ns = 1_000_000_000u64;
+        // Install N sessions.
+        let keys: Vec<SessionKey> = (0..N)
+            .map(|i| make_v4_key((i % 250) as u8, 1024 + (i / 250) as u16))
+            .collect();
+        for k in &keys {
+            assert!(table.install_with_protocol(
+                k.clone(),
+                decision(),
+                metadata(),
+                install_ns,
+                PROTO_UDP,
+                0
+            ));
+        }
+        // Touch every session once per second for 256 seconds. After
+        // each touch round, advance the GC.
+        for tick_off in 1..=256u64 {
+            let now = install_ns + tick_off * WHEEL_TICK_NS;
+            for k in &keys {
+                table.touch(k, now);
+            }
+            table.last_gc_ns = now - SESSION_GC_INTERVAL_NS;
+            let _ = table.expire_stale_entries(now);
+        }
+        // Total wheel entries across all buckets should be bounded by
+        // N x 256 (the absolute ceiling, never reached because GC
+        // drains stale entries on visit).
+        let total_entries: usize = table.wheel.buckets.iter().map(|b| b.len()).sum();
+        assert!(
+            total_entries <= N * (WHEEL_BUCKETS - 1) + N,
+            "wheel entries should be bounded by N x WHEEL_BUCKETS; got {}",
+            total_entries
+        );
+        // Per-bucket K (max) under per-second-touch on every session
+        // is bounded by N (after one full rotation). With 20% headroom
+        // matches §Acceptance gate 4b's K <= 12,000 bound at N=10K.
+        let max_bucket = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.len())
+            .max()
+            .unwrap_or(0);
+        assert!(
+            max_bucket <= (N as f64 * 1.2) as usize,
+            "max K per bucket must be bounded by ~N; got {} (N={})",
+            max_bucket,
+            N
+        );
     }
 
     #[test]

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -70,6 +70,28 @@ impl SessionWheel {
     }
 }
 
+/// Per-call statistics for `expire_stale_entries` pop work, used by
+/// the timer-wheel unit tests to assert K-bounds and entry
+/// classification under specific synthetic workloads. Fields are
+/// accumulated over all buckets popped in a single call.
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct WheelPopStats {
+    /// Total `WheelEntry`s scanned (popped from a bucket and
+    /// classified) during the call.
+    pub(crate) scanned: usize,
+    /// Entries dropped because the canonical key is no longer in
+    /// `sessions` (already removed by another path).
+    pub(crate) dropped_gone: usize,
+    /// Entries dropped because `wheel_tick != scheduled_tick` (a
+    /// fresher entry has superseded this one).
+    pub(crate) dropped_stale: usize,
+    /// Entries that actually expired and were removed.
+    pub(crate) expired: usize,
+    /// Entries that were re-bucketed (long-timeout / not yet
+    /// expired).
+    pub(crate) re_bucketed: usize,
+}
+
 /// Configurable session timeout values (in nanoseconds).
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SessionTimeouts {
@@ -295,6 +317,12 @@ pub(crate) struct SessionTable {
     /// #965: bucketed timer wheel that mirrors `sessions`. Pop one
     /// bucket per tick (1 s) instead of scanning the whole HashMap.
     wheel: SessionWheel,
+    /// #965: stats from the most-recent `expire_stale_entries` call.
+    /// Reset at the start of each call. Used by unit tests to assert
+    /// K-bounds and classification (scanned / dropped_stale /
+    /// dropped_gone / expired / re_bucketed). Accumulator overhead
+    /// is 4-5 increments per popped entry — sub-µs at typical loads.
+    last_pop_stats: WheelPopStats,
 }
 
 impl SessionTable {
@@ -315,7 +343,15 @@ impl SessionTable {
             delta_drops: 0,
             delta_drained: 0,
             wheel: SessionWheel::new(),
+            last_pop_stats: WheelPopStats::default(),
         }
+    }
+
+    /// #965: stats from the most-recent `expire_stale_entries` call.
+    /// Used by tests to validate K-bounds and entry classification.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn last_pop_stats(&self) -> WheelPopStats {
+        self.last_pop_stats
     }
 
     /// #965: lazily initialize the wheel cursor to the first observed
@@ -419,6 +455,8 @@ impl SessionTable {
         }
         self.last_gc_ns = now_ns;
         self.wheel_observe(now_ns);
+        // Reset per-call stats; tests read them via last_pop_stats().
+        self.last_pop_stats = WheelPopStats::default();
         let now_tick = now_ns / WHEEL_TICK_NS;
         let mut expired_entries: Vec<ExpiredSession> = Vec::new();
         while self.wheel.cursor_tick < now_tick {
@@ -434,20 +472,24 @@ impl SessionTable {
                 let WheelEntry { key, scheduled_tick } = self.wheel.buckets[bucket_idx]
                     .pop_front()
                     .expect("len snapshot bounds the iteration");
+                self.last_pop_stats.scanned += 1;
                 // Case 1: entry already removed elsewhere — drop hint.
                 let Some(entry) = self.sessions.get(&key) else {
+                    self.last_pop_stats.dropped_gone += 1;
                     continue;
                 };
                 // Case 2: stale duplicate — entry's canonical wheel_tick
                 // has advanced past this scheduled_tick, so the new tick
                 // already has its own wheel entry. Drop.
                 if entry.wheel_tick != scheduled_tick {
+                    self.last_pop_stats.dropped_stale += 1;
                     continue;
                 }
                 // Case 3 vs 4: canonical entry. Match today's strict `>`
                 // expiration semantics.
                 if now_ns.saturating_sub(entry.last_seen_ns) > entry.expires_after_ns {
                     if let Some(removed) = self.remove_entry(&key) {
+                        self.last_pop_stats.expired += 1;
                         let decision = removed.decision;
                         let metadata = removed.metadata;
                         if key.protocol == PROTO_TCP {
@@ -502,6 +544,7 @@ impl SessionTable {
                         key,
                         scheduled_tick: new_target_tick,
                     });
+                    self.last_pop_stats.re_bucketed += 1;
                 }
             }
             self.wheel.cursor_tick = self.wheel.cursor_tick.saturating_add(1);
@@ -1722,53 +1765,142 @@ mod tests {
         assert_eq!(table.len(), 0);
     }
 
-    /// Compile-only test: ensure the alias path's `lookup_with_origin`
-    /// body type-checks (the &mut self.sessions borrow is scoped before
-    /// self.wheel.buckets is touched). Codex round-3/4 caught the
-    /// `.map(|entry| { ... self.wheel ... })` shape that wouldn't
-    /// compile. This test exists to guard against future refactors
-    /// that reintroduce that shape — failure is a compile-time error
-    /// not a runtime assertion.
+    /// Alias path: lookup_with_origin called on a NAT-translated
+    /// reverse alias key resolves to the canonical forward key (via
+    /// reverse_translated_index), then pushes the CANONICAL key into
+    /// the wheel — never the alias. Round-3/4 of plan iteration caught
+    /// that the .map(|entry| { ... self.wheel ... }) shape wouldn't
+    /// compile; this test additionally validates the runtime
+    /// invariant that the canonical key, not the alias, lands in the
+    /// wheel after a sub-tick advance.
     #[test]
-    fn wheel_alias_lookup_does_not_double_borrow_self() {
-        // The body of lookup_with_origin compiles iff the &mut
-        // self.sessions borrow is dropped before push_to_wheel.
-        // Existence of this test = the file compiled with the correct
-        // borrow shape.
+    fn wheel_alias_lookup_refreshes_canonical_key() {
         let mut table = SessionTable::new();
-        let key = key_v4();
-        let now = 1_000_000_000u64;
-        // The actual lookup does the alias resolution + wheel push.
-        let _ = table.lookup_with_origin(&key, now, 0);
+        // Install a forward session with NAT rewrite_dst so that the
+        // alias index gets populated automatically by index_forward_nat_key.
+        let canonical_key = SessionKey {
+            addr_family: 2,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 42)),
+            src_port: 5201,
+            dst_port: 42424,
+        };
+        let alias_key = SessionKey {
+            addr_family: 2,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 255, 192, 41)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            src_port: 5201,
+            dst_port: 42424,
+        };
+        let mut reverse_metadata = metadata();
+        reverse_metadata.is_reverse = true;
+        let nat = SessionDecision {
+            resolution: resolution(),
+            nat: NatDecision {
+                rewrite_dst: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+                ..NatDecision::default()
+            },
+        };
+        let install_ns = 1_000_000_000u64;
+        assert!(table.install_with_protocol(
+            canonical_key.clone(),
+            nat,
+            reverse_metadata,
+            install_ns,
+            PROTO_TCP,
+            0x10,
+        ));
+        // Sanity: install pushed the canonical key to its bucket.
+        let initial_canonical_count: usize = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.iter().filter(|e| e.key == canonical_key).count())
+            .sum();
+        assert_eq!(initial_canonical_count, 1, "install pushed canonical");
+        let initial_alias_count: usize = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.iter().filter(|e| e.key == alias_key).count())
+            .sum();
+        assert_eq!(initial_alias_count, 0, "alias key MUST NOT be in wheel");
+        // Now look up via the ALIAS, advancing the canonical entry's
+        // expiration tick by enough to cross the second-grid (so the
+        // throttle fires a new push).
+        let lookup_ns = install_ns + 2 * WHEEL_TICK_NS;
+        let hit = table.lookup_with_origin(&alias_key, lookup_ns, 0x10);
+        assert!(hit.is_some(), "alias lookup must hit");
+        // Wheel state after alias lookup: canonical key has a NEW
+        // entry (the one pushed by lookup_with_origin); alias key
+        // STILL has no entries.
+        let canonical_count: usize = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.iter().filter(|e| e.key == canonical_key).count())
+            .sum();
+        assert!(
+            canonical_count >= 2,
+            "alias lookup must push a fresh wheel entry under the canonical key; \
+             canonical_count={}",
+            canonical_count
+        );
+        let alias_count: usize = table
+            .wheel
+            .buckets
+            .iter()
+            .map(|b| b.iter().filter(|e| e.key == alias_key).count())
+            .sum();
+        assert_eq!(
+            alias_count, 0,
+            "alias key MUST never appear in any bucket; alias_count={}",
+            alias_count
+        );
     }
 
-    /// Sustained per-second touch on every session: K (entries scanned
-    /// per popped bucket) is bounded. Catches a regression where touch
-    /// inadvertently adds multiple wheel entries per call.
+    /// Sustained per-second touch on every session: K (entries
+    /// scanned per popped bucket) is bounded by N, and pop
+    /// classification matches the plan's expected pattern: every
+    /// scanned entry is a stale duplicate (entries_dropped_stale ≈ K),
+    /// no entries get re-bucketed (sessions are kept alive by
+    /// per-second touches that update wheel_tick), and no entries
+    /// expire.
     ///
-    /// This is the per-second-touch K-bound from §Acceptance gate 4b.
+    /// This is the per-second-touch K-bound from §Acceptance gate 4b
+    /// (corrected per Codex round-7 #2 classifications and round-12
+    /// instrumentation requirement).
+    ///
+    /// Test scale: N = 1000 (smaller than the 10K plan target to keep
+    /// CI runtime under 1 s; the assertion shape is what matters).
     #[test]
     fn wheel_per_second_touch_bounds_k_per_bucket() {
         let mut table = SessionTable::new();
         const N: usize = 1000;
         let install_ns = 1_000_000_000u64;
-        // Install N sessions.
+        // Install N sessions, each at a distinct sub-tick install
+        // offset so they spread across buckets after warm-up.
         let keys: Vec<SessionKey> = (0..N)
             .map(|i| make_v4_key((i % 250) as u8, 1024 + (i / 250) as u16))
             .collect();
-        for k in &keys {
+        for (i, k) in keys.iter().enumerate() {
             assert!(table.install_with_protocol(
                 k.clone(),
                 decision(),
                 metadata(),
-                install_ns,
+                install_ns + (i as u64) * 1_000, // 1 µs spacing
                 PROTO_UDP,
                 0
             ));
         }
-        // Touch every session once per second for 256 seconds. After
-        // each touch round, advance the GC.
-        for tick_off in 1..=256u64 {
+        // Warm-up: touch every session once per tick for ≥ 300 ticks
+        // so the wheel reaches steady state under per-second touch on
+        // every session. After each touch round, run GC at the
+        // matching tick.
+        const WARMUP_TICKS: u64 = 300;
+        for tick_off in 1..=WARMUP_TICKS {
             let now = install_ns + tick_off * WHEEL_TICK_NS;
             for k in &keys {
                 table.touch(k, now);
@@ -1776,30 +1908,119 @@ mod tests {
             table.last_gc_ns = now - SESSION_GC_INTERVAL_NS;
             let _ = table.expire_stale_entries(now);
         }
-        // Total wheel entries across all buckets should be bounded by
-        // N x 256 (the absolute ceiling, never reached because GC
-        // drains stale entries on visit).
-        let total_entries: usize = table.wheel.buckets.iter().map(|b| b.len()).sum();
+        // Measurement tick: advance one more, capture the next pop's
+        // stats via last_pop_stats().
+        let measure_now = install_ns + (WARMUP_TICKS + 1) * WHEEL_TICK_NS;
+        for k in &keys {
+            table.touch(k, measure_now);
+        }
+        table.last_gc_ns = measure_now - SESSION_GC_INTERVAL_NS;
+        let _ = table.expire_stale_entries(measure_now);
+        let stats = table.last_pop_stats();
+
+        // §Acceptance gate 4b classifications under sustained per-
+        // second touch: every popped entry is stale duplicate, no
+        // re-bucketing, no expirations.
         assert!(
-            total_entries <= N * (WHEEL_BUCKETS - 1) + N,
-            "wheel entries should be bounded by N x WHEEL_BUCKETS; got {}",
-            total_entries
+            stats.scanned > 0,
+            "must have scanned entries; stats={:?}",
+            stats
         );
-        // Per-bucket K (max) under per-second-touch on every session
-        // is bounded by N (after one full rotation). With 20% headroom
-        // matches §Acceptance gate 4b's K <= 12,000 bound at N=10K.
-        let max_bucket = table
-            .wheel
-            .buckets
-            .iter()
-            .map(|b| b.len())
-            .max()
-            .unwrap_or(0);
+        // K bound: scanned ≤ N × 1.2 (20 % headroom — a 2× duplicate-
+        // push regression would scan >2 N and fail this).
+        let k_bound = (N as f64 * 1.2) as usize;
         assert!(
-            max_bucket <= (N as f64 * 1.2) as usize,
-            "max K per bucket must be bounded by ~N; got {} (N={})",
-            max_bucket,
-            N
+            stats.scanned <= k_bound,
+            "K (scanned) must be bounded by N×1.2 = {}; got scanned={} stats={:?}",
+            k_bound,
+            stats.scanned,
+            stats
+        );
+        // No re-bucketing under sustained-per-tick touch: each
+        // session's canonical wheel_tick advances every tick, so all
+        // popped entries with stale `scheduled_tick != wheel_tick`
+        // hit the dropped_stale path, not re-bucket.
+        assert_eq!(
+            stats.re_bucketed, 0,
+            "expected 0 re-bucketed under per-second touch; stats={:?}",
+            stats
+        );
+        assert_eq!(
+            stats.expired, 0,
+            "expected 0 expirations under per-second touch; stats={:?}",
+            stats
+        );
+        // dropped_stale + dropped_gone + expired + re_bucketed = scanned.
+        assert_eq!(
+            stats.dropped_stale + stats.dropped_gone + stats.expired + stats.re_bucketed,
+            stats.scanned,
+            "case classification must sum to scanned; stats={:?}",
+            stats
+        );
+        // dropped_stale dominates (the lazy-delete discriminator is
+        // the right path for this workload).
+        assert!(
+            stats.dropped_stale >= stats.scanned * 9 / 10,
+            "expected dropped_stale ≈ scanned (≥90 %); stats={:?}",
+            stats
+        );
+    }
+
+    /// Across one full wheel rotation under sustained per-second
+    /// touch, the total number of entries scanned ≈ 256 × N (every
+    /// bucket pops N stale duplicates). Catches leakage of stale
+    /// entries that the lazy-delete discriminator should drop on
+    /// visit but didn't.
+    #[test]
+    fn wheel_per_second_touch_total_scan_per_rotation_matches_model() {
+        let mut table = SessionTable::new();
+        const N: usize = 500;
+        let install_ns = 1_000_000_000u64;
+        let keys: Vec<SessionKey> = (0..N)
+            .map(|i| make_v4_key((i % 250) as u8, 1024 + (i / 250) as u16))
+            .collect();
+        for (i, k) in keys.iter().enumerate() {
+            assert!(table.install_with_protocol(
+                k.clone(),
+                decision(),
+                metadata(),
+                install_ns + (i as u64) * 1_000,
+                PROTO_UDP,
+                0
+            ));
+        }
+        // Warm up beyond one full rotation so steady-state holds.
+        const WARMUP_TICKS: u64 = 300;
+        for tick_off in 1..=WARMUP_TICKS {
+            let now = install_ns + tick_off * WHEEL_TICK_NS;
+            for k in &keys {
+                table.touch(k, now);
+            }
+            table.last_gc_ns = now - SESSION_GC_INTERVAL_NS;
+            let _ = table.expire_stale_entries(now);
+        }
+        // Now measure across exactly WHEEL_BUCKETS=256 ticks.
+        let mut total_scanned = 0usize;
+        for tick_off in 1..=WHEEL_BUCKETS as u64 {
+            let now = install_ns + (WARMUP_TICKS + tick_off) * WHEEL_TICK_NS;
+            for k in &keys {
+                table.touch(k, now);
+            }
+            table.last_gc_ns = now - SESSION_GC_INTERVAL_NS;
+            let _ = table.expire_stale_entries(now);
+            total_scanned += table.last_pop_stats().scanned;
+        }
+        // Plan §Acceptance gate 4b: total_scanned ∈ [0.9, 1.1] × 256 × N.
+        let model = WHEEL_BUCKETS * N;
+        let lower = (model as f64 * 0.9) as usize;
+        let upper = (model as f64 * 1.1) as usize;
+        assert!(
+            (lower..=upper).contains(&total_scanned),
+            "total_scanned ({}) must be within ±10% of model ({}); range [{}, {}]",
+            total_scanned,
+            model,
+            lower,
+            upper
         );
     }
 

--- a/userspace-dp/src/session.rs
+++ b/userspace-dp/src/session.rs
@@ -450,13 +450,15 @@ impl SessionTable {
     /// See docs/pr/965-session-gc-timer-wheel/plan.md for the full
     /// algorithm and complexity analysis.
     pub fn expire_stale_entries(&mut self, now_ns: u64) -> Vec<ExpiredSession> {
+        // Reset per-call stats BEFORE the gc-interval gate so that a
+        // gated no-op call returns zeroed stats rather than leftovers
+        // from a prior call (Codex impl-review round-2 non-blocking note).
+        self.last_pop_stats = WheelPopStats::default();
         if self.last_gc_ns != 0 && now_ns.saturating_sub(self.last_gc_ns) < SESSION_GC_INTERVAL_NS {
             return Vec::new();
         }
         self.last_gc_ns = now_ns;
         self.wheel_observe(now_ns);
-        // Reset per-call stats; tests read them via last_pop_stats().
-        self.last_pop_stats = WheelPopStats::default();
         let now_tick = now_ns / WHEEL_TICK_NS;
         let mut expired_entries: Vec<ExpiredSession> = Vec::new();
         while self.wheel.cursor_tick < now_tick {


### PR DESCRIPTION
## Summary

Replaces `SessionTable::expire_stale_entries`' O(N) scan with a 256-bucket timer wheel using lazy deletion. For realistic mostly-idle deployments per-tick GC cost drops from O(N) to O(N × distinct_active_ticks / 256) — a >50× latency win in the typical case. For sustained per-second touch on every session the wheel does NOT improve wall-time but bounds per-tick work; further wins live under the active-deletion / #964 slab follow-ups.

Plan: `docs/pr/965-session-gc-timer-wheel/plan.md` (PLAN-READY at v11 after 11 rounds of Codex hostile review + Gemini AGREE-TO-MERGE-PLAN).

## Implementation

- 256 buckets × 1-second ticks. Sessions with `expires_after > 256s` land in the FAR_FUTURE bucket and re-bucket on pop. `WheelEntry { key: SessionKey, scheduled_tick: u64 }` = 48 B.
- Lazy-delete discriminator: a popped `WheelEntry` whose `scheduled_tick != entry.wheel_tick` is a stale duplicate, dropped in O(1). Same-tick touches produce zero new wheel entries (`push_to_wheel` is throttled).
- Allocation-free drain: snapshot bucket len, `pop_front` exactly that many times. Same-bucket re-pushes deferred to next rotation; later-bucket re-pushes within the outer multi-tick catch-up loop are popped same call (correct).
- Sub-tick lag: today's `expire_stale_entries` is gated to 1 s by `SESSION_GC_INTERVAL_NS`; the wheel adds at most one more tick of lag depending on phase (absolute lag ≤ 2 s; additional deviation < 1 wheel-tick).
- `WheelPopStats` accumulator (scanned/dropped_gone/dropped_stale/expired/re_bucketed) reset before each call, exposed via `last_pop_stats()` for tests + ops observability.

`push_to_wheel` threaded through every site that updates `last_seen_ns`/`expires_after_ns`: `install_with_protocol_with_origin`, `upsert_synced_with_origin`, `update_session` (covers `refresh_local` + `refresh_for_ha_activation` since both delegate), `refresh_for_ha_transition`, `lookup_with_origin`, `touch`.

## Reviews

- **Plan** (11 rounds): Codex PLAN-READY at round 11; Gemini AGREE-TO-MERGE-PLAN. Major findings caught and fixed across rounds: bucket-helper / pop race (R3), `WheelEntry` size (R4), per-tick complexity model conflated `N/256` vs `K/256` (R5), 4a workload contradiction + Vec-allocation regression (R7), CoS gate ambiguity (R10).
- **Implementation** (2 rounds): Codex round-1 NEEDS-REVISION-MINOR (alias test was a no-op + K-bound test didn't measure K) → fixed via pop-stats instrumentation; Codex round-2 AGREE-TO-MERGE; Gemini AGREE-TO-MERGE-IMPL.

## Test plan

- [x] `cargo test --release`: **863 passed** (851 baseline + 12 new wheel tests), 0 failed.
  - `wheel_pops_expired_entry_from_bucket`
  - `wheel_skips_touched_entry`
  - `wheel_handles_long_timeout_via_far_future_bucket`
  - `wheel_handles_exact_256s_timeout`
  - `first_gc_with_large_monotonic_now_doesnt_walk_billions_of_buckets`
  - `expiry_boundary_strict_greater_than`
  - `wheel_lags_today_subtick_by_at_most_one_tick`
  - `wheel_duplicate_count_per_session_bounded`
  - `wheel_sustained_overload_drains_all_buckets`
  - `wheel_alias_lookup_refreshes_canonical_key`
  - `wheel_per_second_touch_bounds_k_per_bucket`
  - `wheel_per_second_touch_total_scan_per_rotation_matches_model`
- [x] Cluster deploy to `loss:xpf-userspace-fw0/fw1`: rolling deploy successful (Phase 1 secondary, Phase 2 primary).
- [x] Per-CoS-class iperf3 smoke after re-applying `test/incus/cos-iperf-config.set`:

| Class | Port | Shape | Gate | Result | Pass |
|---|---|---|---|---|---|
| iperf-c | 5203 | 25 g | 22 Gb/s | 23.42 Gb/s | ✅ |
| iperf-f | 5206 | 19 g | 17.1 Gb/s | 18.12 Gb/s | ✅ |
| iperf-e | 5205 | 16 g | 14.4 Gb/s | 15.27 Gb/s | ✅ |
| iperf-d | 5204 | 13 g | 11.7 Gb/s | 12.41 Gb/s | ✅ |
| iperf-b | 5202 | 10 g | 9.0 Gb/s | 9.55 Gb/s | ✅ |
| iperf-a | 5201 | 1 g | 0.9 Gb/s | 0.95 Gb/s | ✅ |
| best-effort | 5207 | 100 m | 90 Mb/s | 90 Mb/s | ✅ |

- [x] Failover smoke: iperf3 -P 12 -t 90 through fw0 (primary), force-reboot fw0 at 20 s, fw1 took over in < 10 s, iperf3 survived: **22.84 Gb/s avg, 257 GB received**, fw0 came back as secondary (no auto-preempt). All correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)