### PR TITLE
#963: decompose rewrite_forwarded_frame_in_place slow-path

### DIFF
--- a/docs/pr/963-frame-builder/plan.md
+++ b/docs/pr/963-frame-builder/plan.md
@@ -1,5 +1,4 @@
-# #963: decompose rewrite_forwarded_frame_in_place (the slow-path
-# god function) into v4/v6 specialized helpers + extracted subroutines
+# #963: decompose rewrite_forwarded_frame_in_place (the slow-path god function) into v4/v6 specialized helpers + extracted subroutines
 
 Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mok8khp9-0jm235):
 

--- a/docs/pr/963-frame-builder/plan.md
+++ b/docs/pr/963-frame-builder/plan.md
@@ -1,0 +1,241 @@
+# #963: decompose rewrite_forwarded_frame_in_place (the slow-path
+# god function) into v4/v6 specialized helpers + extracted subroutines
+
+Plan v1 — 2026-04-29.
+
+## Investigation findings (Claude, on commit 430b3d93)
+
+`userspace-dp/src/afxdp/frame.rs:1560` defines
+`rewrite_forwarded_frame_in_place` — the issue's "god function". It's
+~170 lines and handles every permutation of:
+
+- L3 offset trust vs reparse (lines 1573–1576).
+- FabricRedirect vs ForwardCandidate disposition (1581–1593).
+- VLAN presence (vlan_id > 0 → eth_len = 18, else 14) (1595).
+- IPv4 vs IPv6 (matched on `meta.addr_family as i32`) (1619–1695).
+- TTL skip flag (`meta.meta_flags & 0x80`) (1618, 1628, 1650, 1670, 1684).
+- NAT apply gate (1647, 1681).
+- Port enforcement (`enforce_expected_ports`) and conditional
+  L4-checksum recompute (1659–1664, 1687–1692).
+- Debug logging (1696–1726).
+- Cfg-gated checksum verification (1728–1730).
+
+### What's already in place (don't re-build)
+
+The codebase already has the hot-path specialization #963 asks for:
+
+- `RewriteDescriptor` (`flow_cache.rs:34`) — a precomputed packet
+  rewrite plan baked at flow-cache insertion time.
+- `apply_rewrite_descriptor` (`frame.rs:1792`) — the straight-line
+  fast path that uses it. Comments explicitly call out: "Eliminates
+  per-packet branches for address family, VLAN presence, NAT type,
+  and checksum recomputation — all decisions are baked into the
+  descriptor at session/flow-cache insertion time. Scope: IPv4/IPv6
+  TCP and UDP only." (frame.rs:1779–1790)
+
+`rewrite_forwarded_frame_in_place` is the **fallback** for cases the
+descriptor doesn't cover — NAT64 (header-size change), NPTv6
+(checksum-neutral but address rewrite differs), ICMP identifier
+repair, and packets without a flow-cache entry on first sight.
+
+So #963's "god function" complaint is about the *slow path* — the
+hot path is already specialized. The fix is to decompose the slow
+path for readability and maintainability, not to add another layer
+of builder/state abstraction (that's already what the descriptor
+is).
+
+## Approach
+
+**Decision**: extract the slow path into specialized v4 / v6
+sub-functions plus a small set of named extracted helpers. No new
+struct, no builder, no trait. Just function decomposition along the
+existing branch axes.
+
+This is the minimal scope that addresses the issue:
+- Reduces the body of `rewrite_forwarded_frame_in_place` to a
+  small dispatch on address family.
+- Keeps every existing call site identical (no API change).
+- Preserves all existing tests (no behavioral change).
+- Improves I-cache locality for the v4 hot path: when a binding only
+  sees IPv4 traffic, the v6 code is cold and gets evicted from
+  I-cache instead of being interleaved.
+
+### Decomposition
+
+Extract into three private `#[inline]` helpers in `frame.rs`:
+
+```rust
+/// Common preamble: validate L3 offset, compute payload_len,
+/// resolve src_mac/vlan_id/apply_nat, write Ethernet header,
+/// shift payload to its new position.
+///
+/// Returns (eth_len, ip_start, frame_len, apply_nat, skip_ttl)
+/// or None on validation failure.
+#[inline]
+fn rewrite_prepare_eth(
+    frame: &mut [u8],
+    desc: XdpDesc,
+    meta: ForwardPacketMeta,
+    decision: &SessionDecision,
+    apply_nat_on_fabric: bool,
+) -> Option<RewritePrep> { ... }
+
+struct RewritePrep {
+    eth_len: usize,
+    ip_start: usize,
+    frame_len: usize,
+    apply_nat: bool,
+    skip_ttl: bool,
+    vlan_id: u16, // for the cfg-gated debug-log block
+}
+
+/// Apply NAT + TTL + checksum to the IPv4 portion of `packet`.
+/// Returns Some(()) on success, None on validation failure.
+#[inline]
+fn rewrite_apply_v4(
+    packet: &mut [u8],
+    ip_start: usize,
+    meta: ForwardPacketMeta,
+    decision: &SessionDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<()> { ... }
+
+#[inline]
+fn rewrite_apply_v6(
+    packet: &mut [u8],
+    ip_start: usize,
+    meta: ForwardPacketMeta,
+    decision: &SessionDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<()> { ... }
+```
+
+`rewrite_forwarded_frame_in_place` becomes:
+
+```rust
+pub(super) fn rewrite_forwarded_frame_in_place(
+    area: &MmapArea,
+    desc: XdpDesc,
+    meta: impl Into<ForwardPacketMeta>,
+    decision: &SessionDecision,
+    apply_nat_on_fabric: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<u32> {
+    let meta = meta.into();
+    let frame = unsafe { area.slice_mut_unchecked(desc.addr as usize, UMEM_FRAME_SIZE as usize)? };
+    let prep = rewrite_prepare_eth(frame, desc, meta, decision, apply_nat_on_fabric)?;
+    let packet = &mut frame[..prep.frame_len];
+    match meta.addr_family as i32 {
+        libc::AF_INET => rewrite_apply_v4(
+            packet, prep.ip_start, meta, decision,
+            prep.apply_nat, prep.skip_ttl, expected_ports,
+        )?,
+        libc::AF_INET6 => rewrite_apply_v6(
+            packet, prep.ip_start, meta, decision,
+            prep.apply_nat, prep.skip_ttl, expected_ports,
+        )?,
+        _ => return None,
+    }
+    // Debug log block + checksum verification (unchanged shape, just
+    // moved to live next to the dispatch).
+    debug_log_inplace_eth(packet, &prep, meta);
+    if cfg!(feature = "debug-log") {
+        verify_built_frame_checksums(packet);
+    }
+    Some(prep.frame_len as u32)
+}
+```
+
+### What this is NOT
+
+- Not a new `PacketEditor` or `FrameBuilder` struct. The hot path
+  already has `RewriteDescriptor`; adding another abstraction layer
+  duplicates intent and breaks the principle "don't add abstractions
+  beyond what the task requires" (CLAUDE.md).
+- Not a behavior change. Every helper inlines into the same
+  generated code as today's body (verified by `cargo bench` /
+  `cargo asm` if needed; the `#[inline]` attribute keeps the
+  compiler's options identical).
+- Not a perf claim. The win is readability/maintainability —
+  swapping the v4 branch for a future change becomes editing a
+  named function instead of finding the right `match` arm in a
+  170-line body.
+
+## Files touched
+
+- `userspace-dp/src/afxdp/frame.rs`: extract three helpers, rewrite
+  the body of `rewrite_forwarded_frame_in_place`. ~120 LOC moved,
+  ~30 LOC added (new helper signatures + the dispatch). No public
+  API change.
+
+## Tests
+
+All existing tests must continue to pass:
+- `rewrite_forwarded_frame_in_place_keeps_icmpv6_checksum_valid_after_snat`
+- `rewrite_forwarded_frame_in_place_keeps_icmpv6_echo_identifier_and_sequence`
+- `rewrite_forwarded_frame_in_place_keeps_ipv6_tcp_ports_after_vlan_snat`
+- `rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_snat`
+- `rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_dnat`
+- `rewrite_forwarded_frame_in_place_reuses_rx_frame` (in tests.rs)
+- All `apply_rewrite_descriptor_*` tests (the hot-path specialized
+  function is unchanged).
+
+No new tests required — the refactor is structure-only. A new test
+to demonstrate the refactor's behavior would necessarily duplicate
+an existing one.
+
+## Acceptance gates
+
+1. `cargo build --release` clean (no new warnings beyond baseline).
+2. `cargo test --release` ≥ baseline (863 post-#965), 0 failed.
+3. Cluster smoke (HARD): no regression on the unloaded-session path.
+   Run on `loss:xpf-userspace-fw0/fw1` (the userspace-dp HA cluster
+   that is the default deploy target) AND with CoS configured on
+   every iperf3 forwarding-class via `test/incus/cos-iperf-config.set`.
+   CoS state is wiped by `cluster-deploy`, so the smoke runner must
+   re-apply that fixture before measurement.
+
+   | Class       | Port  | Shaped rate | P=12 gate     |
+   |-------------|-------|-------------|---------------|
+   | iperf-c     | 5203  | 25 g exact  | ≥ 22 Gb/s     |
+   | iperf-f     | 5206  | 19 g exact  | ≥ 17.1 Gb/s   |
+   | iperf-e     | 5205  | 16 g exact  | ≥ 14.4 Gb/s   |
+   | iperf-d     | 5204  | 13 g exact  | ≥ 11.7 Gb/s   |
+   | iperf-b     | 5202  | 10 g exact  | ≥ 9.0 Gb/s    |
+   | iperf-a     | 5201  | 1 g exact   | ≥ 0.9 Gb/s    |
+   | best-effort | 5207  | 100 m exact | ≥ 90 Mb/s     |
+
+   Every P=12 row is a blocking gate. iperf-c also keeps the P=1 ≥
+   6 Gb/s historical gate.
+4. Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot fw0
+   at +20s, fw1 takes over within 10s, iperf3 average ≥ 1 Gb/s and
+   ≥ 5 GB received.
+5. Codex hostile review (plan + impl): AGREE-TO-MERGE.
+6. Gemini adversarial review (plan + impl): AGREE-TO-MERGE.
+7. Copilot review on PR: all valid findings addressed.
+
+## Risk
+
+**Low.** Pure structural refactor with no behavior change. The
+helpers all `#[inline]`, so the compiler's lowering options are
+identical to today. Existing test coverage is dense (~30 tests
+exercising every branch axis in the function).
+
+The only realistic risk is an off-by-one or borrow-checker mistake
+during the cut — caught by the test suite.
+
+## Out of scope
+
+- Adding a new `PacketEditor` / `FrameBuilder` struct (the issue's
+  title floats this; investigation found `RewriteDescriptor` already
+  fills that role for the hot path).
+- Refactoring `apply_rewrite_descriptor` (it's already specialized).
+- Decomposing other long functions in `frame.rs` (e.g.
+  `parse_session_flow_from_bytes`, `decode_frame_summary`) — out of
+  scope for this PR; tracked under separate issues if needed.
+- Performance work — this is a readability refactor; perf parity is
+  the gate, not perf improvement.

--- a/docs/pr/963-frame-builder/plan.md
+++ b/docs/pr/963-frame-builder/plan.md
@@ -1,7 +1,35 @@
 # #963: decompose rewrite_forwarded_frame_in_place (the slow-path
 # god function) into v4/v6 specialized helpers + extracted subroutines
 
-Plan v1 — 2026-04-29.
+Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mok8bo19-r2vheq):
+five blocking findings, all fixed.
+
+1. Payload-shift / eth-header ordering corrected. Plan v1 prose
+   said "write Ethernet header, shift payload" — backwards. Current
+   code correctly does `copy_within` BEFORE `write_eth_header_slice`
+   (else VLAN push corrupts the IP header). Helper docstring now
+   pins the order explicitly.
+
+2. Two sentinel tests added: `_skips_nat_for_fabric_redirect_when_disabled`
+   (inverse of the existing `_when_enabled` test) and
+   `_skips_ttl_when_fabric_ingress_flag_set`. These guard the
+   apply_nat and skip_ttl booleans through the extraction.
+
+3. Port-enforcement decision pinned: keep `enforce_expected_ports`
+   (reparsing variant) in the helpers; switching to
+   `enforce_expected_ports_at` is a separate optimization.
+
+4. `#[inline]` codegen claim weakened. Plan v1 said "compiler
+   lowering options identical" — false; `#[inline]` is a hint, not
+   a guarantee. Now framed as "perf parity is the gate, not perf
+   improvement".
+
+5. Acceptance commands corrected: `--manifest-path
+   userspace-dp/Cargo.toml`. Honesty caveat added that the iperf3
+   CoS smoke exercises the warmed flow-cache HOT path, not the
+   slow-path fallback this PR refactors; slow-path coverage comes
+   from unit tests + first-sight packets in the smoke + post-
+   failover sessions.
 
 ## Investigation findings (Claude, on commit 430b3d93)
 
@@ -22,27 +50,30 @@ Plan v1 — 2026-04-29.
 
 ### What's already in place (don't re-build)
 
-The codebase already has the hot-path specialization #963 asks for:
+The codebase already covers the cases #963's title would address
+with a builder/state pattern:
 
 - `RewriteDescriptor` (`flow_cache.rs:34`) — a precomputed packet
-  rewrite plan baked at flow-cache insertion time.
+  rewrite plan baked at flow-cache insertion time. This is NOT
+  technically a builder for the slow path; it is the reason the
+  slow path doesn't need a new state-pattern abstraction (the
+  decisions for cached flows are made elsewhere and passed in).
 - `apply_rewrite_descriptor` (`frame.rs:1792`) — the straight-line
-  fast path that uses it. Comments explicitly call out: "Eliminates
-  per-packet branches for address family, VLAN presence, NAT type,
-  and checksum recomputation — all decisions are baked into the
-  descriptor at session/flow-cache insertion time. Scope: IPv4/IPv6
-  TCP and UDP only." (frame.rs:1779–1790)
+  fast path that consumes `RewriteDescriptor`. Comments explicitly
+  call out: "Eliminates per-packet branches for address family,
+  VLAN presence, NAT type, and checksum recomputation — all
+  decisions are baked into the descriptor at session/flow-cache
+  insertion time. Scope: IPv4/IPv6 TCP and UDP only."
+  (frame.rs:1779–1790)
 
 `rewrite_forwarded_frame_in_place` is the **fallback** for cases the
 descriptor doesn't cover — NAT64 (header-size change), NPTv6
 (checksum-neutral but address rewrite differs), ICMP identifier
 repair, and packets without a flow-cache entry on first sight.
 
-So #963's "god function" complaint is about the *slow path* — the
-hot path is already specialized. The fix is to decompose the slow
-path for readability and maintainability, not to add another layer
-of builder/state abstraction (that's already what the descriptor
-is).
+So #963's "god function" complaint is about the *slow path*. The
+fix is to decompose the slow path along its existing branch axes
+for readability, not to introduce a new abstraction layer.
 
 ## Approach
 
@@ -66,11 +97,20 @@ Extract into three private `#[inline]` helpers in `frame.rs`:
 
 ```rust
 /// Common preamble: validate L3 offset, compute payload_len,
-/// resolve src_mac/vlan_id/apply_nat, write Ethernet header,
-/// shift payload to its new position.
+/// resolve src_mac/vlan_id/apply_nat, **shift the payload to its
+/// new position FIRST**, then write the Ethernet header.
 ///
-/// Returns (eth_len, ip_start, frame_len, apply_nat, skip_ttl)
-/// or None on validation failure.
+/// Order matters: when VLAN tag is added (eth_len 14 → 18) the
+/// payload shifts forward by 4 bytes. If we wrote the new
+/// Ethernet header first, the `copy_within(14.., 18)` payload
+/// shift would read from bytes that have just been overwritten
+/// by the VLAN tag and corrupt the IP header. The current
+/// implementation at `frame.rs:1605-1614` correctly orders
+/// `copy_within` BEFORE `write_eth_header_slice`; the helper
+/// must preserve that order (Codex round-1 #1 caught a wording
+/// flip in plan v1).
+///
+/// Returns RewritePrep on success, None on validation failure.
 #[inline]
 fn rewrite_prepare_eth(
     frame: &mut [u8],
@@ -156,14 +196,18 @@ pub(super) fn rewrite_forwarded_frame_in_place(
   already has `RewriteDescriptor`; adding another abstraction layer
   duplicates intent and breaks the principle "don't add abstractions
   beyond what the task requires" (CLAUDE.md).
-- Not a behavior change. Every helper inlines into the same
-  generated code as today's body (verified by `cargo bench` /
-  `cargo asm` if needed; the `#[inline]` attribute keeps the
-  compiler's options identical).
+- Not a behavior change. The helpers carry `#[inline]` as a hint to
+  the compiler, but `#[inline]` is **only a hint** — it does not
+  guarantee that codegen is identical to today's monolithic body.
+  The compiler may inline some, none, or all of them, and code
+  size / register allocation may shift either direction. If a
+  noticeable codegen change occurs it should show up as a perf
+  delta in the smoke gate (Codex round-1 #4 corrected an
+  overstated claim in plan v1).
 - Not a perf claim. The win is readability/maintainability —
   swapping the v4 branch for a future change becomes editing a
   named function instead of finding the right `match` arm in a
-  170-line body.
+  170-line body. Perf parity is the gate, not perf improvement.
 
 ## Files touched
 
@@ -180,24 +224,66 @@ All existing tests must continue to pass:
 - `rewrite_forwarded_frame_in_place_keeps_ipv6_tcp_ports_after_vlan_snat`
 - `rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_snat`
 - `rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_dnat`
+- `rewrite_forwarded_frame_in_place_applies_nat_for_fabric_redirect_when_enabled`
+  (the existing fabric-redirect-with-NAT test at `frame.rs:6664`)
 - `rewrite_forwarded_frame_in_place_reuses_rx_frame` (in tests.rs)
 - All `apply_rewrite_descriptor_*` tests (the hot-path specialized
   function is unchanged).
 
-No new tests required — the refactor is structure-only. A new test
-to demonstrate the refactor's behavior would necessarily duplicate
-an existing one.
+### New sentinel tests (Codex round-1 #2)
+
+Two cross-cutting boolean axes are not fully covered today and are
+exactly the kind of subtle invariant that can be severed during a
+function extraction. Add:
+
+1. `rewrite_forwarded_frame_in_place_skips_nat_for_fabric_redirect_when_disabled`:
+   the inverse of the existing `_when_enabled` test. Set
+   `disposition = FabricRedirect`, `apply_nat_on_fabric = false`,
+   `decision.nat = SNAT to 198.51.100.99`. After the rewrite,
+   assert the source IP in the frame is the ORIGINAL (not the
+   SNAT'd) — confirms the `apply_nat` gate at the dispatch point
+   correctly suppresses NAT.
+
+2. `rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set`:
+   set `meta.meta_flags = FABRIC_INGRESS_FLAG (0x80)` so the
+   sending peer is treated as having already decremented TTL.
+   Capture the IP TTL before and after the rewrite; assert
+   pre == post (no decrement).
+
+These guard the `apply_nat` and `skip_ttl` booleans through the
+extraction.
+
+### Port-enforcement behavior (Codex round-1 #3)
+
+The current `rewrite_forwarded_frame_in_place` calls
+`enforce_expected_ports` (`frame.rs:1659`, `1687`), which reparses
+L4 offset from the packet. There is also an
+`enforce_expected_ports_at` variant (`frame.rs:2301`) that takes a
+precomputed L4 offset.
+
+**Decision**: keep `enforce_expected_ports` (the reparsing variant)
+in the extracted v4/v6 helpers. Switching to `_at` is a separate
+optimization with its own metadata-vs-parsed offset semantics
+question; mixing it into a structure-only refactor would mask any
+behavioral change behind the move. If `_at` becomes desirable
+later, file a follow-up.
 
 ## Acceptance gates
 
-1. `cargo build --release` clean (no new warnings beyond baseline).
-2. `cargo test --release` ≥ baseline (863 post-#965), 0 failed.
-3. Cluster smoke (HARD): no regression on the unloaded-session path.
-   Run on `loss:xpf-userspace-fw0/fw1` (the userspace-dp HA cluster
-   that is the default deploy target) AND with CoS configured on
-   every iperf3 forwarding-class via `test/incus/cos-iperf-config.set`.
-   CoS state is wiped by `cluster-deploy`, so the smoke runner must
-   re-apply that fixture before measurement.
+The repo has no root `Cargo.toml`; cargo commands must run with
+`--manifest-path userspace-dp/Cargo.toml` (Codex round-1 #5).
+
+1. `cargo build --release --manifest-path userspace-dp/Cargo.toml`
+   clean (no new warnings beyond baseline).
+2. `cargo test --release --manifest-path userspace-dp/Cargo.toml`
+   ≥ baseline (863 post-#965) + 2 new sentinel tests = 865, 0 failed.
+3. Cluster smoke (HARD): no regression on the warmed-flow-cache
+   forwarding path. Run on `loss:xpf-userspace-fw0/fw1` (the
+   userspace-dp HA cluster that is the default deploy target) AND
+   with CoS configured on every iperf3 forwarding-class via
+   `test/incus/cos-iperf-config.set`. CoS state is wiped by
+   `cluster-deploy`, so the smoke runner must re-apply that fixture
+   before measurement.
 
    | Class       | Port  | Shaped rate | P=12 gate     |
    |-------------|-------|-------------|---------------|
@@ -211,9 +297,32 @@ an existing one.
 
    Every P=12 row is a blocking gate. iperf-c also keeps the P=1 ≥
    6 Gb/s historical gate.
+
+   **Important honesty caveat** (Codex round-1 #5): the iperf3 CoS
+   smoke exercises the WARMED descriptor flow-cache path (i.e.
+   `apply_rewrite_descriptor` for steady-state TCP/UDP), NOT the
+   `rewrite_forwarded_frame_in_place` slow-path fallback this PR
+   refactors. The smoke validates that the hot path stays at line-
+   rate (no regression) but does not directly hit the changed code.
+   The slow path is exercised by:
+   - First-sight TCP/UDP packets before the flow cache warms up
+     (every connection's first few packets).
+   - ICMP echo / ICMPv6 Neighbor Discovery / ICMP Time Exceeded —
+     all of which the cluster smoke generates incidentally during
+     warm-up + iperf3 control plane chatter.
+   - The unit-test suite, which directly hits the slow path on
+     every relevant branch axis.
+
+   For NAT64 / NPTv6 coverage the unit tests are the primary
+   guarantee since the cluster smoke fixture does not configure
+   either feature.
+
 4. Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot fw0
    at +20s, fw1 takes over within 10s, iperf3 average ≥ 1 Gb/s and
-   ≥ 5 GB received.
+   ≥ 5 GB received. (The failover window forces the freshly-
+   installed sessions on fw1 to traverse the slow path until their
+   flow-cache entries warm up — provides incidental coverage of the
+   refactored code under realistic load.)
 5. Codex hostile review (plan + impl): AGREE-TO-MERGE.
 6. Gemini adversarial review (plan + impl): AGREE-TO-MERGE.
 7. Copilot review on PR: all valid findings addressed.

--- a/docs/pr/963-frame-builder/plan.md
+++ b/docs/pr/963-frame-builder/plan.md
@@ -1,7 +1,26 @@
 # #963: decompose rewrite_forwarded_frame_in_place (the slow-path
 # god function) into v4/v6 specialized helpers + extracted subroutines
 
-Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mok8bo19-r2vheq):
+Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mok8khp9-0jm235):
+
+a. Stale Risk section still claimed "compiler's lowering options
+   identical" via `#[inline]`. Rewrote to say `#[inline]` is a hint,
+   not a guarantee; perf parity is validated by the smoke gate.
+
+b. "Improves I-cache locality" deterministic claim softened to a
+   *possible* side-benefit, since `#[inline]` doesn't guarantee
+   the v6 helper is kept out-of-line.
+
+c. Removed the phantom `debug_log_inplace_eth(...)` 4th helper
+   from the body sketch. The cfg(debug-log) block stays inline
+   (it captures local prep state; extracting it would just widen
+   the helper signature with no benefit).
+
+Plus: TTL sentinel test extended to be table-driven over IPv4
+TTL and IPv6 hop-limit so it validates the skip_ttl gate in
+both rewrite_apply_v4 and rewrite_apply_v6.
+
+v2 — Addresses Codex round-1 (task-mok8bo19-r2vheq):
 five blocking findings, all fixed.
 
 1. Payload-shift / eth-header ordering corrected. Plan v1 prose
@@ -87,9 +106,11 @@ This is the minimal scope that addresses the issue:
   small dispatch on address family.
 - Keeps every existing call site identical (no API change).
 - Preserves all existing tests (no behavioral change).
-- Improves I-cache locality for the v4 hot path: when a binding only
-  sees IPv4 traffic, the v6 code is cold and gets evicted from
-  I-cache instead of being interleaved.
+- *May* improve I-cache locality for the v4-only branch in
+  bindings that see only IPv4 traffic — but this depends on
+  whether the compiler keeps the v6 helper out-of-line, which
+  `#[inline]` does not guarantee. Treat as a possible
+  side-benefit, NOT a deterministic outcome (Codex round-2 #2).
 
 ### Decomposition
 
@@ -180,9 +201,19 @@ pub(super) fn rewrite_forwarded_frame_in_place(
         )?,
         _ => return None,
     }
-    // Debug log block + checksum verification (unchanged shape, just
-    // moved to live next to the dispatch).
-    debug_log_inplace_eth(packet, &prep, meta);
+    // The cfg(feature = "debug-log") header-dump block and the
+    // verify_built_frame_checksums call stay INLINE here (not
+    // extracted into a 4th helper). They reference local state
+    // (vlan_id from prep, frame_len, ip_start, addr_family) and
+    // moving them into a helper would either widen the helper's
+    // signature with all those params or require a captured
+    // state struct — either way more code, no benefit. Keep the
+    // existing inline block under the new dispatch.
+    #[cfg(feature = "debug-log")]
+    {
+        // Same thread_local INPLACE_FWD_DBG_COUNT block as today's
+        // body, lines 1696-1726, just relocated below the dispatch.
+    }
     if cfg!(feature = "debug-log") {
         verify_built_frame_checksums(packet);
     }
@@ -245,13 +276,17 @@ function extraction. Add:
    correctly suppresses NAT.
 
 2. `rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set`:
-   set `meta.meta_flags = FABRIC_INGRESS_FLAG (0x80)` so the
-   sending peer is treated as having already decremented TTL.
-   Capture the IP TTL before and after the rewrite; assert
-   pre == post (no decrement).
+   table-driven over IPv4 TTL (offset 8) and IPv6 hop-limit
+   (offset 7). For each address family, set
+   `meta.meta_flags = FABRIC_INGRESS_FLAG (0x80)` so the sending
+   peer is treated as having already decremented TTL. Capture the
+   relevant byte before and after the rewrite; assert pre == post
+   (no decrement). Covering both families validates the skip_ttl
+   gate in both extracted helpers (rewrite_apply_v4 and
+   rewrite_apply_v6) — Codex round-2 suggestion.
 
 These guard the `apply_nat` and `skip_ttl` booleans through the
-extraction.
+extraction across both families.
 
 ### Port-enforcement behavior (Codex round-1 #3)
 
@@ -329,10 +364,12 @@ The repo has no root `Cargo.toml`; cargo commands must run with
 
 ## Risk
 
-**Low.** Pure structural refactor with no behavior change. The
-helpers all `#[inline]`, so the compiler's lowering options are
-identical to today. Existing test coverage is dense (~30 tests
-exercising every branch axis in the function).
+**Low.** Pure structural refactor with no behavior change.
+`#[inline]` is a hint to the compiler, not a guarantee — codegen
+may shift either direction (size, register allocation, layout).
+Perf parity is validated by the cluster smoke gate, not asserted
+by the inline attribute. Existing test coverage is dense (~30
+tests exercising every branch axis in the function).
 
 The only realistic risk is an off-by-one or borrow-checker mistake
 during the cut — caught by the test suite.

--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -1557,18 +1557,34 @@ pub(super) fn build_forwarded_frame_into(
     )
 }
 
-pub(super) fn rewrite_forwarded_frame_in_place(
-    area: &MmapArea,
+/// Common preamble for `rewrite_forwarded_frame_in_place`: validate
+/// L3 offset, compute payload_len, resolve src_mac/vlan_id/apply_nat,
+/// SHIFT the payload to its new position FIRST, then write the
+/// Ethernet header.
+///
+/// Order matters: when VLAN tag is added (eth_len 14 → 18) the
+/// payload shifts forward by 4 bytes. If we wrote the new Ethernet
+/// header first, the `copy_within(14.., 18)` payload shift would
+/// read from bytes that have just been overwritten by the VLAN tag
+/// and corrupt the IP header.
+struct RewritePrep {
+    eth_len: usize,
+    ip_start: usize,
+    frame_len: usize,
+    apply_nat: bool,
+    skip_ttl: bool,
+    vlan_id: u16, // for the cfg-gated debug-log block
+}
+
+#[inline]
+fn rewrite_prepare_eth(
+    frame: &mut [u8],
     desc: XdpDesc,
-    meta: impl Into<ForwardPacketMeta>,
+    meta: ForwardPacketMeta,
     decision: &SessionDecision,
     apply_nat_on_fabric: bool,
-    expected_ports: Option<(u16, u16)>,
-) -> Option<u32> {
-    let meta = meta.into();
+) -> Option<RewritePrep> {
     let dst_mac = decision.resolution.neighbor_mac?;
-    let enforced_ports = expected_ports;
-    let frame = unsafe { area.slice_mut_unchecked(desc.addr as usize, UMEM_FRAME_SIZE as usize)? };
     let current_len = desc.len as usize;
     let l3 = match meta.l3_offset {
         14 | 18 => meta.l3_offset as usize,
@@ -1602,6 +1618,8 @@ pub(super) fn rewrite_forwarded_frame_in_place(
     if frame_len > frame.len() {
         return None;
     }
+    // Shift payload BEFORE writing the new Ethernet header (see
+    // doc-comment above for why the order matters on VLAN push).
     if eth_len != l3 {
         frame.copy_within(l3..l3 + payload_len, eth_len);
     }
@@ -1612,90 +1630,153 @@ pub(super) fn rewrite_forwarded_frame_in_place(
         vlan_id,
         ether_type,
     )?;
-    let packet = &mut frame[..frame_len];
-    let ip_start = eth_len;
-    // Fabric-ingress packets already had TTL decremented by the sending peer.
+    // Fabric-ingress packets already had TTL decremented by the
+    // sending peer (FABRIC_INGRESS_FLAG = 0x80).
     let skip_ttl = (meta.meta_flags & 0x80) != 0;
+    Some(RewritePrep {
+        eth_len,
+        ip_start: eth_len,
+        frame_len,
+        apply_nat,
+        skip_ttl,
+        vlan_id,
+    })
+}
+
+#[inline]
+fn rewrite_apply_v4(
+    packet: &mut [u8],
+    ip_start: usize,
+    meta: ForwardPacketMeta,
+    decision: &SessionDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<()> {
+    if packet.len() < ip_start + 20 {
+        return None;
+    }
+    let ihl = ((packet[ip_start] & 0x0f) as usize) * 4;
+    if ihl < 20 || packet.len() < ip_start + ihl {
+        return None;
+    }
+    if !skip_ttl && packet[ip_start + 8] <= 1 {
+        return None;
+    }
+    let old_src = Ipv4Addr::new(
+        packet[ip_start + 12],
+        packet[ip_start + 13],
+        packet[ip_start + 14],
+        packet[ip_start + 15],
+    );
+    let old_dst = Ipv4Addr::new(
+        packet[ip_start + 16],
+        packet[ip_start + 17],
+        packet[ip_start + 18],
+        packet[ip_start + 19],
+    );
+    let old_ttl = packet[ip_start + 8];
+    let rel_l4 = ihl;
+    let repaired_ports =
+        restore_l4_tuple_from_meta(&mut packet[ip_start..], meta, rel_l4).unwrap_or(false);
+    if apply_nat {
+        apply_nat_ipv4(&mut packet[ip_start..], meta.protocol, decision.nat)?;
+    }
+    if !skip_ttl {
+        packet[ip_start + 8] -= 1;
+    }
+    adjust_ipv4_header_checksum(
+        &mut packet[ip_start..ip_start + ihl],
+        old_src,
+        old_dst,
+        old_ttl,
+    )?;
+    let enforced = enforce_expected_ports(packet, meta.addr_family, meta.protocol, expected_ports)
+        .unwrap_or(false);
+    if repaired_ports && !enforced {
+        recompute_l4_checksum_ipv4(&mut packet[ip_start..], ihl, meta.protocol, true)?;
+    }
+    Some(())
+}
+
+#[inline]
+fn rewrite_apply_v6(
+    packet: &mut [u8],
+    ip_start: usize,
+    meta: ForwardPacketMeta,
+    decision: &SessionDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<()> {
+    if packet.len() < ip_start + 40 {
+        return None;
+    }
+    if !skip_ttl && packet[ip_start + 7] <= 1 {
+        return None;
+    }
+    let meta_rel = meta.l4_offset.wrapping_sub(meta.l3_offset) as usize;
+    let rel_l4 = if meta_rel >= 40 && meta.l4_offset > meta.l3_offset {
+        meta_rel
+    } else {
+        packet_rel_l4_offset(&packet[ip_start..], meta.addr_family)?
+    };
+    let repaired_ports =
+        restore_l4_tuple_from_meta(&mut packet[ip_start..], meta, rel_l4).unwrap_or(false);
+    if apply_nat {
+        apply_nat_ipv6(&mut packet[ip_start..], meta.protocol, decision.nat)?;
+    }
+    if !skip_ttl {
+        packet[ip_start + 7] -= 1;
+    }
+    let enforced = enforce_expected_ports(packet, meta.addr_family, meta.protocol, expected_ports)
+        .unwrap_or(false);
+    if repaired_ports && !enforced {
+        recompute_l4_checksum_ipv6(&mut packet[ip_start..], meta.protocol)?;
+    }
+    Some(())
+}
+
+pub(super) fn rewrite_forwarded_frame_in_place(
+    area: &MmapArea,
+    desc: XdpDesc,
+    meta: impl Into<ForwardPacketMeta>,
+    decision: &SessionDecision,
+    apply_nat_on_fabric: bool,
+    expected_ports: Option<(u16, u16)>,
+) -> Option<u32> {
+    let meta = meta.into();
+    let frame = unsafe { area.slice_mut_unchecked(desc.addr as usize, UMEM_FRAME_SIZE as usize)? };
+    let prep = rewrite_prepare_eth(frame, desc, meta, decision, apply_nat_on_fabric)?;
+    let packet = &mut frame[..prep.frame_len];
     match meta.addr_family as i32 {
-        libc::AF_INET => {
-            if packet.len() < ip_start + 20 {
-                return None;
-            }
-            let ihl = ((packet[ip_start] & 0x0f) as usize) * 4;
-            if ihl < 20 || packet.len() < ip_start + ihl {
-                return None;
-            }
-            if !skip_ttl && packet[ip_start + 8] <= 1 {
-                return None;
-            }
-            let old_src = Ipv4Addr::new(
-                packet[ip_start + 12],
-                packet[ip_start + 13],
-                packet[ip_start + 14],
-                packet[ip_start + 15],
-            );
-            let old_dst = Ipv4Addr::new(
-                packet[ip_start + 16],
-                packet[ip_start + 17],
-                packet[ip_start + 18],
-                packet[ip_start + 19],
-            );
-            let old_ttl = packet[ip_start + 8];
-            let rel_l4 = ihl;
-            let repaired_ports =
-                restore_l4_tuple_from_meta(&mut packet[ip_start..], meta, rel_l4).unwrap_or(false);
-            if apply_nat {
-                apply_nat_ipv4(&mut packet[ip_start..], meta.protocol, decision.nat)?;
-            }
-            if !skip_ttl {
-                packet[ip_start + 8] -= 1;
-            }
-            adjust_ipv4_header_checksum(
-                &mut packet[ip_start..ip_start + ihl],
-                old_src,
-                old_dst,
-                old_ttl,
-            )?;
-            let enforced =
-                enforce_expected_ports(packet, meta.addr_family, meta.protocol, enforced_ports)
-                    .unwrap_or(false);
-            if repaired_ports && !enforced {
-                recompute_l4_checksum_ipv4(&mut packet[ip_start..], ihl, meta.protocol, true)?;
-            }
-        }
-        libc::AF_INET6 => {
-            if packet.len() < ip_start + 40 {
-                return None;
-            }
-            if !skip_ttl && packet[ip_start + 7] <= 1 {
-                return None;
-            }
-            let meta_rel = meta.l4_offset.wrapping_sub(meta.l3_offset) as usize;
-            let rel_l4 = if meta_rel >= 40 && meta.l4_offset > meta.l3_offset {
-                meta_rel
-            } else {
-                packet_rel_l4_offset(&packet[ip_start..], meta.addr_family)?
-            };
-            let repaired_ports =
-                restore_l4_tuple_from_meta(&mut packet[ip_start..], meta, rel_l4).unwrap_or(false);
-            if apply_nat {
-                apply_nat_ipv6(&mut packet[ip_start..], meta.protocol, decision.nat)?;
-            }
-            if !skip_ttl {
-                packet[ip_start + 7] -= 1;
-            }
-            let enforced =
-                enforce_expected_ports(packet, meta.addr_family, meta.protocol, enforced_ports)
-                    .unwrap_or(false);
-            if repaired_ports && !enforced {
-                recompute_l4_checksum_ipv6(&mut packet[ip_start..], meta.protocol)?;
-            }
-        }
+        libc::AF_INET => rewrite_apply_v4(
+            packet,
+            prep.ip_start,
+            meta,
+            decision,
+            prep.apply_nat,
+            prep.skip_ttl,
+            expected_ports,
+        )?,
+        libc::AF_INET6 => rewrite_apply_v6(
+            packet,
+            prep.ip_start,
+            meta,
+            decision,
+            prep.apply_nat,
+            prep.skip_ttl,
+            expected_ports,
+        )?,
         _ => return None,
     }
     // Debug: dump first N in-place rewritten frames' Ethernet headers
     #[cfg(feature = "debug-log")]
     {
+        let eth_len = prep.eth_len;
+        let ip_start = prep.ip_start;
+        let frame_len = prep.frame_len;
+        let vlan_id = prep.vlan_id;
         thread_local! {
             static INPLACE_FWD_DBG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
         }
@@ -1726,9 +1807,9 @@ pub(super) fn rewrite_forwarded_frame_in_place(
     }
     // Checksum verification for in-place path.
     if cfg!(feature = "debug-log") {
-        verify_built_frame_checksums(&packet[..frame_len]);
+        verify_built_frame_checksums(&packet[..prep.frame_len]);
     }
-    Some(frame_len as u32)
+    Some(prep.frame_len as u32)
 }
 
 #[inline(always)]
@@ -6726,6 +6807,204 @@ mod tests {
         assert_eq!(&out[30..34], &[172, 16, 80, 200]);
         assert_eq!(out[22], 63);
         assert!(tcp_checksum_ok_ipv4(&out[14..]));
+    }
+
+    /// Sentinel for #963 round-1 #2: inverse of the
+    /// `_when_enabled` test above. Set
+    /// `disposition = FabricRedirect`, `apply_nat_on_fabric = false`,
+    /// SNAT rewrite_src to 198.51.100.99. After the rewrite, assert
+    /// the source IP in the frame is the ORIGINAL — confirms the
+    /// `apply_nat` gate at the dispatch correctly suppresses NAT
+    /// when fabric NAT is disabled.
+    #[test]
+    fn rewrite_forwarded_frame_in_place_skips_nat_for_fabric_redirect_when_disabled() {
+        let mut frame = Vec::new();
+        write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, 0x0800);
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
+            102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
+            b'd', b'a', b't', b'a',
+        ]);
+        let ip_sum = checksum16(&frame[14..34]);
+        frame[24] = (ip_sum >> 8) as u8;
+        frame[25] = ip_sum as u8;
+        recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false).expect("tcp sum");
+
+        let mut area = MmapArea::new(4096).expect("mmap");
+        area.slice_mut(0, frame.len())
+            .expect("slice")
+            .copy_from_slice(&frame);
+        let meta = UserspaceDpMeta {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            l3_offset: 14,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            ..UserspaceDpMeta::default()
+        };
+        let frame_len = rewrite_forwarded_frame_in_place(
+            &area,
+            XdpDesc {
+                addr: 0,
+                len: frame.len() as u32,
+                options: 0,
+            },
+            meta,
+            &SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::FabricRedirect,
+                    local_ifindex: 0,
+                    egress_ifindex: 21,
+                    tx_ifindex: 21,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(10, 99, 13, 2))),
+                    neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+                    src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                    tx_vlan_id: 0,
+                },
+                nat: NatDecision {
+                    rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 99))),
+                    ..NatDecision::default()
+                },
+            },
+            false, // apply_nat_on_fabric = false
+            None,
+        )
+        .expect("rewrite in place");
+
+        let out = area.slice(0, frame_len as usize).expect("rewritten frame");
+        // Source IP MUST be the original 10.0.61.102, not the SNAT'd
+        // 198.51.100.99. This validates that apply_nat=false is
+        // correctly threaded through the dispatch into rewrite_apply_v4.
+        assert_eq!(
+            &out[26..30],
+            &[10, 0, 61, 102],
+            "apply_nat_on_fabric=false must suppress SNAT"
+        );
+        assert_eq!(&out[30..34], &[172, 16, 80, 200]);
+        assert_eq!(out[22], 63); // TTL still decremented (skip_ttl=false)
+    }
+
+    /// Sentinel for #963 round-1 #2 (extended in round-2): table-
+    /// driven over IPv4 TTL (offset 8 from IP start) and IPv6
+    /// hop-limit (offset 7 from IP start). For each address family,
+    /// set `meta.meta_flags = 0x80 (FABRIC_INGRESS_FLAG)` so the
+    /// sending peer is treated as having already decremented TTL.
+    /// Capture the relevant byte before and after; assert pre == post
+    /// (no decrement). Validates the skip_ttl gate in BOTH
+    /// rewrite_apply_v4 and rewrite_apply_v6.
+    #[test]
+    fn rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set() {
+        // Table-driven: (addr_family, ether_type, ip_header,
+        //                 ttl_rel_offset_from_ip_start)
+        // ttl_rel_offset is HEADER-relative (not Ethernet-relative)
+        // to avoid confusion (Codex round-3 non-blocking note).
+        let v4_header: Vec<u8> = vec![
+            0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
+            102, 172, 16, 80, 200,
+        ];
+        let v4_payload: Vec<u8> = vec![
+            0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10,
+            0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
+        ];
+        let v6_header: Vec<u8> = vec![
+            0x60, 0x00, 0x00, 0x00, 0x00, 0x14, PROTO_TCP, 64,
+            // src 2001:db8::1
+            0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+            // dst 2001:db8::200
+            0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02, 0x00,
+        ];
+        let v6_payload: Vec<u8> = vec![
+            0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10,
+            0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        for (label, addr_family, ether_type, ip_header, ip_payload, ttl_rel_offset, src_ip) in [
+            (
+                "v4",
+                libc::AF_INET as u8,
+                0x0800u16,
+                v4_header,
+                v4_payload,
+                8usize,
+                IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            ),
+            (
+                "v6",
+                libc::AF_INET6 as u8,
+                0x86ddu16,
+                v6_header,
+                v6_payload,
+                7usize,
+                IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+            ),
+        ] {
+            let mut frame = Vec::new();
+            write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, ether_type);
+            frame.extend_from_slice(&ip_header);
+            frame.extend_from_slice(&ip_payload);
+            if addr_family == libc::AF_INET as u8 {
+                let ip_sum = checksum16(&frame[14..14 + ip_header.len()]);
+                frame[24] = (ip_sum >> 8) as u8;
+                frame[25] = ip_sum as u8;
+                recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false)
+                    .expect("v4 tcp sum");
+            } else {
+                recompute_l4_checksum_ipv6(&mut frame[14..], PROTO_TCP).expect("v6 tcp sum");
+            }
+            let pre_ttl = frame[14 + ttl_rel_offset];
+
+            let mut area = MmapArea::new(4096).expect("mmap");
+            area.slice_mut(0, frame.len())
+                .expect("slice")
+                .copy_from_slice(&frame);
+            let meta = UserspaceDpMeta {
+                magic: USERSPACE_META_MAGIC,
+                version: USERSPACE_META_VERSION,
+                length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+                l3_offset: 14,
+                addr_family,
+                protocol: PROTO_TCP,
+                meta_flags: 0x80, // FABRIC_INGRESS_FLAG — peer already decremented TTL
+                ..UserspaceDpMeta::default()
+            };
+            let frame_len = rewrite_forwarded_frame_in_place(
+                &area,
+                XdpDesc {
+                    addr: 0,
+                    len: frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                &SessionDecision {
+                    resolution: ForwardingResolution {
+                        disposition: ForwardingDisposition::ForwardCandidate,
+                        local_ifindex: 0,
+                        egress_ifindex: 12,
+                        tx_ifindex: 12,
+                        tunnel_endpoint_id: 0,
+                        next_hop: Some(src_ip),
+                        neighbor_mac: Some([0, 1, 2, 3, 4, 5]),
+                        src_mac: Some([0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]),
+                        tx_vlan_id: 0,
+                    },
+                    nat: NatDecision::default(),
+                },
+                false,
+                None,
+            )
+            .unwrap_or_else(|| panic!("[{}] rewrite_in_place returned None", label));
+
+            let out = area.slice(0, frame_len as usize).expect("rewritten frame");
+            let post_ttl = out[14 + ttl_rel_offset];
+            assert_eq!(
+                pre_ttl, post_ttl,
+                "[{}] FABRIC_INGRESS_FLAG must suppress TTL/hop-limit decrement \
+                 (pre={} post={})",
+                label, pre_ttl, post_ttl
+            );
+        }
     }
 
     // --- apply_rewrite_descriptor tests ---

--- a/userspace-dp/src/afxdp/frame.rs
+++ b/userspace-dp/src/afxdp/frame.rs
@@ -6901,8 +6901,11 @@ mod tests {
         //                 ttl_rel_offset_from_ip_start)
         // ttl_rel_offset is HEADER-relative (not Ethernet-relative)
         // to avoid confusion (Codex round-3 non-blocking note).
+        // IP total_len = 0x002c (44 bytes = 20 IP + 24 TCP/data) so
+        // the IP header total_len matches the actual constructed
+        // frame (Codex impl review round-1 caught a 0x0030 mismatch).
         let v4_header: Vec<u8> = vec![
-            0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
+            0x45, 0x00, 0x00, 0x2c, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
             102, 172, 16, 80, 200,
         ];
         let v4_payload: Vec<u8> = vec![


### PR DESCRIPTION
## Summary

Extract the 170-line god function at `userspace-dp/src/afxdp/frame.rs:1560` into three `#[inline]` helpers along its existing branch axes. Pure structural refactor; no behavior change, no API change.

Plan: `docs/pr/963-frame-builder/plan.md` (PLAN-READY at v3 after 3 rounds of Codex hostile review + Gemini AGREE-TO-MERGE-PLAN).

## Why this scope (not a builder/state pattern)

The hot path already uses `RewriteDescriptor` + `apply_rewrite_descriptor` (`flow_cache.rs:34` / `frame.rs:1792`) — a precomputed straight-line rewrite for warmed-flow-cache TCP/UDP. The remaining 170-line function is the **slow-path fallback** for cases the descriptor doesn't cover (NAT64, NPTv6, ICMP repair, first-sight packets without a flow-cache entry). Adding a `PacketEditor` / `FrameBuilder` here would duplicate the role `RewriteDescriptor` already fills.

## Implementation

- **`rewrite_prepare_eth`**: validate L3 offset, compute payload_len, resolve src_mac/vlan_id/apply_nat, **shift the payload to its new position FIRST**, then write the Ethernet header. Order matters — flipping it corrupts the IP header on VLAN push (Codex round-1 #1 caught this in the plan).
- **`rewrite_apply_v4`**: IPv4-specific TTL check, `restore_l4_tuple_from_meta`, NAT (gated on `apply_nat`), TTL decrement (gated on `skip_ttl`), `adjust_ipv4_header_checksum` (uses `old_src/old_dst/old_ttl` captured BEFORE NAT mutates them), `enforce_expected_ports`, conditional `recompute_l4_checksum_ipv4`.
- **`rewrite_apply_v6`**: IPv6-specific hop-limit check, `restore_l4_tuple_from_meta`, NAT, hop-limit decrement, `enforce_expected_ports`, conditional `recompute_l4_checksum_ipv6`.
- `rewrite_forwarded_frame_in_place` becomes a small dispatch (~10 lines).
- `cfg(debug-log)` header dump + `verify_built_frame_checksums` stay inline.

`#[inline]` is a hint, not a guarantee — perf parity is validated by the smoke gate, not asserted by the inline attribute.

## Reviews

- **Plan** (3 rounds): Codex round-3 PLAN-READY, Gemini AGREE-TO-MERGE-PLAN. Major findings caught and fixed: payload-shift / eth-header ordering bug (R1), missing sentinel tests (R1), stale `#[inline]` codegen claim (R1+R2), phantom 4th helper in body sketch (R2), I-cache determinism overclaim (R2).
- **Implementation** (Codex + Gemini): Codex round-1 NEEDS-REVISION-MINOR (test-only IP total_len mismatch — fixed in `c3d7bc7b`); Gemini AGREE-TO-MERGE-IMPL.

## Test plan

- [x] `cargo test --release --manifest-path userspace-dp/Cargo.toml`: **865 passed** (863 baseline + 2 new sentinels), 0 failed.
  - `rewrite_forwarded_frame_in_place_skips_nat_for_fabric_redirect_when_disabled`: inverse of the existing `_when_enabled` test. With `apply_nat_on_fabric=false`, source IP must be the original (not SNAT'd).
  - `rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set`: table-driven over IPv4 TTL (offset 8) and IPv6 hop-limit (offset 7). With `FABRIC_INGRESS_FLAG=0x80`, pre-rewrite == post-rewrite for the relevant byte (validates `skip_ttl` in BOTH `rewrite_apply_v4` and `rewrite_apply_v6`).
- [x] Cluster deploy to `loss:xpf-userspace-fw0/fw1`: rolling deploy clean (Phase 1 secondary, Phase 2 primary).
- [x] Per-CoS-class iperf3 smoke after re-applying `test/incus/cos-iperf-config.set`:

| Class | Port | Shape | Gate | Result | Pass |
|---|---|---|---|---|---|
| iperf-c | 5203 | 25 g | 22 Gb/s | 23.42 Gb/s | ✅ |
| iperf-f | 5206 | 19 g | 17.1 Gb/s | 18.13 Gb/s | ✅ |
| iperf-e | 5205 | 16 g | 14.4 Gb/s | 15.27 Gb/s | ✅ |
| iperf-d | 5204 | 13 g | 11.7 Gb/s | 12.41 Gb/s | ✅ |
| iperf-b | 5202 | 10 g | 9.0 Gb/s | 9.55 Gb/s | ✅ |
| iperf-a | 5201 | 1 g | 0.9 Gb/s | 0.95 Gb/s | ✅ |
| best-effort | 5207 | 100 m | 90 Mb/s | 90 Mb/s | ✅ |

This smoke exercises the warmed flow-cache HOT path (`apply_rewrite_descriptor`), not the slow-path fallback this PR refactors. Slow-path coverage comes from the unit tests + first-sight packets + post-failover sessions.

- [x] Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot fw0 at +20s, fw1 took over in <10s, iperf3 survived: **23.01 Gb/s avg, 258.9 GB received**, fw0 came back as secondary. Post-failover sessions on fw1 traverse the slow path until their flow-cache entries warm up — provides incidental coverage of the refactored code under realistic load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)