### PR TITLE
#956 Phase 1: extract cos/ecn.rs from tx.rs

### DIFF
--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -334,33 +334,38 @@ and is reused; do not add a duplicate.
   generated code if visibilities and `#[inline]` attributes are
   preserved.
 
-## Files touched
+## Files touched (as actually shipped)
 
-- **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~250 LOC (moved
-  code + 15 tests).
+After 6 rounds of plan iteration, the implementation took a
+narrower cut than the plan originally specified: the production
+code moved to `cos/ecn.rs`, but the 15 ECN unit tests + the 5
+shared fixtures stayed in `tx::tests`. They reach the moved items
+via the new `use super::cos::{...}` import. This avoided a same-PR
+fixture relocation while admission tests (which share those
+fixtures) still live in `tx.rs`. Test reorganization is deferred
+to Phase 2 alongside the admission move (Copilot review on
+PR #976 flagged the original plan-text vs implementation drift).
+
+- **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~210 LOC of
+  production code only (no tests in this Phase 1).
 - **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC — `mod ecn;`
   plus `pub(super) use ecn::{maybe_mark_ecn_ce,
   maybe_mark_ecn_ce_prepared, ECN_MASK, ECN_NOT_ECT, ECN_ECT_0,
-  ECN_ECT_1, ECN_CE};`. (Codex round-5 #2 caught a duplicate entry
-  in v5.)
-- `userspace-dp/src/afxdp/test_fixtures.rs` (EXISTS, currently
-  ~663 LOC at this commit; round-5 #3 corrected the v4 ~860 LOC
-  estimate): EXTENDED with the ~80 LOC of shared fixtures moved
-  out of `tx::tests` (`build_ipv4_test_packet`,
-  `build_ipv6_test_packet`, `compute_ipv4_header_checksum`,
-  `insert_single_vlan_tag`, `test_prepared_item_in_umem`). Existing
-  `pub(super)` visibility pattern preserved.
-- `userspace-dp/src/afxdp/tx.rs`: removes ~250 LOC (moved code +
-  marker tests), removes ~80 LOC (fixtures moved to `test_fixtures.rs`),
-  adds `use` statements pointing at `cos::{...}` and
-  `test_fixtures::*`. Net: ~330 LOC smaller.
+  ECN_ECT_1, ECN_CE};`.
+- `userspace-dp/src/afxdp/tx.rs`: removes the ~210 LOC of moved
+  production code; adds `use super::cos::{maybe_mark_ecn_ce,
+  maybe_mark_ecn_ce_prepared}` for the production marker calls
+  and `#[cfg(test)] use super::cos::ecn::{...}` /
+  `#[cfg(test)] use super::cos::{ECN_*}` for the test-only
+  imports (Copilot review #4 caught that test-only items were
+  reachable in non-test builds and would trigger
+  `unused_imports`). Marker tests + shared fixtures stay in
+  `tx::tests`.
 - `userspace-dp/src/afxdp.rs`: adds `#[path = "afxdp/cos/mod.rs"]
   mod cos;` (private, explicit path, matching the existing
-  `#[path = "afxdp/tx.rs"] mod tx;` pattern at line 97 — Codex
-  round-5 #1 caught a stale `pub(super) mod cos;` residue in v4).
-  The existing `#[cfg(test)] #[path = "afxdp/test_fixtures.rs"]
-  mod test_fixtures;` line at `afxdp.rs:93-94` already declares the
-  test_fixtures module — DO NOT add a duplicate (Codex round-3 #3).
+  `#[path = "afxdp/tx.rs"] mod tx;` pattern at line 97).
+- `userspace-dp/src/afxdp/test_fixtures.rs`: **NOT modified in
+  Phase 1**. Fixture relocation deferred (see preface above).
 
 ## Tests
 
@@ -385,11 +390,16 @@ All **15 existing tests** for the moved code must continue to pass
 The **15 admission-path tests** that exercise the marker indirectly
 through `apply_cos_admission_ecn_policy` (including the Prepared
 UMEM path and VLAN Prepared path) STAY in `tx::tests` because the
-admission policy stays in `tx.rs` (see Phase 1 scope). They depend
-on shared fixtures that this PR moves out of `tx::tests` into the
-existing `afxdp::test_fixtures` module (per the Test fixtures
-section above), so both staying admission tests and moving marker
-tests can `use crate::afxdp::test_fixtures::*;`.
+admission policy stays in `tx.rs` (see Phase 1 scope). The 15 ECN
+marker tests and the 5 shared fixtures (`build_ipv4_test_packet`,
+`build_ipv6_test_packet`, `compute_ipv4_header_checksum`,
+`insert_single_vlan_tag`, `test_prepared_item_in_umem`) ALSO stay
+in `tx::tests` for this Phase 1 (Copilot review on PR #976 caught
+the plan/implementation drift here — original plan text said
+fixtures move to `afxdp::test_fixtures`, but the actual Phase 1
+shipped without that move to keep the diff minimal while
+admission tests still need the same fixtures). Fixture relocation
+is deferred to Phase 2 alongside the admission move.
 
 No new tests required — the refactor is structure-only and the
 existing test suite has dense branch coverage.

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,6 +1,37 @@
 # #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
 
-Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mokb9f8h-mwlbl8):
+Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mokbj8l7-x8capj):
+four blocking findings + one stale-text fix.
+
+a. Visibility re-export model corrected. `pub(super) use ecn::{...}`
+   in `cos/mod.rs` does NOT widen visibility past what the source
+   items permit. Items must be `pub(in crate::afxdp)` in `ecn.rs`
+   AND re-exported with `pub(super) use` in `cos/mod.rs`. Plan now
+   shows both halves.
+
+b. Test-fixture sharing via `tx::tests` was broken: `pub(super) fn`
+   inside `tx::tests` makes it visible to `tx`, not to a sibling
+   `cos::ecn::tests`. And `mod tests` is private. v3 introduces a
+   new `#[cfg(test)] mod test_fixtures;` at `afxdp/` (sibling of
+   `tx.rs`/`cos/`) with `pub(in crate::afxdp)` helpers. Both
+   `tx::tests` and `cos::ecn::tests` import via
+   `crate::afxdp::test_fixtures::*`.
+
+c. Stale Risk-section prose said the const_assert invariants "must
+   move with the constants" — flipped from v1, but the surrounding
+   plan now says they STAY in tx.rs for Phase 1 and only move with
+   admission later. Risk text now consistent.
+
+d. Phase order: queue_service depends on builders
+   (`prime_cos_root_for_service`, `build_cos_batch_from_queue`,
+   `apply_cos_send_result`, `apply_cos_prepared_result`). v2 had
+   builders in Phase 8 — would leave queue_service depending back
+   on `tx.rs`. Swapped: Phase 6 = builders, Phase 7 = queue_service.
+
+e. Stale "+ 13 tests" residue in Files-touched section — replaced
+   with 15.
+
+v2 — Addresses Codex round-1 (task-mokb9f8h-mwlbl8):
 five blocking findings, all fixed.
 
 1. Visibility: `pub(super)` from `afxdp::cos::ecn` only exposes to
@@ -138,26 +169,34 @@ Move from `tx.rs`:
 - The two `const _: () = assert!` compile-time invariants for the
   threshold (move only when admission moves in Phase 2).
 
-### Visibility model (Codex round-1 #1)
+### Visibility model (Codex round-1 #1, refined per round-2 #1)
 
 `pub(super)` from inside `afxdp::cos::ecn` only exposes to
-`afxdp::cos`, NOT back up to `afxdp::tx`. To make the moved
-functions callable from `tx.rs`, the cleanest options are:
+`afxdp::cos` — NOT back up to `afxdp::tx`. And `pub(super) use ...`
+in `cos/mod.rs` does NOT widen visibility past what the source
+items already permit; it can only re-export at a visibility ≤ the
+source. So the round-1 fix needs both halves:
 
-(a) Declare each exported item as `pub(in crate::afxdp)` —
-    visible to anything inside the `afxdp` module tree.
-(b) Re-export from `cos/mod.rs`:
-    ```rust
-    pub(super) use ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
-    ```
-    where `pub(super)` here means "visible to `afxdp`" because
-    `cos/mod.rs` lives at `afxdp::cos`.
+```rust
+// userspace-dp/src/afxdp/cos/ecn.rs
+pub(in crate::afxdp) fn maybe_mark_ecn_ce(req: &mut TxRequest) -> bool { ... }
+pub(in crate::afxdp) fn maybe_mark_ecn_ce_prepared(...) -> bool { ... }
 
-**Decision**: use option (b). Re-exporting from `cos/mod.rs` keeps
-the per-file visibility within `cos/ecn.rs` as `pub(super)` (i.e.
-"visible to siblings within `cos/`") and lets `cos/mod.rs` decide
-the surface area exposed to `afxdp`. This is the pattern the codebase
-already follows for `afxdp` itself (see `afxdp.rs`).
+// userspace-dp/src/afxdp/cos/mod.rs
+pub(super) use ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
+```
+
+Items declared `pub(in crate::afxdp)` are visible to anything in the
+`afxdp` module tree (including `afxdp::tx`). The `pub(super) use`
+re-export is a convenience so call sites can write
+`use super::cos::{maybe_mark_ecn_ce, ...}` instead of the longer
+`use super::cos::ecn::{...}` path.
+
+The internal `EthernetL3` enum, `ethernet_l3` parser, and the
+`mark_ecn_ce_ipv4`/`_ipv6` helpers stay file-private (no `pub`)
+since they have no callers outside `cos::ecn` after the move. The 5
+codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`, `ECN_ECT_1`,
+`ECN_CE`) likewise stay file-private.
 
 ### Path imports (Codex round-1 #5)
 
@@ -167,22 +206,42 @@ in tx.rs becomes `use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};`
 qualified `crate::afxdp::ethernet::...` form is preferred for
 readability and stability across future module reshuffles.
 
-### Test fixtures (Codex round-1 #4)
+### Test fixtures (Codex round-1 #4, refined per round-2 #2)
 
 `tx::tests` contains shared fixtures used by BOTH the marker tests
 (moving) AND admission/V_min tests (staying):
 `build_ipv4_test_packet`, `build_ipv6_test_packet`,
 `compute_ipv4_header_checksum`, `insert_single_vlan_tag`,
 `test_prepared_item_in_umem`. A naive helper move would break the
-remaining `tx::tests`.
+remaining `tx::tests`. Round-1 #4 noted the problem; round-2 #2
+flagged that my proposed fix (`pub(super) fn` inside
+`tx::tests`) doesn't actually compile — `mod tests` is private and
+cross-importing from another module's `mod tests` is brittle even
+with `pub(super)` on the helpers.
 
-**Decision**: keep the fixtures in `tx::tests` and make them
-`pub(super)` (or `pub(in crate::afxdp)`) so `cos::ecn::tests` can
-import them via
-`use crate::afxdp::tx::tests::{build_ipv4_test_packet, ...};`.
-Fixtures don't move in Phase 1; they get re-evaluated when admission
-extracts in Phase 2 (likely the right place for them is
-`cos/test_helpers.rs` once both admission and ecn live in `cos/`).
+**Decision (Codex round-2 #2 preferred fix)**: introduce a new
+`#[cfg(test)] mod test_fixtures;` at `userspace-dp/src/afxdp/`
+(sibling of `tx.rs` and the new `cos/`). It carries the shared
+fixture functions with `pub(in crate::afxdp)` visibility:
+
+```rust
+// userspace-dp/src/afxdp/test_fixtures.rs
+#![cfg(test)]
+pub(in crate::afxdp) fn build_ipv4_test_packet(...) -> Vec<u8> { ... }
+pub(in crate::afxdp) fn build_ipv6_test_packet(...) -> Vec<u8> { ... }
+pub(in crate::afxdp) fn compute_ipv4_header_checksum(hdr: &[u8]) -> u16 { ... }
+pub(in crate::afxdp) fn insert_single_vlan_tag(...) -> Vec<u8> { ... }
+pub(in crate::afxdp) fn test_prepared_item_in_umem(...) -> ... { ... }
+```
+
+`tx::tests` and `cos::ecn::tests` both import via
+`use crate::afxdp::test_fixtures::*;`. This is robust against
+future moves and works with the existing `mod tests` private-by-
+default convention.
+
+The fixtures get moved out of `tx::tests` in this PR (small,
+self-contained move) so the marker tests can reach them from
+`cos::ecn::tests`.
 
 ### Module declaration
 
@@ -210,11 +269,17 @@ pattern — investigation will pin the exact form.)
 - **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC declaring
   `pub(super) mod ecn;`.
 - **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~250 LOC (moved
-  code + 13 tests).
+  code + 15 tests; round-2 #5 caught a stale "13 tests" residue).
+- **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC (`pub(super)
+  mod ecn;` + `pub(super) use ecn::{maybe_mark_ecn_ce, ...};`).
+- **NEW** `userspace-dp/src/afxdp/test_fixtures.rs`: ~80 LOC of
+  shared test fixtures moved out of `tx::tests`.
 - `userspace-dp/src/afxdp/tx.rs`: removes ~250 LOC (moved code +
-  tests), adds 1 `use` statement + visibility tweak. Net: ~250 LOC
-  smaller.
-- `userspace-dp/src/afxdp.rs`: adds `mod cos;` declaration (1 LOC).
+  marker tests), removes ~80 LOC (fixtures moved to `test_fixtures.rs`),
+  adds `use` statements pointing at `cos::ecn` and
+  `test_fixtures`. Net: ~330 LOC smaller.
+- `userspace-dp/src/afxdp.rs`: adds `pub(super) mod cos;` and
+  `#[cfg(test)] pub(in crate::afxdp) mod test_fixtures;` (~2 LOC).
 
 ## Tests
 
@@ -295,8 +360,10 @@ The compile-time invariants
 `const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);`
 and
 `const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);`
-must move with the constants and continue to fire — verified by
-the build still succeeding.
+**stay with the constants in `tx.rs` for Phase 1** (round-2 #3
+caught a stale prose flip from v1 that said they "must move"). They
+move with admission and the threshold constants in Phase 2 to
+`cos/admission.rs`. The build asserts continue to fire either way.
 
 ## Out of scope (future Phase 2+ PRs)
 
@@ -332,17 +399,22 @@ container helpers:
   `CoSServicePhase` / `ExactCoSQueueKind` enums and
   `CoSPendingTxItem` accessors. Required before queue service can
   cleanly extract.
-- **Phase 6**: `cos/queue_service.rs` — `select_cos_guarantee_batch`,
+- **Phase 6**: `cos/builders.rs` — `build_cos_interface_runtime`,
+  `build_cos_batch_from_queue`, `apply_cos_send_result`,
+  `apply_cos_prepared_result`, `prime_cos_root_for_service`.
+  Codex round-2 #4 caught that `queue_service` calls all of these,
+  so builders must extract BEFORE queue_service or queue_service
+  will be left dependent on `tx.rs`. Phase 6 in v3 (was Phase 8 in
+  v2).
+- **Phase 7**: `cos/queue_service.rs` — `select_cos_guarantee_batch`,
   `select_cos_surplus_batch`, `service_exact_*`, `drain_shaped_tx`,
   MQFQ virtual-time logic, `select_exact_cos_guarantee_queue_*`.
-- **Phase 7**: `cos/cross_binding.rs` —
+  Pulls in builders/appliers from Phase 6.
+- **Phase 8**: `cos/cross_binding.rs` —
   `redirect_local_cos_request_to_owner`,
   `redirect_prepared_cos_request_to_owner`,
   `prepared_cos_request_stays_on_current_tx_binding`, the MPSC
-  inbox handling.
-- **Phase 8**: `cos/builders.rs` — `build_cos_interface_runtime`,
-  `build_cos_batch_from_queue`, `apply_cos_send_result`,
-  `apply_cos_prepared_result`, `prime_cos_root_for_service`.
+  inbox handling. Was Phase 7 in v2.
 
 After Phase 8 the `tx.rs` left in place is just XSK ring management
 (descriptor pop/push, kick threshold, completion reap) +

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,6 +1,42 @@
 # #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
 
-Plan v1 — 2026-04-29.
+Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mokb9f8h-mwlbl8):
+five blocking findings, all fixed.
+
+1. Visibility: `pub(super)` from `afxdp::cos::ecn` only exposes to
+   `afxdp::cos`, not back up to `afxdp::tx`. Plan now uses
+   `pub(super) use ecn::{...}` re-export from `cos/mod.rs` so the
+   parent `afxdp` module can reach the symbols.
+
+2. Constants belong with policy, not the marker. Threshold
+   `COS_ECN_MARK_THRESHOLD_*` constants STAY in tx.rs alongside
+   `apply_cos_admission_ecn_policy` (which also stays in Phase 1).
+   They move with admission to `cos/admission.rs` in Phase 2 — the
+   correct dependency direction.
+
+3. Test count was 13; actual is 15 — corrected (added
+   `maybe_mark_ecn_ce_dispatches_by_addr_family`,
+   `_handles_single_vlan_tagged_frame`,
+   `_rejects_unknown_ethertype`).
+
+4. Test fixtures (`build_ipv4_test_packet` etc.) are shared between
+   moving marker tests AND staying admission tests. Plan now keeps
+   fixtures in `tx::tests` (made `pub(super)`) so `cos::ecn::tests`
+   can import them. Fixtures re-evaluate their home in Phase 2.
+
+5. Path import: `super::ethernet` is wrong from inside `cos::ecn`.
+   Use `crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN}` (or
+   the equivalent `super::super::ethernet::{...}`). Plan picks the
+   fully-qualified form for stability.
+
+Plus future-phase ordering corrected:
+- `flow_hash` now precedes admission (admission's flow-fair
+  promotion calls `cos_flow_hash_seed_from_os`).
+- Added explicit `queue_ops` phase before `queue_service` — queue
+  service depends on `cos_queue_push/pop` and the `CoSBatch` enum
+  having a clear home.
+
+Now an 8-phase plan (Phase 1 = ECN; ends at builders).
 
 ## Investigation findings (Claude, on commit 76384e9a)
 
@@ -39,25 +75,40 @@ The major subsystems currently colocated in tx.rs:
 
 ### Phase 1 scope (this PR): extract `cos/ecn.rs`
 
-ECN marking is the most self-contained subsystem in the file. It
-has:
+ECN marking is the most self-contained byte-mutation subsystem in
+the file. It has:
 - A small bounded surface: 4 mutating functions
   (`maybe_mark_ecn_ce`, `maybe_mark_ecn_ce_prepared`,
   `mark_ecn_ce_ipv4`, `mark_ecn_ce_ipv6`) plus the `ethernet_l3`
   parser + `EthernetL3` enum.
-- 8 named ECN constants (`COS_ECN_MARK_THRESHOLD_NUM`,
-  `COS_ECN_MARK_THRESHOLD_DEN`, `ECN_MASK`, `ECN_NOT_ECT`,
-  `ECN_ECT_0`, `ECN_ECT_1`, `ECN_CE`) with two compile-time
-  invariants (`const _: () = assert!`).
-- 13 existing unit tests dense across all branches (ECT-0/ECT-1/
-  not-ECT/CE-untouched/short-buffer × v4/v6, plus QinQ rejection
-  and tagged-non-IP rejection).
-- Three call sites in tx.rs: `apply_cos_admission_ecn_policy`
-  (lines ~3700-3796 within tx.rs) and elsewhere.
+- 5 ECN codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`,
+  `ECN_ECT_0`, `ECN_ECT_1`, `ECN_CE`) — these belong with the
+  byte mutator since they describe IP TOS / IPv6 tclass low bits.
+- **15 existing unit tests** (Codex round-1 #3 corrected my count
+  of 13): `mark_ecn_ce_ipv4_*` (5), `mark_ecn_ce_ipv6_*` (5),
+  `maybe_mark_ecn_ce_dispatches_by_addr_family`,
+  `maybe_mark_ecn_ce_handles_single_vlan_tagged_frame`,
+  `maybe_mark_ecn_ce_rejects_unknown_ethertype`, plus 2
+  `ethernet_l3_*` tests (QinQ rejection + tagged-non-IP rejection).
+- Two main call sites in tx.rs: the in-tx-request marker path and
+  the prepared-UMEM marker path (both inside or near
+  `apply_cos_admission_ecn_policy`).
 
 It does NOT depend on other CoS subsystems (token bucket, queue ops,
-builders) — only on `super::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN}`,
-`TxRequest`, `PreparedTxRequest`, and `MmapArea`. Self-contained.
+builders) — only on `crate::afxdp::ethernet::{ETH_HDR_LEN,
+VLAN_TAG_LEN}`, `TxRequest`, `PreparedTxRequest`, and `MmapArea`.
+Self-contained for the byte-mutation surface.
+
+**What stays in tx.rs (Codex round-1 #2)**:
+
+The threshold constants `COS_ECN_MARK_THRESHOLD_NUM` and
+`COS_ECN_MARK_THRESHOLD_DEN` (plus their two `const _: () = assert!`
+compile-time invariants) belong with `apply_cos_admission_ecn_policy`,
+not with the byte mutator. They are admission-policy tuning knobs,
+not ECN codepoint definitions. Moving them into `cos::ecn` and
+having admission reach back creates exactly the wrong dependency
+direction (a byte-mutation module owning admission tuning). Phase 2
+will extract them when admission policy moves to `cos/admission.rs`.
 
 Phase 1 establishes the `cos/` submodule pattern that Phase 2+ PRs
 will extend.
@@ -73,28 +124,75 @@ userspace-dp/src/afxdp/cos/
 ```
 
 Move from `tx.rs`:
-- All 8 ECN constants + the two compile-time invariants.
+- 5 ECN codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`,
+  `ECN_ECT_1`, `ECN_CE`).
 - `EthernetL3` enum.
 - `ethernet_l3` parser.
 - `mark_ecn_ce_ipv4` and `mark_ecn_ce_ipv6` helpers.
 - `maybe_mark_ecn_ce` and `maybe_mark_ecn_ce_prepared`.
-- All 13 unit tests for the above.
+- All **15** unit tests for the above (Codex round-1 #3).
 
-Update `tx.rs`:
-- Remove the moved items.
-- `use super::cos::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};`
-  for the call sites that survive in tx.rs.
-- Make `COS_ECN_MARK_THRESHOLD_NUM` / `_DEN` `pub(super) const` in
-  `cos::ecn` so `apply_cos_admission_ecn_policy` (which stays in
-  tx.rs in this phase) can still reach them.
+**Stays in tx.rs**:
+- `COS_ECN_MARK_THRESHOLD_NUM` / `_DEN` (admission tuning, used by
+  `apply_cos_admission_ecn_policy` which also stays).
+- The two `const _: () = assert!` compile-time invariants for the
+  threshold (move only when admission moves in Phase 2).
+
+### Visibility model (Codex round-1 #1)
+
+`pub(super)` from inside `afxdp::cos::ecn` only exposes to
+`afxdp::cos`, NOT back up to `afxdp::tx`. To make the moved
+functions callable from `tx.rs`, the cleanest options are:
+
+(a) Declare each exported item as `pub(in crate::afxdp)` —
+    visible to anything inside the `afxdp` module tree.
+(b) Re-export from `cos/mod.rs`:
+    ```rust
+    pub(super) use ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
+    ```
+    where `pub(super)` here means "visible to `afxdp`" because
+    `cos/mod.rs` lives at `afxdp::cos`.
+
+**Decision**: use option (b). Re-exporting from `cos/mod.rs` keeps
+the per-file visibility within `cos/ecn.rs` as `pub(super)` (i.e.
+"visible to siblings within `cos/`") and lets `cos/mod.rs` decide
+the surface area exposed to `afxdp`. This is the pattern the codebase
+already follows for `afxdp` itself (see `afxdp.rs`).
+
+### Path imports (Codex round-1 #5)
+
+From inside `afxdp::cos::ecn`, the existing `use super::ethernet::{...}`
+in tx.rs becomes `use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};`
+(or equivalently `use super::super::ethernet::{...}`). The fully-
+qualified `crate::afxdp::ethernet::...` form is preferred for
+readability and stability across future module reshuffles.
+
+### Test fixtures (Codex round-1 #4)
+
+`tx::tests` contains shared fixtures used by BOTH the marker tests
+(moving) AND admission/V_min tests (staying):
+`build_ipv4_test_packet`, `build_ipv6_test_packet`,
+`compute_ipv4_header_checksum`, `insert_single_vlan_tag`,
+`test_prepared_item_in_umem`. A naive helper move would break the
+remaining `tx::tests`.
+
+**Decision**: keep the fixtures in `tx::tests` and make them
+`pub(super)` (or `pub(in crate::afxdp)`) so `cos::ecn::tests` can
+import them via
+`use crate::afxdp::tx::tests::{build_ipv4_test_packet, ...};`.
+Fixtures don't move in Phase 1; they get re-evaluated when admission
+extracts in Phase 2 (likely the right place for them is
+`cos/test_helpers.rs` once both admission and ecn live in `cos/`).
+
+### Module declaration
 
 Update `userspace-dp/src/afxdp.rs` to declare the new submodule:
 ```rust
-mod cos;
+pub(super) mod cos;
 ```
 
-(Or the appropriate spot in the existing `mod` declarations —
-investigation will pin the exact location.)
+(or whatever visibility matches the existing `pub(super) mod tx;`
+pattern — investigation will pin the exact form.)
 
 ### What this is NOT
 
@@ -120,7 +218,8 @@ investigation will pin the exact location.)
 
 ## Tests
 
-All 13 existing ECN/ethernet_l3 tests must continue to pass:
+All **15 existing tests** for the moved code must continue to pass
+(Codex round-1 #3):
 - `mark_ecn_ce_ipv4_converts_ect0_to_ce_and_updates_checksum`
 - `mark_ecn_ce_ipv4_converts_ect1_to_ce_and_updates_checksum`
 - `mark_ecn_ce_ipv4_leaves_not_ect_untouched`
@@ -131,9 +230,18 @@ All 13 existing ECN/ethernet_l3 tests must continue to pass:
 - `mark_ecn_ce_ipv6_leaves_not_ect_untouched`
 - `mark_ecn_ce_ipv6_leaves_ce_untouched`
 - `mark_ecn_ce_ipv6_rejects_short_buffer`
+- `maybe_mark_ecn_ce_dispatches_by_addr_family`
+- `maybe_mark_ecn_ce_handles_single_vlan_tagged_frame`
+- `maybe_mark_ecn_ce_rejects_unknown_ethertype`
 - `ethernet_l3_rejects_qinq_until_explicitly_supported`
 - `ethernet_l3_rejects_vlan_tagged_non_ip_payload`
-- (one more `ethernet_l3` test — verified during investigation)
+
+The **15 admission-path tests** that exercise the marker indirectly
+through `apply_cos_admission_ecn_policy` (including the Prepared
+UMEM path and VLAN Prepared path) STAY in `tx::tests` because the
+admission policy stays in `tx.rs` (see Phase 1 scope). They depend
+on shared fixtures that also stay in `tx::tests` and are made
+`pub(super)` so `cos::ecn::tests` can import them.
 
 No new tests required — the refactor is structure-only and the
 existing test suite has dense branch coverage.
@@ -193,26 +301,55 @@ the build still succeeding.
 ## Out of scope (future Phase 2+ PRs)
 
 This PR is the first in a chain. Subsequent PRs (one issue, one PR
-each, but tracked under #956 umbrella) will extract:
+each, tracked under the #956 umbrella) extract additional
+subsystems. Order revised per Codex round-1 #6 — `flow_hash` must
+precede admission because `apply_cos_queue_flow_fair_promotion`
+calls `cos_flow_hash_seed_from_os`, and a `queue_ops` phase is
+broken out explicitly so queue service has somewhere to land its
+container helpers:
 
-- **Phase 2**: `cos/admission.rs` — `apply_cos_admission_ecn_policy`,
-  `apply_cos_queue_flow_fair_promotion`, the per-flow share-cap
-  helpers (`cos_queue_flow_share_limit`,
-  `cos_flow_aware_buffer_limit`, account_*).
-- **Phase 3**: `cos/token_bucket.rs` — `refill_cos_tokens`,
-  `maybe_top_up_*`, `cos_tick_for_ns`, `cos_timer_wheel_*`.
-- **Phase 4**: `cos/flow_hash.rs` — flow-bucket hashing helpers.
-- **Phase 5**: `cos/queue_service.rs` — `select_cos_*`,
-  `service_exact_*`, `drain_shaped_tx`, MQFQ virtual-time logic.
-- **Phase 6**: `cos/cross_binding.rs` — redirect logic + MPSC.
-- **Phase 7**: `cos/builders.rs` — `build_cos_interface_runtime`,
-  `apply_cos_send_result`, etc.
+- **Phase 2**: `cos/flow_hash.rs` — `mix_cos_flow_bucket`,
+  `exact_cos_flow_bucket`, `cos_item_flow_key`,
+  `cos_flow_bucket_index`, `cos_flow_hash_seed_from_os`,
+  `cos_queue_prospective_active_flows`. Pure functions; few callers
+  outside admission/promotion.
+- **Phase 3**: `cos/admission.rs` — `apply_cos_admission_ecn_policy`
+  (and the `COS_ECN_MARK_THRESHOLD_*` constants currently kept in
+  `tx.rs` move with it), `apply_cos_queue_flow_fair_promotion`, the
+  per-flow share-cap helpers (`cos_queue_flow_share_limit`,
+  `cos_flow_aware_buffer_limit`, `account_cos_queue_flow_enqueue`,
+  `account_cos_queue_flow_dequeue`, `bdp_floor_bytes`).
+- **Phase 4**: `cos/token_bucket.rs` — `refill_cos_tokens`,
+  `maybe_top_up_cos_root_lease`, `maybe_top_up_cos_queue_lease`,
+  `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+  `cos_refill_ns_until`, `cos_surplus_quantum_bytes`,
+  `cos_guarantee_quantum_bytes`.
+- **Phase 5**: `cos/queue_ops.rs` — `cos_queue_push_back`,
+  `cos_queue_push_front`, `cos_queue_pop_front`,
+  `cos_queue_pop_front_no_snapshot`, `cos_queue_front`,
+  `cos_queue_len`, `cos_queue_is_empty`,
+  `cos_queue_min_finish_bucket`, plus the `CoSBatch` /
+  `CoSServicePhase` / `ExactCoSQueueKind` enums and
+  `CoSPendingTxItem` accessors. Required before queue service can
+  cleanly extract.
+- **Phase 6**: `cos/queue_service.rs` — `select_cos_guarantee_batch`,
+  `select_cos_surplus_batch`, `service_exact_*`, `drain_shaped_tx`,
+  MQFQ virtual-time logic, `select_exact_cos_guarantee_queue_*`.
+- **Phase 7**: `cos/cross_binding.rs` —
+  `redirect_local_cos_request_to_owner`,
+  `redirect_prepared_cos_request_to_owner`,
+  `prepared_cos_request_stays_on_current_tx_binding`, the MPSC
+  inbox handling.
+- **Phase 8**: `cos/builders.rs` — `build_cos_interface_runtime`,
+  `build_cos_batch_from_queue`, `apply_cos_send_result`,
+  `apply_cos_prepared_result`, `prime_cos_root_for_service`.
 
-After Phase 7 the `tx.rs` left in place is just XSK ring management
-+ orchestration glue (~3-5K LOC). Each phase is independently
-reviewable, smokeable, and mergeable.
+After Phase 8 the `tx.rs` left in place is just XSK ring management
+(descriptor pop/push, kick threshold, completion reap) +
+orchestration glue (`drain_pending_tx`, `bound_pending_tx_*`)
+(~3-5K LOC). Each phase is independently reviewable, smokeable,
+and mergeable.
 
-If during Phase 1 review a smaller or different first cut emerges
-(e.g., extract token-bucket first because it has even fewer call
-sites), the plan can swap order — Phase 1 must just be the
-smallest defensible cohesive piece.
+If during Phase 1 review a smaller or different first cut emerges,
+the plan can swap order — Phase 1 must just be the smallest
+defensible cohesive piece.

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,6 +1,24 @@
 # #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
 
-Plan v4 — 2026-04-29. Addresses Codex round-3 (task-mokbrce8-p76zar):
+Plan v5 — 2026-04-29. Addresses Codex round-4 (task-mokc037q-sjefmd):
+three stale-text findings.
+
+A. Module declaration style: v4 said `pub(super) mod cos;` and
+   claimed to match `pub(super) mod tx;` — but the existing local
+   style is `#[path = "afxdp/tx.rs"] mod tx;` (private, explicit
+   path). Now matches: `#[path = "afxdp/cos/mod.rs"] mod cos;`.
+
+B. Stale fixture-history at the round-1 changelog still said the
+   plan "keeps fixtures in `tx::tests`" — superseded by v2+. Now
+   says fixtures move to the existing `afxdp::test_fixtures`
+   module (with a back-reference to the corrected actionable
+   section).
+
+C. v3-changelog summary said "8-phase plan ends at builders" —
+   wrong, builders is Phase 6, queue_service Phase 7, cross_binding
+   Phase 8. Corrected.
+
+v4 — Addresses Codex round-3 (task-mokbrce8-p76zar):
 three findings.
 
 i. ECN codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`,
@@ -69,9 +87,11 @@ five blocking findings, all fixed.
    `_rejects_unknown_ethertype`).
 
 4. Test fixtures (`build_ipv4_test_packet` etc.) are shared between
-   moving marker tests AND staying admission tests. Plan now keeps
-   fixtures in `tx::tests` (made `pub(super)`) so `cos::ecn::tests`
-   can import them. Fixtures re-evaluate their home in Phase 2.
+   moving marker tests AND staying admission tests. v2 superseded
+   the v1 plan and now moves the shared fixtures out of `tx::tests`
+   into the existing `afxdp::test_fixtures` module (see the
+   actionable Test fixtures section in v3+ for the corrected
+   approach).
 
 5. Path import: `super::ethernet` is wrong from inside `cos::ecn`.
    Use `crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN}` (or
@@ -85,7 +105,8 @@ Plus future-phase ordering corrected:
   service depends on `cos_queue_push/pop` and the `CoSBatch` enum
   having a clear home.
 
-Now an 8-phase plan (Phase 1 = ECN; ends at builders).
+Now an 8-phase plan (Phase 1 = ECN; Phase 6 = builders; Phase 7 =
+queue_service; Phase 8 = cross_binding).
 
 ## Investigation findings (Claude, on commit 76384e9a)
 
@@ -271,15 +292,23 @@ DO NOT add a duplicate `#[cfg(test)] mod test_fixtures;` declaration
 in `afxdp.rs` — the existing `#[cfg(test)] #[path = ...] mod
 test_fixtures;` line at `afxdp.rs:93-94` is already in place.
 
-### Module declaration
+### Module declaration (Codex round-4 #1)
 
-Update `userspace-dp/src/afxdp.rs` to declare the new submodule:
+Match the existing local style at `afxdp.rs:97`:
 ```rust
-pub(super) mod cos;
+#[path = "afxdp/tx.rs"]
+mod tx;
 ```
 
-(or whatever visibility matches the existing `pub(super) mod tx;`
-pattern — investigation will pin the exact form.)
+So the new `cos` module declaration is:
+```rust
+#[path = "afxdp/cos/mod.rs"]
+mod cos;
+```
+
+Private (no `pub`), explicit path. The `#[cfg(test)] #[path = ...]
+mod test_fixtures;` declaration at `afxdp.rs:93-94` already exists
+and is reused; do not add a duplicate.
 
 ### What this is NOT
 

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,0 +1,218 @@
+# #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
+
+Plan v1 — 2026-04-29.
+
+## Investigation findings (Claude, on commit 76384e9a)
+
+`userspace-dp/src/afxdp/tx.rs` is 18,008 lines with 153 functions.
+The issue ("#956: Deconstruct tx.rs God File into CoS Subsystems")
+asks for it to be broken into a dedicated `cos/` module. That is too
+large for one PR — moving 5K–10K LOC at once is high coordination
+risk and review fatigue. This PR is **Phase 1 of a multi-PR plan**.
+
+The major subsystems currently colocated in tx.rs:
+
+1. **XSK ring management** (descriptor pop/push, completion reap,
+   kick threshold) — pure XDP socket plumbing.
+2. **CoS pending-tx draining** (`drain_pending_tx`,
+   `drain_pending_tx_local_owner`, ingestion paths).
+3. **Cross-binding redirect** (`redirect_local_cos_request_to_owner`,
+   `redirect_prepared_cos_request_to_owner`, MPSC inbox handling).
+4. **CoS queue service** (`select_cos_guarantee_batch`,
+   `select_cos_surplus_batch`, `service_exact_*`, MQFQ virtual-time
+   selection).
+5. **ECN marking + parsing** (`maybe_mark_ecn_ce`,
+   `maybe_mark_ecn_ce_prepared`, `mark_ecn_ce_ipv4`,
+   `mark_ecn_ce_ipv6`, `ethernet_l3` + `EthernetL3` enum).
+6. **CoS admission policy** (`apply_cos_admission_ecn_policy`,
+   `apply_cos_queue_flow_fair_promotion`).
+7. **Token-bucket / timer wheel** (`refill_cos_tokens`,
+   `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+   `maybe_top_up_cos_root_lease`, etc.).
+8. **Flow-bucket hashing + share limits** (`mix_cos_flow_bucket`,
+   `exact_cos_flow_bucket`, `cos_queue_flow_share_limit`,
+   `cos_flow_aware_buffer_limit`, account_*).
+9. **CoS queue ops** (`cos_queue_push_*`, `cos_queue_pop_*`,
+   `cos_queue_len`, `cos_queue_min_finish_bucket`).
+10. **Builders + appliers** (`build_cos_interface_runtime`,
+    `apply_cos_send_result`, `apply_cos_prepared_result`).
+
+### Phase 1 scope (this PR): extract `cos/ecn.rs`
+
+ECN marking is the most self-contained subsystem in the file. It
+has:
+- A small bounded surface: 4 mutating functions
+  (`maybe_mark_ecn_ce`, `maybe_mark_ecn_ce_prepared`,
+  `mark_ecn_ce_ipv4`, `mark_ecn_ce_ipv6`) plus the `ethernet_l3`
+  parser + `EthernetL3` enum.
+- 8 named ECN constants (`COS_ECN_MARK_THRESHOLD_NUM`,
+  `COS_ECN_MARK_THRESHOLD_DEN`, `ECN_MASK`, `ECN_NOT_ECT`,
+  `ECN_ECT_0`, `ECN_ECT_1`, `ECN_CE`) with two compile-time
+  invariants (`const _: () = assert!`).
+- 13 existing unit tests dense across all branches (ECT-0/ECT-1/
+  not-ECT/CE-untouched/short-buffer × v4/v6, plus QinQ rejection
+  and tagged-non-IP rejection).
+- Three call sites in tx.rs: `apply_cos_admission_ecn_policy`
+  (lines ~3700-3796 within tx.rs) and elsewhere.
+
+It does NOT depend on other CoS subsystems (token bucket, queue ops,
+builders) — only on `super::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN}`,
+`TxRequest`, `PreparedTxRequest`, and `MmapArea`. Self-contained.
+
+Phase 1 establishes the `cos/` submodule pattern that Phase 2+ PRs
+will extend.
+
+## Approach
+
+Create the new module:
+
+```
+userspace-dp/src/afxdp/cos/
+├── mod.rs       — module declaration + re-exports
+└── ecn.rs       — moved code (constants, EthernetL3, helpers, tests)
+```
+
+Move from `tx.rs`:
+- All 8 ECN constants + the two compile-time invariants.
+- `EthernetL3` enum.
+- `ethernet_l3` parser.
+- `mark_ecn_ce_ipv4` and `mark_ecn_ce_ipv6` helpers.
+- `maybe_mark_ecn_ce` and `maybe_mark_ecn_ce_prepared`.
+- All 13 unit tests for the above.
+
+Update `tx.rs`:
+- Remove the moved items.
+- `use super::cos::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};`
+  for the call sites that survive in tx.rs.
+- Make `COS_ECN_MARK_THRESHOLD_NUM` / `_DEN` `pub(super) const` in
+  `cos::ecn` so `apply_cos_admission_ecn_policy` (which stays in
+  tx.rs in this phase) can still reach them.
+
+Update `userspace-dp/src/afxdp.rs` to declare the new submodule:
+```rust
+mod cos;
+```
+
+(Or the appropriate spot in the existing `mod` declarations —
+investigation will pin the exact location.)
+
+### What this is NOT
+
+- Not a behavior change. Every moved item is dropped into
+  `cos/ecn.rs` with identical signature and body.
+- Not a rename. Function names and constant names stay the same.
+- Not the full `cos/` submodule decomposition. Phase 2+ extends
+  with admission, queue service, builders, etc.
+- Not a perf claim. Moving code between files does not change
+  generated code if visibilities and `#[inline]` attributes are
+  preserved.
+
+## Files touched
+
+- **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC declaring
+  `pub(super) mod ecn;`.
+- **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~250 LOC (moved
+  code + 13 tests).
+- `userspace-dp/src/afxdp/tx.rs`: removes ~250 LOC (moved code +
+  tests), adds 1 `use` statement + visibility tweak. Net: ~250 LOC
+  smaller.
+- `userspace-dp/src/afxdp.rs`: adds `mod cos;` declaration (1 LOC).
+
+## Tests
+
+All 13 existing ECN/ethernet_l3 tests must continue to pass:
+- `mark_ecn_ce_ipv4_converts_ect0_to_ce_and_updates_checksum`
+- `mark_ecn_ce_ipv4_converts_ect1_to_ce_and_updates_checksum`
+- `mark_ecn_ce_ipv4_leaves_not_ect_untouched`
+- `mark_ecn_ce_ipv4_leaves_ce_untouched`
+- `mark_ecn_ce_ipv4_rejects_short_buffer`
+- `mark_ecn_ce_ipv6_converts_ect0_to_ce`
+- `mark_ecn_ce_ipv6_converts_ect1_to_ce`
+- `mark_ecn_ce_ipv6_leaves_not_ect_untouched`
+- `mark_ecn_ce_ipv6_leaves_ce_untouched`
+- `mark_ecn_ce_ipv6_rejects_short_buffer`
+- `ethernet_l3_rejects_qinq_until_explicitly_supported`
+- `ethernet_l3_rejects_vlan_tagged_non_ip_payload`
+- (one more `ethernet_l3` test — verified during investigation)
+
+No new tests required — the refactor is structure-only and the
+existing test suite has dense branch coverage.
+
+## Acceptance gates
+
+The repo has no root `Cargo.toml`; cargo commands must run with
+`--manifest-path userspace-dp/Cargo.toml`.
+
+1. `cargo build --release --manifest-path userspace-dp/Cargo.toml`
+   clean (no new warnings beyond baseline).
+2. `cargo test --release --manifest-path userspace-dp/Cargo.toml`
+   ≥ baseline (865 post-#963), 0 failed.
+3. Cluster smoke (HARD): no regression on the warmed-flow-cache
+   path. Run on `loss:xpf-userspace-fw0/fw1` AND with CoS configured
+   via `test/incus/cos-iperf-config.set`. CoS state is wiped by
+   `cluster-deploy`, so the smoke runner must re-apply the fixture
+   before measurement. The ECN marking path is exercised when
+   queues fill — iperf-c at ≥ 22 Gb/s through the 25 g shape will
+   hit it.
+
+   | Class       | Port  | Shape | P=12 gate     |
+   |-------------|-------|-------|---------------|
+   | iperf-c     | 5203  | 25 g  | ≥ 22 Gb/s     |
+   | iperf-f     | 5206  | 19 g  | ≥ 17.1 Gb/s   |
+   | iperf-e     | 5205  | 16 g  | ≥ 14.4 Gb/s   |
+   | iperf-d     | 5204  | 13 g  | ≥ 11.7 Gb/s   |
+   | iperf-b     | 5202  | 10 g  | ≥ 9.0 Gb/s    |
+   | iperf-a     | 5201  | 1 g   | ≥ 0.9 Gb/s    |
+   | best-effort | 5207  | 100 m | ≥ 90 Mb/s     |
+
+   Every P=12 row is a blocking gate. iperf-c also keeps the P=1
+   ≥ 6 Gb/s historical gate.
+
+4. Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot fw0
+   at +20s, fw1 takes over within 10s, iperf3 average ≥ 1 Gb/s and
+   ≥ 5 GB received.
+5. Codex hostile review (plan + impl): AGREE-TO-MERGE.
+6. Gemini adversarial review (plan + impl): AGREE-TO-MERGE.
+7. Copilot review on PR: all valid findings addressed.
+
+## Risk
+
+**Low.** Pure structural refactor — no algorithm changes, no
+behavior change. The moved code is ~250 LOC of leaf functions and
+constants with dense test coverage. The only realistic risk is a
+visibility / `use`-statement mistake during the cut, caught at
+compile time.
+
+The compile-time invariants
+`const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);`
+and
+`const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);`
+must move with the constants and continue to fire — verified by
+the build still succeeding.
+
+## Out of scope (future Phase 2+ PRs)
+
+This PR is the first in a chain. Subsequent PRs (one issue, one PR
+each, but tracked under #956 umbrella) will extract:
+
+- **Phase 2**: `cos/admission.rs` — `apply_cos_admission_ecn_policy`,
+  `apply_cos_queue_flow_fair_promotion`, the per-flow share-cap
+  helpers (`cos_queue_flow_share_limit`,
+  `cos_flow_aware_buffer_limit`, account_*).
+- **Phase 3**: `cos/token_bucket.rs` — `refill_cos_tokens`,
+  `maybe_top_up_*`, `cos_tick_for_ns`, `cos_timer_wheel_*`.
+- **Phase 4**: `cos/flow_hash.rs` — flow-bucket hashing helpers.
+- **Phase 5**: `cos/queue_service.rs` — `select_cos_*`,
+  `service_exact_*`, `drain_shaped_tx`, MQFQ virtual-time logic.
+- **Phase 6**: `cos/cross_binding.rs` — redirect logic + MPSC.
+- **Phase 7**: `cos/builders.rs` — `build_cos_interface_runtime`,
+  `apply_cos_send_result`, etc.
+
+After Phase 7 the `tx.rs` left in place is just XSK ring management
++ orchestration glue (~3-5K LOC). Each phase is independently
+reviewable, smokeable, and mergeable.
+
+If during Phase 1 review a smaller or different first cut emerges
+(e.g., extract token-bucket first because it has even fewer call
+sites), the plan can swap order — Phase 1 must just be the
+smallest defensible cohesive piece.

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,6 +1,24 @@
 # #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
 
-Plan v3 — 2026-04-29. Addresses Codex round-2 (task-mokbj8l7-x8capj):
+Plan v4 — 2026-04-29. Addresses Codex round-3 (task-mokbrce8-p76zar):
+three findings.
+
+i. ECN codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`,
+   `ECN_ECT_1`, `ECN_CE`) cannot stay file-private to `cos::ecn`
+   because 15 admission tests in `tx::tests` use them directly.
+   Now `pub(in crate::afxdp)` and re-exported from `cos/mod.rs`.
+
+ii. Stale text in the Tests section still said fixtures "stay in
+    `tx::tests`" — contradicted the corrected Test-fixtures
+    section. Now consistent: fixtures move to the existing
+    `afxdp::test_fixtures` module.
+
+iii. `test_fixtures.rs` already EXISTS in the repo (declared at
+    `afxdp.rs:93-94` via `#[path = ...]` form). v3 said NEW;
+    v4 says EXTEND, and notes not to add a duplicate `mod`
+    declaration.
+
+v3 — Addresses Codex round-2 (task-mokbj8l7-x8capj):
 four blocking findings + one stale-text fix.
 
 a. Visibility re-export model corrected. `pub(super) use ecn::{...}`
@@ -194,9 +212,16 @@ re-export is a convenience so call sites can write
 
 The internal `EthernetL3` enum, `ethernet_l3` parser, and the
 `mark_ecn_ce_ipv4`/`_ipv6` helpers stay file-private (no `pub`)
-since they have no callers outside `cos::ecn` after the move. The 5
-codepoint masks (`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`, `ECN_ECT_1`,
-`ECN_CE`) likewise stay file-private.
+since they have no callers outside `cos::ecn` after the move.
+
+**ECN codepoint masks (Codex round-3 #1)**: the 5 codepoint masks
+(`ECN_MASK`, `ECN_NOT_ECT`, `ECN_ECT_0`, `ECN_ECT_1`, `ECN_CE`)
+ARE used by 15 admission tests that stay in `tx::tests` (at
+`tx.rs:15612` and `tx.rs:16462`). They cannot stay file-private to
+`cos::ecn`. Make them `pub(in crate::afxdp)` so internal tests and
+admission code can still import them via
+`use crate::afxdp::cos::ecn::{ECN_MASK, ...};` (or via a
+`pub(super) use ecn::{ECN_MASK, ...};` re-export from `cos/mod.rs`).
 
 ### Path imports (Codex round-1 #5)
 
@@ -219,29 +244,32 @@ flagged that my proposed fix (`pub(super) fn` inside
 cross-importing from another module's `mod tests` is brittle even
 with `pub(super)` on the helpers.
 
-**Decision (Codex round-2 #2 preferred fix)**: introduce a new
-`#[cfg(test)] mod test_fixtures;` at `userspace-dp/src/afxdp/`
-(sibling of `tx.rs` and the new `cos/`). It carries the shared
-fixture functions with `pub(in crate::afxdp)` visibility:
+**Decision (Codex round-2 #2 preferred fix, refined per round-3 #3)**:
+extend the EXISTING `userspace-dp/src/afxdp/test_fixtures.rs`
+module (already declared at `afxdp.rs:93-94` via
+`#[cfg(test)] #[path = "afxdp/test_fixtures.rs"] mod test_fixtures;`).
+Move the shared fixtures out of `tx::tests` into
+`test_fixtures.rs`, matching the existing `pub(super)` visibility
+pattern used by `forwarding_snapshot`, `nat_snapshot`, etc.:
 
 ```rust
-// userspace-dp/src/afxdp/test_fixtures.rs
-#![cfg(test)]
-pub(in crate::afxdp) fn build_ipv4_test_packet(...) -> Vec<u8> { ... }
-pub(in crate::afxdp) fn build_ipv6_test_packet(...) -> Vec<u8> { ... }
-pub(in crate::afxdp) fn compute_ipv4_header_checksum(hdr: &[u8]) -> u16 { ... }
-pub(in crate::afxdp) fn insert_single_vlan_tag(...) -> Vec<u8> { ... }
-pub(in crate::afxdp) fn test_prepared_item_in_umem(...) -> ... { ... }
+// userspace-dp/src/afxdp/test_fixtures.rs (extended)
+pub(super) fn build_ipv4_test_packet(...) -> Vec<u8> { ... }
+pub(super) fn build_ipv6_test_packet(...) -> Vec<u8> { ... }
+pub(super) fn compute_ipv4_header_checksum(hdr: &[u8]) -> u16 { ... }
+pub(super) fn insert_single_vlan_tag(...) -> Vec<u8> { ... }
+pub(super) fn test_prepared_item_in_umem(...) -> ... { ... }
 ```
 
-`tx::tests` and `cos::ecn::tests` both import via
-`use crate::afxdp::test_fixtures::*;`. This is robust against
-future moves and works with the existing `mod tests` private-by-
-default convention.
+`pub(super)` here exposes the items to `afxdp` (the parent of
+`afxdp::test_fixtures`); `afxdp::tx::tests` and
+`afxdp::cos::ecn::tests` reach them via
+`use crate::afxdp::test_fixtures::*;` (descendants of `afxdp` can
+access items visible to `afxdp` itself).
 
-The fixtures get moved out of `tx::tests` in this PR (small,
-self-contained move) so the marker tests can reach them from
-`cos::ecn::tests`.
+DO NOT add a duplicate `#[cfg(test)] mod test_fixtures;` declaration
+in `afxdp.rs` — the existing `#[cfg(test)] #[path = ...] mod
+test_fixtures;` line at `afxdp.rs:93-94` is already in place.
 
 ### Module declaration
 
@@ -269,17 +297,25 @@ pattern — investigation will pin the exact form.)
 - **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC declaring
   `pub(super) mod ecn;`.
 - **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~250 LOC (moved
-  code + 15 tests; round-2 #5 caught a stale "13 tests" residue).
+  code + 15 tests).
 - **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC (`pub(super)
-  mod ecn;` + `pub(super) use ecn::{maybe_mark_ecn_ce, ...};`).
-- **NEW** `userspace-dp/src/afxdp/test_fixtures.rs`: ~80 LOC of
-  shared test fixtures moved out of `tx::tests`.
+  mod ecn;` + `pub(super) use ecn::{maybe_mark_ecn_ce,
+  maybe_mark_ecn_ce_prepared, ECN_MASK, ECN_NOT_ECT, ECN_ECT_0,
+  ECN_ECT_1, ECN_CE};`).
+- `userspace-dp/src/afxdp/test_fixtures.rs` (EXISTS,
+  ~860 LOC currently): EXTENDED with the ~80 LOC of shared fixtures
+  moved out of `tx::tests` (`build_ipv4_test_packet`,
+  `build_ipv6_test_packet`, `compute_ipv4_header_checksum`,
+  `insert_single_vlan_tag`, `test_prepared_item_in_umem`). Existing
+  `pub(super)` visibility pattern preserved.
 - `userspace-dp/src/afxdp/tx.rs`: removes ~250 LOC (moved code +
   marker tests), removes ~80 LOC (fixtures moved to `test_fixtures.rs`),
-  adds `use` statements pointing at `cos::ecn` and
-  `test_fixtures`. Net: ~330 LOC smaller.
-- `userspace-dp/src/afxdp.rs`: adds `pub(super) mod cos;` and
-  `#[cfg(test)] pub(in crate::afxdp) mod test_fixtures;` (~2 LOC).
+  adds `use` statements pointing at `cos::{...}` and
+  `test_fixtures::*`. Net: ~330 LOC smaller.
+- `userspace-dp/src/afxdp.rs`: adds `pub(super) mod cos;` (~1 LOC).
+  The existing `#[cfg(test)] #[path = "afxdp/test_fixtures.rs"]
+  mod test_fixtures;` line at `afxdp.rs:93-94` already declares the
+  test_fixtures module — DO NOT add a duplicate (Codex round-3 #3).
 
 ## Tests
 
@@ -305,8 +341,10 @@ The **15 admission-path tests** that exercise the marker indirectly
 through `apply_cos_admission_ecn_policy` (including the Prepared
 UMEM path and VLAN Prepared path) STAY in `tx::tests` because the
 admission policy stays in `tx.rs` (see Phase 1 scope). They depend
-on shared fixtures that also stay in `tx::tests` and are made
-`pub(super)` so `cos::ecn::tests` can import them.
+on shared fixtures that this PR moves out of `tx::tests` into the
+existing `afxdp::test_fixtures` module (per the Test fixtures
+section above), so both staying admission tests and moving marker
+tests can `use crate::afxdp::test_fixtures::*;`.
 
 No new tests required — the refactor is structure-only and the
 existing test suite has dense branch coverage.

--- a/docs/pr/956-tx-decomposition/plan.md
+++ b/docs/pr/956-tx-decomposition/plan.md
@@ -1,6 +1,19 @@
 # #956 Phase 1: extract cos/ecn.rs from tx.rs (establish the cos/ submodule)
 
-Plan v5 — 2026-04-29. Addresses Codex round-4 (task-mokc037q-sjefmd):
+Plan v6 — 2026-04-29. Addresses Codex round-5 (task-mokc6mah-pcctmc):
+three minor inventory cleanups.
+
+α. Files-touched section duplicated the `cos/mod.rs` entry — kept
+   only the fuller one with the `pub(super) use` re-export list.
+
+β. Files-touched section's `afxdp.rs` bullet still said `pub(super)
+   mod cos;` — contradicted the corrected actionable section.
+   Updated to `#[path = "afxdp/cos/mod.rs"] mod cos;`.
+
+γ. v4 estimated test_fixtures.rs at ~860 LOC; actual at this commit
+   is 663 LOC. Corrected.
+
+v5 — Addresses Codex round-4 (task-mokc037q-sjefmd):
 three stale-text findings.
 
 A. Module declaration style: v4 said `pub(super) mod cos;` and
@@ -323,17 +336,17 @@ and is reused; do not add a duplicate.
 
 ## Files touched
 
-- **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC declaring
-  `pub(super) mod ecn;`.
 - **NEW** `userspace-dp/src/afxdp/cos/ecn.rs`: ~250 LOC (moved
   code + 15 tests).
-- **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC (`pub(super)
-  mod ecn;` + `pub(super) use ecn::{maybe_mark_ecn_ce,
+- **NEW** `userspace-dp/src/afxdp/cos/mod.rs`: ~5 LOC — `mod ecn;`
+  plus `pub(super) use ecn::{maybe_mark_ecn_ce,
   maybe_mark_ecn_ce_prepared, ECN_MASK, ECN_NOT_ECT, ECN_ECT_0,
-  ECN_ECT_1, ECN_CE};`).
-- `userspace-dp/src/afxdp/test_fixtures.rs` (EXISTS,
-  ~860 LOC currently): EXTENDED with the ~80 LOC of shared fixtures
-  moved out of `tx::tests` (`build_ipv4_test_packet`,
+  ECN_ECT_1, ECN_CE};`. (Codex round-5 #2 caught a duplicate entry
+  in v5.)
+- `userspace-dp/src/afxdp/test_fixtures.rs` (EXISTS, currently
+  ~663 LOC at this commit; round-5 #3 corrected the v4 ~860 LOC
+  estimate): EXTENDED with the ~80 LOC of shared fixtures moved
+  out of `tx::tests` (`build_ipv4_test_packet`,
   `build_ipv6_test_packet`, `compute_ipv4_header_checksum`,
   `insert_single_vlan_tag`, `test_prepared_item_in_umem`). Existing
   `pub(super)` visibility pattern preserved.
@@ -341,7 +354,10 @@ and is reused; do not add a duplicate.
   marker tests), removes ~80 LOC (fixtures moved to `test_fixtures.rs`),
   adds `use` statements pointing at `cos::{...}` and
   `test_fixtures::*`. Net: ~330 LOC smaller.
-- `userspace-dp/src/afxdp.rs`: adds `pub(super) mod cos;` (~1 LOC).
+- `userspace-dp/src/afxdp.rs`: adds `#[path = "afxdp/cos/mod.rs"]
+  mod cos;` (private, explicit path, matching the existing
+  `#[path = "afxdp/tx.rs"] mod tx;` pattern at line 97 — Codex
+  round-5 #1 caught a stale `pub(super) mod cos;` residue in v4).
   The existing `#[cfg(test)] #[path = "afxdp/test_fixtures.rs"]
   mod test_fixtures;` line at `afxdp.rs:93-94` already declares the
   test_fixtures module — DO NOT add a duplicate (Codex round-3 #3).

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -87,6 +87,8 @@ mod rst;
 mod sharded_neighbor;
 #[path = "afxdp/session_glue.rs"]
 mod session_glue;
+#[path = "afxdp/cos/mod.rs"]
+mod cos;
 #[path = "afxdp/shared_ops.rs"]
 mod shared_ops;
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/cos/ecn.rs
+++ b/userspace-dp/src/afxdp/cos/ecn.rs
@@ -1,0 +1,239 @@
+// #956 Phase 1: ECN marking + Ethernet L3 parser, extracted from
+// tx.rs. The threshold constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`
+// and the admission policy `apply_cos_admission_ecn_policy` STAY in
+// tx.rs in this phase — they are admission-policy tuning knobs and
+// move with admission to cos/admission.rs in Phase 2 (correct
+// dependency direction; a byte-mutation module should not own
+// admission tuning).
+//
+// Tests that exercise these helpers continue to live in `tx::tests`
+// in Phase 1; they reach the moved items via
+// `use super::cos::ecn::{...}` (and the re-exports from
+// `cos/mod.rs`). Phase 2 will revisit test placement when the
+// admission-path tests they share fixtures with also move.
+
+use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
+use crate::afxdp::types::{PreparedTxRequest, TxRequest};
+use crate::afxdp::umem::MmapArea;
+
+/// ECN codepoint masks (low 2 bits of IPv4 TOS / IPv6 tclass).
+///
+/// `pub(in crate::afxdp)` because admission tests in `tx::tests`
+/// reference these masks directly (15 admission tests at
+/// `tx.rs:15612` and `tx.rs:16462` — see plan v3 round-3 #1).
+pub(in crate::afxdp) const ECN_MASK: u8 = 0b0000_0011;
+pub(in crate::afxdp) const ECN_NOT_ECT: u8 = 0b0000_0000;
+pub(in crate::afxdp) const ECN_ECT_0: u8 = 0b0000_0010;
+pub(in crate::afxdp) const ECN_ECT_1: u8 = 0b0000_0001;
+pub(in crate::afxdp) const ECN_CE: u8 = 0b0000_0011;
+
+/// Parsed L3 discriminator + offset from a forwarded Ethernet frame.
+/// Carries both pieces together so the ECN mark path dispatches off the
+/// bytes it actually parsed, not the `expected_addr_family` sideband —
+/// a malformed frame whose sideband says AF_INET but whose ethertype
+/// says something else must not get its "TOS byte" stamped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::afxdp) enum EthernetL3 {
+    Ipv4(usize),
+    Ipv6(usize),
+}
+
+/// Parse the outer Ethernet header, transparently walk a single 802.1Q
+/// / 802.1ad VLAN tag, and report the L3 family + header offset. The
+/// CoS admission path sees frames post-forward-build, so VLAN tags
+/// from tagged subinterfaces (e.g. `reth0 unit 80`) are already
+/// present. Callers use the returned family to dispatch to the
+/// matching ECN marker and the offset to locate the TOS / tclass byte.
+///
+/// Returns `None` for:
+/// - buffers shorter than the parse requires (no slice-out-of-bounds
+///   panic on the hot path),
+/// - non-IP ethertypes (including ARP, MPLS, and the tail of a QinQ
+///   stack) — we refuse to guess rather than stamp a byte that is not
+///   a TOS / tclass byte,
+/// - nested VLAN tags (QinQ / 802.1ad-over-Q) — not implemented yet;
+///   adding support means one more 4-byte hop plus recursive inner-
+///   ethertype inspection. The single-tag path covers the only lab
+///   fixture we currently exercise.
+///
+/// Historically this helper just returned an offset, and dispatch was
+/// based on `expected_addr_family`. The gap that exposed was: if the
+/// sideband said AF_INET but the frame was ARP-inside-VLAN, we would
+/// still compute offset = 18 and stamp byte 19 inside the ARP body.
+/// Returning the parsed family here closes that drift permanently —
+/// the marker cannot disagree with the wire bytes it is mutating.
+#[inline]
+pub(in crate::afxdp) fn ethernet_l3(bytes: &[u8]) -> Option<EthernetL3> {
+    if bytes.len() < ETH_HDR_LEN {
+        return None;
+    }
+    let outer = u16::from_be_bytes([bytes[12], bytes[13]]);
+    match outer {
+        0x0800 => Some(EthernetL3::Ipv4(ETH_HDR_LEN)),
+        0x86DD => Some(EthernetL3::Ipv6(ETH_HDR_LEN)),
+        // 802.1Q / 802.1ad single VLAN tag. The inner ethertype lives
+        // 4 bytes after the outer one; if that inner ethertype is
+        // *itself* a VLAN TPID we have a QinQ stack that we do not
+        // support yet — reject it rather than stamping into an inner
+        // tag.
+        0x8100 | 0x88A8 => {
+            let inner_off = ETH_HDR_LEN + VLAN_TAG_LEN;
+            if bytes.len() < inner_off + 2 {
+                return None;
+            }
+            let inner = u16::from_be_bytes([bytes[inner_off - 2], bytes[inner_off - 1]]);
+            match inner {
+                0x0800 => Some(EthernetL3::Ipv4(inner_off)),
+                0x86DD => Some(EthernetL3::Ipv6(inner_off)),
+                // QinQ or unknown inner — refuse to guess.
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Mark the IPv4 packet at `l3_offset` within `bytes` as ECN CE if it
+/// is already ECT(0) or ECT(1). Updates the IP header checksum
+/// incrementally (RFC 1624). Returns true iff the packet was marked.
+/// Never modifies a NOT-ECT packet (protects non-ECN flows per RFC
+/// 3168 section 6.1.1.1).
+#[inline]
+pub(in crate::afxdp) fn mark_ecn_ce_ipv4(bytes: &mut [u8], l3_offset: usize) -> bool {
+    // Need the full 20-byte base IPv4 header (through the checksum field).
+    // Short buffers are returned false rather than panicking — this path
+    // runs per admission on the hot path and cannot trust upstream
+    // length validation to have covered every corner.
+    let end = l3_offset.saturating_add(20);
+    if bytes.len() < end {
+        return false;
+    }
+    let tos_idx = l3_offset + 1;
+    let old_tos = bytes[tos_idx];
+    let ecn = old_tos & ECN_MASK;
+    // Branchless: only ECT(0) and ECT(1) cross to CE; NOT-ECT and CE
+    // are left unchanged. A non-ECT packet returning false routes into
+    // the existing admission drop path unchanged.
+    if ecn != ECN_ECT_0 && ecn != ECN_ECT_1 {
+        return false;
+    }
+    let new_tos = (old_tos & !ECN_MASK) | ECN_CE;
+    bytes[tos_idx] = new_tos;
+
+    // RFC 1624 incremental checksum update for a single byte change to
+    // the TOS field (16-bit word = [version/IHL, TOS]). The header
+    // checksum sits at l3_offset+10..l3_offset+12 in network byte order.
+    //
+    //   HC' = ~(~HC + ~m + m')
+    //
+    // where m and m' are the 16-bit words at the mutated position. The
+    // version/IHL byte is unchanged so it cancels inside `old_word` /
+    // `new_word` — but keeping it in the word avoids a conditional on
+    // which half of the 16-bit word we touched.
+    let ihl = bytes[l3_offset];
+    let old_word = ((ihl as u32) << 8) | old_tos as u32;
+    let new_word = ((ihl as u32) << 8) | new_tos as u32;
+    let csum_idx = l3_offset + 10;
+    let old_csum = ((bytes[csum_idx] as u32) << 8) | bytes[csum_idx + 1] as u32;
+    // ~HC + ~m + m' in 32-bit arithmetic, then fold carries.
+    let mut sum = (!old_csum & 0xffff) + (!old_word & 0xffff) + new_word;
+    // Fold any carries out of the low 16 bits. Two folds are sufficient
+    // for the three 16-bit addends above (max ~3 * 0xffff fits in 18
+    // bits, one fold collapses to 17 bits, second to 16 bits).
+    while sum > 0xffff {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    let new_csum = (!sum) & 0xffff;
+    bytes[csum_idx] = (new_csum >> 8) as u8;
+    bytes[csum_idx + 1] = (new_csum & 0xff) as u8;
+    true
+}
+
+/// Mark the IPv6 packet at `l3_offset` within `bytes` as ECN CE if it
+/// is already ECT(0) or ECT(1). IPv6 has no header checksum so no
+/// incremental update is needed. Returns true iff the packet was marked.
+#[inline]
+pub(in crate::afxdp) fn mark_ecn_ce_ipv6(bytes: &mut [u8], l3_offset: usize) -> bool {
+    // tclass spans the low nibble of byte[l3_offset] and the high
+    // nibble of byte[l3_offset+1]. We need both bytes in range.
+    let end = l3_offset.saturating_add(2);
+    if bytes.len() < end {
+        return false;
+    }
+    // Version/tclass-high byte: [vvvv tttt]. ECN bits are the low 2
+    // bits of tclass, which sit in the high nibble of byte[l3_offset+1]
+    // as bits 5..4. Extract with a simple shift-mask.
+    let b1 = bytes[l3_offset + 1];
+    let ecn = (b1 >> 4) & ECN_MASK;
+    if ecn != ECN_ECT_0 && ecn != ECN_ECT_1 {
+        return false;
+    }
+    // Clear the old ECN bits (bits 5..4 of byte[l3_offset+1]) and OR in
+    // CE shifted into place.
+    let cleared = b1 & !(ECN_MASK << 4);
+    bytes[l3_offset + 1] = cleared | (ECN_CE << 4);
+    true
+}
+
+/// Dispatch ECN marking based on the L3 protocol family stamped on
+/// the TxRequest. Returns true iff the packet was marked.
+#[inline]
+pub(in crate::afxdp) fn maybe_mark_ecn_ce(req: &mut TxRequest) -> bool {
+    // Dispatch off the parsed Ethernet header, not the sideband
+    // `expected_addr_family`. The sideband is populated at RX time and
+    // can drift for injected or re-queued frames whose wire bytes got
+    // rewritten (e.g. NAT64, tunnel transit). Trusting the parse keeps
+    // the marker from stamping the wrong protocol body on any frame
+    // where the two disagree.
+    match ethernet_l3(&req.bytes) {
+        Some(EthernetL3::Ipv4(l3_offset)) => mark_ecn_ce_ipv4(&mut req.bytes, l3_offset),
+        Some(EthernetL3::Ipv6(l3_offset)) => mark_ecn_ce_ipv6(&mut req.bytes, l3_offset),
+        None => false,
+    }
+}
+
+/// Mark a prepared (zero-copy) TX frame as ECN CE in place inside the
+/// UMEM. Only fires on ECT(0)/ECT(1) per RFC 3168 §6.1.1.1. Returns
+/// true iff the packet was marked. Out-of-range offset/len pairs
+/// (e.g. a PreparedTxRequest that somehow escaped bounds checks)
+/// return false without panicking — the caller falls through into
+/// the existing admission path unchanged.
+///
+/// This is the Prepared-variant counterpart to `maybe_mark_ecn_ce`;
+/// #718 / #722 originally only handled the Local variant, leaving
+/// the XSK-RX→XSK-TX zero-copy hot path (iperf3, NAT'd flows) with
+/// the marker dormant. See `docs/cos-validation-notes.md` for the
+/// counter-reading methodology.
+///
+/// # Safety
+///
+/// The caller must hold exclusive access to the frame at
+/// `[req.offset, req.offset + req.len)` within `umem`. On the CoS
+/// admission path this is guaranteed: admission runs *before* the
+/// frame is enqueued into the CoS queue, let alone submitted to the
+/// XSK TX ring, so the worker that built the frame is still the sole
+/// owner. Callers that invoke this outside of the admission gate
+/// must provide the same guarantee.
+#[inline]
+pub(in crate::afxdp) fn maybe_mark_ecn_ce_prepared(
+    req: &PreparedTxRequest,
+    umem: &MmapArea,
+) -> bool {
+    let offset = req.offset as usize;
+    let len = req.len as usize;
+    // SAFETY: see function-level doc. The admission path owns the
+    // frame until `cos_queue_push_back` takes it, which is strictly
+    // after this call. Out-of-range slices return None (handled
+    // below) rather than producing a dangling reference.
+    let Some(bytes) = (unsafe { umem.slice_mut_unchecked(offset, len) }) else {
+        return false;
+    };
+    // Same rationale as `maybe_mark_ecn_ce`: dispatch off the parsed
+    // wire bytes, not `expected_addr_family`. See that helper's
+    // comment for the drift scenarios this protects against.
+    match ethernet_l3(bytes) {
+        Some(EthernetL3::Ipv4(l3_offset)) => mark_ecn_ce_ipv4(bytes, l3_offset),
+        Some(EthernetL3::Ipv6(l3_offset)) => mark_ecn_ce_ipv6(bytes, l3_offset),
+        None => false,
+    }
+}

--- a/userspace-dp/src/afxdp/cos/ecn.rs
+++ b/userspace-dp/src/afxdp/cos/ecn.rs
@@ -78,7 +78,13 @@ pub(in crate::afxdp) fn ethernet_l3(bytes: &[u8]) -> Option<EthernetL3> {
         // tag.
         0x8100 | 0x88A8 => {
             let inner_off = ETH_HDR_LEN + VLAN_TAG_LEN;
-            if bytes.len() < inner_off + 2 {
+            // Inner ethertype lives at bytes[inner_off-2..inner_off],
+            // so we only need `bytes.len() >= inner_off`. The downstream
+            // markers (`mark_ecn_ce_ipv4` / `_ipv6`) have their own
+            // bounds checks for the IP header itself; the parser must
+            // not over-reject frames that ARE long enough to identify
+            // the L3 family (Copilot review on PR #976).
+            if bytes.len() < inner_off {
                 return None;
             }
             let inner = u16::from_be_bytes([bytes[inner_off - 2], bytes[inner_off - 1]]);
@@ -175,8 +181,10 @@ pub(in crate::afxdp) fn mark_ecn_ce_ipv6(bytes: &mut [u8], l3_offset: usize) -> 
     true
 }
 
-/// Dispatch ECN marking based on the L3 protocol family stamped on
-/// the TxRequest. Returns true iff the packet was marked.
+/// Dispatch ECN marking based on the L3 protocol family parsed
+/// from the TxRequest's bytes (NOT the `expected_addr_family`
+/// sideband — see the dispatch body for the rationale). Returns
+/// true iff the packet was marked.
 #[inline]
 pub(in crate::afxdp) fn maybe_mark_ecn_ce(req: &mut TxRequest) -> bool {
     // Dispatch off the parsed Ethernet header, not the sideband

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -1,0 +1,14 @@
+// #956 Phase 1: cos/ submodule. Phase 1 extracts ECN marking;
+// subsequent phases extend with admission, token bucket, flow hash,
+// queue ops, builders, queue service, and cross-binding (see
+// docs/pr/956-tx-decomposition/plan.md for the full phased plan).
+
+pub(super) mod ecn;
+
+// Re-export the items consumed by sibling `tx.rs`. The items
+// themselves are `pub(in crate::afxdp)` in `ecn.rs`; this re-export
+// shortens the import path on call sites.
+pub(super) use ecn::{
+    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
+    ECN_NOT_ECT,
+};

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3538,222 +3538,17 @@ const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
 const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);
 const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
 
-/// ECN codepoint masks (low 2 bits of IPv4 TOS / IPv6 tclass).
-const ECN_MASK: u8 = 0b0000_0011;
-const ECN_NOT_ECT: u8 = 0b0000_0000;
-const ECN_ECT_0: u8 = 0b0000_0010;
-const ECN_ECT_1: u8 = 0b0000_0001;
-const ECN_CE: u8 = 0b0000_0011;
-
-use super::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
-
-/// Parsed L3 discriminator + offset from a forwarded Ethernet frame.
-/// Carries both pieces together so the ECN mark path dispatches off the
-/// bytes it actually parsed, not the `expected_addr_family` sideband —
-/// a malformed frame whose sideband says AF_INET but whose ethertype
-/// says something else must not get its "TOS byte" stamped.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EthernetL3 {
-    Ipv4(usize),
-    Ipv6(usize),
-}
-
-/// Parse the outer Ethernet header, transparently walk a single 802.1Q
-/// / 802.1ad VLAN tag, and report the L3 family + header offset. The
-/// CoS admission path sees frames post-forward-build, so VLAN tags
-/// from tagged subinterfaces (e.g. `reth0 unit 80`) are already
-/// present. Callers use the returned family to dispatch to the
-/// matching ECN marker and the offset to locate the TOS / tclass byte.
-///
-/// Returns `None` for:
-/// - buffers shorter than the parse requires (no slice-out-of-bounds
-///   panic on the hot path),
-/// - non-IP ethertypes (including ARP, MPLS, and the tail of a QinQ
-///   stack) — we refuse to guess rather than stamp a byte that is not
-///   a TOS / tclass byte,
-/// - nested VLAN tags (QinQ / 802.1ad-over-Q) — not implemented yet;
-///   adding support means one more 4-byte hop plus recursive inner-
-///   ethertype inspection. The single-tag path covers the only lab
-///   fixture we currently exercise.
-///
-/// Historically this helper just returned an offset, and dispatch was
-/// based on `expected_addr_family`. The gap that exposed was: if the
-/// sideband said AF_INET but the frame was ARP-inside-VLAN, we would
-/// still compute offset = 18 and stamp byte 19 inside the ARP body.
-/// Returning the parsed family here closes that drift permanently —
-/// the marker cannot disagree with the wire bytes it is mutating.
-#[inline]
-fn ethernet_l3(bytes: &[u8]) -> Option<EthernetL3> {
-    if bytes.len() < ETH_HDR_LEN {
-        return None;
-    }
-    let outer = u16::from_be_bytes([bytes[12], bytes[13]]);
-    match outer {
-        0x0800 => Some(EthernetL3::Ipv4(ETH_HDR_LEN)),
-        0x86DD => Some(EthernetL3::Ipv6(ETH_HDR_LEN)),
-        // 802.1Q / 802.1ad single VLAN tag. The inner ethertype lives
-        // 4 bytes after the outer one; if that inner ethertype is
-        // *itself* a VLAN TPID we have a QinQ stack that we do not
-        // support yet — reject it rather than stamping into an inner
-        // tag.
-        0x8100 | 0x88A8 => {
-            let inner_off = ETH_HDR_LEN + VLAN_TAG_LEN;
-            if bytes.len() < inner_off + 2 {
-                return None;
-            }
-            let inner = u16::from_be_bytes([bytes[inner_off - 2], bytes[inner_off - 1]]);
-            match inner {
-                0x0800 => Some(EthernetL3::Ipv4(inner_off)),
-                0x86DD => Some(EthernetL3::Ipv6(inner_off)),
-                // QinQ or unknown inner — refuse to guess.
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
-
-/// Mark the IPv4 packet at `l3_offset` within `bytes` as ECN CE if it
-/// is already ECT(0) or ECT(1). Updates the IP header checksum
-/// incrementally (RFC 1624). Returns true iff the packet was marked.
-/// Never modifies a NOT-ECT packet (protects non-ECN flows per RFC
-/// 3168 section 6.1.1.1).
-#[inline]
-fn mark_ecn_ce_ipv4(bytes: &mut [u8], l3_offset: usize) -> bool {
-    // Need the full 20-byte base IPv4 header (through the checksum field).
-    // Short buffers are returned false rather than panicking — this path
-    // runs per admission on the hot path and cannot trust upstream
-    // length validation to have covered every corner.
-    let end = l3_offset.saturating_add(20);
-    if bytes.len() < end {
-        return false;
-    }
-    let tos_idx = l3_offset + 1;
-    let old_tos = bytes[tos_idx];
-    let ecn = old_tos & ECN_MASK;
-    // Branchless: only ECT(0) and ECT(1) cross to CE; NOT-ECT and CE
-    // are left unchanged. A non-ECT packet returning false routes into
-    // the existing admission drop path unchanged.
-    if ecn != ECN_ECT_0 && ecn != ECN_ECT_1 {
-        return false;
-    }
-    let new_tos = (old_tos & !ECN_MASK) | ECN_CE;
-    bytes[tos_idx] = new_tos;
-
-    // RFC 1624 incremental checksum update for a single byte change to
-    // the TOS field (16-bit word = [version/IHL, TOS]). The header
-    // checksum sits at l3_offset+10..l3_offset+12 in network byte order.
-    //
-    //   HC' = ~(~HC + ~m + m')
-    //
-    // where m and m' are the 16-bit words at the mutated position. The
-    // version/IHL byte is unchanged so it cancels inside `old_word` /
-    // `new_word` — but keeping it in the word avoids a conditional on
-    // which half of the 16-bit word we touched.
-    let ihl = bytes[l3_offset];
-    let old_word = ((ihl as u32) << 8) | old_tos as u32;
-    let new_word = ((ihl as u32) << 8) | new_tos as u32;
-    let csum_idx = l3_offset + 10;
-    let old_csum = ((bytes[csum_idx] as u32) << 8) | bytes[csum_idx + 1] as u32;
-    // ~HC + ~m + m' in 32-bit arithmetic, then fold carries.
-    let mut sum = (!old_csum & 0xffff) + (!old_word & 0xffff) + new_word;
-    // Fold any carries out of the low 16 bits. Two folds are sufficient
-    // for the three 16-bit addends above (max ~3 * 0xffff fits in 18
-    // bits, one fold collapses to 17 bits, second to 16 bits).
-    while sum > 0xffff {
-        sum = (sum & 0xffff) + (sum >> 16);
-    }
-    let new_csum = (!sum) & 0xffff;
-    bytes[csum_idx] = (new_csum >> 8) as u8;
-    bytes[csum_idx + 1] = (new_csum & 0xff) as u8;
-    true
-}
-
-/// Mark the IPv6 packet at `l3_offset` within `bytes` as ECN CE if it
-/// is already ECT(0) or ECT(1). IPv6 has no header checksum so no
-/// incremental update is needed. Returns true iff the packet was marked.
-#[inline]
-fn mark_ecn_ce_ipv6(bytes: &mut [u8], l3_offset: usize) -> bool {
-    // tclass spans the low nibble of byte[l3_offset] and the high
-    // nibble of byte[l3_offset+1]. We need both bytes in range.
-    let end = l3_offset.saturating_add(2);
-    if bytes.len() < end {
-        return false;
-    }
-    // Version/tclass-high byte: [vvvv tttt]. ECN bits are the low 2
-    // bits of tclass, which sit in the high nibble of byte[l3_offset+1]
-    // as bits 5..4. Extract with a simple shift-mask.
-    let b1 = bytes[l3_offset + 1];
-    let ecn = (b1 >> 4) & ECN_MASK;
-    if ecn != ECN_ECT_0 && ecn != ECN_ECT_1 {
-        return false;
-    }
-    // Clear the old ECN bits (bits 5..4 of byte[l3_offset+1]) and OR in
-    // CE shifted into place.
-    let cleared = b1 & !(ECN_MASK << 4);
-    bytes[l3_offset + 1] = cleared | (ECN_CE << 4);
-    true
-}
-
-/// Dispatch ECN marking based on the L3 protocol family stamped on
-/// the TxRequest. Returns true iff the packet was marked.
-#[inline]
-fn maybe_mark_ecn_ce(req: &mut TxRequest) -> bool {
-    // Dispatch off the parsed Ethernet header, not the sideband
-    // `expected_addr_family`. The sideband is populated at RX time and
-    // can drift for injected or re-queued frames whose wire bytes got
-    // rewritten (e.g. NAT64, tunnel transit). Trusting the parse keeps
-    // the marker from stamping the wrong protocol body on any frame
-    // where the two disagree.
-    match ethernet_l3(&req.bytes) {
-        Some(EthernetL3::Ipv4(l3_offset)) => mark_ecn_ce_ipv4(&mut req.bytes, l3_offset),
-        Some(EthernetL3::Ipv6(l3_offset)) => mark_ecn_ce_ipv6(&mut req.bytes, l3_offset),
-        None => false,
-    }
-}
-
-/// Mark a prepared (zero-copy) TX frame as ECN CE in place inside the
-/// UMEM. Only fires on ECT(0)/ECT(1) per RFC 3168 §6.1.1.1. Returns
-/// true iff the packet was marked. Out-of-range offset/len pairs
-/// (e.g. a PreparedTxRequest that somehow escaped bounds checks)
-/// return false without panicking — the caller falls through into
-/// the existing admission path unchanged.
-///
-/// This is the Prepared-variant counterpart to `maybe_mark_ecn_ce`;
-/// #718 / #722 originally only handled the Local variant, leaving
-/// the XSK-RX→XSK-TX zero-copy hot path (iperf3, NAT'd flows) with
-/// the marker dormant. See `docs/cos-validation-notes.md` for the
-/// counter-reading methodology.
-///
-/// # Safety
-///
-/// The caller must hold exclusive access to the frame at
-/// `[req.offset, req.offset + req.len)` within `umem`. On the CoS
-/// admission path this is guaranteed: admission runs *before* the
-/// frame is enqueued into the CoS queue, let alone submitted to the
-/// XSK TX ring, so the worker that built the frame is still the sole
-/// owner. Callers that invoke this outside of the admission gate
-/// must provide the same guarantee.
-#[inline]
-fn maybe_mark_ecn_ce_prepared(req: &PreparedTxRequest, umem: &MmapArea) -> bool {
-    let offset = req.offset as usize;
-    let len = req.len as usize;
-    // SAFETY: see function-level doc. The admission path owns the
-    // frame until `cos_queue_push_back` takes it, which is strictly
-    // after this call. Out-of-range slices return None (handled
-    // below) rather than producing a dangling reference.
-    let Some(bytes) = (unsafe { umem.slice_mut_unchecked(offset, len) }) else {
-        return false;
-    };
-    // Same rationale as `maybe_mark_ecn_ce`: dispatch off the parsed
-    // wire bytes, not `expected_addr_family`. See that helper's
-    // comment for the drift scenarios this protects against.
-    match ethernet_l3(bytes) {
-        Some(EthernetL3::Ipv4(l3_offset)) => mark_ecn_ce_ipv4(bytes, l3_offset),
-        Some(EthernetL3::Ipv6(l3_offset)) => mark_ecn_ce_ipv6(bytes, l3_offset),
-        None => false,
-    }
-}
+// #956 Phase 1: ECN codepoint masks, EthernetL3 enum, ethernet_l3
+// parser, mark_ecn_ce_ipv4/ipv6, and maybe_mark_ecn_ce/_prepared
+// were extracted to userspace-dp/src/afxdp/cos/ecn.rs. Admission
+// policy `apply_cos_admission_ecn_policy` (and the threshold
+// constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`) stay here; they
+// move with admission to cos/admission.rs in Phase 2.
+use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
+use super::cos::{
+    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
+    ECN_NOT_ECT,
+};
 
 /// Core ECN admission decision, factored out so tests can drive it
 /// without spinning up a full `BindingWorker` while still exercising
@@ -16735,6 +16530,7 @@ mod tests {
     /// between the MAC addresses and the ethertype. Used by the
     /// VLAN-aware regression tests for both Local and Prepared paths.
     fn insert_single_vlan_tag(packet: Vec<u8>, vid: u16, priority: u8) -> Vec<u8> {
+        use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
         assert!(packet.len() >= ETH_HDR_LEN, "packet must be eth-framed");
         let mut tagged = Vec::with_capacity(packet.len() + VLAN_TAG_LEN);
         tagged.extend_from_slice(&packet[..12]); // dst + src MAC

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3544,11 +3544,18 @@ const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
 // policy `apply_cos_admission_ecn_policy` (and the threshold
 // constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`) stay here; they
 // move with admission to cos/admission.rs in Phase 2.
+//
+// Production code uses only the marker entry points; the
+// codepoint masks + parser + per-family helpers are referenced
+// only by `tx::tests` (admission tests + ECN unit tests that
+// stay here for Phase 1). The test-only imports are gated
+// behind `#[cfg(test)]` to avoid `unused_imports` warnings in
+// non-test builds (Copilot review on PR #976).
+use super::cos::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
+#[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
-use super::cos::{
-    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
-    ECN_NOT_ECT,
-};
+#[cfg(test)]
+use super::cos::{ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
 
 /// Core ECN admission decision, factored out so tests can drive it
 /// without spinning up a full `BindingWorker` while still exercising


### PR DESCRIPTION
## Summary

First step in decomposing `userspace-dp/src/afxdp/tx.rs` (18,008 lines / 153 functions) into a dedicated `cos/` submodule. Phase 1 extracts the most self-contained CoS subsystem (ECN marking, ~210 LOC) and establishes the pattern that subsequent phases extend.

Plan: `docs/pr/956-tx-decomposition/plan.md` (PLAN-READY at v6 after 6 rounds of Codex hostile review + Gemini AGREE-TO-MERGE-PLAN).

## Phased plan (this PR is Phase 1 of 8)

The full decomposition is too large for one PR (5K-10K LOC moved). Subsequent phases (separate PRs under #956 umbrella):
- **Phase 2**: `cos/flow_hash.rs` (precedes admission — `apply_cos_queue_flow_fair_promotion` calls `cos_flow_hash_seed_from_os`)
- **Phase 3**: `cos/admission.rs` (incl. `apply_cos_admission_ecn_policy` + `COS_ECN_MARK_THRESHOLD_*` + flow-share helpers)
- **Phase 4**: `cos/token_bucket.rs`
- **Phase 5**: `cos/queue_ops.rs`
- **Phase 6**: `cos/builders.rs` (precedes queue_service)
- **Phase 7**: `cos/queue_service.rs`
- **Phase 8**: `cos/cross_binding.rs`

## Implementation (Phase 1)

Moved from `tx.rs` to `userspace-dp/src/afxdp/cos/ecn.rs` (~210 LOC):
- 5 ECN codepoint masks (`ECN_MASK` / `NOT_ECT` / `ECT_0` / `ECT_1` / `CE`) — `pub(in crate::afxdp)` since admission tests still reference them.
- `EthernetL3` enum + `ethernet_l3` parser (single-VLAN aware, rejects QinQ + non-IP payloads).
- `mark_ecn_ce_ipv4` (RFC 1624 incremental checksum update) + `mark_ecn_ce_ipv6`.
- `maybe_mark_ecn_ce` + `maybe_mark_ecn_ce_prepared` dispatchers.

`cos/mod.rs` re-exports the marker fns + codepoint masks for the shorter `super::cos::{...}` path on tx.rs call sites.

`afxdp.rs` adds `#[path = "afxdp/cos/mod.rs"] mod cos;` matching the existing `#[path = "afxdp/tx.rs"] mod tx;` style.

### Stays in tx.rs for Phase 1 (per the plan)

- `COS_ECN_MARK_THRESHOLD_NUM/_DEN` + their two `const_assert` invariants — admission-policy tuning, not codepoint definitions. Moves with admission to `cos/admission.rs` in Phase 2 (correct dependency direction; a byte-mutation module should not own admission tuning).
- `apply_cos_admission_ecn_policy` — moves with admission in Phase 2.
- The 15 ECN/ethernet_l3 unit tests + the shared test fixtures — they reach the moved items via the new `use super::cos::{...}` import. Test reorganization deferred to Phase 2 alongside admission, since admission tests share fixtures with the marker tests and a same-PR fixture relocation would couple the two phases.

## Reviews

- **Plan** (6 rounds): Codex round-6 PLAN-READY, Gemini AGREE-TO-MERGE-PLAN. Major findings caught and fixed across rounds:
  - Visibility model: `pub(super)` from `cos::ecn` doesn't reach `tx`; need `pub(in crate::afxdp)` items + `pub(super) use` re-export from `cos/mod.rs` (R1+R2)
  - Test fixture sharing model: `pub(super) fn` inside `tx::tests` doesn't make fixtures visible to siblings (R1+R2)
  - Phase ordering: `flow_hash` before admission (admission's flow-fair promotion depends on it); builders before queue_service (queue_service calls builders/appliers) (R1+R2)
  - Threshold constants `COS_ECN_MARK_THRESHOLD_*` belong with admission policy, not the byte mutator (R1)
  - `mod cos` declaration style matches the existing `#[path = "..."] mod tx;` private-explicit-path form (R4)
  - Various inventory cleanups (R3, R5)

## Test plan

- [x] `cargo test --release --manifest-path userspace-dp/Cargo.toml`: **865 passed**, 0 failed (no test count change; tests stay in `tx::tests` for Phase 1).
- [x] Cluster deploy to `loss:xpf-userspace-fw0/fw1`: rolling deploy clean (Phase 1 secondary, Phase 2 primary).
- [x] Per-CoS-class iperf3 smoke after re-applying `test/incus/cos-iperf-config.set`:

| Class | Port | Shape | Gate | Result | Pass |
|---|---|---|---|---|---|
| iperf-c | 5203 | 25 g | 22 Gb/s | 23.46 Gb/s | ✅ |
| iperf-f | 5206 | 19 g | 17.1 Gb/s | 18.14 Gb/s | ✅ |
| iperf-e | 5205 | 16 g | 14.4 Gb/s | 15.25 Gb/s | ✅ |
| iperf-d | 5204 | 13 g | 11.7 Gb/s | 12.41 Gb/s | ✅ |
| iperf-b | 5202 | 10 g | 9.0 Gb/s | 9.55 Gb/s | ✅ |
| iperf-a | 5201 | 1 g | 0.9 Gb/s | 0.95 Gb/s | ✅ |
| best-effort | 5207 | 100 m | 90 Mb/s | 90 Mb/s | ✅ |

- [x] Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot fw0 at +20s, fw1 took over in <10s, iperf3 survived: **22.48 Gb/s avg, 252.9 GB received**, fw0 came back as secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)