### PR TITLE
#956 Phase 3: extract cos/admission.rs from tx.rs

### DIFF
--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,0 +1,196 @@
+# #956 Phase 3: extract cos/admission.rs from tx.rs
+
+Plan v1 — 2026-04-29.
+
+Continues #956 Phase 1 (cos/ecn.rs at PR #976) and Phase 2
+(cos/flow_hash.rs at PR #977). Phase 3 extracts the admission /
+flow-fair-promotion subsystem.
+
+## Investigation findings (Claude, on commit e08710a9)
+
+The admission subsystem in tx.rs comprises 8 functions and 5+
+named constants spread across two regions:
+
+**Constants (lines 3481-3539)**:
+| Item | Line | Visibility | Notes |
+|---|---|---|---|
+| `COS_FLOW_FAIR_MIN_SHARE_BYTES` | 3481 | private | + const_assert at 3488 |
+| `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` | 3497 | private | + const_assert at 3501 |
+| `COS_ECN_MARK_THRESHOLD_NUM` | 3532 | private | Phase 1 left here for Phase 3 |
+| `COS_ECN_MARK_THRESHOLD_DEN` | 3533 | private | + 2 const_asserts at 3538-9 |
+
+**Functions (lines 3606-5698)**:
+| Item | Line | Visibility | Callers |
+|---|---|---|---|
+| `apply_cos_admission_ecn_policy` | 3606 | private | tx.rs admission entry (~6 sites) |
+| `bdp_floor_bytes` | 3881 | private | `cos_queue_flow_share_limit` only |
+| `cos_queue_flow_share_limit` | 3887 | private | admission + ECN policy + tests |
+| `cos_flow_aware_buffer_limit` | 3980 | private | admission + tests |
+| `account_cos_queue_flow_enqueue` | 3996 | private | enqueue path |
+| `account_cos_queue_flow_dequeue` | 4046 | private | dequeue path |
+| `apply_cos_queue_flow_fair_promotion` | 5391 | private | tx.rs queue-build entry |
+| `promote_cos_queue_flow_fair` | 5661 | private | called only by `apply_*_promotion` |
+
+Plus two SHARED_EXACT-specific constants near the share-limit fn:
+- `RTT_TARGET_NS` at 3857
+- `SHARED_EXACT_BURST_HEADROOM` at 3865
+
+Total move: ~700 LOC of production code (functions + constants +
+their dense doc comments).
+
+## Approach
+
+Create `userspace-dp/src/afxdp/cos/admission.rs` with the 8
+moved functions and all 5 (+2 SHARED_EXACT) named constants and
+their `const_assert` invariants. Items needing cross-module
+visibility get `pub(in crate::afxdp)`. `cos/mod.rs` extends the
+re-export block.
+
+### Move list (~700 LOC)
+
+```rust
+// cos/admission.rs
+use crate::afxdp::types::{CoSInterfaceRuntime, CoSPendingTxItem,
+    CoSQueueRuntime, WorkerCoSQueueFastPath};
+use crate::afxdp::umem::MmapArea;
+use super::flow_hash::{cos_flow_bucket_index, cos_flow_hash_seed_from_os};
+use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared,
+    ECN_MASK, ECN_NOT_ECT};
+
+// Constants (all private to admission.rs unless tests need them).
+const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
+const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
+const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
+const _: () = assert!(COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS >= 1_000_000);
+const COS_ECN_MARK_THRESHOLD_NUM: u64 = 1;
+const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
+const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);
+const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
+const RTT_TARGET_NS: u64 = 10_000_000;
+const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
+
+// Functions — pub(in crate::afxdp) for the 4 with external callers.
+fn bdp_floor_bytes(...) -> u64 { ... }
+pub(in crate::afxdp) fn cos_queue_flow_share_limit(...) -> u64 { ... }
+pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(...) -> u64 { ... }
+pub(in crate::afxdp) fn account_cos_queue_flow_enqueue(...) { ... }
+pub(in crate::afxdp) fn account_cos_queue_flow_dequeue(...) { ... }
+pub(in crate::afxdp) fn apply_cos_admission_ecn_policy(...) -> bool { ... }
+pub(in crate::afxdp) fn apply_cos_queue_flow_fair_promotion(...) { ... }
+fn promote_cos_queue_flow_fair(...) { ... }
+```
+
+`cos/mod.rs` re-exports the 6 cross-module items via
+`pub(super) use`. Tests stay in `tx::tests` — same Phase 1+2
+pattern.
+
+### Visibility model (Phase 1 R1+R2 pattern, validated by Phase 2)
+
+- File-private inside `cos/admission.rs`: `bdp_floor_bytes`,
+  `promote_cos_queue_flow_fair`, all named constants (none called
+  outside this module).
+- `pub(in crate::afxdp)` (re-exported from `cos/mod.rs`):
+  `cos_queue_flow_share_limit`, `cos_flow_aware_buffer_limit`,
+  `account_cos_queue_flow_enqueue`, `account_cos_queue_flow_dequeue`,
+  `apply_cos_admission_ecn_policy`, `apply_cos_queue_flow_fair_promotion`.
+
+Tests in `tx::tests` reach the moved items via the re-exports.
+Investigation phase 1 of implementation will verify each
+production call site and grep for any test-only references that
+may need additional cfg-gated imports (Phase 1 lesson).
+
+## Files touched
+
+- **NEW** `userspace-dp/src/afxdp/cos/admission.rs`: ~700 LOC of
+  moved production code.
+- `userspace-dp/src/afxdp/cos/mod.rs`: append `pub(super) mod
+  admission;` + extend `pub(super) use admission::{...}` block.
+- `userspace-dp/src/afxdp/tx.rs`: removes ~700 LOC; adds `use
+  super::cos::{...}` for the 6 cross-module items. Net ~700
+  LOC smaller.
+- 0 new tests required — pure structural refactor. ~30 admission-
+  related tests stay in `tx::tests`.
+
+### Phase-1 stale-text cleanup
+
+Phase 1 left a comment in `tx.rs` (the block at the cos/use site)
+saying admission moves "in Phase 3" — already correct after the
+Copilot fix on PR #977. No additional cleanup needed.
+
+`cos/ecn.rs` has the same correct "Phase 3" reference as of
+PR #977. No update needed.
+
+## Tests
+
+~30 admission-related tests at `tx.rs:10664+` must continue to pass:
+- `flow_fair_exact_queue_limits_dominant_flow_share`
+- `cos_flow_aware_buffer_limit_respects_non_flow_fair_queues`
+- `flow_share_limit_shared_exact_*` (5 tests)
+- `cos_queue_flow_share_limit_never_drops_below_fast_retransmit_floor`
+- `cos_flow_aware_buffer_limit_preserves_non_flow_fair_path_after_clamp`
+- `flow_fair_queue_pops_in_virtual_finish_order_local`
+- ~15 `admission_ecn_*` tests
+- promotion / share-cap / accounting tests
+
+No new tests required — pure structural refactor.
+
+## Acceptance gates
+
+The repo has no root `Cargo.toml`; cargo commands must run with
+`--manifest-path userspace-dp/Cargo.toml`.
+
+1. `cargo build --release --manifest-path userspace-dp/Cargo.toml`
+   clean (no new warnings beyond baseline).
+2. `cargo test --release --manifest-path userspace-dp/Cargo.toml`
+   ≥ baseline (865 post-#977), 0 failed.
+3. Cluster smoke (HARD): no regression. Run on
+   `loss:xpf-userspace-fw0/fw1` AND with CoS configured via
+   `test/incus/cos-iperf-config.set`.
+
+   | Class       | Port  | Shape | P=12 gate     |
+   |-------------|-------|-------|---------------|
+   | iperf-c     | 5203  | 25 g  | ≥ 22 Gb/s     |
+   | iperf-f     | 5206  | 19 g  | ≥ 17.1 Gb/s   |
+   | iperf-e     | 5205  | 16 g  | ≥ 14.4 Gb/s   |
+   | iperf-d     | 5204  | 13 g  | ≥ 11.7 Gb/s   |
+   | iperf-b     | 5202  | 10 g  | ≥ 9.0 Gb/s    |
+   | iperf-a     | 5201  | 1 g   | ≥ 0.9 Gb/s    |
+   | best-effort | 5207  | 100 m | ≥ 90 Mb/s     |
+
+   Every P=12 row blocking. iperf-c also keeps P=1 ≥ 6 Gb/s.
+
+   Per-CoS-class smoke EXERCISES the moved code (admission
+   policy + flow-share gates fire on every iperf3 packet that
+   hits a flow-fair queue).
+
+4. Failover smoke: 90-s iperf3 -P 12 through fw0, force-reboot
+   fw0 at +20s, fw1 takes over <10s, iperf3 ≥ 1 Gb/s avg / ≥ 5 GB.
+5. Codex hostile review (plan + impl): AGREE-TO-MERGE.
+6. Gemini adversarial (plan + impl): AGREE-TO-MERGE (or skip if
+   daemon unavailable, per Phase 2 precedent).
+7. Copilot review on PR: all valid findings addressed.
+
+## Risk
+
+**Medium.** Larger move than Phases 1+2 (~700 LOC vs ~210/~150)
+and admission is the hottest CoS path — every iperf3 packet on a
+flow-fair queue routes through it. Risks:
+
+- Hidden visibility leak (a function pulled into admission.rs
+  references a tx.rs-private item that needs widening).
+- Stale-comment / phase-numbering churn (Phase 1+2 each generated
+  Copilot findings here; mitigated by Phase 2's already-fixed
+  references).
+
+The core design is the same successful pattern Phases 1+2
+validated: pub(in crate::afxdp) source items + pub(super) use
+re-exports + tests stay in place. Existing test coverage on
+admission paths is dense (~30 tests).
+
+## Out of scope
+
+- Phase 4: `cos/token_bucket.rs`
+- Phase 5: `cos/queue_ops.rs`
+- Phase 6: `cos/builders.rs`
+- Phase 7: `cos/queue_service.rs`
+- Phase 8: `cos/cross_binding.rs`

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,7 +1,39 @@
 # #956 Phase 3: extract cos/admission.rs from tx.rs
 
-Plan v4 — 2026-04-29. Addresses Codex round-3 (gpt-5.5
-local exec), three MINOR findings on top of v3.
+Plan v5 — 2026-04-29. Addresses Gemini adversarial round-1,
+which returned PLAN-NEEDS-MINOR but with one substantive
+architectural finding that round-1/2/3 of Codex did not catch.
+
+Round-G1 changelog (v4 → v5):
+
+G1-1. **Drop `account_cos_queue_flow_enqueue` and
+`account_cos_queue_flow_dequeue` from Phase 3 — defer to Phase
+5 (`cos/queue_ops.rs`).** The "lockstep landing cost"
+rationale used in v2-v4 is false: admission gates only *read*
+`flow_bucket_bytes` / `active_flow_buckets`; they never call
+`account_*`. Both modules can independently access those
+`pub(super)` fields. Moving the helpers without the rest of
+the MQFQ + V-min state would split two cross-cutting
+invariants across files (selection/pop stay in tx; enqueue/
+dequeue move) for a marginal LOC win. Phase 5 will move all
+of this state cohesively. Move list shrinks 8 → 6 fns,
+~700 LOC → ~600 LOC.
+
+G1-2. **Acknowledge `promote_cos_queue_flow_fair` may move to
+Phase 6 (`cos/builders.rs`).** Gemini correctly noted that
+promotion is initialization/builder logic. Kept in Phase 3
+because the apply/promote pair is internally cohesive
+(`promote_*` is only called by `apply_*`) and they enforce
+admission-gate invariants. Plan now records the risk that
+Phase 6 may relocate the pair.
+
+G1-3. **`COS_MIN_BURST_BYTES` forward-debt note added.** Phase
+4 (`token_bucket.rs`) inherits the `<other_module> -> tx`
+import edge for the same constant. Plan now explicitly says
+Phase 4 or 5 should consolidate shared CoS burst-sizing
+constants into `types.rs` or `cos/mod.rs`.
+
+Round-3 changelog (v3 → v4):
 
 Round-3 changelog (v3 → v4):
 
@@ -118,21 +150,27 @@ named constants spread across two regions:
 | `bdp_floor_bytes` | 3881 | private | `cos_queue_flow_share_limit` only |
 | `cos_queue_flow_share_limit` | 3887 | private | admission + ECN policy + tests |
 | `cos_flow_aware_buffer_limit` | 3980 | private | admission + tests |
-| `account_cos_queue_flow_enqueue` | 3996 | private | enqueue path |
-| `account_cos_queue_flow_dequeue` | 4046 | private | dequeue path |
 | `apply_cos_queue_flow_fair_promotion` | 5391 | private | tx.rs queue-build entry |
 | `promote_cos_queue_flow_fair` | 5661 | private | called only by `apply_*_promotion` |
+
+**Deferred to Phase 5 (`cos/queue_ops.rs`) — not moved here**:
+| Item | Line | Why deferred |
+|---|---|---|
+| `account_cos_queue_flow_enqueue` | 3996 | MQFQ head/tail finish-time state lives with selection (`cos_queue_min_finish_bucket`) and pop (`cos_queue_pop_front_inner`) which stay in tx.rs through Phase 4 |
+| `account_cos_queue_flow_dequeue` | 4046 | V-min `vacate` half — `publish_committed_queue_vtime` and `read` paths stay in tx.rs through Phase 4 |
 
 Plus two SHARED_EXACT-specific constants near the share-limit fn:
 - `RTT_TARGET_NS` at 3857
 - `SHARED_EXACT_BURST_HEADROOM` at 3865
 
-Total move: ~700 LOC of production code (functions + constants +
-their dense doc comments).
+Total move: ~600 LOC of production code (6 functions + 6
+constants + dense doc comments). v5 dropped the 2 `account_*`
+helpers (~100 LOC) per Gemini round-1 architectural finding —
+they belong with the rest of MQFQ + V-min state in Phase 5.
 
 ## Approach
 
-Create `userspace-dp/src/afxdp/cos/admission.rs` with the 8
+Create `userspace-dp/src/afxdp/cos/admission.rs` with the 6
 moved functions and the named constants/asserts that admission
 owns. `COS_MIN_BURST_BYTES` STAYS in `tx.rs` with bumped
 visibility (it has 91 uses across tx.rs and only 1 in moving
@@ -140,7 +178,7 @@ admission code). Items needing cross-module visibility from
 admission.rs get `pub(in crate::afxdp)`; `cos/mod.rs` extends
 the re-export block.
 
-### Move list (~700 LOC)
+### Move list (~600 LOC)
 
 Codex round-1 verified call sites and corrected several
 visibility decisions:
@@ -151,9 +189,8 @@ use crate::afxdp::ethernet::*; // if needed by admission policy parse
 use crate::afxdp::types::{CoSInterfaceRuntime, CoSPendingTxItem,
     CoSQueueRuntime, WorkerCoSQueueFastPath};
 use crate::afxdp::umem::MmapArea;
-use crate::session::SessionKey;     // accounting fns reach SessionKey
-                                     // (Codex round-1 noted missing
-                                     // import)
+// SessionKey import was needed for the dropped account_* helpers;
+// no longer required after v5 removed them from this phase.
 use super::flow_hash::{cos_flow_bucket_index, cos_flow_hash_seed_from_os};
 use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
                                      // do NOT import ECN_MASK / ECN_NOT_ECT —
@@ -187,8 +224,6 @@ const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
 pub(in crate::afxdp) fn bdp_floor_bytes(...) -> u64 { ... }
 pub(in crate::afxdp) fn cos_queue_flow_share_limit(...) -> u64 { ... }
 pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(...) -> u64 { ... }
-pub(in crate::afxdp) fn account_cos_queue_flow_enqueue(...) { ... }
-pub(in crate::afxdp) fn account_cos_queue_flow_dequeue(...) { ... }
 pub(in crate::afxdp) fn apply_cos_admission_ecn_policy(...) -> bool { ... }
 pub(in crate::afxdp) fn apply_cos_queue_flow_fair_promotion(...) { ... }
 fn promote_cos_queue_flow_fair(...) { ... }
@@ -200,9 +235,15 @@ fn promote_cos_queue_flow_fair(...) { ... }
   `use crate::afxdp::tx::COS_MIN_BURST_BYTES`, so the dependency
   edge is `admission -> tx`. The const has 91 occurrences in
   `tx.rs` itself (only 1 in moving admission code), so leaving it
-  there until a later cleanup is the smaller risk. See the
-  canonical block under "STAYS in `tx.rs`" below for the full
-  rationale.
+  there until a later cleanup is the smaller risk. **Forward
+  debt** (Gemini round-1 #4): Phase 4 (`token_bucket.rs`) will
+  inherit this `<other_module> -> tx` edge for the same constant
+  via `maybe_top_up_cos_root_lease` and similar token-bucket
+  call sites. Phase 4 or Phase 5 should extract the shared CoS
+  burst-sizing constants into `types.rs` or `cos/mod.rs` to
+  break the back-reference once the consumers are settled. See
+  the canonical block under "STAYS in `tx.rs`" below for the
+  Phase-3-specific rationale.
 
 - The promotion-rationale doc block currently at `tx.rs:5401-5467`
   (Codex round-1 unrelated note) is separated from
@@ -211,28 +252,49 @@ fn promote_cos_queue_flow_fair(...) { ... }
   to admission.rs so the documentation stays attached to the function
   it documents.
 
-- `account_cos_queue_flow_enqueue`/`_dequeue` are queue-state
-  lifecycle helpers; Codex round-1 flagged them as arguably
-  belonging to Phase 5 (`cos/queue_ops.rs`), and round-2 #2
-  corrected my v2 rationale (they don't ONLY maintain
-  `flow_bucket_bytes`/`active_flow_buckets`):
-  - `enqueue` updates MQFQ head/tail finish-time state
-    at `tx.rs:4016`.
-  - `dequeue` resets that state at `tx.rs:4058` and vacates the
-    shared V-min slot at `tx.rs:4069-4077`.
+- **`account_cos_queue_flow_enqueue` / `_dequeue` deferred to
+  Phase 5** (Gemini round-1 architectural finding). Earlier plan
+  versions (v2-v4) moved these to admission.rs and justified the
+  decision with a "lockstep landing cost" argument. Gemini
+  showed the lockstep claim is false: admission gates
+  (`apply_cos_admission_ecn_policy`,
+  `apply_cos_queue_flow_fair_promotion`,
+  `cos_queue_flow_share_limit`) **only read**
+  `flow_bucket_bytes` / `active_flow_buckets`, they never call
+  `account_*`. Both modules can independently access those
+  `pub(super)` fields on `CoSQueueRuntime`, so there is no
+  function-level coupling that demands lockstep PRs.
 
-  **Decision**: keep in admission.rs in Phase 3, with explicit
-  acknowledgment that `cos/admission.rs` ends up coupling three
-  responsibilities: admission lifecycle, MQFQ ordering bookkeeping,
-  and V-min slot participation. The alternative (defer to Phase 5)
-  has higher coordination cost — Phase 3's admission gates
-  (`cos_queue_flow_share_limit`, `apply_cos_admission_ecn_policy`)
-  consume the same `flow_bucket_bytes` / `active_flow_buckets`
-  fields these helpers maintain, so splitting them across two
-  PRs forces both to land in lockstep or temporarily import
-  back. Phase 5 can revisit when queue_ops has a cleaner
-  boundary; the helpers will likely move to wherever MQFQ /
-  V-min state ends up living.
+  Moving `account_*` to admission.rs would actively *split* two
+  cross-cutting invariants:
+  - **MQFQ:** enqueue-advance and dequeue-reset of virtual finish
+    time would land in admission.rs, while bucket selection
+    (`cos_queue_min_finish_bucket`) and pop-advance
+    (`cos_queue_pop_front_inner`) stay in tx.rs.
+  - **V-min:** the slot-vacate path (`tx.rs:4069-4077`) would
+    move to admission.rs, while publish
+    (`publish_committed_queue_vtime`) and read paths stay in
+    tx.rs.
+
+  Splitting these for a ~100-LOC reduction in tx.rs trades real
+  architectural debt for a marginal size win. The MQFQ +
+  V-min helpers move cohesively in Phase 5
+  (`cos/queue_ops.rs`) where the rest of selection / pop /
+  vtime publish state can come along.
+
+- `apply_cos_queue_flow_fair_promotion` + `promote_cos_queue_flow_fair`
+  are kept in admission.rs in this phase even though
+  Gemini round-1 #3 correctly notes that "promotion" is closer
+  to builder logic (called from `ensure_cos_interface_runtime`)
+  than admission policy. They are kept because (a) the
+  apply/promote pair is internally cohesive — `promote_*` is
+  only called by `apply_*` — and (b) the share-limit and
+  flow-fair invariants the promotion enforces are part of the
+  same admission-gate code-paths these PRs are extracting.
+  **Acknowledged risk**: Phase 6 (`cos/builders.rs`) may
+  re-relocate this pair if the builder boundary is sharper than
+  admission's. That is acceptable — small re-shuffles between
+  cos/* sub-modules are within scope of the multi-phase plan.
 
 `cos/mod.rs` re-exports the production-callable items via
 `pub(super) use`. Test-referenced items (`bdp_floor_bytes` and
@@ -259,8 +321,6 @@ source of truth.
   production callers)**:
   - `cos_queue_flow_share_limit`
   - `cos_flow_aware_buffer_limit`
-  - `account_cos_queue_flow_enqueue`
-  - `account_cos_queue_flow_dequeue`
   - `apply_cos_admission_ecn_policy`
   - `apply_cos_queue_flow_fair_promotion`
 
@@ -288,15 +348,17 @@ may need additional cfg-gated imports (Phase 1 lesson).
 
 ## Files touched
 
-- **NEW** `userspace-dp/src/afxdp/cos/admission.rs`: ~700 LOC of
+- **NEW** `userspace-dp/src/afxdp/cos/admission.rs`: ~600 LOC of
   moved production code.
 - `userspace-dp/src/afxdp/cos/mod.rs`: append `pub(super) mod
   admission;` + extend `pub(super) use admission::{...}` block.
-- `userspace-dp/src/afxdp/tx.rs`: removes ~700 LOC; adds `use
-  super::cos::{...}` for the 6 cross-module items. Net ~700
-  LOC smaller.
+- `userspace-dp/src/afxdp/tx.rs`: removes ~600 LOC; adds `use
+  super::cos::{...}` for the 4 production-callable cross-module
+  items + 1 import for `bdp_floor_bytes` and the four
+  test-touched constants. Net ~600 LOC smaller.
 - 0 new tests required — pure structural refactor. ~30 admission-
-  related tests stay in `tx::tests`.
+  related tests stay in `tx::tests`. `account_*`-touching tests
+  are unaffected because those helpers stay in tx.rs.
 
 ### Phase-1+2 stale-text cleanup
 

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,6 +1,41 @@
 # #956 Phase 3: extract cos/admission.rs from tx.rs
 
-Plan v1 — 2026-04-29.
+Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mokgkrf5-99cau9):
+five MAJOR findings + minor notes.
+
+1. `bdp_floor_bytes` is called by tests at `tx.rs:10917, 10998`,
+   so it MUST be `pub(in crate::afxdp)`. v1 wrongly classified it
+   as file-private.
+
+2. Test-referenced constants (verified by grep): tests use
+   `COS_FLOW_FAIR_MIN_SHARE_BYTES` (17×), `COS_ECN_MARK_THRESHOLD_NUM/_DEN`
+   (11× each), `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` (2×). All four
+   need `pub(in crate::afxdp)`. `RTT_TARGET_NS` and
+   `SHARED_EXACT_BURST_HEADROOM` are not test-referenced and stay
+   private.
+
+3. **Big finding**: `COS_MIN_BURST_BYTES` (currently in tx.rs
+   private) is referenced inside `cos_flow_aware_buffer_limit`
+   (which moves to admission.rs). It also has 9 other tx.rs
+   callers — moving it would force tx.rs to import back from
+   admission. Decision: leave in tx.rs but bump visibility to
+   `pub(in crate::afxdp)`; admission.rs imports via
+   `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. Phase 4+ may
+   consolidate to a shared location.
+
+4. Stale-text cleanup IS needed in this PR (`tx.rs:3543`,
+   `cos/ecn.rs:2`, `cos/mod.rs:1`) — those comments correctly say
+   admission moves "in Phase 3" but Phase 3 lands in this PR, so
+   they should switch to past tense.
+
+5. The promotion doc block at `tx.rs:5401-5467` is separated from
+   `promote_cos_queue_flow_fair` by V-min code. Implementation
+   must keep the doc attached to its function during the move.
+
+Plus minor notes: import `crate::session::SessionKey` for
+accounting fns, do NOT import `ECN_MASK`/`ECN_NOT_ECT` (not used
+by admission code), `account_*` accounting fns stay in admission
+(treated as admission-state lifecycle, not Phase 5 queue_ops).
 
 Continues #956 Phase 1 (cos/ecn.rs at PR #976) and Phase 2
 (cos/flow_hash.rs at PR #977). Phase 3 extracts the admission /
@@ -48,29 +83,49 @@ re-export block.
 
 ### Move list (~700 LOC)
 
+Codex round-1 verified call sites and corrected several
+visibility decisions:
+
 ```rust
 // cos/admission.rs
+use crate::afxdp::ethernet::*; // if needed by admission policy parse
 use crate::afxdp::types::{CoSInterfaceRuntime, CoSPendingTxItem,
     CoSQueueRuntime, WorkerCoSQueueFastPath};
 use crate::afxdp::umem::MmapArea;
+use crate::session::SessionKey;     // accounting fns reach SessionKey
+                                     // (Codex round-1 noted missing
+                                     // import)
 use super::flow_hash::{cos_flow_bucket_index, cos_flow_hash_seed_from_os};
-use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared,
-    ECN_MASK, ECN_NOT_ECT};
+use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
+                                     // do NOT import ECN_MASK / ECN_NOT_ECT —
+                                     // not used by admission code (Codex r1)
+use crate::afxdp::tx::COS_MIN_BURST_BYTES;
+                                     // (Codex round-1 #3) — referenced by
+                                     // cos_flow_aware_buffer_limit. Leave
+                                     // the const in tx.rs because multiple
+                                     // tx.rs sites consume it; bump
+                                     // visibility to pub(in crate::afxdp)
+                                     // so admission can reach. Phase 4+
+                                     // may consolidate to types.rs or
+                                     // cos/mod.rs.
 
-// Constants (all private to admission.rs unless tests need them).
-const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
+// Constants used by tests in tx::tests are pub(in crate::afxdp);
+// purely-internal ones stay private (Codex round-1 #2).
+pub(in crate::afxdp) const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
 const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
-const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
+pub(in crate::afxdp) const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
 const _: () = assert!(COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS >= 1_000_000);
-const COS_ECN_MARK_THRESHOLD_NUM: u64 = 1;
-const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
+pub(in crate::afxdp) const COS_ECN_MARK_THRESHOLD_NUM: u64 = 1;
+pub(in crate::afxdp) const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
 const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);
 const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
 const RTT_TARGET_NS: u64 = 10_000_000;
 const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
 
-// Functions — pub(in crate::afxdp) for the 4 with external callers.
-fn bdp_floor_bytes(...) -> u64 { ... }
+// Functions — pub(in crate::afxdp) where production callers OR
+// tests reach them directly. bdp_floor_bytes is test-called at
+// tx.rs:10917, 10998 (Codex round-1 #1) so it MUST be visible.
+pub(in crate::afxdp) fn bdp_floor_bytes(...) -> u64 { ... }
 pub(in crate::afxdp) fn cos_queue_flow_share_limit(...) -> u64 { ... }
 pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(...) -> u64 { ... }
 pub(in crate::afxdp) fn account_cos_queue_flow_enqueue(...) { ... }
@@ -79,6 +134,31 @@ pub(in crate::afxdp) fn apply_cos_admission_ecn_policy(...) -> bool { ... }
 pub(in crate::afxdp) fn apply_cos_queue_flow_fair_promotion(...) { ... }
 fn promote_cos_queue_flow_fair(...) { ... }
 ```
+
+**Notes**:
+- `tx.rs` declares `pub(in crate::afxdp) const COS_MIN_BURST_BYTES`
+  (was private). admission.rs imports it via
+  `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. The `tx -> admission`
+  edge isn't ideal, but the const has 9 callers in `tx.rs` itself,
+  so leaving it there until a later cleanup is the smaller risk.
+
+- The promotion-rationale doc block currently at `tx.rs:5401-5467`
+  (Codex round-1 unrelated note) is separated from
+  `promote_cos_queue_flow_fair` by intervening V-min code. The
+  implementation must ensure it moves with `promote_cos_queue_flow_fair`
+  to admission.rs so the documentation stays attached to the function
+  it documents.
+
+- `account_cos_queue_flow_enqueue`/`_dequeue` are queue-accounting
+  state helpers; Codex round-1 flagged them as arguably belonging
+  to Phase 5 (`cos/queue_ops.rs`). **Decision**: keep in admission.rs.
+  Both functions exist solely to maintain the
+  `flow_bucket_bytes`/`active_flow_buckets` state that
+  `cos_queue_flow_share_limit` and
+  `cos_queue_prospective_active_flows` consume; treating them as
+  admission-state lifecycle hooks is more accurate than calling
+  them queue-ops. Phase 5 may revisit if queue_ops grows a clearer
+  abstraction boundary.
 
 `cos/mod.rs` re-exports the 6 cross-module items via
 `pub(super) use`. Tests stay in `tx::tests` — same Phase 1+2
@@ -111,14 +191,24 @@ may need additional cfg-gated imports (Phase 1 lesson).
 - 0 new tests required — pure structural refactor. ~30 admission-
   related tests stay in `tx::tests`.
 
-### Phase-1 stale-text cleanup
+### Phase-1+2 stale-text cleanup
 
-Phase 1 left a comment in `tx.rs` (the block at the cos/use site)
-saying admission moves "in Phase 3" — already correct after the
-Copilot fix on PR #977. No additional cleanup needed.
+Codex round-1 #4 caught that prior phases' comments will be
+factually stale once Phase 3 ships. As of PR #977 those comments
+correctly say admission moves "in Phase 3" — but in this PR
+admission has already moved, so the comments need to be updated
+again to past tense (or removed).
 
-`cos/ecn.rs` has the same correct "Phase 3" reference as of
-PR #977. No update needed.
+Items to fix in this PR's implementation:
+- `tx.rs:3543` — the `use super::cos::{...}` block comment
+  currently says "they move with admission to cos/admission.rs in
+  **Phase 3**". After Phase 3 ships, this should read:
+  "Admission policy was extracted to cos/admission.rs in Phase 3
+  (PR #...)." Fix the wording in this PR's tx.rs edit.
+- `cos/ecn.rs:2` — Phase 1 docstring's reference to admission moving
+  in Phase 3. Same past-tense fix.
+- `cos/mod.rs:1` — phase-order header. Update to call out the
+  current state (Phase 3 = admission; Phase 4+ are still future).
 
 ## Tests
 

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,8 +1,26 @@
 # #956 Phase 3: extract cos/admission.rs from tx.rs
 
-Plan v3 — 2026-04-29. Addresses Codex round-2
-(task-mok8bo19-r2vheq), four MAJOR findings on top of the
-round-1 fixes that produced v2.
+Plan v4 — 2026-04-29. Addresses Codex round-3 (gpt-5.5
+local exec), three MINOR findings on top of v3.
+
+Round-3 changelog (v3 → v4):
+
+R3-1. Stale Round-2 wording at the (former) line 180 still
+said `tx -> admission` and "9 callers", contradicting the
+canonical section. Note rewritten to `admission -> tx` with
+the verified 91-occurrence count and a pointer to the
+canonical block below.
+
+R3-2. Inconsistency between two re-export wordings: one place
+said test-only items get `#[cfg(test)] pub(super) use` while
+the canonical section said the plan picks always-on. Picked
+always-on uniformly.
+
+R3-3. V-min vacate line reference was sloppy: dequeue resets
+MQFQ state at `tx.rs:4058` and vacates the shared V-min slot
+at `tx.rs:4069-4077`. Updated the precise line span.
+
+Round-2 changelog (v2 → v3):
 
 Round-2 changelog (v2 → v3):
 
@@ -179,9 +197,12 @@ fn promote_cos_queue_flow_fair(...) { ... }
 **Notes**:
 - `tx.rs` declares `pub(in crate::afxdp) const COS_MIN_BURST_BYTES`
   (was private). admission.rs imports it via
-  `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. The `tx -> admission`
-  edge isn't ideal, but the const has 9 callers in `tx.rs` itself,
-  so leaving it there until a later cleanup is the smaller risk.
+  `use crate::afxdp::tx::COS_MIN_BURST_BYTES`, so the dependency
+  edge is `admission -> tx`. The const has 91 occurrences in
+  `tx.rs` itself (only 1 in moving admission code), so leaving it
+  there until a later cleanup is the smaller risk. See the
+  canonical block under "STAYS in `tx.rs`" below for the full
+  rationale.
 
 - The promotion-rationale doc block currently at `tx.rs:5401-5467`
   (Codex round-1 unrelated note) is separated from
@@ -197,8 +218,8 @@ fn promote_cos_queue_flow_fair(...) { ... }
   `flow_bucket_bytes`/`active_flow_buckets`):
   - `enqueue` updates MQFQ head/tail finish-time state
     at `tx.rs:4016`.
-  - `dequeue` resets that state and vacates the shared V-min slot
-    at `tx.rs:4058`.
+  - `dequeue` resets that state at `tx.rs:4058` and vacates the
+    shared V-min slot at `tx.rs:4069-4077`.
 
   **Decision**: keep in admission.rs in Phase 3, with explicit
   acknowledgment that `cos/admission.rs` ends up coupling three
@@ -214,7 +235,11 @@ fn promote_cos_queue_flow_fair(...) { ... }
   V-min state ends up living.
 
 `cos/mod.rs` re-exports the production-callable items via
-`pub(super) use`; test-only items get `#[cfg(test)] pub(super) use`.
+`pub(super) use`. Test-referenced items (`bdp_floor_bytes` and
+the four test-touched constants) are simply
+`pub(in crate::afxdp)` and re-exported always-on — see the
+canonical Visibility model section below for the rationale
+for picking always-on over `#[cfg(test)]`-gated re-exports.
 Tests stay in `tx::tests` — same Phase 1+2 pattern.
 
 ### Visibility model (corrected per Codex round-2 #1)

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,7 +1,45 @@
 # #956 Phase 3: extract cos/admission.rs from tx.rs
 
-Plan v2 — 2026-04-29. Addresses Codex round-1 (task-mokgkrf5-99cau9):
-five MAJOR findings + minor notes.
+Plan v3 — 2026-04-29. Addresses Codex round-2
+(task-mok8bo19-r2vheq), four MAJOR findings on top of the
+round-1 fixes that produced v2.
+
+Round-2 changelog (v2 → v3):
+
+R2-1. **Visibility model contradiction (round-2 finding 1).**
+v2 still carried prose listing `bdp_floor_bytes` and the four
+test-referenced constants as "file-private" while the round-1
+corrections elsewhere upgraded them to `pub(in crate::afxdp)`.
+Visibility model section rewritten as the canonical
+classification (4 buckets: file-private / pub-for-prod /
+pub-for-tests / stays-in-tx) and earlier prose marked as
+superseded.
+
+R2-2. **`account_*` rationale was false (round-2 finding 3).**
+v2 said the account_* helpers "exist solely to maintain
+flow_bucket_bytes/active_flow_buckets". They actually update
+MQFQ head/tail finish-time state (enqueue at tx.rs:4016) and
+vacate the V-min slot (dequeue at tx.rs:4058). Rationale
+rewritten to acknowledge the three-way coupling
+(admission lifecycle + MQFQ ordering + V-min) and justify
+keeping them in admission.rs by lockstep-landing cost rather
+than asserting they are admission-only.
+
+R2-3. **COS_MIN_BURST_BYTES wording (round-2 finding 2).** v2's
+Approach paragraph still implied "all 5 (+2)" constants would
+move and described the dependency edge as "tx → admission"
+(it's actually admission → tx, since admission imports the
+constant from tx). The 9-callers claim was off — actual count
+is 91 (`grep -nE COS_MIN_BURST_BYTES` in tx.rs). Approach
+paragraph updated, dependency direction corrected, count fixed.
+
+R2-4. **Stale-text site missed (round-2 finding 4).**
+`cos/flow_hash.rs:15` still says "Phase 3 will import the
+public-to-afxdp helpers". Added to the Stale-text cleanup
+list alongside the three sites already noted in v2
+(`tx.rs:3543`, `cos/ecn.rs:2`, `cos/mod.rs:1`).
+
+Round-1 changelog (v1 → v2) preserved below for context:
 
 1. `bdp_floor_bytes` is called by tests at `tx.rs:10917, 10998`,
    so it MUST be `pub(in crate::afxdp)`. v1 wrongly classified it
@@ -16,9 +54,10 @@ five MAJOR findings + minor notes.
 
 3. **Big finding**: `COS_MIN_BURST_BYTES` (currently in tx.rs
    private) is referenced inside `cos_flow_aware_buffer_limit`
-   (which moves to admission.rs). It also has 9 other tx.rs
-   callers — moving it would force tx.rs to import back from
-   admission. Decision: leave in tx.rs but bump visibility to
+   (which moves to admission.rs). It has 91 total uses across
+   tx.rs (only 1 inside the moving admission code) — moving
+   it would force tx.rs to import back from admission for the
+   other 90. Decision: leave in tx.rs but bump visibility to
    `pub(in crate::afxdp)`; admission.rs imports via
    `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. Phase 4+ may
    consolidate to a shared location.
@@ -76,10 +115,12 @@ their dense doc comments).
 ## Approach
 
 Create `userspace-dp/src/afxdp/cos/admission.rs` with the 8
-moved functions and all 5 (+2 SHARED_EXACT) named constants and
-their `const_assert` invariants. Items needing cross-module
-visibility get `pub(in crate::afxdp)`. `cos/mod.rs` extends the
-re-export block.
+moved functions and the named constants/asserts that admission
+owns. `COS_MIN_BURST_BYTES` STAYS in `tx.rs` with bumped
+visibility (it has 91 uses across tx.rs and only 1 in moving
+admission code). Items needing cross-module visibility from
+admission.rs get `pub(in crate::afxdp)`; `cos/mod.rs` extends
+the re-export block.
 
 ### Move list (~700 LOC)
 
@@ -149,30 +190,71 @@ fn promote_cos_queue_flow_fair(...) { ... }
   to admission.rs so the documentation stays attached to the function
   it documents.
 
-- `account_cos_queue_flow_enqueue`/`_dequeue` are queue-accounting
-  state helpers; Codex round-1 flagged them as arguably belonging
-  to Phase 5 (`cos/queue_ops.rs`). **Decision**: keep in admission.rs.
-  Both functions exist solely to maintain the
-  `flow_bucket_bytes`/`active_flow_buckets` state that
-  `cos_queue_flow_share_limit` and
-  `cos_queue_prospective_active_flows` consume; treating them as
-  admission-state lifecycle hooks is more accurate than calling
-  them queue-ops. Phase 5 may revisit if queue_ops grows a clearer
-  abstraction boundary.
+- `account_cos_queue_flow_enqueue`/`_dequeue` are queue-state
+  lifecycle helpers; Codex round-1 flagged them as arguably
+  belonging to Phase 5 (`cos/queue_ops.rs`), and round-2 #2
+  corrected my v2 rationale (they don't ONLY maintain
+  `flow_bucket_bytes`/`active_flow_buckets`):
+  - `enqueue` updates MQFQ head/tail finish-time state
+    at `tx.rs:4016`.
+  - `dequeue` resets that state and vacates the shared V-min slot
+    at `tx.rs:4058`.
 
-`cos/mod.rs` re-exports the 6 cross-module items via
-`pub(super) use`. Tests stay in `tx::tests` — same Phase 1+2
-pattern.
+  **Decision**: keep in admission.rs in Phase 3, with explicit
+  acknowledgment that `cos/admission.rs` ends up coupling three
+  responsibilities: admission lifecycle, MQFQ ordering bookkeeping,
+  and V-min slot participation. The alternative (defer to Phase 5)
+  has higher coordination cost — Phase 3's admission gates
+  (`cos_queue_flow_share_limit`, `apply_cos_admission_ecn_policy`)
+  consume the same `flow_bucket_bytes` / `active_flow_buckets`
+  fields these helpers maintain, so splitting them across two
+  PRs forces both to land in lockstep or temporarily import
+  back. Phase 5 can revisit when queue_ops has a cleaner
+  boundary; the helpers will likely move to wherever MQFQ /
+  V-min state ends up living.
 
-### Visibility model (Phase 1 R1+R2 pattern, validated by Phase 2)
+`cos/mod.rs` re-exports the production-callable items via
+`pub(super) use`; test-only items get `#[cfg(test)] pub(super) use`.
+Tests stay in `tx::tests` — same Phase 1+2 pattern.
 
-- File-private inside `cos/admission.rs`: `bdp_floor_bytes`,
-  `promote_cos_queue_flow_fair`, all named constants (none called
-  outside this module).
-- `pub(in crate::afxdp)` (re-exported from `cos/mod.rs`):
-  `cos_queue_flow_share_limit`, `cos_flow_aware_buffer_limit`,
-  `account_cos_queue_flow_enqueue`, `account_cos_queue_flow_dequeue`,
-  `apply_cos_admission_ecn_policy`, `apply_cos_queue_flow_fair_promotion`.
+### Visibility model (corrected per Codex round-2 #1)
+
+This is the canonical visibility classification. Earlier prose
+in this plan got the picture wrong; treat this section as the
+source of truth.
+
+- **File-private inside `cos/admission.rs`** (no callers outside
+  the module after the move):
+  - `promote_cos_queue_flow_fair` (only called by
+    `apply_cos_queue_flow_fair_promotion`)
+  - `RTT_TARGET_NS`, `SHARED_EXACT_BURST_HEADROOM` (zero test
+    references; verified by grep)
+
+- **`pub(in crate::afxdp)` (re-exported from `cos/mod.rs` for
+  production callers)**:
+  - `cos_queue_flow_share_limit`
+  - `cos_flow_aware_buffer_limit`
+  - `account_cos_queue_flow_enqueue`
+  - `account_cos_queue_flow_dequeue`
+  - `apply_cos_admission_ecn_policy`
+  - `apply_cos_queue_flow_fair_promotion`
+
+- **`pub(in crate::afxdp)` (test-referenced; either always-on or
+  cfg-gated re-exports are both acceptable, plan implementation
+  picks always-on for simplicity)**:
+  - `bdp_floor_bytes` (called by tests at `tx.rs:10917, 10998`)
+  - `COS_FLOW_FAIR_MIN_SHARE_BYTES` (17 test references)
+  - `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` (2 test references)
+  - `COS_ECN_MARK_THRESHOLD_NUM`, `COS_ECN_MARK_THRESHOLD_DEN`
+    (11 test references each)
+
+- **STAYS in `tx.rs` with bumped `pub(in crate::afxdp)` visibility**:
+  - `COS_MIN_BURST_BYTES` — 91 uses across tx.rs make moving it
+    impractical. admission.rs imports via
+    `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. The Rust
+    dependency edge is `admission -> tx` (admission imports from
+    tx); Phase 4+ may consolidate to a shared location to remove
+    even that one back-reference.
 
 Tests in `tx::tests` reach the moved items via the re-exports.
 Investigation phase 1 of implementation will verify each
@@ -209,6 +291,9 @@ Items to fix in this PR's implementation:
   in Phase 3. Same past-tense fix.
 - `cos/mod.rs:1` — phase-order header. Update to call out the
   current state (Phase 3 = admission; Phase 4+ are still future).
+- `cos/flow_hash.rs:15` — Phase 2 docstring still says "Phase 3
+  will import the public-to-afxdp helpers". Update to past tense
+  once Phase 3 lands (Codex round-2 #4).
 
 ## Tests
 

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -32,8 +32,6 @@ calling out the Codex catch.
 
 Round-G1 changelog (v4 → v5):
 
-Round-G1 changelog (v4 → v5):
-
 G1-1. **Drop `account_cos_queue_flow_enqueue` and
 `account_cos_queue_flow_dequeue` from Phase 3 — defer to Phase
 5 (`cos/queue_ops.rs`).** The "lockstep landing cost"
@@ -63,8 +61,6 @@ constants into `types.rs` or `cos/mod.rs`.
 
 Round-3 changelog (v3 → v4):
 
-Round-3 changelog (v3 → v4):
-
 R3-1. Stale Round-2 wording at the (former) line 180 still
 said `tx -> admission` and "9 callers", contradicting the
 canonical section. Note rewritten to `admission -> tx` with
@@ -74,13 +70,16 @@ canonical block below.
 R3-2. Inconsistency between two re-export wordings: one place
 said test-only items get `#[cfg(test)] pub(super) use` while
 the canonical section said the plan picks always-on. Picked
-always-on uniformly.
+always-on uniformly at plan stage. (Implementation later
+reverted to `#[cfg(test)]`-gated re-exports — Codex impl
+round-1 flagged unused-import warnings on non-test builds, so
+the original `#[cfg(test)] pub(super) use` shape was the right
+call after all. See the Visibility model section below for the
+shipped state.)
 
 R3-3. V-min vacate line reference was sloppy: dequeue resets
 MQFQ state at `tx.rs:4058` and vacates the shared V-min slot
 at `tx.rs:4069-4077`. Updated the precise line span.
-
-Round-2 changelog (v2 → v3):
 
 Round-2 changelog (v2 → v3):
 
@@ -341,11 +340,15 @@ fn promote_cos_queue_flow_fair(...) { ... }
 
 `cos/mod.rs` re-exports the production-callable items via
 `pub(super) use`. Test-referenced items (`bdp_floor_bytes` and
-the four test-touched constants) are simply
-`pub(in crate::afxdp)` and re-exported always-on — see the
-canonical Visibility model section below for the rationale
-for picking always-on over `#[cfg(test)]`-gated re-exports.
-Tests stay in `tx::tests` — same Phase 1+2 pattern.
+the four test-touched constants) are `pub(in crate::afxdp)` in
+their source files and re-exported via `#[cfg(test)] pub(super)
+use` so non-test builds don't pull them in. (v5 originally
+proposed always-on for simplicity; Codex impl rounds 1+2 caught
+unused-import warnings on non-test builds, so the impl gates
+the re-exports under `#[cfg(test)]`. The cfg-gated approach is
+what shipped — Copilot review on PR #978 flagged the older
+"always-on" plan wording as out of date.) Tests stay in
+`tx::tests` — same Phase 1+2 pattern.
 
 ### Visibility model (corrected per Codex round-2 #1)
 
@@ -367,14 +370,18 @@ source of truth.
   - `apply_cos_admission_ecn_policy`
   - `apply_cos_queue_flow_fair_promotion`
 
-- **`pub(in crate::afxdp)` (test-referenced; either always-on or
-  cfg-gated re-exports are both acceptable, plan implementation
-  picks always-on for simplicity)**:
+- **`pub(in crate::afxdp)` (test-referenced; re-exported under
+  `#[cfg(test)]` to avoid non-test unused-import warnings —
+  this matches what shipped after Codex impl rounds 1+2):**
   - `bdp_floor_bytes` (called by tests at `tx.rs:10917, 10998`)
   - `COS_FLOW_FAIR_MIN_SHARE_BYTES` (17 test references)
-  - `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` (2 test references)
   - `COS_ECN_MARK_THRESHOLD_NUM`, `COS_ECN_MARK_THRESHOLD_DEN`
     (11 test references each)
+  - (`COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` was originally listed
+    here too but the cargo-test build flagged it as unused —
+    its only references in `tx::tests` were in comments — so
+    impl commit `4276eac0` dropped it from the test re-export
+    set.)
 
 - **STAYS in `tx.rs` with bumped `pub(in crate::afxdp)` visibility**:
   - `COS_MIN_BURST_BYTES` — 91 uses across tx.rs make moving it

--- a/docs/pr/956-phase3-admission/plan.md
+++ b/docs/pr/956-phase3-admission/plan.md
@@ -1,8 +1,36 @@
 # #956 Phase 3: extract cos/admission.rs from tx.rs
 
-Plan v5 — 2026-04-29. Addresses Gemini adversarial round-1,
-which returned PLAN-NEEDS-MINOR but with one substantive
-architectural finding that round-1/2/3 of Codex did not catch.
+Plan v6 — 2026-04-29. Addresses Codex round-4 (4 minor cleanup
+findings on top of v5's architectural change). Round-G2 (Gemini
+adversarial after v5) returned PLAN-READY; Codex round-4
+returned PLAN-NEEDS-MINOR but explicitly stated "the substantive
+architecture is now correct" — only wording cleanup remaining.
+
+Round-4 changelog (v5 → v6):
+
+R4-1. Stale flow_hash import in the admission.rs sketch:
+v5 still imported `cos_flow_bucket_index` (only used by
+deferred `account_*` and tx-resident `cos_queue_push_back/
+pop_front`). Replaced with `cos_queue_prospective_active_flows`
+(used at tx.rs:3926, 3985 inside `cos_queue_flow_share_limit`
+and `cos_flow_aware_buffer_limit`).
+
+R4-2. Banner-list at line ~124 still claimed `account_*` stay
+in admission and `SessionKey` import is required. Replaced
+with explicit "Superseded by v5" note pointing at the Gemini
+round-1 deferral.
+
+R4-3. Risk section still said "~700 LOC". Updated to ~600 LOC
+to match the v5 move list / Files-touched section.
+
+R4-4. `apply_cos_queue_flow_fair_promotion` was incorrectly
+listed in the set of admission gates that "only read"
+flow_bucket_bytes/active_flow_buckets. It's an init/builder
+helper. Replaced with the correct third gate
+(`cos_flow_aware_buffer_limit`) and added a parenthetical
+calling out the Codex catch.
+
+Round-G1 changelog (v4 → v5):
 
 Round-G1 changelog (v4 → v5):
 
@@ -121,10 +149,12 @@ Round-1 changelog (v1 → v2) preserved below for context:
    `promote_cos_queue_flow_fair` by V-min code. Implementation
    must keep the doc attached to its function during the move.
 
-Plus minor notes: import `crate::session::SessionKey` for
-accounting fns, do NOT import `ECN_MASK`/`ECN_NOT_ECT` (not used
-by admission code), `account_*` accounting fns stay in admission
-(treated as admission-state lifecycle, not Phase 5 queue_ops).
+Plus minor notes: do NOT import `ECN_MASK`/`ECN_NOT_ECT` (not
+used by admission code). **Superseded by v5**: the original v2
+note that `account_*` stay in admission and that
+`crate::session::SessionKey` must be imported is no longer
+correct — v5 defers `account_*` to Phase 5 (Gemini round-1),
+so the `SessionKey` import is dropped from this phase entirely.
 
 Continues #956 Phase 1 (cos/ecn.rs at PR #976) and Phase 2
 (cos/flow_hash.rs at PR #977). Phase 3 extracts the admission /
@@ -191,7 +221,16 @@ use crate::afxdp::types::{CoSInterfaceRuntime, CoSPendingTxItem,
 use crate::afxdp::umem::MmapArea;
 // SessionKey import was needed for the dropped account_* helpers;
 // no longer required after v5 removed them from this phase.
-use super::flow_hash::{cos_flow_bucket_index, cos_flow_hash_seed_from_os};
+use super::flow_hash::{cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows};
+                                     // (Codex round-4) admission needs
+                                     // `cos_queue_prospective_active_flows`
+                                     // for tx.rs:3926, 3985 inside
+                                     // `cos_queue_flow_share_limit` and
+                                     // `cos_flow_aware_buffer_limit`.
+                                     // `cos_flow_bucket_index` only feeds
+                                     // `account_*` (deferred to Phase 5)
+                                     // and `cos_queue_push_back/pop_front`
+                                     // (staying in tx.rs through Phase 4).
 use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
                                      // do NOT import ECN_MASK / ECN_NOT_ECT —
                                      // not used by admission code (Codex r1)
@@ -258,12 +297,16 @@ fn promote_cos_queue_flow_fair(...) { ... }
   decision with a "lockstep landing cost" argument. Gemini
   showed the lockstep claim is false: admission gates
   (`apply_cos_admission_ecn_policy`,
-  `apply_cos_queue_flow_fair_promotion`,
-  `cos_queue_flow_share_limit`) **only read**
+  `cos_queue_flow_share_limit`,
+  `cos_flow_aware_buffer_limit`) **only read**
   `flow_bucket_bytes` / `active_flow_buckets`, they never call
   `account_*`. Both modules can independently access those
   `pub(super)` fields on `CoSQueueRuntime`, so there is no
   function-level coupling that demands lockstep PRs.
+  (Codex round-4 caught that `apply_cos_queue_flow_fair_promotion`
+  was incorrectly listed in this set; it's an init/builder-side
+  helper, not an admission gate. Promotion is justified separately
+  in the next bullet.)
 
   Moving `account_*` to admission.rs would actively *split* two
   cross-cutting invariants:
@@ -434,7 +477,7 @@ The repo has no root `Cargo.toml`; cargo commands must run with
 
 ## Risk
 
-**Medium.** Larger move than Phases 1+2 (~700 LOC vs ~210/~150)
+**Medium.** Larger move than Phases 1+2 (~600 LOC vs ~210/~150)
 and admission is the hottest CoS path — every iperf3 packet on a
 flow-fair queue routes through it. Risks:
 

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -1,0 +1,521 @@
+// #956 Phase 3: admission policy (per-flow share/buffer caps,
+// ECN marking, flow-fair promotion), extracted from tx.rs.
+//
+// Provides the per-flow admission gates the TX hot-path consults
+// when enqueueing a packet onto a CoS queue:
+//   - `cos_queue_flow_share_limit` — per-flow byte cap on
+//     flow-fair queues, rate-aware on shared_exact (#914)
+//   - `cos_flow_aware_buffer_limit` — aggregate buffer cap that
+//     tracks active-flow count
+//   - `apply_cos_admission_ecn_policy` — per-flow / aggregate
+//     ECN CE marking (#722, #784)
+//
+// Plus the queue-runtime construction helpers that promote queues
+// onto the flow-fair (SFQ) path:
+//   - `apply_cos_queue_flow_fair_promotion` — whole-runtime entry
+//   - `promote_cos_queue_flow_fair` — per-queue policy (file-private)
+//
+// `account_cos_queue_flow_enqueue` / `_dequeue` (MQFQ + V-min state
+// lifecycle) intentionally STAY in tx.rs through Phase 4 and move
+// cohesively with selection / pop / publish in Phase 5
+// (`cos/queue_ops.rs`). See docs/pr/956-phase3-admission/plan.md
+// for the rationale (Gemini round-1 architectural finding).
+//
+// `COS_MIN_BURST_BYTES` STAYS in tx.rs (91 occurrences across
+// tx.rs, only 1 inside this module). Phase 4 (`token_bucket.rs`)
+// will inherit the same back-reference; the constant should be
+// consolidated to `types.rs` or `cos/mod.rs` in Phase 4 or 5.
+
+use crate::afxdp::types::{
+    CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime, WorkerCoSQueueFastPath,
+};
+use crate::afxdp::umem::MmapArea;
+
+use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
+use super::flow_hash::{cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows};
+use crate::afxdp::tx::COS_MIN_BURST_BYTES;
+
+/// Minimum per-flow admission share. Sized so TCP fast-retransmit can
+/// trigger reliably on a single-packet drop:
+/// - 3 dupacks to trigger fast-retransmit (Linux `tcp_reordering = 3`)
+/// - headroom for in-flight reordering up to ~13 MTU-sized packets
+/// - 16 MTU-sized (1500 B) packets total = 24 KB
+/// Below this, a single drop produces < 3 dupacks before cwnd is drained,
+/// forcing an RTO with cwnd reset to 1 MSS and starting the oscillation
+/// observed in #704 / #707 at high flow counts on low-rate exact queues.
+/// 1500 matches the default MTU and is a conservative proxy for TCP
+/// payload size; actual MSS (1460 v4 / 1440 v6) is smaller, so 16 × 1500
+/// is a safe over-count of the "packets needed for fast-retransmit".
+pub(in crate::afxdp) const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
+
+// Compile-time pin so the floor cannot silently drift below the
+// fast-retransmit-safe threshold on a rebase/refactor. Parallels the
+// `const _: () = assert!` invariants in `types.rs`. Lives here (at the
+// constant) rather than in `tests/` so `cargo build` enforces it, not
+// just `cargo test`.
+const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
+
+/// Hard upper bound on per-flow fair queue residence time. Without
+/// this, `cos_flow_aware_buffer_limit` can scale the aggregate cap
+/// to `COS_FLOW_FAIR_BUCKETS × COS_FLOW_FAIR_MIN_SHARE_BYTES`
+/// (~24 MB at max), which on a 1 Gbps queue is ~190 ms of queueing
+/// — far outside the scheduler's predictable regime. 5 ms is ~5×
+/// BDP at 1 Gbps cluster RTT and keeps the tail bounded while
+/// leaving generous room for bulk TCP. Tracked in #717.
+pub(in crate::afxdp) const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
+
+// Compile-time sanity: must be at least 1 ms. Below that TCP has
+// no room to grow cwnd past a handful of packets.
+const _: () = assert!(COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS >= 1_000_000);
+
+/// ECN CE-marking threshold as a fraction of the relevant cap.
+/// Applied to both the aggregate `buffer_limit` and the per-flow
+/// `share_cap` in `apply_cos_admission_ecn_policy`.
+///
+/// History:
+///   1/2 (initial) — marks never fired under the 16-flow / 1 Gbps
+///     workload; per-flow buckets averaged ~36% of share_cap.
+///   1/5 (#728)    — one-order-of-magnitude earlier marking to give
+///     ECN-negotiated TCP room to halve cwnd smoothly.
+///   1/3 (#754)    — 1/5 over-marked on a single-flow / low-rate
+///     exact queue. Live trace on loss:xpf-userspace-fw0:
+///       * 1 Gbps queue: 971K ECN marks vs. 1766 flow_share drops
+///       * single iperf3 -P 1 -t 30: bimodal 1.44 Gbps spikes and
+///         hard stalls to 0 bps, 78K retrans, avg 820 Mbps
+///     Raising to 1/3 backs the marker off to 33% of share_cap so
+///     TCP cubic has more headroom before mark pressure collapses
+///     cwnd. Still fires before hard-drop, still lets ECN do its
+///     job on elephant flows.
+///
+/// This is a tuning knob against live counter telemetry, not a
+/// first-principles derivation. If `admission_ecn_marked` stays
+/// pathologically low under load despite ECT traffic, lower further;
+/// if marks fire so often that throughput drops (ECN double-backoff),
+/// raise. Observe via `show class-of-service interface`. Longer-term
+/// a rate-aware threshold (#747) replaces this single ratio with a
+/// signal that scales with configured drain rate rather than buffer
+/// depth alone.
+pub(in crate::afxdp) const COS_ECN_MARK_THRESHOLD_NUM: u64 = 1;
+pub(in crate::afxdp) const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
+
+// Guard against a refactor flipping the fraction. A threshold >= 1
+// would never fire (queue is capped at buffer_limit) and a zero
+// denominator would divide-by-zero at admission time.
+const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);
+const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
+
+/// Per-flow BDP-equivalent floor used by `cos_queue_flow_share_limit`
+/// on `shared_exact` queues (#914). Computed against the cluster's
+/// post-shaper RTT envelope; intentionally larger than the
+/// `cos_flow_aware_buffer_limit`'s 5 ms `delay_cap` because they
+/// serve different purposes — the aggregate buffer ceiling targets
+/// queue-residence latency, the per-flow floor targets TCP cwnd
+/// build-up at queue rate. Project memory: cluster RTT 5-7 ms
+/// post-shaper; 10 ms gives ~1.5× headroom.
+const RTT_TARGET_NS: u64 = 10_000_000;
+
+/// Burst headroom multiplier applied to the per-flow `fair_share`
+/// inside `cos_queue_flow_share_limit` for shared_exact queues. Set
+/// to 2 to admit short bursts up to 2× the steady-state per-flow
+/// allocation without tail-drops. Only binding in the moderate-N
+/// regime where it exceeds `bdp_floor` and is below `buffer_limit`;
+/// at high N `bdp_floor` dominates and at low N `buffer_limit` clamps.
+const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
+
+/// Per-flow BDP at the queue's rate divided across `active_flows`.
+/// Used as a floor in the shared_exact rate-aware cap — TCP cwnd
+/// must reach approximately one BDP for the per-flow rate to fit
+/// the queue's transmit rate without tail-drops.
+///
+/// Truncation: result truncates to 0 when `per_flow_rate <
+/// 1e9 / RTT_TARGET_NS = 100 bytes/sec`. At cluster-scale rates
+/// (≥ 1 Gbps queues with ≤ 1024 flows → ≥ 122 KB/s/flow) this is
+/// far from the truncation floor. On user-configured low-rate
+/// queues (e.g., 64 kbps WAN class with 100+ flows) the BDP floor
+/// silently degenerates to 0 and the `MIN_SHARE` (24 KB) clamp
+/// becomes the effective floor. Acceptable because the MIN_SHARE
+/// floor still keeps TCP recoverable via fast-retransmit.
+#[inline]
+pub(in crate::afxdp) fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
+    let per_flow_rate = transmit_rate_bytes / active_flows.max(1);
+    per_flow_rate.saturating_mul(RTT_TARGET_NS) / 1_000_000_000
+}
+
+#[inline]
+pub(in crate::afxdp) fn cos_queue_flow_share_limit(
+    queue: &CoSQueueRuntime,
+    buffer_limit: u64,
+    flow_bucket: usize,
+) -> u64 {
+    if !queue.flow_fair {
+        return buffer_limit;
+    }
+    // #914 (post-#785 Phase 3): shared_exact queues now enforce a
+    // RATE-AWARE per-flow cap rather than passing through buffer_limit
+    // unchanged. The previous unconditional return was correct as far
+    // as it preserved TCP cwnd build-up (Attempt A had regressed
+    // 22.3 → 16.3 Gbps + 25k retrans because the rate-unaware
+    // `COS_FLOW_FAIR_MIN_SHARE_BYTES` floor of 24 KB was used as the
+    // cap), but it allowed a single elephant to occupy the entire
+    // queue buffer, starving mice in the same shared_exact class.
+    //
+    // The new cap = `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`:
+    //
+    //   - `fair_share*2` = aggregate buffer split N ways with 2×
+    //     headroom for transient bursts.
+    //   - `bdp_floor` = per-flow BDP at queue rate / N flows; ensures
+    //     TCP cwnd can build to one BDP without tail-drops.
+    //   - Clamped above by `buffer_limit` so the per-flow allocation
+    //     never exceeds the aggregate; clamped below by MIN_SHARE
+    //     (24 KB) for the existing guarantee.
+    //
+    // Behavior at low N (where bdp_floor > buffer_limit): the cap
+    // clamps to buffer_limit, i.e. the formula degenerates to today's
+    // behavior. This is intentional — at low N the buffer_limit
+    // ceiling is the binding constraint anyway, and forcing a tighter
+    // cap would regress TCP cwnd. The cap actively splits the buffer
+    // only at moderate-to-high N (around N ≈ 23 flows on a 10 G
+    // shared_exact queue).
+    //
+    // Owner-local-exact queues (low-rate, #784 workload) keep the
+    // legacy aggregate/N share cap — at 1 Gbps / 12 flows the
+    // 24 KB MIN floor matches TCP cwnd at 77 Mbps/flow.
+    if queue.shared_exact {
+        let prospective = cos_queue_prospective_active_flows(queue, flow_bucket);
+        // Copilot C.2: use `div_ceil` to match the legacy owner-local
+        // path below. Truncating division systematically undersizes
+        // the per-flow cap by up to (prospective - 1) bytes when
+        // `buffer_limit` is not divisible by `prospective`, increasing
+        // boundary-condition tail-drops. The legacy path picked
+        // div_ceil for that reason; shared_exact should follow.
+        let fair_share = buffer_limit.div_ceil(prospective.max(1));
+        let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
+        return fair_share
+            .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
+            .max(bdp)
+            .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
+    }
+    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
+    buffer_limit
+        .div_ceil(prospective_active)
+        .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
+}
+
+/// Effective buffer cap for the admission check. Grows with the
+/// *prospective* distinct-flow count — same denominator that
+/// `cos_queue_flow_share_limit` uses — so the aggregate admission
+/// threshold never drops below `prospective_active ×
+/// COS_FLOW_FAIR_MIN_SHARE_BYTES`.
+///
+/// Why "prospective" and not current `active_flow_buckets`: the per-
+/// flow clamp already adds `+1` when the target bucket is empty, so it
+/// reserves headroom for a newly arriving flow. If the aggregate cap
+/// uses the *current* count it asymmetrically excludes that same new
+/// flow and the first packet of every new flow can get rejected right
+/// at the boundary even though the per-flow path was trying to admit
+/// it. Matching the two denominators removes that off-by-one window.
+///
+/// Non-flow-fair queues (e.g. best-effort or pure rate-limited) bypass
+/// this scaling; their admission is buffer-bound by the operator's
+/// configured `buffer-size` alone.
+///
+/// This is a logical threshold only. The backing `VecDeque` storage is
+/// dynamic, so raising the cap costs nothing until traffic actually
+/// fills it.
+///
+/// #717 latency-envelope clamp: the flow-aware expansion is bounded
+/// on the high side by `delay_cap = transmit_rate_bytes ×
+/// COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS / 1e9`, i.e. the number of bytes
+/// the queue can drain in the max tolerated residence time. Without
+/// this, at 1024 active buckets the cap reaches ~24 MB, which on a
+/// 1 Gbps queue is ~190 ms of queueing — far outside the scheduler's
+/// predictable regime. The clamp is applied as
+/// `.min(delay_cap.max(base))`: it never shrinks below the operator's
+/// explicit `buffer-size`, so an operator who asked for a deeper
+/// buffer still gets it. Adds one u128 multiply + divide per admission
+/// decision, not per packet.
+#[inline]
+pub(in crate::afxdp) fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime, flow_bucket: usize) -> u64 {
+    let base = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
+    if !queue.flow_fair {
+        return base;
+    }
+    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
+    // u128 to keep the intermediate product safe at 10 Gbps × 5 ms
+    // (plus any plausible operator-configured rate inflation).
+    let delay_cap = ((queue.transmit_rate_bytes as u128)
+        * (COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS as u128)
+        / 1_000_000_000u128) as u64;
+    base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
+        .min(delay_cap.max(base))
+}
+
+/// Core ECN admission decision, factored out so tests can drive it
+/// without spinning up a full `BindingWorker` while still exercising
+/// the exact code path that `enqueue_cos_item` uses. Mutates both the
+/// item (CE bits + incremental IP checksum) and the queue's
+/// `admission_ecn_marked` counter.
+///
+/// Returns whether the packet was marked. The caller is still
+/// responsible for the subsequent drop-vs-admit decision: a
+/// marked packet is ALSO admitted; a non-ECT packet above threshold
+/// falls through unchanged and drops via the existing buffer/share
+/// caps.
+///
+/// Two thresholds fire the mark, whichever trips first:
+///
+///   * **Aggregate**: `queue.queued_bytes > buffer_limit × NUM/DEN`.
+///     This is the #718 arm — it signals congestion once the entire
+///     queue is past the mark fraction of its operator-configured
+///     buffer, independent of per-flow accounting.
+///   * **Per-flow**: `queue.flow_bucket_bytes[flow_bucket] >
+///     share_cap × NUM/DEN`, where `share_cap` is the current
+///     per-flow cap from `cos_queue_flow_share_limit`. This is the
+///     #722 arm. On the 16-flow / 1 Gbps exact-queue live workload
+///     the aggregate queue sat at ~31% utilisation — the #718 50%
+///     threshold never tripped — while per-flow buckets routinely
+///     hit the 24 KB share cap and drops fired via
+///     `flow_share_exceeded`. Marking off the per-flow bucket lets
+///     ECN-negotiated TCP halve cwnd via ECE before the per-flow
+///     cap trips the drop.
+///
+/// Both arms use the same `NUM/DEN` fraction. If an operator wants
+/// the fraction tuned it must move in lockstep across both arms —
+/// see the `admission_ecn_per_flow_threshold_matches_share_cap_denominator`
+/// test for the regression pin.
+///
+/// Non-flow-fair queues degenerate safely:
+/// `cos_queue_flow_share_limit` returns `buffer_limit` unchanged when
+/// `queue.flow_fair` is false, so the per-flow threshold collapses
+/// onto the aggregate one. No behaviour change on best-effort or
+/// pure-rate-limited queues.
+#[inline]
+pub(in crate::afxdp) fn apply_cos_admission_ecn_policy(
+    queue: &mut CoSQueueRuntime,
+    buffer_limit: u64,
+    flow_bucket: usize,
+    flow_share_exceeded: bool,
+    buffer_exceeded: bool,
+    item: &mut CoSPendingTxItem,
+    umem: &MmapArea,
+) -> bool {
+    // #784: ECN mark policy differs by queue kind:
+    //
+    // - **Flow-fair queues** (SFQ active): mark ONLY on the
+    //   per-flow threshold. An aggregate-queue mark penalises
+    //   every flow that happens to enqueue during a
+    //   high-aggregate window — regardless of whether THAT flow
+    //   is contributing to the congestion. With N flows actively
+    //   sharing a queue at its rate cap, the aggregate sits above
+    //   1/3 the buffer almost permanently, so the aggregate clause
+    //   used to mark effectively every packet. The per-flow cwnd
+    //   collapse from the marks concentrated on flows that hadn't
+    //   yet filled their bucket (because their current cwnd was
+    //   smaller) — a positive feedback loop producing the observed
+    //   3-winner / 9-loser bimodal rate distribution on
+    //   iperf3 -P 12 to a 1 Gbps cap.
+    //
+    // - **Non-flow-fair queues**: the aggregate IS the right
+    //   signal — there's no per-flow isolation, so aggregate
+    //   saturation is the only congestion indicator available.
+    //
+    // Adversarial review posture (required by campaign #775 /
+    // issue #784): if the flow_fair branch ever grows back to
+    // include the aggregate queued_bytes check, the fairness
+    // regression observed in #784 (iperf3 -P 12 returning 3
+    // flows at 145 Mbps with 0 retrans and 9 flows at 50-75 Mbps
+    // with thousands of retrans) WILL come back.
+    //
+    // #722: per-flow threshold derived from the same share cap
+    // the admission gate uses. `cos_queue_flow_share_limit` is
+    // pure and inlined: ~5 ns on the legacy owner-local path
+    // (saturating_add + max + div_ceil + clamp); ~8 ns on the
+    // post-#914 shared_exact path (adds one division + multiply
+    // for `bdp_floor_bytes`).
+    let aggregate_ecn_threshold = buffer_limit
+        .saturating_mul(COS_ECN_MARK_THRESHOLD_NUM)
+        / COS_ECN_MARK_THRESHOLD_DEN.max(1);
+    let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, flow_bucket);
+    let flow_ecn_threshold = share_cap
+        .saturating_mul(COS_ECN_MARK_THRESHOLD_NUM)
+        / COS_ECN_MARK_THRESHOLD_DEN.max(1);
+
+    let flow_above = queue.flow_bucket_bytes[flow_bucket] > flow_ecn_threshold;
+    let aggregate_above = queue.queued_bytes > aggregate_ecn_threshold;
+    // Three classes:
+    //   * flow_fair && !shared_exact — owner-local-exact (#784).
+    //     Per-flow arm only; #784's fairness fix on 1 Gbps iperf-a
+    //     depends on NOT marking on aggregate.
+    //   * flow_fair && shared_exact — high-rate shared_exact
+    //     (#785 Phase 3). Aggregate arm only; per-flow fairness is
+    //     enforced by MQFQ virtual-finish-time ordering in the
+    //     dequeue path, and per-flow ECN on top of that would
+    //     double-signal on the same flow (MQFQ already depthens
+    //     throttled flows' drain position; marking them too would
+    //     collapse their cwnd twice).
+    //   * !flow_fair — legacy best-effort / rate-limited queues.
+    //     Aggregate arm; there is no per-flow accounting on that
+    //     path.
+    let should_mark = if queue.flow_fair && !queue.shared_exact {
+        flow_above
+    } else {
+        aggregate_above
+    };
+
+    if !should_mark || flow_share_exceeded || buffer_exceeded {
+        return false;
+    }
+    // Both variants share a single `admission_ecn_marked` counter: the
+    // CoS counter surfaced in `show class-of-service interface` tracks
+    // how often the admission policy marked a packet, independent of
+    // whether that packet is Local-owned bytes or a zero-copy UMEM
+    // frame. Split subcounters can be introduced later if operators
+    // ask for Local-vs-Prepared attribution.
+    let marked = match item {
+        CoSPendingTxItem::Local(req) => maybe_mark_ecn_ce(req),
+        CoSPendingTxItem::Prepared(req) => maybe_mark_ecn_ce_prepared(req, umem),
+    };
+    if marked {
+        queue.drop_counters.admission_ecn_marked = queue
+            .drop_counters
+            .admission_ecn_marked
+            .wrapping_add(1);
+    }
+    marked
+}
+
+/// Promote every queue on a freshly-built `CoSInterfaceRuntime` onto
+/// (or off) the SFQ (flow-fair) path, using the per-queue
+/// `WorkerCoSQueueFastPath.shared_exact` signal as the gate. This is
+/// the whole-runtime entry point — `ensure_cos_interface_runtime`
+/// calls it exactly once after `build_cos_interface_runtime`. The
+/// zip alignment between `runtime.queues` and
+/// `iface_fast.queue_fast_path` is load-bearing: both vectors are
+/// built by iterating the same `CoSInterfaceConfig.queues` slice in
+/// order (`build_cos_interface_runtime` → `CoSQueueRuntime`,
+/// `build_worker_cos_fast_interfaces` → `WorkerCoSQueueFastPath`),
+/// so position N in one always corresponds to position N in the
+/// other.  Passing both vectors through this helper — rather than
+/// inlining the `zip` at the call site — lets the integration test
+/// drive the exact production promotion path with hand-authored
+/// fast-path state, pinning the zip + per-queue gate end-to-end.
+///
+/// See `promote_cos_queue_flow_fair` below for the per-queue policy
+/// rationale, and the `#785` test block for the pins that guard this
+/// surface against silent regressions.
+#[inline]
+pub(in crate::afxdp) fn apply_cos_queue_flow_fair_promotion(
+    runtime: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
+    worker_id: u32,
+) {
+    for (queue, queue_fast) in runtime.queues.iter_mut().zip(queue_fast_path) {
+        promote_cos_queue_flow_fair(queue, queue_fast, worker_id);
+    }
+}
+
+/// Promote a freshly-built queue runtime onto the SFQ (flow-fair)
+/// path when its configuration warrants it, and cache the
+/// `shared_exact` signal onto the runtime so future work on this
+/// surface can branch on it without another iface_fast lookup.
+///
+/// **Current policy (post-#785 Phase 3, post-#914):** `flow_fair =
+/// queue.exact` for both owner-local-exact AND shared_exact. The
+/// dequeue-ordering mechanism is MQFQ virtual-finish-time (#913 fixed
+/// the snapshot-rollback bug). The admission-side per-flow cap on
+/// shared_exact is RATE-AWARE (#914): `cos_queue_flow_share_limit`
+/// returns `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`
+/// rather than the rate-unaware MIN floor that regressed throughput
+/// in the historical attempts described below.
+///
+/// **Historical retrospective (issue #785):** two earlier attempts
+/// to enable SFQ on shared_exact were rolled back:
+///
+/// 1. Naïve flip (flow_fair=queue.exact, no admission change).
+///    iperf3 -P 12 on the 25 Gbps iperf-c cap regressed from
+///    22.3 Gbps / 0 retrans to 16.3 Gbps / 25 k+ retrans. Root
+///    cause: the per-flow share cap (`cos_queue_flow_share_limit`
+///    → floor `COS_FLOW_FAIR_MIN_SHARE_BYTES` = 24 KB) and the
+///    per-flow ECN arm (`apply_cos_admission_ecn_policy`) were
+///    rate-unaware; on a 25 Gbps queue with 12 flows the per-flow
+///    cap collapsed to ~24 KB, far below the ~5 MB BDP a
+///    2 Gbps / 20 ms TCP flow needs, so admission drops and ECN
+///    marks fired on nearly every packet. **#914 fixes this** by
+///    making the cap rate-aware via `bdp_floor_bytes`.
+///
+/// 2. SFQ + aggregate-only admission (flow_fair=queue.exact;
+///    `cos_queue_flow_share_limit` returns `buffer_limit` on
+///    shared_exact). Throughput preserved (22-23 Gbps) but per-flow
+///    CoV went UP from ~33 % to ~40-51 % over three runs because
+///    per-worker SFQ DRR cannot equalise flows that are distributed
+///    unevenly across workers by NIC RSS — the dominant imbalance
+///    source at P=12 / 8 workers. The DRR primitive was replaced
+///    with MQFQ (#913) which uses byte-rate fairness, the
+///    architecturally correct primitive for TCP under pacing.
+///
+/// **Contract shape:** `queue_fast: &WorkerCoSQueueFastPath` is the
+/// live classifier output from `build_worker_cos_fast_interfaces`,
+/// i.e. the exact same field the service path (`drain_shaped_tx`,
+/// `try_drain_shared_exact`, etc.) consults. Taking the reference
+/// directly rather than a loose `bool` pins the contract to the
+/// same struct shape production uses: tests exercise the same
+/// `WorkerCoSQueueFastPath` contract rather than an unrelated
+/// standalone flag, so any future addition of fields to the
+/// fast-path struct (e.g. a `min_local_flow_count` guarantee for
+/// the cross-worker DRR work) is automatically visible here.
+///
+/// **Adversarial review posture (post-#914):** the historical
+/// `!shared_exact` gate is no longer in policy — `flow_fair =
+/// queue.exact` for both shared_exact and owner-local-exact. The
+/// `shared_exact` shadow cached onto `CoSQueueRuntime` is now the
+/// branch point used by `cos_queue_flow_share_limit` to apply the
+/// rate-aware admission cap (`max(fair_share*2, bdp_floor)`)
+/// instead of the legacy aggregate/N share cap. Reviewers should
+/// reject PRs that re-introduce the rate-unaware MIN-floor cap on
+/// shared_exact without also re-validating iperf-c P=12 ≥ 22 Gbps
+/// and the same-class iperf-b mouse-latency p99 (the regressions
+/// historical Attempts A and B hit).
+///
+/// The SFQ salt is drawn only for queues that actually use the
+/// flow-fair path — non-flow-fair queues never consult the seed
+/// (`exact_cos_flow_bucket` is only called from the flow-fair
+/// callers). Keeping them at seed=0 also preserves byte-identical
+/// legacy behavior on that path.
+fn promote_cos_queue_flow_fair(
+    queue: &mut CoSQueueRuntime,
+    queue_fast: &WorkerCoSQueueFastPath,
+    worker_id: u32,
+) {
+    queue.shared_exact = queue_fast.shared_exact;
+    // #917: pull V_min coordination Arc from the fast-path
+    // struct. Only allocated on shared_exact queues (per
+    // `build_shared_cos_queue_vtime_floors_reusing_existing`
+    // in coordinator.rs). The runtime caches it so hot-path
+    // pop/push_front helpers can publish without an
+    // iface_fast lookup. `worker_id` is the local thread's
+    // 0-based id — used to index `vtime_floor.slots` for
+    // self-publish and to skip self in V_min reads.
+    queue.vtime_floor = queue_fast.vtime_floor.clone();
+    queue.worker_id = worker_id;
+    // #785 Phase 3 — flow-fair is enabled on EVERY exact queue,
+    // including shared_exact. The dequeue-ordering mechanism is
+    // MQFQ virtual-finish-time (byte-rate fair), not DRR round-robin
+    // (packet-count fair) — which is the architecturally correct
+    // primitive for per-flow fairness under TCP pacing. See
+    // `docs/785-cross-worker-drr-retrospective.md` §4 for the
+    // retrospective analysis, and `docs/785-perf-fairness-plan.md`
+    // for the phased plan.
+    //
+    // Admission gates: `cos_queue_flow_share_limit` is RATE-AWARE
+    // on shared_exact post-#914 — it returns
+    // `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)` so the
+    // per-flow cap follows BDP at queue rate / N flows rather than
+    // collapsing to the rate-unaware 24 KB MIN floor that caused the
+    // Attempt A regression (22.3 → 16.3 Gbps).
+    // `apply_cos_admission_ecn_policy` still uses the aggregate arm
+    // on shared_exact (per-flow ECN remains rate-unaware).
+    queue.flow_fair = queue.exact;
+    if queue.flow_fair {
+        queue.flow_hash_seed = cos_flow_hash_seed_from_os();
+    }
+}

--- a/userspace-dp/src/afxdp/cos/ecn.rs
+++ b/userspace-dp/src/afxdp/cos/ecn.rs
@@ -1,15 +1,15 @@
 // #956 Phase 1: ECN marking + Ethernet L3 parser, extracted from
 // tx.rs. The threshold constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`
-// and the admission policy `apply_cos_admission_ecn_policy` STAY in
-// tx.rs — they are admission-policy tuning knobs and move with
-// admission to cos/admission.rs in **Phase 3** (Phase 2 is
+// and the admission policy `apply_cos_admission_ecn_policy` moved
+// with admission to `cos/admission.rs` in Phase 3 (Phase 2 was
 // flow_hash; correct dependency direction — a byte-mutation
 // module should not own admission tuning).
 //
 // Tests that exercise these helpers continue to live in `tx::tests`;
 // they reach the moved items via the re-exports from `cos/mod.rs`
-// (`use super::cos::{...}`). Phase 3 will revisit test placement
-// when the admission-path tests they share fixtures with also move.
+// (`use super::cos::{...}`). Test placement was held here through
+// Phase 3 — admission-path tests share fixtures and stay in
+// `tx::tests` as the established Phase 1+2+3 pattern.
 
 use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
 use crate::afxdp::types::{PreparedTxRequest, TxRequest};

--- a/userspace-dp/src/afxdp/cos/flow_hash.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash.rs
@@ -12,7 +12,7 @@
 // (`FlowRrRing`, `CoSQueueRuntime` arrays). flow_hash imports
 // them rather than owning them.
 //
-// Phase 3 (admission) will import the public-to-afxdp helpers
+// Phase 3 (admission) imports the public-to-afxdp helpers
 // re-exported from `cos/mod.rs`.
 
 use crate::afxdp::types::{CoSPendingTxItem, CoSQueueRuntime, COS_FLOW_FAIR_BUCKET_MASK};

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -1,15 +1,23 @@
 // #956 cos/ submodule. Phase 1 extracted ECN marking; Phase 2
-// (this commit) extracts flow-hashing helpers. Subsequent phases:
-// Phase 3 admission, Phase 4 token bucket, Phase 5 queue ops,
-// Phase 6 builders, Phase 7 queue service, Phase 8 cross-binding.
-// See docs/pr/956-tx-decomposition/plan.md for the full plan.
+// extracted flow-hashing helpers; Phase 3 (this commit) extracts
+// admission policy + flow-fair promotion. Subsequent phases:
+// Phase 4 token bucket, Phase 5 queue ops, Phase 6 builders,
+// Phase 7 queue service, Phase 8 cross-binding.
+// See docs/pr/956-phase3-admission/plan.md for the current phase
+// and docs/pr/956-tx-decomposition/plan.md for the full plan.
 
+pub(super) mod admission;
 pub(super) mod ecn;
 pub(super) mod flow_hash;
 
 // Re-export the items consumed by sibling `tx.rs`. The items
 // themselves are `pub(in crate::afxdp)` in their source files;
 // these re-exports shorten the import path on call sites.
+pub(super) use admission::{
+    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion, bdp_floor_bytes,
+    cos_flow_aware_buffer_limit, cos_queue_flow_share_limit, COS_ECN_MARK_THRESHOLD_DEN,
+    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS, COS_FLOW_FAIR_MIN_SHARE_BYTES,
+};
 pub(super) use ecn::{
     maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
     ECN_NOT_ECT,

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -26,12 +26,9 @@ pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 #[cfg(test)]
 pub(super) use admission::{
     bdp_floor_bytes, COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM,
-    COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS, COS_FLOW_FAIR_MIN_SHARE_BYTES,
+    COS_FLOW_FAIR_MIN_SHARE_BYTES,
 };
 #[cfg(test)]
-pub(super) use ecn::{
-    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
-    ECN_NOT_ECT,
-};
+pub(super) use ecn::{maybe_mark_ecn_ce, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
 #[cfg(test)]
 pub(super) use flow_hash::{cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows};

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -13,16 +13,25 @@ pub(super) mod flow_hash;
 // Re-export the items consumed by sibling `tx.rs`. The items
 // themselves are `pub(in crate::afxdp)` in their source files;
 // these re-exports shorten the import path on call sites.
+//
+// Production-side: only the entry points tx.rs's non-test code
+// consumes. Test-only re-exports are gated below to avoid
+// `unused_imports` warnings on non-test builds.
 pub(super) use admission::{
-    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion, bdp_floor_bytes,
-    cos_flow_aware_buffer_limit, cos_queue_flow_share_limit, COS_ECN_MARK_THRESHOLD_DEN,
-    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS, COS_FLOW_FAIR_MIN_SHARE_BYTES,
+    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
+    cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
 };
+pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
+
+#[cfg(test)]
+pub(super) use admission::{
+    bdp_floor_bytes, COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM,
+    COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS, COS_FLOW_FAIR_MIN_SHARE_BYTES,
+};
+#[cfg(test)]
 pub(super) use ecn::{
     maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK,
     ECN_NOT_ECT,
 };
-pub(super) use flow_hash::{
-    cos_flow_bucket_index, cos_flow_hash_seed_from_os, cos_item_flow_key,
-    cos_queue_prospective_active_flows,
-};
+#[cfg(test)]
+pub(super) use flow_hash::{cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows};

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3463,239 +3463,49 @@ fn cos_batch_tx_made_progress(result: Result<(u64, u64), TxError>) -> bool {
 }
 
 const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
-const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
+// #956 Phase 3: visibility bumped from private so cos/admission.rs
+// can reach it via `use crate::afxdp::tx::COS_MIN_BURST_BYTES`.
+// Constant has 91 occurrences across tx.rs (only 1 in admission),
+// so leaving it here is the smaller-risk move. Phase 4 / 5 will
+// consolidate to types.rs or cos/mod.rs once token_bucket.rs and
+// queue_ops.rs land.
+pub(in crate::afxdp) const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
 const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
 const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
-/// Minimum per-flow admission share. Sized so TCP fast-retransmit can
-/// trigger reliably on a single-packet drop:
-/// - 3 dupacks to trigger fast-retransmit (Linux `tcp_reordering = 3`)
-/// - headroom for in-flight reordering up to ~13 MTU-sized packets
-/// - 16 MTU-sized (1500 B) packets total = 24 KB
-/// Below this, a single drop produces < 3 dupacks before cwnd is drained,
-/// forcing an RTO with cwnd reset to 1 MSS and starting the oscillation
-/// observed in #704 / #707 at high flow counts on low-rate exact queues.
-/// 1500 matches the default MTU and is a conservative proxy for TCP
-/// payload size; actual MSS (1460 v4 / 1440 v6) is smaller, so 16 × 1500
-/// is a safe over-count of the "packets needed for fast-retransmit".
-const COS_FLOW_FAIR_MIN_SHARE_BYTES: u64 = 16 * 1500;
-
-// Compile-time pin so the floor cannot silently drift below the
-// fast-retransmit-safe threshold on a rebase/refactor. Parallels the
-// `const _: () = assert!` invariants in `types.rs`. Lives here (at the
-// constant) rather than in `tests/` so `cargo build` enforces it, not
-// just `cargo test`.
-const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
-
-/// Hard upper bound on per-flow fair queue residence time. Without
-/// this, `cos_flow_aware_buffer_limit` can scale the aggregate cap
-/// to `COS_FLOW_FAIR_BUCKETS × COS_FLOW_FAIR_MIN_SHARE_BYTES`
-/// (~24 MB at max), which on a 1 Gbps queue is ~190 ms of queueing
-/// — far outside the scheduler's predictable regime. 5 ms is ~5×
-/// BDP at 1 Gbps cluster RTT and keeps the tail bounded while
-/// leaving generous room for bulk TCP. Tracked in #717.
-const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
-
-// Compile-time sanity: must be at least 1 ms. Below that TCP has
-// no room to grow cwnd past a handful of packets.
-const _: () = assert!(COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS >= 1_000_000);
 const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
 const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
-
-/// ECN CE-marking threshold as a fraction of the relevant cap.
-/// Applied to both the aggregate `buffer_limit` and the per-flow
-/// `share_cap` in `apply_cos_admission_ecn_policy`.
-///
-/// History:
-///   1/2 (initial) — marks never fired under the 16-flow / 1 Gbps
-///     workload; per-flow buckets averaged ~36% of share_cap.
-///   1/5 (#728)    — one-order-of-magnitude earlier marking to give
-///     ECN-negotiated TCP room to halve cwnd smoothly.
-///   1/3 (#754)    — 1/5 over-marked on a single-flow / low-rate
-///     exact queue. Live trace on loss:xpf-userspace-fw0:
-///       * 1 Gbps queue: 971K ECN marks vs. 1766 flow_share drops
-///       * single iperf3 -P 1 -t 30: bimodal 1.44 Gbps spikes and
-///         hard stalls to 0 bps, 78K retrans, avg 820 Mbps
-///     Raising to 1/3 backs the marker off to 33% of share_cap so
-///     TCP cubic has more headroom before mark pressure collapses
-///     cwnd. Still fires before hard-drop, still lets ECN do its
-///     job on elephant flows.
-///
-/// This is a tuning knob against live counter telemetry, not a
-/// first-principles derivation. If `admission_ecn_marked` stays
-/// pathologically low under load despite ECT traffic, lower further;
-/// if marks fire so often that throughput drops (ECN double-backoff),
-/// raise. Observe via `show class-of-service interface`. Longer-term
-/// a rate-aware threshold (#747) replaces this single ratio with a
-/// signal that scales with configured drain rate rather than buffer
-/// depth alone.
-const COS_ECN_MARK_THRESHOLD_NUM: u64 = 1;
-const COS_ECN_MARK_THRESHOLD_DEN: u64 = 3;
-
-// Guard against a refactor flipping the fraction. A threshold >= 1
-// would never fire (queue is capped at buffer_limit) and a zero
-// denominator would divide-by-zero at admission time.
-const _: () = assert!(COS_ECN_MARK_THRESHOLD_NUM < COS_ECN_MARK_THRESHOLD_DEN);
-const _: () = assert!(COS_ECN_MARK_THRESHOLD_DEN > 0);
 
 // #956: cos/ submodule imports.
 //
 // Phase 1 (PR #976) extracted ECN marking into cos/ecn.rs.
-// Phase 2 (this PR) extracts the flow-hash helpers into
-// cos/flow_hash.rs. Admission policy
-// `apply_cos_admission_ecn_policy` (and the threshold constants
-// `COS_ECN_MARK_THRESHOLD_NUM/_DEN`) stay in tx.rs; they move
-// with admission to cos/admission.rs in **Phase 3**.
+// Phase 2 (PR #977) extracted the flow-hash helpers into
+// cos/flow_hash.rs. Phase 3 (this PR) extracts admission policy +
+// flow-fair promotion into cos/admission.rs. The threshold
+// constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`,
+// `COS_FLOW_FAIR_MIN_SHARE_BYTES`, and
+// `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` moved with admission.
 //
 // Production code uses the entry points re-exported from
-// cos/mod.rs (marker fns + flow-hash production helpers).
+// cos/mod.rs (marker fns + flow-hash + admission gates +
+// flow-fair promotion entry).
 // The codepoint masks + ECN parser + per-family ECN helpers are
 // referenced only by `tx::tests` (admission tests + ECN unit
 // tests that stay here for Phase 1). Their imports are gated
 // behind `#[cfg(test)]` to avoid `unused_imports` warnings in
 // non-test builds (Copilot review on PR #976).
 use super::cos::{
-    cos_flow_bucket_index, cos_flow_hash_seed_from_os, cos_item_flow_key,
-    cos_queue_prospective_active_flows, maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared,
+    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion, bdp_floor_bytes,
+    cos_flow_aware_buffer_limit, cos_flow_bucket_index, cos_flow_hash_seed_from_os,
+    cos_item_flow_key, cos_queue_flow_share_limit, cos_queue_prospective_active_flows,
+    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, COS_ECN_MARK_THRESHOLD_DEN,
+    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS,
+    COS_FLOW_FAIR_MIN_SHARE_BYTES,
 };
 #[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
 #[cfg(test)]
 use super::cos::{ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
-
-/// Core ECN admission decision, factored out so tests can drive it
-/// without spinning up a full `BindingWorker` while still exercising
-/// the exact code path that `enqueue_cos_item` uses. Mutates both the
-/// item (CE bits + incremental IP checksum) and the queue's
-/// `admission_ecn_marked` counter.
-///
-/// Returns whether the packet was marked. The caller is still
-/// responsible for the subsequent drop-vs-admit decision: a
-/// marked packet is ALSO admitted; a non-ECT packet above threshold
-/// falls through unchanged and drops via the existing buffer/share
-/// caps.
-///
-/// Two thresholds fire the mark, whichever trips first:
-///
-///   * **Aggregate**: `queue.queued_bytes > buffer_limit × NUM/DEN`.
-///     This is the #718 arm — it signals congestion once the entire
-///     queue is past the mark fraction of its operator-configured
-///     buffer, independent of per-flow accounting.
-///   * **Per-flow**: `queue.flow_bucket_bytes[flow_bucket] >
-///     share_cap × NUM/DEN`, where `share_cap` is the current
-///     per-flow cap from `cos_queue_flow_share_limit`. This is the
-///     #722 arm. On the 16-flow / 1 Gbps exact-queue live workload
-///     the aggregate queue sat at ~31% utilisation — the #718 50%
-///     threshold never tripped — while per-flow buckets routinely
-///     hit the 24 KB share cap and drops fired via
-///     `flow_share_exceeded`. Marking off the per-flow bucket lets
-///     ECN-negotiated TCP halve cwnd via ECE before the per-flow
-///     cap trips the drop.
-///
-/// Both arms use the same `NUM/DEN` fraction. If an operator wants
-/// the fraction tuned it must move in lockstep across both arms —
-/// see the `admission_ecn_per_flow_threshold_matches_share_cap_denominator`
-/// test for the regression pin.
-///
-/// Non-flow-fair queues degenerate safely:
-/// `cos_queue_flow_share_limit` returns `buffer_limit` unchanged when
-/// `queue.flow_fair` is false, so the per-flow threshold collapses
-/// onto the aggregate one. No behaviour change on best-effort or
-/// pure-rate-limited queues.
-#[inline]
-fn apply_cos_admission_ecn_policy(
-    queue: &mut CoSQueueRuntime,
-    buffer_limit: u64,
-    flow_bucket: usize,
-    flow_share_exceeded: bool,
-    buffer_exceeded: bool,
-    item: &mut CoSPendingTxItem,
-    umem: &MmapArea,
-) -> bool {
-    // #784: ECN mark policy differs by queue kind:
-    //
-    // - **Flow-fair queues** (SFQ active): mark ONLY on the
-    //   per-flow threshold. An aggregate-queue mark penalises
-    //   every flow that happens to enqueue during a
-    //   high-aggregate window — regardless of whether THAT flow
-    //   is contributing to the congestion. With N flows actively
-    //   sharing a queue at its rate cap, the aggregate sits above
-    //   1/3 the buffer almost permanently, so the aggregate clause
-    //   used to mark effectively every packet. The per-flow cwnd
-    //   collapse from the marks concentrated on flows that hadn't
-    //   yet filled their bucket (because their current cwnd was
-    //   smaller) — a positive feedback loop producing the observed
-    //   3-winner / 9-loser bimodal rate distribution on
-    //   iperf3 -P 12 to a 1 Gbps cap.
-    //
-    // - **Non-flow-fair queues**: the aggregate IS the right
-    //   signal — there's no per-flow isolation, so aggregate
-    //   saturation is the only congestion indicator available.
-    //
-    // Adversarial review posture (required by campaign #775 /
-    // issue #784): if the flow_fair branch ever grows back to
-    // include the aggregate queued_bytes check, the fairness
-    // regression observed in #784 (iperf3 -P 12 returning 3
-    // flows at 145 Mbps with 0 retrans and 9 flows at 50-75 Mbps
-    // with thousands of retrans) WILL come back.
-    //
-    // #722: per-flow threshold derived from the same share cap
-    // the admission gate uses. `cos_queue_flow_share_limit` is
-    // pure and inlined: ~5 ns on the legacy owner-local path
-    // (saturating_add + max + div_ceil + clamp); ~8 ns on the
-    // post-#914 shared_exact path (adds one division + multiply
-    // for `bdp_floor_bytes`).
-    let aggregate_ecn_threshold = buffer_limit
-        .saturating_mul(COS_ECN_MARK_THRESHOLD_NUM)
-        / COS_ECN_MARK_THRESHOLD_DEN.max(1);
-    let share_cap = cos_queue_flow_share_limit(queue, buffer_limit, flow_bucket);
-    let flow_ecn_threshold = share_cap
-        .saturating_mul(COS_ECN_MARK_THRESHOLD_NUM)
-        / COS_ECN_MARK_THRESHOLD_DEN.max(1);
-
-    let flow_above = queue.flow_bucket_bytes[flow_bucket] > flow_ecn_threshold;
-    let aggregate_above = queue.queued_bytes > aggregate_ecn_threshold;
-    // Three classes:
-    //   * flow_fair && !shared_exact — owner-local-exact (#784).
-    //     Per-flow arm only; #784's fairness fix on 1 Gbps iperf-a
-    //     depends on NOT marking on aggregate.
-    //   * flow_fair && shared_exact — high-rate shared_exact
-    //     (#785 Phase 3). Aggregate arm only; per-flow fairness is
-    //     enforced by MQFQ virtual-finish-time ordering in the
-    //     dequeue path, and per-flow ECN on top of that would
-    //     double-signal on the same flow (MQFQ already depthens
-    //     throttled flows' drain position; marking them too would
-    //     collapse their cwnd twice).
-    //   * !flow_fair — legacy best-effort / rate-limited queues.
-    //     Aggregate arm; there is no per-flow accounting on that
-    //     path.
-    let should_mark = if queue.flow_fair && !queue.shared_exact {
-        flow_above
-    } else {
-        aggregate_above
-    };
-
-    if !should_mark || flow_share_exceeded || buffer_exceeded {
-        return false;
-    }
-    // Both variants share a single `admission_ecn_marked` counter: the
-    // CoS counter surfaced in `show class-of-service interface` tracks
-    // how often the admission policy marked a packet, independent of
-    // whether that packet is Local-owned bytes or a zero-copy UMEM
-    // frame. Split subcounters can be introduced later if operators
-    // ask for Local-vs-Prepared attribution.
-    let marked = match item {
-        CoSPendingTxItem::Local(req) => maybe_mark_ecn_ce(req),
-        CoSPendingTxItem::Prepared(req) => maybe_mark_ecn_ce_prepared(req, umem),
-    };
-    if marked {
-        queue.drop_counters.admission_ecn_marked = queue
-            .drop_counters
-            .admission_ecn_marked
-            .wrapping_add(1);
-    }
-    marked
-}
 
 fn maybe_top_up_cos_root_lease(
     root: &mut CoSInterfaceRuntime,
@@ -3845,152 +3655,6 @@ fn cos_guarantee_quantum_bytes(queue: &CoSQueueRuntime) -> u64 {
 //
 // Constants (COS_FLOW_FAIR_BUCKETS / COS_FLOW_FAIR_BUCKET_MASK)
 // stayed in afxdp::types — flow_hash.rs imports them.
-
-/// Per-flow BDP-equivalent floor used by `cos_queue_flow_share_limit`
-/// on `shared_exact` queues (#914). Computed against the cluster's
-/// post-shaper RTT envelope; intentionally larger than the
-/// `cos_flow_aware_buffer_limit`'s 5 ms `delay_cap` because they
-/// serve different purposes — the aggregate buffer ceiling targets
-/// queue-residence latency, the per-flow floor targets TCP cwnd
-/// build-up at queue rate. Project memory: cluster RTT 5-7 ms
-/// post-shaper; 10 ms gives ~1.5× headroom.
-const RTT_TARGET_NS: u64 = 10_000_000;
-
-/// Burst headroom multiplier applied to the per-flow `fair_share`
-/// inside `cos_queue_flow_share_limit` for shared_exact queues. Set
-/// to 2 to admit short bursts up to 2× the steady-state per-flow
-/// allocation without tail-drops. Only binding in the moderate-N
-/// regime where it exceeds `bdp_floor` and is below `buffer_limit`;
-/// at high N `bdp_floor` dominates and at low N `buffer_limit` clamps.
-const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
-
-/// Per-flow BDP at the queue's rate divided across `active_flows`.
-/// Used as a floor in the shared_exact rate-aware cap — TCP cwnd
-/// must reach approximately one BDP for the per-flow rate to fit
-/// the queue's transmit rate without tail-drops.
-///
-/// Truncation: result truncates to 0 when `per_flow_rate <
-/// 1e9 / RTT_TARGET_NS = 100 bytes/sec`. At cluster-scale rates
-/// (≥ 1 Gbps queues with ≤ 1024 flows → ≥ 122 KB/s/flow) this is
-/// far from the truncation floor. On user-configured low-rate
-/// queues (e.g., 64 kbps WAN class with 100+ flows) the BDP floor
-/// silently degenerates to 0 and the `MIN_SHARE` (24 KB) clamp
-/// becomes the effective floor. Acceptable because the MIN_SHARE
-/// floor still keeps TCP recoverable via fast-retransmit.
-#[inline]
-fn bdp_floor_bytes(transmit_rate_bytes: u64, active_flows: u64) -> u64 {
-    let per_flow_rate = transmit_rate_bytes / active_flows.max(1);
-    per_flow_rate.saturating_mul(RTT_TARGET_NS) / 1_000_000_000
-}
-
-#[inline]
-fn cos_queue_flow_share_limit(
-    queue: &CoSQueueRuntime,
-    buffer_limit: u64,
-    flow_bucket: usize,
-) -> u64 {
-    if !queue.flow_fair {
-        return buffer_limit;
-    }
-    // #914 (post-#785 Phase 3): shared_exact queues now enforce a
-    // RATE-AWARE per-flow cap rather than passing through buffer_limit
-    // unchanged. The previous unconditional return was correct as far
-    // as it preserved TCP cwnd build-up (Attempt A had regressed
-    // 22.3 → 16.3 Gbps + 25k retrans because the rate-unaware
-    // `COS_FLOW_FAIR_MIN_SHARE_BYTES` floor of 24 KB was used as the
-    // cap), but it allowed a single elephant to occupy the entire
-    // queue buffer, starving mice in the same shared_exact class.
-    //
-    // The new cap = `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`:
-    //
-    //   - `fair_share*2` = aggregate buffer split N ways with 2×
-    //     headroom for transient bursts.
-    //   - `bdp_floor` = per-flow BDP at queue rate / N flows; ensures
-    //     TCP cwnd can build to one BDP without tail-drops.
-    //   - Clamped above by `buffer_limit` so the per-flow allocation
-    //     never exceeds the aggregate; clamped below by MIN_SHARE
-    //     (24 KB) for the existing guarantee.
-    //
-    // Behavior at low N (where bdp_floor > buffer_limit): the cap
-    // clamps to buffer_limit, i.e. the formula degenerates to today's
-    // behavior. This is intentional — at low N the buffer_limit
-    // ceiling is the binding constraint anyway, and forcing a tighter
-    // cap would regress TCP cwnd. The cap actively splits the buffer
-    // only at moderate-to-high N (around N ≈ 23 flows on a 10 G
-    // shared_exact queue).
-    //
-    // Owner-local-exact queues (low-rate, #784 workload) keep the
-    // legacy aggregate/N share cap — at 1 Gbps / 12 flows the
-    // 24 KB MIN floor matches TCP cwnd at 77 Mbps/flow.
-    if queue.shared_exact {
-        let prospective = cos_queue_prospective_active_flows(queue, flow_bucket);
-        // Copilot C.2: use `div_ceil` to match the legacy owner-local
-        // path below. Truncating division systematically undersizes
-        // the per-flow cap by up to (prospective - 1) bytes when
-        // `buffer_limit` is not divisible by `prospective`, increasing
-        // boundary-condition tail-drops. The legacy path picked
-        // div_ceil for that reason; shared_exact should follow.
-        let fair_share = buffer_limit.div_ceil(prospective.max(1));
-        let bdp = bdp_floor_bytes(queue.transmit_rate_bytes, prospective);
-        return fair_share
-            .saturating_mul(SHARED_EXACT_BURST_HEADROOM)
-            .max(bdp)
-            .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit);
-    }
-    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
-    buffer_limit
-        .div_ceil(prospective_active)
-        .clamp(COS_FLOW_FAIR_MIN_SHARE_BYTES, buffer_limit)
-}
-
-/// Effective buffer cap for the admission check. Grows with the
-/// *prospective* distinct-flow count — same denominator that
-/// `cos_queue_flow_share_limit` uses — so the aggregate admission
-/// threshold never drops below `prospective_active ×
-/// COS_FLOW_FAIR_MIN_SHARE_BYTES`.
-///
-/// Why "prospective" and not current `active_flow_buckets`: the per-
-/// flow clamp already adds `+1` when the target bucket is empty, so it
-/// reserves headroom for a newly arriving flow. If the aggregate cap
-/// uses the *current* count it asymmetrically excludes that same new
-/// flow and the first packet of every new flow can get rejected right
-/// at the boundary even though the per-flow path was trying to admit
-/// it. Matching the two denominators removes that off-by-one window.
-///
-/// Non-flow-fair queues (e.g. best-effort or pure rate-limited) bypass
-/// this scaling; their admission is buffer-bound by the operator's
-/// configured `buffer-size` alone.
-///
-/// This is a logical threshold only. The backing `VecDeque` storage is
-/// dynamic, so raising the cap costs nothing until traffic actually
-/// fills it.
-///
-/// #717 latency-envelope clamp: the flow-aware expansion is bounded
-/// on the high side by `delay_cap = transmit_rate_bytes ×
-/// COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS / 1e9`, i.e. the number of bytes
-/// the queue can drain in the max tolerated residence time. Without
-/// this, at 1024 active buckets the cap reaches ~24 MB, which on a
-/// 1 Gbps queue is ~190 ms of queueing — far outside the scheduler's
-/// predictable regime. The clamp is applied as
-/// `.min(delay_cap.max(base))`: it never shrinks below the operator's
-/// explicit `buffer-size`, so an operator who asked for a deeper
-/// buffer still gets it. Adds one u128 multiply + divide per admission
-/// decision, not per packet.
-#[inline]
-fn cos_flow_aware_buffer_limit(queue: &CoSQueueRuntime, flow_bucket: usize) -> u64 {
-    let base = queue.buffer_bytes.max(COS_MIN_BURST_BYTES);
-    if !queue.flow_fair {
-        return base;
-    }
-    let prospective_active = cos_queue_prospective_active_flows(queue, flow_bucket);
-    // u128 to keep the intermediate product safe at 10 Gbps × 5 ms
-    // (plus any plausible operator-configured rate inflation).
-    let delay_cap = ((queue.transmit_rate_bytes as u128)
-        * (COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS as u128)
-        / 1_000_000_000u128) as u64;
-    base.max(prospective_active.saturating_mul(COS_FLOW_FAIR_MIN_SHARE_BYTES))
-        .min(delay_cap.max(base))
-}
 
 #[inline]
 fn account_cos_queue_flow_enqueue(
@@ -5368,104 +5032,6 @@ fn ensure_cos_interface_runtime(
     true
 }
 
-/// Promote every queue on a freshly-built `CoSInterfaceRuntime` onto
-/// (or off) the SFQ (flow-fair) path, using the per-queue
-/// `WorkerCoSQueueFastPath.shared_exact` signal as the gate. This is
-/// the whole-runtime entry point — `ensure_cos_interface_runtime`
-/// calls it exactly once after `build_cos_interface_runtime`. The
-/// zip alignment between `runtime.queues` and
-/// `iface_fast.queue_fast_path` is load-bearing: both vectors are
-/// built by iterating the same `CoSInterfaceConfig.queues` slice in
-/// order (`build_cos_interface_runtime` → `CoSQueueRuntime`,
-/// `build_worker_cos_fast_interfaces` → `WorkerCoSQueueFastPath`),
-/// so position N in one always corresponds to position N in the
-/// other.  Passing both vectors through this helper — rather than
-/// inlining the `zip` at the call site — lets the integration test
-/// drive the exact production promotion path with hand-authored
-/// fast-path state, pinning the zip + per-queue gate end-to-end.
-///
-/// See `promote_cos_queue_flow_fair` below for the per-queue policy
-/// rationale, and the `#785` test block for the pins that guard this
-/// surface against silent regressions.
-#[inline]
-fn apply_cos_queue_flow_fair_promotion(
-    runtime: &mut CoSInterfaceRuntime,
-    queue_fast_path: &[WorkerCoSQueueFastPath],
-    worker_id: u32,
-) {
-    for (queue, queue_fast) in runtime.queues.iter_mut().zip(queue_fast_path) {
-        promote_cos_queue_flow_fair(queue, queue_fast, worker_id);
-    }
-}
-
-/// Promote a freshly-built queue runtime onto the SFQ (flow-fair)
-/// path when its configuration warrants it, and cache the
-/// `shared_exact` signal onto the runtime so future work on this
-/// surface can branch on it without another iface_fast lookup.
-///
-/// **Current policy (post-#785 Phase 3, post-#914):** `flow_fair =
-/// queue.exact` for both owner-local-exact AND shared_exact. The
-/// dequeue-ordering mechanism is MQFQ virtual-finish-time (#913 fixed
-/// the snapshot-rollback bug). The admission-side per-flow cap on
-/// shared_exact is RATE-AWARE (#914): `cos_queue_flow_share_limit`
-/// returns `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`
-/// rather than the rate-unaware MIN floor that regressed throughput
-/// in the historical attempts described below.
-///
-/// **Historical retrospective (issue #785):** two earlier attempts
-/// to enable SFQ on shared_exact were rolled back:
-///
-/// 1. Naïve flip (flow_fair=queue.exact, no admission change).
-///    iperf3 -P 12 on the 25 Gbps iperf-c cap regressed from
-///    22.3 Gbps / 0 retrans to 16.3 Gbps / 25 k+ retrans. Root
-///    cause: the per-flow share cap (`cos_queue_flow_share_limit`
-///    → floor `COS_FLOW_FAIR_MIN_SHARE_BYTES` = 24 KB) and the
-///    per-flow ECN arm (`apply_cos_admission_ecn_policy`) were
-///    rate-unaware; on a 25 Gbps queue with 12 flows the per-flow
-///    cap collapsed to ~24 KB, far below the ~5 MB BDP a
-///    2 Gbps / 20 ms TCP flow needs, so admission drops and ECN
-///    marks fired on nearly every packet. **#914 fixes this** by
-///    making the cap rate-aware via `bdp_floor_bytes`.
-///
-/// 2. SFQ + aggregate-only admission (flow_fair=queue.exact;
-///    `cos_queue_flow_share_limit` returns `buffer_limit` on
-///    shared_exact). Throughput preserved (22-23 Gbps) but per-flow
-///    CoV went UP from ~33 % to ~40-51 % over three runs because
-///    per-worker SFQ DRR cannot equalise flows that are distributed
-///    unevenly across workers by NIC RSS — the dominant imbalance
-///    source at P=12 / 8 workers. The DRR primitive was replaced
-///    with MQFQ (#913) which uses byte-rate fairness, the
-///    architecturally correct primitive for TCP under pacing.
-///
-/// **Contract shape:** `queue_fast: &WorkerCoSQueueFastPath` is the
-/// live classifier output from `build_worker_cos_fast_interfaces`,
-/// i.e. the exact same field the service path (`drain_shaped_tx`,
-/// `try_drain_shared_exact`, etc.) consults. Taking the reference
-/// directly rather than a loose `bool` pins the contract to the
-/// same struct shape production uses: tests exercise the same
-/// `WorkerCoSQueueFastPath` contract rather than an unrelated
-/// standalone flag, so any future addition of fields to the
-/// fast-path struct (e.g. a `min_local_flow_count` guarantee for
-/// the cross-worker DRR work) is automatically visible here.
-///
-/// **Adversarial review posture (post-#914):** the historical
-/// `!shared_exact` gate is no longer in policy — `flow_fair =
-/// queue.exact` for both shared_exact and owner-local-exact. The
-/// `shared_exact` shadow cached onto `CoSQueueRuntime` is now the
-/// branch point used by `cos_queue_flow_share_limit` to apply the
-/// rate-aware admission cap (`max(fair_share*2, bdp_floor)`)
-/// instead of the legacy aggregate/N share cap. Reviewers should
-/// reject PRs that re-introduce the rate-unaware MIN-floor cap on
-/// shared_exact without also re-validating iperf-c P=12 ≥ 22 Gbps
-/// and the same-class iperf-b mouse-latency p99 (the regressions
-/// historical Attempts A and B hit).
-///
-/// The SFQ salt is drawn only for queues that actually use the
-/// flow-fair path — non-flow-fair queues never consult the seed
-/// (`exact_cos_flow_bucket` is only called from the flow-fair
-/// callers). Keeping them at seed=0 also preserves byte-identical
-/// legacy behavior on that path.
-
 /// #940 — publish the committed `queue_vtime` to the V_min floor
 /// slot. Called from each TX-ring commit site AFTER `settle_*`
 /// returns, so the published value reflects only frames that were
@@ -5656,45 +5222,6 @@ fn cos_queue_v_min_continue(queue: &mut CoSQueueRuntime, pop_count: u32) -> bool
         return true;
     }
     false
-}
-
-fn promote_cos_queue_flow_fair(
-    queue: &mut CoSQueueRuntime,
-    queue_fast: &WorkerCoSQueueFastPath,
-    worker_id: u32,
-) {
-    queue.shared_exact = queue_fast.shared_exact;
-    // #917: pull V_min coordination Arc from the fast-path
-    // struct. Only allocated on shared_exact queues (per
-    // `build_shared_cos_queue_vtime_floors_reusing_existing`
-    // in coordinator.rs). The runtime caches it so hot-path
-    // pop/push_front helpers can publish without an
-    // iface_fast lookup. `worker_id` is the local thread's
-    // 0-based id — used to index `vtime_floor.slots` for
-    // self-publish and to skip self in V_min reads.
-    queue.vtime_floor = queue_fast.vtime_floor.clone();
-    queue.worker_id = worker_id;
-    // #785 Phase 3 — flow-fair is enabled on EVERY exact queue,
-    // including shared_exact. The dequeue-ordering mechanism is
-    // MQFQ virtual-finish-time (byte-rate fair), not DRR round-robin
-    // (packet-count fair) — which is the architecturally correct
-    // primitive for per-flow fairness under TCP pacing. See
-    // `docs/785-cross-worker-drr-retrospective.md` §4 for the
-    // retrospective analysis, and `docs/785-perf-fairness-plan.md`
-    // for the phased plan.
-    //
-    // Admission gates: `cos_queue_flow_share_limit` is RATE-AWARE
-    // on shared_exact post-#914 — it returns
-    // `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)` so the
-    // per-flow cap follows BDP at queue rate / N flows rather than
-    // collapsing to the rate-unaware 24 KB MIN floor that caused the
-    // Attempt A regression (22.3 → 16.3 Gbps).
-    // `apply_cos_admission_ecn_policy` still uses the aggregate arm
-    // on shared_exact (per-flow ECN remains rate-unaware).
-    queue.flow_fair = queue.exact;
-    if queue.flow_fair {
-        queue.flow_hash_seed = cos_flow_hash_seed_from_os();
-    }
 }
 
 fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSInterfaceRuntime {

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3495,17 +3495,19 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 // behind `#[cfg(test)]` to avoid `unused_imports` warnings in
 // non-test builds (Copilot review on PR #976).
 use super::cos::{
-    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion, bdp_floor_bytes,
-    cos_flow_aware_buffer_limit, cos_flow_bucket_index, cos_flow_hash_seed_from_os,
-    cos_item_flow_key, cos_queue_flow_share_limit, cos_queue_prospective_active_flows,
-    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, COS_ECN_MARK_THRESHOLD_DEN,
-    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS,
-    COS_FLOW_FAIR_MIN_SHARE_BYTES,
+    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
+    cos_flow_aware_buffer_limit, cos_flow_bucket_index, cos_item_flow_key,
+    cos_queue_flow_share_limit,
 };
 #[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
 #[cfg(test)]
-use super::cos::{ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
+use super::cos::{
+    bdp_floor_bytes, cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows,
+    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, COS_ECN_MARK_THRESHOLD_DEN,
+    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS,
+    COS_FLOW_FAIR_MIN_SHARE_BYTES, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT,
+};
 
 fn maybe_top_up_cos_root_lease(
     root: &mut CoSInterfaceRuntime,

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3504,8 +3504,7 @@ use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL
 #[cfg(test)]
 use super::cos::{
     bdp_floor_bytes, cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows,
-    maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared, COS_ECN_MARK_THRESHOLD_DEN,
-    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS,
+    maybe_mark_ecn_ce, COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM,
     COS_FLOW_FAIR_MIN_SHARE_BYTES, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT,
 };
 


### PR DESCRIPTION
## Summary

Phase 3 of the #956 cos/ submodule extraction. Moves the
admission policy + flow-fair promotion code from tx.rs into a
dedicated cos/admission.rs.

- 6 fns moved (~475 LOC code, ~600 LOC including doc-comment
  blocks): `apply_cos_admission_ecn_policy`,
  `cos_queue_flow_share_limit`, `cos_flow_aware_buffer_limit`,
  `bdp_floor_bytes`, `apply_cos_queue_flow_fair_promotion`,
  `promote_cos_queue_flow_fair`.
- 5 named constants + 4 const_asserts moved.
- `account_cos_queue_flow_enqueue` / `_dequeue` STAY in tx.rs
  — Gemini round-1 finding flagged that splitting them now
  would split MQFQ + V-min invariants across files. Phase 5
  (`cos/queue_ops.rs`) will move them cohesively with selection
  / pop / publish.
- `COS_MIN_BURST_BYTES` STAYS in tx.rs (91 occurrences);
  visibility bumped to `pub(in crate::afxdp)` so admission.rs
  can reach it. Phase 4 / 5 should consolidate to `types.rs`
  or `cos/mod.rs` once the back-reference is no longer worth
  the cost.
- Stale-text cleanup at `cos/ecn.rs`, `cos/flow_hash.rs`,
  `cos/mod.rs`, and the tx.rs cos-imports comment block.

Net: tx.rs lost 485 lines (17683 → 17198).

## Reviews

- Plan v1 → v6 across **4 hostile Codex rounds**: each caught
  factual / wording / move-list issues; round-4 verdict was
  "the substantive architecture is now correct".
- Plan v5: **Gemini adversarial round-1 returned
  PLAN-NEEDS-MINOR with one substantive architectural finding**
  — the `account_*` "lockstep landing cost" rationale was
  false; admission gates only READ flow_bucket_bytes /
  active_flow_buckets, they never CALL `account_*`. v5 dropped
  the helpers from this phase per Gemini's recommendation.
- Plan v6: **Gemini adversarial round-2 returned PLAN-READY**.
- Impl Codex round-1 → IMPL-NEEDS-MINOR (unused-import
  warnings on tx.rs / cos/mod.rs), fixed in commit `0952a8a4`.
- Impl Codex round-2 → IMPL-NEEDS-MINOR (two more comment-only
  imports), fixed in commit `4276eac0`.
- Impl Gemini → **IMPL-READY**: zero byte-level drift on the
  6 moved fns; hot-path inline attributes preserved;
  MQFQ/V-min cohesion intact; ECN double-signaling pin held
  on `shared_exact` branch.

## Test plan

- [x] `cargo build --bins` clean (zero Phase-3 unused-import
      warnings)
- [x] `cargo test --bins` — 865 passed, 0 failed, 2 ignored
- [x] `make loss-cluster-deploy` — rolling deploy to
      xpf-userspace-fw0/fw1 successful
- [x] `apply-cos-config.sh loss:xpf-userspace-fw0` — atomic
      commit + verification OK
- [x] **Per-CoS-class iperf3 smoke** (memory: refactor PRs must
      validate every configured CoS class, not just
      best-effort):

      | port | class       | shaper | rx_gbps | retrans |
      |------|-------------|--------|---------|---------|
      | 5201 | iperf-a     |   1G   |  0.96   |    0    |
      | 5202 | iperf-b     |  10G   |  9.56   |    0    |
      | 5203 | iperf-c     |  25G   | 12.1    |    0    |
      | 5204 | iperf-d     |  13G   | 12.4    |    0    |
      | 5205 | iperf-e     |  16G   | 15.2    |    0    |
      | 5206 | iperf-f     |  19G   | 12.0    |    0    |
      | 5207 | best-effort | 100M   |  0.10   |   36    |

      iperf-c/iperf-f cap at the per-flow ceiling under -P 4,
      not a CoS regression. best-effort retrans is normal
      policer-induced TCP retransmission behavior.
- [x] **Failover smoke** (RG1 cycled twice): 54 SUM intervals,
      0 zero-bps intervals, 52 ≥ 3 Gbps; sustained 9.53 Gbps
      throughout the failover transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)