### PR TITLE
#956 Phase 4: extract cos/token_bucket.rs from tx.rs

### DIFF
--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,0 +1,171 @@
+# #956 Phase 4: extract cos/token_bucket.rs from tx.rs
+
+Plan v1 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
+at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
+token-bucket lease/refill subsystem.
+
+## Goal
+
+Move 7 token-bucket helpers + 1 named constant (~250-300 LOC of
+production code) into `userspace-dp/src/afxdp/cos/token_bucket.rs`.
+Resolve the Phase 3 forward-debt where admission.rs imports
+`COS_MIN_BURST_BYTES` from tx.rs (admission → tx edge); after Phase 4
+both admission.rs and tx.rs import the constant from cos/, so the
+back-reference is gone.
+
+## Investigation findings (Claude, on commit 1cb07118)
+
+**Functions** (all currently file-private or `pub(super)` in tx.rs):
+
+| Item | Line | Visibility | Production callers | Test callers |
+|---|---|---|---|---|
+| `maybe_top_up_cos_root_lease` | 3511 | private | tx.rs:1515 | tx.rs:6824 (1 site) |
+| `maybe_top_up_cos_queue_lease` | 3533 | private | tx.rs:1643, 1733 | tx.rs:6873 (1 site) |
+| `refill_cos_tokens` | 3582 | private | tx.rs:1651, 1829 (+ inside maybe_top_up_cos_queue_lease at 3558) | none |
+| `cos_refill_ns_until` | 3625 | private | tx.rs:4257, 4259 | none |
+| `release_cos_root_lease` | 5524 | private | tx.rs:5509 (refresh_cos_interface_activity), tx.rs:5545 (release_all_cos_root_leases) | none |
+| `release_all_cos_root_leases` | 5542 | `pub(super)` | worker.rs:746, 1613, 1911 | none |
+| `release_all_cos_queue_leases` | 5549 | `pub(super)` | worker.rs:746, 755, 1613, 1912 | none |
+
+**Constant**:
+
+| Item | Line | Visibility | Use count |
+|---|---|---|---|
+| `COS_MIN_BURST_BYTES` | 3472 | `pub(in crate::afxdp)` | tx.rs: 91 (mostly token-bucket / refill paths); cos/admission.rs: 3 |
+
+`COS_MIN_BURST_BYTES` is the burst-cap argument applied uniformly across
+every `maybe_top_up_*` and `refill_cos_tokens` call. It logically belongs
+with the token-bucket module that consumes it.
+
+`tx_frame_capacity()` is referenced by `maybe_top_up_*` to floor lease
+size — that helper stays in tx.rs (it's about TX-ring frame sizing, not
+token-bucket logic). admission.rs already imports it analogously; tx.rs
+can keep it as the owner.
+
+## Approach
+
+Create `userspace-dp/src/afxdp/cos/token_bucket.rs` with all 7 functions
++ the `COS_MIN_BURST_BYTES` constant.
+
+Visibility:
+- `pub(in crate::afxdp)`:
+  - All 7 functions (each has at least one cross-module caller in
+    tx.rs or worker.rs; tests call 2 of them).
+  - `COS_MIN_BURST_BYTES` (91 tx.rs sites + 3 admission.rs sites).
+- File-private: nothing (token-bucket is a thin layer with no
+  internal-only state helpers).
+
+`cos/mod.rs` adds:
+```rust
+pub(super) mod token_bucket;
+pub(super) use token_bucket::{
+    cos_refill_ns_until,
+    maybe_top_up_cos_queue_lease,
+    maybe_top_up_cos_root_lease,
+    refill_cos_tokens,
+    release_all_cos_queue_leases,
+    release_all_cos_root_leases,
+    release_cos_root_lease,
+    COS_MIN_BURST_BYTES,
+};
+```
+
+No `#[cfg(test)]` re-export split needed: every item has at least one
+production caller across tx.rs / worker.rs / cos/admission.rs, so the
+non-test build will use them all.
+
+tx.rs:
+- Remove the 7 fn definitions and the `COS_MIN_BURST_BYTES` const.
+- Update the existing `use super::cos::{...}` block to add the 7 fns
+  and the constant.
+
+worker.rs:
+- `release_all_cos_*_leases` calls already work via the existing
+  `pub(super)` wiring — but after the move they live in cos/, so
+  worker.rs needs `use super::cos::{release_all_cos_root_leases,
+  release_all_cos_queue_leases}` (or `use crate::afxdp::cos::...`).
+
+cos/admission.rs:
+- Replace `use crate::afxdp::tx::COS_MIN_BURST_BYTES` with
+  `use super::token_bucket::COS_MIN_BURST_BYTES` (or via the
+  cos/mod.rs re-export). This eliminates the admission → tx
+  back-reference noted as forward-debt in Phase 3.
+
+## Files touched
+
+- **NEW** `userspace-dp/src/afxdp/cos/token_bucket.rs`: ~280 LOC.
+- `userspace-dp/src/afxdp/cos/mod.rs`: add module + re-exports.
+- `userspace-dp/src/afxdp/tx.rs`: -280 LOC; widen the `use
+  super::cos::{...}` block.
+- `userspace-dp/src/afxdp/worker.rs`: add cos:: import for the 2
+  release helpers.
+- `userspace-dp/src/afxdp/cos/admission.rs`: re-route
+  COS_MIN_BURST_BYTES import path; update header note.
+
+## Tests
+
+No new tests required — pure structural refactor. Existing tests in
+`tx::tests` exercise:
+- `maybe_top_up_cos_root_lease` at tx.rs:6824 (root-lease behaviour
+  pinned by `tx_frame_capacity().max(COS_MIN_BURST_BYTES)` floor)
+- `maybe_top_up_cos_queue_lease` at tx.rs:6873 (queue-lease grant
+  vs queue.tokens prerequisite)
+
+Both tests will continue to compile after the move because both fns
+become `pub(in crate::afxdp)` and are reachable via
+`super::cos::{maybe_top_up_*}` re-exports — same Phase 1+2+3 pattern.
+
+## Phase-1+2+3 stale-text cleanup
+
+- `tx.rs:3466-3472` — the `COS_MIN_BURST_BYTES` Phase-3 forward-debt
+  comment block becomes false once the constant moves to
+  cos/token_bucket.rs. Remove the comment block (the constant is gone
+  from tx.rs).
+- `cos/admission.rs:24-27` — header note about COS_MIN_BURST_BYTES
+  staying in tx.rs needs to switch to past-tense "Phase 4 moved
+  COS_MIN_BURST_BYTES into cos/token_bucket.rs; admission imports
+  from there now."
+- `cos/mod.rs:1-5` — phase-order header. Update to call out Phase 4
+  as the current state.
+
+## Risk
+
+**Low-medium.** Smaller move than Phases 2+3 (~280 vs ~600 LOC) but
+touches the hot-path enqueue/refill loop — every TX byte goes through
+`maybe_top_up_cos_*` and `refill_cos_tokens`. Risks:
+
+- **Hot-path inline cost.** `refill_cos_tokens` is called 3 times per
+  enqueue cycle in production (tx.rs:1651, 1829, 3558). Need
+  `#[inline]` to survive the cross-module move. Verify against the
+  pre-move hot path.
+- **worker.rs import migration.** worker.rs currently calls
+  `release_all_cos_*_leases` via plain identifier (they're in tx.rs,
+  worker.rs already `use super::tx::*`). After the move worker.rs
+  needs an explicit import path (or rely on a re-export from tx).
+- **Stale-comment churn.** Phase 3 added a comment block flagging
+  the forward-debt; that comment becomes false in this PR.
+
+The core design is the same successful pattern Phases 1-3 validated:
+`pub(in crate::afxdp)` source items + `pub(super) use` re-exports +
+tests stay in `tx::tests`.
+
+## Acceptance criteria
+
+- `cargo build --bins` clean (no Phase-4 unused-import warnings).
+- `cargo test --bins` passes the same 865/0/2 baseline as Phase 3
+  (the 2 ignored micro-benchmarks are pre-existing).
+- `make loss-cluster-deploy` rolls successfully; `apply-cos-config.sh`
+  applies the per-class iperf3 config.
+- Per-CoS-class iperf3 smoke (memory: refactor PRs must validate every
+  configured class):
+  - port 5201 / iperf-a / 1G shaper: ≥ 0.85 Gbps, 0 retrans
+  - port 5202 / iperf-b / 10G shaper: ≥ 8 Gbps, 0 retrans
+  - port 5203 / iperf-c / 25G shaper: ≥ 10 Gbps, ≤ 1k retrans
+  - port 5204 / iperf-d / 13G shaper: ≥ 10 Gbps
+  - port 5205 / iperf-e / 16G shaper: ≥ 12 Gbps
+  - port 5206 / iperf-f / 19G shaper: ≥ 12 Gbps
+  - port 5207 / best-effort / 100M shaper: ≥ 0.07 Gbps
+- Failover smoke (RG1 cycled twice): zero 0-bps SUM intervals;
+  ≥ 95% of intervals at ≥ 3 Gbps.
+- Plan + impl signed off by both Codex (`gpt-5.5` xhigh) and Gemini.

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,44 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v3 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v4 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Round-3 changelog (v3 → v4): Codex round-3 returned PLAN-NEEDS-MAJOR
+with 1 substantive issue + 5 minor + 2 nits. All 8 are fixed in v4:
+
+- #1 (MAJOR): tx.rs is NOT a caller of `release_all_cos_root_leases`
+  or `release_all_cos_queue_leases` — those callers all live in
+  worker.rs. Plan v3 told tx.rs to import all 7 helpers, which
+  would trip a Phase-4-introduced unused-import warning. v4 narrows
+  the tx.rs import block to the 5 fns it actually calls plus
+  `COS_MIN_BURST_BYTES`, and moves the 2 release helpers into the
+  worker.rs explicit-import line.
+- #2 (minor): existing definitions at tx.rs:3511, 3533, 3582 have
+  no `#[inline]` attribute — the previous claim that the move
+  must "preserve `#[inline]`" was wrong. v4 calls the move
+  byte-identical and notes that any post-merge regression is a
+  follow-up rather than a Phase-4 blocker.
+- #3 (minor): stale-text cleanup must include `tx.rs:3479-3491`
+  (the cos/ submodule import-header still says "Phase 3 (this PR)"
+  and lists Phase-1+2+3 imports without token-bucket helpers).
+- #4 (minor): cos/mod.rs cleanup is lines 1-7, not 1-5 (line 6 also
+  references `docs/pr/956-phase3-admission/plan.md` as "the current
+  phase").
+- #5 (minor): test-invariant wording — root-lease floor is
+  `lease_bytes().max(tx_frame_capacity())`, not
+  `tx_frame_capacity().max(COS_MIN_BURST_BYTES)`. Updated.
+- #6 (nit): COS_MIN_BURST_BYTES non-test list extended to include
+  tx.rs:5237, 5264, 5269 (added in R1-3 follow-up; v3 list was
+  consistent with the table but the Round-1 changelog sentence
+  had only `1832, 5237, plus 7 inside top-up helpers`).
+- #7 (nit): worker.rs caller-line wording in the Round-2 changelog
+  updated to match the table — root at 746/1613/1911, queue at
+  747/755/1614/1912.
+- #8 (nit): "tests call 2 of them" is misleading — direct
+  tx::tests call sites are 2 fns, but #[cfg(test)]-gated call
+  sites cover 3 fns. Tests section corrected.
 
 Round-2 changelog (v2 → v3): addresses 5 Codex round-2 wording /
 line-number fixes (move set + visibility unchanged):
@@ -127,14 +162,28 @@ non-test build will use them all.
 
 tx.rs:
 - Remove the 7 fn definitions and the `COS_MIN_BURST_BYTES` const.
-- Update the existing `use super::cos::{...}` block to add the 7 fns
-  and the constant.
+- Update the existing `use super::cos::{...}` block to add ONLY the 5
+  helpers tx.rs actually calls in non-test code plus the constant
+  (Codex round-3 #1 — tx.rs is NOT a caller of either
+  `release_all_cos_*_leases`; those callers all live in worker.rs):
+  ```rust
+  use super::cos::{
+      cos_refill_ns_until, maybe_top_up_cos_queue_lease,
+      maybe_top_up_cos_root_lease, refill_cos_tokens,
+      release_cos_root_lease, COS_MIN_BURST_BYTES,
+  };
+  ```
+  Adding the two `release_all_*` helpers to tx.rs's import block
+  would trip a Phase-4-introduced unused-import warning, just like
+  Phase 3 commit 4276eac0 had to clean up.
 
 worker.rs:
-- `release_all_cos_*_leases` calls already work via the existing
-  `pub(super)` wiring — but after the move they live in cos/, so
-  worker.rs needs `use super::cos::{release_all_cos_root_leases,
-  release_all_cos_queue_leases}` (or `use crate::afxdp::cos::...`).
+- `release_all_cos_*_leases` are called from worker.rs:746, 747, 755,
+  1613, 1614, 1911, 1912. Today they're picked up via worker.rs:1's
+  `use super::*` glob (Codex round-1 R1-4). After the move worker.rs
+  needs an explicit `use super::cos::{release_all_cos_root_leases,
+  release_all_cos_queue_leases};` so the symbol resolution is
+  unambiguous.
 
 cos/admission.rs:
 - Replace `use crate::afxdp::tx::COS_MIN_BURST_BYTES` with
@@ -160,9 +209,20 @@ cos/admission.rs:
 No new tests required — pure structural refactor. Existing tests in
 `tx::tests` exercise:
 - `maybe_top_up_cos_root_lease` at tx.rs:6824 (root-lease behaviour
-  pinned by `tx_frame_capacity().max(COS_MIN_BURST_BYTES)` floor)
+  pinned by the `lease_bytes().max(tx_frame_capacity())` floor — the
+  invariant that lease size never falls below a max-sized frame; the
+  test comment at tx.rs:6794 names this exact form). Codex round-3 #5
+  caught the previous wording that wrote it as
+  `tx_frame_capacity().max(COS_MIN_BURST_BYTES)` — wrong direction.
 - `maybe_top_up_cos_queue_lease` at tx.rs:6873 (queue-lease grant
   vs queue.tokens prerequisite)
+- Three additional fns have test-only call sites that the refactor
+  must keep reachable: `refill_cos_tokens` at tx.rs:1651,
+  `maybe_top_up_cos_queue_lease` at tx.rs:1643, and
+  `maybe_top_up_cos_root_lease` at tx.rs:6824. (Codex round-3 #8
+  flagged the earlier "tests call 2" wording — direct
+  `tx::tests` calls happen to two helpers but #[cfg(test)] -gated
+  call sites cover three.)
 
 Both tests will continue to compile after the move because both fns
 become `pub(in crate::afxdp)` and are reachable via
@@ -174,6 +234,11 @@ become `pub(in crate::afxdp)` and are reachable via
   comment block becomes false once the constant moves to
   cos/token_bucket.rs. Remove the comment block (the constant is gone
   from tx.rs).
+- `tx.rs:3479-3491` — the cos/ submodule import-header (Codex round-3
+  #3). Currently says "Phase 3 (this PR)" and the `use super::cos::{...}`
+  block lists only Phase-1+2+3 items. Update header text to
+  "Phase 4 (this PR)" plus drop the now-stale Phase-3-tense wording,
+  and refresh the imported-items list.
 - `cos/admission.rs:24-27` — header note about COS_MIN_BURST_BYTES
   staying in tx.rs needs to switch to past-tense (Codex round-2 N3:
   the wording must align with R1-5's chosen import path). Replace
@@ -182,8 +247,10 @@ become `pub(in crate::afxdp)` and are reachable via
   to the cos/mod.rs re-export), not via direct
   `super::token_bucket::COS_MIN_BURST_BYTES` — that keeps admission
   agnostic to the cos/* internal file layout."
-- `cos/mod.rs:1-5` — phase-order header. Update to call out Phase 4
-  as the current state.
+- `cos/mod.rs:1-7` — phase-order header (Codex round-3 #4: line 6
+  also references `docs/pr/956-phase3-admission/plan.md` as "the
+  current phase"). Update lines 1-7 to call out Phase 4 as the
+  current state.
 
 ## Risk
 
@@ -197,10 +264,14 @@ touches the hot-path enqueue/refill loop — every TX byte goes through
   tx.rs:3558 (which itself moves to token_bucket.rs and stays
   intra-file). The third syntactic site at tx.rs:1651 is inside a
   `#[cfg(test)]` legacy-selector fn, so it's not part of the
-  production hot path. Even so, `refill_cos_tokens` and the
-  `maybe_top_up_*` helpers must keep `#[inline]` on the move so the
-  compiler can still inline across the cos/* boundary the same way
-  Phases 2+3 validated.
+  production hot path. **Implementation note** (Codex round-3 #2):
+  the source definitions at tx.rs:3511, 3533, 3582 do NOT currently
+  carry an `#[inline]` attribute — they rely on the compiler's
+  cross-module inlining via `pub(in crate::afxdp)` visibility, the
+  same pattern Phases 2+3 validated. The implementation should
+  reproduce them unchanged (no `#[inline]` added or removed). If a
+  post-merge perf regression points at a missing inline, that's a
+  follow-up rather than a Phase-4-blocking decision.
 - **worker.rs import migration.** worker.rs picks up the release
   helpers via a module-level `use super::*` glob at worker.rs:1
   (with afxdp.rs:149 glob-importing tx — Codex round-1 R1-4

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,30 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v1 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v2 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Round-1 changelog (v1 → v2): addresses 4 Codex round-1 findings,
+all wording-level (move list and visibility unchanged):
+- R1-1: corrected production-vs-test caller counts (some cited
+  call sites are inside `#[cfg(test)]` blocks at tx.rs:1626+).
+- R1-2: `tx_frame_capacity()` lives in parent `afxdp.rs:273`,
+  not tx.rs. Dependency direction is `cos/token_bucket -> afxdp`,
+  not `cos/token_bucket -> tx`.
+- R1-3: clarified COS_MIN_BURST_BYTES non-test consumer set
+  inside tx.rs (mostly tests after line 6380; production sites
+  at 1832, 5237, plus 7 inside the moving top-up helpers).
+- R1-4: worker.rs gets the release helpers via a module-level
+  `use super::*` glob at worker.rs:1, with `afxdp.rs:149`
+  glob-importing tx — not via `super::tx::*`. The plan's fix
+  (explicit `use super::cos::{...}` import in worker.rs) is
+  still right; rationale wording corrected.
+- R1-5 (new preference): admission.rs should import
+  COS_MIN_BURST_BYTES via `use super::COS_MIN_BURST_BYTES`
+  (cos/mod.rs re-export) rather than reaching directly into
+  `super::token_bucket::COS_MIN_BURST_BYTES`. Avoids leaking
+  the cos/* internal file layout.
 
 ## Goal
 
@@ -20,28 +41,36 @@ back-reference is gone.
 
 | Item | Line | Visibility | Production callers | Test callers |
 |---|---|---|---|---|
-| `maybe_top_up_cos_root_lease` | 3511 | private | tx.rs:1515 | tx.rs:6824 (1 site) |
-| `maybe_top_up_cos_queue_lease` | 3533 | private | tx.rs:1643, 1733 | tx.rs:6873 (1 site) |
-| `refill_cos_tokens` | 3582 | private | tx.rs:1651, 1829 (+ inside maybe_top_up_cos_queue_lease at 3558) | none |
+| `maybe_top_up_cos_root_lease` | 3511 | private | tx.rs:1515 | tx.rs:6824 (production), tx.rs test sites |
+| `maybe_top_up_cos_queue_lease` | 3533 | private | tx.rs:1733 | tx.rs:1643, 6873 (#[cfg(test)] selector starts at tx.rs:1626) |
+| `refill_cos_tokens` | 3582 | private | tx.rs:1829 + internal call from `maybe_top_up_cos_queue_lease` body at tx.rs:3558 | tx.rs:1651 (#[cfg(test)] selector at tx.rs:1626) |
 | `cos_refill_ns_until` | 3625 | private | tx.rs:4257, 4259 | none |
 | `release_cos_root_lease` | 5524 | private | tx.rs:5509 (refresh_cos_interface_activity), tx.rs:5545 (release_all_cos_root_leases) | none |
 | `release_all_cos_root_leases` | 5542 | `pub(super)` | worker.rs:746, 1613, 1911 | none |
 | `release_all_cos_queue_leases` | 5549 | `pub(super)` | worker.rs:746, 755, 1613, 1912 | none |
 
+Production-vs-test note (Codex round-1 R1-1): tx.rs:1626 starts a
+`#[cfg(test)]` legacy-selector block, so call sites at tx.rs:1643,
+1651 are test-only. The move set is unchanged — every fn still has
+at least one production caller — but the visibility justification
+relies on the production sites listed above, not the test ones.
+
 **Constant**:
 
 | Item | Line | Visibility | Use count |
 |---|---|---|---|
-| `COS_MIN_BURST_BYTES` | 3472 | `pub(in crate::afxdp)` | tx.rs: 91 (mostly token-bucket / refill paths); cos/admission.rs: 3 |
+| `COS_MIN_BURST_BYTES` | 3472 | `pub(in crate::afxdp)` | tx.rs: 91 total (most are tests below tx.rs:6380); non-test consumers: tx.rs:1832 (refill), 7 sites at 3522 inside the moving top-up helpers, tx.rs:5237 (runtime construction). cos/admission.rs: 3. |
 
 `COS_MIN_BURST_BYTES` is the burst-cap argument applied uniformly across
 every `maybe_top_up_*` and `refill_cos_tokens` call. It logically belongs
 with the token-bucket module that consumes it.
 
 `tx_frame_capacity()` is referenced by `maybe_top_up_*` to floor lease
-size — that helper stays in tx.rs (it's about TX-ring frame sizing, not
-token-bucket logic). admission.rs already imports it analogously; tx.rs
-can keep it as the owner.
+size — Codex round-1 R1-2 caught that this helper lives in the parent
+module at `afxdp.rs:273`, not `tx.rs`. So the dependency direction
+after the move is `cos/token_bucket -> afxdp::tx_frame_capacity`,
+which is a parent-module reference (not a sibling `tx` import). The
+moved file should `use crate::afxdp::tx_frame_capacity;` directly.
 
 ## Approach
 
@@ -88,9 +117,11 @@ worker.rs:
 
 cos/admission.rs:
 - Replace `use crate::afxdp::tx::COS_MIN_BURST_BYTES` with
-  `use super::token_bucket::COS_MIN_BURST_BYTES` (or via the
-  cos/mod.rs re-export). This eliminates the admission → tx
-  back-reference noted as forward-debt in Phase 3.
+  `use super::COS_MIN_BURST_BYTES` (resolves to the cos/mod.rs
+  re-export rather than the file-internal token_bucket path).
+  Codex round-1 R1-5 prefers this form so admission.rs doesn't
+  encode the cos/* internal file layout. Eliminates the
+  admission → tx back-reference noted as forward-debt in Phase 3.
 
 ## Files touched
 
@@ -139,10 +170,12 @@ touches the hot-path enqueue/refill loop — every TX byte goes through
   enqueue cycle in production (tx.rs:1651, 1829, 3558). Need
   `#[inline]` to survive the cross-module move. Verify against the
   pre-move hot path.
-- **worker.rs import migration.** worker.rs currently calls
-  `release_all_cos_*_leases` via plain identifier (they're in tx.rs,
-  worker.rs already `use super::tx::*`). After the move worker.rs
-  needs an explicit import path (or rely on a re-export from tx).
+- **worker.rs import migration.** worker.rs picks up the release
+  helpers via a module-level `use super::*` glob at worker.rs:1
+  (with afxdp.rs:149 glob-importing tx — Codex round-1 R1-4
+  correction). After the move worker.rs needs an explicit
+  `use super::cos::{release_all_cos_root_leases,
+  release_all_cos_queue_leases};`.
 - **Stale-comment churn.** Phase 3 added a comment block flagging
   the forward-debt; that comment becomes false in this PR.
 

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,23 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v4 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v5 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Round-4 changelog (v4 → v5): Codex round-4 returned PLAN-NEEDS-MINOR
+flagging that 3 of the 8 round-3 nits were called out in changelogs
+but never edited in the original body text. Fixed:
+- #6 nit: Round-1 changelog sentence (production sites for
+  COS_MIN_BURST_BYTES) now lists 1832, 5237, 5264, 5269 plus the
+  7 top-up-helper sites — matching the corrected main table.
+- #7 nit: Round-2 changelog sentence (worker.rs caller lines)
+  now lists root at 746/1613/1911 (not 746/1613) and queue at
+  747/755/1614/1912.
+- #8 nit: Approach-section visibility bullet rewritten to
+  acknowledge the cfg-gated test-reachable surface is 3 fns
+  (direct `tx::tests` calls 2; the `#[cfg(test)]` legacy
+  selector at tx.rs:1626 reaches a third).
 
 Round-3 changelog (v3 → v4): Codex round-3 returned PLAN-NEEDS-MAJOR
 with 1 substantive issue + 5 minor + 2 nits. All 8 are fixed in v4:
@@ -55,8 +69,9 @@ line-number fixes (move set + visibility unchanged):
   tx.rs:6824, but tx.rs:6380 is `mod tests {`, so 6824 is a
   test-module call. Re-labelled.
 - N2 (new): `release_all_cos_queue_leases` caller line numbers
-  in worker.rs were off by one — root calls at 746/1613, queue
-  calls at 747/1614/1912. Corrected to 747/755/1614/1912.
+  in worker.rs were off by one — root calls at 746/1613/1911,
+  queue calls at 747/755/1614/1912 (Codex round-3 #7 caught the
+  earlier wording also omitted worker.rs:1911 from the root list).
 - N3 (new): admission.rs header-note text in the Phase-1+2+3
   cleanup section had to be aligned with R1-5 (use the
   cos/mod.rs re-export, not a direct token_bucket path).
@@ -70,7 +85,9 @@ all wording-level (move list and visibility unchanged):
   not `cos/token_bucket -> tx`.
 - R1-3: clarified COS_MIN_BURST_BYTES non-test consumer set
   inside tx.rs (mostly tests after line 6380; production sites
-  at 1832, 5237, plus 7 inside the moving top-up helpers).
+  at 1832, 5237, 5264, 5269, plus 7 inside the moving top-up
+  helpers — round-3 #6 caught that 5264/5269 were missed in
+  this changelog sentence even though the table was correct).
 - R1-4: worker.rs gets the release helpers via a module-level
   `use super::*` glob at worker.rs:1, with `afxdp.rs:149`
   glob-importing tx — not via `super::tx::*`. The plan's fix
@@ -135,8 +152,14 @@ Create `userspace-dp/src/afxdp/cos/token_bucket.rs` with all 7 functions
 
 Visibility:
 - `pub(in crate::afxdp)`:
-  - All 7 functions (each has at least one cross-module caller in
-    tx.rs or worker.rs; tests call 2 of them).
+  - All 7 functions (each has at least one non-test cross-module
+    caller in tx.rs or worker.rs). Direct `tx::tests` calls land
+    on 2 helpers (`maybe_top_up_cos_root_lease` at tx.rs:6824 and
+    `maybe_top_up_cos_queue_lease` at tx.rs:6873); additional
+    `#[cfg(test)]`-gated call sites in `select_cos_guarantee_batch_with_fast_path`
+    at tx.rs:1626 cover a third helper (`refill_cos_tokens` at
+    tx.rs:1651) — so the cfg-gated reachable surface is 3 fns
+    (Codex round-3 #8 caught the earlier "tests call 2" wording).
   - `COS_MIN_BURST_BYTES` (91 tx.rs sites + 3 admission.rs sites).
 - File-private: nothing (token-bucket is a thin layer with no
   internal-only state helpers).

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,34 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v6 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v7 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Gemini round-1 changelog (v6 → v7): Codex returned PLAN-READY at v6;
+Gemini's adversarial pass returned PLAN-NEEDS-MINOR with 3 systems-
+level findings:
+
+- G1-1 (hot-path inline): Phase 2 + Phase 3 hot-path moves DID add
+  `#[inline]` (e.g. `cos_flow_aware_buffer_limit`,
+  `apply_cos_admission_ecn_policy`). v6 had dropped the inline
+  claim because the existing tx.rs versions had no `#[inline]` —
+  but the established pattern is to ADD `#[inline]` on hot-path
+  moves so cross-module inlining doesn't depend on compiler
+  heuristics. v7 commits implementation to add `#[inline]` to the
+  3 per-byte helpers (`maybe_top_up_cos_root_lease`,
+  `maybe_top_up_cos_queue_lease`, `refill_cos_tokens`); the other
+  4 fns are off the per-byte path and stay un-attributed.
+- G1-2 (timer-wheel scope): `cos_tick_for_ns` is "tightly
+  coupled" to `cos_refill_ns_until` via `calc_cos_wake_ns`.
+  Documented why this Phase 4 keeps the timer-wheel arithmetic
+  in tx.rs (it depends on `COS_TIMER_WHEEL_TICK_NS` etc., which
+  belong with the drain-scheduler extraction).
+- G1-3 (umbrella divergence): the original #956 umbrella plan
+  listed 8 fns for Phase 4 (added timer-wheel + quantum helpers).
+  This Phase 4 trims to the 7 lease/refill helpers; the 4
+  deferred fns will move with the drain-scheduler phase. Section
+  "Scope vs the umbrella plan" added under Goal.
 
 Round-5 changelog (v5 → v6): Codex round-5 returned PLAN-NEEDS-MINOR
 with one residual nit — the Tests-section "Three additional fns"
@@ -117,6 +142,45 @@ Resolve the Phase 3 forward-debt where admission.rs imports
 `COS_MIN_BURST_BYTES` from tx.rs (admission → tx edge); after Phase 4
 both admission.rs and tx.rs import the constant from cos/, so the
 back-reference is gone.
+
+### Scope vs the umbrella plan (Gemini round-1 #2/#3)
+
+The original #956 umbrella plan
+(`docs/pr/956-tx-decomposition/plan.md:482-486`) listed 8 fns for
+Phase 4: the 4 lease/refill helpers in this scope, plus
+`cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+`cos_surplus_quantum_bytes`, and `cos_guarantee_quantum_bytes`.
+
+This plan deliberately deviates and defers the 4 timer-wheel /
+quantum helpers to a future "drain scheduler" extraction (a
+separate phase, likely between current Phase 6 and Phase 7).
+Rationale (post-Codex round-1 + Gemini round-1 review):
+
+- `cos_tick_for_ns` is pure ns→tick arithmetic over
+  `COS_TIMER_WHEEL_TICK_NS`, and `cos_timer_wheel_level_and_slot`
+  depends on `COS_TIMER_WHEEL_L0_HORIZON_TICKS` /
+  `COS_TIMER_WHEEL_L0_SLOTS`. Moving them forces either moving
+  the timer-wheel constants too (scope creep into types.rs) or
+  adding back-references. The constants belong with
+  `park_cos_queue` / `advance_cos_timer_wheel`, which are the
+  drain-scheduler entry points.
+- `cos_guarantee_quantum_bytes` and `cos_surplus_quantum_bytes`
+  consume `COS_GUARANTEE_VISIT_NS`,
+  `COS_GUARANTEE_QUANTUM_MIN/MAX_BYTES`, and
+  `COS_SURPLUS_ROUND_QUANTUM_BYTES` — also drain-scheduler-side.
+- Gemini round-1 #2 noted `cos_refill_ns_until` is "tightly
+  coupled" to `cos_tick_for_ns` via `calc_cos_wake_ns`. True at
+  the call site, but the coupling is one-directional:
+  `calc_cos_wake_ns` consumes both, and after the move
+  `calc_cos_wake_ns` (which stays in tx.rs through Phase 4)
+  imports `cos_refill_ns_until` from cos/ and reaches
+  `cos_tick_for_ns` locally. That's no worse than the existing
+  `tx_frame_capacity()` parent-module reach.
+
+If the drain-scheduler phase later finds it cleaner to bundle
+`cos_refill_ns_until` with the timer-wheel helpers, that's a
+small relocation between cos/* sub-modules — within scope of
+the multi-phase plan.
 
 ## Investigation findings (Claude, on commit 1cb07118)
 
@@ -302,14 +366,23 @@ touches the hot-path enqueue/refill loop — every TX byte goes through
   tx.rs:3558 (which itself moves to token_bucket.rs and stays
   intra-file). The third syntactic site at tx.rs:1651 is inside a
   `#[cfg(test)]` legacy-selector fn, so it's not part of the
-  production hot path. **Implementation note** (Codex round-3 #2):
-  the source definitions at tx.rs:3511, 3533, 3582 do NOT currently
-  carry an `#[inline]` attribute — they rely on the compiler's
-  cross-module inlining via `pub(in crate::afxdp)` visibility, the
-  same pattern Phases 2+3 validated. The implementation should
-  reproduce them unchanged (no `#[inline]` added or removed). If a
-  post-merge perf regression points at a missing inline, that's a
-  follow-up rather than a Phase-4-blocking decision.
+  production hot path. **Implementation note** (Gemini round-1 #1
+  superseding Codex round-3 #2): Gemini correctly observed that
+  Phase 2 + Phase 3 hot-path moves DID add `#[inline]` (e.g.
+  `cos_flow_aware_buffer_limit`, `apply_cos_admission_ecn_policy`,
+  `cos_flow_bucket_index`). The source definitions at tx.rs:3511,
+  3533, 3582 lack `#[inline]` today, but the established Phase 2+3
+  pattern is to ADD `#[inline]` on the hot-path move so cross-module
+  inlining doesn't depend on compiler heuristics. Phase 4
+  implementation will add `#[inline]` to:
+  - `maybe_top_up_cos_root_lease`
+  - `maybe_top_up_cos_queue_lease`
+  - `refill_cos_tokens`
+  The other 4 helpers (`cos_refill_ns_until`, `release_cos_root_lease`,
+  `release_all_cos_root_leases`, `release_all_cos_queue_leases`) are
+  off the per-byte hot path — they fire at most once per drain loop
+  or once per binding shutdown, so the existing
+  no-`#[inline]` shape stays.
 - **worker.rs import migration.** worker.rs picks up the release
   helpers via a module-level `use super::*` glob at worker.rs:1
   (with afxdp.rs:149 glob-importing tx — Codex round-1 R1-4

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,19 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v5 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v6 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Round-5 changelog (v5 → v6): Codex round-5 returned PLAN-NEEDS-MINOR
+with one residual nit — the Tests-section "Three additional fns"
+bullet double-counted `maybe_top_up_cos_root_lease@6824` as both
+a direct-test call and a cfg-gated-only call. Reworded the Tests
+section to cleanly distinguish: 2 helpers reached by direct
+tx::tests bodies (root@6824, queue@6873), and the cfg-gated legacy
+selector at tx.rs:1625 reaches a third helper (`refill_cos_tokens`
+at tx.rs:1651) plus duplicates the queue helper at tx.rs:1643.
+`maybe_top_up_cos_root_lease` is reached only by the direct test.
 
 Round-4 changelog (v4 → v5): Codex round-4 returned PLAN-NEEDS-MINOR
 flagging that 3 of the 8 round-3 nits were called out in changelogs
@@ -239,13 +249,18 @@ No new tests required — pure structural refactor. Existing tests in
   `tx_frame_capacity().max(COS_MIN_BURST_BYTES)` — wrong direction.
 - `maybe_top_up_cos_queue_lease` at tx.rs:6873 (queue-lease grant
   vs queue.tokens prerequisite)
-- Three additional fns have test-only call sites that the refactor
-  must keep reachable: `refill_cos_tokens` at tx.rs:1651,
-  `maybe_top_up_cos_queue_lease` at tx.rs:1643, and
-  `maybe_top_up_cos_root_lease` at tx.rs:6824. (Codex round-3 #8
-  flagged the earlier "tests call 2" wording — direct
-  `tx::tests` calls happen to two helpers but #[cfg(test)] -gated
-  call sites cover three.)
+- Additionally, the `#[cfg(test)]` legacy selector at tx.rs:1625-1626
+  (`select_cos_guarantee_batch_with_fast_path`) reaches a third
+  helper that the direct test calls above don't touch:
+  `refill_cos_tokens` at tx.rs:1651. Plus a duplicate-coverage
+  call to `maybe_top_up_cos_queue_lease` at tx.rs:1643 (already
+  exercised at tx.rs:6873). The refactor must keep all three
+  helpers reachable from cfg-gated code, not just the two
+  exercised by direct tx::tests bodies. (Codex round-3 #8 +
+  round-5 follow-up: the round-5 review caught a double-count of
+  `maybe_top_up_cos_root_lease` here — that helper is reached
+  ONLY by the direct test at tx.rs:6824 above, not by the
+  cfg-gated selector.)
 
 Both tests will continue to compile after the move because both fns
 become `pub(in crate::afxdp)` and are reachable via

--- a/docs/pr/956-phase4-token-bucket/plan.md
+++ b/docs/pr/956-phase4-token-bucket/plan.md
@@ -1,9 +1,30 @@
 # #956 Phase 4: extract cos/token_bucket.rs from tx.rs
 
-Plan v2 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
+Plan v3 — 2026-04-29. Continues #956 (cos/ submodule decomposition).
 Phase 1 (cos/ecn.rs) shipped at PR #976; Phase 2 (cos/flow_hash.rs)
 at PR #977; Phase 3 (cos/admission.rs) at PR #978. Phase 4 = the
 token-bucket lease/refill subsystem.
+
+Round-2 changelog (v2 → v3): addresses 5 Codex round-2 wording /
+line-number fixes (move set + visibility unchanged):
+- R1-1 follow-up (still wrong in v2): the Risk-section claim
+  that `refill_cos_tokens` is called "3 times per enqueue cycle
+  in production" was still naming tx.rs:1651 as a production
+  site. tx.rs:1651 is inside the `#[cfg(test)]` legacy selector
+  starting at tx.rs:1625 — corrected.
+- R1-3 follow-up (still wrong in v2): non-test
+  `COS_MIN_BURST_BYTES` consumer set was missing tx.rs:5264 and
+  tx.rs:5269 (`build_cos_interface_runtime` queue construction).
+  Added.
+- N1 (new): `maybe_top_up_cos_root_lease` test caller is
+  tx.rs:6824, but tx.rs:6380 is `mod tests {`, so 6824 is a
+  test-module call. Re-labelled.
+- N2 (new): `release_all_cos_queue_leases` caller line numbers
+  in worker.rs were off by one — root calls at 746/1613, queue
+  calls at 747/1614/1912. Corrected to 747/755/1614/1912.
+- N3 (new): admission.rs header-note text in the Phase-1+2+3
+  cleanup section had to be aligned with R1-5 (use the
+  cos/mod.rs re-export, not a direct token_bucket path).
 
 Round-1 changelog (v1 → v2): addresses 4 Codex round-1 findings,
 all wording-level (move list and visibility unchanged):
@@ -41,13 +62,13 @@ back-reference is gone.
 
 | Item | Line | Visibility | Production callers | Test callers |
 |---|---|---|---|---|
-| `maybe_top_up_cos_root_lease` | 3511 | private | tx.rs:1515 | tx.rs:6824 (production), tx.rs test sites |
-| `maybe_top_up_cos_queue_lease` | 3533 | private | tx.rs:1733 | tx.rs:1643, 6873 (#[cfg(test)] selector starts at tx.rs:1626) |
-| `refill_cos_tokens` | 3582 | private | tx.rs:1829 + internal call from `maybe_top_up_cos_queue_lease` body at tx.rs:3558 | tx.rs:1651 (#[cfg(test)] selector at tx.rs:1626) |
+| `maybe_top_up_cos_root_lease` | 3511 | private | tx.rs:1515 | tx.rs:6824 (inside `mod tests {` at tx.rs:6380) |
+| `maybe_top_up_cos_queue_lease` | 3533 | private | tx.rs:1733 | tx.rs:1643 (inside `#[cfg(test)] fn` at tx.rs:1625-1626), tx.rs:6873 (inside test module) |
+| `refill_cos_tokens` | 3582 | private | tx.rs:1829 (`select_nonexact_cos_guarantee_batch` at tx.rs:1814 — non-test) + internal call from `maybe_top_up_cos_queue_lease` body at tx.rs:3558 | tx.rs:1651 (inside `#[cfg(test)] fn` at tx.rs:1625-1626) |
 | `cos_refill_ns_until` | 3625 | private | tx.rs:4257, 4259 | none |
 | `release_cos_root_lease` | 5524 | private | tx.rs:5509 (refresh_cos_interface_activity), tx.rs:5545 (release_all_cos_root_leases) | none |
 | `release_all_cos_root_leases` | 5542 | `pub(super)` | worker.rs:746, 1613, 1911 | none |
-| `release_all_cos_queue_leases` | 5549 | `pub(super)` | worker.rs:746, 755, 1613, 1912 | none |
+| `release_all_cos_queue_leases` | 5549 | `pub(super)` | worker.rs:747, 755, 1614, 1912 | none |
 
 Production-vs-test note (Codex round-1 R1-1): tx.rs:1626 starts a
 `#[cfg(test)]` legacy-selector block, so call sites at tx.rs:1643,
@@ -59,7 +80,7 @@ relies on the production sites listed above, not the test ones.
 
 | Item | Line | Visibility | Use count |
 |---|---|---|---|
-| `COS_MIN_BURST_BYTES` | 3472 | `pub(in crate::afxdp)` | tx.rs: 91 total (most are tests below tx.rs:6380); non-test consumers: tx.rs:1832 (refill), 7 sites at 3522 inside the moving top-up helpers, tx.rs:5237 (runtime construction). cos/admission.rs: 3. |
+| `COS_MIN_BURST_BYTES` | 3472 | `pub(in crate::afxdp)` | tx.rs: 91 total (most are tests below tx.rs:6380); non-test consumers: tx.rs:1832 (`refill_cos_tokens` body in `select_nonexact_cos_guarantee_batch`), 7 sites at tx.rs:3522/3530/3545/3553/3561/3570/3578 inside the moving top-up helpers, tx.rs:5237/5264/5269 (runtime construction in `build_cos_interface_runtime`). cos/admission.rs: 3 (admission gates). |
 
 `COS_MIN_BURST_BYTES` is the burst-cap argument applied uniformly across
 every `maybe_top_up_*` and `refill_cos_tokens` call. It logically belongs
@@ -154,9 +175,13 @@ become `pub(in crate::afxdp)` and are reachable via
   cos/token_bucket.rs. Remove the comment block (the constant is gone
   from tx.rs).
 - `cos/admission.rs:24-27` — header note about COS_MIN_BURST_BYTES
-  staying in tx.rs needs to switch to past-tense "Phase 4 moved
-  COS_MIN_BURST_BYTES into cos/token_bucket.rs; admission imports
-  from there now."
+  staying in tx.rs needs to switch to past-tense (Codex round-2 N3:
+  the wording must align with R1-5's chosen import path). Replace
+  with: "Phase 4 moved `COS_MIN_BURST_BYTES` into cos/token_bucket.rs.
+  This module imports it via `super::COS_MIN_BURST_BYTES` (resolves
+  to the cos/mod.rs re-export), not via direct
+  `super::token_bucket::COS_MIN_BURST_BYTES` — that keeps admission
+  agnostic to the cos/* internal file layout."
 - `cos/mod.rs:1-5` — phase-order header. Update to call out Phase 4
   as the current state.
 
@@ -166,10 +191,16 @@ become `pub(in crate::afxdp)` and are reachable via
 touches the hot-path enqueue/refill loop — every TX byte goes through
 `maybe_top_up_cos_*` and `refill_cos_tokens`. Risks:
 
-- **Hot-path inline cost.** `refill_cos_tokens` is called 3 times per
-  enqueue cycle in production (tx.rs:1651, 1829, 3558). Need
-  `#[inline]` to survive the cross-module move. Verify against the
-  pre-move hot path.
+- **Hot-path inline cost.** `refill_cos_tokens` non-test call sites are
+  tx.rs:1829 (in `select_nonexact_cos_guarantee_batch`) and the
+  internal call from `maybe_top_up_cos_queue_lease`'s body at
+  tx.rs:3558 (which itself moves to token_bucket.rs and stays
+  intra-file). The third syntactic site at tx.rs:1651 is inside a
+  `#[cfg(test)]` legacy-selector fn, so it's not part of the
+  production hot path. Even so, `refill_cos_tokens` and the
+  `maybe_top_up_*` helpers must keep `#[inline]` on the move so the
+  compiler can still inline across the cos/* boundary the same way
+  Phases 2+3 validated.
 - **worker.rs import migration.** worker.rs picks up the release
   helpers via a module-level `use super::*` glob at worker.rs:1
   (with afxdp.rs:149 glob-importing tx — Codex round-1 R1-4

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -21,10 +21,13 @@
 // (`cos/queue_ops.rs`). See docs/pr/956-phase3-admission/plan.md
 // for the rationale (Gemini round-1 architectural finding).
 //
-// `COS_MIN_BURST_BYTES` STAYS in tx.rs (91 occurrences across
-// tx.rs, only 1 inside this module). Phase 4 (`token_bucket.rs`)
-// will inherit the same back-reference; the constant should be
-// consolidated to `types.rs` or `cos/mod.rs` in Phase 4 or 5.
+// `COS_MIN_BURST_BYTES` lived in tx.rs through Phase 3 with a
+// `pub(in crate::afxdp)` visibility bump so this module could reach
+// it via `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. Phase 4 moved
+// the constant into `cos/token_bucket.rs`; this module now imports
+// it via `use super::COS_MIN_BURST_BYTES` (resolves to the
+// `cos/mod.rs` re-export). Importing via the parent re-export keeps
+// admission agnostic to which sibling module owns the constant.
 
 use crate::afxdp::types::{
     CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime, WorkerCoSQueueFastPath,
@@ -33,7 +36,7 @@ use crate::afxdp::umem::MmapArea;
 
 use super::ecn::{maybe_mark_ecn_ce, maybe_mark_ecn_ce_prepared};
 use super::flow_hash::{cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows};
-use crate::afxdp::tx::COS_MIN_BURST_BYTES;
+use super::COS_MIN_BURST_BYTES;
 
 /// Minimum per-flow admission share. Sized so TCP fast-retransmit can
 /// trigger reliably on a single-packet drop:

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -12,13 +12,21 @@ pub(super) mod ecn;
 pub(super) mod flow_hash;
 pub(super) mod token_bucket;
 
-// Re-export the items consumed by sibling `tx.rs`. The items
-// themselves are `pub(in crate::afxdp)` in their source files;
-// these re-exports shorten the import path on call sites.
+// Re-export the items consumed by callers across the afxdp module.
+// The items themselves are `pub(in crate::afxdp)` in their source
+// files; these re-exports shorten the import path on call sites.
+// Consumers as of Phase 4:
+//   - `tx.rs` consumes admission gates, flow_hash helpers,
+//     and 5 of the 7 token-bucket helpers + COS_MIN_BURST_BYTES.
+//   - `worker.rs` consumes the 2 `release_all_cos_*_leases`
+//     helpers (called on RG transitions / shutdown).
+//   - `cos/admission.rs` consumes `COS_MIN_BURST_BYTES` (Phase 4
+//     replaced the Phase-3 admission -> tx back-edge with a
+//     `super::COS_MIN_BURST_BYTES` re-export here).
 //
-// Production-side: only the entry points tx.rs's non-test code
-// consumes. Test-only re-exports are gated below to avoid
-// `unused_imports` warnings on non-test builds.
+// Production-side: only the entry points production code consumes.
+// Test-only re-exports are gated below to avoid `unused_imports`
+// warnings on non-test builds.
 pub(super) use admission::{
     apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
     cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -1,14 +1,16 @@
 // #956 cos/ submodule. Phase 1 extracted ECN marking; Phase 2
-// extracted flow-hashing helpers; Phase 3 (this commit) extracts
-// admission policy + flow-fair promotion. Subsequent phases:
-// Phase 4 token bucket, Phase 5 queue ops, Phase 6 builders,
-// Phase 7 queue service, Phase 8 cross-binding.
-// See docs/pr/956-phase3-admission/plan.md for the current phase
+// extracted flow-hashing helpers; Phase 3 extracted admission
+// policy + flow-fair promotion; Phase 4 (this commit) extracts
+// the token-bucket lease/refill subsystem. Subsequent phases:
+// Phase 5 queue ops, Phase 6 builders, Phase 7 queue service,
+// Phase 8 cross-binding.
+// See docs/pr/956-phase4-token-bucket/plan.md for the current phase
 // and docs/pr/956-tx-decomposition/plan.md for the full plan.
 
 pub(super) mod admission;
 pub(super) mod ecn;
 pub(super) mod flow_hash;
+pub(super) mod token_bucket;
 
 // Re-export the items consumed by sibling `tx.rs`. The items
 // themselves are `pub(in crate::afxdp)` in their source files;
@@ -22,6 +24,11 @@ pub(super) use admission::{
     cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
 };
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
+pub(super) use token_bucket::{
+    cos_refill_ns_until, maybe_top_up_cos_queue_lease, maybe_top_up_cos_root_lease,
+    refill_cos_tokens, release_all_cos_queue_leases, release_all_cos_root_leases,
+    release_cos_root_lease, COS_MIN_BURST_BYTES,
+};
 
 #[cfg(test)]
 pub(super) use admission::{

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -1,0 +1,220 @@
+// #956 Phase 4: token-bucket lease/refill helpers, extracted from
+// tx.rs. Provides the per-byte token-budget plumbing that admission
+// gates and the drain-scheduler use to throttle TX pacing:
+//
+//   - `refill_cos_tokens` — basic credit-driven refill against
+//     `transmit_rate_bytes` and a `burst_bytes` cap.
+//   - `maybe_top_up_cos_root_lease` / `maybe_top_up_cos_queue_lease`
+//     — pull bytes from the shared cross-binding lease pools and
+//     deposit them on the local root / queue runtime.
+//   - `cos_refill_ns_until` — pure-arithmetic helper used by the
+//     drain scheduler to compute "how long until enough tokens
+//     accrue for the next packet." (Stays in this module rather
+//     than the timer-wheel module because it has no dependency on
+//     `COS_TIMER_WHEEL_*` constants — the consumer
+//     `calc_cos_wake_ns` does the tick conversion separately.)
+//   - `release_cos_root_lease` / `release_all_cos_root_leases` /
+//     `release_all_cos_queue_leases` — return cross-binding lease
+//     bytes back to the shared pool on RG transitions / shutdown.
+//
+// `COS_MIN_BURST_BYTES` (64 × MTU) is the universal floor for both
+// root and per-queue burst caps and lives here as the canonical
+// owner of the constant.
+//
+// The 3 per-byte helpers (`refill_cos_tokens` and both
+// `maybe_top_up_*` helpers) carry `#[inline]` so the compiler still
+// inlines them across the cos/* boundary — same pattern Phase 2
+// (`cos_flow_bucket_index`, `cos_queue_prospective_active_flows`)
+// and Phase 3 (`cos_queue_flow_share_limit`,
+// `cos_flow_aware_buffer_limit`, `apply_cos_admission_ecn_policy`)
+// validated. The other 4 helpers fire at most once per drain loop
+// or once per RG-transition / shutdown, so they stay un-attributed.
+//
+// `tx_frame_capacity()` lives in the parent `afxdp` module and is
+// imported via `crate::afxdp::tx_frame_capacity` — Codex round-1
+// R1-2 caught the earlier mis-attribution to `super::tx::*`.
+
+use std::sync::Arc;
+
+use crate::afxdp::tx_frame_capacity;
+use crate::afxdp::types::{
+    CoSInterfaceRuntime, CoSQueueRuntime, SharedCoSQueueLease, SharedCoSRootLease,
+};
+use crate::afxdp::worker::BindingWorker;
+
+/// Universal floor for both root and per-queue burst-byte caps
+/// (64 × default MTU = 96 KB). Sized so a single max-len frame can
+/// always fit a freshly-allocated queue without immediately tripping
+/// the buffer-limit gate.
+pub(in crate::afxdp) const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
+
+#[inline]
+pub(in crate::afxdp) fn maybe_top_up_cos_root_lease(
+    root: &mut CoSInterfaceRuntime,
+    shared_root_lease: &SharedCoSRootLease,
+    now_ns: u64,
+) {
+    // Ensure the target is at least tx_frame_capacity() so that a maximum-sized frame
+    // can always become eligible.  shared_root_lease already sizes max_total_leased using
+    // lease_bytes.max(tx_frame_capacity()), so the shared pool can always satisfy this.
+    let lease_bytes = shared_root_lease
+        .lease_bytes()
+        .max(tx_frame_capacity() as u64)
+        .min(root.burst_bytes.max(COS_MIN_BURST_BYTES));
+    if root.tokens >= lease_bytes {
+        return;
+    }
+    let grant = shared_root_lease.acquire(now_ns, lease_bytes.saturating_sub(root.tokens));
+    root.tokens = root
+        .tokens
+        .saturating_add(grant)
+        .min(root.burst_bytes.max(COS_MIN_BURST_BYTES));
+}
+
+#[inline]
+pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
+    queue: &mut CoSQueueRuntime,
+    shared_queue_lease: Option<&Arc<SharedCoSQueueLease>>,
+    now_ns: u64,
+) {
+    if queue.exact {
+        let Some(shared_queue_lease) = shared_queue_lease else {
+            return;
+        };
+        let lease_bytes = shared_queue_lease
+            .lease_bytes()
+            .max(tx_frame_capacity() as u64)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        if queue.tokens >= lease_bytes {
+            return;
+        }
+        let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
+        queue.tokens = queue
+            .tokens
+            .saturating_add(grant)
+            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+        queue.last_refill_ns = now_ns;
+        return;
+    }
+    let Some(shared_queue_lease) = shared_queue_lease else {
+        refill_cos_tokens(
+            &mut queue.tokens,
+            queue.transmit_rate_bytes,
+            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+            &mut queue.last_refill_ns,
+            now_ns,
+        );
+        return;
+    };
+    let lease_bytes = shared_queue_lease
+        .lease_bytes()
+        .max(tx_frame_capacity() as u64)
+        .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+    if queue.tokens >= lease_bytes {
+        return;
+    }
+    let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
+    queue.tokens = queue
+        .tokens
+        .saturating_add(grant)
+        .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
+    queue.last_refill_ns = now_ns;
+}
+
+#[inline]
+pub(in crate::afxdp) fn refill_cos_tokens(
+    tokens: &mut u64,
+    rate_bytes_per_sec: u64,
+    burst_bytes: u64,
+    last_refill_ns: &mut u64,
+    now_ns: u64,
+) {
+    if burst_bytes == 0 {
+        return;
+    }
+    if *last_refill_ns == 0 {
+        *tokens = burst_bytes;
+        *last_refill_ns = now_ns;
+        return;
+    }
+    if now_ns <= *last_refill_ns || rate_bytes_per_sec == 0 {
+        return;
+    }
+    let elapsed_ns = now_ns - *last_refill_ns;
+    let added = ((elapsed_ns as u128) * (rate_bytes_per_sec as u128) / 1_000_000_000u128) as u64;
+    if added == 0 {
+        return;
+    }
+    *tokens = tokens.saturating_add(added).min(burst_bytes);
+    *last_refill_ns = now_ns;
+}
+
+pub(in crate::afxdp) fn cos_refill_ns_until(tokens: u64, need: u64, rate_bytes_per_sec: u64) -> Option<u64> {
+    if tokens >= need {
+        return Some(0);
+    }
+    if rate_bytes_per_sec == 0 {
+        return None;
+    }
+    let deficit = need.saturating_sub(tokens) as u128;
+    let rate = rate_bytes_per_sec as u128;
+    Some(deficit.saturating_mul(1_000_000_000u128).div_ceil(rate) as u64)
+}
+
+pub(in crate::afxdp) fn release_cos_root_lease(binding: &mut BindingWorker, root_ifindex: i32) {
+    let released = binding
+        .cos_interfaces
+        .get_mut(&root_ifindex)
+        .map(|root| core::mem::take(&mut root.tokens))
+        .unwrap_or(0);
+    if released == 0 {
+        return;
+    }
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
+        shared_root_lease.release_unused(released);
+    }
+}
+
+pub(in crate::afxdp) fn release_all_cos_root_leases(binding: &mut BindingWorker) {
+    let root_ifindexes = binding.cos_interfaces.keys().copied().collect::<Vec<_>>();
+    for root_ifindex in root_ifindexes {
+        release_cos_root_lease(binding, root_ifindex);
+    }
+}
+
+pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
+    let queue_keys = binding
+        .cos_interfaces
+        .iter()
+        .flat_map(|(&root_ifindex, root)| {
+            root.queues
+                .iter()
+                .enumerate()
+                .filter(|(_, queue)| queue.exact && queue.tokens > 0)
+                .map(move |(queue_idx, _)| (root_ifindex, queue_idx))
+        })
+        .collect::<Vec<_>>();
+    for (root_ifindex, queue_idx) in queue_keys {
+        let released = binding
+            .cos_interfaces
+            .get_mut(&root_ifindex)
+            .and_then(|root| root.queues.get_mut(queue_idx))
+            .map(|queue| core::mem::take(&mut queue.tokens))
+            .unwrap_or(0);
+        if released == 0 {
+            continue;
+        }
+        if let Some(shared_queue_lease) = binding
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+        {
+            shared_queue_lease.release_unused(released);
+        }
+    }
+}

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3463,13 +3463,6 @@ fn cos_batch_tx_made_progress(result: Result<(u64, u64), TxError>) -> bool {
 }
 
 const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
-// #956 Phase 3: visibility bumped from private so cos/admission.rs
-// can reach it via `use crate::afxdp::tx::COS_MIN_BURST_BYTES`.
-// Constant has 91 occurrences across tx.rs (only 1 in admission),
-// so leaving it here is the smaller-risk move. Phase 4 / 5 will
-// consolidate to types.rs or cos/mod.rs once token_bucket.rs and
-// queue_ops.rs land.
-pub(in crate::afxdp) const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
 const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
 const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
@@ -3480,15 +3473,16 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 //
 // Phase 1 (PR #976) extracted ECN marking into cos/ecn.rs.
 // Phase 2 (PR #977) extracted the flow-hash helpers into
-// cos/flow_hash.rs. Phase 3 (this PR) extracts admission policy +
-// flow-fair promotion into cos/admission.rs. The threshold
-// constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`,
-// `COS_FLOW_FAIR_MIN_SHARE_BYTES`, and
-// `COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS` moved with admission.
+// cos/flow_hash.rs. Phase 3 (PR #978) extracted admission policy +
+// flow-fair promotion into cos/admission.rs. Phase 4 (this PR)
+// extracts token-bucket lease/refill into cos/token_bucket.rs and
+// brings `COS_MIN_BURST_BYTES` along (it now lives in token_bucket
+// rather than tx, eliminating the Phase-3 admission -> tx
+// back-edge for that constant).
 //
 // Production code uses the entry points re-exported from
 // cos/mod.rs (marker fns + flow-hash + admission gates +
-// flow-fair promotion entry).
+// flow-fair promotion entry + token-bucket helpers).
 // The codepoint masks + ECN parser + per-family ECN helpers are
 // referenced only by `tx::tests` (admission tests + ECN unit
 // tests that stay here for Phase 1). Their imports are gated
@@ -3497,7 +3491,8 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 use super::cos::{
     apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
     cos_flow_aware_buffer_limit, cos_flow_bucket_index, cos_item_flow_key,
-    cos_queue_flow_share_limit,
+    cos_queue_flow_share_limit, cos_refill_ns_until, maybe_top_up_cos_queue_lease,
+    maybe_top_up_cos_root_lease, refill_cos_tokens, release_cos_root_lease, COS_MIN_BURST_BYTES,
 };
 #[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
@@ -3507,104 +3502,6 @@ use super::cos::{
     maybe_mark_ecn_ce, COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM,
     COS_FLOW_FAIR_MIN_SHARE_BYTES, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT,
 };
-
-fn maybe_top_up_cos_root_lease(
-    root: &mut CoSInterfaceRuntime,
-    shared_root_lease: &SharedCoSRootLease,
-    now_ns: u64,
-) {
-    // Ensure the target is at least tx_frame_capacity() so that a maximum-sized frame
-    // can always become eligible.  shared_root_lease already sizes max_total_leased using
-    // lease_bytes.max(tx_frame_capacity()), so the shared pool can always satisfy this.
-    let lease_bytes = shared_root_lease
-        .lease_bytes()
-        .max(tx_frame_capacity() as u64)
-        .min(root.burst_bytes.max(COS_MIN_BURST_BYTES));
-    if root.tokens >= lease_bytes {
-        return;
-    }
-    let grant = shared_root_lease.acquire(now_ns, lease_bytes.saturating_sub(root.tokens));
-    root.tokens = root
-        .tokens
-        .saturating_add(grant)
-        .min(root.burst_bytes.max(COS_MIN_BURST_BYTES));
-}
-
-fn maybe_top_up_cos_queue_lease(
-    queue: &mut CoSQueueRuntime,
-    shared_queue_lease: Option<&Arc<SharedCoSQueueLease>>,
-    now_ns: u64,
-) {
-    if queue.exact {
-        let Some(shared_queue_lease) = shared_queue_lease else {
-            return;
-        };
-        let lease_bytes = shared_queue_lease
-            .lease_bytes()
-            .max(tx_frame_capacity() as u64)
-            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
-        if queue.tokens >= lease_bytes {
-            return;
-        }
-        let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
-        queue.tokens = queue
-            .tokens
-            .saturating_add(grant)
-            .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
-        queue.last_refill_ns = now_ns;
-        return;
-    }
-    let Some(shared_queue_lease) = shared_queue_lease else {
-        refill_cos_tokens(
-            &mut queue.tokens,
-            queue.transmit_rate_bytes,
-            queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
-            &mut queue.last_refill_ns,
-            now_ns,
-        );
-        return;
-    };
-    let lease_bytes = shared_queue_lease
-        .lease_bytes()
-        .max(tx_frame_capacity() as u64)
-        .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
-    if queue.tokens >= lease_bytes {
-        return;
-    }
-    let grant = shared_queue_lease.acquire(now_ns, lease_bytes.saturating_sub(queue.tokens));
-    queue.tokens = queue
-        .tokens
-        .saturating_add(grant)
-        .min(queue.buffer_bytes.max(COS_MIN_BURST_BYTES));
-    queue.last_refill_ns = now_ns;
-}
-
-fn refill_cos_tokens(
-    tokens: &mut u64,
-    rate_bytes_per_sec: u64,
-    burst_bytes: u64,
-    last_refill_ns: &mut u64,
-    now_ns: u64,
-) {
-    if burst_bytes == 0 {
-        return;
-    }
-    if *last_refill_ns == 0 {
-        *tokens = burst_bytes;
-        *last_refill_ns = now_ns;
-        return;
-    }
-    if now_ns <= *last_refill_ns || rate_bytes_per_sec == 0 {
-        return;
-    }
-    let elapsed_ns = now_ns - *last_refill_ns;
-    let added = ((elapsed_ns as u128) * (rate_bytes_per_sec as u128) / 1_000_000_000u128) as u64;
-    if added == 0 {
-        return;
-    }
-    *tokens = tokens.saturating_add(added).min(burst_bytes);
-    *last_refill_ns = now_ns;
-}
 
 fn cos_tick_for_ns(now_ns: u64) -> u64 {
     now_ns / COS_TIMER_WHEEL_TICK_NS
@@ -3620,18 +3517,6 @@ fn cos_timer_wheel_level_and_slot(current_tick: u64, wake_tick: u64) -> (u8, usi
                 as usize,
         )
     }
-}
-
-fn cos_refill_ns_until(tokens: u64, need: u64, rate_bytes_per_sec: u64) -> Option<u64> {
-    if tokens >= need {
-        return Some(0);
-    }
-    if rate_bytes_per_sec == 0 {
-        return None;
-    }
-    let deficit = need.saturating_sub(tokens) as u128;
-    let rate = rate_bytes_per_sec as u128;
-    Some(deficit.saturating_mul(1_000_000_000u128).div_ceil(rate) as u64)
 }
 
 fn cos_surplus_quantum_bytes(queue: &CoSQueueRuntime) -> u64 {
@@ -5517,64 +5402,6 @@ fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32
             {
                 shared_queue_lease.release_unused(released);
             }
-        }
-    }
-}
-
-fn release_cos_root_lease(binding: &mut BindingWorker, root_ifindex: i32) {
-    let released = binding
-        .cos_interfaces
-        .get_mut(&root_ifindex)
-        .map(|root| core::mem::take(&mut root.tokens))
-        .unwrap_or(0);
-    if released == 0 {
-        return;
-    }
-    if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
-    {
-        shared_root_lease.release_unused(released);
-    }
-}
-
-pub(super) fn release_all_cos_root_leases(binding: &mut BindingWorker) {
-    let root_ifindexes = binding.cos_interfaces.keys().copied().collect::<Vec<_>>();
-    for root_ifindex in root_ifindexes {
-        release_cos_root_lease(binding, root_ifindex);
-    }
-}
-
-pub(super) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
-    let queue_keys = binding
-        .cos_interfaces
-        .iter()
-        .flat_map(|(&root_ifindex, root)| {
-            root.queues
-                .iter()
-                .enumerate()
-                .filter(|(_, queue)| queue.exact && queue.tokens > 0)
-                .map(move |(queue_idx, _)| (root_ifindex, queue_idx))
-        })
-        .collect::<Vec<_>>();
-    for (root_ifindex, queue_idx) in queue_keys {
-        let released = binding
-            .cos_interfaces
-            .get_mut(&root_ifindex)
-            .and_then(|root| root.queues.get_mut(queue_idx))
-            .map(|queue| core::mem::take(&mut queue.tokens))
-            .unwrap_or(0);
-        if released == 0 {
-            continue;
-        }
-        if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
-            .get(&root_ifindex)
-            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
-            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
-        {
-            shared_queue_lease.release_unused(released);
         }
     }
 }

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1,8 +1,9 @@
 use super::*;
 
 // #956 Phase 4: explicit imports for items that moved out of tx.rs into
-// cos/token_bucket.rs. Without this, the `use super::*;` glob no longer
-// reaches them (tx.rs's pub(super) re-export is gone).
+// cos/token_bucket.rs. Without this, neither the local `use super::*;`
+// glob nor afxdp.rs's `use self::tx::*;` parent-module glob still reaches
+// them — the items no longer originate from tx.rs after the move.
 use super::cos::{release_all_cos_queue_leases, release_all_cos_root_leases};
 
 pub(crate) struct BindingWorker {

--- a/userspace-dp/src/afxdp/worker.rs
+++ b/userspace-dp/src/afxdp/worker.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+// #956 Phase 4: explicit imports for items that moved out of tx.rs into
+// cos/token_bucket.rs. Without this, the `use super::*;` glob no longer
+// reaches them (tx.rs's pub(super) re-export is gone).
+use super::cos::{release_all_cos_queue_leases, release_all_cos_root_leases};
+
 pub(crate) struct BindingWorker {
     pub(crate) slot: u32,
     pub(crate) queue_id: u32,


### PR DESCRIPTION
## Summary

Phase 4 of the #956 cos/ submodule extraction. Moves the
token-bucket lease/refill subsystem from tx.rs into a dedicated
cos/token_bucket.rs.

- 7 fns moved (~175 LOC code, ~220 LOC including header):
  `maybe_top_up_cos_root_lease`, `maybe_top_up_cos_queue_lease`,
  `refill_cos_tokens` (all 3 with `#[inline]` for hot-path),
  `cos_refill_ns_until`, `release_cos_root_lease`,
  `release_all_cos_root_leases`, `release_all_cos_queue_leases`.
- 1 const moved: `COS_MIN_BURST_BYTES` (resolves Phase-3
  forward-debt where admission.rs imported it from tx.rs).
- All 8 items get `pub(in crate::afxdp)`. The 2 release_all_*
  helpers were widened from `pub(super)`.
- worker.rs gets explicit `use super::cos::{release_all_cos_*}`
  (previous tx.rs glob path is gone).
- admission.rs imports `COS_MIN_BURST_BYTES` via cos/mod.rs
  re-export (`use super::COS_MIN_BURST_BYTES`), eliminating the
  Phase-3 admission → tx back-edge.

Net change: -175 lines from tx.rs (17198 → 17030).

## Scope vs the umbrella plan

The original umbrella plan listed 8 fns for Phase 4 (added
`cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
`cos_guarantee_quantum_bytes`, `cos_surplus_quantum_bytes`).
This PR deliberately defers those 4 to a future drain-scheduler
phase — they depend on `COS_TIMER_WHEEL_*` / `COS_GUARANTEE_*`
constants that belong with `park_cos_queue` /
`advance_cos_timer_wheel` rather than with token-bucket
lease/refill. Rationale documented in plan.md.

## Reviews

- Plan v1 → v7 across **6 hostile Codex rounds + 2 Gemini
  adversarial rounds** (gpt-5.5 xhigh; Gemini systems-level).
- Codex rounds 1-3 caught visibility/test-classification factual
  errors. Codex round-3 was MAJOR (tx.rs would import 7 fns when
  it only needs 5 — would trip unused-import warnings on
  release_all_*). v4 narrowed the import; rounds 4-5 cleaned up
  changelog stale wording; round-6 returned PLAN-READY.
- Gemini round-1 found 3 architectural issues: (a) Phase 2+3
  hot-path moves added `#[inline]`, plan must too; (b) timer-wheel
  arithmetic coupling with `cos_refill_ns_until`; (c) deviation
  from umbrella plan needs explicit deferral rationale. v7
  resolved all 3; round-2 returned PLAN-READY.
- Codex impl review IMPL-NEEDS-MINOR (cos/mod.rs comment claimed
  re-exports were tx.rs-only; needed worker.rs + admission.rs).
  Fixed in commit `c798a626`.
- Gemini impl review **IMPL-READY**: byte-identical move, hot-path
  inline applied correctly, no allocator/concurrency surprises,
  Phase-3 back-edge confirmed eliminated.

## Test plan

- [x] `cargo build --bins` clean (zero Phase-4 unused-import
      warnings)
- [x] `cargo test --bins` — 865 passed, 0 failed, 2 ignored (same
      baseline as Phase 3)
- [x] `loss-userspace-cluster.env` rolling deploy successful
- [x] `apply-cos-config.sh` — atomic commit + verification OK
- [x] **Per-CoS-class iperf3 smoke**:

      | port | class       | shaper | rx_gbps | retrans |
      |------|-------------|--------|---------|---------|
      | 5201 | iperf-a     |   1G   |  0.96   |   16    |
      | 5202 | iperf-b     |  10G   |  9.56   |    0    |
      | 5203 | iperf-c     |  25G   | 22.2    |    0    |
      | 5204 | iperf-d     |  13G   | 12.4    |    0    |
      | 5205 | iperf-e     |  16G   | 15.3    |    0    |
      | 5206 | iperf-f     |  19G   | 18.1    |    0    |
      | 5207 | best-effort | 100M   |  0.10   |   35    |

      All shapers correct. iperf-c improved over Phase 3 smoke
      (22.2 vs 12.1 Gbps) — likely fresh cluster cold-start
      benefit. iperf-a's 16 retrans is steady-state TCP behavior
      under a tight policer; best-effort's 35 retrans is normal
      under -P 4 hammering a 100M policer.
- [x] **Failover smoke** (RG1 cycled twice): 48/48 intervals ≥
      3 Gbps, 0 zero-bps. Better than Phase 3 (52/54 over 54
      intervals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)