### PR TITLE
#956 Phase 6: extract cos/builders.rs from tx.rs

### DIFF
--- a/docs/pr/956-phase6-builders/plan.md
+++ b/docs/pr/956-phase6-builders/plan.md
@@ -1,7 +1,27 @@
 # #956 Phase 6: extract cos/builders.rs from tx.rs
 
-Plan v2 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
+Plan v3 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
 Phases 1-5 merged at PRs #976-#980.
+
+Round-2 changelog (v2 → v3): Codex round-2 returned PLAN-NEEDS-MAJOR
+with 3 concrete fixes; Gemini round-2 returned PLAN-READY (accepting
+the narrow approach):
+
+- Codex #1 (#[inline]): v2 wrongly claimed both moved fns are
+  bring-up-only. `ensure_cos_interface_runtime` sits on the
+  steady-state enqueue path (callers at tx.rs:3948/4077/4298/4308)
+  and already carries `#[inline]`. The move must preserve it. v3
+  flips the inline note.
+- Codex #2 (imports incomplete): the planned cos/builders.rs
+  import block missed `BindingWorker`, `ForwardingState`,
+  `FlowRrRing`, `CoSTimerWheelRuntime`, `CoSQueueDropCounters`,
+  `CoSQueueOwnerProfile`, `COS_PRIORITY_LEVELS`,
+  `COS_FLOW_FAIR_BUCKETS`, `TX_BATCH_SIZE`, `VecDeque`. Listed
+  `WorkerCoSInterfaceFastPath` was unused. v3 has the complete
+  surface.
+- Codex #3 (Risk-section contradiction): v2's Risk text said "No
+  new back-edges" while the import discussion documented the
+  `cos_tick_for_ns` back-edge two paragraphs earlier. v3 reworded.
 
 Round-1 changelog (v1 → v2): Codex round-1 returned PLAN-NEEDS-MAJOR
 ("scope too broad — narrow to interface-runtime") and Gemini round-1
@@ -71,23 +91,31 @@ the flow-fair path." Nothing else.
 | `ensure_cos_interface_runtime` | 4299 | private | tx.rs:3948, 4077 | none |
 | `build_cos_interface_runtime` | 4339 | private | called by `ensure_cos_interface_runtime` (moving) at tx.rs:4324; production caller list contains only that one site | tx.rs:5972 / 9124 / 9169 (`#[cfg(test)] mod tests` at tx.rs:5425) |
 
-**Imports needed in cos/builders.rs**:
+**Imports needed in cos/builders.rs** (Codex round-2 verified the
+full surface — v2's list was incomplete):
 
 ```rust
+use std::collections::VecDeque;
+
 use crate::afxdp::types::{
-    CoSInterfaceConfig, CoSInterfaceRuntime, CoSQueueRuntime,
-    WorkerCoSInterfaceFastPath,
+    BindingWorker, CoSInterfaceConfig, CoSInterfaceRuntime,
+    CoSQueueDropCounters, CoSQueueOwnerProfile, CoSQueueRuntime,
+    CoSTimerWheelRuntime, FlowRrRing, ForwardingState,
+    COS_FLOW_FAIR_BUCKETS, COS_PRIORITY_LEVELS, TX_BATCH_SIZE,
 };
 use super::admission::apply_cos_queue_flow_fair_promotion;
-// build_cos_interface_runtime currently calls cos_tick_for_ns;
-// after the move it imports from crate::afxdp::tx
-// (parent-module-internal helper, stays in tx.rs through the
-// drain-scheduler phase).
+// build_cos_interface_runtime calls cos_tick_for_ns. The helper
+// stays in tx.rs through the drain-scheduler phase; this PR bumps
+// its visibility to pub(in crate::afxdp) so cos/builders.rs can
+// reach it. ONE explicit back-edge from cos -> tx, documented
+// as drain-scheduler-phase forward-debt — same shape Phase 3
+// originally had with COS_MIN_BURST_BYTES (which Phase 4 then
+// resolved by relocating the constant).
 use crate::afxdp::tx::cos_tick_for_ns;
 ```
 
-(Codex round-1 will verify the exact import set — `cos_tick_for_ns`
-visibility may need bumping if it's currently private.)
+`WorkerCoSInterfaceFastPath` was in v2's import list but is NOT
+referenced by either moving fn (Codex round-2 catch). Removed.
 
 ## Approach
 
@@ -99,8 +127,14 @@ Visibility:
   (3 direct `tx::tests` callers; production caller is
   `ensure_cos_interface_runtime`, also moving).
 
-`#[inline]`: not warranted on either fn — both fire once per
-interface bring-up, not on the per-byte path.
+`#[inline]` (Codex round-2 #1 corrected v2's wrong claim):
+`ensure_cos_interface_runtime` is NOT bring-up-only. It sits on
+the steady-state enqueue path — production callers at tx.rs:3948,
+4077, 4298, 4308 — and already carries `#[inline]` in source.
+The move MUST preserve that attribute (per the Phase 4/5 hot-path
+inline lesson). `build_cos_interface_runtime` is a one-shot
+constructor and stays without `#[inline]` (matches its current
+state in tx.rs).
 
 `tx.rs` import additions:
 ```rust
@@ -133,9 +167,14 @@ through the cfg-gated re-export.
 ## Risk
 
 **Low.** Smallest move yet (~100 LOC vs 600-800 in earlier
-phases). Clean dependency graph: `cos/builders.rs` →
+phases). Forward dependencies clean: `cos/builders.rs` →
 `cos/admission.rs` → `cos/queue_ops.rs` → `cos/flow_hash.rs`
-+ `cos/token_bucket.rs`. No new back-edges.
++ `cos/token_bucket.rs`. ONE back-edge introduced
+(`cos/builders -> tx::cos_tick_for_ns`), documented above as
+drain-scheduler-phase forward-debt. Codex round-2 caught the
+earlier "No new back-edges" wording in this section — it
+contradicted the back-edge already documented in the import
+discussion. Corrected.
 
 The deferral of `build_cos_batch_from_queue`, `apply_cos_*_result`,
 and `prime_cos_root_for_service` to later phases is documented

--- a/docs/pr/956-phase6-builders/plan.md
+++ b/docs/pr/956-phase6-builders/plan.md
@@ -1,0 +1,82 @@
+# #956 Phase 6: extract cos/builders.rs from tx.rs
+
+Plan v1 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
+Phases 1-5 merged at PRs #976-#980. Phase 6 = the runtime/batch
+builders + send-result helpers that the queue-service path
+(deferred to Phase 7) will consume.
+
+## Goal
+
+Move 6 builder/lifecycle helpers out of tx.rs into
+`userspace-dp/src/afxdp/cos/builders.rs`. This deliberately
+extracts BEFORE Phase 7 (queue_service) so the service-path entry
+points have clean dependencies on cos/* rather than on tx.rs.
+
+## Investigation findings (Claude, on commit 78b68219)
+
+**Move list (6 fns)** in tx.rs source order:
+
+| Item | Line | Visibility | Production callers (non-test) | Test-only |
+|---|---|---|---|---|
+| `prime_cos_root_for_service` | 1505 | private | tx.rs (drain entry — to verify) | tests |
+| `build_cos_batch_from_queue` | 3231 | private | tx.rs select_cos_*_batch paths (Phase 7 consumers) | tests |
+| `ensure_cos_interface_runtime` | 4299 | private | tx.rs interface lifecycle | tests |
+| `build_cos_interface_runtime` | 4339 | private | called by `ensure_cos_interface_runtime` (moving) | tests |
+| `apply_cos_send_result` | 4635 | private | tx.rs TX-completion handler | tests |
+| `apply_cos_prepared_result` | 4696 | private | tx.rs TX-completion handler | tests |
+
+(Codex round-1 will verify the call-site classification — same
+production-vs-test trap Phases 4/5 exposed.)
+
+## Approach
+
+Create `userspace-dp/src/afxdp/cos/builders.rs` with all 6
+functions. Visibility: items with cross-module production callers
+become `pub(in crate::afxdp)`; helpers with only co-located callers
+stay file-private.
+
+Likely classification (subject to Codex verification):
+- `pub(in crate::afxdp)`:
+  - `prime_cos_root_for_service`
+  - `build_cos_batch_from_queue` (Phase 7 will consume)
+  - `ensure_cos_interface_runtime`
+  - `apply_cos_send_result`
+  - `apply_cos_prepared_result`
+- File-private:
+  - `build_cos_interface_runtime` (only `ensure_cos_interface_runtime`,
+    co-located after move)
+
+Test-only re-exports: cfg-gated where any moved fn has direct
+`tx::tests` callers but no production caller in tx.rs. Codex
+round-1 verifies.
+
+`#[inline]` per the Phase 4/5 lesson: hot-path fns get explicit
+attribute. Most builders are one-shot (interface bring-up,
+TX-completion); `build_cos_batch_from_queue` is the one that may
+fire per dispatch and warrants `#[inline]`.
+
+## Scope notes (Codex/Gemini round-1 will validate)
+
+- `apply_cos_queue_flow_fair_promotion` is already in
+  `cos/admission.rs` (Phase 3). `ensure_cos_interface_runtime`
+  imports it from cos/.
+- `cos_queue_*` ops moved in Phase 5; `build_cos_batch_from_queue`
+  reaches them via the cos/ re-exports.
+- `build_shared_cos_*` helpers in coordinator.rs and
+  `build_worker_cos_*` in worker.rs are deferred to Phase 8
+  (cross_binding) where they'll move with the rest of the
+  shared-lease wiring.
+
+## Files touched
+
+- **NEW** `cos/builders.rs`: ~250-300 LOC.
+- `cos/mod.rs`: register module + re-exports.
+- `tx.rs`: remove the 6 fn definitions; extend cos:: import.
+- 0 changes in worker.rs / coordinator.rs (deferred builders).
+
+## Acceptance
+
+- `cargo build --bins` clean.
+- `cargo test --bins` 865/0/2.
+- Cluster smoke per the standard 7-class iperf3 + failover.
+- Both reviewers (Codex hostile + Gemini adversarial) sign off.

--- a/docs/pr/956-phase6-builders/plan.md
+++ b/docs/pr/956-phase6-builders/plan.md
@@ -1,82 +1,149 @@
 # #956 Phase 6: extract cos/builders.rs from tx.rs
 
-Plan v1 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
-Phases 1-5 merged at PRs #976-#980. Phase 6 = the runtime/batch
-builders + send-result helpers that the queue-service path
-(deferred to Phase 7) will consume.
+Plan v2 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
+Phases 1-5 merged at PRs #976-#980.
+
+Round-1 changelog (v1 → v2): Codex round-1 returned PLAN-NEEDS-MAJOR
+("scope too broad — narrow to interface-runtime") and Gemini round-1
+returned PLAN-NEEDS-MAJOR ("expand scope to include the full CoS
+runtime: timer wheel + activity refresh + completion helpers +
+state management"). The two reviewers diverged.
+
+v2 takes Codex's narrow-scope recommendation. Gemini's expand-scope
+alternative would roll Phase 6 into ~Phase 6 + 7 + a deferred
+drain-scheduler phase — a single ~1500+ LOC PR touching the absolute
+hottest tx.rs paths. The narrow approach lands a clean 2-fn extraction
+now, with the larger consolidation explicitly deferred.
+
+The umbrella plan's 5-fn list mixed three architectural categories
+together. v2 narrows Phase 6 to ONLY the interface-runtime
+construction pair and defers the rest:
+
+- **Drop `build_cos_batch_from_queue`** → defer to Phase 7
+  (queue_service). It mutates the queue (`cos_queue_pop_front` +
+  rollback push) and uses the private `CoSBatch` /
+  `CoSServicePhase` enums (tx.rs:771, 776). Architecturally a
+  queue-service primitive, not a builder. Co-move with the
+  enums when Phase 7 lands.
+- **Drop `apply_cos_send_result` + `apply_cos_prepared_result`**
+  → keep in tx.rs. They depend on `refresh_cos_interface_activity`
+  (tx.rs:4590), restore helpers (tx.rs:4805/4820), and pair with
+  the un-listed `apply_direct_exact_send_result` (tx.rs:3171).
+  Moving them in isolation would force moving 3+ neighboring
+  helpers — scope creep. Defer to a future "TX-completion"
+  extraction (likely between Phase 7 and Phase 8).
+- **Drop `prime_cos_root_for_service`** → keep in tx.rs. It
+  calls `advance_cos_timer_wheel` (tx.rs:3702 → uses private
+  timer-wheel constants `COS_TIMER_WHEEL_TICK_NS` /
+  `COS_TIMER_WHEEL_L0_HORIZON_TICKS` etc.). Codex Phase 4 noted
+  the timer-wheel constants belong with the deferred
+  drain-scheduler phase; this fn does too.
+
+Phase 6 is now tight: 2 fns covering interface-runtime
+construction.
 
 ## Goal
 
-Move 6 builder/lifecycle helpers out of tx.rs into
-`userspace-dp/src/afxdp/cos/builders.rs`. This deliberately
-extracts BEFORE Phase 7 (queue_service) so the service-path entry
-points have clean dependencies on cos/* rather than on tx.rs.
+Move 2 builder fns out of tx.rs into
+`userspace-dp/src/afxdp/cos/builders.rs`:
+
+- `ensure_cos_interface_runtime` (tx.rs:4299) — production
+  caller for binding lifecycle (binds new ifindex → constructs
+  + promotes runtime). Calls `build_cos_interface_runtime` and
+  `apply_cos_queue_flow_fair_promotion` (already in
+  cos/admission.rs).
+- `build_cos_interface_runtime` (tx.rs:4339) — pure constructor
+  from `CoSInterfaceConfig`. Called once by
+  `ensure_cos_interface_runtime` and 3 times in `tx::tests`
+  (5972, 9124, 9169) — needs `pub(in crate::afxdp)` plus
+  `#[cfg(test)]` re-export for the test sites.
+
+This focused scope keeps the cos/builders.rs boundary clean:
+"build a CoSInterfaceRuntime from config; promote queues onto
+the flow-fair path." Nothing else.
 
 ## Investigation findings (Claude, on commit 78b68219)
 
-**Move list (6 fns)** in tx.rs source order:
+**Move list (2 fns)**:
 
-| Item | Line | Visibility | Production callers (non-test) | Test-only |
+| Item | Line | Visibility | Production callers | Test callers |
 |---|---|---|---|---|
-| `prime_cos_root_for_service` | 1505 | private | tx.rs (drain entry — to verify) | tests |
-| `build_cos_batch_from_queue` | 3231 | private | tx.rs select_cos_*_batch paths (Phase 7 consumers) | tests |
-| `ensure_cos_interface_runtime` | 4299 | private | tx.rs interface lifecycle | tests |
-| `build_cos_interface_runtime` | 4339 | private | called by `ensure_cos_interface_runtime` (moving) | tests |
-| `apply_cos_send_result` | 4635 | private | tx.rs TX-completion handler | tests |
-| `apply_cos_prepared_result` | 4696 | private | tx.rs TX-completion handler | tests |
+| `ensure_cos_interface_runtime` | 4299 | private | tx.rs:3948, 4077 | none |
+| `build_cos_interface_runtime` | 4339 | private | called by `ensure_cos_interface_runtime` (moving) at tx.rs:4324; production caller list contains only that one site | tx.rs:5972 / 9124 / 9169 (`#[cfg(test)] mod tests` at tx.rs:5425) |
 
-(Codex round-1 will verify the call-site classification — same
-production-vs-test trap Phases 4/5 exposed.)
+**Imports needed in cos/builders.rs**:
+
+```rust
+use crate::afxdp::types::{
+    CoSInterfaceConfig, CoSInterfaceRuntime, CoSQueueRuntime,
+    WorkerCoSInterfaceFastPath,
+};
+use super::admission::apply_cos_queue_flow_fair_promotion;
+// build_cos_interface_runtime currently calls cos_tick_for_ns;
+// after the move it imports from crate::afxdp::tx
+// (parent-module-internal helper, stays in tx.rs through the
+// drain-scheduler phase).
+use crate::afxdp::tx::cos_tick_for_ns;
+```
+
+(Codex round-1 will verify the exact import set — `cos_tick_for_ns`
+visibility may need bumping if it's currently private.)
 
 ## Approach
 
-Create `userspace-dp/src/afxdp/cos/builders.rs` with all 6
-functions. Visibility: items with cross-module production callers
-become `pub(in crate::afxdp)`; helpers with only co-located callers
-stay file-private.
+Visibility:
+- `ensure_cos_interface_runtime` → `pub(in crate::afxdp)`
+  (production callers stay in tx.rs).
+- `build_cos_interface_runtime` → `pub(in crate::afxdp)` plus
+  `#[cfg(test)] pub(super) use` re-export from `cos/mod.rs`
+  (3 direct `tx::tests` callers; production caller is
+  `ensure_cos_interface_runtime`, also moving).
 
-Likely classification (subject to Codex verification):
-- `pub(in crate::afxdp)`:
-  - `prime_cos_root_for_service`
-  - `build_cos_batch_from_queue` (Phase 7 will consume)
-  - `ensure_cos_interface_runtime`
-  - `apply_cos_send_result`
-  - `apply_cos_prepared_result`
-- File-private:
-  - `build_cos_interface_runtime` (only `ensure_cos_interface_runtime`,
-    co-located after move)
+`#[inline]`: not warranted on either fn — both fire once per
+interface bring-up, not on the per-byte path.
 
-Test-only re-exports: cfg-gated where any moved fn has direct
-`tx::tests` callers but no production caller in tx.rs. Codex
-round-1 verifies.
-
-`#[inline]` per the Phase 4/5 lesson: hot-path fns get explicit
-attribute. Most builders are one-shot (interface bring-up,
-TX-completion); `build_cos_batch_from_queue` is the one that may
-fire per dispatch and warrants `#[inline]`.
-
-## Scope notes (Codex/Gemini round-1 will validate)
-
-- `apply_cos_queue_flow_fair_promotion` is already in
-  `cos/admission.rs` (Phase 3). `ensure_cos_interface_runtime`
-  imports it from cos/.
-- `cos_queue_*` ops moved in Phase 5; `build_cos_batch_from_queue`
-  reaches them via the cos/ re-exports.
-- `build_shared_cos_*` helpers in coordinator.rs and
-  `build_worker_cos_*` in worker.rs are deferred to Phase 8
-  (cross_binding) where they'll move with the rest of the
-  shared-lease wiring.
+`tx.rs` import additions:
+```rust
+use super::cos::{ensure_cos_interface_runtime};
+#[cfg(test)]
+use super::cos::build_cos_interface_runtime;
+```
 
 ## Files touched
 
-- **NEW** `cos/builders.rs`: ~250-300 LOC.
-- `cos/mod.rs`: register module + re-exports.
-- `tx.rs`: remove the 6 fn definitions; extend cos:: import.
-- 0 changes in worker.rs / coordinator.rs (deferred builders).
+- **NEW** `userspace-dp/src/afxdp/cos/builders.rs`: ~80-120 LOC.
+- `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
+- `userspace-dp/src/afxdp/tx.rs`: -80-120 LOC; extend cos:: imports
+  (production block + cfg-gated block).
+- `userspace-dp/src/afxdp/tx.rs`: bump `cos_tick_for_ns` visibility
+  to `pub(in crate::afxdp)` so `cos/builders.rs` can call it.
+
+## Tests
+
+No new tests required — pure structural refactor. The 3 direct
+test sites at tx.rs:5972/9124/9169 reach `build_cos_interface_runtime`
+through the cfg-gated re-export.
+
+## Phase-1+2+3+4+5 stale-text cleanup
+
+- `cos/mod.rs:1-7` — phase-order header. Update to call out
+  Phase 6 as the current state.
+- `tx.rs` cos-imports comment block — bump phase note.
+
+## Risk
+
+**Low.** Smallest move yet (~100 LOC vs 600-800 in earlier
+phases). Clean dependency graph: `cos/builders.rs` →
+`cos/admission.rs` → `cos/queue_ops.rs` → `cos/flow_hash.rs`
++ `cos/token_bucket.rs`. No new back-edges.
+
+The deferral of `build_cos_batch_from_queue`, `apply_cos_*_result`,
+and `prime_cos_root_for_service` to later phases is documented
+in this plan's changelog.
 
 ## Acceptance
 
-- `cargo build --bins` clean.
+- `cargo build --bins` clean (no Phase-6 unused-import warnings).
 - `cargo test --bins` 865/0/2.
 - Cluster smoke per the standard 7-class iperf3 + failover.
 - Both reviewers (Codex hostile + Gemini adversarial) sign off.

--- a/docs/pr/956-phase6-builders/plan.md
+++ b/docs/pr/956-phase6-builders/plan.md
@@ -1,7 +1,23 @@
 # #956 Phase 6: extract cos/builders.rs from tx.rs
 
-Plan v3 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
+Plan v4 — 2026-04-30. Continues #956 (cos/ submodule decomposition).
 Phases 1-5 merged at PRs #976-#980.
+
+Round-3 changelog (v3 → v4): Codex round-3 returned PLAN-NEEDS-MAJOR
+with 3 import-correctness fixes:
+- #1 `BindingWorker` lives in `worker.rs` (re-exported at the
+  afxdp root), not in `types`. `TX_BATCH_SIZE` is a root const in
+  `afxdp.rs`, not in `types`. Both import lines split out.
+- #2 `COS_MIN_BURST_BYTES` is consumed at tx.rs:4348/4375/4380
+  inside `build_cos_interface_runtime`'s body — was missing from
+  the import surface. Added via `super::COS_MIN_BURST_BYTES`
+  (cos/mod.rs re-export from token_bucket).
+- #3 `apply_cos_queue_flow_fair_promotion`'s production caller
+  is `ensure_cos_interface_runtime` itself (moving). After the
+  move the only direct callers of this fn in tx.rs are in
+  `tx::tests`. cos/mod.rs must therefore relocate the re-export
+  from always-on to cfg-gated, mirroring the Phase 4 unused-
+  import cleanup at commits 0952a8a4 / 4276eac0.
 
 Round-2 changelog (v2 → v3): Codex round-2 returned PLAN-NEEDS-MAJOR
 with 3 concrete fixes; Gemini round-2 returned PLAN-READY (accepting
@@ -98,12 +114,22 @@ full surface — v2's list was incomplete):
 use std::collections::VecDeque;
 
 use crate::afxdp::types::{
-    BindingWorker, CoSInterfaceConfig, CoSInterfaceRuntime,
-    CoSQueueDropCounters, CoSQueueOwnerProfile, CoSQueueRuntime,
-    CoSTimerWheelRuntime, FlowRrRing, ForwardingState,
-    COS_FLOW_FAIR_BUCKETS, COS_PRIORITY_LEVELS, TX_BATCH_SIZE,
+    CoSInterfaceConfig, CoSInterfaceRuntime, CoSQueueDropCounters,
+    CoSQueueOwnerProfile, CoSQueueRuntime, CoSTimerWheelRuntime,
+    FlowRrRing, ForwardingState, COS_FLOW_FAIR_BUCKETS,
+    COS_PRIORITY_LEVELS,
 };
+use crate::afxdp::worker::BindingWorker;  // not in types — Phase 4
+                                          // pattern: pub(crate) struct
+                                          // lives in worker.rs.
+use crate::afxdp::TX_BATCH_SIZE;          // root const in afxdp.rs,
+                                          // not types — Codex round-3 #1.
 use super::admission::apply_cos_queue_flow_fair_promotion;
+use super::COS_MIN_BURST_BYTES;           // build_cos_interface_runtime
+                                          // body uses it at tx.rs:4348/
+                                          // 4375/4380 — Codex round-3 #2.
+                                          // Reaches via cos/mod.rs
+                                          // re-export from token_bucket.
 // build_cos_interface_runtime calls cos_tick_for_ns. The helper
 // stays in tx.rs through the drain-scheduler phase; this PR bumps
 // its visibility to pub(in crate::afxdp) so cos/builders.rs can
@@ -116,6 +142,16 @@ use crate::afxdp::tx::cos_tick_for_ns;
 
 `WorkerCoSInterfaceFastPath` was in v2's import list but is NOT
 referenced by either moving fn (Codex round-2 catch). Removed.
+
+`apply_cos_queue_flow_fair_promotion` is consumed inside the moved
+`ensure_cos_interface_runtime` body (tx.rs:4326). After the move,
+the only remaining direct callers in `tx.rs` are inside `tx::tests`
+(14446, 14505, 14555, 14564, 14616). cos/mod.rs must therefore
+relocate this re-export from the always-on block to the cfg-gated
+`#[cfg(test)] pub(super) use` block (Codex round-3 #3 — without
+this, the always-on re-export is unused in non-test builds and
+trips a Phase-6-introduced unused-import warning the same way
+Phase 4 commits 0952a8a4 / 4276eac0 had to clean up).
 
 ## Approach
 

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -1,0 +1,158 @@
+// #956 Phase 6: CoS interface-runtime builders, extracted from
+// tx.rs. Provides the construction half of the binding lifecycle:
+//
+//   - `ensure_cos_interface_runtime` — production caller hook
+//     (binding lifecycle). Sits on the steady-state enqueue path
+//     because every enqueue checks whether the runtime exists for
+//     the egress ifindex; carries `#[inline]`.
+//   - `build_cos_interface_runtime` — pure constructor from
+//     `CoSInterfaceConfig`. Called once by `ensure_*` and 3 times
+//     by `tx::tests`; pub(in crate::afxdp) plus cfg-gated
+//     re-export from cos/mod.rs.
+//
+// One back-edge: `cos/builders -> tx::cos_tick_for_ns` (timer-wheel
+// helper that depends on `COS_TIMER_WHEEL_TICK_NS` and friends).
+// Documented as drain-scheduler-phase forward-debt — the helper
+// + constants will move together when timer-wheel + drain-pacing
+// extraction lands.
+//
+// `apply_cos_queue_flow_fair_promotion` (cos/admission.rs) is
+// imported here. After this PR, ensure_cos_interface_runtime is
+// the only non-test caller of that fn — cos/mod.rs's re-export
+// for it shifts from always-on to cfg-gated.
+
+use std::collections::VecDeque;
+
+use crate::afxdp::types::{
+    CoSInterfaceConfig, CoSInterfaceRuntime, CoSQueueDropCounters, CoSQueueOwnerProfile,
+    CoSQueueRuntime, CoSTimerWheelRuntime, FlowRrRing, ForwardingState, COS_FLOW_FAIR_BUCKETS,
+    COS_PRIORITY_LEVELS,
+};
+use crate::afxdp::worker::BindingWorker;
+use crate::afxdp::TX_BATCH_SIZE;
+use crate::afxdp::tx::cos_tick_for_ns;
+use super::admission::apply_cos_queue_flow_fair_promotion;
+use super::COS_MIN_BURST_BYTES;
+
+#[inline]
+pub(in crate::afxdp) fn ensure_cos_interface_runtime(
+    binding: &mut BindingWorker,
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    now_ns: u64,
+) -> bool {
+    if egress_ifindex <= 0 {
+        return false;
+    }
+    // #774 fast path: if the runtime is already materialised,
+    // that's the dominant case on steady state. A single
+    // `contains_key` on the cos_interfaces hot map skips the two
+    // forwarding.cos.interfaces + cos_fast_interfaces lookups
+    // and the later-pass duplicate. Profiled at 0.9% CPU before
+    // this fix.
+    if binding.cos_interfaces.contains_key(&egress_ifindex) {
+        return true;
+    }
+    let Some(config) = forwarding.cos.interfaces.get(&egress_ifindex) else {
+        return false;
+    };
+    if !binding.cos_fast_interfaces.contains_key(&egress_ifindex) {
+        return false;
+    }
+    {
+        let mut runtime = build_cos_interface_runtime(config, now_ns);
+        if let Some(iface_fast) = binding.cos_fast_interfaces.get(&egress_ifindex) {
+            apply_cos_queue_flow_fair_promotion(
+                &mut runtime,
+                &iface_fast.queue_fast_path,
+                binding.worker_id,
+            );
+        }
+        binding.cos_interfaces.insert(egress_ifindex, runtime);
+        binding.cos_interface_order.push(egress_ifindex);
+        binding.cos_interface_order.sort_unstable();
+    }
+    true
+}
+
+pub(in crate::afxdp) fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSInterfaceRuntime {
+    let mut queue_indices_by_priority: [Vec<usize>; COS_PRIORITY_LEVELS] =
+        std::array::from_fn(|_| Vec::new());
+    for (idx, queue) in config.queues.iter().enumerate() {
+        let priority = usize::from(queue.priority).min(COS_PRIORITY_LEVELS - 1);
+        queue_indices_by_priority[priority].push(idx);
+    }
+    CoSInterfaceRuntime {
+        shaping_rate_bytes: config.shaping_rate_bytes,
+        burst_bytes: config.burst_bytes.max(COS_MIN_BURST_BYTES),
+        tokens: 0,
+        default_queue: config.default_queue,
+        nonempty_queues: 0,
+        runnable_queues: 0,
+        exact_guarantee_rr: 0,
+        nonexact_guarantee_rr: 0,
+        #[cfg(test)]
+        legacy_guarantee_rr: 0,
+        queues: config
+            .queues
+            .iter()
+            .map(|queue| CoSQueueRuntime {
+                queue_id: queue.queue_id,
+                priority: queue.priority,
+                transmit_rate_bytes: queue.transmit_rate_bytes,
+                exact: queue.exact,
+                flow_fair: false,
+                // Populated by `promote_cos_queue_flow_fair` from the
+                // live `WorkerCoSQueueFastPath.shared_exact` signal.
+                shared_exact: false,
+                // Zero until `ensure_cos_interface_runtime` promotes a queue
+                // onto the flow-fair path and draws a real seed. On the
+                // non-flow-fair path this field is never read.
+                flow_hash_seed: 0,
+                surplus_weight: queue.surplus_weight,
+                surplus_deficit: 0,
+                buffer_bytes: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
+                dscp_rewrite: queue.dscp_rewrite,
+                tokens: if queue.exact {
+                    0
+                } else {
+                    queue.buffer_bytes.max(COS_MIN_BURST_BYTES)
+                },
+                last_refill_ns: if queue.exact { 0 } else { now_ns },
+                queued_bytes: 0,
+                active_flow_buckets: 0,
+            active_flow_buckets_peak: 0,
+                flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            flow_bucket_head_finish_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            flow_bucket_tail_finish_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+            queue_vtime: 0,
+            pop_snapshot_stack: Vec::with_capacity(TX_BATCH_SIZE),
+                flow_rr_buckets: FlowRrRing::default(),
+                flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
+                runnable: false,
+                parked: false,
+                next_wakeup_tick: 0,
+                wheel_level: 0,
+                wheel_slot: 0,
+                items: VecDeque::new(),
+                local_item_count: 0,
+
+                vtime_floor: None,
+
+                worker_id: 0,
+                drop_counters: CoSQueueDropCounters::default(),
+                owner_profile: CoSQueueOwnerProfile::new(),
+                consecutive_v_min_skips: 0,
+                v_min_suspended_remaining: 0,
+                v_min_hard_cap_overrides_scratch: 0,
+            })
+            .collect(),
+        queue_indices_by_priority,
+        rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
+        timer_wheel: CoSTimerWheelRuntime {
+            current_tick: cos_tick_for_ns(now_ns),
+            level0: std::array::from_fn(|_| Vec::new()),
+            level1: std::array::from_fn(|_| Vec::new()),
+        },
+    }
+}

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -1,14 +1,15 @@
 // #956 cos/ submodule. Phase 1 extracted ECN marking; Phase 2
 // extracted flow-hashing helpers; Phase 3 extracted admission
-// policy + flow-fair promotion; Phase 4 extracted the token-bucket
-// lease/refill subsystem; Phase 5 (this commit) extracts queue ops
-// + MQFQ ordering bookkeeping + V-min slot lifecycle. Subsequent
-// phases: Phase 6 builders, Phase 7 queue service, Phase 8
-// cross-binding.
-// See docs/pr/956-phase5-queue-ops/plan.md for the current phase
+// policy + flow-fair promotion; Phase 4 extracted token-bucket
+// lease/refill; Phase 5 extracted queue ops + MQFQ ordering +
+// V-min lifecycle; Phase 6 (this commit) extracts CoS interface-
+// runtime builders. Subsequent phases: Phase 7 queue service,
+// Phase 8 cross-binding.
+// See docs/pr/956-phase6-builders/plan.md for the current phase
 // and docs/pr/956-tx-decomposition/plan.md for the full plan.
 
 pub(super) mod admission;
+pub(super) mod builders;
 pub(super) mod ecn;
 pub(super) mod flow_hash;
 pub(super) mod queue_ops;
@@ -17,23 +18,25 @@ pub(super) mod token_bucket;
 // Re-export the items consumed by callers across the afxdp module.
 // The items themselves are `pub(in crate::afxdp)` in their source
 // files; these re-exports shorten the import path on call sites.
-// Consumers as of Phase 5:
-//   - `tx.rs` consumes admission gates, flow_hash helpers,
-//     5 of 7 token-bucket helpers + COS_MIN_BURST_BYTES, and
-//     the 14 always-on queue_ops helpers.
+// Consumers as of Phase 6:
+//   - `tx.rs` consumes admission gates (no longer the promotion
+//     entry — that's now consumed inside cos/builders.rs),
+//     flow_hash helpers, 5 of 7 token-bucket helpers +
+//     COS_MIN_BURST_BYTES, the 14 always-on queue_ops helpers,
+//     and `ensure_cos_interface_runtime`.
 //   - `worker.rs` consumes the 2 `release_all_cos_*_leases`
 //     plus `cos_queue_len` and `cos_queue_pop_front_no_snapshot`.
-//   - `cos/admission.rs` consumes `COS_MIN_BURST_BYTES` (Phase 4
-//     replaced the Phase-3 admission -> tx back-edge with a
-//     `super::COS_MIN_BURST_BYTES` re-export here).
+//   - `cos/admission.rs` consumes `COS_MIN_BURST_BYTES`.
+//   - `cos/builders.rs` consumes `apply_cos_queue_flow_fair_promotion`
+//     and `COS_MIN_BURST_BYTES`.
 //
 // Production-side: only the entry points production code consumes.
 // Test-only re-exports are gated below to avoid `unused_imports`
 // warnings on non-test builds.
 pub(super) use admission::{
-    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
-    cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
+    apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
 };
+pub(super) use builders::ensure_cos_interface_runtime;
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 pub(super) use queue_ops::{
     cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all,
@@ -48,11 +51,17 @@ pub(super) use token_bucket::{
     release_cos_root_lease, COS_MIN_BURST_BYTES,
 };
 
+// Phase 6 relocated apply_cos_queue_flow_fair_promotion's only
+// remaining tx.rs caller (ensure_cos_interface_runtime) into
+// cos/builders.rs. tx.rs's only direct callers now live in
+// tx::tests, so the re-export shifts to cfg-gated.
 #[cfg(test)]
 pub(super) use admission::{
-    bdp_floor_bytes, COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM,
-    COS_FLOW_FAIR_MIN_SHARE_BYTES,
+    apply_cos_queue_flow_fair_promotion, bdp_floor_bytes, COS_ECN_MARK_THRESHOLD_DEN,
+    COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MIN_SHARE_BYTES,
 };
+#[cfg(test)]
+pub(super) use builders::build_cos_interface_runtime;
 #[cfg(test)]
 pub(super) use ecn::{maybe_mark_ecn_ce, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -3488,13 +3488,12 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 // behind `#[cfg(test)]` to avoid `unused_imports` warnings in
 // non-test builds (Copilot review on PR #976).
 use super::cos::{
-    apply_cos_admission_ecn_policy, apply_cos_queue_flow_fair_promotion,
-    cos_flow_aware_buffer_limit, cos_flow_bucket_index, cos_item_flow_key, cos_item_len,
-    cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all, cos_queue_flow_share_limit,
-    cos_queue_front, cos_queue_is_empty, cos_queue_pop_front, cos_queue_push_back,
-    cos_queue_push_front,
-    cos_queue_restore_front, cos_queue_v_min_consume_suspension, cos_queue_v_min_continue,
-    cos_refill_ns_until, maybe_top_up_cos_queue_lease, maybe_top_up_cos_root_lease,
+    apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_flow_bucket_index,
+    cos_item_flow_key, cos_item_len, cos_queue_clear_orphan_snapshot_after_drop,
+    cos_queue_drain_all, cos_queue_flow_share_limit, cos_queue_front, cos_queue_is_empty,
+    cos_queue_pop_front, cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
+    cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, cos_refill_ns_until,
+    ensure_cos_interface_runtime, maybe_top_up_cos_queue_lease, maybe_top_up_cos_root_lease,
     publish_committed_queue_vtime, refill_cos_tokens, release_cos_root_lease,
     COS_MIN_BURST_BYTES,
 };
@@ -3502,14 +3501,20 @@ use super::cos::{
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
 #[cfg(test)]
 use super::cos::{
-    account_cos_queue_flow_dequeue, account_cos_queue_flow_enqueue, bdp_floor_bytes,
+    account_cos_queue_flow_dequeue, account_cos_queue_flow_enqueue,
+    apply_cos_queue_flow_fair_promotion, bdp_floor_bytes, build_cos_interface_runtime,
     cos_flow_hash_seed_from_os, cos_queue_prospective_active_flows, maybe_mark_ecn_ce,
     COS_ECN_MARK_THRESHOLD_DEN, COS_ECN_MARK_THRESHOLD_NUM, COS_FLOW_FAIR_MIN_SHARE_BYTES, ECN_CE,
     ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT, V_MIN_CONSECUTIVE_SKIP_HARD_CAP,
     V_MIN_SUSPENSION_BATCHES,
 };
 
-fn cos_tick_for_ns(now_ns: u64) -> u64 {
+// #956 Phase 6: visibility bumped from private so cos/builders.rs
+// can reach it via `use crate::afxdp::tx::cos_tick_for_ns`. Timer-
+// wheel helpers stay in tx.rs through the drain-scheduler phase
+// (they consume the private COS_TIMER_WHEEL_* constants and are
+// tightly coupled to advance_cos_timer_wheel).
+pub(in crate::afxdp) fn cos_tick_for_ns(now_ns: u64) -> u64 {
     now_ns / COS_TIMER_WHEEL_TICK_NS
 }
 
@@ -4293,129 +4298,6 @@ fn cos_queue_accepts_prepared(root: &CoSInterfaceRuntime, requested_queue: Optio
         return false;
     };
     queue.local_item_count == 0
-}
-
-#[inline]
-fn ensure_cos_interface_runtime(
-    binding: &mut BindingWorker,
-    forwarding: &ForwardingState,
-    egress_ifindex: i32,
-    now_ns: u64,
-) -> bool {
-    if egress_ifindex <= 0 {
-        return false;
-    }
-    // #774 fast path: if the runtime is already materialised,
-    // that's the dominant case on steady state. A single
-    // `contains_key` on the cos_interfaces hot map skips the two
-    // forwarding.cos.interfaces + cos_fast_interfaces lookups
-    // and the later-pass duplicate. Profiled at 0.9% CPU before
-    // this fix.
-    if binding.cos_interfaces.contains_key(&egress_ifindex) {
-        return true;
-    }
-    let Some(config) = forwarding.cos.interfaces.get(&egress_ifindex) else {
-        return false;
-    };
-    if !binding.cos_fast_interfaces.contains_key(&egress_ifindex) {
-        return false;
-    }
-    {
-        let mut runtime = build_cos_interface_runtime(config, now_ns);
-        if let Some(iface_fast) = binding.cos_fast_interfaces.get(&egress_ifindex) {
-            apply_cos_queue_flow_fair_promotion(
-                &mut runtime,
-                &iface_fast.queue_fast_path,
-                binding.worker_id,
-            );
-        }
-        binding.cos_interfaces.insert(egress_ifindex, runtime);
-        binding.cos_interface_order.push(egress_ifindex);
-        binding.cos_interface_order.sort_unstable();
-    }
-    true
-}
-
-fn build_cos_interface_runtime(config: &CoSInterfaceConfig, now_ns: u64) -> CoSInterfaceRuntime {
-    let mut queue_indices_by_priority: [Vec<usize>; COS_PRIORITY_LEVELS] =
-        std::array::from_fn(|_| Vec::new());
-    for (idx, queue) in config.queues.iter().enumerate() {
-        let priority = usize::from(queue.priority).min(COS_PRIORITY_LEVELS - 1);
-        queue_indices_by_priority[priority].push(idx);
-    }
-    CoSInterfaceRuntime {
-        shaping_rate_bytes: config.shaping_rate_bytes,
-        burst_bytes: config.burst_bytes.max(COS_MIN_BURST_BYTES),
-        tokens: 0,
-        default_queue: config.default_queue,
-        nonempty_queues: 0,
-        runnable_queues: 0,
-        exact_guarantee_rr: 0,
-        nonexact_guarantee_rr: 0,
-        #[cfg(test)]
-        legacy_guarantee_rr: 0,
-        queues: config
-            .queues
-            .iter()
-            .map(|queue| CoSQueueRuntime {
-                queue_id: queue.queue_id,
-                priority: queue.priority,
-                transmit_rate_bytes: queue.transmit_rate_bytes,
-                exact: queue.exact,
-                flow_fair: false,
-                // Populated by `promote_cos_queue_flow_fair` from the
-                // live `WorkerCoSQueueFastPath.shared_exact` signal.
-                shared_exact: false,
-                // Zero until `ensure_cos_interface_runtime` promotes a queue
-                // onto the flow-fair path and draws a real seed. On the
-                // non-flow-fair path this field is never read.
-                flow_hash_seed: 0,
-                surplus_weight: queue.surplus_weight,
-                surplus_deficit: 0,
-                buffer_bytes: queue.buffer_bytes.max(COS_MIN_BURST_BYTES),
-                dscp_rewrite: queue.dscp_rewrite,
-                tokens: if queue.exact {
-                    0
-                } else {
-                    queue.buffer_bytes.max(COS_MIN_BURST_BYTES)
-                },
-                last_refill_ns: if queue.exact { 0 } else { now_ns },
-                queued_bytes: 0,
-                active_flow_buckets: 0,
-            active_flow_buckets_peak: 0,
-                flow_bucket_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_head_finish_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            flow_bucket_tail_finish_bytes: [0; COS_FLOW_FAIR_BUCKETS],
-            queue_vtime: 0,
-            pop_snapshot_stack: Vec::with_capacity(TX_BATCH_SIZE),
-                flow_rr_buckets: FlowRrRing::default(),
-                flow_bucket_items: std::array::from_fn(|_| VecDeque::new()),
-                runnable: false,
-                parked: false,
-                next_wakeup_tick: 0,
-                wheel_level: 0,
-                wheel_slot: 0,
-                items: VecDeque::new(),
-                local_item_count: 0,
-
-                vtime_floor: None,
-
-                worker_id: 0,
-                drop_counters: CoSQueueDropCounters::default(),
-                owner_profile: CoSQueueOwnerProfile::new(),
-                consecutive_v_min_skips: 0,
-                v_min_suspended_remaining: 0,
-                v_min_hard_cap_overrides_scratch: 0,
-            })
-            .collect(),
-        queue_indices_by_priority,
-        rr_index_by_priority: [0; COS_PRIORITY_LEVELS],
-        timer_wheel: CoSTimerWheelRuntime {
-            current_tick: cos_tick_for_ns(now_ns),
-            level0: std::array::from_fn(|_| Vec::new()),
-            level1: std::array::from_fn(|_| Vec::new()),
-        },
-    }
 }
 
 fn cos_queue_dscp_rewrite(


### PR DESCRIPTION
## Summary

Phase 6 of the #956 cos/ submodule extraction. Narrow scope:
2 fns covering CoS interface-runtime construction.

- 2 fns moved (~123 LOC removed from tx.rs):
  - `ensure_cos_interface_runtime` (#[inline] preserved — sits
    on steady-state enqueue path), `pub(in crate::afxdp)`.
  - `build_cos_interface_runtime`, `pub(in crate::afxdp)` +
    cfg-gated re-export from cos/mod.rs (3 direct test sites at
    tx.rs:5972/9124/9169).
- `apply_cos_queue_flow_fair_promotion`'s last tx.rs production
  caller moved with `ensure_cos_interface_runtime` into
  cos/builders.rs. cos/mod.rs relocates the re-export from
  always-on to cfg-gated (mirrors Phase 4 cleanup at `0952a8a4`/
  `4276eac0`).
- `cos_tick_for_ns` visibility bumped to `pub(in crate::afxdp)`
  (one back-edge from cos -> tx, documented as drain-scheduler-
  phase forward-debt).

## Scope decisions

**Narrow approach over expand approach.** Codex round-1 said
narrow Phase 6 to interface-runtime construction only; Gemini
round-1 said expand to include the full CoS runtime (timer
wheel + completion helpers + state management) — ~1500 LOC
touching hot paths. This PR takes the narrow approach. Gemini
round-2 returned PLAN-READY accepting the trade-off.

**Deferred from Phase 6**:
- `build_cos_batch_from_queue` → Phase 7 (queue-service
  primitive; uses private `CoSBatch` / `CoSServicePhase` enums).
- `apply_cos_send_result` + `apply_cos_prepared_result` →
  future TX-completion phase (depend on
  `refresh_cos_interface_activity` + restore helpers).
- `prime_cos_root_for_service` → drain-scheduler phase (calls
  `advance_cos_timer_wheel`).

Net change: -123 lines from tx.rs (16245 → 16122).

## Reviews

- Plan v1 → v4 across **4 hostile Codex rounds + 2 Gemini
  adversarial rounds** (gpt-5.5 xhigh; Gemini systems-level).
- Codex caught: scope too broad (round 1, dropped 3 fns), wrong
  inline classification (round 2), incorrect import surface
  (round 3 — added BindingWorker/TX_BATCH_SIZE/COS_MIN_BURST_BYTES),
  re-export shuffle (round 3 — apply_*_promotion to cfg-gated).
- Gemini round-2 PLAN-READY accepting narrow scope.

## Test plan

- [x] `cargo build --bins` clean (no Phase-6 unused-import
      warnings)
- [x] `cargo test --bins` — 865 passed, 0 failed, 2 ignored
- [x] `loss-userspace-cluster.env` rolling deploy successful
- [x] `apply-cos-config.sh` — atomic commit + verification OK
- [x] **Per-CoS-class iperf3 smoke**:

      | port | class       | shaper | rx_gbps | retrans |
      |------|-------------|--------|---------|---------|
      | 5201 | iperf-a     |   1G   |  0.95   |    0    |
      | 5202 | iperf-b     |  10G   |  9.55   |    0    |
      | 5203 | iperf-c     |  25G   | 21.2    | 2123    |
      | 5204 | iperf-d     |  13G   | 12.4    |    0    |
      | 5205 | iperf-e     |  16G   | 15.3    |    0    |
      | 5206 | iperf-f     |  19G   | 18.1    |    0    |
      | 5207 | best-effort | 100M   |  0.09   |   48    |

- [x] **Failover smoke** (RG1 cycled twice, 2 runs):
  - Run 1: post-deploy transient — 6s zero-traffic dip on
    first failover, recovered cleanly on second (40/48 ≥3G).
  - Run 2: 56/56 intervals ≥3 Gbps, 0 zero-bps. Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)