### PR TITLE
#956 Phase 8: extract cos/cross_binding.rs from tx.rs (FINAL)

### DIFF
--- a/docs/pr/956-phase8-cross-binding/plan.md
+++ b/docs/pr/956-phase8-cross-binding/plan.md
@@ -1,0 +1,76 @@
+# #956 Phase 8: extract cos/cross_binding.rs from tx.rs
+
+Plan v1 — 2026-04-30. **Final phase** of #956. Phases 1-7 merged
+at PRs #976-#982.
+
+## Goal
+
+Move 5 cross-binding redirect helpers from tx.rs into
+`userspace-dp/src/afxdp/cos/cross_binding.rs`. These resolve the
+"is this request bound to the owner of the egress, or do we hand
+off via MPSC inbox?" question for both Local and Prepared TX
+requests.
+
+## Move list (5 fns)
+
+| Item | Line | Visibility | Notes |
+|---|---|---|---|
+| `redirect_local_cos_request_to_owner` | 1217 | private | step-1 entry |
+| `redirect_local_cos_request_to_owner_binding` | 1248 | private | step-2 inbox handoff |
+| `prepared_cos_request_stays_on_current_tx_binding` | 1268 | private | gate predicate |
+| `redirect_prepared_cos_request_to_owner` | 1276 | private | prepared step-1 |
+| `redirect_prepared_cos_request_to_owner_binding` | 1328 | private | prepared step-2 |
+
+(Codex round-1 verifies callers. Plan-stage assumption: each fn
+has tx.rs production callers — non-test — so all 5 become
+`pub(in crate::afxdp)`.)
+
+## Approach
+
+`cos/cross_binding.rs` (~160 LOC) hosts the 5 fns + module-level
+docs explaining the two-step redirect model (resolve owner →
+hand off via MPSC inbox if it's a different binding).
+
+Visibility: all 5 → `pub(in crate::afxdp)`. tx.rs's existing cos::
+import block extends with the new entries.
+
+`#[inline]` per Phase 4-7 lesson: all 5 are per-enqueue hot path
+helpers — add `#[inline]` on the move.
+
+## Files touched
+
+- **NEW** `userspace-dp/src/afxdp/cos/cross_binding.rs`: ~180 LOC.
+- `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
+- `userspace-dp/src/afxdp/tx.rs`: -160 LOC; extend cos:: imports.
+
+## After this Phase 8
+
+`tx.rs` left in place is just XSK ring management (descriptor
+pop/push, kick threshold, completion reap) + orchestration glue
+(drain_pending_tx, bound_pending_tx_*) + the deferred TX-completion
+family that was bumped to `pub(in crate::afxdp)` during Phase 7
+(apply_cos_*_result, restore_cos_*_inner, transmit_*, etc).
+
+The umbrella plan called for those to also extract eventually
+(probably as cos/tx_completion.rs and a coordinator/worker-side
+cross-binding extraction). Those are explicitly OUT-OF-SCOPE for
+this PR and tracked as future work.
+
+## Tests
+
+No new tests — pure structural refactor. Existing tests in
+`tx::tests` exercise the 5 fns indirectly via the `enqueue_*` and
+`drain_*` paths.
+
+## Risk
+
+**Low.** Smallest move in the campaign (~160 LOC). Forward
+dependencies clean: cross_binding.rs imports types and a few
+helpers from existing cos/* modules. No new back-edges expected.
+
+## Acceptance
+
+- `cargo build --bins` clean
+- `cargo test --bins` 865/0/2
+- Cluster smoke per the standard 7-class iperf3 + failover
+- Both reviewers (Codex hostile + Gemini adversarial) sign off

--- a/docs/pr/956-phase8-cross-binding/plan.md
+++ b/docs/pr/956-phase8-cross-binding/plan.md
@@ -1,72 +1,101 @@
 # #956 Phase 8: extract cos/cross_binding.rs from tx.rs
 
-Plan v1 — 2026-04-30. **Final phase** of #956. Phases 1-7 merged
+Plan v2 — 2026-04-30. **Final phase** of #956. Phases 1-7 merged
 at PRs #976-#982.
 
-## Goal
+Round-1 changelog (v1 → v2): Codex round-1 returned
+PLAN-NEEDS-MAJOR with 7 findings. v2 expands scope to capture the
+true cross-binding cluster:
 
-Move 5 cross-binding redirect helpers from tx.rs into
-`userspace-dp/src/afxdp/cos/cross_binding.rs`. These resolve the
-"is this request bound to the owner of the egress, or do we hand
-off via MPSC inbox?" question for both Local and Prepared TX
-requests.
+- v1 listed only the 5 redirect_* fns; v2 adds the helpers they
+  depend on (cos_fast_interface, cos_fast_queue,
+  resolve_local_routing_decision) and the routing-decision types
+  (Step1Action, LocalRoutingDecision).
+- Visibility corrected: `redirect_local_cos_request_to_owner_binding`
+  has only test callers (tx.rs:3941, 3989) — needs cfg-gated re-
+  export, not always-on.
+- Back-edge to `recycle_prepared_immediately` (tx.rs:2622, stays
+  in tx.rs) acknowledged; visibility already pub(super), bumped
+  to pub(in crate::afxdp).
+- cos/mod.rs wiring made explicit.
 
-## Move list (5 fns)
+## Move list (v2)
 
-| Item | Line | Visibility | Notes |
+### Types (2)
+| Item | Line | Kind |
+|---|---|---|
+| `Step1Action` | 1131 | enum |
+| `LocalRoutingDecision` | 1147 | struct |
+
+### Helpers (3)
+| Item | Line | Notes |
+|---|---|---|
+| `resolve_local_routing_decision` | 1164 | step-1 owner resolution |
+| `cos_fast_interface` | 1199 | binding fast-path lookup |
+| `cos_fast_queue` | 1207 | binding queue fast-path lookup |
+
+### Redirect fns (5)
+| Item | Line | Visibility | Callers |
 |---|---|---|---|
-| `redirect_local_cos_request_to_owner` | 1217 | private | step-1 entry |
-| `redirect_local_cos_request_to_owner_binding` | 1248 | private | step-2 inbox handoff |
-| `prepared_cos_request_stays_on_current_tx_binding` | 1268 | private | gate predicate |
-| `redirect_prepared_cos_request_to_owner` | 1276 | private | prepared step-1 |
-| `redirect_prepared_cos_request_to_owner_binding` | 1328 | private | prepared step-2 |
+| `redirect_local_cos_request_to_owner` | 1217 | pub | production |
+| `redirect_local_cos_request_to_owner_binding` | 1248 | cfg-gated | tests only (tx.rs:3941, 3989) |
+| `prepared_cos_request_stays_on_current_tx_binding` | 1268 | pub | production |
+| `redirect_prepared_cos_request_to_owner` | 1276 | pub | production |
+| `redirect_prepared_cos_request_to_owner_binding` | 1328 | pub | production |
 
-(Codex round-1 verifies callers. Plan-stage assumption: each fn
-has tx.rs production callers — non-test — so all 5 become
-`pub(in crate::afxdp)`.)
+**Total: 2 types + 8 fns ≈ 250 LOC**
+
+## Back-edges to tx.rs (deferred TX-completion / worker-binding)
+
+`recycle_prepared_immediately` (tx.rs:2622) — currently
+`pub(super)`. Bumped to `pub(in crate::afxdp)` so cos/cross_binding.rs
+can call it. Stays in tx.rs because it touches XSK ring frame
+recycling — worker-binding territory, not cos.
 
 ## Approach
 
-`cos/cross_binding.rs` (~160 LOC) hosts the 5 fns + module-level
-docs explaining the two-step redirect model (resolve owner →
-hand off via MPSC inbox if it's a different binding).
+Visibility:
+- `pub(in crate::afxdp)`: 4 redirect fns + 3 helpers + 2 types.
+- cfg-gated `pub(super) use`: redirect_local_cos_request_to_owner_binding
+  (test-only after move).
 
-Visibility: all 5 → `pub(in crate::afxdp)`. tx.rs's existing cos::
-import block extends with the new entries.
+`#[inline]` per Phase 4-7 lesson:
+- Per-byte hot path (called from enqueue): all 4 production
+  redirect fns + 3 helpers + resolve_local_routing_decision —
+  add `#[inline]`.
+- Larger memcpy bodies (redirect_prepared variants ~47-51 lines)
+  follow Phase 7 precedent for similar-sized fns: leave un-
+  attributed; LLVM heuristic should cover.
 
-`#[inline]` per Phase 4-7 lesson: all 5 are per-enqueue hot path
-helpers — add `#[inline]` on the move.
+## cos/mod.rs additions
+
+```rust
+pub(super) mod cross_binding;
+
+pub(super) use cross_binding::{
+    cos_fast_interface, cos_fast_queue, prepared_cos_request_stays_on_current_tx_binding,
+    redirect_local_cos_request_to_owner, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding, resolve_local_routing_decision,
+    LocalRoutingDecision, Step1Action,
+};
+
+#[cfg(test)]
+pub(super) use cross_binding::redirect_local_cos_request_to_owner_binding;
+```
 
 ## Files touched
 
-- **NEW** `userspace-dp/src/afxdp/cos/cross_binding.rs`: ~180 LOC.
+- **NEW** `userspace-dp/src/afxdp/cos/cross_binding.rs`: ~280 LOC.
 - `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
-- `userspace-dp/src/afxdp/tx.rs`: -160 LOC; extend cos:: imports.
-
-## After this Phase 8
-
-`tx.rs` left in place is just XSK ring management (descriptor
-pop/push, kick threshold, completion reap) + orchestration glue
-(drain_pending_tx, bound_pending_tx_*) + the deferred TX-completion
-family that was bumped to `pub(in crate::afxdp)` during Phase 7
-(apply_cos_*_result, restore_cos_*_inner, transmit_*, etc).
-
-The umbrella plan called for those to also extract eventually
-(probably as cos/tx_completion.rs and a coordinator/worker-side
-cross-binding extraction). Those are explicitly OUT-OF-SCOPE for
-this PR and tracked as future work.
-
-## Tests
-
-No new tests — pure structural refactor. Existing tests in
-`tx::tests` exercise the 5 fns indirectly via the `enqueue_*` and
-`drain_*` paths.
+- `userspace-dp/src/afxdp/tx.rs`: -250 LOC; bump
+  `recycle_prepared_immediately` to `pub(in crate::afxdp)`; extend
+  cos:: imports.
 
 ## Risk
 
-**Low.** Smallest move in the campaign (~160 LOC). Forward
-dependencies clean: cross_binding.rs imports types and a few
-helpers from existing cos/* modules. No new back-edges expected.
+**Low.** Smallest move of remaining work (~250 LOC). Forward
+dependencies clean: cross_binding.rs imports types from afxdp::types,
+worker::BindingWorker, and one back-edge to tx::recycle_prepared_immediately.
 
 ## Acceptance
 
@@ -74,3 +103,15 @@ helpers from existing cos/* modules. No new back-edges expected.
 - `cargo test --bins` 865/0/2
 - Cluster smoke per the standard 7-class iperf3 + failover
 - Both reviewers (Codex hostile + Gemini adversarial) sign off
+
+## After this Phase 8
+
+`tx.rs` left in place is XSK ring management + worker-binding glue
++ deferred TX-completion family (apply_cos_*_result, restore_*_inner,
+transmit_*, etc — bumped to `pub(in crate::afxdp)` during Phase 7).
+
+Future work (out of scope for #956):
+- TX-completion phase: extract apply_cos_*_result + restore_*_inner
+  + advance_cos_timer_wheel + timer-wheel constants.
+- Worker-binding extraction: extract transmit_batch, reap_tx_completions,
+  cos_queue_dscp_rewrite, etc.

--- a/docs/pr/956-phase8-cross-binding/plan.md
+++ b/docs/pr/956-phase8-cross-binding/plan.md
@@ -67,21 +67,25 @@ Visibility:
   follow Phase 7 precedent for similar-sized fns: leave un-
   attributed; LLVM heuristic should cover.
 
-## cos/mod.rs additions
+## cos/mod.rs additions (final implementation)
 
 ```rust
 pub(super) mod cross_binding;
 
 pub(super) use cross_binding::{
-    cos_fast_interface, cos_fast_queue, prepared_cos_request_stays_on_current_tx_binding,
-    redirect_local_cos_request_to_owner, redirect_prepared_cos_request_to_owner,
-    redirect_prepared_cos_request_to_owner_binding, resolve_local_routing_decision,
-    LocalRoutingDecision, Step1Action,
+    prepared_cos_request_stays_on_current_tx_binding, redirect_local_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner, redirect_prepared_cos_request_to_owner_binding,
+    resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
 };
 
 #[cfg(test)]
 pub(super) use cross_binding::redirect_local_cos_request_to_owner_binding;
 ```
+
+`cos_fast_interface` / `cos_fast_queue` ended up not needing
+re-export because tx.rs's only direct callers of the lookup
+helpers are tests and the moving fns themselves
+(`resolve_local_routing_decision` reaches them inline).
 
 ## Files touched
 

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -14,8 +14,9 @@
 //     gate predicate for prepared requests.
 //   - `redirect_prepared_cos_request_to_owner` + `_binding`
 //     handle the prepared (zero-copy UMEM) variant; the binding-
-//     side call invokes `tx::recycle_prepared_immediately` if
-//     ownership transfer fails.
+//     side call invokes `tx::recycle_prepared_immediately` after
+//     a successful redirect/enqueue, once the data has been copied
+//     out of UMEM (the original frame is no longer referenced).
 //   - `cos_fast_interface` / `cos_fast_queue` are the binding
 //     fast-path lookups consumed by the redirect logic.
 //
@@ -158,6 +159,7 @@ pub(in crate::afxdp) fn redirect_local_cos_request_to_owner(
     Err(req)
 }
 
+#[cfg(test)]
 #[inline]
 pub(in crate::afxdp) fn redirect_local_cos_request_to_owner_binding(
     current_live: &Arc<BindingLiveState>,

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -1,0 +1,291 @@
+// #956 Phase 8: cross-binding redirect helpers, extracted from
+// tx.rs. Final phase of the cos/ submodule decomposition.
+//
+// These helpers resolve the "is this request bound to the owner
+// of the egress, or do we hand off via MPSC inbox?" question for
+// both Local and Prepared TX requests:
+//
+//   - `resolve_local_routing_decision` returns the routing
+//     decision (enqueue locally / inbox-redirect / drop) for a
+//     local request.
+//   - `redirect_local_cos_request_to_owner` is step 1 of the
+//     two-step redirect; `_binding` (test-only) is step 2.
+//   - `prepared_cos_request_stays_on_current_tx_binding` is the
+//     gate predicate for prepared requests.
+//   - `redirect_prepared_cos_request_to_owner` + `_binding`
+//     handle the prepared (zero-copy UMEM) variant; the binding-
+//     side call invokes `tx::recycle_prepared_immediately` if
+//     ownership transfer fails.
+//   - `cos_fast_interface` / `cos_fast_queue` are the binding
+//     fast-path lookups consumed by the redirect logic.
+//
+// One back-edge: `tx::recycle_prepared_immediately` (XSK frame
+// recycling — worker-binding territory). Visibility bumped to
+// `pub(in crate::afxdp)` in this PR.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use crate::afxdp::tx::recycle_prepared_immediately;
+use crate::afxdp::types::{
+    PreparedTxRequest, TxRequest, WorkerCommand, WorkerCoSInterfaceFastPath,
+    WorkerCoSQueueFastPath,
+};
+use crate::afxdp::umem::BindingLiveState;
+use crate::afxdp::worker::BindingWorker;
+use crate::afxdp::FastMap;
+
+/// #780: Step 1 action variants. Mirrors the action taken inside
+/// `redirect_local_cos_request_to_owner` after the bail checks
+/// have been passed.
+#[derive(Clone)]
+pub(in crate::afxdp) enum Step1Action {
+    /// The owner worker's owner_live arc is directly addressable
+    /// (fast path).
+    Arc(Arc<BindingLiveState>),
+    /// Fall back to the per-worker command channel (slow path).
+    Command(u32),
+}
+
+/// #780: routing-decision cache value. Carries BOTH Step 1 and
+/// Step 2 options so the dispatch in `ingest_cos_pending_tx_with_provenance`
+/// can fall through Step 1 → Step 2 → Step 3 (EnqueueLocal) on
+/// Err at each boundary — exact cascade semantics of the
+/// pre-#780 three-function chain. Codex review round 2 flagged
+/// the previous revision's lack of fallthrough as a HIGH
+/// semantic regression.
+#[derive(Clone)]
+pub(in crate::afxdp) struct LocalRoutingDecision {
+    /// `None` when Step 1 bails (queue absent, shared_exact-with-
+    /// owner, or owner_worker_id == current_worker_id). Present
+    /// when Step 1 would route.
+    pub(in crate::afxdp) step1: Option<Step1Action>,
+    /// `None` when Step 2 bails (iface absent, no tx_owner_live,
+    /// or ptr_eq(tx_owner_live, current_live)). Present when
+    /// Step 2 would route.
+    pub(in crate::afxdp) step2: Option<Arc<BindingLiveState>>,
+}
+
+/// #780: resolve the routing decision for a (iface, queue) pair.
+/// Preserves the exact pre-#780 cascade semantics. Moved out of
+/// the closure so it can be unit-tested independently. Carries
+/// BOTH step options in the returned decision so dispatch can
+/// walk the same fallthrough as the original cascade when an
+/// earlier step's enqueue returns Err.
+#[inline]
+pub(in crate::afxdp) fn resolve_local_routing_decision(
+    iface_fast_opt: Option<&WorkerCoSInterfaceFastPath>,
+    cos_queue_id: Option<u8>,
+    current_worker_id: u32,
+    current_live: &Arc<BindingLiveState>,
+) -> LocalRoutingDecision {
+    let mut step1: Option<Step1Action> = None;
+    let mut step2: Option<Arc<BindingLiveState>> = None;
+    if let Some(iface_fast) = iface_fast_opt {
+        // Step 1 (mirrors redirect_local_cos_request_to_owner):
+        if let Some(queue_fast) = iface_fast.queue_fast_path(cos_queue_id) {
+            let step1_bail = (queue_fast.shared_exact && iface_fast.tx_owner_live.is_some())
+                || queue_fast.owner_worker_id == current_worker_id;
+            if !step1_bail {
+                step1 = Some(match queue_fast.owner_live.as_ref() {
+                    Some(arc) => Step1Action::Arc(arc.clone()),
+                    None => Step1Action::Command(queue_fast.owner_worker_id),
+                });
+            }
+        }
+        // Step 2 (mirrors redirect_local_cos_request_to_owner_binding):
+        // ALWAYS evaluated — the old cascade ran Step 2 after Step 1
+        // returned Err, so Step 2 is reachable whether or not Step 1
+        // also routes. We cache both here; the dispatch loop walks
+        // Step 1 first, falling through to Step 2 on Err.
+        if let Some(owner_live) = iface_fast.tx_owner_live.as_ref() {
+            if !Arc::ptr_eq(owner_live, current_live) {
+                step2 = Some(owner_live.clone());
+            }
+        }
+    }
+    LocalRoutingDecision { step1, step2 }
+}
+
+#[inline]
+pub(in crate::afxdp) fn cos_fast_interface<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
+    egress_ifindex: i32,
+) -> Option<&'a WorkerCoSInterfaceFastPath> {
+    cos_fast_interfaces.get(&egress_ifindex)
+}
+
+#[inline]
+pub(in crate::afxdp) fn cos_fast_queue<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
+    egress_ifindex: i32,
+    requested_queue_id: Option<u8>,
+) -> Option<(&'a WorkerCoSInterfaceFastPath, &'a WorkerCoSQueueFastPath)> {
+    let iface = cos_fast_interface(cos_fast_interfaces, egress_ifindex)?;
+    let queue = iface.queue_fast_path(requested_queue_id)?;
+    Some((iface, queue))
+}
+
+#[inline]
+pub(in crate::afxdp) fn redirect_local_cos_request_to_owner(
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
+    req: TxRequest,
+    current_worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+) -> Result<(), TxRequest> {
+    let Some((iface_fast, queue_fast)) =
+        cos_fast_queue(cos_fast_interfaces, req.egress_ifindex, req.cos_queue_id)
+    else {
+        return Err(req);
+    };
+    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
+        return Err(req);
+    }
+    let owner_worker_id = queue_fast.owner_worker_id;
+    if owner_worker_id == current_worker_id {
+        return Err(req);
+    }
+    if let Some(owner_live) = queue_fast.owner_live.as_ref() {
+        return owner_live.enqueue_tx_owned(req);
+    }
+    let Some(commands) = worker_commands_by_id.get(&owner_worker_id) else {
+        return Err(req);
+    };
+    if let Ok(mut pending) = commands.lock() {
+        pending.push_back(WorkerCommand::EnqueueShapedLocal(req));
+        return Ok(());
+    }
+    Err(req)
+}
+
+#[inline]
+pub(in crate::afxdp) fn redirect_local_cos_request_to_owner_binding(
+    current_live: &Arc<BindingLiveState>,
+    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
+    req: TxRequest,
+) -> Result<(), TxRequest> {
+    // Caller ordering matters: shared exact queues that already have a local TX
+    // path were filtered out in redirect_local_cos_request_to_owner().
+    let Some(iface_fast) = cos_fast_interface(cos_fast_interfaces, req.egress_ifindex) else {
+        return Err(req);
+    };
+    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
+        return Err(req);
+    };
+    if Arc::ptr_eq(owner_live, current_live) {
+        return Err(req);
+    }
+    owner_live.enqueue_tx_owned(req)
+}
+
+#[inline]
+pub(in crate::afxdp) fn prepared_cos_request_stays_on_current_tx_binding(
+    binding_ifindex: i32,
+    iface_fast: &WorkerCoSInterfaceFastPath,
+    queue_fast: &WorkerCoSQueueFastPath,
+) -> bool {
+    binding_ifindex == iface_fast.tx_ifindex && queue_fast.shared_exact
+}
+
+#[inline]
+pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
+    binding: &mut BindingWorker,
+    req: PreparedTxRequest,
+    current_worker_id: u32,
+    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
+) -> Result<(), PreparedTxRequest> {
+    let Some((iface_fast, queue_fast)) = cos_fast_queue(
+        &binding.cos_fast_interfaces,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) else {
+        return Err(req);
+    };
+    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
+        return Err(req);
+    }
+    let owner_worker_id = queue_fast.owner_worker_id;
+    if owner_worker_id == current_worker_id {
+        return Err(req);
+    }
+    let Some(frame) = binding
+        .umem
+        .area()
+        .slice(req.offset as usize, req.len as usize)
+        .map(|frame| frame.to_vec())
+    else {
+        return Err(req);
+    };
+    let local_req = TxRequest {
+        bytes: frame,
+        expected_ports: req.expected_ports,
+        expected_addr_family: req.expected_addr_family,
+        expected_protocol: req.expected_protocol,
+        flow_key: req.flow_key.clone(),
+        egress_ifindex: req.egress_ifindex,
+        cos_queue_id: req.cos_queue_id,
+        dscp_rewrite: req.dscp_rewrite,
+    };
+    if redirect_local_cos_request_to_owner(
+        &binding.cos_fast_interfaces,
+        local_req,
+        current_worker_id,
+        worker_commands_by_id,
+    )
+    .is_ok()
+    {
+        recycle_prepared_immediately(binding, &req);
+        return Ok(());
+    }
+    Err(req)
+}
+
+#[inline]
+pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
+    binding: &mut BindingWorker,
+    req: PreparedTxRequest,
+) -> Result<(), PreparedTxRequest> {
+    let Some((iface_fast, queue_fast)) = cos_fast_queue(
+        &binding.cos_fast_interfaces,
+        req.egress_ifindex,
+        req.cos_queue_id,
+    ) else {
+        return Err(req);
+    };
+    // Keep shared exact traffic on the current binding when it already sits on
+    // the resolved TX path; redirecting it sideways would force a copy back
+    // into local TX instead of preserving the prepared path.
+    if prepared_cos_request_stays_on_current_tx_binding(binding.ifindex, iface_fast, queue_fast) {
+        return Err(req);
+    }
+    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
+        return Err(req);
+    };
+    if Arc::ptr_eq(owner_live, &binding.live) {
+        return Err(req);
+    }
+    let Some(frame) = binding
+        .umem
+        .area()
+        .slice(req.offset as usize, req.len as usize)
+        .map(|frame| frame.to_vec())
+    else {
+        return Err(req);
+    };
+    let local_req = TxRequest {
+        bytes: frame,
+        expected_ports: req.expected_ports,
+        expected_addr_family: req.expected_addr_family,
+        expected_protocol: req.expected_protocol,
+        flow_key: req.flow_key.clone(),
+        egress_ifindex: req.egress_ifindex,
+        cos_queue_id: req.cos_queue_id,
+        dscp_rewrite: req.dscp_rewrite,
+    };
+    if owner_live.enqueue_tx(local_req).is_ok() {
+        recycle_prepared_immediately(binding, &req);
+        return Ok(());
+    }
+    Err(req)
+}
+

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -3,14 +3,15 @@
 // policy + flow-fair promotion; Phase 4 extracted token-bucket
 // lease/refill; Phase 5 extracted queue ops + MQFQ ordering +
 // V-min lifecycle; Phase 6 extracted CoS interface-runtime
-// builders; Phase 7 (this commit) extracts the dispatch / drain /
-// submit subsystem (~2400 LOC). Subsequent phase: Phase 8
-// cross-binding.
-// See docs/pr/956-phase7-queue-service/plan.md for the current
-// phase and docs/pr/956-tx-decomposition/plan.md for the full plan.
+// builders; Phase 7 extracted the dispatch / drain / submit
+// subsystem; Phase 8 (this commit) extracts the cross-binding
+// redirect helpers — FINAL phase of #956.
+// See docs/pr/956-phase8-cross-binding/plan.md for this phase
+// and docs/pr/956-tx-decomposition/plan.md for the full plan.
 
 pub(super) mod admission;
 pub(super) mod builders;
+pub(super) mod cross_binding;
 pub(super) mod ecn;
 pub(super) mod flow_hash;
 pub(super) mod queue_ops;
@@ -21,6 +22,11 @@ pub(super) use admission::{
     apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
 };
 pub(super) use builders::ensure_cos_interface_runtime;
+pub(super) use cross_binding::{
+    prepared_cos_request_stays_on_current_tx_binding, redirect_local_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner, redirect_prepared_cos_request_to_owner_binding,
+    resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
+};
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 pub(super) use queue_ops::{
     cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all,
@@ -43,6 +49,8 @@ pub(super) use admission::{
 };
 #[cfg(test)]
 pub(super) use builders::build_cos_interface_runtime;
+#[cfg(test)]
+pub(super) use cross_binding::redirect_local_cos_request_to_owner_binding;
 #[cfg(test)]
 pub(super) use ecn::{maybe_mark_ecn_ce, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -1124,255 +1124,6 @@ fn ingest_cos_pending_tx_with_provenance(
     bound_pending_tx_local(binding);
 }
 
-/// #780: Step 1 action variants. Mirrors the action taken inside
-/// `redirect_local_cos_request_to_owner` after the bail checks
-/// have been passed.
-#[derive(Clone)]
-enum Step1Action {
-    /// The owner worker's owner_live arc is directly addressable
-    /// (fast path).
-    Arc(Arc<BindingLiveState>),
-    /// Fall back to the per-worker command channel (slow path).
-    Command(u32),
-}
-
-/// #780: routing-decision cache value. Carries BOTH Step 1 and
-/// Step 2 options so the dispatch in `ingest_cos_pending_tx_with_provenance`
-/// can fall through Step 1 → Step 2 → Step 3 (EnqueueLocal) on
-/// Err at each boundary — exact cascade semantics of the
-/// pre-#780 three-function chain. Codex review round 2 flagged
-/// the previous revision's lack of fallthrough as a HIGH
-/// semantic regression.
-#[derive(Clone)]
-struct LocalRoutingDecision {
-    /// `None` when Step 1 bails (queue absent, shared_exact-with-
-    /// owner, or owner_worker_id == current_worker_id). Present
-    /// when Step 1 would route.
-    step1: Option<Step1Action>,
-    /// `None` when Step 2 bails (iface absent, no tx_owner_live,
-    /// or ptr_eq(tx_owner_live, current_live)). Present when
-    /// Step 2 would route.
-    step2: Option<Arc<BindingLiveState>>,
-}
-
-/// #780: resolve the routing decision for a (iface, queue) pair.
-/// Preserves the exact pre-#780 cascade semantics. Moved out of
-/// the closure so it can be unit-tested independently. Carries
-/// BOTH step options in the returned decision so dispatch can
-/// walk the same fallthrough as the original cascade when an
-/// earlier step's enqueue returns Err.
-fn resolve_local_routing_decision(
-    iface_fast_opt: Option<&WorkerCoSInterfaceFastPath>,
-    cos_queue_id: Option<u8>,
-    current_worker_id: u32,
-    current_live: &Arc<BindingLiveState>,
-) -> LocalRoutingDecision {
-    let mut step1: Option<Step1Action> = None;
-    let mut step2: Option<Arc<BindingLiveState>> = None;
-    if let Some(iface_fast) = iface_fast_opt {
-        // Step 1 (mirrors redirect_local_cos_request_to_owner):
-        if let Some(queue_fast) = iface_fast.queue_fast_path(cos_queue_id) {
-            let step1_bail = (queue_fast.shared_exact && iface_fast.tx_owner_live.is_some())
-                || queue_fast.owner_worker_id == current_worker_id;
-            if !step1_bail {
-                step1 = Some(match queue_fast.owner_live.as_ref() {
-                    Some(arc) => Step1Action::Arc(arc.clone()),
-                    None => Step1Action::Command(queue_fast.owner_worker_id),
-                });
-            }
-        }
-        // Step 2 (mirrors redirect_local_cos_request_to_owner_binding):
-        // ALWAYS evaluated — the old cascade ran Step 2 after Step 1
-        // returned Err, so Step 2 is reachable whether or not Step 1
-        // also routes. We cache both here; the dispatch loop walks
-        // Step 1 first, falling through to Step 2 on Err.
-        if let Some(owner_live) = iface_fast.tx_owner_live.as_ref() {
-            if !Arc::ptr_eq(owner_live, current_live) {
-                step2 = Some(owner_live.clone());
-            }
-        }
-    }
-    LocalRoutingDecision { step1, step2 }
-}
-
-#[inline]
-fn cos_fast_interface<'a>(
-    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
-    egress_ifindex: i32,
-) -> Option<&'a WorkerCoSInterfaceFastPath> {
-    cos_fast_interfaces.get(&egress_ifindex)
-}
-
-#[inline]
-fn cos_fast_queue<'a>(
-    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
-    egress_ifindex: i32,
-    requested_queue_id: Option<u8>,
-) -> Option<(&'a WorkerCoSInterfaceFastPath, &'a WorkerCoSQueueFastPath)> {
-    let iface = cos_fast_interface(cos_fast_interfaces, egress_ifindex)?;
-    let queue = iface.queue_fast_path(requested_queue_id)?;
-    Some((iface, queue))
-}
-
-fn redirect_local_cos_request_to_owner(
-    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
-    req: TxRequest,
-    current_worker_id: u32,
-    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-) -> Result<(), TxRequest> {
-    let Some((iface_fast, queue_fast)) =
-        cos_fast_queue(cos_fast_interfaces, req.egress_ifindex, req.cos_queue_id)
-    else {
-        return Err(req);
-    };
-    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
-        return Err(req);
-    }
-    let owner_worker_id = queue_fast.owner_worker_id;
-    if owner_worker_id == current_worker_id {
-        return Err(req);
-    }
-    if let Some(owner_live) = queue_fast.owner_live.as_ref() {
-        return owner_live.enqueue_tx_owned(req);
-    }
-    let Some(commands) = worker_commands_by_id.get(&owner_worker_id) else {
-        return Err(req);
-    };
-    if let Ok(mut pending) = commands.lock() {
-        pending.push_back(WorkerCommand::EnqueueShapedLocal(req));
-        return Ok(());
-    }
-    Err(req)
-}
-
-fn redirect_local_cos_request_to_owner_binding(
-    current_live: &Arc<BindingLiveState>,
-    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
-    req: TxRequest,
-) -> Result<(), TxRequest> {
-    // Caller ordering matters: shared exact queues that already have a local TX
-    // path were filtered out in redirect_local_cos_request_to_owner().
-    let Some(iface_fast) = cos_fast_interface(cos_fast_interfaces, req.egress_ifindex) else {
-        return Err(req);
-    };
-    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
-        return Err(req);
-    };
-    if Arc::ptr_eq(owner_live, current_live) {
-        return Err(req);
-    }
-    owner_live.enqueue_tx_owned(req)
-}
-
-#[inline]
-fn prepared_cos_request_stays_on_current_tx_binding(
-    binding_ifindex: i32,
-    iface_fast: &WorkerCoSInterfaceFastPath,
-    queue_fast: &WorkerCoSQueueFastPath,
-) -> bool {
-    binding_ifindex == iface_fast.tx_ifindex && queue_fast.shared_exact
-}
-
-fn redirect_prepared_cos_request_to_owner(
-    binding: &mut BindingWorker,
-    req: PreparedTxRequest,
-    current_worker_id: u32,
-    worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
-) -> Result<(), PreparedTxRequest> {
-    let Some((iface_fast, queue_fast)) = cos_fast_queue(
-        &binding.cos_fast_interfaces,
-        req.egress_ifindex,
-        req.cos_queue_id,
-    ) else {
-        return Err(req);
-    };
-    if queue_fast.shared_exact && iface_fast.tx_owner_live.is_some() {
-        return Err(req);
-    }
-    let owner_worker_id = queue_fast.owner_worker_id;
-    if owner_worker_id == current_worker_id {
-        return Err(req);
-    }
-    let Some(frame) = binding
-        .umem
-        .area()
-        .slice(req.offset as usize, req.len as usize)
-        .map(|frame| frame.to_vec())
-    else {
-        return Err(req);
-    };
-    let local_req = TxRequest {
-        bytes: frame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key.clone(),
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-    };
-    if redirect_local_cos_request_to_owner(
-        &binding.cos_fast_interfaces,
-        local_req,
-        current_worker_id,
-        worker_commands_by_id,
-    )
-    .is_ok()
-    {
-        recycle_prepared_immediately(binding, &req);
-        return Ok(());
-    }
-    Err(req)
-}
-
-fn redirect_prepared_cos_request_to_owner_binding(
-    binding: &mut BindingWorker,
-    req: PreparedTxRequest,
-) -> Result<(), PreparedTxRequest> {
-    let Some((iface_fast, queue_fast)) = cos_fast_queue(
-        &binding.cos_fast_interfaces,
-        req.egress_ifindex,
-        req.cos_queue_id,
-    ) else {
-        return Err(req);
-    };
-    // Keep shared exact traffic on the current binding when it already sits on
-    // the resolved TX path; redirecting it sideways would force a copy back
-    // into local TX instead of preserving the prepared path.
-    if prepared_cos_request_stays_on_current_tx_binding(binding.ifindex, iface_fast, queue_fast) {
-        return Err(req);
-    }
-    let Some(owner_live) = iface_fast.tx_owner_live.as_ref() else {
-        return Err(req);
-    };
-    if Arc::ptr_eq(owner_live, &binding.live) {
-        return Err(req);
-    }
-    let Some(frame) = binding
-        .umem
-        .area()
-        .slice(req.offset as usize, req.len as usize)
-        .map(|frame| frame.to_vec())
-    else {
-        return Err(req);
-    };
-    let local_req = TxRequest {
-        bytes: frame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key.clone(),
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-    };
-    if owner_live.enqueue_tx(local_req).is_ok() {
-        recycle_prepared_immediately(binding, &req);
-        return Ok(());
-    }
-    Err(req)
-}
-
 pub(in crate::afxdp) fn prime_cos_root_for_service(binding: &mut BindingWorker, root_ifindex: i32, now_ns: u64) -> bool {
     let shared_root_lease = binding
         .cos_fast_interfaces
@@ -1475,11 +1226,13 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 // non-test builds (Copilot review on PR #976).
 use super::cos::{
     apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_flow_bucket_index,
-    cos_item_flow_key,
-    cos_queue_drain_all, cos_queue_flow_share_limit, cos_queue_is_empty, cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
-    drain_shaped_tx, ensure_cos_interface_runtime,
-    maybe_top_up_cos_root_lease, park_cos_queue, publish_committed_queue_vtime,
-    release_cos_root_lease, CoSServicePhase,
+    cos_item_flow_key, cos_queue_drain_all, cos_queue_flow_share_limit,
+    cos_queue_is_empty, cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
+    drain_shaped_tx, ensure_cos_interface_runtime, maybe_top_up_cos_root_lease, park_cos_queue,
+    prepared_cos_request_stays_on_current_tx_binding, publish_committed_queue_vtime,
+    redirect_local_cos_request_to_owner, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding, release_cos_root_lease,
+    resolve_local_routing_decision, CoSServicePhase, LocalRoutingDecision, Step1Action,
 };
 #[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
@@ -1487,7 +1240,7 @@ use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL
 use super::cos::{
     account_cos_queue_flow_dequeue, account_cos_queue_flow_enqueue,
     apply_cos_queue_flow_fair_promotion, assign_local_dscp_rewrite, bdp_floor_bytes,
-    build_cos_interface_runtime, cos_batch_tx_made_progress, cos_flow_hash_seed_from_os,
+    build_cos_interface_runtime, cos_batch_tx_made_progress, cos_flow_hash_seed_from_os, redirect_local_cos_request_to_owner_binding,
     cos_guarantee_quantum_bytes, cos_queue_clear_orphan_snapshot_after_drop,
     cos_queue_pop_front, cos_queue_prospective_active_flows,
     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, count_park_reason,
@@ -2619,7 +2372,7 @@ fn recycle_completed_tx_offset(
     }
 }
 
-pub(super) fn recycle_prepared_immediately(binding: &mut BindingWorker, req: &PreparedTxRequest) {
+pub(in crate::afxdp) fn recycle_prepared_immediately(binding: &mut BindingWorker, req: &PreparedTxRequest) {
     // #760 / Codex review note: when `req.recycle` is
     // `FillOnSlot(fill_slot)` with `fill_slot != binding.slot`,
     // `recycle_cancelled_prepared_offset` routes the frame to THIS

--- a/userspace-dp/src/afxdp/types.rs
+++ b/userspace-dp/src/afxdp/types.rs
@@ -2098,7 +2098,7 @@ pub(super) struct LearnedNeighborKey {
 }
 
 #[derive(Clone, Debug)]
-pub(super) enum WorkerCommand {
+pub(in crate::afxdp) enum WorkerCommand {
     UpsertSynced(SyncedSessionEntry),
     UpsertLocal(SyncedSessionEntry),
     DeleteSynced(SessionKey),

--- a/userspace-dp/src/afxdp/umem.rs
+++ b/userspace-dp/src/afxdp/umem.rs
@@ -1760,7 +1760,7 @@ mod tests {
 }
 
 /// Raw ring state: (rxP, rxC, frP, frC, txP, txC, crP, crC)
-pub(super) struct BindingLiveState {
+pub(in crate::afxdp) struct BindingLiveState {
     pub(super) bound: AtomicBool,
     pub(super) xsk_registered: AtomicBool,
     pub(super) bind_mode: AtomicU8,


### PR DESCRIPTION
## Summary

**Final phase of #956**. Closes out the cos/ submodule decomposition.

Move list (~250 LOC):
- 2 types: `Step1Action` enum, `LocalRoutingDecision` struct
- 8 fns: `resolve_local_routing_decision`, `cos_fast_interface`,
  `cos_fast_queue`, `redirect_local_cos_request_to_owner` +
  `_binding` (test-only),
  `prepared_cos_request_stays_on_current_tx_binding`,
  `redirect_prepared_cos_request_to_owner` + `_binding`

Visibility:
- `pub(in crate::afxdp)`: 7 production-callable items
- cfg-gated: `redirect_local_cos_request_to_owner_binding`
  (test-only)

`#[inline]` preserved/added on per-byte hot path.

One back-edge: `tx::recycle_prepared_immediately` (visibility
bumped to `pub(in crate::afxdp)`). Stays in tx.rs because it
touches XSK ring frame recycling — worker-binding territory.

Sibling visibility bumps: `umem::BindingLiveState`,
`types::WorkerCommand` → `pub(in crate::afxdp)`.

Net change: -249 lines from tx.rs.

## Reviews

- Plan v1 → v2 across 1 hostile Codex round + 1 Gemini
  adversarial round. Both reviewers reached the same
  architectural conclusion (move list under-counted; needed
  `Step1Action`, `LocalRoutingDecision`, 3 helpers); v2 expanded.

## Test plan

- [x] `cargo build --bins` clean
- [x] `cargo test --bins` — **865 passed, 0 failed, 2 ignored**
- [x] `loss-userspace-cluster.env` rolling deploy successful
- [x] `apply-cos-config.sh` — atomic commit + verification OK
- [x] **Per-CoS-class iperf3 smoke** (all shapers correct):

      | port | class       | shaper | rx_gbps | retrans |
      |------|-------------|--------|---------|---------|
      | 5201 | iperf-a     |   1G   |  0.96   |    0    |
      | 5202 | iperf-b     |  10G   |  9.56   |    0    |
      | 5203 | iperf-c     |  25G   | 12.4    |    0    |
      | 5204 | iperf-d     |  13G   | 12.4    |    0    |
      | 5205 | iperf-e     |  16G   | 15.3    |    0    |
      | 5206 | iperf-f     |  19G   | 18.1    |    0    |
      | 5207 | best-effort | 100M   |  0.10   |   34    |

- [x] **Failover smoke** (RG1 cycled twice): **48/48 intervals
      ≥3 Gbps, 0 zero-bps**.

## After this Phase 8

The cos/ submodule decomposition (#956) is **COMPLETE**:

```
userspace-dp/src/afxdp/cos/
├── admission.rs      (Phase 3, PR #978)
├── builders.rs       (Phase 6, PR #981)
├── cross_binding.rs  (Phase 8, this PR)
├── ecn.rs            (Phase 1, PR #976)
├── flow_hash.rs      (Phase 2, PR #977)
├── mod.rs
├── queue_ops.rs      (Phase 5, PR #980)
├── queue_service.rs  (Phase 7, PR #982)
└── token_bucket.rs   (Phase 4, PR #979)
```

`tx.rs` left behind is XSK ring management + worker-binding glue +
the deferred TX-completion family. Future TX-completion / worker-
binding extractions can proceed against a much cleaner tx.rs surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)