### PR TITLE
P1: extract cos/tx_completion.rs (closes #956 Phase 6+7 subset back-edges)

### DIFF
--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -1,7 +1,30 @@
 # P1: extract cos/tx_completion.rs from tx.rs
 
-Plan v4 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
+Plan v5 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
 decomposition merged at PR #983.
+
+## v5 changelog vs v4 (from Codex round-4)
+
+- R4-MA: stale back-edge wording at the bottom of the "Back-edges
+  remaining" section (was "P1 does NOT claim 'every back-edge resolved'
+  — only 'every back-edge introduced by #956 Phases 6/7/8 closed.'")
+  was contradicting the Goal section's narrowed claim. Fixed to
+  reference the Phase 6 + TX-completion-subset-of-Phase-7 scope
+  consistently.
+- R4-MB: move count corrected from "19 fns + 2 constants" to
+  "17 fns + 2 constants" (matching the actual table rows: 12 timer
+  wheel = 10 fns + 2 const, 7 TX-completion = 7 fns).
+- R4-MC: file-private count corrected from "5 fns + 1 const" to
+  "4 fns + 1 const". `wake_cos_queue` caller-evidence citation
+  corrected — sole call site is tx.rs:1419 (the line 1305 reference
+  was actually inside `wake_cos_queue`'s own body).
+- R4-MD: atomic-ordering paragraph rewritten to mention the indirect
+  Acquire/AcqRel chain via `shared_*_lease.consume()` calls
+  (types.rs:1669-1679). The direct Ordering::Relaxed claim still
+  holds for the moved-body imports.
+- R4-ME: Files-touched bullet for `cos/queue_service.rs` now
+  explicitly instructs the implementor to update the now-stale
+  "back-edges to tx.rs" header comment at lines 23-29.
 
 ## v4 changelog vs v3 (from Codex round-3)
 
@@ -101,7 +124,7 @@ Remaining (NOT in P1 scope):
 
 All deferred to #984 (afxdp/tx/ split).
 
-## Move list (19 fns + 2 constants)
+## Move list (17 fns + 2 constants)
 
 ### Timer wheel cluster (~150 LOC)
 
@@ -163,14 +186,16 @@ Functions (13):
   `pub(in crate::afxdp)` purely for the test-only and (post-move)
   intra-cluster reach via `cos/mod.rs` re-export.
 
-File-private (5 fns + 1 const) — only callers are co-located in the
+File-private (4 fns + 1 const) — only callers are co-located in the
 move set:
-- `wake_cos_queue` (tx.rs:1305 inside cos_tick_for_ns area, 1419 inside
-  wake_due_cos_timer_slot — both moving).
-- `rearm_cos_queue` (tx.rs:1396 inside cascade, 1422 inside wake_due —
-  both moving).
-- `cascade_cos_timer_wheel_level1` (tx.rs:1375 inside advance_cos_timer_wheel).
-- `wake_due_cos_timer_slot` (tx.rs:1377 inside advance_cos_timer_wheel).
+- `wake_cos_queue` (sole caller tx.rs:1419 inside `wake_due_cos_timer_slot`,
+  which is moving).
+- `rearm_cos_queue` (callers tx.rs:1396 inside cascade and 1422 inside
+  wake_due — both moving).
+- `cascade_cos_timer_wheel_level1` (sole caller tx.rs:1375 inside
+  `advance_cos_timer_wheel`, which is moving).
+- `wake_due_cos_timer_slot` (sole caller tx.rs:1377 inside
+  `advance_cos_timer_wheel`, which is moving).
 - `COS_TIMER_WHEEL_L0_HORIZON_TICKS`.
 
 `COS_TIMER_WHEEL_L0_SLOTS` / `_L1_SLOTS` (referenced by
@@ -375,8 +400,17 @@ are:
 `cos/cross_binding.rs:30`:
 - `recycle_prepared_immediately` (tx.rs:2375)
 
-P1 does NOT claim "every back-edge resolved" — only "every back-edge
-introduced by #956 Phases 6/7/8 closed."
+P1's narrowed scope (matching the Goal section above): closes the
+**Phase 6 builder edge** AND the **TX-completion / timer-wheel subset
+of Phase 7 deferrals**. The remaining Phase 7 XSK-ring helpers and
+Phase 8's `cross_binding -> tx::recycle_prepared_immediately` stay in
+tx.rs, deferred to #984. P1 does NOT claim "every Phase 6/7/8
+back-edge closed" — that was a v3 wording error corrected in v4.
+
+The implementor should also update the now-stale TX-completion
+back-edge commentary in `cos/queue_service.rs:23-29` (which describes
+the moved symbols as "back-edges to tx.rs") to reflect their new
+location in `cos/tx_completion.rs`.
 
 ## Files touched
 
@@ -384,7 +418,10 @@ introduced by #956 Phases 6/7/8 closed."
   (~600 moved + ~50 lines header/imports/notes).
 - `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
 - `userspace-dp/src/afxdp/cos/queue_service.rs`: split tx import block
-  (10 symbols → super::tx_completion::, 8 stay on crate::afxdp::tx).
+  (10 symbols → super::tx_completion::, 8 stay on crate::afxdp::tx);
+  update the now-stale "back-edges to tx.rs" header comment at lines
+  23-29 to reflect that the TX-completion/timer-wheel symbols moved
+  to `cos/tx_completion.rs`.
 - `userspace-dp/src/afxdp/cos/builders.rs`: switch single
   `cos_tick_for_ns` import; update comment block.
 - `userspace-dp/src/afxdp/tx.rs`: −600 LOC; one always-on cos:: import,
@@ -411,13 +448,20 @@ block in tx.rs. The cos/mod.rs re-export chain backs that import.
   hit the slow path when timer slots have queued queues. No per-byte
   overhead concern.
 
-Atomic ordering: the moved bodies only touch existing
-`Ordering::Relaxed` counters via `fetch_add` (drain_sent_bytes,
-sent_packets, etc.). They do NOT call `publish_committed_queue_vtime`
-— that callsite stays in `cos/queue_service.rs:770/920/1076/1229`
-which is NOT moving. The Release/Acquire publish boundary is
-unchanged by P1. `Ordering::Relaxed` is the only ordering symbol used
-inside tx_completion.rs.
+Atomic ordering: direct atomic ops inside the moved bodies are all
+`Ordering::Relaxed` `fetch_add`s on per-byte / per-packet counters
+(drain_sent_bytes, sent_packets, etc.). They do NOT call
+`publish_committed_queue_vtime` — that callsite stays in
+`cos/queue_service.rs:770/920/1076/1229` which is NOT moving, so the
+Release/Acquire publish boundary is unchanged by P1.
+
+Indirect ordering: the apply bodies call `shared_root_lease.consume(...)`
+and `shared_queue_lease.consume(...)` at tx.rs:1170/1178/2205/2214/
+2270/2279. Those `consume` impls (afxdp/types.rs:1669-1679) use
+`Ordering::Acquire` / `Ordering::AcqRel` internally. P1 does not
+change those orderings — the move just relocates the call site, not
+the lease implementation. Only `Ordering::Relaxed` is named directly
+in the moved bodies, hence the import.
 
 After this PR, every `pub(in crate::afxdp)` visibility bump from
 Phases 6/7/8 except those tied to XSK-ring helpers (#984 scope) is

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -343,7 +343,7 @@ visibility from cos/mod.rs. File-private items are NOT re-exported.)
 
 ## tx.rs changes
 
-1. Remove the 19 fn definitions + 2 constants.
+1. Remove the 17 fn definitions + 2 constants.
 2. Remove the Phase-6 visibility-bump comment block above
    `cos_tick_for_ns` (will not exist post-move).
 3. **Always-on import** (cos:: block at tx.rs:1227 / 1240) — add ONLY

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -110,9 +110,11 @@ Move the TX-completion + timer-wheel cluster from tx.rs into
 - The **Phase 6 builder edge** (`cos/builders.rs -> tx::cos_tick_for_ns`)
   is closed.
 - The **TX-completion / timer-wheel subset of the Phase 7 back-edge
-  cluster** is closed: 10 of the 18 symbols imported by
+  cluster** is closed: 10 of the 18 functions imported by
   `cos/queue_service.rs` from `crate::afxdp::tx::` move to
-  `super::tx_completion::`.
+  `super::tx_completion::`. The other 8 functions plus `TxError` plus
+  4 guarantee/quantum constants stay on `crate::afxdp::tx::`,
+  deferred to #984.
 
 Remaining (NOT in P1 scope):
 - Phase 7's XSK-ring / worker-binding / per-byte primitives
@@ -281,9 +283,10 @@ use crate::afxdp::tx::{
 };
 ```
 
-After P1: split into two `use` blocks. The 10 moved symbols come from
+After P1: split into two `use` blocks. The 10 moved fns come from
 `super::tx_completion` (or `super::` via cos/mod.rs re-export); the
-unmoved 8 stay on `crate::afxdp::tx`:
+remaining 8 unmoved fns + `TxError` + 4 quantum/guarantee constants
+stay on `crate::afxdp::tx`:
 
 ```rust
 use super::tx_completion::{
@@ -384,7 +387,7 @@ afxdp/tx/ module split (#984). After P1's queue_service.rs migration,
 the remaining cos→tx imports in queue_service.rs and cross_binding.rs
 are:
 
-`cos/queue_service.rs` (the 8 unmoved symbols + 4 constants):
+`cos/queue_service.rs` (the 8 unmoved fns + `TxError` + 4 guarantee/quantum constants):
 - `cos_queue_dscp_rewrite` (tx.rs:1966)
 - `maybe_wake_tx` (tx.rs:2808)
 - `reap_tx_completions`
@@ -418,10 +421,11 @@ location in `cos/tx_completion.rs`.
   (~600 moved + ~50 lines header/imports/notes).
 - `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
 - `userspace-dp/src/afxdp/cos/queue_service.rs`: split tx import block
-  (10 symbols → super::tx_completion::, 8 stay on crate::afxdp::tx);
-  update the now-stale "back-edges to tx.rs" header comment at lines
-  23-29 to reflect that the TX-completion/timer-wheel symbols moved
-  to `cos/tx_completion.rs`.
+  (10 fns → super::tx_completion::; 8 unmoved fns + TxError + 4
+  guarantee/quantum constants stay on crate::afxdp::tx); update the
+  now-stale "back-edges to tx.rs" header comment at lines 23-29 to
+  reflect that the TX-completion/timer-wheel symbols moved to
+  `cos/tx_completion.rs`.
 - `userspace-dp/src/afxdp/cos/builders.rs`: switch single
   `cos_tick_for_ns` import; update comment block.
 - `userspace-dp/src/afxdp/tx.rs`: −600 LOC; one always-on cos:: import,

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -159,7 +159,7 @@ All deferred to #984 (afxdp/tx/ split).
 
 **~600 LOC** moved. After this PR, `tx.rs` size drops from 13731 → ~13130.
 
-## Visibility rules — source-verified (14 + 6)
+## Visibility rules — source-verified
 
 `pub(in crate::afxdp)` (14 items) — required because they have callers
 outside `cos/tx_completion.rs`:

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -1,43 +1,63 @@
 # P1: extract cos/tx_completion.rs from tx.rs
 
-Plan v2 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
-decomposition merged at PR #983. Closes the back-edges Phase 7+8
-deliberately introduced.
+Plan v3 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
+decomposition merged at PR #983.
 
-## v2 changelog vs v1 (from Codex round-1)
+## v3 changelog vs v2 (from Codex round-2)
 
-- R1-1: `mark_cos_queue_runnable` cannot be file-private (tx.rs:2080
-  `enqueue_cos_item`, NOT moving). Bumped to `pub(in crate::afxdp)`.
-- R1-2: `normalize_cos_queue_state` cannot be file-private — both
-  `refresh_cos_interface_activity` (originally NOT moving) AND a test
-  at tx.rs:10612 reach it. Now `pub(in crate::afxdp)` (see also R1-3).
-- R1-3: **`refresh_cos_interface_activity` joins the move list.** All 3
-  tx.rs callers (1180, 2217, 2282) are themselves in moving fns, and
-  cos/queue_service.rs has 13 callers — moving it kills the largest
-  remaining cos→tx back-edge in P1's scope. Net move size grows from
-  18→19 fns, ~550→~600 LOC.
-- R1-4: Test usages of moved items (tx.rs:10533, 10558, 10612, 10673,
-  10737) require `pub(in crate::afxdp)` visibility on
-  `COS_TIMER_WHEEL_TICK_NS`, `normalize_cos_queue_state`,
-  `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`,
-  AND a `use super::cos::{...}` line in tx.rs so the bottom-of-file
-  `mod tests { use super::*; }` block resolves them.
-- R1-6: Remaining cos→tx back-edges from `queue_service` and
-  `cross_binding` (transmit_*, reap_tx_completions, maybe_wake_tx,
-  recycle_*, refresh deferred to #984) named explicitly (see "Back-edges
-  remaining" below).
-- R1-7: Hot-path `#[inline]` list reconciled with current source.
-- R1-8: Imports corrected — `BindingWorker` lives in `worker.rs`,
-  `ParkReason` lives in `cos/queue_service.rs`,
-  `std::sync::atomic::Ordering` is required.
+- R2-F1 [BLOCKER]: queue_service.rs imports **10** moving symbols from
+  `crate::afxdp::tx` (lines 59-65), not 1. v3 spells out the full
+  migration: switch all 10 to `super::tx_completion::{...}` (or via
+  `super::` re-export). v2 understated this; "1 fewer import" wording
+  removed.
+- R2-F2 [BLOCKER]: `cos/builders.rs` imports `cos_tick_for_ns` from
+  `crate::afxdp::tx` (builders.rs:33). v3 adds builders.rs to
+  files-touched and the import migration list.
+- R2-F3 [BLOCKER]: `tx_completion.rs` import block was source-inaccurate.
+  v3 reconciles against actual moved-fn bodies:
+  - Add `cos_queue_is_empty`, `cos_queue_push_front` to queue_ops imports.
+  - Use `CoSServicePhase` (queue_service) — NOT `ParkReason`.
+  - Add `maybe_top_up_cos_root_lease`, `release_cos_root_lease`,
+    `park_cos_queue`, `count_park_reason` from queue_service.
+- R2-F4 [BLOCKER]: tx.rs always-on `use super::cos::{...}` block only
+  needs `mark_cos_queue_runnable` (the one production caller outside
+  the move set, at tx.rs:2080). All other moved items are reached only
+  by tests at tx.rs:10533-10737 → goes in a `#[cfg(test)] use
+  super::cos::{...}` block. Avoids unused-import warnings on
+  `cargo build --bins`.
+- R2-F5 [MINOR]: visibility count fixed — 14 items are
+  `pub(in crate::afxdp)`, not 10.
+
+## v2 changelog vs v1 (preserved from round-1)
+
+- R1-1: `mark_cos_queue_runnable` was classified file-private but
+  tx::enqueue_cos_item at tx.rs:2080 calls it (NOT moving) — v2 makes
+  it `pub(in crate::afxdp)`.
+- R1-2: `normalize_cos_queue_state` was classified file-private but
+  `refresh_cos_interface_activity` AND test at tx.rs:10612 reach it —
+  v2 makes it `pub(in crate::afxdp)`.
+- R1-3: **`refresh_cos_interface_activity` joins the move list.** All
+  3 tx.rs callers (1180/2217/2282) are in moving fns; cos/queue_service.rs
+  has 13 callers. Moving it kills the largest cos→tx back-edge.
+- R1-4: Test usages of moved items at tx.rs:10533/10537/10558/10562/
+  10612/10673/10737 — bumped 4 items to `pub(in crate::afxdp)` AND
+  added a tx.rs cos:: import line so tests resolve them.
+- R1-7/R1-8: `#[inline]` list reconciled. Imports corrected —
+  `BindingWorker` lives in `worker.rs:13`, `CoSServicePhase` in
+  `cos/queue_service.rs`, `std::sync::atomic::Ordering` added.
 
 ## Goal
 
 Move the TX-completion + timer-wheel cluster from tx.rs into
-`userspace-dp/src/afxdp/cos/tx_completion.rs`. After this PR every
-moving cos↔tx back-edge that #956 Phases 6/7/8 deliberately accepted is
-resolved. Remaining back-edges to tx.rs are XSK-ring / worker-binding /
-prepared-frame helpers, slated for #984 (afxdp/tx/ split).
+`userspace-dp/src/afxdp/cos/tx_completion.rs`. After this PR:
+- Every cos→tx back-edge introduced by #956 Phases 6/7/8 is closed.
+- `cos/queue_service.rs` no longer imports any of the 10 moving symbols
+  from `crate::afxdp::tx`.
+- `cos/builders.rs` no longer imports `cos_tick_for_ns` from tx.
+
+Remaining cos→tx back-edges after P1 are XSK-ring / worker-binding /
+prepared-frame primitives (transmit_*, reap_tx_completions, maybe_wake_tx,
+recycle_*), slated for #984 (afxdp/tx/ split).
 
 ## Move list (19 fns + 2 constants)
 
@@ -64,7 +84,7 @@ prepared-frame helpers, slated for #984 (afxdp/tx/ split).
 |---|---|---|
 | `prime_cos_root_for_service` | 1127 | `pub(in crate::afxdp)` |
 | `apply_direct_exact_send_result` | 1142 | `pub(in crate::afxdp)` |
-| `refresh_cos_interface_activity` | 2114 | `pub(in crate::afxdp)` ⬅ added in v2 |
+| `refresh_cos_interface_activity` | 2114 | `pub(in crate::afxdp)` |
 | `apply_cos_send_result` | 2159 | `pub(in crate::afxdp)` |
 | `apply_cos_prepared_result` | 2220 | `pub(in crate::afxdp)` |
 | `restore_cos_local_items_inner` | 2285 | `pub(in crate::afxdp)` (test at 10673) |
@@ -74,22 +94,35 @@ prepared-frame helpers, slated for #984 (afxdp/tx/ split).
 
 **~600 LOC** moved. After this PR, `tx.rs` size drops from 13731 → ~13130.
 
-## Visibility rules — source-verified
+## Visibility rules — source-verified (14 + 6)
 
-`pub(in crate::afxdp)` (10 items) — required because they have callers
+`pub(in crate::afxdp)` (14 items) — required because they have callers
 outside `cos/tx_completion.rs`:
-- production cos/queue_service.rs callers, OR
-- production tx.rs callers in non-moving fns (`mark_cos_queue_runnable`
-  at tx.rs:2080), OR
-- `tx::tests` callers at tx.rs:10533–10737.
+
+Constants (1):
+- `COS_TIMER_WHEEL_TICK_NS` — tests at tx.rs:10533, 10537, 10558, 10562
+
+Functions (13):
+- 11 with cos/queue_service.rs callers (most named in queue_service.rs:59-65):
+  `prime_cos_root_for_service`, `apply_direct_exact_send_result`,
+  `apply_cos_send_result`, `apply_cos_prepared_result`,
+  `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+  `count_tx_ring_full_submit_stall`, `refresh_cos_interface_activity`,
+  `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`,
+  `advance_cos_timer_wheel`.
+- 1 with cos/builders.rs caller: `cos_tick_for_ns` (already counted).
+- 1 with tx.rs production caller: `mark_cos_queue_runnable` (tx.rs:2080).
+- 1 with test caller: `normalize_cos_queue_state` (tx.rs:10612).
 
 File-private (5 fns + 1 const) — only callers are co-located in the
 move set:
-- `wake_cos_queue` (1305, 1419)
-- `rearm_cos_queue` (1396, 1422)
-- `cascade_cos_timer_wheel_level1` (1375)
-- `wake_due_cos_timer_slot` (1377)
-- `COS_TIMER_WHEEL_L0_HORIZON_TICKS`
+- `wake_cos_queue` (tx.rs:1305 inside cos_tick_for_ns area, 1419 inside
+  wake_due_cos_timer_slot — both moving).
+- `rearm_cos_queue` (tx.rs:1396 inside cascade, 1422 inside wake_due —
+  both moving).
+- `cascade_cos_timer_wheel_level1` (tx.rs:1375 inside advance_cos_timer_wheel).
+- `wake_due_cos_timer_slot` (tx.rs:1377 inside advance_cos_timer_wheel).
+- `COS_TIMER_WHEEL_L0_HORIZON_TICKS`.
 
 `COS_TIMER_WHEEL_L0_SLOTS` / `_L1_SLOTS` (referenced by
 `cos_timer_wheel_level_and_slot` and `cascade_cos_timer_wheel_level1`)
@@ -113,10 +146,12 @@ Not inlined (off per-byte path; preserve existing attributes):
 - `wake_cos_queue`, `rearm_cos_queue`,
   `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`.
 
-(Codex round-2 verifies which of these already carry `#[inline]` and
-preserves them — never silently downgrades.)
+(Round-3 reviewer: verify which of these already carry `#[inline]` and
+preserve them — never silently downgrade.)
 
-## Imports for cos/tx_completion.rs (corrected, source-verified)
+## Imports for cos/tx_completion.rs (source-verified)
+
+Reconciled against the moved-fn bodies (tx.rs:1127-1422, 2114-2310):
 
 ```rust
 use std::collections::VecDeque;
@@ -127,16 +162,18 @@ use crate::afxdp::types::{
     CoSTimerWheelRuntime, PreparedTxRequest, PreparedTxRecycle,
     TxRequest, COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
 };
-use crate::afxdp::worker::BindingWorker;        // worker.rs:13
+use crate::afxdp::worker::BindingWorker;     // worker.rs:13
 
 use super::queue_ops::{
     cos_item_len, cos_queue_clear_orphan_snapshot_after_drop,
-    cos_queue_drain_all, cos_queue_pop_front, cos_queue_push_back,
-    cos_queue_push_front, cos_queue_restore_front,
+    cos_queue_drain_all, cos_queue_is_empty, cos_queue_pop_front,
+    cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
     publish_committed_queue_vtime,
 };
-use super::queue_service::{count_park_reason, park_cos_queue, ParkReason};
-//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ queue_service.rs:2145
+use super::queue_service::{
+    count_park_reason, maybe_top_up_cos_root_lease, park_cos_queue,
+    release_cos_root_lease, CoSServicePhase, ParkReason,
+};
 
 // Back-edges remaining to tx.rs (slated for #984 — afxdp/tx/ split):
 use crate::afxdp::tx::{
@@ -145,8 +182,66 @@ use crate::afxdp::tx::{
 };
 ```
 
-(Round-2 reviewers: verify exact import surface against the moved
-function bodies; this list is the upper bound and may be trimmed.)
+(Round-3 reviewers: verify the exact list against the moved bodies
+once written; this is the upper bound. Unused imports trigger build
+warnings.)
+
+## cos/queue_service.rs import migration
+
+Source today (queue_service.rs:59-65):
+```rust
+use crate::afxdp::tx::{
+    apply_cos_prepared_result, apply_cos_send_result,
+    apply_direct_exact_send_result, cos_queue_dscp_rewrite, cos_tick_for_ns,
+    cos_timer_wheel_level_and_slot, count_tx_ring_full_submit_stall, maybe_wake_tx,
+    prime_cos_root_for_service, reap_tx_completions, recycle_cancelled_prepared_offset,
+    refresh_cos_interface_activity, remember_prepared_recycle, restore_cos_local_items_inner,
+    restore_cos_prepared_items_inner, stamp_submits, transmit_batch, transmit_prepared_queue,
+    TxError, COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
+    COS_GUARANTEE_VISIT_NS, COS_SURPLUS_ROUND_QUANTUM_BYTES,
+};
+```
+
+After P1: split into two `use` blocks. The 10 moved symbols come from
+`super::tx_completion` (or `super::` via cos/mod.rs re-export); the
+unmoved 8 stay on `crate::afxdp::tx`:
+
+```rust
+use super::tx_completion::{
+    apply_cos_prepared_result, apply_cos_send_result,
+    apply_direct_exact_send_result, cos_tick_for_ns,
+    cos_timer_wheel_level_and_slot, count_tx_ring_full_submit_stall,
+    prime_cos_root_for_service, refresh_cos_interface_activity,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+};
+use crate::afxdp::tx::{
+    cos_queue_dscp_rewrite, maybe_wake_tx, reap_tx_completions,
+    recycle_cancelled_prepared_offset, remember_prepared_recycle,
+    stamp_submits, transmit_batch, transmit_prepared_queue,
+    TxError, COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
+    COS_GUARANTEE_VISIT_NS, COS_SURPLUS_ROUND_QUANTUM_BYTES,
+};
+```
+
+(`advance_cos_timer_wheel` is moved but is NOT in queue_service.rs's
+current import list — it's reached via tx.rs. After move, it's reached
+via `super::tx_completion::advance_cos_timer_wheel` if needed in
+queue_service or via cos/mod.rs re-export.)
+
+## cos/builders.rs import migration
+
+Source today (builders.rs:33):
+```rust
+use crate::afxdp::tx::cos_tick_for_ns;
+```
+
+After P1:
+```rust
+use super::tx_completion::cos_tick_for_ns;
+```
+
+The "One back-edge" comment block at builders.rs:14-19 must be updated
+or removed — that back-edge is now closed.
 
 ## cos/mod.rs additions
 
@@ -169,36 +264,48 @@ visibility from cos/mod.rs. File-private items are NOT re-exported.)
 
 ## tx.rs changes
 
-- Remove the 19 fn definitions + 2 constants.
-- Remove the Phase-6 visibility-bump comment block above
-  `cos_tick_for_ns`.
-- Add at the existing `use super::cos::{...}` block (currently at
-  tx.rs:1227 / 1240):
+1. Remove the 19 fn definitions + 2 constants.
+2. Remove the Phase-6 visibility-bump comment block above
+   `cos_tick_for_ns` (will not exist post-move).
+3. **Always-on import** (cos:: block at tx.rs:1227 / 1240) — add ONLY
+   the production caller's symbol:
 
-  ```rust
-  use super::cos::{
-      advance_cos_timer_wheel, apply_cos_prepared_result, apply_cos_send_result,
-      apply_direct_exact_send_result, cos_tick_for_ns, cos_timer_wheel_level_and_slot,
-      count_tx_ring_full_submit_stall, mark_cos_queue_runnable,
-      normalize_cos_queue_state, prime_cos_root_for_service,
-      refresh_cos_interface_activity, restore_cos_local_items_inner,
-      restore_cos_prepared_items_inner, COS_TIMER_WHEEL_TICK_NS,
-  };
-  ```
+   ```rust
+   use super::cos::mark_cos_queue_runnable;
+   ```
 
-  This satisfies BOTH (a) production callers in non-moving tx.rs fns
-  (`enqueue_cos_item` at 2080 needing `mark_cos_queue_runnable`) AND
-  (b) the bottom-of-file `mod tests { use super::*; }` block at
-  tx.rs:2907 reaching items via `super::*`.
+   This is the only moved symbol used outside the `mod tests` block —
+   `enqueue_cos_item` at tx.rs:2080 calls it.
+
+4. **Test-only import block** — added next to `mod tests` (around
+   tx.rs:2907):
+
+   ```rust
+   #[cfg(test)]
+   use super::cos::{
+       advance_cos_timer_wheel, normalize_cos_queue_state,
+       restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+       COS_TIMER_WHEEL_TICK_NS,
+   };
+   ```
+
+   Or equivalently, add these to the existing `#[cfg(test)]` block
+   inside `mod tests { use super::*; … }`. Either pattern resolves
+   `mod tests` calls at tx.rs:10533, 10537, 10558, 10562, 10612,
+   10673, 10737 without leaking unused imports into release builds.
+
+(Splitting always-on vs cfg-test imports avoids `cargo build --bins`
+unused-import warnings — see Acceptance section.)
 
 ## Back-edges remaining — explicit, scoped to #984
 
 These are NOT in P1's scope. They stay because they're XSK-ring /
 worker-binding / prepared-frame primitives owned by `tx::*` until the
-afxdp/tx/ module split (#984). The list below is taken from the current
-import block of `cos/queue_service.rs` and `cos/cross_binding.rs`:
+afxdp/tx/ module split (#984). After P1's queue_service.rs migration,
+the remaining cos→tx imports in queue_service.rs and cross_binding.rs
+are:
 
-From `cos/queue_service.rs:59` (still in source after this PR):
+`cos/queue_service.rs` (the 8 unmoved symbols + 4 constants):
 - `cos_queue_dscp_rewrite` (tx.rs:1966)
 - `maybe_wake_tx` (tx.rs:2808)
 - `reap_tx_completions`
@@ -208,40 +315,33 @@ From `cos/queue_service.rs:59` (still in source after this PR):
 - `transmit_batch`, `transmit_prepared_queue`
 - `TxError`
 - guarantee/quantum constants (`COS_GUARANTEE_VISIT_NS`,
-  `COS_GUARANTEE_QUANTUM_*`, `COS_SURPLUS_ROUND_QUANTUM_BYTES`)
+  `COS_GUARANTEE_QUANTUM_MAX_BYTES`, `COS_GUARANTEE_QUANTUM_MIN_BYTES`,
+  `COS_SURPLUS_ROUND_QUANTUM_BYTES`)
 
-From `cos/cross_binding.rs:30`:
+`cos/cross_binding.rs:30`:
 - `recycle_prepared_immediately` (tx.rs:2375)
 
-After P1: 1 fewer cos→tx import (`refresh_cos_interface_activity`
-gone). The plan does NOT claim "every back-edge resolved" — only
-"every back-edge introduced by Phases 6/7/8 closed."
+P1 does NOT claim "every back-edge resolved" — only "every back-edge
+introduced by #956 Phases 6/7/8 closed."
 
 ## Files touched
 
 - **NEW** `userspace-dp/src/afxdp/cos/tx_completion.rs`: ~650 LOC
   (~600 moved + ~50 lines header/imports/notes).
 - `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
-- `userspace-dp/src/afxdp/cos/queue_service.rs`: switch
-  `refresh_cos_interface_activity` import from `super::tx::` to
-  `super::tx_completion::` (or `super::` via cos/mod.rs re-export —
-  reviewer preference).
-- `userspace-dp/src/afxdp/tx.rs`: −600 LOC; extend the cos:: import
-  block.
+- `userspace-dp/src/afxdp/cos/queue_service.rs`: split tx import block
+  (10 symbols → super::tx_completion::, 8 stay on crate::afxdp::tx).
+- `userspace-dp/src/afxdp/cos/builders.rs`: switch single
+  `cos_tick_for_ns` import; update comment block.
+- `userspace-dp/src/afxdp/tx.rs`: −600 LOC; one always-on cos:: import,
+  one test-only cos:: import block.
 
 ## Tests
 
 No new tests required — pure structural refactor. Existing
 `tx::tests` callers (tx.rs:10533, 10537, 10558, 10562, 10612, 10673,
-10737) reach moved items via the cos:: re-export chain through
-tx.rs's `use super::cos::{...}` line, which `mod tests { use super::*; }`
-imports transitively. Same Phase 1-8 pattern.
-
-If any test reaches an item whose `pub(in crate::afxdp)` visibility is
-not enough (e.g. wants direct fn-private access), it will fail to
-compile — at which point we either (a) bump the item's visibility (no
-real cost), or (b) move the test to `cos/tx_completion.rs` alongside
-its target. v2 expects no such test to exist.
+10737) reach moved items via the test-only `#[cfg(test)] use super::cos::{...}`
+block in tx.rs. The cos/mod.rs re-export chain backs that import.
 
 ## Risk
 
@@ -269,7 +369,8 @@ cleaned up.
 
 ## Acceptance
 
-- `cargo build --bins` clean (no new unused-import warnings).
+- `cargo build --bins` clean (no new unused-import warnings — F4
+  always-on/test-only split prevents warnings on test-only items).
 - `cargo test --bins` 865/0/2 (current rolling baseline).
 - Cluster smoke: `cluster-setup.sh deploy`, `apply-cos-config.sh`,
   per-CoS-class iperf3 (all 7 classes 5201-5207), failover (RG1

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -1,0 +1,183 @@
+# P1: extract cos/tx_completion.rs from tx.rs
+
+Plan v1 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
+decomposition merged at PR #983. Closes the back-edges Phase 7+8
+deliberately introduced.
+
+## Goal
+
+Move the TX-completion + timer-wheel cluster from tx.rs into
+`userspace-dp/src/afxdp/cos/tx_completion.rs`. After this PR every
+back-edge `cos/* -> tx::*` from Phases 6/7/8 is resolved — cos/* is
+fully self-contained, tx.rs is purely XSK-ring + worker-binding glue.
+
+## Move list (18 fns + 2 constants)
+
+### Timer wheel cluster (~150 LOC)
+
+| Item | Line | Visibility |
+|---|---|---|
+| `COS_TIMER_WHEEL_TICK_NS` | 1202 | const |
+| `COS_TIMER_WHEEL_L0_HORIZON_TICKS` | 1207 | const (depends on `COS_TIMER_WHEEL_L0_SLOTS` from types.rs) |
+| `cos_tick_for_ns` | 1266 | `pub(in crate::afxdp)` |
+| `cos_timer_wheel_level_and_slot` | 1270 | `pub(in crate::afxdp)` |
+| `wake_cos_queue` | 1292 | private |
+| `count_tx_ring_full_submit_stall` | 1322 | `pub(in crate::afxdp)` |
+| `rearm_cos_queue` | 1341 | private |
+| `mark_cos_queue_runnable` | 1345 | private |
+| `normalize_cos_queue_state` | 1351 | private |
+| `advance_cos_timer_wheel` | 1370 | `pub(in crate::afxdp)` |
+| `cascade_cos_timer_wheel_level1` | 1381 | private |
+| `wake_due_cos_timer_slot` | 1400 | private |
+
+### TX-completion cluster (~400 LOC)
+
+| Item | Line | Visibility |
+|---|---|---|
+| `prime_cos_root_for_service` | 1127 | `pub(in crate::afxdp)` |
+| `apply_direct_exact_send_result` | 1142 | `pub(in crate::afxdp)` |
+| `apply_cos_send_result` | 2159 | `pub(in crate::afxdp)` |
+| `apply_cos_prepared_result` | 2220 | `pub(in crate::afxdp)` |
+| `restore_cos_local_items_inner` | 2285 | `pub(in crate::afxdp)` |
+| `restore_cos_prepared_items_inner` | 2300 | `pub(in crate::afxdp)` |
+
+### Total
+**~550 LOC** moved. After this PR, `tx.rs` size drops from 13731 → ~13180.
+
+## Visibility
+
+Production callers (cos/queue_service.rs and tx.rs after move):
+- All 6 TX-completion fns: `pub(in crate::afxdp)` (already bumped during Phase 7).
+- `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`, `count_tx_ring_full_submit_stall`,
+  `advance_cos_timer_wheel`: `pub(in crate::afxdp)` (bumped during Phase 6/7).
+- Internal helpers (`wake_cos_queue`, `rearm_cos_queue`, `mark_cos_queue_runnable`,
+  `normalize_cos_queue_state`, `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`):
+  file-private after move (only co-located callers).
+- Constants `COS_TIMER_WHEEL_TICK_NS`, `COS_TIMER_WHEEL_L0_HORIZON_TICKS`: file-private.
+
+`COS_TIMER_WHEEL_L0_SLOTS` / `_L1_SLOTS` (used by `cos_timer_wheel_level_and_slot` and
+`cascade_cos_timer_wheel_level1`) live in afxdp/types.rs as `pub(super)` — already
+reachable from cos/* descendants via the existing pattern.
+
+## #[inline]
+
+Per the Phase 4-8 lesson:
+- Hot-path: `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+  `mark_cos_queue_runnable`, `normalize_cos_queue_state`,
+  `count_tx_ring_full_submit_stall` — add `#[inline]` if not already
+  present.
+- Per-batch (called from drain loop): `apply_cos_send_result`,
+  `apply_cos_prepared_result`, `apply_direct_exact_send_result`,
+  `prime_cos_root_for_service`, `advance_cos_timer_wheel` — add
+  `#[inline]`.
+- Off per-byte path: `wake_cos_queue`, `rearm_cos_queue`,
+  `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`,
+  `restore_cos_*_inner` — preserve existing attributes; do not add.
+
+(Codex round-1 verifies which fns currently carry `#[inline]` in
+source — preserve those.)
+
+## Imports for cos/tx_completion.rs (subject to verification)
+
+```rust
+use std::collections::VecDeque;
+
+use crate::afxdp::types::{
+    BindingWorker, CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
+    CoSTimerWheelRuntime, ParkReason, PreparedTxRequest, PreparedTxRecycle,
+    TxRequest, COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
+};
+use crate::afxdp::worker::BindingWorker;
+
+use super::queue_ops::{
+    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all,
+    cos_queue_pop_front, cos_queue_push_back, cos_queue_push_front,
+    cos_queue_restore_front, publish_committed_queue_vtime,
+};
+use super::queue_service::{count_park_reason, park_cos_queue, ParkReason as ServiceParkReason};
+
+// Back-edges remaining to tx.rs (still in tx.rs through #984's tx/ split):
+use crate::afxdp::tx::{
+    recycle_cancelled_prepared_offset, recycle_prepared_immediately,
+    refresh_cos_interface_activity, transmit_batch, transmit_prepared_queue,
+    reap_tx_completions, maybe_wake_tx,
+};
+```
+
+Codex round-1 will validate the exact import surface.
+
+## cos/mod.rs additions
+
+```rust
+pub(super) mod tx_completion;
+
+pub(super) use tx_completion::{
+    advance_cos_timer_wheel, apply_cos_prepared_result, apply_cos_send_result,
+    apply_direct_exact_send_result, cos_tick_for_ns, cos_timer_wheel_level_and_slot,
+    count_tx_ring_full_submit_stall, prime_cos_root_for_service,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+};
+```
+
+(Test-touched items get cfg-gated re-exports if any; verified by Codex round-1.)
+
+## tx.rs
+
+- Remove the 18 fn definitions + 2 constants.
+- Remove the `cos_tick_for_ns` Phase-6 visibility-bump comment block.
+- Add `use super::cos::{...}` for the 10 production-callable items.
+- The remaining back-edges from cos/queue_service to tx.rs (transmit_*,
+  reap_tx_completions, etc) STAY because those are XSK-ring/worker-binding
+  helpers slated for #984 (afxdp/tx/ split).
+
+## Files touched
+
+- **NEW** `userspace-dp/src/afxdp/cos/tx_completion.rs`: ~600 LOC
+  (~550 moved + ~50 lines header/imports/notes).
+- `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
+- `userspace-dp/src/afxdp/tx.rs`: -550 LOC; extend cos:: imports.
+
+## Tests
+
+No new tests required — pure structural refactor. Existing
+`tx::tests` callers reach moved items via the cos:: re-export
+chain — same Phase 1-8 pattern.
+
+## Risk
+
+**Low-medium.** ~550 LOC. Hot-path concerns:
+
+- `apply_cos_send_result` / `apply_cos_prepared_result` fire per
+  batch (~hundreds of times per drain cycle). `#[inline]` preserves
+  cross-module inlining per Phase 4-8 lesson.
+- `cos_tick_for_ns` is a one-liner; cross-module move + `#[inline]`
+  should be free.
+- Timer-wheel functions (`advance_cos_timer_wheel`,
+  `cascade_*_level1`, `wake_due_*`) fire on each drain cycle but
+  only hit the slow path when timer slots have queued queues. No
+  per-byte overhead concern.
+
+Atomic ordering: `apply_cos_send_result` advances queue state and
+calls `publish_committed_queue_vtime` (cos/queue_ops.rs) — that
+fn's Release ordering is preserved by the move (already-extracted
+publish_* doesn't change).
+
+After this PR, every `pub(in crate::afxdp)` visibility bump in
+tx.rs from Phases 6/7/8 except those tied to XSK-ring helpers (#984
+scope) is cleaned up.
+
+## Acceptance
+
+- `cargo build --bins` clean (no new unused-import warnings).
+- `cargo test --bins` 865/0/2 (current rolling baseline).
+- Cluster smoke: `cluster-setup.sh deploy`, `apply-cos-config.sh`,
+  per-CoS-class iperf3 (all 7 classes 5201-5207), failover (RG1
+  cycled twice, ≥95% intervals ≥3 Gbps, 0 zero-bps).
+- **Triadic plan + impl review**: Codex + Gemini converge
+  PLAN-READY/IMPL-READY with NO new findings on the cross-reviews.
+- Copilot review on the PR addressed.
+
+## After P1
+
+Stage 2 of the long sequence: #984 — afxdp/tx/ module
+(P2a stats.rs, P2b rings.rs, P2c dispatch.rs, P2d collapse tx.rs).

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -1,170 +1,271 @@
 # P1: extract cos/tx_completion.rs from tx.rs
 
-Plan v1 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
+Plan v2 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
 decomposition merged at PR #983. Closes the back-edges Phase 7+8
 deliberately introduced.
+
+## v2 changelog vs v1 (from Codex round-1)
+
+- R1-1: `mark_cos_queue_runnable` cannot be file-private (tx.rs:2080
+  `enqueue_cos_item`, NOT moving). Bumped to `pub(in crate::afxdp)`.
+- R1-2: `normalize_cos_queue_state` cannot be file-private — both
+  `refresh_cos_interface_activity` (originally NOT moving) AND a test
+  at tx.rs:10612 reach it. Now `pub(in crate::afxdp)` (see also R1-3).
+- R1-3: **`refresh_cos_interface_activity` joins the move list.** All 3
+  tx.rs callers (1180, 2217, 2282) are themselves in moving fns, and
+  cos/queue_service.rs has 13 callers — moving it kills the largest
+  remaining cos→tx back-edge in P1's scope. Net move size grows from
+  18→19 fns, ~550→~600 LOC.
+- R1-4: Test usages of moved items (tx.rs:10533, 10558, 10612, 10673,
+  10737) require `pub(in crate::afxdp)` visibility on
+  `COS_TIMER_WHEEL_TICK_NS`, `normalize_cos_queue_state`,
+  `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`,
+  AND a `use super::cos::{...}` line in tx.rs so the bottom-of-file
+  `mod tests { use super::*; }` block resolves them.
+- R1-6: Remaining cos→tx back-edges from `queue_service` and
+  `cross_binding` (transmit_*, reap_tx_completions, maybe_wake_tx,
+  recycle_*, refresh deferred to #984) named explicitly (see "Back-edges
+  remaining" below).
+- R1-7: Hot-path `#[inline]` list reconciled with current source.
+- R1-8: Imports corrected — `BindingWorker` lives in `worker.rs`,
+  `ParkReason` lives in `cos/queue_service.rs`,
+  `std::sync::atomic::Ordering` is required.
 
 ## Goal
 
 Move the TX-completion + timer-wheel cluster from tx.rs into
 `userspace-dp/src/afxdp/cos/tx_completion.rs`. After this PR every
-back-edge `cos/* -> tx::*` from Phases 6/7/8 is resolved — cos/* is
-fully self-contained, tx.rs is purely XSK-ring + worker-binding glue.
+moving cos↔tx back-edge that #956 Phases 6/7/8 deliberately accepted is
+resolved. Remaining back-edges to tx.rs are XSK-ring / worker-binding /
+prepared-frame helpers, slated for #984 (afxdp/tx/ split).
 
-## Move list (18 fns + 2 constants)
+## Move list (19 fns + 2 constants)
 
 ### Timer wheel cluster (~150 LOC)
 
-| Item | Line | Visibility |
+| Item | Line | Visibility after move |
 |---|---|---|
-| `COS_TIMER_WHEEL_TICK_NS` | 1202 | const |
-| `COS_TIMER_WHEEL_L0_HORIZON_TICKS` | 1207 | const (depends on `COS_TIMER_WHEEL_L0_SLOTS` from types.rs) |
+| `COS_TIMER_WHEEL_TICK_NS` | 1202 | `pub(in crate::afxdp)` (tests at 10533/10537/10558/10562) |
+| `COS_TIMER_WHEEL_L0_HORIZON_TICKS` | 1207 | file-private |
 | `cos_tick_for_ns` | 1266 | `pub(in crate::afxdp)` |
 | `cos_timer_wheel_level_and_slot` | 1270 | `pub(in crate::afxdp)` |
-| `wake_cos_queue` | 1292 | private |
+| `wake_cos_queue` | 1292 | file-private |
 | `count_tx_ring_full_submit_stall` | 1322 | `pub(in crate::afxdp)` |
-| `rearm_cos_queue` | 1341 | private |
-| `mark_cos_queue_runnable` | 1345 | private |
-| `normalize_cos_queue_state` | 1351 | private |
+| `rearm_cos_queue` | 1341 | file-private |
+| `mark_cos_queue_runnable` | 1345 | `pub(in crate::afxdp)` (called by `enqueue_cos_item` tx.rs:2080) |
+| `normalize_cos_queue_state` | 1351 | `pub(in crate::afxdp)` (test at 10612) |
 | `advance_cos_timer_wheel` | 1370 | `pub(in crate::afxdp)` |
-| `cascade_cos_timer_wheel_level1` | 1381 | private |
-| `wake_due_cos_timer_slot` | 1400 | private |
+| `cascade_cos_timer_wheel_level1` | 1381 | file-private |
+| `wake_due_cos_timer_slot` | 1400 | file-private |
 
-### TX-completion cluster (~400 LOC)
+### TX-completion cluster (~450 LOC)
 
-| Item | Line | Visibility |
+| Item | Line | Visibility after move |
 |---|---|---|
 | `prime_cos_root_for_service` | 1127 | `pub(in crate::afxdp)` |
 | `apply_direct_exact_send_result` | 1142 | `pub(in crate::afxdp)` |
+| `refresh_cos_interface_activity` | 2114 | `pub(in crate::afxdp)` ⬅ added in v2 |
 | `apply_cos_send_result` | 2159 | `pub(in crate::afxdp)` |
 | `apply_cos_prepared_result` | 2220 | `pub(in crate::afxdp)` |
-| `restore_cos_local_items_inner` | 2285 | `pub(in crate::afxdp)` |
-| `restore_cos_prepared_items_inner` | 2300 | `pub(in crate::afxdp)` |
+| `restore_cos_local_items_inner` | 2285 | `pub(in crate::afxdp)` (test at 10673) |
+| `restore_cos_prepared_items_inner` | 2300 | `pub(in crate::afxdp)` (test at 10737) |
 
 ### Total
-**~550 LOC** moved. After this PR, `tx.rs` size drops from 13731 → ~13180.
 
-## Visibility
+**~600 LOC** moved. After this PR, `tx.rs` size drops from 13731 → ~13130.
 
-Production callers (cos/queue_service.rs and tx.rs after move):
-- All 6 TX-completion fns: `pub(in crate::afxdp)` (already bumped during Phase 7).
-- `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`, `count_tx_ring_full_submit_stall`,
-  `advance_cos_timer_wheel`: `pub(in crate::afxdp)` (bumped during Phase 6/7).
-- Internal helpers (`wake_cos_queue`, `rearm_cos_queue`, `mark_cos_queue_runnable`,
-  `normalize_cos_queue_state`, `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`):
-  file-private after move (only co-located callers).
-- Constants `COS_TIMER_WHEEL_TICK_NS`, `COS_TIMER_WHEEL_L0_HORIZON_TICKS`: file-private.
+## Visibility rules — source-verified
 
-`COS_TIMER_WHEEL_L0_SLOTS` / `_L1_SLOTS` (used by `cos_timer_wheel_level_and_slot` and
-`cascade_cos_timer_wheel_level1`) live in afxdp/types.rs as `pub(super)` — already
-reachable from cos/* descendants via the existing pattern.
+`pub(in crate::afxdp)` (10 items) — required because they have callers
+outside `cos/tx_completion.rs`:
+- production cos/queue_service.rs callers, OR
+- production tx.rs callers in non-moving fns (`mark_cos_queue_runnable`
+  at tx.rs:2080), OR
+- `tx::tests` callers at tx.rs:10533–10737.
 
-## #[inline]
+File-private (5 fns + 1 const) — only callers are co-located in the
+move set:
+- `wake_cos_queue` (1305, 1419)
+- `rearm_cos_queue` (1396, 1422)
+- `cascade_cos_timer_wheel_level1` (1375)
+- `wake_due_cos_timer_slot` (1377)
+- `COS_TIMER_WHEEL_L0_HORIZON_TICKS`
 
-Per the Phase 4-8 lesson:
-- Hot-path: `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
+`COS_TIMER_WHEEL_L0_SLOTS` / `_L1_SLOTS` (referenced by
+`cos_timer_wheel_level_and_slot` and `cascade_cos_timer_wheel_level1`)
+already live in `afxdp/types.rs` as `pub(super)` — reachable from
+`cos/*` via the existing pattern.
+
+## #[inline] adds — source-verified list
+
+Hot-path additions for cross-module inlining (per Phase 4-8 lesson):
+- `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
   `mark_cos_queue_runnable`, `normalize_cos_queue_state`,
-  `count_tx_ring_full_submit_stall` — add `#[inline]` if not already
-  present.
-- Per-batch (called from drain loop): `apply_cos_send_result`,
-  `apply_cos_prepared_result`, `apply_direct_exact_send_result`,
-  `prime_cos_root_for_service`, `advance_cos_timer_wheel` — add
-  `#[inline]`.
-- Off per-byte path: `wake_cos_queue`, `rearm_cos_queue`,
-  `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`,
-  `restore_cos_*_inner` — preserve existing attributes; do not add.
+  `count_tx_ring_full_submit_stall` — already short, single-purpose.
+- `prime_cos_root_for_service`, `apply_direct_exact_send_result`,
+  `apply_cos_send_result`, `apply_cos_prepared_result`,
+  `advance_cos_timer_wheel`, `restore_cos_local_items_inner`,
+  `restore_cos_prepared_items_inner` — per-batch in drain loop.
+- `refresh_cos_interface_activity` — fires every per-batch helper, so
+  must inline across the cos→cos boundary too.
 
-(Codex round-1 verifies which fns currently carry `#[inline]` in
-source — preserve those.)
+Not inlined (off per-byte path; preserve existing attributes):
+- `wake_cos_queue`, `rearm_cos_queue`,
+  `cascade_cos_timer_wheel_level1`, `wake_due_cos_timer_slot`.
 
-## Imports for cos/tx_completion.rs (subject to verification)
+(Codex round-2 verifies which of these already carry `#[inline]` and
+preserves them — never silently downgrades.)
+
+## Imports for cos/tx_completion.rs (corrected, source-verified)
 
 ```rust
 use std::collections::VecDeque;
+use std::sync::atomic::Ordering;
 
 use crate::afxdp::types::{
-    BindingWorker, CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
-    CoSTimerWheelRuntime, ParkReason, PreparedTxRequest, PreparedTxRecycle,
+    CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
+    CoSTimerWheelRuntime, PreparedTxRequest, PreparedTxRecycle,
     TxRequest, COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
 };
-use crate::afxdp::worker::BindingWorker;
+use crate::afxdp::worker::BindingWorker;        // worker.rs:13
 
 use super::queue_ops::{
-    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all,
-    cos_queue_pop_front, cos_queue_push_back, cos_queue_push_front,
-    cos_queue_restore_front, publish_committed_queue_vtime,
+    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop,
+    cos_queue_drain_all, cos_queue_pop_front, cos_queue_push_back,
+    cos_queue_push_front, cos_queue_restore_front,
+    publish_committed_queue_vtime,
 };
-use super::queue_service::{count_park_reason, park_cos_queue, ParkReason as ServiceParkReason};
+use super::queue_service::{count_park_reason, park_cos_queue, ParkReason};
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ queue_service.rs:2145
 
-// Back-edges remaining to tx.rs (still in tx.rs through #984's tx/ split):
+// Back-edges remaining to tx.rs (slated for #984 — afxdp/tx/ split):
 use crate::afxdp::tx::{
-    recycle_cancelled_prepared_offset, recycle_prepared_immediately,
-    refresh_cos_interface_activity, transmit_batch, transmit_prepared_queue,
-    reap_tx_completions, maybe_wake_tx,
+    maybe_wake_tx, reap_tx_completions, recycle_cancelled_prepared_offset,
+    recycle_prepared_immediately, transmit_batch, transmit_prepared_queue,
 };
 ```
 
-Codex round-1 will validate the exact import surface.
+(Round-2 reviewers: verify exact import surface against the moved
+function bodies; this list is the upper bound and may be trimmed.)
 
 ## cos/mod.rs additions
 
 ```rust
 pub(super) mod tx_completion;
 
-pub(super) use tx_completion::{
+pub(in crate::afxdp) use tx_completion::{
     advance_cos_timer_wheel, apply_cos_prepared_result, apply_cos_send_result,
     apply_direct_exact_send_result, cos_tick_for_ns, cos_timer_wheel_level_and_slot,
-    count_tx_ring_full_submit_stall, prime_cos_root_for_service,
-    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+    count_tx_ring_full_submit_stall, mark_cos_queue_runnable,
+    normalize_cos_queue_state, prime_cos_root_for_service,
+    refresh_cos_interface_activity, restore_cos_local_items_inner,
+    restore_cos_prepared_items_inner, COS_TIMER_WHEEL_TICK_NS,
 };
 ```
 
-(Test-touched items get cfg-gated re-exports if any; verified by Codex round-1.)
+(Re-export visibility matches the items themselves: anything
+`pub(in crate::afxdp)` in tx_completion.rs gets the same re-export
+visibility from cos/mod.rs. File-private items are NOT re-exported.)
 
-## tx.rs
+## tx.rs changes
 
-- Remove the 18 fn definitions + 2 constants.
-- Remove the `cos_tick_for_ns` Phase-6 visibility-bump comment block.
-- Add `use super::cos::{...}` for the 10 production-callable items.
-- The remaining back-edges from cos/queue_service to tx.rs (transmit_*,
-  reap_tx_completions, etc) STAY because those are XSK-ring/worker-binding
-  helpers slated for #984 (afxdp/tx/ split).
+- Remove the 19 fn definitions + 2 constants.
+- Remove the Phase-6 visibility-bump comment block above
+  `cos_tick_for_ns`.
+- Add at the existing `use super::cos::{...}` block (currently at
+  tx.rs:1227 / 1240):
+
+  ```rust
+  use super::cos::{
+      advance_cos_timer_wheel, apply_cos_prepared_result, apply_cos_send_result,
+      apply_direct_exact_send_result, cos_tick_for_ns, cos_timer_wheel_level_and_slot,
+      count_tx_ring_full_submit_stall, mark_cos_queue_runnable,
+      normalize_cos_queue_state, prime_cos_root_for_service,
+      refresh_cos_interface_activity, restore_cos_local_items_inner,
+      restore_cos_prepared_items_inner, COS_TIMER_WHEEL_TICK_NS,
+  };
+  ```
+
+  This satisfies BOTH (a) production callers in non-moving tx.rs fns
+  (`enqueue_cos_item` at 2080 needing `mark_cos_queue_runnable`) AND
+  (b) the bottom-of-file `mod tests { use super::*; }` block at
+  tx.rs:2907 reaching items via `super::*`.
+
+## Back-edges remaining — explicit, scoped to #984
+
+These are NOT in P1's scope. They stay because they're XSK-ring /
+worker-binding / prepared-frame primitives owned by `tx::*` until the
+afxdp/tx/ module split (#984). The list below is taken from the current
+import block of `cos/queue_service.rs` and `cos/cross_binding.rs`:
+
+From `cos/queue_service.rs:59` (still in source after this PR):
+- `cos_queue_dscp_rewrite` (tx.rs:1966)
+- `maybe_wake_tx` (tx.rs:2808)
+- `reap_tx_completions`
+- `recycle_cancelled_prepared_offset`
+- `remember_prepared_recycle`
+- `stamp_submits`
+- `transmit_batch`, `transmit_prepared_queue`
+- `TxError`
+- guarantee/quantum constants (`COS_GUARANTEE_VISIT_NS`,
+  `COS_GUARANTEE_QUANTUM_*`, `COS_SURPLUS_ROUND_QUANTUM_BYTES`)
+
+From `cos/cross_binding.rs:30`:
+- `recycle_prepared_immediately` (tx.rs:2375)
+
+After P1: 1 fewer cos→tx import (`refresh_cos_interface_activity`
+gone). The plan does NOT claim "every back-edge resolved" — only
+"every back-edge introduced by Phases 6/7/8 closed."
 
 ## Files touched
 
-- **NEW** `userspace-dp/src/afxdp/cos/tx_completion.rs`: ~600 LOC
-  (~550 moved + ~50 lines header/imports/notes).
+- **NEW** `userspace-dp/src/afxdp/cos/tx_completion.rs`: ~650 LOC
+  (~600 moved + ~50 lines header/imports/notes).
 - `userspace-dp/src/afxdp/cos/mod.rs`: register module + re-exports.
-- `userspace-dp/src/afxdp/tx.rs`: -550 LOC; extend cos:: imports.
+- `userspace-dp/src/afxdp/cos/queue_service.rs`: switch
+  `refresh_cos_interface_activity` import from `super::tx::` to
+  `super::tx_completion::` (or `super::` via cos/mod.rs re-export —
+  reviewer preference).
+- `userspace-dp/src/afxdp/tx.rs`: −600 LOC; extend the cos:: import
+  block.
 
 ## Tests
 
 No new tests required — pure structural refactor. Existing
-`tx::tests` callers reach moved items via the cos:: re-export
-chain — same Phase 1-8 pattern.
+`tx::tests` callers (tx.rs:10533, 10537, 10558, 10562, 10612, 10673,
+10737) reach moved items via the cos:: re-export chain through
+tx.rs's `use super::cos::{...}` line, which `mod tests { use super::*; }`
+imports transitively. Same Phase 1-8 pattern.
+
+If any test reaches an item whose `pub(in crate::afxdp)` visibility is
+not enough (e.g. wants direct fn-private access), it will fail to
+compile — at which point we either (a) bump the item's visibility (no
+real cost), or (b) move the test to `cos/tx_completion.rs` alongside
+its target. v2 expects no such test to exist.
 
 ## Risk
 
-**Low-medium.** ~550 LOC. Hot-path concerns:
+**Low-medium.** ~600 LOC. Hot-path concerns:
 
-- `apply_cos_send_result` / `apply_cos_prepared_result` fire per
-  batch (~hundreds of times per drain cycle). `#[inline]` preserves
-  cross-module inlining per Phase 4-8 lesson.
+- `apply_cos_send_result` / `apply_cos_prepared_result` /
+  `refresh_cos_interface_activity` fire per batch. Cross-module
+  `#[inline]` preserves the inlining boundary per Phase 4-8 lesson.
 - `cos_tick_for_ns` is a one-liner; cross-module move + `#[inline]`
-  should be free.
+  is free.
 - Timer-wheel functions (`advance_cos_timer_wheel`,
-  `cascade_*_level1`, `wake_due_*`) fire on each drain cycle but
-  only hit the slow path when timer slots have queued queues. No
-  per-byte overhead concern.
+  `cascade_*_level1`, `wake_due_*`) fire on each drain cycle but only
+  hit the slow path when timer slots have queued queues. No per-byte
+  overhead concern.
 
 Atomic ordering: `apply_cos_send_result` advances queue state and
-calls `publish_committed_queue_vtime` (cos/queue_ops.rs) — that
-fn's Release ordering is preserved by the move (already-extracted
-publish_* doesn't change).
+calls `publish_committed_queue_vtime` (cos/queue_ops.rs) — that fn's
+Release ordering is preserved by the move (already-extracted
+publish_* doesn't change). `Ordering::Release` / `Ordering::Acquire`
+explicitly imported from `std::sync::atomic`.
 
-After this PR, every `pub(in crate::afxdp)` visibility bump in
-tx.rs from Phases 6/7/8 except those tied to XSK-ring helpers (#984
-scope) is cleaned up.
+After this PR, every `pub(in crate::afxdp)` visibility bump from
+Phases 6/7/8 except those tied to XSK-ring helpers (#984 scope) is
+cleaned up.
 
 ## Acceptance
 

--- a/docs/pr/p1-tx-completion/plan.md
+++ b/docs/pr/p1-tx-completion/plan.md
@@ -1,7 +1,41 @@
 # P1: extract cos/tx_completion.rs from tx.rs
 
-Plan v3 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
+Plan v4 — 2026-04-30. First PR after #956's 8-phase cos/ submodule
 decomposition merged at PR #983.
+
+## v4 changelog vs v3 (from Codex round-3)
+
+- R3-B1 [BLOCKER]: `tx_completion.rs` import block was still wrong.
+  `maybe_top_up_cos_root_lease` and `release_cos_root_lease` live in
+  `cos/token_bucket.rs` (lines 52, 164), not `cos/queue_service.rs`.
+  And the v3 block listed unused imports (`ParkReason`,
+  `count_park_reason`, `PreparedTxRecycle`, `CoSTimerWheelRuntime`,
+  several `queue_ops` items, the entire `crate::afxdp::tx::{...}`
+  back-edge block). Plan v4 import block reconciled by reading the
+  moved-fn bodies symbol-by-symbol.
+- R3-B2 [BLOCKER]: "every Phase 6/7/8 back-edge closed" was overstated.
+  Plan v4 narrows the claim: P1 closes the **Phase 6 builder edge**
+  (`cos/builders.rs -> tx::cos_tick_for_ns`) AND the
+  **TX-completion / timer-wheel subset of Phase 7 deferrals** (the 10
+  symbols moved out of queue_service.rs's tx import block). Phase 7's
+  XSK-ring helpers (transmit_*, reap_tx_completions, etc.) and Phase
+  8's `cross_binding -> tx::recycle_prepared_immediately` edge stay,
+  scoped to #984.
+- R3-M1 [MINOR]: `advance_cos_timer_wheel` reclassified. It has NO
+  queue_service production caller — only the moving
+  `prime_cos_root_for_service` (tx.rs:1135) and tests
+  (tx.rs:10533/10537/10558/10562). Visibility stays
+  `pub(in crate::afxdp)` for the test-only access; the rationale text
+  is corrected (was: "queue_service caller", actual: "test-visible +
+  internally used by moved cluster").
+- R3-M2 [MINOR]: atomic-ordering paragraph rewritten. Moved
+  `apply_cos_send_result` body does NOT call
+  `publish_committed_queue_vtime` — that callsite is in
+  `queue_service.rs` (lines 770/920/1076/1229), which is NOT moving.
+  The Release/Acquire boundary stays inside `queue_service` /
+  `queue_ops`. The moved `apply_*` bodies only touch existing
+  `Ordering::Relaxed` counters (per-byte / per-packet
+  `fetch_add`s) — no cross-thread happens-before changes.
 
 ## v3 changelog vs v2 (from Codex round-2)
 
@@ -50,14 +84,22 @@ decomposition merged at PR #983.
 
 Move the TX-completion + timer-wheel cluster from tx.rs into
 `userspace-dp/src/afxdp/cos/tx_completion.rs`. After this PR:
-- Every cos→tx back-edge introduced by #956 Phases 6/7/8 is closed.
-- `cos/queue_service.rs` no longer imports any of the 10 moving symbols
-  from `crate::afxdp::tx`.
-- `cos/builders.rs` no longer imports `cos_tick_for_ns` from tx.
+- The **Phase 6 builder edge** (`cos/builders.rs -> tx::cos_tick_for_ns`)
+  is closed.
+- The **TX-completion / timer-wheel subset of the Phase 7 back-edge
+  cluster** is closed: 10 of the 18 symbols imported by
+  `cos/queue_service.rs` from `crate::afxdp::tx::` move to
+  `super::tx_completion::`.
 
-Remaining cos→tx back-edges after P1 are XSK-ring / worker-binding /
-prepared-frame primitives (transmit_*, reap_tx_completions, maybe_wake_tx,
-recycle_*), slated for #984 (afxdp/tx/ split).
+Remaining (NOT in P1 scope):
+- Phase 7's XSK-ring / worker-binding / per-byte primitives
+  (`maybe_wake_tx`, `reap_tx_completions`, `transmit_*`,
+  `recycle_cancelled_prepared_offset`, `remember_prepared_recycle`,
+  `stamp_submits`, `cos_queue_dscp_rewrite`, `TxError`, the
+  guarantee/quantum constants).
+- Phase 8's `cross_binding -> tx::recycle_prepared_immediately`.
+
+All deferred to #984 (afxdp/tx/ split).
 
 ## Move list (19 fns + 2 constants)
 
@@ -100,19 +142,26 @@ recycle_*), slated for #984 (afxdp/tx/ split).
 outside `cos/tx_completion.rs`:
 
 Constants (1):
-- `COS_TIMER_WHEEL_TICK_NS` — tests at tx.rs:10533, 10537, 10558, 10562
+- `COS_TIMER_WHEEL_TICK_NS` — tests at tx.rs:10533, 10537, 10558, 10562.
 
 Functions (13):
-- 11 with cos/queue_service.rs callers (most named in queue_service.rs:59-65):
+- 10 with cos/queue_service.rs production callers (verified against
+  queue_service.rs:59-65 import list AND actual usage):
   `prime_cos_root_for_service`, `apply_direct_exact_send_result`,
   `apply_cos_send_result`, `apply_cos_prepared_result`,
   `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`,
   `count_tx_ring_full_submit_stall`, `refresh_cos_interface_activity`,
-  `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`,
-  `advance_cos_timer_wheel`.
+  `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`.
 - 1 with cos/builders.rs caller: `cos_tick_for_ns` (already counted).
-- 1 with tx.rs production caller: `mark_cos_queue_runnable` (tx.rs:2080).
-- 1 with test caller: `normalize_cos_queue_state` (tx.rs:10612).
+- 1 with tx.rs production caller: `mark_cos_queue_runnable` (tx.rs:2080
+  inside `enqueue_cos_item`, NOT moving).
+- 1 with test caller only: `normalize_cos_queue_state` (tx.rs:10612).
+- 1 with test caller + internal-to-cluster only:
+  `advance_cos_timer_wheel` — sole production caller is the moving
+  `prime_cos_root_for_service` at tx.rs:1135; tests at tx.rs:10533,
+  10537, 10558, 10562. NOT a queue_service item — visibility is
+  `pub(in crate::afxdp)` purely for the test-only and (post-move)
+  intra-cluster reach via `cos/mod.rs` re-export.
 
 File-private (5 fns + 1 const) — only callers are co-located in the
 move set:
@@ -149,9 +198,10 @@ Not inlined (off per-byte path; preserve existing attributes):
 (Round-3 reviewer: verify which of these already carry `#[inline]` and
 preserve them — never silently downgrade.)
 
-## Imports for cos/tx_completion.rs (source-verified)
+## Imports for cos/tx_completion.rs (source-verified, v4)
 
-Reconciled against the moved-fn bodies (tx.rs:1127-1422, 2114-2310):
+Reconciled symbol-by-symbol against the moved-fn bodies (tx.rs:1127-1207,
+1266-1422, 2114-2156, 2159-2218, 2220-2283, 2285-2312):
 
 ```rust
 use std::collections::VecDeque;
@@ -159,32 +209,36 @@ use std::sync::atomic::Ordering;
 
 use crate::afxdp::types::{
     CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
-    CoSTimerWheelRuntime, PreparedTxRequest, PreparedTxRecycle,
-    TxRequest, COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
+    PreparedTxRequest, TxRequest,
+    COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
 };
-use crate::afxdp::worker::BindingWorker;     // worker.rs:13
+use crate::afxdp::worker::BindingWorker;        // worker.rs:13
 
-use super::queue_ops::{
-    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop,
-    cos_queue_drain_all, cos_queue_is_empty, cos_queue_pop_front,
-    cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
-    publish_committed_queue_vtime,
-};
-use super::queue_service::{
-    count_park_reason, maybe_top_up_cos_root_lease, park_cos_queue,
-    release_cos_root_lease, CoSServicePhase, ParkReason,
-};
-
-// Back-edges remaining to tx.rs (slated for #984 — afxdp/tx/ split):
-use crate::afxdp::tx::{
-    maybe_wake_tx, reap_tx_completions, recycle_cancelled_prepared_offset,
-    recycle_prepared_immediately, transmit_batch, transmit_prepared_queue,
+use super::queue_ops::{cos_queue_is_empty, cos_queue_push_front};
+use super::queue_service::{park_cos_queue, CoSServicePhase};
+use super::token_bucket::{
+    maybe_top_up_cos_root_lease, release_cos_root_lease,
 };
 ```
 
-(Round-3 reviewers: verify the exact list against the moved bodies
-once written; this is the upper bound. Unused imports trigger build
-warnings.)
+NOT imported (verified absent from moved bodies):
+- `crate::afxdp::tx::*` — the moved bodies do NOT call any tx-resident
+  helper. There is **no remaining cos→tx import in tx_completion.rs**.
+- `CoSTimerWheelRuntime` (only `CoSInterfaceRuntime` is used directly;
+  the wheel is reached via `root.timer_wheel`).
+- `PreparedTxRecycle`, `ParkReason`, `count_park_reason`,
+  `publish_committed_queue_vtime` — not referenced.
+- `cos_item_len`, `cos_queue_clear_orphan_snapshot_after_drop`,
+  `cos_queue_drain_all`, `cos_queue_pop_front`, `cos_queue_push_back`,
+  `cos_queue_restore_front` — not referenced.
+
+`VecDeque` is used as the parameter type on the two
+`restore_cos_*_items_inner` fns; importing from `std::collections` is
+explicit per project style.
+
+(Round-4 reviewer: re-verify on the implementation diff. If the
+implementation discovers a needed symbol not in the list above, add it
+in v5; if a listed symbol turns out unused, drop it.)
 
 ## cos/queue_service.rs import migration
 
@@ -357,11 +411,13 @@ block in tx.rs. The cos/mod.rs re-export chain backs that import.
   hit the slow path when timer slots have queued queues. No per-byte
   overhead concern.
 
-Atomic ordering: `apply_cos_send_result` advances queue state and
-calls `publish_committed_queue_vtime` (cos/queue_ops.rs) — that fn's
-Release ordering is preserved by the move (already-extracted
-publish_* doesn't change). `Ordering::Release` / `Ordering::Acquire`
-explicitly imported from `std::sync::atomic`.
+Atomic ordering: the moved bodies only touch existing
+`Ordering::Relaxed` counters via `fetch_add` (drain_sent_bytes,
+sent_packets, etc.). They do NOT call `publish_committed_queue_vtime`
+— that callsite stays in `cos/queue_service.rs:770/920/1076/1229`
+which is NOT moving. The Release/Acquire publish boundary is
+unchanged by P1. `Ordering::Relaxed` is the only ordering symbol used
+inside tx_completion.rs.
 
 After this PR, every `pub(in crate::afxdp)` visibility bump from
 Phases 6/7/8 except those tied to XSK-ring helpers (#984 scope) is

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -10,11 +10,8 @@
 //     by `tx::tests`; pub(in crate::afxdp) plus cfg-gated
 //     re-export from cos/mod.rs.
 //
-// One back-edge: `cos/builders -> tx::cos_tick_for_ns` (timer-wheel
-// helper that depends on `COS_TIMER_WHEEL_TICK_NS` and friends).
-// Documented as drain-scheduler-phase forward-debt — the helper
-// + constants will move together when timer-wheel + drain-pacing
-// extraction lands.
+// `cos_tick_for_ns` moved to cos/tx_completion.rs in #956 P1; the
+// Phase-6 cos/builders -> tx back-edge is now closed.
 //
 // `apply_cos_queue_flow_fair_promotion` (cos/admission.rs) is
 // imported here. After this PR, ensure_cos_interface_runtime is
@@ -30,8 +27,8 @@ use crate::afxdp::types::{
 };
 use crate::afxdp::worker::BindingWorker;
 use crate::afxdp::TX_BATCH_SIZE;
-use crate::afxdp::tx::cos_tick_for_ns;
 use super::admission::apply_cos_queue_flow_fair_promotion;
+use super::tx_completion::cos_tick_for_ns;
 use super::COS_MIN_BURST_BYTES;
 
 #[inline]

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -77,10 +77,13 @@ pub(super) use tx_completion::{
     COS_TIMER_WHEEL_TICK_NS,
 };
 #[cfg(test)]
+pub(super) use tx_completion::{
+    count_park_reason, park_cos_queue, CoSServicePhase, ParkReason,
+};
+#[cfg(test)]
 pub(super) use queue_service::{
     assign_local_dscp_rewrite, cos_batch_tx_made_progress, cos_guarantee_quantum_bytes,
-    park_cos_queue, CoSServicePhase,
-    count_park_reason, drain_exact_local_fifo_items_to_scratch,
+    drain_exact_local_fifo_items_to_scratch,
     drain_exact_local_items_to_scratch_flow_fair, drain_exact_prepared_fifo_items_to_scratch,
     drain_exact_prepared_items_to_scratch_flow_fair, estimate_cos_queue_wakeup_tick,
     release_exact_local_scratch_frames, release_exact_prepared_scratch,
@@ -88,5 +91,5 @@ pub(super) use queue_service::{
     select_cos_surplus_batch, select_exact_cos_guarantee_queue_with_fast_path,
     select_nonexact_cos_guarantee_batch, settle_exact_local_fifo_submission,
     settle_exact_local_scratch_submission_flow_fair, settle_exact_prepared_fifo_submission,
-    CoSBatch, ExactCoSScratchBuild, ParkReason,
+    CoSBatch, ExactCoSScratchBuild,
 };

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -17,13 +17,13 @@ pub(super) mod flow_hash;
 pub(super) mod queue_ops;
 pub(super) mod queue_service;
 pub(super) mod token_bucket;
+pub(super) mod tx_completion;
 
 pub(super) use admission::{
     apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_queue_flow_share_limit,
 };
 pub(super) use builders::ensure_cos_interface_runtime;
 pub(super) use cross_binding::{
-    prepared_cos_request_stays_on_current_tx_binding, redirect_local_cos_request_to_owner,
     redirect_prepared_cos_request_to_owner, redirect_prepared_cos_request_to_owner_binding,
     resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
 };
@@ -35,12 +35,19 @@ pub(super) use queue_ops::{
     cos_queue_restore_front, cos_queue_v_min_consume_suspension, cos_queue_v_min_continue,
     publish_committed_queue_vtime,
 };
-pub(super) use queue_service::{drain_shaped_tx, park_cos_queue, CoSServicePhase};
+pub(super) use queue_service::drain_shaped_tx;
 pub(super) use token_bucket::{
-    cos_refill_ns_until, maybe_top_up_cos_queue_lease, maybe_top_up_cos_root_lease,
+    cos_refill_ns_until, maybe_top_up_cos_queue_lease,
     refill_cos_tokens, release_all_cos_queue_leases, release_all_cos_root_leases,
-    release_cos_root_lease, COS_MIN_BURST_BYTES,
+    COS_MIN_BURST_BYTES,
 };
+#[cfg(test)]
+pub(super) use token_bucket::{maybe_top_up_cos_root_lease, release_cos_root_lease};
+// tx.rs reaches `mark_cos_queue_runnable` via `super::cos::` for its
+// non-moving `enqueue_cos_item` path. Other production callers
+// (queue_service, builders) reach moved items directly via
+// `super::tx_completion::*`.
+pub(super) use tx_completion::mark_cos_queue_runnable;
 
 #[cfg(test)]
 pub(super) use admission::{
@@ -50,7 +57,10 @@ pub(super) use admission::{
 #[cfg(test)]
 pub(super) use builders::build_cos_interface_runtime;
 #[cfg(test)]
-pub(super) use cross_binding::redirect_local_cos_request_to_owner_binding;
+pub(super) use cross_binding::{
+    prepared_cos_request_stays_on_current_tx_binding, redirect_local_cos_request_to_owner,
+    redirect_local_cos_request_to_owner_binding,
+};
 #[cfg(test)]
 pub(super) use ecn::{maybe_mark_ecn_ce, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT};
 #[cfg(test)]
@@ -61,8 +71,15 @@ pub(super) use queue_ops::{
     V_MIN_CONSECUTIVE_SKIP_HARD_CAP, V_MIN_SUSPENSION_BATCHES,
 };
 #[cfg(test)]
+pub(super) use tx_completion::{
+    advance_cos_timer_wheel, normalize_cos_queue_state,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+    COS_TIMER_WHEEL_TICK_NS,
+};
+#[cfg(test)]
 pub(super) use queue_service::{
     assign_local_dscp_rewrite, cos_batch_tx_made_progress, cos_guarantee_quantum_bytes,
+    park_cos_queue, CoSServicePhase,
     count_park_reason, drain_exact_local_fifo_items_to_scratch,
     drain_exact_local_items_to_scratch_flow_fair, drain_exact_prepared_fifo_items_to_scratch,
     drain_exact_prepared_items_to_scratch_flow_fair, estimate_cos_queue_wakeup_tick,

--- a/userspace-dp/src/afxdp/cos/queue_service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service.rs
@@ -57,14 +57,18 @@ use super::{
     refill_cos_tokens, COS_MIN_BURST_BYTES,
 };
 
-// #956 P1: TX-completion + timer-wheel symbols moved to
-// cos/tx_completion.rs.
+// #956 P1: TX-completion + timer-wheel symbols + scheduling primitives
+// (CoSServicePhase, ParkReason, count_park_reason, park_cos_queue)
+// moved to cos/tx_completion.rs. Moving the scheduling primitives
+// breaks the previous cyclic queue_service <-> tx_completion module
+// dependency (Copilot review on PR #990).
 use super::tx_completion::{
     apply_cos_prepared_result, apply_cos_send_result,
     apply_direct_exact_send_result, cos_tick_for_ns,
-    cos_timer_wheel_level_and_slot, count_tx_ring_full_submit_stall,
-    prime_cos_root_for_service, refresh_cos_interface_activity,
-    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+    count_park_reason, count_tx_ring_full_submit_stall,
+    park_cos_queue, prime_cos_root_for_service, refresh_cos_interface_activity,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner, CoSServicePhase,
+    ParkReason,
 };
 // Remaining back-edges to tx.rs (XSK-ring / worker-binding /
 // prepared-frame primitives + TxError + guarantee/quantum constants —
@@ -76,12 +80,6 @@ use crate::afxdp::tx::{
     COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
     COS_GUARANTEE_VISIT_NS, COS_SURPLUS_ROUND_QUANTUM_BYTES,
 };
-
-#[derive(Clone, Copy)]
-pub(in crate::afxdp) enum CoSServicePhase {
-    Guarantee,
-    Surplus,
-}
 
 pub(in crate::afxdp) enum CoSBatch {
     Local {
@@ -2143,59 +2141,6 @@ pub(in crate::afxdp) fn estimate_cos_queue_wakeup_tick(
     Some(cos_tick_for_ns(wake_ns).max(cos_tick_for_ns(now_ns).saturating_add(1)))
 }
 
-// #710: park-reason classification used at every `park_cos_queue` call
-// site to attribute the wait to its upstream cause. `RootTokenStarvation`
-// means the interface-level shaper token bucket was empty; the queue
-// itself had work and tokens to send but the root could not admit more
-// bytes this tick. `QueueTokenStarvation` means the per-queue (exact)
-// token bucket was empty — the queue's own rate cap is the limiter.
-// Both are "parks" rather than "drops" because the timer wheel will
-// wake the queue when tokens refill; no packet is lost.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(in crate::afxdp) enum ParkReason {
-    RootTokenStarvation,
-    QueueTokenStarvation,
-}
-
-#[inline]
-pub(in crate::afxdp) fn count_park_reason(root: &mut CoSInterfaceRuntime, queue_idx: usize, reason: ParkReason) {
-    if let Some(queue) = root.queues.get_mut(queue_idx) {
-        match reason {
-            ParkReason::RootTokenStarvation => {
-                queue.drop_counters.root_token_starvation_parks = queue
-                    .drop_counters
-                    .root_token_starvation_parks
-                    .wrapping_add(1);
-            }
-            ParkReason::QueueTokenStarvation => {
-                queue.drop_counters.queue_token_starvation_parks = queue
-                    .drop_counters
-                    .queue_token_starvation_parks
-                    .wrapping_add(1);
-            }
-        }
-    }
-}
-
-pub(in crate::afxdp) fn park_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize, wake_tick: u64) {
-    let (level, slot) = cos_timer_wheel_level_and_slot(root.timer_wheel.current_tick, wake_tick);
-    let Some(queue) = root.queues.get_mut(queue_idx) else {
-        return;
-    };
-    if queue.runnable {
-        root.runnable_queues = root.runnable_queues.saturating_sub(1);
-    }
-    queue.runnable = false;
-    queue.parked = true;
-    queue.next_wakeup_tick = wake_tick;
-    queue.wheel_level = level;
-    queue.wheel_slot = slot;
-    if level == 0 {
-        root.timer_wheel.level0[slot].push(queue_idx);
-    } else {
-        root.timer_wheel.level1[slot].push(queue_idx);
-    }
-}
 
 #[inline]
 pub(in crate::afxdp) fn assign_local_dscp_rewrite(items: &mut VecDeque<TxRequest>, queue_dscp_rewrite: Option<u8>) {

--- a/userspace-dp/src/afxdp/cos/queue_service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service.rs
@@ -20,13 +20,17 @@
 // LLVM's heuristic threshold should cover them; revisit only if a
 // post-merge perf regression points at one.
 //
-// Back-edges to tx.rs are deferred TX-completion + worker-binding
-// helpers (apply_cos_*_result, restore_cos_*_inner,
-// prime_cos_root_for_service, advance_cos_timer_wheel, transmit_*,
-// reap_tx_completions, refresh_cos_interface_activity, etc).
-// Visibility on those bumped to pub(in crate::afxdp) in tx.rs as
-// part of this PR. They will move with the future TX-completion
-// extraction.
+// TX-completion + timer-wheel back-edges (apply_cos_*_result,
+// restore_cos_*_inner, prime_cos_root_for_service,
+// refresh_cos_interface_activity, cos_tick_for_ns +
+// cos_timer_wheel_level_and_slot + count_tx_ring_full_submit_stall)
+// moved to cos/tx_completion.rs in #956 P1.
+//
+// Remaining back-edges to crate::afxdp::tx are XSK-ring /
+// worker-binding / prepared-frame primitives (transmit_*,
+// reap_tx_completions, maybe_wake_tx, recycle_*, stamp_submits,
+// cos_queue_dscp_rewrite, TxError, the guarantee/quantum constants).
+// Those move with the afxdp/tx/ split in #984.
 
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
@@ -53,17 +57,23 @@ use super::{
     refill_cos_tokens, COS_MIN_BURST_BYTES,
 };
 
-// Back-edges to tx.rs (Phase 7 deferrals — TX-completion + worker-
-// binding family). Visibility bumped to pub(in crate::afxdp) so this
-// module can reach them.
-use crate::afxdp::tx::{
+// #956 P1: TX-completion + timer-wheel symbols moved to
+// cos/tx_completion.rs.
+use super::tx_completion::{
     apply_cos_prepared_result, apply_cos_send_result,
-    apply_direct_exact_send_result, cos_queue_dscp_rewrite, cos_tick_for_ns,
-    cos_timer_wheel_level_and_slot, count_tx_ring_full_submit_stall, maybe_wake_tx,
-    prime_cos_root_for_service, reap_tx_completions, recycle_cancelled_prepared_offset,
-    refresh_cos_interface_activity, remember_prepared_recycle, restore_cos_local_items_inner,
-    restore_cos_prepared_items_inner, stamp_submits, transmit_batch, transmit_prepared_queue,
-    TxError, COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
+    apply_direct_exact_send_result, cos_tick_for_ns,
+    cos_timer_wheel_level_and_slot, count_tx_ring_full_submit_stall,
+    prime_cos_root_for_service, refresh_cos_interface_activity,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+};
+// Remaining back-edges to tx.rs (XSK-ring / worker-binding /
+// prepared-frame primitives + TxError + guarantee/quantum constants —
+// deferred to #984 / afxdp/tx/ split).
+use crate::afxdp::tx::{
+    cos_queue_dscp_rewrite, maybe_wake_tx, reap_tx_completions,
+    recycle_cancelled_prepared_offset, remember_prepared_recycle, stamp_submits,
+    transmit_batch, transmit_prepared_queue, TxError,
+    COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
     COS_GUARANTEE_VISIT_NS, COS_SURPLUS_ROUND_QUANTUM_BYTES,
 };
 

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -29,8 +29,83 @@ use crate::afxdp::types::{
 use crate::afxdp::worker::BindingWorker;
 
 use super::queue_ops::{cos_queue_is_empty, cos_queue_push_front};
-use super::queue_service::{park_cos_queue, CoSServicePhase};
 use super::token_bucket::{maybe_top_up_cos_root_lease, release_cos_root_lease};
+
+// ============================================================================
+// Service phase + park-reason types
+// ============================================================================
+
+/// Drain phases the scheduler walks through per tick. `Guarantee`
+/// services queues against their per-queue token bucket; `Surplus`
+/// distributes remaining root-bucket bytes across runnable queues
+/// using deficit round-robin.
+#[derive(Clone, Copy)]
+pub(in crate::afxdp) enum CoSServicePhase {
+    Guarantee,
+    Surplus,
+}
+
+// #710: park-reason classification used at every `park_cos_queue` call
+// site to attribute the wait to its upstream cause. `RootTokenStarvation`
+// means the interface-level shaper token bucket was empty; the queue
+// itself had work and tokens to send but the root could not admit more
+// bytes this tick. `QueueTokenStarvation` means the per-queue (exact)
+// token bucket was empty — the queue's own rate cap is the limiter.
+// Both are "parks" rather than "drops" because the timer wheel will
+// wake the queue when tokens refill; no packet is lost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) enum ParkReason {
+    RootTokenStarvation,
+    QueueTokenStarvation,
+}
+
+#[inline]
+pub(in crate::afxdp) fn count_park_reason(
+    root: &mut CoSInterfaceRuntime,
+    queue_idx: usize,
+    reason: ParkReason,
+) {
+    if let Some(queue) = root.queues.get_mut(queue_idx) {
+        match reason {
+            ParkReason::RootTokenStarvation => {
+                queue.drop_counters.root_token_starvation_parks = queue
+                    .drop_counters
+                    .root_token_starvation_parks
+                    .wrapping_add(1);
+            }
+            ParkReason::QueueTokenStarvation => {
+                queue.drop_counters.queue_token_starvation_parks = queue
+                    .drop_counters
+                    .queue_token_starvation_parks
+                    .wrapping_add(1);
+            }
+        }
+    }
+}
+
+pub(in crate::afxdp) fn park_cos_queue(
+    root: &mut CoSInterfaceRuntime,
+    queue_idx: usize,
+    wake_tick: u64,
+) {
+    let (level, slot) = cos_timer_wheel_level_and_slot(root.timer_wheel.current_tick, wake_tick);
+    let Some(queue) = root.queues.get_mut(queue_idx) else {
+        return;
+    };
+    if queue.runnable {
+        root.runnable_queues = root.runnable_queues.saturating_sub(1);
+    }
+    queue.runnable = false;
+    queue.parked = true;
+    queue.next_wakeup_tick = wake_tick;
+    queue.wheel_level = level;
+    queue.wheel_slot = slot;
+    if level == 0 {
+        root.timer_wheel.level0[slot].push(queue_idx);
+    } else {
+        root.timer_wheel.level1[slot].push(queue_idx);
+    }
+}
 
 // ============================================================================
 // Constants

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -1,0 +1,496 @@
+// #956 P1 (PR following #983): TX-completion + timer-wheel cluster
+// extracted from tx.rs.
+//
+// This module owns:
+//   - The CoS interface timer wheel (advance / cascade / wake-due
+//     slot management + the COS_TIMER_WHEEL_TICK_NS / horizon
+//     constants).
+//   - The TX-completion apply path (apply_direct_exact_send_result,
+//     apply_cos_send_result, apply_cos_prepared_result) and the
+//     refresh / restore helpers they use.
+//   - prime_cos_root_for_service (single drain-cycle entry called by
+//     queue_service before each service pass).
+//
+// Closes the Phase 6 builder back-edge (cos/builders.rs ->
+// tx::cos_tick_for_ns) and the TX-completion / timer-wheel subset of
+// the Phase 7 deferrals (10 of the 18 fns imported by
+// cos/queue_service.rs from crate::afxdp::tx::). The remaining 8 fns
+// + TxError + 4 guarantee/quantum constants stay on
+// crate::afxdp::tx, deferred to #984 (afxdp/tx/ split).
+
+use std::collections::VecDeque;
+use std::sync::atomic::Ordering;
+
+use crate::afxdp::types::{
+    CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
+    PreparedTxRequest, TxRequest,
+    COS_TIMER_WHEEL_L0_SLOTS, COS_TIMER_WHEEL_L1_SLOTS,
+};
+use crate::afxdp::worker::BindingWorker;
+
+use super::queue_ops::{cos_queue_is_empty, cos_queue_push_front};
+use super::queue_service::{park_cos_queue, CoSServicePhase};
+use super::token_bucket::{maybe_top_up_cos_root_lease, release_cos_root_lease};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+pub(in crate::afxdp) const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
+const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
+
+// ============================================================================
+// Timer-wheel cluster
+// ============================================================================
+
+#[inline]
+pub(in crate::afxdp) fn cos_tick_for_ns(now_ns: u64) -> u64 {
+    now_ns / COS_TIMER_WHEEL_TICK_NS
+}
+
+#[inline]
+pub(in crate::afxdp) fn cos_timer_wheel_level_and_slot(
+    current_tick: u64,
+    wake_tick: u64,
+) -> (u8, usize) {
+    if wake_tick.saturating_sub(current_tick) < COS_TIMER_WHEEL_L0_HORIZON_TICKS {
+        (0, (wake_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize)
+    } else {
+        (
+            1,
+            ((wake_tick / COS_TIMER_WHEEL_L0_SLOTS as u64) % COS_TIMER_WHEEL_L1_SLOTS as u64)
+                as usize,
+        )
+    }
+}
+
+fn wake_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize) {
+    let Some(queue) = root.queues.get_mut(queue_idx) else {
+        return;
+    };
+    if cos_queue_is_empty(queue) {
+        queue.runnable = false;
+        queue.parked = false;
+        queue.next_wakeup_tick = 0;
+        return;
+    }
+    if !queue.runnable {
+        root.runnable_queues = root.runnable_queues.saturating_add(1);
+    }
+    mark_cos_queue_runnable(queue);
+}
+
+// #710: count an exact-drain TX submit stall on a specific queue.
+// NOT packet loss — on the exact path, `writer.insert == 0` leaves
+// the FIFO items in `queue.items` or restores them (flow-fair path);
+// frames that had been copied into UMEM are released back to
+// `free_tx_frames`, and the items get another chance next drain tick.
+// The counter signals TX-ring / completion-reap pressure, which is
+// an upstream cause for the downstream effects operators chase
+// (#706 mutex contention, #709 owner-worker hotspot).
+//
+// Non-exact transmit paths (`transmit_batch`, `transmit_prepared_queue`)
+// do not carry queue identity at the submit site and do not reach
+// this helper. Their frame-level failures are counted in the binding-
+// level `tx_submit_error_drops` counter instead.
+#[inline]
+pub(in crate::afxdp) fn count_tx_ring_full_submit_stall(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    queue_idx: usize,
+    stalled_packets: u64,
+) {
+    if stalled_packets == 0 {
+        return;
+    }
+    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+        if let Some(queue) = root.queues.get_mut(queue_idx) {
+            queue.drop_counters.tx_ring_full_submit_stalls = queue
+                .drop_counters
+                .tx_ring_full_submit_stalls
+                .wrapping_add(stalled_packets);
+        }
+    }
+}
+
+fn rearm_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize, wake_tick: u64) {
+    park_cos_queue(root, queue_idx, wake_tick);
+}
+
+#[inline]
+pub(in crate::afxdp) fn mark_cos_queue_runnable(queue: &mut CoSQueueRuntime) {
+    queue.runnable = true;
+    queue.parked = false;
+    queue.next_wakeup_tick = 0;
+}
+
+#[inline]
+pub(in crate::afxdp) fn normalize_cos_queue_state(queue: &mut CoSQueueRuntime) {
+    if cos_queue_is_empty(queue) {
+        queue.runnable = false;
+        queue.parked = false;
+        queue.next_wakeup_tick = 0;
+        queue.surplus_deficit = 0;
+        return;
+    }
+    // Non-empty queues have only two valid steady states:
+    // 1. parked with a wakeup tick
+    // 2. runnable immediately
+    // Anything else can strand backlog forever.
+    if queue.parked && queue.next_wakeup_tick > 0 {
+        queue.runnable = false;
+        return;
+    }
+    mark_cos_queue_runnable(queue);
+}
+
+#[inline]
+pub(in crate::afxdp) fn advance_cos_timer_wheel(root: &mut CoSInterfaceRuntime, now_ns: u64) {
+    let now_tick = cos_tick_for_ns(now_ns);
+    while root.timer_wheel.current_tick < now_tick {
+        root.timer_wheel.current_tick = root.timer_wheel.current_tick.saturating_add(1);
+        if root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64 == 0 {
+            cascade_cos_timer_wheel_level1(root);
+        }
+        wake_due_cos_timer_slot(root);
+    }
+}
+
+fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {
+    let slot = ((root.timer_wheel.current_tick / COS_TIMER_WHEEL_L0_SLOTS as u64)
+        % COS_TIMER_WHEEL_L1_SLOTS as u64) as usize;
+    let queued = core::mem::take(&mut root.timer_wheel.level1[slot]);
+    let mut rearm = Vec::with_capacity(queued.len());
+    for queue_idx in queued {
+        let Some(queue) = root.queues.get(queue_idx) else {
+            continue;
+        };
+        if !queue.parked || queue.wheel_level != 1 || queue.wheel_slot != slot {
+            continue;
+        }
+        rearm.push((queue_idx, queue.next_wakeup_tick));
+    }
+    for (queue_idx, wake_tick) in rearm {
+        rearm_cos_queue(root, queue_idx, wake_tick);
+    }
+}
+
+fn wake_due_cos_timer_slot(root: &mut CoSInterfaceRuntime) {
+    let slot = (root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize;
+    let queued = core::mem::take(&mut root.timer_wheel.level0[slot]);
+    let mut rearm = Vec::with_capacity(queued.len());
+    let mut wake = Vec::with_capacity(queued.len());
+    for queue_idx in queued {
+        let Some(queue) = root.queues.get(queue_idx) else {
+            continue;
+        };
+        if !queue.parked || queue.wheel_level != 0 || queue.wheel_slot != slot {
+            continue;
+        }
+        if queue.next_wakeup_tick <= root.timer_wheel.current_tick {
+            wake.push(queue_idx);
+        } else {
+            rearm.push((queue_idx, queue.next_wakeup_tick));
+        }
+    }
+    for queue_idx in wake {
+        wake_cos_queue(root, queue_idx);
+    }
+    for (queue_idx, wake_tick) in rearm {
+        rearm_cos_queue(root, queue_idx, wake_tick);
+    }
+}
+
+// ============================================================================
+// TX-completion cluster
+// ============================================================================
+
+#[inline]
+pub(in crate::afxdp) fn prime_cos_root_for_service(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    now_ns: u64,
+) -> bool {
+    let shared_root_lease = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.clone());
+    let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+        return false;
+    };
+    advance_cos_timer_wheel(root, now_ns);
+    if let Some(shared_root_lease) = shared_root_lease.as_ref() {
+        maybe_top_up_cos_root_lease(root, shared_root_lease, now_ns);
+    }
+    true
+}
+
+#[inline]
+pub(in crate::afxdp) fn apply_direct_exact_send_result(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    queue_idx: usize,
+    sent_packets: u64,
+    sent_bytes: u64,
+) {
+    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+        if let Some(queue) = root.queues.get_mut(queue_idx) {
+            queue.queued_bytes = queue.queued_bytes.saturating_sub(sent_bytes);
+            queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+            // #760 instrumentation: record the exact-owner-local
+            // send at the same place the token bucket decrements.
+            // Divide by a scrape window to get an observed per-queue
+            // drain rate and compare against
+            // `queue.transmit_rate_bytes` to detect a cap bypass.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
+        }
+        root.tokens = root.tokens.saturating_sub(sent_bytes);
+    }
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
+        shared_root_lease.consume(sent_bytes);
+    }
+    if let Some(shared_queue_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+        .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+    {
+        shared_queue_lease.consume(sent_bytes);
+    }
+    refresh_cos_interface_activity(binding, root_ifindex);
+    if sent_packets > 0 {
+        binding
+            .live
+            .tx_packets
+            .fetch_add(sent_packets, Ordering::Relaxed);
+        binding
+            .live
+            .tx_bytes
+            .fetch_add(sent_bytes, Ordering::Relaxed);
+        // #760 instrumentation, exact-owner-local path. Paired with
+        // tx_bytes unconditionally — if the per-queue drain_sent_bytes
+        // above (guarded by `if let Some(queue)`) ever undercounts
+        // this, the gap is an `apply_*` early-return / queue-miss.
+        binding
+            .live
+            .owner_profile_owner
+            .drain_sent_bytes_shaped_unconditional
+            .fetch_add(sent_bytes, Ordering::Relaxed);
+    }
+}
+
+#[inline]
+pub(in crate::afxdp) fn refresh_cos_interface_activity(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+) {
+    let mut new_nonempty = 0usize;
+    let mut new_runnable = 0usize;
+    let mut released_queue_leases = Vec::<(usize, u64)>::new();
+    let old_nonempty = binding
+        .cos_interfaces
+        .get(&root_ifindex)
+        .map(|root| root.nonempty_queues)
+        .unwrap_or(0);
+    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+        for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
+            normalize_cos_queue_state(queue);
+            if cos_queue_is_empty(queue) && queue.exact && queue.tokens > 0 {
+                released_queue_leases.push((queue_idx, core::mem::take(&mut queue.tokens)));
+            }
+            if cos_queue_is_empty(queue) {
+                continue;
+            }
+            new_nonempty = new_nonempty.saturating_add(1);
+            if queue.runnable {
+                new_runnable = new_runnable.saturating_add(1);
+            }
+        }
+        root.nonempty_queues = new_nonempty;
+        root.runnable_queues = new_runnable;
+    }
+    if old_nonempty == 0 && new_nonempty > 0 {
+        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_add(1);
+    } else if old_nonempty > 0 && new_nonempty == 0 {
+        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_sub(1);
+        release_cos_root_lease(binding, root_ifindex);
+    }
+    if let Some(iface_fast) = binding.cos_fast_interfaces.get(&root_ifindex) {
+        for (queue_idx, released) in released_queue_leases {
+            if let Some(shared_queue_lease) = iface_fast
+                .queue_fast_path
+                .get(queue_idx)
+                .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+            {
+                shared_queue_lease.release_unused(released);
+            }
+        }
+    }
+}
+
+#[inline]
+pub(in crate::afxdp) fn apply_cos_send_result(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    queue_idx: usize,
+    phase: CoSServicePhase,
+    batch_bytes: u64,
+    sent_bytes: u64,
+    retry: VecDeque<TxRequest>,
+) {
+    let mut exact_queue_idx = None;
+    {
+        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+            return;
+        };
+        if let Some(queue) = root.queues.get_mut(queue_idx) {
+            exact_queue_idx = queue.exact.then_some(queue_idx);
+            let retry_bytes = restore_cos_local_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
+            match phase {
+                CoSServicePhase::Guarantee => {
+                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+                }
+                CoSServicePhase::Surplus => {
+                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
+                }
+            }
+            // #760 instrumentation: record non-exact / surplus /
+            // shared-exact sends at the same site the queue's token
+            // or surplus accounting is debited. Paired with the
+            // apply_direct_exact_send_result write so the sum across
+            // all sites equals the bytes the CoS scheduler accounted.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
+        }
+        root.tokens = root.tokens.saturating_sub(sent_bytes);
+    }
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
+        shared_root_lease.consume(sent_bytes);
+    }
+    if let Some(queue_idx) = exact_queue_idx {
+        if let Some(shared_queue_lease) = binding
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+        {
+            shared_queue_lease.consume(sent_bytes);
+        }
+    }
+    refresh_cos_interface_activity(binding, root_ifindex);
+}
+
+#[inline]
+pub(in crate::afxdp) fn apply_cos_prepared_result(
+    binding: &mut BindingWorker,
+    root_ifindex: i32,
+    queue_idx: usize,
+    phase: CoSServicePhase,
+    batch_bytes: u64,
+    sent_bytes: u64,
+    retry: VecDeque<PreparedTxRequest>,
+) {
+    let mut exact_queue_idx = None;
+    {
+        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+            return;
+        };
+        if let Some(queue) = root.queues.get_mut(queue_idx) {
+            exact_queue_idx = queue.exact.then_some(queue_idx);
+            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
+            queue.queued_bytes = queue
+                .queued_bytes
+                .saturating_sub(batch_bytes)
+                .saturating_add(retry_bytes);
+            match phase {
+                CoSServicePhase::Guarantee => {
+                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
+                }
+                CoSServicePhase::Surplus => {
+                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
+                }
+            }
+            // #760 instrumentation, the FOURTH apply_* site. This is
+            // the prepared-batch path (CoSBatch::Prepared, in-place
+            // rewrite — the common case for forwarded traffic). The
+            // initial instrumentation commit missed this site; the
+            // first 120 s iperf3 measurement showed only ~987 Mbps
+            // on drain_sent_bytes while the receiver reported 1.55
+            // Gbps, leaving ~563 Mbps unaccounted — all of it
+            // flowing through this path. Same Relaxed semantics as
+            // the other three apply_* sites.
+            queue
+                .owner_profile
+                .drain_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
+        }
+        root.tokens = root.tokens.saturating_sub(sent_bytes);
+    }
+    if let Some(shared_root_lease) = binding
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
+    {
+        shared_root_lease.consume(sent_bytes);
+    }
+    if let Some(queue_idx) = exact_queue_idx {
+        if let Some(shared_queue_lease) = binding
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+        {
+            shared_queue_lease.consume(sent_bytes);
+        }
+    }
+    refresh_cos_interface_activity(binding, root_ifindex);
+}
+
+#[inline]
+pub(in crate::afxdp) fn restore_cos_local_items_inner(
+    queue: &mut CoSQueueRuntime,
+    mut retry: VecDeque<TxRequest>,
+) -> u64 {
+    let mut retry_bytes = 0u64;
+    while let Some(req) = retry.pop_back() {
+        retry_bytes = retry_bytes.saturating_add(req.bytes.len() as u64);
+        cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
+    }
+    if !cos_queue_is_empty(queue) {
+        mark_cos_queue_runnable(queue);
+    }
+    retry_bytes
+}
+
+#[inline]
+pub(in crate::afxdp) fn restore_cos_prepared_items_inner(
+    queue: &mut CoSQueueRuntime,
+    mut retry: VecDeque<PreparedTxRequest>,
+) -> u64 {
+    let mut retry_bytes = 0u64;
+    while let Some(req) = retry.pop_back() {
+        retry_bytes = retry_bytes.saturating_add(req.len as u64);
+        cos_queue_push_front(queue, CoSPendingTxItem::Prepared(req));
+    }
+    if !cos_queue_is_empty(queue) {
+        mark_cos_queue_runnable(queue);
+    }
+    retry_bytes
+}

--- a/userspace-dp/src/afxdp/tx.rs
+++ b/userspace-dp/src/afxdp/tx.rs
@@ -1124,87 +1124,12 @@ fn ingest_cos_pending_tx_with_provenance(
     bound_pending_tx_local(binding);
 }
 
-pub(in crate::afxdp) fn prime_cos_root_for_service(binding: &mut BindingWorker, root_ifindex: i32, now_ns: u64) -> bool {
-    let shared_root_lease = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.clone());
-    let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
-        return false;
-    };
-    advance_cos_timer_wheel(root, now_ns);
-    if let Some(shared_root_lease) = shared_root_lease.as_ref() {
-        maybe_top_up_cos_root_lease(root, shared_root_lease, now_ns);
-    }
-    true
-}
 
-pub(in crate::afxdp) fn apply_direct_exact_send_result(
-    binding: &mut BindingWorker,
-    root_ifindex: i32,
-    queue_idx: usize,
-    sent_packets: u64,
-    sent_bytes: u64,
-) {
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
-        if let Some(queue) = root.queues.get_mut(queue_idx) {
-            queue.queued_bytes = queue.queued_bytes.saturating_sub(sent_bytes);
-            queue.tokens = queue.tokens.saturating_sub(sent_bytes);
-            // #760 instrumentation: record the exact-owner-local
-            // send at the same place the token bucket decrements.
-            // Divide by a scrape window to get an observed per-queue
-            // drain rate and compare against
-            // `queue.transmit_rate_bytes` to detect a cap bypass.
-            queue
-                .owner_profile
-                .drain_sent_bytes
-                .fetch_add(sent_bytes, Ordering::Relaxed);
-        }
-        root.tokens = root.tokens.saturating_sub(sent_bytes);
-    }
-    if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
-    {
-        shared_root_lease.consume(sent_bytes);
-    }
-    if let Some(shared_queue_lease) = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
-        .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
-    {
-        shared_queue_lease.consume(sent_bytes);
-    }
-    refresh_cos_interface_activity(binding, root_ifindex);
-    if sent_packets > 0 {
-        binding
-            .live
-            .tx_packets
-            .fetch_add(sent_packets, Ordering::Relaxed);
-        binding
-            .live
-            .tx_bytes
-            .fetch_add(sent_bytes, Ordering::Relaxed);
-        // #760 instrumentation, exact-owner-local path. Paired with
-        // tx_bytes unconditionally — if the per-queue drain_sent_bytes
-        // above (guarded by `if let Some(queue)`) ever undercounts
-        // this, the gap is an `apply_*` early-return / queue-miss.
-        binding
-            .live
-            .owner_profile_owner
-            .drain_sent_bytes_shaped_unconditional
-            .fetch_add(sent_bytes, Ordering::Relaxed);
-    }
-}
 
-const COS_TIMER_WHEEL_TICK_NS: u64 = 50_000;
 pub(in crate::afxdp) const COS_GUARANTEE_VISIT_NS: u64 = 200_000;
 pub(in crate::afxdp) const COS_GUARANTEE_QUANTUM_MIN_BYTES: u64 = 1500;
 pub(in crate::afxdp) const COS_GUARANTEE_QUANTUM_MAX_BYTES: u64 = 512 * 1024;
 pub(in crate::afxdp) const COS_SURPLUS_ROUND_QUANTUM_BYTES: u64 = 1500;
-const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 
 // #956: cos/ submodule imports.
 //
@@ -1227,12 +1152,11 @@ const COS_TIMER_WHEEL_L0_HORIZON_TICKS: u64 = COS_TIMER_WHEEL_L0_SLOTS as u64;
 use super::cos::{
     apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_flow_bucket_index,
     cos_item_flow_key, cos_queue_drain_all, cos_queue_flow_share_limit,
-    cos_queue_is_empty, cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
-    drain_shaped_tx, ensure_cos_interface_runtime, maybe_top_up_cos_root_lease, park_cos_queue,
-    prepared_cos_request_stays_on_current_tx_binding, publish_committed_queue_vtime,
-    redirect_local_cos_request_to_owner, redirect_prepared_cos_request_to_owner,
-    redirect_prepared_cos_request_to_owner_binding, release_cos_root_lease,
-    resolve_local_routing_decision, CoSServicePhase, LocalRoutingDecision, Step1Action,
+    cos_queue_is_empty, cos_queue_push_back, cos_queue_restore_front,
+    drain_shaped_tx, ensure_cos_interface_runtime, mark_cos_queue_runnable,
+    publish_committed_queue_vtime, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding,
+    resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
 };
 #[cfg(test)]
 use super::cos::ecn::{ethernet_l3, mark_ecn_ce_ipv4, mark_ecn_ce_ipv6, EthernetL3};
@@ -1257,171 +1181,18 @@ use super::cos::{
     COS_FLOW_FAIR_MIN_SHARE_BYTES, ECN_CE, ECN_ECT_0, ECN_ECT_1, ECN_MASK, ECN_NOT_ECT,
     V_MIN_CONSECUTIVE_SKIP_HARD_CAP, V_MIN_SUSPENSION_BATCHES,
 };
-
-// #956 Phase 6: visibility bumped from private so cos/builders.rs
-// can reach it via `use crate::afxdp::tx::cos_tick_for_ns`. Timer-
-// wheel helpers stay in tx.rs through the drain-scheduler phase
-// (they consume the private COS_TIMER_WHEEL_* constants and are
-// tightly coupled to advance_cos_timer_wheel).
-pub(in crate::afxdp) fn cos_tick_for_ns(now_ns: u64) -> u64 {
-    now_ns / COS_TIMER_WHEEL_TICK_NS
-}
-
-pub(in crate::afxdp) fn cos_timer_wheel_level_and_slot(current_tick: u64, wake_tick: u64) -> (u8, usize) {
-    if wake_tick.saturating_sub(current_tick) < COS_TIMER_WHEEL_L0_HORIZON_TICKS {
-        (0, (wake_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize)
-    } else {
-        (
-            1,
-            ((wake_tick / COS_TIMER_WHEEL_L0_SLOTS as u64) % COS_TIMER_WHEEL_L1_SLOTS as u64)
-                as usize,
-        )
-    }
-}
-
-// #956 Phase 2: flow-hashing helpers (mix_cos_flow_bucket,
-// exact_cos_flow_bucket, cos_flow_hash_seed_from_os,
-// cos_item_flow_key, cos_flow_bucket_index,
-// cos_queue_prospective_active_flows) extracted to
-// userspace-dp/src/afxdp/cos/flow_hash.rs. Production callers
-// import via super::cos::{...}; tests import the same way.
-//
-// Constants (COS_FLOW_FAIR_BUCKETS / COS_FLOW_FAIR_BUCKET_MASK)
-// stayed in afxdp::types — flow_hash.rs imports them.
-
-fn wake_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize) {
-    let Some(queue) = root.queues.get_mut(queue_idx) else {
-        return;
-    };
-    if cos_queue_is_empty(queue) {
-        queue.runnable = false;
-        queue.parked = false;
-        queue.next_wakeup_tick = 0;
-        return;
-    }
-    if !queue.runnable {
-        root.runnable_queues = root.runnable_queues.saturating_add(1);
-    }
-    mark_cos_queue_runnable(queue);
-}
-
-// #710: count an exact-drain TX submit stall on a specific queue.
-// NOT packet loss — on the exact path, `writer.insert == 0` leaves
-// the FIFO items in `queue.items` or restores them (flow-fair path);
-// frames that had been copied into UMEM are released back to
-// `free_tx_frames`, and the items get another chance next drain tick.
-// The counter signals TX-ring / completion-reap pressure, which is
-// an upstream cause for the downstream effects operators chase
-// (#706 mutex contention, #709 owner-worker hotspot).
-//
-// Non-exact transmit paths (`transmit_batch`, `transmit_prepared_queue`)
-// do not carry queue identity at the submit site and do not reach
-// this helper. Their frame-level failures are counted in the binding-
-// level `tx_submit_error_drops` counter instead.
-#[inline]
-pub(in crate::afxdp) fn count_tx_ring_full_submit_stall(
-    binding: &mut BindingWorker,
-    root_ifindex: i32,
-    queue_idx: usize,
-    stalled_packets: u64,
-) {
-    if stalled_packets == 0 {
-        return;
-    }
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
-        if let Some(queue) = root.queues.get_mut(queue_idx) {
-            queue.drop_counters.tx_ring_full_submit_stalls = queue
-                .drop_counters
-                .tx_ring_full_submit_stalls
-                .wrapping_add(stalled_packets);
-        }
-    }
-}
-
-fn rearm_cos_queue(root: &mut CoSInterfaceRuntime, queue_idx: usize, wake_tick: u64) {
-    park_cos_queue(root, queue_idx, wake_tick);
-}
-
-fn mark_cos_queue_runnable(queue: &mut CoSQueueRuntime) {
-    queue.runnable = true;
-    queue.parked = false;
-    queue.next_wakeup_tick = 0;
-}
-
-fn normalize_cos_queue_state(queue: &mut CoSQueueRuntime) {
-    if cos_queue_is_empty(queue) {
-        queue.runnable = false;
-        queue.parked = false;
-        queue.next_wakeup_tick = 0;
-        queue.surplus_deficit = 0;
-        return;
-    }
-    // Non-empty queues have only two valid steady states:
-    // 1. parked with a wakeup tick
-    // 2. runnable immediately
-    // Anything else can strand backlog forever.
-    if queue.parked && queue.next_wakeup_tick > 0 {
-        queue.runnable = false;
-        return;
-    }
-    mark_cos_queue_runnable(queue);
-}
-
-pub(in crate::afxdp) fn advance_cos_timer_wheel(root: &mut CoSInterfaceRuntime, now_ns: u64) {
-    let now_tick = cos_tick_for_ns(now_ns);
-    while root.timer_wheel.current_tick < now_tick {
-        root.timer_wheel.current_tick = root.timer_wheel.current_tick.saturating_add(1);
-        if root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64 == 0 {
-            cascade_cos_timer_wheel_level1(root);
-        }
-        wake_due_cos_timer_slot(root);
-    }
-}
-
-fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {
-    let slot = ((root.timer_wheel.current_tick / COS_TIMER_WHEEL_L0_SLOTS as u64)
-        % COS_TIMER_WHEEL_L1_SLOTS as u64) as usize;
-    let queued = core::mem::take(&mut root.timer_wheel.level1[slot]);
-    let mut rearm = Vec::with_capacity(queued.len());
-    for queue_idx in queued {
-        let Some(queue) = root.queues.get(queue_idx) else {
-            continue;
-        };
-        if !queue.parked || queue.wheel_level != 1 || queue.wheel_slot != slot {
-            continue;
-        }
-        rearm.push((queue_idx, queue.next_wakeup_tick));
-    }
-    for (queue_idx, wake_tick) in rearm {
-        rearm_cos_queue(root, queue_idx, wake_tick);
-    }
-}
-
-fn wake_due_cos_timer_slot(root: &mut CoSInterfaceRuntime) {
-    let slot = (root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize;
-    let queued = core::mem::take(&mut root.timer_wheel.level0[slot]);
-    let mut rearm = Vec::with_capacity(queued.len());
-    let mut wake = Vec::with_capacity(queued.len());
-    for queue_idx in queued {
-        let Some(queue) = root.queues.get(queue_idx) else {
-            continue;
-        };
-        if !queue.parked || queue.wheel_level != 0 || queue.wheel_slot != slot {
-            continue;
-        }
-        if queue.next_wakeup_tick <= root.timer_wheel.current_tick {
-            wake.push(queue_idx);
-        } else {
-            rearm.push((queue_idx, queue.next_wakeup_tick));
-        }
-    }
-    for queue_idx in wake {
-        wake_cos_queue(root, queue_idx);
-    }
-    for (queue_idx, wake_tick) in rearm {
-        rearm_cos_queue(root, queue_idx, wake_tick);
-    }
-}
+// #956 P1: TX-completion + timer-wheel items reached by
+// `mod tests { use super::*; }` at the bottom of this file, plus
+// `redirect_local_cos_request_to_owner` which is also test-only after
+// the cross_binding extraction in #956 Phase 8.
+#[cfg(test)]
+use super::cos::{
+    advance_cos_timer_wheel, cos_queue_push_front, maybe_top_up_cos_root_lease,
+    normalize_cos_queue_state, park_cos_queue,
+    prepared_cos_request_stays_on_current_tx_binding, redirect_local_cos_request_to_owner,
+    restore_cos_local_items_inner, restore_cos_prepared_items_inner,
+    CoSServicePhase, COS_TIMER_WHEEL_TICK_NS,
+};
 
 pub(super) fn resolve_cos_queue_id(
     forwarding: &ForwardingState,
@@ -2111,206 +1882,6 @@ fn enqueue_cos_item(
     Ok(())
 }
 
-pub(in crate::afxdp) fn refresh_cos_interface_activity(binding: &mut BindingWorker, root_ifindex: i32) {
-    let mut new_nonempty = 0usize;
-    let mut new_runnable = 0usize;
-    let mut released_queue_leases = Vec::<(usize, u64)>::new();
-    let old_nonempty = binding
-        .cos_interfaces
-        .get(&root_ifindex)
-        .map(|root| root.nonempty_queues)
-        .unwrap_or(0);
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
-        for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
-            normalize_cos_queue_state(queue);
-            if cos_queue_is_empty(queue) && queue.exact && queue.tokens > 0 {
-                released_queue_leases.push((queue_idx, core::mem::take(&mut queue.tokens)));
-            }
-            if cos_queue_is_empty(queue) {
-                continue;
-            }
-            new_nonempty = new_nonempty.saturating_add(1);
-            if queue.runnable {
-                new_runnable = new_runnable.saturating_add(1);
-            }
-        }
-        root.nonempty_queues = new_nonempty;
-        root.runnable_queues = new_runnable;
-    }
-    if old_nonempty == 0 && new_nonempty > 0 {
-        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_add(1);
-    } else if old_nonempty > 0 && new_nonempty == 0 {
-        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_sub(1);
-        release_cos_root_lease(binding, root_ifindex);
-    }
-    if let Some(iface_fast) = binding.cos_fast_interfaces.get(&root_ifindex) {
-        for (queue_idx, released) in released_queue_leases {
-            if let Some(shared_queue_lease) = iface_fast
-                .queue_fast_path
-                .get(queue_idx)
-                .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
-            {
-                shared_queue_lease.release_unused(released);
-            }
-        }
-    }
-}
-
-pub(in crate::afxdp) fn apply_cos_send_result(
-    binding: &mut BindingWorker,
-    root_ifindex: i32,
-    queue_idx: usize,
-    phase: CoSServicePhase,
-    batch_bytes: u64,
-    sent_bytes: u64,
-    retry: VecDeque<TxRequest>,
-) {
-    let mut exact_queue_idx = None;
-    {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
-        };
-        if let Some(queue) = root.queues.get_mut(queue_idx) {
-            exact_queue_idx = queue.exact.then_some(queue_idx);
-            let retry_bytes = restore_cos_local_items_inner(queue, retry);
-            queue.queued_bytes = queue
-                .queued_bytes
-                .saturating_sub(batch_bytes)
-                .saturating_add(retry_bytes);
-            match phase {
-                CoSServicePhase::Guarantee => {
-                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
-                }
-                CoSServicePhase::Surplus => {
-                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
-                }
-            }
-            // #760 instrumentation: record non-exact / surplus /
-            // shared-exact sends at the same site the queue's token
-            // or surplus accounting is debited. Paired with the
-            // apply_direct_exact_send_result write so the sum across
-            // all sites equals the bytes the CoS scheduler accounted.
-            queue
-                .owner_profile
-                .drain_sent_bytes
-                .fetch_add(sent_bytes, Ordering::Relaxed);
-        }
-        root.tokens = root.tokens.saturating_sub(sent_bytes);
-    }
-    if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
-    {
-        shared_root_lease.consume(sent_bytes);
-    }
-    if let Some(queue_idx) = exact_queue_idx {
-        if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
-            .get(&root_ifindex)
-            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
-            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
-        {
-            shared_queue_lease.consume(sent_bytes);
-        }
-    }
-    refresh_cos_interface_activity(binding, root_ifindex);
-}
-
-pub(in crate::afxdp) fn apply_cos_prepared_result(
-    binding: &mut BindingWorker,
-    root_ifindex: i32,
-    queue_idx: usize,
-    phase: CoSServicePhase,
-    batch_bytes: u64,
-    sent_bytes: u64,
-    retry: VecDeque<PreparedTxRequest>,
-) {
-    let mut exact_queue_idx = None;
-    {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
-        };
-        if let Some(queue) = root.queues.get_mut(queue_idx) {
-            exact_queue_idx = queue.exact.then_some(queue_idx);
-            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
-            queue.queued_bytes = queue
-                .queued_bytes
-                .saturating_sub(batch_bytes)
-                .saturating_add(retry_bytes);
-            match phase {
-                CoSServicePhase::Guarantee => {
-                    queue.tokens = queue.tokens.saturating_sub(sent_bytes);
-                }
-                CoSServicePhase::Surplus => {
-                    queue.surplus_deficit = queue.surplus_deficit.saturating_sub(sent_bytes);
-                }
-            }
-            // #760 instrumentation, the FOURTH apply_* site. This is
-            // the prepared-batch path (CoSBatch::Prepared, in-place
-            // rewrite — the common case for forwarded traffic). The
-            // initial instrumentation commit missed this site; the
-            // first 120 s iperf3 measurement showed only ~987 Mbps
-            // on drain_sent_bytes while the receiver reported 1.55
-            // Gbps, leaving ~563 Mbps unaccounted — all of it
-            // flowing through this path. Same Relaxed semantics as
-            // the other three apply_* sites.
-            queue
-                .owner_profile
-                .drain_sent_bytes
-                .fetch_add(sent_bytes, Ordering::Relaxed);
-        }
-        root.tokens = root.tokens.saturating_sub(sent_bytes);
-    }
-    if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
-        .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
-    {
-        shared_root_lease.consume(sent_bytes);
-    }
-    if let Some(queue_idx) = exact_queue_idx {
-        if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
-            .get(&root_ifindex)
-            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
-            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
-        {
-            shared_queue_lease.consume(sent_bytes);
-        }
-    }
-    refresh_cos_interface_activity(binding, root_ifindex);
-}
-
-pub(in crate::afxdp) fn restore_cos_local_items_inner(
-    queue: &mut CoSQueueRuntime,
-    mut retry: VecDeque<TxRequest>,
-) -> u64 {
-    let mut retry_bytes = 0u64;
-    while let Some(req) = retry.pop_back() {
-        retry_bytes = retry_bytes.saturating_add(req.bytes.len() as u64);
-        cos_queue_push_front(queue, CoSPendingTxItem::Local(req));
-    }
-    if !cos_queue_is_empty(queue) {
-        mark_cos_queue_runnable(queue);
-    }
-    retry_bytes
-}
-
-pub(in crate::afxdp) fn restore_cos_prepared_items_inner(
-    queue: &mut CoSQueueRuntime,
-    mut retry: VecDeque<PreparedTxRequest>,
-) -> u64 {
-    let mut retry_bytes = 0u64;
-    while let Some(req) = retry.pop_back() {
-        retry_bytes = retry_bytes.saturating_add(req.len as u64);
-        cos_queue_push_front(queue, CoSPendingTxItem::Prepared(req));
-    }
-    if !cos_queue_is_empty(queue) {
-        mark_cos_queue_runnable(queue);
-    }
-    retry_bytes
-}
 
 fn process_pending_queue_in_place<T, F>(pending: &mut VecDeque<T>, mut f: F)
 where


### PR DESCRIPTION
## Summary

- Extracts the TX-completion + timer-wheel cluster (17 fns + 2 constants, ~430 LOC) from `tx.rs` into `userspace-dp/src/afxdp/cos/tx_completion.rs`.
- Closes the **Phase 6 builder back-edge** (`cos/builders.rs -> tx::cos_tick_for_ns`) and the **TX-completion / timer-wheel subset of the Phase 7 deferrals** (10 of 18 fns imported by `cos/queue_service.rs` from `crate::afxdp::tx::` move to `super::tx_completion::`).
- Remaining 8 fns + `TxError` + 4 guarantee/quantum constants stay on `crate::afxdp::tx::` — deferred to #984 (afxdp/tx/ split).
- `tx.rs` drops 13731 → 13302 LOC (-429).

## Plan + review

- Plan iterated v1 → v5.3 (commit `e38e86ae`) over 8 review rounds.
- Triadic plan review: Codex r8 PLAN-READY, Gemini r8 PLAN-READY (`pro` model, full systems-level analysis), cross-reviews both AGREE-PLAN-READY. No new findings.
- Triadic impl review on commit `529ff285`: Codex MERGE-READY, Gemini MERGE-READY, cross-reviews both AGREE-MERGE-READY. No findings.

## Move set

**Timer wheel (10 fns + 2 const):**
`COS_TIMER_WHEEL_TICK_NS` (now `pub(in crate::afxdp)` for tests), `COS_TIMER_WHEEL_L0_HORIZON_TICKS` (file-private), `cos_tick_for_ns`, `cos_timer_wheel_level_and_slot`, `wake_cos_queue` (file-private), `count_tx_ring_full_submit_stall`, `rearm_cos_queue` (file-private), `mark_cos_queue_runnable`, `normalize_cos_queue_state`, `advance_cos_timer_wheel`, `cascade_cos_timer_wheel_level1` (file-private), `wake_due_cos_timer_slot` (file-private).

**TX-completion (7 fns):**
`prime_cos_root_for_service`, `apply_direct_exact_send_result`, `refresh_cos_interface_activity`, `apply_cos_send_result`, `apply_cos_prepared_result`, `restore_cos_local_items_inner`, `restore_cos_prepared_items_inner`.

## Visibility

- 14 items `pub(in crate::afxdp)` (10 with cos/queue_service.rs callers, 1 with cos/builders.rs caller, 1 with tx.rs production caller, 1 test-only, 1 test+intra-cluster).
- 4 fns + 1 const file-private (no callers outside the move set).
- `#[inline]` on hot-path fns per Phase 4-8 lesson; preserves existing `#[inline]` on `count_tx_ring_full_submit_stall`.

## Atomic ordering

Moved bodies use `Ordering::Relaxed` directly only. The `Release/Acquire` publish boundary stays in `cos/queue_service.rs` (`publish_committed_queue_vtime` callsites unchanged). Indirect `Acquire/AcqRel` via `shared_*_lease.consume()` (`types.rs:1669-1679`) — same lease impl, just relocated call site.

## Test plan

- [x] `cargo build --bins` clean (89 warnings, 0 unused-imports new from this PR; baseline was 90 dead-code warnings).
- [x] `cargo test --bins` 865/0/2 — exact rolling baseline match.
- [x] Cluster deploy: `cluster-setup.sh deploy all` rolling deploy on `loss:xpf-userspace-fw0/fw1`. Software version after deploy: `userspace-forwarding-ok-20260402-bfb00432-956-g529ff285`.
- [x] CoS config applied via `apply-cos-config.sh` (atomic commit + verification OK; 7 classes shown in queue table).
- [x] Per-CoS-class iperf3 (5201..5207, 30s each, 4 streams): all classes respect their rate limits, none zero-bps.
  - 5201 (iperf-a, 1G cap): 0.95 Gbps
  - 5202 (iperf-b, 10G cap): 9.54 Gbps
  - 5203 (iperf-c, 25G cap): 12.18 Gbps
  - 5204 (iperf-d, 13G cap): 12.40 Gbps
  - 5205 (iperf-e, 16G cap): 15.26 Gbps
  - 5206 (iperf-f, 19G cap): 17.43 Gbps
  - 5207 (best-effort, 100M cap): 0.095 Gbps
- [x] Failover (RG1 cycled twice during 100s iperf3): 100/100 intervals ≥ 3 Gbps, 0 zero-bps, lowest interval 3.42 Gbps, sum 5.23 Gbps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)