### PR TITLE
tx/transmit.rs: colocate remember_prepared_recycle test with production (#984 P3 Phase 1b)

### DIFF
--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -1051,48 +1051,6 @@ mod tests {
         assert_eq!(shared_recycles, vec![(7, 42)]);
     }
 
-    #[test]
-    fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {
-        let mut in_flight_prepared_recycles = FastMap::default();
-
-        remember_prepared_recycle(
-            &mut in_flight_prepared_recycles,
-            &PreparedTxRequest {
-                offset: 41,
-                len: 64,
-                recycle: PreparedTxRecycle::FreeTxFrame,
-                expected_ports: None,
-                expected_addr_family: libc::AF_INET as u8,
-                expected_protocol: PROTO_TCP,
-                flow_key: None,
-                egress_ifindex: 0,
-                cos_queue_id: None,
-                dscp_rewrite: None,
-            },
-        );
-        remember_prepared_recycle(
-            &mut in_flight_prepared_recycles,
-            &PreparedTxRequest {
-                offset: 42,
-                len: 64,
-                recycle: PreparedTxRecycle::FillOnSlot(7),
-                expected_ports: None,
-                expected_addr_family: libc::AF_INET as u8,
-                expected_protocol: PROTO_TCP,
-                flow_key: None,
-                egress_ifindex: 0,
-                cos_queue_id: None,
-                dscp_rewrite: None,
-            },
-        );
-
-        assert_eq!(in_flight_prepared_recycles.len(), 1);
-        assert_eq!(
-            in_flight_prepared_recycles.get(&42),
-            Some(&PreparedTxRecycle::FillOnSlot(7))
-        );
-        assert!(!in_flight_prepared_recycles.contains_key(&41));
-    }
 
     #[test]
     fn clone_prepared_request_for_cos_returns_local_copy_with_metadata() {

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -486,7 +486,6 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::afxdp::tx::test_support::*;
     use crate::afxdp::PROTO_TCP;
 
     #[test]

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -482,3 +482,54 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     maybe_wake_tx(binding, true, now_ns);
     Ok((sent_packets, sent_bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::afxdp::tx::test_support::*;
+    use crate::afxdp::PROTO_TCP;
+
+    #[test]
+    fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {
+        let mut in_flight_prepared_recycles = FastMap::default();
+
+        remember_prepared_recycle(
+            &mut in_flight_prepared_recycles,
+            &PreparedTxRequest {
+                offset: 41,
+                len: 64,
+                recycle: PreparedTxRecycle::FreeTxFrame,
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 0,
+                cos_queue_id: None,
+                dscp_rewrite: None,
+            },
+        );
+        remember_prepared_recycle(
+            &mut in_flight_prepared_recycles,
+            &PreparedTxRequest {
+                offset: 42,
+                len: 64,
+                recycle: PreparedTxRecycle::FillOnSlot(7),
+                expected_ports: None,
+                expected_addr_family: libc::AF_INET as u8,
+                expected_protocol: PROTO_TCP,
+                flow_key: None,
+                egress_ifindex: 0,
+                cos_queue_id: None,
+                dscp_rewrite: None,
+            },
+        );
+
+        assert_eq!(in_flight_prepared_recycles.len(), 1);
+        assert_eq!(
+            in_flight_prepared_recycles.get(&42),
+            Some(&PreparedTxRecycle::FillOnSlot(7))
+        );
+        assert!(!in_flight_prepared_recycles.contains_key(&41));
+    }
+
+}


### PR DESCRIPTION
Phase 1b sibling to #998. Moves `remember_prepared_recycle_tracks_only_shared_fill_recycles` from `tx/mod.rs::tests` to `tx/transmit.rs::tests`.

Adds explicit `use crate::afxdp::PROTO_TCP;` because transmit.rs's production scope doesn't glob crate::afxdp::*.

## Test plan
- [x] cargo build --bins clean
- [x] cargo test --bins 865/0/2
- [ ] Codex hostile review
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)