### PR TITLE
tx/rings.rs: colocate apply_prepared_recycle test with production (#984 P3 Phase 1a)

### DIFF
--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -1029,27 +1029,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn apply_prepared_recycle_routes_fill_and_free_explicitly() {
-        let mut free_tx_frames = VecDeque::new();
-        let mut shared_recycles = Vec::new();
-
-        apply_prepared_recycle(
-            &mut free_tx_frames,
-            &mut shared_recycles,
-            PreparedTxRecycle::FreeTxFrame,
-            41,
-        );
-        apply_prepared_recycle(
-            &mut free_tx_frames,
-            &mut shared_recycles,
-            PreparedTxRecycle::FillOnSlot(7),
-            42,
-        );
-
-        assert_eq!(free_tx_frames, VecDeque::from(vec![41]));
-        assert_eq!(shared_recycles, vec![(7, 42)]);
-    }
 
     #[test]
     fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -24,8 +24,6 @@ pub(in crate::afxdp) use stats::{record_kick_latency, record_tx_completions_with
 pub(super) mod rings;
 pub(in crate::afxdp) use rings::{maybe_wake_tx, reap_tx_completions};
 pub(super) use rings::{drain_pending_fill, maybe_wake_rx};
-#[cfg(test)]
-use rings::apply_prepared_recycle;
 
 // #984 P2c: TX-ring submit + per-frame recycle cluster (transmit_batch,
 // transmit_prepared_queue, recycle_*, TxError) extracted to sibling

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -195,7 +195,7 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
     binding.empty_rx_polls = 0;
 }
 
-pub(super) fn apply_prepared_recycle(
+fn apply_prepared_recycle(
     free_tx_frames: &mut VecDeque<u64>,
     shared_recycles: &mut Vec<(u32, u64)>,
     recycle: PreparedTxRecycle,
@@ -324,7 +324,6 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::afxdp::tx::test_support::*;
 
     #[test]
     fn apply_prepared_recycle_routes_fill_and_free_explicitly() {

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -12,9 +12,10 @@
 //     RX_WAKE_* / TX_WAKE_* constants in afxdp.rs).
 //   - `recycle_completed_tx_offset` (file-private helper): per-offset
 //     cleanup invoked from inside `reap_tx_completions`.
-//   - `apply_prepared_recycle` (pub(super) for tx/mod.rs's cfg-test
-//     re-export): `recycle_completed_tx_offset`'s
-//     `PreparedTxRecycle` dispatcher.
+//   - `apply_prepared_recycle` (file-private):
+//     `recycle_completed_tx_offset`'s `PreparedTxRecycle`
+//     dispatcher. Now exercised by a colocated test in this
+//     module's `mod tests`.
 //
 // Single-writer (owner worker), all atomic ops `Ordering::Relaxed`.
 

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -320,3 +320,32 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
         binding.last_tx_wake_ns = now_ns;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::afxdp::tx::test_support::*;
+
+    #[test]
+    fn apply_prepared_recycle_routes_fill_and_free_explicitly() {
+        let mut free_tx_frames = VecDeque::new();
+        let mut shared_recycles = Vec::new();
+
+        apply_prepared_recycle(
+            &mut free_tx_frames,
+            &mut shared_recycles,
+            PreparedTxRecycle::FreeTxFrame,
+            41,
+        );
+        apply_prepared_recycle(
+            &mut free_tx_frames,
+            &mut shared_recycles,
+            PreparedTxRecycle::FillOnSlot(7),
+            42,
+        );
+
+        assert_eq!(free_tx_frames, VecDeque::from(vec![41]));
+        assert_eq!(shared_recycles, vec![(7, 42)]);
+    }
+
+}


### PR DESCRIPTION
Phase 1a of Path A test redistribution after #997.

Moves `apply_prepared_recycle_routes_fill_and_free_explicitly` from `tx/mod.rs::tests` into a fresh `mod tests` at the bottom of `tx/rings.rs` (where the production fn lives).

## Test plan
- [x] cargo build --bins clean
- [x] cargo test --bins 865/0/2 (matches baseline)
- [ ] Codex hostile review
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)