### PR TITLE
cos/builders.rs: colocate 2 build_cos_interface_runtime tests with production (#984 P3 Phase 4b)

### DIFF
--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -153,3 +153,80 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(config: &CoSInterfaceConfig,
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::afxdp::tx::test_support::*;
+    use crate::afxdp::types::{CoSQueueConfig, FastMap};
+
+    #[test]
+    fn build_cos_interface_runtime_starts_exact_queue_with_zero_local_tokens() {
+        let runtime = build_cos_interface_runtime(
+            &CoSInterfaceConfig {
+                shaping_rate_bytes: 25_000_000,
+                burst_bytes: 256 * 1024,
+                default_queue: 5,
+                dscp_classifier: String::new(),
+                ieee8021_classifier: String::new(),
+                dscp_queue_by_dscp: [u8::MAX; 64],
+                ieee8021_queue_by_pcp: [u8::MAX; 8],
+                queue_by_forwarding_class: FastMap::default(),
+                queues: vec![CoSQueueConfig {
+                    queue_id: 5,
+                    forwarding_class: "iperf-b".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 10_000_000,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: 128 * 1024,
+                    dscp_rewrite: None,
+                }],
+            },
+            1_000_000_000,
+        );
+
+        assert_eq!(runtime.queues[0].tokens, 0);
+        assert_eq!(runtime.queues[0].last_refill_ns, 0);
+    }
+
+    #[test]
+    fn build_cos_interface_runtime_leaves_flow_hash_seed_zero_until_promotion() {
+        // The seed is drawn in `ensure_cos_interface_runtime`, not in
+        // `build_cos_interface_runtime`. Pin this so a refactor that
+        // accidentally moves the getrandom call into the builder is
+        // caught: builder-time seeding would burn a syscall per non-
+        // flow-fair queue and would also drift the struct doc invariant
+        // that non-flow-fair queues keep seed=0.
+        let root = test_cos_runtime_with_queues(
+            10_000_000_000 / 8,
+            vec![
+                CoSQueueConfig {
+                    queue_id: 4,
+                    forwarding_class: "iperf-a".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 1_000_000_000 / 8,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: COS_MIN_BURST_BYTES,
+                    dscp_rewrite: None,
+                },
+                CoSQueueConfig {
+                    queue_id: 5,
+                    forwarding_class: "iperf-b".into(),
+                    priority: 5,
+                    transmit_rate_bytes: 10_000_000_000 / 8,
+                    exact: true,
+                    surplus_weight: 1,
+                    buffer_bytes: COS_MIN_BURST_BYTES,
+                    dscp_rewrite: None,
+                },
+            ],
+        );
+        for queue in &root.queues {
+            assert!(!queue.flow_fair);
+            assert_eq!(queue.flow_hash_seed, 0);
+        }
+    }
+
+}

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -6,9 +6,10 @@
 //     because every enqueue checks whether the runtime exists for
 //     the egress ifindex; carries `#[inline]`.
 //   - `build_cos_interface_runtime` — pure constructor from
-//     `CoSInterfaceConfig`. Called once by `ensure_*` and 3 times
-//     by `tx::tests`; pub(in crate::afxdp) plus cfg-gated
-//     re-export from cos/mod.rs.
+//     `CoSInterfaceConfig`. Called once by `ensure_*` and by
+//     `tx::test_support` fixture builders; pub(in crate::afxdp)
+//     plus cfg-gated re-export from cos/mod.rs. Direct unit tests
+//     for this fn live in this file's `mod tests` (#984 P3 phase 4b).
 //
 // `cos_tick_for_ns` moved to cos/tx_completion.rs in #956 P1; the
 // Phase-6 cos/builders -> tx back-edge is now closed.

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -376,35 +376,6 @@ mod tests {
         assert_eq!(root.queues[0].last_refill_ns, 0);
     }
 
-    #[test]
-    fn build_cos_interface_runtime_starts_exact_queue_with_zero_local_tokens() {
-        let runtime = build_cos_interface_runtime(
-            &CoSInterfaceConfig {
-                shaping_rate_bytes: 25_000_000,
-                burst_bytes: 256 * 1024,
-                default_queue: 5,
-                dscp_classifier: String::new(),
-                ieee8021_classifier: String::new(),
-                dscp_queue_by_dscp: [u8::MAX; 64],
-                ieee8021_queue_by_pcp: [u8::MAX; 8],
-                queue_by_forwarding_class: FastMap::default(),
-                queues: vec![CoSQueueConfig {
-                    queue_id: 5,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 10_000_000,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: 128 * 1024,
-                    dscp_rewrite: None,
-                }],
-            },
-            1_000_000_000,
-        );
-
-        assert_eq!(runtime.queues[0].tokens, 0);
-        assert_eq!(runtime.queues[0].last_refill_ns, 0);
-    }
 
 
 
@@ -3093,44 +3064,6 @@ mod tests {
 
 
 
-    #[test]
-    fn build_cos_interface_runtime_leaves_flow_hash_seed_zero_until_promotion() {
-        // The seed is drawn in `ensure_cos_interface_runtime`, not in
-        // `build_cos_interface_runtime`. Pin this so a refactor that
-        // accidentally moves the getrandom call into the builder is
-        // caught: builder-time seeding would burn a syscall per non-
-        // flow-fair queue and would also drift the struct doc invariant
-        // that non-flow-fair queues keep seed=0.
-        let root = test_cos_runtime_with_queues(
-            10_000_000_000 / 8,
-            vec![
-                CoSQueueConfig {
-                    queue_id: 4,
-                    forwarding_class: "iperf-a".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 1_000_000_000 / 8,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                },
-                CoSQueueConfig {
-                    queue_id: 5,
-                    forwarding_class: "iperf-b".into(),
-                    priority: 5,
-                    transmit_rate_bytes: 10_000_000_000 / 8,
-                    exact: true,
-                    surplus_weight: 1,
-                    buffer_bytes: COS_MIN_BURST_BYTES,
-                    dscp_rewrite: None,
-                },
-            ],
-        );
-        for queue in &root.queues {
-            assert!(!queue.flow_fair);
-            assert_eq!(queue.flow_hash_seed, 0);
-        }
-    }
 
 
 


### PR DESCRIPTION
Phase 4b sibling. Moves 2 tests (build_cos_interface_runtime_leaves_flow_hash_seed_zero_until_promotion, build_cos_interface_runtime_starts_exact_queue_with_zero_local_tokens) from tx/mod.rs::tests to cos/builders.rs::tests.

Adds CoSQueueConfig + FastMap imports.

## Test plan
- [x] cargo test --bins 865/0/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)