### PR TITLE
refactor: strip phase debris from tx/mod.rs + cos/* headers, codify modularity discipline

### DIFF
--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -210,6 +210,41 @@ the mechanics, so this section is sequencing only.
   the fixture is `buffer_bytes: 125_000`, not `125 * 1024`. Don't mix
   KB and KiB.
 
+## Modularity discipline
+
+Monolithic files and god functions silently degrade reviewability and
+inlining. Treat the trend as a defect, not a style preference.
+
+- **No monolithic files.** A `.rs` file that crosses ~2,000 LOC of
+  production code (excluding `mod tests`) is a smell. By the time it
+  hits ~3,000 LOC the next change to that file should split it before
+  adding new logic. Apply the same rule to test files: when a single
+  `mod tests` block accumulates >200 tests across unrelated subjects,
+  colocate the tests next to the code they exercise (per-file `mod
+  tests` blocks are the project pattern; see the `tx/` and `cos/`
+  layouts for examples).
+- **No god functions.** A function with >100 lines or >8 parameters
+  is a refactor cue. Pull subsystems into their own helpers (state
+  machine → enum + dispatch fn, repeated parameter cluster → context
+  struct). The 31-parameter `poll_binding_process_descriptor` in
+  `afxdp.rs` is the standing cautionary example; tracked as #945 /
+  #961.
+- **One responsibility per module.** A module that mixes admission
+  policy with byte-mutation, or memory mapping with ring management,
+  will get sliced apart eventually — do it on the way in. The
+  `userspace-dp/src/afxdp/` decomposition (`tx/`, `cos/`, the planned
+  `umem/` and `frame/` splits in #986/#988) is the working template.
+- **Refactor with new features, not after.** When a feature would
+  add ~200+ LOC to a module that's already approaching the threshold
+  above, the PR splits the module first, lands the feature on the
+  smaller pieces. "I'll clean it up next sprint" doesn't survive
+  contact with the next on-call rotation.
+- **Reviewers escalate monolith creep.** A PR that adds a new
+  helper to a 2,500-line file gets a Medium-severity review note
+  pointing to the relevant tracking issue (or asking the author to
+  open one). Don't let "but the surrounding code is already like
+  that" land.
+
 ## Overflow / failure policy
 
 | Scenario | Policy |

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -228,7 +228,7 @@ inlining. Treat the trend as a defect, not a style preference.
   machine → enum + dispatch fn, repeated parameter cluster → context
   struct). The standing cautionary example is
   `poll_binding_process_descriptor` in `afxdp.rs`: #945 brought it
-  down from 31 parameters to 13, but the body is still long and the
+  down from 31 parameters to 15, but the body is still long and the
   parameter cluster is still a refactor smell — tracked as #961.
 - **One responsibility per module.** A module that mixes admission
   policy with byte-mutation, or memory mapping with ring management,

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -226,9 +226,10 @@ inlining. Treat the trend as a defect, not a style preference.
 - **No god functions.** A function with >100 lines or >8 parameters
   is a refactor cue. Pull subsystems into their own helpers (state
   machine → enum + dispatch fn, repeated parameter cluster → context
-  struct). The 31-parameter `poll_binding_process_descriptor` in
-  `afxdp.rs` is the standing cautionary example; tracked as #945 /
-  #961.
+  struct). The standing cautionary example is
+  `poll_binding_process_descriptor` in `afxdp.rs`: #945 brought it
+  down from 31 parameters to 13, but the body is still long and the
+  parameter cluster is still a refactor smell — tracked as #961.
 - **One responsibility per module.** A module that mixes admission
   policy with byte-mutation, or memory mapping with ring management,
   will get sliced apart eventually — do it on the way in. The
@@ -240,10 +241,10 @@ inlining. Treat the trend as a defect, not a style preference.
   smaller pieces. "I'll clean it up next sprint" doesn't survive
   contact with the next on-call rotation.
 - **Reviewers escalate monolith creep.** A PR that adds a new
-  helper to a 2,500-line file gets a Medium-severity review note
-  pointing to the relevant tracking issue (or asking the author to
-  open one). Don't let "but the surrounding code is already like
-  that" land.
+  helper to a 2,500-line file gets a Medium+ review note pointing
+  to the relevant tracking issue (or asking the author to open
+  one). Don't let "but the surrounding code is already like that"
+  land.
 
 ## Overflow / failure policy
 

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -1,34 +1,8 @@
-// #956 Phase 3: admission policy (per-flow share/buffer caps,
-// ECN marking, flow-fair promotion), extracted from tx.rs.
-//
-// Provides the per-flow admission gates the TX hot-path consults
-// when enqueueing a packet onto a CoS queue:
-//   - `cos_queue_flow_share_limit` — per-flow byte cap on
-//     flow-fair queues, rate-aware on shared_exact (#914)
-//   - `cos_flow_aware_buffer_limit` — aggregate buffer cap that
-//     tracks active-flow count
-//   - `apply_cos_admission_ecn_policy` — per-flow / aggregate
-//     ECN CE marking (#722, #784)
-//
-// Plus the queue-runtime construction helpers that promote queues
-// onto the flow-fair (SFQ) path:
-//   - `apply_cos_queue_flow_fair_promotion` — whole-runtime entry
-//   - `promote_cos_queue_flow_fair` — per-queue policy (file-private)
-//
-// `account_cos_queue_flow_enqueue` / `_dequeue` (MQFQ + V-min state
-// lifecycle) stayed in tx.rs through Phase 4 and moved cohesively
-// with selection / pop / publish in Phase 5 — see
-// `cos/queue_ops.rs` and docs/pr/956-phase5-queue-ops/plan.md.
-// (Gemini round-1 of Phase 3 was the original architectural
-// finding requiring the deferral.)
-//
-// `COS_MIN_BURST_BYTES` lived in tx.rs through Phase 3 with a
-// `pub(in crate::afxdp)` visibility bump so this module could reach
-// it via `use crate::afxdp::tx::COS_MIN_BURST_BYTES`. Phase 4 moved
-// the constant into `cos/token_bucket.rs`; this module now imports
-// it via `use super::COS_MIN_BURST_BYTES` (resolves to the
-// `cos/mod.rs` re-export). Importing via the parent re-export keeps
-// admission agnostic to which sibling module owns the constant.
+// Per-flow admission gates (share/buffer caps, ECN CE-marking) +
+// flow-fair (SFQ) queue promotion. `COS_MIN_BURST_BYTES` is
+// imported via `super::COS_MIN_BURST_BYTES` (cos/mod.rs re-export)
+// so admission stays agnostic to which sibling module owns the
+// constant.
 
 use crate::afxdp::types::{
     CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime, WorkerCoSQueueFastPath,

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -1,23 +1,7 @@
-// #956 Phase 6: CoS interface-runtime builders, extracted from
-// tx.rs. Provides the construction half of the binding lifecycle:
-//
-//   - `ensure_cos_interface_runtime` — production caller hook
-//     (binding lifecycle). Sits on the steady-state enqueue path
-//     because every enqueue checks whether the runtime exists for
-//     the egress ifindex; carries `#[inline]`.
-//   - `build_cos_interface_runtime` — pure constructor from
-//     `CoSInterfaceConfig`. Called once by `ensure_*` and by
-//     `tx::test_support` fixture builders; pub(in crate::afxdp)
-//     plus cfg-gated re-export from cos/mod.rs. Direct unit tests
-//     for this fn live in this file's `mod tests` (#984 P3 phase 4b).
-//
-// `cos_tick_for_ns` moved to cos/tx_completion.rs in #956 P1; the
-// Phase-6 cos/builders -> tx back-edge is now closed.
-//
-// `apply_cos_queue_flow_fair_promotion` (cos/admission.rs) is
-// imported here. After this PR, ensure_cos_interface_runtime is
-// the only non-test caller of that fn — cos/mod.rs's re-export
-// for it shifts from always-on to cfg-gated.
+// CoS interface-runtime construction. `ensure_cos_interface_runtime`
+// sits on the steady-state enqueue path (every enqueue checks
+// whether the runtime exists for the egress ifindex) and carries
+// `#[inline]`.
 
 use std::collections::VecDeque;
 

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -1,28 +1,10 @@
-// #956 Phase 8: cross-binding redirect helpers, extracted from
-// tx.rs. Final phase of the cos/ submodule decomposition.
+// Cross-binding redirect: routes a TX request to the owner binding
+// of the egress (or hands off via MPSC inbox) for both Local and
+// Prepared variants.
 //
-// These helpers resolve the "is this request bound to the owner
-// of the egress, or do we hand off via MPSC inbox?" question for
-// both Local and Prepared TX requests:
-//
-//   - `resolve_local_routing_decision` returns the routing
-//     decision (enqueue locally / inbox-redirect / drop) for a
-//     local request.
-//   - `redirect_local_cos_request_to_owner` is step 1 of the
-//     two-step redirect; `_binding` (test-only) is step 2.
-//   - `prepared_cos_request_stays_on_current_tx_binding` is the
-//     gate predicate for prepared requests.
-//   - `redirect_prepared_cos_request_to_owner` + `_binding`
-//     handle the prepared (zero-copy UMEM) variant; the binding-
-//     side call invokes `tx::recycle_prepared_immediately` after
-//     a successful redirect/enqueue, once the data has been copied
-//     out of UMEM (the original frame is no longer referenced).
-//   - `cos_fast_interface` / `cos_fast_queue` are the binding
-//     fast-path lookups consumed by the redirect logic.
-//
-// One back-edge: `tx::recycle_prepared_immediately` (XSK frame
-// recycling — worker-binding territory). Visibility bumped to
-// `pub(in crate::afxdp)` in this PR.
+// Back-edge to `tx::recycle_prepared_immediately`: prepared
+// redirects copy the frame into the owner binding and then release
+// the source UMEM frame on this binding.
 
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};

--- a/userspace-dp/src/afxdp/cos/ecn.rs
+++ b/userspace-dp/src/afxdp/cos/ecn.rs
@@ -1,15 +1,7 @@
-// #956 Phase 1: ECN marking + Ethernet L3 parser, extracted from
-// tx.rs. The threshold constants `COS_ECN_MARK_THRESHOLD_NUM/_DEN`
-// and the admission policy `apply_cos_admission_ecn_policy` moved
-// with admission to `cos/admission.rs` in Phase 3 (Phase 2 was
-// flow_hash; correct dependency direction — a byte-mutation
-// module should not own admission tuning).
-//
-// ECN-marker unit tests now live in this file (`mod tests` at
-// the bottom). Pre-#984 P3 phase 2c they lived in `tx::tests` via
-// the `cos/mod.rs` re-exports; that pattern is now retired for
-// helpers in this module. Admission-path tests live in
-// `cos/admission.rs::tests` (#984 P3 phase 5b).
+// ECN CE-marking + Ethernet L3 parser. Threshold constants and the
+// `apply_cos_admission_ecn_policy` gate live with admission in
+// `cos/admission.rs` (a byte-mutation module shouldn't own
+// admission tuning).
 
 use crate::afxdp::ethernet::{ETH_HDR_LEN, VLAN_TAG_LEN};
 use crate::afxdp::types::{PreparedTxRequest, TxRequest};

--- a/userspace-dp/src/afxdp/cos/flow_hash.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash.rs
@@ -1,19 +1,9 @@
-// #956 Phase 2: flow-hashing helpers, extracted from tx.rs.
+// Per-queue flow-hash machinery for SFQ admission + promotion.
 //
-// Provides the per-queue hash machinery used by SFQ admission +
-// promotion: a per-queue salt (`cos_flow_hash_seed_from_os`), a
-// 5-tuple → bucket-index mapper (`exact_cos_flow_bucket` /
-// `cos_flow_bucket_index`), the prospective-flow counter for
-// admission gates (`cos_queue_prospective_active_flows`), and the
-// `CoSPendingTxItem → SessionKey` accessor (`cos_item_flow_key`).
-//
-// Constants (`COS_FLOW_FAIR_BUCKETS`, `COS_FLOW_FAIR_BUCKET_MASK`)
-// stay in `afxdp::types` because they size other types there
-// (`FlowRrRing`, `CoSQueueRuntime` arrays). flow_hash imports
-// them rather than owning them.
-//
-// Phase 3 (admission) imports the public-to-afxdp helpers
-// re-exported from `cos/mod.rs`.
+// `COS_FLOW_FAIR_BUCKETS` / `COS_FLOW_FAIR_BUCKET_MASK` live in
+// `afxdp::types` because they size other types there (`FlowRrRing`,
+// `CoSQueueRuntime` arrays); flow_hash imports them rather than
+// owning them.
 
 use crate::afxdp::types::{CoSPendingTxItem, CoSQueueRuntime, COS_FLOW_FAIR_BUCKET_MASK};
 use crate::session::SessionKey;

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -30,8 +30,4 @@ pub(super) use token_bucket::{
     refill_cos_tokens, release_all_cos_queue_leases, release_all_cos_root_leases,
     COS_MIN_BURST_BYTES,
 };
-// tx.rs reaches `mark_cos_queue_runnable` via `super::cos::` for its
-// non-moving `enqueue_cos_item` path. Other production callers
-// (queue_service, builders) reach moved items directly via
-// `super::tx_completion::*`.
 pub(super) use tx_completion::mark_cos_queue_runnable;

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -1,14 +1,3 @@
-// #956 cos/ submodule. Phase 1 extracted ECN marking; Phase 2
-// extracted flow-hashing helpers; Phase 3 extracted admission
-// policy + flow-fair promotion; Phase 4 extracted token-bucket
-// lease/refill; Phase 5 extracted queue ops + MQFQ ordering +
-// V-min lifecycle; Phase 6 extracted CoS interface-runtime
-// builders; Phase 7 extracted the dispatch / drain / submit
-// subsystem; Phase 8 (this commit) extracts the cross-binding
-// redirect helpers — FINAL phase of #956.
-// See docs/pr/956-phase8-cross-binding/plan.md for this phase
-// and docs/pr/956-tx-decomposition/plan.md for the full plan.
-
 pub(super) mod admission;
 pub(super) mod builders;
 pub(super) mod cross_binding;

--- a/userspace-dp/src/afxdp/cos/queue_ops.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops.rs
@@ -1,41 +1,7 @@
-// #956 Phase 5: queue ops + MQFQ ordering bookkeeping + V-min slot
-// lifecycle, extracted from tx.rs. Provides the full queue-state
-// surface that admission gates feed into and the drain scheduler
-// consumes:
-//
-//   - Queue accessors: cos_queue_is_empty, cos_queue_len,
-//     cos_queue_front, cos_queue_min_finish_bucket (file-private),
-//     cos_item_len.
-//   - Enqueue / dequeue: cos_queue_push_back, cos_queue_push_front,
-//     cos_queue_pop_front, cos_queue_pop_front_no_snapshot,
-//     cos_queue_pop_front_inner (file-private),
-//     cos_queue_drain_all, cos_queue_restore_front,
-//     cos_queue_clear_orphan_snapshot_after_drop.
-//   - MQFQ ordering bookkeeping (Phase 3 deferred these — Gemini
-//     Phase 3 round-1 finding): account_cos_queue_flow_enqueue,
-//     account_cos_queue_flow_dequeue. Both are
-//     pub(in crate::afxdp); colocated tests live in this file's
-//     `mod tests` (#984 P3 phase 5a).
-//   - V-min slot lifecycle: publish_committed_queue_vtime,
-//     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue,
-//     and the file-private compute_v_min_lag_threshold helper plus
-//     the V_MIN_READ_CADENCE / V_MIN_LAG_THRESHOLD_NS /
-//     V_MIN_MIN_LAG_BYTES constants. The throttle-cap constants
-//     V_MIN_CONSECUTIVE_SKIP_HARD_CAP and V_MIN_SUSPENSION_BATCHES
-//     are pub(in crate::afxdp); colocated V-min tests live in
-//     this file's `mod tests`.
-//
-// 14 always-on cross-module fns get pub(in crate::afxdp); 4 items
-// (account_*, V_MIN_CONSECUTIVE_SKIP_HARD_CAP, V_MIN_SUSPENSION_BATCHES)
-// get pub(in crate::afxdp) with #[cfg(test)] pub(super) use
-// re-export from cos/mod.rs. Per-byte hot-path fns carry #[inline]
-// per the Phase 4 lesson — pub(in crate::afxdp) plus #[inline]
-// preserves cross-module inlining in release builds.
-//
-// CoSBatch / CoSServicePhase / ExactCoSQueueKind enums and their
-// consumers (select_cos_*_batch, service_exact_*_queue_direct)
-// stay in tx.rs through Phase 7 (queue_service) — they live with
-// the dispatch entry points, not the queue state primitives.
+// CoS queue primitives: accessors, enqueue/dequeue, MQFQ ordering
+// bookkeeping, V-min slot lifecycle. Per-byte hot-path fns carry
+// `#[inline]` to preserve cross-module inlining at the
+// `pub(in crate::afxdp)` boundary.
 
 use std::collections::VecDeque;
 

--- a/userspace-dp/src/afxdp/cos/queue_service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service.rs
@@ -1,36 +1,16 @@
-// #956 Phase 7: CoS dispatch / drain / submit subsystem, extracted
-// from tx.rs. The largest move of the campaign — ~2400 LOC covering
-// the full per-byte hot-path chain:
+// CoS dispatch / drain / submit subsystem. Hot-path call chain:
 //
-//   drain_shaped_tx ->
-//     select_cos_*_batch (guarantee / nonexact / surplus / fast-path) ->
-//       service_exact_*_queue_direct(_flow_fair) ->
-//         drain_exact_*_to_scratch ->
-//           submit_cos_batch + cos_batch_tx_made_progress ->
-//             settle_exact_*_submission*
+//   drain_shaped_tx
+//    -> select_cos_*_batch (guarantee / nonexact / surplus)
+//      -> service_exact_*_queue_direct(_flow_fair)
+//        -> drain_exact_*_to_scratch
+//          -> submit_cos_batch + cos_batch_tx_made_progress
+//            -> settle_exact_*_submission*
 //
-// Plus the dispatch types (CoSBatch, CoSServicePhase, ExactCoSQueueKind,
-// ExactCoSQueueSelection, ExactCoSScratchBuild, DrainedQueueRef,
-// ParkReason) and scheduler helpers (cos_*_quantum_bytes,
-// estimate_cos_queue_wakeup_tick, count_park_reason, park_cos_queue).
-//
-// Per the Phase 4-6 lesson, all per-byte / per-batch hot-path fns
-// carry #[inline] (added on the move; the source bodies didn't have
-// it). Larger bodies (drain_*_to_scratch, settle_*) skip #[inline] —
-// LLVM's heuristic threshold should cover them; revisit only if a
-// post-merge perf regression points at one.
-//
-// TX-completion + timer-wheel back-edges (apply_cos_*_result,
-// restore_cos_*_inner, prime_cos_root_for_service,
-// refresh_cos_interface_activity, cos_tick_for_ns +
-// cos_timer_wheel_level_and_slot + count_tx_ring_full_submit_stall)
-// moved to cos/tx_completion.rs in #956 P1.
-//
-// Remaining back-edges to crate::afxdp::tx are XSK-ring /
-// worker-binding / prepared-frame primitives (transmit_*,
-// reap_tx_completions, maybe_wake_tx, recycle_*, stamp_submits,
-// cos_queue_dscp_rewrite, TxError, the guarantee/quantum constants).
-// Those move with the afxdp/tx/ split in #984.
+// All per-byte / per-batch hot-path fns carry `#[inline]` to
+// preserve cross-module inlining at the `pub(in crate::afxdp)`
+// boundary. Larger drain/settle bodies skip `#[inline]` — LLVM's
+// heuristic threshold covers them.
 
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;

--- a/userspace-dp/src/afxdp/cos/queue_service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service.rs
@@ -37,11 +37,6 @@ use super::{
     refill_cos_tokens, COS_MIN_BURST_BYTES,
 };
 
-// #956 P1: TX-completion + timer-wheel symbols + scheduling primitives
-// (CoSServicePhase, ParkReason, count_park_reason, park_cos_queue)
-// moved to cos/tx_completion.rs. Moving the scheduling primitives
-// breaks the previous cyclic queue_service <-> tx_completion module
-// dependency (Copilot review on PR #990).
 use super::tx_completion::{
     apply_cos_prepared_result, apply_cos_send_result,
     apply_direct_exact_send_result, cos_tick_for_ns,
@@ -50,9 +45,9 @@ use super::tx_completion::{
     restore_cos_local_items_inner, restore_cos_prepared_items_inner, CoSServicePhase,
     ParkReason,
 };
-// Remaining back-edges to tx.rs (XSK-ring / worker-binding /
-// prepared-frame primitives + TxError + guarantee/quantum constants —
-// deferred to #984 / afxdp/tx/ split).
+// Back-edges to crate::afxdp::tx are XSK-ring / worker-binding /
+// prepared-frame primitives — primitives that own the kernel ring
+// state and are hosted there for that reason.
 use crate::afxdp::tx::{
     cos_queue_dscp_rewrite, maybe_wake_tx, reap_tx_completions,
     recycle_cancelled_prepared_offset, remember_prepared_recycle, stamp_submits,

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -1,38 +1,14 @@
-// #956 Phase 4: token-bucket lease/refill helpers, extracted from
-// tx.rs. Provides the per-byte token-budget plumbing that admission
-// gates and the drain-scheduler use to throttle TX pacing:
-//
-//   - `refill_cos_tokens` — basic credit-driven refill against
-//     `transmit_rate_bytes` and a `burst_bytes` cap.
-//   - `maybe_top_up_cos_root_lease` / `maybe_top_up_cos_queue_lease`
-//     — pull bytes from the shared cross-binding lease pools and
-//     deposit them on the local root / queue runtime.
-//   - `cos_refill_ns_until` — pure-arithmetic helper used by the
-//     drain scheduler to compute "how long until enough tokens
-//     accrue for the next packet." (Stays in this module rather
-//     than the timer-wheel module because it has no dependency on
-//     `COS_TIMER_WHEEL_*` constants — the consumer
-//     `calc_cos_wake_ns` does the tick conversion separately.)
-//   - `release_cos_root_lease` / `release_all_cos_root_leases` /
-//     `release_all_cos_queue_leases` — return cross-binding lease
-//     bytes back to the shared pool on RG transitions / shutdown.
+// Token-bucket lease/refill plumbing for TX pacing.
 //
 // `COS_MIN_BURST_BYTES` (64 × MTU) is the universal floor for both
-// root and per-queue burst caps and lives here as the canonical
-// owner of the constant.
+// root and per-queue burst caps and lives here as canonical owner.
 //
-// The 3 per-byte helpers (`refill_cos_tokens` and both
-// `maybe_top_up_*` helpers) carry `#[inline]` so the compiler still
-// inlines them across the cos/* boundary — same pattern Phase 2
-// (`cos_flow_bucket_index`, `cos_queue_prospective_active_flows`)
-// and Phase 3 (`cos_queue_flow_share_limit`,
-// `cos_flow_aware_buffer_limit`, `apply_cos_admission_ecn_policy`)
-// validated. The other 4 helpers fire at most once per drain loop
-// or once per RG-transition / shutdown, so they stay un-attributed.
-//
-// `tx_frame_capacity()` lives in the parent `afxdp` module and is
-// imported via `crate::afxdp::tx_frame_capacity` — Codex round-1
-// R1-2 caught the earlier mis-attribution to `super::tx::*`.
+// The 3 per-byte helpers (`refill_cos_tokens`,
+// `maybe_top_up_cos_root_lease`, `maybe_top_up_cos_queue_lease`)
+// carry `#[inline]` to preserve cross-module inlining at the
+// `pub(in crate::afxdp)` boundary. The other 4 helpers fire at
+// most once per drain loop or once per RG-transition / shutdown,
+// so they stay un-attributed.
 
 use std::sync::Arc;
 

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -1,22 +1,9 @@
-// #956 P1 (PR following #983): TX-completion + timer-wheel cluster
-// extracted from tx.rs.
-//
-// This module owns:
-//   - The CoS interface timer wheel (advance / cascade / wake-due
-//     slot management + the COS_TIMER_WHEEL_TICK_NS / horizon
-//     constants).
-//   - The TX-completion apply path (apply_direct_exact_send_result,
-//     apply_cos_send_result, apply_cos_prepared_result) and the
-//     refresh / restore helpers they use.
-//   - prime_cos_root_for_service (single drain-cycle entry called by
-//     queue_service before each service pass).
-//
-// Closes the Phase 6 builder back-edge (cos/builders.rs ->
-// tx::cos_tick_for_ns) and the TX-completion / timer-wheel subset of
-// the Phase 7 deferrals (10 of the 18 fns imported by
-// cos/queue_service.rs from crate::afxdp::tx::). The remaining 8 fns
-// + TxError + 4 guarantee/quantum constants stay on
-// crate::afxdp::tx, deferred to #984 (afxdp/tx/ split).
+// CoS TX-completion + timer-wheel. Owns the interface timer wheel
+// (advance / cascade / wake-due slot management), the TX-completion
+// apply path (apply_direct_exact_send_result, apply_cos_send_result,
+// apply_cos_prepared_result) and the refresh / restore helpers they
+// use, plus prime_cos_root_for_service (single drain-cycle entry
+// called by queue_service before each service pass).
 
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -1,29 +1,7 @@
-// #984 P2d (FINAL): CoS classify + enqueue + cached-selection cluster,
-// extracted from tx/mod.rs.
-//
-// 6 public items (all pub(in crate::afxdp), incl CoSTxSelection struct):
-//   - CoSTxSelection (struct + fields)
-//   - resolve_cached_cos_tx_selection
-//   - resolve_cos_queue_id
-//   - resolve_cos_tx_selection
-//   - enqueue_local_into_cos
-//   - cos_queue_dscp_rewrite
-//
-// 10 helpers in cos_classify.rs (4 file-private + 6 pub(super)):
-//   pub(super):
-//     - prepare_local_request_for_cos (test pin)
-//     - enqueue_prepared_into_cos (drain.rs sibling caller)
-//     - clone_prepared_request_for_cos (test pin)
-//     - resolve_cos_queue_idx (test pin)
-//     - demote_prepared_cos_queue_to_local (test pin)
-//     - cos_queue_accepts_prepared (test pin)
-//   file-private:
-//     - map_cached_forwarding_class_queue
-//     - resolve_cos_dscp_classifier_queue_id
-//     - resolve_cos_ieee8021_classifier_queue_id
-//     - enqueue_cos_item
-//
-// Single-writer (owner worker), all atomic ops Ordering::Relaxed.
+// CoS classification: maps a packet's policy/filter/classifier
+// signals to a CoS queue id and an optional DSCP rewrite, then
+// enqueues onto the chosen queue. Single-writer (owner worker);
+// atomic ops use `Ordering::Relaxed`.
 
 use super::*;
 

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -1,18 +1,5 @@
-// #984 P2c2: drain dispatch + queue-bound + pending-queue helpers,
-// extracted from tx/mod.rs.
-//
-// Items here:
-//   - pending_tx_capacity, bound_pending_tx_local,
-//     bound_pending_tx_prepared: queue-bound / backpressure helpers.
-//   - drain_pending_tx, drain_pending_tx_local_owner: per-tick drain
-//     dispatch entry points.
-//   - drop_cos_bound_*, partition_*, binding_has_pending_tx_work,
-//     ingest_*: file-private drain helpers.
-//   - process_pending_queue_in_place, take_/restore_pending_tx_requests:
-//     pending-queue manipulation helpers (file-private).
-//   - COS_GUARANTEE_*/COS_SURPLUS_* constants.
-//
-// Single-writer (owner worker), all atomic ops Ordering::Relaxed.
+// Per-tick drain dispatch + queue-bound / pending-queue helpers.
+// Single-writer (owner worker); atomic ops use `Ordering::Relaxed`.
 
 use super::*;
 

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -1,101 +1,51 @@
 use super::*;
 
-// #984 P2a: TX latency-histogram + completion-sidecar helpers
-// extracted to sibling module `tx/stats.rs`. The re-export below is
-// load-bearing: `umem.rs::tests` (umem.rs:950+) reaches the three fns
-// through `crate::afxdp::tx::{stamp_submits,
-// record_tx_completions_with_stamp, record_kick_latency}` and that
-// path resolves through this `pub(in crate::afxdp) use`.
 pub(super) mod stats;
 pub(in crate::afxdp) use stats::stamp_submits;
-// `record_kick_latency` and `record_tx_completions_with_stamp` are
-// reached only by `umem.rs::tests` via `crate::afxdp::tx::*` (see
-// umem.rs:966/1077/1124/1188 — all `#[cfg(test)]`). Production callers
-// inside `tx/rings.rs` import them directly from `super::stats::*`.
 #[cfg(test)]
 pub(in crate::afxdp) use stats::{record_kick_latency, record_tx_completions_with_stamp};
 
-// #984 P2b: XSK kernel-ring discipline (TX completion drain, fill ring
-// submit, RX/TX kernel wake) extracted to sibling module `tx/rings.rs`.
-// External callers (cos/queue_service.rs uses reap_tx_completions and
-// maybe_wake_tx; afxdp.rs / frame_tx.rs use drain_pending_fill and
-// maybe_wake_rx) reach the moved fns through these re-exports at the
-// same `crate::afxdp::tx::*` paths they used pre-move.
 pub(super) mod rings;
 pub(in crate::afxdp) use rings::{maybe_wake_tx, reap_tx_completions};
 pub(super) use rings::{drain_pending_fill, maybe_wake_rx};
 
-// #984 P2c: TX-ring submit + per-frame recycle cluster (transmit_batch,
-// transmit_prepared_queue, recycle_*, TxError) extracted to sibling
-// module `tx/transmit.rs`. External callers (cos/queue_service.rs
-// imports recycle_cancelled_prepared_offset, remember_prepared_recycle,
-// transmit_batch, transmit_prepared_queue, TxError;
-// cos/cross_binding.rs and worker.rs:1974 import recycle_prepared_immediately)
-// reach the moved items via the re-export below.
 pub(super) mod transmit;
 pub(in crate::afxdp) use transmit::{
-    recycle_cancelled_prepared_offset, recycle_prepared_immediately,
-    remember_prepared_recycle, transmit_batch, transmit_prepared_queue, TxError,
+    recycle_cancelled_prepared_offset, recycle_prepared_immediately, remember_prepared_recycle,
+    transmit_batch, transmit_prepared_queue, TxError,
 };
-// transmit_prepared_batch is sibling-internal (only caller in tx/mod.rs);
-// this private import keeps it available within this module.
 use transmit::transmit_prepared_batch;
 
-// #984 P2c2: drain dispatch + queue-bound + pending-queue helpers
-// extracted to sibling module `tx/drain.rs`. cos/queue_service.rs
-// imports the 4 quantum/guarantee constants via crate::afxdp::tx::*,
-// so that re-export is load-bearing.
 pub(super) mod drain;
 pub(super) use drain::{
     bound_pending_tx_local, bound_pending_tx_prepared, drain_pending_tx,
     drain_pending_tx_local_owner, pending_tx_capacity,
 };
 pub(in crate::afxdp) use drain::{
-    COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES,
-    COS_GUARANTEE_VISIT_NS, COS_SURPLUS_ROUND_QUANTUM_BYTES,
+    COS_GUARANTEE_QUANTUM_MAX_BYTES, COS_GUARANTEE_QUANTUM_MIN_BYTES, COS_GUARANTEE_VISIT_NS,
+    COS_SURPLUS_ROUND_QUANTUM_BYTES,
 };
 
-// #984 P2d (FINAL): CoS classify + enqueue + cached-selection cluster
-// extracted to sibling module `tx/cos_classify.rs`. Closes #984.
 pub(super) mod cos_classify;
+pub(super) use cos_classify::{
+    enqueue_local_into_cos, resolve_cached_cos_tx_selection, resolve_cos_queue_id,
+    resolve_cos_tx_selection, CoSTxSelection,
+};
+pub(in crate::afxdp) use cos_classify::cos_queue_dscp_rewrite;
+// Private use, not a re-export: a `pub(super) use` of a `pub(super)`
+// item triggers E0364. drain.rs reaches this through `use super::*;`.
+use cos_classify::enqueue_prepared_into_cos;
 
-// #984 P3 follow-up: shared test helpers hoisted out of the inline
-// `mod tests` so per-file test modules in `tx/*.rs` and `cos/*.rs`
-// siblings can reuse them via `crate::afxdp::tx::test_support::*`.
 #[cfg(test)]
 pub(in crate::afxdp) mod test_support;
 
-pub(super) use cos_classify::{
-    CoSTxSelection, enqueue_local_into_cos, resolve_cached_cos_tx_selection,
-    resolve_cos_queue_id, resolve_cos_tx_selection,
-};
-pub(in crate::afxdp) use cos_classify::cos_queue_dscp_rewrite;
-// Private import (NOT re-export — E0364 if pub(super) re-export of
-// pub(super) source): drain.rs reaches it via `use super::*;`.
-use cos_classify::enqueue_prepared_into_cos;
-
-// #956: cos/ submodule imports.
-//
-// Phase 1 (PR #976) extracted ECN marking into cos/ecn.rs.
-// Phase 2 (PR #977) extracted the flow-hash helpers into
-// cos/flow_hash.rs. Phase 3 (PR #978) extracted admission policy +
-// flow-fair promotion into cos/admission.rs. Phase 4 (PR #979)
-// extracted token-bucket lease/refill into cos/token_bucket.rs.
-// Phase 5 (this PR) extracts queue ops + MQFQ ordering bookkeeping
-// + V-min slot lifecycle into cos/queue_ops.rs.
-//
-// Production code uses the entry points re-exported from
-// cos/mod.rs (marker fns + flow-hash + admission gates +
-// flow-fair promotion entry + token-bucket helpers + queue-ops
-// fns).
 use super::cos::{
     apply_cos_admission_ecn_policy, cos_flow_aware_buffer_limit, cos_flow_bucket_index,
-    cos_item_flow_key, cos_queue_drain_all, cos_queue_flow_share_limit,
-    cos_queue_is_empty, cos_queue_push_back, cos_queue_restore_front,
-    drain_shaped_tx, ensure_cos_interface_runtime, mark_cos_queue_runnable,
-    publish_committed_queue_vtime, redirect_prepared_cos_request_to_owner,
-    redirect_prepared_cos_request_to_owner_binding,
-    resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
+    cos_item_flow_key, cos_queue_drain_all, cos_queue_flow_share_limit, cos_queue_is_empty,
+    cos_queue_push_back, cos_queue_restore_front, drain_shaped_tx, ensure_cos_interface_runtime,
+    mark_cos_queue_runnable, publish_committed_queue_vtime, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding, resolve_local_routing_decision,
+    LocalRoutingDecision, Step1Action,
 };
 #[cfg(test)]
 use super::cos::COS_MIN_BURST_BYTES;

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -1,23 +1,6 @@
-// #984 P2b: XSK kernel-ring discipline cluster, extracted from
-// tx/mod.rs.
-//
-// Six items live here:
-//   - `reap_tx_completions`: drain the XSK completion ring via
-//     `device.complete()` and feed completed offsets to the stats
-//     fold + per-offset cleanup.
-//   - `drain_pending_fill`: refill the XSK fill ring via
-//     `device.fill().insert(...)` + `commit()`.
-//   - `maybe_wake_rx` / `maybe_wake_tx`: kernel-wakeup gates that
-//     issue `sendto` after fill / TX submit (rate-limited per the
-//     RX_WAKE_* / TX_WAKE_* constants in afxdp.rs).
-//   - `recycle_completed_tx_offset` (file-private helper): per-offset
-//     cleanup invoked from inside `reap_tx_completions`.
-//   - `apply_prepared_recycle` (file-private):
-//     `recycle_completed_tx_offset`'s `PreparedTxRecycle`
-//     dispatcher. Now exercised by a colocated test in this
-//     module's `mod tests`.
-//
-// Single-writer (owner worker), all atomic ops `Ordering::Relaxed`.
+// XSK kernel-ring discipline: completion drain, fill submit, RX/TX
+// kernel wake. Single-writer (owner worker); atomic ops use
+// `Ordering::Relaxed`.
 
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;

--- a/userspace-dp/src/afxdp/tx/stats.rs
+++ b/userspace-dp/src/afxdp/tx/stats.rs
@@ -1,23 +1,5 @@
-// #984 P2a: TX latency-histogram + completion-sidecar helpers,
-// extracted from tx.rs (now tx/mod.rs).
-//
-// All three functions are pure stat-recorders:
-//   - `stamp_submits<I>`: write per-frame submit timestamps into the
-//     per-binding sidecar `&mut [u64]`, called once per writer.commit().
-//   - `record_tx_completions_with_stamp`: read sidecar at completion
-//     time, fold per-batch deltas into bucket-local counters, bump
-//     `OwnerProfileOwnerWrites.tx_submit_latency_*`.
-//   - `record_kick_latency`: kick-side analogue, bumps
-//     `OwnerProfileOwnerWrites.tx_kick_latency_*`.
-//
-// Single-writer: the owner worker is the only thread that calls these.
-// All counter updates use `Ordering::Relaxed`; the sidecar `&mut [u64]`
-// is non-atomic (single-writer guarantees plus per-frame timestamps).
-//
-// Canonical pins live in `umem.rs::tests` (umem.rs:950+); they reach
-// these fns via `crate::afxdp::tx::{stamp_submits,
-// record_tx_completions_with_stamp, record_kick_latency}` thanks to
-// the load-bearing re-export in `tx/mod.rs`.
+// Single-writer (owner worker thread): per-frame counters use
+// `Ordering::Relaxed` and the sidecar `&mut [u64]` is non-atomic.
 
 use std::sync::atomic::Ordering;
 

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -1,11 +1,7 @@
-//! Shared test helpers for the TX module and its CoS-shaping siblings.
-//!
-//! Hoisted from `tx/mod.rs::tests` (#984 P3 follow-up) so that
-//! per-file test modules in `tx/*.rs` and `cos/*.rs` can colocate
-//! their tests with the code they exercise without duplicating
-//! these constructors. Visibility is `pub(in crate::afxdp)` so any
+//! Shared test fixtures for the TX module and its CoS-shaping
+//! siblings. Visibility is `pub(in crate::afxdp)` so any
 //! `#[cfg(test)] mod tests` under `crate::afxdp::*` can reach them
-//! via `use crate::afxdp::tx::test_support::*;`.
+//! via `crate::afxdp::tx::test_support::*`.
 
 #![cfg(test)]
 

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -1,7 +1,7 @@
 //! Shared test fixtures for the TX module and its CoS-shaping
 //! siblings. Visibility is `pub(in crate::afxdp)` so any
 //! `#[cfg(test)] mod tests` under `crate::afxdp::*` can reach them
-//! via `crate::afxdp::tx::test_support::*`.
+//! via `use crate::afxdp::tx::test_support::*;`.
 
 #![cfg(test)]
 

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -1,16 +1,5 @@
-// #984 P2c: TX-ring submit + per-frame recycle cluster, extracted
-// from tx/mod.rs.
-//
-// Items here:
-//   - TxError: error type returned by submit fns.
-//   - recycle_cancelled_prepared_offset: prepared-frame cancel handler.
-//   - recycle_prepared_immediately: prepared-frame eager-cleanup helper.
-//   - remember_prepared_recycle: per-offset PreparedTxRecycle bookkeeping.
-//   - transmit_batch: XSK TX-ring submit for local TxRequests.
-//   - transmit_prepared_batch (pub(super)): caller hook from tx/mod.rs.
-//   - transmit_prepared_queue: XSK TX-ring submit for prepared frames.
-//
-// Single-writer (owner worker), all atomic ops Ordering::Relaxed.
+// XSK TX-ring submit + per-frame recycle. Single-writer (owner
+// worker); atomic ops use `Ordering::Relaxed`.
 
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;


### PR DESCRIPTION
Cleanup PR after the #984 P3 test redistribution closed (#997-#1015 merged).

## Changes

**Comment / preamble cleanup (the bulk of the diff):**
- `tx/mod.rs`: 101 → 51 LOC; only kept the E0364 explanation as a real WHY.
- `cos/mod.rs`: 50 → 36 LOC; phase chronology dropped.
- 13 sibling file headers (tx/* and cos/*): dropped "#956 Phase X / extracted from tx.rs / item enumeration / external callers" preambles. Kept single-writer invariants, `#[inline]` rationale, hot-path diagram (queue_service), constant-ownership rationale (flow_hash, admission), back-edge documentation (cross_binding).

**Light reorder in `tx/mod.rs`** (Copilot caught this — clarifying scope): the rewrite groups each `pub(super) mod X;` immediately above its `use X::{...}` re-exports. Pre-cleanup `test_support` and the cos_classify uses were scattered across two blocks. No semantic / visibility change — every export is byte-identical.

**docs/engineering-style.md:** new "Modularity discipline" section codifying the rule the user asked for going forward — files >~2000 LOC and fns >100 LOC or >8 params trigger refactor *on the way in* (not "later"); tests colocate with their production code; reviewers escalate monolith creep.

## Why

Project guidance (CLAUDE.md, engineering-style.md): "Body paragraphs explain *why*, not *what*. The diff shows what." Comments referencing "current task, fix, or callers" rot as the codebase evolves. The phase-extraction commentary is exactly that — git log + PR descriptions own the history.

## Diff stats

After round-2 fixes:
```
~20 files changed, ~130 insertions(+), ~420 deletions(-)
```

Net ~-290 LOC, all comments and the tx/mod.rs reorder. No behavior change.

## Test plan
- [x] cargo build --bins clean
- [x] cargo test --bins 865/0/2
- [x] Codex round-1 IMPL-NEEDS-MINOR (3 findings) → addressed in `1c15ab32`
- [ ] Codex round-2 confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)