### PR TITLE
tx/dispatch.rs: move frame_tx.rs into the tx subsystem (#1016 Phase 0)

### DIFF
--- a/bpf/headers/xpf_maps.h
+++ b/bpf/headers/xpf_maps.h
@@ -351,7 +351,7 @@ struct {
  * forwarding on mlx5 SR-IOV VFs running kernel 7.0.0-rc7+. Observed
  * symptoms: ping RTT 0.4 ms → 300 ms with 33% loss, iperf3 sustained
  * 0 bps, and the Rust helper emitted `DBG SEG_MISS` for every
- * frame it handled. (The SEG_MISS log fires from frame_tx.rs on
+ * frame it handled. (The SEG_MISS log fires from tx/dispatch.rs on
  * frame-length criteria independent of bpf_redirect_map's result,
  * so it's a symptom that packets reached the helper in a state the
  * TX path couldn't service — not direct evidence about the redirect.)

--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -63,8 +63,6 @@ mod forwarding;
 mod forwarding_build;
 #[path = "afxdp/frame.rs"]
 mod frame;
-#[path = "afxdp/frame_tx.rs"]
-mod frame_tx;
 #[path = "afxdp/mpsc_inbox.rs"]
 mod mpsc_inbox;
 #[path = "afxdp/gre.rs"]
@@ -121,7 +119,7 @@ use self::flow_cache::*;
 use self::forwarding::*;
 use self::forwarding_build::*;
 use self::frame::*;
-use self::frame_tx::*;
+use self::tx::dispatch::*;
 use self::gre::{encapsulate_native_gre_frame, try_native_gre_decap_from_frame};
 use self::icmp::{FABRIC_INGRESS_FLAG, build_local_time_exceeded_request, is_icmp_error};
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -63,7 +63,7 @@ fn recycle_ingress_frame(ingress_binding: &mut BindingWorker, source_offset: u64
     }
 }
 
-pub(super) fn enqueue_pending_forwards(
+pub(in crate::afxdp) fn enqueue_pending_forwards(
     left: &mut [BindingWorker],
     ingress_index: usize,
     ingress_binding: &mut BindingWorker,
@@ -885,7 +885,7 @@ fn resolve_pending_forward_target_binding<'a>(
     )
 }
 
-pub(super) fn handle_forward_build_failure(
+pub(in crate::afxdp) fn handle_forward_build_failure(
     binding: &BindingIdentity,
     live: &BindingLiveState,
     slow_path: Option<&Arc<SlowPathReinjector>>,
@@ -936,7 +936,7 @@ pub(super) fn handle_forward_build_failure(
     }
 }
 
-pub(super) fn apply_shared_recycles(
+pub(in crate::afxdp) fn apply_shared_recycles(
     left: &mut [BindingWorker],
     current_index: usize,
     current: &mut BindingWorker,
@@ -959,7 +959,7 @@ pub(super) fn apply_shared_recycles(
     }
 }
 
-pub(super) fn resolve_tx_binding_ifindex(forwarding: &ForwardingState, egress_ifindex: i32) -> i32 {
+pub(in crate::afxdp) fn resolve_tx_binding_ifindex(forwarding: &ForwardingState, egress_ifindex: i32) -> i32 {
     if let Some(fabric) = forwarding
         .fabrics
         .iter()
@@ -987,7 +987,7 @@ fn resolve_pending_forward_cos_tx_selection(
     )
 }
 
-pub(super) fn maybe_reinject_slow_path(
+pub(in crate::afxdp) fn maybe_reinject_slow_path(
     binding: &BindingIdentity,
     live: &BindingLiveState,
     slow_path: Option<&Arc<SlowPathReinjector>>,
@@ -1036,7 +1036,7 @@ pub(super) fn maybe_reinject_slow_path(
     );
 }
 
-pub(super) fn maybe_reinject_slow_path_from_frame(
+pub(in crate::afxdp) fn maybe_reinject_slow_path_from_frame(
     binding: &BindingIdentity,
     live: &BindingLiveState,
     slow_path: Option<&Arc<SlowPathReinjector>>,
@@ -1186,7 +1186,7 @@ pub(super) fn extract_l3_packet_from_frame(
     Some(frame[l3..].to_vec())
 }
 
-pub(super) fn extract_l3_packet_with_nat(
+pub(in crate::afxdp) fn extract_l3_packet_with_nat(
     frame: &[u8],
     meta: impl Into<ForwardPacketMeta>,
     nat: NatDecision,

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -27,6 +27,7 @@ pub(in crate::afxdp) use drain::{
 };
 
 pub(super) mod cos_classify;
+pub(super) mod dispatch;
 pub(super) use cos_classify::{
     enqueue_local_into_cos, resolve_cached_cos_tx_selection, resolve_cos_queue_id,
     resolve_cos_tx_selection, CoSTxSelection,


### PR DESCRIPTION
Phase 0 of #1016 — closes the location concern from #984.

Mechanical rename: `afxdp/frame_tx.rs` → `afxdp/tx/dispatch.rs`. No body changes; the 1,000+ LOC enqueue_pending_forwards god function decoupling is Phase 1 (pairs with #946 / #988 / #961).

## Diff
- Move file via `git mv`.
- afxdp.rs: drop the `#[path = "afxdp/frame_tx.rs"] mod frame_tx;` pair; `use self::frame_tx::*;` → `use self::tx::dispatch::*;`.
- tx/mod.rs: declare `pub(super) mod dispatch;`.
- 7 fns widen pub(super) → pub(in crate::afxdp) so they remain reachable from afxdp.rs at the deeper nesting.

## Test plan
- [x] cargo test --bins 865/0/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)