### PR TITLE
umem: extract MmapArea raw OS allocator into umem/mmap.rs (#986 Phase 0)

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -100,7 +100,7 @@ mod tunnel;
 mod tx;
 #[path = "afxdp/types.rs"]
 mod types;
-#[path = "afxdp/umem.rs"]
+#[path = "afxdp/umem/mod.rs"]
 mod umem;
 
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/umem/mmap.rs
+++ b/userspace-dp/src/afxdp/umem/mmap.rs
@@ -1,0 +1,133 @@
+// Raw OS memory allocation for AF_XDP UMEM regions.
+//
+// Owns the mmap()/munmap() lifecycle and the hugepage selection
+// policy: try explicit 2 MB hugepages first, fall back to standard
+// pages with a transparent-hugepage advisory hint.
+
+use std::io;
+use std::os::raw::c_void;
+use std::ptr::NonNull;
+
+pub(in crate::afxdp) struct MmapArea {
+    ptr: NonNull<u8>,
+    /// Original requested size (passed to XSK via as_nonnull_slice).
+    len: usize,
+    /// Actual mmap size (may be rounded up for hugepage alignment).
+    mapped_len: usize,
+    /// Whether the region is backed by explicit 2 MB hugepages.
+    hugepage: bool,
+}
+
+const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
+
+impl MmapArea {
+    pub(in crate::afxdp) fn new(len: usize) -> io::Result<Self> {
+        // Round up to 2 MB boundary for hugepage eligibility.
+        let aligned_len = (len + HUGE_PAGE_SIZE - 1) & !(HUGE_PAGE_SIZE - 1);
+
+        // Attempt 1: explicit 2 MB hugepages (requires system reservation).
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                aligned_len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE
+                    | libc::MAP_ANONYMOUS
+                    | libc::MAP_HUGETLB
+                    | libc::MAP_POPULATE
+                    | (21 << libc::MAP_HUGE_SHIFT), // MAP_HUGE_2MB
+                -1,
+                0,
+            )
+        };
+        if ptr != libc::MAP_FAILED {
+            let ptr = NonNull::new(ptr.cast::<u8>())
+                .ok_or_else(|| io::Error::other("null mmap pointer"))?;
+            eprintln!(
+                "xpf-ha: umem alloc {} bytes ({} MB, 2MB hugepages)",
+                aligned_len,
+                aligned_len / (1024 * 1024)
+            );
+            return Ok(Self {
+                ptr,
+                len,
+                mapped_len: aligned_len,
+                hugepage: true,
+            });
+        }
+
+        // Attempt 2: standard pages with MAP_POPULATE + THP advisory hint.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                aligned_len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_POPULATE,
+                -1,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+        // Request transparent hugepage backing (advisory, cannot fail).
+        unsafe {
+            libc::madvise(ptr, aligned_len, libc::MADV_HUGEPAGE);
+        }
+        let ptr =
+            NonNull::new(ptr.cast::<u8>()).ok_or_else(|| io::Error::other("null mmap pointer"))?;
+        eprintln!(
+            "xpf-ha: umem alloc {} bytes ({} MB, standard pages + THP hint)",
+            aligned_len,
+            aligned_len / (1024 * 1024)
+        );
+        Ok(Self {
+            ptr,
+            len,
+            mapped_len: aligned_len,
+            hugepage: false,
+        })
+    }
+
+    /// Returns the original requested length (for XSK registration).
+    pub(in crate::afxdp) fn as_nonnull_slice(&self) -> NonNull<[u8]> {
+        NonNull::slice_from_raw_parts(self.ptr, self.len)
+    }
+
+    /// Whether this region is backed by explicit 2 MB hugepages.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(in crate::afxdp) fn is_hugepage_backed(&self) -> bool {
+        self.hugepage
+    }
+
+    pub(in crate::afxdp) fn slice(&self, offset: usize, len: usize) -> Option<&[u8]> {
+        let end = offset.checked_add(len)?;
+        if end > self.len {
+            return None;
+        }
+        Some(unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().add(offset), len) })
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(in crate::afxdp) fn slice_mut(&mut self, offset: usize, len: usize) -> Option<&mut [u8]> {
+        unsafe { self.slice_mut_unchecked(offset, len) }
+    }
+
+    pub(in crate::afxdp) unsafe fn slice_mut_unchecked(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Option<&mut [u8]> {
+        let end = offset.checked_add(len)?;
+        if end > self.len {
+            return None;
+        }
+        Some(unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().add(offset), len) })
+    }
+}
+
+impl Drop for MmapArea {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::munmap(self.ptr.as_ptr().cast::<c_void>(), self.mapped_len) };
+    }
+}

--- a/userspace-dp/src/afxdp/umem/mmap.rs
+++ b/userspace-dp/src/afxdp/umem/mmap.rs
@@ -70,7 +70,11 @@ impl MmapArea {
         if ptr == libc::MAP_FAILED {
             return Err(io::Error::last_os_error());
         }
-        // Request transparent hugepage backing (advisory, cannot fail).
+        // Best-effort: request transparent hugepage backing.
+        // `madvise(MADV_HUGEPAGE)` can fail (EINVAL on unsupported
+        // kernels, ENOMEM under pressure); the return is ignored
+        // intentionally because falling back to non-THP standard
+        // pages is correct.
         unsafe {
             libc::madvise(ptr, aligned_len, libc::MADV_HUGEPAGE);
         }
@@ -113,6 +117,18 @@ impl MmapArea {
         unsafe { self.slice_mut_unchecked(offset, len) }
     }
 
+    /// Returns a `&mut [u8]` view into the UMEM region from a
+    /// shared `&self` reference.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that no other borrow (mutable or
+    /// shared) into the same `[offset, offset + len)` byte range
+    /// is live for the lifetime of the returned slice, and that no
+    /// other thread is concurrently reading or writing that range.
+    /// AF_XDP single-writer (owner-worker) discipline plus per-frame
+    /// offset assignment from the free-frame ring is what holds
+    /// these invariants in production.
     pub(in crate::afxdp) unsafe fn slice_mut_unchecked(
         &self,
         offset: usize,

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+pub(super) mod mmap;
+pub(in crate::afxdp) use mmap::MmapArea;
+
 pub(super) struct WorkerUmemInner {
     area: MmapArea,
     umem: Umem,
@@ -85,18 +88,8 @@ impl WorkerUmemPool {
     }
 }
 
-pub(super) struct MmapArea {
-    ptr: NonNull<u8>,
-    /// Original requested size (passed to XSK via as_nonnull_slice).
-    len: usize,
-    /// Actual mmap size (may be rounded up for hugepage alignment).
-    mapped_len: usize,
-    /// Whether the region is backed by explicit 2 MB hugepages.
-    hugepage: bool,
-}
 
 /// 2 MB hugepage size.
-const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
 
 /// Hard capacity of the per-binding redirect inbox
 /// (`BindingLiveState::pending_tx`). Sized to cover the highest expected
@@ -402,117 +395,7 @@ impl OwnerProfilePeerWrites {
     }
 }
 
-impl MmapArea {
-    pub(super) fn new(len: usize) -> io::Result<Self> {
-        // Round up to 2 MB boundary for hugepage eligibility.
-        let aligned_len = (len + HUGE_PAGE_SIZE - 1) & !(HUGE_PAGE_SIZE - 1);
 
-        // Attempt 1: explicit 2 MB hugepages (requires system reservation).
-        let ptr = unsafe {
-            libc::mmap(
-                std::ptr::null_mut(),
-                aligned_len,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE
-                    | libc::MAP_ANONYMOUS
-                    | libc::MAP_HUGETLB
-                    | libc::MAP_POPULATE
-                    | (21 << libc::MAP_HUGE_SHIFT), // MAP_HUGE_2MB
-                -1,
-                0,
-            )
-        };
-        if ptr != libc::MAP_FAILED {
-            let ptr = NonNull::new(ptr.cast::<u8>())
-                .ok_or_else(|| io::Error::other("null mmap pointer"))?;
-            eprintln!(
-                "xpf-ha: umem alloc {} bytes ({} MB, 2MB hugepages)",
-                aligned_len,
-                aligned_len / (1024 * 1024)
-            );
-            return Ok(Self {
-                ptr,
-                len,
-                mapped_len: aligned_len,
-                hugepage: true,
-            });
-        }
-
-        // Attempt 2: standard pages with MAP_POPULATE + THP advisory hint.
-        let ptr = unsafe {
-            libc::mmap(
-                std::ptr::null_mut(),
-                aligned_len,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_POPULATE,
-                -1,
-                0,
-            )
-        };
-        if ptr == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error());
-        }
-        // Request transparent hugepage backing (advisory, cannot fail).
-        unsafe {
-            libc::madvise(ptr, aligned_len, libc::MADV_HUGEPAGE);
-        }
-        let ptr =
-            NonNull::new(ptr.cast::<u8>()).ok_or_else(|| io::Error::other("null mmap pointer"))?;
-        eprintln!(
-            "xpf-ha: umem alloc {} bytes ({} MB, standard pages + THP hint)",
-            aligned_len,
-            aligned_len / (1024 * 1024)
-        );
-        Ok(Self {
-            ptr,
-            len,
-            mapped_len: aligned_len,
-            hugepage: false,
-        })
-    }
-
-    /// Returns the original requested length (for XSK registration).
-    pub(super) fn as_nonnull_slice(&self) -> NonNull<[u8]> {
-        NonNull::slice_from_raw_parts(self.ptr, self.len)
-    }
-
-    /// Whether this region is backed by explicit 2 MB hugepages.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(super) fn is_hugepage_backed(&self) -> bool {
-        self.hugepage
-    }
-
-    pub(super) fn slice(&self, offset: usize, len: usize) -> Option<&[u8]> {
-        let end = offset.checked_add(len)?;
-        if end > self.len {
-            return None;
-        }
-        Some(unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().add(offset), len) })
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(super) fn slice_mut(&mut self, offset: usize, len: usize) -> Option<&mut [u8]> {
-        unsafe { self.slice_mut_unchecked(offset, len) }
-    }
-
-    pub(super) unsafe fn slice_mut_unchecked(
-        &self,
-        offset: usize,
-        len: usize,
-    ) -> Option<&mut [u8]> {
-        let end = offset.checked_add(len)?;
-        if end > self.len {
-            return None;
-        }
-        Some(unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().add(offset), len) })
-    }
-}
-
-impl Drop for MmapArea {
-    fn drop(&mut self) {
-        let _ = unsafe { libc::munmap(self.ptr.as_ptr().cast::<c_void>(), self.mapped_len) };
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) mod mmap;
+mod mmap;
 pub(in crate::afxdp) use mmap::MmapArea;
 
 pub(super) struct WorkerUmemInner {
@@ -87,9 +87,6 @@ impl WorkerUmemPool {
         Ok(Self { umem, free_frames })
     }
 }
-
-
-/// 2 MB hugepage size.
 
 /// Hard capacity of the per-binding redirect inbox
 /// (`BindingLiveState::pending_tx`). Sized to cover the highest expected
@@ -394,8 +391,6 @@ impl OwnerProfilePeerWrites {
         }
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Phase 0 of #986 umem.rs decomposition.

Establishes the `umem/` directory layout and pulls the raw OS-interaction code (mmap()/munmap(), hugepage selection, slice accessors) out of the 2,647-line monolith.

## Diff
- `afxdp/umem.rs` → `afxdp/umem/mod.rs` (directory module).
- New `afxdp/umem/mmap.rs` (~133 LOC): MmapArea struct, HUGE_PAGE_SIZE const, inherent impl, Drop impl.
- umem/mod.rs declares `pub(in crate::afxdp) mod mmap;` and re-exports MmapArea.
- Visibility widened pub(super) → pub(in crate::afxdp) on items reached across the new module boundary.

After this PR:
- umem/mod.rs: 2,530 LOC (still a smell — Phase 1 will extract ring management; Phase 2 frame recycling; Phase 3 telemetry).
- umem/mmap.rs: 133 LOC.

## Test plan
- [x] cargo test --bins 865/0/2 (no body changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)