### PR TITLE
coordinator: extract BpfMaps trivial-cluster (#985 Phase 1)

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -272,7 +272,7 @@ const fn tx_frame_capacity() -> usize {
     UMEM_FRAME_SIZE as usize
 }
 
-#[path = "afxdp/coordinator.rs"]
+#[path = "afxdp/coordinator/mod.rs"]
 mod coordinator;
 #[cfg(test)]
 #[path = "afxdp/tests.rs"]

--- a/userspace-dp/src/afxdp/coordinator/bpf_maps.rs
+++ b/userspace-dp/src/afxdp/coordinator/bpf_maps.rs
@@ -1,0 +1,16 @@
+// BPF map file descriptors owned by the Coordinator. Bundled
+// together because they share lifecycle (loaded on `cluster up`,
+// dropped on `cluster down`) and have no other state.
+
+use crate::afxdp::bpf_map::OwnedFd;
+
+#[derive(Default)]
+pub(crate) struct BpfMaps {
+    pub(crate) map_fd: Option<OwnedFd>,
+    pub(crate) heartbeat_map_fd: Option<OwnedFd>,
+    pub(crate) session_map_fd: Option<OwnedFd>,
+    pub(crate) conntrack_v4_fd: Option<OwnedFd>,
+    pub(crate) conntrack_v6_fd: Option<OwnedFd>,
+    pub(crate) dnat_table_fd: Option<OwnedFd>,
+    pub(crate) dnat_table_v6_fd: Option<OwnedFd>,
+}

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1,13 +1,9 @@
 use super::*;
+mod bpf_maps;
+pub(crate) use bpf_maps::BpfMaps;
 
 pub struct Coordinator {
-    pub(crate) map_fd: Option<OwnedFd>,
-    pub(crate) heartbeat_map_fd: Option<OwnedFd>,
-    pub(crate) session_map_fd: Option<OwnedFd>,
-    pub(crate) conntrack_v4_fd: Option<OwnedFd>,
-    pub(crate) conntrack_v6_fd: Option<OwnedFd>,
-    pub(crate) dnat_table_fd: Option<OwnedFd>,
-    pub(crate) dnat_table_v6_fd: Option<OwnedFd>,
+    pub(crate) bpf_maps: BpfMaps,
     pub(crate) slow_path: Option<Arc<SlowPathReinjector>>,
     pub(crate) local_tunnel_deliveries: Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
     pub(crate) tunnel_sources: BTreeMap<u16, LocalTunnelSourceHandle>,
@@ -68,13 +64,7 @@ pub struct Coordinator {
 impl Coordinator {
     pub fn new() -> Self {
         Self {
-            map_fd: None,
-            heartbeat_map_fd: None,
-            session_map_fd: None,
-            conntrack_v4_fd: None,
-            conntrack_v6_fd: None,
-            dnat_table_fd: None,
-            dnat_table_v6_fd: None,
+            bpf_maps: BpfMaps::default(),
             slow_path: None,
             local_tunnel_deliveries: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             tunnel_sources: BTreeMap::new(),
@@ -267,12 +257,12 @@ impl Coordinator {
                 let _ = join.join();
             }
         }
-        if let Some(map_fd) = self.map_fd.as_ref() {
+        if let Some(map_fd) = self.bpf_maps.map_fd.as_ref() {
             for slot in self.live.keys().copied().collect::<Vec<_>>() {
                 let _ = delete_xsk_slot(map_fd.fd, slot);
             }
         }
-        if let Some(map_fd) = self.heartbeat_map_fd.as_ref() {
+        if let Some(map_fd) = self.bpf_maps.heartbeat_map_fd.as_ref() {
             for slot in self.live.keys().copied().collect::<Vec<_>>() {
                 let _ = delete_heartbeat_slot(map_fd.fd, slot);
             }
@@ -300,13 +290,13 @@ impl Coordinator {
             .map(|slow| slow.status())
             .unwrap_or_default();
         self.slow_path = None;
-        self.map_fd = None;
-        self.heartbeat_map_fd = None;
-        self.session_map_fd = None;
-        self.conntrack_v4_fd = None;
-        self.conntrack_v6_fd = None;
-        self.dnat_table_fd = None;
-        self.dnat_table_v6_fd = None;
+        self.bpf_maps.map_fd = None;
+        self.bpf_maps.heartbeat_map_fd = None;
+        self.bpf_maps.session_map_fd = None;
+        self.bpf_maps.conntrack_v4_fd = None;
+        self.bpf_maps.conntrack_v6_fd = None;
+        self.bpf_maps.dnat_table_fd = None;
+        self.bpf_maps.dnat_table_v6_fd = None;
         self.forwarding = ForwardingState::default();
         self.shared_forwarding
             .store(Arc::new(ForwardingState::default()));
@@ -638,13 +628,13 @@ impl Coordinator {
             self.live.len()
         );
         let session_map_raw_fd = session_map_fd.fd;
-        self.map_fd = Some(map_fd);
-        self.heartbeat_map_fd = Some(heartbeat_map_fd);
-        self.session_map_fd = Some(session_map_fd);
-        self.conntrack_v4_fd = conntrack_v4_fd;
-        self.conntrack_v6_fd = conntrack_v6_fd;
-        self.dnat_table_fd = dnat_table_fd;
-        self.dnat_table_v6_fd = dnat_table_v6_fd;
+        self.bpf_maps.map_fd = Some(map_fd);
+        self.bpf_maps.heartbeat_map_fd = Some(heartbeat_map_fd);
+        self.bpf_maps.session_map_fd = Some(session_map_fd);
+        self.bpf_maps.conntrack_v4_fd = conntrack_v4_fd;
+        self.bpf_maps.conntrack_v6_fd = conntrack_v6_fd;
+        self.bpf_maps.dnat_table_fd = dnat_table_fd;
+        self.bpf_maps.dnat_table_v6_fd = dnat_table_v6_fd;
         let worker_binding_ifindexes = workers
             .iter()
             .map(|(worker_id, binding_plans)| {

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -120,7 +120,7 @@ impl super::Coordinator {
             });
         }
         let current = self.ha_state.load();
-        let session_map_fd = self.session_map_fd.as_ref().map(|fd| fd.fd).unwrap_or(-1);
+        let session_map_fd = self.bpf_maps.session_map_fd.as_ref().map(|fd| fd.fd).unwrap_or(-1);
 
         // RG activation is still allowed to be a narrow ownership transition,
         // but split-RG continuity depends on rewarming the derived reverse
@@ -267,7 +267,7 @@ impl super::Coordinator {
             ha_state.as_ref(),
             entry.metadata.owner_rg_id,
             now_secs,
-        ) && let Some(session_map_fd) = self.session_map_fd.as_ref()
+        ) && let Some(session_map_fd) = self.bpf_maps.session_map_fd.as_ref()
         {
             let _ = publish_live_session_entry(
                 session_map_fd.fd,
@@ -295,7 +295,7 @@ impl super::Coordinator {
                 ha_state.as_ref(),
                 reverse.metadata.owner_rg_id,
                 now_secs,
-            ) && let Some(session_map_fd) = self.session_map_fd.as_ref()
+            ) && let Some(session_map_fd) = self.bpf_maps.session_map_fd.as_ref()
             {
                 let _ = publish_live_session_entry(
                     session_map_fd.fd,
@@ -329,7 +329,7 @@ impl super::Coordinator {
             }
         });
         if let Some(entry) = removed_entry.as_ref() {
-            if let Some(session_map_fd) = self.session_map_fd.as_ref() {
+            if let Some(session_map_fd) = self.bpf_maps.session_map_fd.as_ref() {
                 delete_session_map_entry_for_removed_session(
                     session_map_fd.fd,
                     &entry.key,


### PR DESCRIPTION
Phase 1 of #985 decomposing the 40-field Coordinator god struct. Extracts the trivial 7-field BPF FD cluster (shared lifecycle, no other state). 32 call sites updated. Coordinator field count 40 → 34.

## Test plan
- [x] cargo test --bins 865/0/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)