### PR TITLE
#988 P2a: extract pure header-parsing leaf fns to frame/inspect.rs

### DIFF
--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -6,7 +6,7 @@
 //! try_parse_metadata) remain in mod.rs for now and will land in a
 //! follow-on phase to keep this diff reviewable.
 
-use super::*;
+use super::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP, PROTO_UDP, SessionFlow, UserspaceDpMeta};
 
 /// Check if a frame contains a TCP RST flag.
 pub(in crate::afxdp) fn frame_has_tcp_rst(frame: &[u8]) -> bool {
@@ -330,7 +330,11 @@ pub(in crate::afxdp) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &Se
     }
 }
 
-pub(in crate::afxdp) fn parse_flow_ports(frame: &[u8], l4: usize, protocol: u8) -> Option<(u16, u16)> {
+pub(in crate::afxdp) fn parse_flow_ports(
+    frame: &[u8],
+    l4: usize,
+    protocol: u8,
+) -> Option<(u16, u16)> {
     match protocol {
         PROTO_TCP | PROTO_UDP => {
             let bytes = frame.get(l4..l4 + 4)?;

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -1,0 +1,349 @@
+//! Header inspection / parsing helpers — pure read-only fns over
+//! Ethernet/IPv4/IPv6/TCP/UDP/ICMP byte buffers. No mutation.
+//!
+//! Phase 2 split out of `frame.rs` per #988. Larger inspect fns
+//! (parse_session_flow_*, authoritative_forward_ports,
+//! try_parse_metadata) remain in mod.rs for now and will land in a
+//! follow-on phase to keep this diff reviewable.
+
+use super::*;
+
+/// Check if a frame contains a TCP RST flag.
+pub(in crate::afxdp) fn frame_has_tcp_rst(frame: &[u8]) -> bool {
+    let l3 = match frame_l3_offset(frame) {
+        Some(off) => off,
+        None => return false,
+    };
+    let ip = match frame.get(l3..) {
+        Some(ip) if ip.len() >= 20 => ip,
+        _ => return false,
+    };
+    let (protocol, l4_offset) = match ip[0] >> 4 {
+        4 => {
+            let ihl = ((ip[0] & 0x0f) as usize) * 4;
+            (ip[9], ihl)
+        }
+        6 if ip.len() >= 40 => (ip[6], 40usize),
+        _ => return false,
+    };
+    if protocol != PROTO_TCP {
+        return false;
+    }
+    let tcp = match ip.get(l4_offset..) {
+        Some(t) if t.len() >= 14 => t,
+        _ => return false,
+    };
+    // TCP flags at offset 13: RST = 0x04
+    (tcp[13] & 0x04) != 0
+}
+
+/// Extract TCP flags and window from raw frame, auto-detecting L3 from Ethernet header.
+/// Returns (tcp_flags, tcp_window) or None.
+pub(in crate::afxdp) fn extract_tcp_flags_and_window(frame: &[u8]) -> Option<(u8, u16)> {
+    let l3 = frame_l3_offset(frame)?;
+    let ip = frame.get(l3..)?;
+    let (protocol, l4_offset) = match ip.first()? >> 4 {
+        4 => {
+            if ip.len() < 20 {
+                return None;
+            }
+            let ihl = ((ip[0] & 0x0f) as usize) * 4;
+            (ip[9], ihl)
+        }
+        6 => {
+            if ip.len() < 40 {
+                return None;
+            }
+            (ip[6], 40usize)
+        }
+        _ => return None,
+    };
+    if protocol != PROTO_TCP {
+        return None;
+    }
+    let tcp = ip.get(l4_offset..)?;
+    if tcp.len() < 16 {
+        return None;
+    }
+    let flags = tcp[13];
+    let window = u16::from_be_bytes([tcp[14], tcp[15]]);
+    Some((flags, window))
+}
+
+/// Extract TCP window size from raw frame data.
+/// Returns None if not a TCP frame or if frame is too short.
+#[allow(dead_code)]
+pub(in crate::afxdp) fn extract_tcp_window(frame: &[u8], addr_family: u8) -> Option<u16> {
+    let l3 = match frame_l3_offset(frame) {
+        Some(off) => off,
+        None => return None,
+    };
+    let ip = frame.get(l3..)?;
+    let (protocol, l4_offset) = match addr_family as i32 {
+        libc::AF_INET => {
+            if ip.len() < 20 {
+                return None;
+            }
+            let ihl = ((ip[0] & 0x0f) as usize) * 4;
+            (ip[9], ihl)
+        }
+        libc::AF_INET6 => {
+            if ip.len() < 40 {
+                return None;
+            }
+            (ip[6], 40usize)
+        }
+        _ => return None,
+    };
+    if protocol != PROTO_TCP {
+        return None;
+    }
+    let tcp = ip.get(l4_offset..)?;
+    if tcp.len() < 16 {
+        return None;
+    }
+    // TCP window is at offset 14-15 (big-endian)
+    Some(u16::from_be_bytes([tcp[14], tcp[15]]))
+}
+
+pub(in crate::afxdp) fn frame_l3_offset(frame: &[u8]) -> Option<usize> {
+    if frame.len() < 14 {
+        return None;
+    }
+    let eth_proto = u16::from_be_bytes([frame[12], frame[13]]);
+    if matches!(eth_proto, 0x8100 | 0x88a8) {
+        if frame.len() < 18 {
+            return None;
+        }
+        return Some(18);
+    }
+    Some(14)
+}
+
+pub(in crate::afxdp) fn tcp_flags_str(flags: u8) -> String {
+    let mut s = String::with_capacity(12);
+    if flags & 0x02 != 0 {
+        s.push_str("SYN ");
+    }
+    if flags & 0x10 != 0 {
+        s.push_str("ACK ");
+    }
+    if flags & 0x01 != 0 {
+        s.push_str("FIN ");
+    }
+    if flags & 0x04 != 0 {
+        s.push_str("RST ");
+    }
+    if flags & 0x08 != 0 {
+        s.push_str("PSH ");
+    }
+    if flags & 0x20 != 0 {
+        s.push_str("URG ");
+    }
+    if s.ends_with(' ') {
+        s.truncate(s.len() - 1);
+    }
+    if s.is_empty() {
+        s.push_str("none");
+    }
+    s
+}
+
+pub(in crate::afxdp) fn frame_l4_offset(frame: &[u8], addr_family: u8) -> Option<usize> {
+    let l3 = frame_l3_offset(frame)?;
+    match addr_family as i32 {
+        libc::AF_INET => {
+            if frame.len() < l3 + 20 {
+                return None;
+            }
+            let ihl = usize::from(frame[l3] & 0x0f) * 4;
+            if ihl < 20 || frame.len() < l3 + ihl {
+                return None;
+            }
+            Some(l3 + ihl)
+        }
+        libc::AF_INET6 => {
+            if frame.len() < l3 + 40 {
+                return None;
+            }
+            let mut protocol = *frame.get(l3 + 6)?;
+            let mut offset = l3 + 40;
+            for _ in 0..6 {
+                match protocol {
+                    0 | 43 | 60 => {
+                        let opt = frame.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
+                        if frame.len() < offset {
+                            return None;
+                        }
+                    }
+                    51 => {
+                        let opt = frame.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
+                        if frame.len() < offset {
+                            return None;
+                        }
+                    }
+                    44 => {
+                        let frag = frame.get(offset..offset + 8)?;
+                        protocol = frag[0];
+                        offset = offset.checked_add(8)?;
+                        if frame.len() < offset {
+                            return None;
+                        }
+                    }
+                    59 => return None,
+                    _ => return Some(offset),
+                }
+            }
+            Some(offset)
+        }
+        _ => None,
+    }
+}
+
+pub(in crate::afxdp) fn packet_rel_l4_offset(packet: &[u8], addr_family: u8) -> Option<usize> {
+    match addr_family as i32 {
+        libc::AF_INET => {
+            if packet.len() < 20 {
+                return None;
+            }
+            let ihl = usize::from(packet[0] & 0x0f) * 4;
+            if ihl < 20 || packet.len() < ihl {
+                return None;
+            }
+            Some(ihl)
+        }
+        libc::AF_INET6 => {
+            if packet.len() < 40 {
+                return None;
+            }
+            let mut protocol = *packet.get(6)?;
+            let mut offset = 40usize;
+            for _ in 0..6 {
+                match protocol {
+                    0 | 43 | 60 => {
+                        let opt = packet.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    51 => {
+                        let opt = packet.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    44 => {
+                        let frag = packet.get(offset..offset + 8)?;
+                        protocol = frag[0];
+                        offset = offset.checked_add(8)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    59 => return None,
+                    _ => return Some(offset),
+                }
+            }
+            Some(offset)
+        }
+        _ => None,
+    }
+}
+
+/// Like `packet_rel_l4_offset` but also returns the final L4 protocol
+/// after walking IPv6 extension headers. For IPv4, returns the protocol
+/// byte from the IP header. Needed for GRE inner packet parsing where
+/// the initial next-header (packet[6]) may be an extension header, not
+/// the actual L4 protocol.
+pub(in crate::afxdp) fn packet_rel_l4_offset_and_protocol(
+    packet: &[u8],
+    addr_family: u8,
+) -> Option<(usize, u8)> {
+    match addr_family as i32 {
+        libc::AF_INET => {
+            if packet.len() < 20 {
+                return None;
+            }
+            let ihl = usize::from(packet[0] & 0x0f) * 4;
+            if ihl < 20 || packet.len() < ihl {
+                return None;
+            }
+            Some((ihl, packet[9]))
+        }
+        libc::AF_INET6 => {
+            if packet.len() < 40 {
+                return None;
+            }
+            let mut protocol = *packet.get(6)?;
+            let mut offset = 40usize;
+            for _ in 0..6 {
+                match protocol {
+                    0 | 43 | 60 => {
+                        let opt = packet.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    51 => {
+                        let opt = packet.get(offset..offset + 2)?;
+                        protocol = opt[0];
+                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    44 => {
+                        let frag = packet.get(offset..offset + 8)?;
+                        protocol = frag[0];
+                        offset = offset.checked_add(8)?;
+                        if packet.len() < offset {
+                            return None;
+                        }
+                    }
+                    59 => return None,
+                    _ => return Some((offset, protocol)),
+                }
+            }
+            Some((offset, protocol))
+        }
+        _ => None,
+    }
+}
+
+pub(in crate::afxdp) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &SessionFlow) -> bool {
+    if flow.src_ip.is_unspecified() || flow.dst_ip.is_unspecified() {
+        return false;
+    }
+    match meta.protocol {
+        PROTO_TCP | PROTO_UDP => flow.forward_key.src_port != 0 && flow.forward_key.dst_port != 0,
+        _ => true,
+    }
+}
+
+pub(in crate::afxdp) fn parse_flow_ports(frame: &[u8], l4: usize, protocol: u8) -> Option<(u16, u16)> {
+    match protocol {
+        PROTO_TCP | PROTO_UDP => {
+            let bytes = frame.get(l4..l4 + 4)?;
+            Some((
+                u16::from_be_bytes([bytes[0], bytes[1]]),
+                u16::from_be_bytes([bytes[2], bytes[3]]),
+            ))
+        }
+        PROTO_ICMP | PROTO_ICMPV6 => {
+            let bytes = frame.get(l4 + 4..l4 + 6)?;
+            let ident = u16::from_be_bytes([bytes[0], bytes[1]]);
+            Some((ident, 0))
+        }
+        _ => None,
+    }
+}

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -8,6 +8,7 @@ mod inspect;
 // `checksum.rs` (only the SNAT/DNAT rewrites here call it) and is
 // pulled in via a non-pub `use` to avoid a glob re-export at a
 // wider visibility than its own.
+use checksum::adjust_l4_checksum_ipv6_addr_bytes;
 pub(in crate::afxdp) use checksum::{
     adjust_ipv4_header_checksum, adjust_l4_checksum_ipv4, adjust_l4_checksum_ipv4_dst,
     adjust_l4_checksum_ipv4_src, adjust_l4_checksum_ipv4_words, adjust_l4_checksum_ipv6,
@@ -16,7 +17,6 @@ pub(in crate::afxdp) use checksum::{
     checksum16_ipv6, ipv4_words, ipv6_words, ipv6_words_from_octets, ipv6_words_from_slice,
     recompute_l4_checksum_ipv4, recompute_l4_checksum_ipv6,
 };
-use checksum::adjust_l4_checksum_ipv6_addr_bytes;
 
 // Phase 2: pure header-parsing leaf fns. `frame_has_tcp_rst` is
 // re-exported at `pub(in crate::afxdp)` (called from afxdp.rs,
@@ -224,10 +224,6 @@ pub(super) fn parse_session_flow(
     parse_session_flow_from_bytes(frame, meta)
 }
 
-
-
-
-
 pub(in crate::afxdp) fn apply_dscp_rewrite_to_frame(frame: &mut [u8], dscp: u8) -> Option<()> {
     let dscp = dscp & 0x3f;
     let l3 = frame_l3_offset(frame)?;
@@ -347,11 +343,6 @@ pub(super) fn decode_frame_summary(frame: &[u8]) -> String {
         String::new()
     }
 }
-
-
-
-
-
 
 pub(super) fn parse_session_flow_from_frame(
     frame: &[u8],
@@ -493,7 +484,6 @@ pub(super) fn parse_ipv4_session_flow_from_frame(
         },
     })
 }
-
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn parse_zone_encoded_fabric_ingress(
@@ -6197,8 +6187,7 @@ mod tests {
             0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
         ];
         let v6_header: Vec<u8> = vec![
-            0x60, 0x00, 0x00, 0x00, 0x00, 0x14, PROTO_TCP, 64,
-            // src 2001:db8::1
+            0x60, 0x00, 0x00, 0x00, 0x00, 0x14, PROTO_TCP, 64, // src 2001:db8::1
             0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
             // dst 2001:db8::200
             0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02, 0x00,

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 mod checksum;
+mod inspect;
+
 // Cross-module helpers reach into `frame::*` via the explicit list
 // below. `adjust_l4_checksum_ipv6_addr_bytes` is file-private to
 // `checksum.rs` (only the SNAT/DNAT rewrites here call it) and is
@@ -15,6 +17,17 @@ pub(in crate::afxdp) use checksum::{
     recompute_l4_checksum_ipv4, recompute_l4_checksum_ipv6,
 };
 use checksum::adjust_l4_checksum_ipv6_addr_bytes;
+
+// Phase 2: pure header-parsing leaf fns. `frame_has_tcp_rst` is
+// re-exported at `pub(in crate::afxdp)` (called from afxdp.rs,
+// tx/transmit.rs, cos/queue_service.rs); the rest are pub(super)
+// (only need afxdp-level visibility, used by sibling afxdp/* files).
+pub(in crate::afxdp) use inspect::frame_has_tcp_rst;
+pub(super) use inspect::{
+    extract_tcp_flags_and_window, extract_tcp_window, frame_l3_offset, frame_l4_offset,
+    metadata_tuple_complete, packet_rel_l4_offset, packet_rel_l4_offset_and_protocol,
+    parse_flow_ports, tcp_flags_str,
+};
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn authoritative_forward_ports(
@@ -211,117 +224,9 @@ pub(super) fn parse_session_flow(
     parse_session_flow_from_bytes(frame, meta)
 }
 
-/// Check if a frame contains a TCP RST flag. Returns (is_rst, summary) for logging.
-pub(in crate::afxdp) fn frame_has_tcp_rst(frame: &[u8]) -> bool {
-    let l3 = match frame_l3_offset(frame) {
-        Some(off) => off,
-        None => return false,
-    };
-    let ip = match frame.get(l3..) {
-        Some(ip) if ip.len() >= 20 => ip,
-        _ => return false,
-    };
-    let (protocol, l4_offset) = match ip[0] >> 4 {
-        4 => {
-            let ihl = ((ip[0] & 0x0f) as usize) * 4;
-            (ip[9], ihl)
-        }
-        6 if ip.len() >= 40 => (ip[6], 40usize),
-        _ => return false,
-    };
-    if protocol != PROTO_TCP {
-        return false;
-    }
-    let tcp = match ip.get(l4_offset..) {
-        Some(t) if t.len() >= 14 => t,
-        _ => return false,
-    };
-    // TCP flags at offset 13: RST = 0x04
-    (tcp[13] & 0x04) != 0
-}
 
-/// Extract TCP flags and window from raw frame, auto-detecting L3 from Ethernet header.
-/// Returns (tcp_flags, tcp_window) or None.
-pub(super) fn extract_tcp_flags_and_window(frame: &[u8]) -> Option<(u8, u16)> {
-    let l3 = frame_l3_offset(frame)?;
-    let ip = frame.get(l3..)?;
-    let (protocol, l4_offset) = match ip.first()? >> 4 {
-        4 => {
-            if ip.len() < 20 {
-                return None;
-            }
-            let ihl = ((ip[0] & 0x0f) as usize) * 4;
-            (ip[9], ihl)
-        }
-        6 => {
-            if ip.len() < 40 {
-                return None;
-            }
-            (ip[6], 40usize)
-        }
-        _ => return None,
-    };
-    if protocol != PROTO_TCP {
-        return None;
-    }
-    let tcp = ip.get(l4_offset..)?;
-    if tcp.len() < 16 {
-        return None;
-    }
-    let flags = tcp[13];
-    let window = u16::from_be_bytes([tcp[14], tcp[15]]);
-    Some((flags, window))
-}
 
-/// Extract TCP window size from raw frame data.
-/// Returns None if not a TCP frame or if frame is too short.
-#[allow(dead_code)]
-pub(super) fn extract_tcp_window(frame: &[u8], addr_family: u8) -> Option<u16> {
-    let l3 = match frame_l3_offset(frame) {
-        Some(off) => off,
-        None => return None,
-    };
-    let ip = frame.get(l3..)?;
-    let (protocol, l4_offset) = match addr_family as i32 {
-        libc::AF_INET => {
-            if ip.len() < 20 {
-                return None;
-            }
-            let ihl = ((ip[0] & 0x0f) as usize) * 4;
-            (ip[9], ihl)
-        }
-        libc::AF_INET6 => {
-            if ip.len() < 40 {
-                return None;
-            }
-            (ip[6], 40usize)
-        }
-        _ => return None,
-    };
-    if protocol != PROTO_TCP {
-        return None;
-    }
-    let tcp = ip.get(l4_offset..)?;
-    if tcp.len() < 16 {
-        return None;
-    }
-    // TCP window is at offset 14-15 (big-endian)
-    Some(u16::from_be_bytes([tcp[14], tcp[15]]))
-}
 
-pub(super) fn frame_l3_offset(frame: &[u8]) -> Option<usize> {
-    if frame.len() < 14 {
-        return None;
-    }
-    let eth_proto = u16::from_be_bytes([frame[12], frame[13]]);
-    if matches!(eth_proto, 0x8100 | 0x88a8) {
-        if frame.len() < 18 {
-            return None;
-        }
-        return Some(18);
-    }
-    Some(14)
-}
 
 pub(in crate::afxdp) fn apply_dscp_rewrite_to_frame(frame: &mut [u8], dscp: u8) -> Option<()> {
     let dscp = dscp & 0x3f;
@@ -443,215 +348,10 @@ pub(super) fn decode_frame_summary(frame: &[u8]) -> String {
     }
 }
 
-pub(super) fn tcp_flags_str(flags: u8) -> String {
-    let mut s = String::with_capacity(12);
-    if flags & 0x02 != 0 {
-        s.push_str("SYN ");
-    }
-    if flags & 0x10 != 0 {
-        s.push_str("ACK ");
-    }
-    if flags & 0x01 != 0 {
-        s.push_str("FIN ");
-    }
-    if flags & 0x04 != 0 {
-        s.push_str("RST ");
-    }
-    if flags & 0x08 != 0 {
-        s.push_str("PSH ");
-    }
-    if flags & 0x20 != 0 {
-        s.push_str("URG ");
-    }
-    if s.ends_with(' ') {
-        s.truncate(s.len() - 1);
-    }
-    if s.is_empty() {
-        s.push_str("none");
-    }
-    s
-}
 
-pub(super) fn frame_l4_offset(frame: &[u8], addr_family: u8) -> Option<usize> {
-    let l3 = frame_l3_offset(frame)?;
-    match addr_family as i32 {
-        libc::AF_INET => {
-            if frame.len() < l3 + 20 {
-                return None;
-            }
-            let ihl = usize::from(frame[l3] & 0x0f) * 4;
-            if ihl < 20 || frame.len() < l3 + ihl {
-                return None;
-            }
-            Some(l3 + ihl)
-        }
-        libc::AF_INET6 => {
-            if frame.len() < l3 + 40 {
-                return None;
-            }
-            let mut protocol = *frame.get(l3 + 6)?;
-            let mut offset = l3 + 40;
-            for _ in 0..6 {
-                match protocol {
-                    0 | 43 | 60 => {
-                        let opt = frame.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
-                        if frame.len() < offset {
-                            return None;
-                        }
-                    }
-                    51 => {
-                        let opt = frame.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
-                        if frame.len() < offset {
-                            return None;
-                        }
-                    }
-                    44 => {
-                        let frag = frame.get(offset..offset + 8)?;
-                        protocol = frag[0];
-                        offset = offset.checked_add(8)?;
-                        if frame.len() < offset {
-                            return None;
-                        }
-                    }
-                    59 => return None,
-                    _ => return Some(offset),
-                }
-            }
-            Some(offset)
-        }
-        _ => None,
-    }
-}
 
-pub(super) fn packet_rel_l4_offset(packet: &[u8], addr_family: u8) -> Option<usize> {
-    match addr_family as i32 {
-        libc::AF_INET => {
-            if packet.len() < 20 {
-                return None;
-            }
-            let ihl = usize::from(packet[0] & 0x0f) * 4;
-            if ihl < 20 || packet.len() < ihl {
-                return None;
-            }
-            Some(ihl)
-        }
-        libc::AF_INET6 => {
-            if packet.len() < 40 {
-                return None;
-            }
-            let mut protocol = *packet.get(6)?;
-            let mut offset = 40usize;
-            for _ in 0..6 {
-                match protocol {
-                    0 | 43 | 60 => {
-                        let opt = packet.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    51 => {
-                        let opt = packet.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    44 => {
-                        let frag = packet.get(offset..offset + 8)?;
-                        protocol = frag[0];
-                        offset = offset.checked_add(8)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    59 => return None,
-                    _ => return Some(offset),
-                }
-            }
-            Some(offset)
-        }
-        _ => None,
-    }
-}
 
-/// Like `packet_rel_l4_offset` but also returns the final L4 protocol
-/// after walking IPv6 extension headers. For IPv4, returns the protocol
-/// byte from the IP header. Needed for GRE inner packet parsing where
-/// the initial next-header (packet[6]) may be an extension header, not
-/// the actual L4 protocol.
-pub(super) fn packet_rel_l4_offset_and_protocol(
-    packet: &[u8],
-    addr_family: u8,
-) -> Option<(usize, u8)> {
-    match addr_family as i32 {
-        libc::AF_INET => {
-            if packet.len() < 20 {
-                return None;
-            }
-            let ihl = usize::from(packet[0] & 0x0f) * 4;
-            if ihl < 20 || packet.len() < ihl {
-                return None;
-            }
-            Some((ihl, packet[9]))
-        }
-        libc::AF_INET6 => {
-            if packet.len() < 40 {
-                return None;
-            }
-            let mut protocol = *packet.get(6)?;
-            let mut offset = 40usize;
-            for _ in 0..6 {
-                match protocol {
-                    0 | 43 | 60 => {
-                        let opt = packet.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    51 => {
-                        let opt = packet.get(offset..offset + 2)?;
-                        protocol = opt[0];
-                        offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    44 => {
-                        let frag = packet.get(offset..offset + 8)?;
-                        protocol = frag[0];
-                        offset = offset.checked_add(8)?;
-                        if packet.len() < offset {
-                            return None;
-                        }
-                    }
-                    59 => return None,
-                    _ => return Some((offset, protocol)),
-                }
-            }
-            Some((offset, protocol))
-        }
-        _ => None,
-    }
-}
 
-pub(super) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &SessionFlow) -> bool {
-    if flow.src_ip.is_unspecified() || flow.dst_ip.is_unspecified() {
-        return false;
-    }
-    match meta.protocol {
-        PROTO_TCP | PROTO_UDP => flow.forward_key.src_port != 0 && flow.forward_key.dst_port != 0,
-        _ => true,
-    }
-}
 
 pub(super) fn parse_session_flow_from_frame(
     frame: &[u8],
@@ -794,23 +494,6 @@ pub(super) fn parse_ipv4_session_flow_from_frame(
     })
 }
 
-pub(super) fn parse_flow_ports(frame: &[u8], l4: usize, protocol: u8) -> Option<(u16, u16)> {
-    match protocol {
-        PROTO_TCP | PROTO_UDP => {
-            let bytes = frame.get(l4..l4 + 4)?;
-            Some((
-                u16::from_be_bytes([bytes[0], bytes[1]]),
-                u16::from_be_bytes([bytes[2], bytes[3]]),
-            ))
-        }
-        PROTO_ICMP | PROTO_ICMPV6 => {
-            let bytes = frame.get(l4 + 4..l4 + 6)?;
-            let ident = u16::from_be_bytes([bytes[0], bytes[1]]);
-            Some((ident, 0))
-        }
-        _ => None,
-    }
-}
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn parse_zone_encoded_fabric_ingress(


### PR DESCRIPTION
## Summary

- Move 10 pure read-only header-parsing fns from \`frame/mod.rs\` into a new \`frame/inspect.rs\` (349 LOC)
- frame/mod.rs production LOC: 2,804 → 2,487 (−317; still over 2,000 threshold but moving)
- \`frame_has_tcp_rst\` keeps \`pub(in crate::afxdp)\` for external callers (afxdp.rs / tx/transmit.rs / cos/queue_service.rs); the rest are \`pub(super)\` re-exports

## Why

#988 Phase 2a of frame.rs decomposition. Per \`docs/refactor/988-frame-decomp.md\` (origin/research/988-frame-design). Phase 0/1 (checksum.rs) in #1019/#1021.

The 10 fns moved here are leaf-cluster (no internal cross-fn deps with the rest of frame, only call each other) — chosen as the safest first slice. Larger inspect cluster (\`parse_session_flow_*\`, \`authoritative_forward_ports\`, \`try_parse_metadata\`) stays in mod.rs and lands in Phase 2b to keep this diff reviewable.

## Migrated fns

- \`frame_l3_offset\`, \`frame_l4_offset\`
- \`packet_rel_l4_offset\`, \`packet_rel_l4_offset_and_protocol\`
- \`extract_tcp_flags_and_window\`, \`extract_tcp_window\`
- \`frame_has_tcp_rst\`
- \`tcp_flags_str\`
- \`metadata_tuple_complete\`
- \`parse_flow_ports\`

Visibility was widened from \`pub(super)\` (visible to afxdp via mod.rs's re-export) to \`pub(in crate::afxdp)\` in \`inspect.rs\` so frame/mod.rs's \`pub(super) use inspect::{…}\` re-export is well-typed (E0364 otherwise).

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo test --release\` — 865 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)