### PR TITLE
#985 P6: extract SessionManager from coordinator god struct

### DIFF
--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -3,11 +3,13 @@ mod bpf_maps;
 mod cos_state;
 mod ha_state;
 mod neighbor_manager;
+mod session_manager;
 mod worker_manager;
 pub(crate) use bpf_maps::BpfMaps;
 pub(crate) use cos_state::SharedCoSState;
 pub(in crate::afxdp) use ha_state::HaState;
 pub(crate) use neighbor_manager::NeighborManager;
+pub(in crate::afxdp) use session_manager::SessionManager;
 pub(in crate::afxdp) use worker_manager::WorkerManager;
 
 pub struct Coordinator {
@@ -20,12 +22,8 @@ pub struct Coordinator {
     pub(crate) cos: SharedCoSState,
     pub(crate) shared_validation: Arc<ArcSwap<ValidationState>>,
     pub(crate) neighbors: NeighborManager,
-    pub(crate) shared_sessions: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(crate) shared_nat_sessions: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(crate) shared_forward_wire_sessions: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(crate) shared_owner_rg_indexes: SharedSessionOwnerRgIndexes,
+    pub(in crate::afxdp) sessions: SessionManager,
     pub(in crate::afxdp) workers: WorkerManager,
-    pub(crate) session_export_seq: AtomicU64,
     pub(crate) forwarding: ForwardingState,
     pub(crate) recent_exceptions: Arc<Mutex<VecDeque<ExceptionStatus>>>,
     pub(crate) recent_session_deltas: Arc<Mutex<VecDeque<SessionDeltaInfo>>>,
@@ -60,12 +58,8 @@ impl Coordinator {
             cos: SharedCoSState::new(),
             shared_validation: Arc::new(ArcSwap::from_pointee(ValidationState::default())),
             neighbors: NeighborManager::new(),
-            shared_sessions: Arc::new(Mutex::new(FastMap::default())),
-            shared_nat_sessions: Arc::new(Mutex::new(FastMap::default())),
-            shared_forward_wire_sessions: Arc::new(Mutex::new(FastMap::default())),
-            shared_owner_rg_indexes: SharedSessionOwnerRgIndexes::default(),
+            sessions: SessionManager::new(),
             workers: WorkerManager::new(),
-            session_export_seq: AtomicU64::new(0),
             forwarding: ForwardingState::default(),
             recent_exceptions: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_RECENT_EXCEPTIONS))),
             recent_session_deltas: Arc::new(Mutex::new(VecDeque::with_capacity(
@@ -288,16 +282,16 @@ impl Coordinator {
             manager_keys.clear();
         }
         if clear_synced_state {
-            if let Ok(mut sessions) = self.shared_sessions.lock() {
+            if let Ok(mut sessions) = self.sessions.synced.lock() {
                 sessions.clear();
             }
-            if let Ok(mut nat_sessions) = self.shared_nat_sessions.lock() {
+            if let Ok(mut nat_sessions) = self.sessions.nat.lock() {
                 nat_sessions.clear();
             }
-            if let Ok(mut forward_wire_sessions) = self.shared_forward_wire_sessions.lock() {
+            if let Ok(mut forward_wire_sessions) = self.sessions.forward_wire.lock() {
                 forward_wire_sessions.clear();
             }
-            self.shared_owner_rg_indexes.clear();
+            self.sessions.owner_rg_indexes.clear();
         }
         if let Ok(mut recent) = self.recent_exceptions.lock() {
             recent.clear();
@@ -315,7 +309,7 @@ impl Coordinator {
     }
 
     pub(crate) fn snapshot_shared_session_entries(&self) -> Vec<SyncedSessionEntry> {
-        self.shared_sessions
+        self.sessions.synced
             .lock()
             .map(|sessions| sessions.values().cloned().collect())
             .unwrap_or_default()
@@ -666,10 +660,10 @@ impl Coordinator {
             let local_tunnel_deliveries = self.local_tunnel_deliveries.clone();
             let shared_forwarding = self.ha.forwarding.clone();
             let shared_validation = self.shared_validation.clone();
-            let shared_sessions = self.shared_sessions.clone();
-            let shared_nat_sessions = self.shared_nat_sessions.clone();
-            let shared_forward_wire_sessions = self.shared_forward_wire_sessions.clone();
-            let shared_owner_rg_indexes = self.shared_owner_rg_indexes.clone();
+            let shared_sessions = self.sessions.synced.clone();
+            let shared_nat_sessions = self.sessions.nat.clone();
+            let shared_forward_wire_sessions = self.sessions.forward_wire.clone();
+            let shared_owner_rg_indexes = self.sessions.owner_rg_indexes.clone();
             let stop_clone = stop.clone();
             let heartbeat_clone = heartbeat.clone();
             let session_export_ack_clone = session_export_ack.clone();
@@ -829,10 +823,10 @@ impl Coordinator {
             let dynamic_neighbors = self.neighbors.dynamic.clone();
             let live = self.workers.live.clone();
             let identities = self.workers.identities.clone();
-            let shared_sessions = self.shared_sessions.clone();
-            let shared_nat_sessions = self.shared_nat_sessions.clone();
-            let shared_forward_wire_sessions = self.shared_forward_wire_sessions.clone();
-            let shared_owner_rg_indexes = self.shared_owner_rg_indexes.clone();
+            let shared_sessions = self.sessions.synced.clone();
+            let shared_nat_sessions = self.sessions.nat.clone();
+            let shared_forward_wire_sessions = self.sessions.forward_wire.clone();
+            let shared_owner_rg_indexes = self.sessions.owner_rg_indexes.clone();
             let worker_commands = self
                 .workers
                 .handles

--- a/userspace-dp/src/afxdp/coordinator/session_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/session_manager.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Cross-thread session-table state shared between the coordinator,
 /// HA worker, and packet workers via `Arc<Mutex<...>>`.
 ///
-/// The 4 session tables (synced + nat + forward-wire) plus the
+/// The 3 session tables (synced + nat + forward-wire) plus the
 /// owner-RG index live here together because they're written and
 /// queried as a unit by the HA bulk-sync, incremental-sync, and
 /// session-resolution paths. The `export_seq` counter is the

--- a/userspace-dp/src/afxdp/coordinator/session_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/session_manager.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+/// Cross-thread session-table state shared between the coordinator,
+/// HA worker, and packet workers via `Arc<Mutex<...>>`.
+///
+/// The 4 session tables (synced + nat + forward-wire) plus the
+/// owner-RG index live here together because they're written and
+/// queried as a unit by the HA bulk-sync, incremental-sync, and
+/// session-resolution paths. The `export_seq` counter is the
+/// per-RG ack sequence number that pairs with the export ack
+/// broadcast in HA `export_owner_rg_sessions`.
+pub(in crate::afxdp) struct SessionManager {
+    pub(in crate::afxdp) synced: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) nat: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) forward_wire: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) owner_rg_indexes: SharedSessionOwnerRgIndexes,
+    pub(in crate::afxdp) export_seq: AtomicU64,
+}
+
+impl SessionManager {
+    pub(super) fn new() -> Self {
+        Self {
+            synced: Arc::new(Mutex::new(FastMap::default())),
+            nat: Arc::new(Mutex::new(FastMap::default())),
+            forward_wire: Arc::new(Mutex::new(FastMap::default())),
+            owner_rg_indexes: SharedSessionOwnerRgIndexes::default(),
+            export_seq: AtomicU64::new(0),
+        }
+    }
+}

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -55,10 +55,10 @@ impl super::Coordinator {
                 pending.push_back(WorkerCommand::VacateAllSharedExactSlots);
             }
             demote_shared_owner_rgs(
-                &self.shared_sessions,
-                &self.shared_nat_sessions,
-                &self.shared_forward_wire_sessions,
-                &self.shared_owner_rg_indexes,
+                &self.sessions.synced,
+                &self.sessions.nat,
+                &self.sessions.forward_wire,
+                &self.sessions.owner_rg_indexes,
                 &self.forwarding,
                 self.dynamic_neighbors_ref(),
                 &demoted_rgs,
@@ -79,7 +79,7 @@ impl super::Coordinator {
                 "xpf-ha: RG activation detected: {:?}, workers={}, shared_sessions={}",
                 activated_rgs,
                 self.workers.handles.len(),
-                self.shared_sessions.lock().map(|s| s.len()).unwrap_or(0),
+                self.sessions.synced.lock().map(|s| s.len()).unwrap_or(0),
             );
             self.handle_activated_rgs(&activated_rgs, now_secs);
         }
@@ -128,10 +128,10 @@ impl super::Coordinator {
         // entries and restoring any redirect aliases that were removed during
         // demotion. This is not the old worker-wide HA refresh scan.
         prewarm_reverse_synced_sessions_for_owner_rgs(
-            &self.shared_sessions,
-            &self.shared_nat_sessions,
-            &self.shared_forward_wire_sessions,
-            &self.shared_owner_rg_indexes,
+            &self.sessions.synced,
+            &self.sessions.nat,
+            &self.sessions.forward_wire,
+            &self.sessions.owner_rg_indexes,
             &worker_commands,
             session_map_fd,
             &self.forwarding,
@@ -142,8 +142,8 @@ impl super::Coordinator {
         );
         if session_map_fd >= 0 {
             let republished = republish_bpf_session_entries_for_owner_rgs(
-                &self.shared_sessions,
-                &self.shared_owner_rg_indexes,
+                &self.sessions.synced,
+                &self.sessions.owner_rg_indexes,
                 session_map_fd,
                 activated_rgs,
             );
@@ -165,7 +165,7 @@ impl super::Coordinator {
             return Ok(Vec::new());
         }
         let sequence = self
-            .session_export_seq
+            .sessions.export_seq
             .fetch_add(1, Ordering::Relaxed)
             .saturating_add(1);
         for handle in self.workers.handles.values() {
@@ -240,7 +240,7 @@ impl super::Coordinator {
         let now_secs = monotonic_nanos() / 1_000_000_000;
         let ha_state = self.ha.rg_runtime.load();
         let previous_entry = self
-            .shared_sessions
+            .sessions.synced
             .lock()
             .ok()
             .and_then(|sessions| sessions.get(&entry.key).cloned());
@@ -256,10 +256,10 @@ impl super::Coordinator {
             None
         };
         publish_shared_session(
-            &self.shared_sessions,
-            &self.shared_nat_sessions,
-            &self.shared_forward_wire_sessions,
-            &self.shared_owner_rg_indexes,
+            &self.sessions.synced,
+            &self.sessions.nat,
+            &self.sessions.forward_wire,
+            &self.sessions.owner_rg_indexes,
             &entry,
         );
         // Keep the immediate BPF publish aligned with the worker-side
@@ -279,7 +279,7 @@ impl super::Coordinator {
             );
         }
         refresh_reverse_prewarm_owner_rg_indexes(
-            &self.shared_owner_rg_indexes.reverse_prewarm_sessions,
+            &self.sessions.owner_rg_indexes.reverse_prewarm_sessions,
             &self.forwarding,
             self.dynamic_neighbors_ref(),
             previous_entry.as_ref(),
@@ -287,10 +287,10 @@ impl super::Coordinator {
         );
         if let Some(reverse) = &reverse_entry {
             publish_shared_session(
-                &self.shared_sessions,
-                &self.shared_nat_sessions,
-                &self.shared_forward_wire_sessions,
-                &self.shared_owner_rg_indexes,
+                &self.sessions.synced,
+                &self.sessions.nat,
+                &self.sessions.forward_wire,
+                &self.sessions.owner_rg_indexes,
                 reverse,
             );
             if synced_entry_allows_local_replace(
@@ -319,7 +319,7 @@ impl super::Coordinator {
 
     pub fn delete_synced_session(&self, key: SessionKey) {
         let removed_entry = self
-            .shared_sessions
+            .sessions.synced
             .lock()
             .ok()
             .and_then(|sessions| sessions.get(&key).cloned());
@@ -341,14 +341,14 @@ impl super::Coordinator {
             }
         }
         remove_shared_session(
-            &self.shared_sessions,
-            &self.shared_nat_sessions,
-            &self.shared_forward_wire_sessions,
-            &self.shared_owner_rg_indexes,
+            &self.sessions.synced,
+            &self.sessions.nat,
+            &self.sessions.forward_wire,
+            &self.sessions.owner_rg_indexes,
             &key,
         );
         refresh_reverse_prewarm_owner_rg_indexes(
-            &self.shared_owner_rg_indexes.reverse_prewarm_sessions,
+            &self.sessions.owner_rg_indexes.reverse_prewarm_sessions,
             &self.forwarding,
             self.dynamic_neighbors_ref(),
             removed_entry.as_ref(),
@@ -356,10 +356,10 @@ impl super::Coordinator {
         );
         if let Some(reverse_key) = &reverse_key {
             remove_shared_session(
-                &self.shared_sessions,
-                &self.shared_nat_sessions,
-                &self.shared_forward_wire_sessions,
-                &self.shared_owner_rg_indexes,
+                &self.sessions.synced,
+                &self.sessions.nat,
+                &self.sessions.forward_wire,
+                &self.sessions.owner_rg_indexes,
                 reverse_key,
             );
         }
@@ -391,7 +391,7 @@ impl super::Coordinator {
         let zone_name_to_id = &self.forwarding.zone_name_to_id;
 
         let sessions = self
-            .shared_sessions
+            .sessions.synced
             .lock()
             .map_err(|_| "shared sessions lock poisoned".to_string())?;
 
@@ -704,14 +704,14 @@ mod tests {
             tcp_flags: 0x10,
         };
         publish_shared_session(
-            &coordinator.shared_sessions,
-            &coordinator.shared_nat_sessions,
-            &coordinator.shared_forward_wire_sessions,
-            &coordinator.shared_owner_rg_indexes,
+            &coordinator.sessions.synced,
+            &coordinator.sessions.nat,
+            &coordinator.sessions.forward_wire,
+            &coordinator.sessions.owner_rg_indexes,
             &entry,
         );
         refresh_reverse_prewarm_owner_rg_indexes(
-            &coordinator.shared_owner_rg_indexes.reverse_prewarm_sessions,
+            &coordinator.sessions.owner_rg_indexes.reverse_prewarm_sessions,
             &coordinator.forwarding,
             coordinator.dynamic_neighbors_ref(),
             None,
@@ -751,7 +751,7 @@ mod tests {
 
         let reverse_key = reverse_session_key(&entry.key, entry.decision.nat);
         let reverse = coordinator
-            .shared_sessions
+            .sessions.synced
             .lock()
             .expect("shared sessions")
             .get(&reverse_key)

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -370,10 +370,10 @@ fn reconcile_stop_preserves_shared_synced_sessions() {
         tcp_flags: 0,
     };
     publish_shared_session(
-        &coordinator.shared_sessions,
-        &coordinator.shared_nat_sessions,
-        &coordinator.shared_forward_wire_sessions,
-        &coordinator.shared_owner_rg_indexes,
+        &coordinator.sessions.synced,
+        &coordinator.sessions.nat,
+        &coordinator.sessions.forward_wire,
+        &coordinator.sessions.owner_rg_indexes,
         &entry,
     );
 


### PR DESCRIPTION
## Summary

- Extract \`SessionManager\` into \`coordinator/session_manager.rs\` with 5 cross-thread session-table fields
- Field count on \`Coordinator\`: 21 → 17

## Migrations

- \`shared_sessions\` → \`sessions.synced\`
- \`shared_nat_sessions\` → \`sessions.nat\`
- \`shared_forward_wire_sessions\` → \`sessions.forward_wire\`
- \`shared_owner_rg_indexes\` → \`sessions.owner_rg_indexes\`
- \`session_export_seq\` → \`sessions.export_seq\`

## Why

#985 Phase 6 of Coordinator decomposition. Per \`docs/refactor/985-coordinator-decomp.md\` (origin/research/985-coordinator-design). Phases 0/1 (BpfMaps) #1019/#1023, P2 (NeighborManager) #1024, P3 (SharedCoSState) #1025, P4 (HaState) #1027, P5 (WorkerManager) #1029.

The 4 session tables plus the owner-RG index live here together because they're written and queried as a unit by the HA bulk-sync, incremental-sync, and session-resolution paths. The \`export_seq\` counter is the per-RG ack sequence number that pairs with the export ack broadcast in HA \`export_owner_rg_sessions\`.

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo test --release\` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 + RG1 cycled-twice failover) — touches HA session sync paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)