### PR TITLE
#1047 P2 (step 2): extract session/entry.rs (public-facing data types)

### DIFF
--- a/userspace-dp/src/session/entry.rs
+++ b/userspace-dp/src/session/entry.rs
@@ -1,0 +1,132 @@
+// Public-facing session data types extracted from session/mod.rs (#1047 P2 step 2).
+// Pure relocation — bodies are byte-for-byte identical; visibility is
+// unchanged (everything was already pub(crate)).
+//
+// SessionEntry (the internal storage type) stays in mod.rs because its
+// fields are file-private and accessed directly by SessionTable's impl.
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SessionDecision {
+    pub(crate) resolution: ForwardingResolution,
+    pub(crate) nat: NatDecision,
+}
+
+/// #919: zone names dropped from the fast path. `ingress_zone` and
+/// `egress_zone` are now `u16` IDs that index into
+/// `forwarding.zone_id_to_name` for slow-path consumers (logging,
+/// gRPC export, status). `0` means "unknown / unset" (matches the
+/// existing `UserspaceDpMeta.ingress_zone` default at types.rs:64).
+/// Removing the `Arc<str>` saves 28 bytes per `SessionMetadata` and
+/// eliminates the `LOCK XADD` atomic on every `metadata.clone()`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionMetadata {
+    pub(crate) ingress_zone: u16,
+    pub(crate) egress_zone: u16,
+    pub(crate) owner_rg_id: i32,
+    pub(crate) fabric_ingress: bool,
+    pub(crate) is_reverse: bool,
+    /// For NAT64 sessions: stores original IPv6 addresses so reverse IPv4
+    /// replies can be translated back.
+    pub(crate) nat64_reverse: Option<Nat64ReverseInfo>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionLookup {
+    pub(crate) decision: SessionDecision,
+    pub(crate) metadata: SessionMetadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ForwardSessionMatch {
+    pub(crate) key: SessionKey,
+    pub(crate) decision: SessionDecision,
+    pub(crate) metadata: SessionMetadata,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SessionOrigin {
+    ForwardFlow,
+    ReverseFlow,
+    LocalMiss,
+    MissingNeighborSeed,
+    SyncImport,
+    SharedMaterialize,
+    SharedPromote,
+    #[allow(dead_code)] // enum variant for completeness
+    WorkerLocalImport,
+}
+
+impl SessionOrigin {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ForwardFlow => "forward_flow",
+            Self::ReverseFlow => "reverse_flow",
+            Self::LocalMiss => "local_miss",
+            Self::MissingNeighborSeed => "missing_neighbor_seed",
+            Self::SyncImport => "sync_import",
+            Self::SharedMaterialize => "shared_materialize",
+            Self::SharedPromote => "shared_promote",
+            Self::WorkerLocalImport => "worker_local_import",
+        }
+    }
+
+    /// Returns true for origins that represent peer-synced sessions.
+    /// These are sessions that arrived from the HA peer rather than
+    /// being created by local traffic.
+    pub(crate) fn is_peer_synced(self) -> bool {
+        matches!(
+            self,
+            Self::SyncImport | Self::SharedMaterialize | Self::WorkerLocalImport
+        )
+    }
+
+    pub(crate) fn is_promotable_synced(self) -> bool {
+        matches!(self, Self::SyncImport | Self::SharedMaterialize)
+    }
+
+    pub(crate) fn worker_replica_origin(self) -> Self {
+        if self.is_promotable_synced() {
+            Self::SyncImport
+        } else {
+            Self::WorkerLocalImport
+        }
+    }
+
+    pub(crate) fn materialized_shared_hit_origin(self) -> Self {
+        if self.is_promotable_synced() {
+            Self::SharedMaterialize
+        } else {
+            Self::WorkerLocalImport
+        }
+    }
+
+    pub(crate) fn is_transient_local_seed(self) -> bool {
+        matches!(self, Self::MissingNeighborSeed)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SessionDeltaKind {
+    Open,
+    Close,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionDelta {
+    pub(crate) kind: SessionDeltaKind,
+    pub(crate) key: SessionKey,
+    pub(crate) decision: SessionDecision,
+    pub(crate) metadata: SessionMetadata,
+    pub(crate) origin: SessionOrigin,
+    pub(crate) fabric_redirect_sync: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ExpiredSession {
+    pub(crate) key: SessionKey,
+    pub(crate) decision: SessionDecision,
+    pub(crate) metadata: SessionMetadata,
+    pub(crate) origin: SessionOrigin,
+}

--- a/userspace-dp/src/session/entry.rs
+++ b/userspace-dp/src/session/entry.rs
@@ -17,7 +17,7 @@ pub(crate) struct SessionDecision {
 /// `egress_zone` are now `u16` IDs that index into
 /// `forwarding.zone_id_to_name` for slow-path consumers (logging,
 /// gRPC export, status). `0` means "unknown / unset" (matches the
-/// existing `UserspaceDpMeta.ingress_zone` default at types.rs:64).
+/// existing `UserspaceDpMeta.ingress_zone` default at afxdp/types/mod.rs:64).
 /// Removing the `Arc<str>` saves 28 bytes per `SessionMetadata` and
 /// eliminates the `LOCK XADD` atomic on every `metadata.clone()`.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -12,6 +12,8 @@ use std::net::IpAddr;
 // at pub(crate) keeps the existing crate::session::* surface intact.
 mod key;
 pub(crate) use key::*;
+mod entry;
+pub(crate) use entry::*;
 
 const SESSION_GC_INTERVAL_NS: u64 = 1_000_000_000;
 const DEFAULT_MAX_SESSIONS: usize = 131072;
@@ -186,129 +188,6 @@ struct SessionEntry {
     wheel_tick: u64,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct SessionDecision {
-    pub(crate) resolution: ForwardingResolution,
-    pub(crate) nat: NatDecision,
-}
-
-/// #919: zone names dropped from the fast path. `ingress_zone` and
-/// `egress_zone` are now `u16` IDs that index into
-/// `forwarding.zone_id_to_name` for slow-path consumers (logging,
-/// gRPC export, status). `0` means "unknown / unset" (matches the
-/// existing `UserspaceDpMeta.ingress_zone` default at types.rs:64).
-/// Removing the `Arc<str>` saves 28 bytes per `SessionMetadata` and
-/// eliminates the `LOCK XADD` atomic on every `metadata.clone()`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct SessionMetadata {
-    pub(crate) ingress_zone: u16,
-    pub(crate) egress_zone: u16,
-    pub(crate) owner_rg_id: i32,
-    pub(crate) fabric_ingress: bool,
-    pub(crate) is_reverse: bool,
-    /// For NAT64 sessions: stores original IPv6 addresses so reverse IPv4
-    /// replies can be translated back.
-    pub(crate) nat64_reverse: Option<Nat64ReverseInfo>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct SessionLookup {
-    pub(crate) decision: SessionDecision,
-    pub(crate) metadata: SessionMetadata,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ForwardSessionMatch {
-    pub(crate) key: SessionKey,
-    pub(crate) decision: SessionDecision,
-    pub(crate) metadata: SessionMetadata,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum SessionOrigin {
-    ForwardFlow,
-    ReverseFlow,
-    LocalMiss,
-    MissingNeighborSeed,
-    SyncImport,
-    SharedMaterialize,
-    SharedPromote,
-    #[allow(dead_code)] // enum variant for completeness
-    WorkerLocalImport,
-}
-
-impl SessionOrigin {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ForwardFlow => "forward_flow",
-            Self::ReverseFlow => "reverse_flow",
-            Self::LocalMiss => "local_miss",
-            Self::MissingNeighborSeed => "missing_neighbor_seed",
-            Self::SyncImport => "sync_import",
-            Self::SharedMaterialize => "shared_materialize",
-            Self::SharedPromote => "shared_promote",
-            Self::WorkerLocalImport => "worker_local_import",
-        }
-    }
-
-    /// Returns true for origins that represent peer-synced sessions.
-    /// These are sessions that arrived from the HA peer rather than
-    /// being created by local traffic.
-    pub(crate) fn is_peer_synced(self) -> bool {
-        matches!(
-            self,
-            Self::SyncImport | Self::SharedMaterialize | Self::WorkerLocalImport
-        )
-    }
-
-    pub(crate) fn is_promotable_synced(self) -> bool {
-        matches!(self, Self::SyncImport | Self::SharedMaterialize)
-    }
-
-    pub(crate) fn worker_replica_origin(self) -> Self {
-        if self.is_promotable_synced() {
-            Self::SyncImport
-        } else {
-            Self::WorkerLocalImport
-        }
-    }
-
-    pub(crate) fn materialized_shared_hit_origin(self) -> Self {
-        if self.is_promotable_synced() {
-            Self::SharedMaterialize
-        } else {
-            Self::WorkerLocalImport
-        }
-    }
-
-    pub(crate) fn is_transient_local_seed(self) -> bool {
-        matches!(self, Self::MissingNeighborSeed)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum SessionDeltaKind {
-    Open,
-    Close,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct SessionDelta {
-    pub(crate) kind: SessionDeltaKind,
-    pub(crate) key: SessionKey,
-    pub(crate) decision: SessionDecision,
-    pub(crate) metadata: SessionMetadata,
-    pub(crate) origin: SessionOrigin,
-    pub(crate) fabric_redirect_sync: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ExpiredSession {
-    pub(crate) key: SessionKey,
-    pub(crate) decision: SessionDecision,
-    pub(crate) metadata: SessionMetadata,
-    pub(crate) origin: SessionOrigin,
-}
 
 pub(crate) struct SessionTable {
     sessions: FxHashMap<SessionKey, SessionEntry>,


### PR DESCRIPTION
## Summary

Second step of the #1047 session structural split. Lifts the public-facing session data types from `session/mod.rs` into a new `session/entry.rs`.

## What moved (132 LOC)

| Item | Visibility |
|------|------------|
| `struct SessionDecision` | pub(crate) |
| `struct SessionMetadata` | pub(crate) |
| `struct SessionLookup` | pub(crate) |
| `struct ForwardSessionMatch` | pub(crate) |
| `enum SessionOrigin` + `impl SessionOrigin` | pub(crate) |
| `enum SessionDeltaKind` | pub(crate) |
| `struct SessionDelta` | pub(crate) |
| `struct ExpiredSession` | pub(crate) |

## What stays in `session/mod.rs`

`struct SessionEntry` — file-private internal storage type. Its fields are accessed directly by SessionTable's impl block, so moving it would require widening every field to `pub(in crate::session)`. Not worth the visibility churn for this pass; SessionEntry is paired tightly with SessionTable's lifecycle.

## How the public API stays intact

`session/mod.rs` adds:
```rust
mod entry;
pub(crate) use entry::*;
```

External callers reaching `crate::session::SessionDecision`, `crate::session::SessionDelta`, etc. continue to resolve through the glob re-export. No public API change.

## Diff shape

Pure relocation — bodies are byte-for-byte identical, no visibility changes (everything was already `pub(crate)`).

## LOC

| File | Before | After |
|------|--------|-------|
| session/mod.rs | 1,234 | 1,113 |
| session/entry.rs | — | 132 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster)

## Related

#1047. Continues the session split from #1058 (key.rs). Remaining: wheel.rs and the SessionTable/SessionEntry pair (will likely stay together in mod.rs given their tight field-level coupling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)