### PR TITLE
#1048 P2 step 2: server.rs → server/{mod,handlers,state}.rs

### DIFF
--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -19,7 +19,7 @@ mod xsk_ffi;
 
 mod protocol;
 mod server;
-use server::handle_stream;
+use server::{handle_stream, Args, PollMode, ServerState};
 
 use afxdp::SyncedSessionEntry;
 use chrono::Utc;
@@ -37,36 +37,6 @@ use std::time::{Duration, Instant};
 
 use state_writer::StateWriter;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PollMode {
-    BusyPoll,
-    Interrupt,
-}
-
-impl PollMode {
-    fn from_str(s: &str) -> Self {
-        match s {
-            "interrupt" => PollMode::Interrupt,
-            _ => PollMode::BusyPoll,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct Args {
-    control_socket: String,
-    state_file: String,
-    workers: usize,
-    ring_entries: usize,
-    poll_mode: PollMode,
-}
-
-struct ServerState {
-    status: ProcessStatus,
-    snapshot: Option<ConfigSnapshot>,
-    afxdp: afxdp::Coordinator,
-    state_writer: Arc<StateWriter>,
-}
 
 fn main() {
     if let Err(err) = run() {

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -19,7 +19,10 @@ mod xsk_ffi;
 
 mod protocol;
 mod server;
-use server::{handle_stream, Args, PollMode, ServerState};
+// Re-export at the crate root so other modules (afxdp/bind, afxdp/coordinator)
+// can continue to reach `crate::PollMode` after the move into server/state.rs
+// without depending on ancestor-privacy of a private use statement.
+pub(crate) use server::{handle_stream, Args, PollMode, ServerState};
 
 use afxdp::SyncedSessionEntry;
 use chrono::Utc;

--- a/userspace-dp/src/server/handlers.rs
+++ b/userspace-dp/src/server/handlers.rs
@@ -1,10 +1,12 @@
-// Control-socket request dispatcher (#1048 P2). Pure relocation
-// of `handle_stream` from main.rs into a dedicated module.
+// Control-socket request dispatcher (#1048 P2 step 2 — relocated from
+// src/server.rs into src/server/handlers.rs as part of the directory-
+// module split). Pure relocation of `handle_stream`.
 // All helper functions called by handle_stream remain in main.rs;
 // they are private items at the crate root and thus accessible
-// from this child module via `use super::*` / direct paths.
+// from this grandchild module via `use super::super::*` (which
+// climbs server/handlers → server → crate root).
 
-use super::*;
+use super::super::*;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/userspace-dp/src/server/mod.rs
+++ b/userspace-dp/src/server/mod.rs
@@ -4,8 +4,10 @@
 //
 // This file is a thin index — declarations + re-exports only.
 
-pub(crate) mod handlers;
-pub(crate) mod state;
+// Submodules are private — external callers reach their items only
+// through the explicit `pub(crate) use` re-exports below.
+mod handlers;
+mod state;
 
 pub(crate) use handlers::handle_stream;
 pub(crate) use state::{Args, PollMode, ServerState};

--- a/userspace-dp/src/server/mod.rs
+++ b/userspace-dp/src/server/mod.rs
@@ -1,0 +1,11 @@
+// #1048 P2 step 2: server/ became a directory module so the
+// public-API state types and the handler dispatch can live in
+// separate sibling files (server/state.rs and server/handlers.rs).
+//
+// This file is a thin index — declarations + re-exports only.
+
+pub(crate) mod handlers;
+pub(crate) mod state;
+
+pub(crate) use handlers::handle_stream;
+pub(crate) use state::{Args, PollMode, ServerState};

--- a/userspace-dp/src/server/state.rs
+++ b/userspace-dp/src/server/state.rs
@@ -1,0 +1,40 @@
+// Server state types extracted from main.rs (#1048 P2 step 2).
+// `PollMode` was already pub at the crate root; `Args` and
+// `ServerState` were file-private — widened to pub(crate) here
+// (and likewise their fields) so server/handlers.rs and main.rs's
+// run() loop can both construct and destructure them.
+
+use crate::state_writer::StateWriter;
+use crate::{afxdp, ConfigSnapshot, ProcessStatus};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollMode {
+    BusyPoll,
+    Interrupt,
+}
+
+impl PollMode {
+    pub(crate) fn from_str(s: &str) -> Self {
+        match s {
+            "interrupt" => PollMode::Interrupt,
+            _ => PollMode::BusyPoll,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Args {
+    pub(crate) control_socket: String,
+    pub(crate) state_file: String,
+    pub(crate) workers: usize,
+    pub(crate) ring_entries: usize,
+    pub(crate) poll_mode: PollMode,
+}
+
+pub(crate) struct ServerState {
+    pub(crate) status: ProcessStatus,
+    pub(crate) snapshot: Option<ConfigSnapshot>,
+    pub(crate) afxdp: afxdp::Coordinator,
+    pub(crate) state_writer: Arc<StateWriter>,
+}


### PR DESCRIPTION
## Summary

Second step of the `main.rs` → `server/` subsystem split. Converts step 1's single `src/server.rs` into the directory-module layout the user called for in #1048's "Clean Sweep" plan, and moves `Args`/`PollMode`/`ServerState` out of `main.rs` into the new `server/state.rs`.

## New layout

| File | LOC | Role |
|------|-----|------|
| `server/mod.rs` | 11 | Thin index — module declarations + re-exports |
| `server/handlers.rs` | 430 | `handle_stream` control-socket dispatcher (was step 1's `server.rs`) |
| `server/state.rs` | 40 | `PollMode` + `Args` + `ServerState` |

## Visibility widening (server/state.rs)

- `pub enum PollMode` — unchanged (already pub at crate root)
- `impl PollMode { fn from_str }` → `pub(crate) fn from_str`
- `struct Args` → `pub(crate) struct Args`; 5 fields → `pub(crate)`
- `struct ServerState` → `pub(crate) struct ServerState`; 4 fields → `pub(crate)`

Both `main.rs` and `server/handlers.rs` construct/destructure these types, so `pub(crate)` is the minimum visibility that works.

## Use-statement reshuffles

- `server/handlers.rs` (was `server.rs`): `use super::*;` widened to `use super::super::*;` — `super` of handlers.rs is `server/`, but the items `handle_stream` needs (refresh_status, build_synced_session_*, etc.) live in main.rs (the crate root), one level up.
- `server/state.rs`: explicit imports `use crate::{afxdp, ConfigSnapshot, ProcessStatus};` plus `use crate::state_writer::StateWriter;` plus `use std::sync::Arc;` for the four ServerState field types.
- `main.rs`: existing `use server::handle_stream;` extended to `use server::{handle_stream, Args, PollMode, ServerState};`.

## LOC

| File | Before | After |
|------|--------|-------|
| main.rs | 872 | 842 |
| server.rs | 429 | (renamed → server/handlers.rs) |
| server/handlers.rs | — | 430 |
| server/mod.rs | — | 11 |
| server/state.rs | — | 40 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster) — `handle_stream` is on the control-socket path; smoke validates session install / status poll round-trip

## Related

#1048. Continues #1061. The user's "Clean Sweep" `server/{mod,handlers,state}.rs` layout is now fully in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)