### PR TITLE
Issue 68.3: extract TX-request types to afxdp/types/tx.rs

### DIFF
--- a/userspace-dp/src/afxdp/types/mod.rs
+++ b/userspace-dp/src/afxdp/types/mod.rs
@@ -26,6 +26,10 @@ pub(in crate::afxdp) use forwarding::*;
 pub use forwarding::NeighborEntry;
 pub(crate) use forwarding::{ForwardingDisposition, ForwardingResolution};
 
+// Issue 68.3: TX-request types extracted into types/tx.rs.
+mod tx;
+pub(in crate::afxdp) use tx::*;
+
 pub(super) type FastMap<K, V> = FxHashMap<K, V>;
 pub(super) type FastSet<T> = FxHashSet<T>;
 pub(super) type OwnerRgSessionIndex = FastMap<i32, FastSet<SessionKey>>;
@@ -279,20 +283,6 @@ impl HAGroupRuntime {
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct SessionFlow {
     pub(super) src_ip: IpAddr,
@@ -343,90 +333,6 @@ impl ResolutionDebug {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(super) struct TxRequest {
-    pub(super) bytes: Vec<u8>,
-    #[allow(dead_code)]
-    pub(super) expected_ports: Option<(u16, u16)>,
-    #[allow(dead_code)]
-    pub(super) expected_addr_family: u8,
-    #[allow(dead_code)]
-    pub(super) expected_protocol: u8,
-    pub(super) flow_key: Option<SessionKey>,
-    pub(super) egress_ifindex: i32,
-    pub(super) cos_queue_id: Option<u8>,
-    pub(super) dscp_rewrite: Option<u8>,
-}
-
-pub(super) enum PendingForwardFrame {
-    Live,
-    Owned(Vec<u8>),
-    Prebuilt(Vec<u8>),
-}
-
-impl Default for PendingForwardFrame {
-    fn default() -> Self {
-        Self::Live
-    }
-}
-
-pub(super) struct PendingForwardRequest {
-    pub(super) target_ifindex: i32,
-    pub(super) target_binding_index: Option<usize>,
-    pub(super) ingress_queue_id: u32,
-    pub(super) desc: XdpDesc,
-    pub(super) frame: PendingForwardFrame,
-    pub(super) meta: ForwardPacketMeta,
-    pub(super) decision: SessionDecision,
-    pub(super) apply_nat_on_fabric: bool,
-    pub(super) expected_ports: Option<(u16, u16)>,
-    pub(super) flow_key: Option<SessionKey>,
-    pub(super) nat64_reverse: Option<Nat64ReverseInfo>,
-    pub(super) cos_queue_id: Option<u8>,
-    pub(super) dscp_rewrite: Option<u8>,
-}
-
-pub(super) struct PreparedTxRequest {
-    pub(super) offset: u64,
-    pub(super) len: u32,
-    pub(super) recycle: PreparedTxRecycle,
-    #[allow(dead_code)]
-    pub(super) expected_ports: Option<(u16, u16)>,
-    #[allow(dead_code)]
-    pub(super) expected_addr_family: u8,
-    #[allow(dead_code)]
-    pub(super) expected_protocol: u8,
-    pub(super) flow_key: Option<SessionKey>,
-    pub(super) egress_ifindex: i32,
-    pub(super) cos_queue_id: Option<u8>,
-    pub(super) dscp_rewrite: Option<u8>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct ExactLocalScratchTxRequest {
-    pub(super) offset: u64,
-    pub(super) len: u32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct ExactPreparedScratchTxRequest {
-    pub(super) offset: u64,
-    pub(super) len: u32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum PreparedTxRecycle {
-    FreeTxFrame,
-    FillOnSlot(u32),
-}
-
-#[derive(Debug)]
-pub(super) struct LocalTunnelTxPlan {
-    pub(super) tx_ifindex: i32,
-    pub(super) tx_request: TxRequest,
-    pub(super) session_entry: SyncedSessionEntry,
-    pub(super) reverse_session_entry: Option<SyncedSessionEntry>,
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct LearnedNeighborKey {

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -1,0 +1,94 @@
+// TX-request types extracted from afxdp/types/mod.rs (Issue 68.3).
+// 8 items / ~80 LOC of transmit-side request descriptors used by
+// tx/dispatch.rs and the per-binding pending-forward queues.
+//
+// Pure relocation. Original `pub(super)` widened to `pub(in crate::afxdp)`
+// in this file; types/mod.rs re-exports via `pub(in crate::afxdp) use
+// tx::*;` so external call sites resolve unchanged.
+
+use super::*;
+
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) struct TxRequest {
+    pub(in crate::afxdp) bytes: Vec<u8>,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_ports: Option<(u16, u16)>,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_addr_family: u8,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_protocol: u8,
+    pub(in crate::afxdp) flow_key: Option<SessionKey>,
+    pub(in crate::afxdp) egress_ifindex: i32,
+    pub(in crate::afxdp) cos_queue_id: Option<u8>,
+    pub(in crate::afxdp) dscp_rewrite: Option<u8>,
+}
+
+pub(in crate::afxdp) enum PendingForwardFrame {
+    Live,
+    Owned(Vec<u8>),
+    Prebuilt(Vec<u8>),
+}
+
+impl Default for PendingForwardFrame {
+    fn default() -> Self {
+        Self::Live
+    }
+}
+
+pub(in crate::afxdp) struct PendingForwardRequest {
+    pub(in crate::afxdp) target_ifindex: i32,
+    pub(in crate::afxdp) target_binding_index: Option<usize>,
+    pub(in crate::afxdp) ingress_queue_id: u32,
+    pub(in crate::afxdp) desc: XdpDesc,
+    pub(in crate::afxdp) frame: PendingForwardFrame,
+    pub(in crate::afxdp) meta: ForwardPacketMeta,
+    pub(in crate::afxdp) decision: SessionDecision,
+    pub(in crate::afxdp) apply_nat_on_fabric: bool,
+    pub(in crate::afxdp) expected_ports: Option<(u16, u16)>,
+    pub(in crate::afxdp) flow_key: Option<SessionKey>,
+    pub(in crate::afxdp) nat64_reverse: Option<Nat64ReverseInfo>,
+    pub(in crate::afxdp) cos_queue_id: Option<u8>,
+    pub(in crate::afxdp) dscp_rewrite: Option<u8>,
+}
+
+pub(in crate::afxdp) struct PreparedTxRequest {
+    pub(in crate::afxdp) offset: u64,
+    pub(in crate::afxdp) len: u32,
+    pub(in crate::afxdp) recycle: PreparedTxRecycle,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_ports: Option<(u16, u16)>,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_addr_family: u8,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) expected_protocol: u8,
+    pub(in crate::afxdp) flow_key: Option<SessionKey>,
+    pub(in crate::afxdp) egress_ifindex: i32,
+    pub(in crate::afxdp) cos_queue_id: Option<u8>,
+    pub(in crate::afxdp) dscp_rewrite: Option<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct ExactLocalScratchTxRequest {
+    pub(in crate::afxdp) offset: u64,
+    pub(in crate::afxdp) len: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct ExactPreparedScratchTxRequest {
+    pub(in crate::afxdp) offset: u64,
+    pub(in crate::afxdp) len: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) enum PreparedTxRecycle {
+    FreeTxFrame,
+    FillOnSlot(u32),
+}
+
+#[derive(Debug)]
+pub(in crate::afxdp) struct LocalTunnelTxPlan {
+    pub(in crate::afxdp) tx_ifindex: i32,
+    pub(in crate::afxdp) tx_request: TxRequest,
+    pub(in crate::afxdp) session_entry: SyncedSessionEntry,
+    pub(in crate::afxdp) reverse_session_entry: Option<SyncedSessionEntry>,
+}


### PR DESCRIPTION
## Summary

Third step of Issue 68. Extracts 8 TX-request types (~76 LOC) from `afxdp/types/mod.rs` into a new sibling `afxdp/types/tx.rs`.

## What moved

- `TxRequest` — the per-frame send descriptor
- `PendingForwardFrame` (enum) + `impl Default`
- `PendingForwardRequest`
- `PreparedTxRequest`
- `ExactLocalScratchTxRequest`
- `ExactPreparedScratchTxRequest`
- `PreparedTxRecycle` (enum)
- `LocalTunnelTxPlan`

## Visibility

Original `pub(super)` translated to `pub(in crate::afxdp)` in tx.rs. types/mod.rs adds:

```rust
mod tx;
pub(in crate::afxdp) use tx::*;
```

External call sites (mainly tx/dispatch.rs) reach `crate::afxdp::types::TxRequest` etc. through the glob re-export — unchanged surface.

## LOC

| File | Before | After |
|------|--------|-------|
| types/mod.rs | 710 | 616 |
| types/tx.rs | — | 94 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)