### PR TITLE
Issue 68.4: extract worker/runtime types to afxdp/types/runtime.rs

### DIFF
--- a/userspace-dp/src/afxdp/types/mod.rs
+++ b/userspace-dp/src/afxdp/types/mod.rs
@@ -30,6 +30,10 @@ pub(crate) use forwarding::{ForwardingDisposition, ForwardingResolution};
 mod tx;
 pub(in crate::afxdp) use tx::*;
 
+// Issue 68.4: worker / runtime types extracted into types/runtime.rs.
+mod runtime;
+pub(in crate::afxdp) use runtime::*;
+
 pub(super) type FastMap<K, V> = FxHashMap<K, V>;
 pub(super) type FastSet<T> = FxHashSet<T>;
 pub(super) type OwnerRgSessionIndex = FastMap<i32, FastSet<SessionKey>>;
@@ -197,46 +201,7 @@ impl From<ForwardPacketMeta> for UserspaceDpMeta {
         }
     }
 }
-#[repr(C)]
-pub(super) struct XdpOptions {
-    pub(super) flags: u32,
-}
 
-pub(super) struct WorkerHandle {
-    pub(super) stop: Arc<AtomicBool>,
-    pub(super) heartbeat: Arc<AtomicU64>,
-    pub(super) commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
-    pub(super) session_export_ack: Arc<AtomicU64>,
-    pub(super) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
-    // #869: per-worker busy/idle runtime telemetry publish slot.
-    pub(super) runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
-    pub(super) join: Option<JoinHandle<()>>,
-}
-
-pub(super) struct LocalTunnelSourceHandle {
-    pub(super) stop: Arc<AtomicBool>,
-    pub(super) join: Option<JoinHandle<()>>,
-}
-
-pub(super) struct BindingPlan {
-    pub(super) status: BindingStatus,
-    pub(super) live: Arc<BindingLiveState>,
-    pub(super) xsk_map_fd: c_int,
-    pub(super) heartbeat_map_fd: c_int,
-    pub(super) session_map_fd: c_int,
-    pub(super) conntrack_v4_fd: c_int,
-    pub(super) conntrack_v6_fd: c_int,
-    pub(super) ring_entries: u32,
-    pub(super) bind_strategy: AfXdpBindStrategy,
-    pub(super) poll_mode: crate::PollMode,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(super) struct ValidationState {
-    pub(super) snapshot_installed: bool,
-    pub(super) config_generation: u64,
-    pub(super) fib_generation: u32,
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum PacketDisposition {
@@ -245,41 +210,6 @@ pub(super) enum PacketDisposition {
     ConfigGenerationMismatch,
     FibGenerationMismatch,
     UnsupportedPacket,
-}
-
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-pub(super) enum HAForwardingLease {
-    #[default]
-    Inactive,
-    ActiveUntil(u64),
-}
-
-impl HAForwardingLease {
-    pub(super) fn active(self, now_secs: u64) -> bool {
-        matches!(self, Self::ActiveUntil(until) if until != 0 && now_secs <= until)
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-pub(super) struct HAGroupRuntime {
-    pub(super) active: bool,
-    pub(super) watchdog_timestamp: u64,
-    pub(super) lease: HAForwardingLease,
-}
-
-impl HAGroupRuntime {
-    pub(super) fn active_lease_until(watchdog_timestamp: u64, now_secs: u64) -> HAForwardingLease {
-        HAForwardingLease::ActiveUntil(
-            watchdog_timestamp
-                .max(now_secs)
-                .saturating_add(super::HA_WATCHDOG_STALE_AFTER_SECS),
-        )
-    }
-
-    pub(super) fn is_forwarding_active(self, now_secs: u64) -> bool {
-        self.active && self.lease.active(now_secs)
-    }
 }
 
 
@@ -306,161 +236,6 @@ impl SessionFlow {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(super) struct ResolutionDebug {
-    pub(super) ingress_ifindex: i32,
-    pub(super) src_ip: Option<IpAddr>,
-    pub(super) dst_ip: Option<IpAddr>,
-    pub(super) src_port: u16,
-    pub(super) dst_port: u16,
-    /// #919: stored as zone IDs; the slow-path `into_*` conversion
-    /// looks up the name via `forwarding.zone_id_to_name`.
-    pub(super) from_zone: Option<u16>,
-    pub(super) to_zone: Option<u16>,
-}
-
-impl ResolutionDebug {
-    pub(super) fn from_flow(ingress_ifindex: i32, flow: &SessionFlow) -> Self {
-        Self {
-            ingress_ifindex,
-            src_ip: Some(flow.src_ip),
-            dst_ip: Some(flow.dst_ip),
-            src_port: flow.forward_key.src_port,
-            dst_port: flow.forward_key.dst_port,
-            from_zone: None,
-            to_zone: None,
-        }
-    }
-}
-
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct LearnedNeighborKey {
-    pub(super) ingress_ifindex: i32,
-    pub(super) ingress_vlan_id: u16,
-    pub(super) src_ip: IpAddr,
-    pub(super) src_mac: [u8; 6],
-}
-
-#[derive(Clone, Debug)]
-pub(in crate::afxdp) enum WorkerCommand {
-    UpsertSynced(SyncedSessionEntry),
-    UpsertLocal(SyncedSessionEntry),
-    DeleteSynced(SessionKey),
-    DemoteOwnerRGS { owner_rgs: Vec<i32> },
-    RefreshOwnerRGS { owner_rgs: Vec<i32> },
-    ExportOwnerRGSessions { sequence: u64, owner_rgs: Vec<i32> },
-    EnqueueShapedLocal(TxRequest),
-    /// #941 Work item C: vacate ALL V_min slots owned by this worker
-    /// across every binding's shared_exact queues. Enqueued by the
-    /// coordinator on HA demotion (RG primary→secondary). The actual
-    /// vacate runs on the worker thread (single-writer invariant) —
-    /// this command sets a flag in `WorkerCommandResults`; the outer
-    /// poll loop dispatches via `vacate_all_shared_exact_slots`.
-    VacateAllSharedExactSlots,
-}
-
-#[derive(Default)]
-pub(super) struct DebugPollCounters {
-    pub(super) rx: u64,
-    #[allow(dead_code)]
-    pub(super) tx: u64,
-    pub(super) forward: u64,
-    #[allow(dead_code)]
-    pub(super) local: u64,
-    #[allow(dead_code)]
-    pub(super) session_hit: u64,
-    #[allow(dead_code)]
-    pub(super) session_miss: u64,
-    #[allow(dead_code)]
-    pub(super) session_create: u64,
-    #[allow(dead_code)]
-    pub(super) no_route: u64,
-    #[allow(dead_code)]
-    pub(super) missing_neigh: u64,
-    #[allow(dead_code)]
-    pub(super) policy_deny: u64,
-    #[allow(dead_code)]
-    pub(super) ha_inactive: u64,
-    #[allow(dead_code)]
-    pub(super) no_egress_binding: u64,
-    #[allow(dead_code)]
-    pub(super) build_fail: u64,
-    #[allow(dead_code)]
-    pub(super) tx_err: u64,
-    #[allow(dead_code)]
-    pub(super) metadata_err: u64,
-    pub(super) disposition_other: u64,
-    pub(super) enqueue_ok: u64,
-    pub(super) enqueue_inplace: u64,
-    pub(super) enqueue_direct: u64,
-    pub(super) enqueue_copy: u64,
-    pub(super) rx_from_trust: u64,
-    pub(super) rx_from_wan: u64,
-    pub(super) fwd_trust_to_wan: u64,
-    pub(super) fwd_wan_to_trust: u64,
-    pub(super) nat_applied_snat: u64,
-    pub(super) nat_applied_dnat: u64,
-    pub(super) nat_applied_none: u64,
-    #[allow(dead_code)]
-    pub(super) frame_build_none: u64,
-    pub(super) rx_tcp_rst: u64,
-    #[allow(dead_code)]
-    pub(super) tx_tcp_rst: u64,
-    pub(super) rx_bytes_total: u64,
-    pub(super) tx_bytes_total: u64,
-    pub(super) rx_oversized: u64,
-    pub(super) rx_max_frame: u32,
-    pub(super) tx_max_frame: u32,
-    pub(super) seg_needed_but_none: u64,
-    pub(super) wan_return_hits: u64,
-    #[allow(dead_code)]
-    pub(super) wan_return_misses: u64,
-    pub(super) rx_tcp_fin: u64,
-    pub(super) rx_tcp_synack: u64,
-    pub(super) rx_tcp_zero_window: u64,
-    pub(super) fwd_tcp_fin: u64,
-    pub(super) fwd_tcp_rst: u64,
-    pub(super) fwd_tcp_zero_window: u64,
-}
-
-/// #945: shared/passed-through context for `poll_binding_process_descriptor`.
-///
-/// All 16 fields are shared (`&'a` or `&'a Arc<...>`) references that
-/// the function reads from or that wrap interior-mutable state behind
-/// `Mutex`/`Arc`. NOT read-only in the strict sense — several entries
-/// like `dynamic_neighbors` are mutated through their inner `Mutex`
-/// (e.g. `dynamic_neighbors.lock().insert(...)` at afxdp.rs ARP/NA
-/// learn sites).
-///
-/// Constructed once per RX-batch call at the
-/// `poll_binding_process_descriptor` call site. `'a` is covariant.
-pub(super) struct WorkerContext<'a> {
-    pub(super) ident: &'a BindingIdentity,
-    pub(super) binding_lookup: &'a WorkerBindingLookup,
-    pub(super) forwarding: &'a ForwardingState,
-    pub(super) ha_state: &'a BTreeMap<i32, HAGroupRuntime>,
-    pub(super) dynamic_neighbors: &'a Arc<super::sharded_neighbor::ShardedNeighborMap>,
-    pub(super) shared_sessions: &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(super) shared_nat_sessions: &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(super) shared_forward_wire_sessions:
-        &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
-    pub(super) shared_owner_rg_indexes: &'a SharedSessionOwnerRgIndexes,
-    pub(super) slow_path: Option<&'a Arc<SlowPathReinjector>>,
-    pub(super) local_tunnel_deliveries:
-        &'a Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
-    pub(super) recent_exceptions: &'a Arc<Mutex<VecDeque<ExceptionStatus>>>,
-    pub(super) last_resolution: &'a Arc<Mutex<Option<PacketResolution>>>,
-    pub(super) peer_worker_commands: &'a [Arc<Mutex<VecDeque<WorkerCommand>>>],
-    pub(super) dnat_fds: &'a DnatTableFds,
-    pub(super) rg_epochs: &'a [AtomicU32; MAX_RG_EPOCHS],
-}
-
-/// #945: mutable telemetry context for `poll_binding_process_descriptor`.
-pub(super) struct TelemetryContext<'a> {
-    pub(super) dbg: &'a mut DebugPollCounters,
-    pub(super) counters: &'a mut BatchCounters,
-}
 
 #[cfg(test)]
 mod flow_rr_ring_tests {

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -1,0 +1,243 @@
+// Worker / runtime / per-binding plumbing types extracted from
+// afxdp/types/mod.rs (Issue 68.4). Includes worker handles + commands,
+// validation/disposition runtime state, debug poll counters, the
+// per-call WorkerContext / TelemetryContext bundles, BindingPlan,
+// XdpOptions, ResolutionDebug, LearnedNeighborKey, and the small HA
+// runtime types that the worker needs to thread through the dispatch
+// pipeline.
+//
+// Pure relocation. Original `pub(super)` widened to `pub(in crate::afxdp)`
+// in this file; types/mod.rs re-exports via `pub(in crate::afxdp) use
+// runtime::*;` so external call sites resolve unchanged.
+
+use super::*;
+
+#[repr(C)]
+pub(in crate::afxdp) struct XdpOptions {
+    pub(in crate::afxdp) flags: u32,
+}
+
+pub(in crate::afxdp) struct WorkerHandle {
+    pub(in crate::afxdp) stop: Arc<AtomicBool>,
+    pub(in crate::afxdp) heartbeat: Arc<AtomicU64>,
+    pub(in crate::afxdp) commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
+    pub(in crate::afxdp) session_export_ack: Arc<AtomicU64>,
+    pub(in crate::afxdp) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
+    // #869: per-worker busy/idle runtime telemetry publish slot.
+    pub(in crate::afxdp) runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
+    pub(in crate::afxdp) join: Option<JoinHandle<()>>,
+}
+
+pub(in crate::afxdp) struct LocalTunnelSourceHandle {
+    pub(in crate::afxdp) stop: Arc<AtomicBool>,
+    pub(in crate::afxdp) join: Option<JoinHandle<()>>,
+}
+
+pub(in crate::afxdp) struct BindingPlan {
+    pub(in crate::afxdp) status: BindingStatus,
+    pub(in crate::afxdp) live: Arc<BindingLiveState>,
+    pub(in crate::afxdp) xsk_map_fd: c_int,
+    pub(in crate::afxdp) heartbeat_map_fd: c_int,
+    pub(in crate::afxdp) session_map_fd: c_int,
+    pub(in crate::afxdp) conntrack_v4_fd: c_int,
+    pub(in crate::afxdp) conntrack_v6_fd: c_int,
+    pub(in crate::afxdp) ring_entries: u32,
+    pub(in crate::afxdp) bind_strategy: AfXdpBindStrategy,
+    pub(in crate::afxdp) poll_mode: crate::PollMode,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::afxdp) struct ValidationState {
+    pub(in crate::afxdp) snapshot_installed: bool,
+    pub(in crate::afxdp) config_generation: u64,
+    pub(in crate::afxdp) fib_generation: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub(in crate::afxdp) enum HAForwardingLease {
+    #[default]
+    Inactive,
+    ActiveUntil(u64),
+}
+
+impl HAForwardingLease {
+    pub(in crate::afxdp) fn active(self, now_secs: u64) -> bool {
+        matches!(self, Self::ActiveUntil(until) if until != 0 && now_secs <= until)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(in crate::afxdp) struct HAGroupRuntime {
+    pub(in crate::afxdp) active: bool,
+    pub(in crate::afxdp) watchdog_timestamp: u64,
+    pub(in crate::afxdp) lease: HAForwardingLease,
+}
+
+impl HAGroupRuntime {
+    pub(in crate::afxdp) fn active_lease_until(watchdog_timestamp: u64, now_secs: u64) -> HAForwardingLease {
+        HAForwardingLease::ActiveUntil(
+            watchdog_timestamp
+                .max(now_secs)
+                .saturating_add(super::HA_WATCHDOG_STALE_AFTER_SECS),
+        )
+    }
+
+    pub(in crate::afxdp) fn is_forwarding_active(self, now_secs: u64) -> bool {
+        self.active && self.lease.active(now_secs)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(in crate::afxdp) struct ResolutionDebug {
+    pub(in crate::afxdp) ingress_ifindex: i32,
+    pub(in crate::afxdp) src_ip: Option<IpAddr>,
+    pub(in crate::afxdp) dst_ip: Option<IpAddr>,
+    pub(in crate::afxdp) src_port: u16,
+    pub(in crate::afxdp) dst_port: u16,
+    /// #919: stored as zone IDs; the slow-path `into_*` conversion
+    /// looks up the name via `forwarding.zone_id_to_name`.
+    pub(in crate::afxdp) from_zone: Option<u16>,
+    pub(in crate::afxdp) to_zone: Option<u16>,
+}
+
+impl ResolutionDebug {
+    pub(in crate::afxdp) fn from_flow(ingress_ifindex: i32, flow: &SessionFlow) -> Self {
+        Self {
+            ingress_ifindex,
+            src_ip: Some(flow.src_ip),
+            dst_ip: Some(flow.dst_ip),
+            src_port: flow.forward_key.src_port,
+            dst_port: flow.forward_key.dst_port,
+            from_zone: None,
+            to_zone: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct LearnedNeighborKey {
+    pub(in crate::afxdp) ingress_ifindex: i32,
+    pub(in crate::afxdp) ingress_vlan_id: u16,
+    pub(in crate::afxdp) src_ip: IpAddr,
+    pub(in crate::afxdp) src_mac: [u8; 6],
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) enum WorkerCommand {
+    UpsertSynced(SyncedSessionEntry),
+    UpsertLocal(SyncedSessionEntry),
+    DeleteSynced(SessionKey),
+    DemoteOwnerRGS { owner_rgs: Vec<i32> },
+    RefreshOwnerRGS { owner_rgs: Vec<i32> },
+    ExportOwnerRGSessions { sequence: u64, owner_rgs: Vec<i32> },
+    EnqueueShapedLocal(TxRequest),
+    /// #941 Work item C: vacate ALL V_min slots owned by this worker
+    /// across every binding's shared_exact queues. Enqueued by the
+    /// coordinator on HA demotion (RG primary→secondary). The actual
+    /// vacate runs on the worker thread (single-writer invariant) —
+    /// this command sets a flag in `WorkerCommandResults`; the outer
+    /// poll loop dispatches via `vacate_all_shared_exact_slots`.
+    VacateAllSharedExactSlots,
+}
+
+#[derive(Default)]
+pub(in crate::afxdp) struct DebugPollCounters {
+    pub(in crate::afxdp) rx: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) tx: u64,
+    pub(in crate::afxdp) forward: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) local: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) session_hit: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) session_miss: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) session_create: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) no_route: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) missing_neigh: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) policy_deny: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) ha_inactive: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) no_egress_binding: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) build_fail: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) tx_err: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) metadata_err: u64,
+    pub(in crate::afxdp) disposition_other: u64,
+    pub(in crate::afxdp) enqueue_ok: u64,
+    pub(in crate::afxdp) enqueue_inplace: u64,
+    pub(in crate::afxdp) enqueue_direct: u64,
+    pub(in crate::afxdp) enqueue_copy: u64,
+    pub(in crate::afxdp) rx_from_trust: u64,
+    pub(in crate::afxdp) rx_from_wan: u64,
+    pub(in crate::afxdp) fwd_trust_to_wan: u64,
+    pub(in crate::afxdp) fwd_wan_to_trust: u64,
+    pub(in crate::afxdp) nat_applied_snat: u64,
+    pub(in crate::afxdp) nat_applied_dnat: u64,
+    pub(in crate::afxdp) nat_applied_none: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) frame_build_none: u64,
+    pub(in crate::afxdp) rx_tcp_rst: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) tx_tcp_rst: u64,
+    pub(in crate::afxdp) rx_bytes_total: u64,
+    pub(in crate::afxdp) tx_bytes_total: u64,
+    pub(in crate::afxdp) rx_oversized: u64,
+    pub(in crate::afxdp) rx_max_frame: u32,
+    pub(in crate::afxdp) tx_max_frame: u32,
+    pub(in crate::afxdp) seg_needed_but_none: u64,
+    pub(in crate::afxdp) wan_return_hits: u64,
+    #[allow(dead_code)]
+    pub(in crate::afxdp) wan_return_misses: u64,
+    pub(in crate::afxdp) rx_tcp_fin: u64,
+    pub(in crate::afxdp) rx_tcp_synack: u64,
+    pub(in crate::afxdp) rx_tcp_zero_window: u64,
+    pub(in crate::afxdp) fwd_tcp_fin: u64,
+    pub(in crate::afxdp) fwd_tcp_rst: u64,
+    pub(in crate::afxdp) fwd_tcp_zero_window: u64,
+}
+
+/// #945: shared/passed-through context for `poll_binding_process_descriptor`.
+///
+/// All 16 fields are shared (`&'a` or `&'a Arc<...>`) references that
+/// the function reads from or that wrap interior-mutable state behind
+/// `Mutex`/`Arc`. NOT read-only in the strict sense — several entries
+/// like `dynamic_neighbors` are mutated through their inner `Mutex`
+/// (e.g. `dynamic_neighbors.lock().insert(...)` at afxdp.rs ARP/NA
+/// learn sites).
+///
+/// Constructed once per RX-batch call at the
+/// `poll_binding_process_descriptor` call site. `'a` is covariant.
+pub(in crate::afxdp) struct WorkerContext<'a> {
+    pub(in crate::afxdp) ident: &'a BindingIdentity,
+    pub(in crate::afxdp) binding_lookup: &'a WorkerBindingLookup,
+    pub(in crate::afxdp) forwarding: &'a ForwardingState,
+    pub(in crate::afxdp) ha_state: &'a BTreeMap<i32, HAGroupRuntime>,
+    pub(in crate::afxdp) dynamic_neighbors: &'a Arc<super::sharded_neighbor::ShardedNeighborMap>,
+    pub(in crate::afxdp) shared_sessions: &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) shared_nat_sessions: &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) shared_forward_wire_sessions:
+        &'a Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    pub(in crate::afxdp) shared_owner_rg_indexes: &'a SharedSessionOwnerRgIndexes,
+    pub(in crate::afxdp) slow_path: Option<&'a Arc<SlowPathReinjector>>,
+    pub(in crate::afxdp) local_tunnel_deliveries:
+        &'a Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>>,
+    pub(in crate::afxdp) recent_exceptions: &'a Arc<Mutex<VecDeque<ExceptionStatus>>>,
+    pub(in crate::afxdp) last_resolution: &'a Arc<Mutex<Option<PacketResolution>>>,
+    pub(in crate::afxdp) peer_worker_commands: &'a [Arc<Mutex<VecDeque<WorkerCommand>>>],
+    pub(in crate::afxdp) dnat_fds: &'a DnatTableFds,
+    pub(in crate::afxdp) rg_epochs: &'a [AtomicU32; MAX_RG_EPOCHS],
+}
+
+/// #945: mutable telemetry context for `poll_binding_process_descriptor`.
+pub(in crate::afxdp) struct TelemetryContext<'a> {
+    pub(in crate::afxdp) dbg: &'a mut DebugPollCounters,
+    pub(in crate::afxdp) counters: &'a mut BatchCounters,
+}


### PR DESCRIPTION
## Summary

Fourth and final step of Issue 68. Extracts 13 worker/runtime/per-binding plumbing types (~214 LOC) from `afxdp/types/mod.rs` into a new sibling `afxdp/types/runtime.rs`.

## What moved

| Category | Items |
|---|---|
| Worker plumbing | WorkerHandle, LocalTunnelSourceHandle, WorkerCommand (enum), WorkerContext<'a>, TelemetryContext<'a> |
| Per-binding state | XdpOptions, BindingPlan, ValidationState |
| HA runtime | HAForwardingLease + impl, HAGroupRuntime + impl |
| Diagnostics | DebugPollCounters, ResolutionDebug + impl, LearnedNeighborKey |

## Visibility

Original `pub(super)` translated to `pub(in crate::afxdp)` in runtime.rs. `WorkerCommand` was already `pub(in crate::afxdp)` and stays that way. types/mod.rs adds:

```rust
mod runtime;
pub(in crate::afxdp) use runtime::*;
```

## After this PR

`types/mod.rs` is 391 LOC — the cross-cutting types (SharedSessionOwnerRgIndexes, PendingNeighPacket, UserspaceDpMeta, ForwardPacketMeta, PacketDisposition, SessionFlow, BindingIdentity) plus the FastMap/FastSet/OwnerRgSessionIndex aliases stay there as the irreducible glue layer.

## Cumulative Issue 68 result

| File | Master | After 68.1-4 |
|------|--------|---|
| types/mod.rs | 1,733 | 391 |
| types/cos.rs | — | 766 |
| types/forwarding.rs | — | 313 |
| types/tx.rs | — | 94 |
| types/runtime.rs | — | 243 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)