### PR TITLE
Issue 67.2: extract neighbor-dispatch cluster from afxdp.rs

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -683,112 +683,14 @@ use poll_descriptor::poll_binding_process_descriptor;
 // extracted into afxdp/session_delta.rs.
 mod session_delta;
 use session_delta::{flush_session_deltas, purge_queued_flows_for_closed_deltas};
-fn retry_pending_neigh(
-    binding: &mut BindingWorker,
-    left: &mut [BindingWorker],
-    binding_index: usize,
-    right: &mut [BindingWorker],
-    binding_lookup: &WorkerBindingLookup,
-    forwarding: &ForwardingState,
-    dynamic_neighbors: &Arc<ShardedNeighborMap>,
-    now_ns: u64,
-    area: &MmapArea,
-) {
-    if binding.pending_neigh.is_empty() {
-        return;
-    }
-    {
-        let mut i = 0;
-        while i < binding.pending_neigh.len() {
-            let pkt = &binding.pending_neigh[i];
-            // Timeout: recycle frame and drop
-            if now_ns.saturating_sub(pkt.queued_ns) > PENDING_NEIGH_TIMEOUT_NS {
-                let addr = pkt.addr;
-                binding.pending_neigh.remove(i);
-                binding.pending_fill_frames.push_back(addr);
-                continue;
-            }
-            // Check if neighbor MAC is now available, mirroring the lookup
-            // order from lookup_neighbor_entry(): static/permanent neighbors
-            // first, then dynamic_neighbors.
-            let mac = if let Some(hop) = pkt.decision.resolution.next_hop {
-                let neigh_key = (pkt.decision.resolution.egress_ifindex, hop);
-                forwarding
-                    .neighbors
-                    .get(&neigh_key)
-                    .map(|e| e.mac)
-                    .or_else(|| dynamic_neighbors.get(&neigh_key).map(|e| e.mac))
-            } else {
-                None
-            };
-            if let Some(neighbor_mac) = mac {
-                let ingress_slot = binding.slot;
-                let ingress_ifindex = binding.ifindex;
-                let ingress_queue = binding.queue_id;
-                let pkt = binding.pending_neigh.remove(i).unwrap();
-                let mut decision = pkt.decision;
-                decision.resolution.neighbor_mac = Some(neighbor_mac);
-                decision.resolution.disposition = ForwardingDisposition::ForwardCandidate;
-                let expected_ports = None;
-                if let Some(frame_len) = rewrite_forwarded_frame_in_place(
-                    &*area,
-                    pkt.desc,
-                    pkt.meta,
-                    &decision,
-                    false,
-                    expected_ports,
-                ) {
-                    let target_ifindex = if decision.resolution.tx_ifindex > 0 {
-                        decision.resolution.tx_ifindex
-                    } else {
-                        resolve_tx_binding_ifindex(forwarding, decision.resolution.egress_ifindex)
-                    };
-                    if let Some(target_idx) = binding_lookup.target_index(
-                        binding_index,
-                        ingress_ifindex,
-                        ingress_queue,
-                        target_ifindex,
-                    ) {
-                        let cos = resolve_cos_tx_selection(
-                            forwarding,
-                            decision.resolution.egress_ifindex,
-                            pkt.meta,
-                            None,
-                        );
-                        let req = PreparedTxRequest {
-                            offset: pkt.desc.addr,
-                            len: frame_len,
-                            recycle: PreparedTxRecycle::FillOnSlot(ingress_slot),
-                            expected_ports: None,
-                            expected_addr_family: pkt.meta.addr_family,
-                            expected_protocol: pkt.meta.protocol,
-                            flow_key: None,
-                            egress_ifindex: decision.resolution.egress_ifindex,
-                            cos_queue_id: cos.queue_id,
-                            dscp_rewrite: cos.dscp_rewrite,
-                        };
-                        if target_idx == binding_index {
-                            binding.pending_tx_prepared.push_back(req);
-                        } else if let Some(target) =
-                            binding_by_index_mut(left, binding_index, binding, right, target_idx)
-                        {
-                            target.pending_tx_prepared.push_back(req);
-                            bound_pending_tx_prepared(target);
-                        } else {
-                            binding.pending_fill_frames.push_back(pkt.addr);
-                        }
-                    } else {
-                        binding.pending_fill_frames.push_back(pkt.addr);
-                    }
-                } else {
-                    binding.pending_fill_frames.push_back(pkt.addr);
-                }
-                continue;
-            }
-            i += 1;
-        }
-    }
-}
+
+// Issue 67.2: neighbor-dispatch helpers extracted into
+// afxdp/neighbor_dispatch.rs.
+mod neighbor_dispatch;
+use neighbor_dispatch::{
+    build_missing_neighbor_session_metadata,
+    learn_dynamic_neighbor_from_packet, retry_pending_neigh,
+};
 
 #[cfg_attr(not(test), allow(dead_code))]
 fn build_live_forward_request(
@@ -914,97 +816,6 @@ fn build_live_forward_request_from_frame(
 // its unit test and potential future use.
 #[allow(dead_code)]
 
-fn learn_dynamic_neighbor_from_packet(
-    area: &MmapArea,
-    desc: XdpDesc,
-    meta: UserspaceDpMeta,
-    src_ip: IpAddr,
-    last_learned_neighbor: &mut Option<LearnedNeighborKey>,
-    forwarding: &ForwardingState,
-    dynamic_neighbors: &Arc<ShardedNeighborMap>,
-) {
-    let Some(frame) = area.slice(desc.addr as usize, desc.len as usize) else {
-        return;
-    };
-    if frame.len() < 12 {
-        return;
-    }
-    if frame[6] == 0x02
-        && frame[7] == 0xbf
-        && frame[8] == 0x72
-        && frame[9] == FABRIC_ZONE_MAC_MAGIC
-        && frame[10] == 0x00
-    {
-        return;
-    }
-    let mut src_mac = [0u8; 6];
-    src_mac.copy_from_slice(&frame[6..12]);
-    if src_mac == [0; 6] || (src_mac[0] & 1) != 0 {
-        return;
-    }
-    let learned = LearnedNeighborKey {
-        ingress_ifindex: meta.ingress_ifindex as i32,
-        ingress_vlan_id: meta.ingress_vlan_id,
-        src_ip,
-        src_mac,
-    };
-    if last_learned_neighbor.as_ref() == Some(&learned) {
-        return;
-    }
-    learn_dynamic_neighbor(
-        forwarding,
-        dynamic_neighbors,
-        meta.ingress_ifindex as i32,
-        meta.ingress_vlan_id,
-        src_ip,
-        src_mac,
-    );
-    *last_learned_neighbor = Some(learned);
-}
-
-fn learn_dynamic_neighbor(
-    forwarding: &ForwardingState,
-    dynamic_neighbors: &Arc<ShardedNeighborMap>,
-    ingress_ifindex: i32,
-    ingress_vlan_id: u16,
-    src_ip: IpAddr,
-    src_mac: [u8; 6],
-) {
-    let mut ifindexes = vec![ingress_ifindex];
-    if let Some(logical_ifindex) =
-        resolve_ingress_logical_ifindex(forwarding, ingress_ifindex, ingress_vlan_id)
-    {
-        if logical_ifindex > 0 && logical_ifindex != ingress_ifindex {
-            ifindexes.push(logical_ifindex);
-        }
-    }
-    // #949: multi-ifindex insert atomically vs readers — both
-    // ingress_ifindex and the resolved logical (VLAN sub-) ifindex
-    // get the same MAC under one bulk acquisition so a reader sees
-    // either both or neither, never a stale half.
-    dynamic_neighbors.with_all_shards(|bulk| {
-        for ifindex in ifindexes {
-            bulk.insert((ifindex, src_ip), NeighborEntry { mac: src_mac });
-        }
-    });
-}
-
-fn build_missing_neighbor_session_metadata(
-    forwarding: &ForwardingState,
-    ingress_zone: u16,
-    egress_zone: u16,
-    fabric_ingress: bool,
-    decision: SessionDecision,
-) -> SessionMetadata {
-    SessionMetadata {
-        ingress_zone,
-        egress_zone,
-        owner_rg_id: owner_rg_for_resolution(forwarding, decision.resolution),
-        fabric_ingress,
-        is_reverse: false,
-        nat64_reverse: None,
-    }
-}
 
 fn binding_by_index_mut<'a>(
     left: &'a mut [BindingWorker],

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -1,0 +1,218 @@
+// Neighbor-dispatch helpers extracted from afxdp.rs (Issue 67.2).
+//
+// `retry_pending_neigh` is the post-poll loop that walks the
+// per-binding pending-neighbor queue, re-issues bpf_fib_lookup +
+// neighbor lookups, and resumes any flow whose neighbor has now
+// resolved (or drops it if the cap is exceeded).
+//
+// `learn_dynamic_neighbor*` are called from the RX descriptor
+// path when an inbound ARP/NDP advert resolves a previously
+// missing neighbor — they upsert into the dynamic neighbor map.
+//
+// `build_missing_neighbor_session_metadata` constructs the
+// SessionMetadata stub used while the neighbor is unresolved
+// so subsequent retries have the full forward context.
+//
+// Pure relocation. `use super::*;` brings every type, helper,
+// and sibling-submodule item from afxdp.rs into scope.
+
+use super::*;
+
+pub(super) fn retry_pending_neigh(
+    binding: &mut BindingWorker,
+    left: &mut [BindingWorker],
+    binding_index: usize,
+    right: &mut [BindingWorker],
+    binding_lookup: &WorkerBindingLookup,
+    forwarding: &ForwardingState,
+    dynamic_neighbors: &Arc<ShardedNeighborMap>,
+    now_ns: u64,
+    area: &MmapArea,
+) {
+    if binding.pending_neigh.is_empty() {
+        return;
+    }
+    {
+        let mut i = 0;
+        while i < binding.pending_neigh.len() {
+            let pkt = &binding.pending_neigh[i];
+            // Timeout: recycle frame and drop
+            if now_ns.saturating_sub(pkt.queued_ns) > PENDING_NEIGH_TIMEOUT_NS {
+                let addr = pkt.addr;
+                binding.pending_neigh.remove(i);
+                binding.pending_fill_frames.push_back(addr);
+                continue;
+            }
+            // Check if neighbor MAC is now available, mirroring the lookup
+            // order from lookup_neighbor_entry(): static/permanent neighbors
+            // first, then dynamic_neighbors.
+            let mac = if let Some(hop) = pkt.decision.resolution.next_hop {
+                let neigh_key = (pkt.decision.resolution.egress_ifindex, hop);
+                forwarding
+                    .neighbors
+                    .get(&neigh_key)
+                    .map(|e| e.mac)
+                    .or_else(|| dynamic_neighbors.get(&neigh_key).map(|e| e.mac))
+            } else {
+                None
+            };
+            if let Some(neighbor_mac) = mac {
+                let ingress_slot = binding.slot;
+                let ingress_ifindex = binding.ifindex;
+                let ingress_queue = binding.queue_id;
+                let pkt = binding.pending_neigh.remove(i).unwrap();
+                let mut decision = pkt.decision;
+                decision.resolution.neighbor_mac = Some(neighbor_mac);
+                decision.resolution.disposition = ForwardingDisposition::ForwardCandidate;
+                let expected_ports = None;
+                if let Some(frame_len) = rewrite_forwarded_frame_in_place(
+                    &*area,
+                    pkt.desc,
+                    pkt.meta,
+                    &decision,
+                    false,
+                    expected_ports,
+                ) {
+                    let target_ifindex = if decision.resolution.tx_ifindex > 0 {
+                        decision.resolution.tx_ifindex
+                    } else {
+                        resolve_tx_binding_ifindex(forwarding, decision.resolution.egress_ifindex)
+                    };
+                    if let Some(target_idx) = binding_lookup.target_index(
+                        binding_index,
+                        ingress_ifindex,
+                        ingress_queue,
+                        target_ifindex,
+                    ) {
+                        let cos = resolve_cos_tx_selection(
+                            forwarding,
+                            decision.resolution.egress_ifindex,
+                            pkt.meta,
+                            None,
+                        );
+                        let req = PreparedTxRequest {
+                            offset: pkt.desc.addr,
+                            len: frame_len,
+                            recycle: PreparedTxRecycle::FillOnSlot(ingress_slot),
+                            expected_ports: None,
+                            expected_addr_family: pkt.meta.addr_family,
+                            expected_protocol: pkt.meta.protocol,
+                            flow_key: None,
+                            egress_ifindex: decision.resolution.egress_ifindex,
+                            cos_queue_id: cos.queue_id,
+                            dscp_rewrite: cos.dscp_rewrite,
+                        };
+                        if target_idx == binding_index {
+                            binding.pending_tx_prepared.push_back(req);
+                        } else if let Some(target) =
+                            binding_by_index_mut(left, binding_index, binding, right, target_idx)
+                        {
+                            target.pending_tx_prepared.push_back(req);
+                            bound_pending_tx_prepared(target);
+                        } else {
+                            binding.pending_fill_frames.push_back(pkt.addr);
+                        }
+                    } else {
+                        binding.pending_fill_frames.push_back(pkt.addr);
+                    }
+                } else {
+                    binding.pending_fill_frames.push_back(pkt.addr);
+                }
+                continue;
+            }
+            i += 1;
+        }
+    }
+}
+
+pub(super) fn learn_dynamic_neighbor_from_packet(
+    area: &MmapArea,
+    desc: XdpDesc,
+    meta: UserspaceDpMeta,
+    src_ip: IpAddr,
+    last_learned_neighbor: &mut Option<LearnedNeighborKey>,
+    forwarding: &ForwardingState,
+    dynamic_neighbors: &Arc<ShardedNeighborMap>,
+) {
+    let Some(frame) = area.slice(desc.addr as usize, desc.len as usize) else {
+        return;
+    };
+    if frame.len() < 12 {
+        return;
+    }
+    if frame[6] == 0x02
+        && frame[7] == 0xbf
+        && frame[8] == 0x72
+        && frame[9] == FABRIC_ZONE_MAC_MAGIC
+        && frame[10] == 0x00
+    {
+        return;
+    }
+    let mut src_mac = [0u8; 6];
+    src_mac.copy_from_slice(&frame[6..12]);
+    if src_mac == [0; 6] || (src_mac[0] & 1) != 0 {
+        return;
+    }
+    let learned = LearnedNeighborKey {
+        ingress_ifindex: meta.ingress_ifindex as i32,
+        ingress_vlan_id: meta.ingress_vlan_id,
+        src_ip,
+        src_mac,
+    };
+    if last_learned_neighbor.as_ref() == Some(&learned) {
+        return;
+    }
+    learn_dynamic_neighbor(
+        forwarding,
+        dynamic_neighbors,
+        meta.ingress_ifindex as i32,
+        meta.ingress_vlan_id,
+        src_ip,
+        src_mac,
+    );
+    *last_learned_neighbor = Some(learned);
+}
+
+pub(super) fn learn_dynamic_neighbor(
+    forwarding: &ForwardingState,
+    dynamic_neighbors: &Arc<ShardedNeighborMap>,
+    ingress_ifindex: i32,
+    ingress_vlan_id: u16,
+    src_ip: IpAddr,
+    src_mac: [u8; 6],
+) {
+    let mut ifindexes = vec![ingress_ifindex];
+    if let Some(logical_ifindex) =
+        resolve_ingress_logical_ifindex(forwarding, ingress_ifindex, ingress_vlan_id)
+    {
+        if logical_ifindex > 0 && logical_ifindex != ingress_ifindex {
+            ifindexes.push(logical_ifindex);
+        }
+    }
+    // #949: multi-ifindex insert atomically vs readers — both
+    // ingress_ifindex and the resolved logical (VLAN sub-) ifindex
+    // get the same MAC under one bulk acquisition so a reader sees
+    // either both or neither, never a stale half.
+    dynamic_neighbors.with_all_shards(|bulk| {
+        for ifindex in ifindexes {
+            bulk.insert((ifindex, src_ip), NeighborEntry { mac: src_mac });
+        }
+    });
+}
+
+pub(super) fn build_missing_neighbor_session_metadata(
+    forwarding: &ForwardingState,
+    ingress_zone: u16,
+    egress_zone: u16,
+    fabric_ingress: bool,
+    decision: SessionDecision,
+) -> SessionMetadata {
+    SessionMetadata {
+        ingress_zone,
+        egress_zone,
+        owner_rg_id: owner_rg_for_resolution(forwarding, decision.resolution),
+        fabric_ingress,
+        is_reverse: false,
+        nat64_reverse: None,
+    }
+}

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -173,7 +173,7 @@ pub(super) fn learn_dynamic_neighbor_from_packet(
     *last_learned_neighbor = Some(learned);
 }
 
-pub(super) fn learn_dynamic_neighbor(
+fn learn_dynamic_neighbor(
     forwarding: &ForwardingState,
     dynamic_neighbors: &Arc<ShardedNeighborMap>,
     ingress_ifindex: i32,


### PR DESCRIPTION
## Summary

Second step of Issue 67. Extracts four neighbor-related fns (~200 LOC) from `userspace-dp/src/afxdp.rs` into a new sibling module `userspace-dp/src/afxdp/neighbor_dispatch.rs`.

## What moved

- `retry_pending_neigh` (108 LOC) — post-poll loop that walks the per-binding pending-neighbor queue, re-issues `bpf_fib_lookup` + neighbor lookups, resumes flows whose neighbors resolved (or drops them when the cap is exceeded).
- `learn_dynamic_neighbor_from_packet` (47 LOC) — RX-path entry point for learning a neighbor from an inbound ARP/NDP advert.
- `learn_dynamic_neighbor` (26 LOC) — internal upsert helper.
- `build_missing_neighbor_session_metadata` (16 LOC) — constructs the SessionMetadata stub used while neighbor is unresolved.

## Visibility

- `retry_pending_neigh`, `learn_dynamic_neighbor_from_packet`, `build_missing_neighbor_session_metadata` widened to `pub(super)` (called from afxdp.rs / poll_descriptor.rs).
- `learn_dynamic_neighbor` stays file-private (only called by `learn_dynamic_neighbor_from_packet` inside the new module).

afxdp.rs adds:
```rust
mod neighbor_dispatch;
use neighbor_dispatch::{
    build_missing_neighbor_session_metadata,
    learn_dynamic_neighbor_from_packet, retry_pending_neigh,
};
```

## LOC

| File | Before | After |
|------|--------|-------|
| afxdp.rs | 1,275 | 1,086 |
| afxdp/neighbor_dispatch.rs | — | 218 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean (92 warnings, same as master)
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)