### PR TITLE
Issue 70 / #994: move reverse_session_key to session/key.rs

### DIFF
--- a/userspace-dp/src/afxdp.rs
+++ b/userspace-dp/src/afxdp.rs
@@ -13,7 +13,7 @@ use crate::screen::{ScreenProfile, ScreenState, ScreenVerdict, extract_screen_in
 use crate::session::{
     ForwardSessionMatch, SessionDecision, SessionDelta, SessionDeltaKind, SessionKey,
     SessionLookup, SessionMetadata, SessionOrigin, SessionTable, forward_wire_key,
-    reverse_canonical_key,
+    reverse_canonical_key, reverse_session_key,
 };
 use crate::slowpath::{EnqueueOutcome, SlowPathReinjector, SlowPathStatus, open_tun};
 use crate::xsk_ffi::xdp::XdpDesc;

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -1,41 +1,5 @@
 use super::*;
 
-pub(super) fn reverse_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey {
-    let (src_port, dst_port) = if matches!(key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        (key.src_port, key.dst_port)
-    } else {
-        (
-            nat.rewrite_dst_port.unwrap_or(key.dst_port),
-            nat.rewrite_src_port.unwrap_or(key.src_port),
-        )
-    };
-    let wire_src = nat.rewrite_dst.unwrap_or(key.dst_ip);
-    let wire_dst = nat.rewrite_src.unwrap_or(key.src_ip);
-    let (addr_family, protocol) = if nat.nat64 {
-        let af = match wire_src {
-            IpAddr::V4(_) => libc::AF_INET as u8,
-            IpAddr::V6(_) => libc::AF_INET6 as u8,
-        };
-        let proto = if af == libc::AF_INET as u8 && key.protocol == PROTO_ICMPV6 {
-            PROTO_ICMP
-        } else if af == libc::AF_INET6 as u8 && key.protocol == PROTO_ICMP {
-            PROTO_ICMPV6
-        } else {
-            key.protocol
-        };
-        (af, proto)
-    } else {
-        (key.addr_family, key.protocol)
-    };
-    SessionKey {
-        addr_family,
-        protocol,
-        src_ip: wire_src,
-        dst_ip: wire_dst,
-        src_port,
-        dst_port,
-    }
-}
 
 pub(super) fn resolution_target_for_session(
     flow: &SessionFlow,

--- a/userspace-dp/src/session/key.rs
+++ b/userspace-dp/src/session/key.rs
@@ -136,3 +136,54 @@ pub(crate) fn reverse_canonical_key(forward_key: &SessionKey, _nat: NatDecision)
         dst_port,
     }
 }
+
+// Issue 70 / #994: `reverse_session_key` extracted from
+// afxdp/session_glue (the audit's "abstraction-leak" junk drawer).
+// Pure SessionKey + NatDecision → SessionKey transformation, fits
+// alongside forward_wire_key / translated_session_key /
+// reverse_canonical_key already in this file. Visibility widened
+// from `pub(super)` (afxdp-internal) to `pub(crate)` so existing
+// callers in afxdp/{ha,session_delta,session_glue}.rs continue to
+// resolve through the session::* re-export.
+//
+// Note: the audit also called out resolution_target_for_session as
+// a candidate to move here, but it takes &SessionFlow and SessionFlow
+// lives in afxdp/types (46 references inside afxdp/ — moving it
+// would be a much larger refactor). Left in session_glue for now.
+
+pub(crate) fn reverse_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey {
+    let (src_port, dst_port) = if matches!(key.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        (key.src_port, key.dst_port)
+    } else {
+        (
+            nat.rewrite_dst_port.unwrap_or(key.dst_port),
+            nat.rewrite_src_port.unwrap_or(key.src_port),
+        )
+    };
+    let wire_src = nat.rewrite_dst.unwrap_or(key.dst_ip);
+    let wire_dst = nat.rewrite_src.unwrap_or(key.src_ip);
+    let (addr_family, protocol) = if nat.nat64 {
+        let af = match wire_src {
+            IpAddr::V4(_) => libc::AF_INET as u8,
+            IpAddr::V6(_) => libc::AF_INET6 as u8,
+        };
+        let proto = if af == libc::AF_INET as u8 && key.protocol == PROTO_ICMPV6 {
+            PROTO_ICMP
+        } else if af == libc::AF_INET6 as u8 && key.protocol == PROTO_ICMP {
+            PROTO_ICMPV6
+        } else {
+            key.protocol
+        };
+        (af, proto)
+    } else {
+        (key.addr_family, key.protocol)
+    };
+    SessionKey {
+        addr_family,
+        protocol,
+        src_ip: wire_src,
+        dst_ip: wire_dst,
+        src_port,
+        dst_port,
+    }
+}


### PR DESCRIPTION
## Summary

Per the Session Glue Deconstruction Roadmap audit: pure key-transform helpers belong alongside `SessionKey` in `session/key.rs`, not in afxdp's session_glue "junk drawer".

Moves `reverse_session_key` (35 LOC) from `afxdp/session_glue/mod.rs` → `session/key.rs`, where it joins the existing key-transform family extracted in #1058 (`forward_wire_key`, `translated_session_key`, `reverse_canonical_key`, `reply_matches_forward_session`).

## What moved

- `reverse_session_key(key: &SessionKey, nat: NatDecision) -> SessionKey` — pure transformation, no side effects, no dependencies outside `crate::session` (uses only SessionKey + NatDecision + std types).

## Visibility

Widened from `pub(super) fn` (afxdp-internal) to `pub(crate) fn` so the existing callers (afxdp.rs, afxdp/ha.rs, afxdp/session_delta.rs, afxdp/session_glue/mod.rs) continue to resolve through `crate::session::*`.

`afxdp.rs`'s `use crate::session::{...}` block extended to include `reverse_session_key`.

## Why `resolution_target_for_session` is NOT in this PR

The audit also flagged `resolution_target_for_session` as a candidate. It IS a pure 1-line transformation, but it takes `&SessionFlow` — and `SessionFlow` lives in `afxdp/types/cos.rs` with **46 references inside afxdp/**. Moving SessionFlow to `session/` would be a much larger refactor (and arguably wrong: SessionFlow is the afxdp-side flow descriptor, not a session-table concept).

So the literal audit guidance is half-right: `reverse_session_key` moves cleanly; `resolution_target_for_session` stays in session_glue until/unless SessionFlow's home gets re-evaluated separately.

## LOC

| File | Before | After |
|------|--------|-------|
| afxdp/session_glue/mod.rs | 1,235 | 1,201 |
| session/key.rs | 138 | 189 |

## Test plan

- [x] `cargo build --release -p userspace-dp` — clean (92 warnings, baseline)
- [x] `cargo test --release -p userspace-dp` — 865 passed, 0 failed
- [ ] Cluster smoke (per-CoS iperf3 on loss userspace cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)