### PR TITLE
#1069: reuse local reverse_key in flush_session_deltas Close branch

### DIFF
--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -175,10 +175,10 @@ pub(super) fn flush_session_deltas(
                 &reverse_key,
             );
             replicate_session_delete(peer_worker_commands, &delta.key);
-            replicate_session_delete(
-                peer_worker_commands,
-                &reverse_session_key(&delta.key, delta.decision.nat),
-            );
+            // #1069: reuse the reverse_key already computed above instead of
+            // recomputing it. reverse_session_key is pure on its inputs and
+            // delta + nat are not modified between the two replicate calls.
+            replicate_session_delete(peer_worker_commands, &reverse_key);
             if cfg!(feature = "debug-log") {
                 debug_log!(
                     "SESS_DELETE_DONE: bpf_entries_after={}",


### PR DESCRIPTION
Closes #1069. The Close branch computed reverse_session_key twice — once into a local, once inline. Reuse the local. reverse_session_key is pure on its inputs; net effect is one less hash per session close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)