### PR TITLE
#1065: doc fix — FabricRedirect IS cacheable (matches code)

### DIFF
--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -161,10 +161,13 @@ impl ForwardingDisposition {
     ///   - `ForwardCandidate`: Normal forwarded traffic with a resolved
     ///     neighbor and egress interface. The common fast path.
     ///   - `FabricRedirect`: Targets a fabric overlay binding. Cacheable
-    ///     because the per-flow `flow_owner_rg_id` + `rg_epochs` invalidation
-    ///     in `flow_cache::should_invalidate_for_rg_change` flushes the
-    ///     entry when the owning RG flips on failover/failback, so the
-    ///     window in which a cached `FabricRedirect` could point at a stale
+    ///     because each cache entry captures the owning RG epoch into
+    ///     `FlowCacheStamp::owner_rg_epoch` at insert time
+    ///     (`flow_cache.rs:60-83`), and `FlowCache::lookup`
+    ///     (`flow_cache.rs:314-347`) treats the entry as a miss when
+    ///     `current_epoch != entry.stamp.owner_rg_epoch`. The owning RG
+    ///     bumps its epoch on every active/standby flip, so the window
+    ///     in which a cached `FabricRedirect` could point at a stale
     ///     fabric peer is bounded by the next RG epoch bump (#1065).
     ///
     /// Not cacheable:

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -160,13 +160,14 @@ impl ForwardingDisposition {
     /// Cacheable:
     ///   - `ForwardCandidate`: Normal forwarded traffic with a resolved
     ///     neighbor and egress interface. The common fast path.
+    ///   - `FabricRedirect`: Targets a fabric overlay binding. Cacheable
+    ///     because the per-flow `flow_owner_rg_id` + `rg_epochs` invalidation
+    ///     in `flow_cache::should_invalidate_for_rg_change` flushes the
+    ///     entry when the owning RG flips on failover/failback, so the
+    ///     window in which a cached `FabricRedirect` could point at a stale
+    ///     fabric peer is bounded by the next RG epoch bump (#1065).
     ///
     /// Not cacheable:
-    ///   - `FabricRedirect`: Targets a fabric overlay binding that differs
-    ///     from the normal egress binding. Fabric target selection depends on
-    ///     per-packet queue hashing and binding availability, which the cache
-    ///     entry cannot capture. Also, fabric sessions may flip back to
-    ///     ForwardCandidate after failback, making cached fabric entries stale.
     ///   - `LocalDelivery`: Delivered to the kernel stack, not forwarded
     ///     through XSK bindings. No rewrite descriptor to cache.
     ///   - `HAInactive`: The owning RG is not active on this node. Transient


### PR DESCRIPTION
Closes #1065. Doc-only fix. The is_cacheable() match block has always included FabricRedirect; the doc rationale was stale (claimed it was 'not cacheable' due to per-packet hashing + failback staleness). The flow_cache RG-epoch invalidation handles staleness, so the code is correct — only the doc lagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)