### PR TITLE
#1128: extract record_rx_descriptor_telemetry from poll_descriptor inner loop

### DIFF
--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -38,7 +38,7 @@ pub(super) fn poll_binding_process_descriptor(
         binding.scratch_forwards.clear();
         binding.scratch_rst_teardowns.clear();
         while let Some(desc) = received.read() {
-            record_rx_batch_telemetry(desc, area, telemetry, worker_ctx);
+            record_rx_descriptor_telemetry(desc, area, telemetry, worker_ctx);
             let mut recycle_now = true;
             if let Some(meta) = try_parse_metadata(unsafe { &*area }, desc) {
                 telemetry.counters.metadata_packets += 1;
@@ -2227,29 +2227,35 @@ pub(super) fn poll_binding_process_descriptor(
 // #1128: per-descriptor RX-side bookkeeping lifted out of the inner
 // loop in `poll_binding_process_descriptor`.
 //
-// The work here is:
-//   - prefetch the metadata header (96 bytes, two cache lines) and
-//     the first 64 bytes of frame data into L1 (#909);
-//   - bump the per-binding counters that drive `show interfaces`
-//     and the live status RPCs;
-//   - emit `debug-log`-gated breadcrumbs for oversized RX, RX-side
-//     TCP flag census (FIN / SYN+ACK / zero-window / RST), poison-
-//     descriptor detection, and a per-binding first-10 frame dump.
+// The work here, in order, is:
+//   1. prefetch the metadata header (96 bytes, two cache lines) and
+//      the first 64 bytes of frame data into L1 (#909);
+//   2. bump the unconditional per-binding counters that drive
+//      `show interfaces` and the live status RPCs:
+//      `telemetry.counters.{touched, rx_packets, rx_bytes}` and
+//      `telemetry.dbg.{rx, rx_bytes_total, rx_max_frame}`;
+//   3. for desc.len > 1514, bump `telemetry.dbg.rx_oversized` and
+//      (only under `cfg!(feature = "debug-log")`) eprint up to 20
+//      oversized-frame breadcrumbs;
+//   4. under `cfg!(feature = "debug-log")` only: RX-side TCP flag
+//      census (FIN / SYN+ACK / zero-window / RST), poison-
+//      descriptor detection, and a per-binding first-10 frame dump.
 //
-// In release builds without `--features debug-log` the `cfg!(...)`
-// branches collapse to false and LLVM eliminates the entire
-// debug-only body, leaving just the prefetches and the four counter
-// bumps — small enough that LLVM will inline a single call site
-// regardless of any annotation. `#[inline]` (not `#[inline(always)]`)
-// is deliberate: with `--features debug-log` the body is ~200 LOC,
-// and forcing inline of that into the hot loop would bloat L1-i in
+// In release builds without `--features debug-log` every
+// `cfg!(...)` branch in steps 3 and 4 collapses to false and LLVM
+// eliminates the debug-only body, leaving just the prefetches plus
+// the unconditional counter increments in step 2. That residue is
+// small enough that LLVM will inline a single call site regardless
+// of any annotation. `#[inline]` (not `#[inline(always)]`) is
+// deliberate: with `--features debug-log` the body is ~200 LOC, and
+// forcing inline of that into the hot loop would bloat L1-i in
 // debug builds for no production gain. `#[inline]` lets the
 // compiler honor the body-size heuristic, which inlines tight
 // production builds and correctly declines on the bulky debug
 // path. The goal is *source-level* separation of housekeeping
 // noise from forwarding logic, per the modularity discipline in #1128.
 #[inline]
-pub(super) fn record_rx_batch_telemetry(
+fn record_rx_descriptor_telemetry(
     desc: XdpDesc,
     area: *const MmapArea,
     telemetry: &mut TelemetryContext,

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -2239,10 +2239,15 @@ pub(super) fn poll_binding_process_descriptor(
 // In release builds without `--features debug-log` the `cfg!(...)`
 // branches collapse to false and LLVM eliminates the entire
 // debug-only body, leaving just the prefetches and the four counter
-// bumps. The function is `#[inline]` so the optimizer is free to
-// fold it back into the caller — the goal is *source-level*
-// separation of housekeeping noise from forwarding logic, per the
-// modularity discipline in #1128.
+// bumps — small enough that LLVM will inline a single call site
+// regardless of any annotation. `#[inline]` (not `#[inline(always)]`)
+// is deliberate: with `--features debug-log` the body is ~200 LOC,
+// and forcing inline of that into the hot loop would bloat L1-i in
+// debug builds for no production gain. `#[inline]` lets the
+// compiler honor the body-size heuristic, which inlines tight
+// production builds and correctly declines on the bulky debug
+// path. The goal is *source-level* separation of housekeeping
+// noise from forwarding logic, per the modularity discipline in #1128.
 #[inline]
 pub(super) fn record_rx_batch_telemetry(
     desc: XdpDesc,
@@ -2267,7 +2272,7 @@ pub(super) fn record_rx_batch_telemetry(
     #[cfg(target_arch = "x86_64")]
     {
         debug_assert!(
-            desc.addr % 64 == 0,
+            desc.addr.is_multiple_of(64),
             "UMEM frame at desc.addr={} should be 64-byte aligned",
             desc.addr,
         );

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -38,183 +38,7 @@ pub(super) fn poll_binding_process_descriptor(
         binding.scratch_forwards.clear();
         binding.scratch_rst_teardowns.clear();
         while let Some(desc) = received.read() {
-            // Prefetch the userspace-dp metadata header (96 bytes) at
-            // desc.addr - meta_len. try_parse_metadata reads this
-            // first, on the magic/version/length compare; before this
-            // prefetch landed, that compare consumed ~33 % of
-            // poll_binding_process_descriptor self-time on a perf
-            // profile under iperf3 -P 128 / 25 Gb/s shaper (#909).
-            //
-            // The metadata is exactly 96 bytes (UserspaceDpMeta has a
-            // const-asserted size; first field is `magic`) and starts
-            // 96 bytes before the frame. UMEM frames are 4096-byte
-            // aligned with a 256-byte headroom, so desc.addr is
-            // 64-byte aligned by construction; the 96 bytes therefore
-            // straddle exactly two cache lines and we issue two
-            // prefetches.
-            #[cfg(target_arch = "x86_64")]
-            {
-                debug_assert!(
-                    desc.addr % 64 == 0,
-                    "UMEM frame at desc.addr={} should be 64-byte aligned",
-                    desc.addr,
-                );
-                let meta_len = std::mem::size_of::<UserspaceDpMeta>();
-                if (desc.addr as usize) >= meta_len {
-                    let meta_offset = (desc.addr as usize) - meta_len;
-                    if let Some(pf_meta) =
-                        unsafe { &*area }.slice(meta_offset, meta_len)
-                    {
-                        unsafe {
-                            core::arch::x86_64::_mm_prefetch(
-                                pf_meta.as_ptr() as *const i8,
-                                core::arch::x86_64::_MM_HINT_T0,
-                            );
-                            core::arch::x86_64::_mm_prefetch(
-                                pf_meta.as_ptr().add(64) as *const i8,
-                                core::arch::x86_64::_MM_HINT_T0,
-                            );
-                        }
-                    }
-                }
-            }
-
-            // Prefetch frame data into L1 while processing telemetry.counters.
-            // UMEM frames are cold (last touched by NIC DMA); this hides
-            // ~100ns DRAM latency before metadata parse.
-            #[cfg(target_arch = "x86_64")]
-            if let Some(pf) = unsafe { &*area }.slice(desc.addr as usize, 64.min(desc.len as usize))
-            {
-                unsafe {
-                    core::arch::x86_64::_mm_prefetch(
-                        pf.as_ptr() as *const i8,
-                        core::arch::x86_64::_MM_HINT_T0,
-                    );
-                }
-            }
-            telemetry.counters.touched = true;
-            telemetry.counters.rx_packets += 1;
-            telemetry.counters.rx_bytes += desc.len as u64;
-            telemetry.dbg.rx += 1;
-            telemetry.dbg.rx_bytes_total += desc.len as u64;
-            if desc.len > telemetry.dbg.rx_max_frame {
-                telemetry.dbg.rx_max_frame = desc.len;
-            }
-            if desc.len > 1514 {
-                telemetry.dbg.rx_oversized += 1;
-                if cfg!(feature = "debug-log") {
-                    thread_local! {
-                        static OVERSIZED_RX_LOG: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-                    }
-                    OVERSIZED_RX_LOG.with(|c| {
-                        let n = c.get();
-                        if n < 20 {
-                            c.set(n + 1);
-                            eprintln!("DBG OVERSIZED_RX[{}]: if={} q={} desc.len={} (exceeds ETH+MTU 1514)",
-                                n, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len,
-                            );
-                        }
-                    });
-                }
-            }
-            // TCP flag detection on RX
-            if cfg!(feature = "debug-log") {
-                if desc.len >= 54 {
-                    if let Some(rx_frame) =
-                        unsafe { &*area }.slice(desc.addr as usize, desc.len as usize)
-                    {
-                        // Check for FIN, SYN+ACK, zero-window
-                        if let Some(tcp_info) = extract_tcp_flags_and_window(rx_frame) {
-                            if (tcp_info.0 & 0x01) != 0 {
-                                // FIN
-                                telemetry.dbg.rx_tcp_fin += 1;
-                            }
-                            if (tcp_info.0 & 0x12) == 0x12 {
-                                // SYN+ACK
-                                telemetry.dbg.rx_tcp_synack += 1;
-                            }
-                            if tcp_info.1 == 0 && (tcp_info.0 & 0x02) == 0 {
-                                // zero window, not SYN
-                                telemetry.dbg.rx_tcp_zero_window += 1;
-                                if telemetry.dbg.rx_tcp_zero_window <= 10 {
-                                    eprintln!(
-                                        "RX_TCP_ZERO_WIN[{}]: if={} q={} len={} flags=0x{:02x}",
-                                        telemetry.dbg.rx_tcp_zero_window,
-                                        worker_ctx.ident.ifindex,
-                                        worker_ctx.ident.queue_id,
-                                        desc.len,
-                                        tcp_info.0,
-                                    );
-                                }
-                            }
-                        }
-                        if frame_has_tcp_rst(rx_frame) {
-                            telemetry.dbg.rx_tcp_rst += 1;
-                            thread_local! {
-                                static RX_RST_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-                            }
-                            RX_RST_LOG_COUNT.with(|c| {
-                                let n = c.get();
-                                if n < 50 {
-                                    c.set(n + 1);
-                                    let summary = decode_frame_summary(rx_frame);
-                                    eprintln!(
-                                        "RST_DETECT RX[{}]: if={} q={} len={} {}",
-                                        n, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len, summary,
-                                    );
-                                    if n < 5 {
-                                        let hex_len =
-                                            (desc.len as usize).min(rx_frame.len()).min(80);
-                                        let hex: String = rx_frame[..hex_len]
-                                            .iter()
-                                            .map(|b| format!("{:02x}", b))
-                                            .collect::<Vec<_>>()
-                                            .join(" ");
-                                        eprintln!("RST_DETECT RX_HEX[{n}]: {hex}");
-                                    }
-                                }
-                            });
-                        }
-                    }
-                }
-            }
-            // Poison check: detect if kernel recycled descriptor without writing data
-            if cfg!(feature = "debug-log") {
-                if desc.len >= 8 {
-                    if let Some(first8) = unsafe { &*area }.slice(desc.addr as usize, 8) {
-                        if first8 == &0xDEAD_BEEF_DEAD_BEEFu64.to_ne_bytes() {
-                            eprintln!(
-                                "DBG POISON_DETECTED: if={} q={} desc.addr={:#x} desc.len={} — kernel returned poisoned frame!",
-                                worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.addr, desc.len,
-                            );
-                        }
-                    }
-                }
-            }
-            if cfg!(feature = "debug-log") {
-                if telemetry.dbg.rx <= 10 {
-                    if let Some(rx_frame) =
-                        unsafe { &*area }.slice(desc.addr as usize, desc.len as usize)
-                    {
-                        // Decode IP+TCP details from the frame
-                        let pkt_detail = decode_frame_summary(rx_frame);
-                        eprintln!(
-                            "DBG RX_ETH[{}]: if={} q={} len={} {}",
-                            telemetry.dbg.rx, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len, pkt_detail,
-                        );
-                        // Full hex dump for first 3 packets
-                        if telemetry.dbg.rx <= 3 {
-                            let dump_len = (desc.len as usize).min(rx_frame.len()).min(80);
-                            let hex: String = rx_frame[..dump_len]
-                                .iter()
-                                .map(|b| format!("{:02x}", b))
-                                .collect::<Vec<_>>()
-                                .join(" ");
-                            eprintln!("DBG RX_HEX[{}]: {}", telemetry.dbg.rx, hex);
-                        }
-                    }
-                }
-            }
+            record_rx_batch_telemetry(desc, area, telemetry, worker_ctx);
             let mut recycle_now = true;
             if let Some(meta) = try_parse_metadata(unsafe { &*area }, desc) {
                 telemetry.counters.metadata_packets += 1;
@@ -2398,4 +2222,204 @@ pub(super) fn poll_binding_process_descriptor(
         }
         received.release();
         drop(received);
+}
+
+// #1128: per-descriptor RX-side bookkeeping lifted out of the inner
+// loop in `poll_binding_process_descriptor`.
+//
+// The work here is:
+//   - prefetch the metadata header (96 bytes, two cache lines) and
+//     the first 64 bytes of frame data into L1 (#909);
+//   - bump the per-binding counters that drive `show interfaces`
+//     and the live status RPCs;
+//   - emit `debug-log`-gated breadcrumbs for oversized RX, RX-side
+//     TCP flag census (FIN / SYN+ACK / zero-window / RST), poison-
+//     descriptor detection, and a per-binding first-10 frame dump.
+//
+// In release builds without `--features debug-log` the `cfg!(...)`
+// branches collapse to false and LLVM eliminates the entire
+// debug-only body, leaving just the prefetches and the four counter
+// bumps. The function is `#[inline]` so the optimizer is free to
+// fold it back into the caller — the goal is *source-level*
+// separation of housekeeping noise from forwarding logic, per the
+// modularity discipline in #1128.
+#[inline]
+pub(super) fn record_rx_batch_telemetry(
+    desc: XdpDesc,
+    area: *const MmapArea,
+    telemetry: &mut TelemetryContext,
+    worker_ctx: &WorkerContext,
+) {
+    // Prefetch the userspace-dp metadata header (96 bytes) at
+    // desc.addr - meta_len. try_parse_metadata reads this
+    // first, on the magic/version/length compare; before this
+    // prefetch landed, that compare consumed ~33 % of
+    // poll_binding_process_descriptor self-time on a perf
+    // profile under iperf3 -P 128 / 25 Gb/s shaper (#909).
+    //
+    // The metadata is exactly 96 bytes (UserspaceDpMeta has a
+    // const-asserted size; first field is `magic`) and starts
+    // 96 bytes before the frame. UMEM frames are 4096-byte
+    // aligned with a 256-byte headroom, so desc.addr is
+    // 64-byte aligned by construction; the 96 bytes therefore
+    // straddle exactly two cache lines and we issue two
+    // prefetches.
+    #[cfg(target_arch = "x86_64")]
+    {
+        debug_assert!(
+            desc.addr % 64 == 0,
+            "UMEM frame at desc.addr={} should be 64-byte aligned",
+            desc.addr,
+        );
+        let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+        if (desc.addr as usize) >= meta_len {
+            let meta_offset = (desc.addr as usize) - meta_len;
+            if let Some(pf_meta) = unsafe { &*area }.slice(meta_offset, meta_len) {
+                unsafe {
+                    core::arch::x86_64::_mm_prefetch(
+                        pf_meta.as_ptr() as *const i8,
+                        core::arch::x86_64::_MM_HINT_T0,
+                    );
+                    core::arch::x86_64::_mm_prefetch(
+                        pf_meta.as_ptr().add(64) as *const i8,
+                        core::arch::x86_64::_MM_HINT_T0,
+                    );
+                }
+            }
+        }
+    }
+
+    // Prefetch frame data into L1 while processing telemetry.counters.
+    // UMEM frames are cold (last touched by NIC DMA); this hides
+    // ~100ns DRAM latency before metadata parse.
+    #[cfg(target_arch = "x86_64")]
+    if let Some(pf) = unsafe { &*area }.slice(desc.addr as usize, 64.min(desc.len as usize)) {
+        unsafe {
+            core::arch::x86_64::_mm_prefetch(
+                pf.as_ptr() as *const i8,
+                core::arch::x86_64::_MM_HINT_T0,
+            );
+        }
+    }
+    telemetry.counters.touched = true;
+    telemetry.counters.rx_packets += 1;
+    telemetry.counters.rx_bytes += desc.len as u64;
+    telemetry.dbg.rx += 1;
+    telemetry.dbg.rx_bytes_total += desc.len as u64;
+    if desc.len > telemetry.dbg.rx_max_frame {
+        telemetry.dbg.rx_max_frame = desc.len;
+    }
+    if desc.len > 1514 {
+        telemetry.dbg.rx_oversized += 1;
+        if cfg!(feature = "debug-log") {
+            thread_local! {
+                static OVERSIZED_RX_LOG: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+            }
+            OVERSIZED_RX_LOG.with(|c| {
+                let n = c.get();
+                if n < 20 {
+                    c.set(n + 1);
+                    eprintln!(
+                        "DBG OVERSIZED_RX[{}]: if={} q={} desc.len={} (exceeds ETH+MTU 1514)",
+                        n, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len,
+                    );
+                }
+            });
+        }
+    }
+    // TCP flag detection on RX
+    if cfg!(feature = "debug-log") {
+        if desc.len >= 54 {
+            if let Some(rx_frame) = unsafe { &*area }.slice(desc.addr as usize, desc.len as usize)
+            {
+                // Check for FIN, SYN+ACK, zero-window
+                if let Some(tcp_info) = extract_tcp_flags_and_window(rx_frame) {
+                    if (tcp_info.0 & 0x01) != 0 {
+                        // FIN
+                        telemetry.dbg.rx_tcp_fin += 1;
+                    }
+                    if (tcp_info.0 & 0x12) == 0x12 {
+                        // SYN+ACK
+                        telemetry.dbg.rx_tcp_synack += 1;
+                    }
+                    if tcp_info.1 == 0 && (tcp_info.0 & 0x02) == 0 {
+                        // zero window, not SYN
+                        telemetry.dbg.rx_tcp_zero_window += 1;
+                        if telemetry.dbg.rx_tcp_zero_window <= 10 {
+                            eprintln!(
+                                "RX_TCP_ZERO_WIN[{}]: if={} q={} len={} flags=0x{:02x}",
+                                telemetry.dbg.rx_tcp_zero_window,
+                                worker_ctx.ident.ifindex,
+                                worker_ctx.ident.queue_id,
+                                desc.len,
+                                tcp_info.0,
+                            );
+                        }
+                    }
+                }
+                if frame_has_tcp_rst(rx_frame) {
+                    telemetry.dbg.rx_tcp_rst += 1;
+                    thread_local! {
+                        static RX_RST_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+                    }
+                    RX_RST_LOG_COUNT.with(|c| {
+                        let n = c.get();
+                        if n < 50 {
+                            c.set(n + 1);
+                            let summary = decode_frame_summary(rx_frame);
+                            eprintln!(
+                                "RST_DETECT RX[{}]: if={} q={} len={} {}",
+                                n, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len, summary,
+                            );
+                            if n < 5 {
+                                let hex_len = (desc.len as usize).min(rx_frame.len()).min(80);
+                                let hex: String = rx_frame[..hex_len]
+                                    .iter()
+                                    .map(|b| format!("{:02x}", b))
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
+                                eprintln!("RST_DETECT RX_HEX[{n}]: {hex}");
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+    // Poison check: detect if kernel recycled descriptor without writing data
+    if cfg!(feature = "debug-log") {
+        if desc.len >= 8 {
+            if let Some(first8) = unsafe { &*area }.slice(desc.addr as usize, 8) {
+                if first8 == &0xDEAD_BEEF_DEAD_BEEFu64.to_ne_bytes() {
+                    eprintln!(
+                        "DBG POISON_DETECTED: if={} q={} desc.addr={:#x} desc.len={} — kernel returned poisoned frame!",
+                        worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.addr, desc.len,
+                    );
+                }
+            }
+        }
+    }
+    if cfg!(feature = "debug-log") {
+        if telemetry.dbg.rx <= 10 {
+            if let Some(rx_frame) = unsafe { &*area }.slice(desc.addr as usize, desc.len as usize)
+            {
+                // Decode IP+TCP details from the frame
+                let pkt_detail = decode_frame_summary(rx_frame);
+                eprintln!(
+                    "DBG RX_ETH[{}]: if={} q={} len={} {}",
+                    telemetry.dbg.rx, worker_ctx.ident.ifindex, worker_ctx.ident.queue_id, desc.len, pkt_detail,
+                );
+                // Full hex dump for first 3 packets
+                if telemetry.dbg.rx <= 3 {
+                    let dump_len = (desc.len as usize).min(rx_frame.len()).min(80);
+                    let hex: String = rx_frame[..dump_len]
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    eprintln!("DBG RX_HEX[{}]: {}", telemetry.dbg.rx, hex);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Lift the 177-line per-descriptor RX-telemetry block out of the inner loop in `poll_binding_process_descriptor` into a private `record_rx_descriptor_telemetry` helper in the same file.
- Loop body for telemetry shrinks to one call; forwarding logic now starts immediately after.
- `#[inline]` (not `#[inline(always)]`) is deliberate: in production builds the `cfg!(feature = "debug-log")` body DCEs and the residue inlines naturally; in `--features debug-log` the body is ~200 LOC and forcing inline would bloat L1-i for no production gain.
- Goal is **source-level** separation of housekeeping noise from forwarding logic per #1128.

## Behavior preserved

- Same prefetches (#909): metadata header (96 B, two cache lines) + first 64 B of frame data.
- Same counter set on `telemetry.counters` (touched / rx_packets / rx_bytes / metadata_packets / validated_*) and `telemetry.dbg` (rx / rx_bytes_total / rx_max_frame / rx_oversized / rx_tcp_{fin,synack,zero_window,rst}).
- Same `cfg!(feature = "debug-log")` gating on every eprintln; release builds without that feature DCE the debug-only branches.

## Naming note

The helper is invoked once per descriptor inside `while let Some(desc) = received.read()`, not over a batch — `record_rx_descriptor_telemetry` matches the actual semantics. Issue #1128 uses "BatchTelemetry" because a true batch implementation (bulk pre-loop counter increments + pipelined prefetch across N descriptors) is a separate, larger change; this PR is the source-level cleanup step toward it.

## Test plan

- [x] `cargo build --release` clean (no new warnings vs master)
- [x] `cargo test --release` — 880 tests pass
- [x] Cluster smoke: deploy clean on `loss:xpf-userspace-fw0/1`, both nodes healthy, ICMP transit forwarding alive (TTL=63 / 1.5ms through firewall)

## Reviews

- Codex hostile review (`task-monojpsl-...`): MERGE-NEEDS-MINOR — fixed `clippy::manual_is_multiple_of` and clarified `#[inline]` rationale
- Gemini Pro adversarial (`task-monojrgq-...`): REQUEST_CHANGES on `#[inline]` → resolved by reverting per Codex's correct counter-argument about debug-log L1-i bloat
- Copilot first round: rename to match per-descriptor semantics, drop visibility, expand doc — done
- Copilot second round: align PR title with helper name — done in this edit

Closes #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)