### PR TITLE
#1137: port SCREEN_SYN_FRAG to userspace-dp/src/screen.rs (follow-up to #866)

### DIFF
--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2857,6 +2857,37 @@ func TestBuildScreenSnapshotsIncludesAdvancedFields(t *testing.T) {
 	}
 }
 
+// #1137 Copilot review regression: a profile with ONLY syn_frag
+// enabled (and no other check) must still pass the
+// "at least one check enabled" emit gate. Without this, a future
+// refactor could drop SynFrag from the gate and silently omit the
+// whole profile from the userspace snapshot.
+func TestBuildScreenSnapshotsIncludesSynFragOnlyProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"lan": {Name: "lan", ScreenProfile: "syn-frag-only"},
+	}
+	cfg.Security.Screen = map[string]*config.ScreenProfile{
+		"syn-frag-only": {
+			Name: "syn-frag-only",
+			TCP:  config.TCPScreen{SynFrag: true},
+		},
+	}
+	snaps := buildScreenSnapshots(cfg)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1 — syn_frag-only profile must pass the emit gate", len(snaps))
+	}
+	if !snaps[0].SynFrag {
+		t.Fatalf("SynFrag = false, want true")
+	}
+	// Sanity: nothing else should be on
+	if snaps[0].SynFin || snaps[0].NoFlag || snaps[0].FinNoAck ||
+		snaps[0].WinNuke || snaps[0].PingDeath || snaps[0].Teardrop ||
+		snaps[0].SourceRoute || snaps[0].Land {
+		t.Fatalf("unexpected other-checks set: %+v", snaps[0])
+	}
+}
+
 func TestBuildFlowExportSnapshot(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -281,6 +281,7 @@ type ScreenProfileSnapshot struct {
 	PingDeath          bool   `json:"ping_death,omitempty"`
 	Teardrop           bool   `json:"teardrop,omitempty"`
 	ICMPFragment       bool   `json:"icmp_fragment,omitempty"`
+	SynFrag            bool   `json:"syn_frag,omitempty"`
 	SourceRoute        bool   `json:"source_route,omitempty"`
 	ICMPFloodThreshold uint32 `json:"icmp_flood_threshold,omitempty"`
 	UDPFloodThreshold  uint32 `json:"udp_flood_threshold,omitempty"`

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -1263,6 +1263,7 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 			WinNuke:     sp.TCP.WinNuke,
 			PingDeath:   sp.ICMP.PingDeath,
 			Teardrop:    sp.IP.TearDrop,
+			SynFrag:     sp.TCP.SynFrag, // #1137 — port from typed config
 			SourceRoute: sp.IP.SourceRouteOption,
 		}
 		if sp.ICMP.FloodThreshold > 0 {
@@ -1289,7 +1290,7 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 		// Only include profiles that have at least one check enabled
 		if snap.Land || snap.SynFin || snap.NoFlag || snap.FinNoAck ||
 			snap.WinNuke || snap.PingDeath || snap.Teardrop ||
-			snap.SourceRoute ||
+			snap.SynFrag || snap.SourceRoute ||
 			snap.ICMPFloodThreshold > 0 || snap.UDPFloodThreshold > 0 ||
 			snap.SYNFloodThreshold > 0 ||
 			snap.SessionLimitSrc > 0 || snap.SessionLimitDst > 0 ||

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -18,6 +18,7 @@ pub(super) fn build_screen_profiles(snapshot: &ConfigSnapshot) -> FxHashMap<Stri
                 ping_death: sp.ping_death,
                 teardrop: sp.teardrop,
                 icmp_fragment: sp.icmp_fragment,
+                syn_frag: sp.syn_frag,
                 source_route: sp.source_route,
                 icmp_flood_threshold: sp.icmp_flood_threshold,
                 udp_flood_threshold: sp.udp_flood_threshold,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -468,6 +468,10 @@ pub(crate) struct ScreenProfileSnapshot {
     pub teardrop: bool,
     #[serde(rename = "icmp_fragment", default)]
     pub icmp_fragment: bool,
+    /// #1137: TCP SYN packet that's also the first fragment of a
+    /// fragmented datagram — a fragmentation-based attack signature.
+    #[serde(rename = "syn_frag", default)]
+    pub syn_frag: bool,
     #[serde(rename = "source_route", default)]
     pub source_route: bool,
     #[serde(rename = "icmp_flood_threshold", default)]

--- a/userspace-dp/src/screen.rs
+++ b/userspace-dp/src/screen.rs
@@ -312,8 +312,18 @@ impl ScreenState {
             return ScreenVerdict::Drop("land-attack");
         }
 
-        // TCP-specific stateless checks
-        if pkt.protocol == PROTO_TCP {
+        // TCP-specific stateless checks.
+        //
+        // Outer guard `!is_fragment || is_first_fragment` mirrors the
+        // BPF #853 defense (#1137 / Copilot review): subsequent
+        // fragments don't carry the L4 header, so `tcp_flags` is
+        // unreliable for them. Without this guard a subsequent
+        // fragment whose payload bytes happen to look like flag bits
+        // could falsely trip syn_fin / no_flag / fin_no_ack / winnuke
+        // / syn_frag. First-fragments DO carry the TCP header, so
+        // they pass through the guard and the SYN-centric checks
+        // (including syn_frag) fire correctly.
+        if pkt.protocol == PROTO_TCP && (!pkt.is_fragment || pkt.is_first_fragment) {
             let tf = pkt.tcp_flags;
 
             // SYN+FIN
@@ -337,10 +347,9 @@ impl ScreenState {
             }
 
             // #1137: SYN-fragment — TCP SYN on a first-fragment is the
-            // fragmentation-based attack pattern. Subsequent fragments
-            // (is_fragment && !is_first_fragment) don't have an L4 header
-            // so tcp_flags is unreliable for them; gating on
-            // is_first_fragment avoids false positives.
+            // fragmentation-based attack pattern. The outer guard
+            // already excludes subsequent fragments; this check fires
+            // on first-fragment + SYN, which is the actual attack.
             if profile.syn_frag && (tf & TCP_SYN) != 0 && pkt.is_first_fragment {
                 return ScreenVerdict::Drop("syn-frag");
             }
@@ -543,6 +552,21 @@ pub(crate) fn extract_screen_info(
         // IPv6: walk the extension header chain looking for
         // NEXTHDR_FRAGMENT (44). Fixed IPv6 base header is 40 bytes.
         // We bound the walk to MAX_EXT_HDRS=8 like the BPF parser.
+        //
+        // Parity note (#1137 / Codex round-1): if the chain is
+        // truncated (out-of-bounds before we find a FRAGMENT
+        // header), we silently `break` and leave is_first_fragment
+        // at its default `false`. The BPF `parse_ipv6hdr` returns
+        // -1 on the same condition, causing the packet to be
+        // dropped earlier in the pipeline. On the userspace-dp
+        // path the upstream metadata parser (try_parse_metadata)
+        // should already have rejected malformed IPv6 packets
+        // before they reach extract_screen_info, so the parity
+        // gap is theoretical. If a SYN-bearing IPv6 frame with a
+        // truncated FRAGMENT header somehow reaches the screen
+        // layer, it would pass syn_frag — operators relying on
+        // that defense should keep the BPF screen path enabled
+        // upstream of userspace-dp.
         const NEXTHDR_HOP: u8 = 0;
         const NEXTHDR_ROUTING: u8 = 43;
         const NEXTHDR_FRAGMENT: u8 = 44;

--- a/userspace-dp/src/screen.rs
+++ b/userspace-dp/src/screen.rs
@@ -43,6 +43,11 @@ pub(crate) struct ScreenPacketInfo {
     pub dst_port: u16, // host byte order
     pub pkt_len: u16,  // total packet length from meta
     pub is_fragment: bool,
+    /// #1137: 1 = first fragment of a fragmented datagram (IPv4: MF=1
+    /// && offset==0; IPv6: MF=1 && offset==0). Mirrors the BPF
+    /// `is_first_fragment` flag in pkt_meta. `is_fragment=1 &&
+    /// is_first_fragment=0` indicates a subsequent fragment.
+    pub is_first_fragment: bool,
     pub ip_ihl: u8,        // IPv4 IHL field (header length in 32-bit words)
     pub ip_frag_off: u16,  // raw frag_off field (network byte order already parsed)
     pub ip_total_len: u16, // IPv4 total length
@@ -59,6 +64,10 @@ pub(crate) struct ScreenProfile {
     pub ping_death: bool,
     pub teardrop: bool,
     pub icmp_fragment: bool,
+    /// #1137: TCP SYN on a first-fragment is the fragmentation-based
+    /// attack pattern. Mirrors the BPF SCREEN_SYN_FRAG (#866) on the
+    /// userspace dataplane path.
+    pub syn_frag: bool,
     pub source_route: bool,
     pub icmp_flood_threshold: u32, // packets per second, 0 = disabled
     pub udp_flood_threshold: u32,  // packets per second, 0 = disabled
@@ -326,6 +335,15 @@ impl ScreenState {
             if profile.winnuke && (tf & TCP_URG) != 0 && pkt.dst_port == 139 {
                 return ScreenVerdict::Drop("winnuke");
             }
+
+            // #1137: SYN-fragment — TCP SYN on a first-fragment is the
+            // fragmentation-based attack pattern. Subsequent fragments
+            // (is_fragment && !is_first_fragment) don't have an L4 header
+            // so tcp_flags is unreliable for them; gating on
+            // is_first_fragment avoids false positives.
+            if profile.syn_frag && (tf & TCP_SYN) != 0 && pkt.is_first_fragment {
+                return ScreenVerdict::Drop("syn-frag");
+            }
         }
 
         // Ping of Death: oversized ICMP
@@ -503,19 +521,69 @@ pub(crate) fn extract_screen_info(
         dst_port,
         pkt_len,
         is_fragment: false,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0,
         ip_total_len: 0,
     };
 
-    // Extract IPv4-specific fields from the frame
     if addr_family == libc::AF_INET as u8 && l3_offset + 20 <= frame.len() {
+        // IPv4: extract IHL, total_len, frag_off from the fixed 20-byte
+        // base header. frag_off is bytes 6-7, big-endian.
         let ip_hdr = &frame[l3_offset..];
         info.ip_ihl = ip_hdr[0] & 0x0F;
         info.ip_total_len = u16::from_be_bytes([ip_hdr[2], ip_hdr[3]]);
         info.ip_frag_off = u16::from_be_bytes([ip_hdr[6], ip_hdr[7]]);
-        // Fragment if MF bit set or fragment offset > 0
-        info.is_fragment = (info.ip_frag_off & 0x3FFF) != 0; // MF=0x2000, offset=0x1FFF
+        // Fragment if MF bit (0x2000) set OR fragment offset (0x1FFF) > 0.
+        // First fragment: MF=1 AND offset==0 (#1137, mirrors BPF #866).
+        info.is_fragment = (info.ip_frag_off & 0x3FFF) != 0;
+        info.is_first_fragment =
+            (info.ip_frag_off & 0x2000) != 0 && (info.ip_frag_off & 0x1FFF) == 0;
+    } else if addr_family == libc::AF_INET6 as u8 && l3_offset + 40 <= frame.len() {
+        // IPv6: walk the extension header chain looking for
+        // NEXTHDR_FRAGMENT (44). Fixed IPv6 base header is 40 bytes.
+        // We bound the walk to MAX_EXT_HDRS=8 like the BPF parser.
+        const NEXTHDR_HOP: u8 = 0;
+        const NEXTHDR_ROUTING: u8 = 43;
+        const NEXTHDR_FRAGMENT: u8 = 44;
+        const NEXTHDR_DEST: u8 = 60;
+        const NEXTHDR_AUTH: u8 = 51;
+        let mut nexthdr = frame[l3_offset + 6];
+        let mut offset = l3_offset + 40;
+        for _ in 0..8 {
+            match nexthdr {
+                NEXTHDR_HOP | NEXTHDR_ROUTING | NEXTHDR_DEST => {
+                    if offset + 2 > frame.len() {
+                        break;
+                    }
+                    nexthdr = frame[offset];
+                    offset += (frame[offset + 1] as usize + 1) * 8;
+                }
+                NEXTHDR_AUTH => {
+                    if offset + 2 > frame.len() {
+                        break;
+                    }
+                    nexthdr = frame[offset];
+                    offset += (frame[offset + 1] as usize + 2) * 4;
+                }
+                NEXTHDR_FRAGMENT => {
+                    if offset + 8 > frame.len() {
+                        break;
+                    }
+                    // IPv6 frag_off layout (big-endian u16 at offset+2):
+                    //   offset (13 bits, top) | reserved (2 bits) | M (1 bit, lowest)
+                    // Mirrors BPF #866: MF=0x1, offset=0xFFF8.
+                    let frag_off =
+                        u16::from_be_bytes([frame[offset + 2], frame[offset + 3]]);
+                    info.ip_frag_off = frag_off;
+                    info.is_fragment = (frag_off & 0x1) != 0 || (frag_off & 0xFFF8) != 0;
+                    info.is_first_fragment =
+                        (frag_off & 0x1) != 0 && (frag_off & 0xFFF8) == 0;
+                    break;
+                }
+                _ => break,
+            }
+        }
     }
 
     info

--- a/userspace-dp/src/screen_tests.rs
+++ b/userspace-dp/src/screen_tests.rs
@@ -16,6 +16,7 @@ fn default_profile() -> ScreenProfile {
         ping_death: true,
         teardrop: true,
         icmp_fragment: true,
+        syn_frag: true,
         source_route: true,
         icmp_flood_threshold: 0,
         udp_flood_threshold: 0,
@@ -41,6 +42,7 @@ fn tcp_pkt(src: IpAddr, dst: IpAddr, src_port: u16, dst_port: u16, flags: u8) ->
         dst_port,
         pkt_len: 60,
         is_fragment: false,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0,
         ip_total_len: 60,
@@ -65,6 +67,7 @@ fn icmp_pkt(src: IpAddr, dst: IpAddr, pkt_len: u16) -> ScreenPacketInfo {
         dst_port: 0,
         pkt_len,
         is_fragment: false,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0,
         ip_total_len: pkt_len,
@@ -85,6 +88,7 @@ fn udp_pkt(src: IpAddr, dst: IpAddr) -> ScreenPacketInfo {
         dst_port: 5001,
         pkt_len: 100,
         is_fragment: false,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0,
         ip_total_len: 100,
@@ -347,6 +351,7 @@ fn teardrop_drops() {
         dst_port: 80,
         pkt_len: 28,
         is_fragment: true,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0x0001 | 0x2000, // offset=1 (non-first frag), MF=1
         ip_total_len: 24,             // 20 byte header + 4 byte payload (< 8)
@@ -370,6 +375,7 @@ fn teardrop_first_fragment_passes() {
         dst_port: 80,
         pkt_len: 24,
         is_fragment: true,
+        is_first_fragment: false,
         ip_ihl: 5,
         ip_frag_off: 0x2000, // offset=0 (first frag), MF=1
         ip_total_len: 24,
@@ -414,6 +420,224 @@ fn icmpv6_fragment_drops() {
     assert_eq!(
         state.check_packet("trust", &pkt, 1),
         ScreenVerdict::Drop("icmp-fragment")
+    );
+}
+
+// ================================================================
+// #1137 SCREEN_SYN_FRAG — TCP SYN on a first-fragment is the
+// fragmentation-based attack pattern. Mirrors BPF SCREEN_SYN_FRAG
+// (see #866 / docs/pr/bug-batch-866-867-916-925/design.md §1).
+// ================================================================
+
+#[test]
+fn syn_frag_drops_on_first_fragment_with_syn() {
+    let mut state = make_state("trust", default_profile());
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_SYN,
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = true;
+    assert_eq!(
+        state.check_packet("trust", &pkt, 1),
+        ScreenVerdict::Drop("syn-frag")
+    );
+}
+
+#[test]
+fn syn_frag_passes_when_first_fragment_without_syn() {
+    let mut state = make_state("trust", default_profile());
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_ACK, // ACK without SYN — not a SYN-fragment
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = true;
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+}
+
+#[test]
+fn syn_frag_passes_on_subsequent_fragment() {
+    // Subsequent fragments don't carry the L4 header, so tcp_flags is
+    // unreliable. is_first_fragment=0 keeps the check from firing on
+    // them — even if SYN bit is somehow set in the meta (e.g. a
+    // crafted attacker frame), is_first_fragment guards us.
+    let mut state = make_state("trust", default_profile());
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_SYN,
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = false;
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+}
+
+#[test]
+fn syn_frag_passes_on_non_fragmented_syn() {
+    // Non-fragmented TCP SYN is normal connection setup, not the
+    // syn-frag attack. Should pass regardless of profile.syn_frag.
+    let mut profile = ScreenProfile::default();
+    profile.syn_frag = true;
+    let mut state = make_state("trust", profile);
+    let pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_SYN,
+    );
+    // Defaults: is_fragment=false, is_first_fragment=false
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+}
+
+#[test]
+fn syn_frag_disabled_when_profile_off() {
+    // Even a SYN-bearing first-fragment passes when the profile
+    // doesn't enable syn_frag.
+    let profile = ScreenProfile::default(); // all checks off
+    let mut state = make_state("trust", profile);
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_SYN,
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = true;
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+}
+
+#[test]
+fn extract_screen_info_ipv4_first_fragment() {
+    // Build a synthetic IPv4 header at offset 14 (Ethernet) with
+    // MF=1 and offset=0. version=4, ihl=5, tot_len=40 (20 IP + 20 TCP),
+    // protocol=TCP, src=1.2.3.4 dst=5.6.7.8.
+    let mut frame = vec![0u8; 14 + 40];
+    // Ethernet: zeroed (we don't parse it here)
+    let ip = 14;
+    frame[ip] = 0x45; // version=4, ihl=5
+    frame[ip + 2..ip + 4].copy_from_slice(&40u16.to_be_bytes());
+    // frag_off: MF (0x2000) | offset 0 = 0x2000 BE
+    frame[ip + 6..ip + 8].copy_from_slice(&0x2000u16.to_be_bytes());
+    frame[ip + 9] = 6; // protocol = TCP
+    frame[ip + 12..ip + 16].copy_from_slice(&[1, 2, 3, 4]);
+    frame[ip + 16..ip + 20].copy_from_slice(&[5, 6, 7, 8]);
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,    // TCP
+        0x02, // SYN
+        40,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    );
+    assert!(info.is_fragment, "MF=1 → is_fragment");
+    assert!(info.is_first_fragment, "MF=1 && offset==0 → is_first_fragment");
+}
+
+#[test]
+fn extract_screen_info_ipv4_subsequent_fragment() {
+    // offset=8 octets (encoded as 0x0001 since offset is in 8-byte units),
+    // MF=0 (last fragment).
+    let mut frame = vec![0u8; 14 + 40];
+    let ip = 14;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&40u16.to_be_bytes());
+    frame[ip + 6..ip + 8].copy_from_slice(&0x0001u16.to_be_bytes());
+    frame[ip + 9] = 6;
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0,
+        40,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        0,
+        0,
+        14,
+    );
+    assert!(info.is_fragment, "offset>0 → is_fragment");
+    assert!(
+        !info.is_first_fragment,
+        "offset>0 → is_first_fragment must be 0"
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv6_first_fragment() {
+    // IPv6 base header (40 bytes) at offset 14, with NextHdr=44 (FRAGMENT),
+    // followed by an 8-byte fragment ext header. MF=1, offset=0.
+    let mut frame = vec![0u8; 14 + 40 + 8];
+    // IPv6 first byte: version=6 in top nibble
+    frame[14] = 0x60;
+    frame[14 + 6] = 44; // NextHdr = FRAGMENT
+    // Fragment header at offset 14+40 = 54: nexthdr=6 (TCP), reserved=0,
+    // frag_off (MF=1, offset=0) = 0x0001 in big-endian.
+    let frag_off_pos = 14 + 40 + 2;
+    frame[14 + 40] = 6; // inner nexthdr = TCP
+    frame[frag_off_pos..frag_off_pos + 2].copy_from_slice(&0x0001u16.to_be_bytes());
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET6 as u8,
+        6,
+        0x02,
+        48,
+        IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+        IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap()),
+        12345,
+        80,
+        14,
+    );
+    assert!(info.is_fragment, "IPv6 MF=1 → is_fragment");
+    assert!(
+        info.is_first_fragment,
+        "IPv6 MF=1 && offset==0 → is_first_fragment"
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv6_subsequent_fragment() {
+    // IPv6 fragment with offset>0 (e.g. offset=1 in 8-byte units → 0x0008).
+    let mut frame = vec![0u8; 14 + 40 + 8];
+    frame[14] = 0x60;
+    frame[14 + 6] = 44;
+    let frag_off_pos = 14 + 40 + 2;
+    frame[14 + 40] = 6;
+    frame[frag_off_pos..frag_off_pos + 2].copy_from_slice(&0x0008u16.to_be_bytes());
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET6 as u8,
+        6,
+        0,
+        48,
+        IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+        IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap()),
+        0,
+        0,
+        14,
+    );
+    assert!(info.is_fragment, "IPv6 offset>0 → is_fragment");
+    assert!(
+        !info.is_first_fragment,
+        "IPv6 offset>0 → is_first_fragment must be 0"
     );
 }
 

--- a/userspace-dp/src/screen_tests.rs
+++ b/userspace-dp/src/screen_tests.rs
@@ -375,7 +375,11 @@ fn teardrop_first_fragment_passes() {
         dst_port: 80,
         pkt_len: 24,
         is_fragment: true,
-        is_first_fragment: false,
+        // #1137 Copilot review: ip_frag_off=0x2000 means MF=1 &&
+        // offset==0, which IS a first-fragment. Keep the fields
+        // consistent with each other so future regressions don't
+        // hide behind misleading metadata.
+        is_first_fragment: true,
         ip_ihl: 5,
         ip_frag_off: 0x2000, // offset=0 (first frag), MF=1
         ip_total_len: 24,
@@ -639,6 +643,53 @@ fn extract_screen_info_ipv6_subsequent_fragment() {
         !info.is_first_fragment,
         "IPv6 offset>0 → is_first_fragment must be 0"
     );
+}
+
+#[test]
+fn tcp_no_flag_passes_on_subsequent_fragment_with_zero_flags() {
+    // #1137 Copilot review regression: subsequent fragments don't
+    // carry the L4 header, so tcp_flags is meaningless. Without the
+    // outer `!is_fragment || is_first_fragment` guard, a subsequent
+    // fragment with tcp_flags=0 (because the meta wasn't filled)
+    // would falsely trip SCREEN_TCP_NO_FLAG. Mirrors the BPF #853
+    // defense.
+    let mut profile = ScreenProfile::default();
+    profile.no_flag = true;
+    let mut state = make_state("trust", profile);
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        0, // tcp_flags=0 on a subsequent fragment is normal — meta wasn't filled
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = false;
+    assert_eq!(
+        state.check_packet("trust", &pkt, 1),
+        ScreenVerdict::Pass,
+        "subsequent fragment must not trip TCP_NO_FLAG even with tf=0"
+    );
+}
+
+#[test]
+fn tcp_syn_fin_passes_on_subsequent_fragment_with_syn_fin_bytes() {
+    // Adversarial: subsequent fragment whose payload bytes happen to
+    // look like SYN+FIN. The outer guard must keep this from tripping
+    // syn_fin (the bytes aren't real TCP flags).
+    let mut profile = ScreenProfile::default();
+    profile.syn_fin = true;
+    let mut state = make_state("trust", profile);
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        12345,
+        80,
+        TCP_SYN | TCP_FIN,
+    );
+    pkt.is_fragment = true;
+    pkt.is_first_fragment = false;
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
 }
 
 // ================================================================


### PR DESCRIPTION
## Summary

Follow-up to #866 (BPF SCREEN_SYN_FRAG fix). The deployed test cluster (\`loss:xpf-userspace-fw0/1\`) runs the userspace-dp data path which has its own screen implementation in \`userspace-dp/src/screen.rs\`, and that implementation didn't include SCREEN_SYN_FRAG.

This PR mirrors the BPF #866 logic in Rust:

**Go side** (\`pkg/dataplane/userspace/\`):
- \`SynFrag bool\` added to \`ScreenProfileSnapshot\` (protocol.go) and populated from \`sp.TCP.SynFrag\` in \`buildScreenSnapshots\` (snapshot.go); included in the "at least one check enabled" gate.

**Rust side** (\`userspace-dp/src/\`):
- \`syn_frag\` field on \`ScreenProfile\` and \`ScreenProfileSnapshot\` (\`#[serde(rename = "syn_frag")]\`).
- \`is_first_fragment\` field on \`ScreenPacketInfo\`.
- \`extract_screen_info\` updated:
  - **IPv4**: \`(frag_off & 0x2000) && !(frag_off & 0x1FFF)\` — same predicate as #866.
  - **IPv6**: walks the extension header chain to NEXTHDR_FRAGMENT (44), then \`(frag_off & 0x1) && !(frag_off & 0xFFF8)\`. IPv6 fragmentation wasn't previously parsed at all in this function.
- SCREEN_SYN_FRAG check in TCP block: fires on \`(tf & SYN) && is_first_fragment\`.
- Wired through \`build_screen_profiles\` in \`forwarding_build.rs\`.

**Tests** — 9 new tests in \`screen_tests.rs\` covering positive (SYN+first-frag drops), negative (no SYN, no first-frag, no profile flag), and the \`extract_screen_info\` parsing for both IPv4 and IPv6 fragments (first vs subsequent).

## Test plan

- [x] \`cargo build --release\` clean (no new warnings vs master)
- [x] \`cargo test --release\` — 898 passing (was 889 baseline + 9 new)
- [x] \`go test ./pkg/dataplane/userspace/... ./pkg/config/...\` green
- [ ] Cluster smoke deploy on \`loss:xpf-userspace-fw0/1\`
- [ ] Functional positive: scapy SYN-fragment from \`cluster-userspace-host\` → SCREEN_DROPS counter bumps with profile applied to lan zone

Closes #1137. Companion to #866 (BPF code path) which already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)