### PR TITLE
#963 PR-B: extract byte-write kernels into frame/byte_writes.rs

### DIFF
--- a/userspace-dp/src/afxdp/frame/byte_writes.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes.rs
@@ -44,22 +44,22 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[inline(always)]
-pub(in crate::afxdp) fn write_ipv4_src(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
+pub(super) fn write_ipv4_src(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
     packet[ip + 12..ip + 16].copy_from_slice(&addr.octets());
 }
 
 #[inline(always)]
-pub(in crate::afxdp) fn write_ipv4_dst(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
+pub(super) fn write_ipv4_dst(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
     packet[ip + 16..ip + 20].copy_from_slice(&addr.octets());
 }
 
 #[inline(always)]
-pub(in crate::afxdp) fn write_ipv6_src(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
+pub(super) fn write_ipv6_src(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
     packet[ip + 8..ip + 24].copy_from_slice(&addr.octets());
 }
 
 #[inline(always)]
-pub(in crate::afxdp) fn write_ipv6_dst(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
+pub(super) fn write_ipv6_dst(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
     packet[ip + 24..ip + 40].copy_from_slice(&addr.octets());
 }
 
@@ -68,7 +68,7 @@ pub(in crate::afxdp) fn write_ipv6_dst(packet: &mut [u8], ip: usize, addr: Ipv6A
 /// truncated frame at the L4 boundary skips the write rather than
 /// panicking. Mirrors the inline pattern at the previous call sites.
 #[inline(always)]
-pub(in crate::afxdp) fn write_l4_src_port(packet: &mut [u8], l4: usize, port: u16) {
+pub(super) fn write_l4_src_port(packet: &mut [u8], l4: usize, port: u16) {
     if packet.len() >= l4 + 2 {
         packet[l4..l4 + 2].copy_from_slice(&port.to_be_bytes());
     }
@@ -77,7 +77,7 @@ pub(in crate::afxdp) fn write_l4_src_port(packet: &mut [u8], l4: usize, port: u1
 /// L4 destination-port write at offset `l4 + 2`. Same bounds-check
 /// discipline as `write_l4_src_port`.
 #[inline(always)]
-pub(in crate::afxdp) fn write_l4_dst_port(packet: &mut [u8], l4: usize, port: u16) {
+pub(super) fn write_l4_dst_port(packet: &mut [u8], l4: usize, port: u16) {
     if packet.len() >= l4 + 4 {
         packet[l4 + 2..l4 + 4].copy_from_slice(&port.to_be_bytes());
     }

--- a/userspace-dp/src/afxdp/frame/byte_writes.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes.rs
@@ -1,0 +1,80 @@
+// #963 PR-B: unconditional byte-write kernels for L3/L4 packet
+// mutation. Extracted from inline call sites in
+// `apply_rewrite_descriptor` (frame/mod.rs) and the generic-path
+// NAT helpers (`apply_nat_ipv4`, `apply_nat_ipv6`,
+// `apply_nat_port_rewrite`) so a single source of truth defines
+// "byte 12-15 is the IPv4 source address" etc.
+//
+// Design discipline (Codex + Gemini design review, rev 4):
+//
+//  - Helpers are *maximally stupid*. No `Option` matching, no
+//    family branches, no fallback paths. Caller does the
+//    `if let Some(IpAddr::V4(_))` match and calls the bare-bones
+//    helper. This keeps the optimizer's job simple — it sees a
+//    constant-offset memcpy with no phase-ordering surprise from
+//    pushing conditionals into a generic body.
+//
+//  - All helpers are `#[inline(always)]`. The hot path in
+//    `apply_rewrite_descriptor` calls each helper exactly once per
+//    packet; forcing inline guarantees zero call overhead. Because
+//    the helpers themselves are 1-2 instructions wide each, there
+//    is no L1-i bloat concern (unlike the larger
+//    `record_rx_descriptor_telemetry` from #1128 where `#[inline]`
+//    was the deliberate choice).
+//
+//  - IP-write helpers have NO length guards. Callers MUST have
+//    already validated `packet.len() >= ip + 20` (IPv4) or
+//    `packet.len() >= ip + 40` (IPv6). The fast path validates this
+//    near the top of the v4/v6 arms; the generic-path NAT helpers
+//    are only called after their own bounds-checks fire.
+//
+//  - L4 port-write helpers DO have length guards. The fast path
+//    today already gates port writes on `packet.len() >= l4 + 2`
+//    or `+ 4`; preserving that guard keeps behavior identical to
+//    pre-extraction.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[inline(always)]
+pub(in crate::afxdp) fn write_ipv4_src(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
+    packet[ip + 12..ip + 16].copy_from_slice(&addr.octets());
+}
+
+#[inline(always)]
+pub(in crate::afxdp) fn write_ipv4_dst(packet: &mut [u8], ip: usize, addr: Ipv4Addr) {
+    packet[ip + 16..ip + 20].copy_from_slice(&addr.octets());
+}
+
+#[inline(always)]
+pub(in crate::afxdp) fn write_ipv6_src(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
+    packet[ip + 8..ip + 24].copy_from_slice(&addr.octets());
+}
+
+#[inline(always)]
+pub(in crate::afxdp) fn write_ipv6_dst(packet: &mut [u8], ip: usize, addr: Ipv6Addr) {
+    packet[ip + 24..ip + 40].copy_from_slice(&addr.octets());
+}
+
+/// L4 source-port write at offset `l4` (TCP+UDP share this layout
+/// for the source-port field at bytes 0-1). Bounds-checked: a
+/// truncated frame at the L4 boundary skips the write rather than
+/// panicking. Mirrors the inline pattern at the previous call sites.
+#[inline(always)]
+pub(in crate::afxdp) fn write_l4_src_port(packet: &mut [u8], l4: usize, port: u16) {
+    if packet.len() >= l4 + 2 {
+        packet[l4..l4 + 2].copy_from_slice(&port.to_be_bytes());
+    }
+}
+
+/// L4 destination-port write at offset `l4 + 2`. Same bounds-check
+/// discipline as `write_l4_src_port`.
+#[inline(always)]
+pub(in crate::afxdp) fn write_l4_dst_port(packet: &mut [u8], l4: usize, port: u16) {
+    if packet.len() >= l4 + 4 {
+        packet[l4 + 2..l4 + 4].copy_from_slice(&port.to_be_bytes());
+    }
+}
+
+#[cfg(test)]
+#[path = "byte_writes_tests.rs"]
+mod tests;

--- a/userspace-dp/src/afxdp/frame/byte_writes.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes.rs
@@ -1,9 +1,17 @@
 // #963 PR-B: unconditional byte-write kernels for L3/L4 packet
 // mutation. Extracted from inline call sites in
-// `apply_rewrite_descriptor` (frame/mod.rs) and the generic-path
-// NAT helpers (`apply_nat_ipv4`, `apply_nat_ipv6`,
-// `apply_nat_port_rewrite`) so a single source of truth defines
-// "byte 12-15 is the IPv4 source address" etc.
+// `apply_rewrite_descriptor` (frame/mod.rs, both v4 and v6 arms)
+// and from `apply_nat_ipv4` + `apply_nat_port_rewrite` so a single
+// source of truth defines "byte 12-15 is the IPv4 source address"
+// etc.
+//
+// `apply_nat_ipv6` is intentionally NOT refactored: that path
+// works in `[u8; 16]` octets directly (not `Ipv6Addr`), and
+// threading the helper through there would require a round-trip
+// via `Ipv6Addr::from(octets).octets()` for cosmetic gain. The
+// PR-B scope is "extract kernels", not "unify every byte-write
+// site"; future PR can revisit `apply_nat_ipv6` if it ever needs
+// to switch to `Ipv6Addr` for other reasons.
 //
 // Design discipline (Codex + Gemini design review, rev 4):
 //

--- a/userspace-dp/src/afxdp/frame/byte_writes.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes.rs
@@ -1,17 +1,10 @@
 // #963 PR-B: unconditional byte-write kernels for L3/L4 packet
 // mutation. Extracted from inline call sites in
 // `apply_rewrite_descriptor` (frame/mod.rs, both v4 and v6 arms)
-// and from `apply_nat_ipv4` + `apply_nat_port_rewrite` so a single
-// source of truth defines "byte 12-15 is the IPv4 source address"
-// etc.
-//
-// `apply_nat_ipv6` is intentionally NOT refactored: that path
-// works in `[u8; 16]` octets directly (not `Ipv6Addr`), and
-// threading the helper through there would require a round-trip
-// via `Ipv6Addr::from(octets).octets()` for cosmetic gain. The
-// PR-B scope is "extract kernels", not "unify every byte-write
-// site"; future PR can revisit `apply_nat_ipv6` if it ever needs
-// to switch to `Ipv6Addr` for other reasons.
+// and from `apply_nat_ipv4`, `apply_nat_ipv6`, `apply_nat_port_rewrite`,
+// `enforce_expected_ports`, and `enforce_expected_ports_at` so a
+// single source of truth defines "byte 12-15 is the IPv4 source
+// address" etc.
 //
 // Design discipline (Codex + Gemini design review, rev 4):
 //

--- a/userspace-dp/src/afxdp/frame/byte_writes_tests.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes_tests.rs
@@ -1,0 +1,91 @@
+// #963 PR-B: pin the byte-write helpers' offset semantics. These
+// helpers do nothing but copy bytes, so the tests check exact
+// byte positions and the surrounding unmodified bytes (so a
+// future refactor that drifts offsets surfaces here).
+
+use super::*;
+
+const ZERO_FRAME_LEN: usize = 64;
+
+fn zero_frame() -> Vec<u8> {
+    vec![0u8; ZERO_FRAME_LEN]
+}
+
+#[test]
+fn write_ipv4_src_writes_at_ip_plus_12() {
+    let mut packet = zero_frame();
+    let ip = 14; // typical Ethernet header offset
+    write_ipv4_src(&mut packet, ip, Ipv4Addr::new(10, 0, 1, 2));
+    assert_eq!(&packet[ip + 12..ip + 16], &[10, 0, 1, 2]);
+    // Surrounding bytes untouched
+    assert_eq!(&packet[..ip + 12], &[0u8; 26]);
+    assert_eq!(&packet[ip + 16..], &[0u8; 34]);
+}
+
+#[test]
+fn write_ipv4_dst_writes_at_ip_plus_16() {
+    let mut packet = zero_frame();
+    let ip = 14;
+    write_ipv4_dst(&mut packet, ip, Ipv4Addr::new(192, 168, 1, 1));
+    assert_eq!(&packet[ip + 16..ip + 20], &[192, 168, 1, 1]);
+    assert_eq!(&packet[..ip + 16], &[0u8; 30]);
+    assert_eq!(&packet[ip + 20..], &[0u8; 30]);
+}
+
+#[test]
+fn write_ipv6_src_writes_at_ip_plus_8() {
+    let mut packet = vec![0u8; 128];
+    let ip = 14;
+    let addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+    write_ipv6_src(&mut packet, ip, addr);
+    assert_eq!(&packet[ip + 8..ip + 24], &addr.octets());
+    assert_eq!(&packet[..ip + 8], &[0u8; 22]);
+    // 128-byte frame, ip+24 = 38 → 128-38 = 90 trailing bytes.
+    assert_eq!(&packet[ip + 24..], &[0u8; 90]);
+}
+
+#[test]
+fn write_ipv6_dst_writes_at_ip_plus_24() {
+    let mut packet = vec![0u8; 128];
+    let ip = 14;
+    let addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2);
+    write_ipv6_dst(&mut packet, ip, addr);
+    assert_eq!(&packet[ip + 24..ip + 40], &addr.octets());
+    assert_eq!(&packet[..ip + 24], &[0u8; 38]);
+    // 128-byte frame, ip+40 = 54 → 128-54 = 74 trailing bytes.
+    assert_eq!(&packet[ip + 40..], &[0u8; 74]);
+}
+
+#[test]
+fn write_l4_src_port_writes_be_at_l4() {
+    let mut packet = zero_frame();
+    let l4 = 34; // typical TCP-after-IPv4 offset
+    write_l4_src_port(&mut packet, l4, 0x1234);
+    assert_eq!(&packet[l4..l4 + 2], &[0x12, 0x34]);
+}
+
+#[test]
+fn write_l4_dst_port_writes_be_at_l4_plus_2() {
+    let mut packet = zero_frame();
+    let l4 = 34;
+    write_l4_dst_port(&mut packet, l4, 0xabcd);
+    assert_eq!(&packet[l4 + 2..l4 + 4], &[0xab, 0xcd]);
+}
+
+#[test]
+fn write_l4_src_port_skips_truncated_frame() {
+    // packet is exactly l4+1 long → write would need l4+2; skip.
+    let l4 = 10;
+    let mut packet = vec![0u8; l4 + 1];
+    write_l4_src_port(&mut packet, l4, 0xffff);
+    assert_eq!(packet[l4], 0, "truncated frame: write must be skipped");
+}
+
+#[test]
+fn write_l4_dst_port_skips_truncated_frame() {
+    // packet is exactly l4+3 long → write would need l4+4; skip.
+    let l4 = 10;
+    let mut packet = vec![0u8; l4 + 3];
+    write_l4_dst_port(&mut packet, l4, 0xffff);
+    assert_eq!(&packet[l4..l4 + 3], &[0u8; 3]);
+}

--- a/userspace-dp/src/afxdp/frame/byte_writes_tests.rs
+++ b/userspace-dp/src/afxdp/frame/byte_writes_tests.rs
@@ -62,6 +62,9 @@ fn write_l4_src_port_writes_be_at_l4() {
     let l4 = 34; // typical TCP-after-IPv4 offset
     write_l4_src_port(&mut packet, l4, 0x1234);
     assert_eq!(&packet[l4..l4 + 2], &[0x12, 0x34]);
+    // Surrounding bytes untouched (matches the IPv4/IPv6 test discipline).
+    assert_eq!(&packet[..l4], &[0u8; 34]);
+    assert_eq!(&packet[l4 + 2..], &[0u8; 28]);
 }
 
 #[test]
@@ -70,6 +73,9 @@ fn write_l4_dst_port_writes_be_at_l4_plus_2() {
     let l4 = 34;
     write_l4_dst_port(&mut packet, l4, 0xabcd);
     assert_eq!(&packet[l4 + 2..l4 + 4], &[0xab, 0xcd]);
+    // Bytes before l4+2 (including src-port slot) and after l4+4 untouched.
+    assert_eq!(&packet[..l4 + 2], &[0u8; 36]);
+    assert_eq!(&packet[l4 + 4..], &[0u8; 26]);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -1115,9 +1115,9 @@ pub(super) fn apply_nat_ipv6(packet: &mut [u8], protocol: u8, nat: NatDecision) 
         return None;
     }
     // #963 PR-B: keep `Ipv6Addr` here so the byte-write helpers fold
-    // cleanly. `Ipv6Addr` is `repr(transparent)` over `[u8; 16]`, so
-    // `addr.octets()` is a zero-cost conversion at the checksum
-    // call sites that need raw bytes.
+    // cleanly. `addr.octets()` returns `[u8; 16]` and the optimizer
+    // elides the copy at the checksum call sites that need raw
+    // bytes -- no layout guarantee is being relied on, just inlining.
     let new_src = nat.rewrite_src.and_then(|ip| match ip {
         IpAddr::V6(ip) => Some(ip),
         _ => None,

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -1,7 +1,13 @@
 use super::*;
 
+mod byte_writes;
 mod checksum;
 mod inspect;
+
+use byte_writes::{
+    write_ipv4_dst, write_ipv4_src, write_ipv6_dst, write_ipv6_src, write_l4_dst_port,
+    write_l4_src_port,
+};
 
 // Cross-module helpers reach into `frame::*` via the explicit list
 // below. `adjust_l4_checksum_ipv6_addr_bytes` is file-private to
@@ -869,27 +875,27 @@ pub(super) fn apply_rewrite_descriptor(
                 }
             }
 
-            // NAT: direct byte writes for IP addresses.
+            // NAT: direct byte writes for IP addresses (#963 PR-B
+            // helpers). Caller-side `if let Some(IpAddr::V4(_))`
+            // matching keeps conditional logic visible at the call
+            // site and lets the `#[inline(always)]` helpers fold
+            // into a single MOV/MOVB instruction.
             if apply_nat {
                 if let Some(IpAddr::V4(new_src)) = rd.rewrite_src_ip {
-                    packet[ip + 12..ip + 16].copy_from_slice(&new_src.octets());
+                    write_ipv4_src(packet, ip, new_src);
                 }
                 if let Some(IpAddr::V4(new_dst)) = rd.rewrite_dst_ip {
-                    packet[ip + 16..ip + 20].copy_from_slice(&new_dst.octets());
+                    write_ipv4_dst(packet, ip, new_dst);
                 }
             }
 
             // NAT: direct byte writes for L4 ports.
             if apply_nat {
                 if let Some(new_sport) = rd.rewrite_src_port {
-                    if packet.len() >= l4 + 2 {
-                        packet[l4..l4 + 2].copy_from_slice(&new_sport.to_be_bytes());
-                    }
+                    write_l4_src_port(packet, l4, new_sport);
                 }
                 if let Some(new_dport) = rd.rewrite_dst_port {
-                    if packet.len() >= l4 + 4 {
-                        packet[l4 + 2..l4 + 4].copy_from_slice(&new_dport.to_be_bytes());
-                    }
+                    write_l4_dst_port(packet, l4, new_dport);
                 }
             }
 
@@ -974,27 +980,23 @@ pub(super) fn apply_rewrite_descriptor(
                 }
             }
 
-            // NAT: direct byte writes for IPv6 addresses.
+            // NAT: direct byte writes for IPv6 addresses (#963 PR-B).
             if apply_nat {
                 if let Some(IpAddr::V6(new_src)) = rd.rewrite_src_ip {
-                    packet[ip + 8..ip + 24].copy_from_slice(&new_src.octets());
+                    write_ipv6_src(packet, ip, new_src);
                 }
                 if let Some(IpAddr::V6(new_dst)) = rd.rewrite_dst_ip {
-                    packet[ip + 24..ip + 40].copy_from_slice(&new_dst.octets());
+                    write_ipv6_dst(packet, ip, new_dst);
                 }
             }
 
-            // NAT: direct byte writes for L4 ports.
+            // NAT: direct byte writes for L4 ports (#963 PR-B).
             if apply_nat {
                 if let Some(new_sport) = rd.rewrite_src_port {
-                    if packet.len() >= l4 + 2 {
-                        packet[l4..l4 + 2].copy_from_slice(&new_sport.to_be_bytes());
-                    }
+                    write_l4_src_port(packet, l4, new_sport);
                 }
                 if let Some(new_dport) = rd.rewrite_dst_port {
-                    if packet.len() >= l4 + 4 {
-                        packet[l4 + 2..l4 + 4].copy_from_slice(&new_dport.to_be_bytes());
-                    }
+                    write_l4_dst_port(packet, l4, new_dport);
                 }
             }
 
@@ -1058,21 +1060,24 @@ pub(super) fn apply_nat_ipv4(packet: &mut [u8], protocol: u8, nat: NatDecision) 
         return None;
     }
 
-    // --- IP address rewriting ---
+    // --- IP address rewriting (#963 PR-B helpers) ---
+    // The line above (`if ihl < 20 || packet.len() < ihl { return None; }`)
+    // guarantees `packet.len() >= 20`, so the unconditional byte-write
+    // helpers are safe; no None-propagation needed here.
     if new_src.is_some() && new_dst.is_none() {
         let new_src = new_src?;
-        packet.get_mut(12..16)?.copy_from_slice(&new_src.octets());
+        write_ipv4_src(packet, 0, new_src);
         adjust_l4_checksum_ipv4_src(packet, ihl, protocol, old_src, new_src)?;
     } else if new_dst.is_some() && new_src.is_none() {
         let new_dst = new_dst?;
-        packet.get_mut(16..20)?.copy_from_slice(&new_dst.octets());
+        write_ipv4_dst(packet, 0, new_dst);
         adjust_l4_checksum_ipv4_dst(packet, ihl, protocol, old_dst, new_dst)?;
     } else if new_src.is_some() || new_dst.is_some() {
         if let Some(ip) = new_src {
-            packet.get_mut(12..16)?.copy_from_slice(&ip.octets());
+            write_ipv4_src(packet, 0, ip);
         }
         if let Some(ip) = new_dst {
-            packet.get_mut(16..20)?.copy_from_slice(&ip.octets());
+            write_ipv4_dst(packet, 0, ip);
         }
         let new_src = new_src.unwrap_or(old_src);
         let new_dst = new_dst.unwrap_or(old_dst);
@@ -1191,11 +1196,16 @@ pub(super) fn apply_nat_port_rewrite(
         return Some(());
     }
 
+    // #963 PR-B: byte-write kernel + caller-side checksum delta. The
+    // helper only writes the port bytes; the surrounding `if old !=
+    // new` short-circuit and incremental-checksum call stay here,
+    // preserving the existing semantics (no checksum work when the
+    // port doesn't actually change).
     if let Some(new_src_port) = nat.rewrite_src_port {
         let port_offset = l4_offset; // TCP/UDP src port at offset +0
         let old_port = u16::from_be_bytes([packet[port_offset], packet[port_offset + 1]]);
         if old_port != new_src_port {
-            packet[port_offset..port_offset + 2].copy_from_slice(&new_src_port.to_be_bytes());
+            write_l4_src_port(packet, l4_offset, new_src_port);
             adjust_l4_checksum_port(packet, l4_offset, protocol, old_port, new_src_port)?;
         }
     }
@@ -1204,7 +1214,7 @@ pub(super) fn apply_nat_port_rewrite(
         let port_offset = l4_offset + 2; // TCP/UDP dst port at offset +2
         let old_port = u16::from_be_bytes([packet[port_offset], packet[port_offset + 1]]);
         if old_port != new_dst_port {
-            packet[port_offset..port_offset + 2].copy_from_slice(&new_dst_port.to_be_bytes());
+            write_l4_dst_port(packet, l4_offset, new_dst_port);
             adjust_l4_checksum_port(packet, l4_offset, protocol, old_port, new_dst_port)?;
         }
     }

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -1114,12 +1114,16 @@ pub(super) fn apply_nat_ipv6(packet: &mut [u8], protocol: u8, nat: NatDecision) 
     if packet.len() < 40 {
         return None;
     }
+    // #963 PR-B: keep `Ipv6Addr` here so the byte-write helpers fold
+    // cleanly. `Ipv6Addr` is `repr(transparent)` over `[u8; 16]`, so
+    // `addr.octets()` is a zero-cost conversion at the checksum
+    // call sites that need raw bytes.
     let new_src = nat.rewrite_src.and_then(|ip| match ip {
-        IpAddr::V6(ip) => Some(ip.octets()),
+        IpAddr::V6(ip) => Some(ip),
         _ => None,
     });
     let new_dst = nat.rewrite_dst.and_then(|ip| match ip {
-        IpAddr::V6(ip) => Some(ip.octets()),
+        IpAddr::V6(ip) => Some(ip),
         _ => None,
     });
 
@@ -1130,29 +1134,33 @@ pub(super) fn apply_nat_ipv6(packet: &mut [u8], protocol: u8, nat: NatDecision) 
     if new_src.is_some() && new_dst.is_none() {
         let new_src = new_src?;
         let old_src: [u8; 16] = packet.get(8..24)?.try_into().ok()?;
-        packet.get_mut(8..24)?.copy_from_slice(&new_src);
+        write_ipv6_src(packet, 0, new_src);
         if !skip_l4_csum {
-            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_src, &new_src)?;
+            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_src, &new_src.octets())?;
         }
     } else if new_dst.is_some() && new_src.is_none() {
         let new_dst = new_dst?;
         let old_dst: [u8; 16] = packet.get(24..40)?.try_into().ok()?;
-        packet.get_mut(24..40)?.copy_from_slice(&new_dst);
+        write_ipv6_dst(packet, 0, new_dst);
         if !skip_l4_csum {
-            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_dst, &new_dst)?;
+            adjust_l4_checksum_ipv6_addr_bytes(packet, protocol, &old_dst, &new_dst.octets())?;
         }
     } else if new_src.is_some() || new_dst.is_some() {
         let old_src_words = ipv6_words_from_slice(packet.get(8..24)?)?;
         let old_dst_words = ipv6_words_from_slice(packet.get(24..40)?)?;
         if let Some(ip) = new_src {
-            packet.get_mut(8..24)?.copy_from_slice(&ip);
+            write_ipv6_src(packet, 0, ip);
         }
         if let Some(ip) = new_dst {
-            packet.get_mut(24..40)?.copy_from_slice(&ip);
+            write_ipv6_dst(packet, 0, ip);
         }
         if !skip_l4_csum {
-            let new_src_words = new_src.map(ipv6_words_from_octets).unwrap_or(old_src_words);
-            let new_dst_words = new_dst.map(ipv6_words_from_octets).unwrap_or(old_dst_words);
+            let new_src_words = new_src
+                .map(|a| ipv6_words_from_octets(a.octets()))
+                .unwrap_or(old_src_words);
+            let new_dst_words = new_dst
+                .map(|a| ipv6_words_from_octets(a.octets()))
+                .unwrap_or(old_dst_words);
             match protocol {
                 PROTO_TCP | PROTO_UDP | PROTO_ICMPV6 => {
                     adjust_l4_checksum_ipv6_words(
@@ -1275,16 +1283,16 @@ pub(super) fn enforce_expected_ports(
     }
     let packet = frame.get_mut(l3..)?;
     let rel_l4 = l4.checked_sub(l3)?;
+    // #963 PR-B: byte-write helpers replace the inline copy_from_slice.
+    // The earlier `frame.get(l4..l4 + 4)?` upstream guarantees
+    // `packet.len() >= rel_l4 + 4`, so the helper's internal length
+    // guard is redundant-but-correct.
     if current_src != expected_src {
-        packet
-            .get_mut(rel_l4..rel_l4 + 2)?
-            .copy_from_slice(&expected_src.to_be_bytes());
+        write_l4_src_port(packet, rel_l4, expected_src);
         adjust_l4_checksum_port(packet, rel_l4, protocol, current_src, expected_src)?;
     }
     if current_dst != expected_dst {
-        packet
-            .get_mut(rel_l4 + 2..rel_l4 + 4)?
-            .copy_from_slice(&expected_dst.to_be_bytes());
+        write_l4_dst_port(packet, rel_l4, expected_dst);
         adjust_l4_checksum_port(packet, rel_l4, protocol, current_dst, expected_dst)?;
     }
     Some(true)
@@ -1315,16 +1323,16 @@ pub(super) fn enforce_expected_ports_at(
     }
     let packet = frame.get_mut(l3..)?;
     let rel_l4 = l4.checked_sub(l3)?;
+    // #963 PR-B: byte-write helpers replace the inline copy_from_slice.
+    // The earlier `frame.get(l4..l4 + 4)?` upstream guarantees
+    // `packet.len() >= rel_l4 + 4`, so the helper's internal length
+    // guard is redundant-but-correct.
     if current_src != expected_src {
-        packet
-            .get_mut(rel_l4..rel_l4 + 2)?
-            .copy_from_slice(&expected_src.to_be_bytes());
+        write_l4_src_port(packet, rel_l4, expected_src);
         adjust_l4_checksum_port(packet, rel_l4, protocol, current_src, expected_src)?;
     }
     if current_dst != expected_dst {
-        packet
-            .get_mut(rel_l4 + 2..rel_l4 + 4)?
-            .copy_from_slice(&expected_dst.to_be_bytes());
+        write_l4_dst_port(packet, rel_l4, expected_dst);
         adjust_l4_checksum_port(packet, rel_l4, protocol, current_dst, expected_dst)?;
     }
     Some(true)


### PR DESCRIPTION
## Summary

Per design doc revision 4 (`docs/pr/963-frame-editor-redux/design.md` §5.2, PROCEED-AS-PROPOSED from Codex round 3 + Gemini round 3): extract L3/L4 byte-mutation kernels into a dedicated `frame/byte_writes.rs` module. Six `#[inline(always)]` helpers; one source of truth for "byte 12-15 is the IPv4 source address" etc.

Design discipline:

- **Maximally stupid helpers** — no Option matching, no family branches. Caller pattern: `if let Some(IpAddr::V4(new_src)) = rd.rewrite_src_ip { write_ipv4_src(packet, ip, new_src); }`.
- **`#[inline(always)]`** because helpers are 1-2 instructions wide; called once per packet in a tight loop.
- **IP helpers have no length guards** — callers validate the precondition (apply_rewrite_descriptor's `if packet.len() < ip + 20 { return None }` near the top of each arm).
- **L4 port helpers DO carry length guards** mirroring the inline pattern.

Refactored call sites (per Gemini round-1 consistency request): `apply_rewrite_descriptor` v4/v6 arms, `apply_nat_ipv4`, `apply_nat_ipv6`, `apply_nat_port_rewrite`, `enforce_expected_ports`, `enforce_expected_ports_at`. `apply_nat_ipv6` lifts to `Ipv6Addr` at the source/dst extraction sites and uses `addr.octets()` at the checksum sites — the optimizer elides the copy.

## Test plan

- [x] `cargo build --release` clean (no new warnings vs master)
- [x] `cargo test --release` — 908 passing (was 900 baseline + 8 new unit tests)
- [ ] Cluster smoke deploy on `loss:xpf-userspace-fw0/1`
- [ ] **PR-C**: perf-stat validation methodology (`cycles`, `instructions`, `L1-icache-load-misses`, `branch-misses`, `stalled-cycles-frontend`; medians over 5 runs; tolerances ±2-5%) per design doc §6.2. Deferred to a follow-up — `#[inline(always)]` makes codegen impact by-design near-zero, but the formal validation gate is the design doc's stated acceptance gate and stays open until PR-C lands.

Closes part of #963 (extraction of byte-write kernels). Full issue closure waits on PR-C perf-stat validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
