### PR TITLE
fix(forwarding): correct clamp_tcp_mss incremental checksum update (#989 prereq)

### DIFF
--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -802,14 +802,16 @@ pub(super) fn clamp_tcp_mss(packet: &mut [u8], max_mss: u16) -> bool {
                 // Clamp MSS and adjust TCP checksum
                 let old_bytes = [tcp[pos + 2], tcp[pos + 3]];
                 tcp[pos + 2..pos + 4].copy_from_slice(&max_mss.to_be_bytes());
-                // Incremental checksum update
+                // Incremental TCP checksum update per RFC 1624:
+                //   HC' = HC + m + ~m'  (ones-complement, end-around carry)
+                // The result is stored directly; no further negation.
                 let old_val = u16::from_be_bytes(old_bytes) as u32;
                 let new_val = max_mss as u32;
                 let old_csum = u16::from_be_bytes([tcp[16], tcp[17]]) as u32;
-                let mut sum = (!old_csum & 0xFFFF) + old_val + (!new_val & 0xFFFF);
+                let mut sum = old_csum + old_val + (!new_val & 0xFFFF);
                 sum = (sum & 0xFFFF) + (sum >> 16);
                 sum = (sum & 0xFFFF) + (sum >> 16);
-                tcp[16..18].copy_from_slice(&(!(sum as u16)).to_be_bytes());
+                tcp[16..18].copy_from_slice(&(sum as u16).to_be_bytes());
                 return true;
             }
             return false;

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -1977,3 +1977,112 @@ fn tx_binding_resolution_uses_fabric_parent_ifindex() {
     let state = build_forwarding_state(&nat_snapshot_with_fabric());
     assert_eq!(resolve_tx_binding_ifindex(&state, 21), 21);
 }
+
+// #989 prerequisite (PR-A): pre-existing checksum-update bug in
+// clamp_tcp_mss caught by an independent ones-complement
+// recomputation. The bug was sign-flipped delta:
+//
+//   buggy: sum = ~old_csum + old_val + ~new_val; HC' = ~sum
+//          → HC' = old_csum + (new_val - old_val)
+//   right: sum = old_csum + old_val + ~new_val;  HC' = sum
+//          → HC' = old_csum + (old_val - new_val)
+//
+// The right form preserves the sum-over-all=0xFFFF invariant that
+// validates a TCP checksum on the wire. The bug never surfaced as
+// dropped packets because clamp_tcp_mss is dead_code'd in master
+// and only reachable via the GRE encap path.
+
+fn _csum_tcp_v4_oracle(src: [u8; 4], dst: [u8; 4], tcp: &[u8]) -> u16 {
+    let tcp_len = tcp.len() as u16;
+    let mut sum: u32 = 0;
+    for chunk in src.chunks(2).chain(dst.chunks(2)) {
+        sum += u32::from(u16::from_be_bytes([chunk[0], chunk[1]]));
+    }
+    sum += u32::from(6u16);
+    sum += u32::from(tcp_len);
+    let mut i = 0;
+    while i + 1 < tcp.len() {
+        sum += u32::from(u16::from_be_bytes([tcp[i], tcp[i + 1]]));
+        i += 2;
+    }
+    if i < tcp.len() {
+        sum += u32::from(u16::from_be_bytes([tcp[i], 0]));
+    }
+    while sum >> 16 != 0 {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    sum as u16
+}
+
+fn _set_v4_tcp_checksum(tcp: &mut [u8], src: [u8; 4], dst: [u8; 4]) {
+    tcp[16..18].copy_from_slice(&[0, 0]);
+    let raw = _csum_tcp_v4_oracle(src, dst, tcp);
+    tcp[16..18].copy_from_slice(&(!raw).to_be_bytes());
+}
+
+/// Build a 24-byte TCP segment (20-byte header + 4-byte MSS option)
+/// with `flags` set and MSS=`mss`. Returns (packet=ip+tcp, src, dst).
+fn _build_v4_syn_with_mss(flags: u8, mss: u16) -> (Vec<u8>, [u8; 4], [u8; 4]) {
+    let src = [10, 0, 0, 1];
+    let dst = [10, 0, 0, 2];
+    // IPv4 header (20 bytes) + TCP header (24 bytes) = 44 total.
+    let mut ip = vec![0u8; 20];
+    ip[0] = 0x45; // version=4, IHL=5
+    ip[2..4].copy_from_slice(&44u16.to_be_bytes()); // total length
+    ip[8] = 64; // TTL
+    ip[9] = 6; // proto = TCP
+    ip[12..16].copy_from_slice(&src);
+    ip[16..20].copy_from_slice(&dst);
+
+    let mut tcp = vec![0u8; 24];
+    tcp[0..2].copy_from_slice(&12345u16.to_be_bytes());
+    tcp[2..4].copy_from_slice(&80u16.to_be_bytes());
+    tcp[4..8].copy_from_slice(&1u32.to_be_bytes()); // seq
+    tcp[12] = 6 << 4; // data_offset = 6 (24 bytes)
+    tcp[13] = flags;
+    tcp[14..16].copy_from_slice(&65535u16.to_be_bytes()); // window
+    // MSS option at TCP offset 20: kind=2, len=4, value=mss
+    tcp[20] = 2;
+    tcp[21] = 4;
+    tcp[22..24].copy_from_slice(&mss.to_be_bytes());
+
+    _set_v4_tcp_checksum(&mut tcp, src, dst);
+
+    let mut packet = ip;
+    packet.extend_from_slice(&tcp);
+    (packet, src, dst)
+}
+
+#[test]
+fn clamp_tcp_mss_v4_preserves_checksum_invariant() {
+    let (mut packet, src, dst) = _build_v4_syn_with_mss(0x02, 1460);
+    // Sanity: the unmodified packet validates.
+    {
+        let tcp = &packet[20..];
+        assert_eq!(
+            _csum_tcp_v4_oracle(src, dst, tcp),
+            0xFFFF,
+            "test fixture must produce a valid initial checksum"
+        );
+    }
+
+    let clamped = super::clamp_tcp_mss(&mut packet, 1200);
+    assert!(clamped, "MSS 1460 > 1200 → must clamp");
+
+    // MSS bytes rewritten.
+    let tcp = &packet[20..];
+    assert_eq!(
+        u16::from_be_bytes([tcp[22], tcp[23]]),
+        1200,
+        "MSS option rewritten to clamp value"
+    );
+    // The post-clamp TCP checksum must still validate against an
+    // independent ones-complement recomputation. The pre-fix code
+    // would store an HC that gives sum-over=0xFDF7 (off by 520);
+    // this assertion fails on the buggy formula.
+    assert_eq!(
+        _csum_tcp_v4_oracle(src, dst, tcp),
+        0xFFFF,
+        "clamp_tcp_mss must maintain the TCP checksum sum-over-all = 0xFFFF invariant"
+    );
+}

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -1992,7 +1992,7 @@ fn tx_binding_resolution_uses_fabric_parent_ifindex() {
 // dropped packets because clamp_tcp_mss is dead_code'd in master
 // and only reachable via the GRE encap path.
 
-fn _csum_tcp_v4_oracle(src: [u8; 4], dst: [u8; 4], tcp: &[u8]) -> u16 {
+fn csum_tcp_v4_oracle(src: [u8; 4], dst: [u8; 4], tcp: &[u8]) -> u16 {
     let tcp_len = tcp.len() as u16;
     let mut sum: u32 = 0;
     for chunk in src.chunks(2).chain(dst.chunks(2)) {
@@ -2014,15 +2014,15 @@ fn _csum_tcp_v4_oracle(src: [u8; 4], dst: [u8; 4], tcp: &[u8]) -> u16 {
     sum as u16
 }
 
-fn _set_v4_tcp_checksum(tcp: &mut [u8], src: [u8; 4], dst: [u8; 4]) {
+fn set_v4_tcp_checksum(tcp: &mut [u8], src: [u8; 4], dst: [u8; 4]) {
     tcp[16..18].copy_from_slice(&[0, 0]);
-    let raw = _csum_tcp_v4_oracle(src, dst, tcp);
+    let raw = csum_tcp_v4_oracle(src, dst, tcp);
     tcp[16..18].copy_from_slice(&(!raw).to_be_bytes());
 }
 
 /// Build a 24-byte TCP segment (20-byte header + 4-byte MSS option)
 /// with `flags` set and MSS=`mss`. Returns (packet=ip+tcp, src, dst).
-fn _build_v4_syn_with_mss(flags: u8, mss: u16) -> (Vec<u8>, [u8; 4], [u8; 4]) {
+fn build_v4_syn_with_mss(flags: u8, mss: u16) -> (Vec<u8>, [u8; 4], [u8; 4]) {
     let src = [10, 0, 0, 1];
     let dst = [10, 0, 0, 2];
     // IPv4 header (20 bytes) + TCP header (24 bytes) = 44 total.
@@ -2046,7 +2046,7 @@ fn _build_v4_syn_with_mss(flags: u8, mss: u16) -> (Vec<u8>, [u8; 4], [u8; 4]) {
     tcp[21] = 4;
     tcp[22..24].copy_from_slice(&mss.to_be_bytes());
 
-    _set_v4_tcp_checksum(&mut tcp, src, dst);
+    set_v4_tcp_checksum(&mut tcp, src, dst);
 
     let mut packet = ip;
     packet.extend_from_slice(&tcp);
@@ -2055,12 +2055,12 @@ fn _build_v4_syn_with_mss(flags: u8, mss: u16) -> (Vec<u8>, [u8; 4], [u8; 4]) {
 
 #[test]
 fn clamp_tcp_mss_v4_preserves_checksum_invariant() {
-    let (mut packet, src, dst) = _build_v4_syn_with_mss(0x02, 1460);
+    let (mut packet, src, dst) = build_v4_syn_with_mss(0x02, 1460);
     // Sanity: the unmodified packet validates.
     {
         let tcp = &packet[20..];
         assert_eq!(
-            _csum_tcp_v4_oracle(src, dst, tcp),
+            csum_tcp_v4_oracle(src, dst, tcp),
             0xFFFF,
             "test fixture must produce a valid initial checksum"
         );
@@ -2081,7 +2081,7 @@ fn clamp_tcp_mss_v4_preserves_checksum_invariant() {
     // would store an HC that gives sum-over=0xFDF7 (off by 520);
     // this assertion fails on the buggy formula.
     assert_eq!(
-        _csum_tcp_v4_oracle(src, dst, tcp),
+        csum_tcp_v4_oracle(src, dst, tcp),
         0xFFFF,
         "clamp_tcp_mss must maintain the TCP checksum sum-over-all = 0xFFFF invariant"
     );


### PR DESCRIPTION
## Summary

Pre-existing bug in `clamp_tcp_mss` incremental checksum update — sign-flipped delta produces a checksum that does NOT preserve the TCP sum-over-all = 0xFFFF invariant.

**Buggy:** `sum = ~old_csum + old_val + ~new_val; HC' = ~sum` → `HC' = old_csum + (new_val − old_val)`
**Right (RFC 1624/1071):** `sum = old_csum + old_val + ~new_val; HC' = sum` → `HC' = old_csum + (old_val − new_val)`

Independent ones-complement recomputation of the post-clamp packet sums to `0xFFFF − 2·(old_val − new_val)` instead of `0xFFFF`.

## Why this never surfaced on the wire

`clamp_tcp_mss` is `#[allow(dead_code)]` but does have callers — the copy-builder path in `build_forwarded_frame_into_from_frame` at `frame/mod.rs:315/:354`, reachable via TX fallback in `tx/dispatch.rs:462-469/:721-725`. The live GRE path masks the bad result: `force_tunnel_l4_recompute` is set at `frame/mod.rs:260` whenever `tunnel_tcp_mss > 0`, which causes `recompute_l4_checksum_*` at `frame/mod.rs:317-318/:356-357` to overwrite the incremental checksum from scratch right after the clamp. So today's GRE path produces a correct on-wire checksum despite the broken increment — but any future caller that doesn't re-emit L4 from scratch would hit dropped packets.

## How it was caught

Surfaced while writing colocated unit tests for the #989 relocation. Codex round-1 review specifically asked for "targeted coverage for direct TCP helpers, especially `clamp_tcp_mss` checksum behavior." The independent-recomputation oracle in the test caught the bug immediately on the relocated body. Splitting the fix out so #989 stays a pure relocation.

Independently verified that `checksum16_adjust` (`frame/checksum.rs:146`), `compute_ip_csum_delta`, and `compute_l4_csum_delta` (`afxdp/checksum.rs`) use the conventional RFC-1624 form `~(~HC + ~m + m')` which is correct; the bug was isolated to `clamp_tcp_mss`.

## What's in this PR

- `userspace-dp/src/afxdp/forwarding/mod.rs` — fix the formula. 2-line code change + 3-line RFC reference comment.
- `userspace-dp/src/afxdp/forwarding/tests.rs` — `clamp_tcp_mss_v4_preserves_checksum_invariant` regression test that builds a SYN+MSS packet, calls `clamp_tcp_mss`, and validates the resulting checksum via independent ones-complement recomputation. Fails on the buggy formula (`left=65015 right=65535`), passes on the fix.

## Test plan

- [x] `cargo test --release` — 917 tests pass (was 916 + 1 new).
- [x] `cargo build --release` — clean, no new warnings.
- [x] Negative test: stash the fix, run only the new test → fails with documented `65015 != 65535` mismatch. Re-apply fix → passes.
- [x] Cluster smoke (loss userspace cluster, all 6 CoS classes) — green; iperf-a 954 Mbps (1G shaper, exact), iperf-b–f all ~6.3-6.8 Gbps with 0 retransmits.

Prerequisite for #989 (L4 protocol specialization → `frame/tcp.rs`). After this lands, the relocation PR rebases on top with byte-for-byte identical bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
