### PR TITLE
#1043 P3: relocate NAT show cases to server_show_nat.go

### DIFF
--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -2,7 +2,6 @@ package grpcapi
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
@@ -1601,286 +1600,28 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		}
 
 	case "nat-static":
-		if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-			buf.WriteString("No static NAT rules configured.\n")
-		} else {
-			for _, rs := range cfg.Security.NAT.Static {
-				fmt.Fprintf(&buf, "Static NAT rule-set: %s\n", rs.Name)
-				fmt.Fprintf(&buf, "  From zone: %s\n", rs.FromZone)
-				for _, rule := range rs.Rules {
-					fmt.Fprintf(&buf, "  Rule: %s\n", rule.Name)
-					fmt.Fprintf(&buf, "    Match destination-address: %s\n", rule.Match)
-					if rule.IsNPTv6 {
-						fmt.Fprintf(&buf, "    Then nptv6-prefix:         %s\n", rule.Then)
-					} else {
-						fmt.Fprintf(&buf, "    Then static-nat prefix:    %s\n", rule.Then)
-					}
-				}
-				buf.WriteString("\n")
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showNATStatic(cfg, &buf)
 
 	case "nat-nptv6":
-		if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-			buf.WriteString("No NPTv6 rules configured.\n")
-		} else {
-			found := false
-			for _, rs := range cfg.Security.NAT.Static {
-				for _, rule := range rs.Rules {
-					if !rule.IsNPTv6 {
-						continue
-					}
-					if !found {
-						fmt.Fprintf(&buf, "%-20s %-20s %-50s %-50s\n",
-							"Rule-set", "Rule", "External prefix", "Internal prefix")
-						found = true
-					}
-					fmt.Fprintf(&buf, "%-20s %-20s %-50s %-50s\n",
-						rs.Name, rule.Name, rule.Match, rule.Then)
-				}
-			}
-			if !found {
-				buf.WriteString("No NPTv6 rules configured.\n")
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showNATNPTv6(cfg, &buf)
 
 	case "persistent-nat":
-		if s.dp == nil || s.dp.GetPersistentNAT() == nil {
-			buf.WriteString("Persistent NAT table not available\n")
-		} else {
-			bindings := s.dp.GetPersistentNAT().All()
-			if len(bindings) == 0 {
-				buf.WriteString("No persistent NAT bindings\n")
-			} else {
-				fmt.Fprintf(&buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
-				fmt.Fprintf(&buf, "%-20s %-8s %-20s %-8s %-15s %-10s\n",
-					"Source IP", "SrcPort", "NAT IP", "NATPort", "Pool", "Timeout")
-				for _, b := range bindings {
-					remaining := time.Until(b.LastSeen.Add(b.Timeout))
-					if remaining < 0 {
-						remaining = 0
-					}
-					fmt.Fprintf(&buf, "%-20s %-8d %-20s %-8d %-15s %-10s\n",
-						b.SrcIP, b.SrcPort, b.NatIP, b.NatPort, b.PoolName,
-						remaining.Truncate(time.Second))
-				}
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showPersistentNAT(&buf)
 
 	case "nat-source-rule-detail":
-		if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
-			buf.WriteString("No source NAT rules configured\n")
-		} else {
-			// Count active SNAT sessions per rule-set
-			type ruleSetKey struct{ from, to string }
-			rsSessions := make(map[ruleSetKey]int)
-			if s.dp != nil && s.dp.IsLoaded() && s.dp.LastCompileResult() != nil {
-				cr := s.dp.LastCompileResult()
-				zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-				for name, id := range cr.ZoneIDs {
-					zoneByID[id] = name
-				}
-				_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-					if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-						rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-					}
-					return true
-				})
-			}
-
-			ruleIdx := 0
-			for _, rs := range cfg.Security.NAT.Source {
-				for _, rule := range rs.Rules {
-					ruleIdx++
-					action := "interface"
-					if rule.Then.PoolName != "" {
-						action = "pool " + rule.Then.PoolName
-					} else if rule.Then.Off {
-						action = "off"
-					}
-					srcMatch := "0.0.0.0/0"
-					if rule.Match.SourceAddress != "" {
-						srcMatch = rule.Match.SourceAddress
-					}
-					dstMatch := "0.0.0.0/0"
-					if rule.Match.DestinationAddress != "" {
-						dstMatch = rule.Match.DestinationAddress
-					}
-					fmt.Fprintf(&buf, "source NAT rule: %s\n", rule.Name)
-					fmt.Fprintf(&buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-					fmt.Fprintf(&buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-					fmt.Fprintf(&buf, "    Match:\n")
-					fmt.Fprintf(&buf, "      Source addresses:      %s\n", srcMatch)
-					fmt.Fprintf(&buf, "      Destination addresses: %s\n", dstMatch)
-					if rule.Match.Protocol != "" {
-						fmt.Fprintf(&buf, "      IP protocol:           %s\n", rule.Match.Protocol)
-					}
-					fmt.Fprintf(&buf, "    Action:                  %s\n", action)
-
-					if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
-						if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {
-							if pool.PersistentNAT != nil {
-								fmt.Fprintf(&buf, "    Persistent NAT:          enabled\n")
-							}
-							if len(pool.Addresses) > 0 {
-								fmt.Fprintf(&buf, "    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
-							}
-							portLow, portHigh := pool.PortLow, pool.PortHigh
-							if portLow == 0 {
-								portLow = 1024
-							}
-							if portHigh == 0 {
-								portHigh = 65535
-							}
-							fmt.Fprintf(&buf, "    Port range:              %d-%d\n", portLow, portHigh)
-						}
-					}
-
-					if s.dp != nil && s.dp.LastCompileResult() != nil {
-						ruleKey := rs.Name + "/" + rule.Name
-						if cid, ok := s.dp.LastCompileResult().NATCounterIDs[ruleKey]; ok {
-							cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
-							if err == nil {
-								fmt.Fprintf(&buf, "    Translation hits:        %d packets  %d bytes\n",
-									cnt.Packets, cnt.Bytes)
-							}
-						}
-					}
-
-					sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-					fmt.Fprintf(&buf, "    Number of sessions:      %d\n\n", sessions)
-				}
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showNATSourceRuleDetail(cfg, &buf)
 
 	case "nat-dest-rule-detail":
-		if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
-			buf.WriteString("No destination NAT rules configured\n")
-		} else {
-			dnat := cfg.Security.NAT.Destination
-			type ruleSetKey struct{ from, to string }
-			rsSessions := make(map[ruleSetKey]int)
-			if s.dp != nil && s.dp.IsLoaded() && s.dp.LastCompileResult() != nil {
-				cr := s.dp.LastCompileResult()
-				zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-				for name, id := range cr.ZoneIDs {
-					zoneByID[id] = name
-				}
-				_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-					if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
-						rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-					}
-					return true
-				})
-			}
-
-			ruleIdx := 0
-			for _, rs := range dnat.RuleSets {
-				for _, rule := range rs.Rules {
-					ruleIdx++
-					action := "off"
-					if rule.Then.PoolName != "" {
-						action = "pool " + rule.Then.PoolName
-					}
-					dstMatch := "0.0.0.0/0"
-					if rule.Match.DestinationAddress != "" {
-						dstMatch = rule.Match.DestinationAddress
-					}
-					fmt.Fprintf(&buf, "destination NAT rule: %s\n", rule.Name)
-					fmt.Fprintf(&buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-					fmt.Fprintf(&buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-					fmt.Fprintf(&buf, "    Match:\n")
-					fmt.Fprintf(&buf, "      Destination addresses: %s\n", dstMatch)
-					if rule.Match.DestinationPort != 0 {
-						fmt.Fprintf(&buf, "      Destination port:      %d\n", rule.Match.DestinationPort)
-					}
-					if rule.Match.Protocol != "" {
-						fmt.Fprintf(&buf, "      IP protocol:           %s\n", rule.Match.Protocol)
-					}
-					if rule.Match.Application != "" {
-						fmt.Fprintf(&buf, "      Application:           %s\n", rule.Match.Application)
-					}
-					fmt.Fprintf(&buf, "    Action:                  %s\n", action)
-
-					if rule.Then.PoolName != "" && dnat.Pools != nil {
-						if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {
-							fmt.Fprintf(&buf, "    Pool address:            %s\n", pool.Address)
-							if pool.Port != 0 {
-								fmt.Fprintf(&buf, "    Pool port:               %d\n", pool.Port)
-							}
-						}
-					}
-
-					if s.dp != nil && s.dp.LastCompileResult() != nil {
-						ruleKey := rs.Name + "/" + rule.Name
-						if cid, ok := s.dp.LastCompileResult().NATCounterIDs[ruleKey]; ok {
-							cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
-							if err == nil {
-								fmt.Fprintf(&buf, "    Translation hits:        %d packets  %d bytes\n",
-									cnt.Packets, cnt.Bytes)
-							}
-						}
-					}
-
-					sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-					fmt.Fprintf(&buf, "    Number of sessions:      %d\n\n", sessions)
-				}
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showNATDestRuleDetail(cfg, &buf)
 
 	case "persistent-nat-detail":
-		if s.dp == nil || s.dp.GetPersistentNAT() == nil {
-			buf.WriteString("Persistent NAT table not available\n")
-		} else {
-			bindings := s.dp.GetPersistentNAT().All()
-			if len(bindings) == 0 {
-				buf.WriteString("No persistent NAT bindings\n")
-			} else {
-				type natKey struct {
-					ip   uint32
-					port uint16
-				}
-				sessionCounts := make(map[natKey]int)
-				if s.dp.IsLoaded() {
-					_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-						if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-							sessionCounts[natKey{val.NATSrcIP, val.NATSrcPort}]++
-						}
-						return true
-					})
-				}
-
-				fmt.Fprintf(&buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
-				for i, b := range bindings {
-					if i > 0 {
-						buf.WriteString("\n")
-					}
-					remaining := time.Until(b.LastSeen.Add(b.Timeout))
-					if remaining < 0 {
-						remaining = 0
-					}
-					natIP := b.NatIP.As4()
-					nk := natKey{
-						ip:   binary.NativeEndian.Uint32(natIP[:]),
-						port: b.NatPort,
-					}
-					sessions := sessionCounts[nk]
-
-					fmt.Fprintf(&buf, "Persistent NAT binding:\n")
-					fmt.Fprintf(&buf, "  Internal IP:        %s\n", b.SrcIP)
-					fmt.Fprintf(&buf, "  Internal port:      %d\n", b.SrcPort)
-					fmt.Fprintf(&buf, "  Reflexive IP:       %s\n", b.NatIP)
-					fmt.Fprintf(&buf, "  Reflexive port:     %d\n", b.NatPort)
-					fmt.Fprintf(&buf, "  Pool:               %s\n", b.PoolName)
-					if b.PermitAnyRemoteHost {
-						fmt.Fprintf(&buf, "  Any remote host:    yes\n")
-					}
-					fmt.Fprintf(&buf, "  Current sessions:   %d\n", sessions)
-					fmt.Fprintf(&buf, "  Left time:          %s\n", remaining.Truncate(time.Second))
-					fmt.Fprintf(&buf, "  Configured timeout: %ds\n", int(b.Timeout.Seconds()))
-				}
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showPersistentNATDetail(&buf)
 
 	case "tunnels":
 		if s.routing == nil {
@@ -2994,20 +2735,8 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		}
 
 	case "nat64":
-		if cfg == nil || len(cfg.Security.NAT.NAT64) == 0 {
-			buf.WriteString("No NAT64 rule-sets configured\n")
-		} else {
-			for _, rs := range cfg.Security.NAT.NAT64 {
-				fmt.Fprintf(&buf, "NAT64 rule-set: %s\n", rs.Name)
-				if rs.Prefix != "" {
-					fmt.Fprintf(&buf, "  Prefix:      %s\n", rs.Prefix)
-				}
-				if rs.SourcePool != "" {
-					fmt.Fprintf(&buf, "  Source pool:  %s\n", rs.SourcePool)
-				}
-				buf.WriteString("\n")
-			}
-		}
+		// #1043 Phase 3: case body extracted to server_show_nat.go
+		s.showNAT64(cfg, &buf)
 
 	case "ike":
 		if cfg == nil || len(cfg.Security.IPsec.Gateways) == 0 {

--- a/pkg/grpcapi/server_show_nat.go
+++ b/pkg/grpcapi/server_show_nat.go
@@ -1,0 +1,338 @@
+// Phase 3 of #1043: extract the seven NAT-related ShowText case bodies
+// into dedicated methods. Same methodology as Phases 1-2 (#1148, #1150):
+// semantic relocation, no behavior change. Each case body is moved
+// verbatim apart from `&buf` references becoming `buf` (passed-in
+// `*strings.Builder`). Output is unchanged.
+
+package grpcapi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// showNATStatic renders `cli show security nat static` — static NAT and
+// NPTv6 prefix rule-sets from configuration.
+func (s *Server) showNATStatic(cfg *config.Config, buf *strings.Builder) {
+	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
+		buf.WriteString("No static NAT rules configured.\n")
+		return
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		fmt.Fprintf(buf, "Static NAT rule-set: %s\n", rs.Name)
+		fmt.Fprintf(buf, "  From zone: %s\n", rs.FromZone)
+		for _, rule := range rs.Rules {
+			fmt.Fprintf(buf, "  Rule: %s\n", rule.Name)
+			fmt.Fprintf(buf, "    Match destination-address: %s\n", rule.Match)
+			if rule.IsNPTv6 {
+				fmt.Fprintf(buf, "    Then nptv6-prefix:         %s\n", rule.Then)
+			} else {
+				fmt.Fprintf(buf, "    Then static-nat prefix:    %s\n", rule.Then)
+			}
+		}
+		buf.WriteString("\n")
+	}
+}
+
+// showNATNPTv6 renders `cli show security nat nptv6` — only the NPTv6
+// rules within the static rule-sets.
+func (s *Server) showNATNPTv6(cfg *config.Config, buf *strings.Builder) {
+	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
+		buf.WriteString("No NPTv6 rules configured.\n")
+		return
+	}
+	found := false
+	for _, rs := range cfg.Security.NAT.Static {
+		for _, rule := range rs.Rules {
+			if !rule.IsNPTv6 {
+				continue
+			}
+			if !found {
+				fmt.Fprintf(buf, "%-20s %-20s %-50s %-50s\n",
+					"Rule-set", "Rule", "External prefix", "Internal prefix")
+				found = true
+			}
+			fmt.Fprintf(buf, "%-20s %-20s %-50s %-50s\n",
+				rs.Name, rule.Name, rule.Match, rule.Then)
+		}
+	}
+	if !found {
+		buf.WriteString("No NPTv6 rules configured.\n")
+	}
+}
+
+// showPersistentNAT renders the persistent-NAT bindings table with
+// remaining timeout per binding.
+func (s *Server) showPersistentNAT(buf *strings.Builder) {
+	if s.dp == nil || s.dp.GetPersistentNAT() == nil {
+		buf.WriteString("Persistent NAT table not available\n")
+		return
+	}
+	bindings := s.dp.GetPersistentNAT().All()
+	if len(bindings) == 0 {
+		buf.WriteString("No persistent NAT bindings\n")
+		return
+	}
+	fmt.Fprintf(buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
+	fmt.Fprintf(buf, "%-20s %-8s %-20s %-8s %-15s %-10s\n",
+		"Source IP", "SrcPort", "NAT IP", "NATPort", "Pool", "Timeout")
+	for _, b := range bindings {
+		remaining := time.Until(b.LastSeen.Add(b.Timeout))
+		if remaining < 0 {
+			remaining = 0
+		}
+		fmt.Fprintf(buf, "%-20s %-8d %-20s %-8d %-15s %-10s\n",
+			b.SrcIP, b.SrcPort, b.NatIP, b.NatPort, b.PoolName,
+			remaining.Truncate(time.Second))
+	}
+}
+
+// showNATSourceRuleDetail renders detailed source NAT rule information,
+// including pool details, translation hit counters, and active session
+// counts per rule-set.
+func (s *Server) showNATSourceRuleDetail(cfg *config.Config, buf *strings.Builder) {
+	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
+		buf.WriteString("No source NAT rules configured\n")
+		return
+	}
+	// Count active SNAT sessions per rule-set
+	type ruleSetKey struct{ from, to string }
+	rsSessions := make(map[ruleSetKey]int)
+	if s.dp != nil && s.dp.IsLoaded() && s.dp.LastCompileResult() != nil {
+		cr := s.dp.LastCompileResult()
+		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
+		for name, id := range cr.ZoneIDs {
+			zoneByID[id] = name
+		}
+		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+	}
+
+	ruleIdx := 0
+	for _, rs := range cfg.Security.NAT.Source {
+		for _, rule := range rs.Rules {
+			ruleIdx++
+			action := "interface"
+			if rule.Then.PoolName != "" {
+				action = "pool " + rule.Then.PoolName
+			} else if rule.Then.Off {
+				action = "off"
+			}
+			srcMatch := "0.0.0.0/0"
+			if rule.Match.SourceAddress != "" {
+				srcMatch = rule.Match.SourceAddress
+			}
+			dstMatch := "0.0.0.0/0"
+			if rule.Match.DestinationAddress != "" {
+				dstMatch = rule.Match.DestinationAddress
+			}
+			fmt.Fprintf(buf, "source NAT rule: %s\n", rule.Name)
+			fmt.Fprintf(buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
+			fmt.Fprintf(buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
+			fmt.Fprintf(buf, "    Match:\n")
+			fmt.Fprintf(buf, "      Source addresses:      %s\n", srcMatch)
+			fmt.Fprintf(buf, "      Destination addresses: %s\n", dstMatch)
+			if rule.Match.Protocol != "" {
+				fmt.Fprintf(buf, "      IP protocol:           %s\n", rule.Match.Protocol)
+			}
+			fmt.Fprintf(buf, "    Action:                  %s\n", action)
+
+			if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
+				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {
+					if pool.PersistentNAT != nil {
+						fmt.Fprintf(buf, "    Persistent NAT:          enabled\n")
+					}
+					if len(pool.Addresses) > 0 {
+						fmt.Fprintf(buf, "    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
+					}
+					portLow, portHigh := pool.PortLow, pool.PortHigh
+					if portLow == 0 {
+						portLow = 1024
+					}
+					if portHigh == 0 {
+						portHigh = 65535
+					}
+					fmt.Fprintf(buf, "    Port range:              %d-%d\n", portLow, portHigh)
+				}
+			}
+
+			if s.dp != nil && s.dp.LastCompileResult() != nil {
+				ruleKey := rs.Name + "/" + rule.Name
+				if cid, ok := s.dp.LastCompileResult().NATCounterIDs[ruleKey]; ok {
+					cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
+					if err == nil {
+						fmt.Fprintf(buf, "    Translation hits:        %d packets  %d bytes\n",
+							cnt.Packets, cnt.Bytes)
+					}
+				}
+			}
+
+			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
+			fmt.Fprintf(buf, "    Number of sessions:      %d\n\n", sessions)
+		}
+	}
+}
+
+// showNATDestRuleDetail renders detailed destination NAT rule
+// information, including pool address/port, translation hit counters,
+// and active session counts per rule-set.
+func (s *Server) showNATDestRuleDetail(cfg *config.Config, buf *strings.Builder) {
+	if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
+		buf.WriteString("No destination NAT rules configured\n")
+		return
+	}
+	dnat := cfg.Security.NAT.Destination
+	type ruleSetKey struct{ from, to string }
+	rsSessions := make(map[ruleSetKey]int)
+	if s.dp != nil && s.dp.IsLoaded() && s.dp.LastCompileResult() != nil {
+		cr := s.dp.LastCompileResult()
+		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
+		for name, id := range cr.ZoneIDs {
+			zoneByID[id] = name
+		}
+		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+	}
+
+	ruleIdx := 0
+	for _, rs := range dnat.RuleSets {
+		for _, rule := range rs.Rules {
+			ruleIdx++
+			action := "off"
+			if rule.Then.PoolName != "" {
+				action = "pool " + rule.Then.PoolName
+			}
+			dstMatch := "0.0.0.0/0"
+			if rule.Match.DestinationAddress != "" {
+				dstMatch = rule.Match.DestinationAddress
+			}
+			fmt.Fprintf(buf, "destination NAT rule: %s\n", rule.Name)
+			fmt.Fprintf(buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
+			fmt.Fprintf(buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
+			fmt.Fprintf(buf, "    Match:\n")
+			fmt.Fprintf(buf, "      Destination addresses: %s\n", dstMatch)
+			if rule.Match.DestinationPort != 0 {
+				fmt.Fprintf(buf, "      Destination port:      %d\n", rule.Match.DestinationPort)
+			}
+			if rule.Match.Protocol != "" {
+				fmt.Fprintf(buf, "      IP protocol:           %s\n", rule.Match.Protocol)
+			}
+			if rule.Match.Application != "" {
+				fmt.Fprintf(buf, "      Application:           %s\n", rule.Match.Application)
+			}
+			fmt.Fprintf(buf, "    Action:                  %s\n", action)
+
+			if rule.Then.PoolName != "" && dnat.Pools != nil {
+				if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {
+					fmt.Fprintf(buf, "    Pool address:            %s\n", pool.Address)
+					if pool.Port != 0 {
+						fmt.Fprintf(buf, "    Pool port:               %d\n", pool.Port)
+					}
+				}
+			}
+
+			if s.dp != nil && s.dp.LastCompileResult() != nil {
+				ruleKey := rs.Name + "/" + rule.Name
+				if cid, ok := s.dp.LastCompileResult().NATCounterIDs[ruleKey]; ok {
+					cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
+					if err == nil {
+						fmt.Fprintf(buf, "    Translation hits:        %d packets  %d bytes\n",
+							cnt.Packets, cnt.Bytes)
+					}
+				}
+			}
+
+			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
+			fmt.Fprintf(buf, "    Number of sessions:      %d\n\n", sessions)
+		}
+	}
+}
+
+// showPersistentNATDetail renders per-binding detail for persistent-NAT
+// bindings, including current session counts per (NAT IP, NAT port).
+func (s *Server) showPersistentNATDetail(buf *strings.Builder) {
+	if s.dp == nil || s.dp.GetPersistentNAT() == nil {
+		buf.WriteString("Persistent NAT table not available\n")
+		return
+	}
+	bindings := s.dp.GetPersistentNAT().All()
+	if len(bindings) == 0 {
+		buf.WriteString("No persistent NAT bindings\n")
+		return
+	}
+	type natKey struct {
+		ip   uint32
+		port uint16
+	}
+	sessionCounts := make(map[natKey]int)
+	if s.dp.IsLoaded() {
+		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				sessionCounts[natKey{val.NATSrcIP, val.NATSrcPort}]++
+			}
+			return true
+		})
+	}
+
+	fmt.Fprintf(buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
+	for i, b := range bindings {
+		if i > 0 {
+			buf.WriteString("\n")
+		}
+		remaining := time.Until(b.LastSeen.Add(b.Timeout))
+		if remaining < 0 {
+			remaining = 0
+		}
+		natIP := b.NatIP.As4()
+		nk := natKey{
+			ip:   binary.NativeEndian.Uint32(natIP[:]),
+			port: b.NatPort,
+		}
+		sessions := sessionCounts[nk]
+
+		fmt.Fprintf(buf, "Persistent NAT binding:\n")
+		fmt.Fprintf(buf, "  Internal IP:        %s\n", b.SrcIP)
+		fmt.Fprintf(buf, "  Internal port:      %d\n", b.SrcPort)
+		fmt.Fprintf(buf, "  Reflexive IP:       %s\n", b.NatIP)
+		fmt.Fprintf(buf, "  Reflexive port:     %d\n", b.NatPort)
+		fmt.Fprintf(buf, "  Pool:               %s\n", b.PoolName)
+		if b.PermitAnyRemoteHost {
+			fmt.Fprintf(buf, "  Any remote host:    yes\n")
+		}
+		fmt.Fprintf(buf, "  Current sessions:   %d\n", sessions)
+		fmt.Fprintf(buf, "  Left time:          %s\n", remaining.Truncate(time.Second))
+		fmt.Fprintf(buf, "  Configured timeout: %ds\n", int(b.Timeout.Seconds()))
+	}
+}
+
+// showNAT64 renders `cli show security nat nat64` — NAT64 rule-sets
+// from configuration.
+func (s *Server) showNAT64(cfg *config.Config, buf *strings.Builder) {
+	if cfg == nil || len(cfg.Security.NAT.NAT64) == 0 {
+		buf.WriteString("No NAT64 rule-sets configured\n")
+		return
+	}
+	for _, rs := range cfg.Security.NAT.NAT64 {
+		fmt.Fprintf(buf, "NAT64 rule-set: %s\n", rs.Name)
+		if rs.Prefix != "" {
+			fmt.Fprintf(buf, "  Prefix:      %s\n", rs.Prefix)
+		}
+		if rs.SourcePool != "" {
+			fmt.Fprintf(buf, "  Source pool:  %s\n", rs.SourcePool)
+		}
+		buf.WriteString("\n")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the **#1043** server_show.go modularity-discipline split.
Extracts the seven NAT-related ShowText case bodies into a new sibling
file `pkg/grpcapi/server_show_nat.go`.

- `nat-static`
- `nat-nptv6`
- `persistent-nat`
- `nat-source-rule-detail`
- `nat-dest-rule-detail`
- `persistent-nat-detail`
- `nat64`

Methodology matches **#1148** (Phase 1: firewall) and **#1150** (Phase 2:
chassis): semantic relocation, no behavior change. Each case body is
moved verbatim apart from (a) `&buf` references becoming `buf`
(passed-in `*strings.Builder`) and (b) the original `if … { … } else { … }`
structure flattened into an early-return form (`if … { …; return }; …`)
so the extracted methods read with one fewer indentation level. Output
is unchanged.

| Metric                       | Before  | After   |
|------------------------------|---------|---------|
| `server_show.go` LOC         | 3,873   | 3,603   |
| `server_show_nat.go` LOC     | —       | 338     |

The `encoding/binary` import in `server_show.go` is dropped — its only
callsite (in `persistent-nat-detail`) moved to the new file.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 880+ tests pass
- [x] Deploy on loss userspace cluster (`xpf-userspace-fw0/fw1`)
- [x] v4 smoke against `172.16.80.200` — 959 Mbps, 0 retr
- [x] v6 smoke against `2001:559:8585:80::200` — 945 Mbps, 0 retr

## Phase progress

- [x] Phase 1 (#1148): firewall, -130 LOC
- [x] Phase 2 (#1150): chassis, -72 LOC
- [x] **Phase 3 (this PR): NAT, -270 LOC**
- [ ] Phase 4: dhcp/lldp/snmp (~242 LOC)
- [ ] Phase 5: flow (~245 LOC)
- [ ] Phase 6: interfaces extras (~221 LOC)
- [ ] Phase 7: system (~217 LOC)
- [ ] Phase 8: zones detail (~159 LOC) — brings server_show.go under 2,000 LOC
- [ ] Phase 9: misc cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)