### PR TITLE
#1043 P9: relocate route-* show cases to server_show_routes_text.go

### DIFF
--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -17,7 +17,6 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/feeds"
-	"github.com/psaab/xpf/pkg/frr"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
@@ -1209,67 +1208,27 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		}
 
 	case "route-all":
-		if s.routing == nil {
-			fmt.Fprintln(&buf, "Routing manager not available")
-		} else {
-			var instances []*config.RoutingInstanceConfig
-			if cfg != nil {
-				instances = cfg.RoutingInstances
-			}
-			allTables, err := s.routing.GetAllTableRoutes(instances)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "get routes: %v", err)
-			}
-			buf.WriteString(routing.FormatAllRoutes(allTables))
+		// #1043 Phase 9: case body extracted to server_show_routes_text.go
+		if err := s.showRouteAll(cfg, &buf); err != nil {
+			return nil, err
 		}
 
 	case "route-summary":
-		if s.routing == nil {
-			fmt.Fprintln(&buf, "Routing manager not available")
-		} else {
-			var instances []*config.RoutingInstanceConfig
-			if cfg != nil {
-				instances = cfg.RoutingInstances
-			}
-			allTables, err := s.routing.GetAllTableRoutes(instances)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "get routes: %v", err)
-			}
-			routerID := ""
-			if cfg != nil {
-				if cfg.Protocols.OSPF != nil && cfg.Protocols.OSPF.RouterID != "" {
-					routerID = cfg.Protocols.OSPF.RouterID
-				} else if cfg.Protocols.BGP != nil && cfg.Protocols.BGP.RouterID != "" {
-					routerID = cfg.Protocols.BGP.RouterID
-				}
-			}
-			buf.WriteString(routing.FormatRouteSummary(allTables, routerID))
+		// #1043 Phase 9: case body extracted to server_show_routes_text.go
+		if err := s.showRouteSummary(cfg, &buf); err != nil {
+			return nil, err
 		}
 
 	case "route-terse":
-		if s.routing == nil {
-			fmt.Fprintln(&buf, "Routing manager not available")
-		} else {
-			entries, err := s.routing.GetRoutes()
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "get routes: %v", err)
-			}
-			buf.WriteString(routing.FormatRouteTerse(entries))
+		// #1043 Phase 9: case body extracted to server_show_routes_text.go
+		if err := s.showRouteTerse(&buf); err != nil {
+			return nil, err
 		}
 
 	case "route-detail":
-		if s.frr == nil {
-			fmt.Fprintln(&buf, "FRR manager not available")
-		} else {
-			routes, err := s.frr.GetRouteDetailJSON()
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "get route detail: %v", err)
-			}
-			if len(routes) == 0 {
-				buf.WriteString("No routes\n")
-			} else {
-				buf.WriteString(frr.FormatRouteDetail(routes))
-			}
+		// #1043 Phase 9: case body extracted to server_show_routes_text.go
+		if err := s.showRouteDetail(&buf); err != nil {
+			return nil, err
 		}
 
 	case "interfaces-extensive":

--- a/pkg/grpcapi/server_show_routes_text.go
+++ b/pkg/grpcapi/server_show_routes_text.go
@@ -1,0 +1,100 @@
+// Phase 9 of #1043: extract the four route-* ShowText case bodies into
+// dedicated methods. Same methodology as Phases 1-8: semantic
+// relocation, no behavior change. Each case body is moved verbatim
+// apart from `&buf` references becoming `buf` (passed-in
+// `*strings.Builder`). The methods return `error` because the
+// originals had `return nil, status.Errorf(codes.Internal, …)` paths
+// on routing/FRR fetch failure; the dispatcher rewraps via
+// `if err := …; err != nil { return nil, err }` (same pattern as
+// Phase 6 interfaces and Phase 7 commit-history).
+
+package grpcapi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/frr"
+	"github.com/psaab/xpf/pkg/routing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// showRouteAll renders the per-VRF route tables (main + each routing
+// instance) using `routing.FormatAllRoutes`.
+func (s *Server) showRouteAll(cfg *config.Config, buf *strings.Builder) error {
+	if s.routing == nil {
+		fmt.Fprintln(buf, "Routing manager not available")
+		return nil
+	}
+	var instances []*config.RoutingInstanceConfig
+	if cfg != nil {
+		instances = cfg.RoutingInstances
+	}
+	allTables, err := s.routing.GetAllTableRoutes(instances)
+	if err != nil {
+		return status.Errorf(codes.Internal, "get routes: %v", err)
+	}
+	buf.WriteString(routing.FormatAllRoutes(allTables))
+	return nil
+}
+
+// showRouteSummary renders the FRR-style route summary with
+// router-ID extracted from OSPF or BGP config.
+func (s *Server) showRouteSummary(cfg *config.Config, buf *strings.Builder) error {
+	if s.routing == nil {
+		fmt.Fprintln(buf, "Routing manager not available")
+		return nil
+	}
+	var instances []*config.RoutingInstanceConfig
+	if cfg != nil {
+		instances = cfg.RoutingInstances
+	}
+	allTables, err := s.routing.GetAllTableRoutes(instances)
+	if err != nil {
+		return status.Errorf(codes.Internal, "get routes: %v", err)
+	}
+	routerID := ""
+	if cfg != nil {
+		if cfg.Protocols.OSPF != nil && cfg.Protocols.OSPF.RouterID != "" {
+			routerID = cfg.Protocols.OSPF.RouterID
+		} else if cfg.Protocols.BGP != nil && cfg.Protocols.BGP.RouterID != "" {
+			routerID = cfg.Protocols.BGP.RouterID
+		}
+	}
+	buf.WriteString(routing.FormatRouteSummary(allTables, routerID))
+	return nil
+}
+
+// showRouteTerse renders the terse main-table route listing.
+func (s *Server) showRouteTerse(buf *strings.Builder) error {
+	if s.routing == nil {
+		fmt.Fprintln(buf, "Routing manager not available")
+		return nil
+	}
+	entries, err := s.routing.GetRoutes()
+	if err != nil {
+		return status.Errorf(codes.Internal, "get routes: %v", err)
+	}
+	buf.WriteString(routing.FormatRouteTerse(entries))
+	return nil
+}
+
+// showRouteDetail renders the FRR JSON-backed detailed route view.
+func (s *Server) showRouteDetail(buf *strings.Builder) error {
+	if s.frr == nil {
+		fmt.Fprintln(buf, "FRR manager not available")
+		return nil
+	}
+	routes, err := s.frr.GetRouteDetailJSON()
+	if err != nil {
+		return status.Errorf(codes.Internal, "get route detail: %v", err)
+	}
+	if len(routes) == 0 {
+		buf.WriteString("No routes\n")
+		return nil
+	}
+	buf.WriteString(frr.FormatRouteDetail(routes))
+	return nil
+}


### PR DESCRIPTION
## Summary

Phase 9 of the **#1043** server_show.go modularity-discipline split.
Extracts four route-related ShowText case bodies into a new sibling
file `pkg/grpcapi/server_show_routes_text.go`:

- `route-all`     → `showRouteAll(cfg, buf) error`
- `route-summary` → `showRouteSummary(cfg, buf) error`
- `route-terse`   → `showRouteTerse(buf) error`
- `route-detail`  → `showRouteDetail(buf) error`

Same methodology as Phases 1-8: semantic relocation, no behavior
change. All four methods return `error` because the originals had
`return nil, status.Errorf(...)` paths on routing/FRR fetch failure;
the dispatcher rewraps via `if err := …; err != nil { return nil, err }`
(same pattern as Phase 6 interfaces and Phase 7 commit-history).

| Metric                            | Before  | After   |
|-----------------------------------|---------|---------|
| `server_show.go` LOC              | 2,575   | 2,535   |
| `server_show_routes_text.go` LOC  | —       | 100     |

The `github.com/psaab/xpf/pkg/frr` import in `server_show.go` is
dropped — package `frr.FormatRouteDetail` was the only `frr.X`
callsite in this file (the `s.frr.X` method calls in other still-
resident cases don't need the import).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 880+ tests pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke against `172.16.80.200` — 956 Mbps, 0 retr (8s, hitting
      iperf-a CoS class)
- [x] v6 smoke against `2001:559:8585:80::200` — 944 Mbps, 0 retr

## Phase progress

- [x] Phases 1-8 (#1148, #1150, #1151, #1153, #1154, #1155, #1156, #1157)
- [x] **Phase 9 (this PR): routes, -40 LOC**
- [ ] Phase 10: policies (`policies-hit-count`, `policies-detail`,
      `policy-options`) — ~270 LOC
- [ ] Phase 11: chassis-cluster + chassis-hardware/forwarding (~140 LOC)
- [ ] Phase 12: residual cleanup (tunnels, rpm, security-log, security-alarms,
      schedulers, ipsec-statistics, applications, address-book,
      dynamic-address, alg) — brings server_show.go below 2,000 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)