### PR TITLE
#1043 P11: relocate chassis-cluster* show cases to server_show_cluster_text.go

### DIFF
--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -21,7 +21,6 @@ import (
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -1264,145 +1263,44 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		return s.ShowText(ctx, &pb.ShowTextRequest{Topic: "chassis"})
 
 	case "chassis-forwarding":
-		// #877: Junos-style forwarding-daemon health view.
-		// #881: CPU rows are 5s/1m/5m windows from s.fwdSampler.
-		// #879: cluster mode renders BOTH node0:/node1: blocks. To
-		// prevent infinite recursion, peer calls carry the
-		// `xpf-no-peer:1` gRPC metadata; when present we skip the
-		// peer dial-back and emit a single local block.
-		md, _ := metadata.FromIncomingContext(ctx)
-		isPeerCall := len(md.Get("xpf-no-peer")) > 0
-
-		localBuf := s.buildLocalForwarding()
-
-		if s.cluster == nil || isPeerCall {
-			buf.WriteString(localBuf)
-			break
-		}
-
-		// Cluster mode, original (non-peer) call — compose two blocks.
-		localNodeID := s.cluster.NodeID()
-		fmt.Fprintf(&buf, "node%d:\n%s\n%s",
-			localNodeID, chassisForwardingSeparator, localBuf)
-
-		peerBuf, peerErr := s.dialAndShowForwarding(ctx)
-		// Codex round-1 fix: guard against PeerNodeID() returning 0
-		// before the first heartbeat — would produce two `node0:`
-		// headers. If peer was never seen, label it as unknown.
-		peerLabel := "node?"
-		if s.cluster.PeerAlive() {
-			peerLabel = fmt.Sprintf("node%d", s.cluster.PeerNodeID())
-		}
-		fmt.Fprintf(&buf, "\n%s:\n%s\n", peerLabel, chassisForwardingSeparator)
-		if peerErr != nil {
-			fmt.Fprintf(&buf, "FWDD status:\n  (peer unreachable: %s)\n", peerErr)
-		} else {
-			buf.WriteString(peerBuf)
-		}
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisForwarding(ctx, &buf)
 
 	case "chassis-cluster", "chassis-cluster-status":
-		if s.cluster != nil {
-			buf.WriteString(s.cluster.FormatStatus())
-		} else {
-			fmt.Fprintln(&buf, "Cluster not configured")
-		}
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterStatus(&buf)
 
 	case "chassis-cluster-interfaces":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		input := s.buildInterfacesInput()
-		buf.WriteString(s.cluster.FormatInterfaces(input))
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterInterfaces(&buf)
 
 	case "chassis-cluster-information":
-		if s.cluster != nil {
-			buf.WriteString(s.cluster.FormatInformation())
-		} else {
-			cfg := s.store.ActiveConfig()
-			if cfg == nil || cfg.Chassis.Cluster == nil {
-				fmt.Fprintln(&buf, "Cluster not configured")
-				break
-			}
-			cc := cfg.Chassis.Cluster
-			hbInterval := cc.HeartbeatInterval
-			if hbInterval == 0 {
-				hbInterval = 1000
-			}
-			hbThreshold := cc.HeartbeatThreshold
-			if hbThreshold == 0 {
-				hbThreshold = 3
-			}
-			fmt.Fprintf(&buf, "Cluster ID: %d\n", cc.ClusterID)
-			fmt.Fprintf(&buf, "Node ID: %d\n", cc.NodeID)
-			fmt.Fprintf(&buf, "RETH count: %d\n", cc.RethCount)
-			fmt.Fprintf(&buf, "Heartbeat interval: %d ms\n", hbInterval)
-			fmt.Fprintf(&buf, "Heartbeat threshold: %d\n", hbThreshold)
-			fmt.Fprintf(&buf, "Redundancy groups: %d\n", len(cc.RedundancyGroups))
-		}
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterInformation(&buf)
 
 	case "chassis-cluster-statistics":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		buf.WriteString(s.cluster.FormatStatistics())
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterStatistics(&buf)
 
 	case "chassis-cluster-control-plane-statistics":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		buf.WriteString(s.cluster.FormatControlPlaneStatistics())
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterControlPlaneStatistics(&buf)
 
 	case "chassis-cluster-data-plane-statistics":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		buf.WriteString(s.cluster.FormatDataPlaneStatistics())
-		if status, err := s.userspaceDataplaneStatus(); err == nil {
-			buf.WriteString("\n")
-			buf.WriteString(dpuserspace.FormatStatusSummary(status))
-		}
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterDataPlaneStatistics(&buf)
 
 	case "chassis-cluster-data-plane-interfaces":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		buf.WriteString(s.cluster.FormatDataPlaneInterfaces())
-		if status, err := s.userspaceDataplaneStatus(); err == nil {
-			buf.WriteString("\n")
-			buf.WriteString(dpuserspace.FormatBindings(status))
-		}
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterDataPlaneInterfaces(&buf)
 
 	case "chassis-cluster-ip-monitoring-status":
-		if s.cluster == nil {
-			fmt.Fprintln(&buf, "Cluster not configured")
-			break
-		}
-		buf.WriteString(s.cluster.FormatIPMonitoringStatus())
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterIPMonitoringStatus(&buf)
 
 	case "chassis-cluster-fabric-statistics":
-		if s.dp == nil || !s.dp.IsLoaded() {
-			fmt.Fprintln(&buf, "Dataplane not loaded")
-			break
-		}
-		total, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirect)
-		fab0, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab0)
-		fab1, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab1)
-		zone, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectZone)
-		drops, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricFwdDrop)
-		fmt.Fprintln(&buf, "Fabric redirect statistics:")
-		fmt.Fprintf(&buf, "    Total redirects:          %d\n", total)
-		fmt.Fprintf(&buf, "    fab0 redirects:           %d\n", fab0)
-		fmt.Fprintf(&buf, "    fab1 redirects:           %d\n", fab1)
-		fmt.Fprintf(&buf, "    Zone-encoded redirects:   %d\n", zone)
-		fmt.Fprintf(&buf, "    Redirect drops:           %d\n", drops)
-		fmt.Fprintln(&buf)
-		fmt.Fprintln(&buf, "Note: XDP-redirected packets bypass AF_PACKET (tcpdump).")
-		fmt.Fprintln(&buf, "Use these counters or 'monitor interface <fab>' for fabric telemetry.")
+		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
+		s.showChassisClusterFabricStatistics(&buf)
 
 	case "chassis-environment":
 		// #1043 Phase 7: case body extracted to server_show_system.go

--- a/pkg/grpcapi/server_show_cluster_text.go
+++ b/pkg/grpcapi/server_show_cluster_text.go
@@ -1,0 +1,195 @@
+// Phase 11 of #1043: extract the chassis-forwarding and
+// chassis-cluster-* ShowText case bodies into dedicated methods. Same
+// methodology as Phases 1-10: semantic relocation, no behavior change.
+// Each case body is moved verbatim apart from `&buf` references
+// becoming `buf` (passed-in `*strings.Builder`) and `break`-on-guard
+// patterns flattened into early-return form.
+//
+// `showChassisForwarding` takes `ctx` because the original case used
+// `metadata.FromIncomingContext(ctx)` and called the peer-dial helper
+// `s.dialAndShowForwarding(ctx)` for cluster mode. Error/output
+// semantics are preserved.
+//
+// `chassis-hardware` is left in the dispatcher: it is a trivial
+// `return s.ShowText(ctx, &pb.ShowTextRequest{Topic: "chassis"})`
+// alias and extracting it would not improve readability.
+
+package grpcapi
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"google.golang.org/grpc/metadata"
+)
+
+// showChassisForwarding renders the Junos-style forwarding-daemon
+// health view (#877). In cluster mode it composes node0:/node1:
+// blocks; the `xpf-no-peer:1` gRPC metadata bypasses the peer dial
+// to prevent infinite recursion (#879).
+func (s *Server) showChassisForwarding(ctx context.Context, buf *strings.Builder) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	isPeerCall := len(md.Get("xpf-no-peer")) > 0
+
+	localBuf := s.buildLocalForwarding()
+
+	if s.cluster == nil || isPeerCall {
+		buf.WriteString(localBuf)
+		return
+	}
+
+	// Cluster mode, original (non-peer) call — compose two blocks.
+	localNodeID := s.cluster.NodeID()
+	fmt.Fprintf(buf, "node%d:\n%s\n%s",
+		localNodeID, chassisForwardingSeparator, localBuf)
+
+	peerBuf, peerErr := s.dialAndShowForwarding(ctx)
+	// Codex round-1 fix: guard against PeerNodeID() returning 0
+	// before the first heartbeat — would produce two `node0:`
+	// headers. If peer was never seen, label it as unknown.
+	peerLabel := "node?"
+	if s.cluster.PeerAlive() {
+		peerLabel = fmt.Sprintf("node%d", s.cluster.PeerNodeID())
+	}
+	fmt.Fprintf(buf, "\n%s:\n%s\n", peerLabel, chassisForwardingSeparator)
+	if peerErr != nil {
+		fmt.Fprintf(buf, "FWDD status:\n  (peer unreachable: %s)\n", peerErr)
+	} else {
+		buf.WriteString(peerBuf)
+	}
+}
+
+// showChassisClusterStatus renders the cluster status (also serves the
+// `chassis-cluster-status` alias).
+func (s *Server) showChassisClusterStatus(buf *strings.Builder) {
+	if s.cluster != nil {
+		buf.WriteString(s.cluster.FormatStatus())
+	} else {
+		fmt.Fprintln(buf, "Cluster not configured")
+	}
+}
+
+// showChassisClusterInterfaces renders cluster RETH interfaces.
+func (s *Server) showChassisClusterInterfaces(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	input := s.buildInterfacesInput()
+	buf.WriteString(s.cluster.FormatInterfaces(input))
+}
+
+// showChassisClusterInformation renders cluster identity (cluster-id,
+// node-id, RETH count, heartbeat tunables, redundancy-group count).
+// Falls back to config-derived values when no live cluster manager.
+func (s *Server) showChassisClusterInformation(buf *strings.Builder) {
+	if s.cluster != nil {
+		buf.WriteString(s.cluster.FormatInformation())
+		return
+	}
+	cfg := s.store.ActiveConfig()
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	cc := cfg.Chassis.Cluster
+	hbInterval := cc.HeartbeatInterval
+	if hbInterval == 0 {
+		hbInterval = 1000
+	}
+	hbThreshold := cc.HeartbeatThreshold
+	if hbThreshold == 0 {
+		hbThreshold = 3
+	}
+	fmt.Fprintf(buf, "Cluster ID: %d\n", cc.ClusterID)
+	fmt.Fprintf(buf, "Node ID: %d\n", cc.NodeID)
+	fmt.Fprintf(buf, "RETH count: %d\n", cc.RethCount)
+	fmt.Fprintf(buf, "Heartbeat interval: %d ms\n", hbInterval)
+	fmt.Fprintf(buf, "Heartbeat threshold: %d\n", hbThreshold)
+	fmt.Fprintf(buf, "Redundancy groups: %d\n", len(cc.RedundancyGroups))
+}
+
+// showChassisClusterStatistics renders aggregate cluster statistics.
+func (s *Server) showChassisClusterStatistics(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	buf.WriteString(s.cluster.FormatStatistics())
+}
+
+// showChassisClusterControlPlaneStatistics renders control-plane
+// (heartbeat / sync) cluster statistics.
+func (s *Server) showChassisClusterControlPlaneStatistics(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	buf.WriteString(s.cluster.FormatControlPlaneStatistics())
+}
+
+// showChassisClusterDataPlaneStatistics renders data-plane cluster
+// statistics, plus the userspace data-plane status summary if
+// available.
+func (s *Server) showChassisClusterDataPlaneStatistics(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	buf.WriteString(s.cluster.FormatDataPlaneStatistics())
+	if status, err := s.userspaceDataplaneStatus(); err == nil {
+		buf.WriteString("\n")
+		buf.WriteString(dpuserspace.FormatStatusSummary(status))
+	}
+}
+
+// showChassisClusterDataPlaneInterfaces renders cluster data-plane
+// interface bindings, plus the userspace data-plane bindings list if
+// available.
+func (s *Server) showChassisClusterDataPlaneInterfaces(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	buf.WriteString(s.cluster.FormatDataPlaneInterfaces())
+	if status, err := s.userspaceDataplaneStatus(); err == nil {
+		buf.WriteString("\n")
+		buf.WriteString(dpuserspace.FormatBindings(status))
+	}
+}
+
+// showChassisClusterIPMonitoringStatus renders the IP-monitoring
+// (RPM-driven RG transition) status table.
+func (s *Server) showChassisClusterIPMonitoringStatus(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	buf.WriteString(s.cluster.FormatIPMonitoringStatus())
+}
+
+// showChassisClusterFabricStatistics renders BPF-level fabric redirect
+// counters (cross-chassis forwarding telemetry).
+func (s *Server) showChassisClusterFabricStatistics(buf *strings.Builder) {
+	if s.dp == nil || !s.dp.IsLoaded() {
+		fmt.Fprintln(buf, "Dataplane not loaded")
+		return
+	}
+	total, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirect)
+	fab0, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab0)
+	fab1, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab1)
+	zone, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectZone)
+	drops, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricFwdDrop)
+	fmt.Fprintln(buf, "Fabric redirect statistics:")
+	fmt.Fprintf(buf, "    Total redirects:          %d\n", total)
+	fmt.Fprintf(buf, "    fab0 redirects:           %d\n", fab0)
+	fmt.Fprintf(buf, "    fab1 redirects:           %d\n", fab1)
+	fmt.Fprintf(buf, "    Zone-encoded redirects:   %d\n", zone)
+	fmt.Fprintf(buf, "    Redirect drops:           %d\n", drops)
+	fmt.Fprintln(buf)
+	fmt.Fprintln(buf, "Note: XDP-redirected packets bypass AF_PACKET (tcpdump).")
+	fmt.Fprintln(buf, "Use these counters or 'monitor interface <fab>' for fabric telemetry.")
+}


### PR DESCRIPTION
## Summary

Phase 11 of the **#1043** server_show.go modularity-discipline split.
Extracts ten chassis-cluster ShowText case bodies into a new sibling
file `pkg/grpcapi/server_show_cluster_text.go`:

- `chassis-forwarding`                          → `showChassisForwarding(ctx, buf)`
- `chassis-cluster` / `chassis-cluster-status`  → `showChassisClusterStatus(buf)`
- `chassis-cluster-interfaces`                  → `showChassisClusterInterfaces(buf)`
- `chassis-cluster-information`                 → `showChassisClusterInformation(buf)`
- `chassis-cluster-statistics`                  → `showChassisClusterStatistics(buf)`
- `chassis-cluster-control-plane-statistics`    → `showChassisClusterControlPlaneStatistics(buf)`
- `chassis-cluster-data-plane-statistics`       → `showChassisClusterDataPlaneStatistics(buf)`
- `chassis-cluster-data-plane-interfaces`       → `showChassisClusterDataPlaneInterfaces(buf)`
- `chassis-cluster-ip-monitoring-status`        → `showChassisClusterIPMonitoringStatus(buf)`
- `chassis-cluster-fabric-statistics`           → `showChassisClusterFabricStatistics(buf)`

Same methodology as Phases 1-10: semantic relocation, no behavior
change. Each case body is moved verbatim apart from `&buf` references
becoming `buf` and `break` patterns becoming early-return.

`showChassisForwarding` takes `ctx context.Context` because the
original case used `metadata.FromIncomingContext(ctx)` and called the
peer-dial helper `s.dialAndShowForwarding(ctx)`.

`chassis-hardware` is left in the dispatcher: it is a trivial alias
(`return s.ShowText(ctx, &pb.ShowTextRequest{Topic: "chassis"})`) and
extracting it would not improve readability.

| Metric                              | Before  | After   |
|-------------------------------------|---------|---------|
| `server_show.go` LOC                | 2,304   | 2,202   |
| `server_show_cluster_text.go` LOC   | —       | 195     |

The `google.golang.org/grpc/metadata` import in `server_show.go` is
dropped — its only callsite was in `chassis-forwarding`, now moved.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 880+ tests pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke against `172.16.80.200` — 958 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke against `2001:559:8585:80::200` — 944 Mbps, 0 retr

## Phase progress

- [x] Phases 1-10
- [x] **Phase 11 (this PR): chassis-cluster, -102 LOC**
- [ ] Phase 12: residual cleanup — brings server_show.go below 2,000 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)