### PR TITLE
#959 Phase 1: extract dbg_* counters into WorkerTelemetry sub-struct

### DIFF
--- a/docs/pr/959-phase1-telemetry/plan.md
+++ b/docs/pr/959-phase1-telemetry/plan.md
@@ -1,0 +1,151 @@
+# Plan: #959 Phase 1 — extract `dbg_*` into `WorkerTelemetry`
+
+## Status
+
+Phase 1 of #959 BindingWorker decomposition. Closes #1125 (already
+closed as duplicate). Sequenced before #1127 (PacketBatch) per the
+note on that issue.
+
+## Problem
+
+`BindingWorker` (`userspace-dp/src/afxdp/worker/mod.rs:34`) has 80+
+fields. The 23 `dbg_*` counters are the cleanest extraction target:
+
+- Almost all write-only (incremented from many sites). Three
+  exceptions are read for comparison or formatting:
+  - `dbg_rx_avail_max` — comparison at `worker/lifecycle.rs:124`.
+  - `dbg_sendto_enobufs`, `dbg_sendto_err` — formatted in
+    `tx/rings.rs` ENOBUFS / error log paths.
+- No aliasing concerns: counters are accessed independently of any
+  XSK ring, scratch buffer, or CoS state.
+- Many access patterns: `binding.dbg_*`, `self.dbg_*`,
+  `b.dbg_*` (dominant in worker/mod.rs:1156-1599), `worker.dbg_*`.
+  Total raw `\.dbg_` matches in `userspace-dp/src/afxdp`: ~120
+  (incl. comments, tests, and `BindingLiveState`'s own mirror
+  fields which must NOT change).
+
+## Scope
+
+Move these 24 fields out of `BindingWorker` into a new
+`WorkerTelemetry` struct, aggregated at one field
+`pub(crate) telemetry: WorkerTelemetry`:
+
+```
+dbg_fill_submitted, dbg_fill_failed,
+dbg_poll_cycles, dbg_backpressure,
+dbg_rx_empty, dbg_rx_wakeups,
+dbg_tx_ring_submitted, dbg_tx_ring_full,
+dbg_completions_reaped,
+dbg_sendto_calls, dbg_sendto_err,
+dbg_sendto_eagain, dbg_sendto_enobufs,
+dbg_bound_pending_overflow, dbg_cos_queue_overflow,
+dbg_tx_tcp_rst,
+dbg_rx_avail_nonzero, dbg_rx_avail_max,
+dbg_fill_pending, dbg_device_avail,
+dbg_rx_wake_sendto_ok, dbg_rx_wake_sendto_err,
+dbg_rx_wake_sendto_errno
+```
+
+23 fields total. (Note: there are `dbg_*` mirror fields in a
+separate publish-snapshot struct at `worker/mod.rs:1851+` and in
+`BindingLiveState` atomics at `umem/mod.rs:763+` — both **out of
+scope**. Those are different types and the Rust compiler distinguishes
+them by type, not by name.)
+
+## Methodology — compiler-driven, NOT sed-driven
+
+This was the major change after round-1 plan review:
+
+1. Add `pub(crate) struct WorkerTelemetry { … }` with the 23 fields
+   and `#[derive(Default)]`. Place in
+   `userspace-dp/src/afxdp/worker/telemetry.rs` (new file).
+2. Add `pub(crate) telemetry: WorkerTelemetry` field to BindingWorker.
+3. **Remove** the 23 `dbg_*` fields from `BindingWorker`. The
+   compiler now flags every callsite that accesses a removed field.
+4. Update the `Self { … }` constructor literal at
+   `worker/mod.rs:421-443` (BindingWorker is constructed via
+   `BindingWorker::create` which uses an explicit struct literal,
+   not `Default`/`new`/builder). Remove the 23 field initializers
+   from the literal; add one `telemetry: WorkerTelemetry::default()`
+   line.
+5. Walk every compile error and rewrite the access:
+   `binding.dbg_X` → `binding.telemetry.dbg_X`,
+   `self.dbg_X` → `self.telemetry.dbg_X`,
+   `b.dbg_X` → `b.telemetry.dbg_X`,
+   `worker.dbg_X` → `worker.telemetry.dbg_X`,
+   etc.
+   The compiler is exhaustive — every miss fails the build.
+6. **Important**: do NOT touch `snap.dbg_X` (publish snapshot at
+   `coordinator/mod.rs:1218`), `live.dbg_X` (BindingLiveState in
+   tests), or any access on the `BindingLiveState` mirror at
+   `umem/mod.rs:763`. These are different types; the compiler
+   protects us.
+7. `cargo build --release` clean.
+8. `cargo test --release` clean.
+9. Smoke v4 + v6.
+
+## Why compiler-driven beats sed
+
+- **Sed risk**: `binding` and `self` are not unique tokens. A
+  separate `BindingStatus` snapshot struct in `coordinator/mod.rs`
+  is read into a local also named `binding` (see lines 1218-1225,
+  1348-1351). A regex `s/binding\.dbg_/.../g` would corrupt those
+  callsites.
+- **Compiler risk**: zero. The compiler knows the type of each
+  receiver. Removing the fields from BindingWorker fails every
+  BindingWorker access; the snapshot/atomic mirrors keep their own
+  fields and are unaffected.
+- **Cost**: the compiler walks ~30-50 callsites to fix manually
+  instead of one-shot sed. Trade safety for editing time. For a
+  refactor that must not regress the data-plane, compiler-driven is
+  the right choice.
+
+## Acceptance
+
+- `go build ./...` (Go side untouched, but verify nothing leaked).
+- `cargo build --release` clean.
+- `cargo test --release` — all tests pass.
+- v4 smoke against `172.16.80.200` — 0 retr.
+- v6 smoke against `2001:559:8585:80::200` — 0 retr.
+- Codex + Gemini hostile code review on the resulting PR.
+
+## Risks
+
+1. **Sed misses.** Fields that appear in `format!` / `info!` /
+   `eprintln!` calls (unlikely but possible). Mitigation: build will
+   fail on any miss; fix and re-build.
+2. **Other structs mirror these field names.** The publish-snapshot
+   struct at `worker/mod.rs:1851+` has `dbg_tx_ring_full`,
+   `dbg_sendto_enobufs`, etc. Sed must NOT touch that struct's
+   fields. Mitigation: scope sed to BindingWorker call sites only;
+   those use `binding.dbg_*` / `self.dbg_*` patterns, not
+   `snapshot.dbg_*`. Verify by grep before sed.
+3. **Future merge conflicts.** This PR moves 24 fields. If a separate
+   PR adds a new `dbg_*` field, it'll conflict. Mitigation: small
+   focused PR, ship fast.
+
+## NOT in scope (deferred to Phase 2+)
+
+- `scratch_*` extraction into `WorkerScratch` (Phase 2).
+- `cos_*` extraction into `CosEngine` / `ShaperEngine` (Phase 3).
+- XSK rings / device / umem extraction (Phase 4).
+- `pending_direct_tx_*` counters — these are TX-path counters, not
+  generic debug counters; their semantic affinity is different and
+  they may belong with the TX engine extraction in a later phase.
+- `flow_cache*` — flow-cache state, not telemetry.
+- `last_*_ns` timestamps — these gate retry logic, not pure
+  telemetry; out of scope.
+- `#[repr(align(64))]` on the new struct — that's a Phase N
+  optimization once the cache-line layout is measured. Phase 1 just
+  makes the struct exist; alignment is non-functional and adds
+  review surface.
+
+## Phase 2+ preview (not in this PR)
+
+After Phase 1 lands, candidate extractions in priority order:
+- Phase 2: `scratch_*` (11 fields) → `WorkerScratch`
+- Phase 3: `cos_*` (5 fields) → `CosEngine`
+- Phase 4: `pending_direct_tx_*` + `pending_*_packets` counters (6
+  fields) → `TxPipelineCounters`
+- Phase 5: XSK rings (`device`, `rx`, `tx`) → `XskRings` (highest
+  risk; ring borrows are heavily aliased through the codebase)

--- a/docs/pr/959-phase1-telemetry/plan.md
+++ b/docs/pr/959-phase1-telemetry/plan.md
@@ -26,7 +26,7 @@ fields. The 23 `dbg_*` counters are the cleanest extraction target:
 
 ## Scope
 
-Move these 24 fields out of `BindingWorker` into a new
+Move these 23 fields out of `BindingWorker` into a new
 `WorkerTelemetry` struct, aggregated at one field
 `pub(crate) telemetry: WorkerTelemetry`:
 

--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -131,7 +131,7 @@ pub(super) fn service_exact_local_queue_direct(
 
     if inserted == 0 {
         let dropped = binding.scratch_exact_local_tx.len() as u64;
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         release_exact_local_scratch_frames(
@@ -142,7 +142,7 @@ pub(super) fn service_exact_local_queue_direct(
         binding.live.set_error("tx ring insert failed".to_string());
         return false;
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_local_fifo_submission(
@@ -276,7 +276,7 @@ fn service_exact_local_queue_direct_flow_fair(
 
     if inserted == 0 {
         let dropped = binding.scratch_local_tx.len() as u64;
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         restore_exact_local_scratch_to_queue_head_flow_fair(
@@ -291,7 +291,7 @@ fn service_exact_local_queue_direct_flow_fair(
         binding.live.set_error("tx ring insert failed".to_string());
         return false;
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_local_scratch_submission_flow_fair(
@@ -405,7 +405,7 @@ pub(super) fn service_exact_prepared_queue_direct(
                 .slice(req.offset as usize, req.len as usize)
             {
                 if frame_has_tcp_rst(frame_data) {
-                    binding.dbg_tx_tcp_rst += 1;
+                    binding.telemetry.dbg_tx_tcp_rst += 1;
                 }
             }
         }
@@ -439,7 +439,7 @@ pub(super) fn service_exact_prepared_queue_direct(
 
     if inserted == 0 {
         let dropped = binding.scratch_exact_prepared_tx.len() as u64;
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         release_exact_prepared_scratch(&mut binding.scratch_exact_prepared_tx);
@@ -449,7 +449,7 @@ pub(super) fn service_exact_prepared_queue_direct(
             .set_error("prepared tx ring insert failed".to_string());
         return false;
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_fifo_submission(
@@ -552,7 +552,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
                 .slice(req.offset as usize, req.len as usize)
             {
                 if frame_has_tcp_rst(frame_data) {
-                    binding.dbg_tx_tcp_rst += 1;
+                    binding.telemetry.dbg_tx_tcp_rst += 1;
                 }
             }
         }
@@ -585,7 +585,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
 
     if inserted == 0 {
         let dropped = binding.scratch_prepared_tx.len() as u64;
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         restore_exact_prepared_scratch_to_queue_head_flow_fair(
@@ -601,7 +601,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
             .set_error("prepared tx ring insert failed".to_string());
         return false;
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_scratch_submission_flow_fair(

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -799,7 +799,7 @@ fn enqueue_cos_item(
     // the bound-pending FIFO evict sites; the two are now tracked on
     // separate counters so operators can disambiguate CoS shaping
     // pressure from bound-pending pressure.
-    binding.dbg_cos_queue_overflow += 1;
+    binding.telemetry.dbg_cos_queue_overflow += 1;
     binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
     binding.live.set_error(format!(
         "class-of-service queue overflow on ifindex {} queue {}",

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -15,7 +15,7 @@ pub(in crate::afxdp) fn bound_pending_tx_local(binding: &mut BindingWorker) {
             // #804: bound-pending FIFO overflow — distinct from the CoS
             // queue admission overflow counter. Keep this attribution
             // precise so operators can tell which path is dropping.
-            binding.dbg_bound_pending_overflow += 1;
+            binding.telemetry.dbg_bound_pending_overflow += 1;
             binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
             // #710: dedicated drop-reason counter. Subset of tx_errors.
             binding
@@ -37,7 +37,7 @@ pub(in crate::afxdp) fn bound_pending_tx_prepared(binding: &mut BindingWorker) {
             // #804: bound-pending FIFO overflow (prepared side). Same
             // semantic bucket as `bound_pending_tx_local` — internal
             // prepared/local distinction is irrelevant to operators.
-            binding.dbg_bound_pending_overflow += 1;
+            binding.telemetry.dbg_bound_pending_overflow += 1;
             recycle_prepared_immediately(binding, &req);
             binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
             // #710: same drop category — prepared vs local FIFO is an

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -59,7 +59,7 @@ pub(in crate::afxdp) fn reap_tx_completions(
         recycle_completed_tx_offset(binding, shared_recycles, offset);
     }
     binding.outstanding_tx = binding.outstanding_tx.saturating_sub(reaped);
-    binding.dbg_completions_reaped += reaped as u64;
+    binding.telemetry.dbg_completions_reaped += reaped as u64;
     binding
         .live
         .tx_completions
@@ -101,15 +101,15 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
         inserted
     };
     if inserted == 0 {
-        binding.dbg_fill_failed += binding.scratch_fill.len() as u64;
+        binding.telemetry.dbg_fill_failed += binding.scratch_fill.len() as u64;
         for offset in binding.scratch_fill.drain(..).rev() {
             binding.pending_fill_frames.push_front(offset);
         }
         return false;
     }
-    binding.dbg_fill_submitted += inserted as u64;
+    binding.telemetry.dbg_fill_submitted += inserted as u64;
     if inserted < binding.scratch_fill.len() as u32 {
-        binding.dbg_fill_failed += (binding.scratch_fill.len() as u32 - inserted) as u64;
+        binding.telemetry.dbg_fill_failed += (binding.scratch_fill.len() as u32 - inserted) as u64;
         for offset in binding.scratch_fill.drain(inserted as usize..).rev() {
             binding.pending_fill_frames.push_front(offset);
         }
@@ -157,10 +157,10 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
     };
     let rc = unsafe { libc::poll(&mut pfd, 1, 0) };
     if rc >= 0 {
-        binding.dbg_rx_wake_sendto_ok += 1;
+        binding.telemetry.dbg_rx_wake_sendto_ok += 1;
     } else {
-        binding.dbg_rx_wake_sendto_err += 1;
-        binding.dbg_rx_wake_sendto_errno = unsafe { *libc::__errno_location() };
+        binding.telemetry.dbg_rx_wake_sendto_err += 1;
+        binding.telemetry.dbg_rx_wake_sendto_errno = unsafe { *libc::__errno_location() };
     }
     // Also sendto for TX completions (needed for copy mode and TX kick).
     unsafe {
@@ -173,7 +173,7 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
             0,
         );
     }
-    binding.dbg_rx_wakeups += 1;
+    binding.telemetry.dbg_rx_wakeups += 1;
     binding.live.rx_wakeups.fetch_add(1, Ordering::Relaxed);
     binding.last_rx_wake_ns = now_ns;
     binding.empty_rx_polls = 0;
@@ -236,7 +236,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
             )
         };
         let kick_end = monotonic_nanos();
-        binding.dbg_sendto_calls += 1;
+        binding.telemetry.dbg_sendto_calls += 1;
         // #825 plan §3.3 LOW-3 R1 sentinel, code-review R1 HIGH-1 hardening:
         // skip record unless (a) `kick_start != 0` AND (b) `kick_end >=
         // kick_start`. Both guards are required:
@@ -260,7 +260,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
             let errno = unsafe { *libc::__errno_location() };
             // EAGAIN/EWOULDBLOCK is normal for MSG_DONTWAIT; ENOBUFS means kernel dropped.
             if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK {
-                binding.dbg_sendto_eagain += 1;
+                binding.telemetry.dbg_sendto_eagain += 1;
                 // #825 plan §3.3 site 1 / §5: parallel atomic to
                 // `dbg_sendto_eagain` (which is worker-local and
                 // never published). Counts outer `sendto` returns
@@ -275,8 +275,8 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                     .tx_kick_retry_count
                     .fetch_add(1, Ordering::Relaxed);
             } else if errno == libc::ENOBUFS {
-                binding.dbg_sendto_enobufs += 1;
-                if binding.dbg_sendto_enobufs <= 10 {
+                binding.telemetry.dbg_sendto_enobufs += 1;
+                if binding.telemetry.dbg_sendto_enobufs <= 10 {
                     eprintln!(
                         "TX_ENOBUFS: slot={} if={} q={} outstanding_tx={} free_tx={}",
                         binding.slot,
@@ -287,8 +287,8 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                     );
                 }
             } else {
-                binding.dbg_sendto_err += 1;
-                if binding.dbg_sendto_err <= 5 {
+                binding.telemetry.dbg_sendto_err += 1;
+                if binding.telemetry.dbg_sendto_err <= 5 {
                     eprintln!(
                         "DBG SENDTO_ERR: slot={} if={} q={} errno={} outstanding_tx={} free_tx={}",
                         binding.slot,

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -136,7 +136,7 @@ pub(in crate::afxdp) fn transmit_batch(
         // RST detection: log when we're about to transmit a TCP RST
         if cfg!(feature = "debug-log") {
             if frame_has_tcp_rst(&req.bytes) {
-                binding.dbg_tx_tcp_rst += 1;
+                binding.telemetry.dbg_tx_tcp_rst += 1;
                 thread_local! {
                     static TX_RST_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
                 }
@@ -208,7 +208,7 @@ pub(in crate::afxdp) fn transmit_batch(
     );
 
     if inserted == 0 {
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         maybe_wake_tx(binding, true, now_ns);
         while let Some((offset, req)) = binding.scratch_local_tx.pop() {
             binding.free_tx_frames.push_front(offset);
@@ -216,7 +216,7 @@ pub(in crate::afxdp) fn transmit_batch(
         }
         return Err(TxError::Retry("tx ring insert failed".to_string()));
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let mut sent_packets = 0u64;
@@ -377,7 +377,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
                 .slice(req.offset as usize, req.len as usize)
             {
                 if frame_has_tcp_rst(frame_data) {
-                    binding.dbg_tx_tcp_rst += 1;
+                    binding.telemetry.dbg_tx_tcp_rst += 1;
                     thread_local! {
                         static PREP_TX_RST_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
                     }
@@ -441,14 +441,14 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     );
 
     if inserted == 0 {
-        binding.dbg_tx_ring_full += 1;
+        binding.telemetry.dbg_tx_ring_full += 1;
         maybe_wake_tx(binding, true, now_ns);
         while let Some(req) = binding.scratch_prepared_tx.pop() {
             pending.push_front(req);
         }
         return Err(TxError::Retry("prepared tx ring insert failed".to_string()));
     }
-    binding.dbg_tx_ring_submitted += inserted as u64;
+    binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
     binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
 
     let mut sent_packets = 0u64;

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -76,7 +76,7 @@ pub(super) fn poll_binding(
     );
     let fill_work = drain_pending_fill(binding, now_ns);
     let mut did_work = tx_work || fill_work;
-    binding.dbg_poll_cycles += 1;
+    binding.telemetry.dbg_poll_cycles += 1;
     let mut counters = BatchCounters::default();
     let mut ident: Option<BindingIdentity> = None;
     for _ in 0..MAX_RX_BATCHES_PER_POLL {
@@ -84,7 +84,7 @@ pub(super) fn poll_binding(
         // fill ring exhaustion. The NIC holds packets until we refill (#201).
         let tx_backlog = binding.pending_tx_local.len() + binding.pending_tx_prepared.len();
         if tx_backlog >= binding.max_pending_tx {
-            binding.dbg_backpressure += 1;
+            binding.telemetry.dbg_backpressure += 1;
             // Try to drain TX first — completions free frames for both TX and fill.
             let _ = drain_pending_tx(
                 binding,
@@ -120,17 +120,17 @@ pub(super) fn poll_binding(
         }
         if cfg!(feature = "debug-log") {
             if raw_avail > 0 {
-                binding.dbg_rx_avail_nonzero += 1;
-                if raw_avail > binding.dbg_rx_avail_max {
-                    binding.dbg_rx_avail_max = raw_avail;
+                binding.telemetry.dbg_rx_avail_nonzero += 1;
+                if raw_avail > binding.telemetry.dbg_rx_avail_max {
+                    binding.telemetry.dbg_rx_avail_max = raw_avail;
                 }
             }
             // Ring diagnostics are only consumed by debug-log summaries.
-            binding.dbg_fill_pending = binding.device.pending();
-            binding.dbg_device_avail = binding.device.available();
+            binding.telemetry.dbg_fill_pending = binding.device.pending();
+            binding.telemetry.dbg_device_avail = binding.device.available();
         }
         if available == 0 {
-            binding.dbg_rx_empty += 1;
+            binding.telemetry.dbg_rx_empty += 1;
             maybe_wake_rx(binding, false, now_ns);
             // Check pending neighbor buffer even when RX is empty.
             // Without this, buffered SYN packets wait until the next

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -5,6 +5,10 @@ use super::*;
 mod lifecycle;
 use lifecycle::poll_binding;
 
+// #959 Phase 1: per-worker debug counters live in worker/telemetry.rs.
+mod telemetry;
+pub(crate) use telemetry::WorkerTelemetry;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -113,40 +117,10 @@ pub(crate) struct BindingWorker {
     pub(crate) outstanding_tx: u32,
     pub(crate) empty_rx_polls: u32,
     pub(crate) last_learned_neighbor: Option<LearnedNeighborKey>,
-    pub(crate) dbg_fill_submitted: u64,
-    pub(crate) dbg_fill_failed: u64,
-    pub(crate) dbg_poll_cycles: u64,
-    pub(crate) dbg_backpressure: u64,
-    pub(crate) dbg_rx_empty: u64,
-    pub(crate) dbg_rx_wakeups: u64,
-    // TX pipeline debug counters
-    pub(crate) dbg_tx_ring_submitted: u64, // descriptors inserted into TX ring
-    pub(crate) dbg_tx_ring_full: u64,      // times TX ring insert returned 0
-    pub(crate) dbg_completions_reaped: u64, // completion descriptors read
-    pub(crate) dbg_sendto_calls: u64,      // number of sendto/wake calls
-    pub(crate) dbg_sendto_err: u64,        // sendto returned error (non-EAGAIN/ENOBUFS)
-    pub(crate) dbg_sendto_eagain: u64,     // sendto returned EAGAIN/EWOULDBLOCK
-    pub(crate) dbg_sendto_enobufs: u64,    // sendto returned ENOBUFS (kernel TX drop)
-    // #802/#804: per-binding bound-pending FIFO overflow — incremented at
-    // the `bound_pending_tx_local`/`bound_pending_tx_prepared` evict
-    // sites only. Pre-#804 this counter was named `dbg_pending_overflow`
-    // and also doubled as the CoS admission overflow accumulator; the
-    // two semantics are now tracked on separate fields so operators can
-    // tell which path is dropping.
-    pub(crate) dbg_bound_pending_overflow: u64,
-    // #804: per-binding class-of-service queue admission overflow —
-    // incremented in `enqueue_cos_item()` when the CoS admission gate
-    // rejects the item.
-    pub(crate) dbg_cos_queue_overflow: u64,
-    pub(crate) dbg_tx_tcp_rst: u64,        // TCP RST packets transmitted
-    // Ring diagnostics — raw values from xsk_ffi API
-    pub(crate) dbg_rx_avail_nonzero: u64, // times rx.available() > 0
-    pub(crate) dbg_rx_avail_max: u32,     // max rx.available() seen this interval
-    pub(crate) dbg_fill_pending: u32,     // fill ring: userspace produced - kernel consumed
-    pub(crate) dbg_device_avail: u32,     // device queue available (completion ring pending)
-    pub(crate) dbg_rx_wake_sendto_ok: u64, // sendto() returned >= 0 in maybe_wake_rx
-    pub(crate) dbg_rx_wake_sendto_err: u64, // sendto() returned < 0 in maybe_wake_rx
-    pub(crate) dbg_rx_wake_sendto_errno: i32, // last errno from sendto in maybe_wake_rx
+    /// #959 Phase 1: 23 `dbg_*` debug counters extracted into
+    /// `WorkerTelemetry` to reduce BindingWorker's mutable surface
+    /// area. Field semantics unchanged; access via `binding.telemetry.telemetry.dbg_X`.
+    pub(crate) telemetry: WorkerTelemetry,
     pub(crate) pending_direct_tx_packets: u64,
     pub(crate) pending_copy_tx_packets: u64,
     pub(crate) pending_in_place_tx_packets: u64,
@@ -418,29 +392,7 @@ impl BindingWorker {
             outstanding_tx: 0,
             empty_rx_polls: 0,
             last_learned_neighbor: None,
-            dbg_fill_submitted: 0,
-            dbg_fill_failed: 0,
-            dbg_poll_cycles: 0,
-            dbg_backpressure: 0,
-            dbg_rx_empty: 0,
-            dbg_rx_wakeups: 0,
-            dbg_tx_ring_submitted: 0,
-            dbg_tx_ring_full: 0,
-            dbg_completions_reaped: 0,
-            dbg_sendto_calls: 0,
-            dbg_sendto_err: 0,
-            dbg_sendto_eagain: 0,
-            dbg_sendto_enobufs: 0,
-            dbg_bound_pending_overflow: 0,
-            dbg_cos_queue_overflow: 0,
-            dbg_tx_tcp_rst: 0,
-            dbg_rx_avail_nonzero: 0,
-            dbg_rx_avail_max: 0,
-            dbg_fill_pending: 0,
-            dbg_device_avail: 0,
-            dbg_rx_wake_sendto_ok: 0,
-            dbg_rx_wake_sendto_err: 0,
-            dbg_rx_wake_sendto_errno: 0,
+            telemetry: WorkerTelemetry::default(),
             pending_direct_tx_packets: 0,
             pending_copy_tx_packets: 0,
             pending_in_place_tx_packets: 0,
@@ -1153,32 +1105,32 @@ pub(crate) fn worker_loop(
                         ptx_local,
                         total_accounted,
                         expected_total,
-                        b.dbg_fill_submitted,
-                        b.dbg_poll_cycles,
-                        b.dbg_backpressure,
-                        b.dbg_rx_empty,
-                        b.dbg_rx_wakeups,
+                        b.telemetry.dbg_fill_submitted,
+                        b.telemetry.dbg_poll_cycles,
+                        b.telemetry.dbg_backpressure,
+                        b.telemetry.dbg_rx_empty,
+                        b.telemetry.dbg_rx_wakeups,
                     );
                     // TX pipeline debug counters
                     #[cfg(feature = "debug-log")]
                     {
-                        dbg_tx_tcp_rst += b.dbg_tx_tcp_rst;
+                        dbg_tx_tcp_rst += b.telemetry.dbg_tx_tcp_rst;
                     }
                     let _ = write!(
                         binding_summary,
                         " TX:ring_sub={}/ring_full={}/compl={}/sendto={}/err={}/eagain={}/enobufs={}/bp_overflow={}/cos_overflow={}",
-                        b.dbg_tx_ring_submitted,
-                        b.dbg_tx_ring_full,
-                        b.dbg_completions_reaped,
-                        b.dbg_sendto_calls,
-                        b.dbg_sendto_err,
-                        b.dbg_sendto_eagain,
-                        b.dbg_sendto_enobufs,
-                        b.dbg_bound_pending_overflow,
-                        b.dbg_cos_queue_overflow,
+                        b.telemetry.dbg_tx_ring_submitted,
+                        b.telemetry.dbg_tx_ring_full,
+                        b.telemetry.dbg_completions_reaped,
+                        b.telemetry.dbg_sendto_calls,
+                        b.telemetry.dbg_sendto_err,
+                        b.telemetry.dbg_sendto_eagain,
+                        b.telemetry.dbg_sendto_enobufs,
+                        b.telemetry.dbg_bound_pending_overflow,
+                        b.telemetry.dbg_cos_queue_overflow,
                     );
                     #[cfg(feature = "debug-log")]
-                    let _ = write!(binding_summary, "/rst={}", b.dbg_tx_tcp_rst);
+                    let _ = write!(binding_summary, "/rst={}", b.telemetry.dbg_tx_tcp_rst);
                     if let Some(s) = xsk_stats {
                         let _ = write!(
                             binding_summary,
@@ -1214,13 +1166,13 @@ pub(crate) fn worker_loop(
                         let _ = write!(
                             binding_summary,
                             " RING:rx_nz={}/rx_max={}/fill_pend={}/dev_avail={} RX_WAKE:ok={}/err={}/errno={}",
-                            b.dbg_rx_avail_nonzero,
-                            b.dbg_rx_avail_max,
-                            b.dbg_fill_pending,
-                            b.dbg_device_avail,
-                            b.dbg_rx_wake_sendto_ok,
-                            b.dbg_rx_wake_sendto_err,
-                            b.dbg_rx_wake_sendto_errno,
+                            b.telemetry.dbg_rx_avail_nonzero,
+                            b.telemetry.dbg_rx_avail_max,
+                            b.telemetry.dbg_fill_pending,
+                            b.telemetry.dbg_device_avail,
+                            b.telemetry.dbg_rx_wake_sendto_ok,
+                            b.telemetry.dbg_rx_wake_sendto_err,
+                            b.telemetry.dbg_rx_wake_sendto_errno,
                         );
                         // Direct mmap diagnosis: read raw ring producer/consumer
                         if let Some((rxp, rxc, frp, frc, txp, txc, crp, crc)) =
@@ -1503,32 +1455,32 @@ pub(crate) fn worker_loop(
                 for b in bindings.iter_mut() {
                     // #802: publish ring-pressure counters into BindingLiveState
                     // BEFORE resetting the worker-local window. The worker-local
-                    // counters (b.dbg_tx_ring_full, etc.) are accumulated by the
+                    // counters (b.telemetry.dbg_tx_ring_full, etc.) are accumulated by the
                     // hot path and reset each ~1s debug tick; without this
                     // publish they'd never be visible outside the worker thread.
                     // fetch_add is used because the atomic holds the cumulative
                     // total while the local counter holds only the current
                     // window. Relaxed is sufficient — diagnostic counters, no
                     // synchronization contract.
-                    if b.dbg_tx_ring_full != 0 {
+                    if b.telemetry.dbg_tx_ring_full != 0 {
                         b.live
                             .dbg_tx_ring_full
-                            .fetch_add(b.dbg_tx_ring_full, Ordering::Relaxed);
+                            .fetch_add(b.telemetry.dbg_tx_ring_full, Ordering::Relaxed);
                     }
-                    if b.dbg_sendto_enobufs != 0 {
+                    if b.telemetry.dbg_sendto_enobufs != 0 {
                         b.live
                             .dbg_sendto_enobufs
-                            .fetch_add(b.dbg_sendto_enobufs, Ordering::Relaxed);
+                            .fetch_add(b.telemetry.dbg_sendto_enobufs, Ordering::Relaxed);
                     }
-                    if b.dbg_bound_pending_overflow != 0 {
+                    if b.telemetry.dbg_bound_pending_overflow != 0 {
                         b.live
                             .dbg_bound_pending_overflow
-                            .fetch_add(b.dbg_bound_pending_overflow, Ordering::Relaxed);
+                            .fetch_add(b.telemetry.dbg_bound_pending_overflow, Ordering::Relaxed);
                     }
-                    if b.dbg_cos_queue_overflow != 0 {
+                    if b.telemetry.dbg_cos_queue_overflow != 0 {
                         b.live
                             .dbg_cos_queue_overflow
-                            .fetch_add(b.dbg_cos_queue_overflow, Ordering::Relaxed);
+                            .fetch_add(b.telemetry.dbg_cos_queue_overflow, Ordering::Relaxed);
                     }
                     // #802: kernel xdp_statistics.rx_fill_ring_empty_descs is
                     // already absolute (kernel-cumulative), so publish with
@@ -1573,30 +1525,30 @@ pub(crate) fn worker_loop(
                         .umem_inflight_frames
                         .store(inflight, Ordering::Relaxed);
 
-                    b.dbg_fill_submitted = 0;
-                    b.dbg_fill_failed = 0;
-                    b.dbg_poll_cycles = 0;
-                    b.dbg_backpressure = 0;
-                    b.dbg_rx_empty = 0;
-                    b.dbg_rx_wakeups = 0;
-                    b.dbg_tx_ring_submitted = 0;
-                    b.dbg_tx_ring_full = 0;
-                    b.dbg_completions_reaped = 0;
-                    b.dbg_sendto_calls = 0;
-                    b.dbg_sendto_err = 0;
-                    b.dbg_sendto_eagain = 0;
-                    b.dbg_sendto_enobufs = 0;
-                    b.dbg_bound_pending_overflow = 0;
-                    b.dbg_cos_queue_overflow = 0;
+                    b.telemetry.dbg_fill_submitted = 0;
+                    b.telemetry.dbg_fill_failed = 0;
+                    b.telemetry.dbg_poll_cycles = 0;
+                    b.telemetry.dbg_backpressure = 0;
+                    b.telemetry.dbg_rx_empty = 0;
+                    b.telemetry.dbg_rx_wakeups = 0;
+                    b.telemetry.dbg_tx_ring_submitted = 0;
+                    b.telemetry.dbg_tx_ring_full = 0;
+                    b.telemetry.dbg_completions_reaped = 0;
+                    b.telemetry.dbg_sendto_calls = 0;
+                    b.telemetry.dbg_sendto_err = 0;
+                    b.telemetry.dbg_sendto_eagain = 0;
+                    b.telemetry.dbg_sendto_enobufs = 0;
+                    b.telemetry.dbg_bound_pending_overflow = 0;
+                    b.telemetry.dbg_cos_queue_overflow = 0;
                     #[cfg(feature = "debug-log")]
                     {
-                        b.dbg_tx_tcp_rst = 0;
+                        b.telemetry.dbg_tx_tcp_rst = 0;
                     }
-                    b.dbg_rx_avail_nonzero = 0;
-                    b.dbg_rx_avail_max = 0;
-                    b.dbg_rx_wake_sendto_ok = 0;
-                    b.dbg_rx_wake_sendto_err = 0;
-                    b.dbg_rx_wake_sendto_errno = 0;
+                    b.telemetry.dbg_rx_avail_nonzero = 0;
+                    b.telemetry.dbg_rx_avail_max = 0;
+                    b.telemetry.dbg_rx_wake_sendto_ok = 0;
+                    b.telemetry.dbg_rx_wake_sendto_err = 0;
+                    b.telemetry.dbg_rx_wake_sendto_errno = 0;
                 }
             }
         }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -119,7 +119,7 @@ pub(crate) struct BindingWorker {
     pub(crate) last_learned_neighbor: Option<LearnedNeighborKey>,
     /// #959 Phase 1: 23 `dbg_*` debug counters extracted into
     /// `WorkerTelemetry` to reduce BindingWorker's mutable surface
-    /// area. Field semantics unchanged; access via `binding.telemetry.telemetry.dbg_X`.
+    /// area. Field semantics unchanged; access via `binding.telemetry.dbg_X`.
     pub(crate) telemetry: WorkerTelemetry,
     pub(crate) pending_direct_tx_packets: u64,
     pub(crate) pending_copy_tx_packets: u64,

--- a/userspace-dp/src/afxdp/worker/telemetry.rs
+++ b/userspace-dp/src/afxdp/worker/telemetry.rs
@@ -1,0 +1,46 @@
+//! #959 Phase 1 — extracts the `dbg_*` debug counters out of
+//! `BindingWorker` into a dedicated `WorkerTelemetry` sub-struct.
+//!
+//! Pure structural extraction: no semantic change, no alignment hint,
+//! no field reordering beyond what's necessary to hold the 23
+//! counters in a coherent group. Phase 2+ may add `#[repr(align(64))]`
+//! once the cache-line layout is profiled.
+
+/// Per-worker debug telemetry counters incremented from the data-
+/// plane hot path. Read sites (formatting, max-window comparison)
+/// are minimal and confined to the per-second debug tick; see
+/// `worker/lifecycle.rs` and `tx/rings.rs`.
+///
+/// Field semantics are documented at each callsite in the worker
+/// implementation; this struct preserves the names verbatim so that
+/// existing log lines, gRPC snapshot fields, and operator runbooks
+/// continue to work.
+#[derive(Debug, Default)]
+pub(crate) struct WorkerTelemetry {
+    pub(crate) dbg_fill_submitted: u64,
+    pub(crate) dbg_fill_failed: u64,
+    pub(crate) dbg_poll_cycles: u64,
+    pub(crate) dbg_backpressure: u64,
+    pub(crate) dbg_rx_empty: u64,
+    pub(crate) dbg_rx_wakeups: u64,
+    // TX pipeline debug counters
+    pub(crate) dbg_tx_ring_submitted: u64,
+    pub(crate) dbg_tx_ring_full: u64,
+    pub(crate) dbg_completions_reaped: u64,
+    pub(crate) dbg_sendto_calls: u64,
+    pub(crate) dbg_sendto_err: u64,
+    pub(crate) dbg_sendto_eagain: u64,
+    pub(crate) dbg_sendto_enobufs: u64,
+    // #802/#804: per-binding bound-pending / CoS overflow counters
+    pub(crate) dbg_bound_pending_overflow: u64,
+    pub(crate) dbg_cos_queue_overflow: u64,
+    pub(crate) dbg_tx_tcp_rst: u64,
+    // Ring diagnostics — raw values from xsk_ffi
+    pub(crate) dbg_rx_avail_nonzero: u64,
+    pub(crate) dbg_rx_avail_max: u32,
+    pub(crate) dbg_fill_pending: u32,
+    pub(crate) dbg_device_avail: u32,
+    pub(crate) dbg_rx_wake_sendto_ok: u64,
+    pub(crate) dbg_rx_wake_sendto_err: u64,
+    pub(crate) dbg_rx_wake_sendto_errno: i32,
+}

--- a/userspace-dp/src/afxdp/worker/telemetry.rs
+++ b/userspace-dp/src/afxdp/worker/telemetry.rs
@@ -6,10 +6,10 @@
 //! counters in a coherent group. Phase 2+ may add `#[repr(align(64))]`
 //! once the cache-line layout is profiled.
 
-/// Per-worker debug telemetry counters incremented from the data-
-/// plane hot path. Read sites (formatting, max-window comparison)
-/// are minimal and confined to the per-second debug tick; see
-/// `worker/lifecycle.rs` and `tx/rings.rs`.
+/// Per-worker debug telemetry counters incremented from the
+/// data-plane hot path. Read sites (formatting, max-window
+/// comparison) are minimal and confined to the per-second debug
+/// tick; see `worker/lifecycle.rs` and `tx/rings.rs`.
 ///
 /// Field semantics are documented at each callsite in the worker
 /// implementation; this struct preserves the names verbatim so that


### PR DESCRIPTION
## Summary

First phase of **#959** BindingWorker decomposition. Moves the 23
`dbg_*` debug counters out of `BindingWorker` (currently 80+ fields)
into a new `WorkerTelemetry` sub-struct, accessed via
`binding.telemetry.dbg_X`.

Closes #1125 (already closed as duplicate).

## Methodology

**Compiler-driven, NOT sed-driven.** Plan-review round-1 (Codex)
caught that name-only sed would corrupt three other types that
share the `dbg_*` field-name prefix:

- `binding.dbg_X` in `coordinator/mod.rs` accesses a different
  `BindingStatus` snapshot struct.
- `live.dbg_X` in tests accesses `BindingLiveState` atomics.
- `b.live.dbg_X` in the worker's per-second publish path also
  accesses `BindingLiveState`.

Workflow:

1. Define `pub(crate) struct WorkerTelemetry` (`worker/telemetry.rs`).
2. Add `pub(crate) telemetry: WorkerTelemetry` to BindingWorker.
3. Remove the 23 individual `dbg_*` fields from BindingWorker.
4. The Rust compiler walks every callsite that referenced a removed
   field and reports E0609.
5. Each error site rewrites `X.dbg_Y` → `X.telemetry.dbg_Y`.

The compiler protects against collisions: BindingLiveState's mirror
`dbg_*` fields and the snapshot struct's `dbg_*` fields keep their
direct-field access because they're different types entirely. Only
the 7 files that actually access BindingWorker's `dbg_*` fields
needed editing.

## Files changed

| File | Change |
|------|--------|
| `userspace-dp/src/afxdp/worker/telemetry.rs` | new, 50 LOC |
| `userspace-dp/src/afxdp/worker/mod.rs` | -30 fields, +9 (mod, use, struct field, init) |
| `userspace-dp/src/afxdp/worker/lifecycle.rs` | rewrite ~10 callsites |
| `userspace-dp/src/afxdp/cos/queue_service/service.rs` | ~10 callsites |
| `userspace-dp/src/afxdp/tx/cos_classify.rs` | 1 callsite |
| `userspace-dp/src/afxdp/tx/drain.rs` | 2 callsites |
| `userspace-dp/src/afxdp/tx/rings.rs` | ~10 callsites |
| `userspace-dp/src/afxdp/tx/transmit.rs` | ~10 callsites |

## Test plan

- [x] `cargo build --release` — clean (just 93 pre-existing warnings)
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `go build ./...` — clean (Go side untouched)
- [x] `go test ./...` — all 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 958 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke `2001:559:8585:80::200` — 944 Mbps, 0 retr

## NOT in scope

Phase 2+ extractions deferred:
- `scratch_*` (11 fields) → `WorkerScratch`
- `cos_*` (5 fields) → `CosEngine`
- `pending_direct_tx_*` counters → `TxPipelineCounters`
- XSK rings → `XskRings` (highest risk)
- `#[repr(align(64))]` cache-line alignment

## Plan

`docs/pr/959-phase1-telemetry/plan.md` (committed in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)