### PR TITLE
#959 Phase 2: extract scratch_* buffers into WorkerScratch sub-struct

### DIFF
--- a/docs/pr/959-phase2-scratch/plan.md
+++ b/docs/pr/959-phase2-scratch/plan.md
@@ -1,0 +1,68 @@
+# Plan: #959 Phase 2 — extract `scratch_*` into `WorkerScratch`
+
+## Status
+
+Phase 2 of #959 BindingWorker decomposition. Phase 1 shipped via
+#1167 (23 `dbg_*` counters → `WorkerTelemetry`).
+
+## Scope
+
+Move the 11 `scratch_*` reusable buffers out of `BindingWorker` into
+a new `WorkerScratch` sub-struct accessed via
+`binding.scratch.scratch_X`:
+
+```
+scratch_recycle, scratch_forwards, scratch_fill,
+scratch_prepared_tx, scratch_local_tx,
+scratch_exact_prepared_tx, scratch_exact_local_tx,
+scratch_completed_offsets, scratch_post_recycles,
+scratch_cross_binding_tx, scratch_rst_teardowns
+```
+
+These are pre-allocated in `BindingWorker::create` and reused every
+poll cycle (cleared at the top, pushed-to as the descriptor loop
+produces work). No allocation pattern change; pure structural
+extraction.
+
+## Methodology
+
+Same compiler-driven approach as Phase 1 (#1167):
+
+1. New file `userspace-dp/src/afxdp/worker/scratch.rs` defining
+   `pub(crate) struct WorkerScratch` with `Default` derived.
+2. Add `pub(crate) scratch: WorkerScratch` to `BindingWorker`.
+3. Remove the 11 individual `scratch_*` fields.
+4. Update the `Self { … }` initializer at
+   `worker/mod.rs:348-376` (BindingWorker::create) to populate the
+   nested `scratch: WorkerScratch { … }` block. The capacity hints
+   stay attached to each Vec — no runtime change.
+5. Compiler walks every E0609. Each error rewrites
+   `X.scratch_Y` → `X.scratch.scratch_Y`. Mechanical sed scoped to
+   the 6 affected files.
+
+## Files affected (6 edited + 1 new)
+
+- new: `userspace-dp/src/afxdp/worker/scratch.rs`
+- edit: `userspace-dp/src/afxdp/worker/mod.rs`
+- edit: `userspace-dp/src/afxdp/worker/lifecycle.rs`
+- edit: `userspace-dp/src/afxdp/poll_descriptor.rs`
+- edit: `userspace-dp/src/afxdp/cos/queue_service/service.rs`
+- edit: `userspace-dp/src/afxdp/tx/transmit.rs`
+- edit: `userspace-dp/src/afxdp/tx/rings.rs`
+
+118 callsites total.
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed (no count change vs Phase 1).
+- `go build ./... && go test ./...` clean.
+- v4 + v6 smoke against `172.16.80.200` / `2001:559:8585:80::200`.
+- Codex + Gemini hostile review.
+
+## NOT in scope
+
+- `cos_*` (5 fields) → Phase 3.
+- `pending_direct_tx_*` counters → Phase 4.
+- XSK rings → Phase 5.
+- `#[repr(align(64))]` — deferred.

--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -37,7 +37,7 @@ pub(super) fn service_exact_local_queue_direct(
         let _ = reap_tx_completions(binding, shared_recycles);
     }
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
-    binding.scratch_exact_local_tx.clear();
+    binding.scratch.scratch_exact_local_tx.clear();
     let root_budget = binding
         .cos_interfaces
         .get(&root_ifindex)
@@ -55,7 +55,7 @@ pub(super) fn service_exact_local_queue_direct(
         drain_exact_local_fifo_items_to_scratch(
             queue,
             &mut binding.free_tx_frames,
-            &mut binding.scratch_exact_local_tx,
+            &mut binding.scratch.scratch_exact_local_tx,
             binding.umem.area(),
             root_budget,
             secondary_budget,
@@ -70,7 +70,7 @@ pub(super) fn service_exact_local_queue_direct(
         } => {
             release_exact_local_scratch_frames(
                 &mut binding.free_tx_frames,
-                &mut binding.scratch_exact_local_tx,
+                &mut binding.scratch.scratch_exact_local_tx,
             );
             if dropped_bytes > 0 {
                 subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
@@ -89,7 +89,7 @@ pub(super) fn service_exact_local_queue_direct(
             return false;
         }
     }
-    if binding.scratch_exact_local_tx.is_empty() {
+    if binding.scratch.scratch_exact_local_tx.is_empty() {
         maybe_wake_tx(binding, true, now_ns);
         binding
             .live
@@ -99,8 +99,8 @@ pub(super) fn service_exact_local_queue_direct(
 
     let mut writer = binding
         .tx
-        .transmit(binding.scratch_exact_local_tx.len() as u32);
-    let inserted = writer.insert(binding.scratch_exact_local_tx.iter().map(|req| XdpDesc {
+        .transmit(binding.scratch.scratch_exact_local_tx.len() as u32);
+    let inserted = writer.insert(binding.scratch.scratch_exact_local_tx.iter().map(|req| XdpDesc {
         addr: req.offset,
         len: req.len,
         options: 0,
@@ -122,7 +122,7 @@ pub(super) fn service_exact_local_queue_direct(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_exact_local_tx
+            .scratch.scratch_exact_local_tx
             .iter()
             .take(inserted as usize)
             .map(|req| req.offset),
@@ -130,13 +130,13 @@ pub(super) fn service_exact_local_queue_direct(
     );
 
     if inserted == 0 {
-        let dropped = binding.scratch_exact_local_tx.len() as u64;
+        let dropped = binding.scratch.scratch_exact_local_tx.len() as u64;
         binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         release_exact_local_scratch_frames(
             &mut binding.free_tx_frames,
-            &mut binding.scratch_exact_local_tx,
+            &mut binding.scratch.scratch_exact_local_tx,
         );
         refresh_cos_interface_activity(binding, root_ifindex);
         binding.live.set_error("tx ring insert failed".to_string());
@@ -151,7 +151,7 @@ pub(super) fn service_exact_local_queue_direct(
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.free_tx_frames,
-        &mut binding.scratch_exact_local_tx,
+        &mut binding.scratch.scratch_exact_local_tx,
         inserted as usize,
     );
     // #940: post-settle V_min publish. FIFO queues currently have
@@ -181,7 +181,7 @@ fn service_exact_local_queue_direct_flow_fair(
         let _ = reap_tx_completions(binding, shared_recycles);
     }
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
-    binding.scratch_local_tx.clear();
+    binding.scratch.scratch_local_tx.clear();
     let root_budget = binding
         .cos_interfaces
         .get(&root_ifindex)
@@ -199,7 +199,7 @@ fn service_exact_local_queue_direct_flow_fair(
         drain_exact_local_items_to_scratch_flow_fair(
             queue,
             &mut binding.free_tx_frames,
-            &mut binding.scratch_local_tx,
+            &mut binding.scratch.scratch_local_tx,
             binding.umem.area(),
             root_budget,
             secondary_budget,
@@ -218,7 +218,7 @@ fn service_exact_local_queue_direct_flow_fair(
                     .get_mut(&root_ifindex)
                     .and_then(|root| root.queues.get_mut(queue_idx)),
                 &mut binding.free_tx_frames,
-                &mut binding.scratch_local_tx,
+                &mut binding.scratch.scratch_local_tx,
             );
             if dropped_bytes > 0 {
                 subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
@@ -237,7 +237,7 @@ fn service_exact_local_queue_direct_flow_fair(
             return false;
         }
     }
-    if binding.scratch_local_tx.is_empty() {
+    if binding.scratch.scratch_local_tx.is_empty() {
         maybe_wake_tx(binding, true, now_ns);
         binding
             .live
@@ -245,10 +245,10 @@ fn service_exact_local_queue_direct_flow_fair(
         return false;
     }
 
-    let mut writer = binding.tx.transmit(binding.scratch_local_tx.len() as u32);
+    let mut writer = binding.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
     let inserted = writer.insert(
         binding
-            .scratch_local_tx
+            .scratch.scratch_local_tx
             .iter()
             .map(|(offset, req)| XdpDesc {
                 addr: *offset,
@@ -267,7 +267,7 @@ fn service_exact_local_queue_direct_flow_fair(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_local_tx
+            .scratch.scratch_local_tx
             .iter()
             .take(inserted as usize)
             .map(|(offset, _)| *offset),
@@ -275,7 +275,7 @@ fn service_exact_local_queue_direct_flow_fair(
     );
 
     if inserted == 0 {
-        let dropped = binding.scratch_local_tx.len() as u64;
+        let dropped = binding.scratch.scratch_local_tx.len() as u64;
         binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
@@ -285,7 +285,7 @@ fn service_exact_local_queue_direct_flow_fair(
                 .get_mut(&root_ifindex)
                 .and_then(|root| root.queues.get_mut(queue_idx)),
             &mut binding.free_tx_frames,
-            &mut binding.scratch_local_tx,
+            &mut binding.scratch.scratch_local_tx,
         );
         refresh_cos_interface_activity(binding, root_ifindex);
         binding.live.set_error("tx ring insert failed".to_string());
@@ -300,7 +300,7 @@ fn service_exact_local_queue_direct_flow_fair(
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.free_tx_frames,
-        &mut binding.scratch_local_tx,
+        &mut binding.scratch.scratch_local_tx,
         inserted as usize,
     );
     // #940: post-settle V_min publish. Settle has already applied
@@ -342,7 +342,7 @@ pub(super) fn service_exact_prepared_queue_direct(
         );
     }
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
-    binding.scratch_exact_prepared_tx.clear();
+    binding.scratch.scratch_exact_prepared_tx.clear();
     let root_budget = binding
         .cos_interfaces
         .get(&root_ifindex)
@@ -359,7 +359,7 @@ pub(super) fn service_exact_prepared_queue_direct(
         };
         drain_exact_prepared_fifo_items_to_scratch(
             queue,
-            &mut binding.scratch_exact_prepared_tx,
+            &mut binding.scratch.scratch_exact_prepared_tx,
             binding.umem.area(),
             &mut binding.free_tx_frames,
             &mut binding.pending_fill_frames,
@@ -375,7 +375,7 @@ pub(super) fn service_exact_prepared_queue_direct(
             error,
             dropped_bytes,
         } => {
-            release_exact_prepared_scratch(&mut binding.scratch_exact_prepared_tx);
+            release_exact_prepared_scratch(&mut binding.scratch.scratch_exact_prepared_tx);
             if dropped_bytes > 0 {
                 subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
             } else {
@@ -393,12 +393,12 @@ pub(super) fn service_exact_prepared_queue_direct(
             return false;
         }
     }
-    if binding.scratch_exact_prepared_tx.is_empty() {
+    if binding.scratch.scratch_exact_prepared_tx.is_empty() {
         return false;
     }
 
     if cfg!(feature = "debug-log") {
-        for req in &binding.scratch_exact_prepared_tx {
+        for req in &binding.scratch.scratch_exact_prepared_tx {
             if let Some(frame_data) = binding
                 .umem
                 .area()
@@ -413,8 +413,8 @@ pub(super) fn service_exact_prepared_queue_direct(
 
     let mut writer = binding
         .tx
-        .transmit(binding.scratch_exact_prepared_tx.len() as u32);
-    let inserted = writer.insert(binding.scratch_exact_prepared_tx.iter().map(|req| XdpDesc {
+        .transmit(binding.scratch.scratch_exact_prepared_tx.len() as u32);
+    let inserted = writer.insert(binding.scratch.scratch_exact_prepared_tx.iter().map(|req| XdpDesc {
         addr: req.offset,
         len: req.len,
         options: 0,
@@ -430,7 +430,7 @@ pub(super) fn service_exact_prepared_queue_direct(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_exact_prepared_tx
+            .scratch.scratch_exact_prepared_tx
             .iter()
             .take(inserted as usize)
             .map(|req| req.offset),
@@ -438,11 +438,11 @@ pub(super) fn service_exact_prepared_queue_direct(
     );
 
     if inserted == 0 {
-        let dropped = binding.scratch_exact_prepared_tx.len() as u64;
+        let dropped = binding.scratch.scratch_exact_prepared_tx.len() as u64;
         binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
-        release_exact_prepared_scratch(&mut binding.scratch_exact_prepared_tx);
+        release_exact_prepared_scratch(&mut binding.scratch.scratch_exact_prepared_tx);
         refresh_cos_interface_activity(binding, root_ifindex);
         binding
             .live
@@ -457,7 +457,7 @@ pub(super) fn service_exact_prepared_queue_direct(
             .cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
-        &mut binding.scratch_exact_prepared_tx,
+        &mut binding.scratch.scratch_exact_prepared_tx,
         &mut binding.in_flight_prepared_recycles,
         inserted as usize,
     );
@@ -483,7 +483,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     now_ns: u64,
 ) -> bool {
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
-    binding.scratch_prepared_tx.clear();
+    binding.scratch.scratch_prepared_tx.clear();
     let root_budget = binding
         .cos_interfaces
         .get(&root_ifindex)
@@ -500,7 +500,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
         };
         drain_exact_prepared_items_to_scratch_flow_fair(
             queue,
-            &mut binding.scratch_prepared_tx,
+            &mut binding.scratch.scratch_prepared_tx,
             binding.umem.area(),
             &mut binding.free_tx_frames,
             &mut binding.pending_fill_frames,
@@ -521,7 +521,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
                     .cos_interfaces
                     .get_mut(&root_ifindex)
                     .and_then(|root| root.queues.get_mut(queue_idx)),
-                &mut binding.scratch_prepared_tx,
+                &mut binding.scratch.scratch_prepared_tx,
             );
             if dropped_bytes > 0 {
                 subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
@@ -540,12 +540,12 @@ fn service_exact_prepared_queue_direct_flow_fair(
             return false;
         }
     }
-    if binding.scratch_prepared_tx.is_empty() {
+    if binding.scratch.scratch_prepared_tx.is_empty() {
         return false;
     }
 
     if cfg!(feature = "debug-log") {
-        for req in &binding.scratch_prepared_tx {
+        for req in &binding.scratch.scratch_prepared_tx {
             if let Some(frame_data) = binding
                 .umem
                 .area()
@@ -560,8 +560,8 @@ fn service_exact_prepared_queue_direct_flow_fair(
 
     let mut writer = binding
         .tx
-        .transmit(binding.scratch_prepared_tx.len() as u32);
-    let inserted = writer.insert(binding.scratch_prepared_tx.iter().map(|req| XdpDesc {
+        .transmit(binding.scratch.scratch_prepared_tx.len() as u32);
+    let inserted = writer.insert(binding.scratch.scratch_prepared_tx.iter().map(|req| XdpDesc {
         addr: req.offset,
         len: req.len,
         options: 0,
@@ -576,7 +576,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_prepared_tx
+            .scratch.scratch_prepared_tx
             .iter()
             .take(inserted as usize)
             .map(|req| req.offset),
@@ -584,7 +584,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     );
 
     if inserted == 0 {
-        let dropped = binding.scratch_prepared_tx.len() as u64;
+        let dropped = binding.scratch.scratch_prepared_tx.len() as u64;
         binding.telemetry.dbg_tx_ring_full += 1;
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
@@ -593,7 +593,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
                 .cos_interfaces
                 .get_mut(&root_ifindex)
                 .and_then(|root| root.queues.get_mut(queue_idx)),
-            &mut binding.scratch_prepared_tx,
+            &mut binding.scratch.scratch_prepared_tx,
         );
         refresh_cos_interface_activity(binding, root_ifindex);
         binding
@@ -609,7 +609,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
             .cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
-        &mut binding.scratch_prepared_tx,
+        &mut binding.scratch.scratch_prepared_tx,
         &mut binding.in_flight_prepared_recycles,
         inserted as usize,
     );

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -34,9 +34,9 @@ pub(super) fn poll_binding_process_descriptor(
     telemetry: &mut TelemetryContext,
 ) {
         let mut received = binding.rx.receive(available);
-        binding.scratch_recycle.clear();
-        binding.scratch_forwards.clear();
-        binding.scratch_rst_teardowns.clear();
+        binding.scratch.scratch_recycle.clear();
+        binding.scratch.scratch_forwards.clear();
+        binding.scratch.scratch_rst_teardowns.clear();
         while let Some(desc) = received.read() {
             record_rx_descriptor_telemetry(desc, area, telemetry, worker_ctx);
             let mut recycle_now = true;
@@ -49,7 +49,7 @@ pub(super) fn poll_binding_process_descriptor(
                     let Some(raw_frame) =
                         unsafe { &*area }.slice(desc.addr as usize, desc.len as usize)
                     else {
-                        binding.scratch_recycle.push(desc.addr);
+                        binding.scratch.scratch_recycle.push(desc.addr);
                         continue;
                     };
                     // #947: ARP classification + reply parsing extracted to
@@ -72,11 +72,11 @@ pub(super) fn poll_binding_process_descriptor(
                             )
                             .unwrap_or(meta.ingress_ifindex as i32);
                             add_kernel_neighbor(neigh_ifindex, arp.sender_ip, arp.sender_mac);
-                            binding.scratch_recycle.push(desc.addr);
+                            binding.scratch.scratch_recycle.push(desc.addr);
                             continue;
                         }
                         parser::ArpClassification::OtherArp => {
-                            binding.scratch_recycle.push(desc.addr);
+                            binding.scratch.scratch_recycle.push(desc.addr);
                             continue;
                         }
                         parser::ArpClassification::NotArp => {}
@@ -179,7 +179,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     screen.check_packet(zone_name, &screen_pkt, now_secs)
                                 {
                                     binding.live.screen_drops.fetch_add(1, Ordering::Relaxed);
-                                    binding.scratch_recycle.push(desc.addr);
+                                    binding.scratch.scratch_recycle.push(desc.addr);
                                     continue;
                                 }
                             }
@@ -217,7 +217,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 "slow_path",
                                 worker_ctx.forwarding,
                             );
-                            binding.scratch_recycle.push(desc.addr);
+                            binding.scratch.scratch_recycle.push(desc.addr);
                             continue;
                         }
                     }
@@ -290,7 +290,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         now_secs,
                                     );
                                     if let Some(request) = local_icmp_te {
-                                        binding.scratch_forwards.push(request);
+                                        binding.scratch.scratch_forwards.push(request);
                                         // Don't recycle here — enqueue_pending_forwards
                                         // returns the frame via pending_fill_frames
                                         // when processing the prebuilt TE response.
@@ -422,13 +422,13 @@ pub(super) fn poll_binding_process_descriptor(
                                                 .unwrap_or(PendingForwardFrame::Live);
                                             telemetry.dbg.forward += 1;
                                             telemetry.dbg.tx += 1;
-                                            binding.scratch_forwards.push(request);
+                                            binding.scratch.scratch_forwards.push(request);
                                             recycle_now = false;
                                         }
                                     }
                                 }
                                 if recycle_now {
-                                    binding.scratch_recycle.push(desc.addr);
+                                    binding.scratch.scratch_recycle.push(desc.addr);
                                 }
                                 continue;
                             } // else: cached HA-valid — fast path above
@@ -528,7 +528,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     now_secs,
                                 );
                                 if let Some(request) = local_icmp_te {
-                                    binding.scratch_forwards.push(request);
+                                    binding.scratch.scratch_forwards.push(request);
                                     // Don't recycle: the TE response references
                                     // the original frame via desc.addr on the request.
                                     // The continue skips recycle_now handling.
@@ -600,7 +600,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             true,
                                         );
                                     }
-                                    binding.scratch_forwards.push(request);
+                                    binding.scratch.scratch_forwards.push(request);
                                     continue;
                                 }
                             }
@@ -991,7 +991,7 @@ pub(super) fn poll_binding_process_descriptor(
                                                 meta,
                                                 None,
                                             );
-                                            binding.scratch_forwards.push(PendingForwardRequest {
+                                            binding.scratch.scratch_forwards.push(PendingForwardRequest {
                                                 target_ifindex,
                                                 target_binding_index: worker_ctx.binding_lookup.target_index(
                                                     binding_index,
@@ -1177,7 +1177,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         now_secs,
                                     );
                                     if let Some(request) = local_icmp_te {
-                                        binding.scratch_forwards.push(request);
+                                        binding.scratch.scratch_forwards.push(request);
                                         recycle_now = false;
                                     } else {
                                         let mut created = 0u64;
@@ -1786,7 +1786,7 @@ pub(super) fn poll_binding_process_descriptor(
                             && let Some(flow) = flow.as_ref()
                         {
                             binding
-                                .scratch_rst_teardowns
+                                .scratch.scratch_rst_teardowns
                                 .push((flow.forward_key.clone(), decision.nat));
                         }
                         telemetry.counters.forward_candidate_packets += 1;
@@ -1865,7 +1865,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 }
                             }
                             let request_target_binding_index = request.target_binding_index;
-                            binding.scratch_forwards.push(request);
+                            binding.scratch.scratch_forwards.push(request);
                             recycle_now = false;
                             // ── Flow cache population ────────────────────
                             // Cache ForwardCandidate decisions for established
@@ -2203,7 +2203,7 @@ pub(super) fn poll_binding_process_descriptor(
                 );
             }
             if recycle_now {
-                binding.scratch_recycle.push(desc.addr);
+                binding.scratch.scratch_recycle.push(desc.addr);
             }
         }
         received.release();

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -29,10 +29,10 @@ pub(in crate::afxdp) fn reap_tx_completions(
         return 0;
     }
     let mut reaped = 0u32;
-    binding.scratch_completed_offsets.clear();
+    binding.scratch.scratch_completed_offsets.clear();
     let mut completed = binding.device.complete(available);
     while let Some(offset) = completed.read() {
-        binding.scratch_completed_offsets.push(offset);
+        binding.scratch.scratch_completed_offsets.push(offset);
         reaped += 1;
     }
     completed.release();
@@ -50,12 +50,12 @@ pub(in crate::afxdp) fn reap_tx_completions(
     // pins under `#[cfg(test)]` below.
     record_tx_completions_with_stamp(
         &mut binding.tx_submit_ns,
-        &binding.scratch_completed_offsets,
+        &binding.scratch.scratch_completed_offsets,
         ts_completion,
         &binding.live.owner_profile_owner,
     );
-    for i in 0..binding.scratch_completed_offsets.len() {
-        let offset = binding.scratch_completed_offsets[i];
+    for i in 0..binding.scratch.scratch_completed_offsets.len() {
+        let offset = binding.scratch.scratch_completed_offsets[i];
         recycle_completed_tx_offset(binding, shared_recycles, offset);
     }
     binding.outstanding_tx = binding.outstanding_tx.saturating_sub(reaped);
@@ -73,8 +73,8 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
         return false;
     }
     let batch_size = binding.pending_fill_frames.len().min(FILL_BATCH_SIZE);
-    binding.scratch_fill.clear();
-    while binding.scratch_fill.len() < batch_size {
+    binding.scratch.scratch_fill.clear();
+    while binding.scratch.scratch_fill.len() < batch_size {
         let Some(offset) = binding.pending_fill_frames.pop_front() else {
             break;
         };
@@ -89,32 +89,32 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
                 frame.copy_from_slice(&0xDEAD_BEEF_DEAD_BEEFu64.to_ne_bytes());
             }
         }
-        binding.scratch_fill.push(offset);
+        binding.scratch.scratch_fill.push(offset);
     }
-    if binding.scratch_fill.is_empty() {
+    if binding.scratch.scratch_fill.is_empty() {
         return false;
     }
     let inserted = {
-        let mut fill = binding.device.fill(binding.scratch_fill.len() as u32);
-        let inserted = fill.insert(binding.scratch_fill.iter().copied());
+        let mut fill = binding.device.fill(binding.scratch.scratch_fill.len() as u32);
+        let inserted = fill.insert(binding.scratch.scratch_fill.iter().copied());
         fill.commit();
         inserted
     };
     if inserted == 0 {
-        binding.telemetry.dbg_fill_failed += binding.scratch_fill.len() as u64;
-        for offset in binding.scratch_fill.drain(..).rev() {
+        binding.telemetry.dbg_fill_failed += binding.scratch.scratch_fill.len() as u64;
+        for offset in binding.scratch.scratch_fill.drain(..).rev() {
             binding.pending_fill_frames.push_front(offset);
         }
         return false;
     }
     binding.telemetry.dbg_fill_submitted += inserted as u64;
-    if inserted < binding.scratch_fill.len() as u32 {
-        binding.telemetry.dbg_fill_failed += (binding.scratch_fill.len() as u32 - inserted) as u64;
-        for offset in binding.scratch_fill.drain(inserted as usize..).rev() {
+    if inserted < binding.scratch.scratch_fill.len() as u32 {
+        binding.telemetry.dbg_fill_failed += (binding.scratch.scratch_fill.len() as u32 - inserted) as u64;
+        for offset in binding.scratch.scratch_fill.drain(inserted as usize..).rev() {
             binding.pending_fill_frames.push_front(offset);
         }
     }
-    binding.scratch_fill.clear();
+    binding.scratch.scratch_fill.clear();
     // Only wake NAPI when the kernel signals it needs fill ring entries,
     // or as a safety net every FILL_WAKE_SAFETY_INTERVAL_NS to prevent
     // lost-wakeup stalls from the race between commit() and needs_wakeup.

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -91,8 +91,8 @@ pub(in crate::afxdp) fn transmit_batch(
         return Err(TxError::Retry("no free TX frame available".to_string()));
     }
 
-    binding.scratch_local_tx.clear();
-    while binding.scratch_local_tx.len() < batch_size {
+    binding.scratch.scratch_local_tx.clear();
+    while binding.scratch.scratch_local_tx.len() < batch_size {
         let Some(mut req) = pending.pop_front() else {
             break;
         };
@@ -101,7 +101,7 @@ pub(in crate::afxdp) fn transmit_batch(
         }
         if req.bytes.len() > tx_frame_capacity() {
             // Unwind already-prepared entries before returning.
-            for (off, r) in binding.scratch_local_tx.drain(..) {
+            for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
                 binding.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }
@@ -123,7 +123,7 @@ pub(in crate::afxdp) fn transmit_batch(
         }) else {
             binding.free_tx_frames.push_front(offset);
             // Unwind already-prepared entries before returning.
-            for (off, r) in binding.scratch_local_tx.drain(..) {
+            for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
                 binding.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }
@@ -165,18 +165,18 @@ pub(in crate::afxdp) fn transmit_batch(
                 });
             }
         }
-        binding.scratch_local_tx.push((offset, req));
+        binding.scratch.scratch_local_tx.push((offset, req));
     }
 
-    if binding.scratch_local_tx.is_empty() {
+    if binding.scratch.scratch_local_tx.is_empty() {
         maybe_wake_tx(binding, true, now_ns);
         return Err(TxError::Retry("no prepared TX frame available".to_string()));
     }
 
-    let mut writer = binding.tx.transmit(binding.scratch_local_tx.len() as u32);
+    let mut writer = binding.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
     let inserted = writer.insert(
         binding
-            .scratch_local_tx
+            .scratch.scratch_local_tx
             .iter()
             .map(|(offset, req)| XdpDesc {
                 addr: *offset,
@@ -200,7 +200,7 @@ pub(in crate::afxdp) fn transmit_batch(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_local_tx
+            .scratch.scratch_local_tx
             .iter()
             .take(inserted as usize)
             .map(|(offset, _)| *offset),
@@ -210,7 +210,7 @@ pub(in crate::afxdp) fn transmit_batch(
     if inserted == 0 {
         binding.telemetry.dbg_tx_ring_full += 1;
         maybe_wake_tx(binding, true, now_ns);
-        while let Some((offset, req)) = binding.scratch_local_tx.pop() {
+        while let Some((offset, req)) = binding.scratch.scratch_local_tx.pop() {
             binding.free_tx_frames.push_front(offset);
             pending.push_front(req);
         }
@@ -222,7 +222,7 @@ pub(in crate::afxdp) fn transmit_batch(
     let mut sent_packets = 0u64;
     let mut sent_bytes = 0u64;
     let mut retry_tail = Vec::new();
-    for (idx, (offset, req)) in binding.scratch_local_tx.drain(..).enumerate() {
+    for (idx, (offset, req)) in binding.scratch.scratch_local_tx.drain(..).enumerate() {
         if idx < inserted as usize {
             sent_packets += 1;
             sent_bytes += req.bytes.len() as u64;
@@ -260,13 +260,13 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
         return Ok((0, 0));
     }
     let batch_size = pending.len().min(TX_BATCH_SIZE);
-    binding.scratch_prepared_tx.clear();
-    while binding.scratch_prepared_tx.len() < batch_size {
+    binding.scratch.scratch_prepared_tx.clear();
+    while binding.scratch.scratch_prepared_tx.len() < batch_size {
         let Some(req) = pending.pop_front() else {
             break;
         };
         if req.len as usize > tx_frame_capacity() {
-            let orphaned: Vec<_> = binding.scratch_prepared_tx.drain(..).collect();
+            let orphaned: Vec<_> = binding.scratch.scratch_prepared_tx.drain(..).collect();
             recycle_prepared_immediately(binding, &req);
             for r in &orphaned {
                 recycle_prepared_immediately(binding, r);
@@ -292,12 +292,12 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
                 tx_frame_capacity()
             )));
         }
-        binding.scratch_prepared_tx.push(req);
+        binding.scratch.scratch_prepared_tx.push(req);
     }
-    if binding.scratch_prepared_tx.is_empty() {
+    if binding.scratch.scratch_prepared_tx.is_empty() {
         return Ok((0, 0));
     }
-    for req in &binding.scratch_prepared_tx {
+    for req in &binding.scratch.scratch_prepared_tx {
         let Some(dscp_rewrite) = req.dscp_rewrite else {
             continue;
         };
@@ -309,7 +309,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
         }) else {
             let err_offset = req.offset;
             let err_len = req.len;
-            let orphaned: Vec<_> = binding.scratch_prepared_tx.drain(..).collect();
+            let orphaned: Vec<_> = binding.scratch.scratch_prepared_tx.drain(..).collect();
             for r in &orphaned {
                 recycle_prepared_immediately(binding, r);
             }
@@ -333,7 +333,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
         };
         let _ = apply_dscp_rewrite_to_frame(frame, dscp_rewrite);
     }
-    for req in &binding.scratch_prepared_tx {
+    for req in &binding.scratch.scratch_prepared_tx {
         if binding
             .umem
             .area()
@@ -342,7 +342,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
         {
             let err_offset = req.offset;
             let err_len = req.len;
-            let orphaned: Vec<_> = binding.scratch_prepared_tx.drain(..).collect();
+            let orphaned: Vec<_> = binding.scratch.scratch_prepared_tx.drain(..).collect();
             for r in &orphaned {
                 recycle_prepared_immediately(binding, r);
             }
@@ -370,7 +370,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
 
     // RST detection on prepared TX path: check UMEM frames before submitting to TX ring
     if cfg!(feature = "debug-log") {
-        for req in &binding.scratch_prepared_tx {
+        for req in &binding.scratch.scratch_prepared_tx {
             if let Some(frame_data) = binding
                 .umem
                 .area()
@@ -412,8 +412,8 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
 
     let mut writer = binding
         .tx
-        .transmit(binding.scratch_prepared_tx.len() as u32);
-    let inserted = writer.insert(binding.scratch_prepared_tx.iter().map(|req| XdpDesc {
+        .transmit(binding.scratch.scratch_prepared_tx.len() as u32);
+    let inserted = writer.insert(binding.scratch.scratch_prepared_tx.iter().map(|req| XdpDesc {
         addr: req.offset,
         len: req.len,
         options: 0,
@@ -433,7 +433,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     stamp_submits(
         &mut binding.tx_submit_ns,
         binding
-            .scratch_prepared_tx
+            .scratch.scratch_prepared_tx
             .iter()
             .take(inserted as usize)
             .map(|req| req.offset),
@@ -443,7 +443,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     if inserted == 0 {
         binding.telemetry.dbg_tx_ring_full += 1;
         maybe_wake_tx(binding, true, now_ns);
-        while let Some(req) = binding.scratch_prepared_tx.pop() {
+        while let Some(req) = binding.scratch.scratch_prepared_tx.pop() {
             pending.push_front(req);
         }
         return Err(TxError::Retry("prepared tx ring insert failed".to_string()));
@@ -454,7 +454,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     let mut sent_packets = 0u64;
     let mut sent_bytes = 0u64;
     let mut retry_tail = Vec::new();
-    for (idx, req) in binding.scratch_prepared_tx.drain(..).enumerate() {
+    for (idx, req) in binding.scratch.scratch_prepared_tx.drain(..).enumerate() {
         if idx < inserted as usize {
             remember_prepared_recycle(&mut binding.in_flight_prepared_recycles, &req);
             sent_packets += 1;

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -204,8 +204,8 @@ pub(super) fn poll_binding(
             &worker_ctx,
             &mut telemetry,
         );
-        let mut pending_forwards = core::mem::take(&mut binding.scratch_forwards);
-        let mut rst_teardowns = core::mem::take(&mut binding.scratch_rst_teardowns);
+        let mut pending_forwards = core::mem::take(&mut binding.scratch.scratch_forwards);
+        let mut rst_teardowns = core::mem::take(&mut binding.scratch.scratch_rst_teardowns);
         for (forward_key, nat) in rst_teardowns.drain(..) {
             // Evict from flow cache so stale entries aren't used after RST.
             // #918: 4-way set-associative cache requires walking the set
@@ -228,14 +228,14 @@ pub(super) fn poll_binding(
                 &mut pending_forwards,
             );
         }
-        binding.scratch_rst_teardowns = rst_teardowns;
+        binding.scratch.scratch_rst_teardowns = rst_teardowns;
         if !pending_forwards.is_empty() {
             // Use raw pointer to avoid Arc::clone (~5% CPU from lock incq).
             // Safety: the Arc<BindingLiveState> outlives this function call;
             // binding is borrowed mutably by enqueue_pending_forwards but
             // ingress_live is only used for read-only error logging inside it.
             let ingress_live: *const BindingLiveState = &*binding.live;
-            let mut scratch_post_recycles = core::mem::take(&mut binding.scratch_post_recycles);
+            let mut scratch_post_recycles = core::mem::take(&mut binding.scratch.scratch_post_recycles);
             enqueue_pending_forwards(
                 left,
                 binding_index,
@@ -257,9 +257,9 @@ pub(super) fn poll_binding(
                 cos_owner_worker_by_queue,
                 cos_owner_live_by_queue,
             );
-            binding.scratch_post_recycles = scratch_post_recycles;
+            binding.scratch.scratch_post_recycles = scratch_post_recycles;
         }
-        binding.scratch_forwards = pending_forwards;
+        binding.scratch.scratch_forwards = pending_forwards;
         // Reserved: cross-binding in-place TX from flow cache fast path.
         // Currently only self-target (hairpin) uses the inline path;
         // cross-binding goes through enqueue_pending_forwards above.
@@ -280,10 +280,10 @@ pub(super) fn poll_binding(
             binding_lookup,
             shared_recycles,
         );
-        if !binding.scratch_recycle.is_empty() {
+        if !binding.scratch.scratch_recycle.is_empty() {
             binding
                 .pending_fill_frames
-                .extend(binding.scratch_recycle.drain(..));
+                .extend(binding.scratch.scratch_recycle.drain(..));
         }
         let _ = drain_pending_fill(binding, now_ns);
         counters.rx_batches += 1;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -65,7 +65,7 @@ pub(crate) struct BindingWorker {
     pub(crate) pending_fill_frames: VecDeque<u64>,
     /// #959 Phase 2: 11 `scratch_*` reusable buffers extracted into
     /// `WorkerScratch`. Field semantics unchanged; access via
-    /// `binding.scratch.scratch.scratch_X`.
+    /// `binding.scratch.scratch_X`.
     pub(crate) scratch: WorkerScratch,
     /// #812: per-UMEM-frame submit timestamp sidecar. Indexed by
     /// `offset >> UMEM_FRAME_SHIFT`. Pre-allocated once at binding

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -9,6 +9,11 @@ use lifecycle::poll_binding;
 mod telemetry;
 pub(crate) use telemetry::WorkerTelemetry;
 
+// #959 Phase 2: per-binding reusable scratch buffers live in
+// worker/scratch.rs.
+mod scratch;
+pub(crate) use scratch::WorkerScratch;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -58,15 +63,10 @@ pub(crate) struct BindingWorker {
     pub(crate) cos_interface_rr: usize,
     pub(crate) cos_nonempty_interfaces: usize,
     pub(crate) pending_fill_frames: VecDeque<u64>,
-    pub(crate) scratch_recycle: Vec<u64>,
-    pub(crate) scratch_forwards: Vec<PendingForwardRequest>,
-    pub(crate) scratch_fill: Vec<u64>,
-    pub(crate) scratch_prepared_tx: Vec<PreparedTxRequest>,
-    pub(crate) scratch_local_tx: Vec<(u64, TxRequest)>,
-    pub(crate) scratch_exact_prepared_tx: Vec<ExactPreparedScratchTxRequest>,
-    pub(crate) scratch_exact_local_tx: Vec<ExactLocalScratchTxRequest>,
-    pub(crate) scratch_completed_offsets: Vec<u64>,
-    pub(crate) scratch_post_recycles: Vec<(u32, u64)>,
+    /// #959 Phase 2: 11 `scratch_*` reusable buffers extracted into
+    /// `WorkerScratch`. Field semantics unchanged; access via
+    /// `binding.scratch.scratch.scratch_X`.
+    pub(crate) scratch: WorkerScratch,
     /// #812: per-UMEM-frame submit timestamp sidecar. Indexed by
     /// `offset >> UMEM_FRAME_SHIFT`. Pre-allocated once at binding
     /// construction (length = total UMEM frames) so the hot-path
@@ -99,12 +99,6 @@ pub(crate) struct BindingWorker {
     /// Packets waiting for neighbor resolution. The UMEM frame is held
     /// (not recycled) until the neighbor resolves or the entry times out.
     pub(crate) pending_neigh: VecDeque<PendingNeighPacket>,
-    /// Flow cache fast-path: cross-binding in-place rewrites deferred
-    /// until after the RX batch (borrow checker prevents mutable access
-    /// to two bindings simultaneously inside the RX loop).
-    #[allow(dead_code)] // reserved for cross-binding fast-path
-    pub(crate) scratch_cross_binding_tx: Vec<(usize, PreparedTxRequest)>,
-    pub(crate) scratch_rst_teardowns: Vec<(SessionKey, NatDecision)>,
     pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
     pub(crate) heartbeat_map_fd: c_int,
     pub(crate) session_map_fd: c_int,
@@ -351,15 +345,19 @@ impl BindingWorker {
             cos_interface_rr: 0,
             cos_nonempty_interfaces: 0,
             pending_fill_frames: VecDeque::new(),
-            scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
-            scratch_forwards: Vec::with_capacity(RX_BATCH_SIZE as usize),
-            scratch_fill: Vec::with_capacity(FILL_BATCH_SIZE),
-            scratch_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
-            scratch_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
-            scratch_exact_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
-            scratch_exact_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
-            scratch_completed_offsets: Vec::with_capacity(ring_entries as usize),
-            scratch_post_recycles: Vec::with_capacity(RX_BATCH_SIZE as usize),
+            scratch: WorkerScratch {
+                scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_forwards: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_fill: Vec::with_capacity(FILL_BATCH_SIZE),
+                scratch_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_exact_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_exact_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_completed_offsets: Vec::with_capacity(ring_entries as usize),
+                scratch_post_recycles: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_cross_binding_tx: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_rst_teardowns: Vec::with_capacity(16),
+            },
             // #812: pre-allocate the submit-timestamp sidecar once,
             // sized to the binding's total UMEM frame count so every
             // legal `offset >> UMEM_FRAME_SHIFT` index lands inside
@@ -378,8 +376,6 @@ impl BindingWorker {
             // idle. Start at 0 capacity and let VecDeque grow on push as
             // packets actually queue up.
             pending_neigh: VecDeque::new(),
-            scratch_cross_binding_tx: Vec::with_capacity(RX_BATCH_SIZE as usize),
-            scratch_rst_teardowns: Vec::with_capacity(16),
             in_flight_prepared_recycles: FastMap::default(),
             heartbeat_map_fd,
             session_map_fd,
@@ -1076,7 +1072,7 @@ pub(crate) fn worker_loop(
                     let rx_avail = b.rx.available_relaxed();
                     let xsk_stats = b.device.statistics_v2().ok();
                     let inflight_recycles = b.in_flight_prepared_recycles.len() as u32;
-                    let scratch_recycle_len = b.scratch_recycle.len() as u32;
+                    let scratch_recycle_len = b.scratch.scratch_recycle.len() as u32;
                     let ptx_prepared = b.pending_tx_prepared.len() as u32;
                     let ptx_local = b.pending_tx_local.len() as u32;
                     let total_accounted = b.pending_fill_frames.len() as u32
@@ -1352,7 +1348,7 @@ pub(crate) fn worker_loop(
                                 + sb.free_tx_frames.len() as u32
                                 + sb.outstanding_tx
                                 + ifl
-                                + sb.scratch_recycle.len() as u32
+                                + sb.scratch.scratch_recycle.len() as u32
                                 + ptxp;
                             let raw = diagnose_raw_ring_state(sb.rx.as_raw_fd());
                             let mut stall_line = format!(

--- a/userspace-dp/src/afxdp/worker/scratch.rs
+++ b/userspace-dp/src/afxdp/worker/scratch.rs
@@ -1,0 +1,39 @@
+//! #959 Phase 2 — extracts the per-binding `scratch_*` reusable
+//! buffers out of `BindingWorker` into a dedicated `WorkerScratch`
+//! sub-struct.
+//!
+//! These vectors are pre-allocated once and reused every poll cycle
+//! to avoid per-packet allocations. They're cleared at the start of
+//! each cycle and pushed-to as the descriptor loop produces work for
+//! the TX submit / fill / recycle / cross-binding handoff stages.
+//!
+//! Pure structural extraction: no semantic change, no allocation
+//! change, no field reordering. Field names preserved so the
+//! `binding.scratch.scratch_X` access pattern keeps the same
+//! grep-friendly suffix as the original `binding.scratch_X`.
+
+use super::*;
+
+/// Per-binding reusable scratch buffers cleared each poll cycle.
+///
+/// Naming preserves the historical `scratch_*` prefix inside the
+/// struct so callers find the same field name with `.scratch.` in
+/// front: `binding.scratch.scratch_recycle` (was
+/// `binding.scratch_recycle`).
+#[derive(Default)]
+pub(crate) struct WorkerScratch {
+    pub(crate) scratch_recycle: Vec<u64>,
+    pub(crate) scratch_forwards: Vec<PendingForwardRequest>,
+    pub(crate) scratch_fill: Vec<u64>,
+    pub(crate) scratch_prepared_tx: Vec<PreparedTxRequest>,
+    pub(crate) scratch_local_tx: Vec<(u64, TxRequest)>,
+    pub(crate) scratch_exact_prepared_tx: Vec<ExactPreparedScratchTxRequest>,
+    pub(crate) scratch_exact_local_tx: Vec<ExactLocalScratchTxRequest>,
+    pub(crate) scratch_completed_offsets: Vec<u64>,
+    pub(crate) scratch_post_recycles: Vec<(u32, u64)>,
+    /// Reserved for the cross-binding fast-path (see commentary in
+    /// `BindingWorker`'s original field).
+    #[allow(dead_code)]
+    pub(crate) scratch_cross_binding_tx: Vec<(usize, PreparedTxRequest)>,
+    pub(crate) scratch_rst_teardowns: Vec<(SessionKey, NatDecision)>,
+}

--- a/userspace-dp/src/afxdp/worker/scratch.rs
+++ b/userspace-dp/src/afxdp/worker/scratch.rs
@@ -22,7 +22,14 @@ use super::*;
 /// struct so callers find the same field name with `.scratch.` in
 /// front: `binding.scratch.scratch_recycle` (was
 /// `binding.scratch_recycle`).
-#[derive(Default)]
+///
+/// **Intentionally NOT `Default`.** Codex round-1 review on
+/// PR #1168 flagged that a `#[derive(Default)]` would silently
+/// produce zero-capacity Vecs on accidental
+/// `WorkerScratch::default()` calls, regressing the no-allocation-
+/// on-hot-path contract. The only legal construction path is the
+/// explicit literal in `BindingWorker::create` which carries the
+/// per-Vec `with_capacity` hints.
 pub(crate) struct WorkerScratch {
     pub(crate) scratch_recycle: Vec<u64>,
     pub(crate) scratch_forwards: Vec<PendingForwardRequest>,

--- a/userspace-dp/src/afxdp/worker/scratch.rs
+++ b/userspace-dp/src/afxdp/worker/scratch.rs
@@ -7,10 +7,12 @@
 //! each cycle and pushed-to as the descriptor loop produces work for
 //! the TX submit / fill / recycle / cross-binding handoff stages.
 //!
-//! Pure structural extraction: no semantic change, no allocation
-//! change, no field reordering. Field names preserved so the
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-2. Field names preserved so the
 //! `binding.scratch.scratch_X` access pattern keeps the same
 //! grep-friendly suffix as the original `binding.scratch_X`.
+//! (Rust's default `repr(Rust)` does not guarantee layout, so this
+//! says nothing about field ordering or struct size.)
 
 use super::*;
 
@@ -31,8 +33,11 @@ pub(crate) struct WorkerScratch {
     pub(crate) scratch_exact_local_tx: Vec<ExactLocalScratchTxRequest>,
     pub(crate) scratch_completed_offsets: Vec<u64>,
     pub(crate) scratch_post_recycles: Vec<(u32, u64)>,
-    /// Reserved for the cross-binding fast-path (see commentary in
-    /// `BindingWorker`'s original field).
+    /// Flow cache fast-path: cross-binding in-place rewrites
+    /// deferred until after the RX batch (the borrow checker
+    /// prevents mutable access to two bindings simultaneously
+    /// inside the RX loop). Reserved for the cross-binding
+    /// fast-path; not yet wired (hence `#[allow(dead_code)]`).
     #[allow(dead_code)]
     pub(crate) scratch_cross_binding_tx: Vec<(usize, PreparedTxRequest)>,
     pub(crate) scratch_rst_teardowns: Vec<(SessionKey, NatDecision)>,


### PR DESCRIPTION
## Summary

Phase 2 of **#959** BindingWorker decomposition. Phase 1 shipped via
**#1167** (23 dbg_* counters → WorkerTelemetry).

Moves the 11 `scratch_*` reusable per-binding buffers out of
`BindingWorker` into a new `WorkerScratch` sub-struct accessed via
`binding.scratch.scratch_X`:

| Field |
|-------|
| `scratch_recycle` |
| `scratch_forwards` |
| `scratch_fill` |
| `scratch_prepared_tx` |
| `scratch_local_tx` |
| `scratch_exact_prepared_tx` |
| `scratch_exact_local_tx` |
| `scratch_completed_offsets` |
| `scratch_post_recycles` |
| `scratch_cross_binding_tx` |
| `scratch_rst_teardowns` |

These are pre-allocated in `BindingWorker::create` and reused every
poll cycle (cleared at the top, pushed-to as the descriptor loop
produces work). **No allocation pattern change.** Same
`Vec::with_capacity` calls, same capacities, same lifetimes — they
just live inside a nested struct now.

## Methodology

Same compiler-driven approach as Phase 1:

1. New `worker/scratch.rs` with `WorkerScratch::default()`.
2. Add nested `scratch: WorkerScratch` to BindingWorker.
3. Remove 11 individual `scratch_*` fields.
4. Compiler reports E0609 at each callsite; rewrite
   `X.scratch_Y` → `X.scratch.scratch_Y`. 118 sites total.
5. 6 files edited.

`BindingWorker::create` constructor now populates a nested
`scratch: WorkerScratch { … }` literal carrying all capacity hints.

## Files affected

| File | Change |
|------|--------|
| `userspace-dp/src/afxdp/worker/scratch.rs` | new, 41 LOC |
| `userspace-dp/src/afxdp/worker/mod.rs` | -11 fields, +nested literal |
| `userspace-dp/src/afxdp/worker/lifecycle.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/poll_descriptor.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/cos/queue_service/service.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/tx/transmit.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/tx/rings.rs` | callsite rewrites |

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `go build ./...` + `go test ./...` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 959 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke `2001:559:8585:80::200` — 946 Mbps, 0 retr

## NOT in scope

Phase 3+ deferred:
- `cos_*` (5 fields) → Phase 3
- `pending_direct_tx_*` counters → Phase 4
- XSK rings → Phase 5 (highest risk)
- `#[repr(align(64))]` cache-line alignment — late phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)