### PR TITLE
#959 Phase 3: extract cos_* fields into WorkerCos sub-struct

### DIFF
--- a/docs/pr/959-phase3-cos/plan.md
+++ b/docs/pr/959-phase3-cos/plan.md
@@ -1,0 +1,46 @@
+# Plan: #959 Phase 3 — extract `cos_*` into `WorkerCos`
+
+## Status
+
+Phase 3 of #959. Phase 1 (#1167) extracted `dbg_*` → `WorkerTelemetry`.
+Phase 2 (#1168) extracted `scratch_*` → `WorkerScratch`.
+
+## Scope
+
+Move 5 `cos_*` per-binding CoS scheduling fields out of
+`BindingWorker` into a new `WorkerCos` sub-struct accessed via
+`binding.cos.cos_X`:
+
+```
+cos_fast_interfaces, cos_interfaces, cos_interface_order,
+cos_interface_rr, cos_nonempty_interfaces
+```
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-2.
+
+- New file `userspace-dp/src/afxdp/worker/cos_state.rs`
+  (filename is `cos_state.rs` not `cos.rs` because the
+  `worker::cos` module name is already taken by
+  `worker/cos.rs` which holds runtime helpers — the
+  data-holding sub-struct gets its own file).
+- Replace 5 BindingWorker fields with `pub(crate) cos: WorkerCos`.
+- 12 files affected for callsite rewrite; 102 callsites total.
+- `WorkerCos` has NO `Default` derive (per Phase 2 lesson — the
+  legitimate construction goes through the explicit
+  `BindingWorker::create` literal).
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against `172.16.80.200` / `2001:559:8585:80::200`.
+- Codex + Gemini hostile review.
+
+## NOT in scope
+
+- `pending_direct_tx_*` counters → Phase 4.
+- XSK rings → Phase 5.
+- `#[repr(align(64))]` cache-line alignment — late phase.

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -32,27 +32,27 @@ pub(in crate::afxdp) fn ensure_cos_interface_runtime(
     // forwarding.cos.interfaces + cos_fast_interfaces lookups
     // and the later-pass duplicate. Profiled at 0.9% CPU before
     // this fix.
-    if binding.cos_interfaces.contains_key(&egress_ifindex) {
+    if binding.cos.cos_interfaces.contains_key(&egress_ifindex) {
         return true;
     }
     let Some(config) = forwarding.cos.interfaces.get(&egress_ifindex) else {
         return false;
     };
-    if !binding.cos_fast_interfaces.contains_key(&egress_ifindex) {
+    if !binding.cos.cos_fast_interfaces.contains_key(&egress_ifindex) {
         return false;
     }
     {
         let mut runtime = build_cos_interface_runtime(config, now_ns);
-        if let Some(iface_fast) = binding.cos_fast_interfaces.get(&egress_ifindex) {
+        if let Some(iface_fast) = binding.cos.cos_fast_interfaces.get(&egress_ifindex) {
             apply_cos_queue_flow_fair_promotion(
                 &mut runtime,
                 &iface_fast.queue_fast_path,
                 binding.worker_id,
             );
         }
-        binding.cos_interfaces.insert(egress_ifindex, runtime);
-        binding.cos_interface_order.push(egress_ifindex);
-        binding.cos_interface_order.sort_unstable();
+        binding.cos.cos_interfaces.insert(egress_ifindex, runtime);
+        binding.cos.cos_interface_order.push(egress_ifindex);
+        binding.cos.cos_interface_order.sort_unstable();
     }
     true
 }

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -179,7 +179,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
     worker_commands_by_id: &BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>>,
 ) -> Result<(), PreparedTxRequest> {
     let Some((iface_fast, queue_fast)) = cos_fast_queue(
-        &binding.cos_fast_interfaces,
+        &binding.cos.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     ) else {
@@ -211,7 +211,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
         dscp_rewrite: req.dscp_rewrite,
     };
     if redirect_local_cos_request_to_owner(
-        &binding.cos_fast_interfaces,
+        &binding.cos.cos_fast_interfaces,
         local_req,
         current_worker_id,
         worker_commands_by_id,
@@ -230,7 +230,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
     req: PreparedTxRequest,
 ) -> Result<(), PreparedTxRequest> {
     let Some((iface_fast, queue_fast)) = cos_fast_queue(
-        &binding.cos_fast_interfaces,
+        &binding.cos.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     ) else {

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -130,14 +130,14 @@ pub(in crate::afxdp) fn drain_shaped_tx(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> Option<DrainedQueueRef> {
-    if binding.cos_nonempty_interfaces == 0 || binding.cos_interface_order.is_empty() {
+    if binding.cos.cos_nonempty_interfaces == 0 || binding.cos.cos_interface_order.is_empty() {
         return None;
     }
-    let start = binding.cos_interface_rr % binding.cos_interface_order.len();
-    for offset in 0..binding.cos_interface_order.len() {
+    let start = binding.cos.cos_interface_rr % binding.cos.cos_interface_order.len();
+    for offset in 0..binding.cos.cos_interface_order.len() {
         let root_ifindex =
-            binding.cos_interface_order[(start + offset) % binding.cos_interface_order.len()];
-        let Some(root) = binding.cos_interfaces.get(&root_ifindex) else {
+            binding.cos.cos_interface_order[(start + offset) % binding.cos.cos_interface_order.len()];
+        let Some(root) = binding.cos.cos_interfaces.get(&root_ifindex) else {
             continue;
         };
         if root.nonempty_queues == 0 {
@@ -152,7 +152,7 @@ pub(in crate::afxdp) fn drain_shaped_tx(
             now_ns,
             shared_recycles,
         ) {
-            binding.cos_interface_rr = (start + offset + 1) % binding.cos_interface_order.len();
+            binding.cos.cos_interface_rr = (start + offset + 1) % binding.cos.cos_interface_order.len();
             return serviced;
         }
         let Some(batch) = build_nonexact_cos_batch(binding, root_ifindex, now_ns) else {
@@ -165,7 +165,7 @@ pub(in crate::afxdp) fn drain_shaped_tx(
         // scan by id; now we carry the idx through for direct
         // indexed access.
         let located = cos_batch_queue_ref(binding, root_ifindex, &batch);
-        binding.cos_interface_rr = (start + offset + 1) % binding.cos_interface_order.len();
+        binding.cos.cos_interface_rr = (start + offset + 1) % binding.cos.cos_interface_order.len();
         if submit_cos_batch(binding, root_ifindex, batch, now_ns, shared_recycles) {
             return located.map(|(queue_idx, queue_id)| DrainedQueueRef {
                 root_ifindex,
@@ -188,7 +188,7 @@ fn cos_batch_queue_ref(
         CoSBatch::Local { queue_idx, .. } | CoSBatch::Prepared { queue_idx, .. } => *queue_idx,
     };
     binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(queue_idx))
         .map(|queue| (queue_idx, queue.queue_id))
@@ -201,7 +201,7 @@ fn build_nonexact_cos_batch(
     now_ns: u64,
 ) -> Option<CoSBatch> {
     let selected = {
-        let root = binding.cos_interfaces.get_mut(&root_ifindex)?;
+        let root = binding.cos.cos_interfaces.get_mut(&root_ifindex)?;
         select_nonexact_cos_guarantee_batch(root, now_ns)
             .or_else(|| select_cos_surplus_batch(root, now_ns))
     };
@@ -244,17 +244,17 @@ fn service_exact_guarantee_queue_direct_with_info(
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> Option<Option<DrainedQueueRef>> {
     let queue_fast_path = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)?
         .queue_fast_path
         .as_slice();
     let selection = {
-        let root = binding.cos_interfaces.get_mut(&root_ifindex)?;
+        let root = binding.cos.cos_interfaces.get_mut(&root_ifindex)?;
         select_exact_cos_guarantee_queue_with_fast_path(root, queue_fast_path, now_ns)?
     };
 
     let queue_id = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(selection.queue_idx))
         .map(|queue| queue.queue_id);
@@ -786,7 +786,7 @@ fn subtract_direct_cos_queue_bytes(
         refresh_cos_interface_activity(binding, root_ifindex);
         return;
     }
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+    if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             queue.queued_bytes = queue.queued_bytes.saturating_sub(dropped_bytes);
         }
@@ -1114,7 +1114,7 @@ fn restore_cos_local_items(
     retry: VecDeque<TxRequest>,
 ) {
     {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+        let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
@@ -1136,7 +1136,7 @@ fn restore_cos_prepared_items(
     retry: VecDeque<PreparedTxRequest>,
 ) {
     {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+        let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {

--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -18,7 +18,7 @@ pub(super) fn service_exact_local_queue_direct(
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> bool {
     let flow_fair = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(queue_idx))
         .map(|queue| queue.flow_fair)
@@ -39,12 +39,12 @@ pub(super) fn service_exact_local_queue_direct(
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
     binding.scratch.scratch_exact_local_tx.clear();
     let root_budget = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.tokens)
         .unwrap_or(0);
     let build = {
-        let root = match binding.cos_interfaces.get_mut(&root_ifindex) {
+        let root = match binding.cos.cos_interfaces.get_mut(&root_ifindex) {
             Some(root) => root,
             None => return false,
         };
@@ -147,7 +147,7 @@ pub(super) fn service_exact_local_queue_direct(
 
     let (sent_packets, sent_bytes) = settle_exact_local_fifo_submission(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.free_tx_frames,
@@ -159,7 +159,7 @@ pub(super) fn service_exact_local_queue_direct(
     // to shield future flow_fair-FIFO adoption.
     publish_committed_queue_vtime(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get(&root_ifindex)
             .and_then(|root| root.queues.get(queue_idx)),
     );
@@ -183,12 +183,12 @@ fn service_exact_local_queue_direct_flow_fair(
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
     binding.scratch.scratch_local_tx.clear();
     let root_budget = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.tokens)
         .unwrap_or(0);
     let build = {
-        let root = match binding.cos_interfaces.get_mut(&root_ifindex) {
+        let root = match binding.cos.cos_interfaces.get_mut(&root_ifindex) {
             Some(root) => root,
             None => return false,
         };
@@ -214,7 +214,7 @@ fn service_exact_local_queue_direct_flow_fair(
         } => {
             restore_exact_local_scratch_to_queue_head_flow_fair(
                 binding
-                    .cos_interfaces
+                    .cos.cos_interfaces
                     .get_mut(&root_ifindex)
                     .and_then(|root| root.queues.get_mut(queue_idx)),
                 &mut binding.free_tx_frames,
@@ -281,7 +281,7 @@ fn service_exact_local_queue_direct_flow_fair(
         maybe_wake_tx(binding, true, now_ns);
         restore_exact_local_scratch_to_queue_head_flow_fair(
             binding
-                .cos_interfaces
+                .cos.cos_interfaces
                 .get_mut(&root_ifindex)
                 .and_then(|root| root.queues.get_mut(queue_idx)),
             &mut binding.free_tx_frames,
@@ -296,7 +296,7 @@ fn service_exact_local_queue_direct_flow_fair(
 
     let (sent_packets, sent_bytes) = settle_exact_local_scratch_submission_flow_fair(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.free_tx_frames,
@@ -309,7 +309,7 @@ fn service_exact_local_queue_direct_flow_fair(
     // actually-shipped frames.
     publish_committed_queue_vtime(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get(&root_ifindex)
             .and_then(|root| root.queues.get(queue_idx)),
     );
@@ -327,7 +327,7 @@ pub(super) fn service_exact_prepared_queue_direct(
     now_ns: u64,
 ) -> bool {
     let flow_fair = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(queue_idx))
         .map(|queue| queue.flow_fair)
@@ -344,12 +344,12 @@ pub(super) fn service_exact_prepared_queue_direct(
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
     binding.scratch.scratch_exact_prepared_tx.clear();
     let root_budget = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.tokens)
         .unwrap_or(0);
     let build = {
-        let root = match binding.cos_interfaces.get_mut(&root_ifindex) {
+        let root = match binding.cos.cos_interfaces.get_mut(&root_ifindex) {
             Some(root) => root,
             None => return false,
         };
@@ -454,7 +454,7 @@ pub(super) fn service_exact_prepared_queue_direct(
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_fifo_submission(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.scratch.scratch_exact_prepared_tx,
@@ -465,7 +465,7 @@ pub(super) fn service_exact_prepared_queue_direct(
     // vtime_floor=None today; no-op shield for future adoption.
     publish_committed_queue_vtime(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get(&root_ifindex)
             .and_then(|root| root.queues.get(queue_idx)),
     );
@@ -485,12 +485,12 @@ fn service_exact_prepared_queue_direct_flow_fair(
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
     binding.scratch.scratch_prepared_tx.clear();
     let root_budget = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.tokens)
         .unwrap_or(0);
     let build = {
-        let root = match binding.cos_interfaces.get_mut(&root_ifindex) {
+        let root = match binding.cos.cos_interfaces.get_mut(&root_ifindex) {
             Some(root) => root,
             None => return false,
         };
@@ -518,7 +518,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
         } => {
             restore_exact_prepared_scratch_to_queue_head_flow_fair(
                 binding
-                    .cos_interfaces
+                    .cos.cos_interfaces
                     .get_mut(&root_ifindex)
                     .and_then(|root| root.queues.get_mut(queue_idx)),
                 &mut binding.scratch.scratch_prepared_tx,
@@ -590,7 +590,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
         maybe_wake_tx(binding, true, now_ns);
         restore_exact_prepared_scratch_to_queue_head_flow_fair(
             binding
-                .cos_interfaces
+                .cos.cos_interfaces
                 .get_mut(&root_ifindex)
                 .and_then(|root| root.queues.get_mut(queue_idx)),
             &mut binding.scratch.scratch_prepared_tx,
@@ -606,7 +606,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_scratch_submission_flow_fair(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.scratch.scratch_prepared_tx,
@@ -618,7 +618,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     // queue.queue_vtime now reflects only actually-shipped frames.
     publish_committed_queue_vtime(
         binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get(&root_ifindex)
             .and_then(|root| root.queues.get(queue_idx)),
     );

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -183,7 +183,7 @@ pub(in crate::afxdp) fn cos_refill_ns_until(tokens: u64, need: u64, rate_bytes_p
 
 pub(in crate::afxdp) fn release_cos_root_lease(binding: &mut BindingWorker, root_ifindex: i32) {
     let released = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get_mut(&root_ifindex)
         .map(|root| core::mem::take(&mut root.tokens))
         .unwrap_or(0);
@@ -191,7 +191,7 @@ pub(in crate::afxdp) fn release_cos_root_lease(binding: &mut BindingWorker, root
         return;
     }
     if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
     {
@@ -200,7 +200,7 @@ pub(in crate::afxdp) fn release_cos_root_lease(binding: &mut BindingWorker, root
 }
 
 pub(in crate::afxdp) fn release_all_cos_root_leases(binding: &mut BindingWorker) {
-    let root_ifindexes = binding.cos_interfaces.keys().copied().collect::<Vec<_>>();
+    let root_ifindexes = binding.cos.cos_interfaces.keys().copied().collect::<Vec<_>>();
     for root_ifindex in root_ifindexes {
         release_cos_root_lease(binding, root_ifindex);
     }
@@ -208,7 +208,7 @@ pub(in crate::afxdp) fn release_all_cos_root_leases(binding: &mut BindingWorker)
 
 pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker) {
     let queue_keys = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .iter()
         .flat_map(|(&root_ifindex, root)| {
             root.queues
@@ -220,7 +220,7 @@ pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker
         .collect::<Vec<_>>();
     for (root_ifindex, queue_idx) in queue_keys {
         let released = binding
-            .cos_interfaces
+            .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx))
             .map(|queue| core::mem::take(&mut queue.tokens))
@@ -229,7 +229,7 @@ pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker
             continue;
         }
         if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
+            .cos.cos_fast_interfaces
             .get(&root_ifindex)
             .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
             .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -165,7 +165,7 @@ pub(in crate::afxdp) fn count_tx_ring_full_submit_stall(
     if stalled_packets == 0 {
         return;
     }
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+    if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             queue.drop_counters.tx_ring_full_submit_stalls = queue
                 .drop_counters
@@ -274,10 +274,10 @@ pub(in crate::afxdp) fn prime_cos_root_for_service(
     now_ns: u64,
 ) -> bool {
     let shared_root_lease = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_root_lease.clone());
-    let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+    let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
         return false;
     };
     advance_cos_timer_wheel(root, now_ns);
@@ -295,7 +295,7 @@ pub(in crate::afxdp) fn apply_direct_exact_send_result(
     sent_packets: u64,
     sent_bytes: u64,
 ) {
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+    if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             queue.queued_bytes = queue.queued_bytes.saturating_sub(sent_bytes);
             queue.tokens = queue.tokens.saturating_sub(sent_bytes);
@@ -312,14 +312,14 @@ pub(in crate::afxdp) fn apply_direct_exact_send_result(
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
     if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
     {
         shared_root_lease.consume(sent_bytes);
     }
     if let Some(shared_queue_lease) = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
         .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
@@ -357,11 +357,11 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
     let mut new_runnable = 0usize;
     let mut released_queue_leases = Vec::<(usize, u64)>::new();
     let old_nonempty = binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .map(|root| root.nonempty_queues)
         .unwrap_or(0);
-    if let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) {
+    if let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) {
         for (queue_idx, queue) in root.queues.iter_mut().enumerate() {
             normalize_cos_queue_state(queue);
             if cos_queue_is_empty(queue) && queue.exact && queue.tokens > 0 {
@@ -379,12 +379,12 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
         root.runnable_queues = new_runnable;
     }
     if old_nonempty == 0 && new_nonempty > 0 {
-        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_add(1);
+        binding.cos.cos_nonempty_interfaces = binding.cos.cos_nonempty_interfaces.saturating_add(1);
     } else if old_nonempty > 0 && new_nonempty == 0 {
-        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_sub(1);
+        binding.cos.cos_nonempty_interfaces = binding.cos.cos_nonempty_interfaces.saturating_sub(1);
         release_cos_root_lease(binding, root_ifindex);
     }
-    if let Some(iface_fast) = binding.cos_fast_interfaces.get(&root_ifindex) {
+    if let Some(iface_fast) = binding.cos.cos_fast_interfaces.get(&root_ifindex) {
         for (queue_idx, released) in released_queue_leases {
             if let Some(shared_queue_lease) = iface_fast
                 .queue_fast_path
@@ -409,7 +409,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
 ) {
     let mut exact_queue_idx = None;
     {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+        let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
@@ -440,7 +440,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
     if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
     {
@@ -448,7 +448,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     }
     if let Some(queue_idx) = exact_queue_idx {
         if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
+            .cos.cos_fast_interfaces
             .get(&root_ifindex)
             .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
             .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
@@ -471,7 +471,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
 ) {
     let mut exact_queue_idx = None;
     {
-        let Some(root) = binding.cos_interfaces.get_mut(&root_ifindex) else {
+        let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
@@ -506,7 +506,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
     if let Some(shared_root_lease) = binding
-        .cos_fast_interfaces
+        .cos.cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref())
     {
@@ -514,7 +514,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     }
     if let Some(queue_idx) = exact_queue_idx {
         if let Some(shared_queue_lease) = binding
-            .cos_fast_interfaces
+            .cos.cos_fast_interfaces
             .get(&root_ifindex)
             .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
             .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -330,7 +330,7 @@ pub(in crate::afxdp) fn enqueue_local_into_cos(
         return Err(req);
     }
     if binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&egress_ifindex)
         .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
     {
@@ -375,7 +375,7 @@ pub(in crate::afxdp) fn enqueue_local_into_cos(
                 // available or the request cannot be materialized safely.
                 let area = binding.umem.area();
                 let slot = binding.slot;
-                if let Some(root) = binding.cos_interfaces.get_mut(&egress_ifindex) {
+                if let Some(root) = binding.cos.cos_interfaces.get_mut(&egress_ifindex) {
                     let _ = demote_prepared_cos_queue_to_local(
                         area,
                         &mut binding.free_tx_frames,
@@ -459,7 +459,7 @@ pub(super) fn enqueue_prepared_into_cos(
         return Err(req);
     }
     if binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&egress_ifindex)
         .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
     {
@@ -666,7 +666,7 @@ pub(in crate::afxdp) fn cos_queue_dscp_rewrite(
     queue_idx: usize,
 ) -> Option<u8> {
     binding
-        .cos_interfaces
+        .cos.cos_interfaces
         .get(&root_ifindex)
         .and_then(|root| root.queues.get(queue_idx))
         .and_then(|queue| queue.dscp_rewrite)
@@ -683,7 +683,7 @@ fn enqueue_cos_item(
     let (accepted, queue_id, recycle) = {
         // Split-borrow: `umem` sits alongside `cos_interfaces` on
         // `BindingWorker`, so we can take a shared borrow on the umem
-        // field while holding `&mut binding.cos_interfaces` for the
+        // field while holding `&mut binding.cos.cos_interfaces` for the
         // admission-gate block. The Prepared-variant ECN marker
         // (#727) needs this to mutate frame bytes in the UMEM
         // in-place; the admission gate runs strictly before the
@@ -691,7 +691,7 @@ fn enqueue_cos_item(
         // the bytes concurrently. Both fields are borrowed explicitly
         // here so the borrow checker keeps us honest.
         let umem = binding.umem.area();
-        let Some(root) = binding.cos_interfaces.get_mut(&egress_ifindex) else {
+        let Some(root) = binding.cos.cos_interfaces.get_mut(&egress_ifindex) else {
             return Err(item);
         };
         let Some(mut queue_idx) = resolve_cos_queue_idx(root, requested_queue) else {
@@ -780,7 +780,7 @@ fn enqueue_cos_item(
         }
     };
     if root_became_nonempty {
-        binding.cos_nonempty_interfaces = binding.cos_nonempty_interfaces.saturating_add(1);
+        binding.cos.cos_nonempty_interfaces = binding.cos.cos_nonempty_interfaces.saturating_add(1);
     }
     if accepted {
         return Ok(());

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -32,7 +32,7 @@ fn enqueue_local_request_to_target_or_owner(
     req: TxRequest,
 ) -> Result<(), TxRequest> {
     if request_uses_shared_exact_queue_lease(
-        &target_binding.cos_fast_interfaces,
+        &target_binding.cos.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     ) {
@@ -41,7 +41,7 @@ fn enqueue_local_request_to_target_or_owner(
         return Ok(());
     }
     let owner_live = cos_owner_live_for_request(
-        &target_binding.cos_fast_interfaces,
+        &target_binding.cos.cos_fast_interfaces,
         req.egress_ifindex,
         req.cos_queue_id,
     );
@@ -394,11 +394,11 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 let is_nat64 = request.decision.nat.nat64;
                 let uses_native_tunnel = request.decision.resolution.tunnel_endpoint_id != 0;
                 let owner_matches_target = request_uses_shared_exact_queue_lease(
-                    &target_binding.cos_fast_interfaces,
+                    &target_binding.cos.cos_fast_interfaces,
                     request.decision.resolution.egress_ifindex,
                     request.cos_queue_id,
                 ) || cos_owner_live_for_request(
-                    &target_binding.cos_fast_interfaces,
+                    &target_binding.cos.cos_fast_interfaces,
                     request.decision.resolution.egress_ifindex,
                     request.cos_queue_id,
                 )

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -99,7 +99,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
         if let Some(serviced) = serviced.as_ref() {
             let delta = monotonic_nanos().saturating_sub(start_ns);
             let bucket = bucket_index_for_ns(delta);
-            if let Some(root) = binding.cos_interfaces.get(&serviced.root_ifindex) {
+            if let Some(root) = binding.cos.cos_interfaces.get(&serviced.root_ifindex) {
                 if let Some(queue) = root.queues.get(serviced.queue_idx) {
                     if queue.queue_id == serviced.queue_id {
                         queue.owner_profile.drain_latency_hist[bucket]
@@ -159,7 +159,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
                 if let Some(serviced) = serviced.as_ref() {
                     let delta = monotonic_nanos().saturating_sub(start_ns);
                     let bucket = bucket_index_for_ns(delta);
-                    if let Some(root) = binding.cos_interfaces.get(&serviced.root_ifindex) {
+                    if let Some(root) = binding.cos.cos_interfaces.get(&serviced.root_ifindex) {
                         if let Some(queue) = root.queues.get(serviced.queue_idx) {
                             if queue.queue_id == serviced.queue_id {
                                 queue.owner_profile.drain_latency_hist[bucket]
@@ -458,7 +458,7 @@ fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
         || !binding.pending_tx_prepared.is_empty()
         || !binding.pending_tx_local.is_empty()
         || !binding.live.pending_tx_empty()
-        || binding.cos_nonempty_interfaces > 0
+        || binding.cos.cos_nonempty_interfaces > 0
 }
 
 pub(in crate::afxdp) fn drain_pending_tx_local_owner(
@@ -622,7 +622,7 @@ fn ingest_cos_pending_tx_with_provenance(
         let key = (req.egress_ifindex, req.cos_queue_id);
         if cached_key != Some(key) {
             cached_key = Some(key);
-            let iface_fast_opt = binding.cos_fast_interfaces.get(&req.egress_ifindex);
+            let iface_fast_opt = binding.cos.cos_fast_interfaces.get(&req.egress_ifindex);
             cached_decision = Some(resolve_local_routing_decision(
                 iface_fast_opt,
                 req.cos_queue_id,

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1078,7 +1078,7 @@ pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
     // `flush_v_min_scratches_into` so it's directly unit-testable
     // without needing to construct a full `BindingWorker`.
     flush_v_min_scratches_into(
-        binding.cos_interfaces.values_mut(),
+        binding.cos.cos_interfaces.values_mut(),
         &binding.live.v_min_throttle_hard_cap_overrides,
         &binding.live.v_min_throttles,
     );

--- a/userspace-dp/src/afxdp/worker/cos.rs
+++ b/userspace-dp/src/afxdp/worker/cos.rs
@@ -188,7 +188,7 @@ pub(super) fn build_worker_cos_statuses(
     build_worker_cos_statuses_from_maps(
         bindings
             .iter()
-            .map(|binding| (&binding.cos_interfaces, Some(binding.live.as_ref()))),
+            .map(|binding| (&binding.cos.cos_interfaces, Some(binding.live.as_ref()))),
         forwarding,
     )
 }
@@ -199,7 +199,7 @@ pub(super) fn build_worker_cos_statuses(
 ///
 /// The snapshot source is `BindingLiveState`, which is binding-local,
 /// not queue-local. A binding can drain multiple interfaces (via
-/// `drain_shaped_tx` round-robining `binding.cos_interface_order`), so
+/// `drain_shaped_tx` round-robining `binding.cos.cos_interface_order`), so
 /// attribution has to be unambiguous at the BINDING level, not the
 /// interface level: if two interfaces on the same binding each have
 /// one owner-local exact queue, the binding-wide snapshot still has
@@ -265,7 +265,7 @@ pub(super) fn cos_runtime_config_changed(current: &ForwardingState, next: &Forwa
 /// (config-reload reset-epoch). Single-writer invariant: this worker
 /// owns its slots; race-free against peer Acquire reads.
 pub(super) fn vacate_all_shared_exact_slots_for_binding(binding: &BindingWorker) {
-    for root in binding.cos_interfaces.values() {
+    for root in binding.cos.cos_interfaces.values() {
         for queue in &root.queues {
             if !queue.shared_exact {
                 continue;
@@ -284,7 +284,7 @@ pub(super) fn reset_binding_cos_runtime(binding: &mut BindingWorker) {
     release_all_cos_queue_leases(binding);
     let mut dropped_local = 0u64;
     let mut dropped_prepared = Vec::new();
-    for root in binding.cos_interfaces.values_mut() {
+    for root in binding.cos.cos_interfaces.values_mut() {
         for queue in &mut root.queues {
             // #785 Phase 3 — Codex round-3 NEW-2 / Rust reviewer
             // LOW: teardown drains the whole queue without a
@@ -320,10 +320,10 @@ pub(super) fn reset_binding_cos_runtime(binding: &mut BindingWorker) {
     // stale value in their V_min calculation, throttling them
     // unnecessarily until the first post-reset post-settle publish.
     vacate_all_shared_exact_slots_for_binding(binding);
-    binding.cos_interfaces.clear();
-    binding.cos_interface_order.clear();
-    binding.cos_interface_rr = 0;
-    binding.cos_nonempty_interfaces = 0;
+    binding.cos.cos_interfaces.clear();
+    binding.cos.cos_interface_order.clear();
+    binding.cos.cos_interface_rr = 0;
+    binding.cos.cos_nonempty_interfaces = 0;
 
     let dropped_total = dropped_local.saturating_add(dropped_prepared.len() as u64);
     if dropped_total > 0 {

--- a/userspace-dp/src/afxdp/worker/cos_state.rs
+++ b/userspace-dp/src/afxdp/worker/cos_state.rs
@@ -1,0 +1,32 @@
+//! #959 Phase 3 — extracts the per-binding `cos_*` CoS-engine state
+//! out of `BindingWorker` into a dedicated `WorkerCos` sub-struct.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-3. Field names preserved so the
+//! `binding.cos.cos_X` access pattern keeps the same grep-friendly
+//! suffix as the original `binding.cos_X`.
+//!
+//! Filename is `cos_state.rs`, not `cos.rs`, because the
+//! `worker::cos` module already exists (it holds the worker-side
+//! CoS runtime helpers). This module exclusively defines the data-
+//! holding sub-struct.
+
+use super::*;
+
+/// Per-binding CoS scheduling state. Owned by the worker that owns
+/// this binding.
+///
+/// **Intentionally NOT `Default`.** A `WorkerCos::default()` would
+/// silently produce empty `FastMap`s and a zero `cos_interface_rr`,
+/// which is also the legitimate construction state — but going
+/// through `Default` would lose the FastMap's hashing properties
+/// (rebuilding from scratch with default builder). The only legal
+/// construction path is the explicit literal in
+/// `BindingWorker::create`. Same rule as `WorkerScratch`.
+pub(crate) struct WorkerCos {
+    pub(crate) cos_fast_interfaces: FastMap<i32, WorkerCoSInterfaceFastPath>,
+    pub(crate) cos_interfaces: FastMap<i32, CoSInterfaceRuntime>,
+    pub(crate) cos_interface_order: Vec<i32>,
+    pub(crate) cos_interface_rr: usize,
+    pub(crate) cos_nonempty_interfaces: usize,
+}

--- a/userspace-dp/src/afxdp/worker/cos_state.rs
+++ b/userspace-dp/src/afxdp/worker/cos_state.rs
@@ -16,13 +16,14 @@ use super::*;
 /// Per-binding CoS scheduling state. Owned by the worker that owns
 /// this binding.
 ///
-/// **Intentionally NOT `Default`.** A `WorkerCos::default()` would
-/// silently produce empty `FastMap`s and a zero `cos_interface_rr`,
-/// which is also the legitimate construction state — but going
-/// through `Default` would lose the FastMap's hashing properties
-/// (rebuilding from scratch with default builder). The only legal
-/// construction path is the explicit literal in
-/// `BindingWorker::create`. Same rule as `WorkerScratch`.
+/// **Intentionally NOT `Default`** — for consistency with the
+/// `WorkerScratch` decomposition pattern (#1168), where Default
+/// would have silently regressed Vec capacity. A `WorkerCos::default()`
+/// would technically produce the same state as the explicit literal
+/// in `BindingWorker::create` (FastMaps are equally `default()`'d
+/// there) — but blocking it forces all construction through the
+/// explicit literal so any future field with non-trivial init
+/// requirements can't accidentally bypass it.
 pub(crate) struct WorkerCos {
     pub(crate) cos_fast_interfaces: FastMap<i32, WorkerCoSInterfaceFastPath>,
     pub(crate) cos_interfaces: FastMap<i32, CoSInterfaceRuntime>,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -14,6 +14,12 @@ pub(crate) use telemetry::WorkerTelemetry;
 mod scratch;
 pub(crate) use scratch::WorkerScratch;
 
+// #959 Phase 3: per-binding CoS scheduling state lives in
+// worker/cos_state.rs (the `cos` module name is taken by
+// worker/cos.rs which holds runtime helpers).
+mod cos_state;
+pub(crate) use cos_state::WorkerCos;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -57,11 +63,10 @@ pub(crate) struct BindingWorker {
     pub(crate) pending_tx_prepared: VecDeque<PreparedTxRequest>,
     pub(crate) pending_tx_local: VecDeque<TxRequest>,
     pub(crate) max_pending_tx: usize,
-    pub(crate) cos_fast_interfaces: FastMap<i32, WorkerCoSInterfaceFastPath>,
-    pub(crate) cos_interfaces: FastMap<i32, CoSInterfaceRuntime>,
-    pub(crate) cos_interface_order: Vec<i32>,
-    pub(crate) cos_interface_rr: usize,
-    pub(crate) cos_nonempty_interfaces: usize,
+    /// #959 Phase 3: 5 `cos_*` per-binding CoS scheduling fields
+    /// extracted into `WorkerCos`. Field semantics unchanged;
+    /// access via `binding.cos.cos_X`.
+    pub(crate) cos: WorkerCos,
     pub(crate) pending_fill_frames: VecDeque<u64>,
     /// #959 Phase 2: 11 `scratch_*` reusable buffers extracted into
     /// `WorkerScratch`. Field semantics unchanged; access via
@@ -339,11 +344,13 @@ impl BindingWorker {
             pending_tx_prepared: VecDeque::new(),
             pending_tx_local: VecDeque::new(),
             max_pending_tx,
-            cos_fast_interfaces: FastMap::default(),
-            cos_interfaces: FastMap::default(),
-            cos_interface_order: Vec::new(),
-            cos_interface_rr: 0,
-            cos_nonempty_interfaces: 0,
+            cos: WorkerCos {
+                cos_fast_interfaces: FastMap::default(),
+                cos_interfaces: FastMap::default(),
+                cos_interface_order: Vec::new(),
+                cos_interface_rr: 0,
+                cos_nonempty_interfaces: 0,
+            },
             pending_fill_frames: VecDeque::new(),
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -526,7 +533,7 @@ pub(crate) fn worker_loop(
         cos_shared_queue_vtime_floors.as_ref(),
     );
     for binding in bindings.iter_mut() {
-        binding.cos_fast_interfaces = cos_fast_interfaces.clone();
+        binding.cos.cos_fast_interfaces = cos_fast_interfaces.clone();
     }
     let mut interrupt_poll_fds = if poll_mode == crate::PollMode::Interrupt {
         bindings
@@ -775,7 +782,7 @@ pub(crate) fn worker_loop(
                 cos_shared_queue_vtime_floors.as_ref(),
             );
             for binding in bindings.iter_mut() {
-                binding.cos_fast_interfaces = cos_fast_interfaces.clone();
+                binding.cos.cos_fast_interfaces = cos_fast_interfaces.clone();
             }
         }
         let ha_runtime = ha_state.load();
@@ -1615,7 +1622,7 @@ fn apply_worker_shaped_tx_requests(
     for req in requests {
         let binding_index = bindings
             .first()
-            .and_then(|binding| binding.cos_fast_interfaces.get(&req.egress_ifindex))
+            .and_then(|binding| binding.cos.cos_fast_interfaces.get(&req.egress_ifindex))
             .and_then(|iface_fast| {
                 binding_lookup
                     .first_by_if


### PR DESCRIPTION
## Summary

Phase 3 of **#959** BindingWorker decomposition.
- Phase 1 (#1167): 23 `dbg_*` → `WorkerTelemetry`
- Phase 2 (#1168): 11 `scratch_*` → `WorkerScratch`
- **Phase 3 (this PR): 5 `cos_*` → `WorkerCos`**

Moves 5 per-binding CoS scheduling fields out of `BindingWorker`:

| Field |
|-------|
| `cos_fast_interfaces` |
| `cos_interfaces` |
| `cos_interface_order` |
| `cos_interface_rr` |
| `cos_nonempty_interfaces` |

Access pattern: `binding.cos.cos_X`. New file is `worker/cos_state.rs`
(the `worker::cos` name is already taken by `worker/cos.rs` which
houses the CoS runtime helpers — the data sub-struct gets its own file).

## Methodology

Same compiler-driven approach as Phases 1-2. Remove the 5 fields from
BindingWorker, let the compiler report E0609 at every callsite,
rewrite `X.cos_Y` → `X.cos.cos_Y`. 12 files affected, 102 callsites.

`WorkerCos` has **NO `Default`** derive — applying the lesson from
Phase 2 review (Codex caught that auto-Default could regress
allocation timing). Only legal construction is the explicit literal
in `BindingWorker::create`.

## Files affected (13 = 1 new struct + 1 new plan + 11 callsite rewrites)

- new: `userspace-dp/src/afxdp/worker/cos_state.rs`
- edit: `userspace-dp/src/afxdp/worker/mod.rs`
- edit: `userspace-dp/src/afxdp/worker/cos.rs`
- edit: `userspace-dp/src/afxdp/cos/builders.rs`
- edit: `userspace-dp/src/afxdp/cos/cross_binding.rs`
- edit: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`
- edit: `userspace-dp/src/afxdp/cos/queue_service/service.rs`
- edit: `userspace-dp/src/afxdp/cos/token_bucket.rs`
- edit: `userspace-dp/src/afxdp/cos/tx_completion.rs`
- edit: `userspace-dp/src/afxdp/tx/cos_classify.rs`
- edit: `userspace-dp/src/afxdp/tx/dispatch.rs`
- edit: `userspace-dp/src/afxdp/tx/drain.rs`
- edit: `userspace-dp/src/afxdp/umem/mod.rs`
- new: `docs/pr/959-phase3-cos/plan.md`

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `go build ./...` clean
- [x] `go test ./...` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 958 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke `2001:559:8585:80::200` — 945 Mbps, 0 retr

## NOT in scope

Phase 4+ deferred:
- `pending_direct_tx_*` counters (6 fields) → Phase 4
- XSK rings (device, rx, tx) → Phase 5 (highest risk)
- `#[repr(align(64))]` cache-line alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)