### PR TITLE
#959 Phase 4: extract pending_*_tx_* counters into WorkerTxCounters

### DIFF
--- a/docs/pr/959-phase4-tx-counters/plan.md
+++ b/docs/pr/959-phase4-tx-counters/plan.md
@@ -1,0 +1,58 @@
+# Plan: #959 Phase 4 — extract `pending_*_tx_*` into `WorkerTxCounters`
+
+## Status
+
+Phase 4 of #959. Phase 1 (#1167) extracted `dbg_*` → `WorkerTelemetry`.
+Phase 2 (#1168) extracted `scratch_*` → `WorkerScratch`.
+Phase 3 (#1169) extracted `cos_*` → `WorkerCos`.
+
+## Scope
+
+Move 6 `pending_*_tx_*` per-binding TX-disposition packet counters
+out of `BindingWorker` into a new `WorkerTxCounters` sub-struct
+accessed via `binding.tx_counters.pending_X`:
+
+```
+pending_direct_tx_packets, pending_copy_tx_packets,
+pending_in_place_tx_packets,
+pending_direct_tx_no_frame_fallback_packets,
+pending_direct_tx_build_fallback_packets,
+pending_direct_tx_disallowed_fallback_packets
+```
+
+These are incremented from the descriptor loop and TX dispatch
+pipeline; drained on the per-second debug tick into the
+`BindingLiveState` atomic mirrors.
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-3.
+
+- New file `userspace-dp/src/afxdp/worker/tx_counters.rs`.
+- Replace 6 BindingWorker fields with `pub(crate) tx_counters: WorkerTxCounters`.
+- 3 files affected for callsite rewrite; 29 callsites total
+  (smallest phase yet).
+- `WorkerTxCounters` has NO `Default` derive (per Phase 2 lesson).
+
+The `BindingLiveState` mirror at `umem/mod.rs:996+` reads
+`binding.pending_X` and feeds `b.live.pending_X.fetch_add(...)`. After
+this PR, only the read side becomes `binding.tx_counters.pending_X`;
+the atomic side `b.live.pending_X` is unchanged (different struct).
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5 named runs (per the standing rule that test failures must be
+  proven before merge).
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against `172.16.80.200` / `2001:559:8585:80::200`.
+- Codex + Gemini hostile review.
+
+## NOT in scope
+
+- XSK rings (device, rx, tx) → Phase 5 (highest risk).
+- `flow_cache*` → separate concern (cache, not counter).
+- `last_*_ns` timestamps → gating logic, out of scope.
+- `#[repr(align(64))]` cache-line alignment — late phase.

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -388,7 +388,7 @@ pub(super) fn poll_binding_process_descriptor(
                                                         .dscp_rewrite,
                                                 },
                                             );
-                                            binding.pending_in_place_tx_packets += 1;
+                                            binding.tx_counters.pending_in_place_tx_packets += 1;
                                             telemetry.dbg.forward += 1;
                                             telemetry.dbg.tx += 1;
                                             recycle_now = false;

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -150,7 +150,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
             }
             dbg.enqueue_ok += 1;
             dbg.enqueue_copy += 1;
-            target_binding.pending_copy_tx_packets += 1;
+            target_binding.tx_counters.pending_copy_tx_packets += 1;
             dbg.tx_bytes_total += frame_len as u64;
             if (frame_len as u32) > dbg.tx_max_frame {
                 dbg.tx_max_frame = frame_len as u32;
@@ -277,7 +277,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 {
                     dbg.enqueue_ok += segments as u64;
                     dbg.enqueue_direct += segments as u64;
-                    target_binding.pending_direct_tx_packets += segments as u64;
+                    target_binding.tx_counters.pending_direct_tx_packets += segments as u64;
                     dbg.tx_bytes_total += bytes;
                     if max_frame > dbg.tx_max_frame {
                         dbg.tx_max_frame = max_frame;
@@ -341,7 +341,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                         bound_pending_tx_local(target_binding);
                         dbg.enqueue_ok += 1;
                         dbg.enqueue_copy += 1;
-                        target_binding.pending_copy_tx_packets += 1;
+                        target_binding.tx_counters.pending_copy_tx_packets += 1;
                         dbg.tx_bytes_total += seg_frame_len as u64;
                         if (seg_frame_len as u32) > dbg.tx_max_frame {
                             dbg.tx_max_frame = seg_frame_len as u32;
@@ -442,7 +442,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     dscp_rewrite: request.dscp_rewrite,
                                 });
                             bound_pending_tx_prepared(target_binding);
-                            target_binding.pending_in_place_tx_packets += 1;
+                            target_binding.tx_counters.pending_in_place_tx_packets += 1;
                             dbg.enqueue_ok += 1;
                             dbg.enqueue_inplace += 1;
                             dbg.tx_bytes_total += frame_len as u64;
@@ -527,7 +527,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 }
                                 dbg.enqueue_ok += 1;
                                 dbg.enqueue_copy += 1;
-                                target_binding.pending_copy_tx_packets += 1;
+                                target_binding.tx_counters.pending_copy_tx_packets += 1;
                                 dbg.tx_bytes_total += cp1_len as u64;
                                 if (cp1_len as u32) > dbg.tx_max_frame {
                                     dbg.tx_max_frame = cp1_len as u32;
@@ -679,7 +679,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 bound_pending_tx_prepared(target_binding);
                                 dbg.enqueue_ok += 1;
                                 dbg.enqueue_direct += 1;
-                                target_binding.pending_direct_tx_packets += 1;
+                                target_binding.tx_counters.pending_direct_tx_packets += 1;
                                 dbg.tx_bytes_total += written as u64;
                                 if (written as u32) > dbg.tx_max_frame {
                                     dbg.tx_max_frame = written as u32;
@@ -700,13 +700,13 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     if !direct_built {
                         match direct_tx_fallback_reason {
                             Some(DirectTxFallbackReason::NoFreeTxFrame) => {
-                                target_binding.pending_direct_tx_no_frame_fallback_packets += 1;
+                                target_binding.tx_counters.pending_direct_tx_no_frame_fallback_packets += 1;
                             }
                             Some(DirectTxFallbackReason::BuildReturnedNone) => {
-                                target_binding.pending_direct_tx_build_fallback_packets += 1;
+                                target_binding.tx_counters.pending_direct_tx_build_fallback_packets += 1;
                             }
                             Some(DirectTxFallbackReason::DisallowedByRewriteMode) => {
-                                target_binding.pending_direct_tx_disallowed_fallback_packets += 1;
+                                target_binding.tx_counters.pending_direct_tx_disallowed_fallback_packets += 1;
                             }
                             None => {}
                         }
@@ -786,7 +786,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 }
                                 dbg.enqueue_ok += 1;
                                 dbg.enqueue_copy += 1;
-                                target_binding.pending_copy_tx_packets += 1;
+                                target_binding.tx_counters.pending_copy_tx_packets += 1;
                                 dbg.tx_bytes_total += cp2_len as u64;
                                 if (cp2_len as u32) > dbg.tx_max_frame {
                                     dbg.tx_max_frame = cp2_len as u32;

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -993,50 +993,50 @@ pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
     if binding.debug_state_counter & 0xFFFF != 0 {
         return;
     }
-    if binding.pending_direct_tx_packets != 0 {
+    if binding.tx_counters.pending_direct_tx_packets != 0 {
         binding
             .live
             .direct_tx_packets
-            .fetch_add(binding.pending_direct_tx_packets, Ordering::Relaxed);
-        binding.pending_direct_tx_packets = 0;
+            .fetch_add(binding.tx_counters.pending_direct_tx_packets, Ordering::Relaxed);
+        binding.tx_counters.pending_direct_tx_packets = 0;
     }
-    if binding.pending_copy_tx_packets != 0 {
+    if binding.tx_counters.pending_copy_tx_packets != 0 {
         binding
             .live
             .copy_tx_packets
-            .fetch_add(binding.pending_copy_tx_packets, Ordering::Relaxed);
-        binding.pending_copy_tx_packets = 0;
+            .fetch_add(binding.tx_counters.pending_copy_tx_packets, Ordering::Relaxed);
+        binding.tx_counters.pending_copy_tx_packets = 0;
     }
-    if binding.pending_in_place_tx_packets != 0 {
+    if binding.tx_counters.pending_in_place_tx_packets != 0 {
         binding
             .live
             .in_place_tx_packets
-            .fetch_add(binding.pending_in_place_tx_packets, Ordering::Relaxed);
-        binding.pending_in_place_tx_packets = 0;
+            .fetch_add(binding.tx_counters.pending_in_place_tx_packets, Ordering::Relaxed);
+        binding.tx_counters.pending_in_place_tx_packets = 0;
     }
-    if binding.pending_direct_tx_no_frame_fallback_packets != 0 {
+    if binding.tx_counters.pending_direct_tx_no_frame_fallback_packets != 0 {
         binding.live.direct_tx_no_frame_fallback_packets.fetch_add(
-            binding.pending_direct_tx_no_frame_fallback_packets,
+            binding.tx_counters.pending_direct_tx_no_frame_fallback_packets,
             Ordering::Relaxed,
         );
-        binding.pending_direct_tx_no_frame_fallback_packets = 0;
+        binding.tx_counters.pending_direct_tx_no_frame_fallback_packets = 0;
     }
-    if binding.pending_direct_tx_build_fallback_packets != 0 {
+    if binding.tx_counters.pending_direct_tx_build_fallback_packets != 0 {
         binding.live.direct_tx_build_fallback_packets.fetch_add(
-            binding.pending_direct_tx_build_fallback_packets,
+            binding.tx_counters.pending_direct_tx_build_fallback_packets,
             Ordering::Relaxed,
         );
-        binding.pending_direct_tx_build_fallback_packets = 0;
+        binding.tx_counters.pending_direct_tx_build_fallback_packets = 0;
     }
-    if binding.pending_direct_tx_disallowed_fallback_packets != 0 {
+    if binding.tx_counters.pending_direct_tx_disallowed_fallback_packets != 0 {
         binding
             .live
             .direct_tx_disallowed_fallback_packets
             .fetch_add(
-                binding.pending_direct_tx_disallowed_fallback_packets,
+                binding.tx_counters.pending_direct_tx_disallowed_fallback_packets,
                 Ordering::Relaxed,
             );
-        binding.pending_direct_tx_disallowed_fallback_packets = 0;
+        binding.tx_counters.pending_direct_tx_disallowed_fallback_packets = 0;
     }
     if binding.flow_cache.hits != 0 {
         binding

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -20,6 +20,11 @@ pub(crate) use scratch::WorkerScratch;
 mod cos_state;
 pub(crate) use cos_state::WorkerCos;
 
+// #959 Phase 4: per-binding TX-disposition packet counters live in
+// worker/tx_counters.rs.
+mod tx_counters;
+pub(crate) use tx_counters::WorkerTxCounters;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -120,12 +125,10 @@ pub(crate) struct BindingWorker {
     /// `WorkerTelemetry` to reduce BindingWorker's mutable surface
     /// area. Field semantics unchanged; access via `binding.telemetry.dbg_X`.
     pub(crate) telemetry: WorkerTelemetry,
-    pub(crate) pending_direct_tx_packets: u64,
-    pub(crate) pending_copy_tx_packets: u64,
-    pub(crate) pending_in_place_tx_packets: u64,
-    pub(crate) pending_direct_tx_no_frame_fallback_packets: u64,
-    pub(crate) pending_direct_tx_build_fallback_packets: u64,
-    pub(crate) pending_direct_tx_disallowed_fallback_packets: u64,
+    /// #959 Phase 4: 6 `pending_*_tx_*` packet counters extracted
+    /// into `WorkerTxCounters`. Field semantics unchanged; access
+    /// via `binding.tx_counters.pending_X`.
+    pub(crate) tx_counters: WorkerTxCounters,
     pub(crate) flow_cache: FlowCache,
     pub(crate) flow_cache_session_touch: u64,
     /// Timestamp when this binding was created.
@@ -396,12 +399,14 @@ impl BindingWorker {
             empty_rx_polls: 0,
             last_learned_neighbor: None,
             telemetry: WorkerTelemetry::default(),
-            pending_direct_tx_packets: 0,
-            pending_copy_tx_packets: 0,
-            pending_in_place_tx_packets: 0,
-            pending_direct_tx_no_frame_fallback_packets: 0,
-            pending_direct_tx_build_fallback_packets: 0,
-            pending_direct_tx_disallowed_fallback_packets: 0,
+            tx_counters: WorkerTxCounters {
+                pending_direct_tx_packets: 0,
+                pending_copy_tx_packets: 0,
+                pending_in_place_tx_packets: 0,
+                pending_direct_tx_no_frame_fallback_packets: 0,
+                pending_direct_tx_build_fallback_packets: 0,
+                pending_direct_tx_disallowed_fallback_packets: 0,
+            },
             flow_cache: FlowCache::new(),
             flow_cache_session_touch: 0,
             bind_time_ns: {

--- a/userspace-dp/src/afxdp/worker/tx_counters.rs
+++ b/userspace-dp/src/afxdp/worker/tx_counters.rs
@@ -1,0 +1,32 @@
+//! #959 Phase 4 — extracts the per-binding `pending_*_tx_*` and
+//! `pending_direct_tx_*_fallback_*` packet counters out of
+//! `BindingWorker` into a dedicated `WorkerTxCounters` sub-struct.
+//!
+//! These six counters track the disposition of TX-bound packets
+//! (direct, copy, in-place) and the three fallback paths the direct
+//! TX engine takes when the fast-path is unavailable. They're
+//! incremented from the descriptor loop and the TX dispatch
+//! pipeline, then drained to the `BindingLiveState` atomics on the
+//! per-second debug tick.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-4. Field names preserved so the
+//! `binding.tx_counters.pending_*_tx_*` access pattern keeps the
+//! same grep-friendly suffix as the original
+//! `binding.pending_*_tx_*`.
+
+/// Per-binding TX-disposition packet counters. Drained on the
+/// per-second debug tick into `BindingLiveState` atomic mirrors.
+///
+/// **Intentionally NOT `Default`** — for consistency with the
+/// `WorkerScratch` (#1168) and `WorkerCos` (#1169) decomposition
+/// pattern. Only legal construction is the explicit literal in
+/// `BindingWorker::create`.
+pub(crate) struct WorkerTxCounters {
+    pub(crate) pending_direct_tx_packets: u64,
+    pub(crate) pending_copy_tx_packets: u64,
+    pub(crate) pending_in_place_tx_packets: u64,
+    pub(crate) pending_direct_tx_no_frame_fallback_packets: u64,
+    pub(crate) pending_direct_tx_build_fallback_packets: u64,
+    pub(crate) pending_direct_tx_disallowed_fallback_packets: u64,
+}


### PR DESCRIPTION
## Summary

Phase 4 of **#959** BindingWorker decomposition.
- Phase 1 (#1167): 23 \`dbg_*\` → \`WorkerTelemetry\`
- Phase 2 (#1168): 11 \`scratch_*\` → \`WorkerScratch\`
- Phase 3 (#1169): 5 \`cos_*\` → \`WorkerCos\`
- **Phase 4 (this PR): 6 \`pending_*_tx_*\` → \`WorkerTxCounters\`**

Moves 6 per-binding TX-disposition packet counters out of
`BindingWorker`:

| Field |
|-------|
| `pending_direct_tx_packets` |
| `pending_copy_tx_packets` |
| `pending_in_place_tx_packets` |
| `pending_direct_tx_no_frame_fallback_packets` |
| `pending_direct_tx_build_fallback_packets` |
| `pending_direct_tx_disallowed_fallback_packets` |

Access pattern: `binding.tx_counters.pending_X`.

## Methodology

Same compiler-driven approach as Phases 1-3. Smallest phase yet —
3 files affected, 29 callsites rewritten.

The `BindingLiveState` mirror at `umem/mod.rs:996+` reads
`binding.pending_X` and feeds `b.live.pending_X.fetch_add(...)` on
the per-second debug tick. After this PR, the read side becomes
`binding.tx_counters.pending_X`; the atomic side `b.live.pending_X`
is unchanged (different struct, compiler-protected).

`WorkerTxCounters` has **NO `Default`** derive (per Phase 2 lesson).

## Files affected

| File | Change |
|------|--------|
| `userspace-dp/src/afxdp/worker/tx_counters.rs` | new, 27 LOC |
| `userspace-dp/src/afxdp/worker/mod.rs` | -6 fields, +nested literal |
| `userspace-dp/src/afxdp/poll_descriptor.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/tx/dispatch.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/umem/mod.rs` | callsite rewrites |
| `docs/pr/959-phase4-tx-counters/plan.md` | new plan |

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `cargo test --release flush_clears_records_and_increments_sequence` — 5/5 named runs PASS (the prior sandbox-flake test, verified)
- [x] `go build ./...` clean
- [x] `go test ./...` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 7.58 Gbps, 0 retr
- [x] v6 smoke `2001:559:8585:80::200` — 7.64 Gbps, 0 retr

## NOT in scope

- XSK rings (`device`, `rx`, `tx`) → Phase 5 (highest risk)
- `flow_cache*` → separate concern (cache, not counter)
- `last_*_ns` timestamps → gating logic
- `#[repr(align(64))]` cache-line alignment — late phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)