### PR TITLE
#959 Phase 5: extract BPF map FDs into WorkerBpfMaps sub-struct

### DIFF
--- a/docs/pr/959-phase5-bpfmaps/plan.md
+++ b/docs/pr/959-phase5-bpfmaps/plan.md
@@ -1,0 +1,57 @@
+# Plan: #959 Phase 5 — extract BPF map FDs into `WorkerBpfMaps`
+
+## Status
+
+Phase 5 of #959. Phases 1-4 (#1167, #1168, #1169, #1170) extracted
+`dbg_*`, `scratch_*`, `cos_*`, `pending_*_tx_*`.
+
+## Scope
+
+Move 4 BPF map file descriptors out of `BindingWorker` into a new
+`WorkerBpfMaps` sub-struct:
+
+```
+heartbeat_map_fd, session_map_fd, conntrack_v4_fd, conntrack_v6_fd
+```
+
+Access pattern: `binding.bpf_maps.X_fd`.
+
+These FDs are opened once at binding construction (from the
+coordinator's pinned BPF map paths) and used through the binding's
+lifetime for: heartbeat updates (per-second), session table deltas
+(per-RX-batch), and conntrack v4/v6 lookups during fast-path session
+resolution.
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-4. 24 callsites across 4
+files (worker/mod.rs, poll_descriptor.rs, session_glue/mod.rs,
+bpf_map.rs).
+
+`WorkerBpfMaps` has NO `Default` derive — these are real OS FDs and
+a `c_int = 0` default would alias `stdin`, with potentially
+destructive consequences if any later BPF syscall used it.
+
+The `BindingPlan` struct (in `runtime.rs`) also has fields named
+`heartbeat_map_fd` etc. but is a different type. The compiler's
+type-level distinction protects us; a perl over-replacement that hit
+`plan.heartbeat_map_fd → plan.bpf_maps.heartbeat_map_fd` was caught
+by the build and reverted. (Plan stays a flat-field struct;
+BindingWorker gains the nested sub-struct.)
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5/5 named runs.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against `172.16.80.200` / `2001:559:8585:80::200`.
+- Codex hostile review.
+
+## NOT in scope
+
+- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred.
+- `flow_cache` → cache, not FD.
+- TX pipeline state (`free_tx_frames`, `pending_tx_*`) — separate
+  group, deferred.

--- a/docs/pr/959-phase5-bpfmaps/plan.md
+++ b/docs/pr/959-phase5-bpfmaps/plan.md
@@ -24,9 +24,11 @@ resolution.
 
 ## Methodology
 
-Same compiler-driven approach as Phases 1-4. 24 callsites across 4
-files (worker/mod.rs, poll_descriptor.rs, session_glue/mod.rs,
-bpf_map.rs).
+Same compiler-driven approach as Phases 1-4. 30 callsites across 4
+files (worker/mod.rs 7, poll_descriptor.rs 13, session_glue/mod.rs 6,
+bpf_map.rs 4). The pre-implementation grep counted 24 because it
+under-counted multi-arg call sites where two FDs appear on the same
+line.
 
 `WorkerBpfMaps` has NO `Default` derive — these are real OS FDs and
 a `c_int = 0` default would alias `stdin`, with potentially

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -143,7 +143,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
         return;
     }
     match touch_heartbeat(
-        binding.heartbeat_map_fd,
+        binding.bpf_maps.heartbeat_map_fd,
         binding.slot,
         &binding.live,
         now_ns,
@@ -158,7 +158,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
                     debug_log!(
                         "HB_UPDATE slot={} fd={} age={}ms now_ns={} LATE",
                         binding.slot,
-                        binding.heartbeat_map_fd,
+                        binding.bpf_maps.heartbeat_map_fd,
                         age_ms,
                         now_ns,
                     );
@@ -171,7 +171,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
                             "HB_UPDATE[{}] slot={} fd={} age={}ms now_ns={} OK",
                             n,
                             binding.slot,
-                            binding.heartbeat_map_fd,
+                            binding.bpf_maps.heartbeat_map_fd,
                             age_ms,
                             now_ns,
                         );
@@ -184,7 +184,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
             eprintln!(
                 "HB_UPDATE_ERR slot={} fd={} age={}ms err={}",
                 binding.slot,
-                binding.heartbeat_map_fd,
+                binding.bpf_maps.heartbeat_map_fd,
                 age_ns / 1_000_000,
                 err,
             );

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -444,7 +444,7 @@ pub(super) fn poll_binding_process_descriptor(
                     let mut decision = if let Some(flow) = flow.as_ref() {
                         if let Some(resolved) = resolve_flow_session_decision(
                             sessions,
-                            binding.session_map_fd,
+                            binding.bpf_maps.session_map_fd,
                             worker_ctx.shared_sessions,
                             worker_ctx.shared_nat_sessions,
                             worker_ctx.shared_forward_wire_sessions,
@@ -594,7 +594,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         meta.tcp_flags,
                                     ) {
                                         let _ = publish_live_session_entry(
-                                            binding.session_map_fd,
+                                            binding.bpf_maps.session_map_fd,
                                             &flow.forward_key,
                                             NatDecision::default(),
                                             true,
@@ -824,7 +824,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             flow.forward_key.src_port,
                                             flow.forward_key.dst_ip,
                                             flow.forward_key.dst_port,
-                                            count_bpf_session_entries(binding.session_map_fd),
+                                            count_bpf_session_entries(binding.bpf_maps.session_map_fd),
                                             sessions.len(),
                                         );
                                         // Dump all local sessions to compare
@@ -895,7 +895,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 };
                                 if install_helper_local_session_on_miss(
                                     sessions,
-                                    binding.session_map_fd,
+                                    binding.bpf_maps.session_map_fd,
                                     worker_ctx.shared_sessions,
                                     worker_ctx.shared_nat_sessions,
                                     worker_ctx.shared_forward_wire_sessions,
@@ -1228,7 +1228,7 @@ pub(super) fn poll_binding_process_descriptor(
                                                 tcp_flags: meta.tcp_flags,
                                             };
                                             let _ = publish_live_session_entry(
-                                                binding.session_map_fd,
+                                                binding.bpf_maps.session_map_fd,
                                                 &flow.forward_key,
                                                 decision.nat,
                                                 false,
@@ -1348,13 +1348,13 @@ pub(super) fn poll_binding_process_descriptor(
                                             )
                                         {
                                             let _ = publish_live_session_key(
-                                                binding.session_map_fd,
+                                                binding.bpf_maps.session_map_fd,
                                                 &reverse_key,
                                             );
                                             // Verify session keys and log creations (debug-only: BPF syscalls)
                                             if cfg!(feature = "debug-log") {
                                                 if verify_session_key_in_bpf(
-                                                    binding.session_map_fd,
+                                                    binding.bpf_maps.session_map_fd,
                                                     &reverse_key,
                                                 ) {
                                                     SESSION_PUBLISH_VERIFY_OK
@@ -1371,11 +1371,11 @@ pub(super) fn poll_binding_process_descriptor(
                                                         reverse_key.src_port,
                                                         reverse_key.dst_ip,
                                                         reverse_key.dst_port,
-                                                        binding.session_map_fd,
+                                                        binding.bpf_maps.session_map_fd,
                                                     );
                                                 }
                                                 if !verify_session_key_in_bpf(
-                                                    binding.session_map_fd,
+                                                    binding.bpf_maps.session_map_fd,
                                                     &flow.forward_key,
                                                 ) {
                                                     debug_log!(
@@ -1412,13 +1412,13 @@ pub(super) fn poll_binding_process_descriptor(
                                                         reverse_key.dst_port,
                                                         decision.nat.rewrite_src,
                                                         decision.nat.rewrite_dst,
-                                                        binding.session_map_fd,
+                                                        binding.bpf_maps.session_map_fd,
                                                         count_bpf_session_entries(
-                                                            binding.session_map_fd
+                                                            binding.bpf_maps.session_map_fd
                                                         ),
                                                     );
                                                     dump_bpf_session_entries(
-                                                        binding.session_map_fd,
+                                                        binding.bpf_maps.session_map_fd,
                                                         20,
                                                     );
                                                 }
@@ -2089,7 +2089,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             &entry,
                                         );
                                         let _ = publish_session_map_entry_for_session(
-                                            binding.session_map_fd,
+                                            binding.bpf_maps.session_map_fd,
                                             &flow.forward_key,
                                             pending_decision,
                                             &entry.metadata,

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -668,16 +668,16 @@ pub(super) fn teardown_tcp_rst_flow(
     let reverse_key = reverse_session_key(forward_key, nat);
     sessions.delete(forward_key);
     sessions.delete(&reverse_key);
-    delete_live_session_entry(current.session_map_fd, forward_key, nat, false);
-    delete_live_session_entry(current.session_map_fd, &reverse_key, nat, true);
+    delete_live_session_entry(current.bpf_maps.session_map_fd, forward_key, nat, false);
+    delete_live_session_entry(current.bpf_maps.session_map_fd, &reverse_key, nat, true);
     delete_bpf_conntrack_entry(
-        current.conntrack_v4_fd,
-        current.conntrack_v6_fd,
+        current.bpf_maps.conntrack_v4_fd,
+        current.bpf_maps.conntrack_v6_fd,
         forward_key,
     );
     delete_bpf_conntrack_entry(
-        current.conntrack_v4_fd,
-        current.conntrack_v6_fd,
+        current.bpf_maps.conntrack_v4_fd,
+        current.bpf_maps.conntrack_v6_fd,
         &reverse_key,
     );
     remove_shared_session(

--- a/userspace-dp/src/afxdp/worker/bpf_maps.rs
+++ b/userspace-dp/src/afxdp/worker/bpf_maps.rs
@@ -1,0 +1,32 @@
+//! #959 Phase 5 — extracts the per-binding BPF map file descriptors
+//! out of `BindingWorker` into a dedicated `WorkerBpfMaps` sub-struct.
+//!
+//! These four FDs are opened once at binding construction (from the
+//! coordinator's pinned BPF map paths) and used through the binding's
+//! lifetime for: heartbeat updates (per-second), session table
+//! deltas (per-RX-batch), and conntrack v4/v6 lookups during fast-
+//! path session resolution.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-5. Field names preserved so
+//! `binding.bpf_maps.heartbeat_map_fd` keeps the same grep-friendly
+//! suffix as the original `binding.heartbeat_map_fd`.
+
+use std::ffi::c_int;
+
+/// Per-binding BPF map file descriptors. Opened once at binding
+/// construction; constant for the binding's lifetime.
+///
+/// **Intentionally NOT `Default`** — these are real OS-level file
+/// descriptors. A `WorkerBpfMaps::default()` would silently produce
+/// `c_int = 0` (which is `stdin`), which any subsequent BPF syscall
+/// would treat as a valid (wrong) FD with potentially destructive
+/// effects. Construction must go through the explicit literal in
+/// `BindingWorker::create` which receives the FDs from the
+/// coordinator's already-validated `OwnedFd` opens.
+pub(crate) struct WorkerBpfMaps {
+    pub(crate) heartbeat_map_fd: c_int,
+    pub(crate) session_map_fd: c_int,
+    pub(crate) conntrack_v4_fd: c_int,
+    pub(crate) conntrack_v6_fd: c_int,
+}

--- a/userspace-dp/src/afxdp/worker/bpf_maps.rs
+++ b/userspace-dp/src/afxdp/worker/bpf_maps.rs
@@ -12,7 +12,10 @@
 //! `binding.bpf_maps.heartbeat_map_fd` keeps the same grep-friendly
 //! suffix as the original `binding.heartbeat_map_fd`.
 
-use std::ffi::c_int;
+// Use `core::ffi::c_int` to match the rest of the afxdp module which
+// pulls `c_int` via `super::*` (e.g. afxdp/mod.rs, bpf_map.rs). This
+// keeps the FFI integer type source consistent across the crate.
+use core::ffi::c_int;
 
 /// Per-binding BPF map file descriptors. Opened once at binding
 /// construction; constant for the binding's lifetime.

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -25,6 +25,10 @@ pub(crate) use cos_state::WorkerCos;
 mod tx_counters;
 pub(crate) use tx_counters::WorkerTxCounters;
 
+// #959 Phase 5: per-binding BPF map FDs live in worker/bpf_maps.rs.
+mod bpf_maps;
+pub(crate) use bpf_maps::WorkerBpfMaps;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -110,10 +114,9 @@ pub(crate) struct BindingWorker {
     /// (not recycled) until the neighbor resolves or the entry times out.
     pub(crate) pending_neigh: VecDeque<PendingNeighPacket>,
     pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
-    pub(crate) heartbeat_map_fd: c_int,
-    pub(crate) session_map_fd: c_int,
-    pub(crate) conntrack_v4_fd: c_int,
-    pub(crate) conntrack_v6_fd: c_int,
+    /// #959 Phase 5: 4 BPF map FDs extracted into `WorkerBpfMaps`.
+    /// Field semantics unchanged; access via `binding.bpf_maps.X_fd`.
+    pub(crate) bpf_maps: WorkerBpfMaps,
     pub(crate) last_heartbeat_update_ns: u64,
     pub(crate) debug_state_counter: u32,
     pub(crate) last_rx_wake_ns: u64,
@@ -387,10 +390,12 @@ impl BindingWorker {
             // packets actually queue up.
             pending_neigh: VecDeque::new(),
             in_flight_prepared_recycles: FastMap::default(),
-            heartbeat_map_fd,
-            session_map_fd,
-            conntrack_v4_fd,
-            conntrack_v6_fd,
+            bpf_maps: WorkerBpfMaps {
+                heartbeat_map_fd,
+                session_map_fd,
+                conntrack_v4_fd,
+                conntrack_v6_fd,
+            },
             last_heartbeat_update_ns: init_now,
             debug_state_counter: 0,
             last_rx_wake_ns: init_now,
@@ -651,15 +656,15 @@ pub(crate) fn worker_loop(
     // Cache BPF map FDs — they don't change during the worker's lifetime.
     let session_map_fd = bindings
         .first()
-        .map(|binding| binding.session_map_fd)
+        .map(|binding| binding.bpf_maps.session_map_fd)
         .unwrap_or(-1);
     let conntrack_v4_fd = bindings
         .first()
-        .map(|binding| binding.conntrack_v4_fd)
+        .map(|binding| binding.bpf_maps.conntrack_v4_fd)
         .unwrap_or(-1);
     let conntrack_v6_fd = bindings
         .first()
-        .map(|binding| binding.conntrack_v6_fd)
+        .map(|binding| binding.bpf_maps.conntrack_v6_fd)
         .unwrap_or(-1);
     let mut last_ct_refresh_ns: u64 = 0;
     cos_status.store(Arc::new(build_worker_cos_statuses(
@@ -1029,7 +1034,7 @@ pub(crate) fn worker_loop(
                     flush_session_deltas(
                         &ident,
                         &binding.live,
-                        binding.session_map_fd,
+                        binding.bpf_maps.session_map_fd,
                         conntrack_v4_fd,
                         conntrack_v6_fd,
                         &deltas,
@@ -1055,7 +1060,7 @@ pub(crate) fn worker_loop(
                 flush_session_deltas(
                     &ident,
                     &binding.live,
-                    binding.session_map_fd,
+                    binding.bpf_maps.session_map_fd,
                     conntrack_v4_fd,
                     conntrack_v6_fd,
                     &deltas,
@@ -1271,7 +1276,7 @@ pub(crate) fn worker_loop(
                     SESSION_PUBLISH_VERIFY_OK.swap(0, Ordering::Relaxed),
                     SESSION_PUBLISH_VERIFY_FAIL.swap(0, Ordering::Relaxed),
                     if let Some(b) = bindings.first() {
-                        count_bpf_session_entries(b.session_map_fd)
+                        count_bpf_session_entries(b.bpf_maps.session_map_fd)
                     } else {
                         0
                     },
@@ -1434,7 +1439,7 @@ pub(crate) fn worker_loop(
                         if let Some(b) = bindings.first() {
                             eprintln!(
                                 "DBG STALL_BPF_SESSIONS: entries={}",
-                                count_bpf_session_entries(b.session_map_fd)
+                                count_bpf_session_entries(b.bpf_maps.session_map_fd)
                             );
                         }
                     } else if prev_fwd_total > 0 {


### PR DESCRIPTION
## Summary

Phase 5 of **#959** BindingWorker decomposition.
- Phase 1 (#1167): 23 \`dbg_*\` → \`WorkerTelemetry\`
- Phase 2 (#1168): 11 \`scratch_*\` → \`WorkerScratch\`
- Phase 3 (#1169): 5 \`cos_*\` → \`WorkerCos\`
- Phase 4 (#1170): 6 \`pending_*_tx_*\` → \`WorkerTxCounters\`
- **Phase 5 (this PR): 4 BPF map FDs → \`WorkerBpfMaps\`**

Moves 4 BPF map file descriptors out of `BindingWorker`:

| Field |
|-------|
| `heartbeat_map_fd` |
| `session_map_fd` |
| `conntrack_v4_fd` |
| `conntrack_v6_fd` |

Access pattern: `binding.bpf_maps.X_fd`.

## Methodology

Same compiler-driven approach as Phases 1-4. 24 callsites across 4
files (worker/mod.rs, poll_descriptor.rs, session_glue/mod.rs,
bpf_map.rs).

`WorkerBpfMaps` has **NO `Default`** derive — these are real OS
FDs and a `c_int = 0` default would alias `stdin`, with potentially
destructive consequences if any later BPF syscall used it.

**Important caught by build:** the `BindingPlan` struct
(`runtime.rs`) also has fields named `heartbeat_map_fd` etc. The
initial perl over-replacement hit `plan.heartbeat_map_fd →
plan.bpf_maps.heartbeat_map_fd` and the build failed there.
Reverted those four lines: `BindingPlan` stays flat-fields;
BindingWorker gains the nested sub-struct.

## Files affected

| File | Change |
|------|--------|
| `userspace-dp/src/afxdp/worker/bpf_maps.rs` | new, 31 LOC |
| `userspace-dp/src/afxdp/worker/mod.rs` | -4 fields, +nested literal |
| `userspace-dp/src/afxdp/poll_descriptor.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/session_glue/mod.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/bpf_map.rs` | callsite rewrites |
| `docs/pr/959-phase5-bpfmaps/plan.md` | new plan |

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `cargo test --release flush_clears_records_and_increments_sequence` — 5/5 named runs (the prior sandbox-flake test, per the standing rule)
- [x] `go build ./...` clean
- [x] `go test ./...` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 957 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke `2001:559:8585:80::200` — 945 Mbps, 0 retr

## NOT in scope

- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred
- `flow_cache` → cache, not FD
- TX pipeline state (`free_tx_frames`, `pending_tx_*`) → separate group
- `#[repr(align(64))]` cache-line alignment — late phase

## #959 progress

| Phase | Fields | PR | BindingWorker count after |
|-------|--------|-----|--------------------------|
| Pre-#959 | — | — | 80+ |
| 1: dbg_* | 23 | #1167 | ~57 |
| 2: scratch_* | 11 | #1168 | ~46 |
| 3: cos_* | 5 | #1169 | ~41 |
| 4: pending_*_tx_* | 6 | #1170 | ~35 |
| **5: BPF FDs (this PR)** | 4 | this | **~31** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)