### PR TITLE
#959 Phase 6: extract timing/wake fields into WorkerTimers sub-struct

### DIFF
--- a/docs/pr/959-phase6-timers/plan.md
+++ b/docs/pr/959-phase6-timers/plan.md
@@ -1,0 +1,58 @@
+# Plan: #959 Phase 6 — extract timing/wake state into `WorkerTimers`
+
+## Status
+
+Phase 6 of #959. Phases 1-5 (#1167, #1168, #1169, #1170, #1171)
+extracted dbg_*, scratch_*, cos_*, pending_*_tx_*, BPF FDs.
+
+## Scope
+
+Move 5 timing/wake-pacing fields out of `BindingWorker` into a new
+`WorkerTimers` sub-struct:
+
+```
+last_heartbeat_update_ns, debug_state_counter,
+last_rx_wake_ns, last_tx_wake_ns, empty_rx_polls
+```
+
+Access pattern: `binding.timers.last_X_ns` etc.
+
+These fields gate per-binding pacing decisions: when to TX wake-up
+syscall, when to RX wake, when to update the BPF heartbeat map, and
+the per-second debug-tick counter.
+
+## NOT moved
+
+`outstanding_tx` stays at the BindingWorker level — it's a TX
+pipeline counter (sequenced for Phase 7 alongside `free_tx_frames`,
+`pending_tx_*`, etc.), not a timer.
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-5. 13 callsites across 4
+files (worker/lifecycle.rs, tx/rings.rs, umem/mod.rs, bpf_map.rs) —
+smallest phase yet.
+
+`WorkerTimers` has NO `Default` — derived Default would seed the
+last-wake timestamps with 0, causing the first heartbeat / RX-wake /
+TX-wake decisions to fire immediately as if the binding had been
+idle since epoch.
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5/5 named runs.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against 172.16.80.200 / 2001:559:8585:80::200.
+- Codex hostile review.
+
+## NOT in scope
+
+- TX pipeline state (`free_tx_frames`, `pending_tx_*`,
+  `max_pending_tx`, `pending_fill_frames`,
+  `in_flight_prepared_recycles`, `outstanding_tx`,
+  `tx_submit_ns`) → Phase 7.
+- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred.
+- `flow_cache*`, `pending_neigh`, bind metadata → separate phases.

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -138,7 +138,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
     // The fill ring is primed before bind, so the driver's initial NAPI
     // posts WQEs immediately. All queues should be ready to receive.
     // No xsk_rx_confirmed gating needed.
-    let age_ns = now_ns.saturating_sub(binding.last_heartbeat_update_ns);
+    let age_ns = now_ns.saturating_sub(binding.timers.last_heartbeat_update_ns);
     if age_ns < HEARTBEAT_UPDATE_INTERVAL_NS {
         return;
     }
@@ -178,7 +178,7 @@ pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
                     }
                 });
             }
-            binding.last_heartbeat_update_ns = now_ns;
+            binding.timers.last_heartbeat_update_ns = now_ns;
         }
         Err(err) => {
             eprintln!(

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -121,7 +121,7 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
     // Without the needs_wakeup gate, every drain triggers a sendto() syscall
     // (142K/sec at line rate), spending ~20% CPU in syscall entry/exit.
     if binding.device.needs_wakeup()
-        || now_ns.saturating_sub(binding.last_rx_wake_ns) >= FILL_WAKE_SAFETY_INTERVAL_NS
+        || now_ns.saturating_sub(binding.timers.last_rx_wake_ns) >= FILL_WAKE_SAFETY_INTERVAL_NS
     {
         maybe_wake_rx(binding, true, now_ns);
     }
@@ -140,11 +140,11 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
     // processing — using sendto() for RX wake was the root cause of
     // fill ring starvation on idle interfaces with zero-copy mlx5.
     if !force {
-        binding.empty_rx_polls = binding.empty_rx_polls.saturating_add(1);
-        if binding.empty_rx_polls < RX_WAKE_IDLE_POLLS {
+        binding.timers.empty_rx_polls = binding.timers.empty_rx_polls.saturating_add(1);
+        if binding.timers.empty_rx_polls < RX_WAKE_IDLE_POLLS {
             return;
         }
-        if now_ns.saturating_sub(binding.last_rx_wake_ns) < RX_WAKE_MIN_INTERVAL_NS {
+        if now_ns.saturating_sub(binding.timers.last_rx_wake_ns) < RX_WAKE_MIN_INTERVAL_NS {
             return;
         }
     }
@@ -175,8 +175,8 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
     }
     binding.telemetry.dbg_rx_wakeups += 1;
     binding.live.rx_wakeups.fetch_add(1, Ordering::Relaxed);
-    binding.last_rx_wake_ns = now_ns;
-    binding.empty_rx_polls = 0;
+    binding.timers.last_rx_wake_ns = now_ns;
+    binding.timers.empty_rx_polls = 0;
 }
 
 fn apply_prepared_recycle(
@@ -213,7 +213,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
     if !bind_mode.is_zerocopy()
         || binding.tx.needs_wakeup()
         || force
-        || now_ns.saturating_sub(binding.last_tx_wake_ns) >= TX_WAKE_MIN_INTERVAL_NS
+        || now_ns.saturating_sub(binding.timers.last_tx_wake_ns) >= TX_WAKE_MIN_INTERVAL_NS
     {
         // Use direct sendto() instead of binding.tx.wake() so we can capture errors.
         let fd = binding.tx.as_raw_fd();
@@ -301,7 +301,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                 }
             }
         }
-        binding.last_tx_wake_ns = now_ns;
+        binding.timers.last_tx_wake_ns = now_ns;
     }
 }
 

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -989,8 +989,8 @@ impl BindingLiveState {
 pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
     // Use a simple modular counter to avoid 7 atomic stores on every call.
     // At ~1M calls/sec, checking every 65536 calls ~= every 65ms.
-    binding.debug_state_counter = binding.debug_state_counter.wrapping_add(1);
-    if binding.debug_state_counter & 0xFFFF != 0 {
+    binding.timers.debug_state_counter = binding.timers.debug_state_counter.wrapping_add(1);
+    if binding.timers.debug_state_counter & 0xFFFF != 0 {
         return;
     }
     if binding.tx_counters.pending_direct_tx_packets != 0 {

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -151,7 +151,7 @@ pub(super) fn poll_binding(
             update_binding_debug_state(binding);
             return did_work;
         }
-        binding.empty_rx_polls = 0;
+        binding.timers.empty_rx_polls = 0;
         if ident.is_none() {
             ident = Some(binding.identity());
         }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -29,6 +29,11 @@ pub(crate) use tx_counters::WorkerTxCounters;
 mod bpf_maps;
 pub(crate) use bpf_maps::WorkerBpfMaps;
 
+// #959 Phase 6: per-binding timing / wake-pacing state lives in
+// worker/timers.rs.
+mod timers;
+pub(crate) use timers::WorkerTimers;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -117,12 +122,13 @@ pub(crate) struct BindingWorker {
     /// #959 Phase 5: 4 BPF map FDs extracted into `WorkerBpfMaps`.
     /// Field semantics unchanged; access via `binding.bpf_maps.X_fd`.
     pub(crate) bpf_maps: WorkerBpfMaps,
-    pub(crate) last_heartbeat_update_ns: u64,
-    pub(crate) debug_state_counter: u32,
-    pub(crate) last_rx_wake_ns: u64,
-    pub(crate) last_tx_wake_ns: u64,
+    /// #959 Phase 6: 5 timing / wake-pacing fields extracted into
+    /// `WorkerTimers`. Field semantics unchanged; access via
+    /// `binding.timers.last_X_ns` etc. `outstanding_tx` stays at
+    /// the BindingWorker level — it's a TX-pipeline counter
+    /// (sequenced for Phase 7), not a timer.
+    pub(crate) timers: WorkerTimers,
     pub(crate) outstanding_tx: u32,
-    pub(crate) empty_rx_polls: u32,
     pub(crate) last_learned_neighbor: Option<LearnedNeighborKey>,
     /// #959 Phase 1: 23 `dbg_*` debug counters extracted into
     /// `WorkerTelemetry` to reduce BindingWorker's mutable surface
@@ -396,12 +402,14 @@ impl BindingWorker {
                 conntrack_v4_fd,
                 conntrack_v6_fd,
             },
-            last_heartbeat_update_ns: init_now,
-            debug_state_counter: 0,
-            last_rx_wake_ns: init_now,
-            last_tx_wake_ns: init_now,
+            timers: WorkerTimers {
+                last_heartbeat_update_ns: init_now,
+                debug_state_counter: 0,
+                last_rx_wake_ns: init_now,
+                last_tx_wake_ns: init_now,
+                empty_rx_polls: 0,
+            },
             outstanding_tx: 0,
-            empty_rx_polls: 0,
             last_learned_neighbor: None,
             telemetry: WorkerTelemetry::default(),
             tx_counters: WorkerTxCounters {

--- a/userspace-dp/src/afxdp/worker/timers.rs
+++ b/userspace-dp/src/afxdp/worker/timers.rs
@@ -1,0 +1,31 @@
+//! #959 Phase 6 — extracts the per-binding timing / wake-pacing
+//! fields out of `BindingWorker` into a dedicated `WorkerTimers`
+//! sub-struct.
+//!
+//! These five fields gate per-binding pacing decisions: when to
+//! send a TX wake-up syscall (last_tx_wake_ns), when to RX wake
+//! (last_rx_wake_ns), when to update the BPF heartbeat map
+//! (last_heartbeat_update_ns), and the per-second debug-tick
+//! counter (debug_state_counter / empty_rx_polls).
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-6. Field names preserved so
+//! `binding.timers.last_rx_wake_ns` keeps the same grep-friendly
+//! suffix as the original `binding.last_rx_wake_ns`.
+
+/// Per-binding timing / wake-pacing state.
+///
+/// **Intentionally NOT `Default`** — for consistency with the
+/// other #959 sub-structs. The legitimate construction goes through
+/// the explicit literal in `BindingWorker::create` which seeds the
+/// timestamps with `init_now` (a single sampled `monotonic_nanos()`
+/// at worker construction); a derived Default would seed with 0,
+/// causing the first heartbeat / RX-wake / TX-wake decisions to
+/// immediately fire as if the binding had been idle since epoch.
+pub(crate) struct WorkerTimers {
+    pub(crate) last_heartbeat_update_ns: u64,
+    pub(crate) debug_state_counter: u32,
+    pub(crate) last_rx_wake_ns: u64,
+    pub(crate) last_tx_wake_ns: u64,
+    pub(crate) empty_rx_polls: u32,
+}


### PR DESCRIPTION
## Summary

Phase 6 of **#959** BindingWorker decomposition.
- Phases 1-5 (#1167-#1171): \`dbg_*\`, \`scratch_*\`, \`cos_*\`, \`pending_*_tx_*\`, BPF FDs
- **Phase 6 (this PR): 5 timing/wake fields → \`WorkerTimers\`**

Moves 5 per-binding timing / wake-pacing fields:

| Field |
|-------|
| \`last_heartbeat_update_ns\` |
| \`debug_state_counter\` |
| \`last_rx_wake_ns\` |
| \`last_tx_wake_ns\` |
| \`empty_rx_polls\` |

Access pattern: \`binding.timers.last_X_ns\` etc.

These fields gate per-binding pacing decisions: TX wake-up syscall
timing, RX wake, BPF heartbeat map update cadence, and the per-second
debug-tick counter.

**`outstanding_tx` stays at the BindingWorker level** — it's a TX
pipeline counter (sequenced for Phase 7), not a timer.

## Methodology

Same compiler-driven approach as Phases 1-5. **13 callsites across 4
files** — smallest phase yet.

`WorkerTimers` has **NO `Default`** — a derived Default would seed
the last-wake timestamps with 0, making the first heartbeat/RX-wake/
TX-wake decisions fire immediately as if the binding had been idle
since epoch. Construction goes through the explicit literal in
`BindingWorker::create` which seeds with `init_now`.

## Files affected

| File | Change |
|------|--------|
| `userspace-dp/src/afxdp/worker/timers.rs` | new, 32 LOC |
| `userspace-dp/src/afxdp/worker/mod.rs` | -5 fields, +nested literal |
| `userspace-dp/src/afxdp/worker/lifecycle.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/tx/rings.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/umem/mod.rs` | callsite rewrites |
| `userspace-dp/src/afxdp/bpf_map.rs` | callsite rewrites |
| `docs/pr/959-phase6-timers/plan.md` | new plan |

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 952 passed, 0 failed
- [x] `cargo test --release flush_clears_records_and_increments_sequence` — 5/5 named runs (per the standing rule)
- [x] `go build ./...` clean
- [x] `go test ./...` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke `172.16.80.200` — 960 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke `2001:559:8585:80::200` — 945 Mbps, 0 retr

## #959 progress

| Phase | Fields | PR | BindingWorker after |
|-------|--------|-----|--------------------|
| Pre-#959 | — | — | 80+ |
| 1: dbg_* | 23 | #1167 | ~57 |
| 2: scratch_* | 11 | #1168 | ~46 |
| 3: cos_* | 5 | #1169 | ~41 |
| 4: pending_*_tx_* | 6 | #1170 | ~35 |
| 5: BPF FDs | 4 | #1171 | ~31 |
| **6: timers (this PR)** | 5 | this | **~26** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)