### PR TITLE
#959 Phase 7: extract TX pipeline state into WorkerTxPipeline sub-struct

### DIFF
--- a/docs/pr/959-phase7-tx-pipeline/plan.md
+++ b/docs/pr/959-phase7-tx-pipeline/plan.md
@@ -1,0 +1,54 @@
+# Plan: #959 Phase 7 — extract TX pipeline state into `WorkerTxPipeline`
+
+## Status
+
+Phase 7 of #959. Phases 1-6 (#1167-#1172) extracted dbg_*, scratch_*,
+cos_*, pending_*_tx_*, BPF FDs, timers.
+
+## Scope
+
+Move 7 TX pipeline fields out of `BindingWorker` into a new
+`WorkerTxPipeline` sub-struct accessed via `binding.tx_pipeline.X`:
+
+```
+free_tx_frames, pending_tx_prepared, pending_tx_local,
+max_pending_tx, pending_fill_frames, in_flight_prepared_recycles,
+tx_submit_ns
+```
+
+**`outstanding_tx` deliberately excluded** — it collides with the
+`BindingStatus.outstanding_tx` snapshot mirror at
+`coordinator/mod.rs:1227,1353` and `protocol.rs:1611`. Will handle
+in a tiny followup phase that disambiguates by type.
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-6. **158 callsites across
+13 files** — largest phase by far.
+
+`WorkerTxPipeline` has NO `Default` derive — `tx_submit_ns` must be
+sized to `total_frames` at construction (`Box<[u64]>` of
+`TX_SIDECAR_UNSTAMPED` sentinels), not zero-length. Construction
+goes through the explicit literal in `BindingWorker::create`.
+
+Collision-avoidance: `live.max_pending_tx` accesses on
+`BindingLiveState` (atomic mirror) at `umem/tests.rs:41,86,107` and
+similar must NOT be rewritten. The compiler protects: BindingLiveState
+doesn't have a `tx_pipeline` field, so any over-replacement fails to
+build.
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5/5 named runs.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against 172.16.80.200 / 2001:559:8585:80::200.
+- Codex hostile review.
+
+## NOT in scope
+
+- `outstanding_tx` → tiny followup phase.
+- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred.
+- `flow_cache*`, `pending_neigh`, bind metadata → separate phases.

--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -33,7 +33,7 @@ pub(super) fn service_exact_local_queue_direct(
             shared_recycles,
         );
     }
-    if binding.free_tx_frames.is_empty() {
+    if binding.tx_pipeline.free_tx_frames.is_empty() {
         let _ = reap_tx_completions(binding, shared_recycles);
     }
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
@@ -54,7 +54,7 @@ pub(super) fn service_exact_local_queue_direct(
         };
         drain_exact_local_fifo_items_to_scratch(
             queue,
-            &mut binding.free_tx_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
             &mut binding.scratch.scratch_exact_local_tx,
             binding.umem.area(),
             root_budget,
@@ -69,7 +69,7 @@ pub(super) fn service_exact_local_queue_direct(
             dropped_bytes,
         } => {
             release_exact_local_scratch_frames(
-                &mut binding.free_tx_frames,
+                &mut binding.tx_pipeline.free_tx_frames,
                 &mut binding.scratch.scratch_exact_local_tx,
             );
             if dropped_bytes > 0 {
@@ -120,7 +120,7 @@ pub(super) fn service_exact_local_queue_direct(
     // `free_tx_frames` and MUST NOT be stamped.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_exact_local_tx
             .iter()
@@ -135,7 +135,7 @@ pub(super) fn service_exact_local_queue_direct(
         count_tx_ring_full_submit_stall(binding, root_ifindex, queue_idx, dropped);
         maybe_wake_tx(binding, true, now_ns);
         release_exact_local_scratch_frames(
-            &mut binding.free_tx_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
             &mut binding.scratch.scratch_exact_local_tx,
         );
         refresh_cos_interface_activity(binding, root_ifindex);
@@ -150,7 +150,7 @@ pub(super) fn service_exact_local_queue_direct(
             .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
-        &mut binding.free_tx_frames,
+        &mut binding.tx_pipeline.free_tx_frames,
         &mut binding.scratch.scratch_exact_local_tx,
         inserted as usize,
     );
@@ -177,7 +177,7 @@ fn service_exact_local_queue_direct_flow_fair(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> bool {
-    if binding.free_tx_frames.is_empty() {
+    if binding.tx_pipeline.free_tx_frames.is_empty() {
         let _ = reap_tx_completions(binding, shared_recycles);
     }
     let queue_dscp_rewrite = cos_queue_dscp_rewrite(binding, root_ifindex, queue_idx);
@@ -198,7 +198,7 @@ fn service_exact_local_queue_direct_flow_fair(
         };
         drain_exact_local_items_to_scratch_flow_fair(
             queue,
-            &mut binding.free_tx_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
             &mut binding.scratch.scratch_local_tx,
             binding.umem.area(),
             root_budget,
@@ -217,7 +217,7 @@ fn service_exact_local_queue_direct_flow_fair(
                     .cos.cos_interfaces
                     .get_mut(&root_ifindex)
                     .and_then(|root| root.queues.get_mut(queue_idx)),
-                &mut binding.free_tx_frames,
+                &mut binding.tx_pipeline.free_tx_frames,
                 &mut binding.scratch.scratch_local_tx,
             );
             if dropped_bytes > 0 {
@@ -265,7 +265,7 @@ fn service_exact_local_queue_direct_flow_fair(
     // ring submit from being attributed to submit→completion latency.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_local_tx
             .iter()
@@ -284,7 +284,7 @@ fn service_exact_local_queue_direct_flow_fair(
                 .cos.cos_interfaces
                 .get_mut(&root_ifindex)
                 .and_then(|root| root.queues.get_mut(queue_idx)),
-            &mut binding.free_tx_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
             &mut binding.scratch.scratch_local_tx,
         );
         refresh_cos_interface_activity(binding, root_ifindex);
@@ -299,7 +299,7 @@ fn service_exact_local_queue_direct_flow_fair(
             .cos.cos_interfaces
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
-        &mut binding.free_tx_frames,
+        &mut binding.tx_pipeline.free_tx_frames,
         &mut binding.scratch.scratch_local_tx,
         inserted as usize,
     );
@@ -361,8 +361,8 @@ pub(super) fn service_exact_prepared_queue_direct(
             queue,
             &mut binding.scratch.scratch_exact_prepared_tx,
             binding.umem.area(),
-            &mut binding.free_tx_frames,
-            &mut binding.pending_fill_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
+            &mut binding.tx_pipeline.pending_fill_frames,
             binding.slot,
             root_budget,
             secondary_budget,
@@ -428,7 +428,7 @@ pub(super) fn service_exact_prepared_queue_direct(
     // not the moment before a potential preemption window.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_exact_prepared_tx
             .iter()
@@ -458,7 +458,7 @@ pub(super) fn service_exact_prepared_queue_direct(
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.scratch.scratch_exact_prepared_tx,
-        &mut binding.in_flight_prepared_recycles,
+        &mut binding.tx_pipeline.in_flight_prepared_recycles,
         inserted as usize,
     );
     // #940: post-settle V_min publish. FIFO queues have
@@ -502,8 +502,8 @@ fn service_exact_prepared_queue_direct_flow_fair(
             queue,
             &mut binding.scratch.scratch_prepared_tx,
             binding.umem.area(),
-            &mut binding.free_tx_frames,
-            &mut binding.pending_fill_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
+            &mut binding.tx_pipeline.pending_fill_frames,
             binding.slot,
             root_budget,
             secondary_budget,
@@ -574,7 +574,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     // exact_local variant above for the preemption-window rationale.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_prepared_tx
             .iter()
@@ -610,7 +610,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
             .get_mut(&root_ifindex)
             .and_then(|root| root.queues.get_mut(queue_idx)),
         &mut binding.scratch.scratch_prepared_tx,
-        &mut binding.in_flight_prepared_recycles,
+        &mut binding.tx_pipeline.in_flight_prepared_recycles,
         inserted as usize,
     );
     // #940: post-settle V_min publish. Settle has applied any

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -96,7 +96,7 @@ pub(super) fn retry_pending_neigh(
             .expect("pending_neigh shrank during retry sweep");
         // Timeout: recycle frame and drop.
         if now_ns.saturating_sub(pkt.queued_ns) > PENDING_NEIGH_TIMEOUT_NS {
-            binding.pending_fill_frames.push_back(pkt.addr);
+            binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
             continue;
         }
         // Check if neighbor MAC is now available, mirroring the lookup
@@ -165,7 +165,7 @@ pub(super) fn retry_pending_neigh(
             false,
             expected_ports,
         ) else {
-            binding.pending_fill_frames.push_back(pkt.addr);
+            binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
             continue;
         };
         let target_ifindex = if decision.resolution.tx_ifindex > 0 {
@@ -179,7 +179,7 @@ pub(super) fn retry_pending_neigh(
             ingress_queue,
             target_ifindex,
         ) else {
-            binding.pending_fill_frames.push_back(pkt.addr);
+            binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
             continue;
         };
         let cos = resolve_cos_tx_selection(
@@ -201,14 +201,14 @@ pub(super) fn retry_pending_neigh(
             dscp_rewrite: cos.dscp_rewrite,
         };
         if target_idx == binding_index {
-            binding.pending_tx_prepared.push_back(req);
+            binding.tx_pipeline.pending_tx_prepared.push_back(req);
         } else if let Some(target) =
             binding_by_index_mut(left, binding_index, binding, right, target_idx)
         {
-            target.pending_tx_prepared.push_back(req);
+            target.tx_pipeline.pending_tx_prepared.push_back(req);
             bound_pending_tx_prepared(target);
         } else {
-            binding.pending_fill_frames.push_back(pkt.addr);
+            binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
         }
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -366,7 +366,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             )
                                         });
                                         if let Some(frame_len) = frame_len {
-                                            binding.pending_tx_prepared.push_back(
+                                            binding.tx_pipeline.pending_tx_prepared.push_back(
                                                 PreparedTxRequest {
                                                     offset: desc.addr,
                                                     len: frame_len,

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -721,24 +721,24 @@ pub(super) fn cancel_queued_flow_on_binding(
     forward_key: &SessionKey,
     reverse_key: &SessionKey,
 ) {
-    let mut kept_local = VecDeque::with_capacity(binding.pending_tx_local.len());
-    while let Some(req) = binding.pending_tx_local.pop_front() {
+    let mut kept_local = VecDeque::with_capacity(binding.tx_pipeline.pending_tx_local.len());
+    while let Some(req) = binding.tx_pipeline.pending_tx_local.pop_front() {
         if tx_request_matches_flow(&req, forward_key, reverse_key) {
             continue;
         }
         kept_local.push_back(req);
     }
-    binding.pending_tx_local = kept_local;
+    binding.tx_pipeline.pending_tx_local = kept_local;
 
-    let mut kept_prepared = VecDeque::with_capacity(binding.pending_tx_prepared.len());
-    while let Some(req) = binding.pending_tx_prepared.pop_front() {
+    let mut kept_prepared = VecDeque::with_capacity(binding.tx_pipeline.pending_tx_prepared.len());
+    while let Some(req) = binding.tx_pipeline.pending_tx_prepared.pop_front() {
         if prepared_request_matches_flow(&req, forward_key, reverse_key) {
             recycle_cancelled_prepared(binding, &req);
             continue;
         }
         kept_prepared.push_back(req);
     }
-    binding.pending_tx_prepared = kept_prepared;
+    binding.tx_pipeline.pending_tx_prepared = kept_prepared;
 
     // #706: the cross-worker redirect inbox (`binding.live.pending_tx`) is
     // now a lock-free MPSC ring (`MpscInbox`). In-place filtering from an
@@ -763,7 +763,7 @@ pub(super) fn cancel_pending_forwards(
     let mut kept = Vec::with_capacity(pending_forwards.len());
     for req in pending_forwards.drain(..) {
         if pending_forward_matches_flow(&req, forward_key, reverse_key) {
-            binding.pending_fill_frames.push_back(req.desc.addr);
+            binding.tx_pipeline.pending_fill_frames.push_back(req.desc.addr);
             continue;
         }
         kept.push(req);
@@ -773,11 +773,11 @@ pub(super) fn cancel_pending_forwards(
 
 pub(super) fn recycle_cancelled_prepared(binding: &mut BindingWorker, req: &PreparedTxRequest) {
     match req.recycle {
-        PreparedTxRecycle::FreeTxFrame => binding.free_tx_frames.push_back(req.offset),
+        PreparedTxRecycle::FreeTxFrame => binding.tx_pipeline.free_tx_frames.push_back(req.offset),
         PreparedTxRecycle::FillOnSlot(slot) if slot == binding.slot => {
-            binding.pending_fill_frames.push_back(req.offset);
+            binding.tx_pipeline.pending_fill_frames.push_back(req.offset);
         }
-        PreparedTxRecycle::FillOnSlot(_) => binding.free_tx_frames.push_back(req.offset),
+        PreparedTxRecycle::FillOnSlot(_) => binding.tx_pipeline.free_tx_frames.push_back(req.offset),
     }
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -334,7 +334,7 @@ pub(in crate::afxdp) fn enqueue_local_into_cos(
         .get(&egress_ifindex)
         .is_some_and(|root| cos_queue_accepts_prepared(root, req.cos_queue_id))
     {
-        match prepare_local_request_for_cos(binding.umem.area(), &mut binding.free_tx_frames, req) {
+        match prepare_local_request_for_cos(binding.umem.area(), &mut binding.tx_pipeline.free_tx_frames, req) {
             Ok(prepared_req) => {
                 let item_len = prepared_req.len as u64;
                 match enqueue_cos_item(
@@ -378,8 +378,8 @@ pub(in crate::afxdp) fn enqueue_local_into_cos(
                 if let Some(root) = binding.cos.cos_interfaces.get_mut(&egress_ifindex) {
                     let _ = demote_prepared_cos_queue_to_local(
                         area,
-                        &mut binding.free_tx_frames,
-                        &mut binding.pending_fill_frames,
+                        &mut binding.tx_pipeline.free_tx_frames,
+                        &mut binding.tx_pipeline.pending_fill_frames,
                         slot,
                         root,
                         req.cos_queue_id,
@@ -787,11 +787,11 @@ fn enqueue_cos_item(
     }
     if let Some((recycle, offset)) = recycle {
         match recycle {
-            PreparedTxRecycle::FreeTxFrame => binding.free_tx_frames.push_back(offset),
+            PreparedTxRecycle::FreeTxFrame => binding.tx_pipeline.free_tx_frames.push_back(offset),
             PreparedTxRecycle::FillOnSlot(slot) if slot == binding.slot => {
-                binding.pending_fill_frames.push_back(offset);
+                binding.tx_pipeline.pending_fill_frames.push_back(offset);
             }
-            PreparedTxRecycle::FillOnSlot(_) => binding.free_tx_frames.push_back(offset),
+            PreparedTxRecycle::FillOnSlot(_) => binding.tx_pipeline.free_tx_frames.push_back(offset),
         }
     }
     // #804: CoS admission overflow — NOT bound-pending. Pre-#804 this

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -36,7 +36,7 @@ fn enqueue_local_request_to_target_or_owner(
         req.egress_ifindex,
         req.cos_queue_id,
     ) {
-        target_binding.pending_tx_local.push_back(req);
+        target_binding.tx_pipeline.pending_tx_local.push_back(req);
         bound_pending_tx_local(target_binding);
         return Ok(());
     }
@@ -50,15 +50,15 @@ fn enqueue_local_request_to_target_or_owner(
             return owner_live.enqueue_tx_owned(req);
         }
     }
-    target_binding.pending_tx_local.push_back(req);
+    target_binding.tx_pipeline.pending_tx_local.push_back(req);
     bound_pending_tx_local(target_binding);
     Ok(())
 }
 
 #[inline]
 fn recycle_ingress_frame(ingress_binding: &mut BindingWorker, source_offset: u64, now_ns: u64) {
-    ingress_binding.pending_fill_frames.push_back(source_offset);
-    if ingress_binding.pending_fill_frames.len() >= FILL_BATCH_SIZE {
+    ingress_binding.tx_pipeline.pending_fill_frames.push_back(source_offset);
+    if ingress_binding.tx_pipeline.pending_fill_frames.len() >= FILL_BATCH_SIZE {
         let _ = drain_pending_fill(ingress_binding, now_ns);
     }
 }
@@ -283,7 +283,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                         dbg.tx_max_frame = max_frame;
                     }
                     copied_source_frame = true;
-                    if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE {
+                    if target_binding.tx_pipeline.pending_tx_prepared.len() >= TX_BATCH_SIZE {
                         let _ = drain_pending_tx_local_owner(
                             target_binding,
                             now_ns,
@@ -328,7 +328,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                             }
                         }
                         let seg_frame_len = frame.len();
-                        target_binding.pending_tx_local.push_back(TxRequest {
+                        target_binding.tx_pipeline.pending_tx_local.push_back(TxRequest {
                             bytes: frame,
                             expected_ports,
                             expected_addr_family: request.meta.addr_family,
@@ -348,7 +348,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                         }
                     }
                     copied_source_frame = true;
-                    if target_binding.pending_tx_local.len() >= TX_BATCH_SIZE {
+                    if target_binding.tx_pipeline.pending_tx_local.len() >= TX_BATCH_SIZE {
                         let _ = drain_pending_tx_local_owner(
                             target_binding,
                             now_ns,
@@ -428,7 +428,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     ) {
                         Some(frame_len) => {
                             target_binding
-                                .pending_tx_prepared
+                                .tx_pipeline.pending_tx_prepared
                                 .push_back(PreparedTxRequest {
                                     offset: source_offset,
                                     len: frame_len,
@@ -550,11 +550,11 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     // intermediate Vec allocation and one memcpy.
                     // NAT64 cannot use direct TX (header size changes), so
                     // it falls through to the copy path below.
-                    let mut direct_tx_offset = target_binding.free_tx_frames.pop_front();
+                    let mut direct_tx_offset = target_binding.tx_pipeline.free_tx_frames.pop_front();
                     if direct_tx_offset.is_none()
                         && (target_binding.outstanding_tx > 0
-                            || !target_binding.pending_tx_prepared.is_empty()
-                            || !target_binding.pending_tx_local.is_empty())
+                            || !target_binding.tx_pipeline.pending_tx_prepared.is_empty()
+                            || !target_binding.tx_pipeline.pending_tx_local.is_empty())
                     {
                         let _ = drain_pending_tx_local_owner(
                             target_binding,
@@ -566,20 +566,20 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                             cos_owner_worker_by_queue,
                             cos_owner_live_by_queue,
                         );
-                        direct_tx_offset = target_binding.free_tx_frames.pop_front();
+                        direct_tx_offset = target_binding.tx_pipeline.free_tx_frames.pop_front();
                     }
                     let mut direct_tx_fallback_reason = None;
                     let direct_built = if is_nat64 || uses_native_tunnel {
                         // NAT64 can't use direct TX — return the frame if we popped one.
                         if let Some(off) = direct_tx_offset {
-                            target_binding.free_tx_frames.push_front(off);
+                            target_binding.tx_pipeline.free_tx_frames.push_front(off);
                         }
                         direct_tx_fallback_reason =
                             Some(DirectTxFallbackReason::DisallowedByRewriteMode);
                         false
                     } else if !owner_matches_target {
                         if let Some(off) = direct_tx_offset {
-                            target_binding.free_tx_frames.push_front(off);
+                            target_binding.tx_pipeline.free_tx_frames.push_front(off);
                         }
                         // A prepared/direct frame on a non-owner binding would be
                         // cloned back into a local Vec during CoS owner redirection.
@@ -633,7 +633,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     expected_ports,
                                     built_ports,
                                 ) {
-                                    target_binding.free_tx_frames.push_front(tx_offset);
+                                    target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
                                     record_exception(
                                         recent_exceptions,
                                         ingress_ident,
@@ -647,10 +647,10 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 }
                             }
                             if build_failed {
-                                target_binding.free_tx_frames.push_front(tx_offset);
+                                target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
                                 true
                             } else if written > tx_frame_capacity() {
-                                target_binding.free_tx_frames.push_front(tx_offset);
+                                target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
                                 record_exception(
                                     recent_exceptions,
                                     ingress_ident,
@@ -663,7 +663,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 true
                             } else {
                                 target_binding
-                                    .pending_tx_prepared
+                                    .tx_pipeline.pending_tx_prepared
                                     .push_back(PreparedTxRequest {
                                         offset: tx_offset,
                                         len: written as u32,
@@ -687,7 +687,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 true
                             }
                         } else {
-                            target_binding.free_tx_frames.push_front(tx_offset);
+                            target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
                             direct_tx_fallback_reason =
                                 Some(DirectTxFallbackReason::BuildReturnedNone);
                             false
@@ -800,8 +800,8 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     }
                 }
             }
-            if target_binding.pending_tx_prepared.len() >= TX_BATCH_SIZE
-                || target_binding.pending_tx_local.len() >= TX_BATCH_SIZE
+            if target_binding.tx_pipeline.pending_tx_prepared.len() >= TX_BATCH_SIZE
+                || target_binding.tx_pipeline.pending_tx_local.len() >= TX_BATCH_SIZE
             {
                 let _ = drain_pending_tx_local_owner(
                     target_binding,
@@ -850,10 +850,10 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
             recycle_ingress_frame(ingress_binding, source_offset, now_ns);
         }
     }
-    while !ingress_binding.pending_fill_frames.is_empty() {
-        let pending_before = ingress_binding.pending_fill_frames.len();
+    while !ingress_binding.tx_pipeline.pending_fill_frames.is_empty() {
+        let pending_before = ingress_binding.tx_pipeline.pending_fill_frames.len();
         let _ = drain_pending_fill(ingress_binding, now_ns);
-        if ingress_binding.pending_fill_frames.len() >= pending_before {
+        if ingress_binding.tx_pipeline.pending_fill_frames.len() >= pending_before {
             break;
         }
     }
@@ -952,10 +952,10 @@ pub(in crate::afxdp) fn apply_shared_recycles(
             && let Some(binding) =
                 binding_by_index_mut(left, current_index, current, right, target_index)
         {
-            binding.pending_fill_frames.push_back(offset);
+            binding.tx_pipeline.pending_fill_frames.push_back(offset);
             continue;
         }
-        current.pending_fill_frames.push_back(offset);
+        current.tx_pipeline.pending_fill_frames.push_back(offset);
     }
 }
 
@@ -1281,10 +1281,10 @@ fn segment_forwarded_tcp_frames_into_prepared(
     }
 
     let segment_count = data.len().div_ceil(segment_payload_max);
-    if target_binding.free_tx_frames.len() < segment_count
+    if target_binding.tx_pipeline.free_tx_frames.len() < segment_count
         && (target_binding.outstanding_tx > 0
-            || !target_binding.pending_tx_prepared.is_empty()
-            || !target_binding.pending_tx_local.is_empty())
+            || !target_binding.tx_pipeline.pending_tx_prepared.is_empty()
+            || !target_binding.tx_pipeline.pending_tx_local.is_empty())
     {
         let _ = drain_pending_tx_local_owner(
             target_binding,
@@ -1297,7 +1297,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
             cos_owner_live_by_queue,
         );
     }
-    if target_binding.free_tx_frames.len() < segment_count {
+    if target_binding.tx_pipeline.free_tx_frames.len() < segment_count {
         return None;
     }
 
@@ -1342,13 +1342,13 @@ fn segment_forwarded_tcp_frames_into_prepared(
         let frame_len = eth_len + total_ip_len;
         if frame_len > tx_frame_capacity() {
             for req in prepared.drain(..).rev() {
-                target_binding.free_tx_frames.push_front(req.offset);
+                target_binding.tx_pipeline.free_tx_frames.push_front(req.offset);
             }
             return None;
         }
-        let Some(tx_offset) = target_binding.free_tx_frames.pop_front() else {
+        let Some(tx_offset) = target_binding.tx_pipeline.free_tx_frames.pop_front() else {
             for req in prepared.drain(..).rev() {
-                target_binding.free_tx_frames.push_front(req.offset);
+                target_binding.tx_pipeline.free_tx_frames.push_front(req.offset);
             }
             return None;
         };
@@ -1358,9 +1358,9 @@ fn segment_forwarded_tcp_frames_into_prepared(
                 .area()
                 .slice_mut_unchecked(tx_offset as usize, frame_len)
         }) else {
-            target_binding.free_tx_frames.push_front(tx_offset);
+            target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
             for req in prepared.drain(..).rev() {
-                target_binding.free_tx_frames.push_front(req.offset);
+                target_binding.tx_pipeline.free_tx_frames.push_front(req.offset);
             }
             return None;
         };
@@ -1452,9 +1452,9 @@ fn segment_forwarded_tcp_frames_into_prepared(
             Some(())
         })();
         if built.is_none() {
-            target_binding.free_tx_frames.push_front(tx_offset);
+            target_binding.tx_pipeline.free_tx_frames.push_front(tx_offset);
             for req in prepared.drain(..).rev() {
-                target_binding.free_tx_frames.push_front(req.offset);
+                target_binding.tx_pipeline.free_tx_frames.push_front(req.offset);
             }
             return None;
         }
@@ -1477,7 +1477,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
     }
 
     for req in prepared {
-        target_binding.pending_tx_prepared.push_back(req);
+        target_binding.tx_pipeline.pending_tx_prepared.push_back(req);
     }
     bound_pending_tx_prepared(target_binding);
     Some((segment_count as u32, total_bytes, max_frame))

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -10,8 +10,8 @@ pub(in crate::afxdp) fn pending_tx_capacity(ring_entries: u32) -> usize {
 }
 
 pub(in crate::afxdp) fn bound_pending_tx_local(binding: &mut BindingWorker) {
-    while binding.pending_tx_local.len() > binding.max_pending_tx {
-        if binding.pending_tx_local.pop_front().is_some() {
+    while binding.tx_pipeline.pending_tx_local.len() > binding.tx_pipeline.max_pending_tx {
+        if binding.tx_pipeline.pending_tx_local.pop_front().is_some() {
             // #804: bound-pending FIFO overflow — distinct from the CoS
             // queue admission overflow counter. Keep this attribution
             // precise so operators can tell which path is dropping.
@@ -31,9 +31,9 @@ pub(in crate::afxdp) fn bound_pending_tx_local(binding: &mut BindingWorker) {
 }
 
 pub(in crate::afxdp) fn bound_pending_tx_prepared(binding: &mut BindingWorker) {
-    let limit = binding.max_pending_tx;
-    while binding.pending_tx_prepared.len() > limit {
-        if let Some(req) = binding.pending_tx_prepared.pop_front() {
+    let limit = binding.tx_pipeline.max_pending_tx;
+    while binding.tx_pipeline.pending_tx_prepared.len() > limit {
+        if let Some(req) = binding.tx_pipeline.pending_tx_prepared.pop_front() {
             // #804: bound-pending FIFO overflow (prepared side). Same
             // semantic bucket as `bound_pending_tx_local` — internal
             // prepared/local distinction is irrelevant to operators.
@@ -72,8 +72,8 @@ pub(in crate::afxdp) fn drain_pending_tx(
     // If outstanding entries remain after reaping (kernel didn't finish in
     // the previous kick), re-kick now so they don't stall forever.
     if binding.outstanding_tx > 0
-        && binding.pending_tx_prepared.is_empty()
-        && binding.pending_tx_local.is_empty()
+        && binding.tx_pipeline.pending_tx_prepared.is_empty()
+        && binding.tx_pipeline.pending_tx_local.is_empty()
     {
         maybe_wake_tx(binding, false, now_ns);
     }
@@ -189,7 +189,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
     if !forwarding.cos.interfaces.is_empty() {
         drop_cos_bound_prepared_leftovers(binding);
     }
-    while !binding.pending_tx_prepared.is_empty() {
+    while !binding.tx_pipeline.pending_tx_prepared.is_empty() {
         match transmit_prepared_batch(binding, now_ns) {
             Ok((packets, bytes)) => {
                 if packets == 0 {
@@ -228,7 +228,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
             }
         }
     }
-    if binding.pending_tx_local.is_empty() && binding.live.pending_tx_empty() {
+    if binding.tx_pipeline.pending_tx_local.is_empty() && binding.live.pending_tx_empty() {
         update_binding_debug_state(binding);
         return did_work || binding_has_pending_tx_work(binding);
     }
@@ -245,7 +245,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
     let mut retry = VecDeque::new();
     while let Some(req) = pending.pop_front() {
         retry.push_back(req);
-        if retry.len() >= TX_BATCH_SIZE || binding.free_tx_frames.is_empty() || pending.is_empty() {
+        if retry.len() >= TX_BATCH_SIZE || binding.tx_pipeline.free_tx_frames.is_empty() || pending.is_empty() {
             match transmit_batch(binding, &mut retry, now_ns, shared_recycles) {
                 Ok((packets, bytes)) => {
                     if packets > 0 {
@@ -303,7 +303,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
 /// defense rather than only a narrow redirect-to-owner +
 /// local-enqueue failure.
 fn drop_cos_bound_prepared_leftovers(binding: &mut BindingWorker) {
-    if binding.pending_tx_prepared.is_empty() {
+    if binding.tx_pipeline.pending_tx_prepared.is_empty() {
         return;
     }
     // #784 Codex review: the earlier head-peek fast-exit was a
@@ -320,9 +320,9 @@ fn drop_cos_bound_prepared_leftovers(binding: &mut BindingWorker) {
     // per-frame.
     let mut dropped = 0u64;
     let mut dropped_bytes = 0u64;
-    let original_len = binding.pending_tx_prepared.len();
+    let original_len = binding.tx_pipeline.pending_tx_prepared.len();
     for _ in 0..original_len {
-        let Some(req) = binding.pending_tx_prepared.pop_front() else {
+        let Some(req) = binding.tx_pipeline.pending_tx_prepared.pop_front() else {
             break;
         };
         if req.cos_queue_id.is_some() {
@@ -330,7 +330,7 @@ fn drop_cos_bound_prepared_leftovers(binding: &mut BindingWorker) {
             dropped_bytes = dropped_bytes.saturating_add(req.len as u64);
             recycle_prepared_immediately(binding, &req);
         } else {
-            binding.pending_tx_prepared.push_back(req);
+            binding.tx_pipeline.pending_tx_prepared.push_back(req);
         }
     }
     if dropped > 0 {
@@ -455,8 +455,8 @@ fn drop_cos_bound_local_leftovers(
 
 fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
     binding.outstanding_tx > 0
-        || !binding.pending_tx_prepared.is_empty()
-        || !binding.pending_tx_local.is_empty()
+        || !binding.tx_pipeline.pending_tx_prepared.is_empty()
+        || !binding.tx_pipeline.pending_tx_local.is_empty()
         || !binding.live.pending_tx_empty()
         || binding.cos.cos_nonempty_interfaces > 0
 }
@@ -525,8 +525,8 @@ fn ingest_cos_pending_tx_with_provenance(
         return;
     }
 
-    if !binding.pending_tx_prepared.is_empty() {
-        let mut pending = core::mem::take(&mut binding.pending_tx_prepared);
+    if !binding.tx_pipeline.pending_tx_prepared.is_empty() {
+        let mut pending = core::mem::take(&mut binding.tx_pipeline.pending_tx_prepared);
         process_pending_queue_in_place(&mut pending, |req| {
             let req = match redirect_prepared_cos_request_to_owner(
                 binding,
@@ -546,10 +546,10 @@ fn ingest_cos_pending_tx_with_provenance(
                 Err(req) => Err(req),
             }
         });
-        binding.pending_tx_prepared = pending;
+        binding.tx_pipeline.pending_tx_prepared = pending;
     }
 
-    let mut pending = core::mem::take(&mut binding.pending_tx_local);
+    let mut pending = core::mem::take(&mut binding.tx_pipeline.pending_tx_local);
     // #709: the split between owner-local and peer-redirected packets.
     // `pending` starts with this worker's own locally-produced requests
     // (this worker drove RX on this binding). `take_pending_tx_into`
@@ -675,7 +675,7 @@ fn ingest_cos_pending_tx_with_provenance(
             Err(req) => Err(req),
         }
     });
-    binding.pending_tx_local = pending;
+    binding.tx_pipeline.pending_tx_local = pending;
     bound_pending_tx_local(binding);
 }
 
@@ -704,14 +704,14 @@ fn take_pending_tx_requests(binding: &mut BindingWorker) -> VecDeque<TxRequest> 
     // target so the owner-worker hot path stays allocation-free. `pop`
     // from the lock-free inbox appends into the same buffer without a
     // queue-to-queue copy.
-    let mut out = core::mem::take(&mut binding.pending_tx_local);
+    let mut out = core::mem::take(&mut binding.tx_pipeline.pending_tx_local);
     binding.live.take_pending_tx_into(&mut out);
     out
 }
 
 fn restore_pending_tx_requests(binding: &mut BindingWorker, mut retry: VecDeque<TxRequest>) {
-    retry.append(&mut binding.pending_tx_local);
-    binding.pending_tx_local = retry;
+    retry.append(&mut binding.tx_pipeline.pending_tx_local);
+    binding.tx_pipeline.pending_tx_local = retry;
     bound_pending_tx_local(binding);
 }
 

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -49,7 +49,7 @@ pub(in crate::afxdp) fn reap_tx_completions(
     // exact production algorithm — NOT a test-only fake. See unit
     // pins under `#[cfg(test)]` below.
     record_tx_completions_with_stamp(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         &binding.scratch.scratch_completed_offsets,
         ts_completion,
         &binding.live.owner_profile_owner,
@@ -69,13 +69,13 @@ pub(in crate::afxdp) fn reap_tx_completions(
 }
 
 pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: u64) -> bool {
-    if binding.pending_fill_frames.is_empty() {
+    if binding.tx_pipeline.pending_fill_frames.is_empty() {
         return false;
     }
-    let batch_size = binding.pending_fill_frames.len().min(FILL_BATCH_SIZE);
+    let batch_size = binding.tx_pipeline.pending_fill_frames.len().min(FILL_BATCH_SIZE);
     binding.scratch.scratch_fill.clear();
     while binding.scratch.scratch_fill.len() < batch_size {
-        let Some(offset) = binding.pending_fill_frames.pop_front() else {
+        let Some(offset) = binding.tx_pipeline.pending_fill_frames.pop_front() else {
             break;
         };
         // Poison the frame before submitting to fill ring — the kernel should
@@ -103,7 +103,7 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
     if inserted == 0 {
         binding.telemetry.dbg_fill_failed += binding.scratch.scratch_fill.len() as u64;
         for offset in binding.scratch.scratch_fill.drain(..).rev() {
-            binding.pending_fill_frames.push_front(offset);
+            binding.tx_pipeline.pending_fill_frames.push_front(offset);
         }
         return false;
     }
@@ -111,7 +111,7 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
     if inserted < binding.scratch.scratch_fill.len() as u32 {
         binding.telemetry.dbg_fill_failed += (binding.scratch.scratch_fill.len() as u32 - inserted) as u64;
         for offset in binding.scratch.scratch_fill.drain(inserted as usize..).rev() {
-            binding.pending_fill_frames.push_front(offset);
+            binding.tx_pipeline.pending_fill_frames.push_front(offset);
         }
     }
     binding.scratch.scratch_fill.clear();
@@ -196,15 +196,15 @@ fn recycle_completed_tx_offset(
     shared_recycles: &mut Vec<(u32, u64)>,
     offset: u64,
 ) {
-    if let Some(recycle) = binding.in_flight_prepared_recycles.remove(&offset) {
+    if let Some(recycle) = binding.tx_pipeline.in_flight_prepared_recycles.remove(&offset) {
         apply_prepared_recycle(
-            &mut binding.free_tx_frames,
+            &mut binding.tx_pipeline.free_tx_frames,
             shared_recycles,
             recycle,
             offset,
         );
     } else {
-        binding.free_tx_frames.push_back(offset);
+        binding.tx_pipeline.free_tx_frames.push_back(offset);
     }
 }
 
@@ -283,7 +283,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                         binding.ifindex,
                         binding.queue_id,
                         binding.outstanding_tx,
-                        binding.free_tx_frames.len(),
+                        binding.tx_pipeline.free_tx_frames.len(),
                     );
                 }
             } else {
@@ -296,7 +296,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                         binding.queue_id,
                         errno,
                         binding.outstanding_tx,
-                        binding.free_tx_frames.len(),
+                        binding.tx_pipeline.free_tx_frames.len(),
                     );
                 }
             }

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -53,8 +53,8 @@ pub(in crate::afxdp) fn recycle_prepared_immediately(binding: &mut BindingWorker
     // drop site back to the source worker; deferred until the
     // shared-UMEM prototype is activated.
     recycle_cancelled_prepared_offset(
-        &mut binding.free_tx_frames,
-        &mut binding.pending_fill_frames,
+        &mut binding.tx_pipeline.free_tx_frames,
+        &mut binding.tx_pipeline.pending_fill_frames,
         binding.slot,
         req.recycle,
         req.offset,
@@ -79,12 +79,12 @@ pub(in crate::afxdp) fn transmit_batch(
     if pending.is_empty() {
         return Ok((0, 0));
     }
-    if binding.free_tx_frames.is_empty() {
+    if binding.tx_pipeline.free_tx_frames.is_empty() {
         let _ = reap_tx_completions(binding, shared_recycles);
     }
     let batch_size = pending
         .len()
-        .min(binding.free_tx_frames.len())
+        .min(binding.tx_pipeline.free_tx_frames.len())
         .min(TX_BATCH_SIZE);
     if batch_size == 0 {
         maybe_wake_tx(binding, true, now_ns);
@@ -102,7 +102,7 @@ pub(in crate::afxdp) fn transmit_batch(
         if req.bytes.len() > tx_frame_capacity() {
             // Unwind already-prepared entries before returning.
             for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
-                binding.free_tx_frames.push_back(off);
+                binding.tx_pipeline.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }
             return Err(TxError::Drop(format!(
@@ -111,7 +111,7 @@ pub(in crate::afxdp) fn transmit_batch(
                 tx_frame_capacity()
             )));
         }
-        let Some(offset) = binding.free_tx_frames.pop_front() else {
+        let Some(offset) = binding.tx_pipeline.free_tx_frames.pop_front() else {
             pending.push_front(req);
             break;
         };
@@ -121,10 +121,10 @@ pub(in crate::afxdp) fn transmit_batch(
                 .area()
                 .slice_mut_unchecked(offset as usize, req.bytes.len())
         }) else {
-            binding.free_tx_frames.push_front(offset);
+            binding.tx_pipeline.free_tx_frames.push_front(offset);
             // Unwind already-prepared entries before returning.
             for (off, r) in binding.scratch.scratch_local_tx.drain(..) {
-                binding.free_tx_frames.push_back(off);
+                binding.tx_pipeline.free_tx_frames.push_back(off);
                 pending.push_front(r);
             }
             return Err(TxError::Drop(format!(
@@ -198,7 +198,7 @@ pub(in crate::afxdp) fn transmit_batch(
     // from inflating the observed latency.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_local_tx
             .iter()
@@ -211,7 +211,7 @@ pub(in crate::afxdp) fn transmit_batch(
         binding.telemetry.dbg_tx_ring_full += 1;
         maybe_wake_tx(binding, true, now_ns);
         while let Some((offset, req)) = binding.scratch.scratch_local_tx.pop() {
-            binding.free_tx_frames.push_front(offset);
+            binding.tx_pipeline.free_tx_frames.push_front(offset);
             pending.push_front(req);
         }
         return Err(TxError::Retry("tx ring insert failed".to_string()));
@@ -227,7 +227,7 @@ pub(in crate::afxdp) fn transmit_batch(
             sent_packets += 1;
             sent_bytes += req.bytes.len() as u64;
         } else {
-            binding.free_tx_frames.push_front(offset);
+            binding.tx_pipeline.free_tx_frames.push_front(offset);
             retry_tail.push(req);
         }
     }
@@ -245,9 +245,9 @@ pub(super) fn transmit_prepared_batch(
     binding: &mut BindingWorker,
     now_ns: u64,
 ) -> Result<(u64, u64), TxError> {
-    let mut pending = core::mem::take(&mut binding.pending_tx_prepared);
+    let mut pending = core::mem::take(&mut binding.tx_pipeline.pending_tx_prepared);
     let result = transmit_prepared_queue(binding, &mut pending, now_ns);
-    binding.pending_tx_prepared = pending;
+    binding.tx_pipeline.pending_tx_prepared = pending;
     result
 }
 
@@ -431,7 +431,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     // kernel-visible submit time, not the pre-submit planning window.
     let ts_submit = monotonic_nanos();
     stamp_submits(
-        &mut binding.tx_submit_ns,
+        &mut binding.tx_pipeline.tx_submit_ns,
         binding
             .scratch.scratch_prepared_tx
             .iter()
@@ -456,7 +456,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     let mut retry_tail = Vec::new();
     for (idx, req) in binding.scratch.scratch_prepared_tx.drain(..).enumerate() {
         if idx < inserted as usize {
-            remember_prepared_recycle(&mut binding.in_flight_prepared_recycles, &req);
+            remember_prepared_recycle(&mut binding.tx_pipeline.in_flight_prepared_recycles, &req);
             sent_packets += 1;
             sent_bytes += req.len as u64;
         } else {

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -82,8 +82,8 @@ pub(super) fn poll_binding(
     for _ in 0..MAX_RX_BATCHES_PER_POLL {
         // Backpressure: skip RX when TX queues are heavily loaded to prevent
         // fill ring exhaustion. The NIC holds packets until we refill (#201).
-        let tx_backlog = binding.pending_tx_local.len() + binding.pending_tx_prepared.len();
-        if tx_backlog >= binding.max_pending_tx {
+        let tx_backlog = binding.tx_pipeline.pending_tx_local.len() + binding.tx_pipeline.pending_tx_prepared.len();
+        if tx_backlog >= binding.tx_pipeline.max_pending_tx {
             binding.telemetry.dbg_backpressure += 1;
             // Try to drain TX first — completions free frames for both TX and fill.
             let _ = drain_pending_tx(
@@ -282,7 +282,7 @@ pub(super) fn poll_binding(
         );
         if !binding.scratch.scratch_recycle.is_empty() {
             binding
-                .pending_fill_frames
+                .tx_pipeline.pending_fill_frames
                 .extend(binding.scratch.scratch_recycle.drain(..));
         }
         let _ = drain_pending_fill(binding, now_ns);

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -34,6 +34,11 @@ pub(crate) use bpf_maps::WorkerBpfMaps;
 mod timers;
 pub(crate) use timers::WorkerTimers;
 
+// #959 Phase 7: per-binding TX pipeline state lives in
+// worker/tx_pipeline.rs.
+mod tx_pipeline;
+pub(crate) use tx_pipeline::WorkerTxPipeline;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -73,52 +78,21 @@ pub(crate) struct BindingWorker {
     pub(crate) device: crate::xsk_ffi::DeviceQueue,
     pub(crate) rx: crate::xsk_ffi::RingRx,
     pub(crate) tx: crate::xsk_ffi::RingTx,
-    pub(crate) free_tx_frames: VecDeque<u64>,
-    pub(crate) pending_tx_prepared: VecDeque<PreparedTxRequest>,
-    pub(crate) pending_tx_local: VecDeque<TxRequest>,
-    pub(crate) max_pending_tx: usize,
+    /// #959 Phase 7: 7 TX pipeline fields extracted into
+    /// `WorkerTxPipeline`. Field semantics unchanged; access via
+    /// `binding.tx_pipeline.X`.
+    pub(crate) tx_pipeline: WorkerTxPipeline,
     /// #959 Phase 3: 5 `cos_*` per-binding CoS scheduling fields
     /// extracted into `WorkerCos`. Field semantics unchanged;
     /// access via `binding.cos.cos_X`.
     pub(crate) cos: WorkerCos,
-    pub(crate) pending_fill_frames: VecDeque<u64>,
     /// #959 Phase 2: 11 `scratch_*` reusable buffers extracted into
     /// `WorkerScratch`. Field semantics unchanged; access via
     /// `binding.scratch.scratch_X`.
     pub(crate) scratch: WorkerScratch,
-    /// #812: per-UMEM-frame submit timestamp sidecar. Indexed by
-    /// `offset >> UMEM_FRAME_SHIFT`. Pre-allocated once at binding
-    /// construction (length = total UMEM frames) so the hot-path
-    /// stamp write is a single store — NO allocation, NO grow.
-    ///
-    /// Single-writer invariant (plan §3.3): submit and completion for
-    /// one frame offset are the same thread (the owner worker that
-    /// owns this binding's `free_tx_frames` via
-    /// `pop_front`/`push_front`), so plain `Vec<u64>` is correct —
-    /// no atomic needed. `WorkerUmem` is `Rc` (not `Arc`) at
-    /// `umem.rs:16-18`, enforcing single-owner semantics even when
-    /// multiple bindings share a UMEM under the mlx5 special case.
-    ///
-    /// Unstamped slots hold `TX_SIDECAR_UNSTAMPED` (`u64::MAX`) — the
-    /// reap path (`reap_tx_completions`) skips the histogram
-    /// increment for these to avoid biasing the tail toward bucket 0
-    /// (plan §5.4). A `monotonic_nanos() == 0` return (VDSO failure,
-    /// plan §3.4a / §6.1 test #5) causes `stamp_submits` to early-
-    /// return without writing the slot (Codex round-1 MED + Rust
-    /// round-1 MED-2) — the slot's pre-existing UNSTAMPED state
-    /// (from the previous reap or from worker construction) is what
-    /// the reap checks.
-    /// Rust round-1 MED-1: `Box<[u64]>` rather than `Vec<u64>` to
-    /// convey single-size intent at the type level. The sidecar is
-    /// pre-allocated to `total_frames` at binding construction and
-    /// NEVER grown. A future refactor that naively added `push` to
-    /// `Vec<u64>` would silently allocate on the hot path; `Box<[u64]>`
-    /// has no `push` method, so the mistake fails to compile.
-    pub(crate) tx_submit_ns: Box<[u64]>,
     /// Packets waiting for neighbor resolution. The UMEM frame is held
     /// (not recycled) until the neighbor resolves or the entry times out.
     pub(crate) pending_neigh: VecDeque<PendingNeighPacket>,
-    pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
     /// #959 Phase 5: 4 BPF map FDs extracted into `WorkerBpfMaps`.
     /// Field semantics unchanged; access via `binding.bpf_maps.X_fd`.
     pub(crate) bpf_maps: WorkerBpfMaps,
@@ -352,10 +326,25 @@ impl BindingWorker {
             device,
             rx,
             tx,
-            free_tx_frames: reserved_tx_frames,
-            pending_tx_prepared: VecDeque::new(),
-            pending_tx_local: VecDeque::new(),
-            max_pending_tx,
+            tx_pipeline: WorkerTxPipeline {
+                free_tx_frames: reserved_tx_frames,
+                pending_tx_prepared: VecDeque::new(),
+                pending_tx_local: VecDeque::new(),
+                max_pending_tx,
+                pending_fill_frames: VecDeque::new(),
+                in_flight_prepared_recycles: FastMap::default(),
+                // #812: pre-allocate the submit-timestamp sidecar once,
+                // sized to the binding's total UMEM frame count so every
+                // legal `offset >> UMEM_FRAME_SHIFT` index lands inside
+                // the vec. Initial contents are the unstamped sentinel so
+                // any stray pre-existing offset in flight (cross-restart
+                // completion) is skipped by the reap path (plan §5.4).
+                // Allocation happens here — NEVER on the hot path.
+                // Rust round-1 MED-1: Box<[u64]> — allocate-once, never
+                // grow. `vec![...].into_boxed_slice()` produces an
+                // exactly-sized heap allocation with no spare capacity.
+                tx_submit_ns: vec![TX_SIDECAR_UNSTAMPED; total_frames as usize].into_boxed_slice(),
+            },
             cos: WorkerCos {
                 cos_fast_interfaces: FastMap::default(),
                 cos_interfaces: FastMap::default(),
@@ -363,7 +352,6 @@ impl BindingWorker {
                 cos_interface_rr: 0,
                 cos_nonempty_interfaces: 0,
             },
-            pending_fill_frames: VecDeque::new(),
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
                 scratch_forwards: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -377,17 +365,6 @@ impl BindingWorker {
                 scratch_cross_binding_tx: Vec::with_capacity(RX_BATCH_SIZE as usize),
                 scratch_rst_teardowns: Vec::with_capacity(16),
             },
-            // #812: pre-allocate the submit-timestamp sidecar once,
-            // sized to the binding's total UMEM frame count so every
-            // legal `offset >> UMEM_FRAME_SHIFT` index lands inside
-            // the vec. Initial contents are the unstamped sentinel so
-            // any stray pre-existing offset in flight (cross-restart
-            // completion) is skipped by the reap path (plan §5.4).
-            // Allocation happens here — NEVER on the hot path.
-            // Rust round-1 MED-1: Box<[u64]> — allocate-once, never
-            // grow. `vec![...].into_boxed_slice()` produces an
-            // exactly-sized heap allocation with no spare capacity.
-            tx_submit_ns: vec![TX_SIDECAR_UNSTAMPED; total_frames as usize].into_boxed_slice(),
             // GEMINI-NEXT.md Section 3 cold start: lazy allocation. The
             // 4096-cap is enforced at admission (poll_descriptor.rs check
             // against MAX_PENDING_NEIGH), so pre-allocating that capacity
@@ -395,7 +372,6 @@ impl BindingWorker {
             // idle. Start at 0 capacity and let VecDeque grow on push as
             // packets actually queue up.
             pending_neigh: VecDeque::new(),
-            in_flight_prepared_recycles: FastMap::default(),
             bpf_maps: WorkerBpfMaps {
                 heartbeat_map_fd,
                 session_map_fd,
@@ -1096,14 +1072,14 @@ pub(crate) fn worker_loop(
                     let fill_pending = b.device.pending();
                     let rx_avail = b.rx.available_relaxed();
                     let xsk_stats = b.device.statistics_v2().ok();
-                    let inflight_recycles = b.in_flight_prepared_recycles.len() as u32;
+                    let inflight_recycles = b.tx_pipeline.in_flight_prepared_recycles.len() as u32;
                     let scratch_recycle_len = b.scratch.scratch_recycle.len() as u32;
-                    let ptx_prepared = b.pending_tx_prepared.len() as u32;
-                    let ptx_local = b.pending_tx_local.len() as u32;
-                    let total_accounted = b.pending_fill_frames.len() as u32
+                    let ptx_prepared = b.tx_pipeline.pending_tx_prepared.len() as u32;
+                    let ptx_local = b.tx_pipeline.pending_tx_local.len() as u32;
+                    let total_accounted = b.tx_pipeline.pending_fill_frames.len() as u32
                         + fill_pending
                         + rx_avail
-                        + b.free_tx_frames.len() as u32
+                        + b.tx_pipeline.free_tx_frames.len() as u32
                         + b.outstanding_tx
                         + inflight_recycles
                         + scratch_recycle_len
@@ -1115,10 +1091,10 @@ pub(crate) fn worker_loop(
                         i,
                         b.ifindex,
                         b.queue_id,
-                        b.pending_fill_frames.len(),
+                        b.tx_pipeline.pending_fill_frames.len(),
                         fill_pending,
                         rx_avail,
-                        b.free_tx_frames.len(),
+                        b.tx_pipeline.free_tx_frames.len(),
                         b.outstanding_tx,
                         inflight_recycles,
                         scratch_recycle_len,
@@ -1364,13 +1340,13 @@ pub(crate) fn worker_loop(
                             use std::fmt::Write;
                             let fill_p = sb.device.pending();
                             let rx_a = sb.rx.available_relaxed();
-                            let ifl = sb.in_flight_prepared_recycles.len() as u32;
-                            let ptxp = sb.pending_tx_prepared.len() as u32;
-                            let ptxl = sb.pending_tx_local.len() as u32;
-                            let total = sb.pending_fill_frames.len() as u32
+                            let ifl = sb.tx_pipeline.in_flight_prepared_recycles.len() as u32;
+                            let ptxp = sb.tx_pipeline.pending_tx_prepared.len() as u32;
+                            let ptxl = sb.tx_pipeline.pending_tx_local.len() as u32;
+                            let total = sb.tx_pipeline.pending_fill_frames.len() as u32
                                 + fill_p
                                 + rx_a
-                                + sb.free_tx_frames.len() as u32
+                                + sb.tx_pipeline.free_tx_frames.len() as u32
                                 + sb.outstanding_tx
                                 + ifl
                                 + sb.scratch.scratch_recycle.len() as u32
@@ -1381,10 +1357,10 @@ pub(crate) fn worker_loop(
                                 si,
                                 sb.ifindex,
                                 sb.queue_id,
-                                sb.pending_fill_frames.len(),
+                                sb.tx_pipeline.pending_fill_frames.len(),
                                 fill_p,
                                 rx_a,
-                                sb.free_tx_frames.len(),
+                                sb.tx_pipeline.free_tx_frames.len(),
                                 sb.outstanding_tx,
                                 ifl,
                                 ptxp,
@@ -1535,8 +1511,8 @@ pub(crate) fn worker_loop(
                     // reads ~70-80% at idle because AF_XDP keeps the fill
                     // ring pre-populated by design.
                     let total = b.umem.total_frames();
-                    let free_tx = b.free_tx_frames.len() as u32;
-                    let pending_fill = b.pending_fill_frames.len() as u32;
+                    let free_tx = b.tx_pipeline.free_tx_frames.len() as u32;
+                    let pending_fill = b.tx_pipeline.pending_fill_frames.len() as u32;
                     let kernel_fill = b.device.pending();
                     let inflight = total
                         .saturating_sub(free_tx)
@@ -1673,7 +1649,7 @@ fn apply_worker_shaped_tx_requests(
         match enqueue_local_into_cos(binding, forwarding, req, now_ns) {
             Ok(()) => {}
             Err(req) => {
-                binding.pending_tx_local.push_back(req);
+                binding.tx_pipeline.pending_tx_local.push_back(req);
                 bound_pending_tx_local(binding);
             }
         }

--- a/userspace-dp/src/afxdp/worker/tx_pipeline.rs
+++ b/userspace-dp/src/afxdp/worker/tx_pipeline.rs
@@ -1,0 +1,46 @@
+//! #959 Phase 7 — extracts the per-binding TX pipeline state out of
+//! `BindingWorker` into a dedicated `WorkerTxPipeline` sub-struct.
+//!
+//! These seven fields hold the per-binding TX pipeline buffers and
+//! the per-frame submit-timestamp sidecar:
+//!
+//! - `free_tx_frames` — UMEM frame addresses available for TX.
+//! - `pending_tx_prepared` — TX-ready requests awaiting ring submit.
+//! - `pending_tx_local` — local-TX requests awaiting ring submit.
+//! - `max_pending_tx` — TX backpressure threshold (configured once).
+//! - `pending_fill_frames` — fill-ring back-pressure queue.
+//! - `in_flight_prepared_recycles` — completion-time recycle map.
+//! - `tx_submit_ns` — per-UMEM-frame submit timestamp sidecar
+//!   (#812). Pre-allocated to total UMEM frames at construction;
+//!   never grown. `Box<[u64]>` (not `Vec<u64>`) at the type level
+//!   so any future `push` attempt fails to compile.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-7. Field names preserved so
+//! `binding.tx_pipeline.free_tx_frames` keeps the same grep-friendly
+//! suffix as the original `binding.free_tx_frames`.
+//!
+//! NOT IN THIS PHASE: `outstanding_tx` (collides with the
+//! `BindingStatus.outstanding_tx` snapshot mirror; deferred to a
+//! tiny followup phase that handles the type disambiguation).
+
+use super::*;
+
+/// Per-binding TX pipeline state. See module-level docs.
+///
+/// **Intentionally NOT `Default`** — `tx_submit_ns` must be sized
+/// to `total_frames` at construction, not zero-length. Construction
+/// goes through the explicit literal in `BindingWorker::create`
+/// which receives `total_frames` from the BindingPlan.
+pub(crate) struct WorkerTxPipeline {
+    pub(crate) free_tx_frames: VecDeque<u64>,
+    pub(crate) pending_tx_prepared: VecDeque<PreparedTxRequest>,
+    pub(crate) pending_tx_local: VecDeque<TxRequest>,
+    pub(crate) max_pending_tx: usize,
+    pub(crate) pending_fill_frames: VecDeque<u64>,
+    pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
+    /// #812 per-UMEM-frame submit timestamp sidecar; see module
+    /// docs and the original commentary preserved on the
+    /// `BindingWorker::tx_submit_ns` field history.
+    pub(crate) tx_submit_ns: Box<[u64]>,
+}

--- a/userspace-dp/src/afxdp/worker/tx_pipeline.rs
+++ b/userspace-dp/src/afxdp/worker/tx_pipeline.rs
@@ -39,8 +39,14 @@ pub(crate) struct WorkerTxPipeline {
     pub(crate) max_pending_tx: usize,
     pub(crate) pending_fill_frames: VecDeque<u64>,
     pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
-    /// #812 per-UMEM-frame submit timestamp sidecar; see module
-    /// docs and the original commentary preserved on the
-    /// `BindingWorker::tx_submit_ns` field history.
+    /// #812 per-UMEM-frame submit timestamp sidecar. Indexed by
+    /// `offset >> UMEM_FRAME_SHIFT`. Pre-allocated to total UMEM
+    /// frames at `BindingWorker::create` so the hot-path stamp
+    /// write is a single store — NO allocation, NO grow.
+    /// `Box<[u64]>` (not `Vec<u64>`) at the type level so any
+    /// future `push` attempt fails to compile (Rust round-1 MED-1).
+    /// Unstamped slots hold `TX_SIDECAR_UNSTAMPED` (`u64::MAX`); the
+    /// reap path skips the histogram increment for these to avoid
+    /// biasing the tail toward bucket 0 (plan §5.4).
     pub(crate) tx_submit_ns: Box<[u64]>,
 }


### PR DESCRIPTION
## Summary

Phase 7 of **#959** BindingWorker decomposition.
- Phases 1-6 (#1167-#1172): \`dbg_*\`, \`scratch_*\`, \`cos_*\`, \`pending_*_tx_*\`, BPF FDs, timers
- **Phase 7 (this PR): 7 TX pipeline fields → \`WorkerTxPipeline\`**

Moves 7 TX pipeline fields out of `BindingWorker`:

| Field |
|-------|
| \`free_tx_frames\` |
| \`pending_tx_prepared\` |
| \`pending_tx_local\` |
| \`max_pending_tx\` |
| \`pending_fill_frames\` |
| \`in_flight_prepared_recycles\` |
| \`tx_submit_ns\` |

Access pattern: \`binding.tx_pipeline.X\`.

**`outstanding_tx` deliberately excluded** — collides with the
\`BindingStatus.outstanding_tx\` snapshot mirror in
\`coordinator/mod.rs:1227,1353\` and \`protocol.rs:1611\`. Tiny
followup phase will handle it.

## Methodology

Same compiler-driven approach as Phases 1-6. **158 callsites across
13 files** — largest phase by far.

`WorkerTxPipeline` has **NO `Default`** — \`tx_submit_ns\` must be
sized to \`total_frames\` at construction (\`Box<[u64]>\` of
\`TX_SIDECAR_UNSTAMPED\` sentinels), not zero-length. Construction
goes through the explicit literal in \`BindingWorker::create\`.

**Collision avoidance**: \`live.max_pending_tx\` accesses on
\`BindingLiveState\` (atomic mirror) at \`umem/tests.rs:41,86,107\` were
NOT rewritten — the compiler protects (BindingLiveState has no
tx_pipeline field).

## Files affected

| File | Change |
|------|--------|
| \`userspace-dp/src/afxdp/worker/tx_pipeline.rs\` | new, 47 LOC |
| \`userspace-dp/src/afxdp/worker/mod.rs\` | -7 fields, +nested literal |
| \`userspace-dp/src/afxdp/worker/lifecycle.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/poll_descriptor.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/session_glue/mod.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/neighbor_dispatch.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/cos/queue_service/service.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/cos_classify.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/dispatch.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/drain.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/rings.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/transmit.rs\` | callsite rewrites |
| \`docs/pr/959-phase7-tx-pipeline/plan.md\` | new plan |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 952 passed, 0 failed
- [x] \`cargo test --release flush_clears_records_and_increments_sequence\` — 5/5 named runs
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke \`172.16.80.200\` — 959 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke \`2001:559:8585:80::200\` — 944 Mbps, 0 retr

## #959 progress

| Phase | Fields | PR |
|-------|--------|-----|
| 1: dbg_* | 23 | #1167 |
| 2: scratch_* | 11 | #1168 |
| 3: cos_* | 5 | #1169 |
| 4: pending_*_tx_* | 6 | #1170 |
| 5: BPF FDs | 4 | #1171 |
| 6: timers | 5 | #1172 |
| **7: tx_pipeline (this)** | 7 | this |
| Total moved | **61** | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)