### PR TITLE
#959 Phase 8: extract bind metadata into WorkerBindMeta sub-struct

### DIFF
--- a/docs/pr/959-phase8-bindmeta/plan.md
+++ b/docs/pr/959-phase8-bindmeta/plan.md
@@ -1,0 +1,56 @@
+# Plan: #959 Phase 8 — extract bind metadata into `WorkerBindMeta`
+
+## Status
+
+Phase 8 of #959. Phases 1-7 (#1167-#1173) extracted dbg_*,
+scratch_*, cos_*, pending_*_tx_*, BPF FDs, timers, TX pipeline.
+
+## Scope
+
+Move 3 binding registration / identity fields out of `BindingWorker`
+into a new `WorkerBindMeta` sub-struct:
+
+```
+bind_time_ns, bind_mode, xsk_rx_confirmed
+```
+
+Access pattern: `binding.bind_meta.X`.
+
+These three fields hold per-binding state set at registration:
+- `bind_time_ns` — monotonic creation timestamp; used by
+  heartbeat-gating logic.
+- `bind_mode` — copy vs zero-copy XSK bind result; used by
+  TX-wake gating.
+- `xsk_rx_confirmed` — flips true once the XSK RX ring delivers
+  the first packet, proving the NIC's XSK queue is live.
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-7. **6 callsites across 3
+files** — smallest phase yet.
+
+`WorkerBindMeta` has NO `Default` derive — `bind_time_ns` must be
+seeded with the actual monotonic-now sample.
+
+**Collision caught at build time**: `BindingLiveState.bind_mode` (an
+AtomicU8 mirror) at `umem/mod.rs:564,634,637` and `tx/rings.rs:212`
+was over-replaced by the perl pass. The compiler rejected those
+sites; reverted to keep the BindingLiveState atomic accesses
+unchanged. Only BindingWorker.bind_mode → BindingWorker.bind_meta.bind_mode
+moved.
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5/5 named runs.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against 172.16.80.200 / 2001:559:8585:80::200.
+- Codex hostile review.
+
+## NOT in scope
+
+- `outstanding_tx` → tiny followup phase (collides with BindingStatus mirror).
+- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred.
+- `flow_cache*` → separate small phase (2 fields).

--- a/userspace-dp/src/afxdp/worker/bind_meta.rs
+++ b/userspace-dp/src/afxdp/worker/bind_meta.rs
@@ -26,7 +26,16 @@ use super::*;
 /// any heartbeat-gating logic that checks
 /// `now_ns - bind_time_ns < grace_period`.
 pub(crate) struct WorkerBindMeta {
+    /// Reserved for heartbeat-gating logic (matches the
+    /// `#[allow(dead_code)]` allowance on the original
+    /// `BindingWorker::bind_time_ns` field — preserved here so
+    /// extraction doesn't regress warning hygiene).
+    #[allow(dead_code)]
     pub(crate) bind_time_ns: u64,
+    /// Reserved for heartbeat-gating logic (matches the
+    /// `#[allow(dead_code)]` allowance on the original
+    /// `BindingWorker::bind_mode` field).
+    #[allow(dead_code)]
     pub(crate) bind_mode: XskBindMode,
     pub(crate) xsk_rx_confirmed: bool,
 }

--- a/userspace-dp/src/afxdp/worker/bind_meta.rs
+++ b/userspace-dp/src/afxdp/worker/bind_meta.rs
@@ -1,0 +1,32 @@
+//! #959 Phase 8 — extracts the per-binding registration / identity
+//! metadata out of `BindingWorker` into a dedicated `WorkerBindMeta`
+//! sub-struct.
+//!
+//! Three fields:
+//! - `bind_time_ns` — monotonic timestamp when this binding was
+//!   created. Used by heartbeat-gating logic.
+//! - `bind_mode` — copy vs zero-copy XSK bind mode (set after
+//!   bind succeeds).
+//! - `xsk_rx_confirmed` — flips true once the XSK RX ring has
+//!   delivered at least one packet, proving the NIC's XSK receive
+//!   queue is active for this binding.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-8. Field names preserved.
+
+use super::*;
+
+/// Per-binding registration / identity metadata. Set at binding
+/// construction and during the bind-mode transition. Never reset
+/// after the binding is bound.
+///
+/// **Intentionally NOT `Default`** — `bind_time_ns` must be
+/// initialized to the actual monotonic-now sample from
+/// `BindingWorker::create`. Default would seed with 0 and break
+/// any heartbeat-gating logic that checks
+/// `now_ns - bind_time_ns < grace_period`.
+pub(crate) struct WorkerBindMeta {
+    pub(crate) bind_time_ns: u64,
+    pub(crate) bind_mode: XskBindMode,
+    pub(crate) xsk_rx_confirmed: bool,
+}

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -115,8 +115,8 @@ pub(super) fn poll_binding(
 
         let raw_avail = binding.rx.available();
         let available = raw_avail.min(RX_BATCH_SIZE);
-        if raw_avail > 0 && !binding.xsk_rx_confirmed {
-            binding.xsk_rx_confirmed = true;
+        if raw_avail > 0 && !binding.bind_meta.xsk_rx_confirmed {
+            binding.bind_meta.xsk_rx_confirmed = true;
         }
         if cfg!(feature = "debug-log") {
             if raw_avail > 0 {

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -39,6 +39,11 @@ pub(crate) use timers::WorkerTimers;
 mod tx_pipeline;
 pub(crate) use tx_pipeline::WorkerTxPipeline;
 
+// #959 Phase 8: per-binding registration / identity metadata lives
+// in worker/bind_meta.rs.
+mod bind_meta;
+pub(crate) use bind_meta::WorkerBindMeta;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -114,15 +119,11 @@ pub(crate) struct BindingWorker {
     pub(crate) tx_counters: WorkerTxCounters,
     pub(crate) flow_cache: FlowCache,
     pub(crate) flow_cache_session_touch: u64,
-    /// Timestamp when this binding was created.
-    #[allow(dead_code)] // reserved for heartbeat gating logic
-    pub(crate) bind_time_ns: u64,
-    /// Zero-copy vs copy mode (affects heartbeat gating).
-    #[allow(dead_code)] // reserved for heartbeat gating logic
-    pub(crate) bind_mode: XskBindMode,
-    /// Set true once the XSK RX ring has delivered at least one packet,
-    /// proving the NIC's XSK receive queue is active for this binding.
-    pub(crate) xsk_rx_confirmed: bool,
+    /// #959 Phase 8: 3 binding registration / identity fields
+    /// (bind_time_ns, bind_mode, xsk_rx_confirmed) extracted into
+    /// `WorkerBindMeta`. Field semantics unchanged; access via
+    /// `binding.bind_meta.X`.
+    pub(crate) bind_meta: WorkerBindMeta,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -398,16 +399,18 @@ impl BindingWorker {
             },
             flow_cache: FlowCache::new(),
             flow_cache_session_touch: 0,
-            bind_time_ns: {
-                let mut ts = libc::timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                };
-                unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
-                ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+            bind_meta: WorkerBindMeta {
+                bind_time_ns: {
+                    let mut ts = libc::timespec {
+                        tv_sec: 0,
+                        tv_nsec: 0,
+                    };
+                    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+                    ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+                },
+                bind_mode,
+                xsk_rx_confirmed: false,
             },
-            xsk_rx_confirmed: false,
-            bind_mode,
         };
         update_binding_debug_state(&mut binding);
         Ok(binding)


### PR DESCRIPTION
## Summary

Phase 8 of **#959** BindingWorker decomposition. Smallest phase yet —
3 fields, 6 callsites.

Moves 3 binding registration / identity fields out of `BindingWorker`:

| Field | Purpose |
|-------|---------|
| \`bind_time_ns\` | monotonic creation timestamp (heartbeat gating) |
| \`bind_mode\` | copy vs zero-copy XSK bind result (TX-wake gating) |
| \`xsk_rx_confirmed\` | flips true once XSK RX delivers first packet |

Access pattern: \`binding.bind_meta.X\`.

## Methodology

Same compiler-driven approach as Phases 1-7. **6 callsites across 3
files** (worker/lifecycle.rs, tx/rings.rs, umem/mod.rs).

`WorkerBindMeta` has **NO `Default`** derive — \`bind_time_ns\` must
be seeded with the actual monotonic-now sample.

**Collision caught at build time**: \`BindingLiveState.bind_mode\`
(an AtomicU8 mirror) at \`umem/mod.rs:564,634,637\` and
\`tx/rings.rs:212\` was over-replaced by the perl pass. The compiler
rejected those sites with "no field bind_meta on BindingLiveState".
Reverted with a targeted perl pass — BindingLiveState atomic
accesses remain unchanged; only \`BindingWorker.bind_mode →
binding.bind_meta.bind_mode\` moved.

## Files affected

| File | Change |
|------|--------|
| \`userspace-dp/src/afxdp/worker/bind_meta.rs\` | new, 30 LOC |
| \`userspace-dp/src/afxdp/worker/mod.rs\` | -3 fields, +nested literal |
| \`userspace-dp/src/afxdp/worker/lifecycle.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/tx/rings.rs\` | callsite rewrite |
| \`userspace-dp/src/afxdp/umem/mod.rs\` | callsite rewrites |
| \`docs/pr/959-phase8-bindmeta/plan.md\` | new plan |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 952 passed, 0 failed
- [x] \`cargo test --release flush_clears_records_and_increments_sequence\` — 5/5 named runs
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke \`172.16.80.200\` — 958 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke \`2001:559:8585:80::200\` — 946 Mbps, 0 retr

## #959 progress

| Phase | Fields | PR |
|-------|--------|-----|
| 1: dbg_* | 23 | #1167 |
| 2: scratch_* | 11 | #1168 |
| 3: cos_* | 5 | #1169 |
| 4: pending_*_tx_* | 6 | #1170 |
| 5: BPF FDs | 4 | #1171 |
| 6: timers | 5 | #1172 |
| 7: tx_pipeline | 7 | #1173 |
| **8: bind_meta (this)** | 3 | this |
| **Total moved** | **64** | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)