### PR TITLE
#959 Phase 9: extract flow-cache state into WorkerFlowCacheState

### DIFF
--- a/docs/pr/959-phase9-flowcache/plan.md
+++ b/docs/pr/959-phase9-flowcache/plan.md
@@ -21,7 +21,7 @@ refresh in the descriptor loop.
 
 Filename is `flow_cache_state.rs` because `flow_cache.rs` is taken
 by the FlowCache data structure itself (in
-`userspace-dp/src/flow_cache.rs`).
+`userspace-dp/src/afxdp/flow_cache.rs`).
 
 ## Methodology
 

--- a/docs/pr/959-phase9-flowcache/plan.md
+++ b/docs/pr/959-phase9-flowcache/plan.md
@@ -1,0 +1,47 @@
+# Plan: #959 Phase 9 — extract flow-cache state into `WorkerFlowCacheState`
+
+## Status
+
+Phase 9 of #959. Phases 1-8 (#1167-#1174) extracted dbg_*,
+scratch_*, cos_*, pending_*_tx_*, BPF FDs, timers, TX pipeline,
+bind metadata.
+
+## Scope
+
+Move 2 flow-cache state fields out of `BindingWorker` into a new
+`WorkerFlowCacheState` sub-struct accessed via `binding.flow.X`:
+
+```
+flow_cache, flow_cache_session_touch
+```
+
+`flow_cache` is the per-worker FlowCache lookup. `flow_cache_session_touch`
+counts session touches; the 64-touch boundary triggers a session-table
+refresh in the descriptor loop.
+
+Filename is `flow_cache_state.rs` because `flow_cache.rs` is taken
+by the FlowCache data structure itself (in
+`userspace-dp/src/flow_cache.rs`).
+
+## Methodology
+
+Same compiler-driven approach as Phases 1-8. 18 callsites across 3
+files (poll_descriptor.rs, worker/lifecycle.rs, umem/mod.rs).
+
+`WorkerFlowCacheState` has NO `Default` derive — for consistency
+with the other #959 sub-structs.
+
+## Acceptance
+
+- `cargo build --release` clean.
+- `cargo test --release` — 952 passed.
+- `cargo test --release flush_clears_records_and_increments_sequence`
+  — 5/5 named runs.
+- `go build ./...` + `go test ./...` clean.
+- v4 + v6 smoke against 172.16.80.200 / 2001:559:8585:80::200.
+- Codex hostile review.
+
+## NOT in scope
+
+- `outstanding_tx` → tiny followup phase.
+- XSK rings (`device`, `rx`, `tx`) → still highest-risk; deferred.

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -229,7 +229,7 @@ pub(super) fn poll_binding_process_descriptor(
                     if FlowCacheEntry::packet_eligible(meta)
                         && let Some(flow) = flow.as_ref()
                     {
-                        if let Some(cached) = binding.flow_cache.lookup(
+                        if let Some(cached) = binding.flow.flow_cache.lookup(
                             &flow.forward_key,
                             FlowCacheLookup::for_packet(meta, validation),
                             now_secs,
@@ -245,7 +245,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 resolution_target_for_session(flow, cached.decision),
                                 cached.decision.resolution,
                             ) {
-                                binding.flow_cache.invalidate_slot(
+                                binding.flow.flow_cache.invalidate_slot(
                                     &flow.forward_key,
                                     meta.ingress_ifindex as i32,
                                 );
@@ -264,8 +264,8 @@ pub(super) fn poll_binding_process_descriptor(
                                     );
                                 }
                                 // Amortize session timestamp touch — every 64 cache hits.
-                                binding.flow_cache_session_touch += 1;
-                                if binding.flow_cache_session_touch & 63 == 0 {
+                                binding.flow.flow_cache_session_touch += 1;
+                                if binding.flow.flow_cache_session_touch & 63 == 0 {
                                     sessions.touch(&flow.forward_key, now_ns);
                                 }
                                 if matches!(
@@ -1885,7 +1885,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     &worker_ctx.rg_epochs,
                                 )
                             {
-                                binding.flow_cache.insert(entry);
+                                binding.flow.flow_cache.insert(entry);
                             }
                             // ── End flow cache population ────────────────
                         } else {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1038,37 +1038,37 @@ pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
             );
         binding.tx_counters.pending_direct_tx_disallowed_fallback_packets = 0;
     }
-    if binding.flow_cache.hits != 0 {
+    if binding.flow.flow_cache.hits != 0 {
         binding
             .live
             .flow_cache_hits
-            .fetch_add(binding.flow_cache.hits, Ordering::Relaxed);
-        binding.flow_cache.hits = 0;
+            .fetch_add(binding.flow.flow_cache.hits, Ordering::Relaxed);
+        binding.flow.flow_cache.hits = 0;
     }
-    if binding.flow_cache.misses != 0 {
+    if binding.flow.flow_cache.misses != 0 {
         binding
             .live
             .flow_cache_misses
-            .fetch_add(binding.flow_cache.misses, Ordering::Relaxed);
-        binding.flow_cache.misses = 0;
+            .fetch_add(binding.flow.flow_cache.misses, Ordering::Relaxed);
+        binding.flow.flow_cache.misses = 0;
     }
-    if binding.flow_cache.evictions != 0 {
+    if binding.flow.flow_cache.evictions != 0 {
         binding
             .live
             .flow_cache_evictions
-            .fetch_add(binding.flow_cache.evictions, Ordering::Relaxed);
-        binding.flow_cache.evictions = 0;
+            .fetch_add(binding.flow.flow_cache.evictions, Ordering::Relaxed);
+        binding.flow.flow_cache.evictions = 0;
     }
     // #918: surface collision-driven evictions distinctly from
     // stale-on-lookup evictions so the post-merge acceptance gate
     // (`collision_evictions / hits < 1 %` under 100E100M load) is
     // observable from the standard binding-counter snapshot.
-    if binding.flow_cache.collision_evictions != 0 {
+    if binding.flow.flow_cache.collision_evictions != 0 {
         binding
             .live
             .flow_cache_collision_evictions
-            .fetch_add(binding.flow_cache.collision_evictions, Ordering::Relaxed);
-        binding.flow_cache.collision_evictions = 0;
+            .fetch_add(binding.flow.flow_cache.collision_evictions, Ordering::Relaxed);
+        binding.flow.flow_cache.collision_evictions = 0;
     }
     // #941 Work item D + #943: flush each queue's per-queue scratch
     // counters (hard-cap overrides AND regular V_min throttles) into

--- a/userspace-dp/src/afxdp/worker/flow_cache_state.rs
+++ b/userspace-dp/src/afxdp/worker/flow_cache_state.rs
@@ -1,0 +1,30 @@
+//! #959 Phase 9 — extracts the per-binding flow-cache state out of
+//! `BindingWorker` into a dedicated `WorkerFlowCacheState` sub-struct.
+//!
+//! Two fields:
+//! - `flow_cache` — per-worker flow lookup cache (the `FlowCache`
+//!   data structure from `super::*`).
+//! - `flow_cache_session_touch` — count of session touches modulo
+//!   the periodic-refresh threshold; the 64-touch boundary triggers
+//!   a session-table refresh in the descriptor loop.
+//!
+//! Pure structural extraction: capacities and access semantics
+//! unchanged from master pre-Phase-9. Field names preserved.
+//!
+//! Filename is `flow_cache_state.rs` because `flow_cache.rs` is
+//! taken by the `FlowCache` data structure itself (in
+//! `userspace-dp/src/flow_cache.rs`).
+
+use super::*;
+
+/// Per-binding flow-cache state. Owned by the worker that owns this
+/// binding.
+///
+/// **Intentionally NOT `Default`** — for consistency with the other
+/// #959 sub-structs. `FlowCache::new()` is the canonical
+/// construction; the explicit literal in `BindingWorker::create`
+/// uses it.
+pub(crate) struct WorkerFlowCacheState {
+    pub(crate) flow_cache: FlowCache,
+    pub(crate) flow_cache_session_touch: u64,
+}

--- a/userspace-dp/src/afxdp/worker/flow_cache_state.rs
+++ b/userspace-dp/src/afxdp/worker/flow_cache_state.rs
@@ -13,7 +13,7 @@
 //!
 //! Filename is `flow_cache_state.rs` because `flow_cache.rs` is
 //! taken by the `FlowCache` data structure itself (in
-//! `userspace-dp/src/flow_cache.rs`).
+//! `userspace-dp/src/afxdp/flow_cache.rs`).
 
 use super::*;
 

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -211,7 +211,7 @@ pub(super) fn poll_binding(
             // #918: 4-way set-associative cache requires walking the set
             // for the matching key — `invalidate_slot` does that.
             binding
-                .flow_cache
+                .flow.flow_cache
                 .invalidate_slot(&forward_key, binding.ifindex);
             teardown_tcp_rst_flow(
                 left,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use bind_meta::WorkerBindMeta;
 
 // #959 Phase 9: per-binding flow-cache state lives in
 // worker/flow_cache_state.rs (the `flow_cache` name is taken by
-// the `FlowCache` data structure in src/flow_cache.rs).
+// the `FlowCache` data structure in src/afxdp/flow_cache.rs).
 mod flow_cache_state;
 pub(crate) use flow_cache_state::WorkerFlowCacheState;
 

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -44,6 +44,12 @@ pub(crate) use tx_pipeline::WorkerTxPipeline;
 mod bind_meta;
 pub(crate) use bind_meta::WorkerBindMeta;
 
+// #959 Phase 9: per-binding flow-cache state lives in
+// worker/flow_cache_state.rs (the `flow_cache` name is taken by
+// the `FlowCache` data structure in src/flow_cache.rs).
+mod flow_cache_state;
+pub(crate) use flow_cache_state::WorkerFlowCacheState;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -117,8 +123,10 @@ pub(crate) struct BindingWorker {
     /// into `WorkerTxCounters`. Field semantics unchanged; access
     /// via `binding.tx_counters.pending_X`.
     pub(crate) tx_counters: WorkerTxCounters,
-    pub(crate) flow_cache: FlowCache,
-    pub(crate) flow_cache_session_touch: u64,
+    /// #959 Phase 9: 2 flow-cache state fields extracted into
+    /// `WorkerFlowCacheState`. Field semantics unchanged; access
+    /// via `binding.flow.flow_cache` and `binding.flow.flow_cache_session_touch`.
+    pub(crate) flow: WorkerFlowCacheState,
     /// #959 Phase 8: 3 binding registration / identity fields
     /// (bind_time_ns, bind_mode, xsk_rx_confirmed) extracted into
     /// `WorkerBindMeta`. Field semantics unchanged; access via
@@ -397,8 +405,10 @@ impl BindingWorker {
                 pending_direct_tx_build_fallback_packets: 0,
                 pending_direct_tx_disallowed_fallback_packets: 0,
             },
-            flow_cache: FlowCache::new(),
-            flow_cache_session_touch: 0,
+            flow: WorkerFlowCacheState {
+                flow_cache: FlowCache::new(),
+                flow_cache_session_touch: 0,
+            },
             bind_meta: WorkerBindMeta {
                 bind_time_ns: {
                     let mut ts = libc::timespec {


### PR DESCRIPTION
## Summary

Phase 9 of **#959** BindingWorker decomposition.

Moves 2 flow-cache state fields out of `BindingWorker`:

| Field |
|-------|
| \`flow_cache\` |
| \`flow_cache_session_touch\` |

Access pattern: \`binding.flow.X\`.

Filename is `flow_cache_state.rs` because `flow_cache.rs` is taken
by the FlowCache data structure itself (in
\`userspace-dp/src/flow_cache.rs\`).

## Methodology

Same compiler-driven approach as Phases 1-8. **18 callsites across 3
files** (poll_descriptor.rs, worker/lifecycle.rs, umem/mod.rs).

`WorkerFlowCacheState` has **NO `Default`** derive for consistency
with the other #959 sub-structs.

## Files affected

| File | Change |
|------|--------|
| \`userspace-dp/src/afxdp/worker/flow_cache_state.rs\` | new, 30 LOC |
| \`userspace-dp/src/afxdp/worker/mod.rs\` | -2 fields, +nested literal |
| \`userspace-dp/src/afxdp/poll_descriptor.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/worker/lifecycle.rs\` | callsite rewrites |
| \`userspace-dp/src/afxdp/umem/mod.rs\` | callsite rewrites |
| \`docs/pr/959-phase9-flowcache/plan.md\` | new plan |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 952 passed, 0 failed
- [x] \`cargo test --release flush_clears_records_and_increments_sequence\` — 5/5 named runs
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — 30 packages pass
- [x] Deploy on loss userspace cluster
- [x] v4 smoke \`172.16.80.200\` — 958 Mbps, 0 retr (iperf-a CoS class)
- [x] v6 smoke \`2001:559:8585:80::200\` — 946 Mbps, 0 retr

## #959 progress

| Phase | Fields | PR |
|-------|--------|-----|
| 1: dbg_* | 23 | #1167 |
| 2: scratch_* | 11 | #1168 |
| 3: cos_* | 5 | #1169 |
| 4: pending_*_tx_* | 6 | #1170 |
| 5: BPF FDs | 4 | #1171 |
| 6: timers | 5 | #1172 |
| 7: tx_pipeline | 7 | #1173 |
| 8: bind_meta | 3 | #1174 |
| **9: flow_cache (this)** | 2 | this |
| **Total moved** | **66** | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)