### PR TITLE
#959 Phase 10: relocate outstanding_tx into WorkerTxPipeline

### DIFF
--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -143,7 +143,7 @@ pub(super) fn service_exact_local_queue_direct(
         return false;
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_local_fifo_submission(
         binding
@@ -292,7 +292,7 @@ fn service_exact_local_queue_direct_flow_fair(
         return false;
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_local_scratch_submission_flow_fair(
         binding
@@ -450,7 +450,7 @@ pub(super) fn service_exact_prepared_queue_direct(
         return false;
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_fifo_submission(
         binding
@@ -602,7 +602,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
         return false;
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let (sent_packets, sent_bytes) = settle_exact_prepared_scratch_submission_flow_fair(
         binding

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -552,7 +552,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     // it falls through to the copy path below.
                     let mut direct_tx_offset = target_binding.tx_pipeline.free_tx_frames.pop_front();
                     if direct_tx_offset.is_none()
-                        && (target_binding.outstanding_tx > 0
+                        && (target_binding.tx_pipeline.outstanding_tx > 0
                             || !target_binding.tx_pipeline.pending_tx_prepared.is_empty()
                             || !target_binding.tx_pipeline.pending_tx_local.is_empty())
                     {
@@ -1282,7 +1282,7 @@ fn segment_forwarded_tcp_frames_into_prepared(
 
     let segment_count = data.len().div_ceil(segment_payload_max);
     if target_binding.tx_pipeline.free_tx_frames.len() < segment_count
-        && (target_binding.outstanding_tx > 0
+        && (target_binding.tx_pipeline.outstanding_tx > 0
             || !target_binding.tx_pipeline.pending_tx_prepared.is_empty()
             || !target_binding.tx_pipeline.pending_tx_local.is_empty())
     {

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -71,7 +71,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
     // In copy mode, the kernel needs sendto() to process TX ring entries.
     // If outstanding entries remain after reaping (kernel didn't finish in
     // the previous kick), re-kick now so they don't stall forever.
-    if binding.outstanding_tx > 0
+    if binding.tx_pipeline.outstanding_tx > 0
         && binding.tx_pipeline.pending_tx_prepared.is_empty()
         && binding.tx_pipeline.pending_tx_local.is_empty()
     {
@@ -454,7 +454,7 @@ fn drop_cos_bound_local_leftovers(
 }
 
 fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
-    binding.outstanding_tx > 0
+    binding.tx_pipeline.outstanding_tx > 0
         || !binding.tx_pipeline.pending_tx_prepared.is_empty()
         || !binding.tx_pipeline.pending_tx_local.is_empty()
         || !binding.live.pending_tx_empty()

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -21,7 +21,7 @@ pub(in crate::afxdp) fn reap_tx_completions(
     binding: &mut BindingWorker,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> u32 {
-    if binding.outstanding_tx == 0 {
+    if binding.tx_pipeline.outstanding_tx == 0 {
         return 0;
     }
     let available = binding.device.available();
@@ -58,7 +58,7 @@ pub(in crate::afxdp) fn reap_tx_completions(
         let offset = binding.scratch.scratch_completed_offsets[i];
         recycle_completed_tx_offset(binding, shared_recycles, offset);
     }
-    binding.outstanding_tx = binding.outstanding_tx.saturating_sub(reaped);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_sub(reaped);
     binding.telemetry.dbg_completions_reaped += reaped as u64;
     binding
         .live
@@ -282,7 +282,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                         binding.slot,
                         binding.ifindex,
                         binding.queue_id,
-                        binding.outstanding_tx,
+                        binding.tx_pipeline.outstanding_tx,
                         binding.tx_pipeline.free_tx_frames.len(),
                     );
                 }
@@ -295,7 +295,7 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
                         binding.ifindex,
                         binding.queue_id,
                         errno,
-                        binding.outstanding_tx,
+                        binding.tx_pipeline.outstanding_tx,
                         binding.tx_pipeline.free_tx_frames.len(),
                     );
                 }

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -217,7 +217,7 @@ pub(in crate::afxdp) fn transmit_batch(
         return Err(TxError::Retry("tx ring insert failed".to_string()));
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let mut sent_packets = 0u64;
     let mut sent_bytes = 0u64;
@@ -449,7 +449,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
         return Err(TxError::Retry("prepared tx ring insert failed".to_string()));
     }
     binding.telemetry.dbg_tx_ring_submitted += inserted as u64;
-    binding.outstanding_tx = binding.outstanding_tx.saturating_add(inserted);
+    binding.tx_pipeline.outstanding_tx = binding.tx_pipeline.outstanding_tx.saturating_add(inserted);
 
     let mut sent_packets = 0u64;
     let mut sent_bytes = 0u64;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -89,9 +89,11 @@ pub(crate) struct BindingWorker {
     pub(crate) device: crate::xsk_ffi::DeviceQueue,
     pub(crate) rx: crate::xsk_ffi::RingRx,
     pub(crate) tx: crate::xsk_ffi::RingTx,
-    /// #959 Phase 7: 7 TX pipeline fields extracted into
-    /// `WorkerTxPipeline`. Field semantics unchanged; access via
-    /// `binding.tx_pipeline.X`.
+    /// #959 Phase 7 + Phase 10: 8 TX pipeline fields extracted into
+    /// `WorkerTxPipeline` (Phase 7 brought 7; Phase 10 added
+    /// `outstanding_tx` once the BindingStatus mirror collision was
+    /// resolved by type-level disambiguation). Field semantics
+    /// unchanged; access via `binding.tx_pipeline.X`.
     pub(crate) tx_pipeline: WorkerTxPipeline,
     /// #959 Phase 3: 5 `cos_*` per-binding CoS scheduling fields
     /// extracted into `WorkerCos`. Field semantics unchanged;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -109,11 +109,8 @@ pub(crate) struct BindingWorker {
     pub(crate) bpf_maps: WorkerBpfMaps,
     /// #959 Phase 6: 5 timing / wake-pacing fields extracted into
     /// `WorkerTimers`. Field semantics unchanged; access via
-    /// `binding.timers.last_X_ns` etc. `outstanding_tx` stays at
-    /// the BindingWorker level — it's a TX-pipeline counter
-    /// (sequenced for Phase 7), not a timer.
+    /// `binding.timers.last_X_ns` etc.
     pub(crate) timers: WorkerTimers,
-    pub(crate) outstanding_tx: u32,
     pub(crate) last_learned_neighbor: Option<LearnedNeighborKey>,
     /// #959 Phase 1: 23 `dbg_*` debug counters extracted into
     /// `WorkerTelemetry` to reduce BindingWorker's mutable surface
@@ -340,6 +337,7 @@ impl BindingWorker {
                 pending_tx_prepared: VecDeque::new(),
                 pending_tx_local: VecDeque::new(),
                 max_pending_tx,
+                outstanding_tx: 0,
                 pending_fill_frames: VecDeque::new(),
                 in_flight_prepared_recycles: FastMap::default(),
                 // #812: pre-allocate the submit-timestamp sidecar once,
@@ -394,7 +392,6 @@ impl BindingWorker {
                 last_tx_wake_ns: init_now,
                 empty_rx_polls: 0,
             },
-            outstanding_tx: 0,
             last_learned_neighbor: None,
             telemetry: WorkerTelemetry::default(),
             tx_counters: WorkerTxCounters {
@@ -1093,7 +1090,7 @@ pub(crate) fn worker_loop(
                         + fill_pending
                         + rx_avail
                         + b.tx_pipeline.free_tx_frames.len() as u32
-                        + b.outstanding_tx
+                        + b.tx_pipeline.outstanding_tx
                         + inflight_recycles
                         + scratch_recycle_len
                         + ptx_prepared; // prepared TX holds UMEM frames
@@ -1108,7 +1105,7 @@ pub(crate) fn worker_loop(
                         fill_pending,
                         rx_avail,
                         b.tx_pipeline.free_tx_frames.len(),
-                        b.outstanding_tx,
+                        b.tx_pipeline.outstanding_tx,
                         inflight_recycles,
                         scratch_recycle_len,
                         ptx_prepared,
@@ -1360,7 +1357,7 @@ pub(crate) fn worker_loop(
                                 + fill_p
                                 + rx_a
                                 + sb.tx_pipeline.free_tx_frames.len() as u32
-                                + sb.outstanding_tx
+                                + sb.tx_pipeline.outstanding_tx
                                 + ifl
                                 + sb.scratch.scratch_recycle.len() as u32
                                 + ptxp;
@@ -1374,7 +1371,7 @@ pub(crate) fn worker_loop(
                                 fill_p,
                                 rx_a,
                                 sb.tx_pipeline.free_tx_frames.len(),
-                                sb.outstanding_tx,
+                                sb.tx_pipeline.outstanding_tx,
                                 ifl,
                                 ptxp,
                                 ptxl,
@@ -1501,14 +1498,16 @@ pub(crate) fn worker_loop(
                             .rx_fill_ring_empty_descs
                             .store(stats.rx_fill_ring_empty_descs, Ordering::Relaxed);
                     }
-                    // #802: outstanding_tx is a transient gauge on BindingWorker
-                    // (current in-flight TX). Publish to the existing atomic
-                    // mirror on BindingLiveState so the snapshot reader sees
-                    // a recent value. store() because it's a gauge, not a
-                    // counter.
+                    // #802: outstanding_tx is a transient gauge on
+                    // BindingWorker.tx_pipeline (current in-flight TX).
+                    // Publish to the existing atomic mirror on
+                    // BindingLiveState so the snapshot reader sees a
+                    // recent value. store() because it's a gauge, not a
+                    // counter. (#959 Phase 10 moved the field from
+                    // BindingWorker to WorkerTxPipeline.)
                     b.live
                         .debug_outstanding_tx
-                        .store(b.outstanding_tx, Ordering::Relaxed);
+                        .store(b.tx_pipeline.outstanding_tx, Ordering::Relaxed);
                     // #878: publish UMEM in-flight gauge as a single atomic
                     // so the daemon's `show chassis forwarding` Buffer% can
                     // divide by `umem_total_frames` without torn-load risk.

--- a/userspace-dp/src/afxdp/worker/tx_pipeline.rs
+++ b/userspace-dp/src/afxdp/worker/tx_pipeline.rs
@@ -1,13 +1,22 @@
 //! #959 Phase 7 — extracts the per-binding TX pipeline state out of
 //! `BindingWorker` into a dedicated `WorkerTxPipeline` sub-struct.
+//! #959 Phase 10 — adds `outstanding_tx` to this same sub-struct
+//! (was held back from Phase 7 to avoid collision with the
+//! `BindingStatus.outstanding_tx` snapshot mirror; the type-level
+//! disambiguation now keeps the two distinct).
 //!
-//! These seven fields hold the per-binding TX pipeline buffers and
+//! These eight fields hold the per-binding TX pipeline buffers and
 //! the per-frame submit-timestamp sidecar:
 //!
 //! - `free_tx_frames` — UMEM frame addresses available for TX.
 //! - `pending_tx_prepared` — TX-ready requests awaiting ring submit.
 //! - `pending_tx_local` — local-TX requests awaiting ring submit.
 //! - `max_pending_tx` — TX backpressure threshold (configured once).
+//! - `outstanding_tx` — transient gauge of in-flight TX descriptors
+//!   (incremented at `sendto`/local-TX insert, decremented when the
+//!   completion ring is reaped). Mirrored to
+//!   `BindingLiveState.debug_outstanding_tx` once per debug tick so
+//!   the snapshot reader sees a recent value (#802).
 //! - `pending_fill_frames` — fill-ring back-pressure queue.
 //! - `in_flight_prepared_recycles` — completion-time recycle map.
 //! - `tx_submit_ns` — per-UMEM-frame submit timestamp sidecar
@@ -16,13 +25,9 @@
 //!   so any future `push` attempt fails to compile.
 //!
 //! Pure structural extraction: capacities and access semantics
-//! unchanged from master pre-Phase-7. Field names preserved so
+//! unchanged from master pre-Phase-7/10. Field names preserved so
 //! `binding.tx_pipeline.free_tx_frames` keeps the same grep-friendly
 //! suffix as the original `binding.free_tx_frames`.
-//!
-//! NOT IN THIS PHASE: `outstanding_tx` (collides with the
-//! `BindingStatus.outstanding_tx` snapshot mirror; deferred to a
-//! tiny followup phase that handles the type disambiguation).
 
 use super::*;
 
@@ -37,6 +42,14 @@ pub(crate) struct WorkerTxPipeline {
     pub(crate) pending_tx_prepared: VecDeque<PreparedTxRequest>,
     pub(crate) pending_tx_local: VecDeque<TxRequest>,
     pub(crate) max_pending_tx: usize,
+    /// Transient gauge of in-flight TX descriptors — incremented
+    /// when a frame is inserted onto the TX ring (or local-TX queue
+    /// drained into the ring), decremented when the completion ring
+    /// is reaped. Mirrored once per debug tick to
+    /// `BindingLiveState.debug_outstanding_tx` for the snapshot
+    /// reader (#802). NOT a counter — a saturating gauge of
+    /// in-flight work.
+    pub(crate) outstanding_tx: u32,
     pub(crate) pending_fill_frames: VecDeque<u64>,
     pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,
     /// #812 per-UMEM-frame submit timestamp sidecar. Indexed by

--- a/userspace-dp/src/afxdp/worker/tx_pipeline.rs
+++ b/userspace-dp/src/afxdp/worker/tx_pipeline.rs
@@ -13,8 +13,9 @@
 //! - `pending_tx_local` — local-TX requests awaiting ring submit.
 //! - `max_pending_tx` — TX backpressure threshold (configured once).
 //! - `outstanding_tx` — transient gauge of in-flight TX descriptors
-//!   (incremented at `sendto`/local-TX insert, decremented when the
-//!   completion ring is reaped). Mirrored to
+//!   (incremented when a TX ring descriptor is inserted, decremented
+//!   when the completion ring is reaped — `sendto` is the wake/kick,
+//!   not the increment site). Mirrored to
 //!   `BindingLiveState.debug_outstanding_tx` once per debug tick so
 //!   the snapshot reader sees a recent value (#802).
 //! - `pending_fill_frames` — fill-ring back-pressure queue.
@@ -43,12 +44,15 @@ pub(crate) struct WorkerTxPipeline {
     pub(crate) pending_tx_local: VecDeque<TxRequest>,
     pub(crate) max_pending_tx: usize,
     /// Transient gauge of in-flight TX descriptors — incremented
-    /// when a frame is inserted onto the TX ring (or local-TX queue
-    /// drained into the ring), decremented when the completion ring
-    /// is reaped. Mirrored once per debug tick to
-    /// `BindingLiveState.debug_outstanding_tx` for the snapshot
-    /// reader (#802). NOT a counter — a saturating gauge of
-    /// in-flight work.
+    /// when a TX ring descriptor is inserted (the
+    /// `saturating_add(inserted)` sites in tx/transmit.rs and the
+    /// CoS direct-submit paths in cos/queue_service/service.rs),
+    /// decremented when the completion ring is reaped
+    /// (saturating_sub in tx/rings.rs). `sendto` is the wake/kick
+    /// of the kernel TX path, NOT the increment site. Mirrored once
+    /// per debug tick to `BindingLiveState.debug_outstanding_tx`
+    /// for the snapshot reader (#802). NOT a counter — a
+    /// saturating gauge of in-flight work.
     pub(crate) outstanding_tx: u32,
     pub(crate) pending_fill_frames: VecDeque<u64>,
     pub(crate) in_flight_prepared_recycles: FastMap<u64, PreparedTxRecycle>,


### PR DESCRIPTION
## Summary

- Pure structural follow-on to Phase 7. `outstanding_tx: u32` moves from `BindingWorker` directly into the existing `WorkerTxPipeline` sub-struct (slotted after `max_pending_tx`).
- Held back from Phase 7 because of the BindingStatus snapshot mirror collision at `coordinator/mod.rs:1216,1353` and `protocol.rs:1394,1515,1611`. The Rust compiler resolves both accesses by type, so Phase 10 just rewrites the BindingWorker callsites.
- 22 callsites rewritten across `tx/{drain,dispatch,transmit,rings}.rs`, `cos/queue_service/service.rs`, and `worker/mod.rs` (`b`/`sb` iter aliases). BindingStatus mirror sites are untouched.

## Test plan

- [x] `cargo build` clean (93 pre-existing warnings, 0 new)
- [x] 952/952 cargo tests pass (`cargo test --release`)
- [x] `tx_completion` named tests 5/5 clean (flake check)
- [x] 30 Go packages pass (`go test ./...`)
- [x] Deploy clean on loss userspace cluster (rolling secondary then primary)
- [x] v4 smoke: ~957 Mbps against 172.16.80.200 (best-effort port 5201)
- [x] v6 smoke: ~944 Mbps against 2001:559:8585:80::200 (best-effort port 5201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)