### PR TITLE
#959 Phase 11: extract XSK rings into WorkerXskRings (closes #959)

### DIFF
--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -98,6 +98,7 @@ pub(super) fn service_exact_local_queue_direct(
     }
 
     let mut writer = binding
+        .xsk
         .tx
         .transmit(binding.scratch.scratch_exact_local_tx.len() as u32);
     let inserted = writer.insert(binding.scratch.scratch_exact_local_tx.iter().map(|req| XdpDesc {
@@ -245,7 +246,7 @@ fn service_exact_local_queue_direct_flow_fair(
         return false;
     }
 
-    let mut writer = binding.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
+    let mut writer = binding.xsk.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
     let inserted = writer.insert(
         binding
             .scratch.scratch_local_tx
@@ -412,6 +413,7 @@ pub(super) fn service_exact_prepared_queue_direct(
     }
 
     let mut writer = binding
+        .xsk
         .tx
         .transmit(binding.scratch.scratch_exact_prepared_tx.len() as u32);
     let inserted = writer.insert(binding.scratch.scratch_exact_prepared_tx.iter().map(|req| XdpDesc {
@@ -559,6 +561,7 @@ fn service_exact_prepared_queue_direct_flow_fair(
     }
 
     let mut writer = binding
+        .xsk
         .tx
         .transmit(binding.scratch.scratch_prepared_tx.len() as u32);
     let inserted = writer.insert(binding.scratch.scratch_prepared_tx.iter().map(|req| XdpDesc {

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -10,7 +10,7 @@ use super::*;
 
 // Per-batch packet processing lifted from `poll_binding` (#678).
 //
-// Runs `binding.rx.receive(available)` + the descriptor while-let +
+// Runs `binding.xsk.rx.receive(available)` + the descriptor while-let +
 // `received.release(); drop(received);` as its own compilation unit so
 // it surfaces under its own symbol in `perf top`. Body is byte-for-byte
 // identical to the previous inner-loop content; only the enclosing
@@ -33,7 +33,7 @@ pub(super) fn poll_binding_process_descriptor(
     worker_ctx: &WorkerContext,
     telemetry: &mut TelemetryContext,
 ) {
-        let mut received = binding.rx.receive(available);
+        let mut received = binding.xsk.rx.receive(available);
         binding.scratch.scratch_recycle.clear();
         binding.scratch.scratch_forwards.clear();
         binding.scratch.scratch_rst_teardowns.clear();

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -215,7 +215,8 @@ pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, 
         || force
         || now_ns.saturating_sub(binding.timers.last_tx_wake_ns) >= TX_WAKE_MIN_INTERVAL_NS
     {
-        // Use direct sendto() instead of binding.xsk.tx.wake() so we can capture errors.
+        // Use a direct sendto() syscall (not any wrapper) so we can
+        // observe errno and feed the #825 kick-latency telemetry.
         let fd = binding.xsk.tx.as_raw_fd();
         // #825 plan §3.3 site 1: two fresh `monotonic_nanos()` calls
         // bracket the `sendto` syscall. `now_ns` is caller-cached —

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -24,13 +24,13 @@ pub(in crate::afxdp) fn reap_tx_completions(
     if binding.tx_pipeline.outstanding_tx == 0 {
         return 0;
     }
-    let available = binding.device.available();
+    let available = binding.xsk.device.available();
     if available == 0 {
         return 0;
     }
     let mut reaped = 0u32;
     binding.scratch.scratch_completed_offsets.clear();
-    let mut completed = binding.device.complete(available);
+    let mut completed = binding.xsk.device.complete(available);
     while let Some(offset) = completed.read() {
         binding.scratch.scratch_completed_offsets.push(offset);
         reaped += 1;
@@ -95,7 +95,7 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
         return false;
     }
     let inserted = {
-        let mut fill = binding.device.fill(binding.scratch.scratch_fill.len() as u32);
+        let mut fill = binding.xsk.device.fill(binding.scratch.scratch_fill.len() as u32);
         let inserted = fill.insert(binding.scratch.scratch_fill.iter().copied());
         fill.commit();
         inserted
@@ -120,7 +120,7 @@ pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: 
     // lost-wakeup stalls from the race between commit() and needs_wakeup.
     // Without the needs_wakeup gate, every drain triggers a sendto() syscall
     // (142K/sec at line rate), spending ~20% CPU in syscall entry/exit.
-    if binding.device.needs_wakeup()
+    if binding.xsk.device.needs_wakeup()
         || now_ns.saturating_sub(binding.timers.last_rx_wake_ns) >= FILL_WAKE_SAFETY_INTERVAL_NS
     {
         maybe_wake_rx(binding, true, now_ns);
@@ -148,7 +148,7 @@ pub(in crate::afxdp) fn maybe_wake_rx(binding: &mut BindingWorker, force: bool, 
             return;
         }
     }
-    let fd = binding.device.as_raw_fd();
+    let fd = binding.xsk.device.as_raw_fd();
     // Use poll(POLLIN) for RX wakeup — triggers XDP_WAKEUP_RX.
     let mut pfd = libc::pollfd {
         fd,
@@ -211,12 +211,12 @@ fn recycle_completed_tx_offset(
 pub(in crate::afxdp) fn maybe_wake_tx(binding: &mut BindingWorker, force: bool, now_ns: u64) {
     let bind_mode = XskBindMode::from_u8(binding.live.bind_mode.load(Ordering::Relaxed));
     if !bind_mode.is_zerocopy()
-        || binding.tx.needs_wakeup()
+        || binding.xsk.tx.needs_wakeup()
         || force
         || now_ns.saturating_sub(binding.timers.last_tx_wake_ns) >= TX_WAKE_MIN_INTERVAL_NS
     {
-        // Use direct sendto() instead of binding.tx.wake() so we can capture errors.
-        let fd = binding.tx.as_raw_fd();
+        // Use direct sendto() instead of binding.xsk.tx.wake() so we can capture errors.
+        let fd = binding.xsk.tx.as_raw_fd();
         // #825 plan §3.3 site 1: two fresh `monotonic_nanos()` calls
         // bracket the `sendto` syscall. `now_ns` is caller-cached —
         // stale up to `IDLE_SPIN_ITERS * spin_cost` per #812 §3.1 R1

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -173,7 +173,7 @@ pub(in crate::afxdp) fn transmit_batch(
         return Err(TxError::Retry("no prepared TX frame available".to_string()));
     }
 
-    let mut writer = binding.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
+    let mut writer = binding.xsk.tx.transmit(binding.scratch.scratch_local_tx.len() as u32);
     let inserted = writer.insert(
         binding
             .scratch.scratch_local_tx
@@ -411,6 +411,7 @@ pub(in crate::afxdp) fn transmit_prepared_queue(
     }
 
     let mut writer = binding
+        .xsk
         .tx
         .transmit(binding.scratch.scratch_prepared_tx.len() as u32);
     let inserted = writer.insert(binding.scratch.scratch_prepared_tx.iter().map(|req| XdpDesc {

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -113,7 +113,7 @@ pub(super) fn poll_binding(
             return did_work;
         }
 
-        let raw_avail = binding.rx.available();
+        let raw_avail = binding.xsk.rx.available();
         let available = raw_avail.min(RX_BATCH_SIZE);
         if raw_avail > 0 && !binding.bind_meta.xsk_rx_confirmed {
             binding.bind_meta.xsk_rx_confirmed = true;
@@ -126,8 +126,8 @@ pub(super) fn poll_binding(
                 }
             }
             // Ring diagnostics are only consumed by debug-log summaries.
-            binding.telemetry.dbg_fill_pending = binding.device.pending();
-            binding.telemetry.dbg_device_avail = binding.device.available();
+            binding.telemetry.dbg_fill_pending = binding.xsk.device.pending();
+            binding.telemetry.dbg_device_avail = binding.xsk.device.available();
         }
         if available == 0 {
             binding.telemetry.dbg_rx_empty += 1;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -50,6 +50,14 @@ pub(crate) use bind_meta::WorkerBindMeta;
 mod flow_cache_state;
 pub(crate) use flow_cache_state::WorkerFlowCacheState;
 
+// #959 Phase 11 — XSK kernel-ring handles in
+// worker/xsk_rings.rs. Holds the three socket-ring objects
+// `device`, `rx`, `tx` (was held back as highest-risk because
+// of the `off.rx`/`off.tx` and `telemetry.dbg.rx`/`.tx`
+// snapshot/diagnostic name collisions).
+mod xsk_rings;
+pub(crate) use xsk_rings::WorkerXskRings;
+
 // #957 P1: worker-side CoS runtime helpers split out into a sibling
 // submodule. Note this module is `worker::cos`, separate from the
 // `afxdp::cos` directory module imported below as `super::cos`.
@@ -86,9 +94,10 @@ pub(crate) struct BindingWorker {
     pub(crate) live: Arc<BindingLiveState>,
     #[allow(dead_code)]
     pub(crate) user: User,
-    pub(crate) device: crate::xsk_ffi::DeviceQueue,
-    pub(crate) rx: crate::xsk_ffi::RingRx,
-    pub(crate) tx: crate::xsk_ffi::RingTx,
+    /// #959 Phase 11: 3 XSK kernel-ring handles extracted into
+    /// `WorkerXskRings`. Field semantics unchanged; access via
+    /// `binding.xsk.device`, `binding.xsk.rx`, `binding.xsk.tx`.
+    pub(crate) xsk: WorkerXskRings,
     /// #959 Phase 7 + Phase 10: 8 TX pipeline fields extracted into
     /// `WorkerTxPipeline` (Phase 7 brought 7; Phase 10 added
     /// `outstanding_tx` once the BindingStatus mirror collision was
@@ -331,9 +340,7 @@ impl BindingWorker {
             umem: worker_umem,
             live,
             user,
-            device,
-            rx,
-            tx,
+            xsk: WorkerXskRings { device, rx, tx },
             tx_pipeline: WorkerTxPipeline {
                 free_tx_frames: reserved_tx_frames,
                 pending_tx_prepared: VecDeque::new(),
@@ -545,7 +552,7 @@ pub(crate) fn worker_loop(
         bindings
             .iter()
             .map(|binding| libc::pollfd {
-                fd: binding.device.as_raw_fd(),
+                fd: binding.xsk.device.as_raw_fd(),
                 events: libc::POLLIN,
                 revents: 0,
             })
@@ -1081,9 +1088,9 @@ pub(crate) fn worker_loop(
                 let mut binding_summary = String::new();
                 for (i, b) in bindings.iter().enumerate() {
                     use std::fmt::Write;
-                    let fill_pending = b.device.pending();
-                    let rx_avail = b.rx.available_relaxed();
-                    let xsk_stats = b.device.statistics_v2().ok();
+                    let fill_pending = b.xsk.device.pending();
+                    let rx_avail = b.xsk.rx.available_relaxed();
+                    let xsk_stats = b.xsk.device.statistics_v2().ok();
                     let inflight_recycles = b.tx_pipeline.in_flight_prepared_recycles.len() as u32;
                     let scratch_recycle_len = b.scratch.scratch_recycle.len() as u32;
                     let ptx_prepared = b.tx_pipeline.pending_tx_prepared.len() as u32;
@@ -1154,7 +1161,7 @@ pub(crate) fn worker_loop(
                     }
                     // Socket error check (SO_ERROR) — detect kernel-side errors
                     {
-                        let fd = b.rx.as_raw_fd();
+                        let fd = b.xsk.rx.as_raw_fd();
                         let mut so_err: c_int = 0;
                         let mut so_err_len: libc::socklen_t = core::mem::size_of::<c_int>() as _;
                         let rc = unsafe {
@@ -1185,7 +1192,7 @@ pub(crate) fn worker_loop(
                         );
                         // Direct mmap diagnosis: read raw ring producer/consumer
                         if let Some((rxp, rxc, frp, frc, txp, txc, crp, crc)) =
-                            diagnose_raw_ring_state(b.rx.as_raw_fd())
+                            diagnose_raw_ring_state(b.xsk.rx.as_raw_fd())
                         {
                             let _ = write!(
                                 binding_summary,
@@ -1350,8 +1357,8 @@ pub(crate) fn worker_loop(
                         // Dump comprehensive per-binding state at stall moment
                         for (si, sb) in bindings.iter().enumerate() {
                             use std::fmt::Write;
-                            let fill_p = sb.device.pending();
-                            let rx_a = sb.rx.available_relaxed();
+                            let fill_p = sb.xsk.device.pending();
+                            let rx_a = sb.xsk.rx.available_relaxed();
                             let ifl = sb.tx_pipeline.in_flight_prepared_recycles.len() as u32;
                             let ptxp = sb.tx_pipeline.pending_tx_prepared.len() as u32;
                             let ptxl = sb.tx_pipeline.pending_tx_local.len() as u32;
@@ -1363,7 +1370,7 @@ pub(crate) fn worker_loop(
                                 + ifl
                                 + sb.scratch.scratch_recycle.len() as u32
                                 + ptxp;
-                            let raw = diagnose_raw_ring_state(sb.rx.as_raw_fd());
+                            let raw = diagnose_raw_ring_state(sb.xsk.rx.as_raw_fd());
                             let mut stall_line = format!(
                                 "DBG STALL_BINDING[{}]: if={} q={} pfill={} fring={} rxring={} free_tx={} otx={} ifl={} ptxp={} ptxl={} total={}/{}",
                                 si,
@@ -1386,7 +1393,7 @@ pub(crate) fn worker_loop(
                                     " RAW:rxP={rxp}/rxC={rxc}/frP={frp}/frC={frc}/txP={txp}/txC={txc}/crP={crp}/crC={crc}"
                                 );
                             }
-                            if let Ok(Some(stats)) = sb.device.statistics_v2().map(Some) {
+                            if let Ok(Some(stats)) = sb.xsk.device.statistics_v2().map(Some) {
                                 let _ = write!(
                                     stall_line,
                                     " xsk:drop={}/rfull={}/fempty={}/tempty={}",
@@ -1495,7 +1502,7 @@ pub(crate) fn worker_loop(
                     // already absolute (kernel-cumulative), so publish with
                     // store() not fetch_add. Sampling failures are silently
                     // ignored — the atomic simply retains its last good value.
-                    if let Ok(stats) = b.device.statistics_v2() {
+                    if let Ok(stats) = b.xsk.device.statistics_v2() {
                         b.live
                             .rx_fill_ring_empty_descs
                             .store(stats.rx_fill_ring_empty_descs, Ordering::Relaxed);
@@ -1527,7 +1534,7 @@ pub(crate) fn worker_loop(
                     let total = b.umem.total_frames();
                     let free_tx = b.tx_pipeline.free_tx_frames.len() as u32;
                     let pending_fill = b.tx_pipeline.pending_fill_frames.len() as u32;
-                    let kernel_fill = b.device.pending();
+                    let kernel_fill = b.xsk.device.pending();
                     let inflight = total
                         .saturating_sub(free_tx)
                         .saturating_sub(pending_fill)

--- a/userspace-dp/src/afxdp/worker/xsk_rings.rs
+++ b/userspace-dp/src/afxdp/worker/xsk_rings.rs
@@ -27,8 +27,6 @@
 //! `binding`/`b`/`sb`/`target_binding` aliases used for the
 //! BindingWorker rings) so the rewrite is purely mechanical.
 
-use super::*;
-
 /// Per-binding XSK ring handles. See module-level docs.
 ///
 /// **Intentionally NOT `Default`** — the rings are constructed

--- a/userspace-dp/src/afxdp/worker/xsk_rings.rs
+++ b/userspace-dp/src/afxdp/worker/xsk_rings.rs
@@ -1,0 +1,42 @@
+//! #959 Phase 11 — extracts the three XSK kernel-ring handles
+//! (`device`, `rx`, `tx`) out of `BindingWorker` into a dedicated
+//! `WorkerXskRings` sub-struct.
+//!
+//! These are the per-binding handles to the kernel AF_XDP socket
+//! rings:
+//!
+//! - `device` — the `DeviceQueue` that owns the underlying XSK file
+//!   descriptor and the fill / completion ring pair (kernel-side
+//!   pacing).
+//! - `rx` — the RX ring (`RingRx`); `available()` / `receive()` /
+//!   `as_raw_fd()` are the hot-path entry points.
+//! - `tx` — the TX ring (`RingTx`); `transmit()` writes descriptors,
+//!   `needs_wakeup()` + `as_raw_fd()` drive the sendto kick.
+//!
+//! Pure structural extraction: ring objects, bind ordering, FD
+//! lifetimes, and access semantics are all unchanged from master
+//! pre-Phase-11. Field names preserved so `binding.xsk.rx` keeps
+//! the same grep-friendly suffix as the original `binding.rx`.
+//!
+//! Phase 11 is the last #959 BindingWorker decomposition phase —
+//! it was held back as the highest-risk because of the snapshot-
+//! mirror name collisions on `off.rx` / `off.tx` (XDP socket ring
+//! offsets in `bpf_map.rs`) and `telemetry.dbg.rx` / `.tx`
+//! (in-loop diagnostic counters in `poll_descriptor.rs`). Both
+//! disambiguate by alias prefix (`off.` and `dbg.` vs the
+//! `binding`/`b`/`sb`/`target_binding` aliases used for the
+//! BindingWorker rings) so the rewrite is purely mechanical.
+
+use super::*;
+
+/// Per-binding XSK ring handles. See module-level docs.
+///
+/// **Intentionally NOT `Default`** — the rings are constructed
+/// from `open_binding_worker_rings()` which performs the kernel
+/// `bpf()`/`mmap()` system calls; a default-derived value would
+/// hold dangling FDs.
+pub(crate) struct WorkerXskRings {
+    pub(crate) device: crate::xsk_ffi::DeviceQueue,
+    pub(crate) rx: crate::xsk_ffi::RingRx,
+    pub(crate) tx: crate::xsk_ffi::RingTx,
+}


### PR DESCRIPTION
## Summary

- Final phase of the #959 BindingWorker decomposition. Three flat XSK kernel-ring fields (`device: DeviceQueue`, `rx: RingRx`, `tx: RingTx`) move into a dedicated `WorkerXskRings` sub-struct in `worker/xsk_rings.rs`. Access pattern: `binding.xsk.{device,rx,tx}`.
- Held back as highest-risk because of name collisions with `off.rx`/`off.tx` (XDP ring offsets in `bpf_map.rs`) and `telemetry.dbg.rx`/`.tx` (in-loop diagnostic counters in `poll_descriptor.rs`). Both disambiguate by alias prefix — the perl rewrite is whitelist-scoped to BindingWorker aliases (`binding`, `b`, `sb`, `target_binding`, `other_binding`) so neither is touched.
- 29 BindingWorker accesses rewritten across 6 files. Constructor inlines a `WorkerXskRings { device, rx, tx }` literal at the same spot the flat fields used to live.
- **#959 is now complete** — Phases 1-11 cover telemetry, scratch, cos, tx_counters, bpf_maps, timers, tx_pipeline, bind_meta, flow, and xsk.

## Test plan

- [x] `cargo build` clean (94 pre-existing warnings, 0 new)
- [x] 952/952 cargo tests pass (`cargo test --release`)
- [x] `tx_completion` named tests 5/5 clean (flake check)
- [x] 30 Go packages pass (`go test ./...`)
- [x] Deploy clean on loss userspace cluster (rolling secondary then primary)
- [x] v4 smoke: 955 Mbps, 0 retrans against 172.16.80.200 (best-effort 5201)
- [x] v6 smoke: 942 Mbps, 0 retrans against 2001:559:8585:80::200 (best-effort 5201)
- [x] grep confirms no `off.xsk.` or `dbg.xsk.` over-replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)