### PR TITLE
#946 Phase 1: extract per-packet pipeline stages 5-11 into named helpers

### DIFF
--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -1,6 +1,31 @@
 # #946 Phase 1 — Extract Per-Packet Sub-Stages from `poll_binding_process_descriptor`
 
-Status: **DRAFT v3 — addressing Codex round-2 PLAN-NEEDS-MAJOR**
+Status: **FINAL v3.2 — shipped as PR #1179, commit ea8fa4e6**
+
+## v3.2 changes vs v3.1 (post-implementation reconciliation)
+
+During implementation we narrowed the scope by one notch from
+what v3.1 specified. The original v3.1 plan listed eight
+extracted stages (1, 2-4, 5, 6, 7+8, 9, 10, 11). The shipped
+PR extracts SEVEN stages: stages 5, 6, 7+8, 9, 10, 11.
+Stages 1 (`stage_record_rx_telemetry`) and 2-4
+(`stage_parse_and_classify`) are kept inline because:
+
+- Stage 1 was already named (`record_rx_descriptor_telemetry` is
+  pre-existing in `poll_descriptor.rs:2258`). Re-extracting it
+  into the new `poll_stages` module would just be relocation.
+- Stage 2-4 (`stage_parse_and_classify`) would have to fire the
+  metadata-error and non-Valid-disposition side effects internally
+  to preserve behavior (a 7-arg signature: `binding_live`, `ident`,
+  `forwarding`, `recent_exceptions` plus the inputs). The original
+  if-let-else structure colocates those side effects at the bottom
+  of the loop body (poll_descriptor.rs:2181–2204). Extracting it
+  would have widened the helper's responsibility for marginal
+  seam value (stages 2-4 are ~15 LOC).
+
+Code-motion delta: 7 stages = ~150 LOC moved, vs the original
+v3.1 estimate of 8 stages = ~200 LOC. Same architectural seams;
+slightly tighter scope.
 
 ## v3 changes (Codex round-2 findings)
 
@@ -172,11 +197,13 @@ That's ~2,400 LOC of branchy per-packet code in one function.
 
 ## Phase 1 scope (explicit)
 
-**In scope** — extract these as named functions:
+**In scope (as shipped in v3.2)** — extract these as named functions:
 
-- (1) `stage_record_rx_telemetry`
-- (2)+(3)+(4) `stage_parse_and_classify` → `StageOutcome<ParsedFrame>`
-   where `ParsedFrame` carries `meta` + `raw_frame: &'a [u8]`.
+- Stage 1 (`record_rx_descriptor_telemetry`) was already extracted
+  pre-#946 (`poll_descriptor.rs:2258`); keeping that name.
+- Stages 2-4 (parse meta, classify, slice raw_frame) **stay inline**
+  in `poll_descriptor.rs` — see v3.2 reconciliation note at the top
+  of this doc.
 - (5) `stage_link_layer_classify` → `StageOutcome<()>` (per Codex
   round-2 answer to Q2: collapse the four ARP/NDP arms; side
   effects on `dynamic_neighbors` stay inside the helper).
@@ -228,26 +255,17 @@ struct FabricIngressOutcome {
     packet_fabric_ingress: bool,
 }
 
-// ── Stage 2-4: parse metadata, classify, slice UMEM ──────────────
+// ── Stages 2-4 NOT EXTRACTED in v3.2 ─────────────────────────────
 //
-// Side effects handled INSIDE the helper to preserve current
-// behavior:
-//   - Parse failure: telemetry.dbg.metadata_err += 1,
-//     binding.live.metadata_errors.fetch_add, record_exception.
-//   - Non-Valid disposition: record_disposition (live counters +
-//     recent_exceptions).
-// Returns RecycleAndContinue on either failure path; Continue on
-// successful parse + classify + slice.
-fn stage_parse_and_classify<'a>(
-    desc: &XdpDesc,
-    area: &'a MmapArea,
-    validation: ValidationState,
-    binding_live: &BindingLiveState,
-    ident: &BindingIdentity,
-    forwarding: &ForwardingState,
-    recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
-    telemetry: &mut TelemetryContext,
-) -> StageOutcome<(UserspaceDpMeta, &'a [u8])>;
+// Original v3.1 plan included a `stage_parse_and_classify` helper
+// here. Implementation revealed that preserving the
+// metadata-error and non-Valid-disposition side effects
+// (record_exception, record_disposition, live.metadata_errors)
+// requires a 7-arg signature with helper-internal side effects,
+// while the current if-let-else structure colocates those side
+// effects at the bottom of the loop body
+// (poll_descriptor.rs:2181-2204). Marginal seam value vs widened
+// helper responsibility — left inline. Phase 1.5 / 2 can revisit.
 
 // ── Stage 5: ARP / NDP classification ─────────────────────────────
 //
@@ -333,32 +351,31 @@ fn stage_ipsec_passthrough_check(
 ) -> StageOutcome<()>;
 ```
 
-The main loop body becomes (compile-realistic v3):
+The main loop body becomes (as shipped in v3.2 — stages 1-4 stay
+inline; stages 5-11 dispatch into `poll_stages.rs`):
 
 ```rust
 while let Some(desc) = received.read() {
-    stage_record_rx_telemetry(desc, area, telemetry, worker_ctx);
-    let mut recycle_now = true;  // restored — deferred stages 12+
-                                 // toggle this when packet leaves
-                                 // via TX (flow-cache, session-hit
-                                 // TTL, cluster-peer-return).
-    let StageOutcome::Continue((mut meta, raw_frame)) = stage_parse_and_classify(
-        desc,
-        unsafe { &*area },
-        validation,
-        &binding.live,
-        &worker_ctx.ident,
-        worker_ctx.forwarding,
-        worker_ctx.recent_exceptions,
-        telemetry,
-    ) else {
-        binding.scratch.scratch_recycle.push(desc.addr);
-        continue;
-    };
+    record_rx_descriptor_telemetry(desc, area, telemetry, worker_ctx);
+    let mut recycle_now = true;  // deferred stages 12+ toggle this
+                                 // when packet leaves via TX
+                                 // (flow-cache, session-hit TTL,
+                                 // cluster-peer-return).
+    if let Some(meta) = try_parse_metadata(unsafe { &*area }, desc) {
+        telemetry.counters.metadata_packets += 1;
+        let disposition = classify_metadata(meta, validation);
+        if disposition == PacketDisposition::Valid {
+            telemetry.counters.validated_packets += 1;
+            telemetry.counters.validated_bytes += desc.len as u64;
+            let Some(raw_frame) = unsafe { &*area }.slice(...) else {
+                binding.scratch.scratch_recycle.push(desc.addr);
+                continue;
+            };
 
-    if let StageOutcome::RecycleAndContinue =
-        stage_link_layer_classify(raw_frame, meta, worker_ctx)
-    {
+            // ── Phase 1 stages 5-11 dispatch here ─────────────────
+            if let StageOutcome::RecycleAndContinue =
+                stage_link_layer_classify(raw_frame, meta, worker_ctx)
+            {
         binding.scratch.scratch_recycle.push(desc.addr);
         continue;
     }
@@ -413,6 +430,13 @@ while let Some(desc) = received.read() {
     // recycle_now = false when the packet leaves via TX.
     ...
 
+        } else {
+            record_disposition(...);  // non-Valid disposition
+        }
+    } else {
+        // metadata parse failure — fires record_exception, etc.
+        ...
+    }
     if recycle_now {
         binding.scratch.scratch_recycle.push(desc.addr);
     }

--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -1,6 +1,31 @@
 # #946 Phase 1 — Extract Per-Packet Sub-Stages from `poll_binding_process_descriptor`
 
-Status: **DRAFT — pending adversarial plan review**
+Status: **DRAFT v2 — addressing Codex round-1 PLAN-NEEDS-MAJOR**
+
+## v2 changes (Codex round-1 findings)
+
+1. Stage inventory was incomplete. v1 missed two real stages:
+   **IPsec passthrough** ([poll_descriptor.rs:188–222](../../../userspace-dp/src/afxdp/poll_descriptor.rs)) and the
+   **flow-cache fast path** (line 224 onward, ~600 LOC). v2 lists
+   them.
+2. The "scratch_forwards is a full batch boundary" claim was
+   overbroad. v2 corrects this: scratch_forwards covers only the
+   pending-forward (slow-path) path; the flow-cache fast path
+   bypasses it and pushes directly to `pending_tx_prepared` in the
+   per-packet body.
+3. v1's `stage_native_gre_decap` signature was self-referential.
+   v2 returns `(updated_meta, Option<Vec<u8>>)` and the caller binds
+   the active slice locally.
+4. v1's two-arm `StageOutcome` was underdesigned. v2 uses
+   `StageOutcome<T>` (generic) for stages where one shape fits, and
+   stage-specific output types where the outcomes diverge (ARP/NDP,
+   the flow-cache fast path).
+5. v1 dropped the false claim that #1127 (PacketBatch SoA) is
+   *required* for Phase 2 — Phase 2 can ship batched iteration via
+   per-stage `Vec<StageOutput>` accumulation without a new SoA struct.
+6. v1 punted on stages 10+ as "complex control flow." v2 is explicit
+   that step 10 (Screen) **is** extractable and is in scope; steps
+   11–15 are deferred as a **scope choice** (not a seam limitation).
 
 ## Issue framing
 
@@ -10,159 +35,307 @@ worker loop iterates over *batches per stage*, not stages per packet.
 This Phase 1 plan does **not** ship that final architecture. Phase 1
 extracts the existing per-packet body of
 `poll_binding_process_descriptor` (currently 2,436 LOC, one giant
-`while let Some(desc) = received.read()` loop) into a small set of
-named per-packet helper functions. No batch reordering, no
-stage-per-batch iteration. This is pure code-motion that establishes
-the seams a future Phase 2/3 will exploit to swap to batched stages.
-
-The final pipeline architecture (true VPP-style) requires a
-`PacketBatch<N>` SoA buffer (#1127) and the `PacketEditor` builder
-(#963) — those are independent issues with their own plans. Phase 1
-is a precondition: without seams, the future batched extraction would
-have to do all of code-motion + batching at once, which is the
-"all-or-nothing risky refactor" pattern that previous attempts
-(#961 PacketContext rounds 1–2) failed at.
+`while let Some(desc) = received.read()` loop) into named per-packet
+helper functions. No batch reordering, no stage-per-batch iteration.
+This is pure code-motion that establishes the seams a future
+Phase 2/3 will exploit to swap to batched stages.
 
 ## What's already batched
 
-The codebase **already** has a coarse per-RX-burst batch boundary:
+The codebase has a **partial** per-RX-burst batch boundary, NOT a
+full one:
 
-- `binding.scratch.scratch_forwards: Vec<PendingForwardRequest>` accumulates forwarding decisions during the RX while-let.
-- After the loop drains, `enqueue_pending_forwards` (in `tx/dispatch.rs`) iterates the batch and dispatches to local TX or cross-worker MPSC.
-- `binding.scratch.scratch_recycle: Vec<u64>` collects UMEM frame addresses to recycle, drained after the batch.
-- `binding.scratch.scratch_rst_teardowns: Vec<...>` collects RST-driven session teardowns, drained after the batch.
+- **Slow-path**: `binding.scratch.scratch_forwards: Vec<PendingForwardRequest>`
+  accumulates forwarding decisions during the RX while-let. After the
+  loop drains, `enqueue_pending_forwards` (in `tx/dispatch.rs`)
+  iterates the batch and dispatches to local TX or cross-worker MPSC.
+- **Per-burst housekeeping**: `binding.scratch.scratch_recycle: Vec<u64>`
+  collects UMEM frame addresses to recycle, drained after the batch.
+  `binding.scratch.scratch_rst_teardowns` collects RST-driven session
+  teardowns, drained after the batch.
+- **Flow-cache fast path** ([poll_descriptor.rs:306,369](../../../userspace-dp/src/afxdp/poll_descriptor.rs)):
+  bypasses `scratch_forwards` entirely. On a flow-cache hit, the
+  packet's `PreparedTxRequest` is pushed directly to
+  `binding.tx_pipeline.pending_tx_prepared` from inside the per-packet
+  loop. This is intentional — it skips the
+  `PendingForwardRequest → enqueue_pending_forwards → PreparedTxRequest`
+  conversion entirely for the hot per-flow path.
 
-This means Phase 1 is **adding seams to the per-packet path inside
-the while-let** — the batch boundary itself is unchanged.
+So scratch_forwards is the slow-path batch boundary; the fast path
+bypasses it. Phase 1 doesn't touch either of these — it adds named
+seams to the per-packet code that runs before both paths.
 
-## What's NOT batched (the Phase 1 target)
+## Stage inventory (corrected v2)
 
-Inside the while-let body, every packet goes through this sequence:
+The while-let body executes this sequence per descriptor:
 
-1. `record_rx_descriptor_telemetry(desc, area, telemetry, worker_ctx)`
-2. `try_parse_metadata` → `Option<UserspaceDpMeta>` (early return on None)
-3. `classify_metadata` → `PacketDisposition` (early return on Invalid)
-4. UMEM area slice for raw frame bytes (early return on None)
-5. **ARP / NDP classification** — early-return paths that recycle the
-   frame and continue without flowing through the rest of the pipeline
-   (ARP) or fall through (NDP NA).
-6. **Native GRE decap** — replaces meta and frame-slice, may own a
-   decapped frame.
-7. `parse_session_flow_from_bytes` → `Option<SessionFlow>`
+1. `record_rx_descriptor_telemetry` — TX-side telemetry sample.
+2. `try_parse_metadata` → `Option<UserspaceDpMeta>` (early return on None).
+3. `classify_metadata` → `PacketDisposition` (early return on Invalid).
+4. UMEM area slice for `raw_frame: &[u8]` (early return on None).
+5. **ARP / NDP classification** — early-return paths (ARP recycles
+   without flowing through; NDP NA learns and falls through).
+6. **Native GRE decap** — replaces meta and frame slice; may produce
+   an owned `Vec<u8>` for the decapped frame.
+7. `parse_session_flow_from_bytes` → `Option<SessionFlow>`.
 8. Dynamic-neighbor learning from the source IP (host-only).
-9. Fabric-ingress detection + `meta.meta_flags |= FABRIC_INGRESS_FLAG`.
-10. Screen/IDS check (slow path, only runs when profiles configured).
-11. Session lookup → fast-path / slow-path branch.
-12. Slow path: policy eval → NAT slot → forwarding lookup → push to
-    `scratch_forwards`.
-13. Fast path: hit existing session → push to `scratch_forwards`.
-14. Reverse-NAT and ICMP slow-path arms.
-15. MissingNeighbor side-queue: build session metadata, install,
+9. **Fabric-ingress detection** — sets `meta.meta_flags |= FABRIC_INGRESS_FLAG`
+   if the ingress is a fabric overlay.
+10. **Screen/IDS check** (slow path, only runs when profiles
+    configured).
+11. **IPsec passthrough check** ([poll_descriptor.rs:188](../../../userspace-dp/src/afxdp/poll_descriptor.rs))
+    — for ESP/IKE, slow-path-reinject and recycle.
+12. **Flow-cache fast path** ([poll_descriptor.rs:224](../../../userspace-dp/src/afxdp/poll_descriptor.rs))
+    — packet-eligible + flow lookup, validate cached decision, ICMP-TE
+    on TTL=1, in-place rewrite + `pending_tx_prepared.push_back`, fall
+    through on miss/invalid.
+13. **Session lookup → fast-path / slow-path branch.**
+14. **Slow path**: policy eval → NAT slot → forwarding lookup →
+    `scratch_forwards.push`.
+15. **Reverse-NAT / ICMP slow-path arms.**
+16. **MissingNeighbor side queue** — build session metadata, install,
     publish, push to `pending_neigh`.
 
 That's ~2,400 LOC of branchy per-packet code in one function.
 
-## Phase 1 scope: extract by-stage, no behavioral change
+## Phase 1 scope (explicit)
 
-Extract into named functions, file-internal in
-`afxdp/poll_descriptor.rs` or sibling files under `afxdp/poll/`:
+**In scope** — extract these as named functions:
 
-1. **`stage_record_rx_telemetry`** — wraps step (1).  Takes a `&XdpDesc`,
-   the `*const MmapArea`, telemetry, worker_ctx. Returns nothing.
+- (1) `stage_record_rx_telemetry`
+- (2)+(3)+(4) `stage_parse_and_classify` → `StageOutcome<ParsedFrame>`
+   where `ParsedFrame` carries `meta` + `raw_frame: &'a [u8]`.
+- (5) `stage_link_layer_classify` → `LinkLayerOutcome` (5 distinct
+  arms, NOT a generic StageOutcome — see "Open questions" #2).
+- (6) `stage_native_gre_decap` → `(UserspaceDpMeta, Option<Vec<u8>>)`
+  *plus* the caller binds the active slice locally (the helper does
+  NOT return the slice — that would be self-referential).
+- (7)+(8) `stage_parse_flow_and_learn` → `Option<SessionFlow>`,
+  side-effect on `worker_ctx.dynamic_neighbors` and
+  `binding.last_learned_neighbor`. The combined name makes the side
+  effect explicit.
+- (9) `stage_classify_fabric_ingress` — mutates `meta` in place,
+  returns `bool` for `packet_fabric_ingress` (used downstream).
+- (10) `stage_screen_check` → `StageOutcome<()>` (RecycleAndContinue
+  on screen drop; Continue otherwise). This is the screen/IDS slow
+  path that currently runs at [poll_descriptor.rs:144](../../../userspace-dp/src/afxdp/poll_descriptor.rs).
+- (11) `stage_ipsec_passthrough_check` → `StageOutcome<()>` (the
+  ESP/IKE branch at line 188; on hit, slow-path-reinject + recycle +
+  return RecycleAndContinue; otherwise Continue).
 
-2. **`stage_parse_and_classify`** — wraps steps (2)–(4). Takes the raw
-   inputs, returns either `StageOutcome::RecycleAndContinue` or
-   `StageOutcome::Continue { meta, raw_frame: &[u8] }`.
+**Explicitly deferred to a Phase 1.5 / Phase 2** — these stay inline
+in the main function for now:
 
-3. **`stage_link_layer_classify`** — wraps step (5) ARP / NDP. Returns
-   `StageOutcome::RecycleAndContinue` (ARP request/reply/other) or
-   `StageOutcome::Continue { learn_neighbor: Option<NeighborLearnHint> }`
-   for NDP NA + IP fall-through.
+- (12) Flow-cache fast path — ~600 LOC with multiple early returns,
+  a TTL ICMP-TE side path, and an in-place rewrite that pushes
+  directly to `pending_tx_prepared`. Extracting this is genuinely
+  hard because the helper would need to express six distinct
+  outcomes, and the TTL/ICMP-TE arm shares state with the cached
+  decision. **Scope choice**: defer to a follow-up phase that can
+  focus on this single transformation.
+- (13)–(16) Session lookup, slow-path policy/NAT/forwarding, fast
+  path, reverse-NAT/ICMP, MissingNeighbor side queue. These are
+  ~1,000+ LOC with deeply intertwined state and no obvious seams.
+  **Scope choice**: each gets its own phase.
 
-4. **`stage_native_gre_decap`** — wraps step (6). Returns updated
-   `meta`, optional owned decap frame, and the active frame slice
-   (borrowing one of the two).
+## Phase 1 stage signatures (concrete)
 
-5. **`stage_parse_flow_and_learn`** — wraps steps (7)–(8). Returns
-   `Option<SessionFlow>` and updates dynamic_neighbors as a side effect.
+```rust
+// Generic outcome for stages with a single non-recycle output.
+enum StageOutcome<T> {
+    RecycleAndContinue,
+    Continue(T),
+}
 
-6. **`stage_classify_fabric_ingress`** — wraps step (9). Mutates `meta`
-   in place.
+// Stage 2-4 combined: parse metadata, classify, slice the UMEM frame.
+fn stage_parse_and_classify<'a>(
+    desc: &XdpDesc,
+    area: &'a MmapArea,
+    validation: ValidationState,
+    telemetry: &mut TelemetryContext,
+) -> StageOutcome<(UserspaceDpMeta, &'a [u8])>;
 
-7. Steps (10)–(15) stay in the main function for Phase 1. They have
-   complex control flow (early-return arms for fast/slow path, NAT,
-   ICMP, missing-neighbor side queue) that doesn't have clean seams
-   yet. Phase 2 will tackle these once Phase 1 lands.
+// Stage 5: ARP/NDP. 5 distinct arms, side effects internal.
+enum LinkLayerOutcome {
+    /// ARP reply: dynamic neighbor was learned, recycle the frame.
+    ArpLearnAndRecycle,
+    /// ARP request/other: recycle without learning.
+    ArpRecycle,
+    /// NDP NA: dynamic neighbor was learned, fall through.
+    NdpLearnAndContinue,
+    /// Plain non-link-layer packet: fall through.
+    Continue,
+}
 
-## What stays per-packet
+fn stage_link_layer_classify(
+    raw_frame: &[u8],
+    meta: UserspaceDpMeta,
+    worker_ctx: &WorkerContext,
+) -> LinkLayerOutcome;
 
-All of (1)–(15) stay per-packet within the while-let. The only
-change is that (1)–(9) become named function calls instead of inline
-code. The semantic order and branching of the loop body is byte-for-byte
-unchanged at the IR level (modulo whatever rustc inlines).
+// Stage 6: GRE decap. Returns (new_meta, optional owned decap frame).
+// The caller binds `packet_frame: &[u8]` from owned_packet_frame.as_deref()
+// .unwrap_or(raw_frame). Helper does NOT return the slice — that would
+// be a self-referential return type.
+fn stage_native_gre_decap(
+    raw_frame: &[u8],
+    meta: UserspaceDpMeta,
+    forwarding: &ForwardingState,
+) -> (UserspaceDpMeta, Option<Vec<u8>>);
 
-This means:
-- No new allocations
-- No new branches
-- No new state
-- No new types beyond `StageOutcome` (a small enum with two arms)
-- No reordering of side effects
+// Stage 7+8 combined: parse flow, learn dynamic neighbor as side
+// effect. Combined name flags the side effect (per Codex).
+fn stage_parse_flow_and_learn(
+    area: &MmapArea,
+    desc: &XdpDesc,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    binding: &mut BindingWorker,
+    worker_ctx: &WorkerContext,
+) -> Option<SessionFlow>;
+
+// Stage 9: fabric ingress. Mutates meta. Returns the bool needed by
+// later stages.
+fn stage_classify_fabric_ingress(
+    packet_frame: &[u8],
+    meta: &mut UserspaceDpMeta,
+    worker_ctx: &WorkerContext,
+) -> (Option<u16>, bool);  // (ingress_zone_override, packet_fabric_ingress)
+
+// Stage 10: screen/IDS slow path.
+fn stage_screen_check(
+    flow: Option<&SessionFlow>,
+    meta: UserspaceDpMeta,
+    ingress_zone_override: Option<u16>,
+    binding: &mut BindingWorker,
+    screen: &mut ScreenState,
+    worker_ctx: &WorkerContext,
+) -> StageOutcome<()>;
+
+// Stage 11: IPsec passthrough.
+fn stage_ipsec_passthrough_check(
+    flow: Option<&SessionFlow>,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    binding: &mut BindingWorker,
+    worker_ctx: &WorkerContext,
+) -> StageOutcome<()>;
+```
+
+The main loop body becomes:
+
+```rust
+while let Some(desc) = received.read() {
+    stage_record_rx_telemetry(desc, area, telemetry, worker_ctx);
+    let StageOutcome::Continue((mut meta, raw_frame)) =
+        stage_parse_and_classify(desc, unsafe { &*area }, validation, telemetry)
+    else {
+        binding.scratch.scratch_recycle.push(desc.addr);
+        continue;
+    };
+    match stage_link_layer_classify(raw_frame, meta, worker_ctx) {
+        LinkLayerOutcome::ArpLearnAndRecycle | LinkLayerOutcome::ArpRecycle => {
+            binding.scratch.scratch_recycle.push(desc.addr);
+            continue;
+        }
+        LinkLayerOutcome::NdpLearnAndContinue | LinkLayerOutcome::Continue => {}
+    }
+    let (new_meta, owned_packet_frame) = stage_native_gre_decap(
+        raw_frame, meta, worker_ctx.forwarding,
+    );
+    meta = new_meta;
+    let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);
+    let flow = stage_parse_flow_and_learn(...);
+    let (ingress_zone_override, packet_fabric_ingress) =
+        stage_classify_fabric_ingress(packet_frame, &mut meta, worker_ctx);
+    if let StageOutcome::RecycleAndContinue = stage_screen_check(...) {
+        binding.scratch.scratch_recycle.push(desc.addr);
+        continue;
+    }
+    if let StageOutcome::RecycleAndContinue = stage_ipsec_passthrough_check(...) {
+        binding.scratch.scratch_recycle.push(desc.addr);
+        continue;
+    }
+    // Stages 12-16 stay inline in this PR.
+    ...
+}
+```
 
 ## Why this is safe / shippable
 
 - **Pure code motion**: each extracted function returns the same
   values the inline code would have produced; control flow is
-  preserved by the `StageOutcome` enum's two arms.
-- **No SessionState, SessionTable, FlowCache, ScreenState mutability
-  changes**: those are all in steps (10)–(15) which Phase 1 leaves
-  alone.
-- **No worker_ctx field shape changes**: the extracted functions take
-  `worker_ctx: &WorkerContext` by reference, identical to today.
+  preserved by the explicit StageOutcome / LinkLayerOutcome arms.
+- **No state shape changes**: BindingWorker, WorkerContext, sessions,
+  screen, etc. all retain their current shape and access pattern.
+  Stages take `&mut` references where the original code mutated.
+- **No reordering of side effects**: dynamic neighbor learning,
+  telemetry counter updates, screen drops, recycle pushes, etc. all
+  fire in the exact same order they do today.
 - **Compiler-driven verification**: extracting a function and
-  inlining its callsite is a transformation rustc can verify via
-  type-checking the function signature.
-- **Smoke is the same**: v4 + v6 iperf3 against
-  172.16.80.200 / 2001:559:8585:80::200 on the loss userspace cluster.
-  No throughput regression expected (rustc is likely to re-inline the
-  small extracted helpers anyway).
+  inlining its callsite is a transformation rustc verifies via type
+  checking. The explicit StageOutcome arms make every early-return
+  path a compile-time-checked variant.
+- **Hidden ordering invariants** (Codex finding 6) are preserved
+  because the per-packet stage order in the new while-let body is
+  byte-identical to the inline order:
+  - ARP recycles before forwarding (stages 5 → continue).
+  - NDP learns AND falls through (LinkLayerOutcome::NdpLearnAndContinue).
+  - GRE decap precedes flow/screen/fabric (stage 6 before 7).
+  - Fabric flags feed later forwarding (stage 9 mutates meta in
+    place; later stages see the updated flags).
+  - `raw_frame` vs `packet_frame` is preserved by the caller-binds
+    pattern: helper returns `Option<Vec<u8>>`, caller does
+    `let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);`.
+
+## Test plan
+
+- `cargo build` clean (0 new warnings).
+- `cargo test --release` — full 952+ test cargo suite passes.
+- Named flow-cache test 5/5 clean (flake check).
+- 30 Go test packages pass.
+- v4 + v6 smoke against 172.16.80.200 / 2001:559:8585:80::200 on
+  loss userspace cluster (best-effort 5201, plus iperf-c 5203 for
+  high-rate sanity).
+- Per-class CoS smoke (best-effort, iperf-a..f) since the change
+  touches the dispatch ingress path. Although Phase 1 is pure code
+  motion, the per-class smoke catches inadvertent classifier or
+  policer regression.
 
 ## Why a future phase is required
 
 Phase 1 doesn't realize the L1-i locality benefit #946 cites because
-each packet still walks all stages before the next packet starts. To
-realize the benefit, **Phase 2** would need to:
+each packet still walks all extracted stages before the next packet
+starts. To realize the benefit, Phase 2 would need to:
 
-1. Add a `PacketBatch<N>` SoA struct (or use the existing
-   `scratch_forwards` shape) holding parsed-and-classified packets.
-2. Run stage 2 (parse_and_classify) over the entire RX burst before
-   any packet enters stage 3.
-3. Run stage 3 (link_layer_classify) over the surviving packets
-   before stage 4. Etc.
+1. Run stage 2 (parse_and_classify) over the entire RX burst before
+   any packet enters stage 5.
+2. Same for stages 5, 6, 7, 9, 10, 11.
+3. Accumulate per-packet outcomes in `Vec<StageOutput>` between
+   stages, drained per stage.
 
-Phase 2 is **gated on**:
-- #1127 (PacketBatch SoA struct) — cleanest concrete prerequisite.
-- The existing `scratch_forwards` boundary growing to cover the
-  per-packet half of the loop too (i.e., `scratch_parsed`,
-  `scratch_classified`, etc.).
-
-Phase 1 does NOT block on these. It's a pure refactor that makes
-Phase 2 mechanical.
+Phase 2 does NOT require a new `PacketBatch<N>` SoA struct (#1127);
+the existing scratch_forwards-style boundary can be replicated for
+each stage. A separate `PacketBatch` redesign is independent.
 
 ## Risk assessment
 
 - **Architectural mismatch risk** (the #961 dead-end pattern):
   **LOW**. Phase 1 is pure code motion — it cannot push the codebase
   toward a wrong architecture because it doesn't introduce new
-  abstractions. The named functions are just labels for existing
-  inline code blocks.
+  abstractions beyond two enums (StageOutcome<T> generic and
+  LinkLayerOutcome stage-specific). The named functions are just
+  labels for existing inline code blocks.
 - **Behavioral regression risk**: **LOW**. No state shape or order
-  changes. The enum-based StageOutcome makes the early-return arms
+  changes. The enum-based outcomes make every early-return arm
   explicit at the type level (the compiler will catch any missed
   recycle path).
-- **Test coverage**: existing 952-test cargo suite + 30 Go test
-  packages + smoke run on the cluster.
-- **Rollback**: trivially revertable (each extraction is one commit's
-  code motion).
+- **Borrow-checker risk on stage_native_gre_decap**: addressed in
+  v2 by returning `Option<Vec<u8>>` and letting the caller bind the
+  slice. No self-referential return type.
+- **Scope creep risk**: explicitly bounded — flow-cache fast path
+  (stage 12) and stages 13–16 stay inline. They will be tackled in
+  follow-up phases.
 
 ## Out of scope (explicitly)
 
@@ -171,24 +344,30 @@ Phase 2 mechanical.
 - `PacketEditor` builder for the rewrite half (#963).
 - Decoupling control plane from data plane (#948).
 - HAL abstraction (#987).
+- Flow-cache fast path extraction (Phase 1.5 / 2).
+- Session lookup, policy, NAT, forwarding, MissingNeighbor stages
+  (Phase 2+).
 
 ## Open questions for adversarial review
 
-1. Is "code motion only, no behavior change" the right scope, or
-   should Phase 1 also introduce the `PacketBatch<N>` struct (#1127)
-   to avoid two refactors of the same code?
-2. The `StageOutcome` enum — should it be one type with multiple
-   arms, or should each stage have its own outcome type?
-3. ARP / NDP classification at step (5) currently has 5 distinct
-   branches (Reply, Request, Other, NA-with-mac, NotArp). Should
-   these be flattened into a single `LinkLayerOutcome` enum, or
-   should each stage have its own?
-4. Step (8) "learn dynamic neighbor from packet" is a side effect on
-   `worker_ctx.dynamic_neighbors` and `binding.last_learned_neighbor`.
-   Should this be split into a separate stage (per the issue's
-   preference for stage purity), or kept as part of
-   `stage_parse_flow_and_learn` since the data flow is identical?
-5. Are there hidden ordering invariants between the listed stages
-   (e.g., does the screen check at step (10) implicitly depend on a
-   side effect from step (5) ARP early-return)? My read is no, but
-   this is the kind of trap that breaks pure code-motion refactors.
+1. Phase 1 extracts 8 stages and leaves stages 12–16 inline. Is this
+   the right scope for one PR, or should the extraction split into
+   two smaller PRs (e.g., stages 1–6 first, then 7–11)?
+2. `LinkLayerOutcome` has 4 arms (ArpLearnAndRecycle, ArpRecycle,
+   NdpLearnAndContinue, Continue). The first two collapse to "recycle"
+   from the caller's perspective; only the side effects on
+   dynamic_neighbors differ. Should the helper consume the side
+   effect internally and the outcome reduce to RecycleAndContinue +
+   Continue?
+3. `stage_classify_fabric_ingress` returns `(Option<u16>, bool)`. The
+   caller uses both the `ingress_zone_override` and the
+   `packet_fabric_ingress` flag downstream. Should this be a struct
+   with named fields instead of a tuple?
+4. The plan separates stage_screen_check (10) from
+   stage_ipsec_passthrough_check (11). They both have shape
+   `StageOutcome<()>` and run sequentially. Is fusing them worth
+   the loss of granularity?
+5. Does any reviewer see a hidden invariant between stages that this
+   plan would break? Specific traps to check: telemetry counter
+   ordering, recycle-on-error path completeness, and meta_flags
+   propagation through GRE decap → flow parse → fabric classify.

--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -1,0 +1,194 @@
+# #946 Phase 1 — Extract Per-Packet Sub-Stages from `poll_binding_process_descriptor`
+
+Status: **DRAFT — pending adversarial plan review**
+
+## Issue framing
+
+#946 asks for a VPP / `rte_graph` style batched pipeline where the
+worker loop iterates over *batches per stage*, not stages per packet.
+
+This Phase 1 plan does **not** ship that final architecture. Phase 1
+extracts the existing per-packet body of
+`poll_binding_process_descriptor` (currently 2,436 LOC, one giant
+`while let Some(desc) = received.read()` loop) into a small set of
+named per-packet helper functions. No batch reordering, no
+stage-per-batch iteration. This is pure code-motion that establishes
+the seams a future Phase 2/3 will exploit to swap to batched stages.
+
+The final pipeline architecture (true VPP-style) requires a
+`PacketBatch<N>` SoA buffer (#1127) and the `PacketEditor` builder
+(#963) — those are independent issues with their own plans. Phase 1
+is a precondition: without seams, the future batched extraction would
+have to do all of code-motion + batching at once, which is the
+"all-or-nothing risky refactor" pattern that previous attempts
+(#961 PacketContext rounds 1–2) failed at.
+
+## What's already batched
+
+The codebase **already** has a coarse per-RX-burst batch boundary:
+
+- `binding.scratch.scratch_forwards: Vec<PendingForwardRequest>` accumulates forwarding decisions during the RX while-let.
+- After the loop drains, `enqueue_pending_forwards` (in `tx/dispatch.rs`) iterates the batch and dispatches to local TX or cross-worker MPSC.
+- `binding.scratch.scratch_recycle: Vec<u64>` collects UMEM frame addresses to recycle, drained after the batch.
+- `binding.scratch.scratch_rst_teardowns: Vec<...>` collects RST-driven session teardowns, drained after the batch.
+
+This means Phase 1 is **adding seams to the per-packet path inside
+the while-let** — the batch boundary itself is unchanged.
+
+## What's NOT batched (the Phase 1 target)
+
+Inside the while-let body, every packet goes through this sequence:
+
+1. `record_rx_descriptor_telemetry(desc, area, telemetry, worker_ctx)`
+2. `try_parse_metadata` → `Option<UserspaceDpMeta>` (early return on None)
+3. `classify_metadata` → `PacketDisposition` (early return on Invalid)
+4. UMEM area slice for raw frame bytes (early return on None)
+5. **ARP / NDP classification** — early-return paths that recycle the
+   frame and continue without flowing through the rest of the pipeline
+   (ARP) or fall through (NDP NA).
+6. **Native GRE decap** — replaces meta and frame-slice, may own a
+   decapped frame.
+7. `parse_session_flow_from_bytes` → `Option<SessionFlow>`
+8. Dynamic-neighbor learning from the source IP (host-only).
+9. Fabric-ingress detection + `meta.meta_flags |= FABRIC_INGRESS_FLAG`.
+10. Screen/IDS check (slow path, only runs when profiles configured).
+11. Session lookup → fast-path / slow-path branch.
+12. Slow path: policy eval → NAT slot → forwarding lookup → push to
+    `scratch_forwards`.
+13. Fast path: hit existing session → push to `scratch_forwards`.
+14. Reverse-NAT and ICMP slow-path arms.
+15. MissingNeighbor side-queue: build session metadata, install,
+    publish, push to `pending_neigh`.
+
+That's ~2,400 LOC of branchy per-packet code in one function.
+
+## Phase 1 scope: extract by-stage, no behavioral change
+
+Extract into named functions, file-internal in
+`afxdp/poll_descriptor.rs` or sibling files under `afxdp/poll/`:
+
+1. **`stage_record_rx_telemetry`** — wraps step (1).  Takes a `&XdpDesc`,
+   the `*const MmapArea`, telemetry, worker_ctx. Returns nothing.
+
+2. **`stage_parse_and_classify`** — wraps steps (2)–(4). Takes the raw
+   inputs, returns either `StageOutcome::RecycleAndContinue` or
+   `StageOutcome::Continue { meta, raw_frame: &[u8] }`.
+
+3. **`stage_link_layer_classify`** — wraps step (5) ARP / NDP. Returns
+   `StageOutcome::RecycleAndContinue` (ARP request/reply/other) or
+   `StageOutcome::Continue { learn_neighbor: Option<NeighborLearnHint> }`
+   for NDP NA + IP fall-through.
+
+4. **`stage_native_gre_decap`** — wraps step (6). Returns updated
+   `meta`, optional owned decap frame, and the active frame slice
+   (borrowing one of the two).
+
+5. **`stage_parse_flow_and_learn`** — wraps steps (7)–(8). Returns
+   `Option<SessionFlow>` and updates dynamic_neighbors as a side effect.
+
+6. **`stage_classify_fabric_ingress`** — wraps step (9). Mutates `meta`
+   in place.
+
+7. Steps (10)–(15) stay in the main function for Phase 1. They have
+   complex control flow (early-return arms for fast/slow path, NAT,
+   ICMP, missing-neighbor side queue) that doesn't have clean seams
+   yet. Phase 2 will tackle these once Phase 1 lands.
+
+## What stays per-packet
+
+All of (1)–(15) stay per-packet within the while-let. The only
+change is that (1)–(9) become named function calls instead of inline
+code. The semantic order and branching of the loop body is byte-for-byte
+unchanged at the IR level (modulo whatever rustc inlines).
+
+This means:
+- No new allocations
+- No new branches
+- No new state
+- No new types beyond `StageOutcome` (a small enum with two arms)
+- No reordering of side effects
+
+## Why this is safe / shippable
+
+- **Pure code motion**: each extracted function returns the same
+  values the inline code would have produced; control flow is
+  preserved by the `StageOutcome` enum's two arms.
+- **No SessionState, SessionTable, FlowCache, ScreenState mutability
+  changes**: those are all in steps (10)–(15) which Phase 1 leaves
+  alone.
+- **No worker_ctx field shape changes**: the extracted functions take
+  `worker_ctx: &WorkerContext` by reference, identical to today.
+- **Compiler-driven verification**: extracting a function and
+  inlining its callsite is a transformation rustc can verify via
+  type-checking the function signature.
+- **Smoke is the same**: v4 + v6 iperf3 against
+  172.16.80.200 / 2001:559:8585:80::200 on the loss userspace cluster.
+  No throughput regression expected (rustc is likely to re-inline the
+  small extracted helpers anyway).
+
+## Why a future phase is required
+
+Phase 1 doesn't realize the L1-i locality benefit #946 cites because
+each packet still walks all stages before the next packet starts. To
+realize the benefit, **Phase 2** would need to:
+
+1. Add a `PacketBatch<N>` SoA struct (or use the existing
+   `scratch_forwards` shape) holding parsed-and-classified packets.
+2. Run stage 2 (parse_and_classify) over the entire RX burst before
+   any packet enters stage 3.
+3. Run stage 3 (link_layer_classify) over the surviving packets
+   before stage 4. Etc.
+
+Phase 2 is **gated on**:
+- #1127 (PacketBatch SoA struct) — cleanest concrete prerequisite.
+- The existing `scratch_forwards` boundary growing to cover the
+  per-packet half of the loop too (i.e., `scratch_parsed`,
+  `scratch_classified`, etc.).
+
+Phase 1 does NOT block on these. It's a pure refactor that makes
+Phase 2 mechanical.
+
+## Risk assessment
+
+- **Architectural mismatch risk** (the #961 dead-end pattern):
+  **LOW**. Phase 1 is pure code motion — it cannot push the codebase
+  toward a wrong architecture because it doesn't introduce new
+  abstractions. The named functions are just labels for existing
+  inline code blocks.
+- **Behavioral regression risk**: **LOW**. No state shape or order
+  changes. The enum-based StageOutcome makes the early-return arms
+  explicit at the type level (the compiler will catch any missed
+  recycle path).
+- **Test coverage**: existing 952-test cargo suite + 30 Go test
+  packages + smoke run on the cluster.
+- **Rollback**: trivially revertable (each extraction is one commit's
+  code motion).
+
+## Out of scope (explicitly)
+
+- True batched stage iteration (Phase 2+).
+- `PacketBatch<N>` SoA struct (#1127).
+- `PacketEditor` builder for the rewrite half (#963).
+- Decoupling control plane from data plane (#948).
+- HAL abstraction (#987).
+
+## Open questions for adversarial review
+
+1. Is "code motion only, no behavior change" the right scope, or
+   should Phase 1 also introduce the `PacketBatch<N>` struct (#1127)
+   to avoid two refactors of the same code?
+2. The `StageOutcome` enum — should it be one type with multiple
+   arms, or should each stage have its own outcome type?
+3. ARP / NDP classification at step (5) currently has 5 distinct
+   branches (Reply, Request, Other, NA-with-mac, NotArp). Should
+   these be flattened into a single `LinkLayerOutcome` enum, or
+   should each stage have its own?
+4. Step (8) "learn dynamic neighbor from packet" is a side effect on
+   `worker_ctx.dynamic_neighbors` and `binding.last_learned_neighbor`.
+   Should this be split into a separate stage (per the issue's
+   preference for stage purity), or kept as part of
+   `stage_parse_flow_and_learn` since the data flow is identical?
+5. Are there hidden ordering invariants between the listed stages
+   (e.g., does the screen check at step (10) implicitly depend on a
+   side effect from step (5) ARP early-return)? My read is no, but
+   this is the kind of trap that breaks pure code-motion refactors.

--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -128,8 +128,7 @@ existing `continue;` in the while-let. Codex round 2 enumerated them:
 | 183  | Screen drop | yes | yes (stage 10) |
 | 221  | IPsec passthrough | yes | yes (stage 11) |
 | 297  | Flow-cache TTL ICMP-TE generated | no (returned via pending_fill_frames) | NO — flow-cache stage deferred |
-| 397  | Flow-cache slow-path fallback (scratch_forwards push) | no (recycled later as part of forward) | NO — flow-cache deferred |
-| 433  | Flow-cache in-place rewrite success | no (frame travels as TX) | NO — flow-cache deferred |
+| 433  | Flow-cache terminal `continue;` (covers both in-place rewrite success and the scratch_forwards fallback inside the same block at line 397) | no (frame travels as TX) | NO — flow-cache deferred |
 | 535  | Session-hit TTL ICMP-TE generated | no (same as 297) | NO — session-hit stage deferred |
 | 604  | Cluster-peer-return fast path | no (frame travels via fabric TX) | NO — cluster-peer stage deferred |
 
@@ -178,8 +177,9 @@ That's ~2,400 LOC of branchy per-packet code in one function.
 - (1) `stage_record_rx_telemetry`
 - (2)+(3)+(4) `stage_parse_and_classify` → `StageOutcome<ParsedFrame>`
    where `ParsedFrame` carries `meta` + `raw_frame: &'a [u8]`.
-- (5) `stage_link_layer_classify` → `LinkLayerOutcome` (5 distinct
-  arms, NOT a generic StageOutcome — see "Open questions" #2).
+- (5) `stage_link_layer_classify` → `StageOutcome<()>` (per Codex
+  round-2 answer to Q2: collapse the four ARP/NDP arms; side
+  effects on `dynamic_neighbors` stay inside the helper).
 - (6) `stage_native_gre_decap` → `(UserspaceDpMeta, Option<Vec<u8>>)`
   *plus* the caller binds the active slice locally (the helper does
   NOT return the slice — that would be self-referential).
@@ -243,9 +243,9 @@ fn stage_parse_and_classify<'a>(
     area: &'a MmapArea,
     validation: ValidationState,
     binding_live: &BindingLiveState,
-    ident: &WorkerIdent,
+    ident: &BindingIdentity,
     forwarding: &ForwardingState,
-    recent_exceptions: &RecentExceptions,
+    recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
     telemetry: &mut TelemetryContext,
 ) -> StageOutcome<(UserspaceDpMeta, &'a [u8])>;
 
@@ -427,7 +427,7 @@ Phase 1 preserves it.
 
 - **Pure code motion**: each extracted function returns the same
   values the inline code would have produced; control flow is
-  preserved by the explicit StageOutcome / LinkLayerOutcome arms.
+  preserved by the explicit StageOutcome / FabricIngressOutcome arms.
 - **No state shape changes**: BindingWorker, WorkerContext, sessions,
   screen, etc. all retain their current shape and access pattern.
   Stages take `&mut` references where the original code mutated.
@@ -452,11 +452,25 @@ Phase 1 preserves it.
   - **Dynamic-neighbor learning only for non-GRE-owned frames**
     (line 113 guard). v3's `learn_from_live_frame` flag passes
     `owned_packet_frame.is_none()` from the caller.
-  - **`raw_frame` must stay available for deferred TTL/ICMP paths.**
-    The flow-cache TTL path at line 281 and session-hit TTL path
-    use `raw_frame` directly (NOT `packet_frame`). v3's caller
-    binds both: `let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);`
-    — `raw_frame` is preserved for deferred code.
+  - **`raw_frame` must stay available for deferred TTL/ICMP/debug
+    paths.** Beyond the flow-cache TTL path at line 281, deferred
+    code uses `raw_frame` for embedded ICMP handling at
+    [poll_descriptor.rs:865](../../../userspace-dp/src/afxdp/poll_descriptor.rs)
+    and [poll_descriptor.rs:963](../../../userspace-dp/src/afxdp/poll_descriptor.rs),
+    and for debug TCP inspection at
+    [poll_descriptor.rs:1633](../../../userspace-dp/src/afxdp/poll_descriptor.rs).
+    v3's caller binds both: `let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);`
+    — `raw_frame` is preserved as a separate live binding for
+    deferred code that must look at the un-decapped Ethernet frame.
+  - **`metadata_packets` is a batch counter, NOT a live counter.**
+    `telemetry.counters.metadata_packets += 1` fires AFTER
+    successful metadata parse and BEFORE classify, regardless of
+    whether the disposition turns out to be Valid or not. It must
+    NOT fire on parse failure, and the valid-path counters
+    (validated_packets/validated_bytes) are batch counters
+    (`telemetry.counters`), NOT `record_disposition(PacketDisposition::Valid)`
+    live-counter calls. The Valid path's only live-counter side
+    effect is via the deferred stages 12+.
   - **`meta_flags` mutation must precede screen/IPsec/flow-cache.**
     Stage 9 sets `FABRIC_INGRESS_FLAG`. Screen (10), IPsec (11),
     and the deferred flow-cache (12) all read meta after stage 9
@@ -507,7 +521,7 @@ each stage. A separate `PacketBatch` redesign is independent.
   **LOW**. Phase 1 is pure code motion — it cannot push the codebase
   toward a wrong architecture because it doesn't introduce new
   abstractions beyond two enums (StageOutcome<T> generic and
-  LinkLayerOutcome stage-specific). The named functions are just
+  FabricIngressOutcome named struct). The named functions are just
   labels for existing inline code blocks.
 - **Behavioral regression risk**: **LOW**. No state shape or order
   changes. The enum-based outcomes make every early-return arm
@@ -536,7 +550,7 @@ each stage. A separate `PacketBatch` redesign is independent.
 1. Phase 1 extracts 8 stages and leaves stages 12–16 inline. Is this
    the right scope for one PR, or should the extraction split into
    two smaller PRs (e.g., stages 1–6 first, then 7–11)?
-2. `LinkLayerOutcome` has 4 arms (ArpLearnAndRecycle, ArpRecycle,
+2. (Resolved per Codex round-2 Q2.) `LinkLayerOutcome` had 4 arms (ArpLearnAndRecycle, ArpRecycle,
    NdpLearnAndContinue, Continue). The first two collapse to "recycle"
    from the caller's perspective; only the side effects on
    dynamic_neighbors differ. Should the helper consume the side

--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -1,6 +1,56 @@
 # #946 Phase 1 — Extract Per-Packet Sub-Stages from `poll_binding_process_descriptor`
 
-Status: **DRAFT v2 — addressing Codex round-1 PLAN-NEEDS-MAJOR**
+Status: **DRAFT v3 — addressing Codex round-2 PLAN-NEEDS-MAJOR**
+
+## v3 changes (Codex round-2 findings)
+
+Codex round 2 accepted the architectural shape but flagged 5
+tactical signature defects that would break behavior preservation
+once implementation began. v3 fixes each.
+
+1. **`stage_parse_and_classify` drops side effects.** Metadata
+   parse failure increments `binding.live.metadata_errors`,
+   `telemetry.dbg.metadata_err`, and calls `record_exception`
+   (poll_descriptor.rs:2192–2204). Non-Valid disposition calls
+   `record_disposition` (line 2181) which updates live counters and
+   `recent_exceptions`. v2's helper only got `telemetry`; v3 takes
+   `&mut binding.live`, `worker_ctx.recent_exceptions`, the ident,
+   and `worker_ctx.forwarding`. Side effects fire inside the helper.
+2. **`stage_parse_flow_and_learn` cannot reproduce the GRE guard.**
+   The current code learns dynamic neighbors only when
+   `owned_packet_frame.is_none()` (poll_descriptor.rs:113). v3's
+   helper takes an explicit `learn_from_live_frame: bool` flag, and
+   the broad `&mut BindingWorker` narrows to
+   `&mut binding.last_learned_neighbor`.
+3. **`stage_screen_check` signature was incomplete.** Needs
+   `packet_frame: &[u8]` (for `extract_screen_info`), `now_secs`
+   (for `screen.check_packet`), and only `&binding.live.screen_drops`
+   for the live drop counter — caller still owns the recycle push.
+4. **Stage inventory still missed 3 continue sites.** v3 explicitly
+   lists all 9 `continue;` sites (53, 76, 80, 183, 221, 297, 433,
+   535, 604) and notes 535 (session-hit TTL ICMP-TE) and 604
+   (cluster-peer-return fast path) belong to the deferred stages
+   13–16. Flow-cache also has a scratch_forwards fallback at line
+   397 — v3 calls this out so the future Phase 1.5 helper covers it.
+5. **Main-loop sketch was not compile-realistic.** Deferred inline
+   code at lines 419, 583, 1814 calls `owned_packet_frame.take()`,
+   so the binding must be `mut`. v3's sketch reflects this and
+   restores `let mut recycle_now = true` before the deferred body.
+
+Open question answers from Codex round 2:
+- **Q1** (split into 2 PRs?): One PR is acceptable after the
+  signature fixes; 8 helpers ≈ 400–1200 LOC, in line with our
+  Phase-N decompositions. Split only if churn grows beyond pure
+  code motion.
+- **Q2** (LinkLayerOutcome arms): collapse to `StageOutcome<()>`;
+  side effects (ARP/NDP neighbor learning) stay inside the helper.
+  v2 was inconsistent — said 5 arms, defined 4. v3 just uses
+  `StageOutcome<()>`.
+- **Q3** (fabric ingress tuple): v3 returns a small named struct
+  `FabricIngressOutcome { ingress_zone_override, packet_fabric_ingress }`.
+- **Q4** (fuse screen+ipsec?): no, keep them separate; different
+  inputs, side effects, ordering matters.
+- **Q5** (hidden invariants): documented at the bottom.
 
 ## v2 changes (Codex round-1 findings)
 
@@ -65,7 +115,30 @@ So scratch_forwards is the slow-path batch boundary; the fast path
 bypasses it. Phase 1 doesn't touch either of these — it adds named
 seams to the per-packet code that runs before both paths.
 
-## Stage inventory (corrected v2)
+## All 9 continue/recycle sites in the loop body (v3)
+
+For Phase 1 to be behavior-preserving we have to account for every
+existing `continue;` in the while-let. Codex round 2 enumerated them:
+
+| Line | Site | Recycles? | Phase 1? |
+|------|------|-----------|----------|
+| 53   | UMEM slice failed | yes | yes (stage 2-4) |
+| 76   | ARP reply | yes | yes (stage 5) |
+| 80   | ARP other | yes | yes (stage 5) |
+| 183  | Screen drop | yes | yes (stage 10) |
+| 221  | IPsec passthrough | yes | yes (stage 11) |
+| 297  | Flow-cache TTL ICMP-TE generated | no (returned via pending_fill_frames) | NO — flow-cache stage deferred |
+| 397  | Flow-cache slow-path fallback (scratch_forwards push) | no (recycled later as part of forward) | NO — flow-cache deferred |
+| 433  | Flow-cache in-place rewrite success | no (frame travels as TX) | NO — flow-cache deferred |
+| 535  | Session-hit TTL ICMP-TE generated | no (same as 297) | NO — session-hit stage deferred |
+| 604  | Cluster-peer-return fast path | no (frame travels via fabric TX) | NO — cluster-peer stage deferred |
+
+Phase 1 covers continues at 53, 76, 80, 183, 221 — every one of these
+is a recycle-and-continue (the simple StageOutcome shape). The 5
+deferred continues all leave the per-packet body via TX-side paths,
+not via recycle, and live in the deferred stages 12–16.
+
+## Stage inventory (corrected v3)
 
 The while-let body executes this sequence per descriptor:
 
@@ -138,128 +211,217 @@ in the main function for now:
   ~1,000+ LOC with deeply intertwined state and no obvious seams.
   **Scope choice**: each gets its own phase.
 
-## Phase 1 stage signatures (concrete)
+## Phase 1 stage signatures (concrete v3)
 
 ```rust
 // Generic outcome for stages with a single non-recycle output.
+// Used everywhere in Phase 1.
 enum StageOutcome<T> {
     RecycleAndContinue,
     Continue(T),
 }
 
-// Stage 2-4 combined: parse metadata, classify, slice the UMEM frame.
+// Small named struct — clearer than the (Option<u16>, bool) tuple
+// used by stage 9. Caller pattern-matches on both fields.
+struct FabricIngressOutcome {
+    ingress_zone_override: Option<u16>,
+    packet_fabric_ingress: bool,
+}
+
+// ── Stage 2-4: parse metadata, classify, slice UMEM ──────────────
+//
+// Side effects handled INSIDE the helper to preserve current
+// behavior:
+//   - Parse failure: telemetry.dbg.metadata_err += 1,
+//     binding.live.metadata_errors.fetch_add, record_exception.
+//   - Non-Valid disposition: record_disposition (live counters +
+//     recent_exceptions).
+// Returns RecycleAndContinue on either failure path; Continue on
+// successful parse + classify + slice.
 fn stage_parse_and_classify<'a>(
     desc: &XdpDesc,
     area: &'a MmapArea,
     validation: ValidationState,
+    binding_live: &BindingLiveState,
+    ident: &WorkerIdent,
+    forwarding: &ForwardingState,
+    recent_exceptions: &RecentExceptions,
     telemetry: &mut TelemetryContext,
 ) -> StageOutcome<(UserspaceDpMeta, &'a [u8])>;
 
-// Stage 5: ARP/NDP. 5 distinct arms, side effects internal.
-enum LinkLayerOutcome {
-    /// ARP reply: dynamic neighbor was learned, recycle the frame.
-    ArpLearnAndRecycle,
-    /// ARP request/other: recycle without learning.
-    ArpRecycle,
-    /// NDP NA: dynamic neighbor was learned, fall through.
-    NdpLearnAndContinue,
-    /// Plain non-link-layer packet: fall through.
-    Continue,
-}
-
+// ── Stage 5: ARP / NDP classification ─────────────────────────────
+//
+// All 4 cases (ARP reply learn-and-recycle, ARP request/other
+// recycle, NDP NA learn-and-fall-through, plain fall-through)
+// collapse to RecycleAndContinue + Continue. Neighbor-learn side
+// effects are kept inside the helper — downstream code does not
+// read the learned neighbor for the same packet.
 fn stage_link_layer_classify(
     raw_frame: &[u8],
     meta: UserspaceDpMeta,
     worker_ctx: &WorkerContext,
-) -> LinkLayerOutcome;
+) -> StageOutcome<()>;
 
-// Stage 6: GRE decap. Returns (new_meta, optional owned decap frame).
-// The caller binds `packet_frame: &[u8]` from owned_packet_frame.as_deref()
-// .unwrap_or(raw_frame). Helper does NOT return the slice — that would
-// be a self-referential return type.
+// ── Stage 6: GRE decap ────────────────────────────────────────────
+//
+// Returns the (possibly-updated) meta + the optional owned decap
+// frame. Caller binds the active slice locally:
+//
+//   let (meta, owned) = stage_native_gre_decap(raw_frame, meta, ...);
+//   let packet_frame = owned.as_deref().unwrap_or(raw_frame);
+//
+// `owned_packet_frame: Option<Vec<u8>>` must be a `mut` binding
+// because deferred stage-12+ code calls `.take()` (lines 419, 583,
+// 1814).
 fn stage_native_gre_decap(
     raw_frame: &[u8],
     meta: UserspaceDpMeta,
     forwarding: &ForwardingState,
 ) -> (UserspaceDpMeta, Option<Vec<u8>>);
 
-// Stage 7+8 combined: parse flow, learn dynamic neighbor as side
-// effect. Combined name flags the side effect (per Codex).
+// ── Stage 7+8: parse flow + learn dynamic neighbor ───────────────
+//
+// `learn_from_live_frame` MUST be true only when the active slice
+// is the un-decapped raw_frame (i.e. owned_packet_frame.is_none() at
+// call site). Mirrors the current GRE guard at line 113.
+//
+// Narrowed binding access — only takes &mut binding.last_learned_neighbor
+// (not the whole BindingWorker).
 fn stage_parse_flow_and_learn(
     area: &MmapArea,
     desc: &XdpDesc,
     packet_frame: &[u8],
     meta: UserspaceDpMeta,
-    binding: &mut BindingWorker,
+    learn_from_live_frame: bool,
+    last_learned_neighbor: &mut Option<LearnedNeighborKey>,
     worker_ctx: &WorkerContext,
 ) -> Option<SessionFlow>;
 
-// Stage 9: fabric ingress. Mutates meta. Returns the bool needed by
-// later stages.
+// ── Stage 9: fabric ingress classification ────────────────────────
+//
+// Mutates meta in place to set FABRIC_INGRESS_FLAG when applicable.
+// Returns a named struct with both outputs.
 fn stage_classify_fabric_ingress(
     packet_frame: &[u8],
     meta: &mut UserspaceDpMeta,
     worker_ctx: &WorkerContext,
-) -> (Option<u16>, bool);  // (ingress_zone_override, packet_fabric_ingress)
+) -> FabricIngressOutcome;
 
-// Stage 10: screen/IDS slow path.
+// ── Stage 10: screen / IDS slow path ──────────────────────────────
+//
+// Adds packet_frame and now_secs (Codex round-2 finding 3). Caller
+// owns the recycle push; helper only increments
+// binding.live.screen_drops on a Drop verdict.
 fn stage_screen_check(
     flow: Option<&SessionFlow>,
+    packet_frame: &[u8],
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
-    binding: &mut BindingWorker,
+    now_secs: u64,
     screen: &mut ScreenState,
+    binding_live: &BindingLiveState,
     worker_ctx: &WorkerContext,
 ) -> StageOutcome<()>;
 
-// Stage 11: IPsec passthrough.
+// ── Stage 11: IPsec passthrough ───────────────────────────────────
 fn stage_ipsec_passthrough_check(
     flow: Option<&SessionFlow>,
     packet_frame: &[u8],
     meta: UserspaceDpMeta,
-    binding: &mut BindingWorker,
+    binding_live: &BindingLiveState,
     worker_ctx: &WorkerContext,
 ) -> StageOutcome<()>;
 ```
 
-The main loop body becomes:
+The main loop body becomes (compile-realistic v3):
 
 ```rust
 while let Some(desc) = received.read() {
     stage_record_rx_telemetry(desc, area, telemetry, worker_ctx);
-    let StageOutcome::Continue((mut meta, raw_frame)) =
-        stage_parse_and_classify(desc, unsafe { &*area }, validation, telemetry)
-    else {
+    let mut recycle_now = true;  // restored — deferred stages 12+
+                                 // toggle this when packet leaves
+                                 // via TX (flow-cache, session-hit
+                                 // TTL, cluster-peer-return).
+    let StageOutcome::Continue((mut meta, raw_frame)) = stage_parse_and_classify(
+        desc,
+        unsafe { &*area },
+        validation,
+        &binding.live,
+        &worker_ctx.ident,
+        worker_ctx.forwarding,
+        worker_ctx.recent_exceptions,
+        telemetry,
+    ) else {
         binding.scratch.scratch_recycle.push(desc.addr);
         continue;
     };
-    match stage_link_layer_classify(raw_frame, meta, worker_ctx) {
-        LinkLayerOutcome::ArpLearnAndRecycle | LinkLayerOutcome::ArpRecycle => {
-            binding.scratch.scratch_recycle.push(desc.addr);
-            continue;
-        }
-        LinkLayerOutcome::NdpLearnAndContinue | LinkLayerOutcome::Continue => {}
+
+    if let StageOutcome::RecycleAndContinue =
+        stage_link_layer_classify(raw_frame, meta, worker_ctx)
+    {
+        binding.scratch.scratch_recycle.push(desc.addr);
+        continue;
     }
-    let (new_meta, owned_packet_frame) = stage_native_gre_decap(
-        raw_frame, meta, worker_ctx.forwarding,
-    );
+
+    let (new_meta, mut owned_packet_frame) =  // mut: deferred .take() at lines 419, 583, 1814
+        stage_native_gre_decap(raw_frame, meta, worker_ctx.forwarding);
     meta = new_meta;
     let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);
-    let flow = stage_parse_flow_and_learn(...);
-    let (ingress_zone_override, packet_fabric_ingress) =
+
+    let flow = stage_parse_flow_and_learn(
+        unsafe { &*area },
+        desc,
+        packet_frame,
+        meta,
+        owned_packet_frame.is_none(),  // GRE guard — preserves line-113 behavior
+        &mut binding.last_learned_neighbor,
+        worker_ctx,
+    );
+
+    let FabricIngressOutcome { ingress_zone_override, packet_fabric_ingress } =
         stage_classify_fabric_ingress(packet_frame, &mut meta, worker_ctx);
-    if let StageOutcome::RecycleAndContinue = stage_screen_check(...) {
+
+    if let StageOutcome::RecycleAndContinue = stage_screen_check(
+        flow.as_ref(),
+        packet_frame,
+        meta,
+        ingress_zone_override,
+        now_secs,
+        screen,
+        &binding.live,
+        worker_ctx,
+    ) {
         binding.scratch.scratch_recycle.push(desc.addr);
         continue;
     }
-    if let StageOutcome::RecycleAndContinue = stage_ipsec_passthrough_check(...) {
+
+    if let StageOutcome::RecycleAndContinue = stage_ipsec_passthrough_check(
+        flow.as_ref(),
+        packet_frame,
+        meta,
+        &binding.live,
+        worker_ctx,
+    ) {
         binding.scratch.scratch_recycle.push(desc.addr);
         continue;
     }
-    // Stages 12-16 stay inline in this PR.
+
+    // ── Deferred stages 12-16 stay inline in this PR ────────────────
+    // Flow-cache fast path, session lookup, slow-path policy/NAT/
+    // forwarding, reverse-NAT/ICMP, MissingNeighbor side queue.
+    // These stages can call owned_packet_frame.take() and may set
+    // recycle_now = false when the packet leaves via TX.
     ...
+
+    if recycle_now {
+        binding.scratch.scratch_recycle.push(desc.addr);
+    }
 }
 ```
+
+Note: the trailing `if recycle_now` is the ORIGINAL behavior at
+[poll_descriptor.rs:2205–2207](../../../userspace-dp/src/afxdp/poll_descriptor.rs).
+Phase 1 preserves it.
 
 ## Why this is safe / shippable
 
@@ -276,17 +438,38 @@ while let Some(desc) = received.read() {
   inlining its callsite is a transformation rustc verifies via type
   checking. The explicit StageOutcome arms make every early-return
   path a compile-time-checked variant.
-- **Hidden ordering invariants** (Codex finding 6) are preserved
-  because the per-packet stage order in the new while-let body is
-  byte-identical to the inline order:
-  - ARP recycles before forwarding (stages 5 → continue).
-  - NDP learns AND falls through (LinkLayerOutcome::NdpLearnAndContinue).
-  - GRE decap precedes flow/screen/fabric (stage 6 before 7).
-  - Fabric flags feed later forwarding (stage 9 mutates meta in
-    place; later stages see the updated flags).
-  - `raw_frame` vs `packet_frame` is preserved by the caller-binds
-    pattern: helper returns `Option<Vec<u8>>`, caller does
-    `let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);`.
+- **Hidden ordering invariants** preserved (per Codex round 2):
+  - **Metadata/disposition side effects fire BEFORE recycle.**
+    `record_disposition` and `record_exception` both update
+    `binding.live.*` and `recent_exceptions` before the recycle
+    push. v3's stage_parse_and_classify keeps this ordering by
+    firing the side effects internally before returning
+    RecycleAndContinue.
+  - **`validated_packets`/`validated_bytes` increment BEFORE
+    raw-frame slice success** (poll_descriptor.rs:47–48 vs 49).
+    v3's stage_parse_and_classify increments these between
+    classify and slice.
+  - **Dynamic-neighbor learning only for non-GRE-owned frames**
+    (line 113 guard). v3's `learn_from_live_frame` flag passes
+    `owned_packet_frame.is_none()` from the caller.
+  - **`raw_frame` must stay available for deferred TTL/ICMP paths.**
+    The flow-cache TTL path at line 281 and session-hit TTL path
+    use `raw_frame` directly (NOT `packet_frame`). v3's caller
+    binds both: `let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);`
+    — `raw_frame` is preserved for deferred code.
+  - **`meta_flags` mutation must precede screen/IPsec/flow-cache.**
+    Stage 9 sets `FABRIC_INGRESS_FLAG`. Screen (10), IPsec (11),
+    and the deferred flow-cache (12) all read meta after stage 9
+    so they see the flag. v3's loop sketch shows the ordering
+    explicitly: stage 9 → 10 → 11 → deferred 12+.
+  - **ARP recycles BEFORE normal forwarding** (stages 5 → continue).
+  - **NDP learns AND falls through** (StageOutcome::Continue
+    after the helper updates dynamic_neighbors internally).
+  - **GRE decap precedes flow/screen/fabric** (stage 6 before 7
+    before 9 before 10).
+  - **`owned_packet_frame` is `mut`** — deferred stage code at
+    lines 419, 583, 1814 calls `.take()`. The new sketch reflects
+    this.
 
 ## Test plan
 

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -392,6 +392,11 @@ impl BatchCounters {
 mod poll_descriptor;
 use poll_descriptor::poll_binding_process_descriptor;
 
+// #946 Phase 1: per-packet pipeline stages extracted from the
+// while-let body in `poll_binding_process_descriptor`. See
+// `docs/pr/946-pipeline-phase1/plan.md` for the full plan.
+mod poll_stages;
+
 // Issue 67.1: session-delta processing (flush_session_deltas et al.)
 // extracted into afxdp/session_delta.rs.
 mod session_delta;

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -17,9 +17,16 @@ use super::poll_stages::{
 //
 // Runs `binding.xsk.rx.receive(available)` + the descriptor while-let +
 // `received.release(); drop(received);` as its own compilation unit so
-// it surfaces under its own symbol in `perf top`. Body is byte-for-byte
-// identical to the previous inner-loop content; only the enclosing
-// function boundary is new.
+// it surfaces under its own symbol in `perf top`.
+//
+// #946 Phase 1 (commit ea8fa4e6) extracted seven per-packet
+// sub-stages out of the while-let body into named helpers in
+// `afxdp/poll_stages.rs`. The helpers are all `#[inline]` so the
+// extracted bodies stay in the caller's CGU and the call/return
+// overhead is amortized to zero — the refactor is pure
+// code-motion at the IR level (modulo what rustc's inliner picks
+// up; the explicit hint matches other hot-path extractions in
+// this repo).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn poll_binding_process_descriptor(
     binding: &mut BindingWorker,

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -7,6 +7,11 @@
 // that the extracted fn references.
 
 use super::*;
+use super::poll_stages::{
+    stage_classify_fabric_ingress, stage_ipsec_passthrough_check, stage_link_layer_classify,
+    stage_native_gre_decap, stage_parse_flow_and_learn, stage_screen_check, FabricIngressOutcome,
+    StageOutcome,
+};
 
 // Per-batch packet processing lifted from `poll_binding` (#678).
 //
@@ -52,174 +57,76 @@ pub(super) fn poll_binding_process_descriptor(
                         binding.scratch.scratch_recycle.push(desc.addr);
                         continue;
                     };
-                    // #947: ARP classification + reply parsing extracted to
-                    // `parser.rs`. Any ARP frame (request/reply/etc.) is
-                    // recycled — ARP does not transit the firewall. ARP
-                    // replies additionally update the dynamic neighbor cache
-                    // and the kernel's neighbor table.
-                    match parser::classify_arp(raw_frame) {
-                        parser::ArpClassification::Reply(arp) => {
-                            worker_ctx.dynamic_neighbors.insert(
-                                (meta.ingress_ifindex as i32, arp.sender_ip),
-                                NeighborEntry {
-                                    mac: arp.sender_mac,
-                                },
-                            );
-                            let neigh_ifindex = resolve_ingress_logical_ifindex(
-                                worker_ctx.forwarding,
-                                meta.ingress_ifindex as i32,
-                                meta.ingress_vlan_id,
-                            )
-                            .unwrap_or(meta.ingress_ifindex as i32);
-                            add_kernel_neighbor(neigh_ifindex, arp.sender_ip, arp.sender_mac);
-                            binding.scratch.scratch_recycle.push(desc.addr);
-                            continue;
-                        }
-                        parser::ArpClassification::OtherArp => {
-                            binding.scratch.scratch_recycle.push(desc.addr);
-                            continue;
-                        }
-                        parser::ArpClassification::NotArp => {}
-                    }
-                    // #947: NDP Neighbor Advertisement parsing extracted to
-                    // `parser.rs`. NA with a Target Link-Layer Address option
-                    // updates the dynamic neighbor cache and the kernel's
-                    // neighbor table. Unlike ARP, the NA frame falls through
-                    // to normal IPv6 forwarding processing afterward.
-                    if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
-                        && let Some(mac) = na.target_mac
+                    // #946 Phase 1 stage 5: ARP / NDP link-layer
+                    // classification. ARP frames recycle without
+                    // transiting; NDP NA learns and falls through.
+                    if let StageOutcome::RecycleAndContinue =
+                        stage_link_layer_classify(raw_frame, meta, worker_ctx)
                     {
-                        worker_ctx.dynamic_neighbors.insert(
-                            (meta.ingress_ifindex as i32, na.target_ip),
-                            NeighborEntry { mac },
-                        );
-                        let neigh_ifindex = resolve_ingress_logical_ifindex(
-                            worker_ctx.forwarding,
-                            meta.ingress_ifindex as i32,
-                            meta.ingress_vlan_id,
-                        )
-                        .unwrap_or(meta.ingress_ifindex as i32);
-                        add_kernel_neighbor(neigh_ifindex, na.target_ip, mac);
+                        binding.scratch.scratch_recycle.push(desc.addr);
+                        continue;
                     }
-                    let native_gre_packet =
-                        try_native_gre_decap_from_frame(raw_frame, meta, worker_ctx.forwarding);
-                    let mut meta = native_gre_packet
-                        .as_ref()
-                        .map(|packet| packet.meta)
-                        .unwrap_or(meta);
-                    let mut owned_packet_frame = native_gre_packet.map(|packet| packet.frame);
+                    // #946 Phase 1 stage 6: native GRE decap. Caller
+                    // binds the active slice locally; helper does NOT
+                    // return the slice (would be self-referential).
+                    // `owned_packet_frame` MUST be `mut` — deferred
+                    // stage-12+ code at lines below calls `.take()`.
+                    let (mut meta, mut owned_packet_frame) =
+                        stage_native_gre_decap(raw_frame, meta, worker_ctx.forwarding);
                     let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);
-                    let flow = parse_session_flow_from_bytes(packet_frame, meta);
-                    if owned_packet_frame.is_none()
-                        && let Some(flow) = flow.as_ref()
-                    {
-                        learn_dynamic_neighbor_from_packet(
-                            unsafe { &*area },
-                            desc,
-                            meta,
-                            flow.src_ip,
-                            &mut binding.last_learned_neighbor,
-                            worker_ctx.forwarding,
-                            worker_ctx.dynamic_neighbors,
-                        );
-                    }
-                    let ingress_zone_override = parse_zone_encoded_fabric_ingress_from_frame(
+                    // #946 Phase 1 stage 7+8: parse session flow and
+                    // learn the source-side dynamic neighbor.
+                    // `learn_from_live_frame` MUST be
+                    // `owned_packet_frame.is_none()` — preserves the
+                    // GRE guard at the original line 113 (neighbor
+                    // learning uses the live UMEM Ethernet frame so
+                    // the source MAC is the outer host's, not the
+                    // GRE tunnel egress).
+                    let flow = stage_parse_flow_and_learn(
+                        unsafe { &*area },
+                        desc,
                         packet_frame,
                         meta,
-                        worker_ctx.forwarding,
+                        owned_packet_frame.is_none(),
+                        &mut binding.last_learned_neighbor,
+                        worker_ctx,
                     );
-                    let packet_fabric_ingress = ingress_zone_override.is_some()
-                        || ingress_is_fabric_overlay(worker_ctx.forwarding, meta.ingress_ifindex as i32);
-                    // Flag fabric-ingress packets so rewrite functions skip TTL
-                    // decrement. The sending peer already decremented TTL when
-                    // it forwarded the packet across the fabric link.
-                    if packet_fabric_ingress {
-                        meta.meta_flags |= FABRIC_INGRESS_FLAG;
+                    // #946 Phase 1 stage 9: fabric-ingress
+                    // classification. Mutates meta.meta_flags. MUST
+                    // run before screen/IPsec/flow-cache because they
+                    // read meta.meta_flags downstream.
+                    let FabricIngressOutcome {
+                        ingress_zone_override,
+                        packet_fabric_ingress,
+                    } = stage_classify_fabric_ingress(packet_frame, &mut meta, worker_ctx);
+                    // #946 Phase 1 stage 10: screen / IDS slow-path.
+                    // Caller still owns the recycle push (matches
+                    // original code's pattern).
+                    if let StageOutcome::RecycleAndContinue = stage_screen_check(
+                        flow.as_ref(),
+                        packet_frame,
+                        meta,
+                        ingress_zone_override,
+                        now_secs,
+                        screen,
+                        &binding.live,
+                        worker_ctx,
+                    ) {
+                        binding.scratch.scratch_recycle.push(desc.addr);
+                        continue;
                     }
-                    // Screen/IDS check — runs BEFORE session lookup.
-                    // Resolve ingress zone name for screen profile lookup.
-                    // Slow path — only runs when screen profiles configured.
-                    // #919: ingress_zone_override is now Option<u16>; resolve
-                    // ID → name via zone_id_to_name when present.
-                    if screen.has_profiles() {
-                        if let Some(flow) = flow.as_ref() {
-                            let zone_name = ingress_zone_override
-                                .and_then(|id| {
-                                    worker_ctx.forwarding.zone_id_to_name.get(&id).map(|s| s.as_str())
-                                })
-                                .or_else(|| {
-                                    // #921: ifindex → u16 → name via
-                                    // zone_id_to_name. Slow path (only
-                                    // when screen profiles configured).
-                                    worker_ctx.forwarding
-                                        .ifindex_to_zone_id
-                                        .get(&(meta.ingress_ifindex as i32))
-                                        .and_then(|id| worker_ctx.forwarding.zone_id_to_name.get(id))
-                                        .map(|s| s.as_str())
-                                });
-                            if let Some(zone_name) = zone_name {
-                                let l3_off = if meta.ingress_vlan_id > 0 {
-                                    18
-                                } else {
-                                    14 // default Ethernet header
-                                };
-                                let screen_pkt = extract_screen_info(
-                                    packet_frame,
-                                    meta.addr_family,
-                                    meta.protocol,
-                                    meta.tcp_flags,
-                                    meta.pkt_len,
-                                    flow.src_ip,
-                                    flow.dst_ip,
-                                    flow.forward_key.src_port,
-                                    flow.forward_key.dst_port,
-                                    l3_off,
-                                );
-                                if let ScreenVerdict::Drop(_reason) =
-                                    screen.check_packet(zone_name, &screen_pkt, now_secs)
-                                {
-                                    binding.live.screen_drops.fetch_add(1, Ordering::Relaxed);
-                                    binding.scratch.scratch_recycle.push(desc.addr);
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-                    // IPsec passthrough: ESP (proto 50) and IKE (UDP 500/4500)
-                    // must be handled by the kernel XFRM subsystem. Send these
-                    // packets to the slow-path TUN device so the kernel can
-                    // encrypt/decrypt via XFRM, then recycle the UMEM frame.
-                    if let Some(flow) = flow.as_ref() {
-                        if is_ipsec_traffic(meta.protocol, flow.forward_key.dst_port) {
-                            let ipsec_decision = SessionDecision {
-                                resolution: ForwardingResolution {
-                                    disposition: ForwardingDisposition::LocalDelivery,
-                                    local_ifindex: 0,
-                                    egress_ifindex: 0,
-                                    tx_ifindex: 0,
-                                    tunnel_endpoint_id: 0,
-                                    next_hop: None,
-                                    neighbor_mac: None,
-                                    src_mac: None,
-                                    tx_vlan_id: 0,
-                                },
-                                nat: NatDecision::default(),
-                            };
-                            maybe_reinject_slow_path_from_frame(
-                                &worker_ctx.ident,
-                                &binding.live,
-                                worker_ctx.slow_path,
-                                worker_ctx.local_tunnel_deliveries,
-                                packet_frame,
-                                meta,
-                                ipsec_decision,
-                                worker_ctx.recent_exceptions,
-                                "slow_path",
-                                worker_ctx.forwarding,
-                            );
-                            binding.scratch.scratch_recycle.push(desc.addr);
-                            continue;
-                        }
+                    // #946 Phase 1 stage 11: IPsec passthrough. ESP
+                    // (proto 50) and IKE (UDP 500/4500) reinject via
+                    // the slow-path TUN; recycle the UMEM frame.
+                    if let StageOutcome::RecycleAndContinue = stage_ipsec_passthrough_check(
+                        flow.as_ref(),
+                        packet_frame,
+                        meta,
+                        &binding.live,
+                        worker_ctx,
+                    ) {
+                        binding.scratch.scratch_recycle.push(desc.addr);
+                        continue;
                     }
                     // ── Flow cache fast path ────────────────────────────
                     // For established TCP (ACK-only) and UDP, check the per-

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -1,0 +1,320 @@
+//! #946 Phase 1 — per-packet pipeline stages.
+//!
+//! Pure code-motion extraction of seven sub-stages out of the
+//! `poll_binding_process_descriptor` while-let body. No batch
+//! reordering, no behavioral change. Each helper here is the
+//! direct semantic equivalent of the inline block it replaces.
+//!
+//! Stages owned by Phase 1:
+//! - stage 5: link-layer (ARP/NDP) classify  → [stage_link_layer_classify]
+//! - stage 6: native GRE decap               → [stage_native_gre_decap]
+//! - stage 7+8: parse flow + learn neighbor  → [stage_parse_flow_and_learn]
+//! - stage 9: fabric-ingress classification  → [stage_classify_fabric_ingress]
+//! - stage 10: screen / IDS slow-path        → [stage_screen_check]
+//! - stage 11: IPsec passthrough             → [stage_ipsec_passthrough_check]
+//!
+//! Stages NOT in scope (kept inline in `poll_descriptor.rs` for
+//! Phase 1; will be tackled in follow-up phases):
+//! - stages 1-4: rx telemetry, parse meta, classify, slice
+//! - stages 12+: flow-cache fast path, session lookup, slow-path
+//!   policy/NAT/forwarding, reverse-NAT/ICMP, MissingNeighbor
+//!
+//! See `docs/pr/946-pipeline-phase1/plan.md` for the full plan,
+//! the 9-continue table, and the hidden-invariants list.
+
+use super::*;
+
+/// Generic outcome for a per-packet stage. The `RecycleAndContinue`
+/// arm signals that the caller should push `desc.addr` to
+/// `binding.scratch.scratch_recycle` and `continue` the while-let.
+/// `Continue(T)` carries the stage's output to the next stage.
+pub(super) enum StageOutcome<T> {
+    RecycleAndContinue,
+    Continue(T),
+}
+
+/// Output of `stage_classify_fabric_ingress`. The stage *also*
+/// mutates `meta.meta_flags` to set `FABRIC_INGRESS_FLAG`; this
+/// struct carries the two return values the caller needs separately.
+pub(super) struct FabricIngressOutcome {
+    pub(super) ingress_zone_override: Option<u16>,
+    pub(super) packet_fabric_ingress: bool,
+}
+
+/// Stage 5 — ARP / NDP link-layer classification.
+///
+/// ARP frames (Reply / Request / Other) are recycled without
+/// flowing through the rest of the pipeline. ARP Reply additionally
+/// learns a dynamic neighbor and adds a kernel ARP entry.
+///
+/// NDP NA with a Target Link-Layer Address option learns a dynamic
+/// neighbor and adds a kernel neighbor entry, then falls through to
+/// normal IPv6 forwarding (the NA frame itself transits the
+/// firewall).
+///
+/// Plain non-link-layer packets fall through unchanged.
+///
+/// Side effects on `worker_ctx.dynamic_neighbors` (interior
+/// mutability behind `Arc`) and the kernel ARP/NDP table are kept
+/// inside this helper — the caller does not need visibility into
+/// the learned neighbor for the same packet.
+pub(super) fn stage_link_layer_classify(
+    raw_frame: &[u8],
+    meta: UserspaceDpMeta,
+    worker_ctx: &WorkerContext,
+) -> StageOutcome<()> {
+    match parser::classify_arp(raw_frame) {
+        parser::ArpClassification::Reply(arp) => {
+            worker_ctx.dynamic_neighbors.insert(
+                (meta.ingress_ifindex as i32, arp.sender_ip),
+                NeighborEntry {
+                    mac: arp.sender_mac,
+                },
+            );
+            let neigh_ifindex = resolve_ingress_logical_ifindex(
+                worker_ctx.forwarding,
+                meta.ingress_ifindex as i32,
+                meta.ingress_vlan_id,
+            )
+            .unwrap_or(meta.ingress_ifindex as i32);
+            add_kernel_neighbor(neigh_ifindex, arp.sender_ip, arp.sender_mac);
+            return StageOutcome::RecycleAndContinue;
+        }
+        parser::ArpClassification::OtherArp => {
+            return StageOutcome::RecycleAndContinue;
+        }
+        parser::ArpClassification::NotArp => {}
+    }
+    if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
+        && let Some(mac) = na.target_mac
+    {
+        worker_ctx.dynamic_neighbors.insert(
+            (meta.ingress_ifindex as i32, na.target_ip),
+            NeighborEntry { mac },
+        );
+        let neigh_ifindex = resolve_ingress_logical_ifindex(
+            worker_ctx.forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        add_kernel_neighbor(neigh_ifindex, na.target_ip, mac);
+    }
+    StageOutcome::Continue(())
+}
+
+/// Stage 6 — native GRE decapsulation.
+///
+/// Returns the (possibly-updated) `meta` and the optional owned
+/// decap frame. Caller binds the active slice locally:
+///
+/// ```text
+/// let (meta, owned) = stage_native_gre_decap(raw_frame, meta, ...);
+/// let packet_frame = owned.as_deref().unwrap_or(raw_frame);
+/// ```
+///
+/// `owned_packet_frame: Option<Vec<u8>>` MUST be a `mut` binding at
+/// the call site because deferred stage-12+ code calls `.take()` on
+/// it (poll_descriptor.rs lines 419, 583, 1814).
+///
+/// The helper does NOT return the active slice — that would be a
+/// self-referential return type (the slice would borrow from the
+/// returned `Vec`).
+pub(super) fn stage_native_gre_decap(
+    raw_frame: &[u8],
+    meta: UserspaceDpMeta,
+    forwarding: &ForwardingState,
+) -> (UserspaceDpMeta, Option<Vec<u8>>) {
+    let native_gre_packet = try_native_gre_decap_from_frame(raw_frame, meta, forwarding);
+    let new_meta = native_gre_packet
+        .as_ref()
+        .map(|packet| packet.meta)
+        .unwrap_or(meta);
+    let owned_packet_frame = native_gre_packet.map(|packet| packet.frame);
+    (new_meta, owned_packet_frame)
+}
+
+/// Stage 7+8 — parse session flow and learn the source-side
+/// dynamic neighbor.
+///
+/// `learn_from_live_frame` MUST be `owned_packet_frame.is_none()`
+/// at the call site. Mirrors the GRE guard at
+/// poll_descriptor.rs:113 — neighbor learning uses the un-decapped
+/// raw_frame (via `area`/`desc`) so the source MAC comes from the
+/// live UMEM Ethernet frame; learning from a decapped GRE inner
+/// frame would record the GRE tunnel's egress MAC instead of the
+/// outer host's.
+///
+/// Side effects: `worker_ctx.dynamic_neighbors` (interior mut),
+/// `last_learned_neighbor` (caller's &mut), kernel neighbor table.
+pub(super) fn stage_parse_flow_and_learn(
+    area: &MmapArea,
+    desc: XdpDesc,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    learn_from_live_frame: bool,
+    last_learned_neighbor: &mut Option<LearnedNeighborKey>,
+    worker_ctx: &WorkerContext,
+) -> Option<SessionFlow> {
+    let flow = parse_session_flow_from_bytes(packet_frame, meta);
+    if learn_from_live_frame
+        && let Some(flow) = flow.as_ref()
+    {
+        learn_dynamic_neighbor_from_packet(
+            area,
+            desc,
+            meta,
+            flow.src_ip,
+            last_learned_neighbor,
+            worker_ctx.forwarding,
+            worker_ctx.dynamic_neighbors,
+        );
+    }
+    flow
+}
+
+/// Stage 9 — fabric-ingress classification.
+///
+/// Mutates `meta.meta_flags` to set `FABRIC_INGRESS_FLAG` when the
+/// packet's ingress is a fabric overlay or carries a zone-encoded
+/// fabric ingress marker. Returns the discovered zone override
+/// (used by the screen stage) and the fabric flag (used by
+/// downstream forwarding).
+///
+/// This stage MUST run before screen / IPsec / flow-cache because
+/// those downstream stages read `meta.meta_flags` and the
+/// `FABRIC_INGRESS_FLAG` is required to skip TTL decrement on
+/// fabric-traversed packets (the sending peer already decremented
+/// TTL when forwarding across the fabric link).
+pub(super) fn stage_classify_fabric_ingress(
+    packet_frame: &[u8],
+    meta: &mut UserspaceDpMeta,
+    worker_ctx: &WorkerContext,
+) -> FabricIngressOutcome {
+    let ingress_zone_override =
+        parse_zone_encoded_fabric_ingress_from_frame(packet_frame, *meta, worker_ctx.forwarding);
+    let packet_fabric_ingress = ingress_zone_override.is_some()
+        || ingress_is_fabric_overlay(worker_ctx.forwarding, meta.ingress_ifindex as i32);
+    if packet_fabric_ingress {
+        meta.meta_flags |= FABRIC_INGRESS_FLAG;
+    }
+    FabricIngressOutcome {
+        ingress_zone_override,
+        packet_fabric_ingress,
+    }
+}
+
+/// Stage 10 — screen / IDS slow-path check.
+///
+/// Only runs when screen profiles are configured (the `has_profiles`
+/// gate). Resolves the ingress zone name (preferring the
+/// fabric-zone override from stage 9), extracts a `ScreenPacketInfo`
+/// from the packet, and runs `screen.check_packet`. On a Drop
+/// verdict, increments `binding_live.screen_drops` and returns
+/// `RecycleAndContinue` — the caller still owns the recycle push
+/// (matching the original code's pattern).
+pub(super) fn stage_screen_check(
+    flow: Option<&SessionFlow>,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    ingress_zone_override: Option<u16>,
+    now_secs: u64,
+    screen: &mut ScreenState,
+    binding_live: &BindingLiveState,
+    worker_ctx: &WorkerContext,
+) -> StageOutcome<()> {
+    if !screen.has_profiles() {
+        return StageOutcome::Continue(());
+    }
+    let Some(flow) = flow else {
+        return StageOutcome::Continue(());
+    };
+    let zone_name = ingress_zone_override
+        .and_then(|id| {
+            worker_ctx
+                .forwarding
+                .zone_id_to_name
+                .get(&id)
+                .map(|s| s.as_str())
+        })
+        .or_else(|| {
+            worker_ctx
+                .forwarding
+                .ifindex_to_zone_id
+                .get(&(meta.ingress_ifindex as i32))
+                .and_then(|id| worker_ctx.forwarding.zone_id_to_name.get(id))
+                .map(|s| s.as_str())
+        });
+    let Some(zone_name) = zone_name else {
+        return StageOutcome::Continue(());
+    };
+    let l3_off = if meta.ingress_vlan_id > 0 { 18 } else { 14 };
+    let screen_pkt = extract_screen_info(
+        packet_frame,
+        meta.addr_family,
+        meta.protocol,
+        meta.tcp_flags,
+        meta.pkt_len,
+        flow.src_ip,
+        flow.dst_ip,
+        flow.forward_key.src_port,
+        flow.forward_key.dst_port,
+        l3_off,
+    );
+    if let ScreenVerdict::Drop(_reason) = screen.check_packet(zone_name, &screen_pkt, now_secs) {
+        binding_live.screen_drops.fetch_add(1, Ordering::Relaxed);
+        return StageOutcome::RecycleAndContinue;
+    }
+    StageOutcome::Continue(())
+}
+
+/// Stage 11 — IPsec passthrough.
+///
+/// ESP (proto 50) and IKE (UDP 500/4500) must transit the kernel
+/// XFRM subsystem. On a match, this stage builds a synthetic
+/// `SessionDecision` with `LocalDelivery` disposition and
+/// reinjects the packet via the slow-path TUN device, then signals
+/// `RecycleAndContinue` so the caller drops the UMEM frame.
+///
+/// Non-IPsec packets fall through unchanged.
+pub(super) fn stage_ipsec_passthrough_check(
+    flow: Option<&SessionFlow>,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    binding_live: &BindingLiveState,
+    worker_ctx: &WorkerContext,
+) -> StageOutcome<()> {
+    let Some(flow) = flow else {
+        return StageOutcome::Continue(());
+    };
+    if !is_ipsec_traffic(meta.protocol, flow.forward_key.dst_port) {
+        return StageOutcome::Continue(());
+    }
+    let ipsec_decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::LocalDelivery,
+            local_ifindex: 0,
+            egress_ifindex: 0,
+            tx_ifindex: 0,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: None,
+            src_mac: None,
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    };
+    maybe_reinject_slow_path_from_frame(
+        &worker_ctx.ident,
+        binding_live,
+        worker_ctx.slow_path,
+        worker_ctx.local_tunnel_deliveries,
+        packet_frame,
+        meta,
+        ipsec_decision,
+        worker_ctx.recent_exceptions,
+        "slow_path",
+        worker_ctx.forwarding,
+    );
+    StageOutcome::RecycleAndContinue
+}

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -58,6 +58,7 @@ pub(super) struct FabricIngressOutcome {
 /// mutability behind `Arc`) and the kernel ARP/NDP table are kept
 /// inside this helper — the caller does not need visibility into
 /// the learned neighbor for the same packet.
+#[inline]
 pub(super) fn stage_link_layer_classify(
     raw_frame: &[u8],
     meta: UserspaceDpMeta,
@@ -114,12 +115,19 @@ pub(super) fn stage_link_layer_classify(
 /// ```
 ///
 /// `owned_packet_frame: Option<Vec<u8>>` MUST be a `mut` binding at
-/// the call site because deferred stage-12+ code calls `.take()` on
-/// it (poll_descriptor.rs lines 419, 583, 1814).
+/// the call site because the deferred stage-12+ code in
+/// `poll_descriptor.rs` calls `.take()` on it (grep
+/// `owned_packet_frame.take(` — the deferred flow-cache,
+/// session-hit reverse-NAT, and missing-neighbor side-queue paths
+/// each move the owned decap frame out before pushing the
+/// resulting forward request). Symbol references rather than line
+/// numbers because the line numbers drift any time a stage above
+/// is touched.
 ///
 /// The helper does NOT return the active slice — that would be a
 /// self-referential return type (the slice would borrow from the
 /// returned `Vec`).
+#[inline]
 pub(super) fn stage_native_gre_decap(
     raw_frame: &[u8],
     meta: UserspaceDpMeta,
@@ -147,6 +155,7 @@ pub(super) fn stage_native_gre_decap(
 ///
 /// Side effects: `worker_ctx.dynamic_neighbors` (interior mut),
 /// `last_learned_neighbor` (caller's &mut), kernel neighbor table.
+#[inline]
 pub(super) fn stage_parse_flow_and_learn(
     area: &MmapArea,
     desc: XdpDesc,
@@ -186,6 +195,7 @@ pub(super) fn stage_parse_flow_and_learn(
 /// `FABRIC_INGRESS_FLAG` is required to skip TTL decrement on
 /// fabric-traversed packets (the sending peer already decremented
 /// TTL when forwarding across the fabric link).
+#[inline]
 pub(super) fn stage_classify_fabric_ingress(
     packet_frame: &[u8],
     meta: &mut UserspaceDpMeta,
@@ -213,6 +223,7 @@ pub(super) fn stage_classify_fabric_ingress(
 /// verdict, increments `binding_live.screen_drops` and returns
 /// `RecycleAndContinue` — the caller still owns the recycle push
 /// (matching the original code's pattern).
+#[inline]
 pub(super) fn stage_screen_check(
     flow: Option<&SessionFlow>,
     packet_frame: &[u8],
@@ -277,6 +288,7 @@ pub(super) fn stage_screen_check(
 /// `RecycleAndContinue` so the caller drops the UMEM frame.
 ///
 /// Non-IPsec packets fall through unchanged.
+#[inline]
 pub(super) fn stage_ipsec_passthrough_check(
     flow: Option<&SessionFlow>,
     packet_frame: &[u8],


### PR DESCRIPTION
## Summary

First phase of #946 (Pipeline / Chain of Responsibility). Pure code-motion refactor — no batch reordering, no behavioral change. Seven per-packet sub-stages move out of the 2,400-LOC `poll_binding_process_descriptor` while-let body into named helpers in a new sibling module `afxdp/poll_stages.rs`:

| Stage | Helper |
|-------|--------|
| 5 | `stage_link_layer_classify` (ARP / NDP) |
| 6 | `stage_native_gre_decap` |
| 7+8 | `stage_parse_flow_and_learn` |
| 9 | `stage_classify_fabric_ingress` |
| 10 | `stage_screen_check` |
| 11 | `stage_ipsec_passthrough_check` |

Stages 1-4 (rx telemetry, parse meta, classify, slice) and 12-16 (flow-cache, session lookup, slow-path policy/NAT/forwarding, reverse-NAT/ICMP, MissingNeighbor) explicitly stay inline as a **scope choice** — Phase 1 establishes the seams; Phase 2+ will tackle each remaining stage.

## Why this is shippable as one PR

- **Pure code motion**: each helper is the direct semantic equivalent of the inline block it replaces; control flow is preserved by the `StageOutcome<T>` enum's two arms.
- **No state shape changes**: BindingWorker, WorkerContext, sessions, screen, etc. all retain their access patterns.
- **No reordering of side effects**: dynamic neighbor learning, screen drops, recycle pushes, IPsec slow-path reinject all fire in the exact same order.
- **Borrow-checker clean**: `XdpDesc` and `UserspaceDpMeta` are `Copy`; `dynamic_neighbors` has interior mutability; the narrow `&mut binding.last_learned_neighbor` and `&mut meta` borrows don't overlap.

## Plan + adversarial review

Plan doc: `docs/pr/946-pipeline-phase1/plan.md`. Three rounds of Codex adversarial review before any code landed:

- **Round 1** PLAN-NEEDS-MAJOR — architectural defects (stage inventory incomplete, scratch_forwards claim overbroad, GRE signature self-referential, two-arm StageOutcome too narrow, false #1127 dependency).
- **Round 2** PLAN-NEEDS-MAJOR — 5 tactical signature defects (parse_and_classify dropped side effects; parse_flow_and_learn missing GRE guard; screen_check missing packet_frame/now_secs; stage inventory still missed 3 continues; main-loop sketch wasn't compile-realistic).
- **Round 3** PLAN-NEEDS-MINOR — 4 doc-cleanup items (continue table line 397 wrong, stale type names, stale LinkLayerOutcome refs, two new hidden invariants).

All findings addressed in v3.1.

## Test plan

- [x] `cargo build` clean (93 pre-existing warnings, 0 new)
- [x] 952/952 cargo tests pass (`cargo test --release`)
- [x] `flow_cache` named-test 5/5 flake check clean
- [x] 30 Go test packages pass
- [x] Deploy clean on loss userspace cluster (rolling secondary then primary)
- [x] v4 smoke: 956 Mbps, 0 retrans against 172.16.80.200
- [x] v6 smoke: 946 Mbps, 0 retrans against 2001:559:8585:80::200

## Diff

3 files, +393/-161:
- `userspace-dp/src/afxdp/poll_stages.rs` (new, +321)
- `userspace-dp/src/afxdp/poll_descriptor.rs` (-161 inline blocks → +66 stage calls)
- `userspace-dp/src/afxdp/mod.rs` (+5 module declaration)
- `docs/pr/946-pipeline-phase1/plan.md` (plan doc, separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)