### PR TITLE
docs(#946): plan.md — drop stale stage_parse_and_classify refs in invariants section

### DIFF
--- a/docs/pr/946-pipeline-phase1/plan.md
+++ b/docs/pr/946-pipeline-phase1/plan.md
@@ -466,13 +466,16 @@ Phase 1 preserves it.
   - **Metadata/disposition side effects fire BEFORE recycle.**
     `record_disposition` and `record_exception` both update
     `binding.live.*` and `recent_exceptions` before the recycle
-    push. v3's stage_parse_and_classify keeps this ordering by
-    firing the side effects internally before returning
-    RecycleAndContinue.
+    push. In v3.2 (as shipped) stages 2-4 stay inline so this
+    ordering is preserved naturally by the unchanged
+    if-let-else structure at the bottom of the loop body
+    (poll_descriptor.rs:2181-2204) — record_disposition and
+    record_exception fire there, before the trailing
+    `if recycle_now` block.
   - **`validated_packets`/`validated_bytes` increment BEFORE
     raw-frame slice success** (poll_descriptor.rs:47–48 vs 49).
-    v3's stage_parse_and_classify increments these between
-    classify and slice.
+    Preserved naturally by the inline code path; stages 2-4
+    were not extracted in v3.2.
   - **Dynamic-neighbor learning only for non-GRE-owned frames**
     (line 113 guard). v3's `learn_from_live_frame` flag passes
     `owned_packet_frame.is_none()` from the caller.


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #1179 (#946 Phase 1).

The plan.md hidden-invariants section at lines 469 and 474 still claimed two invariants were preserved by `v3's stage_parse_and_classify` — but v3.2 (as shipped) doesn't extract stages 2-4; they stay inline. The invariants are preserved naturally by the unchanged inline if-let-else structure, not by an extracted helper that doesn't exist.

8-line edit. No code change.

## Test plan

- [x] Doc-only — no build/test/smoke needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)