### PR TITLE
fix(cos): skip CoS state for forwarding-only interfaces (10× reverse-throughput regression)

### DIFF
--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -651,6 +651,7 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
         // (transparent-root token top-up / queue-service wakeup) still
         // apply when at least one CoS knob is set.
         let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
+            || iface.cos_shaping_burst_bytes > 0
             || !iface.cos_scheduler_map.is_empty()
             || !iface.cos_dscp_classifier.is_empty()
             || !iface.cos_ieee8021_classifier.is_empty()

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -638,18 +638,30 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
 
     let mut state = CoSState::default();
     for iface in &snapshot.interfaces {
-        // #916: zero `cos_shaping_rate_bytes_per_sec` is a valid Junos
-        // configuration meaning "no interface-level shaping cap"
-        // (transparent root) — but only when the interface actually
-        // participates in CoS (scheduler-map / classifier / rewrite-rule).
-        // Interfaces with no CoS configuration at all (e.g. a plain
-        // forwarding-only LAN egress) must NOT get a CoSState entry,
-        // because that would funnel every TX through the per-interface
-        // owner worker via cross-binding redirect — collapsing 6-worker
-        // parallelism to one CPU and capping reverse throughput at
-        // ~2 Gbps instead of ~22 Gbps. f0e364d7's runtime fast paths
-        // (transparent-root token top-up / queue-service wakeup) still
-        // apply when at least one CoS knob is set.
+        // Skip interfaces that do not participate in CoS at all.
+        //
+        // An interface participates in CoS when ANY of these knobs is set:
+        //   - `cos_shaping_rate_bytes_per_sec` (interface shaping cap)
+        //   - `cos_shaping_burst_bytes`        (shaping burst override)
+        //   - `cos_scheduler_map`              (per-class scheduling)
+        //   - `cos_dscp_classifier`            (DSCP → forwarding-class)
+        //   - `cos_ieee8021_classifier`        (802.1p → forwarding-class)
+        //   - `cos_dscp_rewrite_rule`          (egress DSCP rewrite)
+        //
+        // f0e364d7 (#916) removed the prior `shaping_rate == 0` skip so
+        // that zero-shaping-rate-with-classes interfaces would get a
+        // transparent-root CoS runtime instead of being silently dropped.
+        // That side-effect added every forwarding-only interface (no CoS
+        // knobs at all) to CoSState too — and a CoSState entry triggers
+        // the cross-binding redirect that funnels every TX through the
+        // per-interface owner worker, collapsing 6-worker parallelism
+        // to one CPU and capping reverse throughput at ~2 Gbps instead
+        // of ~22 Gbps on this lab.
+        //
+        // The transparent-root runtime fast paths
+        // (`maybe_top_up_cos_root_lease` / `estimate_cos_queue_wakeup_tick`
+        // rate-zero handling) still apply when at least one CoS knob is
+        // set; only the no-CoS-at-all case is skipped here.
         let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
             || iface.cos_shaping_burst_bytes > 0
             || !iface.cos_scheduler_map.is_empty()

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -648,12 +648,21 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
         //   - `cos_dscp_rewrite_rule`          (egress DSCP rewrite)
         //
         // `cos_shaping_burst_bytes` is intentionally NOT a standalone arm.
-        // In Junos config grammar, `burst-size` is parsed only as a
-        // sub-knob of `shaping-rate`, so a snapshot can never carry
-        // burst-only without also carrying shaping-rate. Treating
-        // burst-bytes as standalone admission would reintroduce the
-        // owner-worker redirect for any pathological snapshot shape that
-        // happened to set burst alone, with no real CoS behavior to apply.
+        // The Go compiler does in fact allow a committed config to carry
+        // burst-only without rate (`pkg/config/compiler_class_of_service.go`
+        // accepts `BurstSizeBytes > 0` independently of `ShapingRateBytes`),
+        // but a burst value without ANY of {rate, scheduler-map, classifier,
+        // rewrite-rule} has no CoS behavior to apply: nothing classifies
+        // packets into queues, nothing schedules between queues, and the
+        // root rate is unlimited. Admitting such an interface to CoSState
+        // therefore produces no shaping, classification, or rewrite — only
+        // the cross-binding owner-worker redirect, i.e. the regression this
+        // gate exists to prevent.
+        //
+        // Pre-f0e364d7 baseline already skipped this case (the old
+        // `shaping_rate == 0` skip caught burst-only too); we restore that
+        // behavior for the no-real-CoS-effect case while preserving
+        // f0e364d7's deadlock fix when at least one CoS knob is set.
         //
         // f0e364d7 (#916) removed the prior `shaping_rate == 0` skip so
         // that zero-shaping-rate-with-classes interfaces would get a

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -730,24 +730,62 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
             }
         }
         let scheduler_map_resolved_to_queues = !queues.is_empty();
-        let dscp_classifier_has_mappings = dscp_classifiers
+
+        // Determine the set of (queue_id, forwarding_class) pairs that this
+        // interface will actually materialize at runtime. If the
+        // scheduler-map resolved, those are the configured queues. If not,
+        // the synthetic default best-effort queue (queue_id=0,
+        // class="best-effort") is added later — but ONLY if we admit the
+        // interface, so we model it here for the gate's purposes.
+        let (iface_queue_ids, iface_classes): (Vec<u8>, Vec<&str>) =
+            if scheduler_map_resolved_to_queues {
+                (
+                    queues.iter().map(|q| q.queue_id).collect(),
+                    queues.iter().map(|q| q.forwarding_class.as_str()).collect(),
+                )
+            } else {
+                (vec![0], vec!["best-effort"])
+            };
+
+        // A classifier arm contributes only if it maps at least one
+        // DSCP/802.1p code-point to a queue_id the interface actually
+        // materializes. A classifier mapping to queue 5 on an interface
+        // that only has queue 0 admits the interface for nothing —
+        // packets land in `resolve_cos_queue_idx` and get dropped, the
+        // owner-worker redirect engages, and no observable classification
+        // happens. Same logic for the rewrite-rule: it contributes only
+        // if it has an entry for a forwarding-class the interface
+        // materializes.
+        let dscp_classifier_targets_iface_queue = dscp_classifiers
             .get(&iface.cos_dscp_classifier)
-            .map(|c| !c.queue_by_dscp.is_empty())
+            .map(|c| {
+                c.queue_by_dscp
+                    .values()
+                    .any(|q| iface_queue_ids.contains(q))
+            })
             .unwrap_or(false);
-        let ieee8021_classifier_has_mappings = ieee8021_classifiers
+        let ieee8021_classifier_targets_iface_queue = ieee8021_classifiers
             .get(&iface.cos_ieee8021_classifier)
-            .map(|c| !c.queue_by_pcp.is_empty())
+            .map(|c| {
+                c.queue_by_pcp
+                    .values()
+                    .any(|q| iface_queue_ids.contains(q))
+            })
             .unwrap_or(false);
-        let dscp_rewrite_has_mappings = dscp_rewrite_rule
-            .map(|r| !r.dscp_by_forwarding_class.is_empty())
+        let dscp_rewrite_targets_iface_class = dscp_rewrite_rule
+            .map(|r| {
+                r.dscp_by_forwarding_class
+                    .keys()
+                    .any(|fc| iface_classes.contains(&fc.as_str()))
+            })
             .unwrap_or(false);
 
         // Post-build gate. See comment above for rationale.
         let contributes_usable_cos_state = iface.cos_shaping_rate_bytes_per_sec > 0
             || scheduler_map_resolved_to_queues
-            || dscp_classifier_has_mappings
-            || ieee8021_classifier_has_mappings
-            || dscp_rewrite_has_mappings;
+            || dscp_classifier_targets_iface_queue
+            || ieee8021_classifier_targets_iface_queue
+            || dscp_rewrite_targets_iface_class;
         if !contributes_usable_cos_state {
             continue;
         }

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -638,60 +638,49 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
 
     let mut state = CoSState::default();
     for iface in &snapshot.interfaces {
-        // Skip interfaces that do not participate in CoS at all.
+        // Skip interfaces that do not contribute any usable CoS state.
         //
         // f0e364d7 (#916) removed the prior `shaping_rate == 0` skip so
         // that zero-shaping-rate-with-classes interfaces would get a
         // transparent-root CoS runtime instead of being silently dropped.
-        // That side-effect added every forwarding-only interface to
-        // CoSState too — and a CoSState entry triggers the cross-binding
-        // redirect that funnels every TX through the per-interface owner
-        // worker, collapsing 6-worker parallelism to one CPU and capping
-        // reverse throughput at ~2 Gbps instead of ~22 Gbps on the loss
-        // userspace cluster.
+        // That side-effect added every interface that produced no usable
+        // CoS state to `CoSState` too — and any `CoSState` entry triggers
+        // the cross-binding redirect that funnels every TX through the
+        // per-interface owner worker, collapsing 6-worker parallelism
+        // to one CPU and capping reverse throughput at ~2 Gbps instead
+        // of ~22 Gbps on the loss userspace cluster.
         //
-        // An interface participates in CoS when ANY of these is set AND
-        // (for named references) actually resolves to something the
-        // builder can use:
-        //   - `cos_shaping_rate_bytes_per_sec > 0`     — interface shaping cap
-        //   - named scheduler-map present in config    — per-class scheduling
-        //   - named DSCP classifier present in config  — DSCP → fwd-class
-        //   - named 802.1p classifier present in config — 802.1p → fwd-class
-        //   - named DSCP rewrite-rule present in config — egress DSCP rewrite
+        // The fix is to gate on whether the interface PRODUCES anything
+        // useful — not on whether knob *names* are populated. We resolve
+        // the scheduler-map, DSCP classifier, 802.1p classifier, and
+        // DSCP rewrite-rule first, then only insert a `CoSState` entry
+        // when at least one of these is true:
+        //   - `cos_shaping_rate_bytes_per_sec > 0` (interface shaping cap)
+        //   - the scheduler-map resolved to ≥ 1 queue
+        //   - the DSCP classifier resolved to ≥ 1 mapping
+        //   - the 802.1p classifier resolved to ≥ 1 mapping
+        //   - the DSCP rewrite-rule resolved to ≥ 1 mapping
         //
-        // The resolution check is what distinguishes this from a plain
-        // is-non-empty test: a typo'd scheduler-map name ("wan-mapp" vs
-        // "wan-map") would otherwise pass an is-empty gate while resolving
-        // to no usable queues downstream, which would put the interface in
-        // CoSState with only the default best-effort queue — re-triggering
-        // the owner-worker redirect collapse for an interface that has no
-        // effective CoS policy.
+        // This cleanly handles every config shape that downstream falls
+        // back to a synthetic default best-effort queue with no
+        // classification/rewrite/rate cap — including:
+        //   - forwarding-only (no CoS knobs at all)
+        //   - burst-only without rate
+        //     (`pkg/config/compiler_class_of_service.go:285-312` allows
+        //     a committed snapshot of this shape; pre-f0e364d7 also
+        //     skipped it via the rate-zero skip, so admitting it would
+        //     be the divergence)
+        //   - typo'd named references (e.g. `wan-mapp` vs `wan-map`)
+        //     where the named entity does not exist
+        //   - empty named entities (e.g. a scheduler-map declared with
+        //     no entries — `compileClassOfService` keeps these)
+        //   - scheduler-maps / classifiers whose entries all reference
+        //     undefined forwarding-classes (warning-only configs that
+        //     survive validation)
         //
-        // `cos_shaping_burst_bytes` is intentionally NOT a standalone arm.
-        // The Go compiler does allow a committed config to carry
-        // `BurstSizeBytes > 0` independently of `ShapingRateBytes`
-        // (`pkg/config/compiler_class_of_service.go:285-312`). If admitted,
-        // a burst-only config WOULD carry an observable buffer-cap
-        // admission effect (`afxdp/cos/admission.rs` enforces
-        // `buffer_bytes` as a per-queue admission limit). But pre-f0e364d7
-        // also dropped this case (the rate-zero skip caught it), so this
-        // behavior was never observable in production prior to f0e364d7,
-        // and admitting a burst-only interface inevitably installs the
-        // cross-binding owner-worker redirect that the burst-cap
-        // observation alone cannot justify. We choose pre-f0e364d7-baseline
-        // semantics here: burst-only without any other CoS knob is
-        // skipped. f0e364d7's transparent-root runtime fast paths still
-        // apply when at least one resolvable CoS knob is set.
-        let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
-            || (!iface.cos_scheduler_map.is_empty()
-                && scheduler_maps.contains_key(&iface.cos_scheduler_map))
-            || (!iface.cos_dscp_classifier.is_empty()
-                && dscp_classifiers.contains_key(&iface.cos_dscp_classifier))
-            || (!iface.cos_ieee8021_classifier.is_empty()
-                && ieee8021_classifiers.contains_key(&iface.cos_ieee8021_classifier))
-            || (!iface.cos_dscp_rewrite_rule.is_empty()
-                && dscp_rewrite_rules.contains_key(&iface.cos_dscp_rewrite_rule));
-        if iface.ifindex <= 0 || !has_cos_config {
+        // f0e364d7's transparent-root runtime fast paths still apply
+        // whenever at least one resolution produces real CoS state.
+        if iface.ifindex <= 0 {
             continue;
         }
         let burst_bytes = if iface.cos_shaping_burst_bytes > 0 {
@@ -740,6 +729,33 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                 });
             }
         }
+        let scheduler_map_resolved_to_queues = !queues.is_empty();
+        let dscp_classifier_has_mappings = dscp_classifiers
+            .get(&iface.cos_dscp_classifier)
+            .map(|c| !c.queue_by_dscp.is_empty())
+            .unwrap_or(false);
+        let ieee8021_classifier_has_mappings = ieee8021_classifiers
+            .get(&iface.cos_ieee8021_classifier)
+            .map(|c| !c.queue_by_pcp.is_empty())
+            .unwrap_or(false);
+        let dscp_rewrite_has_mappings = dscp_rewrite_rule
+            .map(|r| !r.dscp_by_forwarding_class.is_empty())
+            .unwrap_or(false);
+
+        // Post-build gate. See comment above for rationale.
+        let contributes_usable_cos_state = iface.cos_shaping_rate_bytes_per_sec > 0
+            || scheduler_map_resolved_to_queues
+            || dscp_classifier_has_mappings
+            || ieee8021_classifier_has_mappings
+            || dscp_rewrite_has_mappings;
+        if !contributes_usable_cos_state {
+            continue;
+        }
+        let dscp_queue_by_dscp =
+            build_cos_dscp_queue_table(&iface.cos_dscp_classifier, &dscp_classifiers);
+        let ieee8021_queue_by_pcp =
+            build_cos_ieee8021_queue_table(&iface.cos_ieee8021_classifier, &ieee8021_classifiers);
+
         if queues.is_empty() {
             queues.push(CoSQueueConfig {
                 queue_id: 0,
@@ -774,14 +790,8 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
                 default_queue,
                 dscp_classifier: iface.cos_dscp_classifier.clone(),
                 ieee8021_classifier: iface.cos_ieee8021_classifier.clone(),
-                dscp_queue_by_dscp: build_cos_dscp_queue_table(
-                    &iface.cos_dscp_classifier,
-                    &dscp_classifiers,
-                ),
-                ieee8021_queue_by_pcp: build_cos_ieee8021_queue_table(
-                    &iface.cos_ieee8021_classifier,
-                    &ieee8021_classifiers,
-                ),
+                dscp_queue_by_dscp,
+                ieee8021_queue_by_pcp,
                 queue_by_forwarding_class,
                 queues,
             },

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -657,9 +657,14 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
         // when at least one of these is true:
         //   - `cos_shaping_rate_bytes_per_sec > 0` (interface shaping cap)
         //   - the scheduler-map resolved to ≥ 1 queue
-        //   - the DSCP classifier resolved to ≥ 1 mapping
-        //   - the 802.1p classifier resolved to ≥ 1 mapping
-        //   - the DSCP rewrite-rule resolved to ≥ 1 mapping
+        //   - the DSCP classifier targets ≥ 1 queue_id this interface
+        //     will materialize (real scheduler-map queues, or the
+        //     synthetic default best-effort queue 0)
+        //   - the 802.1p classifier targets ≥ 1 materialized queue_id
+        //     (same materialization rule)
+        //   - the DSCP rewrite-rule targets ≥ 1 materialized
+        //     forwarding-class (real scheduler-map class, or synthetic
+        //     "best-effort" if the rule has a "best-effort" entry)
         //
         // This cleanly handles every config shape that downstream falls
         // back to a synthetic default best-effort queue with no

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -642,11 +642,18 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
         //
         // An interface participates in CoS when ANY of these knobs is set:
         //   - `cos_shaping_rate_bytes_per_sec` (interface shaping cap)
-        //   - `cos_shaping_burst_bytes`        (shaping burst override)
         //   - `cos_scheduler_map`              (per-class scheduling)
         //   - `cos_dscp_classifier`            (DSCP → forwarding-class)
         //   - `cos_ieee8021_classifier`        (802.1p → forwarding-class)
         //   - `cos_dscp_rewrite_rule`          (egress DSCP rewrite)
+        //
+        // `cos_shaping_burst_bytes` is intentionally NOT a standalone arm.
+        // In Junos config grammar, `burst-size` is parsed only as a
+        // sub-knob of `shaping-rate`, so a snapshot can never carry
+        // burst-only without also carrying shaping-rate. Treating
+        // burst-bytes as standalone admission would reintroduce the
+        // owner-worker redirect for any pathological snapshot shape that
+        // happened to set burst alone, with no real CoS behavior to apply.
         //
         // f0e364d7 (#916) removed the prior `shaping_rate == 0` skip so
         // that zero-shaping-rate-with-classes interfaces would get a
@@ -663,7 +670,6 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
         // rate-zero handling) still apply when at least one CoS knob is
         // set; only the no-CoS-at-all case is skipped here.
         let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
-            || iface.cos_shaping_burst_bytes > 0
             || !iface.cos_scheduler_map.is_empty()
             || !iface.cos_dscp_classifier.is_empty()
             || !iface.cos_ieee8021_classifier.is_empty()

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -640,49 +640,57 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
     for iface in &snapshot.interfaces {
         // Skip interfaces that do not participate in CoS at all.
         //
-        // An interface participates in CoS when ANY of these knobs is set:
-        //   - `cos_shaping_rate_bytes_per_sec` (interface shaping cap)
-        //   - `cos_scheduler_map`              (per-class scheduling)
-        //   - `cos_dscp_classifier`            (DSCP → forwarding-class)
-        //   - `cos_ieee8021_classifier`        (802.1p → forwarding-class)
-        //   - `cos_dscp_rewrite_rule`          (egress DSCP rewrite)
-        //
-        // `cos_shaping_burst_bytes` is intentionally NOT a standalone arm.
-        // The Go compiler does in fact allow a committed config to carry
-        // burst-only without rate (`pkg/config/compiler_class_of_service.go`
-        // accepts `BurstSizeBytes > 0` independently of `ShapingRateBytes`),
-        // but a burst value without ANY of {rate, scheduler-map, classifier,
-        // rewrite-rule} has no CoS behavior to apply: nothing classifies
-        // packets into queues, nothing schedules between queues, and the
-        // root rate is unlimited. Admitting such an interface to CoSState
-        // therefore produces no shaping, classification, or rewrite — only
-        // the cross-binding owner-worker redirect, i.e. the regression this
-        // gate exists to prevent.
-        //
-        // Pre-f0e364d7 baseline already skipped this case (the old
-        // `shaping_rate == 0` skip caught burst-only too); we restore that
-        // behavior for the no-real-CoS-effect case while preserving
-        // f0e364d7's deadlock fix when at least one CoS knob is set.
-        //
         // f0e364d7 (#916) removed the prior `shaping_rate == 0` skip so
         // that zero-shaping-rate-with-classes interfaces would get a
         // transparent-root CoS runtime instead of being silently dropped.
-        // That side-effect added every forwarding-only interface (no CoS
-        // knobs at all) to CoSState too — and a CoSState entry triggers
-        // the cross-binding redirect that funnels every TX through the
-        // per-interface owner worker, collapsing 6-worker parallelism
-        // to one CPU and capping reverse throughput at ~2 Gbps instead
-        // of ~22 Gbps on this lab.
+        // That side-effect added every forwarding-only interface to
+        // CoSState too — and a CoSState entry triggers the cross-binding
+        // redirect that funnels every TX through the per-interface owner
+        // worker, collapsing 6-worker parallelism to one CPU and capping
+        // reverse throughput at ~2 Gbps instead of ~22 Gbps on the loss
+        // userspace cluster.
         //
-        // The transparent-root runtime fast paths
-        // (`maybe_top_up_cos_root_lease` / `estimate_cos_queue_wakeup_tick`
-        // rate-zero handling) still apply when at least one CoS knob is
-        // set; only the no-CoS-at-all case is skipped here.
+        // An interface participates in CoS when ANY of these is set AND
+        // (for named references) actually resolves to something the
+        // builder can use:
+        //   - `cos_shaping_rate_bytes_per_sec > 0`     — interface shaping cap
+        //   - named scheduler-map present in config    — per-class scheduling
+        //   - named DSCP classifier present in config  — DSCP → fwd-class
+        //   - named 802.1p classifier present in config — 802.1p → fwd-class
+        //   - named DSCP rewrite-rule present in config — egress DSCP rewrite
+        //
+        // The resolution check is what distinguishes this from a plain
+        // is-non-empty test: a typo'd scheduler-map name ("wan-mapp" vs
+        // "wan-map") would otherwise pass an is-empty gate while resolving
+        // to no usable queues downstream, which would put the interface in
+        // CoSState with only the default best-effort queue — re-triggering
+        // the owner-worker redirect collapse for an interface that has no
+        // effective CoS policy.
+        //
+        // `cos_shaping_burst_bytes` is intentionally NOT a standalone arm.
+        // The Go compiler does allow a committed config to carry
+        // `BurstSizeBytes > 0` independently of `ShapingRateBytes`
+        // (`pkg/config/compiler_class_of_service.go:285-312`). If admitted,
+        // a burst-only config WOULD carry an observable buffer-cap
+        // admission effect (`afxdp/cos/admission.rs` enforces
+        // `buffer_bytes` as a per-queue admission limit). But pre-f0e364d7
+        // also dropped this case (the rate-zero skip caught it), so this
+        // behavior was never observable in production prior to f0e364d7,
+        // and admitting a burst-only interface inevitably installs the
+        // cross-binding owner-worker redirect that the burst-cap
+        // observation alone cannot justify. We choose pre-f0e364d7-baseline
+        // semantics here: burst-only without any other CoS knob is
+        // skipped. f0e364d7's transparent-root runtime fast paths still
+        // apply when at least one resolvable CoS knob is set.
         let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
-            || !iface.cos_scheduler_map.is_empty()
-            || !iface.cos_dscp_classifier.is_empty()
-            || !iface.cos_ieee8021_classifier.is_empty()
-            || !iface.cos_dscp_rewrite_rule.is_empty();
+            || (!iface.cos_scheduler_map.is_empty()
+                && scheduler_maps.contains_key(&iface.cos_scheduler_map))
+            || (!iface.cos_dscp_classifier.is_empty()
+                && dscp_classifiers.contains_key(&iface.cos_dscp_classifier))
+            || (!iface.cos_ieee8021_classifier.is_empty()
+                && ieee8021_classifiers.contains_key(&iface.cos_ieee8021_classifier))
+            || (!iface.cos_dscp_rewrite_rule.is_empty()
+                && dscp_rewrite_rules.contains_key(&iface.cos_dscp_rewrite_rule));
         if iface.ifindex <= 0 || !has_cos_config {
             continue;
         }

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -640,12 +640,22 @@ fn build_cos_state(snapshot: &ConfigSnapshot) -> CoSState {
     for iface in &snapshot.interfaces {
         // #916: zero `cos_shaping_rate_bytes_per_sec` is a valid Junos
         // configuration meaning "no interface-level shaping cap"
-        // (transparent root). The runtime build path handles this
-        // case (see `maybe_top_up_cos_root_lease` /
-        // `estimate_cos_queue_wakeup_tick` rate-zero fast paths).
-        // Previously this condition skipped the entire interface,
-        // causing CoS classifier to silently not apply.
-        if iface.ifindex <= 0 {
+        // (transparent root) — but only when the interface actually
+        // participates in CoS (scheduler-map / classifier / rewrite-rule).
+        // Interfaces with no CoS configuration at all (e.g. a plain
+        // forwarding-only LAN egress) must NOT get a CoSState entry,
+        // because that would funnel every TX through the per-interface
+        // owner worker via cross-binding redirect — collapsing 6-worker
+        // parallelism to one CPU and capping reverse throughput at
+        // ~2 Gbps instead of ~22 Gbps. f0e364d7's runtime fast paths
+        // (transparent-root token top-up / queue-service wakeup) still
+        // apply when at least one CoS knob is set.
+        let has_cos_config = iface.cos_shaping_rate_bytes_per_sec > 0
+            || !iface.cos_scheduler_map.is_empty()
+            || !iface.cos_dscp_classifier.is_empty()
+            || !iface.cos_ieee8021_classifier.is_empty()
+            || !iface.cos_dscp_rewrite_rule.is_empty();
+        if iface.ifindex <= 0 || !has_cos_config {
             continue;
         }
         let burst_bytes = if iface.cos_shaping_burst_bytes > 0 {

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -756,9 +756,14 @@ fn build_cos_state_skips_interface_with_no_cos_config() {
 
 #[test]
 fn build_cos_state_admits_each_cos_field_in_isolation() {
-    // The skip predicate is an OR over six fields. Pin every arm so a
-    // future refactor can't silently drop one — Codex review on
-    // PR #1183 flagged this as coverage debt (Q5).
+    // The skip predicate is an OR over five arms (rate, scheduler-map,
+    // DSCP classifier, 802.1p classifier, DSCP rewrite). Pin every arm so
+    // a future refactor can't silently drop one — Codex review on
+    // PR #1183 flagged this as coverage debt (Q5). The sixth `InterfaceSnapshot`
+    // CoS field, `cos_shaping_burst_bytes`, is intentionally NOT a
+    // standalone arm; see the dedicated burst-only-skip test below and
+    // the gate comment in `forwarding_build.rs::build_cos_state` for
+    // rationale.
     let cos = ClassOfServiceSnapshot {
         forwarding_classes: vec![CoSForwardingClassSnapshot {
             name: "best-effort".into(),

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -753,3 +753,116 @@ fn build_cos_state_skips_interface_with_no_cos_config() {
         "interface with scheduler-map but no shaping-rate must still appear (transparent root)"
     );
 }
+
+#[test]
+fn build_cos_state_admits_each_cos_field_in_isolation() {
+    // The skip predicate is an OR over six fields. Pin every arm so a
+    // future refactor can't silently drop one — Codex review on
+    // PR #1183 flagged this as coverage debt (Q5).
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![CoSForwardingClassSnapshot {
+            name: "best-effort".into(),
+            queue: 0,
+        }],
+        schedulers: vec![],
+        scheduler_maps: vec![CoSSchedulerMapSnapshot {
+            name: "wan-map".into(),
+            entries: vec![CoSSchedulerMapEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                scheduler: String::new(),
+            }],
+        }],
+        dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+            name: "dscp-cls".into(),
+            entries: vec![CoSDSCPClassifierEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                dscp_values: vec![0],
+            }],
+        }],
+        ieee8021_classifiers: vec![CoSIEEE8021ClassifierSnapshot {
+            name: "p8021-cls".into(),
+            entries: vec![CoSIEEE8021ClassifierEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                code_points: vec![0],
+            }],
+        }],
+        dscp_rewrite_rules: vec![CoSDSCPRewriteRuleSnapshot {
+            name: "dscp-rw".into(),
+            entries: vec![CoSDSCPRewriteRuleEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                dscp_value: 0,
+            }],
+        }],
+    };
+    let cases: &[(i32, &str, InterfaceSnapshot)] = &[
+        (
+            201,
+            "shaping-rate only",
+            InterfaceSnapshot {
+                ifindex: 201,
+                cos_shaping_rate_bytes_per_sec: 1_000_000,
+                ..Default::default()
+            },
+        ),
+        (
+            202,
+            "burst-bytes only",
+            InterfaceSnapshot {
+                ifindex: 202,
+                cos_shaping_burst_bytes: 256_000,
+                ..Default::default()
+            },
+        ),
+        (
+            203,
+            "scheduler-map only",
+            InterfaceSnapshot {
+                ifindex: 203,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            204,
+            "DSCP classifier only",
+            InterfaceSnapshot {
+                ifindex: 204,
+                cos_dscp_classifier: "dscp-cls".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            205,
+            "802.1p classifier only",
+            InterfaceSnapshot {
+                ifindex: 205,
+                cos_ieee8021_classifier: "p8021-cls".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            206,
+            "DSCP rewrite-rule only",
+            InterfaceSnapshot {
+                ifindex: 206,
+                cos_dscp_rewrite_rule: "dscp-rw".into(),
+                ..Default::default()
+            },
+        ),
+    ];
+    for (ifindex, label, iface) in cases {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![iface.clone()],
+            class_of_service: Some(cos.clone()),
+            ..Default::default()
+        };
+        let state = build_cos_state(&snapshot);
+        assert!(
+            state.interfaces.contains_key(ifindex),
+            "{label}: interface must be admitted to CoSState (ifindex {ifindex})"
+        );
+    }
+}

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -995,3 +995,95 @@ fn build_cos_state_skips_interface_with_unresolvable_named_references() {
         );
     }
 }
+
+#[test]
+fn build_cos_state_skips_interface_with_resolvable_but_empty_scheduler_map() {
+    // Copilot review on PR #1183 caught this: `compileClassOfService`
+    // keeps a named scheduler-map even when it has zero entries, so
+    // a `contains_key` admission check would let a config like
+    // `set class-of-service interfaces ifd unit X scheduler-map empty-map`
+    // (with `empty-map` declared but no entries) pass the gate, then
+    // collapse downstream to a synthetic best-effort default queue —
+    // re-triggering the owner-worker redirect collapse for an interface
+    // with no effective CoS policy.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 401,
+            cos_shaping_rate_bytes_per_sec: 0,
+            cos_scheduler_map: "empty-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            schedulers: vec![],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "empty-map".into(),
+                entries: vec![], // <- the critical case: declared but empty
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&401),
+        "interface attached to a resolvable but empty scheduler-map must NOT enter CoSState"
+    );
+}
+
+#[test]
+fn build_cos_state_skips_interface_with_scheduler_map_all_undefined_forwarding_classes() {
+    // The Junos compiler emits a warning for scheduler-map entries that
+    // reference undefined forwarding-classes but does NOT drop the
+    // scheduler-map itself. After resolution, every entry's
+    // `class_to_queue.get` returns None, so `queues` is empty and the
+    // interface would otherwise fall through to the synthetic default
+    // best-effort queue. The post-build gate must reject this case so
+    // we don't reintroduce the owner-worker redirect on an interface
+    // with no effective CoS policy.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 402,
+            cos_shaping_rate_bytes_per_sec: 0,
+            cos_scheduler_map: "broken-map".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            // forwarding_classes intentionally does NOT include the
+            // class names referenced by `broken-map` below, so every
+            // entry collapses at `class_to_queue.get(&entry.forwarding_class)`.
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            schedulers: vec![],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "broken-map".into(),
+                entries: vec![
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "missing-class-a".into(),
+                        scheduler: String::new(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "missing-class-b".into(),
+                        scheduler: String::new(),
+                    },
+                ],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&402),
+        "scheduler-map whose entries all reference undefined forwarding-classes must NOT admit interface"
+    );
+}

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -1087,3 +1087,182 @@ fn build_cos_state_skips_interface_with_scheduler_map_all_undefined_forwarding_c
         "scheduler-map whose entries all reference undefined forwarding-classes must NOT admit interface"
     );
 }
+
+#[test]
+fn build_cos_state_skips_classifier_only_mapping_to_unmaterialized_queue() {
+    // An interface attaches a DSCP classifier whose entries map to
+    // forwarding-class `voice` (queue 5). The interface has NO
+    // scheduler-map, so the only queue it would materialize is the
+    // synthetic default best-effort (queue 0). The classifier maps to
+    // queue 5, which the interface won't have at runtime — packets
+    // matching the classifier would land in `resolve_cos_queue_idx`
+    // and get dropped, while the interface still installs the
+    // owner-worker redirect. Gate must skip such interfaces.
+    // (Copilot review on PR #1183 caught this.)
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![
+            CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            },
+            CoSForwardingClassSnapshot {
+                name: "voice".into(),
+                queue: 5,
+            },
+        ],
+        schedulers: vec![],
+        scheduler_maps: vec![],
+        dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+            name: "voice-cls".into(),
+            entries: vec![CoSDSCPClassifierEntrySnapshot {
+                forwarding_class: "voice".into(), // queue 5
+                loss_priority: String::new(),
+                dscp_values: vec![0x2e],
+            }],
+        }],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![],
+    };
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 501,
+            cos_dscp_classifier: "voice-cls".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(cos),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&501),
+        "DSCP classifier mapping to queue the interface won't materialize (no scheduler-map) must NOT admit"
+    );
+}
+
+#[test]
+fn build_cos_state_admits_classifier_mapping_to_materialized_queue() {
+    // The opposite of the previous test: a DSCP classifier mapping to
+    // queue 0 is OK on an interface with no scheduler-map, because the
+    // synthetic default best-effort queue IS queue 0. Packets land
+    // there and the classifier IS observable, so the interface
+    // legitimately needs to be in CoSState.
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![CoSForwardingClassSnapshot {
+            name: "best-effort".into(),
+            queue: 0,
+        }],
+        schedulers: vec![],
+        scheduler_maps: vec![],
+        dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+            name: "be-cls".into(),
+            entries: vec![CoSDSCPClassifierEntrySnapshot {
+                forwarding_class: "best-effort".into(), // queue 0
+                loss_priority: String::new(),
+                dscp_values: vec![0x10],
+            }],
+        }],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![],
+    };
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 502,
+            cos_dscp_classifier: "be-cls".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(cos),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        state.interfaces.contains_key(&502),
+        "DSCP classifier mapping to materialized queue must admit interface"
+    );
+}
+
+#[test]
+fn build_cos_state_skips_rewrite_only_mapping_to_unmaterialized_class() {
+    // A DSCP rewrite-rule whose ONLY entry is for forwarding-class
+    // `voice` is attached to an interface with no scheduler-map. The
+    // interface only has the synthetic default best-effort class —
+    // the `voice` rewrite has no queue to attach to, so no packet can
+    // ever observe it. Gate must skip.
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![
+            CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            },
+            CoSForwardingClassSnapshot {
+                name: "voice".into(),
+                queue: 5,
+            },
+        ],
+        schedulers: vec![],
+        scheduler_maps: vec![],
+        dscp_classifiers: vec![],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![CoSDSCPRewriteRuleSnapshot {
+            name: "voice-rw".into(),
+            entries: vec![CoSDSCPRewriteRuleEntrySnapshot {
+                forwarding_class: "voice".into(),
+                loss_priority: String::new(),
+                dscp_value: 0x2e,
+            }],
+        }],
+    };
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 503,
+            cos_dscp_rewrite_rule: "voice-rw".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(cos),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&503),
+        "DSCP rewrite-rule for class the interface won't materialize must NOT admit"
+    );
+}
+
+#[test]
+fn build_cos_state_admits_rewrite_only_mapping_to_materialized_class() {
+    // A DSCP rewrite-rule with a `best-effort` entry is observable on
+    // an interface with no scheduler-map, because the synthetic default
+    // best-effort queue IS the materialized class. Packets in that
+    // queue can carry the rewrite — interface should be admitted.
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![CoSForwardingClassSnapshot {
+            name: "best-effort".into(),
+            queue: 0,
+        }],
+        schedulers: vec![],
+        scheduler_maps: vec![],
+        dscp_classifiers: vec![],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![CoSDSCPRewriteRuleSnapshot {
+            name: "be-rw".into(),
+            entries: vec![CoSDSCPRewriteRuleEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                dscp_value: 0,
+            }],
+        }],
+    };
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 504,
+            cos_dscp_rewrite_rule: "be-rw".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(cos),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        state.interfaces.contains_key(&504),
+        "DSCP rewrite-rule for the materialized best-effort class must admit"
+    );
+}

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -808,15 +808,6 @@ fn build_cos_state_admits_each_cos_field_in_isolation() {
             },
         ),
         (
-            202,
-            "burst-bytes only",
-            InterfaceSnapshot {
-                ifindex: 202,
-                cos_shaping_burst_bytes: 256_000,
-                ..Default::default()
-            },
-        ),
-        (
             203,
             "scheduler-map only",
             InterfaceSnapshot {
@@ -865,4 +856,34 @@ fn build_cos_state_admits_each_cos_field_in_isolation() {
             "{label}: interface must be admitted to CoSState (ifindex {ifindex})"
         );
     }
+}
+
+#[test]
+fn build_cos_state_skips_interface_with_burst_only_no_other_cos_knobs() {
+    // Junos grammar parses `burst-size` only as a sub-knob of
+    // `shaping-rate`, so an interface can never carry a burst-bytes
+    // value without also carrying a non-zero shaping-rate. A pathological
+    // snapshot with burst-only must NOT be admitted to CoSState — there
+    // is no real CoS behavior to apply, and admitting would reintroduce
+    // the cross-binding owner-worker redirect that PR #1183 eliminates.
+    // (Copilot review on PR #1183 caught the prior over-broad predicate.)
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 250,
+            cos_shaping_rate_bytes_per_sec: 0,
+            cos_shaping_burst_bytes: 256_000,
+            cos_scheduler_map: String::new(),
+            cos_dscp_classifier: String::new(),
+            cos_ieee8021_classifier: String::new(),
+            cos_dscp_rewrite_rule: String::new(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot::default()),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&250),
+        "interface with burst-only (no rate, no classes, no rewrite) must NOT be in CoSState"
+    );
 }

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -865,13 +865,15 @@ fn build_cos_state_admits_each_cos_field_in_isolation() {
 
 #[test]
 fn build_cos_state_skips_interface_with_burst_only_no_other_cos_knobs() {
-    // Junos grammar parses `burst-size` only as a sub-knob of
-    // `shaping-rate`, so an interface can never carry a burst-bytes
-    // value without also carrying a non-zero shaping-rate. A pathological
-    // snapshot with burst-only must NOT be admitted to CoSState — there
-    // is no real CoS behavior to apply, and admitting would reintroduce
-    // the cross-binding owner-worker redirect that PR #1183 eliminates.
-    // (Copilot review on PR #1183 caught the prior over-broad predicate.)
+    // The Go compiler permits a committed config to carry
+    // `BurstSizeBytes > 0` independently of `ShapingRateBytes`
+    // (`pkg/config/compiler_class_of_service.go:285-312`), so this
+    // snapshot shape IS reachable from real config. We deliberately
+    // skip it anyway: pre-f0e364d7 also skipped burst-only (the old
+    // `shaping_rate == 0` skip caught it), and admitting it would
+    // install the cross-binding owner-worker redirect that PR #1183
+    // exists to remove. The buffer-cap admission effect that admission
+    // would unlock has never been observable in production.
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             ifindex: 250,
@@ -891,4 +893,105 @@ fn build_cos_state_skips_interface_with_burst_only_no_other_cos_knobs() {
         !state.interfaces.contains_key(&250),
         "interface with burst-only (no rate, no classes, no rewrite) must NOT be in CoSState"
     );
+}
+
+#[test]
+fn build_cos_state_skips_interface_with_unresolvable_named_references() {
+    // A typo'd scheduler-map / classifier / rewrite-rule name is
+    // non-empty but does not resolve to any entry in the CoS config.
+    // Pre-fix, an is-non-empty gate would admit such an interface and
+    // build only a default best-effort queue with rate=0, re-triggering
+    // the owner-worker redirect collapse for an interface with no
+    // effective CoS policy. The predicate must require named references
+    // to actually resolve.
+    let cos = ClassOfServiceSnapshot {
+        forwarding_classes: vec![CoSForwardingClassSnapshot {
+            name: "best-effort".into(),
+            queue: 0,
+        }],
+        schedulers: vec![],
+        scheduler_maps: vec![CoSSchedulerMapSnapshot {
+            name: "wan-map".into(),
+            entries: vec![CoSSchedulerMapEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                scheduler: String::new(),
+            }],
+        }],
+        dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+            name: "dscp-cls".into(),
+            entries: vec![CoSDSCPClassifierEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                dscp_values: vec![0],
+            }],
+        }],
+        ieee8021_classifiers: vec![CoSIEEE8021ClassifierSnapshot {
+            name: "p8021-cls".into(),
+            entries: vec![CoSIEEE8021ClassifierEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                code_points: vec![0],
+            }],
+        }],
+        dscp_rewrite_rules: vec![CoSDSCPRewriteRuleSnapshot {
+            name: "dscp-rw".into(),
+            entries: vec![CoSDSCPRewriteRuleEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                loss_priority: String::new(),
+                dscp_value: 0,
+            }],
+        }],
+    };
+    // Each typo'd reference (one CoS field non-empty but unresolvable)
+    // must NOT admit the interface to CoSState.
+    let cases: &[(i32, &str, InterfaceSnapshot)] = &[
+        (
+            301,
+            "typo'd scheduler-map",
+            InterfaceSnapshot {
+                ifindex: 301,
+                cos_scheduler_map: "wan-mapp".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            302,
+            "typo'd DSCP classifier",
+            InterfaceSnapshot {
+                ifindex: 302,
+                cos_dscp_classifier: "dscp-cls-typo".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            303,
+            "typo'd 802.1p classifier",
+            InterfaceSnapshot {
+                ifindex: 303,
+                cos_ieee8021_classifier: "p8021-cls-typo".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            304,
+            "typo'd DSCP rewrite-rule",
+            InterfaceSnapshot {
+                ifindex: 304,
+                cos_dscp_rewrite_rule: "dscp-rw-typo".into(),
+                ..Default::default()
+            },
+        ),
+    ];
+    for (ifindex, label, iface) in cases {
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![iface.clone()],
+            class_of_service: Some(cos.clone()),
+            ..Default::default()
+        };
+        let state = build_cos_state(&snapshot);
+        assert!(
+            !state.interfaces.contains_key(ifindex),
+            "{label}: unresolvable name must NOT admit interface to CoSState (ifindex {ifindex})"
+        );
+    }
 }

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -694,3 +694,62 @@ fn build_cos_state_mixed_zero_and_nonzero_shaping_rate() {
     assert!(!shaped.queues.is_empty());
     assert!(!transparent.queues.is_empty());
 }
+
+#[test]
+fn build_cos_state_skips_interface_with_no_cos_config() {
+    // An interface that is NOT participating in CoS (no scheduler-map,
+    // no classifier, no rewrite-rule, no shaping-rate) must NOT receive
+    // a CoSState entry — otherwise the per-interface owner-worker
+    // dispatch funnels every TX into one worker, collapsing throughput
+    // (regression hunted in iperf3 -P 12 -R: 22 Gbps → 2 Gbps until
+    // this gate was reinstated).
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            // Forwarding-only LAN egress with no CoS at all.
+            InterfaceSnapshot {
+                ifindex: 100,
+                cos_shaping_rate_bytes_per_sec: 0,
+                cos_shaping_burst_bytes: 0,
+                cos_scheduler_map: String::new(),
+                cos_dscp_classifier: String::new(),
+                cos_ieee8021_classifier: String::new(),
+                cos_dscp_rewrite_rule: String::new(),
+                ..Default::default()
+            },
+            // Sibling that DOES participate in CoS — must still appear.
+            InterfaceSnapshot {
+                ifindex: 101,
+                cos_shaping_rate_bytes_per_sec: 0,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            schedulers: vec![],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![CoSSchedulerMapEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    scheduler: String::new(),
+                }],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+    let state = build_cos_state(&snapshot);
+    assert!(
+        !state.interfaces.contains_key(&100),
+        "interface with no CoS config must NOT be added to CoSState"
+    );
+    assert!(
+        state.interfaces.contains_key(&101),
+        "interface with scheduler-map but no shaping-rate must still appear (transparent root)"
+    );
+}


### PR DESCRIPTION
## Summary

Forward fix for the 10× reverse-throughput regression introduced by f0e364d7 (#1147 / #916 "transparent-root semantics — fix CoS deadlock when no shaping-rate"). The deadlock fix is preserved; the unintended cross-binding-redirect collapse on plain forwarding interfaces is removed.

## Symptom

`iperf3 -c 172.16.80.200 -P 12 -t 8 -p 5201 -R` on the loss userspace cluster:
- master `38881341`: **1.96 Gbps, ~500K retrans**
- this PR:           **22.5 Gbps, 0 retrans**

## Root cause

f0e364d7 removed the `iface.cos_shaping_rate_bytes_per_sec == 0` skip in `build_cos_state` so an interface with classes configured but no shaping-rate would still get a CoS runtime (transparent root). Side effect: every forwarding-only interface (e.g. the LAN egress `ge-7-0-1`) now gets a transparent CoSState too. Cross-binding redirect funnels every TX on that interface to the per-interface owner worker, collapsing 6-worker parallelism to one CPU at ~2 Gbps.

## Fix

Skip only when ALL five CoS-related fields are empty/zero:
- `cos_shaping_rate_bytes_per_sec == 0`
- `cos_scheduler_map.is_empty()`
- `cos_dscp_classifier.is_empty()`
- `cos_ieee8021_classifier.is_empty()`
- `cos_dscp_rewrite_rule.is_empty()`

If any CoS knob is set, the interface goes through `build_cos_state` and f0e364d7's transparent-root runtime fast paths still apply.

## Bisect log

| commit                    | reverse Gbps | retrans  | verdict |
|---------------------------|-------------:|---------:|---------|
| 38881341 (master)         |        1.96  |    500K  | BAD     |
| **f0e364d7** (#1147)      |        1.80  |    470K  | **BAD ← first bad** |
| 3bd3cb3c                  |       22.9   |        0 | GOOD    |
| 5196abd4                  |       22.6   |        0 | GOOD    |
| efa06ee8                  |       18.5   |        0 | GOOD    |
| 308f025f                  |       22.3   |      148 | GOOD    |
| a264075d                  |       21.8   |        0 | GOOD    |
| d8bf0603 (Apr 21 baseline)|       22.5   |     1008 | GOOD    |

## Test plan

- [x] cargo build clean
- [x] cargo test --release: **953 / 953 pass** (incl. new regression test + all three f0e364d7 transparent-root tests)
- [x] new test `build_cos_state_skips_interface_with_no_cos_config` asserts:
  - iface with all five CoS fields empty → NOT in CoSState
  - sibling with `cos_scheduler_map = "wan-map"` but `shaping_rate = 0` → still in CoSState
- [x] Deploy on loss userspace cluster (fw0 + fw1)
- [x] v4 reverse `-P 12 -t 8 -p 5201`: **22.5 Gbps, 0 retrans**
- [x] v6 reverse `-P 12 -t 8 -p 5201`: **22.5 Gbps, 0 retrans**
- [x] v4 single reverse `-p 5201`:        6.88 Gbps, 0 retrans
- [x] v4 push `-P 12 -p 5201`:              966 Mbps (iperf-a 1 Gb shaper — WAI), 298 retrans
- [x] Per-class CoS 5201-5206 v4 push+rev: all 0 retrans, single-stream throughput tracks each class's shape rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)