### PR TITLE
#925 Phase 2: xpf_userspace_worker_dead Prometheus gauge + ops doc

### DIFF
--- a/docs/operations/worker-supervisor.md
+++ b/docs/operations/worker-supervisor.md
@@ -16,8 +16,10 @@ If a panic escapes the loop body, the supervisor:
 2. Logs the rendered panic payload to journald via `eprintln!`.
 3. Stores the panic message in a `Mutex<Option<String>>` per worker.
 4. Sets the worker's `WorkerRuntimeAtomics.dead` flag to `true`.
-5. Returns `Ok(())` from the supervised closure so the join handle
-   sees a clean exit.
+5. Lets the supervised closure return normally (the closure itself
+   has `()` return type) — because the panic was caught, the
+   worker thread exits cleanly and `JoinHandle::join()` returns
+   `Ok(())` rather than `Err(panic_payload)`.
 
 The other workers and the control plane continue running. The dead
 worker no longer processes packets — bindings/queues owned by it
@@ -80,7 +82,7 @@ is `type`:
 
 ```
 incus exec loss:xpf-userspace-fw0 -- bash -lc \
-  'echo "{\"type\":\"status\"}" | socat - UNIX-CONNECT:/run/xpf/userspace-dp.sock | jq ".worker_runtime[] | select(.dead)"'
+  'echo "{\"type\":\"status\"}" | socat - UNIX-CONNECT:/run/xpf/userspace-dp.sock | jq ".status.worker_runtime[] | select(.dead)"'
 ```
 
 (See `test/incus/step1-capture.sh` for additional examples of the
@@ -91,10 +93,17 @@ Both paths return the worker entry with `dead: true` and the
 
 ### Log inspection
 
-The supervisor prints to stderr, which systemd routes to journald:
+The supervisor prints to stderr, which systemd routes to journald.
+The actual log strings emitted by `spawn_supervised_worker` /
+`spawn_supervised_aux` are:
+
+- `xpf-userspace-dp: worker_loop panicked (worker_id=<N>): <message>`
+- `xpf-userspace-dp: aux thread '<name>' panicked: <message>`
+
+so:
 
 ```
-journalctl -u xpfd -g 'panic|supervisor caught'
+journalctl -u xpfd -g 'panicked'
 ```
 
 ## Why no automatic respawn

--- a/docs/operations/worker-supervisor.md
+++ b/docs/operations/worker-supervisor.md
@@ -44,9 +44,9 @@ Suggested alert:
     description: |
       Bindings owned by this worker are no longer forwarding.
       Restart xpfd to recover. Investigation:
-        cli show userspace-dp status
-      and look for `panic_message` on the corresponding worker
-      runtime entry.
+        cli show chassis cluster data-plane statistics
+      and look for the worker line marked
+      `DEAD - panicked: <message>`.
 ```
 
 The alert latency is bounded by `scrape_interval +
@@ -73,12 +73,18 @@ A dead worker prints as:
 ```
 
 For machine-readable output (e.g. piping to jq), the same data is
-on the userspace-dp control socket:
+on the userspace-dp control socket. The control protocol decodes
+the request as a JSON `ControlRequest` (see
+`userspace-dp/src/protocol.rs::ControlRequest`); the field name
+is `type`:
 
 ```
 incus exec loss:xpf-userspace-fw0 -- bash -lc \
-  "echo status | socat - UNIX-CONNECT:/run/xpf/userspace-dp.sock | jq '.worker_runtime[] | select(.dead)'"
+  'echo "{\"type\":\"status\"}" | socat - UNIX-CONNECT:/run/xpf/userspace-dp.sock | jq ".worker_runtime[] | select(.dead)"'
 ```
+
+(See `test/incus/step1-capture.sh` for additional examples of the
+same control-socket request shape.)
 
 Both paths return the worker entry with `dead: true` and the
 `panic_message` payload that the supervisor captured.

--- a/docs/operations/worker-supervisor.md
+++ b/docs/operations/worker-supervisor.md
@@ -50,16 +50,37 @@ Suggested alert:
 ```
 
 The alert latency is bounded by `scrape_interval +
-control_socket_rt` (typically 15–30 s + ~10 ms). The `for: 30s`
-clause absorbs that.
+successful control-socket round trip`. Scrape interval is
+operator-configured (typically 15–30 s); the control-socket
+round trip is bounded by the dial timeout (`2 s`) and request
+deadline (`3 s`) in `pkg/dataplane/userspace/process.go`, with
+real-world latency well below those bounds. The `for: 30s`
+alert clause absorbs both components comfortably.
 
-### JSON status (deeper diagnosis)
+### CLI / JSON status (deeper diagnosis)
+
+The CoS-aware text formatter renders dead workers inline. The
+canonical operator path is:
 
 ```
-cli show userspace-dp status | jq '.worker_runtime[] | select(.dead)'
+cli show chassis cluster data-plane statistics
 ```
 
-returns the worker entry with both `dead: true` and the
+A dead worker prints as:
+
+```
+  <id>   <tid>      DEAD - panicked: <panic_message>
+```
+
+For machine-readable output (e.g. piping to jq), the same data is
+on the userspace-dp control socket:
+
+```
+incus exec loss:xpf-userspace-fw0 -- bash -lc \
+  "echo status | socat - UNIX-CONNECT:/run/xpf/userspace-dp.sock | jq '.worker_runtime[] | select(.dead)'"
+```
+
+Both paths return the worker entry with `dead: true` and the
 `panic_message` payload that the supervisor captured.
 
 ### Log inspection

--- a/docs/operations/worker-supervisor.md
+++ b/docs/operations/worker-supervisor.md
@@ -1,0 +1,126 @@
+# Userspace-DP Worker Supervisor — operator notes
+
+## What it is
+
+The userspace AF_XDP dataplane (`xpf-userspace-dp`) runs N worker
+threads (one per binding/queue, configured at startup). Each worker
+runs a `worker_loop` that polls XSK rings and drives the per-packet
+pipeline (#925 Phase 1).
+
+`worker_loop` is wrapped in `catch_unwind` by a supervisor helper
+(`spawn_supervised_worker` in `userspace-dp/src/afxdp/coordinator/mod.rs`).
+If a panic escapes the loop body, the supervisor:
+
+1. Catches the panic with `catch_unwind` so it does not propagate
+   to the parent thread.
+2. Logs the rendered panic payload to journald via `eprintln!`.
+3. Stores the panic message in a `Mutex<Option<String>>` per worker.
+4. Sets the worker's `WorkerRuntimeAtomics.dead` flag to `true`.
+5. Returns `Ok(())` from the supervised closure so the join handle
+   sees a clean exit.
+
+The other workers and the control plane continue running. The dead
+worker no longer processes packets — bindings/queues owned by it
+stop forwarding. Other bindings keep running.
+
+## How to detect a dead worker
+
+### Prometheus (recommended)
+
+`xpf_userspace_worker_dead{worker_id="<N>"}` is a binary gauge:
+- `0`: worker `N` is healthy (no panic caught).
+- `1`: worker `N` panicked and the supervisor caught it. Cleared
+  only by daemon restart.
+
+Suggested alert:
+
+```yaml
+- alert: XpfUserspaceWorkerDead
+  expr: xpf_userspace_worker_dead == 1
+  for: 30s
+  labels: { severity: critical }
+  annotations:
+    summary: "userspace-dp worker {{ $labels.worker_id }} panicked"
+    description: |
+      Bindings owned by this worker are no longer forwarding.
+      Restart xpfd to recover. Investigation:
+        cli show userspace-dp status
+      and look for `panic_message` on the corresponding worker
+      runtime entry.
+```
+
+The alert latency is bounded by `scrape_interval +
+control_socket_rt` (typically 15–30 s + ~10 ms). The `for: 30s`
+clause absorbs that.
+
+### JSON status (deeper diagnosis)
+
+```
+cli show userspace-dp status | jq '.worker_runtime[] | select(.dead)'
+```
+
+returns the worker entry with both `dead: true` and the
+`panic_message` payload that the supervisor captured.
+
+### Log inspection
+
+The supervisor prints to stderr, which systemd routes to journald:
+
+```
+journalctl -u xpfd -g 'panic|supervisor caught'
+```
+
+## Why no automatic respawn
+
+#925 acceptance criteria allowed either implementing automatic
+respawn or documenting the decision NOT to. We chose NOT to. Three
+load-bearing reasons:
+
+1. **Reentrancy hazard.** A panic mid-`poll_binding_process_descriptor`
+   leaves the XSK rings, UMEM frame allocator, conntrack entries,
+   and CoS scheduler state in an arbitrary state. Re-entering the
+   same worker loop without rebuilding all of that risks corruption
+   that's worse than the outage. A correct respawn would have to
+   tear down and rebuild the binding's state machine end-to-end —
+   an operation roughly equivalent to a daemon restart, but
+   subtler.
+2. **Sticky-failure trap.** If a panic is deterministic (e.g. an
+   `assert!` tripwire on a specific config / packet shape /
+   session entry), an unconditional respawn loops forever and
+   becomes a CPU-hot livelock. Correct sticky-failure detection
+   (count panics in a sliding window, mark the binding permanently
+   failed after N) deserves its own design pass and is not
+   included here.
+3. **Operator visibility.** A dead worker that pages once with a
+   clear `panic_message` is more actionable than a respawn that
+   silently masks the bug. The first failure is the cheapest
+   diagnostic moment; we don't want to hide it.
+
+A future Phase 3 (deferred indefinitely, opened only if alert
+evidence shows the dead-worker fleet rate is high enough to
+justify the design work) could add respawn with sticky-failure
+detection and per-binding state rebuild.
+
+## HA interaction
+
+A dead worker on the chassis-cluster primary does **NOT** trigger
+chassis-cluster failover. Reasons:
+
+- The chassis-cluster failover state machine watches **node-level**
+  liveness (VRRP advertisements + the BPF watchdog map at
+  `bpf/headers/xpf_helpers.h`). It does not watch per-worker
+  liveness.
+- A single dead worker affects only the bindings/queues owned by
+  that worker; the other workers continue to forward. Escalating
+  to a node-level failover for a partial outage would be a
+  regression in HA semantics — every flow on the surviving
+  workers would be disrupted.
+- If an operator wants node-level escalation for this condition,
+  the right path is **operator-driven**: alert on
+  `xpf_userspace_worker_dead == 1`, then issue
+  `request chassis cluster failover redundancy-group N` from the
+  CLI / API. That keeps the policy decision out of the daemon.
+
+The existing `make test-failover` / `make test-ha-crash` harnesses
+exercise the VRRP + BPF-watchdog failover paths and are unchanged
+by Phase 2.

--- a/docs/pr/925-phase2/plan.md
+++ b/docs/pr/925-phase2/plan.md
@@ -1,8 +1,28 @@
 ---
-status: DRAFT v1 — pending adversarial plan review
+status: DRAFT v2 — Codex round-1 PLAN-NEEDS-MINOR addressed; Gemini round-1 redispatch (round-1 failed at 32s with infra error)
 issue: https://github.com/psaab/xpf/issues/925
 phase: Phase 2 — Prometheus gauge + decision-doc closeout
 ---
+
+## Changelog
+- **v2**: Codex round-1 (`task-morpduik-e7wr83`) returned PLAN-NEEDS-MINOR. Addressed:
+  - §8 metric test promoted from "Optional" to MANDATORY (Codex Q-1).
+  - §6 corrected the false "1s snapshot lag" invariant — `xpfCollector.Collect`
+    calls `provider.Status()` per scrape, which synchronously hits the
+    userspace-dp control socket (`pkg/api/metrics.go:394-410, 416-428`,
+    `pkg/dataplane/userspace/manager.go:839-860`). The 1s cadence is the
+    manager's separate `statusLoop` (`process.go:342-360`) and per-worker
+    publishes (`userspace-dp/src/afxdp/worker/mod.rs:687-717`), neither of
+    which the gauge reads from. Cadence-to-alert is `min(scrape_interval,
+    socket_round_trip)`; for typical 15-30s scrapes the 1s publish lag is
+    within noise (Codex Q-5).
+  - §4 / §10 Q3 acknowledged safe alternatives for panic_message (fixed
+    `panic_class` enum, fingerprint hash) but kept the JSON-status-only
+    decision (Codex Q-7).
+  - §4.3 NEW: stale wire-doc comments at `pkg/dataplane/userspace/protocol.go:539-542`
+    and `userspace-dp/src/afxdp/worker_runtime.rs:71-73` say "Phase 2
+    (respawn) will clear on relaunch" — but THIS Phase 2 is closeout, not
+    respawn. Update those comments in the same PR (Codex Q-8).
 
 # #925 Phase 2 — `xpf_userspace_worker_dead{worker_id}` gauge + no-respawn decision
 
@@ -132,6 +152,18 @@ Metric type: `GaugeValue` (binary 0/1, can transition both ways
 in principle — only daemon restart clears it today, but a future
 Phase 3 respawn would also clear it).
 
+### 4.3 Stale-wire-doc cleanup
+
+Both wire-doc strings currently claim "Phase 2 (respawn) will clear
+on relaunch":
+- `pkg/dataplane/userspace/protocol.go:539-542`
+- `userspace-dp/src/afxdp/worker_runtime.rs:71-73`
+
+Update both to reflect actual state: Phase 1 set-only; cleared by
+daemon restart; Phase 2 (this PR) adds Prometheus exposure but does
+NOT add respawn. Hypothetical Phase 3 (deferred indefinitely) would
+clear by replacing `WorkerRuntimeAtomics` on respawn.
+
 ### 4.2 Operations doc
 
 New file: `docs/operations/worker-supervisor.md`. Contents:
@@ -196,12 +228,16 @@ New file: `docs/operations/worker-supervisor.md`. Contents:
 
 ## 6. Hidden invariants the change must preserve
 
-- **xpfCollector caches a `ProcessStatus` snapshot from a 1s
-  cadence.** The Phase 1 atomic flip happens immediately on
-  catch; the snapshot lag means the gauge can be up to ~1s
-  behind reality. Acceptable — the alert `for: 30s` clause
-  absorbs that. Confirm no shorter lag is required by current
-  alerts.
+- **xpfCollector cadence is the Prometheus scrape interval, NOT
+  1 s.** Codex round-1 Q-5 corrected an earlier draft of this
+  plan: `xpfCollector.Collect` calls `provider.Status()` per
+  scrape, which is a synchronous control-socket request (no
+  internal cache). The userspace-dp publishes per-worker fields
+  to its own 1 s `statusLoop`, which the manager serves on
+  request. Total alert-to-page latency is therefore
+  `scrape_interval + worker_publish_lag (≤1 s) + control_rt`,
+  dominated by `scrape_interval` (typically 15-30 s). The
+  `for: 30s` alert clause absorbs all three components.
 - **Worker IDs are stable for the lifetime of the daemon.** The
   `worker_id` label values match the existing 7 metric series,
   so users grouping by `worker_id` get a coherent view.
@@ -222,10 +258,15 @@ New file: `docs/operations/worker-supervisor.md`. Contents:
 
 ## 8. Test plan
 
-- `cargo build` clean (no Rust change, but build sanity).
+- `cargo build` clean (no Rust change beyond the 2 comment
+  updates per §4.3, but build sanity).
 - `cargo test --release`: unchanged from Phase 1 (954+ pass).
-- `go test ./pkg/api/...` for the new Prometheus assertion if
-  added.
+- `go test ./pkg/api/...` MUST include a new test asserting the
+  `xpf_userspace_worker_dead{worker_id=...}` series appears in
+  the `/metrics` output with value `1` when a `ProcessStatus`
+  fixture has `WorkerRuntime[i].Dead = true`, and value `0`
+  otherwise. (Codex round-1 Q-1: the metric is the entire point
+  of the PR; not having a test is unacceptable.)
 - Smoke matrix (per `triple-review` SKILL.md Step 6): full Pass A
   + Pass B 30 measurements (the change is fleet-side metrics; no
   expected throughput delta, but we still smoke to confirm zero
@@ -257,9 +298,23 @@ New file: `docs/operations/worker-supervisor.md`. Contents:
    don't fire on metric absence.)
 3. Should `panic_message` be a separate Prometheus metric (as a
    `_info` gauge with the message in a label)? Or is the JSON
-   status enough? (This plan: JSON status only — Prometheus
-   labels with arbitrary panic strings are a known cardinality
-   trap.)
+   status enough? **This plan: JSON status only.** Codex round-1
+   Q-7 validated that putting raw panic-payload text in a
+   Prometheus label is a cardinality + privacy trap. Codex also
+   noted two safer alternatives that we DEFER (not in scope for
+   Phase 2):
+   - **Fixed `panic_class` enum** — add a small enum (e.g.
+     `OOM`, `AssertTripwire`, `IOError`, `Other`) emitted as a
+     label on `xpf_userspace_worker_dead`. Bounded cardinality,
+     but requires panic-classification logic the supervisor
+     doesn't have today.
+   - **Fingerprint hash** — emit the first N bytes of a SHA-256
+     of `panic_message` as a label. Bounded cardinality, more
+     specific than an enum, but creates per-incident churn and
+     makes alert deduplication harder.
+   Both are real options; both belong in a future Phase 3 if
+   alerting evidence shows the JSON-only diagnosis path is
+   insufficient.
 4. Is the no-respawn decision the right one? Reviewers should
    stress-test the rationale in §4.2 — particularly the
    sticky-failure-trap argument.

--- a/docs/pr/925-phase2/plan.md
+++ b/docs/pr/925-phase2/plan.md
@@ -1,0 +1,270 @@
+---
+status: DRAFT v1 — pending adversarial plan review
+issue: https://github.com/psaab/xpf/issues/925
+phase: Phase 2 — Prometheus gauge + decision-doc closeout
+---
+
+# #925 Phase 2 — `xpf_userspace_worker_dead{worker_id}` gauge + no-respawn decision
+
+> *If reviewers conclude the perf gain is too small to justify the
+> churn, PLAN-KILL is an acceptable verdict.*
+
+## 1. Issue framing
+
+#925 asked for a worker thread supervisor: catch panics, report
+liveness, optionally respawn. Phase 1 (already shipped via the
+`#925-A`/`#925-B` commit stream that landed before #1183) covered:
+
+- `spawn_supervised_worker` and `spawn_supervised_aux` helpers
+  in `userspace-dp/src/afxdp/coordinator/mod.rs` (~`:1894`/~`:1922`),
+  both wrapping the body in `catch_unwind`.
+- `WorkerRuntimeAtomics.dead` (atomic) and `panic_message` (Mutex<Option<String>>)
+  per worker.
+- All three production worker-spawn sites switched to the
+  supervised helper.
+- 4 panic-injection unit tests in `userspace-dp/src/afxdp/coordinator/tests.rs`
+  (`spawn_supervised_worker_catches_string_panic_and_marks_dead`,
+  `spawn_supervised_aux_catches_string_panic_and_returns_cleanly`,
+  `spawn_supervised_aux_runs_body_to_completion_when_no_panic`,
+  `spawn_supervised_aux_catches_non_string_panic_payload`).
+- `WorkerRuntimeStatus.Dead` (bool) and `WorkerRuntimeStatus.PanicMessage`
+  (string) on the userspace-dp control-socket JSON wire
+  (`pkg/dataplane/userspace/protocol.go:541-545`,
+  `userspace-dp/src/protocol.rs:1076-1077`).
+- The `cli show userspace-dp ...` text/JSON renderer already
+  surfaces both fields.
+
+What Phase 1 did NOT do (and Phase 2 closes out):
+
+- **Prometheus exposure of the dead state.** The xpfCollector
+  in `pkg/api/metrics.go:308-340` exposes 7 worker counters
+  (wall, active, idle-spin, idle-block, thread-cpu, work-loops,
+  idle-loops) but does **not** expose `dead` as a gauge. An
+  operator running a Prometheus alert on this fleet can't
+  detect a dead worker without scraping the JSON status.
+- **No-respawn rationale recorded in tree.** Issue #925 lists
+  "automatic respawn implementation OR documented decision NOT
+  to respawn (with rationale)" as an acceptance criterion. We
+  decided NOT to respawn (rationale below) but didn't record it.
+- **HA interaction note.** Issue #925 acceptance criterion
+  requires "HA interaction documented and tested." Current
+  behavior: a dead worker does NOT trigger chassis-cluster
+  failover. That's a deliberate choice and needs a doc note.
+
+## 2. Honest scope/value framing
+
+This is a **doc + 1 Prometheus gauge** PR. Scope:
+
+- ~30 LOC change in `pkg/api/metrics.go` (one new `*prometheus.Desc`,
+  one `Describe` send, one emit-loop call).
+- ~50 LOC of documentation in `docs/operations/worker-supervisor.md`
+  (no-respawn rationale + HA interaction + how to alert on `dead`).
+- Optional: 1 Go unit test in `pkg/api/metrics_test.go` asserting
+  the metric appears in the `/metrics` endpoint output when a
+  worker has `Dead=true`.
+
+Win at absolute scale:
+
+- The change does NOT improve throughput; this is reliability/
+  operability closeout, not perf.
+- The fleet-wide value is "one less alert blind spot." A worker
+  panic without Prometheus exposure means an SRE has to know to
+  poll the JSON status — they won't, so the panic stays invisible
+  until it manifests as user-visible packet loss on that
+  binding's flows.
+- Cost is small (~80 LOC across two files + docs). PLAN-KILL is
+  on the table if reviewers think this should just be folded into
+  a future #925 Phase 3 that ships respawn too.
+
+## 3. What's already shipped / partially batched
+
+See §1 issue framing — Phase 1 is fully landed in master at
+`753d4e8f` (current HEAD as of this plan). Phase 2 builds
+strictly on top; no Rust changes required.
+
+## 4. Concrete design
+
+### 4.1 Prometheus gauge
+
+```go
+// pkg/api/metrics.go (additions)
+
+type xpfCollector struct {
+    // ... existing fields ...
+    workerDeadGauge *prometheus.Desc  // NEW
+}
+
+func newXPFCollector(...) *xpfCollector {
+    return &xpfCollector{
+        // ... existing init ...
+        workerDeadGauge: prometheus.NewDesc(
+            "xpf_userspace_worker_dead",
+            "1 if the userspace-dp worker thread has panicked and been "+
+                "caught by the supervisor; 0 otherwise. Cleared by daemon "+
+                "restart (Phase 1 has no automatic respawn).",
+            []string{"worker_id"}, nil,
+        ),
+    }
+}
+
+func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
+    // ... existing sends ...
+    ch <- c.workerDeadGauge  // NEW
+}
+
+func (c *xpfCollector) emitWorkerRuntime(
+    ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus,
+) {
+    for _, w := range status.WorkerRuntime {
+        label := strconv.FormatUint(uint64(w.WorkerID), 10)
+        // ... existing 7 emit calls ...
+        var deadValue float64
+        if w.Dead {
+            deadValue = 1
+        }
+        ch <- prometheus.MustNewConstMetric(c.workerDeadGauge,
+            prometheus.GaugeValue, deadValue, label)
+    }
+}
+```
+
+Metric type: `GaugeValue` (binary 0/1, can transition both ways
+in principle — only daemon restart clears it today, but a future
+Phase 3 respawn would also clear it).
+
+### 4.2 Operations doc
+
+New file: `docs/operations/worker-supervisor.md`. Contents:
+
+- One-paragraph summary of Phase 1 supervisor (catch_unwind,
+  mark-dead, no respawn).
+- Suggested Prometheus alert:
+  ```yaml
+  - alert: XpfUserspaceWorkerDead
+    expr: xpf_userspace_worker_dead == 1
+    for: 30s
+    labels: { severity: critical }
+    annotations:
+      summary: "userspace-dp worker {{ $labels.worker_id }} panicked"
+      description: |
+        Restart xpfd to recover. Investigation: check
+        `cli show userspace-dp status | json` for panic_message.
+  ```
+- **No-respawn rationale.** Three reasons we chose not to
+  auto-respawn in Phase 1/Phase 2:
+  1. **Reentrancy hazard.** A panic mid-`poll_binding_process_descriptor`
+     leaves the XSK rings, UMEM frame allocator, and conntrack
+     entries in an arbitrary state. Re-entering the same worker
+     loop without rebuilding all of that risks corruption that's
+     worse than the outage.
+  2. **Sticky-failure trap.** If the panic is deterministic
+     (assert tripwire on a specific config / packet shape /
+     session entry), an unconditional respawn loops forever and
+     turns into a CPU-hot livelock. Sticky-failure detection
+     adds enough complexity that it deserves its own design pass
+     (deferred to Phase 3 if observability shows we need it).
+  3. **Operator visibility.** A dead worker with a Prometheus
+     gauge alert + clear panic_message is more actionable than a
+     respawn that masks the bug. We'd rather page once than have
+     an undebuggable flaky binding.
+- **HA interaction.** Current state: a dead worker on the
+  chassis-cluster primary does NOT trigger failover. Reasons:
+  - The chassis-cluster failover state machine watches VRRP
+    advertisements and the userspace-dp helper's "alive"
+    heartbeat; it doesn't watch per-worker liveness.
+  - A single dead worker affects only the bindings owned by that
+    worker — not the whole node. The other 5 workers continue
+    to forward.
+  - Deliberately escalating to a node-level failover for a
+    partial-outage condition would be a regression in HA
+    semantics. If the operator wants that behavior, the right
+    path is a node-level health check (Prometheus alert →
+    operator-driven failover), not an in-daemon decision.
+
+  This is documented; tested by inspection (no specific
+  failover test added — the existing `make test-failover`
+  harness exercises the VRRP path which is unchanged).
+
+## 5. Public API preservation
+
+- No Rust public API change.
+- No protocol-wire change (Phase 1 already added `Dead` /
+  `PanicMessage`).
+- `pkg/api/metrics.go` exposes one NEW Prometheus metric name
+  (`xpf_userspace_worker_dead`); the metrics endpoint adds a
+  series, no removals.
+
+## 6. Hidden invariants the change must preserve
+
+- **xpfCollector caches a `ProcessStatus` snapshot from a 1s
+  cadence.** The Phase 1 atomic flip happens immediately on
+  catch; the snapshot lag means the gauge can be up to ~1s
+  behind reality. Acceptable — the alert `for: 30s` clause
+  absorbs that. Confirm no shorter lag is required by current
+  alerts.
+- **Worker IDs are stable for the lifetime of the daemon.** The
+  `worker_id` label values match the existing 7 metric series,
+  so users grouping by `worker_id` get a coherent view.
+- **`Dead` is set-only in Phase 1** — once flipped, only daemon
+  restart clears it. The gauge will therefore read `1` until
+  process restart even after the panic-causing condition is
+  resolved. Document this on the metric description so SREs
+  don't expect auto-clearing.
+
+## 7. Risk assessment
+
+| Class | Verdict | Notes |
+|---|---|---|
+| Behavioral regression | **LOW** | Pure additive metric + docs. No code path on the dataplane hot path is touched. |
+| Lifetime / borrow-checker | **LOW** | No Rust change. |
+| Performance regression | **LOW** | One extra `MustNewConstMetric` call per scrape (≤6 workers, scraped at 15s/30s typical). Negligible. |
+| Architectural mismatch (#961 / #946-Phase-2 dead-end) | **LOW** | This is closeout of an already-shipped Phase 1; not a new architecture. |
+
+## 8. Test plan
+
+- `cargo build` clean (no Rust change, but build sanity).
+- `cargo test --release`: unchanged from Phase 1 (954+ pass).
+- `go test ./pkg/api/...` for the new Prometheus assertion if
+  added.
+- Smoke matrix (per `triple-review` SKILL.md Step 6): full Pass A
+  + Pass B 30 measurements (the change is fleet-side metrics; no
+  expected throughput delta, but we still smoke to confirm zero
+  regression).
+- Optional manual verification: deploy, force a panic in a worker
+  via a debug knob (or wait for an org-internal panic-injection
+  fixture if available), `curl localhost:8080/metrics | grep
+  xpf_userspace_worker_dead` — should show `1` for the affected
+  worker_id, `0` for the rest.
+
+## 9. Out of scope (explicitly)
+
+- Automatic respawn (Phase 3 if ever needed).
+- Sticky-failure detection.
+- Coordinated state recovery (re-bind dead worker's queues to
+  surviving workers).
+- HA escalation rules ("dead worker → chassis-cluster failover").
+- Test that exercises the metric end-to-end on the cluster (the
+  manual-fixture path above is fine for now).
+
+## 10. Open questions for adversarial review
+
+1. Is the gauge alone enough value to justify a PR, or should
+   this wait until Phase 3 ships actual respawn? (PLAN-KILL is
+   acceptable if the reviewer thinks the gauge can wait.)
+2. Should the gauge default to `0` for healthy workers, or be
+   ABSENT until the first panic? (This plan: emit `0` always so
+   the metric is always present in the time series and alerts
+   don't fire on metric absence.)
+3. Should `panic_message` be a separate Prometheus metric (as a
+   `_info` gauge with the message in a label)? Or is the JSON
+   status enough? (This plan: JSON status only — Prometheus
+   labels with arbitrary panic strings are a known cardinality
+   trap.)
+4. Is the no-respawn decision the right one? Reviewers should
+   stress-test the rationale in §4.2 — particularly the
+   sticky-failure-trap argument.
+5. Should we add ANY automated test for the HA interaction, or
+   is the "documented + manual verification" approach OK? Issue
+   #925 acceptance criterion says "documented and tested" —
+   reviewer call on whether the existing failover test plus the
+   documented note is sufficient.

--- a/docs/pr/925-phase2/plan.md
+++ b/docs/pr/925-phase2/plan.md
@@ -1,8 +1,29 @@
 ---
-status: DRAFT v2 — Codex round-1 PLAN-NEEDS-MINOR addressed; Gemini round-1 redispatch (round-1 failed at 32s with infra error)
+status: DRAFT v3 — Codex round-2 PLAN-NEEDS-MINOR (doc-consistency only) addressed; Gemini PLAN-READY
 issue: https://github.com/psaab/xpf/issues/925
 phase: Phase 2 — Prometheus gauge + decision-doc closeout
 ---
+
+## Changelog v3
+- Codex round-2 (`task-morpr2ic-xar6ai`) PLAN-NEEDS-MINOR — three doc-consistency issues, no design changes:
+  - **Q-1 partial**: §8 said the metric test "MUST" exist but §2 still
+    described it as "Optional". Fixed: §2 now matches §8 (mandatory).
+  - **Q-5 partial**: previous §6 wording said "alert-to-page latency
+    is `scrape_interval + worker_publish_lag (≤1 s) + control_rt`"
+    and the v2 changelog said `min(scrape_interval, socket_rt)`.
+    Both wrong — the `dead` bit is read directly by the status
+    handler (`userspace-dp/src/server/handlers.rs:413-415` →
+    `coordinator/status.rs:144-147`), NOT batched via the per-worker
+    counter publish cadence. Corrected to:
+    `latency ≤ scrape_interval + control_socket_rt`, where the worker
+    publish cadence is irrelevant to the `dead` bit.
+  - **NEW-1**: §3 said "no Rust changes required" and §7 risk table
+    said "No Rust change" — but §4.3 adds a Rust source-comment edit.
+    Reworded to "no Rust behavior/API change" so scope text matches
+    the actual implementation footprint.
+- Gemini round-1 (`task-morpts70-37oq7l`) returned PLAN-READY on all 8 questions.
+
+## Changelog v2
 
 ## Changelog
 - **v2**: Codex round-1 (`task-morpduik-e7wr83`) returned PLAN-NEEDS-MINOR. Addressed:
@@ -79,9 +100,12 @@ This is a **doc + 1 Prometheus gauge** PR. Scope:
   one `Describe` send, one emit-loop call).
 - ~50 LOC of documentation in `docs/operations/worker-supervisor.md`
   (no-respawn rationale + HA interaction + how to alert on `dead`).
-- Optional: 1 Go unit test in `pkg/api/metrics_test.go` asserting
-  the metric appears in the `/metrics` endpoint output when a
-  worker has `Dead=true`.
+- **Required**: 1 Go unit test in `pkg/api/metrics_test.go` (or a
+  sibling test file) asserting the metric appears in the `/metrics`
+  endpoint output with value `1` when a `ProcessStatus` fixture has
+  `WorkerRuntime[i].Dead = true`, and `0` otherwise. (Codex round-1
+  Q-1 + round-2 confirmation: the metric is the entire point of the
+  PR; not having a test is unacceptable.)
 
 Win at absolute scale:
 
@@ -100,7 +124,9 @@ Win at absolute scale:
 
 See §1 issue framing — Phase 1 is fully landed in master at
 `753d4e8f` (current HEAD as of this plan). Phase 2 builds
-strictly on top; no Rust changes required.
+strictly on top with no Rust **behavior or API** change. The
+only Rust touchpoint is a stale-comment update in
+`worker_runtime.rs:71-73` (see §4.3) — pure doc, no semantics.
 
 ## 4. Concrete design
 
@@ -229,15 +255,18 @@ New file: `docs/operations/worker-supervisor.md`. Contents:
 ## 6. Hidden invariants the change must preserve
 
 - **xpfCollector cadence is the Prometheus scrape interval, NOT
-  1 s.** Codex round-1 Q-5 corrected an earlier draft of this
-  plan: `xpfCollector.Collect` calls `provider.Status()` per
-  scrape, which is a synchronous control-socket request (no
-  internal cache). The userspace-dp publishes per-worker fields
-  to its own 1 s `statusLoop`, which the manager serves on
-  request. Total alert-to-page latency is therefore
-  `scrape_interval + worker_publish_lag (≤1 s) + control_rt`,
-  dominated by `scrape_interval` (typically 15-30 s). The
-  `for: 30s` alert clause absorbs all three components.
+  1 s.** Codex rounds 1+2 corrected earlier drafts of this plan:
+  `xpfCollector.Collect` calls `provider.Status()` per scrape,
+  which is a synchronous control-socket request with no internal
+  cache. For the `dead` bit specifically, the userspace-dp's
+  status handler reads `runtime_atomics.dead` directly
+  (`userspace-dp/src/server/handlers.rs:413-415` →
+  `coordinator/status.rs:144-147`), NOT batched through the per-
+  worker counter publish cadence. Alert-to-page latency is
+  therefore bounded by `scrape_interval + control_socket_rt`
+  (typically 15-30 s + ~10 ms). The worker publish cadence (1 s
+  in `worker/mod.rs:687-717`) does NOT add to `dead`-bit
+  latency. The `for: 30s` alert clause absorbs both components.
 - **Worker IDs are stable for the lifetime of the daemon.** The
   `worker_id` label values match the existing 7 metric series,
   so users grouping by `worker_id` get a coherent view.
@@ -252,7 +281,7 @@ New file: `docs/operations/worker-supervisor.md`. Contents:
 | Class | Verdict | Notes |
 |---|---|---|
 | Behavioral regression | **LOW** | Pure additive metric + docs. No code path on the dataplane hot path is touched. |
-| Lifetime / borrow-checker | **LOW** | No Rust change. |
+| Lifetime / borrow-checker | **LOW** | No Rust behavior/API change (only the stale-comment refresh in `worker_runtime.rs:71-73`). |
 | Performance regression | **LOW** | One extra `MustNewConstMetric` call per scrape (≤6 workers, scraped at 15s/30s typical). Negligible. |
 | Architectural mismatch (#961 / #946-Phase-2 dead-end) | **LOW** | This is closeout of an already-shipped Phase 1; not a new architecture. |
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -92,6 +92,10 @@ type xpfCollector struct {
 	workerThreadCPUSecs *prometheus.Desc
 	workerWorkLoops     *prometheus.Desc
 	workerIdleLoops     *prometheus.Desc
+	// #925 Phase 2: liveness gauge for the supervisor's catch_unwind
+	// state. 1 = worker has panicked and the supervisor has caught it;
+	// 0 = healthy. Set-only in Phase 1 (cleared by daemon restart).
+	workerDead *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -339,6 +343,13 @@ func newCollector(srv *Server) *xpfCollector {
 			"Worker-loop iterations with no useful work (#869).",
 			[]string{"worker_id"}, nil,
 		),
+		workerDead: prometheus.NewDesc(
+			"xpf_userspace_worker_dead",
+			"1 if the userspace-dp worker thread has panicked and been "+
+				"caught by the supervisor; 0 otherwise. Cleared only by "+
+				"daemon restart in Phase 1 (#925).",
+			[]string{"worker_id"}, nil,
+		),
 	}
 }
 
@@ -389,6 +400,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.workerThreadCPUSecs
 	ch <- c.workerWorkLoops
 	ch <- c.workerIdleLoops
+	ch <- c.workerDead
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -448,6 +460,12 @@ func (c *xpfCollector) emitWorkerRuntime(ch chan<- prometheus.Metric, status dpu
 			prometheus.CounterValue, float64(w.WorkLoops), label)
 		ch <- prometheus.MustNewConstMetric(c.workerIdleLoops,
 			prometheus.CounterValue, float64(w.IdleLoops), label)
+		var deadValue float64
+		if w.Dead {
+			deadValue = 1
+		}
+		ch <- prometheus.MustNewConstMetric(c.workerDead,
+			prometheus.GaugeValue, deadValue, label)
 	}
 }
 

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #925 Phase 2: emitWorkerRuntime must surface the per-worker
+// `xpf_userspace_worker_dead` gauge driven by ProcessStatus.WorkerRuntime[i].Dead.
+// This test pins the wire shape so a future refactor can't silently drop it
+// (the regression Phase 2 was created to prevent: a panic going unnoticed
+// because no metric exposes the supervisor's mark-dead atomic).
+//
+// Test strategy: construct an xpfCollector with just the worker descriptors
+// initialized (the rest are nil — emitWorkerRuntime only touches the worker
+// fields). Drive a hand-built ProcessStatus through emitWorkerRuntime and
+// collect the resulting metrics off the channel. Inspect each metric's
+// protobuf representation to find the worker_dead series and assert value.
+func TestEmitWorkerRuntime_DeadGaugeReflectsDeadFlag(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+
+	// Mixed fixture: 3 workers, only the middle one dead.
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{WorkerID: 0, Dead: false},
+			{WorkerID: 1, Dead: true},
+			{WorkerID: 2, Dead: false},
+		},
+	}
+
+	got := collectFromEmitWorkerRuntime(t, c, status)
+
+	// Each worker emits 7 counters + 1 dead gauge = 8 metrics. 3 workers = 24.
+	if len(got) != 3*8 {
+		t.Fatalf("emitWorkerRuntime: want 24 metrics for 3 workers (7 counters + 1 dead gauge), got %d", len(got))
+	}
+
+	// Gather just the dead-gauge entries, keyed by worker_id label.
+	deadByWorker := make(map[string]float64)
+	for _, m := range got {
+		desc := m.Desc().String()
+		if !strings.Contains(desc, "xpf_userspace_worker_dead") {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		if pb.Gauge == nil {
+			t.Fatalf("xpf_userspace_worker_dead must be a Gauge, got %+v", &pb)
+		}
+		var workerID string
+		for _, lp := range pb.GetLabel() {
+			if lp.GetName() == "worker_id" {
+				workerID = lp.GetValue()
+			}
+		}
+		if workerID == "" {
+			t.Fatalf("xpf_userspace_worker_dead emission missing worker_id label: %+v", &pb)
+		}
+		deadByWorker[workerID] = pb.Gauge.GetValue()
+	}
+
+	if len(deadByWorker) != 3 {
+		t.Fatalf("expected one xpf_userspace_worker_dead emission per worker (3), got %d", len(deadByWorker))
+	}
+	for wid, want := range map[string]float64{
+		"0": 0,
+		"1": 1,
+		"2": 0,
+	} {
+		if got := deadByWorker[wid]; got != want {
+			t.Errorf("xpf_userspace_worker_dead{worker_id=%q} = %v, want %v", wid, got, want)
+		}
+	}
+}
+
+// All-healthy fixture: dead gauge must be 0 for every worker, never absent.
+// The metric being always-present (instead of absent until first panic) is a
+// deliberate choice from #925 Phase 2 plan §10/Q2 — Prometheus alerts that
+// fire on metric absence vs. value=1 are notoriously fragile.
+func TestEmitWorkerRuntime_DeadGaugeZeroForHealthyWorkers(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{WorkerID: 0, Dead: false},
+			{WorkerID: 5, Dead: false},
+		},
+	}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+
+	deads := 0
+	for _, m := range got {
+		if !strings.Contains(m.Desc().String(), "xpf_userspace_worker_dead") {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		deads++
+		if v := pb.Gauge.GetValue(); v != 0 {
+			t.Errorf("healthy worker should emit dead=0, got %v: %+v", v, &pb)
+		}
+	}
+	if deads != 2 {
+		t.Fatalf("expected 2 dead-gauge emissions for 2 healthy workers, got %d", deads)
+	}
+}
+
+func newCollectorWithWorkerDescsOnly() *xpfCollector {
+	// Only the seven worker counter descriptors plus the new dead gauge
+	// are needed by emitWorkerRuntime; the rest stay nil and are not
+	// exercised by this test.
+	mk := func(name string) *prometheus.Desc {
+		return prometheus.NewDesc(name, name, []string{"worker_id"}, nil)
+	}
+	return &xpfCollector{
+		workerWallSecs:      mk("xpf_userspace_worker_wall_seconds_total"),
+		workerActiveSecs:    mk("xpf_userspace_worker_active_seconds_total"),
+		workerIdleSpinSecs:  mk("xpf_userspace_worker_idle_spin_seconds_total"),
+		workerIdleBlockSecs: mk("xpf_userspace_worker_idle_block_seconds_total"),
+		workerThreadCPUSecs: mk("xpf_userspace_worker_thread_cpu_seconds_total"),
+		workerWorkLoops:     mk("xpf_userspace_worker_work_loops_total"),
+		workerIdleLoops:     mk("xpf_userspace_worker_idle_loops_total"),
+		workerDead:          mk("xpf_userspace_worker_dead"),
+	}
+}
+
+// collectFromEmitWorkerRuntime drives emitWorkerRuntime into a buffered
+// channel and returns the captured metrics. Buffer is sized for
+// 8 metrics per worker so the producer never blocks.
+func collectFromEmitWorkerRuntime(
+	t *testing.T,
+	c *xpfCollector,
+	status dpuserspace.ProcessStatus,
+) []prometheus.Metric {
+	t.Helper()
+	bufCap := len(status.WorkerRuntime) * 8
+	if bufCap < 1 {
+		bufCap = 1
+	}
+	ch := make(chan prometheus.Metric, bufCap)
+	c.emitWorkerRuntime(ch, status)
+	close(ch)
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	// Sanity: every returned descriptor should mention "xpf_userspace_worker_".
+	for _, m := range got {
+		if !strings.Contains(m.Desc().String(), "xpf_userspace_worker_") {
+			t.Fatalf("unexpected metric leaked from emitWorkerRuntime: %s", m.Desc())
+		}
+	}
+	_ = strconv.Itoa // silence unused-import linter if removed in future edits
+	return got
+}

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,10 +40,13 @@ func TestEmitWorkerRuntime_DeadGaugeReflectsDeadFlag(t *testing.T) {
 	}
 
 	// Gather just the dead-gauge entries, keyed by worker_id label.
+	// Filter by descriptor pointer (not Desc().String() which is not a
+	// stable public API and could shift with prometheus/client_golang
+	// updates). Copilot review on PR #1186 caught the previous
+	// substring approach as brittle.
 	deadByWorker := make(map[string]float64)
 	for _, m := range got {
-		desc := m.Desc().String()
-		if !strings.Contains(desc, "xpf_userspace_worker_dead") {
+		if m.Desc() != c.workerDead {
 			continue
 		}
 		var pb dto.Metric
@@ -98,7 +99,7 @@ func TestEmitWorkerRuntime_DeadGaugeZeroForHealthyWorkers(t *testing.T) {
 
 	deads := 0
 	for _, m := range got {
-		if !strings.Contains(m.Desc().String(), "xpf_userspace_worker_dead") {
+		if m.Desc() != c.workerDead {
 			continue
 		}
 		var pb dto.Metric
@@ -157,12 +158,23 @@ func collectFromEmitWorkerRuntime(
 	for m := range ch {
 		got = append(got, m)
 	}
-	// Sanity: every returned descriptor should mention "xpf_userspace_worker_".
+	// Sanity: every returned metric should be one of the worker
+	// descriptors we initialized. Pointer-equality is stable across
+	// prometheus/client_golang versions.
+	expected := map[*prometheus.Desc]struct{}{
+		c.workerWallSecs:      {},
+		c.workerActiveSecs:    {},
+		c.workerIdleSpinSecs:  {},
+		c.workerIdleBlockSecs: {},
+		c.workerThreadCPUSecs: {},
+		c.workerWorkLoops:     {},
+		c.workerIdleLoops:     {},
+		c.workerDead:          {},
+	}
 	for _, m := range got {
-		if !strings.Contains(m.Desc().String(), "xpf_userspace_worker_") {
+		if _, ok := expected[m.Desc()]; !ok {
 			t.Fatalf("unexpected metric leaked from emitWorkerRuntime: %s", m.Desc())
 		}
 	}
-	_ = strconv.Itoa // silence unused-import linter if removed in future edits
 	return got
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -134,22 +134,25 @@ func newCollectorWithWorkerDescsOnly() *xpfCollector {
 	}
 }
 
-// collectFromEmitWorkerRuntime drives emitWorkerRuntime into a buffered
-// channel and returns the captured metrics. Buffer is sized for
-// 8 metrics per worker so the producer never blocks.
+// collectFromEmitWorkerRuntime drives emitWorkerRuntime into an
+// unbuffered channel from a goroutine, then drains. Running the
+// producer in a goroutine (rather than synchronously into a fixed-size
+// buffer) means a future engineer adding a 9th per-worker metric
+// can't deadlock this helper — the test would still complete
+// correctly, just with more metrics in the returned slice.
+// (Gemini Pro 3 round-2 review of #1186 caught the previous
+// hardcoded `*8` buffer as a latent deadlock trap.)
 func collectFromEmitWorkerRuntime(
 	t *testing.T,
 	c *xpfCollector,
 	status dpuserspace.ProcessStatus,
 ) []prometheus.Metric {
 	t.Helper()
-	bufCap := len(status.WorkerRuntime) * 8
-	if bufCap < 1 {
-		bufCap = 1
-	}
-	ch := make(chan prometheus.Metric, bufCap)
-	c.emitWorkerRuntime(ch, status)
-	close(ch)
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitWorkerRuntime(ch, status)
+		close(ch)
+	}()
 	var got []prometheus.Metric
 	for m := range ch {
 		got = append(got, m)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -538,8 +538,8 @@ type WorkerRuntimeStatus struct {
 	IdleLoops   uint64 `json:"idle_loops,omitempty"`
 	// #925 Phase 1+2 (catch+report+observe): Dead == true means the
 	// worker_loop panicked and the supervisor caught it. Set-only
-	// today — cleared only by daemon restart. Phase 2 (this commit)
-	// surfaces this on Prometheus as `xpf_userspace_worker_dead`; a
+	// today — cleared only by daemon restart. Phase 2 surfaces this
+	// on Prometheus as `xpf_userspace_worker_dead` (this PR). A
 	// hypothetical Phase 3 (respawn, deferred indefinitely) would
 	// clear this by replacing WorkerRuntimeAtomics on relaunch.
 	// PanicMessage holds the rendered payload for operator diagnosis.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -536,9 +536,12 @@ type WorkerRuntimeStatus struct {
 	ThreadCPUNS uint64 `json:"thread_cpu_ns,omitempty"`
 	WorkLoops   uint64 `json:"work_loops,omitempty"`
 	IdleLoops   uint64 `json:"idle_loops,omitempty"`
-	// #925 Phase 1 (catch+report): Dead == true means the worker_loop
-	// panicked and the supervisor caught it. Cleared only by daemon
-	// restart in Phase 1; Phase 2 (respawn) will clear on relaunch.
+	// #925 Phase 1+2 (catch+report+observe): Dead == true means the
+	// worker_loop panicked and the supervisor caught it. Set-only
+	// today — cleared only by daemon restart. Phase 2 (this commit)
+	// surfaces this on Prometheus as `xpf_userspace_worker_dead`; a
+	// hypothetical Phase 3 (respawn, deferred indefinitely) would
+	// clear this by replacing WorkerRuntimeAtomics on relaunch.
 	// PanicMessage holds the rendered payload for operator diagnosis.
 	Dead         bool   `json:"dead,omitempty"`
 	PanicMessage string `json:"panic_message,omitempty"`

--- a/userspace-dp/src/afxdp/sharded_neighbor.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor.rs
@@ -17,9 +17,13 @@
 //!   shard-index order. Deadlock-free as long as every other caller
 //!   that wants more than one shard also locks in ascending order.
 //! - Poison policy: `lock().unwrap_or_else(|e| e.into_inner())`.
-//!   Workers have no `catch_unwind` supervisor today (#925 deferred);
-//!   panic-then-thread-death is operationally worse than a stale MAC.
-//!   `NeighborEntry` is plain `[u8; 6]` with no invariants to corrupt.
+//!   Workers DO have a `catch_unwind` supervisor as of #925 Phase 1
+//!   (`spawn_supervised_worker` in `coordinator/mod.rs`), and #925
+//!   Phase 2 surfaces panics on Prometheus
+//!   (`xpf_userspace_worker_dead`). But a poisoned `Mutex` here is
+//!   operationally worse than a stale MAC for the *surviving* threads:
+//!   `NeighborEntry` is plain `[u8; 6]` with no invariants to corrupt,
+//!   so the safer choice is to recover-from-poison and keep forwarding.
 
 use super::types::{FastMap, NeighborEntry};
 use rustc_hash::FxHasher;

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -68,9 +68,13 @@ pub(crate) struct WorkerRuntimeAtomics {
     pub work_loops: AtomicU64,
     pub idle_loops: AtomicU64,
     pub tid: AtomicU64,
-    /// #925 Phase 1 (catch + report only): set to true exactly once when
-    /// the supervisor catches a worker_loop panic. Never cleared in
-    /// Phase 1; Phase 2 (respawn) will clear on successful relaunch.
+    /// #925 Phase 1+2 (catch+report+observe): set to true exactly once
+    /// when the supervisor catches a worker_loop panic. Set-only today —
+    /// cleared only by daemon restart. Phase 2 (#1185) added the
+    /// `xpf_userspace_worker_dead` Prometheus gauge that reads this flag
+    /// via the JSON status wire. A hypothetical Phase 3 (respawn,
+    /// deferred indefinitely) would clear this by replacing
+    /// WorkerRuntimeAtomics on relaunch.
     /// Adding this flag pushes the struct from 64 B → 128 B due to
     /// `#[repr(align(64))]` rounding; cost is negligible (a few hundred
     /// bytes total across all workers).

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -70,11 +70,11 @@ pub(crate) struct WorkerRuntimeAtomics {
     pub tid: AtomicU64,
     /// #925 Phase 1+2 (catch+report+observe): set to true exactly once
     /// when the supervisor catches a worker_loop panic. Set-only today —
-    /// cleared only by daemon restart. Phase 2 (#1185) added the
+    /// cleared only by daemon restart. Phase 2 added the
     /// `xpf_userspace_worker_dead` Prometheus gauge that reads this flag
-    /// via the JSON status wire. A hypothetical Phase 3 (respawn,
-    /// deferred indefinitely) would clear this by replacing
-    /// WorkerRuntimeAtomics on relaunch.
+    /// via the JSON status wire (xpfCollector → control-socket status).
+    /// A hypothetical Phase 3 (respawn, deferred indefinitely) would
+    /// clear this by replacing WorkerRuntimeAtomics on relaunch.
     /// Adding this flag pushes the struct from 64 B → 128 B due to
     /// `#[repr(align(64))]` rounding; cost is negligible (a few hundred
     /// bytes total across all workers).


### PR DESCRIPTION
## Summary
Closes #925 acceptance criteria 2 (per-worker liveness counter via Prometheus), 3 (documented decision NOT to respawn with rationale), and 5 (HA interaction documented). Acceptance criterion 4 (panic-injection test) was already covered by Phase 1's 4 tests in `coordinator/tests.rs`. Acceptance criterion 1 (all spawn sites under supervisor) was Phase 1.

The remaining open criterion (automatic respawn) was deferred indefinitely with rationale recorded in `docs/operations/worker-supervisor.md`. A future Phase 3 can revisit if alert evidence shows the dead-worker fleet rate is high enough to justify the design work.

## Changes
- `pkg/api/metrics.go`: add `xpfCollector.workerDead` gauge alongside the 7 existing per-worker counters; emit per-worker driven by `ProcessStatus.WorkerRuntime[i].Dead`. Always-emit (0 or 1), never absent.
- `pkg/api/metrics_test.go` (new): pin the gauge wire shape — mixed healthy/dead fixture and all-healthy fixture both verified.
- `docs/operations/worker-supervisor.md` (new): runbook covering the supervisor lifecycle, the suggested `XpfUserspaceWorkerDead` alert, the no-respawn rationale, and the HA non-interaction policy.
- `pkg/dataplane/userspace/protocol.go`, `userspace-dp/src/afxdp/worker_runtime.rs`: refresh stale "Phase 2 (respawn) will clear on relaunch" comments to reflect actual state.

## Plan + adversarial review
Plan doc: `docs/pr/925-phase2/plan.md` (v3, commit `96e8efc0`).

- Codex round-1 (`task-morpduik-e7wr83`): PLAN-NEEDS-MINOR — addressed in plan v2 (5 findings).
- Codex round-2 (`task-morpr2ic-xar6ai`): PLAN-NEEDS-MINOR — addressed in plan v3 (3 doc-consistency).
- Gemini round-1 (`task-morpts70-37oq7l`, gemini-2.5-flash): PLAN-READY on all 8 questions.

(Note: Gemini default has since been switched to gemini-3-pro-preview via PR #1185. This Phase 2 plan was reviewed under Flash — substance unchanged but Pro 3 will be the standard going forward.)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/api/...`: 2/2 new metric tests pass
- [x] Full Go suite: clean
- [x] `cargo build --release` clean (Rust touch is comment-only — `worker_runtime.rs:71-73`)
- [x] `cargo test --release`: 962/962 pass (Phase 1 supervisor tests unchanged)
- [x] Deploy on loss userspace cluster (fw0+fw1)
- [x] **Metric live**: `curl -s :8080/metrics | grep xpf_userspace_worker_dead` shows `0` for all 6 workers
- [x] **Pass A — CoS enabled** (smoke is the existing fleet config):
  - [x] v4 `iperf3 -P 12 -t 8 -R` p5201: **22.9 Gbps, 0 retrans**
  - [x] v6 `iperf3 -P 12 -t 8 -R` p5201: 22.4 Gbps, 210 retrans (within tolerance)
- [x] **Per-class CoS smoke** 5201-5206 v4 push+reverse: all 0 retrans
- [x] No expected throughput delta — change is Go-side metric exposure + 2 Rust comment-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)