### PR TITLE
#1189 Phase 1: extract supervisor helpers + WorkerManager::stop_and_clear

### DIFF
--- a/docs/operations/worker-supervisor.md
+++ b/docs/operations/worker-supervisor.md
@@ -8,7 +8,7 @@ runs a `worker_loop` that polls XSK rings and drives the per-packet
 pipeline (#925 Phase 1).
 
 `worker_loop` is wrapped in `catch_unwind` by a supervisor helper
-(`spawn_supervised_worker` in `userspace-dp/src/afxdp/coordinator/mod.rs`).
+(`spawn_supervised_worker` in `userspace-dp/src/afxdp/coordinator/supervisor.rs`).
 If a panic escapes the loop body, the supervisor:
 
 1. Catches the panic with `catch_unwind` so it does not propagate

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,0 +1,180 @@
+---
+status: DRAFT v1 — pending adversarial plan review (Phase 1 / WorkerManager only)
+issue: #1189
+phase: First incremental migration of one manager surface
+---
+
+## 1. Issue framing
+
+Issue #1189: `coordinator/mod.rs` is currently 1,959 lines
+("3,000-line monolith" in the issue body — actual count is
+1,959, with manager stubs already split out as separate files
+totalling ~290 LOC). Codex's Tier D review confirmed direction
+is right but premise is partially stale (decomposition started,
+just not finished).
+
+Current state:
+
+```
+coordinator/
+  bpf_maps.rs            16 LOC
+  cos_state.rs           26 LOC
+  ha_state.rs            25 LOC
+  inject.rs              154 LOC  (active — packet inject path)
+  mod.rs                 1959 LOC (the monolith)
+  neighbor_manager.rs    19 LOC   (stub)
+  session_manager.rs     30 LOC   (stub)
+  status.rs              191 LOC  (active — status surface)
+  tests.rs               1016 LOC
+  worker_manager.rs      31 LOC   (stub)
+```
+
+The named manager files exist as types but are mostly empty
+shells; the real logic lives in `mod.rs`'s `Coordinator` impl.
+
+## 2. Honest scope/value framing
+
+**This PR ships ONE manager surface only — `WorkerManager`** —
+to validate the migration shape before committing to the full
+4-manager decomposition. Migrating all four at once would be a
+multi-thousand-line PR with high merge-conflict surface.
+
+Win:
+
+- `coordinator/mod.rs` shrinks by the worker-supervision LOC
+  (estimated ~300-500 lines)
+- `worker_manager.rs` grows from 31 LOC stub to a real
+  `WorkerManager` with the moved methods
+- Future PRs can do `ConfigManager`, `NeighborManager`,
+  `SessionManager` as independent migrations
+- Each migration is **pure code motion + delegation** — no
+  behavior change
+
+**If reviewers find any cross-manager state coupling that
+prevents clean extraction (e.g., `WorkerManager` methods access
+private fields of `Coordinator` that other managers also need),
+PLAN-NEEDS-MAJOR is the right call.**
+
+## 3. Code paths affected
+
+### Coordinator's worker-supervision surface
+
+Need to identify which methods on `Coordinator` are
+worker-supervision concerns. Candidates (subject to
+implementation-phase audit):
+
+- `spawn_worker(...)` and the supervision loop
+- `WorkerCommand` dispatch path
+- Worker liveness tracking
+- Per-worker init / shutdown ordering
+
+These methods become methods on `WorkerManager`, with
+`Coordinator` owning a `WorkerManager` field and delegating.
+
+### `worker_manager.rs` grows
+
+Currently 31 LOC of stub. Will absorb the migrated methods.
+
+### Call sites
+
+`Coordinator::spawn_worker` callers (etc.) keep their interface
+via delegation: `Coordinator::spawn_worker` → `self.worker_manager.spawn(...)`.
+External callers see no change.
+
+## 4. Concrete design
+
+1. **Audit `mod.rs` for worker-related methods** — produce a
+   list with line numbers (do this in implementation phase, not
+   plan).
+
+2. **Lift each method to `WorkerManager`**, preserving behavior.
+   Where a method needs access to fields outside
+   `WorkerManager`'s scope, pass them as `&mut` parameters
+   rather than absorbing the field into `WorkerManager` (avoids
+   ownership refactor cascade).
+
+3. **`Coordinator` keeps a thin delegation layer**: each old
+   `Coordinator::method()` becomes
+   `self.worker_manager.method(self.peer_field, ...)`.
+
+4. **Tests**: existing `coordinator/tests.rs` (1016 LOC) covers
+   the public-API behavior; should pass unchanged. If any test
+   reaches into private worker-state directly, relocate it.
+
+5. **No behavior change**: every method's body moves verbatim;
+   only the receiver type changes.
+
+## 5. Public API preservation
+
+`Coordinator::spawn_worker(...)` (etc.) — keep all public
+signatures unchanged. Internal call site changes from `self.x`
+to `self.worker_manager.x`.
+
+## 6. Risk assessment
+
+| Class | Level | Why |
+|---|---|---|
+| Behavioral regression | LOW | Pure code motion + delegation |
+| Borrow-checker / lifetime | **MEDIUM** | If a method needs `&mut self.coordinator_field` AND `&mut self.worker_manager`, Rust's split-borrow may refuse |
+| Cross-manager coupling | **MEDIUM** | Worker supervision may touch HA state, neighbor state, etc. — split-borrow concerns multiply |
+| Test breakage | LOW | `tests.rs` should pass unchanged; relocate any private-field reaches |
+| Performance regression | LOW | Delegation adds one indirection per call; not on per-packet hot path |
+
+The Rust borrow-checker risk is the dominant one. Mitigation:
+where a method spans multiple managers' state, keep it on
+`Coordinator` with a comment "spans multiple managers' state;
+not migrated to a manager" — leave for future refactor with a
+proper redesign.
+
+## 7. Test plan
+
+**Cargo build**: clean.
+
+**Cargo tests**: `cargo test --release` — all 952+ pass.
+
+**5x flake check** on the most affected named test (probably
+something in `coordinator/tests.rs`).
+
+**Go tests**: unaffected (Rust-only).
+
+**Smoke matrix on loss userspace cluster**:
+- Pass A (CoS off): 6 cells, 0 retrans
+- Pass B (CoS on): 24 cells, 0 retrans
+- Total: 30 cells, 0 retrans (this is pure code motion + delegation)
+
+**Failover smoke**: `make test-failover` if accessible — the
+worker-supervision path is exercised heavily during failover.
+
+## 8. Out of scope
+
+- Migrating ConfigManager, NeighborManager, SessionManager —
+  each is its own follow-up PR
+- Adding tests for `WorkerManager` in isolation (the issue body
+  cites "untestable"; making it testable is part of the value
+  but adding new unit tests is follow-up work, not blocking
+  this PR)
+- Renaming any methods or changing signatures
+- Splitting `tests.rs` into per-manager test files
+
+## 9. Open questions for adversarial review
+
+1. Is `WorkerManager` the right first target, or would
+   `NeighborManager` / `SessionManager` be lower-coupling and
+   thus a better Phase 1?
+2. How tangled is worker supervision with HA state in the
+   current `mod.rs`? If extraction requires touching HA state
+   too, that's a Phase 1.5 (or a different first target).
+3. Will the 1016-line `tests.rs` break in non-obvious ways?
+   Specifically, do any tests construct `Coordinator` and then
+   call worker-related private methods?
+4. Does the existing `worker_manager.rs` (31 LOC stub) have any
+   committed direction the migration must follow, or is it an
+   empty starting point?
+
+## 10. Verdict request
+
+PLAN-READY → execute Phase 1 (WorkerManager only).
+PLAN-NEEDS-MINOR → tweak choice or scope, then execute.
+PLAN-NEEDS-MAJOR → revise (e.g., different first manager).
+PLAN-KILL → premise wrong; e.g., extraction structurally
+impossible due to coupling.

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v6 — Codex round-5 PLAN-NEEDS-MINOR; aligned section 2 line-56 test-citation with section 3 (1001 is a comment, not field access), added mod.rs:1061 to accessor migration, corrected `OwnedFd.fd` visibility from "public" to `pub(super)`, fixed section 4 step 6 to reference free-function paths (mod.rs:1849/1894/1922) not fictional `Coordinator::*` methods
+status: REVISED v7 — Codex round-6 PLAN-NEEDS-MINOR; added explicit step 7 covering post-move comment/doc updates (mod.rs:1890 "see ... in this file" reference; docs/operations/worker-supervisor.md:11 path; sharded_neighbor.rs:21 path)
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -338,6 +338,24 @@ which are NOT moved in Phase 1 — those tests are unaffected.
    the move they live in `coordinator::supervisor`; any leftover
    bare call would fail to resolve and be caught by the
    compiler.
+7. **Comment / doc-path cleanup** — the supervisor helper bodies
+   include doc comments that reference the helpers' *current*
+   location. After the move, three known references go stale and
+   must be updated by hand (no `pub(in crate::afxdp)`/
+   compiler signal to flag them):
+   - `coordinator/mod.rs:1890` (inside the moving
+     `spawn_supervised_aux` doc) — "see `recent_exceptions`
+     users in this file" still resolves correctly because
+     `recent_exceptions` is on `Coordinator` (which stays in
+     `mod.rs`); update the wording to "see `recent_exceptions`
+     users in `coordinator/mod.rs`" so it remains accurate after
+     the helper itself moves to `supervisor.rs`.
+   - `docs/operations/worker-supervisor.md:11` — currently
+     "`spawn_supervised_worker` in `userspace-dp/src/afxdp/
+     coordinator/mod.rs`"; update path to `coordinator/supervisor.rs`.
+   - `userspace-dp/src/afxdp/sharded_neighbor.rs:21` — currently
+     "`spawn_supervised_worker` in `coordinator/mod.rs`"; update
+     path to `coordinator/supervisor.rs`.
 
 **Hard rule (Codex round-1 #4):** WorkerManager methods MUST NOT
 take `&mut Coordinator`. `stop_and_clear` complies — it takes

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v2 — Codex round-1 PLAN-NEEDS-MAJOR; scope narrowed per Codex's findings
+status: REVISED v3 — Codex round-2 PLAN-NEEDS-MINOR; deleted v1 residue, reframed stop extraction with fd inputs, moved spawn_supervised_aux out of WorkerManager, documented test path updates
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -103,74 +103,162 @@ state, it stays on Coordinator.
 
 ## 3. Code paths affected
 
-### Coordinator's worker-supervision surface
+### `coordinator/mod.rs` — items leaving the file
 
-Need to identify which methods on `Coordinator` are
-worker-supervision concerns. Candidates (subject to
-implementation-phase audit):
+Phase 1 v3 moves four concrete slices out of `mod.rs`:
 
-- `spawn_worker(...)` and the supervision loop
-- `WorkerCommand` dispatch path
-- Worker liveness tracking
-- Per-worker init / shutdown ordering
+1. **`panic_payload_message(payload: &Box<dyn Any + Send>) -> String`**
+   — pure free function (`mod.rs:~1080`). Becomes a `pub(super)`
+   free function in a new `coordinator/supervisor.rs` (rationale
+   below).
+2. **`spawn_supervised_worker(...)`** — the panic-catch wrapper
+   for the per-worker `worker_loop` thread. Pure code motion to
+   `coordinator/supervisor.rs` as a `pub(super)` free function.
+   It already takes its dependencies as parameters and does not
+   touch `Coordinator` or `WorkerManager` state.
+3. **`spawn_supervised_aux(...)`** — the panic-catch wrapper for
+   *non-worker* aux threads (currently used by the neighbor
+   monitor at `mod.rs:780` and the local-tunnel source at
+   `mod.rs:830`). This is **not** worker-lifecycle and must not
+   live on `WorkerManager`. Lands in `coordinator/supervisor.rs`
+   alongside `spawn_supervised_worker` as a `pub(super)` free
+   function.
+4. **Worker stop/clear loop** at `mod.rs:202-222` (iterate
+   `self.workers.handles` to send shutdown / await joins / drop
+   `xsk_map`/`heartbeat_map` entries / clear `handles`). Becomes
+   a method `WorkerManager::stop_and_clear(&mut self,
+   xsk_map_fd: BorrowedFd<'_>, heartbeat_map_fd: BorrowedFd<'_>)`.
+   The map fds are passed in because they live on `Coordinator`
+   (or one of its sub-managers), not `WorkerManager`.
+5. **Accessor wrappers** for `last_planned_workers` /
+   `last_planned_bindings` — trivial `&self` getters added on
+   `WorkerManager`, then `mod.rs` reads `self.workers.last_planned_workers()`
+   instead of `self.workers.last_planned_workers` directly. Pure
+   wrapper change; no behavior change.
 
-These methods become methods on `WorkerManager`, with
-`Coordinator` owning a `WorkerManager` field and delegating.
+### What **stays on `Coordinator`** in Phase 1
+
+- `Coordinator::reconcile` (multi-manager state).
+- HA `WorkerCommand` dispatch in `ha.rs:40,102,171,310,366` (HA-owned).
+- `refresh_bindings` (CoS / forwarding / worker state span).
+- `worker_panics.clear()` — the panic-tracking map is a
+  `Coordinator` field, not a `WorkerManager` field. Phase 1 keeps
+  the clear in `Coordinator` and only moves the handle-iteration
+  / join / map-cleanup loop into `WorkerManager::stop_and_clear`.
+- Neighbor monitor and local-tunnel source supervision (they
+  call `spawn_supervised_aux` after this PR; `Coordinator` still
+  owns the join handles).
+
+### `coordinator/supervisor.rs` (new file, ~80-120 LOC)
+
+New sibling of `worker_manager.rs` holding the three free
+functions above. Visibility: `pub(super)` so `mod.rs` and
+`worker_manager.rs` can call into it without exposing the
+helpers crate-wide.
 
 ### `worker_manager.rs` grows
 
-Currently 31 LOC of stub. Will absorb the migrated methods.
+From 31 LOC stub (struct + `new()`) to ~60-90 LOC: add
+`stop_and_clear(...)` plus `last_planned_workers()` /
+`last_planned_bindings()` accessors.
 
-### Call sites
+### Test surface
 
-`Coordinator::spawn_worker` callers (etc.) keep their interface
-via delegation: `Coordinator::spawn_worker` → `self.worker_manager.spawn(...)`.
-External callers see no change.
+Existing tests at `coordinator/tests.rs:312,840,958` and
+`ha_tests.rs:235` reach into worker-related items directly:
+
+- `tests.rs:312,840,958` reference `super::panic_payload_message`
+  and `super::spawn_supervised_worker` /
+  `super::spawn_supervised_aux` from inside the
+  `coordinator::tests` module.
+
+After the move, `super::panic_payload_message` etc. resolve into
+`coordinator::supervisor::panic_payload_message`. Two equally
+valid options — pick one in implementation:
+
+- **Option A (preferred):** update test paths to
+  `super::supervisor::panic_payload_message` etc. Cleaner; no
+  re-export.
+- **Option B:** add `pub(super) use supervisor::{panic_payload_message,
+  spawn_supervised_worker, spawn_supervised_aux};` in `mod.rs`
+  so test paths stay unchanged. Smaller diff but adds a
+  coordinator-module re-export.
+
+`ha_tests.rs:235` reaches `super::ha::*` worker-command sites
+which are NOT moved in Phase 1 — those tests are unaffected.
 
 ## 4. Concrete design
 
-1. **Audit `mod.rs` for worker-related methods** — produce a
-   list with line numbers (do this in implementation phase, not
-   plan).
+1. Create `coordinator/supervisor.rs`. Move
+   `panic_payload_message`, `spawn_supervised_worker`, and
+   `spawn_supervised_aux` into it as `pub(super)` free
+   functions. Body verbatim (these already take their deps as
+   parameters; no receiver change needed).
+2. Add `mod supervisor;` to `coordinator/mod.rs`.
+3. Add method `pub(super) fn stop_and_clear(&mut self,
+   xsk_map_fd: BorrowedFd<'_>, heartbeat_map_fd: BorrowedFd<'_>)`
+   to `WorkerManager`. Body is the existing `mod.rs:202-222`
+   loop with `self.workers.` references rewritten to `self.`.
+   `Coordinator::shutdown` (or wherever the loop lives today)
+   becomes:
 
-2. **Lift each method to `WorkerManager`**, preserving behavior.
-   Where a method needs access to fields outside
-   `WorkerManager`'s scope, pass them as `&mut` parameters
-   rather than absorbing the field into `WorkerManager` (avoids
-   ownership refactor cascade).
+   ```rust
+   self.workers.stop_and_clear(
+       self.xsk_map.as_fd(),
+       self.heartbeat_map.as_fd(),
+   );
+   self.worker_panics.clear();   // stays on Coordinator
+   ```
 
-3. **`Coordinator` keeps a thin delegation layer**: each old
-   `Coordinator::method()` becomes
-   `self.worker_manager.method(self.peer_field, ...)`.
+4. Add `last_planned_workers(&self) -> usize` and
+   `last_planned_bindings(&self) -> usize` accessors on
+   `WorkerManager`. Update mod.rs read sites to call the
+   accessors. (Field visibility unchanged: still
+   `pub(in crate::afxdp)` for write access in `reconcile`.)
+5. Update test paths per Option A or Option B above.
+6. Verify nothing else references `Coordinator::panic_payload_message`,
+   `Coordinator::spawn_supervised_worker`, or
+   `Coordinator::spawn_supervised_aux`.
 
-4. **Tests**: existing `coordinator/tests.rs` (1016 LOC) covers
-   the public-API behavior; should pass unchanged. If any test
-   reaches into private worker-state directly, relocate it.
+**Hard rule (Codex round-1 #4):** WorkerManager methods MUST NOT
+take `&mut Coordinator`. `stop_and_clear` complies — it takes
+borrowed fds, not the parent.
 
-5. **No behavior change**: every method's body moves verbatim;
-   only the receiver type changes.
+**Honesty about "pure code motion":** the supervisor functions
+move verbatim. `stop_and_clear` is **not** byte-identical to the
+old loop body — it loses the implicit `self.workers.` qualifier
+on every reference and gains explicit fd parameters at the call
+site. Behaviorally identical, but the body is rewritten, not
+copy-pasted. Accessor wrappers are obviously not byte-identical
+either. Phase 1 is "behavior-preserving refactor", not "byte-
+verbatim move".
 
 ## 5. Public API preservation
 
-`Coordinator::spawn_worker(...)` (etc.) — keep all public
-signatures unchanged. Internal call site changes from `self.x`
-to `self.worker_manager.x`.
+No external (non-`afxdp`) signatures change. Within `afxdp`:
+
+- `Coordinator::shutdown` (or whichever entry owns the
+  stop loop) keeps its signature; its body now calls
+  `self.workers.stop_and_clear(...)` and then
+  `self.worker_panics.clear()`.
+- `panic_payload_message`, `spawn_supervised_worker`,
+  `spawn_supervised_aux` change resolution path from
+  `coordinator::*` to `coordinator::supervisor::*`. With
+  Option B re-exports their old paths still resolve.
+- New: `WorkerManager::stop_and_clear`,
+  `WorkerManager::last_planned_workers`,
+  `WorkerManager::last_planned_bindings` — all `pub(super)` /
+  `pub(in crate::afxdp)`.
 
 ## 6. Risk assessment
 
 | Class | Level | Why |
 |---|---|---|
-| Behavioral regression | LOW | Pure code motion + delegation |
-| Borrow-checker / lifetime | **MEDIUM** | If a method needs `&mut self.coordinator_field` AND `&mut self.worker_manager`, Rust's split-borrow may refuse |
-| Cross-manager coupling | **MEDIUM** | Worker supervision may touch HA state, neighbor state, etc. — split-borrow concerns multiply |
-| Test breakage | LOW | `tests.rs` should pass unchanged; relocate any private-field reaches |
-| Performance regression | LOW | Delegation adds one indirection per call; not on per-packet hot path |
-
-The Rust borrow-checker risk is the dominant one. Mitigation:
-where a method spans multiple managers' state, keep it on
-`Coordinator` with a comment "spans multiple managers' state;
-not migrated to a manager" — leave for future refactor with a
-proper redesign.
+| Behavioral regression | LOW | Supervisor helpers move verbatim; `stop_and_clear` is the same loop with explicit fd params; accessors are trivial getters |
+| Borrow-checker / lifetime | LOW-MED | `stop_and_clear` takes `BorrowedFd<'_>` so it does not double-borrow `self` while mutating `self.workers`. The map fds live on `Coordinator`, not under `self.workers`, so the split-borrow is clean |
+| Cross-manager coupling | LOW | Phase 1 explicitly excludes anything that spans multiple managers (reconcile, HA dispatch, refresh_bindings, neighbor/tunnel supervision lifecycle) |
+| Test path breakage | LOW | Predictable: tests need either updated `super::supervisor::*` paths or a re-export in `mod.rs`. Documented above |
+| Performance regression | LOW | `stop_and_clear` runs at shutdown only; accessor wrappers compile to direct field reads |
 
 ## 7. Test plan
 

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v5 — Codex round-4 PLAN-NEEDS-MAJOR; scrubbed last `BorrowedFd<'_>` residue at sections 2/6, named actual cleanup site (`stop_inner` at mod.rs:187), added `status.rs:184` and the three production helper-call sites at mod.rs:679/780/830, dropped tests.rs:1001 (was a comment), corrected panic_payload_message location to mod.rs:1849
+status: REVISED v6 — Codex round-5 PLAN-NEEDS-MINOR; aligned section 2 line-56 test-citation with section 3 (1001 is a comment, not field access), added mod.rs:1061 to accessor migration, corrected `OwnedFd.fd` visibility from "public" to `pub(super)`, fixed section 4 step 6 to reference free-function paths (mod.rs:1849/1894/1922) not fictional `Coordinator::*` methods
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -55,8 +55,9 @@ Coordinator` into `impl WorkerManager`**.
    (`ha.rs:40,102,171,310,366`), not just worker supervision.
 3. Tests reach private worker state directly via two paths —
    field access (`coordinator.workers.identities/live` at
-   `coordinator/tests.rs:312,322,958,1001`) and helper-function
-   calls (`super::panic_payload_message` /
+   `coordinator/tests.rs:312,322,958`; line 1001 is a *comment*,
+   not field access) and helper-function calls
+   (`super::panic_payload_message` /
    `super::spawn_supervised_worker` /
    `super::spawn_supervised_aux` at
    `coordinator/tests.rs:840,869,889,903,918`). `ha_tests.rs:235`
@@ -145,18 +146,23 @@ Phase 1 v5 moves five concrete slices out of `mod.rs`:
    xsk_map_fd: Option<&OwnedFd>, heartbeat_map_fd: Option<&OwnedFd>)`
    — see section 4 step 3 for the full signature and body.
    `OwnedFd` here is the project's local
-   `crate::afxdp::bpf_map::OwnedFd` (with public `.fd: c_int`
+   `crate::afxdp::bpf_map::OwnedFd` (with `pub(super) fd: c_int`
    field), **not** `std::os::fd::OwnedFd`. The map fds live on
    `Coordinator` via `BpfMaps`, not on `WorkerManager`, hence
    the explicit parameters.
 5. **Accessor wrappers** for `last_planned_workers` /
    `last_planned_bindings` — trivial `&self` getters added on
    `WorkerManager`. All read sites get updated:
-   - `mod.rs` (stage label / status surface in `reconcile`)
+   - `mod.rs:572-573` (stage label inside `reconcile`).
+   - `mod.rs:1061` (`num_workers = self.workers.last_planned_workers.max(1)` —
+     CoS vtime floor sizing).
    - `coordinator/status.rs:184` (`Coordinator::planned_counts`,
      which currently reads
      `self.workers.last_planned_workers` and
      `self.workers.last_planned_bindings` directly).
+   The two write sites at `mod.rs:288-289` (reconcile clear path)
+   and `mod.rs:568-569` (reconcile set path) keep direct field
+   access — accessors are read-only by design.
    The fields keep `pub(in crate::afxdp)` visibility because
    `reconcile` writes them; the accessors just give callers a
    stable read path. Pure wrapper change; no behavior change.
@@ -271,7 +277,7 @@ which are NOT moved in Phase 1 — those tests are unaffected.
 
    where `OwnedFd` is `crate::afxdp::bpf_map::OwnedFd` (the
    project's local newtype, **not** `std::os::fd::OwnedFd`; it
-   has a public `.fd: c_int` field). Body is the existing
+   has a `pub(super) fd: c_int` field). Body is the existing
    `mod.rs:202-222` block with `self.workers.` references
    rewritten to `self.`, preserving the `if let Some(map_fd) =
    ...` conditional cleanup exactly as today:
@@ -325,9 +331,13 @@ which are NOT moved in Phase 1 — those tests are unaffected.
    accessors. (Field visibility unchanged: still
    `pub(in crate::afxdp)` for write access in `reconcile`.)
 5. Update test paths per Option A or Option B above.
-6. Verify nothing else references `Coordinator::panic_payload_message`,
-   `Coordinator::spawn_supervised_worker`, or
-   `Coordinator::spawn_supervised_aux`.
+6. Verify nothing else references the three free functions (at
+   `mod.rs:1849`, `mod.rs:1894`, `mod.rs:1922`) outside the
+   sites listed above. They are free `fn` items in the
+   `coordinator` module, not methods on `Coordinator`. After
+   the move they live in `coordinator::supervisor`; any leftover
+   bare call would fail to resolve and be caught by the
+   compiler.
 
 **Hard rule (Codex round-1 #4):** WorkerManager methods MUST NOT
 take `&mut Coordinator`. `stop_and_clear` complies — it takes

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v7 — Codex round-6 PLAN-NEEDS-MINOR; added explicit step 7 covering post-move comment/doc updates (mod.rs:1890 "see ... in this file" reference; docs/operations/worker-supervisor.md:11 path; sharded_neighbor.rs:21 path)
+status: REVISED v8 — Codex round-7 PLAN-NEEDS-MINOR; softened byte-identical claim to acknowledge module-relative path rewrites are required (`super::worker_runtime::WorkerRuntimeAtomics` at mod.rs:1924 → `super::super::worker_runtime::WorkerRuntimeAtomics` or absolute `crate::afxdp::worker_runtime::WorkerRuntimeAtomics` after move into supervisor.rs); added step 8 covering this path rewrite
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -101,13 +101,18 @@ Win for Phase 1:
 - Validates the migration shape (small struct + sibling
   module + `pub(in crate::afxdp)` field for test access) before
   larger extractions like `reconcile` or HA dispatch
-- This is a **behavior-preserving refactor**, not byte-verbatim
-  motion. Specifically: the supervisor helpers
-  (`panic_payload_message`, `spawn_supervised_worker`,
-  `spawn_supervised_aux`) move byte-identical into
-  `coordinator/supervisor.rs`. The stop loop becomes
+- This is a **behavior-preserving refactor**. The supervisor
+  helpers (`panic_payload_message`, `spawn_supervised_worker`,
+  `spawn_supervised_aux`) move into `coordinator/supervisor.rs`
+  with their bodies essentially intact, but **module-relative
+  paths must be rewritten** because `super::` resolves to a
+  different parent after the move. Concretely, the
+  `Arc<super::worker_runtime::WorkerRuntimeAtomics>` parameter at
+  `mod.rs:1924` becomes `Arc<crate::afxdp::worker_runtime::WorkerRuntimeAtomics>`
+  (or `super::super::worker_runtime::WorkerRuntimeAtomics`) in
+  the new file. See section 4 step 8. The stop loop becomes
   `WorkerManager::stop_and_clear(...)` with explicit fd inputs;
-  the body is the same logic with `self.workers.` references
+  body is the same logic with `self.workers.` references
   rewritten to `self.`. Accessors are obviously not byte-
   identical. No observable behavior change in any case.
 
@@ -356,15 +361,32 @@ which are NOT moved in Phase 1 — those tests are unaffected.
    - `userspace-dp/src/afxdp/sharded_neighbor.rs:21` — currently
      "`spawn_supervised_worker` in `coordinator/mod.rs`"; update
      path to `coordinator/supervisor.rs`.
+8. **Module-relative path rewrites inside the moved helpers** —
+   `spawn_supervised_worker` at `mod.rs:1924` takes
+   `Arc<super::worker_runtime::WorkerRuntimeAtomics>`. From
+   `mod.rs`, `super::` resolves to `coordinator`'s parent
+   (`afxdp`); after the move into `coordinator/supervisor.rs`,
+   `super::` resolves to `coordinator`, which does **not** own
+   `worker_runtime`. The fix in the new file: change to
+   `Arc<crate::afxdp::worker_runtime::WorkerRuntimeAtomics>`
+   (absolute, robust to further refactors) or
+   `Arc<super::super::worker_runtime::WorkerRuntimeAtomics>`
+   (relative, two hops up). Pick the absolute form for clarity.
+   Re-grep the moved helper bodies for any other `super::*`
+   path-bearing references and rewrite the same way; the
+   compiler will catch any miss.
 
 **Hard rule (Codex round-1 #4):** WorkerManager methods MUST NOT
 take `&mut Coordinator`. `stop_and_clear` complies — it takes
 borrowed fds, not the parent.
 
 **Honesty about "pure code motion":** the supervisor functions
-move verbatim. `stop_and_clear` is **not** byte-identical to the
-old loop body — it loses the implicit `self.workers.` qualifier
-on every reference and gains explicit fd parameters at the call
+move with their bodies essentially intact, but module-relative
+paths inside them must be rewritten (see step 8 above —
+`super::worker_runtime` no longer resolves correctly after the
+move). `stop_and_clear` is **not** byte-identical to the old
+loop body — it loses the implicit `self.workers.` qualifier on
+every reference and gains explicit fd parameters at the call
 site. Behaviorally identical, but the body is rewritten, not
 copy-pasted. Accessor wrappers are obviously not byte-identical
 either. Phase 1 is "behavior-preserving refactor", not "byte-
@@ -413,7 +435,7 @@ something in `coordinator/tests.rs`).
 **Smoke matrix on loss userspace cluster**:
 - Pass A (CoS off): 6 cells, 0 retrans
 - Pass B (CoS on): 24 cells, 0 retrans
-- Total: 30 cells, 0 retrans (this is a behavior-preserving refactor — supervisor helpers move byte-identical; stop loop and accessors rewritten in shape but not in behavior)
+- Total: 30 cells, 0 retrans (this is a behavior-preserving refactor — supervisor helper bodies move essentially intact with module-relative path rewrites; stop loop and accessors rewritten in shape but not in behavior)
 
 **Failover smoke**: `make test-failover` if accessible — the
 worker-supervision path is exercised heavily during failover.

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v9 — Codex round-8 PLAN-NEEDS-MINOR; corrected Option B to private `use supervisor::{...};` (not `pub(super) use`, which Rust rejects as private-item re-export of `pub(super)` items), and trimmed the production `use` import to only the two spawn helpers actually called from production sites (`panic_payload_message` is test-only)
+status: REVISED v10 — Codex round-9 PLAN-NEEDS-MINOR; corrected Option B test-scope wording — a test-module-local `use` only resolves bare calls; preserving the existing `super::panic_payload_message` test path needs `#[cfg(test)] use supervisor::panic_payload_message;` in `coordinator/mod.rs` (the parent module), not in the test module itself
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -261,10 +261,16 @@ helpers — `panic_payload_message` is exclusively used by tests
 trigger an `unused_imports` warning under `#[cfg(not(test))]`
 builds. Under Option A the prod `use` covers production calls
 and tests use the explicit `super::supervisor::*` path. Under
-Option B the same prod `use` covers production calls and a
-separate private `use supervisor::{panic_payload_message,
-spawn_supervised_worker, spawn_supervised_aux};` (or a single
-combined `use supervisor::*;`) in the test module covers tests.
+Option B the prod `use` covers production calls and a
+`#[cfg(test)] use supervisor::panic_payload_message;` is added
+in `coordinator/mod.rs` (the parent module of `tests`) so that
+the existing `super::panic_payload_message` test path at
+`tests.rs:840` continues to resolve. Note: a test-module-local
+import would *not* satisfy `super::panic_payload_message`
+because `super::` from inside the test module resolves to
+`coordinator::` (where the symbol must live to be reachable via
+that path); the `cfg(test) use` in the parent module gates
+the import to test builds without leaking it into prod.
 
 Implementation checklist must touch all five lines (840, 869,
 889, 903, 918) under Option A or none under Option B; do not

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v10 — Codex round-9 PLAN-NEEDS-MINOR; corrected Option B test-scope wording — a test-module-local `use` only resolves bare calls; preserving the existing `super::panic_payload_message` test path needs `#[cfg(test)] use supervisor::panic_payload_message;` in `coordinator/mod.rs` (the parent module), not in the test module itself
+status: v10 FINAL — Codex round-10 PLAN-READY. Implementation uses Option A (tests call `super::supervisor::*` directly; cleanest path, no re-export needed). Plan rounds 1-10 progression preserved in git history
 issue: #1189
 phase: First incremental migration of one manager surface
 ---

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: DRAFT v1 — pending adversarial plan review (Phase 1 / WorkerManager only)
+status: REVISED v2 — Codex round-1 PLAN-NEEDS-MAJOR; scope narrowed per Codex's findings
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -32,28 +32,74 @@ coordinator/
 The named manager files exist as types but are mostly empty
 shells; the real logic lives in `mod.rs`'s `Coordinator` impl.
 
-## 2. Honest scope/value framing
+## 2. Honest scope/value framing — v2 (narrowed per Codex round-1)
 
-**This PR ships ONE manager surface only — `WorkerManager`** —
-to validate the migration shape before committing to the full
-4-manager decomposition. Migrating all four at once would be a
-multi-thousand-line PR with high merge-conflict surface.
+**Important correction:** `WorkerManager` already exists as a
+struct (`coordinator/worker_manager.rs:13-19`) with the right
+fields (`live`, `identities`, `handles`, `last_planned_*`).
+`Coordinator` already owns it via `pub(in crate::afxdp) workers:
+WorkerManager` field. This PR is NOT "create WorkerManager" —
+it's **migrate selected worker-related METHODS from `impl
+Coordinator` into `impl WorkerManager`**.
 
-Win:
+**Codex round-1 narrowed the scope.** The original plan said
+"extract worker supervision" but Codex caught:
 
-- `coordinator/mod.rs` shrinks by the worker-supervision LOC
-  (estimated ~300-500 lines)
-- `worker_manager.rs` grows from 31 LOC stub to a real
-  `WorkerManager` with the moved methods
-- Future PRs can do `ConfigManager`, `NeighborManager`,
-  `SessionManager` as independent migrations
-- Each migration is **pure code motion + delegation** — no
-  behavior change
+1. The named `Coordinator::spawn_worker` doesn't exist — worker
+   spawn is embedded in `Coordinator::reconcile`
+   (`mod.rs:322,630`) which passes 12+ deps to `worker_loop`
+   (HA runtime, shared forwarding, fabrics, RG epochs, sessions,
+   neighbors, slow path, local tunnel, CoS shared maps, event
+   stream, panic slots, recent status queues).
+2. `WorkerCommand` dispatch is owned by HA paths
+   (`ha.rs:40,102,171,310,366`), not just worker supervision.
+3. Tests reach private worker state directly
+   (`coordinator/tests.rs:312,840,958`,
+   `ha_tests.rs:235`).
 
-**If reviewers find any cross-manager state coupling that
-prevents clean extraction (e.g., `WorkerManager` methods access
-private fields of `Coordinator` that other managers also need),
-PLAN-NEEDS-MAJOR is the right call.**
+So `reconcile` and HA command dispatch CANNOT migrate cleanly
+in Phase 1. They span too many managers' state.
+
+**Phase 1 v2 — concrete movable slices only:**
+
+- `panic_payload_message` helper (free function or method;
+  pure formatting)
+- `spawn_supervised_worker` / `spawn_supervised_aux` (the panic-
+  catch wrapper; depends only on `WorkerHandle` lifecycle, no
+  cross-manager state)
+- Worker stop/clear loops at `mod.rs:202-222` (iterate
+  `self.workers.handles` to send shutdown / await joins / clear)
+- `last_planned_workers` / `last_planned_bindings` accessor
+  methods (currently inline; pure getter wrappers)
+
+**Stays on `Coordinator` for Phase 1:**
+
+- `reconcile` (multi-manager state)
+- HA command dispatch in `ha.rs` (HA-owned)
+- `refresh_bindings` (CoS / forwarding / worker state span)
+- CoS refresh
+- Neighbor monitor
+- Local tunnel source spawning
+
+**Follow-up phases (not this PR):** larger extractions of
+`reconcile` or HA dispatch require a `WorkerSpawnDeps` /
+context type design — out of scope here.
+
+Win for Phase 1:
+- `coordinator/mod.rs` shrinks by ~50-150 LOC (the panic /
+  shutdown / accessor helpers)
+- `worker_manager.rs` grows from 31 LOC stub with `new()` only
+  to ~120-200 LOC with the migrated methods
+- Validates the migration shape (delegation pattern + test
+  access via `pub(in crate::afxdp)` field) before larger
+  extractions
+- Each migrated method is **pure code motion** — body verbatim,
+  receiver type changes from `&mut Coordinator` (or `&self`) to
+  `&mut WorkerManager` (or `&self`). No behavior change.
+
+**Hard rule (Codex round-1 #4):** WorkerManager methods MUST
+NOT take `&mut Coordinator`. If a method needs Coordinator-only
+state, it stays on Coordinator.
 
 ## 3. Code paths affected
 

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v4 — Codex round-3 PLAN-NEEDS-MAJOR; corrected stop_and_clear signature to match actual `Option<&OwnedFd>` types in `BpfMaps`, scrubbed "pure code motion" residue document-wide, corrected test line citations (helper uses are 840/869/889/903/918; 312/322/958/1001 are unaffected direct-field access)
+status: REVISED v5 — Codex round-4 PLAN-NEEDS-MAJOR; scrubbed last `BorrowedFd<'_>` residue at sections 2/6, named actual cleanup site (`stop_inner` at mod.rs:187), added `status.rs:184` and the three production helper-call sites at mod.rs:679/780/830, dropped tests.rs:1001 (was a comment), corrected panic_payload_message location to mod.rs:1849
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -118,10 +118,10 @@ state, it stays on Coordinator.
 
 ### `coordinator/mod.rs` — items leaving the file
 
-Phase 1 v3 moves four concrete slices out of `mod.rs`:
+Phase 1 v5 moves five concrete slices out of `mod.rs`:
 
 1. **`panic_payload_message(payload: &Box<dyn Any + Send>) -> String`**
-   — pure free function (`mod.rs:~1080`). Becomes a `pub(super)`
+   — pure free function at `mod.rs:1849`. Becomes a `pub(super)`
    free function in a new `coordinator/supervisor.rs` (rationale
    below).
 2. **`spawn_supervised_worker(...)`** — the panic-catch wrapper
@@ -136,18 +136,30 @@ Phase 1 v3 moves four concrete slices out of `mod.rs`:
    live on `WorkerManager`. Lands in `coordinator/supervisor.rs`
    alongside `spawn_supervised_worker` as a `pub(super)` free
    function.
-4. **Worker stop/clear loop** at `mod.rs:202-222` (iterate
+4. **Worker stop/clear loop** at `mod.rs:202-222` (inside
+   `Coordinator::stop_inner` at `mod.rs:187`, called by both
+   `stop` and `stop_with_event_stream`). Iterates
    `self.workers.handles` to send shutdown / await joins / drop
-   `xsk_map`/`heartbeat_map` entries / clear `handles`). Becomes
+   `xsk_map`/`heartbeat_map` entries / clear `handles`. Becomes
    a method `WorkerManager::stop_and_clear(&mut self,
-   xsk_map_fd: BorrowedFd<'_>, heartbeat_map_fd: BorrowedFd<'_>)`.
-   The map fds are passed in because they live on `Coordinator`
-   (or one of its sub-managers), not `WorkerManager`.
+   xsk_map_fd: Option<&OwnedFd>, heartbeat_map_fd: Option<&OwnedFd>)`
+   — see section 4 step 3 for the full signature and body.
+   `OwnedFd` here is the project's local
+   `crate::afxdp::bpf_map::OwnedFd` (with public `.fd: c_int`
+   field), **not** `std::os::fd::OwnedFd`. The map fds live on
+   `Coordinator` via `BpfMaps`, not on `WorkerManager`, hence
+   the explicit parameters.
 5. **Accessor wrappers** for `last_planned_workers` /
    `last_planned_bindings` — trivial `&self` getters added on
-   `WorkerManager`, then `mod.rs` reads `self.workers.last_planned_workers()`
-   instead of `self.workers.last_planned_workers` directly. Pure
-   wrapper change; no behavior change.
+   `WorkerManager`. All read sites get updated:
+   - `mod.rs` (stage label / status surface in `reconcile`)
+   - `coordinator/status.rs:184` (`Coordinator::planned_counts`,
+     which currently reads
+     `self.workers.last_planned_workers` and
+     `self.workers.last_planned_bindings` directly).
+   The fields keep `pub(in crate::afxdp)` visibility because
+   `reconcile` writes them; the accessors just give callers a
+   stable read path. Pure wrapper change; no behavior change.
 
 ### What **stays on `Coordinator`** in Phase 1
 
@@ -182,7 +194,11 @@ Two distinct kinds of test reaches into private worker-related state.
 **Direct field access (unaffected by this PR):**
 
 - `tests.rs:312,322` insert into `coordinator.workers.identities`.
-- `tests.rs:958,1001` insert into / inspect `coordinator.workers.live`.
+- `tests.rs:958` inserts into `coordinator.workers.live`.
+- `tests.rs:1001` is a comment about deliberately *not*
+  inserting into `coordinator.workers.live` for slot 7 — no
+  field access, just documentation; flagging here only because a
+  future grep would surface it.
 
 These rely on the existing `pub(in crate::afxdp)` field
 visibility on `WorkerManager`'s fields and continue to work
@@ -208,6 +224,25 @@ valid options — pick one in implementation:
   spawn_supervised_worker, spawn_supervised_aux};` in `mod.rs`
   so the existing five test paths stay unchanged. Smaller diff
   but adds a coordinator-module re-export.
+
+**Production helper-call sites in `mod.rs` (require path
+update under both Option A and Option B):**
+
+- `mod.rs:679` — `spawn_supervised_worker(...)` from
+  `Coordinator::reconcile` (the worker spawn path).
+- `mod.rs:780` — `spawn_supervised_aux("neigh-monitor", ...)`
+  from the neighbor-monitor setup.
+- `mod.rs:830` — `spawn_supervised_aux(format!(...), ...)`
+  from the local-tunnel source setup.
+
+These are bare unqualified calls today (the helpers live in the
+same module). After the move they need to resolve into
+`supervisor::*`. The cleanest fix is a `use supervisor::{
+panic_payload_message, spawn_supervised_worker,
+spawn_supervised_aux};` at the top of `mod.rs` so the three
+production sites stay untouched. (This is module-scope `use`,
+not the test-only `pub(super) use` of Option B; both can coexist
+or only the production `use` is needed under Option A.)
 
 Implementation checklist must touch all five lines (840, 869,
 889, 903, 918) under Option A or none under Option B; do not
@@ -265,8 +300,9 @@ which are NOT moved in Phase 1 — those tests are unaffected.
    self.live.clear();
    ```
 
-   `Coordinator::shutdown` (or wherever the cleanup lives today)
-   replaces `mod.rs:202-222` with:
+   `Coordinator::stop_inner` at `mod.rs:187` (called by both
+   `stop` and `stop_with_event_stream`) replaces `mod.rs:202-222`
+   with:
 
    ```rust
    self.workers.stop_and_clear(
@@ -310,10 +346,12 @@ verbatim move".
 
 No external (non-`afxdp`) signatures change. Within `afxdp`:
 
-- `Coordinator::shutdown` (or whichever entry owns the
-  stop loop) keeps its signature; its body now calls
-  `self.workers.stop_and_clear(...)` and then
-  `self.worker_panics.clear()`.
+- `Coordinator::stop_inner` (`mod.rs:187`) keeps its signature
+  (`pub(crate) fn stop_inner(&mut self, clear_synced_state: bool)`);
+  its body now calls `self.workers.stop_and_clear(...)` and
+  then `self.worker_panics.clear()` in place of the inline
+  `mod.rs:202-222` block. Both public callers (`stop` and
+  `stop_with_event_stream`) pick up the change transparently.
 - `panic_payload_message`, `spawn_supervised_worker`,
   `spawn_supervised_aux` change resolution path from
   `coordinator::*` to `coordinator::supervisor::*`. With
@@ -328,7 +366,7 @@ No external (non-`afxdp`) signatures change. Within `afxdp`:
 | Class | Level | Why |
 |---|---|---|
 | Behavioral regression | LOW | Supervisor helpers move verbatim; `stop_and_clear` is the same loop with explicit fd params; accessors are trivial getters |
-| Borrow-checker / lifetime | LOW-MED | `stop_and_clear` takes `BorrowedFd<'_>` so it does not double-borrow `self` while mutating `self.workers`. The map fds live on `Coordinator`, not under `self.workers`, so the split-borrow is clean |
+| Borrow-checker / lifetime | LOW-MED | `stop_and_clear` takes `Option<&OwnedFd>` (read-only borrow on `BpfMaps` fields) and `&mut self` for the WorkerManager. The map fds live on `Coordinator` via `self.bpf_maps`, not under `self.workers`, so the split-borrow `self.workers.stop_and_clear(self.bpf_maps.map_fd.as_ref(), self.bpf_maps.heartbeat_map_fd.as_ref())` is clean — disjoint fields |
 | Cross-manager coupling | LOW | Phase 1 explicitly excludes anything that spans multiple managers (reconcile, HA dispatch, refresh_bindings, neighbor/tunnel supervision lifecycle) |
 | Test path breakage | LOW | Predictable: tests need either updated `super::supervisor::*` paths or a re-export in `mod.rs`. Documented above |
 | Performance regression | LOW | `stop_and_clear` runs at shutdown only; accessor wrappers compile to direct field reads |

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v8 — Codex round-7 PLAN-NEEDS-MINOR; softened byte-identical claim to acknowledge module-relative path rewrites are required (`super::worker_runtime::WorkerRuntimeAtomics` at mod.rs:1924 → `super::super::worker_runtime::WorkerRuntimeAtomics` or absolute `crate::afxdp::worker_runtime::WorkerRuntimeAtomics` after move into supervisor.rs); added step 8 covering this path rewrite
+status: REVISED v9 — Codex round-8 PLAN-NEEDS-MINOR; corrected Option B to private `use supervisor::{...};` (not `pub(super) use`, which Rust rejects as private-item re-export of `pub(super)` items), and trimmed the production `use` import to only the two spawn helpers actually called from production sites (`panic_payload_message` is test-only)
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -231,10 +231,14 @@ valid options — pick one in implementation:
   from `super::panic_payload_message` →
   `super::supervisor::panic_payload_message` (similarly for
   the other two helpers). Cleaner; no re-export.
-- **Option B:** add `pub(super) use supervisor::{panic_payload_message,
+- **Option B:** add a private `use supervisor::{panic_payload_message,
   spawn_supervised_worker, spawn_supervised_aux};` in `mod.rs`
-  so the existing five test paths stay unchanged. Smaller diff
-  but adds a coordinator-module re-export.
+  so the existing five test paths stay unchanged. (Rust rejects
+  `pub(super) use` of `pub(super)` items as a private-item
+  re-export, so the `use` MUST be private — module-scope only.
+  An alternative is to widen the helpers to `pub(in crate::afxdp)`
+  and use `pub(super) use`, but the private `use` is the cleaner
+  fix and keeps visibility minimal.)
 
 **Production helper-call sites in `mod.rs` (require path
 update under both Option A and Option B):**
@@ -248,12 +252,19 @@ update under both Option A and Option B):**
 
 These are bare unqualified calls today (the helpers live in the
 same module). After the move they need to resolve into
-`supervisor::*`. The cleanest fix is a `use supervisor::{
-panic_payload_message, spawn_supervised_worker,
-spawn_supervised_aux};` at the top of `mod.rs` so the three
-production sites stay untouched. (This is module-scope `use`,
-not the test-only `pub(super) use` of Option B; both can coexist
-or only the production `use` is needed under Option A.)
+`supervisor::*`. The cleanest fix is a private
+`use supervisor::{spawn_supervised_worker, spawn_supervised_aux};`
+at the top of `mod.rs` so the three production sites stay
+untouched. Note: the production import only needs the two spawn
+helpers — `panic_payload_message` is exclusively used by tests
+(`tests.rs:840`), so importing it in non-test scope would
+trigger an `unused_imports` warning under `#[cfg(not(test))]`
+builds. Under Option A the prod `use` covers production calls
+and tests use the explicit `super::supervisor::*` path. Under
+Option B the same prod `use` covers production calls and a
+separate private `use supervisor::{panic_payload_message,
+spawn_supervised_worker, spawn_supervised_aux};` (or a single
+combined `use supervisor::*;`) in the test module covers tests.
 
 Implementation checklist must touch all five lines (840, 869,
 889, 903, 918) under Option A or none under Option B; do not

--- a/docs/pr/1189-coordinator-decompose/plan.md
+++ b/docs/pr/1189-coordinator-decompose/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v3 — Codex round-2 PLAN-NEEDS-MINOR; deleted v1 residue, reframed stop extraction with fd inputs, moved spawn_supervised_aux out of WorkerManager, documented test path updates
+status: REVISED v4 — Codex round-3 PLAN-NEEDS-MAJOR; corrected stop_and_clear signature to match actual `Option<&OwnedFd>` types in `BpfMaps`, scrubbed "pure code motion" residue document-wide, corrected test line citations (helper uses are 840/869/889/903/918; 312/322/958/1001 are unaffected direct-field access)
 issue: #1189
 phase: First incremental migration of one manager surface
 ---
@@ -53,9 +53,16 @@ Coordinator` into `impl WorkerManager`**.
    stream, panic slots, recent status queues).
 2. `WorkerCommand` dispatch is owned by HA paths
    (`ha.rs:40,102,171,310,366`), not just worker supervision.
-3. Tests reach private worker state directly
-   (`coordinator/tests.rs:312,840,958`,
-   `ha_tests.rs:235`).
+3. Tests reach private worker state directly via two paths —
+   field access (`coordinator.workers.identities/live` at
+   `coordinator/tests.rs:312,322,958,1001`) and helper-function
+   calls (`super::panic_payload_message` /
+   `super::spawn_supervised_worker` /
+   `super::spawn_supervised_aux` at
+   `coordinator/tests.rs:840,869,889,903,918`). `ha_tests.rs:235`
+   reaches `super::ha::*` worker-command sites which are NOT
+   moved in Phase 1. See section 3 for the test-surface
+   treatment.
 
 So `reconcile` and HA command dispatch CANNOT migrate cleanly
 in Phase 1. They span too many managers' state.
@@ -90,12 +97,18 @@ Win for Phase 1:
   shutdown / accessor helpers)
 - `worker_manager.rs` grows from 31 LOC stub with `new()` only
   to ~120-200 LOC with the migrated methods
-- Validates the migration shape (delegation pattern + test
-  access via `pub(in crate::afxdp)` field) before larger
-  extractions
-- Each migrated method is **pure code motion** — body verbatim,
-  receiver type changes from `&mut Coordinator` (or `&self`) to
-  `&mut WorkerManager` (or `&self`). No behavior change.
+- Validates the migration shape (small struct + sibling
+  module + `pub(in crate::afxdp)` field for test access) before
+  larger extractions like `reconcile` or HA dispatch
+- This is a **behavior-preserving refactor**, not byte-verbatim
+  motion. Specifically: the supervisor helpers
+  (`panic_payload_message`, `spawn_supervised_worker`,
+  `spawn_supervised_aux`) move byte-identical into
+  `coordinator/supervisor.rs`. The stop loop becomes
+  `WorkerManager::stop_and_clear(...)` with explicit fd inputs;
+  the body is the same logic with `self.workers.` references
+  rewritten to `self.`. Accessors are obviously not byte-
+  identical. No observable behavior change in any case.
 
 **Hard rule (Codex round-1 #4):** WorkerManager methods MUST
 NOT take `&mut Coordinator`. If a method needs Coordinator-only
@@ -164,25 +177,41 @@ From 31 LOC stub (struct + `new()`) to ~60-90 LOC: add
 
 ### Test surface
 
-Existing tests at `coordinator/tests.rs:312,840,958` and
-`ha_tests.rs:235` reach into worker-related items directly:
+Two distinct kinds of test reaches into private worker-related state.
 
-- `tests.rs:312,840,958` reference `super::panic_payload_message`
-  and `super::spawn_supervised_worker` /
-  `super::spawn_supervised_aux` from inside the
-  `coordinator::tests` module.
+**Direct field access (unaffected by this PR):**
 
-After the move, `super::panic_payload_message` etc. resolve into
-`coordinator::supervisor::panic_payload_message`. Two equally
+- `tests.rs:312,322` insert into `coordinator.workers.identities`.
+- `tests.rs:958,1001` insert into / inspect `coordinator.workers.live`.
+
+These rely on the existing `pub(in crate::afxdp)` field
+visibility on `WorkerManager`'s fields and continue to work
+unchanged — the fields keep that visibility because `reconcile`
+in `mod.rs` writes them.
+
+**Helper-function calls (require path update):**
+
+- `tests.rs:840` — `super::panic_payload_message(&payload)`
+- `tests.rs:869` — `super::spawn_supervised_worker(...)`
+- `tests.rs:889,903,918` — `super::spawn_supervised_aux(...)`
+
+After the move, `super::panic_payload_message` etc. no longer
+resolve directly inside `coordinator::tests` (because the
+helpers have moved to `coordinator::supervisor`). Two equally
 valid options — pick one in implementation:
 
-- **Option A (preferred):** update test paths to
-  `super::supervisor::panic_payload_message` etc. Cleaner; no
-  re-export.
+- **Option A (preferred):** update the five call sites above
+  from `super::panic_payload_message` →
+  `super::supervisor::panic_payload_message` (similarly for
+  the other two helpers). Cleaner; no re-export.
 - **Option B:** add `pub(super) use supervisor::{panic_payload_message,
   spawn_supervised_worker, spawn_supervised_aux};` in `mod.rs`
-  so test paths stay unchanged. Smaller diff but adds a
-  coordinator-module re-export.
+  so the existing five test paths stay unchanged. Smaller diff
+  but adds a coordinator-module re-export.
+
+Implementation checklist must touch all five lines (840, 869,
+889, 903, 918) under Option A or none under Option B; do not
+mix the two.
 
 `ha_tests.rs:235` reaches `super::ha::*` worker-command sites
 which are NOT moved in Phase 1 — those tests are unaffected.
@@ -195,20 +224,64 @@ which are NOT moved in Phase 1 — those tests are unaffected.
    functions. Body verbatim (these already take their deps as
    parameters; no receiver change needed).
 2. Add `mod supervisor;` to `coordinator/mod.rs`.
-3. Add method `pub(super) fn stop_and_clear(&mut self,
-   xsk_map_fd: BorrowedFd<'_>, heartbeat_map_fd: BorrowedFd<'_>)`
-   to `WorkerManager`. Body is the existing `mod.rs:202-222`
-   loop with `self.workers.` references rewritten to `self.`.
-   `Coordinator::shutdown` (or wherever the loop lives today)
-   becomes:
+3. Add method on `WorkerManager`:
+
+   ```rust
+   pub(super) fn stop_and_clear(
+       &mut self,
+       xsk_map_fd: Option<&OwnedFd>,
+       heartbeat_map_fd: Option<&OwnedFd>,
+   )
+   ```
+
+   where `OwnedFd` is `crate::afxdp::bpf_map::OwnedFd` (the
+   project's local newtype, **not** `std::os::fd::OwnedFd`; it
+   has a public `.fd: c_int` field). Body is the existing
+   `mod.rs:202-222` block with `self.workers.` references
+   rewritten to `self.`, preserving the `if let Some(map_fd) =
+   ...` conditional cleanup exactly as today:
+
+   ```rust
+   for handle in self.handles.values_mut() {
+       handle.stop.store(true, Ordering::Relaxed);
+   }
+   for (_, handle) in self.handles.iter_mut() {
+       if let Some(join) = handle.join.take() {
+           let _ = join.join();
+       }
+   }
+   if let Some(map_fd) = xsk_map_fd {
+       for slot in self.live.keys().copied().collect::<Vec<_>>() {
+           let _ = delete_xsk_slot(map_fd.fd, slot);
+       }
+   }
+   if let Some(map_fd) = heartbeat_map_fd {
+       for slot in self.live.keys().copied().collect::<Vec<_>>() {
+           let _ = delete_heartbeat_slot(map_fd.fd, slot);
+       }
+   }
+   self.handles.clear();
+   self.identities.clear();
+   self.live.clear();
+   ```
+
+   `Coordinator::shutdown` (or wherever the cleanup lives today)
+   replaces `mod.rs:202-222` with:
 
    ```rust
    self.workers.stop_and_clear(
-       self.xsk_map.as_fd(),
-       self.heartbeat_map.as_fd(),
+       self.bpf_maps.map_fd.as_ref(),
+       self.bpf_maps.heartbeat_map_fd.as_ref(),
    );
    self.worker_panics.clear();   // stays on Coordinator
    ```
+
+   The conditional-cleanup behavior is preserved bit-for-bit:
+   `Option<&OwnedFd>` is `None` exactly when `bpf_maps.*` is
+   `None` today, so the same branches execute in both cases.
+   `worker_panics.clear()` stays on `Coordinator` per Codex
+   round-2 guidance — `worker_panics` is a Coordinator field,
+   not WorkerManager state.
 
 4. Add `last_planned_workers(&self) -> usize` and
    `last_planned_bindings(&self) -> usize` accessors on
@@ -274,7 +347,7 @@ something in `coordinator/tests.rs`).
 **Smoke matrix on loss userspace cluster**:
 - Pass A (CoS off): 6 cells, 0 retrans
 - Pass B (CoS on): 24 cells, 0 retrans
-- Total: 30 cells, 0 retrans (this is pure code motion + delegation)
+- Total: 30 cells, 0 retrans (this is a behavior-preserving refactor — supervisor helpers move byte-identical; stop loop and accessors rewritten in shape but not in behavior)
 
 **Failover smoke**: `make test-failover` if accessible — the
 worker-supervision path is exercised heavily during failover.

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -6,7 +6,9 @@ mod inject;
 mod neighbor_manager;
 mod session_manager;
 mod status;
+mod supervisor;
 mod worker_manager;
+use supervisor::{spawn_supervised_aux, spawn_supervised_worker};
 pub(crate) use bpf_maps::BpfMaps;
 pub(crate) use cos_state::SharedCoSState;
 pub(in crate::afxdp) use ha_state::HaState;
@@ -199,27 +201,10 @@ impl Coordinator {
         self.tunnel_sources.clear();
         self.local_tunnel_deliveries
             .store(Arc::new(BTreeMap::new()));
-        for handle in self.workers.handles.values_mut() {
-            handle.stop.store(true, Ordering::Relaxed);
-        }
-        for (_, handle) in self.workers.handles.iter_mut() {
-            if let Some(join) = handle.join.take() {
-                let _ = join.join();
-            }
-        }
-        if let Some(map_fd) = self.bpf_maps.map_fd.as_ref() {
-            for slot in self.workers.live.keys().copied().collect::<Vec<_>>() {
-                let _ = delete_xsk_slot(map_fd.fd, slot);
-            }
-        }
-        if let Some(map_fd) = self.bpf_maps.heartbeat_map_fd.as_ref() {
-            for slot in self.workers.live.keys().copied().collect::<Vec<_>>() {
-                let _ = delete_heartbeat_slot(map_fd.fd, slot);
-            }
-        }
-        self.workers.handles.clear();
-        self.workers.identities.clear();
-        self.workers.live.clear();
+        self.workers.stop_and_clear(
+            self.bpf_maps.map_fd.as_ref(),
+            self.bpf_maps.heartbeat_map_fd.as_ref(),
+        );
         // #925 Phase 1: drop the per-worker panic slots alongside the
         // workers themselves so a long-running daemon that reconciles
         // through many worker-id sets doesn't accumulate stale slots.
@@ -569,8 +554,8 @@ impl Coordinator {
         self.workers.last_planned_bindings = planned_bindings;
         self.last_reconcile_stage = format!(
             "planned:workers={}:bindings={}:live={}",
-            self.workers.last_planned_workers,
-            self.workers.last_planned_bindings,
+            self.workers.last_planned_workers(),
+            self.workers.last_planned_bindings(),
             self.workers.live.len()
         );
         eprintln!(
@@ -1058,7 +1043,7 @@ impl Coordinator {
         // boot which produces zero-slot floors (the reconcile
         // re-fires once workers are planned).
         let current_queue_vtime_floors = self.cos.queue_vtime_floors.load();
-        let num_workers = self.workers.last_planned_workers.max(1);
+        let num_workers = self.workers.last_planned_workers().max(1);
         let next_queue_vtime_floors = build_shared_cos_queue_vtime_floors_reusing_existing(
             &self.forwarding,
             num_workers,
@@ -1836,123 +1821,6 @@ fn shared_cos_owner_live_by_queue_match(
         })
 }
 
-/// #925 Phase 1: render a panic payload as an operator-readable string.
-///
-/// Cases:
-/// - `&str` payload → the panic argument verbatim.
-/// - `String` payload → its content.
-/// - Anything else → literal `"non-string panic payload"`.
-///
-/// We deliberately do NOT try to extract a concrete type name from a
-/// `dyn Any` payload — `type_name_of_val` on a `Box<dyn Any>` returns
-/// the trait object's name, not the inner type, which would mislead.
-fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        String::from("non-string panic payload")
-    }
-}
-
-/// #925 Phase 1.5: spawn an auxiliary (non-worker) thread on a
-/// named thread and wrap it with `catch_unwind`. On panic, log a
-/// stderr message that surfaces in journald, then exit the thread
-/// without respawning.
-///
-/// Used for control-plane helper threads that don't have per-worker
-/// `runtime_atomics` (e.g. `neigh-monitor`, `xpf-native-gre-origin-*`).
-/// Worker threads use `spawn_supervised_worker` which records the
-/// panic in the per-worker `dead` flag exposed through
-/// `crate::protocol::WorkerRuntimeStatus` on the userspace
-/// control-socket JSON status path (NOT gRPC — the dataplane status
-/// is JSON-over-Unix-socket, only the daemon's outward-facing API
-/// is gRPC). Aux threads have no equivalent status surface and rely
-/// on journald log scraping.
-///
-/// Operator-visible degradation when an aux thread dies (#925-A):
-/// - `neigh-monitor` death: dynamic neighbor cache stops updating;
-///   forwarding falls back to slow-path NDP/ARP resolution after
-///   kernel TTL expiration. Degrades over minutes.
-/// - `xpf-native-gre-origin-*` death: that tunnel's local-origin
-///   packet stream stops; transit packets through the tunnel are
-///   unaffected (those go through worker_loop).
-///
-/// `AssertUnwindSafe` rationale: aux thread bodies own their state
-/// and `Arc`s; no `&mut` parameters cross the unwind. Shared
-/// `Arc<Mutex<…>>` may become poisoned. Same-file consumers
-/// follow two poison-tolerant patterns: (a) `into_inner` recovery
-/// (e.g. the worker `panic_slot` write at the bottom of
-/// `spawn_supervised_worker`), and (b) `if let Ok(mut guard) =
-/// lock { ... }` which silently drops the guard on poison and
-/// proceeds — lossy for that one operation but never propagates
-/// the panic (see `recent_exceptions` users in this file). Aux
-/// threads only touch `Arc<Mutex<…>>` via the `(b)` pattern, so a
-/// poisoned mutex degrades a single error-recording attempt and
-/// does not cascade.
-fn spawn_supervised_aux<S, F>(name: S, body: F) -> std::io::Result<thread::JoinHandle<()>>
-where
-    S: Into<String>,
-    F: FnOnce() + Send + 'static,
-{
-    let name = name.into();
-    let log_name = name.clone();
-    thread::Builder::new().name(name).spawn(move || {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
-        if let Err(payload) = result {
-            let msg = panic_payload_message(&payload);
-            eprintln!(
-                "xpf-userspace-dp: aux thread '{log_name}' panicked: {msg}",
-            );
-        }
-    })
-}
-
-/// #925 Phase 1: spawn `body` on a named thread and wrap it with
-/// `catch_unwind`. On panic, mark `runtime_atomics.dead = true` and
-/// publish the rendered payload to `panic_slot`.
-///
-/// `AssertUnwindSafe` rationale (narrow): `worker_loop` takes owned
-/// values and `Arc`s — there are no `&mut` parameters to invalidate
-/// across an unwind. Owned values get dropped on unwind. Shared
-/// `Arc<Mutex<…>>` state MAY become poisoned; per #925's "detection
-/// only" framing this PR does not promise full state recovery — see
-/// `docs/pr/925-worker-supervisor/plan.md` §"AssertUnwindSafe rationale".
-fn spawn_supervised_worker<F>(
-    worker_id: u32,
-    runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
-    panic_slot: Arc<Mutex<Option<String>>>,
-    body: F,
-) -> std::io::Result<thread::JoinHandle<()>>
-where
-    F: FnOnce() + Send + 'static,
-{
-    thread::Builder::new()
-        .name(format!("xpf-userspace-worker-{worker_id}"))
-        .spawn(move || {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
-            if let Err(payload) = result {
-                let msg = panic_payload_message(&payload);
-                eprintln!(
-                    "xpf-userspace-dp: worker_loop panicked (worker_id={worker_id}): {msg}",
-                );
-                // Write the message under the slot mutex; on poison
-                // (a prior panic during read), use into_inner — same
-                // pattern as #949's dynamic_neighbors policy.
-                match panic_slot.lock() {
-                    Ok(mut slot) => *slot = Some(msg),
-                    Err(poisoned) => *poisoned.into_inner() = Some(msg),
-                }
-                // Mark dead. Relaxed is fine — the panic_slot mutex
-                // publishes the message; the dead flag is a one-shot
-                // diagnostic, not a synchronization barrier.
-                runtime_atomics
-                    .dead
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-        })
-}
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -182,7 +182,7 @@ impl super::Coordinator {
     }
 
     pub fn planned_counts(&self) -> (usize, usize) {
-        (self.workers.last_planned_workers, self.workers.last_planned_bindings)
+        (self.workers.last_planned_workers(), self.workers.last_planned_bindings())
     }
 
     pub fn reconcile_debug(&self) -> (u64, String) {

--- a/userspace-dp/src/afxdp/coordinator/supervisor.rs
+++ b/userspace-dp/src/afxdp/coordinator/supervisor.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+/// #925 Phase 1: render a panic payload as an operator-readable string.
+///
+/// Cases:
+/// - `&str` payload → the panic argument verbatim.
+/// - `String` payload → its content.
+/// - Anything else → literal `"non-string panic payload"`.
+///
+/// We deliberately do NOT try to extract a concrete type name from a
+/// `dyn Any` payload — `type_name_of_val` on a `Box<dyn Any>` returns
+/// the trait object's name, not the inner type, which would mislead.
+pub(super) fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        String::from("non-string panic payload")
+    }
+}
+
+/// #925 Phase 1.5: spawn an auxiliary (non-worker) thread on a
+/// named thread and wrap it with `catch_unwind`. On panic, log a
+/// stderr message that surfaces in journald, then exit the thread
+/// without respawning.
+///
+/// Used for control-plane helper threads that don't have per-worker
+/// `runtime_atomics` (e.g. `neigh-monitor`, `xpf-native-gre-origin-*`).
+/// Worker threads use `spawn_supervised_worker` which records the
+/// panic in the per-worker `dead` flag exposed through
+/// `crate::protocol::WorkerRuntimeStatus` on the userspace
+/// control-socket JSON status path (NOT gRPC — the dataplane status
+/// is JSON-over-Unix-socket, only the daemon's outward-facing API
+/// is gRPC). Aux threads have no equivalent status surface and rely
+/// on journald log scraping.
+///
+/// Operator-visible degradation when an aux thread dies (#925-A):
+/// - `neigh-monitor` death: dynamic neighbor cache stops updating;
+///   forwarding falls back to slow-path NDP/ARP resolution after
+///   kernel TTL expiration. Degrades over minutes.
+/// - `xpf-native-gre-origin-*` death: that tunnel's local-origin
+///   packet stream stops; transit packets through the tunnel are
+///   unaffected (those go through worker_loop).
+///
+/// `AssertUnwindSafe` rationale: aux thread bodies own their state
+/// and `Arc`s; no `&mut` parameters cross the unwind. Shared
+/// `Arc<Mutex<…>>` may become poisoned. Same-file consumers
+/// follow two poison-tolerant patterns: (a) `into_inner` recovery
+/// (e.g. the worker `panic_slot` write at the bottom of
+/// `spawn_supervised_worker`), and (b) `if let Ok(mut guard) =
+/// lock { ... }` which silently drops the guard on poison and
+/// proceeds — lossy for that one operation but never propagates
+/// the panic (see `recent_exceptions` users in `coordinator/mod.rs`).
+/// Aux threads only touch `Arc<Mutex<…>>` via the `(b)` pattern, so a
+/// poisoned mutex degrades a single error-recording attempt and
+/// does not cascade.
+pub(super) fn spawn_supervised_aux<S, F>(name: S, body: F) -> std::io::Result<thread::JoinHandle<()>>
+where
+    S: Into<String>,
+    F: FnOnce() + Send + 'static,
+{
+    let name = name.into();
+    let log_name = name.clone();
+    thread::Builder::new().name(name).spawn(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+        if let Err(payload) = result {
+            let msg = panic_payload_message(&payload);
+            eprintln!(
+                "xpf-userspace-dp: aux thread '{log_name}' panicked: {msg}",
+            );
+        }
+    })
+}
+
+/// #925 Phase 1: spawn `body` on a named thread and wrap it with
+/// `catch_unwind`. On panic, mark `runtime_atomics.dead = true` and
+/// publish the rendered payload to `panic_slot`.
+///
+/// `AssertUnwindSafe` rationale (narrow): `worker_loop` takes owned
+/// values and `Arc`s — there are no `&mut` parameters to invalidate
+/// across an unwind. Owned values get dropped on unwind. Shared
+/// `Arc<Mutex<…>>` state MAY become poisoned; per #925's "detection
+/// only" framing this PR does not promise full state recovery — see
+/// `docs/pr/925-worker-supervisor/plan.md` §"AssertUnwindSafe rationale".
+pub(super) fn spawn_supervised_worker<F>(
+    worker_id: u32,
+    runtime_atomics: Arc<crate::afxdp::worker_runtime::WorkerRuntimeAtomics>,
+    panic_slot: Arc<Mutex<Option<String>>>,
+    body: F,
+) -> std::io::Result<thread::JoinHandle<()>>
+where
+    F: FnOnce() + Send + 'static,
+{
+    thread::Builder::new()
+        .name(format!("xpf-userspace-worker-{worker_id}"))
+        .spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+            if let Err(payload) = result {
+                let msg = panic_payload_message(&payload);
+                eprintln!(
+                    "xpf-userspace-dp: worker_loop panicked (worker_id={worker_id}): {msg}",
+                );
+                // Write the message under the slot mutex; on poison
+                // (a prior panic during read), use into_inner — same
+                // pattern as #949's dynamic_neighbors policy.
+                match panic_slot.lock() {
+                    Ok(mut slot) => *slot = Some(msg),
+                    Err(poisoned) => *poisoned.into_inner() = Some(msg),
+                }
+                // Mark dead. Relaxed is fine — the panic_slot mutex
+                // publishes the message; the dead flag is a one-shot
+                // diagnostic, not a synchronization barrier.
+                runtime_atomics
+                    .dead
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+        })
+}

--- a/userspace-dp/src/afxdp/coordinator/supervisor.rs
+++ b/userspace-dp/src/afxdp/coordinator/supervisor.rs
@@ -45,7 +45,7 @@ pub(super) fn panic_payload_message(payload: &Box<dyn std::any::Any + Send>) -> 
 ///
 /// `AssertUnwindSafe` rationale: aux thread bodies own their state
 /// and `Arc`s; no `&mut` parameters cross the unwind. Shared
-/// `Arc<Mutex<…>>` may become poisoned. Same-file consumers
+/// `Arc<Mutex<…>>` may become poisoned. Consumers in `coordinator/mod.rs`
 /// follow two poison-tolerant patterns: (a) `into_inner` recovery
 /// (e.g. the worker `panic_slot` write at the bottom of
 /// `spawn_supervised_worker`), and (b) `if let Ok(mut guard) =

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -837,7 +837,7 @@ fn ring_pressure_counters_round_trip_through_snapshot() {
 fn caught_message<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
     let r = std::panic::catch_unwind(f);
     let payload = r.unwrap_err();
-    super::panic_payload_message(&payload)
+    super::supervisor::panic_payload_message(&payload)
 }
 
 #[test]
@@ -866,7 +866,7 @@ fn spawn_supervised_worker_catches_string_panic_and_marks_dead() {
     use std::sync::atomic::Ordering;
     let atomics = Arc::new(super::super::worker_runtime::WorkerRuntimeAtomics::new());
     let slot = Arc::new(Mutex::new(None::<String>));
-    let join = super::spawn_supervised_worker(7, atomics.clone(), slot.clone(), || {
+    let join = super::supervisor::spawn_supervised_worker(7, atomics.clone(), slot.clone(), || {
         panic!("intentional test panic")
     })
     .expect("spawn_supervised_worker");
@@ -886,7 +886,7 @@ fn spawn_supervised_worker_catches_string_panic_and_marks_dead() {
 /// catch_unwind + journald log + clean exit.
 #[test]
 fn spawn_supervised_aux_catches_string_panic_and_returns_cleanly() {
-    let join = super::spawn_supervised_aux("test-aux", || {
+    let join = super::supervisor::spawn_supervised_aux("test-aux", || {
         panic!("intentional aux test panic")
     })
     .expect("spawn_supervised_aux");
@@ -900,7 +900,7 @@ fn spawn_supervised_aux_runs_body_to_completion_when_no_panic() {
     use std::sync::atomic::{AtomicBool, Ordering};
     let ran = Arc::new(AtomicBool::new(false));
     let ran_clone = ran.clone();
-    let join = super::spawn_supervised_aux("test-aux-noop", move || {
+    let join = super::supervisor::spawn_supervised_aux("test-aux-noop", move || {
         ran_clone.store(true, Ordering::Relaxed);
     })
     .expect("spawn_supervised_aux");
@@ -915,7 +915,7 @@ fn spawn_supervised_aux_runs_body_to_completion_when_no_panic() {
 fn spawn_supervised_aux_catches_non_string_panic_payload() {
     // Non-string payload exercises the panic_payload_message fallback
     // path, mirroring the worker_loop integration test above.
-    let join = super::spawn_supervised_aux("test-aux-i32", || {
+    let join = super::supervisor::spawn_supervised_aux("test-aux-i32", || {
         std::panic::panic_any(99_i32)
     })
     .expect("spawn_supervised_aux");

--- a/userspace-dp/src/afxdp/coordinator/worker_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/worker_manager.rs
@@ -28,4 +28,44 @@ impl WorkerManager {
             last_planned_bindings: 0,
         }
     }
+
+    pub(super) fn last_planned_workers(&self) -> usize {
+        self.last_planned_workers
+    }
+
+    pub(super) fn last_planned_bindings(&self) -> usize {
+        self.last_planned_bindings
+    }
+
+    /// #1189 Phase 1: stop all workers, drain map slots, and clear
+    /// per-worker state. Called from `Coordinator::stop_inner`.
+    /// Caller passes the BPF map fds because they live on
+    /// `Coordinator::bpf_maps`, not on `WorkerManager`.
+    pub(super) fn stop_and_clear(
+        &mut self,
+        xsk_map_fd: Option<&crate::afxdp::bpf_map::OwnedFd>,
+        heartbeat_map_fd: Option<&crate::afxdp::bpf_map::OwnedFd>,
+    ) {
+        for handle in self.handles.values_mut() {
+            handle.stop.store(true, Ordering::Relaxed);
+        }
+        for (_, handle) in self.handles.iter_mut() {
+            if let Some(join) = handle.join.take() {
+                let _ = join.join();
+            }
+        }
+        if let Some(map_fd) = xsk_map_fd {
+            for slot in self.live.keys().copied().collect::<Vec<_>>() {
+                let _ = delete_xsk_slot(map_fd.fd, slot);
+            }
+        }
+        if let Some(map_fd) = heartbeat_map_fd {
+            for slot in self.live.keys().copied().collect::<Vec<_>>() {
+                let _ = delete_heartbeat_slot(map_fd.fd, slot);
+            }
+        }
+        self.handles.clear();
+        self.identities.clear();
+        self.live.clear();
+    }
 }

--- a/userspace-dp/src/afxdp/coordinator/worker_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/worker_manager.rs
@@ -56,11 +56,13 @@ impl WorkerManager {
                 let _ = join.join();
             }
         }
-        for (&slot, _) in &self.live {
-            if let Some(fd) = xsk_map_fd {
+        if let Some(fd) = xsk_map_fd {
+            for (&slot, _) in &self.live {
                 let _ = delete_xsk_slot(fd.fd, slot);
             }
-            if let Some(fd) = heartbeat_map_fd {
+        }
+        if let Some(fd) = heartbeat_map_fd {
+            for (&slot, _) in &self.live {
                 let _ = delete_heartbeat_slot(fd.fd, slot);
             }
         }

--- a/userspace-dp/src/afxdp/coordinator/worker_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/worker_manager.rs
@@ -14,8 +14,8 @@ pub(in crate::afxdp) struct WorkerManager {
     pub(in crate::afxdp) live: BTreeMap<u32, Arc<BindingLiveState>>,
     pub(in crate::afxdp) identities: BTreeMap<u32, BindingIdentity>,
     pub(in crate::afxdp) handles: BTreeMap<u32, WorkerHandle>,
-    pub(in crate::afxdp) last_planned_workers: usize,
-    pub(in crate::afxdp) last_planned_bindings: usize,
+    pub(super) last_planned_workers: usize,
+    pub(super) last_planned_bindings: usize,
 }
 
 impl WorkerManager {
@@ -29,10 +29,12 @@ impl WorkerManager {
         }
     }
 
+    #[inline]
     pub(super) fn last_planned_workers(&self) -> usize {
         self.last_planned_workers
     }
 
+    #[inline]
     pub(super) fn last_planned_bindings(&self) -> usize {
         self.last_planned_bindings
     }
@@ -49,19 +51,17 @@ impl WorkerManager {
         for handle in self.handles.values_mut() {
             handle.stop.store(true, Ordering::Relaxed);
         }
-        for (_, handle) in self.handles.iter_mut() {
+        for handle in self.handles.values_mut() {
             if let Some(join) = handle.join.take() {
                 let _ = join.join();
             }
         }
-        if let Some(map_fd) = xsk_map_fd {
-            for slot in self.live.keys().copied().collect::<Vec<_>>() {
-                let _ = delete_xsk_slot(map_fd.fd, slot);
+        for (&slot, _) in &self.live {
+            if let Some(fd) = xsk_map_fd {
+                let _ = delete_xsk_slot(fd.fd, slot);
             }
-        }
-        if let Some(map_fd) = heartbeat_map_fd {
-            for slot in self.live.keys().copied().collect::<Vec<_>>() {
-                let _ = delete_heartbeat_slot(map_fd.fd, slot);
+            if let Some(fd) = heartbeat_map_fd {
+                let _ = delete_heartbeat_slot(fd.fd, slot);
             }
         }
         self.handles.clear();

--- a/userspace-dp/src/afxdp/sharded_neighbor.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor.rs
@@ -18,7 +18,7 @@
 //!   that wants more than one shard also locks in ascending order.
 //! - Poison policy: `lock().unwrap_or_else(|e| e.into_inner())`.
 //!   Workers DO have a `catch_unwind` supervisor as of #925 Phase 1
-//!   (`spawn_supervised_worker` in `coordinator/mod.rs`), and #925
+//!   (`spawn_supervised_worker` in `coordinator/supervisor.rs`), and #925
 //!   Phase 2 surfaces panics on Prometheus
 //!   (`xpf_userspace_worker_dead`). But a poisoned `Mutex` here is
 //!   operationally worse than a stale MAC for the *surviving* threads:


### PR DESCRIPTION
## Summary

Behavior-preserving refactor: split the worker supervision/lifecycle slice out of the 1,959-line `coordinator/mod.rs` into two new structures.

**New file `coordinator/supervisor.rs`** (~110 LOC) holds the three free fns moved from `mod.rs`:
- `panic_payload_message` — body byte-identical
- `spawn_supervised_aux` — body byte-identical (used for neighbor monitor + local tunnel source threads)
- `spawn_supervised_worker` — body byte-identical except path rewrite `Arc<super::worker_runtime::WorkerRuntimeAtomics>` → `Arc<crate::afxdp::worker_runtime::WorkerRuntimeAtomics>` (`super::` resolves differently after move)

**`WorkerManager` grows from 31 LOC stub to 71 LOC**:
- `stop_and_clear(Option<&OwnedFd>, Option<&OwnedFd>)` — moves the 21-line stop loop from `mod.rs:202-222` into the manager. Map fds passed in because `BpfMaps` lives on `Coordinator`. `worker_panics.clear()` stays on `Coordinator` (it's a Coordinator field, not WorkerManager state).
- `last_planned_workers()` / `last_planned_bindings()` accessors. Three read sites updated: `status.rs:185`, `mod.rs:557-558`, `mod.rs:1046`. Two write sites in `reconcile` keep direct field access.

**`mod.rs` shrinks by 149 LOC**. Adds `mod supervisor;` + `use supervisor::{spawn_supervised_aux, spawn_supervised_worker};` (`panic_payload_message` is test-only, not imported in production).

## Plan + adversarial review

Plan doc: `docs/pr/1189-coordinator-decompose/plan.md` (v10 commit 9729ea9f).

Codex plan reviews — 10 rounds:
- v1→v2: scope narrowed (PLAN-NEEDS-MAJOR — generic "extract WorkerManager" → 5 specific movable slices)
- v2→v3: stale text scrub (PLAN-NEEDS-MINOR ×4)
- v3→v4: stop API mismatch with actual `Option<OwnedFd>` types (PLAN-NEEDS-MAJOR)
- v4→v8: stale residue, missing read sites, fictional method names, byte-identical claims, missing path-rewrite step (PLAN-NEEDS-MINOR/MINOR/MINOR/MINOR)
- v9: Option B private-use Rust error (PLAN-NEEDS-MINOR)
- v10: Option B test-scope wording (PLAN-NEEDS-MINOR)
- Round 10: **PLAN-READY**

## Test plan

- [x] cargo build --release: clean
- [x] cargo test --release: 974/974 pass
- [x] Deploy on loss userspace cluster
- [x] **Pass A — CoS disabled** (best-effort fast path)
  - [x] v4 push: 7.57 Gb/s, 0 retrans against 172.16.80.200
  - [x] v4 reverse (`-R`): 7.38 Gb/s, 0 retrans
  - [x] v6 push: 7.51 Gb/s, 0 retrans against 2001:559:8585:80::200
  - [x] v6 reverse (`-R`): 7.33 Gb/s, 0 retrans
  - [x] v4 multi-stream reverse: 22.8 Gb/s line rate, 0 retrans
  - [x] v6 multi-stream reverse: 22.6 Gb/s line rate, 0 retrans
- [x] **Pass B — CoS enabled** (per-class shaper + classifier)
  - [x] All 24 per-class cells (5201-5206 × v4+v6 × push+rev) pass, 0 retrans
  - [x] iperf-a (1 Gb/s shape): hits 959/946 Mbps push cleanly, 0 retrans

🤖 Generated with [Claude Code](https://claude.com/claude-code)