### PR TITLE
#1188: replace per-tick .load_full() with .load() + Arc::ptr_eq short-circuit in worker tick

### DIFF
--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v5 — Codex+Gemini round-4 caught two more bugs: (1) `arc_swap::Guard::into_inner` is hallucinated — no such method exists; use `Arc::clone(&*guard)` which still gives TOCTOU avoidance because we clone the exact observed Arc; (2) forwarding-site ordering: `screen_state.update_profiles` + `sessions.set_timeouts` at `worker/mod.rs:731-732` read `forwarding`, must use `new_forwarding` not the cached pre-assignment value. v5 specifies the full forwarding-site code template and scrubs stale prose at lines 59, 192, 234
+status: REVISED v6 — Codex round-5 caught Gemini round-4's hallucination claim was itself wrong. Verified `arc_swap::Guard::into_inner(lease: Self) -> T` exists in arc-swap 1.8.2 (Cargo.lock-confirmed; src/lib.rs). It is strictly better than `Arc::clone(&*guard)` because it transfers ownership via `mem::forget` + raw pointer extraction, avoiding the atomic refcount increment. Reverted to `Guard::into_inner`. v5 forwarding-site ordering template kept. v6 also scrubs the remaining stale `.load_full()` / `Arc::as_ptr` prose Codex flagged at lines 261, 294, 300
 issue: #1188
 phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
 ---
@@ -71,8 +71,9 @@ if let Some(new_forwarding) =
 - Steady state (no config change): saved 12 atomic RMW ops/tick →
   ~0.96B–9.6B ops/sec eliminated from the QPI/UPI bus.
 - On actual config change (rare, < 1/sec normally): one
-  cheap `.load()` + one `Arc::clone` (atomic increment).
-  Negligible at ~1/sec rate.
+  cheap `.load()` + one `Guard::into_inner` (no atomic increment;
+  ownership transfer via `mem::forget`). Negligible at ~1/sec
+  rate.
 - No coordinator-side changes. No new types except the helper
   fn. No semantics change.
 
@@ -166,7 +167,7 @@ forgiving than the forwarding site.
 - v5: full template above shows correct ordering; "use new_X for side effects, then assign" is the rule.
 
 The helper is non-mutating and returns the freshly observed Arc
-(`Arc::clone(&*guard)`). No TOCTOU window, no second `.load_full()`,
+(`arc_swap::Guard::into_inner`). No TOCTOU window, no second `.load_full()`,
 old/new comparison and side effects all use whichever value
 is correct.
 
@@ -185,19 +186,19 @@ To avoid 6 copies of the same pattern, introduce a small helper:
 /// `cos_runtime_config_changed(old, new)` while both the old and
 /// new Arcs are accessible.
 ///
-/// **TOCTOU avoidance (Codex round-2 / Gemini round-4 correction):**
-/// clone the exact `Arc` the `Guard` is observing — `Arc::clone(&*guard)`
-/// — instead of calling `.load_full()` a second time. Calling
-/// `.load_full()` again could return a *newer* Arc if the coordinator
-/// rotated between our `ptr_eq` check and the second load. Cloning
-/// the observed Guard pins the exact snapshot we compared.
+/// **TOCTOU avoidance:** consume the observed `Guard` via
+/// `arc_swap::Guard::into_inner(guard)` to extract the exact Arc
+/// the Guard was observing. This avoids a second `.load_full()`
+/// (which could return a *newer* Arc if the coordinator rotated
+/// between our `ptr_eq` check and the second load) AND avoids the
+/// atomic refcount increment that `Arc::clone(&*guard)` would
+/// incur. `Guard::into_inner` uses `mem::forget` + raw pointer
+/// extraction internally — see arc-swap 1.8.2 `src/lib.rs`.
 ///
-/// **Why not `arc_swap::Guard::into_inner`?** Because that method
-/// does not exist. `arc_swap::Guard` is a hazard-pointer-style protect
-/// — it does not hold its own strong refcount. Converting a Guard
-/// to an owned `Arc<T>` requires an atomic refcount increment via
-/// `Arc::clone`. That increment cost is real and acceptable: it
-/// only fires when the configuration actually changed (rare).
+/// Review note (rounds 4-5): Gemini Pro 3.1 round-4 erroneously
+/// claimed `into_inner` was hallucinated; Codex round-5 verified
+/// it exists in the locked arc-swap version. v6 reverts to
+/// `Guard::into_inner` — strictly better than `Arc::clone(&*guard)`.
 ///
 /// Gemini Pro 3.1 round-2: use idiomatic `Arc::ptr_eq` (the `Guard`
 /// derefs to `&Arc<T>`); `T: ?Sized` is dropped — all 6 call sites
@@ -210,7 +211,7 @@ fn load_arc_if_changed<T>(
     if Arc::ptr_eq(cached, &*guard) {
         None
     } else {
-        Some(Arc::clone(&*guard))
+        Some(arc_swap::Guard::into_inner(guard))
     }
 }
 ```
@@ -258,7 +259,7 @@ The helper is a private fn or a module-local utility.
 | Behavioral regression | **VERY LOW** | Side effects only fire on actual change; same as today |
 | Borrow-checker | LOW | The `Guard` returned by `.load()` is dropped at end of block; no lifetime issues |
 | Performance regression | **VERY LOW** (correctness side) | One extra pointer comparison per tick — negligible |
-| Correctness on rotation | LOW | If the Arc is rotated between the `.load()` ptr comparison and the subsequent `.load_full()`, we just observe the new Arc — slightly newer than the guard, but always-monotonic |
+| Correctness on rotation | LOW | `Guard::into_inner` consumes the exact Arc the `Guard` was observing, so there's no second-load TOCTOU window |
 | Test breakage | LOW | Existing tests assert config-change observation; that path is unchanged |
 
 ## 8. Test plan
@@ -291,17 +292,16 @@ The helper is a private fn or a module-local utility.
    some prior tick. If coordinator rotates twice between two
    ticks, we still observe a difference.
 
-2. **Is the `drop(live_X_guard)` before `.load_full()` necessary?**
-   `.load()` holds a hazard-pointer-style guard internally. If
-   we hold the guard while calling `.load_full()` (which clones
-   the Arc), are we double-borrowing the inner Arc? Confirm
-   `arc_swap` semantics permit this.
+2. ~~Is the `drop(live_X_guard)` before `.load_full()` necessary?~~
+   **Resolved (round-2/round-5):** v6 uses `Guard::into_inner`
+   which consumes the Guard, transferring ownership without an
+   atomic increment. No `drop` ceremony, no second `.load_full()`.
 
 3. **What if 5 of 6 fields are usually changed together?** Then
    the `.load() + ptr_eq` short-circuit hits N times less
-   often, and we pay the `.load_full()` cost N times anyway.
-   Likelihood: low — config reloads change `forwarding`, while
-   CoS lease rotations are independent.
+   often, and we pay one `Guard::into_inner` per changed
+   field anyway. Likelihood: low — config reloads change
+   `forwarding`, while CoS lease rotations are independent.
 
 4. **Should the `shared_validation` `.load()` site (line 721) be
    refactored similarly for consistency?** It's already cheap

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v3 — Codex + Gemini Pro 3.1 round-2 PLAN-NEEDS-MINOR converged on helper signature: use `Arc::ptr_eq(cached, &*guard)` (idiomatic) + `arc_swap::Guard::into_inner(guard)` (avoids TOCTOU + second load) + drop `T: ?Sized` (minimal trait bounds; all 6 sites sized)
+status: REVISED v4 — Codex round-3 PLAN-NEEDS-MAJOR caught semantic bug: v3 helper mutated `cached_X` before the side-effect block, but `worker/mod.rs:727` needs OLD forwarding to call `cos_runtime_config_changed(old, new)`. v4 changes helper to non-mutating `load_arc_if_changed -> Option<Arc<T>>` so callers control the assignment order
 issue: #1188
 phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
 ---
@@ -40,9 +40,13 @@ the same socket) — exactly what the issue body describes.
 ## 2. Honest scope/value framing
 
 **The fix:** replace each `.load_full()` with `.load()` (returns
-a `Guard<Arc<T>>`, no clone) + `Arc::as_ptr` comparison against
-the cached Arc. Only call `.load_full()` when the pointer
-differs (i.e., the coordinator actually rotated the Arc).
+a `Guard<Arc<T>>`, no clone) + `Arc::ptr_eq(cached, &*guard)`
+comparison. When the comparison shows divergence, consume the
+observed `Guard` via `arc_swap::Guard::into_inner(guard)` (no
+second load, no TOCTOU window). The caller decides when to
+assign the new Arc to its cached slot — the forwarding site at
+`worker/mod.rs:727` needs to compare old vs new before the
+assignment to call `cos_runtime_config_changed(old, new)`.
 
 ```rust
 // before:
@@ -124,43 +128,61 @@ if !Arc::ptr_eq(&cached_X, &live_X) {
 to (using the helper from §4.3):
 
 ```rust
-if refresh_arc_if_changed(&mut cached_X, &shared_X) {
-    /* refresh side effects, same as before */
+if let Some(new_X) = load_arc_if_changed(&cached_X, &shared_X) {
+    /* refresh side effects can use BOTH `&cached_X` (old) and
+       `&new_X` (new) here — e.g. forwarding site at
+       worker/mod.rs:727 needs old/new for
+       cos_runtime_config_changed(old, new) */
+    cached_X = new_X;
 }
 ```
 
-The helper consumes the observed `Guard` directly — no second
-`.load_full()` call, no TOCTOU window, no explicit `drop(guard)`
-ceremony.
+**Critical (Codex round-3 catch):** the assignment of
+`cached_X = new_X` happens at the **end** of the side-effect
+block, not before it, so the forwarding site can still compare
+the old `forwarding` against the new one via
+`cos_runtime_config_changed(old, new)` at `worker/cos.rs:256`.
+The earlier v3 helper inverted this order and would have caused
+CoS runtime resets to be silently skipped on forwarding-config
+changes.
+
+The helper is non-mutating and returns the freshly observed Arc
+without assigning. No TOCTOU window, no second `.load_full()`,
+old/new comparison preserved.
 
 ### 4.3 Optional: helper macro
 
 To avoid 6 copies of the same pattern, introduce a small helper:
 
 ```rust
-/// Refresh `cached` from `shared` if and only if the underlying Arc
-/// has been rotated. Returns true if a refresh occurred.
+/// If the `ArcSwap` has been rotated since `cached` was observed,
+/// return the freshly-rotated `Arc`. Otherwise return `None`.
 ///
-/// Codex round-2: consume the observed Guard via `Guard::into_inner`
-/// instead of doing a second `.load_full()`. This preserves the
-/// exact Arc snapshot we just compared and removes a (tiny) TOCTOU
-/// window where the coordinator could swap a third Arc between our
-/// `.load()` ptr-eq and the redundant `.load_full()`.
+/// **Non-mutating by design (Codex round-3 catch):** the helper does
+/// not assign to `cached`. The caller decides when to assign,
+/// because some callers (notably the forwarding site at
+/// `worker/mod.rs:727`) need to call
+/// `cos_runtime_config_changed(old, new)` while both the old and
+/// new Arcs are accessible.
+///
+/// Codex round-2: consume the observed `Guard` via
+/// `Guard::into_inner` instead of doing a second `.load_full()`.
+/// This preserves the exact Arc snapshot we just compared and
+/// removes a (tiny) TOCTOU window.
 ///
 /// Gemini Pro 3.1 round-2: use idiomatic `Arc::ptr_eq` (the `Guard`
 /// derefs to `&Arc<T>`); `T: ?Sized` is dropped — all 6 call sites
-/// are sized concrete types, and `arc-swap`'s `RefCnt` impl is
-/// cleanest with sized `T`.
-fn refresh_arc_if_changed<T>(
-    cached: &mut Arc<T>,
+/// are sized concrete types.
+fn load_arc_if_changed<T>(
+    cached: &Arc<T>,
     shared: &ArcSwap<T>,
-) -> bool {
+) -> Option<Arc<T>> {
     let guard = shared.load();
     if Arc::ptr_eq(cached, &*guard) {
-        return false;
+        None
+    } else {
+        Some(arc_swap::Guard::into_inner(guard))
     }
-    *cached = arc_swap::Guard::into_inner(guard);
-    true
 }
 ```
 
@@ -189,9 +211,8 @@ The helper is a private fn or a module-local utility.
 
 - **Visibility:** when the coordinator swaps an Arc, the next
   worker tick must observe the change. `ArcSwap::load()` provides
-  acquire-ordered access; `Arc::as_ptr` reads the cached Arc's
-  data pointer. Pointer comparison is a value comparison, no
-  ordering issue.
+  acquire-ordered access; `Arc::ptr_eq` compares Arc identity.
+  Pointer comparison is a value comparison, no ordering issue.
 - **Refresh side effects:** each of the 6 sites does specific
   bookkeeping when the Arc changes (rebuild cos_fast_interfaces,
   release_all_cos_root_leases, etc.). The new pattern preserves
@@ -222,7 +243,7 @@ The helper is a private fn or a module-local utility.
 - Smoke matrix on loss userspace cluster: 30 cells, 0 retrans
 - **Perf measurement** (the critical gate): collect
   `perf stat -e cache-misses,cache-references,LLC-load-misses`
-  on the master baseline vs the v2 build during steady-state
+  on the master baseline vs the v4 build during steady-state
   iperf3 run. Document atomic-RMW reduction.
 
 ## 9. Out of scope

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v4 — Codex round-3 PLAN-NEEDS-MAJOR caught semantic bug: v3 helper mutated `cached_X` before the side-effect block, but `worker/mod.rs:727` needs OLD forwarding to call `cos_runtime_config_changed(old, new)`. v4 changes helper to non-mutating `load_arc_if_changed -> Option<Arc<T>>` so callers control the assignment order
+status: REVISED v5 — Codex+Gemini round-4 caught two more bugs: (1) `arc_swap::Guard::into_inner` is hallucinated — no such method exists; use `Arc::clone(&*guard)` which still gives TOCTOU avoidance because we clone the exact observed Arc; (2) forwarding-site ordering: `screen_state.update_profiles` + `sessions.set_timeouts` at `worker/mod.rs:731-732` read `forwarding`, must use `new_forwarding` not the cached pre-assignment value. v5 specifies the full forwarding-site code template and scrubs stale prose at lines 59, 192, 234
 issue: #1188
 phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
 ---
@@ -56,15 +56,13 @@ if !Arc::ptr_eq(&forwarding, &live_forwarding) {
     // ... refresh dependent state ...
 }
 
-// after:
-let live_forwarding_guard = shared_forwarding.load();
-if !std::ptr::eq(
-    Arc::as_ptr(&forwarding),
-    Arc::as_ptr(&*live_forwarding_guard),
-) {
-    let live_forwarding = shared_forwarding.load_full();
-    forwarding = live_forwarding;
-    // ... refresh dependent state ...
+// after — see helper at §4.3 and per-site templates at §4.2:
+if let Some(new_forwarding) =
+    load_arc_if_changed(&forwarding, &shared_forwarding)
+{
+    /* compare old vs new for cos_runtime_config_changed,
+       update screen_state + sessions from new_forwarding,
+       THEN assign forwarding = new_forwarding */
 }
 ```
 
@@ -73,9 +71,10 @@ if !std::ptr::eq(
 - Steady state (no config change): saved 12 atomic RMW ops/tick →
   ~0.96B–9.6B ops/sec eliminated from the QPI/UPI bus.
 - On actual config change (rare, < 1/sec normally): one
-  `.load()` cost + one `.load_full()` cost — slight overhead vs
-  current code. Negligible at ~1/sec rate.
-- No coordinator-side changes. No new types. No semantics change.
+  cheap `.load()` + one `Arc::clone` (atomic increment).
+  Negligible at ~1/sec rate.
+- No coordinator-side changes. No new types except the helper
+  fn. No semantics change.
 
 **The architectural value:** matches the existing `Arc::ptr_eq`
 intent — the existing code clearly *wanted* to compare without
@@ -115,40 +114,61 @@ The 3 `.load()` sites are NOT the problem; they don't clone. The
 
 ### 4.2 Pattern
 
-For each of the 6 sites, transform from:
+For each of the 6 sites, transform from the existing
+`load_full + ptr_eq` pattern to the helper.
+
+**Forwarding site** (the most order-sensitive — `worker/mod.rs:725-736`):
 
 ```rust
-let live_X = shared_X.load_full();
-if !Arc::ptr_eq(&cached_X, &live_X) {
-    cached_X = live_X;
-    /* refresh side effects */
+if let Some(new_forwarding) =
+    load_arc_if_changed(&forwarding, &shared_forwarding)
+{
+    // Compare BEFORE assignment — needs both old and new.
+    let cos_changed =
+        cos_runtime_config_changed(forwarding.as_ref(), new_forwarding.as_ref());
+
+    // Use NEW values for side effects (Codex round-4 catch).
+    // `screen_state.update_profiles` and `sessions.set_timeouts`
+    // must read the freshly-rotated forwarding, not the cached
+    // pre-assignment value.
+    screen_state.update_profiles(new_forwarding.screen_profiles.clone());
+    sessions.set_timeouts(new_forwarding.session_timeouts);
+
+    forwarding = new_forwarding;
+
+    if cos_changed {
+        reset_worker_cos_runtimes(&mut bindings);
+        rebuild_cos_fast_interfaces = true;
+    }
 }
 ```
 
-to (using the helper from §4.3):
+**The other 5 sites** (`shared_cos_owner_worker_by_queue`,
+`shared_cos_owner_live_by_queue`, `shared_cos_root_leases`,
+`shared_cos_queue_leases`, `shared_cos_queue_vtime_floors` —
+all simpler, no `cos_runtime_config_changed` analog):
 
 ```rust
 if let Some(new_X) = load_arc_if_changed(&cached_X, &shared_X) {
-    /* refresh side effects can use BOTH `&cached_X` (old) and
-       `&new_X` (new) here — e.g. forwarding site at
-       worker/mod.rs:727 needs old/new for
-       cos_runtime_config_changed(old, new) */
     cached_X = new_X;
+    /* same side effects as before — usually setting
+       rebuild_cos_fast_interfaces = true; or releasing leases */
 }
 ```
 
-**Critical (Codex round-3 catch):** the assignment of
-`cached_X = new_X` happens at the **end** of the side-effect
-block, not before it, so the forwarding site can still compare
-the old `forwarding` against the new one via
-`cos_runtime_config_changed(old, new)` at `worker/cos.rs:256`.
-The earlier v3 helper inverted this order and would have caused
-CoS runtime resets to be silently skipped on forwarding-config
-changes.
+For these 5 sites, the assignment can come first because the
+side effects don't read the cached value. Pattern is more
+forgiving than the forwarding site.
+
+**Both bugs caught by reviewers in earlier rounds:**
+- v3: helper mutated cached before block ran → `cos_runtime_config_changed` would skip (Codex round-3).
+- v4: helper non-mutating but `screen_state.update_profiles(forwarding.X)` would read OLD forwarding if assignment was at end (Codex round-4).
+- v5: full template above shows correct ordering; "use new_X for side effects, then assign" is the rule.
 
 The helper is non-mutating and returns the freshly observed Arc
-without assigning. No TOCTOU window, no second `.load_full()`,
-old/new comparison preserved.
+(`Arc::clone(&*guard)`). No TOCTOU window, no second `.load_full()`,
+old/new comparison and side effects all use whichever value
+is correct.
 
 ### 4.3 Optional: helper macro
 
@@ -165,10 +185,19 @@ To avoid 6 copies of the same pattern, introduce a small helper:
 /// `cos_runtime_config_changed(old, new)` while both the old and
 /// new Arcs are accessible.
 ///
-/// Codex round-2: consume the observed `Guard` via
-/// `Guard::into_inner` instead of doing a second `.load_full()`.
-/// This preserves the exact Arc snapshot we just compared and
-/// removes a (tiny) TOCTOU window.
+/// **TOCTOU avoidance (Codex round-2 / Gemini round-4 correction):**
+/// clone the exact `Arc` the `Guard` is observing — `Arc::clone(&*guard)`
+/// — instead of calling `.load_full()` a second time. Calling
+/// `.load_full()` again could return a *newer* Arc if the coordinator
+/// rotated between our `ptr_eq` check and the second load. Cloning
+/// the observed Guard pins the exact snapshot we compared.
+///
+/// **Why not `arc_swap::Guard::into_inner`?** Because that method
+/// does not exist. `arc_swap::Guard` is a hazard-pointer-style protect
+/// — it does not hold its own strong refcount. Converting a Guard
+/// to an owned `Arc<T>` requires an atomic refcount increment via
+/// `Arc::clone`. That increment cost is real and acceptable: it
+/// only fires when the configuration actually changed (rare).
 ///
 /// Gemini Pro 3.1 round-2: use idiomatic `Arc::ptr_eq` (the `Guard`
 /// derefs to `&Arc<T>`); `T: ?Sized` is dropped — all 6 call sites
@@ -181,22 +210,20 @@ fn load_arc_if_changed<T>(
     if Arc::ptr_eq(cached, &*guard) {
         None
     } else {
-        Some(arc_swap::Guard::into_inner(guard))
+        Some(Arc::clone(&*guard))
     }
 }
 ```
 
-Usage:
+Usage: see per-site templates in §4.2. The forwarding site is
+the most order-sensitive (must compare old/new and use new
+values for `screen_state` / `sessions` updates BEFORE
+assignment). The other 5 sites can assign first.
 
-```rust
-if refresh_arc_if_changed(&mut forwarding, &shared_forwarding) {
-    let cos_changed = cos_runtime_config_changed(/* ... */);
-    /* same side effects as before */
-}
-```
-
-Each of the 6 sites becomes a 1-line `if` head + the existing
-side-effect block.
+Each of the 6 sites becomes an `if let Some(new_X) = ...` head
+plus the existing side-effect block, with the assignment
+(`cached_X = new_X`) placed correctly relative to the side
+effects per the per-site templates above.
 
 **Decision: ship the helper.** It makes the 6 sites uniform and
 the diff cleaner; it's also a future-proof primitive for any

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,160 +1,267 @@
 ---
-status: DRAFT v1 — pending adversarial plan review (PLAN-KILL is on the table)
+status: REVISED v2 — Codex + Gemini Pro 3.1 round-1 PLAN-KILL on the consolidation idea, but Gemini caught the REAL bug. Pivoted to the actual fix.
 issue: #1188
-phase: Investigate consolidating per-tick ArcSwap loads in worker_loop
+phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
 ---
 
-## 1. Issue framing
+## 1. Issue framing — corrected
 
-Issue #1188 claims `BindingWorker` / `worker_loop` performs "up
-to 8 separate `ArcSwap` pointers on every iteration" and asserts
-this saturates the QPI/UPI bus.
+Issue #1188's headline ("up to 8 ArcSwap loads per iteration → bus
+saturation") is **substantively correct**. The original v1 plan
+(consolidate 3 fields into `ImmutableRuntime`) was wrong because:
 
-**Reality check** (`userspace-dp/src/afxdp/worker/mod.rs:445-490`):
-worker_loop has **11** `Arc<ArcSwap<...>>` parameters in its
-signature, but the per-call-frequency varies wildly:
+1. v1 inventoried only 3 per-tick `.load()` calls. Gemini Pro 3.1
+   caught the actual count: **6 per-tick `.load_full()` calls**
+   at `worker/mod.rs:725, 738, 743, 748, 757, 765`.
+2. **`.load_full()` ALWAYS clones the `Arc`**, doing one atomic
+   refcount increment on the clone and one decrement when the
+   guard drops if unchanged. That's 2 atomic RMW operations per
+   `.load_full()` per tick.
+3. The existing code already does `Arc::ptr_eq(&cached, &live)`
+   immediately after each `.load_full()` (lines 727, 739, 744,
+   749, 758, 766), so the clone is **wasted** in the common case
+   (no config change since last tick).
 
-| Arc field | When loaded | Cost |
-|---|---|---|
-| `shared_validation` | Once at init (line 488); per-tick refresh on config-gen change (line 721) | 1 cached + occasional |
-| `shared_forwarding` | Once at init via `load_full()` (line 489) | 1 cached |
-| `shared_cos_owner_worker_by_queue` | Once at init (line 490) | 1 cached |
-| `shared_cos_owner_live_by_queue` | Once at init | 1 cached |
-| `shared_cos_root_leases` | Once at init | 1 cached |
-| `shared_cos_queue_leases` | Once at init | 1 cached |
-| `shared_cos_queue_vtime_floors` | Once at init | 1 cached |
-| `ha_state` | Per-tick refresh (line 801) | 1/tick |
-| `shared_fabrics` | Per-tick refresh (line 908) | 1/tick |
-| `local_tunnel_deliveries` | Reference-only on tunnel paths | rare |
-| `cos_status` | Read by status path, not hot | rare |
+**Cycle math (corrected):**
 
-**Actual atomic load count on hot path**: ~3 `.load()` calls per
-poll tick (`shared_validation` refresh + `ha_state` + `shared_fabrics`).
-A poll tick processes a batch of ~64 packets, so per packet
-the cost is ~3/64 = **0.047 atomic loads/packet**. At 14.8M pps
-that's ~700k atomic loads/sec — not nothing but two orders of
-magnitude smaller than the issue body's "hundreds of millions
-per second" claim.
+- 6 `.load_full()` × 2 RMW ops = 12 atomic RMW ops/tick on shared
+  Arc control blocks
+- ~10K-100K worker ticks/sec per worker (depends on poll_mode and
+  load) × 8 workers
+- ≈ 0.96B–9.6B atomic RMWs/sec on the shared cache lines holding
+  the Arc control blocks
 
-The issue body's QPI/UPI saturation framing is exaggerated.
-But the underlying observation — that there are *some* per-tick
-atomic loads worth consolidating — is real.
+These atomic RMWs all hit the SAME cache line for each shared
+state's Arc, which the coordinator core also touches whenever it
+swaps. Result: MESI cache-line ping-pong on the QPI/UPI between
+worker cores (or between worker cores and coordinator core on
+the same socket) — exactly what the issue body describes.
 
 ## 2. Honest scope/value framing
 
-**Pessimistic case:** the proposed `ImmutableRuntime`
-consolidation lumps `shared_validation`, `ha_state`, and
-`shared_fabrics` into a single `Arc<ArcSwap<ImmutableRuntime>>`.
-Worker does one `.load()` per tick. That saves 2 atomic ops per
-tick. At ~10k ticks/sec per worker × 8 workers = 160k ops/sec
-saved. Trivial.
+**The fix:** replace each `.load_full()` with `.load()` (returns
+a `Guard<Arc<T>>`, no clone) + `Arc::as_ptr` comparison against
+the cached Arc. Only call `.load_full()` when the pointer
+differs (i.e., the coordinator actually rotated the Arc).
 
-**Plausible case:** the *coordinator side* cost grows. Today,
-when only HA state changes, only `ha_state` is republished. With
-consolidation, ANY change rebuilds the entire `ImmutableRuntime`
-snapshot. HA changes are rare (failover events), but config
-reload and fabric updates each force a full snapshot rebuild.
-That's net negative on coordinator CPU.
+```rust
+// before:
+let live_forwarding = shared_forwarding.load_full();   // clone always
+if !Arc::ptr_eq(&forwarding, &live_forwarding) {
+    forwarding = live_forwarding;
+    // ... refresh dependent state ...
+}
 
-**The architectural win:** consistency. Today, a worker that
-loads `ha_state` but not `shared_fabrics` in the same tick can
-see torn updates between them. Bundling them into a single
-snapshot guarantees consistency. *That* is the legitimate value
-proposition — not bus traffic.
+// after:
+let live_forwarding_guard = shared_forwarding.load();
+if !std::ptr::eq(
+    Arc::as_ptr(&forwarding),
+    Arc::as_ptr(&*live_forwarding_guard),
+) {
+    let live_forwarding = shared_forwarding.load_full();
+    forwarding = live_forwarding;
+    // ... refresh dependent state ...
+}
+```
 
-**If reviewers conclude:**
-- the per-tick atomic-load saving is too small (~2-3 ops/tick),
-- AND the consistency argument doesn't justify forcing every
-  control-plane mutation to rebuild the entire snapshot,
+**Win:**
 
-then **PLAN-KILL is the right call.** This refactor would be
-churn for negligible gain.
+- Steady state (no config change): saved 12 atomic RMW ops/tick →
+  ~0.96B–9.6B ops/sec eliminated from the QPI/UPI bus.
+- On actual config change (rare, < 1/sec normally): one
+  `.load()` cost + one `.load_full()` cost — slight overhead vs
+  current code. Negligible at ~1/sec rate.
+- No coordinator-side changes. No new types. No semantics change.
+
+**The architectural value:** matches the existing `Arc::ptr_eq`
+intent — the existing code clearly *wanted* to compare without
+cloning, but `.load_full()` semantics forced the clone first.
+This refactor expresses the intent correctly.
+
+**This v2 plan is concrete, measurable, narrow.** No PLAN-KILL
+discussion this round — the underlying problem is real and the
+fix is clear.
 
 ## 3. What's already shipped
 
-- 11 `Arc<ArcSwap<...>>` fields in worker_loop signature
-- Worker caches `forwarding`, `cos_*` states in local `mut`
-  variables at init; only reloads on explicit triggers
-  (config-gen mismatch, RG transition).
-- `ha_state` and `shared_fabrics` reload per-tick
-- `shared_validation` reloads on config-gen change
+- 6 `.load_full()` + `Arc::ptr_eq` blocks at
+  `worker/mod.rs:725-780`
+- 1 `.load()` + manual `==` comparison for `shared_validation`
+  at line 721-723 (the right pattern, only used in one place)
+- 1 `.load()` for `ha_state` at line 801 (cached as `ha_runtime`,
+  separately compared)
+- 1 `.load()` for `shared_fabrics` at line 908 (cached as
+  `live_fabrics`)
 
-## 4. Concrete design (if not killed)
+The 3 `.load()` sites are NOT the problem; they don't clone. The
+6 `.load_full()` sites are.
 
-1. Define `ImmutableRuntime` containing the 3 per-tick-loaded states:
-   ```rust
-   struct ImmutableRuntime {
-       validation: ValidationState,
-       ha_runtime: BTreeMap<i32, HAGroupRuntime>,
-       fabrics: Vec<FabricLink>,
-   }
-   ```
-2. Replace 3 separate `Arc<ArcSwap<...>>` with one `Arc<ArcSwap<ImmutableRuntime>>`.
-3. Coordinator update path: when any of the 3 states change, rebuild full snapshot, swap.
-4. Worker: single `.load()` per tick → `&ImmutableRuntime` reference passed down.
+## 4. Concrete design
 
-**The cost question:** rebuild requires cloning the unchanged 2
-states. `ValidationState` is a small struct; `BTreeMap<i32, HAGroupRuntime>`
-is bounded by # of redundancy groups (typically 1-4); `Vec<FabricLink>`
-is tiny. Cloning all three on each update is cheap, but not free.
+### 4.1 The 6 sites to fix
+
+| Line | Field | Cache var |
+|---|---|---|
+| 725 | `shared_forwarding` | `forwarding` |
+| 738 | `shared_cos_owner_worker_by_queue` | `cos_owner_worker_by_queue` |
+| 743 | `shared_cos_owner_live_by_queue` | `cos_owner_live_by_queue` |
+| 748 | `shared_cos_root_leases` | `cos_shared_root_leases` |
+| 757 | `shared_cos_queue_leases` | `cos_shared_queue_leases` |
+| 765 | `shared_cos_queue_vtime_floors` | `cos_shared_queue_vtime_floors` |
+
+### 4.2 Pattern
+
+For each of the 6 sites, transform from:
+
+```rust
+let live_X = shared_X.load_full();
+if !Arc::ptr_eq(&cached_X, &live_X) {
+    cached_X = live_X;
+    /* refresh side effects */
+}
+```
+
+to:
+
+```rust
+let live_X_guard = shared_X.load();
+if !std::ptr::eq(
+    Arc::as_ptr(&cached_X),
+    Arc::as_ptr(&*live_X_guard),
+) {
+    drop(live_X_guard);   // release guard before doing the actual reload
+    cached_X = shared_X.load_full();
+    /* refresh side effects, same as before */
+}
+```
+
+The `drop(live_X_guard)` before `.load_full()` is to avoid holding two Arc references when we don't need to. Optional — the guard goes out of scope at end of the `if` block anyway. Skip the explicit drop if it complicates the diff.
+
+### 4.3 Optional: helper macro
+
+To avoid 6 copies of the same pattern, introduce a small helper:
+
+```rust
+/// Refresh `cached` from `shared` if and only if the underlying Arc
+/// has been rotated. Returns true if a refresh occurred.
+fn refresh_arc_if_changed<T: ?Sized>(
+    cached: &mut Arc<T>,
+    shared: &ArcSwap<T>,
+) -> bool {
+    let guard = shared.load();
+    if std::ptr::eq(Arc::as_ptr(cached), Arc::as_ptr(&*guard)) {
+        return false;
+    }
+    drop(guard);
+    *cached = shared.load_full();
+    true
+}
+```
+
+Usage:
+
+```rust
+if refresh_arc_if_changed(&mut forwarding, &shared_forwarding) {
+    let cos_changed = cos_runtime_config_changed(/* ... */);
+    /* same side effects as before */
+}
+```
+
+Each of the 6 sites becomes a 1-line `if` head + the existing
+side-effect block.
+
+**Decision: ship the helper.** It makes the 6 sites uniform and
+the diff cleaner; it's also a future-proof primitive for any
+new `ArcSwap` field added to worker_loop.
 
 ## 5. Public API preservation
 
-worker_loop signature changes (3 separate params → 1 consolidated).
-Coordinator builds the snapshot. Internal-only change.
+`worker_loop` signature unchanged. No external API changes.
+The helper is a private fn or a module-local utility.
 
 ## 6. Hidden invariants the change must preserve
 
-- HA RG transitions must propagate to workers within the same
-  poll tick they fire on the coordinator side.
-- Config-gen mismatch detection must continue to trigger
-  validation refresh.
-- Fabric link changes must be visible by next tick.
+- **Visibility:** when the coordinator swaps an Arc, the next
+  worker tick must observe the change. `ArcSwap::load()` provides
+  acquire-ordered access; `Arc::as_ptr` reads the cached Arc's
+  data pointer. Pointer comparison is a value comparison, no
+  ordering issue.
+- **Refresh side effects:** each of the 6 sites does specific
+  bookkeeping when the Arc changes (rebuild cos_fast_interfaces,
+  release_all_cos_root_leases, etc.). The new pattern preserves
+  these by keeping the existing block inside the `if changed`
+  branch.
+- **No torn reads of dependent state:** the same tick that
+  observes `shared_forwarding` rotation may not yet observe a
+  related `shared_cos_*` rotation if they were swapped
+  separately. This is **the same as today** — both the old and
+  new code observe each Arc independently.
 
 ## 7. Risk assessment
 
 | Class | Level | Why |
 |---|---|---|
-| Behavioral regression | LOW | Same data, single pointer |
-| Coordinator CPU cost | **MED** | Snapshot rebuild on every state change of any of the 3 |
-| Borrow-checker | LOW | Single `Arc<ArcSwap<...>>` is cleaner than 3 |
-| Performance regression | LOW | Worker side strictly faster (1 load vs 3) |
-| Architectural mismatch | LOW-MED | Consistency win is real; bus-traffic-saturation framing is wrong |
+| Behavioral regression | **VERY LOW** | Side effects only fire on actual change; same as today |
+| Borrow-checker | LOW | The `Guard` returned by `.load()` is dropped at end of block; no lifetime issues |
+| Performance regression | **VERY LOW** (correctness side) | One extra pointer comparison per tick — negligible |
+| Correctness on rotation | LOW | If the Arc is rotated between the `.load()` ptr comparison and the subsequent `.load_full()`, we just observe the new Arc — slightly newer than the guard, but always-monotonic |
+| Test breakage | LOW | Existing tests assert config-change observation; that path is unchanged |
 
 ## 8. Test plan
 
 - `cargo build --release`: clean
 - `cargo test --release`: 974/974 pass
-- 5x flake check on `make test-failover` — HA path is most affected
+- 5x flake check on `make test-failover` (verifies HA / config
+  changes still propagate)
 - Smoke matrix on loss userspace cluster: 30 cells, 0 retrans
-- **HA stress**: rapid `request chassis cluster failover` cycle to
-  verify coordinator snapshot rebuild keeps up
+- **Perf measurement** (the critical gate): collect
+  `perf stat -e cache-misses,cache-references,LLC-load-misses`
+  on the master baseline vs the v2 build during steady-state
+  iperf3 run. Document atomic-RMW reduction.
 
 ## 9. Out of scope
 
-- The 5 `shared_cos_*` fields (loaded once at init, cached) — no
-  per-tick load reduction available
-- `local_tunnel_deliveries`, `cos_status` (not on hot path)
-- `dynamic_neighbors` — already a `ShardedNeighborMap`, not a
-  bare `ArcSwap`
-- Parameter-list cleanup of worker_loop's 30+ args (separate
-  refactor, larger scope)
+- Further consolidation of unrelated worker_loop parameters
+  (#945/#946 territory; not this PR).
+- Coordinator-side changes (none needed).
+- Adding new ArcSwap fields or replacing existing fields with
+  alternative concurrency primitives.
 
 ## 10. Open questions for adversarial review
 
-1. **Is this PLAN-KILL?** Per-packet atomic-load savings ~700k/sec. Is the consistency argument alone worth the churn, or is this churn-for-aesthetics?
+1. **Is `Arc::as_ptr` comparison sound across threads?** `ArcSwap`
+   provides acquire-ordered loads, so the `*const T` read from
+   the guard reflects a value the coordinator published with
+   release-ordered store. Pointer comparison is a value op on
+   `*const T`. The cached `Arc<T>` was the published value at
+   some prior tick. If coordinator rotates twice between two
+   ticks, we still observe a difference.
 
-2. **Coordinator rebuild cost:** the snapshot must be rebuilt on every change of any of {validation, ha_runtime, fabrics}. Concretely: under a config reload that triggers all three within a 100ms window, the coordinator does 3 rebuilds. Each rebuild clones ~3 small structs. Is this measurable?
+2. **Is the `drop(live_X_guard)` before `.load_full()` necessary?**
+   `.load()` holds a hazard-pointer-style guard internally. If
+   we hold the guard while calling `.load_full()` (which clones
+   the Arc), are we double-borrowing the inner Arc? Confirm
+   `arc_swap` semantics permit this.
 
-3. **Why NOT also consolidate the `shared_cos_*` fields?** The plan keeps them as 5 separate `Arc<ArcSwap<...>>`. Justify: they're loaded once at init, cached in mut locals, and CoS reload is rare. But if we're consolidating for consistency, why exclude these?
+3. **What if 5 of 6 fields are usually changed together?** Then
+   the `.load() + ptr_eq` short-circuit hits N times less
+   often, and we pay the `.load_full()` cost N times anyway.
+   Likelihood: low — config reloads change `forwarding`, while
+   CoS lease rotations are independent.
 
-4. **Tear semantics:** today, a config-reload + HA failover within microseconds of each other could leave a worker seeing new validation but old ha_runtime in the same tick. Does that actually cause an observable bug, or is the codepath already tolerant?
+4. **Should the `shared_validation` `.load()` site (line 721) be
+   refactored similarly for consistency?** It's already cheap
+   (no `.load_full()`) but the value-equality check (`**live != validation`) is more expensive than `Arc::as_ptr` comparison
+   would be. Borderline; if the diff is small, fold in;
+   otherwise leave for a follow-up.
 
-5. **Comparison with #946 / #945 context-object work:** is the right fix here actually a `WorkerSnapshot` parameter type that bundles all the args worker_loop takes (~30 params), rather than a narrow `ImmutableRuntime` for 3 of them?
+5. **Helper fn vs inline?** Question 4 in section 4.3. Already
+   chose helper. Confirm.
 
 ## 11. Verdict request
 
-PLAN-READY → execute consolidation as designed.
-PLAN-NEEDS-MINOR → tweak (e.g., include or exclude specific fields).
-PLAN-NEEDS-MAJOR → revise (e.g., adopt the broader WorkerSnapshot framing).
-**PLAN-KILL → premise wrong**: the cited "hundreds of millions of atomic operations per second" is wrong by ~1000×; the actual saving is ~2-3 ops/tick; the consistency argument is real but minor; the coordinator rebuild cost may even net out negative. If the cycle math doesn't justify it, kill.
+PLAN-READY → execute the 6-site refactor.
+PLAN-NEEDS-MINOR → tweak helper signature or include #4.
+PLAN-NEEDS-MAJOR → revise.
+PLAN-KILL → premise wrong (but Gemini Pro 3.1 verified the bug
+is real, so this is unlikely).

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v7 — Codex round-6 NEEDS-MINOR fixes: softened `Guard::into_inner` cost-savings claim (it is NOT categorically free of atomic refcount increments — `HybridProtection::into_inner` may still call `T::inc` when the guard has debt; `load_full()` is literally `Guard::into_inner(self.load())`). The real win in this PR is the `Arc::ptr_eq` short-circuit, not an into_inner-vs-clone difference. Stale `Arc::as_ptr` references replaced with `Arc::ptr_eq` (the actual API used). Stale "v4 build" replaced with "v7 build" in §8
+status: v8 FINAL — Codex round-7 PLAN-READY after one §10 wording fix (§10 question 2 still claimed "without an atomic increment"; corrected to match §2/§4.3 caveat). Implementation shipped at commit 98c61a8e on refactor/1188-runtime-snapshot
 issue: #1188
 phase: Replace unconditional `.load_full()` with `.load()` + `Arc::ptr_eq` short-circuit in worker tick loop
 ---
@@ -308,9 +308,12 @@ The helper is a private fn or a module-local utility.
    ticks, we still observe a difference.
 
 2. ~~Is the `drop(live_X_guard)` before `.load_full()` necessary?~~
-   **Resolved (round-2/round-5):** v6 uses `Guard::into_inner`
-   which consumes the Guard, transferring ownership without an
-   atomic increment. No `drop` ceremony, no second `.load_full()`.
+   **Resolved (round-2/round-5/round-7):** v7 uses `Guard::into_inner`
+   which consumes the observed Guard and avoids a second
+   `.load_full()` (no TOCTOU window). The refcount cost on the
+   change branch may match `load_full()` (see §2 and §4.3 for the
+   `HybridProtection::into_inner` caveat) — the win is the
+   `Arc::ptr_eq` short-circuit, not the change-branch path.
 
 3. **What if 5 of 6 fields are usually changed together?** Then
    the `.load() + ptr_eq` short-circuit hits N times less

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,0 +1,160 @@
+---
+status: DRAFT v1 — pending adversarial plan review (PLAN-KILL is on the table)
+issue: #1188
+phase: Investigate consolidating per-tick ArcSwap loads in worker_loop
+---
+
+## 1. Issue framing
+
+Issue #1188 claims `BindingWorker` / `worker_loop` performs "up
+to 8 separate `ArcSwap` pointers on every iteration" and asserts
+this saturates the QPI/UPI bus.
+
+**Reality check** (`userspace-dp/src/afxdp/worker/mod.rs:445-490`):
+worker_loop has **11** `Arc<ArcSwap<...>>` parameters in its
+signature, but the per-call-frequency varies wildly:
+
+| Arc field | When loaded | Cost |
+|---|---|---|
+| `shared_validation` | Once at init (line 488); per-tick refresh on config-gen change (line 721) | 1 cached + occasional |
+| `shared_forwarding` | Once at init via `load_full()` (line 489) | 1 cached |
+| `shared_cos_owner_worker_by_queue` | Once at init (line 490) | 1 cached |
+| `shared_cos_owner_live_by_queue` | Once at init | 1 cached |
+| `shared_cos_root_leases` | Once at init | 1 cached |
+| `shared_cos_queue_leases` | Once at init | 1 cached |
+| `shared_cos_queue_vtime_floors` | Once at init | 1 cached |
+| `ha_state` | Per-tick refresh (line 801) | 1/tick |
+| `shared_fabrics` | Per-tick refresh (line 908) | 1/tick |
+| `local_tunnel_deliveries` | Reference-only on tunnel paths | rare |
+| `cos_status` | Read by status path, not hot | rare |
+
+**Actual atomic load count on hot path**: ~3 `.load()` calls per
+poll tick (`shared_validation` refresh + `ha_state` + `shared_fabrics`).
+A poll tick processes a batch of ~64 packets, so per packet
+the cost is ~3/64 = **0.047 atomic loads/packet**. At 14.8M pps
+that's ~700k atomic loads/sec — not nothing but two orders of
+magnitude smaller than the issue body's "hundreds of millions
+per second" claim.
+
+The issue body's QPI/UPI saturation framing is exaggerated.
+But the underlying observation — that there are *some* per-tick
+atomic loads worth consolidating — is real.
+
+## 2. Honest scope/value framing
+
+**Pessimistic case:** the proposed `ImmutableRuntime`
+consolidation lumps `shared_validation`, `ha_state`, and
+`shared_fabrics` into a single `Arc<ArcSwap<ImmutableRuntime>>`.
+Worker does one `.load()` per tick. That saves 2 atomic ops per
+tick. At ~10k ticks/sec per worker × 8 workers = 160k ops/sec
+saved. Trivial.
+
+**Plausible case:** the *coordinator side* cost grows. Today,
+when only HA state changes, only `ha_state` is republished. With
+consolidation, ANY change rebuilds the entire `ImmutableRuntime`
+snapshot. HA changes are rare (failover events), but config
+reload and fabric updates each force a full snapshot rebuild.
+That's net negative on coordinator CPU.
+
+**The architectural win:** consistency. Today, a worker that
+loads `ha_state` but not `shared_fabrics` in the same tick can
+see torn updates between them. Bundling them into a single
+snapshot guarantees consistency. *That* is the legitimate value
+proposition — not bus traffic.
+
+**If reviewers conclude:**
+- the per-tick atomic-load saving is too small (~2-3 ops/tick),
+- AND the consistency argument doesn't justify forcing every
+  control-plane mutation to rebuild the entire snapshot,
+
+then **PLAN-KILL is the right call.** This refactor would be
+churn for negligible gain.
+
+## 3. What's already shipped
+
+- 11 `Arc<ArcSwap<...>>` fields in worker_loop signature
+- Worker caches `forwarding`, `cos_*` states in local `mut`
+  variables at init; only reloads on explicit triggers
+  (config-gen mismatch, RG transition).
+- `ha_state` and `shared_fabrics` reload per-tick
+- `shared_validation` reloads on config-gen change
+
+## 4. Concrete design (if not killed)
+
+1. Define `ImmutableRuntime` containing the 3 per-tick-loaded states:
+   ```rust
+   struct ImmutableRuntime {
+       validation: ValidationState,
+       ha_runtime: BTreeMap<i32, HAGroupRuntime>,
+       fabrics: Vec<FabricLink>,
+   }
+   ```
+2. Replace 3 separate `Arc<ArcSwap<...>>` with one `Arc<ArcSwap<ImmutableRuntime>>`.
+3. Coordinator update path: when any of the 3 states change, rebuild full snapshot, swap.
+4. Worker: single `.load()` per tick → `&ImmutableRuntime` reference passed down.
+
+**The cost question:** rebuild requires cloning the unchanged 2
+states. `ValidationState` is a small struct; `BTreeMap<i32, HAGroupRuntime>`
+is bounded by # of redundancy groups (typically 1-4); `Vec<FabricLink>`
+is tiny. Cloning all three on each update is cheap, but not free.
+
+## 5. Public API preservation
+
+worker_loop signature changes (3 separate params → 1 consolidated).
+Coordinator builds the snapshot. Internal-only change.
+
+## 6. Hidden invariants the change must preserve
+
+- HA RG transitions must propagate to workers within the same
+  poll tick they fire on the coordinator side.
+- Config-gen mismatch detection must continue to trigger
+  validation refresh.
+- Fabric link changes must be visible by next tick.
+
+## 7. Risk assessment
+
+| Class | Level | Why |
+|---|---|---|
+| Behavioral regression | LOW | Same data, single pointer |
+| Coordinator CPU cost | **MED** | Snapshot rebuild on every state change of any of the 3 |
+| Borrow-checker | LOW | Single `Arc<ArcSwap<...>>` is cleaner than 3 |
+| Performance regression | LOW | Worker side strictly faster (1 load vs 3) |
+| Architectural mismatch | LOW-MED | Consistency win is real; bus-traffic-saturation framing is wrong |
+
+## 8. Test plan
+
+- `cargo build --release`: clean
+- `cargo test --release`: 974/974 pass
+- 5x flake check on `make test-failover` — HA path is most affected
+- Smoke matrix on loss userspace cluster: 30 cells, 0 retrans
+- **HA stress**: rapid `request chassis cluster failover` cycle to
+  verify coordinator snapshot rebuild keeps up
+
+## 9. Out of scope
+
+- The 5 `shared_cos_*` fields (loaded once at init, cached) — no
+  per-tick load reduction available
+- `local_tunnel_deliveries`, `cos_status` (not on hot path)
+- `dynamic_neighbors` — already a `ShardedNeighborMap`, not a
+  bare `ArcSwap`
+- Parameter-list cleanup of worker_loop's 30+ args (separate
+  refactor, larger scope)
+
+## 10. Open questions for adversarial review
+
+1. **Is this PLAN-KILL?** Per-packet atomic-load savings ~700k/sec. Is the consistency argument alone worth the churn, or is this churn-for-aesthetics?
+
+2. **Coordinator rebuild cost:** the snapshot must be rebuilt on every change of any of {validation, ha_runtime, fabrics}. Concretely: under a config reload that triggers all three within a 100ms window, the coordinator does 3 rebuilds. Each rebuild clones ~3 small structs. Is this measurable?
+
+3. **Why NOT also consolidate the `shared_cos_*` fields?** The plan keeps them as 5 separate `Arc<ArcSwap<...>>`. Justify: they're loaded once at init, cached in mut locals, and CoS reload is rare. But if we're consolidating for consistency, why exclude these?
+
+4. **Tear semantics:** today, a config-reload + HA failover within microseconds of each other could leave a worker seeing new validation but old ha_runtime in the same tick. Does that actually cause an observable bug, or is the codepath already tolerant?
+
+5. **Comparison with #946 / #945 context-object work:** is the right fix here actually a `WorkerSnapshot` parameter type that bundles all the args worker_loop takes (~30 params), rather than a narrow `ImmutableRuntime` for 3 of them?
+
+## 11. Verdict request
+
+PLAN-READY → execute consolidation as designed.
+PLAN-NEEDS-MINOR → tweak (e.g., include or exclude specific fields).
+PLAN-NEEDS-MAJOR → revise (e.g., adopt the broader WorkerSnapshot framing).
+**PLAN-KILL → premise wrong**: the cited "hundreds of millions of atomic operations per second" is wrong by ~1000×; the actual saving is ~2-3 ops/tick; the consistency argument is real but minor; the coordinator rebuild cost may even net out negative. If the cycle math doesn't justify it, kill.

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,7 +1,7 @@
 ---
-status: REVISED v6 — Codex round-5 caught Gemini round-4's hallucination claim was itself wrong. Verified `arc_swap::Guard::into_inner(lease: Self) -> T` exists in arc-swap 1.8.2 (Cargo.lock-confirmed; src/lib.rs). It is strictly better than `Arc::clone(&*guard)` because it transfers ownership via `mem::forget` + raw pointer extraction, avoiding the atomic refcount increment. Reverted to `Guard::into_inner`. v5 forwarding-site ordering template kept. v6 also scrubs the remaining stale `.load_full()` / `Arc::as_ptr` prose Codex flagged at lines 261, 294, 300
+status: REVISED v7 — Codex round-6 NEEDS-MINOR fixes: softened `Guard::into_inner` cost-savings claim (it is NOT categorically free of atomic refcount increments — `HybridProtection::into_inner` may still call `T::inc` when the guard has debt; `load_full()` is literally `Guard::into_inner(self.load())`). The real win in this PR is the `Arc::ptr_eq` short-circuit, not an into_inner-vs-clone difference. Stale `Arc::as_ptr` references replaced with `Arc::ptr_eq` (the actual API used). Stale "v4 build" replaced with "v7 build" in §8
 issue: #1188
-phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
+phase: Replace unconditional `.load_full()` with `.load()` + `Arc::ptr_eq` short-circuit in worker tick loop
 ---
 
 ## 1. Issue framing — corrected
@@ -71,9 +71,14 @@ if let Some(new_forwarding) =
 - Steady state (no config change): saved 12 atomic RMW ops/tick →
   ~0.96B–9.6B ops/sec eliminated from the QPI/UPI bus.
 - On actual config change (rare, < 1/sec normally): one
-  cheap `.load()` + one `Guard::into_inner` (no atomic increment;
-  ownership transfer via `mem::forget`). Negligible at ~1/sec
-  rate.
+  cheap `.load()` + one `Guard::into_inner` consume. Note:
+  `Guard::into_inner` is NOT categorically free —
+  `HybridProtection::into_inner` may still call `T::inc` when
+  the guard has debt. So in the worst case the change branch
+  pays the same as today's `.load_full()` (which is itself
+  implemented as `Guard::into_inner(self.load())`). The win
+  is the `ptr_eq` short-circuit, not the change-branch cost.
+  Negligible either way at ~1/sec change rate.
 - No coordinator-side changes. No new types except the helper
   fn. No semantics change.
 
@@ -190,15 +195,25 @@ To avoid 6 copies of the same pattern, introduce a small helper:
 /// `arc_swap::Guard::into_inner(guard)` to extract the exact Arc
 /// the Guard was observing. This avoids a second `.load_full()`
 /// (which could return a *newer* Arc if the coordinator rotated
-/// between our `ptr_eq` check and the second load) AND avoids the
-/// atomic refcount increment that `Arc::clone(&*guard)` would
-/// incur. `Guard::into_inner` uses `mem::forget` + raw pointer
-/// extraction internally — see arc-swap 1.8.2 `src/lib.rs`.
+/// between our `ptr_eq` check and the second load).
 ///
-/// Review note (rounds 4-5): Gemini Pro 3.1 round-4 erroneously
-/// claimed `into_inner` was hallucinated; Codex round-5 verified
-/// it exists in the locked arc-swap version. v6 reverts to
-/// `Guard::into_inner` — strictly better than `Arc::clone(&*guard)`.
+/// **Cost (Codex round-6 caveat):** `Guard::into_inner` is NOT
+/// categorically free of atomic refcount work —
+/// `HybridProtection::into_inner` may call `T::inc` when the
+/// guard holds a debt slot. In fact `load_full()` is literally
+/// implemented as `Guard::into_inner(self.load())` (arc-swap
+/// 1.8.2 src/lib.rs:414). So the on-change branch may cost the
+/// same as today's `.load_full()`. The win is the
+/// `Arc::ptr_eq` short-circuit, not a magical cost difference.
+///
+/// Review history (rounds 2-6):
+/// - Codex round-2: suggested `Guard::into_inner`.
+/// - Gemini round-4: claimed `into_inner` was hallucinated (it
+///   wasn't); switched to `Arc::clone(&*guard)`.
+/// - Codex round-5: verified `into_inner` exists in arc-swap
+///   1.8.2 src/lib.rs.
+/// - Codex round-6: warned the "saves the atomic increment"
+///   claim was overstated; cost may be the same as load_full().
 ///
 /// Gemini Pro 3.1 round-2: use idiomatic `Arc::ptr_eq` (the `Guard`
 /// derefs to `&Arc<T>`); `T: ?Sized` is dropped — all 6 call sites
@@ -271,7 +286,7 @@ The helper is a private fn or a module-local utility.
 - Smoke matrix on loss userspace cluster: 30 cells, 0 retrans
 - **Perf measurement** (the critical gate): collect
   `perf stat -e cache-misses,cache-references,LLC-load-misses`
-  on the master baseline vs the v4 build during steady-state
+  on the master baseline vs the v7 build during steady-state
   iperf3 run. Document atomic-RMW reduction.
 
 ## 9. Out of scope
@@ -284,7 +299,7 @@ The helper is a private fn or a module-local utility.
 
 ## 10. Open questions for adversarial review
 
-1. **Is `Arc::as_ptr` comparison sound across threads?** `ArcSwap`
+1. **Is `Arc::ptr_eq` comparison sound across threads?** `ArcSwap`
    provides acquire-ordered loads, so the `*const T` read from
    the guard reflects a value the coordinator published with
    release-ordered store. Pointer comparison is a value op on
@@ -305,7 +320,7 @@ The helper is a private fn or a module-local utility.
 
 4. **Should the `shared_validation` `.load()` site (line 721) be
    refactored similarly for consistency?** It's already cheap
-   (no `.load_full()`) but the value-equality check (`**live != validation`) is more expensive than `Arc::as_ptr` comparison
+   (no `.load_full()`) but the value-equality check (`**live != validation`) is more expensive than `Arc::ptr_eq` comparison
    would be. Borderline; if the diff is small, fold in;
    otherwise leave for a follow-up.
 

--- a/docs/pr/1188-runtime-snapshot/plan.md
+++ b/docs/pr/1188-runtime-snapshot/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v2 — Codex + Gemini Pro 3.1 round-1 PLAN-KILL on the consolidation idea, but Gemini caught the REAL bug. Pivoted to the actual fix.
+status: REVISED v3 — Codex + Gemini Pro 3.1 round-2 PLAN-NEEDS-MINOR converged on helper signature: use `Arc::ptr_eq(cached, &*guard)` (idiomatic) + `arc_swap::Guard::into_inner(guard)` (avoids TOCTOU + second load) + drop `T: ?Sized` (minimal trait bounds; all 6 sites sized)
 issue: #1188
 phase: Replace `.load_full()` with `.load()` + `Arc::as_ptr` comparison in worker tick loop
 ---
@@ -121,21 +121,17 @@ if !Arc::ptr_eq(&cached_X, &live_X) {
 }
 ```
 
-to:
+to (using the helper from §4.3):
 
 ```rust
-let live_X_guard = shared_X.load();
-if !std::ptr::eq(
-    Arc::as_ptr(&cached_X),
-    Arc::as_ptr(&*live_X_guard),
-) {
-    drop(live_X_guard);   // release guard before doing the actual reload
-    cached_X = shared_X.load_full();
+if refresh_arc_if_changed(&mut cached_X, &shared_X) {
     /* refresh side effects, same as before */
 }
 ```
 
-The `drop(live_X_guard)` before `.load_full()` is to avoid holding two Arc references when we don't need to. Optional — the guard goes out of scope at end of the `if` block anyway. Skip the explicit drop if it complicates the diff.
+The helper consumes the observed `Guard` directly — no second
+`.load_full()` call, no TOCTOU window, no explicit `drop(guard)`
+ceremony.
 
 ### 4.3 Optional: helper macro
 
@@ -144,16 +140,26 @@ To avoid 6 copies of the same pattern, introduce a small helper:
 ```rust
 /// Refresh `cached` from `shared` if and only if the underlying Arc
 /// has been rotated. Returns true if a refresh occurred.
-fn refresh_arc_if_changed<T: ?Sized>(
+///
+/// Codex round-2: consume the observed Guard via `Guard::into_inner`
+/// instead of doing a second `.load_full()`. This preserves the
+/// exact Arc snapshot we just compared and removes a (tiny) TOCTOU
+/// window where the coordinator could swap a third Arc between our
+/// `.load()` ptr-eq and the redundant `.load_full()`.
+///
+/// Gemini Pro 3.1 round-2: use idiomatic `Arc::ptr_eq` (the `Guard`
+/// derefs to `&Arc<T>`); `T: ?Sized` is dropped — all 6 call sites
+/// are sized concrete types, and `arc-swap`'s `RefCnt` impl is
+/// cleanest with sized `T`.
+fn refresh_arc_if_changed<T>(
     cached: &mut Arc<T>,
     shared: &ArcSwap<T>,
 ) -> bool {
     let guard = shared.load();
-    if std::ptr::eq(Arc::as_ptr(cached), Arc::as_ptr(&*guard)) {
+    if Arc::ptr_eq(cached, &*guard) {
         return false;
     }
-    drop(guard);
-    *cached = shared.load_full();
+    *cached = arc_swap::Guard::into_inner(guard);
     true
 }
 ```

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -464,6 +464,7 @@ impl BindingWorker {
 /// `src/lib.rs:414`), so the on-change branch may pay the same as
 /// today. The win is the steady-state short-circuit, not the
 /// on-change path.
+#[inline]
 fn load_arc_if_changed<T>(
     cached: &Arc<T>,
     shared: &ArcSwap<T>,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -442,6 +442,40 @@ impl BindingWorker {
         }
     }
 }
+
+/// #1188: replace per-tick `.load_full() + Arc::ptr_eq` with `.load() +
+/// Arc::ptr_eq` short-circuit. Returns `Some(new_arc)` when the
+/// `ArcSwap` has been rotated since `cached` was observed; returns
+/// `None` when the cached Arc is still current.
+///
+/// Steady state (no rotation): the `Arc::ptr_eq` short-circuit avoids
+/// the unconditional Arc clone that `.load_full()` performs. At ~10K-
+/// 100K worker ticks/sec × 8 workers, this eliminates ~12 atomic RMW
+/// operations per tick (6 sites × 2 ops for clone + drop) on the
+/// shared Arc control blocks — the bus-saturation issue the ticket
+/// describes.
+///
+/// On actual change: `Guard::into_inner` consumes the observed Guard
+/// and yields the exact Arc snapshot we just compared, avoiding a
+/// second `.load_full()` (which could otherwise return a *newer* Arc
+/// if the coordinator rotated between the `ptr_eq` check and the
+/// second load — small TOCTOU window). Note: `load_full()` is itself
+/// implemented as `Guard::into_inner(self.load())` (arc-swap 1.8.2
+/// `src/lib.rs:414`), so the on-change branch may pay the same as
+/// today. The win is the steady-state short-circuit, not the
+/// on-change path.
+fn load_arc_if_changed<T>(
+    cached: &Arc<T>,
+    shared: &ArcSwap<T>,
+) -> Option<Arc<T>> {
+    let guard = shared.load();
+    if Arc::ptr_eq(cached, &*guard) {
+        None
+    } else {
+        Some(arc_swap::Guard::into_inner(guard))
+    }
+}
+
 pub(crate) fn worker_loop(
     worker_id: u32,
     binding_plans: Vec<BindingPlan>,
@@ -722,51 +756,63 @@ pub(crate) fn worker_loop(
         if **live_validation != validation {
             validation = **live_validation;
         }
-        let live_forwarding = shared_forwarding.load_full();
         let mut rebuild_cos_fast_interfaces = false;
-        if !Arc::ptr_eq(&forwarding, &live_forwarding) {
+        // #1188: per-tick Arc refresh — `.load() + Arc::ptr_eq`
+        // short-circuits the unconditional `.load_full()` clone
+        // when the coordinator hasn't rotated the Arc.
+        if let Some(new_forwarding) =
+            load_arc_if_changed(&forwarding, &shared_forwarding)
+        {
+            // Compare BEFORE assignment — needs both old and new.
             let cos_changed =
-                cos_runtime_config_changed(forwarding.as_ref(), live_forwarding.as_ref());
-            forwarding = live_forwarding;
-            screen_state.update_profiles(forwarding.screen_profiles.clone());
-            sessions.set_timeouts(forwarding.session_timeouts);
+                cos_runtime_config_changed(forwarding.as_ref(), new_forwarding.as_ref());
+
+            // Use NEW values for dependent state updates (forwarding-site
+            // ordering — old `forwarding` is stale once rotated).
+            screen_state.update_profiles(new_forwarding.screen_profiles.clone());
+            sessions.set_timeouts(new_forwarding.session_timeouts);
+
+            forwarding = new_forwarding;
+
             if cos_changed {
                 reset_worker_cos_runtimes(&mut bindings);
                 rebuild_cos_fast_interfaces = true;
             }
         }
-        let live_cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
-        if !Arc::ptr_eq(&cos_owner_worker_by_queue, &live_cos_owner_worker_by_queue) {
-            cos_owner_worker_by_queue = live_cos_owner_worker_by_queue;
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_owner_worker_by_queue, &shared_cos_owner_worker_by_queue)
+        {
+            cos_owner_worker_by_queue = new_x;
             rebuild_cos_fast_interfaces = true;
         }
-        let live_cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
-        if !Arc::ptr_eq(&cos_owner_live_by_queue, &live_cos_owner_live_by_queue) {
-            cos_owner_live_by_queue = live_cos_owner_live_by_queue;
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_owner_live_by_queue, &shared_cos_owner_live_by_queue)
+        {
+            cos_owner_live_by_queue = new_x;
             rebuild_cos_fast_interfaces = true;
         }
-        let live_cos_shared_root_leases = shared_cos_root_leases.load_full();
-        if !Arc::ptr_eq(&cos_shared_root_leases, &live_cos_shared_root_leases) {
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_shared_root_leases, &shared_cos_root_leases)
+        {
             for binding in bindings.iter_mut() {
                 release_all_cos_root_leases(binding);
                 release_all_cos_queue_leases(binding);
             }
-            cos_shared_root_leases = live_cos_shared_root_leases;
+            cos_shared_root_leases = new_x;
             rebuild_cos_fast_interfaces = true;
         }
-        let live_cos_shared_queue_leases = shared_cos_queue_leases.load_full();
-        if !Arc::ptr_eq(&cos_shared_queue_leases, &live_cos_shared_queue_leases) {
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_shared_queue_leases, &shared_cos_queue_leases)
+        {
             for binding in bindings.iter_mut() {
                 release_all_cos_queue_leases(binding);
             }
-            cos_shared_queue_leases = live_cos_shared_queue_leases;
+            cos_shared_queue_leases = new_x;
             rebuild_cos_fast_interfaces = true;
         }
-        let live_cos_shared_queue_vtime_floors = shared_cos_queue_vtime_floors.load_full();
-        if !Arc::ptr_eq(
-            &cos_shared_queue_vtime_floors,
-            &live_cos_shared_queue_vtime_floors,
-        ) {
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_shared_queue_vtime_floors, &shared_cos_queue_vtime_floors)
+        {
             // #917: Arc-replacement of the V_min floors map.
             // Each shared_exact queue's per-worker slots default
             // to NOT_PARTICIPATING in the new Arc. Workers will
@@ -775,7 +821,7 @@ pub(crate) fn worker_loop(
             // this slot see "not participating" and skip it in
             // V_min reduction (per plan §3.4 / §3.7 lifecycle
             // rules).
-            cos_shared_queue_vtime_floors = live_cos_shared_queue_vtime_floors;
+            cos_shared_queue_vtime_floors = new_x;
             rebuild_cos_fast_interfaces = true;
         }
         if rebuild_cos_fast_interfaces {


### PR DESCRIPTION
## Summary

Eliminates ~12 atomic RMW operations per worker tick on shared
`Arc` control blocks by short-circuiting the per-tick refresh loop
in `worker_loop` with `Arc::ptr_eq` before the `Arc` clone.

The 6 sites at `worker/mod.rs:725, 738, 743, 748, 757, 765`
unconditionally called `.load_full()` (which clones the inner Arc
— 1 atomic `fetch_add` for the clone + 1 `fetch_sub` when the
clone is dropped if unchanged) and then immediately compared via
`Arc::ptr_eq`. In steady state (coordinator hasn't rotated the
Arc), this is wasted work.

At ~10K-100K worker ticks/sec × 8 workers, that's
~0.96B-9.6B atomic RMWs/sec on shared cache lines holding the Arc
control blocks — the QPI/UPI bus saturation issue #1188 describes.
**Gemini Pro 3.1 round-1 verified the count by reading the actual
code; the issue body's claim is correct.**

## Fix

New helper `load_arc_if_changed(cached, shared) -> Option<Arc<T>>`
uses cheap `.load()` (no clone) + `Arc::ptr_eq` short-circuit.
On rotation, consumes the observed `Guard` via
`arc_swap::Guard::into_inner` to get the exact Arc the Guard
was observing — avoids a second `.load_full()` and the small
TOCTOU window.

Note (Codex round-6 caveat): `Guard::into_inner` is NOT free;
`HybridProtection::into_inner` may call `T::inc` when the guard
holds a debt slot, and `load_full()` is itself implemented as
`Guard::into_inner(self.load())`. **The win is the `Arc::ptr_eq`
short-circuit, not the change-branch cost.**

## Plan + adversarial review

Plan doc: `docs/pr/1188-runtime-snapshot/plan.md` (v8 commit 5a495ecf)

Codex plan reviews — 7 rounds:
- Round 1: PLAN-KILL (consolidation idea wrong; cycle math overstated)
- Round 1 Gemini Pro 3.1: PLAN-KILL **but caught the real bug at lines 725-765**
- v2: pivot to `.load() + Arc::ptr_eq`
- Round 3: PLAN-NEEDS-MAJOR (mutating helper; cos_runtime_config_changed skip bug)
- v4: non-mutating `Option<Arc<T>>`
- Round 4: PLAN-NEEDS-MAJOR (Gemini wrong-claimed `Guard::into_inner` hallucinated → switched to `Arc::clone`; Codex caught forwarding-site ordering bug)
- v5: forwarding-site ordering (screen_state/sessions use new_X)
- Round 5: PLAN-NEEDS-MAJOR (Codex verified Guard::into_inner exists in arc-swap 1.8.2)
- v6: revert to Guard::into_inner
- Round 6: PLAN-NEEDS-MINOR (overclaimed cost-savings)
- v7: softened cost claims
- Round 7: PLAN-READY

## Test plan

- [x] cargo build --release: clean
- [x] cargo test --release: 974/974 pass
- [x] Deploy on loss userspace cluster
- [x] **Pass A — CoS disabled**
  - [x] v4 push: 7.62 Gb/s, 0 retrans
  - [x] v4 reverse: 7.34 Gb/s, 0 retrans
  - [x] v6 push: 7.57 Gb/s, 0 retrans
  - [x] v6 reverse: 7.54 Gb/s, 0 retrans
  - [x] v4 multi-stream reverse: 22.9 Gb/s, 0 retrans
  - [x] v6 multi-stream reverse: 22.6 Gb/s, 0 retrans
- [x] **Pass B — CoS enabled** (per-class shaper + classifier)
  - [x] All 24 per-class cells pass, 0 retrans
  - [x] iperf-a (1 Gb/s shape): 960/946 Mbps push hits shape rate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)