### PR TITLE
#1210: scrub stale CoS scheduler comments + tx.rs:NNN breadcrumbs

### DIFF
--- a/docs/pr/1210-stale-cos-comments/plan.md
+++ b/docs/pr/1210-stale-cos-comments/plan.md
@@ -1,8 +1,39 @@
 ---
-status: DRAFT v1 — pending adversarial plan review
+status: REVISED v2 — addressing Codex (PLAN-NEEDS-MINOR, task-mou6if9l-ih4eck) and Gemini (PLAN-NEEDS-MINOR, task-mou6jq7b-brjq3z)
 issue: #1210
 phase: single PR — pure doc/comment edits, no behavior change
 ---
+
+## Round-1 verdict resolution
+
+Both reviewers PLAN-NEEDS-MINOR. Same-shape findings:
+
+- **Inventory missed test files and other paths.** Both flag
+  `admission_tests.rs:1178,1207,1234`, `flow_hash_tests.rs:30,107,164`,
+  plus `tx.rs:NNN` line references in `tx/cos_classify.rs:571,580`,
+  `umem/mod.rs:150`, `umem/tests.rs:518,519,1031,1064,1074`,
+  `protocol.rs:1315`. **v2 widens the grep to all `userspace-dp/src/`
+  Rust files, not just `cos/` and `types/`.**
+- **types/cos.rs:81 is NOT a stale reference.** The line says "1024
+  buckets gave..." — a valid historical comparison. Original v1
+  listed it under "1024 → 4096" mass-replace. **v2 explicitly
+  preserves it.**
+- **§3.B replacement text is accurate** per both reviewers — slight
+  wording tightening to clarify V_min sync only applies to
+  shared_exact (not owner-local).
+- **`tx.rs:NNN` references**: drop the breadcrumb (Codex) or update
+  to module/function anchor (Gemini). v2 picks per-site:
+  - `queue_service/mod.rs:117` — drop (decayed review breadcrumb).
+  - `docs/userspace-capture-plan.md:118,452` — replace with
+    `userspace-dp/src/afxdp/tx/transmit.rs:transmit_batch()`.
+  - `tx/cos_classify.rs:571,580` — replace with module/function
+    anchor.
+  - `umem/mod.rs:150` — replace with module/function anchor.
+  - `umem/tests.rs:*` — replace; tests-side, low cost.
+  - `protocol.rs:1315` — replace with current path.
+  - `types/cos.rs:718` — replace with `cos/queue_service/mod.rs:drain_shaped_tx`.
+
+
 
 ## 1. Issue framing
 
@@ -85,7 +116,9 @@ Verified inventory across `userspace-dp/src/afxdp/cos/`,
 - Network ring sizes, MTU, syslog buffer sizes — orthogonal.
 - Doc files marked KILLED / WITHDRAWN — historical record by design.
 
-## 4. Concrete changes
+## 4. Concrete changes (v2)
+
+### `1024 → 4096` mass-replace
 
 | File | Line(s) | Change |
 |---|---|---|
@@ -93,13 +126,37 @@ Verified inventory across `userspace-dp/src/afxdp/cos/`,
 | `userspace-dp/src/afxdp/cos/flow_hash.rs` | 104-108 | `1024` / `10 bits wide` → `4096` / `12 bits wide` |
 | `userspace-dp/src/afxdp/cos/queue_ops/pop.rs` | 46, 135 | `1024` → `4096` |
 | `userspace-dp/src/afxdp/cos/admission.rs` | 110, 208 | `1024` → `4096` |
-| `userspace-dp/src/afxdp/types/cos.rs` | 81, 230, 564, 579 | `1024` → `4096` |
-| `userspace-dp/src/afxdp/types/cos.rs` | 99 | leave (intentional historical comparison) |
-| `userspace-dp/src/afxdp/types/cos.rs` | 432-434 | rewrite per §3.B |
-| `userspace-dp/src/afxdp/cos/queue_service/mod.rs` | 117 | replace `tx.rs:262` ref |
-| `docs/userspace-capture-plan.md` | 118 | replace `afxdp/tx.rs` ref |
+| `userspace-dp/src/afxdp/types/cos.rs` | 230, 564, 579 | `1024` → `4096` |
+| `userspace-dp/src/afxdp/cos/admission_tests.rs` | 1178, 1207, 1234 | `1024 active buckets` → `4096 active buckets` |
+| `userspace-dp/src/afxdp/cos/flow_hash_tests.rs` | 30, 107, 164 | review per-line; either update or rename adjacent test (`exact_cos_flow_bucket_distribution_at_1024`-style) |
 
-Total: ~12 lines edited across 8 files.
+### Preserved (intentional historical comparison)
+
+| File | Line(s) | Reason |
+|---|---|---|
+| `userspace-dp/src/afxdp/types/cos.rs` | 81 | "1024 buckets gave ~17.7%" — comparison frame for current 4096 |
+| `userspace-dp/src/afxdp/types/cos.rs` | 99 | "(was ~58 KB at 1024)" — structural footprint comparison |
+
+### `flow_fair = queue.exact && !shared_exact` rewrite
+
+| File | Line(s) | Change |
+|---|---|---|
+| `userspace-dp/src/afxdp/types/cos.rs` | 432-434 | rewrite per §3.B — slight wording tightening for V_min sync scope |
+
+### `tx.rs:NNN` line reference cleanup
+
+| File | Line(s) | Change |
+|---|---|---|
+| `userspace-dp/src/afxdp/cos/queue_service/mod.rs` | 117 | drop the `tx.rs:262` breadcrumb |
+| `userspace-dp/src/afxdp/types/cos.rs` | 718 | replace with `cos/queue_service/mod.rs:drain_shaped_tx` |
+| `userspace-dp/src/afxdp/tx/cos_classify.rs` | 571, 580 | replace with module/function anchor |
+| `userspace-dp/src/afxdp/umem/mod.rs` | 150 | replace `tx.rs::stamp_submits` with current module path |
+| `userspace-dp/src/afxdp/umem/tests.rs` | 518, 519, 1031, 1064, 1074 | replace with current paths |
+| `userspace-dp/src/protocol.rs` | 1315 | replace `tx.rs:289/330` with current path |
+| `docs/userspace-capture-plan.md` | 118, 452 | replace with `userspace-dp/src/afxdp/tx/transmit.rs:transmit_batch()` |
+
+Total: ~25 lines edited across ~13 files (vs original v1 estimate of
+12 lines / 8 files). v2 is wider but still pure doc.
 
 ## 5. Public API preservation
 

--- a/docs/pr/1210-stale-cos-comments/plan.md
+++ b/docs/pr/1210-stale-cos-comments/plan.md
@@ -1,0 +1,169 @@
+---
+status: DRAFT v1 — pending adversarial plan review
+issue: #1210
+phase: single PR — pure doc/comment edits, no behavior change
+---
+
+## 1. Issue framing
+
+Per #1210 and Codex CoS findings retrospective: source-tree comments
+and docs reference scheduler invariants that no longer match the
+current code. The drift cost three plan-review cycles in this session
+already (PR #1203, #936 v1, Phase 2 byte-rate). #1205 ships a CI check
+to prevent future drift; this PR scrubs the existing drift.
+
+## 2. Honest scope/value framing
+
+**Pure documentation edits.** Zero behavior change. Zero new tests.
+
+The value is small per-edit but compounds: each stale anchor reads as
+authority on the current scheduler when reviewers / future readers
+encounter it. Removing them prevents the next plan from being drafted
+against fictional code state.
+
+**If reviewers conclude the scrub is too aggressive (e.g., we're
+losing intentional historical retrospective text), PLAN-NEEDS-MINOR
+on the specific lines is the right verdict.**
+
+## 3. What's being scrubbed
+
+Verified inventory across `userspace-dp/src/afxdp/cos/`,
+`userspace-dp/src/afxdp/types/`, and `docs/` excluding `_KILLED` /
+`_WITHDRAWN` plan files (those preserve history by design):
+
+### A. `COS_FLOW_FAIR_BUCKETS = 1024` references
+
+- `userspace-dp/src/afxdp/cos/queue_ops/mod.rs:64` — comment says
+  "1024, typical workloads 2-16". Update to "4096".
+- `userspace-dp/src/afxdp/cos/flow_hash.rs:104` — comment says "With
+  `COS_FLOW_FAIR_BUCKETS = 1024` the mask in `cos_flow_bucket_index`
+  is 10 bits wide". Update to "4096" + "12 bits wide".
+- `userspace-dp/src/afxdp/cos/queue_ops/pop.rs:46,135` — "1024" in
+  active-set bound discussion. Update to "4096".
+- `userspace-dp/src/afxdp/cos/admission.rs:110,208` — "1024 flows" /
+  "1024 active buckets" in cap-derivation comments. Update to "4096".
+- `userspace-dp/src/afxdp/types/cos.rs:81,99,230,564,579` — multiple
+  references to "1024 buckets" in struct field docs. Update each to
+  the current 4096 footprint, preserving the historical-comparison
+  parenthetical (e.g., "~232 KB per queue, was ~58 KB at 1024" stays
+  as-is — that's an intentional comparison, not a stale claim).
+
+### B. `flow_fair = queue.exact && !shared_exact` references
+
+- `userspace-dp/src/afxdp/types/cos.rs:432-434` — the high-impact one.
+  Comment block currently reads:
+  > Under the current promotion policy (`flow_fair = queue.exact &&
+  > !shared_exact`), shared_exact queues are NOT on the flow-fair
+  > path — they stay on the single-FIFO-per-worker drain with no
+  > SFQ DRR ordering. The shadow exists so future cross-worker
+  > fairness work (tracked in issue #786) can branch on it.
+
+  Reality (admission.rs:478-486): `flow_fair = queue.exact` for both
+  owner-local AND shared_exact since #785 Phase 3. Update to:
+  > Under the current promotion policy (`flow_fair = queue.exact`),
+  > shared_exact queues ARE on the flow-fair path with cross-worker
+  > V_min sync via `vtime_floor: Arc<...>` (#917). The cached
+  > `shared_exact` flag remains on `CoSQueueRuntime` so admission
+  > paths can apply rate-aware caps differently from owner-local
+  > exact queues (`cos_queue_flow_share_limit`, #914).
+
+### C. Old `tx.rs:` line references
+
+- `userspace-dp/src/afxdp/cos/queue_service/mod.rs:117` — references
+  "tx.rs:262". The CoS code split since the reference; update to the
+  current module path or drop the line reference (keep just the
+  conceptual context).
+- `docs/userspace-capture-plan.md:118` — "afxdp/tx.rs:transmit_batch()".
+  Update to current `tx/transmit.rs` or `cos/queue_service/service.rs`
+  per the actual function location.
+
+### D. Out of scope
+
+- Buffer-size mentions of "1024" that are NOT bucket-count related
+  (e.g., `COS_ROOT_LEASE_MAX_BYTES = 512 * 1024` at
+  `shared_cos_lease.rs:212` is bytes, not buckets).
+- Network ring sizes, MTU, syslog buffer sizes — orthogonal.
+- Doc files marked KILLED / WITHDRAWN — historical record by design.
+
+## 4. Concrete changes
+
+| File | Line(s) | Change |
+|---|---|---|
+| `userspace-dp/src/afxdp/cos/queue_ops/mod.rs` | 64 | `1024` → `4096` |
+| `userspace-dp/src/afxdp/cos/flow_hash.rs` | 104-108 | `1024` / `10 bits wide` → `4096` / `12 bits wide` |
+| `userspace-dp/src/afxdp/cos/queue_ops/pop.rs` | 46, 135 | `1024` → `4096` |
+| `userspace-dp/src/afxdp/cos/admission.rs` | 110, 208 | `1024` → `4096` |
+| `userspace-dp/src/afxdp/types/cos.rs` | 81, 230, 564, 579 | `1024` → `4096` |
+| `userspace-dp/src/afxdp/types/cos.rs` | 99 | leave (intentional historical comparison) |
+| `userspace-dp/src/afxdp/types/cos.rs` | 432-434 | rewrite per §3.B |
+| `userspace-dp/src/afxdp/cos/queue_service/mod.rs` | 117 | replace `tx.rs:262` ref |
+| `docs/userspace-capture-plan.md` | 118 | replace `afxdp/tx.rs` ref |
+
+Total: ~12 lines edited across 8 files.
+
+## 5. Public API preservation
+
+None. Comments only.
+
+## 6. Hidden invariants the change must preserve
+
+- **No behavior change.** All tests must still pass byte-for-byte.
+- **Historical retrospectives at the doc level (e.g., the multi-line
+  rationale in `admission.rs:395-461` explaining why the policy
+  changed in #785 Phase 3) stay as-is.** They're intentional record
+  of why current code is the way it is.
+- **`docs/pr/*/plan.md` files marked KILLED/WITHDRAWN** stay as-is.
+
+## 7. Risk assessment
+
+| Class | Level | Why |
+|---|---|---|
+| Behavioral regression | **NONE** | Comments only |
+| Over-aggressive scrub | LOW | Each line listed individually; reviewer can flag specific lines |
+| Missing references | LOW | Inventory is grep-derived; reviewer should run the same grep |
+
+## 8. Test plan
+
+- `cargo build --release` clean
+- `cargo test --release` 977+ pass (no test changes; just verifying
+  no comment edit accidentally landed inside a string/doctest)
+- `go build ./...` clean
+- `go test ./...` pass
+- `grep -rn "COS_FLOW_FAIR_BUCKETS = 1024"
+  userspace-dp/src/afxdp/cos/` returns nothing
+- `grep -rn "flow_fair = queue.exact && !shared_exact"
+  userspace-dp/src/afxdp/cos/` returns nothing
+
+## 9. Out of scope
+
+- The CI check (#1205) — separate PR
+- Buffer-size unrelated `1024` references
+- Adding new docs / clarifying anything beyond removing the stale text
+
+## 10. Open questions for adversarial review
+
+1. **Aggressiveness of the §3.B rewrite.** I'm replacing the comment
+   text wholesale rather than just deleting "NOT" / "no SFQ DRR
+   ordering". Is the replacement accurate per current code, or am I
+   over-claiming about V_min sync semantics?
+
+2. **Historical comparison parentheticals.** `types/cos.rs:99` says
+   "(was ~58 KB at 1024)". I'm keeping it. Is that the right call,
+   or should the parenthetical also be scrubbed?
+
+3. **Whether the `tx.rs:262` style references should be dropped or
+   updated.** Some references are useful as conceptual anchors even
+   if the file moved. Drop, update to module-relative path, or
+   case-by-case?
+
+4. **Coverage gaps.** My grep was limited to
+   `userspace-dp/src/afxdp/cos/`, `userspace-dp/src/afxdp/types/`,
+   and `docs/`. Are there other paths with stale CoS references
+   (e.g., `pkg/dataplane/userspace/`, `pkg/api/`, `cmd/`)?
+
+## 11. Verdict request
+
+PLAN-READY → execute scrub.
+PLAN-NEEDS-MINOR → tweak specific lines; same scope.
+PLAN-NEEDS-MAJOR → wider rewrite or different organization.
+PLAN-KILL → unlikely; this is pure hygiene.

--- a/docs/pr/1210-stale-cos-comments/plan.md
+++ b/docs/pr/1210-stale-cos-comments/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v2 — addressing Codex (PLAN-NEEDS-MINOR, task-mou6if9l-ih4eck) and Gemini (PLAN-NEEDS-MINOR, task-mou6jq7b-brjq3z)
+status: REVISED v3 — Codex r2 caught one more stale ref (worker/cos_tests.rs:312); both reviewers PLAN-NEEDS-MINOR rounds-1/2; v3 ready to ship
 issue: #1210
 phase: single PR — pure doc/comment edits, no behavior change
 ---
@@ -153,6 +153,7 @@ Verified inventory across `userspace-dp/src/afxdp/cos/`,
 | `userspace-dp/src/afxdp/umem/mod.rs` | 150 | replace `tx.rs::stamp_submits` with current module path |
 | `userspace-dp/src/afxdp/umem/tests.rs` | 518, 519, 1031, 1064, 1074 | replace with current paths |
 | `userspace-dp/src/protocol.rs` | 1315 | replace `tx.rs:289/330` with current path |
+| `userspace-dp/src/afxdp/worker/cos_tests.rs` | 312 | replace `tx.rs line ~250` with current path (v3 — Codex r2 catch) |
 | `docs/userspace-capture-plan.md` | 118, 452 | replace with `userspace-dp/src/afxdp/tx/transmit.rs:transmit_batch()` |
 
 Total: ~25 lines edited across ~13 files (vs original v1 estimate of

--- a/docs/userspace-capture-plan.md
+++ b/docs/userspace-capture-plan.md
@@ -115,7 +115,7 @@ header, VLAN tags (if present), IP header, payload. No metadata prepended.
 
 ### 2. Egress capture
 
-**Location**: `afxdp/tx.rs:transmit_batch()`, after frame is written to
+**Location**: `userspace-dp/src/afxdp/tx/transmit.rs::transmit_batch()`, after frame is written to
 UMEM but before TX ring submission.
 
 ```rust
@@ -449,7 +449,7 @@ Could be offered as a `capture-to-file` option alongside tap interfaces.
 |------|--------|
 | `userspace-dp/src/capture.rs` | NEW: CaptureDispatcher, CaptureWriter, CaptureConfig |
 | `userspace-dp/src/afxdp.rs` | Add capture hooks in poll_binding |
-| `userspace-dp/src/afxdp/tx.rs` | Add capture hooks in transmit paths |
+| `userspace-dp/src/afxdp/tx/transmit.rs` | Add capture hooks in transmit paths |
 | `userspace-dp/src/main.rs` | Handle "capture" control requests |
 | `pkg/dataplane/userspace/protocol.go` | CaptureControlRequest struct |
 | `pkg/dataplane/userspace/manager.go` | EnableCapture, tap interface lifecycle |

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -107,7 +107,7 @@ const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
 ///
 /// Truncation: result truncates to 0 when `per_flow_rate <
 /// 1e9 / RTT_TARGET_NS = 100 bytes/sec`. At cluster-scale rates
-/// (≥ 1 Gbps queues with ≤ 1024 flows → ≥ 122 KB/s/flow) this is
+/// (≥ 1 Gbps queues with ≤ 4096 flows → ≥ 122 KB/s/flow) this is
 /// far from the truncation floor. On user-configured low-rate
 /// queues (e.g., 64 kbps WAN class with 100+ flows) the BDP floor
 /// silently degenerates to 0 and the `MIN_SHARE` (24 KB) clamp
@@ -205,7 +205,7 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
 /// on the high side by `delay_cap = transmit_rate_bytes ×
 /// COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS / 1e9`, i.e. the number of bytes
 /// the queue can drain in the max tolerated residence time. Without
-/// this, at 1024 active buckets the cap reaches ~24 MB, which on a
+/// this, at 4096 active buckets the cap reaches ~24 MB, which on a
 /// 1 Gbps queue is ~190 ms of queueing — far outside the scheduler's
 /// predictable regime. The clamp is applied as
 /// `.min(delay_cap.max(base))`: it never shrinks below the operator's

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -36,8 +36,9 @@ const _: () = assert!(COS_FLOW_FAIR_MIN_SHARE_BYTES >= 16 * 1500);
 /// Hard upper bound on per-flow fair queue residence time. Without
 /// this, `cos_flow_aware_buffer_limit` can scale the aggregate cap
 /// to `COS_FLOW_FAIR_BUCKETS × COS_FLOW_FAIR_MIN_SHARE_BYTES`
-/// (~24 MB at max), which on a 1 Gbps queue is ~190 ms of queueing
-/// — far outside the scheduler's predictable regime. 5 ms is ~5×
+/// (~98 MB at max with 4096 buckets × 24 KB), which on a 1 Gbps
+/// queue is ~786 ms of queueing — far outside the scheduler's
+/// predictable regime. 5 ms is ~5×
 /// BDP at 1 Gbps cluster RTT and keeps the tail bounded while
 /// leaving generous room for bulk TCP. Tracked in #717.
 pub(in crate::afxdp) const COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS: u64 = 5_000_000;
@@ -107,7 +108,7 @@ const SHARED_EXACT_BURST_HEADROOM: u64 = 2;
 ///
 /// Truncation: result truncates to 0 when `per_flow_rate <
 /// 1e9 / RTT_TARGET_NS = 100 bytes/sec`. At cluster-scale rates
-/// (≥ 1 Gbps queues with ≤ 4096 flows → ≥ 122 KB/s/flow) this is
+/// (≥ 1 Gbps queues with ≤ 4096 flows → ≥ 30.5 KB/s/flow) this is
 /// far from the truncation floor. On user-configured low-rate
 /// queues (e.g., 64 kbps WAN class with 100+ flows) the BDP floor
 /// silently degenerates to 0 and the `MIN_SHARE` (24 KB) clamp
@@ -205,8 +206,9 @@ pub(in crate::afxdp) fn cos_queue_flow_share_limit(
 /// on the high side by `delay_cap = transmit_rate_bytes ×
 /// COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS / 1e9`, i.e. the number of bytes
 /// the queue can drain in the max tolerated residence time. Without
-/// this, at 4096 active buckets the cap reaches ~24 MB, which on a
-/// 1 Gbps queue is ~190 ms of queueing — far outside the scheduler's
+/// this, at 4096 active buckets the cap reaches ~98 MB
+/// (4096 × 24 KB MIN_SHARE), which on a 1 Gbps queue is ~786 ms
+/// of queueing — far outside the scheduler's
 /// predictable regime. The clamp is applied as
 /// `.min(delay_cap.max(base))`: it never shrinks below the operator's
 /// explicit `buffer-size`, so an operator who asked for a deeper

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1217,7 +1217,7 @@ fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
     assert_eq!(
         cap, expected_delay_cap,
         "flow-aware cap must be clamped to the 5 ms delay envelope, not the ~98 MB \
-         unclamped expansion (4096 × 24 KB at the GEMINI-NEXT.md fairness bump)"
+         unclamped expansion (4096 × 24 KB at the #785 fairness bump)"
     );
 
     // Counter-factual: prove the pre-clamp formula would have
@@ -1231,7 +1231,7 @@ fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
         unclamped,
         COS_FLOW_FAIR_BUCKETS as u64 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
         "unclamped formula baseline: COS_FLOW_FAIR_BUCKETS × COS_FLOW_FAIR_MIN_SHARE_BYTES \
-         (4096 × 24 KB = ~98 MB after the GEMINI-NEXT.md fairness bump from 1024)"
+         (4096 × 24 KB = ~98 MB after the #785 fairness bump from 1024)"
     );
     assert!(
         cap < unclamped,

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1175,7 +1175,7 @@ fn cos_queue_flow_share_limit_never_drops_below_fast_retransmit_floor() {
 
 #[test]
 fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
-    // #717: at the architectural maximum of 1024 active buckets
+    // #717: at the architectural maximum of 4096 active buckets
     // the pre-clamp flow-aware expansion reaches
     // 1024 × COS_FLOW_FAIR_MIN_SHARE_BYTES ≈ 24 MB. On a 1 Gbps
     // queue that is ~190 ms of queue residence — far outside the

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1231,7 +1231,7 @@ fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
         unclamped,
         COS_FLOW_FAIR_BUCKETS as u64 * COS_FLOW_FAIR_MIN_SHARE_BYTES,
         "unclamped formula baseline: COS_FLOW_FAIR_BUCKETS × COS_FLOW_FAIR_MIN_SHARE_BYTES \
-         (4096 × 24 KB = ~96 MB after the GEMINI-NEXT.md fairness bump from 1024)"
+         (4096 × 24 KB = ~98 MB after the GEMINI-NEXT.md fairness bump from 1024)"
     );
     assert!(
         cap < unclamped,

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -1177,8 +1177,8 @@ fn cos_queue_flow_share_limit_never_drops_below_fast_retransmit_floor() {
 fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
     // #717: at the architectural maximum of 4096 active buckets
     // the pre-clamp flow-aware expansion reaches
-    // 1024 × COS_FLOW_FAIR_MIN_SHARE_BYTES ≈ 24 MB. On a 1 Gbps
-    // queue that is ~190 ms of queue residence — far outside the
+    // 4096 × COS_FLOW_FAIR_MIN_SHARE_BYTES ≈ 98 MB. On a 1 Gbps
+    // queue that is ~786 ms of queue residence — far outside the
     // scheduler's predictable regime. The latency-envelope clamp
     // caps the aggregate at
     // `transmit_rate_bytes × COS_FLOW_FAIR_MAX_QUEUE_DELAY_NS / 1e9`
@@ -1204,7 +1204,7 @@ fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
     let queue = &mut root.queues[0];
     queue.flow_fair = true;
 
-    // Drive to the architectural maximum: 1024 populated buckets.
+    // Drive to the architectural maximum: 4096 populated buckets.
     queue.active_flow_buckets = COS_FLOW_FAIR_BUCKETS as u16;
     for bucket in 0..COS_FLOW_FAIR_BUCKETS {
         queue.flow_bucket_bytes[bucket] = 1_000;
@@ -1216,12 +1216,12 @@ fn cos_flow_aware_buffer_limit_clamps_high_flow_count_to_max_delay() {
     let expected_delay_cap = 625_000u64;
     assert_eq!(
         cap, expected_delay_cap,
-        "flow-aware cap must be clamped to the 5 ms delay envelope, not the ~24 MB \
-         unclamped expansion"
+        "flow-aware cap must be clamped to the 5 ms delay envelope, not the ~98 MB \
+         unclamped expansion (4096 × 24 KB at the GEMINI-NEXT.md fairness bump)"
     );
 
     // Counter-factual: prove the pre-clamp formula would have
-    // returned 24 MB. Guards against a future refactor silently
+    // returned ~98 MB. Guards against a future refactor silently
     // deleting the clamp.
     let unclamped = u64::from(queue.active_flow_buckets)
         .max(1)

--- a/userspace-dp/src/afxdp/cos/flow_hash.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash.rs
@@ -101,8 +101,8 @@ pub(in crate::afxdp) fn cos_flow_hash_seed_from_os() -> u64 {
     nonzero(fallback)
 }
 
-// #711: returns `u16` (was `u8`). With `COS_FLOW_FAIR_BUCKETS = 1024`
-// the mask in `cos_flow_bucket_index` is 10 bits wide; a `u8` return
+// #711: returns `u16` (was `u8`). With `COS_FLOW_FAIR_BUCKETS = 4096`
+// the mask in `cos_flow_bucket_index` is 12 bits wide; a `u8` return
 // would silently re-collapse the hash into 256 buckets and give no
 // benefit from the bucket grow. Returning `u16` preserves the full
 // hash width through the mask step.

--- a/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
@@ -27,10 +27,10 @@ fn exact_cos_flow_bucket_diverges_across_seeds_for_same_flow() {
     // probeable pure function of the 5-tuple. Two queues with different
     // seeds must be able to send the same flow into different buckets.
     // A deterministic hash would make this test a tautology that always
-    // fails, so we scan seeds until we find a divergence; with a 1024-
-    // bucket output, collision rate is ~1/1024 per seed pair, so 8191
-    // attempts is well below any reasonable flake tolerance (collision
-    // probability ≈ (1/1024)^8191 if the hash were uniform).
+    // fails, so we scan seeds until we find a divergence; with the
+    // 4096-bucket output, collision rate is ~1/4096 per seed pair, so
+    // 8191 attempts is well below any reasonable flake tolerance
+    // (collision probability ≈ (1/4096)^8191 if the hash were uniform).
     let flow = test_session_key(9000, 5201);
     let reference = cos_flow_bucket_index(0, Some(&flow));
     let mut saw_divergence = false;
@@ -95,19 +95,19 @@ fn exact_cos_flow_bucket_handles_missing_flow_key() {
 }
 
 #[test]
-fn exact_cos_flow_bucket_distribution_at_1024_keeps_collisions_below_budget() {
+fn exact_cos_flow_bucket_distribution_keeps_collisions_below_budget() {
     // #711 correctness pin. The whole point of growing buckets
-    // 64 → 1024 is collision reduction. A hash-mix regression can
-    // produce acceptable distribution on one seed while clustering
-    // badly under others; a single-seed test is too easy to
-    // accidentally satisfy. Exercise multiple deterministic seeds
+    // 64 → 1024 → 4096 is collision reduction. A hash-mix regression
+    // can produce acceptable distribution on one seed while
+    // clustering badly under others; a single-seed test is too easy
+    // to accidentally satisfy. Exercise multiple deterministic seeds
     // and mix v4/v6 tuples so the guarantee covers a realistic
     // traffic shape.
     //
-    // Theoretical baseline for 64 uniform flows into 1024 buckets:
-    // E[colliding pairs] ≈ 64·63/(2·1024) ≈ 1.97 — so ~62-63
+    // Theoretical baseline for 64 uniform flows into 4096 buckets:
+    // E[colliding pairs] ≈ 64·63/(2·4096) ≈ 0.49 — so ~63-64
     // distinct buckets on average. A budget of 58/64 per seed is
-    // ~2 sigma conservative under a uniform-hash null hypothesis;
+    // very conservative under a uniform-hash null hypothesis;
     // if this test fires, the hash function has become materially
     // non-uniform and the fairness guarantee is silently gone.
     use std::collections::BTreeSet;

--- a/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
+++ b/userspace-dp/src/afxdp/cos/flow_hash_tests.rs
@@ -161,8 +161,8 @@ fn exact_cos_flow_bucket_distribution_keeps_collisions_below_budget() {
 /// buffer / prospective_active_flows, halved/thirded if a
 /// bucket holds 2-3 flows).
 ///
-/// Budget: for 12 narrow-input flows in 1024 buckets under a
-/// good hash, E[colliding pairs] ≈ 12*11/(2*1024) ≈ 0.06 —
+/// Budget: for 12 narrow-input flows in 4096 buckets under a
+/// good hash, E[colliding pairs] ≈ 12*11/(2*4096) ≈ 0.016 —
 /// essentially always 12 distinct buckets. Under the prior
 /// boost-style hash_combine, narrow inputs observably collapse
 /// to 3-6 distinct buckets across most seeds. Demand >=11

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -61,7 +61,7 @@ pub(in crate::afxdp) fn cos_queue_len(queue: &CoSQueueRuntime) -> usize {
 /// whose ordering actually matters.
 ///
 /// Linear scan over the active ring. Size bound: `active_flow_buckets
-/// <= COS_FLOW_FAIR_BUCKETS = 1024`, typical workloads 2-16. At 12
+/// <= COS_FLOW_FAIR_BUCKETS = 4096`, typical workloads 2-16. At 12
 /// active buckets this is 12 × (u64 load + compare) ≈ 20 ns — well
 /// below NAPI batch pacing.
 ///

--- a/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
@@ -43,7 +43,7 @@ fn cos_queue_pop_front_inner(
         // rotation order. The active set (`flow_rr_buckets`) is
         // still maintained on 0↔>0 transitions so the min-scan
         // only iterates the currently-active buckets (typically
-        // 2-16), not all 1024.
+        // 2-16), not all 4096.
         let bucket_u16 = cos_queue_min_finish_bucket(queue)?;
         let bucket = usize::from(bucket_u16);
         if push_snapshot {
@@ -132,7 +132,7 @@ fn cos_queue_pop_front_inner(
         } else {
             // Bucket drained — deregister from the active set.
             // `FlowRrRing::remove` is O(active_count), typically
-            // 2-16 compares; bounded by 1024 worst case.
+            // 2-16 compares; bounded by 4096 worst case.
             queue.flow_rr_buckets.remove(bucket_u16);
         }
         item

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -114,7 +114,7 @@ pub(in crate::afxdp) enum ExactCoSScratchBuild {
 /// within a single drain pass, so using the idx for direct indexed
 /// access is safe and avoids the O(#queues) linear scan by
 /// `queue_id` that the first revision of this PR used (Copilot
-/// review, tx.rs:262).
+/// review).
 ///
 /// `queue_id` is retained as a stable 8-bit identifier for the
 /// snapshot and telemetry paths which key on id, not idx.

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -568,7 +568,7 @@ pub(in crate::afxdp) fn demote_prepared_cos_queue_to_local(
     // Single-worker invariant (Gemini R2): demote and pop run
     // in the same worker thread, and any in-flight pop's
     // snapshot is cleared by cos_queue_drain_all below
-    // (tx.rs:4742). So no cross-batch pop_snapshot_stack
+    // (cos_queue_drain_all). So no cross-batch pop_snapshot_stack
     // entries can be live at this point — restoring vtime +
     // head/tail finish-times can't race with a concurrent
     // pop's snapshot interpretation.
@@ -577,7 +577,7 @@ pub(in crate::afxdp) fn demote_prepared_cos_queue_to_local(
     // arrays (32 KB each at 4096 buckets — the GEMINI-NEXT.md fairness
     // bump from 1024). Both are already cache-resident in the queue;
     // demote is a rare TX-frame-exhaustion fallback called from
-    // enqueue_local_into_cos at tx.rs:5211, not a hot-path operation.
+    // enqueue_local_into_cos at tx/cos_classify.rs::enqueue_local_into_cos, not a hot-path operation.
     let saved_queue_vtime = queue.queue_vtime;
     let saved_head_finish = queue.flow_bucket_head_finish_bytes;
     let saved_tail_finish = queue.flow_bucket_tail_finish_bytes;

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -574,10 +574,10 @@ pub(in crate::afxdp) fn demote_prepared_cos_queue_to_local(
     // pop's snapshot interpretation.
     //
     // Footprint: 64 KB stack memcpy of two [u64; COS_FLOW_FAIR_BUCKETS]
-    // arrays (32 KB each at 4096 buckets — the GEMINI-NEXT.md fairness
+    // arrays (32 KB each at 4096 buckets — the #785 fairness
     // bump from 1024). Both are already cache-resident in the queue;
     // demote is a rare TX-frame-exhaustion fallback called from
-    // enqueue_local_into_cos at tx/cos_classify.rs::enqueue_local_into_cos, not a hot-path operation.
+    // tx/cos_classify.rs::enqueue_local_into_cos, not a hot-path operation.
     let saved_queue_vtime = queue.queue_vtime;
     let saved_head_finish = queue.flow_bucket_head_finish_bytes;
     let saved_tail_finish = queue.flow_bucket_tail_finish_bytes;

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -227,7 +227,7 @@ impl FlowRrRing {
     ///
     /// O(len) — scans the ring. `len` is bounded by the number of
     /// concurrently active flow buckets, typically 2-16 on
-    /// iperf3-style workloads, up to `COS_FLOW_FAIR_BUCKETS = 1024`
+    /// iperf3-style workloads, up to `COS_FLOW_FAIR_BUCKETS = 4096`
     /// worst case. Returns `true` if the bucket was found and
     /// removed.
     ///
@@ -429,11 +429,14 @@ pub(in crate::afxdp) struct CoSQueueRuntime {
     pub(in crate::afxdp) flow_fair: bool,
     /// #785: cached shadow of `WorkerCoSQueueFastPath.shared_exact`
     /// populated by `promote_cos_queue_flow_fair`. Under the current
-    /// promotion policy (`flow_fair = queue.exact && !shared_exact`),
-    /// shared_exact queues are NOT on the flow-fair path — they stay
-    /// on the single-FIFO-per-worker drain with no SFQ DRR ordering.
-    /// The shadow exists so future cross-worker fairness work
-    /// (tracked in issue #786) can branch on it.
+    /// promotion policy (`flow_fair = queue.exact`), shared_exact
+    /// queues ARE on the flow-fair MQFQ path with cross-worker V_min
+    /// sync via `vtime_floor: Arc<...>` (#917). The cached
+    /// `shared_exact` flag remains on `CoSQueueRuntime` so admission
+    /// paths can apply rate-aware caps differently from owner-local
+    /// exact queues — see `cos_queue_flow_share_limit` (#914), which
+    /// returns `max(fair_share*2, bdp_floor).clamp(MIN, buffer_limit)`
+    /// on shared_exact instead of the legacy MIN-floor cap.
     ///
     /// Keeping the field on the queue runtime makes the policy bit
     /// available to hot-path helpers directly from
@@ -561,7 +564,7 @@ pub(in crate::afxdp) struct CoSQueueRuntime {
     /// so no hot-path realloc occurs. Each entry is 24 bytes
     /// (`CoSQueuePopSnapshot`), so the worst-case footprint is
     /// `TX_BATCH_SIZE × 24` bytes per queue — on top of the
-    /// 1024-bucket bookkeeping arrays already resident in
+    /// 4096-bucket bookkeeping arrays already resident in
     /// `CoSQueueRuntime`. Lowered from 256 → 64 in #920 (worst-case
     /// stack ~1.5 KB).
     ///
@@ -576,7 +579,7 @@ pub(in crate::afxdp) struct CoSQueueRuntime {
     /// #785 Phase 3 — active-set tracking for flow-fair MQFQ.
     /// Still populated on bucket 0→>0 / >0→0 transitions so that
     /// `cos_queue_front`/`cos_queue_pop_front` can scan just the
-    /// small active set rather than all 1024 SFQ buckets to find
+    /// small active set rather than all 4096 SFQ buckets to find
     /// the minimum finish time. Semantically a set (membership),
     /// not a DRR ring — the ordering is governed by
     /// `flow_bucket_finish_bytes`, not ring position.
@@ -715,7 +718,7 @@ pub(in crate::afxdp) struct CoSTimerWheelRuntime {
 
 /// #751: per-queue owner-side drain telemetry. Written by the owner
 /// worker when a drain cycle services this specific queue (see
-/// `drain_shaped_tx`'s per-queue return signal in tx.rs); read via
+/// `drain_shaped_tx`'s per-queue return signal in cos/queue_service/mod.rs); read via
 /// the snapshot path published through ArcSwap to Prometheus and to
 /// `show class-of-service interface`.
 ///

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -147,7 +147,7 @@ const _ASSERT_TX_SUBMIT_BUCKET_COUNT_IS_16: () = assert!(TX_SUBMIT_LAT_BUCKETS =
 /// against this value means the submit stamp was never written (e.g.
 /// a surviving offset across a restart, or a `monotonic_nanos() == 0`
 /// clock-gettime failure where `stamp_submits` early-returned without
-/// touching the slot — `tx.rs::stamp_submits`). The reap path MUST
+/// touching the slot — `tx/transmit.rs::stamp_submits`). The reap path MUST
 /// skip the histogram increment for these so the tail of the
 /// distribution is not silently biased toward bucket 0 (plan §5.4).
 ///

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -147,7 +147,7 @@ const _ASSERT_TX_SUBMIT_BUCKET_COUNT_IS_16: () = assert!(TX_SUBMIT_LAT_BUCKETS =
 /// against this value means the submit stamp was never written (e.g.
 /// a surviving offset across a restart, or a `monotonic_nanos() == 0`
 /// clock-gettime failure where `stamp_submits` early-returned without
-/// touching the slot — `tx/transmit.rs::stamp_submits`). The reap path MUST
+/// touching the slot — `tx/stats.rs::stamp_submits`). The reap path MUST
 /// skip the histogram increment for these so the tail of the
 /// distribution is not silently biased toward bucket 0 (plan §5.4).
 ///

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -188,7 +188,7 @@ fn drain_latency_hist_increments_on_recorded_drain() {
     // #709: exercise the hist-update path in isolation. We do not
     // call `drain_shaped_tx` here (requires a fully-constructed
     // BindingWorker fixture); instead, we recreate the exact shape
-    // tx.rs uses — bucket_index_for_ns + fetch_add — and assert
+    // umem/mod.rs::bucket_index_for_ns uses + fetch_add — and assert
     // the bucket landed in the right slot.
     let live = BindingLiveState::new();
     let delta_ns = 1500u64; // bucket 1 ([1024, 2048))

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1028,7 +1028,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
     //   (b) `record_kick_latency` itself pins to "well-formed
     //       inputs only": no in-band sentinel check inside the
     //       helper, matching `record_tx_completions_with_stamp`'s
-    //       `ts_completion >= ts_submit` pattern at tx/transmit.rs::transmit_batch.
+    //       `ts_completion >= ts_submit` pattern at tx/stats.rs::record_tx_completions_with_stamp.
     //
     // The pin: drive `record_kick_latency` with a synthetic
     // "underflow would produce this" delta and verify it DOES
@@ -1061,7 +1061,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
     // Invariant pinned: if a future refactor were to add a
     // sentinel inside `record_kick_latency`, this assertion
     // would fail and flag the behavior change explicitly.
-    // The production call site at tx/transmit.rs:maybe_wake_tx uses
+    // The production call site at tx/rings.rs::maybe_wake_tx uses
     // `if kick_start != 0 && kick_end >= kick_start {
     // record_kick_latency(...) }` which is the correct guard
     // location (code-review R1 HIGH-1).
@@ -1071,7 +1071,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
 fn tx_kick_retry_count_observable_via_snapshot() {
     // #825 code-review R1 MED-3: pin that the `tx_kick_retry_count`
     // field is (a) writable via the same owner-side atomic that the
-    // production call site at tx/transmit.rs:maybe_wake_tx EAGAIN branch uses
+    // production call site at tx/rings.rs::maybe_wake_tx EAGAIN branch uses
     // (`binding.live.owner_profile_owner.tx_kick_retry_count
     //   .fetch_add(1, Ordering::Relaxed)`) and (b) observable via
     // `BindingLiveState::snapshot()` with the expected value. This

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -515,8 +515,8 @@ fn tx_latency_hist_partial_batch_stamping_only_touches_accepted_prefix() {
 #[test]
 fn tx_latency_hist_retry_unwind_leaves_no_stamps() {
     // #812 plan §6.1 test #3. The `inserted == 0` retry-unwind
-    // path at the commit-rejected sites (e.g. tx.rs:1858-1866
-    // / tx.rs:6038-6045) hands NO offsets to `stamp_submits`
+    // path at the commit-rejected sites (e.g. tx/transmit.rs::commit-rejected helpers
+    // / tx/transmit.rs::ring-rejected paths) hands NO offsets to `stamp_submits`
     // — the descriptors are pushed back onto free_tx_frames
     // and the call-site Pattern is `.take(inserted as usize)`
     // which is `.take(0)` here. Pin the behaviour by invoking
@@ -1028,7 +1028,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
     //   (b) `record_kick_latency` itself pins to "well-formed
     //       inputs only": no in-band sentinel check inside the
     //       helper, matching `record_tx_completions_with_stamp`'s
-    //       `ts_completion >= ts_submit` pattern at tx.rs:113-119.
+    //       `ts_completion >= ts_submit` pattern at tx/transmit.rs::transmit_batch.
     //
     // The pin: drive `record_kick_latency` with a synthetic
     // "underflow would produce this" delta and verify it DOES
@@ -1061,7 +1061,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
     // Invariant pinned: if a future refactor were to add a
     // sentinel inside `record_kick_latency`, this assertion
     // would fail and flag the behavior change explicitly.
-    // The production call site at tx.rs:maybe_wake_tx uses
+    // The production call site at tx/transmit.rs:maybe_wake_tx uses
     // `if kick_start != 0 && kick_end >= kick_start {
     // record_kick_latency(...) }` which is the correct guard
     // location (code-review R1 HIGH-1).
@@ -1071,7 +1071,7 @@ fn tx_kick_latency_sentinel_underflow_skipped_at_call_site() {
 fn tx_kick_retry_count_observable_via_snapshot() {
     // #825 code-review R1 MED-3: pin that the `tx_kick_retry_count`
     // field is (a) writable via the same owner-side atomic that the
-    // production call site at tx.rs:maybe_wake_tx EAGAIN branch uses
+    // production call site at tx/transmit.rs:maybe_wake_tx EAGAIN branch uses
     // (`binding.live.owner_profile_owner.tx_kick_retry_count
     //   .fetch_add(1, Ordering::Relaxed)`) and (b) observable via
     // `BindingLiveState::snapshot()` with the expected value. This

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -309,7 +309,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
     first.insert(80, make_root());
     // #751: seed per-queue drain stats directly on the first
     // worker's queue runtime. This is what the TX drain loop
-    // writes in production (tx/transmit.rs::transmit); tests pin the
+    // writes in production (tx/drain.rs per-queue drain telemetry); tests pin the
     // aggregated value rather than the old binding-wide rollup.
     first.get_mut(&80).unwrap().queues[0]
         .owner_profile

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -309,7 +309,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
     first.insert(80, make_root());
     // #751: seed per-queue drain stats directly on the first
     // worker's queue runtime. This is what the TX drain loop
-    // writes in production (tx.rs line ~250); tests pin the
+    // writes in production (tx/transmit.rs::transmit); tests pin the
     // aggregated value rather than the old binding-wide rollup.
     first.get_mut(&80).unwrap().queues[0]
         .owner_profile

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1312,7 +1312,7 @@ pub(crate) struct BindingStatus {
     #[serde(rename = "tx_submit_error_drops", default)]
     pub tx_submit_error_drops: u64,
     // #760 instrumentation: post-CoS backup transmit bytes
-    // (drain_pending_tx fallbacks at tx.rs:289/330) that bypass
+    // (drain_pending_tx fallbacks (worker/lifecycle.rs::drain_pending_tx)) that bypass
     // any CoS queue's token gate.
     #[serde(rename = "post_drain_backup_bytes", default)]
     pub post_drain_backup_bytes: u64,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1312,7 +1312,7 @@ pub(crate) struct BindingStatus {
     #[serde(rename = "tx_submit_error_drops", default)]
     pub tx_submit_error_drops: u64,
     // #760 instrumentation: post-CoS backup transmit bytes
-    // (drain_pending_tx fallbacks (worker/lifecycle.rs::drain_pending_tx)) that bypass
+    // (drain_pending_tx fallbacks (tx/drain.rs::drain_pending_tx)) that bypass
     // any CoS queue's token gate.
     #[serde(rename = "post_drain_backup_bytes", default)]
     pub post_drain_backup_bytes: u64,


### PR DESCRIPTION
## Summary

Source-tree comments and docs reference scheduler invariants that no longer match the current code. Three plan-review cycles in the #789 fairness work this session were drafted against stale anchors. This PR scrubs the existing drift; #1205 (sibling) ships a CI check to prevent future drift.

**Pure documentation change. No behavior change. 977/977 tests pass.**

## Changes (14 files, 45 +/- 42 lines)

### `1024 -> 4096` (post-#785 bucket grow)

`cos/{queue_ops/mod.rs, flow_hash.rs, queue_ops/pop.rs, admission.rs, admission_tests.rs}`, `types/cos.rs:230,564,579`. Plus `10 bits wide -> 12 bits wide` in `flow_hash.rs`.

### Preserved (intentional historical comparison)

- `types/cos.rs:81` — "1024 buckets gave ~17.7%" comparison frame for current 4096
- `types/cos.rs:99` — "was ~58 KB at 1024" structural footprint comparison

Both confirmed by Codex + Gemini reviewers.

### `types/cos.rs:432-443` (shared_exact field doc) — rewritten

Old text claimed shared_exact stays on single-FIFO drain. Reality (`admission.rs:478-486`): `flow_fair = queue.exact` for both owner-local AND shared_exact since #785 Phase 3, with V_min sync via #917 and rate-aware admission via #914.

### `flow_hash_tests.rs`

- Rename `exact_cos_flow_bucket_distribution_at_1024_keeps_collisions_below_budget` -> `exact_cos_flow_bucket_distribution_keeps_collisions_below_budget`
- Update math comments for 4096 buckets (E[colliding pairs] ≈ 64·63/(2·4096) ≈ 0.49)
- Update collision probability comment in adjacent test

### `tx.rs:NNN` breadcrumb cleanup (post-#956+ tx.rs decomposition)

10 references across `queue_service/mod.rs`, `types/cos.rs`, `tx/cos_classify.rs`, `umem/mod.rs`, `umem/tests.rs`, `worker/cos_tests.rs`, `protocol.rs`, `docs/userspace-capture-plan.md`. Each replaced with current module/function anchor or dropped if it was a decayed review breadcrumb.

## Plan + adversarial review

Plan: `docs/pr/1210-stale-cos-comments/plan.md` (v3, commit `5c9b1970`)

- Round-1: Codex `task-mou6if9l-ih4eck` PLAN-NEEDS-MINOR; Gemini `task-mou6jq7b-brjq3z` PLAN-NEEDS-MINOR
- Round-2: Codex `task-mou73a8b-0trmjm` PLAN-NEEDS-MINOR (caught one missed ref in `worker/cos_tests.rs:312`, addressed in v3); Gemini `task-mou73qm8-d641cu` PLAN-NEEDS-MINOR

## Test plan

- [x] cargo build --release: clean
- [x] cargo test --release: 977/977 pass
- [x] Renamed test `exact_cos_flow_bucket_distribution_keeps_collisions_below_budget` passes with updated math
- [x] No production code touched; comments + test names + doc paths only

## Out of scope

- The CI drift check (#1205, separate PR; depends on this one merging first)
- Any behavior change

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)