### PR TITLE
#1205: CoS doc/code drift CI guard

### DIFF
--- a/docs/pr/1205-cos-drift-check/plan.md
+++ b/docs/pr/1205-cos-drift-check/plan.md
@@ -1,0 +1,196 @@
+---
+status: DRAFT v1 — pending adversarial plan review
+issue: #1205
+phase: single PR — new test only; no production code
+---
+
+## 1. Issue framing
+
+Per #1205 and Codex CoS findings retrospective: this session burned
+three plan-review cycles on stale code-comment anchors (PR #1203,
+#936 v1, Phase 2 byte-rate). #1210 scrubs the existing drift; this PR
+adds a test that prevents future drift.
+
+## 2. Scope
+
+A single Rust integration test (`tests/cos_doc_drift.rs` or similar
+under `userspace-dp/tests/`) that fails when known-stale policy
+references reappear in active CoS source files.
+
+## 3. Concrete design
+
+### Test location
+
+`userspace-dp/tests/cos_doc_drift.rs` — at the cargo workspace integration
+test level, runs as part of `cargo test --release`.
+
+### Test shape
+
+```rust
+//! CoS doc/code drift guard (#1205).
+//!
+//! Fails if any of the listed stale references reappear in the active
+//! CoS scheduler source tree. See `docs/pr/1205-cos-drift-check/plan.md`
+//! for context. Add new entries when a fairness/MQFQ change makes a
+//! prior assertion stale; never silence by suppressing the check.
+//!
+//! Whitelist: lines marked `// drift-check: historical` are tolerated.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const STALE_PATTERNS: &[(&str, &str)] = &[
+    ("COS_FLOW_FAIR_BUCKETS = 1024",
+     "value is 4096 since #785 Phase 3"),
+    ("flow_fair = queue.exact && !shared_exact",
+     "policy is `flow_fair = queue.exact` since #785 Phase 3"),
+    ("shared_exact queues are NOT on the flow-fair path",
+     "shared_exact runs flow_fair via #917 V_min sync since #785 Phase 3"),
+    ("single-FIFO-per-worker drain",
+     "shared_exact uses MQFQ, not FIFO, since #785 Phase 3"),
+];
+
+const SCAN_DIRS: &[&str] = &[
+    "src/afxdp/cos",
+    "src/afxdp/types",
+    "src/session",
+];
+
+const ALLOW_MARKER: &str = "drift-check: historical";
+
+#[test]
+fn cos_doc_drift_guard() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let mut violations = Vec::new();
+
+    for dir in SCAN_DIRS {
+        let p = Path::new(manifest_dir).join(dir);
+        scan_dir(&p, &mut violations);
+    }
+
+    if !violations.is_empty() {
+        let report: Vec<String> = violations.iter()
+            .map(|v| format!("  {}:{}: {} (rationale: {})",
+                v.path.display(), v.line, v.pattern, v.rationale))
+            .collect();
+        panic!(
+            "CoS doc/code drift detected (#1205):\n{}\n\n\
+             If this is intentional historical retrospective text, \
+             add `// drift-check: historical` on the same line.",
+            report.join("\n")
+        );
+    }
+}
+
+struct Violation {
+    path: PathBuf,
+    line: usize,
+    pattern: &'static str,
+    rationale: &'static str,
+}
+
+fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_dir(&path, violations);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for (lineno, line) in content.lines().enumerate() {
+            if line.contains(ALLOW_MARKER) {
+                continue;
+            }
+            for (pattern, rationale) in STALE_PATTERNS {
+                if line.contains(pattern) {
+                    violations.push(Violation {
+                        path: path.clone(),
+                        line: lineno + 1,
+                        pattern,
+                        rationale,
+                    });
+                }
+            }
+        }
+    }
+}
+```
+
+## 4. Public API preservation
+
+None. Test only.
+
+## 5. Hidden invariants
+
+- The test must pass on master ONCE #1210 has scrubbed existing
+  drift. Order constraint: this PR depends on #1210 merging first,
+  OR this PR's blocklist starts empty and gets populated as a
+  follow-up.
+
+  Recommendation: ship #1205 with the patterns from §3 already
+  included, and gate merge on #1210 having merged. The
+  acceptance-criterion line in #1210's PR will literally be "does
+  the #1205 test pass with this scrub applied".
+
+- The test runs in `cargo test --release` — no separate make target.
+
+- Skip directories should be added if they appear (e.g., a future
+  `userspace-dp/src/scheduler/` extraction). Listed explicitly so
+  reviewers see what's in scope.
+
+## 6. Risk
+
+| Class | Level | Why |
+|---|---|---|
+| Behavioral regression | **NONE** | Test only |
+| False positives | LOW-MED | If a future legitimate use of one of the strings appears, allow-marker handles it |
+| Maintenance burden | LOW | Add a new entry only when a fairness/MQFQ landing makes a prior text stale |
+| Order with #1210 | MED | Need to merge #1210 first OR ship `STALE_PATTERNS` empty initially |
+
+## 7. Test plan
+
+- `cargo test --release cos_doc_drift_guard` passes after #1210 merges.
+- Hand-test: temporarily add one of the stale strings to a file in
+  `src/afxdp/cos/`; test fails with the expected diagnostic.
+- Hand-test: same string + `// drift-check: historical` marker; test
+  passes.
+- `cargo build --release` clean (test compiles).
+- 5×flake on the test (deterministic file scan; should be 5/5).
+
+## 8. Out of scope
+
+- Doc files (`docs/`). The test only scans Rust source; doc drift is
+  caught by the periodic refresh in #1208's audit.
+- Go-side analogue. If `pkg/dataplane/userspace/` ever develops
+  scheduler-relevant comments, add a sibling test then.
+- Custom DSL or cargo-config integration. Plain test, plain assertion.
+
+## 9. Open questions for adversarial review
+
+1. **Allow-marker placement.** Current spec: `// drift-check:
+   historical` on the same line. Is multi-line block-marker support
+   needed for retrospectives that span 5+ lines (e.g., the
+   `admission.rs:395-461` rationale)?
+2. **Initial blocklist completeness.** Are the 4 patterns the right
+   set? Should we also include `\`tx.rs:` or `tx\.rs:` as a literal
+   pattern to catch old line references?
+3. **Order with #1210.** Recommended approach (merge #1210 first or
+   ship blocklist empty initially) — pick one.
+4. **Scope breadth.** Is `src/session/` worth scanning for drift
+   patterns? Currently has `installed_at_ns` / `installed_on_binding_slot`
+   doc text from #789 work; not directly fairness, but adjacent.
+
+## 10. Verdict request
+
+PLAN-READY → execute.
+PLAN-NEEDS-MINOR → tighten patterns / allow-marker semantics.

--- a/docs/pr/1205-cos-drift-check/plan.md
+++ b/docs/pr/1205-cos-drift-check/plan.md
@@ -1,5 +1,5 @@
 ---
-status: REVISED v2 — addressing Codex (PLAN-NEEDS-MINOR, task-mou6j4qs-48a6t6) and Gemini (PLAN-NEEDS-MINOR, task-mou6jz6b-xdep7x)
+status: REVISED v3 — round-2 verdict: Codex PLAN-NEEDS-MINOR (broad numeric pattern), Gemini PLAN-READY. v3 drops NUMERIC_STALE_PATTERNS; ready to ship.
 issue: #1205
 phase: single PR — new test only; no production code
 ---
@@ -90,11 +90,12 @@ const STALE_PATTERNS: &[(&str, &str)] = &[
      "value is 4096 since #785 Phase 3"),
 ];
 
-// Numeric-suffix patterns: blocked iff followed by a non-`[0-9_]` char.
-// Avoids false-positive on legitimate larger numerals like `1024_000`.
-const NUMERIC_STALE_PATTERNS: &[(&str, &str)] = &[
-    ("= 1024", "value is 4096 since #785 Phase 3"),
-];
+// v3: Codex round-2 caught that `= 1024` is too broad with the wider
+// SCAN_DIRS — flags legitimate live constants in mod.rs:201,
+// neighbor.rs:490, flow_cache.rs (unrelated buffer sizes etc).
+// The 8 prose patterns above cover the actual stale CoS-bucket
+// references unambiguously; the numeric pattern adds risk without
+// closing a real gap. Removed in v3.
 
 // `tx.rs:` followed by an ASCII digit — old line-number breadcrumbs
 // are stale across the tx.rs decomposition (#956+). Module/function
@@ -167,17 +168,8 @@ fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
                     violations.push(Violation { path: path.clone(), line: lineno + 1, pattern, rationale });
                 }
             }
-            // Numeric-stale patterns: pattern hit, AND next char (if any)
-            // is NOT in [0-9_]. Avoids false-positive on `1024_000`.
-            for (pattern, rationale) in NUMERIC_STALE_PATTERNS {
-                if let Some(idx) = line.find(pattern) {
-                    let next = line.as_bytes().get(idx + pattern.len()).copied();
-                    let safe_next = next.map(|c| c.is_ascii_digit() || c == b'_').unwrap_or(false);
-                    if !safe_next {
-                        violations.push(Violation { path: path.clone(), line: lineno + 1, pattern, rationale });
-                    }
-                }
-            }
+            // v3: NUMERIC_STALE_PATTERNS dropped — `= 1024` was too broad
+            // with the wider SCAN_DIRS. Prose patterns above are sufficient.
             // tx.rs:N (digit-suffix) — line-number breadcrumb pattern.
             if let Some(idx) = line.find(TX_LINE_REF_PATTERN) {
                 let next = line.as_bytes().get(idx + TX_LINE_REF_PATTERN.len()).copied();

--- a/docs/pr/1205-cos-drift-check/plan.md
+++ b/docs/pr/1205-cos-drift-check/plan.md
@@ -1,8 +1,36 @@
 ---
-status: DRAFT v1 — pending adversarial plan review
+status: REVISED v2 — addressing Codex (PLAN-NEEDS-MINOR, task-mou6j4qs-48a6t6) and Gemini (PLAN-NEEDS-MINOR, task-mou6jz6b-xdep7x)
 issue: #1205
 phase: single PR — new test only; no production code
 ---
+
+## Round-1 verdict resolution
+
+Both reviewers PLAN-NEEDS-MINOR. Convergent findings:
+
+- **Blocklist is too narrow.** Codex: add `1024-bucket bookkeeping`,
+  `all 1024 SFQ buckets`, `bounded by 1024 worst case`,
+  `1024 active buckets`. Both reviewers: add `tx.rs:` line refs.
+  v2 expands the blocklist with these phrase patterns AND a
+  separate predicate for `tx.rs:N` (digit-suffix, per Codex).
+- **SCAN_DIRS too narrow.** Both flag missing `worker/cos.rs`,
+  `tx/cos_classify.rs`, `coordinator/cos_state.rs`. Gemini suggests
+  collapsing to just `src/afxdp/` + `src/session/` since `scan_dir`
+  is recursive. v2 adopts this — broader scope, simpler code.
+- **Order with #1210**: both confirm "ship #1205 with patterns
+  populated, gate merge on #1210 first". Codex: "stacking #1205 on
+  top of #1210 for validation is fine". v2 records this explicitly.
+- **Substring greediness.** Codex: for numeric stale patterns,
+  require char after `1024` to not be `[0-9_]`. Gemini: the existing
+  4 patterns are long enough to be safe via `.contains()`. v2 adopts
+  Codex's more cautious approach for the two numeric patterns
+  (`= 1024`).
+- **Same-line allow marker is sufficient** (both confirm). No
+  block markers.
+- **Don't silently ignore missing scan dirs** (Codex). v2 panics
+  loudly if a configured scan root is missing.
+
+
 
 ## 1. Issue framing
 
@@ -39,6 +67,10 @@ test level, runs as part of `cargo test --release`.
 use std::fs;
 use std::path::{Path, PathBuf};
 
+// Substring patterns must NOT appear on a non-historical line in
+// any file under SCAN_DIRS. Each entry is (pattern, rationale).
+//
+// v2 expanded blocklist per Codex+Gemini reviews:
 const STALE_PATTERNS: &[(&str, &str)] = &[
     ("COS_FLOW_FAIR_BUCKETS = 1024",
      "value is 4096 since #785 Phase 3"),
@@ -48,11 +80,29 @@ const STALE_PATTERNS: &[(&str, &str)] = &[
      "shared_exact runs flow_fair via #917 V_min sync since #785 Phase 3"),
     ("single-FIFO-per-worker drain",
      "shared_exact uses MQFQ, not FIFO, since #785 Phase 3"),
+    ("1024-bucket bookkeeping",
+     "value is 4096 since #785 Phase 3"),
+    ("all 1024 SFQ buckets",
+     "value is 4096 since #785 Phase 3"),
+    ("bounded by 1024 worst case",
+     "value is 4096 since #785 Phase 3"),
+    ("1024 active buckets",
+     "value is 4096 since #785 Phase 3"),
 ];
 
+// Numeric-suffix patterns: blocked iff followed by a non-`[0-9_]` char.
+// Avoids false-positive on legitimate larger numerals like `1024_000`.
+const NUMERIC_STALE_PATTERNS: &[(&str, &str)] = &[
+    ("= 1024", "value is 4096 since #785 Phase 3"),
+];
+
+// `tx.rs:` followed by an ASCII digit — old line-number breadcrumbs
+// are stale across the tx.rs decomposition (#956+). Module/function
+// anchors like `tx.rs::transmit_batch` are fine.
+const TX_LINE_REF_PATTERN: &str = "tx.rs:";
+
 const SCAN_DIRS: &[&str] = &[
-    "src/afxdp/cos",
-    "src/afxdp/types",
+    "src/afxdp",   // recursive — covers cos/, types/, worker/cos.rs, tx/cos_classify.rs, coordinator/cos_state.rs, etc.
     "src/session",
 ];
 
@@ -90,10 +140,11 @@ struct Violation {
 }
 
 fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
+    // v2: panic loudly if a configured scan root is missing.
+    // Silent return on read_dir error converted refactor-induced
+    // path moves into false passes (Codex finding).
+    let entries = fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("scan_dir({}): {} — fix SCAN_DIRS or your tree is broken", dir.display(), e));
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
@@ -113,11 +164,28 @@ fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
             }
             for (pattern, rationale) in STALE_PATTERNS {
                 if line.contains(pattern) {
+                    violations.push(Violation { path: path.clone(), line: lineno + 1, pattern, rationale });
+                }
+            }
+            // Numeric-stale patterns: pattern hit, AND next char (if any)
+            // is NOT in [0-9_]. Avoids false-positive on `1024_000`.
+            for (pattern, rationale) in NUMERIC_STALE_PATTERNS {
+                if let Some(idx) = line.find(pattern) {
+                    let next = line.as_bytes().get(idx + pattern.len()).copied();
+                    let safe_next = next.map(|c| c.is_ascii_digit() || c == b'_').unwrap_or(false);
+                    if !safe_next {
+                        violations.push(Violation { path: path.clone(), line: lineno + 1, pattern, rationale });
+                    }
+                }
+            }
+            // tx.rs:N (digit-suffix) — line-number breadcrumb pattern.
+            if let Some(idx) = line.find(TX_LINE_REF_PATTERN) {
+                let next = line.as_bytes().get(idx + TX_LINE_REF_PATTERN.len()).copied();
+                if next.map(|c| c.is_ascii_digit()).unwrap_or(false) {
                     violations.push(Violation {
-                        path: path.clone(),
-                        line: lineno + 1,
-                        pattern,
-                        rationale,
+                        path: path.clone(), line: lineno + 1,
+                        pattern: TX_LINE_REF_PATTERN,
+                        rationale: "stale tx.rs:NNN line breadcrumb across the tx.rs decomposition (#956+); use module/function anchor instead",
                     });
                 }
             }

--- a/docs/pr/1205-cos-drift-check/plan.md
+++ b/docs/pr/1205-cos-drift-check/plan.md
@@ -171,7 +171,13 @@ fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
             // v3: NUMERIC_STALE_PATTERNS dropped — `= 1024` was too broad
             // with the wider SCAN_DIRS. Prose patterns above are sufficient.
             // tx.rs:N (digit-suffix) — line-number breadcrumb pattern.
-            if let Some(idx) = line.find(TX_LINE_REF_PATTERN) {
+            // Round-2 PR review (Codex+Gemini): use match_indices to
+            // catch ALL occurrences on a line, not just the first.
+            // A line like `// tx.rs::transmit_batch and tx.rs:262`
+            // would have line.find() see only the first `tx.rs::`
+            // (next char `:`, not digit), accept it, and silently
+            // miss the digit-suffix breadcrumb later.
+            for (idx, _) in line.match_indices(TX_LINE_REF_PATTERN) {
                 let next = line.as_bytes().get(idx + TX_LINE_REF_PATTERN.len()).copied();
                 if next.map(|c| c.is_ascii_digit()).unwrap_or(false) {
                     violations.push(Violation {
@@ -181,6 +187,10 @@ fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
                     });
                 }
             }
+            // Self-tests: detects_tx_rs_line_ref_after_module_anchor_on_same_line
+            // pins the find-vs-match_indices fix.
+            // previous_line_allow_marker_does_not_suppress pins same-line
+            // allow-marker scoping.
         }
     }
 }

--- a/userspace-dp/tests/cos_doc_drift.rs
+++ b/userspace-dp/tests/cos_doc_drift.rs
@@ -87,7 +87,7 @@ fn cos_doc_drift_guard() {
     }
 
     if !violations.is_empty() {
-        violations.sort_by(|a, b| a.path.cmp(&b.path).then(a.line.cmp(&b.line)));
+        violations.sort_unstable_by(|a, b| a.path.cmp(&b.path).then(a.line.cmp(&b.line)));
         let report: Vec<String> = violations
             .iter()
             .map(|v| {

--- a/userspace-dp/tests/cos_doc_drift.rs
+++ b/userspace-dp/tests/cos_doc_drift.rs
@@ -87,6 +87,7 @@ fn cos_doc_drift_guard() {
     }
 
     if !violations.is_empty() {
+        violations.sort_by(|a, b| a.path.cmp(&b.path).then(a.line.cmp(&b.line)));
         let report: Vec<String> = violations
             .iter()
             .map(|v| {
@@ -118,7 +119,7 @@ fn cos_doc_drift_guard() {
 struct Violation {
     path: PathBuf,
     line: usize,
-    pattern: String,
+    pattern: &'static str,
     rationale: &'static str,
 }
 
@@ -154,10 +155,13 @@ fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
         {
             continue;
         }
-        let content = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
+        let content = fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "scan_dir: cannot read {} — {} — fix file permissions or SCAN_DIRS",
+                path.display(),
+                e
+            )
+        });
         scan_content(&path, &content, violations);
     }
 }
@@ -172,7 +176,7 @@ fn scan_content(path: &Path, content: &str, violations: &mut Vec<Violation>) {
                 violations.push(Violation {
                     path: path.to_path_buf(),
                     line: lineno + 1,
-                    pattern: (*pattern).to_string(),
+                    pattern,
                     rationale,
                 });
             }
@@ -191,7 +195,7 @@ fn scan_content(path: &Path, content: &str, violations: &mut Vec<Violation>) {
                 violations.push(Violation {
                     path: path.to_path_buf(),
                     line: lineno + 1,
-                    pattern: TX_LINE_REF_PATTERN.to_string(),
+                    pattern: TX_LINE_REF_PATTERN,
                     rationale: TX_LINE_REF_RATIONALE,
                 });
             }

--- a/userspace-dp/tests/cos_doc_drift.rs
+++ b/userspace-dp/tests/cos_doc_drift.rs
@@ -180,7 +180,12 @@ fn scan_content(path: &Path, content: &str, violations: &mut Vec<Violation>) {
         // tx.rs:N — digit-suffix breadcrumb. Module/function anchors
         // like `tx.rs::transmit_batch` are acceptable (only digits
         // trigger the violation).
-        if let Some(idx) = line.find(TX_LINE_REF_PATTERN) {
+        //
+        // Iterate ALL occurrences (Codex+Gemini r2 PR review): a line
+        // like `// tx.rs::transmit_batch and tx.rs:262` would only
+        // have `find()` see the first `tx.rs::` (next char `:`), miss
+        // the digit-suffix later. `match_indices` catches every match.
+        for (idx, _) in line.match_indices(TX_LINE_REF_PATTERN) {
             let next = line.as_bytes().get(idx + TX_LINE_REF_PATTERN.len()).copied();
             if next.map(|c| c.is_ascii_digit()).unwrap_or(false) {
                 violations.push(Violation {
@@ -231,6 +236,33 @@ mod self_tests {
             &mut v,
         );
         assert_eq!(v.len(), 1, "only the digit-suffix one should fire");
+    }
+
+    #[test]
+    fn detects_tx_rs_line_ref_after_module_anchor_on_same_line() {
+        // Codex+Gemini r2 PR review: line.find() saw only the first
+        // `tx.rs::` and missed the digit-suffix later. match_indices
+        // fixes this.
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "// see tx.rs::transmit_batch and tx.rs:262 for context\n",
+            &mut v,
+        );
+        assert_eq!(v.len(), 1, "must catch tx.rs:NNN even if a tx.rs::module anchor precedes it");
+    }
+
+    #[test]
+    fn previous_line_allow_marker_does_not_suppress() {
+        // Allow marker is same-line only. A marker on the line BEFORE
+        // a stale phrase must NOT silence it.
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "// drift-check: historical\n// COS_FLOW_FAIR_BUCKETS = 1024\n",
+            &mut v,
+        );
+        assert_eq!(v.len(), 1, "previous-line allow marker must NOT suppress next-line stale phrase");
     }
 
     #[test]

--- a/userspace-dp/tests/cos_doc_drift.rs
+++ b/userspace-dp/tests/cos_doc_drift.rs
@@ -1,0 +1,258 @@
+//! CoS doc/code drift guard (#1205).
+//!
+//! Fails if known-stale scheduler policy references reappear in
+//! active CoS source. Each entry in `STALE_PATTERNS` carries a
+//! one-line rationale describing why that exact substring is wrong
+//! against the current code state.
+//!
+//! Add a new entry only when a fairness/MQFQ change makes a prior
+//! assertion stale; never silence by suppressing the check.
+//!
+//! Whitelist: lines marked `// drift-check: historical` are tolerated
+//! verbatim (e.g., intentional retrospective text comparing pre- and
+//! post-refactor state).
+//!
+//! Companion of #1210 (which scrubbed the existing drift). This test
+//! must pass on master once #1210 has merged; until then the test
+//! will report violations that #1210 will remove.
+//!
+//! Reviewed PLAN-READY (Codex round-2 task-mou73ban-paip6b
+//! PLAN-NEEDS-MINOR addressed in v3; Gemini round-2
+//! task-mou73zm2-ikjmii PLAN-READY in v2).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Substring patterns that must NOT appear on a non-historical line
+/// in any file under `SCAN_DIRS`. Each entry is `(pattern, rationale)`.
+///
+/// Why these specific phrases:
+/// - `COS_FLOW_FAIR_BUCKETS = 1024`: the constant has been 4096 since
+///   #785 Phase 3.
+/// - `flow_fair = queue.exact && !shared_exact`: the policy gate was
+///   lifted in #785 Phase 3; current code is `flow_fair = queue.exact`
+///   for both owner-local AND shared_exact.
+/// - `shared_exact queues are NOT on the flow-fair path`: stale claim
+///   that contradicts current promotion in `admission.rs:478-486`.
+/// - `single-FIFO-per-worker drain`: stale; shared_exact runs MQFQ
+///   with cross-worker V_min sync (#917).
+/// - `1024-bucket bookkeeping` / `all 1024 SFQ buckets` /
+///   `bounded by 1024 worst case` / `1024 active buckets`: prose
+///   variants of the bucket-count drift.
+const STALE_PATTERNS: &[(&str, &str)] = &[
+    ("COS_FLOW_FAIR_BUCKETS = 1024", "value is 4096 since #785 Phase 3"),
+    (
+        "flow_fair = queue.exact && !shared_exact",
+        "policy is `flow_fair = queue.exact` since #785 Phase 3",
+    ),
+    (
+        "shared_exact queues are NOT on the flow-fair path",
+        "shared_exact runs flow_fair with cross-worker V_min sync (#917) since #785 Phase 3",
+    ),
+    (
+        "single-FIFO-per-worker drain",
+        "shared_exact uses MQFQ, not FIFO, since #785 Phase 3",
+    ),
+    ("1024-bucket bookkeeping", "value is 4096 since #785 Phase 3"),
+    ("all 1024 SFQ buckets", "value is 4096 since #785 Phase 3"),
+    ("bounded by 1024 worst case", "value is 4096 since #785 Phase 3"),
+    ("1024 active buckets", "value is 4096 since #785 Phase 3"),
+];
+
+/// `tx.rs:` followed by an ASCII digit — old line-number breadcrumbs
+/// stale across the tx.rs decomposition (#956+). Module/function
+/// anchors like `tx.rs::transmit_batch` are accepted (only digits
+/// trigger the violation).
+const TX_LINE_REF_PATTERN: &str = "tx.rs:";
+const TX_LINE_REF_RATIONALE: &str =
+    "stale tx.rs:NNN line breadcrumb across the tx.rs decomposition (#956+); use module/function anchor instead";
+
+const SCAN_DIRS: &[&str] = &[
+    // Recursive scan covers cos/, types/, worker/cos.rs,
+    // tx/cos_classify.rs, coordinator/cos_state.rs, etc.
+    "src/afxdp",
+    "src/session",
+];
+
+const ALLOW_MARKER: &str = "drift-check: historical";
+
+#[test]
+fn cos_doc_drift_guard() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let mut violations: Vec<Violation> = Vec::new();
+
+    for dir in SCAN_DIRS {
+        let p = Path::new(manifest_dir).join(dir);
+        scan_dir(&p, &mut violations);
+    }
+
+    if !violations.is_empty() {
+        let report: Vec<String> = violations
+            .iter()
+            .map(|v| {
+                format!(
+                    "  {}:{}: {:?} ({})",
+                    v.path.display(),
+                    v.line,
+                    v.pattern,
+                    v.rationale
+                )
+            })
+            .collect();
+        panic!(
+            "CoS doc/code drift detected (#1205): {} violation(s)\n{}\n\n\
+             If a violation flags an intentional historical retrospective \
+             (e.g., explicit before/after comparison text), add the \
+             allow-marker `// {}` on the same line.\n\n\
+             If a stale phrase has reappeared in real code/comments, \
+             rewrite the phrase to reflect current code state. Do NOT \
+             silence by suppressing the test. See \
+             docs/pr/1205-cos-drift-check/plan.md for context.",
+            violations.len(),
+            report.join("\n"),
+            ALLOW_MARKER,
+        );
+    }
+}
+
+struct Violation {
+    path: PathBuf,
+    line: usize,
+    pattern: String,
+    rationale: &'static str,
+}
+
+fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) {
+    // Per Codex round-1 finding #7: panic loudly if a configured scan
+    // root is missing. Silent return on read_dir error converted
+    // refactor-induced path moves into false passes.
+    let entries = fs::read_dir(dir).unwrap_or_else(|e| {
+        panic!(
+            "scan_dir({}): {} — fix SCAN_DIRS in tests/cos_doc_drift.rs \
+             or your tree is broken",
+            dir.display(),
+            e
+        )
+    });
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_dir(&path, violations);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        // Skip the drift-check test file itself: it must contain the
+        // stale strings as part of its blocklist, but those occurrences
+        // are not real drift.
+        if path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|n| n == "cos_doc_drift.rs")
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        scan_content(&path, &content, violations);
+    }
+}
+
+fn scan_content(path: &Path, content: &str, violations: &mut Vec<Violation>) {
+    for (lineno, line) in content.lines().enumerate() {
+        if line.contains(ALLOW_MARKER) {
+            continue;
+        }
+        for (pattern, rationale) in STALE_PATTERNS {
+            if line.contains(pattern) {
+                violations.push(Violation {
+                    path: path.to_path_buf(),
+                    line: lineno + 1,
+                    pattern: (*pattern).to_string(),
+                    rationale,
+                });
+            }
+        }
+        // tx.rs:N — digit-suffix breadcrumb. Module/function anchors
+        // like `tx.rs::transmit_batch` are acceptable (only digits
+        // trigger the violation).
+        if let Some(idx) = line.find(TX_LINE_REF_PATTERN) {
+            let next = line.as_bytes().get(idx + TX_LINE_REF_PATTERN.len()).copied();
+            if next.map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                violations.push(Violation {
+                    path: path.to_path_buf(),
+                    line: lineno + 1,
+                    pattern: TX_LINE_REF_PATTERN.to_string(),
+                    rationale: TX_LINE_REF_RATIONALE,
+                });
+            }
+        }
+    }
+}
+
+// --- self-tests on the in-memory scan logic -------------------------------
+
+#[cfg(test)]
+mod self_tests {
+    use super::*;
+
+    #[test]
+    fn detects_stale_bucket_count() {
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "// COS_FLOW_FAIR_BUCKETS = 1024 today\n",
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+    }
+
+    #[test]
+    fn allow_marker_suppresses() {
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "// COS_FLOW_FAIR_BUCKETS = 1024 was the old value // drift-check: historical\n",
+            &mut v,
+        );
+        assert!(v.is_empty(), "marker should suppress violation");
+    }
+
+    #[test]
+    fn detects_tx_rs_line_ref() {
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "    // ref tx.rs:262 here\n    // tx.rs::transmit_batch is fine\n",
+            &mut v,
+        );
+        assert_eq!(v.len(), 1, "only the digit-suffix one should fire");
+    }
+
+    #[test]
+    fn detects_stale_policy_phrase() {
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "/// flow_fair = queue.exact && !shared_exact, per #785\n",
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+    }
+
+    #[test]
+    fn no_false_positive_on_unrelated_text() {
+        let mut v = Vec::new();
+        scan_content(
+            Path::new("test.rs"),
+            "/// 4096 buckets gives ~1.6% birthday collision at N=12\n\
+             /// flow_fair = queue.exact for shared_exact since #785\n",
+            &mut v,
+        );
+        assert!(v.is_empty(), "unexpected violation: {:?}", v.iter().map(|x| &x.pattern).collect::<Vec<_>>());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `userspace-dp/tests/cos_doc_drift.rs` — a Rust integration test that fails when known-stale CoS scheduler policy references reappear in active source. Companion of #1210 (PR #1212) which scrubs the existing drift.

This session burned three plan-review cycles drafting plans against stale comments (PR #1203 Phase 1, #1203 Phase 2, #936 v1). Codex CoS findings retrospective recommended a 50-line drift check to prevent the next cycle. This is that check.

## Order

**Depends on PR #1212 (#1210) merging first.** Until then this test fails on master with the exact violations #1210 is designed to remove. That's the acceptance test for #1210.

After #1212 merges and this rebases on master, the test passes cleanly. Going forward it fails CI on any PR that introduces a new stale reference.

## Blocklist (8 prose patterns + 1 numeric pattern)

```rust
const STALE_PATTERNS: &[(&str, &str)] = &[
    ("COS_FLOW_FAIR_BUCKETS = 1024", "value is 4096 since #785 Phase 3"),
    ("flow_fair = queue.exact && !shared_exact", "policy is `flow_fair = queue.exact` since #785 Phase 3"),
    ("shared_exact queues are NOT on the flow-fair path", "shared_exact runs flow_fair with cross-worker V_min sync (#917) since #785 Phase 3"),
    ("single-FIFO-per-worker drain", "shared_exact uses MQFQ, not FIFO, since #785 Phase 3"),
    ("1024-bucket bookkeeping", "value is 4096 since #785 Phase 3"),
    ("all 1024 SFQ buckets", "value is 4096 since #785 Phase 3"),
    ("bounded by 1024 worst case", "value is 4096 since #785 Phase 3"),
    ("1024 active buckets", "value is 4096 since #785 Phase 3"),
];

// `tx.rs:` followed by an ASCII digit fires; module/function anchors
// like `tx.rs::transmit_batch` are accepted.
const TX_LINE_REF_PATTERN: &str = "tx.rs:";
```

## Allow marker

`// drift-check: historical` on the same line whitelists intentional retrospective text (e.g., explicit before/after comparisons). Same-line semantics avoid stateful block-parsing bugs (forgetting an end-marker).

## Self-tests

5 inline self-tests verify `scan_content()`:
- Detects stale bucket count
- Allow marker suppresses violations
- `tx.rs:NNN` digit-suffix fires; `tx.rs::module_anchor` does not
- Detects stale policy phrase
- No false-positive on legitimate related text (e.g., "4096 buckets gives ~1.6% birthday collision")

## Plan + adversarial review

Plan: `docs/pr/1205-cos-drift-check/plan.md` (v3, commit `b209152e`)

- Round-1: Codex `task-mou6j4qs-48a6t6` PLAN-NEEDS-MINOR; Gemini `task-mou6jz6b-xdep7x` PLAN-NEEDS-MINOR
- Round-2: Codex `task-mou73ban-paip6b` PLAN-NEEDS-MINOR (`NUMERIC_STALE_PATTERNS = ["= 1024"]` was too broad — flagged legitimate live constants in `mod.rs:201`, `neighbor.rs:490`, `flow_cache.rs`; v3 dropped it entirely; the 8 prose patterns cover the actual cases unambiguously); Gemini `task-mou73zm2-ikjmii` PLAN-READY

## Test plan

- [x] cargo build --release: clean
- [x] cargo test --release --test cos_doc_drift on this branch: 5/5 self-tests pass; main test FAILS with the 7 expected violations from current master (they get scrubbed by #1212)
- [x] After PR #1212 merges and this rebases, main test must pass

## Out of scope

- Doc files (`docs/`). Doc drift is caught by the periodic refresh in #1208's audit.
- Go-side analogue. If `pkg/dataplane/userspace/` ever develops scheduler-relevant comments, file a sibling test.

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)