### PR TITLE
docs: per-module README.md across the codebase

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -316,3 +316,9 @@
   - **Action**: pyshell M2 — `reduce_events` docstring moved to first statement per PEP 257
     - **File(s)**: `test/incus/step2-sched-switch-reduce.py`
   - **Result**: `python3 -m py_compile` OK on all 4 modified `.py` files; reducer tests 13/13 green (was 10, +3 new); classifier tests 11/11 green (was 8, +3 new); V8 non-regression preserved (`step1-histogram-classify.py` unchanged)
+
+## 2026-05-10 — docs README reference fix
+
+- **Timestamp**: 2026-05-10T03:24:56Z
+  - **Action**: Correct stale filename references in module READMEs (`eventengine.go`/`dhcprelay.go` -> `engine.go`/`relay.go`) so entry-point file:line links resolve.
+  - **File(s)**: `pkg/eventengine/README.md`, `pkg/dhcprelay/README.md`

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -1,0 +1,51 @@
+# bpf/
+
+eBPF programs that drive the in-kernel packet pipeline. 14 programs
+total: 9 XDP ingress, 5 TC egress. They compose via tail-calls; metadata
+crosses stages through a per-CPU array scratch map.
+
+```
+XDP ingress: main → screen → zone → conntrack → policy → nat → nat64 → forward
+TC egress:   main → screen_egress → conntrack → nat → forward
+```
+
+## Layout
+
+- `headers/` — shared C headers used by every program.
+- `xdp/` — XDP ingress programs.
+- `tc/` — TC egress programs.
+
+## Compilation
+
+`make generate` invokes `bpf2go` (cilium/ebpf) which compiles the C and
+emits Go bindings. Don't write Go that pokes at BPF map keys/values
+without going through those bindings — they encode the C struct layout.
+
+## Verifier traps (CLAUDE.md authoritative)
+
+- Branch merges lose packet range; re-read `ctx->data` /
+  `ctx->data_end` after every branch.
+- 512-byte combined stack across call frames. Push large locals to a
+  scratch map and mark big helpers `__noinline`.
+- Variable-offset packet pointers lose range when `var_off` is wide
+  (0xffff). Use a constant offset from a validated pointer.
+- Mask `meta->l3_offset` (u16) with `& 0x3F` before pointer arithmetic
+  (commit `66833c5`) so the verifier can track the range.
+- `__u16` causes sign-extension (`smin=-32768`) — fails for packet-pointer
+  math. Use `__u32` then narrow.
+- Pointer bitwise OR is rejected. `if (sv4 || sv6)` where both are
+  pointers triggers a compiler `|=` on pointer registers — split into
+  separate null checks.
+
+## Kernel-version notes
+
+- xdp_zone fails the verifier on kernel 6.12 (NAT64 complexity). Passes
+  on 6.18+. Production is 6.18.9.
+- Generic XDP on virtio-net preserves `skb->ip_summed=CHECKSUM_PARTIAL`
+  through `bpf_redirect_map`. From-scratch checksums get corrupted —
+  use the `meta->csum_partial` path that writes only the pseudo-header
+  seed.
+
+## Subdirs
+
+See `headers/README.md`, `xdp/README.md`, `tc/README.md`.

--- a/bpf/headers/README.md
+++ b/bpf/headers/README.md
@@ -1,0 +1,27 @@
+# bpf/headers/
+
+Shared C headers for every BPF program in the pipeline.
+
+## Files
+
+- `xpf_common.h` — packet metadata layout (`struct pkt_meta`), AF_XDP
+  frame header, the per-CPU scratch map shape that crosses tail-call
+  stages.
+- `xpf_maps.h` — BPF map definitions: conntrack, NAT pools, session
+  indices, screen counters, application table, redirect-capable flags,
+  HA watchdog.
+- `xpf_helpers.h` — packet parsing, checksum incremental update, GRE
+  encap helpers.
+- `xpf_conntrack.h` — flow-key hashing (5-tuple, NAT-aware).
+- `xpf_nat.h` — NAT helpers (SNAT/DNAT/static, NAT64, NPTv6).
+- `xpf_trace.h` — debug logging (`bpf_printk` wrappers, gated on
+  compile-time flag).
+
+## Conventions
+
+- Go code in `pkg/dataplane` mirrors these structs. When you change a
+  layout here, run `make generate` and update the matching Go struct's
+  trailing `Pad [N]byte` so `unsafe.Sizeof` matches the C `sizeof`.
+- IP addresses are `__be32` on the wire but read with
+  `binary.NativeEndian` in Go because cilium/ebpf serializes map values
+  in native endian.

--- a/bpf/tc/README.md
+++ b/bpf/tc/README.md
@@ -1,0 +1,33 @@
+# bpf/tc/
+
+5 TC egress programs, tail-call chained.
+
+```
+tc_main → tc_screen_egress → tc_conntrack → tc_nat → tc_forward
+```
+
+## Stage responsibilities
+
+- `tc_main` — egress entry; per-RG and per-zone classification.
+- `tc_screen_egress` — egress-direction checks (rate limits on outbound
+  to remote zones, etc.).
+- `tc_conntrack` — egress session table lookup (separate from XDP
+  ingress conntrack — egress sees post-routing tuple).
+- `tc_nat` — egress NAT (SNAT pool allocation, address-persistent
+  mapping).
+- `tc_forward` — final L2/L3 emission; TC redirect to the egress
+  netdev.
+
+## Why TC, not XDP, on egress
+
+XDP has no egress equivalent that's universally supported across drivers
+the lab uses. TC clsact is supported everywhere and integrates with the
+kernel's `netfilter` chains (which we don't use, but interoperate
+with). NetEm test setups also hook here.
+
+## Notes
+
+- The conntrack table is shared with the XDP ingress side; both
+  directions update the same flow entry.
+- TCP MSS clamping ingress is in XDP (`xdp_screen`); the egress side is
+  here in `tc_main` for GRE-specific gre-in / gre-out cases.

--- a/bpf/xdp/README.md
+++ b/bpf/xdp/README.md
@@ -1,0 +1,43 @@
+# bpf/xdp/
+
+9 XDP ingress programs, tail-call chained.
+
+```
+xdp_main → xdp_screen → xdp_zone → xdp_conntrack → xdp_policy
+                                                       ↓
+                                              xdp_nat → xdp_nat64 → xdp_forward
+```
+
+`xdp_main` is the lightweight CPU-distribution stage; `xdp_cpumap` runs
+on the target CPU after the cpumap redirect.
+
+## Stage responsibilities
+
+- `xdp_main` — cpumap redirect for parallelism.
+- `xdp_cpumap` — entry point on the destination CPU.
+- `xdp_screen` — DDoS / sanity checks (land, syn-flood, ping-of-death,
+  teardrop, rate limits, SYN-cookie generation).
+- `xdp_zone` — zone classification, per-RG / fabric redirect for HA
+  fallback (`try_fabric_redirect`), NAT64 translate, conntrack
+  fast-path entry.
+- `xdp_conntrack` — session lookup, sets `meta->next_prog`. When no NAT
+  flag is set, jumps directly to `xdp_forward`.
+- `xdp_policy` — first-match-wins zone-pair policy lookup. Builds REJECT
+  responses (TCP RST, ICMP unreachable) with `__noinline` helpers using
+  the session_v4_scratch map as a byte buffer (stack budget would
+  otherwise exceed 512B).
+- `xdp_nat` — SNAT / DNAT / static. Owns the TTL check for non-NAT
+  flows that bypass `xdp_forward` via the conntrack fast path.
+- `xdp_nat64` — RFC 6052 IPv6↔IPv4 translation. Generic-XDP
+  CHECKSUM_PARTIAL trap: write only the pseudo-header seed when
+  `meta->csum_partial` is set.
+- `xdp_forward` — FIB lookup, MAC rewrite, TX. TTL check duplicated here
+  for sessions that skipped `xdp_nat`. `redirect_capable` flag falls
+  back to `XDP_PASS` for non-native interfaces (iavf VFs).
+
+## Notes
+
+- All TTL handling lives in `xdp_nat` AND `xdp_forward`; either path
+  alone misses the other's session class. Don't consolidate.
+- The 4 REJECT helpers (RST v4/v6, ICMP unreach v4/v6) are
+  `__noinline` — inlining blew the 512B combined-stack limit.

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -1,0 +1,33 @@
+# cmd/cli
+
+Standalone Junos-style CLI client. Connects to xpfd's gRPC API and runs
+the same readline / tab-completion / `?`-help experience as the
+daemon-local CLI.
+
+## Entry
+
+`main.go` parses flags, dials the gRPC API, and hands control to the
+shared `pkg/cli` engine.
+
+## Flags
+
+- `-addr` — gRPC server address. Default `127.0.0.1:50051`.
+- `-c "<command>"` — single-command, non-interactive mode. Exits with
+  the command's status. Useful for scripted operations.
+
+## Tab completion
+
+Driven by the gRPC `Complete` RPC, which lowers the same `pkg/cmdtree`
+tree the daemon uses. Adding a command in `pkg/cmdtree/tree.go` shows up
+here and in the daemon-local CLI without changes here.
+
+## Operational notes
+
+- Output streams over gRPC. There's no separate SSH / Telnet layer —
+  authentication is by gRPC peer credentials.
+- `| match <pattern>` filtering is client-side; the server sends full
+  output. (Junos pipes are simulated this way.)
+- Per memory `feedback_cli_binary_path.md`: some VMs have a stale
+  `/usr/local/sbin/cli` that shadows the current `/usr/local/bin/cli`
+  via PATH. Delete the sbin copy after a deploy if you see weird
+  behavior.

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -27,7 +27,6 @@ here and in the daemon-local CLI without changes here.
   authentication is by gRPC peer credentials.
 - `| match <pattern>` filtering is client-side; the server sends full
   output. (Junos pipes are simulated this way.)
-- Per memory `feedback_cli_binary_path.md`: some VMs have a stale
-  `/usr/local/sbin/cli` that shadows the current `/usr/local/bin/cli`
-  via PATH. Delete the sbin copy after a deploy if you see weird
-  behavior.
+- Some lab VMs have a stale `/usr/local/sbin/cli` that shadows the
+  current `/usr/local/bin/cli` via `PATH`. If a deploy looks correct
+  but the CLI behavior is stale, delete the `sbin` copy.

--- a/cmd/xpfd/README.md
+++ b/cmd/xpfd/README.md
@@ -1,0 +1,44 @@
+# cmd/xpfd
+
+The xpfd daemon — the firewall control plane. Loads eBPF (or spawns the
+Rust AF_XDP helper), applies compiled config to every subsystem,
+handles signals, and exposes gRPC + HTTP REST + an interactive CLI.
+
+## Entry
+
+`main.go` parses flags and constructs `pkg/daemon.Daemon` via
+`daemon.New(opts)`. The daemon instance assembles every subsystem
+manager from `pkg/*` and runs them under an errgroup.
+
+## Flags
+
+- `-config` — config file path. Default `/etc/xpf/xpf.conf`.
+- `-no-dataplane` — config-only mode (parse + validate without loading
+  BPF). Useful for offline checks.
+- `-api-addr` — HTTP REST listener. Default `127.0.0.1:8080`.
+- `-grpc-addr` — gRPC listener. Default `127.0.0.1:50051`.
+- `-debug` — verbose logging.
+
+## Subcommands
+
+- `xpfd version` — prints version and commit.
+- `xpfd cleanup` — removes pinned BPF state and FRR-managed routes.
+  Runs on uninstall.
+
+## TTY detection
+
+`unix.IoctlGetTermios(fd, TCGETS)` — when stdin is a real TTY, the
+daemon spawns the local CLI (`pkg/cli`) on the same terminal. Service
+units run without a TTY and skip that path.
+
+## Cluster mode
+
+`/etc/xpf/node-id` selects node (`0` or `1`); absence is standalone.
+Cluster nodes pick up the bondless-RETH naming convention
+(`fxp0`, `em0`, `ge-{0,7}-0-X`) and run the chassis-cluster state
+machine.
+
+## Read order
+
+Start at `pkg/daemon/daemon.go:296` (`New`) for the assembly. From
+there, every imported `pkg/*` has its own README.

--- a/dpdk_worker/README.md
+++ b/dpdk_worker/README.md
@@ -1,0 +1,66 @@
+# dpdk_worker/
+
+Optional DPDK userspace dataplane backend. Single-pass packet processor
+implemented in C with DPDK, sharing memory with the Go daemon for the
+control plane (port stats, FIB sync, session counters). Selected via
+`set system dataplane-type dpdk`.
+
+This is a separate execution mode from the eBPF default and the AF_XDP
+userspace-dp backend. It's checked in but not built by default.
+
+## Entry
+
+`main.c` — DPDK EAL init, port configuration, signal handling. Per-lcore
+RX dispatch via a function table:
+
+- `rx_loop_poll` — continuous polling.
+- `rx_loop_interrupt` — NAPI interrupt-driven.
+- `rx_loop_adaptive` — switches between the two based on offered load.
+
+## Modules
+
+| File | Purpose |
+|------|---------|
+| `parse.c` | L3+L4 parsing into `pkt_meta`. |
+| `zone.c` | Zone classification. |
+| `screen.c` | Screen / IDS checks. |
+| `conntrack.c` | Session lookup + state update. |
+| `policy.c` | First-match-wins policy evaluation. |
+| `nat.c` | NAT44 (SNAT/DNAT/static). |
+| `nat64.c` | RFC 6052 IPv6↔IPv4 translation. |
+| `filter.c` / `policer.c` | Firewall filter + token-bucket policer. |
+| `forward.c` | Output selection, MAC rewrite, TX. |
+| `reject.c` | TCP RST / ICMP unreachable rejects. |
+| `gc.c` | Session sweep (`gc_sweep`). |
+| `power.c` | Power-efficiency tuning per lcore. |
+| `events.h`, `counters.h`, `tables.h` | Event counters, per-lcore stats, hash table / LPM / session slab definitions. |
+
+## Shared memory
+
+`struct shared_memory` (defined in `tables.h`) lives in a DPDK memzone.
+The Go side (`pkg/dataplane/dpdk`) opens the same memzone and reads /
+writes the same structs:
+
+- Conntrack hash table.
+- NAT pool state.
+- LPM4 / LPM6 routing tables.
+- Session slab (entries indexed by 32-bit handles).
+
+CGo bridge in `pkg/dataplane/dpdk` handles the memory layout
+synchronization.
+
+## Build
+
+Requires DPDK headers + libraries on the build host. Not part of
+`make build`. The Go side stubs out the backend behind a build tag when
+DPDK isn't available.
+
+## Gotchas
+
+- All allocations go through `rte_malloc` (NUMA-aware). Don't use libc
+  `malloc` from inside the worker loop.
+- mbuf allocation comes from a per-lcore mempool; the pool size has to
+  exceed the in-flight burst size by a comfortable margin or RX
+  silently drops.
+- Signal-driven shutdown sets `g_force_quit`; loops poll it on every
+  tick.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1,0 +1,45 @@
+# pkg/api
+
+HTTP REST API on `127.0.0.1:8080`. Read-only access to system state plus
+operational commands (clear, ping, traceroute). Health probes for
+liveness/readiness. Prometheus metrics endpoint. SSE event streams.
+
+## Entry points
+
+- `Server` — `server.go:74`
+- `NewServer(cfg Config)` — `server.go:93`
+- `Config` — `server.go:44`. All dependencies (configstore, dataplane, frr,
+  vrrp, etc.) injected here; the package has no global state.
+
+## Surface
+
+- `/healthz`, `/readyz` — liveness, readiness. `CompileHealthFn` (#758) lets
+  the daemon downgrade `/readyz` to 503 when a recent compile failed
+  silently; without the callback `/readyz` defaults to 200.
+- `/metrics` — Prometheus exposition.
+- `/v1/...` — REST mirrors of the gRPC API: sessions, routes, NAT, DHCP,
+  IPsec, VRRP, etc.
+- `/events` — Server-Sent Events stream of dataplane events. Backed by the
+  `pkg/logging` event ring buffer; long-lived consumers must drain.
+
+## Callers
+
+`cmd/xpfd` builds the `Server` from its assembled dependencies and runs it
+under the daemon's errgroup. Nothing else imports this package.
+
+## Dependencies
+
+`config`, `configstore`, `conntrack`, `dataplane`, `dhcp`, `frr`, `ipsec`,
+`logging`, `routing`, `vrrp`.
+
+## Gotchas
+
+- The status-poll path (1 Hz) shares the userspace dataplane control socket
+  with HA sync, session installs, snapshot sync, and forwarding sync.
+  Adding a new caller at >1 Hz here will starve session installs during
+  bulk sync (per CLAUDE.md control-socket rules).
+- The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
+  bounded; if a consumer stops reading, events are dropped silently — by
+  design.
+- `CompileHealthFn` may be `nil` when the daemon is in `-no-dataplane`
+  mode. All readyz code paths null-check it.

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -1,0 +1,34 @@
+# pkg/appid
+
+Application identification runtime. Maps Junos `applications` /
+`application-set` definitions to protocol+port tuples for BPF compilation,
+and resolves session display names from the dataplane's assigned `app_id`.
+
+## Entry points
+
+- `CatalogNames(cfg, includeAll) []string` — `runtime.go:42`. Returns the
+  list of application names the BPF compiler must lower into the policy
+  `app_id` table. `includeAll=false` returns only apps referenced by
+  policies; `true` returns every defined app.
+- `ResolveSessionName(appNames, cfg, proto, dstPort, appID) string` —
+  `runtime.go:95`. Three-tier lookup: dataplane `app_id` (authoritative
+  from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
+  (`junos-http`, `junos-ssh`, …). Used for session display, NetFlow
+  records, and syslog session-close events.
+
+## Callers
+
+`pkg/cli`, `pkg/dataplane` (compilation), `pkg/grpcapi`, `pkg/daemon`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- The built-in fallback table is intentionally narrow. There is no L7 DPI
+  in this package — real identifications come from the dataplane's
+  `app_id` field on the session. See `project_653_done.md` (memory) for
+  why the operator-facing contract was made explicit.
+- `application-set` aliasing must already be expanded in `cfg` before
+  calling either function. This package does not flatten sets.

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -28,7 +28,9 @@ and resolves session display names from the dataplane's assigned `app_id`.
 
 - The built-in fallback table is intentionally narrow. There is no L7 DPI
   in this package — real identifications come from the dataplane's
-  `app_id` field on the session. See `project_653_done.md` (memory) for
-  why the operator-facing contract was made explicit.
+  `app_id` field on the session. See PR #1196 for the operator-facing
+  contract (`show services application-identification status` plus a
+  commit warning that flags policies relying on AppID matches that the
+  runtime won't actually evaluate).
 - `application-set` aliasing must already be expanded in `cfg` before
   calling either function. This package does not flatten sets.

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -1,0 +1,38 @@
+# pkg/cli
+
+Interactive Junos-style CLI: readline-driven REPL with tab completion, `?`
+help, prefix matching, `| match` filtering, and command history. Used by
+both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
+(`cmd/cli`) once it has a gRPC connection.
+
+## Entry points
+
+- `CLI` — `cli.go:47`. The REPL engine.
+- `New(...)` — `cli.go:108`. Takes ~10 injected managers (configstore,
+  dataplane, cluster, frr, dhcp, …). The package has no globals.
+- `Build()` — compiles the readline command tree from `pkg/cmdtree`. Add a
+  new command in `pkg/cmdtree/tree.go` and it shows up here, in the remote
+  CLI, and in gRPC tab completion automatically.
+
+## Callers
+
+`cmd/cli` (remote client), `cmd/xpfd` (when stdin is a TTY).
+
+## Dependencies
+
+`appid`, `cluster`, `cmdtree`, `config`, `configstore`, `dataplane`,
+`dhcp`, `dhcprelay`, `feeds`, `frr`, `ipsec`, `lldp`, `logging`, `routing`,
+`rpm`, `vrrp`.
+
+## Gotchas
+
+- TTY detection uses `unix.IoctlGetTermios(fd, TCGETS)`, **not**
+  `os.ModeCharDevice` — `/dev/null` matches `ModeCharDevice` and would
+  trick the latter into starting an interactive session in a systemd unit.
+- Commits prefer the daemon's atomicity primitive: `commitFn` and
+  `commitConfirmedFn` hold the apply semaphore across `store.Commit()` and
+  the dataplane apply. This serializes CLI commits with HTTP/gRPC
+  commits (#846). Falls back to `store.Commit()` + `applyConfigFn` only
+  when the daemon hookups are absent (test/standalone).
+- `fwdSampler` (forwarding CPU stats) can be `nil` — every show handler
+  null-checks it.

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -1,0 +1,47 @@
+# pkg/cluster
+
+Chassis-cluster HA state machine. Owns node state (Primary, Secondary,
+SecondaryHold, Lost, Disabled), redundancy-group election, readiness
+gates, manual failover, and the callbacks that fire session/config/IPsec
+sync.
+
+## Entry points
+
+- `NodeState` — `cluster.go:20`. State enum constants.
+- `RedundancyGroupState` — `cluster.go:47`. Per-RG state with
+  readiness/transferReady tracking.
+- `Manager` — `cluster.go:~100`. Election logic, weight calculation, event
+  history.
+- `ClusterEvent` — `events.go:80`. State-change notifications consumed by
+  VRRP, the dataplane, and the syslog/SNMP trap senders.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`, `pkg/vrrp`.
+
+## Dependencies
+
+`config`, `dataplane`.
+
+## Failover timing (CLAUDE.md authoritative)
+
+- ~60 ms with default 30 ms VRRP advertisements (masterDownInterval ~97 ms).
+- Planned shutdown: burst of 3× priority-0 advertisements; peer takes over
+  in ~1 ms.
+- Failback: ~130 ms (daemon startup + BPF load + sync hold release).
+- Heartbeat: 200 ms interval, threshold 5 (1 s detection).
+- Event debounce 500 ms before priority updates fire.
+
+## Gotchas
+
+- `Ready` and `TransferReady` are different gates. `Ready` allows VRRP to
+  participate in election; `TransferReady` is the stricter gate for
+  explicit operator-initiated `request chassis cluster failover`.
+- `TakeoverHoldTime` adds extra delay before election when this node would
+  immediately preempt. Used to avoid election thrash on simultaneous boot.
+- HA delete-sync callbacks fire from the GC loop. They must not block, and
+  must log at `slog.Debug` — earlier `slog.Info` flooded at 15 req/s and
+  drowned out real diagnostics (per CLAUDE.md logging rules).
+- Dual-active overlap is intentional: primary sets `rg_active=true`
+  immediately on becoming master; secondary defers `rg_active=false` until
+  it sees the VRRP BACKUP event. Brief overlap, never both inactive.

--- a/pkg/cmdtree/README.md
+++ b/pkg/cmdtree/README.md
@@ -1,0 +1,39 @@
+# pkg/cmdtree
+
+Single source of truth for every CLI command tree (operational +
+configuration). Used by the local CLI, the remote CLI, and the gRPC
+tab-completion RPC. Adding a command here automatically propagates to all
+three frontends.
+
+## Entry points
+
+- `Node` — `tree.go:23`. Tree node: description, static children,
+  `DynamicFn`/`ContextDynamicFn` for config-aware completions.
+- `Candidate` — `tree.go:49`. `(name, desc)` pair surfaced during tab
+  completion.
+- `OperationalTree` — `tree.go:56`. Canonical root for `show`, `clear`,
+  `request`, `monitor`, `ping`, `traceroute`, etc.
+- `ConfigTopLevel` — root for the `set`/`delete` configuration grammar.
+- `KeysFromTree(tree)` — `tree.go:927`. Used by `pkg/cli` and `pkg/grpcapi`
+  for Junos-style prefix matching.
+- `WriteHelp`, `LookupDesc`, `PrintTreeHelp`, `CompleteFromTree` — the
+  helper API the three frontends consume.
+
+## Callers
+
+`pkg/cli`, `pkg/grpcapi`, `cmd/cli`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- `DynamicFn` and `ContextDynamicFn` run inside the interactive readline
+  loop — they must not block on I/O, locks held by long operations, or
+  network calls. Snapshot the candidate config once; iterate.
+- `ContextDynamicFn` receives the words consumed so far, so completions
+  can depend on earlier args (e.g. zone-pair → policy-name suggestions).
+- The `tree.go` file is large by design (it's grammar). Don't refactor it
+  into many small files just to reduce LOC — the single-file form is what
+  makes it greppable for "where is this command defined?".

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1,0 +1,46 @@
+# pkg/config
+
+Junos configuration parser, AST, typed data model, and compilation
+pipeline. Three phases: text → AST (`ConfigTree`) → typed `Config` struct.
+Handles both hierarchical (`family inet { dhcp; }`) and flat set
+(`set interfaces eth0 unit 0 family inet dhcp`) syntaxes.
+
+This is the foundation almost every other package imports. It depends on
+nothing internal.
+
+## Entry points
+
+- `Lexer` — `lexer.go:63`.
+- `Parser` — `parser.go:17`. **Hierarchical** input.
+- `ParseSetCommand(line) (*Node, error)` — for **one** flat-set line.
+- `ConfigTree` — `ast.go`. Hierarchical node tree built by both shapes.
+- `Config` — `types.go`. The fully typed result every consumer wants.
+- The compiler — `compiler/` (~30 files, ~11K LOC) across six phases:
+  interfaces → zones → routing → NAT → firewall → filters.
+
+## Callers
+
+Almost everyone. The package has no internal dependencies.
+
+## Gotchas
+
+The compiler must accept both AST shapes:
+
+- Hierarchical `family inet { dhcp; }` lowers to `Node{Keys:["family","inet"]}`
+  with a child `Node{Keys:["dhcp"]}`.
+- Flat `set interfaces eth0 unit 0 family inet dhcp` lowers to
+  `Node{Keys:["family"]}` with child `Node{Keys:["inet"]}`.
+
+If you only handle one shape, set-syntax tests will look fine but real
+hierarchical commits will break (or vice versa).
+
+**Testing flat-set syntax:** ALWAYS use `ParseSetCommand()` + a
+`tree.SetPath()` loop, NEVER `NewParser()` on a multi-line set blob. The
+parser treats newlines as whitespace and merges multiple set lines into
+one giant node. This trap has bitten the project repeatedly — see
+CLAUDE.md.
+
+**C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
+exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
+values in native endian, not big-endian, so use `binary.NativeEndian`
+when packing IP addresses (already in network byte order on the wire).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1,0 +1,41 @@
+# pkg/configstore
+
+Atomic candidate / active / rollback configuration persistence. JSON files
+written via temp-file + rename for crash safety, with a JSONL audit
+journal and rolling commit history. AES-GCM at-rest encryption when a
+master password is set.
+
+## Entry points
+
+- `Store` — high-level API: `Candidate`, `Active`, `Commit`,
+  `CommitConfirmed`, `Rollback`, `History`.
+- `DB` — `db.go:15`. Low-level atomic file I/O.
+- `History` — `history.go`. Bounded ring of recent commits.
+- `Journal` — `journal.go`. Append-only JSONL audit trail.
+- `Crypto` — `crypto.go`. AES-256-GCM key derivation from
+  `/etc/xpf/config-key`.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`, `pkg/api`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- Atomic write protocol: write temp file → fsync → rename. If the daemon
+  is killed mid-fsync the previous file survives intact, and subsequent
+  reads can fall back to a rollback slot.
+- `Candidate` may be dirty (uncommitted edits accumulating). `Commit`
+  atomically promotes candidate → active and bumps the rollback ring.
+- Rollback slots are 0..49 (FIFO). Oldest is silently discarded when the
+  ring is full.
+- The encryption key path is fixed at `/etc/xpf/config-key`. If the file
+  is missing on a node that previously committed encrypted state, the
+  daemon refuses to start — there is no plaintext fallback.
+- Commit atomicity (#846): `pkg/daemon` wraps `Commit()` together with
+  `applyConfig()` under a single semaphore. Bypassing the daemon (e.g.
+  using `Store` directly) loses that serialization, so concurrent CLI +
+  HTTP commits can race.

--- a/pkg/conntrack/README.md
+++ b/pkg/conntrack/README.md
@@ -1,0 +1,42 @@
+# pkg/conntrack
+
+Connection-tracking garbage collection. Periodically scans the BPF session
+map, ages out expired flows, accumulates per-IP session counts for screen
+rate-limiting, and fires delete callbacks (used by HA delete-sync).
+
+## Entry points
+
+- `GC` — `gc.go:34`.
+- `NewGC(dp dataplane.DataPlane, interval time.Duration)` — `gc.go:86`.
+- `GCStats` — `gc.go:17`. Last-sweep metrics surfaced to `show system
+  buffers`.
+- `OnDeleteV4`, `OnDeleteV6` — per-deleted-session callbacks; HA wires
+  these to the session-sync delete path.
+- `IsLocalPrimary` — when this callback returns false, expiry is skipped
+  on this node (peer is primary; it owns the GC decision).
+- `SkipSweep` — when set, the BPF map scan is skipped entirely. The
+  userspace dataplane uses this to avoid duplicating its own per-worker
+  GC; the helper still mirrors sessions back to the BPF map for CLI
+  display.
+
+## Callers
+
+`pkg/daemon`, `pkg/api`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`dataplane` only.
+
+## Gotchas
+
+- Delete callbacks fire **inside** the GC loop. Keep them non-blocking
+  and at `slog.Debug` for high-frequency paths — earlier `slog.Info` here
+  flooded HA sync at 15 req/s.
+- `MaxSessions` = 10M entries combined (forward + reverse). The
+  user-visible session count is the total / 2.
+- The adaptive interval kicks in near the high-water mark and aggressively
+  shortens until the table drains. Don't read `GCStats.Interval` and
+  assume it's the configured value.
+- `SkipSweep=true` saves ~19% CPU on the userspace-dp path. If you reach
+  for it on the eBPF path, sessions never expire — the eBPF path has no
+  alternative GC.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1,0 +1,52 @@
+# pkg/daemon
+
+Daemon lifecycle and orchestration. Loads eBPF, applies compiled config
+to all subsystems (routing, NAT, DHCP, cluster, …), handles signals
+(SIGHUP reload, SIGTERM shutdown), and wires the commit-atomicity
+semaphore (#846) so `Store.Commit()` and `applyConfig()` always run
+together.
+
+This is the package `cmd/xpfd` instantiates. It depends on essentially
+every other internal package.
+
+## Entry points
+
+- `Daemon` — `daemon.go:59`.
+- `Options` — `daemon.go:44`. `ConfigPath`, `NoDataplane`, `APIAddr`,
+  `GRPCAddr`, `Version`.
+- `New(opts) *Daemon` — `daemon.go:296`.
+- `CompileHealth` — `daemon.go:286`. Snapshot of the most recent compile
+  outcome; `pkg/api` consumes it for `/readyz`.
+
+## Cluster mode
+
+Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).
+Absent → standalone. Cluster mode triggers the bondless-RETH naming
+convention (`fxp0`, `em0`, `ge-{0,7}-0-X`).
+
+## Interface management
+
+`enumerateAndRenameInterfaces()` runs at startup (in `linksetup.go`),
+writes `.link` files for every PCI-enumerated NIC, and assigns vSRX names
+based on PCI bus order plus the cluster node ID. RETH members match by
+`OriginalName=` (PCI kernel name), not `MACAddress=` — the MAC alternates
+between physical and virtual at boot, and `ensureRethLinkOriginalName()`
+auto-fixes stale `.link` files.
+
+Any interface not declared in the active config is brought down and given
+`ActivationPolicy=always-down` in networkd.
+
+## Notable gotchas
+
+- ISSU (in-service software upgrade) preserves sessions across the upgrade
+  by handing the BPF map FDs to the new daemon and timing the cutover
+  against HA failover.
+- CoS configuration is wiped on every cluster deploy. Re-apply with
+  `test/incus/apply-cos-config.sh` after `cluster-setup.sh deploy`. (See
+  CLAUDE.md.)
+- `commitFn` and `commitConfirmedFn` are passed to `pkg/cli` and
+  `pkg/grpcapi`; they hold the apply semaphore across the commit + apply
+  pair so concurrent committers serialize.
+- FRR reload runs with a 15 s context timeout to keep `systemctl reload
+  frr` from hanging. The systemd unit has `TimeoutStopSec=20` as a safety
+  net.

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -1,0 +1,68 @@
+# pkg/dataplane
+
+Abstract dataplane interface plus the eBPF backend. Compiles the typed
+config from `pkg/config` into BPF-map entries (zones, policies, NAT,
+filters, applications), attaches the 14 BPF programs (9 XDP + 5 TC), and
+exposes session iteration to GC, the CLI, and the metrics surface.
+
+Pluggable: alternative backends (DPDK in `pkg/dataplane/dpdk`, userspace
+AF_XDP in `pkg/dataplane/userspace`) register via `RegisterBackend`. The
+Go interface is the only thing every caller sees.
+
+## Entry points
+
+- `DataPlane` — `dataplane.go:104`. Abstract interface.
+- `Manager` — `loader.go:39`. eBPF implementation.
+- `New() *Manager` — `loader.go:66`.
+- `Compile(cfg *config.Config) (*CompileResult, error)` — six-phase
+  lowering to BPF map entries.
+- `CompileResult` — `compiler.go:23`. Zone/policy/NAT/app IDs and the
+  per-interface networkd configs.
+- Session iteration: `IterateSessions`, `IterateSessionsByZonePair`, etc.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/api`, `pkg/grpcapi`, `pkg/conntrack`.
+
+## Dependencies
+
+`appid`, `config`, `networkd`.
+
+## BPF verifier and kernel constraints
+
+These are the project's recurring traps. Read CLAUDE.md for the
+authoritative list; quick recap:
+
+- Branch merges lose packet range — re-read `ctx->data` / `ctx->data_end`
+  after any branch.
+- 512-byte combined stack across call frames — push large locals into
+  scratch maps; mark big helpers `__noinline`.
+- Variable-offset packet pointers lose range when `var_off` is wide
+  (0xffff). Use a constant offset from a validated pointer.
+- Mask `meta->l3_offset` (u16) with `& 0x3F` before packet-pointer
+  arithmetic so the verifier can track the range (commit `66833c5`).
+- `__u16` causes sign-extension (`smin=-32768`) — fails for packet-pointer
+  math.
+- Pointer bitwise OR is rejected (`if (sv4 || sv6)` where both are
+  pointers triggers a compiler `|=` on pointer registers). Use separate
+  null checks.
+- xdp_zone fails the verifier on kernel 6.12 (NAT64 complexity); passes
+  on 6.18+.
+
+## SR-IOV / driver constraints
+
+- iavf (VF) has no native XDP — generic mode only, ~16% CPU loss.
+  i40e/ice on the PF have native XDP.
+- `bpf_redirect_map` requires `ndo_xdp_xmit` on the target. Mixing native
+  + generic interfaces in a redirect set silently drops.
+- Workaround: per-interface `redirect_capable` flag in `xdp_forward.c`.
+  Non-native interfaces fall back to `XDP_PASS` (kernel forwarding).
+- The lab uses PF passthrough (i40e) on the WAN interface; all other
+  interfaces are virtio with native XDP. Per-VF passthrough would need
+  generic XDP and hit the iavf cliff.
+
+## Byte order
+
+Use `binary.NativeEndian.Uint32(ip4)` for `__be32` BPF fields, **not**
+`BigEndian`. cilium/ebpf serializes map values in native endian; the IP
+bytes are already in network order on the wire.

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -1,0 +1,36 @@
+# pkg/dhcp
+
+DHCPv4 and DHCPv6 clients. Acquires and renews leases on firewall
+interfaces and (DHCPv6) delegated prefixes. Persists DUIDs across
+restarts so the same client identifier returns to the same lease.
+
+## Entry points
+
+- `Manager` — `dhcp.go:85`.
+- `New(stateDir)` — `dhcp.go:103`.
+- `Lease` — `dhcp.go:36`. Result of one DHCP negotiation.
+- `DelegatedPrefix` — `dhcp.go:76`. From DHCPv6 PD.
+- `Start()`, `Renew()`, `StopAll()`, `DelegatedPrefixes()`.
+
+## Callers
+
+`pkg/daemon` (lifecycle).
+
+## Dependencies
+
+External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
+
+## Gotchas
+
+- Each DHCP client uses `context.Background()`, not the daemon context.
+  On graceful SIGTERM the daemon exits without calling `StopAll()`,
+  intentionally leaving the lease in place so the next daemon process
+  reuses it (no DAD storm, no DHCP renew at startup).
+- The lease-change callback is debounced 2 seconds to avoid floods during
+  config apply.
+- DUID is cached per-interface in the state directory with type hints
+  (`duid-ll`, `duid-llt`).
+- The DHCP client owns the address. `pkg/networkd` deliberately skips
+  address reconciliation on DHCP-marked interfaces.
+- DHCP-learned default routes go into FRR with admin distance 200 — lower
+  priority than static routes, so a configured static default wins.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -6,12 +6,12 @@ to the interface name.
 
 ## Entry points
 
-- `Manager` — `dhcprelay.go:49`.
-- `NewManager()` — `dhcprelay.go:55`.
-- `Apply(cfg)` — `dhcprelay.go:63`. Starts/stops per-interface relay
+- `Manager` — `relay.go:49`.
+- `NewManager()` — `relay.go:55`.
+- `Apply(cfg)` — `relay.go:63`. Starts/stops per-interface relay
   goroutines.
-- `Stats()` — `dhcprelay.go:131`. Per-interface counters.
-- `RelayStats` — `dhcprelay.go:33`.
+- `Stats()` — `relay.go:131`. Per-interface counters.
+- `RelayStats` — `relay.go:33`.
 
 ## Callers
 

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -1,0 +1,31 @@
+# pkg/dhcprelay
+
+RFC 3046 DHCPv4 relay agent. Forwards DHCP between clients on local
+interfaces and remote servers, inserting Option 82 with `circuit-id` set
+to the interface name.
+
+## Entry points
+
+- `Manager` — `dhcprelay.go:49`.
+- `NewManager()` — `dhcprelay.go:55`.
+- `Apply(cfg)` — `dhcprelay.go:63`. Starts/stops per-interface relay
+  goroutines.
+- `Stats()` — `dhcprelay.go:131`. Per-interface counters.
+- `RelayStats` — `dhcprelay.go:33`.
+
+## Callers
+
+`pkg/daemon`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- Listens per-interface on UDP 67/68. The interface must already have an
+  IPv4 address — that's what fills `giaddr`.
+- Option 82 sub-option 1 (`circuit-id`) is set to the interface name; on
+  the reply path it's stripped before forwarding to the client.
+- Server addresses are resolved once at `Apply()` time; if a server's DNS
+  changes you need a config reload.

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -1,0 +1,32 @@
+# pkg/dhcpserver
+
+Manages Kea DHCPv4/v6 server config and lifecycle. Generates
+`/etc/kea/kea-dhcp{4,6}.conf` from the typed config and reloads the
+`kea-dhcp{4,6}-server` units via systemd.
+
+## Entry points
+
+- `Manager` — `dhcpserver.go:23`.
+- `New()` — `dhcpserver.go:29`.
+- `Apply(cfg)` — `dhcpserver.go:34`. Regenerates config and restarts.
+- `Clear()` — `dhcpserver.go:76`. Stops Kea and removes config files.
+- `Lease` — `dhcpserver.go:95`. Surfaced to the CLI for `show dhcp
+  server leases`.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- Config is regenerated fully on every `Apply()` (no diff). The Kea config
+  schema is JSON-based, so this is cheap.
+- If the typed config drops the DHCP server entirely, `Apply()` stops the
+  service and removes the config file. Running Kea processes are not
+  killed via SIGKILL — systemd manages the lifecycle.
+- Lease queries shell out to Kea's lease-database control channel; if the
+  socket is missing the call returns an empty list (not an error).

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -1,0 +1,37 @@
+# pkg/eventengine
+
+Event-driven automation engine implementing Junos-style `event-options`
+policies. Matches RPM probe events against policy clauses (with optional
+temporal `within` windows) and triggers commit-and-apply actions.
+
+## Entry points
+
+- `Engine` — `eventengine.go:25`.
+- `New(store, commitFn)` — `eventengine.go:45`.
+- `Apply(cfg)` — `eventengine.go:55`. Loads policies, resets temporal
+  state.
+- `HandleEvent(evt)` — `eventengine.go:64`. Called by the RPM event
+  callback.
+- `CommitFn` — `eventengine.go:22`. The atomic commit-and-apply hook.
+
+## Callers
+
+`pkg/daemon` (event loop, RPM results).
+
+## Dependencies
+
+`pkg/config`, `pkg/configstore`, `pkg/rpm`.
+
+## Gotchas
+
+- 30 s policy cooldown (`eventengine.go:39`). The same policy will not
+  trigger more than once in any 30 s window.
+- Temporal `within` clauses keep a sliding window of timestamps per
+  (policy, event) pair. Old timestamps are pruned on every evaluation so
+  the window is bounded.
+- `CommitFn` holds the apply semaphore across both commit and apply — the
+  same primitive HTTP/gRPC commits use (#846) — so event-triggered
+  commits serialize with operator commits.
+- Policy evaluation runs under a lock; command execution (the actual
+  shell-out for `then ...` actions) releases the lock first to avoid
+  deadlocking on a self-triggered apply.

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -6,13 +6,13 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 ## Entry points
 
-- `Engine` — `eventengine.go:25`.
-- `New(store, commitFn)` — `eventengine.go:45`.
-- `Apply(cfg)` — `eventengine.go:55`. Loads policies, resets temporal
+- `Engine` — `engine.go:25`.
+- `New(store, commitFn)` — `engine.go:45`.
+- `Apply(cfg)` — `engine.go:55`. Loads policies, resets temporal
   state.
-- `HandleEvent(evt)` — `eventengine.go:64`. Called by the RPM event
+- `HandleEvent(evt)` — `engine.go:64`. Called by the RPM event
   callback.
-- `CommitFn` — `eventengine.go:22`. The atomic commit-and-apply hook.
+- `CommitFn` — `engine.go:22`. The atomic commit-and-apply hook.
 
 ## Callers
 
@@ -24,7 +24,7 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 ## Gotchas
 
-- 30 s policy cooldown (`eventengine.go:39`). The same policy will not
+- 30 s policy cooldown (`engine.go:39`). The same policy will not
   trigger more than once in any 30 s window.
 - Temporal `within` clauses keep a sliding window of timestamps per
   (policy, event) pair. Old timestamps are pruned on every evaluation so

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -1,0 +1,31 @@
+# pkg/feeds
+
+Dynamic-address feed fetcher. Periodically pulls CIDR prefixes from HTTP
+feed servers and triggers config recompile when the resolved set changes.
+
+## Entry points
+
+- `Manager` — `feeds.go:19`.
+- `New(updateFn)` — `feeds.go:36`.
+- `Apply(cfg)` — `feeds.go:62`. Starts/stops per-feed refresh goroutines.
+- `StopAll()`, `FeedInfo` — surfaced to `show security dynamic-address`.
+
+## Callers
+
+`pkg/daemon` (compile-cycle integration), `pkg/grpcapi` (status queries).
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- HTTP client timeout is 30 s. Timeouts log a warning but do not stop the
+  manager — the next refresh tick retries.
+- Multiple feeds can share a server; each feed's path is appended to the
+  base URL.
+- Default refresh interval is 1 hour; the Junos config can override via
+  `update-interval`.
+- Feed bodies are parsed line-by-line, one CIDR per line. Invalid lines
+  are skipped silently — by design, since feed providers occasionally
+  emit comments.

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -1,0 +1,37 @@
+# pkg/flowexport
+
+NetFlow v9 exporter. Exports session-close events (and optional
+per-packet samples) to remote collectors with per-zone direction filters
+and 1-in-N sampling.
+
+## Entry points
+
+- `Exporter` — `exporter.go:106`.
+- `NewExporter(cfg)` — `exporter.go:109`.
+- `Run(ctx)` — `exporter.go:111`. Main export loop.
+- `ExportConfig` — `exporter.go:23`. Resolved per-collector config.
+- `BuildExportConfig(cfg)` — `exporter.go:42`.
+- `SamplingDir` — `exporter.go:17`. Direction enum.
+- `SessionCloseData` — wire shape consumed from `pkg/conntrack` delete
+  callbacks.
+
+## Callers
+
+`pkg/daemon` calls `ExportSessionClose()` from the session-close hook.
+
+## Dependencies
+
+`pkg/config`, `pkg/logging`.
+
+## Gotchas
+
+- 1-in-N sampling uses a monotonic counter on `ExportConfig`. With small
+  N a burst of close events can sample several consecutive flows; that's
+  expected.
+- NetFlow v9 templates refresh every 60 s. If a collector restarts and
+  misses a refresh it sees opaque records until the next cycle —
+  configure the collector to handle template re-resolution.
+- Per-zone batches flush on either timeout or batch-full, whichever
+  fires first.
+- The package never blocks the GC loop — record assembly is offloaded to
+  the exporter's own goroutine.

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -1,0 +1,48 @@
+# pkg/frr
+
+FRR (FRRouting) integration. Generates a managed section inside
+`/etc/frr/frr.conf` from the typed config (static routes, OSPF, BGP,
+ISIS, RIP, BFD profiles, multi-VRF instances) and queries protocol state
+via `vtysh`.
+
+This package is the only place in the codebase that's allowed to touch
+kernel routes — and it doesn't, directly. It writes config and reloads
+FRR, which then owns the kernel route table.
+
+## Entry points
+
+- `Manager` — `frr.go:29`.
+- `New()` — `frr.go:34`. Defaults to `/etc/frr/frr.conf`.
+- `ApplyFull(cfg)` — apply full config (idempotent diff against on-disk).
+- `FullConfig` — `frr.go:60`.
+- `InstanceConfig` — `frr.go:41`. One per-VRF.
+- State queries (vtysh): `GetRIPRoutes` (frr.go:141), `GetISISAdjacency`,
+  `GetBGPNeighbors`, …
+
+## Callers
+
+`pkg/daemon` (lifecycle), `pkg/grpcapi` (show commands).
+
+## Dependencies
+
+`pkg/config` only.
+
+## Managed-section markers
+
+`! BEGIN BPFRX MANAGED CONFIG` … `! END BPFRX MANAGED CONFIG`. User-edited
+content **outside** the markers is preserved across `ApplyFull`. Don't
+move or rename the markers — they're literal strings.
+
+## Gotchas
+
+- Static routes have RETH names (`reth0`) but FRR wants the physical
+  member name in cluster mode. The package translates via `RethMap` from
+  the typed config.
+- IPv6 next-hops without an explicit interface require `IPv6NextHopInterfaces`
+  for link-local resolution — link-local addresses alone are ambiguous to
+  FRR.
+- In cluster mode the package emits a blackhole default at admin distance
+  250 so traffic to the active fabric peer survives a brief
+  active/active overlap.
+- `vtysh -c` is run synchronously in batch mode for state queries. There
+  is no streaming; long output is buffered.

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -1,0 +1,37 @@
+# pkg/fwdstatus
+
+Builds and renders the single-screen forwarding-daemon health view
+displayed by `show chassis forwarding`. Computes 5 s / 1 m / 5 m CPU
+windows from a sampled time series and pretty-prints a Junos-style
+fixed-width table.
+
+## Entry points
+
+- `ForwardingStatus` — `fwdstatus.go:39`. Flat status struct.
+- `Format(s ForwardingStatus) string` — `fwdstatus.go:74`. Junos-style
+  one-screen render.
+- `State` — `fwdstatus.go:14`. Online / Degraded / Unknown.
+- `CPUMode` — `fwdstatus.go:24`. Workers vs. eBPF.
+
+## Callers
+
+`pkg/grpcapi` (show command), `pkg/daemon` (status sampling).
+
+## Dependencies
+
+None internal. Pure formatting on top of the standard library — kept
+dependency-free to avoid a circular import via `pkg/cli` or `pkg/grpcapi`.
+
+## Gotchas
+
+- The CPU windows are tracked externally by a `Sampler` (a ring buffer
+  the caller maintains). This package consumes already-windowed values
+  and renders them; it doesn't sample.
+- The eBPF mode renders the worker-thread row as `N/A — eBPF path has no
+  worker threads`. Don't add code that fakes a worker entry there; the
+  N/A is informative.
+- Daemon CPU is per-core percent (can exceed 100 on a multi-core
+  daemon); worker CPU is `Σ(thread_cpu_ns) / Σ(wall_ns)` and is bounded
+  to `n_workers * 100`.
+- Windows shorter than the daemon uptime render as `-` to avoid lying
+  about a 5 m average that hasn't elapsed yet.

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -1,0 +1,43 @@
+# pkg/grpcapi
+
+gRPC server. Implements ~48 RPCs spanning config lifecycle (enter, set,
+delete, commit, rollback, history), operational queries (sessions,
+routes, NAT, IPsec, DHCP, VRRP, …), diagnostics (ping, traceroute as
+server-streaming), monitoring (drops, interface), mutations (clear), and
+tab completion. The wire schema is `proto/xpf/v1`.
+
+## Entry points
+
+- `Server` — `server.go:69`.
+- `Config` — `server.go:38`. Dependency injection point.
+- `NewServer(cfg)` — `server.go:83`.
+- `Run(ctx)` — starts the listener.
+- Tab completion: `Complete` RPC, backed by `pkg/cmdtree`.
+
+## Callers
+
+`cmd/xpfd` (instantiates and runs); `cmd/cli` (consumes); HTTP REST
+bridge in `pkg/api`.
+
+## Dependencies
+
+`cluster`, `config`, `configstore`, `conntrack`, `dataplane`, `dhcp`,
+`dhcpserver`, `feeds`, `frr`, `ipsec`, `logging`, `fwdstatus`, `ra`,
+`routing`, `rpm`, `vrrp`, plus most of the rest of `pkg/`.
+
+## Gotchas
+
+- Configure mode is **exclusive on the secondary node** in cluster mode.
+  Primary (RG0 master) is the config authority; the secondary rejects
+  `EnterConfigure` until it's promoted.
+- `peerSessionID()` is extracted from the gRPC peer credentials and used
+  to distinguish exclusive vs. shared configure sessions. A session ID is
+  required for any commit.
+- `CommitFn` (passed in by the daemon) holds the apply semaphore across
+  `Commit()` and the dataplane apply. This is the same primitive `pkg/cli`
+  uses; concurrent operator commits serialize via that semaphore (#846).
+- Tab completion (`Complete` RPC) and `?` help come from `pkg/cmdtree` —
+  add commands there once and they show up in every CLI surface.
+- Server-streaming RPCs (Ping, Traceroute, MonitorPacketDrop,
+  MonitorInterface) must drain on client disconnect; cancel the context
+  to free buffered output.

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -1,0 +1,44 @@
+# pkg/ipsec
+
+strongSwan integration. Generates `swanctl.conf` from the typed config
+(IKE proposals, traffic selectors, DPD profiles, NAT traversal, XFRM
+interface IDs) and queries SA/SP state via `swanctl`.
+
+## Entry points
+
+- `Manager` — `ipsec.go:25`.
+- `New()` — `ipsec.go:31`. Default swanctl conf dir
+  `/etc/swanctl/conf.d`.
+- `Apply(cfg)` — `ipsec.go:40`. Generate config and reload strongSwan.
+- `Clear()` — `ipsec.go:69`.
+- `SAStatus`, `TerminateAllSAs`, `InitiateConnection`.
+
+## Callers
+
+`pkg/daemon` (lifecycle), `pkg/grpcapi` (show / request commands).
+
+## Dependencies
+
+`pkg/config` only.
+
+## File layout
+
+- Writes `/etc/swanctl/conf.d/xpf.conf` with mode 0600.
+- Reloads via `swanctl --reload`.
+
+## Gotchas
+
+- IKE version negotiation supports v1-only, v2-only, or dual (default).
+  Aggressive mode is opt-in.
+- NAT traversal modes: `disable`, `force`, `enable` (auto-detect).
+  `NoNATTraversal` is a legacy flag retained for older configs.
+- Traffic selectors are auto-derived from the policy source / destination
+  prefixes when not given explicitly. Mixing explicit and derived
+  selectors is supported but the explicit set wins.
+- DPD (dead-peer detection) profiles auto-generate from IKE/ESP
+  lifetimes. Operators can override with explicit `dead-peer-detection
+  delay/timeout`.
+- XFRM interface ID is derived from the bind-interface name via
+  `xfrmiIfID()`. The same name → same numeric ID across reboots — don't
+  rename a bind interface without expecting a reset of the SAs that ride
+  it.

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -1,0 +1,33 @@
+# pkg/lldp
+
+IEEE 802.1AB Link Layer Discovery Protocol. Sends periodic LLDP frames
+out unmanaged interfaces, receives neighbor announcements, and ages
+entries by TTL.
+
+## Entry points
+
+- `Manager` — `lldp.go:84`.
+- `Neighbor` — `lldp.go:55`. Chassis ID, port ID, TTL, system name and
+  description.
+- `New()` — `lldp.go:92`.
+- `Apply(cfg)` — `lldp.go:99`.
+- `Stop()` — `lldp.go:159`.
+- `Neighbors()` — `lldp.go:171`. Snapshot consumed by `show lldp
+  neighbors`.
+
+## Callers
+
+`pkg/daemon`, `pkg/grpcapi`, `pkg/cli`.
+
+## Dependencies
+
+Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
+
+## Gotchas
+
+- Uses AF_PACKET raw sockets — the daemon needs `CAP_NET_RAW`. Without
+  it, send/receive silently fail and the neighbor table stays empty.
+- TTL countdown is per-neighbor; expired entries auto-purge from the
+  `Neighbors()` snapshot.
+- The neighbor map is RWMutex-guarded. `Neighbors()` returns a copy, not
+  a reference, so callers can iterate without holding the lock.

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -1,0 +1,45 @@
+# pkg/logging
+
+Multi-backend structured logging. Wraps `slog.Handler` with syslog
+routing, a ring-buffer event subscription stream (consumed by the SSE
+endpoint and the CLI's `monitor` commands), local file streaming with
+facility/severity filtering, and a per-IP session aggregator for top-N
+reports.
+
+## Entry points
+
+- `SyslogSlogHandler` — `slog_handler.go:13`. Slog handler that
+  fans events out to configured syslog clients.
+- `EventBuffer` — `eventbuf.go:38`. Bounded ring buffer (256 entries
+  default).
+- `Subscription` — `eventbuf.go:51`. A consumer of the event ring.
+- `LocalLogWriter` — `locallog.go:14`. File-based writer with
+  facility/severity filters.
+- `SessionAggregator` — `aggregator.go:14`. Top-N per-IP rollups.
+
+## Callers
+
+`pkg/daemon`, `pkg/api`, `pkg/grpcapi`, `pkg/flowexport`, `pkg/cli`.
+
+## Dependencies
+
+`pkg/config`, `pkg/dataplane`.
+
+## Logging rules (CLAUDE.md authoritative)
+
+- Use `slog.Debug` for high-frequency or per-packet diagnostics. Use
+  `slog.Info` only for state transitions and one-time events.
+- The HA watchdog sync was previously logging at `slog.Info` 15 times per
+  second, drowning out real diagnostics. Don't reintroduce that pattern.
+- Never put `slog.Info` inside per-session, per-packet, or per-poll-tick
+  loops.
+
+## Gotchas
+
+- The binary RT_FLOW format used by Junos session logging is custom; it
+  is not human-readable without a parser. Use the local-log facility for
+  human-readable session events.
+- The event buffer is bounded. If a subscriber stops draining, new events
+  drop silently — by design. Don't wire a slow consumer to it.
+- The session aggregator flushes on a 5-minute timer. The flushed
+  snapshot is the basis for `show security session aggregate`.

--- a/pkg/monitoriface/README.md
+++ b/pkg/monitoriface/README.md
@@ -1,0 +1,35 @@
+# pkg/monitoriface
+
+Interface-statistics snapshot reader and renderer. Reads kernel counters
+plus userspace-dataplane counters (XSK bindings, TX packets, kernel
+drops) and renders the `monitor interface` view in any of four modes:
+packets, bytes, delta, rate.
+
+## Entry points
+
+- `Snapshot` — `monitor.go:35`. Kernel counters (Rx/TxBytes, errors,
+  collisions, etc.).
+- `UserspaceSnapshot` — `monitor.go:53`. Per-binding XSK stats.
+- `CounterReader` interface — `monitor.go:18`. Abstracts BPF map access
+  so tests can inject a fake.
+- `ReadSnapshot()` — `monitor.go:465`.
+- `RenderSingleInterface()` — `monitor.go:536`.
+- `RenderTrafficSummary()` — `monitor.go:714`.
+
+## Callers
+
+`pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config`, `pkg/dataplane`, `pkg/dataplane/userspace`.
+
+## Gotchas
+
+- Delta and rate modes need a baseline snapshot. The caller is
+  responsible for sampling on a consistent interval; this package does
+  no scheduling itself.
+- Userspace snapshots require a `StatusReader` callback to the dataplane
+  process. With the eBPF backend, the userspace half is empty.
+- VLAN sub-interfaces resolve to their physical parent via
+  `ResolvePhysicalParent` so per-NIC summary rows aren't double-counted.

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -1,0 +1,50 @@
+# pkg/networkd
+
+systemd-networkd file generator. Writes `.link`, `.network`, and
+`.netdev` files for every xpfd-managed interface, handles MAC-based
+rename, VLAN parent flagging, DHCP avoidance, and atomic file
+replacement. Triggers `networkctl reload` only when files actually
+changed.
+
+## Entry points
+
+- `Manager` — `networkd.go:51`.
+- `InterfaceConfig` — `networkd.go:22`. MAC, addresses, bonding, VLAN
+  parent, VRF binding, description.
+- `New()` — `networkd.go:56`.
+- `Apply(...)` — `networkd.go:66`.
+- `Clear()` — `networkd.go:201`.
+- `FindExternallyManaged()` — `networkd.go:225`. Detects networkd files
+  the daemon doesn't own.
+
+## Callers
+
+`pkg/daemon`, `pkg/dataplane`.
+
+## Dependencies
+
+Standard library only.
+
+## Naming conventions (CLAUDE.md authoritative)
+
+- File prefix `10-xpf-` distinguishes xpf-managed files from manual
+  configs. Anything else is left alone.
+- Non-RETH interfaces match by `MACAddress=` — MAC is stable.
+- RETH member interfaces match by `OriginalName=` (PCI kernel name)
+  because the MAC alternates between physical and virtual at boot. The
+  daemon's `ensureRethLinkOriginalName()` auto-fixes stale `.link` files
+  that still use `MACAddress=`.
+- `KeepConfiguration=static` on RETH interfaces preserves VRRP VIPs
+  across `networkctl reload`.
+
+## Gotchas
+
+- `Apply()` only calls `networkctl reload` when files actually changed.
+  This matters: a reload bounces interfaces, and an idempotent reapply
+  must be cheap.
+- Interfaces not in the typed config get `ActivationPolicy=always-down`
+  in their `.network` file, so they stay down across reboots.
+- DHCP-marked interfaces skip address reconciliation entirely — the
+  daemon's DHCP client (`pkg/dhcp`) owns the address.
+- VRF and tunnel interfaces created elsewhere are excluded from the
+  unmanaged-interface scan via the `daemonOwned` map.

--- a/pkg/nftables/README.md
+++ b/pkg/nftables/README.md
@@ -1,0 +1,31 @@
+# pkg/nftables
+
+Manages nftables rules via the netlink API (no shell-out to `nft`). Sole
+purpose today: install a rule that DROPs outgoing TCP RSTs from NAT SNAT
+addresses. This is critical for HA failover correctness — without it
+the kernel can generate an RST for a connection it doesn't own at the
+moment of takeover, killing the user-visible TCP session.
+
+## Entry points
+
+- `InstallRSTSuppression()` — `rst_suppress.go:36`. Atomic
+  delete-then-create within a single netlink batch, so there is no
+  window where the old table is gone but the new one isn't installed.
+- `RemoveRSTSuppression()` — `rst_suppress.go:60`.
+
+## Callers
+
+`pkg/daemon`.
+
+## Dependencies
+
+External: `github.com/google/nftables`. No internal `pkg/*` deps.
+
+## Gotchas
+
+- Issue #450: deleting the table without immediate atomic recreate gives
+  the kernel a window to send RSTs for connections owned by the peer
+  during HA failover. The atomic delete+add pattern via `Flush()` is the
+  fix; preserve it.
+- Table name `xpf_dp_rst`, family `INet` (covers both IPv4 and IPv6 in
+  one table — don't split it without rethinking the atomic batch).

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -1,0 +1,39 @@
+# pkg/ra
+
+Embedded IPv6 Router Advertisement sender. Replaces external `radvd`
+with per-interface goroutines built on `mdlayher/ndp`. Handles startup
+burst, goodbye RAs, and re-burst recovery after RETH MAC link-cycle.
+
+## Entry points
+
+- `Manager` — `ra.go:17`.
+- `New()` — `ra.go:23`.
+- `Apply(cfg)` — `ra.go:31`. Starts/stops per-interface senders.
+- `Withdraw(ifname)` — `ra.go:100`. Stop sending on one interface.
+- `ResendBurst(ifname)` — `ra.go:117`. Re-send the startup burst (used
+  after a link cycle).
+- `WithdrawOnce(ifname)` — `ra.go:150`. Send a single goodbye RA
+  (lifetime=0).
+- `Status()` — `ra.go:210`. Per-interface SenderInfo.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config`.
+
+## Gotchas
+
+- Link DOWN→UP during a RETH MAC cycle kills the AF_PACKET socket.
+  `ResendBurst()` is what closes that gap — without it, hosts see an RA
+  outage from the moment of the link cycle until the next periodic RA.
+- The goodbye RA carries router lifetime 0, telling hosts to drop this
+  router as default gateway. Send one when explicitly withdrawing a zone
+  or shutting down.
+- IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
+  the kernel's own duplicate-address detection on the link-local
+  address.
+- Per RFC 5798, `AdvertiseInterval` is stored in milliseconds but goes
+  on the wire in centiseconds. Don't double-convert.

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -1,0 +1,50 @@
+# pkg/routing
+
+Manages static routes, GRE tunnels, VRFs, XFRM interfaces, and tunnel
+keepalive probes via netlink. Tracks link state for monitored interfaces
+and exposes per-tunnel RTT/loss metrics for weight-based failover.
+
+This package owns netlink object lifecycles. FRR (`pkg/frr`) owns the
+kernel route table; this package owns the *interfaces* routes hang off
+of.
+
+## Entry points
+
+- `Manager` — `routing.go:43`.
+- `VRFSpec` — `routing.go:71`.
+- `KeepaliveState` — `routing.go:24`. Per-tunnel probe status.
+- `TunnelStatus` — `routing.go:959`.
+- `RouteEntry` — `routing.go:1032`.
+- `InterfaceMonitorStatus` — `routing.go:36`.
+- `New()` — `routing.go:89`.
+- `ApplyTunnels(cfg)` — `routing.go:494`.
+- `ReconcileVRFs(cfg)` — `routing.go:190`.
+- `ApplyXfrmi(cfg)` — `routing.go:863`.
+
+## Callers
+
+`pkg/daemon`, `pkg/api`, `pkg/grpcapi`, `pkg/cli`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## ip-rule priorities
+
+- 33000–33099: rib-group inter-VRF leaking (`from all lookup <table>`).
+- 34000–34999: PBR (firewall-filter `routing-instance` action).
+- main table at 32766 — both ranges sit after main intentionally.
+
+## Gotchas
+
+- #848: `ifaceMu` serializes tunnel/xfrmi/bond slice access. Long-running
+  reads snapshot under the lock and iterate the copy lock-free.
+- `vrfsMu` is a separate lock. `ReconcileVRFs` holds it for the entire
+  netlink reconciliation; it isn't re-entrant.
+- Keepalive runner goroutines drain on the `done` channel before the
+  netlink handle is closed. Closing the handle while a goroutine still
+  holds it would be a use-after-close.
+- Static routes go through `pkg/frr`, not this package. The "next-table"
+  and "rib-group" leaking modes go through `ip rule` (here), not FRR.
+- RPM probes that need VRF binding use `SO_BINDTODEVICE` on the VRF
+  device, not on the destination interface.

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -1,0 +1,36 @@
+# pkg/rpm
+
+Real-time Performance Monitoring probes (ping, TCP, HTTP). Tracks RTT
+and jitter, emits events for the event-options engine, and binds probes
+to VRFs via `SO_BINDTODEVICE` when configured.
+
+## Entry points
+
+- `Manager` — `rpm.go:76`.
+- `ProbeResult` — `rpm.go:48`. Per-test metrics (RTT, jitter,
+  success/fail counters).
+- `Event` — `rpm.go:66`. `test_failed`, `probe_failed`, `test_completed`.
+- `New()` — `rpm.go:101`.
+- `Apply(cfg)` — `rpm.go:108`.
+- `StopAll()` — `rpm.go:141`.
+- `Results()` — `rpm.go:153`.
+- `SetEventCallback(fn)` — `rpm.go:85`.
+
+## Callers
+
+`pkg/daemon`, `pkg/eventengine`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config` only.
+
+## Gotchas
+
+- VRF binding is set in the dialer's control function via
+  `SO_BINDTODEVICE` to `vrf-<ri-name>` — not on the destination interface
+  itself.
+- Events expose both the test owner (probe name) and the test name so
+  event-options policies can match on either via `attributes-match`.
+- A consecutive-failure counter discriminates transient blips from
+  sustained failures; `test_failed` only fires when the threshold is
+  crossed, not on every individual missed probe.

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -1,0 +1,33 @@
+# pkg/scheduler
+
+Time-window scheduler for Junos `schedulers` blocks. Evaluates active
+state every 60 s and notifies a callback when any scheduler's
+active/inactive state changes. Used to gate firewall filters,
+forwarding-class rewrites, and other config that should engage only
+during specific windows.
+
+## Entry points
+
+- `Scheduler` — `scheduler.go:14`.
+- `New(cfgs, updateFn)` — `scheduler.go:24`. The callback fires only on
+  state change, not every tick.
+- `Run(ctx)` — `scheduler.go:37`.
+- `IsActive(name)` — `scheduler.go:54`.
+- `ActiveState()` — `scheduler.go:61`. Snapshot of every scheduler's
+  active flag.
+- `Update(cfgs)` — `scheduler.go:72`.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config`.
+
+## Gotchas
+
+- Evaluation interval is fixed at 60 s. Don't try to drive sub-minute
+  precision through this package.
+- `updateFn` receives the **full** active-state map, not just the
+  changed entries. Callers compute their own diff if they care.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -1,0 +1,44 @@
+# pkg/snmp
+
+SNMPv2c and SNMPv3 agent. Responds to GET / GETNEXT / GETBULK on
+ifTable, ifXTable, and a small set of system OIDs. Also sends link-up /
+link-down traps. ASN.1 BER encoding is hand-coded, no external library.
+
+## Entry points
+
+- `Agent` — `agent.go:122`.
+- `IfData` — `agent.go:96`. Per-interface metrics (name, MTU, speed,
+  admin/oper status, octets, errors, drops).
+- `V3UserDisplay` — `v3.go:732`.
+- `NewAgent()` — `agent.go:136`.
+- `Start()` — `agent.go:180`.
+- `Stop()` — `agent.go:226`.
+- `SetIfDataFn(fn)` — `agent.go:164`. Caller-supplied accessor for live
+  interface data.
+- `NotifyLinkUp` / `NotifyLinkDown` — `traps.go:123,128`.
+
+## Callers
+
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`.
+
+## Dependencies
+
+`pkg/config`.
+
+## ASN.1 specifics
+
+- Tag constants used: Counter32 (0x41), Gauge32 (0x42), Counter64 (0x46).
+- Exception values: `noSuchObject` (0x80), `noSuchInstance` (0x81),
+  `endOfMibView` (0x82) — emitted for missing OIDs in walks.
+- GETNEXT walking order is driven by a static OID list; it must stay in
+  ascending order.
+
+## Gotchas
+
+- Maximum response packet size is 4096 bytes. GETBULK may legitimately
+  require multiple responses.
+- Traps fire immediately on link-state change — they aren't queued, so
+  back-to-back link flaps produce back-to-back traps.
+- Don't add a third BER library to this package. The hand-coded encoder
+  is intentional; keeping the surface small avoids bringing in an SNMP
+  framework with its own poll loop and threading model.

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -1,0 +1,64 @@
+# pkg/vrrp
+
+Native VRRPv3 (RFC 5798) state machine. ~60 ms failover with 30 ms RETH
+advertisements, IPv6 support, AF_PACKET RX fallback for VLAN
+sub-interfaces, async GARP burst on `becomeMaster`, and sync-hold
+preemption control for HA bulk session sync.
+
+This is the package that drives chassis-cluster failover.
+
+## Entry points
+
+- `Manager` — `manager.go:25`. Owns every `Instance` goroutine, the event
+  channel, and sync-hold state.
+- `Instance` — `vrrp.go:13`. Per-RG config: interface, group ID, VIPs,
+  priority, preempt, timers.
+- `VRRPEvent` — `instance.go:44`. INIT / BACKUP / MASTER transitions.
+- `NewManager()` — `manager.go:47`.
+- `Start()` — `manager.go:55`.
+- `Stop()` — `manager.go:62`.
+- `UpdateInstances(cfg)` — `manager.go:169`.
+- `ReleaseSyncHold(rg)` — `manager.go:120`.
+- `ResignRG(rg)` — `manager.go:256`.
+
+## Callers
+
+`pkg/daemon`, `pkg/api`, `pkg/grpcapi`, `pkg/cli`.
+
+## Dependencies
+
+`pkg/config`, `pkg/cluster`.
+
+## Failover timing (CLAUDE.md authoritative)
+
+- ~60 ms with 30 ms RETH advertisements (masterDownInterval ~97 ms).
+- Planned shutdown: 3× priority-0 advert burst → peer takeover ~1 ms.
+- Heartbeat 200 ms, threshold 5 (1 s detection).
+- Async GARP: first pair <1 ms; remaining sent at 50 ms intervals in a
+  background goroutine. Critical path stays addVIPs → sendAdvert →
+  emitEvent (sync), then `go sendGARP()` (async).
+- Event debounce 500 ms before priority updates.
+- Sync hold: VRRP starts with `preempt=false`; released after bulk
+  session sync (or 10 s timeout). `preemptNowCh` triggers instant
+  preemption when sync completes early.
+
+## Sockets
+
+- IPv4: per-instance raw socket (proto 112) plus AF_PACKET fallback for
+  VLAN sub-interfaces (the kernel's raw IP doesn't reliably receive
+  multicast on VLANs).
+- IPv6: separate raw socket; hop limit set to 255 per RFC.
+
+## Gotchas
+
+- Use the **non-VIP** primary IP as source on advertisements. Sourcing
+  from the VIP would self-filter peer adverts.
+- RETH virtual MAC per node: `02:bf:72:CC:RR:NN`. Programmed via link
+  DOWN → set MAC → link UP. This bounces all kernel addresses; VIPs are
+  re-added by `ReconcileVIPs()` immediately afterwards.
+- Bind retry on simultaneous boot avoids losing the master election to
+  whichever node booted first.
+- Event channel is bounded at 256; backpressure increments an atomic
+  counter and triggers a reconciliation callback. Don't switch to an
+  unbounded channel — the counter is the early warning that something
+  upstream stopped draining.

--- a/proto/README.md
+++ b/proto/README.md
@@ -15,8 +15,9 @@ today; ~48 RPCs.
 PATH=$PATH:$HOME/go/bin make proto
 ```
 
-Regenerates the Go stubs into `proto/xpf/v1/*.pb.go`. The generator is
-in PATH after a Go install of `protoc-gen-go` and `protoc-gen-go-grpc`.
+Regenerates the Go stubs into `pkg/grpcapi/xpfv1/` (`xpf.pb.go`,
+`xpf_grpc.pb.go`). The generator is in PATH after a Go install of
+`protoc-gen-go` and `protoc-gen-go-grpc`.
 
 ## RPC categories
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,50 @@
+# proto/
+
+Protobuf service and message definitions for the gRPC API. The wire
+contract between `cmd/xpfd` (server, via `pkg/grpcapi`) and `cmd/cli`
+(client).
+
+## Layout
+
+`xpf/v1/` — versioned namespace. `BpfrxService` is the only service
+today; ~48 RPCs.
+
+## Regeneration
+
+```bash
+PATH=$PATH:$HOME/go/bin make proto
+```
+
+Regenerates the Go stubs into `proto/xpf/v1/*.pb.go`. The generator is
+in PATH after a Go install of `protoc-gen-go` and `protoc-gen-go-grpc`.
+
+## RPC categories
+
+- **Config lifecycle:** `EnterConfigure`, `ExitConfigure`, `Set`,
+  `Delete`, `Load`, `Commit`, `CommitCheck`, `CommitConfirmed`,
+  `ConfirmCommit`, `Rollback`, `ShowConfig`, `ShowCompare`,
+  `ShowRollback`, `ListHistory`.
+- **Operational queries:** `GetStatus`, `GetGlobalStats`, `GetZones`,
+  `GetPolicies`, `GetSessions`, `GetSessionSummary`, `GetNATSource`,
+  `GetNATDestination`, `GetScreen`, `GetEvents`, `GetInterfaces`,
+  `ShowInterfacesDetail`, `GetDHCPLeases`, `GetRoutes`,
+  `GetOSPFStatus`, `GetBGPStatus`, `GetRIPStatus`, `GetISISStatus`,
+  `GetIPsecSA`, `GetNATPoolStats`, `GetNATRuleStats`, `GetVRRPStatus`,
+  `MatchPolicies`.
+- **Diagnostics (server-streaming):** `Ping`, `Traceroute`.
+- **Monitoring (server-streaming):** `MonitorPacketDrop`,
+  `MonitorInterface`.
+- **Mutations:** `ClearSessions`, `ClearCounters`,
+  `ClearDHCPClientIdentifier`.
+- **Generic:** `ShowText` (catch-all for schedulers, snmp, dhcp-relay,
+  firewall, alg).
+- **System:** `GetSystemInfo`, `SystemAction` (reboot / halt).
+- **Tab completion:** `Complete`.
+
+## Versioning
+
+The `v1` directory is the contract version. Breaking changes require
+`v2` alongside; the server can support both for a deprecation window.
+Don't add fields with new tag numbers below 16 unless you really need
+the wire-size win — protobuf reserves 1–15 for the most common fields,
+and bumping a hot field above 15 is a one-byte regression per message.

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -1,0 +1,70 @@
+# userspace-dp/
+
+Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
+(screen → zone → conntrack → policy → NAT → forward) but in userspace.
+Runs as a separate `xpf-userspace-dp` binary the Go daemon spawns over a
+Unix-socket control protocol.
+
+The eBPF backend (`pkg/dataplane`) is the default; this crate is the
+opt-in AF_XDP zero-copy backend used on hardware that benefits from it.
+
+## Crate entry
+
+`src/main.rs` — argv parsing, then `server::lifecycle::run()`.
+
+## Top-level layout
+
+| Path | Purpose |
+|------|---------|
+| `src/afxdp/` | Core dataplane: workers, UMEM, RX/TX rings, frame parsing, session glue. |
+| `src/server/` | Control-socket lifecycle and request dispatch. |
+| `src/session/` | Session table (slab + Fx-hash indices) + timer wheel. |
+| `src/filter/` | Junos-style firewall filter compiler + engine + policer. |
+| `src/event_stream/` | Push-based binary session-delta stream to the daemon. |
+| `src/bin/` | Helper binaries (`fairness-eval`). |
+| `src/nat.rs`, `nat64.rs`, `nptv6.rs`, `policy.rs`, `screen.rs`, `slowpath.rs`, `fairness.rs`, `flowexport.rs` | Single-file feature modules consumed by the worker hot path. |
+
+## Architecture
+
+One worker thread per RSS queue. Each worker owns its AF_XDP socket,
+UMEM (12K+ RX/TX frames, 256-byte headroom), RX/TX/fill/completion rings,
+a per-worker reverse-NAT cache, and a per-worker session table view.
+
+The hot path is the `worker_loop` (in `src/afxdp/worker/`), which polls
+all bindings in batch (`RX_BATCH_SIZE=64`, up to `MAX_RX_BATCHES_PER_POLL=4`
+per tick). Per descriptor: parse → screen → session lookup → NAT/policy
+decision → forwarding build → enqueue TX or recycle.
+
+## External interfaces
+
+- **Unix socket** (`/tmp/xpf-userspace-dp.sock`): newline-delimited text
+  protocol — `BIND`, `CONFIG`, `SESSION_INJECT`, `STATUS`, `STOP`, etc.
+- **AF_XDP rings** (kernel ↔ userspace): RX/TX/fill/completion.
+- **BPF maps** (shared with the XDP shim): session table mirror,
+  conntrack, NAT pools, heartbeat.
+- **Sysctl tuning**: raises `SO_RCVBUF`, enables NAPI busy-poll in
+  `BusyPoll` mode.
+
+## Critical invariants (CLAUDE.md authoritative)
+
+- AF_XDP UMEM ownership is per-queue. A flow that hashes to queue N is
+  *physically tied* to worker N — there is no cross-worker descriptor
+  sharing. This is why every "rebalance flows across workers" design
+  has been plan-killed; see `docs/per-5-tuple/state.md` for the formal
+  ceiling.
+- `RX_BATCH_SIZE = 64` is paired with the L1d footprint (≤14 KB
+  working set per batch). A `const_assert` enforces it; don't bump it
+  without re-validating.
+- `TX_BATCH_SIZE = 64` is paired with the CoS guarantee quantum in
+  `tx/`. Changing requires re-running the `guarantee_phase_*` tests.
+- Generic-XDP fallback consumes UMEM frames permanently on mlx5; the
+  XDP shim redirects `XDP_PASS` to a cpumap stage that frees the frame
+  immediately.
+- `HEARTBEAT_GRACE_PERIOD_NS = 6 s` — during the bootstrap window the
+  XDP shim falls back to `XDP_PASS` so the kernel bootstraps NAPI.
+  After 6 s the userspace heartbeat keeps the redirect alive.
+
+## Subdir READMEs
+
+See `src/afxdp/README.md`, `src/server/README.md`, `src/session/README.md`,
+`src/filter/README.md`, `src/event_stream/README.md`, `src/bin/README.md`.

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -1,0 +1,56 @@
+# userspace-dp/src/afxdp/
+
+The hot path. Coordinator + per-worker threads + UMEM + RX/TX/fill/
+completion rings + frame parsing + session glue + neighbor cache + HA
+sync.
+
+## Submodules
+
+- `coordinator/` — spawns and supervises workers, owns the binding
+  plan, tracks worker liveness (`#925`), publishes status snapshots,
+  receives lifecycle commands from the control socket. `mod.rs` is the
+  single entry that owns shared state Arcs; `worker_manager.rs` keeps
+  the per-worker handle table.
+- `worker/` — the per-worker poll loop. `mod.rs` runs the dispatch;
+  `poll_stages.rs` (extracted in #946 Phase 1) holds the per-packet
+  pipeline stages.
+- `frame/` — packet parsing (L2 / L3 / L4), checksum helpers, TCP MSS
+  clamp. `tests.rs` was relocated out of `mod.rs` in #1046 Phase 1.
+- `umem/` — UMEM allocator, fill ring, completion ring. Frames are
+  4 KB (`UMEM_FRAME_SIZE = 4096`); index is `addr >> 12`.
+- `tx/` — TX ring management, batched enqueue, TSO segmentation
+  (`tx/tcp_segmentation.rs` after PR #1199), per-binding TX counters.
+- `cos/` — Class-of-Service scheduler: token-bucket admission, MQFQ
+  active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
+  `docs/per-5-tuple/state.md` for the architectural ceiling.
+- `forwarding/` — FIB lookup, next-hop selection, VLAN/GRE encap.
+- `session_glue/` — bridges the userspace session table back to the
+  BPF session map mirror so the CLI / GC see the same sessions.
+- `types/` — shared structs: `BindingPlan`, `BindingStatus`,
+  `WorkerRuntimeAtomics`, `SharedCoSQueueLease`, `BatchCounters`, …
+
+## Hot-path constants
+
+- `RX_BATCH_SIZE = 64`
+- `TX_BATCH_SIZE = 64`
+- `MAX_RX_BATCHES_PER_POLL = 4`
+- `FILL_WAKE_SAFETY_INTERVAL_NS = 500_000` (lost-wakeup safety net)
+- `HEARTBEAT_GRACE_PERIOD_NS = 6 * 1_000_000_000`
+
+These are paired with cache-footprint and CoS-quantum invariants —
+const-asserts catch unintentional changes.
+
+## CPU pinning
+
+`worker::pin_current_thread(worker_id)` (in `neighbor.rs`) honors the
+inherited systemd `CPUAffinity=` mask. Worker N pins to the N-th
+*allowed* CPU in that mask, so `CPUAffinity=2 3 4 5` puts workers
+0..3 on CPUs 2..5 — outside the default mask but inside the unit's.
+Don't revert to absolute-index pinning; the `CPUAffinity=` test catches
+it explicitly.
+
+## Reading order
+
+`coordinator/mod.rs` for ownership and lifecycle, then
+`worker/mod.rs` for the dispatch, then `worker/poll_stages.rs` for the
+per-packet stages, then peer modules as needed.

--- a/userspace-dp/src/bin/README.md
+++ b/userspace-dp/src/bin/README.md
@@ -1,0 +1,19 @@
+# userspace-dp/src/bin/
+
+Standalone binaries that link against the crate but aren't the
+dataplane helper.
+
+## Binaries
+
+- `fairness-eval` (`fairness-eval.rs`) — consumes `iperf3 -J` output
+  plus a Prometheus scrape of `xpf_userspace_binding_active_flow_count`
+  and emits a fairness-regime verdict (Cstruct, observed CoV, starved
+  flows). The merge bar for any fairness-mechanism PR is a PASS from
+  this binary against the loss userspace cluster.
+
+  Black-box discipline: cargo integration tests in `tests/*.rs` exercise
+  the binary via `env!("CARGO_BIN_EXE_<name>")`, which prevents tests
+  from reaching internal types and keeps the contract textual.
+
+  See PR #1220 (harness shipped) and PR #1223 (fixture) for
+  acceptance-test plumbing.

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -1,0 +1,29 @@
+# userspace-dp/src/event_stream/
+
+Push-based binary session-delta stream. Replaces the previous polled
+`drain_session_deltas` RPC: the helper sends frames to a Go-side
+listener as session events occur, with monotonic sequence numbers and a
+periodic ACK from the daemon.
+
+## Files
+
+- `mod.rs` — `EventStreamSender` owns its own I/O thread, connects to
+  the daemon's listener, sends frames, handles reconnect on EPIPE.
+- `codec.rs` — frame layout: `(op, seq, payload_len, payload)` where
+  `op` ∈ `OPEN`, `UPDATE`, `CLOSE`, `ACK`. Little-endian, fixed-width
+  header.
+- `codec_tests.rs`, `tests.rs` — co-located.
+
+## Why push
+
+Polled deltas at 1 Hz were missing fast-cycling sessions (open + close
+between ticks). The push stream sees every transition. The Go listener
+buffers and batches before forwarding to syslog / NetFlow.
+
+## Gotchas
+
+- The sequence number is monotonic across reconnects; the daemon ACKs
+  the highest seen so the helper can prune its retransmit buffer.
+- If the daemon is slow to drain, the helper's send queue fills and
+  blocks the worker thread that produced the event. That's intentional
+  back-pressure — there is no silent drop.

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -1,0 +1,29 @@
+# userspace-dp/src/filter/
+
+Junos-style firewall filter compiler, evaluation engine, and policer.
+Mirrors the BPF firewall-filter pipeline in userspace.
+
+## Files
+
+- `mod.rs` — public surface: `FilterAction` (Accept / Discard / Reject /
+  Count / Forward / RateLimit / DSCP / ForwardingClass), per-term
+  counters.
+- `compiler.rs` — parses the typed config's filter terms and lowers
+  them to compiled `FilterTerm` matchers (prefix sets, protocol /
+  port / TCP-flag / DSCP matches).
+- `engine.rs` — per-term evaluation, first-match-wins. Holds the
+  token-bucket policer for `then policer ...` actions.
+- `policer.rs` — token-bucket implementation with a `rate_limit_ns`
+  refill window.
+- `tests.rs` — co-located unit tests covering matching ports, prefix
+  sets, TCP flags.
+
+## Conventions
+
+- Prefix sets compile to a small adaptive structure: a linear scan for
+  ≤8 entries, an LPM trie above. The threshold is tuned for the
+  observed working set in policy lookups.
+- Hit counters live on each `FilterTerm` and are surfaced through the
+  status JSON.
+- `from-interface` is matched at the binding level (caller sets the
+  ingress interface; the term doesn't re-derive it).

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -1,0 +1,50 @@
+# userspace-dp/src/server/
+
+Control-socket lifecycle and request dispatch. The Go daemon talks to
+this surface over a Unix socket using a newline-delimited text protocol.
+
+## Files
+
+- `mod.rs` — module root, public API surface.
+- `lifecycle.rs` — `run()` is the daemon entry called from `main.rs`.
+  Argv parsing (`--workers N`, `--socket PATH`, etc.), socket setup,
+  sysctl tuning, signal handling.
+- `state.rs` — `ServerState`: coordinator handle, latest config
+  snapshot, session-table handle, policy state.
+- `handlers.rs` — request dispatch. Stateless handlers per request kind
+  (`apply_snapshot`, `set_forwarding_state`, `set_queue_state`,
+  `inject_packet`, `stop_workers`, `rebind`, …).
+- `helpers.rs` — shared daemon-loop utilities (`replan_queues`,
+  `replan_bindings_from_candidates`, `summarize_queues`, capability
+  checks).
+
+## Request protocol
+
+Each request is one JSON object per line, response is one JSON object.
+The shapes are mirrored in `pkg/dataplane/userspace/protocol.go` on the
+Go side; **the JSON tags ARE the contract** — changing one without
+updating the other breaks the helper.
+
+## Reconciliation
+
+`replan_queues` derives the binding plan from the current
+`ConfigSnapshot`: enumerate userspace-candidate interfaces, count their
+RX queues, and emit one `BindingStatus` per `(queue_id, interface)`
+pair. The Rust planner does:
+
+```rust
+binding.worker_id = (queue_id % workers.max(1)) as u32;
+```
+
+so a clean 1:1 queue→worker mapping requires `queue_count == workers`.
+The Go side ensures that via `pkg/daemon/rss_indirection.go` (mlx5
+today; see #1243 kill record for why i40e doesn't reshape).
+
+## Gotchas
+
+- `defer_workers=true` requests skip the worker spawn until the next
+  reconcile. Used during RETH MAC programming so workers don't bind to
+  an interface that's about to drop and re-add its MAC.
+- The control socket is shared with status poll, HA sync, session
+  installs, snapshot sync, and forwarding sync. Adding a new caller at
+  >1 Hz starves session installs during bulk sync.

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1,0 +1,47 @@
+# userspace-dp/src/session/
+
+Userspace session table and timer-wheel garbage collector. Owned by the
+coordinator; per-worker handles read and update under shared locks.
+
+## Files
+
+- `mod.rs` — `SessionTable`: slab-allocated `SessionEntry`s, three
+  `FxHashMap`s indexing by canonical / forward / reverse key. Slab +
+  integer-handle layout shipped in #964 Step 1.
+- `key.rs` — `SessionKey`, `forward_wire_key` (ingress 5-tuple),
+  `reverse_canonical_key` (post-NAT lookup), and
+  `reply_matches_forward_session` (the predicate used to detect "this
+  inbound packet matches an existing outbound flow").
+- `entry.rs` — `SessionEntry`: decision, metadata, origin, timestamps,
+  expiry tick, wheel bucket.
+- `wheel.rs` — bucketed timer wheel (1 s per tick, 256 buckets). One
+  sweep per second by the coordinator; lazy-delete on lookup picks up
+  stragglers.
+- `tests.rs` — co-located unit tests.
+
+## Timeouts
+
+| Class | Default |
+|-------|---------|
+| TCP   | 300 s |
+| UDP   | 60 s |
+| ICMP  | 60 s |
+| TCP closing | 30 s |
+
+Per-application overrides come from the typed config and land here as
+per-entry `expires_after_ns`.
+
+## GC
+
+`SESSION_GC_INTERVAL_NS = 1_000_000_000` (1 s). Single-threaded sweep
+walks the wheel bucket for the current tick; stale entries get
+lazy-deleted on the next lookup if they slip past the sweep (e.g.
+because they were re-bucketed mid-sweep).
+
+## Why a slab + integer handles
+
+Pre-#964 the table was `HashMap<Key, Arc<SessionEntry>>`. Reverse-NAT
+and alias lookups now run 2.2–2.3× faster because integer handles are
+cheap to compare and the slab layout fits more entries per cache line.
+The owner-RG export path got a 2× regression on a rare HA codepath
+that's documented in `project_964_step1_done.md` (memory).

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -43,5 +43,5 @@ because they were re-bucketed mid-sweep).
 Pre-#964 the table was `HashMap<Key, Arc<SessionEntry>>`. Reverse-NAT
 and alias lookups now run 2.2–2.3× faster because integer handles are
 cheap to compare and the slab layout fits more entries per cache line.
-The owner-RG export path got a 2× regression on a rare HA codepath
-that's documented in `project_964_step1_done.md` (memory).
+The owner-RG export path took a 2× regression on a rare HA codepath
+that's known and accepted; see PR #1182 for the trade-off.


### PR DESCRIPTION
## Summary

Adds **46 README.md files** — one per top-level module — to make the codebase navigable without re-deriving the architecture from issue archaeology.

## Coverage

**Go packages under \`pkg/*\` (31)**

api, appid, cli, cluster, cmdtree, config, configstore, conntrack, daemon, dataplane, dhcp, dhcprelay, dhcpserver, eventengine, feeds, flowexport, frr, fwdstatus, grpcapi, ipsec, lldp, logging, monitoriface, networkd, nftables, ra, routing, rpm, scheduler, snmp, vrrp.

**Non-Go modules (15)**

- \`bpf/\` (+ \`headers/\`, \`xdp/\`, \`tc/\` subdir READMEs)
- \`userspace-dp/\` (+ \`src/afxdp/\`, \`src/server/\`, \`src/session/\`, \`src/filter/\`, \`src/event_stream/\`, \`src/bin/\`)
- \`cmd/xpfd/\`, \`cmd/cli/\`
- \`proto/\`
- \`dpdk_worker/\`

## What each README covers

- **Purpose** — one or two sentences.
- **Entry points** — main types and functions with \`file:line\` references.
- **Callers + dependencies** — who imports the module and what the module imports internally.
- **Gotchas** — project-specific traps a new reader would otherwise hit, citing CLAUDE.md where authoritative.

## Style

Concise. No marketing language, no emojis. Where possible the README points at a single canonical file (e.g. \`pkg/cmdtree\` → \`tree.go\`) and tells the reader what to read first.

## Test plan

- [x] Doc-only change; no code touched.
- [x] All 46 files render clean as Markdown (verified locally).
- [x] No README clobbers an existing one (root, \`docs/pr/\`, \`testing-docs/\`, and \`test/xsk-repro/\` already had READMEs and were left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)