### PR TITLE
docs: address triple-review on per-module READMEs (#1251 followup)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-10
 
+- **Timestamp**: 2026-05-10T15:24:00Z
+  - **Action**: PR #1253 review follow-up — corrected `userspace-dp/src/server/README.md` RSS-indirection behavior to match `pkg/daemon/rss_indirection.go` (reshape conditions, workers>=queues stale-table cleanup restore path, and queue concentration semantics).
+  - **File(s)**: `userspace-dp/src/server/README.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-10T15:05:00Z
   - **Action**: PR #1253 review pass — corrected `pkg/configstore/README.md` encryption-key location wording to match `master.key` under the configstore DB directory (`db.dir`) and removed stale `/etc/xpf/config-key` path guidance.
   - **File(s)**: `pkg/configstore/README.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-10
 
+- **Timestamp**: 2026-05-10T04:16:52Z
+  - **Action**: Addressed Copilot PR review follow-up in `userspace-dp/README.md` by narrowing invariant attribution: UMEM ceiling points to `docs/per-5-tuple/state.md`; hot-path constants now explicitly attributed to `userspace-dp/src/afxdp/mod.rs`.
+  - **File(s)**: `userspace-dp/README.md`
+
 - **Timestamp**: 2026-05-10T04:06:34Z
   - **Action**: PR #1251 follow-up adversarial doc review — fixed two remaining stale path references in module READMEs (`xdp_forward.c` now fully qualified, and userspace single-file module refs now consistently `src/*.rs`).
   - **File(s)**: `pkg/dataplane/README.md`, `userspace-dp/README.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-10
 
+- **Timestamp**: 2026-05-10T15:05:00Z
+  - **Action**: PR #1253 review pass — corrected `pkg/configstore/README.md` encryption-key location wording to match `master.key` under the configstore DB directory (`db.dir`) and removed stale `/etc/xpf/config-key` path guidance.
+  - **File(s)**: `pkg/configstore/README.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-10T04:06:32Z
   - **Action**: PR comment follow-up review for `docs/per-5-tuple/state.md` — replaced a non-existent memory-file reference with in-repo issue/table references (#836/#937/#1215) to keep the fairness section self-contained and verifiable.
   - **File(s)**: `docs/per-5-tuple/state.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-05-10
+
+- **Timestamp**: 2026-05-10T04:06:34Z
+  - **Action**: PR #1251 follow-up adversarial doc review — fixed two remaining stale path references in module READMEs (`xdp_forward.c` now fully qualified, and userspace single-file module refs now consistently `src/*.rs`).
+  - **File(s)**: `pkg/dataplane/README.md`, `userspace-dp/README.md`
+
 ## 2026-05-07
 
 - **Timestamp**: 2026-05-07T16:13:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -328,3 +328,12 @@
 - **Timestamp**: 2026-05-10T03:24:56Z
   - **Action**: Correct stale filename references in module READMEs (`eventengine.go`/`dhcprelay.go` -> `engine.go`/`relay.go`) so entry-point file:line links resolve.
   - **File(s)**: `pkg/eventengine/README.md`, `pkg/dhcprelay/README.md`
+
+## 2026-05-10 — docs README wiring/source corrections
+
+- **Timestamp**: 2026-05-10T05:18:20Z
+  - **Action**: Correct `SessionCloseData` attribution to `logging.EventReader` session-close records (not conntrack GC delete callbacks).
+  - **File(s)**: `pkg/flowexport/README.md`
+- **Timestamp**: 2026-05-10T05:18:20Z
+  - **Action**: Correct configstore encryption note to match implementation (`master.key` + HKDF with configured PRF).
+  - **File(s)**: `pkg/configstore/README.md`

--- a/cmd/xpfd/README.md
+++ b/cmd/xpfd/README.md
@@ -40,5 +40,5 @@ machine.
 
 ## Read order
 
-Start at `pkg/daemon/daemon.go:296` (`New`) for the assembly. From
+Start at `pkg/daemon/daemon.go` (`New`) for the assembly. From
 there, every imported `pkg/*` has its own README.

--- a/dpdk_worker/README.md
+++ b/dpdk_worker/README.md
@@ -37,7 +37,7 @@ RX dispatch via a function table:
 
 ## Shared memory
 
-`struct shared_memory` (defined in `tables.h`) lives in a DPDK memzone.
+`struct shared_memory` (defined in `shared_mem.h`) lives in a DPDK memzone.
 The Go side (`pkg/dataplane/dpdk`) opens the same memzone and reads /
 writes the same structs:
 

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -7,7 +7,7 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
 ## Entry points
 
 - `Server` — `server.go`
-- `NewServer(cfg Config)` — `server.go`
+- `NewServer(cfg Config) *Server` — `server.go`.
 - `Config` — `server.go`. All dependencies (configstore, dataplane, frr,
   vrrp, etc.) injected here; the package has no global state.
 

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -13,14 +13,15 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
 
 ## Surface
 
-- `/healthz`, `/readyz` — liveness, readiness. `CompileHealthFn` (#758) lets
-  the daemon downgrade `/readyz` to 503 when a recent compile failed
-  silently; without the callback `/readyz` defaults to 200.
-- `/metrics` — Prometheus exposition.
-- `/v1/...` — REST mirrors of the gRPC API: sessions, routes, NAT, DHCP,
-  IPsec, VRRP, etc.
-- `/events` — Server-Sent Events stream of dataplane events. Backed by the
-  `pkg/logging` event ring buffer; long-lived consumers must drain.
+- `GET /health` — liveness/readiness. `CompileHealthFn` (#758) lets the
+  daemon downgrade `/health` to 503 when a recent compile failed
+  silently; without the callback it defaults to 200.
+- `GET /metrics` — Prometheus exposition.
+- `GET /api/v1/...` — REST mirrors of the gRPC API: sessions, routes,
+  NAT, DHCP, IPsec, VRRP, OSPF, BGP, etc.
+- `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
+  events. Backed by the `pkg/logging` event ring buffer; long-lived
+  consumers must drain.
 
 ## Callers
 

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -6,9 +6,9 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
 
 ## Entry points
 
-- `Server` — `server.go:74`
-- `NewServer(cfg Config)` — `server.go:93`
-- `Config` — `server.go:44`. All dependencies (configstore, dataplane, frr,
+- `Server` — `server.go`
+- `NewServer(cfg Config)` — `server.go`
+- `Config` — `server.go`. All dependencies (configstore, dataplane, frr,
   vrrp, etc.) injected here; the package has no global state.
 
 ## Surface

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -15,8 +15,10 @@ and resolves session display names from the dataplane's assigned `app_id`.
 - `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string` —
   `runtime.go`. Three-tier lookup: dataplane `app_id` (authoritative
   from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
-  (`junos-http`, `junos-ssh`, …). Used for session display, NetFlow
-  records, and syslog session-close events.
+  (`junos-http`, `junos-ssh`, …). Used for session display in the CLI
+  and gRPC paths. (`pkg/logging` resolves app names through its own
+  `EventReader.resolveAppName`, and `pkg/flowexport` does not call
+  this function — the wiring isn't shared with NetFlow / syslog.)
 
 ## Callers
 
@@ -34,5 +36,5 @@ and resolves session display names from the dataplane's assigned `app_id`.
   contract (`show services application-identification status` plus a
   commit warning that flags policies relying on AppID matches that the
   runtime won't actually evaluate).
-- `application-set` aliasing must already be expanded in `cfg` before
-  calling either function. This package does not flatten sets.
+- `CatalogNames` calls `config.ExpandApplicationSet` internally to
+  flatten `application-set` aliases. Callers don't need to pre-expand.

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -6,12 +6,12 @@ and resolves session display names from the dataplane's assigned `app_id`.
 
 ## Entry points
 
-- `CatalogNames(cfg, includeAll) []string` — `runtime.go:42`. Returns the
+- `CatalogNames(cfg, includeAll) []string` — `runtime.go`. Returns the
   list of application names the BPF compiler must lower into the policy
   `app_id` table. `includeAll=false` returns only apps referenced by
   policies; `true` returns every defined app.
 - `ResolveSessionName(appNames, cfg, proto, dstPort, appID) string` —
-  `runtime.go:95`. Three-tier lookup: dataplane `app_id` (authoritative
+  `runtime.go`. Three-tier lookup: dataplane `app_id` (authoritative
   from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
   (`junos-http`, `junos-ssh`, …). Used for session display, NetFlow
   records, and syslog session-close events.

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -13,12 +13,16 @@ and resolves session display names from the dataplane's assigned `app_id`.
   Returns an error if application-set expansion fails — callers must
   handle it.
 - `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string` —
-  `runtime.go`. Three-tier lookup: dataplane `app_id` (authoritative
-  from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
-  (`junos-http`, `junos-ssh`, …). Used for session display in the CLI
-  and gRPC paths. (`pkg/logging` resolves app names through its own
-  `EventReader.resolveAppName`, and `pkg/flowexport` does not call
-  this function — the wiring isn't shared with NetFlow / syslog.)
+  `runtime.go`. Lookup order: dataplane `app_id` (authoritative from
+  BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
+  (`junos-http`, `junos-ssh`, …). When AppID is **enabled** in
+  `services.application-identification` and the dataplane has not
+  assigned an `app_id` for the session (`appID == 0`), the function
+  returns `UNKNOWN` rather than guessing from port heuristics. Used
+  for session display in the CLI and gRPC paths. (`pkg/logging`
+  resolves app names through its own `EventReader.resolveAppName`,
+  and `pkg/flowexport` does not call this function — the wiring
+  isn't shared with NetFlow / syslog.)
 
 ## Callers
 

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -6,13 +6,13 @@ and resolves session display names from the dataplane's assigned `app_id`.
 
 ## Entry points
 
-- `CatalogNames(cfg, includeAll) ([]string, error)` — `runtime.go`.
+- `CatalogNames(cfg *config.Config, includeAll bool) ([]string, error)` — `runtime.go`.
   Returns the list of application names the BPF compiler must lower
   into the policy `app_id` table. `includeAll=false` returns only
   apps referenced by policies; `true` returns every defined app.
   Returns an error if application-set expansion fails — callers must
   handle it.
-- `ResolveSessionName(appNames, cfg, proto, dstPort, appID) string` —
+- `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string` —
   `runtime.go`. Three-tier lookup: dataplane `app_id` (authoritative
   from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
   (`junos-http`, `junos-ssh`, …). Used for session display, NetFlow

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -6,10 +6,12 @@ and resolves session display names from the dataplane's assigned `app_id`.
 
 ## Entry points
 
-- `CatalogNames(cfg, includeAll) []string` — `runtime.go`. Returns the
-  list of application names the BPF compiler must lower into the policy
-  `app_id` table. `includeAll=false` returns only apps referenced by
-  policies; `true` returns every defined app.
+- `CatalogNames(cfg, includeAll) ([]string, error)` — `runtime.go`.
+  Returns the list of application names the BPF compiler must lower
+  into the policy `app_id` table. `includeAll=false` returns only
+  apps referenced by policies; `true` returns every defined app.
+  Returns an error if application-set expansion fails — callers must
+  handle it.
 - `ResolveSessionName(appNames, cfg, proto, dstPort, appID) string` —
   `runtime.go`. Three-tier lookup: dataplane `app_id` (authoritative
   from BPF) → exact `(proto, dstPort)` match → narrow built-in fallback

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -10,9 +10,12 @@ both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
 - `CLI` — `cli.go`. The REPL engine.
 - `New(...)` — `cli.go`. Takes ~10 injected managers (configstore,
   dataplane, cluster, frr, dhcp, …). The package has no globals.
-- `Build()` — compiles the readline command tree from `pkg/cmdtree`. Add a
-  new command in `pkg/cmdtree/tree.go` and it shows up here, in the remote
-  CLI, and in gRPC tab completion automatically.
+- The readline command tree is compiled from `pkg/cmdtree` at REPL
+  start; add a new command in `pkg/cmdtree/tree.go` and it shows up
+  here, in the remote CLI, and in gRPC tab completion automatically.
+- Per-injection setters: `SetForwardingSampler`, `SetRPMResultsFn`,
+  `SetFeedsFn`, `SetLLDPNeighborsFn`, `SetVRRPManager`,
+  `SetApplyConfigFn`, `SetCommitFns`, …. All on `*CLI`.
 
 ## Callers
 

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -7,8 +7,8 @@ both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
 
 ## Entry points
 
-- `CLI` — `cli.go:47`. The REPL engine.
-- `New(...)` — `cli.go:108`. Takes ~10 injected managers (configstore,
+- `CLI` — `cli.go`. The REPL engine.
+- `New(...)` — `cli.go`. Takes ~10 injected managers (configstore,
   dataplane, cluster, frr, dhcp, …). The package has no globals.
 - `Build()` — compiles the readline command tree from `pkg/cmdtree`. Add a
   new command in `pkg/cmdtree/tree.go` and it shows up here, in the remote

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -12,9 +12,11 @@ sync.
   readiness/transferReady tracking.
 - `Manager` — `cluster.go`. Election logic, weight calculation, event
   history.
-- `ClusterEvent` — `cluster.go`. State-change notifications consumed
-  by VRRP, the dataplane, and the syslog/SNMP trap senders. (Type
-  defined in `cluster.go`; the consumer lives in `reth.go`.)
+- `ClusterEvent` — `cluster.go`. State-change notifications. The
+  primary consumer of the `Manager.Events()` channel is
+  `pkg/daemon/daemon_ha.go`, which fans events out (HA sync, status
+  publish, etc.). `pkg/cluster/reth.go::HandleStateChange` is a
+  state-handler method, not the event-channel consumer.
 
 ## Callers
 

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -7,13 +7,14 @@ sync.
 
 ## Entry points
 
-- `NodeState` — `cluster.go:20`. State enum constants.
-- `RedundancyGroupState` — `cluster.go:47`. Per-RG state with
+- `NodeState` — `cluster.go`. State enum constants.
+- `RedundancyGroupState` — `cluster.go`. Per-RG state with
   readiness/transferReady tracking.
-- `Manager` — `cluster.go:~100`. Election logic, weight calculation, event
+- `Manager` — `cluster.go`. Election logic, weight calculation, event
   history.
-- `ClusterEvent` — `events.go:80`. State-change notifications consumed by
-  VRRP, the dataplane, and the syslog/SNMP trap senders.
+- `ClusterEvent` — `cluster.go`. State-change notifications consumed
+  by VRRP, the dataplane, and the syslog/SNMP trap senders. (Type
+  defined in `cluster.go`; the consumer lives in `reth.go`.)
 
 ## Callers
 

--- a/pkg/cmdtree/README.md
+++ b/pkg/cmdtree/README.md
@@ -7,14 +7,14 @@ three frontends.
 
 ## Entry points
 
-- `Node` — `tree.go:23`. Tree node: description, static children,
+- `Node` — `tree.go`. Tree node: description, static children,
   `DynamicFn`/`ContextDynamicFn` for config-aware completions.
-- `Candidate` — `tree.go:49`. `(name, desc)` pair surfaced during tab
+- `Candidate` — `tree.go`. `(name, desc)` pair surfaced during tab
   completion.
-- `OperationalTree` — `tree.go:56`. Canonical root for `show`, `clear`,
+- `OperationalTree` — `tree.go`. Canonical root for `show`, `clear`,
   `request`, `monitor`, `ping`, `traceroute`, etc.
 - `ConfigTopLevel` — root for the `set`/`delete` configuration grammar.
-- `KeysFromTree(tree)` — `tree.go:927`. Used by `pkg/cli` and `pkg/grpcapi`
+- `KeysFromTree(tree)` — `tree.go`. Used by `pkg/cli` and `pkg/grpcapi`
   for Junos-style prefix matching.
 - `WriteHelp`, `LookupDesc`, `PrintTreeHelp`, `CompleteFromTree` — the
   helper API the three frontends consume.

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -15,8 +15,14 @@ nothing internal.
 - `ParseSetCommand(line) (*Node, error)` — for **one** flat-set line.
 - `ConfigTree` — `ast.go`. Hierarchical node tree built by both shapes.
 - `Config` — `types.go`. The fully typed result every consumer wants.
-- The compiler — `compiler/` (~30 files, ~11K LOC) across six phases:
-  interfaces → zones → routing → NAT → firewall → filters.
+- The compiler — eleven `compiler*.go` files in `pkg/config/`
+  (`compiler.go` plus per-area files: interfaces, routing, security,
+  services, system, firewall, NAT, IPsec, protocols,
+  class-of-service, plus `compiler.go` itself), ~7.6K LOC total.
+  Phase dispatch in `compiler.go` runs zone IDs → screen profile IDs
+  → zones → address book → applications → policies → NAT (incl.
+  static, NAT64, NPTv6) → screen profiles → default policy → flow
+  timeouts → firewall filters → flow config → port mirroring.
 
 ## Callers
 

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -15,14 +15,17 @@ nothing internal.
 - `ParseSetCommand(line) (*Node, error)` — for **one** flat-set line.
 - `ConfigTree` — `ast.go`. Hierarchical node tree built by both shapes.
 - `Config` — `types.go`. The fully typed result every consumer wants.
-- The compiler — eleven `compiler*.go` files in `pkg/config/`
-  (`compiler.go` plus per-area files: interfaces, routing, security,
-  services, system, firewall, NAT, IPsec, protocols,
-  class-of-service, plus `compiler.go` itself), ~7.6K LOC total.
-  Phase dispatch in `compiler.go` runs zone IDs → screen profile IDs
-  → zones → address book → applications → policies → NAT (incl.
-  static, NAT64, NPTv6) → screen profiles → default policy → flow
-  timeouts → firewall filters → flow config → port mirroring.
+- `CompileConfig(tree) (*Config, error)` — `compiler.go`. AST-to-typed-
+  struct walker. Clones the tree, expands `apply-groups` (with
+  `${node}` fallback for cluster mode), then dispatches over AST
+  nodes via a switch statement to fill the typed `Config`. Eleven
+  `compiler*.go` files in this package, ~7.6K LOC total
+  (`compiler.go` + `compiler_interfaces.go`, `_routing.go`,
+  `_security.go`, `_services.go`, `_system.go`, `_firewall.go`,
+  `_nat.go`, `_ipsec.go`, `_protocols.go`, `_class_of_service.go`).
+  Note: this is the **AST → typed Go struct** stage; the BPF-map
+  compilation (zones, policies, NAT IDs, etc.) happens later in
+  `pkg/dataplane.Manager.Compile`.
 
 ## Callers
 

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -12,7 +12,9 @@ nothing internal.
 
 - `Lexer` — `lexer.go`.
 - `Parser` — `parser.go`. **Hierarchical** input.
-- `ParseSetCommand(line) (*Node, error)` — for **one** flat-set line.
+- `ParseSetCommand(input string) ([]string, error)` — `parser.go`.
+  Parses one flat-set line into the path components. The caller then
+  applies that path with `tree.SetPath()` to build the AST.
 - `ConfigTree` — `ast.go`. Hierarchical node tree built by both shapes.
 - `Config` — `types.go`. The fully typed result every consumer wants.
 - `CompileConfig(tree) (*Config, error)` — `compiler.go`. AST-to-typed-
@@ -20,9 +22,10 @@ nothing internal.
   `${node}` fallback for cluster mode), then dispatches over AST
   nodes via a switch statement to fill the typed `Config`. Eleven
   `compiler*.go` files in this package, ~7.6K LOC total
-  (`compiler.go` + `compiler_interfaces.go`, `_routing.go`,
-  `_security.go`, `_services.go`, `_system.go`, `_firewall.go`,
-  `_nat.go`, `_ipsec.go`, `_protocols.go`, `_class_of_service.go`).
+  (`compiler.go` + `compiler_interfaces.go`, `compiler_routing.go`,
+  `compiler_security.go`, `compiler_services.go`, `compiler_system.go`,
+  `compiler_firewall.go`, `compiler_nat.go`, `compiler_ipsec.go`,
+  `compiler_protocols.go`, `compiler_class_of_service.go`).
   Note: this is the **AST → typed Go struct** stage; the BPF-map
   compilation (zones, policies, NAT IDs, etc.) happens later in
   `pkg/dataplane.Manager.Compile`.

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -10,8 +10,8 @@ nothing internal.
 
 ## Entry points
 
-- `Lexer` — `lexer.go:63`.
-- `Parser` — `parser.go:17`. **Hierarchical** input.
+- `Lexer` — `lexer.go`.
+- `Parser` — `parser.go`. **Hierarchical** input.
 - `ParseSetCommand(line) (*Node, error)` — for **one** flat-set line.
 - `ConfigTree` — `ast.go`. Hierarchical node tree built by both shapes.
 - `Config` — `types.go`. The fully typed result every consumer wants.

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -38,9 +38,10 @@ master password is set.
   atomically promotes candidate → active and bumps the rollback ring.
 - Rollback slots are 0..49 (FIFO). Oldest is silently discarded when the
   ring is full.
-- The encryption key path is fixed at `/etc/xpf/config-key`. If the file
-  is missing on a node that previously committed encrypted state, the
-  daemon refuses to start — there is no plaintext fallback.
+- The encryption key material lives in `master.key` inside the configstore
+  DB directory (`db.dir`). If that file is missing on a node that previously
+  committed encrypted state, the daemon refuses to start — there is no
+  plaintext fallback.
 - Commit atomicity (#846): `pkg/daemon` wraps `Commit()` together with
   `applyConfig()` under a single semaphore. Bypassing the daemon (e.g.
   using `Store` directly) loses that serialization, so concurrent CLI +

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -15,8 +15,8 @@ master password is set.
 - `crypto.go` — AES-256-GCM at-rest encryption helpers
   (`maybeEncryptTreeJSON`, `maybeDecryptTreeJSON`,
   `deriveEncryptionKey`). No public type; the encryption hooks are
-  methods on `*DB`. Key material is derived from a master password
-  via PBKDF2.
+  methods on `*DB`. A random 32-byte `master.key` is generated/stored
+  on disk, then HKDF (with the configured PRF) derives the AES-GCM key.
 
 ## Callers
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -7,8 +7,13 @@ master password is set.
 
 ## Entry points
 
-- `Store` — high-level API: `Candidate`, `Active`, `Commit`,
-  `CommitConfirmed`, `Rollback`, `History`.
+- `Store` — high-level API. Public methods include `ShowCandidate`,
+  `ShowActive`, `ActiveConfig`, `ActiveTree`, `Commit`,
+  `CommitCheck`, `CommitConfirmed`, `Rollback`, `ListHistory`,
+  `EnterConfigure`, `EnterConfigureSession`,
+  `EnterConfigureExclusive`, `ExitConfigure`, `SyncApply`. (See
+  `store.go` for the full surface — there's no shorthand
+  `Candidate()` or `History()`; use the `Show*` / `List*` forms.)
 - `DB` — `db.go`. Low-level atomic file I/O.
 - `History` — `history.go`. Bounded ring of recent commits.
 - `Journal` — `journal.go`. Append-only JSONL audit trail.
@@ -31,16 +36,21 @@ master password is set.
 
 ## Gotchas
 
-- Atomic write protocol: write temp file → fsync → rename. If the daemon
-  is killed mid-fsync the previous file survives intact, and subsequent
-  reads can fall back to a rollback slot.
-- `Candidate` may be dirty (uncommitted edits accumulating). `Commit`
-  atomically promotes candidate → active and bumps the rollback ring.
-- Rollback slots are 0..49 (FIFO). Oldest is silently discarded when the
-  ring is full.
-- The encryption key path is fixed at `/etc/xpf/config-key`. If the file
-  is missing on a node that previously committed encrypted state, the
-  daemon refuses to start — there is no plaintext fallback.
+- Atomic write protocol: write temp file → `os.Rename` (POSIX-atomic
+  on the same filesystem). The previous file survives an interrupted
+  rename intact, and subsequent reads can fall back to a rollback
+  slot. Note: `db.go` does not call `f.Sync()` between write and
+  rename — durability against power-loss within the rename window
+  relies on the filesystem journal, not on an explicit `fsync`.
+- The candidate (in-memory) tree may be dirty (uncommitted edits
+  accumulating). `Commit` atomically promotes candidate → active
+  and bumps the rollback ring.
+- Rollback slots are 0..49 (FIFO). Oldest is silently discarded when
+  the ring is full.
+- The encryption key lives at `<db.dir>/master.key` (mode 0600,
+  generated on first encrypted commit). If the file is missing on a
+  node that previously committed encrypted state, decryption fails —
+  there is no plaintext fallback.
 - Commit atomicity (#846): `pkg/daemon` wraps `Commit()` together with
   `applyConfig()` under a single semaphore. Bypassing the daemon (e.g.
   using `Store` directly) loses that serialization, so concurrent CLI +

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -16,7 +16,7 @@ master password is set.
   (`maybeEncryptTreeJSON`, `maybeDecryptTreeJSON`,
   `deriveEncryptionKey`). No public type; the encryption hooks are
   methods on `*DB`. Key material is derived from a master password
-  via PBKDF2.
+  via HKDF (`xpf-configstore-master-password` info string) over a master.key on disk.
 
 ## Callers
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -15,8 +15,11 @@ master password is set.
 - `crypto.go` — AES-256-GCM at-rest encryption helpers
   (`maybeEncryptTreeJSON`, `maybeDecryptTreeJSON`,
   `deriveEncryptionKey`). No public type; the encryption hooks are
-  methods on `*DB`. Key material is derived from a master password
-  via HKDF (`xpf-configstore-master-password` info string) over a master.key on disk.
+  methods on `*DB`. The encryption key is derived via HKDF
+  (info string `xpf-configstore-master-password`, mode 0600 random
+  bytes) from a randomly-generated `master.key` file in the
+  configstore directory. The "master-password" naming is an HKDF
+  info string only — it isn't a user-supplied password.
 
 ## Callers
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -9,7 +9,7 @@ master password is set.
 
 - `Store` — high-level API: `Candidate`, `Active`, `Commit`,
   `CommitConfirmed`, `Rollback`, `History`.
-- `DB` — `db.go:15`. Low-level atomic file I/O.
+- `DB` — `db.go`. Low-level atomic file I/O.
 - `History` — `history.go`. Bounded ring of recent commits.
 - `Journal` — `journal.go`. Append-only JSONL audit trail.
 - `Crypto` — `crypto.go`. AES-256-GCM key derivation from

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -12,8 +12,11 @@ master password is set.
 - `DB` — `db.go`. Low-level atomic file I/O.
 - `History` — `history.go`. Bounded ring of recent commits.
 - `Journal` — `journal.go`. Append-only JSONL audit trail.
-- `Crypto` — `crypto.go`. AES-256-GCM key derivation from
-  `/etc/xpf/config-key`.
+- `crypto.go` — AES-256-GCM at-rest encryption helpers
+  (`maybeEncryptTreeJSON`, `maybeDecryptTreeJSON`,
+  `deriveEncryptionKey`). No public type; the encryption hooks are
+  methods on `*DB`. Key material is derived from a master password
+  via PBKDF2.
 
 ## Callers
 

--- a/pkg/conntrack/README.md
+++ b/pkg/conntrack/README.md
@@ -7,7 +7,7 @@ rate-limiting, and fires delete callbacks (used by HA delete-sync).
 ## Entry points
 
 - `GC` — `gc.go`.
-- `NewGC(dp dataplane.DataPlane, interval time.Duration)` — `gc.go`.
+- `NewGC(dp dataplane.DataPlane, interval time.Duration) *GC` — `gc.go`.
 - `GCStats` — `gc.go`. Last-sweep metrics surfaced to `show system
   buffers`.
 - `OnDeleteV4`, `OnDeleteV6` — per-deleted-session callbacks; HA wires

--- a/pkg/conntrack/README.md
+++ b/pkg/conntrack/README.md
@@ -6,9 +6,9 @@ rate-limiting, and fires delete callbacks (used by HA delete-sync).
 
 ## Entry points
 
-- `GC` — `gc.go:34`.
-- `NewGC(dp dataplane.DataPlane, interval time.Duration)` — `gc.go:86`.
-- `GCStats` — `gc.go:17`. Last-sweep metrics surfaced to `show system
+- `GC` — `gc.go`.
+- `NewGC(dp dataplane.DataPlane, interval time.Duration)` — `gc.go`.
+- `GCStats` — `gc.go`. Last-sweep metrics surfaced to `show system
   buffers`.
 - `OnDeleteV4`, `OnDeleteV6` — per-deleted-session callbacks; HA wires
   these to the session-sync delete path.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -16,7 +16,7 @@ every other internal package.
   `GRPCAddr`, `Version`.
 - `New(opts) *Daemon` — `daemon.go`.
 - `CompileHealth` — `daemon.go`. Snapshot of the most recent compile
-  outcome; `pkg/api` consumes it for `/readyz`.
+  outcome; `pkg/api` consumes it for the `/health` endpoint.
 
 ## Cluster mode
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -14,7 +14,7 @@ every other internal package.
 - `Daemon` — `daemon.go`.
 - `Options` — `daemon.go`. `ConfigPath`, `NoDataplane`, `APIAddr`,
   `GRPCAddr`, `Version`.
-- `New(opts) *Daemon` — `daemon.go`.
+- `New(opts Options) *Daemon` — `daemon.go`.
 - `CompileHealth` — `daemon.go`. Snapshot of the most recent compile
   outcome; `pkg/api` consumes it for the `/health` endpoint.
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -11,11 +11,11 @@ every other internal package.
 
 ## Entry points
 
-- `Daemon` — `daemon.go:59`.
-- `Options` — `daemon.go:44`. `ConfigPath`, `NoDataplane`, `APIAddr`,
+- `Daemon` — `daemon.go`.
+- `Options` — `daemon.go`. `ConfigPath`, `NoDataplane`, `APIAddr`,
   `GRPCAddr`, `Version`.
-- `New(opts) *Daemon` — `daemon.go:296`.
-- `CompileHealth` — `daemon.go:286`. Snapshot of the most recent compile
+- `New(opts) *Daemon` — `daemon.go`.
+- `CompileHealth` — `daemon.go`. Snapshot of the most recent compile
   outcome; `pkg/api` consumes it for `/readyz`.
 
 ## Cluster mode

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -11,12 +11,12 @@ Go interface is the only thing every caller sees.
 
 ## Entry points
 
-- `DataPlane` — `dataplane.go:104`. Abstract interface.
-- `Manager` — `loader.go:39`. eBPF implementation.
-- `New() *Manager` — `loader.go:66`.
+- `DataPlane` — `dataplane.go`. Abstract interface.
+- `Manager` — `loader.go`. eBPF implementation.
+- `New() *Manager` — `loader.go`.
 - `Compile(cfg *config.Config) (*CompileResult, error)` — six-phase
   lowering to BPF map entries.
-- `CompileResult` — `compiler.go:23`. Zone/policy/NAT/app IDs and the
+- `CompileResult` — `compiler.go`. Zone/policy/NAT/app IDs and the
   per-interface networkd configs.
 - Session iteration: `IterateSessions`, `IterateSessionsByZonePair`, etc.
 

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -15,10 +15,11 @@ Go interface is the only thing every caller sees.
 - `Manager` — `loader.go`. eBPF implementation.
 - `New() *Manager` — `loader.go`.
 - `Compile(cfg *config.Config) (*CompileResult, error)` — multi-phase
-  lowering to BPF map entries. Phases live in `compiler.go` (zones,
-  screen profiles, address book, applications, policies, NAT,
-  static NAT, NAT64 prefixes, NPTv6, screen profiles, default
-  policy, flow timeouts).
+  lowering to BPF map entries. Phases live in `compiler.go`: zone IDs,
+  screen profile IDs, zones, address book, applications, policies,
+  NAT, static NAT, NAT64 prefixes, NPTv6, screen profiles, default
+  policy, flow timeouts, firewall filters, flow config, port
+  mirroring.
 - `CompileResult` — `compiler.go`. Zone/policy/NAT/app IDs and the
   per-interface networkd configs.
 - Session iteration: `IterateSessions`, `BatchIterateSessions`,

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -14,11 +14,15 @@ Go interface is the only thing every caller sees.
 - `DataPlane` — `dataplane.go`. Abstract interface.
 - `Manager` — `loader.go`. eBPF implementation.
 - `New() *Manager` — `loader.go`.
-- `Compile(cfg *config.Config) (*CompileResult, error)` — six-phase
-  lowering to BPF map entries.
+- `Compile(cfg *config.Config) (*CompileResult, error)` — multi-phase
+  lowering to BPF map entries. Phases live in `compiler.go` (zones,
+  screen profiles, address book, applications, policies, NAT,
+  static NAT, NAT64 prefixes, NPTv6, screen profiles, default
+  policy, flow timeouts).
 - `CompileResult` — `compiler.go`. Zone/policy/NAT/app IDs and the
   per-interface networkd configs.
-- Session iteration: `IterateSessions`, `IterateSessionsByZonePair`, etc.
+- Session iteration: `IterateSessions`, `BatchIterateSessions`,
+  `IterateSessionsV6`, `BatchIterateSessionsV6`.
 
 ## Callers
 

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -55,7 +55,7 @@ authoritative list; quick recap:
   i40e/ice on the PF have native XDP.
 - `bpf_redirect_map` requires `ndo_xdp_xmit` on the target. Mixing native
   + generic interfaces in a redirect set silently drops.
-- Workaround: per-interface `redirect_capable` flag in `xdp_forward.c`.
+- Workaround: per-interface `redirect_capable` flag in `bpf/xdp/xdp_forward.c`.
   Non-native interfaces fall back to `XDP_PASS` (kernel forwarding).
 - The lab uses PF passthrough (i40e) on the WAN interface; all other
   interfaces are virtio with native XDP. Per-VF passthrough would need

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -6,10 +6,10 @@ restarts so the same client identifier returns to the same lease.
 
 ## Entry points
 
-- `Manager` — `dhcp.go:85`.
-- `New(stateDir)` — `dhcp.go:103`.
-- `Lease` — `dhcp.go:36`. Result of one DHCP negotiation.
-- `DelegatedPrefix` — `dhcp.go:76`. From DHCPv6 PD.
+- `Manager` — `dhcp.go`.
+- `New(stateDir)` — `dhcp.go`.
+- `Lease` — `dhcp.go`. Result of one DHCP negotiation.
+- `DelegatedPrefix` — `dhcp.go`. From DHCPv6 PD.
 - `Start()`, `Renew()`, `StopAll()`, `DelegatedPrefixes()`.
 
 ## Callers

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -12,7 +12,11 @@ restarts so the same client identifier returns to the same lease.
   when any client's lease changes.
 - `Lease` — `dhcp.go`. Result of one DHCP negotiation.
 - `DelegatedPrefix` — `dhcp.go`. From DHCPv6 PD.
-- `Start()`, `Renew()`, `StopAll()`, `DelegatedPrefixes()`.
+- `Start(ctx context.Context, ifaceName string, af AddressFamily)` —
+  `dhcp.go`. Spawn a per-interface client goroutine.
+- `Renew(ifaceName string) error` — `dhcp.go`.
+- `StopAll()` — `dhcp.go`.
+- `DelegatedPrefixes() []DelegatedPrefix` — `dhcp.go`.
 
 ## Callers
 

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -7,7 +7,9 @@ restarts so the same client identifier returns to the same lease.
 ## Entry points
 
 - `Manager` — `dhcp.go`.
-- `New(stateDir)` — `dhcp.go`.
+- `New(stateDir string, onAddressChange func()) (*Manager, error)` —
+  `dhcp.go`. The `onAddressChange` callback fires (debounced 2 s)
+  when any client's lease changes.
 - `Lease` — `dhcp.go`. Result of one DHCP negotiation.
 - `DelegatedPrefix` — `dhcp.go`. From DHCPv6 PD.
 - `Start()`, `Renew()`, `StopAll()`, `DelegatedPrefixes()`.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -27,5 +27,7 @@ to the interface name.
   IPv4 address — that's what fills `giaddr`.
 - Option 82 sub-option 1 (`circuit-id`) is set to the interface name; on
   the reply path it's stripped before forwarding to the client.
-- Server addresses are resolved once at `Apply()` time; if a server's DNS
-  changes you need a config reload.
+- Server addresses must be **literal IPs**. `Apply()` calls
+  `net.ParseIP` and rejects hostnames; there is no DNS resolution
+  path. To target a hostname, the operator must resolve it externally
+  and put the IP in the config.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -8,7 +8,7 @@ to the interface name.
 
 - `Manager` — `relay.go`.
 - `NewManager()` — `relay.go`.
-- `Apply(cfg)` — `relay.go`. Starts/stops per-interface relay
+- `Apply(ctx context.Context, cfg *config.DHCPRelayConfig)` — `relay.go`. Starts/stops per-interface relay
   goroutines.
 - `Stats()` — `relay.go`. Per-interface counters.
 - `RelayStats` — `relay.go`.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -6,12 +6,12 @@ to the interface name.
 
 ## Entry points
 
-- `Manager` — `relay.go:49`.
-- `NewManager()` — `relay.go:55`.
-- `Apply(cfg)` — `relay.go:63`. Starts/stops per-interface relay
+- `Manager` — `relay.go`.
+- `NewManager()` — `relay.go`.
+- `Apply(cfg)` — `relay.go`. Starts/stops per-interface relay
   goroutines.
-- `Stats()` — `relay.go:131`. Per-interface counters.
-- `RelayStats` — `relay.go:33`.
+- `Stats()` — `relay.go`. Per-interface counters.
+- `RelayStats` — `relay.go`.
 
 ## Callers
 

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -6,11 +6,11 @@ Manages Kea DHCPv4/v6 server config and lifecycle. Generates
 
 ## Entry points
 
-- `Manager` — `dhcpserver.go:23`.
-- `New()` — `dhcpserver.go:29`.
-- `Apply(cfg)` — `dhcpserver.go:34`. Regenerates config and restarts.
-- `Clear()` — `dhcpserver.go:76`. Stops Kea and removes config files.
-- `Lease` — `dhcpserver.go:95`. Surfaced to the CLI for `show dhcp
+- `Manager` — `dhcpserver.go`.
+- `New()` — `dhcpserver.go`.
+- `Apply(cfg)` — `dhcpserver.go`. Regenerates config and restarts.
+- `Clear()` — `dhcpserver.go`. Stops Kea and removes config files.
+- `Lease` — `dhcpserver.go`. Surfaced to the CLI for `show dhcp
   server leases`.
 
 ## Callers

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -8,7 +8,7 @@ Manages Kea DHCPv4/v6 server config and lifecycle. Generates
 
 - `Manager` — `dhcpserver.go`.
 - `New()` — `dhcpserver.go`.
-- `Apply(cfg)` — `dhcpserver.go`. Regenerates config and restarts.
+- `Apply(cfg *config.DHCPServerConfig) error` — `dhcpserver.go`. Regenerates config and restarts.
 - `Clear()` — `dhcpserver.go`. Stops Kea and removes config files.
 - `Lease` — `dhcpserver.go`. Surfaced to the CLI for `show dhcp
   server leases`.

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -28,5 +28,7 @@ Manages Kea DHCPv4/v6 server config and lifecycle. Generates
 - If the typed config drops the DHCP server entirely, `Apply()` stops the
   service and removes the config file. Running Kea processes are not
   killed via SIGKILL — systemd manages the lifecycle.
-- Lease queries shell out to Kea's lease-database control channel; if the
-  socket is missing the call returns an empty list (not an error).
+- Lease queries read Kea's CSV lease backends directly:
+  `/var/lib/kea/kea-leases4.csv` and `kea-leases6.csv`. No control
+  channel / socket call. Missing files yield an empty list, not an
+  error.

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -6,13 +6,13 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 ## Entry points
 
-- `Engine` — `engine.go:25`.
-- `New(store, commitFn)` — `engine.go:45`.
-- `Apply(cfg)` — `engine.go:55`. Loads policies, resets temporal
+- `Engine` — `engine.go`.
+- `New(store, commitFn)` — `engine.go`.
+- `Apply(cfg)` — `engine.go`. Loads policies, resets temporal
   state.
-- `HandleEvent(evt)` — `engine.go:64`. Called by the RPM event
+- `HandleEvent(evt)` — `engine.go`. Called by the RPM event
   callback.
-- `CommitFn` — `engine.go:22`. The atomic commit-and-apply hook.
+- `CommitFn` — `engine.go`. The atomic commit-and-apply hook.
 
 ## Callers
 
@@ -24,7 +24,7 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 ## Gotchas
 
-- 30 s policy cooldown (`engine.go:39`). The same policy will not
+- 30 s policy cooldown (`engine.go`). The same policy will not
   trigger more than once in any 30 s window.
 - Temporal `within` clauses keep a sliding window of timestamps per
   (policy, event) pair. Old timestamps are pruned on every evaluation so

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -8,7 +8,7 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 - `Engine` — `engine.go`.
 - `New(store, commitFn)` — `engine.go`.
-- `Apply(cfg)` — `engine.go`. Loads policies, resets temporal
+- `Apply(policies []*config.EventPolicy)` — `engine.go`. Loads policies, resets temporal
   state.
 - `HandleEvent(evt)` — `engine.go`. Called by the RPM event
   callback.

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -5,9 +5,9 @@ feed servers and triggers config recompile when the resolved set changes.
 
 ## Entry points
 
-- `Manager` — `feeds.go:19`.
-- `New(updateFn)` — `feeds.go:36`.
-- `Apply(cfg)` — `feeds.go:62`. Starts/stops per-feed refresh goroutines.
+- `Manager` — `feeds.go`.
+- `New(updateFn)` — `feeds.go`.
+- `Apply(cfg)` — `feeds.go`. Starts/stops per-feed refresh goroutines.
 - `StopAll()`, `FeedInfo` — surfaced to `show security dynamic-address`.
 
 ## Callers

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -7,7 +7,7 @@ feed servers and triggers config recompile when the resolved set changes.
 
 - `Manager` — `feeds.go`.
 - `New(updateFn)` — `feeds.go`.
-- `Apply(cfg)` — `feeds.go`. Starts/stops per-feed refresh goroutines.
+- `Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)` — `feeds.go`. Starts/stops per-feed refresh goroutines.
 - `StopAll()`, `FeedInfo` — surfaced to `show security dynamic-address`.
 
 ## Callers

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -1,27 +1,38 @@
 # pkg/flowexport
 
-NetFlow v9 exporter. Exports session-close events to remote
-collectors with per-zone direction filters and 1-in-N session
-sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE events
-in `pkg/daemon/daemon_flow.go`, not the conntrack GC delete
+NetFlow v9 and IPFIX (NetFlow v10) exporters. Both ship session-close
+events to remote collectors with per-zone direction filters and 1-in-N
+session sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE
+events in `pkg/daemon/daemon_flow.go`, not the conntrack GC delete
 callback. No per-packet sampling path.
 
 ## Entry points
 
+NetFlow v9:
 - `Exporter` — `exporter.go`.
 - `NewExporter(cfg ExportConfig) (*Exporter, error)` — `exporter.go`.
 - `Run(ctx context.Context)` — `exporter.go`. Main export loop.
+- `Exporter.ExportSessionClose(rec, evt)` — emit one record.
+
+IPFIX:
+- `IPFIXExporter` — `ipfix.go`.
+- `NewIPFIXExporter(cfg ExportConfig) (*IPFIXExporter, error)` — `ipfix.go`.
+- `IPFIXExporter.Run(ctx context.Context)` — `ipfix.go`.
+- `IPFIXExporter.ExportSessionClose(rec, evt)` — emit one record.
+
+Shared:
 - `ExportConfig` — `exporter.go`. Resolved per-collector config.
 - `BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig` — `exporter.go`.
 - `SamplingDir` — `exporter.go`. Direction enum.
-- `SessionCloseData` — wire shape built from `logging.EventReader` SESSION_CLOSE records (in `pkg/daemon/daemon_flow.go`), not from `pkg/conntrack`
-  records.
+- `SessionCloseData` — wire shape built from `logging.EventReader`
+  SESSION_CLOSE records (in `pkg/daemon/daemon_flow.go`).
 
 ## Callers
 
-`pkg/daemon/daemon_flow.go::startFlowExporter` and
-`startIPFIXExporter` call `Exporter.ExportSessionClose()` from the
-`logging.EventReader` SESSION_CLOSE callback.
+`pkg/daemon/daemon_flow.go::startFlowExporter` calls
+`Exporter.ExportSessionClose()` for NetFlow v9; `startIPFIXExporter`
+calls `IPFIXExporter.ExportSessionClose()` for IPFIX. Both run from
+the `logging.EventReader` SESSION_CLOSE callback.
 
 ## Dependencies
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -35,8 +35,9 @@ callback. No per-packet sampling path.
 - NetFlow v9 templates refresh every 60 s. If a collector restarts and
   misses a refresh it sees opaque records until the next cycle —
   configure the collector to handle template re-resolution.
-- Per-zone batches flush on either timeout or batch-full, whichever
-  fires first.
+- Two batches are maintained: `batchV4` and `batchV6` (split by
+  family, not by zone). Both flush on a 100 ms ticker or on
+  shutdown.
 - `ExportSessionClose` builds the flow record synchronously from the
   event-reader callback. The export goroutine (started in `Run(ctx)`)
   is what actually transmits and refreshes templates; record assembly

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -14,8 +14,8 @@ callback. No per-packet sampling path.
 - `ExportConfig` — `exporter.go`. Resolved per-collector config.
 - `BuildExportConfig(cfg)` — `exporter.go`.
 - `SamplingDir` — `exporter.go`. Direction enum.
-- `SessionCloseData` — wire shape consumed from `pkg/conntrack` delete
-  callbacks.
+- `SessionCloseData` — parsed session-close payload assembled from
+  `logging.EventReader` records before export.
 
 ## Callers
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -2,9 +2,9 @@
 
 NetFlow v9 exporter. Exports session-close events to remote
 collectors with per-zone direction filters and 1-in-N session
-sampling. (Wired only from session close — `pkg/daemon` calls
-`Exporter.ExportSessionClose` from the GC delete callback. No
-per-packet sampling path.)
+sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE events
+in `pkg/daemon/daemon_flow.go`, not the conntrack GC delete
+callback. No per-packet sampling path.
 
 ## Entry points
 
@@ -19,7 +19,9 @@ per-packet sampling path.)
 
 ## Callers
 
-`pkg/daemon` calls `ExportSessionClose()` from the session-close hook.
+`pkg/daemon/daemon_flow.go::startFlowExporter` and
+`startIPFIXExporter` call `Exporter.ExportSessionClose()` from the
+`logging.EventReader` SESSION_CLOSE callback.
 
 ## Dependencies
 
@@ -35,5 +37,7 @@ per-packet sampling path.)
   configure the collector to handle template re-resolution.
 - Per-zone batches flush on either timeout or batch-full, whichever
   fires first.
-- The package never blocks the GC loop — record assembly is offloaded to
-  the exporter's own goroutine.
+- `ExportSessionClose` builds the flow record synchronously from the
+  event-reader callback. The export goroutine (started in `Run(ctx)`)
+  is what actually transmits and refreshes templates; record assembly
+  itself isn't offloaded.

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -6,12 +6,12 @@ and 1-in-N sampling.
 
 ## Entry points
 
-- `Exporter` — `exporter.go:106`.
-- `NewExporter(cfg)` — `exporter.go:109`.
-- `Run(ctx)` — `exporter.go:111`. Main export loop.
-- `ExportConfig` — `exporter.go:23`. Resolved per-collector config.
-- `BuildExportConfig(cfg)` — `exporter.go:42`.
-- `SamplingDir` — `exporter.go:17`. Direction enum.
+- `Exporter` — `exporter.go`.
+- `NewExporter(cfg)` — `exporter.go`.
+- `Run(ctx)` — `exporter.go`. Main export loop.
+- `ExportConfig` — `exporter.go`. Resolved per-collector config.
+- `BuildExportConfig(cfg)` — `exporter.go`.
+- `SamplingDir` — `exporter.go`. Direction enum.
 - `SessionCloseData` — wire shape consumed from `pkg/conntrack` delete
   callbacks.
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -9,13 +9,13 @@ callback. No per-packet sampling path.
 ## Entry points
 
 - `Exporter` — `exporter.go`.
-- `NewExporter(cfg)` — `exporter.go`.
-- `Run(ctx)` — `exporter.go`. Main export loop.
+- `NewExporter(cfg ExportConfig) (*Exporter, error)` — `exporter.go`.
+- `Run(ctx context.Context)` — `exporter.go`. Main export loop.
 - `ExportConfig` — `exporter.go`. Resolved per-collector config.
-- `BuildExportConfig(cfg)` — `exporter.go`.
+- `BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig` — `exporter.go`.
 - `SamplingDir` — `exporter.go`. Direction enum.
-- `SessionCloseData` — wire shape consumed from `pkg/conntrack` delete
-  callbacks.
+- `SessionCloseData` — wire shape built from `logging.EventReader` SESSION_CLOSE records (in `pkg/daemon/daemon_flow.go`), not from `pkg/conntrack`
+  records.
 
 ## Callers
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -1,8 +1,10 @@
 # pkg/flowexport
 
-NetFlow v9 exporter. Exports session-close events (and optional
-per-packet samples) to remote collectors with per-zone direction filters
-and 1-in-N sampling.
+NetFlow v9 exporter. Exports session-close events to remote
+collectors with per-zone direction filters and 1-in-N session
+sampling. (Wired only from session close — `pkg/daemon` calls
+`Exporter.ExportSessionClose` from the GC delete callback. No
+per-packet sampling path.)
 
 ## Entry points
 

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -12,8 +12,8 @@ FRR, which then owns the kernel route table.
 ## Entry points
 
 - `Manager` — `frr.go`.
-- `New()` — `frr.go`. Defaults to `/etc/frr/frr.conf`.
-- `ApplyFull(cfg)` — apply full config (idempotent diff against on-disk).
+- `New() *Manager` — `frr.go`. Defaults to `/etc/frr/frr.conf`.
+- `ApplyFull(fc *FullConfig) error` — apply full config (idempotent diff against on-disk).
 - `FullConfig` — `frr.go`.
 - `InstanceConfig` — `frr.go`. One per-VRF.
 - State queries (vtysh): `GetRIPRoutes`, `GetISISAdjacency`,

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -11,11 +11,11 @@ FRR, which then owns the kernel route table.
 
 ## Entry points
 
-- `Manager` — `frr.go:29`.
-- `New()` — `frr.go:34`. Defaults to `/etc/frr/frr.conf`.
+- `Manager` — `frr.go`.
+- `New()` — `frr.go`. Defaults to `/etc/frr/frr.conf`.
 - `ApplyFull(cfg)` — apply full config (idempotent diff against on-disk).
-- `FullConfig` — `frr.go:60`.
-- `InstanceConfig` — `frr.go:41`. One per-VRF.
+- `FullConfig` — `frr.go`.
+- `InstanceConfig` — `frr.go`. One per-VRF.
 - State queries (vtysh): `GetRIPRoutes` (frr.go:141), `GetISISAdjacency`,
   `GetBGPNeighbors`, …
 

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -16,8 +16,10 @@ FRR, which then owns the kernel route table.
 - `ApplyFull(cfg)` — apply full config (idempotent diff against on-disk).
 - `FullConfig` — `frr.go`.
 - `InstanceConfig` — `frr.go`. One per-VRF.
-- State queries (vtysh): `GetRIPRoutes` (frr.go), `GetISISAdjacency`,
-  `GetBGPNeighbors`, …
+- State queries (vtysh): `GetRIPRoutes`, `GetISISAdjacency`,
+  `GetBGPSummary`, `GetBGPNeighborDetail`, `GetBGPRoutes`,
+  `GetBGPNeighborReceivedRoutes`, `GetBGPNeighborAdvertisedRoutes`, …
+  All in `frr.go`.
 
 ## Callers
 

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -16,7 +16,7 @@ FRR, which then owns the kernel route table.
 - `ApplyFull(cfg)` — apply full config (idempotent diff against on-disk).
 - `FullConfig` — `frr.go`.
 - `InstanceConfig` — `frr.go`. One per-VRF.
-- State queries (vtysh): `GetRIPRoutes` (frr.go:141), `GetISISAdjacency`,
+- State queries (vtysh): `GetRIPRoutes` (frr.go), `GetISISAdjacency`,
   `GetBGPNeighbors`, …
 
 ## Callers

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -7,11 +7,11 @@ fixed-width table.
 
 ## Entry points
 
-- `ForwardingStatus` — `fwdstatus.go:39`. Flat status struct.
-- `Format(s ForwardingStatus) string` — `fwdstatus.go:74`. Junos-style
+- `ForwardingStatus` — `fwdstatus.go`. Flat status struct.
+- `Format(s ForwardingStatus) string` — `fwdstatus.go`. Junos-style
   one-screen render.
-- `State` — `fwdstatus.go:14`. Online / Degraded / Unknown.
-- `CPUMode` — `fwdstatus.go:24`. Workers vs. eBPF.
+- `State` — `fwdstatus.go`. Online / Degraded / Unknown.
+- `CPUMode` — `fwdstatus.go`. Workers vs. eBPF.
 
 ## Callers
 

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -19,8 +19,10 @@ fixed-width table.
 
 ## Dependencies
 
-None internal. Pure formatting on top of the standard library — kept
-dependency-free to avoid a circular import via `pkg/cli` or `pkg/grpcapi`.
+`pkg/dataplane` and `pkg/dataplane/userspace` (used by `Sampler` and
+`builder.go` for live BPF map / userspace-helper stats). The package
+deliberately avoids importing `pkg/cli` or `pkg/grpcapi` to prevent
+circular imports — those are the consumers, not dependencies.
 
 ## Gotchas
 

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -8,7 +8,7 @@ fixed-width table.
 ## Entry points
 
 - `ForwardingStatus` — `fwdstatus.go`. Flat status struct.
-- `Format(s ForwardingStatus) string` — `fwdstatus.go`. Junos-style
+- `Format(fs *ForwardingStatus) string` — `fwdstatus.go`. Junos-style
   one-screen render.
 - `State` — `fwdstatus.go`. Online / Degraded / Unknown.
 - `CPUMode` — `fwdstatus.go`. Workers vs. eBPF.

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -26,14 +26,16 @@ circular imports — those are the consumers, not dependencies.
 
 ## Gotchas
 
-- The CPU windows are tracked externally by a `Sampler` (a ring buffer
-  the caller maintains). This package consumes already-windowed values
-  and renders them; it doesn't sample.
-- The eBPF mode renders the worker-thread row as `N/A — eBPF path has no
-  worker threads`. Don't add code that fakes a worker entry there; the
-  N/A is informative.
+- CPU samples are collected by `Sampler` (`sampler.go`), which owns
+  its own ring buffer and timer goroutine started via
+  `Sampler.Start(ctx)`. The renderer consumes already-windowed
+  values from the Sampler.
+- The eBPF mode renders the worker-thread row as `N/A — eBPF path
+  has no worker threads`. Don't add code that fakes a worker entry
+  there; the N/A is informative.
 - Daemon CPU is per-core percent (can exceed 100 on a multi-core
-  daemon); worker CPU is `Σ(thread_cpu_ns) / Σ(wall_ns)` and is bounded
-  to `n_workers * 100`.
+  daemon); worker CPU is computed as `Σ(thread_cpu_ns) / Σ(wall_ns)`,
+  i.e. a per-worker average effectively bounded around 100%, not a
+  multi-core sum.
 - Windows shorter than the daemon uptime render as `-` to avoid lying
   about a 5 m average that hasn't elapsed yet.

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -8,9 +8,9 @@ tab completion. The wire schema is `proto/xpf/v1`.
 
 ## Entry points
 
-- `Server` — `server.go:69`.
-- `Config` — `server.go:38`. Dependency injection point.
-- `NewServer(cfg)` — `server.go:83`.
+- `Server` — `server.go`.
+- `Config` — `server.go`. Dependency injection point.
+- `NewServer(cfg)` — `server.go`.
 - `Run(ctx)` — starts the listener.
 - Tab completion: `Complete` RPC, backed by `pkg/cmdtree`.
 

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -10,8 +10,9 @@ tab completion. The wire schema is `proto/xpf/v1`.
 
 - `Server` — `server.go`.
 - `Config` — `server.go`. Dependency injection point.
-- `NewServer(cfg)` — `server.go`.
-- `Run(ctx)` — starts the listener.
+- `NewServer(addr string, cfg Config) *Server` — `server.go`.
+- `Run(ctx context.Context) error` — `server.go`. Starts the listener
+  and blocks until the context is cancelled.
 - Tab completion: `Complete` RPC, backed by `pkg/cmdtree`.
 
 ## Callers

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -10,7 +10,7 @@ interface IDs) and queries SA/SP state via `swanctl`.
 - `New()` — `ipsec.go`. Default swanctl conf dir
   `/etc/swanctl/conf.d`.
 - `Apply(ipsecCfg *config.IPsecConfig) error` — `ipsec.go`. Generate config and reload strongSwan.
-- `Clear()` — `ipsec.go`.
+- `Clear() error` — `ipsec.go`.
 - `SAStatus`, `TerminateAllSAs`, `InitiateConnection`.
 
 ## Callers

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -9,7 +9,7 @@ interface IDs) and queries SA/SP state via `swanctl`.
 - `Manager` — `ipsec.go`.
 - `New()` — `ipsec.go`. Default swanctl conf dir
   `/etc/swanctl/conf.d`.
-- `Apply(cfg)` — `ipsec.go`. Generate config and reload strongSwan.
+- `Apply(ipsecCfg *config.IPsecConfig) error` — `ipsec.go`. Generate config and reload strongSwan.
 - `Clear()` — `ipsec.go`.
 - `SAStatus`, `TerminateAllSAs`, `InitiateConnection`.
 

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -6,11 +6,11 @@ interface IDs) and queries SA/SP state via `swanctl`.
 
 ## Entry points
 
-- `Manager` — `ipsec.go:25`.
-- `New()` — `ipsec.go:31`. Default swanctl conf dir
+- `Manager` — `ipsec.go`.
+- `New()` — `ipsec.go`. Default swanctl conf dir
   `/etc/swanctl/conf.d`.
-- `Apply(cfg)` — `ipsec.go:40`. Generate config and reload strongSwan.
-- `Clear()` — `ipsec.go:69`.
+- `Apply(cfg)` — `ipsec.go`. Generate config and reload strongSwan.
+- `Clear()` — `ipsec.go`.
 - `SAStatus`, `TerminateAllSAs`, `InitiateConnection`.
 
 ## Callers

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -6,13 +6,13 @@ entries by TTL.
 
 ## Entry points
 
-- `Manager` — `lldp.go:84`.
-- `Neighbor` — `lldp.go:55`. Chassis ID, port ID, TTL, system name and
+- `Manager` — `lldp.go`.
+- `Neighbor` — `lldp.go`. Chassis ID, port ID, TTL, system name and
   description.
-- `New()` — `lldp.go:92`.
-- `Apply(cfg)` — `lldp.go:99`.
-- `Stop()` — `lldp.go:159`.
-- `Neighbors()` — `lldp.go:171`. Snapshot consumed by `show lldp
+- `New()` — `lldp.go`.
+- `Apply(cfg)` — `lldp.go`.
+- `Stop()` — `lldp.go`.
+- `Neighbors()` — `lldp.go`. Snapshot consumed by `show lldp
   neighbors`.
 
 ## Callers

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -10,7 +10,7 @@ entries by TTL.
 - `Neighbor` — `lldp.go`. Chassis ID, port ID, TTL, system name and
   description.
 - `New()` — `lldp.go`.
-- `Apply(cfg)` — `lldp.go`.
+- `Apply(ctx context.Context, cfg *LLDPConfig)` — `lldp.go`.
 - `Stop()` — `lldp.go`.
 - `Neighbors()` — `lldp.go`. Snapshot consumed by `show lldp
   neighbors`.

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -10,8 +10,9 @@ reports.
 
 - `SyslogSlogHandler` — `slog_handler.go`. Slog handler that
   fans events out to configured syslog clients.
-- `EventBuffer` — `eventbuf.go`. Bounded ring buffer (256 entries
-  default).
+- `EventBuffer` — `eventbuf.go`. `NewEventBuffer(size int)` — the
+  caller picks the size; `pkg/daemon/daemon_run.go` constructs it
+  with 1000. Bounded ring; full → drops the oldest entry.
 - `Subscription` — `eventbuf.go`. A consumer of the event ring.
 - `LocalLogWriter` — `locallog.go`. File-based writer with
   facility/severity filters.

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -8,14 +8,14 @@ reports.
 
 ## Entry points
 
-- `SyslogSlogHandler` — `slog_handler.go:13`. Slog handler that
+- `SyslogSlogHandler` — `slog_handler.go`. Slog handler that
   fans events out to configured syslog clients.
-- `EventBuffer` — `eventbuf.go:38`. Bounded ring buffer (256 entries
+- `EventBuffer` — `eventbuf.go`. Bounded ring buffer (256 entries
   default).
-- `Subscription` — `eventbuf.go:51`. A consumer of the event ring.
-- `LocalLogWriter` — `locallog.go:14`. File-based writer with
+- `Subscription` — `eventbuf.go`. A consumer of the event ring.
+- `LocalLogWriter` — `locallog.go`. File-based writer with
   facility/severity filters.
-- `SessionAggregator` — `aggregator.go:14`. Top-N per-IP rollups.
+- `SessionAggregator` — `aggregator.go`. Top-N per-IP rollups.
 
 ## Callers
 

--- a/pkg/monitoriface/README.md
+++ b/pkg/monitoriface/README.md
@@ -12,9 +12,9 @@ packets, bytes, delta, rate.
 - `UserspaceSnapshot` — `monitor.go`. Per-binding XSK stats.
 - `CounterReader` interface — `monitor.go`. Abstracts BPF map access
   so tests can inject a fake.
-- `ReadSnapshot()` — `monitor.go`.
-- `RenderSingleInterface()` — `monitor.go`.
-- `RenderTrafficSummary()` — `monitor.go`.
+- `ReadSnapshot(counterReader CounterReader, statusReader StatusReader, kernelName string) (Snapshot, error)` — `monitor.go`.
+- `RenderSingleInterface(w io.Writer, hostname, displayName, kernelName string, snap, prev, baseline *Snapshot, startTime time.Time)` — `monitor.go`.
+- `RenderTrafficSummary(w io.Writer, hostname string, names []string, kernelNames map[string]string, snaps, prevSnaps map[string]*Snapshot, mode SummaryMode, startTime time.Time)` — `monitor.go`.
 
 ## Callers
 

--- a/pkg/monitoriface/README.md
+++ b/pkg/monitoriface/README.md
@@ -7,14 +7,14 @@ packets, bytes, delta, rate.
 
 ## Entry points
 
-- `Snapshot` — `monitor.go:35`. Kernel counters (Rx/TxBytes, errors,
+- `Snapshot` — `monitor.go`. Kernel counters (Rx/TxBytes, errors,
   collisions, etc.).
-- `UserspaceSnapshot` — `monitor.go:53`. Per-binding XSK stats.
-- `CounterReader` interface — `monitor.go:18`. Abstracts BPF map access
+- `UserspaceSnapshot` — `monitor.go`. Per-binding XSK stats.
+- `CounterReader` interface — `monitor.go`. Abstracts BPF map access
   so tests can inject a fake.
-- `ReadSnapshot()` — `monitor.go:465`.
-- `RenderSingleInterface()` — `monitor.go:536`.
-- `RenderTrafficSummary()` — `monitor.go:714`.
+- `ReadSnapshot()` — `monitor.go`.
+- `RenderSingleInterface()` — `monitor.go`.
+- `RenderTrafficSummary()` — `monitor.go`.
 
 ## Callers
 

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -8,13 +8,13 @@ changed.
 
 ## Entry points
 
-- `Manager` — `networkd.go:51`.
-- `InterfaceConfig` — `networkd.go:22`. MAC, addresses, bonding, VLAN
+- `Manager` — `networkd.go`.
+- `InterfaceConfig` — `networkd.go`. MAC, addresses, bonding, VLAN
   parent, VRF binding, description.
-- `New()` — `networkd.go:56`.
-- `Apply(...)` — `networkd.go:66`.
-- `Clear()` — `networkd.go:201`.
-- `FindExternallyManaged()` — `networkd.go:225`. Detects networkd files
+- `New()` — `networkd.go`.
+- `Apply(...)` — `networkd.go`.
+- `Clear()` — `networkd.go`.
+- `FindExternallyManaged()` — `networkd.go`. Detects networkd files
   the daemon doesn't own.
 
 ## Callers

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -14,7 +14,7 @@ changed.
 - `New()` — `networkd.go`.
 - `Apply(...)` — `networkd.go`.
 - `Clear()` — `networkd.go`.
-- `FindExternallyManaged()` — `networkd.go`. Detects networkd files
+- `FindExternallyManaged(dir string) map[string]bool` — `networkd.go`. Detects networkd files
   the daemon doesn't own.
 
 ## Callers

--- a/pkg/nftables/README.md
+++ b/pkg/nftables/README.md
@@ -8,10 +8,10 @@ moment of takeover, killing the user-visible TCP session.
 
 ## Entry points
 
-- `InstallRSTSuppression()` — `rst_suppress.go:36`. Atomic
+- `InstallRSTSuppression()` — `rst_suppress.go`. Atomic
   delete-then-create within a single netlink batch, so there is no
   window where the old table is gone but the new one isn't installed.
-- `RemoveRSTSuppression()` — `rst_suppress.go:60`.
+- `RemoveRSTSuppression()` — `rst_suppress.go`.
 
 ## Callers
 

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -6,15 +6,15 @@ burst, goodbye RAs, and re-burst recovery after RETH MAC link-cycle.
 
 ## Entry points
 
-- `Manager` — `ra.go:17`.
-- `New()` — `ra.go:23`.
-- `Apply(cfg)` — `ra.go:31`. Starts/stops per-interface senders.
-- `Withdraw(ifname)` — `ra.go:100`. Stop sending on one interface.
-- `ResendBurst(ifname)` — `ra.go:117`. Re-send the startup burst (used
+- `Manager` — `ra.go`.
+- `New()` — `ra.go`.
+- `Apply(cfg)` — `ra.go`. Starts/stops per-interface senders.
+- `Withdraw(ifname)` — `ra.go`. Stop sending on one interface.
+- `ResendBurst(ifname)` — `ra.go`. Re-send the startup burst (used
   after a link cycle).
-- `WithdrawOnce(ifname)` — `ra.go:150`. Send a single goodbye RA
+- `WithdrawOnce(ifname)` — `ra.go`. Send a single goodbye RA
   (lifetime=0).
-- `Status()` — `ra.go:210`. Per-interface SenderInfo.
+- `Status()` — `ra.go`. Per-interface SenderInfo.
 
 ## Callers
 

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -8,12 +8,15 @@ burst, goodbye RAs, and re-burst recovery after RETH MAC link-cycle.
 
 - `Manager` — `ra.go`.
 - `New()` — `ra.go`.
-- `Apply(cfg)` — `ra.go`. Starts/stops per-interface senders.
-- `Withdraw(ifname)` — `ra.go`. Stop sending on one interface.
-- `ResendBurst(ifname)` — `ra.go`. Re-send the startup burst (used
-  after a link cycle).
-- `WithdrawOnce(ifname)` — `ra.go`. Send a single goodbye RA
-  (lifetime=0).
+- `Apply(configs []*config.RAInterfaceConfig) error` — `ra.go`.
+  Starts/stops per-interface senders.
+- `Withdraw() error` — `ra.go`. Stops every sender.
+- `ResendBurst()` — `ra.go`. Re-sends the startup burst (used after a
+  link cycle) on every active sender.
+- `WithdrawInterfaces(names []string)` — `ra.go`. Stops senders by
+  interface name.
+- `WithdrawOnce(configs []*config.RAInterfaceConfig)` — `ra.go`.
+  Sends a single goodbye RA (lifetime=0) on each listed interface.
 - `Status()` — `ra.go`. Per-interface SenderInfo.
 
 ## Callers

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -1,8 +1,9 @@
 # pkg/routing
 
 Manages static routes, GRE tunnels, VRFs, XFRM interfaces, and tunnel
-keepalive probes via netlink. Tracks link state for monitored interfaces
-and exposes per-tunnel RTT/loss metrics for weight-based failover.
+keepalive probes via netlink. Tracks link state for monitored
+interfaces and exposes per-tunnel up/down state via `KeepaliveState`
+for weight-based failover.
 
 This package owns netlink object lifecycles. FRR (`pkg/frr`) owns the
 kernel route table; this package owns the *interfaces* routes hang off

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -10,16 +10,16 @@ of.
 
 ## Entry points
 
-- `Manager` — `routing.go:43`.
-- `VRFSpec` — `routing.go:71`.
-- `KeepaliveState` — `routing.go:24`. Per-tunnel probe status.
-- `TunnelStatus` — `routing.go:959`.
-- `RouteEntry` — `routing.go:1032`.
-- `InterfaceMonitorStatus` — `routing.go:36`.
-- `New()` — `routing.go:89`.
-- `ApplyTunnels(cfg)` — `routing.go:494`.
-- `ReconcileVRFs(cfg)` — `routing.go:190`.
-- `ApplyXfrmi(cfg)` — `routing.go:863`.
+- `Manager` — `routing.go`.
+- `VRFSpec` — `routing.go`.
+- `KeepaliveState` — `routing.go`. Per-tunnel probe status.
+- `TunnelStatus` — `routing.go`.
+- `RouteEntry` — `routing.go`.
+- `InterfaceMonitorStatus` — `routing.go`.
+- `New()` — `routing.go`.
+- `ApplyTunnels(cfg)` — `routing.go`.
+- `ReconcileVRFs(cfg)` — `routing.go`.
+- `ApplyXfrmi(cfg)` — `routing.go`.
 
 ## Callers
 

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -31,9 +31,15 @@ of.
 
 ## ip-rule priorities
 
-- 33000–33099: rib-group inter-VRF leaking (`from all lookup <table>`).
-- 34000–34999: PBR (firewall-filter `routing-instance` action).
-- main table at 32766 — both ranges sit after main intentionally.
+- `100–199`: next-table inter-VRF leaking (static routes with
+  `next-table` directive). `nextTableRulePriority` in `routing.go`.
+- `31000–31999`: PBR (firewall-filter `routing-instance` action).
+  `pbrRulePriority` in `routing.go`.
+- `33000–33099`: rib-group inter-VRF leaking (`from all lookup
+  <table>`).
+- main table at `32766`. The next-table range sits **before** main
+  (lower priority value = higher priority). PBR sits before main as
+  well; rib-group sits after.
 
 ## Gotchas
 

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -16,10 +16,10 @@ of.
 - `TunnelStatus` — `routing.go`.
 - `RouteEntry` — `routing.go`.
 - `InterfaceMonitorStatus` — `routing.go`.
-- `New()` — `routing.go`.
-- `ApplyTunnels(cfg)` — `routing.go`.
-- `ReconcileVRFs(cfg)` — `routing.go`.
-- `ApplyXfrmi(cfg)` — `routing.go`.
+- `New() (*Manager, error)` — `routing.go`.
+- `ApplyTunnels(tunnels []*config.TunnelConfig) error` — `routing.go`.
+- `ReconcileVRFs(desired []VRFSpec) error` — `routing.go`.
+- `ApplyXfrmi(vpns map[string]*config.IPsecVPN) error` — `routing.go`.
 
 ## Callers
 

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -6,15 +6,15 @@ to VRFs via `SO_BINDTODEVICE` when configured.
 
 ## Entry points
 
-- `Manager` — `rpm.go:76`.
-- `ProbeResult` — `rpm.go:48`. Per-test metrics (RTT, jitter,
+- `Manager` — `rpm.go`.
+- `ProbeResult` — `rpm.go`. Per-test metrics (RTT, jitter,
   success/fail counters).
-- `Event` — `rpm.go:66`. `test_failed`, `probe_failed`, `test_completed`.
-- `New()` — `rpm.go:101`.
-- `Apply(cfg)` — `rpm.go:108`.
-- `StopAll()` — `rpm.go:141`.
-- `Results()` — `rpm.go:153`.
-- `SetEventCallback(fn)` — `rpm.go:85`.
+- `Event` — `rpm.go`. `test_failed`, `probe_failed`, `test_completed`.
+- `New()` — `rpm.go`.
+- `Apply(cfg)` — `rpm.go`.
+- `StopAll()` — `rpm.go`.
+- `Results()` — `rpm.go`.
+- `SetEventCallback(fn)` — `rpm.go`.
 
 ## Callers
 

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -11,7 +11,7 @@ to VRFs via `SO_BINDTODEVICE` when configured.
   success/fail counters).
 - `Event` — `rpm.go`. `test_failed`, `probe_failed`, `test_completed`.
 - `New()` — `rpm.go`.
-- `Apply(cfg)` — `rpm.go`.
+- `Apply(ctx context.Context, cfg *config.RPMConfig)` — `rpm.go`.
 - `StopAll()` — `rpm.go`.
 - `Results()` — `rpm.go`.
 - `SetEventCallback(fn)` — `rpm.go`.

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -8,14 +8,14 @@ during specific windows.
 
 ## Entry points
 
-- `Scheduler` — `scheduler.go:14`.
-- `New(cfgs, updateFn)` — `scheduler.go:24`. The callback fires only on
+- `Scheduler` — `scheduler.go`.
+- `New(cfgs, updateFn)` — `scheduler.go`. The callback fires only on
   state change, not every tick.
-- `Run(ctx)` — `scheduler.go:37`.
-- `IsActive(name)` — `scheduler.go:54`.
-- `ActiveState()` — `scheduler.go:61`. Snapshot of every scheduler's
+- `Run(ctx)` — `scheduler.go`.
+- `IsActive(name)` — `scheduler.go`.
+- `ActiveState()` — `scheduler.go`. Snapshot of every scheduler's
   active flag.
-- `Update(cfgs)` — `scheduler.go:72`.
+- `Update(cfgs)` — `scheduler.go`.
 
 ## Callers
 

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -9,18 +9,15 @@ during specific windows.
 ## Entry points
 
 - `Scheduler` — `scheduler.go`.
-- `New(schedulers map[string]*config.SchedulerConfig, updateFn func(map[string]bool)) *Scheduler` — `scheduler.go`.
+- `New(schedulers map[string]*config.SchedulerConfig, updateFn func(map[string]bool)) *Scheduler` —
+  `scheduler.go`. The `updateFn` callback fires only on state change,
+  not every tick.
 - `Run(ctx context.Context)` — `scheduler.go`.
 - `IsActive(name string) bool` — `scheduler.go`.
-- `ActiveState() map[string]bool` — `scheduler.go`.
-- `Update(schedulers map[string]*config.SchedulerConfig)` — `scheduler.go`.
-- `New(cfgs, updateFn)` — `scheduler.go`. The callback fires only on
-  state change, not every tick.
-- `Run(ctx)` — `scheduler.go`.
-- `IsActive(name)` — `scheduler.go`.
-- `ActiveState()` — `scheduler.go`. Snapshot of every scheduler's
-  active flag.
-- `Update(cfgs)` — `scheduler.go`.
+- `ActiveState() map[string]bool` — `scheduler.go`. Snapshot of every
+  scheduler's active flag.
+- `Update(schedulers map[string]*config.SchedulerConfig)` —
+  `scheduler.go`.
 
 ## Callers
 

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -9,6 +9,11 @@ during specific windows.
 ## Entry points
 
 - `Scheduler` — `scheduler.go`.
+- `New(schedulers map[string]*config.SchedulerConfig, updateFn func(map[string]bool)) *Scheduler` — `scheduler.go`.
+- `Run(ctx context.Context)` — `scheduler.go`.
+- `IsActive(name string) bool` — `scheduler.go`.
+- `ActiveState() map[string]bool` — `scheduler.go`.
+- `Update(schedulers map[string]*config.SchedulerConfig)` — `scheduler.go`.
 - `New(cfgs, updateFn)` — `scheduler.go`. The callback fires only on
   state change, not every tick.
 - `Run(ctx)` — `scheduler.go`.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -11,7 +11,7 @@ link-down traps. ASN.1 BER encoding is hand-coded, no external library.
   admin/oper status, octets, errors, drops).
 - `V3UserDisplay` — `v3.go`.
 - `NewAgent(cfg *config.SNMPConfig) *Agent` — `agent.go`.
-- `Start()` — `agent.go`.
+- `Start(ctx context.Context) error` — `agent.go`. Blocks until ctx cancelled.
 - `Stop()` — `agent.go`.
 - `SetIfDataFn(fn)` — `agent.go`. Caller-supplied accessor for live
   interface data.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -9,13 +9,13 @@ link-down traps. ASN.1 BER encoding is hand-coded, no external library.
 - `Agent` — `agent.go`.
 - `IfData` — `agent.go`. Per-interface metrics (name, MTU, speed,
   admin/oper status, octets, errors, drops).
-- `V3UserDisplay` — `v3.go:732`.
+- `V3UserDisplay` — `v3.go`.
 - `NewAgent()` — `agent.go`.
 - `Start()` — `agent.go`.
 - `Stop()` — `agent.go`.
 - `SetIfDataFn(fn)` — `agent.go`. Caller-supplied accessor for live
   interface data.
-- `NotifyLinkUp` / `NotifyLinkDown` — `traps.go:123,128`.
+- `NotifyLinkUp` / `NotifyLinkDown` — `traps.go`.
 
 ## Callers
 

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -6,14 +6,14 @@ link-down traps. ASN.1 BER encoding is hand-coded, no external library.
 
 ## Entry points
 
-- `Agent` — `agent.go:122`.
-- `IfData` — `agent.go:96`. Per-interface metrics (name, MTU, speed,
+- `Agent` — `agent.go`.
+- `IfData` — `agent.go`. Per-interface metrics (name, MTU, speed,
   admin/oper status, octets, errors, drops).
 - `V3UserDisplay` — `v3.go:732`.
-- `NewAgent()` — `agent.go:136`.
-- `Start()` — `agent.go:180`.
-- `Stop()` — `agent.go:226`.
-- `SetIfDataFn(fn)` — `agent.go:164`. Caller-supplied accessor for live
+- `NewAgent()` — `agent.go`.
+- `Start()` — `agent.go`.
+- `Stop()` — `agent.go`.
+- `SetIfDataFn(fn)` — `agent.go`. Caller-supplied accessor for live
   interface data.
 - `NotifyLinkUp` / `NotifyLinkDown` — `traps.go:123,128`.
 

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -10,7 +10,7 @@ link-down traps. ASN.1 BER encoding is hand-coded, no external library.
 - `IfData` — `agent.go`. Per-interface metrics (name, MTU, speed,
   admin/oper status, octets, errors, drops).
 - `V3UserDisplay` — `v3.go`.
-- `NewAgent()` — `agent.go`.
+- `NewAgent(cfg *config.SNMPConfig) *Agent` — `agent.go`.
 - `Start()` — `agent.go`.
 - `Stop()` — `agent.go`.
 - `SetIfDataFn(fn)` — `agent.go`. Caller-supplied accessor for live

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -17,7 +17,7 @@ This is the package that drives chassis-cluster failover.
 - `NewManager()` — `manager.go`.
 - `Start()` — `manager.go`.
 - `Stop()` — `manager.go`.
-- `UpdateInstances(cfg)` — `manager.go`.
+- `UpdateInstances(desired []*Instance) error` — `manager.go`.
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all
   instances.
 - `ResignRG(rgID int)` — `manager.go`. Forces this node out of master

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -16,9 +16,10 @@ This is the package that drives chassis-cluster failover.
 - `VRRPEvent` — `instance.go`. INIT / BACKUP / MASTER transitions.
 - `NewManager()` — `manager.go`.
 - `Start(ctx context.Context) error` — `manager.go`. **Returns
-  immediately** after wiring `m.cancel`; per-instance goroutines run
-  independently. Doesn't block. Stop them via `Stop()` or by
-  cancelling the parent context.
+  immediately** after wiring `m.cancel`. Per-instance goroutines run
+  independently and observe their own `stopCh`, **not** the parent
+  context. Stop them via `Stop()`, which closes each instance's
+  `stopCh`.
 - `Stop()` — `manager.go`.
 - `UpdateInstances(desired []*Instance) error` — `manager.go`.
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -15,7 +15,10 @@ This is the package that drives chassis-cluster failover.
   priority, preempt, timers.
 - `VRRPEvent` — `instance.go`. INIT / BACKUP / MASTER transitions.
 - `NewManager()` — `manager.go`.
-- `Start(ctx context.Context) error` — `manager.go`. Blocks until ctx cancelled.
+- `Start(ctx context.Context) error` — `manager.go`. **Returns
+  immediately** after wiring `m.cancel`; per-instance goroutines run
+  independently. Doesn't block. Stop them via `Stop()` or by
+  cancelling the parent context.
 - `Stop()` — `manager.go`.
 - `UpdateInstances(desired []*Instance) error` — `manager.go`.
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -18,8 +18,10 @@ This is the package that drives chassis-cluster failover.
 - `Start()` — `manager.go`.
 - `Stop()` — `manager.go`.
 - `UpdateInstances(cfg)` — `manager.go`.
-- `ReleaseSyncHold(rg)` — `manager.go`.
-- `ResignRG(rg)` — `manager.go`.
+- `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all
+  instances.
+- `ResignRG(rgID int)` — `manager.go`. Forces this node out of master
+  for the given redundancy group ID.
 
 ## Callers
 

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -9,17 +9,17 @@ This is the package that drives chassis-cluster failover.
 
 ## Entry points
 
-- `Manager` — `manager.go:25`. Owns every `Instance` goroutine, the event
+- `Manager` — `manager.go`. Owns every `Instance` goroutine, the event
   channel, and sync-hold state.
-- `Instance` — `vrrp.go:13`. Per-RG config: interface, group ID, VIPs,
+- `Instance` — `vrrp.go`. Per-RG config: interface, group ID, VIPs,
   priority, preempt, timers.
-- `VRRPEvent` — `instance.go:44`. INIT / BACKUP / MASTER transitions.
-- `NewManager()` — `manager.go:47`.
-- `Start()` — `manager.go:55`.
-- `Stop()` — `manager.go:62`.
-- `UpdateInstances(cfg)` — `manager.go:169`.
-- `ReleaseSyncHold(rg)` — `manager.go:120`.
-- `ResignRG(rg)` — `manager.go:256`.
+- `VRRPEvent` — `instance.go`. INIT / BACKUP / MASTER transitions.
+- `NewManager()` — `manager.go`.
+- `Start()` — `manager.go`.
+- `Stop()` — `manager.go`.
+- `UpdateInstances(cfg)` — `manager.go`.
+- `ReleaseSyncHold(rg)` — `manager.go`.
+- `ResignRG(rg)` — `manager.go`.
 
 ## Callers
 

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -15,7 +15,7 @@ This is the package that drives chassis-cluster failover.
   priority, preempt, timers.
 - `VRRPEvent` — `instance.go`. INIT / BACKUP / MASTER transitions.
 - `NewManager()` — `manager.go`.
-- `Start()` — `manager.go`.
+- `Start(ctx context.Context) error` — `manager.go`. Blocks until ctx cancelled.
 - `Stop()` — `manager.go`.
 - `UpdateInstances(desired []*Instance) error` — `manager.go`.
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -42,8 +42,9 @@ decision → forwarding build → enqueue TX or recycle.
 - **AF_XDP rings** (kernel ↔ userspace): RX/TX/fill/completion.
 - **BPF maps** (shared with the XDP shim): session table mirror,
   conntrack, NAT pools, heartbeat.
-- **Sysctl tuning**: raises `SO_RCVBUF`, enables NAPI busy-poll in
-  `BusyPoll` mode.
+- **Sysctl tuning**: writes `/proc/sys/net/core/rmem_default` and
+  `rmem_max` (see `userspace-dp/src/server/lifecycle.rs`); enables
+  NAPI busy-poll in `BusyPoll` mode.
 
 ## Critical invariants
 
@@ -68,10 +69,12 @@ logging rules, not these specific hot-path constants.
 - Generic-XDP fallback consumes UMEM frames permanently on mlx5; the
   XDP shim redirects `XDP_PASS` to a cpumap stage that frees the frame
   immediately.
-- `HEARTBEAT_GRACE_PERIOD_NS = 6 s` in `userspace-dp/src/afxdp/mod.rs` —
-  during the bootstrap window the XDP shim falls back to `XDP_PASS` so
-  the kernel bootstraps NAPI. After 6 s the userspace heartbeat keeps
-  the redirect alive.
+- `HEARTBEAT_GRACE_PERIOD_NS = 6 s` is defined in
+  `userspace-dp/src/afxdp/mod.rs` but currently `#[allow(dead_code)]`
+  — reserved for future XDP-shim heartbeat gating logic. Workers
+  write the heartbeat immediately on bind today
+  (`userspace-dp/src/afxdp/worker/mod.rs`), so there is no live
+  6-second grace window.
 
 ## Subdir READMEs
 

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -45,7 +45,11 @@ decision → forwarding build → enqueue TX or recycle.
 - **Sysctl tuning**: raises `SO_RCVBUF`, enables NAPI busy-poll in
   `BusyPoll` mode.
 
-## Critical invariants (CLAUDE.md authoritative)
+## Critical invariants
+
+These invariants are enforced in code (`const_assert`s and runtime
+checks) and documented in `docs/per-5-tuple/state.md` — they are *not*
+in CLAUDE.md, which only covers Go-side concerns.
 
 - AF_XDP UMEM ownership is per-queue. A flow that hashes to queue N is
   *physically tied* to worker N — there is no cross-worker descriptor

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -48,8 +48,10 @@ decision → forwarding build → enqueue TX or recycle.
 ## Critical invariants
 
 These invariants are enforced in code (`const_assert`s and runtime
-checks) and documented in `docs/per-5-tuple/state.md` — they are *not*
-in CLAUDE.md, which only covers Go-side concerns.
+checks) and discussed in `docs/per-5-tuple/state.md`. They aren't
+mirrored into CLAUDE.md — that file's authoritative content covers
+Go, BPF, and Rust-helper logging rules, but not these specific
+hot-path constants.
 
 - AF_XDP UMEM ownership is per-queue. A flow that hashes to queue N is
   *physically tied* to worker N — there is no cross-worker descriptor

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -22,7 +22,7 @@ opt-in AF_XDP zero-copy backend used on hardware that benefits from it.
 | `src/filter/` | Junos-style firewall filter compiler + engine + policer. |
 | `src/event_stream/` | Push-based binary session-delta stream to the daemon. |
 | `src/bin/` | Helper binaries (`fairness-eval`). |
-| `src/nat.rs`, `nat64.rs`, `nptv6.rs`, `policy.rs`, `screen.rs`, `slowpath.rs`, `fairness.rs`, `flowexport.rs` | Single-file feature modules consumed by the worker hot path. |
+| `src/nat.rs`, `src/nat64.rs`, `src/nptv6.rs`, `src/policy.rs`, `src/screen.rs`, `src/slowpath.rs`, `src/fairness.rs`, `src/flowexport.rs` | Single-file feature modules consumed by the worker hot path. |
 
 ## Architecture
 

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -48,10 +48,11 @@ decision → forwarding build → enqueue TX or recycle.
 ## Critical invariants
 
 These invariants are enforced in code (`const_assert`s and runtime
-checks) and discussed in `docs/per-5-tuple/state.md`. They aren't
-mirrored into CLAUDE.md — that file's authoritative content covers
-Go, BPF, and Rust-helper logging rules, but not these specific
-hot-path constants.
+checks). `docs/per-5-tuple/state.md` documents the AF_XDP UMEM ownership
+ceiling; the batch and heartbeat constants are pinned in
+`userspace-dp/src/afxdp/mod.rs`. They aren't mirrored into CLAUDE.md —
+that file's authoritative content covers Go, BPF, and Rust-helper
+logging rules, not these specific hot-path constants.
 
 - AF_XDP UMEM ownership is per-queue. A flow that hashes to queue N is
   *physically tied* to worker N — there is no cross-worker descriptor
@@ -59,16 +60,18 @@ hot-path constants.
   has been plan-killed; see `docs/per-5-tuple/state.md` for the formal
   ceiling.
 - `RX_BATCH_SIZE = 64` is paired with the L1d footprint (≤14 KB
-  working set per batch). A `const_assert` enforces it; don't bump it
-  without re-validating.
+  working set per batch) in `userspace-dp/src/afxdp/mod.rs`. A
+  `const_assert` enforces it; don't bump it without re-validating.
 - `TX_BATCH_SIZE = 64` is paired with the CoS guarantee quantum in
-  `tx/`. Changing requires re-running the `guarantee_phase_*` tests.
+  `userspace-dp/src/afxdp/mod.rs`. Changing requires re-running the
+  `guarantee_phase_*` tests.
 - Generic-XDP fallback consumes UMEM frames permanently on mlx5; the
   XDP shim redirects `XDP_PASS` to a cpumap stage that frees the frame
   immediately.
-- `HEARTBEAT_GRACE_PERIOD_NS = 6 s` — during the bootstrap window the
-  XDP shim falls back to `XDP_PASS` so the kernel bootstraps NAPI.
-  After 6 s the userspace heartbeat keeps the redirect alive.
+- `HEARTBEAT_GRACE_PERIOD_NS = 6 s` in `userspace-dp/src/afxdp/mod.rs` —
+  during the bootstrap window the XDP shim falls back to `XDP_PASS` so
+  the kernel bootstraps NAPI. After 6 s the userspace heartbeat keeps
+  the redirect alive.
 
 ## Subdir READMEs
 

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -11,9 +11,9 @@ sync.
   receives lifecycle commands from the control socket. `mod.rs` is the
   single entry that owns shared state Arcs; `worker_manager.rs` keeps
   the per-worker handle table.
-- `worker/` — the per-worker poll loop. `mod.rs` runs the dispatch;
-  `poll_stages.rs` (extracted in #946 Phase 1) holds the per-packet
-  pipeline stages.
+- `worker/` — the per-worker poll loop (`mod.rs` runs the dispatch).
+- `poll_stages.rs` — sibling of `worker/`, not inside it. Holds the
+  per-packet pipeline stages extracted in #946 Phase 1.
 - `frame/` — packet parsing (L2 / L3 / L4), checksum helpers, TCP MSS
   clamp. `tests.rs` was relocated out of `mod.rs` in #1046 Phase 1.
 - `umem/` — UMEM allocator, fill ring, completion ring. Frames are
@@ -52,5 +52,5 @@ it explicitly.
 ## Reading order
 
 `coordinator/mod.rs` for ownership and lifecycle, then
-`worker/mod.rs` for the dispatch, then `worker/poll_stages.rs` for the
-per-packet stages, then peer modules as needed.
+`worker/mod.rs` for the dispatch, then the sibling `poll_stages.rs`
+for the per-packet stages, then peer modules as needed.

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -24,6 +24,7 @@ buffers and batches before forwarding to syslog / NetFlow.
 
 - The sequence number is monotonic across reconnects; the daemon ACKs
   the highest seen so the helper can prune its retransmit buffer.
-- If the daemon is slow to drain, the helper's send queue fills and
-  blocks the worker thread that produced the event. That's intentional
-  back-pressure — there is no silent drop.
+- The default `push_delta()` path is **non-blocking** (`try_send`) and
+  **silently drops** when the channel is full — the count is exposed as
+  `frames_dropped`. Use `push_delta_lossless()` only when correctness
+  requires every frame and the producer can tolerate back-pressure.

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -9,9 +9,11 @@ periodic ACK from the daemon.
 
 - `mod.rs` — `EventStreamSender` owns its own I/O thread, connects to
   the daemon's listener, sends frames, handles reconnect on EPIPE.
-- `codec.rs` — frame layout: `(op, seq, payload_len, payload)` where
-  `op` ∈ `OPEN`, `UPDATE`, `CLOSE`, `ACK`. Little-endian, fixed-width
-  header.
+- `codec.rs` — frame layout: 16-byte header
+  `[length:u32 LE][type:u8][reserved:3][seq:u64 LE]` followed by the
+  payload. Message types: `MSG_SESSION_OPEN`, `MSG_SESSION_CLOSE`,
+  `MSG_SESSION_UPDATE`, `MSG_ACK`, `MSG_PAUSE`, `MSG_RESUME`,
+  `MSG_DRAIN_REQUEST`, `MSG_DRAIN_COMPLETE` (1..8).
 - `codec_tests.rs`, `tests.rs` — co-located.
 
 ## Why push

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -25,6 +25,9 @@ buffers and batches before forwarding to syslog / NetFlow.
 - The sequence number is monotonic across reconnects; the daemon ACKs
   the highest seen so the helper can prune its retransmit buffer.
 - The default `push_delta()` path is **non-blocking** (`try_send`) and
-  **silently drops** when the channel is full — the count is exposed as
-  `frames_dropped`. Use `push_delta_lossless()` only when correctness
-  requires every frame and the producer can tolerate back-pressure.
+  **silently drops** when the channel is full. The internal counter
+  is `EventStreamShared.frames_dropped` (`mod.rs`); the surface
+  exported through the daemon status JSON is `event_stream_dropped`
+  (see `protocol.rs`). Use `push_delta_lossless()` only when
+  correctness requires every frame and the producer can tolerate
+  back-pressure.

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -13,7 +13,8 @@ periodic ACK from the daemon.
   `[length:u32 LE][type:u8][reserved:3][seq:u64 LE]` followed by the
   payload. Message types: `MSG_SESSION_OPEN`, `MSG_SESSION_CLOSE`,
   `MSG_SESSION_UPDATE`, `MSG_ACK`, `MSG_PAUSE`, `MSG_RESUME`,
-  `MSG_DRAIN_REQUEST`, `MSG_DRAIN_COMPLETE` (1..8).
+  `MSG_DRAIN_REQUEST`, `MSG_DRAIN_COMPLETE`, `MSG_FULL_RESYNC`,
+  `MSG_KEEPALIVE` (1..10).
 - `codec_tests.rs`, `tests.rs` — co-located.
 
 ## Why push

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -5,25 +5,31 @@ Mirrors the BPF firewall-filter pipeline in userspace.
 
 ## Files
 
-- `mod.rs` — public surface: `FilterAction` (Accept / Discard / Reject /
-  Count / Forward / RateLimit / DSCP / ForwardingClass), per-term
-  counters.
+- `mod.rs` — public surface: `FilterAction` (`Accept` / `Discard` /
+  `Reject` only), `FilterTerm` (the matched-and-action carrier),
+  `PortMatcher`, `FilterTermCounter`. Side-effect actions like
+  counting, logging, policing, forwarding-class assignment, and DSCP
+  rewrite are **fields on `FilterTerm`** (e.g. `count`, `log`,
+  `policer_name`, `forwarding_class`, `dscp_rewrite`), not enum
+  variants — the engine applies them around the action verdict.
 - `compiler.rs` — parses the typed config's filter terms and lowers
-  them to compiled `FilterTerm` matchers (prefix sets, protocol /
-  port / TCP-flag / DSCP matches).
-- `engine.rs` — per-term evaluation, first-match-wins. Holds the
-  token-bucket policer for `then policer ...` actions.
-- `policer.rs` — token-bucket implementation with a `rate_limit_ns`
-  refill window.
+  them to `FilterTerm`s (prefix vectors, protocol bitmap, port
+  matcher, DSCP bitmap).
+- `engine.rs` — per-term evaluation, first-match-wins. Hands off to
+  the policer for `then policer ...` actions.
+- `policer.rs` — token-bucket implementation; the per-policer field
+  is `rate_bytes_per_ns` (rate, not interval).
 - `tests.rs` — co-located unit tests covering matching ports, prefix
-  sets, TCP flags.
+  vectors, TCP flags.
 
 ## Conventions
 
-- Prefix sets compile to a small adaptive structure: a linear scan for
-  ≤8 entries, an LPM trie above. The threshold is tuned for the
-  observed working set in policy lookups.
-- Hit counters live on each `FilterTerm` and are surfaced through the
-  status JSON.
+- Prefix matching uses linear scan over `Vec<PrefixV4>` /
+  `Vec<PrefixV6>` per term (`source_v4`, `source_v6`, `dest_v4`,
+  `dest_v6` on `FilterTerm`). There is no LPM trie in this package
+  today — the previous README claim of an "adaptive scan above 8
+  entries" was incorrect.
+- Hit counters live on each `FilterTerm` (`Arc<FilterTermCounter>`)
+  and are surfaced through the status JSON.
 - `from-interface` is matched at the binding level (caller sets the
   ingress interface; the term doesn't re-derive it).

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -41,14 +41,14 @@ binding.worker_id = (queue_id % workers.max(1)) as u32;
 so a clean 1:1 queue→worker mapping requires `queue_count ==
 workers`. The Go side's `pkg/daemon/rss_indirection.go` reshapes
 RSS indirection only on **mlx5** drivers and only when `workers >
-1` and `workers < queues`; with `workers == 1` it leaves the
+1` and `workers < queues`. With `workers == 1` it leaves the
 default RSS spread alone (single worker drains all queues), and on
 non-mlx5 drivers (i40e, etc.) it doesn't reshape at all. The
-`workers == 1` path can also restore default tables when reshape
-was previously enabled and is now disabled. On non-mlx5 + `workers
-> 1 && workers < queues`, the modulo collision can leave one
-worker bound to multiple queues. See PR #1243's kill record for
-why i40e doesn't reshape and the trade-offs that left.
+default RSS table is **only** restored when the kill switch fires
+(`enabled == false`) — not on the `workers == 1` path. On non-mlx5
++ `workers > 1 && workers < queues`, the modulo collision can
+leave one worker bound to multiple queues. See PR #1243's kill
+record for why i40e doesn't reshape and the trade-offs that left.
 
 ## Gotchas
 

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -37,12 +37,16 @@ binding.worker_id = (queue_id % workers.max(1)) as u32;
 ```
 
 so a clean 1:1 queue→worker mapping requires `queue_count ==
-workers`. The Go side reshapes RSS indirection in
-`pkg/daemon/rss_indirection.go` only on **mlx5** drivers and only
-when `workers < queues`; on i40e and other drivers the modulo
-collision can happen, with one worker bound to multiple queues.
-See PR #1243's kill record for why i40e doesn't reshape and the
-trade-offs that left.
+workers`. The Go side's `pkg/daemon/rss_indirection.go` reshapes
+RSS indirection only on **mlx5** drivers and only when `workers >
+1` and `workers < queues`; with `workers == 1` it leaves the
+default RSS spread alone (single worker drains all queues), and on
+non-mlx5 drivers (i40e, etc.) it doesn't reshape at all. The
+`workers == 1` path can also restore default tables when reshape
+was previously enabled and is now disabled. On non-mlx5 + `workers
+> 1 && workers < queues`, the modulo collision can leave one
+worker bound to multiple queues. See PR #1243's kill record for
+why i40e doesn't reshape and the trade-offs that left.
 
 ## Gotchas
 

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -38,17 +38,20 @@ pair. The Rust planner does:
 binding.worker_id = (queue_id % workers.max(1)) as u32;
 ```
 
-so a clean 1:1 queue→worker mapping requires `queue_count ==
-workers`. The Go side's `pkg/daemon/rss_indirection.go` reshapes
-RSS indirection only on **mlx5** drivers and only when `workers >
-1` and `workers < queues`. With `workers == 1` it leaves the
-default RSS spread alone (single worker drains all queues), and on
-non-mlx5 drivers (i40e, etc.) it doesn't reshape at all. The
-default RSS table is **only** restored when the kill switch fires
-(`enabled == false`) — not on the `workers == 1` path. On non-mlx5
-+ `workers > 1 && workers < queues`, the modulo collision can
-leave one worker bound to multiple queues. See PR #1243's kill
-record for why i40e doesn't reshape and the trade-offs that left.
+so modulo assignment can map multiple queues onto the same worker when
+`queues > workers`. The Go side's `pkg/daemon/rss_indirection.go`
+reshapes RSS indirection only on **mlx5** drivers and only when
+`workers > 1 && workers < queues`, concentrating traffic onto queues
+`0..workers-1` (it does not change planner `queue_count`). With
+`workers == 1` it leaves the default RSS spread alone (single worker
+drains all queues), and on non-mlx5 drivers (i40e, etc.) it doesn't
+reshape at all. The default RSS table is restored when the kill switch
+fires (`enabled == false`) and also on the `workers >= queues` cleanup
+path if a stale constrained table is detected from a prior
+`workers < queues` apply. On non-mlx5 + `workers > 1 && workers <
+queues`, modulo collision can leave one worker bound to multiple
+queues. See PR #1243's kill record for why i40e doesn't reshape and
+the trade-offs that left.
 
 ## Gotchas
 

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -36,9 +36,13 @@ pair. The Rust planner does:
 binding.worker_id = (queue_id % workers.max(1)) as u32;
 ```
 
-so a clean 1:1 queue→worker mapping requires `queue_count == workers`.
-The Go side ensures that via `pkg/daemon/rss_indirection.go` (mlx5
-today; see #1243 kill record for why i40e doesn't reshape).
+so a clean 1:1 queue→worker mapping requires `queue_count ==
+workers`. The Go side reshapes RSS indirection in
+`pkg/daemon/rss_indirection.go` only on **mlx5** drivers and only
+when `workers < queues`; on i40e and other drivers the modulo
+collision can happen, with one worker bound to multiple queues.
+See PR #1243's kill record for why i40e doesn't reshape and the
+trade-offs that left.
 
 ## Gotchas
 

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -7,7 +7,9 @@ this surface over a Unix socket using a newline-delimited text protocol.
 
 - `mod.rs` — module root, public API surface.
 - `lifecycle.rs` — `run()` is the daemon entry called from `main.rs`.
-  Argv parsing (`--workers N`, `--socket PATH`, etc.), socket setup,
+  Argv parsing (`--workers N`, `--control-socket PATH`, etc.),
+  socket setup (control + a derived dedicated session-install
+  socket so session installs don't share the control channel),
   sysctl tuning, signal handling.
 - `state.rs` — `ServerState`: coordinator handle, latest config
   snapshot, session-table handle, policy state.
@@ -53,6 +55,9 @@ why i40e doesn't reshape and the trade-offs that left.
 - `defer_workers=true` requests skip the worker spawn until the next
   reconcile. Used during RETH MAC programming so workers don't bind to
   an interface that's about to drop and re-add its MAC.
-- The control socket is shared with status poll, HA sync, session
-  installs, snapshot sync, and forwarding sync. Adding a new caller at
-  >1 Hz starves session installs during bulk sync.
+- Session installs run on a **dedicated** session-install socket
+  (`derive_session_socket_path` next to the control socket), so they
+  do not share the control-channel queue with status poll, HA sync,
+  snapshot sync, and forwarding sync. The control channel is still
+  shared by those other callers; adding a new caller there at >1 Hz
+  can still starve the other low-frequency control operations.

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -41,14 +41,17 @@ binding.worker_id = (queue_id % workers.max(1)) as u32;
 so a clean 1:1 queue→worker mapping requires `queue_count ==
 workers`. The Go side's `pkg/daemon/rss_indirection.go` reshapes
 RSS indirection only on **mlx5** drivers and only when `workers >
-1` and `workers < queues`. With `workers == 1` it leaves the
-default RSS spread alone (single worker drains all queues), and on
-non-mlx5 drivers (i40e, etc.) it doesn't reshape at all. The
-default RSS table is **only** restored when the kill switch fires
-(`enabled == false`) — not on the `workers == 1` path. On non-mlx5
-+ `workers > 1 && workers < queues`, the modulo collision can
-leave one worker bound to multiple queues. See PR #1243's kill
-record for why i40e doesn't reshape and the trade-offs that left.
+1 && workers < queues`. With `workers == 1` it leaves the live RSS
+table untouched (single worker drains all queues), and on non-mlx5
+drivers (i40e, etc.) it doesn't reshape at all. The default RSS
+table is restored either when the kill switch fires
+(`enabled == false`), or via `maybeRestoreDefault()` on the
+`workers > 1 && workers >= queues > 1` path — there to undo a
+concentrated table written by an earlier `workers < queues`
+configuration (#805). On non-mlx5 + `workers > 1 && workers <
+queues`, the modulo collision can leave one worker bound to
+multiple queues. See PR #1243's kill record for why i40e doesn't
+reshape.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Retroactive triple-review of PR #1251 returned **NEEDS-FOLLOWUP-MAJOR** from Gemini Pro 3 (\`task-moz8g3zg-jkqdrv\`). Codex review (\`task-moz8o6y7-st6xoz\`) was lost when the Codex runtime restarted; Gemini's findings stand on their own. Three concrete fixes here.

## Findings → fixes

1. **Stripped all \`file.ext:NNN\` line numbers** across the 46 READMEs. Line numbers bit-rot on the very next refactor and produce active disinformation. The bare \`file.ext\` reference is stable enough to be useful. Gemini's recommendation: "strip all \`file:line\` references … to prevent immediate bit-rot and fix the hallucinated file names."

2. **Fixed \`pkg/cluster/README.md\` ClusterEvent file ref.** Was \`events.go\` (hallucinated by the agent that wrote the README). The type actually lives at \`cluster.go\` (defined at \`cluster.go:81\`; consumer at \`reth.go:55\`). Gemini caught this specific case.

3. **Removed fake \`CLAUDE.md\` citation in \`userspace-dp/README.md\`.** The "Critical invariants (CLAUDE.md authoritative)" header listed AF_XDP UMEM ownership, \`RX_BATCH_SIZE=64\`, and \`HEARTBEAT_GRACE_PERIOD_NS\` — none of which are in CLAUDE.md (those live in code as \`const_assert\` and are documented in \`docs/per-5-tuple/state.md\`). Re-attributed.

## Sample-checks (still passing)

- \`pkg/conntrack\` "MaxSessions = 10M": verified at \`gc.go:29\`.
- \`pkg/vrrp\` "02:bf:72:CC:RR:NN" MAC pattern: verified at \`pkg/cluster/reth.go:107\`.
- \`userspace-dp/src/afxdp\` constants: \`RX_BATCH_SIZE = 64\` has \`const_assert\` at \`mod.rs:190\`; \`HEARTBEAT_GRACE_PERIOD_NS = 6_000_000_000\` at \`mod.rs:240\`.
- Other CLAUDE.md citations (BPF verifier traps in \`bpf/\`, failover timing in \`pkg/cluster\` and \`pkg/vrrp\`, naming in \`pkg/networkd\`, logging rules in \`pkg/logging\`, control-socket rules in \`pkg/api\`): all verified accurate against the live CLAUDE.md.

## Out of scope

Gemini also flagged coverage gaps (no READMEs for \`pkg/dataplane/{dpdk,userspace}/\`, \`userspace-dp/src/afxdp/{coordinator,cos,frame,tx,types,umem,worker,forwarding,session_glue}/\`) and a quality-vs-size question (whether 31 small \`pkg/*\` READMEs should be one architectural map). Those are scoping decisions; not addressed in this followup. The current top-level READMEs explicitly point downward into the relevant code so a reader can still navigate.

## Test plan

- [x] Doc-only change.
- [x] All 33 modified READMEs render clean.
- [x] No surviving \`file.ext:NNN\` patterns (verified by grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)