### PR TITLE
Fix userspace-dp debug test failures

### DIFF
--- a/userspace-dp/src/afxdp/frame/checksum.rs
+++ b/userspace-dp/src/afxdp/frame/checksum.rs
@@ -40,10 +40,10 @@ pub(in crate::afxdp) fn checksum16_add_bytes(sum: u32, bytes: &[u8]) -> u32 {
 fn checksum16_add_bytes_scalar(mut sum: u32, bytes: &[u8]) -> u32 {
     let mut chunks = bytes.chunks_exact(2);
     for chunk in &mut chunks {
-        sum += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+        sum = sum.wrapping_add(u16::from_be_bytes([chunk[0], chunk[1]]) as u32);
     }
     if let Some(last) = chunks.remainder().first() {
-        sum += (*last as u32) << 8;
+        sum = sum.wrapping_add((*last as u32) << 8);
     }
     sum
 }

--- a/userspace-dp/src/afxdp/types/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease_tests.rs
@@ -147,12 +147,22 @@ fn v8_acquire_zero_when_no_active_flows() {
     assert_eq!(granted, 0, "no active flows → no grants");
 }
 
+#[cfg(debug_assertions)]
 #[test]
-fn v8_acquire_returns_zero_for_out_of_range_worker_id() {
+#[should_panic(expected = "worker_id 2 out of range")]
+fn v8_acquire_debug_panics_for_out_of_range_worker_id() {
     let lease = SharedCoSQueueLease::new_v8(10_000_000, 64 * 1024, 2, 1);
     // max_worker_id = 1, so worker_id 0 and 1 are valid; 2+ are out of range.
-    // debug_assert in production fires; release-mode returns 0.
-    // Since cargo test --release skips debug_assert, this returns 0 cleanly.
+    // Debug builds should fail loudly for this caller bug.
+    let _ = lease.acquire_v8(2, 1_000_000, 4_096);
+}
+
+#[cfg(not(debug_assertions))]
+#[test]
+fn v8_acquire_release_returns_zero_for_out_of_range_worker_id() {
+    let lease = SharedCoSQueueLease::new_v8(10_000_000, 64 * 1024, 2, 1);
+    // max_worker_id = 1, so worker_id 0 and 1 are valid; 2+ are out of range.
+    // Release-mode skips debug_assert, so this returns 0 cleanly.
     let granted = lease.acquire_v8(2, 1_000_000, 4_096);
     assert_eq!(granted, 0, "out-of-range worker_id → 0 grant");
 }


### PR DESCRIPTION
## Summary
- make the scalar checksum reference use wrapping accumulation so debug builds match the intended one's-complement arithmetic
- split the shared CoS lease out-of-range worker test by debug vs release behavior

## Validation
- `cargo test --bin xpf-userspace-dp simd_matches_scalar`
- `cargo test --bin xpf-userspace-dp v8_acquire`
- `cargo test` in `userspace-dp`
- `git diff --check`