### PR TITLE
Add isolated mixed-CoS generator mode

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -253,6 +253,29 @@ once for queue 5. Non-canonical fixtures must set `COS_QUEUE_ID` and
 unless the operator explicitly sets `MIXED_RSS_EXPECTATION=any` or a
 different mixed-class expression.
 
+For hostile qualification runs where generator placement itself is a
+suspect, use the opt-in isolated mode:
+
+```bash
+COS_IFINDEX=<egress-ifindex> \
+IPERF_CPUSET=0-3 MIXED_IPERF_CPUSET=4-7 \
+PRIMARY_RSS_STEERING="vf0/rss-context-a" \
+MIXED_RSS_STEERING="vf1/rss-context-b" \
+ARTIFACT_DIR=/tmp/fairness-isolated \
+./test/incus/fairness-harness.sh --mixed-cos-isolated
+```
+
+`--mixed-cos-isolated` still evaluates both classes from one metrics
+scrape, but it requires explicit placement metadata and writes
+`generator-placement.txt` under `ARTIFACT_DIR` (or a generated `/tmp`
+artifact directory). The placement file records per-class ports,
+streams, reverse flag, CoS ifindex/queue, shaper rates, CPU sets,
+network namespaces, command prefixes, generator binaries, RSS/NIC
+steering notes, and the exact iperf command line. This mode is for
+separating scheduler behavior from test-generator cross-talk and
+RSS/NIC placement assumptions; the lightweight `--mixed-cos` mode
+remains the default for routine runs.
+
 ## Required metrics — exported in production via gRPC/Prometheus
 
 For production observability, xpf MUST export:

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -16,6 +16,7 @@
 # Usage:
 #   fairness-harness.sh [TARGET] [PORT] [N] [DURATION] [REVERSE] [METRICS_URL]
 #   fairness-harness.sh --mixed-cos [TARGET] [PORT] [N] [DURATION] [REVERSE] [METRICS_URL]
+#   fairness-harness.sh --mixed-cos-isolated [TARGET] [PORT] [N] [DURATION] [REVERSE] [METRICS_URL]
 #
 # Mixed CoS mode defaults to canonical fixture ports 5201 (queue 4)
 # and 5202 (queue 5) and evaluates each class separately from the
@@ -28,15 +29,29 @@
 # MIXED_RSS_EXPECTATION=any when only the primary class should enforce
 # an RSS/workload expectation.
 #
+# --mixed-cos-isolated keeps the mixed-CoS evaluator but requires explicit
+# generator placement knobs so the two classes can be separated for hostile
+# reviews. Supported knobs:
+#   IPERF_NETNS / MIXED_IPERF_NETNS         optional `ip netns exec` namespaces
+#   IPERF_CPUSET / MIXED_IPERF_CPUSET       optional `taskset -c` CPU lists
+#   IPERF_CMD_PREFIX / MIXED_IPERF_CMD_PREFIX
+#                                           optional command prefix words
+#   IPERF_BIN / MIXED_IPERF_BIN             generator binary, default iperf3
+#   PRIMARY_RSS_STEERING / MIXED_RSS_STEERING
+#                                           free-form NIC/RSS assumption notes
+#   ARTIFACT_DIR                            placement artifact directory
+#
 # Defaults match the existing iperf-c P=12 -R workload that produced the
 # 47% per-flow CoV measurement that motivates the harness.
 
 set -euo pipefail
 
 MIXED_COS=${MIXED_COS:-0}
+ISOLATED_GENERATORS=${ISOLATED_GENERATORS:-0}
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --mixed-cos) MIXED_COS=1; shift ;;
+        --mixed-cos-isolated) MIXED_COS=1; ISOLATED_GENERATORS=1; shift ;;
         --) shift; break ;;
         *) echo "fairness-harness: unknown flag $1" >&2; exit 2 ;;
     esac
@@ -71,6 +86,19 @@ RSS_EXPECTATION=${RSS_EXPECTATION:-any}
 MIXED_RSS_EXPECTATION=${MIXED_RSS_EXPECTATION:-$RSS_EXPECTATION}
 WARMUP=${WARMUP:-5}
 FINAL_BURST=${FINAL_BURST:-1}
+ARTIFACT_DIR=${ARTIFACT_DIR:-}
+IPERF_BIN=${IPERF_BIN:-iperf3}
+MIXED_IPERF_BIN=${MIXED_IPERF_BIN:-$IPERF_BIN}
+IPERF_NETNS=${IPERF_NETNS:-}
+MIXED_IPERF_NETNS=${MIXED_IPERF_NETNS:-}
+IPERF_CPUSET=${IPERF_CPUSET:-}
+MIXED_IPERF_CPUSET=${MIXED_IPERF_CPUSET:-}
+IPERF_CMD_PREFIX=${IPERF_CMD_PREFIX:-}
+MIXED_IPERF_CMD_PREFIX=${MIXED_IPERF_CMD_PREFIX:-}
+PRIMARY_RSS_STEERING=${PRIMARY_RSS_STEERING:-unspecified}
+MIXED_RSS_STEERING=${MIXED_RSS_STEERING:-unspecified}
+PRIMARY_GENERATOR_LABEL=${PRIMARY_GENERATOR_LABEL:-primary}
+MIXED_GENERATOR_LABEL=${MIXED_GENERATOR_LABEL:-mixed}
 
 WORK_DIR=$(mktemp -d -t fairness-harness.XXXXXX)
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -152,6 +180,166 @@ else
     SHAPER_RATE_BPS=${SHAPER_RATE_BPS:-25000000000}
 fi
 
+format_command() {
+    local arg
+    for arg in "$@"; do
+        printf '%q ' "$arg"
+    done
+}
+
+append_prefix_words() {
+    local -n cmd_ref=$1
+    local prefix=$2
+
+    if [[ -n "$prefix" ]]; then
+        local words=()
+        # Intentionally word-split test-harness prefixes such as:
+        #   incus exec loss:cluster-userspace-host --
+        #   ip vrf exec blue
+        # Prefixes that need shell quoting should be wrapped by a small
+        # script and passed as IPERF_BIN instead.
+        # shellcheck disable=SC2206
+        words=( $prefix )
+        cmd_ref+=("${words[@]}")
+    fi
+}
+
+build_iperf_cmd() {
+    local cmd_name=$1
+    local -n cmd_ref=$cmd_name
+    local port=$2
+    local streams=$3
+    local reverse_flag=$4
+    local netns=$5
+    local cpuset=$6
+    local cmd_prefix=$7
+    local iperf_bin=$8
+
+    cmd_ref=()
+    if [[ -n "$netns" ]]; then
+        cmd_ref+=(ip netns exec "$netns")
+    fi
+    if [[ -n "$cpuset" ]]; then
+        cmd_ref+=(taskset -c "$cpuset")
+    fi
+    append_prefix_words "$cmd_name" "$cmd_prefix"
+    cmd_ref+=("$iperf_bin" -c "$TARGET" -P "$streams" -t "$T" -p "$port")
+    append_prefix_words "$cmd_name" "$reverse_flag"
+    cmd_ref+=(-J --forceflush)
+}
+
+generator_signature() {
+    printf 'netns=%s|cpuset=%s|prefix=%s|bin=%s|rss=%s' \
+        "$1" "$2" "$3" "$4" "$5"
+}
+
+validate_isolated_generators() {
+    [[ "$ISOLATED_GENERATORS" -eq 1 ]] || return 0
+    if [[ "$MIXED_COS" -ne 1 ]]; then
+        echo "fairness-harness: isolated generator mode requires mixed CoS mode" >&2
+        exit 2
+    fi
+
+    local has_isolation=0
+    for value in \
+        "$IPERF_NETNS" "$MIXED_IPERF_NETNS" \
+        "$IPERF_CPUSET" "$MIXED_IPERF_CPUSET" \
+        "$IPERF_CMD_PREFIX" "$MIXED_IPERF_CMD_PREFIX" \
+        "$PRIMARY_RSS_STEERING" "$MIXED_RSS_STEERING"
+    do
+        if [[ -n "$value" && "$value" != "unspecified" ]]; then
+            has_isolation=1
+            break
+        fi
+    done
+    if [[ "$has_isolation" -ne 1 ]]; then
+        echo "fairness-harness: --mixed-cos-isolated requires CPU, netns, prefix, or RSS steering placement metadata" >&2
+        exit 2
+    fi
+
+    if [[ -n "$IPERF_CPUSET" && -n "$MIXED_IPERF_CPUSET" && "$IPERF_CPUSET" == "$MIXED_IPERF_CPUSET" ]]; then
+        echo "fairness-harness: isolated mode requires distinct IPERF_CPUSET and MIXED_IPERF_CPUSET when both are set" >&2
+        exit 2
+    fi
+
+    local primary_sig
+    local mixed_sig
+    primary_sig=$(generator_signature "$IPERF_NETNS" "$IPERF_CPUSET" "$IPERF_CMD_PREFIX" "$IPERF_BIN" "$PRIMARY_RSS_STEERING")
+    mixed_sig=$(generator_signature "$MIXED_IPERF_NETNS" "$MIXED_IPERF_CPUSET" "$MIXED_IPERF_CMD_PREFIX" "$MIXED_IPERF_BIN" "$MIXED_RSS_STEERING")
+    if [[ "$primary_sig" == "$mixed_sig" ]]; then
+        echo "fairness-harness: isolated mode primary and mixed generator placement are identical" >&2
+        exit 2
+    fi
+}
+
+setup_artifact_dir() {
+    if [[ "$ISOLATED_GENERATORS" -eq 1 && -z "$ARTIFACT_DIR" ]]; then
+        ARTIFACT_DIR=$(mktemp -d -t fairness-harness-artifacts.XXXXXX)
+    fi
+    if [[ -n "$ARTIFACT_DIR" ]]; then
+        mkdir -p "$ARTIFACT_DIR"
+    fi
+}
+
+write_placement_artifact() {
+    [[ -n "$ARTIFACT_DIR" ]] || return 0
+
+    local primary_cmd=()
+    local mixed_cmd=()
+    build_iperf_cmd primary_cmd "$PORT" "$N" "$REVERSE" "$IPERF_NETNS" "$IPERF_CPUSET" "$IPERF_CMD_PREFIX" "$IPERF_BIN"
+    if [[ "$MIXED_COS" -eq 1 ]]; then
+        build_iperf_cmd mixed_cmd "$MIXED_PORT" "$MIXED_N" "$MIXED_REVERSE" "$MIXED_IPERF_NETNS" "$MIXED_IPERF_CPUSET" "$MIXED_IPERF_CMD_PREFIX" "$MIXED_IPERF_BIN"
+    fi
+
+    local artifact="$ARTIFACT_DIR/generator-placement.txt"
+    local mode=single
+    if [[ "$ISOLATED_GENERATORS" -eq 1 ]]; then
+        mode=mixed-cos-isolated
+    elif [[ "$MIXED_COS" -eq 1 ]]; then
+        mode=mixed-cos
+    fi
+
+    {
+        printf 'mode=%s\n' "$mode"
+        printf 'target=%s\n' "$TARGET"
+        printf 'metrics_url=%s\n' "$METRICS_URL"
+        printf 'duration_secs=%s\n' "$T"
+        printf 'primary.label=%s\n' "$PRIMARY_GENERATOR_LABEL"
+        printf 'primary.port=%s\n' "$PORT"
+        printf 'primary.streams=%s\n' "$N"
+        printf 'primary.reverse=%s\n' "$REVERSE"
+        printf 'primary.cos_ifindex=%s\n' "${COS_IFINDEX:-}"
+        printf 'primary.cos_queue_id=%s\n' "${COS_QUEUE_ID:-}"
+        printf 'primary.shaper_rate_bps=%s\n' "${SHAPER_RATE_BPS:-}"
+        printf 'primary.netns=%s\n' "$IPERF_NETNS"
+        printf 'primary.cpuset=%s\n' "$IPERF_CPUSET"
+        printf 'primary.cmd_prefix=%s\n' "$IPERF_CMD_PREFIX"
+        printf 'primary.bin=%s\n' "$IPERF_BIN"
+        printf 'primary.rss_steering=%s\n' "$PRIMARY_RSS_STEERING"
+        printf 'primary.command=%s\n' "$(format_command "${primary_cmd[@]}")"
+        if [[ "$MIXED_COS" -eq 1 ]]; then
+            printf 'mixed.label=%s\n' "$MIXED_GENERATOR_LABEL"
+            printf 'mixed.port=%s\n' "$MIXED_PORT"
+            printf 'mixed.streams=%s\n' "$MIXED_N"
+            printf 'mixed.reverse=%s\n' "$MIXED_REVERSE"
+            printf 'mixed.cos_ifindex=%s\n' "${COS_IFINDEX:-}"
+            printf 'mixed.cos_queue_id=%s\n' "${MIXED_COS_QUEUE_ID:-}"
+            printf 'mixed.shaper_rate_bps=%s\n' "${MIXED_SHAPER_RATE_BPS:-}"
+            printf 'mixed.netns=%s\n' "$MIXED_IPERF_NETNS"
+            printf 'mixed.cpuset=%s\n' "$MIXED_IPERF_CPUSET"
+            printf 'mixed.cmd_prefix=%s\n' "$MIXED_IPERF_CMD_PREFIX"
+            printf 'mixed.bin=%s\n' "$MIXED_IPERF_BIN"
+            printf 'mixed.rss_steering=%s\n' "$MIXED_RSS_STEERING"
+            printf 'mixed.command=%s\n' "$(format_command "${mixed_cmd[@]}")"
+        fi
+    } > "$artifact"
+    echo "fairness-harness: wrote generator placement artifact: $artifact"
+}
+
+validate_isolated_generators
+setup_artifact_dir
+write_placement_artifact
+
 scrape_metrics() {
     local binding_out=$1
     local cos_out=$2
@@ -197,9 +385,15 @@ run_iperf() {
     local port=$3
     local streams=$4
     local reverse_flag=$5
+    local netns=${6:-}
+    local cpuset=${7:-}
+    local cmd_prefix=${8:-}
+    local iperf_bin=${9:-iperf3}
+    local cmd=()
 
-    echo "fairness-harness: running ${label}: iperf3 -c $TARGET -P $streams -t $T -p $port $reverse_flag for ${T}s"
-    iperf3 -c "$TARGET" -P "$streams" -t "$T" -p "$port" $reverse_flag -J --forceflush > "$out"
+    build_iperf_cmd cmd "$port" "$streams" "$reverse_flag" "$netns" "$cpuset" "$cmd_prefix" "$iperf_bin"
+    echo "fairness-harness: running ${label}: $(format_command "${cmd[@]}")for ${T}s"
+    "${cmd[@]}" > "$out"
 }
 
 run_eval() {
@@ -240,9 +434,9 @@ cleanup() {
 trap 'cleanup; rm -rf "$WORK_DIR"' EXIT
 
 if [[ "$MIXED_COS" -eq 1 ]]; then
-    run_iperf "primary port $PORT queue $COS_QUEUE_ID" "$IPERF_OUT" "$PORT" "$N" "$REVERSE" &
+    run_iperf "primary port $PORT queue $COS_QUEUE_ID" "$IPERF_OUT" "$PORT" "$N" "$REVERSE" "$IPERF_NETNS" "$IPERF_CPUSET" "$IPERF_CMD_PREFIX" "$IPERF_BIN" &
     PRIMARY_PID=$!
-    run_iperf "mixed port $MIXED_PORT queue $MIXED_COS_QUEUE_ID" "$MIXED_IPERF_OUT" "$MIXED_PORT" "$MIXED_N" "$MIXED_REVERSE" &
+    run_iperf "mixed port $MIXED_PORT queue $MIXED_COS_QUEUE_ID" "$MIXED_IPERF_OUT" "$MIXED_PORT" "$MIXED_N" "$MIXED_REVERSE" "$MIXED_IPERF_NETNS" "$MIXED_IPERF_CPUSET" "$MIXED_IPERF_CMD_PREFIX" "$MIXED_IPERF_BIN" &
     MIXED_PID=$!
 
     IPERF_STATUS=0
@@ -260,7 +454,7 @@ if [[ "$MIXED_COS" -eq 1 ]]; then
         exit "$IPERF_STATUS"
     fi
 else
-    run_iperf "single" "$IPERF_OUT" "$PORT" "$N" "$REVERSE"
+    run_iperf "single" "$IPERF_OUT" "$PORT" "$N" "$REVERSE" "$IPERF_NETNS" "$IPERF_CPUSET" "$IPERF_CMD_PREFIX" "$IPERF_BIN"
 fi
 
 cleanup


### PR DESCRIPTION
## Summary
- add `--mixed-cos-isolated` to `test/incus/fairness-harness.sh`
- support per-class generator placement via netns, CPU set, command prefix, binary, and RSS/NIC steering metadata
- write `generator-placement.txt` artifacts with per-class shaper rates and exact iperf command lines
- document hostile qualification usage in `docs/fairness-regimes.md`

## Live validation
- Deployed `master` to `loss:xpf-userspace-fw0/fw1` with `BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env ./test/incus/cluster-setup.sh deploy all`
- Re-applied symmetric CoS fixture: `./test/incus/apply-cos-config.sh --symmetric loss:xpf-userspace-fw0`
- `--mixed-cos` reverse run, `COS_IFINDEX=5`, 90s: PASS queue 4 and queue 5
- `--mixed-cos-isolated` reverse run, primary taskset `0-3`, mixed taskset `4-7`, 90s: PASS queue 4 and queue 5
- Artifact: `/tmp/cos-mixed-isolated-20260511/generator-placement.txt`

## Local validation
- `bash -n test/incus/fairness-harness.sh`
- isolated-mode smoke with `/bin/true` generators and artifact assertion
- identical-placement negative smoke exits 2
- normal mixed-mode smoke with `/bin/true` generators
- `cargo test --manifest-path userspace-dp/Cargo.toml --bin fairness-eval`
- `git diff --check`

Fixes #1257