### PR TITLE
Expose fairness RSS structure metrics

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -321,7 +321,24 @@ lightweight `--mixed-cos` mode remains the default for routine runs.
 
 For production observability, xpf MUST export:
 
-- **`xpf_fairness_saturated{queue=...}`** Prometheus gauge: 0 or
+- **`xpf_fairness_active_flows{ifindex=..., queue_id=...}`** gauge:
+  total active flows observed for the egress CoS queue in the current
+  userspace status snapshot.
+- **`xpf_fairness_active_workers{ifindex=..., queue_id=...}`** gauge:
+  workers with at least one active flow for the egress CoS queue.
+- **`xpf_fairness_max_worker_flow_share{ifindex=..., queue_id=...}`**
+  gauge: largest fraction of the queue's active flows owned by one
+  worker. This is the production-facing `max-worker-flow-share`
+  signal from #1247.
+- **`xpf_fairness_cstruct{ifindex=..., queue_id=...}`** gauge: the
+  current computed structural CoV ceiling for the egress CoS queue.
+  It is derived from
+  `xpf_userspace_cos_active_flow_count{ifindex,queue_id,worker_id}`;
+  no packet-path state or global atomics are added.
+- **`xpf_fairness_cos_active_flow_counts_truncated`** gauge: 1 when
+  the status snapshot was truncated before the fairness RSS gauges
+  were derived; 0 otherwise.
+- **`xpf_fairness_saturated{ifindex=..., queue_id=...}`** Prometheus gauge: 0 or
   1. Computed from rolling 30-second window of aggregate
   throughput vs structural cap (per "Saturation detection").
   Diagnostic only — saturation does not change pass/fail of the
@@ -331,14 +348,12 @@ For production observability, xpf MUST export:
   low_n_degenerate}` labels is dropped: with the structural-
   ceiling gate replacing fixed regime bands, distinguishing
   balanced/skewed/degenerate is not load-bearing on pass/fail —
-  the per-worker active-flow distribution `{aᵢ}` is the
-  underlying signal and is exported separately if the harness
-  needs it for context.
-- **`xpf_fairness_cstruct{queue=...}`** gauge: the current
-  computed structural CoV ceiling.
-- **`xpf_fairness_observed_cov{queue=...}`** gauge: rolling
+  the per-worker active-flow distribution `{a_i}` is the underlying
+  signal and is exported separately if the harness needs it for
+  context.
+- **`xpf_fairness_observed_cov{ifindex=..., queue_id=...}`** gauge: rolling
   observed CoV for the queue.
-- **`xpf_fairness_starved_flows{queue=...}`** counter:
+- **`xpf_fairness_starved_flows{ifindex=..., queue_id=...}`** counter:
   monotonic count of flows that fell below the starved-flow
   threshold (< 1% of mean per-flow throughput) over their lifetime.
 
@@ -347,11 +362,12 @@ Operators tracking this contract in production monitor the gap
 healthy production system has the gap `≤ 0.05` and the counter
 flat.
 
-**These Prometheus metrics do not currently exist in the
-collector.** They are mandated by this contract and must be
-added in a follow-up PR alongside the harness work that computes
-`Cstruct` and the rolling-window inputs. Until that PR ships, the
-contract is enforced via the test harness only.
+The RSS-structure gauges above are exported from the production
+Prometheus collector. The rolling throughput metrics
+(`xpf_fairness_saturated`, `xpf_fairness_observed_cov`, and
+`xpf_fairness_starved_flows`) still require a follow-up runtime window;
+until that ships, observed CoV and starved-flow gates are enforced via
+the test harness.
 
 ## Steady-state measurement window
 

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -320,6 +320,16 @@ checked at runtime, not just in test.
 violates that expectation. Runtime config/alerting can build on the
 same expectation language.
 
+The second production-observability slice exports per-CoS RSS structure
+gauges from the existing userspace status snapshot:
+`xpf_fairness_cstruct`, `xpf_fairness_active_flows`,
+`xpf_fairness_active_workers`, and
+`xpf_fairness_max_worker_flow_share`, plus
+`xpf_fairness_cos_active_flow_counts_truncated` to mark capped source
+snapshots. These make structural skew visible in Prometheus without
+adding packet-path state. Opt-in config/alerting for expectation
+violations remains separate follow-up work.
+
 ## Open work
 
 - **#547 — Deterministic RSS-skew test fixture**: SHIPPED as PR #1223
@@ -335,9 +345,9 @@ same expectation language.
   closure archive. Do not re-open #1211 directly. As of the
   2026-05-07 sweep below, NO empirically failing workload exists.
 - **#1247 — Path 4 workload/RSS expectation gate**: first harness
-  slice shipped in this work; runtime config/alerting remains the
-  production follow-up if operators want opt-in paging on structural
-  skew.
+  slice shipped in this work; production RSS-structure gauges are now
+  exported from Prometheus. Runtime config/alerting remains the
+  follow-up if operators want opt-in paging on structural skew.
 
 ## Empirical sweep across workload classes (2026-05-07)
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"math"
 	"net"
 	"os"
 	"runtime"
@@ -105,6 +106,14 @@ type xpfCollector struct {
 	// #1248: class-specific active flow distribution by egress CoS
 	// queue. This is the production/mixed-workload {a_i} source.
 	cosActiveFlowCount *prometheus.Desc
+	// #1247: production RSS/workload health gauges derived from the
+	// same per-CoS {a_i} snapshot. These expose the structural ceiling
+	// without adding packet-path state or global atomics.
+	fairnessCstruct            *prometheus.Desc
+	fairnessActiveWorkers      *prometheus.Desc
+	fairnessActiveFlows        *prometheus.Desc
+	fairnessMaxWorkerFlowShare *prometheus.Desc
+	fairnessCoSCountsTruncated *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -374,6 +383,32 @@ func newCollector(srv *Server) *xpfCollector {
 				"fairness harness input for mixed workloads (#1248).",
 			[]string{"ifindex", "queue_id", "worker_id"}, nil,
 		),
+		fairnessCstruct: prometheus.NewDesc(
+			"xpf_fairness_cstruct",
+			"Structural per-flow CoV ceiling for this egress CoS queue, derived from "+
+				"xpf_userspace_cos_active_flow_count and the fairness-regimes contract (#1247).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessActiveWorkers: prometheus.NewDesc(
+			"xpf_fairness_active_workers",
+			"Number of workers with at least one active flow for this egress CoS queue (#1247).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessActiveFlows: prometheus.NewDesc(
+			"xpf_fairness_active_flows",
+			"Total active flows observed for this egress CoS queue in the current userspace snapshot (#1247).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessMaxWorkerFlowShare: prometheus.NewDesc(
+			"xpf_fairness_max_worker_flow_share",
+			"Largest fraction of this egress CoS queue's active flows owned by one worker (#1247).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessCoSCountsTruncated: prometheus.NewDesc(
+			"xpf_fairness_cos_active_flow_counts_truncated",
+			"1 when the userspace CoS active-flow snapshot was truncated before fairness RSS gauges were derived; 0 otherwise (#1247).",
+			nil, nil,
+		),
 	}
 }
 
@@ -427,6 +462,11 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.workerDead
 	ch <- c.bindingActiveFlowCount
 	ch <- c.cosActiveFlowCount
+	ch <- c.fairnessCstruct
+	ch <- c.fairnessActiveWorkers
+	ch <- c.fairnessActiveFlows
+	ch <- c.fairnessMaxWorkerFlowShare
+	ch <- c.fairnessCoSCountsTruncated
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -466,6 +506,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp da
 	c.emitWorkerRuntime(ch, status)
 	c.emitBindingActiveFlowCount(ch, status)
 	c.emitCoSActiveFlowCount(ch, status)
+	c.emitFairnessRSSGauges(ch, status)
 }
 
 // #1219: emit per-binding distinct active flow count for the fairness
@@ -498,6 +539,131 @@ func (c *xpfCollector) emitCoSActiveFlowCount(ch chan<- prometheus.Metric, statu
 			strconv.Itoa(row.Ifindex),
 			strconv.FormatUint(uint64(row.QueueID), 10),
 			strconv.FormatUint(uint64(row.WorkerID), 10),
+		)
+	}
+}
+
+type fairnessRSSKey struct {
+	ifindex int
+	queueID uint8
+}
+
+type fairnessRSSAggregate struct {
+	totalActiveFlows uint64
+	activeWorkers    uint64
+	maxWorkerFlows   uint32
+	weightedMean     float64
+	weightedM2       float64
+}
+
+func (a *fairnessRSSAggregate) add(active uint32) {
+	if active == 0 {
+		return
+	}
+	weight := float64(active)
+	value := 1.0 / weight
+	oldTotal := float64(a.totalActiveFlows)
+	newTotal := oldTotal + weight
+	delta := value - a.weightedMean
+	a.weightedMean += (weight / newTotal) * delta
+	a.weightedM2 += weight * delta * (value - a.weightedMean)
+
+	a.totalActiveFlows += uint64(active)
+	a.activeWorkers++
+	if active > a.maxWorkerFlows {
+		a.maxWorkerFlows = active
+	}
+}
+
+func (a fairnessRSSAggregate) cstruct() float64 {
+	if a.totalActiveFlows == 0 || a.weightedMean == 0 {
+		return 0
+	}
+	variance := a.weightedM2 / float64(a.totalActiveFlows)
+	if variance <= 0 {
+		return 0
+	}
+	return math.Sqrt(variance) / a.weightedMean
+}
+
+func (a fairnessRSSAggregate) maxWorkerFlowShare() float64 {
+	if a.totalActiveFlows == 0 {
+		return 0
+	}
+	return float64(a.maxWorkerFlows) / float64(a.totalActiveFlows)
+}
+
+// #1247: expose production RSS/workload health gauges from the same
+// per-CoS active-flow distribution used by the fairness harness. This
+// remains a status-snapshot calculation; it does not feed scheduling and
+// does not add packet-path shared state.
+func (c *xpfCollector) emitFairnessRSSGauges(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	truncated := 0.0
+	if status.CoSActiveFlowCountsTruncated {
+		truncated = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessCoSCountsTruncated,
+		prometheus.GaugeValue,
+		truncated,
+	)
+
+	byQueue := make(map[fairnessRSSKey]*fairnessRSSAggregate)
+	for _, row := range status.CoSActiveFlowCounts {
+		key := fairnessRSSKey{ifindex: row.Ifindex, queueID: row.QueueID}
+		agg := byQueue[key]
+		if agg == nil {
+			agg = &fairnessRSSAggregate{}
+			byQueue[key] = agg
+		}
+		agg.add(row.ActiveFlowCount)
+	}
+
+	keys := make([]fairnessRSSKey, 0, len(byQueue))
+	for key := range byQueue {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ifindex != keys[j].ifindex {
+			return keys[i].ifindex < keys[j].ifindex
+		}
+		return keys[i].queueID < keys[j].queueID
+	})
+
+	for _, key := range keys {
+		agg := byQueue[key]
+		if agg == nil || agg.totalActiveFlows == 0 {
+			continue
+		}
+		ifindexLabel := strconv.Itoa(key.ifindex)
+		queueLabel := strconv.FormatUint(uint64(key.queueID), 10)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessCstruct,
+			prometheus.GaugeValue,
+			agg.cstruct(),
+			ifindexLabel,
+			queueLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessActiveWorkers,
+			prometheus.GaugeValue,
+			float64(agg.activeWorkers),
+			ifindexLabel,
+			queueLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessActiveFlows,
+			prometheus.GaugeValue,
+			float64(agg.totalActiveFlows),
+			ifindexLabel,
+			queueLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessMaxWorkerFlowShare,
+			prometheus.GaugeValue,
+			agg.maxWorkerFlowShare(),
+			ifindexLabel,
+			queueLabel,
 		)
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -302,4 +303,220 @@ func TestEmitCoSActiveFlowCount_LabelsAndValue(t *testing.T) {
 	if !found {
 		t.Fatalf("queue 4 worker 1 series missing from emitCoSActiveFlowCount output")
 	}
+}
+
+func TestEmitFairnessRSSGauges_DerivesStructuralCeiling(t *testing.T) {
+	c := &xpfCollector{
+		fairnessCstruct: prometheus.NewDesc(
+			"xpf_fairness_cstruct",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessActiveWorkers: prometheus.NewDesc(
+			"xpf_fairness_active_workers",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessActiveFlows: prometheus.NewDesc(
+			"xpf_fairness_active_flows",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessMaxWorkerFlowShare: prometheus.NewDesc(
+			"xpf_fairness_max_worker_flow_share",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessCoSCountsTruncated: prometheus.NewDesc(
+			"xpf_fairness_cos_active_flow_counts_truncated",
+			"test desc",
+			nil,
+			nil,
+		),
+	}
+
+	status := dpuserspace.ProcessStatus{
+		CoSActiveFlowCountsTruncated: true,
+		CoSActiveFlowCounts: []dpuserspace.CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 3},
+			{Ifindex: 80, QueueID: 4, WorkerID: 2, ActiveFlowCount: 0},
+			{Ifindex: 80, QueueID: 5, WorkerID: 0, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 5, WorkerID: 1, ActiveFlowCount: 2},
+		},
+	}
+
+	got := collectFromEmitFairnessRSSGauges(t, c, status)
+	if len(got) != 9 {
+		t.Fatalf("emitFairnessRSSGauges: want 9 metrics (truncation + 4 per active queue), got %d", len(got))
+	}
+
+	assertGaugeClose(t, got, c.fairnessCoSCountsTruncated, nil, 1)
+	labelsQ4 := map[string]string{"ifindex": "80", "queue_id": "4"}
+	assertGaugeClose(t, got, c.fairnessCstruct, labelsQ4, 0.577350269)
+	assertGaugeClose(t, got, c.fairnessActiveWorkers, labelsQ4, 2)
+	assertGaugeClose(t, got, c.fairnessActiveFlows, labelsQ4, 4)
+	assertGaugeClose(t, got, c.fairnessMaxWorkerFlowShare, labelsQ4, 0.75)
+
+	labelsQ5 := map[string]string{"ifindex": "80", "queue_id": "5"}
+	assertGaugeClose(t, got, c.fairnessCstruct, labelsQ5, 0)
+	assertGaugeClose(t, got, c.fairnessActiveWorkers, labelsQ5, 2)
+	assertGaugeClose(t, got, c.fairnessActiveFlows, labelsQ5, 4)
+	assertGaugeClose(t, got, c.fairnessMaxWorkerFlowShare, labelsQ5, 0.5)
+}
+
+func TestEmitFairnessRSSGauges_EmptyDistributionOnlyReportsTruncation(t *testing.T) {
+	c := &xpfCollector{
+		fairnessCstruct: prometheus.NewDesc(
+			"xpf_fairness_cstruct",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessActiveWorkers: prometheus.NewDesc(
+			"xpf_fairness_active_workers",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessActiveFlows: prometheus.NewDesc(
+			"xpf_fairness_active_flows",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessMaxWorkerFlowShare: prometheus.NewDesc(
+			"xpf_fairness_max_worker_flow_share",
+			"test desc",
+			[]string{"ifindex", "queue_id"},
+			nil,
+		),
+		fairnessCoSCountsTruncated: prometheus.NewDesc(
+			"xpf_fairness_cos_active_flow_counts_truncated",
+			"test desc",
+			nil,
+			nil,
+		),
+	}
+
+	got := collectFromEmitFairnessRSSGauges(t, c, dpuserspace.ProcessStatus{})
+	if len(got) != 1 {
+		t.Fatalf("empty fairness distribution should emit only truncation gauge, got %d metrics", len(got))
+	}
+	assertGaugeClose(t, got, c.fairnessCoSCountsTruncated, nil, 0)
+}
+
+func TestFairnessRSSAggregateCstruct_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		dist []uint32
+		want float64
+	}{
+		{name: "single one-flow worker", dist: []uint32{1}, want: 0},
+		{name: "single multi-flow worker", dist: []uint32{5}, want: 0},
+		{name: "uniform multi-worker", dist: []uint32{3, 3, 3}, want: 0},
+		{name: "severe skew", dist: []uint32{1, 99}, want: 4.92468529477},
+		{
+			name: "near-uniform billion-scale counts stay nonzero",
+			dist: []uint32{1_000_000_000, 1_000_000_001},
+			want: 4.9999999975e-10,
+		},
+		{
+			name: "near-uniform uint32-max counts stay nonzero",
+			dist: []uint32{4_294_967_294, 4_294_967_295},
+			want: 1.16415321868e-10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var agg fairnessRSSAggregate
+			for _, active := range tt.dist {
+				agg.add(active)
+			}
+			if got := agg.cstruct(); math.Abs(got-tt.want) > 1e-12 {
+				t.Fatalf("cstruct(%v) = %.15g, want %.15g", tt.dist, got, tt.want)
+			}
+		})
+	}
+}
+
+func collectFromEmitFairnessRSSGauges(
+	t *testing.T,
+	c *xpfCollector,
+	status dpuserspace.ProcessStatus,
+) []prometheus.Metric {
+	t.Helper()
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitFairnessRSSGauges(ch, status)
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	expected := map[*prometheus.Desc]struct{}{
+		c.fairnessCstruct:            {},
+		c.fairnessActiveWorkers:      {},
+		c.fairnessActiveFlows:        {},
+		c.fairnessMaxWorkerFlowShare: {},
+		c.fairnessCoSCountsTruncated: {},
+	}
+	for _, m := range got {
+		if _, ok := expected[m.Desc()]; !ok {
+			t.Fatalf("unexpected metric leaked from emitFairnessRSSGauges: %s", m.Desc())
+		}
+	}
+	return got
+}
+
+func assertGaugeClose(
+	t *testing.T,
+	metrics []prometheus.Metric,
+	desc *prometheus.Desc,
+	wantLabels map[string]string,
+	want float64,
+) {
+	t.Helper()
+	for _, m := range metrics {
+		if m.Desc() != desc {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		if !metricHasLabels(&pb, wantLabels) {
+			continue
+		}
+		if pb.Gauge == nil {
+			t.Fatalf("metric %s has no gauge", desc)
+		}
+		if got := pb.Gauge.GetValue(); math.Abs(got-want) > 0.000001 {
+			t.Fatalf("metric %s labels=%v got %v, want %v", desc, wantLabels, got, want)
+		}
+		return
+	}
+	t.Fatalf("metric %s labels=%v not found", desc, wantLabels)
+}
+
+func metricHasLabels(pb *dto.Metric, want map[string]string) bool {
+	if len(want) == 0 {
+		return len(pb.GetLabel()) == 0
+	}
+	got := map[string]string{}
+	for _, label := range pb.GetLabel() {
+		got[label.GetName()] = label.GetValue()
+	}
+	for name, value := range want {
+		if got[name] != value {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- add production Prometheus gauges derived from the existing per-CoS active-flow snapshot: `xpf_fairness_cstruct`, `xpf_fairness_active_flows`, `xpf_fairness_active_workers`, and `xpf_fairness_max_worker_flow_share`
- add `xpf_fairness_cos_active_flow_counts_truncated` so operators can tell when the source snapshot was capped
- compute Cstruct from the `{a_i}` distribution with a weighted streaming variance, without allocating per-flow share vectors and without adding packet-path state or global atomics
- update fairness docs and Path 4 state to distinguish shipped RSS-structure gauges from still-open rolling observed-CoV/starvation windows
- align future rolling fairness metric labels on `{ifindex, queue_id}` and document the truncation gauge in the Path 4 state

## Validation
- `go test ./pkg/api`
- `go test ./pkg/api -run 'TestEmit(FairnessRSSGauges|CoSActiveFlowCount)|TestFairnessRSSAggregateCstruct'`
- `git diff --check`

Follow-up to #1247. This does not add opt-in runtime alert config yet; it makes the structural RSS state observable in production first.