### PR TITLE
Expose userspace fairness status text

### DIFF
--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -41,6 +41,10 @@ func (c *ctl) handleShow(args []string) error {
 								return c.showText("chassis-cluster-data-plane-statistics")
 							case "interfaces":
 								return c.showText("chassis-cluster-data-plane-interfaces")
+							case "fairness":
+								return c.showText("chassis-cluster-data-plane-fairness")
+							case "flows":
+								return c.showTextFiltered("chassis-cluster-data-plane-flows", strings.Join(args[4:], " "))
 							}
 						}
 						return c.showText("chassis-cluster-data-plane-statistics")

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -330,6 +330,16 @@ snapshots. These make structural skew visible in Prometheus without
 adding packet-path state. Opt-in config/alerting for expectation
 violations remains separate follow-up work.
 
+The operator text surface mirrors the same data:
+`show chassis cluster data-plane fairness` prints per-CoS active flows,
+active workers, Cstruct, and max-worker share, while
+`show chassis cluster data-plane flows` prints the bounded active
+flow-to-worker map with session, wire, and reverse-canonical tuples.
+Operators can request `show chassis cluster data-plane flows all` for
+the full helper-reported snapshot, or
+`show chassis cluster data-plane flows limit <rows>` for an explicit row
+cap.
+
 ## Open work
 
 - **#547 — Deterministic RSS-skew test fixture**: SHIPPED as PR #1223
@@ -346,8 +356,9 @@ violations remains separate follow-up work.
   2026-05-07 sweep below, NO empirically failing workload exists.
 - **#1247 — Path 4 workload/RSS expectation gate**: first harness
   slice shipped in this work; production RSS-structure gauges are now
-  exported from Prometheus. Runtime config/alerting remains the
-  follow-up if operators want opt-in paging on structural skew.
+  exported from Prometheus and the userspace status text. Runtime
+  config/alerting remains the follow-up if operators want opt-in paging
+  on structural skew.
 
 ## Empirical sweep across workload classes (2026-05-07)
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bufio"
-	"math"
 	"net"
 	"os"
 	"runtime"
@@ -543,56 +542,6 @@ func (c *xpfCollector) emitCoSActiveFlowCount(ch chan<- prometheus.Metric, statu
 	}
 }
 
-type fairnessRSSKey struct {
-	ifindex int
-	queueID uint8
-}
-
-type fairnessRSSAggregate struct {
-	totalActiveFlows uint64
-	activeWorkers    uint64
-	maxWorkerFlows   uint32
-	weightedMean     float64
-	weightedM2       float64
-}
-
-func (a *fairnessRSSAggregate) add(active uint32) {
-	if active == 0 {
-		return
-	}
-	weight := float64(active)
-	value := 1.0 / weight
-	oldTotal := float64(a.totalActiveFlows)
-	newTotal := oldTotal + weight
-	delta := value - a.weightedMean
-	a.weightedMean += (weight / newTotal) * delta
-	a.weightedM2 += weight * delta * (value - a.weightedMean)
-
-	a.totalActiveFlows += uint64(active)
-	a.activeWorkers++
-	if active > a.maxWorkerFlows {
-		a.maxWorkerFlows = active
-	}
-}
-
-func (a fairnessRSSAggregate) cstruct() float64 {
-	if a.totalActiveFlows == 0 || a.weightedMean == 0 {
-		return 0
-	}
-	variance := a.weightedM2 / float64(a.totalActiveFlows)
-	if variance <= 0 {
-		return 0
-	}
-	return math.Sqrt(variance) / a.weightedMean
-}
-
-func (a fairnessRSSAggregate) maxWorkerFlowShare() float64 {
-	if a.totalActiveFlows == 0 {
-		return 0
-	}
-	return float64(a.maxWorkerFlows) / float64(a.totalActiveFlows)
-}
-
 // #1247: expose production RSS/workload health gauges from the same
 // per-CoS active-flow distribution used by the fairness harness. This
 // remains a status-snapshot calculation; it does not feed scheduling and
@@ -608,60 +557,34 @@ func (c *xpfCollector) emitFairnessRSSGauges(ch chan<- prometheus.Metric, status
 		truncated,
 	)
 
-	byQueue := make(map[fairnessRSSKey]*fairnessRSSAggregate)
-	for _, row := range status.CoSActiveFlowCounts {
-		key := fairnessRSSKey{ifindex: row.Ifindex, queueID: row.QueueID}
-		agg := byQueue[key]
-		if agg == nil {
-			agg = &fairnessRSSAggregate{}
-			byQueue[key] = agg
-		}
-		agg.add(row.ActiveFlowCount)
-	}
-
-	keys := make([]fairnessRSSKey, 0, len(byQueue))
-	for key := range byQueue {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].ifindex != keys[j].ifindex {
-			return keys[i].ifindex < keys[j].ifindex
-		}
-		return keys[i].queueID < keys[j].queueID
-	})
-
-	for _, key := range keys {
-		agg := byQueue[key]
-		if agg == nil || agg.totalActiveFlows == 0 {
-			continue
-		}
-		ifindexLabel := strconv.Itoa(key.ifindex)
-		queueLabel := strconv.FormatUint(uint64(key.queueID), 10)
+	for _, row := range dpuserspace.CoSFairnessRSSSummaries(status) {
+		ifindexLabel := strconv.Itoa(row.Ifindex)
+		queueLabel := strconv.FormatUint(uint64(row.QueueID), 10)
 		ch <- prometheus.MustNewConstMetric(
 			c.fairnessCstruct,
 			prometheus.GaugeValue,
-			agg.cstruct(),
+			row.Cstruct,
 			ifindexLabel,
 			queueLabel,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.fairnessActiveWorkers,
 			prometheus.GaugeValue,
-			float64(agg.activeWorkers),
+			float64(row.ActiveWorkers),
 			ifindexLabel,
 			queueLabel,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.fairnessActiveFlows,
 			prometheus.GaugeValue,
-			float64(agg.totalActiveFlows),
+			float64(row.ActiveFlows),
 			ifindexLabel,
 			queueLabel,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.fairnessMaxWorkerFlowShare,
 			prometheus.GaugeValue,
-			agg.maxWorkerFlowShare(),
+			row.MaxWorkerFlowShare,
 			ifindexLabel,
 			queueLabel,
 		)

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -410,7 +410,7 @@ func TestEmitFairnessRSSGauges_EmptyDistributionOnlyReportsTruncation(t *testing
 	assertGaugeClose(t, got, c.fairnessCoSCountsTruncated, nil, 0)
 }
 
-func TestFairnessRSSAggregateCstruct_EdgeCases(t *testing.T) {
+func TestCoSFairnessRSSSummaries_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name string
 		dist []uint32
@@ -434,11 +434,20 @@ func TestFairnessRSSAggregateCstruct_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var agg fairnessRSSAggregate
-			for _, active := range tt.dist {
-				agg.add(active)
+			status := dpuserspace.ProcessStatus{}
+			for workerID, active := range tt.dist {
+				status.CoSActiveFlowCounts = append(status.CoSActiveFlowCounts, dpuserspace.CoSActiveFlowCountStatus{
+					Ifindex:         80,
+					QueueID:         4,
+					WorkerID:        uint32(workerID),
+					ActiveFlowCount: active,
+				})
 			}
-			if got := agg.cstruct(); math.Abs(got-tt.want) > 1e-12 {
+			rows := dpuserspace.CoSFairnessRSSSummaries(status)
+			if len(rows) != 1 {
+				t.Fatalf("CoSFairnessRSSSummaries(%v) returned %d rows, want 1", tt.dist, len(rows))
+			}
+			if got := rows[0].Cstruct; math.Abs(got-tt.want) > 1e-12 {
 				t.Fatalf("cstruct(%v) = %.15g, want %.15g", tt.dist, got, tt.want)
 			}
 		})

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -65,6 +65,14 @@ func (c *CLI) showChassisCluster(args []string) error {
 					return c.showChassisClusterDataPlaneStats()
 				case "interfaces":
 					return c.showChassisClusterDataPlaneInterfaces()
+				case "fairness":
+					return c.showChassisClusterDataPlaneFairness()
+				case "flows":
+					limit, err := dpuserspace.ParseFlowWorkerMapLimitSpec(strings.Join(args[2:], " "))
+					if err != nil {
+						return err
+					}
+					return c.showChassisClusterDataPlaneFlows(limit)
 				}
 			}
 			cmdtree.PrintTreeHelp("show chassis cluster data-plane:", operationalTree, "show", "chassis", "cluster", "data-plane")
@@ -212,6 +220,32 @@ func (c *CLI) showChassisClusterDataPlaneInterfaces() error {
 		fmt.Println()
 		fmt.Print(dpuserspace.FormatBindings(status))
 	}
+	return nil
+}
+
+func (c *CLI) showChassisClusterDataPlaneFairness() error {
+	if c.cluster == nil {
+		fmt.Println("Cluster not configured")
+		return nil
+	}
+	status, err := c.userspaceDataplaneStatus()
+	if err != nil {
+		return err
+	}
+	fmt.Print(dpuserspace.FormatFairnessRSS(status))
+	return nil
+}
+
+func (c *CLI) showChassisClusterDataPlaneFlows(limit int) error {
+	if c.cluster == nil {
+		fmt.Println("Cluster not configured")
+		return nil
+	}
+	status, err := c.userspaceDataplaneStatus()
+	if err != nil {
+		return err
+	}
+	fmt.Print(dpuserspace.FormatFlowWorkerMap(status, limit))
 	return nil
 }
 

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -73,6 +73,11 @@ var OperationalTree = map[string]*Node{
 				"data-plane": {Desc: "Show data-plane information", Children: map[string]*Node{
 					"statistics": {Desc: "Show data-plane statistics"},
 					"interfaces": {Desc: "Show data-plane interfaces"},
+					"fairness":   {Desc: "Show userspace fairness RSS structure"},
+					"flows": {Desc: "Show userspace flow-to-worker diagnostics", Children: map[string]*Node{
+						"all":   {Desc: "Show all helper-reported flow-to-worker rows"},
+						"limit": {Desc: "Limit flow-to-worker rows"},
+					}},
 				}},
 				"ip-monitoring": {Desc: "Show IP monitoring information", Children: map[string]*Node{
 					"status": {Desc: "Show IP monitoring status"},

--- a/pkg/dataplane/userspace/fairness.go
+++ b/pkg/dataplane/userspace/fairness.go
@@ -1,0 +1,111 @@
+package userspace
+
+import (
+	"math"
+	"sort"
+)
+
+type CoSFairnessRSSSummary struct {
+	Ifindex             int
+	QueueID             uint8
+	ActiveFlows         uint64
+	ActiveWorkers       uint64
+	Cstruct             float64
+	MaxWorkerFlowShare  float64
+	SourceRowsTruncated bool
+}
+
+type cosFairnessRSSKey struct {
+	ifindex int
+	queueID uint8
+}
+
+type cosFairnessRSSAggregate struct {
+	totalActiveFlows uint64
+	activeWorkers    uint64
+	maxWorkerFlows   uint32
+	weightedMean     float64
+	weightedM2       float64
+}
+
+func (a *cosFairnessRSSAggregate) add(active uint32) {
+	if active == 0 {
+		return
+	}
+	weight := float64(active)
+	value := 1.0 / weight
+	oldTotal := float64(a.totalActiveFlows)
+	newTotal := oldTotal + weight
+	delta := value - a.weightedMean
+	a.weightedMean += (weight / newTotal) * delta
+	a.weightedM2 += weight * delta * (value - a.weightedMean)
+
+	a.totalActiveFlows += uint64(active)
+	a.activeWorkers++
+	if active > a.maxWorkerFlows {
+		a.maxWorkerFlows = active
+	}
+}
+
+func (a cosFairnessRSSAggregate) cstruct() float64 {
+	if a.totalActiveFlows == 0 || a.weightedMean == 0 {
+		return 0
+	}
+	variance := a.weightedM2 / float64(a.totalActiveFlows)
+	if variance <= 0 {
+		return 0
+	}
+	return math.Sqrt(variance) / a.weightedMean
+}
+
+func (a cosFairnessRSSAggregate) maxWorkerFlowShare() float64 {
+	if a.totalActiveFlows == 0 {
+		return 0
+	}
+	return float64(a.maxWorkerFlows) / float64(a.totalActiveFlows)
+}
+
+// CoSFairnessRSSSummaries derives the production/operator RSS-structure
+// view from the low-frequency per-CoS active-flow snapshot. It is status
+// math only: no packet-path state, no locks, no scheduler feedback.
+func CoSFairnessRSSSummaries(status ProcessStatus) []CoSFairnessRSSSummary {
+	byQueue := make(map[cosFairnessRSSKey]*cosFairnessRSSAggregate)
+	for _, row := range status.CoSActiveFlowCounts {
+		key := cosFairnessRSSKey{ifindex: row.Ifindex, queueID: row.QueueID}
+		agg := byQueue[key]
+		if agg == nil {
+			agg = &cosFairnessRSSAggregate{}
+			byQueue[key] = agg
+		}
+		agg.add(row.ActiveFlowCount)
+	}
+
+	keys := make([]cosFairnessRSSKey, 0, len(byQueue))
+	for key := range byQueue {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ifindex != keys[j].ifindex {
+			return keys[i].ifindex < keys[j].ifindex
+		}
+		return keys[i].queueID < keys[j].queueID
+	})
+
+	out := make([]CoSFairnessRSSSummary, 0, len(keys))
+	for _, key := range keys {
+		agg := byQueue[key]
+		if agg == nil || agg.totalActiveFlows == 0 {
+			continue
+		}
+		out = append(out, CoSFairnessRSSSummary{
+			Ifindex:             key.ifindex,
+			QueueID:             key.queueID,
+			ActiveFlows:         agg.totalActiveFlows,
+			ActiveWorkers:       agg.activeWorkers,
+			Cstruct:             agg.cstruct(),
+			MaxWorkerFlowShare:  agg.maxWorkerFlowShare(),
+			SourceRowsTruncated: status.CoSActiveFlowCountsTruncated,
+		})
+	}
+	return out
+}

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -2,9 +2,14 @@ package userspace
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
+
+const defaultFlowWorkerMapLimit = 128
+const flowWorkerMapAllLimit = -1
 
 func localHAForwardingRole(status ProcessStatus) string {
 	if len(status.HAGroups) == 0 {
@@ -338,6 +343,149 @@ func FormatStatusSummary(status ProcessStatus) string {
 	return b.String()
 }
 
+func FormatFairnessRSS(status ProcessStatus) string {
+	var b strings.Builder
+	rows := CoSFairnessRSSSummaries(status)
+	fmt.Fprintln(&b, "Userspace fairness RSS structure:")
+	if status.CoSActiveFlowCountsTruncated {
+		fmt.Fprintln(&b, "  warning: CoS active-flow snapshot truncated; derived values are partial")
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(&b, "  none")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "  %-8s %-7s %-11s %-13s %-10s %-10s\n",
+		"Ifindex", "Queue", "ActiveFlows", "ActiveWorkers", "Cstruct", "MaxShare")
+	for _, row := range rows {
+		maxShare := fmt.Sprintf("%.2f%%", 100.0*row.MaxWorkerFlowShare)
+		fmt.Fprintf(&b, "  %-8d %-7d %-11d %-13d %-10.6f %-10s\n",
+			row.Ifindex,
+			row.QueueID,
+			row.ActiveFlows,
+			row.ActiveWorkers,
+			row.Cstruct,
+			maxShare,
+		)
+	}
+	return b.String()
+}
+
+func FormatFlowWorkerMap(status ProcessStatus, limit int) string {
+	var b strings.Builder
+	rows := append([]FlowWorkerStatus(nil), status.FlowWorkerMap...)
+	sort.Slice(rows, func(i, j int) bool { return flowWorkerStatusLess(rows[i], rows[j]) })
+	if limit == 0 {
+		limit = defaultFlowWorkerMapLimit
+	}
+
+	fmt.Fprintln(&b, "Userspace flow-worker map:")
+	if status.FlowWorkerMapTruncated {
+		fmt.Fprintln(&b, "  warning: helper flow-worker snapshot truncated before daemon formatting")
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(&b, "  none")
+		return b.String()
+	}
+	if limit > 0 && len(rows) > limit {
+		fmt.Fprintf(&b, "  showing first %d of %d rows\n", limit, len(rows))
+		rows = rows[:limit]
+	}
+	fmt.Fprintf(&b, "  %-6s %-6s %-5s %-12s %-7s %-11s %-11s %-7s %-5s %s\n",
+		"Worker", "Queue", "Slot", "Interface", "Ifidx", "Ingress", "Egress", "TxIf", "CoS", "Session")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "  %-6d %-6d %-5d %-12s %-7d %-11d %-11d %-7d %-5s %s",
+			row.WorkerID,
+			row.QueueID,
+			row.Slot,
+			orDash(row.Interface),
+			row.Ifindex,
+			row.IngressIfindex,
+			row.EgressIfindex,
+			row.TxIfindex,
+			formatOptionalUint8(row.CoSQueueID),
+			formatFlowTuple(row.SessionKey),
+		)
+		if wire := formatFlowTuple(row.ForwardWireKey); wire != "-" {
+			fmt.Fprintf(&b, " wire=%s", wire)
+		}
+		if rev := formatFlowTuple(row.ReverseCanonicalKey); rev != "-" {
+			fmt.Fprintf(&b, " reverse=%s", rev)
+		}
+		if row.AgeEpochs > 0 {
+			fmt.Fprintf(&b, " age-epochs=%d", row.AgeEpochs)
+		}
+		if row.DSCPRewrite != nil {
+			fmt.Fprintf(&b, " dscp-rewrite=%d", *row.DSCPRewrite)
+		}
+		fmt.Fprintln(&b)
+	}
+	return b.String()
+}
+
+func ParseFlowWorkerMapLimitSpec(spec string) (int, error) {
+	fields := strings.Fields(spec)
+	switch len(fields) {
+	case 0:
+		return 0, nil
+	case 1:
+		field := strings.ToLower(fields[0])
+		if field == "all" {
+			return flowWorkerMapAllLimit, nil
+		}
+		if field == "limit" {
+			return 0, fmt.Errorf("missing flow-worker map limit after limit")
+		}
+		if value, ok := strings.CutPrefix(field, "limit="); ok {
+			return parsePositiveFlowWorkerMapLimit(value)
+		}
+		return parsePositiveFlowWorkerMapLimit(field)
+	case 2:
+		if strings.ToLower(fields[0]) != "limit" {
+			return 0, fmt.Errorf("invalid flow-worker map selector %q: expected all or limit <rows>", spec)
+		}
+		return parsePositiveFlowWorkerMapLimit(fields[1])
+	default:
+		return 0, fmt.Errorf("invalid flow-worker map selector %q: expected all or limit <rows>", spec)
+	}
+}
+
+func parsePositiveFlowWorkerMapLimit(value string) (int, error) {
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit <= 0 {
+		return 0, fmt.Errorf("invalid flow-worker map limit %q: expected a positive integer", value)
+	}
+	return limit, nil
+}
+
+func flowWorkerStatusLess(a, b FlowWorkerStatus) bool {
+	if a.WorkerID != b.WorkerID {
+		return a.WorkerID < b.WorkerID
+	}
+	if a.QueueID != b.QueueID {
+		return a.QueueID < b.QueueID
+	}
+	if a.Slot != b.Slot {
+		return a.Slot < b.Slot
+	}
+	return flowTupleLess(a.SessionKey, b.SessionKey)
+}
+
+func flowTupleLess(a, b FlowTupleStatus) bool {
+	if a.Protocol != b.Protocol {
+		return a.Protocol < b.Protocol
+	}
+	if a.SrcIP != b.SrcIP {
+		return a.SrcIP < b.SrcIP
+	}
+	if a.SrcPort != b.SrcPort {
+		return a.SrcPort < b.SrcPort
+	}
+	if a.DstIP != b.DstIP {
+		return a.DstIP < b.DstIP
+	}
+	return a.DstPort < b.DstPort
+}
+
 func FormatBindings(status ProcessStatus) string {
 	var b strings.Builder
 
@@ -428,6 +576,62 @@ func FormatBindings(status ProcessStatus) string {
 		}
 	}
 	return b.String()
+}
+
+func formatOptionalUint8(value *uint8) string {
+	if value == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *value)
+}
+
+func formatFlowTuple(tuple FlowTupleStatus) string {
+	if tuple.SrcIP == "" && tuple.DstIP == "" && tuple.SrcPort == 0 && tuple.DstPort == 0 && tuple.Protocol == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%s %s->%s",
+		protocolName(tuple.Protocol),
+		formatTupleEndpoint(tuple.SrcIP, tuple.SrcPort),
+		formatTupleEndpoint(tuple.DstIP, tuple.DstPort),
+	)
+}
+
+func formatTupleEndpoint(ip string, port uint16) string {
+	if ip == "" {
+		ip = "?"
+	}
+	if port == 0 {
+		return ip
+	}
+	if strings.Contains(ip, ":") {
+		return fmt.Sprintf("[%s]:%d", ip, port)
+	}
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+func protocolName(protocol uint8) string {
+	switch protocol {
+	case 1:
+		return "icmp"
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	case 58:
+		return "icmp6"
+	default:
+		if protocol == 0 {
+			return "proto0"
+		}
+		return fmt.Sprintf("proto%d", protocol)
+	}
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
 }
 
 func formatStatusAge(d time.Duration) string {

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -115,6 +115,160 @@ func TestFormatStatusSummaryReportsStandbyArmedRole(t *testing.T) {
 	}
 }
 
+func TestFormatFairnessRSS(t *testing.T) {
+	status := ProcessStatus{
+		CoSActiveFlowCountsTruncated: true,
+		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 3},
+			{Ifindex: 80, QueueID: 4, WorkerID: 2, ActiveFlowCount: 0},
+			{Ifindex: 80, QueueID: 5, WorkerID: 0, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 5, WorkerID: 1, ActiveFlowCount: 2},
+		},
+	}
+
+	out := FormatFairnessRSS(status)
+	for _, want := range []string{
+		"Userspace fairness RSS structure:",
+		"warning: CoS active-flow snapshot truncated",
+		"Ifindex",
+		"Queue",
+		"ActiveFlows",
+		"Cstruct",
+		"80       4       4           2             0.577350   75.00%",
+		"80       5       4           2             0.000000   50.00%",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fairness output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatFlowWorkerMap(t *testing.T) {
+	cosQueue := uint8(4)
+	dscpRewrite := uint8(46)
+	status := ProcessStatus{
+		FlowWorkerMapTruncated: true,
+		FlowWorkerMap: []FlowWorkerStatus{
+			{
+				Slot:           3,
+				QueueID:        2,
+				WorkerID:       1,
+				Interface:      "ge-0-0-2",
+				Ifindex:        80,
+				IngressIfindex: 70,
+				EgressIfindex:  80,
+				TxIfindex:      80,
+				CoSQueueID:     &cosQueue,
+				DSCPRewrite:    &dscpRewrite,
+				AgeEpochs:      7,
+				SessionKey: FlowTupleStatus{
+					Protocol: 6,
+					SrcIP:    "172.16.80.10",
+					SrcPort:  40000,
+					DstIP:    "172.16.80.200",
+					DstPort:  5201,
+				},
+				ForwardWireKey: FlowTupleStatus{
+					Protocol: 6,
+					SrcIP:    "172.16.80.10",
+					SrcPort:  40000,
+					DstIP:    "172.16.80.200",
+					DstPort:  5201,
+				},
+				ReverseCanonicalKey: FlowTupleStatus{
+					Protocol: 6,
+					SrcIP:    "172.16.80.200",
+					SrcPort:  5201,
+					DstIP:    "172.16.80.10",
+					DstPort:  40000,
+				},
+			},
+			{
+				Slot:     1,
+				QueueID:  1,
+				WorkerID: 0,
+				SessionKey: FlowTupleStatus{
+					Protocol: 17,
+					SrcIP:    "2001:db8::1",
+					SrcPort:  12345,
+					DstIP:    "2001:db8::2",
+					DstPort:  5201,
+				},
+			},
+		},
+	}
+
+	out := FormatFlowWorkerMap(status, 1)
+	for _, want := range []string{
+		"Userspace flow-worker map:",
+		"warning: helper flow-worker snapshot truncated",
+		"showing first 1 of 2 rows",
+		"Worker",
+		"Queue",
+		"Session",
+		"0      1      1",
+		"udp [2001:db8::1]:12345->[2001:db8::2]:5201",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("flow-worker output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "172.16.80.10") {
+		t.Fatalf("flow-worker output exceeded limit:\n%s", out)
+	}
+
+	allOut := FormatFlowWorkerMap(status, flowWorkerMapAllLimit)
+	if strings.Contains(allOut, "showing first") {
+		t.Fatalf("flow-worker all output should not be bounded:\n%s", allOut)
+	}
+	for _, want := range []string{
+		"172.16.80.10:40000->172.16.80.200:5201",
+		"wire=tcp 172.16.80.10:40000->172.16.80.200:5201",
+		"reverse=tcp 172.16.80.200:5201->172.16.80.10:40000",
+	} {
+		if !strings.Contains(allOut, want) {
+			t.Fatalf("flow-worker all output missing %q:\n%s", want, allOut)
+		}
+	}
+}
+
+func TestParseFlowWorkerMapLimitSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    int
+		wantErr bool
+	}{
+		{name: "default", spec: "", want: 0},
+		{name: "all", spec: "all", want: flowWorkerMapAllLimit},
+		{name: "bare limit", spec: "256", want: 256},
+		{name: "limit keyword", spec: "limit 4096", want: 4096},
+		{name: "limit equals", spec: "limit=1024", want: 1024},
+		{name: "zero", spec: "limit 0", wantErr: true},
+		{name: "negative", spec: "-1", wantErr: true},
+		{name: "extra", spec: "limit 1 extra", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFlowWorkerMapLimitSpec(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseFlowWorkerMapLimitSpec(%q) succeeded, want error", tt.spec)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseFlowWorkerMapLimitSpec(%q) error = %v", tt.spec, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseFlowWorkerMapLimitSpec(%q) = %d, want %d", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatBindings(t *testing.T) {
 	status := ProcessStatus{
 		Fabrics: []FabricSnapshot{

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -1056,6 +1056,12 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
 		s.showChassisClusterDataPlaneInterfaces(&buf)
 
+	case "chassis-cluster-data-plane-fairness":
+		s.showChassisClusterDataPlaneFairness(&buf)
+
+	case "chassis-cluster-data-plane-flows":
+		s.showChassisClusterDataPlaneFlows(req.Filter, &buf)
+
 	case "chassis-cluster-ip-monitoring-status":
 		// #1043 Phase 11: case body extracted to server_show_cluster_text.go
 		s.showChassisClusterIPMonitoringStatus(&buf)

--- a/pkg/grpcapi/server_show_cluster_text.go
+++ b/pkg/grpcapi/server_show_cluster_text.go
@@ -161,6 +161,41 @@ func (s *Server) showChassisClusterDataPlaneInterfaces(buf *strings.Builder) {
 	}
 }
 
+// showChassisClusterDataPlaneFairness renders the userspace per-CoS
+// fairness RSS structure snapshot.
+func (s *Server) showChassisClusterDataPlaneFairness(buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	status, err := s.userspaceDataplaneStatus()
+	if err != nil {
+		fmt.Fprintf(buf, "Userspace status unavailable: %v\n", err)
+		return
+	}
+	buf.WriteString(dpuserspace.FormatFairnessRSS(status))
+}
+
+// showChassisClusterDataPlaneFlows renders the bounded active
+// flow-to-worker diagnostic map.
+func (s *Server) showChassisClusterDataPlaneFlows(filter string, buf *strings.Builder) {
+	if s.cluster == nil {
+		fmt.Fprintln(buf, "Cluster not configured")
+		return
+	}
+	limit, err := dpuserspace.ParseFlowWorkerMapLimitSpec(filter)
+	if err != nil {
+		fmt.Fprintf(buf, "syntax error: %v\n", err)
+		return
+	}
+	status, err := s.userspaceDataplaneStatus()
+	if err != nil {
+		fmt.Fprintf(buf, "Userspace status unavailable: %v\n", err)
+		return
+	}
+	buf.WriteString(dpuserspace.FormatFlowWorkerMap(status, limit))
+}
+
 // showChassisClusterIPMonitoringStatus renders the IP-monitoring
 // (RPM-driven RG transition) status table.
 func (s *Server) showChassisClusterIPMonitoringStatus(buf *strings.Builder) {


### PR DESCRIPTION
## Summary
- add `show chassis cluster data-plane fairness` for per-CoS RSS structure: active flows, active workers, Cstruct, and max-worker share
- add `show chassis cluster data-plane flows` for bounded active flow-to-worker diagnostics with session/wire/reverse tuples
- factor RSS summary math into `dpuserspace.CoSFairnessRSSSummaries` so Prometheus and operator text share one implementation
- document the new status surface in `docs/per-5-tuple/state.md`

This is observability only: no packet-path state, no global atomics, and no scheduling feedback loop.

Refs #1247.
Refs #1249.

## Validation
- `go test ./pkg/api ./pkg/dataplane/userspace ./pkg/cmdtree ./pkg/cli ./pkg/grpcapi`
- `git diff --check`