### PR TITLE
Add runtime fairness RSS expectations

### DIFF
--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -327,8 +327,7 @@ gauges from the existing userspace status snapshot:
 `xpf_fairness_max_worker_flow_share`, plus
 `xpf_fairness_cos_active_flow_counts_truncated` to mark capped source
 snapshots. These make structural skew visible in Prometheus without
-adding packet-path state. Opt-in config/alerting for expectation
-violations remains separate follow-up work.
+adding packet-path state.
 
 The operator text surface mirrors the same data:
 `show chassis cluster data-plane fairness` prints per-CoS active flows,
@@ -339,6 +338,18 @@ Operators can request `show chassis cluster data-plane flows all` for
 the full helper-reported snapshot, or
 `show chassis cluster data-plane flows limit <rows>` for an explicit row
 cap.
+
+The runtime expectation slice adds opt-in production evaluation via
+`class-of-service fairness rss-expectation ifindex <n> queue <q>
+<expectation>`, where `<expectation>` uses the same vocabulary as
+`fairness-eval` in Junos-style set syntax (`balanced`,
+`at-least-active-workers <N>`, `max-worker-flow-share <X>`, or
+`cstruct-max <X>`; threshold values use fractions such as `0.5` in
+set syntax). Configured expectations are rendered under
+`show chassis cluster data-plane fairness` and exported as:
+
+- `xpf_fairness_rss_expectation_configured{ifindex,queue_id,expectation}`
+- `xpf_fairness_rss_skew_violation{ifindex,queue_id,expectation}`
 
 ## Open work
 
@@ -357,8 +368,8 @@ cap.
 - **#1247 — Path 4 workload/RSS expectation gate**: first harness
   slice shipped in this work; production RSS-structure gauges are now
   exported from Prometheus and the userspace status text. Runtime
-  config/alerting remains the follow-up if operators want opt-in paging
-  on structural skew.
+  expectation config and skew-violation gauges are available; alert
+  routing remains deployment policy.
 
 ## Empirical sweep across workload classes (2026-05-07)
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -113,6 +113,8 @@ type xpfCollector struct {
 	fairnessActiveFlows        *prometheus.Desc
 	fairnessMaxWorkerFlowShare *prometheus.Desc
 	fairnessCoSCountsTruncated *prometheus.Desc
+	fairnessRSSExpectation     *prometheus.Desc
+	fairnessRSSSkewViolation   *prometheus.Desc
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -408,6 +410,16 @@ func newCollector(srv *Server) *xpfCollector {
 			"1 when the userspace CoS active-flow snapshot was truncated before fairness RSS gauges were derived; 0 otherwise (#1247).",
 			nil, nil,
 		),
+		fairnessRSSExpectation: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_configured",
+			"1 for each configured opt-in RSS/workload expectation evaluated against this egress CoS queue (#1247).",
+			[]string{"ifindex", "queue_id", "expectation"}, nil,
+		),
+		fairnessRSSSkewViolation: prometheus.NewDesc(
+			"xpf_fairness_rss_skew_violation",
+			"1 when the configured RSS/workload expectation fails for this egress CoS queue; 0 when it passes (#1247).",
+			[]string{"ifindex", "queue_id", "expectation"}, nil,
+		),
 	}
 }
 
@@ -466,6 +478,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.fairnessActiveFlows
 	ch <- c.fairnessMaxWorkerFlowShare
 	ch <- c.fairnessCoSCountsTruncated
+	ch <- c.fairnessRSSExpectation
+	ch <- c.fairnessRSSSkewViolation
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -587,6 +601,45 @@ func (c *xpfCollector) emitFairnessRSSGauges(ch chan<- prometheus.Metric, status
 			row.MaxWorkerFlowShare,
 			ifindexLabel,
 			queueLabel,
+		)
+	}
+	c.emitFairnessRSSExpectationGauges(ch, status, c.configuredFairnessRSSExpectations())
+}
+
+func (c *xpfCollector) configuredFairnessRSSExpectations() []dpuserspace.FairnessRSSExpectation {
+	if c == nil || c.srv == nil || c.srv.store == nil {
+		return nil
+	}
+	return dpuserspace.FairnessRSSExpectationsFromConfig(c.srv.store.ActiveConfig())
+}
+
+func (c *xpfCollector) emitFairnessRSSExpectationGauges(
+	ch chan<- prometheus.Metric,
+	status dpuserspace.ProcessStatus,
+	expectations []dpuserspace.FairnessRSSExpectation,
+) {
+	for _, result := range dpuserspace.EvaluateFairnessRSSExpectations(status, expectations) {
+		ifindexLabel := strconv.Itoa(result.Ifindex)
+		queueLabel := strconv.FormatUint(uint64(result.QueueID), 10)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessRSSExpectation,
+			prometheus.GaugeValue,
+			1,
+			ifindexLabel,
+			queueLabel,
+			result.Expectation,
+		)
+		violation := 1.0
+		if result.Pass {
+			violation = 0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessRSSSkewViolation,
+			prometheus.GaugeValue,
+			violation,
+			ifindexLabel,
+			queueLabel,
+			result.Expectation,
 		)
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -410,6 +410,64 @@ func TestEmitFairnessRSSGauges_EmptyDistributionOnlyReportsTruncation(t *testing
 	assertGaugeClose(t, got, c.fairnessCoSCountsTruncated, nil, 0)
 }
 
+func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
+	c := &xpfCollector{
+		fairnessRSSExpectation: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_configured",
+			"test desc",
+			[]string{"ifindex", "queue_id", "expectation"},
+			nil,
+		),
+		fairnessRSSSkewViolation: prometheus.NewDesc(
+			"xpf_fairness_rss_skew_violation",
+			"test desc",
+			[]string{"ifindex", "queue_id", "expectation"},
+			nil,
+		),
+	}
+	status := dpuserspace.ProcessStatus{
+		Workers: 4,
+		CoSActiveFlowCounts: []dpuserspace.CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 3},
+			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: 4, WorkerID: 2, ActiveFlowCount: 0},
+			{Ifindex: 80, QueueID: 4, WorkerID: 3, ActiveFlowCount: 0},
+			{Ifindex: 80, QueueID: 5, WorkerID: 0, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 5, WorkerID: 1, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 5, WorkerID: 2, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 5, WorkerID: 3, ActiveFlowCount: 2},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitFairnessRSSExpectationGauges(ch, status, []dpuserspace.FairnessRSSExpectation{
+			{Ifindex: 80, QueueID: 4, RSSExpectation: "balanced"},
+			{Ifindex: 80, QueueID: 5, RSSExpectation: "balanced"},
+			{Ifindex: 80, QueueID: 6, RSSExpectation: "cstruct-max:0.25"},
+		})
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	if len(got) != 6 {
+		t.Fatalf("expected 6 expectation metrics, got %d", len(got))
+	}
+	labelsQ4 := map[string]string{"ifindex": "80", "queue_id": "4", "expectation": "balanced"}
+	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ4, 1)
+	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ4, 1)
+
+	labelsQ5 := map[string]string{"ifindex": "80", "queue_id": "5", "expectation": "balanced"}
+	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ5, 1)
+	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ5, 0)
+
+	labelsQ6 := map[string]string{"ifindex": "80", "queue_id": "6", "expectation": "cstruct-max:0.25"}
+	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ6, 1)
+	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ6, 1)
+}
+
 func TestCoSFairnessRSSSummaries_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name string
@@ -475,6 +533,8 @@ func collectFromEmitFairnessRSSGauges(
 		c.fairnessActiveFlows:        {},
 		c.fairnessMaxWorkerFlowShare: {},
 		c.fairnessCoSCountsTruncated: {},
+		c.fairnessRSSExpectation:     {},
+		c.fairnessRSSSkewViolation:   {},
 	}
 	for _, m := range got {
 		if _, ok := expected[m.Desc()]; !ok {

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -232,7 +232,7 @@ func (c *CLI) showChassisClusterDataPlaneFairness() error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(dpuserspace.FormatFairnessRSS(status))
+	fmt.Print(dpuserspace.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(c.store.ActiveConfig())))
 	return nil
 }
 

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -1189,6 +1189,21 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"scheduler-map": {args: 1, children: nil},
 			}},
 		}},
+		"fairness": {children: map[string]*schemaNode{
+			"rss-expectation": {children: map[string]*schemaNode{
+				"ifindex": {args: 1, multi: true, children: map[string]*schemaNode{
+					"queue": {args: 1, multi: true, children: map[string]*schemaNode{
+						"any":                     {children: nil},
+						"balanced":                {children: nil},
+						"active-workers":          {args: 1, children: nil},
+						"at-least-active-workers": {args: 1, children: nil},
+						"max-worker-flow-share":   {args: 1, children: nil},
+						"cstruct":                 {args: 1, children: nil},
+						"cstruct-max":             {args: 1, children: nil},
+					}},
+				}},
+			}},
+		}},
 	}},
 	"firewall": {children: map[string]*schemaNode{
 		"policer": {args: 1, multi: true, children: map[string]*schemaNode{
@@ -1368,15 +1383,15 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		}},
 		"dataplane-type": {args: 1, children: nil},
 		"dataplane": {desc: "Dataplane configuration", children: map[string]*schemaNode{
-			"cores":          {args: 1, desc: "Number of dataplane cores", children: nil},
-			"memory":         {args: 1, desc: "Dataplane memory allocation", children: nil},
-			"socket-mem":     {args: 1, desc: "DPDK socket memory", children: nil},
-			"binary":         {args: 1, desc: "Userspace dataplane helper binary path", children: nil},
-			"control-socket": {args: 1, desc: "Unix control socket path", children: nil},
-			"state-file":     {args: 1, desc: "Helper state file path", children: nil},
-			"workers":        {args: 1, desc: "Worker thread count", children: nil},
-			"ring-entries":   {args: 1, desc: "AF_XDP ring entries per queue", children: nil},
-			"poll-mode":      {args: 1, desc: "Worker poll mode (busy-poll or interrupt)", children: nil},
+			"cores":               {args: 1, desc: "Number of dataplane cores", children: nil},
+			"memory":              {args: 1, desc: "Dataplane memory allocation", children: nil},
+			"socket-mem":          {args: 1, desc: "DPDK socket memory", children: nil},
+			"binary":              {args: 1, desc: "Userspace dataplane helper binary path", children: nil},
+			"control-socket":      {args: 1, desc: "Unix control socket path", children: nil},
+			"state-file":          {args: 1, desc: "Helper state file path", children: nil},
+			"workers":             {args: 1, desc: "Worker thread count", children: nil},
+			"ring-entries":        {args: 1, desc: "AF_XDP ring entries per queue", children: nil},
+			"poll-mode":           {args: 1, desc: "Worker poll mode (busy-poll or interrupt)", children: nil},
 			"rss-indirection":     {args: 1, desc: "mlx5 RSS indirection reshaping (enable|disable)", children: nil},
 			"claim-host-tunables": {args: 1, desc: "Allow xpfd to write host-scope tunables (true|false, default false)", children: nil},
 			"cpu-governor":        {args: 1, desc: "Host cpufreq governor (performance|schedutil|default)", children: nil},

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	fairnesscontract "github.com/psaab/xpf/pkg/fairness"
 )
 
 func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
@@ -31,7 +33,6 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	if cos.Interfaces == nil {
 		cos.Interfaces = make(map[string]*CoSInterface)
 	}
-
 	if fcNode := node.FindChild("forwarding-classes"); fcNode != nil {
 		// Enforce the FC ↔ queue bijection. Junos semantics give
 		// each queue ID one forwarding class, and each FC one
@@ -320,7 +321,100 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 		}
 	}
 
+	if fairnessNode := node.FindChild("fairness"); fairnessNode != nil {
+		if rssNode := fairnessNode.FindChild("rss-expectation"); rssNode != nil {
+			seen := make(map[string]string)
+			for _, ifindexNode := range rssNode.FindChildren("ifindex") {
+				if len(ifindexNode.Keys) < 2 {
+					continue
+				}
+				ifindex, err := strconv.Atoi(ifindexNode.Keys[1])
+				if err != nil || ifindex <= 0 {
+					return fmt.Errorf("class-of-service fairness rss-expectation ifindex %q: expected positive integer", ifindexNode.Keys[1])
+				}
+				for _, queueNode := range ifindexNode.FindChildren("queue") {
+					if len(queueNode.Keys) < 2 {
+						continue
+					}
+					queue, err := strconv.Atoi(queueNode.Keys[1])
+					if err != nil || queue < 0 || queue > 255 {
+						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %q: expected queue 0..255", ifindex, queueNode.Keys[1])
+					}
+					expr, err := collectCoSFairnessRSSExpectation(queueNode)
+					if err != nil {
+						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: %w", ifindex, queue, err)
+					}
+					parsed, err := fairnesscontract.ParseRSSExpectation(expr)
+					if err != nil {
+						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: %w", ifindex, queue, err)
+					}
+					key := fmt.Sprintf("%d/%d", ifindex, queue)
+					canonical := parsed.Canonical()
+					if existing, ok := seen[key]; ok {
+						if existing == canonical {
+							continue
+						}
+						return fmt.Errorf("class-of-service fairness rss-expectation ifindex %d queue %d: duplicate expectation %q conflicts with %q", ifindex, queue, canonical, existing)
+					}
+					seen[key] = canonical
+					cos.FairnessExpectations = append(cos.FairnessExpectations, &CoSFairnessExpectation{
+						Ifindex:        ifindex,
+						QueueID:        uint8(queue),
+						RSSExpectation: canonical,
+					})
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+func collectCoSFairnessRSSExpectation(queueNode *Node) (string, error) {
+	var expr string
+	set := func(next string) error {
+		if next == "" {
+			return nil
+		}
+		if expr != "" && expr != next {
+			return fmt.Errorf("multiple expectations configured: %q and %q", expr, next)
+		}
+		expr = next
+		return nil
+	}
+	if queueNode.FindChild("any") != nil {
+		if err := set("any"); err != nil {
+			return "", err
+		}
+	}
+	if queueNode.FindChild("balanced") != nil {
+		if err := set("balanced"); err != nil {
+			return "", err
+		}
+	}
+	for _, key := range []string{"active-workers", "at-least-active-workers"} {
+		if n := queueNode.FindChild(key); n != nil {
+			if err := set("at-least-active-workers:" + nodeVal(n)); err != nil {
+				return "", err
+			}
+		}
+	}
+	if n := queueNode.FindChild("max-worker-flow-share"); n != nil {
+		if err := set("max-worker-flow-share:" + nodeVal(n)); err != nil {
+			return "", err
+		}
+	}
+	for _, key := range []string{"cstruct", "cstruct-max"} {
+		if n := queueNode.FindChild(key); n != nil {
+			if err := set("cstruct-max:" + nodeVal(n)); err != nil {
+				return "", err
+			}
+		}
+	}
+	if expr == "" {
+		return "", fmt.Errorf("missing expectation; expected any, balanced, at-least-active-workers, max-worker-flow-share, or cstruct-max")
+	}
+	return expr, nil
 }
 
 func parseCoSTransmitRate(node *Node) (uint64, bool) {

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -164,6 +164,73 @@ func TestCompileClassOfServiceSetSyntax(t *testing.T) {
 	}
 }
 
+func TestCompileClassOfServiceFairnessRSSExpectations(t *testing.T) {
+	lines := []string{
+		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
+		"set class-of-service fairness rss-expectation ifindex 5 queue 5 max-worker-flow-share 0.5",
+		"set class-of-service fairness rss-expectation ifindex 6 queue 7 cstruct-max 0.25",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	got := cfg.ClassOfService.FairnessExpectations
+	if len(got) != 3 {
+		t.Fatalf("FairnessExpectations len = %d, want 3: %#v", len(got), got)
+	}
+	tests := []struct {
+		idx     int
+		ifindex int
+		queueID uint8
+		expect  string
+	}{
+		{idx: 0, ifindex: 5, queueID: 4, expect: "balanced"},
+		{idx: 1, ifindex: 5, queueID: 5, expect: "max-worker-flow-share:0.5"},
+		{idx: 2, ifindex: 6, queueID: 7, expect: "cstruct-max:0.25"},
+	}
+	for _, tt := range tests {
+		row := got[tt.idx]
+		if row.Ifindex != tt.ifindex || row.QueueID != tt.queueID || row.RSSExpectation != tt.expect {
+			t.Fatalf("expectation[%d] = ifindex=%d queue=%d expectation=%q, want ifindex=%d queue=%d expectation=%q",
+				tt.idx, row.Ifindex, row.QueueID, row.RSSExpectation, tt.ifindex, tt.queueID, tt.expect)
+		}
+	}
+}
+
+func TestCompileClassOfServiceFairnessRSSExpectationRejectsDuplicateConflict(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
+		"set class-of-service fairness rss-expectation ifindex 5 queue 4 cstruct-max 0.25",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded, want duplicate fairness expectation error")
+	}
+	if !strings.Contains(err.Error(), "multiple expectations configured") {
+		t.Fatalf("CompileConfig error = %v, want multiple expectations configured", err)
+	}
+}
+
 func TestCoSIperfSymmetricFixtureCompilesReverseSourcePortOutputFilter(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "test", "incus", "cos-iperf-symmetric.set"))
 	if err != nil {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -298,13 +298,14 @@ type SchedulerConfig struct {
 // ClassOfServiceConfig holds CoS forwarding classes, schedulers,
 // scheduler-maps, and per-interface shaping configuration.
 type ClassOfServiceConfig struct {
-	ForwardingClasses   map[string]*CoSForwardingClass
-	DSCPClassifiers     map[string]*CoSDSCPClassifier
-	IEEE8021Classifiers map[string]*CoSIEEE8021Classifier
-	DSCPRewriteRules    map[string]*CoSDSCPRewriteRule
-	Schedulers          map[string]*CoSScheduler
-	SchedulerMaps       map[string]*CoSSchedulerMap
-	Interfaces          map[string]*CoSInterface
+	ForwardingClasses    map[string]*CoSForwardingClass
+	DSCPClassifiers      map[string]*CoSDSCPClassifier
+	IEEE8021Classifiers  map[string]*CoSIEEE8021Classifier
+	DSCPRewriteRules     map[string]*CoSDSCPRewriteRule
+	Schedulers           map[string]*CoSScheduler
+	SchedulerMaps        map[string]*CoSSchedulerMap
+	Interfaces           map[string]*CoSInterface
+	FairnessExpectations []*CoSFairnessExpectation
 }
 
 // CoSForwardingClass maps a forwarding-class name to a queue number.
@@ -394,6 +395,15 @@ type CoSInterfaceUnit struct {
 	DSCPClassifier     string
 	IEEE8021Classifier string
 	DSCPRewriteRule    string
+}
+
+// CoSFairnessExpectation declares an opt-in RSS/workload expectation for
+// one egress CoS queue. Ifindex is used intentionally because the
+// userspace status snapshot reports the same kernel identity.
+type CoSFairnessExpectation struct {
+	Ifindex        int
+	QueueID        uint8
+	RSSExpectation string
 }
 
 // SystemConfig holds system-level configuration.

--- a/pkg/dataplane/userspace/fairness.go
+++ b/pkg/dataplane/userspace/fairness.go
@@ -3,16 +3,41 @@ package userspace
 import (
 	"math"
 	"sort"
+
+	"github.com/psaab/xpf/pkg/config"
+	fairnesscontract "github.com/psaab/xpf/pkg/fairness"
 )
+
+const maxFairnessRSSWorkerSlots = 4096
 
 type CoSFairnessRSSSummary struct {
 	Ifindex             int
 	QueueID             uint8
 	ActiveFlows         uint64
 	ActiveWorkers       uint64
+	MinWorkerFlows      uint32
+	MaxWorkerFlows      uint32
+	WorkerFlowCounts    []uint32
 	Cstruct             float64
 	MaxWorkerFlowShare  float64
 	SourceRowsTruncated bool
+}
+
+type FairnessRSSExpectation struct {
+	Ifindex        int
+	QueueID        uint8
+	RSSExpectation string
+}
+
+type FairnessRSSExpectationResult struct {
+	Ifindex       int
+	QueueID       uint8
+	Expectation   string
+	Pass          bool
+	Reason        string
+	ActiveFlows   uint64
+	ActiveWorkers uint64
+	Cstruct       float64
 }
 
 type cosFairnessRSSKey struct {
@@ -21,48 +46,42 @@ type cosFairnessRSSKey struct {
 }
 
 type cosFairnessRSSAggregate struct {
-	totalActiveFlows uint64
-	activeWorkers    uint64
-	maxWorkerFlows   uint32
-	weightedMean     float64
-	weightedM2       float64
+	workerFlows map[uint32]uint32
 }
 
-func (a *cosFairnessRSSAggregate) add(active uint32) {
-	if active == 0 {
-		return
+func (a *cosFairnessRSSAggregate) add(workerID uint32, active uint32) {
+	if a.workerFlows == nil {
+		a.workerFlows = make(map[uint32]uint32)
 	}
-	weight := float64(active)
-	value := 1.0 / weight
-	oldTotal := float64(a.totalActiveFlows)
-	newTotal := oldTotal + weight
-	delta := value - a.weightedMean
-	a.weightedMean += (weight / newTotal) * delta
-	a.weightedM2 += weight * delta * (value - a.weightedMean)
-
-	a.totalActiveFlows += uint64(active)
-	a.activeWorkers++
-	if active > a.maxWorkerFlows {
-		a.maxWorkerFlows = active
-	}
+	a.workerFlows[workerID] += active
 }
 
-func (a cosFairnessRSSAggregate) cstruct() float64 {
-	if a.totalActiveFlows == 0 || a.weightedMean == 0 {
-		return 0
+func (a cosFairnessRSSAggregate) summary(
+	key cosFairnessRSSKey,
+	workers int,
+	truncated bool,
+) CoSFairnessRSSSummary {
+	workerIDs := make([]uint32, 0, len(a.workerFlows))
+	for workerID := range a.workerFlows {
+		workerIDs = append(workerIDs, workerID)
 	}
-	variance := a.weightedM2 / float64(a.totalActiveFlows)
-	if variance <= 0 {
-		return 0
-	}
-	return math.Sqrt(variance) / a.weightedMean
-}
+	sort.Slice(workerIDs, func(i, j int) bool { return workerIDs[i] < workerIDs[j] })
 
-func (a cosFairnessRSSAggregate) maxWorkerFlowShare() float64 {
-	if a.totalActiveFlows == 0 {
-		return 0
+	workerSlots := boundedFairnessRSSWorkerSlots(workers, len(workerIDs))
+	distribution := make([]uint32, workerSlots)
+	var overflow []uint32
+	for _, workerID := range workerIDs {
+		active := a.workerFlows[workerID]
+		if workerID < uint32(workerSlots) {
+			distribution[workerID] = active
+			continue
+		}
+		if active > 0 {
+			overflow = append(overflow, active)
+		}
 	}
-	return float64(a.maxWorkerFlows) / float64(a.totalActiveFlows)
+	distribution = append(distribution, overflow...)
+	return summarizeCoSFairnessRSSDistribution(key, distribution, truncated)
 }
 
 // CoSFairnessRSSSummaries derives the production/operator RSS-structure
@@ -77,7 +96,7 @@ func CoSFairnessRSSSummaries(status ProcessStatus) []CoSFairnessRSSSummary {
 			agg = &cosFairnessRSSAggregate{}
 			byQueue[key] = agg
 		}
-		agg.add(row.ActiveFlowCount)
+		agg.add(row.WorkerID, row.ActiveFlowCount)
 	}
 
 	keys := make([]cosFairnessRSSKey, 0, len(byQueue))
@@ -94,18 +113,174 @@ func CoSFairnessRSSSummaries(status ProcessStatus) []CoSFairnessRSSSummary {
 	out := make([]CoSFairnessRSSSummary, 0, len(keys))
 	for _, key := range keys {
 		agg := byQueue[key]
-		if agg == nil || agg.totalActiveFlows == 0 {
+		if agg == nil {
 			continue
 		}
-		out = append(out, CoSFairnessRSSSummary{
-			Ifindex:             key.ifindex,
-			QueueID:             key.queueID,
-			ActiveFlows:         agg.totalActiveFlows,
-			ActiveWorkers:       agg.activeWorkers,
-			Cstruct:             agg.cstruct(),
-			MaxWorkerFlowShare:  agg.maxWorkerFlowShare(),
-			SourceRowsTruncated: status.CoSActiveFlowCountsTruncated,
+		summary := agg.summary(key, status.Workers, status.CoSActiveFlowCountsTruncated)
+		if summary.ActiveFlows == 0 {
+			continue
+		}
+		out = append(out, summary)
+	}
+	return out
+}
+
+func summarizeCoSFairnessRSSDistribution(
+	key cosFairnessRSSKey,
+	distribution []uint32,
+	truncated bool,
+) CoSFairnessRSSSummary {
+	var totalActiveFlows uint64
+	var activeWorkers uint64
+	var minWorkerFlows uint32
+	var maxWorkerFlows uint32
+	var weightedMean float64
+	var weightedM2 float64
+	for _, active := range distribution {
+		if active == 0 {
+			continue
+		}
+		weight := float64(active)
+		value := 1.0 / weight
+		oldTotal := float64(totalActiveFlows)
+		newTotal := oldTotal + weight
+		delta := value - weightedMean
+		weightedMean += (weight / newTotal) * delta
+		weightedM2 += weight * delta * (value - weightedMean)
+
+		totalActiveFlows += uint64(active)
+		activeWorkers++
+		if minWorkerFlows == 0 || active < minWorkerFlows {
+			minWorkerFlows = active
+		}
+		if active > maxWorkerFlows {
+			maxWorkerFlows = active
+		}
+	}
+	cstruct := 0.0
+	if totalActiveFlows > 0 && weightedMean > 0 {
+		variance := weightedM2 / float64(totalActiveFlows)
+		if variance > 0 {
+			cstruct = math.Sqrt(variance) / weightedMean
+		}
+	}
+	maxWorkerFlowShare := 0.0
+	if totalActiveFlows > 0 {
+		maxWorkerFlowShare = float64(maxWorkerFlows) / float64(totalActiveFlows)
+	}
+	return CoSFairnessRSSSummary{
+		Ifindex:             key.ifindex,
+		QueueID:             key.queueID,
+		ActiveFlows:         totalActiveFlows,
+		ActiveWorkers:       activeWorkers,
+		MinWorkerFlows:      minWorkerFlows,
+		MaxWorkerFlows:      maxWorkerFlows,
+		WorkerFlowCounts:    append([]uint32(nil), distribution...),
+		Cstruct:             cstruct,
+		MaxWorkerFlowShare:  maxWorkerFlowShare,
+		SourceRowsTruncated: truncated,
+	}
+}
+
+func FairnessRSSExpectationsFromConfig(cfg *config.Config) []FairnessRSSExpectation {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return nil
+	}
+	out := make([]FairnessRSSExpectation, 0, len(cfg.ClassOfService.FairnessExpectations))
+	for _, row := range cfg.ClassOfService.FairnessExpectations {
+		if row == nil {
+			continue
+		}
+		out = append(out, FairnessRSSExpectation{
+			Ifindex:        row.Ifindex,
+			QueueID:        row.QueueID,
+			RSSExpectation: row.RSSExpectation,
 		})
 	}
 	return out
+}
+
+func EvaluateFairnessRSSExpectations(
+	status ProcessStatus,
+	expectations []FairnessRSSExpectation,
+) []FairnessRSSExpectationResult {
+	if len(expectations) == 0 {
+		return nil
+	}
+	summaries := CoSFairnessRSSSummaries(status)
+	byQueue := make(map[cosFairnessRSSKey]CoSFairnessRSSSummary, len(summaries))
+	for _, summary := range summaries {
+		byQueue[cosFairnessRSSKey{ifindex: summary.Ifindex, queueID: summary.QueueID}] = summary
+	}
+	out := make([]FairnessRSSExpectationResult, 0, len(expectations))
+	for _, expectation := range expectations {
+		parsed, err := fairnesscontract.ParseRSSExpectation(expectation.RSSExpectation)
+		key := cosFairnessRSSKey{ifindex: expectation.Ifindex, queueID: expectation.QueueID}
+		summary, ok := byQueue[key]
+		if !ok {
+			summary = summarizeCoSFairnessRSSDistribution(
+				key,
+				make([]uint32, boundedFairnessRSSWorkerSlots(status.Workers, 0)),
+				status.CoSActiveFlowCountsTruncated,
+			)
+		}
+		result := fairnesscontract.RSSExpectationResult{Pass: false, Reason: errString(err)}
+		canonical := expectation.RSSExpectation
+		if err == nil {
+			canonical = parsed.Canonical()
+			result = fairnesscontract.EvaluateRSSExpectation(
+				parsed,
+				summary.WorkerFlowCounts,
+				summary.Cstruct,
+				fairnessRSSTotalWorkers(status.Workers, len(summary.WorkerFlowCounts)),
+			)
+		}
+		out = append(out, FairnessRSSExpectationResult{
+			Ifindex:       expectation.Ifindex,
+			QueueID:       expectation.QueueID,
+			Expectation:   canonical,
+			Pass:          result.Pass,
+			Reason:        result.Reason,
+			ActiveFlows:   summary.ActiveFlows,
+			ActiveWorkers: summary.ActiveWorkers,
+			Cstruct:       summary.Cstruct,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ifindex != out[j].Ifindex {
+			return out[i].Ifindex < out[j].Ifindex
+		}
+		if out[i].QueueID != out[j].QueueID {
+			return out[i].QueueID < out[j].QueueID
+		}
+		return out[i].Expectation < out[j].Expectation
+	})
+	return out
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func boundedFairnessRSSWorkerSlots(workers int, fallback int) int {
+	if workers > 0 {
+		if workers > maxFairnessRSSWorkerSlots {
+			return maxFairnessRSSWorkerSlots
+		}
+		return workers
+	}
+	if fallback < 0 {
+		return 0
+	}
+	if fallback > maxFairnessRSSWorkerSlots {
+		return maxFairnessRSSWorkerSlots
+	}
+	return fallback
+}
+
+func fairnessRSSTotalWorkers(workers int, fallback int) uint32 {
+	return uint32(boundedFairnessRSSWorkerSlots(workers, fallback))
 }

--- a/pkg/dataplane/userspace/fairness_test.go
+++ b/pkg/dataplane/userspace/fairness_test.go
@@ -1,0 +1,45 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCoSFairnessRSSSummariesBoundsSparseWorkerID(t *testing.T) {
+	status := ProcessStatus{
+		Workers: 2,
+		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: 4, WorkerID: ^uint32(0), ActiveFlowCount: 2},
+		},
+	}
+
+	rows := CoSFairnessRSSSummaries(status)
+	if len(rows) != 1 {
+		t.Fatalf("CoSFairnessRSSSummaries returned %d rows, want 1", len(rows))
+	}
+	if got, max := len(rows[0].WorkerFlowCounts), maxFairnessRSSWorkerSlots+1; got > max {
+		t.Fatalf("worker distribution length = %d, want <= %d", got, max)
+	}
+	if got := rows[0].ActiveFlows; got != 3 {
+		t.Fatalf("ActiveFlows = %d, want 3", got)
+	}
+	if got := rows[0].ActiveWorkers; got != 2 {
+		t.Fatalf("ActiveWorkers = %d, want 2", got)
+	}
+}
+
+func TestEvaluateFairnessRSSExpectationsFailsMissingQueue(t *testing.T) {
+	results := EvaluateFairnessRSSExpectations(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
+		{Ifindex: 80, QueueID: 4, RSSExpectation: "max-worker-flow-share:0.5"},
+	})
+	if len(results) != 1 {
+		t.Fatalf("EvaluateFairnessRSSExpectations returned %d rows, want 1", len(results))
+	}
+	if results[0].Pass {
+		t.Fatalf("missing queue expectation passed: %+v", results[0])
+	}
+	if !strings.Contains(results[0].Reason, "no active flows observed") {
+		t.Fatalf("missing queue reason = %q, want no active flows observed", results[0].Reason)
+	}
+}

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -343,7 +343,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	return b.String()
 }
 
-func FormatFairnessRSS(status ProcessStatus) string {
+func FormatFairnessRSS(status ProcessStatus, expectations []FairnessRSSExpectation) string {
 	var b strings.Builder
 	rows := CoSFairnessRSSSummaries(status)
 	fmt.Fprintln(&b, "Userspace fairness RSS structure:")
@@ -352,20 +352,38 @@ func FormatFairnessRSS(status ProcessStatus) string {
 	}
 	if len(rows) == 0 {
 		fmt.Fprintln(&b, "  none")
-		return b.String()
+	} else {
+		fmt.Fprintf(&b, "  %-8s %-7s %-11s %-13s %-10s %-10s\n",
+			"Ifindex", "Queue", "ActiveFlows", "ActiveWorkers", "Cstruct", "MaxShare")
+		for _, row := range rows {
+			maxShare := fmt.Sprintf("%.2f%%", 100.0*row.MaxWorkerFlowShare)
+			fmt.Fprintf(&b, "  %-8d %-7d %-11d %-13d %-10.6f %-10s\n",
+				row.Ifindex,
+				row.QueueID,
+				row.ActiveFlows,
+				row.ActiveWorkers,
+				row.Cstruct,
+				maxShare,
+			)
+		}
 	}
-	fmt.Fprintf(&b, "  %-8s %-7s %-11s %-13s %-10s %-10s\n",
-		"Ifindex", "Queue", "ActiveFlows", "ActiveWorkers", "Cstruct", "MaxShare")
-	for _, row := range rows {
-		maxShare := fmt.Sprintf("%.2f%%", 100.0*row.MaxWorkerFlowShare)
-		fmt.Fprintf(&b, "  %-8d %-7d %-11d %-13d %-10.6f %-10s\n",
-			row.Ifindex,
-			row.QueueID,
-			row.ActiveFlows,
-			row.ActiveWorkers,
-			row.Cstruct,
-			maxShare,
-		)
+	if results := EvaluateFairnessRSSExpectations(status, expectations); len(results) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "RSS expectations:")
+		fmt.Fprintf(&b, "  %-8s %-7s %-28s %-6s %-11s %-13s %-10s %s\n",
+			"Ifindex", "Queue", "Expectation", "Pass", "ActiveFlows", "ActiveWorkers", "Cstruct", "Reason")
+		for _, result := range results {
+			fmt.Fprintf(&b, "  %-8d %-7d %-28s %-6t %-11d %-13d %-10.6f %s\n",
+				result.Ifindex,
+				result.QueueID,
+				result.Expectation,
+				result.Pass,
+				result.ActiveFlows,
+				result.ActiveWorkers,
+				result.Cstruct,
+				result.Reason,
+			)
+		}
 	}
 	return b.String()
 }

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -127,7 +127,10 @@ func TestFormatFairnessRSS(t *testing.T) {
 		},
 	}
 
-	out := FormatFairnessRSS(status)
+	out := FormatFairnessRSS(status, []FairnessRSSExpectation{
+		{Ifindex: 80, QueueID: 4, RSSExpectation: "balanced"},
+		{Ifindex: 80, QueueID: 5, RSSExpectation: "max-worker-flow-share:50%"},
+	})
 	for _, want := range []string{
 		"Userspace fairness RSS structure:",
 		"warning: CoS active-flow snapshot truncated",
@@ -137,6 +140,28 @@ func TestFormatFairnessRSS(t *testing.T) {
 		"Cstruct",
 		"80       4       4           2             0.577350   75.00%",
 		"80       5       4           2             0.000000   50.00%",
+		"RSS expectations:",
+		"80       4       balanced                     false",
+		"balanced: active_workers=2 expected",
+		"80       5       max-worker-flow-share:0.5    true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fairness output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatFairnessRSSShowsExpectationsWithoutRows(t *testing.T) {
+	out := FormatFairnessRSS(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
+		{Ifindex: 80, QueueID: 4, RSSExpectation: "cstruct-max:0.25"},
+	})
+	for _, want := range []string{
+		"Userspace fairness RSS structure:",
+		"  none",
+		"RSS expectations:",
+		"80       4       cstruct-max:0.25",
+		"false",
+		"cstruct-max: no active flows observed",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("fairness output missing %q:\n%s", want, out)

--- a/pkg/fairness/expectation.go
+++ b/pkg/fairness/expectation.go
@@ -1,0 +1,208 @@
+package fairness
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type RSSExpectationKind string
+
+const (
+	RSSExpectationAny                  RSSExpectationKind = "any"
+	RSSExpectationBalanced             RSSExpectationKind = "balanced"
+	RSSExpectationAtLeastActiveWorkers RSSExpectationKind = "at-least-active-workers"
+	RSSExpectationMaxWorkerFlowShare   RSSExpectationKind = "max-worker-flow-share"
+	RSSExpectationCstructMax           RSSExpectationKind = "cstruct-max"
+)
+
+type RSSExpectation struct {
+	Kind          RSSExpectationKind
+	ActiveWorkers uint32
+	Threshold     float64
+}
+
+func (e RSSExpectation) Canonical() string {
+	switch e.Kind {
+	case RSSExpectationAny:
+		return "any"
+	case RSSExpectationBalanced:
+		return "balanced"
+	case RSSExpectationAtLeastActiveWorkers:
+		return fmt.Sprintf("at-least-active-workers:%d", e.ActiveWorkers)
+	case RSSExpectationMaxWorkerFlowShare:
+		return fmt.Sprintf("max-worker-flow-share:%g", e.Threshold)
+	case RSSExpectationCstructMax:
+		return fmt.Sprintf("cstruct-max:%g", e.Threshold)
+	default:
+		return string(e.Kind)
+	}
+}
+
+type RSSExpectationResult struct {
+	Pass   bool
+	Reason string
+}
+
+func ParseRSSExpectation(raw string) (RSSExpectation, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.EqualFold(raw, "any") {
+		return RSSExpectation{Kind: RSSExpectationAny}, nil
+	}
+	if strings.EqualFold(raw, "balanced") {
+		return RSSExpectation{Kind: RSSExpectationBalanced}, nil
+	}
+
+	compact := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return -1
+		}
+		return r
+	}, raw)
+	normalized := strings.ReplaceAll(compact, "<=", ":")
+	normalized = strings.ReplaceAll(normalized, ">=", ":")
+	normalized = strings.ReplaceAll(normalized, "=", ":")
+	key, value, ok := strings.Cut(normalized, ":")
+	if !ok {
+		return RSSExpectation{}, fmt.Errorf("unknown RSS expectation %q; expected any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X", raw)
+	}
+
+	switch key {
+	case "at-least-active-workers", "active-workers":
+		n, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return RSSExpectation{}, fmt.Errorf("invalid RSS expectation active worker count %q", raw)
+		}
+		return RSSExpectation{Kind: RSSExpectationAtLeastActiveWorkers, ActiveWorkers: uint32(n)}, nil
+	case "max-worker-flow-share":
+		share, err := parseFractionOrPercent(value)
+		if err != nil {
+			return RSSExpectation{}, fmt.Errorf("invalid RSS expectation max-worker-flow-share: %w", err)
+		}
+		return RSSExpectation{Kind: RSSExpectationMaxWorkerFlowShare, Threshold: share}, nil
+	case "cstruct", "cstruct-max":
+		max, err := parseNonnegativeNumberOrPercent(value)
+		if err != nil {
+			return RSSExpectation{}, fmt.Errorf("invalid RSS expectation cstruct threshold: %w", err)
+		}
+		return RSSExpectation{Kind: RSSExpectationCstructMax, Threshold: max}, nil
+	default:
+		return RSSExpectation{}, fmt.Errorf("unknown RSS expectation %q; expected any, balanced, at-least-active-workers:N, max-worker-flow-share:X, or cstruct-max:X", raw)
+	}
+}
+
+func EvaluateRSSExpectation(
+	expectation RSSExpectation,
+	distribution []uint32,
+	cstruct float64,
+	nTotalWorkers uint32,
+) RSSExpectationResult {
+	if nTotalWorkers == 0 {
+		nTotalWorkers = uint32(len(distribution))
+	}
+
+	var total uint64
+	var activeWorkers uint32
+	var minActive uint32
+	var maxActive uint32
+	for _, active := range distribution {
+		total += uint64(active)
+		if active == 0 {
+			continue
+		}
+		activeWorkers++
+		if minActive == 0 || active < minActive {
+			minActive = active
+		}
+		if active > maxActive {
+			maxActive = active
+		}
+	}
+	maxShare := 0.0
+	if total > 0 {
+		maxShare = float64(maxActive) / float64(total)
+	}
+
+	switch expectation.Kind {
+	case RSSExpectationAny:
+		return RSSExpectationResult{Pass: true, Reason: "any: no RSS/workload expectation configured"}
+	}
+	if total == 0 {
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("%s: no active flows observed", expectation.Kind)}
+	}
+
+	switch expectation.Kind {
+	case RSSExpectationAtLeastActiveWorkers:
+		if activeWorkers >= expectation.ActiveWorkers {
+			return RSSExpectationResult{Pass: true, Reason: fmt.Sprintf("active_workers=%d >= expected %d", activeWorkers, expectation.ActiveWorkers)}
+		}
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("active_workers=%d < expected %d", activeWorkers, expectation.ActiveWorkers)}
+	case RSSExpectationMaxWorkerFlowShare:
+		if maxShare <= expectation.Threshold {
+			return RSSExpectationResult{Pass: true, Reason: fmt.Sprintf("max_worker_flow_share=%.4f <= expected %.4f", maxShare, expectation.Threshold)}
+		}
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("max_worker_flow_share=%.4f > expected %.4f", maxShare, expectation.Threshold)}
+	case RSSExpectationCstructMax:
+		if cstruct <= expectation.Threshold {
+			return RSSExpectationResult{Pass: true, Reason: fmt.Sprintf("cstruct=%.4f <= expected %.4f", cstruct, expectation.Threshold)}
+		}
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("cstruct=%.4f > expected %.4f", cstruct, expectation.Threshold)}
+	case RSSExpectationBalanced:
+		expectedActive := uint64(nTotalWorkers)
+		if total < expectedActive {
+			expectedActive = total
+		}
+		pass := uint64(activeWorkers) == expectedActive && maxActive-minActive <= 1
+		if pass {
+			return RSSExpectationResult{Pass: true, Reason: fmt.Sprintf("balanced: active_workers=%d, min=%d, max=%d", activeWorkers, minActive, maxActive)}
+		}
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("balanced: active_workers=%d expected %d, min=%d, max=%d", activeWorkers, expectedActive, minActive, maxActive)}
+	default:
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("unknown RSS expectation kind %q", expectation.Kind)}
+	}
+}
+
+func parseNumberOrPercent(raw string) (float64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, fmt.Errorf("missing value")
+	}
+	var value float64
+	var err error
+	if percent, ok := strings.CutSuffix(raw, "%"); ok {
+		value, err = strconv.ParseFloat(percent, 64)
+		value /= 100.0
+	} else {
+		value, err = strconv.ParseFloat(raw, 64)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", raw)
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("%q is not a finite number", raw)
+	}
+	return value, nil
+}
+
+func parseFractionOrPercent(raw string) (float64, error) {
+	value, err := parseNumberOrPercent(raw)
+	if err != nil {
+		return 0, err
+	}
+	if value < 0 || value > 1 {
+		return 0, fmt.Errorf("%q must be between 0 and 1 or 0%% and 100%%", raw)
+	}
+	return value, nil
+}
+
+func parseNonnegativeNumberOrPercent(raw string) (float64, error) {
+	value, err := parseNumberOrPercent(raw)
+	if err != nil {
+		return 0, err
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("%q must be non-negative", raw)
+	}
+	return value, nil
+}

--- a/pkg/fairness/expectation_test.go
+++ b/pkg/fairness/expectation_test.go
@@ -1,0 +1,144 @@
+package fairness
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRSSExpectation(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "any empty", raw: "", want: "any"},
+		{name: "balanced", raw: "balanced", want: "balanced"},
+		{name: "active workers", raw: "active-workers:4", want: "at-least-active-workers:4"},
+		{name: "max share percent", raw: "max-worker-flow-share:50%", want: "max-worker-flow-share:0.5"},
+		{name: "cstruct operator", raw: "cstruct <= 25%", want: "cstruct-max:0.25"},
+		{name: "cstruct above one", raw: "cstruct-max:1.2", want: "cstruct-max:1.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRSSExpectation(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseRSSExpectation(%q) error = %v", tt.raw, err)
+			}
+			if got.Canonical() != tt.want {
+				t.Fatalf("ParseRSSExpectation(%q) canonical = %q, want %q", tt.raw, got.Canonical(), tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRSSExpectationRejectsInvalidValues(t *testing.T) {
+	for _, raw := range []string{
+		"bogus",
+		"at-least-active-workers:not-a-number",
+		"max-worker-flow-share:150%",
+		"max-worker-flow-share:-1",
+		"cstruct-max:-0.1",
+		"cstruct-max:NaN",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseRSSExpectation(raw); err == nil {
+				t.Fatalf("ParseRSSExpectation(%q) succeeded, want error", raw)
+			}
+		})
+	}
+}
+
+func TestEvaluateRSSExpectation(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		dist       []uint32
+		cstruct    float64
+		workers    uint32
+		wantPass   bool
+		wantReason string
+	}{
+		{
+			name:       "balanced pass",
+			raw:        "balanced",
+			dist:       []uint32{2, 2, 2, 2},
+			workers:    4,
+			wantPass:   true,
+			wantReason: "balanced: active_workers=4, min=2, max=2",
+		},
+		{
+			name:       "balanced skew fail",
+			raw:        "balanced",
+			dist:       []uint32{9, 1, 1, 0},
+			workers:    4,
+			wantPass:   false,
+			wantReason: "balanced: active_workers=3 expected 4, min=1, max=9",
+		},
+		{
+			name:       "active workers pass",
+			raw:        "at-least-active-workers:3",
+			dist:       []uint32{2, 0, 1, 1},
+			workers:    4,
+			wantPass:   true,
+			wantReason: "active_workers=3 >= expected 3",
+		},
+		{
+			name:       "max share fail",
+			raw:        "max-worker-flow-share:50%",
+			dist:       []uint32{3, 1},
+			workers:    2,
+			wantPass:   false,
+			wantReason: "max_worker_flow_share=0.7500 > expected 0.5000",
+		},
+		{
+			name:       "cstruct pass",
+			raw:        "cstruct-max:0.6",
+			dist:       []uint32{3, 1},
+			cstruct:    0.577350269,
+			workers:    2,
+			wantPass:   true,
+			wantReason: "cstruct=0.5774 <= expected 0.6000",
+		},
+		{
+			name:       "max share no traffic fails",
+			raw:        "max-worker-flow-share:50%",
+			dist:       []uint32{0, 0, 0, 0},
+			workers:    4,
+			wantPass:   false,
+			wantReason: "max-worker-flow-share: no active flows observed",
+		},
+		{
+			name:       "cstruct no traffic fails",
+			raw:        "cstruct-max:0.25",
+			dist:       []uint32{0, 0, 0, 0},
+			workers:    4,
+			wantPass:   false,
+			wantReason: "cstruct-max: no active flows observed",
+		},
+		{
+			name:       "active workers no traffic fails",
+			raw:        "at-least-active-workers:0",
+			dist:       []uint32{0, 0, 0, 0},
+			workers:    4,
+			wantPass:   false,
+			wantReason: "at-least-active-workers: no active flows observed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectation, err := ParseRSSExpectation(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseRSSExpectation(%q): %v", tt.raw, err)
+			}
+			got := EvaluateRSSExpectation(expectation, tt.dist, tt.cstruct, tt.workers)
+			if got.Pass != tt.wantPass {
+				t.Fatalf("EvaluateRSSExpectation pass = %t, want %t; reason=%s", got.Pass, tt.wantPass, got.Reason)
+			}
+			if !strings.Contains(got.Reason, tt.wantReason) {
+				t.Fatalf("EvaluateRSSExpectation reason = %q, want substring %q", got.Reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_show_cluster_text.go
+++ b/pkg/grpcapi/server_show_cluster_text.go
@@ -173,7 +173,7 @@ func (s *Server) showChassisClusterDataPlaneFairness(buf *strings.Builder) {
 		fmt.Fprintf(buf, "Userspace status unavailable: %v\n", err)
 		return
 	}
-	buf.WriteString(dpuserspace.FormatFairnessRSS(status))
+	buf.WriteString(dpuserspace.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(s.store.ActiveConfig())))
 }
 
 // showChassisClusterDataPlaneFlows renders the bounded active


### PR DESCRIPTION
## Summary
- add shared Go RSS expectation parser/evaluator for the same expectation vocabulary used by fairness-eval
- add opt-in config under `class-of-service fairness rss-expectation ifindex <n> queue <q> ...`
- evaluate configured expectations against the existing userspace CoS active-flow snapshot
- show pass/fail reason in `show chassis cluster data-plane fairness`
- export `xpf_fairness_rss_expectation_configured` and `xpf_fairness_rss_skew_violation` gauges

This remains observability/control-plane evaluation only: no packet-path state, no global atomics, and no scheduler feedback loop.

Refs #1247.

## Validation
- `go test ./pkg/fairness ./pkg/config ./pkg/api ./pkg/dataplane/userspace ./pkg/cmdtree ./pkg/cli ./pkg/grpcapi`
- `go test ./pkg/...`
- `git diff --check`