### PR TITLE
Fairness RSS expectation polish

### DIFF
--- a/pkg/dataplane/userspace/fairness_test.go
+++ b/pkg/dataplane/userspace/fairness_test.go
@@ -29,6 +29,56 @@ func TestCoSFairnessRSSSummariesBoundsSparseWorkerID(t *testing.T) {
 	}
 }
 
+func TestCoSFairnessRSSSummariesMultipleOverflowWorkers(t *testing.T) {
+	status := ProcessStatus{
+		Workers: 2,
+		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: 4, WorkerID: 4096, ActiveFlowCount: 2},
+			{Ifindex: 80, QueueID: 4, WorkerID: ^uint32(0), ActiveFlowCount: 3},
+		},
+	}
+
+	rows := CoSFairnessRSSSummaries(status)
+	if len(rows) != 1 {
+		t.Fatalf("CoSFairnessRSSSummaries returned %d rows, want 1", len(rows))
+	}
+	if got := rows[0].ActiveFlows; got != 6 {
+		t.Fatalf("ActiveFlows = %d, want 6", got)
+	}
+	if got := rows[0].ActiveWorkers; got != 3 {
+		t.Fatalf("ActiveWorkers = %d, want 3", got)
+	}
+	if got := len(rows[0].WorkerFlowCounts); got != 4 {
+		t.Fatalf("worker distribution length = %d, want 4", got)
+	}
+}
+
+func TestBoundedFairnessRSSWorkerSlots(t *testing.T) {
+	tests := []struct {
+		name     string
+		workers  int
+		fallback int
+		want     int
+	}{
+		{name: "negative workers and fallback", workers: -1, fallback: -1, want: 0},
+		{name: "zero workers uses fallback", workers: 0, fallback: 8, want: 8},
+		{name: "positive workers ignore fallback", workers: 4, fallback: 8, want: 4},
+		{name: "workers capped", workers: maxFairnessRSSWorkerSlots + 1, fallback: 1, want: maxFairnessRSSWorkerSlots},
+		{name: "fallback capped", workers: 0, fallback: maxFairnessRSSWorkerSlots + 1, want: maxFairnessRSSWorkerSlots},
+		{name: "worker cap boundary", workers: maxFairnessRSSWorkerSlots, fallback: 1, want: maxFairnessRSSWorkerSlots},
+		{name: "fallback cap boundary", workers: 0, fallback: maxFairnessRSSWorkerSlots, want: maxFairnessRSSWorkerSlots},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boundedFairnessRSSWorkerSlots(tt.workers, tt.fallback); got != tt.want {
+				t.Fatalf("boundedFairnessRSSWorkerSlots(%d, %d) = %d, want %d", tt.workers, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateFairnessRSSExpectationsFailsMissingQueue(t *testing.T) {
 	results := EvaluateFairnessRSSExpectations(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
 		{Ifindex: 80, QueueID: 4, RSSExpectation: "max-worker-flow-share:0.5"},

--- a/pkg/fairness/expectation.go
+++ b/pkg/fairness/expectation.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 type RSSExpectationKind string
@@ -55,7 +56,7 @@ func ParseRSSExpectation(raw string) (RSSExpectation, error) {
 	}
 
 	compact := strings.Map(func(r rune) rune {
-		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+		if unicode.IsSpace(r) {
 			return -1
 		}
 		return r
@@ -128,6 +129,9 @@ func EvaluateRSSExpectation(
 	case RSSExpectationAny:
 		return RSSExpectationResult{Pass: true, Reason: "any: no RSS/workload expectation configured"}
 	}
+	if !knownRSSExpectationKind(expectation.Kind) {
+		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("unknown RSS expectation kind %q", expectation.Kind)}
+	}
 	if total == 0 {
 		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("%s: no active flows observed", expectation.Kind)}
 	}
@@ -160,6 +164,19 @@ func EvaluateRSSExpectation(
 		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("balanced: active_workers=%d expected %d, min=%d, max=%d", activeWorkers, expectedActive, minActive, maxActive)}
 	default:
 		return RSSExpectationResult{Pass: false, Reason: fmt.Sprintf("unknown RSS expectation kind %q", expectation.Kind)}
+	}
+}
+
+func knownRSSExpectationKind(kind RSSExpectationKind) bool {
+	switch kind {
+	case RSSExpectationAny,
+		RSSExpectationBalanced,
+		RSSExpectationAtLeastActiveWorkers,
+		RSSExpectationMaxWorkerFlowShare,
+		RSSExpectationCstructMax:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/fairness/expectation_test.go
+++ b/pkg/fairness/expectation_test.go
@@ -16,6 +16,7 @@ func TestParseRSSExpectation(t *testing.T) {
 		{name: "active workers", raw: "active-workers:4", want: "at-least-active-workers:4"},
 		{name: "max share percent", raw: "max-worker-flow-share:50%", want: "max-worker-flow-share:0.5"},
 		{name: "cstruct operator", raw: "cstruct <= 25%", want: "cstruct-max:0.25"},
+		{name: "cstruct unicode whitespace", raw: "cstruct\u00a0<=\u00a025%", want: "cstruct-max:0.25"},
 		{name: "cstruct above one", raw: "cstruct-max:1.2", want: "cstruct-max:1.2"},
 	}
 
@@ -117,6 +118,14 @@ func TestEvaluateRSSExpectation(t *testing.T) {
 			wantReason: "cstruct-max: no active flows observed",
 		},
 		{
+			name:       "balanced no traffic fails",
+			raw:        "balanced",
+			dist:       []uint32{0, 0, 0, 0},
+			workers:    4,
+			wantPass:   false,
+			wantReason: "balanced: no active flows observed",
+		},
+		{
 			name:       "active workers no traffic fails",
 			raw:        "at-least-active-workers:0",
 			dist:       []uint32{0, 0, 0, 0},
@@ -140,5 +149,15 @@ func TestEvaluateRSSExpectation(t *testing.T) {
 				t.Fatalf("EvaluateRSSExpectation reason = %q, want substring %q", got.Reason, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestEvaluateRSSExpectationRejectsUnknownKindBeforeNoTraffic(t *testing.T) {
+	got := EvaluateRSSExpectation(RSSExpectation{Kind: "bogus"}, []uint32{0, 0}, 0, 2)
+	if got.Pass {
+		t.Fatalf("EvaluateRSSExpectation passed unknown kind: %+v", got)
+	}
+	if !strings.Contains(got.Reason, `unknown RSS expectation kind "bogus"`) {
+		t.Fatalf("EvaluateRSSExpectation reason = %q, want unknown-kind error", got.Reason)
 	}
 }


### PR DESCRIPTION
## Summary

- normalize RSS expectation expressions with `unicode.IsSpace` so Go parser behavior matches the Rust harness on copied/non-ASCII whitespace
- report exported `EvaluateRSSExpectation` unknown-kind errors before the no-active-flows path
- add tests for balanced no-traffic, unknown-kind handling, multiple overflow worker IDs, and worker-slot bounding/capping

## Follow-up tracking

Refs #1265. This intentionally handles only the parser/evaluator/test-coverage items. Metric-label schema, interface-name ergonomics, and duplicate hierarchical leaves remain tracked there.

## Validation

- `go test ./pkg/fairness ./pkg/dataplane/userspace ./pkg/config ./pkg/api`
- `go test ./pkg/...`
- `git diff --check`
