### PR TITLE
Add runtime fairness throughput metrics

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-05-12
+
+- **Timestamp**: 2026-05-12T00:30:00Z
+  - **Action**: PR #1267 round-2 review follow-up — fixed fairness throughput window boundary pruning/rate denominator coupling to prevent false-positive saturation at steady sub-cap traffic, and added a regression test for the 10s-scrape/30s-window boundary case.
+  - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `_Log.md`
+
 ## 2026-05-10
 
 - **Timestamp**: 2026-05-10T15:24:00Z

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -341,7 +341,11 @@ For production observability, xpf MUST export:
 - **`xpf_fairness_saturated{ifindex=..., queue_id=...}`** Prometheus gauge: 0 or
   1. Computed from the daemon's rolling 30-second per-flow byte
   window as aggregate queue throughput vs the configured CoS queue
-  transmit rate (per "Saturation detection").
+  transmit rate (per "Saturation detection"). If a queue does not
+  report an explicit `transmit_rate_bytes`, the daemon falls back to
+  the interface shaping rate; on a multi-queue interface this means
+  `saturated=1` requires that queue to approach the interface-level
+  cap.
   Diagnostic only — saturation does not change pass/fail of the
   Cstruct gate, but operators may want to know whether their
   workload is actually hitting the shaper. The original v3 enum
@@ -370,8 +374,10 @@ Prometheus collector. The rolling throughput metrics
 `xpf_fairness_starved_flows`) are derived from worker-owned
 flow-cache byte counters surfaced through the bounded flow-worker
 status snapshot. The daemon keeps the 30-second window in collector
-state; truncated flow-worker snapshots suppress metric emission rather
-than reporting a false-healthy queue.
+state and advances the wall-clock window on every healthy scrape, even
+when no flow byte counter moved. Truncated flow-worker snapshots reset
+the runtime window and suppress metric emission rather than reporting
+a false-healthy queue from stale samples.
 
 ## Steady-state measurement window
 

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -339,8 +339,9 @@ For production observability, xpf MUST export:
   the status snapshot was truncated before the fairness RSS gauges
   were derived; 0 otherwise.
 - **`xpf_fairness_saturated{ifindex=..., queue_id=...}`** Prometheus gauge: 0 or
-  1. Computed from rolling 30-second window of aggregate
-  throughput vs structural cap (per "Saturation detection").
+  1. Computed from the daemon's rolling 30-second per-flow byte
+  window as aggregate queue throughput vs the configured CoS queue
+  transmit rate (per "Saturation detection").
   Diagnostic only — saturation does not change pass/fail of the
   Cstruct gate, but operators may want to know whether their
   workload is actually hitting the shaper. The original v3 enum
@@ -352,10 +353,11 @@ For production observability, xpf MUST export:
   signal and is exported separately if the harness needs it for
   context.
 - **`xpf_fairness_observed_cov{ifindex=..., queue_id=...}`** gauge: rolling
-  observed CoV for the queue.
+  observed CoV across per-flow byte totals for the queue.
 - **`xpf_fairness_starved_flows{ifindex=..., queue_id=...}`** counter:
-  monotonic count of flows that fell below the starved-flow
-  threshold (< 1% of mean per-flow throughput) over their lifetime.
+  monotonic count of flows that enter the starved-flow threshold
+  (< 1% of mean per-flow throughput), de-duplicated while the flow
+  remains in the rolling window.
 
 Operators tracking this contract in production monitor the gap
 `(observed_cov - cstruct)` and the starved-flow counter. A
@@ -365,9 +367,11 @@ flat.
 The RSS-structure gauges above are exported from the production
 Prometheus collector. The rolling throughput metrics
 (`xpf_fairness_saturated`, `xpf_fairness_observed_cov`, and
-`xpf_fairness_starved_flows`) still require a follow-up runtime window;
-until that ships, observed CoV and starved-flow gates are enforced via
-the test harness.
+`xpf_fairness_starved_flows`) are derived from worker-owned
+flow-cache byte counters surfaced through the bounded flow-worker
+status snapshot. The daemon keeps the 30-second window in collector
+state; truncated flow-worker snapshots suppress metric emission rather
+than reporting a false-healthy queue.
 
 ## Steady-state measurement window
 

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -351,6 +351,20 @@ set syntax). Configured expectations are rendered under
 - `xpf_fairness_rss_expectation_configured{ifindex,queue_id,expectation}`
 - `xpf_fairness_rss_skew_violation{ifindex,queue_id,expectation}`
 
+The runtime throughput slice exports the remaining observed-workload
+metrics from a rolling 30-second daemon window:
+
+- `xpf_fairness_saturated{ifindex,queue_id}`
+- `xpf_fairness_observed_cov{ifindex,queue_id}`
+- `xpf_fairness_starved_flows{ifindex,queue_id}`
+
+Workers account bytes on the owner-local flow-cache entry already
+touched by established TCP/UDP cache hits and publish the cumulative
+byte count in the bounded flow-worker snapshot. The Go collector
+converts successive snapshots into per-flow byte deltas, maintains the
+rolling window, and suppresses the observed metrics while the source
+flow-worker snapshot is truncated.
+
 ## Open work
 
 - **#547 — Deterministic RSS-skew test fixture**: SHIPPED as PR #1223

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -362,8 +362,10 @@ Workers account bytes on the owner-local flow-cache entry already
 touched by established TCP/UDP cache hits and publish the cumulative
 byte count in the bounded flow-worker snapshot. The Go collector
 converts successive snapshots into per-flow byte deltas, maintains the
-rolling window, and suppresses the observed metrics while the source
-flow-worker snapshot is truncated.
+rolling window, and advances that window on healthy scrapes even when
+no flow byte counter moved. Truncated flow-worker snapshots reset the
+window and suppress the observed metrics until a fresh baseline is
+available.
 
 ## Open work
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -27,7 +28,6 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -28,6 +27,7 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,6 +21,7 @@ import (
 // xpfCollector implements prometheus.Collector, reading BPF maps on each scrape.
 type xpfCollector struct {
 	srv *Server
+	mu  sync.Mutex
 
 	// Global counters
 	packetsTotal         *prometheus.Desc
@@ -115,6 +117,10 @@ type xpfCollector struct {
 	fairnessCoSCountsTruncated *prometheus.Desc
 	fairnessRSSExpectation     *prometheus.Desc
 	fairnessRSSSkewViolation   *prometheus.Desc
+	fairnessSaturated          *prometheus.Desc
+	fairnessObservedCoV        *prometheus.Desc
+	fairnessStarvedFlows       *prometheus.Desc
+	fairnessThroughputWindow   *dpuserspace.FairnessThroughputWindow
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -420,6 +426,22 @@ func newCollector(srv *Server) *xpfCollector {
 			"1 when the configured RSS/workload expectation fails for this egress CoS queue; 0 when it passes (#1247).",
 			[]string{"ifindex", "queue_id", "expectation"}, nil,
 		),
+		fairnessSaturated: prometheus.NewDesc(
+			"xpf_fairness_saturated",
+			"1 when the rolling per-flow byte window is at or above 95% of the configured egress CoS queue transmit rate (#1264).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessObservedCoV: prometheus.NewDesc(
+			"xpf_fairness_observed_cov",
+			"Rolling observed coefficient of variation across per-flow byte totals for this egress CoS queue (#1264).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessStarvedFlows: prometheus.NewDesc(
+			"xpf_fairness_starved_flows",
+			"Monotonic count of flows that enter below 1% of the rolling mean per-flow bytes for this egress CoS queue, de-duplicated while the flow remains in the rolling window (#1264).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessThroughputWindow: dpuserspace.NewFairnessThroughputWindow(30 * time.Second),
 	}
 }
 
@@ -480,6 +502,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.fairnessCoSCountsTruncated
 	ch <- c.fairnessRSSExpectation
 	ch <- c.fairnessRSSSkewViolation
+	ch <- c.fairnessSaturated
+	ch <- c.fairnessObservedCoV
+	ch <- c.fairnessStarvedFlows
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -520,6 +545,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp da
 	c.emitBindingActiveFlowCount(ch, status)
 	c.emitCoSActiveFlowCount(ch, status)
 	c.emitFairnessRSSGauges(ch, status)
+	c.emitFairnessThroughputGauges(ch, status)
 }
 
 // #1219: emit per-binding distinct active flow count for the fairness
@@ -640,6 +666,48 @@ func (c *xpfCollector) emitFairnessRSSExpectationGauges(
 			ifindexLabel,
 			queueLabel,
 			result.Expectation,
+		)
+	}
+}
+
+func (c *xpfCollector) emitFairnessThroughputGauges(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	c.mu.Lock()
+	if c.fairnessThroughputWindow == nil {
+		c.fairnessThroughputWindow = dpuserspace.NewFairnessThroughputWindow(30 * time.Second)
+	}
+	summaries := c.fairnessThroughputWindow.Update(time.Now(), status)
+	c.mu.Unlock()
+
+	for _, row := range summaries {
+		if row.SourceTruncated || row.FlowCount == 0 || row.WindowSeconds <= 0 {
+			continue
+		}
+		ifindexLabel := strconv.Itoa(row.Ifindex)
+		queueLabel := strconv.FormatUint(uint64(row.QueueID), 10)
+		saturated := 0.0
+		if row.Saturated {
+			saturated = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessSaturated,
+			prometheus.GaugeValue,
+			saturated,
+			ifindexLabel,
+			queueLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessObservedCoV,
+			prometheus.GaugeValue,
+			row.ObservedCoV,
+			ifindexLabel,
+			queueLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessStarvedFlows,
+			prometheus.CounterValue,
+			float64(row.StarvedFlowsTotal),
+			ifindexLabel,
+			queueLabel,
 		)
 	}
 }

--- a/pkg/dataplane/userspace/fairness_throughput.go
+++ b/pkg/dataplane/userspace/fairness_throughput.go
@@ -1,0 +1,313 @@
+package userspace
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+const defaultFairnessThroughputWindow = 30 * time.Second
+
+type FairnessThroughputSummary struct {
+	Ifindex           int
+	QueueID           uint8
+	FlowCount         int
+	ObservedCoV       float64
+	Saturated         bool
+	StarvedFlowsTotal uint64
+	WindowSeconds     float64
+	ObservedBytes     uint64
+	SourceTruncated   bool
+}
+
+type FairnessThroughputWindow struct {
+	window     time.Duration
+	lastUpdate time.Time
+	prev       map[fairnessFlowThroughputKey]uint64
+	queues     map[fairnessQueueKey]*fairnessQueueThroughputWindow
+}
+
+type fairnessQueueKey struct {
+	ifindex int
+	queueID uint8
+}
+
+type fairnessFlowThroughputKey struct {
+	queue fairnessQueueKey
+	tuple FlowTupleStatus
+}
+
+type fairnessThroughputSample struct {
+	at       time.Time
+	duration time.Duration
+	deltas   map[fairnessFlowThroughputKey]uint64
+}
+
+type fairnessQueueThroughputWindow struct {
+	samples      []fairnessThroughputSample
+	bytesByFlow  map[fairnessFlowThroughputKey]uint64
+	starvedFlows map[fairnessFlowThroughputKey]struct{}
+	starvedTotal uint64
+}
+
+func NewFairnessThroughputWindow(window time.Duration) *FairnessThroughputWindow {
+	if window <= 0 {
+		window = defaultFairnessThroughputWindow
+	}
+	return &FairnessThroughputWindow{
+		window: window,
+		prev:   make(map[fairnessFlowThroughputKey]uint64),
+		queues: make(map[fairnessQueueKey]*fairnessQueueThroughputWindow),
+	}
+}
+
+func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) []FairnessThroughputSummary {
+	if w == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if w.window <= 0 {
+		w.window = defaultFairnessThroughputWindow
+	}
+	if w.prev == nil {
+		w.prev = make(map[fairnessFlowThroughputKey]uint64)
+	}
+	if w.queues == nil {
+		w.queues = make(map[fairnessQueueKey]*fairnessQueueThroughputWindow)
+	}
+
+	duration := time.Duration(0)
+	if !w.lastUpdate.IsZero() && now.After(w.lastUpdate) {
+		duration = now.Sub(w.lastUpdate)
+	}
+	w.lastUpdate = now
+
+	queueRates := fairnessQueueTransmitRates(status)
+	seen := make(map[fairnessFlowThroughputKey]uint64)
+	sampleDeltas := make(map[fairnessQueueKey]map[fairnessFlowThroughputKey]uint64)
+	if !status.FlowWorkerMapTruncated {
+		for _, row := range status.FlowWorkerMap {
+			if row.CoSQueueID == nil || row.EgressIfindex == 0 {
+				continue
+			}
+			key := fairnessFlowThroughputKey{
+				queue: fairnessQueueKey{ifindex: row.EgressIfindex, queueID: *row.CoSQueueID},
+				tuple: row.ForwardWireKey,
+			}
+			if key.tuple == (FlowTupleStatus{}) {
+				key.tuple = row.SessionKey
+			}
+			seen[key] = row.ObservedBytes
+			previous, ok := w.prev[key]
+			w.prev[key] = row.ObservedBytes
+			if duration <= 0 || !ok {
+				continue
+			}
+			delta := uint64(0)
+			if row.ObservedBytes >= previous {
+				delta = row.ObservedBytes - previous
+			} else {
+				delta = row.ObservedBytes
+			}
+			if delta == 0 {
+				continue
+			}
+			deltas := sampleDeltas[key.queue]
+			if deltas == nil {
+				deltas = make(map[fairnessFlowThroughputKey]uint64)
+				sampleDeltas[key.queue] = deltas
+			}
+			deltas[key] += delta
+		}
+	}
+	for key := range w.prev {
+		if _, ok := seen[key]; !ok {
+			delete(w.prev, key)
+		}
+	}
+
+	for queue, deltas := range sampleDeltas {
+		state := w.queueState(queue)
+		state.addSample(fairnessThroughputSample{
+			at:       now,
+			duration: duration,
+			deltas:   deltas,
+		})
+	}
+	for _, state := range w.queues {
+		state.prune(now.Add(-w.window))
+	}
+
+	keys := make([]fairnessQueueKey, 0, len(w.queues))
+	for key := range w.queues {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ifindex != keys[j].ifindex {
+			return keys[i].ifindex < keys[j].ifindex
+		}
+		return keys[i].queueID < keys[j].queueID
+	})
+
+	out := make([]FairnessThroughputSummary, 0, len(keys))
+	for _, key := range keys {
+		state := w.queues[key]
+		if state == nil || len(state.bytesByFlow) == 0 {
+			continue
+		}
+		summary := state.summary(key, queueRates[key])
+		summary.SourceTruncated = status.FlowWorkerMapTruncated
+		out = append(out, summary)
+	}
+	return out
+}
+
+func (w *FairnessThroughputWindow) queueState(key fairnessQueueKey) *fairnessQueueThroughputWindow {
+	state := w.queues[key]
+	if state == nil {
+		state = &fairnessQueueThroughputWindow{
+			bytesByFlow:  make(map[fairnessFlowThroughputKey]uint64),
+			starvedFlows: make(map[fairnessFlowThroughputKey]struct{}),
+		}
+		w.queues[key] = state
+	}
+	return state
+}
+
+func (q *fairnessQueueThroughputWindow) addSample(sample fairnessThroughputSample) {
+	if q.bytesByFlow == nil {
+		q.bytesByFlow = make(map[fairnessFlowThroughputKey]uint64)
+	}
+	if q.starvedFlows == nil {
+		q.starvedFlows = make(map[fairnessFlowThroughputKey]struct{})
+	}
+	q.samples = append(q.samples, sample)
+	for flow, delta := range sample.deltas {
+		q.bytesByFlow[flow] += delta
+	}
+}
+
+func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
+	keepFrom := 0
+	for keepFrom < len(q.samples) && q.samples[keepFrom].at.Before(cutoff) {
+		for flow, delta := range q.samples[keepFrom].deltas {
+			if q.bytesByFlow[flow] <= delta {
+				delete(q.bytesByFlow, flow)
+			} else {
+				q.bytesByFlow[flow] -= delta
+			}
+		}
+		keepFrom++
+	}
+	if keepFrom > 0 {
+		copy(q.samples, q.samples[keepFrom:])
+		q.samples = q.samples[:len(q.samples)-keepFrom]
+	}
+	for flow := range q.starvedFlows {
+		if _, ok := q.bytesByFlow[flow]; !ok {
+			delete(q.starvedFlows, flow)
+		}
+	}
+}
+
+func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64) FairnessThroughputSummary {
+	var totalBytes uint64
+	values := make([]float64, 0, len(q.bytesByFlow))
+	for _, bytes := range q.bytesByFlow {
+		if bytes == 0 {
+			continue
+		}
+		totalBytes += bytes
+		values = append(values, float64(bytes))
+	}
+	windowSeconds := q.windowSeconds()
+	observedCoV := coefficientOfVariation(values)
+	saturated := false
+	if transmitRateBytes > 0 && windowSeconds > 0 {
+		observedRate := float64(totalBytes) / windowSeconds
+		saturated = observedRate >= 0.95*float64(transmitRateBytes)
+	}
+	q.markStarved(values)
+	return FairnessThroughputSummary{
+		Ifindex:           key.ifindex,
+		QueueID:           key.queueID,
+		FlowCount:         len(values),
+		ObservedCoV:       observedCoV,
+		Saturated:         saturated,
+		StarvedFlowsTotal: q.starvedTotal,
+		WindowSeconds:     windowSeconds,
+		ObservedBytes:     totalBytes,
+	}
+}
+
+func (q *fairnessQueueThroughputWindow) windowSeconds() float64 {
+	var total time.Duration
+	for _, sample := range q.samples {
+		total += sample.duration
+	}
+	return total.Seconds()
+}
+
+func (q *fairnessQueueThroughputWindow) markStarved(values []float64) {
+	if len(values) < 2 {
+		return
+	}
+	var total float64
+	for _, value := range values {
+		total += value
+	}
+	if total <= 0 {
+		return
+	}
+	threshold := (total / float64(len(values))) * 0.01
+	for flow, bytes := range q.bytesByFlow {
+		if bytes == 0 || float64(bytes) >= threshold {
+			continue
+		}
+		if _, ok := q.starvedFlows[flow]; ok {
+			continue
+		}
+		q.starvedFlows[flow] = struct{}{}
+		q.starvedTotal++
+	}
+}
+
+func coefficientOfVariation(values []float64) float64 {
+	if len(values) < 2 {
+		return 0
+	}
+	var mean float64
+	var m2 float64
+	for i, value := range values {
+		delta := value - mean
+		mean += delta / float64(i+1)
+		m2 += delta * (value - mean)
+	}
+	if mean <= 0 {
+		return 0
+	}
+	variance := m2 / float64(len(values))
+	if variance <= 0 {
+		return 0
+	}
+	return math.Sqrt(variance) / mean
+}
+
+func fairnessQueueTransmitRates(status ProcessStatus) map[fairnessQueueKey]uint64 {
+	out := make(map[fairnessQueueKey]uint64)
+	for _, iface := range status.CoSInterfaces {
+		for _, queue := range iface.Queues {
+			if queue.QueueID < 0 || queue.QueueID > 255 {
+				continue
+			}
+			rate := queue.TransmitRateBytes
+			if rate == 0 {
+				rate = iface.ShapingRateBytes
+			}
+			out[fairnessQueueKey{ifindex: iface.Ifindex, queueID: uint8(queue.QueueID)}] = rate
+		}
+	}
+	return out
+}

--- a/pkg/dataplane/userspace/fairness_throughput.go
+++ b/pkg/dataplane/userspace/fairness_throughput.go
@@ -167,7 +167,7 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		if state == nil || len(state.bytesByFlow) == 0 {
 			continue
 		}
-		summary := state.summary(key, queueRates[key], w.window)
+		summary := state.summary(key, queueRates[key])
 		out = append(out, summary)
 	}
 	return out
@@ -210,7 +210,7 @@ func (q *fairnessQueueThroughputWindow) addSample(sample fairnessThroughputSampl
 
 func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
 	keepFrom := 0
-	for keepFrom < len(q.samples) && q.samples[keepFrom].at.Before(cutoff) {
+	for keepFrom < len(q.samples) && !q.samples[keepFrom].at.After(cutoff) {
 		for flow, delta := range q.samples[keepFrom].deltas {
 			if q.bytesByFlow[flow] <= delta {
 				delete(q.bytesByFlow, flow)
@@ -231,7 +231,7 @@ func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
 	}
 }
 
-func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64, window time.Duration) FairnessThroughputSummary {
+func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64) FairnessThroughputSummary {
 	var totalBytes uint64
 	values := make([]float64, 0, len(q.bytesByFlow))
 	for _, bytes := range q.bytesByFlow {
@@ -242,9 +242,6 @@ func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRa
 		values = append(values, float64(bytes))
 	}
 	windowSeconds := q.windowSeconds()
-	if limit := window.Seconds(); limit > 0 && windowSeconds > limit {
-		windowSeconds = limit
-	}
 	observedCoV := coefficientOfVariation(values)
 	saturated := false
 	if transmitRateBytes > 0 && windowSeconds > 0 {

--- a/pkg/dataplane/userspace/fairness_throughput.go
+++ b/pkg/dataplane/userspace/fairness_throughput.go
@@ -84,43 +84,51 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 	}
 	w.lastUpdate = now
 
+	if status.FlowWorkerMapTruncated {
+		w.resetWindowState()
+		return nil
+	}
+
 	queueRates := fairnessQueueTransmitRates(status)
 	seen := make(map[fairnessFlowThroughputKey]uint64)
+	sampleQueues := make(map[fairnessQueueKey]struct{}, len(w.queues))
+	for queue := range w.queues {
+		sampleQueues[queue] = struct{}{}
+	}
 	sampleDeltas := make(map[fairnessQueueKey]map[fairnessFlowThroughputKey]uint64)
-	if !status.FlowWorkerMapTruncated {
-		for _, row := range status.FlowWorkerMap {
-			if row.CoSQueueID == nil || row.EgressIfindex == 0 {
-				continue
-			}
-			key := fairnessFlowThroughputKey{
-				queue: fairnessQueueKey{ifindex: row.EgressIfindex, queueID: *row.CoSQueueID},
-				tuple: row.ForwardWireKey,
-			}
-			if key.tuple == (FlowTupleStatus{}) {
-				key.tuple = row.SessionKey
-			}
-			seen[key] = row.ObservedBytes
-			previous, ok := w.prev[key]
-			w.prev[key] = row.ObservedBytes
-			if duration <= 0 || !ok {
-				continue
-			}
-			delta := uint64(0)
-			if row.ObservedBytes >= previous {
-				delta = row.ObservedBytes - previous
-			} else {
-				delta = row.ObservedBytes
-			}
-			if delta == 0 {
-				continue
-			}
-			deltas := sampleDeltas[key.queue]
-			if deltas == nil {
-				deltas = make(map[fairnessFlowThroughputKey]uint64)
-				sampleDeltas[key.queue] = deltas
-			}
-			deltas[key] += delta
+	for _, row := range status.FlowWorkerMap {
+		if row.CoSQueueID == nil || row.EgressIfindex == 0 {
+			continue
 		}
+		key := fairnessFlowThroughputKey{
+			queue: fairnessQueueKey{ifindex: row.EgressIfindex, queueID: *row.CoSQueueID},
+			tuple: row.ForwardWireKey,
+		}
+		if key.tuple == (FlowTupleStatus{}) {
+			key.tuple = row.SessionKey
+		}
+		sampleQueues[key.queue] = struct{}{}
+		seen[key] = row.ObservedBytes
+		previous, ok := w.prev[key]
+		w.prev[key] = row.ObservedBytes
+		if duration <= 0 || !ok {
+			continue
+		}
+		delta := uint64(0)
+		if row.ObservedBytes >= previous {
+			delta = row.ObservedBytes - previous
+		} else {
+			delta = row.ObservedBytes
+		}
+		if delta == 0 {
+			continue
+		}
+		deltas := sampleDeltas[key.queue]
+		if deltas == nil {
+			deltas = make(map[fairnessFlowThroughputKey]uint64)
+			sampleDeltas[key.queue] = deltas
+		}
+		deltas[key] += delta
 	}
 	for key := range w.prev {
 		if _, ok := seen[key]; !ok {
@@ -128,13 +136,15 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		}
 	}
 
-	for queue, deltas := range sampleDeltas {
-		state := w.queueState(queue)
-		state.addSample(fairnessThroughputSample{
-			at:       now,
-			duration: duration,
-			deltas:   deltas,
-		})
+	if duration > 0 {
+		for queue := range sampleQueues {
+			state := w.queueState(queue)
+			state.addSample(fairnessThroughputSample{
+				at:       now,
+				duration: duration,
+				deltas:   sampleDeltas[queue],
+			})
+		}
 	}
 	for _, state := range w.queues {
 		state.prune(now.Add(-w.window))
@@ -157,11 +167,20 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		if state == nil || len(state.bytesByFlow) == 0 {
 			continue
 		}
-		summary := state.summary(key, queueRates[key])
-		summary.SourceTruncated = status.FlowWorkerMapTruncated
+		summary := state.summary(key, queueRates[key], w.window)
 		out = append(out, summary)
 	}
 	return out
+}
+
+func (w *FairnessThroughputWindow) resetWindowState() {
+	w.lastUpdate = time.Time{}
+	clear(w.prev)
+	for _, state := range w.queues {
+		state.samples = nil
+		clear(state.bytesByFlow)
+		clear(state.starvedFlows)
+	}
 }
 
 func (w *FairnessThroughputWindow) queueState(key fairnessQueueKey) *fairnessQueueThroughputWindow {
@@ -212,7 +231,7 @@ func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
 	}
 }
 
-func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64) FairnessThroughputSummary {
+func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64, window time.Duration) FairnessThroughputSummary {
 	var totalBytes uint64
 	values := make([]float64, 0, len(q.bytesByFlow))
 	for _, bytes := range q.bytesByFlow {
@@ -223,6 +242,9 @@ func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRa
 		values = append(values, float64(bytes))
 	}
 	windowSeconds := q.windowSeconds()
+	if limit := window.Seconds(); limit > 0 && windowSeconds > limit {
+		windowSeconds = limit
+	}
 	observedCoV := coefficientOfVariation(values)
 	saturated := false
 	if transmitRateBytes > 0 && windowSeconds > 0 {

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -1,0 +1,168 @@
+package userspace
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestFairnessThroughputWindowComputesRollingCoVAndSaturation(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	if got := window.Update(now, status); len(got) != 0 {
+		t.Fatalf("first update produced %d summaries, want 0", len(got))
+	}
+
+	status.FlowWorkerMap[0].ObservedBytes = 6_000
+	status.FlowWorkerMap[1].ObservedBytes = 2_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	summary := got[0]
+	if !summary.Saturated {
+		t.Fatalf("Saturated = false, want true: %+v", summary)
+	}
+	if summary.FlowCount != 2 {
+		t.Fatalf("FlowCount = %d, want 2", summary.FlowCount)
+	}
+	if math.Abs(summary.ObservedCoV-(2.0/3.0)) > 0.0001 {
+		t.Fatalf("ObservedCoV = %.6f, want %.6f", summary.ObservedCoV, 2.0/3.0)
+	}
+	if summary.ObservedBytes != 6_000 {
+		t.Fatalf("ObservedBytes = %d, want 6000", summary.ObservedBytes)
+	}
+	if summary.WindowSeconds != 10 {
+		t.Fatalf("WindowSeconds = %.1f, want 10", summary.WindowSeconds)
+	}
+}
+
+func TestFairnessThroughputWindowCountsStarvedFlowsOnce(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 101_000
+	status.FlowWorkerMap[1].ObservedBytes = 1_100
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	if got[0].StarvedFlowsTotal != 1 {
+		t.Fatalf("StarvedFlowsTotal = %d, want 1", got[0].StarvedFlowsTotal)
+	}
+
+	status.FlowWorkerMap[0].ObservedBytes = 201_000
+	status.FlowWorkerMap[1].ObservedBytes = 1_200
+	got = window.Update(now.Add(20*time.Second), status)
+	if got[0].StarvedFlowsTotal != 1 {
+		t.Fatalf("StarvedFlowsTotal after repeated starvation = %d, want 1", got[0].StarvedFlowsTotal)
+	}
+}
+
+func TestFairnessThroughputWindowPrunesStarvedFlowDedup(t *testing.T) {
+	window := NewFairnessThroughputWindow(5 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 101_000
+	status.FlowWorkerMap[1].ObservedBytes = 1_001
+	got := window.Update(now.Add(time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	if got[0].StarvedFlowsTotal != 1 {
+		t.Fatalf("StarvedFlowsTotal = %d, want 1", got[0].StarvedFlowsTotal)
+	}
+
+	status.FlowWorkerMap = status.FlowWorkerMap[:1]
+	status.FlowWorkerMap[0].ObservedBytes = 201_000
+	got = window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("after prune produced %d summaries, want 1", len(got))
+	}
+
+	second := throughputStatus(queueID, 0, 5_000).FlowWorkerMap[1]
+	status.FlowWorkerMap = append(status.FlowWorkerMap, second)
+	status.FlowWorkerMap[0].ObservedBytes = 202_000
+	window.Update(now.Add(11*time.Second), status)
+
+	status.FlowWorkerMap[0].ObservedBytes = 302_000
+	status.FlowWorkerMap[1].ObservedBytes = 5_001
+	got = window.Update(now.Add(12*time.Second), status)
+	if got[0].StarvedFlowsTotal != 2 {
+		t.Fatalf("StarvedFlowsTotal after re-entry = %d, want 2", got[0].StarvedFlowsTotal)
+	}
+}
+
+func TestFairnessThroughputWindowPrunesOldSamples(t *testing.T) {
+	window := NewFairnessThroughputWindow(15 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 2_000
+	status.FlowWorkerMap[1].ObservedBytes = 2_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 || got[0].ObservedBytes != 2_000 {
+		t.Fatalf("after first delta got %+v, want 2000 observed bytes", got)
+	}
+
+	status.FlowWorkerMap[0].ObservedBytes = 3_000
+	status.FlowWorkerMap[1].ObservedBytes = 3_000
+	got = window.Update(now.Add(30*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("after prune got %d summaries, want 1", len(got))
+	}
+	if got[0].ObservedBytes != 2_000 {
+		t.Fatalf("ObservedBytes after prune = %d, want 2000", got[0].ObservedBytes)
+	}
+}
+
+func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) ProcessStatus {
+	return ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{{
+			Ifindex: 80,
+			Queues: []CoSQueueStatus{{
+				QueueID:           int(queueID),
+				TransmitRateBytes: 500,
+			}},
+		}},
+		FlowWorkerMap: []FlowWorkerStatus{
+			{
+				EgressIfindex: 80,
+				CoSQueueID:    &queueID,
+				ForwardWireKey: FlowTupleStatus{
+					AddrFamily: 2,
+					Protocol:   6,
+					SrcIP:      "10.0.0.1",
+					DstIP:      "198.51.100.1",
+					SrcPort:    10001,
+					DstPort:    5201,
+				},
+				ObservedBytes: firstBytes,
+			},
+			{
+				EgressIfindex: 80,
+				CoSQueueID:    &queueID,
+				ForwardWireKey: FlowTupleStatus{
+					AddrFamily: 2,
+					Protocol:   6,
+					SrcIP:      "10.0.0.2",
+					DstIP:      "198.51.100.1",
+					SrcPort:    10002,
+					DstPort:    5201,
+				},
+				ObservedBytes: secondBytes,
+			},
+		},
+	}
+}

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -94,6 +94,30 @@ func TestFairnessThroughputWindowAdvancesDuringIdleScrapes(t *testing.T) {
 	}
 }
 
+func TestFairnessThroughputWindowPrunesBoundarySampleWithoutCapping(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	for step := 1; step <= 4; step++ {
+		status.FlowWorkerMap[0].ObservedBytes += 5_000
+		got := window.Update(now.Add(time.Duration(step)*10*time.Second), status)
+		if len(got) != 1 {
+			t.Fatalf("step %d produced %d summaries, want 1", step, len(got))
+		}
+		if step == 4 {
+			if got[0].ObservedBytes != 15_000 {
+				t.Fatalf("ObservedBytes after boundary prune = %d, want 15000", got[0].ObservedBytes)
+			}
+			if got[0].WindowSeconds != 30 {
+				t.Fatalf("WindowSeconds after boundary prune = %.1f, want 30", got[0].WindowSeconds)
+			}
+		}
+	}
+}
+
 func TestFairnessThroughputWindowTruncationResetsWindow(t *testing.T) {
 	window := NewFairnessThroughputWindow(30 * time.Second)
 	now := time.Unix(100, 0)

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -153,6 +153,34 @@ func TestFairnessThroughputWindowTruncationResetsWindow(t *testing.T) {
 	}
 }
 
+func TestFairnessThroughputWindowDoesNotInflateSaturationAtWindowBoundary(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 0, 0)
+
+	window.Update(now, status)
+
+	var got []FairnessThroughputSummary
+	for i := 1; i <= 4; i++ {
+		status.FlowWorkerMap[0].ObservedBytes += 2_000
+		status.FlowWorkerMap[1].ObservedBytes += 2_000
+		got = window.Update(now.Add(time.Duration(i)*10*time.Second), status)
+	}
+	if len(got) != 1 {
+		t.Fatalf("boundary update produced %d summaries, want 1", len(got))
+	}
+	if got[0].Saturated {
+		t.Fatalf("Saturated at steady 400 B/s = true, want false: %+v", got[0])
+	}
+	if got[0].ObservedBytes != 12_000 {
+		t.Fatalf("ObservedBytes at boundary = %d, want 12000", got[0].ObservedBytes)
+	}
+	if got[0].WindowSeconds != 30 {
+		t.Fatalf("WindowSeconds at boundary = %.1f, want 30", got[0].WindowSeconds)
+	}
+}
+
 func TestFairnessThroughputWindowPrunesStarvedFlowDedup(t *testing.T) {
 	window := NewFairnessThroughputWindow(5 * time.Second)
 	now := time.Unix(100, 0)

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -65,6 +65,70 @@ func TestFairnessThroughputWindowCountsStarvedFlowsOnce(t *testing.T) {
 	}
 }
 
+func TestFairnessThroughputWindowAdvancesDuringIdleScrapes(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 6_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	if !got[0].Saturated {
+		t.Fatalf("Saturated after 500 B/s sample = false, want true: %+v", got[0])
+	}
+
+	status.FlowWorkerMap = nil
+	got = window.Update(now.Add(20*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("idle update produced %d summaries, want 1", len(got))
+	}
+	if got[0].Saturated {
+		t.Fatalf("Saturated after idle wall-clock advance = true, want false: %+v", got[0])
+	}
+	if got[0].WindowSeconds != 20 {
+		t.Fatalf("WindowSeconds after idle update = %.1f, want 20", got[0].WindowSeconds)
+	}
+}
+
+func TestFairnessThroughputWindowTruncationResetsWindow(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 1_000, 1_000)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 6_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+
+	truncated := status
+	truncated.FlowWorkerMapTruncated = true
+	if got := window.Update(now.Add(20*time.Second), truncated); len(got) != 0 {
+		t.Fatalf("truncated update produced %d summaries, want 0", len(got))
+	}
+
+	status.FlowWorkerMap[0].ObservedBytes = 7_000
+	got = window.Update(now.Add(30*time.Second), status)
+	if len(got) != 0 {
+		t.Fatalf("post-truncation baseline update produced stale summaries: %+v", got)
+	}
+
+	status.FlowWorkerMap[0].ObservedBytes = 8_000
+	got = window.Update(now.Add(40*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("post-truncation delta update produced %d summaries, want 1", len(got))
+	}
+	if got[0].WindowSeconds != 10 {
+		t.Fatalf("post-truncation WindowSeconds = %.1f, want 10", got[0].WindowSeconds)
+	}
+}
+
 func TestFairnessThroughputWindowPrunesStarvedFlowDedup(t *testing.T) {
 	window := NewFairnessThroughputWindow(5 * time.Second)
 	now := time.Unix(100, 0)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -620,6 +620,7 @@ type FlowWorkerStatus struct {
 	CoSQueueID          *uint8          `json:"cos_queue_id,omitempty"`
 	DSCPRewrite         *uint8          `json:"dscp_rewrite,omitempty"`
 	AgeEpochs           uint16          `json:"age_epochs,omitempty"`
+	ObservedBytes       uint64          `json:"observed_bytes,omitempty"`
 }
 
 type CoSActiveFlowCountStatus struct {

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -280,8 +280,9 @@ func TestProcessStatusFlowWorkerMapRoundTrip(t *testing.T) {
 				SrcPort:    49152,
 				DstPort:    5201,
 			},
-			CoSQueueID: &cosQueueID,
-			AgeEpochs:  3,
+			CoSQueueID:    &cosQueueID,
+			AgeEpochs:     3,
+			ObservedBytes: 123456,
 		}},
 	}
 	raw, err := json.Marshal(&in)

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -435,6 +435,9 @@ func FormatFlowWorkerMap(status ProcessStatus, limit int) string {
 		if row.DSCPRewrite != nil {
 			fmt.Fprintf(&b, " dscp-rewrite=%d", *row.DSCPRewrite)
 		}
+		if row.ObservedBytes > 0 {
+			fmt.Fprintf(&b, " observed-bytes=%d", row.ObservedBytes)
+		}
 		fmt.Fprintln(&b)
 	}
 	return b.String()

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -187,6 +187,7 @@ func TestFormatFlowWorkerMap(t *testing.T) {
 				CoSQueueID:     &cosQueue,
 				DSCPRewrite:    &dscpRewrite,
 				AgeEpochs:      7,
+				ObservedBytes:  123456,
 				SessionKey: FlowTupleStatus{
 					Protocol: 6,
 					SrcIP:    "172.16.80.10",
@@ -251,6 +252,7 @@ func TestFormatFlowWorkerMap(t *testing.T) {
 		"172.16.80.10:40000->172.16.80.200:5201",
 		"wire=tcp 172.16.80.10:40000->172.16.80.200:5201",
 		"reverse=tcp 172.16.80.200:5201->172.16.80.10:40000",
+		"observed-bytes=123456",
 	} {
 		if !strings.Contains(allOut, want) {
 			t.Fatalf("flow-worker all output missing %q:\n%s", want, allOut)

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -126,6 +126,11 @@ pub(super) struct FlowCacheEntry {
     /// Validation stamp captured at insert time. Stale entries are treated as
     /// misses without requiring per-entry scans at RG transition.
     pub(super) stamp: FlowCacheStamp,
+    /// #1264: cumulative bytes observed for this cached flow by the
+    /// worker-owned flow cache. Updated only while the entry is already
+    /// mutably borrowed on cache insert/hit, so the telemetry adds no shared
+    /// atomics and no cross-worker cache-line traffic.
+    pub(super) observed_bytes: u64,
     /// #1219: per-hit recency counter. Owner-only single u16 store on every
     /// `lookup()` hit — see `FlowCache::current_epoch` for the comparison
     /// reference. The ~65ms-tick scan in `count_active_flows()` counts
@@ -148,6 +153,7 @@ pub(super) struct FlowCacheDebugEntry {
     pub(super) cos_queue_id: Option<u8>,
     pub(super) dscp_rewrite: Option<u8>,
     pub(super) age_epochs: u16,
+    pub(super) observed_bytes: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -317,6 +323,7 @@ impl FlowCacheEntry {
                 ha_state,
                 rg_epochs,
             ),
+            observed_bytes: u64::from(meta.pkt_len),
             // #1219: 0 = "never touched"; first lookup hit will stamp
             // it with the current epoch.
             last_used_epoch: 0,
@@ -455,6 +462,7 @@ impl FlowCache {
                 cos_queue_id: entry.descriptor.tx_selection.queue_id,
                 dscp_rewrite: entry.descriptor.tx_selection.dscp_rewrite,
                 age_epochs,
+                observed_bytes: entry.observed_bytes,
             });
         }
         let cos_counts = cos_counts
@@ -525,6 +533,7 @@ impl FlowCache {
         row[FLOW_CACHE_WAYS - 1] = way;
     }
 
+    #[cfg(test)]
     #[inline]
     pub(super) fn lookup(
         &mut self,
@@ -532,6 +541,30 @@ impl FlowCache {
         lookup: FlowCacheLookup,
         now_secs: u64,
         rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+    ) -> Option<&FlowCacheEntry> {
+        self.lookup_with_observed_bytes(key, lookup, now_secs, rg_epochs, 0)
+    }
+
+    #[inline]
+    pub(super) fn lookup_counted(
+        &mut self,
+        key: &crate::session::SessionKey,
+        lookup: FlowCacheLookup,
+        now_secs: u64,
+        rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+        packet_len: u16,
+    ) -> Option<&FlowCacheEntry> {
+        self.lookup_with_observed_bytes(key, lookup, now_secs, rg_epochs, u64::from(packet_len))
+    }
+
+    #[inline]
+    fn lookup_with_observed_bytes(
+        &mut self,
+        key: &crate::session::SessionKey,
+        lookup: FlowCacheLookup,
+        now_secs: u64,
+        rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+        observed_bytes: u64,
     ) -> Option<&FlowCacheEntry> {
         let set = Self::set_index(key, lookup.ingress_ifindex);
         let base = set * FLOW_CACHE_WAYS;
@@ -591,6 +624,7 @@ impl FlowCache {
                     .as_mut()
                     .expect("BUG: entry at entry_idx is None after key match — impossible cache state");
                 entry.last_used_epoch = now;
+                entry.observed_bytes = entry.observed_bytes.saturating_add(observed_bytes);
                 return Some(entry);
             }
         }

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -99,6 +99,7 @@ fn make_entry(
         decision: make_decision(ForwardingDisposition::ForwardCandidate),
         metadata: make_metadata(owner_rg_id),
         stamp,
+        observed_bytes: 0,
         last_used_epoch: 0,
     }
 }
@@ -133,6 +134,37 @@ fn cache_hit_with_matching_stamp() {
     assert!(hit.is_some(), "expected cache hit with matching stamp");
     assert_eq!(cache.hits, 1);
     assert_eq!(cache.misses, 0);
+}
+
+#[test]
+fn cache_hit_accumulates_observed_bytes() {
+    let rg_epochs = default_rg_epochs();
+    let mut cache = FlowCache::new();
+    let key = make_key();
+    let stamp = FlowCacheStamp {
+        config_generation: 5,
+        fib_generation: 3,
+        owner_rg_id: 0,
+        owner_rg_epoch: 0,
+        owner_rg_lease_until: 0,
+    };
+    cache.insert(make_entry(key.clone(), stamp, 0));
+
+    let lookup = FlowCacheLookup {
+        ingress_ifindex: 7,
+        config_generation: 5,
+        fib_generation: 3,
+    };
+    assert!(cache
+        .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
+        .is_some());
+    assert!(cache
+        .lookup_counted(&key, lookup, 0, &rg_epochs, 900)
+        .is_some());
+
+    let (_active_count, rows, _cos_counts, _truncated) = cache.active_flow_debug_entries(8);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].observed_bytes, 2400);
 }
 
 // ----------------------------------------------------------------
@@ -1401,6 +1433,7 @@ fn active_flow_debug_entries_include_worker_join_keys() {
     assert_eq!(row.cos_queue_id, Some(4));
     assert_eq!(row.dscp_rewrite, Some(46));
     assert_eq!(row.age_epochs, 0);
+    assert_eq!(row.observed_bytes, 0);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -143,11 +143,12 @@ pub(super) fn poll_binding_process_descriptor(
                     if FlowCacheEntry::packet_eligible(meta)
                         && let Some(flow) = flow.as_ref()
                     {
-                        if let Some(cached) = binding.flow.flow_cache.lookup(
+                        if let Some(cached) = binding.flow.flow_cache.lookup_counted(
                             &flow.forward_key,
                             FlowCacheLookup::for_packet(meta, validation),
                             now_secs,
                             &worker_ctx.rg_epochs,
+                            meta.pkt_len,
                         ) {
                             if !cached_flow_decision_valid(
                                 worker_ctx.forwarding,

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -1813,6 +1813,7 @@ fn epoch_based_flow_cache_invalidation_for_demoted_owner_rg() {
             owner_rg_epoch: 0,
             owner_rg_lease_until: 0,
         },
+        observed_bytes: 0,
         last_used_epoch: 0,
     });
 
@@ -1893,6 +1894,7 @@ fn epoch_based_flow_cache_unrelated_rg_not_invalidated() {
             owner_rg_epoch: 0,
             owner_rg_lease_until: 0,
         },
+        observed_bytes: 0,
         last_used_epoch: 0,
     });
 

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1179,6 +1179,7 @@ pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
                 cos_queue_id: entry.cos_queue_id,
                 dscp_rewrite: entry.dscp_rewrite,
                 age_epochs: entry.age_epochs,
+                observed_bytes: entry.observed_bytes,
             })
             .collect(),
         flow_map_truncated,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1117,6 +1117,8 @@ pub(crate) struct FlowWorkerStatus {
     pub dscp_rewrite: Option<u8>,
     #[serde(rename = "age_epochs", default)]
     pub age_epochs: u16,
+    #[serde(rename = "observed_bytes", default)]
+    pub observed_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Closes #1264.

Adds the production runtime throughput side of the CoS fairness contract:

- worker-owned flow-cache byte accounting surfaced as `observed_bytes` in the bounded flow-worker snapshot
- daemon-side 30-second rolling per-flow throughput window per `{ifindex, queue_id}`
- Prometheus metrics for `xpf_fairness_saturated`, `xpf_fairness_observed_cov`, and `xpf_fairness_starved_flows`
- fail-closed handling for truncated flow-worker snapshots so dead/incomplete telemetry does not look healthy
- docs updated to describe the runtime window and reset/de-dup semantics

The packet hot path remains owner-local: cache hits update the already-borrowed flow-cache entry with a saturating `u64` byte counter. There are no global packet-rate atomics and no scheduler feedback loop.

## Validation

- `go test ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`
- `go test ./pkg/...`
- `cargo test flow_cache` from `userspace-dp/`
- `cargo test` from `userspace-dp/` (passes with existing warning set)
- `git diff --check`
