### PR TITLE
Polish fairness RSS expectation telemetry

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -338,6 +338,16 @@ For production observability, xpf MUST export:
 - **`xpf_fairness_cos_active_flow_counts_truncated`** gauge: 1 when
   the status snapshot was truncated before the fairness RSS gauges
   were derived; 0 otherwise.
+- **`xpf_fairness_rss_expectation_configured{ifindex=..., queue_id=..., kind=...}`**
+  gauge: 1 for each configured opt-in RSS/workload expectation. The
+  label is the stable expectation kind, not the full threshold string.
+- **`xpf_fairness_rss_expectation_value{ifindex=..., queue_id=..., kind=...}`**
+  gauge: configured numeric value for expectation kinds that take a
+  value, such as active-worker count or `max-worker-flow-share`
+  threshold.
+- **`xpf_fairness_rss_skew_violation{ifindex=..., queue_id=..., kind=...}`**
+  gauge: 1 when the configured RSS/workload expectation fails for the
+  egress CoS queue; 0 when it passes.
 - **`xpf_fairness_saturated{ifindex=..., queue_id=...}`** Prometheus gauge: 0 or
   1. Computed from the daemon's rolling 30-second per-flow byte
   window as aggregate queue throughput vs the configured CoS queue

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -345,11 +345,25 @@ The runtime expectation slice adds opt-in production evaluation via
 `fairness-eval` in Junos-style set syntax (`balanced`,
 `at-least-active-workers <N>`, `max-worker-flow-share <X>`, or
 `cstruct-max <X>`; threshold values use fractions such as `0.5` in
-set syntax). Configured expectations are rendered under
+set syntax). The key is intentionally ifindex-only: the userspace
+status snapshot and Prometheus labels are keyed by kernel ifindex, and
+interface names can be renamed or absent during dataplane restarts.
+Configured expectations are rendered under
 `show chassis cluster data-plane fairness` and exported as:
 
-- `xpf_fairness_rss_expectation_configured{ifindex,queue_id,expectation}`
-- `xpf_fairness_rss_skew_violation{ifindex,queue_id,expectation}`
+- `xpf_fairness_rss_expectation_configured{ifindex,queue_id,kind}`
+- `xpf_fairness_rss_expectation_value{ifindex,queue_id,kind}`
+- `xpf_fairness_rss_skew_violation{ifindex,queue_id,kind}`
+
+The `kind` label is one of the stable expectation kinds (`any`,
+`balanced`, `at-least-active-workers`, `max-worker-flow-share`, or
+`cstruct-max`). Numeric knobs such as active-worker count and
+thresholds are exported as metric values rather than labels. This is
+a compatibility break from the initial #1247/#1263 metric shape, which
+used the full canonical expectation string as a label and therefore
+made arbitrary thresholds part of the Prometheus label cardinality.
+Duplicate expectation leaves are rejected at compile time; repeated
+identical `set` commands remain idempotent.
 
 The runtime throughput slice exports the remaining observed-workload
 metrics from a rolling 30-second daemon window:

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -110,17 +110,18 @@ type xpfCollector struct {
 	// #1247: production RSS/workload health gauges derived from the
 	// same per-CoS {a_i} snapshot. These expose the structural ceiling
 	// without adding packet-path state or global atomics.
-	fairnessCstruct            *prometheus.Desc
-	fairnessActiveWorkers      *prometheus.Desc
-	fairnessActiveFlows        *prometheus.Desc
-	fairnessMaxWorkerFlowShare *prometheus.Desc
-	fairnessCoSCountsTruncated *prometheus.Desc
-	fairnessRSSExpectation     *prometheus.Desc
-	fairnessRSSSkewViolation   *prometheus.Desc
-	fairnessSaturated          *prometheus.Desc
-	fairnessObservedCoV        *prometheus.Desc
-	fairnessStarvedFlows       *prometheus.Desc
-	fairnessThroughputWindow   *dpuserspace.FairnessThroughputWindow
+	fairnessCstruct             *prometheus.Desc
+	fairnessActiveWorkers       *prometheus.Desc
+	fairnessActiveFlows         *prometheus.Desc
+	fairnessMaxWorkerFlowShare  *prometheus.Desc
+	fairnessCoSCountsTruncated  *prometheus.Desc
+	fairnessRSSExpectation      *prometheus.Desc
+	fairnessRSSExpectationValue *prometheus.Desc
+	fairnessRSSSkewViolation    *prometheus.Desc
+	fairnessSaturated           *prometheus.Desc
+	fairnessObservedCoV         *prometheus.Desc
+	fairnessStarvedFlows        *prometheus.Desc
+	fairnessThroughputWindow    *dpuserspace.FairnessThroughputWindow
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -419,12 +420,17 @@ func newCollector(srv *Server) *xpfCollector {
 		fairnessRSSExpectation: prometheus.NewDesc(
 			"xpf_fairness_rss_expectation_configured",
 			"1 for each configured opt-in RSS/workload expectation evaluated against this egress CoS queue (#1247).",
-			[]string{"ifindex", "queue_id", "expectation"}, nil,
+			[]string{"ifindex", "queue_id", "kind"}, nil,
+		),
+		fairnessRSSExpectationValue: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_value",
+			"Configured numeric value for RSS/workload expectation kinds that take one, such as active-worker count or threshold (#1265).",
+			[]string{"ifindex", "queue_id", "kind"}, nil,
 		),
 		fairnessRSSSkewViolation: prometheus.NewDesc(
 			"xpf_fairness_rss_skew_violation",
 			"1 when the configured RSS/workload expectation fails for this egress CoS queue; 0 when it passes (#1247).",
-			[]string{"ifindex", "queue_id", "expectation"}, nil,
+			[]string{"ifindex", "queue_id", "kind"}, nil,
 		),
 		fairnessSaturated: prometheus.NewDesc(
 			"xpf_fairness_saturated",
@@ -501,6 +507,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.fairnessMaxWorkerFlowShare
 	ch <- c.fairnessCoSCountsTruncated
 	ch <- c.fairnessRSSExpectation
+	ch <- c.fairnessRSSExpectationValue
 	ch <- c.fairnessRSSSkewViolation
 	ch <- c.fairnessSaturated
 	ch <- c.fairnessObservedCoV
@@ -653,8 +660,18 @@ func (c *xpfCollector) emitFairnessRSSExpectationGauges(
 			1,
 			ifindexLabel,
 			queueLabel,
-			result.Expectation,
+			result.ExpectationKind,
 		)
+		if result.HasExpectationValue {
+			ch <- prometheus.MustNewConstMetric(
+				c.fairnessRSSExpectationValue,
+				prometheus.GaugeValue,
+				result.ExpectationValue,
+				ifindexLabel,
+				queueLabel,
+				result.ExpectationKind,
+			)
+		}
 		violation := 1.0
 		if result.Pass {
 			violation = 0
@@ -665,7 +682,7 @@ func (c *xpfCollector) emitFairnessRSSExpectationGauges(
 			violation,
 			ifindexLabel,
 			queueLabel,
-			result.Expectation,
+			result.ExpectationKind,
 		)
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -415,13 +415,19 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 		fairnessRSSExpectation: prometheus.NewDesc(
 			"xpf_fairness_rss_expectation_configured",
 			"test desc",
-			[]string{"ifindex", "queue_id", "expectation"},
+			[]string{"ifindex", "queue_id", "kind"},
+			nil,
+		),
+		fairnessRSSExpectationValue: prometheus.NewDesc(
+			"xpf_fairness_rss_expectation_value",
+			"test desc",
+			[]string{"ifindex", "queue_id", "kind"},
 			nil,
 		),
 		fairnessRSSSkewViolation: prometheus.NewDesc(
 			"xpf_fairness_rss_skew_violation",
 			"test desc",
-			[]string{"ifindex", "queue_id", "expectation"},
+			[]string{"ifindex", "queue_id", "kind"},
 			nil,
 		),
 	}
@@ -452,19 +458,20 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 	for m := range ch {
 		got = append(got, m)
 	}
-	if len(got) != 6 {
-		t.Fatalf("expected 6 expectation metrics, got %d", len(got))
+	if len(got) != 7 {
+		t.Fatalf("expected 7 expectation metrics, got %d", len(got))
 	}
-	labelsQ4 := map[string]string{"ifindex": "80", "queue_id": "4", "expectation": "balanced"}
+	labelsQ4 := map[string]string{"ifindex": "80", "queue_id": "4", "kind": "balanced"}
 	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ4, 1)
 	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ4, 1)
 
-	labelsQ5 := map[string]string{"ifindex": "80", "queue_id": "5", "expectation": "balanced"}
+	labelsQ5 := map[string]string{"ifindex": "80", "queue_id": "5", "kind": "balanced"}
 	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ5, 1)
 	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ5, 0)
 
-	labelsQ6 := map[string]string{"ifindex": "80", "queue_id": "6", "expectation": "cstruct-max:0.25"}
+	labelsQ6 := map[string]string{"ifindex": "80", "queue_id": "6", "kind": "cstruct-max"}
 	assertGaugeClose(t, got, c.fairnessRSSExpectation, labelsQ6, 1)
+	assertGaugeClose(t, got, c.fairnessRSSExpectationValue, labelsQ6, 0.25)
 	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ6, 1)
 }
 
@@ -528,13 +535,14 @@ func collectFromEmitFairnessRSSGauges(
 		got = append(got, m)
 	}
 	expected := map[*prometheus.Desc]struct{}{
-		c.fairnessCstruct:            {},
-		c.fairnessActiveWorkers:      {},
-		c.fairnessActiveFlows:        {},
-		c.fairnessMaxWorkerFlowShare: {},
-		c.fairnessCoSCountsTruncated: {},
-		c.fairnessRSSExpectation:     {},
-		c.fairnessRSSSkewViolation:   {},
+		c.fairnessCstruct:             {},
+		c.fairnessActiveWorkers:       {},
+		c.fairnessActiveFlows:         {},
+		c.fairnessMaxWorkerFlowShare:  {},
+		c.fairnessCoSCountsTruncated:  {},
+		c.fairnessRSSExpectation:      {},
+		c.fairnessRSSExpectationValue: {},
+		c.fairnessRSSSkewViolation:    {},
 	}
 	for _, m := range got {
 		if _, ok := expected[m.Desc()]; !ok {

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -372,7 +372,6 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 
 func collectCoSFairnessRSSExpectation(queueNode *Node) (string, error) {
 	var expr string
-	seenKinds := make(map[string]struct{})
 	set := func(kind string, nodes []*Node, next func(*Node) string) error {
 		if len(nodes) == 0 {
 			return nil
@@ -380,14 +379,7 @@ func collectCoSFairnessRSSExpectation(queueNode *Node) (string, error) {
 		if len(nodes) > 1 {
 			return fmt.Errorf("duplicate %s expectation leaf", kind)
 		}
-		if _, ok := seenKinds[kind]; ok {
-			return fmt.Errorf("duplicate %s expectation leaf", kind)
-		}
-		seenKinds[kind] = struct{}{}
 		value := next(nodes[0])
-		if value == "" {
-			return nil
-		}
 		if expr != "" && expr != value {
 			return fmt.Errorf("multiple expectations configured: %q and %q", expr, value)
 		}

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -372,44 +372,52 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 
 func collectCoSFairnessRSSExpectation(queueNode *Node) (string, error) {
 	var expr string
-	set := func(next string) error {
-		if next == "" {
+	seenKinds := make(map[string]struct{})
+	set := func(kind string, nodes []*Node, next func(*Node) string) error {
+		if len(nodes) == 0 {
 			return nil
 		}
-		if expr != "" && expr != next {
-			return fmt.Errorf("multiple expectations configured: %q and %q", expr, next)
+		if len(nodes) > 1 {
+			return fmt.Errorf("duplicate %s expectation leaf", kind)
 		}
-		expr = next
+		if _, ok := seenKinds[kind]; ok {
+			return fmt.Errorf("duplicate %s expectation leaf", kind)
+		}
+		seenKinds[kind] = struct{}{}
+		value := next(nodes[0])
+		if value == "" {
+			return nil
+		}
+		if expr != "" && expr != value {
+			return fmt.Errorf("multiple expectations configured: %q and %q", expr, value)
+		}
+		expr = value
 		return nil
 	}
-	if queueNode.FindChild("any") != nil {
-		if err := set("any"); err != nil {
-			return "", err
-		}
+	setFlag := func(kind string) error {
+		return set(kind, queueNode.FindChildren(kind), func(*Node) string { return kind })
 	}
-	if queueNode.FindChild("balanced") != nil {
-		if err := set("balanced"); err != nil {
-			return "", err
+	setValue := func(kind string, names ...string) error {
+		var nodes []*Node
+		for _, name := range names {
+			nodes = append(nodes, queueNode.FindChildren(name)...)
 		}
+		return set(kind, nodes, func(n *Node) string { return kind + ":" + nodeVal(n) })
 	}
-	for _, key := range []string{"active-workers", "at-least-active-workers"} {
-		if n := queueNode.FindChild(key); n != nil {
-			if err := set("at-least-active-workers:" + nodeVal(n)); err != nil {
-				return "", err
-			}
-		}
+	if err := setFlag("any"); err != nil {
+		return "", err
 	}
-	if n := queueNode.FindChild("max-worker-flow-share"); n != nil {
-		if err := set("max-worker-flow-share:" + nodeVal(n)); err != nil {
-			return "", err
-		}
+	if err := setFlag("balanced"); err != nil {
+		return "", err
 	}
-	for _, key := range []string{"cstruct", "cstruct-max"} {
-		if n := queueNode.FindChild(key); n != nil {
-			if err := set("cstruct-max:" + nodeVal(n)); err != nil {
-				return "", err
-			}
-		}
+	if err := setValue("at-least-active-workers", "active-workers", "at-least-active-workers"); err != nil {
+		return "", err
+	}
+	if err := setValue("max-worker-flow-share", "max-worker-flow-share"); err != nil {
+		return "", err
+	}
+	if err := setValue("cstruct-max", "cstruct", "cstruct-max"); err != nil {
+		return "", err
 	}
 	if expr == "" {
 		return "", fmt.Errorf("missing expectation; expected any, balanced, at-least-active-workers, max-worker-flow-share, or cstruct-max")

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -231,6 +231,61 @@ func TestCompileClassOfServiceFairnessRSSExpectationRejectsDuplicateConflict(t *
 	}
 }
 
+func TestCompileClassOfServiceFairnessRSSExpectationSetDuplicateSameValueDedupes(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
+		"set class-of-service fairness rss-expectation ifindex 5 queue 4 balanced",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig error = %v", err)
+	}
+	if got := cfg.ClassOfService.FairnessExpectations; len(got) != 1 || got[0].RSSExpectation != "balanced" {
+		t.Fatalf("FairnessExpectations = %#v, want one balanced row", got)
+	}
+}
+
+func TestCompileClassOfServiceFairnessRSSExpectationRejectsHierarchicalDuplicateLeaf(t *testing.T) {
+	raw := `
+class-of-service {
+    fairness {
+        rss-expectation {
+            ifindex 5 {
+                queue 4 {
+                    balanced;
+                    balanced;
+                }
+            }
+        }
+    }
+}
+system {
+    dataplane-type userspace;
+}
+`
+	parser := NewParser(raw)
+	tree, errs := parser.Parse()
+	if len(errs) != 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded, want duplicate hierarchical fairness expectation error")
+	}
+	if !strings.Contains(err.Error(), "duplicate balanced expectation leaf") {
+		t.Fatalf("CompileConfig error = %v, want duplicate balanced expectation leaf", err)
+	}
+}
+
 func TestCoSIperfSymmetricFixtureCompilesReverseSourcePortOutputFilter(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "test", "incus", "cos-iperf-symmetric.set"))
 	if err != nil {

--- a/pkg/dataplane/userspace/fairness.go
+++ b/pkg/dataplane/userspace/fairness.go
@@ -30,14 +30,17 @@ type FairnessRSSExpectation struct {
 }
 
 type FairnessRSSExpectationResult struct {
-	Ifindex       int
-	QueueID       uint8
-	Expectation   string
-	Pass          bool
-	Reason        string
-	ActiveFlows   uint64
-	ActiveWorkers uint64
-	Cstruct       float64
+	Ifindex             int
+	QueueID             uint8
+	Expectation         string
+	ExpectationKind     string
+	ExpectationValue    float64
+	HasExpectationValue bool
+	Pass                bool
+	Reason              string
+	ActiveFlows         uint64
+	ActiveWorkers       uint64
+	Cstruct             float64
 }
 
 type cosFairnessRSSKey struct {
@@ -226,8 +229,13 @@ func EvaluateFairnessRSSExpectations(
 		}
 		result := fairnesscontract.RSSExpectationResult{Pass: false, Reason: errString(err)}
 		canonical := expectation.RSSExpectation
+		kind := "invalid"
+		var value float64
+		hasValue := false
 		if err == nil {
 			canonical = parsed.Canonical()
+			kind = parsed.MetricKind()
+			value, hasValue = parsed.MetricValue()
 			result = fairnesscontract.EvaluateRSSExpectation(
 				parsed,
 				summary.WorkerFlowCounts,
@@ -236,14 +244,17 @@ func EvaluateFairnessRSSExpectations(
 			)
 		}
 		out = append(out, FairnessRSSExpectationResult{
-			Ifindex:       expectation.Ifindex,
-			QueueID:       expectation.QueueID,
-			Expectation:   canonical,
-			Pass:          result.Pass,
-			Reason:        result.Reason,
-			ActiveFlows:   summary.ActiveFlows,
-			ActiveWorkers: summary.ActiveWorkers,
-			Cstruct:       summary.Cstruct,
+			Ifindex:             expectation.Ifindex,
+			QueueID:             expectation.QueueID,
+			Expectation:         canonical,
+			ExpectationKind:     kind,
+			ExpectationValue:    value,
+			HasExpectationValue: hasValue,
+			Pass:                result.Pass,
+			Reason:              result.Reason,
+			ActiveFlows:         summary.ActiveFlows,
+			ActiveWorkers:       summary.ActiveWorkers,
+			Cstruct:             summary.Cstruct,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/pkg/fairness/expectation.go
+++ b/pkg/fairness/expectation.go
@@ -41,6 +41,24 @@ func (e RSSExpectation) Canonical() string {
 	}
 }
 
+func (e RSSExpectation) MetricKind() string {
+	if !knownRSSExpectationKind(e.Kind) {
+		return "unknown"
+	}
+	return string(e.Kind)
+}
+
+func (e RSSExpectation) MetricValue() (float64, bool) {
+	switch e.Kind {
+	case RSSExpectationAtLeastActiveWorkers:
+		return float64(e.ActiveWorkers), true
+	case RSSExpectationMaxWorkerFlowShare, RSSExpectationCstructMax:
+		return e.Threshold, true
+	default:
+		return 0, false
+	}
+}
+
 type RSSExpectationResult struct {
 	Pass   bool
 	Reason string

--- a/pkg/fairness/expectation_test.go
+++ b/pkg/fairness/expectation_test.go
@@ -50,6 +50,35 @@ func TestParseRSSExpectationRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestRSSExpectationMetricShape(t *testing.T) {
+	tests := []struct {
+		raw      string
+		wantKind string
+		wantVal  float64
+		wantHas  bool
+	}{
+		{raw: "balanced", wantKind: "balanced"},
+		{raw: "at-least-active-workers:3", wantKind: "at-least-active-workers", wantVal: 3, wantHas: true},
+		{raw: "max-worker-flow-share:50%", wantKind: "max-worker-flow-share", wantVal: 0.5, wantHas: true},
+		{raw: "cstruct-max:0.25", wantKind: "cstruct-max", wantVal: 0.25, wantHas: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := ParseRSSExpectation(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseRSSExpectation(%q): %v", tt.raw, err)
+			}
+			if got.MetricKind() != tt.wantKind {
+				t.Fatalf("MetricKind() = %q, want %q", got.MetricKind(), tt.wantKind)
+			}
+			value, ok := got.MetricValue()
+			if ok != tt.wantHas || value != tt.wantVal {
+				t.Fatalf("MetricValue() = (%v, %t), want (%v, %t)", value, ok, tt.wantVal, tt.wantHas)
+			}
+		})
+	}
+}
+
 func TestEvaluateRSSExpectation(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Closes #1265.

Completes the remaining RSS expectation polish after #1266:

- replace the high-cardinality `expectation` Prometheus label with stable `kind` labels on:
  - `xpf_fairness_rss_expectation_configured{ifindex,queue_id,kind}`
  - `xpf_fairness_rss_skew_violation{ifindex,queue_id,kind}`
- add `xpf_fairness_rss_expectation_value{ifindex,queue_id,kind}` for numeric knobs such as active-worker count and threshold values
- keep CLI/status rendering on the canonical expectation string for operator readability
- explicitly document the metric-label compatibility break and the ifindex-only config key decision
- reject duplicate hierarchical RSS expectation leaves instead of relying on first-child lookup, while preserving idempotent repeated identical `set` commands

## Validation

- `go test ./pkg/fairness ./pkg/config ./pkg/dataplane/userspace ./pkg/api`
- `go test ./pkg/...`
- `git diff --check`
