### PR TITLE
Add worker v8 CoS lease telemetry

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -372,6 +372,16 @@ For production observability, xpf MUST export:
   monotonic count of flows that enter the starved-flow threshold
   (< 1% of mean per-flow throughput), de-duplicated while the flow
   remains in the rolling window.
+- **`xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=...}`**
+  counter: cumulative v8 CoS queue-lease acquire calls made by the
+  worker. Use `rate()` over the same scrape window as worker TX
+  throughput to test the #1240 hypothesis that some workers request
+  queue tokens more frequently.
+- **`xpf_userspace_worker_cos_queue_lease_acquire_v8_granted_bytes_total{worker_id=...}`**
+  counter: cumulative bytes granted by those v8 acquire calls. Compare
+  per-worker grant rate with per-worker TX byte rate and active-flow
+  distribution to separate lease acquisition imbalance from TCP/NIC
+  effects.
 
 Operators tracking this contract in production monitor the gap
 `(observed_cov - cstruct)` and the starved-flow counter. A

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -87,13 +87,15 @@ type xpfCollector struct {
 	cosOwnerPPS              *prometheus.Desc
 	cosPeerPPS               *prometheus.Desc
 	// #869: per-worker busy/idle runtime counters.
-	workerWallSecs      *prometheus.Desc
-	workerActiveSecs    *prometheus.Desc
-	workerIdleSpinSecs  *prometheus.Desc
-	workerIdleBlockSecs *prometheus.Desc
-	workerThreadCPUSecs *prometheus.Desc
-	workerWorkLoops     *prometheus.Desc
-	workerIdleLoops     *prometheus.Desc
+	workerWallSecs                           *prometheus.Desc
+	workerActiveSecs                         *prometheus.Desc
+	workerIdleSpinSecs                       *prometheus.Desc
+	workerIdleBlockSecs                      *prometheus.Desc
+	workerThreadCPUSecs                      *prometheus.Desc
+	workerWorkLoops                          *prometheus.Desc
+	workerIdleLoops                          *prometheus.Desc
+	workerCoSQueueLeaseAcquireV8Calls        *prometheus.Desc
+	workerCoSQueueLeaseAcquireV8GrantedBytes *prometheus.Desc
 	// #925 Phase 2: liveness gauge for the supervisor's catch_unwind
 	// state. 1 = worker has panicked and the supervisor has caught it;
 	// 0 = healthy. Set-only in Phase 1 (cleared by daemon restart).
@@ -369,6 +371,16 @@ func newCollector(srv *Server) *xpfCollector {
 			"Worker-loop iterations with no useful work (#869).",
 			[]string{"worker_id"}, nil,
 		),
+		workerCoSQueueLeaseAcquireV8Calls: prometheus.NewDesc(
+			"xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total",
+			"V8 CoS queue-lease acquire calls made by this worker (#1240).",
+			[]string{"worker_id"}, nil,
+		),
+		workerCoSQueueLeaseAcquireV8GrantedBytes: prometheus.NewDesc(
+			"xpf_userspace_worker_cos_queue_lease_acquire_v8_granted_bytes_total",
+			"Bytes granted by v8 CoS queue-lease acquire calls for this worker (#1240).",
+			[]string{"worker_id"}, nil,
+		),
 		workerDead: prometheus.NewDesc(
 			"xpf_userspace_worker_dead",
 			"1 if the userspace-dp worker thread has panicked and been "+
@@ -498,6 +510,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.workerThreadCPUSecs
 	ch <- c.workerWorkLoops
 	ch <- c.workerIdleLoops
+	ch <- c.workerCoSQueueLeaseAcquireV8Calls
+	ch <- c.workerCoSQueueLeaseAcquireV8GrantedBytes
 	ch <- c.workerDead
 	ch <- c.bindingActiveFlowCount
 	ch <- c.cosActiveFlowCount
@@ -749,6 +763,10 @@ func (c *xpfCollector) emitWorkerRuntime(ch chan<- prometheus.Metric, status dpu
 			prometheus.CounterValue, float64(w.WorkLoops), label)
 		ch <- prometheus.MustNewConstMetric(c.workerIdleLoops,
 			prometheus.CounterValue, float64(w.IdleLoops), label)
+		ch <- prometheus.MustNewConstMetric(c.workerCoSQueueLeaseAcquireV8Calls,
+			prometheus.CounterValue, float64(w.CoSQueueLeaseAcquireV8Calls), label)
+		ch <- prometheus.MustNewConstMetric(c.workerCoSQueueLeaseAcquireV8GrantedBytes,
+			prometheus.CounterValue, float64(w.CoSQueueLeaseAcquireV8GrantedBytes), label)
 		var deadValue float64
 		if w.Dead {
 			deadValue = 1

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -27,17 +27,26 @@ func TestEmitWorkerRuntime_DeadGaugeReflectsDeadFlag(t *testing.T) {
 	// Mixed fixture: 3 workers, only the middle one dead.
 	status := dpuserspace.ProcessStatus{
 		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
-			{WorkerID: 0, Dead: false},
-			{WorkerID: 1, Dead: true},
-			{WorkerID: 2, Dead: false},
+			{
+				WorkerID: 0, CoSQueueLeaseAcquireV8Calls: 7,
+				CoSQueueLeaseAcquireV8GrantedBytes: 4096, Dead: false,
+			},
+			{
+				WorkerID: 1, CoSQueueLeaseAcquireV8Calls: 11,
+				CoSQueueLeaseAcquireV8GrantedBytes: 0, Dead: true,
+			},
+			{
+				WorkerID: 2, CoSQueueLeaseAcquireV8Calls: 13,
+				CoSQueueLeaseAcquireV8GrantedBytes: 8192, Dead: false,
+			},
 		},
 	}
 
 	got := collectFromEmitWorkerRuntime(t, c, status)
 
-	// Each worker emits 7 counters + 1 dead gauge = 8 metrics. 3 workers = 24.
-	if len(got) != 3*8 {
-		t.Fatalf("emitWorkerRuntime: want 24 metrics for 3 workers (7 counters + 1 dead gauge), got %d", len(got))
+	// Each worker emits 9 counters + 1 dead gauge = 10 metrics. 3 workers = 30.
+	if len(got) != 3*10 {
+		t.Fatalf("emitWorkerRuntime: want 30 metrics for 3 workers (9 counters + 1 dead gauge), got %d", len(got))
 	}
 
 	// Gather just the dead-gauge entries, keyed by worker_id label.
@@ -81,6 +90,25 @@ func TestEmitWorkerRuntime_DeadGaugeReflectsDeadFlag(t *testing.T) {
 			t.Errorf("xpf_userspace_worker_dead{worker_id=%q} = %v, want %v", wid, got, want)
 		}
 	}
+
+	leaseCallsByWorker := metricValuesByWorker(t, got, c.workerCoSQueueLeaseAcquireV8Calls, true)
+	if len(leaseCallsByWorker) != 3 {
+		t.Fatalf("expected one lease-acquire-calls emission per worker (3), got %d", len(leaseCallsByWorker))
+	}
+	for wid, want := range map[string]float64{"0": 7, "1": 11, "2": 13} {
+		if got := leaseCallsByWorker[wid]; got != want {
+			t.Errorf("xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=%q} = %v, want %v", wid, got, want)
+		}
+	}
+	leaseBytesByWorker := metricValuesByWorker(t, got, c.workerCoSQueueLeaseAcquireV8GrantedBytes, true)
+	if len(leaseBytesByWorker) != 3 {
+		t.Fatalf("expected one lease-acquire-bytes emission per worker (3), got %d", len(leaseBytesByWorker))
+	}
+	for wid, want := range map[string]float64{"0": 4096, "1": 0, "2": 8192} {
+		if got := leaseBytesByWorker[wid]; got != want {
+			t.Errorf("xpf_userspace_worker_cos_queue_lease_acquire_v8_granted_bytes_total{worker_id=%q} = %v, want %v", wid, got, want)
+		}
+	}
 }
 
 // All-healthy fixture: dead gauge must be 0 for every worker, never absent.
@@ -118,21 +146,23 @@ func TestEmitWorkerRuntime_DeadGaugeZeroForHealthyWorkers(t *testing.T) {
 }
 
 func newCollectorWithWorkerDescsOnly() *xpfCollector {
-	// Only the seven worker counter descriptors plus the new dead gauge
+	// Only the worker counter descriptors plus the dead gauge
 	// are needed by emitWorkerRuntime; the rest stay nil and are not
 	// exercised by this test.
 	mk := func(name string) *prometheus.Desc {
 		return prometheus.NewDesc(name, name, []string{"worker_id"}, nil)
 	}
 	return &xpfCollector{
-		workerWallSecs:      mk("xpf_userspace_worker_wall_seconds_total"),
-		workerActiveSecs:    mk("xpf_userspace_worker_active_seconds_total"),
-		workerIdleSpinSecs:  mk("xpf_userspace_worker_idle_spin_seconds_total"),
-		workerIdleBlockSecs: mk("xpf_userspace_worker_idle_block_seconds_total"),
-		workerThreadCPUSecs: mk("xpf_userspace_worker_thread_cpu_seconds_total"),
-		workerWorkLoops:     mk("xpf_userspace_worker_work_loops_total"),
-		workerIdleLoops:     mk("xpf_userspace_worker_idle_loops_total"),
-		workerDead:          mk("xpf_userspace_worker_dead"),
+		workerWallSecs:                           mk("xpf_userspace_worker_wall_seconds_total"),
+		workerActiveSecs:                         mk("xpf_userspace_worker_active_seconds_total"),
+		workerIdleSpinSecs:                       mk("xpf_userspace_worker_idle_spin_seconds_total"),
+		workerIdleBlockSecs:                      mk("xpf_userspace_worker_idle_block_seconds_total"),
+		workerThreadCPUSecs:                      mk("xpf_userspace_worker_thread_cpu_seconds_total"),
+		workerWorkLoops:                          mk("xpf_userspace_worker_work_loops_total"),
+		workerIdleLoops:                          mk("xpf_userspace_worker_idle_loops_total"),
+		workerCoSQueueLeaseAcquireV8Calls:        mk("xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total"),
+		workerCoSQueueLeaseAcquireV8GrantedBytes: mk("xpf_userspace_worker_cos_queue_lease_acquire_v8_granted_bytes_total"),
+		workerDead:                               mk("xpf_userspace_worker_dead"),
 	}
 }
 
@@ -163,14 +193,16 @@ func collectFromEmitWorkerRuntime(
 	// descriptors we initialized. Pointer-equality is stable across
 	// prometheus/client_golang versions.
 	expected := map[*prometheus.Desc]struct{}{
-		c.workerWallSecs:      {},
-		c.workerActiveSecs:    {},
-		c.workerIdleSpinSecs:  {},
-		c.workerIdleBlockSecs: {},
-		c.workerThreadCPUSecs: {},
-		c.workerWorkLoops:     {},
-		c.workerIdleLoops:     {},
-		c.workerDead:          {},
+		c.workerWallSecs:                           {},
+		c.workerActiveSecs:                         {},
+		c.workerIdleSpinSecs:                       {},
+		c.workerIdleBlockSecs:                      {},
+		c.workerThreadCPUSecs:                      {},
+		c.workerWorkLoops:                          {},
+		c.workerIdleLoops:                          {},
+		c.workerCoSQueueLeaseAcquireV8Calls:        {},
+		c.workerCoSQueueLeaseAcquireV8GrantedBytes: {},
+		c.workerDead:                               {},
 	}
 	for _, m := range got {
 		if _, ok := expected[m.Desc()]; !ok {
@@ -178,6 +210,46 @@ func collectFromEmitWorkerRuntime(
 		}
 	}
 	return got
+}
+
+func metricValuesByWorker(
+	t *testing.T,
+	metrics []prometheus.Metric,
+	desc *prometheus.Desc,
+	counter bool,
+) map[string]float64 {
+	t.Helper()
+	out := make(map[string]float64)
+	for _, m := range metrics {
+		if m.Desc() != desc {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		var workerID string
+		for _, lp := range pb.GetLabel() {
+			if lp.GetName() == "worker_id" {
+				workerID = lp.GetValue()
+			}
+		}
+		if workerID == "" {
+			t.Fatalf("worker metric missing worker_id label: %+v", &pb)
+		}
+		if counter {
+			if pb.Counter == nil {
+				t.Fatalf("worker metric must be a Counter: %+v", &pb)
+			}
+			out[workerID] = pb.Counter.GetValue()
+		} else {
+			if pb.Gauge == nil {
+				t.Fatalf("worker metric must be a Gauge: %+v", &pb)
+			}
+			out[workerID] = pb.Gauge.GetValue()
+		}
+	}
+	return out
 }
 
 // #1219: emitBindingActiveFlowCount must surface the per-binding

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -549,6 +549,11 @@ type WorkerRuntimeStatus struct {
 	ThreadCPUNS uint64 `json:"thread_cpu_ns,omitempty"`
 	WorkLoops   uint64 `json:"work_loops,omitempty"`
 	IdleLoops   uint64 `json:"idle_loops,omitempty"`
+	// #1240: cumulative v8 per-worker queue-lease acquire calls and
+	// granted bytes. Scrape with rate() and compare against per-worker
+	// TX throughput to diagnose token-acquisition imbalance.
+	CoSQueueLeaseAcquireV8Calls        uint64 `json:"cos_queue_lease_acquire_v8_calls,omitempty"`
+	CoSQueueLeaseAcquireV8GrantedBytes uint64 `json:"cos_queue_lease_acquire_v8_granted_bytes,omitempty"`
 	// #925 Phase 1+2 (catch+report+observe): Dead == true means the
 	// worker_loop panicked and the supervisor caught it. Set-only
 	// today — cleared only by daemon restart. Phase 2 surfaces this

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -216,6 +216,9 @@ impl super::Coordinator {
                     thread_cpu_ns: s.thread_cpu_ns,
                     work_loops: s.work_loops,
                     idle_loops: s.idle_loops,
+                    cos_queue_lease_acquire_v8_calls: s.cos_queue_lease_acquire_v8_calls,
+                    cos_queue_lease_acquire_v8_granted_bytes: s
+                        .cos_queue_lease_acquire_v8_granted_bytes,
                     dead,
                     panic_message,
                 }

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -27,7 +27,7 @@ pub(super) use queue_ops::{
 };
 pub(super) use queue_service::drain_shaped_tx;
 pub(super) use token_bucket::{
-    cos_refill_ns_until, maybe_top_up_cos_queue_lease,
+    cos_refill_ns_until, maybe_top_up_cos_queue_lease, CoSQueueLeaseAcquireTelemetry,
     refill_cos_tokens, release_all_cos_queue_leases, release_all_cos_root_leases,
     COS_MIN_BURST_BYTES,
 };

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -32,7 +32,7 @@ use super::{
     cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_pop_front, cos_queue_pop_front_with_cap,
     cos_queue_push_front, cos_queue_v_min_consume_suspension, cos_queue_v_min_continue,
     cos_refill_ns_until, maybe_top_up_cos_queue_lease, publish_committed_queue_vtime,
-    refill_cos_tokens, COS_MIN_BURST_BYTES,
+    refill_cos_tokens, CoSQueueLeaseAcquireTelemetry, COS_MIN_BURST_BYTES,
 };
 // #1229 v7 per-bucket TX accounting + threshold-gated EWMA.
 use super::fairness::account_flow_bucket_tx;
@@ -123,6 +123,21 @@ pub(in crate::afxdp) struct DrainedQueueRef {
 }
 
 #[inline]
+fn record_cos_queue_lease_acquire(
+    binding: &mut BindingWorker,
+    telemetry: CoSQueueLeaseAcquireTelemetry,
+) {
+    binding.cos.cos_queue_lease_acquire_v8_calls = binding
+        .cos
+        .cos_queue_lease_acquire_v8_calls
+        .wrapping_add(telemetry.v8_calls);
+    binding.cos.cos_queue_lease_acquire_v8_granted_bytes = binding
+        .cos
+        .cos_queue_lease_acquire_v8_granted_bytes
+        .wrapping_add(telemetry.v8_granted_bytes);
+}
+
+#[inline]
 pub(in crate::afxdp) fn drain_shaped_tx(
     binding: &mut BindingWorker,
     now_ns: u64,
@@ -144,16 +159,20 @@ pub(in crate::afxdp) fn drain_shaped_tx(
         if !prime_cos_root_for_service(binding, root_ifindex, now_ns) {
             continue;
         }
+        let mut lease_telemetry = CoSQueueLeaseAcquireTelemetry::default();
         if let Some(serviced) = service_exact_guarantee_queue_direct_with_info(
             binding,
             root_ifindex,
             now_ns,
             shared_recycles,
+            &mut lease_telemetry,
         ) {
+            record_cos_queue_lease_acquire(binding, lease_telemetry);
             binding.cos.cos_interface_rr =
                 (start + offset + 1) % binding.cos.cos_interface_order.len();
             return serviced;
         }
+        record_cos_queue_lease_acquire(binding, lease_telemetry);
         let Some(batch) = build_nonexact_cos_batch(binding, root_ifindex, now_ns) else {
             continue;
         };
@@ -218,8 +237,17 @@ fn service_exact_guarantee_queue_direct(
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) -> Option<bool> {
-    service_exact_guarantee_queue_direct_with_info(binding, root_ifindex, now_ns, shared_recycles)
-        .map(|slot| slot.is_some())
+    let mut lease_telemetry = CoSQueueLeaseAcquireTelemetry::default();
+    let ret = service_exact_guarantee_queue_direct_with_info(
+        binding,
+        root_ifindex,
+        now_ns,
+        shared_recycles,
+        &mut lease_telemetry,
+    )
+    .map(|slot| slot.is_some());
+    record_cos_queue_lease_acquire(binding, lease_telemetry);
+    ret
 }
 
 /// #751: variant that additionally reports which queue was actually
@@ -237,6 +265,7 @@ fn service_exact_guarantee_queue_direct_with_info(
     root_ifindex: i32,
     now_ns: u64,
     shared_recycles: &mut Vec<(u32, u64)>,
+    lease_telemetry: &mut CoSQueueLeaseAcquireTelemetry,
 ) -> Option<Option<DrainedQueueRef>> {
     let queue_fast_path = binding
         .cos
@@ -246,7 +275,12 @@ fn service_exact_guarantee_queue_direct_with_info(
         .as_slice();
     let selection = {
         let root = binding.cos.cos_interfaces.get_mut(&root_ifindex)?;
-        select_exact_cos_guarantee_queue_with_fast_path(root, queue_fast_path, now_ns)?
+        select_exact_cos_guarantee_queue_with_lease_telemetry(
+            root,
+            queue_fast_path,
+            now_ns,
+            lease_telemetry,
+        )?
     };
 
     let queue_id = binding
@@ -322,7 +356,7 @@ pub(in crate::afxdp) fn select_cos_guarantee_batch_with_fast_path(
             continue;
         }
         if queue.config.exact {
-            maybe_top_up_cos_queue_lease(
+            let _ = maybe_top_up_cos_queue_lease(
                 queue,
                 queue_fast_path
                     .get(queue_idx)
@@ -399,11 +433,28 @@ pub(in crate::afxdp) fn select_cos_guarantee_batch_with_fast_path(
 // independently of the non-exact pass via `exact_guarantee_rr` — the two
 // classes are scheduled with strict-priority exact-over-nonexact and
 // class-independent RR within each class.
+#[cfg(test)]
 #[inline]
 pub(in crate::afxdp) fn select_exact_cos_guarantee_queue_with_fast_path(
     root: &mut CoSInterfaceRuntime,
     queue_fast_path: &[WorkerCoSQueueFastPath],
     now_ns: u64,
+) -> Option<ExactCoSQueueSelection> {
+    let mut lease_telemetry = CoSQueueLeaseAcquireTelemetry::default();
+    select_exact_cos_guarantee_queue_with_lease_telemetry(
+        root,
+        queue_fast_path,
+        now_ns,
+        &mut lease_telemetry,
+    )
+}
+
+#[inline]
+fn select_exact_cos_guarantee_queue_with_lease_telemetry(
+    root: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
+    now_ns: u64,
+    lease_telemetry: &mut CoSQueueLeaseAcquireTelemetry,
 ) -> Option<ExactCoSQueueSelection> {
     let queue_count = root.queues.len();
     if queue_count == 0 {
@@ -416,13 +467,14 @@ pub(in crate::afxdp) fn select_exact_cos_guarantee_queue_with_fast_path(
         if cos_queue_is_empty(queue) || !queue.hot.runnable || !queue.config.exact {
             continue;
         }
-        maybe_top_up_cos_queue_lease(
+        let top_up = maybe_top_up_cos_queue_lease(
             queue,
             queue_fast_path
                 .get(queue_idx)
                 .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref()),
             now_ns,
         );
+        lease_telemetry.add_assign(top_up);
         let Some(head) = cos_queue_front(queue) else {
             continue;
         };

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -24,6 +24,32 @@ use crate::afxdp::worker::BindingWorker;
 /// the buffer-limit gate.
 pub(in crate::afxdp) const COS_MIN_BURST_BYTES: u64 = 64 * 1500;
 
+/// Worker-local observation of v8 queue-lease acquisitions. The hot path
+/// accumulates this in `WorkerCos`, not in the shared lease, so the
+/// diagnostic path does not add cross-worker atomics to `acquire_v8`.
+#[must_use = "queue-lease acquire telemetry must be accumulated by the caller"]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::afxdp) struct CoSQueueLeaseAcquireTelemetry {
+    pub(in crate::afxdp) v8_calls: u64,
+    pub(in crate::afxdp) v8_granted_bytes: u64,
+}
+
+impl CoSQueueLeaseAcquireTelemetry {
+    #[inline]
+    pub(in crate::afxdp) fn add_assign(&mut self, other: Self) {
+        self.v8_calls = self.v8_calls.wrapping_add(other.v8_calls);
+        self.v8_granted_bytes = self
+            .v8_granted_bytes
+            .wrapping_add(other.v8_granted_bytes);
+    }
+
+    #[inline]
+    fn record_v8_grant(&mut self, granted: u64) {
+        self.v8_calls = self.v8_calls.wrapping_add(1);
+        self.v8_granted_bytes = self.v8_granted_bytes.wrapping_add(granted);
+    }
+}
+
 #[inline]
 pub(in crate::afxdp) fn maybe_top_up_cos_root_lease(
     root: &mut CoSInterfaceRuntime,
@@ -69,12 +95,18 @@ fn acquire_via_lease(
     queue: &CoSQueueRuntime,
     now_ns: u64,
     requested: u64,
-) -> u64 {
+) -> (u64, CoSQueueLeaseAcquireTelemetry) {
     if lease.is_v8() {
         let worker_id = queue.v_min.worker_id as usize;
-        lease.acquire_v8(worker_id, now_ns, requested)
+        let granted = lease.acquire_v8(worker_id, now_ns, requested);
+        let mut telemetry = CoSQueueLeaseAcquireTelemetry::default();
+        telemetry.record_v8_grant(granted);
+        (granted, telemetry)
     } else {
-        lease.acquire(now_ns, requested)
+        (
+            lease.acquire(now_ns, requested),
+            CoSQueueLeaseAcquireTelemetry::default(),
+        )
     }
 }
 
@@ -123,7 +155,7 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
     queue: &mut CoSQueueRuntime,
     shared_queue_lease: Option<&Arc<SharedCoSQueueLease>>,
     now_ns: u64,
-) {
+) -> CoSQueueLeaseAcquireTelemetry {
     // #916: transparent queue. When `transmit_rate_bytes == 0`
     // (scheduler had no `transmit-rate` configured AND the parent
     // root has no `shaping-rate`, see the fallback in
@@ -135,7 +167,7 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
     if queue.transmit_rate_bytes() == 0 {
         queue.hot.tokens = queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES);
         queue.hot.last_refill_ns = now_ns;
-        return;
+        return CoSQueueLeaseAcquireTelemetry::default();
     }
     // #1229 Phase 6 v8: lazy-install lease back-reference + rehydrate
     // per-worker counter on first sight of a v8 lease. Idempotent:
@@ -147,16 +179,16 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
     }
     if queue.config.exact {
         let Some(shared_queue_lease) = shared_queue_lease else {
-            return;
+            return CoSQueueLeaseAcquireTelemetry::default();
         };
         let lease_bytes = shared_queue_lease
             .lease_bytes()
             .max(tx_frame_capacity() as u64)
             .min(queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES));
         if queue.hot.tokens >= lease_bytes {
-            return;
+            return CoSQueueLeaseAcquireTelemetry::default();
         }
-        let grant = acquire_via_lease(
+        let (grant, telemetry) = acquire_via_lease(
             shared_queue_lease,
             queue,
             now_ns,
@@ -168,7 +200,7 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
             .saturating_add(grant)
             .min(queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES));
         queue.hot.last_refill_ns = now_ns;
-        return;
+        return telemetry;
     }
     let Some(shared_queue_lease) = shared_queue_lease else {
         let transmit_rate_bytes = queue.transmit_rate_bytes();
@@ -179,16 +211,16 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
             &mut queue.hot.last_refill_ns,
             now_ns,
         );
-        return;
+        return CoSQueueLeaseAcquireTelemetry::default();
     };
     let lease_bytes = shared_queue_lease
         .lease_bytes()
         .max(tx_frame_capacity() as u64)
         .min(queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES));
     if queue.hot.tokens >= lease_bytes {
-        return;
+        return CoSQueueLeaseAcquireTelemetry::default();
     }
-    let grant = acquire_via_lease(
+    let (grant, telemetry) = acquire_via_lease(
         shared_queue_lease,
         queue,
         now_ns,
@@ -200,6 +232,7 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
         .saturating_add(grant)
         .min(queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES));
     queue.hot.last_refill_ns = now_ns;
+    telemetry
 }
 
 #[inline]

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -176,7 +176,7 @@ fn maybe_top_up_cos_queue_lease_unblocks_local_exact_queue_without_tokens() {
         Some(shared_queue_lease.clone()),
     )];
 
-    maybe_top_up_cos_queue_lease(
+    let _ = maybe_top_up_cos_queue_lease(
         &mut root.queues[0],
         Some(&shared_queue_lease),
         1_000_000_000,
@@ -190,6 +190,42 @@ fn maybe_top_up_cos_queue_lease_unblocks_local_exact_queue_without_tokens() {
         select_cos_guarantee_batch_with_fast_path(&mut root, &queue_fast_path, 1_000_000_000,)
             .is_some()
     );
+}
+
+#[test]
+fn maybe_top_up_cos_queue_lease_reports_v8_acquire_calls_and_grants() {
+    let mut root = test_cos_runtime_with_queues(
+        100_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 100_000_000 / 8,
+            exact: true,
+            surplus_sharing: false,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+        }],
+    );
+    root.queues[0].hot.tokens = 0;
+    root.queues[0].v_min.worker_id = 0;
+    let lease = Arc::new(SharedCoSQueueLease::new_v8(
+        100_000_000 / 8,
+        COS_MIN_BURST_BYTES,
+        1,
+        0,
+    ));
+    lease.rehydrate_worker_active_count(0, 1);
+
+    let telemetry = maybe_top_up_cos_queue_lease(&mut root.queues[0], Some(&lease), 200_000);
+
+    assert_eq!(telemetry.v8_calls, 1);
+    assert!(
+        telemetry.v8_granted_bytes > 0,
+        "active v8 worker should receive a nonzero grant"
+    );
+    assert_eq!(telemetry.v8_granted_bytes, root.queues[0].hot.tokens);
 }
 
 #[test]
@@ -257,7 +293,7 @@ fn maybe_top_up_cos_queue_lease_transparent_when_queue_rate_zero_exact_no_lease(
     // No shared queue lease — old code would early-return with
     // tokens still at 0; new code's transparent fast-path runs
     // before the exact branch and fills to the buffer cap.
-    maybe_top_up_cos_queue_lease(&mut root.queues[0], None, 1_000_000_000);
+    let _ = maybe_top_up_cos_queue_lease(&mut root.queues[0], None, 1_000_000_000);
 
     assert!(
         root.queues[0].hot.tokens >= COS_MIN_BURST_BYTES,
@@ -299,7 +335,7 @@ fn maybe_top_up_cos_queue_lease_transparent_non_exact_with_nonzero_last_refill()
     // would skip refill at rate=0; new fast-path fills regardless.
     root.queues[0].hot.last_refill_ns = 500_000_000;
 
-    maybe_top_up_cos_queue_lease(&mut root.queues[0], None, 1_000_000_000);
+    let _ = maybe_top_up_cos_queue_lease(&mut root.queues[0], None, 1_000_000_000);
 
     assert!(
         root.queues[0].hot.tokens >= COS_MIN_BURST_BYTES,
@@ -341,7 +377,7 @@ fn transparent_root_preserves_per_queue_exact_cap() {
     );
     root.queues[0].hot.tokens = 0;
 
-    maybe_top_up_cos_queue_lease(&mut root.queues[0], Some(&lease), 1_000_000_000);
+    let _ = maybe_top_up_cos_queue_lease(&mut root.queues[0], Some(&lease), 1_000_000_000);
 
     // Per-queue tokens populated by lease.acquire — bounded by the
     // lease size and buffer cap. The transparent-queue fast-path

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -463,8 +463,7 @@ pub(in crate::afxdp) struct CoSQueueConfigState {
     pub(in crate::afxdp) exact: bool,
     /// #915: only meaningful when `exact == true`. When set, the
     /// queue (1) is NOT parked on `queue.hot.tokens < head_len` in
-    /// the exact-guarantee selector
-    /// (`select_exact_cos_guarantee_queue_with_fast_path`), and
+    /// the exact-guarantee selector, and
     /// (2) participates in `select_cos_surplus_batch` as if it
     /// were non-exact. The combined effect is that the queue
     /// retains its strict-priority guarantee but can also draw

--- a/userspace-dp/src/afxdp/worker/cos_state.rs
+++ b/userspace-dp/src/afxdp/worker/cos_state.rs
@@ -30,4 +30,9 @@ pub(crate) struct WorkerCos {
     pub(crate) cos_interface_order: Vec<i32>,
     pub(crate) cos_interface_rr: usize,
     pub(crate) cos_nonempty_interfaces: usize,
+    /// #1240: cumulative worker-owned v8 queue-lease acquire calls
+    /// observed while draining this binding's CoS queues.
+    pub(crate) cos_queue_lease_acquire_v8_calls: u64,
+    /// #1240: cumulative bytes granted by v8 queue-lease acquire calls.
+    pub(crate) cos_queue_lease_acquire_v8_granted_bytes: u64,
 }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -367,6 +367,8 @@ impl BindingWorker {
                 cos_interface_order: Vec::new(),
                 cos_interface_rr: 0,
                 cos_nonempty_interfaces: 0,
+                cos_queue_lease_acquire_v8_calls: 0,
+                cos_queue_lease_acquire_v8_granted_bytes: 0,
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -475,6 +477,22 @@ fn load_arc_if_changed<T>(
     } else {
         Some(arc_swap::Guard::into_inner(guard))
     }
+}
+
+#[inline]
+fn refresh_worker_cos_queue_lease_runtime_counters(
+    counters: &mut super::worker_runtime::WorkerRuntimeCounters,
+    bindings: &[BindingWorker],
+) {
+    let mut calls = 0u64;
+    let mut granted_bytes = 0u64;
+    for binding in bindings {
+        calls = calls.wrapping_add(binding.cos.cos_queue_lease_acquire_v8_calls);
+        granted_bytes = granted_bytes
+            .wrapping_add(binding.cos.cos_queue_lease_acquire_v8_granted_bytes);
+    }
+    counters.cos_queue_lease_acquire_v8_calls = calls;
+    counters.cos_queue_lease_acquire_v8_granted_bytes = granted_bytes;
 }
 
 pub(crate) fn worker_loop(
@@ -748,6 +766,7 @@ pub(crate) fn worker_loop(
                 if sampled_cpu_ns != 0 {
                     wr_counters.thread_cpu_ns = sampled_cpu_ns;
                 }
+                refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);
                 runtime_atomics.publish(&wr_counters);
                 wr_last_publish_ns = loop_now_ns;
             }

--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -51,6 +51,8 @@ pub(crate) struct WorkerRuntimeCounters {
     pub thread_cpu_ns: u64,
     pub work_loops: u64,
     pub idle_loops: u64,
+    pub cos_queue_lease_acquire_v8_calls: u64,
+    pub cos_queue_lease_acquire_v8_granted_bytes: u64,
 }
 
 /// Cacheline-isolated atomic publish slot.  The worker copies its local
@@ -67,6 +69,8 @@ pub(crate) struct WorkerRuntimeAtomics {
     pub thread_cpu_ns: AtomicU64,
     pub work_loops: AtomicU64,
     pub idle_loops: AtomicU64,
+    pub cos_queue_lease_acquire_v8_calls: AtomicU64,
+    pub cos_queue_lease_acquire_v8_granted_bytes: AtomicU64,
     pub tid: AtomicU64,
     /// #925 Phase 1+2 (catch+report+observe): set to true exactly once
     /// when the supervisor catches a worker_loop panic. Set-only today —
@@ -94,6 +98,8 @@ impl WorkerRuntimeAtomics {
             thread_cpu_ns: AtomicU64::new(0),
             work_loops: AtomicU64::new(0),
             idle_loops: AtomicU64::new(0),
+            cos_queue_lease_acquire_v8_calls: AtomicU64::new(0),
+            cos_queue_lease_acquire_v8_granted_bytes: AtomicU64::new(0),
             tid: AtomicU64::new(0),
             dead: AtomicBool::new(false),
             _pad: [],
@@ -110,6 +116,12 @@ impl WorkerRuntimeAtomics {
         self.thread_cpu_ns.store(c.thread_cpu_ns, Ordering::Relaxed);
         self.work_loops.store(c.work_loops, Ordering::Relaxed);
         self.idle_loops.store(c.idle_loops, Ordering::Relaxed);
+        self.cos_queue_lease_acquire_v8_calls
+            .store(c.cos_queue_lease_acquire_v8_calls, Ordering::Relaxed);
+        self.cos_queue_lease_acquire_v8_granted_bytes.store(
+            c.cos_queue_lease_acquire_v8_granted_bytes,
+            Ordering::Relaxed,
+        );
     }
 
     /// Snapshot for status readers.  Not atomic across fields — each
@@ -123,6 +135,12 @@ impl WorkerRuntimeAtomics {
             thread_cpu_ns: self.thread_cpu_ns.load(Ordering::Relaxed),
             work_loops: self.work_loops.load(Ordering::Relaxed),
             idle_loops: self.idle_loops.load(Ordering::Relaxed),
+            cos_queue_lease_acquire_v8_calls: self
+                .cos_queue_lease_acquire_v8_calls
+                .load(Ordering::Relaxed),
+            cos_queue_lease_acquire_v8_granted_bytes: self
+                .cos_queue_lease_acquire_v8_granted_bytes
+                .load(Ordering::Relaxed),
         }
     }
 
@@ -174,4 +192,3 @@ pub(crate) fn current_tid() -> u64 {
 #[cfg(test)]
 #[path = "worker_runtime_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/afxdp/worker_runtime_tests.rs
+++ b/userspace-dp/src/afxdp/worker_runtime_tests.rs
@@ -16,6 +16,8 @@ fn snapshot_roundtrip() {
         thread_cpu_ns: 9_950_000_000,
         work_loops: 1_234_567,
         idle_loops: 1_234,
+        cos_queue_lease_acquire_v8_calls: 55,
+        cos_queue_lease_acquire_v8_granted_bytes: 123_456,
     };
     atomics.publish(&c);
     let s = atomics.snapshot();
@@ -26,6 +28,14 @@ fn snapshot_roundtrip() {
     assert_eq!(s.thread_cpu_ns, c.thread_cpu_ns);
     assert_eq!(s.work_loops, c.work_loops);
     assert_eq!(s.idle_loops, c.idle_loops);
+    assert_eq!(
+        s.cos_queue_lease_acquire_v8_calls,
+        c.cos_queue_lease_acquire_v8_calls
+    );
+    assert_eq!(
+        s.cos_queue_lease_acquire_v8_granted_bytes,
+        c.cos_queue_lease_acquire_v8_granted_bytes
+    );
 }
 
 #[test]
@@ -38,6 +48,8 @@ fn counters_default_zero() {
     assert_eq!(c.thread_cpu_ns, 0);
     assert_eq!(c.work_loops, 0);
     assert_eq!(c.idle_loops, 0);
+    assert_eq!(c.cos_queue_lease_acquire_v8_calls, 0);
+    assert_eq!(c.cos_queue_lease_acquire_v8_granted_bytes, 0);
 }
 
 #[test]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1170,6 +1170,18 @@ pub struct WorkerRuntimeStatus {
     pub work_loops: u64,
     #[serde(rename = "idle_loops", default)]
     pub idle_loops: u64,
+    /// #1240: cumulative v8 per-worker queue-lease acquire calls
+    /// observed by this worker across its bindings. Operators should
+    /// compare `rate()` against per-worker TX rate to diagnose lease-
+    /// request frequency imbalance.
+    #[serde(rename = "cos_queue_lease_acquire_v8_calls", default)]
+    pub cos_queue_lease_acquire_v8_calls: u64,
+    /// #1240: cumulative bytes granted by v8 queue-lease acquire calls.
+    #[serde(
+        rename = "cos_queue_lease_acquire_v8_granted_bytes",
+        default
+    )]
+    pub cos_queue_lease_acquire_v8_granted_bytes: u64,
     /// #925: true if the worker_loop thread panicked and the supervisor
     /// caught it. Set once on first panic; never cleared in Phase 1.
     /// Operators see DEAD in `cli show chassis forwarding` and must


### PR DESCRIPTION
## Summary
- add worker-owned counters for v8 CoS queue-lease acquire calls and granted bytes without adding hot shared atomics to acquire_v8
- expose the counters through userspace status JSON and Prometheus as xpf_userspace_worker_cos_queue_lease_acquire_v8_{calls,granted_bytes}_total
- document the metrics for the #1240 fairness investigation and add Rust/Go coverage

Closes #1240

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml maybe_top_up_cos_queue_lease_reports_v8_acquire_calls_and_grants -- --nocapture
- cargo test --manifest-path userspace-dp/Cargo.toml worker_runtime -- --nocapture
- go test ./pkg/api ./pkg/dataplane/userspace
- git diff --check

Note: the Rust targeted tests still emit the existing crate warnings; no new test failures.