### PR TITLE
Expose AF_XDP TX completion uniformity telemetry

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -382,6 +382,23 @@ For production observability, xpf MUST export:
   per-worker grant rate with per-worker TX byte rate and active-flow
   distribution to separate lease acquisition imbalance from TCP/NIC
   effects.
+- **`xpf_userspace_binding_tx_completions_total{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
+  counter: cumulative AF_XDP TX completions reaped by each binding's
+  owner worker. Use `rate()` during fairness runs to detect per-RX-queue
+  completion-service asymmetry.
+- **`xpf_userspace_binding_tx_completion_ring_available{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
+  gauge: last sampled AF_XDP TX completion-ring descriptors available
+  before the owner worker drained completions. This is a diagnostic
+  status sample, not a scheduler input. The worker resets the local
+  sample after publishing; a zero value can mean either no completion
+  backlog or no TX work in the last debug window, so disambiguate with
+  `rate(xpf_userspace_binding_tx_completions_total[...])`.
+- **`xpf_userspace_binding_tx_completion_ring_available_max{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
+  gauge: maximum sampled completion-ring availability in the last
+  debug window. Non-zero skew here distinguishes TX completion backlog
+  from pure RSS/flow-placement skew. Like the current-value gauge, this
+  is reset after each publish and should be interpreted alongside the
+  per-binding completion rate.
 
 Operators tracking this contract in production monitor the gap
 `(observed_cov - cstruct)` and the starved-flow counter. A

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -381,6 +381,26 @@ no flow byte counter moved. Truncated flow-worker snapshots reset the
 window and suppress the observed metrics until a fresh baseline is
 available.
 
+### PR #1241 — TX completion uniformity telemetry
+
+Before the next full fairness measurement, the dataplane must expose
+whether one AF_XDP binding is falling behind in TX completion service.
+The readiness slice adds:
+
+- `xpf_userspace_binding_tx_completions_total{binding_slot,queue_id,worker_id,iface}`
+- `xpf_userspace_binding_tx_completion_ring_available{binding_slot,queue_id,worker_id,iface}`
+- `xpf_userspace_binding_tx_completion_ring_available_max{binding_slot,queue_id,worker_id,iface}`
+
+The completion counter gives per-binding completion rate via
+Prometheus `rate()`. The two ring gauges are owner-local samples
+published on the existing debug cadence: last observed CQ depth before
+drain and the debug-window peak. The worker resets both local samples
+after publishing, so a zero gauge can mean either no completion backlog
+or no TX work in that debug window; pair it with
+`rate(xpf_userspace_binding_tx_completions_total[...])` before treating
+the queue as idle. These are diagnostic signals only; they do not feed
+MQFQ, v8 lease selection, or admission.
+
 ## Open work
 
 - **#547 — Deterministic RSS-skew test fixture**: SHIPPED as PR #1223

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -106,6 +106,12 @@ type xpfCollector struct {
 	// docs/fairness-regimes.md). Refreshed at the helper's ~65ms
 	// debug-state tick.
 	bindingActiveFlowCount *prometheus.Desc
+	// #1241: per-binding AF_XDP TX completion service telemetry.
+	// These signals let fairness measurements distinguish scheduler/RSS
+	// skew from per-queue completion-ring service asymmetry.
+	bindingTXCompletions                *prometheus.Desc
+	bindingTXCompletionRingAvailable    *prometheus.Desc
+	bindingTXCompletionRingAvailableMax *prometheus.Desc
 	// #1248: class-specific active flow distribution by egress CoS
 	// queue. This is the production/mixed-workload {a_i} source.
 	cosActiveFlowCount *prometheus.Desc
@@ -396,6 +402,21 @@ func newCollector(srv *Server) *xpfCollector {
 				"compute the structural CoV ceiling per docs/fairness-regimes.md (#1219).",
 			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
 		),
+		bindingTXCompletions: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completions_total",
+			"Cumulative AF_XDP TX completions reaped by this binding's owner worker (#1241).",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+		),
+		bindingTXCompletionRingAvailable: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completion_ring_available",
+			"Last sampled AF_XDP TX completion-ring descriptors available before the owner worker drained completions (#1241).",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+		),
+		bindingTXCompletionRingAvailableMax: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completion_ring_available_max",
+			"Maximum sampled AF_XDP TX completion-ring descriptors available in the last debug window (#1241).",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+		),
 		cosActiveFlowCount: prometheus.NewDesc(
 			"xpf_userspace_cos_active_flow_count",
 			"Distinct active flows observed for this egress CoS queue on this worker "+
@@ -514,6 +535,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.workerCoSQueueLeaseAcquireV8GrantedBytes
 	ch <- c.workerDead
 	ch <- c.bindingActiveFlowCount
+	ch <- c.bindingTXCompletions
+	ch <- c.bindingTXCompletionRingAvailable
+	ch <- c.bindingTXCompletionRingAvailableMax
 	ch <- c.cosActiveFlowCount
 	ch <- c.fairnessCstruct
 	ch <- c.fairnessActiveWorkers
@@ -564,6 +588,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp da
 	c.emitCoSOwnerProfile(ch, status)
 	c.emitWorkerRuntime(ch, status)
 	c.emitBindingActiveFlowCount(ch, status)
+	c.emitBindingTXCompletionTelemetry(ch, status)
 	c.emitCoSActiveFlowCount(ch, status)
 	c.emitFairnessRSSGauges(ch, status)
 	c.emitFairnessThroughputGauges(ch, status)
@@ -582,6 +607,37 @@ func (c *xpfCollector) emitBindingActiveFlowCount(ch chan<- prometheus.Metric, s
 			strconv.FormatUint(uint64(b.QueueID), 10),
 			strconv.FormatUint(uint64(b.WorkerID), 10),
 			b.Interface,
+		)
+	}
+}
+
+// #1241: emit per-binding AF_XDP TX completion service telemetry for
+// flow-fairness qualification runs. `tx_completions_total` gives the
+// per-queue completion rate via Prometheus `rate()`. The two gauges
+// expose latest and peak completion-ring backlog observed by the owner
+// worker before drain, without introducing a hot-path shared counter.
+func (c *xpfCollector) emitBindingTXCompletionTelemetry(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, b := range status.Bindings {
+		slot := strconv.FormatUint(uint64(b.Slot), 10)
+		queueID := strconv.FormatUint(uint64(b.QueueID), 10)
+		workerID := strconv.FormatUint(uint64(b.WorkerID), 10)
+		ch <- prometheus.MustNewConstMetric(
+			c.bindingTXCompletions,
+			prometheus.CounterValue,
+			float64(b.TXCompletions),
+			slot, queueID, workerID, b.Interface,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.bindingTXCompletionRingAvailable,
+			prometheus.GaugeValue,
+			float64(b.TXCompletionRingAvailable),
+			slot, queueID, workerID, b.Interface,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.bindingTXCompletionRingAvailableMax,
+			prometheus.GaugeValue,
+			float64(b.TXCompletionRingAvailableMax),
+			slot, queueID, workerID, b.Interface,
 		)
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -320,6 +320,64 @@ func TestEmitBindingActiveFlowCount_LabelsAndValue(t *testing.T) {
 	}
 }
 
+func TestEmitBindingTXCompletionTelemetry_LabelsAndValues(t *testing.T) {
+	c := &xpfCollector{
+		bindingTXCompletions: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completions_total",
+			"test desc",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"},
+			nil,
+		),
+		bindingTXCompletionRingAvailable: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completion_ring_available",
+			"test desc",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"},
+			nil,
+		),
+		bindingTXCompletionRingAvailableMax: prometheus.NewDesc(
+			"xpf_userspace_binding_tx_completion_ring_available_max",
+			"test desc",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"},
+			nil,
+		),
+	}
+
+	status := dpuserspace.ProcessStatus{
+		Bindings: []dpuserspace.BindingStatus{{
+			Slot:                         2,
+			QueueID:                      5,
+			WorkerID:                     7,
+			Interface:                    "ge-0-0-1",
+			TXCompletions:                1234,
+			TXCompletionRingAvailable:    17,
+			TXCompletionRingAvailableMax: 29,
+		}},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitBindingTXCompletionTelemetry(ch, status)
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	if len(got) != 3 {
+		t.Fatalf("emitBindingTXCompletionTelemetry: want 3 metrics, got %d", len(got))
+	}
+
+	labels := map[string]string{
+		"binding_slot": "2",
+		"queue_id":     "5",
+		"worker_id":    "7",
+		"iface":        "ge-0-0-1",
+	}
+	assertCounterClose(t, got, c.bindingTXCompletions, labels, 1234)
+	assertGaugeClose(t, got, c.bindingTXCompletionRingAvailable, labels, 17)
+	assertGaugeClose(t, got, c.bindingTXCompletionRingAvailableMax, labels, 29)
+}
+
 func TestEmitCoSActiveFlowCount_LabelsAndValue(t *testing.T) {
 	c := &xpfCollector{
 		cosActiveFlowCount: prometheus.NewDesc(
@@ -647,6 +705,36 @@ func assertGaugeClose(
 			t.Fatalf("metric %s has no gauge", desc)
 		}
 		if got := pb.Gauge.GetValue(); math.Abs(got-want) > 0.000001 {
+			t.Fatalf("metric %s labels=%v got %v, want %v", desc, wantLabels, got, want)
+		}
+		return
+	}
+	t.Fatalf("metric %s labels=%v not found", desc, wantLabels)
+}
+
+func assertCounterClose(
+	t *testing.T,
+	metrics []prometheus.Metric,
+	desc *prometheus.Desc,
+	wantLabels map[string]string,
+	want float64,
+) {
+	t.Helper()
+	for _, m := range metrics {
+		if m.Desc() != desc {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		if !metricHasLabels(&pb, wantLabels) {
+			continue
+		}
+		if pb.Counter == nil {
+			t.Fatalf("metric %s has no counter", desc)
+		}
+		if got := pb.Counter.GetValue(); math.Abs(got-want) > 0.000001 {
 			t.Fatalf("metric %s labels=%v got %v, want %v", desc, wantLabels, got, want)
 		}
 		return

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -753,6 +753,12 @@ type BindingStatus struct {
 	DebugPendingTXPrepared            uint32    `json:"debug_pending_tx_prepared,omitempty"`
 	DebugPendingTXLocal               uint32    `json:"debug_pending_tx_local,omitempty"`
 	DebugOutstandingTX                uint32    `json:"debug_outstanding_tx,omitempty"`
+	// #1241: low-frequency AF_XDP TX completion-ring availability
+	// samples, published from owner-local worker telemetry. Current is
+	// the last sampled CQ depth before a reap; Max is the peak in the
+	// last debug window.
+	TXCompletionRingAvailable         uint32    `json:"tx_completion_ring_available,omitempty"`
+	TXCompletionRingAvailableMax      uint32    `json:"tx_completion_ring_available_max,omitempty"`
 	DebugInFlightRecycles             uint32    `json:"debug_in_flight_recycles,omitempty"`
 	// #802/#804: ring-pressure instrumentation mirror fields. See the
 	// Rust `BindingStatus` for semantics and write sites. The #804
@@ -833,6 +839,10 @@ type BindingCountersSnapshot struct {
 	DbgCoSQueueOverflow         uint64 `json:"dbg_cos_queue_overflow,omitempty"`
 	RxFillRingEmptyDescs        uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
 	OutstandingTX               uint32 `json:"outstanding_tx,omitempty"`
+	// #1241: low-frequency AF_XDP TX completion-ring availability
+	// gauges mirrored from BindingStatus for fast-poll consumers.
+	TXCompletionRingAvailable    uint32 `json:"tx_completion_ring_available,omitempty"`
+	TXCompletionRingAvailableMax uint32 `json:"tx_completion_ring_available_max,omitempty"`
 	// #878: per-binding capacities pulled through to the leaner
 	// snapshot so the daemon's fast poller can compute Buffer%
 	// without joining the full BindingStatus. See BindingStatus

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -24,6 +24,11 @@ var tx_kick_latency_wire_keys = []string{
 	"tx_kick_retry_count",
 }
 
+var tx_completion_ring_wire_keys = []string{
+	"tx_completion_ring_available",
+	"tx_completion_ring_available_max",
+}
+
 func TestBindingStatusTxKickLatencyRoundTrip(t *testing.T) {
 	// Encode a Go BindingStatus with non-trivial values on the
 	// four kick-latency fields; decode the JSON back; assert
@@ -151,6 +156,72 @@ func TestBindingCountersSnapshotTxKickLatencyBackwardCompat(t *testing.T) {
 	if back.TxKickRetryCount != 0 {
 		t.Fatalf("pre-#825 TxKickRetryCount must be 0, got %d",
 			back.TxKickRetryCount)
+	}
+}
+
+func TestBindingStatusTXCompletionRingRoundTrip(t *testing.T) {
+	in := BindingStatus{
+		WorkerID:                     3,
+		Slot:                         7,
+		Ifindex:                      11,
+		QueueID:                      2,
+		TXCompletionRingAvailable:    17,
+		TXCompletionRingAvailableMax: 29,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range tx_completion_ring_wire_keys {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from BindingStatus JSON: %s", key, string(raw))
+		}
+	}
+
+	var back BindingStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingStatus: %v", err)
+	}
+	if back.TXCompletionRingAvailable != 17 {
+		t.Fatalf("TXCompletionRingAvailable: got %d, want 17", back.TXCompletionRingAvailable)
+	}
+	if back.TXCompletionRingAvailableMax != 29 {
+		t.Fatalf("TXCompletionRingAvailableMax: got %d, want 29", back.TXCompletionRingAvailableMax)
+	}
+}
+
+func TestBindingCountersSnapshotTXCompletionRingRoundTrip(t *testing.T) {
+	in := BindingCountersSnapshot{
+		WorkerID:                     3,
+		Ifindex:                      11,
+		QueueID:                      2,
+		TXCompletionRingAvailable:    31,
+		TXCompletionRingAvailableMax: 47,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range tx_completion_ring_wire_keys {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from BindingCountersSnapshot JSON: %s", key, string(raw))
+		}
+	}
+
+	var back BindingCountersSnapshot
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingCountersSnapshot: %v", err)
+	}
+	if !reflect.DeepEqual(back, in) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", back, in)
 	}
 }
 

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1196,6 +1196,8 @@ impl Coordinator {
                 binding.debug_pending_tx_prepared = snap.debug_pending_tx_prepared;
                 binding.debug_pending_tx_local = snap.debug_pending_tx_local;
                 binding.debug_outstanding_tx = snap.debug_outstanding_tx;
+                binding.tx_completion_ring_available = snap.tx_completion_ring_available;
+                binding.tx_completion_ring_available_max = snap.tx_completion_ring_available_max;
                 binding.debug_in_flight_recycles = snap.debug_in_flight_recycles;
                 // #878: per-binding capacities + in-flight gauge flow
                 // into BindingStatus so the daemon's fwdstatus
@@ -1327,6 +1329,8 @@ impl Coordinator {
                 binding.debug_pending_tx_prepared = 0;
                 binding.debug_pending_tx_local = 0;
                 binding.debug_outstanding_tx = 0;
+                binding.tx_completion_ring_available = 0;
+                binding.tx_completion_ring_available_max = 0;
                 binding.debug_in_flight_recycles = 0;
                 // #878: capacities + in-flight gauge zero when the
                 // binding has no live state (slot unregistered). The

--- a/userspace-dp/src/afxdp/tx/rings.rs
+++ b/userspace-dp/src/afxdp/tx/rings.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 
 use crate::afxdp::neighbor::monotonic_nanos;
 use crate::afxdp::types::PreparedTxRecycle;
-use crate::afxdp::worker::BindingWorker;
+use crate::afxdp::worker::{BindingWorker, WorkerTelemetry};
 use crate::afxdp::{
     FILL_BATCH_SIZE, FILL_WAKE_SAFETY_INTERVAL_NS,
     RX_WAKE_IDLE_POLLS, RX_WAKE_MIN_INTERVAL_NS,
@@ -24,10 +24,12 @@ pub(in crate::afxdp) fn reap_tx_completions(
     if binding.tx_pipeline.outstanding_tx == 0 {
         return 0;
     }
-    let available = binding.xsk.device.available();
-    if available == 0 {
+    let Some(available) = record_tx_completion_ring_available_for_reap(
+        &mut binding.telemetry,
+        binding.xsk.device.available(),
+    ) else {
         return 0;
-    }
+    };
     let mut reaped = 0u32;
     binding.scratch.scratch_completed_offsets.clear();
     let mut completed = binding.xsk.device.complete(available);
@@ -66,6 +68,26 @@ pub(in crate::afxdp) fn reap_tx_completions(
         .fetch_add(reaped as u64, Ordering::Relaxed);
     update_binding_debug_state(binding);
     reaped
+}
+
+fn record_tx_completion_ring_available(telemetry: &mut WorkerTelemetry, available: u32) {
+    telemetry.dbg_tx_completion_ring_available = available;
+    telemetry.dbg_tx_completion_ring_available_max = telemetry
+        .dbg_tx_completion_ring_available_max
+        .max(available);
+}
+
+#[must_use]
+fn record_tx_completion_ring_available_for_reap(
+    telemetry: &mut WorkerTelemetry,
+    available: u32,
+) -> Option<u32> {
+    record_tx_completion_ring_available(telemetry, available);
+    if available == 0 {
+        None
+    } else {
+        Some(available)
+    }
 }
 
 pub(in crate::afxdp) fn drain_pending_fill(binding: &mut BindingWorker, now_ns: u64) -> bool {
@@ -330,6 +352,51 @@ mod tests {
 
         assert_eq!(free_tx_frames, VecDeque::from(vec![41]));
         assert_eq!(shared_recycles, vec![(7, 42)]);
+    }
+
+    #[test]
+    fn record_tx_completion_ring_available_tracks_zero_current_and_window_max() {
+        let mut telemetry = WorkerTelemetry::default();
+
+        record_tx_completion_ring_available(&mut telemetry, 8);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 8);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available_max, 8);
+
+        record_tx_completion_ring_available(&mut telemetry, 0);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 0);
+        assert_eq!(
+            telemetry.dbg_tx_completion_ring_available_max, 8,
+            "available == 0 must still publish the current idle sample without clearing the debug-window peak"
+        );
+
+        record_tx_completion_ring_available(&mut telemetry, 13);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 13);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available_max, 13);
+    }
+
+    #[test]
+    fn record_tx_completion_ring_available_for_reap_records_before_zero_decision() {
+        let mut telemetry = WorkerTelemetry {
+            dbg_tx_completion_ring_available_max: 8,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            record_tx_completion_ring_available_for_reap(&mut telemetry, 0),
+            None
+        );
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 0);
+        assert_eq!(
+            telemetry.dbg_tx_completion_ring_available_max, 8,
+            "zero-available reap decisions must preserve the debug-window peak"
+        );
+
+        assert_eq!(
+            record_tx_completion_ring_available_for_reap(&mut telemetry, 13),
+            Some(13)
+        );
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 13);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available_max, 13);
     }
 
 }

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -371,6 +371,15 @@ pub(in crate::afxdp) struct BindingLiveState {
     pub(super) debug_pending_tx_prepared: AtomicU32,
     pub(super) debug_pending_tx_local: AtomicU32,
     pub(super) debug_outstanding_tx: AtomicU32,
+    /// #1241: last sampled AF_XDP TX completion-ring availability
+    /// before the owner worker drained completions. Published on the
+    /// existing debug tick from owner-local telemetry so the forwarding
+    /// hot path does not introduce cross-worker cacheline traffic.
+    pub(super) tx_completion_ring_available: AtomicU32,
+    /// #1241: maximum sampled completion-ring availability during the
+    /// last debug window. This catches short CQ buildup that a latest
+    /// sample can miss when the owner drains quickly.
+    pub(super) tx_completion_ring_available_max: AtomicU32,
     pub(super) debug_in_flight_recycles: AtomicU32,
     /// #878: total UMEM frames allocated to this binding. Set once
     /// at worker construction (after `binding_frame_count_for_driver`)
@@ -525,6 +534,8 @@ impl BindingLiveState {
             debug_pending_tx_prepared: AtomicU32::new(0),
             debug_pending_tx_local: AtomicU32::new(0),
             debug_outstanding_tx: AtomicU32::new(0),
+            tx_completion_ring_available: AtomicU32::new(0),
+            tx_completion_ring_available_max: AtomicU32::new(0),
             debug_in_flight_recycles: AtomicU32::new(0),
             // #878: capacities are stored once by the worker at
             // construction time (in worker.rs after
@@ -809,6 +820,10 @@ impl BindingLiveState {
             debug_pending_tx_prepared: self.debug_pending_tx_prepared.load(Ordering::Relaxed),
             debug_pending_tx_local: self.debug_pending_tx_local.load(Ordering::Relaxed),
             debug_outstanding_tx: self.debug_outstanding_tx.load(Ordering::Relaxed),
+            tx_completion_ring_available: self.tx_completion_ring_available.load(Ordering::Relaxed),
+            tx_completion_ring_available_max: self
+                .tx_completion_ring_available_max
+                .load(Ordering::Relaxed),
             debug_in_flight_recycles: self.debug_in_flight_recycles.load(Ordering::Relaxed),
             // #878: per-binding UMEM/TX-ring capacities (set once at
             // worker startup) and current in-flight frames

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1583,6 +1583,7 @@ pub(crate) fn worker_loop(
                     b.live
                         .debug_outstanding_tx
                         .store(b.tx_pipeline.outstanding_tx, Ordering::Relaxed);
+                    publish_tx_completion_ring_telemetry(&b.live, &mut b.telemetry);
                     // #878: publish UMEM in-flight gauge as a single atomic
                     // so the daemon's `show chassis forwarding` Buffer% can
                     // divide by `umem_total_frames` without torn-load risk.
@@ -1764,6 +1765,30 @@ pub(crate) fn push_recent_session_delta(
     recent_session_deltas.push_back(delta);
 }
 
+fn publish_tx_completion_ring_telemetry(
+    live: &BindingLiveState,
+    telemetry: &mut WorkerTelemetry,
+) {
+    // #1241: publish owner-local AF_XDP TX completion-ring availability
+    // samples on the same low-frequency debug cadence as the existing
+    // ring-pressure gauges. These are gauges, not counters: current is
+    // the last sampled CQ depth before a reap, max is the peak in this
+    // debug window. Reset happens only after both stores so current and
+    // max are published from the same telemetry window; a future reorder
+    // must not clear either local sample before both live gauges are
+    // updated.
+    live.tx_completion_ring_available.store(
+        telemetry.dbg_tx_completion_ring_available,
+        Ordering::Relaxed,
+    );
+    live.tx_completion_ring_available_max.store(
+        telemetry.dbg_tx_completion_ring_available_max,
+        Ordering::Relaxed,
+    );
+    telemetry.dbg_tx_completion_ring_available = 0;
+    telemetry.dbg_tx_completion_ring_available_max = 0;
+}
+
 pub(crate) struct BindingLiveSnapshot {
     pub(crate) bound: bool,
     pub(crate) xsk_registered: bool,
@@ -1870,6 +1895,12 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) debug_pending_tx_prepared: u32,
     pub(crate) debug_pending_tx_local: u32,
     pub(crate) debug_outstanding_tx: u32,
+    /// #1241: last sampled AF_XDP TX completion-ring availability
+    /// before the owner worker drained completions.
+    pub(crate) tx_completion_ring_available: u32,
+    /// #1241: maximum sampled completion-ring availability in the
+    /// last debug window.
+    pub(crate) tx_completion_ring_available_max: u32,
     pub(crate) debug_in_flight_recycles: u32,
     /// #878: per-binding UMEM total frames (set once at worker
     /// construction). Used as the denominator for the `show chassis
@@ -1921,4 +1952,32 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) tx_kick_latency_count: u64,
     pub(crate) tx_kick_latency_sum_ns: u64,
     pub(crate) tx_kick_retry_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_tx_completion_ring_telemetry_stores_before_reset() {
+        let live = BindingLiveState::new();
+        let mut telemetry = WorkerTelemetry {
+            dbg_tx_completion_ring_available: 5,
+            dbg_tx_completion_ring_available_max: 9,
+            ..Default::default()
+        };
+
+        publish_tx_completion_ring_telemetry(&live, &mut telemetry);
+
+        assert_eq!(
+            live.tx_completion_ring_available.load(Ordering::Relaxed),
+            5
+        );
+        assert_eq!(
+            live.tx_completion_ring_available_max.load(Ordering::Relaxed),
+            9
+        );
+        assert_eq!(telemetry.dbg_tx_completion_ring_available, 0);
+        assert_eq!(telemetry.dbg_tx_completion_ring_available_max, 0);
+    }
 }

--- a/userspace-dp/src/afxdp/worker/telemetry.rs
+++ b/userspace-dp/src/afxdp/worker/telemetry.rs
@@ -27,6 +27,8 @@ pub(crate) struct WorkerTelemetry {
     pub(crate) dbg_tx_ring_submitted: u64,
     pub(crate) dbg_tx_ring_full: u64,
     pub(crate) dbg_completions_reaped: u64,
+    pub(crate) dbg_tx_completion_ring_available: u32,
+    pub(crate) dbg_tx_completion_ring_available_max: u32,
     pub(crate) dbg_sendto_calls: u64,
     pub(crate) dbg_sendto_err: u64,
     pub(crate) dbg_sendto_eagain: u64,

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -661,6 +661,8 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         dbg_cos_queue_overflow: 12,
         rx_fill_ring_empty_descs: 7,
         outstanding_tx: 8,
+        tx_completion_ring_available: 30,
+        tx_completion_ring_available_max: 32,
         tx_errors: 9,
         tx_submit_error_drops: 10,
         pending_tx_local_overflow_drops: 11,
@@ -705,6 +707,12 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         "dbg_cos_queue_overflow",
         "rx_fill_ring_empty_descs",
         "outstanding_tx",
+        // #1241: TX completion-ring uniformity wire keys. These
+        // are required before full flow-fairness measurements so
+        // step1/fairness consumers can separate CQ backlog from
+        // RSS-placement skew.
+        "tx_completion_ring_available",
+        "tx_completion_ring_available_max",
         "tx_errors",
         "tx_submit_error_drops",
         "pending_tx_local_overflow_drops",
@@ -807,6 +815,8 @@ fn tx_latency_hist_serialization_roundtrip() {
         dbg_cos_queue_overflow: 0,
         rx_fill_ring_empty_descs: 0,
         outstanding_tx: 0,
+        tx_completion_ring_available: 0,
+        tx_completion_ring_available_max: 0,
         tx_errors: 0,
         tx_submit_error_drops: 0,
         pending_tx_local_overflow_drops: 0,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1491,6 +1491,16 @@ pub(crate) struct BindingStatus {
     pub debug_pending_tx_local: u32,
     #[serde(rename = "debug_outstanding_tx", default)]
     pub debug_outstanding_tx: u32,
+    /// #1241: last sampled AF_XDP TX completion-ring availability
+    /// before completion drain. This is a low-frequency status gauge
+    /// published from owner-local worker telemetry; it is not read by
+    /// the scheduler.
+    #[serde(rename = "tx_completion_ring_available", default)]
+    pub tx_completion_ring_available: u32,
+    /// #1241: maximum sampled completion-ring availability in the last
+    /// debug window.
+    #[serde(rename = "tx_completion_ring_available_max", default)]
+    pub tx_completion_ring_available_max: u32,
     #[serde(rename = "debug_in_flight_recycles", default)]
     pub debug_in_flight_recycles: u32,
     // #802: ring-pressure instrumentation. Operator-facing cumulative
@@ -1638,6 +1648,13 @@ pub(crate) struct BindingCountersSnapshot {
     pub rx_fill_ring_empty_descs: u64,
     #[serde(rename = "outstanding_tx", default)]
     pub outstanding_tx: u32,
+    /// #1241: last sampled AF_XDP TX completion-ring availability.
+    #[serde(rename = "tx_completion_ring_available", default)]
+    pub tx_completion_ring_available: u32,
+    /// #1241: maximum sampled completion-ring availability in the last
+    /// debug window.
+    #[serde(rename = "tx_completion_ring_available_max", default)]
+    pub tx_completion_ring_available_max: u32,
     /// #878: per-binding UMEM total frames. Mirror of BindingStatus.
     #[serde(rename = "umem_total_frames", default)]
     pub umem_total_frames: u32,
@@ -1738,6 +1755,8 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             dbg_cos_queue_overflow: b.dbg_cos_queue_overflow,
             rx_fill_ring_empty_descs: b.rx_fill_ring_empty_descs,
             outstanding_tx: b.outstanding_tx,
+            tx_completion_ring_available: b.tx_completion_ring_available,
+            tx_completion_ring_available_max: b.tx_completion_ring_available_max,
             // #878: capacities + in-flight gauge flow into the
             // leaner snapshot so a step1-capture consumer reading
             // PerBinding (not the full BindingStatus) still sees
@@ -2065,6 +2084,56 @@ mod tests {
         assert_eq!(snap.tx_kick_latency_count, status.tx_kick_latency_count);
         assert_eq!(snap.tx_kick_latency_sum_ns, status.tx_kick_latency_sum_ns);
         assert_eq!(snap.tx_kick_retry_count, status.tx_kick_retry_count);
+    }
+
+    // #1241: pin the TX completion-ring availability wire keys at the
+    // rich BindingStatus layer and the lean BindingCountersSnapshot
+    // projection. Missing keys would decode as zeros on the Go side,
+    // exactly the failure mode this telemetry is meant to avoid before
+    // full fairness measurements.
+    #[test]
+    fn tx_completion_ring_binding_status_wire_roundtrip() {
+        let status = BindingStatus {
+            worker_id: 3,
+            slot: 7,
+            ifindex: 11,
+            queue_id: 2,
+            tx_completion_ring_available: 17,
+            tx_completion_ring_available_max: 29,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&status).expect("serialize BindingStatus");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("deserialize BindingStatus JSON");
+        assert_eq!(value["tx_completion_ring_available"], 17);
+        assert_eq!(value["tx_completion_ring_available_max"], 29);
+
+        let back: BindingStatus =
+            serde_json::from_str(&json).expect("deserialize BindingStatus");
+        assert_eq!(back.tx_completion_ring_available, 17);
+        assert_eq!(back.tx_completion_ring_available_max, 29);
+    }
+
+    #[test]
+    fn tx_completion_ring_from_binding_status_propagates() {
+        let status = BindingStatus {
+            worker_id: 5,
+            queue_id: 3,
+            tx_completion_ring_available: 31,
+            tx_completion_ring_available_max: 47,
+            ..Default::default()
+        };
+
+        let snap: BindingCountersSnapshot = (&status).into();
+        assert_eq!(
+            snap.tx_completion_ring_available,
+            status.tx_completion_ring_available
+        );
+        assert_eq!(
+            snap.tx_completion_ring_available_max,
+            status.tx_completion_ring_available_max
+        );
     }
 
     // #943 Copilot round-2 finding #3: the rich BindingStatus wire


### PR DESCRIPTION
## Summary

Closes #1241.

Adds per-binding AF_XDP TX completion service telemetry so fairness qualification runs can distinguish scheduler/RSS skew from per-queue completion-ring service asymmetry:

- publishes `tx_completion_ring_available` and `tx_completion_ring_available_max` from owner-local worker telemetry on the existing debug cadence
- carries the fields through Rust `BindingStatus`, lean `BindingCountersSnapshot`, Go protocol structs, and Prometheus
- exports:
  - `xpf_userspace_binding_tx_completions_total{binding_slot,queue_id,worker_id,iface}`
  - `xpf_userspace_binding_tx_completion_ring_available{binding_slot,queue_id,worker_id,iface}`
  - `xpf_userspace_binding_tx_completion_ring_available_max{binding_slot,queue_id,worker_id,iface}`
- updates fairness docs/state docs to mark these as diagnostic measurement inputs, not scheduler inputs

Hot-path note: sampling is owner-local in the completion reap path and published through existing low-frequency debug state. This does not add cross-worker shared state or scheduler feedback.

## Validation

- `go test ./pkg/dataplane/userspace ./pkg/api`
- `cargo test --manifest-path userspace-dp/Cargo.toml tx_completion_ring`
- `cargo test --manifest-path userspace-dp/Cargo.toml binding_counters_snapshot`
- `git diff --check`

Rust tests still emit the repo's existing warning set.

## Measurement Next Step

After review/merge, this unblocks the full flow-fairness measurement pass with the symmetric CoS fixture: we can capture active-flow distribution, observed throughput CoV, starvation/retransmits, and now per-binding TX completion service asymmetry in the same run.
