### PR TITLE
Fix parent-bound RETH VLAN CoS classification

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T06:55:00Z
+  - **Action**: PR #1271 round-2 follow-up — made parent-bound RETH VLAN synthetic ifindex allocation deterministic/config-derived, removed kernel-ifindex seeding, switched to high synthetic range with hard-fail on exhaustion, and added sibling-VLAN determinism regression coverage.
+  - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T00:30:00Z
   - **Action**: PR #1267 round-2 review follow-up — fixed fairness throughput window boundary pruning/rate denominator coupling to prevent false-positive saturation at steady sub-cap traffic, and added a regression test for the 10s-scrape/30s-window boundary case.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T07:35:00Z
+  - **Action**: PR #1271 round-3 follow-up — add same-VLAN/different-RETH synthetic-ifindex regressions so `reth0.N` and `reth1.N` cannot collapse into one logical Rust dataplane state key.
+  - **File(s)**: `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T07:20:00Z
   - **Action**: PR #1271 cleanup — removed unrelated `go.mod` direct/indirect dependency churn introduced by local test tooling to keep the diff scoped to synthetic-ifindex changes.
   - **File(s)**: `go.mod`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T07:20:00Z
+  - **Action**: PR #1271 cleanup — removed unrelated `go.mod` direct/indirect dependency churn introduced by local test tooling to keep the diff scoped to synthetic-ifindex changes.
+  - **File(s)**: `go.mod`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T07:16:00Z
   - **Action**: PR #1271 validation follow-up — documented synthetic-ifindex range rationale, improved exhaustion panic guidance, deduplicated VLAN test constants, and reverted unrelated `go.mod` drift from local test tooling.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `go.mod`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,14 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T07:16:00Z
+  - **Action**: PR #1271 validation follow-up — documented synthetic-ifindex range rationale, improved exhaustion panic guidance, deduplicated VLAN test constants, and reverted unrelated `go.mod` drift from local test tooling.
+  - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `go.mod`, `_Log.md`
+
+- **Timestamp**: 2026-05-12T07:08:00Z
+  - **Action**: PR #1271 follow-up — enriched synthetic-ifindex exhaustion panic diagnostics and replaced test magic VLAN bound with named constants during validation pass.
+  - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T06:55:00Z
   - **Action**: PR #1271 round-2 follow-up — made parent-bound RETH VLAN synthetic ifindex allocation deterministic/config-derived, removed kernel-ifindex seeding, switched to high synthetic range with hard-fail on exhaustion, and added sibling-VLAN determinism regression coverage.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -27,7 +28,6 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -28,6 +27,7 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2653,9 +2653,11 @@ func TestBuildInterfaceSnapshotIncludesInputAndOutputFilters(t *testing.T) {
 	}
 }
 
+const maxTestVLANID = 4094
+
 func missingLoopbackVLANID(t *testing.T) int {
 	t.Helper()
-	for vlan := 4094; vlan >= 2; vlan-- {
+	for vlan := maxTestVLANID; vlan >= 2; vlan-- {
 		if _, err := net.InterfaceByName(fmt.Sprintf("lo.%d", vlan)); err != nil {
 			return vlan
 		}
@@ -2667,7 +2669,7 @@ func missingLoopbackVLANID(t *testing.T) int {
 func missingLoopbackVLANIDs(t *testing.T, count int) []int {
 	t.Helper()
 	out := make([]int, 0, count)
-	for vlan := 4094; vlan >= 2 && len(out) < count; vlan-- {
+	for vlan := maxTestVLANID; vlan >= 2 && len(out) < count; vlan-- {
 		if _, err := net.InterfaceByName(fmt.Sprintf("lo.%d", vlan)); err != nil {
 			out = append(out, vlan)
 		}

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2653,6 +2653,100 @@ func TestBuildInterfaceSnapshotIncludesInputAndOutputFilters(t *testing.T) {
 	}
 }
 
+func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *testing.T) {
+	parent, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("loopback interface unavailable: %v", err)
+	}
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"wan": {Name: "wan", Interfaces: []string{"reth0.80"}},
+			},
+		},
+		ClassOfService: &config.ClassOfServiceConfig{
+			Interfaces: map[string]*config.CoSInterface{
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.CoSInterfaceUnit{
+						80: {
+							Unit:               80,
+							SchedulerMap:       "bandwidth-limit",
+							ShapingRateBytes:   25_000_000_000 / 8,
+							BurstSizeBytes:     64 * 1024 * 1024,
+							DSCPRewriteRule:    "wan-rewrite",
+							DSCPClassifier:     "wan-classifier",
+							IEEE8021Classifier: "wan-pcp",
+						},
+					},
+				},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"lo": {
+					Name:            "lo",
+					RedundantParent: "reth0",
+				},
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.InterfaceUnit{
+						80: {
+							Number:         80,
+							VlanID:         80,
+							FilterOutputV4: "bandwidth-output",
+							FilterOutputV6: "bandwidth-output",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	snaps := buildInterfaceSnapshots(cfg)
+	var unitSnap *InterfaceSnapshot
+	for i := range snaps {
+		if snaps[i].Name == "reth0.80" {
+			unitSnap = &snaps[i]
+			break
+		}
+	}
+	if unitSnap == nil {
+		t.Fatal("reth0.80 snapshot not found")
+	}
+	if unitSnap.Ifindex != parent.Index {
+		t.Fatalf("Ifindex = %d, want parent loopback ifindex %d", unitSnap.Ifindex, parent.Index)
+	}
+	if unitSnap.ParentIfindex != parent.Index {
+		t.Fatalf("ParentIfindex = %d, want %d", unitSnap.ParentIfindex, parent.Index)
+	}
+	if unitSnap.LinuxName != "lo.80" {
+		t.Fatalf("LinuxName = %q, want lo.80 logical child name", unitSnap.LinuxName)
+	}
+	if unitSnap.ParentLinuxName != "lo" {
+		t.Fatalf("ParentLinuxName = %q, want lo", unitSnap.ParentLinuxName)
+	}
+	if unitSnap.VLANID != 80 {
+		t.Fatalf("VLANID = %d, want 80", unitSnap.VLANID)
+	}
+	if unitSnap.Zone != "wan" {
+		t.Fatalf("Zone = %q, want wan", unitSnap.Zone)
+	}
+	if unitSnap.FilterOutputV4 != "bandwidth-output" || unitSnap.FilterOutputV6 != "bandwidth-output" {
+		t.Fatalf("output filters not preserved: v4=%q v6=%q", unitSnap.FilterOutputV4, unitSnap.FilterOutputV6)
+	}
+	if unitSnap.CoSSchedulerMap != "bandwidth-limit" {
+		t.Fatalf("CoSSchedulerMap = %q, want bandwidth-limit", unitSnap.CoSSchedulerMap)
+	}
+	if unitSnap.CoSShapingRateBytesPerSec == 0 {
+		t.Fatal("CoSShapingRateBytesPerSec = 0, want configured shaper")
+	}
+	aliases := buildUserspaceIngressBindingAliases(&ConfigSnapshot{Interfaces: []InterfaceSnapshot{*unitSnap}})
+	if _, ok := aliases[uint32(parent.Index)]; ok {
+		t.Fatalf("self alias for parent-bound VLAN should be suppressed: %v", aliases)
+	}
+}
+
 func TestBuildClassOfServiceSnapshotIncludesTransmitRateExact(t *testing.T) {
 	cfg := &config.Config{
 		ClassOfService: &config.ClassOfServiceConfig{

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2653,15 +2653,29 @@ func TestBuildInterfaceSnapshotIncludesInputAndOutputFilters(t *testing.T) {
 	}
 }
 
-func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *testing.T) {
+func missingLoopbackVLANID(t *testing.T) int {
+	t.Helper()
+	for vlan := 4094; vlan >= 2; vlan-- {
+		if _, err := net.InterfaceByName(fmt.Sprintf("lo.%d", vlan)); err != nil {
+			return vlan
+		}
+	}
+	t.Skip("all loopback VLAN names are present")
+	return 0
+}
+
+func TestBuildInterfaceSnapshotSynthesizesLogicalIfindexForMissingRethVLAN(t *testing.T) {
 	parent, err := net.InterfaceByName("lo")
 	if err != nil {
 		t.Skipf("loopback interface unavailable: %v", err)
 	}
+	vlanID := missingLoopbackVLANID(t)
+	unitName := fmt.Sprintf("reth0.%d", vlanID)
+	linuxUnitName := fmt.Sprintf("lo.%d", vlanID)
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			Zones: map[string]*config.ZoneConfig{
-				"wan": {Name: "wan", Interfaces: []string{"reth0.80"}},
+				"wan": {Name: "wan", Interfaces: []string{unitName}},
 			},
 		},
 		ClassOfService: &config.ClassOfServiceConfig{
@@ -2669,8 +2683,8 @@ func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *tes
 				"reth0": {
 					Name: "reth0",
 					Units: map[int]*config.CoSInterfaceUnit{
-						80: {
-							Unit:               80,
+						vlanID: {
+							Unit:               vlanID,
 							SchedulerMap:       "bandwidth-limit",
 							ShapingRateBytes:   25_000_000_000 / 8,
 							BurstSizeBytes:     64 * 1024 * 1024,
@@ -2691,9 +2705,9 @@ func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *tes
 				"reth0": {
 					Name: "reth0",
 					Units: map[int]*config.InterfaceUnit{
-						80: {
-							Number:         80,
-							VlanID:         80,
+						vlanID: {
+							Number:         vlanID,
+							VlanID:         vlanID,
 							FilterOutputV4: "bandwidth-output",
 							FilterOutputV6: "bandwidth-output",
 						},
@@ -2706,28 +2720,34 @@ func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *tes
 	snaps := buildInterfaceSnapshots(cfg)
 	var unitSnap *InterfaceSnapshot
 	for i := range snaps {
-		if snaps[i].Name == "reth0.80" {
+		if snaps[i].Name == unitName {
 			unitSnap = &snaps[i]
 			break
 		}
 	}
 	if unitSnap == nil {
-		t.Fatal("reth0.80 snapshot not found")
+		t.Fatalf("%s snapshot not found", unitName)
 	}
-	if unitSnap.Ifindex != parent.Index {
-		t.Fatalf("Ifindex = %d, want parent loopback ifindex %d", unitSnap.Ifindex, parent.Index)
+	if unitSnap.Ifindex <= 0 || unitSnap.Ifindex == parent.Index {
+		t.Fatalf("Ifindex = %d, want unique logical ifindex distinct from parent %d", unitSnap.Ifindex, parent.Index)
+	}
+	if unitSnap.Ifindex < syntheticInterfaceIfindexMin || unitSnap.Ifindex > syntheticInterfaceIfindexMax {
+		t.Fatalf("Ifindex = %d, want synthetic range [%d,%d]", unitSnap.Ifindex, syntheticInterfaceIfindexMin, syntheticInterfaceIfindexMax)
+	}
+	if !unitSnap.LogicalOnly {
+		t.Fatal("LogicalOnly = false, want true for missing parent-bound RETH VLAN")
 	}
 	if unitSnap.ParentIfindex != parent.Index {
 		t.Fatalf("ParentIfindex = %d, want %d", unitSnap.ParentIfindex, parent.Index)
 	}
-	if unitSnap.LinuxName != "lo.80" {
-		t.Fatalf("LinuxName = %q, want lo.80 logical child name", unitSnap.LinuxName)
+	if unitSnap.LinuxName != linuxUnitName {
+		t.Fatalf("LinuxName = %q, want %s logical child name", unitSnap.LinuxName, linuxUnitName)
 	}
 	if unitSnap.ParentLinuxName != "lo" {
 		t.Fatalf("ParentLinuxName = %q, want lo", unitSnap.ParentLinuxName)
 	}
-	if unitSnap.VLANID != 80 {
-		t.Fatalf("VLANID = %d, want 80", unitSnap.VLANID)
+	if unitSnap.VLANID != vlanID {
+		t.Fatalf("VLANID = %d, want %d", unitSnap.VLANID, vlanID)
 	}
 	if unitSnap.Zone != "wan" {
 		t.Fatalf("Zone = %q, want wan", unitSnap.Zone)
@@ -2741,9 +2761,64 @@ func TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN(t *tes
 	if unitSnap.CoSShapingRateBytesPerSec == 0 {
 		t.Fatal("CoSShapingRateBytesPerSec = 0, want configured shaper")
 	}
-	aliases := buildUserspaceIngressBindingAliases(&ConfigSnapshot{Interfaces: []InterfaceSnapshot{*unitSnap}})
-	if _, ok := aliases[uint32(parent.Index)]; ok {
-		t.Fatalf("self alias for parent-bound VLAN should be suppressed: %v", aliases)
+	snapshot := &ConfigSnapshot{Interfaces: []InterfaceSnapshot{*unitSnap}}
+	aliases := buildUserspaceIngressBindingAliases(snapshot)
+	if len(aliases) != 0 {
+		t.Fatalf("logical-only VLAN should not create XSK binding aliases: %v", aliases)
+	}
+	ifindexes := buildUserspaceIngressIfindexes(snapshot)
+	if len(ifindexes) != 1 || ifindexes[0] != uint32(parent.Index) {
+		t.Fatalf("ingress ifindexes = %v, want only parent %d", ifindexes, parent.Index)
+	}
+}
+
+func TestBuildInterfaceSnapshotDoesNotSynthesizeLogicalIfindexForGenericMissingVLAN(t *testing.T) {
+	parent, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("loopback interface unavailable: %v", err)
+	}
+	vlanID := missingLoopbackVLANID(t)
+	unitName := fmt.Sprintf("lo.%d", vlanID)
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"wan": {Name: "wan", Interfaces: []string{unitName}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"lo": {
+					Name: "lo",
+					Units: map[int]*config.InterfaceUnit{
+						vlanID: {
+							Number: vlanID,
+							VlanID: vlanID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	snaps := buildInterfaceSnapshots(cfg)
+	var unitSnap *InterfaceSnapshot
+	for i := range snaps {
+		if snaps[i].Name == unitName {
+			unitSnap = &snaps[i]
+			break
+		}
+	}
+	if unitSnap == nil {
+		t.Fatalf("%s snapshot not found", unitName)
+	}
+	if unitSnap.Ifindex != 0 {
+		t.Fatalf("Ifindex = %d, want 0 for generic missing VLAN child", unitSnap.Ifindex)
+	}
+	if unitSnap.LogicalOnly {
+		t.Fatal("LogicalOnly = true, want false for generic missing VLAN child")
+	}
+	if unitSnap.ParentIfindex != parent.Index {
+		t.Fatalf("ParentIfindex = %d, want %d", unitSnap.ParentIfindex, parent.Index)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2664,6 +2664,20 @@ func missingLoopbackVLANID(t *testing.T) int {
 	return 0
 }
 
+func missingLoopbackVLANIDs(t *testing.T, count int) []int {
+	t.Helper()
+	out := make([]int, 0, count)
+	for vlan := 4094; vlan >= 2 && len(out) < count; vlan-- {
+		if _, err := net.InterfaceByName(fmt.Sprintf("lo.%d", vlan)); err != nil {
+			out = append(out, vlan)
+		}
+	}
+	if len(out) < count {
+		t.Skipf("need %d missing loopback VLAN names, found %d", count, len(out))
+	}
+	return out
+}
+
 func TestBuildInterfaceSnapshotSynthesizesLogicalIfindexForMissingRethVLAN(t *testing.T) {
 	parent, err := net.InterfaceByName("lo")
 	if err != nil {
@@ -2769,6 +2783,78 @@ func TestBuildInterfaceSnapshotSynthesizesLogicalIfindexForMissingRethVLAN(t *te
 	ifindexes := buildUserspaceIngressIfindexes(snapshot)
 	if len(ifindexes) != 1 || ifindexes[0] != uint32(parent.Index) {
 		t.Fatalf("ingress ifindexes = %v, want only parent %d", ifindexes, parent.Index)
+	}
+}
+
+func TestBuildInterfaceSnapshotSynthesizesDeterministicLogicalIfindexForSiblingRethVLANs(t *testing.T) {
+	parent, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("loopback interface unavailable: %v", err)
+	}
+	vlans := missingLoopbackVLANIDs(t, 2)
+	unitA := fmt.Sprintf("reth0.%d", vlans[0])
+	unitB := fmt.Sprintf("reth0.%d", vlans[1])
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"wan": {Name: "wan", Interfaces: []string{unitA}},
+				"dmz": {Name: "dmz", Interfaces: []string{unitB}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"lo": {
+					Name:            "lo",
+					RedundantParent: "reth0",
+				},
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.InterfaceUnit{
+						vlans[0]: {Number: vlans[0], VlanID: vlans[0]},
+						vlans[1]: {Number: vlans[1], VlanID: vlans[1]},
+					},
+				},
+			},
+		},
+	}
+	readUnits := func() map[string]InterfaceSnapshot {
+		byName := make(map[string]InterfaceSnapshot)
+		for _, snap := range buildInterfaceSnapshots(cfg) {
+			if snap.Name == unitA || snap.Name == unitB {
+				byName[snap.Name] = snap
+			}
+		}
+		return byName
+	}
+	first := readUnits()
+	second := readUnits()
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("missing sibling RETH VLAN snapshots: first=%d second=%d", len(first), len(second))
+	}
+	for _, name := range []string{unitA, unitB} {
+		a := first[name]
+		b := second[name]
+		if a.Ifindex != b.Ifindex {
+			t.Fatalf("%s Ifindex changed across builds: first=%d second=%d", name, a.Ifindex, b.Ifindex)
+		}
+		if a.Ifindex <= 0 {
+			t.Fatalf("%s Ifindex = %d, want >0 synthetic logical ifindex", name, a.Ifindex)
+		}
+		if a.Ifindex < syntheticInterfaceIfindexMin || a.Ifindex > syntheticInterfaceIfindexMax {
+			t.Fatalf("%s Ifindex = %d, want synthetic range [%d,%d]", name, a.Ifindex, syntheticInterfaceIfindexMin, syntheticInterfaceIfindexMax)
+		}
+		if a.Ifindex == parent.Index {
+			t.Fatalf("%s Ifindex = parent ifindex %d, want unique logical ifindex", name, parent.Index)
+		}
+		if !a.LogicalOnly {
+			t.Fatalf("%s LogicalOnly = false, want true", name)
+		}
+		if a.ParentIfindex != parent.Index {
+			t.Fatalf("%s ParentIfindex = %d, want %d", name, a.ParentIfindex, parent.Index)
+		}
+	}
+	if first[unitA].Ifindex == first[unitB].Ifindex {
+		t.Fatalf("sibling VLANs collapsed to same synthetic ifindex: %d", first[unitA].Ifindex)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -2680,6 +2681,64 @@ func missingLoopbackVLANIDs(t *testing.T, count int) []int {
 	return out
 }
 
+func missingVLANIDForParents(t *testing.T, parentNames ...string) int {
+	t.Helper()
+	for vlan := maxTestVLANID; vlan >= 2; vlan-- {
+		missing := true
+		for _, parentName := range parentNames {
+			if _, err := net.InterfaceByName(fmt.Sprintf("%s.%d", parentName, vlan)); err == nil {
+				missing = false
+				break
+			}
+		}
+		if missing {
+			return vlan
+		}
+	}
+	t.Skipf("no VLAN ID is missing for parent interfaces %v", parentNames)
+	return 0
+}
+
+func liveSnapshotParentInterfaces(t *testing.T, count int) []net.Interface {
+	t.Helper()
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("cannot enumerate interfaces: %v", err)
+	}
+	out := make([]net.Interface, 0, count)
+	for _, iface := range interfaces {
+		if iface.Index <= 0 || iface.Name == "" || strings.Contains(iface.Name, ".") || strings.HasPrefix(iface.Name, "reth") {
+			continue
+		}
+		out = append(out, iface)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	if len(out) < count {
+		t.Skipf("need %d live parent interfaces, found %d", count, len(out))
+	}
+	return out[:count]
+}
+
+func TestSyntheticLogicalIfindexDistinguishesSameVIDDifferentReth(t *testing.T) {
+	vlanID := maxTestVLANID
+	unitA := fmt.Sprintf("reth0.%d", vlanID)
+	unitB := fmt.Sprintf("reth1.%d", vlanID)
+	firstUsed := make(map[int]struct{})
+	firstA := syntheticLogicalIfindex(unitA, vlanID, firstUsed)
+	firstB := syntheticLogicalIfindex(unitB, vlanID, firstUsed)
+	secondUsed := make(map[int]struct{})
+	secondA := syntheticLogicalIfindex(unitA, vlanID, secondUsed)
+	secondB := syntheticLogicalIfindex(unitB, vlanID, secondUsed)
+	if firstA != secondA || firstB != secondB {
+		t.Fatalf("synthetic ifindex allocation changed across builds: first=(%d,%d) second=(%d,%d)", firstA, firstB, secondA, secondB)
+	}
+	if firstA == firstB {
+		t.Fatalf("same-VLAN RETH units collapsed to one synthetic ifindex: %s=%d %s=%d", unitA, firstA, unitB, firstB)
+	}
+}
+
 func TestBuildInterfaceSnapshotSynthesizesLogicalIfindexForMissingRethVLAN(t *testing.T) {
 	parent, err := net.InterfaceByName("lo")
 	if err != nil {
@@ -2857,6 +2916,88 @@ func TestBuildInterfaceSnapshotSynthesizesDeterministicLogicalIfindexForSiblingR
 	}
 	if first[unitA].Ifindex == first[unitB].Ifindex {
 		t.Fatalf("sibling VLANs collapsed to same synthetic ifindex: %d", first[unitA].Ifindex)
+	}
+}
+
+func TestBuildInterfaceSnapshotSynthesizesDistinctLogicalIfindexesForSameVLANDifferentReth(t *testing.T) {
+	parents := liveSnapshotParentInterfaces(t, 2)
+	vlanID := missingVLANIDForParents(t, parents[0].Name, parents[1].Name)
+	unitA := fmt.Sprintf("reth0.%d", vlanID)
+	unitB := fmt.Sprintf("reth1.%d", vlanID)
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"wan": {Name: "wan", Interfaces: []string{unitA}},
+				"dmz": {Name: "dmz", Interfaces: []string{unitB}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				parents[0].Name: {
+					Name:            parents[0].Name,
+					RedundantParent: "reth0",
+				},
+				parents[1].Name: {
+					Name:            parents[1].Name,
+					RedundantParent: "reth1",
+				},
+				"reth0": {
+					Name: "reth0",
+					Units: map[int]*config.InterfaceUnit{
+						vlanID: {Number: vlanID, VlanID: vlanID},
+					},
+				},
+				"reth1": {
+					Name: "reth1",
+					Units: map[int]*config.InterfaceUnit{
+						vlanID: {Number: vlanID, VlanID: vlanID},
+					},
+				},
+			},
+		},
+	}
+	readUnits := func() map[string]InterfaceSnapshot {
+		byName := make(map[string]InterfaceSnapshot)
+		for _, snap := range buildInterfaceSnapshots(cfg) {
+			if snap.Name == unitA || snap.Name == unitB {
+				byName[snap.Name] = snap
+			}
+		}
+		return byName
+	}
+	first := readUnits()
+	second := readUnits()
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("missing same-VLAN RETH snapshots: first=%d second=%d", len(first), len(second))
+	}
+	for _, tc := range []struct {
+		name   string
+		parent net.Interface
+		zone   string
+	}{
+		{name: unitA, parent: parents[0], zone: "wan"},
+		{name: unitB, parent: parents[1], zone: "dmz"},
+	} {
+		a := first[tc.name]
+		b := second[tc.name]
+		if a.Ifindex != b.Ifindex {
+			t.Fatalf("%s Ifindex changed across builds: first=%d second=%d", tc.name, a.Ifindex, b.Ifindex)
+		}
+		if a.Ifindex < syntheticInterfaceIfindexMin || a.Ifindex > syntheticInterfaceIfindexMax {
+			t.Fatalf("%s Ifindex = %d, want synthetic range [%d,%d]", tc.name, a.Ifindex, syntheticInterfaceIfindexMin, syntheticInterfaceIfindexMax)
+		}
+		if !a.LogicalOnly {
+			t.Fatalf("%s LogicalOnly = false, want true", tc.name)
+		}
+		if a.ParentIfindex != tc.parent.Index {
+			t.Fatalf("%s ParentIfindex = %d, want %d", tc.name, a.ParentIfindex, tc.parent.Index)
+		}
+		if a.Zone != tc.zone {
+			t.Fatalf("%s Zone = %q, want %q", tc.name, a.Zone, tc.zone)
+		}
+	}
+	if first[unitA].Ifindex == first[unitB].Ifindex {
+		t.Fatalf("same-VLAN RETH units collapsed to same synthetic ifindex: %s=%d %s=%d", unitA, first[unitA].Ifindex, unitB, first[unitB].Ifindex)
 	}
 }
 

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -1170,7 +1170,7 @@ func buildUserspaceIngressIfindexes(snapshot *ConfigSnapshot) []uint32 {
 			continue
 		}
 		if iface.ParentIfindex > 0 {
-			if iface.Ifindex > 0 {
+			if iface.Ifindex > 0 && !iface.LogicalOnly {
 				key := uint32(iface.Ifindex)
 				if !seen[key] {
 					seen[key] = true
@@ -1222,12 +1222,13 @@ func snapshotBindingPlanKey(snapshot *ConfigSnapshot) string {
 		}
 		fmt.Fprintf(
 			&b,
-			"iface=%s/%s/%d/%d/%d/%t;",
+			"iface=%s/%s/%d/%d/%d/%t/%t;",
 			iface.Name,
 			iface.LinuxName,
 			iface.Ifindex,
 			iface.ParentIfindex,
 			iface.RXQueues,
+			iface.LogicalOnly,
 			iface.Tunnel,
 		)
 	}
@@ -1253,7 +1254,7 @@ func buildUserspaceIngressBindingAliases(snapshot *ConfigSnapshot) map[uint32]ui
 		if iface.Zone == "" || userspaceSkipsIngressInterface(iface) {
 			continue
 		}
-		if iface.Ifindex <= 0 || iface.ParentIfindex <= 0 || iface.Ifindex == iface.ParentIfindex {
+		if iface.Ifindex <= 0 || iface.ParentIfindex <= 0 || iface.Ifindex == iface.ParentIfindex || iface.LogicalOnly {
 			continue
 		}
 		out[uint32(iface.Ifindex)] = uint32(iface.ParentIfindex)

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -1253,7 +1253,7 @@ func buildUserspaceIngressBindingAliases(snapshot *ConfigSnapshot) map[uint32]ui
 		if iface.Zone == "" || userspaceSkipsIngressInterface(iface) {
 			continue
 		}
-		if iface.Ifindex <= 0 || iface.ParentIfindex <= 0 {
+		if iface.Ifindex <= 0 || iface.ParentIfindex <= 0 || iface.Ifindex == iface.ParentIfindex {
 			continue
 		}
 		out[uint32(iface.Ifindex)] = uint32(iface.ParentIfindex)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -105,6 +105,7 @@ type InterfaceSnapshot struct {
 	ParentLinuxName           string                     `json:"parent_linux_name,omitempty"`
 	Ifindex                   int                        `json:"ifindex,omitempty"`
 	ParentIfindex             int                        `json:"parent_ifindex,omitempty"`
+	LogicalOnly               bool                       `json:"logical_only,omitempty"`
 	RXQueues                  int                        `json:"rx_queues,omitempty"`
 	VLANID                    int                        `json:"vlan_id,omitempty"`
 	LocalFabric               string                     `json:"local_fabric_member,omitempty"`

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -74,6 +74,59 @@ func buildSnapshot(cfg *config.Config, ucfg config.UserspaceConfig, generation u
 	}
 }
 
+const (
+	syntheticInterfaceIfindexMin = 16384
+	syntheticInterfaceIfindexMax = 32767
+)
+
+func currentKernelIfindexes() map[int]struct{} {
+	out := make(map[int]struct{})
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return out
+	}
+	for _, iface := range ifaces {
+		if iface.Index > 0 {
+			out[iface.Index] = struct{}{}
+		}
+	}
+	return out
+}
+
+func syntheticLogicalIfindex(name string, parentIfindex int, vlanID int, used map[int]struct{}) int {
+	if used == nil {
+		used = make(map[int]struct{})
+	}
+	const fnvOffset = uint32(2166136261)
+	const fnvPrime = uint32(16777619)
+	hash := fnvOffset
+	for _, b := range []byte(fmt.Sprintf("%s/%d/%d", name, parentIfindex, vlanID)) {
+		hash ^= uint32(b)
+		hash *= fnvPrime
+	}
+	span := syntheticInterfaceIfindexMax - syntheticInterfaceIfindexMin + 1
+	start := syntheticInterfaceIfindexMin + int(hash%uint32(span))
+	for offset := 0; offset < span; offset++ {
+		candidate := syntheticInterfaceIfindexMin + ((start - syntheticInterfaceIfindexMin + offset) % span)
+		if _, exists := used[candidate]; exists {
+			continue
+		}
+		used[candidate] = struct{}{}
+		return candidate
+	}
+	return 0
+}
+
+func shouldUseLogicalOnlyParentBoundRethVLAN(cfg *config.Config, ifName string, unit *config.InterfaceUnit, childIfindex int, parentIfindex int) bool {
+	if cfg == nil || unit == nil || childIfindex > 0 || parentIfindex <= 0 || unit.VlanID <= 0 {
+		return false
+	}
+	if !strings.HasPrefix(ifName, "reth") {
+		return false
+	}
+	return config.LinuxIfName(cfg.ResolveReth(ifName)) != config.LinuxIfName(ifName)
+}
+
 // UserspaceBoundLinuxInterfaces returns the deduplicated, sorted set of
 // Linux interface names that the userspace dataplane will bind AF_XDP
 // sockets to for the given compiled config. This is the authoritative
@@ -187,7 +240,10 @@ func neighborsEqual(a, b []NeighborSnapshot) bool {
 // or transition to unusable state (which removes a key from the
 // publishable set).
 func neighborsEqualForwarding(a, b []NeighborSnapshot) bool {
-	type keyMac struct{ ifindex int; ip, mac string }
+	type keyMac struct {
+		ifindex int
+		ip, mac string
+	}
 	publishable := func(ns []NeighborSnapshot) map[keyMac]struct{} {
 		out := make(map[keyMac]struct{}, len(ns))
 		for _, n := range ns {
@@ -213,10 +269,10 @@ func neighborsEqualForwarding(a, b []NeighborSnapshot) bool {
 // should be pushed to userspace-dp. Must mirror userspace-dp's
 // accept rules at userspace-dp/src/afxdp/forwarding/mod.rs:45:
 //
-//   pub(super) fn neighbor_state_usable(state: &str) -> bool {
-//       let normalized = state.to_ascii_lowercase();
-//       !(normalized.contains("failed") || normalized.contains("incomplete"))
-//   }
+//	pub(super) fn neighbor_state_usable(state: &str) -> bool {
+//	    let normalized = state.to_ascii_lowercase();
+//	    !(normalized.contains("failed") || normalized.contains("incomplete"))
+//	}
 //
 // Codex code-review #3: Rust uses SUBSTRING match after
 // lowercasing; previous Go did EXACT match — drift. Fixed to
@@ -423,6 +479,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		return nil
 	}
 	zoneByInterface := buildInterfaceZoneMap(cfg)
+	usedIfindexes := currentKernelIfindexes()
 	// Build RETH RG lookup: physical member → RETH's RedundancyGroup.
 	// Physical members have RedundantParent set but RedundancyGroup=0;
 	// the RG is on the RETH. Without this, flow cache HA checks on
@@ -449,6 +506,9 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		}
 		linuxName := snapshotLinuxName(cfg, name, iface, nil)
 		ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxName)
+		if ifindex > 0 {
+			usedIfindexes[ifindex] = struct{}{}
+		}
 		// Use the interface's own RG, or inherit from RETH parent.
 		rg := iface.RedundancyGroup
 		if rg <= 0 {
@@ -493,17 +553,24 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			unitName := fmt.Sprintf("%s.%d", name, unitNum)
 			parentLinux := snapshotLinuxName(cfg, name, iface, nil)
 			parentIfindex, parentMTU, parentHardwareAddr, _ := buildLinkSnapshot(parentLinux)
+			if parentIfindex > 0 {
+				usedIfindexes[parentIfindex] = struct{}{}
+			}
 			parentRXQueues := userspaceRXQueueCount(parentLinux)
 			linuxUnit := snapshotLinuxName(cfg, name, iface, unit)
 			ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxUnit)
+			if ifindex > 0 {
+				usedIfindexes[ifindex] = struct{}{}
+			}
 			rxQueues := userspaceRXQueueCount(linuxUnit)
+			logicalOnly := false
 			// Bondless RETH VLAN units can transmit through the parent
-			// AF_XDP netdev without a Linux VLAN child. Keep the logical
-			// unit name/VLAN metadata, but key runtime filter and CoS
-			// state by the real parent ifindex so the userspace dataplane
-			// can attach output filters and queue owners.
-			if ifindex <= 0 && parentIfindex > 0 && unit.VlanID > 0 {
-				ifindex = parentIfindex
+			// AF_XDP netdev without a Linux VLAN child. Keep a unique
+			// logical ifindex for Rust FIB/filter/CoS state, while the
+			// existing ParentIfindex path remains the socket bind target.
+			if shouldUseLogicalOnlyParentBoundRethVLAN(cfg, name, unit, ifindex, parentIfindex) {
+				ifindex = syntheticLogicalIfindex(unitName, parentIfindex, unit.VlanID, usedIfindexes)
+				logicalOnly = ifindex > 0
 				if mtu == 0 {
 					mtu = parentMTU
 				}
@@ -522,6 +589,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 				ParentLinuxName:           parentLinux,
 				Ifindex:                   ifindex,
 				ParentIfindex:             parentIfindex,
+				LogicalOnly:               logicalOnly,
 				RXQueues:                  rxQueues,
 				VLANID:                    unit.VlanID,
 				LocalFabric:               iface.LocalFabricMember,

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -75,32 +75,18 @@ func buildSnapshot(cfg *config.Config, ucfg config.UserspaceConfig, generation u
 }
 
 const (
-	syntheticInterfaceIfindexMin = 16384
-	syntheticInterfaceIfindexMax = 32767
+	syntheticInterfaceIfindexMin = 1 << 30
+	syntheticInterfaceIfindexMax = syntheticInterfaceIfindexMin + (1 << 20) - 1
 )
 
-func currentKernelIfindexes() map[int]struct{} {
-	out := make(map[int]struct{})
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return out
-	}
-	for _, iface := range ifaces {
-		if iface.Index > 0 {
-			out[iface.Index] = struct{}{}
-		}
-	}
-	return out
-}
-
-func syntheticLogicalIfindex(name string, parentIfindex int, vlanID int, used map[int]struct{}) int {
+func syntheticLogicalIfindex(name string, vlanID int, used map[int]struct{}) int {
 	if used == nil {
 		used = make(map[int]struct{})
 	}
 	const fnvOffset = uint32(2166136261)
 	const fnvPrime = uint32(16777619)
 	hash := fnvOffset
-	for _, b := range []byte(fmt.Sprintf("%s/%d/%d", name, parentIfindex, vlanID)) {
+	for _, b := range []byte(fmt.Sprintf("%s/%d", name, vlanID)) {
 		hash ^= uint32(b)
 		hash *= fnvPrime
 	}
@@ -114,7 +100,7 @@ func syntheticLogicalIfindex(name string, parentIfindex int, vlanID int, used ma
 		used[candidate] = struct{}{}
 		return candidate
 	}
-	return 0
+	panic(fmt.Sprintf("userspace snapshot: exhausted synthetic ifindex range for %q", name))
 }
 
 func shouldUseLogicalOnlyParentBoundRethVLAN(cfg *config.Config, ifName string, unit *config.InterfaceUnit, childIfindex int, parentIfindex int) bool {
@@ -479,7 +465,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		return nil
 	}
 	zoneByInterface := buildInterfaceZoneMap(cfg)
-	usedIfindexes := currentKernelIfindexes()
+	usedSyntheticIfindexes := make(map[int]struct{})
 	// Build RETH RG lookup: physical member → RETH's RedundancyGroup.
 	// Physical members have RedundantParent set but RedundancyGroup=0;
 	// the RG is on the RETH. Without this, flow cache HA checks on
@@ -506,9 +492,6 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		}
 		linuxName := snapshotLinuxName(cfg, name, iface, nil)
 		ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxName)
-		if ifindex > 0 {
-			usedIfindexes[ifindex] = struct{}{}
-		}
 		// Use the interface's own RG, or inherit from RETH parent.
 		rg := iface.RedundancyGroup
 		if rg <= 0 {
@@ -553,15 +536,9 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			unitName := fmt.Sprintf("%s.%d", name, unitNum)
 			parentLinux := snapshotLinuxName(cfg, name, iface, nil)
 			parentIfindex, parentMTU, parentHardwareAddr, _ := buildLinkSnapshot(parentLinux)
-			if parentIfindex > 0 {
-				usedIfindexes[parentIfindex] = struct{}{}
-			}
 			parentRXQueues := userspaceRXQueueCount(parentLinux)
 			linuxUnit := snapshotLinuxName(cfg, name, iface, unit)
 			ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxUnit)
-			if ifindex > 0 {
-				usedIfindexes[ifindex] = struct{}{}
-			}
 			rxQueues := userspaceRXQueueCount(linuxUnit)
 			logicalOnly := false
 			// Bondless RETH VLAN units can transmit through the parent
@@ -569,8 +546,8 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			// logical ifindex for Rust FIB/filter/CoS state, while the
 			// existing ParentIfindex path remains the socket bind target.
 			if shouldUseLogicalOnlyParentBoundRethVLAN(cfg, name, unit, ifindex, parentIfindex) {
-				ifindex = syntheticLogicalIfindex(unitName, parentIfindex, unit.VlanID, usedIfindexes)
-				logicalOnly = ifindex > 0
+				ifindex = syntheticLogicalIfindex(unitName, unit.VlanID, usedSyntheticIfindexes)
+				logicalOnly = true
 				if mtu == 0 {
 					mtu = parentMTU
 				}

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -75,6 +75,10 @@ func buildSnapshot(cfg *config.Config, ucfg config.UserspaceConfig, generation u
 }
 
 const (
+	// Keep logical-only synthetic ifindexes in a high private range so
+	// they do not collide with kernel-assigned ifindexes in practical
+	// deployments, while remaining positive int32 values for protocol
+	// compatibility.
 	syntheticInterfaceIfindexMin = 1 << 30
 	syntheticInterfaceIfindexMax = syntheticInterfaceIfindexMin + (1 << 20) - 1
 )
@@ -100,7 +104,15 @@ func syntheticLogicalIfindex(name string, vlanID int, used map[int]struct{}) int
 		used[candidate] = struct{}{}
 		return candidate
 	}
-	panic(fmt.Sprintf("userspace snapshot: exhausted synthetic ifindex range for %q", name))
+	panic(fmt.Sprintf(
+		"userspace snapshot: exhausted synthetic ifindex range for %q (vlan=%d hash=%d tried=%d range=[%d,%d]); check for hash collisions or excessive logical-only VLAN units",
+		name,
+		vlanID,
+		hash,
+		span,
+		syntheticInterfaceIfindexMin,
+		syntheticInterfaceIfindexMax,
+	))
 }
 
 func shouldUseLogicalOnlyParentBoundRethVLAN(cfg *config.Config, ifName string, unit *config.InterfaceUnit, childIfindex int, parentIfindex int) bool {

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -492,9 +492,28 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			}
 			unitName := fmt.Sprintf("%s.%d", name, unitNum)
 			parentLinux := snapshotLinuxName(cfg, name, iface, nil)
-			parentIfindex, _, _, _ := buildLinkSnapshot(parentLinux)
+			parentIfindex, parentMTU, parentHardwareAddr, _ := buildLinkSnapshot(parentLinux)
+			parentRXQueues := userspaceRXQueueCount(parentLinux)
 			linuxUnit := snapshotLinuxName(cfg, name, iface, unit)
 			ifindex, mtu, hardwareAddr, addresses := buildLinkSnapshot(linuxUnit)
+			rxQueues := userspaceRXQueueCount(linuxUnit)
+			// Bondless RETH VLAN units can transmit through the parent
+			// AF_XDP netdev without a Linux VLAN child. Keep the logical
+			// unit name/VLAN metadata, but key runtime filter and CoS
+			// state by the real parent ifindex so the userspace dataplane
+			// can attach output filters and queue owners.
+			if ifindex <= 0 && parentIfindex > 0 && unit.VlanID > 0 {
+				ifindex = parentIfindex
+				if mtu == 0 {
+					mtu = parentMTU
+				}
+				if hardwareAddr == "" {
+					hardwareAddr = parentHardwareAddr
+				}
+				if rxQueues == 0 {
+					rxQueues = parentRXQueues
+				}
+			}
 			addresses = mergeInterfaceAddressSnapshots(addresses, buildConfiguredAddressSnapshots(unit.Addresses))
 			out = append(out, InterfaceSnapshot{
 				Name:                      unitName,
@@ -503,7 +522,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 				ParentLinuxName:           parentLinux,
 				Ifindex:                   ifindex,
 				ParentIfindex:             parentIfindex,
-				RXQueues:                  userspaceRXQueueCount(linuxUnit),
+				RXQueues:                  rxQueues,
 				VLANID:                    unit.VlanID,
 				LocalFabric:               iface.LocalFabricMember,
 				RedundancyGroup:           rg, // inherit resolved RG (RETH parent or own)

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -442,6 +442,66 @@ fn build_forwarding_state_prefers_logical_unit_for_ingress_lookup() {
     let state = build_forwarding_state(&snapshot);
     assert_eq!(state.ingress_logical_ifindex.get(&(10, 0)), Some(&11));
 }
+
+#[test]
+fn build_forwarding_state_keeps_parent_bound_vlan_units_distinct() {
+    use crate::ZoneSnapshot;
+
+    let snapshot = ConfigSnapshot {
+        zones: vec![
+            ZoneSnapshot {
+                name: "wan".into(),
+                id: 11,
+            },
+            ZoneSnapshot {
+                name: "dmz".into(),
+                id: 12,
+            },
+        ],
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "reth0.80".into(),
+                zone: "wan".into(),
+                ifindex: 20080,
+                parent_ifindex: 6,
+                vlan_id: 80,
+                hardware_addr: "02:00:00:00:00:06".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "reth0.81".into(),
+                zone: "dmz".into(),
+                ifindex: 20081,
+                parent_ifindex: 6,
+                vlan_id: 81,
+                hardware_addr: "02:00:00:00:00:06".into(),
+                cos_shaping_rate_bytes_per_sec: 20_000_000,
+                ..Default::default()
+            },
+        ],
+        class_of_service: Some(ClassOfServiceSnapshot::default()),
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+
+    assert_eq!(state.ingress_logical_ifindex.get(&(6, 80)), Some(&20080));
+    assert_eq!(state.ingress_logical_ifindex.get(&(6, 81)), Some(&20081));
+    assert_eq!(state.ifindex_to_zone_id.get(&20080).copied(), Some(11));
+    assert_eq!(state.ifindex_to_zone_id.get(&20081).copied(), Some(12));
+    assert_eq!(
+        state.egress.get(&20080).expect("wan egress").bind_ifindex,
+        6
+    );
+    assert_eq!(
+        state.egress.get(&20081).expect("dmz egress").bind_ifindex,
+        6
+    );
+    assert!(state.cos.interfaces.contains_key(&20080));
+    assert!(state.cos.interfaces.contains_key(&20081));
+}
+
 #[test]
 fn build_forwarding_state_disables_tx_selection_when_no_cos_or_filters_exist() {
     let state = build_forwarding_state(&ConfigSnapshot::default());


### PR DESCRIPTION
## Summary

Fixes #1234.

- when a RETH VLAN unit resolves to a missing Linux VLAN child but its physical parent exists, publish the parent ifindex as the runtime key while preserving logical name/VLAN metadata
- carry parent MTU/MAC/RX queue attributes into that parent-bound logical snapshot so userspace CoS and output-filter runtime state can attach
- suppress no-op ingress binding aliases where the logical and parent ifindex are identical
- add a regression test using `lo` as the existing parent and `lo.80` as the absent VLAN child

## Why

On the loss userspace cluster, `reth0.80` maps to `ge-0-0-2.80`, but traffic exits via AF_XDP on parent `ge-0-0-2` and the VLAN child may not exist as a Linux netdev. The old snapshot left `reth0.80` with ifindex 0, so userspace-dp skipped the interface in filter and CoS runtime construction. That produced `Runtime: unavailable`, no queue owners, and zero firewall counter hits for the iperf CoS terms.

## Validation

- `go test ./pkg/dataplane/userspace -run 'TestBuildInterfaceSnapshotFallsBackToParentIfindexForMissingRethVLAN|TestBuildUserspaceIngressBindingAliasesIncludesVLANChild|TestBuildUserspaceIngressIfindexesIncludesVLANChildAndParent'`\n- `go test ./pkg/dataplane/userspace`\n- `go test ./pkg/dataplane/...`\n- `git diff --check`