### PR TITLE
Pin low-N fairness guard behavior

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -351,3 +351,12 @@
 - **Timestamp**: 2026-05-10T05:18:20Z
   - **Action**: Correct configstore encryption note to match implementation (`master.key` + HKDF with configured PRF).
   - **File(s)**: `pkg/configstore/README.md`
+
+## 2026-05-12 — fairness-eval diagnostic message + test rename
+
+- **Timestamp**: 2026-05-12T06:29:24Z
+  - **Action**: Fix Harness guard failure message to print `expected_sum` and `dir_mult` alongside `n_non_starved` so operators can see the bidirectional expansion factor. Update block comment to correctly describe `max(2, floor(10% × expected_sum))` formula.
+  - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`
+- **Timestamp**: 2026-05-12T06:29:24Z
+  - **Action**: Rename `guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount` → `guard_low_n_iface_input_accepts_absolute_floor_p2_gap1`; add inline math comment explaining why absolute floor (not recency) is the operative gate. Drop misleading "recency" claim from assertion messages.
+  - **File(s)**: `userspace-dp/tests/fairness_eval_blackbox.rs`

--- a/_Log.md
+++ b/_Log.md
@@ -354,6 +354,10 @@
 
 ## 2026-05-12 — fairness-eval diagnostic message + test rename
 
+- **Timestamp**: 2026-05-12T06:52:27Z
+  - **Action**: PR #1272 round-3 review follow-up — clarify the top-level guard comment to reference `iface_filter_active`, and pin guard failure tests on `expected`, `non-starved`, and `dir_mult` substrings.
+  - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`, `userspace-dp/tests/fairness_eval_blackbox.rs`
+
 - **Timestamp**: 2026-05-12T06:29:24Z
   - **Action**: Fix Harness guard failure message to print `expected_sum` and `dir_mult` alongside `n_non_starved` so operators can see the bidirectional expansion factor. Update block comment to correctly describe `max(2, floor(10% × expected_sum))` formula.
   - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -23,7 +23,8 @@ const EPSILON: f64 = 0.05;
 // finding #3: sum(per_binding_active_flow_count) ≈ expected_sum
 // within `max(2, floor(10% × expected_sum))`, where
 // expected_sum = non-starved_streams × direction_multiplier
-// (direction_multiplier=1 with --iface, 2 for legacy/bidirectional).
+// (direction_multiplier=1 when iface_filter_active=true, 2 for
+// legacy/bidirectional input).
 const GUARD_RELATIVE: f64 = 0.10;
 const GUARD_ABSOLUTE: u32 = 2;
 

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -20,8 +20,10 @@ use fairness::{
 
 const EPSILON: f64 = 0.05;
 // Tolerance for the harness fail-fast guard per Codex round-4
-// finding #3: sum(per_binding_active_flow_count) ≈ non-starved
-// iperf stream count within `max(2, 10% × N)`.
+// finding #3: sum(per_binding_active_flow_count) ≈ expected_sum
+// within `max(2, floor(10% × expected_sum))`, where
+// expected_sum = non-starved_streams × direction_multiplier
+// (direction_multiplier=1 with --iface, 2 for legacy/bidirectional).
 const GUARD_RELATIVE: f64 = 0.10;
 const GUARD_ABSOLUTE: u32 = 2;
 
@@ -719,7 +721,9 @@ fn main() -> ExitCode {
     }
     if !a_i_sum_check_ok {
         failure_reasons.push(format!(
-            "Harness guard: sum(a_i)={a_i_sum} vs iperf non-starved streams={n_non_starved} differ by more than tolerance={tolerance}"
+            "Harness guard: sum(a_i)={a_i_sum} vs expected={expected_sum} \
+             (non-starved={n_non_starved} × dir_mult={dir_mult}) \
+             differ by more than tolerance={tolerance}"
         ));
     }
     if !rss_expectation_pass {

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -20,10 +20,10 @@ use fairness::{
 
 const EPSILON: f64 = 0.05;
 // Tolerance for the harness fail-fast guard per Codex round-4
-// finding #3: sum(per_binding_active_flow_count) ≈ non-starved
-// iperf stream count within `max(2, 10% × N)`.
+// finding #3 and #1224: sum(per_binding_active_flow_count) ≈
+// non-starved iperf stream count within `max(3, 10% × N)`.
 const GUARD_RELATIVE: f64 = 0.10;
-const GUARD_ABSOLUTE: u32 = 2;
+const GUARD_ABSOLUTE: u32 = 3;
 
 #[derive(Debug, Deserialize)]
 struct Iperf3Output {

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -20,10 +20,10 @@ use fairness::{
 
 const EPSILON: f64 = 0.05;
 // Tolerance for the harness fail-fast guard per Codex round-4
-// finding #3 and #1224: sum(per_binding_active_flow_count) ≈
-// non-starved iperf stream count within `max(3, 10% × N)`.
+// finding #3: sum(per_binding_active_flow_count) ≈ non-starved
+// iperf stream count within `max(2, 10% × N)`.
 const GUARD_RELATIVE: f64 = 0.10;
-const GUARD_ABSOLUTE: u32 = 3;
+const GUARD_ABSOLUTE: u32 = 2;
 
 #[derive(Debug, Deserialize)]
 struct Iperf3Output {

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -540,7 +540,7 @@ fn guard_low_n_legacy_input_rejects_p2_undercount() {
 }
 
 #[test]
-fn guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount() {
+fn guard_low_n_iface_input_accepts_absolute_floor_p2_gap1() {
     let tmp = TempGuard::new("guard_low_n_iface");
     let sockets = [5u64, 6];
     let mut intervals: Vec<Vec<StreamSample>> = Vec::new();
@@ -574,6 +574,10 @@ fn guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount() {
     }
     let tsv_str = synth_tsv_6col(&rows);
 
+    // P=2 streams, --iface active → dir_mult=1 → expected_sum=2.
+    // Only one binding slot reports count=1 (the other is absent →
+    // median=0). a_i_sum=1, gap=|1-2|=1, tolerance=max(0,2)=2.
+    // 1 ≤ 2 → sum guard PASS (absolute floor is the operative gate).
     let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
         "--iface", "ge-0-0-2",
         "--n-workers", "6",
@@ -583,7 +587,7 @@ fn guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount() {
     assert_eq!(
         output.status.code(),
         Some(0),
-        "iface-filtered P=2 single-direction undercount should stay inside the guard; stderr={}",
+        "iface-filtered P=2 gap=1 should stay inside the absolute floor (tolerance=2); stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
     let v = verdict.expect("verdict JSON on low-N iface PASS");

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -480,11 +480,14 @@ fn guard_sum_mismatch_fails() {
     assert_eq!(v["verdict"], "FAIL");
     assert_eq!(v["a_i_sum_check_ok"], false);
     let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
-    assert!(
-        reasons.iter().any(|r| r.as_str().unwrap_or("").contains("Harness guard")),
-        "failure_reasons must contain a Harness guard entry; got: {:?}",
-        reasons
-    );
+    let guard_reason = reasons
+        .iter()
+        .filter_map(|r| r.as_str())
+        .find(|r| r.contains("Harness guard"))
+        .unwrap_or_else(|| panic!("failure_reasons must contain a Harness guard entry; got: {reasons:?}"));
+    assert!(guard_reason.contains("expected=6"), "guard reason missing expected_sum: {guard_reason}");
+    assert!(guard_reason.contains("non-starved=6"), "guard reason missing non-starved: {guard_reason}");
+    assert!(guard_reason.contains("dir_mult=1"), "guard reason missing dir_mult: {guard_reason}");
 }
 
 #[test]
@@ -532,11 +535,14 @@ fn guard_low_n_legacy_input_rejects_p2_undercount() {
     assert_eq!(v["iperf_non_starved_streams"], 2);
     assert_eq!(v["a_i_sum_tolerance"], 2);
     let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
-    assert!(
-        reasons.iter().any(|r| r.as_str().unwrap_or("").contains("Harness guard")),
-        "failure_reasons must contain a Harness guard entry; got: {:?}",
-        reasons
-    );
+    let guard_reason = reasons
+        .iter()
+        .filter_map(|r| r.as_str())
+        .find(|r| r.contains("Harness guard"))
+        .unwrap_or_else(|| panic!("failure_reasons must contain a Harness guard entry; got: {reasons:?}"));
+    assert!(guard_reason.contains("expected=4"), "guard reason missing expected_sum: {guard_reason}");
+    assert!(guard_reason.contains("non-starved=2"), "guard reason missing non-starved: {guard_reason}");
+    assert!(guard_reason.contains("dir_mult=2"), "guard reason missing dir_mult: {guard_reason}");
 }
 
 #[test]

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -488,8 +488,8 @@ fn guard_sum_mismatch_fails() {
 }
 
 #[test]
-fn guard_low_n_legacy_input_accepts_p2_recency_undercount() {
-    let tmp = TempGuard::new("guard_low_n");
+fn guard_low_n_legacy_input_rejects_p2_undercount() {
+    let tmp = TempGuard::new("guard_low_n_legacy");
     let sockets = [5u64, 6];
     let mut intervals: Vec<Vec<StreamSample>> = Vec::new();
     for i in 0..60u64 {
@@ -521,16 +521,77 @@ fn guard_low_n_legacy_input_accepts_p2_recency_undercount() {
     ]);
     assert_eq!(
         output.status.code(),
-        Some(0),
-        "P=2 low-N recency undercount should stay inside the harness guard; stderr={}",
+        Some(1),
+        "legacy P=2 undercount should fail the bidirectional harness guard; stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let v = verdict.expect("verdict JSON on low-N PASS");
+    let v = verdict.expect("verdict JSON on low-N legacy FAIL");
+    assert_eq!(v["verdict"], "FAIL");
+    assert_eq!(v["a_i_sum_check_ok"], false);
+    assert_eq!(v["a_i_sum"], 1);
+    assert_eq!(v["iperf_non_starved_streams"], 2);
+    assert_eq!(v["a_i_sum_tolerance"], 2);
+    let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
+    assert!(
+        reasons.iter().any(|r| r.as_str().unwrap_or("").contains("Harness guard")),
+        "failure_reasons must contain a Harness guard entry; got: {:?}",
+        reasons
+    );
+}
+
+#[test]
+fn guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount() {
+    let tmp = TempGuard::new("guard_low_n_iface");
+    let sockets = [5u64, 6];
+    let mut intervals: Vec<Vec<StreamSample>> = Vec::new();
+    for i in 0..60u64 {
+        intervals.push(vec![
+            StreamSample {
+                socket: sockets[0],
+                start: i as f64,
+                end: i as f64 + 1.0,
+                bits_per_second: 1.0e9,
+            },
+            StreamSample {
+                socket: sockets[1],
+                start: i as f64,
+                end: i as f64 + 1.0,
+                bits_per_second: 1.0e9,
+            },
+        ]);
+    }
+    let json_str = synth_iperf3_json(60, &sockets, intervals);
+    let mut rows: Vec<TsvRow> = Vec::new();
+    for ts in timestamps_for(60) {
+        rows.push(TsvRow {
+            timestamp: ts,
+            binding_slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            iface: "ge-0-0-2",
+            count: 1,
+        });
+    }
+    let tsv_str = synth_tsv_6col(&rows);
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "iface-filtered P=2 single-direction undercount should stay inside the guard; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on low-N iface PASS");
     assert_eq!(v["verdict"], "PASS");
     assert_eq!(v["a_i_sum_check_ok"], true);
     assert_eq!(v["a_i_sum"], 1);
     assert_eq!(v["iperf_non_starved_streams"], 2);
-    assert_eq!(v["a_i_sum_tolerance"], 3);
+    assert_eq!(v["a_i_sum_tolerance"], 2);
 }
 
 #[test]

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -488,6 +488,52 @@ fn guard_sum_mismatch_fails() {
 }
 
 #[test]
+fn guard_low_n_legacy_input_accepts_p2_recency_undercount() {
+    let tmp = TempGuard::new("guard_low_n");
+    let sockets = [5u64, 6];
+    let mut intervals: Vec<Vec<StreamSample>> = Vec::new();
+    for i in 0..60u64 {
+        intervals.push(vec![
+            StreamSample {
+                socket: sockets[0],
+                start: i as f64,
+                end: i as f64 + 1.0,
+                bits_per_second: 1.0e9,
+            },
+            StreamSample {
+                socket: sockets[1],
+                start: i as f64,
+                end: i as f64 + 1.0,
+                bits_per_second: 1.0e9,
+            },
+        ]);
+    }
+    let json_str = synth_iperf3_json(60, &sockets, intervals);
+    let mut tsv_str = String::from("# timestamp\tbinding_slot\tcount\n");
+    for ts in timestamps_for(60) {
+        tsv_str.push_str(&format!("{ts}\t0\t1\n"));
+    }
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "P=2 low-N recency undercount should stay inside the harness guard; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on low-N PASS");
+    assert_eq!(v["verdict"], "PASS");
+    assert_eq!(v["a_i_sum_check_ok"], true);
+    assert_eq!(v["a_i_sum"], 1);
+    assert_eq!(v["iperf_non_starved_streams"], 2);
+    assert_eq!(v["a_i_sum_tolerance"], 3);
+}
+
+#[test]
 fn guard_empty_tsv_fails_via_sum_guard() {
     let tmp = TempGuard::new("guard_empty");
     // 6 healthy streams; TSV has header only (no data rows). With


### PR DESCRIPTION
## Summary
- keep fairness-eval's absolute sum-guard floor at 2 after review showed the proposed 2→3 relaxation masked a real legacy/bidirectional undercount
- expose expected_sum, non-starved stream count, direction multiplier, and tolerance in the guard failure reason
- add blackbox coverage that pins both iface-filtered and legacy/bidirectional guard diagnostics

Refs #1224

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml --test fairness_eval_blackbox guard_sum_mismatch_fails
- cargo test --manifest-path userspace-dp/Cargo.toml --test fairness_eval_blackbox guard_low_n_legacy_input_rejects_p2_undercount
- git diff --check