### PR TITLE
Add fairness multi-sample harness wrapper

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -354,6 +354,10 @@
 
 ## 2026-05-12 fairness_multi_sample round-2 HIGH fixes
 
+- **Timestamp**: 2026-05-12T06:50:50Z
+  - **Action**: Round-3 follow-up — tighten verdict JSON detection to the full fairness-eval schema; remove the `os.getpgid` timeout race by using the process-group leader PID directly; add a bounded post-kill `communicate()`; remove a stale threshold-source reference.
+  - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
+
 - **Timestamp**: 2026-05-12T06:29:25Z
   - **Action**: HIGH1 - Tighten extract_verdict_objects to require verdict+observed_cov+discriminator field
   - **Action**: HIGH2 - Replace subprocess.run with Popen(start_new_session=True)+os.killpg for process-group cleanup on timeout

--- a/_Log.md
+++ b/_Log.md
@@ -355,8 +355,12 @@
 ## 2026-05-12 fairness_multi_sample round-2 HIGH fixes
 
 - **Timestamp**: 2026-05-12T06:50:50Z
-  - **Action**: Round-3 follow-up — tighten verdict JSON detection to the full fairness-eval schema; remove the `os.getpgid` timeout race by using the process-group leader PID directly; add a bounded post-kill `communicate()`; remove a stale threshold-source reference.
+  - **Action**: Round-3 follow-up — tighten verdict JSON detection to the canonical fairness-eval verdict-key set; remove the `os.getpgid` timeout race by using the process-group leader PID directly; add a bounded post-kill `communicate()`; remove a stale threshold-source reference.
   - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
+
+- **Timestamp**: 2026-05-12T07:45:00Z
+  - **Action**: PR #1273 Copilot follow-up — align multi-sample verdict filtering with the canonical 10-key fairness-eval schema and validate summary numeric fields (`cstruct`, `gap`, optional `aggregate_mbps`, and integer `starved_flow_count`) instead of only `observed_cov`.
+  - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md, docs/per-5-tuple/state.md, _Log.md
 
 - **Timestamp**: 2026-05-12T06:29:25Z
   - **Action**: HIGH1 - Tighten extract_verdict_objects to require verdict+observed_cov+discriminator field

--- a/_Log.md
+++ b/_Log.md
@@ -370,3 +370,10 @@
   - **Action**: Tests - Add schema-incomplete and process-group tests; move import time to top
   - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
   - **Result**: 12/12 tests green (was 10)
+
+## 2026-05-12 fairness_multi_sample round-3 fix
+
+- **Timestamp**: 2026-05-12T07:02:16Z
+  - **Action**: Fix pgid capture race - capture os.getpgid(proc.pid) immediately after Popen before communicate() can reap the leader; use cached pgid in both _kill_process_group() calls.
+  - **File(s)**: test/incus/fairness_multi_sample.py
+  - **Result**: 14/14 tests green

--- a/_Log.md
+++ b/_Log.md
@@ -351,3 +351,14 @@
 - **Timestamp**: 2026-05-10T05:18:20Z
   - **Action**: Correct configstore encryption note to match implementation (`master.key` + HKDF with configured PRF).
   - **File(s)**: `pkg/configstore/README.md`
+
+## 2026-05-12 fairness_multi_sample round-2 HIGH fixes
+
+- **Timestamp**: 2026-05-12T06:29:25Z
+  - **Action**: HIGH1 - Tighten extract_verdict_objects to require verdict+observed_cov+discriminator field
+  - **Action**: HIGH2 - Replace subprocess.run with Popen(start_new_session=True)+os.killpg for process-group cleanup on timeout
+  - **Action**: MINOR - Replace statistics.fmean with statistics.mean; remove dead timeout_stream_text
+  - **Action**: Docs - Add fresh-iperf3 requirement and threshold derivation to v8-multi-sample.md
+  - **Action**: Tests - Add schema-incomplete and process-group tests; move import time to top
+  - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
+  - **Result**: 12/12 tests green (was 10)

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -415,7 +415,10 @@ MQFQ, v8 lease selection, or admission.
   `test/incus/fairness_multi_sample.py` and
   `docs/per-5-tuple/v8-multi-sample.md` before publishing a new
   iperf-e headline. The gate is mean observed CoV, sample standard
-  deviation, max run CoV, and every per-run fairness verdict.
+  deviation, max run CoV, and every per-run fairness verdict. The
+  wrapper requires at least two samples, filters stdout to top-level
+  `verdict` JSON objects, rejects non-finite or negative numeric verdict
+  fields, and fails closed on harness timeout.
 - **#1211 follow-up (only if gate flips to FAIL on a real workload)**:
   open a fresh issue using the revisit criteria in the Path 2
   closure archive. Do not re-open #1211 directly. As of the

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -417,8 +417,9 @@ MQFQ, v8 lease selection, or admission.
   iperf-e headline. The gate is mean observed CoV, sample standard
   deviation, max run CoV, and every per-run fairness verdict. The
   wrapper requires at least two samples, filters stdout to top-level
-  `verdict` JSON objects, rejects non-finite or negative numeric verdict
-  fields, and fails closed on harness timeout.
+  fairness-eval verdict JSON objects, rejects non-finite or negative
+  threshold fields, enforces non-negative integer `starved_flow_count`,
+  and fails closed on harness timeout.
 - **#1211 follow-up (only if gate flips to FAIL on a real workload)**:
   open a fresh issue using the revisit criteria in the Path 2
   closure archive. Do not re-open #1211 directly. As of the

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -411,6 +411,11 @@ MQFQ, v8 lease selection, or admission.
   PASS and Guard FAIL depending on RSS placement; tolerance floor
   `GUARD_ABSOLUTE = 2` is too tight at small expected_sum. Small
   follow-up; not a fairness mechanism.
+- **#1232 — v8 multi-sample CoV stability**: use
+  `test/incus/fairness_multi_sample.py` and
+  `docs/per-5-tuple/v8-multi-sample.md` before publishing a new
+  iperf-e headline. The gate is mean observed CoV, sample standard
+  deviation, max run CoV, and every per-run fairness verdict.
 - **#1211 follow-up (only if gate flips to FAIL on a real workload)**:
   open a fresh issue using the revisit criteria in the Path 2
   closure archive. Do not re-open #1211 directly. As of the

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -35,9 +35,10 @@ is the headline stability gate, `--max-stdev-cov 3%` rejects unstable
 run-to-run RSS/placement variance, and `--max-run-cov 25%` prevents one
 bad run from being hidden by the mean.
 
-The wrapper reads stdout JSON objects that pass a schema check
-(`verdict`, `observed_cov`, and at least one of `cstruct`, `gap`,
-`failure_reasons` must be present) and ignores all other structured
+The wrapper reads stdout JSON objects that match the fairness-eval
+verdict schema (`verdict`, `observed_cov`, `cstruct`, `gap`,
+`failure_reasons`, `distribution_a_i`, `n_active`, `aggregate_mbps`,
+`saturated`, and `starved_flow_count`) and ignores all other structured
 logs. Each sample must emit exactly one verdict object with finite,
 non-negative numeric fields. Every harness run has a 600-second default
 timeout; on timeout the wrapper kills the entire process group
@@ -52,18 +53,15 @@ placement draws. Do not invoke `fairness_multi_sample.py` against a
 pre-captured static snapshot — every run would produce identical
 `observed_cov` and the stdev would be trivially 0.
 
-**Threshold derivation**: `--max-mean-cov 15%` comes from the v8
-userspace dataplane baseline measured in
-`feedback_smoke_loss_userspace_only.md`, where the median observed CoV
-across production-shaped flow sets was ≈0.13–0.14; 0.15 is a 1-sigma
-guard margin. `--max-run-cov 25%` approximates the multinomial-floor
-CoV for the worst-case RSS skew distribution seen in that same run
-history (one-in-five runs landing on an unfavorable hash bucket
-distribution). `--max-stdev-cov 3%` allows for ≈±0.03 of run-to-run
-noise (ephemeral-port entropy changes the RSS assignment per run); a
-stdev above 0.03 indicates structural instability rather than sampling
-noise. These thresholds should be updated if the dataplane or NIC
-configuration changes materially.
+**Threshold derivation**: `--max-mean-cov 15%` is a conservative
+stability gate for production-shaped v8 flow sets whose observed CoV is
+expected to sit in the low-to-mid teens when the dataplane is healthy.
+`--max-run-cov 25%` bounds one unfavorable RSS placement draw from being
+hidden by the mean. `--max-stdev-cov 3%` allows for about ±0.03 of
+run-to-run noise from ephemeral-port RSS entropy; a stdev above 0.03
+indicates structural instability rather than sampling noise. These
+thresholds should be updated if the dataplane or NIC configuration
+changes materially.
 
 The wrapper exits:
 

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -1,0 +1,38 @@
+# v8 Multi-Sample Fairness Runbook
+
+Issue #1232 exists because a single iperf-e run can overstate or
+understate CoV stability. Source-port randomness changes the RSS
+placement, so the useful measurement is the run-to-run distribution of
+`observed_cov`, not one lucky sample.
+
+Use the wrapper below for the canonical five-sample run:
+
+```bash
+python3 test/incus/fairness_multi_sample.py \
+  --samples 5 \
+  --out-dir /tmp/xpf-v8-multi-sample-$(date +%Y%m%d-%H%M%S) \
+  --max-mean-cov 15% \
+  --max-stdev-cov 3% \
+  --max-run-cov 25% \
+  -- \
+  2001:559:8585:80::200 5205 12 120 "" http://127.0.0.1:8080/metrics
+```
+
+The command runs `test/incus/fairness-harness.sh` five times, stores
+each sample's stdout, stderr, command, placement artifacts, and
+`verdict.json`, then writes `summary.json` with:
+
+- mean observed CoV
+- sample standard deviation of observed CoV
+- min/max observed CoV
+- per-run fairness verdicts and failure reasons
+
+The wrapper exits:
+
+- `0` when all samples PASS and the mean/stdev/max CoV thresholds pass
+- `1` when at least one fairness verdict or aggregate threshold fails
+- `2` for harness, parsing, or environment errors
+
+This is a measurement runbook, not the final empirical result. Close
+#1232 only after running it on the loss userspace cluster with the
+current userspace dataplane and recording the resulting `summary.json`.

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -37,13 +37,15 @@ bad run from being hidden by the mean.
 
 The wrapper reads stdout JSON objects that match the fairness-eval
 verdict schema (`verdict`, `observed_cov`, `cstruct`, `gap`,
-`failure_reasons`, `distribution_a_i`, `n_active`, `aggregate_mbps`,
-`saturated`, and `starved_flow_count`) and ignores all other structured
-logs. Each sample must emit exactly one verdict object with finite,
-non-negative numeric fields. Every harness run has a 600-second default
-timeout; on timeout the wrapper kills the entire process group
-(including iperf3 and scraper descendants) before writing the partial
-stdout/stderr and `command.json` with `timed_out: true`.
+`failure_reasons`, `distribution_a_i`, `n_active`, `saturated`,
+`a_i_sum_check_ok`, and `starved_flow_count`) and ignores all other
+structured logs. Each sample must emit exactly one verdict object with
+finite, non-negative `observed_cov`, `cstruct`, and `gap`; if
+`aggregate_mbps` is present, it is also finite/non-negative validated.
+`starved_flow_count` must be a non-negative integer. Every harness run
+has a 600-second default timeout; on timeout the wrapper kills the entire
+process group (including iperf3 and scraper descendants) before writing
+the partial stdout/stderr and `command.json` with `timed_out: true`.
 
 **Important**: each sample must exercise a fresh iperf3 measurement
 with a new ephemeral source-port set, not a replay of a fixed snapshot.

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -14,6 +14,7 @@ python3 test/incus/fairness_multi_sample.py \
   --max-mean-cov 15% \
   --max-stdev-cov 3% \
   --max-run-cov 25% \
+  --per-run-timeout-sec 600 \
   -- \
   2001:559:8585:80::200 5205 12 120 "" http://127.0.0.1:8080/metrics
 ```
@@ -27,11 +28,25 @@ each sample's stdout, stderr, command, placement artifacts, and
 - min/max observed CoV
 - per-run fairness verdicts and failure reasons
 
+`--samples` must be at least `2`; the canonical run is `5` samples.
+The default thresholds are CI-grade stability guards over repeated
+iperf-e placement draws, not fairness constants. `--max-mean-cov 15%`
+is the headline stability gate, `--max-stdev-cov 3%` rejects unstable
+run-to-run RSS/placement variance, and `--max-run-cov 25%` prevents one
+bad run from being hidden by the mean.
+
+The wrapper reads stdout JSON objects with a top-level `verdict` key and
+ignores non-verdict structured logs. Each sample must emit exactly one
+verdict object with finite, non-negative numeric fields. Every harness
+run has a 600-second default timeout; a timeout writes the partial
+stdout/stderr and `command.json` with `timed_out: true` before the
+wrapper exits `2`.
+
 The wrapper exits:
 
 - `0` when all samples PASS and the mean/stdev/max CoV thresholds pass
 - `1` when at least one fairness verdict or aggregate threshold fails
-- `2` for harness, parsing, or environment errors
+- `2` for harness timeout, parsing, validation, or environment errors
 
 This is a measurement runbook, not the final empirical result. Close
 #1232 only after running it on the loss userspace cluster with the

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -35,12 +35,35 @@ is the headline stability gate, `--max-stdev-cov 3%` rejects unstable
 run-to-run RSS/placement variance, and `--max-run-cov 25%` prevents one
 bad run from being hidden by the mean.
 
-The wrapper reads stdout JSON objects with a top-level `verdict` key and
-ignores non-verdict structured logs. Each sample must emit exactly one
-verdict object with finite, non-negative numeric fields. Every harness
-run has a 600-second default timeout; a timeout writes the partial
-stdout/stderr and `command.json` with `timed_out: true` before the
-wrapper exits `2`.
+The wrapper reads stdout JSON objects that pass a schema check
+(`verdict`, `observed_cov`, and at least one of `cstruct`, `gap`,
+`failure_reasons` must be present) and ignores all other structured
+logs. Each sample must emit exactly one verdict object with finite,
+non-negative numeric fields. Every harness run has a 600-second default
+timeout; on timeout the wrapper kills the entire process group
+(including iperf3 and scraper descendants) before writing the partial
+stdout/stderr and `command.json` with `timed_out: true`.
+
+**Important**: each sample must exercise a fresh iperf3 measurement
+with a new ephemeral source-port set, not a replay of a fixed snapshot.
+The harness creates a fresh temp directory and reruns iperf3 for each
+invocation, so invoking the wrapper N times yields N independent RSS
+placement draws. Do not invoke `fairness_multi_sample.py` against a
+pre-captured static snapshot — every run would produce identical
+`observed_cov` and the stdev would be trivially 0.
+
+**Threshold derivation**: `--max-mean-cov 15%` comes from the v8
+userspace dataplane baseline measured in
+`feedback_smoke_loss_userspace_only.md`, where the median observed CoV
+across production-shaped flow sets was ≈0.13–0.14; 0.15 is a 1-sigma
+guard margin. `--max-run-cov 25%` approximates the multinomial-floor
+CoV for the worst-case RSS skew distribution seen in that same run
+history (one-in-five runs landing on an unfavorable hash bucket
+distribution). `--max-stdev-cov 3%` allows for ≈±0.03 of run-to-run
+noise (ephemeral-port entropy changes the RSS assignment per run); a
+stdev above 0.03 indicates structural instability rather than sampling
+noise. These thresholds should be updated if the dataplane or NIC
+configuration changes materially.
 
 The wrapper exits:
 

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import os
+import signal
 from pathlib import Path
 import statistics
 import subprocess
@@ -58,7 +59,12 @@ def extract_json_objects(text: str) -> list[dict[str, Any]]:
 
 
 def extract_verdict_objects(text: str) -> list[dict[str, Any]]:
-    return [obj for obj in extract_json_objects(text) if "verdict" in obj]
+    _required = {"verdict", "observed_cov"}
+    _discriminators = {"cstruct", "gap", "failure_reasons"}
+    return [
+        obj for obj in extract_json_objects(text)
+        if _required.issubset(obj) and bool(_discriminators & obj.keys())
+    ]
 
 
 def numeric_field(verdict: dict[str, Any], key: str) -> float:
@@ -71,14 +77,6 @@ def numeric_field(verdict: dict[str, Any], key: str) -> float:
     if number < 0:
         raise MultiSampleError(f"verdict JSON field {key!r} is negative")
     return number
-
-
-def timeout_stream_text(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return str(value)
 
 
 def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[str, Any]) -> dict[str, Any]:
@@ -104,7 +102,7 @@ def summarize(
     max_run_cov: float,
 ) -> dict[str, Any]:
     observed_covs = [float(s["observed_cov"]) for s in samples]
-    mean_cov = statistics.fmean(observed_covs)
+    mean_cov = statistics.mean(observed_covs)
     stdev_cov = statistics.stdev(observed_covs) if len(observed_covs) > 1 else 0.0
     max_cov = max(observed_covs)
     min_cov = min(observed_covs)
@@ -145,6 +143,21 @@ def summarize(
     }
 
 
+def _kill_process_group(pgid: int) -> None:
+    """Send SIGTERM then SIGKILL to a process group to clean up all descendants.
+
+    SIGTERM is sent first as a courtesy, then SIGKILL immediately follows.
+    There is no grace-period delay between them because this function is only
+    called on a CI timeout abort — the harness has already exceeded its time
+    budget and we need it dead fast to avoid tying up ports for subsequent runs.
+    """
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+
+
 def run_samples(args: argparse.Namespace) -> dict[str, Any]:
     harness_args = list(args.harness_args)
     if harness_args and harness_args[0] == "--":
@@ -166,24 +179,29 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
         env = os.environ.copy()
         env["ARTIFACT_DIR"] = str(artifact_dir)
         cmd = [str(args.harness), *harness_args]
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            start_new_session=True,
+        )
+        timed_out = False
         try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                env=env,
-                check=False,
-                timeout=args.per_run_timeout_sec,
-            )
-        except subprocess.TimeoutExpired as exc:
-            (sample_dir / "stdout.log").write_text(
-                timeout_stream_text(exc.stdout),
-                encoding="utf-8",
-            )
-            (sample_dir / "stderr.log").write_text(
-                timeout_stream_text(exc.stderr),
-                encoding="utf-8",
-            )
+            stdout_text, stderr_text = proc.communicate(timeout=args.per_run_timeout_sec)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            try:
+                _kill_process_group(os.getpgid(proc.pid))
+            except ProcessLookupError:
+                pass
+            stdout_text, stderr_text = proc.communicate()
+        exit_code = proc.returncode
+
+        (sample_dir / "stdout.log").write_text(stdout_text, encoding="utf-8")
+        (sample_dir / "stderr.log").write_text(stderr_text, encoding="utf-8")
+        if timed_out:
             (sample_dir / "command.json").write_text(
                 json.dumps(
                     {
@@ -200,15 +218,12 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             raise MultiSampleError(
                 f"sample {index} harness timed out after {args.per_run_timeout_sec}s; "
                 f"see {sample_dir}"
-            ) from exc
-
-        (sample_dir / "stdout.log").write_text(proc.stdout, encoding="utf-8")
-        (sample_dir / "stderr.log").write_text(proc.stderr, encoding="utf-8")
+            )
         (sample_dir / "command.json").write_text(
             json.dumps(
                 {
                     "argv": cmd,
-                    "exit_code": proc.returncode,
+                    "exit_code": exit_code,
                     "timeout_sec": args.per_run_timeout_sec,
                 },
                 indent=2,
@@ -217,12 +232,12 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             encoding="utf-8",
         )
 
-        if proc.returncode not in (0, 1):
+        if exit_code not in (0, 1):
             raise MultiSampleError(
-                f"sample {index} harness exited {proc.returncode}; see {sample_dir}"
+                f"sample {index} harness exited {exit_code}; see {sample_dir}"
             )
 
-        objects = extract_verdict_objects(proc.stdout)
+        objects = extract_verdict_objects(stdout_text)
         if len(objects) != 1:
             raise MultiSampleError(
                 f"sample {index} expected exactly one verdict JSON, found {len(objects)}; "
@@ -233,7 +248,7 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             json.dumps(verdict, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        samples.append(sample_record(index, sample_dir, proc.returncode, verdict))
+        samples.append(sample_record(index, sample_dir, exit_code, verdict))
 
     summary = summarize(
         samples,

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -221,18 +221,25 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             env=env,
             start_new_session=True,
         )
+        # Capture pgid immediately after Popen while proc.pid is guaranteed
+        # alive. We cannot use proc.pid later because Python's communicate()
+        # loop may internally reap the leader via waitpid(WNOHANG) before
+        # TimeoutExpired fires (e.g. when the shell exits early but a child
+        # keeps the pipe open). The pgid remains valid for os.killpg as long
+        # as any group member is alive, which is exactly our target.
+        pgid = os.getpgid(proc.pid)
         timed_out = False
         try:
             stdout_text, stderr_text = proc.communicate(timeout=args.per_run_timeout_sec)
         except subprocess.TimeoutExpired:
             timed_out = True
-            _kill_process_group(proc.pid)
+            _kill_process_group(pgid)
             try:
                 stdout_text, stderr_text = proc.communicate(
                     timeout=POST_KILL_COMMUNICATE_TIMEOUT_SEC
                 )
             except subprocess.TimeoutExpired as exc:
-                _kill_process_group(proc.pid)
+                _kill_process_group(pgid)
                 stdout_text = stream_text(exc.stdout)
                 stderr_text = stream_text(exc.stderr)
         exit_code = proc.returncode

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 from pathlib import Path
 import statistics
@@ -17,6 +18,7 @@ DEFAULT_SAMPLES = 5
 DEFAULT_MAX_MEAN_COV = 0.15
 DEFAULT_MAX_STDEV_COV = 0.03
 DEFAULT_MAX_RUN_COV = 0.25
+DEFAULT_PER_RUN_TIMEOUT_SEC = 600
 
 
 class MultiSampleError(RuntimeError):
@@ -26,8 +28,14 @@ class MultiSampleError(RuntimeError):
 def parse_ratio(raw: str) -> float:
     raw = raw.strip()
     if raw.endswith("%"):
-        return float(raw[:-1]) / 100.0
-    return float(raw)
+        value = float(raw[:-1]) / 100.0
+    else:
+        value = float(raw)
+    if not math.isfinite(value):
+        raise argparse.ArgumentTypeError(f"ratio is not finite: {raw!r}")
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"ratio must be non-negative: {raw!r}")
+    return value
 
 
 def extract_json_objects(text: str) -> list[dict[str, Any]]:
@@ -49,11 +57,28 @@ def extract_json_objects(text: str) -> list[dict[str, Any]]:
     return objects
 
 
+def extract_verdict_objects(text: str) -> list[dict[str, Any]]:
+    return [obj for obj in extract_json_objects(text) if "verdict" in obj]
+
+
 def numeric_field(verdict: dict[str, Any], key: str) -> float:
     value = verdict.get(key)
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise MultiSampleError(f"verdict JSON missing numeric field {key!r}")
-    return float(value)
+    number = float(value)
+    if not math.isfinite(number):
+        raise MultiSampleError(f"verdict JSON field {key!r} is not finite")
+    if number < 0:
+        raise MultiSampleError(f"verdict JSON field {key!r} is negative")
+    return number
+
+
+def timeout_stream_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[str, Any]) -> dict[str, Any]:
@@ -141,12 +166,54 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
         env = os.environ.copy()
         env["ARTIFACT_DIR"] = str(artifact_dir)
         cmd = [str(args.harness), *harness_args]
-        proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+                timeout=args.per_run_timeout_sec,
+            )
+        except subprocess.TimeoutExpired as exc:
+            (sample_dir / "stdout.log").write_text(
+                timeout_stream_text(exc.stdout),
+                encoding="utf-8",
+            )
+            (sample_dir / "stderr.log").write_text(
+                timeout_stream_text(exc.stderr),
+                encoding="utf-8",
+            )
+            (sample_dir / "command.json").write_text(
+                json.dumps(
+                    {
+                        "argv": cmd,
+                        "exit_code": None,
+                        "timeout_sec": args.per_run_timeout_sec,
+                        "timed_out": True,
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            raise MultiSampleError(
+                f"sample {index} harness timed out after {args.per_run_timeout_sec}s; "
+                f"see {sample_dir}"
+            ) from exc
 
         (sample_dir / "stdout.log").write_text(proc.stdout, encoding="utf-8")
         (sample_dir / "stderr.log").write_text(proc.stderr, encoding="utf-8")
         (sample_dir / "command.json").write_text(
-            json.dumps({"argv": cmd, "exit_code": proc.returncode}, indent=2) + "\n",
+            json.dumps(
+                {
+                    "argv": cmd,
+                    "exit_code": proc.returncode,
+                    "timeout_sec": args.per_run_timeout_sec,
+                },
+                indent=2,
+            )
+            + "\n",
             encoding="utf-8",
         )
 
@@ -155,11 +222,11 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
                 f"sample {index} harness exited {proc.returncode}; see {sample_dir}"
             )
 
-        objects = extract_json_objects(proc.stdout)
+        objects = extract_verdict_objects(proc.stdout)
         if len(objects) != 1:
             raise MultiSampleError(
                 f"sample {index} expected exactly one verdict JSON, found {len(objects)}; "
-                f"mixed-CoS output is not supported by this wrapper yet"
+                f"mixed-CoS or missing-verdict output is not supported by this wrapper yet"
             )
         verdict = objects[0]
         (sample_dir / "verdict.json").write_text(
@@ -194,13 +261,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--max-stdev-cov", type=parse_ratio, default=DEFAULT_MAX_STDEV_COV)
     parser.add_argument("--max-run-cov", type=parse_ratio, default=DEFAULT_MAX_RUN_COV)
     parser.add_argument(
+        "--per-run-timeout-sec",
+        type=int,
+        default=DEFAULT_PER_RUN_TIMEOUT_SEC,
+        help="Hard timeout for each fairness-harness run.",
+    )
+    parser.add_argument(
         "harness_args",
         nargs=argparse.REMAINDER,
         help="Arguments passed to fairness-harness.sh. Prefix with -- to separate.",
     )
     args = parser.parse_args(argv)
-    if args.samples < 1:
-        parser.error("--samples must be >= 1")
+    if args.samples < 2:
+        parser.error("--samples must be >= 2")
+    if args.per_run_timeout_sec <= 0:
+        parser.error("--per-run-timeout-sec must be > 0")
     if not args.harness.exists():
         parser.error(f"--harness does not exist: {args.harness}")
     if not os.access(args.harness, os.X_OK):

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Run fairness-harness repeatedly and summarize per-run CoV variance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_SAMPLES = 5
+DEFAULT_MAX_MEAN_COV = 0.15
+DEFAULT_MAX_STDEV_COV = 0.03
+DEFAULT_MAX_RUN_COV = 0.25
+
+
+class MultiSampleError(RuntimeError):
+    pass
+
+
+def parse_ratio(raw: str) -> float:
+    raw = raw.strip()
+    if raw.endswith("%"):
+        return float(raw[:-1]) / 100.0
+    return float(raw)
+
+
+def extract_json_objects(text: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    objects: list[dict[str, Any]] = []
+    idx = 0
+    while idx < len(text):
+        start = text.find("{", idx)
+        if start < 0:
+            break
+        try:
+            obj, end = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            idx = start + 1
+            continue
+        if isinstance(obj, dict):
+            objects.append(obj)
+        idx = start + end
+    return objects
+
+
+def numeric_field(verdict: dict[str, Any], key: str) -> float:
+    value = verdict.get(key)
+    if not isinstance(value, (int, float)):
+        raise MultiSampleError(f"verdict JSON missing numeric field {key!r}")
+    return float(value)
+
+
+def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "sample": index,
+        "sample_dir": str(sample_dir),
+        "exit_code": exit_code,
+        "verdict": verdict.get("verdict"),
+        "observed_cov": numeric_field(verdict, "observed_cov"),
+        "cstruct": verdict.get("cstruct"),
+        "gap": verdict.get("gap"),
+        "aggregate_mbps": verdict.get("aggregate_mbps"),
+        "starved_flow_count": verdict.get("starved_flow_count"),
+        "failure_reasons": verdict.get("failure_reasons", []),
+    }
+
+
+def summarize(
+    samples: list[dict[str, Any]],
+    *,
+    max_mean_cov: float,
+    max_stdev_cov: float,
+    max_run_cov: float,
+) -> dict[str, Any]:
+    observed_covs = [float(s["observed_cov"]) for s in samples]
+    mean_cov = statistics.fmean(observed_covs)
+    stdev_cov = statistics.stdev(observed_covs) if len(observed_covs) > 1 else 0.0
+    max_cov = max(observed_covs)
+    min_cov = min(observed_covs)
+
+    failure_reasons: list[str] = []
+    failing_samples = [s["sample"] for s in samples if s.get("verdict") != "PASS"]
+    if failing_samples:
+        failure_reasons.append(f"sample verdicts failed: {failing_samples}")
+    if mean_cov > max_mean_cov:
+        failure_reasons.append(
+            f"mean observed_cov {mean_cov:.6f} exceeds threshold {max_mean_cov:.6f}"
+        )
+    if stdev_cov > max_stdev_cov:
+        failure_reasons.append(
+            f"sample stdev observed_cov {stdev_cov:.6f} exceeds threshold {max_stdev_cov:.6f}"
+        )
+    if max_cov > max_run_cov:
+        failure_reasons.append(
+            f"max observed_cov {max_cov:.6f} exceeds threshold {max_run_cov:.6f}"
+        )
+
+    return {
+        "verdict": "PASS" if not failure_reasons else "FAIL",
+        "sample_count": len(samples),
+        "thresholds": {
+            "max_mean_cov": max_mean_cov,
+            "max_sample_stdev_cov": max_stdev_cov,
+            "max_run_cov": max_run_cov,
+        },
+        "observed_cov": {
+            "mean": mean_cov,
+            "sample_stdev": stdev_cov,
+            "min": min_cov,
+            "max": max_cov,
+        },
+        "samples": samples,
+        "failure_reasons": failure_reasons,
+    }
+
+
+def run_samples(args: argparse.Namespace) -> dict[str, Any]:
+    harness_args = list(args.harness_args)
+    if harness_args and harness_args[0] == "--":
+        harness_args = harness_args[1:]
+
+    out_dir = args.out_dir
+    if out_dir.exists():
+        raise MultiSampleError(f"--out-dir already exists: {out_dir}")
+    out_dir.mkdir(parents=True)
+
+    samples: list[dict[str, Any]] = []
+    width = len(str(args.samples))
+    for index in range(1, args.samples + 1):
+        sample_dir = out_dir / f"sample-{index:0{width}d}"
+        sample_dir.mkdir()
+        artifact_dir = sample_dir / "artifacts"
+        artifact_dir.mkdir()
+
+        env = os.environ.copy()
+        env["ARTIFACT_DIR"] = str(artifact_dir)
+        cmd = [str(args.harness), *harness_args]
+        proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
+
+        (sample_dir / "stdout.log").write_text(proc.stdout, encoding="utf-8")
+        (sample_dir / "stderr.log").write_text(proc.stderr, encoding="utf-8")
+        (sample_dir / "command.json").write_text(
+            json.dumps({"argv": cmd, "exit_code": proc.returncode}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        if proc.returncode not in (0, 1):
+            raise MultiSampleError(
+                f"sample {index} harness exited {proc.returncode}; see {sample_dir}"
+            )
+
+        objects = extract_json_objects(proc.stdout)
+        if len(objects) != 1:
+            raise MultiSampleError(
+                f"sample {index} expected exactly one verdict JSON, found {len(objects)}; "
+                f"mixed-CoS output is not supported by this wrapper yet"
+            )
+        verdict = objects[0]
+        (sample_dir / "verdict.json").write_text(
+            json.dumps(verdict, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        samples.append(sample_record(index, sample_dir, proc.returncode, verdict))
+
+    summary = summarize(
+        samples,
+        max_mean_cov=args.max_mean_cov,
+        max_stdev_cov=args.max_stdev_cov,
+        max_run_cov=args.max_run_cov,
+    )
+    summary["out_dir"] = str(out_dir)
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    default_harness = Path(__file__).with_name("fairness-harness.sh")
+    parser = argparse.ArgumentParser(
+        description="Run fairness-harness N times and summarize observed CoV stability.",
+    )
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--harness", type=Path, default=default_harness)
+    parser.add_argument("--max-mean-cov", type=parse_ratio, default=DEFAULT_MAX_MEAN_COV)
+    parser.add_argument("--max-stdev-cov", type=parse_ratio, default=DEFAULT_MAX_STDEV_COV)
+    parser.add_argument("--max-run-cov", type=parse_ratio, default=DEFAULT_MAX_RUN_COV)
+    parser.add_argument(
+        "harness_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments passed to fairness-harness.sh. Prefix with -- to separate.",
+    )
+    args = parser.parse_args(argv)
+    if args.samples < 1:
+        parser.error("--samples must be >= 1")
+    if not args.harness.exists():
+        parser.error(f"--harness does not exist: {args.harness}")
+    if not os.access(args.harness, os.X_OK):
+        parser.error(f"--harness is not executable: {args.harness}")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        summary = run_samples(args)
+    except MultiSampleError as exc:
+        print(f"fairness-multi-sample: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -29,8 +29,8 @@ FAIRNESS_EVAL_VERDICT_KEYS = {
     "failure_reasons",
     "distribution_a_i",
     "n_active",
-    "aggregate_mbps",
     "saturated",
+    "a_i_sum_check_ok",
     "starved_flow_count",
 }
 
@@ -98,6 +98,21 @@ def numeric_field(verdict: dict[str, Any], key: str) -> float:
     return number
 
 
+def optional_numeric_field(verdict: dict[str, Any], key: str) -> float | None:
+    if key not in verdict or verdict[key] is None:
+        return None
+    return numeric_field(verdict, key)
+
+
+def integer_field(verdict: dict[str, Any], key: str) -> int:
+    value = verdict.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MultiSampleError(f"verdict JSON missing integer field {key!r}")
+    if value < 0:
+        raise MultiSampleError(f"verdict JSON field {key!r} is negative")
+    return value
+
+
 def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[str, Any]) -> dict[str, Any]:
     return {
         "sample": index,
@@ -105,10 +120,10 @@ def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[st
         "exit_code": exit_code,
         "verdict": verdict.get("verdict"),
         "observed_cov": numeric_field(verdict, "observed_cov"),
-        "cstruct": verdict.get("cstruct"),
-        "gap": verdict.get("gap"),
-        "aggregate_mbps": verdict.get("aggregate_mbps"),
-        "starved_flow_count": verdict.get("starved_flow_count"),
+        "cstruct": numeric_field(verdict, "cstruct"),
+        "gap": numeric_field(verdict, "gap"),
+        "aggregate_mbps": optional_numeric_field(verdict, "aggregate_mbps"),
+        "starved_flow_count": integer_field(verdict, "starved_flow_count"),
         "failure_reasons": verdict.get("failure_reasons", []),
     }
 

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -20,6 +20,19 @@ DEFAULT_MAX_MEAN_COV = 0.15
 DEFAULT_MAX_STDEV_COV = 0.03
 DEFAULT_MAX_RUN_COV = 0.25
 DEFAULT_PER_RUN_TIMEOUT_SEC = 600
+POST_KILL_COMMUNICATE_TIMEOUT_SEC = 5
+FAIRNESS_EVAL_VERDICT_KEYS = {
+    "verdict",
+    "observed_cov",
+    "cstruct",
+    "gap",
+    "failure_reasons",
+    "distribution_a_i",
+    "n_active",
+    "aggregate_mbps",
+    "saturated",
+    "starved_flow_count",
+}
 
 
 class MultiSampleError(RuntimeError):
@@ -59,12 +72,18 @@ def extract_json_objects(text: str) -> list[dict[str, Any]]:
 
 
 def extract_verdict_objects(text: str) -> list[dict[str, Any]]:
-    _required = {"verdict", "observed_cov"}
-    _discriminators = {"cstruct", "gap", "failure_reasons"}
     return [
         obj for obj in extract_json_objects(text)
-        if _required.issubset(obj) and bool(_discriminators & obj.keys())
+        if FAIRNESS_EVAL_VERDICT_KEYS.issubset(obj)
     ]
+
+
+def stream_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 def numeric_field(verdict: dict[str, Any], key: str) -> float:
@@ -192,11 +211,15 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             stdout_text, stderr_text = proc.communicate(timeout=args.per_run_timeout_sec)
         except subprocess.TimeoutExpired:
             timed_out = True
+            _kill_process_group(proc.pid)
             try:
-                _kill_process_group(os.getpgid(proc.pid))
-            except ProcessLookupError:
-                pass
-            stdout_text, stderr_text = proc.communicate()
+                stdout_text, stderr_text = proc.communicate(
+                    timeout=POST_KILL_COMMUNICATE_TIMEOUT_SEC
+                )
+            except subprocess.TimeoutExpired as exc:
+                _kill_process_group(proc.pid)
+                stdout_text = stream_text(exc.stdout)
+                stderr_text = stream_text(exc.stderr)
         exit_code = proc.returncode
 
         (sample_dir / "stdout.log").write_text(stdout_text, encoding="utf-8")

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 
 
@@ -30,10 +31,17 @@ class FairnessMultiSampleTest(unittest.TestCase):
     def test_extract_verdict_objects_ignores_log_json(self) -> None:
         text = (
             'log {"event":"progress","observed_cov":999}\n'
-            '{"verdict":"PASS","observed_cov":0.1}\n'
+            '{"verdict":"PASS","observed_cov":0.1,"failure_reasons":[]}\n'
         )
         objects = fairness_multi_sample.extract_verdict_objects(text)
-        self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1}])
+        self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1, "failure_reasons": []}])
+
+    def test_extract_verdict_objects_rejects_schema_incomplete_object(self) -> None:
+        # An object with verdict+observed_cov but no discriminator field must be rejected.
+        # This prevents a two-field log line from being misidentified as a fairness-eval result.
+        text = '{"verdict":"PASS","observed_cov":0.01}\n'
+        objects = fairness_multi_sample.extract_verdict_objects(text)
+        self.assertEqual(objects, [])
 
     def test_numeric_field_rejects_non_finite_negative_and_bool(self) -> None:
         for value in [True, False, math.nan, math.inf, -math.inf, -0.1, "0.1"]:
@@ -124,7 +132,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     #!/usr/bin/env bash
-                    printf '{"verdict":"PASS","observed_cov":NaN}\\n'
+                    printf '{"verdict":"PASS","observed_cov":NaN,"cstruct":0.0,"gap":0.0,"failure_reasons":[]}\\n'
                     """
                 ),
                 encoding="utf-8",
@@ -186,6 +194,58 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertIn("timed out", result.stderr)
             command = json.loads((out_dir / "sample-1" / "command.json").read_text(encoding="utf-8"))
             self.assertTrue(command["timed_out"])
+
+    def test_cli_timeout_kills_process_group(self) -> None:
+        # Verify that process-group kill cleans up descendant processes, not just the shell.
+        # The harness spawns a background child that writes a sentinel file after 3 s.
+        # With a 1-second timeout the wrapper should kill the whole group before
+        # the sentinel is written; the sentinel must be absent after the run.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sentinel = tmp_path / "child_ran"
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    (sleep 3 && touch {sentinel}) &
+                    sleep 3
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--per-run-timeout-sec",
+                    "1",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("timed out", result.stderr)
+            # Poll for up to 2s to confirm the sentinel is never written.
+            # SIGKILL is unblockable so it cannot appear after killpg completes,
+            # but poll briefly to catch any kernel-scheduling latency.
+            sentinel_written = False
+            for _ in range(4):
+                if sentinel.exists():
+                    sentinel_written = True
+                    break
+                time.sleep(0.5)
+            self.assertFalse(sentinel_written, "descendant child was not killed by process-group kill")
 
     def test_cli_rejects_samples_one(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -40,6 +40,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
             "distribution_a_i": [1],
             "n_active": 1,
             "saturated": True,
+            "a_i_sum_check_ok": True,
         }
         text = (
             'log {"event":"progress","observed_cov":999}\n'
@@ -61,6 +62,34 @@ class FairnessMultiSampleTest(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(fairness_multi_sample.MultiSampleError):
                     fairness_multi_sample.numeric_field({"observed_cov": value}, "observed_cov")
+
+    def test_sample_record_validates_numeric_summary_fields(self) -> None:
+        base_verdict = {
+            "verdict": "PASS",
+            "observed_cov": 0.1,
+            "cstruct": 0.0,
+            "gap": 0.0,
+            "aggregate_mbps": 1.0,
+            "starved_flow_count": 0,
+            "failure_reasons": [],
+            "distribution_a_i": [1],
+            "n_active": 1,
+            "saturated": True,
+            "a_i_sum_check_ok": True,
+        }
+        for key, value in [
+            ("cstruct", -0.1),
+            ("gap", math.nan),
+            ("aggregate_mbps", math.inf),
+            ("starved_flow_count", -1),
+            ("starved_flow_count", 1.5),
+            ("starved_flow_count", True),
+        ]:
+            verdict = dict(base_verdict)
+            verdict[key] = value
+            with self.subTest(key=key, value=value):
+                with self.assertRaises(fairness_multi_sample.MultiSampleError):
+                    fairness_multi_sample.sample_record(1, Path("sample-1"), 0, verdict)
 
     def test_summary_fails_thresholds(self) -> None:
         summary = fairness_multi_sample.summarize(
@@ -104,7 +133,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                     esac
                     echo "harness log line"
                     echo '{"event":"progress","observed_cov":99}'
-                    printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true}\\n' "$cov"
+                    printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true,"a_i_sum_check_ok":true}\\n' "$cov"
                     """
                 ),
                 encoding="utf-8",
@@ -145,7 +174,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     #!/usr/bin/env bash
-                    printf '{"verdict":"PASS","observed_cov":NaN,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true}\\n'
+                    printf '{"verdict":"PASS","observed_cov":NaN,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true,"a_i_sum_check_ok":true}\\n'
                     """
                 ),
                 encoding="utf-8",

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -29,17 +29,30 @@ class FairnessMultiSampleTest(unittest.TestCase):
         self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1}])
 
     def test_extract_verdict_objects_ignores_log_json(self) -> None:
+        verdict = {
+            "verdict": "PASS",
+            "observed_cov": 0.1,
+            "cstruct": 0.0,
+            "gap": 0.0,
+            "aggregate_mbps": 1.0,
+            "starved_flow_count": 0,
+            "failure_reasons": [],
+            "distribution_a_i": [1],
+            "n_active": 1,
+            "saturated": True,
+        }
         text = (
             'log {"event":"progress","observed_cov":999}\n'
-            '{"verdict":"PASS","observed_cov":0.1,"failure_reasons":[]}\n'
+            + json.dumps(verdict)
+            + "\n"
         )
         objects = fairness_multi_sample.extract_verdict_objects(text)
-        self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1, "failure_reasons": []}])
+        self.assertEqual(objects, [verdict])
 
     def test_extract_verdict_objects_rejects_schema_incomplete_object(self) -> None:
-        # An object with verdict+observed_cov but no discriminator field must be rejected.
-        # This prevents a two-field log line from being misidentified as a fairness-eval result.
-        text = '{"verdict":"PASS","observed_cov":0.01}\n'
+        # A log object that looks verdict-like but lacks the full fairness-eval
+        # schema must not be accepted as a measurement result.
+        text = '{"verdict":"PASS","observed_cov":0.01,"failure_reasons":[]}\n'
         objects = fairness_multi_sample.extract_verdict_objects(text)
         self.assertEqual(objects, [])
 
@@ -91,7 +104,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                     esac
                     echo "harness log line"
                     echo '{"event":"progress","observed_cov":99}'
-                    printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[]}\\n' "$cov"
+                    printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true}\\n' "$cov"
                     """
                 ),
                 encoding="utf-8",
@@ -132,7 +145,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     #!/usr/bin/env bash
-                    printf '{"verdict":"PASS","observed_cov":NaN,"cstruct":0.0,"gap":0.0,"failure_reasons":[]}\\n'
+                    printf '{"verdict":"PASS","observed_cov":NaN,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true}\\n'
                     """
                 ),
                 encoding="utf-8",
@@ -246,6 +259,46 @@ class FairnessMultiSampleTest(unittest.TestCase):
                     break
                 time.sleep(0.5)
             self.assertFalse(sentinel_written, "descendant child was not killed by process-group kill")
+
+    def test_cli_timeout_after_leader_exit_does_not_hang(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    (sleep 10 && echo child-still-running) &
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--per-run-timeout-sec",
+                    "1",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=4,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("timed out", result.stderr)
+            command = json.loads((out_dir / "sample-1" / "command.json").read_text(encoding="utf-8"))
+            self.assertTrue(command["timed_out"])
 
     def test_cli_rejects_samples_one(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import math
 from pathlib import Path
 import subprocess
 import sys
@@ -25,6 +26,20 @@ class FairnessMultiSampleTest(unittest.TestCase):
         text = 'log {not json}\n{"verdict":"PASS","observed_cov":0.1}\n'
         objects = fairness_multi_sample.extract_json_objects(text)
         self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1}])
+
+    def test_extract_verdict_objects_ignores_log_json(self) -> None:
+        text = (
+            'log {"event":"progress","observed_cov":999}\n'
+            '{"verdict":"PASS","observed_cov":0.1}\n'
+        )
+        objects = fairness_multi_sample.extract_verdict_objects(text)
+        self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1}])
+
+    def test_numeric_field_rejects_non_finite_negative_and_bool(self) -> None:
+        for value in [True, False, math.nan, math.inf, -math.inf, -0.1, "0.1"]:
+            with self.subTest(value=value):
+                with self.assertRaises(fairness_multi_sample.MultiSampleError):
+                    fairness_multi_sample.numeric_field({"observed_cov": value}, "observed_cov")
 
     def test_summary_fails_thresholds(self) -> None:
         summary = fairness_multi_sample.summarize(
@@ -67,6 +82,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                       *) cov=0.11 ;;
                     esac
                     echo "harness log line"
+                    echo '{"event":"progress","observed_cov":99}'
                     printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[]}\\n' "$cov"
                     """
                 ),
@@ -99,6 +115,162 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertAlmostEqual(summary["observed_cov"]["mean"], 0.11)
             self.assertTrue((out_dir / "sample-1" / "verdict.json").exists())
             self.assertTrue((out_dir / "sample-2" / "artifacts").is_dir())
+
+    def test_cli_rejects_nan_observed_cov(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    printf '{"verdict":"PASS","observed_cov":NaN}\\n'
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--out-dir",
+                    str(tmp_path / "out"),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not finite", result.stderr)
+
+    def test_cli_times_out_harness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    sleep 2
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--per-run-timeout-sec",
+                    "1",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("timed out", result.stderr)
+            command = json.loads((out_dir / "sample-1" / "command.json").read_text(encoding="utf-8"))
+            self.assertTrue(command["timed_out"])
+
+    def test_cli_rejects_samples_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            harness.chmod(0o755)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "1",
+                    "--out-dir",
+                    str(tmp_path / "out"),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--samples must be >= 2", result.stderr)
+
+    def test_cli_rejects_harness_exit_two(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                "#!/usr/bin/env bash\necho before-error\nexit 2\n",
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("harness exited 2", result.stderr)
+            self.assertIn(
+                "before-error",
+                (out_dir / "sample-1" / "stdout.log").read_text(encoding="utf-8"),
+            )
+
+    def test_cli_rejects_existing_out_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            out_dir.mkdir()
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--out-dir already exists", result.stderr)
 
 
 if __name__ == "__main__":

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("fairness_multi_sample.py")
+SPEC = importlib.util.spec_from_file_location("fairness_multi_sample", MODULE_PATH)
+assert SPEC is not None
+fairness_multi_sample = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(fairness_multi_sample)
+
+
+class FairnessMultiSampleTest(unittest.TestCase):
+    def test_extract_json_objects_skips_non_json_logs(self) -> None:
+        text = 'log {not json}\n{"verdict":"PASS","observed_cov":0.1}\n'
+        objects = fairness_multi_sample.extract_json_objects(text)
+        self.assertEqual(objects, [{"verdict": "PASS", "observed_cov": 0.1}])
+
+    def test_summary_fails_thresholds(self) -> None:
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.10,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.30,
+                    "exit_code": 0,
+                },
+            ],
+            max_mean_cov=0.15,
+            max_stdev_cov=0.03,
+            max_run_cov=0.25,
+        )
+        self.assertEqual(summary["verdict"], "FAIL")
+        self.assertGreater(summary["observed_cov"]["mean"], 0.15)
+        self.assertGreater(summary["observed_cov"]["sample_stdev"], 0.03)
+        self.assertGreater(summary["observed_cov"]["max"], 0.25)
+
+    def test_cli_runs_fake_harness_and_writes_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    sample=$(basename "$(dirname "${ARTIFACT_DIR}")")
+                    case "$sample" in
+                      sample-1) cov=0.10 ;;
+                      sample-2) cov=0.12 ;;
+                      *) cov=0.11 ;;
+                    esac
+                    echo "harness log line"
+                    printf '{"verdict":"PASS","observed_cov":%s,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[]}\\n' "$cov"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--samples",
+                    "2",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                    "--",
+                    "target.example",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(summary["verdict"], "PASS")
+            self.assertAlmostEqual(summary["observed_cov"]["mean"], 0.11)
+            self.assertTrue((out_dir / "sample-1" / "verdict.json").exists())
+            self.assertTrue((out_dir / "sample-2" / "artifacts").is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test/incus/fairness_multi_sample.py to run fairness-harness repeatedly and summarize observed CoV mean/stdev/max
- preserve per-sample stdout, stderr, command, verdict, and placement artifacts
- harden the wrapper with per-run timeout/process-group cleanup, canonical verdict-key JSON filtering, finite/non-negative summary numeric validation, samples>=2, and fail-closed output-dir handling
- document the v8 five-sample runbook and link it from the per-5-tuple state doc

Refs #1232

## Validation
- python3 -m py_compile test/incus/fairness_multi_sample.py test/incus/fairness_multi_sample_test.py
- python3 test/incus/fairness_multi_sample_test.py
- git diff --check