### PR TITLE
Document TCP head-start fairness floor

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T06:29:27Z
+  - **Action**: PR round-2 review follow-up — expanded AFD acronym at first use (line 5), changed `observed_cov` to `observed_CoV` in prose formulas (lines 86, 99), made epsilon explicit as 0.05.
+  - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T00:30:00Z
   - **Action**: PR #1267 round-2 review follow-up — fixed fairness throughput window boundary pruning/rate denominator coupling to prevent false-positive saturation at steady sub-cap traffic, and added a regression test for the 10s-scrape/30s-window boundary case.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T07:50:00Z
+  - **Action**: PR #1274 Copilot follow-up — use verdict JSON key names consistently in the Accepted Path publish list.
+  - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T06:46:48Z
   - **Action**: PR #1274 review follow-up — wrapped TCP head-start policy prose and made the observed CoV prose/JSON-field distinction explicit.
   - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-12
 
+- **Timestamp**: 2026-05-12T06:46:48Z
+  - **Action**: PR #1274 review follow-up — wrapped TCP head-start policy prose and made the observed CoV prose/JSON-field distinction explicit.
+  - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-12T06:29:27Z
   - **Action**: PR round-2 review follow-up — expanded AFD acronym at first use (line 5), changed `observed_cov` to `observed_CoV` in prose formulas (lines 86, 99), made epsilon explicit as 0.05.
   - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`

--- a/docs/per-5-tuple/even-flows-recipe.md
+++ b/docs/per-5-tuple/even-flows-recipe.md
@@ -90,7 +90,9 @@ This is a **TCP-level** effect, not a dataplane scheduling issue.
 The dataplane-only ECN/RWND mitigation analysis is recorded in
 `docs/per-5-tuple/tcp-head-start-floor.md`; do not reopen the AFD
 path unless a fresh multi-sample harness run satisfies that document's
-revisit criteria.
+revisit criteria. This does not disable the existing CoS-admission ECN
+path; it only rejects a new leader-selective TCP head-start policing
+loop as the default answer.
 
 Mitigation:
 - `tc-fq` (fair queueing qdisc) on the iperf3 sender's egress.

--- a/docs/per-5-tuple/even-flows-recipe.md
+++ b/docs/per-5-tuple/even-flows-recipe.md
@@ -87,6 +87,10 @@ under shared bottleneck — the leading flow's cwnd never re-converges
 once the others arrive.
 
 This is a **TCP-level** effect, not a dataplane scheduling issue.
+The dataplane-only ECN/RWND mitigation analysis is recorded in
+`docs/per-5-tuple/tcp-head-start-floor.md`; do not reopen the AFD
+path unless a fresh multi-sample harness run satisfies that document's
+revisit criteria.
 
 Mitigation:
 - `tc-fq` (fair queueing qdisc) on the iperf3 sender's egress.

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -104,6 +104,7 @@ because both ship signal to a future reader, but they fail in
 | # | Issue | Killed | Reason |
 |---|-------|--------|--------|
 | C1 | #1245 | EMPIRICAL-KILL | Multi-receiver test methodology: 5-sample CoS-off comparison (12 streams to 1 port vs 12 streams across 6 ports each running its own iperf3 -s) showed CoV mean delta 2.2pp (51.7% vs 49.5%) — within sample noise. Receiver-side TCP coupling is NOT the variance source. Confounds-only, not a dataplane-mechanism kill. |
+| C2 | #1233 | DOC-RESOLVED | TCP cwnd head-start is a sender/test-workload artifact documented in `docs/per-5-tuple/tcp-head-start-floor.md`. xpf keeps existing CoS-admission ECN, but does not add a new leader-selective AFD ECN/drop or RWND clamp loop unless the multi-sample harness produces an actionable FAIL under the documented revisit criteria. |
 
 ## Multinomial fairness ceiling
 

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -1,0 +1,97 @@
+# TCP Head-Start Fairness Floor
+
+Issue #1233 asks whether xpf should add a dataplane-only mechanism to
+mask the iperf3 sender's TCP head-start effect. Current answer:
+**do not implement ECN or receive-window clamping in the dataplane
+unless a fresh, multi-sample harness run produces an actionable
+fairness failure.**
+
+## Evidence
+
+The loss-cluster sweep in `docs/per-5-tuple/even-flows-recipe.md`
+separates three effects:
+
+- RSS placement determines the structural `Cstruct` ceiling.
+- Worker CPU isolation affects per-worker capacity.
+- The first iperf3 stream can retain a larger cwnd after the other
+  streams join, even after `-O 30` warmup omission and long runs.
+
+The strongest counterexample is the sub-saturation recipe: with fixed
+source-port placement plus per-flow sender pacing, the same dataplane
+delivered 12 flows within about 1.5% of each other. That makes the
+head-start effect a sender/TCP behavior, not proof of an xpf scheduler
+defect.
+
+## Option A: Per-Flow ECN Marking
+
+Per-flow ECN marking is the #1211 AFD design under a narrower name.
+It requires:
+
+- ECN-capable TCP endpoints that negotiated ECN on the flow.
+- A per-flow lead/lag estimator in the forwarding path.
+- A control loop that marks only the leading flow strongly enough to
+  reduce cwnd, without causing oscillation or starving it.
+- Hot-path accounting that does not add cross-worker cache-line
+  contention.
+
+It also acts late: by the time xpf can observe a head-start leader,
+that flow already has a larger cwnd. If the sender does not react to
+CE marks, the mechanism is inert; if it does react, convergence is
+sender-algorithm dependent. Reopen this class only under the archived
+#1211 revisit criteria: a real harness FAIL, ECN-responsive senders,
+no app/server bottleneck, and a prototype that avoids hot-path shared
+atomics.
+
+## Option B: Receive-Window Clamping
+
+Firewall-side RWND clamping would rewrite ACKs in the reverse
+direction to reduce the advertised receive window of the leading
+flow. It is technically possible, but it is not a clean xpf product
+feature:
+
+- The dataplane must track TCP window scale from SYN/SYN-ACK before
+  it can compute a meaningful byte window.
+- It must rewrite ACK headers and TCP checksums on every controlled
+  flow in the reverse direction.
+- It limits throughput by `min(cwnd, rwnd)`, so a bad target can drop
+  aggregate throughput instead of transferring bandwidth to lagging
+  flows.
+- It interacts with receiver autotuning, delayed ACKs, zero-window
+  probes, application receive buffers, and middlebox expectations.
+- It changes TCP semantics for all affected applications, not just
+  iperf3 test traffic.
+
+RWND clamping is a last-resort traffic-policing feature, not the
+right default response to a benchmark sender artifact.
+
+## Accepted Path
+
+For measurements whose purpose is to isolate dataplane fairness:
+
+- Use sender-side pacing (`tc-fq`, `SO_MAX_PACING_RATE`, or iperf3
+  `-b`) when the test intent is equal per-flow offered load.
+- Use fixed or swept source ports when the test intent is a known RSS
+  distribution.
+- Publish `observed_cov`, `Cstruct`, `gap`, starved-flow count,
+  aggregate throughput, sender CPU utilization, and the multi-sample
+  mean/stdev/max CoV.
+
+For production traffic, xpf's fairness contract remains
+workload-relative: PASS means `observed_cov <= Cstruct + epsilon` with
+no starved flows. A saturated TCP sender that creates unequal offered
+load is outside what a transparent AF_XDP firewall can fix without
+becoming an endpoint-side pacing or TCP-policing device.
+
+## Revisit Criteria
+
+Open a new implementation issue only if all of these are true:
+
+1. The current userspace dataplane fails the harness on a real
+   workload after multi-sample measurement.
+2. The failure is `observed_cov - Cstruct > 0.05` or starvation, not
+   merely a high absolute CoV caused by RSS structure.
+3. Sender and receiver CPU are not the bottleneck.
+4. The endpoints are known to be responsive to the proposed signal
+   (ECN for ECN marking, receive-window limiting for RWND clamping).
+5. The proposal includes a hot-path design with no shared per-packet
+   atomic counter or cross-NUMA cache-line bounce.

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -78,9 +78,9 @@ For measurements whose purpose is to isolate dataplane fairness:
   `-b`) when the test intent is equal per-flow offered load.
 - Use fixed or swept source ports when the test intent is a known RSS
   distribution.
-- Publish observed CoV (`observed_cov` in verdict JSON), `Cstruct`,
-  `gap`, starved-flow count, aggregate throughput, sender CPU
-  utilization, and the multi-sample mean/stdev/max CoV.
+- Publish verdict JSON keys `observed_cov`, `cstruct`, `gap`,
+  `starved_flow_count`, `aggregate_mbps`, and the iperf CPU fields,
+  plus the multi-sample mean/stdev/max CoV.
 
 For production traffic, xpf's fairness contract remains
 workload-relative. The PR #1217/#1220 gate passes only when there are

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -2,11 +2,12 @@
 
 Issue #1233 asks whether xpf should add a dataplane-only mechanism to
 mask the iperf3 sender's TCP head-start effect. Current answer:
-**do not add a new Approximate Fair Dropping (AFD)-style leader-selective ECN/drop overlay or
-receive-window clamping mechanism unless a fresh, multi-sample harness
-run produces an actionable fairness failure.** This does not change
-xpf's existing CoS-admission/AQM ECN behavior; it rejects a new
-per-flow TCP head-start policing loop in the forwarding path.
+**do not add a new Approximate Fair Dropping (AFD)-style
+leader-selective ECN/drop overlay or receive-window clamping mechanism
+unless a fresh, multi-sample harness run produces an actionable fairness
+failure.** This does not change xpf's existing CoS-admission/AQM ECN
+behavior; it rejects a new per-flow TCP head-start policing loop in the
+forwarding path.
 
 ## Evidence
 
@@ -77,18 +78,18 @@ For measurements whose purpose is to isolate dataplane fairness:
   `-b`) when the test intent is equal per-flow offered load.
 - Use fixed or swept source ports when the test intent is a known RSS
   distribution.
-- Publish `observed_cov`, `Cstruct`, `gap`, starved-flow count,
-  aggregate throughput, sender CPU utilization, and the multi-sample
-  mean/stdev/max CoV.
+- Publish observed CoV (`observed_cov` in verdict JSON), `Cstruct`,
+  `gap`, starved-flow count, aggregate throughput, sender CPU
+  utilization, and the multi-sample mean/stdev/max CoV.
 
 For production traffic, xpf's fairness contract remains
 workload-relative. The PR #1217/#1220 gate passes only when there are
-no starved flows, `observed_CoV ≤ Cstruct + epsilon` (epsilon = 0.05), any configured
-RSS/workload expectation is satisfied, saturated runs clear the
-aggregate-throughput gate, and optional mouse probes stay within the
-p99 SLA. A saturated TCP sender that creates unequal offered load is
-outside what a transparent AF_XDP firewall can fix without becoming an
-endpoint-side pacing or TCP-policing device.
+no starved flows, `observed_CoV ≤ Cstruct + epsilon` (`epsilon = 0.05`),
+any configured RSS/workload expectation is satisfied, saturated runs
+clear the aggregate-throughput gate, and optional mouse probes stay
+within the p99 SLA. A saturated TCP sender that creates unequal offered
+load is outside what a transparent AF_XDP firewall can fix without
+becoming an endpoint-side pacing or TCP-policing device.
 
 ## Revisit Criteria
 

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -2,7 +2,7 @@
 
 Issue #1233 asks whether xpf should add a dataplane-only mechanism to
 mask the iperf3 sender's TCP head-start effect. Current answer:
-**do not add a new AFD-style leader-selective ECN/drop overlay or
+**do not add a new Approximate Fair Dropping (AFD)-style leader-selective ECN/drop overlay or
 receive-window clamping mechanism unless a fresh, multi-sample harness
 run produces an actionable fairness failure.** This does not change
 xpf's existing CoS-admission/AQM ECN behavior; it rejects a new
@@ -83,7 +83,7 @@ For measurements whose purpose is to isolate dataplane fairness:
 
 For production traffic, xpf's fairness contract remains
 workload-relative. The PR #1217/#1220 gate passes only when there are
-no starved flows, `observed_cov <= Cstruct + epsilon`, any configured
+no starved flows, `observed_CoV ≤ Cstruct + epsilon` (epsilon = 0.05), any configured
 RSS/workload expectation is satisfied, saturated runs clear the
 aggregate-throughput gate, and optional mouse probes stay within the
 p99 SLA. A saturated TCP sender that creates unequal offered load is
@@ -96,7 +96,7 @@ Open a new implementation issue only if all of these are true:
 
 1. The current userspace dataplane fails the harness on a real
    workload after multi-sample measurement.
-2. The failure is `observed_cov - Cstruct > 0.05` or starvation, not
+2. The failure is `observed_CoV - Cstruct > 0.05` or starvation, not
    merely a high absolute CoV caused by RSS structure.
 3. Sender and receiver CPU are not the bottleneck.
 4. The endpoints are known to be responsive to the proposed signal

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -2,9 +2,11 @@
 
 Issue #1233 asks whether xpf should add a dataplane-only mechanism to
 mask the iperf3 sender's TCP head-start effect. Current answer:
-**do not implement ECN or receive-window clamping in the dataplane
-unless a fresh, multi-sample harness run produces an actionable
-fairness failure.**
+**do not add a new AFD-style leader-selective ECN/drop overlay or
+receive-window clamping mechanism unless a fresh, multi-sample harness
+run produces an actionable fairness failure.** This does not change
+xpf's existing CoS-admission/AQM ECN behavior; it rejects a new
+per-flow TCP head-start policing loop in the forwarding path.
 
 ## Evidence
 
@@ -22,10 +24,11 @@ delivered 12 flows within about 1.5% of each other. That makes the
 head-start effect a sender/TCP behavior, not proof of an xpf scheduler
 defect.
 
-## Option A: Per-Flow ECN Marking
+## Option A: Per-Flow AFD ECN/Drop Overlay
 
-Per-flow ECN marking is the #1211 AFD design under a narrower name.
-It requires:
+Per-flow ECN marking for TCP head-start correction is the #1211
+Approximate Fair Dropping (AFD) design under a narrower name. It
+requires:
 
 - ECN-capable TCP endpoints that negotiated ECN on the flow.
 - A per-flow lead/lag estimator in the forwarding path.
@@ -38,9 +41,11 @@ It also acts late: by the time xpf can observe a head-start leader,
 that flow already has a larger cwnd. If the sender does not react to
 CE marks, the mechanism is inert; if it does react, convergence is
 sender-algorithm dependent. Reopen this class only under the archived
-#1211 revisit criteria: a real harness FAIL, ECN-responsive senders,
-no app/server bottleneck, and a prototype that avoids hot-path shared
-atomics.
+#1211 revisit criteria in
+`docs/per-5-tuple/path2-archive/CLOSING-RATIONALE.md` and
+`docs/per-5-tuple/path2-archive/plan-v10.md`: a real harness FAIL,
+ECN-responsive senders, no app/server bottleneck, and a prototype that
+avoids contended shared per-packet writes.
 
 ## Option B: Receive-Window Clamping
 
@@ -77,10 +82,13 @@ For measurements whose purpose is to isolate dataplane fairness:
   mean/stdev/max CoV.
 
 For production traffic, xpf's fairness contract remains
-workload-relative: PASS means `observed_cov <= Cstruct + epsilon` with
-no starved flows. A saturated TCP sender that creates unequal offered
-load is outside what a transparent AF_XDP firewall can fix without
-becoming an endpoint-side pacing or TCP-policing device.
+workload-relative. The PR #1217/#1220 gate passes only when there are
+no starved flows, `observed_cov <= Cstruct + epsilon`, any configured
+RSS/workload expectation is satisfied, saturated runs clear the
+aggregate-throughput gate, and optional mouse probes stay within the
+p99 SLA. A saturated TCP sender that creates unequal offered load is
+outside what a transparent AF_XDP firewall can fix without becoming an
+endpoint-side pacing or TCP-policing device.
 
 ## Revisit Criteria
 
@@ -93,5 +101,14 @@ Open a new implementation issue only if all of these are true:
 3. Sender and receiver CPU are not the bottleneck.
 4. The endpoints are known to be responsive to the proposed signal
    (ECN for ECN marking, receive-window limiting for RWND clamping).
-5. The proposal includes a hot-path design with no shared per-packet
-   atomic counter or cross-NUMA cache-line bounce.
+5. The proposal includes a hot-path design with no contended shared
+   per-packet writes, such as a shared atomic counter or cross-NUMA
+   cache-line bounce in the forwarding loop.
+
+## Resolution for #1233
+
+Issue #1233 is resolved as documentation and measurement policy, not a
+dataplane feature. The accepted mitigation is sender-side pacing/source
+port control for test workloads, plus the multi-sample fairness gate
+from PR #1220. Any future dataplane ECN/drop or RWND proposal must open
+a new issue and satisfy the revisit criteria above.


### PR DESCRIPTION
## Summary
- document why a new AFD-style leader-selective ECN/drop overlay and RWND clamping are not production-default fixes for sender TCP head-start
- distinguish that policy from the existing CoS-admission/AQM ECN path
- define the accepted measurement path: sender pacing/source-port control plus multi-sample reporting
- add explicit revisit criteria before opening fresh dataplane mitigation work

Closes #1233

## Validation
- git diff --check