### PR TITLE
Report iperf diagnostics in fairness eval

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -228,16 +228,29 @@ Any fairness measurement run MUST report:
 8. **Aggregate retransmits**: total retransmits across all senders
    (`iperf_retransmits` in `fairness-eval`). Diagnostic; not a hard
    gate.
-9. **iperf CPU utilization**: host/remote totals plus the derived
-   sender-side total/user/system percentages from iperf3's
-   `cpu_utilization_percent`. Diagnostic; not a hard gate, but needed
-   to separate dataplane unfairness from sender or receiver saturation.
+9. **iperf CPU utilization, when present in iperf3 JSON**:
+   host/remote totals plus the derived sender-side total/user/system
+   percentages from iperf3's `cpu_utilization_percent`. Diagnostic;
+   not a hard gate, but needed to separate dataplane unfairness from
+   sender or receiver saturation. Absence of these optional fields means
+   missing diagnostic context, not proof that CPU was healthy.
 10. **ECN marks/drops** (if AQM is enabled): total CE marks and
    AQM drops. Diagnostic for future Path 2 v2 work.
 11. **Mouse p99 latency** (when mouse probes are present).
 12. **Steady-state window**: explicit start/end timestamps,
     excluding the first 5 seconds (warmup) and any final
     sender-shutdown bursts.
+
+The `fairness-eval` verdict always includes `iperf_retransmits` and
+`iperf_reverse`. When iperf3 exports `end.cpu_utilization_percent`, the
+verdict also includes `iperf_cpu_host_total_percent`,
+`iperf_cpu_host_user_percent`, `iperf_cpu_host_system_percent`,
+`iperf_cpu_remote_total_percent`, `iperf_cpu_remote_user_percent`,
+`iperf_cpu_remote_system_percent`, `iperf_sender_cpu_total_percent`,
+`iperf_sender_cpu_user_percent`, and
+`iperf_sender_cpu_system_percent`. In reverse mode, the sender-derived
+fields map to the remote iperf endpoint; in forward mode, they map to
+the host endpoint.
 
 Mixed-workload CoS validation MUST run at least two classes
 concurrently under one metrics scrape so class-specific `{a_i}` cannot

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -225,12 +225,17 @@ Any fairness measurement run MUST report:
    the "Saturation detection" section) and the supporting
    time-series.
 7. **Aggregate throughput** in Mb/s.
-8. **Aggregate retransmits**: total retransmits across all senders.
-   Diagnostic; not a hard gate.
-9. **ECN marks/drops** (if AQM is enabled): total CE marks and
+8. **Aggregate retransmits**: total retransmits across all senders
+   (`iperf_retransmits` in `fairness-eval`). Diagnostic; not a hard
+   gate.
+9. **iperf CPU utilization**: host/remote totals plus the derived
+   sender-side total/user/system percentages from iperf3's
+   `cpu_utilization_percent`. Diagnostic; not a hard gate, but needed
+   to separate dataplane unfairness from sender or receiver saturation.
+10. **ECN marks/drops** (if AQM is enabled): total CE marks and
    AQM drops. Diagnostic for future Path 2 v2 work.
-10. **Mouse p99 latency** (when mouse probes are present).
-11. **Steady-state window**: explicit start/end timestamps,
+11. **Mouse p99 latency** (when mouse probes are present).
+12. **Steady-state window**: explicit start/end timestamps,
     excluding the first 5 seconds (warmup) and any final
     sender-shutdown bursts.
 

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -55,7 +55,8 @@ structural ceiling, or is there a scheduler bug?"
 - Harness: `test/incus/fairness-harness.sh` runs iperf3 + 1 Hz
   /metrics scrape; `userspace-dp/src/bin/fairness-eval` parses
   iperf3 -J + 6-col TSV, aggregates per-worker on filtered iface,
-  emits PASS/FAIL verdict JSON.
+  emits PASS/FAIL verdict JSON, and includes iperf retransmit plus
+  optional host/remote/sender CPU diagnostics when iperf3 exports them.
 
 ### PR #1248 — Per-CoS-queue active-flow distribution (2026-05-10)
 

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -29,6 +29,8 @@ const GUARD_ABSOLUTE: u32 = 2;
 struct Iperf3Output {
     start: Iperf3Start,
     intervals: Vec<Iperf3Interval>,
+    #[serde(default)]
+    end: Option<Iperf3End>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +54,8 @@ struct Iperf3TestStart {
     duration: u64,
     #[serde(default, rename = "num_streams")]
     num_streams: u32,
+    #[serde(default)]
+    reverse: u8,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,6 +69,36 @@ struct Iperf3StreamInterval {
     start: f64,
     end: f64,
     bits_per_second: f64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Iperf3End {
+    #[serde(default)]
+    sum_sent: Iperf3EndSum,
+    #[serde(default)]
+    cpu_utilization_percent: Option<Iperf3CpuUtilization>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Iperf3EndSum {
+    #[serde(default)]
+    retransmits: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Iperf3CpuUtilization {
+    #[serde(default)]
+    host_total: f64,
+    #[serde(default)]
+    host_user: f64,
+    #[serde(default)]
+    host_system: f64,
+    #[serde(default)]
+    remote_total: f64,
+    #[serde(default)]
+    remote_user: f64,
+    #[serde(default)]
+    remote_system: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -123,6 +157,26 @@ struct Verdict {
     epsilon: f64,
     saturated: bool,
     aggregate_mbps: f64,
+    iperf_retransmits: u64,
+    iperf_reverse: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_host_total_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_host_user_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_host_system_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_remote_total_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_remote_user_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_cpu_remote_system_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_sender_cpu_total_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_sender_cpu_user_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iperf_sender_cpu_system_percent: Option<f64>,
     starved_flow_count: u32,
     /// Harness fail-fast guard result: sum(a_i) vs non-starved iperf streams.
     a_i_sum_check_ok: bool,
@@ -658,6 +712,56 @@ fn main() -> ExitCode {
                 / aggregate_buckets_bps.len() as f64)
                 / 1_000_000.0
         };
+    let iperf_retransmits = iperf
+        .end
+        .as_ref()
+        .map(|end| end.sum_sent.retransmits)
+        .unwrap_or(0);
+    let iperf_reverse = iperf.start.test_start.reverse != 0;
+    let iperf_cpu = iperf
+        .end
+        .as_ref()
+        .and_then(|end| end.cpu_utilization_percent.as_ref());
+    let (
+        iperf_cpu_host_total_percent,
+        iperf_cpu_host_user_percent,
+        iperf_cpu_host_system_percent,
+        iperf_cpu_remote_total_percent,
+        iperf_cpu_remote_user_percent,
+        iperf_cpu_remote_system_percent,
+        iperf_sender_cpu_total_percent,
+        iperf_sender_cpu_user_percent,
+        iperf_sender_cpu_system_percent,
+    ) = if let Some(cpu) = iperf_cpu {
+        let sender_total = if iperf_reverse {
+            cpu.remote_total
+        } else {
+            cpu.host_total
+        };
+        let sender_user = if iperf_reverse {
+            cpu.remote_user
+        } else {
+            cpu.host_user
+        };
+        let sender_system = if iperf_reverse {
+            cpu.remote_system
+        } else {
+            cpu.host_system
+        };
+        (
+            Some(cpu.host_total),
+            Some(cpu.host_user),
+            Some(cpu.host_system),
+            Some(cpu.remote_total),
+            Some(cpu.remote_user),
+            Some(cpu.remote_system),
+            Some(sender_total),
+            Some(sender_user),
+            Some(sender_system),
+        )
+    } else {
+        (None, None, None, None, None, None, None, None, None)
+    };
 
     // Saturation: structural cap = (n_active / n_total_workers) × shaper_rate.
     // shaper_rate provided via --shaper-rate-bps; if zero, skip the saturated check.
@@ -758,6 +862,17 @@ fn main() -> ExitCode {
         epsilon: EPSILON,
         saturated,
         aggregate_mbps,
+        iperf_retransmits,
+        iperf_reverse,
+        iperf_cpu_host_total_percent,
+        iperf_cpu_host_user_percent,
+        iperf_cpu_host_system_percent,
+        iperf_cpu_remote_total_percent,
+        iperf_cpu_remote_user_percent,
+        iperf_cpu_remote_system_percent,
+        iperf_sender_cpu_total_percent,
+        iperf_sender_cpu_user_percent,
+        iperf_sender_cpu_system_percent,
         starved_flow_count: starved,
         a_i_sum_check_ok,
         a_i_sum,

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -266,10 +266,57 @@ fn verdict_emits_required_keys() {
     assert!(v["starved_flow_count"].is_u64(), "starved_flow_count must be unsigned integer");
     assert!(v["verdict"].is_string(), "verdict must be string");
     assert!(v["failure_reasons"].is_array(), "failure_reasons must be array");
+    assert!(v["iperf_retransmits"].is_u64(), "iperf_retransmits must be unsigned integer");
+    assert!(v["iperf_reverse"].is_boolean(), "iperf_reverse must be boolean");
+}
+
+#[test]
+fn verdict_emits_iperf_end_diagnostics() {
+    let tmp = TempGuard::new("iperf_diag");
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let mut iperf: Value = serde_json::from_str(&json_str).expect("fixture JSON");
+    iperf["start"]["test_start"]["reverse"] = serde_json::json!(1);
+    iperf["end"] = serde_json::json!({
+        "sum_sent": {
+            "retransmits": 17,
+        },
+        "cpu_utilization_percent": {
+            "host_total": 10.0,
+            "host_user": 1.5,
+            "host_system": 8.5,
+            "remote_total": 74.5,
+            "remote_user": 2.0,
+            "remote_system": 72.5,
+        },
+    });
+    let json_str = serde_json::to_string(&iperf).expect("serialize fixture JSON");
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert!(
+        output.status.success(),
+        "iperf diagnostics fixture must PASS — stderr={}\nstdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let v = verdict.expect("verdict JSON");
+    assert_eq!(v["iperf_retransmits"], 17);
+    assert_eq!(v["iperf_reverse"], true);
+    assert_eq!(v["iperf_cpu_host_total_percent"].as_f64(), Some(10.0));
+    assert_eq!(v["iperf_cpu_host_system_percent"].as_f64(), Some(8.5));
+    assert_eq!(v["iperf_cpu_remote_total_percent"].as_f64(), Some(74.5));
+    assert_eq!(v["iperf_cpu_remote_system_percent"].as_f64(), Some(72.5));
+    assert_eq!(v["iperf_sender_cpu_total_percent"].as_f64(), Some(74.5));
+    assert_eq!(v["iperf_sender_cpu_system_percent"].as_f64(), Some(72.5));
 }
 
 // ---------------------------------------------------------------------------
-// 6 black-box cases.
+// Black-box cases.
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -313,10 +313,14 @@ fn verdict_emits_iperf_end_diagnostics() {
     assert_eq!(v["iperf_retransmits"], 17);
     assert_eq!(v["iperf_reverse"], true);
     assert_eq!(v["iperf_cpu_host_total_percent"].as_f64(), Some(10.0));
+    assert_eq!(v["iperf_cpu_host_user_percent"].as_f64(), Some(1.5));
     assert_eq!(v["iperf_cpu_host_system_percent"].as_f64(), Some(8.5));
     assert_eq!(v["iperf_cpu_remote_total_percent"].as_f64(), Some(74.5));
+    assert_eq!(v["iperf_cpu_remote_user_percent"].as_f64(), Some(2.0));
     assert_eq!(v["iperf_cpu_remote_system_percent"].as_f64(), Some(72.5));
+    // reverse mode: sender is the remote endpoint
     assert_eq!(v["iperf_sender_cpu_total_percent"].as_f64(), Some(74.5));
+    assert_eq!(v["iperf_sender_cpu_user_percent"].as_f64(), Some(2.0));
     assert_eq!(v["iperf_sender_cpu_system_percent"].as_f64(), Some(72.5));
 }
 
@@ -358,10 +362,14 @@ fn verdict_maps_forward_sender_cpu_to_host() {
     assert_eq!(v["iperf_retransmits"], 3);
     assert_eq!(v["iperf_reverse"], false);
     assert_eq!(v["iperf_cpu_host_total_percent"].as_f64(), Some(81.25));
+    assert_eq!(v["iperf_cpu_host_user_percent"].as_f64(), Some(4.25));
     assert_eq!(v["iperf_cpu_host_system_percent"].as_f64(), Some(77.0));
     assert_eq!(v["iperf_cpu_remote_total_percent"].as_f64(), Some(12.5));
+    assert_eq!(v["iperf_cpu_remote_user_percent"].as_f64(), Some(1.0));
     assert_eq!(v["iperf_cpu_remote_system_percent"].as_f64(), Some(11.5));
+    // forward mode: sender is the host endpoint
     assert_eq!(v["iperf_sender_cpu_total_percent"].as_f64(), Some(81.25));
+    assert_eq!(v["iperf_sender_cpu_user_percent"].as_f64(), Some(4.25));
     assert_eq!(v["iperf_sender_cpu_system_percent"].as_f64(), Some(77.0));
 }
 

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -210,8 +210,9 @@ fn run_with_inputs(
 // Required-keys schema test.
 // ---------------------------------------------------------------------------
 
-/// Per v6 plan §3.4 the required-keys set is 10 fields. A rename of any
-/// would be a contract break and must fail loudly. Verify on a PASS run.
+/// Per v6 plan §3.4 plus the iperf diagnostics extension, the
+/// always-present required-keys set is 12 fields. A rename of any would
+/// be a contract break and must fail loudly. Verify on a PASS run.
 #[test]
 fn verdict_emits_required_keys() {
     let tmp = TempGuard::new("schema");
@@ -233,7 +234,9 @@ fn verdict_emits_required_keys() {
     let v = verdict.expect("verdict JSON");
     let obj = v.as_object().expect("verdict JSON is an object");
 
-    // The 10 required keys per v6 plan §3.4.
+    // The 12 always-present required keys per v6 plan §3.4 plus iperf
+    // diagnostics. CPU fields are optional because older iperf3 JSON may
+    // omit end.cpu_utilization_percent.
     for key in [
         "distribution_a_i",
         "n_active",
@@ -245,6 +248,8 @@ fn verdict_emits_required_keys() {
         "starved_flow_count",
         "verdict",
         "failure_reasons",
+        "iperf_retransmits",
+        "iperf_reverse",
     ] {
         assert!(
             obj.contains_key(key),
@@ -313,6 +318,51 @@ fn verdict_emits_iperf_end_diagnostics() {
     assert_eq!(v["iperf_cpu_remote_system_percent"].as_f64(), Some(72.5));
     assert_eq!(v["iperf_sender_cpu_total_percent"].as_f64(), Some(74.5));
     assert_eq!(v["iperf_sender_cpu_system_percent"].as_f64(), Some(72.5));
+}
+
+#[test]
+fn verdict_maps_forward_sender_cpu_to_host() {
+    let tmp = TempGuard::new("iperf_forward_diag");
+    let (_sockets, json_str) = make_balanced_pass_inputs(6, 60);
+    let mut iperf: Value = serde_json::from_str(&json_str).expect("fixture JSON");
+    iperf["start"]["test_start"]["reverse"] = serde_json::json!(0);
+    iperf["end"] = serde_json::json!({
+        "sum_sent": {
+            "retransmits": 3,
+        },
+        "cpu_utilization_percent": {
+            "host_total": 81.25,
+            "host_user": 4.25,
+            "host_system": 77.0,
+            "remote_total": 12.5,
+            "remote_user": 1.0,
+            "remote_system": 11.5,
+        },
+    });
+    let json_str = serde_json::to_string(&iperf).expect("serialize fixture JSON");
+    let tsv_str = make_balanced_tsv(6, &timestamps_for(60), "ge-0-0-2");
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert!(
+        output.status.success(),
+        "forward iperf diagnostics fixture must PASS — stderr={}\nstdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let v = verdict.expect("verdict JSON");
+    assert_eq!(v["iperf_retransmits"], 3);
+    assert_eq!(v["iperf_reverse"], false);
+    assert_eq!(v["iperf_cpu_host_total_percent"].as_f64(), Some(81.25));
+    assert_eq!(v["iperf_cpu_host_system_percent"].as_f64(), Some(77.0));
+    assert_eq!(v["iperf_cpu_remote_total_percent"].as_f64(), Some(12.5));
+    assert_eq!(v["iperf_cpu_remote_system_percent"].as_f64(), Some(11.5));
+    assert_eq!(v["iperf_sender_cpu_total_percent"].as_f64(), Some(81.25));
+    assert_eq!(v["iperf_sender_cpu_system_percent"].as_f64(), Some(77.0));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- parse iperf3 end.sum_sent.retransmits and cpu_utilization_percent
- emit raw host/remote CPU utilization plus derived sender CPU fields in fairness-eval verdict JSON
- cover both reverse-mode remote-sender and forward-mode host-sender CPU mapping
- document exact diagnostic field names and optional CPU-field absence semantics in the fairness measurement contract

Measurement readiness for #1231 and #1233.

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml --test fairness_eval_blackbox
- cargo test --manifest-path userspace-dp/Cargo.toml --release --test fairness_eval_blackbox
- git diff --check
