### PR TITLE
Allow negative fairness gap in multi-sample wrapper

### DIFF
--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -86,14 +86,14 @@ def stream_text(value: Any) -> str:
     return str(value)
 
 
-def numeric_field(verdict: dict[str, Any], key: str) -> float:
+def numeric_field(verdict: dict[str, Any], key: str, *, allow_negative: bool = False) -> float:
     value = verdict.get(key)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise MultiSampleError(f"verdict JSON missing numeric field {key!r}")
     number = float(value)
     if not math.isfinite(number):
         raise MultiSampleError(f"verdict JSON field {key!r} is not finite")
-    if number < 0:
+    if not allow_negative and number < 0:
         raise MultiSampleError(f"verdict JSON field {key!r} is negative")
     return number
 
@@ -121,7 +121,7 @@ def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[st
         "verdict": verdict.get("verdict"),
         "observed_cov": numeric_field(verdict, "observed_cov"),
         "cstruct": numeric_field(verdict, "cstruct"),
-        "gap": numeric_field(verdict, "gap"),
+        "gap": numeric_field(verdict, "gap", allow_negative=True),
         "aggregate_mbps": optional_numeric_field(verdict, "aggregate_mbps"),
         "starved_flow_count": integer_field(verdict, "starved_flow_count"),
         "failure_reasons": verdict.get("failure_reasons", []),

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -57,11 +57,21 @@ class FairnessMultiSampleTest(unittest.TestCase):
         objects = fairness_multi_sample.extract_verdict_objects(text)
         self.assertEqual(objects, [])
 
-    def test_numeric_field_rejects_non_finite_negative_and_bool(self) -> None:
+    def test_numeric_field_rejects_non_finite_negative_and_bool_by_default(self) -> None:
         for value in [True, False, math.nan, math.inf, -math.inf, -0.1, "0.1"]:
             with self.subTest(value=value):
                 with self.assertRaises(fairness_multi_sample.MultiSampleError):
                     fairness_multi_sample.numeric_field({"observed_cov": value}, "observed_cov")
+
+    def test_numeric_field_allows_negative_gap_when_requested(self) -> None:
+        self.assertEqual(
+            fairness_multi_sample.numeric_field(
+                {"gap": -0.25},
+                "gap",
+                allow_negative=True,
+            ),
+            -0.25,
+        )
 
     def test_sample_record_validates_numeric_summary_fields(self) -> None:
         base_verdict = {
@@ -90,6 +100,25 @@ class FairnessMultiSampleTest(unittest.TestCase):
             with self.subTest(key=key, value=value):
                 with self.assertRaises(fairness_multi_sample.MultiSampleError):
                     fairness_multi_sample.sample_record(1, Path("sample-1"), 0, verdict)
+
+    def test_sample_record_accepts_negative_gap(self) -> None:
+        verdict = {
+            "verdict": "PASS",
+            "observed_cov": 0.01,
+            "cstruct": 0.5,
+            "gap": -0.49,
+            "aggregate_mbps": 1.0,
+            "starved_flow_count": 0,
+            "failure_reasons": [],
+            "distribution_a_i": [1],
+            "n_active": 1,
+            "saturated": True,
+            "a_i_sum_check_ok": True,
+        }
+
+        record = fairness_multi_sample.sample_record(1, Path("sample-1"), 0, verdict)
+
+        self.assertEqual(record["gap"], -0.49)
 
     def test_summary_fails_thresholds(self) -> None:
         summary = fairness_multi_sample.summarize(


### PR DESCRIPTION
## Summary

- allow `fairness_multi_sample.py` to accept finite negative `gap` values
- keep non-negative validation for `observed_cov`, `cstruct`, aggregate Mbps, and counters
- add unit coverage for negative-gap acceptance at both helper and sample-record layers

## Why

`gap = observed_cov - cstruct`, so negative values are valid and healthy when the scheduler performs better than the structural RSS bound. The all-class CoS sweep hit this with q4/q5 PASS verdicts and the wrapper aborted before summarizing samples.

Closes #1277.

## Tests

- `git diff --check`
- `python3 test/incus/fairness_multi_sample_test.py`
