### PR TITLE
Add all-class CoS fairness sweep harness

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -353,8 +353,10 @@ The sweep runs ports 5201..5207 through `fairness_multi_sample.py`,
 preserves per-class artifacts, writes `summary.tsv` and `summary.md`,
 and returns non-zero after completing all classes if any class misses
 its thresholds. For the symmetric reverse fixture on the loss cluster,
-`COS_IFINDEX=5` selects the `ge-0-0-1` egress; forward-path sweeps use
-the corresponding shaped egress ifindex for `reth0.80`.
+`COS_IFINDEX=5` selects the `ge-0-0-1` egress. For forward-path sweeps,
+do not hardcode the RETH unit's displayed name into the harness; use
+the ifindex emitted by `xpf_userspace_cos_active_flow_count` for the
+actual shaped egress in that run.
 
 ## Required metrics — exported in production via gRPC/Prometheus
 

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -335,6 +335,27 @@ launch target or wrapper because remote launchers such as `incus exec`
 do not expose the remote iperf PID to this local script. The
 lightweight `--mixed-cos` mode remains the default for routine runs.
 
+Single-class CoS validation MUST NOT stop at the low-rate fixture
+classes. The 100M and 1G classes are mostly shaper-dominated and can
+produce very low CoV even when high-rate classes remain unfair. Use the
+class sweep harness to exercise every canonical fixture port:
+
+```bash
+COS_IFINDEX=<egress-ifindex> \
+IPERF_LAUNCH_ARG_0=/usr/bin/incus \
+IPERF_LAUNCH_ARG_1=exec \
+IPERF_LAUNCH_ARG_2=loss:cluster-userspace-host \
+IPERF_LAUNCH_ARG_3=-- \
+./test/incus/fairness-cos-class-sweep.sh
+```
+
+The sweep runs ports 5201..5207 through `fairness_multi_sample.py`,
+preserves per-class artifacts, writes `summary.tsv` and `summary.md`,
+and returns non-zero after completing all classes if any class misses
+its thresholds. For the symmetric reverse fixture on the loss cluster,
+`COS_IFINDEX=5` selects the `ge-0-0-1` egress; forward-path sweeps use
+the corresponding shaped egress ifindex for `reth0.80`.
+
 ## Required metrics — exported in production via gRPC/Prometheus
 
 For production observability, xpf MUST export:

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -107,6 +107,14 @@ for spec in "${classes[@]}"; do
     status=$?
     if (( status == 2 )); then
         overall_status=2
+        append_error_row "$label" "$port" "$queue" "$rate" "$status"
+        sed -n '1,80p' "$out/wrapper.stderr" >&2
+        continue
+    elif (( status != 0 && status != 1 )); then
+        overall_status=2
+        append_error_row "$label" "$port" "$queue" "$rate" "$status"
+        sed -n '1,80p' "$out/wrapper.stderr" >&2
+        continue
     elif (( status != 0 && overall_status == 0 )); then
         overall_status=1
     fi
@@ -128,30 +136,55 @@ for spec in "${classes[@]}"; do
                 else
                     .
                 end;
-            def avg_numeric(key):
-                ([.samples[] | .[key] | select(type == "number")]) as $values
-                | if ($values | length) == 0 then null else (($values | add) / ($values | length)) end;
-            def sum_numeric(key):
-                ([.samples[] | .[key] | select(type == "number")]) as $values
-                | if ($values | length) == 0 then null else ($values | add) end;
-            def text_or_dash:
-                if . == null then "-" else tostring end;
+            def required_number(path; field_name):
+                getpath(path) as $value
+                | if ($value | type) == "number" then
+                    $value
+                else
+                    error("summary.json missing numeric " + field_name)
+                end;
+            def required_string(path; field_name):
+                getpath(path) as $value
+                | if ($value | type) == "string" and ($value | length) > 0 then
+                    $value
+                else
+                    error("summary.json missing string " + field_name)
+                end;
+            def sample_numbers(key):
+                ([.samples[] | .[key]]) as $values
+                | if any($values[]; (type != "number")) then
+                    error("summary.json sample missing numeric " + key)
+                else
+                    $values
+                end;
+            def sample_verdicts:
+                ([.samples[] | .verdict]) as $values
+                | if any($values[]; (type != "string" or length == 0)) then
+                    error("summary.json sample missing string verdict")
+                else
+                    $values
+                end;
             require_samples
+            | sample_numbers("aggregate_mbps") as $aggregate_mbps
+            | sample_numbers("cstruct") as $cstruct
+            | sample_numbers("gap") as $gap
+            | sample_numbers("starved_flow_count") as $starved
+            | sample_verdicts as $sample_verdicts
             | [
                 $class,
                 $port,
                 $queue,
                 $rate,
                 $status,
-                (.verdict // "ERROR"),
-                (.observed_cov.mean | text_or_dash),
-                (.observed_cov.max | text_or_dash),
-                (.observed_cov.sample_stdev | text_or_dash),
-                (avg_numeric("aggregate_mbps") | text_or_dash),
-                (avg_numeric("cstruct") | text_or_dash),
-                (avg_numeric("gap") | text_or_dash),
-                (sum_numeric("starved_flow_count") | text_or_dash),
-                ([.samples[].verdict] | join(","))
+                required_string(["verdict"]; "verdict"),
+                (required_number(["observed_cov", "mean"]; "observed_cov.mean") | tostring),
+                (required_number(["observed_cov", "max"]; "observed_cov.max") | tostring),
+                (required_number(["observed_cov", "sample_stdev"]; "observed_cov.sample_stdev") | tostring),
+                (($aggregate_mbps | add / length) | tostring),
+                (($cstruct | add / length) | tostring),
+                (($gap | add / length) | tostring),
+                ($starved | add | tostring),
+                ($sample_verdicts | join(","))
             ] | @tsv' "$summary_json" > "$row_file" 2> "$jq_err"; then
             cat "$row_file" >> "$SUMMARY_TSV"
             awk -F'\t' '{printf "summary class=%s wrapper_status=%s verdict=%s mean_cov=%s max_cov=%s\n", $1, $5, $6, $7, $8}' "$row_file"

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -18,7 +18,7 @@ IFACE=${IFACE:-ge-0-0-2}
 COS_IFINDEX=${COS_IFINDEX:-}
 SAMPLES=${SAMPLES:-3}
 PER_RUN_TIMEOUT_SEC=${PER_RUN_TIMEOUT_SEC:-180}
-ARTIFACT_ROOT=${ARTIFACT_ROOT:-/tmp/cos-fairness-all-$(date +%Y%m%d-%H%M%S)}
+ARTIFACT_ROOT=${ARTIFACT_ROOT:-}
 HARNESS=${HARNESS:-$ROOT_DIR/test/incus/fairness-harness.sh}
 WRAPPER=${WRAPPER:-$ROOT_DIR/test/incus/fairness_multi_sample.py}
 FAIRNESS_EVAL=${FAIRNESS_EVAL:-$ROOT_DIR/userspace-dp/target/release/fairness-eval}
@@ -45,7 +45,11 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-mkdir -p "$ARTIFACT_ROOT"
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+    ARTIFACT_ROOT=$(mktemp -d -t cos-fairness-all.XXXXXX)
+else
+    mkdir -p "$ARTIFACT_ROOT"
+fi
 SUMMARY_TSV="$ARTIFACT_ROOT/summary.tsv"
 SUMMARY_MD="$ARTIFACT_ROOT/summary.md"
 
@@ -62,6 +66,21 @@ classes=(
     "q3-iperf-f-19g 5206 3 19000000000"
     "q6-iperf-c-25g 5203 6 25000000000"
 )
+
+mark_parse_error() {
+    overall_status=2
+}
+
+append_error_row() {
+    local label=$1
+    local port=$2
+    local queue=$3
+    local rate=$4
+    local status=$5
+
+    printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\n' \
+        "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
+}
 
 overall_status=0
 for spec in "${classes[@]}"; do
@@ -92,32 +111,57 @@ for spec in "${classes[@]}"; do
 
     summary_json="$out/samples/summary.json"
     if [[ -f "$summary_json" ]]; then
-        jq -r \
+        row_file="$out/summary-row.tsv"
+        jq_err="$out/summary-jq.stderr"
+        if jq -er \
             --arg class "$label" \
             --arg port "$port" \
             --arg queue "$queue" \
             --arg rate "$rate" \
             --arg status "$status" \
-            '[
+            '
+            def require_samples:
+                if (.samples | type) != "array" or (.samples | length) == 0 then
+                    error("summary.json has no samples")
+                else
+                    .
+                end;
+            def avg_numeric(key):
+                ([.samples[] | .[key] | select(type == "number")]) as $values
+                | if ($values | length) == 0 then null else (($values | add) / ($values | length)) end;
+            def sum_numeric(key):
+                ([.samples[] | .[key] | select(type == "number")]) as $values
+                | if ($values | length) == 0 then null else ($values | add) end;
+            def text_or_dash:
+                if . == null then "-" else tostring end;
+            require_samples
+            | [
                 $class,
                 $port,
                 $queue,
                 $rate,
                 $status,
-                .verdict,
-                (.observed_cov.mean | tostring),
-                (.observed_cov.max | tostring),
-                (.observed_cov.sample_stdev | tostring),
-                (([.samples[].aggregate_mbps] | add / length) | tostring),
-                (([.samples[].cstruct] | add / length) | tostring),
-                (([.samples[].gap] | add / length) | tostring),
-                (([.samples[].starved_flow_count] | add) | tostring),
+                (.verdict // "ERROR"),
+                (.observed_cov.mean | text_or_dash),
+                (.observed_cov.max | text_or_dash),
+                (.observed_cov.sample_stdev | text_or_dash),
+                (avg_numeric("aggregate_mbps") | text_or_dash),
+                (avg_numeric("cstruct") | text_or_dash),
+                (avg_numeric("gap") | text_or_dash),
+                (sum_numeric("starved_flow_count") | text_or_dash),
                 ([.samples[].verdict] | join(","))
-            ] | @tsv' "$summary_json" >> "$SUMMARY_TSV"
-        jq '{verdict, observed_cov, samples: [.samples[] | {sample, verdict, aggregate_mbps, observed_cov, cstruct, gap, starved_flow_count}]}' "$summary_json"
+            ] | @tsv' "$summary_json" > "$row_file" 2> "$jq_err"; then
+            cat "$row_file" >> "$SUMMARY_TSV"
+            awk -F'\t' '{printf "summary class=%s wrapper_status=%s verdict=%s mean_cov=%s max_cov=%s\n", $1, $5, $6, $7, $8}' "$row_file"
+        else
+            mark_parse_error
+            append_error_row "$label" "$port" "$queue" "$rate" "$status"
+            echo "fairness-cos-class-sweep: invalid summary for $label: $summary_json" >&2
+            sed -n '1,80p' "$jq_err" >&2
+        fi
     else
-        printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\n' \
-            "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
+        mark_parse_error
+        append_error_row "$label" "$port" "$queue" "$rate" "$status"
         sed -n '1,80p' "$out/wrapper.stderr" >&2
     fi
 done

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -80,6 +80,8 @@ append_error_row() {
 
     printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\n' \
         "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
+    printf "summary class=%s wrapper_status=%s verdict=ERROR mean_cov=- max_cov=-\n" \
+        "$label" "$status"
 }
 
 overall_status=0

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Run fairness_multi_sample.py across every canonical CoS fixture class.
+#
+# This is intentionally a sequential qualification harness: each class gets its
+# own sample directory and verdict, then the script emits an aggregate summary
+# and returns non-zero if any class fails its multi-sample thresholds.
+
+set -uo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+TARGET=${TARGET:-172.16.80.200}
+N=${N:-12}
+DURATION=${DURATION:-75}
+REVERSE=${REVERSE:--R}
+METRICS_URL=${METRICS_URL:-http://127.0.0.1:8080/metrics}
+IFACE=${IFACE:-ge-0-0-2}
+COS_IFINDEX=${COS_IFINDEX:-}
+SAMPLES=${SAMPLES:-3}
+PER_RUN_TIMEOUT_SEC=${PER_RUN_TIMEOUT_SEC:-180}
+ARTIFACT_ROOT=${ARTIFACT_ROOT:-/tmp/cos-fairness-all-$(date +%Y%m%d-%H%M%S)}
+HARNESS=${HARNESS:-$ROOT_DIR/test/incus/fairness-harness.sh}
+WRAPPER=${WRAPPER:-$ROOT_DIR/test/incus/fairness_multi_sample.py}
+FAIRNESS_EVAL=${FAIRNESS_EVAL:-$ROOT_DIR/userspace-dp/target/release/fairness-eval}
+
+if [[ -z "$COS_IFINDEX" ]]; then
+    echo "fairness-cos-class-sweep: COS_IFINDEX is required for the shaped egress interface" >&2
+    exit 2
+fi
+if [[ ! -x "$HARNESS" ]]; then
+    echo "fairness-cos-class-sweep: harness is not executable: $HARNESS" >&2
+    exit 2
+fi
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "fairness-cos-class-sweep: wrapper is not executable: $WRAPPER" >&2
+    exit 2
+fi
+if [[ ! -x "$FAIRNESS_EVAL" ]]; then
+    echo "fairness-cos-class-sweep: fairness-eval is not executable: $FAIRNESS_EVAL" >&2
+    echo "  build with: cargo build --manifest-path userspace-dp/Cargo.toml --release --bin fairness-eval" >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "fairness-cos-class-sweep: jq is required to build the aggregate summary" >&2
+    exit 2
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+SUMMARY_TSV="$ARTIFACT_ROOT/summary.tsv"
+SUMMARY_MD="$ARTIFACT_ROOT/summary.md"
+
+cat > "$SUMMARY_TSV" <<'HEADER'
+class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_cstruct	avg_gap	starved_flows	per_run_verdicts
+HEADER
+
+classes=(
+    "q0-best-effort-100m 5207 0 100000000"
+    "q4-iperf-a-1g 5201 4 1000000000"
+    "q5-iperf-b-10g 5202 5 10000000000"
+    "q1-iperf-d-13g 5204 1 13000000000"
+    "q2-iperf-e-16g 5205 2 16000000000"
+    "q3-iperf-f-19g 5206 3 19000000000"
+    "q6-iperf-c-25g 5203 6 25000000000"
+)
+
+overall_status=0
+for spec in "${classes[@]}"; do
+    read -r label port queue rate <<< "$spec"
+    out="$ARTIFACT_ROOT/$label"
+    mkdir -p "$out"
+
+    echo "=== $(date -Is) class=$label port=$port queue=$queue rate=$rate ==="
+    env \
+        FAIRNESS_EVAL="$FAIRNESS_EVAL" \
+        COS_IFINDEX="$COS_IFINDEX" \
+        COS_QUEUE_ID="$queue" \
+        SHAPER_RATE_BPS="$rate" \
+        IFACE="$IFACE" \
+        "$WRAPPER" \
+            --samples "$SAMPLES" \
+            --out-dir "$out/samples" \
+            --per-run-timeout-sec "$PER_RUN_TIMEOUT_SEC" \
+            --harness "$HARNESS" \
+            -- "$TARGET" "$port" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" \
+        > "$out/wrapper.stdout" 2> "$out/wrapper.stderr"
+    status=$?
+    if (( status == 2 )); then
+        overall_status=2
+    elif (( status != 0 && overall_status == 0 )); then
+        overall_status=1
+    fi
+
+    summary_json="$out/samples/summary.json"
+    if [[ -f "$summary_json" ]]; then
+        jq -r \
+            --arg class "$label" \
+            --arg port "$port" \
+            --arg queue "$queue" \
+            --arg rate "$rate" \
+            --arg status "$status" \
+            '[
+                $class,
+                $port,
+                $queue,
+                $rate,
+                $status,
+                .verdict,
+                (.observed_cov.mean | tostring),
+                (.observed_cov.max | tostring),
+                (.observed_cov.sample_stdev | tostring),
+                (([.samples[].aggregate_mbps] | add / length) | tostring),
+                (([.samples[].cstruct] | add / length) | tostring),
+                (([.samples[].gap] | add / length) | tostring),
+                (([.samples[].starved_flow_count] | add) | tostring),
+                ([.samples[].verdict] | join(","))
+            ] | @tsv' "$summary_json" >> "$SUMMARY_TSV"
+        jq '{verdict, observed_cov, samples: [.samples[] | {sample, verdict, aggregate_mbps, observed_cov, cstruct, gap, starved_flow_count}]}' "$summary_json"
+    else
+        printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\n' \
+            "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
+        sed -n '1,80p' "$out/wrapper.stderr" >&2
+    fi
+done
+
+{
+    printf '# CoS Fairness Class Sweep\n\n'
+    printf 'Artifacts: `%s`\n\n' "$ARTIFACT_ROOT"
+    printf 'Target: `%s`, streams: `%s`, duration: `%s`, reverse: `%s`, metrics: `%s`, cos_ifindex: `%s`\n\n' \
+        "$TARGET" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" "$COS_IFINDEX"
+    printf '| Class | Port | Queue | Verdict | Mean CoV | Max CoV | Stdev CoV | Avg Mbps | Avg Cstruct | Avg Gap | Starved | Per-run |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n'
+    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate _status verdict mean max stdev mbps cstruct gap starved per_run; do
+        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+            "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$cstruct" "$gap" "$starved" "$per_run"
+    done
+} > "$SUMMARY_MD"
+
+echo "fairness-cos-class-sweep: wrote $SUMMARY_TSV"
+echo "fairness-cos-class-sweep: wrote $SUMMARY_MD"
+exit "$overall_status"


### PR DESCRIPTION
## Summary

- add `test/incus/fairness-cos-class-sweep.sh` to run every canonical CoS fixture class through `fairness_multi_sample.py`
- keep collecting after per-class FAILs and write aggregate `summary.tsv` / `summary.md`
- document that q0/q4 low-rate classes are not sufficient evidence for CoS fairness

## Why

The 2026-05-12 all-class reverse sweep showed that q4/1G can have near-zero observed CoV while q3/19G and q6/25G show poor absolute per-flow fairness. We need a repeatable all-class measurement harness so review and qualification do not overfit to low-rate classes.

Depends on #1279 because valid PASS verdicts commonly have negative `gap = observed_cov - cstruct`.

Tracks #1276.

## Validation

- `git diff --check`
- `bash -n test/incus/fairness-cos-class-sweep.sh`
- `COS_IFINDEX= /bin/bash test/incus/fairness-cos-class-sweep.sh` exits 2 with the expected fail-closed error

Lab reference artifact from the motivating run: `/tmp/cos-fairness-all-20260512-070630/findings.md`.
