### PR TITLE
Avoid false TCP segmentation misses on VLAN frames

### DIFF
--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -251,12 +251,13 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
         let mut retained_source_frame = false;
         let mut flow_key = request.flow_key.take();
         {
-            if forwarded_tcp_may_need_segmentation(
+            let tcp_segmentation_needed = forwarded_tcp_may_need_segmentation(
                 source_frame,
                 request.meta,
                 &request.decision,
                 forwarding,
-            ) {
+            );
+            if tcp_segmentation_needed {
                 if let Some((segments, bytes, max_frame)) =
                     segment_forwarded_tcp_frames_into_prepared(
                         target_binding,
@@ -364,9 +365,12 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     }
                 }
             }
-            // Track when segmentation was needed but returned None
-            if !copied_source_frame && source_frame.len() > 1514 {
-                dbg.seg_needed_but_none += 1;
+            // Track when segmentation was needed but both builders returned None.
+            if count_forwarded_tcp_segmentation_miss_if_needed(
+                dbg,
+                copied_source_frame,
+                tcp_segmentation_needed,
+            ) {
                 thread_local! {
                     static SEG_MISS_LOG: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
                 }
@@ -1203,6 +1207,18 @@ pub(in crate::afxdp) fn extract_l3_packet_with_nat(
     Some(packet)
 }
 
+#[inline(always)]
+fn count_forwarded_tcp_segmentation_miss_if_needed(
+    dbg: &mut DebugPollCounters,
+    copied_source_frame: bool,
+    tcp_segmentation_needed: bool,
+) -> bool {
+    if copied_source_frame || !tcp_segmentation_needed {
+        return false;
+    }
+    dbg.seg_needed_but_none += 1;
+    true
+}
 
 #[inline(always)]
 fn forwarded_tcp_may_need_segmentation(
@@ -1228,7 +1244,7 @@ fn forwarded_tcp_may_need_segmentation(
     // `l3_offset=14` as authoritative falsely flags it as needing TCP
     // segmentation. The segmentation builders already re-derive L3 from
     // the frame, so keep this predicate aligned with them.
-    let l3 = frame_l3_offset(frame).or(match meta.l3_offset {
+    let l3 = frame_l3_offset(frame).or_else(|| match meta.l3_offset {
         14 | 18 => Some(meta.l3_offset as usize),
         _ => None,
     });

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -1222,12 +1222,18 @@ fn forwarded_tcp_may_need_segmentation(
         .map(|egress| egress.mtu)
         .unwrap_or_default()
         .max(1280);
-    let l3 = match meta.l3_offset {
-        14 | 18 => meta.l3_offset as usize,
-        _ => match frame_l3_offset(frame) {
-            Some(offset) => offset,
-            None => return false,
-        },
+    // Prefer the actual Ethernet header in the frame. Metadata can lag
+    // behind VLAN normalization; a VLAN frame with 18 bytes of L2 and a
+    // 1500-byte L3 payload is 1518 bytes total, and treating stale
+    // `l3_offset=14` as authoritative falsely flags it as needing TCP
+    // segmentation. The segmentation builders already re-derive L3 from
+    // the frame, so keep this predicate aligned with them.
+    let l3 = frame_l3_offset(frame).or(match meta.l3_offset {
+        14 | 18 => Some(meta.l3_offset as usize),
+        _ => None,
+    });
+    let Some(l3) = l3 else {
+        return false;
     };
     l3 < frame.len() && frame.len().saturating_sub(l3) > mtu
 }
@@ -1235,4 +1241,3 @@ fn forwarded_tcp_may_need_segmentation(
 #[cfg(test)]
 #[path = "dispatch_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/afxdp/tx/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch_tests.rs
@@ -92,6 +92,31 @@ fn forwarded_tcp_may_need_segmentation_skips_mtu_sized_frame() {
 }
 
 #[test]
+fn forwarded_tcp_may_need_segmentation_uses_frame_vlan_offset_over_stale_meta() {
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let meta = UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        // Stale metadata shape observed in #1282: the live frame is VLAN
+        // tagged, but metadata still points at a 14-byte Ethernet header.
+        l3_offset: 14,
+        ..UserspaceDpMeta::default()
+    };
+    let mut frame = vec![0u8; 18 + 1500];
+    frame[12] = 0x81;
+    frame[13] = 0x00;
+    frame[16] = 0x08;
+    frame[17] = 0x00;
+
+    assert!(!forwarded_tcp_may_need_segmentation(
+        &frame,
+        meta,
+        &test_decision(),
+        &forwarding,
+    ));
+}
+
+#[test]
 fn forwarded_tcp_may_need_segmentation_flags_oversized_frame() {
     let forwarding = test_forwarding_with_egress_mtu(1500);
     let meta = UserspaceDpMeta {

--- a/userspace-dp/src/afxdp/tx/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch_tests.rs
@@ -117,6 +117,32 @@ fn forwarded_tcp_may_need_segmentation_uses_frame_vlan_offset_over_stale_meta() 
 }
 
 #[test]
+fn segmentation_miss_counter_skips_mtu_sized_vlan_frame_with_stale_meta() {
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let meta = UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        ..UserspaceDpMeta::default()
+    };
+    let mut frame = vec![0u8; 18 + 1500];
+    frame[12] = 0x81;
+    frame[13] = 0x00;
+    frame[16] = 0x08;
+    frame[17] = 0x00;
+    let tcp_segmentation_needed =
+        forwarded_tcp_may_need_segmentation(&frame, meta, &test_decision(), &forwarding);
+    let mut dbg = DebugPollCounters::default();
+
+    assert!(!count_forwarded_tcp_segmentation_miss_if_needed(
+        &mut dbg,
+        false,
+        tcp_segmentation_needed,
+    ));
+    assert_eq!(dbg.seg_needed_but_none, 0);
+}
+
+#[test]
 fn forwarded_tcp_may_need_segmentation_flags_oversized_frame() {
     let forwarding = test_forwarding_with_egress_mtu(1500);
     let meta = UserspaceDpMeta {

--- a/userspace-dp/src/afxdp/tx/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch_tests.rs
@@ -143,6 +143,30 @@ fn segmentation_miss_counter_skips_mtu_sized_vlan_frame_with_stale_meta() {
 }
 
 #[test]
+fn segmentation_miss_counter_truth_table() {
+    let cases = [
+        (false, true, true, 1),
+        (true, true, false, 0),
+        (true, false, false, 0),
+        (false, false, false, 0),
+    ];
+
+    for (copied_source_frame, tcp_segmentation_needed, expected_counted, expected_counter) in cases {
+        let mut dbg = DebugPollCounters::default();
+
+        assert_eq!(
+            count_forwarded_tcp_segmentation_miss_if_needed(
+                &mut dbg,
+                copied_source_frame,
+                tcp_segmentation_needed,
+            ),
+            expected_counted,
+        );
+        assert_eq!(dbg.seg_needed_but_none, expected_counter);
+    }
+}
+
+#[test]
 fn forwarded_tcp_may_need_segmentation_flags_oversized_frame() {
     let forwarding = test_forwarding_with_egress_mtu(1500);
     let meta = UserspaceDpMeta {


### PR DESCRIPTION
## Summary
- make forwarded TCP segmentation precheck parse the actual frame L3 offset before falling back to metadata
- add a regression for VLAN frames where stale l3_offset=14 made an 18+1500 byte frame look oversized
- scope this to the DBG SEG_MISS false-positive path from #1282; the full-sweep TX-error spike remains under investigation

## Measurement context
- all-class CoS sweep on fw0 logged 120 DBG SEG_MISS lines with frame_len=1518 and egress_mtu=1500
- a focused q6 reverse run on active fw1 produced ~22.65 Gbps with 0 TX errors and 0 DBG SEG_MISS entries: /tmp/issue1282-fw1-q6-20260512-190019

## Validation
- cargo test --manifest-path userspace-dp/Cargo.toml --release forwarded_tcp_may_need_segmentation -- --nocapture
- git diff --check
- cargo fmt --manifest-path userspace-dp/Cargo.toml --check (fails due pre-existing rustfmt drift outside this change)

Addresses part of #1282.