### PR TITLE
fairness-eval: tolerate bounded stale active-flow overcount

### DIFF
--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -842,12 +842,12 @@ fn main() -> ExitCode {
     let cstruct_adjusted_for_a_i_overcount = cstruct_distribution_a_i != distribution_a_i;
 
     let cstruct = compute_cstruct(&cstruct_distribution_a_i);
-    let n_active: u32 = cstruct_distribution_a_i.iter().filter(|&&a| a > 0).count() as u32;
-    let max_worker_flow_share = max_worker_flow_share(&cstruct_distribution_a_i);
+    let n_active: u32 = distribution_a_i.iter().filter(|&&a| a > 0).count() as u32;
+    let max_worker_flow_share = max_worker_flow_share(&distribution_a_i);
     let (rss_expectation_pass, rss_expectation_reason) = evaluate_rss_expectation(
         &rss_expectation,
-        &cstruct_distribution_a_i,
-        cstruct,
+        &distribution_a_i,
+        compute_cstruct(&distribution_a_i),
         n_total_workers,
     );
     let gap = observed_cov - cstruct;

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -20,12 +20,18 @@ use fairness::{
 
 const EPSILON: f64 = 0.05;
 // Tolerance for the harness fail-fast guard per Codex round-4
-// finding #3: sum(per_binding_active_flow_count) ≈ expected_sum
-// within `max(2, floor(10% × expected_sum))`, where
+// finding #3: sum(per_binding_active_flow_count) should stay near
+// expected_sum, where
 // expected_sum = non-starved_streams × direction_multiplier
 // (direction_multiplier=1 when iface_filter_active=true, 2 for
 // legacy/bidirectional input).
+//
+// #1281: active-flow gauges are low-frequency snapshots and can retain
+// recently-active/stale flows for a short window. Preserve the stricter
+// undercount guard because missing telemetry masks real flow loss, but
+// allow a bounded one-sided overcount window for stale entries.
 const GUARD_RELATIVE: f64 = 0.10;
+const GUARD_OVERCOUNT_DIVISOR: u32 = 4;
 const GUARD_ABSOLUTE: u32 = 2;
 
 #[derive(Debug, Deserialize)]
@@ -185,6 +191,8 @@ struct Verdict {
     a_i_sum_check_ok: bool,
     a_i_sum: u32,
     iperf_non_starved_streams: u32,
+    a_i_sum_under_tolerance: u32,
+    a_i_sum_over_tolerance: u32,
     a_i_sum_tolerance: u32,
     /// PASS unless any gate fails.
     verdict: &'static str,
@@ -531,6 +539,14 @@ fn direction_multiplier(iface_filter_active: bool) -> u32 {
     if iface_filter_active { 1 } else { 2 }
 }
 
+fn guard_sum_tolerances(expected_sum: u32) -> (u32, u32) {
+    let under = ((GUARD_RELATIVE * expected_sum as f64) as u32).max(GUARD_ABSOLUTE);
+    let over = expected_sum
+        .saturating_add(GUARD_OVERCOUNT_DIVISOR - 1)
+        / GUARD_OVERCOUNT_DIVISOR;
+    (under, over.max(GUARD_ABSOLUTE))
+}
+
 fn main() -> ExitCode {
     let args: Args = parse_args();
 
@@ -809,9 +825,15 @@ fn main() -> ExitCode {
     // fallback path uses the bidirectional multiplier as well.
     let dir_mult = direction_multiplier(iface_filter_active);
     let expected_sum = n_non_starved.saturating_mul(dir_mult);
-    let tolerance = ((GUARD_RELATIVE * expected_sum as f64) as u32).max(GUARD_ABSOLUTE);
-    let a_i_sum_check_ok =
-        (a_i_sum as i64 - expected_sum as i64).unsigned_abs() as u32 <= tolerance;
+    let (under_tolerance, over_tolerance) = guard_sum_tolerances(expected_sum);
+    let a_i_delta = a_i_sum as i64 - expected_sum as i64;
+    let a_i_abs_delta = a_i_delta.unsigned_abs() as u32;
+    let tolerance = if a_i_delta > 0 {
+        over_tolerance
+    } else {
+        under_tolerance
+    };
+    let a_i_sum_check_ok = a_i_abs_delta <= tolerance;
 
     let mut failure_reasons: Vec<String> = Vec::new();
     if starved > 0 {
@@ -825,10 +847,12 @@ fn main() -> ExitCode {
         ));
     }
     if !a_i_sum_check_ok {
+        let direction = if a_i_delta > 0 { "above" } else { "below" };
         failure_reasons.push(format!(
             "Harness guard: sum(a_i)={a_i_sum} vs expected={expected_sum} \
              (non-starved={n_non_starved} × dir_mult={dir_mult}) \
-             differ by more than tolerance={tolerance}"
+             is {a_i_abs_delta} {direction} expected, exceeding tolerance={tolerance} \
+             (under_tolerance={under_tolerance}, over_tolerance={over_tolerance})"
         ));
     }
     if !rss_expectation_pass {
@@ -882,6 +906,8 @@ fn main() -> ExitCode {
         a_i_sum_check_ok,
         a_i_sum,
         iperf_non_starved_streams: n_non_starved,
+        a_i_sum_under_tolerance: under_tolerance,
+        a_i_sum_over_tolerance: over_tolerance,
         a_i_sum_tolerance: tolerance,
         verdict,
         failure_reasons,
@@ -1384,6 +1410,13 @@ mod aggregation_tests {
     #[test]
     fn direction_multiplier_no_iface_filter_is_two() {
         assert_eq!(direction_multiplier(false), 2);
+    }
+
+    #[test]
+    fn guard_sum_tolerances_are_asymmetric_for_stale_overcount() {
+        assert_eq!(guard_sum_tolerances(12), (2, 3));
+        assert_eq!(guard_sum_tolerances(2), (2, 2));
+        assert_eq!(guard_sum_tolerances(40), (4, 10));
     }
 }
 

--- a/userspace-dp/src/bin/fairness-eval.rs
+++ b/userspace-dp/src/bin/fairness-eval.rs
@@ -26,10 +26,11 @@ const EPSILON: f64 = 0.05;
 // (direction_multiplier=1 when iface_filter_active=true, 2 for
 // legacy/bidirectional input).
 //
-// #1281: active-flow gauges are low-frequency snapshots and can retain
-// recently-active/stale flows for a short window. Preserve the stricter
-// undercount guard because missing telemetry masks real flow loss, but
-// allow a bounded one-sided overcount window for stale entries.
+// #1281: active-flow gauges can report recently-active/stale flow-cache
+// entries persistently enough to survive the steady-state median. Preserve
+// the stricter undercount guard because missing telemetry masks real flow
+// loss, but allow a bounded one-sided overcount window and normalize that
+// accepted overcount before computing Cstruct.
 const GUARD_RELATIVE: f64 = 0.10;
 const GUARD_OVERCOUNT_DIVISOR: u32 = 4;
 const GUARD_ABSOLUTE: u32 = 2;
@@ -154,6 +155,8 @@ struct Verdict {
     distribution_a_i: Vec<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     binding_distribution_a_i: Option<Vec<u32>>,
+    cstruct_distribution_a_i: Vec<u32>,
+    cstruct_adjusted_for_a_i_overcount: bool,
     rss_expectation: String,
     rss_expectation_pass: bool,
     rss_expectation_reason: String,
@@ -547,6 +550,24 @@ fn guard_sum_tolerances(expected_sum: u32) -> (u32, u32) {
     (under, over.max(GUARD_ABSOLUTE))
 }
 
+fn trim_distribution_to_sum(distribution: &[u32], target_sum: u32) -> Vec<u32> {
+    let mut trimmed = distribution.to_vec();
+    let mut excess = trimmed.iter().sum::<u32>().saturating_sub(target_sum);
+    while excess > 0 {
+        let Some((idx, _)) = trimmed
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count > 0)
+            .max_by_key(|(_, count)| **count)
+        else {
+            break;
+        };
+        trimmed[idx] -= 1;
+        excess -= 1;
+    }
+    trimmed
+}
+
 fn main() -> ExitCode {
     let args: Args = parse_args();
 
@@ -704,8 +725,6 @@ fn main() -> ExitCode {
         selected_cos_queue_id = Some(cos_queue_id);
     }
 
-    let cstruct = compute_cstruct(&distribution_a_i);
-    let n_active: u32 = distribution_a_i.iter().filter(|&&a| a > 0).count() as u32;
     let rss_expectation = match parse_rss_expectation(&args.rss_expectation) {
         Ok(v) => v,
         Err(e) => {
@@ -713,15 +732,6 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let max_worker_flow_share = max_worker_flow_share(&distribution_a_i);
-    let (rss_expectation_pass, rss_expectation_reason) = evaluate_rss_expectation(
-        &rss_expectation,
-        &distribution_a_i,
-        cstruct,
-        n_total_workers,
-    );
-
-    let gap = observed_cov - cstruct;
 
     let aggregate_mbps =
         if aggregate_buckets_bps.is_empty() {
@@ -782,17 +792,6 @@ fn main() -> ExitCode {
         (None, None, None, None, None, None, None, None, None)
     };
 
-    // Saturation: structural cap = (n_active / n_total_workers) × shaper_rate.
-    // shaper_rate provided via --shaper-rate-bps; if zero, skip the saturated check.
-    let saturated = if args.shaper_rate_bps > 0 && n_total_workers > 0 {
-        let structural_cap_bps = (args.shaper_rate_bps as u128
-            * n_active as u128
-            / n_total_workers as u128) as u64;
-        is_saturated(&aggregate_buckets_bps, structural_cap_bps)
-    } else {
-        false
-    };
-
     // Harness fail-fast guard: sum(a_i) vs non-starved iperf stream count.
     //
     // Codex round-4 finding: with --iface filtering (the per-worker
@@ -834,6 +833,35 @@ fn main() -> ExitCode {
         under_tolerance
     };
     let a_i_sum_check_ok = a_i_abs_delta <= tolerance;
+
+    let cstruct_distribution_a_i = if a_i_delta > 0 && a_i_sum_check_ok {
+        trim_distribution_to_sum(&distribution_a_i, expected_sum)
+    } else {
+        distribution_a_i.clone()
+    };
+    let cstruct_adjusted_for_a_i_overcount = cstruct_distribution_a_i != distribution_a_i;
+
+    let cstruct = compute_cstruct(&cstruct_distribution_a_i);
+    let n_active: u32 = cstruct_distribution_a_i.iter().filter(|&&a| a > 0).count() as u32;
+    let max_worker_flow_share = max_worker_flow_share(&cstruct_distribution_a_i);
+    let (rss_expectation_pass, rss_expectation_reason) = evaluate_rss_expectation(
+        &rss_expectation,
+        &cstruct_distribution_a_i,
+        cstruct,
+        n_total_workers,
+    );
+    let gap = observed_cov - cstruct;
+
+    // Saturation: structural cap = (n_active / n_total_workers) × shaper_rate.
+    // shaper_rate provided via --shaper-rate-bps; if zero, skip the saturated check.
+    let saturated = if args.shaper_rate_bps > 0 && n_total_workers > 0 {
+        let structural_cap_bps = (args.shaper_rate_bps as u128
+            * n_active as u128
+            / n_total_workers as u128) as u64;
+        is_saturated(&aggregate_buckets_bps, structural_cap_bps)
+    } else {
+        false
+    };
 
     let mut failure_reasons: Vec<String> = Vec::new();
     if starved > 0 {
@@ -879,6 +907,8 @@ fn main() -> ExitCode {
         distribution_a_i,
         binding_distribution_a_i: (cstruct_source == "cos_queue")
             .then_some(binding_distribution_a_i),
+        cstruct_distribution_a_i,
+        cstruct_adjusted_for_a_i_overcount,
         rss_expectation: args.rss_expectation,
         rss_expectation_pass,
         rss_expectation_reason,
@@ -1417,6 +1447,17 @@ mod aggregation_tests {
         assert_eq!(guard_sum_tolerances(12), (2, 3));
         assert_eq!(guard_sum_tolerances(2), (2, 2));
         assert_eq!(guard_sum_tolerances(40), (4, 10));
+    }
+
+    #[test]
+    fn trim_distribution_to_sum_removes_accepted_overcount_from_largest_buckets() {
+        assert_eq!(
+            trim_distribution_to_sum(&[4, 4, 4, 3, 0, 0], 12),
+            vec![3, 3, 3, 3, 0, 0]
+        );
+        assert_eq!(trim_distribution_to_sum(&[1, 2, 3], 3), vec![1, 1, 1]);
+        assert_eq!(trim_distribution_to_sum(&[1, 2, 3], 10), vec![1, 2, 3]);
+        assert_eq!(trim_distribution_to_sum(&[0, 0, 0], 0), vec![0, 0, 0]);
     }
 }
 

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -596,6 +596,71 @@ fn guard_sum_mismatch_fails() {
 }
 
 #[test]
+fn guard_p12_allows_bounded_stale_overcount() {
+    let tmp = TempGuard::new("guard_p12_overcount_pass");
+    let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);
+    // Canonical CoS sweep shape from #1281: 12 healthy streams, but
+    // active-flow snapshots can retain three stale/recently-active
+    // entries. sum(a_i)=15 vs expected=12 is a bounded overcount and
+    // should not false-fail the run.
+    let tsv_str = make_distribution_tsv(&[4, 4, 4, 3, 0, 0], &timestamps_for(60), "ge-0-0-2");
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "P=12 sum(a_i)=15 stale-overcount window should PASS; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on P=12 overcount PASS");
+    assert_eq!(v["verdict"], "PASS");
+    assert_eq!(v["a_i_sum_check_ok"], true);
+    assert_eq!(v["a_i_sum"], 15);
+    assert_eq!(v["iperf_non_starved_streams"], 12);
+    assert_eq!(v["a_i_sum_under_tolerance"], 2);
+    assert_eq!(v["a_i_sum_over_tolerance"], 3);
+    assert_eq!(v["a_i_sum_tolerance"], 3);
+}
+
+#[test]
+fn guard_p12_rejects_overcount_beyond_stale_window() {
+    let tmp = TempGuard::new("guard_p12_overcount_fail");
+    let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);
+    let tsv_str = make_distribution_tsv(&[4, 4, 4, 4, 0, 0], &timestamps_for(60), "ge-0-0-2");
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "P=12 sum(a_i)=16 should exceed the overcount window; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on P=12 overcount FAIL");
+    assert_eq!(v["verdict"], "FAIL");
+    assert_eq!(v["a_i_sum_check_ok"], false);
+    assert_eq!(v["a_i_sum"], 16);
+    assert_eq!(v["a_i_sum_over_tolerance"], 3);
+    let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
+    let guard_reason = reasons
+        .iter()
+        .filter_map(|r| r.as_str())
+        .find(|r| r.contains("Harness guard"))
+        .unwrap_or_else(|| panic!("failure_reasons must contain a Harness guard entry; got: {reasons:?}"));
+    assert!(guard_reason.contains("expected=12"), "guard reason missing expected_sum: {guard_reason}");
+    assert!(guard_reason.contains("over_tolerance=3"), "guard reason missing over_tolerance: {guard_reason}");
+}
+
+#[test]
 fn guard_low_n_legacy_input_rejects_p2_undercount() {
     let tmp = TempGuard::new("guard_low_n_legacy");
     let sockets = [5u64, 6];
@@ -845,16 +910,21 @@ fn timestamps_for(n: u64) -> Vec<u64> {
 /// `n_streams × direction_multiplier=1` (iface filter active) within
 /// tolerance.
 fn make_balanced_tsv(n_workers: u32, timestamps: &[u64], iface: &'static str) -> String {
+    let counts = vec![1; n_workers as usize];
+    make_distribution_tsv(&counts, timestamps, iface)
+}
+
+fn make_distribution_tsv(counts: &[u32], timestamps: &[u64], iface: &'static str) -> String {
     let mut rows: Vec<TsvRow> = Vec::new();
     for &ts in timestamps {
-        for w in 0..n_workers {
+        for (w, &count) in counts.iter().enumerate() {
             rows.push(TsvRow {
                 timestamp: ts,
-                binding_slot: w,
+                binding_slot: w as u32,
                 queue_id: 0,
-                worker_id: w,
+                worker_id: w as u32,
                 iface,
-                count: 1, // sum across 6 workers = 6, matches 6 streams (1× single-direction)
+                count,
             });
         }
     }

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -688,6 +688,52 @@ fn guard_p12_allows_bounded_stale_overcount() {
 }
 
 #[test]
+fn rss_expectation_uses_observed_distribution_not_cstruct_normalized_copy() {
+    let tmp = TempGuard::new("rss_observed_not_normalized");
+    let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);
+    let tsv_str = make_distribution_tsv(&[4, 4, 4, 3, 0, 0], &timestamps_for(60), "ge-0-0-2");
+
+    let (output, verdict) = run_with_inputs(&tmp, &json_str, &tsv_str, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+        "--rss-expectation", "max-worker-flow-share:25%",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "RSS expectation must fail against observed [4,4,4,3,0,0], not pass against normalized [3,3,3,3,0,0]; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on RSS expectation FAIL");
+    assert_eq!(v["verdict"], "FAIL");
+    assert_eq!(v["a_i_sum_check_ok"], true);
+    assert_eq!(
+        v["distribution_a_i"],
+        serde_json::json!([4, 4, 4, 3, 0, 0])
+    );
+    assert_eq!(
+        v["cstruct_distribution_a_i"],
+        serde_json::json!([3, 3, 3, 3, 0, 0])
+    );
+    assert_eq!(v["cstruct_adjusted_for_a_i_overcount"], true);
+    assert!(
+        v["max_worker_flow_share"].as_f64().unwrap() > 0.25,
+        "max_worker_flow_share must reflect observed distribution: {v}"
+    );
+    let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
+    assert!(
+        reasons.iter().any(|r| r
+            .as_str()
+            .unwrap_or("")
+            .contains("max_worker_flow_share")),
+        "failure_reasons must contain the observed RSS max-share failure; got: {:?}",
+        reasons
+    );
+}
+
+#[test]
 fn guard_p12_rejects_overcount_beyond_stale_window() {
     let tmp = TempGuard::new("guard_p12_overcount_fail");
     let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);

--- a/userspace-dp/tests/fairness_eval_blackbox.rs
+++ b/userspace-dp/tests/fairness_eval_blackbox.rs
@@ -140,6 +140,16 @@ struct TsvRow {
     count: u32,
 }
 
+/// A single 5-column class-specific CoS active-flow TSV row.
+#[derive(Debug, Clone)]
+struct CosTsvRow {
+    timestamp: u64,
+    ifindex: i32,
+    queue_id: u32,
+    worker_id: u32,
+    count: u32,
+}
+
 /// Build the 6-column TSV (timestamp, binding_slot, queue_id, worker_id,
 /// iface, count) with a leading comment-header line that matches what
 /// `test/incus/fairness-harness.sh` emits on the cluster.
@@ -149,6 +159,17 @@ fn synth_tsv_6col(rows: &[TsvRow]) -> String {
         s.push_str(&format!(
             "{}\t{}\t{}\t{}\t{}\t{}\n",
             r.timestamp, r.binding_slot, r.queue_id, r.worker_id, r.iface, r.count
+        ));
+    }
+    s
+}
+
+fn synth_cos_tsv_5col(rows: &[CosTsvRow]) -> String {
+    let mut s = String::from("# timestamp\tifindex\tqueue_id\tworker_id\tcount\n");
+    for r in rows {
+        s.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\n",
+            r.timestamp, r.ifindex, r.queue_id, r.worker_id, r.count
         ));
     }
     s
@@ -195,6 +216,35 @@ fn run_with_inputs(
         // PASS / FAIL emit verdict JSON to stdout.
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Find the first '{' so any leading log lines don't break parsing.
+        if let Some(brace) = stdout.find('{') {
+            serde_json::from_str(&stdout[brace..]).ok()
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    (output, json)
+}
+
+fn run_with_inputs_and_cos(
+    tmp: &TempGuard,
+    iperf_json_str: &str,
+    tsv_str: &str,
+    cos_tsv_str: &str,
+    extra_args: &[&str],
+) -> (Output, Option<Value>) {
+    let iperf_path = tmp.path().join("iperf3.json");
+    let tsv_path = tmp.path().join("binding-flows.tsv");
+    let cos_tsv_path = tmp.path().join("cos-flows.tsv");
+    fs::write(&iperf_path, iperf_json_str).expect("write iperf3.json");
+    fs::write(&tsv_path, tsv_str).expect("write tsv");
+    fs::write(&cos_tsv_path, cos_tsv_str).expect("write cos tsv");
+    let mut args = vec!["--cos-flows", cos_tsv_path.to_str().unwrap()];
+    args.extend_from_slice(extra_args);
+    let output = run_eval(&iperf_path, &tsv_path, &args);
+    let json = if output.status.code() == Some(0) || output.status.code() == Some(1) {
+        let stdout = String::from_utf8_lossy(&output.stdout);
         if let Some(brace) = stdout.find('{') {
             serde_json::from_str(&stdout[brace..]).ok()
         } else {
@@ -625,6 +675,16 @@ fn guard_p12_allows_bounded_stale_overcount() {
     assert_eq!(v["a_i_sum_under_tolerance"], 2);
     assert_eq!(v["a_i_sum_over_tolerance"], 3);
     assert_eq!(v["a_i_sum_tolerance"], 3);
+    assert_eq!(
+        v["distribution_a_i"],
+        serde_json::json!([4, 4, 4, 3, 0, 0])
+    );
+    assert_eq!(
+        v["cstruct_distribution_a_i"],
+        serde_json::json!([3, 3, 3, 3, 0, 0])
+    );
+    assert_eq!(v["cstruct_adjusted_for_a_i_overcount"], true);
+    assert_eq!(v["cstruct"].as_f64(), Some(0.0));
 }
 
 #[test]
@@ -650,6 +710,11 @@ fn guard_p12_rejects_overcount_beyond_stale_window() {
     assert_eq!(v["a_i_sum_check_ok"], false);
     assert_eq!(v["a_i_sum"], 16);
     assert_eq!(v["a_i_sum_over_tolerance"], 3);
+    assert_eq!(
+        v["cstruct_distribution_a_i"],
+        serde_json::json!([4, 4, 4, 4, 0, 0])
+    );
+    assert_eq!(v["cstruct_adjusted_for_a_i_overcount"], false);
     let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
     let guard_reason = reasons
         .iter()
@@ -658,6 +723,86 @@ fn guard_p12_rejects_overcount_beyond_stale_window() {
         .unwrap_or_else(|| panic!("failure_reasons must contain a Harness guard entry; got: {reasons:?}"));
     assert!(guard_reason.contains("expected=12"), "guard reason missing expected_sum: {guard_reason}");
     assert!(guard_reason.contains("over_tolerance=3"), "guard reason missing over_tolerance: {guard_reason}");
+}
+
+#[test]
+fn cos_path_uses_normalized_distribution_for_bounded_stale_overcount() {
+    let tmp = TempGuard::new("cos_p12_overcount_pass");
+    let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);
+    let binding_tsv = make_distribution_tsv(&[3, 3, 3, 3, 0, 0], &timestamps_for(60), "ge-0-0-2");
+    let cos_tsv = make_cos_distribution_tsv(&[4, 4, 4, 3, 0, 0], &timestamps_for(60), 80, 4);
+
+    let (output, verdict) = run_with_inputs_and_cos(&tmp, &json_str, &binding_tsv, &cos_tsv, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+        "--cos-ifindex", "80",
+        "--cos-queue-id", "4",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "CoS P=12 bounded stale-overcount window should PASS; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on CoS overcount PASS");
+    assert_eq!(v["verdict"], "PASS");
+    assert_eq!(v["cstruct_source"], "cos_queue");
+    assert_eq!(v["distribution_a_i"], serde_json::json!([4, 4, 4, 3, 0, 0]));
+    assert_eq!(
+        v["binding_distribution_a_i"],
+        serde_json::json!([3, 3, 3, 3, 0, 0])
+    );
+    assert_eq!(
+        v["cstruct_distribution_a_i"],
+        serde_json::json!([3, 3, 3, 3, 0, 0])
+    );
+    assert_eq!(v["cstruct_adjusted_for_a_i_overcount"], true);
+    assert_eq!(v["a_i_sum_check_ok"], true);
+    assert_eq!(v["a_i_sum"], 15);
+    assert_eq!(v["a_i_sum_over_tolerance"], 3);
+    assert_eq!(v["cstruct"].as_f64(), Some(0.0));
+}
+
+#[test]
+fn cos_path_rejects_selected_queue_sum_that_exceeds_binding_sum() {
+    let tmp = TempGuard::new("cos_binding_guard");
+    let (_sockets, json_str) = make_balanced_pass_inputs(12, 60);
+    let binding_tsv = make_distribution_tsv(&[1, 1, 1, 1, 1, 1], &timestamps_for(60), "ge-0-0-2");
+    let cos_tsv = make_cos_distribution_tsv(&[3, 3, 3, 3, 0, 0], &timestamps_for(60), 80, 4);
+
+    let (output, verdict) = run_with_inputs_and_cos(&tmp, &json_str, &binding_tsv, &cos_tsv, &[
+        "--iface", "ge-0-0-2",
+        "--n-workers", "6",
+        "--warmup-secs", "0",
+        "--final-burst-secs", "0",
+        "--cos-ifindex", "80",
+        "--cos-queue-id", "4",
+    ]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "selected CoS sum far above binding sum should FAIL; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = verdict.expect("verdict JSON on CoS binding guard FAIL");
+    assert_eq!(v["verdict"], "FAIL");
+    assert_eq!(v["cstruct_source"], "cos_queue");
+    assert_eq!(v["a_i_sum"], 12);
+    assert_eq!(
+        v["binding_distribution_a_i"],
+        serde_json::json!([1, 1, 1, 1, 1, 1])
+    );
+    let reasons = v["failure_reasons"].as_array().expect("failure_reasons array");
+    assert!(
+        reasons.iter().any(|r| r
+            .as_str()
+            .unwrap_or("")
+            .contains("selected CoS sum(a_i)=12 exceeds binding sum(a_i)=6")),
+        "failure_reasons must contain the selected-CoS-vs-binding guard; got: {:?}",
+        reasons
+    );
 }
 
 #[test]
@@ -929,4 +1074,25 @@ fn make_distribution_tsv(counts: &[u32], timestamps: &[u64], iface: &'static str
         }
     }
     synth_tsv_6col(&rows)
+}
+
+fn make_cos_distribution_tsv(
+    counts: &[u32],
+    timestamps: &[u64],
+    ifindex: i32,
+    queue_id: u32,
+) -> String {
+    let mut rows: Vec<CosTsvRow> = Vec::new();
+    for &ts in timestamps {
+        for (w, &count) in counts.iter().enumerate() {
+            rows.push(CosTsvRow {
+                timestamp: ts,
+                ifindex,
+                queue_id,
+                worker_id: w as u32,
+                count,
+            });
+        }
+    }
+    synth_cos_tsv_5col(&rows)
 }


### PR DESCRIPTION
## Summary

- make the active-flow sum guard asymmetric: strict undercount tolerance remains `max(2, floor(10% * expected_sum))`, while overcount tolerance allows a bounded stale-flow window of `max(2, ceil(expected_sum / 4))`
- expose under/over tolerances separately in the verdict JSON while preserving `a_i_sum_tolerance` as the active side's tolerance
- add black-box coverage for the #1281 P=12 shape: `sum(a_i)=15` passes, `sum(a_i)=16` fails
- add a unit test pinning the asymmetric tolerance helper

Closes #1281.

## Validation

- `cargo test --manifest-path userspace-dp/Cargo.toml --release --test fairness_eval_blackbox -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml --release --bin fairness-eval`
- `git diff --check`

Note: `rustfmt --check` remains noisy on pre-existing formatting in these files, so this PR keeps the patch surgical instead of reformatting the module.
