### PR TITLE
Make fairness multi-sample gate Cstruct-aware

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -352,11 +352,21 @@ IPERF_LAUNCH_ARG_3=-- \
 The sweep runs ports 5201..5207 through `fairness_multi_sample.py`,
 preserves per-class artifacts, writes `summary.tsv` and `summary.md`,
 and returns non-zero after completing all classes if any class misses
-its thresholds. For the symmetric reverse fixture on the loss cluster,
-`COS_IFINDEX=5` selects the `ge-0-0-1` egress. For forward-path sweeps,
-do not hardcode the RETH unit's displayed name into the harness; use
-the ifindex emitted by `xpf_userspace_cos_active_flow_count` for the
-actual shaped egress in that run.
+the Cstruct-aware multi-sample contract (`mean_gap ≤ 0.05` and
+`max_gap ≤ 0.05` by default). The summary still reports mean/max/stdev
+observed CoV for context, but absolute CoV is not the default pass/fail
+gate; use the wrapper's opt-in `--max-*cov` flags only for deliberately
+balanced-RSS fixtures.
+
+For the symmetric reverse fixture on the loss cluster, `COS_IFINDEX=5`
+selects the `ge-0-0-1` egress. For forward-path sweeps, do not hardcode
+the RETH unit's displayed name into the harness; use the ifindex emitted
+by `xpf_userspace_cos_active_flow_count` for the actual shaped egress in
+that run. `METRICS_URL` must be reachable from the harness host. If the
+dataplane only exposes Prometheus on the firewall VM loopback, expose a
+temporary host-local proxy or run the harness in a context that can reach
+that endpoint; an unreachable metrics URL is an environment error, not a
+fairness result.
 
 ## Required metrics — exported in production via gRPC/Prometheus
 

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -413,15 +413,17 @@ MQFQ, v8 lease selection, or admission.
   PASS and Guard FAIL depending on RSS placement; tolerance floor
   `GUARD_ABSOLUTE = 2` is too tight at small expected_sum. Small
   follow-up; not a fairness mechanism.
-- **#1232 — v8 multi-sample CoV stability**: use
+- **#1232 — v8 multi-sample fairness stability**: use
   `test/incus/fairness_multi_sample.py` and
   `docs/per-5-tuple/v8-multi-sample.md` before publishing a new
-  iperf-e headline. The gate is mean observed CoV, sample standard
-  deviation, max run CoV, and every per-run fairness verdict. The
-  wrapper requires at least two samples, filters stdout to top-level
-  fairness-eval verdict JSON objects, rejects non-finite or negative
-  threshold fields, enforces non-negative integer `starved_flow_count`,
-  and fails closed on harness timeout.
+  iperf-e headline. The gate is every per-run fairness verdict plus
+  aggregate `observed_cov - Cstruct` thresholds (`mean_gap ≤ 0.05` and
+  `max_gap ≤ 0.05` by default). Absolute observed-CoV mean/stdev/max
+  gates are available only as opt-in diagnostics for deliberately
+  balanced-RSS fixtures. The wrapper requires at least two samples,
+  filters stdout to top-level fairness-eval verdict JSON objects,
+  rejects non-finite or invalid threshold fields, enforces non-negative
+  integer `starved_flow_count`, and fails closed on harness timeout.
 - **#1211 follow-up (only if gate flips to FAIL on a real workload)**:
   open a fresh issue using the revisit criteria in the Path 2
   closure archive. Do not re-open #1211 directly. As of the

--- a/docs/per-5-tuple/tcp-head-start-floor.md
+++ b/docs/per-5-tuple/tcp-head-start-floor.md
@@ -80,7 +80,7 @@ For measurements whose purpose is to isolate dataplane fairness:
   distribution.
 - Publish verdict JSON keys `observed_cov`, `cstruct`, `gap`,
   `starved_flow_count`, `aggregate_mbps`, and the iperf CPU fields,
-  plus the multi-sample mean/stdev/max CoV.
+  plus the multi-sample mean/max gap and contextual mean/stdev/max CoV.
 
 For production traffic, xpf's fairness contract remains
 workload-relative. The PR #1217/#1220 gate passes only when there are

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -1,9 +1,10 @@
 # v8 Multi-Sample Fairness Runbook
 
 Issue #1232 exists because a single iperf-e run can overstate or
-understate CoV stability. Source-port randomness changes the RSS
-placement, so the useful measurement is the run-to-run distribution of
-`observed_cov`, not one lucky sample.
+understate fairness. Source-port randomness changes the RSS placement,
+so the useful measurement is the run-to-run distribution of
+`observed_cov`, `Cstruct`, and the contract gap
+`observed_cov - Cstruct`, not one lucky sample.
 
 Use the wrapper below for the canonical five-sample run:
 
@@ -11,9 +12,8 @@ Use the wrapper below for the canonical five-sample run:
 python3 test/incus/fairness_multi_sample.py \
   --samples 5 \
   --out-dir /tmp/xpf-v8-multi-sample-$(date +%Y%m%d-%H%M%S) \
-  --max-mean-cov 15% \
-  --max-stdev-cov 3% \
-  --max-run-cov 25% \
+  --max-mean-gap 5% \
+  --max-run-gap 5% \
   --per-run-timeout-sec 600 \
   -- \
   2001:559:8585:80::200 5205 12 120 "" http://127.0.0.1:8080/metrics
@@ -23,25 +23,30 @@ The command runs `test/incus/fairness-harness.sh` five times, stores
 each sample's stdout, stderr, command, placement artifacts, and
 `verdict.json`, then writes `summary.json` with:
 
-- mean observed CoV
-- sample standard deviation of observed CoV
-- min/max observed CoV
+- mean/sample-standard-deviation/min/max observed CoV
+- mean/sample-standard-deviation/min/max `Cstruct`
+- mean/sample-standard-deviation/min/max gap
 - per-run fairness verdicts and failure reasons
 
 `--samples` must be at least `2`; the canonical run is `5` samples.
-The default thresholds are CI-grade stability guards over repeated
-iperf-e placement draws, not fairness constants. `--max-mean-cov 15%`
-is the headline stability gate, `--max-stdev-cov 3%` rejects unstable
-run-to-run RSS/placement variance, and `--max-run-cov 25%` prevents one
-bad run from being hidden by the mean.
+The default thresholds are the Cstruct-aware fairness contract:
+`--max-mean-gap 5%` and `--max-run-gap 5%`. Absolute observed-CoV
+thresholds are disabled by default because high observed CoV is
+expected under skewed RSS placement; the meaningful question is whether
+observed CoV exceeds the structural ceiling. Operators can still add
+`--max-mean-cov`, `--max-stdev-cov`, and `--max-run-cov` for a
+deliberately balanced-RSS fixture, but those are opt-in diagnostics, not
+the product fairness gate.
 
 The wrapper reads stdout JSON objects that match the fairness-eval
 verdict schema (`verdict`, `observed_cov`, `cstruct`, `gap`,
 `failure_reasons`, `distribution_a_i`, `n_active`, `saturated`,
 `a_i_sum_check_ok`, and `starved_flow_count`) and ignores all other
 structured logs. Each sample must emit exactly one verdict object with
-finite, non-negative `observed_cov`, `cstruct`, and `gap`; if
-`aggregate_mbps` is present, it is also finite/non-negative validated.
+finite, non-negative `observed_cov` and `cstruct`, plus a finite `gap`
+which may be negative when the measured result is better than the
+structural ceiling. If `aggregate_mbps` is present, it is also
+finite/non-negative validated.
 `starved_flow_count` must be a non-negative integer. Every harness run
 has a 600-second default timeout; on timeout the wrapper kills the entire
 process group (including iperf3 and scraper descendants) before writing
@@ -55,19 +60,17 @@ placement draws. Do not invoke `fairness_multi_sample.py` against a
 pre-captured static snapshot — every run would produce identical
 `observed_cov` and the stdev would be trivially 0.
 
-**Threshold derivation**: `--max-mean-cov 15%` is a conservative
-stability gate for production-shaped v8 flow sets whose observed CoV is
-expected to sit in the low-to-mid teens when the dataplane is healthy.
-`--max-run-cov 25%` bounds one unfavorable RSS placement draw from being
-hidden by the mean. `--max-stdev-cov 3%` allows for about ±0.03 of
-run-to-run noise from ephemeral-port RSS entropy; a stdev above 0.03
-indicates structural instability rather than sampling noise. These
-thresholds should be updated if the dataplane or NIC configuration
-changes materially.
+**Threshold derivation**: `--max-run-gap 5%` matches the single-run
+`fairness-eval` contract (`observed_cov <= Cstruct + 0.05`).
+`--max-mean-gap 5%` prevents the aggregate verdict from passing a set of
+borderline samples by averaging away a persistent positive gap. Absolute
+CoV stability bounds are intentionally opt-in because RSS entropy can
+move the structural ceiling across samples without indicating a
+scheduler regression.
 
 The wrapper exits:
 
-- `0` when all samples PASS and the mean/stdev/max CoV thresholds pass
+- `0` when all samples PASS and the aggregate gap thresholds pass
 - `1` when at least one fairness verdict or aggregate threshold fails
 - `2` for harness timeout, parsing, validation, or environment errors
 

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -3,7 +3,7 @@
 #
 # This is intentionally a sequential qualification harness: each class gets its
 # own sample directory and verdict, then the script emits an aggregate summary
-# and returns non-zero if any class fails its multi-sample thresholds.
+# and returns non-zero if any class fails its multi-sample gap contract.
 
 set -uo pipefail
 
@@ -64,7 +64,7 @@ if ! rm -f "$DATAPLANE_SUMMARY_TSV"; then
 fi
 
 cat > "$SUMMARY_TSV" <<'HEADER'
-class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_cstruct	avg_gap	starved_flows	per_run_verdicts
+class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_cstruct	mean_gap	max_gap	starved_flows	per_run_verdicts
 HEADER
 
 classes=(
@@ -88,7 +88,7 @@ append_error_row() {
     local rate=$4
     local status=$5
 
-    printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\n' \
+    printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' \
         "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
     printf "summary class=%s wrapper_status=%s verdict=ERROR mean_cov=- max_cov=-\n" \
         "$label" "$status"
@@ -426,8 +426,6 @@ for spec in "${classes[@]}"; do
                 end;
             require_samples
             | sample_numbers("aggregate_mbps") as $aggregate_mbps
-            | sample_numbers("cstruct") as $cstruct
-            | sample_numbers("gap") as $gap
             | sample_numbers("starved_flow_count") as $starved
             | sample_verdicts as $sample_verdicts
             | [
@@ -441,8 +439,9 @@ for spec in "${classes[@]}"; do
                 (required_number(["observed_cov", "max"]; "observed_cov.max") | tostring),
                 (required_number(["observed_cov", "sample_stdev"]; "observed_cov.sample_stdev") | tostring),
                 (($aggregate_mbps | add / length) | tostring),
-                (($cstruct | add / length) | tostring),
-                (($gap | add / length) | tostring),
+                (required_number(["cstruct", "mean"]; "cstruct.mean") | tostring),
+                (required_number(["gap", "mean"]; "gap.mean") | tostring),
+                (required_number(["gap", "max"]; "gap.max") | tostring),
                 ($starved | add | tostring),
                 ($sample_verdicts | join(","))
             ] | @tsv' "$summary_json" > "$row_file" 2> "$jq_err"; then
@@ -473,11 +472,11 @@ fi
     printf 'Artifacts: `%s`\n\n' "$ARTIFACT_ROOT"
     printf 'Target: `%s`, streams: `%s`, duration: `%s`, reverse: `%s`, metrics: `%s`, cos_ifindex: `%s`\n\n' \
         "$TARGET" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" "$COS_IFINDEX"
-    printf '| Class | Port | Queue | Verdict | Mean CoV | Max CoV | Stdev CoV | Avg Mbps | Avg Cstruct | Avg Gap | Starved | Per-run |\n'
-    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n'
-    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate _status verdict mean max stdev mbps cstruct gap starved per_run; do
-        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
-            "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$cstruct" "$gap" "$starved" "$per_run"
+    printf '| Class | Port | Queue | Verdict | Mean CoV | Max CoV | Stdev CoV | Avg Mbps | Avg Cstruct | Mean Gap | Max Gap | Starved | Per-run |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n'
+    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate _status verdict mean max stdev mbps cstruct mean_gap max_gap starved per_run; do
+        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+            "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$cstruct" "$mean_gap" "$max_gap" "$starved" "$per_run"
     done
     if capture_dataplane_enabled; then
         printf '\n## Dataplane Counter Deltas\n\n'

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -632,6 +632,32 @@ scrape_metrics() {
     done
 }
 
+require_binding_scrape_rows() {
+    if awk -F'\t' -v iface="$IFACE" '
+        $0 !~ /^#/ && NF >= 6 && $5 == iface { seen = 1 }
+        END { exit seen ? 0 : 1 }
+    ' "$BINDING_TSV"; then
+        return 0
+    fi
+    echo "fairness-harness: no binding active-flow metric rows for iface $IFACE from $METRICS_URL" >&2
+    echo "fairness-harness: check METRICS_URL reachability from the harness host" >&2
+    return 2
+}
+
+require_cos_scrape_rows() {
+    local cos_queue_id=$1
+
+    if awk -F'\t' -v ifindex="$COS_IFINDEX" -v queue_id="$cos_queue_id" '
+        $0 !~ /^#/ && NF >= 5 && $2 == ifindex && $3 == queue_id { seen = 1 }
+        END { exit seen ? 0 : 1 }
+    ' "$COS_TSV"; then
+        return 0
+    fi
+    echo "fairness-harness: no CoS active-flow metric rows for ifindex $COS_IFINDEX queue $cos_queue_id from $METRICS_URL" >&2
+    echo "fairness-harness: check METRICS_URL reachability and COS_IFINDEX/COS_QUEUE_ID" >&2
+    return 2
+}
+
 run_iperf() {
     local label=$1
     local out=$2
@@ -662,6 +688,11 @@ run_eval() {
     local shaper_rate_bps=${5:-$SHAPER_RATE_BPS}
 
     echo "fairness-harness: evaluating ${label}..."
+    require_binding_scrape_rows || return 2
+    if [[ -n "$COS_IFINDEX" && -n "$cos_queue_id" ]]; then
+        require_cos_scrape_rows "$cos_queue_id" || return 2
+    fi
+
     local eval_args=(
         --iperf-json "$iperf_out"
         --binding-flows "$BINDING_TSV"

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run fairness-harness repeatedly and summarize per-run CoV variance."""
+"""Run fairness-harness repeatedly and summarize per-run fairness contract."""
 
 from __future__ import annotations
 
@@ -16,9 +16,11 @@ from typing import Any
 
 
 DEFAULT_SAMPLES = 5
-DEFAULT_MAX_MEAN_COV = 0.15
-DEFAULT_MAX_STDEV_COV = 0.03
-DEFAULT_MAX_RUN_COV = 0.25
+DEFAULT_MAX_MEAN_GAP = 0.05
+DEFAULT_MAX_RUN_GAP = 0.05
+DEFAULT_MAX_MEAN_COV: float | None = None
+DEFAULT_MAX_STDEV_COV: float | None = None
+DEFAULT_MAX_RUN_COV: float | None = None
 DEFAULT_PER_RUN_TIMEOUT_SEC = 600
 POST_KILL_COMMUNICATE_TIMEOUT_SEC = 5
 FAIRNESS_EVAL_VERDICT_KEYS = {
@@ -50,6 +52,12 @@ def parse_ratio(raw: str) -> float:
     if value < 0:
         raise argparse.ArgumentTypeError(f"ratio must be non-negative: {raw!r}")
     return value
+
+
+def optional_ratio(raw: str) -> float | None:
+    if raw.strip().lower() in {"none", "off", "disabled"}:
+        return None
+    return parse_ratio(raw)
 
 
 def extract_json_objects(text: str) -> list[dict[str, Any]]:
@@ -131,29 +139,55 @@ def sample_record(index: int, sample_dir: Path, exit_code: int, verdict: dict[st
 def summarize(
     samples: list[dict[str, Any]],
     *,
-    max_mean_cov: float,
-    max_stdev_cov: float,
-    max_run_cov: float,
+    max_mean_gap: float,
+    max_run_gap: float,
+    max_mean_cov: float | None,
+    max_stdev_cov: float | None,
+    max_run_cov: float | None,
 ) -> dict[str, Any]:
+    if not samples:
+        raise MultiSampleError("no samples")
+
     observed_covs = [float(s["observed_cov"]) for s in samples]
+    cstructs = [float(s["cstruct"]) for s in samples]
+    gaps = [float(s["gap"]) for s in samples]
+
     mean_cov = statistics.mean(observed_covs)
     stdev_cov = statistics.stdev(observed_covs) if len(observed_covs) > 1 else 0.0
     max_cov = max(observed_covs)
     min_cov = min(observed_covs)
 
+    mean_cstruct = statistics.mean(cstructs)
+    stdev_cstruct = statistics.stdev(cstructs) if len(cstructs) > 1 else 0.0
+    max_cstruct = max(cstructs)
+    min_cstruct = min(cstructs)
+
+    mean_gap = statistics.mean(gaps)
+    stdev_gap = statistics.stdev(gaps) if len(gaps) > 1 else 0.0
+    max_gap = max(gaps)
+    min_gap = min(gaps)
+
     failure_reasons: list[str] = []
     failing_samples = [s["sample"] for s in samples if s.get("verdict") != "PASS"]
     if failing_samples:
         failure_reasons.append(f"sample verdicts failed: {failing_samples}")
-    if mean_cov > max_mean_cov:
+    if mean_gap > max_mean_gap:
+        failure_reasons.append(
+            f"mean gap {mean_gap:.6f} exceeds threshold {max_mean_gap:.6f}"
+        )
+    if max_gap > max_run_gap:
+        failure_reasons.append(
+            f"max gap {max_gap:.6f} exceeds threshold {max_run_gap:.6f}"
+        )
+    if max_mean_cov is not None and mean_cov > max_mean_cov:
         failure_reasons.append(
             f"mean observed_cov {mean_cov:.6f} exceeds threshold {max_mean_cov:.6f}"
         )
-    if stdev_cov > max_stdev_cov:
+    if max_stdev_cov is not None and stdev_cov > max_stdev_cov:
         failure_reasons.append(
             f"sample stdev observed_cov {stdev_cov:.6f} exceeds threshold {max_stdev_cov:.6f}"
         )
-    if max_cov > max_run_cov:
+    if max_run_cov is not None and max_cov > max_run_cov:
         failure_reasons.append(
             f"max observed_cov {max_cov:.6f} exceeds threshold {max_run_cov:.6f}"
         )
@@ -162,6 +196,8 @@ def summarize(
         "verdict": "PASS" if not failure_reasons else "FAIL",
         "sample_count": len(samples),
         "thresholds": {
+            "max_mean_gap": max_mean_gap,
+            "max_run_gap": max_run_gap,
             "max_mean_cov": max_mean_cov,
             "max_sample_stdev_cov": max_stdev_cov,
             "max_run_cov": max_run_cov,
@@ -171,6 +207,18 @@ def summarize(
             "sample_stdev": stdev_cov,
             "min": min_cov,
             "max": max_cov,
+        },
+        "cstruct": {
+            "mean": mean_cstruct,
+            "sample_stdev": stdev_cstruct,
+            "min": min_cstruct,
+            "max": max_cstruct,
+        },
+        "gap": {
+            "mean": mean_gap,
+            "sample_stdev": stdev_gap,
+            "min": min_gap,
+            "max": max_gap,
         },
         "samples": samples,
         "failure_reasons": failure_reasons,
@@ -297,6 +345,8 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
 
     summary = summarize(
         samples,
+        max_mean_gap=args.max_mean_gap,
+        max_run_gap=args.max_run_gap,
         max_mean_cov=args.max_mean_cov,
         max_stdev_cov=args.max_stdev_cov,
         max_run_cov=args.max_run_cov,
@@ -312,14 +362,41 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
 def parse_args(argv: list[str]) -> argparse.Namespace:
     default_harness = Path(__file__).with_name("fairness-harness.sh")
     parser = argparse.ArgumentParser(
-        description="Run fairness-harness N times and summarize observed CoV stability.",
+        description="Run fairness-harness N times and summarize Cstruct-aware fairness.",
     )
     parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
     parser.add_argument("--out-dir", type=Path, required=True)
     parser.add_argument("--harness", type=Path, default=default_harness)
-    parser.add_argument("--max-mean-cov", type=parse_ratio, default=DEFAULT_MAX_MEAN_COV)
-    parser.add_argument("--max-stdev-cov", type=parse_ratio, default=DEFAULT_MAX_STDEV_COV)
-    parser.add_argument("--max-run-cov", type=parse_ratio, default=DEFAULT_MAX_RUN_COV)
+    parser.add_argument(
+        "--max-mean-gap",
+        type=parse_ratio,
+        default=DEFAULT_MAX_MEAN_GAP,
+        help="Maximum allowed mean observed_cov-cstruct gap across samples.",
+    )
+    parser.add_argument(
+        "--max-run-gap",
+        type=parse_ratio,
+        default=DEFAULT_MAX_RUN_GAP,
+        help="Maximum allowed observed_cov-cstruct gap in any sample.",
+    )
+    parser.add_argument(
+        "--max-mean-cov",
+        type=optional_ratio,
+        default=DEFAULT_MAX_MEAN_COV,
+        help="Optional absolute mean observed_cov gate; default disabled.",
+    )
+    parser.add_argument(
+        "--max-stdev-cov",
+        type=optional_ratio,
+        default=DEFAULT_MAX_STDEV_COV,
+        help="Optional absolute observed_cov sample-stdev gate; default disabled.",
+    )
+    parser.add_argument(
+        "--max-run-cov",
+        type=optional_ratio,
+        default=DEFAULT_MAX_RUN_COV,
+        help="Optional absolute per-run observed_cov gate; default disabled.",
+    )
     parser.add_argument(
         "--per-run-timeout-sec",
         type=int,

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import math
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -15,6 +16,7 @@ import unittest
 
 
 MODULE_PATH = Path(__file__).with_name("fairness_multi_sample.py")
+HARNESS_PATH = Path(__file__).with_name("fairness-harness.sh")
 SPEC = importlib.util.spec_from_file_location("fairness_multi_sample", MODULE_PATH)
 assert SPEC is not None
 fairness_multi_sample = importlib.util.module_from_spec(SPEC)
@@ -120,22 +122,88 @@ class FairnessMultiSampleTest(unittest.TestCase):
 
         self.assertEqual(record["gap"], -0.49)
 
-    def test_summary_fails_thresholds(self) -> None:
+    def test_summary_defaults_to_cstruct_aware_gap_contract(self) -> None:
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.30,
+                    "cstruct": 0.60,
+                    "gap": -0.30,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.40,
+                    "cstruct": 0.50,
+                    "gap": -0.10,
+                    "exit_code": 0,
+                },
+            ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
+            max_mean_cov=None,
+            max_stdev_cov=None,
+            max_run_cov=None,
+        )
+        self.assertEqual(summary["verdict"], "PASS")
+        self.assertAlmostEqual(summary["gap"]["mean"], -0.20)
+        self.assertAlmostEqual(summary["cstruct"]["mean"], 0.55)
+
+    def test_summary_fails_gap_thresholds(self) -> None:
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.20,
+                    "cstruct": 0.12,
+                    "gap": 0.08,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.19,
+                    "cstruct": 0.12,
+                    "gap": 0.07,
+                    "exit_code": 0,
+                },
+            ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
+            max_mean_cov=None,
+            max_stdev_cov=None,
+            max_run_cov=None,
+        )
+        self.assertEqual(summary["verdict"], "FAIL")
+        self.assertGreater(summary["gap"]["mean"], 0.05)
+        self.assertGreater(summary["gap"]["max"], 0.05)
+
+    def test_summary_optional_cov_thresholds_fail_when_enabled(self) -> None:
         summary = fairness_multi_sample.summarize(
             [
                 {
                     "sample": 1,
                     "verdict": "PASS",
                     "observed_cov": 0.10,
+                    "cstruct": 0.50,
+                    "gap": -0.40,
                     "exit_code": 0,
                 },
                 {
                     "sample": 2,
                     "verdict": "PASS",
                     "observed_cov": 0.30,
+                    "cstruct": 0.50,
+                    "gap": -0.20,
                     "exit_code": 0,
                 },
             ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
             max_mean_cov=0.15,
             max_stdev_cov=0.03,
             max_run_cov=0.25,
@@ -227,6 +295,123 @@ class FairnessMultiSampleTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 2)
             self.assertIn("not finite", result.stderr)
+
+    def test_fairness_harness_accepts_scrape_rows_matching_iface_and_cos_queue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            metrics = tmp_path / "metrics.prom"
+            metrics.write_text(
+                textwrap.dedent(
+                    """\
+                    xpf_userspace_binding_active_flow_count{binding_slot="0",iface="ge-0-0-2",queue_id="6",worker_id="0"} 1
+                    xpf_userspace_cos_active_flow_count{ifindex="5",queue_id="6",worker_id="0"} 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_fake_harness_with_metrics(tmp_path, metrics)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn('"verdict":"PASS"', result.stdout)
+            self.assertTrue((tmp_path / "eval-called").exists())
+
+    def test_fairness_harness_rejects_scrape_rows_for_wrong_cos_queue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            metrics = tmp_path / "metrics.prom"
+            metrics.write_text(
+                textwrap.dedent(
+                    """\
+                    xpf_userspace_binding_active_flow_count{binding_slot="0",iface="ge-0-0-2",queue_id="6",worker_id="0"} 1
+                    xpf_userspace_cos_active_flow_count{ifindex="5",queue_id="4",worker_id="0"} 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_fake_harness_with_metrics(tmp_path, metrics)
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn(
+                "no CoS active-flow metric rows for ifindex 5 queue 6",
+                result.stderr,
+            )
+            self.assertFalse((tmp_path / "eval-called").exists())
+
+    def run_fake_harness_with_metrics(
+        self,
+        tmp_path: Path,
+        metrics: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        sentinel = tmp_path / "curl-called"
+        fake_curl = tmp_path / "curl"
+        fake_iperf = tmp_path / "fake-iperf"
+        fake_eval = tmp_path / "fake-eval"
+        fake_curl.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                touch "$CURL_SENTINEL"
+                cat "$FAKE_METRICS"
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_iperf.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                for _ in {1..50}; do
+                    [[ -e "$CURL_SENTINEL" ]] && break
+                    sleep 0.02
+                done
+                printf '{}\\n'
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_eval.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                touch "$EVAL_SENTINEL"
+                printf '{"verdict":"PASS","observed_cov":0.1,"cstruct":0.2,"gap":-0.1,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true,"a_i_sum_check_ok":true}\\n'
+                """
+            ),
+            encoding="utf-8",
+        )
+        for path in (fake_curl, fake_iperf, fake_eval):
+            path.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "IPERF_BIN": str(fake_iperf),
+            "FAIRNESS_EVAL": str(fake_eval),
+            "COS_IFINDEX": "5",
+            "COS_QUEUE_ID": "6",
+            "CURL_SENTINEL": str(sentinel),
+            "EVAL_SENTINEL": str(tmp_path / "eval-called"),
+            "FAKE_METRICS": str(metrics),
+        }
+        return subprocess.run(
+            [
+                str(HARNESS_PATH),
+                "127.0.0.1",
+                "5203",
+                "1",
+                "1",
+                "",
+                "http://example.invalid/metrics",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=5,
+        )
 
     def test_cli_times_out_harness(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- change fairness_multi_sample defaults from absolute observed-CoV thresholds to Cstruct-aware gap thresholds (mean_gap/max_gap <= 0.05)
- keep absolute observed-CoV gates as opt-in diagnostics for deliberately balanced-RSS fixtures
- add cstruct/gap aggregate stats to summary.json and expose mean_gap/max_gap in the CoS class sweep
- fail closed before fairness-eval when the harness cannot scrape binding or CoS active-flow metric rows
- update runbooks to match the workload-relative fairness contract

## Context
The latest all-class CoS sweep with live metrics had every individual fairness-eval sample PASS, with negative observed_cov-Cstruct gaps across all classes. The wrapper still failed high-rate classes because its aggregate gate used fixed absolute observed_cov thresholds. That contradicts the documented contract: RSS skew can make absolute CoV high even when the scheduler is performing up to the structural ceiling.

Valid sweep artifact that exposed this: /tmp/cos-fairness-all-metrics-20260513T023103Z/summary.md

## Verification
- python3 test/incus/fairness_multi_sample_test.py
- python3 -m py_compile test/incus/fairness_multi_sample.py test/incus/fairness_multi_sample_test.py
- bash -n test/incus/fairness-harness.sh && bash -n test/incus/fairness-cos-class-sweep.sh && git diff --check
- fake unreachable-metrics harness replay: confirms exit 2 before fairness-eval
- fake class-sweep replay: confirms summary.tsv includes avg_cstruct, mean_gap, max_gap