### PR TITLE
Make v8 CoS queue lease strict by default

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -498,11 +498,20 @@ For changes that should NOT affect fairness:
 For changes that explicitly target fairness improvement:
 
 - The PR body must declare the targeted RSS distribution(s).
-- Improvement is measured as **reduction in `(observed_cov -
-  cstruct)`**, not as absolute CoV. A change that reduces the gap
-  on `{1,3}` distribution from `+0.20` to `+0.05` is a clear win;
-  a change that drops absolute CoV from 30% to 25% is meaningless
-  if the RSS distribution changed too.
+- The PR body must say whether the mechanism is intended to stay
+  work-conserving or to intentionally slow a shaped CoS queue for
+  stricter per-flow equality.
+- Work-conserving improvements are measured as **reduction in
+  `(observed_cov - cstruct)`**, not as absolute CoV. A change that
+  reduces the gap on `{1,3}` distribution from `+0.20` to `+0.05` is a
+  clear win; a change that drops absolute CoV from 30% to 25% is
+  meaningless if the RSS distribution changed too.
+- Non-work-conserving exact-CoS improvements, such as strict
+  active-flow-proportional shared-lease budgeting, must report both
+  the Cstruct gap and the absolute per-flow spread on the declared
+  RSS distribution. These changes are allowed to buy a lower absolute
+  CoV by leaving unclaimed worker share idle, but the PR must also
+  report aggregate throughput impact.
 
 ## Non-goals
 
@@ -514,9 +523,14 @@ xpf does NOT claim, and this contract does NOT require:
   zero-copy. The structural CoV ceiling `Cstruct` is a hard
   physical limit set by the per-worker scheduler's ability to
   divide its share equally among its flows.
-- **Equal per-flow throughput within a single RSS-skewed
-  deployment** beyond what `Cstruct` permits. The 1+3 example
-  has a structural minimum CoV of ~58%; xpf cannot do better.
+- **Work-conserving equal per-flow throughput within a single
+  RSS-skewed deployment** beyond what `Cstruct` permits. The 1+3
+  example has a structural minimum CoV of ~58% if every worker is
+  allowed to consume its full share. Exact shaped CoS queues may
+  deliberately step outside that premise by reserving per-worker
+  budget in proportion to active flows and withholding unarmed
+  surplus; that is a throughput tradeoff, not a general AF_XDP
+  load-balancing guarantee.
 - **A single CoV number that holds across all workloads.** The
   structural ceiling is workload-dependent; the gate is
   workload-relative (`observed_cov ≤ Cstruct + ε`).

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -21,6 +21,13 @@ where `Cstruct` is computed from the per-worker active-flow distribution
 
 The user accepts aggregate throughput regression on degenerate RSS
 distributions if it buys per-flow fairness on the realistic ones.
+For exact shaped CoS queues, the current v8 shared-lease direction is
+strict active-flow-proportional budgeting: reserve each worker's queue
+budget in proportion to its active flow count, and open surplus only
+when the explicit CPU-bound bypass has armed. That intentionally drops
+the work-conservation premise for the shaped queue, so absolute
+per-flow spread is a valid target metric alongside the Cstruct
+compatibility gate.
 
 ## Shipped foundations
 
@@ -130,7 +137,7 @@ this is what makes the future-pitch gate non-trivial.
 | 1 | **Random ephemeral source ports** hashed uniformly into RSS queues. | Sets the multinomial draw with `p_w = 1/K`. |
 | 2 | **Uniform per-worker capacity** `C_w = C` for every active worker. | Lets `C` cancel in CoV; with heterogeneous capacity the bound is strictly larger. |
 | 3 | **Within-worker fair share** — each worker splits its capacity equally across its assigned flows. | Without it, a worker can favor some of its own flows and the formula doesn't apply. |
-| 4 | **Work conservation** — workers never idle below their share. | A non-work-conserving scheduler can clip the heaviest flows ("Harrison-Bergeron") and reduce CoV at the cost of aggregate throughput. CoS-on shaping is exactly this case (CoV mean 16.6% on iperf-d, well below the multinomial floor). |
+| 4 | **Work conservation** — workers never idle below their share. | A non-work-conserving scheduler can clip the heaviest flows ("Harrison-Bergeron") and reduce CoV at the cost of aggregate throughput. CoS-on shaping is exactly this case (CoV mean 16.6% on iperf-d, well below the multinomial floor), and the strict v8 shared-lease path uses the same premise break by withholding unarmed surplus. |
 | 5 | **All admitted, no rate-cap** — every flow is served, none rejected or rate-limited. | Same caveat as #4: admission policy can move CoV in either direction. |
 
 Under all five premises, the **population** CoV (matching production
@@ -251,18 +258,21 @@ Recognized levers:
    workers cooperate to fair-share a *global* per-flow allocation
    (rather than each fair-sharing locally), the within-worker
    premise breaks and the bound no longer applies. The known
-   blockers are AF_XDP ZC physics (queue-ownership: see #836, #937,
-   #1215) and the per-flow rate equality / work conservation /
-   no-Harrison-Bergeron trilemma: any global-fair scheme has to give
-   up at least one of them, and the four prior mechanism kills
-   (#1236, #1237, #1239, #1243) each found a different way to prove
-   that.
+   blockers for moving packets or work are AF_XDP ZC physics
+   (queue-ownership: see #836, #937, #1215) and the per-flow rate
+   equality / work conservation / no-Harrison-Bergeron trilemma. The
+   strict shared-lease path does not move packets across AF_XDP
+   queues; it gives up work conservation inside an exact shaped CoS
+   queue by refusing unarmed surplus.
 6. **Non-work-conserving / shaped (premise 4 / 5).** CoS-on iperf-d
    12-stream CoV mean is 16.6%, well below the 51% multinomial
    floor — because shapers clip each flow's rate, dragging the
-   distribution toward the shaped value. The fairness contract
-   already accommodates this: `Cstruct` is computed from `{aᵢ}`,
-   not from a fixed CoV.
+   distribution toward the shaped value. The strict v8 shared-lease
+   path is the per-worker analogue: it can leave a worker's unused
+   reserved share idle unless the explicit CPU-bound bypass opens
+   surplus. The fairness contract still reports `Cstruct` from
+   `{aᵢ}`, but strict-CoS experiments must also report absolute CoV
+   and aggregate-throughput impact.
 
 ### Bar for future fairness pitches
 

--- a/docs/per-5-tuple/v8-multi-sample.md
+++ b/docs/per-5-tuple/v8-multi-sample.md
@@ -38,6 +38,12 @@ observed CoV exceeds the structural ceiling. Operators can still add
 deliberately balanced-RSS fixture, but those are opt-in diagnostics, not
 the product fairness gate.
 
+For strict exact-CoS lease experiments, keep the default Cstruct gap
+thresholds and add explicit absolute-CoV observations to the report.
+Those experiments intentionally allow a shaped queue to leave unarmed
+surplus idle, so a useful result must show both lower absolute per-flow
+spread and the aggregate-throughput cost paid to get it.
+
 The wrapper reads stdout JSON objects that match the fairness-eval
 verdict schema (`verdict`, `observed_cov`, `cstruct`, `gap`,
 `failure_reasons`, `distribution_a_i`, `n_active`, `saturated`,

--- a/userspace-dp/src/afxdp/types/shared_cos_lease.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease.rs
@@ -31,8 +31,10 @@ pub(in crate::afxdp) struct SharedCoSQueueLease {
 // cross-epoch fetch_add contamination. Two-CAS-with-rollback for
 // outstanding-leased cap (legacy state.credits accounting). Bounded
 // rollback retries. Seqlock-style rotation: epoch_seq EVEN→ODD→EVEN.
-// 100µs grace period before surplus claiming opens. Rate-cap clamped
-// via elapsed_ns.min(EPOCH_DURATION_NS).
+// Surplus claiming opens only when the CPU-bound bypass detector arms;
+// the 100µs grace timestamp remains part of the bypass telemetry and
+// legacy detector history. Rate-cap clamped via
+// elapsed_ns.min(EPOCH_DURATION_NS).
 
 /// Epoch duration. Picked to match existing refill cadence.
 pub(in crate::afxdp) const EPOCH_DURATION_NS: u64 = 200_000;
@@ -91,8 +93,10 @@ struct SharedCoSEpochState {
     /// set to N > 0 by rotation, the next N rotations open the surplus
     /// path immediately (no grace-period gate) for active workers.
     /// Rotation arms it when ANY active worker had a starvation event
-    /// in the prior epoch AND aggregate grant was sub-cap by ≥5%.
-    /// Decays one rotation at a time when no worker signals.
+    /// in the prior epoch, aggregate grant was materially sub-cap, and
+    /// at least one active non-signaling peer was both under-utilized
+    /// and had queue-lease demand in that epoch. Decays one rotation
+    /// at a time when the full detector does not fire.
     bypass_grace_rotations_remaining: AtomicU32,
     /// #1231 v5: telemetry — count of rotations where the bypass was
     /// armed. Operator-visible via Prometheus.
@@ -136,11 +140,17 @@ struct V8State {
     /// #1231 v5: per-worker starvation events this epoch. Each slot is
     /// packed (epoch_tag, event_count). Bumped via tag-checked CAS at
     /// the narrow-signal exit in acquire_v8: "primary exhausted AND
-    /// class room remains AND grace not expired AND active AND
-    /// still_needed > 0". Reset at rotation via atomic swap (returned
-    /// old captures any in-flight bumps; tag mismatch on subsequent
-    /// in-flight CAS naturally rejects them). Length = max_worker_id + 1.
+    /// class room remains AND active AND still_needed > 0". Reset at
+    /// rotation via atomic swap (returned old captures any in-flight
+    /// bumps; tag mismatch on subsequent in-flight CAS naturally
+    /// rejects them). Length = max_worker_id + 1.
     worker_starvation_events: Box<[PackedEpochGrant]>,
+    /// #1290 round-2: per-worker queue-lease demand events this epoch.
+    /// Bumped once per active acquire_v8 call before granting. Rotation
+    /// uses this to distinguish a genuinely backlogged under-utilized
+    /// peer from a naturally quiet peer whose active-flow counter is
+    /// merely nonzero. Length = max_worker_id + 1.
+    worker_demand_events: Box<[PackedEpochGrant]>,
 }
 
 pub(in crate::afxdp) struct SharedCoSRootLease {
@@ -579,6 +589,10 @@ impl SharedCoSQueueLease {
             .map(|_| PackedEpochGrant::new())
             .collect::<Vec<_>>()
             .into_boxed_slice();
+        let worker_demand_events = (0..len)
+            .map(|_| PackedEpochGrant::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         Self {
             config,
             state: SharedCoSLeaseState {
@@ -591,6 +605,7 @@ impl SharedCoSQueueLease {
                 worker_active_flow_buckets,
                 worker_fair_share,
                 worker_starvation_events,
+                worker_demand_events,
             }),
         }
     }
@@ -668,6 +683,15 @@ impl SharedCoSQueueLease {
             return 0;
         }
 
+        let active = v8
+            .worker_active_flow_buckets
+            .get(worker_id)
+            .map(|a| a.load(Ordering::Relaxed) > 0)
+            .unwrap_or(false);
+        if active {
+            bump_epoch_event(&v8.worker_demand_events[worker_id], my_tag);
+        }
+
         let mut total_granted: u64 = 0;
         let mut still_needed = requested;
 
@@ -732,13 +756,7 @@ impl SharedCoSQueueLease {
             still_needed -= take;
         }
 
-        // === SURPLUS PATH: post-grace OR bypass; active workers only ===
-        let active = v8
-            .worker_active_flow_buckets
-            .get(worker_id)
-            .map(|a| a.load(Ordering::Relaxed) > 0)
-            .unwrap_or(false);
-
+        // === SURPLUS PATH: bypass only; active workers only ===
         // #1231 v5: bypass-grace flag set by rotation when 'all peers
         // CPU-bound' regime detected. Cheap-predicate-gated narrow-signal
         // bump (per Codex v5 probe F): only do the expensive tag-checked
@@ -748,10 +766,12 @@ impl SharedCoSQueueLease {
             .bypass_grace_rotations_remaining
             .load(Ordering::Relaxed)
             > 0;
-        if still_needed > 0 && active && now_ns < grace {
+        if still_needed > 0 && active {
             // Cheap predicates passed; do the expensive tag-checked reads
             // to confirm the narrow exit "primary exhausted AND class
-            // room remains AND grace closed AND active AND still_needed>0".
+            // room remains AND active AND still_needed>0". This signal
+            // deliberately remains live after grace because strict exact
+            // CoS no longer opens unarmed post-grace surplus.
             let my_curr = v8.worker_grants[worker_id].0.load(Ordering::Acquire);
             let (my_curr_tag, my_consumed_now) = PackedEpochGrant::unpack(my_curr);
             let class_curr = v8.epoch.packed_granted.0.load(Ordering::Acquire);
@@ -766,19 +786,20 @@ impl SharedCoSQueueLease {
                 // naturally; bounded retry is unnecessary because one
                 // missed bump per epoch is fine (rotation only checks
                 // count > 0).
-                let pg = &v8.worker_starvation_events[worker_id];
-                let curr = pg.0.load(Ordering::Acquire);
-                let (curr_tag, curr_count) = PackedEpochGrant::unpack(curr);
-                if curr_tag == my_tag && curr_count < u32::MAX {
-                    let new = PackedEpochGrant::pack(curr_tag, curr_count + 1);
-                    let _ = pg
-                        .0
-                        .compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire);
-                }
+                bump_epoch_event(&v8.worker_starvation_events[worker_id], my_tag);
             }
         }
 
-        let surplus_open = (now_ns >= grace) || bypass;
+        // Strict per-flow fairness path: do not automatically let
+        // faster workers claim peer primary-share slack just because
+        // half the epoch elapsed. That old post-grace behavior was
+        // work-conserving, but it also let workers with fewer active
+        // flows exceed their active-flow-proportional share during
+        // normal shaper-bound traffic. Keep surplus available only
+        // when the explicit CPU-bound bypass has armed; that path is
+        // already gated by prior-epoch starvation + aggregate underuse
+        // + peer-utilization checks at rotation.
+        let surplus_open = bypass;
         // #1231 v5: telemetry — track if any surplus byte was granted
         // while bypass was the reason (now_ns < grace AND bypass).
         let bypass_was_reason = bypass && now_ns < grace;
@@ -1006,14 +1027,22 @@ impl SharedCoSQueueLease {
         let n_workers = v8.worker_grants.len().min(MAX_WORKERS_SCRATCH);
         debug_assert!(v8.worker_grants.len() <= MAX_WORKERS_SCRATCH);
         let mut signaled_by_worker = [false; MAX_WORKERS_SCRATCH];
+        let mut demanded_by_worker = [false; MAX_WORKERS_SCRATCH];
         let mut prev_grants = [0u32; MAX_WORKERS_SCRATCH];
         let mut active_by_worker = [false; MAX_WORKERS_SCRATCH];
 
-        // STEP 2: swap event slots, track per-worker signal flags.
+        // STEP 2: swap event slots, track per-worker signal/demand flags.
         let mut any_active_worker_signaled = false;
-        for (id, pg) in v8.worker_starvation_events.iter().enumerate() {
-            let old = pg.0.swap(new_packed_zero, Ordering::AcqRel);
-            let (_old_tag, old_count) = PackedEpochGrant::unpack(old);
+        for id in 0..v8.worker_starvation_events.len() {
+            let old_starvation = v8.worker_starvation_events[id]
+                .0
+                .swap(new_packed_zero, Ordering::AcqRel);
+            let (_old_starvation_tag, old_starvation_count) =
+                PackedEpochGrant::unpack(old_starvation);
+            let old_demand = v8.worker_demand_events[id]
+                .0
+                .swap(new_packed_zero, Ordering::AcqRel);
+            let (_old_demand_tag, old_demand_count) = PackedEpochGrant::unpack(old_demand);
             let active = v8
                 .worker_active_flow_buckets
                 .get(id)
@@ -1021,11 +1050,12 @@ impl SharedCoSQueueLease {
                 .unwrap_or(false);
             if id < n_workers {
                 active_by_worker[id] = active;
-                if active && old_count > 0 {
+                demanded_by_worker[id] = old_demand_count > 0;
+                if active && old_starvation_count > 0 {
                     signaled_by_worker[id] = true;
                     any_active_worker_signaled = true;
                 }
-            } else if active && old_count > 0 {
+            } else if active && old_starvation_count > 0 {
                 any_active_worker_signaled = true;
             }
         }
@@ -1039,12 +1069,18 @@ impl SharedCoSQueueLease {
             }
         }
 
-        // #1231 v5.5 STEP 3.5: peer-utilization gate. iperf-c
-        // saturation has CPU-bound peers consuming <60% of share;
-        // iperf-e shaper-bound peers consume ~90%. Discriminator.
-        let mut any_peer_under_util = false;
+        // #1231 v5.5 + #1290 round-2 STEP 3.5: peer-utilization
+        // gate. iperf-c saturation has CPU-bound peers consuming
+        // <60% of share; iperf-e shaper-bound peers consume ~90%.
+        // #1290 adds the demand flag so a naturally quiet peer whose
+        // active-flow counter is merely nonzero cannot be mistaken
+        // for a CPU-bound peer with stranded capacity.
+        let mut any_peer_cpu_bound_under_util = false;
         for id in 0..n_workers {
             if !active_by_worker[id] || signaled_by_worker[id] {
+                continue;
+            }
+            if !demanded_by_worker[id] {
                 continue;
             }
             let share = v8
@@ -1063,7 +1099,7 @@ impl SharedCoSQueueLease {
             // - 60% threshold (v5.5) leaves moderately-utilized
             //   peers alone; only fires on CPU-bound regimes.
             if (prev_grants[id] as u64).saturating_mul(5) < share.saturating_mul(3) {
-                any_peer_under_util = true;
+                any_peer_cpu_bound_under_util = true;
                 break;
             }
         }
@@ -1078,11 +1114,13 @@ impl SharedCoSQueueLease {
         let aggregate_underuse =
             prev_granted.saturating_add(underuse_slack) < prev_cap;
 
-        // #1231 v5 STEP 5: arm or decay bypass. Both conditions
-        // must hold to arm: any active worker signaled starvation
-        // AND the class was sub-cap (room was available — grace
-        // gating was the cause of stranded primary share).
-        if any_active_worker_signaled && aggregate_underuse && any_peer_under_util {
+        // #1231 v5 + #1290 round-2 STEP 5: arm or decay bypass.
+        // All conditions must hold: some active worker hit its
+        // primary share while class room remained, aggregate grants
+        // were materially sub-cap, and at least one active
+        // non-signaling peer both requested queue-lease credit and
+        // consumed <60% of its primary share.
+        if any_active_worker_signaled && aggregate_underuse && any_peer_cpu_bound_under_util {
             v8.epoch
                 .bypass_grace_rotations_remaining
                 .store(5, Ordering::Release);
@@ -1156,6 +1194,18 @@ fn try_bump_outstanding(
         {
             return true;
         }
+    }
+}
+
+#[inline]
+fn bump_epoch_event(pg: &PackedEpochGrant, my_tag: u32) {
+    let curr = pg.0.load(Ordering::Acquire);
+    let (curr_tag, curr_count) = PackedEpochGrant::unpack(curr);
+    if curr_tag == my_tag && curr_count < u32::MAX {
+        let new = PackedEpochGrant::pack(curr_tag, curr_count + 1);
+        let _ = pg
+            .0
+            .compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire);
     }
 }
 
@@ -1260,4 +1310,3 @@ impl SharedCoSRootLease {
 #[cfg(test)]
 #[path = "shared_cos_lease_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/afxdp/types/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease_tests.rs
@@ -374,6 +374,150 @@ fn v8_acquire_proportional_share_with_asymmetric_flow_counts() {
 }
 
 #[test]
+fn v8_post_grace_does_not_grant_unarmed_surplus_beyond_fair_share() {
+    // Two workers, A has 4 flows and B has 1. B's primary share is
+    // 1/5 of the epoch cap. Once B has consumed that share, merely
+    // waiting past the grace point must not let it claim A's reserved
+    // primary share. That would preserve RSS-placement unfairness by
+    // allowing low-flow-count workers to overrun their proportional
+    // budget during normal shaper-bound traffic.
+    let lease = SharedCoSQueueLease::new_v8(50_000_000, 256 * 1024, 2, 1);
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+
+    let first = lease.acquire_v8(1, EPOCH_DURATION_NS, 2_000);
+    assert_eq!(first, 2_000, "B gets its 1/5 primary share");
+
+    let after_grace_same_epoch = EPOCH_DURATION_NS + (EPOCH_DURATION_NS / 2) + 1;
+    let second = lease.acquire_v8(1, after_grace_same_epoch, u64::MAX);
+    assert_eq!(
+        second, 0,
+        "unarmed post-grace surplus must not exceed B's fair share"
+    );
+
+    let v8 = lease.v8.as_ref().unwrap();
+    let curr = v8.worker_starvation_events[1].0.load(Ordering::Acquire);
+    let (_tag, events) = PackedEpochGrant::unpack(curr);
+    assert_eq!(
+        events, 1,
+        "post-grace denial must still feed the bypass detector"
+    );
+}
+
+#[test]
+fn v8_explicit_bypass_still_allows_surplus_beyond_fair_share() {
+    // The strict path only removes unconditional post-grace surplus.
+    // The explicit CPU-bound bypass remains available for the
+    // work-conservation case where rotation detected prior-epoch
+    // starvation, aggregate underuse, and an under-utilized peer.
+    let lease = SharedCoSQueueLease::new_v8(50_000_000, 256 * 1024, 2, 1);
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+
+    let first = lease.acquire_v8(1, EPOCH_DURATION_NS, 2_000);
+    assert_eq!(first, 2_000, "B gets its 1/5 primary share");
+
+    lease
+        .v8
+        .as_ref()
+        .unwrap()
+        .epoch
+        .bypass_grace_rotations_remaining
+        .store(1, Ordering::Release);
+
+    let before_grace_same_epoch = EPOCH_DURATION_NS + 1;
+    let second = lease.acquire_v8(1, before_grace_same_epoch, u64::MAX);
+    assert!(
+        second > 0,
+        "explicit bypass should still open surplus when armed"
+    );
+}
+
+#[test]
+fn bypass_does_not_arm_from_underutil_peer_without_demand() {
+    // A quiet peer with a nonzero active-flow count must not be
+    // treated as CPU-bound merely because it consumed less than its
+    // primary share. Otherwise strict exact CoS would immediately
+    // defeat itself in asymmetric normal-traffic placements.
+    let lease = SharedCoSQueueLease::new_v8(50_000_000, 256 * 1024, 2, 1);
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+
+    let _ = lease.acquire_v8(1, EPOCH_DURATION_NS, 1);
+    {
+        let v8 = lease.v8.as_ref().unwrap();
+        let cap = v8.epoch.epoch_total_grant_cap.load(Ordering::Acquire);
+        assert_eq!(cap, 10_000);
+        let curr = v8.epoch.packed_granted.0.load(Ordering::Acquire);
+        let (tag, _) = PackedEpochGrant::unpack(curr);
+        v8.epoch
+            .packed_granted
+            .0
+            .store(PackedEpochGrant::pack(tag, 3_000), Ordering::Release);
+        v8.worker_grants[0]
+            .0
+            .store(PackedEpochGrant::pack(tag, 1_000), Ordering::Release);
+        v8.worker_starvation_events[1]
+            .0
+            .store(PackedEpochGrant::pack(tag, 1), Ordering::Release);
+        v8.worker_demand_events[0]
+            .0
+            .store(PackedEpochGrant::pack(tag, 0), Ordering::Release);
+    }
+
+    let arms_before = lease.v8_bypass_grace_arms();
+    let _ = lease.acquire_v8(1, 2 * EPOCH_DURATION_NS, 1);
+    assert_eq!(
+        lease.v8_bypass_grace_arms(),
+        arms_before,
+        "underutilized peer without demand must not arm bypass"
+    );
+    assert!(!lease.v8_bypass_grace_active());
+}
+
+#[test]
+fn bypass_arms_for_underutil_peer_with_demand() {
+    // Positive control for the demand-qualified peer-underutil gate:
+    // a signaled worker plus aggregate underuse plus an active peer
+    // that both requested lease credit and consumed <60% of share
+    // still arms the explicit CPU-bound bypass.
+    let lease = SharedCoSQueueLease::new_v8(50_000_000, 256 * 1024, 2, 1);
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+
+    let _ = lease.acquire_v8(1, EPOCH_DURATION_NS, 1);
+    {
+        let v8 = lease.v8.as_ref().unwrap();
+        let cap = v8.epoch.epoch_total_grant_cap.load(Ordering::Acquire);
+        assert_eq!(cap, 10_000);
+        let curr = v8.epoch.packed_granted.0.load(Ordering::Acquire);
+        let (tag, _) = PackedEpochGrant::unpack(curr);
+        v8.epoch
+            .packed_granted
+            .0
+            .store(PackedEpochGrant::pack(tag, 3_000), Ordering::Release);
+        v8.worker_grants[0]
+            .0
+            .store(PackedEpochGrant::pack(tag, 1_000), Ordering::Release);
+        v8.worker_starvation_events[1]
+            .0
+            .store(PackedEpochGrant::pack(tag, 1), Ordering::Release);
+        v8.worker_demand_events[0]
+            .0
+            .store(PackedEpochGrant::pack(tag, 1), Ordering::Release);
+    }
+
+    let arms_before = lease.v8_bypass_grace_arms();
+    let _ = lease.acquire_v8(1, 2 * EPOCH_DURATION_NS, 1);
+    assert_eq!(
+        lease.v8_bypass_grace_arms(),
+        arms_before + 1,
+        "demand-qualified underutilized peer should arm bypass"
+    );
+    assert!(lease.v8_bypass_grace_active());
+}
+
+#[test]
 fn v8_lease_is_send_and_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<SharedCoSQueueLease>();


### PR DESCRIPTION
## Summary
- remove unconditional post-grace surplus from the v8 shared CoS queue lease
- keep surplus available only when the explicit CPU-bound bypass has armed
- add lease-level tests for unarmed post-grace denial and armed-bypass surplus
- update the fairness docs/runbook to distinguish Cstruct-gap compliance from strict exact-CoS experiments that intentionally trade throughput for lower absolute per-flow spread

## Context
A forward q2 run (`iperf3 -c 172.16.80.200 -P 12 -t600 -p 5205`) showed roughly 0.185 per-stream CoV and a 1.65x min/max spread even though the Cstruct-aware reverse sweep was passing. The existing v8 lease already computed active-flow-proportional primary shares, but after half an epoch it reopened surplus for any worker. That made the queue work-conserving and let low-flow workers consume peer primary-share slack during normal shaper-bound traffic.

This PR makes exact shaped CoS stricter by default: a worker can exceed its active-flow-proportional primary share only when the existing CPU-bound bypass has explicitly armed. That should slow faster/low-flow workers in the RSS-skew case we are trying to equalize.

## Verification
- `cargo test --manifest-path userspace-dp/Cargo.toml shared_cos_lease -- --nocapture`
- `git diff --check`

## Measurement follow-up
After review/merge, rerun the forward 12-flow q2 fixture and the all-class CoS sweep. Report absolute CoV, Cstruct gap, aggregate throughput, active-flow distribution, and bypass counters so we can quantify the fairness/throughput tradeoff.