### PR TITLE
Fix forward-mode fairness harness default

### DIFF
--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -12,7 +12,9 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 TARGET=${TARGET:-172.16.80.200}
 N=${N:-12}
 DURATION=${DURATION:-75}
-REVERSE=${REVERSE:--R}
+# Default to reverse only when REVERSE is unset. REVERSE= selects a
+# forward sweep.
+REVERSE=${REVERSE--R}
 METRICS_URL=${METRICS_URL:-http://127.0.0.1:8080/metrics}
 IFACE=${IFACE:-ge-0-0-2}
 COS_IFINDEX=${COS_IFINDEX:-}

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -83,7 +83,9 @@ fi
 PORT=${2:-$DEFAULT_PORT}
 N=${3:-12}
 T=${4:-120}
-REVERSE=${5:--R}
+# Default to the historical reverse fixture only when the argument is
+# absent. An explicit empty fifth argument selects forward mode.
+REVERSE=${5--R}
 METRICS_URL=${6:-http://127.0.0.1:8080/metrics}
 # IFACE filters per-binding samples to one interface so {a_i} reflects
 # per-worker counts for the test's data direction, not bidirectional
@@ -94,7 +96,9 @@ COS_IFINDEX=${COS_IFINDEX:-}
 COS_QUEUE_ID=${COS_QUEUE_ID:-}
 MIXED_PORT=${MIXED_PORT:-5202}
 MIXED_N=${MIXED_N:-$N}
-MIXED_REVERSE=${MIXED_REVERSE:-$REVERSE}
+# Preserve an explicit empty MIXED_REVERSE so mixed forward fixtures do
+# not silently inherit reverse mode.
+MIXED_REVERSE=${MIXED_REVERSE-$REVERSE}
 MIXED_COS_QUEUE_ID=${MIXED_COS_QUEUE_ID:-}
 N_WORKERS=${N_WORKERS:-6}
 SHAPER_RATE_BPS=${SHAPER_RATE_BPS:-}

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -315,6 +315,48 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertIn('"verdict":"PASS"', result.stdout)
             self.assertTrue((tmp_path / "eval-called").exists())
 
+    def test_fairness_harness_empty_reverse_arg_means_forward(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            metrics = tmp_path / "metrics.prom"
+            metrics.write_text(
+                textwrap.dedent(
+                    """\
+                    xpf_userspace_binding_active_flow_count{binding_slot="0",iface="ge-0-0-2",queue_id="6",worker_id="0"} 1
+                    xpf_userspace_cos_active_flow_count{ifindex="5",queue_id="6",worker_id="0"} 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_fake_harness_with_metrics(tmp_path, metrics)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            iperf_args = (tmp_path / "iperf-argv.txt").read_text(encoding="utf-8").splitlines()
+            self.assertNotIn("-R", iperf_args)
+
+    def test_fairness_harness_omitted_reverse_arg_defaults_to_reverse(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            metrics = tmp_path / "metrics.prom"
+            metrics.write_text(
+                textwrap.dedent(
+                    """\
+                    xpf_userspace_binding_active_flow_count{binding_slot="0",iface="ge-0-0-2",queue_id="6",worker_id="0"} 1
+                    xpf_userspace_cos_active_flow_count{ifindex="5",queue_id="6",worker_id="0"} 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_fake_harness_with_metrics(
+                tmp_path,
+                metrics,
+                harness_args=["127.0.0.1", "5203", "1", "1"],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            iperf_args = (tmp_path / "iperf-argv.txt").read_text(encoding="utf-8").splitlines()
+            self.assertIn("-R", iperf_args)
+
     def test_fairness_harness_rejects_scrape_rows_for_wrong_cos_queue(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -341,6 +383,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
         self,
         tmp_path: Path,
         metrics: Path,
+        harness_args: list[str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         sentinel = tmp_path / "curl-called"
         fake_curl = tmp_path / "curl"
@@ -362,6 +405,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 """\
                 #!/usr/bin/env bash
                 set -euo pipefail
+                printf '%s\\n' "$@" > "$IPERF_ARGV_PATH"
                 for _ in {1..50}; do
                     [[ -e "$CURL_SENTINEL" ]] && break
                     sleep 0.02
@@ -395,17 +439,19 @@ class FairnessMultiSampleTest(unittest.TestCase):
             "CURL_SENTINEL": str(sentinel),
             "EVAL_SENTINEL": str(tmp_path / "eval-called"),
             "FAKE_METRICS": str(metrics),
+            "IPERF_ARGV_PATH": str(tmp_path / "iperf-argv.txt"),
         }
-        return subprocess.run(
-            [
-                str(HARNESS_PATH),
+        if harness_args is None:
+            harness_args = [
                 "127.0.0.1",
                 "5203",
                 "1",
                 "1",
                 "",
                 "http://example.invalid/metrics",
-            ],
+            ]
+        return subprocess.run(
+            [str(HARNESS_PATH), *harness_args],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
## Summary
- preserve an explicit empty reverse argument in `fairness-harness.sh` so forward runs do not silently become `-R` reverse runs
- preserve `REVERSE=` / `MIXED_REVERSE=` in the class sweep and mixed harness paths
- add harness tests proving omitted reverse still defaults to `-R`, while an explicit empty argument runs forward

## Validation
- `python3 -m unittest discover -s test/incus -p 'fairness_multi_sample_test.py'`\n- `git diff --check`\n- post-#1290 forward q2 600s measurement: `/tmp/cos-q2-forward-strict-20260513T054433Z`, PASS, observed CoV 0.0921, aggregate 12.92 Gbps\n- all-class forward sweep: `/tmp/cos-forward-all-strict-20260513T055519Z`, all 7 classes PASS\n\n## Measurement note\nThis was found while trying to reproduce `iperf3 -c 172.16.80.200 -P 12 -t600 -p 5205`. The pre-fix harness logged `-R` even when called with an explicit empty fifth argument; the fixed harness logs the forward command without `-R`.