### PR TITLE
Add CoS throughput headroom measurement tooling

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -358,6 +358,30 @@ observed CoV for context, but absolute CoV is not the default pass/fail
 gate; use the wrapper's opt-in `--max-*cov` flags only for deliberately
 balanced-RSS fixtures.
 
+For throughput-headroom investigations, narrow the sweep to the high-rate
+classes and preserve the raw iperf/flow artifacts from each sample:
+
+```bash
+COS_IFINDEX=<egress-ifindex> \
+REVERSE= \
+METRICS_URL=http://127.0.0.1:8080/metrics \
+./test/incus/fairness-cos-throughput-headroom.sh
+```
+
+By default this wrapper runs `CLASS_FILTER=q2,q3,q6` under the strict
+exact fixture, then applies a diagnostic `surplus-sharing` fixture and
+runs the same class set again before restoring the strict fixture. The
+surplus-sharing leg is a headroom diagnostic, not the product fairness
+contract: it shows whether the dataplane can recover aggregate throughput
+when exact queues are allowed to borrow root surplus. Each harness sample
+now preserves `iperf-single.json` (or `iperf-primary.json` /
+`iperf-mixed.json`) plus `binding-flows.tsv` and `cos-flows.tsv` under
+the sample artifact directory, so per-stream rates and active-flow
+placement can be audited after the wrapper exits. The class sweep passes
+`--sample-cooldown-sec` to the multi-sample wrapper (`10` seconds by
+default) so back-to-back iperf runs do not reuse stale CoS active-flow
+buckets as current-run RSS evidence.
+
 For the symmetric reverse fixture on the loss cluster, `COS_IFINDEX=5`
 selects the `ge-0-0-1` egress. For forward-path sweeps, do not hardcode
 the RETH unit's displayed name into the harness; use the ifindex emitted

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -5,6 +5,7 @@
 #
 #   ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 #   ./test/incus/apply-cos-config.sh --symmetric loss:xpf-userspace-fw0
+#   ./test/incus/apply-cos-config.sh --surplus-sharing loss:xpf-userspace-fw0
 #   ./test/incus/apply-cos-config.sh                     # defaults to xpf-userspace-fw0
 #
 # Only the RG0 primary needs the config applied — it replicates to the
@@ -37,10 +38,12 @@ set -euo pipefail
 # silently treated as hostnames.
 SAME_CLASS=0
 SYMMETRIC=0
+SURPLUS_SHARING=0
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --same-class) SAME_CLASS=1; shift ;;
         --symmetric) SYMMETRIC=1; shift ;;
+        --surplus-sharing) SURPLUS_SHARING=1; shift ;;
         --) shift; break ;;
         *) echo "unknown flag: $1" >&2; exit 2 ;;
     esac
@@ -81,7 +84,27 @@ fi
 SETS_TMP="$(mktemp)"
 trap "rm -f '$SETS_TMP'" EXIT
 grep -E '^set ' "$CONFIG_FILE" > "$SETS_TMP"
+if [[ "$SURPLUS_SHARING" -eq 1 ]]; then
+	awk '
+		$1 == "set" &&
+		$2 == "class-of-service" &&
+		$3 == "schedulers" &&
+		$5 == "transmit-rate" &&
+		$NF == "exact" {
+			exact[$4] = 1
+		}
+		END {
+			for (sched in exact) {
+				printf "set class-of-service schedulers %s surplus-sharing\n", sched
+			}
+		}
+	' "$SETS_TMP" | sort >> "$SETS_TMP"
+fi
 
+# Re-runs can leave a root-owned temp file behind on the VM. Remove it
+# before pushing so repeated strict/surplus diagnostic applies do not
+# fail with a stale permission error.
+incus exec "$TARGET" -- rm -f "$REMOTE_SETS" >/dev/null 2>&1 || true
 incus file push --mode 0644 "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
 
 # Deletes that may or may not exist depending on whether this is a

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -18,7 +18,9 @@ REVERSE=${REVERSE--R}
 METRICS_URL=${METRICS_URL:-http://127.0.0.1:8080/metrics}
 IFACE=${IFACE:-ge-0-0-2}
 COS_IFINDEX=${COS_IFINDEX:-}
+CLASS_FILTER=${CLASS_FILTER:-}
 SAMPLES=${SAMPLES:-3}
+SAMPLE_COOLDOWN_SEC=${SAMPLE_COOLDOWN_SEC:-10}
 PER_RUN_TIMEOUT_SEC=${PER_RUN_TIMEOUT_SEC:-180}
 ARTIFACT_ROOT=${ARTIFACT_ROOT:-}
 HARNESS=${HARNESS:-$ROOT_DIR/test/incus/fairness-harness.sh}
@@ -66,7 +68,7 @@ if ! rm -f "$DATAPLANE_SUMMARY_TSV"; then
 fi
 
 cat > "$SUMMARY_TSV" <<'HEADER'
-class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_cstruct	mean_gap	max_gap	starved_flows	per_run_verdicts
+class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_rate_utilization	avg_cstruct	mean_gap	max_gap	starved_flows	per_run_verdicts
 HEADER
 
 classes=(
@@ -79,6 +81,29 @@ classes=(
     "q6-iperf-c-25g 5203 6 25000000000"
 )
 
+class_selected() {
+    local label=$1
+    local port=$2
+    local queue=$3
+    local raw
+    local filter
+    local -a filters
+
+    [[ -n "$CLASS_FILTER" ]] || return 0
+    IFS=',' read -r -a filters <<< "$CLASS_FILTER"
+    for raw in "${filters[@]}"; do
+        filter=${raw//[[:space:]]/}
+        [[ -n "$filter" ]] || continue
+        if [[ "$filter" == "$label" || "$filter" == "$port" || "$filter" == "$queue" ]]; then
+            return 0
+        fi
+        if [[ "$filter" =~ ^q[0-9]+$ && "$label" == "$filter"-* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 mark_parse_error() {
     overall_status=2
 }
@@ -90,7 +115,7 @@ append_error_row() {
     local rate=$4
     local status=$5
 
-    printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' \
+    printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' \
         "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
     printf "summary class=%s wrapper_status=%s verdict=ERROR mean_cov=- max_cov=-\n" \
         "$label" "$status"
@@ -342,8 +367,19 @@ HEADER
 overall_status=0
 dataplane_status=0
 SWEEP_START_ISO=$(date -Is)
-capture_dataplane_snapshot before "$ARTIFACT_ROOT"
+selected_classes=()
 for spec in "${classes[@]}"; do
+    read -r label port queue rate <<< "$spec"
+    if class_selected "$label" "$port" "$queue"; then
+        selected_classes+=("$spec")
+    fi
+done
+if [[ "${#selected_classes[@]}" -eq 0 ]]; then
+    echo "fairness-cos-class-sweep: CLASS_FILTER selected no classes: $CLASS_FILTER" >&2
+    exit 2
+fi
+capture_dataplane_snapshot before "$ARTIFACT_ROOT"
+for spec in "${selected_classes[@]}"; do
     read -r label port queue rate <<< "$spec"
     out="$ARTIFACT_ROOT/$label"
     mkdir -p "$out"
@@ -360,6 +396,7 @@ for spec in "${classes[@]}"; do
             --samples "$SAMPLES" \
             --out-dir "$out/samples" \
             --per-run-timeout-sec "$PER_RUN_TIMEOUT_SEC" \
+            --sample-cooldown-sec "$SAMPLE_COOLDOWN_SEC" \
             --harness "$HARNESS" \
             -- "$TARGET" "$port" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" \
         > "$out/wrapper.stdout" 2> "$out/wrapper.stderr"
@@ -427,9 +464,11 @@ for spec in "${classes[@]}"; do
                     $values
                 end;
             require_samples
+            | ($rate | tonumber) as $rate_bps
             | sample_numbers("aggregate_mbps") as $aggregate_mbps
             | sample_numbers("starved_flow_count") as $starved
             | sample_verdicts as $sample_verdicts
+            | (($aggregate_mbps | add / length)) as $avg_mbps
             | [
                 $class,
                 $port,
@@ -440,7 +479,8 @@ for spec in "${classes[@]}"; do
                 (required_number(["observed_cov", "mean"]; "observed_cov.mean") | tostring),
                 (required_number(["observed_cov", "max"]; "observed_cov.max") | tostring),
                 (required_number(["observed_cov", "sample_stdev"]; "observed_cov.sample_stdev") | tostring),
-                (($aggregate_mbps | add / length) | tostring),
+                ($avg_mbps | tostring),
+                (if $rate_bps > 0 then (($avg_mbps * 1000000 / $rate_bps) | tostring) else "-" end),
                 (required_number(["cstruct", "mean"]; "cstruct.mean") | tostring),
                 (required_number(["gap", "mean"]; "gap.mean") | tostring),
                 (required_number(["gap", "max"]; "gap.max") | tostring),
@@ -474,11 +514,14 @@ fi
     printf 'Artifacts: `%s`\n\n' "$ARTIFACT_ROOT"
     printf 'Target: `%s`, streams: `%s`, duration: `%s`, reverse: `%s`, metrics: `%s`, cos_ifindex: `%s`\n\n' \
         "$TARGET" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" "$COS_IFINDEX"
-    printf '| Class | Port | Queue | Verdict | Mean CoV | Max CoV | Stdev CoV | Avg Mbps | Avg Cstruct | Mean Gap | Max Gap | Starved | Per-run |\n'
-    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n'
-    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate _status verdict mean max stdev mbps cstruct mean_gap max_gap starved per_run; do
-        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
-            "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$cstruct" "$mean_gap" "$max_gap" "$starved" "$per_run"
+    if [[ -n "$CLASS_FILTER" ]]; then
+        printf 'Class filter: `%s`\n\n' "$CLASS_FILTER"
+    fi
+    printf '| Class | Port | Queue | Verdict | Mean CoV | Max CoV | Stdev CoV | Avg Mbps | Avg rate utilization | Avg Cstruct | Mean Gap | Max Gap | Starved | Per-run |\n'
+    printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n'
+    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate _status verdict mean max stdev mbps util cstruct mean_gap max_gap starved per_run; do
+        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+            "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$util" "$cstruct" "$mean_gap" "$max_gap" "$starved" "$per_run"
     done
     if capture_dataplane_enabled; then
         printf '\n## Dataplane Counter Deltas\n\n'

--- a/test/incus/fairness-cos-throughput-headroom.sh
+++ b/test/incus/fairness-cos-throughput-headroom.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Compare high-rate CoS fairness/throughput fixtures under strict exact
+# scheduling and an optional surplus-sharing diagnostic config.
+
+set -uo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+TARGET_VM=${TARGET_VM:-loss:xpf-userspace-fw0}
+APPLY_CONFIG=${APPLY_CONFIG:-1}
+COMPARE_SURPLUS_SHARING=${COMPARE_SURPLUS_SHARING:-1}
+CLASS_FILTER=${CLASS_FILTER:-q2,q3,q6}
+ARTIFACT_ROOT=${ARTIFACT_ROOT:-}
+SWEEP=${SWEEP:-$ROOT_DIR/test/incus/fairness-cos-class-sweep.sh}
+APPLY_COS_CONFIG=${APPLY_COS_CONFIG:-$ROOT_DIR/test/incus/apply-cos-config.sh}
+RESTORE_STRICT_NEEDED=0
+
+enabled() {
+    case "${1,,}" in
+        1|true|yes|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+if [[ ! -x "$SWEEP" ]]; then
+    echo "fairness-cos-throughput-headroom: sweep is not executable: $SWEEP" >&2
+    exit 2
+fi
+if enabled "$APPLY_CONFIG" && [[ ! -x "$APPLY_COS_CONFIG" ]]; then
+    echo "fairness-cos-throughput-headroom: apply script is not executable: $APPLY_COS_CONFIG" >&2
+    exit 2
+fi
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+    ARTIFACT_ROOT=$(mktemp -d -t cos-throughput-headroom.XXXXXX)
+else
+    mkdir -p "$ARTIFACT_ROOT"
+fi
+
+SUMMARY_TSV="$ARTIFACT_ROOT/summary.tsv"
+SUMMARY_MD="$ARTIFACT_ROOT/summary.md"
+cat > "$SUMMARY_TSV" <<'HEADER'
+scenario	class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_cov	stdev_observed_cov	avg_mbps	avg_rate_utilization	avg_cstruct	mean_gap	max_gap	starved_flows	per_run_verdicts
+HEADER
+
+restore_strict_if_needed() {
+    [[ "$RESTORE_STRICT_NEEDED" -eq 1 ]] || return 0
+    enabled "$APPLY_CONFIG" || return 0
+
+    if "$APPLY_COS_CONFIG" "$TARGET_VM" \
+        > "$ARTIFACT_ROOT/restore-strict.stdout" \
+        2> "$ARTIFACT_ROOT/restore-strict.stderr"; then
+        RESTORE_STRICT_NEEDED=0
+        return 0
+    fi
+    return 1
+}
+
+on_exit() {
+    local status=$?
+    trap - EXIT HUP INT QUIT TERM
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        status=2
+    fi
+    exit "$status"
+}
+
+on_int() {
+    local status=130
+    trap - EXIT HUP INT QUIT TERM
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config after interrupt; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        status=2
+    fi
+    exit "$status"
+}
+
+on_term() {
+    local status=143
+    trap - EXIT HUP INT QUIT TERM
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config after termination; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        status=2
+    fi
+    exit "$status"
+}
+
+on_hup() {
+    local status=129
+    trap - EXIT HUP INT QUIT TERM
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config after hangup; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        status=2
+    fi
+    exit "$status"
+}
+
+on_quit() {
+    local status=131
+    trap - EXIT HUP INT QUIT TERM
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config after quit; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        status=2
+    fi
+    exit "$status"
+}
+
+trap on_exit EXIT
+trap on_hup HUP
+trap on_int INT
+trap on_quit QUIT
+trap on_term TERM
+
+apply_config_for_scenario() {
+    local scenario=$1
+    local out=$2
+
+    enabled "$APPLY_CONFIG" || return 0
+    mkdir -p "$out"
+    if [[ "$scenario" == surplus-sharing ]]; then
+        RESTORE_STRICT_NEEDED=1
+        "$APPLY_COS_CONFIG" --surplus-sharing "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
+    else
+        "$APPLY_COS_CONFIG" "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
+    fi
+}
+
+run_scenario() {
+    local scenario=$1
+    local out="$ARTIFACT_ROOT/$scenario"
+    local status
+    local apply_status
+
+    mkdir -p "$out"
+    echo "=== $(date -Is) scenario=$scenario class_filter=$CLASS_FILTER ==="
+    apply_config_for_scenario "$scenario" "$out"
+    apply_status=$?
+    if [[ "$apply_status" -ne 0 ]]; then
+        echo "fairness-cos-throughput-headroom: failed to apply $scenario config; see $out/apply.stderr" >&2
+        printf '%s\t-\t-\t-\t-\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' "$scenario" "$apply_status" >> "$SUMMARY_TSV"
+        return "$apply_status"
+    fi
+
+    env CLASS_FILTER="$CLASS_FILTER" ARTIFACT_ROOT="$out/sweep" "$SWEEP" \
+        > "$out/sweep.stdout" 2> "$out/sweep.stderr"
+    status=$?
+    if [[ -f "$out/sweep/summary.tsv" ]]; then
+        tail -n +2 "$out/sweep/summary.tsv" \
+            | awk -v scenario="$scenario" 'BEGIN { FS = OFS = "\t" } { print scenario, $0 }' \
+            >> "$SUMMARY_TSV"
+    else
+        printf '%s\t-\t-\t-\t-\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' "$scenario" "$status" >> "$SUMMARY_TSV"
+    fi
+    return "$status"
+}
+
+overall_status=0
+run_scenario strict || overall_status=$?
+
+if enabled "$COMPARE_SURPLUS_SHARING"; then
+    run_scenario surplus-sharing || {
+        status=$?
+        if [[ "$overall_status" -eq 0 || "$status" -eq 2 ]]; then
+            overall_status=$status
+        fi
+    }
+    # Leave the fixture in the strict default state after the diagnostic
+    # comparison unless the operator explicitly disabled config applies.
+    if ! restore_strict_if_needed; then
+        echo "fairness-cos-throughput-headroom: failed to restore strict config; see $ARTIFACT_ROOT/restore-strict.stderr" >&2
+        overall_status=2
+    fi
+fi
+
+if ! {
+    printf '# CoS Throughput Headroom Comparison\n\n'
+    printf 'Artifacts: `%s`\n\n' "$ARTIFACT_ROOT"
+    printf 'Class filter: `%s`\n\n' "$CLASS_FILTER"
+    printf '| Scenario | Class | Queue | Verdict | Avg Mbps | Avg rate utilization | Mean CoV | Max CoV | Mean Gap | Max Gap | Starved |\n'
+    printf '|---|---|---:|---|---:|---:|---:|---:|---:|---:|---:|\n'
+    tail -n +2 "$SUMMARY_TSV" | while IFS=$'\t' read -r scenario class _port queue _rate _status verdict mean max _stdev mbps util _cstruct mean_gap max_gap starved _per_run; do
+        printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+            "$scenario" "$class" "$queue" "$verdict" "$mbps" "$util" "$mean" "$max" "$mean_gap" "$max_gap" "$starved"
+    done
+} > "$SUMMARY_MD"; then
+    echo "fairness-cos-throughput-headroom: failed to write $SUMMARY_MD" >&2
+    overall_status=2
+fi
+
+echo "fairness-cos-throughput-headroom: wrote $SUMMARY_TSV"
+echo "fairness-cos-throughput-headroom: wrote $SUMMARY_MD"
+exit "$overall_status"

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -511,6 +511,31 @@ setup_artifact_dir() {
     fi
 }
 
+copy_artifact_file() {
+    local src=$1
+    local dst=$2
+
+    [[ -n "$ARTIFACT_DIR" ]] || return 0
+    [[ -e "$src" ]] || return 0
+    if ! cp "$src" "$ARTIFACT_DIR/$dst"; then
+        echo "fairness-harness: failed to preserve artifact $src -> $ARTIFACT_DIR/$dst" >&2
+        exit 2
+    fi
+}
+
+persist_harness_artifacts() {
+    [[ -n "$ARTIFACT_DIR" ]] || return 0
+
+    copy_artifact_file "$BINDING_TSV" binding-flows.tsv
+    copy_artifact_file "$COS_TSV" cos-flows.tsv
+    if [[ "$MIXED_COS" -eq 1 ]]; then
+        copy_artifact_file "$IPERF_OUT" iperf-primary.json
+        copy_artifact_file "$MIXED_IPERF_OUT" iperf-mixed.json
+    else
+        copy_artifact_file "$IPERF_OUT" iperf-single.json
+    fi
+}
+
 write_placement_artifact() {
     [[ -n "$ARTIFACT_DIR" ]] || return 0
 
@@ -726,6 +751,7 @@ cleanup() {
 }
 trap 'cleanup; rm -rf "$WORK_DIR"' EXIT
 
+IPERF_STATUS=0
 if [[ "$MIXED_COS" -eq 1 ]]; then
     run_iperf "primary port $PORT queue $COS_QUEUE_ID" "$IPERF_OUT" "$PORT" "$N" "$REVERSE" \
         "$IPERF_LAUNCH_NETNS" "$IPERF_LAUNCH_CPUSET" IPERF_LAUNCH_ARG \
@@ -738,7 +764,6 @@ if [[ "$MIXED_COS" -eq 1 ]]; then
     MIXED_PID=$!
     append_runtime_artifact mixed "$MIXED_PID"
 
-    IPERF_STATUS=0
     if wait "$PRIMARY_PID"; then :; else IPERF_STATUS=$?; fi
     if wait "$MIXED_PID"; then
         :
@@ -748,17 +773,21 @@ if [[ "$MIXED_COS" -eq 1 ]]; then
             IPERF_STATUS=$MIXED_WAIT_STATUS
         fi
     fi
-    if [[ "$IPERF_STATUS" -ne 0 ]]; then
-        cleanup
-        exit "$IPERF_STATUS"
-    fi
 else
+    set +e
     run_iperf "single" "$IPERF_OUT" "$PORT" "$N" "$REVERSE" \
         "$IPERF_LAUNCH_NETNS" "$IPERF_LAUNCH_CPUSET" IPERF_LAUNCH_ARG \
         "$IPERF_NETNS" "$IPERF_CPUSET" IPERF_GENERATOR_ARG "$IPERF_BIN"
+    IPERF_STATUS=$?
+    set -e
 fi
 
 cleanup
+persist_harness_artifacts
+
+if [[ "$IPERF_STATUS" -ne 0 ]]; then
+    exit "$IPERF_STATUS"
+fi
 
 if [[ "$MIXED_COS" -eq 1 ]]; then
     set +e

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import statistics
 import subprocess
 import sys
+import time
 from typing import Any
 
 
@@ -22,6 +23,7 @@ DEFAULT_MAX_MEAN_COV: float | None = None
 DEFAULT_MAX_STDEV_COV: float | None = None
 DEFAULT_MAX_RUN_COV: float | None = None
 DEFAULT_PER_RUN_TIMEOUT_SEC = 600
+DEFAULT_SAMPLE_COOLDOWN_SEC = 0
 POST_KILL_COMMUNICATE_TIMEOUT_SEC = 5
 FAIRNESS_EVAL_VERDICT_KEYS = {
     "verdict",
@@ -167,6 +169,14 @@ def summarize(
     max_gap = max(gaps)
     min_gap = min(gaps)
 
+    aggregate_mbps_values: list[float] | None = []
+    for sample in samples:
+        value = sample.get("aggregate_mbps")
+        if value is None:
+            aggregate_mbps_values = None
+            break
+        aggregate_mbps_values.append(float(value))
+
     failure_reasons: list[str] = []
     failing_samples = [s["sample"] for s in samples if s.get("verdict") != "PASS"]
     if failing_samples:
@@ -192,7 +202,7 @@ def summarize(
             f"max observed_cov {max_cov:.6f} exceeds threshold {max_run_cov:.6f}"
         )
 
-    return {
+    summary = {
         "verdict": "PASS" if not failure_reasons else "FAIL",
         "sample_count": len(samples),
         "thresholds": {
@@ -223,6 +233,20 @@ def summarize(
         "samples": samples,
         "failure_reasons": failure_reasons,
     }
+    if aggregate_mbps_values is None:
+        summary["aggregate_mbps"] = None
+    else:
+        summary["aggregate_mbps"] = {
+            "mean": statistics.mean(aggregate_mbps_values),
+            "sample_stdev": (
+                statistics.stdev(aggregate_mbps_values)
+                if len(aggregate_mbps_values) > 1
+                else 0.0
+            ),
+            "min": min(aggregate_mbps_values),
+            "max": max(aggregate_mbps_values),
+        }
+    return summary
 
 
 def _kill_process_group(pgid: int) -> None:
@@ -318,6 +342,7 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
                     "argv": cmd,
                     "exit_code": exit_code,
                     "timeout_sec": args.per_run_timeout_sec,
+                    "sample_cooldown_sec": args.sample_cooldown_sec,
                 },
                 indent=2,
             )
@@ -342,6 +367,8 @@ def run_samples(args: argparse.Namespace) -> dict[str, Any]:
             encoding="utf-8",
         )
         samples.append(sample_record(index, sample_dir, exit_code, verdict))
+        if index < args.samples and args.sample_cooldown_sec > 0:
+            time.sleep(args.sample_cooldown_sec)
 
     summary = summarize(
         samples,
@@ -404,6 +431,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Hard timeout for each fairness-harness run.",
     )
     parser.add_argument(
+        "--sample-cooldown-sec",
+        type=float,
+        default=DEFAULT_SAMPLE_COOLDOWN_SEC,
+        help="Seconds to sleep between samples so dataplane active-flow snapshots can age out.",
+    )
+    parser.add_argument(
         "harness_args",
         nargs=argparse.REMAINDER,
         help="Arguments passed to fairness-harness.sh. Prefix with -- to separate.",
@@ -413,6 +446,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error("--samples must be >= 2")
     if args.per_run_timeout_sec <= 0:
         parser.error("--per-run-timeout-sec must be > 0")
+    if args.sample_cooldown_sec < 0:
+        parser.error("--sample-cooldown-sec must be >= 0")
     if not args.harness.exists():
         parser.error(f"--harness does not exist: {args.harness}")
     if not os.access(args.harness, os.X_OK):

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -13,10 +13,12 @@ import tempfile
 import textwrap
 import time
 import unittest
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("fairness_multi_sample.py")
 HARNESS_PATH = Path(__file__).with_name("fairness-harness.sh")
+CLASS_SWEEP_PATH = Path(__file__).with_name("fairness-cos-class-sweep.sh")
 SPEC = importlib.util.spec_from_file_location("fairness_multi_sample", MODULE_PATH)
 assert SPEC is not None
 fairness_multi_sample = importlib.util.module_from_spec(SPEC)
@@ -151,6 +153,41 @@ class FairnessMultiSampleTest(unittest.TestCase):
         self.assertEqual(summary["verdict"], "PASS")
         self.assertAlmostEqual(summary["gap"]["mean"], -0.20)
         self.assertAlmostEqual(summary["cstruct"]["mean"], 0.55)
+        self.assertIsNone(summary["aggregate_mbps"])
+
+    def test_summary_reports_aggregate_mbps_stats_when_present(self) -> None:
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.10,
+                    "cstruct": 0.50,
+                    "gap": -0.40,
+                    "aggregate_mbps": 900.0,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.20,
+                    "cstruct": 0.50,
+                    "gap": -0.30,
+                    "aggregate_mbps": 1100.0,
+                    "exit_code": 0,
+                },
+            ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
+            max_mean_cov=None,
+            max_stdev_cov=None,
+            max_run_cov=None,
+        )
+
+        self.assertEqual(summary["verdict"], "PASS")
+        self.assertEqual(summary["aggregate_mbps"]["mean"], 1000.0)
+        self.assertEqual(summary["aggregate_mbps"]["min"], 900.0)
+        self.assertEqual(summary["aggregate_mbps"]["max"], 1100.0)
 
     def test_summary_fails_gap_thresholds(self) -> None:
         summary = fairness_multi_sample.summarize(
@@ -263,6 +300,43 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertTrue((out_dir / "sample-1" / "verdict.json").exists())
             self.assertTrue((out_dir / "sample-2" / "artifacts").is_dir())
 
+    def test_run_samples_sleeps_between_samples_when_cooldown_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            harness = tmp_path / "fake-harness.sh"
+            harness.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    printf '{"verdict":"PASS","observed_cov":0.1,"cstruct":0.0,"gap":0.0,"aggregate_mbps":1.0,"starved_flow_count":0,"failure_reasons":[],"distribution_a_i":[1],"n_active":1,"saturated":true,"a_i_sum_check_ok":true}\\n'
+                    """
+                ),
+                encoding="utf-8",
+            )
+            harness.chmod(0o755)
+            out_dir = tmp_path / "out"
+            args = fairness_multi_sample.parse_args(
+                [
+                    "--samples",
+                    "3",
+                    "--sample-cooldown-sec",
+                    "0.25",
+                    "--out-dir",
+                    str(out_dir),
+                    "--harness",
+                    str(harness),
+                ]
+            )
+
+            with mock.patch.object(fairness_multi_sample.time, "sleep") as sleep:
+                summary = fairness_multi_sample.run_samples(args)
+
+            self.assertEqual(summary["verdict"], "PASS")
+            sleep.assert_has_calls([mock.call(0.25), mock.call(0.25)])
+            self.assertEqual(sleep.call_count, 2)
+            command = json.loads((out_dir / "sample-2" / "command.json").read_text(encoding="utf-8"))
+            self.assertEqual(command["sample_cooldown_sec"], 0.25)
+
     def test_cli_rejects_nan_observed_cov(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -334,6 +408,33 @@ class FairnessMultiSampleTest(unittest.TestCase):
             iperf_args = (tmp_path / "iperf-argv.txt").read_text(encoding="utf-8").splitlines()
             self.assertNotIn("-R", iperf_args)
 
+    def test_fairness_harness_preserves_raw_sample_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            metrics = tmp_path / "metrics.prom"
+            metrics.write_text(
+                textwrap.dedent(
+                    """\
+                    xpf_userspace_binding_active_flow_count{binding_slot="0",iface="ge-0-0-2",queue_id="6",worker_id="0"} 1
+                    xpf_userspace_cos_active_flow_count{ifindex="5",queue_id="6",worker_id="0"} 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_fake_harness_with_metrics(tmp_path, metrics)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            artifact_dir = tmp_path / "artifacts"
+            self.assertEqual((artifact_dir / "iperf-single.json").read_text(encoding="utf-8"), "{}\n")
+            self.assertIn(
+                'ge-0-0-2\t1',
+                (artifact_dir / "binding-flows.tsv").read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                '5\t6\t0\t1',
+                (artifact_dir / "cos-flows.tsv").read_text(encoding="utf-8"),
+            )
+
     def test_fairness_harness_omitted_reverse_arg_defaults_to_reverse(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -379,6 +480,75 @@ class FairnessMultiSampleTest(unittest.TestCase):
             )
             self.assertFalse((tmp_path / "eval-called").exists())
 
+    def test_class_sweep_filter_and_rate_utilization_column(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_wrapper = tmp_path / "fake-wrapper.sh"
+            fake_harness = tmp_path / "fake-harness.sh"
+            fake_eval = tmp_path / "fake-eval"
+            out_root = tmp_path / "sweep"
+            fake_wrapper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    out_dir=
+                    while [[ $# -gt 0 ]]; do
+                        case "$1" in
+                            --out-dir) out_dir=$2; shift 2 ;;
+                            --) shift; break ;;
+                            *) shift ;;
+                        esac
+                    done
+                    mkdir -p "$out_dir"
+                    cat > "$out_dir/summary.json" <<'JSON'
+                    {
+                      "verdict": "PASS",
+                      "observed_cov": {"mean": 0.1, "max": 0.2, "sample_stdev": 0.01},
+                      "cstruct": {"mean": 0.3},
+                      "gap": {"mean": -0.2, "max": -0.1},
+                      "samples": [
+                        {"verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0},
+                        {"verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0}
+                      ]
+                    }
+                    JSON
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_harness.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            fake_eval.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            for path in (fake_wrapper, fake_harness, fake_eval):
+                path.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "ARTIFACT_ROOT": str(out_root),
+                "CAPTURE_DATAPLANE": "0",
+                "CLASS_FILTER": "q2",
+                "COS_IFINDEX": "14",
+                "WRAPPER": str(fake_wrapper),
+                "HARNESS": str(fake_harness),
+                "FAIRNESS_EVAL": str(fake_eval),
+            }
+            result = subprocess.run(
+                [str(CLASS_SWEEP_PATH)],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+                timeout=5,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            summary_lines = (out_root / "summary.tsv").read_text(encoding="utf-8").splitlines()
+            self.assertIn("avg_rate_utilization", summary_lines[0])
+            self.assertEqual(len(summary_lines), 2)
+            row = summary_lines[1].split("\t")
+            self.assertEqual(row[0], "q2-iperf-e-16g")
+            self.assertEqual(row[10], "0.5")
+
     def run_fake_harness_with_metrics(
         self,
         tmp_path: Path,
@@ -406,10 +576,11 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 #!/usr/bin/env bash
                 set -euo pipefail
                 printf '%s\\n' "$@" > "$IPERF_ARGV_PATH"
-                for _ in {1..50}; do
+                for _ in {1..100}; do
                     [[ -e "$CURL_SENTINEL" ]] && break
                     sleep 0.02
                 done
+                sleep 0.1
                 printf '{}\\n'
                 """
             ),
@@ -440,6 +611,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
             "EVAL_SENTINEL": str(tmp_path / "eval-called"),
             "FAKE_METRICS": str(metrics),
             "IPERF_ARGV_PATH": str(tmp_path / "iperf-argv.txt"),
+            "ARTIFACT_DIR": str(tmp_path / "artifacts"),
         }
         if harness_args is None:
             harness_args = [


### PR DESCRIPTION
## Summary
- preserve raw per-sample iperf JSON plus binding/CoS active-flow TSVs from `fairness-harness.sh`
- add aggregate Mbps stats to the multi-sample summary
- add `CLASS_FILTER` and avg rate-utilization columns to the CoS class sweep
- add a high-rate q2/q3/q6 throughput-headroom wrapper that compares strict exact scheduling against a diagnostic surplus-sharing fixture and restores strict config afterward
- document the new headroom workflow

## Why
#1290 materially improved fairness, but high-rate forward classes are below configured shaper rates. This PR gives us the artifacts needed to separate endpoint/CPU limits from strict-lease under-utilization and to compare against a controlled work-conserving surplus-sharing diagnostic.

Closes #1292.

## Validation
- `python3 -m unittest discover -s test/incus -p 'fairness_multi_sample_test.py'`\n- `bash -n test/incus/fairness-harness.sh test/incus/fairness-cos-class-sweep.sh test/incus/apply-cos-config.sh test/incus/fairness-cos-throughput-headroom.sh`\n- `git diff --check`\n- dry-run `fairness-cos-throughput-headroom.sh` with fake apply/sweep commands\n\n## Notes\nThe surplus-sharing leg is diagnostic only. It is not changing the fairness contract; it lets us ask whether the dataplane can recover aggregate throughput if exact queues are allowed to borrow root surplus.