### PR TITLE
Refresh active-flow telemetry while idle

### DIFF
--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -135,10 +135,12 @@ pub(super) struct FlowCacheEntry {
     /// `lookup()` hit — see `FlowCache::current_epoch` for the comparison
     /// reference. The ~65ms-tick scan in `count_active_flows()` counts
     /// entries with `(current_epoch - last_used_epoch) < 10` (~650ms
-    /// window). u16 wraps every 65536 epochs × 65ms ≈ 71 minutes, far
-    /// past any concern. Value 0 = "never touched" sentinel (epoch 0 is
-    /// skipped by `tick_advance_epoch`); freshly inserted entries carry
-    /// 0 until their first lookup hit.
+    /// window). The hot path reaches that cadence by poll counter; the idle
+    /// RX-empty path uses a wall-clock cadence so active-flow telemetry also
+    /// ages while traffic is quiet. u16 wraps every 65536 epochs × 65ms ≈ 71
+    /// minutes, far past any concern. Value 0 = "never touched" sentinel
+    /// (epoch 0 is skipped by `tick_advance_epoch`); freshly inserted entries
+    /// carry 0 until their first lookup hit.
     pub(super) last_used_epoch: u16,
 }
 
@@ -388,9 +390,10 @@ impl FlowCache {
     }
 
     /// #1219: count cache entries hit in the last `ACTIVE_WINDOW_EPOCHS`
-    /// ticks. Epoch advance is driven by the umem debug-publish gate
-    /// (every 0xFFFF poll calls, ≈ 65 ms in steady state), so 10
-    /// epochs ≈ 650 ms. Owner-only periodic scan; not on the hot path.
+    /// ticks. Epoch advance is driven by the umem debug-publish gate:
+    /// hot polling uses the 0xFFFF-call counter, while RX-empty idle polling
+    /// uses a ~65ms wall-clock cadence. 10 epochs ≈ 650 ms. Owner-only
+    /// periodic scan; not on the hot path.
     /// O(N) over `FLOW_CACHE_SIZE` (4096 entries, see top of this file).
     #[cfg(test)]
     pub(super) fn count_active_flows(&self) -> u32 {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::afxdp::worker::WorkerTimers;
 
 mod mmap;
 mod profile;
@@ -1060,13 +1061,49 @@ impl BindingLiveState {
     }
 }
 
+const DEBUG_STATE_PUBLISH_MASK: u32 = 0xFFFF;
+const IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS: u64 = 65_000_000;
+
+fn advance_debug_state_publish_counter(timers: &mut WorkerTimers) -> bool {
+    timers.debug_state_counter = timers.debug_state_counter.wrapping_add(1);
+    timers.debug_state_counter & DEBUG_STATE_PUBLISH_MASK == 0
+}
+
+fn idle_debug_state_publish_due(timers: &mut WorkerTimers, now_ns: u64) -> bool {
+    if now_ns.saturating_sub(timers.last_idle_debug_publish_ns)
+        < IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS
+    {
+        return false;
+    }
+    timers.last_idle_debug_publish_ns = now_ns;
+    true
+}
+
 pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
-    // Use a simple modular counter to avoid 7 atomic stores on every call.
-    // At ~1M calls/sec, checking every 65536 calls ~= every 65ms.
-    binding.timers.debug_state_counter = binding.timers.debug_state_counter.wrapping_add(1);
-    if binding.timers.debug_state_counter & 0xFFFF != 0 {
+    // Use a simple modular counter to avoid repeated atomic stores on every
+    // hot-path call. At ~1M calls/sec, checking every 65536 calls ~= every 65ms.
+    if !advance_debug_state_publish_counter(&mut binding.timers) {
         return;
     }
+    publish_binding_debug_state(binding);
+}
+
+pub(super) fn update_binding_idle_debug_state(binding: &mut BindingWorker, now_ns: u64) {
+    // #1294: the hot-path counter's ~65ms assumption only holds while a
+    // binding is polling hot. In interrupt/idle loops, 65536 empty polls can
+    // take seconds to minutes, leaving stale active-flow snapshots visible
+    // long after traffic stops. The RX-empty path already has `now_ns`, so
+    // use a wall-clock-equivalent cadence there without adding per-packet
+    // clock reads or atomics to active forwarding.
+    let regular_publish = advance_debug_state_publish_counter(&mut binding.timers);
+    let idle_publish = idle_debug_state_publish_due(&mut binding.timers, now_ns);
+    if !(regular_publish || idle_publish) {
+        return;
+    }
+    publish_binding_debug_state(binding);
+}
+
+fn publish_binding_debug_state(binding: &mut BindingWorker) {
     if binding.tx_counters.pending_direct_tx_packets != 0 {
         binding.live.direct_tx_packets.fetch_add(
             binding.tx_counters.pending_direct_tx_packets,
@@ -1160,12 +1197,13 @@ pub(super) fn update_binding_debug_state(binding: &mut BindingWorker) {
         );
         binding.flow.flow_cache.collision_evictions = 0;
     }
-    // #1219: advance the flow_cache active-flow epoch and publish
-    // the count for the harness's structural CoV gate. Single
-    // owner-side write per ~65ms tick. With ACTIVE_WINDOW_EPOCHS = 10
-    // the active-flow window is ~650ms. u16 epoch wraparound occurs
-    // at 65536 ticks × 65ms ≈ 71 minutes; epoch 0 is reserved as the
-    // "never touched" sentinel and skipped by tick_advance_epoch.
+    // #1219/#1294: advance the flow_cache active-flow epoch and publish
+    // the count for the harness's structural CoV gate. Hot polling uses the
+    // debug counter; RX-empty idle polling uses the wall-clock cadence in
+    // `update_binding_idle_debug_state`. With ACTIVE_WINDOW_EPOCHS = 10 the
+    // active-flow window is ~650ms. u16 epoch wraparound occurs at 65536
+    // ticks × 65ms ≈ 71 minutes; epoch 0 is reserved as the "never touched"
+    // sentinel and skipped by tick_advance_epoch.
     binding.flow.flow_cache.tick_advance_epoch();
     let (active_flow_count, flow_debug_entries, cos_counts, flow_map_truncated) = binding
         .flow

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1350,3 +1350,60 @@ fn flush_v_min_scratches_no_op_when_all_zero() {
     assert_eq!(hard_cap.load(std::sync::atomic::Ordering::Relaxed), 42);
     assert_eq!(throttles.load(std::sync::atomic::Ordering::Relaxed), 99);
 }
+
+fn debug_state_test_timers() -> WorkerTimers {
+    WorkerTimers {
+        last_heartbeat_update_ns: 0,
+        debug_state_counter: 0,
+        last_idle_debug_publish_ns: 0,
+        last_rx_wake_ns: 0,
+        last_tx_wake_ns: 0,
+        empty_rx_polls: 0,
+    }
+}
+
+#[test]
+fn idle_debug_state_publish_cadence_is_wall_clock_based() {
+    let mut timers = debug_state_test_timers();
+
+    assert!(
+        !idle_debug_state_publish_due(&mut timers, IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS - 1),
+        "idle cadence should not publish before the 65ms boundary"
+    );
+    assert_eq!(
+        timers.last_idle_debug_publish_ns, 0,
+        "non-publish must leave the last-publish timestamp unchanged"
+    );
+
+    assert!(
+        idle_debug_state_publish_due(&mut timers, IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS),
+        "idle cadence must publish on the 65ms boundary"
+    );
+    assert_eq!(
+        timers.last_idle_debug_publish_ns,
+        IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS
+    );
+    assert!(
+        !idle_debug_state_publish_due(
+            &mut timers,
+            IDLE_DEBUG_STATE_PUBLISH_INTERVAL_NS * 2 - 1
+        ),
+        "subsequent idle publishes must also respect the interval"
+    );
+}
+
+#[test]
+fn non_idle_debug_state_keeps_hot_counter_cadence() {
+    let mut timers = debug_state_test_timers();
+
+    for _ in 0..DEBUG_STATE_PUBLISH_MASK {
+        assert!(
+            !advance_debug_state_publish_counter(&mut timers),
+            "hot cadence should not publish before the 65536-call boundary"
+        );
+    }
+
+    assert!(advance_debug_state_publish_counter(&mut timers));
+    assert_eq!(timers.debug_state_counter, DEBUG_STATE_PUBLISH_MASK + 1);
+    assert_eq!(timers.last_idle_debug_publish_ns, 0);
+}

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -148,7 +148,7 @@ pub(super) fn poll_binding(
                 unsafe { &*(binding.umem.area() as *const MmapArea) },
             );
             counters.flush(&binding.live);
-            update_binding_debug_state(binding);
+            update_binding_idle_debug_state(binding, now_ns);
             return did_work;
         }
         binding.timers.empty_rx_polls = 0;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -118,7 +118,7 @@ pub(crate) struct BindingWorker {
     /// #959 Phase 5: 4 BPF map FDs extracted into `WorkerBpfMaps`.
     /// Field semantics unchanged; access via `binding.bpf_maps.X_fd`.
     pub(crate) bpf_maps: WorkerBpfMaps,
-    /// #959 Phase 6: 5 timing / wake-pacing fields extracted into
+    /// #959 Phase 6: 6 timing / wake-pacing fields extracted into
     /// `WorkerTimers`. Field semantics unchanged; access via
     /// `binding.timers.last_X_ns` etc.
     pub(crate) timers: WorkerTimers,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -399,6 +399,7 @@ impl BindingWorker {
             timers: WorkerTimers {
                 last_heartbeat_update_ns: init_now,
                 debug_state_counter: 0,
+                last_idle_debug_publish_ns: init_now,
                 last_rx_wake_ns: init_now,
                 last_tx_wake_ns: init_now,
                 empty_rx_polls: 0,

--- a/userspace-dp/src/afxdp/worker/timers.rs
+++ b/userspace-dp/src/afxdp/worker/timers.rs
@@ -25,6 +25,7 @@
 pub(crate) struct WorkerTimers {
     pub(crate) last_heartbeat_update_ns: u64,
     pub(crate) debug_state_counter: u32,
+    pub(crate) last_idle_debug_publish_ns: u64,
     pub(crate) last_rx_wake_ns: u64,
     pub(crate) last_tx_wake_ns: u64,
     pub(crate) empty_rx_polls: u32,

--- a/userspace-dp/src/afxdp/worker/timers.rs
+++ b/userspace-dp/src/afxdp/worker/timers.rs
@@ -2,11 +2,12 @@
 //! fields out of `BindingWorker` into a dedicated `WorkerTimers`
 //! sub-struct.
 //!
-//! These five fields gate per-binding pacing decisions: when to
+//! These six fields gate per-binding pacing decisions: when to
 //! send a TX wake-up syscall (last_tx_wake_ns), when to RX wake
 //! (last_rx_wake_ns), when to update the BPF heartbeat map
-//! (last_heartbeat_update_ns), and the per-second debug-tick
-//! counter (debug_state_counter / empty_rx_polls).
+//! (last_heartbeat_update_ns), when to publish idle debug state
+//! (last_idle_debug_publish_ns), and the debug-state cadence
+//! counters (debug_state_counter / empty_rx_polls).
 //!
 //! Pure structural extraction: capacities and access semantics
 //! unchanged from master pre-Phase-6. Field names preserved so


### PR DESCRIPTION
## Summary
- add an RX-empty idle debug publish cadence using the existing worker-loop now_ns timestamp
- keep the hot forwarding path on the existing 0xFFFF poll-counter cadence
- advance/publish flow-cache active-flow and CoS active-flow snapshots while workers are idle so stale rows age out near the documented ~650ms window
- document the hot-vs-idle cadence in flow-cache comments

Closes #1294

## Validation
- cargo test -q debug_state
- git diff --check