### PR TITLE
docs: revise shared UMEM XSK plan

### DIFF
--- a/docs/shared-umem-plan.md
+++ b/docs/shared-umem-plan.md
@@ -1,343 +1,419 @@
-# Shared UMEM Implementation Plan (#205)
+# Shared UMEM Implementation Plan
 
-Status: Experimental / Blocked From Baseline Runtime
+Status: Revised plan, branch-only until live validation passes
 
-## Problem
+## Summary
 
-Cross-interface AF_XDP forwarding still copies each frame between
-separate UMEM allocations. On current `master`, the steady-state hot
-transit path is not the copy-path fallback; it is the direct TX builder
-itself. The measured profile on a live transit run shows:
+The previous plan treated the shared-UMEM bind failure as evidence that
+AF_XDP zero-copy shared UMEM does not work across NICs. That conclusion is
+wrong. Linux AF_XDP supports `XDP_SHARED_UMEM` across the same queue, across
+different queues, and across different netdevs. The current xpf failure is
+local:
 
-- `xpf_userspace_dp::afxdp::poll_binding` about `17.6%`
-- `__memmove_evex_unaligned_erms` about `16.7%`
-- `xpf_userspace_dp::afxdp::frame::enqueue_pending_forwards` about `5.8%`
+1. The C bridge still calls `xsk_socket__create`, even though the Rust side
+   describes the path as `xsk_socket__create_shared`.
+2. Worker startup still creates one `WorkerUmemPool` per binding and passes
+   `shared_umem=false`, so no production binding currently shares a UMEM.
+3. The Rust wrapper's ring ownership and `WorkerUmem::umem_mut()` API are
+   still shaped around private UMEM. A real shared group needs explicit
+   private-vs-shared socket creation and a raw UMEM pointer path that does not
+   rely on `Rc::get_mut()`.
 
-Helper counters on the same run showed:
+The new goal is not "turn shared UMEM on everywhere". The goal is to make the
+firewall's normal cross-NIC forwarding path capable of in-place shared-UMEM TX,
+because that is where xpf pays the current payload copy. Same-device sharing is
+useful only as a narrow bring-up/debug milestone; it is not the product target.
 
-- `Direct TX packets`: climbing rapidly
-- `Copy-path TX packets`: `0`
-- `Slow path injected`: `0`
+## Correct AF_XDP Model
 
-So the remaining copy bottleneck is the full-payload copy inside the
-direct path in `build_forwarded_frame_into_from_frame()`:
+Shared UMEM does not change the basic AF_XDP RX delivery constraint. Packets
+still arrive from the NIC queue that RSS selected, and the XDP redirect path
+must still respect the queue/socket delivery rules for the running kernel.
+
+Shared UMEM changes buffer ownership:
+
+- each XSK has its own RX and TX rings
+- one UMEM allocation can back more than one XSK
+- for every unique `{netdev, queue_id}` tuple in a shared group, there must be
+  a fill/completion ring pair
+- in zero-copy mode, each bound netdev gets its own DMA mapping for the same
+  UMEM offsets
+- descriptor `addr` values remain UMEM offsets, not device-specific DMA
+  addresses
+
+For xpf forwarding, the important win is userspace TX reuse: a frame received
+on binding A can be rewritten in the shared UMEM and submitted to binding B's
+TX ring without copying the payload into a second UMEM allocation. That is
+separate from XDP-layer load balancing and does not make arbitrary XSKMAP
+redirects across RX queues safe.
+
+## Current Master Reality
+
+### Bridge is still non-shared
+
+`userspace-dp/csrc/xsk_bridge.c` ignores the per-socket fill/completion rings
+and calls:
+
+```c
+xsk_socket__create(xsk_out, ifname, queue_id, umem, rx, tx, &cfg)
+```
+
+The Rust call sites and errors refer to `xsk_socket__create_shared`, but the
+bridge never calls it. A second socket using the same `xsk_umem` therefore
+hits libxdp/kernel "busy" behavior instead of the shared-UMEM bind path.
+
+### Worker startup never groups UMEM
+
+`userspace-dp/src/afxdp/worker/mod.rs` allocates a fresh `WorkerUmemPool` for
+every binding and always passes `shared_umem=false`. The helper
+`shared_umem_group_key_for_device()` exists, but it is test-only and has no
+production caller.
+
+### Rust ring ownership is still private-mode shaped
+
+`xsk_ffi::create_xsk_binding()` allocates per-socket fill/completion ring
+boxes, but then returns the previous `umem.fill` / `umem.comp` through
+`DeviceQueue`:
 
 ```rust
-out.get_mut(eth_len..frame_len)?.copy_from_slice(payload);
+fill: std::mem::replace(&mut umem.fill, fill_ring),
+comp: std::mem::replace(&mut umem.comp, comp_ring),
 ```
 
-This is the primary remaining bottleneck preventing the userspace
-dataplane from reaching native XDP line rate on transit traffic.
+That is compatible with the current non-shared bridge, where the socket uses
+the UMEM's original FQ/CQ. It is wrong for a real shared socket, where the
+per-socket FQ/CQ passed to libxdp are the rings the worker must drive.
 
-## Current Reality On 2026-03-17
+Also, `WorkerUmem::umem_mut()` uses `Rc::get_mut()`. Once a group has multiple
+bindings cloning the same `WorkerUmem`, the code cannot obtain `&mut Umem`
+for later socket creation. Shared bind must use a controlled raw pointer path
+instead of pretending the UMEM has a unique Rust owner.
 
-The same-device shared-UMEM prototype is not part of the accepted HA baseline.
+### In-place TX is partly ready
 
-What happened:
-
-1. the prototype was merged into normal worker startup on `master`
-2. the HA lab immediately regressed to `16/24` bound and ready bindings
-3. `ifindex 5` and `6` multi-queue `mlx5` bindings failed with:
-   - `configure AF_XDP rings: create fq/cq: Device or resource busy`
-4. the restored baseline branch disables shared-UMEM runtime grouping again and
-   returns the lab to `24/24` bound and ready bindings
-
-So the current rule is explicit:
-
-- same-device shared UMEM remains a prototype
-- it must not be enabled in the default HA runtime path
-- any reintroduction needs an explicit gate plus live validation on a topology
-  that actually exercises the intended same-device path
-
-## Goal
-
-Eliminate the direct-path cross-UMEM payload copy where that is safe.
-The viable target is no longer "all bindings in a worker share one
-UMEM". The viable target is:
-
-- same-device shared UMEM only
-- `mlx5_core` only
-- no cross-NIC shared UMEM
-- no `virtio_net` shared UMEM
-
-Frames received on one binding can then be rewritten in-place and
-submitted directly to another binding's TX ring without any copy, but
-only when both bindings share the same physical device and the same UMEM
-allocation.
-
-## Current Architecture
-
-```
-Worker 0
-  ├── Binding A (ge-0-0-1 queue 0)
-  │     ├── WorkerUmem A  (own MmapArea, own Umem)
-  │     ├── Socket A       (own FD)
-  │     ├── Fill/Completion rings A
-  │     └── RX/TX rings A
-  └── Binding B (ge-0-0-2 queue 0)
-        ├── WorkerUmem B  (own MmapArea, own Umem)
-        ├── Socket B       (own FD)
-        ├── Fill/Completion rings B
-        └── RX/TX rings B
-
-Forward A→B: copy frame from UMEM-A to UMEM-B (memcpy ~1500 bytes)
-```
-
-## Target Architecture
-
-```
-Worker 0
-  ├── SharedUmem group for mlx5 device 0000:08:00.0
-  ├── Binding A (ge-0-0-1 queue 0, same device)
-  │     ├── Socket A (with_shared → shared UMEM FD)
-  │     ├── Fill/Completion rings A (per-socket)
-  │     └── RX/TX rings A
-  └── Binding B (same physical device / queue or sub-interface)
-        ├── Socket B (with_shared → shared UMEM FD)
-        ├── Fill/Completion rings B (per-socket)
-        └── RX/TX rings B
-
-Forward A→B: rewrite frame in-place at same offset, submit to TX-B (zero copy)
-
-Bindings on different physical devices keep private UMEM and still copy.
-```
-
-## Implementation Steps
-
-### Step 1: Identify safe shared-UMEM groups
-
-At worker startup, group bindings by `(driver, device_path)`.
-
-- only `mlx5_core` with a non-empty device path is eligible
-- only groups with two or more bindings are candidates
-- `virtio_net` is always excluded
-- different PCI devices are always excluded
-
-### Step 2: Create one UMEM pool per eligible device group
-
-Create a `WorkerUmemPool` per eligible group, not per worker. Each pool owns:
-
-- one `WorkerUmem`
-- one `VecDeque<u64>` of free frame offsets
-
-Bindings with no eligible group still allocate a private pool and behave exactly
-like current `master`.
-
-### Step 3: Pass the chosen UMEM pool into `BindingWorker::create()`
-
-`BindingWorker::create()` now accepts:
-
-- the `WorkerUmem` to use
-- a mutable frame pool for reserved TX and initial fill offsets
-- a `shared_umem` flag for diagnostics
-
-This preserves current bind/open behavior while moving UMEM ownership out of the
-binding constructor.
-
-### Step 4: Widen in-place rewrite eligibility to same-allocation forwards
-
-The forwarding predicate changes from "same binding only" to "same UMEM allocation":
+`userspace-dp/src/afxdp/tx/dispatch.rs` already has a same-allocation
+predicate:
 
 ```rust
-let can_rewrite_in_place =
-    target_binding.umem.allocation_ptr() == ingress_binding.umem.allocation_ptr();
+target_binding.umem.allocation_ptr() == ingress_umem_ptr
 ```
 
-This keeps the optimization narrow:
+That path can become the shared-UMEM forwarding fast path once bindings
+actually share an allocation. The flow-cache fast path in
+`poll_descriptor.rs` is still same-binding-only and should be widened only
+after shared bind is proven.
 
-- same-binding hairpin still works
-- same-device shared-UMEM bindings can now rewrite in place
-- cross-device forwards still take the existing direct builder copy path
+## Design Principles
 
-### Step 5: Keep current recycle and ownership semantics
+1. Default runtime remains private UMEM until validation proves shared UMEM.
+2. The bridge must expose private and shared socket creation explicitly.
+3. Shared groups are worker-local; no UMEM crosses worker threads.
+4. Frame offsets in a shared group are partitioned once at startup, then
+   recycled through the existing prepared-TX completion model.
+5. Cross-NIC sharing is the primary implementation target because the firewall
+   forwards between NICs. Same-device sharing is optional scaffolding for
+   isolating bridge/ring bugs.
+6. No shared-UMEM change is allowed to weaken current HA deploy, link-cycle,
+   and fallback behavior.
 
-This prototype does not attempt a full worker-global frame rebalance rewrite.
-It keeps the existing prepared-TX recycle model and only changes how eligible
-bindings source their offsets up front. That makes the prototype materially safer
-than the older "share everything in the worker" plan.
+## Proposed Implementation
 
-### Step 6: Validate the safe boundary
+### Phase 0: Repro and Guardrails
 
-The prototype is only acceptable if:
+This is a hard gate. No production xpf worker-startup change may land until
+the direct repro proves the exact deployment environment can run the intended
+shared-UMEM shape. The artifact is scoped to the node class and software stack
+that produced it. A passing artifact from one lab or node class does not
+enable shared UMEM on a different deployment environment.
 
-- it compiles and unit-tests cleanly
-- `virtio_net` behavior is unchanged
-- cross-NIC `mlx5` behavior is unchanged
-- same-allocation forwards can use the in-place path
-- no bind strategy regressions are introduced
+The Phase 0 artifact must be machine-readable and include:
 
-## Performance Impact Estimate
+- kernel release
+- mlx5 driver name and version
+- selected NIC interface names and PCI IDs
+- selected NIC firmware versions
+- libxdp and libbpf versions
+- IOMMU mode
+- MTU
+- queue topology
+- selected device pair
+- same-queue, same-netdev/different-queue, and different-netdev result rows
+- owner bind flags, secondary bind flags, and post-bind
+  `XDP_OPTIONS_ZEROCOPY` result per socket
+- create/delete link-cycle result
 
-- For eligible same-device paths, this should eliminate the direct-path payload
-  copy that currently shows up as about `16.7%` `memmove`.
-- For the current HA lab's cross-NIC transit path, this should not be expected
-  to improve throughput by itself.
-- The right expectation is structural correctness first, then targeted same-device
-  performance gains where the topology actually permits shared UMEM.
+Add direct repro coverage before changing production bind behavior:
 
-## Risk Mitigation
+- extend `test/xsk-repro/libbpf_xsk_shared_test.c` to cover:
+  - same netdev, same queue
+  - same netdev, different queues
+  - different mlx5 netdevs
+- force `XDP_ZEROCOPY` only on the owner/first bind in each zero-copy shared
+  group; secondary shared sockets must bind with exactly `XDP_SHARED_UMEM`
+  and none of `XDP_COPY`, `XDP_ZEROCOPY`, `XDP_USE_NEED_WAKEUP`, or
+  `XDP_USE_SG`
+- assert `XDP_OPTIONS_ZEROCOPY` after bind on the owner socket and every
+  secondary shared socket in the zero-copy cells
+- verify each shared socket has the correct FQ/CQ pair and can receive/fill
+  independently
+- run socket delete/link-cycle loops to reproduce or close the old
+  `__xsk_setup_xdp_prog` teardown fault
+- fail the phase if any socket falls back to copy mode, if any secondary bind
+  needs private UMEM, or if teardown/link-cycle produces a fault
 
-1. **xdpilone shared socket support**: Already uses `Socket::with_shared()`
-   — the API exists and is used (shared_owner=true). Need to verify it
-   works when multiple sockets share one UMEM across bindings on the same
-   physical device.
+The important flag rule is non-negotiable: for libbpf/libxdp shared UMEM, the
+owner bind establishes zero-copy and must still be checked after bind.
+Secondary sockets join the existing UMEM with exactly `XDP_SHARED_UMEM`; they
+must not also pass `XDP_COPY`, `XDP_ZEROCOPY`, `XDP_USE_NEED_WAKEUP`, or
+`XDP_USE_SG`. The kernel rejects those flag combinations for shared sockets in
+`net/xdp/xsk.c`'s bind validation. Zero-copy is verified after bind through
+`XDP_OPTIONS_ZEROCOPY`, not requested again on secondary binds.
 
-2. **Scope control**: Do not silently widen this to `virtio_net` or cross-NIC
-   `mlx5`. Those are known bad directions in this environment.
+### Phase 1: Make the bridge honest
 
-3. **Frame leak**: Shared accounting is harder to debug. Keep the existing
-   per-binding recycle semantics until the same-device path is proven.
+Add two explicit bridge entry points:
 
-4. **VLAN header size change**: In-place rewrite handles this via
-   `copy_within()` (4-byte shift). Verified this already works in
-   `rewrite_forwarded_frame_in_place`.
+- `bridge_xsk_socket_create_private(...)`
+- `bridge_xsk_socket_create_shared(...)`
 
-5. **Segmentation (TSO)**: Segmented frames create multiple TX descriptors
-   from one RX frame. This needs special handling — the source frame
-   cannot be returned to fill ring until ALL segments are transmitted.
-   Current code already handles this via `in_flight_forward_recycles`.
+The private function keeps today's baseline behavior. The shared function
+calls:
 
-## Files Modified
+```c
+xsk_socket__create_shared(xsk_out, ifname, queue_id, umem,
+                          rx, tx, fill, comp, &cfg)
+```
 
-| File | Change |
-|------|--------|
-| `userspace-dp/src/afxdp.rs` | `WorkerUmem` ownership model, grouped UMEM pool creation, tests |
-| `userspace-dp/src/afxdp/bind.rs` | driver/device grouping helpers, UMEM accessor updates |
-| `userspace-dp/src/afxdp/frame.rs` | same-allocation in-place forwarding predicate |
-| `userspace-dp/src/afxdp/tx.rs` | UMEM accessor updates for shared allocation support |
+Do not switch the baseline private path to shared creation as a side effect.
+That keeps the old teardown workaround isolated until shared mode is tested.
 
-## Result: Broad Cross-NIC Shared UMEM Is Not Feasible (2026-03-14)
+### Phase 2: Split Rust XSK creation by ring mode
 
-**Shared UMEM across different NICs does not support zero-copy mode.**
+Replace the single `create_xsk_binding()` helper with an explicit mode:
 
-The loss cluster has two Mellanox ConnectX-5 NICs on separate PCI buses:
-- ge-0-0-1: `0000:08:00.0` (mlx5_core)
-- ge-0-0-2: `0000:09:00.0` (mlx5_core)
+```rust
+enum XskCreateMode {
+    PrivateUmem,
+    SharedUmem,
+}
+```
 
-AF_XDP zero-copy requires the NIC driver to DMA-map the UMEM pages. When
-two sockets share one UMEM but bind to different physical NICs, the second
-socket's `bind()` fails with `EINVAL` because the mlx5 driver cannot map
-pages already DMA-mapped by a different device. The fallback is copy mode
-for the second socket, which means:
+Private mode:
 
-- First socket: zero-copy (no memcpy on RX/TX)
-- Second socket: copy mode (kernel copies every frame into/out of UMEM)
+- calls `bridge_xsk_socket_create_private`
+- returns the UMEM-owned fill/completion rings as `DeviceQueue`
+- preserves current production behavior
 
-This is **worse** than the original per-binding UMEM approach where both
-sockets run in zero-copy mode with a single user-space memcpy for cross-
-interface forwarding.
+Shared mode:
 
-### What would make this work
+- calls `bridge_xsk_socket_create_shared`
+- returns the newly allocated per-socket fill/completion rings as
+  `DeviceQueue`
+- leaves the original UMEM rings owned by `Umem` unless they are explicitly
+  used by the first owner socket
+- applies bind flags by socket role:
+  - owner socket: normal requested mode flags, including `XDP_ZEROCOPY` when
+    the group requires zero-copy; reject the group if post-bind
+    `XDP_OPTIONS_ZEROCOPY` is not set
+  - secondary shared socket: exactly `XDP_SHARED_UMEM`, with no `XDP_COPY`,
+    `XDP_ZEROCOPY`, `XDP_USE_NEED_WAKEUP`, or `XDP_USE_SG`; reject the group
+    if post-bind `XDP_OPTIONS_ZEROCOPY` is not set
 
-Shared UMEM zero-copy works when all sockets bind to the **same NIC**
-(same PCI device, different queues). This applies to:
-- Multi-queue on a single NIC (RSS distribution)
-- VLAN sub-interfaces on the same physical port
+The diagnostic log should print the mode, bind flags, queue, ifindex, ring
+sizes, socket role, and whether the socket reported zero-copy.
 
-For cross-NIC forwarding, the memcpy is unavoidable at the AF_XDP level.
-The remaining optimization path is to make the existing memcpy cheaper
-(e.g., page flipping, io_uring registered buffers, or batched copies).
+### Phase 3: Fix UMEM ownership for shared construction
 
-## Current Prototype Status (2026-03-17)
+Introduce a safe worker-local API that can hand libxdp the same raw UMEM
+pointer for multiple sockets:
 
-The safe reintegration path is still the same in principle, but current live
-validation exposed three practical limits:
+```rust
+impl WorkerUmem {
+    fn as_raw_umem_ptr(&self) -> *mut XskUmemOpaque;
+}
+```
 
-- the current HA lab does not have a proof topology for this prototype
-- the current implementation is not yet deployable on the HA lab because
-  shared UMEM still uses the wrong AF_XDP queue ownership contract
-- the prototype was already shown to be unsafe as a default runtime path on the
-  HA lab, so it is now explicitly branch-only work until those issues are
-  closed
+`create_xsk_binding_shared()` should use that raw pointer and must not require
+`&mut Umem` or `Rc::get_mut()`. The shared path is still single-threaded at
+construction time because each worker builds its bindings on one thread.
 
-### Narrow scope
+Also enforce drop order. The XSK sockets must be deleted before the shared
+UMEM is deleted. Use an explicit drop wrapper or reorder/wrap fields so
+`DeviceQueue` deletion is guaranteed before the last `WorkerUmem` reference
+can delete `xsk_umem`.
 
-- group bindings by `(driver, device_path)`
-- only create a shared group for same-device `mlx5_core`
-- keep `virtio_net` on private UMEM
-- keep cross-NIC traffic on private UMEM
+### Phase 4: Build worker-local cross-NIC UMEM groups
 
-### Current prototype shape
+Replace the same-device-only grouping helper with an explicit policy builder
+that can construct firewall-relevant cross-NIC groups. The policy must be
+operator-gated and default off.
 
-1. `BindingWorker::create()` no longer unconditionally allocates its own
-   UMEM.
-2. Worker startup can create a `WorkerUmemPool` for eligible same-device
-   groups.
-3. Bindings in the same eligible group clone the same `WorkerUmem`
-   allocation and draw offsets from the same frame pool.
-4. In-place rewrite eligibility is widened from "same binding only" to
-   "same UMEM allocation".
+Modes:
 
-### What this can and cannot improve
+```text
+off -> private UMEM only
+same-device-debug -> group by (driver, device_path), only for bring-up tests
+cross-nic -> group the firewall transit bindings that intentionally forward
+             between NICs
+```
 
-This prototype can improve:
+Cross-NIC eligibility:
 
-- same-NIC transit between bindings on the same `mlx5` device
-- same-device VLAN/sub-interface forwarding
-- any worker-local forward where ingress and egress share the same UMEM
+- `mlx5_core`
+- non-empty PCI device path
+- at least two NICs in the group
+- explicit operator/config selection of which interfaces participate
+- Phase 0 artifact matches the deployment environment for this node class and
+  selected device pair
+- all participating bindings are owned by the same worker
+- no `virtio_net`
+- zero-copy is required; copy-mode fallback disables the group
 
-This prototype will not, by itself, fix the current HA lab's main
-cross-NIC transit bottleneck, because the hot path there still crosses
-different physical devices and therefore still requires a copy.
+Same-device-debug eligibility:
 
-### What live validation actually proved
+- `mlx5_core`
+- same non-empty PCI device path
+- at least two bindings in the group
+- only used to isolate shared bridge/ring/drop-order bugs before cross-NIC
+  rollout
 
-On the current HA lab:
+For each eligible group:
 
-- `ge-0-0-1`/`ge-7-0-1` and `ge-0-0-2`/`ge-7-0-2` are different physical
-  `mlx5` PCI devices
-- the WAN50 -> WAN80 path on the active owner already collapses to the
-  existing in-place hairpin behavior on `master`
-- that means WAN50 -> WAN80 is only a no-regression check, not proof
-  that the new same-allocation cross-binding path is exercised
+- compute total frames as the sum of each binding's current private
+  `binding_frame_count_for_driver(...)`
+- create one `WorkerUmemPool` with that total
+- partition offsets from one `VecDeque<u64>` as each binding is constructed
+- pass `shared_umem=true`, the group key, and `XskCreateMode::SharedUmem`
 
-So the current lab can answer:
+Bindings outside an eligible group keep the existing private path.
 
-- did the prototype regress an existing same-device-ish path?
+Shared-group construction must be atomic from the worker's point of view:
 
-It cannot answer:
+- build and bind all sockets in the group into a temporary vector first
+- register no XSKMAP entries for the group until every socket is bound and
+  post-bind zero-copy validation passes
+- if any socket bind or validation fails, delete every socket already created
+  for that group, drop the shared `WorkerUmemPool`, mark every binding in the
+  group with the same error, and do not leave a partially shared group active
+- only after the full group succeeds may the worker move the bindings into the
+  live `bindings` vector and register their XSKMAP slots
 
-- did the prototype materially improve a true same-device cross-binding
-  forward path?
+The operator-provided cross-NIC group is mandatory because NUMA locality, IOMMU
+mode, and NIC placement determine whether the result is useful even when the
+kernel supports the bind. Do not infer cross-NIC grouping from driver name
+alone.
 
-### Current implementation gap
+Deployment scoping is part of the runtime contract, not just documentation.
+The policy builder must compare the configured shared-UMEM group against the
+validated Phase 0 artifact for the current node class. If kernel release, mlx5
+driver name/version, selected interface names, selected NIC PCI IDs, selected
+NIC firmware versions, libxdp/libbpf versions, IOMMU mode, MTU, queue topology,
+or selected device pair do not match the artifact, the group stays private and
+the reason is reported in telemetry.
 
-The current prototype shares one `WorkerUmem` across multiple bindings in
-the same `(driver, device_path)` group, but still opens per-binding AF_XDP
-ring ownership the same way as private UMEM bindings.
+### Phase 5: Use shared allocation for forwarding
 
-In live deployment this caused the second queue on the shared group to fail
-with:
+Keep the existing conservative copy/direct path for non-shared bindings.
 
-- `configure AF_XDP rings: create fq/cq: Device or resource busy`
+Enable same-allocation in-place forwarding only when:
 
-That means the next implementation step is not more baseline performance work.
-It is correct AF_XDP shared-UMEM bring-up on an isolated branch:
+- ingress and target bindings share `WorkerUmem::allocation_ptr()`
+- the source frame is live, not owned/prebuilt
+- NAT64 and native tunnel header-size-changing paths are excluded
+- CoS ownership checks still pass
+- the target TX completion path recycles the original offset only after TX
+  completion
 
-1. establish the right FQ/CQ ownership model for one shared UMEM
-2. bind secondary queues/sockets against that owner correctly
-3. only then retry same-device throughput validation
+`tx/dispatch.rs` already has most of this predicate. After bind validation,
+extend the flow-cache fast path in `poll_descriptor.rs` from "same binding"
+to "same allocation" using the same checks.
 
-### Success criteria for the prototype
+### Phase 6: Telemetry and config contract
 
-- compile and unit-test cleanly on current `master`
-- preserve current per-binding bind strategy behavior for non-shared paths
-- no change for `virtio_net`
-- no change for cross-NIC traffic
-- no AF_XDP bind regressions on multi-queue `mlx5`
-- same-allocation forwards use the in-place rewrite path instead of the
-  direct builder copy path
+Expose enough state to prove what happened:
 
-## Original Testing Plan
+- shared UMEM mode: off, same-device-debug, cross-nic
+- group key per binding
+- group total frame count and per-binding frame quota
+- socket creation mode: private vs shared
+- bind mode: copy vs zero-copy
+- in-place TX packets and bytes by binding
+- direct-copy TX packets and bytes by binding
+- shared-mode bind failures by errno and bind flags
 
-This testing plan is no longer valid as a baseline HA validation plan. It is
-only valid for the prototype branch after the queue-ownership issue is fixed
-and a real same-device proof topology is available.
+The CLI should make shared mode visibly experimental until the full validation
+matrix is green.
 
-1. `cargo build --release` — compiles
-2. Deploy to loss cluster: `loss:xpf-userspace-fw0` + `loss:xpf-userspace-fw1`
-3. Forward throughput: `iperf3 -c 172.16.80.200 -P 8 -t 10` from `loss:cluster-userspace-host`
-4. Reverse throughput: same with `-R`
-5. Profile: `perf record -a -g --freq=997` — verify memcpy eliminated
-6. Verify frame accounting: no FRAME_LEAK in debug output
-7. HA failover: verify sessions survive failover
+### Phase 7: Validation Matrix
+
+Unit tests:
+
+- Phase 0/prod-startup guard: cross-NIC shared mode cannot be enabled unless
+  the direct repro artifact records success for the requested deployment
+  environment and device pair
+- shared-UMEM policy selection for off, same-device-debug, and cross-nic modes
+- private bindings never share allocation
+- shared groups partition offsets without duplicates
+- shared socket creation returns per-socket FQ/CQ rings
+- owner and secondary shared socket creation both validate
+  `XDP_OPTIONS_ZEROCOPY` after bind
+- secondary shared socket creation passes exactly `XDP_SHARED_UMEM`, with no
+  `XDP_COPY`, `XDP_ZEROCOPY`, `XDP_USE_NEED_WAKEUP`, or `XDP_USE_SG`
+- `WorkerUmem` raw pointer path does not require unique `Rc`
+- XSK socket drop happens before UMEM drop
+- partial shared-group bind failure rolls back every socket created for that
+  group and registers no XSKMAP entries
+- same-allocation predicate rejects NAT64/tunnel/prebuilt paths
+
+Direct AF_XDP repro:
+
+- `libbpf_xsk_shared_test` same queue
+- `libbpf_xsk_shared_test` different queue same netdev
+- `libbpf_xsk_shared_test` different mlx5 netdevs
+- all zero-copy cells assert `XDP_OPTIONS_ZEROCOPY`
+- repeated create/delete cycles do not fault
+
+xpf lab validation:
+
+- deploy with shared mode off: no behavior change
+- deploy with cross-nic mode: all participating bindings bound/ready, no EBUSY
+- link-cycle and rolling deploy do not fault
+- no frame leak, no ring-full steady-state failure
+- cross-NIC firewall transit shows `pending_in_place_tx_packets` rising
+- both NICs in the shared group report zero-copy before any performance claim
+  is made
+- perf shows `memmove` reduction on the real cross-NIC firewall transit path
+
+## Revised Expectations
+
+Cross-NIC shared UMEM is the target. The kernel has supported it for years,
+with per-netdev DMA maps for the shared UMEM, and it is the only shared-UMEM
+mode that attacks the firewall's normal cross-NIC memcpy.
+
+Same-device shared UMEM is still useful, but only as a bring-up technique. It
+can answer "does our bridge call the right libxdp function and drive the right
+per-socket FQ/CQ rings?" It cannot answer "did the firewall get faster?" unless
+the measured path actually stays on one NIC.
+
+Cross-NIC mode remains behind an explicit gate until xpf proves:
+
+- the lab kernel/libxdp path binds both NICs in zero-copy
+- teardown and link-cycle handling are stable
+- the performance win beats the private-UMEM copy path on the real HA topology
+
+If cross-NIC sharing works, it removes the current userspace memcpy from the HA
+transit path. If it does not outperform private UMEM in this lab, the failure
+should be recorded as an xpf/lab/driver result, not as a general AF_XDP kernel
+limitation.
+
+## References
+
+- Local note: `/home/ps/paul.md`
+- AF_XDP shared UMEM docs:
+  `https://docs.ebpf.io/linux/concepts/af_xdp/#xdp_shared_umem`
+- libxdp function signature:
+  `https://docs.ebpf.io/ebpf-library/libxdp/functions/xsk_socket__create_shared/`
+- Kernel commit adding shared UMEM between devices:
+  `a1132430c2c55af62d13e9fca752d46f14d548b3`
+- Kernel shared pool implementation:
+  `net/xdp/xsk_buff_pool.c::xp_assign_dev_shared`


### PR DESCRIPTION
## Summary

Revises the shared UMEM implementation plan after re-reading `/home/ps/paul.md` and the current master code.

Key correction: the old plan incorrectly treated cross-NIC shared UMEM zero-copy as impossible. The firewall's hot forwarding path is cross-NIC, so cross-NIC shared UMEM is now the explicit implementation target. Same-device shared UMEM is only retained as optional bring-up/debug scaffolding for isolating bridge/ring/drop-order bugs.

The observed `EBUSY`/bind failures are reframed as local xpf implementation debt:

- the C bridge still calls `xsk_socket__create`, while Rust comments/errors claim `xsk_socket__create_shared`
- worker startup still allocates one `WorkerUmemPool` per binding and passes `shared_umem=false`
- Rust ring ownership is still private-UMEM shaped
- `WorkerUmem::umem_mut()` cannot work after the UMEM is actually cloned/shared via `Rc`

## Plan Changes

The new plan stages the work as:

1. direct AF_XDP repro/guardrail tests before production worker changes, including different-mlx5-netdev zero-copy verification
2. explicit private vs shared bridge entry points
3. Rust XSK creation split by ring mode
4. shared UMEM raw-pointer/drop-order ownership fix
5. operator-gated cross-NIC worker-local UMEM groups for firewall transit bindings
6. same-device-debug grouping only as optional scaffolding
7. validation matrix for bind, teardown, in-place forwarding, zero-copy proof, and perf on the real cross-NIC firewall path

## Validation

- `git diff --check`