### PR TITLE
docs: record module documentation update discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@
 - Prefer editing over rewriting whole files.
 - Do not re-read files you have already read.
 - Test your code before declaring done.
+- When modifying code or changing behavior, update the relevant module
+  documentation in the corresponding Markdown files as part of the same work.
+  Treat README/design/state/operator docs as part of the module contract; if no
+  docs change is needed, say why in the review notes.
 - No sycophantic openers or closing fluff.
 - Keep solutions simple and direct.
 - When working with many teams, don't let the context windows get too large.


### PR DESCRIPTION
## Summary
- add a standing `CLAUDE.md` rule that code and behavior changes must update the corresponding module Markdown docs in the same work item
- require an explicit review note when no docs update is needed

## Testing
- Documentation-only change; no tests run.
