### PR TITLE
userspace: add equal-flow suppression estimator telemetry

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,22 @@
 
 ## 2026-05-14
 
+- **Timestamp**: 2026-05-14T17:53:10Z
+  - **Action**: PR #1305 round-3 review follow-up — extended artifact-warning wording to the equal-flow capped-bps, worker-cap-bps, and throughput-loss-ratio Prometheus help strings.
+  - **File(s)**: `pkg/api/metrics.go`, `_Log.md`
+
+- **Timestamp**: 2026-05-14T17:38:10Z
+  - **Action**: PR #1305 round-2 review follow-up — made the out-of-range worker test assert directly against `bytesByWorker` so the worker-delta cap is independently covered, and added artifact warnings to the equal-flow target/suppression metric help strings.
+  - **File(s)**: `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `_Log.md`
+
+- **Timestamp**: 2026-05-14T16:49:39Z
+  - **Action**: PR #1305 review follow-up — bounded equal-flow estimator worker IDs with the existing fairness RSS worker-slot cap, sharpened Prometheus help strings, and added validity boundary tests for single-worker, unsampled, zero-window, and out-of-range-worker cases.
+  - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `docs/pr/1304-equal-flow-estimator/plan.md`, `_Log.md`
+
+- **Timestamp**: 2026-05-14T14:51:46Z
+  - **Action**: Issue #1304 Phase 0 — add measurement-only equal-flow rate-suppression estimator telemetry for exact CoS queues, document its invariants, and pin estimator math/Prometheus emission tests.
+  - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `docs/pr/1304-equal-flow-estimator/plan.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-14T04:01:00Z
   - **Action**: PR #1301 review follow-up — removed power-of-two UMEM frame-size assumption in memmove fallback bounds calculation by switching to modulo-based in-frame offset math.
   - **File(s)**: `userspace-dp/src/afxdp/frame/mod.rs`, `_Log.md`

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -447,6 +447,41 @@ For production observability, xpf MUST export:
   monotonic count of flows that enter the starved-flow threshold
   (< 1% of mean per-flow throughput), de-duplicated while the flow
   remains in the rolling window.
+- **`xpf_fairness_equal_flow_estimate_valid{ifindex=..., queue_id=...}`**
+  gauge: 1 when the measurement-only equal-flow suppression estimator
+  has enough untruncated source data to model this queue. A valid
+  estimate requires an untruncated flow-worker byte source, an
+  untruncated CoS active-flow source, and at least two active workers
+  with non-zero rolling byte samples.
+- **`xpf_fairness_equal_flow_sampled_active_workers{ifindex=..., queue_id=...}`**
+  gauge: active workers that also have non-zero rolling byte samples in
+  the estimator window.
+- **`xpf_fairness_equal_flow_unsampled_active_workers{ifindex=..., queue_id=...}`**
+  gauge: workers with active flows in the CoS snapshot but no rolling
+  byte samples in the estimator window. Non-zero here means the
+  equal-flow estimate is using a partial traffic sample.
+- **`xpf_fairness_equal_flow_target_per_flow_bps{ifindex=..., queue_id=...}`**
+  gauge: the slowest sampled active worker's observed per-flow bit rate.
+  This is the strict equal-flow target a future non-work-conserving
+  suppressor would use if it chose to trade aggregate throughput for
+  lower absolute per-flow spread.
+- **`xpf_fairness_equal_flow_observed_bps{ifindex=..., queue_id=...}`**,
+  **`xpf_fairness_equal_flow_capped_bps{ifindex=..., queue_id=...}`**,
+  **`xpf_fairness_equal_flow_suppressed_bps{ifindex=..., queue_id=...}`**,
+  and
+  **`xpf_fairness_equal_flow_throughput_loss_ratio{ifindex=..., queue_id=...}`**
+  gauges: measurement-only aggregate model of current throughput,
+  throughput after strict equal-flow suppression, withheld throughput,
+  and withheld/current ratio. These metrics do **not** feed the
+  scheduler and do **not** change the Cstruct pass/fail contract.
+- **`xpf_fairness_equal_flow_worker_observed_bps{ifindex=..., queue_id=..., worker_id=...}`**,
+  **`xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex=..., queue_id=..., worker_id=...}`**,
+  **`xpf_fairness_equal_flow_worker_cap_bps{ifindex=..., queue_id=..., worker_id=...}`**,
+  and
+  **`xpf_fairness_equal_flow_worker_suppressed_bps{ifindex=..., queue_id=..., worker_id=...}`**
+  gauges: per-worker breakdown of the same hypothetical cap. These are
+  intended to answer "which worker would we slow, by how much?" before
+  any enforcement mode is introduced.
 - **`xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=...}`**
   counter: cumulative v8 CoS queue-lease acquire calls made by the
   worker. Use `rate()` over the same scrape window as worker TX
@@ -483,13 +518,18 @@ flat.
 The RSS-structure gauges above are exported from the production
 Prometheus collector. The rolling throughput metrics
 (`xpf_fairness_saturated`, `xpf_fairness_observed_cov`, and
-`xpf_fairness_starved_flows`) are derived from worker-owned
-flow-cache byte counters surfaced through the bounded flow-worker
-status snapshot. The daemon keeps the 30-second window in collector
-state and advances the wall-clock window on every healthy scrape, even
-when no flow byte counter moved. Truncated flow-worker snapshots reset
-the runtime window and suppress metric emission rather than reporting
-a false-healthy queue from stale samples.
+`xpf_fairness_starved_flows`) and the #1304 equal-flow estimator are
+derived from worker-owned flow-cache byte counters surfaced through the
+bounded flow-worker status snapshot. The daemon keeps the 30-second
+window in collector state and advances the wall-clock window on every
+healthy scrape, even when no flow byte counter moved. Truncated
+flow-worker snapshots reset the runtime window and suppress metric
+emission rather than reporting a false-healthy queue from stale samples.
+Truncated CoS active-flow snapshots suppress only the equal-flow
+estimator because the estimator needs both per-worker byte rates and
+per-worker active-flow counts. The estimator is advisory telemetry for
+future rate-suppression work; the dataplane remains work-conserving
+unless a later PR explicitly wires an enforcement mode.
 
 ## Steady-state measurement window
 

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -1,6 +1,6 @@
 # Per-5-Tuple Fairness Drive — State
 
-**As of 2026-05-09.** This document records the standing mandate, the
+**As of 2026-05-14.** This document records the standing mandate, the
 shipped foundations, the killed mechanisms, and the surviving design
 options for cross-worker per-(dip,dport,sip,sport) fairness on the
 xpf userspace AF_XDP dataplane. It is a living state file — update
@@ -393,6 +393,40 @@ no flow byte counter moved. Truncated flow-worker snapshots reset the
 window and suppress the observed metrics until a fresh baseline is
 available.
 
+### Issue #1304 — Equal-flow rate-suppression estimator (active)
+
+The surviving non-work-conserving path is explicit rate suppression
+inside an exact shaped CoS queue: if RSS assigns different numbers of
+backlogged flows to different workers, the queue can intentionally
+withhold excess worker-local throughput so every flow converges toward
+the slowest sampled per-flow rate. That can reduce absolute per-flow
+spread below the work-conserving `Cstruct` floor, but only by giving up
+aggregate throughput.
+
+The first slice is measurement-only. It extends the rolling throughput
+collector to model the cap a future suppressor would apply, without
+feeding any scheduler path:
+
+- `xpf_fairness_equal_flow_estimate_valid{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_sampled_active_workers{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_unsampled_active_workers{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_target_per_flow_bps{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_observed_bps{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_capped_bps{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_suppressed_bps{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_throughput_loss_ratio{ifindex,queue_id}`
+- `xpf_fairness_equal_flow_worker_observed_bps{ifindex,queue_id,worker_id}`
+- `xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex,queue_id,worker_id}`
+- `xpf_fairness_equal_flow_worker_cap_bps{ifindex,queue_id,worker_id}`
+- `xpf_fairness_equal_flow_worker_suppressed_bps{ifindex,queue_id,worker_id}`
+
+The estimator requires untruncated flow-worker byte telemetry and
+untruncated per-CoS active-flow counts. It is valid only when at least
+two active workers have non-zero rolling byte samples. This keeps the
+metric honest: it answers "what throughput would strict equal-flow
+suppression cost on this queue right now?" before any enforcement mode
+is designed.
+
 ### PR #1241 — TX completion uniformity telemetry
 
 Before the next full fairness measurement, the dataplane must expose
@@ -443,6 +477,10 @@ MQFQ, v8 lease selection, or admission.
   exported from Prometheus and the userspace status text. Runtime
   expectation config and skew-violation gauges are available; alert
   routing remains deployment policy.
+- **#1304 — Equal-flow rate-suppression mode**: active. Phase 0 adds
+  measurement-only suppression-cost telemetry. Do not wire enforcement
+  until live class-sweep data shows the estimator is stable and the
+  throughput loss is an acceptable product tradeoff.
 
 ## Empirical sweep across workload classes (2026-05-07)
 

--- a/docs/pr/1304-equal-flow-estimator/plan.md
+++ b/docs/pr/1304-equal-flow-estimator/plan.md
@@ -1,0 +1,100 @@
+# #1304 Equal-Flow Rate-Suppression Estimator
+
+## Goal
+
+Add the first measurement-only slice for issue #1304: quantify how much
+throughput an exact shaped CoS queue would have to suppress to make the
+currently sampled flows converge to one per-flow rate under RSS skew.
+
+This PR does not change packet scheduling, queue admission, AF_XDP
+binding, or CoS token allocation. It only exposes telemetry for review
+and live measurement.
+
+## Background
+
+The existing structural fairness contract is work-conserving. With a
+skewed RSS distribution, perfect worker-local fairness still leaves
+flows on lightly-loaded workers faster than flows on heavily-loaded
+workers. That is the `Cstruct` floor.
+
+The only remaining way to drive absolute per-flow spread below that
+floor without moving packets between AF_XDP queues is to deliberately
+give up work conservation inside a shaped exact CoS queue. The
+suppressor would cap each worker's aggregate queue service to:
+
+```text
+cap_worker_bps = target_per_flow_bps * active_flows_on_worker
+```
+
+where `target_per_flow_bps` is the slowest sampled worker's observed
+per-flow rate.
+
+## Phase 0 Design
+
+Reuse the existing Go-side rolling 30-second fairness throughput window:
+
+- `FlowWorkerMap` supplies cumulative per-flow byte counters and worker
+  ownership.
+- `CoSActiveFlowCounts` supplies the per-CoS queue active-flow count per
+  worker.
+- The collector already advances wall-clock time on healthy scrapes and
+  resets on truncated flow-worker snapshots.
+
+For each egress CoS queue, keep an additional rolling byte total per
+worker alongside the existing byte total per flow. On each summary:
+
+1. Convert per-worker bytes to `observed_bps`.
+2. Divide by the current active-flow count to get observed
+   `per_flow_bps` for each sampled active worker.
+3. Pick the minimum sampled `per_flow_bps` as the strict equal-flow
+   target.
+4. Compute each worker's hypothetical cap and suppressed throughput.
+5. Export the queue-level and worker-level values as Prometheus gauges.
+
+The estimate is valid only when:
+
+- the flow-worker snapshot is not truncated,
+- the CoS active-flow snapshot is not truncated,
+- at least two active workers have non-zero rolling byte samples.
+
+## Invariants
+
+- No new hot-path atomics or packet-path branches.
+- No scheduler path reads the estimator.
+- Truncated source data fails closed by suppressing estimator output or
+  marking the estimate invalid.
+- Worker IDs are bounded with the same `boundedFairnessRSSWorkerSlots`
+  cap used by the production RSS-structure gauges, so malformed status
+  rows cannot create unbounded estimator state or Prometheus labels.
+- The existing `observed_cov <= Cstruct + 0.05` contract remains the
+  pass/fail contract. Equal-flow telemetry is an advisory model for a
+  later non-work-conserving mode.
+- Prometheus labels stay bounded to `{ifindex,queue_id}` and
+  `{ifindex,queue_id,worker_id}`.
+
+## Non-Goals
+
+- No Rust dataplane enforcement.
+- No token-bucket or lease-budget change.
+- No CLI command for the rolling estimator; the CLI status path is
+  stateless across invocations, while the estimator needs a daemon-owned
+  rolling window.
+- No claim that the target distinguishes CPU-bound demand from
+  naturally quiet flows. Phase 0 intentionally measures the strict
+  equalize-to-slowest-sampled outcome so reviewers can quantify its
+  throughput cost first.
+
+## Validation
+
+- Unit test the estimator math on a skewed worker distribution:
+  worker 0 has 3 active flows and 9.6 Kbps observed, worker 1 has
+  1 active flow and 6.4 Kbps observed. Target is 3.2 Kbps/flow, capped
+  aggregate is 12.8 Kbps, suppression is 3.2 Kbps.
+- Unit test invalidation when CoS active-flow counts are truncated.
+- Unit test Prometheus descriptor emission for queue-level and
+  worker-level estimator gauges.
+- Run focused Go tests:
+
+```bash
+go test ./pkg/dataplane/userspace ./pkg/api
+```

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -118,18 +118,30 @@ type xpfCollector struct {
 	// #1247: production RSS/workload health gauges derived from the
 	// same per-CoS {a_i} snapshot. These expose the structural ceiling
 	// without adding packet-path state or global atomics.
-	fairnessCstruct             *prometheus.Desc
-	fairnessActiveWorkers       *prometheus.Desc
-	fairnessActiveFlows         *prometheus.Desc
-	fairnessMaxWorkerFlowShare  *prometheus.Desc
-	fairnessCoSCountsTruncated  *prometheus.Desc
-	fairnessRSSExpectation      *prometheus.Desc
-	fairnessRSSExpectationValue *prometheus.Desc
-	fairnessRSSSkewViolation    *prometheus.Desc
-	fairnessSaturated           *prometheus.Desc
-	fairnessObservedCoV         *prometheus.Desc
-	fairnessStarvedFlows        *prometheus.Desc
-	fairnessThroughputWindow    *dpuserspace.FairnessThroughputWindow
+	fairnessCstruct                           *prometheus.Desc
+	fairnessActiveWorkers                     *prometheus.Desc
+	fairnessActiveFlows                       *prometheus.Desc
+	fairnessMaxWorkerFlowShare                *prometheus.Desc
+	fairnessCoSCountsTruncated                *prometheus.Desc
+	fairnessRSSExpectation                    *prometheus.Desc
+	fairnessRSSExpectationValue               *prometheus.Desc
+	fairnessRSSSkewViolation                  *prometheus.Desc
+	fairnessSaturated                         *prometheus.Desc
+	fairnessObservedCoV                       *prometheus.Desc
+	fairnessStarvedFlows                      *prometheus.Desc
+	fairnessEqualFlowEstimateValid            *prometheus.Desc
+	fairnessEqualFlowSampledActiveWorkers     *prometheus.Desc
+	fairnessEqualFlowUnsampledActiveWorkers   *prometheus.Desc
+	fairnessEqualFlowTargetPerFlowBPS         *prometheus.Desc
+	fairnessEqualFlowObservedBPS              *prometheus.Desc
+	fairnessEqualFlowCappedBPS                *prometheus.Desc
+	fairnessEqualFlowSuppressedBPS            *prometheus.Desc
+	fairnessEqualFlowThroughputLossRatio      *prometheus.Desc
+	fairnessEqualFlowWorkerObservedBPS        *prometheus.Desc
+	fairnessEqualFlowWorkerObservedPerFlowBPS *prometheus.Desc
+	fairnessEqualFlowWorkerCapBPS             *prometheus.Desc
+	fairnessEqualFlowWorkerSuppressedBPS      *prometheus.Desc
+	fairnessThroughputWindow                  *dpuserspace.FairnessThroughputWindow
 }
 
 func newCollector(srv *Server) *xpfCollector {
@@ -480,6 +492,66 @@ func newCollector(srv *Server) *xpfCollector {
 			"Monotonic count of flows that enter below 1% of the rolling mean per-flow bytes for this egress CoS queue, de-duplicated while the flow remains in the rolling window (#1264).",
 			[]string{"ifindex", "queue_id"}, nil,
 		),
+		fairnessEqualFlowEstimateValid: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_estimate_valid",
+			"1 when the measurement-only equal-flow suppression estimator has at least two currently-active-flow workers with rolling byte samples for this egress CoS queue (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowSampledActiveWorkers: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_sampled_active_workers",
+			"Currently-active-flow workers with non-zero rolling byte samples in the measurement-only equal-flow suppression estimator (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowUnsampledActiveWorkers: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_unsampled_active_workers",
+			"Currently-active-flow workers with no rolling byte samples in the measurement-only equal-flow suppression estimator (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowTargetPerFlowBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_target_per_flow_bps",
+			"Slowest sampled currently-active worker's observed per-flow bit rate used as the measurement-only equal-flow suppression target for this egress CoS queue; low values may reflect source artifacts such as idle or receiver-limited flows, not only dataplane unfairness (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowObservedBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_observed_bps",
+			"Observed aggregate bits per second across currently-active-flow workers in the rolling estimator window before hypothetical equal-flow suppression (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowCappedBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_capped_bps",
+			"Estimated aggregate bits per second across currently-active-flow workers after applying the measurement-only equal-flow suppression cap; artifact-sensitive because the cap follows the slowest sampled per-flow rate (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowSuppressedBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_suppressed_bps",
+			"Estimated currently-active-flow worker bits per second that would be withheld by the measurement-only equal-flow suppression cap; artifact-sensitive because the cap follows the slowest sampled per-flow rate (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowThroughputLossRatio: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_throughput_loss_ratio",
+			"Estimated suppressed_bps / observed_bps ratio for the measurement-only equal-flow suppression cap; artifact-sensitive because the cap follows the slowest sampled per-flow rate (#1304).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		fairnessEqualFlowWorkerObservedBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_worker_observed_bps",
+			"Observed bits per second for one currently-active-flow worker in the rolling equal-flow suppression estimator (#1304).",
+			[]string{"ifindex", "queue_id", "worker_id"}, nil,
+		),
+		fairnessEqualFlowWorkerObservedPerFlowBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_worker_observed_per_flow_bps",
+			"Observed per-flow bits per second for one currently-active-flow worker in the rolling equal-flow suppression estimator (#1304).",
+			[]string{"ifindex", "queue_id", "worker_id"}, nil,
+		),
+		fairnessEqualFlowWorkerCapBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_worker_cap_bps",
+			"Estimated bits-per-second cap for one currently-active-flow worker under measurement-only equal-flow suppression; artifact-sensitive because the cap follows the slowest sampled per-flow rate (#1304).",
+			[]string{"ifindex", "queue_id", "worker_id"}, nil,
+		),
+		fairnessEqualFlowWorkerSuppressedBPS: prometheus.NewDesc(
+			"xpf_fairness_equal_flow_worker_suppressed_bps",
+			"Estimated bits per second withheld from one currently-active-flow worker by measurement-only equal-flow suppression; artifact-sensitive because the cap follows the slowest sampled per-flow rate (#1304).",
+			[]string{"ifindex", "queue_id", "worker_id"}, nil,
+		),
 		fairnessThroughputWindow: dpuserspace.NewFairnessThroughputWindow(30 * time.Second),
 	}
 }
@@ -550,6 +622,18 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.fairnessSaturated
 	ch <- c.fairnessObservedCoV
 	ch <- c.fairnessStarvedFlows
+	ch <- c.fairnessEqualFlowEstimateValid
+	ch <- c.fairnessEqualFlowSampledActiveWorkers
+	ch <- c.fairnessEqualFlowUnsampledActiveWorkers
+	ch <- c.fairnessEqualFlowTargetPerFlowBPS
+	ch <- c.fairnessEqualFlowObservedBPS
+	ch <- c.fairnessEqualFlowCappedBPS
+	ch <- c.fairnessEqualFlowSuppressedBPS
+	ch <- c.fairnessEqualFlowThroughputLossRatio
+	ch <- c.fairnessEqualFlowWorkerObservedBPS
+	ch <- c.fairnessEqualFlowWorkerObservedPerFlowBPS
+	ch <- c.fairnessEqualFlowWorkerCapBPS
+	ch <- c.fairnessEqualFlowWorkerSuppressedBPS
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -795,6 +879,117 @@ func (c *xpfCollector) emitFairnessThroughputGauges(ch chan<- prometheus.Metric,
 			float64(row.StarvedFlowsTotal),
 			ifindexLabel,
 			queueLabel,
+		)
+		c.emitFairnessEqualFlowEstimateGauges(ch, row, ifindexLabel, queueLabel)
+	}
+}
+
+func (c *xpfCollector) emitFairnessEqualFlowEstimateGauges(
+	ch chan<- prometheus.Metric,
+	row dpuserspace.FairnessThroughputSummary,
+	ifindexLabel string,
+	queueLabel string,
+) {
+	estimate := row.EqualFlowEstimate
+	if estimate.ActiveWorkers == 0 {
+		return
+	}
+	valid := 0.0
+	if estimate.Valid {
+		valid = 1
+	}
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowEstimateValid,
+		prometheus.GaugeValue,
+		valid,
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowSampledActiveWorkers,
+		prometheus.GaugeValue,
+		float64(estimate.SampledActiveWorkers),
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowUnsampledActiveWorkers,
+		prometheus.GaugeValue,
+		float64(estimate.UnsampledActiveWorkers),
+		ifindexLabel,
+		queueLabel,
+	)
+	if !estimate.Valid {
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowTargetPerFlowBPS,
+		prometheus.GaugeValue,
+		estimate.TargetPerFlowBPS,
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowObservedBPS,
+		prometheus.GaugeValue,
+		estimate.ObservedBPS,
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowCappedBPS,
+		prometheus.GaugeValue,
+		estimate.CappedBPS,
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowSuppressedBPS,
+		prometheus.GaugeValue,
+		estimate.SuppressedBPS,
+		ifindexLabel,
+		queueLabel,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fairnessEqualFlowThroughputLossRatio,
+		prometheus.GaugeValue,
+		estimate.ThroughputLossRatio,
+		ifindexLabel,
+		queueLabel,
+	)
+	for _, worker := range estimate.Workers {
+		workerLabel := strconv.FormatUint(uint64(worker.WorkerID), 10)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessEqualFlowWorkerObservedBPS,
+			prometheus.GaugeValue,
+			worker.ObservedBPS,
+			ifindexLabel,
+			queueLabel,
+			workerLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessEqualFlowWorkerObservedPerFlowBPS,
+			prometheus.GaugeValue,
+			worker.ObservedPerFlow,
+			ifindexLabel,
+			queueLabel,
+			workerLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessEqualFlowWorkerCapBPS,
+			prometheus.GaugeValue,
+			worker.CapBPS,
+			ifindexLabel,
+			queueLabel,
+			workerLabel,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.fairnessEqualFlowWorkerSuppressedBPS,
+			prometheus.GaugeValue,
+			worker.SuppressedBPS,
+			ifindexLabel,
+			queueLabel,
+			workerLabel,
 		)
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -605,6 +605,69 @@ func TestEmitFairnessRSSExpectationGauges(t *testing.T) {
 	assertGaugeClose(t, got, c.fairnessRSSSkewViolation, labelsQ6, 1)
 }
 
+func TestEmitFairnessEqualFlowEstimateGauges(t *testing.T) {
+	c := newCollector(nil)
+	row := dpuserspace.FairnessThroughputSummary{
+		EqualFlowEstimate: dpuserspace.FairnessEqualFlowEstimate{
+			Valid:                  true,
+			TargetPerFlowBPS:       3_200,
+			ObservedBPS:            16_000,
+			CappedBPS:              12_800,
+			SuppressedBPS:          3_200,
+			ThroughputLossRatio:    0.2,
+			ActiveWorkers:          2,
+			SampledActiveWorkers:   2,
+			UnsampledActiveWorkers: 0,
+			Workers: []dpuserspace.FairnessEqualFlowWorkerEstimate{
+				{
+					WorkerID:        0,
+					ActiveFlows:     3,
+					ObservedBPS:     9_600,
+					ObservedPerFlow: 3_200,
+					CapBPS:          9_600,
+				},
+				{
+					WorkerID:        1,
+					ActiveFlows:     1,
+					ObservedBPS:     6_400,
+					ObservedPerFlow: 6_400,
+					CapBPS:          3_200,
+					SuppressedBPS:   3_200,
+				},
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitFairnessEqualFlowEstimateGauges(ch, row, "80", "4")
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	if len(got) != 16 {
+		t.Fatalf("emitFairnessEqualFlowEstimateGauges: want 16 metrics, got %d", len(got))
+	}
+
+	queueLabels := map[string]string{"ifindex": "80", "queue_id": "4"}
+	assertGaugeClose(t, got, c.fairnessEqualFlowEstimateValid, queueLabels, 1)
+	assertGaugeClose(t, got, c.fairnessEqualFlowSampledActiveWorkers, queueLabels, 2)
+	assertGaugeClose(t, got, c.fairnessEqualFlowUnsampledActiveWorkers, queueLabels, 0)
+	assertGaugeClose(t, got, c.fairnessEqualFlowTargetPerFlowBPS, queueLabels, 3_200)
+	assertGaugeClose(t, got, c.fairnessEqualFlowObservedBPS, queueLabels, 16_000)
+	assertGaugeClose(t, got, c.fairnessEqualFlowCappedBPS, queueLabels, 12_800)
+	assertGaugeClose(t, got, c.fairnessEqualFlowSuppressedBPS, queueLabels, 3_200)
+	assertGaugeClose(t, got, c.fairnessEqualFlowThroughputLossRatio, queueLabels, 0.2)
+
+	workerOneLabels := map[string]string{"ifindex": "80", "queue_id": "4", "worker_id": "1"}
+	assertGaugeClose(t, got, c.fairnessEqualFlowWorkerObservedBPS, workerOneLabels, 6_400)
+	assertGaugeClose(t, got, c.fairnessEqualFlowWorkerObservedPerFlowBPS, workerOneLabels, 6_400)
+	assertGaugeClose(t, got, c.fairnessEqualFlowWorkerCapBPS, workerOneLabels, 3_200)
+	assertGaugeClose(t, got, c.fairnessEqualFlowWorkerSuppressedBPS, workerOneLabels, 3_200)
+}
+
 func TestCoSFairnessRSSSummaries_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/dataplane/userspace/fairness_throughput.go
+++ b/pkg/dataplane/userspace/fairness_throughput.go
@@ -18,6 +18,35 @@ type FairnessThroughputSummary struct {
 	WindowSeconds     float64
 	ObservedBytes     uint64
 	SourceTruncated   bool
+	EqualFlowEstimate FairnessEqualFlowEstimate
+}
+
+// FairnessEqualFlowEstimate is a measurement-only model for #1304's
+// equal-flow mode. It computes the per-worker caps that would align
+// delivered per-flow rates to the slowest sampled active worker in the
+// current rolling window. The result is telemetry only; no scheduler
+// path reads it.
+type FairnessEqualFlowEstimate struct {
+	Valid                  bool
+	TargetPerFlowBPS       float64
+	ObservedBPS            float64
+	CappedBPS              float64
+	SuppressedBPS          float64
+	ThroughputLossRatio    float64
+	ActiveWorkers          int
+	SampledActiveWorkers   int
+	UnsampledActiveWorkers int
+	Workers                []FairnessEqualFlowWorkerEstimate
+}
+
+type FairnessEqualFlowWorkerEstimate struct {
+	WorkerID        uint32
+	ActiveFlows     uint32
+	ObservedBytes   uint64
+	ObservedBPS     float64
+	ObservedPerFlow float64
+	CapBPS          float64
+	SuppressedBPS   float64
 }
 
 type FairnessThroughputWindow struct {
@@ -38,16 +67,18 @@ type fairnessFlowThroughputKey struct {
 }
 
 type fairnessThroughputSample struct {
-	at       time.Time
-	duration time.Duration
-	deltas   map[fairnessFlowThroughputKey]uint64
+	at           time.Time
+	duration     time.Duration
+	deltas       map[fairnessFlowThroughputKey]uint64
+	workerDeltas map[uint32]uint64
 }
 
 type fairnessQueueThroughputWindow struct {
-	samples      []fairnessThroughputSample
-	bytesByFlow  map[fairnessFlowThroughputKey]uint64
-	starvedFlows map[fairnessFlowThroughputKey]struct{}
-	starvedTotal uint64
+	samples       []fairnessThroughputSample
+	bytesByFlow   map[fairnessFlowThroughputKey]uint64
+	bytesByWorker map[uint32]uint64
+	starvedFlows  map[fairnessFlowThroughputKey]struct{}
+	starvedTotal  uint64
 }
 
 func NewFairnessThroughputWindow(window time.Duration) *FairnessThroughputWindow {
@@ -90,12 +121,18 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 	}
 
 	queueRates := fairnessQueueTransmitRates(status)
+	workerSlots := uint32(boundedFairnessRSSWorkerSlots(status.Workers, maxFairnessRSSWorkerSlots))
+	var activeWorkerFlows map[fairnessQueueKey]map[uint32]uint32
+	if !status.CoSActiveFlowCountsTruncated {
+		activeWorkerFlows = fairnessQueueActiveWorkerFlows(status, workerSlots)
+	}
 	seen := make(map[fairnessFlowThroughputKey]uint64)
 	sampleQueues := make(map[fairnessQueueKey]struct{}, len(w.queues))
 	for queue := range w.queues {
 		sampleQueues[queue] = struct{}{}
 	}
 	sampleDeltas := make(map[fairnessQueueKey]map[fairnessFlowThroughputKey]uint64)
+	sampleWorkerDeltas := make(map[fairnessQueueKey]map[uint32]uint64)
 	for _, row := range status.FlowWorkerMap {
 		if row.CoSQueueID == nil || row.EgressIfindex == 0 {
 			continue
@@ -129,6 +166,14 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 			sampleDeltas[key.queue] = deltas
 		}
 		deltas[key] += delta
+		if row.WorkerID < workerSlots {
+			workerDeltas := sampleWorkerDeltas[key.queue]
+			if workerDeltas == nil {
+				workerDeltas = make(map[uint32]uint64)
+				sampleWorkerDeltas[key.queue] = workerDeltas
+			}
+			workerDeltas[row.WorkerID] += delta
+		}
 	}
 	for key := range w.prev {
 		if _, ok := seen[key]; !ok {
@@ -140,9 +185,10 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		for queue := range sampleQueues {
 			state := w.queueState(queue)
 			state.addSample(fairnessThroughputSample{
-				at:       now,
-				duration: duration,
-				deltas:   sampleDeltas[queue],
+				at:           now,
+				duration:     duration,
+				deltas:       sampleDeltas[queue],
+				workerDeltas: sampleWorkerDeltas[queue],
 			})
 		}
 	}
@@ -167,7 +213,7 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		if state == nil || len(state.bytesByFlow) == 0 {
 			continue
 		}
-		summary := state.summary(key, queueRates[key])
+		summary := state.summary(key, queueRates[key], activeWorkerFlows[key])
 		out = append(out, summary)
 	}
 	return out
@@ -179,6 +225,7 @@ func (w *FairnessThroughputWindow) resetWindowState() {
 	for _, state := range w.queues {
 		state.samples = nil
 		clear(state.bytesByFlow)
+		clear(state.bytesByWorker)
 		clear(state.starvedFlows)
 	}
 }
@@ -187,8 +234,9 @@ func (w *FairnessThroughputWindow) queueState(key fairnessQueueKey) *fairnessQue
 	state := w.queues[key]
 	if state == nil {
 		state = &fairnessQueueThroughputWindow{
-			bytesByFlow:  make(map[fairnessFlowThroughputKey]uint64),
-			starvedFlows: make(map[fairnessFlowThroughputKey]struct{}),
+			bytesByFlow:   make(map[fairnessFlowThroughputKey]uint64),
+			bytesByWorker: make(map[uint32]uint64),
+			starvedFlows:  make(map[fairnessFlowThroughputKey]struct{}),
 		}
 		w.queues[key] = state
 	}
@@ -199,12 +247,18 @@ func (q *fairnessQueueThroughputWindow) addSample(sample fairnessThroughputSampl
 	if q.bytesByFlow == nil {
 		q.bytesByFlow = make(map[fairnessFlowThroughputKey]uint64)
 	}
+	if q.bytesByWorker == nil {
+		q.bytesByWorker = make(map[uint32]uint64)
+	}
 	if q.starvedFlows == nil {
 		q.starvedFlows = make(map[fairnessFlowThroughputKey]struct{})
 	}
 	q.samples = append(q.samples, sample)
 	for flow, delta := range sample.deltas {
 		q.bytesByFlow[flow] += delta
+	}
+	for workerID, delta := range sample.workerDeltas {
+		q.bytesByWorker[workerID] += delta
 	}
 }
 
@@ -216,6 +270,13 @@ func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
 				delete(q.bytesByFlow, flow)
 			} else {
 				q.bytesByFlow[flow] -= delta
+			}
+		}
+		for workerID, delta := range q.samples[keepFrom].workerDeltas {
+			if q.bytesByWorker[workerID] <= delta {
+				delete(q.bytesByWorker, workerID)
+			} else {
+				q.bytesByWorker[workerID] -= delta
 			}
 		}
 		keepFrom++
@@ -231,7 +292,11 @@ func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {
 	}
 }
 
-func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRateBytes uint64) FairnessThroughputSummary {
+func (q *fairnessQueueThroughputWindow) summary(
+	key fairnessQueueKey,
+	transmitRateBytes uint64,
+	activeWorkerFlows map[uint32]uint32,
+) FairnessThroughputSummary {
 	var totalBytes uint64
 	values := make([]float64, 0, len(q.bytesByFlow))
 	for _, bytes := range q.bytesByFlow {
@@ -258,7 +323,79 @@ func (q *fairnessQueueThroughputWindow) summary(key fairnessQueueKey, transmitRa
 		StarvedFlowsTotal: q.starvedTotal,
 		WindowSeconds:     windowSeconds,
 		ObservedBytes:     totalBytes,
+		EqualFlowEstimate: q.equalFlowEstimate(windowSeconds, activeWorkerFlows),
 	}
+}
+
+func (q *fairnessQueueThroughputWindow) equalFlowEstimate(
+	windowSeconds float64,
+	activeWorkerFlows map[uint32]uint32,
+) FairnessEqualFlowEstimate {
+	if windowSeconds <= 0 || len(activeWorkerFlows) == 0 {
+		return FairnessEqualFlowEstimate{}
+	}
+
+	workerIDs := make([]uint32, 0, len(activeWorkerFlows))
+	for workerID, activeFlows := range activeWorkerFlows {
+		if activeFlows > 0 {
+			workerIDs = append(workerIDs, workerID)
+		}
+	}
+	sort.Slice(workerIDs, func(i, j int) bool { return workerIDs[i] < workerIDs[j] })
+	if len(workerIDs) == 0 {
+		return FairnessEqualFlowEstimate{}
+	}
+
+	estimate := FairnessEqualFlowEstimate{
+		ActiveWorkers: len(workerIDs),
+		Workers:       make([]FairnessEqualFlowWorkerEstimate, 0, len(workerIDs)),
+	}
+	targetPerFlowBPS := 0.0
+	for _, workerID := range workerIDs {
+		activeFlows := activeWorkerFlows[workerID]
+		observedBytes := q.bytesByWorker[workerID]
+		observedBPS := float64(observedBytes) * 8.0 / windowSeconds
+		estimate.ObservedBPS += observedBPS
+		worker := FairnessEqualFlowWorkerEstimate{
+			WorkerID:      workerID,
+			ActiveFlows:   activeFlows,
+			ObservedBytes: observedBytes,
+			ObservedBPS:   observedBPS,
+		}
+		if observedBytes == 0 {
+			estimate.UnsampledActiveWorkers++
+			estimate.Workers = append(estimate.Workers, worker)
+			continue
+		}
+		worker.ObservedPerFlow = observedBPS / float64(activeFlows)
+		if estimate.SampledActiveWorkers == 0 || worker.ObservedPerFlow < targetPerFlowBPS {
+			targetPerFlowBPS = worker.ObservedPerFlow
+		}
+		estimate.SampledActiveWorkers++
+		estimate.Workers = append(estimate.Workers, worker)
+	}
+	if estimate.SampledActiveWorkers < 2 || targetPerFlowBPS <= 0 {
+		return estimate
+	}
+
+	estimate.Valid = true
+	estimate.TargetPerFlowBPS = targetPerFlowBPS
+	for i := range estimate.Workers {
+		worker := &estimate.Workers[i]
+		if worker.ActiveFlows == 0 {
+			continue
+		}
+		worker.CapBPS = targetPerFlowBPS * float64(worker.ActiveFlows)
+		if worker.ObservedBPS > worker.CapBPS {
+			worker.SuppressedBPS = worker.ObservedBPS - worker.CapBPS
+		}
+		estimate.SuppressedBPS += worker.SuppressedBPS
+		estimate.CappedBPS += worker.ObservedBPS - worker.SuppressedBPS
+	}
+	if estimate.ObservedBPS > 0 {
+		estimate.ThroughputLossRatio = estimate.SuppressedBPS / estimate.ObservedBPS
+	}
+	return estimate
 }
 
 func (q *fairnessQueueThroughputWindow) windowSeconds() float64 {
@@ -327,6 +464,23 @@ func fairnessQueueTransmitRates(status ProcessStatus) map[fairnessQueueKey]uint6
 			}
 			out[fairnessQueueKey{ifindex: iface.Ifindex, queueID: uint8(queue.QueueID)}] = rate
 		}
+	}
+	return out
+}
+
+func fairnessQueueActiveWorkerFlows(status ProcessStatus, workerSlots uint32) map[fairnessQueueKey]map[uint32]uint32 {
+	out := make(map[fairnessQueueKey]map[uint32]uint32)
+	for _, row := range status.CoSActiveFlowCounts {
+		if row.ActiveFlowCount == 0 || row.WorkerID >= workerSlots {
+			continue
+		}
+		key := fairnessQueueKey{ifindex: row.Ifindex, queueID: row.QueueID}
+		workers := out[key]
+		if workers == nil {
+			workers = make(map[uint32]uint32)
+			out[key] = workers
+		}
+		workers[row.WorkerID] += row.ActiveFlowCount
 	}
 	return out
 }

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -243,8 +243,200 @@ func TestFairnessThroughputWindowPrunesOldSamples(t *testing.T) {
 	}
 }
 
+func TestFairnessThroughputWindowEqualFlowEstimate(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 0, 0)
+	status.CoSActiveFlowCounts = []CoSActiveFlowCountStatus{
+		{Ifindex: 80, QueueID: queueID, WorkerID: 0, ActiveFlowCount: 3},
+		{Ifindex: 80, QueueID: queueID, WorkerID: 1, ActiveFlowCount: 1},
+	}
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 12_000
+	status.FlowWorkerMap[1].ObservedBytes = 8_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	estimate := got[0].EqualFlowEstimate
+	if !estimate.Valid {
+		t.Fatalf("EqualFlowEstimate.Valid = false, want true: %+v", estimate)
+	}
+	if estimate.ActiveWorkers != 2 || estimate.SampledActiveWorkers != 2 || estimate.UnsampledActiveWorkers != 0 {
+		t.Fatalf("worker counts = active %d sampled %d unsampled %d, want 2/2/0",
+			estimate.ActiveWorkers, estimate.SampledActiveWorkers, estimate.UnsampledActiveWorkers)
+	}
+	if math.Abs(estimate.TargetPerFlowBPS-3_200) > 0.0001 {
+		t.Fatalf("TargetPerFlowBPS = %.3f, want 3200", estimate.TargetPerFlowBPS)
+	}
+	if math.Abs(estimate.ObservedBPS-16_000) > 0.0001 {
+		t.Fatalf("ObservedBPS = %.3f, want 16000", estimate.ObservedBPS)
+	}
+	if math.Abs(estimate.CappedBPS-12_800) > 0.0001 {
+		t.Fatalf("CappedBPS = %.3f, want 12800", estimate.CappedBPS)
+	}
+	if math.Abs(estimate.SuppressedBPS-3_200) > 0.0001 {
+		t.Fatalf("SuppressedBPS = %.3f, want 3200", estimate.SuppressedBPS)
+	}
+	if math.Abs(estimate.ThroughputLossRatio-0.2) > 0.0001 {
+		t.Fatalf("ThroughputLossRatio = %.6f, want 0.2", estimate.ThroughputLossRatio)
+	}
+	if got := estimate.Workers[0].CapBPS; math.Abs(got-9_600) > 0.0001 {
+		t.Fatalf("worker 0 CapBPS = %.3f, want 9600", got)
+	}
+	if got := estimate.Workers[1].CapBPS; math.Abs(got-3_200) > 0.0001 {
+		t.Fatalf("worker 1 CapBPS = %.3f, want 3200", got)
+	}
+	if got := estimate.Workers[1].SuppressedBPS; math.Abs(got-3_200) > 0.0001 {
+		t.Fatalf("worker 1 SuppressedBPS = %.3f, want 3200", got)
+	}
+}
+
+func TestFairnessThroughputWindowEqualFlowEstimateRequiresUntruncatedActiveCounts(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 0, 0)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 12_000
+	status.FlowWorkerMap[1].ObservedBytes = 8_000
+	status.CoSActiveFlowCountsTruncated = true
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	if got[0].EqualFlowEstimate.Valid {
+		t.Fatalf("EqualFlowEstimate.Valid = true with truncated CoS active-flow counts: %+v", got[0].EqualFlowEstimate)
+	}
+	if got[0].EqualFlowEstimate.ActiveWorkers != 0 {
+		t.Fatalf("ActiveWorkers = %d with truncated CoS active-flow counts, want 0", got[0].EqualFlowEstimate.ActiveWorkers)
+	}
+}
+
+func TestFairnessThroughputWindowEqualFlowEstimateValidityBoundaries(t *testing.T) {
+	t.Run("single sampled worker is invalid", func(t *testing.T) {
+		window := NewFairnessThroughputWindow(30 * time.Second)
+		now := time.Unix(100, 0)
+		queueID := uint8(4)
+		status := throughputStatus(queueID, 0, 0)
+		status.FlowWorkerMap = status.FlowWorkerMap[:1]
+		status.CoSActiveFlowCounts = []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: queueID, WorkerID: 0, ActiveFlowCount: 1},
+		}
+
+		window.Update(now, status)
+		status.FlowWorkerMap[0].ObservedBytes = 12_000
+		got := window.Update(now.Add(10*time.Second), status)
+		if len(got) != 1 {
+			t.Fatalf("second update produced %d summaries, want 1", len(got))
+		}
+		estimate := got[0].EqualFlowEstimate
+		if estimate.Valid {
+			t.Fatalf("EqualFlowEstimate.Valid = true for single sampled worker: %+v", estimate)
+		}
+		if estimate.ActiveWorkers != 1 || estimate.SampledActiveWorkers != 1 {
+			t.Fatalf("worker counts = active %d sampled %d, want 1/1", estimate.ActiveWorkers, estimate.SampledActiveWorkers)
+		}
+	})
+
+	t.Run("all active workers unsampled is invalid", func(t *testing.T) {
+		window := NewFairnessThroughputWindow(30 * time.Second)
+		now := time.Unix(100, 0)
+		queueID := uint8(4)
+		status := throughputStatus(queueID, 0, 0)
+		status.Workers = 4
+		status.CoSActiveFlowCounts = []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: queueID, WorkerID: 2, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: queueID, WorkerID: 3, ActiveFlowCount: 1},
+		}
+
+		window.Update(now, status)
+		status.FlowWorkerMap[0].ObservedBytes = 12_000
+		status.FlowWorkerMap[1].ObservedBytes = 8_000
+		got := window.Update(now.Add(10*time.Second), status)
+		if len(got) != 1 {
+			t.Fatalf("second update produced %d summaries, want 1", len(got))
+		}
+		estimate := got[0].EqualFlowEstimate
+		if estimate.Valid {
+			t.Fatalf("EqualFlowEstimate.Valid = true when all active workers are unsampled: %+v", estimate)
+		}
+		if estimate.ActiveWorkers != 2 || estimate.SampledActiveWorkers != 0 || estimate.UnsampledActiveWorkers != 2 {
+			t.Fatalf("worker counts = active %d sampled %d unsampled %d, want 2/0/2",
+				estimate.ActiveWorkers, estimate.SampledActiveWorkers, estimate.UnsampledActiveWorkers)
+		}
+	})
+
+	t.Run("zero window seconds is invalid", func(t *testing.T) {
+		q := &fairnessQueueThroughputWindow{
+			bytesByFlow: map[fairnessFlowThroughputKey]uint64{
+				{queue: fairnessQueueKey{ifindex: 80, queueID: 4}, tuple: FlowTupleStatus{AddrFamily: 2, Protocol: 6, SrcIP: "10.0.0.1", DstIP: "198.51.100.1", SrcPort: 10001, DstPort: 5201}}: 12_000,
+			},
+			bytesByWorker: map[uint32]uint64{0: 12_000, 1: 8_000},
+			starvedFlows:  make(map[fairnessFlowThroughputKey]struct{}),
+		}
+		summary := q.summary(fairnessQueueKey{ifindex: 80, queueID: 4}, 0, map[uint32]uint32{0: 1, 1: 1})
+		if summary.WindowSeconds != 0 {
+			t.Fatalf("WindowSeconds = %.3f, want 0", summary.WindowSeconds)
+		}
+		if summary.EqualFlowEstimate.Valid {
+			t.Fatalf("EqualFlowEstimate.Valid = true with zero window seconds: %+v", summary.EqualFlowEstimate)
+		}
+	})
+}
+
+func TestFairnessThroughputWindowEqualFlowEstimateCapsWorkerIDs(t *testing.T) {
+	window := NewFairnessThroughputWindow(30 * time.Second)
+	now := time.Unix(100, 0)
+	queueID := uint8(4)
+	status := throughputStatus(queueID, 0, 0)
+	status.Workers = 2
+	status.FlowWorkerMap[1].WorkerID = 4_096
+	status.CoSActiveFlowCounts = append(status.CoSActiveFlowCounts,
+		CoSActiveFlowCountStatus{Ifindex: 80, QueueID: queueID, WorkerID: 4_096, ActiveFlowCount: 1},
+	)
+
+	window.Update(now, status)
+	status.FlowWorkerMap[0].ObservedBytes = 12_000
+	status.FlowWorkerMap[1].ObservedBytes = 8_000
+	got := window.Update(now.Add(10*time.Second), status)
+	if len(got) != 1 {
+		t.Fatalf("second update produced %d summaries, want 1", len(got))
+	}
+	queueState := window.queues[fairnessQueueKey{ifindex: 80, queueID: queueID}]
+	if queueState == nil {
+		t.Fatalf("queue state missing after update")
+	}
+	if got := queueState.bytesByWorker[0]; got != 12_000 {
+		t.Fatalf("bytesByWorker[0] = %d, want 12000", got)
+	}
+	if _, ok := queueState.bytesByWorker[4_096]; ok {
+		t.Fatalf("out-of-range worker ID leaked into bytesByWorker: %+v", queueState.bytesByWorker)
+	}
+	if len(queueState.bytesByWorker) != 1 {
+		t.Fatalf("bytesByWorker length = %d, want 1: %+v", len(queueState.bytesByWorker), queueState.bytesByWorker)
+	}
+	estimate := got[0].EqualFlowEstimate
+	if estimate.Valid {
+		t.Fatalf("EqualFlowEstimate.Valid = true after out-of-range worker was ignored: %+v", estimate)
+	}
+	if estimate.ActiveWorkers != 2 || estimate.SampledActiveWorkers != 1 || estimate.UnsampledActiveWorkers != 1 {
+		t.Fatalf("worker counts = active %d sampled %d unsampled %d, want 2/1/1",
+			estimate.ActiveWorkers, estimate.SampledActiveWorkers, estimate.UnsampledActiveWorkers)
+	}
+	for _, worker := range estimate.Workers {
+		if worker.WorkerID >= 2 {
+			t.Fatalf("out-of-range worker ID leaked into estimate: %+v", estimate.Workers)
+		}
+	}
+}
+
 func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) ProcessStatus {
 	return ProcessStatus{
+		Workers: 2,
 		CoSInterfaces: []CoSInterfaceStatus{{
 			Ifindex: 80,
 			Queues: []CoSQueueStatus{{
@@ -256,6 +448,7 @@ func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) Proc
 			{
 				EgressIfindex: 80,
 				CoSQueueID:    &queueID,
+				WorkerID:      0,
 				ForwardWireKey: FlowTupleStatus{
 					AddrFamily: 2,
 					Protocol:   6,
@@ -269,6 +462,7 @@ func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) Proc
 			{
 				EgressIfindex: 80,
 				CoSQueueID:    &queueID,
+				WorkerID:      1,
 				ForwardWireKey: FlowTupleStatus{
 					AddrFamily: 2,
 					Protocol:   6,
@@ -279,6 +473,10 @@ func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) Proc
 				},
 				ObservedBytes: secondBytes,
 			},
+		},
+		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+			{Ifindex: 80, QueueID: queueID, WorkerID: 0, ActiveFlowCount: 1},
+			{Ifindex: 80, QueueID: queueID, WorkerID: 1, ActiveFlowCount: 1},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- add #1304 Phase 0 measurement-only equal-flow suppression estimates to the rolling fairness throughput window
- export queue-level and worker-level Prometheus gauges for target per-flow bps, observed/capped/suppressed bps, throughput-loss ratio, and estimator validity
- document the estimator contract, non-goals, and validation plan in `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, and `docs/pr/1304-equal-flow-estimator/plan.md`

## Important Contract
This does not enforce rate suppression and does not touch the Rust dataplane hot path. It only answers: if we chose strict non-work-conserving equal-flow mode for this exact CoS queue, which workers would be slowed and what aggregate throughput would be withheld?

The estimator is valid only with untruncated flow-worker byte telemetry, untruncated per-CoS active-flow counts, and at least two sampled active workers.

Refs #1304.

## Tests
- `go test ./pkg/dataplane/userspace ./pkg/api`