### PR TITLE
userspace: capture fairness estimator sweeps

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-14
 
+- **Timestamp**: 2026-05-14T19:19:32Z
+  - **Action**: PR #1308 round-1 review follow-up — made equal-flow capture reduction fail closed on SIGTERM-truncated marked scrapes and non-integer active-worker counts, and made sweep summary rows report infrastructure exit status `2` when equal-flow capture fails after the wrapper succeeds.
+  - **File(s)**: `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-14T18:35:00Z
   - **Action**: Issue #1306 — add first-class per-class equal-flow estimator capture to the CoS class sweep harness. The sweep now brackets each wrapper run with continuous Prometheus scraping, preserves raw scrapes, reduces target-class equal-flow aggregate/worker rows, appends equal-flow evidence to `summary.md`, and fails closed on empty/missing/invalid estimator captures.
   - **File(s)**: `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-14
 
+- **Timestamp**: 2026-05-14T19:33:03Z
+  - **Action**: PR #1308 round-2 review follow-up — added explicit equal-flow scrape framing tests for nested begin and end-without-begin paths, added the missing `BindingCountersSnapshot` round-trip pin for `tx_shared_recycle_unknown_slot_drops`, applied `gofmt` to `protocol.go`, and renamed sweep progress output from `wrapper_status` to `exit_status` with a named infrastructure-exit constant.
+  - **File(s)**: `test/incus/fairness_multi_sample_test.py`, `test/incus/fairness-cos-class-sweep.sh`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/protocol_test.go`, `_Log.md`
+
 - **Timestamp**: 2026-05-14T19:19:32Z
   - **Action**: PR #1308 round-1 review follow-up — made equal-flow capture reduction fail closed on SIGTERM-truncated marked scrapes and non-integer active-worker counts, and made sweep summary rows report infrastructure exit status `2` when equal-flow capture fails after the wrapper succeeds.
   - **File(s)**: `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-14
 
+- **Timestamp**: 2026-05-14T18:35:00Z
+  - **Action**: Issue #1306 — add first-class per-class equal-flow estimator capture to the CoS class sweep harness. The sweep now brackets each wrapper run with continuous Prometheus scraping, preserves raw scrapes, reduces target-class equal-flow aggregate/worker rows, appends equal-flow evidence to `summary.md`, and fails closed on empty/missing/invalid estimator captures.
+  - **File(s)**: `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-14T17:53:10Z
   - **Action**: PR #1305 round-3 review follow-up — extended artifact-warning wording to the equal-flow capped-bps, worker-cap-bps, and throughput-loss-ratio Prometheus help strings.
   - **File(s)**: `pkg/api/metrics.go`, `_Log.md`
@@ -468,6 +472,9 @@
   - **Action**: Close PR #1301 round-4 recycle-routing and mixed-mode safety blockers: thread the shared recycle accumulator through close-delta purge, pending TX bound/drop, CoS enqueue demotion, cross-binding prepared redirect, queue-service prepared rejection, neighbor retry, CoS runtime reset, and worker-shaped request paths; remove local-only prepared recycle exports; remove arbitrary-binding fallback for unknown shared recycle slots.
   - **File(s)**: `userspace-dp/src/afxdp/tx/transmit.rs`, `userspace-dp/src/afxdp/tx/mod.rs`, `userspace-dp/src/afxdp/tx/dispatch.rs`, `userspace-dp/src/afxdp/tx/drain.rs`, `userspace-dp/src/afxdp/tx/cos_classify.rs`, `userspace-dp/src/afxdp/tx/tcp_segmentation.rs`, `userspace-dp/src/afxdp/cos/cross_binding.rs`, `userspace-dp/src/afxdp/cos/queue_service/mod.rs`, `userspace-dp/src/afxdp/cos/queue_service/service.rs`, `userspace-dp/src/afxdp/cos/queue_service/drain.rs`, `userspace-dp/src/afxdp/session_glue/mod.rs`, `userspace-dp/src/afxdp/session_delta.rs`, `userspace-dp/src/afxdp/neighbor_dispatch.rs`, `userspace-dp/src/afxdp/worker/cos.rs`, `userspace-dp/src/afxdp/worker/lifecycle.rs`, `userspace-dp/src/afxdp/worker/mod.rs`, `userspace-dp/src/afxdp/tx/README.md`, `userspace-dp/src/afxdp/cos/README.md`, `docs/shared-umem-plan.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml cancelled_prepared --no-run`; `cargo test --manifest-path userspace-dp/Cargo.toml shared_umem -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml cancelled_prepared -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml drain_exact_prepared -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml demote_prepared -- --nocapture`; `go test ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
+- **Timestamp**: 2026-05-14T18:55:40Z
+  - **Action**: #1307 minimal TX-error attribution: add `tx_shared_recycle_unknown_slot_drops` as a per-binding subset of `tx_errors` for shared-UMEM unknown-slot recycle drops, mirror it through Rust/Go status, and make the local fallback `TxError::Drop` path increment `tx_submit_error_drops`.
+  - **File(s)**: `userspace-dp/src/afxdp/umem/mod.rs`, `userspace-dp/src/afxdp/worker/mod.rs`, `userspace-dp/src/afxdp/coordinator/mod.rs`, `userspace-dp/src/afxdp/tx/dispatch.rs`, `userspace-dp/src/afxdp/session_glue/mod.rs`, `userspace-dp/src/afxdp/tx/drain.rs`, `userspace-dp/src/protocol.rs`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/statusfmt.go`, `userspace-dp/src/afxdp/tx/README.md`, `docs/shared-umem-plan.md`, `_Log.md`
 - **Timestamp**: 2026-05-14T06:05:00Z
   - **Action**: Fix shared-UMEM live-status publication discovered during cluster smoke: the shared bind path now publishes the selected mode/group/role into `BindingLiveState` before worker refresh so status snapshots match the kernel bind result instead of reporting `Shared UMEM bindings: 0/N`.
   - **File(s)**: `userspace-dp/src/afxdp/worker/mod.rs`, `userspace-dp/src/afxdp/worker/README.md`, `_Log.md`

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -491,7 +491,8 @@ and stops it after the wrapper exits. Raw scrapes are preserved under
 written beside it as `summary.json`, `aggregate.tsv`, and `worker.tsv`.
 The sweep also writes `<artifact>/equal-flow-summary.tsv` and appends an
 equal-flow section to `summary.md`. Missing or empty scrapes, parse
-errors, or missing required aggregate estimator rows for the target
+errors, missing scrape-end markers, non-integer active-worker counts,
+or missing required aggregate estimator rows for the target
 `COS_IFINDEX` and class queue are infrastructure failures and make the
 sweep exit `2`; they do not produce a false-green fairness verdict.
 - **`xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=...}`**

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -482,6 +482,18 @@ For production observability, xpf MUST export:
   gauges: per-worker breakdown of the same hypothetical cap. These are
   intended to answer "which worker would we slow, by how much?" before
   any enforcement mode is introduced.
+
+The all-class CoS sweep harness captures this estimator as first-class
+run evidence. For each class, `fairness-cos-class-sweep.sh` starts a
+continuous Prometheus scrape before invoking the multi-sample wrapper
+and stops it after the wrapper exits. Raw scrapes are preserved under
+`<artifact>/<class>/equal-flow/metrics-raw.prom`; reducer output is
+written beside it as `summary.json`, `aggregate.tsv`, and `worker.tsv`.
+The sweep also writes `<artifact>/equal-flow-summary.tsv` and appends an
+equal-flow section to `summary.md`. Missing or empty scrapes, parse
+errors, or missing required aggregate estimator rows for the target
+`COS_IFINDEX` and class queue are infrastructure failures and make the
+sweep exit `2`; they do not produce a false-green fairness verdict.
 - **`xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=...}`**
   counter: cumulative v8 CoS queue-lease acquire calls made by the
   worker. Use `rate()` over the same scrape window as worker TX

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -427,6 +427,13 @@ metric honest: it answers "what throughput would strict equal-flow
 suppression cost on this queue right now?" before any enforcement mode
 is designed.
 
+Issue #1306 makes the class sweep preserve that evidence directly:
+each class artifact gets an `equal-flow/` directory with the raw
+Prometheus scrape stream plus reduced aggregate and worker TSV/JSON
+summaries for the target `COS_IFINDEX` and queue. The sweep fails closed
+with exit `2` if those required estimator rows are absent or the scrape
+stream is empty.
+
 ### PR #1241 — TX completion uniformity telemetry
 
 Before the next full fairness measurement, the dataplane must expose

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -431,8 +431,9 @@ Issue #1306 makes the class sweep preserve that evidence directly:
 each class artifact gets an `equal-flow/` directory with the raw
 Prometheus scrape stream plus reduced aggregate and worker TSV/JSON
 summaries for the target `COS_IFINDEX` and queue. The sweep fails closed
-with exit `2` if those required estimator rows are absent or the scrape
-stream is empty.
+with exit `2` if those required estimator rows are absent, the scrape
+stream is empty or truncated, or the active-worker-count gauges are not
+integer counts.
 
 ### PR #1241 — TX completion uniformity telemetry
 

--- a/docs/shared-umem-plan.md
+++ b/docs/shared-umem-plan.md
@@ -444,8 +444,9 @@ Operational success is not "AF_XDP bind says zerocopy". It is the full chain:
 - `In-place VLAN push desc` / `pop desc` increase for VLAN transitions
 - `In-place L2 memmove fb` stays flat
 - unknown shared-recycle slots fail closed, log the dropped `(slot, offset)`,
-  and increment `TX errors` instead of pushing the offset into any fallback
-  binding
+  and increment both `TX errors` and
+  `tx_shared_recycle_unknown_slot_drops` instead of pushing the offset into
+  any fallback binding
 - perf no longer shows `build_forwarded_frame_into_from_frame` as the
   dominant `__memmove_evex_unaligned_erms` caller
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -402,58 +402,58 @@ type UserspaceCapabilities struct {
 }
 
 type ProcessStatus struct {
-	PID                    int                               `json:"pid"`
-	StartedAt              time.Time                         `json:"started_at"`
-	ControlSocket          string                            `json:"control_socket"`
-	StateFile              string                            `json:"state_file"`
-	Workers                int                               `json:"workers"`
-	RingEntries            int                               `json:"ring_entries"`
-	HelperMode             string                            `json:"helper_mode"`
-	IOUringPlanned         bool                              `json:"io_uring_planned"`
-	IOUringActive          bool                              `json:"io_uring_active,omitempty"`
-	IOUringMode            string                            `json:"io_uring_mode,omitempty"`
-	IOUringLastError       string                            `json:"io_uring_last_error,omitempty"`
-	Enabled                bool                              `json:"enabled"`
-	ForwardingArmed        bool                              `json:"forwarding_armed,omitempty"`
-	Capabilities           UserspaceCapabilities             `json:"capabilities"`
-	LastSnapshotGeneration uint64                            `json:"last_snapshot_generation"`
-	LastFIBGeneration      uint32                            `json:"last_fib_generation,omitempty"`
-	LastSnapshotAt         time.Time                         `json:"last_snapshot_at,omitempty"`
-	InterfaceAddresses     int                               `json:"interface_addresses,omitempty"`
-	NeighborEntries        int                               `json:"neighbor_entries,omitempty"`
-	NeighborGeneration     uint64                            `json:"neighbor_generation,omitempty"`
-	RouteEntries           int                               `json:"route_entries,omitempty"`
-	WorkerHeartbeats       []time.Time                       `json:"worker_heartbeats,omitempty"`
+	PID                    int                   `json:"pid"`
+	StartedAt              time.Time             `json:"started_at"`
+	ControlSocket          string                `json:"control_socket"`
+	StateFile              string                `json:"state_file"`
+	Workers                int                   `json:"workers"`
+	RingEntries            int                   `json:"ring_entries"`
+	HelperMode             string                `json:"helper_mode"`
+	IOUringPlanned         bool                  `json:"io_uring_planned"`
+	IOUringActive          bool                  `json:"io_uring_active,omitempty"`
+	IOUringMode            string                `json:"io_uring_mode,omitempty"`
+	IOUringLastError       string                `json:"io_uring_last_error,omitempty"`
+	Enabled                bool                  `json:"enabled"`
+	ForwardingArmed        bool                  `json:"forwarding_armed,omitempty"`
+	Capabilities           UserspaceCapabilities `json:"capabilities"`
+	LastSnapshotGeneration uint64                `json:"last_snapshot_generation"`
+	LastFIBGeneration      uint32                `json:"last_fib_generation,omitempty"`
+	LastSnapshotAt         time.Time             `json:"last_snapshot_at,omitempty"`
+	InterfaceAddresses     int                   `json:"interface_addresses,omitempty"`
+	NeighborEntries        int                   `json:"neighbor_entries,omitempty"`
+	NeighborGeneration     uint64                `json:"neighbor_generation,omitempty"`
+	RouteEntries           int                   `json:"route_entries,omitempty"`
+	WorkerHeartbeats       []time.Time           `json:"worker_heartbeats,omitempty"`
 	// #869: per-worker busy/idle runtime telemetry.
-	WorkerRuntime          []WorkerRuntimeStatus             `json:"worker_runtime,omitempty"`
-	HAGroups               []HAGroupStatus                   `json:"ha_groups,omitempty"`
-	Fabrics                []FabricSnapshot                  `json:"fabrics,omitempty"`
-	Queues                 []QueueStatus                     `json:"queues,omitempty"`
-	Bindings               []BindingStatus                   `json:"bindings,omitempty"`
+	WorkerRuntime []WorkerRuntimeStatus `json:"worker_runtime,omitempty"`
+	HAGroups      []HAGroupStatus       `json:"ha_groups,omitempty"`
+	Fabrics       []FabricSnapshot      `json:"fabrics,omitempty"`
+	Queues        []QueueStatus         `json:"queues,omitempty"`
+	Bindings      []BindingStatus       `json:"bindings,omitempty"`
 	// #802: focused per-binding ring-pressure view. Projected from
 	// Bindings by the Rust helper; parallel rather than replacement.
-	PerBinding             []BindingCountersSnapshot         `json:"per_binding,omitempty"`
+	PerBinding []BindingCountersSnapshot `json:"per_binding,omitempty"`
 	// #1249: bounded low-frequency diagnostic map from active flow-cache
 	// entries to the worker/RX queue that currently owns them. This is
 	// status/debug data only, not a production metric or scheduler input.
-	FlowWorkerMap          []FlowWorkerStatus                `json:"flow_worker_map,omitempty"`
-	FlowWorkerMapTruncated bool                              `json:"flow_worker_map_truncated,omitempty"`
+	FlowWorkerMap          []FlowWorkerStatus `json:"flow_worker_map,omitempty"`
+	FlowWorkerMapTruncated bool               `json:"flow_worker_map_truncated,omitempty"`
 	// #1248: per-CoS-queue active flow distribution by egress ifindex,
 	// queue, and worker. This is the class-specific {a_i} source for
 	// mixed-workload fairness diagnostics.
-	CoSActiveFlowCounts          []CoSActiveFlowCountStatus `json:"cos_active_flow_counts,omitempty"`
-	CoSActiveFlowCountsTruncated bool                       `json:"cos_active_flow_counts_truncated,omitempty"`
-	RecentSessionDeltas    []SessionDeltaInfo                `json:"recent_session_deltas,omitempty"`
-	RecentExceptions       []ExceptionStatus                 `json:"recent_exceptions,omitempty"`
-	CoSInterfaces          []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
-	FilterTermCounters     []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
-	LastResolution         *PacketResolution                 `json:"last_resolution,omitempty"`
-	SlowPath               SlowPathStatus                    `json:"slow_path,omitempty"`
-	LastCacheFlushAt       uint64                            `json:"last_cache_flush_at,omitempty"` // monotonic secs (#312)
-	DataplaneMode          string                            `json:"dataplane_mode,omitempty"`      // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
-	ConfiguredMode         string                            `json:"configured_mode,omitempty"`     // Desired mode from config
-	EntryPrograms          map[int]string                    `json:"entry_programs,omitempty"`      // ifindex -> attached XDP program name
-	FallbackCounters       map[string]uint64                 `json:"fallback_counters,omitempty"`   // reason_name -> count
+	CoSActiveFlowCounts          []CoSActiveFlowCountStatus        `json:"cos_active_flow_counts,omitempty"`
+	CoSActiveFlowCountsTruncated bool                              `json:"cos_active_flow_counts_truncated,omitempty"`
+	RecentSessionDeltas          []SessionDeltaInfo                `json:"recent_session_deltas,omitempty"`
+	RecentExceptions             []ExceptionStatus                 `json:"recent_exceptions,omitempty"`
+	CoSInterfaces                []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
+	FilterTermCounters           []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
+	LastResolution               *PacketResolution                 `json:"last_resolution,omitempty"`
+	SlowPath                     SlowPathStatus                    `json:"slow_path,omitempty"`
+	LastCacheFlushAt             uint64                            `json:"last_cache_flush_at,omitempty"` // monotonic secs (#312)
+	DataplaneMode                string                            `json:"dataplane_mode,omitempty"`      // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
+	ConfiguredMode               string                            `json:"configured_mode,omitempty"`     // Desired mode from config
+	EntryPrograms                map[int]string                    `json:"entry_programs,omitempty"`      // ifindex -> attached XDP program name
+	FallbackCounters             map[string]uint64                 `json:"fallback_counters,omitempty"`   // reason_name -> count
 }
 
 type CoSInterfaceStatus struct {
@@ -504,24 +504,24 @@ type CoSQueueStatus struct {
 	// >= 2^24 ns (~16 ms).
 	ActiveFlowBucketsPeak uint64   `json:"active_flow_buckets_peak,omitempty"`
 	FlowFair              bool     `json:"flow_fair,omitempty"`
-	DrainLatencyHist     []uint64 `json:"drain_latency_hist,omitempty"`
-	DrainInvocations     uint64   `json:"drain_invocations,omitempty"`
-	DrainNoopInvocations uint64   `json:"drain_noop_invocations,omitempty"`
-	RedirectAcquireHist  []uint64 `json:"redirect_acquire_hist,omitempty"`
-	OwnerPPS             uint64   `json:"owner_pps,omitempty"`
-	PeerPPS              uint64   `json:"peer_pps,omitempty"`
+	DrainLatencyHist      []uint64 `json:"drain_latency_hist,omitempty"`
+	DrainInvocations      uint64   `json:"drain_invocations,omitempty"`
+	DrainNoopInvocations  uint64   `json:"drain_noop_invocations,omitempty"`
+	RedirectAcquireHist   []uint64 `json:"redirect_acquire_hist,omitempty"`
+	OwnerPPS              uint64   `json:"owner_pps,omitempty"`
+	PeerPPS               uint64   `json:"peer_pps,omitempty"`
 	// #760 overshoot-hunt instrumentation. DrainSentBytes /
 	// DrainParkRootTokens / DrainParkQueueTokens are queue-scoped.
 	// PostDrainBackupBytes is binding-scoped (same row as
 	// OwnerPPS/PeerPPS). See Rust `CoSQueueStatus` for field
 	// semantics and write-site locations.
-	DrainSentBytes        uint64 `json:"drain_sent_bytes,omitempty"`
-	DrainParkRootTokens   uint64 `json:"drain_park_root_tokens,omitempty"`
-	DrainParkQueueTokens  uint64 `json:"drain_park_queue_tokens,omitempty"`
-	PostDrainBackupBytes                uint64 `json:"post_drain_backup_bytes,omitempty"`
-	DrainSentBytesShapedUnconditional   uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
-	PostDrainBackupCosDrops             uint64 `json:"post_drain_backup_cos_drops,omitempty"`
-	PostDrainBackupCosDropBytes         uint64 `json:"post_drain_backup_cos_drop_bytes,omitempty"`
+	DrainSentBytes                    uint64 `json:"drain_sent_bytes,omitempty"`
+	DrainParkRootTokens               uint64 `json:"drain_park_root_tokens,omitempty"`
+	DrainParkQueueTokens              uint64 `json:"drain_park_queue_tokens,omitempty"`
+	PostDrainBackupBytes              uint64 `json:"post_drain_backup_bytes,omitempty"`
+	DrainSentBytesShapedUnconditional uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
+	PostDrainBackupCosDrops           uint64 `json:"post_drain_backup_cos_drops,omitempty"`
+	PostDrainBackupCosDropBytes       uint64 `json:"post_drain_backup_cos_drop_bytes,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {
@@ -663,113 +663,113 @@ type QueueStatus struct {
 }
 
 type BindingStatus struct {
-	Slot                              uint32    `json:"slot"`
-	QueueID                           uint32    `json:"queue_id"`
-	WorkerID                          uint32    `json:"worker_id"`
-	Interface                         string    `json:"interface,omitempty"`
-	Ifindex                           int       `json:"ifindex,omitempty"`
-	Registered                        bool      `json:"registered"`
-	Armed                             bool      `json:"armed"`
-	Ready                             bool      `json:"ready"`
-	Bound                             bool      `json:"bound"`
-	XSKRegistered                     bool      `json:"xsk_registered"`
-	XSKBindMode                       string    `json:"xsk_bind_mode,omitempty"`
-	ZeroCopy                          bool      `json:"zero_copy,omitempty"`
-	SocketFD                          int       `json:"socket_fd,omitempty"`
-	SharedUMEMMode                    string    `json:"shared_umem_mode,omitempty"`
-	SharedUMEMGroup                   string    `json:"shared_umem_group,omitempty"`
-	SharedUMEMSocketRole              string    `json:"shared_umem_socket_role,omitempty"`
-	SharedUMEMDisabledReason          string    `json:"shared_umem_disabled_reason,omitempty"`
-	RXPackets                         uint64    `json:"rx_packets,omitempty"`
-	RXBytes                           uint64    `json:"rx_bytes,omitempty"`
-	RXBatches                         uint64    `json:"rx_batches,omitempty"`
-	RXWakeups                         uint64    `json:"rx_wakeups,omitempty"`
-	MetadataPackets                   uint64    `json:"metadata_packets,omitempty"`
-	MetadataErrors                    uint64    `json:"metadata_errors,omitempty"`
-	ValidatedPackets                  uint64    `json:"validated_packets,omitempty"`
-	ValidatedBytes                    uint64    `json:"validated_bytes,omitempty"`
-	LocalDeliveryPackets              uint64    `json:"local_delivery_packets,omitempty"`
-	ForwardCandidatePkts              uint64    `json:"forward_candidate_packets,omitempty"`
-	RouteMissPackets                  uint64    `json:"route_miss_packets,omitempty"`
-	NeighborMissPackets               uint64    `json:"neighbor_miss_packets,omitempty"`
-	DiscardRoutePackets               uint64    `json:"discard_route_packets,omitempty"`
-	NextTablePackets                  uint64    `json:"next_table_packets,omitempty"`
-	ExceptionPackets                  uint64    `json:"exception_packets,omitempty"`
-	ConfigGenMismatches               uint64    `json:"config_gen_mismatches,omitempty"`
-	FIBGenMismatches                  uint64    `json:"fib_gen_mismatches,omitempty"`
-	UnsupportedPackets                uint64    `json:"unsupported_packets,omitempty"`
-	FlowCacheHits                     uint64    `json:"flow_cache_hits,omitempty"`
-	FlowCacheMisses                   uint64    `json:"flow_cache_misses,omitempty"`
-	FlowCacheEvictions                uint64    `json:"flow_cache_evictions,omitempty"`
+	Slot                     uint32 `json:"slot"`
+	QueueID                  uint32 `json:"queue_id"`
+	WorkerID                 uint32 `json:"worker_id"`
+	Interface                string `json:"interface,omitempty"`
+	Ifindex                  int    `json:"ifindex,omitempty"`
+	Registered               bool   `json:"registered"`
+	Armed                    bool   `json:"armed"`
+	Ready                    bool   `json:"ready"`
+	Bound                    bool   `json:"bound"`
+	XSKRegistered            bool   `json:"xsk_registered"`
+	XSKBindMode              string `json:"xsk_bind_mode,omitempty"`
+	ZeroCopy                 bool   `json:"zero_copy,omitempty"`
+	SocketFD                 int    `json:"socket_fd,omitempty"`
+	SharedUMEMMode           string `json:"shared_umem_mode,omitempty"`
+	SharedUMEMGroup          string `json:"shared_umem_group,omitempty"`
+	SharedUMEMSocketRole     string `json:"shared_umem_socket_role,omitempty"`
+	SharedUMEMDisabledReason string `json:"shared_umem_disabled_reason,omitempty"`
+	RXPackets                uint64 `json:"rx_packets,omitempty"`
+	RXBytes                  uint64 `json:"rx_bytes,omitempty"`
+	RXBatches                uint64 `json:"rx_batches,omitempty"`
+	RXWakeups                uint64 `json:"rx_wakeups,omitempty"`
+	MetadataPackets          uint64 `json:"metadata_packets,omitempty"`
+	MetadataErrors           uint64 `json:"metadata_errors,omitempty"`
+	ValidatedPackets         uint64 `json:"validated_packets,omitempty"`
+	ValidatedBytes           uint64 `json:"validated_bytes,omitempty"`
+	LocalDeliveryPackets     uint64 `json:"local_delivery_packets,omitempty"`
+	ForwardCandidatePkts     uint64 `json:"forward_candidate_packets,omitempty"`
+	RouteMissPackets         uint64 `json:"route_miss_packets,omitempty"`
+	NeighborMissPackets      uint64 `json:"neighbor_miss_packets,omitempty"`
+	DiscardRoutePackets      uint64 `json:"discard_route_packets,omitempty"`
+	NextTablePackets         uint64 `json:"next_table_packets,omitempty"`
+	ExceptionPackets         uint64 `json:"exception_packets,omitempty"`
+	ConfigGenMismatches      uint64 `json:"config_gen_mismatches,omitempty"`
+	FIBGenMismatches         uint64 `json:"fib_gen_mismatches,omitempty"`
+	UnsupportedPackets       uint64 `json:"unsupported_packets,omitempty"`
+	FlowCacheHits            uint64 `json:"flow_cache_hits,omitempty"`
+	FlowCacheMisses          uint64 `json:"flow_cache_misses,omitempty"`
+	FlowCacheEvictions       uint64 `json:"flow_cache_evictions,omitempty"`
 	// #918: collision-driven subset of flow_cache_evictions (full-set
 	// LRU displacement vs stale-on-lookup eviction). Acceptance gate
 	// watches collision_evictions / hits under load.
-	FlowCacheCollisionEvictions       uint64    `json:"flow_cache_collision_evictions,omitempty"`
+	FlowCacheCollisionEvictions uint64 `json:"flow_cache_collision_evictions,omitempty"`
 	// #1219: snapshot count of distinct active flows on this binding's
 	// flow_cache, refreshed at the helper's ~65ms debug-state tick. The
 	// fairness harness reads this via the xpf_userspace_binding_active_flow_count
 	// Prometheus metric to compute {a_i} for the structural CoV gate
 	// per docs/fairness-regimes.md.
-	ActiveFlowCount                   uint32    `json:"active_flow_count,omitempty"`
+	ActiveFlowCount uint32 `json:"active_flow_count,omitempty"`
 	// #941 Work item D / #943: V_min throttle counters. Hard-cap is
 	// the escape-hatch firing when fairness brake (regular throttle)
 	// has thrown V_MIN_CONSECUTIVE_SKIP_HARD_CAP back-to-back times.
 	// Together: VMinThrottles = "fairness brake fired",
 	// VMinThrottleHardCapOverrides = "brake too tight, escape hatch
 	// rescued throughput". Ratio is the LAG_THRESHOLD diagnostic.
-	VMinThrottleHardCapOverrides      uint64    `json:"v_min_throttle_hard_cap_overrides,omitempty"`
-	VMinThrottles                     uint64    `json:"v_min_throttles,omitempty"`
-	SessionHits                       uint64    `json:"session_hits,omitempty"`
-	SessionMisses                     uint64    `json:"session_misses,omitempty"`
-	SessionCreates                    uint64    `json:"session_creates,omitempty"`
-	SessionExpires                    uint64    `json:"session_expires,omitempty"`
-	SessionDeltaPending               uint64    `json:"session_delta_pending,omitempty"`
-	SessionDeltaGenerated             uint64    `json:"session_delta_generated,omitempty"`
-	SessionDeltaDropped               uint64    `json:"session_delta_dropped,omitempty"`
-	SessionDeltaDrained               uint64    `json:"session_delta_drained,omitempty"`
-	PolicyDeniedPackets               uint64    `json:"policy_denied_packets,omitempty"`
-	ScreenDrops                       uint64    `json:"screen_drops,omitempty"`
-	SNATPackets                       uint64    `json:"snat_packets,omitempty"`
-	DNATPackets                       uint64    `json:"dnat_packets,omitempty"`
-	SlowPathPackets                   uint64    `json:"slow_path_packets,omitempty"`
-	SlowPathBytes                     uint64    `json:"slow_path_bytes,omitempty"`
-	SlowPathLocalDeliveryPackets      uint64    `json:"slow_path_local_delivery_packets,omitempty"`
-	SlowPathMissingNeighborPackets    uint64    `json:"slow_path_missing_neighbor_packets,omitempty"`
-	SlowPathNoRoutePackets            uint64    `json:"slow_path_no_route_packets,omitempty"`
-	SlowPathNextTablePackets          uint64    `json:"slow_path_next_table_packets,omitempty"`
-	SlowPathForwardBuildPackets       uint64    `json:"slow_path_forward_build_packets,omitempty"`
-	SlowPathDrops                     uint64    `json:"slow_path_drops,omitempty"`
-	SlowPathRateLimited               uint64    `json:"slow_path_rate_limited,omitempty"`
-	KernelRXDropped                   uint64    `json:"kernel_rx_dropped,omitempty"`
-	KernelRXInvalidDescs              uint64    `json:"kernel_rx_invalid_descs,omitempty"`
-	TXPackets                         uint64    `json:"tx_packets,omitempty"`
-	TXBytes                           uint64    `json:"tx_bytes,omitempty"`
-	TXErrors                          uint64    `json:"tx_errors,omitempty"`
-	TXSharedRecycleUnknownSlotDrops   uint64    `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
-	TXCompletions                     uint64    `json:"tx_completions,omitempty"`
-	DirectTXPackets                   uint64    `json:"direct_tx_packets,omitempty"`
-	CopyTXPackets                     uint64    `json:"copy_tx_packets,omitempty"`
-	InPlaceTXPackets                  uint64    `json:"in_place_tx_packets,omitempty"`
-	InPlaceVLANPushDescPackets        uint64    `json:"in_place_vlan_push_desc_packets,omitempty"`
-	InPlaceVLANPopDescPackets         uint64    `json:"in_place_vlan_pop_desc_packets,omitempty"`
-	InPlaceVLANPushNoHeadroomPackets  uint64    `json:"in_place_vlan_push_no_headroom_packets,omitempty"`
-	InPlaceL2MemmoveFallbackPackets   uint64    `json:"in_place_l2_memmove_fallback_packets,omitempty"`
-	DirectTXNoFrameFallbackPackets    uint64    `json:"direct_tx_no_frame_fallback_packets,omitempty"`
-	DirectTXBuildFallbackPackets      uint64    `json:"direct_tx_build_fallback_packets,omitempty"`
-	DirectTXDisallowedFallbackPackets uint64    `json:"direct_tx_disallowed_fallback_packets,omitempty"`
-	DebugPendingFillFrames            uint32    `json:"debug_pending_fill_frames,omitempty"`
-	DebugSpareFillFrames              uint32    `json:"debug_spare_fill_frames,omitempty"`
-	DebugFreeTXFrames                 uint32    `json:"debug_free_tx_frames,omitempty"`
-	DebugPendingTXPrepared            uint32    `json:"debug_pending_tx_prepared,omitempty"`
-	DebugPendingTXLocal               uint32    `json:"debug_pending_tx_local,omitempty"`
-	DebugOutstandingTX                uint32    `json:"debug_outstanding_tx,omitempty"`
+	VMinThrottleHardCapOverrides      uint64 `json:"v_min_throttle_hard_cap_overrides,omitempty"`
+	VMinThrottles                     uint64 `json:"v_min_throttles,omitempty"`
+	SessionHits                       uint64 `json:"session_hits,omitempty"`
+	SessionMisses                     uint64 `json:"session_misses,omitempty"`
+	SessionCreates                    uint64 `json:"session_creates,omitempty"`
+	SessionExpires                    uint64 `json:"session_expires,omitempty"`
+	SessionDeltaPending               uint64 `json:"session_delta_pending,omitempty"`
+	SessionDeltaGenerated             uint64 `json:"session_delta_generated,omitempty"`
+	SessionDeltaDropped               uint64 `json:"session_delta_dropped,omitempty"`
+	SessionDeltaDrained               uint64 `json:"session_delta_drained,omitempty"`
+	PolicyDeniedPackets               uint64 `json:"policy_denied_packets,omitempty"`
+	ScreenDrops                       uint64 `json:"screen_drops,omitempty"`
+	SNATPackets                       uint64 `json:"snat_packets,omitempty"`
+	DNATPackets                       uint64 `json:"dnat_packets,omitempty"`
+	SlowPathPackets                   uint64 `json:"slow_path_packets,omitempty"`
+	SlowPathBytes                     uint64 `json:"slow_path_bytes,omitempty"`
+	SlowPathLocalDeliveryPackets      uint64 `json:"slow_path_local_delivery_packets,omitempty"`
+	SlowPathMissingNeighborPackets    uint64 `json:"slow_path_missing_neighbor_packets,omitempty"`
+	SlowPathNoRoutePackets            uint64 `json:"slow_path_no_route_packets,omitempty"`
+	SlowPathNextTablePackets          uint64 `json:"slow_path_next_table_packets,omitempty"`
+	SlowPathForwardBuildPackets       uint64 `json:"slow_path_forward_build_packets,omitempty"`
+	SlowPathDrops                     uint64 `json:"slow_path_drops,omitempty"`
+	SlowPathRateLimited               uint64 `json:"slow_path_rate_limited,omitempty"`
+	KernelRXDropped                   uint64 `json:"kernel_rx_dropped,omitempty"`
+	KernelRXInvalidDescs              uint64 `json:"kernel_rx_invalid_descs,omitempty"`
+	TXPackets                         uint64 `json:"tx_packets,omitempty"`
+	TXBytes                           uint64 `json:"tx_bytes,omitempty"`
+	TXErrors                          uint64 `json:"tx_errors,omitempty"`
+	TXSharedRecycleUnknownSlotDrops   uint64 `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
+	TXCompletions                     uint64 `json:"tx_completions,omitempty"`
+	DirectTXPackets                   uint64 `json:"direct_tx_packets,omitempty"`
+	CopyTXPackets                     uint64 `json:"copy_tx_packets,omitempty"`
+	InPlaceTXPackets                  uint64 `json:"in_place_tx_packets,omitempty"`
+	InPlaceVLANPushDescPackets        uint64 `json:"in_place_vlan_push_desc_packets,omitempty"`
+	InPlaceVLANPopDescPackets         uint64 `json:"in_place_vlan_pop_desc_packets,omitempty"`
+	InPlaceVLANPushNoHeadroomPackets  uint64 `json:"in_place_vlan_push_no_headroom_packets,omitempty"`
+	InPlaceL2MemmoveFallbackPackets   uint64 `json:"in_place_l2_memmove_fallback_packets,omitempty"`
+	DirectTXNoFrameFallbackPackets    uint64 `json:"direct_tx_no_frame_fallback_packets,omitempty"`
+	DirectTXBuildFallbackPackets      uint64 `json:"direct_tx_build_fallback_packets,omitempty"`
+	DirectTXDisallowedFallbackPackets uint64 `json:"direct_tx_disallowed_fallback_packets,omitempty"`
+	DebugPendingFillFrames            uint32 `json:"debug_pending_fill_frames,omitempty"`
+	DebugSpareFillFrames              uint32 `json:"debug_spare_fill_frames,omitempty"`
+	DebugFreeTXFrames                 uint32 `json:"debug_free_tx_frames,omitempty"`
+	DebugPendingTXPrepared            uint32 `json:"debug_pending_tx_prepared,omitempty"`
+	DebugPendingTXLocal               uint32 `json:"debug_pending_tx_local,omitempty"`
+	DebugOutstandingTX                uint32 `json:"debug_outstanding_tx,omitempty"`
 	// #1241: low-frequency AF_XDP TX completion-ring availability
 	// samples, published from owner-local worker telemetry. Current is
 	// the last sampled CQ depth before a reap; Max is the peak in the
 	// last debug window.
-	TXCompletionRingAvailable         uint32    `json:"tx_completion_ring_available,omitempty"`
-	TXCompletionRingAvailableMax      uint32    `json:"tx_completion_ring_available_max,omitempty"`
-	DebugInFlightRecycles             uint32    `json:"debug_in_flight_recycles,omitempty"`
+	TXCompletionRingAvailable    uint32 `json:"tx_completion_ring_available,omitempty"`
+	TXCompletionRingAvailableMax uint32 `json:"tx_completion_ring_available_max,omitempty"`
+	DebugInFlightRecycles        uint32 `json:"debug_in_flight_recycles,omitempty"`
 	// #802/#804: ring-pressure instrumentation mirror fields. See the
 	// Rust `BindingStatus` for semantics and write sites. The #804
 	// split replaces the pre-#804 `dbg_pending_overflow` field with
@@ -779,12 +779,12 @@ type BindingStatus struct {
 	// overflow in `enqueue_cos_item`. A snapshot from a pre-#804
 	// helper deserializes both as 0 (standard Go json zero-value),
 	// which is the right backward-compat behavior.
-	DbgTxRingFull                     uint64    `json:"dbg_tx_ring_full,omitempty"`
-	DbgSendtoENOBUFS                  uint64    `json:"dbg_sendto_enobufs,omitempty"`
-	DbgBoundPendingOverflow           uint64    `json:"dbg_bound_pending_overflow,omitempty"`
-	DbgCoSQueueOverflow               uint64    `json:"dbg_cos_queue_overflow,omitempty"`
-	RxFillRingEmptyDescs              uint64    `json:"rx_fill_ring_empty_descs,omitempty"`
-	OutstandingTX                     uint32    `json:"outstanding_tx,omitempty"`
+	DbgTxRingFull           uint64 `json:"dbg_tx_ring_full,omitempty"`
+	DbgSendtoENOBUFS        uint64 `json:"dbg_sendto_enobufs,omitempty"`
+	DbgBoundPendingOverflow uint64 `json:"dbg_bound_pending_overflow,omitempty"`
+	DbgCoSQueueOverflow     uint64 `json:"dbg_cos_queue_overflow,omitempty"`
+	RxFillRingEmptyDescs    uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
+	OutstandingTX           uint32 `json:"outstanding_tx,omitempty"`
 	// #878: per-binding UMEM total frames and TX-ring depth (set
 	// once at worker construction) plus in-flight gauge (republished
 	// each ~1s by the worker as a single atomic store from local
@@ -794,9 +794,9 @@ type BindingStatus struct {
 	// aggregated as max across bindings. Zero on UmemTotalFrames
 	// means "not yet published" — fwdstatus falls back to the legacy
 	// "unknown" display.
-	UmemTotalFrames                   uint32    `json:"umem_total_frames,omitempty"`
-	TxRingCapacity                    uint32    `json:"tx_ring_capacity,omitempty"`
-	UmemInflightFrames                uint32    `json:"umem_inflight_frames,omitempty"`
+	UmemTotalFrames    uint32 `json:"umem_total_frames,omitempty"`
+	TxRingCapacity     uint32 `json:"tx_ring_capacity,omitempty"`
+	UmemInflightFrames uint32 `json:"umem_inflight_frames,omitempty"`
 	// #812: per-queue TX submit→completion latency telemetry. 16 log2-
 	// spaced buckets (see Rust `DRAIN_HIST_BUCKETS` wire contract), plus
 	// a total completion count and running sum-ns. Emitted on the rich
@@ -805,9 +805,9 @@ type BindingStatus struct {
 	// distributions without a second join. omitempty keeps forward-
 	// compat — a pre-#812 helper that lacks these fields decodes into
 	// empty slice / zero u64.
-	TxSubmitLatencyHist               []uint64  `json:"tx_submit_latency_hist,omitempty"`
-	TxSubmitLatencyCount              uint64    `json:"tx_submit_latency_count,omitempty"`
-	TxSubmitLatencySumNs              uint64    `json:"tx_submit_latency_sum_ns,omitempty"`
+	TxSubmitLatencyHist  []uint64 `json:"tx_submit_latency_hist,omitempty"`
+	TxSubmitLatencyCount uint64   `json:"tx_submit_latency_count,omitempty"`
+	TxSubmitLatencySumNs uint64   `json:"tx_submit_latency_sum_ns,omitempty"`
 	// #825: per-kick `sendto` latency telemetry. 16 log2 buckets
 	// (wire-compatible with `tx_submit_latency_hist` /
 	// `drain_latency_hist`), plus count, sum-ns, and the
@@ -815,13 +815,13 @@ type BindingStatus struct {
 	// #819 §4.1). omitempty keeps forward-compat — a pre-#825
 	// helper that lacks these fields decodes into empty slice /
 	// zero uint64.
-	TxKickLatencyHist                 []uint64  `json:"tx_kick_latency_hist,omitempty"`
-	TxKickLatencyCount                uint64    `json:"tx_kick_latency_count,omitempty"`
-	TxKickLatencySumNs                uint64    `json:"tx_kick_latency_sum_ns,omitempty"`
-	TxKickRetryCount                  uint64    `json:"tx_kick_retry_count,omitempty"`
-	LastHeartbeat                     time.Time `json:"last_heartbeat,omitempty"`
-	LastError                         string    `json:"last_error,omitempty"`
-	LastChange                        time.Time `json:"last_change,omitempty"`
+	TxKickLatencyHist  []uint64  `json:"tx_kick_latency_hist,omitempty"`
+	TxKickLatencyCount uint64    `json:"tx_kick_latency_count,omitempty"`
+	TxKickLatencySumNs uint64    `json:"tx_kick_latency_sum_ns,omitempty"`
+	TxKickRetryCount   uint64    `json:"tx_kick_retry_count,omitempty"`
+	LastHeartbeat      time.Time `json:"last_heartbeat,omitempty"`
+	LastError          string    `json:"last_error,omitempty"`
+	LastChange         time.Time `json:"last_change,omitempty"`
 }
 
 // BindingCountersSnapshot is the focused per-binding ring-pressure view
@@ -832,9 +832,9 @@ type BindingStatus struct {
 //
 // #802.
 type BindingCountersSnapshot struct {
-	WorkerID uint32 `json:"worker_id"`
-	Ifindex  int    `json:"ifindex,omitempty"`
-	QueueID  uint32 `json:"queue_id"`
+	WorkerID         uint32 `json:"worker_id"`
+	Ifindex          int    `json:"ifindex,omitempty"`
+	QueueID          uint32 `json:"queue_id"`
 	DbgTxRingFull    uint64 `json:"dbg_tx_ring_full,omitempty"`
 	DbgSendtoENOBUFS uint64 `json:"dbg_sendto_enobufs,omitempty"`
 	// #804: split from the pre-#804 `dbg_pending_overflow` field. Two
@@ -845,10 +845,10 @@ type BindingCountersSnapshot struct {
 	// zero-value — there is no silent re-attribution of the legacy
 	// counter. Consumers that want a total across either path should
 	// sum these two explicitly.
-	DbgBoundPendingOverflow     uint64 `json:"dbg_bound_pending_overflow,omitempty"`
-	DbgCoSQueueOverflow         uint64 `json:"dbg_cos_queue_overflow,omitempty"`
-	RxFillRingEmptyDescs        uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
-	OutstandingTX               uint32 `json:"outstanding_tx,omitempty"`
+	DbgBoundPendingOverflow uint64 `json:"dbg_bound_pending_overflow,omitempty"`
+	DbgCoSQueueOverflow     uint64 `json:"dbg_cos_queue_overflow,omitempty"`
+	RxFillRingEmptyDescs    uint64 `json:"rx_fill_ring_empty_descs,omitempty"`
+	OutstandingTX           uint32 `json:"outstanding_tx,omitempty"`
 	// #1241: low-frequency AF_XDP TX completion-ring availability
 	// gauges mirrored from BindingStatus for fast-poll consumers.
 	TXCompletionRingAvailable    uint32 `json:"tx_completion_ring_available,omitempty"`
@@ -857,13 +857,13 @@ type BindingCountersSnapshot struct {
 	// snapshot so the daemon's fast poller can compute Buffer%
 	// without joining the full BindingStatus. See BindingStatus
 	// for full semantics.
-	UmemTotalFrames             uint32 `json:"umem_total_frames,omitempty"`
-	TxRingCapacity              uint32 `json:"tx_ring_capacity,omitempty"`
-	UmemInflightFrames          uint32 `json:"umem_inflight_frames,omitempty"`
-	TXErrors                    uint64 `json:"tx_errors,omitempty"`
+	UmemTotalFrames                 uint32 `json:"umem_total_frames,omitempty"`
+	TxRingCapacity                  uint32 `json:"tx_ring_capacity,omitempty"`
+	UmemInflightFrames              uint32 `json:"umem_inflight_frames,omitempty"`
+	TXErrors                        uint64 `json:"tx_errors,omitempty"`
 	TXSharedRecycleUnknownSlotDrops uint64 `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
-	TxSubmitErrorDrops          uint64 `json:"tx_submit_error_drops,omitempty"`
-	PendingTxLocalOverflowDrops uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
+	TxSubmitErrorDrops              uint64 `json:"tx_submit_error_drops,omitempty"`
+	PendingTxLocalOverflowDrops     uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
 	// #812: per-queue TX submit→completion latency histogram, pulled
 	// through from BindingStatus so step1-capture consumers can
 	// compute per-queue latency distributions without a second
@@ -872,17 +872,17 @@ type BindingCountersSnapshot struct {
 	// preserves forward-compat — a pre-#812 helper that lacks these
 	// fields decodes into empty slice / zero u64 without the daemon
 	// erroring.
-	TxSubmitLatencyHist    []uint64 `json:"tx_submit_latency_hist,omitempty"`
-	TxSubmitLatencyCount   uint64   `json:"tx_submit_latency_count,omitempty"`
-	TxSubmitLatencySumNs   uint64   `json:"tx_submit_latency_sum_ns,omitempty"`
+	TxSubmitLatencyHist  []uint64 `json:"tx_submit_latency_hist,omitempty"`
+	TxSubmitLatencyCount uint64   `json:"tx_submit_latency_count,omitempty"`
+	TxSubmitLatencySumNs uint64   `json:"tx_submit_latency_sum_ns,omitempty"`
 	// #825: per-kick `sendto` latency telemetry, pulled through
 	// from BindingStatus so step1-capture / P3 consumers can
 	// compute per-queue kick-latency distributions without a
 	// second query. omitempty on all four preserves forward-compat.
-	TxKickLatencyHist    []uint64 `json:"tx_kick_latency_hist,omitempty"`
-	TxKickLatencyCount   uint64   `json:"tx_kick_latency_count,omitempty"`
-	TxKickLatencySumNs   uint64   `json:"tx_kick_latency_sum_ns,omitempty"`
-	TxKickRetryCount     uint64   `json:"tx_kick_retry_count,omitempty"`
+	TxKickLatencyHist  []uint64 `json:"tx_kick_latency_hist,omitempty"`
+	TxKickLatencyCount uint64   `json:"tx_kick_latency_count,omitempty"`
+	TxKickLatencySumNs uint64   `json:"tx_kick_latency_sum_ns,omitempty"`
+	TxKickRetryCount   uint64   `json:"tx_kick_retry_count,omitempty"`
 	// #918: per-set LRU collision-eviction counter, brought through
 	// to the lean snapshot for fast-poll consumers that need the
 	// flow-cache thrash signal. Default keeps pre-#918 helpers parseable.
@@ -943,15 +943,15 @@ type SessionExportRequest struct {
 }
 
 type SessionSyncRequest struct {
-	Operation        string `json:"operation,omitempty"`
-	AddrFamily       uint8  `json:"addr_family,omitempty"`
-	Protocol         uint8  `json:"protocol,omitempty"`
-	SrcIP            string `json:"src_ip,omitempty"`
-	DstIP            string `json:"dst_ip,omitempty"`
-	SrcPort          uint16 `json:"src_port,omitempty"`
-	DstPort          uint16 `json:"dst_port,omitempty"`
-	IngressZone      string `json:"ingress_zone,omitempty"`
-	EgressZone       string `json:"egress_zone,omitempty"`
+	Operation   string `json:"operation,omitempty"`
+	AddrFamily  uint8  `json:"addr_family,omitempty"`
+	Protocol    uint8  `json:"protocol,omitempty"`
+	SrcIP       string `json:"src_ip,omitempty"`
+	DstIP       string `json:"dst_ip,omitempty"`
+	SrcPort     uint16 `json:"src_port,omitempty"`
+	DstPort     uint16 `json:"dst_port,omitempty"`
+	IngressZone string `json:"ingress_zone,omitempty"`
+	EgressZone  string `json:"egress_zone,omitempty"`
 	// #919/#922: u16 zone-id mirrors. Additive — the Rust daemon
 	// prefers the IDs when nonzero and falls back to the legacy
 	// name strings otherwise. Old peers without these fields
@@ -975,43 +975,43 @@ type SessionSyncRequest struct {
 }
 
 type SessionDeltaInfo struct {
-	Timestamp        time.Time `json:"timestamp"`
-	Slot             uint32    `json:"slot"`
-	QueueID          uint32    `json:"queue_id"`
-	WorkerID         uint32    `json:"worker_id"`
-	Interface        string    `json:"interface,omitempty"`
-	Ifindex          int       `json:"ifindex,omitempty"`
-	Event            string    `json:"event"`
-	AddrFamily       uint8     `json:"addr_family,omitempty"`
-	Protocol         uint8     `json:"protocol,omitempty"`
-	SrcIP            string    `json:"src_ip,omitempty"`
-	DstIP            string    `json:"dst_ip,omitempty"`
-	SrcPort          uint16    `json:"src_port,omitempty"`
-	DstPort          uint16    `json:"dst_port,omitempty"`
-	IngressZone      string    `json:"ingress_zone,omitempty"`
-	EgressZone       string    `json:"egress_zone,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+	Slot        uint32    `json:"slot"`
+	QueueID     uint32    `json:"queue_id"`
+	WorkerID    uint32    `json:"worker_id"`
+	Interface   string    `json:"interface,omitempty"`
+	Ifindex     int       `json:"ifindex,omitempty"`
+	Event       string    `json:"event"`
+	AddrFamily  uint8     `json:"addr_family,omitempty"`
+	Protocol    uint8     `json:"protocol,omitempty"`
+	SrcIP       string    `json:"src_ip,omitempty"`
+	DstIP       string    `json:"dst_ip,omitempty"`
+	SrcPort     uint16    `json:"src_port,omitempty"`
+	DstPort     uint16    `json:"dst_port,omitempty"`
+	IngressZone string    `json:"ingress_zone,omitempty"`
+	EgressZone  string    `json:"egress_zone,omitempty"`
 	// #919/#922: u16 zone-id mirrors decoded directly from the binary
 	// event-stream payload (bytes [21],[22] u8 → u16 here for symmetry
 	// with SessionSyncRequest). The HA delta path prefers these IDs;
 	// the legacy strings stay populated when JSON callers fill them.
-	IngressZoneID    uint16    `json:"ingress_zone_id,omitempty"`
-	EgressZoneID     uint16    `json:"egress_zone_id,omitempty"`
-	OwnerRGID        int       `json:"owner_rg_id,omitempty"`
-	Disposition      string    `json:"disposition,omitempty"`
-	Origin           string    `json:"origin,omitempty"`
-	EgressIfindex    int       `json:"egress_ifindex,omitempty"`
-	TXIfindex        int       `json:"tx_ifindex,omitempty"`
-	TunnelEndpointID uint16    `json:"tunnel_endpoint_id,omitempty"`
-	TXVLANID         uint16    `json:"tx_vlan_id,omitempty"`
-	NextHop          string    `json:"next_hop,omitempty"`
-	NeighborMAC      string    `json:"neighbor_mac,omitempty"`
-	SrcMAC           string    `json:"src_mac,omitempty"`
-	NATSrcIP         string    `json:"nat_src_ip,omitempty"`
-	NATDstIP         string    `json:"nat_dst_ip,omitempty"`
-	NATSrcPort       uint16    `json:"nat_src_port,omitempty"`
-	NATDstPort       uint16    `json:"nat_dst_port,omitempty"`
-	FabricRedirect   bool      `json:"fabric_redirect,omitempty"`
-	FabricIngress    bool      `json:"fabric_ingress,omitempty"`
+	IngressZoneID    uint16 `json:"ingress_zone_id,omitempty"`
+	EgressZoneID     uint16 `json:"egress_zone_id,omitempty"`
+	OwnerRGID        int    `json:"owner_rg_id,omitempty"`
+	Disposition      string `json:"disposition,omitempty"`
+	Origin           string `json:"origin,omitempty"`
+	EgressIfindex    int    `json:"egress_ifindex,omitempty"`
+	TXIfindex        int    `json:"tx_ifindex,omitempty"`
+	TunnelEndpointID uint16 `json:"tunnel_endpoint_id,omitempty"`
+	TXVLANID         uint16 `json:"tx_vlan_id,omitempty"`
+	NextHop          string `json:"next_hop,omitempty"`
+	NeighborMAC      string `json:"neighbor_mac,omitempty"`
+	SrcMAC           string `json:"src_mac,omitempty"`
+	NATSrcIP         string `json:"nat_src_ip,omitempty"`
+	NATDstIP         string `json:"nat_dst_ip,omitempty"`
+	NATSrcPort       uint16 `json:"nat_src_port,omitempty"`
+	NATDstPort       uint16 `json:"nat_dst_port,omitempty"`
+	FabricRedirect   bool   `json:"fabric_redirect,omitempty"`
+	FabricIngress    bool   `json:"fabric_ingress,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -745,6 +745,7 @@ type BindingStatus struct {
 	TXPackets                         uint64    `json:"tx_packets,omitempty"`
 	TXBytes                           uint64    `json:"tx_bytes,omitempty"`
 	TXErrors                          uint64    `json:"tx_errors,omitempty"`
+	TXSharedRecycleUnknownSlotDrops   uint64    `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
 	TXCompletions                     uint64    `json:"tx_completions,omitempty"`
 	DirectTXPackets                   uint64    `json:"direct_tx_packets,omitempty"`
 	CopyTXPackets                     uint64    `json:"copy_tx_packets,omitempty"`
@@ -860,6 +861,7 @@ type BindingCountersSnapshot struct {
 	TxRingCapacity              uint32 `json:"tx_ring_capacity,omitempty"`
 	UmemInflightFrames          uint32 `json:"umem_inflight_frames,omitempty"`
 	TXErrors                    uint64 `json:"tx_errors,omitempty"`
+	TXSharedRecycleUnknownSlotDrops uint64 `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
 	TxSubmitErrorDrops          uint64 `json:"tx_submit_error_drops,omitempty"`
 	PendingTxLocalOverflowDrops uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
 	// #812: per-queue TX submit→completion latency histogram, pulled

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -60,6 +60,35 @@ func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestBindingCountersSnapshotTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
+	in := BindingCountersSnapshot{
+		WorkerID:                        3,
+		Ifindex:                         11,
+		QueueID:                         2,
+		TXErrors:                        9,
+		TXSharedRecycleUnknownSlotDrops: 4,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	if _, ok := obj["tx_shared_recycle_unknown_slot_drops"]; !ok {
+		t.Fatalf("wire key missing from BindingCountersSnapshot JSON: %s", string(raw))
+	}
+
+	var back BindingCountersSnapshot
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingCountersSnapshot: %v", err)
+	}
+	if !reflect.DeepEqual(back, in) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", back, in)
+	}
+}
+
 func TestBindingStatusTxKickLatencyRoundTrip(t *testing.T) {
 	// Encode a Go BindingStatus with non-trivial values on the
 	// four kick-latency fields; decode the JSON back; assert

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -29,6 +29,37 @@ var tx_completion_ring_wire_keys = []string{
 	"tx_completion_ring_available_max",
 }
 
+func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
+	in := BindingStatus{
+		WorkerID:                        3,
+		Slot:                            7,
+		Ifindex:                         11,
+		QueueID:                         2,
+		TXErrors:                        9,
+		TXSharedRecycleUnknownSlotDrops: 4,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	if _, ok := obj["tx_shared_recycle_unknown_slot_drops"]; !ok {
+		t.Fatalf("wire key missing from BindingStatus JSON: %s", string(raw))
+	}
+
+	var back BindingStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingStatus: %v", err)
+	}
+	if back.TXSharedRecycleUnknownSlotDrops != in.TXSharedRecycleUnknownSlotDrops {
+		t.Fatalf("TXSharedRecycleUnknownSlotDrops: got %d, want %d",
+			back.TXSharedRecycleUnknownSlotDrops, in.TXSharedRecycleUnknownSlotDrops)
+	}
+}
+
 func TestBindingStatusTxKickLatencyRoundTrip(t *testing.T) {
 	// Encode a Go BindingStatus with non-trivial values on the
 	// four kick-latency fields; decode the JSON back; assert

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -68,6 +68,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var txPackets uint64
 	var txBytes uint64
 	var txErrors uint64
+	var txSharedRecycleUnknownSlotDrops uint64
 	var txCompletions uint64
 	var kernelRXDropped uint64
 	var kernelRXInvalidDescs uint64
@@ -137,6 +138,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		txPackets += binding.TXPackets
 		txBytes += binding.TXBytes
 		txErrors += binding.TXErrors
+		txSharedRecycleUnknownSlotDrops += binding.TXSharedRecycleUnknownSlotDrops
 		txCompletions += binding.TXCompletions
 		kernelRXDropped += binding.KernelRXDropped
 		kernelRXInvalidDescs += binding.KernelRXInvalidDescs
@@ -276,6 +278,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX packets:                %d\n", txPackets)
 	fmt.Fprintf(&b, "  TX bytes:                  %d\n", txBytes)
 	fmt.Fprintf(&b, "  TX errors:                 %d\n", txErrors)
+	fmt.Fprintf(&b, "  TX shared recycle unk:     %d\n", txSharedRecycleUnknownSlotDrops)
 	fmt.Fprintf(&b, "  TX completions:            %d\n", txCompletions)
 	fmt.Fprintf(&b, "  Kernel RX dropped:         %d\n", kernelRXDropped)
 	fmt.Fprintf(&b, "  Kernel RX invalid descs:   %d\n", kernelRXInvalidDescs)

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -41,7 +41,7 @@ func TestFormatStatusSummary(t *testing.T) {
 		},
 		Bindings: []BindingStatus{
 			{Slot: 0, Armed: false, Ready: true, Bound: true, XSKRegistered: true, XSKBindMode: "zerocopy", ZeroCopy: true, SharedUMEMMode: "cross-nic", SharedUMEMSocketRole: "owner", SharedUMEMGroup: "cross-nic:w0:ge-0-0-1,ge-0-0-2", RXPackets: 10, ValidatedPackets: 8, ExceptionPackets: 1, TXPackets: 3, TXBytes: 420, TXCompletions: 2, KernelRXDropped: 9, KernelRXInvalidDescs: 1, DirectTXPackets: 2, InPlaceTXPackets: 1, InPlaceVLANPushDescPackets: 8, InPlaceVLANPopDescPackets: 9, InPlaceVLANPushNoHeadroomPackets: 10, InPlaceL2MemmoveFallbackPackets: 11, DirectTXNoFrameFallbackPackets: 5, DirectTXBuildFallbackPackets: 6, DebugPendingFillFrames: 10, DebugSpareFillFrames: 11, DebugFreeTXFrames: 12, DebugPendingTXPrepared: 13, DebugPendingTXLocal: 14, DebugOutstandingTX: 15, DebugInFlightRecycles: 16},
-			{Slot: 1, Armed: false, Ready: false, Bound: true, XSKRegistered: false, RXPackets: 5, ValidatedPackets: 4, ExceptionPackets: 2, TXErrors: 1, TXCompletions: 3, KernelRXDropped: 4, KernelRXInvalidDescs: 2, CopyTXPackets: 4, InPlaceVLANPushDescPackets: 3, InPlaceVLANPopDescPackets: 4, InPlaceVLANPushNoHeadroomPackets: 5, InPlaceL2MemmoveFallbackPackets: 6, DirectTXDisallowedFallbackPackets: 7, DebugPendingFillFrames: 20, DebugSpareFillFrames: 21, DebugFreeTXFrames: 22, DebugPendingTXPrepared: 23, DebugPendingTXLocal: 24, DebugOutstandingTX: 25, DebugInFlightRecycles: 26},
+			{Slot: 1, Armed: false, Ready: false, Bound: true, XSKRegistered: false, RXPackets: 5, ValidatedPackets: 4, ExceptionPackets: 2, TXErrors: 1, TXSharedRecycleUnknownSlotDrops: 1, TXCompletions: 3, KernelRXDropped: 4, KernelRXInvalidDescs: 2, CopyTXPackets: 4, InPlaceVLANPushDescPackets: 3, InPlaceVLANPopDescPackets: 4, InPlaceVLANPushNoHeadroomPackets: 5, InPlaceL2MemmoveFallbackPackets: 6, DirectTXDisallowedFallbackPackets: 7, DebugPendingFillFrames: 20, DebugSpareFillFrames: 21, DebugFreeTXFrames: 22, DebugPendingTXPrepared: 23, DebugPendingTXLocal: 24, DebugOutstandingTX: 25, DebugInFlightRecycles: 26},
 		},
 		RecentExceptions: []ExceptionStatus{
 			{Timestamp: now, Slot: 1, QueueID: 0, Interface: "ge-0-0-2", Reason: "metadata_parse", PacketLength: 128},
@@ -75,6 +75,7 @@ func TestFormatStatusSummary(t *testing.T) {
 		"TX packets:                3",
 		"TX bytes:                  420",
 		"TX errors:                 1",
+		"TX shared recycle unk:     1",
 		"TX completions:            5",
 		"Kernel RX dropped:         13",
 		"Kernel RX invalid descs:   3",

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -557,7 +557,7 @@ for spec in "${selected_classes[@]}"; do
     append_dataplane_class_summary "$label" "$out/dataplane/counter-delta.json"
     if (( equal_flow_status != 0 )); then
         overall_status=2
-        append_error_row "$label" "$port" "$queue" "$rate" "$status"
+        append_error_row "$label" "$port" "$queue" "$rate" 2
         echo "fairness-cos-class-sweep: invalid equal-flow estimator capture for $label: $equal_flow_dir" >&2
         [[ -f "$equal_flow_dir/reducer.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/reducer.stderr" >&2
         [[ -f "$equal_flow_dir/summary-row.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/summary-row.stderr" >&2

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -26,6 +26,7 @@ ARTIFACT_ROOT=${ARTIFACT_ROOT:-}
 HARNESS=${HARNESS:-$ROOT_DIR/test/incus/fairness-harness.sh}
 WRAPPER=${WRAPPER:-$ROOT_DIR/test/incus/fairness_multi_sample.py}
 FAIRNESS_EVAL=${FAIRNESS_EVAL:-$ROOT_DIR/userspace-dp/target/release/fairness-eval}
+EQUAL_FLOW_CAPTURE=${EQUAL_FLOW_CAPTURE:-$ROOT_DIR/test/incus/fairness_equal_flow_capture.py}
 CAPTURE_DATAPLANE=${CAPTURE_DATAPLANE:-1}
 DATAPLANE_VM=${DATAPLANE_VM:-loss:xpf-userspace-fw0}
 DATAPLANE_STATUS_PATH=${DATAPLANE_STATUS_PATH:-/run/xpf/userspace-dp.json}
@@ -49,6 +50,18 @@ if [[ ! -x "$FAIRNESS_EVAL" ]]; then
     echo "  build with: cargo build --manifest-path userspace-dp/Cargo.toml --release --bin fairness-eval" >&2
     exit 2
 fi
+if [[ ! -f "$EQUAL_FLOW_CAPTURE" ]]; then
+    echo "fairness-cos-class-sweep: equal-flow capture reducer not found: $EQUAL_FLOW_CAPTURE" >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "fairness-cos-class-sweep: python3 is required for equal-flow estimator capture" >&2
+    exit 2
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    echo "fairness-cos-class-sweep: curl is required for Prometheus metrics capture" >&2
+    exit 2
+fi
 if ! command -v jq >/dev/null 2>&1; then
     echo "fairness-cos-class-sweep: jq is required to build the aggregate summary" >&2
     exit 2
@@ -62,8 +75,13 @@ fi
 SUMMARY_TSV="$ARTIFACT_ROOT/summary.tsv"
 SUMMARY_MD="$ARTIFACT_ROOT/summary.md"
 DATAPLANE_SUMMARY_TSV="$ARTIFACT_ROOT/dataplane-summary.tsv"
+EQUAL_FLOW_SUMMARY_TSV="$ARTIFACT_ROOT/equal-flow-summary.tsv"
 if ! rm -f "$DATAPLANE_SUMMARY_TSV"; then
     echo "fairness-cos-class-sweep: failed to remove stale dataplane summary: $DATAPLANE_SUMMARY_TSV" >&2
+    exit 2
+fi
+if ! rm -f "$EQUAL_FLOW_SUMMARY_TSV"; then
+    echo "fairness-cos-class-sweep: failed to remove stale equal-flow summary: $EQUAL_FLOW_SUMMARY_TSV" >&2
     exit 2
 fi
 
@@ -123,6 +141,126 @@ append_error_row() {
 
 mark_dataplane_error() {
     dataplane_status=2
+}
+
+scrape_equal_flow_metrics() {
+    local dir=$1
+    local raw="$dir/metrics-raw.prom"
+    local stderr="$dir/metrics-scrape.stderr"
+
+    : > "$raw"
+    : > "$stderr"
+    while true; do
+        local ts
+        local metrics
+        local curl_status=0
+        ts=$(date +%s)
+        if metrics=$(curl -sS --max-time 1 "$METRICS_URL" 2>>"$stderr"); then
+            curl_status=0
+        else
+            curl_status=$?
+            metrics=
+        fi
+        {
+            printf '# xpf_fairness_scrape_begin timestamp=%s\n' "$ts"
+            if [[ "$curl_status" -ne 0 ]]; then
+                printf '# xpf_fairness_scrape_error timestamp=%s status=%s\n' "$ts" "$curl_status"
+            fi
+            if [[ -z "$metrics" ]]; then
+                printf '# xpf_fairness_scrape_empty timestamp=%s\n' "$ts"
+            else
+                printf '%s\n' "$metrics"
+            fi
+            printf '# xpf_fairness_scrape_end timestamp=%s\n' "$ts"
+        } >> "$raw"
+        sleep 1
+    done
+}
+
+start_equal_flow_class_capture() {
+    local dir=$1
+
+    mkdir -p "$dir"
+    scrape_equal_flow_metrics "$dir" &
+    EQUAL_FLOW_CAPTURE_PID=$!
+}
+
+stop_equal_flow_class_capture() {
+    local pid=$1
+
+    [[ -n "$pid" ]] || return 0
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+analyze_equal_flow_class_capture() {
+    local dir=$1
+    local queue=$2
+
+    python3 "$EQUAL_FLOW_CAPTURE" \
+        --raw "$dir/metrics-raw.prom" \
+        --ifindex "$COS_IFINDEX" \
+        --queue-id "$queue" \
+        --summary-json "$dir/summary.json" \
+        --aggregate-tsv "$dir/aggregate.tsv" \
+        --worker-tsv "$dir/worker.tsv" \
+        2> "$dir/reducer.stderr"
+}
+
+append_equal_flow_class_summary() {
+    local label=$1
+    local port=$2
+    local queue=$3
+    local rate=$4
+    local summary_json=$5
+    local class_summary_tsv=$6
+    local row_file="${class_summary_tsv}.row"
+
+    if [[ ! -f "$EQUAL_FLOW_SUMMARY_TSV" ]]; then
+        cat > "$EQUAL_FLOW_SUMMARY_TSV" <<'HEADER'
+class	port	queue_id	rate_bps	scrape_count	target_scrape_count	valid_scrape_count	target_per_flow_bps_mean	observed_bps_mean	capped_bps_mean	suppressed_bps_mean	throughput_loss_ratio_mean	unsampled_active_workers_max	worker_count_latest
+HEADER
+    fi
+    cat > "$class_summary_tsv" <<'HEADER'
+class	port	queue_id	rate_bps	scrape_count	target_scrape_count	valid_scrape_count	target_per_flow_bps_mean	observed_bps_mean	capped_bps_mean	suppressed_bps_mean	throughput_loss_ratio_mean	unsampled_active_workers_max	worker_count_latest
+HEADER
+
+    if ! jq -er \
+        --arg class "$label" \
+        --arg port "$port" \
+        --arg queue "$queue" \
+        --arg rate "$rate" \
+        '
+        def required_number(path; field_name):
+            getpath(path) as $value
+            | if ($value | type) == "number" then
+                $value
+            else
+                error("equal-flow summary missing numeric " + field_name)
+            end;
+        [
+            $class,
+            $port,
+            $queue,
+            $rate,
+            (required_number(["scrape_count"]; "scrape_count") | tostring),
+            (required_number(["target_scrape_count"]; "target_scrape_count") | tostring),
+            (required_number(["complete_scrape_count"]; "complete_scrape_count") | tostring),
+            (required_number(["series", "target_per_flow_bps", "mean"]; "series.target_per_flow_bps.mean") | tostring),
+            (required_number(["series", "observed_bps", "mean"]; "series.observed_bps.mean") | tostring),
+            (required_number(["series", "capped_bps", "mean"]; "series.capped_bps.mean") | tostring),
+            (required_number(["series", "suppressed_bps", "mean"]; "series.suppressed_bps.mean") | tostring),
+            (required_number(["series", "throughput_loss_ratio", "mean"]; "series.throughput_loss_ratio.mean") | tostring),
+            (required_number(["series", "unsampled_active_workers", "max"]; "series.unsampled_active_workers.max") | tostring),
+            (required_number(["latest", "worker_count"]; "latest.worker_count") | tostring)
+        ] | @tsv
+        ' "$summary_json" > "$row_file"; then
+        rm -f "$row_file"
+        return 1
+    fi
+    cat "$row_file" >> "$EQUAL_FLOW_SUMMARY_TSV" || return 1
+    cat "$row_file" >> "$class_summary_tsv" || return 1
+    rm -f "$row_file"
 }
 
 capture_dataplane_enabled() {
@@ -231,6 +369,7 @@ write_dataplane_delta() {
         def sum_cos($s; $f): [($s.cos_interfaces // [])[]? | (.queues // [])[]? | .[$f] // 0] | add // 0;
         def counters($s): {
             tx_errors: sum_counter($s; "tx_errors"),
+            tx_shared_recycle_unknown_slot_drops: sum_counter($s; "tx_shared_recycle_unknown_slot_drops"),
             tx_submit_error_drops: sum_counter($s; "tx_submit_error_drops"),
             pending_tx_local_overflow_drops: sum_counter($s; "pending_tx_local_overflow_drops"),
             dbg_tx_ring_full: sum_counter($s; "dbg_tx_ring_full"),
@@ -336,7 +475,7 @@ append_dataplane_class_summary() {
 
     if [[ ! -f "$DATAPLANE_SUMMARY_TSV" ]]; then
         cat > "$DATAPLANE_SUMMARY_TSV" <<'HEADER'
-class	tx_errors_delta	tx_submit_error_drops_delta	pending_tx_local_overflow_drops_delta	dbg_tx_ring_full_delta	dbg_sendto_enobufs_delta	dbg_bound_pending_overflow_delta	dbg_cos_queue_overflow_delta	redirect_inbox_overflow_drops_delta	admission_flow_share_drops_delta	admission_buffer_drops_delta	admission_ecn_marked_delta	tx_ring_full_submit_stalls_delta	binding_post_drain_backup_cos_drops_delta
+class	tx_errors_delta	tx_shared_recycle_unknown_slot_drops_delta	tx_submit_error_drops_delta	pending_tx_local_overflow_drops_delta	dbg_tx_ring_full_delta	dbg_sendto_enobufs_delta	dbg_bound_pending_overflow_delta	dbg_cos_queue_overflow_delta	redirect_inbox_overflow_drops_delta	admission_flow_share_drops_delta	admission_buffer_drops_delta	admission_ecn_marked_delta	tx_ring_full_submit_stalls_delta	binding_post_drain_backup_cos_drops_delta
 HEADER
     fi
 
@@ -345,6 +484,7 @@ HEADER
         | [
             $class,
             ($d.tx_errors // 0),
+            ($d.tx_shared_recycle_unknown_slot_drops // 0),
             ($d.tx_submit_error_drops // 0),
             ($d.pending_tx_local_overflow_drops // 0),
             ($d.dbg_tx_ring_full // 0),
@@ -386,6 +526,9 @@ for spec in "${selected_classes[@]}"; do
 
     echo "=== $(date -Is) class=$label port=$port queue=$queue rate=$rate ==="
     capture_dataplane_snapshot before "$out"
+    equal_flow_dir="$out/equal-flow"
+    EQUAL_FLOW_CAPTURE_PID=
+    start_equal_flow_class_capture "$equal_flow_dir"
     env \
         FAIRNESS_EVAL="$FAIRNESS_EVAL" \
         COS_IFINDEX="$COS_IFINDEX" \
@@ -401,9 +544,28 @@ for spec in "${selected_classes[@]}"; do
             -- "$TARGET" "$port" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" \
         > "$out/wrapper.stdout" 2> "$out/wrapper.stderr"
     status=$?
+    stop_equal_flow_class_capture "$EQUAL_FLOW_CAPTURE_PID"
+    analyze_equal_flow_class_capture "$equal_flow_dir" "$queue"
+    equal_flow_status=$?
+    if (( equal_flow_status == 0 )); then
+        append_equal_flow_class_summary "$label" "$port" "$queue" "$rate" "$equal_flow_dir/summary.json" "$equal_flow_dir/summary.tsv" \
+            2> "$equal_flow_dir/summary-row.stderr"
+        equal_flow_status=$?
+    fi
     capture_dataplane_snapshot after "$out"
     write_dataplane_delta "$out/dataplane/status-before.json" "$out/dataplane/status-after.json" "$out/dataplane"
     append_dataplane_class_summary "$label" "$out/dataplane/counter-delta.json"
+    if (( equal_flow_status != 0 )); then
+        overall_status=2
+        append_error_row "$label" "$port" "$queue" "$rate" "$status"
+        echo "fairness-cos-class-sweep: invalid equal-flow estimator capture for $label: $equal_flow_dir" >&2
+        [[ -f "$equal_flow_dir/reducer.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/reducer.stderr" >&2
+        [[ -f "$equal_flow_dir/summary-row.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/summary-row.stderr" >&2
+        if (( status == 2 || (status != 0 && status != 1) )); then
+            sed -n '1,80p' "$out/wrapper.stderr" >&2
+        fi
+        continue
+    fi
     if (( status == 2 )); then
         overall_status=2
         append_error_row "$label" "$port" "$queue" "$rate" "$status"
@@ -523,6 +685,15 @@ fi
         printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
             "$class" "$port" "$queue" "$verdict" "$mean" "$max" "$stdev" "$mbps" "$util" "$cstruct" "$mean_gap" "$max_gap" "$starved" "$per_run"
     done
+    if [[ -f "$EQUAL_FLOW_SUMMARY_TSV" ]]; then
+        printf '\n## Equal-Flow Estimator Capture\n\n'
+        printf '| Class | Port | Queue | Scrapes | Target scrapes | Valid scrapes | Target per-flow bps mean | Observed bps mean | Capped bps mean | Suppressed bps mean | Loss ratio mean | Unsampled active workers max | Worker rows latest |\n'
+        printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n'
+        tail -n +2 "$EQUAL_FLOW_SUMMARY_TSV" | while IFS=$'\t' read -r class port queue _rate scrapes target_scrapes valid_scrapes target_bps observed_bps capped_bps suppressed_bps loss_ratio unsampled_max worker_count; do
+            printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+                "$class" "$port" "$queue" "$scrapes" "$target_scrapes" "$valid_scrapes" "$target_bps" "$observed_bps" "$capped_bps" "$suppressed_bps" "$loss_ratio" "$unsampled_max" "$worker_count"
+        done
+    fi
     if capture_dataplane_enabled; then
         printf '\n## Dataplane Counter Deltas\n\n'
         printf 'VM: `%s`, status: `%s`\n\n' "$DATAPLANE_VM" "$DATAPLANE_STATUS_PATH"
@@ -540,11 +711,11 @@ fi
         fi
         if [[ -f "$DATAPLANE_SUMMARY_TSV" ]]; then
             printf '### Per-Class TX Attribution\n\n'
-            printf '| Class | TX errors | Submit drops | Pending overflow | TX ring full | ENOBUFS | Bound overflow | CoS overflow | Redirect overflow | Flow-share drops | Buffer drops | ECN marked | TX-ring stalls | Post-drain CoS drops |\n'
-            printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n'
-            tail -n +2 "$DATAPLANE_SUMMARY_TSV" | while IFS=$'\t' read -r class tx submit pending ring enobufs bound cos redirect flow buffer ecn stalls post_drain; do
-                printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
-                    "$class" "$tx" "$submit" "$pending" "$ring" "$enobufs" "$bound" "$cos" "$redirect" "$flow" "$buffer" "$ecn" "$stalls" "$post_drain"
+            printf '| Class | TX errors | Shared recycle unknown-slot | Submit drops | Pending overflow | TX ring full | ENOBUFS | Bound overflow | CoS overflow | Redirect overflow | Flow-share drops | Buffer drops | ECN marked | TX-ring stalls | Post-drain CoS drops |\n'
+            printf '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n'
+            tail -n +2 "$DATAPLANE_SUMMARY_TSV" | while IFS=$'\t' read -r class tx shared_unknown submit pending ring enobufs bound cos redirect flow buffer ecn stalls post_drain; do
+                printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+                    "$class" "$tx" "$shared_unknown" "$submit" "$pending" "$ring" "$enobufs" "$bound" "$cos" "$redirect" "$flow" "$buffer" "$ecn" "$stalls" "$post_drain"
             done
             printf '\n'
         fi

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -32,6 +32,7 @@ DATAPLANE_VM=${DATAPLANE_VM:-loss:xpf-userspace-fw0}
 DATAPLANE_STATUS_PATH=${DATAPLANE_STATUS_PATH:-/run/xpf/userspace-dp.json}
 DATAPLANE_STATS_CMD=${DATAPLANE_STATS_CMD:-"cli -c 'show chassis cluster data-plane statistics'"}
 DATAPLANE_CAPTURE_TIMEOUT_SEC=${DATAPLANE_CAPTURE_TIMEOUT_SEC:-20}
+readonly INFRA_EXIT_STATUS=2
 
 if [[ -z "$COS_IFINDEX" ]]; then
     echo "fairness-cos-class-sweep: COS_IFINDEX is required for the shaped egress interface" >&2
@@ -123,7 +124,7 @@ class_selected() {
 }
 
 mark_parse_error() {
-    overall_status=2
+    overall_status=$INFRA_EXIT_STATUS
 }
 
 append_error_row() {
@@ -135,7 +136,7 @@ append_error_row() {
 
     printf '%s\t%s\t%s\t%s\t%s\tERROR\t-\t-\t-\t-\t-\t-\t-\t-\t-\t-\n' \
         "$label" "$port" "$queue" "$rate" "$status" >> "$SUMMARY_TSV"
-    printf "summary class=%s wrapper_status=%s verdict=ERROR mean_cov=- max_cov=-\n" \
+    printf "summary class=%s exit_status=%s verdict=ERROR mean_cov=- max_cov=-\n" \
         "$label" "$status"
 }
 
@@ -556,23 +557,23 @@ for spec in "${selected_classes[@]}"; do
     write_dataplane_delta "$out/dataplane/status-before.json" "$out/dataplane/status-after.json" "$out/dataplane"
     append_dataplane_class_summary "$label" "$out/dataplane/counter-delta.json"
     if (( equal_flow_status != 0 )); then
-        overall_status=2
-        append_error_row "$label" "$port" "$queue" "$rate" 2
+        overall_status=$INFRA_EXIT_STATUS
+        append_error_row "$label" "$port" "$queue" "$rate" "$INFRA_EXIT_STATUS"
         echo "fairness-cos-class-sweep: invalid equal-flow estimator capture for $label: $equal_flow_dir" >&2
         [[ -f "$equal_flow_dir/reducer.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/reducer.stderr" >&2
         [[ -f "$equal_flow_dir/summary-row.stderr" ]] && sed -n '1,80p' "$equal_flow_dir/summary-row.stderr" >&2
-        if (( status == 2 || (status != 0 && status != 1) )); then
+        if (( status == INFRA_EXIT_STATUS || (status != 0 && status != 1) )); then
             sed -n '1,80p' "$out/wrapper.stderr" >&2
         fi
         continue
     fi
-    if (( status == 2 )); then
-        overall_status=2
+    if (( status == INFRA_EXIT_STATUS )); then
+        overall_status=$INFRA_EXIT_STATUS
         append_error_row "$label" "$port" "$queue" "$rate" "$status"
         sed -n '1,80p' "$out/wrapper.stderr" >&2
         continue
     elif (( status != 0 && status != 1 )); then
-        overall_status=2
+        overall_status=$INFRA_EXIT_STATUS
         append_error_row "$label" "$port" "$queue" "$rate" "$status"
         sed -n '1,80p' "$out/wrapper.stderr" >&2
         continue
@@ -650,7 +651,7 @@ for spec in "${selected_classes[@]}"; do
                 ($sample_verdicts | join(","))
             ] | @tsv' "$summary_json" > "$row_file" 2> "$jq_err"; then
             cat "$row_file" >> "$SUMMARY_TSV"
-            awk -F'\t' '{printf "summary class=%s wrapper_status=%s verdict=%s mean_cov=%s max_cov=%s\n", $1, $5, $6, $7, $8}' "$row_file"
+            awk -F'\t' '{printf "summary class=%s exit_status=%s verdict=%s mean_cov=%s max_cov=%s\n", $1, $5, $6, $7, $8}' "$row_file"
         else
             mark_parse_error
             append_error_row "$label" "$port" "$queue" "$rate" "$status"
@@ -668,7 +669,7 @@ capture_dataplane_snapshot after "$ARTIFACT_ROOT"
 capture_dataplane_journal "$ARTIFACT_ROOT" "$SWEEP_START_ISO"
 write_dataplane_delta "$ARTIFACT_ROOT/dataplane/status-before.json" "$ARTIFACT_ROOT/dataplane/status-after.json" "$ARTIFACT_ROOT/dataplane"
 if (( dataplane_status != 0 )); then
-    overall_status=2
+    overall_status=$INFRA_EXIT_STATUS
 fi
 
 {

--- a/test/incus/fairness_equal_flow_capture.py
+++ b/test/incus/fairness_equal_flow_capture.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Reduce raw Prometheus scrapes to equal-flow estimator artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import statistics
+import sys
+from typing import Any
+
+
+# Metric names are the current Prometheus API from pkg/api/metrics.go.
+AGGREGATE_METRICS = {
+    "xpf_fairness_equal_flow_estimate_valid": "estimate_valid",
+    "xpf_fairness_equal_flow_sampled_active_workers": "sampled_active_workers",
+    "xpf_fairness_equal_flow_unsampled_active_workers": "unsampled_active_workers",
+    "xpf_fairness_equal_flow_target_per_flow_bps": "target_per_flow_bps",
+    "xpf_fairness_equal_flow_observed_bps": "observed_bps",
+    "xpf_fairness_equal_flow_capped_bps": "capped_bps",
+    "xpf_fairness_equal_flow_suppressed_bps": "suppressed_bps",
+    "xpf_fairness_equal_flow_throughput_loss_ratio": "throughput_loss_ratio",
+}
+
+WORKER_METRICS = {
+    "xpf_fairness_equal_flow_worker_observed_bps": "observed_bps",
+    "xpf_fairness_equal_flow_worker_observed_per_flow_bps": "observed_per_flow_bps",
+    "xpf_fairness_equal_flow_worker_cap_bps": "cap_bps",
+    "xpf_fairness_equal_flow_worker_suppressed_bps": "suppressed_bps",
+}
+
+AGGREGATE_FIELDS = tuple(AGGREGATE_METRICS.values())
+WORKER_FIELDS = tuple(WORKER_METRICS.values())
+PROM_SAMPLE_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)\{([^}]*)\}\s+(\S+)(?:\s+\d+)?$")
+LABEL_RE = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"')
+BEGIN_RE = re.compile(r"^# xpf_fairness_scrape_begin timestamp=(\S+)$")
+END_RE = re.compile(r"^# xpf_fairness_scrape_end timestamp=(\S+)$")
+EMPTY_RE = re.compile(r"^# xpf_fairness_scrape_empty timestamp=(\S+)$")
+ERROR_RE = re.compile(r"^# xpf_fairness_scrape_error timestamp=(\S+) status=(\S+)$")
+
+
+class CaptureError(RuntimeError):
+    pass
+
+
+def _decode_label_value(value: str) -> str:
+    return (
+        value.replace(r"\\", "\\")
+        .replace(r"\"", '"')
+        .replace(r"\n", "\n")
+    )
+
+
+def parse_labels(raw: str) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    pos = 0
+    while pos < len(raw):
+        match = LABEL_RE.match(raw, pos)
+        if match is None:
+            raise CaptureError(f"malformed Prometheus labels: {raw!r}")
+        labels[match.group(1)] = _decode_label_value(match.group(2))
+        pos = match.end()
+        if pos == len(raw):
+            break
+        if raw[pos] != ",":
+            raise CaptureError(f"malformed Prometheus labels: {raw!r}")
+        pos += 1
+    return labels
+
+
+def parse_number(raw: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise CaptureError(f"metric value is not numeric: {raw!r}") from exc
+    if not math.isfinite(value):
+        raise CaptureError(f"metric value is not finite: {raw!r}")
+    return value
+
+
+def split_scrapes(raw: str) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    scrapes: list[dict[str, Any]] = []
+    empty_timestamps: list[str] = []
+    error_timestamps: list[str] = []
+    current: dict[str, Any] | None = None
+    saw_markers = False
+
+    for line in raw.splitlines():
+        begin = BEGIN_RE.match(line)
+        if begin is not None:
+            if current is not None:
+                scrapes.append(current)
+            saw_markers = True
+            current = {"timestamp": begin.group(1), "lines": [], "empty": False}
+            continue
+
+        end = END_RE.match(line)
+        if end is not None:
+            saw_markers = True
+            if current is not None:
+                scrapes.append(current)
+                current = None
+            continue
+
+        empty = EMPTY_RE.match(line)
+        if empty is not None:
+            empty_timestamps.append(empty.group(1))
+            if current is not None:
+                current["empty"] = True
+            continue
+
+        error = ERROR_RE.match(line)
+        if error is not None:
+            error_timestamps.append(f"{error.group(1)}:{error.group(2)}")
+            continue
+
+        if current is not None:
+            current["lines"].append(line)
+
+    if current is not None:
+        scrapes.append(current)
+    if not saw_markers and raw.strip():
+        scrapes.append({"timestamp": "unknown", "lines": raw.splitlines(), "empty": False})
+    return scrapes, empty_timestamps, error_timestamps
+
+
+def parse_equal_flow_line(line: str) -> tuple[str, dict[str, str], float] | None:
+    if not line or line.startswith("#"):
+        return None
+    if not line.startswith("xpf_fairness_equal_flow_"):
+        return None
+    match = PROM_SAMPLE_RE.match(line)
+    if match is None:
+        raise CaptureError(f"malformed equal-flow metric line: {line!r}")
+    metric = match.group(1)
+    if metric not in AGGREGATE_METRICS and metric not in WORKER_METRICS:
+        raise CaptureError(f"unknown equal-flow metric name: {metric}")
+    return metric, parse_labels(match.group(2)), parse_number(match.group(3))
+
+
+def reduce_scrapes(scrapes: list[dict[str, Any]], ifindex: str, queue_id: str) -> dict[str, Any]:
+    if not scrapes:
+        raise CaptureError("raw metrics contained no scrapes")
+
+    target_rows: list[dict[str, Any]] = []
+    complete_rows: list[dict[str, Any]] = []
+    missing_by_timestamp: list[str] = []
+
+    for scrape in scrapes:
+        aggregate: dict[str, float] = {}
+        workers: dict[str, dict[str, float]] = {}
+        target_seen = False
+        for line in scrape["lines"]:
+            parsed = parse_equal_flow_line(line)
+            if parsed is None:
+                continue
+            metric, labels, value = parsed
+            if labels.get("ifindex") != ifindex or labels.get("queue_id") != queue_id:
+                continue
+            target_seen = True
+            if metric in AGGREGATE_METRICS:
+                aggregate[AGGREGATE_METRICS[metric]] = value
+            else:
+                worker_id = labels.get("worker_id")
+                if worker_id is None or not worker_id.isdigit():
+                    raise CaptureError(f"{metric} missing numeric worker_id label")
+                workers.setdefault(worker_id, {})[WORKER_METRICS[metric]] = value
+
+        if not target_seen:
+            continue
+
+        row = {
+            "timestamp": scrape["timestamp"],
+            "aggregate": aggregate,
+            "workers": workers,
+        }
+        target_rows.append(row)
+        missing = [field for field in AGGREGATE_FIELDS if field not in aggregate]
+        valid = aggregate.get("estimate_valid") == 1.0
+        complete_workers = {
+            wid: fields
+            for wid, fields in workers.items()
+            if all(field in fields for field in WORKER_FIELDS)
+        }
+        if missing:
+            missing_by_timestamp.append(f"{scrape['timestamp']}: missing {','.join(missing)}")
+            continue
+        if not valid:
+            continue
+        sampled = aggregate.get("sampled_active_workers")
+        if sampled is not None and sampled.is_integer() and len(complete_workers) != int(sampled):
+            missing_by_timestamp.append(
+                f"{scrape['timestamp']}: worker row count {len(complete_workers)} != sampled_active_workers {int(sampled)}"
+            )
+            continue
+        row["workers"] = complete_workers
+        complete_rows.append(row)
+
+    if not target_rows:
+        raise CaptureError(f"no equal-flow estimator rows for ifindex {ifindex} queue {queue_id}")
+    if not complete_rows:
+        detail = "; ".join(missing_by_timestamp[:3]) if missing_by_timestamp else "no valid estimator scrape"
+        raise CaptureError(
+            f"no complete valid equal-flow estimator rows for ifindex {ifindex} queue {queue_id}: {detail}"
+        )
+
+    latest = complete_rows[-1]
+    latest_aggregate = dict(latest["aggregate"])
+    latest_aggregate["worker_count"] = len(latest["workers"])
+    latest_aggregate["timestamp"] = latest["timestamp"]
+
+    series: dict[str, dict[str, float]] = {}
+    for field in AGGREGATE_FIELDS:
+        values = [float(row["aggregate"][field]) for row in complete_rows]
+        series[field] = {
+            "mean": statistics.mean(values),
+            "min": min(values),
+            "max": max(values),
+            "latest": values[-1],
+        }
+
+    return {
+        "ifindex": ifindex,
+        "queue_id": queue_id,
+        "scrape_count": len(scrapes),
+        "target_scrape_count": len(target_rows),
+        "complete_scrape_count": len(complete_rows),
+        "latest": latest_aggregate,
+        "series": series,
+        "complete_rows": complete_rows,
+    }
+
+
+def write_aggregate_tsv(path: Path, reduced: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write(
+            "timestamp\tifindex\tqueue_id\testimate_valid\tsampled_active_workers\t"
+            "unsampled_active_workers\ttarget_per_flow_bps\tobserved_bps\t"
+            "capped_bps\tsuppressed_bps\tthroughput_loss_ratio\n"
+        )
+        for row in reduced["complete_rows"]:
+            aggregate = row["aggregate"]
+            values = [row["timestamp"], reduced["ifindex"], reduced["queue_id"]]
+            values.extend(str(aggregate[field]) for field in AGGREGATE_FIELDS)
+            f.write("\t".join(values) + "\n")
+
+
+def write_worker_tsv(path: Path, reduced: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write(
+            "timestamp\tifindex\tqueue_id\tworker_id\tobserved_bps\t"
+            "observed_per_flow_bps\tcap_bps\tsuppressed_bps\n"
+        )
+        for row in reduced["complete_rows"]:
+            for worker_id in sorted(row["workers"], key=lambda value: int(value)):
+                worker = row["workers"][worker_id]
+                values = [row["timestamp"], reduced["ifindex"], reduced["queue_id"], worker_id]
+                values.extend(str(worker[field]) for field in WORKER_FIELDS)
+                f.write("\t".join(values) + "\n")
+
+
+def public_summary(reduced: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in reduced.items() if key != "complete_rows"}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw", type=Path, required=True)
+    parser.add_argument("--ifindex", required=True)
+    parser.add_argument("--queue-id", required=True)
+    parser.add_argument("--summary-json", type=Path, required=True)
+    parser.add_argument("--aggregate-tsv", type=Path, required=True)
+    parser.add_argument("--worker-tsv", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        raw = args.raw.read_text(encoding="utf-8")
+        scrapes, empty_timestamps, error_timestamps = split_scrapes(raw)
+        if empty_timestamps:
+            raise CaptureError(
+                "empty metrics scrape(s): " + ", ".join(empty_timestamps[:5])
+            )
+        if error_timestamps:
+            raise CaptureError(
+                "metrics scrape curl failure(s): " + ", ".join(error_timestamps[:5])
+            )
+        reduced = reduce_scrapes(scrapes, args.ifindex, args.queue_id)
+        args.summary_json.write_text(
+            json.dumps(public_summary(reduced), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        write_aggregate_tsv(args.aggregate_tsv, reduced)
+        write_worker_tsv(args.worker_tsv, reduced)
+    except (OSError, CaptureError) as exc:
+        print(f"fairness-equal-flow-capture: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/incus/fairness_equal_flow_capture.py
+++ b/test/incus/fairness_equal_flow_capture.py
@@ -92,7 +92,9 @@ def split_scrapes(raw: str) -> tuple[list[dict[str, Any]], list[str], list[str]]
         begin = BEGIN_RE.match(line)
         if begin is not None:
             if current is not None:
-                scrapes.append(current)
+                raise CaptureError(
+                    f"scrape {current['timestamp']} missing end marker before scrape {begin.group(1)}"
+                )
             saw_markers = True
             current = {"timestamp": begin.group(1), "lines": [], "empty": False}
             continue
@@ -100,9 +102,10 @@ def split_scrapes(raw: str) -> tuple[list[dict[str, Any]], list[str], list[str]]
         end = END_RE.match(line)
         if end is not None:
             saw_markers = True
-            if current is not None:
-                scrapes.append(current)
-                current = None
+            if current is None:
+                raise CaptureError(f"scrape end marker without begin marker at {end.group(1)}")
+            scrapes.append(current)
+            current = None
             continue
 
         empty = EMPTY_RE.match(line)
@@ -121,10 +124,16 @@ def split_scrapes(raw: str) -> tuple[list[dict[str, Any]], list[str], list[str]]
             current["lines"].append(line)
 
     if current is not None:
-        scrapes.append(current)
+        raise CaptureError(f"scrape {current['timestamp']} missing end marker")
     if not saw_markers and raw.strip():
         scrapes.append({"timestamp": "unknown", "lines": raw.splitlines(), "empty": False})
     return scrapes, empty_timestamps, error_timestamps
+
+
+def require_count_metric(value: float, field_name: str, timestamp: str) -> int:
+    if not value.is_integer() or value < 0:
+        raise CaptureError(f"{timestamp}: {field_name} must be a non-negative integer, got {value:g}")
+    return int(value)
 
 
 def parse_equal_flow_line(line: str) -> tuple[str, dict[str, str], float] | None:
@@ -188,12 +197,17 @@ def reduce_scrapes(scrapes: list[dict[str, Any]], ifindex: str, queue_id: str) -
         if missing:
             missing_by_timestamp.append(f"{scrape['timestamp']}: missing {','.join(missing)}")
             continue
+        sampled_count = require_count_metric(
+            aggregate["sampled_active_workers"], "sampled_active_workers", scrape["timestamp"]
+        )
+        require_count_metric(
+            aggregate["unsampled_active_workers"], "unsampled_active_workers", scrape["timestamp"]
+        )
         if not valid:
             continue
-        sampled = aggregate.get("sampled_active_workers")
-        if sampled is not None and sampled.is_integer() and len(complete_workers) != int(sampled):
+        if len(complete_workers) != sampled_count:
             missing_by_timestamp.append(
-                f"{scrape['timestamp']}: worker row count {len(complete_workers)} != sampled_active_workers {int(sampled)}"
+                f"{scrape['timestamp']}: worker row count {len(complete_workers)} != sampled_active_workers {sampled_count}"
             )
             continue
         row["workers"] = complete_workers

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("fairness_multi_sample.py")
+EQUAL_FLOW_CAPTURE_PATH = Path(__file__).with_name("fairness_equal_flow_capture.py")
 HARNESS_PATH = Path(__file__).with_name("fairness-harness.sh")
 CLASS_SWEEP_PATH = Path(__file__).with_name("fairness-cos-class-sweep.sh")
 SPEC = importlib.util.spec_from_file_location("fairness_multi_sample", MODULE_PATH)
@@ -24,6 +25,14 @@ assert SPEC is not None
 fairness_multi_sample = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(fairness_multi_sample)
+EQUAL_FLOW_SPEC = importlib.util.spec_from_file_location(
+    "fairness_equal_flow_capture",
+    EQUAL_FLOW_CAPTURE_PATH,
+)
+assert EQUAL_FLOW_SPEC is not None
+fairness_equal_flow_capture = importlib.util.module_from_spec(EQUAL_FLOW_SPEC)
+assert EQUAL_FLOW_SPEC.loader is not None
+EQUAL_FLOW_SPEC.loader.exec_module(fairness_equal_flow_capture)
 
 
 class FairnessMultiSampleTest(unittest.TestCase):
@@ -486,6 +495,8 @@ class FairnessMultiSampleTest(unittest.TestCase):
             fake_wrapper = tmp_path / "fake-wrapper.sh"
             fake_harness = tmp_path / "fake-harness.sh"
             fake_eval = tmp_path / "fake-eval"
+            fake_curl = tmp_path / "curl"
+            curl_sentinel = tmp_path / "curl-called"
             out_root = tmp_path / "sweep"
             fake_wrapper.write_text(
                 textwrap.dedent(
@@ -499,6 +510,10 @@ class FairnessMultiSampleTest(unittest.TestCase):
                             --) shift; break ;;
                             *) shift ;;
                         esac
+                    done
+                    for _ in {1..100}; do
+                        [[ -e "$CURL_SENTINEL" ]] && break
+                        sleep 0.02
                     done
                     mkdir -p "$out_dir"
                     cat > "$out_dir/summary.json" <<'JSON'
@@ -519,15 +534,45 @@ class FairnessMultiSampleTest(unittest.TestCase):
             )
             fake_harness.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
             fake_eval.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-            for path in (fake_wrapper, fake_harness, fake_eval):
+            fake_curl.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    touch "$CURL_SENTINEL"
+                    cat <<'PROM'
+                    xpf_fairness_equal_flow_estimate_valid{ifindex="14",queue_id="2"} 1
+                    xpf_fairness_equal_flow_sampled_active_workers{ifindex="14",queue_id="2"} 2
+                    xpf_fairness_equal_flow_unsampled_active_workers{ifindex="14",queue_id="2"} 0
+                    xpf_fairness_equal_flow_target_per_flow_bps{ifindex="14",queue_id="2"} 1000
+                    xpf_fairness_equal_flow_observed_bps{ifindex="14",queue_id="2"} 3000
+                    xpf_fairness_equal_flow_capped_bps{ifindex="14",queue_id="2"} 2000
+                    xpf_fairness_equal_flow_suppressed_bps{ifindex="14",queue_id="2"} 1000
+                    xpf_fairness_equal_flow_throughput_loss_ratio{ifindex="14",queue_id="2"} 0.3333333333
+                    xpf_fairness_equal_flow_worker_observed_bps{ifindex="14",queue_id="2",worker_id="0"} 1000
+                    xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex="14",queue_id="2",worker_id="0"} 1000
+                    xpf_fairness_equal_flow_worker_cap_bps{ifindex="14",queue_id="2",worker_id="0"} 1000
+                    xpf_fairness_equal_flow_worker_suppressed_bps{ifindex="14",queue_id="2",worker_id="0"} 0
+                    xpf_fairness_equal_flow_worker_observed_bps{ifindex="14",queue_id="2",worker_id="1"} 2000
+                    xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex="14",queue_id="2",worker_id="1"} 2000
+                    xpf_fairness_equal_flow_worker_cap_bps{ifindex="14",queue_id="2",worker_id="1"} 1000
+                    xpf_fairness_equal_flow_worker_suppressed_bps{ifindex="14",queue_id="2",worker_id="1"} 1000
+                    PROM
+                    """
+                ),
+                encoding="utf-8",
+            )
+            for path in (fake_wrapper, fake_harness, fake_eval, fake_curl):
                 path.chmod(0o755)
 
             env = {
                 **os.environ,
+                "PATH": f"{tmp_path}:{os.environ['PATH']}",
                 "ARTIFACT_ROOT": str(out_root),
                 "CAPTURE_DATAPLANE": "0",
                 "CLASS_FILTER": "q2",
                 "COS_IFINDEX": "14",
+                "CURL_SENTINEL": str(curl_sentinel),
                 "WRAPPER": str(fake_wrapper),
                 "HARNESS": str(fake_harness),
                 "FAIRNESS_EVAL": str(fake_eval),
@@ -548,6 +593,100 @@ class FairnessMultiSampleTest(unittest.TestCase):
             row = summary_lines[1].split("\t")
             self.assertEqual(row[0], "q2-iperf-e-16g")
             self.assertEqual(row[10], "0.5")
+            equal_flow_lines = (
+                out_root / "equal-flow-summary.tsv"
+            ).read_text(encoding="utf-8").splitlines()
+            self.assertIn("target_per_flow_bps_mean", equal_flow_lines[0])
+            equal_flow_row = equal_flow_lines[1].split("\t")
+            self.assertEqual(equal_flow_row[0], "q2-iperf-e-16g")
+            self.assertEqual(equal_flow_row[6], "1")
+            self.assertEqual(equal_flow_row[7], "1000.0")
+            self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "metrics-raw.prom").exists())
+            self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "summary.tsv").exists())
+
+    def test_equal_flow_capture_reduces_complete_target_rows(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="6"} 1
+            xpf_fairness_equal_flow_sampled_active_workers{ifindex="5",queue_id="6"} 2
+            xpf_fairness_equal_flow_unsampled_active_workers{ifindex="5",queue_id="6"} 0
+            xpf_fairness_equal_flow_target_per_flow_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_observed_bps{ifindex="5",queue_id="6"} 300
+            xpf_fairness_equal_flow_capped_bps{ifindex="5",queue_id="6"} 200
+            xpf_fairness_equal_flow_suppressed_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_throughput_loss_ratio{ifindex="5",queue_id="6"} 0.333333
+            xpf_fairness_equal_flow_worker_observed_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_cap_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_suppressed_bps{ifindex="5",queue_id="6",worker_id="0"} 0
+            xpf_fairness_equal_flow_worker_observed_bps{ifindex="5",queue_id="6",worker_id="1"} 200
+            xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex="5",queue_id="6",worker_id="1"} 200
+            xpf_fairness_equal_flow_worker_cap_bps{ifindex="5",queue_id="6",worker_id="1"} 100
+            xpf_fairness_equal_flow_worker_suppressed_bps{ifindex="5",queue_id="6",worker_id="1"} 100
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        scrapes, empty, errors = fairness_equal_flow_capture.split_scrapes(raw)
+        self.assertEqual(empty, [])
+        self.assertEqual(errors, [])
+        reduced = fairness_equal_flow_capture.reduce_scrapes(scrapes, "5", "6")
+        self.assertEqual(reduced["complete_scrape_count"], 1)
+        self.assertEqual(reduced["latest"]["worker_count"], 2)
+        self.assertEqual(reduced["series"]["suppressed_bps"]["mean"], 100)
+
+    def test_equal_flow_capture_fails_when_target_class_rows_missing(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="4"} 1
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        scrapes, _, _ = fairness_equal_flow_capture.split_scrapes(raw)
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "no equal-flow estimator rows for ifindex 5 queue 6",
+        ):
+            fairness_equal_flow_capture.reduce_scrapes(scrapes, "5", "6")
+
+    def test_equal_flow_capture_fails_when_worker_rows_are_partial(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="6"} 1
+            xpf_fairness_equal_flow_sampled_active_workers{ifindex="5",queue_id="6"} 2
+            xpf_fairness_equal_flow_unsampled_active_workers{ifindex="5",queue_id="6"} 0
+            xpf_fairness_equal_flow_target_per_flow_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_observed_bps{ifindex="5",queue_id="6"} 300
+            xpf_fairness_equal_flow_capped_bps{ifindex="5",queue_id="6"} 200
+            xpf_fairness_equal_flow_suppressed_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_throughput_loss_ratio{ifindex="5",queue_id="6"} 0.333333
+            xpf_fairness_equal_flow_worker_observed_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_observed_per_flow_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_cap_bps{ifindex="5",queue_id="6",worker_id="0"} 100
+            xpf_fairness_equal_flow_worker_suppressed_bps{ifindex="5",queue_id="6",worker_id="0"} 0
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        scrapes, _, _ = fairness_equal_flow_capture.split_scrapes(raw)
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "worker row count 1 != sampled_active_workers 2",
+        ):
+            fairness_equal_flow_capture.reduce_scrapes(scrapes, "5", "6")
+
+    def test_equal_flow_capture_reports_empty_scrape_marker(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            # xpf_fairness_scrape_empty timestamp=100
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        _scrapes, empty, errors = fairness_equal_flow_capture.split_scrapes(raw)
+        self.assertEqual(empty, ["100"])
+        self.assertEqual(errors, [])
 
     def run_fake_harness_with_metrics(
         self,

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -604,6 +604,84 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "metrics-raw.prom").exists())
             self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "summary.tsv").exists())
 
+    def test_class_sweep_equal_flow_failure_reports_infra_exit_status(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_wrapper = tmp_path / "fake-wrapper.sh"
+            fake_harness = tmp_path / "fake-harness.sh"
+            fake_eval = tmp_path / "fake-eval"
+            fake_curl = tmp_path / "curl"
+            curl_sentinel = tmp_path / "curl-called"
+            out_root = tmp_path / "sweep"
+            fake_wrapper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    for _ in {1..100}; do
+                        [[ -e "$CURL_SENTINEL" ]] && break
+                        sleep 0.02
+                    done
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_harness.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            fake_eval.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            fake_curl.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    touch "$CURL_SENTINEL"
+                    cat <<'PROM'
+                    xpf_fairness_equal_flow_estimate_valid{ifindex="14",queue_id="2"} 1
+                    xpf_fairness_equal_flow_sampled_active_workers{ifindex="14",queue_id="2"} 1.5
+                    xpf_fairness_equal_flow_unsampled_active_workers{ifindex="14",queue_id="2"} 0
+                    xpf_fairness_equal_flow_target_per_flow_bps{ifindex="14",queue_id="2"} 1000
+                    xpf_fairness_equal_flow_observed_bps{ifindex="14",queue_id="2"} 3000
+                    xpf_fairness_equal_flow_capped_bps{ifindex="14",queue_id="2"} 2000
+                    xpf_fairness_equal_flow_suppressed_bps{ifindex="14",queue_id="2"} 1000
+                    xpf_fairness_equal_flow_throughput_loss_ratio{ifindex="14",queue_id="2"} 0.3333333333
+                    PROM
+                    """
+                ),
+                encoding="utf-8",
+            )
+            for path in (fake_wrapper, fake_harness, fake_eval, fake_curl):
+                path.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "PATH": f"{tmp_path}:{os.environ['PATH']}",
+                "ARTIFACT_ROOT": str(out_root),
+                "CAPTURE_DATAPLANE": "0",
+                "CLASS_FILTER": "q2",
+                "COS_IFINDEX": "14",
+                "CURL_SENTINEL": str(curl_sentinel),
+                "WRAPPER": str(fake_wrapper),
+                "HARNESS": str(fake_harness),
+                "FAIRNESS_EVAL": str(fake_eval),
+            }
+            result = subprocess.run(
+                [str(CLASS_SWEEP_PATH)],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+                timeout=5,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("sampled_active_workers must be a non-negative integer", result.stderr)
+            summary_lines = (out_root / "summary.tsv").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(summary_lines), 2)
+            row = summary_lines[1].split("\t")
+            self.assertEqual(row[0], "q2-iperf-e-16g")
+            self.assertEqual(row[4], "2")
+            self.assertEqual(row[5], "ERROR")
+
     def test_equal_flow_capture_reduces_complete_target_rows(self) -> None:
         raw = textwrap.dedent(
             """\
@@ -673,6 +751,41 @@ class FairnessMultiSampleTest(unittest.TestCase):
         with self.assertRaisesRegex(
             fairness_equal_flow_capture.CaptureError,
             "worker row count 1 != sampled_active_workers 2",
+        ):
+            fairness_equal_flow_capture.reduce_scrapes(scrapes, "5", "6")
+
+    def test_equal_flow_capture_fails_on_truncated_marked_scrape(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="6"} 1
+            """
+        )
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "scrape 100 missing end marker",
+        ):
+            fairness_equal_flow_capture.split_scrapes(raw)
+
+    def test_equal_flow_capture_fails_when_sampled_workers_is_fractional(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="6"} 1
+            xpf_fairness_equal_flow_sampled_active_workers{ifindex="5",queue_id="6"} 1.5
+            xpf_fairness_equal_flow_unsampled_active_workers{ifindex="5",queue_id="6"} 0
+            xpf_fairness_equal_flow_target_per_flow_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_observed_bps{ifindex="5",queue_id="6"} 300
+            xpf_fairness_equal_flow_capped_bps{ifindex="5",queue_id="6"} 200
+            xpf_fairness_equal_flow_suppressed_bps{ifindex="5",queue_id="6"} 100
+            xpf_fairness_equal_flow_throughput_loss_ratio{ifindex="5",queue_id="6"} 0.333333
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        scrapes, _, _ = fairness_equal_flow_capture.split_scrapes(raw)
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "sampled_active_workers must be a non-negative integer",
         ):
             fairness_equal_flow_capture.reduce_scrapes(scrapes, "5", "6")
 

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -767,6 +767,33 @@ class FairnessMultiSampleTest(unittest.TestCase):
         ):
             fairness_equal_flow_capture.split_scrapes(raw)
 
+    def test_equal_flow_capture_fails_on_nested_begin_marker(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_begin timestamp=100
+            xpf_fairness_equal_flow_estimate_valid{ifindex="5",queue_id="6"} 1
+            # xpf_fairness_scrape_begin timestamp=101
+            # xpf_fairness_scrape_end timestamp=101
+            """
+        )
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "scrape 100 missing end marker before scrape 101",
+        ):
+            fairness_equal_flow_capture.split_scrapes(raw)
+
+    def test_equal_flow_capture_fails_on_end_without_begin_marker(self) -> None:
+        raw = textwrap.dedent(
+            """\
+            # xpf_fairness_scrape_end timestamp=100
+            """
+        )
+        with self.assertRaisesRegex(
+            fairness_equal_flow_capture.CaptureError,
+            "scrape end marker without begin marker at 100",
+        ):
+            fairness_equal_flow_capture.split_scrapes(raw)
+
     def test_equal_flow_capture_fails_when_sampled_workers_is_fractional(self) -> None:
         raw = textwrap.dedent(
             """\

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1183,6 +1183,8 @@ impl Coordinator {
                 binding.tx_bytes = snap.tx_bytes;
                 binding.tx_completions = snap.tx_completions;
                 binding.tx_errors = snap.tx_errors;
+                binding.tx_shared_recycle_unknown_slot_drops =
+                    snap.tx_shared_recycle_unknown_slot_drops;
                 binding.redirect_inbox_overflow_drops = snap.redirect_inbox_overflow_drops;
                 binding.pending_tx_local_overflow_drops = snap.pending_tx_local_overflow_drops;
                 binding.tx_submit_error_drops = snap.tx_submit_error_drops;
@@ -1333,6 +1335,7 @@ impl Coordinator {
                 binding.tx_bytes = 0;
                 binding.tx_completions = 0;
                 binding.tx_errors = 0;
+                binding.tx_shared_recycle_unknown_slot_drops = 0;
                 binding.post_drain_backup_bytes = 0;
                 binding.drain_sent_bytes_shaped_unconditional = 0;
                 binding.post_drain_backup_cos_drops = 0;

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -748,6 +748,10 @@ fn route_cancelled_shared_recycles(
                 slot, offset
             );
             current.live.tx_errors.fetch_add(1, Ordering::Relaxed);
+            current
+                .live
+                .tx_shared_recycle_unknown_slot_drops
+                .fetch_add(1, Ordering::Relaxed);
         }
     }
 }

--- a/userspace-dp/src/afxdp/tx/README.md
+++ b/userspace-dp/src/afxdp/tx/README.md
@@ -44,9 +44,10 @@ writer to synchronize against.
   The split-slice path used while holding the ingress binding and the
   all-bindings cleanup path must share this resolver so stale lookup entries
   are handled identically. Unknown recycle slots must fail closed and
-  increment `tx_errors` on the worker status surface with bounded one-line
-  logging per drain; never push a foreign offset into an arbitrary binding's
-  fill ring.
+  increment both aggregate `tx_errors` and the subset
+  `tx_shared_recycle_unknown_slot_drops` on the worker status surface with
+  bounded one-line logging per drain; never push a foreign offset into an
+  arbitrary binding's fill ring.
 - `Ordering::Relaxed` is intentional and correct given the
   single-writer invariant. Don't promote without proving a second
   writer exists.

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -1092,6 +1092,8 @@ fn record_shared_recycle_unknown_slot_drops(error_live: Option<&BindingLiveState
     }
     if let Some(live) = error_live {
         live.tx_errors.fetch_add(dropped, Ordering::Relaxed);
+        live.tx_shared_recycle_unknown_slot_drops
+            .fetch_add(dropped, Ordering::Relaxed);
     }
 }
 

--- a/userspace-dp/src/afxdp/tx/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch_tests.rs
@@ -282,6 +282,11 @@ fn shared_recycle_unknown_slot_drop_increments_tx_errors() {
     record_shared_recycle_unknown_slot_drops(None, 5);
 
     assert_eq!(live.tx_errors.load(std::sync::atomic::Ordering::Relaxed), 2);
+    assert_eq!(
+        live.tx_shared_recycle_unknown_slot_drops
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -294,6 +294,10 @@ pub(in crate::afxdp) fn drain_pending_tx(
                 }
                 Err(TxError::Drop(err)) => {
                     binding.live.tx_errors.fetch_add(1, Ordering::Relaxed);
+                    binding
+                        .live
+                        .tx_submit_error_drops
+                        .fetch_add(1, Ordering::Relaxed);
                     binding.live.set_error(err);
                 }
             }

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -316,6 +316,9 @@ pub(in crate::afxdp) struct BindingLiveState {
     pub(super) tx_bytes: AtomicU64,
     pub(super) tx_completions: AtomicU64,
     pub(super) tx_errors: AtomicU64,
+    /// #1307: subset of `tx_errors` for shared-UMEM recycle drops whose
+    /// target slot no longer maps to a live binding.
+    pub(super) tx_shared_recycle_unknown_slot_drops: AtomicU64,
     /// #710: counts packets that hit the redirect-inbox overflow path
     /// in `enqueue_tx` / `enqueue_tx_owned`. Multi-writer (every
     /// redirecting worker writes; the owner reads). Atomic because
@@ -528,6 +531,7 @@ impl BindingLiveState {
             tx_bytes: AtomicU64::new(0),
             tx_completions: AtomicU64::new(0),
             tx_errors: AtomicU64::new(0),
+            tx_shared_recycle_unknown_slot_drops: AtomicU64::new(0),
             redirect_inbox_overflow_drops: AtomicU64::new(0),
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
@@ -833,6 +837,9 @@ impl BindingLiveState {
             tx_bytes: self.tx_bytes.load(Ordering::Relaxed),
             tx_completions: self.tx_completions.load(Ordering::Relaxed),
             tx_errors: self.tx_errors.load(Ordering::Relaxed),
+            tx_shared_recycle_unknown_slot_drops: self
+                .tx_shared_recycle_unknown_slot_drops
+                .load(Ordering::Relaxed),
             redirect_inbox_overflow_drops: self
                 .redirect_inbox_overflow_drops
                 .load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -414,12 +414,15 @@ fn binding_live_snapshot_propagates_710_drop_counters() {
     live.pending_tx_local_overflow_drops
         .store(5, Ordering::Relaxed);
     live.tx_submit_error_drops.store(7, Ordering::Relaxed);
+    live.tx_shared_recycle_unknown_slot_drops
+        .store(13, Ordering::Relaxed);
     live.no_owner_binding_drops.store(11, Ordering::Relaxed);
 
     let snap = live.snapshot();
     assert_eq!(snap.redirect_inbox_overflow_drops, 3);
     assert_eq!(snap.pending_tx_local_overflow_drops, 5);
     assert_eq!(snap.tx_submit_error_drops, 7);
+    assert_eq!(snap.tx_shared_recycle_unknown_slot_drops, 13);
     // `no_owner_binding_drops` has no per-binding protocol surface;
     // it is read directly from the atomic by
     // `Coordinator::cos_no_owner_binding_drops_total()`.

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -2144,6 +2144,7 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) tx_bytes: u64,
     pub(crate) tx_completions: u64,
     pub(crate) tx_errors: u64,
+    pub(crate) tx_shared_recycle_unknown_slot_drops: u64,
     pub(crate) redirect_inbox_overflow_drops: u64,
     pub(crate) pending_tx_local_overflow_drops: u64,
     pub(crate) tx_submit_error_drops: u64,

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -721,6 +721,7 @@ fn binding_counters_snapshot_projects_ring_pressure_fields() {
         rx_fill_ring_empty_descs: 19,
         outstanding_tx: 23,
         tx_errors: 29,
+        tx_shared_recycle_unknown_slot_drops: 43,
         tx_submit_error_drops: 31,
         pending_tx_local_overflow_drops: 37,
         // #918 / #943: pin per-set LRU collision and V_min telemetry
@@ -747,6 +748,7 @@ fn binding_counters_snapshot_projects_ring_pressure_fields() {
     assert_eq!(snap.rx_fill_ring_empty_descs, 19);
     assert_eq!(snap.outstanding_tx, 23);
     assert_eq!(snap.tx_errors, 29);
+    assert_eq!(snap.tx_shared_recycle_unknown_slot_drops, 43);
     assert_eq!(snap.tx_submit_error_drops, 31);
     assert_eq!(snap.pending_tx_local_overflow_drops, 37);
     assert_eq!(snap.flow_cache_collision_evictions, 53);
@@ -779,6 +781,7 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         tx_completion_ring_available: 30,
         tx_completion_ring_available_max: 32,
         tx_errors: 9,
+        tx_shared_recycle_unknown_slot_drops: 14,
         tx_submit_error_drops: 10,
         pending_tx_local_overflow_drops: 11,
         // #812: populated so wire-key assertions below also cover
@@ -829,6 +832,7 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         "tx_completion_ring_available",
         "tx_completion_ring_available_max",
         "tx_errors",
+        "tx_shared_recycle_unknown_slot_drops",
         "tx_submit_error_drops",
         "pending_tx_local_overflow_drops",
         // #812: new wire keys — absence from BindingCountersSnapshot
@@ -933,6 +937,7 @@ fn tx_latency_hist_serialization_roundtrip() {
         tx_completion_ring_available: 0,
         tx_completion_ring_available_max: 0,
         tx_errors: 0,
+        tx_shared_recycle_unknown_slot_drops: 0,
         tx_submit_error_drops: 0,
         pending_tx_local_overflow_drops: 0,
         // Hand-built plausible histogram — bucket 0 heavy,

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1408,6 +1408,11 @@ pub(crate) struct BindingStatus {
     pub tx_bytes: u64,
     #[serde(rename = "tx_errors", default)]
     pub tx_errors: u64,
+    // #1307: shared-UMEM recycle requests dropped because their
+    // recorded fill slot no longer maps to a live binding. Subset of
+    // `tx_errors`.
+    #[serde(rename = "tx_shared_recycle_unknown_slot_drops", default)]
+    pub tx_shared_recycle_unknown_slot_drops: u64,
     // #710: per-binding subset of `tx_errors` attributed to the
     // redirect-inbox overflow path in `BindingLiveState::enqueue_tx` /
     // `enqueue_tx_owned`. Indicates the owner is not draining redirects
@@ -1684,6 +1689,8 @@ pub(crate) struct BindingCountersSnapshot {
     pub umem_inflight_frames: u32,
     #[serde(rename = "tx_errors", default)]
     pub tx_errors: u64,
+    #[serde(rename = "tx_shared_recycle_unknown_slot_drops", default)]
+    pub tx_shared_recycle_unknown_slot_drops: u64,
     #[serde(rename = "tx_submit_error_drops", default)]
     pub tx_submit_error_drops: u64,
     #[serde(rename = "pending_tx_local_overflow_drops", default)]
@@ -1783,6 +1790,7 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             tx_ring_capacity: b.tx_ring_capacity,
             umem_inflight_frames: b.umem_inflight_frames,
             tx_errors: b.tx_errors,
+            tx_shared_recycle_unknown_slot_drops: b.tx_shared_recycle_unknown_slot_drops,
             tx_submit_error_drops: b.tx_submit_error_drops,
             pending_tx_local_overflow_drops: b.pending_tx_local_overflow_drops,
             // #812: clone the histogram Vec<u64> by value (owned


### PR DESCRIPTION
## Summary
- add per-binding `tx_shared_recycle_unknown_slot_drops` and surface it through userspace status, CLI output, and the CoS class sweep dataplane delta table
- attribute fallback `TxError::Drop` paths to `tx_submit_error_drops` instead of only the aggregate `tx_errors`
- add synchronized equal-flow estimator scraping/reduction to `fairness-cos-class-sweep.sh`, including raw Prometheus capture and per-class/root TSV and Markdown summaries
- fail closed on missing, empty, partial, or schema-invalid equal-flow estimator scrapes so fairness qualification cannot silently pass without the estimator data
- update the CoS/per-5-tuple/shared-UMEM docs and `_Log.md` for the new artifacts and TX attribution semantics

Closes #1306
Closes #1307

## Validation
- `python3 -m py_compile test/incus/fairness_equal_flow_capture.py test/incus/fairness_multi_sample_test.py`
- `python3 test/incus/fairness_multi_sample_test.py`
- `go test ./pkg/dataplane/userspace`
- `bash -n test/incus/fairness-cos-class-sweep.sh`
- `git diff --cached --check`
- `cargo test --manifest-path userspace-dp/Cargo.toml shared_recycle_unknown_slot_drop_increments_tx_errors --quiet`
- `cargo test --manifest-path userspace-dp/Cargo.toml binding_live_snapshot_propagates_710_drop_counters --quiet`
- `cargo test --manifest-path userspace-dp/Cargo.toml binding_counters_snapshot_projects_ring_pressure_fields --quiet`
- `cargo test --manifest-path userspace-dp/Cargo.toml binding_counters_snapshot_serializes_with_expected_wire_keys --quiet`
