### PR TITLE
Align equal-flow estimator capture with steady-state windows

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -489,12 +489,27 @@ continuous Prometheus scrape before invoking the multi-sample wrapper
 and stops it after the wrapper exits. Raw scrapes are preserved under
 `<artifact>/<class>/equal-flow/metrics-raw.prom`; reducer output is
 written beside it as `summary.json`, `aggregate.tsv`, and `worker.tsv`.
+The reducer reads the multi-sample `summary.json` plus each preserved
+`iperf-single.json` and includes only scrapes whose timestamps land
+inside the same steady-state window as the fairness verdict
+(`start.timestamp.timesecs + WARMUP + EQUAL_FLOW_ESTIMATOR_WINDOW_SECS`
+through `start.timestamp.timesecs + duration - FINAL_BURST`). This keeps
+suppression-cost estimates aligned with the accepted CoV/Cstruct
+samples instead of averaging ramp, cooldown, or post-iperf telemetry.
+`WARMUP`, `FINAL_BURST`, and the estimator-window exclusion are
+integer-second values to match the `fairness-eval` CLI contract.
+Because the equal-flow gauges are themselves rolling 30-second
+estimates, the class sweep also skips the first
+`EQUAL_FLOW_ESTIMATOR_WINDOW_SECS=30` seconds after warmup by default;
+otherwise the first accepted scrapes can still contain pre-steady bytes
+inside the gauge's source window.
 The sweep also writes `<artifact>/equal-flow-summary.tsv` and appends an
 equal-flow section to `summary.md`. Missing or empty scrapes, parse
 errors, missing scrape-end markers, non-integer active-worker counts,
-or missing required aggregate estimator rows for the target
-`COS_IFINDEX` and class queue are infrastructure failures and make the
-sweep exit `2`; they do not produce a false-green fairness verdict.
+missing sample summaries or iperf artifacts, or missing required
+aggregate estimator rows for the target `COS_IFINDEX` and class queue
+inside the steady-state windows are infrastructure failures and make
+the sweep exit `2`; they do not produce a false-green fairness verdict.
 - **`xpf_userspace_worker_cos_queue_lease_acquire_v8_calls_total{worker_id=...}`**
   counter: cumulative v8 CoS queue-lease acquire calls made by the
   worker. Use `rate()` over the same scrape window as worker TX

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -430,10 +430,16 @@ is designed.
 Issue #1306 makes the class sweep preserve that evidence directly:
 each class artifact gets an `equal-flow/` directory with the raw
 Prometheus scrape stream plus reduced aggregate and worker TSV/JSON
-summaries for the target `COS_IFINDEX` and queue. The sweep fails closed
-with exit `2` if those required estimator rows are absent, the scrape
-stream is empty or truncated, or the active-worker-count gauges are not
-integer counts.
+summaries for the target `COS_IFINDEX` and queue. The reducer uses the
+multi-sample summary and the per-sample preserved `iperf-single.json`
+files to keep only scrapes inside each sample's steady-state window,
+using the same integer-second `WARMUP` and `FINAL_BURST` exclusions as
+`fairness-eval`, plus the default
+`EQUAL_FLOW_ESTIMATOR_WINDOW_SECS=30` rolling-gauge flush after warmup.
+The sweep fails closed with exit `2` if those required
+estimator rows are absent in the steady-state windows, the scrape stream
+is empty or truncated, the sample timing artifacts are missing, or the
+active-worker-count gauges are not integer counts.
 
 ### PR #1241 — TX completion uniformity telemetry
 

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -12,6 +12,9 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 TARGET=${TARGET:-172.16.80.200}
 N=${N:-12}
 DURATION=${DURATION:-75}
+WARMUP=${WARMUP:-5}
+EQUAL_FLOW_ESTIMATOR_WINDOW_SECS=${EQUAL_FLOW_ESTIMATOR_WINDOW_SECS:-30}
+FINAL_BURST=${FINAL_BURST:-1}
 # Default to reverse only when REVERSE is unset. REVERSE= selects a
 # forward sweep.
 REVERSE=${REVERSE--R}
@@ -67,6 +70,21 @@ if ! command -v jq >/dev/null 2>&1; then
     echo "fairness-cos-class-sweep: jq is required to build the aggregate summary" >&2
     exit 2
 fi
+
+require_nonnegative_integer_seconds() {
+    local name=$1
+    local value=$2
+
+    if [[ "$value" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        return 0
+    fi
+    echo "fairness-cos-class-sweep: $name must be a non-negative integer second count, got: $value" >&2
+    exit 2
+}
+
+require_nonnegative_integer_seconds WARMUP "$WARMUP"
+require_nonnegative_integer_seconds EQUAL_FLOW_ESTIMATOR_WINDOW_SECS "$EQUAL_FLOW_ESTIMATOR_WINDOW_SECS"
+require_nonnegative_integer_seconds FINAL_BURST "$FINAL_BURST"
 
 if [[ -z "$ARTIFACT_ROOT" ]]; then
     ARTIFACT_ROOT=$(mktemp -d -t cos-fairness-all.XXXXXX)
@@ -197,11 +215,17 @@ stop_equal_flow_class_capture() {
 analyze_equal_flow_class_capture() {
     local dir=$1
     local queue=$2
+    local sample_summary=$3
 
     python3 "$EQUAL_FLOW_CAPTURE" \
         --raw "$dir/metrics-raw.prom" \
         --ifindex "$COS_IFINDEX" \
         --queue-id "$queue" \
+        --sample-summary "$sample_summary" \
+        --warmup-secs "$WARMUP" \
+        --estimator-window-secs "$EQUAL_FLOW_ESTIMATOR_WINDOW_SECS" \
+        --final-burst-secs "$FINAL_BURST" \
+        --iperf-artifact-role single \
         --summary-json "$dir/summary.json" \
         --aggregate-tsv "$dir/aggregate.tsv" \
         --worker-tsv "$dir/worker.tsv" \
@@ -535,6 +559,8 @@ for spec in "${selected_classes[@]}"; do
         COS_IFINDEX="$COS_IFINDEX" \
         COS_QUEUE_ID="$queue" \
         SHAPER_RATE_BPS="$rate" \
+        WARMUP="$WARMUP" \
+        FINAL_BURST="$FINAL_BURST" \
         IFACE="$IFACE" \
         "$WRAPPER" \
             --samples "$SAMPLES" \
@@ -546,7 +572,7 @@ for spec in "${selected_classes[@]}"; do
         > "$out/wrapper.stdout" 2> "$out/wrapper.stderr"
     status=$?
     stop_equal_flow_class_capture "$EQUAL_FLOW_CAPTURE_PID"
-    analyze_equal_flow_class_capture "$equal_flow_dir" "$queue"
+    analyze_equal_flow_class_capture "$equal_flow_dir" "$queue" "$out/samples/summary.json"
     equal_flow_status=$?
     if (( equal_flow_status == 0 )); then
         append_equal_flow_class_summary "$label" "$port" "$queue" "$rate" "$equal_flow_dir/summary.json" "$equal_flow_dir/summary.tsv" \
@@ -677,6 +703,10 @@ fi
     printf 'Artifacts: `%s`\n\n' "$ARTIFACT_ROOT"
     printf 'Target: `%s`, streams: `%s`, duration: `%s`, reverse: `%s`, metrics: `%s`, cos_ifindex: `%s`\n\n' \
         "$TARGET" "$N" "$DURATION" "$REVERSE" "$METRICS_URL" "$COS_IFINDEX"
+    printf 'Steady-state window per sample: warmup `%s`s, final-burst `%s`s.\n\n' \
+        "$WARMUP" "$FINAL_BURST"
+    printf 'Equal-flow reduction additionally skips `%s`s after warmup for rolling-estimator flush.\n\n' \
+        "$EQUAL_FLOW_ESTIMATOR_WINDOW_SECS"
     if [[ -n "$CLASS_FILTER" ]]; then
         printf 'Class filter: `%s`\n\n' "$CLASS_FILTER"
     fi

--- a/test/incus/fairness_equal_flow_capture.py
+++ b/test/incus/fairness_equal_flow_capture.py
@@ -34,6 +34,16 @@ WORKER_METRICS = {
 
 AGGREGATE_FIELDS = tuple(AGGREGATE_METRICS.values())
 WORKER_FIELDS = tuple(WORKER_METRICS.values())
+IPERF_ARTIFACT_CANDIDATES = (
+    "iperf-single.json",
+    "iperf-primary.json",
+    "iperf-mixed.json",
+)
+IPERF_ARTIFACT_BY_ROLE = {
+    "single": "iperf-single.json",
+    "primary": "iperf-primary.json",
+    "mixed": "iperf-mixed.json",
+}
 PROM_SAMPLE_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)\{([^}]*)\}\s+(\S+)(?:\s+\d+)?$")
 LABEL_RE = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"')
 BEGIN_RE = re.compile(r"^# xpf_fairness_scrape_begin timestamp=(\S+)$")
@@ -136,6 +146,25 @@ def require_count_metric(value: float, field_name: str, timestamp: str) -> int:
     return int(value)
 
 
+def require_nonnegative_number(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CaptureError(f"{field_name} must be numeric")
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise CaptureError(f"{field_name} must be a non-negative finite number")
+    return number
+
+
+def parse_nonnegative_seconds_arg(raw: str) -> int:
+    try:
+        value = int(raw, 10)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{raw!r} must be a non-negative integer second count") from exc
+    if str(value) != raw or value < 0:
+        raise argparse.ArgumentTypeError(f"{raw!r} must be a non-negative integer second count")
+    return value
+
+
 def parse_equal_flow_line(line: str) -> tuple[str, dict[str, str], float] | None:
     if not line or line.startswith("#"):
         return None
@@ -148,6 +177,120 @@ def parse_equal_flow_line(line: str) -> tuple[str, dict[str, str], float] | None
     if metric not in AGGREGATE_METRICS and metric not in WORKER_METRICS:
         raise CaptureError(f"unknown equal-flow metric name: {metric}")
     return metric, parse_labels(match.group(2)), parse_number(match.group(3))
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CaptureError(f"{path}: invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise CaptureError(f"{path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise CaptureError(f"{path}: expected JSON object")
+    return value
+
+
+def _find_iperf_artifact(sample_dir: Path, role: str) -> Path:
+    artifact_dir = sample_dir / "artifacts"
+    if role != "auto":
+        path = artifact_dir / IPERF_ARTIFACT_BY_ROLE[role]
+        if path.is_file():
+            return path
+        raise CaptureError(f"{sample_dir}: missing {path.name} for --iperf-artifact-role {role}")
+
+    found = [artifact_dir / name for name in IPERF_ARTIFACT_CANDIDATES if (artifact_dir / name).is_file()]
+    if len(found) != 1:
+        candidates = ", ".join(str(artifact_dir / name) for name in IPERF_ARTIFACT_CANDIDATES)
+        if not found:
+            raise CaptureError(f"{sample_dir}: no iperf JSON artifact found; expected one of {candidates}")
+        raise CaptureError(
+            f"{sample_dir}: multiple iperf JSON artifacts found: {', '.join(str(p) for p in found)}; "
+            "pass --iperf-artifact-role primary or --iperf-artifact-role mixed"
+        )
+    return found[0]
+
+
+def load_steady_windows(
+    sample_summary_path: Path,
+    *,
+    warmup_secs: int,
+    final_burst_secs: int,
+    estimator_window_secs: int,
+    iperf_artifact_role: str = "auto",
+) -> list[dict[str, Any]]:
+    summary = _read_json_object(sample_summary_path)
+    samples = summary.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise CaptureError(f"{sample_summary_path}: samples must be a non-empty array")
+
+    windows: list[dict[str, Any]] = []
+    for position, sample in enumerate(samples, start=1):
+        if not isinstance(sample, dict):
+            raise CaptureError(f"{sample_summary_path}: sample {position} must be an object")
+        sample_dir_raw = sample.get("sample_dir")
+        if not isinstance(sample_dir_raw, str) or not sample_dir_raw:
+            raise CaptureError(f"{sample_summary_path}: sample {position} missing sample_dir")
+        sample_dir = Path(sample_dir_raw)
+        iperf_path = _find_iperf_artifact(sample_dir, iperf_artifact_role)
+        iperf = _read_json_object(iperf_path)
+        try:
+            start_epoch = require_nonnegative_number(
+                iperf["start"]["timestamp"]["timesecs"],
+                f"{iperf_path}: start.timestamp.timesecs",
+            )
+            duration_secs = require_nonnegative_number(
+                iperf["start"]["test_start"]["duration"],
+                f"{iperf_path}: start.test_start.duration",
+            )
+        except KeyError as exc:
+            raise CaptureError(f"{iperf_path}: missing iperf start timestamp or duration field") from exc
+
+        if duration_secs <= warmup_secs + estimator_window_secs + final_burst_secs:
+            raise CaptureError(
+                f"{iperf_path}: duration {duration_secs:g}s <= warmup {warmup_secs:g}s + "
+                f"estimator-window {estimator_window_secs:g}s + final-burst {final_burst_secs:g}s"
+            )
+        steady_start = start_epoch + warmup_secs + estimator_window_secs
+        steady_end = start_epoch + duration_secs - final_burst_secs
+        windows.append(
+            {
+                "sample": sample.get("sample", position),
+                "sample_dir": str(sample_dir),
+                "iperf_json": str(iperf_path),
+                "start_epoch": steady_start,
+                "end_epoch": steady_end,
+            }
+        )
+    return windows
+
+
+def filter_scrapes_to_steady_windows(
+    scrapes: list[dict[str, Any]],
+    windows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not windows:
+        return scrapes
+    selected: list[dict[str, Any]] = []
+    for scrape in scrapes:
+        timestamp_raw = scrape["timestamp"]
+        try:
+            timestamp = float(timestamp_raw)
+        except ValueError as exc:
+            raise CaptureError(f"scrape timestamp is not numeric and cannot be steady-window filtered: {timestamp_raw}") from exc
+        if not math.isfinite(timestamp):
+            raise CaptureError(f"scrape timestamp is not finite and cannot be steady-window filtered: {timestamp_raw}")
+        if any(window["start_epoch"] <= timestamp < window["end_epoch"] for window in windows):
+            selected.append(scrape)
+    if not selected:
+        first = windows[0]
+        last = windows[-1]
+        raise CaptureError(
+            "steady-window filter selected no scrapes "
+            f"(first={first['start_epoch']:g}-{first['end_epoch']:g}, "
+            f"last={last['start_epoch']:g}-{last['end_epoch']:g})"
+        )
+    return selected
 
 
 def reduce_scrapes(scrapes: list[dict[str, Any]], ifindex: str, queue_id: str) -> dict[str, Any]:
@@ -285,6 +428,34 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--raw", type=Path, required=True)
     parser.add_argument("--ifindex", required=True)
     parser.add_argument("--queue-id", required=True)
+    parser.add_argument(
+        "--sample-summary",
+        type=Path,
+        help=(
+            "fairness_multi_sample.py summary.json. When set, equal-flow "
+            "scrapes are reduced only inside each sample's iperf steady-state window."
+        ),
+    )
+    parser.add_argument("--warmup-secs", type=parse_nonnegative_seconds_arg, default=5)
+    parser.add_argument(
+        "--estimator-window-secs",
+        type=parse_nonnegative_seconds_arg,
+        default=0,
+        help=(
+            "Additional seconds after warmup to exclude so rolling equal-flow "
+            "gauges no longer include pre-steady traffic. The class sweep passes 30s."
+        ),
+    )
+    parser.add_argument("--final-burst-secs", type=parse_nonnegative_seconds_arg, default=1)
+    parser.add_argument(
+        "--iperf-artifact-role",
+        choices=("auto", "single", "primary", "mixed"),
+        default="auto",
+        help=(
+            "Which preserved iperf JSON artifact defines the timing window. "
+            "Use primary or mixed when a future mixed-mode wrapper preserves both."
+        ),
+    )
     parser.add_argument("--summary-json", type=Path, required=True)
     parser.add_argument("--aggregate-tsv", type=Path, required=True)
     parser.add_argument("--worker-tsv", type=Path, required=True)
@@ -304,7 +475,24 @@ def main(argv: list[str]) -> int:
             raise CaptureError(
                 "metrics scrape curl failure(s): " + ", ".join(error_timestamps[:5])
             )
+        raw_scrape_count = len(scrapes)
+        steady_windows: list[dict[str, Any]] = []
+        if args.sample_summary is not None:
+            steady_windows = load_steady_windows(
+                args.sample_summary,
+                warmup_secs=args.warmup_secs,
+                final_burst_secs=args.final_burst_secs,
+                estimator_window_secs=args.estimator_window_secs,
+                iperf_artifact_role=args.iperf_artifact_role,
+            )
+            scrapes = filter_scrapes_to_steady_windows(scrapes, steady_windows)
         reduced = reduce_scrapes(scrapes, args.ifindex, args.queue_id)
+        reduced["raw_scrape_count"] = raw_scrape_count
+        reduced["steady_window_scrape_count"] = len(scrapes)
+        reduced["steady_windows"] = steady_windows
+        reduced["warmup_secs"] = args.warmup_secs
+        reduced["estimator_window_secs"] = args.estimator_window_secs
+        reduced["final_burst_secs"] = args.final_burst_secs
         args.summary_json.write_text(
             json.dumps(public_summary(reduced), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import json
 import math
@@ -515,16 +516,23 @@ class FairnessMultiSampleTest(unittest.TestCase):
                         [[ -e "$CURL_SENTINEL" ]] && break
                         sleep 0.02
                     done
-                    mkdir -p "$out_dir"
-                    cat > "$out_dir/summary.json" <<'JSON'
+                    ts=$(($(date +%s) - 5))
+                    for sample in 1 2; do
+                        sample_dir="$out_dir/sample-$sample"
+                        mkdir -p "$sample_dir/artifacts"
+                        cat > "$sample_dir/artifacts/iperf-single.json" <<JSON
+                    {"start":{"timestamp":{"timesecs":$ts},"test_start":{"duration":120}}}
+                    JSON
+                    done
+                    cat > "$out_dir/summary.json" <<JSON
                     {
                       "verdict": "PASS",
                       "observed_cov": {"mean": 0.1, "max": 0.2, "sample_stdev": 0.01},
                       "cstruct": {"mean": 0.3},
                       "gap": {"mean": -0.2, "max": -0.1},
                       "samples": [
-                        {"verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0},
-                        {"verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0}
+                        {"sample": 1, "sample_dir": "$out_dir/sample-1", "verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0},
+                        {"sample": 2, "sample_dir": "$out_dir/sample-2", "verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0}
                       ]
                     }
                     JSON
@@ -576,6 +584,9 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 "WRAPPER": str(fake_wrapper),
                 "HARNESS": str(fake_harness),
                 "FAIRNESS_EVAL": str(fake_eval),
+                "WARMUP": "0",
+                "EQUAL_FLOW_ESTIMATOR_WINDOW_SECS": "0",
+                "FINAL_BURST": "0",
             }
             result = subprocess.run(
                 [str(CLASS_SWEEP_PATH)],
@@ -618,10 +629,35 @@ class FairnessMultiSampleTest(unittest.TestCase):
                     """\
                     #!/usr/bin/env bash
                     set -euo pipefail
+                    out_dir=
+                    while [[ $# -gt 0 ]]; do
+                        case "$1" in
+                            --out-dir) out_dir=$2; shift 2 ;;
+                            --) shift; break ;;
+                            *) shift ;;
+                        esac
+                    done
                     for _ in {1..100}; do
                         [[ -e "$CURL_SENTINEL" ]] && break
                         sleep 0.02
                     done
+                    ts=$(($(date +%s) - 5))
+                    sample_dir="$out_dir/sample-1"
+                    mkdir -p "$sample_dir/artifacts"
+                    cat > "$sample_dir/artifacts/iperf-single.json" <<JSON
+                    {"start":{"timestamp":{"timesecs":$ts},"test_start":{"duration":120}}}
+                    JSON
+                    cat > "$out_dir/summary.json" <<JSON
+                    {
+                      "verdict": "PASS",
+                      "observed_cov": {"mean": 0.1, "max": 0.2, "sample_stdev": 0.01},
+                      "cstruct": {"mean": 0.3},
+                      "gap": {"mean": -0.2, "max": -0.1},
+                      "samples": [
+                        {"sample": 1, "sample_dir": "$sample_dir", "verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0}
+                      ]
+                    }
+                    JSON
                     exit 0
                     """
                 ),
@@ -663,6 +699,9 @@ class FairnessMultiSampleTest(unittest.TestCase):
                 "WRAPPER": str(fake_wrapper),
                 "HARNESS": str(fake_harness),
                 "FAIRNESS_EVAL": str(fake_eval),
+                "WARMUP": "0",
+                "EQUAL_FLOW_ESTIMATOR_WINDOW_SECS": "0",
+                "FINAL_BURST": "0",
             }
             result = subprocess.run(
                 [str(CLASS_SWEEP_PATH)],
@@ -712,6 +751,262 @@ class FairnessMultiSampleTest(unittest.TestCase):
         self.assertEqual(reduced["complete_scrape_count"], 1)
         self.assertEqual(reduced["latest"]["worker_count"], 2)
         self.assertEqual(reduced["series"]["suppressed_bps"]["mean"], 100)
+
+    def test_equal_flow_capture_filters_to_sample_steady_windows(self) -> None:
+        def metric_block(timestamp: int, observed_bps: int) -> str:
+            return textwrap.dedent(
+                f"""\
+                # xpf_fairness_scrape_begin timestamp={timestamp}
+                xpf_fairness_equal_flow_estimate_valid{{ifindex="5",queue_id="6"}} 1
+                xpf_fairness_equal_flow_sampled_active_workers{{ifindex="5",queue_id="6"}} 1
+                xpf_fairness_equal_flow_unsampled_active_workers{{ifindex="5",queue_id="6"}} 0
+                xpf_fairness_equal_flow_target_per_flow_bps{{ifindex="5",queue_id="6"}} 100
+                xpf_fairness_equal_flow_observed_bps{{ifindex="5",queue_id="6"}} {observed_bps}
+                xpf_fairness_equal_flow_capped_bps{{ifindex="5",queue_id="6"}} 100
+                xpf_fairness_equal_flow_suppressed_bps{{ifindex="5",queue_id="6"}} {observed_bps - 100}
+                xpf_fairness_equal_flow_throughput_loss_ratio{{ifindex="5",queue_id="6"}} 0.5
+                xpf_fairness_equal_flow_worker_observed_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps}
+                xpf_fairness_equal_flow_worker_observed_per_flow_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps}
+                xpf_fairness_equal_flow_worker_cap_bps{{ifindex="5",queue_id="6",worker_id="0"}} 100
+                xpf_fairness_equal_flow_worker_suppressed_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps - 100}
+                # xpf_fairness_scrape_end timestamp={timestamp}
+                """
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sample_dir = tmp_path / "sample-1"
+            artifact_dir = sample_dir / "artifacts"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "iperf-single.json").write_text(
+                json.dumps(
+                    {
+                        "start": {
+                            "timestamp": {"timesecs": 100},
+                            "test_start": {"duration": 20},
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            summary_path = tmp_path / "summary.json"
+            summary_path.write_text(
+                json.dumps({"samples": [{"sample": 1, "sample_dir": str(sample_dir)}]}) + "\n",
+                encoding="utf-8",
+            )
+            raw = metric_block(103, 1000) + metric_block(106, 3000) + metric_block(119, 9000)
+
+            scrapes, empty, errors = fairness_equal_flow_capture.split_scrapes(raw)
+            self.assertEqual(empty, [])
+            self.assertEqual(errors, [])
+            windows = fairness_equal_flow_capture.load_steady_windows(
+                summary_path,
+                warmup_secs=5,
+                estimator_window_secs=0,
+                final_burst_secs=1,
+            )
+            filtered = fairness_equal_flow_capture.filter_scrapes_to_steady_windows(
+                scrapes,
+                windows,
+            )
+            self.assertEqual([row["timestamp"] for row in filtered], ["106"])
+            reduced = fairness_equal_flow_capture.reduce_scrapes(filtered, "5", "6")
+            self.assertEqual(reduced["series"]["observed_bps"]["mean"], 3000)
+
+    def test_equal_flow_capture_applies_estimator_window_flush(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sample_dir = tmp_path / "sample-1"
+            artifact_dir = sample_dir / "artifacts"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "iperf-single.json").write_text(
+                json.dumps(
+                    {
+                        "start": {
+                            "timestamp": {"timesecs": 100},
+                            "test_start": {"duration": 75},
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            summary_path = tmp_path / "summary.json"
+            summary_path.write_text(
+                json.dumps({"samples": [{"sample": 1, "sample_dir": str(sample_dir)}]}) + "\n",
+                encoding="utf-8",
+            )
+
+            windows = fairness_equal_flow_capture.load_steady_windows(
+                summary_path,
+                warmup_secs=5,
+                estimator_window_secs=30,
+                final_burst_secs=1,
+            )
+            self.assertEqual(windows[0]["start_epoch"], 135)
+            self.assertEqual(windows[0]["end_epoch"], 174)
+
+            raw = (
+                "# xpf_fairness_scrape_begin timestamp=134\n"
+                "# xpf_fairness_scrape_end timestamp=134\n"
+                "# xpf_fairness_scrape_begin timestamp=135\n"
+                "# xpf_fairness_scrape_end timestamp=135\n"
+                "# xpf_fairness_scrape_begin timestamp=174\n"
+                "# xpf_fairness_scrape_end timestamp=174\n"
+            )
+            scrapes, _, _ = fairness_equal_flow_capture.split_scrapes(raw)
+            filtered = fairness_equal_flow_capture.filter_scrapes_to_steady_windows(
+                scrapes,
+                windows,
+            )
+            self.assertEqual([row["timestamp"] for row in filtered], ["135"])
+
+    def test_equal_flow_capture_rejects_too_short_for_estimator_window(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sample_dir = tmp_path / "sample-1"
+            artifact_dir = sample_dir / "artifacts"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "iperf-single.json").write_text(
+                json.dumps(
+                    {
+                        "start": {
+                            "timestamp": {"timesecs": 100},
+                            "test_start": {"duration": 36},
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            summary_path = tmp_path / "summary.json"
+            summary_path.write_text(
+                json.dumps({"samples": [{"sample": 1, "sample_dir": str(sample_dir)}]}) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                fairness_equal_flow_capture.CaptureError,
+                r"duration 36s <= warmup 5s \+ estimator-window 30s \+ final-burst 1s",
+            ):
+                fairness_equal_flow_capture.load_steady_windows(
+                    summary_path,
+                    warmup_secs=5,
+                    estimator_window_secs=30,
+                    final_burst_secs=1,
+                )
+
+    def test_equal_flow_capture_includes_exact_steady_start_boundary(self) -> None:
+        def metric_block(timestamp: int, observed_bps: int) -> str:
+            return textwrap.dedent(
+                f"""\
+                # xpf_fairness_scrape_begin timestamp={timestamp}
+                xpf_fairness_equal_flow_estimate_valid{{ifindex="5",queue_id="6"}} 1
+                xpf_fairness_equal_flow_sampled_active_workers{{ifindex="5",queue_id="6"}} 1
+                xpf_fairness_equal_flow_unsampled_active_workers{{ifindex="5",queue_id="6"}} 0
+                xpf_fairness_equal_flow_target_per_flow_bps{{ifindex="5",queue_id="6"}} 100
+                xpf_fairness_equal_flow_observed_bps{{ifindex="5",queue_id="6"}} {observed_bps}
+                xpf_fairness_equal_flow_capped_bps{{ifindex="5",queue_id="6"}} 100
+                xpf_fairness_equal_flow_suppressed_bps{{ifindex="5",queue_id="6"}} {observed_bps - 100}
+                xpf_fairness_equal_flow_throughput_loss_ratio{{ifindex="5",queue_id="6"}} 0.5
+                xpf_fairness_equal_flow_worker_observed_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps}
+                xpf_fairness_equal_flow_worker_observed_per_flow_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps}
+                xpf_fairness_equal_flow_worker_cap_bps{{ifindex="5",queue_id="6",worker_id="0"}} 100
+                xpf_fairness_equal_flow_worker_suppressed_bps{{ifindex="5",queue_id="6",worker_id="0"}} {observed_bps - 100}
+                # xpf_fairness_scrape_end timestamp={timestamp}
+                """
+            )
+
+        raw = metric_block(104, 1000) + metric_block(105, 2000) + metric_block(119, 9000)
+        scrapes, _, _ = fairness_equal_flow_capture.split_scrapes(raw)
+        filtered = fairness_equal_flow_capture.filter_scrapes_to_steady_windows(
+            scrapes,
+            [{"start_epoch": 105, "end_epoch": 119}],
+        )
+        self.assertEqual([row["timestamp"] for row in filtered], ["105"])
+
+    def test_equal_flow_capture_rejects_fractional_second_args(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            fairness_equal_flow_capture.parse_nonnegative_seconds_arg("0.5")
+
+    def test_equal_flow_capture_selects_mixed_artifact_role_explicitly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sample_dir = tmp_path / "sample-1"
+            artifact_dir = sample_dir / "artifacts"
+            artifact_dir.mkdir(parents=True)
+            for name, start in (("iperf-primary.json", 100), ("iperf-mixed.json", 200)):
+                (artifact_dir / name).write_text(
+                    json.dumps(
+                        {
+                            "start": {
+                                "timestamp": {"timesecs": start},
+                                "test_start": {"duration": 20},
+                            }
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            summary_path = tmp_path / "summary.json"
+            summary_path.write_text(
+                json.dumps({"samples": [{"sample": 1, "sample_dir": str(sample_dir)}]}) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(fairness_equal_flow_capture.CaptureError, "multiple iperf JSON artifacts"):
+                fairness_equal_flow_capture.load_steady_windows(
+                    summary_path,
+                    warmup_secs=5,
+                    estimator_window_secs=0,
+                    final_burst_secs=1,
+                )
+            windows = fairness_equal_flow_capture.load_steady_windows(
+                summary_path,
+                warmup_secs=5,
+                estimator_window_secs=0,
+                final_burst_secs=1,
+                iperf_artifact_role="mixed",
+            )
+            self.assertEqual(windows[0]["iperf_json"], str(artifact_dir / "iperf-mixed.json"))
+            self.assertEqual(windows[0]["start_epoch"], 205)
+
+    def test_equal_flow_capture_single_role_rejects_primary_only_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sample_dir = tmp_path / "sample-1"
+            artifact_dir = sample_dir / "artifacts"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "iperf-primary.json").write_text(
+                json.dumps(
+                    {
+                        "start": {
+                            "timestamp": {"timesecs": 100},
+                            "test_start": {"duration": 20},
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            summary_path = tmp_path / "summary.json"
+            summary_path.write_text(
+                json.dumps({"samples": [{"sample": 1, "sample_dir": str(sample_dir)}]}) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                fairness_equal_flow_capture.CaptureError,
+                "missing iperf-single.json for --iperf-artifact-role single",
+            ):
+                fairness_equal_flow_capture.load_steady_windows(
+                    summary_path,
+                    warmup_secs=5,
+                    estimator_window_secs=0,
+                    final_burst_secs=1,
+                    iperf_artifact_role="single",
+                )
 
     def test_equal_flow_capture_fails_when_target_class_rows_missing(self) -> None:
         raw = textwrap.dedent(


### PR DESCRIPTION
## Summary
- Filter equal-flow Prometheus scrapes to the same per-sample steady-state window used by fairness-eval.
- Derive windows from fairness_multi_sample summary.json plus preserved iperf-single.json artifacts.
- Fail closed when sample timing artifacts are missing, and document the windowing contract.

## Why
The all-class sweep previously reduced the equal-flow estimator over the whole wrapper lifetime, so ramp, cooldown, and post-iperf scrapes could inflate suppression-cost estimates. The fairness verdict already excludes warmup and final-burst intervals; this PR makes the estimator evidence use the same window.

## Validation
- python3 test/incus/fairness_multi_sample_test.py
- python3 -m py_compile test/incus/fairness_equal_flow_capture.py test/incus/fairness_multi_sample.py
- bash -n test/incus/fairness-cos-class-sweep.sh test/incus/fairness-harness.sh
- git diff --check
- Replayed reducer against /tmp/cos-fairness-20260514T200547Z high-rate classes:
  - q2: raw 162 scrapes -> steady 135, complete 133, mean loss 0.0514, latest 0.0284
  - q3: raw 161 scrapes -> steady 135, complete 133, mean loss 0.1357, latest 0.1245
  - q6: raw 158 scrapes -> steady 132, complete 131, mean loss 0.1919, latest 0.1931
