### PR TITLE
worker runtime: tighten cpu60s stress test handshake + doc precision

### DIFF
--- a/userspace-dp/src/afxdp/worker_runtime.rs
+++ b/userspace-dp/src/afxdp/worker_runtime.rs
@@ -24,11 +24,17 @@
 //      monotonic counters where cross-field tearing is acceptable. The
 //      rolling-window fields (`wall_ns_60s`, `active_ns_60s`,
 //      `thread_cpu_ns_60s`, `window_ns`) are an exception: they are
-//      published as a coherent tuple guarded by a `window_gen` seqlock
-//      (`AcqRel`/`Release` writes; bracketing `Acquire` reads with a
-//      `fence(Acquire)` between data loads and the `s2` re-check). See
-//      the struct doc on `WorkerRuntimeAtomics` for the publication
-//      invariant.
+//      published as a coherent tuple guarded by a `window_gen` seqlock.
+//      Writers `fetch_add(AcqRel)` to enter the odd publishing state,
+//      Relaxed-store the four window fields, then `fetch_add(Release)`
+//      back to an even committed state. Readers `Acquire`-load
+//      `window_gen` (s1), Relaxed-load the four data fields, issue a
+//      `fence(Acquire)` to seal those loads, then Relaxed-load
+//      `window_gen` again (s2). If `s2 == s1` and even, the four data
+//      fields were observed within a single committed epoch; on retry
+//      exhaustion the reader returns `default()` so `statusfmt`
+//      renders `-`. See the struct doc on `WorkerRuntimeAtomics` for
+//      the publication invariant.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
@@ -87,15 +93,19 @@ pub(crate) struct WorkerRuntimeWindow {
 ///
 /// The rolling-window fields (`wall_ns_60s`, `active_ns_60s`,
 /// `thread_cpu_ns_60s`, `window_ns`) are published as a seqlock-style
-/// atomic tuple guarded by `window_gen`. Writers bump `window_gen` to
-/// an odd value before storing the four window fields, then bump it
-/// back to an even value with Release ordering. Readers Acquire-load
-/// `window_gen` before and after reading the four fields; they retry
-/// (or render "-") if the generation is odd or changed between loads.
-/// This is necessary because `store(Release)` does NOT prevent
-/// subsequent Relaxed stores from being hoisted above it (PR #1311
-/// round-2 finding); a single Release-store fence is insufficient to
-/// publish multiple Relaxed values as a coherent tuple.
+/// atomic tuple guarded by `window_gen`. Writers `fetch_add(AcqRel)`
+/// to enter the odd publishing state, Relaxed-store the four window
+/// fields, then `fetch_add(Release)` back to an even committed state.
+/// Readers `Acquire`-load `window_gen` (s1), Relaxed-load the four
+/// data fields, issue a `fence(Acquire)` to seal those loads, then
+/// Relaxed-load `window_gen` again (s2). If `s2 == s1` and even, the
+/// four data fields were observed within a single committed epoch;
+/// on retry exhaustion the reader returns `default()` so `statusfmt`
+/// renders `-`. This is necessary because `store(Release)` does NOT
+/// prevent subsequent Relaxed stores from being hoisted above it (PR
+/// #1311 round-2 finding); a single Release-store fence is
+/// insufficient to publish multiple Relaxed values as a coherent
+/// tuple.
 #[repr(align(64))]
 pub(crate) struct WorkerRuntimeAtomics {
     pub wall_ns: AtomicU64,
@@ -286,9 +296,10 @@ impl WorkerRuntimeAtomics {
         // Relaxed data loads below could migrate past s2's load in the
         // CPU's out-of-order execution, allowing a torn snapshot to
         // escape the s1==s2 guard. The fence(Acquire) between the data
-        // loads and s2 emits `dmb ish` on ARM (a full bidirectional
-        // barrier), ensuring all four Relaxed loads complete before s2
-        // is observed. Two orthogonal guarantees work together: s1's
+        // loads and s2 emits `dmb ishld` on ARM (a load-load barrier;
+        // bidirectional for loads but does not order stores), ensuring
+        // all four Relaxed loads complete before s2 is observed. Two
+        // orthogonal guarantees work together: s1's
         // Acquire provides visibility of data written before the
         // writer's Release that produced s1's value; the fence prevents
         // those data loads from physically executing after s2 in the

--- a/userspace-dp/src/afxdp/worker_runtime_tests.rs
+++ b/userspace-dp/src/afxdp/worker_runtime_tests.rs
@@ -258,27 +258,38 @@ fn snapshot_window_never_observes_torn_tuple_under_concurrent_writer() {
         std::hint::spin_loop();
     }
 
+    // Record the first invariant violation rather than panicking inline.
+    // Panicking inside the for loop would skip the stop+join cleanup below
+    // and leave the writer thread spinning for the rest of the libtest
+    // process — exactly the cleanup class round-1 fixed for the bounded
+    // wait, just on the actual torn-tuple regression path.
     let mut nonzero_snapshots: u64 = 0;
+    let mut tear_violation: Option<String> = None;
     for _ in 0..100_000 {
         let w = atomics.snapshot_window();
         if w.window_ns > 0 {
             nonzero_snapshots = nonzero_snapshots.saturating_add(1);
-            assert!(
-                w.thread_cpu_ns <= w.window_ns,
-                "torn tuple: thread_cpu_ns={} > window_ns={}",
-                w.thread_cpu_ns,
-                w.window_ns,
-            );
-            assert!(
-                w.active_ns <= w.window_ns,
-                "torn tuple: active_ns={} > window_ns={}",
-                w.active_ns,
-                w.window_ns,
-            );
+            if w.thread_cpu_ns > w.window_ns {
+                tear_violation = Some(format!(
+                    "torn tuple: thread_cpu_ns={} > window_ns={}",
+                    w.thread_cpu_ns, w.window_ns,
+                ));
+                break;
+            }
+            if w.active_ns > w.window_ns {
+                tear_violation = Some(format!(
+                    "torn tuple: active_ns={} > window_ns={}",
+                    w.active_ns, w.window_ns,
+                ));
+                break;
+            }
         }
     }
     stop.store(true, Ordering::Relaxed);
     writer.join().unwrap();
+    if let Some(msg) = tear_violation {
+        panic!("{}", msg);
+    }
 
     // Guard against a broken reader returning all zeros (window_ns=0
     // skips the asserts above): require a non-trivial number of real

--- a/userspace-dp/src/afxdp/worker_runtime_tests.rs
+++ b/userspace-dp/src/afxdp/worker_runtime_tests.rs
@@ -218,6 +218,18 @@ fn snapshot_window_never_observes_torn_tuple_under_concurrent_writer() {
         }
     });
 
+    // Wait for the writer to publish at least one rotation before counting.
+    // Without this guard, OS thread-spawn latency (1-5ms under load) can
+    // cause the reader's 100k Relaxed-read loop (<1ms) to finish before
+    // the writer publishes its first rotation, making the
+    // nonzero_snapshots > 1_000 assertion below false-fail with 0
+    // nonzero observations. The seed publish() at t=unit doesn't enter
+    // the rotation branch, so window_ns stays 0 until the spawned
+    // writer's first publish.
+    while atomics.snapshot_window().window_ns == 0 {
+        std::hint::spin_loop();
+    }
+
     let mut nonzero_snapshots: u64 = 0;
     for _ in 0..100_000 {
         let w = atomics.snapshot_window();

--- a/userspace-dp/src/afxdp/worker_runtime_tests.rs
+++ b/userspace-dp/src/afxdp/worker_runtime_tests.rs
@@ -227,23 +227,34 @@ fn snapshot_window_never_observes_torn_tuple_under_concurrent_writer() {
     // the rotation branch, so window_ns stays 0 until the spawned
     // writer's first publish.
     //
-    // Bound the spin so a future writer regression that panics before the
-    // first publish() fails the test cleanly via writer.join().unwrap()
+    // Bound the spin so a future writer regression fails the test cleanly
     // instead of hanging on the CI runner timeout. 10M iterations is ~1s
     // on a typical x86_64 CPU; the writer normally publishes within a
-    // few ms.
+    // few ms. Two failure paths:
+    //   - writer thread exited before publishing → `is_finished()` aborts
+    //   - writer alive but stuck before first publish → bounded cap fires
+    // Both paths stop the writer and join() before panicking so the test
+    // doesn't leave a detached spinning thread alive until process exit.
     let mut waited: u64 = 0;
     while atomics.snapshot_window().window_ns == 0 {
         waited = waited.saturating_add(1);
-        assert!(
-            waited < 10_000_000,
-            "writer never published first rotation in {} iterations",
-            waited,
-        );
-        assert!(
-            !writer.is_finished(),
-            "writer thread exited before publishing first rotation",
-        );
+        if waited >= 10_000_000 {
+            stop.store(true, Ordering::Relaxed);
+            let _ = writer.join();
+            panic!(
+                "writer never published first rotation in {} iterations",
+                waited,
+            );
+        }
+        if writer.is_finished() {
+            // Writer thread exited before any publish — surface the
+            // writer's panic message if any, otherwise a clear failure.
+            let panic_payload = writer.join();
+            panic!(
+                "writer thread exited before publishing first rotation: {:?}",
+                panic_payload.err(),
+            );
+        }
         std::hint::spin_loop();
     }
 

--- a/userspace-dp/src/afxdp/worker_runtime_tests.rs
+++ b/userspace-dp/src/afxdp/worker_runtime_tests.rs
@@ -226,7 +226,24 @@ fn snapshot_window_never_observes_torn_tuple_under_concurrent_writer() {
     // nonzero observations. The seed publish() at t=unit doesn't enter
     // the rotation branch, so window_ns stays 0 until the spawned
     // writer's first publish.
+    //
+    // Bound the spin so a future writer regression that panics before the
+    // first publish() fails the test cleanly via writer.join().unwrap()
+    // instead of hanging on the CI runner timeout. 10M iterations is ~1s
+    // on a typical x86_64 CPU; the writer normally publishes within a
+    // few ms.
+    let mut waited: u64 = 0;
     while atomics.snapshot_window().window_ns == 0 {
+        waited = waited.saturating_add(1);
+        assert!(
+            waited < 10_000_000,
+            "writer never published first rotation in {} iterations",
+            waited,
+        );
+        assert!(
+            !writer.is_finished(),
+            "writer thread exited before publishing first rotation",
+        );
         std::hint::spin_loop();
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #1311. The two cherry-picked commits land test/doc improvements that were caught in post-merge review of #1311 but didn't make it into the squash:

- Writer-published handshake (`while window_ns == 0 { spin_loop }`) before the 100k reader loop in `snapshot_window_never_observes_torn_tuple_under_concurrent_writer`. Without it, OS thread-spawn latency (1-5ms under load) can cause the reader's <1ms loop to finish before any rotation publishes, false-failing the new `nonzero_snapshots > 1_000` guard.
- Bounded spin-wait on the handshake (assert iteration cap < 10M ≈ ~1s on typical CPU) so a future regression that panics the writer before first publish doesn't hang the test forever.
- File-level doc in `worker_runtime.rs` now describes the actual reader pattern (Acquire s1 / 4 Relaxed loads / fence(Acquire) / Relaxed s2). Prior prose claimed "Acquire-load before AND after" which was inaccurate after the round-2 fence addition.
- Inline fence comment corrected: `dmb ish` -> `dmb ishld` (load-load barrier; bidirectional for loads but does not order stores).

Test-and-doc only. Production seqlock is unchanged.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo test --release worker_runtime` 6/6 PASS
- [x] 5-iter stress test flake check: 5/5 PASS
- [x] `go build ./...` clean

Generated with Claude Code