### PR TITLE
Attribute CoS queue-overflow TX errors in dataplane status

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29,6 +29,10 @@
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `docs/cos-validation-notes.md`, `_Log.md`
   - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
 
+- **Timestamp**: 2026-05-15T21:23:20Z
+  - **Action**: PR #1312 CoS TX-error attribution — round-3 fixes: (1) mirror reset-time CoS queue drains into `binding.live.dbg_cos_queue_overflow` in `reset_binding_cos_runtime` so the binding-scoped subset stays lifetime-matched with `tx_errors`; (2) add Rust regression test `reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter`; (3) update `docs/cos-validation-notes.md` to state the binding-scoped subset includes admission rejects AND reset-time queue drains, and rephrase reason-counter lines as aggregate current-runtime sums (not per-queue rows); (4) extract `saturatingAddU64`/`saturatingSubU64` into `format_math.go` with doc comments; (5) rename ECN accumulator to `cosAdmissionEcnMarked` (Go-style Ecn casing).
+  - **File(s)**: `userspace-dp/src/afxdp/worker/cos.rs`, `userspace-dp/src/afxdp/worker/cos_tests.rs`, `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/format_math.go`, `docs/cos-validation-notes.md`, `_Log.md`
+
 ## 2026-05-14
 
 - **Timestamp**: 2026-05-14T19:33:03Z

--- a/_Log.md
+++ b/_Log.md
@@ -32,6 +32,10 @@
 - **Timestamp**: 2026-05-15T21:23:20Z
   - **Action**: PR #1312 CoS TX-error attribution — round-3 fixes: (1) mirror reset-time CoS queue drains into `binding.live.dbg_cos_queue_overflow` in `reset_binding_cos_runtime` so the binding-scoped subset stays lifetime-matched with `tx_errors`; (2) add Rust regression test `reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter`; (3) update `docs/cos-validation-notes.md` to state the binding-scoped subset includes admission rejects AND reset-time queue drains, and rephrase reason-counter lines as aggregate current-runtime sums (not per-queue rows); (4) extract `saturatingAddU64`/`saturatingSubU64` into `format_math.go` with doc comments; (5) rename ECN accumulator to `cosAdmissionEcnMarked` (Go-style Ecn casing).
   - **File(s)**: `userspace-dp/src/afxdp/worker/cos.rs`, `userspace-dp/src/afxdp/worker/cos_tests.rs`, `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/format_math.go`, `docs/cos-validation-notes.md`, `_Log.md`
+- **Timestamp**: 2026-05-15T21:42:00Z
+  - **Action**: PR #1315 Copilot follow-up — keep the historical `dbg_cos_queue_overflow` wire key but relabel the CLI/docs as binding-lifetime CoS queue drops because the subset now includes reset-time CoS queue drains in addition to admission rejects.
+  - **File(s)**: `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `pkg/dataplane/userspace/protocol.go`, `userspace-dp/src/protocol.rs`, `docs/cos-validation-notes.md`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
 
 ## 2026-05-14
 

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -45,6 +45,38 @@ snapshot carries a different alias for the same ifindex; the ifindex fallback
 keeps those reverse-path counters visible instead of reporting
 `Runtime: unavailable`.
 
+`show chassis cluster data-plane userspace` also prints an aggregate CoS
+admission attribution beside the generic `TX errors` counter:
+
+```
+TX errors:                 332019
+TX errors non-admission:   50
+CoS queue drops lifetime:  331969
+CoS admission drops:       331969
+CoS flow-share drops:      111471
+CoS buffer drops:          220498
+CoS ECN marked:            16496600
+TX shared recycle unk:     0
+```
+
+`TX errors` remains the generic superset used by the dataplane's error
+paths. CoS admission drops intentionally still increment it because a packet
+was not transmitted, but the adjacent `TX errors non-admission` line subtracts
+the binding-scoped `CoS queue drops lifetime` counter from the binding-scoped
+`TX errors` counter so AF_XDP/ring/shared-UMEM failures are not confused with
+expected shaper backpressure. Those two counters share the same lifetime and
+survive CoS config resets. The binding-scoped CoS subset includes admission
+rejects and reset-time CoS queue drains.
+
+The summary `CoS admission drops`, `CoS flow-share drops`, `CoS buffer drops`,
+and `CoS ECN marked` lines are aggregate sums across the current CoS runtime's
+interfaces and queues. They are useful for explaining the active scheduler
+epoch, but they can reset after a CoS config commit. If `CoS queue drops
+lifetime` is larger than the current reason split, a prior epoch or reset-time
+queue drain likely contributed. Treat non-zero lifetime CoS queue drops as a
+shaping or buffering question first; treat non-zero non-admission TX errors as
+the higher-severity transmit-path question.
+
 ### Reading them during an iperf3 run
 
 ```bash

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -68,6 +68,13 @@ expected shaper backpressure. Those two counters share the same lifetime and
 survive CoS config resets. The binding-scoped CoS subset includes admission
 rejects and reset-time CoS queue drains.
 
+The formatter deliberately does not subtract the current-runtime
+`CoS admission drops` reason split from `TX errors`; those reason counters live
+on the active CoS runtime and reset on CoS config commits. If the
+binding-scoped CoS subset briefly appears larger than `TX errors` during a
+publication window, the formatter clamps `TX errors non-admission` to zero.
+Treat that as sample skew unless it persists across later snapshots.
+
 The summary `CoS admission drops`, `CoS flow-share drops`, `CoS buffer drops`,
 and `CoS ECN marked` lines are aggregate sums across the current CoS runtime's
 interfaces and queues. They are useful for explaining the active scheduler

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -371,19 +371,6 @@ func renderBindingScopedTelemetry(b *strings.Builder, view cosInterfaceView, que
 	)
 }
 
-// saturatingAddU64 avoids silent wraparound in the telemetry render.
-// Hot-path this is not (called once per interface at scrape cadence)
-// but honesty-of-summation matters more here than the cycle cost —
-// an overflow under adversarial input is a visible ceiling, not a
-// reset to zero.
-func saturatingAddU64(a, b uint64) uint64 {
-	sum := a + b
-	if sum < a {
-		return ^uint64(0)
-	}
-	return sum
-}
-
 func histHasSample(hist []uint64) bool {
 	for _, count := range hist {
 		if count > 0 {

--- a/pkg/dataplane/userspace/format_math.go
+++ b/pkg/dataplane/userspace/format_math.go
@@ -1,0 +1,22 @@
+package userspace
+
+// saturatingAddU64 avoids silent wraparound in telemetry renderers.
+// Hot-path this is not (called at status/scrape cadence), but
+// honesty-of-summation matters more here than the cycle cost: an
+// overflow under adversarial input is a visible ceiling, not a reset.
+func saturatingAddU64(a, b uint64) uint64 {
+	sum := a + b
+	if sum < a {
+		return ^uint64(0)
+	}
+	return sum
+}
+
+// saturatingSubU64 clamps attribution residuals at zero when the source
+// counters are not sampled from exactly the same publication window.
+func saturatingSubU64(a, b uint64) uint64 {
+	if b > a {
+		return 0
+	}
+	return a - b
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -801,8 +801,9 @@ type BindingStatus struct {
 	// split replaces the pre-#804 `dbg_pending_overflow` field with
 	// two distinct wire keys — `dbg_bound_pending_overflow` for the
 	// `bound_pending` FIFO evict sites in `tx.rs`, and
-	// `dbg_cos_queue_overflow` for the class-of-service admission
-	// overflow in `enqueue_cos_item`. A snapshot from a pre-#804
+	// `dbg_cos_queue_overflow` for binding-lifetime CoS queue drops:
+	// admission rejects in `enqueue_cos_item` plus reset-time CoS queue
+	// drains. The wire key is historical. A snapshot from a pre-#804
 	// helper deserializes both as 0 (standard Go json zero-value),
 	// which is the right backward-compat behavior.
 	DbgTxRingFull           uint64 `json:"dbg_tx_ring_full,omitempty"`

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -68,11 +68,11 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var txPackets uint64
 	var txBytes uint64
 	var txErrors uint64
-	var cosQueueOverflowDrops uint64
+	var bindingCoSAdmissionDrops uint64
 	var txSharedRecycleUnknownSlotDrops uint64
 	var txCompletions uint64
-	var cosAdmissionFlowShareDrops uint64
-	var cosAdmissionBufferDrops uint64
+	var currentRuntimeCoSFlowShareDrops uint64
+	var currentRuntimeCoSBufferDrops uint64
 	var cosAdmissionEcnMarked uint64
 	var kernelRXDropped uint64
 	var kernelRXInvalidDescs uint64
@@ -142,7 +142,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		txPackets += binding.TXPackets
 		txBytes += binding.TXBytes
 		txErrors += binding.TXErrors
-		cosQueueOverflowDrops = saturatingAddU64(cosQueueOverflowDrops, binding.DbgCoSQueueOverflow)
+		bindingCoSAdmissionDrops = saturatingAddU64(bindingCoSAdmissionDrops, binding.DbgCoSQueueOverflow)
 		txSharedRecycleUnknownSlotDrops += binding.TXSharedRecycleUnknownSlotDrops
 		txCompletions += binding.TXCompletions
 		kernelRXDropped += binding.KernelRXDropped
@@ -174,13 +174,16 @@ func FormatStatusSummary(status ProcessStatus) string {
 	}
 	for _, iface := range status.CoSInterfaces {
 		for _, queue := range iface.Queues {
-			cosAdmissionFlowShareDrops = saturatingAddU64(cosAdmissionFlowShareDrops, queue.AdmissionFlowShareDrops)
-			cosAdmissionBufferDrops = saturatingAddU64(cosAdmissionBufferDrops, queue.AdmissionBufferDrops)
+			currentRuntimeCoSFlowShareDrops = saturatingAddU64(currentRuntimeCoSFlowShareDrops, queue.AdmissionFlowShareDrops)
+			currentRuntimeCoSBufferDrops = saturatingAddU64(currentRuntimeCoSBufferDrops, queue.AdmissionBufferDrops)
 			cosAdmissionEcnMarked = saturatingAddU64(cosAdmissionEcnMarked, queue.AdmissionEcnMarked)
 		}
 	}
-	cosAdmissionDrops := saturatingAddU64(cosAdmissionFlowShareDrops, cosAdmissionBufferDrops)
-	nonAdmissionTXErrors := saturatingSubU64(txErrors, cosQueueOverflowDrops)
+	currentRuntimeCoSAdmissionDrops := saturatingAddU64(currentRuntimeCoSFlowShareDrops, currentRuntimeCoSBufferDrops)
+	// The residual must use the binding-lifetime CoS subset counter, not
+	// current-runtime queue reason counters; CoS runtimes reset on config
+	// changes while BindingStatus.TXErrors does not.
+	nonAdmissionTXErrors := saturatingSubU64(txErrors, bindingCoSAdmissionDrops)
 
 	fmt.Fprintln(&b, "Userspace dataplane helper:")
 	fmt.Fprintf(&b, "  PID:                       %d\n", status.PID)
@@ -294,10 +297,10 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX errors:                 %d\n", txErrors)
 	if len(status.CoSInterfaces) > 0 {
 		fmt.Fprintf(&b, "  TX errors non-admission:   %d\n", nonAdmissionTXErrors)
-		fmt.Fprintf(&b, "  CoS queue overflow drops:  %d\n", cosQueueOverflowDrops)
-		fmt.Fprintf(&b, "  CoS admission drops:       %d\n", cosAdmissionDrops)
-		fmt.Fprintf(&b, "  CoS flow-share drops:      %d\n", cosAdmissionFlowShareDrops)
-		fmt.Fprintf(&b, "  CoS buffer drops:          %d\n", cosAdmissionBufferDrops)
+		fmt.Fprintf(&b, "  CoS queue overflow drops:  %d\n", bindingCoSAdmissionDrops)
+		fmt.Fprintf(&b, "  CoS admission drops:       %d\n", currentRuntimeCoSAdmissionDrops)
+		fmt.Fprintf(&b, "  CoS flow-share drops:      %d\n", currentRuntimeCoSFlowShareDrops)
+		fmt.Fprintf(&b, "  CoS buffer drops:          %d\n", currentRuntimeCoSBufferDrops)
 		fmt.Fprintf(&b, "  CoS ECN marked:            %d\n", cosAdmissionEcnMarked)
 	}
 	fmt.Fprintf(&b, "  TX shared recycle unk:     %d\n", txSharedRecycleUnknownSlotDrops)

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -68,7 +68,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var txPackets uint64
 	var txBytes uint64
 	var txErrors uint64
-	var bindingCoSAdmissionDrops uint64
+	var bindingLifetimeCoSQueueDrops uint64
 	var txSharedRecycleUnknownSlotDrops uint64
 	var txCompletions uint64
 	var currentRuntimeCoSFlowShareDrops uint64
@@ -142,7 +142,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		txPackets += binding.TXPackets
 		txBytes += binding.TXBytes
 		txErrors += binding.TXErrors
-		bindingCoSAdmissionDrops = saturatingAddU64(bindingCoSAdmissionDrops, binding.DbgCoSQueueOverflow)
+		bindingLifetimeCoSQueueDrops = saturatingAddU64(bindingLifetimeCoSQueueDrops, binding.DbgCoSQueueOverflow)
 		txSharedRecycleUnknownSlotDrops += binding.TXSharedRecycleUnknownSlotDrops
 		txCompletions += binding.TXCompletions
 		kernelRXDropped += binding.KernelRXDropped
@@ -183,7 +183,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	// The residual must use the binding-lifetime CoS subset counter, not
 	// current-runtime queue reason counters; CoS runtimes reset on config
 	// changes while BindingStatus.TXErrors does not.
-	nonAdmissionTXErrors := saturatingSubU64(txErrors, bindingCoSAdmissionDrops)
+	nonAdmissionTXErrors := saturatingSubU64(txErrors, bindingLifetimeCoSQueueDrops)
 
 	fmt.Fprintln(&b, "Userspace dataplane helper:")
 	fmt.Fprintf(&b, "  PID:                       %d\n", status.PID)
@@ -297,7 +297,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX errors:                 %d\n", txErrors)
 	if len(status.CoSInterfaces) > 0 {
 		fmt.Fprintf(&b, "  TX errors non-admission:   %d\n", nonAdmissionTXErrors)
-		fmt.Fprintf(&b, "  CoS queue overflow drops:  %d\n", bindingCoSAdmissionDrops)
+		fmt.Fprintf(&b, "  CoS queue drops lifetime:  %d\n", bindingLifetimeCoSQueueDrops)
 		fmt.Fprintf(&b, "  CoS admission drops:       %d\n", currentRuntimeCoSAdmissionDrops)
 		fmt.Fprintf(&b, "  CoS flow-share drops:      %d\n", currentRuntimeCoSFlowShareDrops)
 		fmt.Fprintf(&b, "  CoS buffer drops:          %d\n", currentRuntimeCoSBufferDrops)

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -68,8 +68,12 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var txPackets uint64
 	var txBytes uint64
 	var txErrors uint64
+	var cosQueueOverflowDrops uint64
 	var txSharedRecycleUnknownSlotDrops uint64
 	var txCompletions uint64
+	var cosAdmissionFlowShareDrops uint64
+	var cosAdmissionBufferDrops uint64
+	var cosAdmissionEcnMarked uint64
 	var kernelRXDropped uint64
 	var kernelRXInvalidDescs uint64
 	var directTXPackets uint64
@@ -138,6 +142,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		txPackets += binding.TXPackets
 		txBytes += binding.TXBytes
 		txErrors += binding.TXErrors
+		cosQueueOverflowDrops = saturatingAddU64(cosQueueOverflowDrops, binding.DbgCoSQueueOverflow)
 		txSharedRecycleUnknownSlotDrops += binding.TXSharedRecycleUnknownSlotDrops
 		txCompletions += binding.TXCompletions
 		kernelRXDropped += binding.KernelRXDropped
@@ -167,6 +172,15 @@ func FormatStatusSummary(status ProcessStatus) string {
 		slowPathForwardBuildPackets += binding.SlowPathForwardBuildPackets
 		slowPathDrops += binding.SlowPathDrops
 	}
+	for _, iface := range status.CoSInterfaces {
+		for _, queue := range iface.Queues {
+			cosAdmissionFlowShareDrops = saturatingAddU64(cosAdmissionFlowShareDrops, queue.AdmissionFlowShareDrops)
+			cosAdmissionBufferDrops = saturatingAddU64(cosAdmissionBufferDrops, queue.AdmissionBufferDrops)
+			cosAdmissionEcnMarked = saturatingAddU64(cosAdmissionEcnMarked, queue.AdmissionEcnMarked)
+		}
+	}
+	cosAdmissionDrops := saturatingAddU64(cosAdmissionFlowShareDrops, cosAdmissionBufferDrops)
+	nonAdmissionTXErrors := saturatingSubU64(txErrors, cosQueueOverflowDrops)
 
 	fmt.Fprintln(&b, "Userspace dataplane helper:")
 	fmt.Fprintf(&b, "  PID:                       %d\n", status.PID)
@@ -278,6 +292,14 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX packets:                %d\n", txPackets)
 	fmt.Fprintf(&b, "  TX bytes:                  %d\n", txBytes)
 	fmt.Fprintf(&b, "  TX errors:                 %d\n", txErrors)
+	if len(status.CoSInterfaces) > 0 {
+		fmt.Fprintf(&b, "  TX errors non-admission:   %d\n", nonAdmissionTXErrors)
+		fmt.Fprintf(&b, "  CoS queue overflow drops:  %d\n", cosQueueOverflowDrops)
+		fmt.Fprintf(&b, "  CoS admission drops:       %d\n", cosAdmissionDrops)
+		fmt.Fprintf(&b, "  CoS flow-share drops:      %d\n", cosAdmissionFlowShareDrops)
+		fmt.Fprintf(&b, "  CoS buffer drops:          %d\n", cosAdmissionBufferDrops)
+		fmt.Fprintf(&b, "  CoS ECN marked:            %d\n", cosAdmissionEcnMarked)
+	}
 	fmt.Fprintf(&b, "  TX shared recycle unk:     %d\n", txSharedRecycleUnknownSlotDrops)
 	fmt.Fprintf(&b, "  TX completions:            %d\n", txCompletions)
 	fmt.Fprintf(&b, "  Kernel RX dropped:         %d\n", kernelRXDropped)

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -143,7 +143,7 @@ func TestFormatStatusSummaryWorkerRuntimeRolling60sColumn(t *testing.T) {
 	out := FormatStatusSummary(status)
 	for _, want := range []string{
 		"CPU%60s",
-		"75.0",     // 45/60 = 75% on worker 0's rolling window
+		"75.0", // 45/60 = 75% on worker 0's rolling window
 		"DEAD - panicked: boom",
 	} {
 		if !strings.Contains(out, want) {
@@ -194,6 +194,92 @@ func TestFormatStatusSummaryDoesNotCountDisabledSharedUMEMFallback(t *testing.T)
 	out := FormatStatusSummary(status)
 	if !strings.Contains(out, "Shared UMEM bindings:      1/2") {
 		t.Fatalf("summary counted disabled shared UMEM fallback:\n%s", out)
+	}
+}
+
+func TestFormatStatusSummaryAttributesCoSAdmissionTXErrors(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{TXErrors: 100, DbgCoSQueueOverflow: 50},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Queues: []CoSQueueStatus{
+					{AdmissionFlowShareDrops: 3, AdmissionBufferDrops: 2, AdmissionEcnMarked: 7},
+					{AdmissionFlowShareDrops: 1, AdmissionBufferDrops: 4, AdmissionEcnMarked: 11},
+				},
+			},
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	for _, want := range []string{
+		"TX errors:                 100",
+		"TX errors non-admission:   50",
+		"CoS queue overflow drops:  50",
+		"CoS admission drops:       10",
+		"CoS flow-share drops:      4",
+		"CoS buffer drops:          6",
+		"CoS ECN marked:            18",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatStatusSummaryUsesBindingLifetimeForCoSErrorResidual(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{TXErrors: 100, DbgCoSQueueOverflow: 80},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Queues: []CoSQueueStatus{
+					{AdmissionFlowShareDrops: 5, AdmissionBufferDrops: 5},
+				},
+			},
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	for _, want := range []string{
+		"TX errors:                 100",
+		"TX errors non-admission:   20",
+		"CoS queue overflow drops:  80",
+		"CoS admission drops:       10",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing binding-lifetime attribution %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{TXErrors: 1, DbgCoSQueueOverflow: 2},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Queues: []CoSQueueStatus{
+					{AdmissionFlowShareDrops: ^uint64(0) - 1, AdmissionBufferDrops: 10},
+				},
+			},
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	for _, want := range []string{
+		"TX errors non-admission:   0",
+		"CoS queue overflow drops:  2",
+		"CoS admission drops:       18446744073709551615",
+		"CoS flow-share drops:      18446744073709551614",
+		"CoS buffer drops:          10",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing saturated attribution %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -216,7 +216,7 @@ func TestFormatStatusSummaryAttributesCoSAdmissionTXErrors(t *testing.T) {
 	for _, want := range []string{
 		"TX errors:                 100",
 		"TX errors non-admission:   50",
-		"CoS queue overflow drops:  50",
+		"CoS queue drops lifetime:  50",
 		"CoS admission drops:       10",
 		"CoS flow-share drops:      4",
 		"CoS buffer drops:          6",
@@ -246,7 +246,7 @@ func TestFormatStatusSummaryUsesBindingLifetimeForCoSErrorResidual(t *testing.T)
 	for _, want := range []string{
 		"TX errors:                 100",
 		"TX errors non-admission:   20",
-		"CoS queue overflow drops:  80",
+		"CoS queue drops lifetime:  80",
 		"CoS admission drops:       10",
 	} {
 		if !strings.Contains(out, want) {
@@ -275,7 +275,7 @@ func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {
 	out := FormatStatusSummary(status)
 	for _, want := range []string{
 		"TX errors non-admission:   0",
-		"CoS queue overflow drops:  2",
+		"CoS queue drops lifetime:  2",
 		"CoS admission drops:       18446744073709551615",
 		"CoS flow-share drops:      18446744073709551614",
 		"CoS buffer drops:          10",

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -253,6 +253,9 @@ func TestFormatStatusSummaryUsesBindingLifetimeForCoSErrorResidual(t *testing.T)
 			t.Fatalf("summary missing binding-lifetime attribution %q:\n%s", want, out)
 		}
 	}
+	if strings.Contains(out, "TX errors non-admission:   90") {
+		t.Fatalf("summary used current-runtime CoS reason counters for lifetime residual:\n%s", out)
+	}
 }
 
 func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -464,12 +464,13 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// single `dbg_pending_overflow` that conflated the two sites; that
     /// wire key was removed in #804 in favor of the split names.
     pub(super) dbg_bound_pending_overflow: AtomicU64,
-    /// #804: class-of-service queue admission overflow counter —
-    /// incremented in `enqueue_cos_item()` when the CoS admission gate
-    /// rejects the item (flow-share cap + buffer cap exhausted) but the
-    /// caller still needs to account the drop. Separate from
+    /// #804/#1315: binding-lifetime class-of-service queue drop counter.
+    /// Incremented for admission rejects in `enqueue_cos_item()` (flow-share
+    /// cap + buffer cap exhausted) and for reset-time CoS queue drains in
+    /// `reset_binding_cos_runtime()`. Separate from
     /// `dbg_bound_pending_overflow` so operators can disambiguate
-    /// bound-pending pressure from CoS shaping pressure at triage time.
+    /// bound-pending pressure from CoS shaping pressure at triage time. The
+    /// wire key is historical.
     pub(super) dbg_cos_queue_overflow: AtomicU64,
     /// #802: kernel XDP statistics v2 `rx_fill_ring_empty_descs` — the
     /// kernel's native cumulative counter of RX fill-ring starvation

--- a/userspace-dp/src/afxdp/worker/cos.rs
+++ b/userspace-dp/src/afxdp/worker/cos.rs
@@ -323,9 +323,15 @@ pub(super) fn reset_binding_cos_runtime(
 
     let dropped_total = dropped_local.saturating_add(dropped_prepared.len() as u64);
     if dropped_total > 0 {
+        // Keep the CoS subset counter lifetime-matched with tx_errors:
+        // reset-time queue drains are CoS-owned TX drops too.
         binding
             .live
             .tx_errors
+            .fetch_add(dropped_total, Ordering::Relaxed);
+        binding
+            .live
+            .dbg_cos_queue_overflow
             .fetch_add(dropped_total, Ordering::Relaxed);
     }
     for req in dropped_prepared {

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -4,6 +4,11 @@
 // `#[path = "cos_tests.rs"]` from cos.rs.
 
 use super::*;
+use crate::afxdp::cos::queue_ops::cos_queue_push_back;
+use crate::afxdp::tx::test_support::{
+    test_cos_fast_interfaces, test_cos_runtime_with_queues, test_flow_cos_item,
+    test_queue_fast_path,
+};
 use crate::test_zone_ids::*;
 
 // Rates used to force owner-local vs shared-exact classification in
@@ -26,6 +31,54 @@ fn test_tx_request(ifindex: i32) -> TxRequest {
         cos_queue_id: Some(4),
         dscp_rewrite: None,
     }
+}
+
+#[test]
+fn reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter() {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 125_000_000,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            surplus_weight: 1,
+            buffer_bytes: 4_000_000,
+            dscp_rewrite: None,
+        }],
+    );
+    cos_queue_push_back(&mut root.queues[0], test_flow_cos_item(5201, 128));
+    cos_queue_push_back(&mut root.queues[0], test_flow_cos_item(5202, 256));
+    root.nonempty_queues = 1;
+    root.runnable_queues = 1;
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        4,
+        vec![(4, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    reset_binding_cos_runtime(&mut binding, None);
+
+    assert_eq!(
+        binding.live.tx_errors.load(Ordering::Relaxed),
+        2,
+        "reset-time CoS queue drains still count as TX errors",
+    );
+    assert_eq!(
+        binding.live.dbg_cos_queue_overflow.load(Ordering::Relaxed),
+        2,
+        "reset-time CoS queue drains must mirror into the lifetime-matched CoS subset counter",
+    );
+    assert!(binding.cos.cos_interfaces.is_empty());
 }
 
 #[test]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1660,12 +1660,13 @@ pub(crate) struct BindingStatus {
 ///   `bound_pending` FIFO (`pending_tx_local` / `pending_tx_prepared`)
 ///   overflowing its soft cap. **This does not include CoS admission
 ///   overflow** — those are counted separately below.
-/// - `dbg_cos_queue_overflow` (#804): drops from the class-of-service
-///   queue admission gate (`enqueue_cos_item`) when the CoS shaping
-///   path rejects the item. Pre-#804 builds conflated this with
-///   `bound_pending` overflow under the old `dbg_pending_overflow` wire
-///   key; the counter was split so operators can disambiguate shaping
-///   pressure from bound-pending pressure.
+/// - `dbg_cos_queue_overflow` (#804): binding-lifetime CoS queue drops.
+///   This includes class-of-service queue admission rejects
+///   (`enqueue_cos_item`) and reset-time CoS queue drains. The wire key is
+///   historical. Pre-#804 builds conflated this with `bound_pending`
+///   overflow under the old `dbg_pending_overflow` wire key; the counter was
+///   split so operators can disambiguate shaping pressure from bound-pending
+///   pressure.
 /// - `rx_fill_ring_empty_descs`: kernel `xdp_statistics_v2` counter of
 ///   RX fill-ring starvation events.
 /// - `outstanding_tx`: accept-proxy for `completion_reap_max_batch` per


### PR DESCRIPTION
## Summary

- add top-level `show chassis cluster data-plane userspace` attribution for lifetime-matched CoS queue/drop accounting under aggregate `TX errors`
- expose `TX errors non-admission`, `CoS queue drops lifetime`, `CoS admission drops`, `CoS flow-share drops`, `CoS buffer drops`, and `CoS ECN marked` when CoS queue status is present
- keep the residual math on binding-scoped counters so it survives CoS config resets; reset-time CoS queue drains now mirror into the same binding-scoped subset
- report current-runtime CoS admission reason counters as aggregate active-epoch detail
- document how to interpret the generic TX error superset versus CoS shaper backpressure

## Why

The #1312 low-rate reverse rerun showed q0/q4 retransmits and `tx_errors` reproduce with equal-flow enforcement disabled. The drops are CoS queue/admission drops (`dbg_cos_queue_overflow` plus current-runtime `admission_flow_share_drops` / `admission_buffer_drops`), not shared-UMEM, AF_XDP TX-ring, or equal-flow suppression failures. The old summary collapsed those into one scary `TX errors` line.

Round-1 review correctly caught that per-queue CoS reason counters are reset on CoS config changes, while `tx_errors` is binding-lifetime state. The residual now subtracts binding-lifetime `dbg_cos_queue_overflow`, and the current runtime counters are reported only as the active-epoch reason split.

Round-2 review caught the remaining reset-time asymmetry: `reset_binding_cos_runtime` added queue-drain drops to `tx_errors` without mirroring the CoS subset. This branch now mirrors those reset-time queue drains into `dbg_cos_queue_overflow` and pins it with a Rust regression test.

Round-4 review correctly caught that the operator-facing `CoS queue overflow drops` label became too narrow once reset drains were included. The wire key stays historical for compatibility, but the CLI/docs now call the value `CoS queue drops lifetime`.

## Validation

- `go test -count=1 ./pkg/dataplane/userspace`
- `cargo test reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter` from `userspace-dp/`
- #1312 diagnostic rerun: `/tmp/xpf-1312-lowrate-20260515-120722`
  - equal-flow on q0/q4 reproduced admission drops and retransmits
  - equal-flow off q0/q4 reproduced the same shape, confirming equal-flow is not causal

Closes #1312? No. This closes the operator-attribution part; the remaining behavioral work is low-rate exact-shaper admission tuning.
