### PR TITLE
Show reverse CoS runtime by egress ifindex

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-15
 
+- **Timestamp**: 2026-05-15T23:00:00Z
+  - **Action**: Restored `go.mod` to pre-PR state after an unintended direct/indirect dependency classification flip during automation-only progress updates.
+  - **File(s)**: `go.mod`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-15T22:56:00Z
   - **Action**: Reverted unintended `go.mod` direct/indirect dependency reorder so round-1 fix remains scoped to CoS runtime lookup logic and tests.
   - **File(s)**: `go.mod`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,12 @@
 # Action Log
 
+## 2026-05-15
+
+- **Timestamp**: 2026-05-15T22:05:00Z
+  - **Action**: Issue #1278 — make `show class-of-service interface` join configured reverse-egress CoS interfaces to live runtime by configured name first and binding egress ifindex second, so alias drift between `ge-0-0-1.0` and the runtime snapshot no longer hides queue counters.
+  - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `docs/cos-validation-notes.md`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
+
 ## 2026-05-14
 
 - **Timestamp**: 2026-05-14T19:33:03Z

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-15
 
+- **Timestamp**: 2026-05-15T22:52:00Z
+  - **Action**: Round-1 follow-up cleanup — remove duplicate VLAN candidate append path in CoS runtime candidate generation while preserving VLAN-first ordering for unit-zero lookups.
+  - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-15T22:45:00Z
   - **Action**: Round-1 review hardening for issue #1278 — fix unit-zero candidate ordering so VLAN binding ifindex is preferred over parent binding when both exist, preventing wrong runtime CoS counters from being shown.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,13 @@
 
 ## 2026-05-15
 
+- **Timestamp**: 2026-05-15T22:45:00Z
+  - **Action**: Round-1 review hardening for issue #1278 — fix unit-zero candidate ordering so VLAN binding ifindex is preferred over parent binding when both exist, preventing wrong runtime CoS counters from being shown.
+  - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
+
+## 2026-05-15
+
 - **Timestamp**: 2026-05-15T22:05:00Z
   - **Action**: Issue #1278 — make `show class-of-service interface` join configured reverse-egress CoS interfaces to live runtime by configured name first and binding egress ifindex second, so alias drift between `ge-0-0-1.0` and the runtime snapshot no longer hides queue counters.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `docs/cos-validation-notes.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-15
 
+- **Timestamp**: 2026-05-15T22:56:00Z
+  - **Action**: Reverted unintended `go.mod` direct/indirect dependency reorder so round-1 fix remains scoped to CoS runtime lookup logic and tests.
+  - **File(s)**: `go.mod`, `_Log.md`
+  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-15T22:52:00Z
   - **Action**: Round-1 follow-up cleanup — remove duplicate VLAN candidate append path in CoS runtime candidate generation while preserving VLAN-first ordering for unit-zero lookups.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `_Log.md`

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -38,6 +38,13 @@ Zero-valued counters are still printed. That is deliberate: an operator
 needs to see the zero to confirm the counter is wired and the drop path
 simply is not firing, versus the telemetry being broken.
 
+The CLI joins configured CoS interfaces to live userspace runtime rows by
+configured name first, then by the binding egress ifindex. Reverse egress
+configs can display as a physical unit such as `ge-0-0-1.0` while the runtime
+snapshot carries a different alias for the same ifindex; the ifindex fallback
+keeps those reverse-path counters visible instead of reporting
+`Runtime: unavailable`.
+
 ### Reading them during an iperf3 run
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -27,7 +28,6 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167
 	github.com/mdlayher/ndp v1.1.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
@@ -28,6 +27,7 @@ require (
 	github.com/mdlayher/socket v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -507,13 +507,20 @@ func cosRuntimeCandidateNames(ifName, logicalName string, unitNum int, unit *con
 	}
 	add(logicalName)
 	add(config.LinuxIfName(logicalName))
+	hasVLANBindingName := unit != nil && unit.VlanID > 0
 	if unitNum == 0 {
+		if hasVLANBindingName {
+			vlanName := fmt.Sprintf("%s.%d", ifName, unit.VlanID)
+			add(vlanName)
+			add(config.LinuxIfName(vlanName))
+		}
 		add(ifName)
 		add(config.LinuxIfName(ifName))
 	}
-	if unit != nil && unit.VlanID > 0 {
-		add(fmt.Sprintf("%s.%d", ifName, unit.VlanID))
-		add(config.LinuxIfName(fmt.Sprintf("%s.%d", ifName, unit.VlanID)))
+	if hasVLANBindingName {
+		vlanName := fmt.Sprintf("%s.%d", ifName, unit.VlanID)
+		add(vlanName)
+		add(config.LinuxIfName(vlanName))
 	}
 	return names
 }

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -408,13 +408,7 @@ func bucketLowerBoundMicros(bucket int) string {
 }
 
 func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, selector string) []cosInterfaceView {
-	runtimeByName := make(map[string]*CoSInterfaceStatus)
-	if status != nil {
-		for i := range status.CoSInterfaces {
-			iface := &status.CoSInterfaces[i]
-			runtimeByName[iface.InterfaceName] = iface
-		}
-	}
+	runtimeIndex := buildCoSRuntimeIndex(status)
 	selector = strings.TrimSpace(selector)
 	views := make([]cosInterfaceView, 0)
 	for ifName, iface := range cfg.ClassOfService.Interfaces {
@@ -434,12 +428,94 @@ func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, sele
 				unit:           unitNum,
 				cosUnit:        cosUnit,
 				interfaceUnit:  interfaceUnit,
-				interfaceState: runtimeByName[logicalName],
+				interfaceState: runtimeIndex.lookup(ifName, logicalName, unitNum, interfaceUnit),
 			})
 		}
 	}
 	sort.Slice(views, func(i, j int) bool { return views[i].name < views[j].name })
 	return views
+}
+
+type cosRuntimeIndex struct {
+	byName               map[string]*CoSInterfaceStatus
+	byIfindex            map[int]*CoSInterfaceStatus
+	bindingIfindexByName map[string]int
+}
+
+func buildCoSRuntimeIndex(status *ProcessStatus) cosRuntimeIndex {
+	idx := cosRuntimeIndex{
+		byName:               make(map[string]*CoSInterfaceStatus),
+		byIfindex:            make(map[int]*CoSInterfaceStatus),
+		bindingIfindexByName: make(map[string]int),
+	}
+	if status == nil {
+		return idx
+	}
+	for i := range status.CoSInterfaces {
+		iface := &status.CoSInterfaces[i]
+		if iface.InterfaceName != "" {
+			idx.byName[iface.InterfaceName] = iface
+			idx.byName[config.LinuxIfName(iface.InterfaceName)] = iface
+		}
+		if iface.Ifindex > 0 {
+			idx.byIfindex[iface.Ifindex] = iface
+		}
+	}
+	for _, binding := range status.Bindings {
+		if binding.Interface == "" || binding.Ifindex <= 0 {
+			continue
+		}
+		idx.bindingIfindexByName[binding.Interface] = binding.Ifindex
+		idx.bindingIfindexByName[config.LinuxIfName(binding.Interface)] = binding.Ifindex
+	}
+	return idx
+}
+
+func (idx cosRuntimeIndex) lookup(ifName, logicalName string, unitNum int, unit *config.InterfaceUnit) *CoSInterfaceStatus {
+	candidates := cosRuntimeCandidateNames(ifName, logicalName, unitNum, unit)
+	for _, name := range candidates {
+		if runtime := idx.byName[name]; runtime != nil {
+			return runtime
+		}
+	}
+	// #1278: Rust CoS runtime and metrics are keyed by egress ifindex. A
+	// logical unit-zero CoS config can display as ge-0-0-1.0 while runtime
+	// labels the same ifindex with another snapshot alias, hiding the row
+	// from a name-only join.
+	for _, name := range candidates {
+		if ifindex := idx.bindingIfindexByName[name]; ifindex > 0 {
+			if runtime := idx.byIfindex[ifindex]; runtime != nil {
+				return runtime
+			}
+		}
+	}
+	return nil
+}
+
+func cosRuntimeCandidateNames(ifName, logicalName string, unitNum int, unit *config.InterfaceUnit) []string {
+	var names []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		for _, existing := range names {
+			if existing == name {
+				return
+			}
+		}
+		names = append(names, name)
+	}
+	add(logicalName)
+	add(config.LinuxIfName(logicalName))
+	if unitNum == 0 {
+		add(ifName)
+		add(config.LinuxIfName(ifName))
+	}
+	if unit != nil && unit.VlanID > 0 {
+		add(fmt.Sprintf("%s.%d", ifName, unit.VlanID))
+		add(config.LinuxIfName(fmt.Sprintf("%s.%d", ifName, unit.VlanID)))
+	}
+	return names
 }
 
 func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueView {

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -517,7 +517,7 @@ func cosRuntimeCandidateNames(ifName, logicalName string, unitNum int, unit *con
 		add(ifName)
 		add(config.LinuxIfName(ifName))
 	}
-	if hasVLANBindingName {
+	if unitNum != 0 && hasVLANBindingName {
 		vlanName := fmt.Sprintf("%s.%d", ifName, unit.VlanID)
 		add(vlanName)
 		add(config.LinuxIfName(vlanName))

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -128,6 +128,93 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 	}
 }
 
+func TestFormatCoSInterfaceSummaryJoinsUnitZeroRuntimeByIfindex(t *testing.T) {
+	owner := uint32(1)
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			ForwardingClasses: map[string]*config.CoSForwardingClass{
+				"iperf-b": {Name: "iperf-b", Queue: 5},
+			},
+			Schedulers: map[string]*config.CoSScheduler{
+				"iperf-b": {Name: "iperf-b", TransmitRateBytes: 1_250_000_000, TransmitRateExact: true},
+			},
+			SchedulerMaps: map[string]*config.CoSSchedulerMap{
+				"bandwidth-limit": {
+					Name: "bandwidth-limit",
+					Entries: map[string]*config.CoSSchedulerMapEntry{
+						"iperf-b": {ForwardingClass: "iperf-b", Scheduler: "iperf-b"},
+					},
+				},
+			},
+			Interfaces: map[string]*config.CoSInterface{
+				"ge-0-0-1": {
+					Name: "ge-0-0-1",
+					Units: map[int]*config.CoSInterfaceUnit{
+						0: {
+							Unit:             0,
+							ShapingRateBytes: 3_125_000_000,
+							SchedulerMap:     "bandwidth-limit",
+						},
+					},
+				},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0-0-1": {
+					Name: "ge-0-0-1",
+					Units: map[int]*config.InterfaceUnit{
+						0: {Number: 0, FilterOutputV4: "bandwidth-output-reverse"},
+					},
+				},
+			},
+		},
+	}
+	status := &ProcessStatus{
+		Bindings: []BindingStatus{
+			{Interface: "ge-0-0-1", Ifindex: 5, Bound: true},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{{
+			Ifindex:             5,
+			InterfaceName:       "reth0.80",
+			OwnerWorkerID:       &owner,
+			WorkerInstances:     6,
+			NonemptyQueues:      1,
+			RunnableQueues:      1,
+			TimerLevel0Sleepers: 2,
+			Queues: []CoSQueueStatus{{
+				QueueID:                 5,
+				OwnerWorkerID:           &owner,
+				ForwardingClass:         "iperf-b",
+				Priority:                5,
+				Exact:                   true,
+				TransmitRateBytes:       1_250_000_000,
+				BufferBytes:             64 * 1024,
+				QueuedPackets:           12,
+				AdmissionFlowShareDrops: 7,
+			}},
+		}},
+	}
+
+	out := FormatCoSInterfaceSummary(cfg, status, "ge-0-0-1.0")
+	for _, want := range []string{
+		"Interface: ge-0-0-1.0",
+		"Output filter (inet):     bandwidth-output-reverse",
+		"Owner worker:             1",
+		"Runtime workers:          6",
+		"Runtime queues:           nonempty=1 runnable=1",
+		"iperf-b",
+		"Drops: flow_share=7  buffer=0  ecn_marked=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Runtime:                  unavailable") {
+		t.Fatalf("runtime unexpectedly hidden for ge-0-0-1.0:\n%s", out)
+	}
+}
+
 // #915 (Copilot code-review #4): the per-queue formatter exposes
 // a new `Surplus sharing: yes/no` line under exact queues so
 // operators can see which exact queues have opted in. Pin both
@@ -142,9 +229,9 @@ func TestFormatCoSInterfaceSummaryRendersSurplusSharingLineOnExactQueues(t *test
 				"be":      {Name: "be", Queue: 0}, // non-exact, must NOT render line
 			},
 			Schedulers: map[string]*config.CoSScheduler{
-				"sa":   {Name: "sa", TransmitRateBytes: 125_000_000, TransmitRateExact: true, SurplusSharing: true},
-				"sb":   {Name: "sb", TransmitRateBytes: 1_250_000_000, TransmitRateExact: true, SurplusSharing: false},
-				"sbe":  {Name: "sbe", TransmitRateBytes: 12_500_000, TransmitRateExact: false, SurplusSharing: false},
+				"sa":  {Name: "sa", TransmitRateBytes: 125_000_000, TransmitRateExact: true, SurplusSharing: true},
+				"sb":  {Name: "sb", TransmitRateBytes: 1_250_000_000, TransmitRateExact: true, SurplusSharing: false},
+				"sbe": {Name: "sbe", TransmitRateBytes: 12_500_000, TransmitRateExact: false, SurplusSharing: false},
 			},
 			SchedulerMaps: map[string]*config.CoSSchedulerMap{
 				"m": {

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -215,6 +215,101 @@ func TestFormatCoSInterfaceSummaryJoinsUnitZeroRuntimeByIfindex(t *testing.T) {
 	}
 }
 
+func TestFormatCoSInterfaceSummaryPrefersVLANBindingIfindexForUnitZero(t *testing.T) {
+	parentOwner := uint32(3)
+	vlanOwner := uint32(9)
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			ForwardingClasses: map[string]*config.CoSForwardingClass{
+				"iperf-b": {Name: "iperf-b", Queue: 5},
+			},
+			Schedulers: map[string]*config.CoSScheduler{
+				"iperf-b": {Name: "iperf-b", TransmitRateBytes: 1_250_000_000, TransmitRateExact: true},
+			},
+			SchedulerMaps: map[string]*config.CoSSchedulerMap{
+				"bandwidth-limit": {
+					Name: "bandwidth-limit",
+					Entries: map[string]*config.CoSSchedulerMapEntry{
+						"iperf-b": {ForwardingClass: "iperf-b", Scheduler: "iperf-b"},
+					},
+				},
+			},
+			Interfaces: map[string]*config.CoSInterface{
+				"ge-0-0-1": {
+					Name: "ge-0-0-1",
+					Units: map[int]*config.CoSInterfaceUnit{
+						0: {
+							Unit:             0,
+							ShapingRateBytes: 3_125_000_000,
+							SchedulerMap:     "bandwidth-limit",
+						},
+					},
+				},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0-0-1": {
+					Name: "ge-0-0-1",
+					Units: map[int]*config.InterfaceUnit{
+						0: {Number: 0, VlanID: 80},
+					},
+				},
+			},
+		},
+	}
+	status := &ProcessStatus{
+		Bindings: []BindingStatus{
+			{Interface: "ge-0-0-1", Ifindex: 5, Bound: true},
+			{Interface: "ge-0-0-1.80", Ifindex: 10, Bound: true},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Ifindex:       5,
+				InterfaceName: "reth-parent",
+				OwnerWorkerID: &parentOwner,
+				Queues: []CoSQueueStatus{{
+					QueueID:              5,
+					OwnerWorkerID:        &parentOwner,
+					ForwardingClass:      "wrong-parent",
+					Priority:             5,
+					Exact:                true,
+					TransmitRateBytes:    100_000_000,
+					AdmissionBufferDrops: 99,
+				}},
+			},
+			{
+				Ifindex:       10,
+				InterfaceName: "reth-vlan",
+				OwnerWorkerID: &vlanOwner,
+				Queues: []CoSQueueStatus{{
+					QueueID:                 5,
+					OwnerWorkerID:           &vlanOwner,
+					ForwardingClass:         "iperf-b",
+					Priority:                5,
+					Exact:                   true,
+					TransmitRateBytes:       1_250_000_000,
+					AdmissionFlowShareDrops: 7,
+				}},
+			},
+		},
+	}
+
+	out := FormatCoSInterfaceSummary(cfg, status, "ge-0-0-1.0")
+	if !strings.Contains(out, "Owner worker:             9") {
+		t.Fatalf("expected VLAN binding runtime owner in output:\n%s", out)
+	}
+	if strings.Contains(out, "Owner worker:             3") {
+		t.Fatalf("unexpected parent-binding runtime selected:\n%s", out)
+	}
+	if !strings.Contains(out, "Drops: flow_share=7  buffer=0  ecn_marked=0") {
+		t.Fatalf("expected VLAN runtime queue counters in output:\n%s", out)
+	}
+	if strings.Contains(out, "Drops: flow_share=0  buffer=99  ecn_marked=0") {
+		t.Fatalf("unexpected parent runtime queue counters selected:\n%s", out)
+	}
+}
+
 // #915 (Copilot code-review #4): the per-queue formatter exposes
 // a new `Surplus sharing: yes/no` line under exact queues so
 // operators can see which exact queues have opted in. Pin both


### PR DESCRIPTION
## Summary

- make `show class-of-service interface` index live CoS runtime rows by both name and ifindex
- fall back from configured logical names such as `ge-0-0-1.0` to the binding egress ifindex when the runtime snapshot carries a different alias
- add regression coverage for the reverse-egress `ge-0-0-1.0` case where runtime counters were present but displayed as unavailable
- document the name-first / ifindex-second join behavior in the CoS validation notes

## Why

Issue #1278 showed the reverse egress runtime for `ge-0-0-1.0` was hidden in the CLI even though the userspace runtime had the queue state. The formatter was joining configured CoS interfaces to runtime rows only by interface name. Runtime and metrics are keyed by egress ifindex, so alias drift between configured display names and runtime labels can hide the row.

## Validation

- `go test -count=1 ./pkg/dataplane/userspace`
- `git diff --check`

Closes #1278.
