### PR TITLE
Skip idle CoS shaped drain calls

### DIFF
--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -53,6 +53,11 @@ mod.rs for further file-level breakdown.
 - Per-byte hot-path fns are `#[inline]` to preserve cross-module
   inlining across the `pub(in crate::afxdp)` boundary; the larger
   drain/settle bodies aren't inlined (LLVM heuristics suffice).
+- The TX drain caller enters `drain_shaped_tx` only while the binding
+  reports at least one nonempty CoS interface and has an interface order.
+  Configured-but-idle bindings skip the no-op shaped-drain call path
+  entirely; nonempty bindings still call into CoS so runnable work,
+  due parked queues, and shared lease epoch progress are preserved.
 - `drain_shaped_tx` primes an interface root only when queued work is
   runnable now or a parked queue's wake tick is due. Not-yet-due
   parked queues skip timer-wheel advance and shared-root lease top-up

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -101,7 +101,12 @@ pub(in crate::afxdp) fn drain_pending_tx(
     // Original #751 drain loop: service shaped queues until noop.
     // Each shaped drain attributes latency + invocations to the
     // specific queue via drain_shaped_tx's returned queue ref.
-    loop {
+    //
+    // #1318: skip the whole shaped-drain call path when this binding
+    // has no queued CoS work. `drain_shaped_tx` has its own defensive
+    // bail, but the caller would still pay monotonic_nanos(), one
+    // no-op call, and noop telemetry on every idle worker tick.
+    while should_enter_shaped_drain(binding) {
         let start_ns = monotonic_nanos();
         let serviced = drain_shaped_tx(binding, now_ns, shared_recycles);
         if let Some(serviced) = serviced.as_ref() {
@@ -163,7 +168,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
                 shared_recycles,
             );
             let mut serviced_in_inner = false;
-            loop {
+            while should_enter_shaped_drain(binding) {
                 let start_ns = monotonic_nanos();
                 let serviced = drain_shaped_tx(binding, now_ns, shared_recycles);
                 if let Some(serviced) = serviced.as_ref() {
@@ -488,6 +493,19 @@ fn binding_has_pending_tx_work(binding: &BindingWorker) -> bool {
         || !binding.tx_pipeline.pending_tx_local.is_empty()
         || !binding.live.pending_tx_empty()
         || binding.cos.cos_nonempty_interfaces > 0
+}
+
+#[inline]
+fn should_enter_shaped_drain(binding: &BindingWorker) -> bool {
+    has_queued_cos_work(
+        binding.cos.cos_nonempty_interfaces,
+        binding.cos.cos_interface_order.len(),
+    )
+}
+
+#[inline]
+fn has_queued_cos_work(cos_nonempty_interfaces: usize, cos_interface_order_len: usize) -> bool {
+    cos_nonempty_interfaces > 0 && cos_interface_order_len > 0
 }
 
 pub(in crate::afxdp) fn drain_pending_tx_local_owner(

--- a/userspace-dp/src/afxdp/tx/drain_tests.rs
+++ b/userspace-dp/src/afxdp/tx/drain_tests.rs
@@ -119,3 +119,27 @@ fn process_pending_queue_in_place_preserves_failed_item_order() {
 
     assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![2, 4]);
 }
+
+#[test]
+fn shaped_drain_entry_guard_skips_configured_idle_binding() {
+    assert!(
+        !has_queued_cos_work(0, 4),
+        "configured-but-idle bindings must not enter drain_shaped_tx"
+    );
+}
+
+#[test]
+fn shaped_drain_entry_guard_preserves_nonempty_service_path() {
+    assert!(
+        has_queued_cos_work(1, 4),
+        "queued CoS work must still enter drain_shaped_tx for service and lease progress"
+    );
+}
+
+#[test]
+fn shaped_drain_entry_guard_requires_interface_order() {
+    assert!(
+        !has_queued_cos_work(1, 0),
+        "bindings without an interface order cannot make shaped-drain progress"
+    );
+}


### PR DESCRIPTION
## Summary
- gate the TX caller's shaped-drain loops on queued CoS work before calling drain_shaped_tx
- keep nonempty bindings on the existing drain path so runnable queues, due parked queues, and shared lease epoch progress still run
- document the configured-idle behavior and add focused entry-guard tests

Fixes #1318

## Validation
- cargo test afxdp::tx::drain::tests::shaped_drain_entry_guard -- --nocapture
- cargo test afxdp::cos::queue_service::tests::drain_shaped_tx -- --nocapture
- git diff --check

Note: cargo fmt --check was run from userspace-dp and reports broad pre-existing formatting diffs outside this patch, so no package-wide format rewrite was applied.