### PR TITLE
Add issue 1321 validation contract gates

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -405,6 +405,75 @@ placement can be audited after the wrapper exits. The class sweep passes
 default) so back-to-back iperf runs do not reuse stale CoS active-flow
 buckets as current-run RSS evidence.
 
+## 100E100M and surplus give-back validation
+
+Issue #1321 adds two deployment-facing validation contracts on top of the
+Cstruct-relative fairness gate:
+
+1. **100E100M**: 100 elephant streams must keep useful aggregate
+   throughput while 100 mouse probes keep bounded tail latency and do not
+   starve.
+2. **Work-conserving surplus give-back**: a surplus-sharing borrower may
+   exceed its guarantee while peers are idle, but it must hand back that
+   surplus quickly when a peer demands its guarantee and reclaim it after
+   the peer goes idle.
+
+These are separate from equal-flow enforcement. Equal-flow enforcement is
+a non-work-conserving comparison mode for raw equality vs throughput loss;
+it is not proof that surplus-sharing is fair.
+
+The mouse-latency matrix reducer now accepts a configurable gate cell, so
+the same artifact format can express both the legacy #905 gate and the
+#1321 100E100M gate. The canonical 100E100M reduced run is:
+
+```bash
+MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
+MOUSE_LATENCY_GATE_ELEPHANTS=100 \
+MOUSE_LATENCY_GATE_MICE=100 \
+MOUSE_LATENCY_GATE_PERCENTILE=p99_us \
+./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
+```
+
+Run it once under the strict exact fixture and once after applying the
+surplus-sharing fixture. The reducer writes `summary.json` with the gate
+verdict, idle and loaded tail latency, ratio, selected percentile, and
+per-cell representative probe. Probe artifacts now include `rtt_us.p999`;
+the reducer carries that forward as `median_rep.p999_us` so p99.9 can be
+reported even when the hard gate remains p99. If p99.9 becomes a hard
+gate for a specific qualification run, set
+`MOUSE_LATENCY_GATE_PERCENTILE=p999_us`.
+
+Surplus give-back uses a reduced phase artifact instead of trying to
+infer phase semantics from unrelated per-class sweeps. The validator is:
+
+```bash
+./test/incus/fairness_surplus_giveback_validate.py \
+  --input /tmp/xpf-surplus-giveback/phases.json \
+  --out /tmp/xpf-surplus-giveback/verdict.json
+```
+
+The input artifact must contain `root_cap_mbps`,
+`peer_guarantee_mbps`, `handback_window_sec`, and four named phases:
+`borrow_alone`, `peer_demand`, `peer_steady`, and
+`peer_idle_reclaim`. Each phase records `throughput_mbps.borrower` and
+`throughput_mbps.peer`; `peer_steady` may also record
+`cos_admission_drops.peer`. The default gates are:
+
+- peer steady throughput reaches at least 95% of its guarantee
+- handback window is at most 5 seconds
+- borrower throughput during peer steady demand falls to at most 90% of
+  borrower-alone throughput
+- borrower reclaim throughput is at least 110% of its peer-steady
+  throughput
+- root cap is not exceeded by more than 2%
+- peer steady CoS admission drops are zero by default
+
+The phase artifact is the handoff between live traffic runners and the
+contract gate. A live runner can populate it from iperf JSON, Prometheus,
+or dataplane status snapshots, but the pass/fail semantics are
+centralized in the reducer so future harness changes do not silently
+drift the contract.
+
 For the symmetric reverse fixture on the loss cluster, `COS_IFINDEX=5`
 selects the `ge-0-0-1` egress. For forward-path sweeps, do not hardcode
 the RETH unit's displayed name into the harness; use the ifindex emitted

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -82,6 +82,29 @@ the cluster produced. **No scheduler bug; structurally skew-bound
 under that input.** Any fairness mechanism must be evaluated against
 this gate, not against an unconditional CoV target.
 
+### Issue #1321 — 100E100M plus surplus give-back validation contract (2026-05-15)
+
+The next validation surface is deployment-facing rather than a new
+dataplane mechanism. The contract keeps equal-flow enforcement separate
+from work-conserving surplus-sharing:
+
+- 100E100M runs use the existing mouse-latency artifact reducer with
+  configurable gate cells (`MOUSE_LATENCY_GATE_ELEPHANTS=100`,
+  `MOUSE_LATENCY_GATE_MICE=100`) and now preserve p99.9 as
+  `median_rep.p999_us`.
+- Surplus give-back runs reduce live traffic evidence into a four-phase
+  artifact (`borrow_alone`, `peer_demand`, `peer_steady`,
+  `peer_idle_reclaim`) validated by
+  `test/incus/fairness_surplus_giveback_validate.py`.
+- The default give-back gates require the peer to reach 95% of guarantee
+  within a 5 s handback window, no steady peer CoS admission drops,
+  borrower decrease while the peer demands service, borrower reclaim
+  after peer idle, and root-cap respect.
+
+This lane intentionally does not touch the dataplane hot path. It makes
+future exact, surplus-sharing, and optional equal-flow comparison runs
+produce comparable artifacts with explicit pass/fail semantics.
+
 ## Killed designs
 
 Two categories. **Mechanisms** (in-dataplane scheduler / steering /

--- a/docs/pr/1321-validation-contract/plan.md
+++ b/docs/pr/1321-validation-contract/plan.md
@@ -1,0 +1,108 @@
+# Issue #1321 Validation Contract
+
+Status: implemented narrow slice on branch `codex/1321-validation-contract`.
+
+## Goal
+
+Advance issue #1321 without changing dataplane scheduling behavior. The
+useful slice is a stable validation surface for:
+
+- 100 elephant + 100 mouse artifacts under strict exact and
+  surplus-sharing modes.
+- work-conserving surplus borrow/give-back phase artifacts.
+- explicit separation between surplus-sharing and equal-flow comparison.
+
+## Design decisions
+
+1. Reuse the mouse-latency matrix artifact format instead of adding a
+   second 100E100M reducer. The matrix runner now accepts env-configured
+   cells and gate parameters, so `/tmp/.../cell_N100_M100` and
+   `/tmp/.../cell_N0_M100` are enough for the 100E100M gate.
+2. Preserve p99.9 in probe and aggregate artifacts as `p999` /
+   `p999_us`. The default hard gate remains p99 for compatibility; runs
+   that need p99.9 as the hard gate can set
+   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`.
+3. Validate surplus give-back from a reduced phase JSON artifact. The
+   first live runner can be shell, Python, or an operator-curated
+   reducer, but pass/fail semantics are centralized in
+   `fairness_surplus_giveback_validate.py`.
+4. Do not alter dataplane hot path or scheduler behavior in this lane.
+   Issue #1321 is a validation contract until live artifacts prove a
+   concrete implementation defect.
+
+## 100E100M commands
+
+Strict exact fixture:
+
+```bash
+./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
+MOUSE_LATENCY_GATE_ELEPHANTS=100 \
+MOUSE_LATENCY_GATE_MICE=100 \
+./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
+```
+
+Surplus-sharing fixture:
+
+```bash
+./test/incus/apply-cos-config.sh --surplus-sharing loss:xpf-userspace-fw0
+MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
+MOUSE_LATENCY_GATE_ELEPHANTS=100 \
+MOUSE_LATENCY_GATE_MICE=100 \
+./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-surplus
+./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+```
+
+If p99.9 is promoted from reported evidence to the hard gate for a run,
+add:
+
+```bash
+MOUSE_LATENCY_GATE_PERCENTILE=p999_us
+```
+
+## Surplus Give-Back Artifact
+
+Minimum artifact:
+
+```json
+{
+  "root_cap_mbps": 25000,
+  "peer_guarantee_mbps": 10000,
+  "handback_window_sec": 3.2,
+  "phases": [
+    {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
+    {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
+    {
+      "name": "peer_steady",
+      "throughput_mbps": {"borrower": 9000, "peer": 9800},
+      "cos_admission_drops": {"peer": 0}
+    },
+    {"name": "peer_idle_reclaim", "throughput_mbps": {"borrower": 17000, "peer": 0}}
+  ]
+}
+```
+
+Validation:
+
+```bash
+./test/incus/fairness_surplus_giveback_validate.py \
+  --input /tmp/xpf-surplus-giveback/phases.json \
+  --out /tmp/xpf-surplus-giveback/verdict.json
+```
+
+The validator exits `0` for PASS, `1` for contract FAIL, and `2` for
+malformed artifact or infrastructure misuse.
+
+## Focused Validation
+
+```bash
+python3 -m py_compile \
+  test/incus/mouse_latency_probe.py \
+  test/incus/mouse_latency_aggregate.py \
+  test/incus/fairness_surplus_giveback_validate.py
+
+(cd test/incus && python3 -m unittest \
+  mouse_latency_probe_test.py \
+  mouse_latency_aggregate_test.py \
+  fairness_surplus_giveback_validate_test.py)
+```

--- a/docs/pr/README.md
+++ b/docs/pr/README.md
@@ -21,6 +21,7 @@ specs (those live at the repo root `docs/` level).
 | `804-instrumentation/`       | Per-binding ring-pressure counters (PR #804)                 | merged `3d2d63a4`     |
 | `807-refactor/`              | Docs refactor into this dir structure (PR #807)              | merged `61ff77c5`     |
 | `1316-lowrate-cos-buffers/`  | #1312/#1316 low-rate exact CoS buffer sizing measurements    | PR #1316              |
+| `1321-validation-contract/`  | #1321 100E100M and surplus give-back validation contract     | PR branch             |
 | `line-rate-investigation/`   | Parent investigation (#798) plan + phase-B step 0 + gaps doc + 8-matrix findings | #798 open |
 
 ## Conventions

--- a/test/incus/fairness_surplus_giveback_validate.py
+++ b/test/incus/fairness_surplus_giveback_validate.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate issue #1321 surplus borrow/give-back phase artifacts.
+
+Input is a JSON artifact with four named phases:
+
+{
+  "root_cap_mbps": 25000,
+  "peer_guarantee_mbps": 10000,
+  "handback_window_sec": 3.2,
+  "phases": [
+    {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
+    {"name": "peer_demand", "throughput_mbps": {"borrower": 17000, "peer": 4000}},
+    {"name": "peer_steady", "throughput_mbps": {"borrower": 9000, "peer": 9800},
+     "cos_admission_drops": {"peer": 0}},
+    {"name": "peer_idle_reclaim", "throughput_mbps": {"borrower": 17800, "peer": 0}}
+  ]
+}
+
+The script deliberately validates reduced artifacts only. It does not run
+traffic; shell harnesses can feed it summaries from iperf, dataplane status,
+or Prometheus as those live runners evolve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Any
+
+
+REQUIRED_PHASES = ("borrow_alone", "peer_demand", "peer_steady", "peer_idle_reclaim")
+
+
+def _finite_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    out = float(value)
+    if not math.isfinite(out):
+        raise ValueError(f"{field} must be finite")
+    return out
+
+
+def _nonnegative_number(value: Any, field: str) -> float:
+    out = _finite_number(value, field)
+    if out < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return out
+
+
+def _phase_map(artifact: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    phases = artifact.get("phases")
+    if not isinstance(phases, list):
+        raise ValueError("phases must be a list")
+    out: dict[str, dict[str, Any]] = {}
+    for index, phase in enumerate(phases):
+        if not isinstance(phase, dict):
+            raise ValueError(f"phases[{index}] must be an object")
+        name = phase.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"phases[{index}].name must be a non-empty string")
+        if name in out:
+            raise ValueError(f"duplicate phase name: {name}")
+        out[name] = phase
+    missing = [name for name in REQUIRED_PHASES if name not in out]
+    if missing:
+        raise ValueError(f"missing required phase(s): {', '.join(missing)}")
+    return out
+
+
+def _throughput(phase: dict[str, Any], role: str) -> float:
+    throughputs = phase.get("throughput_mbps")
+    if not isinstance(throughputs, dict):
+        raise ValueError(f"phase {phase.get('name')}: throughput_mbps must be an object")
+    return _nonnegative_number(throughputs.get(role), f"phase {phase.get('name')}: throughput_mbps.{role}")
+
+
+def _drops(phase: dict[str, Any], role: str) -> float:
+    drops = phase.get("cos_admission_drops", {})
+    if drops is None:
+        return 0.0
+    if not isinstance(drops, dict):
+        raise ValueError(f"phase {phase.get('name')}: cos_admission_drops must be an object")
+    return _nonnegative_number(drops.get(role, 0), f"phase {phase.get('name')}: cos_admission_drops.{role}")
+
+
+def validate(
+    artifact: dict[str, Any],
+    *,
+    min_peer_guarantee_ratio: float,
+    max_handback_sec: float,
+    max_borrower_demand_ratio: float,
+    min_reclaim_ratio: float,
+    root_cap_tolerance_ratio: float,
+    max_peer_steady_drops: float,
+) -> dict[str, Any]:
+    phases = _phase_map(artifact)
+    root_cap = _nonnegative_number(artifact.get("root_cap_mbps"), "root_cap_mbps")
+    peer_guarantee = _nonnegative_number(artifact.get("peer_guarantee_mbps"), "peer_guarantee_mbps")
+    handback = _nonnegative_number(artifact.get("handback_window_sec"), "handback_window_sec")
+
+    borrow_alone = phases["borrow_alone"]
+    peer_demand = phases["peer_demand"]
+    peer_steady = phases["peer_steady"]
+    reclaim = phases["peer_idle_reclaim"]
+
+    borrow_alone_bps = _throughput(borrow_alone, "borrower")
+    peer_demand_peer = _throughput(peer_demand, "peer")
+    steady_borrower = _throughput(peer_steady, "borrower")
+    steady_peer = _throughput(peer_steady, "peer")
+    reclaim_borrower = _throughput(reclaim, "borrower")
+    steady_peer_drops = _drops(peer_steady, "peer")
+
+    failures: list[str] = []
+    if steady_peer < peer_guarantee * min_peer_guarantee_ratio:
+        failures.append(
+            f"peer steady throughput {steady_peer:.3f} Mbps below "
+            f"{min_peer_guarantee_ratio:.3f} * guarantee {peer_guarantee:.3f} Mbps"
+        )
+    if handback > max_handback_sec:
+        failures.append(
+            f"handback window {handback:.3f}s exceeds {max_handback_sec:.3f}s"
+        )
+    if steady_borrower > borrow_alone_bps * max_borrower_demand_ratio:
+        failures.append(
+            f"borrower did not give back surplus: steady {steady_borrower:.3f} Mbps "
+            f"> {max_borrower_demand_ratio:.3f} * alone {borrow_alone_bps:.3f} Mbps"
+        )
+    if reclaim_borrower < steady_borrower * min_reclaim_ratio:
+        failures.append(
+            f"borrower did not reclaim surplus: reclaim {reclaim_borrower:.3f} Mbps "
+            f"< {min_reclaim_ratio:.3f} * steady {steady_borrower:.3f} Mbps"
+        )
+    if steady_peer_drops > max_peer_steady_drops:
+        failures.append(
+            f"peer steady CoS admission drops {steady_peer_drops:.0f} exceed "
+            f"{max_peer_steady_drops:.0f}"
+        )
+
+    cap_limit = root_cap * (1.0 + root_cap_tolerance_ratio)
+    phase_totals: dict[str, float] = {}
+    for name in REQUIRED_PHASES:
+        total = _throughput(phases[name], "borrower") + _throughput(phases[name], "peer")
+        phase_totals[name] = total
+        if total > cap_limit:
+            failures.append(
+                f"phase {name} total {total:.3f} Mbps exceeds root cap "
+                f"{root_cap:.3f} Mbps with tolerance {root_cap_tolerance_ratio:.3f}"
+            )
+
+    return {
+        "verdict": "PASS" if not failures else "FAIL",
+        "failure_reasons": failures,
+        "thresholds": {
+            "min_peer_guarantee_ratio": min_peer_guarantee_ratio,
+            "max_handback_sec": max_handback_sec,
+            "max_borrower_demand_ratio": max_borrower_demand_ratio,
+            "min_reclaim_ratio": min_reclaim_ratio,
+            "root_cap_tolerance_ratio": root_cap_tolerance_ratio,
+            "max_peer_steady_drops": max_peer_steady_drops,
+        },
+        "metrics": {
+            "borrow_alone_borrower_mbps": borrow_alone_bps,
+            "peer_demand_peer_mbps": peer_demand_peer,
+            "peer_steady_borrower_mbps": steady_borrower,
+            "peer_steady_peer_mbps": steady_peer,
+            "peer_idle_reclaim_borrower_mbps": reclaim_borrower,
+            "peer_steady_drops": steady_peer_drops,
+            "handback_window_sec": handback,
+            "phase_total_mbps": phase_totals,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--min-peer-guarantee-ratio", type=float, default=0.95)
+    parser.add_argument("--max-handback-sec", type=float, default=5.0)
+    parser.add_argument("--max-borrower-demand-ratio", type=float, default=0.90)
+    parser.add_argument("--min-reclaim-ratio", type=float, default=1.10)
+    parser.add_argument("--root-cap-tolerance-ratio", type=float, default=0.02)
+    parser.add_argument("--max-peer-steady-drops", type=float, default=0.0)
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        artifact = json.load(f)
+    verdict = validate(
+        artifact,
+        min_peer_guarantee_ratio=args.min_peer_guarantee_ratio,
+        max_handback_sec=args.max_handback_sec,
+        max_borrower_demand_ratio=args.max_borrower_demand_ratio,
+        min_reclaim_ratio=args.min_reclaim_ratio,
+        root_cap_tolerance_ratio=args.root_cap_tolerance_ratio,
+        max_peer_steady_drops=args.max_peer_steady_drops,
+    )
+    with open(args.out, "w") as f:
+        json.dump(verdict, f, indent=2, sort_keys=True)
+    return 0 if verdict["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ValueError as exc:
+        print(f"fairness_surplus_giveback_validate: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/test/incus/fairness_surplus_giveback_validate_test.py
+++ b/test/incus/fairness_surplus_giveback_validate_test.py
@@ -1,0 +1,65 @@
+import unittest
+
+from fairness_surplus_giveback_validate import validate
+
+
+def _artifact(**overrides):
+    base = {
+        "root_cap_mbps": 25000,
+        "peer_guarantee_mbps": 10000,
+        "handback_window_sec": 3.0,
+        "phases": [
+            {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
+            {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
+            {
+                "name": "peer_steady",
+                "throughput_mbps": {"borrower": 9000, "peer": 9800},
+                "cos_admission_drops": {"peer": 0},
+            },
+            {"name": "peer_idle_reclaim", "throughput_mbps": {"borrower": 17000, "peer": 0}},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _validate(artifact):
+    return validate(
+        artifact,
+        min_peer_guarantee_ratio=0.95,
+        max_handback_sec=5.0,
+        max_borrower_demand_ratio=0.90,
+        min_reclaim_ratio=1.10,
+        root_cap_tolerance_ratio=0.02,
+        max_peer_steady_drops=0,
+    )
+
+
+class SurplusGivebackValidateTests(unittest.TestCase):
+    def test_passes_contract(self):
+        verdict = _validate(_artifact())
+        self.assertEqual(verdict["verdict"], "PASS")
+        self.assertEqual(verdict["failure_reasons"], [])
+
+    def test_fails_peer_below_guarantee(self):
+        artifact = _artifact()
+        artifact["phases"][2]["throughput_mbps"]["peer"] = 9400
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("below" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_slow_handback(self):
+        verdict = _validate(_artifact(handback_window_sec=6.5))
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("handback" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_root_cap_overshoot(self):
+        artifact = _artifact()
+        artifact["phases"][1]["throughput_mbps"] = {"borrower": 23000, "peer": 4000}
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("root cap" in r for r in verdict["failure_reasons"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -7,8 +7,13 @@ For each cell, the median rep (by p99) of the valid reps is selected
 as the representative; its p50/p95/p99 + IQR-of-p99-across-reps +
 achieved-RPS summary populate summary.json.
 
-Decision threshold (#905, plan §7.2):
+Default decision threshold (#905, plan §7.2):
 - p99(N=128, M=10, best-effort) ≤ 2 × p99(N=0, M=10, best-effort)
+
+Issue #1321 can reuse the same artifact reducer for 100E100M by passing
+`--gate-elephants 100 --gate-mice 100`. The reducer records p99.9 when
+probe artifacts include it, but the default hard gate remains p99 unless
+the caller explicitly changes `--gate-percentile`.
 
 The harness only runs best-effort, so cells are keyed by (N, M).
 """
@@ -120,6 +125,7 @@ def summarize_cell(reps: List[dict]) -> dict:
             "p50_us": rtt.get("p50"),
             "p95_us": rtt.get("p95"),
             "p99_us": rtt.get("p99"),
+            "p999_us": rtt.get("p999"),
             "achieved_rps_total": totals.get("achieved_rps_total"),
             # R2 fresh MED 1: propagate per-coroutine attempt-rate
             # distribution to the summary so the diagnosis surface
@@ -136,12 +142,25 @@ def summarize_cell(reps: List[dict]) -> dict:
     return summary
 
 
-def decide(summaries: Dict[CellKey, dict]) -> dict:
-    """Compute the decision-threshold verdict per #905 plan §7.2."""
-    gate_loaded = summaries.get((128, 10))
-    gate_idle = summaries.get((0, 10))
+def decide(
+    summaries: Dict[CellKey, dict],
+    *,
+    gate_elephants: int = 128,
+    gate_mice: int = 10,
+    threshold_ratio: float = 2.0,
+    gate_percentile: str = "p99_us",
+) -> dict:
+    """Compute the mouse-latency gate verdict for the requested cell."""
+    gate_loaded = summaries.get((gate_elephants, gate_mice))
+    gate_idle = summaries.get((0, gate_mice))
     if gate_loaded is None or gate_idle is None:
-        return {"verdict": "INSUFFICIENT-DATA", "reason": "missing gate cell"}
+        return {
+            "verdict": "INSUFFICIENT-DATA",
+            "reason": (
+                f"missing gate cell: loaded=N{gate_elephants}_M{gate_mice}, "
+                f"idle=N0_M{gate_mice}"
+            ),
+        }
     if gate_loaded.get("status") != "OK" or gate_idle.get("status") != "OK":
         return {
             "verdict": "INSUFFICIENT-DATA",
@@ -150,18 +169,25 @@ def decide(summaries: Dict[CellKey, dict]) -> dict:
                 f"idle={gate_idle.get('status')}"
             ),
         }
-    p99_loaded = (gate_loaded.get("median_rep") or {}).get("p99_us")
-    p99_idle = (gate_idle.get("median_rep") or {}).get("p99_us")
-    if p99_loaded is None or p99_idle is None or p99_idle == 0:
-        return {"verdict": "INSUFFICIENT-DATA", "reason": "missing p99 in gate cell"}
-    ratio = p99_loaded / p99_idle
+    loaded_value = (gate_loaded.get("median_rep") or {}).get(gate_percentile)
+    idle_value = (gate_idle.get("median_rep") or {}).get(gate_percentile)
+    if loaded_value is None or idle_value is None or idle_value == 0:
+        return {
+            "verdict": "INSUFFICIENT-DATA",
+            "reason": f"missing {gate_percentile} in gate cell",
+        }
+    ratio = loaded_value / idle_value
     return {
-        "verdict": "PASS" if ratio <= 2.0 else "FAIL",
+        "verdict": "PASS" if ratio <= threshold_ratio else "FAIL",
         "ratio": ratio,
-        "p99_idle_us": p99_idle,
-        "p99_loaded_us": p99_loaded,
-        "threshold": 2.0,
-        "gate": "p99(N=128, M=10) <= 2 * p99(N=0, M=10)",
+        "idle_us": idle_value,
+        "loaded_us": loaded_value,
+        "threshold": threshold_ratio,
+        "percentile": gate_percentile,
+        "gate": (
+            f"{gate_percentile}(N={gate_elephants}, M={gate_mice}) <= "
+            f"{threshold_ratio:g} * {gate_percentile}(N=0, M={gate_mice})"
+        ),
     }
 
 
@@ -186,8 +212,8 @@ def discover_cells(root: str) -> Dict[CellKey, List[dict]]:
 
 def render_markdown(summaries: Dict[CellKey, dict], verdict: dict) -> str:
     lines: List[str] = []
-    lines.append("| N elephants | M mice | reps (valid/total) | p50 µs | p95 µs | p99 µs | RPS | status |")
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("| N elephants | M mice | reps (valid/total) | p50 us | p95 us | p99 us | p99.9 us | RPS | status |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     for key in sorted(summaries.keys()):
         n, m = key
         s = summaries[key]
@@ -197,6 +223,7 @@ def render_markdown(summaries: Dict[CellKey, dict], verdict: dict) -> str:
             f"| {median.get('p50_us', '-')} "
             f"| {median.get('p95_us', '-')} "
             f"| {median.get('p99_us', '-')} "
+            f"| {median.get('p999_us', '-')} "
             f"| {median.get('achieved_rps_total', '-')} "
             f"| {s.get('status', '-')} |"
         )
@@ -205,8 +232,8 @@ def render_markdown(summaries: Dict[CellKey, dict], verdict: dict) -> str:
     if "ratio" in verdict:
         lines.append(
             f"  ratio = {verdict['ratio']:.2f} "
-            f"(p99 loaded {verdict['p99_loaded_us']} µs / "
-            f"p99 idle {verdict['p99_idle_us']} µs); "
+            f"({verdict.get('percentile', 'p99_us')} loaded {verdict['loaded_us']} us / "
+            f"idle {verdict['idle_us']} us); "
             f"threshold ≤ {verdict['threshold']}"
         )
     elif "reason" in verdict:
@@ -218,11 +245,25 @@ def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--root", required=True)
     p.add_argument("--out", required=True)
+    p.add_argument("--gate-elephants", type=int, default=128)
+    p.add_argument("--gate-mice", type=int, default=10)
+    p.add_argument("--threshold-ratio", type=float, default=2.0)
+    p.add_argument(
+        "--gate-percentile",
+        choices=("p50_us", "p95_us", "p99_us", "p999_us"),
+        default="p99_us",
+    )
     args = p.parse_args()
 
     cells = discover_cells(args.root)
     summaries = {key: summarize_cell(reps) for key, reps in cells.items()}
-    verdict = decide(summaries)
+    verdict = decide(
+        summaries,
+        gate_elephants=args.gate_elephants,
+        gate_mice=args.gate_mice,
+        threshold_ratio=args.threshold_ratio,
+        gate_percentile=args.gate_percentile,
+    )
 
     with open(args.out, "w") as f:
         json.dump(

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -15,7 +15,7 @@ from mouse_latency_aggregate import (
 
 def _make_rep(p99: int, ok: bool = True, p50: int = 100, p95: int = 500, rps: float = 200.0) -> dict:
     return {
-        "rtt_us": {"p50": p50, "p95": p95, "p99": p99},
+        "rtt_us": {"p50": p50, "p95": p95, "p99": p99, "p999": p99 + 10},
         "totals": {"achieved_rps_total": rps, "attempts_per_coroutine": [600] * 10},
         "validity": {"ok": ok, "reasons": []},
     }
@@ -91,6 +91,29 @@ class DecideTests(unittest.TestCase):
         summaries = self._gate_summaries(100, 150)
         v = decide(summaries)
         self.assertEqual(v["verdict"], "PASS")
+
+    def test_custom_100e100m_gate_uses_requested_cell(self):
+        idle = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        loaded = summarize_cell([_make_rep(p99=190) for _ in range(10)])
+        summaries = {(0, 100): idle, (100, 100): loaded}
+        v = decide(summaries, gate_elephants=100, gate_mice=100)
+        self.assertEqual(v["verdict"], "PASS")
+        self.assertIn("N=100, M=100", v["gate"])
+
+    def test_custom_gate_percentile(self):
+        idle = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        loaded = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        # p999 is p99+10 from _make_rep, so the ratio is 210/110.
+        loaded["median_rep"]["p999_us"] = 210
+        summaries = {(0, 100): idle, (100, 100): loaded}
+        v = decide(
+            summaries,
+            gate_elephants=100,
+            gate_mice=100,
+            gate_percentile="p999_us",
+            threshold_ratio=1.5,
+        )
+        self.assertEqual(v["verdict"], "FAIL")
 
     def test_missing_gate_cell(self):
         v = decide({(0, 10): summarize_cell([_make_rep(100)] * 10)})

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -114,31 +114,35 @@ def _compute_histogram(rtts_us: List[int]) -> List[int]:
 
 
 def _compute_percentiles(rtts_us: List[int]) -> dict:
-    """Compute p50/p95/p99 + IQR via stdlib `statistics.quantiles`.
+    """Compute p50/p95/p99/p99.9 + IQR via stdlib `statistics.quantiles`.
 
     R1 MED 3: the plan calls for `statistics.quantiles` output, so
     the implementation and the unit tests share an estimator. With
     n=100 cut points (method="inclusive") we get p50=q[49], p95=q[94],
     p99=q[98] (the 99 cut points between 100 quantiles, zero-indexed).
+    Issue #1321's 100E100M contract also needs p99.9, computed the
+    same way with n=1000 and q[998].
     """
     if not rtts_us:
         return {
-            "p50": None, "p95": None, "p99": None,
+            "p50": None, "p95": None, "p99": None, "p999": None,
             "min": None, "max": None, "mean": None, "iqr": None,
         }
     s = sorted(rtts_us)
     if len(s) < 2:
         v = s[0]
         return {
-            "p50": v, "p95": v, "p99": v,
+            "p50": v, "p95": v, "p99": v, "p999": v,
             "min": v, "max": v, "mean": v, "iqr": 0,
         }
     cuts_100 = statistics.quantiles(s, n=100, method="inclusive")
+    cuts_1000 = statistics.quantiles(s, n=1000, method="inclusive")
     cuts_4 = statistics.quantiles(s, n=4, method="inclusive")
     return {
         "p50": int(round(cuts_100[49])),
         "p95": int(round(cuts_100[94])),
         "p99": int(round(cuts_100[98])),
+        "p999": int(round(cuts_1000[998])),
         "min": s[0],
         "max": s[-1],
         "mean": int(statistics.fmean(s)),

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -46,10 +46,12 @@ class PercentileTests(unittest.TestCase):
         rtts = list(range(1, 1001))  # 1..1000
         p = _compute_percentiles(rtts)
         cuts100 = statistics.quantiles(rtts, n=100, method="inclusive")
+        cuts1000 = statistics.quantiles(rtts, n=1000, method="inclusive")
         cuts4 = statistics.quantiles(rtts, n=4, method="inclusive")
         self.assertEqual(p["p50"], int(round(cuts100[49])))
         self.assertEqual(p["p95"], int(round(cuts100[94])))
         self.assertEqual(p["p99"], int(round(cuts100[98])))
+        self.assertEqual(p["p999"], int(round(cuts1000[998])))
         self.assertEqual(p["min"], 1)
         self.assertEqual(p["max"], 1000)
         self.assertEqual(p["iqr"], int(round(cuts4[2] - cuts4[0])))
@@ -57,6 +59,7 @@ class PercentileTests(unittest.TestCase):
     def test_empty(self):
         p = _compute_percentiles([])
         self.assertIsNone(p["p99"])
+        self.assertIsNone(p["p999"])
         self.assertIsNone(p["p50"])
         self.assertIsNone(p["min"])
 
@@ -64,6 +67,7 @@ class PercentileTests(unittest.TestCase):
         p = _compute_percentiles([42])
         self.assertEqual(p["p50"], 42)
         self.assertEqual(p["p99"], 42)
+        self.assertEqual(p["p999"], 42)
         self.assertEqual(p["iqr"], 0)
 
 

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -50,27 +50,16 @@ flock -n 9 || {
 
 OUT_ROOT="$1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DURATION=60          # per-rep probe seconds
+DURATION=${MOUSE_LATENCY_DURATION:-60} # per-rep probe seconds
 WALL_CAP=$((6*3600)) # seconds, plan §4.7
 
 mkdir -p "$OUT_ROOT"
 
 # Prioritized cell order: gate cells first, then remaining M=10 cells,
 # then everything else.
-CELLS=(
-    "0 10"
-    "128 10"
-    "8 10"
-    "32 10"
-    "0 1"
-    "8 1"
-    "32 1"
-    "128 1"
-    "0 50"
-    "8 50"
-    "32 50"
-    "128 50"
-)
+DEFAULT_CELLS=$'0 10\n128 10\n8 10\n32 10\n0 1\n8 1\n32 1\n128 1\n0 50\n8 50\n32 50\n128 50'
+CELLS_RAW=${MOUSE_LATENCY_CELLS:-$DEFAULT_CELLS}
+mapfile -t CELLS < <(printf '%s\n' "$CELLS_RAW" | sed '/^[[:space:]]*$/d')
 
 start_t=$(date +%s)
 
@@ -214,4 +203,8 @@ done
 echo "Matrix complete; running aggregator..."
 python3 "${SCRIPT_DIR}/mouse_latency_aggregate.py" \
     --root "$OUT_ROOT" \
-    --out "${OUT_ROOT}/summary.json"
+    --out "${OUT_ROOT}/summary.json" \
+    --gate-elephants "${MOUSE_LATENCY_GATE_ELEPHANTS:-128}" \
+    --gate-mice "${MOUSE_LATENCY_GATE_MICE:-10}" \
+    --threshold-ratio "${MOUSE_LATENCY_GATE_THRESHOLD_RATIO:-2.0}" \
+    --gate-percentile "${MOUSE_LATENCY_GATE_PERCENTILE:-p99_us}"


### PR DESCRIPTION
## Summary

- make the mouse-latency matrix configurable for the #1321 100E100M gate and preserve p99.9 in probe/aggregate artifacts
- add a reduced-artifact surplus borrow/give-back validator with unit coverage
- document the validation contract and PR-scoped run notes without touching the dataplane hot path

## Validation

- python3 -m py_compile test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py test/incus/fairness_surplus_giveback_validate.py
- (cd test/incus && python3 -m unittest mouse_latency_probe_test.py mouse_latency_aggregate_test.py fairness_surplus_giveback_validate_test.py)
- bash -n test/incus/test-mouse-latency-matrix.sh
- CLI smoke: test/incus/fairness_surplus_giveback_validate.py --input <tmp>/phases.json --out <tmp>/verdict.json

Closes #1321