### PR TITLE
Fix post-merge validation contract gaps

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -469,6 +469,9 @@ default gates are:
 
 - borrower-alone throughput exceeds 105% of the borrower guarantee
 - peer-demand throughput is non-zero (at least 1% of the peer guarantee)
+  as a liveness proxy; this phase proves the artifact is not decorative,
+  while `peer_steady` and handback evidence enforce actual guarantee
+  service
 - peer steady throughput reaches at least 95% of its guarantee
 - handback window is at most 5 seconds
 - borrower throughput during peer steady demand falls to at most 90% of

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -462,10 +462,10 @@ phases: `borrow_alone`, `peer_demand`, `peer_steady`, and
 `peer_idle_reclaim`. Each phase records `throughput_mbps.borrower` and
 `throughput_mbps.peer`; `peer_steady` may also record
 `cos_admission_drops.peer`. Handback evidence is either
-`handback_samples` with time-domain throughput samples, or
-`handback_evidence: {"source": "transition_observed", "observed": true}`
-when another runner has already measured the transition window. The
-default gates are:
+`handback_samples` with time-domain throughput samples. Scalar
+`handback_window_sec` values and self-attested handback labels are not
+accepted as substitutes because the validator must derive the handback
+point from auditable data. The default gates are:
 
 - borrower-alone throughput exceeds 105% of the borrower guarantee
 - peer-demand throughput is non-zero (at least 1% of the peer guarantee)

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -457,12 +457,12 @@ infer phase semantics from unrelated per-class sweeps. The validator is:
 
 The input artifact must contain `root_cap_mbps`,
 `borrower_guarantee_mbps`, `peer_guarantee_mbps`,
-`handback_window_sec`, auditable handback evidence, and four named
+`handback_samples`, and four named
 phases: `borrow_alone`, `peer_demand`, `peer_steady`, and
 `peer_idle_reclaim`. Each phase records `throughput_mbps.borrower` and
 `throughput_mbps.peer`; `peer_steady` may also record
-`cos_admission_drops.peer`. Handback evidence is either
-`handback_samples` with time-domain throughput samples. Scalar
+`cos_admission_drops.peer`. Handback evidence must be time-domain
+throughput samples in `handback_samples`. Scalar
 `handback_window_sec` values and self-attested handback labels are not
 accepted as substitutes because the validator must derive the handback
 point from auditable data. The default gates are:

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -430,7 +430,7 @@ the same artifact format can express both the legacy #905 gate and the
 MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
-MOUSE_LATENCY_GATE_PERCENTILE=p99_us \
+MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
 ```
 
@@ -438,10 +438,13 @@ Run it once under the strict exact fixture and once after applying the
 surplus-sharing fixture. The reducer writes `summary.json` with the gate
 verdict, idle and loaded tail latency, ratio, selected percentile, and
 per-cell representative probe. Probe artifacts now include `rtt_us.p999`;
-the reducer carries that forward as `median_rep.p999_us` so p99.9 can be
-reported even when the hard gate remains p99. If p99.9 becomes a hard
-gate for a specific qualification run, set
-`MOUSE_LATENCY_GATE_PERCENTILE=p999_us`.
+the reducer carries that forward as `median_rep.p999_us`. The 100E100M
+qualification should gate p99.9 by setting
+`MOUSE_LATENCY_GATE_PERCENTILE=p999_us`; legacy #905-style runs may keep
+the default p99 gate. When a non-p99 gate is selected, the representative
+rep is also selected by that same percentile. For p99 runs, `summary.json`
+keeps the historical `p99_idle_us` / `p99_loaded_us` aliases alongside
+the generic `idle_us` / `loaded_us` fields.
 
 Surplus give-back uses a reduced phase artifact instead of trying to
 infer phase semantics from unrelated per-class sweeps. The validator is:
@@ -453,17 +456,26 @@ infer phase semantics from unrelated per-class sweeps. The validator is:
 ```
 
 The input artifact must contain `root_cap_mbps`,
-`peer_guarantee_mbps`, `handback_window_sec`, and four named phases:
-`borrow_alone`, `peer_demand`, `peer_steady`, and
+`borrower_guarantee_mbps`, `peer_guarantee_mbps`,
+`handback_window_sec`, auditable handback evidence, and four named
+phases: `borrow_alone`, `peer_demand`, `peer_steady`, and
 `peer_idle_reclaim`. Each phase records `throughput_mbps.borrower` and
 `throughput_mbps.peer`; `peer_steady` may also record
-`cos_admission_drops.peer`. The default gates are:
+`cos_admission_drops.peer`. Handback evidence is either
+`handback_samples` with time-domain throughput samples, or
+`handback_evidence: {"source": "transition_observed", "observed": true}`
+when another runner has already measured the transition window. The
+default gates are:
 
+- borrower-alone throughput exceeds 105% of the borrower guarantee
+- peer-demand throughput is non-zero (at least 1% of the peer guarantee)
 - peer steady throughput reaches at least 95% of its guarantee
 - handback window is at most 5 seconds
 - borrower throughput during peer steady demand falls to at most 90% of
   borrower-alone throughput
 - borrower reclaim throughput is at least 110% of its peer-steady
+  throughput
+- borrower reclaim throughput reaches at least 90% of borrow-alone
   throughput
 - root cap is not exceeded by more than 2%
 - peer steady CoS admission drops are zero by default

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -91,15 +91,19 @@ from work-conserving surplus-sharing:
 - 100E100M runs use the existing mouse-latency artifact reducer with
   configurable gate cells (`MOUSE_LATENCY_GATE_ELEPHANTS=100`,
   `MOUSE_LATENCY_GATE_MICE=100`) and now preserve p99.9 as
-  `median_rep.p999_us`.
+  `median_rep.p999_us`. Canonical 100E100M runs gate on
+  `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`, and the reducer selects the
+  representative rep by the same percentile it gates.
 - Surplus give-back runs reduce live traffic evidence into a four-phase
   artifact (`borrow_alone`, `peer_demand`, `peer_steady`,
   `peer_idle_reclaim`) validated by
   `test/incus/fairness_surplus_giveback_validate.py`.
-- The default give-back gates require the peer to reach 95% of guarantee
-  within a 5 s handback window, no steady peer CoS admission drops,
-  borrower decrease while the peer demands service, borrower reclaim
-  after peer idle, and root-cap respect.
+- The default give-back gates require proof that the borrower exceeded
+  its own guarantee while alone, the peer-demand phase had real peer
+  demand, the peer reaches 95% of guarantee within an auditable 5 s
+  handback window, no steady peer CoS admission drops, borrower decrease
+  while the peer demands service, borrower reclaim near the borrow-alone
+  baseline after peer idle, and root-cap respect.
 
 This lane intentionally does not touch the dataplane hot path. It makes
 future exact, surplus-sharing, and optional equal-flow comparison runs

--- a/docs/pr/1321-validation-contract/plan.md
+++ b/docs/pr/1321-validation-contract/plan.md
@@ -99,8 +99,10 @@ malformed artifact or infrastructure misuse.
 first handback point, or attach `handback_evidence` showing the scalar
 was measured from a real transition. The validator also checks that the
 borrower actually borrowed above its guarantee, the peer-demand phase
-actually had peer demand, and the borrower reclaimed close to the
-borrow-alone baseline after the peer went idle.
+actually had non-zero peer activity, and the borrower reclaimed close to
+the borrow-alone baseline after the peer went idle. The peer-demand
+threshold is deliberately a low liveness proxy; guarantee service is
+enforced by `peer_steady` and the handback evidence.
 
 ## Focused Validation
 

--- a/docs/pr/1321-validation-contract/plan.md
+++ b/docs/pr/1321-validation-contract/plan.md
@@ -19,9 +19,10 @@ useful slice is a stable validation surface for:
    cells and gate parameters, so `/tmp/.../cell_N100_M100` and
    `/tmp/.../cell_N0_M100` are enough for the 100E100M gate.
 2. Preserve p99.9 in probe and aggregate artifacts as `p999` /
-   `p999_us`. The default hard gate remains p99 for compatibility; runs
-   that need p99.9 as the hard gate can set
-   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`.
+   `p999_us`. Legacy #905-style runs keep the default p99 gate for
+   compatibility. The canonical 100E100M runs set
+   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`, and the reducer selects the
+   representative rep by the same percentile it gates.
 3. Validate surplus give-back from a reduced phase JSON artifact. The
    first live runner can be shell, Python, or an operator-curated
    reducer, but pass/fail semantics are centralized in
@@ -39,6 +40,7 @@ Strict exact fixture:
 MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
+MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
 ```
 
@@ -49,16 +51,13 @@ Surplus-sharing fixture:
 MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
+MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-surplus
 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 ```
 
-If p99.9 is promoted from reported evidence to the hard gate for a run,
-add:
-
-```bash
-MOUSE_LATENCY_GATE_PERCENTILE=p999_us
-```
+The 100E100M qualification gates p99.9. The reducer also supports p99
+for legacy #905-style runs.
 
 ## Surplus Give-Back Artifact
 
@@ -67,8 +66,10 @@ Minimum artifact:
 ```json
 {
   "root_cap_mbps": 25000,
+  "borrower_guarantee_mbps": 10000,
   "peer_guarantee_mbps": 10000,
   "handback_window_sec": 3.2,
+  "handback_evidence": {"source": "transition_observed", "observed": true},
   "phases": [
     {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
     {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
@@ -92,6 +93,14 @@ Validation:
 
 The validator exits `0` for PASS, `1` for contract FAIL, and `2` for
 malformed artifact or infrastructure misuse.
+
+`handback_window_sec` must be auditable. A live runner may either attach
+`handback_samples` time-series entries and let the validator compute the
+first handback point, or attach `handback_evidence` showing the scalar
+was measured from a real transition. The validator also checks that the
+borrower actually borrowed above its guarantee, the peer-demand phase
+actually had peer demand, and the borrower reclaimed close to the
+borrow-alone baseline after the peer went idle.
 
 ## Focused Validation
 

--- a/docs/pr/1321-validation-contract/plan.md
+++ b/docs/pr/1321-validation-contract/plan.md
@@ -68,8 +68,10 @@ Minimum artifact:
   "root_cap_mbps": 25000,
   "borrower_guarantee_mbps": 10000,
   "peer_guarantee_mbps": 10000,
-  "handback_window_sec": 3.2,
-  "handback_evidence": {"source": "transition_observed", "observed": true},
+  "handback_samples": [
+    {"t_sec": 1.0, "throughput_mbps": {"borrower": 16000, "peer": 4000}},
+    {"t_sec": 3.2, "throughput_mbps": {"borrower": 9000, "peer": 9800}}
+  ],
   "phases": [
     {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
     {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
@@ -94,15 +96,16 @@ Validation:
 The validator exits `0` for PASS, `1` for contract FAIL, and `2` for
 malformed artifact or infrastructure misuse.
 
-`handback_window_sec` must be auditable. A live runner may either attach
-`handback_samples` time-series entries and let the validator compute the
-first handback point, or attach `handback_evidence` showing the scalar
-was measured from a real transition. The validator also checks that the
-borrower actually borrowed above its guarantee, the peer-demand phase
-actually had non-zero peer activity, and the borrower reclaimed close to
-the borrow-alone baseline after the peer went idle. The peer-demand
-threshold is deliberately a low liveness proxy; guarantee service is
-enforced by `peer_steady` and the handback evidence.
+The live runner must attach `handback_samples` time-series entries and
+let the validator compute the first handback point. A scalar
+`handback_window_sec` or self-attested evidence label is not accepted as
+a substitute because the validator cannot falsify it from the artifact.
+The validator also checks that the borrower actually borrowed above its
+guarantee, the peer-demand phase actually had non-zero peer activity,
+and the borrower reclaimed close to the borrow-alone baseline after the
+peer went idle. The peer-demand threshold is deliberately a low liveness
+proxy; guarantee service is enforced by `peer_steady` and the derived
+handback sample.
 
 ## Focused Validation
 

--- a/pkg/cmdtree/README.md
+++ b/pkg/cmdtree/README.md
@@ -58,7 +58,7 @@ would otherwise treat it as exact-with-zero-rate.
 
 `buffer-size` intentionally accepts only byte-size values with explicit
 `k`/`m`/`g` suffixes. Percent buffer sizes need a compiler/runtime
-representation before the schema can safely accept them; accepting
+representation before the schema can safely accept them (#1336); accepting
 `10%` while the dataplane only receives `buffer_size_bytes` would turn a
 validation improvement back into a silent zero-byte compile.
 

--- a/pkg/cmdtree/README.md
+++ b/pkg/cmdtree/README.md
@@ -56,6 +56,12 @@ when the same scheduler also has a typed `transmit-rate <rate>` value.
 An exact-only scheduler line still fails commit-check because the compiler
 would otherwise treat it as exact-with-zero-rate.
 
+`buffer-size` intentionally accepts only byte-size values with explicit
+`k`/`m`/`g` suffixes. Percent buffer sizes need a compiler/runtime
+representation before the schema can safely accept them; accepting
+`10%` while the dataplane only receives `buffer_size_bytes` would turn a
+validation improvement back into a silent zero-byte compile.
+
 Adding a new typed subtree means:
 
 1. populate `ValueType` + `Validator` on the relevant Node(s);

--- a/pkg/cmdtree/tree_test.go
+++ b/pkg/cmdtree/tree_test.go
@@ -108,6 +108,24 @@ func containsCand(cands []Candidate, name string) (Candidate, bool) {
 	return Candidate{}, false
 }
 
+func TestConfigTopLevel_SetIncludesClassOfServiceSchedulers(t *testing.T) {
+	setNode := ConfigTopLevel["set"]
+	if setNode == nil {
+		t.Fatal("missing set node")
+	}
+	cosNode := setNode.Children["class-of-service"]
+	if cosNode == nil {
+		t.Fatalf("set completion tree missing class-of-service: %+v", setNode.Children)
+	}
+	schedulersNode := cosNode.Children["schedulers"]
+	if schedulersNode == nil {
+		t.Fatalf("class-of-service completion tree missing schedulers: %+v", cosNode.Children)
+	}
+	if schedulersNode.Children["<scheduler>"] != ConfigClassOfServiceSchedulers {
+		t.Fatalf("schedulers completion tree is not wired to typed scheduler schema")
+	}
+}
+
 func TestSchedulers_TypedLeaf_QuestionHelpShowsPlaceholderAndExamples(t *testing.T) {
 	// After `sched transmit-rate`, `?` should show the rate placeholder
 	// plus example values.

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -39,7 +39,11 @@ nothing internal.
   `transmit-rate asd` fails loud instead of silently zeroing in the
   existing parsers. Scheduler `buffer-size` validation intentionally
   accepts only byte sizes with explicit suffixes because the current
-  compiler stores bytes, not a percent-of-pool representation.
+  compiler, userspace snapshot, and Rust dataplane protocol all carry
+  `buffer_size_bytes`, not a percent-of-pool representation. Do not
+  accept percent syntax in the schema until that runtime representation
+  exists too; otherwise `buffer-size 10%` would validate and then
+  compile as zero bytes through the legacy parser.
   `parseBandwidthLimitStrict` / `parseBurstSizeLimitStrict` /
   `parseScaledDecimalUnitStrict` in `compiler_protocols.go` are the
   error-returning siblings of the legacy zero-return parsers — the legacy

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -42,8 +42,8 @@ nothing internal.
   compiler, userspace snapshot, and Rust dataplane protocol all carry
   `buffer_size_bytes`, not a percent-of-pool representation. Do not
   accept percent syntax in the schema until that runtime representation
-  exists too; otherwise `buffer-size 10%` would validate and then
-  compile as zero bytes through the legacy parser.
+  exists too (tracked in #1336); otherwise `buffer-size 10%` would
+  validate and then compile as zero bytes through the legacy parser.
   `parseBandwidthLimitStrict` / `parseBurstSizeLimitStrict` /
   `parseScaledDecimalUnitStrict` in `compiler_protocols.go` are the
   error-returning siblings of the legacy zero-return parsers — the legacy

--- a/pkg/config/schema_validate_test.go
+++ b/pkg/config/schema_validate_test.go
@@ -193,6 +193,22 @@ func TestSchemaValidate_BufferSize_RejectsBareInteger(t *testing.T) {
 	}
 }
 
+func TestSchemaValidate_BufferSize_RejectsPercentUntilRuntimeRepresentation(t *testing.T) {
+	err := schemaCheck(t, `class-of-service {
+    schedulers {
+        be {
+            buffer-size "10%";
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for percent buffer-size without runtime representation, got nil")
+	}
+	if !strings.Contains(err.Error(), "buffer-size") {
+		t.Fatalf("error should reference buffer-size: %v", err)
+	}
+}
+
 func TestSchemaValidate_BufferSize_RejectsGarbage(t *testing.T) {
 	err := schemaCheck(t, `class-of-service {
     schedulers {

--- a/test/incus/fairness_surplus_giveback_validate.py
+++ b/test/incus/fairness_surplus_giveback_validate.py
@@ -7,8 +7,10 @@ Input is a JSON artifact with four named phases:
   "root_cap_mbps": 25000,
   "borrower_guarantee_mbps": 10000,
   "peer_guarantee_mbps": 10000,
-  "handback_window_sec": 3.2,
-  "handback_evidence": {"source": "transition_observed", "observed": true},
+  "handback_samples": [
+    {"t_sec": 1.0, "throughput_mbps": {"borrower": 16000, "peer": 4000}},
+    {"t_sec": 3.2, "throughput_mbps": {"borrower": 9000, "peer": 9800}}
+  ],
   "phases": [
     {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
     {"name": "peer_demand", "throughput_mbps": {"borrower": 17000, "peer": 4000}},
@@ -94,15 +96,6 @@ def _drops(phase: dict[str, Any], role: str) -> float:
     return _nonnegative_number(drops.get(role, 0), f"phase {phase.get('name')}: cos_admission_drops.{role}")
 
 
-def _handback_scalar_has_evidence(artifact: dict[str, Any]) -> bool:
-    evidence = artifact.get("handback_evidence")
-    if not isinstance(evidence, dict):
-        return False
-    source = evidence.get("source")
-    observed = evidence.get("observed")
-    return bool(observed) and source in {"time_series", "transition_observed"}
-
-
 def _handback_from_samples(
     artifact: dict[str, Any],
     *,
@@ -113,7 +106,7 @@ def _handback_from_samples(
 ) -> Tuple[Optional[float], Optional[str]]:
     samples = artifact.get("handback_samples")
     if samples is None:
-        return None, None
+        return None, "missing_handback_samples"
     if not isinstance(samples, list) or not samples:
         raise ValueError("handback_samples must be a non-empty list when present")
 
@@ -178,10 +171,7 @@ def validate(
         borrow_alone_bps=borrow_alone_bps,
         max_borrower_demand_ratio=max_borrower_demand_ratio,
     )
-    if handback is None and handback_source is None:
-        handback = _nonnegative_number(artifact.get("handback_window_sec"), "handback_window_sec")
-        handback_source = "handback_evidence" if _handback_scalar_has_evidence(artifact) else "unaudited_scalar"
-    elif handback is None:
+    if handback is None:
         handback = max_handback_sec + 1.0
 
     failures: list[str] = []
@@ -213,10 +203,9 @@ def validate(
         failures.append(
             "handback_samples never show peer guarantee restored while borrower gave back surplus"
         )
-    if handback_source == "unaudited_scalar":
+    if handback_source == "missing_handback_samples":
         failures.append(
-            "handback window is an unaudited scalar; provide handback_samples "
-            "or handback_evidence.source with observed=true"
+            "handback_samples are required; scalar handback evidence is not auditable"
         )
     if steady_borrower > borrow_alone_bps * max_borrower_demand_ratio:
         failures.append(

--- a/test/incus/fairness_surplus_giveback_validate.py
+++ b/test/incus/fairness_surplus_giveback_validate.py
@@ -5,8 +5,10 @@ Input is a JSON artifact with four named phases:
 
 {
   "root_cap_mbps": 25000,
+  "borrower_guarantee_mbps": 10000,
   "peer_guarantee_mbps": 10000,
   "handback_window_sec": 3.2,
+  "handback_evidence": {"source": "transition_observed", "observed": true},
   "phases": [
     {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
     {"name": "peer_demand", "throughput_mbps": {"borrower": 17000, "peer": 4000}},
@@ -27,7 +29,7 @@ import argparse
 import json
 import math
 import sys
-from typing import Any
+from typing import Any, Optional, Tuple
 
 
 REQUIRED_PHASES = ("borrow_alone", "peer_demand", "peer_steady", "peer_idle_reclaim")
@@ -46,6 +48,13 @@ def _nonnegative_number(value: Any, field: str) -> float:
     out = _finite_number(value, field)
     if out < 0:
         raise ValueError(f"{field} must be non-negative")
+    return out
+
+
+def _positive_number(value: Any, field: str) -> float:
+    out = _nonnegative_number(value, field)
+    if out <= 0:
+        raise ValueError(f"{field} must be positive")
     return out
 
 
@@ -85,20 +94,71 @@ def _drops(phase: dict[str, Any], role: str) -> float:
     return _nonnegative_number(drops.get(role, 0), f"phase {phase.get('name')}: cos_admission_drops.{role}")
 
 
+def _handback_scalar_has_evidence(artifact: dict[str, Any]) -> bool:
+    evidence = artifact.get("handback_evidence")
+    if not isinstance(evidence, dict):
+        return False
+    source = evidence.get("source")
+    observed = evidence.get("observed")
+    return bool(observed) and source in {"time_series", "transition_observed"}
+
+
+def _handback_from_samples(
+    artifact: dict[str, Any],
+    *,
+    peer_guarantee: float,
+    min_peer_guarantee_ratio: float,
+    borrow_alone_bps: float,
+    max_borrower_demand_ratio: float,
+) -> Tuple[Optional[float], Optional[str]]:
+    samples = artifact.get("handback_samples")
+    if samples is None:
+        return None, None
+    if not isinstance(samples, list) or not samples:
+        raise ValueError("handback_samples must be a non-empty list when present")
+
+    threshold_peer = peer_guarantee * min_peer_guarantee_ratio
+    threshold_borrower = borrow_alone_bps * max_borrower_demand_ratio
+    for index, sample in enumerate(samples):
+        if not isinstance(sample, dict):
+            raise ValueError(f"handback_samples[{index}] must be an object")
+        t_sec = _nonnegative_number(sample.get("t_sec"), f"handback_samples[{index}].t_sec")
+        throughputs = sample.get("throughput_mbps")
+        if not isinstance(throughputs, dict):
+            raise ValueError(f"handback_samples[{index}].throughput_mbps must be an object")
+        borrower = _nonnegative_number(
+            throughputs.get("borrower"),
+            f"handback_samples[{index}].throughput_mbps.borrower",
+        )
+        peer = _nonnegative_number(
+            throughputs.get("peer"),
+            f"handback_samples[{index}].throughput_mbps.peer",
+        )
+        if peer >= threshold_peer and borrower <= threshold_borrower:
+            return t_sec, "handback_samples"
+    return None, "handback_samples_no_match"
+
+
 def validate(
     artifact: dict[str, Any],
     *,
     min_peer_guarantee_ratio: float,
+    min_peer_demand_ratio: float,
+    min_borrower_borrow_ratio: float,
     max_handback_sec: float,
     max_borrower_demand_ratio: float,
     min_reclaim_ratio: float,
+    min_reclaim_alone_ratio: float,
     root_cap_tolerance_ratio: float,
     max_peer_steady_drops: float,
 ) -> dict[str, Any]:
     phases = _phase_map(artifact)
     root_cap = _nonnegative_number(artifact.get("root_cap_mbps"), "root_cap_mbps")
-    peer_guarantee = _nonnegative_number(artifact.get("peer_guarantee_mbps"), "peer_guarantee_mbps")
-    handback = _nonnegative_number(artifact.get("handback_window_sec"), "handback_window_sec")
+    borrower_guarantee = _positive_number(
+        artifact.get("borrower_guarantee_mbps"),
+        "borrower_guarantee_mbps",
+    )
+    peer_guarantee = _positive_number(artifact.get("peer_guarantee_mbps"), "peer_guarantee_mbps")
 
     borrow_alone = phases["borrow_alone"]
     peer_demand = phases["peer_demand"]
@@ -111,8 +171,30 @@ def validate(
     steady_peer = _throughput(peer_steady, "peer")
     reclaim_borrower = _throughput(reclaim, "borrower")
     steady_peer_drops = _drops(peer_steady, "peer")
+    handback, handback_source = _handback_from_samples(
+        artifact,
+        peer_guarantee=peer_guarantee,
+        min_peer_guarantee_ratio=min_peer_guarantee_ratio,
+        borrow_alone_bps=borrow_alone_bps,
+        max_borrower_demand_ratio=max_borrower_demand_ratio,
+    )
+    if handback is None and handback_source is None:
+        handback = _nonnegative_number(artifact.get("handback_window_sec"), "handback_window_sec")
+        handback_source = "handback_evidence" if _handback_scalar_has_evidence(artifact) else "unaudited_scalar"
+    elif handback is None:
+        handback = max_handback_sec + 1.0
 
     failures: list[str] = []
+    if borrow_alone_bps < borrower_guarantee * min_borrower_borrow_ratio:
+        failures.append(
+            f"borrower alone throughput {borrow_alone_bps:.3f} Mbps does not prove surplus borrow: "
+            f"below {min_borrower_borrow_ratio:.3f} * guarantee {borrower_guarantee:.3f} Mbps"
+        )
+    if peer_demand_peer < peer_guarantee * min_peer_demand_ratio:
+        failures.append(
+            f"peer demand throughput {peer_demand_peer:.3f} Mbps below "
+            f"{min_peer_demand_ratio:.3f} * guarantee {peer_guarantee:.3f} Mbps"
+        )
     if steady_peer < peer_guarantee * min_peer_guarantee_ratio:
         failures.append(
             f"peer steady throughput {steady_peer:.3f} Mbps below "
@@ -121,6 +203,15 @@ def validate(
     if handback > max_handback_sec:
         failures.append(
             f"handback window {handback:.3f}s exceeds {max_handback_sec:.3f}s"
+        )
+    if handback_source == "handback_samples_no_match":
+        failures.append(
+            "handback_samples never show peer guarantee restored while borrower gave back surplus"
+        )
+    if handback_source == "unaudited_scalar":
+        failures.append(
+            "handback window is an unaudited scalar; provide handback_samples "
+            "or handback_evidence.source with observed=true"
         )
     if steady_borrower > borrow_alone_bps * max_borrower_demand_ratio:
         failures.append(
@@ -131,6 +222,11 @@ def validate(
         failures.append(
             f"borrower did not reclaim surplus: reclaim {reclaim_borrower:.3f} Mbps "
             f"< {min_reclaim_ratio:.3f} * steady {steady_borrower:.3f} Mbps"
+        )
+    if reclaim_borrower < borrow_alone_bps * min_reclaim_alone_ratio:
+        failures.append(
+            f"borrower reclaim {reclaim_borrower:.3f} Mbps is not near borrow-alone "
+            f"{borrow_alone_bps:.3f} Mbps: below {min_reclaim_alone_ratio:.3f} * alone"
         )
     if steady_peer_drops > max_peer_steady_drops:
         failures.append(
@@ -154,9 +250,12 @@ def validate(
         "failure_reasons": failures,
         "thresholds": {
             "min_peer_guarantee_ratio": min_peer_guarantee_ratio,
+            "min_peer_demand_ratio": min_peer_demand_ratio,
+            "min_borrower_borrow_ratio": min_borrower_borrow_ratio,
             "max_handback_sec": max_handback_sec,
             "max_borrower_demand_ratio": max_borrower_demand_ratio,
             "min_reclaim_ratio": min_reclaim_ratio,
+            "min_reclaim_alone_ratio": min_reclaim_alone_ratio,
             "root_cap_tolerance_ratio": root_cap_tolerance_ratio,
             "max_peer_steady_drops": max_peer_steady_drops,
         },
@@ -168,6 +267,7 @@ def validate(
             "peer_idle_reclaim_borrower_mbps": reclaim_borrower,
             "peer_steady_drops": steady_peer_drops,
             "handback_window_sec": handback,
+            "handback_source": handback_source,
             "phase_total_mbps": phase_totals,
         },
     }
@@ -178,9 +278,12 @@ def main() -> int:
     parser.add_argument("--input", required=True)
     parser.add_argument("--out", required=True)
     parser.add_argument("--min-peer-guarantee-ratio", type=float, default=0.95)
+    parser.add_argument("--min-peer-demand-ratio", type=float, default=0.01)
+    parser.add_argument("--min-borrower-borrow-ratio", type=float, default=1.05)
     parser.add_argument("--max-handback-sec", type=float, default=5.0)
     parser.add_argument("--max-borrower-demand-ratio", type=float, default=0.90)
     parser.add_argument("--min-reclaim-ratio", type=float, default=1.10)
+    parser.add_argument("--min-reclaim-alone-ratio", type=float, default=0.90)
     parser.add_argument("--root-cap-tolerance-ratio", type=float, default=0.02)
     parser.add_argument("--max-peer-steady-drops", type=float, default=0.0)
     args = parser.parse_args()
@@ -190,9 +293,12 @@ def main() -> int:
     verdict = validate(
         artifact,
         min_peer_guarantee_ratio=args.min_peer_guarantee_ratio,
+        min_peer_demand_ratio=args.min_peer_demand_ratio,
+        min_borrower_borrow_ratio=args.min_borrower_borrow_ratio,
         max_handback_sec=args.max_handback_sec,
         max_borrower_demand_ratio=args.max_borrower_demand_ratio,
         min_reclaim_ratio=args.min_reclaim_ratio,
+        min_reclaim_alone_ratio=args.min_reclaim_alone_ratio,
         root_cap_tolerance_ratio=args.root_cap_tolerance_ratio,
         max_peer_steady_drops=args.max_peer_steady_drops,
     )

--- a/test/incus/fairness_surplus_giveback_validate.py
+++ b/test/incus/fairness_surplus_giveback_validate.py
@@ -190,6 +190,11 @@ def validate(
             f"borrower alone throughput {borrow_alone_bps:.3f} Mbps does not prove surplus borrow: "
             f"below {min_borrower_borrow_ratio:.3f} * guarantee {borrower_guarantee:.3f} Mbps"
         )
+    # `peer_demand` is a liveness/audit phase, not the guarantee-service
+    # verdict. The real service gate is `peer_steady` plus the handback
+    # timing evidence. Keep this default low enough that a legitimate
+    # in-transition sample does not fail merely because handback has not
+    # completed yet, while still rejecting decorative all-zero demand.
     if peer_demand_peer < peer_guarantee * min_peer_demand_ratio:
         failures.append(
             f"peer demand throughput {peer_demand_peer:.3f} Mbps below "
@@ -278,7 +283,15 @@ def main() -> int:
     parser.add_argument("--input", required=True)
     parser.add_argument("--out", required=True)
     parser.add_argument("--min-peer-guarantee-ratio", type=float, default=0.95)
-    parser.add_argument("--min-peer-demand-ratio", type=float, default=0.01)
+    parser.add_argument(
+        "--min-peer-demand-ratio",
+        type=float,
+        default=0.01,
+        help=(
+            "minimum peer-demand phase throughput as a fraction of peer guarantee; "
+            "this is a liveness proxy, while peer_steady/handback enforce service"
+        ),
+    )
     parser.add_argument("--min-borrower-borrow-ratio", type=float, default=1.05)
     parser.add_argument("--max-handback-sec", type=float, default=5.0)
     parser.add_argument("--max-borrower-demand-ratio", type=float, default=0.90)

--- a/test/incus/fairness_surplus_giveback_validate_test.py
+++ b/test/incus/fairness_surplus_giveback_validate_test.py
@@ -6,8 +6,10 @@ from fairness_surplus_giveback_validate import validate
 def _artifact(**overrides):
     base = {
         "root_cap_mbps": 25000,
+        "borrower_guarantee_mbps": 10000,
         "peer_guarantee_mbps": 10000,
         "handback_window_sec": 3.0,
+        "handback_evidence": {"source": "transition_observed", "observed": True},
         "phases": [
             {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
             {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
@@ -27,9 +29,12 @@ def _validate(artifact):
     return validate(
         artifact,
         min_peer_guarantee_ratio=0.95,
+        min_peer_demand_ratio=0.01,
+        min_borrower_borrow_ratio=1.05,
         max_handback_sec=5.0,
         max_borrower_demand_ratio=0.90,
         min_reclaim_ratio=1.10,
+        min_reclaim_alone_ratio=0.90,
         root_cap_tolerance_ratio=0.02,
         max_peer_steady_drops=0,
     )
@@ -52,6 +57,58 @@ class SurplusGivebackValidateTests(unittest.TestCase):
         verdict = _validate(_artifact(handback_window_sec=6.5))
         self.assertEqual(verdict["verdict"], "FAIL")
         self.assertTrue(any("handback" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_without_auditable_handback_evidence(self):
+        artifact = _artifact()
+        artifact.pop("handback_evidence")
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("unaudited scalar" in r for r in verdict["failure_reasons"]))
+
+    def test_accepts_time_domain_handback_samples(self):
+        artifact = _artifact()
+        artifact.pop("handback_evidence")
+        artifact["handback_window_sec"] = 999.0
+        artifact["handback_samples"] = [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 3.5, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "PASS")
+        self.assertEqual(verdict["metrics"]["handback_source"], "handback_samples")
+        self.assertEqual(verdict["metrics"]["handback_window_sec"], 3.5)
+
+    def test_fails_when_time_domain_samples_never_show_handback(self):
+        artifact = _artifact()
+        artifact.pop("handback_evidence")
+        artifact["handback_samples"] = [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 3.5, "throughput_mbps": {"borrower": 16000, "peer": 2000}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("never show" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_when_borrower_never_borrows_surplus(self):
+        artifact = _artifact()
+        artifact["phases"][0]["throughput_mbps"]["borrower"] = 10000
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("does not prove surplus borrow" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_when_peer_demand_phase_is_decorative(self):
+        artifact = _artifact()
+        artifact["phases"][1]["throughput_mbps"]["peer"] = 0
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("peer demand throughput" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_when_reclaim_not_near_borrow_alone(self):
+        artifact = _artifact()
+        artifact["phases"][3]["throughput_mbps"]["borrower"] = 9901
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("not near borrow-alone" in r for r in verdict["failure_reasons"]))
 
     def test_fails_root_cap_overshoot(self):
         artifact = _artifact()

--- a/test/incus/fairness_surplus_giveback_validate_test.py
+++ b/test/incus/fairness_surplus_giveback_validate_test.py
@@ -8,8 +8,10 @@ def _artifact(**overrides):
         "root_cap_mbps": 25000,
         "borrower_guarantee_mbps": 10000,
         "peer_guarantee_mbps": 10000,
-        "handback_window_sec": 3.0,
-        "handback_evidence": {"source": "transition_observed", "observed": True},
+        "handback_samples": [
+            {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 3.0, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ],
         "phases": [
             {"name": "borrow_alone", "throughput_mbps": {"borrower": 18000, "peer": 0}},
             {"name": "peer_demand", "throughput_mbps": {"borrower": 16000, "peer": 7000}},
@@ -54,20 +56,33 @@ class SurplusGivebackValidateTests(unittest.TestCase):
         self.assertTrue(any("below" in r for r in verdict["failure_reasons"]))
 
     def test_fails_slow_handback(self):
-        verdict = _validate(_artifact(handback_window_sec=6.5))
+        artifact = _artifact()
+        artifact["handback_samples"] = [
+            {"t_sec": 1.0, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
+            {"t_sec": 6.5, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
         self.assertEqual(verdict["verdict"], "FAIL")
         self.assertTrue(any("handback" in r for r in verdict["failure_reasons"]))
 
-    def test_fails_without_auditable_handback_evidence(self):
+    def test_fails_without_handback_samples(self):
         artifact = _artifact()
-        artifact.pop("handback_evidence")
+        artifact.pop("handback_samples")
         verdict = _validate(artifact)
         self.assertEqual(verdict["verdict"], "FAIL")
-        self.assertTrue(any("unaudited scalar" in r for r in verdict["failure_reasons"]))
+        self.assertTrue(any("handback_samples are required" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_self_attested_handback_evidence_without_samples(self):
+        artifact = _artifact()
+        artifact.pop("handback_samples")
+        artifact["handback_window_sec"] = 1.0
+        artifact["handback_evidence"] = {"source": "transition_observed", "observed": True}
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("handback_samples are required" in r for r in verdict["failure_reasons"]))
 
     def test_accepts_time_domain_handback_samples(self):
         artifact = _artifact()
-        artifact.pop("handback_evidence")
         artifact["handback_window_sec"] = 999.0
         artifact["handback_samples"] = [
             {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
@@ -80,7 +95,6 @@ class SurplusGivebackValidateTests(unittest.TestCase):
 
     def test_fails_when_time_domain_samples_never_show_handback(self):
         artifact = _artifact()
-        artifact.pop("handback_evidence")
         artifact["handback_samples"] = [
             {"t_sec": 0.5, "throughput_mbps": {"borrower": 17000, "peer": 1000}},
             {"t_sec": 3.5, "throughput_mbps": {"borrower": 16000, "peer": 2000}},
@@ -102,6 +116,25 @@ class SurplusGivebackValidateTests(unittest.TestCase):
         verdict = _validate(artifact)
         self.assertEqual(verdict["verdict"], "FAIL")
         self.assertTrue(any("peer demand throughput" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_when_borrower_does_not_give_back_during_steady(self):
+        artifact = _artifact(root_cap_mbps=30000)
+        artifact["phases"][2]["throughput_mbps"]["borrower"] = 17000
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("did not give back surplus" in r for r in verdict["failure_reasons"]))
+
+    def test_fails_when_reclaim_not_above_steady_enough(self):
+        artifact = _artifact()
+        artifact["phases"][0]["throughput_mbps"]["borrower"] = 10600
+        artifact["phases"][2]["throughput_mbps"]["borrower"] = 9000
+        artifact["phases"][3]["throughput_mbps"]["borrower"] = 9700
+        artifact["handback_samples"] = [
+            {"t_sec": 3.0, "throughput_mbps": {"borrower": 9000, "peer": 9800}},
+        ]
+        verdict = _validate(artifact)
+        self.assertEqual(verdict["verdict"], "FAIL")
+        self.assertTrue(any("did not reclaim surplus" in r for r in verdict["failure_reasons"]))
 
     def test_fails_when_reclaim_not_near_borrow_alone(self):
         artifact = _artifact()

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -26,6 +26,12 @@ import sys
 from typing import Dict, List, Optional, Tuple
 
 CellKey = Tuple[int, int]  # (N, M)
+GATE_PERCENTILE_TO_RTT_KEY = {
+    "p50_us": "p50",
+    "p95_us": "p95",
+    "p99_us": "p99",
+    "p999_us": "p999",
+}
 
 
 def has_invalid_marker(rep_dir: str) -> bool:
@@ -86,18 +92,23 @@ def select_valid_reps(reps: List[dict]) -> List[dict]:
     return [r for r in reps if r.get("validity", {}).get("ok")]
 
 
-def median_rep_by_p99(valid_reps: List[dict]) -> Optional[dict]:
-    """Return the rep at the median position of p99 across valid reps."""
+def median_rep_by_percentile(valid_reps: List[dict], percentile_key: str = "p99") -> Optional[dict]:
+    """Return the rep at the median position of the selected percentile."""
     if not valid_reps:
         return None
     sortable = sorted(
         valid_reps,
-        key=lambda r: r.get("rtt_us", {}).get("p99") or 0,
+        key=lambda r: r.get("rtt_us", {}).get(percentile_key) or 0,
     )
     return sortable[len(sortable) // 2]
 
 
-def summarize_cell(reps: List[dict]) -> dict:
+def median_rep_by_p99(valid_reps: List[dict]) -> Optional[dict]:
+    """Backward-compatible helper for callers/tests that want p99 ordering."""
+    return median_rep_by_percentile(valid_reps, "p99")
+
+
+def summarize_cell(reps: List[dict], representative_percentile: str = "p99") -> dict:
     """Produce the per-cell summary record."""
     valid = select_valid_reps(reps)
     summary: dict = {
@@ -105,11 +116,12 @@ def summarize_cell(reps: List[dict]) -> dict:
         "n_reps_valid": len(valid),
         "median_rep": None,
         "iqr_p99_across_reps": None,
+        "representative_percentile": representative_percentile,
     }
     if len(valid) < 7:
         summary["status"] = "INSUFFICIENT-DATA"
         return summary
-    median = median_rep_by_p99(valid)
+    median = median_rep_by_percentile(valid, representative_percentile)
     p99s = sorted(
         r.get("rtt_us", {}).get("p99") or 0 for r in valid
     )
@@ -177,7 +189,7 @@ def decide(
             "reason": f"missing {gate_percentile} in gate cell",
         }
     ratio = loaded_value / idle_value
-    return {
+    verdict = {
         "verdict": "PASS" if ratio <= threshold_ratio else "FAIL",
         "ratio": ratio,
         "idle_us": idle_value,
@@ -189,6 +201,10 @@ def decide(
             f"{threshold_ratio:g} * {gate_percentile}(N=0, M={gate_mice})"
         ),
     }
+    if gate_percentile == "p99_us":
+        verdict["p99_idle_us"] = idle_value
+        verdict["p99_loaded_us"] = loaded_value
+    return verdict
 
 
 def discover_cells(root: str) -> Dict[CellKey, List[dict]]:
@@ -256,7 +272,11 @@ def main() -> int:
     args = p.parse_args()
 
     cells = discover_cells(args.root)
-    summaries = {key: summarize_cell(reps) for key, reps in cells.items()}
+    representative_percentile = GATE_PERCENTILE_TO_RTT_KEY[args.gate_percentile]
+    summaries = {
+        key: summarize_cell(reps, representative_percentile=representative_percentile)
+        for key, reps in cells.items()
+    }
     verdict = decide(
         summaries,
         gate_elephants=args.gate_elephants,

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -3,17 +3,18 @@
 Cell directory layout: <root>/cell_N{n}_M{m}/rep_{i}/probe.json
 Per-rep validity is read from probe.json["validity"]["ok"].
 
-For each cell, the median rep (by p99) of the valid reps is selected
-as the representative; its p50/p95/p99 + IQR-of-p99-across-reps +
-achieved-RPS summary populate summary.json.
+For each cell, the median valid rep for the configured gate percentile
+is selected as the representative; its p50/p95/p99/p99.9 +
+IQR-of-p99-across-reps + achieved-RPS summary populate summary.json.
 
 Default decision threshold (#905, plan §7.2):
 - p99(N=128, M=10, best-effort) ≤ 2 × p99(N=0, M=10, best-effort)
 
 Issue #1321 can reuse the same artifact reducer for 100E100M by passing
 `--gate-elephants 100 --gate-mice 100`. The reducer records p99.9 when
-probe artifacts include it, but the default hard gate remains p99 unless
-the caller explicitly changes `--gate-percentile`.
+probe artifacts include it. The default hard gate remains p99 unless
+the caller explicitly changes `--gate-percentile`; when changed, the
+representative rep is selected by that same percentile.
 
 The harness only runs best-effort, so cells are keyed by (N, M).
 """

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -7,6 +7,7 @@ from mouse_latency_aggregate import (
     decide,
     has_invalid_marker,
     load_cell_reps,
+    median_rep_by_percentile,
     median_rep_by_p99,
     select_valid_reps,
     summarize_cell,
@@ -41,6 +42,22 @@ class MedianByP99Tests(unittest.TestCase):
 
     def test_empty(self):
         self.assertIsNone(median_rep_by_p99([]))
+
+    def test_selects_by_requested_percentile(self):
+        reps = [
+            _make_rep(100),
+            _make_rep(200),
+            _make_rep(300),
+        ]
+        reps[0]["rtt_us"]["p999"] = 10000
+        reps[1]["rtt_us"]["p999"] = 200
+        reps[2]["rtt_us"]["p999"] = 300
+
+        by_p99 = median_rep_by_percentile(reps, "p99")
+        by_p999 = median_rep_by_percentile(reps, "p999")
+
+        self.assertEqual(by_p99["rtt_us"]["p99"], 200)
+        self.assertEqual(by_p999["rtt_us"]["p999"], 300)
 
 
 class SummarizeCellTests(unittest.TestCase):
@@ -101,8 +118,14 @@ class DecideTests(unittest.TestCase):
         self.assertIn("N=100, M=100", v["gate"])
 
     def test_custom_gate_percentile(self):
-        idle = summarize_cell([_make_rep(p99=100) for _ in range(10)])
-        loaded = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        idle = summarize_cell(
+            [_make_rep(p99=100) for _ in range(10)],
+            representative_percentile="p999",
+        )
+        loaded = summarize_cell(
+            [_make_rep(p99=100) for _ in range(10)],
+            representative_percentile="p999",
+        )
         # p999 is p99+10 from _make_rep, so the ratio is 210/110.
         loaded["median_rep"]["p999_us"] = 210
         summaries = {(0, 100): idle, (100, 100): loaded}
@@ -114,6 +137,16 @@ class DecideTests(unittest.TestCase):
             threshold_ratio=1.5,
         )
         self.assertEqual(v["verdict"], "FAIL")
+        self.assertEqual(v["percentile"], "p999_us")
+        self.assertNotIn("p99_idle_us", v)
+
+    def test_p99_gate_preserves_legacy_summary_aliases(self):
+        summaries = self._gate_summaries(100, 190)
+        v = decide(summaries)
+        self.assertEqual(v["idle_us"], 100)
+        self.assertEqual(v["loaded_us"], 190)
+        self.assertEqual(v["p99_idle_us"], 100)
+        self.assertEqual(v["p99_loaded_us"], 190)
 
     def test_missing_gate_cell(self):
         v = decide({(0, 10): summarize_cell([_make_rep(100)] * 10)})


### PR DESCRIPTION
## Summary

Fix-forward after the post-merge #1320/#1335 retrospective:

- strengthen the #1321 surplus give-back reduced-artifact validator so it proves borrow, demand, auditable handback, give-back, and reclaim instead of accepting weak phase summaries
- make the mouse-latency reducer select the representative rep by the configured gate percentile and preserve `p99_idle_us` / `p99_loaded_us` aliases for p99 summary compatibility
- document that canonical 100E100M gates p99.9 while legacy #905-style runs can keep p99
- pin the current safe `buffer-size 10%` behavior with tests/docs: percent buffer-size remains rejected until #1336 defines a runtime representation
- add a direct ConfigTopLevel wiring guard for the typed CoS scheduler schema, since the suspected #1320 completion-wiring gap is already fixed on master

Closes #1338
Closes #1339
Closes #1340
Refs #1336

## Validation

- `python3 -m py_compile test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py test/incus/fairness_surplus_giveback_validate.py`
- `(cd test/incus && python3 -m unittest mouse_latency_probe_test.py mouse_latency_aggregate_test.py fairness_surplus_giveback_validate_test.py)`
- `bash -n test/incus/test-mouse-latency-matrix.sh`
- `git diff --check`
- `go test -count=1 ./pkg/cmdtree/... ./pkg/config/... ./pkg/configstore/...`
- `go test -count=1 ./pkg/...`