### PR TITLE
Fix surplus mouse-latency matrix fixture selection

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -435,16 +435,28 @@ MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
 ```
 
 Run it once under the strict exact fixture and once after applying the
-surplus-sharing fixture. The reducer writes `summary.json` with the gate
-verdict, idle and loaded tail latency, ratio, selected percentile, and
-per-cell representative probe. Probe artifacts now include `rtt_us.p999`;
-the reducer carries that forward as `median_rep.p999_us`. The 100E100M
-qualification should gate p99.9 by setting
+surplus-sharing fixture. Use `MOUSE_COS_SURPLUS_SHARING=1` for the
+surplus leg; the per-rep harness re-applies CoS on every preflight/rep,
+so a one-time manual `apply-cos-config.sh --surplus-sharing` before the
+matrix is not sufficient. The reducer writes `summary.json` with the
+gate verdict, idle and loaded tail latency, ratio, selected percentile,
+and per-cell representative probe. Probe artifacts now include
+`rtt_us.p999`; the reducer carries that forward as `median_rep.p999_us`.
+The 100E100M qualification should gate p99.9 by setting
 `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`; legacy #905-style runs may keep
 the default p99 gate. When a non-p99 gate is selected, the representative
 rep is also selected by that same percentile. For p99 runs, `summary.json`
 keeps the historical `p99_idle_us` / `p99_loaded_us` aliases alongside
 the generic `idle_us` / `loaded_us` fields.
+
+```bash
+MOUSE_COS_SURPLUS_SHARING=1 \
+MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
+MOUSE_LATENCY_GATE_ELEPHANTS=100 \
+MOUSE_LATENCY_GATE_MICE=100 \
+MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
+./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-surplus
+```
 
 Surplus give-back uses a reduced phase artifact instead of trying to
 infer phase semantics from unrelated per-class sweeps. The validator is:

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -93,7 +93,11 @@ from work-conserving surplus-sharing:
   `MOUSE_LATENCY_GATE_MICE=100`) and now preserve p99.9 as
   `median_rep.p999_us`. Canonical 100E100M runs gate on
   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`, and the reducer selects the
-  representative rep by the same percentile it gates.
+  representative rep by the same percentile it gates. Surplus matrix
+  runs must set `MOUSE_COS_SURPLUS_SHARING=1`; the per-rep harness
+  reapplies CoS before every preflight/rep, so manually applying the
+  surplus fixture once before the matrix is overwritten by the runner.
+  Each rep manifest records `cos_surplus_sharing`.
 - Surplus give-back runs reduce live traffic evidence into a four-phase
   artifact (`borrow_alone`, `peer_demand`, `peer_steady`,
   `peer_idle_reclaim`) validated by

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -3,6 +3,10 @@
 #
 # Usage: test-mouse-latency-matrix.sh <out_root>
 #
+# Set MOUSE_COS_SURPLUS_SHARING=1 to run every preflight/rep under
+# the diagnostic surplus-sharing fixture instead of the strict exact
+# fixture. The per-rep manifest records the selected fixture bit.
+#
 # 12 cells: N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}.
 # Per cell: run up to 15 total reps as needed to reach 10 valid reps.
 # Cell stops at 10 valid reps OR 15 total, whichever is first.

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -38,6 +38,7 @@ TARGET_V4="172.16.80.200"
 ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
 MOUSE_PORT="${MOUSE_PORT:-7}"
 MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
+MOUSE_COS_SURPLUS_SHARING="${MOUSE_COS_SURPLUS_SHARING:-0}"
 SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf-a); same-class iperf-b sets 10 Gb/s
 # Validate env-overrides (Copilot D.5): ports/bps must be
 # digits only so they can't smuggle shell metacharacters into
@@ -53,6 +54,11 @@ SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf
 case "$MOUSE_CLASS" in
     best-effort|iperf-a|iperf-b|iperf-c) ;;
     *) echo "ABORT: MOUSE_CLASS='$MOUSE_CLASS' must be one of best-effort/iperf-a/iperf-b/iperf-c" >&2; exit 1 ;;
+esac
+case "${MOUSE_COS_SURPLUS_SHARING,,}" in
+    0|false|no|off) MOUSE_COS_SURPLUS_SHARING=0 ;;
+    1|true|yes|on) MOUSE_COS_SURPLUS_SHARING=1 ;;
+    *) echo "ABORT: MOUSE_COS_SURPLUS_SHARING='$MOUSE_COS_SURPLUS_SHARING' must be boolean" >&2; exit 1 ;;
 esac
 SETTLE_BUDGET=20
 SLACK=10
@@ -193,6 +199,9 @@ PRE_PRIMARY=$(current_primary)
 APPLY_COS_FLAGS=()
 if [[ "$MOUSE_CLASS" == "iperf-b" ]]; then
     APPLY_COS_FLAGS+=(--same-class)
+fi
+if [[ "$MOUSE_COS_SURPLUS_SHARING" -eq 1 ]]; then
+    APPLY_COS_FLAGS+=(--surplus-sharing)
 fi
 "${SCRIPT_DIR}/apply-cos-config.sh" "${APPLY_COS_FLAGS[@]}" \
     "${INCUS_REMOTE}:${PRE_PRIMARY}" \
@@ -468,7 +477,8 @@ N="$N" M="$M" DURATION="$DURATION" STARTED_AT="$STARTED_AT" \
 SCREEN_ENGAGED="$screen_engaged" HA_TRANSITION_SEEN="$ha_seen" \
 MPSTAT_AVG_BUSY="${mpstat_busy:-0}" \
 ELEPHANT_PORT="$ELEPHANT_PORT" MOUSE_PORT="$MOUSE_PORT" \
-MOUSE_CLASS="$MOUSE_CLASS" SHAPER_BPS="$SHAPER_BPS" \
+MOUSE_CLASS="$MOUSE_CLASS" MOUSE_COS_SURPLUS_SHARING="$MOUSE_COS_SURPLUS_SHARING" \
+SHAPER_BPS="$SHAPER_BPS" \
 python3 -c '
 import json, os
 manifest = {
@@ -482,6 +492,7 @@ manifest = {
     "elephant_port": int(os.environ["ELEPHANT_PORT"]),
     "mouse_port": int(os.environ["MOUSE_PORT"]),
     "mouse_class": os.environ["MOUSE_CLASS"],
+    "cos_surplus_sharing": os.environ["MOUSE_COS_SURPLUS_SHARING"] == "1",
     "shaper_bps": int(os.environ["SHAPER_BPS"]),
 }
 print(json.dumps(manifest, indent=2))

--- a/test/incus/test_mouse_latency_shell_test.py
+++ b/test/incus/test_mouse_latency_shell_test.py
@@ -1,0 +1,38 @@
+import pathlib
+import re
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("test-mouse-latency.sh").read_text()
+MATRIX_SCRIPT = pathlib.Path(__file__).with_name("test-mouse-latency-matrix.sh").read_text()
+
+
+class MouseLatencyShellTests(unittest.TestCase):
+    def test_surplus_fixture_env_is_validated_and_passed_to_apply(self):
+        self.assertIn('MOUSE_COS_SURPLUS_SHARING="${MOUSE_COS_SURPLUS_SHARING:-0}"', SCRIPT)
+        self.assertIn('MOUSE_COS_SURPLUS_SHARING=1', SCRIPT)
+        self.assertIn("MOUSE_COS_SURPLUS_SHARING='$MOUSE_COS_SURPLUS_SHARING' must be boolean", SCRIPT)
+
+        self.assertRegex(
+            SCRIPT,
+            re.compile(
+                r'if \[\[ "\$MOUSE_COS_SURPLUS_SHARING" -eq 1 \]\]; then\s+'
+                r'APPLY_COS_FLAGS\+=\(--surplus-sharing\)\s+fi',
+                re.MULTILINE,
+            ),
+        )
+
+    def test_surplus_fixture_choice_is_written_to_manifest(self):
+        self.assertIn(
+            'MOUSE_CLASS="$MOUSE_CLASS" MOUSE_COS_SURPLUS_SHARING="$MOUSE_COS_SURPLUS_SHARING"',
+            SCRIPT,
+        )
+        self.assertIn('"cos_surplus_sharing": os.environ["MOUSE_COS_SURPLUS_SHARING"] == "1"', SCRIPT)
+
+    def test_matrix_documents_surplus_fixture_knob(self):
+        self.assertIn("Set MOUSE_COS_SURPLUS_SHARING=1", MATRIX_SCRIPT)
+        self.assertIn("per-rep manifest records the selected fixture bit", MATRIX_SCRIPT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `MOUSE_COS_SURPLUS_SHARING=1` to `test-mouse-latency.sh` so each preflight/rep applies the surplus-sharing CoS fixture instead of silently reverting to strict exact
- record `cos_surplus_sharing` in each rep manifest
- document the strict-vs-surplus matrix workflow in the fairness docs
- add a shell-source regression guard covering the env knob, `--surplus-sharing` propagation, and manifest bit

Closes #1344.

## Validation

- `bash -n test/incus/test-mouse-latency.sh test/incus/test-mouse-latency-matrix.sh`
- `python3 test/incus/test_mouse_latency_shell_test.py`
- `python3 test/incus/mouse_latency_aggregate_test.py`
- `git diff --check`

## Note

I did not run the full surplus 100E100M matrix here because #1343 still blocks the mouse-latency preflight before gate cells. This PR fixes the runner contract so the surplus leg will actually stay on the surplus fixture once that preflight blocker is resolved.