### PR TITLE
Add paced persistent mouse latency probes

### DIFF
--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -154,9 +154,14 @@ A measurement run **PASSES** iff ALL of:
    throughput floor would be a category error.
 
 4. **Mouse p99** (only when mouse probes are present): mouse
-   TCP-connect+echo p99 latency `≤ 2 × idle_baseline`, where
-   `idle_baseline` is the same probe against the cluster with no
-   elephant traffic.
+   echo-transaction p99 latency `≤ 2 × idle_baseline`, where
+   `idle_baseline` is the same probe mode against the cluster with no
+   elephant traffic. The legacy `per-attempt` probe mode includes TCP
+   connect latency in every sample. High-concurrency 100E100M runs use
+   `persistent` mode so the gate measures established mouse request
+   latency instead of the target echo daemon's accept/close capacity.
+   The reducer rejects gate comparisons whose idle and loaded cells were
+   captured with different probe modes or minimum-interval pacing.
 
 A run that satisfies any single gate while failing another **does
 not pass**. There is no "OR flagged" escape clause; if a gate
@@ -431,6 +436,8 @@ MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
 MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
+MOUSE_PROBE_CONNECTION_MODE=persistent \
+MOUSE_PROBE_MIN_INTERVAL_MS=20 \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
 ```
 
@@ -438,16 +445,26 @@ Run it once under the strict exact fixture and once after applying the
 surplus-sharing fixture. Use `MOUSE_COS_SURPLUS_SHARING=1` for the
 surplus leg; the per-rep harness re-applies CoS on every preflight/rep,
 so a one-time manual `apply-cos-config.sh --surplus-sharing` before the
-matrix is not sufficient. The reducer writes `summary.json` with the
-gate verdict, idle and loaded tail latency, ratio, selected percentile,
-and per-cell representative probe. Probe artifacts now include
-`rtt_us.p999`; the reducer carries that forward as `median_rep.p999_us`.
-The 100E100M qualification should gate p99.9 by setting
-`MOUSE_LATENCY_GATE_PERCENTILE=p999_us`; legacy #905-style runs may keep
-the default p99 gate. When a non-p99 gate is selected, the representative
-rep is also selected by that same percentile. For p99 runs, `summary.json`
-keeps the historical `p99_idle_us` / `p99_loaded_us` aliases alongside
-the generic `idle_us` / `loaded_us` fields.
+matrix is not sufficient. 100E100M uses persistent probe connections with
+a 20 ms per-coroutine interval because the validation target is tail
+latency of mouse transactions under elephant load, not the echo server's
+ability to accept and close tens of thousands of short TCP sessions or
+serve millions of unpaced echo requests per minute. A 60-second, 100-mouse
+rep still produces roughly 280k samples on the isolated validation
+cluster. The reducer writes
+`summary.json` with the gate verdict, idle and loaded tail latency,
+ratio, selected percentile, and per-cell representative probe. Probe
+artifacts now include `rtt_us.p999`; the reducer carries that forward as
+`median_rep.p999_us`. The 100E100M qualification should gate p99.9 by
+setting `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`; legacy #905-style runs
+may keep the default p99 gate. When a non-p99 gate is selected, the
+representative rep is also selected by that same percentile. For p99
+runs, `summary.json` keeps the historical `p99_idle_us` /
+`p99_loaded_us` aliases alongside the generic `idle_us` / `loaded_us`
+fields. The reducer also verifies that gate cells share the same
+`MOUSE_PROBE_CONNECTION_MODE` and `MOUSE_PROBE_MIN_INTERVAL_MS` provenance;
+mixed per-attempt/persistent or paced/unpaced gate artifacts are reported
+as insufficient data rather than a PASS/FAIL verdict.
 
 ```bash
 MOUSE_COS_SURPLUS_SHARING=1 \

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -92,12 +92,18 @@ from work-conserving surplus-sharing:
   configurable gate cells (`MOUSE_LATENCY_GATE_ELEPHANTS=100`,
   `MOUSE_LATENCY_GATE_MICE=100`) and now preserve p99.9 as
   `median_rep.p999_us`. Canonical 100E100M runs gate on
-  `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`, and the reducer selects the
-  representative rep by the same percentile it gates. Surplus matrix
-  runs must set `MOUSE_COS_SURPLUS_SHARING=1`; the per-rep harness
-  reapplies CoS before every preflight/rep, so manually applying the
-  surplus fixture once before the matrix is overwritten by the runner.
-  Each rep manifest records `cos_surplus_sharing`.
+  `MOUSE_LATENCY_GATE_PERCENTILE=p999_us` and use
+  `MOUSE_PROBE_CONNECTION_MODE=persistent` with
+  `MOUSE_PROBE_MIN_INTERVAL_MS=20`, so the gate measures established
+  mouse echo transactions instead of the target echo daemon's TCP
+  accept/close rate or unpaced echo throughput. The reducer selects the
+  representative rep by the same percentile it gates and rejects idle vs
+  loaded gate comparisons captured with different probe modes or
+  minimum-interval pacing. Surplus matrix runs must set
+  `MOUSE_COS_SURPLUS_SHARING=1`; the per-rep harness reapplies CoS
+  before every preflight/rep, so manually applying the surplus fixture
+  once before the matrix is overwritten by the runner. Each rep manifest
+  records `cos_surplus_sharing`.
 - Surplus give-back runs reduce live traffic evidence into a four-phase
   artifact (`borrow_alone`, `peer_demand`, `peer_steady`,
   `peer_idle_reclaim`) validated by

--- a/docs/pr/1321-validation-contract/plan.md
+++ b/docs/pr/1321-validation-contract/plan.md
@@ -21,8 +21,13 @@ useful slice is a stable validation surface for:
 2. Preserve p99.9 in probe and aggregate artifacts as `p999` /
    `p999_us`. Legacy #905-style runs keep the default p99 gate for
    compatibility. The canonical 100E100M runs set
-   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us`, and the reducer selects the
-   representative rep by the same percentile it gates.
+   `MOUSE_LATENCY_GATE_PERCENTILE=p999_us` and
+   `MOUSE_PROBE_CONNECTION_MODE=persistent` with
+   `MOUSE_PROBE_MIN_INTERVAL_MS=20`, and the reducer selects the
+   representative rep by the same percentile it gates. Persistent,
+   interval-bounded mouse probing keeps the 100E100M gate focused on
+   established echo transaction latency instead of the target echo
+   daemon's accept/close capacity or unpaced echo throughput.
 3. Validate surplus give-back from a reduced phase JSON artifact. The
    first live runner can be shell, Python, or an operator-curated
    reducer, but pass/fail semantics are centralized in
@@ -41,6 +46,8 @@ MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
 MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
+MOUSE_PROBE_CONNECTION_MODE=persistent \
+MOUSE_PROBE_MIN_INTERVAL_MS=20 \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-exact
 ```
 
@@ -52,12 +59,15 @@ MOUSE_LATENCY_CELLS=$'0 100\n100 100' \
 MOUSE_LATENCY_GATE_ELEPHANTS=100 \
 MOUSE_LATENCY_GATE_MICE=100 \
 MOUSE_LATENCY_GATE_PERCENTILE=p999_us \
+MOUSE_PROBE_CONNECTION_MODE=persistent \
+MOUSE_PROBE_MIN_INTERVAL_MS=20 \
 ./test/incus/test-mouse-latency-matrix.sh /tmp/xpf-100e100m-surplus
 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 ```
 
-The 100E100M qualification gates p99.9. The reducer also supports p99
-for legacy #905-style runs.
+The 100E100M qualification gates p99.9 in persistent connection mode
+with a 20 ms per-coroutine interval. The reducer also supports p99 for
+legacy #905-style runs.
 
 ## Surplus Give-Back Artifact
 

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -9,6 +9,9 @@ IQR-of-p99-across-reps + achieved-RPS summary populate summary.json.
 Cells require 10 valid reps to report status OK; if the runner reaches
 its 15-rep ceiling with fewer valid reps, the gate is
 INSUFFICIENT-DATA.
+Gate cells must use the same mouse-probe connection mode and pacing
+interval; otherwise the reducer returns INSUFFICIENT-DATA instead of
+comparing unlike latency artifacts.
 
 Default decision threshold (#905, plan §7.2):
 - p99(N=128, M=10, best-effort) ≤ 2 × p99(N=0, M=10, best-effort)
@@ -37,6 +40,62 @@ GATE_PERCENTILE_TO_RTT_KEY = {
     "p999_us": "p999",
 }
 REQUIRED_VALID_REPS = 10
+DEFAULT_PROBE_CONFIG = {
+    "connection_mode": "per-attempt",
+    "min_interval_ms": 0.0,
+}
+
+
+def _normalize_min_interval_ms(value) -> object:
+    if value is None:
+        return DEFAULT_PROBE_CONFIG["min_interval_ms"]
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _probe_config_from_rep(rep: dict) -> dict:
+    """Return the probe mode/pacing tuple for a rep.
+
+    New artifacts record the values in both manifest.json and
+    probe.json["config"]. Older artifacts predate the fields and are
+    treated as the historical defaults: per-attempt mode with no
+    min-interval pacing.
+    """
+    manifest = rep.get("manifest")
+    if not isinstance(manifest, dict):
+        manifest = {}
+    config = rep.get("config")
+    if not isinstance(config, dict):
+        config = {}
+    mode = manifest.get("mouse_probe_connection_mode")
+    if mode is None:
+        mode = config.get("connection_mode")
+    if mode is None:
+        mode = DEFAULT_PROBE_CONFIG["connection_mode"]
+    interval = manifest.get("mouse_probe_min_interval_ms")
+    if interval is None:
+        interval = config.get("min_interval_ms")
+    return {
+        "connection_mode": mode,
+        "min_interval_ms": _normalize_min_interval_ms(interval),
+    }
+
+
+def _probe_config_key(config: dict) -> Tuple[object, object]:
+    return (config.get("connection_mode"), config.get("min_interval_ms"))
+
+
+def _unique_probe_configs(reps: List[dict]) -> List[dict]:
+    by_key = {}
+    for rep in reps:
+        config = _probe_config_from_rep(rep)
+        by_key.setdefault(_probe_config_key(config), config)
+    return [
+        by_key[k]
+        for k in sorted(by_key.keys(), key=lambda k: (str(k[0]), str(k[1])))
+    ]
 
 
 def has_invalid_marker(rep_dir: str) -> bool:
@@ -85,6 +144,13 @@ def load_cell_reps(cell_dir: str) -> List[dict]:
                     "totals": {},
                 })
                 continue
+        manifest_path = os.path.join(rep_dir, "manifest.json")
+        if os.path.isfile(manifest_path):
+            try:
+                with open(manifest_path) as f:
+                    rep["manifest"] = json.load(f)
+            except json.JSONDecodeError:
+                pass
         if marker_reasons:
             v = rep.setdefault("validity", {"ok": False, "reasons": []})
             v["ok"] = False
@@ -123,6 +189,13 @@ def summarize_cell(reps: List[dict], representative_percentile: str = "p99") -> 
         "iqr_p99_across_reps": None,
         "representative_percentile": representative_percentile,
     }
+    probe_configs = _unique_probe_configs(valid)
+    if len(probe_configs) == 1:
+        summary["probe_config"] = probe_configs[0]
+    elif len(probe_configs) > 1:
+        summary["probe_configs"] = probe_configs
+        summary["status"] = "INCONSISTENT-PROBE-CONFIG"
+        return summary
     if len(valid) < REQUIRED_VALID_REPS:
         summary["status"] = "INSUFFICIENT-VALID-REPS"
         return summary
@@ -184,6 +257,16 @@ def decide(
             "reason": (
                 f"gate cell status: loaded={gate_loaded.get('status')}, "
                 f"idle={gate_idle.get('status')}"
+            ),
+        }
+    loaded_probe_config = gate_loaded.get("probe_config")
+    idle_probe_config = gate_idle.get("probe_config")
+    if loaded_probe_config != idle_probe_config:
+        return {
+            "verdict": "INSUFFICIENT-DATA",
+            "reason": (
+                "gate probe config mismatch: "
+                f"loaded={loaded_probe_config}, idle={idle_probe_config}"
             ),
         }
     loaded_value = (gate_loaded.get("median_rep") or {}).get(gate_percentile)

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -14,11 +14,23 @@ from mouse_latency_aggregate import (
 )
 
 
-def _make_rep(p99: int, ok: bool = True, p50: int = 100, p95: int = 500, rps: float = 200.0) -> dict:
+def _make_rep(
+    p99: int,
+    ok: bool = True,
+    p50: int = 100,
+    p95: int = 500,
+    rps: float = 200.0,
+    connection_mode: str = "per-attempt",
+    min_interval_ms: float = 0.0,
+) -> dict:
     return {
         "rtt_us": {"p50": p50, "p95": p95, "p99": p99, "p999": p99 + 10},
         "totals": {"achieved_rps_total": rps, "attempts_per_coroutine": [600] * 10},
         "validity": {"ok": ok, "reasons": []},
+        "config": {
+            "connection_mode": connection_mode,
+            "min_interval_ms": min_interval_ms,
+        },
     }
 
 
@@ -94,6 +106,20 @@ class SummarizeCellTests(unittest.TestCase):
         self.assertEqual(s["status"], "OK")
         # Median p99 of 100..190 is at index 5 → 150.
         self.assertEqual(s["median_rep"]["p99_us"], 150)
+
+    def test_mixed_probe_config_within_cell_is_insufficient(self):
+        reps = [_make_rep(p99=100) for _ in range(7)]
+        reps += [
+            _make_rep(
+                p99=100,
+                connection_mode="persistent",
+                min_interval_ms=20.0,
+            )
+            for _ in range(3)
+        ]
+        s = summarize_cell(reps)
+        self.assertEqual(s["status"], "INCONSISTENT-PROBE-CONFIG")
+        self.assertEqual(len(s["probe_configs"]), 2)
 
 
 class DecideTests(unittest.TestCase):
@@ -177,6 +203,31 @@ class DecideTests(unittest.TestCase):
         self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
         self.assertIn("INSUFFICIENT-VALID-REPS", v["reason"])
 
+    def test_gate_rejects_mixed_probe_configs(self):
+        idle = summarize_cell(
+            [
+                _make_rep(
+                    p99=100,
+                    connection_mode="per-attempt",
+                    min_interval_ms=0.0,
+                )
+                for _ in range(10)
+            ]
+        )
+        loaded = summarize_cell(
+            [
+                _make_rep(
+                    p99=100,
+                    connection_mode="persistent",
+                    min_interval_ms=20.0,
+                )
+                for _ in range(10)
+            ]
+        )
+        v = decide({(0, 10): idle, (128, 10): loaded})
+        self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
+        self.assertIn("probe config mismatch", v["reason"])
+
 
 class LoadCellRepsInvalidMarkerTests(unittest.TestCase):
     def _setup_cell(self, tmpdir: str):
@@ -196,6 +247,22 @@ class LoadCellRepsInvalidMarkerTests(unittest.TestCase):
         if marker:
             open(os.path.join(rep_dir, f"INVALID-{marker}"), "w").close()
         return rep_dir
+
+    def test_manifest_probe_config_overrides_probe_json_config(self):
+        with tempfile.TemporaryDirectory() as t:
+            cell_dir = self._setup_cell(t)
+            rep_dir = self._write_rep(cell_dir, 0, ok=True)
+            with open(os.path.join(rep_dir, "manifest.json"), "w") as f:
+                json.dump({
+                    "mouse_probe_connection_mode": "persistent",
+                    "mouse_probe_min_interval_ms": 20,
+                }, f)
+            reps = load_cell_reps(cell_dir)
+            s = summarize_cell(reps * 10)
+            self.assertEqual(s["probe_config"], {
+                "connection_mode": "persistent",
+                "min_interval_ms": 20.0,
+            })
 
     def test_marker_overrides_probe_ok(self):
         with tempfile.TemporaryDirectory() as t:

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -1,9 +1,16 @@
 """Mouse-latency probe driver — closed-loop TCP echo probes.
 
-Spawns M asyncio coroutines, each looping connect → send → recv-echo →
-close until --duration expires. No per-iteration sleep (closed-loop
-semantics; see plan §4.1). Writes a JSON file with histogram, percentiles,
-per-coroutine attempt counts, and a validity verdict.
+Spawns M asyncio coroutines, each looping echo transactions until
+--duration expires. The default `per-attempt` mode preserves the original
+connect → send → recv-echo → close transaction shape. The `persistent`
+mode keeps one TCP connection per coroutine and measures send →
+recv-echo transactions; this avoids turning high-concurrency 100E100M
+preflights into an echo-server accept/close benchmark. Both modes are
+closed-loop by default. When --min-interval-ms is non-zero, each coroutine
+sleeps only long enough to enforce a minimum start-to-start interval; it
+does not issue open-loop requests. Writes a JSON file with
+histogram, percentiles, per-coroutine attempt counts, and a validity
+verdict.
 
 Validity model (plan §4.2):
 - error_rate < 0.01.
@@ -23,7 +30,7 @@ import os
 import statistics
 import sys
 import time
-from typing import List
+from typing import List, Optional
 
 
 # Histogram bucket upper bounds in microseconds (plan §4.3).
@@ -32,10 +39,35 @@ HISTOGRAM_BUCKETS_US = [
 ]
 
 
-async def _run_probe_coro(
+async def _close_writer(writer: Optional[asyncio.StreamWriter]) -> None:
+    if writer is None:
+        return
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        pass
+
+
+async def _respect_min_interval(
+    attempt_started_ns: int,
+    min_interval_ms: float,
+    deadline: float,
+) -> None:
+    if min_interval_ms <= 0:
+        return
+    elapsed_s = (time.monotonic_ns() - attempt_started_ns) / 1_000_000_000
+    sleep_s = (min_interval_ms / 1000.0) - elapsed_s
+    remaining_s = deadline - time.monotonic()
+    if sleep_s > 0 and remaining_s > 0:
+        await asyncio.sleep(min(sleep_s, remaining_s))
+
+
+async def _run_per_attempt_probe_coro(
     target: str,
     port: int,
     payload_bytes: int,
+    min_interval_ms: float,
     deadline: float,
     rtts_us: List[int],
     attempt_counter: List[int],
@@ -78,13 +110,10 @@ async def _run_probe_coro(
                 )
                 if data != payload:
                     error_counter[0] += 1
+                    await _respect_min_interval(t0, min_interval_ms, deadline)
                     continue
             finally:
-                writer.close()
-                try:
-                    await writer.wait_closed()
-                except (BrokenPipeError, ConnectionResetError, OSError):
-                    pass
+                await _close_writer(writer)
         except (
             asyncio.TimeoutError,
             ConnectionRefusedError,
@@ -94,9 +123,129 @@ async def _run_probe_coro(
             OSError,
         ):
             error_counter[0] += 1
+            await _respect_min_interval(t0, min_interval_ms, deadline)
             continue
         t1 = time.monotonic_ns()
         rtts_us.append((t1 - t0) // 1000)
+        await _respect_min_interval(t0, min_interval_ms, deadline)
+
+
+async def _run_persistent_probe_coro(
+    target: str,
+    port: int,
+    payload_bytes: int,
+    min_interval_ms: float,
+    deadline: float,
+    rtts_us: List[int],
+    attempt_counter: List[int],
+    error_counter: List[int],
+) -> None:
+    """One coroutine using one long-lived echo connection.
+
+    Each counted attempt is an echo transaction. If the connection cannot
+    be established, that failed transaction is counted as an error so the
+    completed + errors == attempted validity invariant remains meaningful.
+    """
+    payload = os.urandom(payload_bytes)
+    reader: Optional[asyncio.StreamReader] = None
+    writer: Optional[asyncio.StreamWriter] = None
+
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            t0 = time.monotonic_ns()
+            if writer is None or writer.is_closing():
+                try:
+                    reader, writer = await asyncio.wait_for(
+                        asyncio.open_connection(target, port),
+                        timeout=min(5.0, remaining),
+                    )
+                except (
+                    asyncio.TimeoutError,
+                    ConnectionRefusedError,
+                    ConnectionResetError,
+                    BrokenPipeError,
+                    OSError,
+                ):
+                    attempt_counter[0] += 1
+                    error_counter[0] += 1
+                    reader = None
+                    writer = None
+                    await _respect_min_interval(t0, min_interval_ms, deadline)
+                    continue
+                # Connection setup is not a latency sample in persistent
+                # mode; it is only a prerequisite for later echo samples.
+                continue
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            t0 = time.monotonic_ns()
+            try:
+                writer.write(payload)
+                await writer.drain()
+            except (
+                asyncio.TimeoutError,
+                ConnectionRefusedError,
+                ConnectionResetError,
+                BrokenPipeError,
+                OSError,
+            ):
+                attempt_counter[0] += 1
+                error_counter[0] += 1
+                await _close_writer(writer)
+                reader = None
+                writer = None
+                await _respect_min_interval(t0, min_interval_ms, deadline)
+                continue
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                attempt_counter[0] += 1
+                error_counter[0] += 1
+                await _close_writer(writer)
+                reader = None
+                writer = None
+                await _respect_min_interval(t0, min_interval_ms, deadline)
+                break
+
+            attempt_counter[0] += 1
+            try:
+                assert reader is not None
+                data = await asyncio.wait_for(
+                    reader.readexactly(payload_bytes),
+                    timeout=min(5.0, remaining),
+                )
+                if data != payload:
+                    error_counter[0] += 1
+                    await _close_writer(writer)
+                    reader = None
+                    writer = None
+                    await _respect_min_interval(t0, min_interval_ms, deadline)
+                    continue
+            except (
+                asyncio.TimeoutError,
+                ConnectionRefusedError,
+                ConnectionResetError,
+                BrokenPipeError,
+                asyncio.IncompleteReadError,
+                OSError,
+            ):
+                error_counter[0] += 1
+                await _close_writer(writer)
+                reader = None
+                writer = None
+                await _respect_min_interval(t0, min_interval_ms, deadline)
+                continue
+            t1 = time.monotonic_ns()
+            rtts_us.append((t1 - t0) // 1000)
+            await _respect_min_interval(t0, min_interval_ms, deadline)
+    finally:
+        await _close_writer(writer)
 
 
 def _compute_histogram(rtts_us: List[int]) -> List[int]:
@@ -192,9 +341,14 @@ async def _run(args: argparse.Namespace) -> dict:
     attempts_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
     errors_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
     deadline = time.monotonic() + args.duration
+    probe_coro = (
+        _run_persistent_probe_coro
+        if args.connection_mode == "persistent"
+        else _run_per_attempt_probe_coro
+    )
     coros = [
-        _run_probe_coro(
-            args.target, args.port, args.payload_bytes, deadline,
+        probe_coro(
+            args.target, args.port, args.payload_bytes, args.min_interval_ms, deadline,
             rtts_per_coro[i], attempts_per_coro[i], errors_per_coro[i],
         )
         for i in range(args.concurrency)
@@ -238,6 +392,8 @@ async def _run(args: argparse.Namespace) -> dict:
             "concurrency": args.concurrency,
             "duration_s": args.duration,
             "payload_bytes": args.payload_bytes,
+            "connection_mode": args.connection_mode,
+            "min_interval_ms": args.min_interval_ms,
         },
         "totals": {
             "attempted": attempted,
@@ -267,6 +423,21 @@ def main() -> int:
     p.add_argument("--concurrency", type=int, required=True)
     p.add_argument("--duration", type=float, required=True)
     p.add_argument("--payload-bytes", type=int, default=64)
+    p.add_argument(
+        "--connection-mode",
+        choices=("per-attempt", "persistent"),
+        default="per-attempt",
+        help=(
+            "per-attempt opens a new TCP connection per echo transaction; "
+            "persistent keeps one connection per coroutine"
+        ),
+    )
+    p.add_argument(
+        "--min-interval-ms",
+        type=float,
+        default=0.0,
+        help="minimum start-to-start interval per coroutine in milliseconds",
+    )
     p.add_argument("--out", required=True)
     args = p.parse_args()
     result = asyncio.run(_run(args))

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -1,7 +1,10 @@
+import asyncio
 import unittest
+from types import SimpleNamespace
 
 from mouse_latency_probe import (
     HISTOGRAM_BUCKETS_US,
+    _run,
     _compute_histogram,
     _compute_percentiles,
     compute_validity,
@@ -139,6 +142,95 @@ class ValidityTests(unittest.TestCase):
         v = compute_validity(10, [600] * 10, completed=5500, errors=100)
         self.assertFalse(v["ok"])
         self.assertTrue(any("inconsistent-counts" in r for r in v["reasons"]))
+
+
+class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
+    async def _run_local_echo_probe(
+        self,
+        *,
+        concurrency,
+        duration,
+        min_interval_ms,
+        connection_mode="persistent",
+    ):
+        connection_count = 0
+
+        async def handle_echo(reader, writer):
+            nonlocal connection_count
+            connection_count += 1
+            try:
+                while True:
+                    data = await reader.read(4096)
+                    if not data:
+                        break
+                    writer.write(data)
+                    await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+            finally:
+                writer.close()
+
+        server = await asyncio.start_server(handle_echo, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        try:
+            args = SimpleNamespace(
+                target="127.0.0.1",
+                port=port,
+                concurrency=concurrency,
+                duration=duration,
+                payload_bytes=16,
+                connection_mode=connection_mode,
+                min_interval_ms=min_interval_ms,
+            )
+            result = await _run(args)
+        finally:
+            server.close()
+            await server.wait_closed()
+        return result, connection_count
+
+    async def test_persistent_mode_reuses_one_connection_per_coroutine(self):
+        result, connection_count = await self._run_local_echo_probe(
+            concurrency=3,
+            duration=0.2,
+            min_interval_ms=0.0,
+        )
+        self.assertEqual(result["config"]["connection_mode"], "persistent")
+        self.assertEqual(result["config"]["min_interval_ms"], 0.0)
+        self.assertGreater(result["totals"]["completed"], 3)
+        self.assertEqual(
+            result["totals"]["attempted"],
+            result["totals"]["completed"] + result["totals"]["errors"],
+        )
+        self.assertLessEqual(result["totals"]["error_rate"], 0.05)
+        self.assertLessEqual(connection_count, 3)
+
+    async def test_min_interval_bounds_persistent_attempt_rate(self):
+        result, connection_count = await self._run_local_echo_probe(
+            concurrency=1,
+            duration=0.12,
+            min_interval_ms=20.0,
+        )
+        self.assertEqual(result["config"]["min_interval_ms"], 20.0)
+        self.assertGreaterEqual(result["totals"]["completed"], 3)
+        self.assertLessEqual(result["totals"]["attempted"], 8)
+        self.assertLessEqual(connection_count, 1)
+
+    async def test_min_interval_bounds_per_attempt_rate(self):
+        result, connection_count = await self._run_local_echo_probe(
+            concurrency=1,
+            duration=0.12,
+            min_interval_ms=20.0,
+            connection_mode="per-attempt",
+        )
+        self.assertEqual(result["config"]["connection_mode"], "per-attempt")
+        self.assertEqual(result["config"]["min_interval_ms"], 20.0)
+        self.assertGreaterEqual(result["totals"]["completed"], 3)
+        self.assertLessEqual(result["totals"]["attempted"], 8)
+        self.assertEqual(
+            result["totals"]["attempted"],
+            result["totals"]["completed"] + result["totals"]["errors"],
+        )
+        self.assertGreaterEqual(connection_count, result["totals"]["completed"])
 
 
 if __name__ == "__main__":

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -7,6 +7,13 @@
 # the diagnostic surplus-sharing fixture instead of the strict exact
 # fixture. The per-rep manifest records the selected fixture bit.
 #
+# Set MOUSE_PROBE_CONNECTION_MODE=persistent for high-concurrency
+# 100E100M runs where the validation target is tail latency of
+# established mouse transactions rather than echo-server accept rate.
+# Set MOUSE_PROBE_MIN_INTERVAL_MS=20 with that mode on the isolated
+# validation cluster; it still produces hundreds of thousands of
+# samples per 60-second rep without overdriving the port-7 echo daemon.
+#
 # 12 cells: N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}.
 # Per cell: run up to 15 total reps as needed to reach 10 valid reps.
 # Cell stops at 10 valid reps OR 15 total, whichever is first.

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -39,12 +39,15 @@ ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
 MOUSE_PORT="${MOUSE_PORT:-7}"
 MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
 MOUSE_COS_SURPLUS_SHARING="${MOUSE_COS_SURPLUS_SHARING:-0}"
+MOUSE_PROBE_CONNECTION_MODE="${MOUSE_PROBE_CONNECTION_MODE:-per-attempt}"
+MOUSE_PROBE_MIN_INTERVAL_MS="${MOUSE_PROBE_MIN_INTERVAL_MS:-0}"
 SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf-a); same-class iperf-b sets 10 Gb/s
 # Validate env-overrides (Copilot D.5): ports/bps must be
 # digits only so they can't smuggle shell metacharacters into
-# the remote `bash -c` interpolations below, and MOUSE_CLASS is
-# whitelisted to the four configured forwarding classes so a
-# typo can't slip a stray value into manifest.json.
+# the remote `bash -c` interpolations below. MOUSE_CLASS and
+# MOUSE_PROBE_CONNECTION_MODE are whitelisted, MOUSE_COS_SURPLUS_SHARING
+# is normalized as a boolean, and MOUSE_PROBE_MIN_INTERVAL_MS is numeric,
+# so typos can't slip stray values into manifest.json or the probe CLI.
 [[ "$ELEPHANT_PORT" =~ ^[0-9]+$ ]] \
     || { echo "ABORT: ELEPHANT_PORT='$ELEPHANT_PORT' must be digits" >&2; exit 1; }
 [[ "$MOUSE_PORT" =~ ^[0-9]+$ ]] \
@@ -60,6 +63,12 @@ case "${MOUSE_COS_SURPLUS_SHARING,,}" in
     1|true|yes|on) MOUSE_COS_SURPLUS_SHARING=1 ;;
     *) echo "ABORT: MOUSE_COS_SURPLUS_SHARING='$MOUSE_COS_SURPLUS_SHARING' must be boolean" >&2; exit 1 ;;
 esac
+case "$MOUSE_PROBE_CONNECTION_MODE" in
+    per-attempt|persistent) ;;
+    *) echo "ABORT: MOUSE_PROBE_CONNECTION_MODE='$MOUSE_PROBE_CONNECTION_MODE' must be per-attempt or persistent" >&2; exit 1 ;;
+esac
+[[ "$MOUSE_PROBE_MIN_INTERVAL_MS" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+    || { echo "ABORT: MOUSE_PROBE_MIN_INTERVAL_MS='$MOUSE_PROBE_MIN_INTERVAL_MS' must be a non-negative number" >&2; exit 1; }
 SETTLE_BUDGET=20
 SLACK=10
 
@@ -170,7 +179,7 @@ trap cleanup EXIT
 # previously left a stale file behind that the next reuse with the
 # same tag would inherit. Belt-and-suspenders.)
 incus_exec "$SOURCE" sh -c \
-    "rm -f /tmp/probe-${REP_TAG}.json /tmp/mpstat-${REP_TAG}.txt /tmp/iperf3-${REP_TAG}.txt" \
+    "rm -f /tmp/mouse_latency_probe.py /tmp/probe-${REP_TAG}.json /tmp/mpstat-${REP_TAG}.txt /tmp/iperf3-${REP_TAG}.txt" \
     < /dev/null > /dev/null 2>&1 || true
 
 # Push helper scripts to the source container (probe driver runs there).
@@ -295,7 +304,9 @@ MPSTAT_PID=$!
 incus_exec "$SOURCE" python3 /tmp/mouse_latency_probe.py \
     --target "$TARGET_V4" --port "$MOUSE_PORT" \
     --concurrency "$M" --duration "$DURATION" \
-    --payload-bytes 64 --out "/tmp/probe-${REP_TAG}.json" \
+    --payload-bytes 64 --connection-mode "$MOUSE_PROBE_CONNECTION_MODE" \
+    --min-interval-ms "$MOUSE_PROBE_MIN_INTERVAL_MS" \
+    --out "/tmp/probe-${REP_TAG}.json" \
     > "${OUT_DIR}/probe-stdout.log" 2>&1 || true
 
 set +e
@@ -478,6 +489,8 @@ SCREEN_ENGAGED="$screen_engaged" HA_TRANSITION_SEEN="$ha_seen" \
 MPSTAT_AVG_BUSY="${mpstat_busy:-0}" \
 ELEPHANT_PORT="$ELEPHANT_PORT" MOUSE_PORT="$MOUSE_PORT" \
 MOUSE_CLASS="$MOUSE_CLASS" MOUSE_COS_SURPLUS_SHARING="$MOUSE_COS_SURPLUS_SHARING" \
+MOUSE_PROBE_CONNECTION_MODE="$MOUSE_PROBE_CONNECTION_MODE" \
+MOUSE_PROBE_MIN_INTERVAL_MS="$MOUSE_PROBE_MIN_INTERVAL_MS" \
 SHAPER_BPS="$SHAPER_BPS" \
 python3 -c '
 import json, os
@@ -493,6 +506,8 @@ manifest = {
     "mouse_port": int(os.environ["MOUSE_PORT"]),
     "mouse_class": os.environ["MOUSE_CLASS"],
     "cos_surplus_sharing": os.environ["MOUSE_COS_SURPLUS_SHARING"] == "1",
+    "mouse_probe_connection_mode": os.environ["MOUSE_PROBE_CONNECTION_MODE"],
+    "mouse_probe_min_interval_ms": float(os.environ["MOUSE_PROBE_MIN_INTERVAL_MS"]),
     "shaper_bps": int(os.environ["SHAPER_BPS"]),
 }
 print(json.dumps(manifest, indent=2))


### PR DESCRIPTION
## Summary

- add `--connection-mode persistent` to `mouse_latency_probe.py` so high-concurrency 100E100M runs measure established echo transactions instead of echo-server accept/close capacity
- add `--min-interval-ms` and wire it through `test-mouse-latency.sh` as `MOUSE_PROBE_MIN_INTERVAL_MS`
- record probe mode and interval in each rep manifest
- document the canonical 100E100M mode as `MOUSE_PROBE_CONNECTION_MODE=persistent` + `MOUSE_PROBE_MIN_INTERVAL_MS=20`

Closes #1343.

## Validation

Local:

- `python3 test/incus/mouse_latency_probe_test.py`
- `python3 test/incus/mouse_latency_aggregate_test.py`
- `python3 -m py_compile test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`
- `bash -n test/incus/test-mouse-latency.sh test/incus/test-mouse-latency-matrix.sh`
- `git diff --check`

Cluster evidence on `loss:cluster-userspace-host` against `172.16.80.200:7`:

- direct M=100, 10s smoke with `persistent + 20ms`: `attempted=46200 completed=46162 errors=38 error_rate=0.0008 p999=13440us validity.ok=true`
- actual harness preflight shape, M=100, 60s with `persistent + 20ms`: artifact `/tmp/xpf-1343-harness-preflight-i20-20260515-232146`; `attempted=283431 completed=283430 errors=1 error_rate=0.0000035 p999=14076us validity.ok=true`; manifest recorded `mouse_probe_connection_mode=persistent` and `mouse_probe_min_interval_ms=20.0`

## Notes

Unpaced persistent mode still overdrives the target echo service over 60 seconds. The 20ms per-coroutine interval keeps a high sample count (~280k samples/rep) while avoiding validation false-failures caused by the echo daemon rather than the dataplane.