### PR TITLE
Fail mouse-latency cells below valid-rep target

### DIFF
--- a/docs/pr/905-mouse-latency/plan.md
+++ b/docs/pr/905-mouse-latency/plan.md
@@ -523,9 +523,9 @@ The cell's hard rep ceiling is **15** (matching §4.7's
 auto-extension), of which up to 5 may be retries. So a cell
 that hits 10 valid reps without retries is done at 10; a cell
 with retry-eligible failures gets up to 5 replacement reps,
-not exceeding 15 total. Cells with > 7 valid reps after 15
-are reported with the data they have; cells with < 7 valid
-reps are INSUFFICIENT-DATA.
+not exceeding 15 total. Gate-grade cells require all 10 valid
+reps; cells with fewer than 10 valid reps after the 15-rep
+ceiling are INSUFFICIENT-DATA.
 
 ### 4.6 Echo-server preflight (R1 #17)
 
@@ -567,7 +567,7 @@ with §4.7 auto-extension):**
   mechanisms are subordinate to the 15-rep ceiling.
 - Cell stops once 10 valid reps are collected, or 15 total
   reps have run, whichever is first.
-- Cell is reported INSUFFICIENT-DATA if fewer than 7 valid
+- Cell is reported INSUFFICIENT-DATA if fewer than 10 valid
   reps after the ceiling.
 
 **Wall-budget math (R2 F4):** per-rep total is iperf3
@@ -713,7 +713,7 @@ Modified files: none.
 - Median-of-10 by p99 picks the 5th-or-6th rep, not the mean.
 - Decision-threshold computes correctly for synthetic inputs at
   PASS, FAIL, exactly-2.0× boundary.
-- INSUFFICIENT-DATA verdict when valid reps < 7.
+- INSUFFICIENT-DATA verdict when valid reps < 10.
 - INVALID cells excluded from median.
 
 `cluster_status_parse_test.py` (R4 HIGH 1, schema updated by

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -6,6 +6,9 @@ Per-rep validity is read from probe.json["validity"]["ok"].
 For each cell, the median valid rep for the configured gate percentile
 is selected as the representative; its p50/p95/p99/p99.9 +
 IQR-of-p99-across-reps + achieved-RPS summary populate summary.json.
+Cells require 10 valid reps to report status OK; if the runner reaches
+its 15-rep ceiling with fewer valid reps, the gate is
+INSUFFICIENT-DATA.
 
 Default decision threshold (#905, plan §7.2):
 - p99(N=128, M=10, best-effort) ≤ 2 × p99(N=0, M=10, best-effort)
@@ -33,6 +36,7 @@ GATE_PERCENTILE_TO_RTT_KEY = {
     "p99_us": "p99",
     "p999_us": "p999",
 }
+REQUIRED_VALID_REPS = 10
 
 
 def has_invalid_marker(rep_dir: str) -> bool:
@@ -119,8 +123,8 @@ def summarize_cell(reps: List[dict], representative_percentile: str = "p99") -> 
         "iqr_p99_across_reps": None,
         "representative_percentile": representative_percentile,
     }
-    if len(valid) < 7:
-        summary["status"] = "INSUFFICIENT-DATA"
+    if len(valid) < REQUIRED_VALID_REPS:
+        summary["status"] = "INSUFFICIENT-VALID-REPS"
         return summary
     median = median_rep_by_percentile(valid, representative_percentile)
     p99s = sorted(

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -62,10 +62,21 @@ class MedianByP99Tests(unittest.TestCase):
 
 class SummarizeCellTests(unittest.TestCase):
     def test_insufficient_valid_reps(self):
-        # Only 5 valid → INSUFFICIENT-DATA
+        # Only 5 valid -> insufficient for a gate-grade cell.
         reps = [_make_rep(100) for _ in range(5)]
         s = summarize_cell(reps)
-        self.assertEqual(s["status"], "INSUFFICIENT-DATA")
+        self.assertEqual(s["status"], "INSUFFICIENT-VALID-REPS")
+
+    def test_nine_valid_reps_is_insufficient(self):
+        # A cell that exhausts the 15-rep ceiling at 9 valid reps must
+        # not render as OK; gate-grade artifacts require the full 10.
+        valid = [_make_rep(p99=100 + 10 * i) for i in range(9)]
+        invalid = [_make_rep(p99=99999, ok=False) for _ in range(6)]
+        s = summarize_cell(valid + invalid)
+        self.assertEqual(s["n_reps_valid"], 9)
+        self.assertEqual(s["n_reps_total"], 15)
+        self.assertEqual(s["status"], "INSUFFICIENT-VALID-REPS")
+        self.assertIsNone(s["median_rep"])
 
     def test_ok_with_10_valid(self):
         reps = [_make_rep(p99=100 + 10 * i) for i in range(10)]
@@ -75,14 +86,14 @@ class SummarizeCellTests(unittest.TestCase):
         self.assertIsNotNone(s["iqr_p99_across_reps"])
 
     def test_excludes_invalid_from_median(self):
-        # 7 valid + 3 invalid; the invalid ones with extreme p99 must
+        # 10 valid + 3 invalid; the invalid ones with extreme p99 must
         # not contribute to the median.
-        valid = [_make_rep(p99=100 + 10 * i) for i in range(7)]
+        valid = [_make_rep(p99=100 + 10 * i) for i in range(10)]
         invalid = [_make_rep(p99=99999, ok=False) for _ in range(3)]
         s = summarize_cell(valid + invalid)
         self.assertEqual(s["status"], "OK")
-        # Median p99 of 100..160 is at index 3 → 130.
-        self.assertEqual(s["median_rep"]["p99_us"], 130)
+        # Median p99 of 100..190 is at index 5 → 150.
+        self.assertEqual(s["median_rep"]["p99_us"], 150)
 
 
 class DecideTests(unittest.TestCase):
@@ -158,6 +169,13 @@ class DecideTests(unittest.TestCase):
         loaded = summarize_cell([_make_rep(p99=100) for _ in range(5)])
         v = decide({(0, 10): idle, (128, 10): loaded})
         self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
+
+    def test_nine_valid_gate_cell_is_insufficient(self):
+        idle = summarize_cell([_make_rep(p99=100) for _ in range(10)])
+        loaded = summarize_cell([_make_rep(p99=100) for _ in range(9)])
+        v = decide({(0, 10): idle, (128, 10): loaded})
+        self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
+        self.assertIn("INSUFFICIENT-VALID-REPS", v["reason"])
 
 
 class LoadCellRepsInvalidMarkerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- require the mouse-latency reducer to see the full 10 valid reps before a cell reports `OK`
- report cells below that target as `INSUFFICIENT-VALID-REPS`
- keep the final verdict fail-closed as `INSUFFICIENT-DATA` when any gate cell lacks enough valid reps
- update the #905 plan text to match the runner's gate-grade 10-valid-rep target

Closes #1360.

## Validation

- `python3 test/incus/mouse_latency_aggregate_test.py`
- `python3 -m py_compile test/incus/mouse_latency_aggregate.py`
- `git diff --check`
- Replayed the surplus 100E100M artifact `/tmp/xpf-100e100m-surplus-persistent-i20-20260515-235752`: loaded `9/15` now reports `INSUFFICIENT-VALID-REPS`; final verdict is `INSUFFICIENT-DATA`; reducer exits `2`.