### PR TITLE
Bound mouse latency probe drain by deadline

### DIFF
--- a/docs/pr/905-mouse-latency/plan.md
+++ b/docs/pr/905-mouse-latency/plan.md
@@ -233,8 +233,10 @@ produce a bounded global rate. v2 drops the sleep entirely:
    a. `t0 = time.monotonic_ns()`.
    b. Open TCP socket to `(target, port)` with a 5 s connect
       timeout.
-   c. Send `--payload-bytes` random bytes; flush.
-   d. Read back exactly `--payload-bytes`; on short-read or
+   c. Send `--payload-bytes` random bytes; flush with a
+      deadline-bounded `drain()`.
+   d. Read back exactly `--payload-bytes`; on drain timeout,
+      short-read, or
       timeout, count as error.
    e. Close socket.
    f. `t1 = time.monotonic_ns()`.
@@ -244,6 +246,12 @@ produce a bounded global rate. v2 drops the sleep entirely:
 
 This is canonical closed-loop "M concurrent mice". Achieved RPS
 falls if RTT rises; that drop IS data, not a bug.
+
+Implementation note: later 100E100M work added a `persistent`
+connection mode and optional `--min-interval-ms` closed-loop
+start-to-start spacing. Both modes keep connect, write-drain, and
+echo-read phases bounded by the probe deadline so TCP backpressure
+cannot stall a rep beyond `--duration`.
 
 ### 4.2 Achieved-RPS as co-metric (R1 #2, #3)
 

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -42,12 +42,32 @@ HISTOGRAM_BUCKETS_US = [
 ]
 
 
-async def _close_writer(writer: Optional[asyncio.StreamWriter]) -> None:
+def _abort_writer(writer: asyncio.StreamWriter) -> None:
+    transport = getattr(writer, "transport", None)
+    if transport is not None:
+        transport.abort()
+
+
+async def _close_writer(
+    writer: Optional[asyncio.StreamWriter],
+    deadline: float,
+    *,
+    abort: bool = False,
+) -> None:
     if writer is None:
+        return
+    if abort:
+        _abort_writer(writer)
+        return
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        _abort_writer(writer)
         return
     writer.close()
     try:
-        await writer.wait_closed()
+        await asyncio.wait_for(writer.wait_closed(), timeout=remaining)
+    except asyncio.TimeoutError:
+        _abort_writer(writer)
     except (BrokenPipeError, ConnectionResetError, OSError):
         pass
 
@@ -123,7 +143,7 @@ async def _run_per_attempt_probe_coro(
                     await _respect_min_interval(t0, min_interval_ms, deadline)
                     continue
             finally:
-                await _close_writer(writer)
+                await _close_writer(writer, deadline)
         except (
             asyncio.TimeoutError,
             ConnectionRefusedError,
@@ -207,7 +227,7 @@ async def _run_persistent_probe_coro(
             ):
                 attempt_counter[0] += 1
                 error_counter[0] += 1
-                await _close_writer(writer)
+                await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
                 await _respect_min_interval(t0, min_interval_ms, deadline)
@@ -217,7 +237,7 @@ async def _run_persistent_probe_coro(
             if remaining <= 0:
                 attempt_counter[0] += 1
                 error_counter[0] += 1
-                await _close_writer(writer)
+                await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
                 await _respect_min_interval(t0, min_interval_ms, deadline)
@@ -232,7 +252,7 @@ async def _run_persistent_probe_coro(
                 )
                 if data != payload:
                     error_counter[0] += 1
-                    await _close_writer(writer)
+                    await _close_writer(writer, deadline, abort=True)
                     reader = None
                     writer = None
                     await _respect_min_interval(t0, min_interval_ms, deadline)
@@ -246,7 +266,7 @@ async def _run_persistent_probe_coro(
                 OSError,
             ):
                 error_counter[0] += 1
-                await _close_writer(writer)
+                await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
                 await _respect_min_interval(t0, min_interval_ms, deadline)
@@ -255,7 +275,7 @@ async def _run_persistent_probe_coro(
             rtts_us.append((t1 - t0) // 1000)
             await _respect_min_interval(t0, min_interval_ms, deadline)
     finally:
-        await _close_writer(writer)
+        await _close_writer(writer, deadline)
 
 
 def _compute_histogram(rtts_us: List[int]) -> List[int]:

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -127,6 +127,7 @@ async def _run_per_attempt_probe_coro(
                 asyncio.open_connection(target, port),
                 timeout=min(5.0, remaining),
             )
+            abort_close = True
             try:
                 writer.write(payload)
                 await _drain_with_deadline(writer, deadline)
@@ -142,8 +143,9 @@ async def _run_per_attempt_probe_coro(
                     error_counter[0] += 1
                     await _respect_min_interval(t0, min_interval_ms, deadline)
                     continue
+                abort_close = False
             finally:
-                await _close_writer(writer, deadline)
+                await _close_writer(writer, deadline, abort=abort_close)
         except (
             asyncio.TimeoutError,
             ConnectionRefusedError,

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -12,6 +12,9 @@ does not issue open-loop requests. Writes a JSON file with
 histogram, percentiles, per-coroutine attempt counts, and a validity
 verdict.
 
+Connect, write-drain, and echo-read phases are deadline-bounded so TCP
+backpressure cannot stall a probe beyond --duration.
+
 Validity model (plan §4.2):
 - error_rate < 0.01.
 - min(attempts_per_coroutine) >= 0.5 × median(attempts) (only when M >= 2).
@@ -63,6 +66,13 @@ async def _respect_min_interval(
         await asyncio.sleep(min(sleep_s, remaining_s))
 
 
+async def _drain_with_deadline(writer: asyncio.StreamWriter, deadline: float) -> None:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise asyncio.TimeoutError("deadline expired before drain")
+    await asyncio.wait_for(writer.drain(), timeout=min(5.0, remaining))
+
+
 async def _run_per_attempt_probe_coro(
     target: str,
     port: int,
@@ -99,7 +109,7 @@ async def _run_per_attempt_probe_coro(
             )
             try:
                 writer.write(payload)
-                await writer.drain()
+                await _drain_with_deadline(writer, deadline)
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     error_counter[0] += 1
@@ -187,7 +197,7 @@ async def _run_persistent_probe_coro(
             t0 = time.monotonic_ns()
             try:
                 writer.write(payload)
-                await writer.drain()
+                await _drain_with_deadline(writer, deadline)
             except (
                 asyncio.TimeoutError,
                 ConnectionRefusedError,

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import unittest
 from types import SimpleNamespace
 
@@ -143,6 +144,51 @@ class ValidityTests(unittest.TestCase):
         v = compute_validity(10, [600] * 10, completed=5500, errors=100)
         self.assertFalse(v["ok"])
         self.assertTrue(any("inconsistent-counts" in r for r in v["reasons"]))
+
+
+class CloseWriterTests(unittest.IsolatedAsyncioTestCase):
+    class _Transport:
+        def __init__(self):
+            self.aborted = False
+
+        def abort(self):
+            self.aborted = True
+
+    class _HangingWriter:
+        def __init__(self):
+            self.closed = False
+            self.transport = CloseWriterTests._Transport()
+            self.wait_started = asyncio.Event()
+
+        def close(self):
+            self.closed = True
+
+        async def wait_closed(self):
+            self.wait_started.set()
+            await asyncio.Event().wait()
+
+    async def test_close_writer_aborts_when_wait_closed_exceeds_deadline(self):
+        writer = self._HangingWriter()
+        deadline = time.monotonic() + 0.01
+
+        await asyncio.wait_for(probe._close_writer(writer, deadline), timeout=0.2)
+
+        self.assertTrue(writer.closed)
+        self.assertTrue(writer.wait_started.is_set())
+        self.assertTrue(writer.transport.aborted)
+
+    async def test_close_writer_abort_mode_skips_graceful_wait(self):
+        writer = self._HangingWriter()
+        deadline = time.monotonic() + 10.0
+
+        await asyncio.wait_for(
+            probe._close_writer(writer, deadline, abort=True),
+            timeout=0.2,
+        )
+
+        self.assertFalse(writer.closed)
+        self.assertFalse(writer.wait_started.is_set())
+        self.assertTrue(writer.transport.aborted)
 
 
 class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from types import SimpleNamespace
 
+import mouse_latency_probe as probe
 from mouse_latency_probe import (
     HISTOGRAM_BUCKETS_US,
     _run,
@@ -231,6 +232,63 @@ class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
             result["totals"]["completed"] + result["totals"]["errors"],
         )
         self.assertGreaterEqual(connection_count, result["totals"]["completed"])
+
+    async def _run_with_forced_drain_timeout(self, *, connection_mode):
+        async def handle_echo(reader, writer):
+            try:
+                while await reader.read(4096):
+                    writer.write(b"x")
+                    await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+            finally:
+                writer.close()
+
+        async def forced_timeout(_writer, _deadline):
+            raise asyncio.TimeoutError("forced drain timeout")
+
+        server = await asyncio.start_server(handle_echo, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        original_drain = probe._drain_with_deadline
+        probe._drain_with_deadline = forced_timeout
+        try:
+            args = SimpleNamespace(
+                target="127.0.0.1",
+                port=port,
+                concurrency=1,
+                duration=0.08,
+                payload_bytes=16,
+                connection_mode=connection_mode,
+                min_interval_ms=20.0,
+            )
+            result = await asyncio.wait_for(_run(args), timeout=1.0)
+        finally:
+            probe._drain_with_deadline = original_drain
+            server.close()
+            await server.wait_closed()
+        return result
+
+    async def test_per_attempt_drain_timeout_counts_error_and_terminates(self):
+        result = await self._run_with_forced_drain_timeout(
+            connection_mode="per-attempt"
+        )
+        self.assertEqual(result["totals"]["completed"], 0)
+        self.assertGreater(result["totals"]["attempted"], 0)
+        self.assertEqual(
+            result["totals"]["attempted"],
+            result["totals"]["errors"],
+        )
+
+    async def test_persistent_drain_timeout_counts_error_and_terminates(self):
+        result = await self._run_with_forced_drain_timeout(
+            connection_mode="persistent"
+        )
+        self.assertEqual(result["totals"]["completed"], 0)
+        self.assertGreater(result["totals"]["attempted"], 0)
+        self.assertEqual(
+            result["totals"]["attempted"],
+            result["totals"]["errors"],
+        )
 
 
 if __name__ == "__main__":

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -167,6 +167,9 @@ class CloseWriterTests(unittest.IsolatedAsyncioTestCase):
             self.wait_started.set()
             await asyncio.Event().wait()
 
+        def write(self, _data):
+            pass
+
     async def test_close_writer_aborts_when_wait_closed_exceeds_deadline(self):
         writer = self._HangingWriter()
         deadline = time.monotonic() + 0.01
@@ -189,6 +192,50 @@ class CloseWriterTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(writer.closed)
         self.assertFalse(writer.wait_started.is_set())
         self.assertTrue(writer.transport.aborted)
+
+    async def test_per_attempt_drain_timeout_closes_with_abort(self):
+        abort_flags = []
+
+        class FakeReader:
+            async def readexactly(self, _n):
+                return b""
+
+        async def open_fake_connection(_target, _port):
+            return FakeReader(), self._HangingWriter()
+
+        async def forced_timeout(_writer, _deadline):
+            raise asyncio.TimeoutError("forced drain timeout")
+
+        async def record_close(_writer, _deadline, *, abort=False):
+            abort_flags.append(abort)
+
+        original_open_connection = probe.asyncio.open_connection
+        original_drain = probe._drain_with_deadline
+        original_close = probe._close_writer
+        probe.asyncio.open_connection = open_fake_connection
+        probe._drain_with_deadline = forced_timeout
+        probe._close_writer = record_close
+        try:
+            rtts = []
+            attempts = [0]
+            errors = [0]
+            await probe._run_per_attempt_probe_coro(
+                "127.0.0.1",
+                1,
+                16,
+                0.0,
+                time.monotonic() + 0.01,
+                rtts,
+                attempts,
+                errors,
+            )
+        finally:
+            probe.asyncio.open_connection = original_open_connection
+            probe._drain_with_deadline = original_drain
+            probe._close_writer = original_close
+
+        self.assertGreaterEqual(errors[0], 1)
+        self.assertIn(True, abort_flags)
 
 
 class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- Bound `writer.drain()` with the same remaining-deadline model as connect/read in both mouse probe connection modes.
- Preserve existing attempt/error accounting: a drain timeout is an errored attempted transaction.
- Add forced-drain-timeout regression tests for `per-attempt` and `persistent` modes.
- Update the #905 plan doc so the module contract includes deadline-bounded drain behavior.

Closes #1363.

## Validation

- `python3 test/incus/mouse_latency_probe_test.py`
- `python3 test/incus/mouse_latency_aggregate_test.py`
- `python3 -m py_compile test/incus/mouse_latency_probe.py`
- `bash -n test/incus/test-mouse-latency.sh test/incus/test-mouse-latency-matrix.sh`
- `git diff --check`