### PR TITLE
Refactor CoS fixture port grid

### DIFF
--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -8,6 +8,14 @@ claims to move TCP fairness, retransmit count, or cwnd-collapse numbers on
 the 16-flow iperf3 workload — otherwise you are likely to repeat the
 mistake described in #725 or the VLAN-offset bug resolved in #728.
 
+Current validation fixture map: iperf ports 5200..5211 and TCP echo
+ports 6200..6211 share the same CoS class index. 5200/6200 are
+best-effort/root-shaped, 5201/6201 are 100M exact, 5202/6202 are 1G
+exact, then 5203..5210 / 6203..6210 step through 3G, 6G, 9G, 12G, 15G,
+18G, 21G, and 24G exact. 5211/6211 are uncapped except for the
+interface root shaper. Older measurements below may cite the pre-grid
+class names (`iperf-a`/`iperf-b`/`iperf-c`) and queue IDs.
+
 ## How to read admission drop counters live
 
 Since #724, `show class-of-service interface` renders three per-queue
@@ -167,8 +175,8 @@ The decision tree:
 
 #1312 pinned the canonical iperf fixture buffers for the low-rate exact
 classes after reverse `-P 12` reproduced high retransmits with equal-flow
-disabled: `scheduler-be` uses `buffer-size 500k` and
-`scheduler-iperf-a` uses `buffer-size 4m`.
+disabled: `scheduler-100m` uses `buffer-size 500k` and
+`scheduler-1g` uses `buffer-size 4m`.
 
 When `buffer-size` is omitted, queue `base` comes from
 `max(transmit_rate_bytes/100, 96_000)` (10 ms of bytes with a 96 KB
@@ -182,7 +190,7 @@ the exact flow-fair admission gates need enough aggregate and per-flow
 headroom to avoid persistent tail-drop at 12 active TCP flows. They also
 trade latency headroom for retransmit suppression (`500k` at 100M ≈ 40 ms
 residence; `4m` at 1G ≈ 32 ms at full queue). Treat changes to these
-fixture values as admission-policy changes and rerun the q0/q4 reverse
+fixture values as admission-policy changes and rerun the q1/q2 reverse
 sweep before trusting low-rate fairness evidence.
 
 ## Pre-buffer-sizing dominant failure mode on this workload

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -266,10 +266,10 @@ harness command is:
 COS_IFINDEX=<egress-ifindex> ./test/incus/fairness-harness.sh --mixed-cos
 ```
 
-With the default symmetric CoS fixture this runs port 5201
-(`iperf-a`, queue 4) and port 5202 (`iperf-b`, queue 5) concurrently,
+With the default symmetric CoS fixture this runs port 5202
+(`iperf-1g`, queue 2) and port 5205 (`iperf-9g`, queue 5) concurrently,
 then invokes `fairness-eval` twice against the same
-`xpf_userspace_cos_active_flow_count` scrape: once for queue 4 and
+`xpf_userspace_cos_active_flow_count` scrape: once for queue 2 and
 once for queue 5. Non-canonical fixtures must set `COS_QUEUE_ID` and
 `MIXED_COS_QUEUE_ID` explicitly. `MIXED_RSS_EXPECTATION` defaults to
 `RSS_EXPECTATION`, so one expectation gate applies to both classes
@@ -346,19 +346,20 @@ produce very low CoV even when high-rate classes remain unfair. Use the
 class sweep harness to exercise every canonical fixture port:
 
 The canonical iperf CoS fixtures intentionally give the two low-rate
-classes deeper buffers than the implicit admission/buffer cap:
-`scheduler-be` uses `buffer-size 500k` and `scheduler-iperf-a` uses
+exact classes deeper buffers than the implicit admission/buffer cap:
+`scheduler-100m` uses `buffer-size 500k` and `scheduler-1g` uses
 `buffer-size 4m`. Without explicit `buffer-size`, queue `base` is
 `max(transmit_rate_bytes/100, 96_000)` (10 ms of bytes with a 96 KB
 floor), then admission applies the flow-aware
 `prospective_active * 24 KB` expansion plus the #717 5 ms envelope clamp
 (`.min(delay_cap.max(base))`). #1312 showed that those implicit caps
 reproduce reverse-mode tail-drop under `-P 12` even when equal-flow
-suppression is disabled: q0 hit aggregate admission drops and q4 hit
-per-flow share drops. The fixture overrides therefore trade queue
-residence for retransmit suppression (q0 500k@100M ≈ 40 ms, q4 4m@1G
+suppression is disabled: the 100M class hit aggregate admission drops,
+and the 1G class hit per-flow share drops. The fixture overrides
+therefore trade queue residence for retransmit suppression (q1
+500k@100M ≈ 40 ms, q2 4m@1G
 ≈ 32 ms at full queue). Do not remove or shrink these buffers without
-rerunning at least the q0/q4 reverse sweep and checking retransmits plus
+rerunning at least the q1/q2 reverse sweep and checking retransmits plus
 CoS admission drop deltas.
 
 Those values are an explicit validation-fixture tradeoff, not a general
@@ -377,7 +378,7 @@ IPERF_LAUNCH_ARG_3=-- \
 ./test/incus/fairness-cos-class-sweep.sh
 ```
 
-The sweep runs ports 5201..5207 through `fairness_multi_sample.py`,
+The sweep runs ports 5200..5211 through `fairness_multi_sample.py`,
 preserves per-class artifacts, writes `summary.tsv` and `summary.md`,
 and returns non-zero after completing all classes if any class misses
 the Cstruct-aware multi-sample contract (`mean_gap ≤ 0.05` and
@@ -396,7 +397,7 @@ METRICS_URL=http://127.0.0.1:8080/metrics \
 ./test/incus/fairness-cos-throughput-headroom.sh
 ```
 
-By default this wrapper runs `CLASS_FILTER=q2,q3,q6` under the strict
+By default this wrapper runs `CLASS_FILTER=q8,q9,q10` under the strict
 exact fixture, then applies a diagnostic `surplus-sharing` fixture and
 runs the same class set again before restoring the strict fixture. The
 surplus-sharing leg is a headroom diagnostic, not the product fairness

--- a/docs/per-5-tuple/state.md
+++ b/docs/per-5-tuple/state.md
@@ -557,15 +557,15 @@ MQFQ, v8 lease selection, or admission.
   rate suppression for positive exact-rate CoS schedulers without
   `surplus-sharing`.
 - **#1312 — Low-rate exact-class buffer sizing**: active follow-up.
-  Reverse q0/q4 retransmits reproduced with equal-flow disabled, so the
+  Reverse low-rate exact-class retransmits reproduced with equal-flow disabled, so the
   equal-flow suppressor was not causal. The canonical iperf fixtures now
-  pin `scheduler-be buffer-size 500k` and
-  `scheduler-iperf-a buffer-size 4m`; the May 15 q0/q4 rerun reduced
+  pin `scheduler-100m buffer-size 500k` and
+  `scheduler-1g buffer-size 4m`; the May 15 rerun reduced
   retransmits from ~74k/~35k per run to ~650/~222 and reduced CoS
   admission drops from ~222k/~104k to ~1.9k/~527. These fixture values
   intentionally raise the default implicit cap from roughly 10 ms of
-  rate-derived buffering to about 40 ms at 100 Mbps for q0 and 32 ms at
-  1 Gbps for q4. Treat them as validation headroom for the reverse
+  rate-derived buffering to about 40 ms at 100 Mbps for q1 and 32 ms at
+  1 Gbps for q2. Treat them as validation headroom for the reverse
   `-P 12` workload, not as a low-latency production default.
 
 ## Empirical sweep across workload classes (2026-05-07)

--- a/docs/xpf-userspace-fw-deploy-verification.md
+++ b/docs/xpf-userspace-fw-deploy-verification.md
@@ -33,8 +33,11 @@ the same procedure.
   priority 200, node1 at 100.
 - `loss:cluster-userspace-host` is up with address `10.0.61.102/24`
   and default route `10.0.61.1` (the RG1 VIP on xpf-userspace-fw).
-- iperf3 server listens on `172.16.80.200` ports 5201 (iperf-a class
-  — 1 Gbps `transmit-rate exact`) and 5202 (iperf-b — 10 Gbps).
+- iperf3 server listens on `172.16.80.200` ports 5200..5211. The
+  canonical 1 Gbps exact class is port 5202 (`iperf-1g`, queue 2);
+  ports 5200 and 5211 are non-exact/root-shaped.
+- TCP echo listeners for mouse-latency tests listen on ports 6200..6211
+  and use the same CoS classes as the corresponding 5200..5211 ports.
 - CoS config from `test/incus/cos-iperf-config.set` must be committed
   on the primary. `test/incus/apply-cos-config.sh loss:xpf-userspace-fw0`
   is the canonical applier. Re-apply after any deploy because the
@@ -72,7 +75,7 @@ sg incus-admin -c "incus exec loss:cluster-userspace-host -- ping -c 5 -W 2 172.
 ### 2. Single-flow throughput (`-P 1`)
 
 ```bash
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- iperf3 -c 172.16.80.200 -P 1 -t 30 -p 5201 -i 3"
+sg incus-admin -c "incus exec loss:cluster-userspace-host -- iperf3 -c 172.16.80.200 -P 1 -t 30 -p 5202 -i 3"
 ```
 
 **Pass**: every 3-second interval reports non-zero throughput. The
@@ -91,7 +94,7 @@ flow should settle somewhere around 1.5–1.7 Gb/s on current master
 ### 3. Parallel fair-share throughput (`-P 16`)
 
 ```bash
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- iperf3 -c 172.16.80.200 -P 16 -t 30 -p 5201 -i 3"
+sg incus-admin -c "incus exec loss:cluster-userspace-host -- iperf3 -c 172.16.80.200 -P 16 -t 30 -p 5202 -i 3"
 ```
 
 This is the workload #754 was measured on. Per-stream distribution
@@ -153,7 +156,7 @@ fast empty-output signal.
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c 'show class-of-service interface reth0'"
 ```
 
-Snapshot the iperf-a queue (queue 4) counters before the tests and
+Snapshot the `iperf-1g` queue (queue 2) counters before the tests and
 again after a 30 s run. Compute deltas.
 
 **Pass** (post-#768 baseline, single 30 s `-P 1` flow):

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -439,14 +439,14 @@ func TestCoSIperfSymmetricFixtureCompilesReverseSourcePortOutputFilter(t *testin
 		t.Fatal("expected reverse filter terms")
 	}
 	term := revFilter.Terms[0]
-	if got := strings.Join(term.SourcePorts, ","); got != "5201" {
-		t.Fatalf("reverse term 0 source ports = %q, want 5201", got)
+	if got := strings.Join(term.SourcePorts, ","); got != "5200,6200" {
+		t.Fatalf("reverse term 0 source ports = %q, want 5200,6200", got)
 	}
 	if len(term.DestinationPorts) != 0 {
 		t.Fatalf("reverse term 0 must not match destination-port; got %v", term.DestinationPorts)
 	}
-	if got := term.ForwardingClass; got != "iperf-a" {
-		t.Fatalf("reverse term 0 forwarding-class = %q, want iperf-a", got)
+	if got := term.ForwardingClass; got != "best-effort" {
+		t.Fatalf("reverse term 0 forwarding-class = %q, want best-effort", got)
 	}
 
 	rev6Filter := cfg.Firewall.FiltersInet6["bandwidth-output-reverse"]
@@ -454,11 +454,11 @@ func TestCoSIperfSymmetricFixtureCompilesReverseSourcePortOutputFilter(t *testin
 		t.Fatal("expected inet6 bandwidth-output-reverse filter with at least 4 terms")
 	}
 	term = rev6Filter.Terms[3]
-	if got := strings.Join(term.SourcePorts, ","); got != "5204" {
-		t.Fatalf("reverse inet6 term 3 source ports = %q, want 5204", got)
+	if got := strings.Join(term.SourcePorts, ","); got != "5203,6203" {
+		t.Fatalf("reverse inet6 term 3 source ports = %q, want 5203,6203", got)
 	}
-	if got := term.ForwardingClass; got != "iperf-d" {
-		t.Fatalf("reverse inet6 term 3 forwarding-class = %q, want iperf-d", got)
+	if got := term.ForwardingClass; got != "iperf-3g" {
+		t.Fatalf("reverse inet6 term 3 forwarding-class = %q, want iperf-3g", got)
 	}
 }
 

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -29,13 +29,14 @@
 #
 set -euo pipefail
 
-# #929: --same-class selects the same-class iperf-b fixture
-# (cos-iperf-same-class.set), which adds term 4 mapping
-# destination-port 7 → iperf-b. #1250: --symmetric selects
-# cos-iperf-symmetric.set, which also shapes reverse iperf3 -R
-# traffic on ge-0-0-1 using source-port terms. Flags must be
-# parsed BEFORE the positional TARGET argument so they are not
-# silently treated as hostnames.
+# #929 compatibility: --same-class still selects
+# cos-iperf-same-class.set for older callers. That fixture mirrors the
+# default 520x/620x map and also preserves the legacy destination-port
+# 7 -> iperf-1g same-class echo override. #1250: --symmetric selects
+# cos-iperf-symmetric.set, which also shapes reverse iperf3 -R and
+# echo replies on ge-0-0-1 using source-port terms. Flags must be
+# parsed BEFORE the positional TARGET argument so they are not silently
+# treated as hostnames.
 SAME_CLASS=0
 SYMMETRIC=0
 SURPLUS_SHARING=0

--- a/test/incus/cos-iperf-config.set
+++ b/test/incus/cos-iperf-config.set
@@ -5,117 +5,214 @@ delete firewall family inet6 filter bandwidth-output
 delete interfaces reth0 unit 80 family inet6 filter output
 
 set class-of-service forwarding-classes queue 0 best-effort
-set class-of-service forwarding-classes queue 1 iperf-d
-set class-of-service forwarding-classes queue 2 iperf-e
-set class-of-service forwarding-classes queue 3 iperf-f
-set class-of-service forwarding-classes queue 4 iperf-a
-set class-of-service forwarding-classes queue 5 iperf-b
-set class-of-service forwarding-classes queue 6 iperf-c
+set class-of-service forwarding-classes queue 1 iperf-100m
+set class-of-service forwarding-classes queue 2 iperf-1g
+set class-of-service forwarding-classes queue 3 iperf-3g
+set class-of-service forwarding-classes queue 4 iperf-6g
+set class-of-service forwarding-classes queue 5 iperf-9g
+set class-of-service forwarding-classes queue 6 iperf-12g
+set class-of-service forwarding-classes queue 7 iperf-15g
+set class-of-service forwarding-classes queue 8 iperf-18g
+set class-of-service forwarding-classes queue 9 iperf-21g
+set class-of-service forwarding-classes queue 10 iperf-24g
+set class-of-service forwarding-classes queue 11 iperf-uncapped
 
-set class-of-service schedulers scheduler-be transmit-rate 100m
-set class-of-service schedulers scheduler-be transmit-rate exact
-set class-of-service schedulers scheduler-be buffer-size 500k
+set class-of-service schedulers scheduler-be priority low
 
-set class-of-service schedulers scheduler-iperf-a transmit-rate 1.0g
-set class-of-service schedulers scheduler-iperf-a transmit-rate exact
-set class-of-service schedulers scheduler-iperf-a buffer-size 4m
+set class-of-service schedulers scheduler-100m transmit-rate 100m
+set class-of-service schedulers scheduler-100m transmit-rate exact
+set class-of-service schedulers scheduler-100m buffer-size 500k
 
-set class-of-service schedulers scheduler-iperf-b transmit-rate 10.0g
-set class-of-service schedulers scheduler-iperf-b transmit-rate exact
+set class-of-service schedulers scheduler-1g transmit-rate 1.0g
+set class-of-service schedulers scheduler-1g transmit-rate exact
+set class-of-service schedulers scheduler-1g buffer-size 4m
 
-set class-of-service schedulers scheduler-iperf-c transmit-rate 25.0g
-set class-of-service schedulers scheduler-iperf-c transmit-rate exact
+set class-of-service schedulers scheduler-3g transmit-rate 3.0g
+set class-of-service schedulers scheduler-3g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-d transmit-rate 13.0g
-set class-of-service schedulers scheduler-iperf-d transmit-rate exact
+set class-of-service schedulers scheduler-6g transmit-rate 6.0g
+set class-of-service schedulers scheduler-6g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-e transmit-rate 16.0g
-set class-of-service schedulers scheduler-iperf-e transmit-rate exact
+set class-of-service schedulers scheduler-9g transmit-rate 9.0g
+set class-of-service schedulers scheduler-9g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-f transmit-rate 19.0g
-set class-of-service schedulers scheduler-iperf-f transmit-rate exact
+set class-of-service schedulers scheduler-12g transmit-rate 12.0g
+set class-of-service schedulers scheduler-12g transmit-rate exact
+
+set class-of-service schedulers scheduler-15g transmit-rate 15.0g
+set class-of-service schedulers scheduler-15g transmit-rate exact
+
+set class-of-service schedulers scheduler-18g transmit-rate 18.0g
+set class-of-service schedulers scheduler-18g transmit-rate exact
+
+set class-of-service schedulers scheduler-21g transmit-rate 21.0g
+set class-of-service schedulers scheduler-21g transmit-rate exact
+
+set class-of-service schedulers scheduler-24g transmit-rate 24.0g
+set class-of-service schedulers scheduler-24g transmit-rate exact
+
+set class-of-service schedulers scheduler-uncapped priority low
 
 set class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-d scheduler scheduler-iperf-d
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-e scheduler scheduler-iperf-e
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-f scheduler scheduler-iperf-f
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-100m scheduler scheduler-100m
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-1g scheduler scheduler-1g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-3g scheduler scheduler-3g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-6g scheduler scheduler-6g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-9g scheduler scheduler-9g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-12g scheduler scheduler-12g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-15g scheduler scheduler-15g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-18g scheduler scheduler-18g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-21g scheduler scheduler-21g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-24g scheduler scheduler-24g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-uncapped scheduler scheduler-uncapped
 
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 25g
 
-set firewall family inet filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet filter bandwidth-output term 0 then count iperf-a
+set firewall family inet filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output term 0 then count best-effort
 set firewall family inet filter bandwidth-output term 0 then accept
 
-set firewall family inet filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet filter bandwidth-output term 1 then count iperf-b
+set firewall family inet filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet filter bandwidth-output term 1 then accept
 
-set firewall family inet filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet filter bandwidth-output term 2 then count iperf-c
+set firewall family inet filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet filter bandwidth-output term 2 then accept
 
-set firewall family inet filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet filter bandwidth-output term 3 then forwarding-class iperf-d
-set firewall family inet filter bandwidth-output term 3 then count iperf-d
+set firewall family inet filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet filter bandwidth-output term 3 then accept
 
-set firewall family inet filter bandwidth-output term 4 from destination-port 5205
-set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-e
-set firewall family inet filter bandwidth-output term 4 then count iperf-e
+set firewall family inet filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet filter bandwidth-output term 4 then accept
 
-set firewall family inet filter bandwidth-output term 5 from destination-port 5206
-set firewall family inet filter bandwidth-output term 5 then forwarding-class iperf-f
-set firewall family inet filter bandwidth-output term 5 then count iperf-f
+set firewall family inet filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet filter bandwidth-output term 5 then count iperf-9g
 set firewall family inet filter bandwidth-output term 5 then accept
 
-set firewall family inet filter bandwidth-output term 6 from destination-port 5207
-set firewall family inet filter bandwidth-output term 6 then forwarding-class best-effort
-set firewall family inet filter bandwidth-output term 6 then count best-effort
+set firewall family inet filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet filter bandwidth-output term 6 then count iperf-12g
 set firewall family inet filter bandwidth-output term 6 then accept
+
+set firewall family inet filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet filter bandwidth-output term 7 then accept
+
+set firewall family inet filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet filter bandwidth-output term 8 then accept
+
+set firewall family inet filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet filter bandwidth-output term 9 then accept
+
+set firewall family inet filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet filter bandwidth-output term 10 then accept
+
+set firewall family inet filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then accept
 
 set interfaces reth0 unit 80 family inet filter output bandwidth-output
 
-set firewall family inet6 filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet6 filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet6 filter bandwidth-output term 0 then count iperf-a
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet6 filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output term 0 then count best-effort
 set firewall family inet6 filter bandwidth-output term 0 then accept
 
-set firewall family inet6 filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet6 filter bandwidth-output term 1 then count iperf-b
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet6 filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet6 filter bandwidth-output term 1 then accept
 
-set firewall family inet6 filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet6 filter bandwidth-output term 2 then count iperf-c
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet6 filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet6 filter bandwidth-output term 2 then accept
 
-set firewall family inet6 filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet6 filter bandwidth-output term 3 then forwarding-class iperf-d
-set firewall family inet6 filter bandwidth-output term 3 then count iperf-d
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet6 filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet6 filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet6 filter bandwidth-output term 3 then accept
 
-set firewall family inet6 filter bandwidth-output term 4 from destination-port 5205
-set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-e
-set firewall family inet6 filter bandwidth-output term 4 then count iperf-e
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet6 filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet6 filter bandwidth-output term 4 then accept
 
-set firewall family inet6 filter bandwidth-output term 5 from destination-port 5206
-set firewall family inet6 filter bandwidth-output term 5 then forwarding-class iperf-f
-set firewall family inet6 filter bandwidth-output term 5 then count iperf-f
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet6 filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet6 filter bandwidth-output term 5 then count iperf-9g
 set firewall family inet6 filter bandwidth-output term 5 then accept
 
-set firewall family inet6 filter bandwidth-output term 6 from destination-port 5207
-set firewall family inet6 filter bandwidth-output term 6 then forwarding-class best-effort
-set firewall family inet6 filter bandwidth-output term 6 then count best-effort
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet6 filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet6 filter bandwidth-output term 6 then count iperf-12g
 set firewall family inet6 filter bandwidth-output term 6 then accept
+
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet6 filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then accept
+
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet6 filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then accept
+
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet6 filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then accept
+
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet6 filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then accept
+
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet6 filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then accept
 
 set interfaces reth0 unit 80 family inet6 filter output bandwidth-output

--- a/test/incus/cos-iperf-same-class.set
+++ b/test/incus/cos-iperf-same-class.set
@@ -1,16 +1,10 @@
-# #929: same-class iperf-b CoS fixture for the mouse-latency
-# tail measurement. Same as cos-iperf-config.set but adds
-# term 4 mapping destination-port 7 → iperf-b, so mice (sent
-# to the operator's existing TCP echo daemon on port 7) share
-# the iperf-b queue with elephants (port 5202). Used to
-# characterize the same-class HOL gate that #913/#918/#914/#920
-# target. Port 7 was chosen because the operator's echo daemon
-# already listens there for the cross-class default — no second
-# listener required.
+# Compatibility fixture for same-class mouse-latency runs.
 #
-# Cross-class default (cos-iperf-config.set) leaves port 7
-# unclassified, so it falls back to best-effort. The same-class
-# fixture below overrides that classification with term 4.
+# The default CoS fixture now maps tcp echo ports 6200..6211 into
+# the same forwarding classes as iperf ports 5200..5211. This file
+# intentionally mirrors cos-iperf-config.set and preserves the legacy
+# destination-port 7 override by mapping it to the 1 Gbps same-class
+# queue used by test-mouse-latency-same-class.sh.
 
 delete class-of-service
 delete firewall family inet filter bandwidth-output
@@ -19,84 +13,226 @@ delete firewall family inet6 filter bandwidth-output
 delete interfaces reth0 unit 80 family inet6 filter output
 
 set class-of-service forwarding-classes queue 0 best-effort
-set class-of-service forwarding-classes queue 4 iperf-a
-set class-of-service forwarding-classes queue 5 iperf-b
-set class-of-service forwarding-classes queue 6 iperf-c
+set class-of-service forwarding-classes queue 1 iperf-100m
+set class-of-service forwarding-classes queue 2 iperf-1g
+set class-of-service forwarding-classes queue 3 iperf-3g
+set class-of-service forwarding-classes queue 4 iperf-6g
+set class-of-service forwarding-classes queue 5 iperf-9g
+set class-of-service forwarding-classes queue 6 iperf-12g
+set class-of-service forwarding-classes queue 7 iperf-15g
+set class-of-service forwarding-classes queue 8 iperf-18g
+set class-of-service forwarding-classes queue 9 iperf-21g
+set class-of-service forwarding-classes queue 10 iperf-24g
+set class-of-service forwarding-classes queue 11 iperf-uncapped
 
-set class-of-service schedulers scheduler-be transmit-rate 100m
-set class-of-service schedulers scheduler-be transmit-rate exact
-set class-of-service schedulers scheduler-be buffer-size 500k
+set class-of-service schedulers scheduler-be priority low
 
-set class-of-service schedulers scheduler-iperf-a transmit-rate 1.0g
-set class-of-service schedulers scheduler-iperf-a transmit-rate exact
-set class-of-service schedulers scheduler-iperf-a buffer-size 4m
+set class-of-service schedulers scheduler-100m transmit-rate 100m
+set class-of-service schedulers scheduler-100m transmit-rate exact
+set class-of-service schedulers scheduler-100m buffer-size 500k
 
-set class-of-service schedulers scheduler-iperf-b transmit-rate 10.0g
-set class-of-service schedulers scheduler-iperf-b transmit-rate exact
+set class-of-service schedulers scheduler-1g transmit-rate 1.0g
+set class-of-service schedulers scheduler-1g transmit-rate exact
+set class-of-service schedulers scheduler-1g buffer-size 4m
 
-set class-of-service schedulers scheduler-iperf-c transmit-rate 25.0g
-set class-of-service schedulers scheduler-iperf-c transmit-rate exact
+set class-of-service schedulers scheduler-3g transmit-rate 3.0g
+set class-of-service schedulers scheduler-3g transmit-rate exact
+
+set class-of-service schedulers scheduler-6g transmit-rate 6.0g
+set class-of-service schedulers scheduler-6g transmit-rate exact
+
+set class-of-service schedulers scheduler-9g transmit-rate 9.0g
+set class-of-service schedulers scheduler-9g transmit-rate exact
+
+set class-of-service schedulers scheduler-12g transmit-rate 12.0g
+set class-of-service schedulers scheduler-12g transmit-rate exact
+
+set class-of-service schedulers scheduler-15g transmit-rate 15.0g
+set class-of-service schedulers scheduler-15g transmit-rate exact
+
+set class-of-service schedulers scheduler-18g transmit-rate 18.0g
+set class-of-service schedulers scheduler-18g transmit-rate exact
+
+set class-of-service schedulers scheduler-21g transmit-rate 21.0g
+set class-of-service schedulers scheduler-21g transmit-rate exact
+
+set class-of-service schedulers scheduler-24g transmit-rate 24.0g
+set class-of-service schedulers scheduler-24g transmit-rate exact
+
+set class-of-service schedulers scheduler-uncapped priority low
 
 set class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-100m scheduler scheduler-100m
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-1g scheduler scheduler-1g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-3g scheduler scheduler-3g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-6g scheduler scheduler-6g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-9g scheduler scheduler-9g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-12g scheduler scheduler-12g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-15g scheduler scheduler-15g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-18g scheduler scheduler-18g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-21g scheduler scheduler-21g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-24g scheduler scheduler-24g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-uncapped scheduler scheduler-uncapped
 
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 25g
 
-set firewall family inet filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet filter bandwidth-output term 0 then count iperf-a
+set firewall family inet filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output term 0 then count best-effort
 set firewall family inet filter bandwidth-output term 0 then accept
 
-set firewall family inet filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet filter bandwidth-output term 1 then count iperf-b
+set firewall family inet filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet filter bandwidth-output term 1 then accept
 
-set firewall family inet filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet filter bandwidth-output term 2 then count iperf-c
+set firewall family inet filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet filter bandwidth-output term 2 then accept
 
-set firewall family inet filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet filter bandwidth-output term 3 then forwarding-class best-effort
-set firewall family inet filter bandwidth-output term 3 then count best-effort
+set firewall family inet filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet filter bandwidth-output term 3 then accept
 
-# #929 same-class: mice on port 7 → iperf-b (queue 5).
-set firewall family inet filter bandwidth-output term 4 from destination-port 7
-set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-b
-set firewall family inet filter bandwidth-output term 4 then count iperf-b-mouse
+set firewall family inet filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet filter bandwidth-output term 4 then accept
+
+set firewall family inet filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet filter bandwidth-output term 5 then count iperf-9g
+set firewall family inet filter bandwidth-output term 5 then accept
+
+set firewall family inet filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet filter bandwidth-output term 6 then count iperf-12g
+set firewall family inet filter bandwidth-output term 6 then accept
+
+set firewall family inet filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet filter bandwidth-output term 7 then accept
+
+set firewall family inet filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet filter bandwidth-output term 8 then accept
+
+set firewall family inet filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet filter bandwidth-output term 9 then accept
+
+set firewall family inet filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet filter bandwidth-output term 10 then accept
+
+set firewall family inet filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then accept
+
+# Legacy #929 same-class echo port: port 7 -> iperf-1g (queue 2).
+set firewall family inet filter bandwidth-output term 12 from destination-port 7
+set firewall family inet filter bandwidth-output term 12 then forwarding-class iperf-1g
+set firewall family inet filter bandwidth-output term 12 then count iperf-1g-legacy-mouse
+set firewall family inet filter bandwidth-output term 12 then accept
 
 set interfaces reth0 unit 80 family inet filter output bandwidth-output
 
-set firewall family inet6 filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet6 filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet6 filter bandwidth-output term 0 then count iperf-a
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet6 filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output term 0 then count best-effort
 set firewall family inet6 filter bandwidth-output term 0 then accept
 
-set firewall family inet6 filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet6 filter bandwidth-output term 1 then count iperf-b
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet6 filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet6 filter bandwidth-output term 1 then accept
 
-set firewall family inet6 filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet6 filter bandwidth-output term 2 then count iperf-c
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet6 filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet6 filter bandwidth-output term 2 then accept
 
-set firewall family inet6 filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet6 filter bandwidth-output term 3 then forwarding-class best-effort
-set firewall family inet6 filter bandwidth-output term 3 then count best-effort
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet6 filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet6 filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet6 filter bandwidth-output term 3 then accept
 
-# #929 same-class: IPv6 mirror of term 4.
-set firewall family inet6 filter bandwidth-output term 4 from destination-port 7
-set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-b
-set firewall family inet6 filter bandwidth-output term 4 then count iperf-b-mouse
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet6 filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet6 filter bandwidth-output term 4 then accept
+
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet6 filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet6 filter bandwidth-output term 5 then count iperf-9g
+set firewall family inet6 filter bandwidth-output term 5 then accept
+
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet6 filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet6 filter bandwidth-output term 6 then count iperf-12g
+set firewall family inet6 filter bandwidth-output term 6 then accept
+
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet6 filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then accept
+
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet6 filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then accept
+
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet6 filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then accept
+
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet6 filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then accept
+
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet6 filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then accept
+
+# Legacy #929 same-class echo port: IPv6 mirror of term 12.
+set firewall family inet6 filter bandwidth-output term 12 from destination-port 7
+set firewall family inet6 filter bandwidth-output term 12 then forwarding-class iperf-1g
+set firewall family inet6 filter bandwidth-output term 12 then count iperf-1g-legacy-mouse
+set firewall family inet6 filter bandwidth-output term 12 then accept
 
 set interfaces reth0 unit 80 family inet6 filter output bandwidth-output

--- a/test/incus/cos-iperf-symmetric.set
+++ b/test/incus/cos-iperf-symmetric.set
@@ -1,13 +1,9 @@
-# Symmetric CoS iperf fixture.
+# Symmetric CoS iperf / mouse-latency fixture.
 #
-# Forward iperf traffic (client -> server) exits reth0.80 with
-# destination-port 5201..5207, so the forward output filter matches
-# destination-port.
-#
-# Reverse iperf3 -R data (server -> client) exits ge-0-0-1 with
-# source-port 5201..5207 and an ephemeral destination port, so the
-# reverse output filter MUST match source-port. Reusing the forward
-# destination-port terms on ge-0-0-1 would leave reverse data unshaped.
+# Forward iperf and TCP echo traffic exits reth0.80 and matches
+# destination-port 5200..5211 and 6200..6211. Reverse iperf3 -R
+# and echo replies exit ge-0-0-1 with source-port 5200..5211 /
+# 6200..6211, so the reverse output filter matches source-port.
 
 delete class-of-service
 delete firewall family inet filter bandwidth-output
@@ -20,193 +16,364 @@ delete firewall family inet6 filter bandwidth-output-reverse
 delete interfaces ge-0-0-1 unit 0 family inet6 filter output
 
 set class-of-service forwarding-classes queue 0 best-effort
-set class-of-service forwarding-classes queue 1 iperf-d
-set class-of-service forwarding-classes queue 2 iperf-e
-set class-of-service forwarding-classes queue 3 iperf-f
-set class-of-service forwarding-classes queue 4 iperf-a
-set class-of-service forwarding-classes queue 5 iperf-b
-set class-of-service forwarding-classes queue 6 iperf-c
+set class-of-service forwarding-classes queue 1 iperf-100m
+set class-of-service forwarding-classes queue 2 iperf-1g
+set class-of-service forwarding-classes queue 3 iperf-3g
+set class-of-service forwarding-classes queue 4 iperf-6g
+set class-of-service forwarding-classes queue 5 iperf-9g
+set class-of-service forwarding-classes queue 6 iperf-12g
+set class-of-service forwarding-classes queue 7 iperf-15g
+set class-of-service forwarding-classes queue 8 iperf-18g
+set class-of-service forwarding-classes queue 9 iperf-21g
+set class-of-service forwarding-classes queue 10 iperf-24g
+set class-of-service forwarding-classes queue 11 iperf-uncapped
 
-set class-of-service schedulers scheduler-be transmit-rate 100m
-set class-of-service schedulers scheduler-be transmit-rate exact
-set class-of-service schedulers scheduler-be buffer-size 500k
+set class-of-service schedulers scheduler-be priority low
 
-set class-of-service schedulers scheduler-iperf-a transmit-rate 1.0g
-set class-of-service schedulers scheduler-iperf-a transmit-rate exact
-set class-of-service schedulers scheduler-iperf-a buffer-size 4m
+set class-of-service schedulers scheduler-100m transmit-rate 100m
+set class-of-service schedulers scheduler-100m transmit-rate exact
+set class-of-service schedulers scheduler-100m buffer-size 500k
 
-set class-of-service schedulers scheduler-iperf-b transmit-rate 10.0g
-set class-of-service schedulers scheduler-iperf-b transmit-rate exact
+set class-of-service schedulers scheduler-1g transmit-rate 1.0g
+set class-of-service schedulers scheduler-1g transmit-rate exact
+set class-of-service schedulers scheduler-1g buffer-size 4m
 
-set class-of-service schedulers scheduler-iperf-c transmit-rate 25.0g
-set class-of-service schedulers scheduler-iperf-c transmit-rate exact
+set class-of-service schedulers scheduler-3g transmit-rate 3.0g
+set class-of-service schedulers scheduler-3g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-d transmit-rate 13.0g
-set class-of-service schedulers scheduler-iperf-d transmit-rate exact
+set class-of-service schedulers scheduler-6g transmit-rate 6.0g
+set class-of-service schedulers scheduler-6g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-e transmit-rate 16.0g
-set class-of-service schedulers scheduler-iperf-e transmit-rate exact
+set class-of-service schedulers scheduler-9g transmit-rate 9.0g
+set class-of-service schedulers scheduler-9g transmit-rate exact
 
-set class-of-service schedulers scheduler-iperf-f transmit-rate 19.0g
-set class-of-service schedulers scheduler-iperf-f transmit-rate exact
+set class-of-service schedulers scheduler-12g transmit-rate 12.0g
+set class-of-service schedulers scheduler-12g transmit-rate exact
+
+set class-of-service schedulers scheduler-15g transmit-rate 15.0g
+set class-of-service schedulers scheduler-15g transmit-rate exact
+
+set class-of-service schedulers scheduler-18g transmit-rate 18.0g
+set class-of-service schedulers scheduler-18g transmit-rate exact
+
+set class-of-service schedulers scheduler-21g transmit-rate 21.0g
+set class-of-service schedulers scheduler-21g transmit-rate exact
+
+set class-of-service schedulers scheduler-24g transmit-rate 24.0g
+set class-of-service schedulers scheduler-24g transmit-rate exact
+
+set class-of-service schedulers scheduler-uncapped priority low
 
 set class-of-service scheduler-maps bandwidth-limit forwarding-class best-effort scheduler scheduler-be
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-a scheduler scheduler-iperf-a
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-b scheduler scheduler-iperf-b
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-c scheduler scheduler-iperf-c
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-d scheduler scheduler-iperf-d
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-e scheduler scheduler-iperf-e
-set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-f scheduler scheduler-iperf-f
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-100m scheduler scheduler-100m
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-1g scheduler scheduler-1g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-3g scheduler scheduler-3g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-6g scheduler scheduler-6g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-9g scheduler scheduler-9g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-12g scheduler scheduler-12g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-15g scheduler scheduler-15g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-18g scheduler scheduler-18g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-21g scheduler scheduler-21g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-24g scheduler scheduler-24g
+set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-uncapped scheduler scheduler-uncapped
 
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 25g
 set class-of-service interfaces ge-0-0-1 unit 0 scheduler-map bandwidth-limit
 set class-of-service interfaces ge-0-0-1 unit 0 shaping-rate 25g
 
-set firewall family inet filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet filter bandwidth-output term 0 then count iperf-a
+set firewall family inet filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output term 0 then count best-effort
 set firewall family inet filter bandwidth-output term 0 then accept
 
-set firewall family inet filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet filter bandwidth-output term 1 then count iperf-b
+set firewall family inet filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet filter bandwidth-output term 1 then accept
 
-set firewall family inet filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet filter bandwidth-output term 2 then count iperf-c
+set firewall family inet filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet filter bandwidth-output term 2 then accept
 
-set firewall family inet filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet filter bandwidth-output term 3 then forwarding-class iperf-d
-set firewall family inet filter bandwidth-output term 3 then count iperf-d
+set firewall family inet filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet filter bandwidth-output term 3 then accept
 
-set firewall family inet filter bandwidth-output term 4 from destination-port 5205
-set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-e
-set firewall family inet filter bandwidth-output term 4 then count iperf-e
+set firewall family inet filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet filter bandwidth-output term 4 then accept
 
-set firewall family inet filter bandwidth-output term 5 from destination-port 5206
-set firewall family inet filter bandwidth-output term 5 then forwarding-class iperf-f
-set firewall family inet filter bandwidth-output term 5 then count iperf-f
+set firewall family inet filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet filter bandwidth-output term 5 then count iperf-9g
 set firewall family inet filter bandwidth-output term 5 then accept
 
-set firewall family inet filter bandwidth-output term 6 from destination-port 5207
-set firewall family inet filter bandwidth-output term 6 then forwarding-class best-effort
-set firewall family inet filter bandwidth-output term 6 then count best-effort
+set firewall family inet filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet filter bandwidth-output term 6 then count iperf-12g
 set firewall family inet filter bandwidth-output term 6 then accept
+
+set firewall family inet filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet filter bandwidth-output term 7 then accept
+
+set firewall family inet filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet filter bandwidth-output term 8 then accept
+
+set firewall family inet filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet filter bandwidth-output term 9 then accept
+
+set firewall family inet filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet filter bandwidth-output term 10 then accept
+
+set firewall family inet filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet filter bandwidth-output term 11 then accept
 
 set interfaces reth0 unit 80 family inet filter output bandwidth-output
 
-set firewall family inet6 filter bandwidth-output term 0 from destination-port 5201
-set firewall family inet6 filter bandwidth-output term 0 then forwarding-class iperf-a
-set firewall family inet6 filter bandwidth-output term 0 then count iperf-a
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 5200
+set firewall family inet6 filter bandwidth-output term 0 from destination-port 6200
+set firewall family inet6 filter bandwidth-output term 0 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output term 0 then count best-effort
 set firewall family inet6 filter bandwidth-output term 0 then accept
 
-set firewall family inet6 filter bandwidth-output term 1 from destination-port 5202
-set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-b
-set firewall family inet6 filter bandwidth-output term 1 then count iperf-b
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 5201
+set firewall family inet6 filter bandwidth-output term 1 from destination-port 6201
+set firewall family inet6 filter bandwidth-output term 1 then forwarding-class iperf-100m
+set firewall family inet6 filter bandwidth-output term 1 then count iperf-100m
 set firewall family inet6 filter bandwidth-output term 1 then accept
 
-set firewall family inet6 filter bandwidth-output term 2 from destination-port 5203
-set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-c
-set firewall family inet6 filter bandwidth-output term 2 then count iperf-c
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 5202
+set firewall family inet6 filter bandwidth-output term 2 from destination-port 6202
+set firewall family inet6 filter bandwidth-output term 2 then forwarding-class iperf-1g
+set firewall family inet6 filter bandwidth-output term 2 then count iperf-1g
 set firewall family inet6 filter bandwidth-output term 2 then accept
 
-set firewall family inet6 filter bandwidth-output term 3 from destination-port 5204
-set firewall family inet6 filter bandwidth-output term 3 then forwarding-class iperf-d
-set firewall family inet6 filter bandwidth-output term 3 then count iperf-d
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 5203
+set firewall family inet6 filter bandwidth-output term 3 from destination-port 6203
+set firewall family inet6 filter bandwidth-output term 3 then forwarding-class iperf-3g
+set firewall family inet6 filter bandwidth-output term 3 then count iperf-3g
 set firewall family inet6 filter bandwidth-output term 3 then accept
 
-set firewall family inet6 filter bandwidth-output term 4 from destination-port 5205
-set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-e
-set firewall family inet6 filter bandwidth-output term 4 then count iperf-e
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 5204
+set firewall family inet6 filter bandwidth-output term 4 from destination-port 6204
+set firewall family inet6 filter bandwidth-output term 4 then forwarding-class iperf-6g
+set firewall family inet6 filter bandwidth-output term 4 then count iperf-6g
 set firewall family inet6 filter bandwidth-output term 4 then accept
 
-set firewall family inet6 filter bandwidth-output term 5 from destination-port 5206
-set firewall family inet6 filter bandwidth-output term 5 then forwarding-class iperf-f
-set firewall family inet6 filter bandwidth-output term 5 then count iperf-f
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 5205
+set firewall family inet6 filter bandwidth-output term 5 from destination-port 6205
+set firewall family inet6 filter bandwidth-output term 5 then forwarding-class iperf-9g
+set firewall family inet6 filter bandwidth-output term 5 then count iperf-9g
 set firewall family inet6 filter bandwidth-output term 5 then accept
 
-set firewall family inet6 filter bandwidth-output term 6 from destination-port 5207
-set firewall family inet6 filter bandwidth-output term 6 then forwarding-class best-effort
-set firewall family inet6 filter bandwidth-output term 6 then count best-effort
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 5206
+set firewall family inet6 filter bandwidth-output term 6 from destination-port 6206
+set firewall family inet6 filter bandwidth-output term 6 then forwarding-class iperf-12g
+set firewall family inet6 filter bandwidth-output term 6 then count iperf-12g
 set firewall family inet6 filter bandwidth-output term 6 then accept
+
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 5207
+set firewall family inet6 filter bandwidth-output term 7 from destination-port 6207
+set firewall family inet6 filter bandwidth-output term 7 then forwarding-class iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then count iperf-15g
+set firewall family inet6 filter bandwidth-output term 7 then accept
+
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 5208
+set firewall family inet6 filter bandwidth-output term 8 from destination-port 6208
+set firewall family inet6 filter bandwidth-output term 8 then forwarding-class iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then count iperf-18g
+set firewall family inet6 filter bandwidth-output term 8 then accept
+
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 5209
+set firewall family inet6 filter bandwidth-output term 9 from destination-port 6209
+set firewall family inet6 filter bandwidth-output term 9 then forwarding-class iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then count iperf-21g
+set firewall family inet6 filter bandwidth-output term 9 then accept
+
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 5210
+set firewall family inet6 filter bandwidth-output term 10 from destination-port 6210
+set firewall family inet6 filter bandwidth-output term 10 then forwarding-class iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then count iperf-24g
+set firewall family inet6 filter bandwidth-output term 10 then accept
+
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 5211
+set firewall family inet6 filter bandwidth-output term 11 from destination-port 6211
+set firewall family inet6 filter bandwidth-output term 11 then forwarding-class iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then count iperf-uncapped
+set firewall family inet6 filter bandwidth-output term 11 then accept
 
 set interfaces reth0 unit 80 family inet6 filter output bandwidth-output
 
-set firewall family inet filter bandwidth-output-reverse term 0 from source-port 5201
-set firewall family inet filter bandwidth-output-reverse term 0 then forwarding-class iperf-a
-set firewall family inet filter bandwidth-output-reverse term 0 then count iperf-a-reverse
+set firewall family inet filter bandwidth-output-reverse term 0 from source-port 5200
+set firewall family inet filter bandwidth-output-reverse term 0 from source-port 6200
+set firewall family inet filter bandwidth-output-reverse term 0 then forwarding-class best-effort
+set firewall family inet filter bandwidth-output-reverse term 0 then count best-effort-reverse
 set firewall family inet filter bandwidth-output-reverse term 0 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 1 from source-port 5202
-set firewall family inet filter bandwidth-output-reverse term 1 then forwarding-class iperf-b
-set firewall family inet filter bandwidth-output-reverse term 1 then count iperf-b-reverse
+set firewall family inet filter bandwidth-output-reverse term 1 from source-port 5201
+set firewall family inet filter bandwidth-output-reverse term 1 from source-port 6201
+set firewall family inet filter bandwidth-output-reverse term 1 then forwarding-class iperf-100m
+set firewall family inet filter bandwidth-output-reverse term 1 then count iperf-100m-reverse
 set firewall family inet filter bandwidth-output-reverse term 1 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 2 from source-port 5203
-set firewall family inet filter bandwidth-output-reverse term 2 then forwarding-class iperf-c
-set firewall family inet filter bandwidth-output-reverse term 2 then count iperf-c-reverse
+set firewall family inet filter bandwidth-output-reverse term 2 from source-port 5202
+set firewall family inet filter bandwidth-output-reverse term 2 from source-port 6202
+set firewall family inet filter bandwidth-output-reverse term 2 then forwarding-class iperf-1g
+set firewall family inet filter bandwidth-output-reverse term 2 then count iperf-1g-reverse
 set firewall family inet filter bandwidth-output-reverse term 2 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 3 from source-port 5204
-set firewall family inet filter bandwidth-output-reverse term 3 then forwarding-class iperf-d
-set firewall family inet filter bandwidth-output-reverse term 3 then count iperf-d-reverse
+set firewall family inet filter bandwidth-output-reverse term 3 from source-port 5203
+set firewall family inet filter bandwidth-output-reverse term 3 from source-port 6203
+set firewall family inet filter bandwidth-output-reverse term 3 then forwarding-class iperf-3g
+set firewall family inet filter bandwidth-output-reverse term 3 then count iperf-3g-reverse
 set firewall family inet filter bandwidth-output-reverse term 3 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 4 from source-port 5205
-set firewall family inet filter bandwidth-output-reverse term 4 then forwarding-class iperf-e
-set firewall family inet filter bandwidth-output-reverse term 4 then count iperf-e-reverse
+set firewall family inet filter bandwidth-output-reverse term 4 from source-port 5204
+set firewall family inet filter bandwidth-output-reverse term 4 from source-port 6204
+set firewall family inet filter bandwidth-output-reverse term 4 then forwarding-class iperf-6g
+set firewall family inet filter bandwidth-output-reverse term 4 then count iperf-6g-reverse
 set firewall family inet filter bandwidth-output-reverse term 4 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 5 from source-port 5206
-set firewall family inet filter bandwidth-output-reverse term 5 then forwarding-class iperf-f
-set firewall family inet filter bandwidth-output-reverse term 5 then count iperf-f-reverse
+set firewall family inet filter bandwidth-output-reverse term 5 from source-port 5205
+set firewall family inet filter bandwidth-output-reverse term 5 from source-port 6205
+set firewall family inet filter bandwidth-output-reverse term 5 then forwarding-class iperf-9g
+set firewall family inet filter bandwidth-output-reverse term 5 then count iperf-9g-reverse
 set firewall family inet filter bandwidth-output-reverse term 5 then accept
 
-set firewall family inet filter bandwidth-output-reverse term 6 from source-port 5207
-set firewall family inet filter bandwidth-output-reverse term 6 then forwarding-class best-effort
-set firewall family inet filter bandwidth-output-reverse term 6 then count best-effort-reverse
+set firewall family inet filter bandwidth-output-reverse term 6 from source-port 5206
+set firewall family inet filter bandwidth-output-reverse term 6 from source-port 6206
+set firewall family inet filter bandwidth-output-reverse term 6 then forwarding-class iperf-12g
+set firewall family inet filter bandwidth-output-reverse term 6 then count iperf-12g-reverse
 set firewall family inet filter bandwidth-output-reverse term 6 then accept
+
+set firewall family inet filter bandwidth-output-reverse term 7 from source-port 5207
+set firewall family inet filter bandwidth-output-reverse term 7 from source-port 6207
+set firewall family inet filter bandwidth-output-reverse term 7 then forwarding-class iperf-15g
+set firewall family inet filter bandwidth-output-reverse term 7 then count iperf-15g-reverse
+set firewall family inet filter bandwidth-output-reverse term 7 then accept
+
+set firewall family inet filter bandwidth-output-reverse term 8 from source-port 5208
+set firewall family inet filter bandwidth-output-reverse term 8 from source-port 6208
+set firewall family inet filter bandwidth-output-reverse term 8 then forwarding-class iperf-18g
+set firewall family inet filter bandwidth-output-reverse term 8 then count iperf-18g-reverse
+set firewall family inet filter bandwidth-output-reverse term 8 then accept
+
+set firewall family inet filter bandwidth-output-reverse term 9 from source-port 5209
+set firewall family inet filter bandwidth-output-reverse term 9 from source-port 6209
+set firewall family inet filter bandwidth-output-reverse term 9 then forwarding-class iperf-21g
+set firewall family inet filter bandwidth-output-reverse term 9 then count iperf-21g-reverse
+set firewall family inet filter bandwidth-output-reverse term 9 then accept
+
+set firewall family inet filter bandwidth-output-reverse term 10 from source-port 5210
+set firewall family inet filter bandwidth-output-reverse term 10 from source-port 6210
+set firewall family inet filter bandwidth-output-reverse term 10 then forwarding-class iperf-24g
+set firewall family inet filter bandwidth-output-reverse term 10 then count iperf-24g-reverse
+set firewall family inet filter bandwidth-output-reverse term 10 then accept
+
+set firewall family inet filter bandwidth-output-reverse term 11 from source-port 5211
+set firewall family inet filter bandwidth-output-reverse term 11 from source-port 6211
+set firewall family inet filter bandwidth-output-reverse term 11 then forwarding-class iperf-uncapped
+set firewall family inet filter bandwidth-output-reverse term 11 then count iperf-uncapped-reverse
+set firewall family inet filter bandwidth-output-reverse term 11 then accept
 
 set interfaces ge-0-0-1 unit 0 family inet filter output bandwidth-output-reverse
 
-set firewall family inet6 filter bandwidth-output-reverse term 0 from source-port 5201
-set firewall family inet6 filter bandwidth-output-reverse term 0 then forwarding-class iperf-a
-set firewall family inet6 filter bandwidth-output-reverse term 0 then count iperf-a-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 0 from source-port 5200
+set firewall family inet6 filter bandwidth-output-reverse term 0 from source-port 6200
+set firewall family inet6 filter bandwidth-output-reverse term 0 then forwarding-class best-effort
+set firewall family inet6 filter bandwidth-output-reverse term 0 then count best-effort-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 0 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 1 from source-port 5202
-set firewall family inet6 filter bandwidth-output-reverse term 1 then forwarding-class iperf-b
-set firewall family inet6 filter bandwidth-output-reverse term 1 then count iperf-b-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 1 from source-port 5201
+set firewall family inet6 filter bandwidth-output-reverse term 1 from source-port 6201
+set firewall family inet6 filter bandwidth-output-reverse term 1 then forwarding-class iperf-100m
+set firewall family inet6 filter bandwidth-output-reverse term 1 then count iperf-100m-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 1 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 2 from source-port 5203
-set firewall family inet6 filter bandwidth-output-reverse term 2 then forwarding-class iperf-c
-set firewall family inet6 filter bandwidth-output-reverse term 2 then count iperf-c-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 2 from source-port 5202
+set firewall family inet6 filter bandwidth-output-reverse term 2 from source-port 6202
+set firewall family inet6 filter bandwidth-output-reverse term 2 then forwarding-class iperf-1g
+set firewall family inet6 filter bandwidth-output-reverse term 2 then count iperf-1g-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 2 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 3 from source-port 5204
-set firewall family inet6 filter bandwidth-output-reverse term 3 then forwarding-class iperf-d
-set firewall family inet6 filter bandwidth-output-reverse term 3 then count iperf-d-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 3 from source-port 5203
+set firewall family inet6 filter bandwidth-output-reverse term 3 from source-port 6203
+set firewall family inet6 filter bandwidth-output-reverse term 3 then forwarding-class iperf-3g
+set firewall family inet6 filter bandwidth-output-reverse term 3 then count iperf-3g-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 3 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 4 from source-port 5205
-set firewall family inet6 filter bandwidth-output-reverse term 4 then forwarding-class iperf-e
-set firewall family inet6 filter bandwidth-output-reverse term 4 then count iperf-e-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 4 from source-port 5204
+set firewall family inet6 filter bandwidth-output-reverse term 4 from source-port 6204
+set firewall family inet6 filter bandwidth-output-reverse term 4 then forwarding-class iperf-6g
+set firewall family inet6 filter bandwidth-output-reverse term 4 then count iperf-6g-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 4 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 5 from source-port 5206
-set firewall family inet6 filter bandwidth-output-reverse term 5 then forwarding-class iperf-f
-set firewall family inet6 filter bandwidth-output-reverse term 5 then count iperf-f-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 5 from source-port 5205
+set firewall family inet6 filter bandwidth-output-reverse term 5 from source-port 6205
+set firewall family inet6 filter bandwidth-output-reverse term 5 then forwarding-class iperf-9g
+set firewall family inet6 filter bandwidth-output-reverse term 5 then count iperf-9g-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 5 then accept
 
-set firewall family inet6 filter bandwidth-output-reverse term 6 from source-port 5207
-set firewall family inet6 filter bandwidth-output-reverse term 6 then forwarding-class best-effort
-set firewall family inet6 filter bandwidth-output-reverse term 6 then count best-effort-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 6 from source-port 5206
+set firewall family inet6 filter bandwidth-output-reverse term 6 from source-port 6206
+set firewall family inet6 filter bandwidth-output-reverse term 6 then forwarding-class iperf-12g
+set firewall family inet6 filter bandwidth-output-reverse term 6 then count iperf-12g-reverse
 set firewall family inet6 filter bandwidth-output-reverse term 6 then accept
+
+set firewall family inet6 filter bandwidth-output-reverse term 7 from source-port 5207
+set firewall family inet6 filter bandwidth-output-reverse term 7 from source-port 6207
+set firewall family inet6 filter bandwidth-output-reverse term 7 then forwarding-class iperf-15g
+set firewall family inet6 filter bandwidth-output-reverse term 7 then count iperf-15g-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 7 then accept
+
+set firewall family inet6 filter bandwidth-output-reverse term 8 from source-port 5208
+set firewall family inet6 filter bandwidth-output-reverse term 8 from source-port 6208
+set firewall family inet6 filter bandwidth-output-reverse term 8 then forwarding-class iperf-18g
+set firewall family inet6 filter bandwidth-output-reverse term 8 then count iperf-18g-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 8 then accept
+
+set firewall family inet6 filter bandwidth-output-reverse term 9 from source-port 5209
+set firewall family inet6 filter bandwidth-output-reverse term 9 from source-port 6209
+set firewall family inet6 filter bandwidth-output-reverse term 9 then forwarding-class iperf-21g
+set firewall family inet6 filter bandwidth-output-reverse term 9 then count iperf-21g-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 9 then accept
+
+set firewall family inet6 filter bandwidth-output-reverse term 10 from source-port 5210
+set firewall family inet6 filter bandwidth-output-reverse term 10 from source-port 6210
+set firewall family inet6 filter bandwidth-output-reverse term 10 then forwarding-class iperf-24g
+set firewall family inet6 filter bandwidth-output-reverse term 10 then count iperf-24g-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 10 then accept
+
+set firewall family inet6 filter bandwidth-output-reverse term 11 from source-port 5211
+set firewall family inet6 filter bandwidth-output-reverse term 11 from source-port 6211
+set firewall family inet6 filter bandwidth-output-reverse term 11 then forwarding-class iperf-uncapped
+set firewall family inet6 filter bandwidth-output-reverse term 11 then count iperf-uncapped-reverse
+set firewall family inet6 filter bandwidth-output-reverse term 11 then accept
 
 set interfaces ge-0-0-1 unit 0 family inet6 filter output bandwidth-output-reverse

--- a/test/incus/cos_port_grid_test.py
+++ b/test/incus/cos_port_grid_test.py
@@ -1,0 +1,179 @@
+import pathlib
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent
+STRICT = (ROOT / "cos-iperf-config.set").read_text()
+SAME_CLASS = (ROOT / "cos-iperf-same-class.set").read_text()
+SYMMETRIC = (ROOT / "cos-iperf-symmetric.set").read_text()
+HARNESS = (ROOT / "fairness-harness.sh").read_text()
+SWEEP = (ROOT / "fairness-cos-class-sweep.sh").read_text()
+MOUSE = (ROOT / "test-mouse-latency.sh").read_text()
+MOUSE_SAME_CLASS = (ROOT / "test-mouse-latency-same-class.sh").read_text()
+HEADROOM = ROOT / "fairness-cos-throughput-headroom.sh"
+
+
+PORT_GRID = [
+    (0, "best-effort", "scheduler-be", 5200, 6200, "25000000000", False),
+    (1, "iperf-100m", "scheduler-100m", 5201, 6201, "100000000", True),
+    (2, "iperf-1g", "scheduler-1g", 5202, 6202, "1000000000", True),
+    (3, "iperf-3g", "scheduler-3g", 5203, 6203, "3000000000", True),
+    (4, "iperf-6g", "scheduler-6g", 5204, 6204, "6000000000", True),
+    (5, "iperf-9g", "scheduler-9g", 5205, 6205, "9000000000", True),
+    (6, "iperf-12g", "scheduler-12g", 5206, 6206, "12000000000", True),
+    (7, "iperf-15g", "scheduler-15g", 5207, 6207, "15000000000", True),
+    (8, "iperf-18g", "scheduler-18g", 5208, 6208, "18000000000", True),
+    (9, "iperf-21g", "scheduler-21g", 5209, 6209, "21000000000", True),
+    (10, "iperf-24g", "scheduler-24g", 5210, 6210, "24000000000", True),
+    (11, "iperf-uncapped", "scheduler-uncapped", 5211, 6211, "25000000000", False),
+]
+
+
+class CoSPortGridTests(unittest.TestCase):
+    def test_strict_and_same_class_fixtures_map_520x_and_620x_to_same_class(self):
+        for fixture in (STRICT, SAME_CLASS):
+            for queue, forwarding_class, scheduler, iperf_port, echo_port, _, exact in PORT_GRID:
+                with self.subTest(queue=queue, fixture="strict-or-same"):
+                    self.assertIn(
+                        f"set class-of-service forwarding-classes queue {queue} {forwarding_class}",
+                        fixture,
+                    )
+                    self.assertIn(
+                        f"set class-of-service scheduler-maps bandwidth-limit forwarding-class {forwarding_class} scheduler {scheduler}",
+                        fixture,
+                    )
+                    self.assertIn(
+                        f"term {queue} from destination-port {iperf_port}",
+                        fixture,
+                    )
+                    self.assertIn(
+                        f"term {queue} from destination-port {echo_port}",
+                        fixture,
+                    )
+                    exact_line = f"set class-of-service schedulers {scheduler} transmit-rate exact"
+                    if exact:
+                        self.assertIn(exact_line, fixture)
+                    else:
+                        self.assertNotIn(exact_line, fixture)
+
+    def test_symmetric_fixture_shapes_reverse_source_ports_for_iperf_and_echo(self):
+        for queue, forwarding_class, _, iperf_port, echo_port, _, _ in PORT_GRID:
+            with self.subTest(queue=queue):
+                self.assertIn(
+                    f"filter bandwidth-output-reverse term {queue} from source-port {iperf_port}",
+                    SYMMETRIC,
+                )
+                self.assertIn(
+                    f"filter bandwidth-output-reverse term {queue} from source-port {echo_port}",
+                    SYMMETRIC,
+                )
+                self.assertIn(
+                    f"filter bandwidth-output-reverse term {queue} then forwarding-class {forwarding_class}",
+                    SYMMETRIC,
+                )
+
+    def test_harness_and_sweep_share_the_canonical_queue_and_rate_map(self):
+        for queue, forwarding_class, _, iperf_port, echo_port, rate_bps, _ in PORT_GRID:
+            with self.subTest(queue=queue):
+                self.assertIn(f"{iperf_port}|{echo_port}) printf '{queue}\\n' ;;", HARNESS)
+                self.assertIn(f"{iperf_port}|{echo_port}) printf '{rate_bps}\\n' ;;", HARNESS)
+                self.assertIn(f"q{queue}-{forwarding_class}", SWEEP)
+                self.assertIn(f" {iperf_port} {queue} {rate_bps}", SWEEP)
+
+    def test_mouse_latency_defaults_use_620x_echo_ports(self):
+        self.assertIn('ELEPHANT_PORT="${ELEPHANT_PORT:-5202}"', MOUSE)
+        self.assertIn('MOUSE_PORT="${MOUSE_PORT:-6200}"', MOUSE)
+        self.assertIn("MOUSE_PORT=6202", MOUSE_SAME_CLASS)
+        self.assertIn("MOUSE_CLASS=iperf-1g", MOUSE_SAME_CLASS)
+
+    def test_same_class_fixture_preserves_legacy_port_7_override(self):
+        for family in ("inet", "inet6"):
+            with self.subTest(family=family):
+                self.assertIn(
+                    f"set firewall family {family} filter bandwidth-output term 12 from destination-port 7",
+                    SAME_CLASS,
+                )
+                self.assertIn(
+                    f"set firewall family {family} filter bandwidth-output term 12 then forwarding-class iperf-1g",
+                    SAME_CLASS,
+                )
+                self.assertIn(
+                    f"set firewall family {family} filter bandwidth-output term 12 then count iperf-1g-legacy-mouse",
+                    SAME_CLASS,
+                )
+
+    def test_headroom_applies_symmetric_fixture_for_reverse_default(self):
+        lines = self._run_headroom_and_capture_apply_args({})
+        self.assertEqual(
+            lines,
+            [
+                "--symmetric loss:xpf-userspace-fw0",
+                "--symmetric --surplus-sharing loss:xpf-userspace-fw0",
+                "--symmetric loss:xpf-userspace-fw0",
+            ],
+        )
+
+    def test_headroom_keeps_forward_fixture_for_explicit_forward(self):
+        lines = self._run_headroom_and_capture_apply_args({"REVERSE": ""})
+        self.assertEqual(
+            lines,
+            [
+                "loss:xpf-userspace-fw0",
+                "--surplus-sharing loss:xpf-userspace-fw0",
+                "loss:xpf-userspace-fw0",
+            ],
+        )
+
+    def _run_headroom_and_capture_apply_args(self, extra_env):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            apply_log = tmp_path / "apply-args.txt"
+            fake_apply = tmp_path / "apply-cos-config.sh"
+            fake_sweep = tmp_path / "fairness-cos-class-sweep.sh"
+            artifact_root = tmp_path / "artifacts"
+            fake_apply.write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$APPLY_LOG\"\n",
+                encoding="utf-8",
+            )
+            fake_sweep.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    mkdir -p "$ARTIFACT_ROOT"
+                    cat > "$ARTIFACT_ROOT/summary.tsv" <<'TSV'
+                    class\tport\tqueue_id\trate_bps\texit_status\tverdict\tmean_observed_cov\tmax_observed_cov\tstdev_observed_cov\tavg_mbps\tavg_rate_utilization\tavg_cstruct\tmean_gap\tmax_gap\tstarved_flows\tper_run_verdicts
+                    q8-iperf-18g\t5208\t8\t18000000000\t0\tPASS\t0.1\t0.1\t0\t1000\t0.1\t0.1\t0\t0\t0\tPASS
+                    TSV
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_apply.chmod(0o755)
+            fake_sweep.chmod(0o755)
+            env = {
+                "PATH": os.environ.get("PATH", ""),
+                "APPLY_COS_CONFIG": str(fake_apply),
+                "APPLY_LOG": str(apply_log),
+                "ARTIFACT_ROOT": str(artifact_root),
+                "SWEEP": str(fake_sweep),
+            }
+            env.update(extra_env)
+            result = subprocess.run(
+                [str(HEADROOM)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return apply_log.read_text(encoding="utf-8").splitlines()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/fairness-cos-class-sweep.sh
+++ b/test/incus/fairness-cos-class-sweep.sh
@@ -109,13 +109,18 @@ class	port	queue_id	rate_bps	exit_status	verdict	mean_observed_cov	max_observed_
 HEADER
 
 classes=(
-    "q0-best-effort-100m 5207 0 100000000"
-    "q4-iperf-a-1g 5201 4 1000000000"
-    "q5-iperf-b-10g 5202 5 10000000000"
-    "q1-iperf-d-13g 5204 1 13000000000"
-    "q2-iperf-e-16g 5205 2 16000000000"
-    "q3-iperf-f-19g 5206 3 19000000000"
-    "q6-iperf-c-25g 5203 6 25000000000"
+    "q0-best-effort-root 5200 0 25000000000"
+    "q1-iperf-100m 5201 1 100000000"
+    "q2-iperf-1g 5202 2 1000000000"
+    "q3-iperf-3g 5203 3 3000000000"
+    "q4-iperf-6g 5204 4 6000000000"
+    "q5-iperf-9g 5205 5 9000000000"
+    "q6-iperf-12g 5206 6 12000000000"
+    "q7-iperf-15g 5207 7 15000000000"
+    "q8-iperf-18g 5208 8 18000000000"
+    "q9-iperf-21g 5209 9 21000000000"
+    "q10-iperf-24g 5210 10 24000000000"
+    "q11-iperf-uncapped-root 5211 11 25000000000"
 )
 
 class_selected() {

--- a/test/incus/fairness-cos-throughput-headroom.sh
+++ b/test/incus/fairness-cos-throughput-headroom.sh
@@ -9,11 +9,20 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 TARGET_VM=${TARGET_VM:-loss:xpf-userspace-fw0}
 APPLY_CONFIG=${APPLY_CONFIG:-1}
 COMPARE_SURPLUS_SHARING=${COMPARE_SURPLUS_SHARING:-1}
-CLASS_FILTER=${CLASS_FILTER:-q2,q3,q6}
+CLASS_FILTER=${CLASS_FILTER:-q8,q9,q10}
 ARTIFACT_ROOT=${ARTIFACT_ROOT:-}
 SWEEP=${SWEEP:-$ROOT_DIR/test/incus/fairness-cos-class-sweep.sh}
 APPLY_COS_CONFIG=${APPLY_COS_CONFIG:-$ROOT_DIR/test/incus/apply-cos-config.sh}
 RESTORE_STRICT_NEEDED=0
+# Mirror fairness-cos-class-sweep.sh's reverse default. If the sweep
+# is going to run iperf3 -R, CoS must be applied with reverse
+# source-port filters; otherwise the headroom numbers are unclassified
+# reverse traffic. An explicit REVERSE= selects forward-only fixtures.
+SWEEP_REVERSE=${REVERSE--R}
+COS_DIRECTION_FLAGS=()
+if [[ -n "$SWEEP_REVERSE" ]]; then
+    COS_DIRECTION_FLAGS+=(--symmetric)
+fi
 
 enabled() {
     case "${1,,}" in
@@ -47,7 +56,7 @@ restore_strict_if_needed() {
     [[ "$RESTORE_STRICT_NEEDED" -eq 1 ]] || return 0
     enabled "$APPLY_CONFIG" || return 0
 
-    if "$APPLY_COS_CONFIG" "$TARGET_VM" \
+    if "$APPLY_COS_CONFIG" "${COS_DIRECTION_FLAGS[@]}" "$TARGET_VM" \
         > "$ARTIFACT_ROOT/restore-strict.stdout" \
         2> "$ARTIFACT_ROOT/restore-strict.stderr"; then
         RESTORE_STRICT_NEEDED=0
@@ -120,9 +129,9 @@ apply_config_for_scenario() {
     mkdir -p "$out"
     if [[ "$scenario" == surplus-sharing ]]; then
         RESTORE_STRICT_NEEDED=1
-        "$APPLY_COS_CONFIG" --surplus-sharing "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
+        "$APPLY_COS_CONFIG" "${COS_DIRECTION_FLAGS[@]}" --surplus-sharing "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
     else
-        "$APPLY_COS_CONFIG" "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
+        "$APPLY_COS_CONFIG" "${COS_DIRECTION_FLAGS[@]}" "$TARGET_VM" > "$out/apply.stdout" 2> "$out/apply.stderr"
     fi
 }
 

--- a/test/incus/fairness-harness.sh
+++ b/test/incus/fairness-harness.sh
@@ -18,8 +18,9 @@
 #   fairness-harness.sh --mixed-cos [TARGET] [PORT] [N] [DURATION] [REVERSE] [METRICS_URL]
 #   fairness-harness.sh --mixed-cos-isolated [TARGET] [PORT] [N] [DURATION] [REVERSE] [METRICS_URL]
 #
-# Mixed CoS mode defaults to canonical fixture ports 5201 (queue 4)
-# and 5202 (queue 5) and evaluates each class separately from the
+# Mixed CoS mode defaults to canonical fixture ports 5202 (queue 2,
+# 1 Gbps exact) and 5205 (queue 5, 9 Gbps exact) and evaluates each
+# class separately from the
 # same live xpf_userspace_cos_active_flow_count scrape. Set COS_IFINDEX
 # to the shaped egress ifindex. Override COS_QUEUE_ID /
 # MIXED_COS_QUEUE_ID only for non-canonical fixtures. In mixed mode the
@@ -58,8 +59,9 @@
 #                                           free-form NIC/RSS audit notes
 #   ARTIFACT_DIR                            placement artifact directory
 #
-# Defaults match the existing iperf-c P=12 -R workload that produced the
-# 47% per-flow CoV measurement that motivates the harness.
+# Defaults track the high-rate canonical CoS grid: single-class mode
+# uses port 5210 (24 Gbps exact), while mixed mode compares the 1 Gbps
+# and 9 Gbps exact classes.
 
 set -euo pipefail
 
@@ -76,9 +78,9 @@ done
 
 TARGET=${1:-172.16.80.200}
 if [[ "$MIXED_COS" -eq 1 ]]; then
-    DEFAULT_PORT=5201
+    DEFAULT_PORT=5202
 else
-    DEFAULT_PORT=5203
+    DEFAULT_PORT=5210
 fi
 PORT=${2:-$DEFAULT_PORT}
 N=${3:-12}
@@ -94,7 +96,7 @@ METRICS_URL=${6:-http://127.0.0.1:8080/metrics}
 IFACE=${IFACE:-ge-0-0-2}
 COS_IFINDEX=${COS_IFINDEX:-}
 COS_QUEUE_ID=${COS_QUEUE_ID:-}
-MIXED_PORT=${MIXED_PORT:-5202}
+MIXED_PORT=${MIXED_PORT:-5205}
 MIXED_N=${MIXED_N:-$N}
 # Preserve an explicit empty MIXED_REVERSE so mixed forward fixtures do
 # not silently inherit reverse mode.
@@ -157,26 +159,36 @@ fi
 
 canonical_cos_queue_for_port() {
     case "$1" in
-        5201) printf '4\n' ;;
-        5202) printf '5\n' ;;
-        5203) printf '6\n' ;;
-        5204) printf '1\n' ;;
-        5205) printf '2\n' ;;
-        5206) printf '3\n' ;;
-        5207) printf '0\n' ;;
+        5200|6200) printf '0\n' ;;
+        5201|6201) printf '1\n' ;;
+        5202|6202) printf '2\n' ;;
+        5203|6203) printf '3\n' ;;
+        5204|6204) printf '4\n' ;;
+        5205|6205) printf '5\n' ;;
+        5206|6206) printf '6\n' ;;
+        5207|6207) printf '7\n' ;;
+        5208|6208) printf '8\n' ;;
+        5209|6209) printf '9\n' ;;
+        5210|6210) printf '10\n' ;;
+        5211|6211) printf '11\n' ;;
         *) return 1 ;;
     esac
 }
 
 canonical_shaper_rate_for_port() {
     case "$1" in
-        5201) printf '1000000000\n' ;;
-        5202) printf '10000000000\n' ;;
-        5203) printf '25000000000\n' ;;
-        5204) printf '13000000000\n' ;;
-        5205) printf '16000000000\n' ;;
-        5206) printf '19000000000\n' ;;
-        5207) printf '100000000\n' ;;
+        5200|6200) printf '25000000000\n' ;;
+        5201|6201) printf '100000000\n' ;;
+        5202|6202) printf '1000000000\n' ;;
+        5203|6203) printf '3000000000\n' ;;
+        5204|6204) printf '6000000000\n' ;;
+        5205|6205) printf '9000000000\n' ;;
+        5206|6206) printf '12000000000\n' ;;
+        5207|6207) printf '15000000000\n' ;;
+        5208|6208) printf '18000000000\n' ;;
+        5209|6209) printf '21000000000\n' ;;
+        5210|6210) printf '24000000000\n' ;;
+        5211|6211) printf '25000000000\n' ;;
         *) return 1 ;;
     esac
 }
@@ -211,7 +223,11 @@ if [[ "$MIXED_COS" -eq 1 ]]; then
         fi
     fi
 else
-    SHAPER_RATE_BPS=${SHAPER_RATE_BPS:-25000000000}
+    if [[ -z "$SHAPER_RATE_BPS" ]]; then
+        if ! SHAPER_RATE_BPS=$(canonical_shaper_rate_for_port "$PORT"); then
+            SHAPER_RATE_BPS=25000000000
+        fi
+    fi
 fi
 
 format_command() {

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -531,8 +531,8 @@ class FairnessMultiSampleTest(unittest.TestCase):
                       "cstruct": {"mean": 0.3},
                       "gap": {"mean": -0.2, "max": -0.1},
                       "samples": [
-                        {"sample": 1, "sample_dir": "$out_dir/sample-1", "verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0},
-                        {"sample": 2, "sample_dir": "$out_dir/sample-2", "verdict": "PASS", "aggregate_mbps": 8000.0, "starved_flow_count": 0}
+                        {"sample": 1, "sample_dir": "$out_dir/sample-1", "verdict": "PASS", "aggregate_mbps": 500.0, "starved_flow_count": 0},
+                        {"sample": 2, "sample_dir": "$out_dir/sample-2", "verdict": "PASS", "aggregate_mbps": 500.0, "starved_flow_count": 0}
                       ]
                     }
                     JSON
@@ -602,18 +602,18 @@ class FairnessMultiSampleTest(unittest.TestCase):
             self.assertIn("avg_rate_utilization", summary_lines[0])
             self.assertEqual(len(summary_lines), 2)
             row = summary_lines[1].split("\t")
-            self.assertEqual(row[0], "q2-iperf-e-16g")
+            self.assertEqual(row[0], "q2-iperf-1g")
             self.assertEqual(row[10], "0.5")
             equal_flow_lines = (
                 out_root / "equal-flow-summary.tsv"
             ).read_text(encoding="utf-8").splitlines()
             self.assertIn("target_per_flow_bps_mean", equal_flow_lines[0])
             equal_flow_row = equal_flow_lines[1].split("\t")
-            self.assertEqual(equal_flow_row[0], "q2-iperf-e-16g")
+            self.assertEqual(equal_flow_row[0], "q2-iperf-1g")
             self.assertEqual(equal_flow_row[6], "1")
             self.assertEqual(equal_flow_row[7], "1000.0")
-            self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "metrics-raw.prom").exists())
-            self.assertTrue((out_root / "q2-iperf-e-16g" / "equal-flow" / "summary.tsv").exists())
+            self.assertTrue((out_root / "q2-iperf-1g" / "equal-flow" / "metrics-raw.prom").exists())
+            self.assertTrue((out_root / "q2-iperf-1g" / "equal-flow" / "summary.tsv").exists())
 
     def test_class_sweep_equal_flow_failure_reports_infra_exit_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -717,7 +717,7 @@ class FairnessMultiSampleTest(unittest.TestCase):
             summary_lines = (out_root / "summary.tsv").read_text(encoding="utf-8").splitlines()
             self.assertEqual(len(summary_lines), 2)
             row = summary_lines[1].split("\t")
-            self.assertEqual(row[0], "q2-iperf-e-16g")
+            self.assertEqual(row[0], "q2-iperf-1g")
             self.assertEqual(row[4], "2")
             self.assertEqual(row[5], "ERROR")
 

--- a/test/incus/test-mouse-latency-matrix.sh
+++ b/test/incus/test-mouse-latency-matrix.sh
@@ -12,7 +12,8 @@
 # established mouse transactions rather than echo-server accept rate.
 # Set MOUSE_PROBE_MIN_INTERVAL_MS=20 with that mode on the isolated
 # validation cluster; it still produces hundreds of thousands of
-# samples per 60-second rep without overdriving the port-7 echo daemon.
+# samples per 60-second rep without overdriving the selected 620x TCP
+# echo daemon.
 #
 # 12 cells: N ∈ {0, 8, 32, 128} × M ∈ {1, 10, 50}.
 # Per cell: run up to 15 total reps as needed to reach 10 valid reps.

--- a/test/incus/test-mouse-latency-same-class.sh
+++ b/test/incus/test-mouse-latency-same-class.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 #
-# #929: same-class iperf-b wrapper for the mouse-latency tail
-# measurement. Routes mice into the SAME CoS class (iperf-b) as
-# the elephants, exercising the same-class HOL gate that
-# #913/#918/#914/#920 target. The default cross-class invocation
-# (mice in best-effort port 7) remains unchanged via the bare
+# Same-class 1 Gbps wrapper for the mouse-latency tail measurement.
+# Routes mice into the SAME CoS class as the elephants by using
+# elephant port 5202 and TCP echo port 6202, both mapped to queue 2
+# (`iperf-1g`) by the canonical CoS fixture. The default cross-class
+# invocation keeps mice on 6200 best-effort via the bare
 # test-mouse-latency-matrix.sh wrapper.
 #
-# Mice still target port 7 (the operator's existing echo daemon —
-# no second listener required), but the --same-class CoS fixture
-# loaded automatically when MOUSE_CLASS=iperf-b adds a term that
-# classifies port 7 traffic as iperf-b instead of best-effort.
+# The old port-7 override fixture is no longer used; echo listeners
+# should run on 6200..6211 so latency probes can use the same class map
+# as iperf 5200..5211.
 #
 # Prerequisites (see docs/pr/929-same-class-harness/plan.md §3.3):
-#   - Echo daemon running on 172.16.80.200:7 (TCP) — same as
-#     the cross-class default
-#   - apply-cos-config.sh --same-class loads the term-4 mapping
-#     port 7 → iperf-b automatically (per MOUSE_CLASS=iperf-b)
+#   - Echo daemon running on 172.16.80.200:6202 (TCP)
+#   - apply-cos-config.sh loads the canonical 520x/620x CoS map
 #
 # CONCURRENCY: this wrapper and the cross-class matrix MUST NOT run
 # simultaneously. test-mouse-latency-matrix.sh enforces a flock-based
@@ -30,7 +27,7 @@ set -euo pipefail
 
 exec env \
     ELEPHANT_PORT=5202 \
-    MOUSE_PORT=7 \
-    MOUSE_CLASS=iperf-b \
-    SHAPER_BPS=$((10 * 1000 * 1000 * 1000)) \
+    MOUSE_PORT=6202 \
+    MOUSE_CLASS=iperf-1g \
+    SHAPER_BPS=$((1 * 1000 * 1000 * 1000)) \
     "$(dirname "$0")/test-mouse-latency-matrix.sh" "$@"

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -2,8 +2,8 @@
 # Run one rep of the #905 mouse-latency cell.
 #
 # Usage: test-mouse-latency.sh <N> <M> <duration_s> <out_dir>
-#   N: elephant streams against 172.16.80.200:5201 (iperf-a)
-#   M: concurrent mouse coroutines against 172.16.80.200:7 (best-effort)
+#   N: elephant streams against 172.16.80.200:5202 (1 Gbps exact)
+#   M: concurrent mouse coroutines against 172.16.80.200:6200 (best-effort)
 #   duration_s: probe duration in seconds (≥ 60 recommended)
 #   out_dir: per-rep output directory (created if missing)
 #
@@ -29,19 +29,20 @@ PRIMARY="xpf-userspace-fw0"
 SECONDARY="xpf-userspace-fw1"
 SOURCE="cluster-userspace-host"
 TARGET_V4="172.16.80.200"
-# #929: env-var overridable so test-mouse-latency-same-class.sh
-# can run the same-class variant at the iperf-b 10 Gb/s shaper
-# rate while still sending mice to port 7; the same-class CoS
-# fixture reclassifies port 7 as iperf-b instead of best-effort.
+# Env-var overridable so test-mouse-latency-same-class.sh can run a
+# same-class variant by selecting the matching 520x elephant port and
+# 620x TCP echo port. The canonical CoS fixture maps 6200..6211 to the
+# same forwarding classes as 5200..5211, so same-class latency no longer
+# needs the legacy port-7 override fixture.
 # SHAPER_BPS MUST move with ELEPHANT_PORT because the cwnd-settle
 # and collapse gates compare against it.
-ELEPHANT_PORT="${ELEPHANT_PORT:-5201}"
-MOUSE_PORT="${MOUSE_PORT:-7}"
+ELEPHANT_PORT="${ELEPHANT_PORT:-5202}"
+MOUSE_PORT="${MOUSE_PORT:-6200}"
 MOUSE_CLASS="${MOUSE_CLASS:-best-effort}"
 MOUSE_COS_SURPLUS_SHARING="${MOUSE_COS_SURPLUS_SHARING:-0}"
 MOUSE_PROBE_CONNECTION_MODE="${MOUSE_PROBE_CONNECTION_MODE:-per-attempt}"
 MOUSE_PROBE_MIN_INTERVAL_MS="${MOUSE_PROBE_MIN_INTERVAL_MS:-0}"
-SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf-a); same-class iperf-b sets 10 Gb/s
+SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (port 5202); same-class wrappers must override with their selected class cap.
 # Validate env-overrides (Copilot D.5): ports/bps must be
 # digits only so they can't smuggle shell metacharacters into
 # the remote `bash -c` interpolations below. MOUSE_CLASS and
@@ -55,8 +56,8 @@ SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (iperf
 [[ "$SHAPER_BPS" =~ ^[0-9]+$ ]] \
     || { echo "ABORT: SHAPER_BPS='$SHAPER_BPS' must be digits" >&2; exit 1; }
 case "$MOUSE_CLASS" in
-    best-effort|iperf-a|iperf-b|iperf-c) ;;
-    *) echo "ABORT: MOUSE_CLASS='$MOUSE_CLASS' must be one of best-effort/iperf-a/iperf-b/iperf-c" >&2; exit 1 ;;
+    best-effort|iperf-100m|iperf-1g|iperf-3g|iperf-6g|iperf-9g|iperf-12g|iperf-15g|iperf-18g|iperf-21g|iperf-24g|iperf-uncapped) ;;
+    *) echo "ABORT: MOUSE_CLASS='$MOUSE_CLASS' must be one of best-effort/iperf-100m/iperf-1g/iperf-3g/iperf-6g/iperf-9g/iperf-12g/iperf-15g/iperf-18g/iperf-21g/iperf-24g/iperf-uncapped" >&2; exit 1 ;;
 esac
 case "${MOUSE_COS_SURPLUS_SHARING,,}" in
     0|false|no|off) MOUSE_COS_SURPLUS_SHARING=0 ;;
@@ -188,7 +189,7 @@ incus_run file push "${SCRIPT_DIR}/mouse_latency_probe.py" \
 
 # ---- step 0: echo-daemon preflight (Copilot D.3: must run BEFORE
 # any CoS state mutation so a failure leaves the cluster in
-# whatever state preceded this rep, not in the same-class fixture).
+# whatever state preceded this rep, not in the selected CoS fixture).
 # Uses bash /dev/tcp rather than `nc -zw1` because the source
 # container doesn't ship netcat by default.
 if ! incus_exec "$SOURCE" timeout 2 bash -c \
@@ -206,9 +207,6 @@ fi
 # attempt to apply on the secondary.
 PRE_PRIMARY=$(current_primary)
 APPLY_COS_FLAGS=()
-if [[ "$MOUSE_CLASS" == "iperf-b" ]]; then
-    APPLY_COS_FLAGS+=(--same-class)
-fi
 if [[ "$MOUSE_COS_SURPLUS_SHARING" -eq 1 ]]; then
     APPLY_COS_FLAGS+=(--surplus-sharing)
 fi


### PR DESCRIPTION
## Summary

- refactor the canonical CoS fixture grid to ports 5200..5211:
  - 5200 best-effort, root-shaped
  - 5201 100 Mbps exact
  - 5202 1 Gbps exact
  - 5203 3 Gbps exact
  - 5204 6 Gbps exact
  - 5205 9 Gbps exact
  - 5206 12 Gbps exact
  - 5207 15 Gbps exact
  - 5208 18 Gbps exact
  - 5209 21 Gbps exact
  - 5210 24 Gbps exact
  - 5211 uncapped except for the interface root shaper
- map TCP echo ports 6200..6211 into the same forwarding classes as the corresponding 5200..5211 iperf ports
- update the symmetric fixture so reverse iperf and echo replies match source-port 5200..5211 and 6200..6211
- update fairness harness defaults, class sweep rows, throughput-headroom filter, mouse-latency defaults, same-class wrapper, tests, and docs
- preserve the legacy `--same-class` port-7 override by mapping destination-port 7 to the 1 Gbps same-class queue
- make the throughput-headroom wrapper apply the symmetric CoS fixture whenever its sweep runs reverse traffic

## Notes

Best-effort and uncapped are deliberately non-exact scheduler-map entries. The Rust CoS builder resolves those to the interface root shaper rate with exact=false, so they stay under the total interface shape without a per-class cap.

The preferred same-class mouse path is now the 620x echo alias (`5202` elephants with `6202` mice for the 1 Gbps class). The old port-7 override remains in `cos-iperf-same-class.set` for external callers that still use `apply-cos-config.sh --same-class` with the legacy echo daemon.

The throughput-headroom wrapper follows `fairness-cos-class-sweep.sh` direction semantics: unset `REVERSE` means reverse mode and applies `--symmetric`; explicit `REVERSE=` means forward mode and applies the normal fixture.

## Validation

- python3 -m unittest discover -s test/incus -p '*_test.py'
- python3 test/incus/cos_port_grid_test.py
- python3 test/incus/test_mouse_latency_shell_test.py
- python3 test/incus/fairness_multi_sample_test.py
- bash -n test/incus/fairness-harness.sh test/incus/fairness-cos-class-sweep.sh test/incus/fairness-cos-throughput-headroom.sh test/incus/apply-cos-config.sh test/incus/test-mouse-latency.sh test/incus/test-mouse-latency-matrix.sh test/incus/test-mouse-latency-same-class.sh
- go test ./pkg/config ./pkg/dataplane/userspace
- git diff --check
