### PR TITLE
userspace: expose CoS drain phase telemetry

### DIFF
--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -278,7 +278,8 @@ drain path without having to scrape Prometheus or attach perf:
 Queue  Owner  Class    ...  Buffer     Queued pkts  Queued bytes  ...
 4      1      iperf-a  ...  1.19 MiB   299          443.24 KiB    ...
        Drops: flow_share=75  buffer=0  ecn_marked=97349
-       OwnerProfile: drain_p50=1us  drain_p99=16us  redirect_p99=2us  owner_pps=12345  peer_pps=6789
+       OwnerProfile: drain_p50=1us  drain_p99=16us  drain_invocations=1234
+       Binding telemetry: redirect_p99=2us  owner_pps=12345  peer_pps=6789
 ```
 
 Field meanings (from `BindingLiveState` in `userspace-dp/src/afxdp/umem.rs`):

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -328,12 +328,16 @@ without reading them is how we ship dormant code.
 
 ### Operational gotchas
 
-- **Non-exact / shared_exact queues have NO OwnerProfile line.**
-  The telemetry is per-binding on the owner's `BindingLiveState`;
-  if there is no single owner binding (shared_exact at ≥ 2.5 Gbps,
-  or non-exact queues), the CLI suppresses the row. An operator
-  wanting the same view for a high-rate shared queue must wait for
-  a sharded-per-worker histogram to land (not planned).
+- **Non-exact / shared_exact queues have no `OwnerProfile` latency
+  line.** The latency histogram is per-binding on the owner's
+  `BindingLiveState`; if there is no single owner binding
+  (shared_exact at ≥ 2.5 Gbps, or non-exact queues), the CLI
+  suppresses that row. Queue-scoped `DrainShape` counters still render
+  when non-zero. For best-effort/exact contention, compare
+  `guarantee`, `surplus`, and
+  `nonexact_while_exact_backlogged`; a rising non-exact/exact-backlog
+  delta means best-effort or uncapped service ran while exact queues on
+  the same shaped interface still had demand.
 - **The counters are process-monotonic.** For a windowed delta on
   live traffic, snapshot before and after and subtract — same as
   the `Drops:` line.
@@ -341,7 +345,11 @@ without reading them is how we ship dormant code.
   `xpf_cos_drain_latency_ns_bucket{ifindex, queue_id, bucket_hi_ns}`,
   `xpf_cos_redirect_acquire_ns_bucket{...}`,
   `xpf_cos_drain_invocations_total{ifindex, queue_id}`,
-  `xpf_cos_owner_pps{ifindex, queue_id}`, and `xpf_cos_peer_pps{...}`.
+  `xpf_cos_owner_pps{ifindex, queue_id}`,
+  `xpf_cos_peer_pps{...}`,
+  `xpf_userspace_cos_drain_guarantee_sent_bytes_total{...}`,
+  `xpf_userspace_cos_drain_surplus_sent_bytes_total{...}`, and
+  `xpf_userspace_cos_drain_nonexact_sent_bytes_while_exact_backlogged_total{...}`.
   Expected cardinality per the plan: ≤ 8192 series per histogram.
 
 ## CPU pinning layout for the loss lab

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -44,7 +44,11 @@ under the daemon's errgroup. Nothing else imports this package.
   (`xpf_userspace_cos_drain_{guarantee,surplus}_sent_bytes_total` and
   `xpf_userspace_cos_drain_nonexact_sent_bytes_while_exact_backlogged_total`)
   deliberately include non-exact queues so best-effort/exact contention can be
-  diagnosed without adding packet-path shared state.
+  diagnosed. Exact-backlog cross-binding visibility uses per-binding
+  cacheline-padded atomic slots (`SharedCoSExactBacklog`) written from the
+  enqueue and completion paths; metric collection still reads from a single
+  `Status()` snapshot per scrape rather than instrumenting the scrape path
+  itself.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -39,6 +39,12 @@ under the daemon's errgroup. Nothing else imports this package.
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during
   bulk sync (per CLAUDE.md control-socket rules).
+- Userspace CoS metrics are emitted from a single `Status()` snapshot per
+  scrape. Queue-scoped drain-phase counters
+  (`xpf_userspace_cos_drain_{guarantee,surplus}_sent_bytes_total` and
+  `xpf_userspace_cos_drain_nonexact_sent_bytes_while_exact_backlogged_total`)
+  deliberately include non-exact queues so best-effort/exact contention can be
+  diagnosed without adding packet-path shared state.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -86,6 +86,13 @@ type xpfCollector struct {
 	cosRedirectAcquireBucket *prometheus.Desc
 	cosOwnerPPS              *prometheus.Desc
 	cosPeerPPS               *prometheus.Desc
+	// #1369: queue-scoped drain-phase counters. Unlike the owner
+	// latency profile, these are meaningful for non-exact queues
+	// too, because they expose whether best-effort/uncapped traffic
+	// consumed service while exact queues still had backlog.
+	cosDrainGuaranteeSentBytes                    *prometheus.Desc
+	cosDrainSurplusSentBytes                      *prometheus.Desc
+	cosDrainNonExactSentBytesWhileExactBacklogged *prometheus.Desc
 	// #1304: Rust-owned opt-in equal-flow enforcement telemetry for
 	// shared v8 CoS queue leases. Kept separate from the
 	// measurement-only xpf_fairness_equal_flow_* estimator gauges.
@@ -364,6 +371,21 @@ func newCollector(srv *Server) *xpfCollector {
 		cosPeerPPS: prometheus.NewDesc(
 			"xpf_cos_peer_pps",
 			"CoS peer-redirected pps (window accumulator, cleared by operator) (#709).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosDrainGuaranteeSentBytes: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_guarantee_sent_bytes_total",
+			"Bytes sent by this CoS queue during guarantee-phase service (#1369).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosDrainSurplusSentBytes: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_surplus_sent_bytes_total",
+			"Bytes sent by this CoS queue during surplus-phase service (#1369).",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosDrainNonExactSentBytesWhileExactBacklogged: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_nonexact_sent_bytes_while_exact_backlogged_total",
+			"Non-exact CoS queue bytes sent while at least one exact queue on the same shaped interface still had backlog; non-zero deltas indicate best-effort/uncapped service competing with exact demand (#1369).",
 			[]string{"ifindex", "queue_id"}, nil,
 		),
 		cosEqualFlowEnforcementEnabled: prometheus.NewDesc(
@@ -659,6 +681,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.cosRedirectAcquireBucket
 	ch <- c.cosOwnerPPS
 	ch <- c.cosPeerPPS
+	ch <- c.cosDrainGuaranteeSentBytes
+	ch <- c.cosDrainSurplusSentBytes
+	ch <- c.cosDrainNonExactSentBytesWhileExactBacklogged
 	ch <- c.cosEqualFlowEnforcementEnabled
 	ch <- c.cosEqualFlowEnforced
 	ch <- c.cosEqualFlowTargetPerFlowBPS
@@ -743,6 +768,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp da
 		return
 	}
 	c.emitCoSOwnerProfile(ch, status)
+	c.emitCoSDrainPhaseTelemetry(ch, status)
 	c.emitCoSEqualFlowEnforcement(ch, status)
 	c.emitWorkerRuntime(ch, status)
 	c.emitBindingActiveFlowCount(ch, status)
@@ -1134,6 +1160,38 @@ func (c *xpfCollector) emitCoSOwnerProfile(ch chan<- prometheus.Metric, status d
 			ch <- prometheus.MustNewConstMetric(c.cosPeerPPS,
 				prometheus.GaugeValue, float64(queue.PeerPPS),
 				ifindexLabel, queueLabel)
+		}
+	}
+}
+
+// #1369: queue-scoped drain-phase bytes for exact-vs-best-effort
+// contention diagnosis. These counters are intentionally not gated on
+// OwnerWorkerID: non-exact queues are the critical source for
+// `*_while_exact_backlogged`, and shared-exact queues still produce a
+// truthful guarantee/surplus phase split.
+func (c *xpfCollector) emitCoSDrainPhaseTelemetry(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, iface := range status.CoSInterfaces {
+		ifindexLabel := strconv.Itoa(iface.Ifindex)
+		for _, queue := range iface.Queues {
+			queueLabel := strconv.Itoa(queue.QueueID)
+			ch <- prometheus.MustNewConstMetric(
+				c.cosDrainGuaranteeSentBytes,
+				prometheus.CounterValue,
+				float64(queue.DrainGuaranteeSentBytes),
+				ifindexLabel, queueLabel,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.cosDrainSurplusSentBytes,
+				prometheus.CounterValue,
+				float64(queue.DrainSurplusSentBytes),
+				ifindexLabel, queueLabel,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.cosDrainNonExactSentBytesWhileExactBacklogged,
+				prometheus.CounterValue,
+				float64(queue.DrainNonExactSentBytesWhileExactBacklogged),
+				ifindexLabel, queueLabel,
+			)
 		}
 	}
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -380,6 +381,70 @@ func TestEmitCoSEqualFlowEnforcement_LabelsAndValues(t *testing.T) {
 		if value != want {
 			t.Fatalf("equal-flow metric %s = %v, want %v", m.Desc(), value, want)
 		}
+	}
+}
+
+func TestEmitCoSDrainPhaseTelemetry_EmitsNonExactExactBacklogCounter(t *testing.T) {
+	c := &xpfCollector{
+		cosDrainGuaranteeSentBytes: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_guarantee_sent_bytes_total",
+			"test desc",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosDrainSurplusSentBytes: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_surplus_sent_bytes_total",
+			"test desc",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+		cosDrainNonExactSentBytesWhileExactBacklogged: prometheus.NewDesc(
+			"xpf_userspace_cos_drain_nonexact_sent_bytes_while_exact_backlogged_total",
+			"test desc",
+			[]string{"ifindex", "queue_id"}, nil,
+		),
+	}
+	status := dpuserspace.ProcessStatus{
+		CoSInterfaces: []dpuserspace.CoSInterfaceStatus{{
+			Ifindex: 80,
+			Queues: []dpuserspace.CoSQueueStatus{{
+				QueueID:                 0,
+				DrainGuaranteeSentBytes: 1024,
+				DrainSurplusSentBytes:   2048,
+				DrainNonExactSentBytesWhileExactBacklogged: 512,
+			}},
+		}},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitCoSDrainPhaseTelemetry(ch, status)
+		close(ch)
+	}()
+	values := map[*prometheus.Desc]float64{}
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		labels := map[string]string{}
+		for _, lp := range pb.GetLabel() {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+		if labels["ifindex"] != "80" || labels["queue_id"] != "0" {
+			t.Fatalf("wrong drain phase labels: %v", labels)
+		}
+		if pb.Counter == nil {
+			t.Fatalf("drain phase metric %s must be a counter: %+v", m.Desc(), &pb)
+		}
+		values[m.Desc()] = pb.Counter.GetValue()
+	}
+
+	want := map[*prometheus.Desc]float64{
+		c.cosDrainGuaranteeSentBytes:                    1024,
+		c.cosDrainSurplusSentBytes:                      2048,
+		c.cosDrainNonExactSentBytesWhileExactBacklogged: 512,
+	}
+	if !reflect.DeepEqual(values, want) {
+		t.Fatalf("drain phase metric values: got %+v, want %+v", values, want)
 	}
 }
 

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -9,6 +9,11 @@ Pluggable: alternative backends (DPDK in `pkg/dataplane/dpdk`, userspace
 AF_XDP in `pkg/dataplane/userspace`) register via `RegisterBackend`. The
 Go interface is the only thing every caller sees.
 
+The userspace backend's status wire format is mirrored here for CLI/API
+consumers. CoS queue status includes queue-scoped drain-phase counters so
+operators can separate guarantee bytes, surplus bytes, and non-exact bytes
+sent while exact queues were still backlogged.
+
 ## Entry points
 
 - `DataPlane` — `dataplane.go`. Abstract interface.

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -50,11 +50,15 @@ type cosQueueView struct {
 	redirectAcquireHist  []uint64
 	ownerPPS             uint64
 	peerPPS              uint64
-	// #760 overshoot-hunt instrumentation. drainSentBytes /
-	// drainParkRootTokens / drainParkQueueTokens are queue-scoped.
+	// #760/#1369 drain-shape instrumentation. drainSentBytes,
+	// phase splits, exact-backlog steal bytes, and park counters are
+	// queue-scoped.
 	// postDrainBackupBytes is binding-scoped (one-per-binding Rust
 	// attribution; summed across queues here for rendering).
 	drainSentBytes                uint64
+	drainGuaranteeSentBytes       uint64
+	drainSurplusSentBytes         uint64
+	drainNonExactWhileExactBytes  uint64
 	drainParkRootTokens           uint64
 	drainParkQueueTokens          uint64
 	postDrainBackupBytes          uint64
@@ -232,9 +236,8 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 			// the interface header via renderBindingScopedTelemetry
 			// so they are no longer repeated under every queue row
 			// (#732). Non-exact / shared_exact queues keep an empty
-			// per-queue hist post-#751 because the drain path only
-			// writes the atomics when it services them, so
-			// drainInvocations==0 correctly suppresses the row.
+			// per-queue histogram, so drainInvocations==0 correctly
+			// suppresses the latency row.
 			if queue.ownerWorker != nil && queue.drainInvocations > 0 {
 				fmt.Fprintf(
 					&b,
@@ -243,16 +246,20 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 					formatHistPercentileMicros(queue.drainLatencyHist, queue.drainInvocations, 99),
 					queue.drainInvocations,
 				)
-				// #760 overshoot-hunt row. Sibling of the OwnerProfile
-				// line so operators can correlate drain-latency with
-				// the rate the queue actually shaped out and the two
-				// gate-park counters. Only rendered when the queue has
-				// been drained at least once — a never-drained queue's
-				// zeros carry no signal.
+			}
+			if queue.hasDrainShapeTelemetry() {
+				// #760/#1369 overshoot-hunt row. This is queue-
+				// scoped, so render it independently of the exact-only
+				// OwnerProfile latency row. Non-exact rows need this
+				// line to expose best-effort/uncapped bytes sent while
+				// exact queues were still backlogged.
 				fmt.Fprintf(
 					&b,
-					"           DrainShape:   sent_bytes=%d  park_root=%d  park_queue=%d\n",
+					"           DrainShape:   sent_bytes=%d  guarantee=%d  surplus=%d  nonexact_while_exact_backlogged=%d  park_root=%d  park_queue=%d\n",
 					queue.drainSentBytes,
+					queue.drainGuaranteeSentBytes,
+					queue.drainSurplusSentBytes,
+					queue.drainNonExactWhileExactBytes,
 					queue.drainParkRootTokens,
 					queue.drainParkQueueTokens,
 				)
@@ -260,6 +267,15 @@ func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, select
 		}
 	}
 	return b.String()
+}
+
+func (q cosQueueView) hasDrainShapeTelemetry() bool {
+	return q.drainSentBytes != 0 ||
+		q.drainGuaranteeSentBytes != 0 ||
+		q.drainSurplusSentBytes != 0 ||
+		q.drainNonExactWhileExactBytes != 0 ||
+		q.drainParkRootTokens != 0 ||
+		q.drainParkQueueTokens != 0
 }
 
 // #709: render a histogram percentile as microseconds. The Rust side
@@ -582,6 +598,9 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			// drained leaves these at zero; the renderer gates on
 			// drainInvocations > 0 so a silent queue stays silent.
 			qv.drainSentBytes = runtimeQueue.DrainSentBytes
+			qv.drainGuaranteeSentBytes = runtimeQueue.DrainGuaranteeSentBytes
+			qv.drainSurplusSentBytes = runtimeQueue.DrainSurplusSentBytes
+			qv.drainNonExactWhileExactBytes = runtimeQueue.DrainNonExactSentBytesWhileExactBacklogged
 			qv.drainParkRootTokens = runtimeQueue.DrainParkRootTokens
 			qv.drainParkQueueTokens = runtimeQueue.DrainParkQueueTokens
 			qv.postDrainBackupBytes = runtimeQueue.PostDrainBackupBytes

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -807,6 +807,41 @@ func TestFormatCoSInterfaceSummarySuppressesZeroedOwnerProfile(t *testing.T) {
 	}
 }
 
+func TestFormatCoSInterfaceSummaryRendersDrainShapeForNonExactQueue(t *testing.T) {
+	status := &ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				InterfaceName:   "reth0.80",
+				WorkerInstances: 1,
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:                 0,
+						ForwardingClass:         "best-effort",
+						Priority:                5,
+						Exact:                   false,
+						TransmitRateBytes:       1_875_000,
+						BufferBytes:             32 * 1024,
+						DrainSentBytes:          4096,
+						DrainGuaranteeSentBytes: 1024,
+						DrainSurplusSentBytes:   3072,
+						DrainNonExactSentBytesWhileExactBacklogged: 2048,
+						DrainParkRootTokens:                        7,
+						DrainParkQueueTokens:                       0,
+					},
+				},
+			},
+		},
+	}
+	out := FormatCoSInterfaceSummary(testCoSConfig(), status, "reth0.80")
+	if strings.Contains(out, "OwnerProfile:") {
+		t.Fatalf("non-exact queue must not render OwnerProfile latency row:\n%s", out)
+	}
+	want := "DrainShape:   sent_bytes=4096  guarantee=1024  surplus=3072  nonexact_while_exact_backlogged=2048  park_root=7  park_queue=0"
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing non-exact DrainShape row %q:\n%s", want, out)
+	}
+}
+
 // Zero-valued counters MUST still render — operators need to see the
 // counter is wired, otherwise "no output" is indistinguishable from
 // "counter missing from the pipeline" when chasing #718 / #722.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -530,13 +530,19 @@ type CoSQueueStatus struct {
 	// PostDrainBackupBytes is binding-scoped (same row as
 	// OwnerPPS/PeerPPS). See Rust `CoSQueueStatus` for field
 	// semantics and write-site locations.
-	DrainSentBytes                    uint64 `json:"drain_sent_bytes,omitempty"`
-	DrainParkRootTokens               uint64 `json:"drain_park_root_tokens,omitempty"`
-	DrainParkQueueTokens              uint64 `json:"drain_park_queue_tokens,omitempty"`
-	PostDrainBackupBytes              uint64 `json:"post_drain_backup_bytes,omitempty"`
-	DrainSentBytesShapedUnconditional uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
-	PostDrainBackupCosDrops           uint64 `json:"post_drain_backup_cos_drops,omitempty"`
-	PostDrainBackupCosDropBytes       uint64 `json:"post_drain_backup_cos_drop_bytes,omitempty"`
+	DrainSentBytes          uint64 `json:"drain_sent_bytes,omitempty"`
+	DrainGuaranteeSentBytes uint64 `json:"drain_guarantee_sent_bytes,omitempty"`
+	DrainSurplusSentBytes   uint64 `json:"drain_surplus_sent_bytes,omitempty"`
+	// #1369: non-exact bytes sent while exact queue demand existed on
+	// the same shaped interface. A rising delta means best-effort or
+	// uncapped service was competing with exact queues.
+	DrainNonExactSentBytesWhileExactBacklogged uint64 `json:"drain_nonexact_sent_bytes_while_exact_backlogged,omitempty"`
+	DrainParkRootTokens                        uint64 `json:"drain_park_root_tokens,omitempty"`
+	DrainParkQueueTokens                       uint64 `json:"drain_park_queue_tokens,omitempty"`
+	PostDrainBackupBytes                       uint64 `json:"post_drain_backup_bytes,omitempty"`
+	DrainSentBytesShapedUnconditional          uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
+	PostDrainBackupCosDrops                    uint64 `json:"post_drain_backup_cos_drops,omitempty"`
+	PostDrainBackupCosDropBytes                uint64 `json:"post_drain_backup_cos_drop_bytes,omitempty"`
 }
 
 type FirewallFilterTermCounterStatus struct {

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -89,6 +89,41 @@ func TestBindingCountersSnapshotTXSharedRecycleUnknownSlotDropsRoundTrip(t *test
 	}
 }
 
+func TestCoSQueueStatusDrainPhaseCountersRoundTrip(t *testing.T) {
+	in := CoSQueueStatus{
+		QueueID:                 0,
+		DrainSentBytes:          4096,
+		DrainGuaranteeSentBytes: 1024,
+		DrainSurplusSentBytes:   3072,
+		DrainNonExactSentBytesWhileExactBacklogged: 2048,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{
+		"drain_guarantee_sent_bytes",
+		"drain_surplus_sent_bytes",
+		"drain_nonexact_sent_bytes_while_exact_backlogged",
+	} {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from CoSQueueStatus JSON: %s", key, string(raw))
+		}
+	}
+
+	var back CoSQueueStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal CoSQueueStatus: %v", err)
+	}
+	if !reflect.DeepEqual(back, in) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", back, in)
+	}
+}
+
 func TestBindingStatusTxKickLatencyRoundTrip(t *testing.T) {
 	// Encode a Go BindingStatus with non-trivial values on the
 	// four kick-latency fields; decode the JSON back; assert

--- a/userspace-dp/src/afxdp/coordinator/cos_state.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_state.rs
@@ -4,6 +4,7 @@ pub(crate) struct SharedCoSState {
     pub(crate) owner_worker_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), u32>>>,
     pub(crate) owner_live_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     pub(crate) root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
+    pub(crate) exact_backlogs: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>>,
     pub(crate) queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     /// #917: per-shared_exact-queue V_min coordination Arcs.
     /// Allocated once per shared_exact CoS queue (mirror of
@@ -19,6 +20,7 @@ impl SharedCoSState {
             owner_worker_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             owner_live_by_queue: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             root_leases: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
+            exact_backlogs: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             queue_leases: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
             queue_vtime_floors: Arc::new(ArcSwap::from_pointee(BTreeMap::new())),
         }

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -215,6 +215,7 @@ impl Coordinator {
             .owner_live_by_queue
             .store(Arc::new(BTreeMap::new()));
         self.cos.root_leases.store(Arc::new(BTreeMap::new()));
+        self.cos.exact_backlogs.store(Arc::new(BTreeMap::new()));
         self.cos.queue_leases.store(Arc::new(BTreeMap::new()));
         self.cos.queue_vtime_floors.store(Arc::new(BTreeMap::new()));
         self.last_slow_path_status = self
@@ -679,6 +680,7 @@ impl Coordinator {
             let shared_cos_owner_worker_by_queue = self.cos.owner_worker_by_queue.clone();
             let shared_cos_owner_live_by_queue = self.cos.owner_live_by_queue.clone();
             let shared_cos_root_leases = self.cos.root_leases.clone();
+            let shared_cos_exact_backlogs = self.cos.exact_backlogs.clone();
             let shared_cos_queue_leases = self.cos.queue_leases.clone();
             let shared_cos_queue_vtime_floors = self.cos.queue_vtime_floors.clone();
             let runtime_atomics =
@@ -722,6 +724,7 @@ impl Coordinator {
                         shared_cos_owner_worker_by_queue,
                         shared_cos_owner_live_by_queue,
                         shared_cos_root_leases,
+                        shared_cos_exact_backlogs,
                         shared_cos_queue_leases,
                         shared_cos_queue_vtime_floors,
                         cos_status_clone,
@@ -1049,6 +1052,7 @@ impl Coordinator {
             &active_shards_by_egress_ifindex,
             current_leases.as_ref(),
         );
+        let current_exact_backlogs = self.cos.exact_backlogs.load();
         // #917: V_min coordination Arcs sized by worker count.
         // workers.last_planned_workers is set in apply_planned_workers
         // before this reconcile fires; defaults to 0 at first
@@ -1060,6 +1064,11 @@ impl Coordinator {
         let current_queue_vtime_floors = self.cos.queue_vtime_floors.load();
         let num_workers = self.workers.last_planned_workers().max(1);
         let current_queue_leases = self.cos.queue_leases.load();
+        let next_exact_backlogs = build_shared_cos_exact_backlogs_reusing_existing(
+            &self.forwarding,
+            num_workers,
+            current_exact_backlogs.as_ref(),
+        );
         let next_queue_leases = build_shared_cos_queue_leases_reusing_existing(
             &self.forwarding,
             &active_shards_by_egress_ifindex,
@@ -1082,6 +1091,9 @@ impl Coordinator {
         }
         if !shared_cos_root_leases_match(current_leases.as_ref(), &next_leases) {
             self.cos.root_leases.store(Arc::new(next_leases));
+        }
+        if !shared_cos_exact_backlogs_match(current_exact_backlogs.as_ref(), &next_exact_backlogs) {
+            self.cos.exact_backlogs.store(Arc::new(next_exact_backlogs));
         }
         if !shared_cos_queue_leases_match(current_queue_leases.as_ref(), &next_queue_leases) {
             self.cos.queue_leases.store(Arc::new(next_queue_leases));
@@ -1738,6 +1750,29 @@ fn build_shared_cos_root_leases_reusing_existing(
     out
 }
 
+fn build_shared_cos_exact_backlogs_reusing_existing(
+    forwarding: &ForwardingState,
+    num_workers: usize,
+    existing: &BTreeMap<i32, Arc<SharedCoSExactBacklog>>,
+) -> BTreeMap<i32, Arc<SharedCoSExactBacklog>> {
+    let max_worker_id = num_workers.saturating_sub(1);
+    let mut out = BTreeMap::new();
+    for (&ifindex, iface) in &forwarding.cos.interfaces {
+        if !iface.queues.iter().any(|queue| queue.exact) {
+            continue;
+        }
+        if let Some(backlog) = existing
+            .get(&ifindex)
+            .filter(|backlog| backlog.matches_config(max_worker_id))
+        {
+            out.insert(ifindex, backlog.clone());
+            continue;
+        }
+        out.insert(ifindex, Arc::new(SharedCoSExactBacklog::new(max_worker_id)));
+    }
+    out
+}
+
 fn build_shared_cos_queue_leases_reusing_existing(
     forwarding: &ForwardingState,
     active_shards_by_egress_ifindex: &BTreeMap<i32, usize>,
@@ -1807,6 +1842,17 @@ fn shared_cos_root_leases_match(
         && current.iter().all(|(ifindex, lease)| {
             next.get(ifindex)
                 .is_some_and(|next| Arc::ptr_eq(lease, next))
+        })
+}
+
+fn shared_cos_exact_backlogs_match(
+    current: &BTreeMap<i32, Arc<SharedCoSExactBacklog>>,
+    next: &BTreeMap<i32, Arc<SharedCoSExactBacklog>>,
+) -> bool {
+    current.len() == next.len()
+        && current.iter().all(|(ifindex, backlog)| {
+            next.get(ifindex)
+                .is_some_and(|next| Arc::ptr_eq(backlog, next))
         })
 }
 

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1064,9 +1064,16 @@ impl Coordinator {
         let current_queue_vtime_floors = self.cos.queue_vtime_floors.load();
         let num_workers = self.workers.last_planned_workers().max(1);
         let current_queue_leases = self.cos.queue_leases.load();
+        let max_binding_slot = self
+            .workers
+            .identities
+            .keys()
+            .next_back()
+            .copied()
+            .unwrap_or(0) as usize;
         let next_exact_backlogs = build_shared_cos_exact_backlogs_reusing_existing(
             &self.forwarding,
-            num_workers,
+            max_binding_slot,
             current_exact_backlogs.as_ref(),
         );
         let next_queue_leases = build_shared_cos_queue_leases_reusing_existing(
@@ -1752,10 +1759,9 @@ fn build_shared_cos_root_leases_reusing_existing(
 
 fn build_shared_cos_exact_backlogs_reusing_existing(
     forwarding: &ForwardingState,
-    num_workers: usize,
+    max_binding_slot: usize,
     existing: &BTreeMap<i32, Arc<SharedCoSExactBacklog>>,
 ) -> BTreeMap<i32, Arc<SharedCoSExactBacklog>> {
-    let max_worker_id = num_workers.saturating_sub(1);
     let mut out = BTreeMap::new();
     for (&ifindex, iface) in &forwarding.cos.interfaces {
         if !iface.queues.iter().any(|queue| queue.exact) {
@@ -1763,12 +1769,15 @@ fn build_shared_cos_exact_backlogs_reusing_existing(
         }
         if let Some(backlog) = existing
             .get(&ifindex)
-            .filter(|backlog| backlog.matches_config(max_worker_id))
+            .filter(|backlog| backlog.matches_config(max_binding_slot))
         {
             out.insert(ifindex, backlog.clone());
             continue;
         }
-        out.insert(ifindex, Arc::new(SharedCoSExactBacklog::new(max_worker_id)));
+        out.insert(
+            ifindex,
+            Arc::new(SharedCoSExactBacklog::new(max_binding_slot)),
+        );
     }
     out
 }

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -23,7 +23,7 @@ where every recent fairness mechanism kill happened (#1236, #1237,
 | `queue_ops/` | CoS queue primitives: accessors, enqueue/dequeue, MQFQ ordering bookkeeping, V-min slot lifecycle. Per-byte hot-path fns carry `#[inline]` to preserve cross-module inlining. |
 | `queue_service/` | CoS dispatch / drain / submit subsystem. Hot-path call chain: `drain_shaped_tx → select_cos_*_batch → service_exact_*_queue_direct → drain_exact_*_to_scratch → submit_cos_batch → settle_exact_*`. |
 | `token_bucket.rs` | Token-bucket lease / refill plumbing for TX pacing. Owns `COS_MIN_BURST_BYTES` (64 × MTU) — the universal floor for both root and per-queue burst caps. |
-| `tx_completion.rs` | TX-completion + interface timer wheel. Owns the wheel advance / cascade / wake-due slot management and the apply paths (`apply_direct_exact_send_result`, `apply_cos_send_result`, `apply_cos_prepared_result`). |
+| `tx_completion.rs` | TX-completion + interface timer wheel. Owns the wheel advance / cascade / wake-due slot management, the apply paths (`apply_direct_exact_send_result`, `apply_cos_send_result`, `apply_cos_prepared_result`), and the queue-scoped `DrainShape` phase counters (`guarantee`, `surplus`, `nonexact_while_exact_backlogged`). |
 
 `queue_ops/` and `queue_service/` are sub-directories; see their own
 mod.rs for further file-level breakdown.

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -14,21 +14,23 @@ pub(super) use admission::{
 };
 pub(super) use builders::ensure_cos_interface_runtime;
 pub(super) use cross_binding::{
-    redirect_prepared_cos_request_to_owner, redirect_prepared_cos_request_to_owner_binding,
-    resolve_local_routing_decision, LocalRoutingDecision, Step1Action,
+    LocalRoutingDecision, Step1Action, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding, resolve_local_routing_decision,
 };
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 pub(super) use queue_ops::{
-    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all,
-    cos_queue_front, cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_len,
-    cos_queue_pop_front, cos_queue_pop_front_no_snapshot, cos_queue_pop_front_with_cap,
-    cos_queue_push_back, cos_queue_push_front, cos_queue_restore_front,
-    cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, publish_committed_queue_vtime,
+    cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all, cos_queue_front,
+    cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_len, cos_queue_pop_front,
+    cos_queue_pop_front_no_snapshot, cos_queue_pop_front_with_cap, cos_queue_push_back,
+    cos_queue_push_front, cos_queue_restore_front, cos_queue_v_min_consume_suspension,
+    cos_queue_v_min_continue, publish_committed_queue_vtime,
 };
 pub(super) use queue_service::drain_shaped_tx;
 pub(super) use token_bucket::{
-    cos_refill_ns_until, maybe_top_up_cos_queue_lease, CoSQueueLeaseAcquireTelemetry,
-    refill_cos_tokens, release_all_cos_queue_leases, release_all_cos_root_leases,
-    COS_MIN_BURST_BYTES,
+    COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_refill_ns_until,
+    maybe_top_up_cos_queue_lease, refill_cos_tokens, release_all_cos_queue_leases,
+    release_all_cos_root_leases,
 };
-pub(super) use tx_completion::mark_cos_queue_runnable;
+pub(super) use tx_completion::{
+    clear_all_cos_exact_backlogs_for_binding, mark_cos_queue_runnable, publish_cos_exact_backlog,
+};

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -356,6 +356,50 @@ fn root_has_backlogged_exact_queue(root: &CoSInterfaceRuntime) -> bool {
 }
 
 #[inline]
+fn exact_backlog_bytes(root: &CoSInterfaceRuntime) -> u64 {
+    root.queues
+        .iter()
+        .filter(|queue| queue.config.exact)
+        .fold(0u64, |acc, queue| {
+            acc.saturating_add(queue.hot.queued_bytes)
+        })
+}
+
+#[inline]
+pub(in crate::afxdp) fn publish_cos_exact_backlog(binding: &BindingWorker, root_ifindex: i32) {
+    let Some(shared_exact_backlog) = binding
+        .cos
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref())
+    else {
+        return;
+    };
+    let Some(root) = binding.cos.cos_interfaces.get(&root_ifindex) else {
+        shared_exact_backlog.publish(binding.worker_id, 0);
+        return;
+    };
+    shared_exact_backlog.publish(binding.worker_id, exact_backlog_bytes(root));
+}
+
+#[inline]
+pub(in crate::afxdp) fn clear_all_cos_exact_backlogs_for_binding(binding: &BindingWorker) {
+    for iface_fast in binding.cos.cos_fast_interfaces.values() {
+        if let Some(shared_exact_backlog) = iface_fast.shared_exact_backlog.as_ref() {
+            shared_exact_backlog.publish(binding.worker_id, 0);
+        }
+    }
+}
+
+#[inline]
+fn interface_has_backlogged_exact_queue(
+    root: &CoSInterfaceRuntime,
+    peer_exact_backlogged: bool,
+) -> bool {
+    root_has_backlogged_exact_queue(root) || peer_exact_backlogged
+}
+
+#[inline]
 fn account_queue_drain_sent_bytes(
     queue: &mut CoSQueueRuntime,
     phase: CoSServicePhase,
@@ -488,6 +532,7 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
         root.nonempty_queues = new_nonempty;
         root.runnable_queues = new_runnable;
     }
+    publish_cos_exact_backlog(binding, root_ifindex);
     if old_nonempty == 0 && new_nonempty > 0 {
         binding.cos.cos_nonempty_interfaces = binding.cos.cos_nonempty_interfaces.saturating_add(1);
     } else if old_nonempty > 0 && new_nonempty == 0 {
@@ -518,6 +563,13 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     retry: VecDeque<TxRequest>,
 ) {
     let mut exact_queue_idx = None;
+    let worker_id = binding.worker_id;
+    let peer_exact_backlogged = binding
+        .cos
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref())
+        .is_some_and(|backlog| backlog.has_peer_backlog(worker_id));
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
@@ -527,7 +579,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
                 .queues
                 .get(queue_idx)
                 .is_some_and(|queue| !queue.config.exact)
-            && root_has_backlogged_exact_queue(root);
+            && interface_has_backlogged_exact_queue(root, peer_exact_backlogged);
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.config.exact.then_some(queue_idx);
             let retry_bytes = restore_cos_local_items_inner(queue, retry);
@@ -588,6 +640,13 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     retry: VecDeque<PreparedTxRequest>,
 ) {
     let mut exact_queue_idx = None;
+    let worker_id = binding.worker_id;
+    let peer_exact_backlogged = binding
+        .cos
+        .cos_fast_interfaces
+        .get(&root_ifindex)
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref())
+        .is_some_and(|backlog| backlog.has_peer_backlog(worker_id));
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
@@ -597,7 +656,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
                 .queues
                 .get(queue_idx)
                 .is_some_and(|queue| !queue.config.exact)
-            && root_has_backlogged_exact_queue(root);
+            && interface_has_backlogged_exact_queue(root, peer_exact_backlogged);
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.config.exact.then_some(queue_idx);
             let retry_bytes = restore_cos_prepared_items_inner(queue, retry);

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -349,6 +349,46 @@ pub(in crate::afxdp) fn maybe_consume_exact_queue_lease(
 }
 
 #[inline]
+fn root_has_backlogged_exact_queue(root: &CoSInterfaceRuntime) -> bool {
+    root.queues
+        .iter()
+        .any(|queue| queue.config.exact && !cos_queue_is_empty(queue))
+}
+
+#[inline]
+fn account_queue_drain_sent_bytes(
+    queue: &mut CoSQueueRuntime,
+    phase: CoSServicePhase,
+    sent_bytes: u64,
+    exact_backlogged: bool,
+) {
+    if sent_bytes == 0 {
+        return;
+    }
+    let profile = &queue.telemetry.owner_profile;
+    profile
+        .drain_sent_bytes
+        .fetch_add(sent_bytes, Ordering::Relaxed);
+    match phase {
+        CoSServicePhase::Guarantee => {
+            profile
+                .drain_guarantee_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
+        }
+        CoSServicePhase::Surplus => {
+            profile
+                .drain_surplus_sent_bytes
+                .fetch_add(sent_bytes, Ordering::Relaxed);
+        }
+    }
+    if exact_backlogged && !queue.config.exact {
+        profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .fetch_add(sent_bytes, Ordering::Relaxed);
+    }
+}
+
+#[inline]
 pub(in crate::afxdp) fn apply_direct_exact_queue_accounting(
     root: &mut CoSInterfaceRuntime,
     queue_idx: usize,
@@ -362,11 +402,7 @@ pub(in crate::afxdp) fn apply_direct_exact_queue_accounting(
         // scrape window to get an observed per-queue drain rate and
         // compare against `queue.transmit_rate_bytes()` to detect a
         // cap bypass.
-        queue
-            .telemetry
-            .owner_profile
-            .drain_sent_bytes
-            .fetch_add(sent_bytes, Ordering::Relaxed);
+        account_queue_drain_sent_bytes(queue, CoSServicePhase::Guarantee, sent_bytes, false);
     }
     root.tokens = root.tokens.saturating_sub(sent_bytes);
 }
@@ -486,6 +522,12 @@ pub(in crate::afxdp) fn apply_cos_send_result(
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
+        let exact_backlogged = sent_bytes > 0
+            && root
+                .queues
+                .get(queue_idx)
+                .is_some_and(|queue| !queue.config.exact)
+            && root_has_backlogged_exact_queue(root);
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.config.exact.then_some(queue_idx);
             let retry_bytes = restore_cos_local_items_inner(queue, retry);
@@ -508,11 +550,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
             // or surplus accounting is debited. Paired with the
             // apply_direct_exact_send_result write so the sum across
             // all sites equals the bytes the CoS scheduler accounted.
-            queue
-                .telemetry
-                .owner_profile
-                .drain_sent_bytes
-                .fetch_add(sent_bytes, Ordering::Relaxed);
+            account_queue_drain_sent_bytes(queue, phase, sent_bytes, exact_backlogged);
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }
@@ -554,6 +592,12 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
         };
+        let exact_backlogged = sent_bytes > 0
+            && root
+                .queues
+                .get(queue_idx)
+                .is_some_and(|queue| !queue.config.exact)
+            && root_has_backlogged_exact_queue(root);
         if let Some(queue) = root.queues.get_mut(queue_idx) {
             exact_queue_idx = queue.config.exact.then_some(queue_idx);
             let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
@@ -580,11 +624,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
             // Gbps, leaving ~563 Mbps unaccounted — all of it
             // flowing through this path. Same Relaxed semantics as
             // the other three apply_* sites.
-            queue
-                .telemetry
-                .owner_profile
-                .drain_sent_bytes
-                .fetch_add(sent_bytes, Ordering::Relaxed);
+            account_queue_drain_sent_bytes(queue, phase, sent_bytes, exact_backlogged);
         }
         root.tokens = root.tokens.saturating_sub(sent_bytes);
     }

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -376,17 +376,17 @@ pub(in crate::afxdp) fn publish_cos_exact_backlog(binding: &BindingWorker, root_
         return;
     };
     let Some(root) = binding.cos.cos_interfaces.get(&root_ifindex) else {
-        shared_exact_backlog.publish(binding.worker_id, 0);
+        shared_exact_backlog.publish(binding.slot, 0);
         return;
     };
-    shared_exact_backlog.publish(binding.worker_id, exact_backlog_bytes(root));
+    shared_exact_backlog.publish(binding.slot, exact_backlog_bytes(root));
 }
 
 #[inline]
 pub(in crate::afxdp) fn clear_all_cos_exact_backlogs_for_binding(binding: &BindingWorker) {
     for iface_fast in binding.cos.cos_fast_interfaces.values() {
         if let Some(shared_exact_backlog) = iface_fast.shared_exact_backlog.as_ref() {
-            shared_exact_backlog.publish(binding.worker_id, 0);
+            shared_exact_backlog.publish(binding.slot, 0);
         }
     }
 }
@@ -563,13 +563,13 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     retry: VecDeque<TxRequest>,
 ) {
     let mut exact_queue_idx = None;
-    let worker_id = binding.worker_id;
+    let binding_slot = binding.slot;
     let peer_exact_backlogged = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref())
-        .is_some_and(|backlog| backlog.has_peer_backlog(worker_id));
+        .is_some_and(|backlog| backlog.has_peer_backlog(binding_slot));
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;
@@ -640,13 +640,13 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     retry: VecDeque<PreparedTxRequest>,
 ) {
     let mut exact_queue_idx = None;
-    let worker_id = binding.worker_id;
+    let binding_slot = binding.slot;
     let peer_exact_backlogged = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
         .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref())
-        .is_some_and(|backlog| backlog.has_peer_backlog(worker_id));
+        .is_some_and(|backlog| backlog.has_peer_backlog(binding_slot));
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return;

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -154,6 +154,57 @@ fn account_queue_drain_sent_bytes_splits_phase_and_exact_backlog_steal() {
 }
 
 #[test]
+fn apply_cos_send_result_counts_nonexact_bytes_when_exact_queue_backlogged() {
+    let root = test_mixed_class_root_with_primed_queues();
+    let fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    apply_cos_send_result(
+        &mut binding,
+        42,
+        1,
+        CoSServicePhase::Surplus,
+        1500,
+        1500,
+        std::collections::VecDeque::new(),
+    );
+
+    let root = binding.cos.cos_interfaces.get(&42).expect("cos root");
+    let nonexact = &root.queues[1];
+    assert!(!nonexact.config.exact);
+    assert_eq!(
+        nonexact
+            .telemetry
+            .owner_profile
+            .drain_surplus_sent_bytes
+            .load(Ordering::Relaxed),
+        1500
+    );
+    assert_eq!(
+        nonexact
+            .telemetry
+            .owner_profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .load(Ordering::Relaxed),
+        1500,
+        "apply_cos_send_result must derive exact_backlogged from the root, not from caller input"
+    );
+}
+
+#[test]
 fn normalize_cos_queue_state_repairs_nonempty_unparked_queue_to_runnable() {
     let mut queue = CoSQueueRuntime {
         config: crate::afxdp::types::CoSQueueConfigState {

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -312,6 +312,82 @@ fn same_worker_second_binding_publish_does_not_erase_first_binding_backlog() {
 }
 
 #[test]
+fn apply_cos_send_result_counts_same_worker_sibling_exact_backlog() {
+    let mut exact_root = test_mixed_class_root_with_primed_queues();
+    for queue in &mut exact_root.queues {
+        if queue.config.exact {
+            queue.hot.queued_bytes = 12_000;
+        } else {
+            queue.hot.items.clear();
+            queue.hot.queued_bytes = 0;
+            queue.hot.runnable = false;
+        }
+    }
+    let mut nonexact_root = test_mixed_class_root_with_primed_queues();
+    for queue in &mut nonexact_root.queues {
+        if queue.config.exact {
+            queue.hot.items.clear();
+            queue.hot.queued_bytes = 0;
+            queue.hot.runnable = false;
+        }
+    }
+    let shared_exact_backlog = Arc::new(SharedCoSExactBacklog::new(1));
+    let mut fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    fast_interfaces
+        .get_mut(&42)
+        .expect("test fast path")
+        .shared_exact_backlog = Some(shared_exact_backlog);
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let binding_a = BindingWorker::new_for_cos_drain_test(0, 0, 42, exact_root, fast_path.clone());
+    let mut binding_b =
+        BindingWorker::new_for_cos_drain_test(1, 0, 42, nonexact_root, fast_path);
+
+    publish_cos_exact_backlog(&binding_a, 42);
+    publish_cos_exact_backlog(&binding_b, 42);
+
+    {
+        let root_b = binding_b.cos.cos_interfaces.get(&42).expect("cos root");
+        assert!(
+            !root_has_backlogged_exact_queue(root_b),
+            "same-worker non-exact binding must prove a local-only scan would miss the sibling backlog"
+        );
+    }
+
+    apply_cos_send_result(
+        &mut binding_b,
+        42,
+        1,
+        CoSServicePhase::Surplus,
+        1500,
+        1500,
+        std::collections::VecDeque::new(),
+    );
+
+    let root_b = binding_b.cos.cos_interfaces.get(&42).expect("cos root");
+    assert_eq!(
+        root_b.queues[1]
+            .telemetry
+            .owner_profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .load(Ordering::Relaxed),
+        1500,
+        "same-worker sibling exact backlog must drive the end-to-end steal telemetry counter"
+    );
+}
+
+#[test]
 fn normalize_cos_queue_state_repairs_nonempty_unparked_queue_to_runnable() {
     let mut queue = CoSQueueRuntime {
         config: crate::afxdp::types::CoSQueueConfigState {

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -263,6 +263,55 @@ fn apply_cos_send_result_counts_nonexact_bytes_when_peer_exact_queue_backlogged(
 }
 
 #[test]
+fn same_worker_second_binding_publish_does_not_erase_first_binding_backlog() {
+    let mut exact_root = test_mixed_class_root_with_primed_queues();
+    for queue in &mut exact_root.queues {
+        if queue.config.exact {
+            queue.hot.queued_bytes = 12_000;
+        } else {
+            queue.hot.items.clear();
+            queue.hot.queued_bytes = 0;
+            queue.hot.runnable = false;
+        }
+    }
+    let mut idle_root = test_mixed_class_root_with_primed_queues();
+    for queue in &mut idle_root.queues {
+        queue.hot.items.clear();
+        queue.hot.queued_bytes = 0;
+        queue.hot.runnable = false;
+    }
+    let shared_exact_backlog = Arc::new(SharedCoSExactBacklog::new(1));
+    let mut fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    fast_interfaces
+        .get_mut(&42)
+        .expect("test fast path")
+        .shared_exact_backlog = Some(shared_exact_backlog.clone());
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let binding_a = BindingWorker::new_for_cos_drain_test(0, 0, 42, exact_root, fast_path.clone());
+    let binding_b = BindingWorker::new_for_cos_drain_test(1, 0, 42, idle_root, fast_path);
+
+    publish_cos_exact_backlog(&binding_a, 42);
+    publish_cos_exact_backlog(&binding_b, 42);
+
+    assert!(
+        shared_exact_backlog.has_peer_backlog(1),
+        "same-worker idle binding must not overwrite a sibling binding's nonzero exact backlog",
+    );
+}
+
+#[test]
 fn normalize_cos_queue_state_repairs_nonempty_unparked_queue_to_runnable() {
     let mut queue = CoSQueueRuntime {
         config: crate::afxdp::types::CoSQueueConfigState {

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -12,7 +12,7 @@ use crate::afxdp::cos::token_bucket::COS_MIN_BURST_BYTES;
 use crate::afxdp::tx::test_support::*;
 use crate::afxdp::types::{
     COS_FLOW_FAIR_BUCKETS, CoSQueueDropCounters, CoSQueueOwnerProfile, FlowRrRing,
-    SharedCoSQueueLease,
+    SharedCoSExactBacklog, SharedCoSQueueLease,
 };
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -201,6 +201,64 @@ fn apply_cos_send_result_counts_nonexact_bytes_when_exact_queue_backlogged() {
             .load(Ordering::Relaxed),
         1500,
         "apply_cos_send_result must derive exact_backlogged from the root, not from caller input"
+    );
+}
+
+#[test]
+fn apply_cos_send_result_counts_nonexact_bytes_when_peer_exact_queue_backlogged() {
+    let mut root = test_mixed_class_root_with_primed_queues();
+    for queue in &mut root.queues {
+        if queue.config.exact {
+            queue.hot.items.clear();
+            queue.hot.queued_bytes = 0;
+            queue.hot.runnable = false;
+        }
+    }
+    let mut fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        0,
+        vec![
+            (0, test_queue_fast_path(false, 0, None, None)),
+            (1, test_queue_fast_path(false, 0, None, None)),
+            (2, test_queue_fast_path(false, 0, None, None)),
+            (3, test_queue_fast_path(false, 0, None, None)),
+        ],
+        None,
+        None,
+    );
+    let shared_exact_backlog = Arc::new(SharedCoSExactBacklog::new(1));
+    shared_exact_backlog.publish(1, 12_000);
+    fast_interfaces
+        .get_mut(&42)
+        .expect("test fast path")
+        .shared_exact_backlog = Some(shared_exact_backlog);
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    apply_cos_send_result(
+        &mut binding,
+        42,
+        1,
+        CoSServicePhase::Surplus,
+        1500,
+        1500,
+        std::collections::VecDeque::new(),
+    );
+
+    let root = binding.cos.cos_interfaces.get(&42).expect("cos root");
+    assert!(
+        !root_has_backlogged_exact_queue(root),
+        "fixture must prove the local-root-only predicate would miss this case"
+    );
+    assert_eq!(
+        root.queues[1]
+            .telemetry
+            .owner_profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .load(Ordering::Relaxed),
+        1500,
+        "non-exact drain must consult interface-global peer exact backlog"
     );
 }
 

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -15,6 +15,7 @@ use crate::afxdp::types::{
     SharedCoSQueueLease,
 };
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 // #915 Codex code-review MEDIUM: direct unit tests for the
 // phase-gated `shared_queue_lease` consumption helper. Both
@@ -92,6 +93,64 @@ fn maybe_consume_exact_queue_lease_no_lease_no_op() {
     maybe_consume_exact_queue_lease(None, CoSServicePhase::Surplus, 1500);
     maybe_consume_exact_queue_lease(None, CoSServicePhase::Guarantee, 1500);
     // No assertion needed — the function must not panic on None.
+}
+
+#[test]
+fn account_queue_drain_sent_bytes_splits_phase_and_exact_backlog_steal() {
+    let mut root = test_mixed_class_root_with_primed_queues();
+    assert!(
+        root_has_backlogged_exact_queue(&root),
+        "mixed fixture must start with backlogged exact queues"
+    );
+
+    let nonexact = &mut root.queues[1];
+    assert!(!nonexact.config.exact);
+    account_queue_drain_sent_bytes(nonexact, CoSServicePhase::Surplus, 2048, true);
+    assert_eq!(
+        nonexact
+            .telemetry
+            .owner_profile
+            .drain_sent_bytes
+            .load(Ordering::Relaxed),
+        2048
+    );
+    assert_eq!(
+        nonexact
+            .telemetry
+            .owner_profile
+            .drain_surplus_sent_bytes
+            .load(Ordering::Relaxed),
+        2048
+    );
+    assert_eq!(
+        nonexact
+            .telemetry
+            .owner_profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .load(Ordering::Relaxed),
+        2048
+    );
+
+    let exact = &mut root.queues[0];
+    assert!(exact.config.exact);
+    account_queue_drain_sent_bytes(exact, CoSServicePhase::Guarantee, 1024, true);
+    assert_eq!(
+        exact
+            .telemetry
+            .owner_profile
+            .drain_guarantee_sent_bytes
+            .load(Ordering::Relaxed),
+        1024
+    );
+    assert_eq!(
+        exact
+            .telemetry
+            .owner_profile
+            .drain_nonexact_sent_bytes_while_exact_backlogged
+            .load(Ordering::Relaxed),
+        0,
+        "exact queue service must not be counted as non-exact steal"
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -513,11 +513,7 @@ pub(super) fn enqueue_prepared_into_cos(
         shared_recycles.as_deref_mut(),
     ) {
         Ok(()) => {
-            recycle_prepared_immediately_with_shared(
-                binding,
-                &req,
-                shared_recycles.as_deref_mut(),
-            );
+            recycle_prepared_immediately_with_shared(binding, &req, shared_recycles.as_deref_mut());
             Ok(())
         }
         Err(CoSPendingTxItem::Local(_)) => Err(req),
@@ -723,6 +719,7 @@ fn enqueue_cos_item(
     mut shared_recycles: Option<&mut Vec<(u32, u64)>>,
 ) -> Result<(), CoSPendingTxItem> {
     let mut root_became_nonempty = false;
+    let mut accepted_exact = false;
     let (accepted, queue_id, recycle) = {
         // Split-borrow: `umem` sits alongside `cos_interfaces` on
         // `BindingWorker`, so we can take a shared borrow on the umem
@@ -821,6 +818,7 @@ fn enqueue_cos_item(
             let queue_was_empty = cos_queue_is_empty(queue);
             queue.hot.queued_bytes = queue.hot.queued_bytes.saturating_add(item_len);
             cos_queue_push_back(queue, item);
+            accepted_exact = queue.config.exact;
             if queue_was_empty {
                 root.nonempty_queues = root.nonempty_queues.saturating_add(1);
                 root_became_nonempty = root_was_empty;
@@ -838,6 +836,9 @@ fn enqueue_cos_item(
         binding.cos.cos_nonempty_interfaces = binding.cos.cos_nonempty_interfaces.saturating_add(1);
     }
     if accepted {
+        if accepted_exact {
+            publish_cos_exact_backlog(binding, egress_ifindex);
+        }
         return Ok(());
     }
     if let Some((recycle, offset)) = recycle {

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use crate::afxdp::tx::test_support::*;
+use crate::afxdp::types::SharedCoSExactBacklog;
 use crate::{
     ClassOfServiceSnapshot, CoSDSCPClassifierEntrySnapshot, CoSDSCPClassifierSnapshot,
     CoSForwardingClassSnapshot, CoSIEEE8021ClassifierEntrySnapshot, CoSIEEE8021ClassifierSnapshot,
@@ -32,6 +33,57 @@ fn resolve_cos_queue_idx_rejects_explicit_queue_miss() {
 
     assert_eq!(resolve_cos_queue_idx(&root, Some(4)), None);
     assert_eq!(resolve_cos_queue_idx(&root, None), Some(0));
+}
+
+#[test]
+fn enqueue_exact_queue_publishes_shared_backlog_slot() {
+    let root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 125_000_000,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            surplus_weight: 1,
+            buffer_bytes: 4_000_000,
+            dscp_rewrite: None,
+        }],
+    );
+    let mut fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        4,
+        vec![(4, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let shared_exact_backlog = Arc::new(SharedCoSExactBacklog::new(1));
+    fast_interfaces
+        .get_mut(&42)
+        .expect("test fast path")
+        .shared_exact_backlog = Some(shared_exact_backlog.clone());
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    assert!(
+        enqueue_cos_item(
+            &mut binding,
+            42,
+            Some(4),
+            512,
+            test_flow_cos_item(5201, 512),
+            None,
+        )
+        .is_ok()
+    );
+
+    assert!(
+        shared_exact_backlog.has_peer_backlog(1),
+        "exact enqueue must publish immediately so peer workers do not undercount exact backlog",
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch_tests.rs
@@ -67,6 +67,7 @@ fn test_cos_fast_interfaces(
             queue_index_by_id,
             tx_owner_live: None,
             shared_root_lease: None,
+            shared_exact_backlog: None,
             queue_fast_path,
         },
     );

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -49,6 +49,6 @@ use super::cos::{
     cos_flow_bucket_index, cos_item_flow_key, cos_queue_drain_all, cos_queue_flow_share_limit,
     cos_queue_is_empty, cos_queue_push_back, cos_queue_restore_front, drain_shaped_tx,
     ensure_cos_interface_runtime, mark_cos_queue_runnable, publish_committed_queue_vtime,
-    redirect_prepared_cos_request_to_owner, redirect_prepared_cos_request_to_owner_binding,
-    resolve_local_routing_decision,
+    publish_cos_exact_backlog, redirect_prepared_cos_request_to_owner,
+    redirect_prepared_cos_request_to_owner_binding, resolve_local_routing_decision,
 };

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -71,6 +71,7 @@ pub(in crate::afxdp) fn test_cos_fast_interfaces(
             queue_index_by_id,
             tx_owner_live,
             shared_root_lease,
+            shared_exact_backlog: None,
             queue_fast_path,
         },
     );

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -876,6 +876,23 @@ pub(in crate::afxdp) struct CoSQueueOwnerProfile {
     /// (apply_direct_exact_send_result for exact-owner-local,
     /// apply_cos_send_result for the non-exact / shared-exact paths).
     pub(in crate::afxdp) drain_sent_bytes: AtomicU64,
+    /// Bytes sent while the queue was serviced in Guarantee phase.
+    /// This is a phase split of `drain_sent_bytes`, not a distinct
+    /// packet path. Exact-owner-local sends are always Guarantee
+    /// phase; shared/non-exact paths write this from the
+    /// `CoSServicePhase` observed at TX completion.
+    pub(in crate::afxdp) drain_guarantee_sent_bytes: AtomicU64,
+    /// Bytes sent while the queue was serviced in Surplus phase.
+    /// A non-zero value on a best-effort / uncapped queue proves it
+    /// used residual root service; a high `drain_sent_bytes` with a
+    /// zero surplus split means the queue is consuming guarantee
+    /// service instead.
+    pub(in crate::afxdp) drain_surplus_sent_bytes: AtomicU64,
+    /// Non-exact bytes sent while at least one exact queue on the same
+    /// CoS interface still had backlog. This is the direct diagnostic
+    /// for best-effort or uncapped traffic stealing service from exact
+    /// queues; it is written only on non-exact queue apply paths.
+    pub(in crate::afxdp) drain_nonexact_sent_bytes_while_exact_backlogged: AtomicU64,
     /// #760 instrumentation. Count of drain iterations where the
     /// root token gate fired (root.tokens < head_len) and the queue
     /// got parked waiting for the interface shaper to refill.
@@ -894,6 +911,9 @@ impl CoSQueueOwnerProfile {
             drain_latency_hist: std::array::from_fn(|_| AtomicU64::new(0)),
             drain_invocations: AtomicU64::new(0),
             drain_sent_bytes: AtomicU64::new(0),
+            drain_guarantee_sent_bytes: AtomicU64::new(0),
+            drain_surplus_sent_bytes: AtomicU64::new(0),
+            drain_nonexact_sent_bytes_while_exact_backlogged: AtomicU64::new(0),
             drain_park_root_tokens: AtomicU64::new(0),
             drain_park_queue_tokens: AtomicU64::new(0),
         }

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -294,6 +294,7 @@ pub(in crate::afxdp) struct WorkerCoSInterfaceFastPath {
     pub(in crate::afxdp) queue_index_by_id: [u16; 256],
     pub(in crate::afxdp) tx_owner_live: Option<Arc<BindingLiveState>>,
     pub(in crate::afxdp) shared_root_lease: Option<Arc<SharedCoSRootLease>>,
+    pub(in crate::afxdp) shared_exact_backlog: Option<Arc<SharedCoSExactBacklog>>,
     pub(in crate::afxdp) queue_fast_path: Vec<WorkerCoSQueueFastPath>,
 }
 

--- a/userspace-dp/src/afxdp/types/mod.rs
+++ b/userspace-dp/src/afxdp/types/mod.rs
@@ -6,8 +6,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 // continues to find them as `super::types::SharedCoS*`.
 mod shared_cos_lease;
 pub(super) use shared_cos_lease::{
-    NOT_PARTICIPATING, PaddedVtimeSlot, SharedCoSQueueLease, SharedCoSQueueVtimeFloor,
-    SharedCoSRootLease, V8RateMode,
+    NOT_PARTICIPATING, PaddedVtimeSlot, SharedCoSExactBacklog, SharedCoSQueueLease,
+    SharedCoSQueueVtimeFloor, SharedCoSRootLease, V8RateMode,
 };
 
 // Issue 68.1: CoS shaper / queue / flow-fair / runtime types extracted
@@ -218,7 +218,6 @@ impl From<ForwardPacketMeta> for UserspaceDpMeta {
     }
 }
 
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum PacketDisposition {
     Valid,
@@ -227,7 +226,6 @@ pub(super) enum PacketDisposition {
     FibGenerationMismatch,
     UnsupportedPacket,
 }
-
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct SessionFlow {
@@ -251,7 +249,6 @@ impl SessionFlow {
         reverse_session_key(&self.forward_key, nat)
     }
 }
-
 
 #[cfg(test)]
 mod flow_rr_ring_tests {
@@ -406,4 +403,3 @@ mod flow_rr_ring_tests {
         );
     }
 }
-

--- a/userspace-dp/src/afxdp/types/shared_cos_lease.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease.rs
@@ -20,6 +20,52 @@ pub(in crate::afxdp) struct SharedCoSQueueLease {
     v8: Option<V8State>,
 }
 
+#[repr(align(64))]
+struct PaddedBacklogSlot(AtomicU64);
+
+/// Interface-global exact-backlog visibility for diagnostics that must not
+/// be limited to the current worker's local CoS root. Each worker owns one
+/// slot and publishes its local exact queued-byte total from
+/// exact enqueue/drain/reset sites; readers test peer slots when deciding
+/// whether non-exact service is stealing from any exact queue on the same
+/// shaped interface. This is telemetry, not a synchronization primitive:
+/// relaxed atomics are sufficient and avoid imposing ordering on the packet
+/// data path.
+pub(in crate::afxdp) struct SharedCoSExactBacklog {
+    worker_bytes: Box<[PaddedBacklogSlot]>,
+}
+
+impl SharedCoSExactBacklog {
+    pub(in crate::afxdp) fn new(max_worker_id: usize) -> Self {
+        Self {
+            worker_bytes: (0..=max_worker_id)
+                .map(|_| PaddedBacklogSlot(AtomicU64::new(0)))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }
+    }
+
+    pub(in crate::afxdp) fn matches_config(&self, max_worker_id: usize) -> bool {
+        self.worker_bytes.len() == max_worker_id.saturating_add(1)
+    }
+
+    #[inline]
+    pub(in crate::afxdp) fn publish(&self, worker_id: u32, bytes: u64) {
+        if let Some(slot) = self.worker_bytes.get(worker_id as usize) {
+            slot.0.store(bytes, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub(in crate::afxdp) fn has_peer_backlog(&self, worker_id: u32) -> bool {
+        self.worker_bytes
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != worker_id as usize)
+            .any(|(_, slot)| slot.0.load(Ordering::Relaxed) > 0)
+    }
+}
+
 // === #1229 Phase 6 v8: per-worker fair lease ===
 // Plan: docs/pr/1229-cross-worker-vtime/phase6-fair-lease.md (commit
 // c159dbd5+, PLAN-READY at task-mowjwl1o-ob7bc5).

--- a/userspace-dp/src/afxdp/types/shared_cos_lease.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease.rs
@@ -24,7 +24,7 @@ pub(in crate::afxdp) struct SharedCoSQueueLease {
 struct PaddedBacklogSlot(AtomicU64);
 
 /// Interface-global exact-backlog visibility for diagnostics that must not
-/// be limited to the current worker's local CoS root. Each worker owns one
+/// be limited to the current binding's local CoS root. Each binding owns one
 /// slot and publishes its local exact queued-byte total from
 /// exact enqueue/drain/reset sites; readers test peer slots when deciding
 /// whether non-exact service is stealing from any exact queue on the same
@@ -36,32 +36,32 @@ pub(in crate::afxdp) struct SharedCoSExactBacklog {
 }
 
 impl SharedCoSExactBacklog {
-    pub(in crate::afxdp) fn new(max_worker_id: usize) -> Self {
+    pub(in crate::afxdp) fn new(max_binding_slot: usize) -> Self {
         Self {
-            worker_bytes: (0..=max_worker_id)
+            worker_bytes: (0..=max_binding_slot)
                 .map(|_| PaddedBacklogSlot(AtomicU64::new(0)))
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         }
     }
 
-    pub(in crate::afxdp) fn matches_config(&self, max_worker_id: usize) -> bool {
-        self.worker_bytes.len() == max_worker_id.saturating_add(1)
+    pub(in crate::afxdp) fn matches_config(&self, max_binding_slot: usize) -> bool {
+        self.worker_bytes.len() == max_binding_slot.saturating_add(1)
     }
 
     #[inline]
-    pub(in crate::afxdp) fn publish(&self, worker_id: u32, bytes: u64) {
-        if let Some(slot) = self.worker_bytes.get(worker_id as usize) {
+    pub(in crate::afxdp) fn publish(&self, binding_slot: u32, bytes: u64) {
+        if let Some(slot) = self.worker_bytes.get(binding_slot as usize) {
             slot.0.store(bytes, Ordering::Relaxed);
         }
     }
 
     #[inline]
-    pub(in crate::afxdp) fn has_peer_backlog(&self, worker_id: u32) -> bool {
+    pub(in crate::afxdp) fn has_peer_backlog(&self, binding_slot: u32) -> bool {
         self.worker_bytes
             .iter()
             .enumerate()
-            .filter(|(idx, _)| *idx != worker_id as usize)
+            .filter(|(idx, _)| *idx != binding_slot as usize)
             .any(|(_, slot)| slot.0.load(Ordering::Relaxed) > 0)
     }
 }

--- a/userspace-dp/src/afxdp/worker/cos.rs
+++ b/userspace-dp/src/afxdp/worker/cos.rs
@@ -117,6 +117,7 @@ pub(super) fn build_worker_cos_fast_interfaces(
     owner_worker_by_queue: &BTreeMap<(i32, u8), u32>,
     owner_live_by_queue: &BTreeMap<(i32, u8), Arc<BindingLiveState>>,
     shared_root_leases: &BTreeMap<i32, Arc<SharedCoSRootLease>>,
+    shared_exact_backlogs: &BTreeMap<i32, Arc<SharedCoSExactBacklog>>,
     shared_queue_leases: &BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>,
     shared_queue_vtime_floors: &BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>,
 ) -> FastMap<i32, WorkerCoSInterfaceFastPath> {
@@ -161,6 +162,7 @@ pub(super) fn build_worker_cos_fast_interfaces(
                 queue_index_by_id,
                 tx_owner_live: tx_owner_live_by_tx_ifindex.get(&tx_ifindex).cloned(),
                 shared_root_lease: shared_root_leases.get(&egress_ifindex).cloned(),
+                shared_exact_backlog: shared_exact_backlogs.get(&egress_ifindex).cloned(),
                 queue_fast_path,
             },
         );
@@ -316,6 +318,7 @@ pub(super) fn reset_binding_cos_runtime(
     // stale value in their V_min calculation, throttling them
     // unnecessarily until the first post-reset post-settle publish.
     vacate_all_shared_exact_slots_for_binding(binding);
+    clear_all_cos_exact_backlogs_for_binding(binding);
     binding.cos.cos_interfaces.clear();
     binding.cos.cos_interface_order.clear();
     binding.cos.cos_interface_rr = 0;
@@ -335,11 +338,7 @@ pub(super) fn reset_binding_cos_runtime(
             .fetch_add(dropped_total, Ordering::Relaxed);
     }
     for req in dropped_prepared {
-        recycle_prepared_immediately_with_shared(
-            binding,
-            &req,
-            shared_recycles.as_deref_mut(),
-        );
+        recycle_prepared_immediately_with_shared(binding, &req, shared_recycles.as_deref_mut());
     }
 }
 

--- a/userspace-dp/src/afxdp/worker/cos.rs
+++ b/userspace-dp/src/afxdp/worker/cos.rs
@@ -427,6 +427,15 @@ pub(crate) fn merge_cos_queue_owner_profile_sum(
     // always sum-of-single-non-zero, but saturating_add keeps us
     // safe if the ownership ever shifts mid-scrape.
     dst.drain_sent_bytes = dst.drain_sent_bytes.saturating_add(src.drain_sent_bytes);
+    dst.drain_guarantee_sent_bytes = dst
+        .drain_guarantee_sent_bytes
+        .saturating_add(src.drain_guarantee_sent_bytes);
+    dst.drain_surplus_sent_bytes = dst
+        .drain_surplus_sent_bytes
+        .saturating_add(src.drain_surplus_sent_bytes);
+    dst.drain_nonexact_sent_bytes_while_exact_backlogged = dst
+        .drain_nonexact_sent_bytes_while_exact_backlogged
+        .saturating_add(src.drain_nonexact_sent_bytes_while_exact_backlogged);
     dst.drain_park_root_tokens = dst
         .drain_park_root_tokens
         .saturating_add(src.drain_park_root_tokens);
@@ -722,12 +731,15 @@ where
                 // "bytes the scheduler actually shaped out"; pair it
                 // with `queue.transmit_rate_bytes` over a scrape
                 // window to detect a direct cap bypass on this row.
-                // drain_park_root_tokens / drain_park_queue_tokens
-                // both rising with drain_sent_bytes sustaining above
-                // configured rate would mean the gate fires but the
-                // refill/accounting is wrong; both near zero with
-                // drain_sent_bytes above rate means the gate never
-                // ran for this queue.
+                // The guarantee/surplus split and non-exact/exact-
+                // backlog counter diagnose whether root surplus or
+                // non-exact guarantee service is stealing service
+                // from exact queues. drain_park_root_tokens /
+                // drain_park_queue_tokens both rising with
+                // drain_sent_bytes sustaining above configured rate
+                // would mean the gate fires but refill/accounting is
+                // wrong; both near zero with drain_sent_bytes above
+                // rate means the gate never ran for this queue.
                 status.drain_sent_bytes = status.drain_sent_bytes.saturating_add(
                     queue
                         .telemetry
@@ -735,6 +747,30 @@ where
                         .drain_sent_bytes
                         .load(Ordering::Relaxed),
                 );
+                status.drain_guarantee_sent_bytes =
+                    status.drain_guarantee_sent_bytes.saturating_add(
+                        queue
+                            .telemetry
+                            .owner_profile
+                            .drain_guarantee_sent_bytes
+                            .load(Ordering::Relaxed),
+                    );
+                status.drain_surplus_sent_bytes = status.drain_surplus_sent_bytes.saturating_add(
+                    queue
+                        .telemetry
+                        .owner_profile
+                        .drain_surplus_sent_bytes
+                        .load(Ordering::Relaxed),
+                );
+                status.drain_nonexact_sent_bytes_while_exact_backlogged = status
+                    .drain_nonexact_sent_bytes_while_exact_backlogged
+                    .saturating_add(
+                        queue
+                            .telemetry
+                            .owner_profile
+                            .drain_nonexact_sent_bytes_while_exact_backlogged
+                            .load(Ordering::Relaxed),
+                    );
                 status.drain_park_root_tokens = status.drain_park_root_tokens.saturating_add(
                     queue
                         .telemetry

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -9,6 +9,7 @@ use crate::afxdp::tx::test_support::{
     test_cos_fast_interfaces, test_cos_runtime_with_queues, test_flow_cos_item,
     test_queue_fast_path,
 };
+use crate::afxdp::types::SharedCoSExactBacklog;
 use crate::test_zone_ids::*;
 
 // Rates used to force owner-local vs shared-exact classification in
@@ -79,6 +80,53 @@ fn reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter() {
         "reset-time CoS queue drains must mirror into the lifetime-matched CoS subset counter",
     );
     assert!(binding.cos.cos_interfaces.is_empty());
+}
+
+#[test]
+fn reset_binding_cos_runtime_clears_shared_exact_backlog_slot() {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 125_000_000,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            surplus_weight: 1,
+            buffer_bytes: 4_000_000,
+            dscp_rewrite: None,
+        }],
+    );
+    cos_queue_push_back(&mut root.queues[0], test_flow_cos_item(5201, 128));
+    root.queues[0].hot.queued_bytes = 128;
+    root.nonempty_queues = 1;
+    root.runnable_queues = 1;
+
+    let mut fast_interfaces = test_cos_fast_interfaces(
+        42,
+        42,
+        4,
+        vec![(4, test_queue_fast_path(false, 0, None, None))],
+        None,
+        None,
+    );
+    let shared_exact_backlog = Arc::new(SharedCoSExactBacklog::new(1));
+    shared_exact_backlog.publish(0, 128);
+    fast_interfaces
+        .get_mut(&42)
+        .expect("test fast path")
+        .shared_exact_backlog = Some(shared_exact_backlog.clone());
+    let fast_path = fast_interfaces.get(&42).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, 42, root, fast_path);
+
+    reset_binding_cos_runtime(&mut binding, None);
+
+    assert!(
+        !shared_exact_backlog.has_peer_backlog(1),
+        "reset must clear this worker's exact-backlog slot before the Arc can be reused",
+    );
 }
 
 #[test]
@@ -1347,6 +1395,7 @@ fn build_worker_cos_fast_interfaces_flattens_owner_and_lease_state() {
         &owner_worker_by_queue,
         &owner_live_by_queue,
         &shared_root_leases,
+        &BTreeMap::new(),
         &shared_queue_leases,
         &BTreeMap::new(),
     );
@@ -1475,6 +1524,7 @@ fn build_worker_cos_fast_interfaces_keeps_low_rate_exact_queue_owner_local() {
         &owner_worker_by_queue,
         &owner_live_by_queue,
         &shared_root_leases,
+        &BTreeMap::new(),
         &shared_queue_leases,
         &BTreeMap::new(),
     );
@@ -1572,6 +1622,7 @@ fn build_worker_cos_fast_interfaces_high_iface_rate_shards_mid_rate_exact_queue(
         &owner_worker_by_queue,
         &owner_live_by_queue,
         &shared_root_leases,
+        &BTreeMap::new(),
         &shared_queue_leases,
         &BTreeMap::new(),
     );
@@ -1726,6 +1777,7 @@ fn build_worker_cos_fast_interfaces_matches_live_loss_ha_3_queue_shape() {
         &owner_worker_by_queue,
         &owner_live_by_queue,
         &shared_root_leases,
+        &BTreeMap::new(),
         &shared_queue_leases,
         &BTreeMap::new(),
     );

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -80,8 +80,8 @@ use cos::{
 // `use self::tx::*;` parent-module glob still reaches them — the items
 // no longer originate from tx.rs after the moves.
 use super::cos::{
-    cos_queue_len, cos_queue_pop_front_no_snapshot, release_all_cos_queue_leases,
-    release_all_cos_root_leases,
+    clear_all_cos_exact_backlogs_for_binding, cos_queue_len, cos_queue_pop_front_no_snapshot,
+    release_all_cos_queue_leases, release_all_cos_root_leases,
 };
 
 pub(crate) struct BindingWorker {
@@ -908,6 +908,7 @@ pub(crate) fn worker_loop(
     shared_cos_owner_worker_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), u32>>>,
     shared_cos_owner_live_by_queue: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>>,
     shared_cos_root_leases: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>>,
+    shared_cos_exact_backlogs: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>>,
     shared_cos_queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     shared_cos_queue_vtime_floors: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
@@ -924,6 +925,7 @@ pub(crate) fn worker_loop(
     let mut cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
     let mut cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
     let mut cos_shared_root_leases = shared_cos_root_leases.load_full();
+    let mut cos_shared_exact_backlogs = shared_cos_exact_backlogs.load_full();
     let mut cos_shared_queue_leases = shared_cos_queue_leases.load_full();
     let mut cos_shared_queue_vtime_floors = shared_cos_queue_vtime_floors.load_full();
     let mut sessions = SessionTable::new();
@@ -962,6 +964,7 @@ pub(crate) fn worker_loop(
         cos_owner_worker_by_queue.as_ref(),
         cos_owner_live_by_queue.as_ref(),
         cos_shared_root_leases.as_ref(),
+        cos_shared_exact_backlogs.as_ref(),
         cos_shared_queue_leases.as_ref(),
         cos_shared_queue_vtime_floors.as_ref(),
     );
@@ -1190,6 +1193,12 @@ pub(crate) fn worker_loop(
             cos_shared_root_leases = new_x;
             rebuild_cos_fast_interfaces = true;
         }
+        if let Some(new_x) =
+            load_arc_if_changed(&cos_shared_exact_backlogs, &shared_cos_exact_backlogs)
+        {
+            cos_shared_exact_backlogs = new_x;
+            rebuild_cos_fast_interfaces = true;
+        }
         if let Some(new_x) = load_arc_if_changed(&cos_shared_queue_leases, &shared_cos_queue_leases)
         {
             for binding in bindings.iter_mut() {
@@ -1226,6 +1235,7 @@ pub(crate) fn worker_loop(
                 cos_owner_worker_by_queue.as_ref(),
                 cos_owner_live_by_queue.as_ref(),
                 cos_shared_root_leases.as_ref(),
+                cos_shared_exact_backlogs.as_ref(),
                 cos_shared_queue_leases.as_ref(),
                 cos_shared_queue_vtime_floors.as_ref(),
             );
@@ -1282,11 +1292,7 @@ pub(crate) fn worker_loop(
                 shaped_tx_requests,
                 &mut shared_recycles,
             );
-            apply_shared_recycles_to_bindings(
-                &mut bindings,
-                &binding_lookup,
-                &mut shared_recycles,
-            );
+            apply_shared_recycles_to_bindings(&mut bindings, &binding_lookup, &mut shared_recycles);
         }
         if !cancelled_keys.is_empty() {
             for key in &cancelled_keys {
@@ -2074,6 +2080,7 @@ pub(crate) fn worker_loop(
     }
     crate::filter::flush_recorded_filter_counters();
     for binding in bindings.iter_mut() {
+        clear_all_cos_exact_backlogs_for_binding(binding);
         release_all_cos_root_leases(binding);
         release_all_cos_queue_leases(binding);
     }
@@ -2392,8 +2399,7 @@ mod tests {
             shared_umem: shared,
         };
 
-        let plan =
-            prepare_shared_binding_plan_for_create(&group, plan, XskSocketRole::SharedOwner);
+        let plan = prepare_shared_binding_plan_for_create(&group, plan, XskSocketRole::SharedOwner);
         let snap = live.snapshot();
 
         assert_eq!(plan.status.shared_umem_mode, "cross-nic");

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -81,7 +81,7 @@ use cos::{
 // no longer originate from tx.rs after the moves.
 use super::cos::{
     clear_all_cos_exact_backlogs_for_binding, cos_queue_len, cos_queue_pop_front_no_snapshot,
-    release_all_cos_queue_leases, release_all_cos_root_leases,
+    publish_cos_exact_backlog, release_all_cos_queue_leases, release_all_cos_root_leases,
 };
 
 pub(crate) struct BindingWorker {
@@ -1241,6 +1241,16 @@ pub(crate) fn worker_loop(
             );
             for binding in bindings.iter_mut() {
                 binding.cos.cos_fast_interfaces = cos_fast_interfaces.clone();
+            }
+            // The new SharedCoSExactBacklog slots in the freshly built
+            // cos_fast_interfaces start at zero. Republish the current
+            // exact-queue backlog for every binding/ifindex so peer workers
+            // do not observe a false-zero window until the next organic
+            // enqueue or drain refresh.
+            for binding in bindings.iter() {
+                for &root_ifindex in binding.cos.cos_interfaces.keys() {
+                    publish_cos_exact_backlog(binding, root_ifindex);
+                }
             }
         }
         let ha_runtime = ha_state.load();

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -957,6 +957,13 @@ pub(crate) struct CoSQueueStatus {
     // queues without a single unambiguous owner-local binding.
     #[serde(rename = "drain_sent_bytes", default)]
     pub drain_sent_bytes: u64,
+    // #1369 drain-phase telemetry. Populated for all queue types,
+    // including non-exact and shared queues — not zeroed for queues
+    // without a single owner-local binding. The steal counter
+    // (`drain_nonexact_sent_bytes_while_exact_backlogged`) uses
+    // interface-global exact-backlog visibility via
+    // `SharedCoSExactBacklog` (per-binding cacheline-padded atomic
+    // slots) rather than a worker-local scan.
     #[serde(rename = "drain_guarantee_sent_bytes", default)]
     pub drain_guarantee_sent_bytes: u64,
     #[serde(rename = "drain_surplus_sent_bytes", default)]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -957,6 +957,12 @@ pub(crate) struct CoSQueueStatus {
     // queues without a single unambiguous owner-local binding.
     #[serde(rename = "drain_sent_bytes", default)]
     pub drain_sent_bytes: u64,
+    #[serde(rename = "drain_guarantee_sent_bytes", default)]
+    pub drain_guarantee_sent_bytes: u64,
+    #[serde(rename = "drain_surplus_sent_bytes", default)]
+    pub drain_surplus_sent_bytes: u64,
+    #[serde(rename = "drain_nonexact_sent_bytes_while_exact_backlogged", default)]
+    pub drain_nonexact_sent_bytes_while_exact_backlogged: u64,
     #[serde(rename = "drain_park_root_tokens", default)]
     pub drain_park_root_tokens: u64,
     #[serde(rename = "drain_park_queue_tokens", default)]


### PR DESCRIPTION
## Summary

Closes #1369.

Adds queue-scoped CoS drain phase telemetry so operators can distinguish guarantee service, surplus service, and non-exact bytes sent while exact queues under the same shaped root were still backlogged.

This is the diagnostic side of the best-effort stealing investigation: if best-effort or uncapped queues still consume service while exact queues have demand, operators can now see it directly instead of inferring from aggregate throughput.

## Implementation notes

- Adds per-queue counters for:
  - `drain_guarantee_sent_bytes`
  - `drain_surplus_sent_bytes`
  - `drain_nonexact_sent_bytes_while_exact_backlogged`
- Wires counters through Rust status, Go protocol structs, CLI formatting, and Prometheus metrics.
- Moves `DrainShape` rendering out from the exact-only owner-profile row so non-exact queues can expose the signal.
- Keeps the exact-backlog scan out of the common exact hot path; it only runs for non-exact queues with sent bytes. Queue count is bounded and small relative to packet work.
- Updates CoS, dataplane, and metrics docs/READMEs.

## Validation

- `go test ./pkg/api ./pkg/dataplane/userspace`
- `cargo test account_queue_drain_sent_bytes --manifest-path userspace-dp/Cargo.toml`
- `git diff --check`

The Rust test run still emits the repository's existing warning backlog; the targeted tests pass.
