### PR TITLE
test/incus: add best-effort versus exact CoS contention harness

### DIFF
--- a/docs/cos-best-effort-contention-harness.md
+++ b/docs/cos-best-effort-contention-harness.md
@@ -61,7 +61,11 @@ The validator fails closed when:
 - any iperf run exits non-zero
 - status snapshots are missing or their capture commands exit non-zero
 - an expected queue has no `drain_sent_bytes` delta
+- any queue has a negative DrainShape counter delta
+- an expected queue's `forwarding_class` does not match the manifest
 - any unexpected queue drains more than `WRONG_QUEUE_SENT_BYTES_TOLERANCE`
+- the contender iperf throughput is below `MIN_CONTENDER_BPS`, because a
+  no-pressure contender cannot prove exact-queue isolation
 - exact+contender throughput drops below exact-alone throughput by more than
   `MAX_EXACT_DROP_RATIO`
 
@@ -71,6 +75,7 @@ Defaults:
 MAX_EXACT_DROP_RATIO=0.15
 WRONG_QUEUE_SENT_BYTES_TOLERANCE=0
 MIN_EXPECTED_SENT_BYTES=1
+MIN_CONTENDER_BPS=100000000
 COS_INTERFACE_NAME=reth0.80
 ```
 

--- a/docs/cos-best-effort-contention-harness.md
+++ b/docs/cos-best-effort-contention-harness.md
@@ -66,6 +66,10 @@ The validator fails closed when:
 - any unexpected queue drains more than `WRONG_QUEUE_SENT_BYTES_TOLERANCE`
 - the contender iperf throughput is below `MIN_CONTENDER_BPS`, because a
   no-pressure contender cannot prove exact-queue isolation
+- exact+contender aggregate throughput is below
+  `MIN_CONTENDED_ROOT_PRESSURE_RATIO * ROOT_SHAPE_BPS`, because a low-rate
+  contended run does not prove best-effort/uncapped traffic is unable to steal
+  under root pressure
 - exact+contender throughput drops below exact-alone throughput by more than
   `MAX_EXACT_DROP_RATIO`
 
@@ -76,6 +80,9 @@ MAX_EXACT_DROP_RATIO=0.15
 WRONG_QUEUE_SENT_BYTES_TOLERANCE=0
 MIN_EXPECTED_SENT_BYTES=1
 MIN_CONTENDER_BPS=100000000
+MIN_EXACT_BASELINE_CAP_RATIO=0.70
+MIN_CONTENDED_ROOT_PRESSURE_RATIO=0.90
+ROOT_SHAPE_BPS=25000000000
 COS_INTERFACE_NAME=reth0.80
 ```
 

--- a/docs/cos-best-effort-contention-harness.md
+++ b/docs/cos-best-effort-contention-harness.md
@@ -1,0 +1,104 @@
+# CoS Best-Effort Contention Harness
+
+`test/incus/cos-be-contention-harness.sh` validates the 5200/5211 CoS port-grid
+edge cases where an exact class must hold its exact-alone throughput while a
+best-effort or uncapped-root contender is present.
+
+The default run targets the isolated loss userspace cluster, applies the
+symmetric CoS fixture, and runs IPv4 forward traffic from
+`loss:cluster-userspace-host` to `172.16.80.200`.
+
+## Cells
+
+The smoke matrix is intentionally small:
+
+| Cell | Exact queue | Exact port | Contender queue | Contender port |
+|---|---:|---:|---:|---:|
+| `exact5202-vs-5200` | 2 | 5202 | 0 | 5200 |
+| `exact5210-vs-5200` | 10 | 5210 | 0 | 5200 |
+| `exact5202-vs-5211` | 2 | 5202 | 11 | 5211 |
+| `exact5210-vs-5211` | 10 | 5210 | 11 | 5211 |
+
+Each cell runs:
+
+1. exact-alone baseline
+2. exact plus contender
+3. offline validation of iperf summaries and queue DrainShape deltas
+
+## Usage
+
+```bash
+./test/incus/cos-be-contention-harness.sh
+```
+
+Useful overrides:
+
+```bash
+DURATION=20 EXACT_PARALLEL=6 CONTENDER_PARALLEL=6 \
+ARTIFACT_ROOT=/tmp/cos-be-contention \
+./test/incus/cos-be-contention-harness.sh
+```
+
+Run one cell:
+
+```bash
+CELL_FILTER=exact5202-vs-5200 ./test/incus/cos-be-contention-harness.sh
+```
+
+Skip config apply when the symmetric fixture is already live:
+
+```bash
+APPLY_CONFIG=0 ./test/incus/cos-be-contention-harness.sh
+```
+
+The default `DURATION=8` and `-P4` settings are short enough for smoke. Increase
+duration and parallelism for qualification.
+
+## Gates
+
+The validator fails closed when:
+
+- any iperf run exits non-zero
+- status snapshots are missing or their capture commands exit non-zero
+- an expected queue has no `drain_sent_bytes` delta
+- any unexpected queue drains more than `WRONG_QUEUE_SENT_BYTES_TOLERANCE`
+- exact+contender throughput drops below exact-alone throughput by more than
+  `MAX_EXACT_DROP_RATIO`
+
+Defaults:
+
+```bash
+MAX_EXACT_DROP_RATIO=0.15
+WRONG_QUEUE_SENT_BYTES_TOLERANCE=0
+MIN_EXPECTED_SENT_BYTES=1
+COS_INTERFACE_NAME=reth0.80
+```
+
+Set `COS_IFINDEX` to pin validation to a specific CoS interface if interface
+names are ambiguous.
+
+## Artifacts
+
+The harness writes an artifact root such as `/tmp/cos-be-contention.xxxxxx`.
+Important files:
+
+- `manifest.json`: cell definitions and CoS interface filter
+- `summary.json`: full verdict, thresholds, throughput, and queue deltas
+- `summary.tsv`: compact per-cell verdict and throughput table
+- `drain-shape.tsv`: per-cell, per-phase queue `sent_bytes`,
+  `park_root`, and `park_queue` deltas
+- `<cell>/baseline/*`: exact-alone iperf and status snapshots
+- `<cell>/contended/*`: exact+contender iperf and status snapshots
+
+Each phase contains:
+
+- `status-before.json`, `status-during.json`, `status-after.json`
+- `exact-iperf.json`, `exact-iperf.rc`, `exact-iperf.stderr`
+- `contender-iperf.json`, `contender-iperf.rc`, `contender-iperf.stderr`
+  for contended phases
+
+The offline validator can be rerun against saved artifacts:
+
+```bash
+python3 test/incus/cos_be_contention_validate.py /tmp/cos-be-contention.xxxxxx
+```

--- a/test/incus/cos-be-contention-harness.sh
+++ b/test/incus/cos-be-contention-harness.sh
@@ -36,6 +36,8 @@ MAX_EXACT_DROP_RATIO="${MAX_EXACT_DROP_RATIO:-0.15}"
 WRONG_QUEUE_SENT_BYTES_TOLERANCE="${WRONG_QUEUE_SENT_BYTES_TOLERANCE:-0}"
 MIN_EXPECTED_SENT_BYTES="${MIN_EXPECTED_SENT_BYTES:-1}"
 MIN_CONTENDER_BPS="${MIN_CONTENDER_BPS:-100000000}"
+MIN_EXACT_BASELINE_CAP_RATIO="${MIN_EXACT_BASELINE_CAP_RATIO:-0.70}"
+ROOT_SHAPE_BPS="${ROOT_SHAPE_BPS:-25000000000}"
 IPERF_EXTRA_ARGS="${IPERF_EXTRA_ARGS:-}"
 
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -161,11 +163,14 @@ start_iperf() {
         remote_cmd+=" ${IPERF_EXTRA_ARGS}"
     fi
     {
+        rc=1
         printf '%s\n' "$remote_cmd" > "$phase_dir/${role}-iperf.cmd"
         run_incus "$HOST" "$remote_cmd" \
             > "$phase_dir/${role}-iperf.json" \
             2> "$phase_dir/${role}-iperf.stderr"
-        printf '%s\n' "$?" > "$phase_dir/${role}-iperf.rc"
+        rc=$?
+        printf '%s\n' "$rc" > "$phase_dir/${role}-iperf.rc"
+        exit "$rc"
     } &
     STARTED_IPERF_PID=$!
 }
@@ -231,15 +236,15 @@ class_selected() {
 }
 
 cells=(
-    "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort"
-    "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort"
-    "exact5202-vs-5211 5202 2 iperf-1g 5211 11 iperf-uncapped"
-    "exact5210-vs-5211 5210 10 iperf-24g 5211 11 iperf-uncapped"
+    "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort 1000000000 500000000"
+    "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort 24000000000 1000000000"
+    "exact5202-vs-5211 5202 2 iperf-1g 5211 11 iperf-uncapped 1000000000 500000000"
+    "exact5210-vs-5211 5210 10 iperf-24g 5211 11 iperf-uncapped 24000000000 1000000000"
 )
 
 selected_cells=()
 for spec in "${cells[@]}"; do
-    read -r label _exact_port _exact_queue _exact_class _contender_port _contender_queue _contender_class <<< "$spec"
+    read -r label _exact_port _exact_queue _exact_class _contender_port _contender_queue _contender_class _exact_cap_bps _min_contender_bps <<< "$spec"
     if class_selected "$label"; then
         selected_cells+=("$spec")
     fi
@@ -264,7 +269,7 @@ if [[ -z "$ACTIVE_FW" ]]; then
 fi
 log "capturing dataplane status from $ACTIVE_FW"
 
-python3 - "$ARTIFACT_ROOT" "$COS_INTERFACE_NAME" "$COS_IFINDEX" "${selected_cells[@]}" <<'PY'
+python3 - "$ARTIFACT_ROOT" "$COS_INTERFACE_NAME" "$COS_IFINDEX" "$ROOT_SHAPE_BPS" "${selected_cells[@]}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -272,8 +277,9 @@ from pathlib import Path
 root = Path(sys.argv[1])
 cos_interface_name = sys.argv[2]
 cos_ifindex_raw = sys.argv[3]
+root_shape_bps = int(sys.argv[4])
 cells = []
-for raw in sys.argv[4:]:
+for raw in sys.argv[5:]:
     (
         label,
         exact_port,
@@ -282,6 +288,8 @@ for raw in sys.argv[4:]:
         contender_port,
         contender_queue,
         contender_forwarding_class,
+        exact_cap_bps,
+        min_contender_bps,
     ) = raw.split()
     cells.append(
         {
@@ -289,9 +297,11 @@ for raw in sys.argv[4:]:
             "exact_port": int(exact_port),
             "exact_queue": int(exact_queue),
             "exact_forwarding_class": exact_forwarding_class,
+            "exact_cap_bps": int(exact_cap_bps),
             "contender_port": int(contender_port),
             "contender_queue": int(contender_queue),
             "contender_forwarding_class": contender_forwarding_class,
+            "min_contender_bps": int(min_contender_bps),
             "baseline_dir": f"{label}/baseline",
             "contended_dir": f"{label}/contended",
         }
@@ -299,6 +309,7 @@ for raw in sys.argv[4:]:
 manifest = {
     "cos_interface_name": cos_interface_name,
     "cos_ifindex": int(cos_ifindex_raw) if cos_ifindex_raw else None,
+    "root_shape_bps": root_shape_bps,
     "cells": cells,
 }
 (root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
@@ -306,7 +317,7 @@ PY
 
 overall_run_status=0
 for spec in "${selected_cells[@]}"; do
-    read -r label exact_port exact_queue _exact_class contender_port contender_queue _contender_class <<< "$spec"
+    read -r label exact_port exact_queue _exact_class contender_port contender_queue _contender_class _exact_cap_bps _min_contender_bps <<< "$spec"
     cell_dir="$ARTIFACT_ROOT/$label"
     log "cell=$label exact_port=$exact_port exact_queue=$exact_queue contender_port=$contender_port contender_queue=$contender_queue"
     if ! run_phase "$cell_dir/baseline" "$exact_port"; then
@@ -325,7 +336,8 @@ python3 "$VALIDATOR" "$ARTIFACT_ROOT" \
     --max-exact-drop-ratio "$MAX_EXACT_DROP_RATIO" \
     --wrong-queue-sent-bytes-tolerance "$WRONG_QUEUE_SENT_BYTES_TOLERANCE" \
     --min-expected-sent-bytes "$MIN_EXPECTED_SENT_BYTES" \
-    --min-contender-bps "$MIN_CONTENDER_BPS"
+    --min-contender-bps "$MIN_CONTENDER_BPS" \
+    --min-exact-baseline-cap-ratio "$MIN_EXACT_BASELINE_CAP_RATIO"
 validator_status=$?
 
 log "summary: $ARTIFACT_ROOT/summary.tsv"

--- a/test/incus/cos-be-contention-harness.sh
+++ b/test/incus/cos-be-contention-harness.sh
@@ -35,6 +35,7 @@ CELL_FILTER="${CELL_FILTER:-}"
 MAX_EXACT_DROP_RATIO="${MAX_EXACT_DROP_RATIO:-0.15}"
 WRONG_QUEUE_SENT_BYTES_TOLERANCE="${WRONG_QUEUE_SENT_BYTES_TOLERANCE:-0}"
 MIN_EXPECTED_SENT_BYTES="${MIN_EXPECTED_SENT_BYTES:-1}"
+MIN_CONTENDER_BPS="${MIN_CONTENDER_BPS:-100000000}"
 IPERF_EXTRA_ARGS="${IPERF_EXTRA_ARGS:-}"
 
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -230,15 +231,15 @@ class_selected() {
 }
 
 cells=(
-    "exact5202-vs-5200 5202 2 5200 0"
-    "exact5210-vs-5200 5210 10 5200 0"
-    "exact5202-vs-5211 5202 2 5211 11"
-    "exact5210-vs-5211 5210 10 5211 11"
+    "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort"
+    "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort"
+    "exact5202-vs-5211 5202 2 iperf-1g 5211 11 iperf-uncapped"
+    "exact5210-vs-5211 5210 10 iperf-24g 5211 11 iperf-uncapped"
 )
 
 selected_cells=()
 for spec in "${cells[@]}"; do
-    read -r label _exact_port _exact_queue _contender_port _contender_queue <<< "$spec"
+    read -r label _exact_port _exact_queue _exact_class _contender_port _contender_queue _contender_class <<< "$spec"
     if class_selected "$label"; then
         selected_cells+=("$spec")
     fi
@@ -273,14 +274,24 @@ cos_interface_name = sys.argv[2]
 cos_ifindex_raw = sys.argv[3]
 cells = []
 for raw in sys.argv[4:]:
-    label, exact_port, exact_queue, contender_port, contender_queue = raw.split()
+    (
+        label,
+        exact_port,
+        exact_queue,
+        exact_forwarding_class,
+        contender_port,
+        contender_queue,
+        contender_forwarding_class,
+    ) = raw.split()
     cells.append(
         {
             "label": label,
             "exact_port": int(exact_port),
             "exact_queue": int(exact_queue),
+            "exact_forwarding_class": exact_forwarding_class,
             "contender_port": int(contender_port),
             "contender_queue": int(contender_queue),
+            "contender_forwarding_class": contender_forwarding_class,
             "baseline_dir": f"{label}/baseline",
             "contended_dir": f"{label}/contended",
         }
@@ -295,7 +306,7 @@ PY
 
 overall_run_status=0
 for spec in "${selected_cells[@]}"; do
-    read -r label exact_port exact_queue contender_port contender_queue <<< "$spec"
+    read -r label exact_port exact_queue _exact_class contender_port contender_queue _contender_class <<< "$spec"
     cell_dir="$ARTIFACT_ROOT/$label"
     log "cell=$label exact_port=$exact_port exact_queue=$exact_queue contender_port=$contender_port contender_queue=$contender_queue"
     if ! run_phase "$cell_dir/baseline" "$exact_port"; then
@@ -313,7 +324,8 @@ fi
 python3 "$VALIDATOR" "$ARTIFACT_ROOT" \
     --max-exact-drop-ratio "$MAX_EXACT_DROP_RATIO" \
     --wrong-queue-sent-bytes-tolerance "$WRONG_QUEUE_SENT_BYTES_TOLERANCE" \
-    --min-expected-sent-bytes "$MIN_EXPECTED_SENT_BYTES"
+    --min-expected-sent-bytes "$MIN_EXPECTED_SENT_BYTES" \
+    --min-contender-bps "$MIN_CONTENDER_BPS"
 validator_status=$?
 
 log "summary: $ARTIFACT_ROOT/summary.tsv"

--- a/test/incus/cos-be-contention-harness.sh
+++ b/test/incus/cos-be-contention-harness.sh
@@ -37,6 +37,7 @@ WRONG_QUEUE_SENT_BYTES_TOLERANCE="${WRONG_QUEUE_SENT_BYTES_TOLERANCE:-0}"
 MIN_EXPECTED_SENT_BYTES="${MIN_EXPECTED_SENT_BYTES:-1}"
 MIN_CONTENDER_BPS="${MIN_CONTENDER_BPS:-100000000}"
 MIN_EXACT_BASELINE_CAP_RATIO="${MIN_EXACT_BASELINE_CAP_RATIO:-0.70}"
+MIN_CONTENDED_ROOT_PRESSURE_RATIO="${MIN_CONTENDED_ROOT_PRESSURE_RATIO:-0.90}"
 ROOT_SHAPE_BPS="${ROOT_SHAPE_BPS:-25000000000}"
 IPERF_EXTRA_ARGS="${IPERF_EXTRA_ARGS:-}"
 
@@ -237,21 +238,21 @@ class_selected() {
 
 # Format:
 #   label exact_port exact_queue exact_class contender_port contender_queue
-#   contender_class exact_cap_bps min_contender_bps
+#   contender_class
 #
-# The pressure floor must prove material contention relative to the exact cap:
-# 1G exact cells require 500M contender pressure; 24G exact cells require 1G,
-# which is the remaining headroom under the default 25G root shape.
+# Exact caps and per-cell contender floors are derived by the validator from
+# the canonical CoS port grid so the live harness and offline reducer do not
+# drift apart.
 cells=(
-    "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort 1000000000 500000000"
-    "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort 24000000000 1000000000"
-    "exact5202-vs-5211 5202 2 iperf-1g 5211 11 iperf-uncapped 1000000000 500000000"
-    "exact5210-vs-5211 5210 10 iperf-24g 5211 11 iperf-uncapped 24000000000 1000000000"
+    "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort"
+    "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort"
+    "exact5202-vs-5211 5202 2 iperf-1g 5211 11 iperf-uncapped"
+    "exact5210-vs-5211 5210 10 iperf-24g 5211 11 iperf-uncapped"
 )
 
 selected_cells=()
 for spec in "${cells[@]}"; do
-    read -r label _exact_port _exact_queue _exact_class _contender_port _contender_queue _contender_class _exact_cap_bps _min_contender_bps <<< "$spec"
+    read -r label _exact_port _exact_queue _exact_class _contender_port _contender_queue _contender_class <<< "$spec"
     if class_selected "$label"; then
         selected_cells+=("$spec")
     fi
@@ -295,8 +296,6 @@ for raw in sys.argv[5:]:
         contender_port,
         contender_queue,
         contender_forwarding_class,
-        exact_cap_bps,
-        min_contender_bps,
     ) = raw.split()
     cells.append(
         {
@@ -304,11 +303,9 @@ for raw in sys.argv[5:]:
             "exact_port": int(exact_port),
             "exact_queue": int(exact_queue),
             "exact_forwarding_class": exact_forwarding_class,
-            "exact_cap_bps": int(exact_cap_bps),
             "contender_port": int(contender_port),
             "contender_queue": int(contender_queue),
             "contender_forwarding_class": contender_forwarding_class,
-            "min_contender_bps": int(min_contender_bps),
             "baseline_dir": f"{label}/baseline",
             "contended_dir": f"{label}/contended",
         }
@@ -324,7 +321,7 @@ PY
 
 overall_run_status=0
 for spec in "${selected_cells[@]}"; do
-    read -r label exact_port exact_queue _exact_class contender_port contender_queue _contender_class _exact_cap_bps _min_contender_bps <<< "$spec"
+    read -r label exact_port exact_queue _exact_class contender_port contender_queue _contender_class <<< "$spec"
     cell_dir="$ARTIFACT_ROOT/$label"
     log "cell=$label exact_port=$exact_port exact_queue=$exact_queue contender_port=$contender_port contender_queue=$contender_queue"
     if ! run_phase "$cell_dir/baseline" "$exact_port"; then
@@ -344,7 +341,8 @@ python3 "$VALIDATOR" "$ARTIFACT_ROOT" \
     --wrong-queue-sent-bytes-tolerance "$WRONG_QUEUE_SENT_BYTES_TOLERANCE" \
     --min-expected-sent-bytes "$MIN_EXPECTED_SENT_BYTES" \
     --min-contender-bps "$MIN_CONTENDER_BPS" \
-    --min-exact-baseline-cap-ratio "$MIN_EXACT_BASELINE_CAP_RATIO"
+    --min-exact-baseline-cap-ratio "$MIN_EXACT_BASELINE_CAP_RATIO" \
+    --min-contended-root-pressure-ratio "$MIN_CONTENDED_ROOT_PRESSURE_RATIO"
 validator_status=$?
 
 log "summary: $ARTIFACT_ROOT/summary.tsv"

--- a/test/incus/cos-be-contention-harness.sh
+++ b/test/incus/cos-be-contention-harness.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Validate exact CoS queues under best-effort/uncapped contention.
+#
+# Runs four IPv4 forward cells on the loss userspace cluster:
+#   exact 5202 vs contender 5200
+#   exact 5210 vs contender 5200
+#   exact 5202 vs contender 5211
+#   exact 5210 vs contender 5211
+#
+# The harness records exact-alone and exact+contender iperf3 JSON plus
+# before/during/after DrainShape snapshots from /run/xpf/userspace-dp.json,
+# then delegates fail-closed validation to cos_be_contention_validate.py.
+
+set -uo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/test/incus/loss-userspace-cluster.env}"
+APPLY_COS_CONFIG="${APPLY_COS_CONFIG:-$ROOT_DIR/test/incus/apply-cos-config.sh}"
+VALIDATOR="${VALIDATOR:-$ROOT_DIR/test/incus/cos_be_contention_validate.py}"
+
+TARGET_IP="${TARGET_IP:-172.16.80.200}"
+DURATION="${DURATION:-8}"
+EXACT_PARALLEL="${EXACT_PARALLEL:-4}"
+CONTENDER_PARALLEL="${CONTENDER_PARALLEL:-4}"
+IPERF_TIMEOUT="${IPERF_TIMEOUT:-$((DURATION + 15))}"
+DURING_CAPTURE_AFTER_SEC="${DURING_CAPTURE_AFTER_SEC:-2}"
+BETWEEN_PHASE_SLEEP_SEC="${BETWEEN_PHASE_SLEEP_SEC:-1}"
+APPLY_CONFIG="${APPLY_CONFIG:-1}"
+USE_SG_INCUS_ADMIN="${USE_SG_INCUS_ADMIN:-1}"
+DATAPLANE_STATUS_PATH="${DATAPLANE_STATUS_PATH:-/run/xpf/userspace-dp.json}"
+COS_INTERFACE_NAME="${COS_INTERFACE_NAME:-reth0.80}"
+COS_IFINDEX="${COS_IFINDEX:-}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-}"
+CELL_FILTER="${CELL_FILTER:-}"
+MAX_EXACT_DROP_RATIO="${MAX_EXACT_DROP_RATIO:-0.15}"
+WRONG_QUEUE_SENT_BYTES_TOLERANCE="${WRONG_QUEUE_SENT_BYTES_TOLERANCE:-0}"
+MIN_EXPECTED_SENT_BYTES="${MIN_EXPECTED_SENT_BYTES:-1}"
+IPERF_EXTRA_ARGS="${IPERF_EXTRA_ARGS:-}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "cos-be-contention-harness: env file not found: $ENV_FILE" >&2
+    exit 2
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+REMOTE_PREFIX="${INCUS_REMOTE:+${INCUS_REMOTE}:}"
+FW0="${REMOTE_PREFIX}${VM0}"
+FW1="${REMOTE_PREFIX}${VM1}"
+HOST="${REMOTE_PREFIX}${LAN_HOST}"
+APPLY_TARGET_VM="${APPLY_TARGET_VM:-$FW0}"
+ACTIVE_FW="${ACTIVE_FW:-}"
+
+enabled() {
+    case "${1,,}" in
+        1|true|yes|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "cos-be-contention-harness: required command not found: $1" >&2
+        exit 2
+    fi
+}
+
+require_cmd incus
+require_cmd python3
+if enabled "$USE_SG_INCUS_ADMIN"; then
+    require_cmd sg
+fi
+if [[ ! -x "$VALIDATOR" ]]; then
+    echo "cos-be-contention-harness: validator is not executable: $VALIDATOR" >&2
+    exit 2
+fi
+if enabled "$APPLY_CONFIG" && [[ ! -x "$APPLY_COS_CONFIG" ]]; then
+    echo "cos-be-contention-harness: apply script is not executable: $APPLY_COS_CONFIG" >&2
+    exit 2
+fi
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+    ARTIFACT_ROOT=$(mktemp -d -t cos-be-contention.XXXXXX)
+else
+    mkdir -p "$ARTIFACT_ROOT"
+fi
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+run_incus() {
+    local vm=$1
+    local cmd=$2
+
+    if enabled "$USE_SG_INCUS_ADMIN"; then
+        local incus_cmd
+        printf -v incus_cmd 'incus exec %q -- bash -lc %q' "$vm" "$cmd"
+        sg incus-admin -c "$incus_cmd"
+    else
+        incus exec "$vm" -- bash -lc "$cmd"
+    fi
+}
+
+run_apply_config() {
+    enabled "$APPLY_CONFIG" || return 0
+
+    log "applying symmetric CoS fixture to $APPLY_TARGET_VM"
+    if enabled "$USE_SG_INCUS_ADMIN"; then
+        local apply_cmd
+        printf -v apply_cmd '%q --symmetric %q' "$APPLY_COS_CONFIG" "$APPLY_TARGET_VM"
+        sg incus-admin -c "$apply_cmd" \
+            > "$ARTIFACT_ROOT/apply-cos.stdout" \
+            2> "$ARTIFACT_ROOT/apply-cos.stderr"
+    else
+        "$APPLY_COS_CONFIG" --symmetric "$APPLY_TARGET_VM" \
+            > "$ARTIFACT_ROOT/apply-cos.stdout" \
+            2> "$ARTIFACT_ROOT/apply-cos.stderr"
+    fi
+}
+
+detect_active_fw() {
+    local vm
+    local stats
+    for vm in "$FW0" "$FW1"; do
+        stats="$(run_incus "$vm" 'cli -c "show chassis cluster data-plane statistics"' 2>/dev/null || true)"
+        if grep -Eq 'Enabled:[[:space:]]+true' <<<"$stats" &&
+            grep -Eq 'Forwarding supported:[[:space:]]+true' <<<"$stats" &&
+            grep -Eq 'HA groups:[[:space:]].*rg[1-9][0-9]* active=true' <<<"$stats"; then
+            printf '%s\n' "$vm"
+            return 0
+        fi
+    done
+    return 1
+}
+
+capture_status() {
+    local phase_dir=$1
+    local phase=$2
+    local rc=0
+
+    mkdir -p "$phase_dir"
+    run_incus "$ACTIVE_FW" "cat \"$DATAPLANE_STATUS_PATH\"" \
+        > "$phase_dir/status-${phase}.json" \
+        2> "$phase_dir/status-${phase}.stderr"
+    rc=$?
+    printf '%s\n' "$rc" > "$phase_dir/status-${phase}.rc"
+    return 0
+}
+
+start_iperf() {
+    local phase_dir=$1
+    local role=$2
+    local port=$3
+    local parallel=$4
+    local remote_cmd
+
+    remote_cmd="timeout -k 2 ${IPERF_TIMEOUT} iperf3 -J --forceflush -c ${TARGET_IP} -p ${port} -P ${parallel} -t ${DURATION}"
+    if [[ -n "$IPERF_EXTRA_ARGS" ]]; then
+        remote_cmd+=" ${IPERF_EXTRA_ARGS}"
+    fi
+    {
+        printf '%s\n' "$remote_cmd" > "$phase_dir/${role}-iperf.cmd"
+        run_incus "$HOST" "$remote_cmd" \
+            > "$phase_dir/${role}-iperf.json" \
+            2> "$phase_dir/${role}-iperf.stderr"
+        printf '%s\n' "$?" > "$phase_dir/${role}-iperf.rc"
+    } &
+    STARTED_IPERF_PID=$!
+}
+
+wait_for_pids() {
+    local status=0
+    local pid
+
+    for pid in "$@"; do
+        if ! wait "$pid"; then
+            status=1
+        fi
+    done
+    return "$status"
+}
+
+run_phase() {
+    local phase_dir=$1
+    local exact_port=$2
+    local contender_port=${3:-}
+    local exact_pid
+    local contender_pid
+    local wait_status=0
+
+    mkdir -p "$phase_dir"
+    capture_status "$phase_dir" before
+    start_iperf "$phase_dir" exact "$exact_port" "$EXACT_PARALLEL"
+    exact_pid=$STARTED_IPERF_PID
+    if [[ -n "$contender_port" ]]; then
+        start_iperf "$phase_dir" contender "$contender_port" "$CONTENDER_PARALLEL"
+        contender_pid=$STARTED_IPERF_PID
+    else
+        contender_pid=
+    fi
+    sleep "$DURING_CAPTURE_AFTER_SEC"
+    capture_status "$phase_dir" during
+    if [[ -n "$contender_pid" ]]; then
+        wait_for_pids "$exact_pid" "$contender_pid" || wait_status=1
+    else
+        wait_for_pids "$exact_pid" || wait_status=1
+    fi
+    capture_status "$phase_dir" after
+    sleep "$BETWEEN_PHASE_SLEEP_SEC"
+    return "$wait_status"
+}
+
+class_selected() {
+    local label=$1
+    local raw
+    local filter
+    local -a filters
+
+    [[ -n "$CELL_FILTER" ]] || return 0
+    IFS=',' read -r -a filters <<< "$CELL_FILTER"
+    for raw in "${filters[@]}"; do
+        filter=${raw//[[:space:]]/}
+        [[ -n "$filter" ]] || continue
+        if [[ "$filter" == "$label" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+cells=(
+    "exact5202-vs-5200 5202 2 5200 0"
+    "exact5210-vs-5200 5210 10 5200 0"
+    "exact5202-vs-5211 5202 2 5211 11"
+    "exact5210-vs-5211 5210 10 5211 11"
+)
+
+selected_cells=()
+for spec in "${cells[@]}"; do
+    read -r label _exact_port _exact_queue _contender_port _contender_queue <<< "$spec"
+    if class_selected "$label"; then
+        selected_cells+=("$spec")
+    fi
+done
+if [[ "${#selected_cells[@]}" -eq 0 ]]; then
+    echo "cos-be-contention-harness: CELL_FILTER selected no cells: $CELL_FILTER" >&2
+    exit 2
+fi
+
+log "artifact root: $ARTIFACT_ROOT"
+run_apply_config || {
+    echo "cos-be-contention-harness: failed to apply symmetric CoS; see $ARTIFACT_ROOT/apply-cos.stderr" >&2
+    exit 2
+}
+
+if [[ -z "$ACTIVE_FW" ]]; then
+    ACTIVE_FW="$(detect_active_fw || true)"
+fi
+if [[ -z "$ACTIVE_FW" ]]; then
+    echo "cos-be-contention-harness: unable to detect active userspace firewall" >&2
+    exit 2
+fi
+log "capturing dataplane status from $ACTIVE_FW"
+
+python3 - "$ARTIFACT_ROOT" "$COS_INTERFACE_NAME" "$COS_IFINDEX" "${selected_cells[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+cos_interface_name = sys.argv[2]
+cos_ifindex_raw = sys.argv[3]
+cells = []
+for raw in sys.argv[4:]:
+    label, exact_port, exact_queue, contender_port, contender_queue = raw.split()
+    cells.append(
+        {
+            "label": label,
+            "exact_port": int(exact_port),
+            "exact_queue": int(exact_queue),
+            "contender_port": int(contender_port),
+            "contender_queue": int(contender_queue),
+            "baseline_dir": f"{label}/baseline",
+            "contended_dir": f"{label}/contended",
+        }
+    )
+manifest = {
+    "cos_interface_name": cos_interface_name,
+    "cos_ifindex": int(cos_ifindex_raw) if cos_ifindex_raw else None,
+    "cells": cells,
+}
+(root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+PY
+
+overall_run_status=0
+for spec in "${selected_cells[@]}"; do
+    read -r label exact_port exact_queue contender_port contender_queue <<< "$spec"
+    cell_dir="$ARTIFACT_ROOT/$label"
+    log "cell=$label exact_port=$exact_port exact_queue=$exact_queue contender_port=$contender_port contender_queue=$contender_queue"
+    if ! run_phase "$cell_dir/baseline" "$exact_port"; then
+        overall_run_status=1
+    fi
+    if ! run_phase "$cell_dir/contended" "$exact_port" "$contender_port"; then
+        overall_run_status=1
+    fi
+done
+
+if [[ "$overall_run_status" -ne 0 ]]; then
+    log "one or more iperf launcher processes returned non-zero; validator will fail closed"
+fi
+
+python3 "$VALIDATOR" "$ARTIFACT_ROOT" \
+    --max-exact-drop-ratio "$MAX_EXACT_DROP_RATIO" \
+    --wrong-queue-sent-bytes-tolerance "$WRONG_QUEUE_SENT_BYTES_TOLERANCE" \
+    --min-expected-sent-bytes "$MIN_EXPECTED_SENT_BYTES"
+validator_status=$?
+
+log "summary: $ARTIFACT_ROOT/summary.tsv"
+log "drain shape: $ARTIFACT_ROOT/drain-shape.tsv"
+exit "$validator_status"

--- a/test/incus/cos-be-contention-harness.sh
+++ b/test/incus/cos-be-contention-harness.sh
@@ -235,6 +235,13 @@ class_selected() {
     return 1
 }
 
+# Format:
+#   label exact_port exact_queue exact_class contender_port contender_queue
+#   contender_class exact_cap_bps min_contender_bps
+#
+# The pressure floor must prove material contention relative to the exact cap:
+# 1G exact cells require 500M contender pressure; 24G exact cells require 1G,
+# which is the remaining headroom under the default 25G root shape.
 cells=(
     "exact5202-vs-5200 5202 2 iperf-1g 5200 0 best-effort 1000000000 500000000"
     "exact5210-vs-5200 5210 10 iperf-24g 5200 0 best-effort 24000000000 1000000000"

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -273,7 +273,11 @@ def _validate_status_capture(phase_dir: Path) -> list[str]:
         if not rc_path.exists():
             failures.append(f"{phase_dir.name}: missing status-{phase}.rc")
             continue
-        rc = read_exit_code(rc_path)
+        try:
+            rc = read_exit_code(rc_path)
+        except ValidationError as exc:
+            failures.append(f"{phase_dir.name}: {exc}")
+            continue
         if rc != 0:
             failures.append(f"{phase_dir.name}: status-{phase} capture exited {rc}")
     return failures
@@ -290,13 +294,35 @@ def analyze_phase(
 ) -> dict[str, Any]:
     failures = _validate_status_capture(phase_dir)
     before_path, during_path, after_path = _phase_status_paths(phase_dir)
-    before_json = load_json(before_path)
-    during_json = load_json(during_path)
-    after_json = load_json(after_path)
+    try:
+        before_json = load_json(before_path)
+    except ValidationError as exc:
+        failures.append(str(exc))
+        return {"verdict": "FAIL", "failure_reasons": failures, "queue_deltas": [], "drain_shape": []}
+    try:
+        during_json = load_json(during_path)
+    except ValidationError as exc:
+        failures.append(str(exc))
+        during_json = before_json
+    try:
+        after_json = load_json(after_path)
+    except ValidationError as exc:
+        failures.append(str(exc))
+        after_json = before_json
     before_shapes = queue_shapes(before_json, interface_name=interface_name, ifindex=ifindex)
     during_shapes = queue_shapes(during_json, interface_name=interface_name, ifindex=ifindex)
     after_shapes = queue_shapes(after_json, interface_name=interface_name, ifindex=ifindex)
     deltas = queue_deltas(before_shapes, after_shapes)
+    during_deltas = queue_deltas(before_shapes, during_shapes)
+
+    for queue_id in sorted(expected_queues):
+        dur_delta = during_deltas.get(queue_id, QueueDelta(queue_id, "-", 0, 0, 0))
+        if dur_delta.sent_bytes < min_expected_sent_bytes:
+            failures.append(
+                f"{phase_dir.name}: expected queue {queue_id} during-snapshot "
+                f"sent_bytes delta {dur_delta.sent_bytes} below {min_expected_sent_bytes}; "
+                "traffic may not have been flowing when during snapshot was taken"
+            )
 
     negative = [
         delta
@@ -362,9 +388,13 @@ def analyze_iperf(phase_dir: Path, roles: tuple[str, ...]) -> tuple[dict[str, An
     summaries: dict[str, Any] = {}
     failures: list[str] = []
     for role in roles:
-        rc = read_exit_code(phase_dir / f"{role}-iperf.rc")
-        if rc != 0:
-            failures.append(f"{phase_dir.name}: {role} iperf exited {rc}")
+        try:
+            rc = read_exit_code(phase_dir / f"{role}-iperf.rc")
+            if rc != 0:
+                failures.append(f"{phase_dir.name}: {role} iperf exited {rc}")
+        except ValidationError as exc:
+            failures.append(f"{phase_dir.name}: {exc}")
+            rc = 1
         try:
             bps = iperf_bps(load_json(phase_dir / f"{role}-iperf.json"))
         except ValidationError as exc:

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -21,6 +21,22 @@ from typing import Any
 DEFAULT_MAX_EXACT_DROP_RATIO = 0.15
 DEFAULT_WRONG_QUEUE_SENT_BYTES_TOLERANCE = 0
 DEFAULT_MIN_EXPECTED_SENT_BYTES = 1
+DEFAULT_MIN_CONTENDER_BPS = 100_000_000.0
+
+FORWARDING_CLASS_BY_PORT = {
+    5200: "best-effort",
+    5201: "iperf-100m",
+    5202: "iperf-1g",
+    5203: "iperf-3g",
+    5204: "iperf-6g",
+    5205: "iperf-9g",
+    5206: "iperf-12g",
+    5207: "iperf-15g",
+    5208: "iperf-18g",
+    5209: "iperf-21g",
+    5210: "iperf-24g",
+    5211: "iperf-uncapped",
+}
 
 
 class ValidationError(ValueError):
@@ -60,6 +76,16 @@ def _nonnegative_int(value: Any, field: str) -> int:
     if value < 0:
         raise ValidationError(f"{field} must be non-negative")
     return value
+
+
+def _forwarding_class(raw: Any, port: Any, field: str) -> str:
+    if raw is not None:
+        if not isinstance(raw, str) or raw == "":
+            raise ValidationError(f"{field} must be a non-empty string")
+        return raw
+    if isinstance(port, int) and port in FORWARDING_CLASS_BY_PORT:
+        return FORWARDING_CLASS_BY_PORT[port]
+    raise ValidationError(f"{field} is required for port {port!r}")
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -211,7 +237,7 @@ def _validate_status_capture(phase_dir: Path) -> list[str]:
 def analyze_phase(
     phase_dir: Path,
     *,
-    expected_queues: set[int],
+    expected_queues: dict[int, str],
     interface_name: str | None,
     ifindex: int | None,
     wrong_queue_sent_bytes_tolerance: int,
@@ -227,12 +253,30 @@ def analyze_phase(
     after_shapes = queue_shapes(after_json, interface_name=interface_name, ifindex=ifindex)
     deltas = queue_deltas(before_shapes, after_shapes)
 
+    negative = [
+        delta
+        for delta in deltas.values()
+        if delta.sent_bytes < 0 or delta.park_root < 0 or delta.park_queue < 0
+    ]
+    if negative:
+        formatted = ", ".join(
+            f"q{d.queue_id}=sent:{d.sent_bytes}/root:{d.park_root}/queue:{d.park_queue}"
+            for d in negative
+        )
+        failures.append(f"{phase_dir.name}: negative DrainShape delta: {formatted}")
+
     for queue_id in sorted(expected_queues):
         delta = deltas.get(queue_id, QueueDelta(queue_id, "-", 0, 0, 0))
         if delta.sent_bytes < min_expected_sent_bytes:
             failures.append(
                 f"{phase_dir.name}: expected queue {queue_id} sent_bytes delta "
                 f"{delta.sent_bytes} below {min_expected_sent_bytes}"
+            )
+        expected_class = expected_queues[queue_id]
+        if expected_class and delta.forwarding_class != expected_class:
+            failures.append(
+                f"{phase_dir.name}: expected queue {queue_id} class {expected_class!r}, "
+                f"got {delta.forwarding_class!r}"
             )
 
     wrong = [
@@ -304,7 +348,12 @@ def validate_artifacts(
     max_exact_drop_ratio: float,
     wrong_queue_sent_bytes_tolerance: int,
     min_expected_sent_bytes: int,
+    min_contender_bps: float,
 ) -> dict[str, Any]:
+    min_contender_bps = _finite_nonnegative_number(
+        min_contender_bps,
+        "min_contender_bps",
+    )
     manifest = load_json(root / "manifest.json")
     cells = manifest.get("cells")
     if not isinstance(cells, list) or not cells:
@@ -324,8 +373,20 @@ def validate_artifacts(
         if not isinstance(cell, dict):
             raise ValidationError(f"manifest.cells[{index}] must be an object")
         label = str(cell.get("label") or f"cell-{index}")
+        exact_port = _nonnegative_int(cell.get("exact_port"), f"{label}.exact_port")
         exact_queue = _nonnegative_int(cell.get("exact_queue"), f"{label}.exact_queue")
+        contender_port = _nonnegative_int(cell.get("contender_port"), f"{label}.contender_port")
         contender_queue = _nonnegative_int(cell.get("contender_queue"), f"{label}.contender_queue")
+        exact_forwarding_class = _forwarding_class(
+            cell.get("exact_forwarding_class"),
+            exact_port,
+            f"{label}.exact_forwarding_class",
+        )
+        contender_forwarding_class = _forwarding_class(
+            cell.get("contender_forwarding_class"),
+            contender_port,
+            f"{label}.contender_forwarding_class",
+        )
         baseline_dir = _resolve_phase_dir(root, cell.get("baseline_dir"), f"{label}.baseline_dir")
         contended_dir = _resolve_phase_dir(root, cell.get("contended_dir"), f"{label}.contended_dir")
 
@@ -333,7 +394,7 @@ def validate_artifacts(
         contended_iperf, contended_iperf_failures = analyze_iperf(contended_dir, ("exact", "contender"))
         baseline_phase = analyze_phase(
             baseline_dir,
-            expected_queues={exact_queue},
+            expected_queues={exact_queue: exact_forwarding_class},
             interface_name=interface_name,
             ifindex=ifindex,
             wrong_queue_sent_bytes_tolerance=wrong_queue_sent_bytes_tolerance,
@@ -341,7 +402,10 @@ def validate_artifacts(
         )
         contended_phase = analyze_phase(
             contended_dir,
-            expected_queues={exact_queue, contender_queue},
+            expected_queues={
+                exact_queue: exact_forwarding_class,
+                contender_queue: contender_forwarding_class,
+            },
             interface_name=interface_name,
             ifindex=ifindex,
             wrong_queue_sent_bytes_tolerance=wrong_queue_sent_bytes_tolerance,
@@ -356,6 +420,7 @@ def validate_artifacts(
         )
         baseline_bps = baseline_iperf["exact"]["bps"]
         contended_exact_bps = contended_iperf["exact"]["bps"]
+        contender_bps = contended_iperf["contender"]["bps"]
         minimum_exact_bps = baseline_bps * (1.0 - max_exact_drop_ratio)
         if baseline_bps <= 0:
             cell_failures.append("exact-alone baseline has zero throughput")
@@ -365,6 +430,12 @@ def validate_artifacts(
                 f"to {contended_exact_bps / 1_000_000.0:.3f} Mbps, below "
                 f"{minimum_exact_bps / 1_000_000.0:.3f} Mbps"
             )
+        if contender_bps < min_contender_bps:
+            cell_failures.append(
+                f"contender throughput {contender_bps / 1_000_000.0:.3f} Mbps below "
+                f"{min_contender_bps / 1_000_000.0:.3f} Mbps; contention pressure "
+                "is too low to prove exact isolation"
+            )
 
         if cell_failures:
             failures.extend(f"{label}: {reason}" for reason in cell_failures)
@@ -372,17 +443,20 @@ def validate_artifacts(
         summary_cells.append(
             {
                 "label": label,
-                "exact_port": cell.get("exact_port"),
+                "exact_port": exact_port,
                 "exact_queue": exact_queue,
-                "contender_port": cell.get("contender_port"),
+                "exact_forwarding_class": exact_forwarding_class,
+                "contender_port": contender_port,
                 "contender_queue": contender_queue,
+                "contender_forwarding_class": contender_forwarding_class,
                 "verdict": "PASS" if not cell_failures else "FAIL",
                 "failure_reasons": cell_failures,
                 "throughput": {
                     "baseline_exact_mbps": baseline_bps / 1_000_000.0,
                     "contended_exact_mbps": contended_exact_bps / 1_000_000.0,
-                    "contender_mbps": contended_iperf["contender"]["bps"] / 1_000_000.0,
+                    "contender_mbps": contender_bps / 1_000_000.0,
                     "minimum_contended_exact_mbps": minimum_exact_bps / 1_000_000.0,
+                    "minimum_contender_mbps": min_contender_bps / 1_000_000.0,
                 },
                 "baseline": {
                     "iperf": baseline_iperf,
@@ -402,6 +476,7 @@ def validate_artifacts(
             "max_exact_drop_ratio": max_exact_drop_ratio,
             "wrong_queue_sent_bytes_tolerance": wrong_queue_sent_bytes_tolerance,
             "min_expected_sent_bytes": min_expected_sent_bytes,
+            "min_contender_bps": min_contender_bps,
         },
         "cos_interface_name": interface_name,
         "cos_ifindex": ifindex,
@@ -483,6 +558,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         default=DEFAULT_MIN_EXPECTED_SENT_BYTES,
     )
+    parser.add_argument(
+        "--min-contender-bps",
+        type=float,
+        default=DEFAULT_MIN_CONTENDER_BPS,
+    )
     return parser.parse_args(argv)
 
 
@@ -494,6 +574,7 @@ def main(argv: list[str]) -> int:
             max_exact_drop_ratio=args.max_exact_drop_ratio,
             wrong_queue_sent_bytes_tolerance=args.wrong_queue_sent_bytes_tolerance,
             min_expected_sent_bytes=args.min_expected_sent_bytes,
+            min_contender_bps=args.min_contender_bps,
         )
     except ValidationError as exc:
         print(f"cos_be_contention_validate: {exc}", file=sys.stderr)

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -22,6 +22,8 @@ DEFAULT_MAX_EXACT_DROP_RATIO = 0.15
 DEFAULT_WRONG_QUEUE_SENT_BYTES_TOLERANCE = 0
 DEFAULT_MIN_EXPECTED_SENT_BYTES = 1
 DEFAULT_MIN_CONTENDER_BPS = 100_000_000.0
+DEFAULT_MIN_EXACT_BASELINE_CAP_RATIO = 0.70
+DEFAULT_ROOT_SHAPE_BPS = 25_000_000_000.0
 
 FORWARDING_CLASS_BY_PORT = {
     5200: "best-effort",
@@ -36,6 +38,19 @@ FORWARDING_CLASS_BY_PORT = {
     5209: "iperf-21g",
     5210: "iperf-24g",
     5211: "iperf-uncapped",
+}
+
+PORT_CAP_BPS_BY_PORT = {
+    5201: 100_000_000.0,
+    5202: 1_000_000_000.0,
+    5203: 3_000_000_000.0,
+    5204: 6_000_000_000.0,
+    5205: 9_000_000_000.0,
+    5206: 12_000_000_000.0,
+    5207: 15_000_000_000.0,
+    5208: 18_000_000_000.0,
+    5209: 21_000_000_000.0,
+    5210: 24_000_000_000.0,
 }
 
 
@@ -82,10 +97,39 @@ def _forwarding_class(raw: Any, port: Any, field: str) -> str:
     if raw is not None:
         if not isinstance(raw, str) or raw == "":
             raise ValidationError(f"{field} must be a non-empty string")
+        if isinstance(port, int) and port in FORWARDING_CLASS_BY_PORT:
+            expected = FORWARDING_CLASS_BY_PORT[port]
+            if raw != expected:
+                raise ValidationError(
+                    f"{field} {raw!r} does not match canonical class {expected!r} "
+                    f"for port {port}"
+                )
         return raw
     if isinstance(port, int) and port in FORWARDING_CLASS_BY_PORT:
         return FORWARDING_CLASS_BY_PORT[port]
     raise ValidationError(f"{field} is required for port {port!r}")
+
+
+def _positive_bps(value: Any, field: str) -> float:
+    out = _finite_nonnegative_number(value, field)
+    if out <= 0:
+        raise ValidationError(f"{field} must be positive")
+    return out
+
+
+def _exact_cap_bps(raw: Any, port: int, field: str) -> float:
+    if raw is not None:
+        return _positive_bps(raw, field)
+    if port in PORT_CAP_BPS_BY_PORT:
+        return PORT_CAP_BPS_BY_PORT[port]
+    raise ValidationError(f"{field} is required for exact port {port}")
+
+
+def _default_min_contender_bps(exact_cap_bps: float, root_shape_bps: float) -> float:
+    root_headroom = max(root_shape_bps - exact_cap_bps, 0.0)
+    if root_headroom > 0:
+        return min(exact_cap_bps * 0.50, root_headroom)
+    return exact_cap_bps * 0.05
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -349,15 +393,24 @@ def validate_artifacts(
     wrong_queue_sent_bytes_tolerance: int,
     min_expected_sent_bytes: int,
     min_contender_bps: float,
+    min_exact_baseline_cap_ratio: float,
 ) -> dict[str, Any]:
     min_contender_bps = _finite_nonnegative_number(
         min_contender_bps,
         "min_contender_bps",
     )
+    min_exact_baseline_cap_ratio = _finite_nonnegative_number(
+        min_exact_baseline_cap_ratio,
+        "min_exact_baseline_cap_ratio",
+    )
     manifest = load_json(root / "manifest.json")
     cells = manifest.get("cells")
     if not isinstance(cells, list) or not cells:
         raise ValidationError("manifest.cells must be a non-empty list")
+    root_shape_bps = _positive_bps(
+        manifest.get("root_shape_bps", DEFAULT_ROOT_SHAPE_BPS),
+        "manifest.root_shape_bps",
+    )
     interface_name = manifest.get("cos_interface_name", "reth0.80")
     if interface_name == "":
         interface_name = None
@@ -365,6 +418,8 @@ def validate_artifacts(
         raise ValidationError("manifest.cos_interface_name must be a string")
     ifindex_raw = manifest.get("cos_ifindex")
     ifindex = None if ifindex_raw in (None, "") else _nonnegative_int(ifindex_raw, "manifest.cos_ifindex")
+    if interface_name is None and ifindex is None:
+        raise ValidationError("manifest must specify cos_interface_name or cos_ifindex")
 
     summary_cells: list[dict[str, Any]] = []
     failures: list[str] = []
@@ -386,6 +441,21 @@ def validate_artifacts(
             cell.get("contender_forwarding_class"),
             contender_port,
             f"{label}.contender_forwarding_class",
+        )
+        exact_cap_bps = _exact_cap_bps(
+            cell.get("exact_cap_bps"),
+            exact_port,
+            f"{label}.exact_cap_bps",
+        )
+        cell_min_contender_bps = max(
+            min_contender_bps,
+            _finite_nonnegative_number(
+                cell.get(
+                    "min_contender_bps",
+                    _default_min_contender_bps(exact_cap_bps, root_shape_bps),
+                ),
+                f"{label}.min_contender_bps",
+            ),
         )
         baseline_dir = _resolve_phase_dir(root, cell.get("baseline_dir"), f"{label}.baseline_dir")
         contended_dir = _resolve_phase_dir(root, cell.get("contended_dir"), f"{label}.contended_dir")
@@ -421,19 +491,24 @@ def validate_artifacts(
         baseline_bps = baseline_iperf["exact"]["bps"]
         contended_exact_bps = contended_iperf["exact"]["bps"]
         contender_bps = contended_iperf["contender"]["bps"]
+        minimum_baseline_bps = exact_cap_bps * min_exact_baseline_cap_ratio
         minimum_exact_bps = baseline_bps * (1.0 - max_exact_drop_ratio)
-        if baseline_bps <= 0:
-            cell_failures.append("exact-alone baseline has zero throughput")
+        if baseline_bps < minimum_baseline_bps:
+            cell_failures.append(
+                f"exact-alone baseline {baseline_bps / 1_000_000.0:.3f} Mbps below "
+                f"{minimum_baseline_bps / 1_000_000.0:.3f} Mbps "
+                f"({min_exact_baseline_cap_ratio:.2%} of {exact_cap_bps / 1_000_000.0:.3f} Mbps cap)"
+            )
         elif contended_exact_bps < minimum_exact_bps:
             cell_failures.append(
                 f"exact throughput dropped from {baseline_bps / 1_000_000.0:.3f} Mbps "
                 f"to {contended_exact_bps / 1_000_000.0:.3f} Mbps, below "
                 f"{minimum_exact_bps / 1_000_000.0:.3f} Mbps"
             )
-        if contender_bps < min_contender_bps:
+        if contender_bps < cell_min_contender_bps:
             cell_failures.append(
                 f"contender throughput {contender_bps / 1_000_000.0:.3f} Mbps below "
-                f"{min_contender_bps / 1_000_000.0:.3f} Mbps; contention pressure "
+                f"{cell_min_contender_bps / 1_000_000.0:.3f} Mbps; contention pressure "
                 "is too low to prove exact isolation"
             )
 
@@ -449,14 +524,18 @@ def validate_artifacts(
                 "contender_port": contender_port,
                 "contender_queue": contender_queue,
                 "contender_forwarding_class": contender_forwarding_class,
+                "exact_cap_bps": exact_cap_bps,
+                "root_shape_bps": root_shape_bps,
                 "verdict": "PASS" if not cell_failures else "FAIL",
                 "failure_reasons": cell_failures,
                 "throughput": {
+                    "exact_cap_mbps": exact_cap_bps / 1_000_000.0,
                     "baseline_exact_mbps": baseline_bps / 1_000_000.0,
                     "contended_exact_mbps": contended_exact_bps / 1_000_000.0,
                     "contender_mbps": contender_bps / 1_000_000.0,
+                    "minimum_baseline_exact_mbps": minimum_baseline_bps / 1_000_000.0,
                     "minimum_contended_exact_mbps": minimum_exact_bps / 1_000_000.0,
-                    "minimum_contender_mbps": min_contender_bps / 1_000_000.0,
+                    "minimum_contender_mbps": cell_min_contender_bps / 1_000_000.0,
                 },
                 "baseline": {
                     "iperf": baseline_iperf,
@@ -477,6 +556,7 @@ def validate_artifacts(
             "wrong_queue_sent_bytes_tolerance": wrong_queue_sent_bytes_tolerance,
             "min_expected_sent_bytes": min_expected_sent_bytes,
             "min_contender_bps": min_contender_bps,
+            "min_exact_baseline_cap_ratio": min_exact_baseline_cap_ratio,
         },
         "cos_interface_name": interface_name,
         "cos_ifindex": ifindex,
@@ -488,8 +568,9 @@ def write_summary_tsv(summary: dict[str, Any], path: Path) -> None:
     with path.open("w", encoding="utf-8") as f:
         f.write(
             "cell\texact_port\texact_queue\tcontender_port\tcontender_queue\tverdict\t"
-            "baseline_exact_mbps\tcontended_exact_mbps\tcontender_mbps\t"
-            "minimum_contended_exact_mbps\tfailure_reasons\n"
+            "exact_cap_mbps\tbaseline_exact_mbps\tminimum_baseline_exact_mbps\t"
+            "contended_exact_mbps\tminimum_contended_exact_mbps\t"
+            "contender_mbps\tminimum_contender_mbps\tfailure_reasons\n"
         )
         for cell in summary["cells"]:
             throughput = cell["throughput"]
@@ -502,10 +583,13 @@ def write_summary_tsv(summary: dict[str, Any], path: Path) -> None:
                         str(cell["contender_port"]),
                         str(cell["contender_queue"]),
                         str(cell["verdict"]),
+                        f"{throughput['exact_cap_mbps']:.3f}",
                         f"{throughput['baseline_exact_mbps']:.3f}",
+                        f"{throughput['minimum_baseline_exact_mbps']:.3f}",
                         f"{throughput['contended_exact_mbps']:.3f}",
-                        f"{throughput['contender_mbps']:.3f}",
                         f"{throughput['minimum_contended_exact_mbps']:.3f}",
+                        f"{throughput['contender_mbps']:.3f}",
+                        f"{throughput['minimum_contender_mbps']:.3f}",
                         "; ".join(cell["failure_reasons"]),
                     ]
                 )
@@ -563,6 +647,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=float,
         default=DEFAULT_MIN_CONTENDER_BPS,
     )
+    parser.add_argument(
+        "--min-exact-baseline-cap-ratio",
+        type=float,
+        default=DEFAULT_MIN_EXACT_BASELINE_CAP_RATIO,
+    )
     return parser.parse_args(argv)
 
 
@@ -575,6 +664,7 @@ def main(argv: list[str]) -> int:
             wrong_queue_sent_bytes_tolerance=args.wrong_queue_sent_bytes_tolerance,
             min_expected_sent_bytes=args.min_expected_sent_bytes,
             min_contender_bps=args.min_contender_bps,
+            min_exact_baseline_cap_ratio=args.min_exact_baseline_cap_ratio,
         )
     except ValidationError as exc:
         print(f"cos_be_contention_validate: {exc}", file=sys.stderr)

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -23,6 +23,7 @@ DEFAULT_WRONG_QUEUE_SENT_BYTES_TOLERANCE = 0
 DEFAULT_MIN_EXPECTED_SENT_BYTES = 1
 DEFAULT_MIN_CONTENDER_BPS = 100_000_000.0
 DEFAULT_MIN_EXACT_BASELINE_CAP_RATIO = 0.70
+DEFAULT_MIN_CONTENDED_ROOT_PRESSURE_RATIO = 0.90
 DEFAULT_ROOT_SHAPE_BPS = 25_000_000_000.0
 
 FORWARDING_CLASS_BY_PORT = {
@@ -394,6 +395,7 @@ def validate_artifacts(
     min_expected_sent_bytes: int,
     min_contender_bps: float,
     min_exact_baseline_cap_ratio: float,
+    min_contended_root_pressure_ratio: float,
 ) -> dict[str, Any]:
     min_contender_bps = _finite_nonnegative_number(
         min_contender_bps,
@@ -402,6 +404,10 @@ def validate_artifacts(
     min_exact_baseline_cap_ratio = _finite_nonnegative_number(
         min_exact_baseline_cap_ratio,
         "min_exact_baseline_cap_ratio",
+    )
+    min_contended_root_pressure_ratio = _finite_nonnegative_number(
+        min_contended_root_pressure_ratio,
+        "min_contended_root_pressure_ratio",
     )
     manifest = load_json(root / "manifest.json")
     cells = manifest.get("cells")
@@ -491,8 +497,10 @@ def validate_artifacts(
         baseline_bps = baseline_iperf["exact"]["bps"]
         contended_exact_bps = contended_iperf["exact"]["bps"]
         contender_bps = contended_iperf["contender"]["bps"]
+        contended_total_bps = contended_exact_bps + contender_bps
         minimum_baseline_bps = exact_cap_bps * min_exact_baseline_cap_ratio
         minimum_exact_bps = baseline_bps * (1.0 - max_exact_drop_ratio)
+        minimum_contended_total_bps = root_shape_bps * min_contended_root_pressure_ratio
         if baseline_bps < minimum_baseline_bps:
             cell_failures.append(
                 f"exact-alone baseline {baseline_bps / 1_000_000.0:.3f} Mbps below "
@@ -510,6 +518,14 @@ def validate_artifacts(
                 f"contender throughput {contender_bps / 1_000_000.0:.3f} Mbps below "
                 f"{cell_min_contender_bps / 1_000_000.0:.3f} Mbps; contention pressure "
                 "is too low to prove exact isolation"
+            )
+        if contended_total_bps < minimum_contended_total_bps:
+            cell_failures.append(
+                f"contended total throughput {contended_total_bps / 1_000_000.0:.3f} Mbps below "
+                f"{minimum_contended_total_bps / 1_000_000.0:.3f} Mbps "
+                f"({min_contended_root_pressure_ratio:.2%} of root shape "
+                f"{root_shape_bps / 1_000_000.0:.3f} Mbps); root pressure is too low "
+                "to prove best-effort/uncapped isolation"
             )
 
         if cell_failures:
@@ -533,9 +549,11 @@ def validate_artifacts(
                     "baseline_exact_mbps": baseline_bps / 1_000_000.0,
                     "contended_exact_mbps": contended_exact_bps / 1_000_000.0,
                     "contender_mbps": contender_bps / 1_000_000.0,
+                    "contended_total_mbps": contended_total_bps / 1_000_000.0,
                     "minimum_baseline_exact_mbps": minimum_baseline_bps / 1_000_000.0,
                     "minimum_contended_exact_mbps": minimum_exact_bps / 1_000_000.0,
                     "minimum_contender_mbps": cell_min_contender_bps / 1_000_000.0,
+                    "minimum_contended_total_mbps": minimum_contended_total_bps / 1_000_000.0,
                 },
                 "baseline": {
                     "iperf": baseline_iperf,
@@ -557,6 +575,7 @@ def validate_artifacts(
             "min_expected_sent_bytes": min_expected_sent_bytes,
             "min_contender_bps": min_contender_bps,
             "min_exact_baseline_cap_ratio": min_exact_baseline_cap_ratio,
+            "min_contended_root_pressure_ratio": min_contended_root_pressure_ratio,
         },
         "cos_interface_name": interface_name,
         "cos_ifindex": ifindex,
@@ -570,7 +589,8 @@ def write_summary_tsv(summary: dict[str, Any], path: Path) -> None:
             "cell\texact_port\texact_queue\tcontender_port\tcontender_queue\tverdict\t"
             "exact_cap_mbps\tbaseline_exact_mbps\tminimum_baseline_exact_mbps\t"
             "contended_exact_mbps\tminimum_contended_exact_mbps\t"
-            "contender_mbps\tminimum_contender_mbps\tfailure_reasons\n"
+            "contender_mbps\tminimum_contender_mbps\t"
+            "contended_total_mbps\tminimum_contended_total_mbps\tfailure_reasons\n"
         )
         for cell in summary["cells"]:
             throughput = cell["throughput"]
@@ -590,6 +610,8 @@ def write_summary_tsv(summary: dict[str, Any], path: Path) -> None:
                         f"{throughput['minimum_contended_exact_mbps']:.3f}",
                         f"{throughput['contender_mbps']:.3f}",
                         f"{throughput['minimum_contender_mbps']:.3f}",
+                        f"{throughput['contended_total_mbps']:.3f}",
+                        f"{throughput['minimum_contended_total_mbps']:.3f}",
                         "; ".join(cell["failure_reasons"]),
                     ]
                 )
@@ -652,6 +674,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=float,
         default=DEFAULT_MIN_EXACT_BASELINE_CAP_RATIO,
     )
+    parser.add_argument(
+        "--min-contended-root-pressure-ratio",
+        type=float,
+        default=DEFAULT_MIN_CONTENDED_ROOT_PRESSURE_RATIO,
+    )
     return parser.parse_args(argv)
 
 
@@ -665,6 +692,7 @@ def main(argv: list[str]) -> int:
             min_expected_sent_bytes=args.min_expected_sent_bytes,
             min_contender_bps=args.min_contender_bps,
             min_exact_baseline_cap_ratio=args.min_exact_baseline_cap_ratio,
+            min_contended_root_pressure_ratio=args.min_contended_root_pressure_ratio,
         )
     except ValidationError as exc:
         print(f"cos_be_contention_validate: {exc}", file=sys.stderr)

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Validate CoS exact-vs-best-effort contention harness artifacts.
+
+The live shell harness records a manifest, iperf3 JSON summaries, iperf exit
+codes, and before/during/after userspace dataplane status snapshots. This
+module deliberately validates only those reduced artifacts so CI can exercise
+the fail-closed rules without a running Incus cluster.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any
+
+
+DEFAULT_MAX_EXACT_DROP_RATIO = 0.15
+DEFAULT_WRONG_QUEUE_SENT_BYTES_TOLERANCE = 0
+DEFAULT_MIN_EXPECTED_SENT_BYTES = 1
+
+
+class ValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class QueueShape:
+    queue_id: int
+    forwarding_class: str
+    sent_bytes: int
+    park_root: int
+    park_queue: int
+
+
+@dataclass(frozen=True)
+class QueueDelta:
+    queue_id: int
+    forwarding_class: str
+    sent_bytes: int
+    park_root: int
+    park_queue: int
+
+
+def _finite_nonnegative_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{field} must be a number")
+    out = float(value)
+    if not math.isfinite(out) or out < 0:
+        raise ValidationError(f"{field} must be finite and non-negative")
+    return out
+
+
+def _nonnegative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError(f"{field} must be an integer")
+    if value < 0:
+        raise ValidationError(f"{field} must be non-negative")
+    return value
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            value = json.load(f)
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing JSON artifact: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON artifact {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"JSON artifact must be an object: {path}")
+    return value
+
+
+def read_exit_code(path: Path) -> int:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing exit-code artifact: {path}") from exc
+    try:
+        code = int(raw)
+    except ValueError as exc:
+        raise ValidationError(f"invalid exit-code artifact {path}: {raw!r}") from exc
+    if code < 0:
+        raise ValidationError(f"invalid negative exit code in {path}: {code}")
+    return code
+
+
+def iperf_bps(artifact: dict[str, Any]) -> float:
+    """Return the receiver-side iperf3 bits/sec summary when available."""
+    end = artifact.get("end")
+    if not isinstance(end, dict):
+        raise ValidationError("iperf JSON missing object field end")
+
+    candidate_paths = (
+        ("end", "sum_received", "bits_per_second"),
+        ("end", "sum", "bits_per_second"),
+        ("end", "sum_sent", "bits_per_second"),
+    )
+    for _root, section, field in candidate_paths:
+        value = end.get(section)
+        if isinstance(value, dict) and field in value:
+            bps = _finite_nonnegative_number(value[field], f"iperf.{section}.{field}")
+            if bps > 0:
+                return bps
+    raise ValidationError("iperf JSON has no positive end summary bits_per_second")
+
+
+def _status_object(snapshot: dict[str, Any]) -> dict[str, Any]:
+    status = snapshot.get("status", snapshot)
+    if not isinstance(status, dict):
+        raise ValidationError("status snapshot must be an object")
+    return status
+
+
+def queue_shapes(
+    snapshot: dict[str, Any],
+    *,
+    interface_name: str | None = None,
+    ifindex: int | None = None,
+) -> dict[int, QueueShape]:
+    status = _status_object(snapshot)
+    cos_interfaces = status.get("cos_interfaces", [])
+    if not isinstance(cos_interfaces, list):
+        raise ValidationError("status.cos_interfaces must be a list")
+
+    shapes: dict[int, QueueShape] = {}
+    for iface_index, iface in enumerate(cos_interfaces):
+        if not isinstance(iface, dict):
+            raise ValidationError(f"status.cos_interfaces[{iface_index}] must be an object")
+        name = iface.get("interface_name")
+        iface_ifindex = iface.get("ifindex")
+        if interface_name and name != interface_name:
+            continue
+        if ifindex is not None and iface_ifindex != ifindex:
+            continue
+        queues = iface.get("queues", [])
+        if not isinstance(queues, list):
+            raise ValidationError(f"status.cos_interfaces[{iface_index}].queues must be a list")
+        for queue_index, queue in enumerate(queues):
+            if not isinstance(queue, dict):
+                raise ValidationError(
+                    f"status.cos_interfaces[{iface_index}].queues[{queue_index}] must be an object"
+                )
+            queue_id = _nonnegative_int(queue.get("queue_id"), "queue.queue_id")
+            previous = shapes.get(queue_id)
+            sent = _nonnegative_int(queue.get("drain_sent_bytes", 0), "queue.drain_sent_bytes")
+            root = _nonnegative_int(
+                queue.get("drain_park_root_tokens", 0),
+                "queue.drain_park_root_tokens",
+            )
+            queue_park = _nonnegative_int(
+                queue.get("drain_park_queue_tokens", 0),
+                "queue.drain_park_queue_tokens",
+            )
+            forwarding_class = str(queue.get("forwarding_class", "-"))
+            current = QueueShape(queue_id, forwarding_class, sent, root, queue_park)
+            if previous is None:
+                shapes[queue_id] = current
+            else:
+                shapes[queue_id] = QueueShape(
+                    queue_id=queue_id,
+                    forwarding_class=previous.forwarding_class,
+                    sent_bytes=previous.sent_bytes + current.sent_bytes,
+                    park_root=previous.park_root + current.park_root,
+                    park_queue=previous.park_queue + current.park_queue,
+                )
+    return shapes
+
+
+def queue_deltas(before: dict[int, QueueShape], after: dict[int, QueueShape]) -> dict[int, QueueDelta]:
+    queue_ids = set(before) | set(after)
+    deltas: dict[int, QueueDelta] = {}
+    for queue_id in sorted(queue_ids):
+        b = before.get(queue_id, QueueShape(queue_id, "-", 0, 0, 0))
+        a = after.get(queue_id, QueueShape(queue_id, b.forwarding_class, 0, 0, 0))
+        deltas[queue_id] = QueueDelta(
+            queue_id=queue_id,
+            forwarding_class=a.forwarding_class,
+            sent_bytes=a.sent_bytes - b.sent_bytes,
+            park_root=a.park_root - b.park_root,
+            park_queue=a.park_queue - b.park_queue,
+        )
+    return deltas
+
+
+def _phase_status_paths(phase_dir: Path) -> tuple[Path, Path, Path]:
+    return (
+        phase_dir / "status-before.json",
+        phase_dir / "status-during.json",
+        phase_dir / "status-after.json",
+    )
+
+
+def _validate_status_capture(phase_dir: Path) -> list[str]:
+    failures: list[str] = []
+    for phase in ("before", "during", "after"):
+        rc_path = phase_dir / f"status-{phase}.rc"
+        if not rc_path.exists():
+            failures.append(f"{phase_dir.name}: missing status-{phase}.rc")
+            continue
+        rc = read_exit_code(rc_path)
+        if rc != 0:
+            failures.append(f"{phase_dir.name}: status-{phase} capture exited {rc}")
+    return failures
+
+
+def analyze_phase(
+    phase_dir: Path,
+    *,
+    expected_queues: set[int],
+    interface_name: str | None,
+    ifindex: int | None,
+    wrong_queue_sent_bytes_tolerance: int,
+    min_expected_sent_bytes: int,
+) -> dict[str, Any]:
+    failures = _validate_status_capture(phase_dir)
+    before_path, during_path, after_path = _phase_status_paths(phase_dir)
+    before_json = load_json(before_path)
+    during_json = load_json(during_path)
+    after_json = load_json(after_path)
+    before_shapes = queue_shapes(before_json, interface_name=interface_name, ifindex=ifindex)
+    during_shapes = queue_shapes(during_json, interface_name=interface_name, ifindex=ifindex)
+    after_shapes = queue_shapes(after_json, interface_name=interface_name, ifindex=ifindex)
+    deltas = queue_deltas(before_shapes, after_shapes)
+
+    for queue_id in sorted(expected_queues):
+        delta = deltas.get(queue_id, QueueDelta(queue_id, "-", 0, 0, 0))
+        if delta.sent_bytes < min_expected_sent_bytes:
+            failures.append(
+                f"{phase_dir.name}: expected queue {queue_id} sent_bytes delta "
+                f"{delta.sent_bytes} below {min_expected_sent_bytes}"
+            )
+
+    wrong = [
+        delta
+        for queue_id, delta in sorted(deltas.items())
+        if queue_id not in expected_queues
+        and delta.sent_bytes > wrong_queue_sent_bytes_tolerance
+    ]
+    if wrong:
+        formatted = ", ".join(f"q{d.queue_id}={d.sent_bytes}" for d in wrong)
+        failures.append(
+            f"{phase_dir.name}: unexpected queue drain sent_bytes above "
+            f"{wrong_queue_sent_bytes_tolerance}: {formatted}"
+        )
+
+    shape_rows = [
+        {
+            "queue_id": queue_id,
+            "class": delta.forwarding_class,
+            "sent_bytes_delta": delta.sent_bytes,
+            "park_root_delta": delta.park_root,
+            "park_queue_delta": delta.park_queue,
+            "before": before_shapes.get(queue_id).__dict__ if queue_id in before_shapes else None,
+            "during": during_shapes.get(queue_id).__dict__ if queue_id in during_shapes else None,
+            "after": after_shapes.get(queue_id).__dict__ if queue_id in after_shapes else None,
+        }
+        for queue_id, delta in sorted(deltas.items())
+    ]
+    return {
+        "verdict": "PASS" if not failures else "FAIL",
+        "failure_reasons": failures,
+        "queue_deltas": [delta.__dict__ for delta in deltas.values()],
+        "drain_shape": shape_rows,
+    }
+
+
+def analyze_iperf(phase_dir: Path, roles: tuple[str, ...]) -> tuple[dict[str, Any], list[str]]:
+    summaries: dict[str, Any] = {}
+    failures: list[str] = []
+    for role in roles:
+        rc = read_exit_code(phase_dir / f"{role}-iperf.rc")
+        if rc != 0:
+            failures.append(f"{phase_dir.name}: {role} iperf exited {rc}")
+        try:
+            bps = iperf_bps(load_json(phase_dir / f"{role}-iperf.json"))
+        except ValidationError as exc:
+            failures.append(f"{phase_dir.name}: {role} {exc}")
+            bps = 0.0
+        summaries[role] = {
+            "bps": bps,
+            "mbps": bps / 1_000_000.0,
+            "exit_code": rc,
+        }
+    return summaries, failures
+
+
+def _resolve_phase_dir(root: Path, raw: Any, field: str) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise ValidationError(f"manifest cell missing non-empty {field}")
+    path = Path(raw)
+    if not path.is_absolute():
+        path = root / path
+    return path
+
+
+def validate_artifacts(
+    root: Path,
+    *,
+    max_exact_drop_ratio: float,
+    wrong_queue_sent_bytes_tolerance: int,
+    min_expected_sent_bytes: int,
+) -> dict[str, Any]:
+    manifest = load_json(root / "manifest.json")
+    cells = manifest.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise ValidationError("manifest.cells must be a non-empty list")
+    interface_name = manifest.get("cos_interface_name", "reth0.80")
+    if interface_name == "":
+        interface_name = None
+    if interface_name is not None and not isinstance(interface_name, str):
+        raise ValidationError("manifest.cos_interface_name must be a string")
+    ifindex_raw = manifest.get("cos_ifindex")
+    ifindex = None if ifindex_raw in (None, "") else _nonnegative_int(ifindex_raw, "manifest.cos_ifindex")
+
+    summary_cells: list[dict[str, Any]] = []
+    failures: list[str] = []
+
+    for index, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            raise ValidationError(f"manifest.cells[{index}] must be an object")
+        label = str(cell.get("label") or f"cell-{index}")
+        exact_queue = _nonnegative_int(cell.get("exact_queue"), f"{label}.exact_queue")
+        contender_queue = _nonnegative_int(cell.get("contender_queue"), f"{label}.contender_queue")
+        baseline_dir = _resolve_phase_dir(root, cell.get("baseline_dir"), f"{label}.baseline_dir")
+        contended_dir = _resolve_phase_dir(root, cell.get("contended_dir"), f"{label}.contended_dir")
+
+        baseline_iperf, baseline_iperf_failures = analyze_iperf(baseline_dir, ("exact",))
+        contended_iperf, contended_iperf_failures = analyze_iperf(contended_dir, ("exact", "contender"))
+        baseline_phase = analyze_phase(
+            baseline_dir,
+            expected_queues={exact_queue},
+            interface_name=interface_name,
+            ifindex=ifindex,
+            wrong_queue_sent_bytes_tolerance=wrong_queue_sent_bytes_tolerance,
+            min_expected_sent_bytes=min_expected_sent_bytes,
+        )
+        contended_phase = analyze_phase(
+            contended_dir,
+            expected_queues={exact_queue, contender_queue},
+            interface_name=interface_name,
+            ifindex=ifindex,
+            wrong_queue_sent_bytes_tolerance=wrong_queue_sent_bytes_tolerance,
+            min_expected_sent_bytes=min_expected_sent_bytes,
+        )
+
+        cell_failures = (
+            baseline_iperf_failures
+            + contended_iperf_failures
+            + baseline_phase["failure_reasons"]
+            + contended_phase["failure_reasons"]
+        )
+        baseline_bps = baseline_iperf["exact"]["bps"]
+        contended_exact_bps = contended_iperf["exact"]["bps"]
+        minimum_exact_bps = baseline_bps * (1.0 - max_exact_drop_ratio)
+        if baseline_bps <= 0:
+            cell_failures.append("exact-alone baseline has zero throughput")
+        elif contended_exact_bps < minimum_exact_bps:
+            cell_failures.append(
+                f"exact throughput dropped from {baseline_bps / 1_000_000.0:.3f} Mbps "
+                f"to {contended_exact_bps / 1_000_000.0:.3f} Mbps, below "
+                f"{minimum_exact_bps / 1_000_000.0:.3f} Mbps"
+            )
+
+        if cell_failures:
+            failures.extend(f"{label}: {reason}" for reason in cell_failures)
+
+        summary_cells.append(
+            {
+                "label": label,
+                "exact_port": cell.get("exact_port"),
+                "exact_queue": exact_queue,
+                "contender_port": cell.get("contender_port"),
+                "contender_queue": contender_queue,
+                "verdict": "PASS" if not cell_failures else "FAIL",
+                "failure_reasons": cell_failures,
+                "throughput": {
+                    "baseline_exact_mbps": baseline_bps / 1_000_000.0,
+                    "contended_exact_mbps": contended_exact_bps / 1_000_000.0,
+                    "contender_mbps": contended_iperf["contender"]["bps"] / 1_000_000.0,
+                    "minimum_contended_exact_mbps": minimum_exact_bps / 1_000_000.0,
+                },
+                "baseline": {
+                    "iperf": baseline_iperf,
+                    "dataplane": baseline_phase,
+                },
+                "contended": {
+                    "iperf": contended_iperf,
+                    "dataplane": contended_phase,
+                },
+            }
+        )
+
+    return {
+        "verdict": "PASS" if not failures else "FAIL",
+        "failure_reasons": failures,
+        "thresholds": {
+            "max_exact_drop_ratio": max_exact_drop_ratio,
+            "wrong_queue_sent_bytes_tolerance": wrong_queue_sent_bytes_tolerance,
+            "min_expected_sent_bytes": min_expected_sent_bytes,
+        },
+        "cos_interface_name": interface_name,
+        "cos_ifindex": ifindex,
+        "cells": summary_cells,
+    }
+
+
+def write_summary_tsv(summary: dict[str, Any], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write(
+            "cell\texact_port\texact_queue\tcontender_port\tcontender_queue\tverdict\t"
+            "baseline_exact_mbps\tcontended_exact_mbps\tcontender_mbps\t"
+            "minimum_contended_exact_mbps\tfailure_reasons\n"
+        )
+        for cell in summary["cells"]:
+            throughput = cell["throughput"]
+            f.write(
+                "\t".join(
+                    [
+                        str(cell["label"]),
+                        str(cell["exact_port"]),
+                        str(cell["exact_queue"]),
+                        str(cell["contender_port"]),
+                        str(cell["contender_queue"]),
+                        str(cell["verdict"]),
+                        f"{throughput['baseline_exact_mbps']:.3f}",
+                        f"{throughput['contended_exact_mbps']:.3f}",
+                        f"{throughput['contender_mbps']:.3f}",
+                        f"{throughput['minimum_contended_exact_mbps']:.3f}",
+                        "; ".join(cell["failure_reasons"]),
+                    ]
+                )
+                + "\n"
+            )
+
+
+def write_drain_shape_tsv(summary: dict[str, Any], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        f.write(
+            "cell\tphase\tqueue_id\tclass\tsent_bytes_delta\tpark_root_delta\tpark_queue_delta\n"
+        )
+        for cell in summary["cells"]:
+            for phase_name in ("baseline", "contended"):
+                for delta in cell[phase_name]["dataplane"]["queue_deltas"]:
+                    f.write(
+                        "\t".join(
+                            [
+                                str(cell["label"]),
+                                phase_name,
+                                str(delta["queue_id"]),
+                                str(delta["forwarding_class"]),
+                                str(delta["sent_bytes"]),
+                                str(delta["park_root"]),
+                                str(delta["park_queue"]),
+                            ]
+                        )
+                        + "\n"
+                    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact_root", type=Path)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--summary-tsv", type=Path)
+    parser.add_argument("--drain-shape-tsv", type=Path)
+    parser.add_argument(
+        "--max-exact-drop-ratio",
+        type=float,
+        default=DEFAULT_MAX_EXACT_DROP_RATIO,
+    )
+    parser.add_argument(
+        "--wrong-queue-sent-bytes-tolerance",
+        type=int,
+        default=DEFAULT_WRONG_QUEUE_SENT_BYTES_TOLERANCE,
+    )
+    parser.add_argument(
+        "--min-expected-sent-bytes",
+        type=int,
+        default=DEFAULT_MIN_EXPECTED_SENT_BYTES,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        summary = validate_artifacts(
+            args.artifact_root,
+            max_exact_drop_ratio=args.max_exact_drop_ratio,
+            wrong_queue_sent_bytes_tolerance=args.wrong_queue_sent_bytes_tolerance,
+            min_expected_sent_bytes=args.min_expected_sent_bytes,
+        )
+    except ValidationError as exc:
+        print(f"cos_be_contention_validate: {exc}", file=sys.stderr)
+        return 2
+
+    summary_json = args.summary_json or args.artifact_root / "summary.json"
+    summary_tsv = args.summary_tsv or args.artifact_root / "summary.tsv"
+    drain_shape_tsv = args.drain_shape_tsv or args.artifact_root / "drain-shape.tsv"
+    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_summary_tsv(summary, summary_tsv)
+    write_drain_shape_tsv(summary, drain_shape_tsv)
+    print(f"cos_be_contention_validate: wrote {summary_json}")
+    print(f"cos_be_contention_validate: wrote {summary_tsv}")
+    print(f"cos_be_contention_validate: wrote {drain_shape_tsv}")
+    return 0 if summary["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/incus/cos_be_contention_validate.py
+++ b/test/incus/cos_be_contention_validate.py
@@ -276,7 +276,7 @@ def _validate_status_capture(phase_dir: Path) -> list[str]:
         try:
             rc = read_exit_code(rc_path)
         except ValidationError as exc:
-            failures.append(f"{phase_dir.name}: {exc}")
+            failures.append(f"{phase_dir.name}: failed to read status-{phase} exit code: {exc}")
             continue
         if rc != 0:
             failures.append(f"{phase_dir.name}: status-{phase} capture exited {rc}")
@@ -303,11 +303,15 @@ def analyze_phase(
         during_json = load_json(during_path)
     except ValidationError as exc:
         failures.append(str(exc))
+        # Fall back to before_json so during_deltas are zero; the during gate
+        # below will then fail for every expected queue (zero < min_expected_sent_bytes).
         during_json = before_json
     try:
         after_json = load_json(after_path)
     except ValidationError as exc:
         failures.append(str(exc))
+        # Fall back to before_json so deltas are zero; expected-queue sent-bytes
+        # checks below will then FAIL for each expected queue.
         after_json = before_json
     before_shapes = queue_shapes(before_json, interface_name=interface_name, ifindex=ifindex)
     during_shapes = queue_shapes(during_json, interface_name=interface_name, ifindex=ifindex)
@@ -393,7 +397,7 @@ def analyze_iperf(phase_dir: Path, roles: tuple[str, ...]) -> tuple[dict[str, An
             if rc != 0:
                 failures.append(f"{phase_dir.name}: {role} iperf exited {rc}")
         except ValidationError as exc:
-            failures.append(f"{phase_dir.name}: {exc}")
+            failures.append(f"{phase_dir.name}: failed to read {role} iperf exit code: {exc}")
             rc = 1
         try:
             bps = iperf_bps(load_json(phase_dir / f"{role}-iperf.json"))

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -125,6 +125,7 @@ def _validate(root: Path) -> dict:
         min_expected_sent_bytes=1,
         min_contender_bps=100_000_000.0,
         min_exact_baseline_cap_ratio=0.70,
+        min_contended_root_pressure_ratio=0.90,
     )
 
 
@@ -146,7 +147,7 @@ class CoSBEContentionValidateTests(unittest.TestCase):
                 during=_status(q0=800, q2=1600),
                 after=_status(q0=1200, q2=1950),
                 exact_bps=920_000_000,
-                contender_bps=15_000_000_000,
+                contender_bps=24_000_000_000,
             )
 
             summary = _validate(root)
@@ -157,6 +158,8 @@ class CoSBEContentionValidateTests(unittest.TestCase):
             self.assertEqual(throughput["exact_cap_mbps"], 1000.0)
             self.assertEqual(throughput["minimum_baseline_exact_mbps"], 700.0)
             self.assertEqual(throughput["minimum_contender_mbps"], 500.0)
+            self.assertEqual(throughput["contended_total_mbps"], 24920.0)
+            self.assertEqual(throughput["minimum_contended_total_mbps"], 22500.0)
             self.assertEqual(summary["cells"][0]["contended"]["dataplane"]["verdict"], "PASS")
 
     def test_default_contender_threshold_math_for_canonical_cells(self) -> None:
@@ -382,6 +385,44 @@ class CoSBEContentionValidateTests(unittest.TestCase):
 
             self.assertEqual(summary["verdict"], "FAIL")
             self.assertTrue(any("exact-alone baseline" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_when_contended_total_does_not_prove_root_pressure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(
+                root,
+                {
+                    "label": "exact5210-vs-5200",
+                    "exact_port": 5210,
+                    "exact_queue": 10,
+                    "exact_forwarding_class": "iperf-24g",
+                    "contender_port": 5200,
+                    "contender_queue": 0,
+                    "contender_forwarding_class": "best-effort",
+                    "baseline_dir": "cell/baseline",
+                    "contended_dir": "cell/contended",
+                },
+            )
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q10=0),
+                during=_status(q10=100),
+                after=_status(q10=200),
+                exact_bps=16_800_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q10=200),
+                during=_status(q0=100, q10=300),
+                after=_status(q0=200, q10=400),
+                exact_bps=14_280_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("root pressure is too low" in reason for reason in summary["failure_reasons"]))
 
     def test_fails_cell_specific_contender_pressure_for_24g_exact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("cos_be_contention_validate.py")
+SPEC = importlib.util.spec_from_file_location("cos_be_contention_validate", MODULE_PATH)
+assert SPEC is not None
+cos_validate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["cos_be_contention_validate"] = cos_validate
+SPEC.loader.exec_module(cos_validate)
+
+
+def _iperf_json(bps: float) -> dict:
+    return {"end": {"sum_received": {"bits_per_second": bps}}}
+
+
+def _status(*, q0: int = 0, q2: int = 0, q10: int = 0, q11: int = 0) -> dict:
+    queues = [
+        {
+            "queue_id": 0,
+            "forwarding_class": "best-effort",
+            "drain_sent_bytes": q0,
+            "drain_park_root_tokens": 1,
+            "drain_park_queue_tokens": 2,
+        },
+        {
+            "queue_id": 2,
+            "forwarding_class": "iperf-1g",
+            "drain_sent_bytes": q2,
+            "drain_park_root_tokens": 3,
+            "drain_park_queue_tokens": 4,
+        },
+        {
+            "queue_id": 10,
+            "forwarding_class": "iperf-24g",
+            "drain_sent_bytes": q10,
+            "drain_park_root_tokens": 5,
+            "drain_park_queue_tokens": 6,
+        },
+        {
+            "queue_id": 11,
+            "forwarding_class": "iperf-uncapped",
+            "drain_sent_bytes": q11,
+            "drain_park_root_tokens": 7,
+            "drain_park_queue_tokens": 8,
+        },
+    ]
+    return {
+        "status": {
+            "cos_interfaces": [
+                {
+                    "ifindex": 14,
+                    "interface_name": "reth0.80",
+                    "queues": queues,
+                }
+            ]
+        }
+    }
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+def _write_phase(
+    phase_dir: Path,
+    *,
+    before: dict,
+    during: dict,
+    after: dict,
+    exact_bps: float,
+    contender_bps: float | None = None,
+    exact_rc: int = 0,
+    contender_rc: int = 0,
+) -> None:
+    phase_dir.mkdir(parents=True)
+    _write_json(phase_dir / "status-before.json", before)
+    _write_json(phase_dir / "status-during.json", during)
+    _write_json(phase_dir / "status-after.json", after)
+    for phase in ("before", "during", "after"):
+        (phase_dir / f"status-{phase}.rc").write_text("0\n", encoding="utf-8")
+    _write_json(phase_dir / "exact-iperf.json", _iperf_json(exact_bps))
+    (phase_dir / "exact-iperf.rc").write_text(f"{exact_rc}\n", encoding="utf-8")
+    if contender_bps is not None:
+        _write_json(phase_dir / "contender-iperf.json", _iperf_json(contender_bps))
+        (phase_dir / "contender-iperf.rc").write_text(f"{contender_rc}\n", encoding="utf-8")
+
+
+def _write_manifest(root: Path, cell: dict | None = None) -> None:
+    if cell is None:
+        cell = {
+            "label": "exact5202-vs-5200",
+            "exact_port": 5202,
+            "exact_queue": 2,
+            "contender_port": 5200,
+            "contender_queue": 0,
+            "baseline_dir": "cell/baseline",
+            "contended_dir": "cell/contended",
+        }
+    _write_json(
+        root / "manifest.json",
+        {
+            "cos_interface_name": "reth0.80",
+            "cells": [cell],
+        },
+    )
+
+
+def _validate(root: Path) -> dict:
+    return cos_validate.validate_artifacts(
+        root,
+        max_exact_drop_ratio=0.15,
+        wrong_queue_sent_bytes_tolerance=0,
+        min_expected_sent_bytes=1,
+    )
+
+
+class CoSBEContentionValidateTests(unittest.TestCase):
+    def test_passes_expected_exact_and_contender_drain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=100),
+                during=_status(q2=600),
+                after=_status(q2=1100),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=200, q2=1100),
+                during=_status(q0=800, q2=1600),
+                after=_status(q0=1200, q2=1950),
+                exact_bps=920_000_000,
+                contender_bps=15_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "PASS")
+            self.assertEqual(summary["failure_reasons"], [])
+            self.assertEqual(summary["cells"][0]["contended"]["dataplane"]["verdict"], "PASS")
+
+    def test_fails_nonzero_iperf_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=0),
+                during=_status(q2=10),
+                after=_status(q2=20),
+                exact_bps=1_000_000_000,
+                exact_rc=1,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=20),
+                during=_status(q0=10, q2=30),
+                after=_status(q0=20, q2=40),
+                exact_bps=1_000_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("iperf exited 1" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_when_expected_queue_does_not_drain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=100),
+                during=_status(q2=100),
+                after=_status(q2=100),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=100),
+                during=_status(q0=10, q2=110),
+                after=_status(q0=20, q2=120),
+                exact_bps=1_000_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("expected queue 2" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_when_unexpected_queue_drains(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=100, q10=10),
+                during=_status(q2=500, q10=20),
+                after=_status(q2=900, q10=30),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=900),
+                during=_status(q0=10, q2=910),
+                after=_status(q0=20, q2=920),
+                exact_bps=1_000_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("unexpected queue drain" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_material_exact_throughput_drop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=0),
+                during=_status(q2=100),
+                after=_status(q2=200),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=100, q2=250),
+                after=_status(q0=200, q2=300),
+                exact_bps=800_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("exact throughput dropped" in reason for reason in summary["failure_reasons"]))
+
+    def test_iperf_parser_prefers_sum_received(self) -> None:
+        artifact = {
+            "end": {
+                "sum_sent": {"bits_per_second": 999},
+                "sum_received": {"bits_per_second": 123},
+            }
+        }
+        self.assertEqual(cos_validate.iperf_bps(artifact), 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -153,7 +153,23 @@ class CoSBEContentionValidateTests(unittest.TestCase):
 
             self.assertEqual(summary["verdict"], "PASS")
             self.assertEqual(summary["failure_reasons"], [])
+            throughput = summary["cells"][0]["throughput"]
+            self.assertEqual(throughput["exact_cap_mbps"], 1000.0)
+            self.assertEqual(throughput["minimum_baseline_exact_mbps"], 700.0)
+            self.assertEqual(throughput["minimum_contender_mbps"], 500.0)
             self.assertEqual(summary["cells"][0]["contended"]["dataplane"]["verdict"], "PASS")
+
+    def test_default_contender_threshold_math_for_canonical_cells(self) -> None:
+        root_shape = 25_000_000_000.0
+
+        self.assertEqual(
+            cos_validate._default_min_contender_bps(1_000_000_000.0, root_shape),
+            500_000_000.0,
+        )
+        self.assertEqual(
+            cos_validate._default_min_contender_bps(24_000_000_000.0, root_shape),
+            1_000_000_000.0,
+        )
 
     def test_fails_nonzero_iperf_exit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -101,8 +101,10 @@ def _write_manifest(root: Path, cell: dict | None = None) -> None:
             "label": "exact5202-vs-5200",
             "exact_port": 5202,
             "exact_queue": 2,
+            "exact_forwarding_class": "iperf-1g",
             "contender_port": 5200,
             "contender_queue": 0,
+            "contender_forwarding_class": "best-effort",
             "baseline_dir": "cell/baseline",
             "contended_dir": "cell/contended",
         }
@@ -121,6 +123,7 @@ def _validate(root: Path) -> dict:
         max_exact_drop_ratio=0.15,
         wrong_queue_sent_bytes_tolerance=0,
         min_expected_sent_bytes=1,
+        min_contender_bps=100_000_000.0,
     )
 
 
@@ -251,6 +254,94 @@ class CoSBEContentionValidateTests(unittest.TestCase):
 
             self.assertEqual(summary["verdict"], "FAIL")
             self.assertTrue(any("exact throughput dropped" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_when_contender_has_no_material_pressure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=0),
+                during=_status(q2=100),
+                after=_status(q2=200),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=1, q2=300),
+                after=_status(q0=1, q2=400),
+                exact_bps=1_000_000_000,
+                contender_bps=1.0,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("contention pressure is too low" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_negative_drain_shape_delta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=200),
+                during=_status(q2=150),
+                after=_status(q2=100),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=100),
+                during=_status(q0=100, q2=200),
+                after=_status(q0=200, q2=300),
+                exact_bps=1_000_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("negative DrainShape delta" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_forwarding_class_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(
+                root,
+                {
+                    "label": "exact5202-vs-5200",
+                    "exact_port": 5202,
+                    "exact_queue": 2,
+                    "exact_forwarding_class": "not-iperf-1g",
+                    "contender_port": 5200,
+                    "contender_queue": 0,
+                    "contender_forwarding_class": "best-effort",
+                    "baseline_dir": "cell/baseline",
+                    "contended_dir": "cell/contended",
+                },
+            )
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=0),
+                during=_status(q2=100),
+                after=_status(q2=200),
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=100, q2=300),
+                after=_status(q0=200, q2=400),
+                exact_bps=1_000_000_000,
+                contender_bps=1_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("expected queue 2 class" in reason for reason in summary["failure_reasons"]))
 
     def test_iperf_parser_prefers_sum_received(self) -> None:
         artifact = {

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -473,6 +473,65 @@ class CoSBEContentionValidateTests(unittest.TestCase):
         }
         self.assertEqual(cos_validate.iperf_bps(artifact), 123)
 
+    def test_fails_missing_status_json_without_aborting_cell(self) -> None:
+        """Missing status-before.json should produce a per-cell FAIL, not a global abort."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            # Write baseline with a missing status-before.json (only iperf JSON provided).
+            baseline_dir = root / "cell" / "baseline"
+            baseline_dir.mkdir(parents=True)
+            _write_json(baseline_dir / "status-during.json", _status(q2=100))
+            _write_json(baseline_dir / "status-after.json", _status(q2=200))
+            for phase in ("before", "during", "after"):
+                (baseline_dir / f"status-{phase}.rc").write_text("0\n", encoding="utf-8")
+            _write_json(baseline_dir / "exact-iperf.json", _iperf_json(1_000_000_000))
+            (baseline_dir / "exact-iperf.rc").write_text("0\n", encoding="utf-8")
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=100, q2=300),
+                after=_status(q0=200, q2=400),
+                exact_bps=920_000_000,
+                contender_bps=24_000_000_000,
+            )
+
+            # Must not raise — missing JSON is a per-cell FAIL, not a global abort.
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(
+                any("missing JSON artifact" in reason for reason in summary["failure_reasons"])
+            )
+
+    def test_fails_during_snapshot_shows_no_traffic_in_expected_queue(self) -> None:
+        """During snapshot that matches before (zero delta) triggers the during gate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=100),
+                during=_status(q2=100),  # no delta from before
+                after=_status(q2=200),   # after gate passes
+                exact_bps=1_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=100, q2=300),
+                after=_status(q0=200, q2=400),
+                exact_bps=920_000_000,
+                contender_bps=24_000_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(
+                any("during-snapshot" in reason for reason in summary["failure_reasons"])
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/incus/cos_be_contention_validate_test.py
+++ b/test/incus/cos_be_contention_validate_test.py
@@ -124,6 +124,7 @@ def _validate(root: Path) -> dict:
         wrong_queue_sent_bytes_tolerance=0,
         min_expected_sent_bytes=1,
         min_contender_bps=100_000_000.0,
+        min_exact_baseline_cap_ratio=0.70,
     )
 
 
@@ -305,7 +306,7 @@ class CoSBEContentionValidateTests(unittest.TestCase):
             self.assertEqual(summary["verdict"], "FAIL")
             self.assertTrue(any("negative DrainShape delta" in reason for reason in summary["failure_reasons"]))
 
-    def test_fails_forwarding_class_mismatch(self) -> None:
+    def test_rejects_forwarding_class_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_manifest(
@@ -338,10 +339,73 @@ class CoSBEContentionValidateTests(unittest.TestCase):
                 contender_bps=1_000_000_000,
             )
 
+            with self.assertRaisesRegex(cos_validate.ValidationError, "does not match canonical class"):
+                _validate(root)
+
+    def test_fails_when_baseline_does_not_prove_exact_cap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(root)
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q2=0),
+                during=_status(q2=100),
+                after=_status(q2=200),
+                exact_bps=500_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q2=200),
+                during=_status(q0=100, q2=300),
+                after=_status(q0=200, q2=400),
+                exact_bps=500_000_000,
+                contender_bps=1_000_000_000,
+            )
+
             summary = _validate(root)
 
             self.assertEqual(summary["verdict"], "FAIL")
-            self.assertTrue(any("expected queue 2 class" in reason for reason in summary["failure_reasons"]))
+            self.assertTrue(any("exact-alone baseline" in reason for reason in summary["failure_reasons"]))
+
+    def test_fails_cell_specific_contender_pressure_for_24g_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_manifest(
+                root,
+                {
+                    "label": "exact5210-vs-5200",
+                    "exact_port": 5210,
+                    "exact_queue": 10,
+                    "exact_forwarding_class": "iperf-24g",
+                    "exact_cap_bps": 24_000_000_000,
+                    "contender_port": 5200,
+                    "contender_queue": 0,
+                    "contender_forwarding_class": "best-effort",
+                    "min_contender_bps": 1_000_000_000,
+                    "baseline_dir": "cell/baseline",
+                    "contended_dir": "cell/contended",
+                },
+            )
+            _write_phase(
+                root / "cell" / "baseline",
+                before=_status(q10=0),
+                during=_status(q10=100),
+                after=_status(q10=200),
+                exact_bps=22_000_000_000,
+            )
+            _write_phase(
+                root / "cell" / "contended",
+                before=_status(q0=0, q10=200),
+                during=_status(q0=100, q10=300),
+                after=_status(q0=200, q10=400),
+                exact_bps=21_000_000_000,
+                contender_bps=500_000_000,
+            )
+
+            summary = _validate(root)
+
+            self.assertEqual(summary["verdict"], "FAIL")
+            self.assertTrue(any("below 1000.000 Mbps" in reason for reason in summary["failure_reasons"]))
 
     def test_iperf_parser_prefers_sum_received(self) -> None:
         artifact = {


### PR DESCRIPTION
## Summary

Closes #1368.

Adds an operator harness and offline validator for the exact failure mode we observed: best-effort or uncapped traffic competing with fixed-rate exact classes on the 5200/5211 CoS port grid.

The harness runs forward IPv4 contention cells for:

- `5202` vs `5200` (1 Gbps exact vs best-effort)
- `5210` vs `5200` (24 Gbps exact vs best-effort)
- `5202` vs `5211` (1 Gbps exact vs uncapped)
- `5210` vs `5211` (24 Gbps exact vs uncapped)

It applies the symmetric CoS fixture, snapshots dataplane counters before/after each cell, writes per-cell artifacts, and feeds them into a strict validator.

## Implementation notes

- Adds `test/incus/cos-be-contention-harness.sh` for live lab runs.
- Adds `test/incus/cos_be_contention_validate.py` for artifact validation.
- Adds Python unit tests for PASS/FAIL/error cases.
- Adds `docs/cos-best-effort-contention-harness.md` with run semantics and artifact layout.

## Validation

- `bash -n test/incus/cos-be-contention-harness.sh`
- `python3 -m py_compile test/incus/cos_be_contention_validate.py test/incus/cos_be_contention_validate_test.py`
- `python3 test/incus/cos_be_contention_validate_test.py`
- `python3 test/incus/cos_port_grid_test.py`
- `python3 test/incus/iperf3_sum_parse_test.py`

Live harness execution is intentionally not run in this PR because it mutates the loss lab CoS config and starts traffic.
