### PR TITLE
docs: #1373 Phase 0 eBPF retirement audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # xpf - eBPF Firewall with Junos Configuration Syntax
 
+> Deprecation notice (#1373): the legacy eBPF dataplane is being retired in
+> favor of the Rust AF_XDP userspace dataplane. New dataplane development should
+> target `userspace-dp`. Phase 0 is documentation/audit only and removes no BPF
+> source.
+
 ## Working Style
 - Think before acting. Read existing files before writing code.
 - Be concise in output but thorough in reasoning.
@@ -89,6 +94,10 @@ Or use `test/incus/cluster-setup.sh` directly with `BPFRX_CLUSTER_ENV` set:
 **IMPORTANT:** Any change touching cluster, VRRP, session sync, or failover code MUST pass `make test-failover` before commit.
 
 ## Architecture
+
+The BPF pipeline below is legacy context during the #1373 retirement. Keep it
+working until the staged removal phases land, but do not start new dataplane
+features on this path unless a blocker explicitly requires compatibility work.
 
 ### BPF Pipeline (14 programs, tail calls)
 ```

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 eBPF zone-based firewall with native Junos configuration syntax.
 
+> Deprecation notice (#1373): the legacy eBPF dataplane is being retired in
+> favor of the Rust AF_XDP userspace dataplane. New dataplane development should
+> target `userspace-dp`. Phase 0 is documentation/audit only and removes no BPF
+> source.
+
 xpf is a high-performance stateful firewall built on Linux eBPF that replicates Juniper vSRX capabilities. It uses the familiar Junos hierarchical configuration syntax and provides a full interactive CLI with tab completion and `?` help.
 
 ## Dual Dataplane Architecture
 
 xpf provides two dataplane backends selectable via configuration. Both share the same Go control plane (config, HA, routing, CLI, APIs) — only the packet forwarding path differs.
+
+The eBPF backend remains present during the #1373 retirement phases as a legacy
+compatibility and rollback path. New feature work should use the userspace
+AF_XDP dataplane and close blockers tracked in
+[`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
 
 ### eBPF Dataplane (default)
 

--- a/_Log.md
+++ b/_Log.md
@@ -7,6 +7,11 @@
   - **File(s)**: `README.md`, `_Log.md`
   - **Validation**: `git diff --check`
 
+- **Timestamp**: 2026-05-17T01:03:00Z
+  - **Action**: PR #1382 round-3 rebase follow-up — aligned the Phase 0 audit with the now-merged #1385 pool-mode SNAT fixes, and kept #1377 as the remaining cross-backend `address-persistent` parity blocker.
+  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `_Log.md`
+  - **Validation**: `git diff --check`
+
 - **Timestamp**: 2026-05-16T23:58:00Z
   - **Action**: PR #1385 round-2 review follow-up — made Rust pool-mode SNAT skip matched rules whose pool has no address for the packet family so later compatible rules can apply, added wrong-family regression tests, and documented userspace/eBPF/DPDK address-persistent algorithm divergence until #1377 defines a shared contract.
   - **File(s)**: `userspace-dp/src/nat.rs`, `userspace-dp/src/nat_tests.rs`, `docs/userspace-dataplane-architecture.md`, `docs/userspace-dataplane-gaps.md`, `README.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -59,6 +59,10 @@
 - **Timestamp**: 2026-05-16T23:24:00Z
   - **Action**: PR #1384 round-1 review follow-up — aligned the #1373 blocker-plan index with #1377/#1380 scope, made all required-before labels explicit, tightened SYN-cookie full-epoch/low-bit-wrap semantics, added risk sections and capability-admission tests to blocker plans, and added SNAT-pool and userspace-buffer parity plan docs.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md`, `_Log.md`
+
+- **Timestamp**: 2026-05-16T23:39:00Z
+  - **Action**: PR #1382 round-1 review follow-up — reconciled Phase 0 retirement docs with #1385/#1386 fix-forward dependencies, removed stale userspace architecture limitations for features already implemented in Rust, changed userspace-dp wording to "being retired", and added Phase 0 exit criteria plus rollback path.
+  - **File(s)**: `README.md`, `docs/userspace-dataplane-gaps.md`, `docs/userspace-dataplane-architecture.md`, `userspace-dp/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `_Log.md`
   - **Validation**: `git diff --check`
 
 - **Timestamp**: 2026-05-16T04:36:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -637,3 +637,7 @@
   - **Action**: PR #1320 round-1 review fixes: preserve split Junos-style `transmit-rate exact`; make typed scheduler leaves fail closed on missing values and unknown trailing modifiers; reject sub-byte scheduler rates that compile to zero bytes/sec; align `buffer-size` validation and help with the compiler's byte-size-only representation; remove unsupported scheduler-level `shaping-rate` from the typed schema; update module docs to match the enforced schema.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validators.go`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `_Log.md`
   - **Validation**: `go test -count=1 ./pkg/config ./pkg/cmdtree ./pkg/configstore` (PASS); `go test -count=1 ./pkg/...` (PASS); `git diff --check` (clean).
+
+- **Timestamp**: 2026-05-16T14:17:38-07:00
+  - **Action**: #1373 Phase 0 documentation/audit update: refresh userspace dataplane gap blockers, add retirement notices to active docs and README entry points, and add an umbrella tracker for the staged eBPF dataplane retirement. Explicitly document that Phase 0 removes no BPF source.
+  - **File(s)**: `docs/userspace-dataplane-gaps.md`, `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `README.md`, `CLAUDE.md`, `docs/testing.md`, `docs/development-workflow.md`, `bpf/README.md`, `userspace-dp/README.md`, `pkg/dataplane/README.md`, `testing-docs/README.md`, `_Log.md`

--- a/bpf/README.md
+++ b/bpf/README.md
@@ -1,5 +1,9 @@
 # bpf/
 
+> Deprecation notice (#1373): this legacy eBPF dataplane is being retired in
+> favor of `userspace-dp`. Phase 0 is documentation/audit only, so this source
+> tree remains intact until later removal phases.
+
 eBPF programs that drive the in-kernel packet pipeline. 14 programs
 total: 9 XDP ingress, 5 TC egress. They compose via tail-calls; metadata
 crosses stages through a per-CPU array scratch map.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,5 +1,9 @@
 # Development workflow — plan, review, code, review, merge
 
+> Deprecation notice (#1373): new dataplane work should target the Rust AF_XDP
+> userspace dataplane. The legacy eBPF dataplane remains in-tree during Phase 0;
+> this phase is documentation/audit only and removes no BPF source.
+
 How non-trivial changes land in this repo. Roles and agent-boundary
 rules are in `AGENTS.md`; read that first. This doc is the process
 layer on top of those roles.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -14,7 +14,7 @@ present until later phase PRs.
 | Issue | Summary | Phase dependency |
 |-------|---------|------------------|
 | #1381 | `dataplane.DataPlane` is BPF-shaped and the userspace manager embeds the eBPF manager | Must land first; blocks Phase 3 |
-| #1377 | Address-persistent SNAT pool mode still needs userspace-owned pool selection; #1385 is the prerequisite fail-closed admission fix for missing/unsafe pools | Before Phase 4 |
+| #1377 | Address-persistent SNAT pool mode still needs userspace-owned pool selection; #1385 is the prerequisite fix for admitted pool-mode rules missing resolved pool addresses/port ranges and wrong-family shadowing | Before Phase 4 |
 | #1378 | Time-based policy schedulers are not propagated to userspace policy evaluation | Before Phase 4 |
 | #1379 | Policy-deny, screen-drop, and filter-log dataplane events are not emitted by userspace | Before Phase 4 |
 | #1374 | SYN-cookie flood protection is implemented in eBPF but missing from userspace | Before Phase 4 |

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -1,0 +1,45 @@
+# #1373 Phase 0 Tracker: Retire Legacy eBPF Dataplane
+
+Phase 0 is a documentation and audit PR for #1373. It announces that new
+dataplane development targets `userspace-dp`, refreshes the userspace gap audit,
+and records the blockers that must close before later retirement phases remove
+legacy eBPF code.
+
+No BPF source is removed in Phase 0. The `bpf/` tree, bpf2go-generated Go
+bindings, eBPF loader, legacy test targets, and BPF-backed CLI surfaces remain
+present until later phase PRs.
+
+## Blockers
+
+| Issue | Summary | Phase dependency |
+|-------|---------|------------------|
+| #1381 | `dataplane.DataPlane` is BPF-shaped and the userspace manager embeds the eBPF manager | Must land first; blocks Phase 3 |
+| #1377 | Address-persistent SNAT pool mode silently degrades to round-robin in userspace | Before Phase 4 |
+| #1378 | Time-based policy schedulers are not propagated to userspace policy evaluation | Before Phase 4 |
+| #1379 | Policy-deny, screen-drop, and filter-log dataplane events are not emitted by userspace | Before Phase 4 |
+| #1374 | SYN-cookie flood protection is implemented in eBPF but missing from userspace | Before Phase 4 |
+| #1375 | RFC 2697/2698 three-color policers are implemented in eBPF but missing from userspace | Before Phase 4 |
+| #1376 | Port mirroring is implemented in eBPF but missing from userspace | Before Phase 4 |
+| #1380 | `show system buffers` reports BPF map utilization with no userspace equivalent | Phase 5 |
+
+## Recommended Order
+
+1. Land #1381 first so the daemon and dataplane interface stop assuming BPF
+   map-writer methods as the abstract contract.
+2. Land #1377, #1378, and #1379 next because these are silent correctness or
+   security-visibility gaps.
+3. Land #1374, #1375, and #1376 before Phase 4 because the current protection is
+   explicit fallback to the legacy eBPF dataplane.
+4. Land #1380 in Phase 5 while replacing BPF-map observability with userspace
+   resource reporting.
+
+## Phase Boundaries
+
+- Phase 0: docs and audit only; no BPF source removal.
+- Phase 1: broad documentation migration. Historical PR-plan docs are preserved
+  as history; add banners only where needed instead of rewriting old plans.
+- Phase 2: test environment consolidation.
+- Phase 3: build-system and Go dataplane interface removal work, after #1381.
+- Phase 4: BPF source removal, only after #1374-#1379 and any production
+  blockers from the audit are closed.
+- Phase 5: CLI and observability cleanup, including #1380.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -14,13 +14,13 @@ present until later phase PRs.
 | Issue | Summary | Phase dependency |
 |-------|---------|------------------|
 | #1381 | `dataplane.DataPlane` is BPF-shaped and the userspace manager embeds the eBPF manager | Must land first; blocks Phase 3 |
-| #1377 | Address-persistent SNAT pool mode silently degrades to round-robin in userspace | Before Phase 4 |
+| #1377 | Address-persistent SNAT pool mode still needs userspace-owned pool selection; #1385 is the prerequisite fail-closed admission fix for missing/unsafe pools | Before Phase 4 |
 | #1378 | Time-based policy schedulers are not propagated to userspace policy evaluation | Before Phase 4 |
 | #1379 | Policy-deny, screen-drop, and filter-log dataplane events are not emitted by userspace | Before Phase 4 |
 | #1374 | SYN-cookie flood protection is implemented in eBPF but missing from userspace | Before Phase 4 |
 | #1375 | RFC 2697/2698 three-color policers are implemented in eBPF but missing from userspace | Before Phase 4 |
 | #1376 | Port mirroring is implemented in eBPF but missing from userspace | Before Phase 4 |
-| #1380 | `show system buffers` reports BPF map utilization with no userspace equivalent | Phase 5 |
+| #1380 | `show system buffers` needs userspace-equivalent resource reporting before the BPF-map view disappears; #1386 closes current mixed-version display parity defects | Phase 5 |
 
 ## Recommended Order
 
@@ -43,3 +43,33 @@ present until later phase PRs.
 - Phase 4: BPF source removal, only after #1374-#1379 and any production
   blockers from the audit are closed.
 - Phase 5: CLI and observability cleanup, including #1380.
+
+## Phase 0 Exit Criteria
+
+Phase 0 is complete only when:
+
+- the userspace gap audit is verified against current code and explicitly calls
+  out fix-forward PR dependencies such as #1385 and #1386 instead of implying
+  they have already landed;
+- the blocker list here and the #1384 blocker-plan bundle have the same scope
+  for #1374, #1375, #1376, #1377, #1378, #1379, #1380, and #1381;
+- active docs are reconciled with the current userspace runtime instead of
+  preserving stale "not implemented" claims for features already implemented in
+  Rust;
+- rollback remains documented as the legacy eBPF dataplane staying present and
+  selectable until later phases; and
+- no BPF source, generated bindings, loader code, legacy tests, or CLI surfaces
+  are removed by the Phase 0 PR.
+
+## Rollback Path
+
+The Phase 0 rollback path is deliberately simple because this PR is docs/audit
+only:
+
+1. keep the legacy eBPF backend in the tree and in build/test targets;
+2. remove or avoid `system dataplane-type userspace` on affected deployments, or
+   set `system dataplane-type ebpf` where an explicit backend is required;
+3. restart/re-apply `xpfd` so the manager selects the eBPF backend and legacy
+   XDP/TC programs; and
+4. do not remove existing BPF pins or source until the later retirement phases
+   have their own tested rollback plans.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,10 @@
 # Testing & Performance Guide
 
+> Deprecation notice (#1373): the legacy eBPF dataplane is being retired. New
+> dataplane validation targets the userspace AF_XDP cluster unless a later phase
+> explicitly requires regression coverage for the legacy path. Phase 0 removes no
+> BPF source or test target.
+
 ## Test Environment
 
 ### VM Setup (Incus)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -345,7 +345,7 @@ ConfigSnapshot {
     neighbors:       [{ifindex, ip, mac}]
     routes:          [{prefix, next_hop, ifindex, table}]
     policies:        [{from_zone, to_zone, src/dst, apps, action}]
-    source_nat_rules:[{from_zone, to_zone, src/dst, interface_mode}]
+    source_nat_rules:[{from_zone, to_zone, src/dst, interface/pool metadata}]
     flow:            {allow_dns_reply, allow_embedded_icmp}
     map_pins:        {xsk_map, heartbeat_map, sessions_map}
     ha_groups:       [{rg_id, active, watchdog_ts}]
@@ -358,12 +358,17 @@ The manager evaluates the active config to determine if the userspace
 dataplane can handle it. Unsupported features cause automatic fallback
 to the kernel BPF pipeline:
 
-**Supported:** Basic SNAT, zone policies, static routes, HA cluster,
-IPv4/IPv6 forwarding, VLAN sub-interfaces
+The current supported/gated split is maintained in
+[`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md). In broad terms,
+the Rust path now owns stateful forwarding, zone/global policies, application
+matching, interface-mode SNAT, DNAT, static NAT, NAT64, NPTv6, firewall
+filters, flow export, TCP MSS clamping, configurable timeouts, VLAN handling,
+route/neighbor lookup, and HA/session-delta ingestion.
 
-**Not supported (falls back to BPF):** DNAT, static NAT, NAT64, IPsec,
-GRE tunnels, firewall filters, custom flow timeouts, flow export,
-global policies, port mirroring
+Remaining explicit gates include SYN-cookie-dependent screen behavior,
+three-color policers, port mirroring, and full pool-mode SNAT semantics.
+Specific Phase 0 fix-forward PRs are tracked for unsafe pool admission (#1385)
+and userspace buffer/status parity (#1386).
 
 ### 4. HA Cluster Integration
 
@@ -517,26 +522,24 @@ system {
 - Ensure VM has enough RAM: `workers × bindings × 160 MB + 2 GB` base (at 16384 ring,
   mlx5 driver; 192 MB for virtio_net)
 
-## Limitations
+## Limitations and Mixed Boundaries
 
-The userspace dataplane handles a subset of the full BPF pipeline's
-features. When unsupported features are configured, the manager
-automatically falls back to the kernel BPF forwarding path.
+This section is a high-level architecture note. The authoritative current gate
+is [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
 
-**Not implemented:**
-- Destination NAT (DNAT), static NAT, NAT64
-- Firewall filters (match/action chains)
-- Custom per-application flow timeouts
-- IPsec / XFRM tunnel processing
-- GRE tunnel encapsulation/decapsulation
-- TCP MSS clamping
-- NetFlow v9 export
-- Port mirroring
-- Global policies (inter-zone default)
-- SYN cookie flood protection
+**Still explicitly gated or incomplete for eBPF retirement:**
+- Source NAT pool mode: #1385 is required to fail closed on missing/unsafe
+  pools; #1377 is required for full address-persistent pool selection.
+- SYN-cookie flood protection: #1374.
+- RFC 2697/2698 three-color policers: #1375.
+- Port mirroring: #1376.
+- Policy-deny, screen-drop, and filter-log event parity: #1379.
+- `show system buffers` userspace parity and BPF-map display retirement:
+  #1380/#1386.
 
-**Handled by fallback to kernel BPF:**
-- ARP, NDP, ICMP (redirected via cpumap)
-- Management traffic (SSH, control plane)
-- Non-IP protocols
-- Packets failing forwarding resolution
+**Handled outside the AF_XDP forwarding fast path:**
+- ARP, NDP, local management traffic, and other kernel-owned packets are passed
+  to cpumap/kernel handling.
+- IPsec/XFRM and GRE transit use kernel/pass-through or tunnel-specific
+  handling where required.
+- Packets failing forwarding resolution can enter the bounded slow path.

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -7,6 +7,15 @@ historical branch plan. For active debugging entry points, use
 
 Last updated: 2026-05-16
 
+## Deprecation Context
+
+Issue #1373 starts retirement of the legacy eBPF dataplane. Phase 0 is
+documentation and audit only: no BPF source, bpf2go bindings, loader code, test
+targets, or CLI surfaces are removed in this phase. Until the blockers below
+are closed, the legacy eBPF dataplane remains present as the compatibility and
+rollback path for configurations the AF_XDP userspace dataplane cannot yet
+own.
+
 ## Implemented In The Current Runtime
 
 These capabilities exist in the current Rust userspace dataplane code path:
@@ -35,14 +44,14 @@ These capabilities exist in the current Rust userspace dataplane code path:
 ## Still Gated By `deriveUserspaceCapabilities()`
 
 These are the remaining explicit configuration gates in
-[`pkg/dataplane/userspace/manager.go`](/home/ps/git/codex-xpf/pkg/dataplane/userspace/manager.go):
+[`pkg/dataplane/userspace/manager.go`](../pkg/dataplane/userspace/manager.go):
 
-| Feature/config shape | Gate status | Reason |
-|----------------------|-------------|--------|
+| Feature/config shape | Gate status | Retirement blocker |
+|----------------------|-------------|--------------------|
 | Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
-| Screen behavior requiring SYN cookies | Gated | SYN-cookie behavior remains a legacy eBPF capability |
-| Three-color policers | Gated | Simple filters are supported; three-color policers are not |
-| Port mirroring | Gated | No userspace mirroring path |
+| Screen behavior requiring SYN cookies | Gated | #1374 |
+| Three-color policers | Gated | #1375 |
+| Port mirroring | Gated | #1376 |
 
 ## Features That Still Use A Mixed Boundary
 
@@ -54,6 +63,36 @@ These are not "missing", but they are not pure userspace forwarding either:
 | Kernel-owned traffic (ARP, local delivery, management, some non-IP) | cpumap or kernel pass-through from XDP |
 | GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
+| DataPlane control-plane contract | Userspace manager still embeds the eBPF manager for many BPF-shaped map-writer methods; tracked by #1381 |
+| Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
+| `show system buffers` | Still reports BPF map utilization through the embedded eBPF manager; userspace-equivalent operator resource reporting is tracked by #1380 |
+
+## Retirement Blockers From The 2026-05-16 Audit
+
+The current #1373 audit produced these tracked blockers:
+
+| Issue | Blocker | Required before |
+|-------|---------|-----------------|
+| #1381 | Split or replace the BPF-shaped `dataplane.DataPlane` interface so userspace no longer embeds the eBPF manager for map-writer methods | Phase 3 build-system / Go removal |
+| #1377 | Preserve address-persistent SNAT pool selection in userspace instead of silently round-robining pool addresses | Phase 4 BPF source removal |
+| #1378 | Propagate time-based policy scheduler state to userspace policy evaluation | Phase 4 BPF source removal |
+| #1379 | Emit policy-deny, screen-drop, and filter-log dataplane events from userspace | Phase 4 BPF source removal |
+| #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent | Phase 4 BPF source removal |
+| #1375 | Implement userspace RFC 2697/2698 three-color policers | Phase 4 BPF source removal |
+| #1376 | Implement userspace port mirroring or explicitly retire the feature | Phase 4 BPF source removal |
+| #1380 | Replace `show system buffers` BPF-map output with userspace resource reporting, or deprecate the command in favor of an equivalent | Phase 5 CLI / observability cleanup |
+
+Recommended dependency order:
+
+1. #1381 first, because it defines the control-plane interface boundary that
+   every later removal phase depends on.
+2. #1377, #1378, and #1379 next, because they are silent correctness or
+   security-visibility regressions in configurations that may otherwise appear
+   admitted.
+3. #1374, #1375, and #1376 before Phase 4, because these are explicit feature
+   gaps currently protected by the legacy eBPF fallback.
+4. #1380 in Phase 5, after the dataplane boundary is settled but before the
+   operator-facing BPF map surface disappears.
 
 ## What This Document Does Not Mean
 
@@ -90,7 +129,10 @@ There are two distinct fallback boundaries:
 
 The highest-value remaining work on current `master` is:
 
-1. close the remaining SYN-cookie-dependent screen gap
-2. implement three-color policer support
-3. implement port mirroring
-4. continue correctness and performance hardening on the active AF_XDP fast path
+1. resolve #1381 so userspace is no longer structurally coupled to the eBPF
+   manager contract
+2. fix #1377, #1378, and #1379 to remove silent correctness and visibility
+   regressions
+3. close #1374, #1375, and #1376 before any BPF source removal
+4. carry #1380 into the Phase 5 CLI / observability cleanup
+5. continue correctness and performance hardening on the active AF_XDP fast path

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -65,7 +65,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager still embeds the eBPF manager for many BPF-shaped map-writer methods; tracked by #1381 |
 | Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
-| `show system buffers` | Still reports BPF map utilization through the embedded eBPF manager; userspace-equivalent operator resource reporting is tracked by #1380 |
+| `show system buffers` | Current `master` still has userspace parity gaps in buffer/status display. #1386 is the fix-forward for active-session footer, detail/non-detail separation, and mixed-version capacity fallback; #1380 tracks the retirement gate for removing BPF-map buffer reporting entirely. |
 
 ## Retirement Blockers From The 2026-05-16 Audit
 
@@ -74,13 +74,13 @@ The current #1373 audit produced these tracked blockers:
 | Issue | Blocker | Required before |
 |-------|---------|-----------------|
 | #1381 | Split or replace the BPF-shaped `dataplane.DataPlane` interface so userspace no longer embeds the eBPF manager for map-writer methods | Phase 3 build-system / Go removal |
-| #1377 | Preserve address-persistent SNAT pool selection in userspace instead of silently round-robining pool addresses | Phase 4 BPF source removal |
+| #1377 | Preserve address-persistent SNAT pool selection in userspace instead of silently round-robining pool addresses; requires #1385-style fail-closed pool admission first | Phase 4 BPF source removal |
 | #1378 | Propagate time-based policy scheduler state to userspace policy evaluation | Phase 4 BPF source removal |
 | #1379 | Emit policy-deny, screen-drop, and filter-log dataplane events from userspace | Phase 4 BPF source removal |
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent | Phase 4 BPF source removal |
 | #1375 | Implement userspace RFC 2697/2698 three-color policers | Phase 4 BPF source removal |
 | #1376 | Implement userspace port mirroring or explicitly retire the feature | Phase 4 BPF source removal |
-| #1380 | Replace `show system buffers` BPF-map output with userspace resource reporting, or deprecate the command in favor of an equivalent | Phase 5 CLI / observability cleanup |
+| #1380 | Replace `show system buffers` BPF-map output with userspace resource reporting, or deprecate the command in favor of an equivalent; #1386 closes current mixed-version display parity defects | Phase 5 CLI / observability cleanup |
 
 Recommended dependency order:
 

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -1,5 +1,10 @@
 # pkg/dataplane
 
+> Deprecation notice (#1373): the legacy eBPF backend in this package is being
+> retired in favor of the Rust AF_XDP userspace dataplane. Phase 0 is
+> documentation/audit only; no BPF source, loader code, or bindings are removed
+> in this phase. The DataPlane interface cleanup is tracked by #1381.
+
 Abstract dataplane interface plus the eBPF backend. Compiles the typed
 config from `pkg/config` into BPF-map entries (zones, policies, NAT,
 filters, applications), attaches the 14 BPF programs (9 XDP + 5 TC), and

--- a/testing-docs/README.md
+++ b/testing-docs/README.md
@@ -1,5 +1,10 @@
 # xpf Testing Documentation
 
+> Deprecation notice (#1373): the legacy eBPF dataplane is being retired. New
+> dataplane validation should use the userspace AF_XDP cluster unless a staged
+> retirement phase calls for explicit legacy regression coverage. Phase 0 removes
+> no BPF source or test target.
+
 Comprehensive test plans and validation procedures for both the legacy eBPF
 dataplane and the userspace AF_XDP dataplane.
 

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -1,8 +1,8 @@
 # userspace-dp/
 
 > #1373 status: this Rust AF_XDP dataplane is the target path for new dataplane
-> development while the legacy eBPF dataplane is retired. Phase 0 updates docs
-> and audit state only; no BPF source is removed yet.
+> development while the legacy eBPF dataplane is being retired. Phase 0 updates
+> docs and audit state only; no BPF source is removed yet.
 
 Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
 (screen → zone → conntrack → policy → NAT → forward) but in userspace.

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -1,5 +1,9 @@
 # userspace-dp/
 
+> #1373 status: this Rust AF_XDP dataplane is the target path for new dataplane
+> development while the legacy eBPF dataplane is retired. Phase 0 updates docs
+> and audit state only; no BPF source is removed yet.
+
 Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
 (screen → zone → conntrack → policy → NAT → forward) but in userspace.
 Runs as a separate `xpf-userspace-dp` binary the Go daemon spawns over a


### PR DESCRIPTION
## Summary
- Refresh docs/userspace-dataplane-gaps.md against the current #1373 audit.
- Add Phase 0 deprecation/retirement notices to active docs and README entry points.
- Add docs/pr/1373-retire-ebpf-dataplane/plan.md as the umbrella tracker.

## Blockers / order
- #1381 first.
- #1377, #1378, and #1379 next.
- #1374, #1375, and #1376 before Phase 4.
- #1380 in Phase 5.

## Phase 0 boundary
No BPF source is removed in this PR. The bpf/ tree, bpf2go bindings, eBPF loader, legacy test targets, and BPF-backed CLI surfaces remain present.

Refs #1373.
Related: #1374, #1375, #1376, #1377, #1378, #1379, #1380, #1381.

## Validation
- git diff --check
- git diff HEAD^ --check
- rg blocker and Phase 0 no-removal coverage across touched docs
- rg deletion/code-removal guard for BPF C/header, loader, Makefile, and test-incus paths
- markdownlint not available in this worktree