### PR TITLE
docs: plan #1373 userspace parity blockers

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45,6 +45,10 @@
 - **Timestamp**: 2026-05-16T23:10:00Z
   - **Action**: PR #1383 round-1 review follow-up — removed backend-specific userspace DTOs from the proposed public session-delta interface to avoid a `pkg/dataplane` ↔ `pkg/dataplane/userspace` import cycle, added the missing caller inventory, and documented compatibility, risk, architectural-mismatch, import-canary, and Phase 1 acceptance gates.
   - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
+
+- **Timestamp**: 2026-05-16T23:24:00Z
+  - **Action**: PR #1384 round-1 review follow-up — aligned the #1373 blocker-plan index with #1377/#1380 scope, made all required-before labels explicit, tightened SYN-cookie full-epoch/low-bit-wrap semantics, added risk sections and capability-admission tests to blocker plans, and added SNAT-pool and userspace-buffer parity plan docs.
+  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md`, `_Log.md`
   - **Validation**: `git diff --check`
 
 - **Timestamp**: 2026-05-16T04:36:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -46,6 +46,11 @@
   - **Action**: PR #1383 round-1 review follow-up — removed backend-specific userspace DTOs from the proposed public session-delta interface to avoid a `pkg/dataplane` ↔ `pkg/dataplane/userspace` import cycle, added the missing caller inventory, and documented compatibility, risk, architectural-mismatch, import-canary, and Phase 1 acceptance gates.
   - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
 
+- **Timestamp**: 2026-05-17T00:59:00Z
+  - **Action**: PR #1384 round-3 review follow-up — changed the blocker-plan bundle introduction to say plans land before their listed #1373 retirement phase, avoiding a Phase 4 blanket statement now that #1380 is a Phase 5 observability blocker.
+  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
+  - **Validation**: `git diff --check`
+
 - **Timestamp**: 2026-05-17T00:24:00Z
   - **Action**: PR #1384 round-2 review follow-up — aligned #1380 with the Phase 5 observability gate, and made the #1377 plan explicitly cover address-persistent SNAT pool selection plus current userspace/eBPF/DPDK algorithm divergence and required compatibility fixtures.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -46,6 +46,11 @@
   - **Action**: PR #1383 round-1 review follow-up — removed backend-specific userspace DTOs from the proposed public session-delta interface to avoid a `pkg/dataplane` ↔ `pkg/dataplane/userspace` import cycle, added the missing caller inventory, and documented compatibility, risk, architectural-mismatch, import-canary, and Phase 1 acceptance gates.
   - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
 
+- **Timestamp**: 2026-05-17T00:24:00Z
+  - **Action**: PR #1384 round-2 review follow-up — aligned #1380 with the Phase 5 observability gate, and made the #1377 plan explicitly cover address-persistent SNAT pool selection plus current userspace/eBPF/DPDK algorithm divergence and required compatibility fixtures.
+  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `_Log.md`
+  - **Validation**: `git diff --check`
+
 - **Timestamp**: 2026-05-16T23:24:00Z
   - **Action**: PR #1384 round-1 review follow-up — aligned the #1373 blocker-plan index with #1377/#1380 scope, made all required-before labels explicit, tightened SYN-cookie full-epoch/low-bit-wrap semantics, added risk sections and capability-admission tests to blocker plans, and added SNAT-pool and userspace-buffer parity plan docs.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md`, `_Log.md`

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -9,10 +9,12 @@ land before Phase 4 removes the legacy eBPF dataplane.
 | Issue | Plan | Required before | Code PR still needed |
 |---|---|---|---|
 | #1374 SYN cookie flood protection | [plan-1374-syn-cookies.md](plan-1374-syn-cookies.md) | #1373 Phase 4 | Yes |
-| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | Phase 4 | Yes |
+| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | #1373 Phase 4 | Yes |
 | #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | #1373 Phase 4 | Yes |
+| #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | #1373 Phase 4 | Partly covered by #1385 |
 | #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | Yes |
 | #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | #1373 Phase 4 | Yes |
+| #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | #1373 Phase 4 | Partly covered by #1386 |
 
 ## Shared Dependency
 
@@ -20,8 +22,8 @@ land before Phase 4 removes the legacy eBPF dataplane.
 `Manager` still embeds the eBPF `DataPlane`, which makes capability removal,
 event source selection, scheduler update dispatch, and BPF source deletion
 coupled to the old map-shaped interface. The implementation PRs for #1374,
-#1375, #1376, #1378, and #1379 should land after #1381 or explicitly include
-the matching interface split/stub slice.
+#1375, #1376, #1377, #1378, #1379, and #1380 should land after #1381 or
+explicitly include the matching interface split/stub slice.
 
 ## Shared Non-Goals
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -2,7 +2,7 @@
 
 Status: design-plan bundle for #1373 blockers. These docs convert the
 reviewed issue contracts into implementation plans for the code PRs that must
-land before Phase 4 removes the legacy eBPF dataplane.
+land before their listed #1373 retirement phase.
 
 ## Blocker Index
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -14,7 +14,7 @@ land before Phase 4 removes the legacy eBPF dataplane.
 | #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | #1373 Phase 4 | Partly covered by #1385 |
 | #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | Yes |
 | #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | #1373 Phase 4 | Yes |
-| #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | #1373 Phase 4 | Partly covered by #1386 |
+| #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | #1373 Phase 5 | Partly covered by #1386 |
 
 ## Shared Dependency
 
@@ -22,8 +22,11 @@ land before Phase 4 removes the legacy eBPF dataplane.
 `Manager` still embeds the eBPF `DataPlane`, which makes capability removal,
 event source selection, scheduler update dispatch, and BPF source deletion
 coupled to the old map-shaped interface. The implementation PRs for #1374,
-#1375, #1376, #1377, #1378, #1379, and #1380 should land after #1381 or
-explicitly include the matching interface split/stub slice.
+#1375, #1376, #1377, #1378, and #1379 should land after #1381 or explicitly
+include the matching interface split/stub slice before Phase 4 BPF source
+removal. #1380 is a Phase 5 CLI/observability cleanup blocker: it must land
+before BPF-map-oriented operator surfaces disappear, but it does not block the
+Phase 4 forwarding-source removal gate by itself.
 
 ## Shared Non-Goals
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -1,0 +1,33 @@
+# #1373 Retire eBPF Dataplane Blocker Plans
+
+Status: design-plan bundle for #1373 blockers. These docs convert the
+reviewed issue contracts into implementation plans for the code PRs that must
+land before Phase 4 removes the legacy eBPF dataplane.
+
+## Blocker Index
+
+| Issue | Plan | Required before | Code PR still needed |
+|---|---|---|---|
+| #1374 SYN cookie flood protection | [plan-1374-syn-cookies.md](plan-1374-syn-cookies.md) | #1373 Phase 4 | Yes |
+| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | Phase 4 | Yes |
+| #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | #1373 Phase 4 | Yes |
+| #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | Yes |
+| #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | #1373 Phase 4 | Yes |
+
+## Shared Dependency
+
+#1381 is the common plumbing dependency for the blocker set. The userspace
+`Manager` still embeds the eBPF `DataPlane`, which makes capability removal,
+event source selection, scheduler update dispatch, and BPF source deletion
+coupled to the old map-shaped interface. The implementation PRs for #1374,
+#1375, #1376, #1378, and #1379 should land after #1381 or explicitly include
+the matching interface split/stub slice.
+
+## Shared Non-Goals
+
+- Do not remove `bpf/` in these blocker implementation PRs; that remains #1373
+  Phase 4.
+- Do not rewrite unrelated dataplane behavior while adding parity for the
+  missing features.
+- Do not use the DPDK worker as a correctness reference when it conflicts with
+  the reviewed userspace-dp contract.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
@@ -29,10 +29,18 @@ Cookie ISN layout:
 [5 bits epoch] [3 bits MSS index] [24 bits MAC]
 ```
 
-The MAC covers source/destination IPs, ports, MSS index, zone, and epoch. The
-secret is cluster-consistent: either synced as HA state or derived from an
-HA-synced master key plus `(zone_id, epoch)`. Local-only secrets are rejected
-because failover would invalidate in-flight cookies.
+The transmitted epoch field is only `epoch & 0x1f`. The full monotonic epoch is
+still part of the MAC input and secret derivation. Validation reconstructs
+candidate full epochs from the current and previous full epochs, then accepts
+only candidates whose low 5 bits match the transmitted field and whose MAC
+validates. A cookie minted 32 epochs ago has the same transmitted low bits as
+the current epoch but must reject because the full epoch used for MAC/secret
+derivation is outside the current/previous validation window.
+
+The MAC covers source/destination IPs, ports, MSS index, zone, and the full
+monotonic epoch. The secret is cluster-consistent: either synced as HA state or
+derived from an HA-synced master key plus `(zone_id, full_epoch)`. Local-only
+secrets are rejected because failover would invalidate in-flight cookies.
 
 On flood threshold:
 
@@ -66,10 +74,26 @@ On returning ACK:
   epoch overlap.
 - Epoch uses monotonic time, not wall clock, so NTP rollback does not invalidate
   cookies.
+- Epoch publication must be generation-atomic with the secret snapshot: workers
+  must not see a new full epoch with an old per-zone secret or the reverse.
 - Failover during an active flood continues accepting cookies minted by the
   former active node for the overlap window.
 - `synproxy_active`, sent, valid, invalid, bypass, and budget-drop counters are
   exposed in userspace status.
+
+## Risks
+
+- Replay/wrap: the low 5 transmitted epoch bits wrap every 32 epochs. The
+  full-epoch MAC rule above is mandatory to prevent old cookies from becoming
+  valid again at low-bit wrap.
+- Failover skew: active and backup nodes need bounded monotonic-epoch skew or a
+  shared epoch source; otherwise cookies minted immediately before failover can
+  be rejected by the new active node.
+- Budget starvation: cookie replies are useful only if the bounded reply budget
+  cannot drain normal forwarding frames. Drop accounting must distinguish
+  invalid-cookie drops from reply-budget drops.
+- Validated-client cache pressure: attacker-generated valid-looking ACKs must
+  not evict legitimate validated clients without caps and counters.
 
 ## Exact Tests
 
@@ -78,6 +102,8 @@ On returning ACK:
 - Cargo: `screen::syn_cookie_validate_rejects_stale_secret`.
 - Cargo: `screen::syn_cookie_mss_index_encoding_parity`.
 - Cargo: `screen::syn_cookie_ntp_rollback_monotonic_epoch`.
+- Cargo: `screen::syn_cookie_epoch_low_bits_wrap_rejects_32_epoch_old_cookie`.
+- Cargo: `screen::syn_cookie_validation_tries_current_and_previous_full_epoch`.
 - Cargo: `screen::syn_cookie_chosen_when_threshold_exceeded`.
 - Cargo: `screen::syn_cookie_budget_drop_does_not_starve_tx`.
 - Go: remove/update the `SynFloodProtectionMode == "syn-cookie"` capability

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
@@ -1,0 +1,95 @@
+# #1374 Userspace SYN Cookie Flood Protection Plan
+
+## Goal
+
+Remove the userspace capability fallback for
+`security flow syn-flood-protection-mode syn-cookie` by implementing eBPF-parity
+SYN cookie behavior in `userspace-dp`.
+
+## Dependencies
+
+- #1381 should land first. Gate removal in
+  `pkg/dataplane/userspace/snapshot.go` and capability reporting should happen
+  through the standalone userspace manager contract, not the embedded eBPF
+  manager.
+- The implementation PR may depend on existing TX reply primitives, but must
+  profile the actual TX completion cost instead of assuming in-place RX-to-TX
+  bounce is required.
+
+## Design
+
+Use SipHash, not HMAC-SHA1/SHA256. Linux SYN cookies and the current kernel
+kfunc path use SipHash-class keyed hashing, and the transmitted budget is only
+the 32-bit TCP ISN. Per-zone secrets rotate every 64 seconds using a monotonic
+epoch. Validation accepts the current and previous epochs.
+
+Cookie ISN layout:
+
+```text
+[5 bits epoch] [3 bits MSS index] [24 bits MAC]
+```
+
+The MAC covers source/destination IPs, ports, MSS index, zone, and epoch. The
+secret is cluster-consistent: either synced as HA state or derived from an
+HA-synced master key plus `(zone_id, epoch)`. Local-only secrets are rejected
+because failover would invalidate in-flight cookies.
+
+On flood threshold:
+
+1. Check existing `SynProfile` threshold state and set `synproxy_active`.
+2. Allocate a cookie-reply frame from a bounded per-binding cookie budget.
+3. Build a SYN-ACK with the encoded ISN and transmit it back to the source.
+4. If the budget is exhausted, drop the flood SYN and increment a screen-drop
+   counter rather than starving normal TX.
+
+On returning ACK:
+
+1. Validate tuple, epoch, MSS index, and MAC.
+2. On success, mark the client validated and send RST, matching the current
+   eBPF behavior; the client's retransmitted SYN then creates the normal
+   policy/NAT/session path.
+3. On failure, drop with no session creation and increment invalid-cookie
+   counters.
+
+## Hot-Path Invariants
+
+- No heap allocation while deciding SYN cookie mint or ACK validation.
+- SipHash key lookup is per-zone and read-only on the published snapshot.
+- Cookie reply frame allocation is bounded; normal forwarding frame ownership
+  takes priority over diagnostic/flood replies.
+- Random ACKs never install sessions.
+- Validated-client state uses a bounded LRU or equivalent capped table.
+
+## State and HA Behavior
+
+- Secrets are consistent across active and backup nodes with current+previous
+  epoch overlap.
+- Epoch uses monotonic time, not wall clock, so NTP rollback does not invalidate
+  cookies.
+- Failover during an active flood continues accepting cookies minted by the
+  former active node for the overlap window.
+- `synproxy_active`, sent, valid, invalid, bypass, and budget-drop counters are
+  exposed in userspace status.
+
+## Exact Tests
+
+- Cargo: `screen::syn_cookie_mint_validate_roundtrip`.
+- Cargo: `screen::syn_cookie_validate_rejects_modified_tuple`.
+- Cargo: `screen::syn_cookie_validate_rejects_stale_secret`.
+- Cargo: `screen::syn_cookie_mss_index_encoding_parity`.
+- Cargo: `screen::syn_cookie_ntp_rollback_monotonic_epoch`.
+- Cargo: `screen::syn_cookie_chosen_when_threshold_exceeded`.
+- Cargo: `screen::syn_cookie_budget_drop_does_not_starve_tx`.
+- Go: remove/update the `SynFloodProtectionMode == "syn-cookie"` capability
+  rejection and the manager test that pins it.
+- Integration: hping3 SYN flood against the userspace HA cluster with
+  `syn-cookie` configured; verify SYN-ACK replies, legitimate retransmitted SYN
+  admission after validated ACK/RST, random ACK drops, and failover acceptance
+  within the epoch overlap.
+- Smoke: existing screen smoke for the other checks still passes.
+
+## Non-Goals
+
+- Do not synthesize a full session directly from the cookie ACK in this PR.
+- Do not change policy, NAT, or FIB semantics on the first retransmitted SYN.
+- Do not remove eBPF source as part of #1374.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
@@ -1,0 +1,77 @@
+# #1375 Userspace Three-Color Policer Plan
+
+## Goal
+
+Add userspace support for Junos three-color policers so configs under
+`firewall three-color-policer` no longer require the eBPF dataplane.
+
+## Dependencies
+
+- #1381 should land first so userspace capability removal and snapshot delivery
+  are owned by the userspace manager, not BPF-shaped map writers.
+- Do not inherit the DPDK srTCM overflow bug; the Rust implementation must use
+  the RFC contract below as the source of truth.
+
+## Design
+
+Extend the userspace policer snapshot and Rust types with srTCM, trTCM,
+`color_blind`, color-aware input handling, and per-color actions for DSCP
+rewrite plus red drop/count behavior.
+
+Use `u128` token refill math with `monotonic_nanos`. Reject invalid config at
+compile/commit time: zero rate, zero burst, `PIR < CIR`, `PBS < CBS`, and
+missing required three-color fields.
+
+srTCM: C fills at CIR; E fills only when C is full and EBS remains; green
+requires C tokens, yellow requires E tokens, red otherwise.
+
+trTCM: C fills independently at CIR; P fills independently at PIR; green
+requires both C and P tokens, yellow requires only P tokens, red otherwise.
+
+Color-aware mode must respect incoming color and never promote packets above
+their incoming color. Color-blind mode evaluates each packet without inherited
+color.
+
+## Hot-Path Invariants
+
+- Flow-cache hits still execute the policer before forwarding.
+- No `f64` token math in the dataplane.
+- No `FxHashMap<String, PolicerState>` mutable hot-path lookup as the final
+  production model; use stable rule IDs with sharded or packed atomic state.
+- Per-color DSCP rewrite and red drop decisions happen in the same forwarding
+  decision that accounts tokens.
+- Per-color counters are updated without central hot atomics.
+
+## State and HA Behavior
+
+- Policer token state is local runtime state; failover may restart token buckets
+  from configured burst values unless a broader HA state-sync PR explicitly
+  adds token sync.
+- Config snapshots carry stable policer/rule identity so counters can survive
+  snapshot rebuilds where practical.
+- Status exposes green/yellow/red packet and byte counters, DSCP rewrites, and
+  red drops through Rust status, Go protocol, CLI, and Prometheus.
+
+## Exact Tests
+
+- Cargo: `policer::srTCM_green_yellow_red_at_thresholds`.
+- Cargo: `policer::srTCM_c_overflow_refills_e_bucket`.
+- Cargo: `policer::trTCM_independent_CIR_PIR`.
+- Cargo: `policer::color_aware_never_promotes_incoming_yellow_or_red`.
+- Cargo: `policer::color_blind_ignores_incoming_color`.
+- Cargo: `policer::u128_bucket_math_boundary_inputs`.
+- Cargo: `policer::three_color_dscp_rewrite`.
+- Cargo: `policer::flow_cache_hits_run_policer`.
+- Go: userspace snapshot round-trip for three-color policer fields, per-color
+  actions, and `ColorBlind`.
+- Go: compiler validation rejects zero rates/bursts, `PIR < CIR`, and
+  `PBS < CBS`.
+- Integration: controlled-rate traffic against userspace cluster verifies
+  green/yellow/red classification, DSCP rewrite, red drop behavior, and
+  per-color counters.
+
+## Non-Goals
+
+- Do not fix the separate DPDK srTCM dead-overflow bug in this PR.
+- Do not redesign CoS shaping or scheduler behavior.
+- Do not remove eBPF source as part of #1375.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
@@ -52,6 +52,19 @@ color.
 - Status exposes green/yellow/red packet and byte counters, DSCP rewrites, and
   red drops through Rust status, Go protocol, CLI, and Prometheus.
 
+## Risks
+
+- Token overflow/math: refill uses rates, bursts, and elapsed time supplied by
+  config and monotonic clocks. All multiplication must stay in `u128` or
+  explicitly saturate before conversion to packet-size units.
+- Atomicity: packed/sharded state must avoid cross-worker false sharing while
+  preserving one logical bucket per configured policer identity.
+- Color semantics: color-aware mode must never promote incoming yellow/red
+  traffic; one wrong branch turns a security control into a bandwidth grant.
+- Counter attribution: green/yellow/red/drop counters must survive snapshot
+  rebuilds by stable identity, or operators cannot audit policer behavior after
+  commits.
+
 ## Exact Tests
 
 - Cargo: `policer::srTCM_green_yellow_red_at_thresholds`.
@@ -66,6 +79,9 @@ color.
   actions, and `ColorBlind`.
 - Go: compiler validation rejects zero rates/bursts, `PIR < CIR`, and
   `PBS < CBS`.
+- Go: `deriveUserspaceCapabilities()` admits three-color policer configs only
+  after the userspace snapshot and Rust runtime support are wired, and rejects
+  them before that point.
 - Integration: controlled-rate traffic against userspace cluster verifies
   green/yellow/red classification, DSCP rewrite, red drop behavior, and
   per-color counters.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -55,6 +55,19 @@ that binding.
 - On failover, the new active node mirrors according to the current config; no
   mirror clone state is synchronized.
 
+## Risks
+
+- Mirror backpressure: mirror clones are intentionally lossy. Queue-full,
+  no-frame, and missing-binding cases must drop only the clone and never delay
+  primary forwarding.
+- Cross-binding ownership: cloned descriptors must use the same recycle/UMEM
+  routing discipline as forwarding descriptors; a mirror drop must not return a
+  frame to the wrong binding.
+- Full-frame fidelity: mirror output must preserve Ethernet/VLAN bytes. Any
+  L3-only fallback path silently breaks packet capture/debug workflows.
+- Sampling ambiguity: per-binding sampling is cheaper than global exact
+  sampling, but docs and counters must not claim exact global 1-in-N behavior.
+
 ## Exact Tests
 
 - Cargo: `mirror::sampling_rate_correctness`.
@@ -67,6 +80,9 @@ that binding.
 - Go: userspace snapshot round-trip for mirror config.
 - Go: commit validation rejects duplicate ingress mirror entries and logs/skips
   nonexistent output ifindex consistently with current compiler behavior.
+- Go: `deriveUserspaceCapabilities()` admits port-mirroring configs only after
+  userspace snapshot/runtime support is wired, and rejects them before that
+  point.
 - Integration: userspace cluster with mirror config and tcpdump on output
   interface verifies sample ratio, full frame preservation, and primary
   forwarding survival under mirror pressure.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -1,0 +1,79 @@
+# #1376 Userspace Port Mirroring Plan
+
+## Goal
+
+Support `forwarding-options port-mirroring` in userspace-dp so ingress mirror
+configs no longer fall back to the eBPF dataplane.
+
+## Dependencies
+
+- #1381 should land first so capability removal and config snapshot shape are
+  independent of the embedded eBPF manager.
+- Cross-binding inject should use the same ownership discipline as existing
+  userspace fabric/cross-binding transmit paths.
+
+## Design
+
+Add `MirrorConfig { output_ifindex, rate }` to the userspace snapshot and Rust
+state. Preserve the current eBPF data model: one mirror entry per ingress
+ifindex. Duplicate ingress ifindex config must be rejected at commit time.
+
+Mirroring runs after ingress policy/forwarding decision while the original
+packet bytes are still available. A matched mirror allocates a clone frame,
+copies the full L2 frame with no truncation, and queues it to the configured
+output binding.
+
+Cross-binding mirror uses cross-binding inject only. Do not use the slow-path
+TUN sink because TUN is L3 and strips Ethernet, while port mirroring requires
+full L2 packet preservation.
+
+Sampling is per-worker/per-binding, matching the current eBPF per-CPU shape:
+`rate == 0` mirrors every packet; `rate == N` mirrors approximately 1 in N for
+that binding.
+
+## Hot-Path Invariants
+
+- Normal forwarding wins over mirroring. Mirror clones are discardable under
+  pressure.
+- Mirror allocation uses a bounded budget or reserve threshold; it cannot drain
+  the frame pool needed by primary RX/TX.
+- Missing destination binding, queue-full, and no-frame paths drop only the
+  mirror clone and account the reason.
+- The mirrored bytes are the full original Ethernet frame, including VLAN tags
+  and IPv4/IPv6 payload.
+- No global sampling atomic unless a future contract explicitly requires exact
+  global 1-in-N semantics.
+
+## State and HA Behavior
+
+- Mirror config is snapshot state and is republished on config changes.
+- Runtime sampling counters are local per binding and reset on worker restart or
+  failover.
+- Counters exposed through Rust status, Go protocol, CLI, and Prometheus:
+  `mirrored_packets`, `mirrored_bytes`, `mirror_drops_no_frame`,
+  `mirror_drops_no_binding`, and `mirror_drops_queue_full`.
+- On failover, the new active node mirrors according to the current config; no
+  mirror clone state is synchronized.
+
+## Exact Tests
+
+- Cargo: `mirror::sampling_rate_correctness`.
+- Cargo: `mirror::cross_binding_inject`.
+- Cargo: `mirror::out_of_frame_drops_increment_counter`.
+- Cargo: `mirror::missing_destination_binding_drop_counter`.
+- Cargo: `mirror::queue_full_drop_counter`.
+- Cargo: `mirror::duplicate_ingress_ifindex_rejected`.
+- Cargo: `mirror::ipv4_ipv6_full_frame_preservation`.
+- Go: userspace snapshot round-trip for mirror config.
+- Go: commit validation rejects duplicate ingress mirror entries and logs/skips
+  nonexistent output ifindex consistently with current compiler behavior.
+- Integration: userspace cluster with mirror config and tcpdump on output
+  interface verifies sample ratio, full frame preservation, and primary
+  forwarding survival under mirror pressure.
+
+## Non-Goals
+
+- Do not implement a TUN-based mirror sink.
+- Do not implement multiple mirror outputs per ingress ifindex.
+- Do not make mirror delivery reliable at the expense of forwarding.
+- Do not remove eBPF source as part of #1376.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
@@ -1,0 +1,74 @@
+# #1377 Userspace Persistent SNAT Pool Plan
+
+## Goal
+
+Make source-NAT pool mode a first-class userspace feature so configs using
+`then source-nat pool <name>` no longer depend on the legacy eBPF dataplane for
+address selection, port-range enforcement, and durable translations.
+
+## Dependencies
+
+- #1381 should land first so NAT config ownership and runtime status are
+  backend-local rather than daemon-side BPF map writes.
+- #1385 closes the immediate snapshot safety gap by failing closed when a
+  pool-mode SNAT rule references a missing or unsafe pool. The full #1377
+  implementation still needs persistent address/port selection semantics.
+
+## Design
+
+Userspace snapshots must carry the resolved pool address set, configured port
+range, rule identity, and persistence mode. Rust NAT state then owns address and
+port allocation on the forwarding path. Missing pools, empty pools, invalid
+port ranges, or unsupported persistence modes must be rejected at commit/snapshot
+admission; they must not produce a broad match with no translation.
+
+Port allocation should be sharded per worker and per pool address to avoid a
+single hot allocator. Persistent mappings need a bounded table keyed by the
+Junos-compatible persistence key, with LRU/timeout reclamation and collision
+handling that never aliases two live clients to the same translated 5-tuple.
+
+## Hot-Path Invariants
+
+- No global allocator lock on the packet path.
+- Port-range validation happens before any `u16` truncation.
+- A pool-mode rule without a usable pool is fail-closed, not a matching no-op.
+- Existing reverse-session NAT behavior remains the source of truth for return
+  traffic.
+
+## State and HA Behavior
+
+- Active translations are session state and must be included in session sync or
+  reconstructed from synced session metadata on failover.
+- Persistent mapping tables are runtime state; failover behavior must be
+  documented if persistence survives only for active synced sessions.
+- Counters expose allocation success, port exhaustion, missing-pool rejects,
+  and persistence table evictions.
+
+## Risks
+
+- Silent broad matches: the worst failure mode is a pool rule that matches
+  traffic but performs no NAT, shadowing later rules. Admission must fail closed.
+- Port exhaustion: allocator contention and exhaustion can cause bursty drops;
+  counters must separate exhaustion from policy/NAT no-match.
+- Persistence leakage: stale mappings can pin scarce ports after lease/session
+  expiry unless reclamation is tied to session lifetime.
+- HA skew: allocating different translated ports on the peer after failover can
+  break return traffic for live sessions.
+
+## Exact Tests
+
+- Go: snapshot builder rejects missing pool, empty pool, invalid port range,
+  and unsupported persistence without emitting a matching no-op rule.
+- Go: userspace snapshot round-trip carries pool addresses, port low/high, rule
+  identity, and persistence mode.
+- Cargo: allocator respects configured port range and never returns duplicate
+  live translated 5-tuples.
+- Cargo: persistent key reuses the same mapping while live and reallocates after
+  expiry.
+- Integration: multiple clients through a userspace SNAT pool preserve reverse
+  traffic across failover and report pool-exhaustion counters under pressure.
+
+## Non-Goals
+
+- Do not redesign all NAT rule matching in this PR.
+- Do not remove eBPF NAT source as part of #1377.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
@@ -1,10 +1,11 @@
-# #1377 Userspace Persistent SNAT Pool Plan
+# #1377 Userspace Address-Persistent SNAT Pool Plan
 
 ## Goal
 
 Make source-NAT pool mode a first-class userspace feature so configs using
 `then source-nat pool <name>` no longer depend on the legacy eBPF dataplane for
-address selection, port-range enforcement, and durable translations.
+address selection, address-persistent pool choice, port-range enforcement, and
+durable translations.
 
 ## Dependencies
 
@@ -12,20 +13,40 @@ address selection, port-range enforcement, and durable translations.
   backend-local rather than daemon-side BPF map writes.
 - #1385 closes the immediate snapshot safety gap by failing closed when a
   pool-mode SNAT rule references a missing or unsafe pool. The full #1377
-  implementation still needs persistent address/port selection semantics.
+  implementation still needs address-persistent pool selection semantics and a
+  cross-backend compatibility decision.
 
 ## Design
 
 Userspace snapshots must carry the resolved pool address set, configured port
-range, rule identity, and persistence mode. Rust NAT state then owns address and
-port allocation on the forwarding path. Missing pools, empty pools, invalid
-port ranges, or unsupported persistence modes must be rejected at commit/snapshot
-admission; they must not produce a broad match with no translation.
+range, rule identity, global `source address-persistent` state, and per-pool
+`persistent-nat` mode. Rust NAT state then owns address and port allocation on
+the forwarding path. Missing pools, empty pools, invalid port ranges, or
+unsupported persistence modes must be rejected at commit/snapshot admission;
+they must not produce a broad match with no translation.
+
+Address-persistent pool selection is not currently cross-backend equivalent and
+must be made explicit before #1373 Phase 4:
+
+- legacy eBPF IPv4 uses `src_ip % num_ips`;
+- legacy eBPF IPv6 XORs the four 32-bit source-address lanes and mods by the
+  IPv6 pool size;
+- current userspace uses a `xpf-userspace-snat-address-persistent-v1` domain
+  tag plus address family and canonical source bytes through SHA-256; and
+- DPDK consumes the shared pool config but has allocator-local implementation
+  details.
+
+#1377 must either standardize a single shared algorithm for all retained
+backends or document a compatibility break and constrain mixed-backend
+failover/rollback tests accordingly. Until then, "address-persistent" means
+stable within one backend's pool order and size, not stable across eBPF,
+userspace, and DPDK.
 
 Port allocation should be sharded per worker and per pool address to avoid a
 single hot allocator. Persistent mappings need a bounded table keyed by the
-Junos-compatible persistence key, with LRU/timeout reclamation and collision
-handling that never aliases two live clients to the same translated 5-tuple.
+Junos-compatible `persistent-nat` key, with LRU/timeout reclamation and
+collision handling that never aliases two live clients to the same translated
+5-tuple.
 
 ## Hot-Path Invariants
 
@@ -34,6 +55,9 @@ handling that never aliases two live clients to the same translated 5-tuple.
 - A pool-mode rule without a usable pool is fail-closed, not a matching no-op.
 - Existing reverse-session NAT behavior remains the source of truth for return
   traffic.
+- Address-persistent pool choice must be deterministic for the configured
+  backend, source address, pool family, and pool order; any cross-backend
+  divergence must be captured in tests and docs.
 
 ## State and HA Behavior
 
@@ -54,6 +78,9 @@ handling that never aliases two live clients to the same translated 5-tuple.
   expiry unless reclamation is tied to session lifetime.
 - HA skew: allocating different translated ports on the peer after failover can
   break return traffic for live sessions.
+- Algorithm divergence: a rollback from userspace to eBPF or DPDK can map the
+  same source to a different pool address unless #1377 standardizes the
+  algorithm or declares the compatibility boundary.
 
 ## Exact Tests
 
@@ -63,6 +90,8 @@ handling that never aliases two live clients to the same translated 5-tuple.
   identity, and persistence mode.
 - Cargo: allocator respects configured port range and never returns duplicate
   live translated 5-tuples.
+- Cargo/Go: address-persistent algorithm fixtures cover IPv4 and IPv6 source
+  addresses, pool reordering, and the chosen cross-backend compatibility rule.
 - Cargo: persistent key reuses the same mapping while live and reallocates after
   expiry.
 - Integration: multiple clients through a userspace SNAT pool preserve reverse

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
@@ -1,0 +1,83 @@
+# #1378 Userspace Policy Scheduler Plan
+
+## Goal
+
+Propagate Junos `schedulers { ... }` state into userspace policy evaluation so
+scheduled policy rules activate and deactivate correctly without the eBPF
+`policy_rules` map.
+
+## Dependencies
+
+- #1381 must land first. `UpdatePolicyScheduleState` currently dispatches
+  through the embedded eBPF `DataPlane`; userspace needs either the split
+  interface or an explicit stub/snapshot branch.
+
+## Design
+
+Add `SchedulerName string`, `Inactive bool`, and a stable rule identity to
+`PolicyRuleSnapshot` and `userspace-dp/src/policy.rs::PolicyRule`. The stable
+identity must not depend on transient array position alone; use a config-driven
+UUID if available or `(policy_set_id, policy_name, rule_name)`/equivalent
+compiled identity.
+
+On scheduler state changes, publish one atomic userspace snapshot delta that
+contains the updated inactive bits for all affected rules. Do not issue
+per-rule fast-path toggles because first-match ordering requires same-instant
+activate/deactivate semantics.
+
+`evaluate_policy` skips inactive rules before address/application matching.
+This is on the new-flow/session-miss path; flow-cache hits keep forwarding
+existing sessions unless a separate `policy-rematch` feature is implemented.
+That matches Junos default behavior: schedulers block new lookups, not existing
+sessions.
+
+Scheduler granularity is 60 seconds. Tests and docs must use deterministic
+clock injection or windows that span multiple evaluator ticks; the earlier
+30-second integration target is invalid.
+
+Missing scheduler references fail closed as commit errors. Do not copy the
+existing eBPF behavior that can default missing scheduler state to active.
+
+## Hot-Path Invariants
+
+- One inactive-branch per rule on miss path is acceptable; no scheduler clock
+  evaluation occurs in the packet worker.
+- Snapshot publication is ArcSwap-atomic across all rule inactive bits.
+- Hit counters are keyed by stable rule identity outside rebuilt rule structs so
+  counters survive scheduler snapshot rebuilds.
+- Do not copy the existing eBPF indexing bug in
+  `UpdatePolicyScheduleState`; userspace updates must target stable identities.
+
+## State and HA Behavior
+
+- Scheduler active state is control-plane derived from config and daemon clock;
+  it is republished after config load, daemon restart, and scheduler state
+  change.
+- Existing sessions continue until normal timeout unless policy-rematch is
+  explicitly configured in a later feature.
+- Counters persist across active/inactive flips and snapshot rebuilds.
+- HA failover recomputes scheduler state on the new active node and publishes a
+  complete policy snapshot before admitting scheduled-policy traffic.
+
+## Exact Tests
+
+- Cargo: `policy::evaluate_policy_skips_inactive_rules`.
+- Cargo: `policy::inactive_rule_falls_through_to_next_match`.
+- Cargo: `policy::hit_counters_survive_scheduler_snapshot_rebuild`.
+- Cargo: `policy::snapshot_publish_applies_inactive_bits_atomically`.
+- Go: userspace snapshot round-trip for `SchedulerName`, `Inactive`, and stable
+  rule identity.
+- Go: deterministic scheduler clock tests for active/inactive windows at
+  60-second granularity.
+- Go: `UpdatePolicyScheduleState` in userspace mode republishes one snapshot
+  delta with updated inactive bits.
+- Go: missing scheduler reference is a commit error.
+- Integration: scheduler window spanning multiple 60-second ticks with a policy
+  referencing it; new connections pass only during active windows, while
+  established sessions retain Junos-default behavior.
+
+## Non-Goals
+
+- Do not implement multi-scheduler-per-rule; current config supports one.
+- Do not implement policy-rematch/session flush in this PR.
+- Do not remove eBPF source as part of #1378.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
@@ -59,6 +59,18 @@ existing eBPF behavior that can default missing scheduler state to active.
 - HA failover recomputes scheduler state on the new active node and publishes a
   complete policy snapshot before admitting scheduled-policy traffic.
 
+## Risks
+
+- Scheduler atomicity: first-match policy ordering requires affected inactive
+  bits to publish as one coherent snapshot. Per-rule toggles can expose an
+  impossible mixed policy state.
+- Clock drift: scheduler state is daemon-clock derived. HA peers must recompute
+  after failover rather than trusting stale peer-local state.
+- Counter continuity: stable rule identity is mandatory because inactive flips
+  and snapshot rebuilds must not reset operator-visible hit counters.
+- Missing scheduler references: fail-open behavior admits traffic outside the
+  intended time window; userspace must reject these commits explicitly.
+
 ## Exact Tests
 
 - Cargo: `policy::evaluate_policy_skips_inactive_rules`.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -68,6 +68,19 @@ forwarding decision.
 - Fan-in/source selection must avoid duplicate syslog records when both legacy
   eBPF and userspace event sources are present during migration.
 
+## Risks
+
+- Duplicate/lost syslog events: overlap mode must select exactly one source for
+  a decision or explicitly de-duplicate fan-in records.
+- Deny storms: policy or screen drops can arrive at Mpps rates. Rate limiting
+  and non-blocking queue behavior must prevent event emission from becoming a
+  forwarding bottleneck.
+- Metadata fidelity: policy/rule/application identity must be available at the
+  decision point; reconstructing it later from mutable config risks wrong audit
+  records after commits.
+- Codec compatibility: adding event types must not renumber existing session
+  frames or mixed-version readers will decode the wrong event kind.
+
 ## Exact Tests
 
 - Cargo: codec encode/decode round-trip for `MSG_POLICY_DENY`.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -1,0 +1,99 @@
+# #1379 Userspace Dataplane Events Plan
+
+## Goal
+
+Emit userspace-dp per-flow `PolicyDeny`, `ScreenDrop`, and `FilterLog` events
+with eBPF syslog parity so removing the eBPF ring buffer does not regress
+security visibility or audit logging.
+
+## Dependencies
+
+- #1381 must land first or in the same stack. Daemon event-source selection and
+  userspace manager ownership are tightly coupled to the DataPlane interface
+  split.
+- #1378-style policy/rule identity plumbing is useful for high-fidelity policy
+  event fields; coordinate identity shape across both PRs.
+
+## Design
+
+Add frame types to `userspace-dp/src/event_stream/codec.rs`:
+
+- `MSG_POLICY_DENY = 11`
+- `MSG_SCREEN_DROP = 12`
+- `MSG_FILTER_LOG = 13`
+
+Keep existing message values stable and add golden codec tests for old and new
+frames.
+
+The frame layout must fit the existing fixed-size event budget and carry the
+fields needed to reproduce eBPF `dataplane.Event` semantics, including source
+and destination tuple, ingress ifindex/interface name path, zone data,
+policy/rule/application identity, reason, NAT-rewritten tuple when applicable,
+and timestamp.
+
+Emission points:
+
+- policy deny path in `userspace-dp/src/policy.rs`
+- screen drop path in `userspace-dp/src/screen.rs`
+- filter log term path in `userspace-dp/src/filter/engine.rs`
+
+FilterLog matches BPF semantics: emit only for `then log` / `then syslog`, not
+plain `then count`.
+
+Go adds a userspace logging `EventSource` adapter that converts these frames
+into the same `dataplane.Event` records consumed by `pkg/logging/ringbuf.go`.
+During the overlap phases before BPF removal, use either a composite fan-in
+source or explicit dataplane-mode event source selection. The daemon must not
+silently keep reading only the legacy eBPF ring buffer while userspace owns the
+forwarding decision.
+
+## Hot-Path Invariants
+
+- Event emission is fixed-size, no heap, copy-by-value, and non-blocking.
+- Use `try_send`; a full event queue drops the event and increments a counter.
+- Add per-source-zone/per-event token buckets to prevent deny storms from
+  starving session open/close/update events.
+- Event frames stay within the existing 256-byte-ish event budget unless the
+  codec is explicitly resized and tested.
+- Policy evaluation returns enough rule/policy/app metadata for event creation;
+  no post-hoc heap lookup on the worker hot path.
+
+## State and HA Behavior
+
+- Event stream is operational telemetry, not synchronized HA state.
+- Dropped-event counters are local per node and exposed in userspace status,
+  CLI, and Prometheus.
+- On failover, the new active node emits events for decisions it owns; no event
+  replay is required.
+- Fan-in/source selection must avoid duplicate syslog records when both legacy
+  eBPF and userspace event sources are present during migration.
+
+## Exact Tests
+
+- Cargo: codec encode/decode round-trip for `MSG_POLICY_DENY`.
+- Cargo: codec encode/decode round-trip for `MSG_SCREEN_DROP`.
+- Cargo: codec encode/decode round-trip for `MSG_FILTER_LOG`.
+- Cargo: golden codec tests for existing session frame type values.
+- Cargo: policy deny path emits a fixed-size event with correct metadata.
+- Cargo: screen drop path emits a rate-limited event and accounts drops when
+  the limiter is empty.
+- Cargo: filter log emits only for log/syslog terms, not count-only terms.
+- Cargo: event queue full uses non-blocking drop-and-count behavior.
+- Go: userspace `EventSource` adapter converts each new frame into the expected
+  `dataplane.Event`.
+- Go: `pkg/logging/ringbuf_test.go` or equivalent verifies identical
+  `RT_FLOW_SESSION_DENY`, screen-drop, and filter-log syslog output for eBPF
+  and userspace events.
+- Go: daemon dispatch test covers userspace source selection or fan-in without
+  duplicate records.
+- Integration: userspace cluster with deny policy, screen drop, and filter log
+  term; generated traffic produces matching syslog records with no session
+  event starvation under a deny storm.
+
+## Non-Goals
+
+- Do not replace the HA session-sync event stream with this logging adapter.
+- Do not emit FilterLog for count-only filter terms.
+- Do not make event delivery reliable at Mpps flood rates; rate-limited loss
+  with counters is acceptable.
+- Do not remove eBPF source as part of #1379.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
@@ -1,0 +1,71 @@
+# #1380 Userspace Buffer and Status Parity Plan
+
+## Goal
+
+Keep operational buffer/status visibility intact after the eBPF dataplane is
+retired. `show system buffers`, gRPC `ShowText`, and related status/metrics
+must expose userspace AF_XDP ring capacity, fill/comp pressure, and active
+session summaries with the same operator utility as the legacy path.
+
+## Dependencies
+
+- #1381 should land first so status and telemetry live behind the abstract
+  runtime domains instead of depending on the embedded eBPF manager.
+- #1386 restores the immediate userspace `show system buffers` parity gaps:
+  active-session footer, detail/non-detail distinction, and fallback from sparse
+  per-binding capacity gauges to binding-level status.
+
+## Design
+
+Treat buffer visibility as runtime telemetry, not config state. The userspace
+helper publishes per-binding/ring capacity, available fill frames, completion
+backlog, RX/TX ring occupancy, and drop/error counters. Go formatting keeps a
+stable aggregate view for `show system buffers` and only emits per-binding rows
+for `show system buffers detail`.
+
+If mixed-version helpers omit a newer capacity surface, Go must fall back to the
+older binding fields or clearly mark the row unavailable. It must not display
+zero capacity for a live binding unless the helper explicitly reported zero.
+
+## Hot-Path Invariants
+
+- Telemetry sampling must not touch AF_XDP rings with contended atomics in the
+  packet path.
+- Formatters must tolerate mixed-version JSON with missing optional fields.
+- Detail output may be verbose; non-detail output remains aggregate and stable.
+- Counter/gauge types must stay stable for Prometheus consumers.
+
+## State and HA Behavior
+
+- Buffer telemetry is local per node and not HA-synchronized.
+- Active-session footer uses the same session source as other userspace status
+  commands so failover and helper restart do not report contradictory totals.
+- Mixed-version cluster peers must still render useful local status.
+
+## Risks
+
+- False-zero capacity: missing fields rendered as zero can hide a compatibility
+  problem and send operators chasing nonexistent ring exhaustion.
+- Status drift: CLI, gRPC, and REST/metrics can diverge if they format different
+  DTOs. Tests should use the same fixture through every output path.
+- Sampling cost: overly frequent ring introspection can perturb the hot path;
+  publish cadence and helper snapshots need bounded overhead.
+- Schema churn: adding/removing fields without nil-aware fallbacks breaks
+  mixed-version upgrades.
+
+## Exact Tests
+
+- Go: aggregate formatter omits per-binding rows, detail formatter includes
+  them, and both preserve the active-session footer.
+- Go: mixed-version status with sparse per-binding capacity falls back to
+  binding-level capacity instead of rendering false zeroes.
+- Go: gRPC `ShowText` and local CLI use the same userspace buffer fixture and
+  produce equivalent text.
+- Integration: userspace cluster under forwarding load shows nonzero AF_XDP
+  capacities, stable active sessions, and no status command hang.
+
+## Non-Goals
+
+- Do not change AF_XDP ring sizing policy in this PR.
+- Do not make buffer telemetry HA state.
+- Do not remove eBPF source as part of #1380.

--- a/docs/pr/README.md
+++ b/docs/pr/README.md
@@ -22,6 +22,7 @@ specs (those live at the repo root `docs/` level).
 | `807-refactor/`              | Docs refactor into this dir structure (PR #807)              | merged `61ff77c5`     |
 | `1316-lowrate-cos-buffers/`  | #1312/#1316 low-rate exact CoS buffer sizing measurements    | PR #1316              |
 | `1321-validation-contract/`  | #1321 100E100M and surplus give-back validation contract     | PR branch             |
+| `1373-retire-ebpf-dataplane/` | #1373 userspace parity blocker plans | PR branch |
 | `line-rate-investigation/`   | Parent investigation (#798) plan + phase-B step 0 + gaps doc + 8-matrix findings | #798 open |
 
 ## Conventions


### PR DESCRIPTION
## Summary

Adds the #1373 blocker-plan bundle for the userspace parity gaps that must be resolved before eBPF dataplane removal:

- #1374 SYN cookie flood protection
- #1375 three-color policers
- #1376 port mirroring
- #1378 policy schedulers
- #1379 dataplane events
- shared dependency: #1381 DataPlane interface split/stub

Each plan covers dependencies, hot-path invariants, state/HA behavior, exact tests, non-goals, and the reviewed corrections called out in the issue contracts.

## Validation

- `rg -n "SipHash|RST|u128|color-aware|cross-binding inject|TUN|stable rule identity|counters survive|rate-limited|no heap|fan-in|#1381" docs/pr/1373-retire-ebpf-dataplane docs/pr/README.md`
- `rg -n "[[:blank:]]$" docs/pr/1373-retire-ebpf-dataplane docs/pr/README.md`
- `awk 'length($0)>120 {print FILENAME ":" FNR ":" length($0) ":" $0}' docs/pr/1373-retire-ebpf-dataplane/*.md docs/pr/README.md` (only pre-existing long rows remain in `docs/pr/README.md`)\n- local link target shell check for bundle README plan links\n\nNo runtime code changed; no Go/Rust test suite run.