### PR TITLE
Userspace address-persistent SNAT pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ system {
 | Stateful forwarding | Yes | Yes |
 | Zone + global policies | Yes | Yes |
 | Application matching | Yes | Yes |
-| Source NAT (interface + pool) | Yes | Interface mode yes; pool mode still gated |
+| Source NAT (interface + pool) | Yes | Interface and pool mode yes; userspace `address-persistent` uses a documented userspace-v1 hash until #1377 defines cross-backend parity |
 | Destination NAT | Yes | Yes |
 | Static NAT (1:1) | Yes | Yes |
 | NAT64 (IPv6↔IPv4) | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ system {
 | SYN cookie flood protection | Yes | No (fallback) |
 | Throughput (25G mlx5) | 22+ Gbps | See validation/perf docs for current results |
 
-The userspace dataplane now covers most of the transit feature set in native Rust, but it is not "fallback-free". Current explicit gates in code still include pool-mode SNAT admission, SYN-cookie-dependent screen behavior, three-color policers, and port mirroring. The exact admission boundary is documented in [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
+The userspace dataplane now covers most of the transit feature set in native Rust, but it is not "fallback-free". Current explicit gates in code still include SYN-cookie-dependent screen behavior, three-color policers, and port mirroring. Pool-mode SNAT is admitted, but #1377 still owns cross-backend `address-persistent` parity. The exact admission boundary is documented in [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
 
 ## Architecture
 

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-16
 
+- **Timestamp**: 2026-05-16T22:18:20Z
+  - **Action**: PR #1385 round-1 review fixes — make userspace source-NAT pool snapshots fail closed when the referenced pool is missing, empty, or has an invalid port range; add regression coverage for each unsafe pool-mode case; refresh the userspace dataplane gap date after the pool-mode capability update.
+  - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `docs/userspace-dataplane-gaps.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-16T04:36:00Z
   - **Action**: PR #1320 round-3 review fixes — validate typed scheduler leaves against the apply-groups-expanded tree before compile; reject `transmit-rate exact` unless the scheduler also has a typed rate; wire `ConfigClassOfServiceSchedulers` into the real config-mode `set class-of-service schedulers <name>` completion tree; update module docs to keep the byte-size-only scheduler buffer contract explicit.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/tree_test.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `pkg/configstore/store.go`, `pkg/configstore/store_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-16
 
+- **Timestamp**: 2026-05-17T00:48:00Z
+  - **Action**: PR #1385 round-3 review follow-up — corrected README prose so pool-mode SNAT is no longer described as an explicit userspace capability gate after the pool-mode fixes; the remaining caveat is cross-backend `address-persistent` parity under #1377.
+  - **File(s)**: `README.md`, `_Log.md`
+  - **Validation**: `git diff --check`
+
 - **Timestamp**: 2026-05-16T23:58:00Z
   - **Action**: PR #1385 round-2 review follow-up — made Rust pool-mode SNAT skip matched rules whose pool has no address for the packet family so later compatible rules can apply, added wrong-family regression tests, and documented userspace/eBPF/DPDK address-persistent algorithm divergence until #1377 defines a shared contract.
   - **File(s)**: `userspace-dp/src/nat.rs`, `userspace-dp/src/nat_tests.rs`, `docs/userspace-dataplane-architecture.md`, `docs/userspace-dataplane-gaps.md`, `README.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-16
 
+- **Timestamp**: 2026-05-16T23:58:00Z
+  - **Action**: PR #1385 round-2 review follow-up — made Rust pool-mode SNAT skip matched rules whose pool has no address for the packet family so later compatible rules can apply, added wrong-family regression tests, and documented userspace/eBPF/DPDK address-persistent algorithm divergence until #1377 defines a shared contract.
+  - **File(s)**: `userspace-dp/src/nat.rs`, `userspace-dp/src/nat_tests.rs`, `docs/userspace-dataplane-architecture.md`, `docs/userspace-dataplane-gaps.md`, `README.md`, `_Log.md`
+  - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml pool_snat_wrong_family`; `go test ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-16T22:18:20Z
   - **Action**: PR #1385 round-1 review fixes — make userspace source-NAT pool snapshots fail closed when the referenced pool is missing, empty, or has an invalid port range; add regression coverage for each unsafe pool-mode case; refresh the userspace dataplane gap date after the pool-mode capability update.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `docs/userspace-dataplane-gaps.md`, `_Log.md`

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -272,6 +272,12 @@ the NAT module applies it:
   address family, and canonical source IP bytes with SHA-256 to choose a stable
   pool index. This is sticky within the current pool size and order; changing
   either can remap existing source IPs to different pool addresses.
+  This is intentionally documented as a userspace-v1 algorithm, not eBPF/DPDK
+  parity: the legacy eBPF path uses `src_ip % num_ips` for IPv4 and a 32-bit
+  lane XOR for IPv6, while DPDK consumes the shared pool config but has its own
+  allocator implementation. Mixed-backend deployments must not assume the same
+  client maps to the same pool address until #1377 defines a shared
+  cross-backend address-persistent contract.
 - **Checksum update:** Incremental RFC 1624 checksum adjustment for
   IP header + TCP/UDP pseudo-header. Avoids full recomputation.
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -265,7 +265,13 @@ the NAT module applies it:
 
 - **SNAT (interface mode):** Rewrite source IP to egress interface address.
   Source port preserved.
-- **SNAT (pool mode):** Not yet implemented.
+- **SNAT (pool mode):** Rewrite source IP to a configured source pool address
+  and allocate a source port from the pool range. By default, pool address
+  selection is round-robin within the packet address family. With global source
+  NAT `address-persistent`, the userspace dataplane hashes a domain tag,
+  address family, and canonical source IP bytes with SHA-256 to choose a stable
+  pool index. This is sticky within the current pool size and order; changing
+  either can remap existing source IPs to different pool addresses.
 - **Checksum update:** Incremental RFC 1624 checksum adjustment for
   IP header + TCP/UDP pseudo-header. Avoids full recomputation.
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -5,7 +5,7 @@ AF_XDP userspace dataplane. It is not a full bug tracker and it is not a
 historical branch plan. For active debugging entry points, use
 [`userspace-debug-map.md`](userspace-debug-map.md).
 
-Last updated: 2026-03-14
+Last updated: 2026-05-16
 
 ## Implemented In The Current Runtime
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -17,7 +17,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | Zone + global policies | Implemented | Address and application terms are pre-expanded by the daemon |
 | Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
 | Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
-| Source NAT (pool mode) | Implemented | IPv4/IPv6 pool address and port allocation; `address-persistent` uses a deterministic source-IP hash |
+| Source NAT (pool mode) | Implemented with caveat | IPv4/IPv6 pool address and port allocation; wrong-family pools are skipped so later compatible rules can match. `address-persistent` uses a userspace-v1 deterministic SHA-256 source-IP hash that intentionally differs from legacy eBPF IPv4 modulo / IPv6 lane-XOR selection and from DPDK allocator internals until #1377 defines a shared cross-backend contract. |
 | Destination NAT | Implemented | Pre-expanded tuple snapshots from Go |
 | Static NAT | Implemented | Bidirectional 1:1 translation |
 | NAT64 | Implemented | Forward and reverse translation with reverse-session state |

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -17,6 +17,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | Zone + global policies | Implemented | Address and application terms are pre-expanded by the daemon |
 | Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
 | Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
+| Source NAT (pool mode) | Implemented | IPv4/IPv6 pool address and port allocation; `address-persistent` uses a deterministic source-IP hash |
 | Destination NAT | Implemented | Pre-expanded tuple snapshots from Go |
 | Static NAT | Implemented | Bidirectional 1:1 translation |
 | NAT64 | Implemented | Forward and reverse translation with reverse-session state |
@@ -39,7 +40,6 @@ These are the remaining explicit configuration gates in
 | Feature/config shape | Gate status | Reason |
 |----------------------|-------------|--------|
 | Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
-| Source NAT (pool mode) | Gated | Capability check still rejects non-interface SNAT rules |
 | Screen behavior requiring SYN cookies | Gated | SYN-cookie behavior remains a legacy eBPF capability |
 | Three-color policers | Gated | Simple filters are supported; three-color policers are not |
 | Port mirroring | Gated | No userspace mirroring path |
@@ -90,8 +90,7 @@ There are two distinct fallback boundaries:
 
 The highest-value remaining work on current `master` is:
 
-1. admit pool-mode SNAT cleanly through the capability gate
-2. close the remaining SYN-cookie-dependent screen gap
-3. implement three-color policer support
-4. implement port mirroring
-5. continue correctness and performance hardening on the active AF_XDP fast path
+1. close the remaining SYN-cookie-dependent screen gap
+2. implement three-color policer support
+3. implement port mirroring
+4. continue correctness and performance hardening on the active AF_XDP fast path

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1448,6 +1448,86 @@ func TestBuildSourceNATSnapshotsPopulatesPoolFields(t *testing.T) {
 	}
 }
 
+func TestBuildSourceNATSnapshotsSkipsUnsafePoolModeRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		pools map[string]*config.NATPool
+	}{
+		{
+			name:  "missing pool",
+			pools: map[string]*config.NATPool{},
+		},
+		{
+			name: "nil pool",
+			pools: map[string]*config.NATPool{
+				"pool-a": nil,
+			},
+		},
+		{
+			name: "empty pool",
+			pools: map[string]*config.NATPool{
+				"pool-a": {Name: "pool-a", PortLow: 1024, PortHigh: 65535},
+			},
+		},
+		{
+			name: "port low overflow",
+			pools: map[string]*config.NATPool{
+				"pool-a": {Name: "pool-a", Addresses: []string{"203.0.113.10/32"}, PortLow: 65536, PortHigh: 65535},
+			},
+		},
+		{
+			name: "port high overflow",
+			pools: map[string]*config.NATPool{
+				"pool-a": {Name: "pool-a", Addresses: []string{"203.0.113.10/32"}, PortLow: 1024, PortHigh: 70000},
+			},
+		},
+		{
+			name: "port range reversed",
+			pools: map[string]*config.NATPool{
+				"pool-a": {Name: "pool-a", Addresses: []string{"203.0.113.10/32"}, PortLow: 40000, PortHigh: 39999},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := sourceNATPoolTestConfig()
+			cfg.Security.NAT.SourcePools = tt.pools
+			if snaps := buildSourceNATSnapshots(cfg); len(snaps) != 0 {
+				t.Fatalf("len(snaps) = %d, want 0; snaps=%+v", len(snaps), snaps)
+			}
+		})
+	}
+}
+
+func sourceNATPoolTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"pool-a": {
+			Name:      "pool-a",
+			Addresses: []string{"203.0.113.10/32"},
+			PortLow:   1024,
+			PortHigh:  65535,
+		},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:     "rs",
+		FromZone: "trust",
+		ToZone:   "wan",
+		Rules: []*config.NATRule{{
+			Name: "snat-pool",
+			Match: config.NATMatch{
+				SourceAddresses:      []string{"10.0.0.0/8"},
+				DestinationAddresses: []string{"0.0.0.0/0"},
+			},
+			Then: config.NATThen{
+				Type:     config.NATSource,
+				PoolName: "pool-a",
+			},
+		}},
+	}}
+	return cfg
+}
+
 func TestBuildFabricSnapshotsUsesLocalMemberAndPeer(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Chassis.Cluster = &config.ClusterConfig{

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1400,6 +1400,54 @@ func TestBuildSnapshotSummary(t *testing.T) {
 	}
 }
 
+func TestBuildSourceNATSnapshotsPopulatesPoolFields(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.AddressPersistent = true
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"pool-a": {
+			Name:      "pool-a",
+			Addresses: []string{"203.0.113.10/32", "203.0.113.11/32", "2001:db8:80::10/128"},
+			PortLow:   40000,
+			PortHigh:  40100,
+		},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:     "rs",
+		FromZone: "trust",
+		ToZone:   "wan",
+		Rules: []*config.NATRule{{
+			Name: "snat-pool",
+			Match: config.NATMatch{
+				SourceAddresses:      []string{"10.0.0.0/8"},
+				DestinationAddresses: []string{"0.0.0.0/0"},
+			},
+			Then: config.NATThen{
+				Type:     config.NATSource,
+				PoolName: "pool-a",
+			},
+		}},
+	}}
+
+	snaps := buildSourceNATSnapshots(cfg)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	got := snaps[0]
+	if got.PoolName != "pool-a" || got.InterfaceMode || got.Off {
+		t.Fatalf("snapshot action fields = %+v", got)
+	}
+	if !got.AddressPersistent {
+		t.Fatalf("AddressPersistent = false, want true")
+	}
+	if got.PortLow != 40000 || got.PortHigh != 40100 {
+		t.Fatalf("port range = %d-%d, want 40000-40100", got.PortLow, got.PortHigh)
+	}
+	wantAddrs := []string{"203.0.113.10/32", "203.0.113.11/32", "2001:db8:80::10/128"}
+	if !reflect.DeepEqual(got.PoolAddresses, wantAddrs) {
+		t.Fatalf("PoolAddresses = %#v, want %#v", got.PoolAddresses, wantAddrs)
+	}
+}
+
 func TestBuildFabricSnapshotsUsesLocalMemberAndPeer(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Chassis.Cluster = &config.ClusterConfig{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -238,6 +238,10 @@ type SourceNATRuleSnapshot struct {
 	InterfaceMode        bool     `json:"interface_mode,omitempty"`
 	Off                  bool     `json:"off,omitempty"`
 	PoolName             string   `json:"pool_name,omitempty"`
+	PoolAddresses        []string `json:"pool_addresses,omitempty"`
+	PortLow              uint16   `json:"port_low,omitempty"`
+	PortHigh             uint16   `json:"port_high,omitempty"`
+	AddressPersistent    bool     `json:"address_persistent,omitempty"`
 }
 
 type StaticNATRuleSnapshot struct {

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -1205,17 +1205,28 @@ func buildSourceNATSnapshots(cfg *config.Config) []SourceNATRuleSnapshot {
 			var poolAddresses []string
 			var portLow, portHigh uint16
 			if rule.Then.PoolName != "" {
-				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok && pool != nil {
-					if pool.Address != "" {
-						poolAddresses = append(poolAddresses, pool.Address)
-					}
-					poolAddresses = append(poolAddresses, pool.Addresses...)
-					if pool.PortLow > 0 {
-						portLow = uint16(pool.PortLow)
-					}
-					if pool.PortHigh > 0 {
-						portHigh = uint16(pool.PortHigh)
-					}
+				pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]
+				if !ok || pool == nil {
+					slog.Warn("userspace snapshot: skipping source NAT rule with missing pool",
+						"rule", rule.Name, "pool", rule.Then.PoolName)
+					continue
+				}
+				if pool.Address != "" {
+					poolAddresses = append(poolAddresses, pool.Address)
+				}
+				poolAddresses = append(poolAddresses, pool.Addresses...)
+				if len(poolAddresses) == 0 {
+					slog.Warn("userspace snapshot: skipping source NAT rule with empty pool",
+						"rule", rule.Name, "pool", rule.Then.PoolName)
+					continue
+				}
+				var valid bool
+				portLow, portHigh, valid = sourceNATPoolPortRange(pool)
+				if !valid {
+					slog.Warn("userspace snapshot: skipping source NAT rule with invalid pool port range",
+						"rule", rule.Name, "pool", rule.Then.PoolName,
+						"port_low", pool.PortLow, "port_high", pool.PortHigh)
+					continue
 				}
 			}
 			out = append(out, SourceNATRuleSnapshot{
@@ -1235,6 +1246,24 @@ func buildSourceNATSnapshots(cfg *config.Config) []SourceNATRuleSnapshot {
 		}
 	}
 	return out
+}
+
+func sourceNATPoolPortRange(pool *config.NATPool) (uint16, uint16, bool) {
+	if pool == nil {
+		return 0, 0, false
+	}
+	low := pool.PortLow
+	if low == 0 {
+		low = 1024
+	}
+	high := pool.PortHigh
+	if high == 0 {
+		high = 65535
+	}
+	if low < 1 || high < 1 || low > 65535 || high > 65535 || low > high {
+		return 0, 0, false
+	}
+	return uint16(low), uint16(high), true
 }
 
 func buildStaticNATSnapshots(cfg *config.Config) []StaticNATRuleSnapshot {

--- a/pkg/dataplane/userspace/snapshot.go
+++ b/pkg/dataplane/userspace/snapshot.go
@@ -1202,6 +1202,22 @@ func buildSourceNATSnapshots(cfg *config.Config) []SourceNATRuleSnapshot {
 			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
 				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
 			}
+			var poolAddresses []string
+			var portLow, portHigh uint16
+			if rule.Then.PoolName != "" {
+				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok && pool != nil {
+					if pool.Address != "" {
+						poolAddresses = append(poolAddresses, pool.Address)
+					}
+					poolAddresses = append(poolAddresses, pool.Addresses...)
+					if pool.PortLow > 0 {
+						portLow = uint16(pool.PortLow)
+					}
+					if pool.PortHigh > 0 {
+						portHigh = uint16(pool.PortHigh)
+					}
+				}
+			}
 			out = append(out, SourceNATRuleSnapshot{
 				Name:                 rule.Name,
 				FromZone:             rs.FromZone,
@@ -1211,6 +1227,10 @@ func buildSourceNATSnapshots(cfg *config.Config) []SourceNATRuleSnapshot {
 				InterfaceMode:        rule.Then.Interface,
 				Off:                  rule.Then.Off,
 				PoolName:             rule.Then.PoolName,
+				PoolAddresses:        poolAddresses,
+				PortLow:              portLow,
+				PortHigh:             portHigh,
+				AddressPersistent:    cfg.Security.NAT.AddressPersistent,
 			})
 		}
 	}

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -2,6 +2,7 @@ use crate::prefix::{PrefixV4, PrefixV6};
 use crate::{DestinationNATRuleSnapshot, SourceNATRuleSnapshot, StaticNATRuleSnapshot};
 use ipnet::IpNet;
 use rustc_hash::FxHashMap;
+use sha2::{Digest, Sha256};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -61,8 +62,10 @@ impl NatDecision {
 pub(crate) struct PortAllocator {
     /// One atomic counter per pool address, used for round-robin port allocation.
     counters: Vec<AtomicU32>,
-    /// Index for round-robin address selection.
-    addr_counter: AtomicU32,
+    /// Index for IPv4 round-robin address selection.
+    addr_counter_v4: AtomicU32,
+    /// Index for IPv6 round-robin address selection.
+    addr_counter_v6: AtomicU32,
     pub(crate) port_low: u16,
     pub(crate) port_high: u16,
 }
@@ -75,7 +78,8 @@ impl Clone for PortAllocator {
                 .iter()
                 .map(|c| AtomicU32::new(c.load(Ordering::Relaxed)))
                 .collect(),
-            addr_counter: AtomicU32::new(self.addr_counter.load(Ordering::Relaxed)),
+            addr_counter_v4: AtomicU32::new(self.addr_counter_v4.load(Ordering::Relaxed)),
+            addr_counter_v6: AtomicU32::new(self.addr_counter_v6.load(Ordering::Relaxed)),
             port_low: self.port_low,
             port_high: self.port_high,
         }
@@ -86,7 +90,8 @@ impl Default for PortAllocator {
     fn default() -> Self {
         Self {
             counters: Vec::new(),
-            addr_counter: AtomicU32::new(0),
+            addr_counter_v4: AtomicU32::new(0),
+            addr_counter_v6: AtomicU32::new(0),
             port_low: 1024,
             port_high: 65535,
         }
@@ -98,19 +103,33 @@ impl PortAllocator {
         let counters = (0..num_addresses).map(|_| AtomicU32::new(0)).collect();
         Self {
             counters,
-            addr_counter: AtomicU32::new(0),
+            addr_counter_v4: AtomicU32::new(0),
+            addr_counter_v6: AtomicU32::new(0),
             port_low,
             port_high,
         }
     }
 
-    /// Pick the next pool address index (round-robin).
-    pub(crate) fn next_address_index(&self) -> usize {
-        if self.counters.is_empty() {
+    /// Pick a pool address index for the current address family.
+    pub(crate) fn address_index(
+        &self,
+        src_ip: IpAddr,
+        family_offset: usize,
+        family_len: usize,
+        address_persistent: bool,
+    ) -> usize {
+        if family_len == 0 {
             return 0;
         }
-        let idx = self.addr_counter.fetch_add(1, Ordering::Relaxed);
-        (idx as usize) % self.counters.len()
+        if address_persistent {
+            return family_offset + sticky_pool_index(src_ip, family_len);
+        }
+        let counter = match src_ip {
+            IpAddr::V4(_) => &self.addr_counter_v4,
+            IpAddr::V6(_) => &self.addr_counter_v6,
+        };
+        let idx = counter.fetch_add(1, Ordering::Relaxed);
+        family_offset + ((idx as usize) % family_len)
     }
 
     /// Allocate the next port for the given address index.
@@ -125,6 +144,29 @@ impl PortAllocator {
     }
 }
 
+fn sticky_pool_index(src_ip: IpAddr, pool_len: usize) -> usize {
+    if pool_len <= 1 {
+        return 0;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"xpf-userspace-snat-address-persistent-v1");
+    match src_ip {
+        IpAddr::V4(addr) => {
+            hasher.update([4]);
+            hasher.update(addr.octets());
+        }
+        IpAddr::V6(addr) => {
+            hasher.update([6]);
+            hasher.update(addr.octets());
+        }
+    }
+    let digest = hasher.finalize();
+    let mut first = [0u8; 8];
+    first.copy_from_slice(&digest[..8]);
+    (u64::from_be_bytes(first) % pool_len as u64) as usize
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SourceNatRule {
     pub(crate) from_zone: String,
@@ -135,6 +177,7 @@ pub(crate) struct SourceNatRule {
     pub(crate) destination_v6: Vec<PrefixV6>,
     pub(crate) interface_mode: bool,
     pub(crate) off: bool,
+    pub(crate) address_persistent: bool,
     pub(crate) pool_addresses_v4: Vec<Ipv4Addr>,
     pub(crate) pool_addresses_v6: Vec<Ipv6Addr>,
     pub(crate) pool_allocator: PortAllocator,
@@ -168,6 +211,7 @@ pub(crate) fn parse_source_nat_rules(snaps: &[SourceNATRuleSnapshot]) -> Vec<Sou
             to_zone: snap.to_zone.clone(),
             interface_mode: snap.interface_mode,
             off: snap.off,
+            address_persistent: snap.address_persistent,
             ..SourceNatRule::default()
         };
         for prefix in &snap.source_addresses {
@@ -241,12 +285,17 @@ pub(crate) fn match_source_nat(
                 ..NatDecision::default()
             });
         }
-        // Pool-mode SNAT: pick address round-robin, allocate port.
+        // Pool-mode SNAT: pick address by source-IP hash when
+        // address-persistent is enabled, otherwise round-robin by family.
         match src_ip {
             IpAddr::V4(_) if !rule.pool_addresses_v4.is_empty() => {
-                let addr_idx = rule.pool_allocator.next_address_index();
-                // addr_idx is mod total_pool; v4 addresses are at indices 0..v4_len
-                let v4_idx = addr_idx % rule.pool_addresses_v4.len();
+                let addr_idx = rule.pool_allocator.address_index(
+                    src_ip,
+                    0,
+                    rule.pool_addresses_v4.len(),
+                    rule.address_persistent,
+                );
+                let v4_idx = addr_idx;
                 let pool_addr = rule.pool_addresses_v4[v4_idx];
                 let port = rule.pool_allocator.next_port(addr_idx);
                 return Some(NatDecision {
@@ -258,10 +307,14 @@ pub(crate) fn match_source_nat(
                 });
             }
             IpAddr::V6(_) if !rule.pool_addresses_v6.is_empty() => {
-                let addr_idx = rule.pool_allocator.next_address_index();
-                // v6 addresses are stored after v4 addresses in the allocator
                 let v6_offset = rule.pool_addresses_v4.len();
-                let v6_idx = (addr_idx.wrapping_sub(v6_offset)) % rule.pool_addresses_v6.len();
+                let addr_idx = rule.pool_allocator.address_index(
+                    src_ip,
+                    v6_offset,
+                    rule.pool_addresses_v6.len(),
+                    rule.address_persistent,
+                );
+                let v6_idx = addr_idx - v6_offset;
                 let pool_addr = rule.pool_addresses_v6[v6_idx];
                 let port = rule.pool_allocator.next_port(addr_idx);
                 return Some(NatDecision {

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -325,9 +325,15 @@ pub(crate) fn match_source_nat(
                     ..NatDecision::default()
                 });
             }
-            _ => {}
+            _ => {
+                // This rule matched the zones/prefixes but the referenced pool
+                // has no address for the packet family. Treat it as an
+                // unusable rule and keep walking so a later compatible rule can
+                // still apply. Returning a default NatDecision here would
+                // silently shadow later SNAT rules.
+                continue;
+            }
         }
-        return Some(NatDecision::default());
     }
     None
 }

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -827,6 +827,54 @@ fn pool_snat_multiple_addresses_round_robin() {
 }
 
 #[test]
+fn pool_snat_address_persistent_sticks_source_to_pool_address() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-sticky".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "sticky-pool".to_string(),
+        pool_addresses: vec![
+            "203.0.113.1".to_string(),
+            "203.0.113.2".to_string(),
+            "203.0.113.3".to_string(),
+        ],
+        port_low: 40000,
+        port_high: 40010,
+        address_persistent: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let src = "10.0.1.101".parse().unwrap();
+    let expected_idx = sticky_pool_index(src, 3);
+    assert_eq!(expected_idx, 1);
+
+    for want_port in 40000..40004 {
+        let d = match_source_nat(
+            &rules,
+            "lan",
+            "wan",
+            src,
+            "8.8.8.8".parse().unwrap(),
+            None,
+            None,
+        )
+        .expect("should match");
+        assert_eq!(d.rewrite_src, Some("203.0.113.2".parse().unwrap()));
+        assert_eq!(d.rewrite_src_port, Some(want_port));
+    }
+}
+
+#[test]
+fn pool_snat_address_persistent_hashes_full_ipv6_address() {
+    let a: IpAddr = "2001:db8::1".parse().unwrap();
+    let b: IpAddr = "2001:db8::2".parse().unwrap();
+
+    assert_eq!(sticky_pool_index(a, 257), 197);
+    assert_eq!(sticky_pool_index(b, 257), 125);
+}
+
+#[test]
 fn pool_snat_port_range_wrapping() {
     let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
         name: "small-range".to_string(),
@@ -988,12 +1036,21 @@ fn pool_snat_zone_mismatch_returns_none() {
 fn port_allocator_basic() {
     let alloc = PortAllocator::new(2, 5000, 5002);
     // Address selection round-robin
-    assert_eq!(alloc.next_address_index(), 0);
-    assert_eq!(alloc.next_address_index(), 1);
-    assert_eq!(alloc.next_address_index(), 0);
+    let src = "10.0.1.100".parse().unwrap();
+    assert_eq!(alloc.address_index(src, 0, 2, false), 0);
+    assert_eq!(alloc.address_index(src, 0, 2, false), 1);
+    assert_eq!(alloc.address_index(src, 0, 2, false), 0);
     // Port allocation for address 0
     assert_eq!(alloc.next_port(0), 5000);
     assert_eq!(alloc.next_port(0), 5001);
     assert_eq!(alloc.next_port(0), 5002);
     assert_eq!(alloc.next_port(0), 5000); // wraps
+
+    let mixed = PortAllocator::new(4, 5000, 5002);
+    let src_v4 = "10.0.1.100".parse().unwrap();
+    let src_v6 = "2001:db8::100".parse().unwrap();
+    assert_eq!(mixed.address_index(src_v4, 0, 2, false), 0);
+    assert_eq!(mixed.address_index(src_v6, 2, 2, false), 2);
+    assert_eq!(mixed.address_index(src_v4, 0, 2, false), 1);
+    assert_eq!(mixed.address_index(src_v6, 2, 2, false), 3);
 }

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -827,6 +827,73 @@ fn pool_snat_multiple_addresses_round_robin() {
 }
 
 #[test]
+fn pool_snat_wrong_family_pool_does_not_shadow_later_rule() {
+    let rules = parse_source_nat_rules(&[
+        SourceNATRuleSnapshot {
+            name: "wrong-family".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            pool_name: "v6-only".to_string(),
+            pool_addresses: vec!["2001:db8::10".to_string()],
+            port_low: 1024,
+            port_high: 65535,
+            ..SourceNATRuleSnapshot::default()
+        },
+        SourceNATRuleSnapshot {
+            name: "usable-v4".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            pool_name: "v4-pool".to_string(),
+            pool_addresses: vec!["203.0.113.20".to_string()],
+            port_low: 40000,
+            port_high: 40000,
+            ..SourceNATRuleSnapshot::default()
+        },
+    ]);
+
+    let d = match_source_nat(
+        &rules,
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        None,
+        None,
+    )
+    .expect("later compatible rule should match");
+    assert_eq!(d.rewrite_src, Some("203.0.113.20".parse().unwrap()));
+    assert_eq!(d.rewrite_src_port, Some(40000));
+}
+
+#[test]
+fn pool_snat_wrong_family_pool_returns_none_when_no_later_rule_matches() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "wrong-family".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "v6-only".to_string(),
+        pool_addresses: vec!["2001:db8::10".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let d = match_source_nat(
+        &rules,
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        None,
+        None,
+    );
+    assert_eq!(d, None);
+}
+
+#[test]
 fn pool_snat_address_persistent_sticks_source_to_pool_address() {
     let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
         name: "pool-sticky".to_string(),

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -412,6 +412,8 @@ pub(crate) struct SourceNATRuleSnapshot {
     pub port_low: u16,
     #[serde(rename = "port_high", default)]
     pub port_high: u16,
+    #[serde(rename = "address_persistent", default)]
+    pub address_persistent: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- Plumb source NAT pool addresses, port range, and address_persistent through the Go/Rust userspace snapshot contract.
- Make userspace pool SNAT choose pool addresses by per-family round-robin by default, or by HA-safe SHA-256 source-IP hash when address-persistent is enabled.
- Document sticky-within-pool-size/order semantics and update the userspace capability docs.

References #1377.
References #1373.

## Tests
- go test ./pkg/dataplane/userspace
- cargo test pool_snat
- cargo test port_allocator_basic

Note: Rust tests pass with existing warning output in unrelated modules.