### PR TITLE
Show userspace buffers from helper status

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The userspace dataplane now covers most of the transit feature set in native Rus
 - **Prometheus metrics** (`/metrics` endpoint)
 - **SNMP**: system + ifTable MIB
 - **RPM probes**, dynamic address feeds
-- **BPF map utilization** (`show system buffers`)
+- **Dataplane buffer utilization** (`show system buffers`): BPF map occupancy on eBPF, AF_XDP UMEM/TX-ring capacity on userspace
 - **LLDP**: link layer discovery protocol
 
 ### Management

--- a/_Log.md
+++ b/_Log.md
@@ -17,6 +17,11 @@
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `docs/userspace-dataplane-gaps.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
 
+- **Timestamp**: 2026-05-17T00:06:00Z
+  - **Action**: PR #1386 round-2 review follow-up — changed userspace buffer capacity fallback from all-or-nothing to per-row fallback so mixed helper snapshots with one populated `per_binding[]` row and one sparse row do not undercount capacity.
+  - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `_Log.md`
+  - **Validation**: `gofmt -w pkg/dataplane/userspace/buffersfmt.go pkg/dataplane/userspace/buffersfmt_test.go`; `go test ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-16T22:19:53Z
   - **Action**: PR #1386 round-1 review fixes — preserve the `Active sessions` footer in userspace `show system buffers`, make non-detail output aggregate-only while `buffers detail` adds per-binding rows, and fall back to `bindings[]` when `per_binding[]` lacks capacity gauges.
   - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `pkg/cli/cli_show_system.go`, `pkg/grpcapi/server_show.go`, `pkg/grpcapi/server_show_system_buffers_test.go`, `docs/userspace-dataplane-architecture.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -17,6 +17,11 @@
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `docs/userspace-dataplane-gaps.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
 
+- **Timestamp**: 2026-05-16T22:19:53Z
+  - **Action**: PR #1386 round-1 review fixes — preserve the `Active sessions` footer in userspace `show system buffers`, make non-detail output aggregate-only while `buffers detail` adds per-binding rows, and fall back to `bindings[]` when `per_binding[]` lacks capacity gauges.
+  - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `pkg/cli/cli_show_system.go`, `pkg/grpcapi/server_show.go`, `pkg/grpcapi/server_show_system_buffers_test.go`, `docs/userspace-dataplane-architecture.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace ./pkg/grpcapi ./pkg/cli ./pkg/fwdstatus`; `git diff --check`
+
 - **Timestamp**: 2026-05-16T04:36:00Z
   - **Action**: PR #1320 round-3 review fixes — validate typed scheduler leaves against the apply-groups-expanded tree before compile; reject `transmit-rate exact` unless the scheduler also has a typed rate; wire `ConfigClassOfServiceSchedulers` into the real config-mode `set class-of-service schedulers <name>` completion tree; update module docs to keep the byte-size-only scheduler buffer contract explicit.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/tree_test.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `pkg/configstore/store.go`, `pkg/configstore/store_test.go`, `_Log.md`

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -56,10 +56,11 @@ debugging entry points, use [`userspace-debug-map.md`](userspace-debug-map.md).
 `show system buffers` uses the userspace helper status path when the
 active dataplane implements `Status() (userspace.ProcessStatus, error)`;
 it does not depend on BPF map occupancy for userspace mode. The rendered
-rows are aggregate-first AF_XDP UMEM frame and TX-ring utilization, with
-`WARNING` at >=80% and `CRITICAL` at >=90%. Per-binding rows follow the
-aggregates so a hot binding is visible even when total aggregate usage is
-low.
+rows are aggregate AF_XDP UMEM frame and TX-ring utilization, with
+`WARNING` at >=80% and `CRITICAL` at >=90%. `show system buffers detail`
+adds per-binding rows after the aggregates so a hot binding is visible
+even when total aggregate usage is low. Both userspace buffer commands
+preserve the legacy `Active sessions` footer.
 
 The bounded source fields are
 `ProcessStatus.PerBinding[].umem_total_frames`,

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -51,6 +51,24 @@ debugging entry points, use [`userspace-debug-map.md`](userspace-debug-map.md).
 
 ## Component Architecture
 
+### 0. Operator Buffer Telemetry
+
+`show system buffers` uses the userspace helper status path when the
+active dataplane implements `Status() (userspace.ProcessStatus, error)`;
+it does not depend on BPF map occupancy for userspace mode. The rendered
+rows are aggregate-first AF_XDP UMEM frame and TX-ring utilization, with
+`WARNING` at >=80% and `CRITICAL` at >=90%. Per-binding rows follow the
+aggregates so a hot binding is visible even when total aggregate usage is
+low.
+
+The bounded source fields are
+`ProcessStatus.PerBinding[].umem_total_frames`,
+`umem_inflight_frames`, `tx_ring_capacity`, and `outstanding_tx`; the
+same fields on `ProcessStatus.Bindings[]` are accepted as a fallback for
+older helper status snapshots. If neither path publishes capacity, the
+CLI reports the missing status fields rather than showing BPF-map
+metrics for userspace buffers.
+
 ### 1. XDP Shim (`userspace-xdp/src/lib.rs`)
 
 A minimal BPF program attached at the NIC driver level that decides

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -32,6 +32,10 @@ func (c *CLI) showSystemBuffers() error {
 			return nil
 		}
 		fmt.Print(dpuserspace.FormatSystemBuffers(status, false))
+		v4, v6 := c.dp.SessionCount()
+		if v4 > 0 || v6 > 0 {
+			fmt.Printf("\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+		}
 		return nil
 	}
 	stats := c.dp.GetMapStats()
@@ -90,6 +94,10 @@ func (c *CLI) showSystemBuffersDetail() error {
 			return nil
 		}
 		fmt.Print(dpuserspace.FormatSystemBuffers(status, true))
+		v4, v6 := c.dp.SessionCount()
+		if v4 > 0 || v6 > 0 {
+			fmt.Printf("\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+		}
 		return nil
 	}
 	stats := c.dp.GetMapStats()

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"golang.org/x/sys/unix"
 )
 
@@ -20,6 +21,17 @@ import (
 func (c *CLI) showSystemBuffers() error {
 	if c.dp == nil {
 		fmt.Println("Dataplane not loaded")
+		return nil
+	}
+	if provider, ok := c.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		status, err := provider.Status()
+		if err != nil {
+			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)
+			return nil
+		}
+		fmt.Print(dpuserspace.FormatSystemBuffers(status, false))
 		return nil
 	}
 	stats := c.dp.GetMapStats()
@@ -67,6 +79,17 @@ func (c *CLI) showSystemBuffers() error {
 func (c *CLI) showSystemBuffersDetail() error {
 	if c.dp == nil {
 		fmt.Println("Dataplane not loaded")
+		return nil
+	}
+	if provider, ok := c.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		status, err := provider.Status()
+		if err != nil {
+			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)
+			return nil
+		}
+		fmt.Print(dpuserspace.FormatSystemBuffers(status, true))
 		return nil
 	}
 	stats := c.dp.GetMapStats()

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -131,8 +131,15 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 	}
 
 	var samples []systemBufferSample
-	if perBindingHasBufferCapacity(status.PerBinding) {
+	seen := make(map[systemBufferBindingKey]struct{}, len(status.PerBinding))
+	if len(status.PerBinding) > 0 {
 		for _, binding := range status.PerBinding {
+			key := systemBufferBindingKey{
+				WorkerID: binding.WorkerID,
+				QueueID:  binding.QueueID,
+				Ifindex:  binding.Ifindex,
+			}
+			seen[key] = struct{}{}
 			sample := systemBufferSample{
 				WorkerID:   binding.WorkerID,
 				QueueID:    binding.QueueID,
@@ -142,34 +149,44 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 				TXRingCap:  binding.TxRingCapacity,
 				TXRingUsed: binding.OutstandingTX,
 			}
-			if full, ok := bindings[systemBufferBindingKey{
-				WorkerID: binding.WorkerID,
-				QueueID:  binding.QueueID,
-				Ifindex:  binding.Ifindex,
-			}]; ok {
+			if full, ok := bindings[key]; ok {
 				sample.Slot = full.Slot
 				sample.HasSlot = true
 				sample.Interface = full.Interface
+				if binding.UmemTotalFrames == 0 {
+					sample.UMEMCap = full.UmemTotalFrames
+					sample.UMEMUsed = full.UmemInflightFrames
+				}
+				if binding.TxRingCapacity == 0 {
+					sample.TXRingCap = full.TxRingCapacity
+					sample.TXRingUsed = full.OutstandingTX
+				}
 			}
 			samples = append(samples, sample)
 		}
-	} else {
-		for _, binding := range status.Bindings {
-			samples = append(samples, systemBufferSample{
-				Slot:       binding.Slot,
-				HasSlot:    true,
-				WorkerID:   binding.WorkerID,
-				QueueID:    binding.QueueID,
-				Ifindex:    binding.Ifindex,
-				Interface:  binding.Interface,
-				UMEMCap:    binding.UmemTotalFrames,
-				UMEMUsed:   binding.UmemInflightFrames,
-				TXRingCap:  binding.TxRingCapacity,
-				TXRingUsed: binding.OutstandingTX,
-			})
-		}
 	}
-
+	for _, binding := range status.Bindings {
+		key := systemBufferBindingKey{
+			WorkerID: binding.WorkerID,
+			QueueID:  binding.QueueID,
+			Ifindex:  binding.Ifindex,
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		samples = append(samples, systemBufferSample{
+			Slot:       binding.Slot,
+			HasSlot:    true,
+			WorkerID:   binding.WorkerID,
+			QueueID:    binding.QueueID,
+			Ifindex:    binding.Ifindex,
+			Interface:  binding.Interface,
+			UMEMCap:    binding.UmemTotalFrames,
+			UMEMUsed:   binding.UmemInflightFrames,
+			TXRingCap:  binding.TxRingCapacity,
+			TXRingUsed: binding.OutstandingTX,
+		})
+	}
 	sort.Slice(samples, func(i, j int) bool {
 		a, b := samples[i], samples[j]
 		if a.WorkerID != b.WorkerID {
@@ -187,15 +204,6 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 		return a.Slot < b.Slot
 	})
 	return samples
-}
-
-func perBindingHasBufferCapacity(bindings []BindingCountersSnapshot) bool {
-	for _, binding := range bindings {
-		if binding.UmemTotalFrames > 0 || binding.TxRingCapacity > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 type systemBufferBindingKey struct {

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -30,7 +30,7 @@ type systemBufferRow struct {
 // `show system buffers`. It only uses bounded AF_XDP gauges published in helper
 // status; if those gauges are absent, it reports the missing wire fields rather
 // than falling back to unrelated BPF map occupancy.
-func FormatSystemBuffers(status ProcessStatus, _ bool) string {
+func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	samples := systemBufferSamples(status)
 	var umemCap, umemUsed, txCap, txUsed uint64
 	var knownUMEM, knownTX int
@@ -64,23 +64,25 @@ func FormatSystemBuffers(status ProcessStatus, _ bool) string {
 			Used:     txUsed,
 		})
 	}
-	for _, sample := range samples {
-		scope := systemBufferSampleScope(sample)
-		if sample.UMEMCap > 0 {
-			rows = append(rows, systemBufferRow{
-				Name:     "AF_XDP UMEM frames",
-				Scope:    scope,
-				Capacity: uint64(sample.UMEMCap),
-				Used:     uint64(sample.UMEMUsed),
-			})
-		}
-		if sample.TXRingCap > 0 {
-			rows = append(rows, systemBufferRow{
-				Name:     "AF_XDP TX ring",
-				Scope:    scope,
-				Capacity: uint64(sample.TXRingCap),
-				Used:     uint64(sample.TXRingUsed),
-			})
+	if detail {
+		for _, sample := range samples {
+			scope := systemBufferSampleScope(sample)
+			if sample.UMEMCap > 0 {
+				rows = append(rows, systemBufferRow{
+					Name:     "AF_XDP UMEM frames",
+					Scope:    scope,
+					Capacity: uint64(sample.UMEMCap),
+					Used:     uint64(sample.UMEMUsed),
+				})
+			}
+			if sample.TXRingCap > 0 {
+				rows = append(rows, systemBufferRow{
+					Name:     "AF_XDP TX ring",
+					Scope:    scope,
+					Capacity: uint64(sample.TXRingCap),
+					Used:     uint64(sample.TXRingUsed),
+				})
+			}
 		}
 	}
 
@@ -129,7 +131,7 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 	}
 
 	var samples []systemBufferSample
-	if len(status.PerBinding) > 0 {
+	if perBindingHasBufferCapacity(status.PerBinding) {
 		for _, binding := range status.PerBinding {
 			sample := systemBufferSample{
 				WorkerID:   binding.WorkerID,
@@ -185,6 +187,15 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 		return a.Slot < b.Slot
 	})
 	return samples
+}
+
+func perBindingHasBufferCapacity(bindings []BindingCountersSnapshot) bool {
+	for _, binding := range bindings {
+		if binding.UmemTotalFrames > 0 || binding.TxRingCapacity > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 type systemBufferBindingKey struct {

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -1,0 +1,210 @@
+package userspace
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type systemBufferSample struct {
+	Slot       uint32
+	HasSlot    bool
+	WorkerID   uint32
+	QueueID    uint32
+	Ifindex    int
+	Interface  string
+	UMEMCap    uint32
+	UMEMUsed   uint32
+	TXRingCap  uint32
+	TXRingUsed uint32
+}
+
+type systemBufferRow struct {
+	Name     string
+	Scope    string
+	Capacity uint64
+	Used     uint64
+}
+
+// FormatSystemBuffers renders userspace dataplane buffer capacity telemetry for
+// `show system buffers`. It only uses bounded AF_XDP gauges published in helper
+// status; if those gauges are absent, it reports the missing wire fields rather
+// than falling back to unrelated BPF map occupancy.
+func FormatSystemBuffers(status ProcessStatus, _ bool) string {
+	samples := systemBufferSamples(status)
+	var umemCap, umemUsed, txCap, txUsed uint64
+	var knownUMEM, knownTX int
+	for _, sample := range samples {
+		if sample.UMEMCap > 0 {
+			knownUMEM++
+			umemCap += uint64(sample.UMEMCap)
+			umemUsed += uint64(sample.UMEMUsed)
+		}
+		if sample.TXRingCap > 0 {
+			knownTX++
+			txCap += uint64(sample.TXRingCap)
+			txUsed += uint64(sample.TXRingUsed)
+		}
+	}
+
+	var rows []systemBufferRow
+	if knownUMEM > 0 {
+		rows = append(rows, systemBufferRow{
+			Name:     "AF_XDP UMEM frames",
+			Scope:    fmt.Sprintf("aggregate/%d", knownUMEM),
+			Capacity: umemCap,
+			Used:     umemUsed,
+		})
+	}
+	if knownTX > 0 {
+		rows = append(rows, systemBufferRow{
+			Name:     "AF_XDP TX ring",
+			Scope:    fmt.Sprintf("aggregate/%d", knownTX),
+			Capacity: txCap,
+			Used:     txUsed,
+		})
+	}
+	for _, sample := range samples {
+		scope := systemBufferSampleScope(sample)
+		if sample.UMEMCap > 0 {
+			rows = append(rows, systemBufferRow{
+				Name:     "AF_XDP UMEM frames",
+				Scope:    scope,
+				Capacity: uint64(sample.UMEMCap),
+				Used:     uint64(sample.UMEMUsed),
+			})
+		}
+		if sample.TXRingCap > 0 {
+			rows = append(rows, systemBufferRow{
+				Name:     "AF_XDP TX ring",
+				Scope:    scope,
+				Capacity: uint64(sample.TXRingCap),
+				Used:     uint64(sample.TXRingUsed),
+			})
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("Userspace Buffer Utilization:\n")
+	if len(rows) == 0 {
+		b.WriteString("  unavailable: helper status does not include bounded AF_XDP capacity gauges\n")
+		b.WriteString("  required status fields: per_binding[].umem_total_frames, per_binding[].umem_inflight_frames, per_binding[].tx_ring_capacity, per_binding[].outstanding_tx\n")
+		b.WriteString("  bindings[] mirrors with the same fields are also accepted\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "%-24s %-24s %12s %12s %8s %s\n", "Buffer", "Scope", "Capacity", "Used", "Usage%", "Status")
+	b.WriteString(strings.Repeat("-", 92) + "\n")
+	warnings := 0
+	for _, row := range rows {
+		pct := 0.0
+		if row.Capacity > 0 {
+			pct = float64(row.Used) * 100.0 / float64(row.Capacity)
+		}
+		status := "OK"
+		if pct >= 90.0 {
+			status = "CRITICAL"
+			warnings++
+		} else if pct >= 80.0 {
+			status = "WARNING"
+			warnings++
+		}
+		fmt.Fprintf(&b, "%-24s %-24s %12d %12d %7.1f%% %s\n",
+			row.Name, row.Scope, row.Capacity, row.Used, pct, status)
+	}
+	if warnings > 0 {
+		fmt.Fprintf(&b, "\n%d userspace buffer row(s) at high utilization\n", warnings)
+	}
+	return b.String()
+}
+
+func systemBufferSamples(status ProcessStatus) []systemBufferSample {
+	bindings := make(map[systemBufferBindingKey]BindingStatus, len(status.Bindings))
+	for _, binding := range status.Bindings {
+		bindings[systemBufferBindingKey{
+			WorkerID: binding.WorkerID,
+			QueueID:  binding.QueueID,
+			Ifindex:  binding.Ifindex,
+		}] = binding
+	}
+
+	var samples []systemBufferSample
+	if len(status.PerBinding) > 0 {
+		for _, binding := range status.PerBinding {
+			sample := systemBufferSample{
+				WorkerID:   binding.WorkerID,
+				QueueID:    binding.QueueID,
+				Ifindex:    binding.Ifindex,
+				UMEMCap:    binding.UmemTotalFrames,
+				UMEMUsed:   binding.UmemInflightFrames,
+				TXRingCap:  binding.TxRingCapacity,
+				TXRingUsed: binding.OutstandingTX,
+			}
+			if full, ok := bindings[systemBufferBindingKey{
+				WorkerID: binding.WorkerID,
+				QueueID:  binding.QueueID,
+				Ifindex:  binding.Ifindex,
+			}]; ok {
+				sample.Slot = full.Slot
+				sample.HasSlot = true
+				sample.Interface = full.Interface
+			}
+			samples = append(samples, sample)
+		}
+	} else {
+		for _, binding := range status.Bindings {
+			samples = append(samples, systemBufferSample{
+				Slot:       binding.Slot,
+				HasSlot:    true,
+				WorkerID:   binding.WorkerID,
+				QueueID:    binding.QueueID,
+				Ifindex:    binding.Ifindex,
+				Interface:  binding.Interface,
+				UMEMCap:    binding.UmemTotalFrames,
+				UMEMUsed:   binding.UmemInflightFrames,
+				TXRingCap:  binding.TxRingCapacity,
+				TXRingUsed: binding.OutstandingTX,
+			})
+		}
+	}
+
+	sort.Slice(samples, func(i, j int) bool {
+		a, b := samples[i], samples[j]
+		if a.WorkerID != b.WorkerID {
+			return a.WorkerID < b.WorkerID
+		}
+		if a.QueueID != b.QueueID {
+			return a.QueueID < b.QueueID
+		}
+		if a.Ifindex != b.Ifindex {
+			return a.Ifindex < b.Ifindex
+		}
+		if a.HasSlot != b.HasSlot {
+			return a.HasSlot
+		}
+		return a.Slot < b.Slot
+	})
+	return samples
+}
+
+type systemBufferBindingKey struct {
+	WorkerID uint32
+	QueueID  uint32
+	Ifindex  int
+}
+
+func systemBufferSampleScope(sample systemBufferSample) string {
+	parts := []string{
+		fmt.Sprintf("worker %d", sample.WorkerID),
+		fmt.Sprintf("queue %d", sample.QueueID),
+	}
+	if sample.HasSlot {
+		parts = append(parts, fmt.Sprintf("slot %d", sample.Slot))
+	}
+	if sample.Interface != "" {
+		parts = append(parts, sample.Interface)
+	} else if sample.Ifindex != 0 {
+		parts = append(parts, fmt.Sprintf("ifindex %d", sample.Ifindex))
+	}
+	return strings.Join(parts, "/")
+}

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -94,6 +94,32 @@ func TestFormatSystemBuffersFallsBackWhenPerBindingLacksCapacity(t *testing.T) {
 	}
 }
 
+func TestFormatSystemBuffersFallsBackPerSparsePerBindingRow(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{Slot: 2, WorkerID: 1, QueueID: 0, Ifindex: 7, Interface: "ge-0-0-1", UmemTotalFrames: 256, UmemInflightFrames: 64},
+			{Slot: 3, WorkerID: 1, QueueID: 1, Ifindex: 8, Interface: "ge-0-0-2", UmemTotalFrames: 512, UmemInflightFrames: 128},
+		},
+		PerBinding: []BindingCountersSnapshot{
+			{WorkerID: 1, QueueID: 0, Ifindex: 7, UmemTotalFrames: 1000, UmemInflightFrames: 500},
+			{WorkerID: 1, QueueID: 1, Ifindex: 8, OutstandingTX: 10},
+		},
+	}
+
+	out := FormatSystemBuffers(status, true)
+	for _, want := range []string{
+		"aggregate/2",
+		"1512",
+		"628",
+		"worker 1/queue 0/slot 2/ge-0-0-1",
+		"worker 1/queue 1/slot 3/ge-0-0-2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestFormatSystemBuffersDocumentsMissingStatusFields(t *testing.T) {
 	out := FormatSystemBuffers(ProcessStatus{
 		PerBinding: []BindingCountersSnapshot{{WorkerID: 0, QueueID: 0, OutstandingTX: 10}},

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -57,7 +57,36 @@ func TestFormatSystemBuffersFallsBackToBindingsAndWarnsAtEighty(t *testing.T) {
 		"AF_XDP UMEM frames",
 		"aggregate/1",
 		"80.0% WARNING",
-		"worker 0/queue 0/slot 0/ge-0-0-0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "worker 0/queue 0/slot 0/ge-0-0-0") {
+		t.Fatalf("non-detail output included per-binding row:\n%s", out)
+	}
+	detail := FormatSystemBuffers(status, true)
+	if !strings.Contains(detail, "worker 0/queue 0/slot 0/ge-0-0-0") {
+		t.Fatalf("detail output missing per-binding row:\n%s", detail)
+	}
+}
+
+func TestFormatSystemBuffersFallsBackWhenPerBindingLacksCapacity(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{Slot: 2, WorkerID: 1, QueueID: 0, Interface: "ge-0-0-1", UmemTotalFrames: 256, UmemInflightFrames: 64},
+		},
+		PerBinding: []BindingCountersSnapshot{
+			{WorkerID: 1, QueueID: 0, OutstandingTX: 10},
+		},
+	}
+
+	out := FormatSystemBuffers(status, true)
+	for _, want := range []string{
+		"aggregate/1",
+		"256",
+		"64",
+		"worker 1/queue 0/slot 2/ge-0-0-1",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -1,0 +1,83 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatSystemBuffersUsesPerBindingAggregatesBeforeDetails(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{Slot: 10, WorkerID: 1, QueueID: 2, Ifindex: 7, Interface: "ge-0-0-1"},
+			{Slot: 11, WorkerID: 1, QueueID: 3, Ifindex: 8, Interface: "ge-0-0-2"},
+		},
+		PerBinding: []BindingCountersSnapshot{
+			{WorkerID: 1, QueueID: 2, Ifindex: 7, UmemTotalFrames: 1000, UmemInflightFrames: 800, TxRingCapacity: 100, OutstandingTX: 90},
+			{WorkerID: 1, QueueID: 3, Ifindex: 8, UmemTotalFrames: 1000, UmemInflightFrames: 100, TxRingCapacity: 100, OutstandingTX: 10},
+		},
+	}
+
+	out := FormatSystemBuffers(status, true)
+	for _, want := range []string{
+		"Userspace Buffer Utilization:",
+		"AF_XDP UMEM frames",
+		"AF_XDP TX ring",
+		"aggregate/2",
+		"2000",
+		"900",
+		"45.0% OK",
+		"100",
+		"90",
+		"90.0% CRITICAL",
+		"worker 1/queue 2/slot 10/ge-0-0-1",
+		"worker 1/queue 3/slot 11/ge-0-0-2",
+		"userspace buffer row(s) at high utilization",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+
+	agg := strings.Index(out, "aggregate/2")
+	detail := strings.Index(out, "worker 1/queue 2")
+	if agg < 0 || detail < 0 || agg > detail {
+		t.Fatalf("aggregate rows must render before detail rows:\n%s", out)
+	}
+}
+
+func TestFormatSystemBuffersFallsBackToBindingsAndWarnsAtEighty(t *testing.T) {
+	status := ProcessStatus{
+		Bindings: []BindingStatus{
+			{Slot: 0, WorkerID: 0, QueueID: 0, Interface: "ge-0-0-0", UmemTotalFrames: 100, UmemInflightFrames: 80},
+		},
+	}
+
+	out := FormatSystemBuffers(status, false)
+	for _, want := range []string{
+		"AF_XDP UMEM frames",
+		"aggregate/1",
+		"80.0% WARNING",
+		"worker 0/queue 0/slot 0/ge-0-0-0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatSystemBuffersDocumentsMissingStatusFields(t *testing.T) {
+	out := FormatSystemBuffers(ProcessStatus{
+		PerBinding: []BindingCountersSnapshot{{WorkerID: 0, QueueID: 0, OutstandingTX: 10}},
+	}, false)
+
+	for _, want := range []string{
+		"unavailable: helper status does not include bounded AF_XDP capacity gauges",
+		"per_binding[].umem_total_frames",
+		"per_binding[].tx_ring_capacity",
+		"bindings[] mirrors",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/pkg/fwdstatus/builder.go
+++ b/pkg/fwdstatus/builder.go
@@ -102,7 +102,8 @@ func Build(
 
 	// --- Buffer % ------------------------------------------------
 	// eBPF path: max BPF map utilization.
-	// Userspace-dp path: unknown (BPF maps don't represent ring fill).
+	// Userspace-dp path: derived from bounded AF_XDP helper status
+	// below; BPF maps do not represent userspace ring fill.
 	//
 	// Note: GetMapStats() iterates every entry of every BPF map and
 	// userspace.Manager.Status() takes Manager.mu.  That's acceptable

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -1725,6 +1725,10 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)
 				} else {
 					buf.WriteString(dpuserspace.FormatSystemBuffers(status, false))
+					v4, v6 := s.dp.SessionCount()
+					if v4 > 0 || v6 > 0 {
+						fmt.Fprintf(&buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+					}
 				}
 			} else {
 				stats := s.dp.GetMapStats()
@@ -1777,6 +1781,10 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)
 				} else {
 					buf.WriteString(dpuserspace.FormatSystemBuffers(status, true))
+					v4, v6 := s.dp.SessionCount()
+					if v4 > 0 || v6 > 0 {
+						fmt.Fprintf(&buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+					}
 				}
 			} else {
 				stats := s.dp.GetMapStats()

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -1717,40 +1717,51 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "buffers":
 		if s.dp != nil {
-			stats := s.dp.GetMapStats()
-			if len(stats) == 0 {
-				buf.WriteString("No BPF maps available\n")
+			if provider, ok := s.dp.(interface {
+				Status() (dpuserspace.ProcessStatus, error)
+			}); ok {
+				status, err := provider.Status()
+				if err != nil {
+					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)
+				} else {
+					buf.WriteString(dpuserspace.FormatSystemBuffers(status, false))
+				}
 			} else {
-				fmt.Fprintf(&buf, "%-24s %-14s %10s %10s %8s %s\n", "Map", "Type", "Max", "Used", "Usage%", "Status")
-				buf.WriteString(strings.Repeat("-", 78) + "\n")
-				var warnings int
-				for _, st := range stats {
-					usage := "-"
-					used := "-"
-					sts := ""
-					if st.Type != "Array" && st.Type != "PerCPUArray" {
-						used = fmt.Sprintf("%d", st.UsedCount)
-						if st.MaxEntries > 0 {
-							pct := float64(st.UsedCount) / float64(st.MaxEntries) * 100
-							usage = fmt.Sprintf("%.1f%%", pct)
-							if pct >= 90 {
-								sts = "CRITICAL"
-								warnings++
-							} else if pct >= 80 {
-								sts = "WARNING"
-								warnings++
+				stats := s.dp.GetMapStats()
+				if len(stats) == 0 {
+					buf.WriteString("No BPF maps available\n")
+				} else {
+					fmt.Fprintf(&buf, "%-24s %-14s %10s %10s %8s %s\n", "Map", "Type", "Max", "Used", "Usage%", "Status")
+					buf.WriteString(strings.Repeat("-", 78) + "\n")
+					var warnings int
+					for _, st := range stats {
+						usage := "-"
+						used := "-"
+						sts := ""
+						if st.Type != "Array" && st.Type != "PerCPUArray" {
+							used = fmt.Sprintf("%d", st.UsedCount)
+							if st.MaxEntries > 0 {
+								pct := float64(st.UsedCount) / float64(st.MaxEntries) * 100
+								usage = fmt.Sprintf("%.1f%%", pct)
+								if pct >= 90 {
+									sts = "CRITICAL"
+									warnings++
+								} else if pct >= 80 {
+									sts = "WARNING"
+									warnings++
+								}
 							}
 						}
+						fmt.Fprintf(&buf, "%-24s %-14s %10d %10s %8s %s\n", st.Name, st.Type, st.MaxEntries, used, usage, sts)
 					}
-					fmt.Fprintf(&buf, "%-24s %-14s %10d %10s %8s %s\n", st.Name, st.Type, st.MaxEntries, used, usage, sts)
+					if warnings > 0 {
+						fmt.Fprintf(&buf, "\n%d map(s) at high utilization — consider increasing max_entries\n", warnings)
+					}
 				}
-				if warnings > 0 {
-					fmt.Fprintf(&buf, "\n%d map(s) at high utilization — consider increasing max_entries\n", warnings)
+				v4, v6 := s.dp.SessionCount()
+				if v4 > 0 || v6 > 0 {
+					fmt.Fprintf(&buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
 				}
-			}
-			v4, v6 := s.dp.SessionCount()
-			if v4 > 0 || v6 > 0 {
-				fmt.Fprintf(&buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
 			}
 		} else {
 			buf.WriteString("Dataplane not loaded\n")
@@ -1758,53 +1769,64 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "buffers-detail":
 		if s.dp != nil {
-			stats := s.dp.GetMapStats()
-			if len(stats) == 0 {
-				buf.WriteString("No BPF maps available\n")
+			if provider, ok := s.dp.(interface {
+				Status() (dpuserspace.ProcessStatus, error)
+			}); ok {
+				status, err := provider.Status()
+				if err != nil {
+					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)
+				} else {
+					buf.WriteString(dpuserspace.FormatSystemBuffers(status, true))
+				}
 			} else {
-				type mapDetail struct {
-					name      string
-					mapType   string
-					max       uint32
-					used      uint32
-					keySize   uint32
-					valueSize uint32
-					pct       float64
-				}
-				var details []mapDetail
-				for _, st := range stats {
-					if st.Type == "Array" || st.Type == "PerCPUArray" {
-						continue
+				stats := s.dp.GetMapStats()
+				if len(stats) == 0 {
+					buf.WriteString("No BPF maps available\n")
+				} else {
+					type mapDetail struct {
+						name      string
+						mapType   string
+						max       uint32
+						used      uint32
+						keySize   uint32
+						valueSize uint32
+						pct       float64
 					}
-					pct := float64(0)
-					if st.MaxEntries > 0 {
-						pct = float64(st.UsedCount) / float64(st.MaxEntries) * 100
+					var details []mapDetail
+					for _, st := range stats {
+						if st.Type == "Array" || st.Type == "PerCPUArray" {
+							continue
+						}
+						pct := float64(0)
+						if st.MaxEntries > 0 {
+							pct = float64(st.UsedCount) / float64(st.MaxEntries) * 100
+						}
+						details = append(details, mapDetail{
+							name: st.Name, mapType: st.Type, max: st.MaxEntries,
+							used: st.UsedCount, keySize: st.KeySize, valueSize: st.ValueSize, pct: pct,
+						})
 					}
-					details = append(details, mapDetail{
-						name: st.Name, mapType: st.Type, max: st.MaxEntries,
-						used: st.UsedCount, keySize: st.KeySize, valueSize: st.ValueSize, pct: pct,
+					sort.Slice(details, func(i, j int) bool {
+						return details[i].pct > details[j].pct
 					})
-				}
-				sort.Slice(details, func(i, j int) bool {
-					return details[i].pct > details[j].pct
-				})
-				buf.WriteString("BPF Map Details (sorted by utilization):\n\n")
-				for _, d := range details {
-					sts := "OK"
-					if d.pct >= 90 {
-						sts = "CRITICAL"
-					} else if d.pct >= 80 {
-						sts = "WARNING"
+					buf.WriteString("BPF Map Details (sorted by utilization):\n\n")
+					for _, d := range details {
+						sts := "OK"
+						if d.pct >= 90 {
+							sts = "CRITICAL"
+						} else if d.pct >= 80 {
+							sts = "WARNING"
+						}
+						fmt.Fprintf(&buf, "Map: %s\n", d.name)
+						fmt.Fprintf(&buf, "  Type: %s, Max: %d, Used: %d, Usage: %.1f%%\n", d.mapType, d.max, d.used, d.pct)
+						fmt.Fprintf(&buf, "  Key size: %d bytes, Value size: %d bytes\n", d.keySize, d.valueSize)
+						fmt.Fprintf(&buf, "  Status: %s\n\n", sts)
 					}
-					fmt.Fprintf(&buf, "Map: %s\n", d.name)
-					fmt.Fprintf(&buf, "  Type: %s, Max: %d, Used: %d, Usage: %.1f%%\n", d.mapType, d.max, d.used, d.pct)
-					fmt.Fprintf(&buf, "  Key size: %d bytes, Value size: %d bytes\n", d.keySize, d.valueSize)
-					fmt.Fprintf(&buf, "  Status: %s\n\n", sts)
 				}
-			}
-			v4, v6 := s.dp.SessionCount()
-			if v4 > 0 || v6 > 0 {
-				fmt.Fprintf(&buf, "Active sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+				v4, v6 := s.dp.SessionCount()
+				if v4 > 0 || v6 > 0 {
+					fmt.Fprintf(&buf, "Active sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
+				}
 			}
 		} else {
 			buf.WriteString("Dataplane not loaded\n")

--- a/pkg/grpcapi/server_show_system_buffers_test.go
+++ b/pkg/grpcapi/server_show_system_buffers_test.go
@@ -1,0 +1,81 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+type systemBuffersUserspaceDP struct {
+	*dataplane.Manager
+	status dpuserspace.ProcessStatus
+}
+
+func (f *systemBuffersUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
+	return f.status, nil
+}
+
+func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
+	s := &Server{
+		store: configstore.New(t.TempDir() + "/xpf.conf"),
+		dp: &systemBuffersUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				PerBinding: []dpuserspace.BindingCountersSnapshot{
+					{WorkerID: 0, QueueID: 0, Ifindex: 5, UmemTotalFrames: 1000, UmemInflightFrames: 800, TxRingCapacity: 100, OutstandingTX: 90},
+				},
+			},
+		},
+	}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "buffers"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Userspace Buffer Utilization:",
+		"AF_XDP UMEM frames",
+		"80.0% WARNING",
+		"AF_XDP TX ring",
+		"90.0% CRITICAL",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ShowText(buffers) output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "No BPF maps available") {
+		t.Fatalf("ShowText(buffers) fell back to BPF map output:\n%s", out)
+	}
+}
+
+func TestShowTextSystemBuffersDetailIncludesUserspaceRows(t *testing.T) {
+	s := &Server{
+		store: configstore.New(t.TempDir() + "/xpf.conf"),
+		dp: &systemBuffersUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				Bindings: []dpuserspace.BindingStatus{
+					{Slot: 3, WorkerID: 2, QueueID: 1, Ifindex: 9, Interface: "ge-0-0-9", UmemTotalFrames: 100, UmemInflightFrames: 10, TxRingCapacity: 100, OutstandingTX: 10},
+				},
+			},
+		},
+	}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "buffers-detail"})
+	if err != nil {
+		t.Fatalf("ShowText() error = %v", err)
+	}
+	out := resp.GetOutput()
+	if !strings.Contains(out, "worker 2/queue 1/slot 3/ge-0-0-9") {
+		t.Fatalf("ShowText(buffers-detail) missing detail scope:\n%s", out)
+	}
+	if strings.Contains(out, "BPF Map Details") {
+		t.Fatalf("ShowText(buffers-detail) fell back to BPF map detail:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_system_buffers_test.go
+++ b/pkg/grpcapi/server_show_system_buffers_test.go
@@ -14,10 +14,16 @@ import (
 type systemBuffersUserspaceDP struct {
 	*dataplane.Manager
 	status dpuserspace.ProcessStatus
+	v4     int
+	v6     int
 }
 
 func (f *systemBuffersUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
 	return f.status, nil
+}
+
+func (f *systemBuffersUserspaceDP) SessionCount() (int, int) {
+	return f.v4, f.v6
 }
 
 func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
@@ -25,6 +31,8 @@ func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
 		store: configstore.New(t.TempDir() + "/xpf.conf"),
 		dp: &systemBuffersUserspaceDP{
 			Manager: dataplane.New(),
+			v4:      3,
+			v6:      2,
 			status: dpuserspace.ProcessStatus{
 				PerBinding: []dpuserspace.BindingCountersSnapshot{
 					{WorkerID: 0, QueueID: 0, Ifindex: 5, UmemTotalFrames: 1000, UmemInflightFrames: 800, TxRingCapacity: 100, OutstandingTX: 90},
@@ -44,21 +52,27 @@ func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
 		"80.0% WARNING",
 		"AF_XDP TX ring",
 		"90.0% CRITICAL",
+		"Active sessions: 3 IPv4, 2 IPv6, 5 total",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("ShowText(buffers) output missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "worker 0/queue 0") {
+		t.Fatalf("ShowText(buffers) included detail scope:\n%s", out)
 	}
 	if strings.Contains(out, "No BPF maps available") {
 		t.Fatalf("ShowText(buffers) fell back to BPF map output:\n%s", out)
 	}
 }
 
-func TestShowTextSystemBuffersDetailIncludesUserspaceRows(t *testing.T) {
+func TestShowTextSystemBuffersDetailIncludesUserspaceRowsAndSessions(t *testing.T) {
 	s := &Server{
 		store: configstore.New(t.TempDir() + "/xpf.conf"),
 		dp: &systemBuffersUserspaceDP{
 			Manager: dataplane.New(),
+			v4:      4,
+			v6:      1,
 			status: dpuserspace.ProcessStatus{
 				Bindings: []dpuserspace.BindingStatus{
 					{Slot: 3, WorkerID: 2, QueueID: 1, Ifindex: 9, Interface: "ge-0-0-9", UmemTotalFrames: 100, UmemInflightFrames: 10, TxRingCapacity: 100, OutstandingTX: 10},
@@ -74,6 +88,9 @@ func TestShowTextSystemBuffersDetailIncludesUserspaceRows(t *testing.T) {
 	out := resp.GetOutput()
 	if !strings.Contains(out, "worker 2/queue 1/slot 3/ge-0-0-9") {
 		t.Fatalf("ShowText(buffers-detail) missing detail scope:\n%s", out)
+	}
+	if !strings.Contains(out, "Active sessions: 4 IPv4, 1 IPv6, 5 total") {
+		t.Fatalf("ShowText(buffers-detail) missing session footer:\n%s", out)
 	}
 	if strings.Contains(out, "BPF Map Details") {
 		t.Fatalf("ShowText(buffers-detail) fell back to BPF map detail:\n%s", out)


### PR DESCRIPTION
## Summary
- add userspace `show system buffers` rendering from bounded AF_XDP UMEM/TX-ring status instead of BPF map stats
- wire both direct CLI and gRPC show text paths through a safe userspace `Status()` assertion before the existing eBPF map path
- document the userspace status fields and add formatter/gRPC coverage

Refs #1380
Refs #1373

## Tests
- `go test ./pkg/dataplane/userspace ./pkg/grpcapi ./pkg/cli ./pkg/fwdstatus ./cmd/cli`