### PR TITLE
Fix mixed-version CoS guarantee display

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27,6 +27,11 @@
   - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `pkg/cli/cli_show_system.go`, `pkg/grpcapi/server_show.go`, `pkg/grpcapi/server_show_system_buffers_test.go`, `docs/userspace-dataplane-architecture.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace ./pkg/grpcapi ./pkg/cli ./pkg/fwdstatus`; `git diff --check`
 
+- **Timestamp**: 2026-05-16T22:21:02Z
+  - **Action**: PR #1388 round-1 review fix — preserve old-status-JSON display compatibility for shaped interfaces whose userspace runtime synthesizes default best-effort queue 0, while keeping residual scheduler-map queues from inheriting false guarantees.
+  - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
+
 - **Timestamp**: 2026-05-16T04:36:00Z
   - **Action**: PR #1320 round-3 review fixes — validate typed scheduler leaves against the apply-groups-expanded tree before compile; reject `transmit-rate exact` unless the scheduler also has a typed rate; wire `ConfigClassOfServiceSchedulers` into the real config-mode `set class-of-service schedulers <name>` completion tree; update module docs to keep the byte-size-only scheduler buffer contract explicit.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/tree_test.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `pkg/configstore/store.go`, `pkg/configstore/store_test.go`, `_Log.md`

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -558,6 +558,7 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			}
 		}
 	}
+	configuredQueueCount := len(queueViews)
 	if view.interfaceState != nil {
 		for _, runtimeQueue := range view.interfaceState.Queues {
 			qv := queueViews[int(runtimeQueue.QueueID)]
@@ -570,6 +571,8 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.exact = runtimeQueue.Exact
 			if runtimeQueue.GuaranteeEnabled != nil {
 				qv.guaranteeEnabled = *runtimeQueue.GuaranteeEnabled
+			} else if isOldJSONSyntheticDefaultQueue(view, runtimeQueue, configuredQueueCount) {
+				qv.guaranteeEnabled = true
 			}
 			qv.equalFlowEnforcement = runtimeQueue.EqualFlowEnforcement
 			qv.equalFlowEnforced = runtimeQueue.EqualFlowEnforced
@@ -627,6 +630,15 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].queueID < out[j].queueID })
 	return out
+}
+
+func isOldJSONSyntheticDefaultQueue(view cosInterfaceView, runtimeQueue CoSQueueStatus, configuredQueueCount int) bool {
+	return configuredQueueCount == 0 &&
+		view.cosUnit != nil &&
+		view.cosUnit.ShapingRateBytes > 0 &&
+		runtimeQueue.QueueID == 0 &&
+		!runtimeQueue.Exact &&
+		runtimeQueue.TransmitRateBytes > 0
 }
 
 func formatCoSRate(bytesPerSecond uint64) string {

--- a/pkg/dataplane/userspace/cosfmt.go
+++ b/pkg/dataplane/userspace/cosfmt.go
@@ -570,8 +570,6 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.exact = runtimeQueue.Exact
 			if runtimeQueue.GuaranteeEnabled != nil {
 				qv.guaranteeEnabled = *runtimeQueue.GuaranteeEnabled
-			} else if qv.transmitRate == 0 && runtimeQueue.TransmitRateBytes > 0 {
-				qv.guaranteeEnabled = true
 			}
 			qv.equalFlowEnforcement = runtimeQueue.EqualFlowEnforcement
 			qv.equalFlowEnforced = runtimeQueue.EqualFlowEnforced

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -149,6 +149,55 @@ func TestFormatCoSInterfaceSummaryOldJSONDoesNotInferGuaranteeFromEffectiveRate(
 	t.Fatalf("missing best-effort queue row for old status JSON:\n%s", out)
 }
 
+func TestFormatCoSInterfaceSummaryOldJSONInfersSyntheticDefaultQueueGuarantee(t *testing.T) {
+	cfg := testCoSConfig()
+	cfg.ClassOfService.ForwardingClasses = nil
+	cfg.ClassOfService.Schedulers = nil
+	cfg.ClassOfService.SchedulerMaps = nil
+	cfg.ClassOfService.Interfaces["reth0"].Units[80].SchedulerMap = ""
+
+	var status ProcessStatus
+	raw := []byte(`{
+		"cos_interfaces": [{
+			"interface_name": "reth0.80",
+			"worker_instances": 1,
+			"queues": [{
+				"queue_id": 0,
+				"forwarding_class": "best-effort",
+				"priority": 1,
+				"exact": false,
+				"transmit_rate_bytes": 1875000,
+				"buffer_bytes": 65536
+			}]
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &status); err != nil {
+		t.Fatalf("unmarshal old status JSON: %v", err)
+	}
+	if status.CoSInterfaces[0].Queues[0].GuaranteeEnabled != nil {
+		t.Fatalf("old status JSON unexpectedly populated guarantee_enabled")
+	}
+
+	out := FormatCoSInterfaceSummary(cfg, &status, "reth0.80")
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "best-effort") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			t.Fatalf("old status JSON synthetic queue row too short: %q\n%s", line, out)
+		}
+		if fields[5] != "yes" {
+			t.Fatalf("old status JSON synthetic queue rendered guarantee=%s, want yes:\n%s", fields[5], out)
+		}
+		if got := fields[6] + " " + fields[7]; got != "15.00 Mb/s" {
+			t.Fatalf("old status JSON synthetic queue rendered rate=%s, want 15.00 Mb/s:\n%s", got, out)
+		}
+		return
+	}
+	t.Fatalf("missing best-effort queue row for old status JSON:\n%s", out)
+}
+
 func TestFormatCoSInterfaceSummaryShowsConfigOnlyInterface(t *testing.T) {
 	out := FormatCoSInterfaceSummary(testCoSConfig(), nil, "reth0.80")
 	for _, want := range []string{

--- a/pkg/dataplane/userspace/cosfmt_test.go
+++ b/pkg/dataplane/userspace/cosfmt_test.go
@@ -103,6 +103,52 @@ func TestFormatCoSInterfaceSummaryPreservesOldJSONGuaranteeFallback(t *testing.T
 	t.Fatalf("missing bandwidth-10mb queue row for old status JSON:\n%s", out)
 }
 
+func TestFormatCoSInterfaceSummaryOldJSONDoesNotInferGuaranteeFromEffectiveRate(t *testing.T) {
+	cfg := testCoSConfig()
+	cfg.ClassOfService.Schedulers["be"].TransmitRateBytes = 0
+
+	var status ProcessStatus
+	raw := []byte(`{
+		"cos_interfaces": [{
+			"interface_name": "reth0.80",
+			"worker_instances": 1,
+			"queues": [{
+				"queue_id": 0,
+				"forwarding_class": "best-effort",
+				"priority": 1,
+				"exact": false,
+				"transmit_rate_bytes": 1875000,
+				"buffer_bytes": 32768
+			}]
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &status); err != nil {
+		t.Fatalf("unmarshal old status JSON: %v", err)
+	}
+	if status.CoSInterfaces[0].Queues[0].GuaranteeEnabled != nil {
+		t.Fatalf("old status JSON unexpectedly populated guarantee_enabled")
+	}
+
+	out := FormatCoSInterfaceSummary(cfg, &status, "reth0.80")
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "best-effort") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			t.Fatalf("old status JSON residual queue row too short: %q\n%s", line, out)
+		}
+		if fields[5] != "no" {
+			t.Fatalf("old status JSON residual queue rendered guarantee=%s, want no:\n%s", fields[5], out)
+		}
+		if fields[6] != "-" {
+			t.Fatalf("old status JSON residual queue rendered inherited rate=%s, want -:\n%s", fields[6], out)
+		}
+		return
+	}
+	t.Fatalf("missing best-effort queue row for old status JSON:\n%s", out)
+}
+
 func TestFormatCoSInterfaceSummaryShowsConfigOnlyInterface(t *testing.T) {
 	out := FormatCoSInterfaceSummary(testCoSConfig(), nil, "reth0.80")
 	for _, want := range []string{


### PR DESCRIPTION
## Summary

Fixes the late #1372 review finding where a new CLI reading old xpfd status JSON inferred `guarantee_enabled=true` from `transmit_rate_bytes > 0`.

Residual-only queues can carry a positive effective runtime transmit rate inherited from the root shape for sizing/accounting, so that field is not proof of an explicit queue guarantee.

## Changes

- Remove the old-JSON fallback that promoted positive runtime transmit rate into a guarantee.
- Keep modern JSON behavior authoritative through `guarantee_enabled` when present.
- Preserve old-JSON explicit-rate display through config-derived scheduler state.
- Add a regression test for residual-only old JSON with inherited effective rate.

## Validation

- `go test ./pkg/dataplane/userspace`
- `git diff --check`