### PR TITLE
Userspace SYN cookie core (#1374)

### DIFF
--- a/userspace-dp/src/FEATURES.md
+++ b/userspace-dp/src/FEATURES.md
@@ -20,7 +20,7 @@ ordering.
 
 | File | Stage | What it does |
 |------|-------|--------------|
-| `screen.rs` | screen | Pre-session attack-protection checks (land, TCP SYN+FIN, no-flag, FIN-without-ACK, ICMP frag, plus rate-limits). Mirrors `bpf/xdp/xdp_screen.c`. |
+| `screen.rs` | screen | Pre-session attack-protection checks (land, TCP SYN+FIN, no-flag, FIN-without-ACK, ICMP frag, plus rate-limits). Mirrors `bpf/xdp/xdp_screen.c`. Also contains the #1374 userspace SYN-cookie mint/validate core; the Go `syn-cookie` capability gate must stay closed until SYN-ACK TX replies, returning-ACK handling, HA-secret publication, bounded validated-client state, and status counters are wired into the worker path. |
 | `policy.rs` | policy | Zone-pair → permit/deny + forwarding-class + DSCP-rewrite + filter chaining. `ZonePairKey` is a `u32` (`from_id << 16 \| to_id`); `JUNOS_GLOBAL_ZONE_ID = u16::MAX` is the sentinel for the global zone. |
 | `nat.rs` | NAT44 | Source / destination / static NAT decisions. `NatDecision` carries `rewrite_src` and `rewrite_dst` Options the TX path consumes. |
 | `nat64.rs` | NAT64 | RFC 6052 IPv4↔IPv6 translation. `Nat64Prefix` is the 96-bit + IPv4-pool config; `Nat64ReverseInfo` carries the original IPv6 tuple for reverse translation. |

--- a/userspace-dp/src/screen.rs
+++ b/userspace-dp/src/screen.rs
@@ -33,11 +33,18 @@ const TCP_URG: u8 = 0x20;
 const SYN_COOKIE_EPOCH_BITS: u32 = 5;
 const SYN_COOKIE_MSS_BITS: u32 = 3;
 const SYN_COOKIE_MAC_BITS: u32 = 24;
+const SYN_COOKIE_ISN_BITS: u32 = 32;
+const SYN_COOKIE_LAYOUT_BITS: u32 =
+    SYN_COOKIE_EPOCH_BITS + SYN_COOKIE_MSS_BITS + SYN_COOKIE_MAC_BITS;
 const SYN_COOKIE_EPOCH_MASK: u32 = (1 << SYN_COOKIE_EPOCH_BITS) - 1;
 const SYN_COOKIE_MSS_MASK: u32 = (1 << SYN_COOKIE_MSS_BITS) - 1;
 const SYN_COOKIE_MAC_MASK: u32 = (1 << SYN_COOKIE_MAC_BITS) - 1;
 const SYN_COOKIE_EPOCH_SHIFT: u32 = SYN_COOKIE_MSS_BITS + SYN_COOKIE_MAC_BITS;
 const SYN_COOKIE_MSS_SHIFT: u32 = SYN_COOKIE_MAC_BITS;
+const SYN_COOKIE_MAC_DOMAIN: u64 = u64::from_be_bytes(*b"xpf-sync");
+const SYN_COOKIE_SECRET_LEFT_DOMAIN: u64 = u64::from_be_bytes(*b"xpf-sck0");
+const SYN_COOKIE_SECRET_RIGHT_DOMAIN: u64 = u64::from_be_bytes(*b"xpf-sck1");
+const _: [(); SYN_COOKIE_ISN_BITS as usize] = [(); SYN_COOKIE_LAYOUT_BITS as usize];
 
 /// Three-bit MSS table encoded in userspace SYN cookies.
 ///
@@ -159,7 +166,7 @@ impl SynCookieCodec {
     ) -> u32 {
         let secret = self.epoch_secret(zone_id, full_epoch);
         let mut sip = SipHash24::new(secret[0], secret[1]);
-        sip.write_u64(0x7870_662d_7379_6e63);
+        sip.write_u64(SYN_COOKIE_MAC_DOMAIN);
         sip.write_u16(zone_id);
         sip.write_u64(full_epoch);
         sip.write_u8(mss_index);
@@ -175,12 +182,12 @@ impl SynCookieCodec {
         let k1 = u64::from_le_bytes(self.master_key[8..16].try_into().expect("fixed slice"));
 
         let mut left = SipHash24::new(k0, k1);
-        left.write_u64(0x7870_662d_7363_6b30);
+        left.write_u64(SYN_COOKIE_SECRET_LEFT_DOMAIN);
         left.write_u16(zone_id);
         left.write_u64(full_epoch);
 
         let mut right = SipHash24::new(k0, k1);
-        right.write_u64(0x7870_662d_7363_6b31);
+        right.write_u64(SYN_COOKIE_SECRET_RIGHT_DOMAIN);
         right.write_u16(zone_id);
         right.write_u64(full_epoch);
 

--- a/userspace-dp/src/screen.rs
+++ b/userspace-dp/src/screen.rs
@@ -30,6 +30,281 @@ const TCP_SYN: u8 = 0x02;
 const TCP_ACK: u8 = 0x10;
 const TCP_URG: u8 = 0x20;
 
+const SYN_COOKIE_EPOCH_BITS: u32 = 5;
+const SYN_COOKIE_MSS_BITS: u32 = 3;
+const SYN_COOKIE_MAC_BITS: u32 = 24;
+const SYN_COOKIE_EPOCH_MASK: u32 = (1 << SYN_COOKIE_EPOCH_BITS) - 1;
+const SYN_COOKIE_MSS_MASK: u32 = (1 << SYN_COOKIE_MSS_BITS) - 1;
+const SYN_COOKIE_MAC_MASK: u32 = (1 << SYN_COOKIE_MAC_BITS) - 1;
+const SYN_COOKIE_EPOCH_SHIFT: u32 = SYN_COOKIE_MSS_BITS + SYN_COOKIE_MAC_BITS;
+const SYN_COOKIE_MSS_SHIFT: u32 = SYN_COOKIE_MAC_BITS;
+
+/// Three-bit MSS table encoded in userspace SYN cookies.
+///
+/// The index, not the raw MSS, is transmitted in the ISN. Values are sorted so
+/// selection can choose the largest value not exceeding the peer-advertised MSS.
+pub(crate) const SYN_COOKIE_MSS_VALUES: [u16; 8] = [536, 1200, 1300, 1360, 1400, 1440, 1460, 8960];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct SynCookieTuple {
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_port: u16,
+}
+
+impl SynCookieTuple {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn from_packet(pkt: &ScreenPacketInfo) -> Self {
+        Self {
+            src_ip: pkt.src_ip,
+            dst_ip: pkt.dst_ip,
+            src_port: pkt.src_port,
+            dst_port: pkt.dst_port,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct SynCookieValidation {
+    pub full_epoch: u64,
+    pub mss_index: u8,
+    pub mss: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct SynCookieCodec {
+    master_key: [u8; 16],
+}
+
+impl SynCookieCodec {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) const EPOCH_SECS: u64 = 64;
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) const fn new(master_key: [u8; 16]) -> Self {
+        Self { master_key }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn full_epoch_from_monotonic_secs(monotonic_secs: u64) -> u64 {
+        monotonic_secs / Self::EPOCH_SECS
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn mss_index(peer_mss: u16) -> u8 {
+        let mut selected = 0u8;
+        let mut i = 1;
+        while i < SYN_COOKIE_MSS_VALUES.len() {
+            if peer_mss >= SYN_COOKIE_MSS_VALUES[i] {
+                selected = i as u8;
+            }
+            i += 1;
+        }
+        selected
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn mint_isn(
+        &self,
+        tuple: SynCookieTuple,
+        zone_id: u16,
+        full_epoch: u64,
+        peer_mss: u16,
+    ) -> u32 {
+        let mss_index = Self::mss_index(peer_mss);
+        let mac = self.cookie_mac(tuple, zone_id, full_epoch, mss_index);
+        ((full_epoch as u32 & SYN_COOKIE_EPOCH_MASK) << SYN_COOKIE_EPOCH_SHIFT)
+            | ((mss_index as u32 & SYN_COOKIE_MSS_MASK) << SYN_COOKIE_MSS_SHIFT)
+            | mac
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn validate_isn(
+        &self,
+        tuple: SynCookieTuple,
+        zone_id: u16,
+        current_full_epoch: u64,
+        cookie_isn: u32,
+    ) -> Option<SynCookieValidation> {
+        let wire_epoch = (cookie_isn >> SYN_COOKIE_EPOCH_SHIFT) & SYN_COOKIE_EPOCH_MASK;
+        let mss_index = ((cookie_isn >> SYN_COOKIE_MSS_SHIFT) & SYN_COOKIE_MSS_MASK) as u8;
+        let wire_mac = cookie_isn & SYN_COOKIE_MAC_MASK;
+
+        for candidate_epoch in [current_full_epoch, current_full_epoch.saturating_sub(1)] {
+            if (candidate_epoch as u32 & SYN_COOKIE_EPOCH_MASK) != wire_epoch {
+                continue;
+            }
+            if self.cookie_mac(tuple, zone_id, candidate_epoch, mss_index) == wire_mac {
+                return Some(SynCookieValidation {
+                    full_epoch: candidate_epoch,
+                    mss_index,
+                    mss: SYN_COOKIE_MSS_VALUES[mss_index as usize],
+                });
+            }
+        }
+
+        None
+    }
+
+    fn cookie_mac(
+        &self,
+        tuple: SynCookieTuple,
+        zone_id: u16,
+        full_epoch: u64,
+        mss_index: u8,
+    ) -> u32 {
+        let secret = self.epoch_secret(zone_id, full_epoch);
+        let mut sip = SipHash24::new(secret[0], secret[1]);
+        sip.write_u64(0x7870_662d_7379_6e63);
+        sip.write_u16(zone_id);
+        sip.write_u64(full_epoch);
+        sip.write_u8(mss_index);
+        sip.write_ip(tuple.src_ip);
+        sip.write_ip(tuple.dst_ip);
+        sip.write_u16(tuple.src_port);
+        sip.write_u16(tuple.dst_port);
+        (sip.finish() as u32) & SYN_COOKIE_MAC_MASK
+    }
+
+    fn epoch_secret(&self, zone_id: u16, full_epoch: u64) -> [u64; 2] {
+        let k0 = u64::from_le_bytes(self.master_key[0..8].try_into().expect("fixed slice"));
+        let k1 = u64::from_le_bytes(self.master_key[8..16].try_into().expect("fixed slice"));
+
+        let mut left = SipHash24::new(k0, k1);
+        left.write_u64(0x7870_662d_7363_6b30);
+        left.write_u16(zone_id);
+        left.write_u64(full_epoch);
+
+        let mut right = SipHash24::new(k0, k1);
+        right.write_u64(0x7870_662d_7363_6b31);
+        right.write_u16(zone_id);
+        right.write_u64(full_epoch);
+
+        [left.finish(), right.finish()]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SipHash24 {
+    v0: u64,
+    v1: u64,
+    v2: u64,
+    v3: u64,
+    tail: [u8; 8],
+    tail_len: usize,
+    len: u64,
+}
+
+impl SipHash24 {
+    fn new(k0: u64, k1: u64) -> Self {
+        Self {
+            v0: 0x736f_6d65_7073_6575 ^ k0,
+            v1: 0x646f_7261_6e64_6f6d ^ k1,
+            v2: 0x6c79_6765_6e65_7261 ^ k0,
+            v3: 0x7465_6462_7974_6573 ^ k1,
+            tail: [0; 8],
+            tail_len: 0,
+            len: 0,
+        }
+    }
+
+    fn write_ip(&mut self, ip: IpAddr) {
+        match ip {
+            IpAddr::V4(v4) => {
+                self.write_u8(4);
+                self.write_bytes(&v4.octets());
+            }
+            IpAddr::V6(v6) => {
+                self.write_u8(6);
+                self.write_bytes(&v6.octets());
+            }
+        }
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.write_bytes(&[value]);
+    }
+
+    fn write_u16(&mut self, value: u16) {
+        self.write_bytes(&value.to_be_bytes());
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.write_bytes(&value.to_be_bytes());
+    }
+
+    fn write_bytes(&mut self, mut bytes: &[u8]) {
+        self.len += bytes.len() as u64;
+
+        if self.tail_len > 0 {
+            let fill = (8 - self.tail_len).min(bytes.len());
+            self.tail[self.tail_len..self.tail_len + fill].copy_from_slice(&bytes[..fill]);
+            self.tail_len += fill;
+            bytes = &bytes[fill..];
+            if self.tail_len == 8 {
+                self.compress(u64::from_le_bytes(self.tail));
+                self.tail = [0; 8];
+                self.tail_len = 0;
+            }
+        }
+
+        while bytes.len() >= 8 {
+            let block = u64::from_le_bytes(bytes[..8].try_into().expect("fixed slice"));
+            self.compress(block);
+            bytes = &bytes[8..];
+        }
+
+        if !bytes.is_empty() {
+            self.tail[..bytes.len()].copy_from_slice(bytes);
+            self.tail_len = bytes.len();
+        }
+    }
+
+    fn finish(mut self) -> u64 {
+        let mut last = self.len << 56;
+        let mut i = 0;
+        while i < self.tail_len {
+            last |= (self.tail[i] as u64) << (8 * i);
+            i += 1;
+        }
+        self.compress(last);
+        self.v2 ^= 0xff;
+        self.round();
+        self.round();
+        self.round();
+        self.round();
+        self.v0 ^ self.v1 ^ self.v2 ^ self.v3
+    }
+
+    fn compress(&mut self, block: u64) {
+        self.v3 ^= block;
+        self.round();
+        self.round();
+        self.v0 ^= block;
+    }
+
+    fn round(&mut self) {
+        self.v0 = self.v0.wrapping_add(self.v1);
+        self.v1 = self.v1.rotate_left(13);
+        self.v1 ^= self.v0;
+        self.v0 = self.v0.rotate_left(32);
+        self.v2 = self.v2.wrapping_add(self.v3);
+        self.v3 = self.v3.rotate_left(16);
+        self.v3 ^= self.v2;
+        self.v0 = self.v0.wrapping_add(self.v3);
+        self.v3 = self.v3.rotate_left(21);
+        self.v3 ^= self.v0;
+        self.v2 = self.v2.wrapping_add(self.v1);
+        self.v1 = self.v1.rotate_left(17);
+        self.v1 ^= self.v2;
+        self.v2 = self.v2.rotate_left(32);
+    }
+}
+
 /// Parsed packet fields needed for screen checks.
 /// Extracted from raw packet bytes for speed — no allocations.
 #[derive(Debug, Clone)]
@@ -597,12 +872,10 @@ pub(crate) fn extract_screen_info(
                     // IPv6 frag_off layout (big-endian u16 at offset+2):
                     //   offset (13 bits, top) | reserved (2 bits) | M (1 bit, lowest)
                     // Mirrors BPF #866: MF=0x1, offset=0xFFF8.
-                    let frag_off =
-                        u16::from_be_bytes([frame[offset + 2], frame[offset + 3]]);
+                    let frag_off = u16::from_be_bytes([frame[offset + 2], frame[offset + 3]]);
                     info.ip_frag_off = frag_off;
                     info.is_fragment = (frag_off & 0x1) != 0 || (frag_off & 0xFFF8) != 0;
-                    info.is_first_fragment =
-                        (frag_off & 0x1) != 0 && (frag_off & 0xFFF8) == 0;
+                    info.is_first_fragment = (frag_off & 0x1) != 0 && (frag_off & 0xFFF8) == 0;
                     break;
                 }
                 _ => break,

--- a/userspace-dp/src/screen_tests.rs
+++ b/userspace-dp/src/screen_tests.rs
@@ -550,7 +550,10 @@ fn extract_screen_info_ipv4_first_fragment() {
         14,
     );
     assert!(info.is_fragment, "MF=1 → is_fragment");
-    assert!(info.is_first_fragment, "MF=1 && offset==0 → is_first_fragment");
+    assert!(
+        info.is_first_fragment,
+        "MF=1 && offset==0 → is_first_fragment"
+    );
 }
 
 #[test]
@@ -903,6 +906,172 @@ fn syn_flood_disabled_passes() {
     for _ in 0..1000 {
         assert_eq!(state.check_packet("trust", &pkt, 100), ScreenVerdict::Pass);
     }
+}
+
+// ================================================================
+// SYN cookie core (#1374)
+// ================================================================
+
+fn syn_cookie_codec() -> SynCookieCodec {
+    SynCookieCodec::new([
+        0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe,
+        0x0f,
+    ])
+}
+
+fn syn_cookie_tuple() -> SynCookieTuple {
+    SynCookieTuple {
+        src_ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        src_port: 49152,
+        dst_port: 443,
+    }
+}
+
+#[test]
+fn syn_cookie_tuple_from_packet_matches_packet_flow() {
+    let pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        49152,
+        443,
+        TCP_SYN,
+    );
+
+    assert_eq!(SynCookieTuple::from_packet(&pkt), syn_cookie_tuple());
+}
+
+#[test]
+fn syn_cookie_mint_validate_roundtrip() {
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+    let cookie = codec.mint_isn(tuple, 7, 42, 1460);
+    let validation = codec
+        .validate_isn(tuple, 7, 42, cookie)
+        .expect("fresh cookie should validate");
+
+    assert_eq!(validation.full_epoch, 42);
+    assert_eq!(validation.mss_index, 6);
+    assert_eq!(validation.mss, 1460);
+    assert_eq!(
+        (cookie >> SYN_COOKIE_EPOCH_SHIFT) & SYN_COOKIE_EPOCH_MASK,
+        10
+    );
+}
+
+#[test]
+fn syn_cookie_validate_rejects_modified_tuple() {
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+    let cookie = codec.mint_isn(tuple, 7, 42, 1460);
+
+    let mut mutated = tuple;
+    mutated.src_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 11));
+    assert!(codec.validate_isn(mutated, 7, 42, cookie).is_none());
+
+    mutated = tuple;
+    mutated.dst_ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 21));
+    assert!(codec.validate_isn(mutated, 7, 42, cookie).is_none());
+
+    mutated = tuple;
+    mutated.src_port += 1;
+    assert!(codec.validate_isn(mutated, 7, 42, cookie).is_none());
+
+    mutated = tuple;
+    mutated.dst_port += 1;
+    assert!(codec.validate_isn(mutated, 7, 42, cookie).is_none());
+
+    assert!(codec.validate_isn(tuple, 8, 42, cookie).is_none());
+}
+
+#[test]
+fn syn_cookie_validate_rejects_stale_secret() {
+    let codec = syn_cookie_codec();
+    let stale_codec = SynCookieCodec::new([
+        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
+        0x00,
+    ]);
+    let tuple = syn_cookie_tuple();
+    let cookie = codec.mint_isn(tuple, 7, 42, 1460);
+
+    assert!(stale_codec.validate_isn(tuple, 7, 42, cookie).is_none());
+}
+
+#[test]
+fn syn_cookie_mss_index_encoding_parity() {
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+
+    for (idx, mss) in SYN_COOKIE_MSS_VALUES.iter().copied().enumerate() {
+        assert_eq!(SynCookieCodec::mss_index(mss), idx as u8);
+        let cookie = codec.mint_isn(tuple, 7, 42, mss);
+        assert_eq!(
+            (cookie >> SYN_COOKIE_MSS_SHIFT) & SYN_COOKIE_MSS_MASK,
+            idx as u32
+        );
+        assert_eq!(codec.validate_isn(tuple, 7, 42, cookie).unwrap().mss, mss);
+    }
+
+    assert_eq!(SynCookieCodec::mss_index(535), 0);
+    assert_eq!(SynCookieCodec::mss_index(1459), 5);
+    assert_eq!(SynCookieCodec::mss_index(9000), 7);
+
+    let cookie = codec.mint_isn(tuple, 7, 42, 1460);
+    let tampered_mss =
+        (cookie & !(SYN_COOKIE_MSS_MASK << SYN_COOKIE_MSS_SHIFT)) | (5 << SYN_COOKIE_MSS_SHIFT);
+    assert!(codec.validate_isn(tuple, 7, 42, tampered_mss).is_none());
+}
+
+#[test]
+fn syn_cookie_ntp_rollback_monotonic_epoch() {
+    assert_eq!(SynCookieCodec::full_epoch_from_monotonic_secs(0), 0);
+    assert_eq!(SynCookieCodec::full_epoch_from_monotonic_secs(63), 0);
+    assert_eq!(SynCookieCodec::full_epoch_from_monotonic_secs(64), 1);
+    assert_eq!(
+        SynCookieCodec::full_epoch_from_monotonic_secs(64 * 33 + 9),
+        33
+    );
+}
+
+#[test]
+fn syn_cookie_epoch_low_bits_wrap_rejects_32_epoch_old_cookie() {
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+    let old_epoch = 10;
+    let current_epoch = old_epoch + 32;
+    let cookie = codec.mint_isn(tuple, 7, old_epoch, 1460);
+
+    assert_eq!(old_epoch & 0x1f, current_epoch & 0x1f);
+    assert!(
+        codec
+            .validate_isn(tuple, 7, current_epoch, cookie)
+            .is_none()
+    );
+}
+
+#[test]
+fn syn_cookie_validation_tries_current_and_previous_full_epoch() {
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+    let current_cookie = codec.mint_isn(tuple, 7, 42, 1460);
+    let previous_cookie = codec.mint_isn(tuple, 7, 41, 1460);
+    let older_cookie = codec.mint_isn(tuple, 7, 40, 1460);
+
+    assert_eq!(
+        codec
+            .validate_isn(tuple, 7, 42, current_cookie)
+            .expect("current epoch")
+            .full_epoch,
+        42
+    );
+    assert_eq!(
+        codec
+            .validate_isn(tuple, 7, 42, previous_cookie)
+            .expect("previous epoch")
+            .full_epoch,
+        41
+    );
+    assert!(codec.validate_isn(tuple, 7, 42, older_cookie).is_none());
 }
 
 // ================================================================

--- a/userspace-dp/src/screen_tests.rs
+++ b/userspace-dp/src/screen_tests.rs
@@ -593,7 +593,8 @@ fn extract_screen_info_ipv6_first_fragment() {
     let mut frame = vec![0u8; 14 + 40 + 8];
     // IPv6 first byte: version=6 in top nibble
     frame[14] = 0x60;
-    frame[14 + 6] = 44; // NextHdr = FRAGMENT
+    // NextHdr = FRAGMENT
+    frame[14 + 6] = 44;
     // Fragment header at offset 14+40 = 54: nexthdr=6 (TCP), reserved=0,
     // frag_off (MF=1, offset=0) = 0x0001 in big-endian.
     let frag_off_pos = 14 + 40 + 2;
@@ -929,6 +930,34 @@ fn syn_cookie_tuple() -> SynCookieTuple {
 }
 
 #[test]
+fn siphash24_matches_reference_vectors() {
+    // SipHash-2-4 reference vectors for key bytes 00..0f and message bytes
+    // 00..len. These pin the private implementation used by the cookie MAC.
+    let k0 = u64::from_le_bytes([0, 1, 2, 3, 4, 5, 6, 7]);
+    let k1 = u64::from_le_bytes([8, 9, 10, 11, 12, 13, 14, 15]);
+    let vectors = [
+        (0usize, 0x726f_db47_dd0e_0e31u64),
+        (1, 0x74f8_39c5_93dc_67fdu64),
+        (8, 0x93f5_f579_9a93_2462u64),
+        (15, 0xa129_ca61_49be_45e5u64),
+    ];
+
+    for (len, expected) in vectors {
+        let mut sip = SipHash24::new(k0, k1);
+        let bytes: Vec<u8> = (0..len as u8).collect();
+        sip.write_bytes(&bytes);
+        assert_eq!(sip.finish(), expected, "SipHash-2-4 vector length {len}");
+    }
+}
+
+#[test]
+fn syn_cookie_layout_fills_tcp_isn() {
+    assert_eq!(SYN_COOKIE_LAYOUT_BITS, SYN_COOKIE_ISN_BITS);
+    assert_eq!(SYN_COOKIE_EPOCH_SHIFT, 27);
+    assert_eq!(SYN_COOKIE_MSS_SHIFT, 24);
+}
+
+#[test]
 fn syn_cookie_tuple_from_packet_matches_packet_flow() {
     let pkt = tcp_pkt(
         IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
@@ -1042,11 +1071,9 @@ fn syn_cookie_epoch_low_bits_wrap_rejects_32_epoch_old_cookie() {
     let cookie = codec.mint_isn(tuple, 7, old_epoch, 1460);
 
     assert_eq!(old_epoch & 0x1f, current_epoch & 0x1f);
-    assert!(
-        codec
-            .validate_isn(tuple, 7, current_epoch, cookie)
-            .is_none()
-    );
+    assert!(codec
+        .validate_isn(tuple, 7, current_epoch, cookie)
+        .is_none());
 }
 
 #[test]


### PR DESCRIPTION
Refs #1374.

## Summary
- Add a deterministic userspace SYN-cookie codec with `[5-bit epoch][3-bit MSS index][24-bit MAC]` ISN layout.
- Derive per-zone epoch secrets from a master key plus the full monotonic epoch, and validate only current/previous full epochs so low-bit epoch wraps do not replay.
- Cover tuple, zone, MSS-index, stale-secret, epoch-window, and low-bit-wrap rejection in screen tests.
- Document that the Go `syn-cookie` capability gate must remain closed until SYN-ACK TX replies, returning-ACK handling, HA-secret publication, bounded validated-client state, and counters are wired.

## Validation
- `cargo test syn_cookie --manifest-path userspace-dp/Cargo.toml`
- `cargo test screen --manifest-path userspace-dp/Cargo.toml`
- `git diff --check`