### PR TITLE
mouse-latency: add 100E100M settle diagnostics

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12,6 +12,11 @@
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py test_mouse_latency_shell_test.py`; `cd test/incus && python3 -m unittest mouse_latency_probe_test.py`; `bash -n test/incus/test-mouse-latency.sh`
 
+- **Timestamp**: 2026-05-17T15:30:19Z
+  - **Action**: Addressed final review nits in orchestrate tests by renaming the settle-diagnostics args mock class for clarity and replacing inline cwnd-byte magic numbers with named KiB constants.
+  - **File(s)**: `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
+  - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py`
+
 - **Timestamp**: 2026-05-17T08:30:20Z
   - **Action**: PR #1394 round-10 follow-up — fixed standalone userspace event-stream callback wiring by always registering session/full-resync callbacks, and added a regression test that verifies standalone SessionOpen and FullResync frames are ACKed instead of stalling behind an unwired callback queue.
   - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`, `pkg/daemon/userspace_sync_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,11 @@
 
 ## 2026-05-17
 
+- **Timestamp**: 2026-05-17T15:28:13Z
+  - **Action**: PR #1359/#1365 follow-up — fixed mouse-latency diagnostics review findings by making `cwnd_settle_ok` tri-state in manifests (unknown/true/false), correcting cwnd byte-unit parsing to 1024-based `K/M/G/TBytes`, recording probe phase timings even on failed/timed-out connect/drain/read attempts, tightening fairness-regimes settle-evidence wording, and extending unit coverage for settle-diagnostics CLI output/status and failure-phase timing counts.
+  - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate.py`, `test/incus/mouse_latency_orchestrate_test.py`, `test/incus/mouse_latency_probe.py`, `test/incus/mouse_latency_probe_test.py`, `test/incus/test_mouse_latency_shell_test.py`, `docs/fairness-regimes.md`, `_Log.md`
+  - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py mouse_latency_aggregate_test.py test_mouse_latency_shell_test.py && python3 -m unittest mouse_latency_probe_test.py && bash -n test-mouse-latency.sh`; `python3 -m py_compile test/incus/mouse_latency_orchestrate.py test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`; `git diff --check`
+
 - **Timestamp**: 2026-05-17T08:30:20Z
   - **Action**: PR #1394 round-10 follow-up — fixed standalone userspace event-stream callback wiring by always registering session/full-resync callbacks, and added a regression test that verifies standalone SessionOpen and FullResync frames are ACKed instead of stalling behind an unwired callback queue.
   - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`, `pkg/daemon/userspace_sync_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -3,7 +3,7 @@
 ## 2026-05-17
 
 - **Timestamp**: 2026-05-17T15:28:13Z
-  - **Action**: PR #1359/#1365 follow-up — fixed mouse-latency diagnostics review findings by making `cwnd_settle_ok` tri-state in manifests (unknown/true/false), correcting cwnd byte-unit parsing to 1024-based `K/M/G/TBytes`, recording probe phase timings even on failed/timed-out connect/drain/read attempts, tightening fairness-regimes settle-evidence wording, and extending unit coverage for settle-diagnostics CLI output/status and failure-phase timing counts.
+  - **Action**: PR #1397 follow-up — fixed mouse-latency diagnostics review findings by making `cwnd_settle_ok` tri-state in manifests (unknown/true/false), correcting cwnd byte-unit parsing to 1024-based `K/M/G/TBytes`, recording probe phase timings even on failed/timed-out connect/drain/read attempts, tightening fairness-regimes settle-evidence wording, and extending unit coverage for settle-diagnostics CLI output/status and failure-phase timing counts.
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate.py`, `test/incus/mouse_latency_orchestrate_test.py`, `test/incus/mouse_latency_probe.py`, `test/incus/mouse_latency_probe_test.py`, `test/incus/test_mouse_latency_shell_test.py`, `docs/fairness-regimes.md`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py mouse_latency_aggregate_test.py test_mouse_latency_shell_test.py && python3 -m unittest mouse_latency_probe_test.py && bash -n test-mouse-latency.sh`; `python3 -m py_compile test/incus/mouse_latency_orchestrate.py test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`; `git diff --check`
 

--- a/_Log.md
+++ b/_Log.md
@@ -7,6 +7,11 @@
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate.py`, `test/incus/mouse_latency_orchestrate_test.py`, `test/incus/mouse_latency_probe.py`, `test/incus/mouse_latency_probe_test.py`, `test/incus/test_mouse_latency_shell_test.py`, `docs/fairness-regimes.md`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py mouse_latency_aggregate_test.py test_mouse_latency_shell_test.py && python3 -m unittest mouse_latency_probe_test.py && bash -n test-mouse-latency.sh`; `python3 -m py_compile test/incus/mouse_latency_orchestrate.py test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`; `git diff --check`
 
+- **Timestamp**: 2026-05-17T15:29:22Z
+  - **Action**: Addressed parallel validation follow-up by making `CWND_SETTLE_OK="true"` conditional on settle-diagnostics success (explicit `else` branch) and renaming settle-diagnostics test helper variables to descriptive names.
+  - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
+  - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py test_mouse_latency_shell_test.py`; `cd test/incus && python3 -m unittest mouse_latency_probe_test.py`; `bash -n test/incus/test-mouse-latency.sh`
+
 - **Timestamp**: 2026-05-17T08:30:20Z
   - **Action**: PR #1394 round-10 follow-up — fixed standalone userspace event-stream callback wiring by always registering session/full-resync callbacks, and added a regression test that verifies standalone SessionOpen and FullResync frames are ACKed instead of stalling behind an unwired callback queue.
   - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`, `pkg/daemon/userspace_sync_test.go`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -17,6 +17,11 @@
   - **File(s)**: `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py`
 
+- **Timestamp**: 2026-05-17T15:31:13Z
+  - **Action**: Applied final Copilot review polish in orchestrate tests by making the mock args class name explicitly `Mock*` and documenting cwnd KiB fixture constants.
+  - **File(s)**: `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
+  - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py`
+
 - **Timestamp**: 2026-05-17T08:30:20Z
   - **Action**: PR #1394 round-10 follow-up — fixed standalone userspace event-stream callback wiring by always registering session/full-resync callbacks, and added a regression test that verifies standalone SessionOpen and FullResync frames are ACKed instead of stalling behind an unwired callback queue.
   - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`, `pkg/daemon/userspace_sync_test.go`, `_Log.md`

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -467,6 +467,22 @@ fields. The reducer also verifies that gate cells share the same
 mixed per-attempt/persistent or paced/unpaced gate artifacts are reported
 as insufficient data rather than a PASS/FAIL verdict.
 
+High-rate 100E100M runs that fail before the mouse probe now leave
+settle evidence in each rep. `cwnd-settle.json` records the final
+settle-window aggregate, threshold reasons, per-flow min/median/max
+throughput, retransmits, and latest cwnd distribution. `mpstat-settle.txt`
+captures source-side CPU during the settle window. `manifest.json` records
+`settle_budget_s`, `cwnd_settle_elapsed_s`, and `cwnd_settle_ok`; use
+`MOUSE_LATENCY_SETTLE_BUDGET=<seconds>` for a deliberately longer
+high-rate settle budget. Probe artifacts also carry `phase_us` and
+`coroutines` diagnostics so a degenerate-coroutine failure can be read as
+timer wake delay (`start_gap_us` / `sleep_overshoot_us`), client socket
+backpressure (`drain_us`), or echo-path delay (`read_us`) before blaming
+root surplus arbitration or dataplane queue residence. The per-rep
+`cos-interface-pre.txt`, `cos-interface-settle.txt`, and
+`cos-interface-post.txt` snapshots preserve the CoS queue counters needed
+for that cross-check.
+
 ```bash
 MOUSE_COS_SURPLUS_SHARING=1 \
 MOUSE_LATENCY_CELLS=$'0 100\n100 100' \

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -473,9 +473,12 @@ When the settle snapshot pull succeeds and diagnostics run, high-rate
 reasons, min/median/max of per-flow mean throughput, retransmits, and
 latest cwnd distribution. `mpstat-settle.txt`
 captures source-side CPU during the settle window. `manifest.json` records
-`settle_budget_s`, `cwnd_settle_elapsed_s`, and `cwnd_settle_ok`; use
-`MOUSE_LATENCY_SETTLE_BUDGET=<seconds>` for a deliberately longer
-high-rate settle budget. Probe artifacts also carry `phase_us` and
+`settle_budget_s`, `cwnd_settle_elapsed_s`, and tri-state
+`cwnd_settle_ok`: `true` only after a successful settle diagnostic,
+`false` after an evaluated-but-unsettled diagnostic, and `null` for cells
+that did not run the settle gate (`N=0`, pull failure, or other pre-gate
+invalidations). Use `MOUSE_LATENCY_SETTLE_BUDGET=<seconds>` for a
+deliberately longer high-rate settle budget. Probe artifacts also carry `phase_us` and
 `coroutines` diagnostics so a degenerate-coroutine failure can be read as
 timer wake delay (`start_gap_us` / `sleep_overshoot_us`), client socket
 backpressure (`drain_us`), or echo-path delay (`read_us`) before blaming

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -467,10 +467,11 @@ fields. The reducer also verifies that gate cells share the same
 mixed per-attempt/persistent or paced/unpaced gate artifacts are reported
 as insufficient data rather than a PASS/FAIL verdict.
 
-High-rate 100E100M runs that fail before the mouse probe now leave
-settle evidence in each rep. `cwnd-settle.json` records the final
-settle-window aggregate, threshold reasons, per-flow min/median/max
-throughput, retransmits, and latest cwnd distribution. `mpstat-settle.txt`
+When the settle snapshot pull succeeds and diagnostics run, high-rate
+100E100M reps include settle evidence before the mouse probe.
+`cwnd-settle.json` records the final settle-window aggregate, threshold
+reasons, min/median/max of per-flow mean throughput, retransmits, and
+latest cwnd distribution. `mpstat-settle.txt`
 captures source-side CPU during the settle window. `manifest.json` records
 `settle_budget_s`, `cwnd_settle_elapsed_s`, and `cwnd_settle_ok`; use
 `MOUSE_LATENCY_SETTLE_BUDGET=<seconds>` for a deliberately longer

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -227,6 +227,8 @@ def summarize_cell(reps: List[dict], representative_percentile: str = "p99") -> 
             "attempts_per_second_per_coroutine_iqr":
                 totals.get("attempts_per_second_per_coroutine_iqr"),
             "attempts_per_coroutine": totals.get("attempts_per_coroutine"),
+            "phase_us": median.get("phase_us"),
+            "coroutines": median.get("coroutines"),
         }
     summary["status"] = "OK"
     return summary

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -97,6 +97,17 @@ class SummarizeCellTests(unittest.TestCase):
         self.assertIsNotNone(s["median_rep"])
         self.assertIsNotNone(s["iqr_p99_across_reps"])
 
+    def test_median_rep_carries_probe_diagnostics(self):
+        reps = [_make_rep(p99=100 + 10 * i) for i in range(10)]
+        reps[5]["phase_us"] = {"read_us": {"p99": 1234}}
+        reps[5]["coroutines"] = [{"id": 0, "max_start_gap_us": 20000}]
+        s = summarize_cell(reps)
+        self.assertEqual(s["median_rep"]["phase_us"], {"read_us": {"p99": 1234}})
+        self.assertEqual(
+            s["median_rep"]["coroutines"],
+            [{"id": 0, "max_start_gap_us": 20000}],
+        )
+
     def test_excludes_invalid_from_median(self):
         # 10 valid + 3 invalid; the invalid ones with extreme p99 must
         # not contribute to the median.

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -7,6 +7,8 @@ variable interpolation and quoting). Each function is invoked via
 Subcommands:
 - check-cwnd-settle: parse a (snapshot of) iperf3.txt, return 0 if
   the last 3 [SUM] rows are within ±15 % AND ≥ 0.7 × shaper.
+- settle-diagnostics: parse the same snapshot and emit JSON evidence
+  explaining the settle verdict.
 - check-collapse: parse a final iperf3.txt, return 0 if any 3
   consecutive [SUM] rows fell below 0.5 × shaper.
 - parse-cluster-state: read cluster-status text from stdin, print
@@ -16,10 +18,30 @@ Subcommands:
 """
 
 import argparse
+import json
+import re
+import statistics
 import sys
 
 from cluster_status_parse import parse_cluster_status
 from iperf3_sum_parse import parse_sum_bps
+
+_IPERF_INTERVAL_RE = re.compile(
+    r"^\[\s*(?P<stream_id>SUM|\d+)\]\s+"
+    r"(?P<start>\d+(?:\.\d+)?)-(?P<end>\d+(?:\.\d+)?)\s+sec\s+"
+    r"\S+\s+\S+\s+"
+    r"(?P<rate>\S+)\s+(?P<rate_unit>[KMGT]?)bits/sec"
+    r"(?:\s+(?P<retransmits>\d+)\s+(?P<cwnd>\S+)\s+(?P<cwnd_unit>[KMGT]?)Bytes)?",
+    re.IGNORECASE,
+)
+
+_UNIT_MULTIPLIER = {
+    "": 1,
+    "K": 1_000,
+    "M": 1_000_000,
+    "G": 1_000_000_000,
+    "T": 1_000_000_000_000,
+}
 
 
 def _last_n_sum_bps(text: str, n: int) -> list:
@@ -31,19 +53,239 @@ def _last_n_sum_bps(text: str, n: int) -> list:
     return out[-n:]
 
 
+def _parse_iperf_interval_rows(text: str) -> list[dict]:
+    """Parse iperf3 text interval rows, including stream-level TCP fields."""
+    rows = []
+    for line in text.splitlines():
+        m = _IPERF_INTERVAL_RE.match(line)
+        if not m:
+            continue
+        rate_multiplier = _UNIT_MULTIPLIER.get(m.group("rate_unit").upper())
+        if rate_multiplier is None:
+            continue
+        try:
+            start = float(m.group("start"))
+            end = float(m.group("end"))
+            rate_bps = int(float(m.group("rate")) * rate_multiplier)
+        except ValueError:
+            continue
+
+        stream_id_raw = m.group("stream_id")
+        stream_id: str | int = (
+            "SUM" if stream_id_raw.upper() == "SUM" else int(stream_id_raw)
+        )
+        retransmits = None
+        if m.group("retransmits") is not None:
+            retransmits = int(m.group("retransmits"))
+        cwnd_bytes = None
+        if m.group("cwnd") is not None:
+            cwnd_multiplier = _UNIT_MULTIPLIER.get(m.group("cwnd_unit").upper())
+            if cwnd_multiplier is not None:
+                try:
+                    cwnd_bytes = int(float(m.group("cwnd")) * cwnd_multiplier)
+                except ValueError:
+                    cwnd_bytes = None
+        rows.append({
+            "stream_id": stream_id,
+            "start": start,
+            "end": end,
+            "duration": end - start,
+            "bps": rate_bps,
+            "retransmits": retransmits,
+            "cwnd_bytes": cwnd_bytes,
+            # iperf3 final sender/receiver summaries span the whole run.
+            "summary": (end - start) > 1.5,
+        })
+    return rows
+
+
+def _median_int(values: list[int]) -> int | None:
+    if not values:
+        return None
+    return int(statistics.median(values))
+
+
+def _min_median_max(values: list[int]) -> dict:
+    if not values:
+        return {"min": None, "median": None, "max": None}
+    return {
+        "min": min(values),
+        "median": _median_int(values),
+        "max": max(values),
+    }
+
+
+def build_cwnd_settle_diagnostics(
+    text: str,
+    shaper_bps: int,
+    *,
+    window_rows: int = 3,
+    elapsed_sec: int | None = None,
+    sample_index: int | None = None,
+) -> dict:
+    """Return settle verdict details for a text-mode iperf3 snapshot."""
+    rows = _parse_iperf_interval_rows(text)
+    sum_rows = [
+        r for r in rows
+        if r["stream_id"] == "SUM" and not r["summary"]
+    ]
+    if len(sum_rows) < window_rows:
+        return {
+            "settled": False,
+            "reasons": [
+                f"insufficient-sum-rows: have={len(sum_rows)} need={window_rows}",
+            ],
+            "elapsed_sec": elapsed_sec,
+            "sample_index": sample_index,
+            "thresholds": {
+                "window_rows": window_rows,
+                "max_aggregate_spread_ratio": 0.15,
+                "min_aggregate_utilization": 0.7,
+                "min_aggregate_bps": int(0.7 * shaper_bps),
+                "shaper_bps": shaper_bps,
+            },
+            "aggregate": {
+                "sum_rows_seen": len(sum_rows),
+                "window_bps": [],
+                "window_bps_min": None,
+                "window_bps_max": None,
+                "window_bps_mean": None,
+                "window_spread_ratio": None,
+                "window_min_utilization": None,
+            },
+            "per_flow": {
+                "flow_count": 0,
+                "mean_bps": _min_median_max([]),
+                "retransmits_total": 0,
+                "cwnd_bytes": _min_median_max([]),
+                "slowest_streams": [],
+                "fastest_streams": [],
+            },
+        }
+
+    window = sum_rows[-window_rows:]
+    window_keys = {(r["start"], r["end"]) for r in window}
+    window_bps = [int(r["bps"]) for r in window]
+    mn, mx = min(window_bps), max(window_bps)
+    spread_ratio = None if mx <= 0 else (mx - mn) / mx
+    min_utilization = None if shaper_bps <= 0 else mn / shaper_bps
+
+    by_stream: dict[int, list[dict]] = {}
+    for row in rows:
+        if row["stream_id"] == "SUM" or row["summary"]:
+            continue
+        if (row["start"], row["end"]) not in window_keys:
+            continue
+        by_stream.setdefault(int(row["stream_id"]), []).append(row)
+
+    stream_summaries = []
+    for stream_id, stream_rows in sorted(by_stream.items()):
+        bps_values = [int(r["bps"]) for r in stream_rows]
+        retransmits = sum(int(r["retransmits"] or 0) for r in stream_rows)
+        latest_cwnd = next(
+            (
+                r["cwnd_bytes"]
+                for r in sorted(stream_rows, key=lambda r: (r["end"], r["start"]), reverse=True)
+                if r["cwnd_bytes"] is not None
+            ),
+            None,
+        )
+        stream_summaries.append({
+            "stream_id": stream_id,
+            "samples": len(stream_rows),
+            "mean_bps": int(statistics.fmean(bps_values)) if bps_values else 0,
+            "min_bps": min(bps_values) if bps_values else None,
+            "max_bps": max(bps_values) if bps_values else None,
+            "retransmits": retransmits,
+            "cwnd_bytes_last": latest_cwnd,
+        })
+
+    flow_means = [s["mean_bps"] for s in stream_summaries]
+    cwnds = [
+        int(s["cwnd_bytes_last"])
+        for s in stream_summaries
+        if s["cwnd_bytes_last"] is not None
+    ]
+    retransmits_total = sum(int(s["retransmits"]) for s in stream_summaries)
+    slowest = sorted(stream_summaries, key=lambda s: s["mean_bps"])[:5]
+    fastest = sorted(stream_summaries, key=lambda s: s["mean_bps"], reverse=True)[:5]
+
+    reasons = []
+    if spread_ratio is not None and spread_ratio > 0.15:
+        reasons.append(
+            f"aggregate-window-spread: ratio={spread_ratio:.4f} > 0.1500"
+        )
+    min_required_bps = 0.7 * shaper_bps
+    if mn < min_required_bps:
+        reasons.append(
+            f"aggregate-too-low: min_bps={mn} < threshold_bps={int(min_required_bps)}"
+        )
+
+    return {
+        "settled": not reasons,
+        "reasons": reasons,
+        "elapsed_sec": elapsed_sec,
+        "sample_index": sample_index,
+        "thresholds": {
+            "window_rows": window_rows,
+            "max_aggregate_spread_ratio": 0.15,
+            "min_aggregate_utilization": 0.7,
+            "min_aggregate_bps": int(min_required_bps),
+            "shaper_bps": shaper_bps,
+        },
+        "aggregate": {
+            "sum_rows_seen": len(sum_rows),
+            "window_intervals": [
+                {"start": r["start"], "end": r["end"]} for r in window
+            ],
+            "window_bps": window_bps,
+            "window_bps_min": mn,
+            "window_bps_max": mx,
+            "window_bps_mean": int(statistics.fmean(window_bps)),
+            "window_spread_ratio": spread_ratio,
+            "window_min_utilization": min_utilization,
+        },
+        "per_flow": {
+            "flow_count": len(stream_summaries),
+            "mean_bps": _min_median_max(flow_means),
+            "retransmits_total": retransmits_total,
+            "cwnd_bytes": _min_median_max(cwnds),
+            "slowest_streams": slowest,
+            "fastest_streams": fastest,
+        },
+    }
+
+
 def cmd_check_cwnd_settle(args: argparse.Namespace) -> int:
     """Exit 0 if cwnd is settled; non-zero otherwise."""
     with open(args.iperf3_txt) as f:
         text = f.read()
-    last3 = _last_n_sum_bps(text, 3)
-    if len(last3) < 3:
-        return 1
-    mn, mx = min(last3), max(last3)
-    if mx > 0 and (mx - mn) > 0.15 * mx:
-        return 1
-    if mn < 0.7 * args.shaper_bps:
-        return 1
-    return 0
+    diagnostics = build_cwnd_settle_diagnostics(
+        text, args.shaper_bps, window_rows=getattr(args, "window_rows", 3),
+    )
+    return 0 if diagnostics["settled"] else 1
+
+
+def cmd_settle_diagnostics(args: argparse.Namespace) -> int:
+    """Emit JSON settle evidence and return 0 only when settled."""
+    with open(args.iperf3_txt) as f:
+        text = f.read()
+    diagnostics = build_cwnd_settle_diagnostics(
+        text,
+        args.shaper_bps,
+        window_rows=args.window_rows,
+        elapsed_sec=args.elapsed_sec,
+        sample_index=args.sample_index,
+    )
+    rendered = json.dumps(diagnostics, indent=2, sort_keys=True)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(rendered)
+            f.write("\n")
+    else:
+        print(rendered)
+    return 0 if diagnostics["settled"] else 1
+
 
 
 def cmd_check_collapse(args: argparse.Namespace) -> int:
@@ -137,7 +379,17 @@ def main() -> int:
     p1 = sub.add_parser("check-cwnd-settle")
     p1.add_argument("iperf3_txt")
     p1.add_argument("shaper_bps", type=int)
+    p1.add_argument("--window-rows", type=int, default=3)
     p1.set_defaults(func=cmd_check_cwnd_settle)
+
+    p1_diag = sub.add_parser("settle-diagnostics")
+    p1_diag.add_argument("iperf3_txt")
+    p1_diag.add_argument("shaper_bps", type=int)
+    p1_diag.add_argument("--window-rows", type=int, default=3)
+    p1_diag.add_argument("--elapsed-sec", type=int)
+    p1_diag.add_argument("--sample-index", type=int)
+    p1_diag.add_argument("--out")
+    p1_diag.set_defaults(func=cmd_settle_diagnostics)
 
     p2 = sub.add_parser("check-collapse")
     p2.add_argument("iperf3_txt")

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -42,6 +42,13 @@ _UNIT_MULTIPLIER = {
     "G": 1_000_000_000,
     "T": 1_000_000_000_000,
 }
+_BYTE_UNIT_MULTIPLIER = {
+    "": 1,
+    "K": 1024,
+    "M": 1024 * 1024,
+    "G": 1024 * 1024 * 1024,
+    "T": 1024 * 1024 * 1024 * 1024,
+}
 
 
 def _last_n_sum_bps(text: str, n: int) -> list:
@@ -79,7 +86,7 @@ def _parse_iperf_interval_rows(text: str) -> list[dict]:
             retransmits = int(m.group("retransmits"))
         cwnd_bytes = None
         if m.group("cwnd") is not None:
-            cwnd_multiplier = _UNIT_MULTIPLIER.get(m.group("cwnd_unit").upper())
+            cwnd_multiplier = _BYTE_UNIT_MULTIPLIER.get(m.group("cwnd_unit").upper())
             if cwnd_multiplier is not None:
                 try:
                     cwnd_bytes = int(float(m.group("cwnd")) * cwnd_multiplier)

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -5,6 +5,7 @@ import unittest
 
 import mouse_latency_orchestrate as orch
 
+# Fixture rows use 120 KBytes and 180 KBytes in iperf3 output.
 _EXPECTED_MIN_CWND_KBYTES = 120
 _EXPECTED_MAX_CWND_KBYTES = 180
 
@@ -103,8 +104,8 @@ class CwndSettleDiagnosticsTests(unittest.TestCase):
 """)
             out_path = os.path.join(t, "cwnd-settle.json")
 
-            class SettleDiagnosticsArgs: pass
-            args = SettleDiagnosticsArgs()
+            class MockSettleDiagnosticsArgs: pass
+            args = MockSettleDiagnosticsArgs()
             args.iperf3_txt = txt
             args.shaper_bps = 300_000_000
             args.window_rows = 3

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -94,16 +94,16 @@ class CwndSettleDiagnosticsTests(unittest.TestCase):
 """)
             out_path = os.path.join(t, "cwnd-settle.json")
 
-            class A: pass
-            a = A()
-            a.iperf3_txt = txt
-            a.shaper_bps = 300_000_000
-            a.window_rows = 3
-            a.elapsed_sec = 20
-            a.sample_index = 1
-            a.out = out_path
+            class SettleArgs: pass
+            args = SettleArgs()
+            args.iperf3_txt = txt
+            args.shaper_bps = 300_000_000
+            args.window_rows = 3
+            args.elapsed_sec = 20
+            args.sample_index = 1
+            args.out = out_path
 
-            self.assertEqual(orch.cmd_settle_diagnostics(a), 1)
+            self.assertEqual(orch.cmd_settle_diagnostics(args), 1)
             with open(out_path) as f:
                 payload = json.load(f)
             self.assertFalse(payload["settled"])

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -18,6 +18,7 @@ class CheckCwndSettleTests(unittest.TestCase):
         a = A()
         a.iperf3_txt = txt_path
         a.shaper_bps = shaper
+        a.window_rows = 3
         return a
 
     def test_settled(self):
@@ -51,6 +52,56 @@ class CheckCwndSettleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as t:
             txt = _write(t, "iperf3.txt", "Connecting to host 172.16.80.200, port 5201\n")
             self.assertEqual(orch.cmd_check_cwnd_settle(self._make_args(txt, 1_000_000_000)), 1)
+
+
+class CwndSettleDiagnosticsTests(unittest.TestCase):
+    def test_diagnostics_reports_aggregate_and_per_flow_window(self):
+        text = """\
+[  5]   0.00-1.00   sec  10.0 MBytes  80.0 Mbits/sec    1    100 KBytes
+[  7]   0.00-1.00   sec  20.0 MBytes  160.0 Mbits/sec   0    200 KBytes
+[SUM]   0.00-1.00   sec  30.0 MBytes  240.0 Mbits/sec
+[  5]   1.00-2.00   sec  11.0 MBytes  88.0 Mbits/sec    2    110 KBytes
+[  7]   1.00-2.00   sec  19.0 MBytes  152.0 Mbits/sec   0    190 KBytes
+[SUM]   1.00-2.00   sec  30.0 MBytes  240.0 Mbits/sec
+[  5]   2.00-3.00   sec  10.5 MBytes  84.0 Mbits/sec    3    120 KBytes
+[  7]   2.00-3.00   sec  19.5 MBytes  156.0 Mbits/sec   0    180 KBytes
+[SUM]   2.00-3.00   sec  30.0 MBytes  240.0 Mbits/sec
+"""
+        d = orch.build_cwnd_settle_diagnostics(
+            text,
+            300_000_000,
+            elapsed_sec=20,
+            sample_index=0,
+        )
+        self.assertTrue(d["settled"], d["reasons"])
+        self.assertEqual(d["elapsed_sec"], 20)
+        self.assertEqual(d["aggregate"]["window_bps"], [240_000_000] * 3)
+        self.assertEqual(d["per_flow"]["flow_count"], 2)
+        self.assertEqual(d["per_flow"]["retransmits_total"], 6)
+        self.assertEqual(d["per_flow"]["mean_bps"]["min"], 84_000_000)
+        self.assertEqual(d["per_flow"]["mean_bps"]["max"], 156_000_000)
+        self.assertEqual(d["per_flow"]["cwnd_bytes"]["min"], 120_000)
+        self.assertEqual(d["per_flow"]["cwnd_bytes"]["max"], 180_000)
+        self.assertEqual(d["per_flow"]["slowest_streams"][0]["stream_id"], 5)
+
+    def test_diagnostics_explains_failed_thresholds(self):
+        text = """\
+[SUM]   0.00-1.00   sec  10.0 MBytes  80.0 Mbits/sec
+[SUM]   1.00-2.00   sec  30.0 MBytes  240.0 Mbits/sec
+[SUM]   2.00-3.00   sec  10.0 MBytes  80.0 Mbits/sec
+"""
+        d = orch.build_cwnd_settle_diagnostics(text, 300_000_000)
+        self.assertFalse(d["settled"])
+        self.assertTrue(any("aggregate-window-spread" in r for r in d["reasons"]))
+        self.assertTrue(any("aggregate-too-low" in r for r in d["reasons"]))
+
+    def test_diagnostics_requires_enough_sum_rows(self):
+        d = orch.build_cwnd_settle_diagnostics(
+            "[SUM]   0.00-1.00   sec  10.0 MBytes  80.0 Mbits/sec\n",
+            300_000_000,
+        )
+        self.assertFalse(d["settled"])
+        self.assertIn("insufficient-sum-rows", d["reasons"][0])
 
 
 class CheckCollapseTests(unittest.TestCase):

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -80,9 +81,34 @@ class CwndSettleDiagnosticsTests(unittest.TestCase):
         self.assertEqual(d["per_flow"]["retransmits_total"], 6)
         self.assertEqual(d["per_flow"]["mean_bps"]["min"], 84_000_000)
         self.assertEqual(d["per_flow"]["mean_bps"]["max"], 156_000_000)
-        self.assertEqual(d["per_flow"]["cwnd_bytes"]["min"], 120_000)
-        self.assertEqual(d["per_flow"]["cwnd_bytes"]["max"], 180_000)
+        self.assertEqual(d["per_flow"]["cwnd_bytes"]["min"], 120 * 1024)
+        self.assertEqual(d["per_flow"]["cwnd_bytes"]["max"], 180 * 1024)
         self.assertEqual(d["per_flow"]["slowest_streams"][0]["stream_id"], 5)
+
+    def test_settle_diagnostics_writes_json_and_returns_status(self):
+        with tempfile.TemporaryDirectory() as t:
+            txt = _write(t, "iperf3.txt", """\
+[SUM]   0.00-1.00   sec  10.0 MBytes  80.0 Mbits/sec
+[SUM]   1.00-2.00   sec  30.0 MBytes  240.0 Mbits/sec
+[SUM]   2.00-3.00   sec  10.0 MBytes  80.0 Mbits/sec
+""")
+            out_path = os.path.join(t, "cwnd-settle.json")
+
+            class A: pass
+            a = A()
+            a.iperf3_txt = txt
+            a.shaper_bps = 300_000_000
+            a.window_rows = 3
+            a.elapsed_sec = 20
+            a.sample_index = 1
+            a.out = out_path
+
+            self.assertEqual(orch.cmd_settle_diagnostics(a), 1)
+            with open(out_path) as f:
+                payload = json.load(f)
+            self.assertFalse(payload["settled"])
+            self.assertEqual(payload["elapsed_sec"], 20)
+            self.assertEqual(payload["sample_index"], 1)
 
     def test_diagnostics_explains_failed_thresholds(self):
         text = """\

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -5,6 +5,9 @@ import unittest
 
 import mouse_latency_orchestrate as orch
 
+_EXPECTED_MIN_CWND_KBYTES = 120
+_EXPECTED_MAX_CWND_KBYTES = 180
+
 
 def _write(tmpdir: str, name: str, content: str) -> str:
     path = os.path.join(tmpdir, name)
@@ -81,8 +84,14 @@ class CwndSettleDiagnosticsTests(unittest.TestCase):
         self.assertEqual(d["per_flow"]["retransmits_total"], 6)
         self.assertEqual(d["per_flow"]["mean_bps"]["min"], 84_000_000)
         self.assertEqual(d["per_flow"]["mean_bps"]["max"], 156_000_000)
-        self.assertEqual(d["per_flow"]["cwnd_bytes"]["min"], 120 * 1024)
-        self.assertEqual(d["per_flow"]["cwnd_bytes"]["max"], 180 * 1024)
+        self.assertEqual(
+            d["per_flow"]["cwnd_bytes"]["min"],
+            _EXPECTED_MIN_CWND_KBYTES * 1024,
+        )
+        self.assertEqual(
+            d["per_flow"]["cwnd_bytes"]["max"],
+            _EXPECTED_MAX_CWND_KBYTES * 1024,
+        )
         self.assertEqual(d["per_flow"]["slowest_streams"][0]["stream_id"], 5)
 
     def test_settle_diagnostics_writes_json_and_returns_status(self):
@@ -94,8 +103,8 @@ class CwndSettleDiagnosticsTests(unittest.TestCase):
 """)
             out_path = os.path.join(t, "cwnd-settle.json")
 
-            class SettleArgs: pass
-            args = SettleArgs()
+            class SettleDiagnosticsArgs: pass
+            args = SettleDiagnosticsArgs()
             args.iperf3_txt = txt
             args.shaper_bps = 300_000_000
             args.window_rows = 3

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -163,27 +163,33 @@ async def _run_per_attempt_probe_coro(
         last_attempt_started_ns = t0
         try:
             connect_started_ns = time.monotonic_ns()
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_connection(target, port),
-                timeout=min(5.0, remaining),
-            )
-            _record_phase_us(phase_samples, "connect_us", connect_started_ns)
+            try:
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_connection(target, port),
+                    timeout=min(5.0, remaining),
+                )
+            finally:
+                _record_phase_us(phase_samples, "connect_us", connect_started_ns)
             abort_close = True
             try:
                 writer.write(payload)
                 drain_started_ns = time.monotonic_ns()
-                await _drain_with_deadline(writer, deadline)
-                _record_phase_us(phase_samples, "drain_us", drain_started_ns)
+                try:
+                    await _drain_with_deadline(writer, deadline)
+                finally:
+                    _record_phase_us(phase_samples, "drain_us", drain_started_ns)
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     error_counter[0] += 1
                     break
                 read_started_ns = time.monotonic_ns()
-                data = await asyncio.wait_for(
-                    reader.readexactly(payload_bytes),
-                    timeout=min(5.0, remaining),
-                )
-                _record_phase_us(phase_samples, "read_us", read_started_ns)
+                try:
+                    data = await asyncio.wait_for(
+                        reader.readexactly(payload_bytes),
+                        timeout=min(5.0, remaining),
+                    )
+                finally:
+                    _record_phase_us(phase_samples, "read_us", read_started_ns)
                 if data != payload:
                     error_counter[0] += 1
                     await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
@@ -240,11 +246,13 @@ async def _run_persistent_probe_coro(
             if writer is None or writer.is_closing():
                 try:
                     connect_started_ns = time.monotonic_ns()
-                    reader, writer = await asyncio.wait_for(
-                        asyncio.open_connection(target, port),
-                        timeout=min(5.0, remaining),
-                    )
-                    _record_phase_us(phase_samples, "connect_us", connect_started_ns)
+                    try:
+                        reader, writer = await asyncio.wait_for(
+                            asyncio.open_connection(target, port),
+                            timeout=min(5.0, remaining),
+                        )
+                    finally:
+                        _record_phase_us(phase_samples, "connect_us", connect_started_ns)
                 except (
                     asyncio.TimeoutError,
                     ConnectionRefusedError,
@@ -274,8 +282,10 @@ async def _run_persistent_probe_coro(
             try:
                 writer.write(payload)
                 drain_started_ns = time.monotonic_ns()
-                await _drain_with_deadline(writer, deadline)
-                _record_phase_us(phase_samples, "drain_us", drain_started_ns)
+                try:
+                    await _drain_with_deadline(writer, deadline)
+                finally:
+                    _record_phase_us(phase_samples, "drain_us", drain_started_ns)
             except (
                 asyncio.TimeoutError,
                 ConnectionRefusedError,
@@ -305,11 +315,13 @@ async def _run_persistent_probe_coro(
             try:
                 assert reader is not None
                 read_started_ns = time.monotonic_ns()
-                data = await asyncio.wait_for(
-                    reader.readexactly(payload_bytes),
-                    timeout=min(5.0, remaining),
-                )
-                _record_phase_us(phase_samples, "read_us", read_started_ns)
+                try:
+                    data = await asyncio.wait_for(
+                        reader.readexactly(payload_bytes),
+                        timeout=min(5.0, remaining),
+                    )
+                finally:
+                    _record_phase_us(phase_samples, "read_us", read_started_ns)
                 if data != payload:
                     error_counter[0] += 1
                     await _close_writer(writer, deadline, abort=True)

--- a/test/incus/mouse_latency_probe.py
+++ b/test/incus/mouse_latency_probe.py
@@ -48,6 +48,34 @@ def _abort_writer(writer: asyncio.StreamWriter) -> None:
         transport.abort()
 
 
+def _phase_bucket(phase_samples: Optional[dict], name: str) -> Optional[List[int]]:
+    if phase_samples is None:
+        return None
+    return phase_samples.setdefault(name, [])
+
+
+def _record_phase_us(
+    phase_samples: Optional[dict],
+    name: str,
+    started_ns: int,
+) -> None:
+    bucket = _phase_bucket(phase_samples, name)
+    if bucket is not None:
+        bucket.append((time.monotonic_ns() - started_ns) // 1000)
+
+
+def _record_start_gap_us(
+    phase_samples: Optional[dict],
+    previous_started_ns: Optional[int],
+    started_ns: int,
+) -> None:
+    if previous_started_ns is None:
+        return
+    bucket = _phase_bucket(phase_samples, "start_gap_us")
+    if bucket is not None:
+        bucket.append((started_ns - previous_started_ns) // 1000)
+
+
 async def _close_writer(
     writer: Optional[asyncio.StreamWriter],
     deadline: float,
@@ -76,6 +104,7 @@ async def _respect_min_interval(
     attempt_started_ns: int,
     min_interval_ms: float,
     deadline: float,
+    sleep_overshoot_us: Optional[List[int]] = None,
 ) -> None:
     if min_interval_ms <= 0:
         return
@@ -83,7 +112,12 @@ async def _respect_min_interval(
     sleep_s = (min_interval_ms / 1000.0) - elapsed_s
     remaining_s = deadline - time.monotonic()
     if sleep_s > 0 and remaining_s > 0:
-        await asyncio.sleep(min(sleep_s, remaining_s))
+        requested_s = min(sleep_s, remaining_s)
+        sleep_started_ns = time.monotonic_ns()
+        await asyncio.sleep(requested_s)
+        actual_s = (time.monotonic_ns() - sleep_started_ns) / 1_000_000_000
+        if sleep_overshoot_us is not None:
+            sleep_overshoot_us.append(max(0, int((actual_s - requested_s) * 1_000_000)))
 
 
 async def _drain_with_deadline(writer: asyncio.StreamWriter, deadline: float) -> None:
@@ -102,6 +136,7 @@ async def _run_per_attempt_probe_coro(
     rtts_us: List[int],
     attempt_counter: List[int],
     error_counter: List[int],
+    phase_samples: Optional[dict] = None,
 ) -> None:
     """One coroutine: closed-loop probe loop until deadline.
 
@@ -116,32 +151,42 @@ async def _run_per_attempt_probe_coro(
     above deadline.
     """
     payload = os.urandom(payload_bytes)
+    last_attempt_started_ns: Optional[int] = None
+    sleep_overshoot = _phase_bucket(phase_samples, "sleep_overshoot_us")
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
         attempt_counter[0] += 1
         t0 = time.monotonic_ns()
+        _record_start_gap_us(phase_samples, last_attempt_started_ns, t0)
+        last_attempt_started_ns = t0
         try:
+            connect_started_ns = time.monotonic_ns()
             reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(target, port),
                 timeout=min(5.0, remaining),
             )
+            _record_phase_us(phase_samples, "connect_us", connect_started_ns)
             abort_close = True
             try:
                 writer.write(payload)
+                drain_started_ns = time.monotonic_ns()
                 await _drain_with_deadline(writer, deadline)
+                _record_phase_us(phase_samples, "drain_us", drain_started_ns)
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     error_counter[0] += 1
                     break
+                read_started_ns = time.monotonic_ns()
                 data = await asyncio.wait_for(
                     reader.readexactly(payload_bytes),
                     timeout=min(5.0, remaining),
                 )
+                _record_phase_us(phase_samples, "read_us", read_started_ns)
                 if data != payload:
                     error_counter[0] += 1
-                    await _respect_min_interval(t0, min_interval_ms, deadline)
+                    await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                     continue
                 abort_close = False
             finally:
@@ -155,11 +200,11 @@ async def _run_per_attempt_probe_coro(
             OSError,
         ):
             error_counter[0] += 1
-            await _respect_min_interval(t0, min_interval_ms, deadline)
+            await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
             continue
         t1 = time.monotonic_ns()
         rtts_us.append((t1 - t0) // 1000)
-        await _respect_min_interval(t0, min_interval_ms, deadline)
+        await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
 
 
 async def _run_persistent_probe_coro(
@@ -171,6 +216,7 @@ async def _run_persistent_probe_coro(
     rtts_us: List[int],
     attempt_counter: List[int],
     error_counter: List[int],
+    phase_samples: Optional[dict] = None,
 ) -> None:
     """One coroutine using one long-lived echo connection.
 
@@ -181,6 +227,8 @@ async def _run_persistent_probe_coro(
     payload = os.urandom(payload_bytes)
     reader: Optional[asyncio.StreamReader] = None
     writer: Optional[asyncio.StreamWriter] = None
+    last_attempt_started_ns: Optional[int] = None
+    sleep_overshoot = _phase_bucket(phase_samples, "sleep_overshoot_us")
 
     try:
         while True:
@@ -191,10 +239,12 @@ async def _run_persistent_probe_coro(
             t0 = time.monotonic_ns()
             if writer is None or writer.is_closing():
                 try:
+                    connect_started_ns = time.monotonic_ns()
                     reader, writer = await asyncio.wait_for(
                         asyncio.open_connection(target, port),
                         timeout=min(5.0, remaining),
                     )
+                    _record_phase_us(phase_samples, "connect_us", connect_started_ns)
                 except (
                     asyncio.TimeoutError,
                     ConnectionRefusedError,
@@ -202,11 +252,13 @@ async def _run_persistent_probe_coro(
                     BrokenPipeError,
                     OSError,
                 ):
+                    _record_start_gap_us(phase_samples, last_attempt_started_ns, t0)
+                    last_attempt_started_ns = t0
                     attempt_counter[0] += 1
                     error_counter[0] += 1
                     reader = None
                     writer = None
-                    await _respect_min_interval(t0, min_interval_ms, deadline)
+                    await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                     continue
                 # Connection setup is not a latency sample in persistent
                 # mode; it is only a prerequisite for later echo samples.
@@ -217,9 +269,13 @@ async def _run_persistent_probe_coro(
                 break
 
             t0 = time.monotonic_ns()
+            _record_start_gap_us(phase_samples, last_attempt_started_ns, t0)
+            last_attempt_started_ns = t0
             try:
                 writer.write(payload)
+                drain_started_ns = time.monotonic_ns()
                 await _drain_with_deadline(writer, deadline)
+                _record_phase_us(phase_samples, "drain_us", drain_started_ns)
             except (
                 asyncio.TimeoutError,
                 ConnectionRefusedError,
@@ -232,7 +288,7 @@ async def _run_persistent_probe_coro(
                 await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
-                await _respect_min_interval(t0, min_interval_ms, deadline)
+                await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                 continue
 
             remaining = deadline - time.monotonic()
@@ -242,22 +298,24 @@ async def _run_persistent_probe_coro(
                 await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
-                await _respect_min_interval(t0, min_interval_ms, deadline)
+                await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                 break
 
             attempt_counter[0] += 1
             try:
                 assert reader is not None
+                read_started_ns = time.monotonic_ns()
                 data = await asyncio.wait_for(
                     reader.readexactly(payload_bytes),
                     timeout=min(5.0, remaining),
                 )
+                _record_phase_us(phase_samples, "read_us", read_started_ns)
                 if data != payload:
                     error_counter[0] += 1
                     await _close_writer(writer, deadline, abort=True)
                     reader = None
                     writer = None
-                    await _respect_min_interval(t0, min_interval_ms, deadline)
+                    await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                     continue
             except (
                 asyncio.TimeoutError,
@@ -271,11 +329,11 @@ async def _run_persistent_probe_coro(
                 await _close_writer(writer, deadline, abort=True)
                 reader = None
                 writer = None
-                await _respect_min_interval(t0, min_interval_ms, deadline)
+                await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
                 continue
             t1 = time.monotonic_ns()
             rtts_us.append((t1 - t0) // 1000)
-            await _respect_min_interval(t0, min_interval_ms, deadline)
+            await _respect_min_interval(t0, min_interval_ms, deadline, sleep_overshoot)
     finally:
         await _close_writer(writer, deadline)
 
@@ -331,6 +389,23 @@ def _compute_percentiles(rtts_us: List[int]) -> dict:
     }
 
 
+def _compute_phase_percentiles(values_us: List[int]) -> dict:
+    p = _compute_percentiles(values_us)
+    return {
+        "count": len(values_us),
+        "p50": p["p50"],
+        "p95": p["p95"],
+        "p99": p["p99"],
+        "p999": p["p999"],
+        "max": p["max"],
+        "mean": p["mean"],
+    }
+
+
+def _max_or_none(values: List[int]) -> Optional[int]:
+    return max(values) if values else None
+
+
 def compute_validity(
     concurrency: int,
     attempts_per_coroutine: List[int],
@@ -372,6 +447,16 @@ async def _run(args: argparse.Namespace) -> dict:
     rtts_per_coro: List[List[int]] = [[] for _ in range(args.concurrency)]
     attempts_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
     errors_per_coro: List[List[int]] = [[0] for _ in range(args.concurrency)]
+    phase_per_coro = [
+        {
+            "connect_us": [],
+            "drain_us": [],
+            "read_us": [],
+            "start_gap_us": [],
+            "sleep_overshoot_us": [],
+        }
+        for _ in range(args.concurrency)
+    ]
     deadline = time.monotonic() + args.duration
     probe_coro = (
         _run_persistent_probe_coro
@@ -382,6 +467,7 @@ async def _run(args: argparse.Namespace) -> dict:
         probe_coro(
             args.target, args.port, args.payload_bytes, args.min_interval_ms, deadline,
             rtts_per_coro[i], attempts_per_coro[i], errors_per_coro[i],
+            phase_per_coro[i],
         )
         for i in range(args.concurrency)
     ]
@@ -418,6 +504,37 @@ async def _run(args: argparse.Namespace) -> dict:
         per_coro_iqr = 0.0
         per_coro_median = 0.0
 
+    phase_names = [
+        "connect_us",
+        "drain_us",
+        "read_us",
+        "start_gap_us",
+        "sleep_overshoot_us",
+    ]
+    phase_samples = {
+        name: [
+            value
+            for coro_phases in phase_per_coro
+            for value in coro_phases.get(name, [])
+        ]
+        for name in phase_names
+    }
+    coroutine_diagnostics = []
+    for i in range(args.concurrency):
+        phases = phase_per_coro[i]
+        coroutine_diagnostics.append({
+            "id": i,
+            "attempted": attempts[i],
+            "completed": len(rtts_per_coro[i]),
+            "errors": errors_per_coro[i][0],
+            "max_rtt_us": _max_or_none(rtts_per_coro[i]),
+            "max_connect_us": _max_or_none(phases["connect_us"]),
+            "max_drain_us": _max_or_none(phases["drain_us"]),
+            "max_read_us": _max_or_none(phases["read_us"]),
+            "max_start_gap_us": _max_or_none(phases["start_gap_us"]),
+            "max_sleep_overshoot_us": _max_or_none(phases["sleep_overshoot_us"]),
+        })
+
     return {
         "config": {
             "target": args.target, "port": args.port,
@@ -437,6 +554,11 @@ async def _run(args: argparse.Namespace) -> dict:
             "attempts_per_second_per_coroutine_median": per_coro_median,
             "attempts_per_second_per_coroutine_iqr": per_coro_iqr,
         },
+        "phase_us": {
+            name: _compute_phase_percentiles(values)
+            for name, values in phase_samples.items()
+        },
+        "coroutines": coroutine_diagnostics,
         "rtt_us": _compute_percentiles(rtts_us),
         "histogram_us": {
             "buckets": HISTOGRAM_BUCKETS_US,

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -297,6 +297,10 @@ class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertLessEqual(result["totals"]["error_rate"], 0.05)
         self.assertLessEqual(connection_count, 3)
+        self.assertEqual(len(result["coroutines"]), 3)
+        self.assertGreater(result["phase_us"]["read_us"]["count"], 0)
+        self.assertGreater(result["phase_us"]["drain_us"]["count"], 0)
+        self.assertIn("max_start_gap_us", result["coroutines"][0])
 
     async def test_min_interval_bounds_persistent_attempt_rate(self):
         result, connection_count = await self._run_local_echo_probe(
@@ -308,6 +312,8 @@ class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
         self.assertGreaterEqual(result["totals"]["completed"], 3)
         self.assertLessEqual(result["totals"]["attempted"], 8)
         self.assertLessEqual(connection_count, 1)
+        self.assertGreater(result["phase_us"]["sleep_overshoot_us"]["count"], 0)
+        self.assertGreaterEqual(result["phase_us"]["start_gap_us"]["max"], 15_000)
 
     async def test_min_interval_bounds_per_attempt_rate(self):
         result, connection_count = await self._run_local_echo_probe(

--- a/test/incus/mouse_latency_probe_test.py
+++ b/test/incus/mouse_latency_probe_test.py
@@ -377,6 +377,7 @@ class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
             result["totals"]["attempted"],
             result["totals"]["errors"],
         )
+        self.assertGreater(result["phase_us"]["drain_us"]["count"], 0)
 
     async def test_persistent_drain_timeout_counts_error_and_terminates(self):
         result = await self._run_with_forced_drain_timeout(
@@ -388,6 +389,7 @@ class PersistentConnectionModeTests(unittest.IsolatedAsyncioTestCase):
             result["totals"]["attempted"],
             result["totals"]["errors"],
         )
+        self.assertGreater(result["phase_us"]["drain_us"]["count"], 0)
 
 
 if __name__ == "__main__":

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -366,8 +366,9 @@ if [[ "$N" -gt 0 ]]; then
     if [[ $settle_diag_rc -ne 0 ]]; then
         CWND_SETTLE_OK="false"
         invalidate "cwnd-not-settled"
+    else
+        CWND_SETTLE_OK="true"
     fi
-    CWND_SETTLE_OK="true"
 fi
 
 # ---- step 2 (deferred to here): start mpstat over the probe window only.

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -349,7 +349,6 @@ if [[ "$N" -gt 0 ]]; then
     # Distinguish pull failure from a real cwnd-not-settled (Copilot R2 #1):
     # the cwnd-settle gate fires only when we actually have iperf3 output.
     if [[ $pull_rc -ne 0 || ! -s "${OUT_DIR}/iperf3-settle.txt" ]]; then
-        CWND_SETTLE_OK="false"
         invalidate "iperf3-settle-pull-failed"
     fi
     set +e

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -74,7 +74,7 @@ esac
 [[ "$MOUSE_PROBE_MIN_INTERVAL_MS" =~ ^[0-9]+([.][0-9]+)?$ ]] \
     || { echo "ABORT: MOUSE_PROBE_MIN_INTERVAL_MS='$MOUSE_PROBE_MIN_INTERVAL_MS' must be a non-negative number" >&2; exit 1; }
 SLACK=10
-CWND_SETTLE_OK="true"
+CWND_SETTLE_OK="unknown"
 CWND_SETTLE_ELAPSED=0
 
 mkdir -p "$OUT_DIR"
@@ -349,6 +349,7 @@ if [[ "$N" -gt 0 ]]; then
     # Distinguish pull failure from a real cwnd-not-settled (Copilot R2 #1):
     # the cwnd-settle gate fires only when we actually have iperf3 output.
     if [[ $pull_rc -ne 0 || ! -s "${OUT_DIR}/iperf3-settle.txt" ]]; then
+        CWND_SETTLE_OK="false"
         invalidate "iperf3-settle-pull-failed"
     fi
     set +e
@@ -366,6 +367,7 @@ if [[ "$N" -gt 0 ]]; then
         CWND_SETTLE_OK="false"
         invalidate "cwnd-not-settled"
     fi
+    CWND_SETTLE_OK="true"
 fi
 
 # ---- step 2 (deferred to here): start mpstat over the probe window only.
@@ -575,6 +577,13 @@ SHAPER_BPS="$SHAPER_BPS" SETTLE_BUDGET="$SETTLE_BUDGET" \
 CWND_SETTLE_OK="$CWND_SETTLE_OK" CWND_SETTLE_ELAPSED="$CWND_SETTLE_ELAPSED" \
 python3 -c '
 import json, os
+settle_raw = os.environ["CWND_SETTLE_OK"]
+if settle_raw == "true":
+    settle_ok = True
+elif settle_raw == "false":
+    settle_ok = False
+else:
+    settle_ok = None
 manifest = {
     "N": int(os.environ["N"]),
     "M": int(os.environ["M"]),
@@ -591,7 +600,7 @@ manifest = {
     "mouse_probe_min_interval_ms": float(os.environ["MOUSE_PROBE_MIN_INTERVAL_MS"]),
     "shaper_bps": int(os.environ["SHAPER_BPS"]),
     "settle_budget_s": int(os.environ["SETTLE_BUDGET"]),
-    "cwnd_settle_ok": os.environ["CWND_SETTLE_OK"] == "true",
+    "cwnd_settle_ok": settle_ok,
     "cwnd_settle_elapsed_s": int(os.environ["CWND_SETTLE_ELAPSED"]),
 }
 print(json.dumps(manifest, indent=2))

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -43,6 +43,7 @@ MOUSE_COS_SURPLUS_SHARING="${MOUSE_COS_SURPLUS_SHARING:-0}"
 MOUSE_PROBE_CONNECTION_MODE="${MOUSE_PROBE_CONNECTION_MODE:-per-attempt}"
 MOUSE_PROBE_MIN_INTERVAL_MS="${MOUSE_PROBE_MIN_INTERVAL_MS:-0}"
 SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (port 5202); same-class wrappers must override with their selected class cap.
+SETTLE_BUDGET="${MOUSE_LATENCY_SETTLE_BUDGET:-20}"
 # Validate env-overrides (Copilot D.5): ports/bps must be
 # digits only so they can't smuggle shell metacharacters into
 # the remote `bash -c` interpolations below. MOUSE_CLASS and
@@ -55,6 +56,8 @@ SHAPER_BPS="${SHAPER_BPS:-$((1 * 1000 * 1000 * 1000))}"  # default 1 Gb/s (port 
     || { echo "ABORT: MOUSE_PORT='$MOUSE_PORT' must be digits" >&2; exit 1; }
 [[ "$SHAPER_BPS" =~ ^[0-9]+$ ]] \
     || { echo "ABORT: SHAPER_BPS='$SHAPER_BPS' must be digits" >&2; exit 1; }
+[[ "$SETTLE_BUDGET" =~ ^[0-9]+$ && "$SETTLE_BUDGET" -gt 0 ]] \
+    || { echo "ABORT: MOUSE_LATENCY_SETTLE_BUDGET='$SETTLE_BUDGET' must be a positive integer second count" >&2; exit 1; }
 case "$MOUSE_CLASS" in
     best-effort|iperf-100m|iperf-1g|iperf-3g|iperf-6g|iperf-9g|iperf-12g|iperf-15g|iperf-18g|iperf-21g|iperf-24g|iperf-uncapped) ;;
     *) echo "ABORT: MOUSE_CLASS='$MOUSE_CLASS' must be one of best-effort/iperf-100m/iperf-1g/iperf-3g/iperf-6g/iperf-9g/iperf-12g/iperf-15g/iperf-18g/iperf-21g/iperf-24g/iperf-uncapped" >&2; exit 1 ;;
@@ -70,8 +73,9 @@ case "$MOUSE_PROBE_CONNECTION_MODE" in
 esac
 [[ "$MOUSE_PROBE_MIN_INTERVAL_MS" =~ ^[0-9]+([.][0-9]+)?$ ]] \
     || { echo "ABORT: MOUSE_PROBE_MIN_INTERVAL_MS='$MOUSE_PROBE_MIN_INTERVAL_MS' must be a non-negative number" >&2; exit 1; }
-SETTLE_BUDGET=20
 SLACK=10
+CWND_SETTLE_OK="true"
+CWND_SETTLE_ELAPSED=0
 
 mkdir -p "$OUT_DIR"
 # Include the cell name in REP_TAG so per-rep temp files on the
@@ -93,7 +97,12 @@ rm -f "${OUT_DIR}"/probe.json \
       "${OUT_DIR}"/probe-stdout.log \
       "${OUT_DIR}"/iperf3.txt \
       "${OUT_DIR}"/iperf3-settle.txt \
+      "${OUT_DIR}"/cwnd-settle.json \
+      "${OUT_DIR}"/mpstat-settle.txt \
       "${OUT_DIR}"/mpstat.txt \
+      "${OUT_DIR}"/cos-interface-pre.txt \
+      "${OUT_DIR}"/cos-interface-settle.txt \
+      "${OUT_DIR}"/cos-interface-post.txt \
       "${OUT_DIR}"/screen-pre.txt \
       "${OUT_DIR}"/screen-pre-fw.txt \
       "${OUT_DIR}"/screen-post.txt \
@@ -156,9 +165,54 @@ for rg, n, st in parse_cluster_status(sys.stdin.read()):
     echo "$node"
 }
 
+write_invalid_manifest() {
+    local reason="$1"
+    local started_at
+    started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    INVALID_REASON="$reason" STARTED_AT="$started_at" \
+    N="$N" M="$M" DURATION="$DURATION" \
+    ELEPHANT_PORT="$ELEPHANT_PORT" MOUSE_PORT="$MOUSE_PORT" \
+    MOUSE_CLASS="$MOUSE_CLASS" MOUSE_COS_SURPLUS_SHARING="$MOUSE_COS_SURPLUS_SHARING" \
+    MOUSE_PROBE_CONNECTION_MODE="$MOUSE_PROBE_CONNECTION_MODE" \
+    MOUSE_PROBE_MIN_INTERVAL_MS="$MOUSE_PROBE_MIN_INTERVAL_MS" \
+    SHAPER_BPS="$SHAPER_BPS" SETTLE_BUDGET="$SETTLE_BUDGET" \
+    CWND_SETTLE_OK="${CWND_SETTLE_OK:-unknown}" \
+    CWND_SETTLE_ELAPSED="${CWND_SETTLE_ELAPSED:-0}" \
+    python3 -c '
+import json, os
+settle_raw = os.environ["CWND_SETTLE_OK"]
+if settle_raw == "true":
+    settle_ok = True
+elif settle_raw == "false":
+    settle_ok = False
+else:
+    settle_ok = None
+manifest = {
+    "N": int(os.environ["N"]),
+    "M": int(os.environ["M"]),
+    "duration_s": int(os.environ["DURATION"]),
+    "started_at": os.environ["STARTED_AT"],
+    "status": "INVALID",
+    "invalid_reason": os.environ["INVALID_REASON"],
+    "elephant_port": int(os.environ["ELEPHANT_PORT"]),
+    "mouse_port": int(os.environ["MOUSE_PORT"]),
+    "mouse_class": os.environ["MOUSE_CLASS"],
+    "cos_surplus_sharing": os.environ["MOUSE_COS_SURPLUS_SHARING"] == "1",
+    "mouse_probe_connection_mode": os.environ["MOUSE_PROBE_CONNECTION_MODE"],
+    "mouse_probe_min_interval_ms": float(os.environ["MOUSE_PROBE_MIN_INTERVAL_MS"]),
+    "shaper_bps": int(os.environ["SHAPER_BPS"]),
+    "settle_budget_s": int(os.environ["SETTLE_BUDGET"]),
+    "cwnd_settle_ok": settle_ok,
+    "cwnd_settle_elapsed_s": int(os.environ["CWND_SETTLE_ELAPSED"]),
+}
+print(json.dumps(manifest, indent=2))
+' > "${OUT_DIR}/manifest.json" || true
+}
+
 invalidate() {
     local reason="$1"
     : > "${OUT_DIR}/INVALID-${reason}"
+    write_invalid_manifest "$reason"
     echo "REP INVALID: $reason" >&2
     exit 0
 }
@@ -169,6 +223,7 @@ cleanup() {
     # cwnd-settle gate or step 4 cursor capture) it isn't running yet.
     [[ -n "${IPERF_PID:-}" ]] && kill "$IPERF_PID" 2>/dev/null || true
     [[ -n "${RG_POLL_PID:-}" ]] && kill "$RG_POLL_PID" 2>/dev/null || true
+    [[ -n "${SETTLE_MPSTAT_PID:-}" ]] && kill "$SETTLE_MPSTAT_PID" 2>/dev/null || true
     [[ -n "${MPSTAT_PID:-}" ]] && kill "$MPSTAT_PID" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -180,7 +235,7 @@ trap cleanup EXIT
 # previously left a stale file behind that the next reuse with the
 # same tag would inherit. Belt-and-suspenders.)
 incus_exec "$SOURCE" sh -c \
-    "rm -f /tmp/mouse_latency_probe.py /tmp/probe-${REP_TAG}.json /tmp/mpstat-${REP_TAG}.txt /tmp/iperf3-${REP_TAG}.txt" \
+    "rm -f /tmp/mouse_latency_probe.py /tmp/probe-${REP_TAG}.json /tmp/mpstat-${REP_TAG}.txt /tmp/mpstat-settle-${REP_TAG}.txt /tmp/iperf3-${REP_TAG}.txt" \
     < /dev/null > /dev/null 2>&1 || true
 
 # Push helper scripts to the source container (probe driver runs there).
@@ -213,6 +268,8 @@ fi
 "${SCRIPT_DIR}/apply-cos-config.sh" "${APPLY_COS_FLAGS[@]}" \
     "${INCUS_REMOTE}:${PRE_PRIMARY}" \
     > "${OUT_DIR}/cos-apply.log" 2>&1
+incus_exec "$PRE_PRIMARY" cli -c "show class-of-service interface" \
+    > "${OUT_DIR}/cos-interface-pre.txt" 2>/dev/null || true
 
 # ---- step 3: RG state polling at 1 Hz (plan §4.5 step 3)
 RG_POLL_FILE="${OUT_DIR}/rg-state-poll.txt"
@@ -266,24 +323,47 @@ if [[ "$N" -gt 0 ]]; then
         "iperf3 -c ${TARGET_V4} -p ${ELEPHANT_PORT} -P ${N} -t ${IPERF_DURATION} -i 1 --forceflush > /tmp/iperf3-${REP_TAG}.txt 2>&1" \
         < /dev/null > /dev/null 2>&1 &
     IPERF_PID=$!
+    incus_exec "$SOURCE" sh -c \
+        "mpstat 1 ${SETTLE_BUDGET} > /tmp/mpstat-settle-${REP_TAG}.txt 2>&1" \
+        < /dev/null > /dev/null 2>&1 &
+    SETTLE_MPSTAT_PID=$!
 
     # Wait the SETTLE_BUDGET, then snapshot iperf3.txt and run the
     # cwnd-settle gate. (Live tailing inside incus exec is hard to
-    # plumb reliably; the budget is the gate.)
+    # plumb reliably; the budget is the gate.) The diagnostics artifact
+    # records the final aggregate window and per-flow TCP spread so a
+    # high-rate failure is attributable instead of just INVALID.
     sleep "$SETTLE_BUDGET"
+    CWND_SETTLE_ELAPSED="$SETTLE_BUDGET"
     set +e
     incus_run file pull \
         "${INCUS_REMOTE}:${SOURCE}/tmp/iperf3-${REP_TAG}.txt" \
         "${OUT_DIR}/iperf3-settle.txt" 2>/dev/null
     pull_rc=$?
+    wait "$SETTLE_MPSTAT_PID" 2>/dev/null
+    incus_run file pull \
+        "${INCUS_REMOTE}:${SOURCE}/tmp/mpstat-settle-${REP_TAG}.txt" \
+        "${OUT_DIR}/mpstat-settle.txt" 2>/dev/null
     set -e
+    SETTLE_MPSTAT_PID=""
     # Distinguish pull failure from a real cwnd-not-settled (Copilot R2 #1):
     # the cwnd-settle gate fires only when we actually have iperf3 output.
     if [[ $pull_rc -ne 0 || ! -s "${OUT_DIR}/iperf3-settle.txt" ]]; then
         invalidate "iperf3-settle-pull-failed"
     fi
-    if ! python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
-            check-cwnd-settle "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS"; then
+    set +e
+    python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+        settle-diagnostics "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS" \
+        --elapsed-sec "$CWND_SETTLE_ELAPSED" \
+        --sample-index 0 \
+        --out "${OUT_DIR}/cwnd-settle.json"
+    settle_diag_rc=$?
+    set -e
+    SETTLE_PRIMARY=$(current_primary)
+    incus_exec "$SETTLE_PRIMARY" cli -c "show class-of-service interface" \
+        > "${OUT_DIR}/cos-interface-settle.txt" 2>/dev/null || true
+    if [[ $settle_diag_rc -ne 0 ]]; then
+        CWND_SETTLE_OK="false"
         invalidate "cwnd-not-settled"
     fi
 fi
@@ -428,6 +508,8 @@ done
 post_primary=$(current_primary)
 incus_exec "$post_primary" cli -c "show security screen statistics zone wan" \
     > "${OUT_DIR}/screen-post.txt" 2>/dev/null || true
+incus_exec "$post_primary" cli -c "show class-of-service interface" \
+    > "${OUT_DIR}/cos-interface-post.txt" 2>/dev/null || true
 screen_engaged="false"
 if ! diff -q "${OUT_DIR}/screen-pre.txt" "${OUT_DIR}/screen-post.txt" \
         > /dev/null 2>&1; then
@@ -489,7 +571,8 @@ ELEPHANT_PORT="$ELEPHANT_PORT" MOUSE_PORT="$MOUSE_PORT" \
 MOUSE_CLASS="$MOUSE_CLASS" MOUSE_COS_SURPLUS_SHARING="$MOUSE_COS_SURPLUS_SHARING" \
 MOUSE_PROBE_CONNECTION_MODE="$MOUSE_PROBE_CONNECTION_MODE" \
 MOUSE_PROBE_MIN_INTERVAL_MS="$MOUSE_PROBE_MIN_INTERVAL_MS" \
-SHAPER_BPS="$SHAPER_BPS" \
+SHAPER_BPS="$SHAPER_BPS" SETTLE_BUDGET="$SETTLE_BUDGET" \
+CWND_SETTLE_OK="$CWND_SETTLE_OK" CWND_SETTLE_ELAPSED="$CWND_SETTLE_ELAPSED" \
 python3 -c '
 import json, os
 manifest = {
@@ -507,6 +590,9 @@ manifest = {
     "mouse_probe_connection_mode": os.environ["MOUSE_PROBE_CONNECTION_MODE"],
     "mouse_probe_min_interval_ms": float(os.environ["MOUSE_PROBE_MIN_INTERVAL_MS"]),
     "shaper_bps": int(os.environ["SHAPER_BPS"]),
+    "settle_budget_s": int(os.environ["SETTLE_BUDGET"]),
+    "cwnd_settle_ok": os.environ["CWND_SETTLE_OK"] == "true",
+    "cwnd_settle_elapsed_s": int(os.environ["CWND_SETTLE_ELAPSED"]),
 }
 print(json.dumps(manifest, indent=2))
 ' > "${OUT_DIR}/manifest.json"

--- a/test/incus/test_mouse_latency_shell_test.py
+++ b/test/incus/test_mouse_latency_shell_test.py
@@ -33,6 +33,28 @@ class MouseLatencyShellTests(unittest.TestCase):
         self.assertIn("Set MOUSE_COS_SURPLUS_SHARING=1", MATRIX_SCRIPT)
         self.assertIn("per-rep manifest records the selected fixture bit", MATRIX_SCRIPT)
 
+    def test_settle_budget_and_diagnostics_are_recorded(self):
+        self.assertIn('SETTLE_BUDGET="${MOUSE_LATENCY_SETTLE_BUDGET:-20}"', SCRIPT)
+        self.assertIn("MOUSE_LATENCY_SETTLE_BUDGET='$SETTLE_BUDGET' must be a positive integer second count", SCRIPT)
+        self.assertIn('settle-diagnostics "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS"', SCRIPT)
+        self.assertIn('"settle_budget_s": int(os.environ["SETTLE_BUDGET"])', SCRIPT)
+        self.assertIn('"cwnd_settle_elapsed_s": int(os.environ["CWND_SETTLE_ELAPSED"])', SCRIPT)
+        self.assertIn('"cwnd_settle_ok": os.environ["CWND_SETTLE_OK"] == "true"', SCRIPT)
+        self.assertIn('"status": "INVALID"', SCRIPT)
+        self.assertIn('write_invalid_manifest "$reason"', SCRIPT)
+
+    def test_runtime_cos_and_settle_cpu_artifacts_are_cleared_and_captured(self):
+        for artifact in (
+            '"/cwnd-settle.json \\',
+            '"/mpstat-settle.txt \\',
+            '"/cos-interface-pre.txt \\',
+            '"/cos-interface-settle.txt \\',
+            '"/cos-interface-post.txt \\',
+        ):
+            self.assertIn(artifact, SCRIPT)
+        self.assertIn("show class-of-service interface", SCRIPT)
+        self.assertIn("mpstat 1 ${SETTLE_BUDGET} > /tmp/mpstat-settle-${REP_TAG}.txt", SCRIPT)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/incus/test_mouse_latency_shell_test.py
+++ b/test/incus/test_mouse_latency_shell_test.py
@@ -39,7 +39,10 @@ class MouseLatencyShellTests(unittest.TestCase):
         self.assertIn('settle-diagnostics "${OUT_DIR}/iperf3-settle.txt" "$SHAPER_BPS"', SCRIPT)
         self.assertIn('"settle_budget_s": int(os.environ["SETTLE_BUDGET"])', SCRIPT)
         self.assertIn('"cwnd_settle_elapsed_s": int(os.environ["CWND_SETTLE_ELAPSED"])', SCRIPT)
-        self.assertIn('"cwnd_settle_ok": os.environ["CWND_SETTLE_OK"] == "true"', SCRIPT)
+        self.assertIn('CWND_SETTLE_OK="unknown"', SCRIPT)
+        self.assertIn('CWND_SETTLE_OK="false"', SCRIPT)
+        self.assertIn('settle_ok = None', SCRIPT)
+        self.assertIn('"cwnd_settle_ok": settle_ok', SCRIPT)
         self.assertIn('"status": "INVALID"', SCRIPT)
         self.assertIn('write_invalid_manifest "$reason"', SCRIPT)
 

--- a/test/incus/test_mouse_latency_shell_test.py
+++ b/test/incus/test_mouse_latency_shell_test.py
@@ -43,6 +43,14 @@ class MouseLatencyShellTests(unittest.TestCase):
         self.assertIn('CWND_SETTLE_OK="false"', SCRIPT)
         self.assertIn('settle_ok = None', SCRIPT)
         self.assertIn('"cwnd_settle_ok": settle_ok', SCRIPT)
+        self.assertRegex(
+            SCRIPT,
+            re.compile(
+                r'if \[\[ \$pull_rc -ne 0 \|\| ! -s "\$\{OUT_DIR\}/iperf3-settle\.txt" \]\]; then\s+'
+                r'invalidate "iperf3-settle-pull-failed"',
+                re.MULTILINE,
+            ),
+        )
         self.assertIn('"status": "INVALID"', SCRIPT)
         self.assertIn('write_invalid_manifest "$reason"', SCRIPT)
 


### PR DESCRIPTION
## Summary

Refs #1359 and #1365.

Adds artifact diagnostics for the 100E100M mouse-latency lane so high-rate exact and surplus-sharing failures are attributable instead of collapsing into `cwnd-not-settled` or `degenerate-coroutine`.

- add `cwnd-settle.json` with settle verdict, aggregate window bps, threshold reasons, per-flow min/median/max, retransmits, cwnd distribution, and slowest/fastest streams
- add `MOUSE_LATENCY_SETTLE_BUDGET=<seconds>` for explicit longer high-rate settle reruns
- capture `mpstat-settle.txt` and `cos-interface-{pre,settle,post}.txt`
- write minimal invalid-rep `manifest.json` with settle status and reason
- extend probe JSON with phase/coroutine diagnostics: connect, drain, read, start-gap, sleep overshoot, and per-coroutine progress
- carry representative probe diagnostics into aggregate summaries
- document the new artifacts in `docs/fairness-regimes.md`

## Validation

From `test/incus`:

- `python3 -m unittest mouse_latency_orchestrate_test.py mouse_latency_aggregate_test.py test_mouse_latency_shell_test.py`
- `python3 -m unittest mouse_latency_probe_test.py`
- `bash -n test-mouse-latency.sh`

From repo root:

- `python3 -m py_compile test/incus/mouse_latency_orchestrate.py test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`
- `git diff --check`

No live Incus/cluster matrix was run. This PR does not change surplus-sharing scheduler behavior; it makes the next 1G surplus and 10G exact reruns diagnosable.