### PR TITLE
test: make userspace loss cluster canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,24 +68,25 @@ If `incus` commands fail with permission errors, use `sg incus-admin -c "make ..
 ## Cluster Test Environment (Two-VM HA)
 
 **Smoke tests run ONLY on the loss userspace cluster** (`loss:xpf-userspace-fw0/fw1`).
-The local `make cluster-*` targets drive the legacy eBPF cluster
-(`bpfrx-fw0/1`) which is regression-only; never use them for smoke.
+The Makefile `cluster-*` targets now default to that userspace cluster via
+`test/incus/loss-userspace-cluster.env`. Use `loss-cluster-*` only for the
+older loss cluster, and set `CLUSTER_ENV=` only when intentionally exercising
+the original local `xpf-fw0/xpf-fw1` regression environment.
 
 ```bash
 # === SMOKE (loss userspace cluster, default for all userspace-dp validation) ===
-export BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env
-./test/incus/cluster-setup.sh deploy all
-./test/incus/cluster-setup.sh ssh 0
+make cluster-deploy
+make cluster-ssh NODE=0
 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0   # deploy wipes CoS — re-apply
 
-# === LEGACY (local bpfrx-fw0/1, regression-only — do NOT use for smoke) ===
-make cluster-init              # Create networks + profile for legacy HA cluster
-make cluster-create            # Launch bpfrx-fw0, bpfrx-fw1, cluster-lan-host
-make cluster-deploy            # Build + push to both legacy VMs + restart
-make cluster-destroy           # Tear down legacy cluster VMs
-make test-failover             # Reboot fw0 during iperf3 — verify TCP survives failover+failback
-make test-ha-crash             # Force-stop/daemon-stop/multi-cycle crash recovery
-make test-restart-connectivity # Verify 0 packet loss during daemon restart
+# === LEGACY (local xpf-fw0/1, regression-only — do NOT use for smoke) ===
+make CLUSTER_ENV= cluster-init    # Create networks + profile for local HA cluster
+make CLUSTER_ENV= cluster-create  # Launch xpf-fw0, xpf-fw1, cluster-lan-host
+make CLUSTER_ENV= cluster-deploy  # Build + push to both legacy VMs + restart
+make CLUSTER_ENV= cluster-destroy # Tear down legacy cluster VMs
+make CLUSTER_ENV= test-failover             # Reboot fw0 during iperf3 — local regression
+make CLUSTER_ENV= test-ha-crash             # Force-stop/daemon-stop/multi-cycle crash recovery
+make CLUSTER_ENV= test-restart-connectivity # Verify restart behavior on local regression cluster
 ```
 
 Or use `test/incus/cluster-setup.sh` directly with `BPFRX_CLUSTER_ENV` set:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime
 # eBPF compilation flags
 BPF_CFLAGS := -O2 -g -Wall -Werror -target bpf
 
-.PHONY: all generate build build-ctl build-userspace-dp proto install clean test test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg build-dpdk-worker build-dpdk clean-dpdk
+.PHONY: all generate build build-ctl build-userspace-dp proto install clean test test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity build-dpdk-worker build-dpdk clean-dpdk
 
 all: generate build build-ctl
 
@@ -54,14 +54,16 @@ clean: clean-dpdk
 	rm -f pkg/dataplane/*_bpfel.o pkg/dataplane/*_bpfeb.o
 	rm -rf userspace-dp/target
 
-# Test environment management (Incus VM/container)
-.PHONY: test-env-init test-vm test-ct test-deploy test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+# Legacy standalone test environment management (single Incus VM/container).
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
 
 test-vm:
 	./test/incus/setup.sh create-vm
+
+standalone-test-vm: test-vm
 
 test-ct:
 	./test/incus/setup.sh create-ct
@@ -95,107 +97,131 @@ test-journal:
 
 # Connectivity tests (standalone + cluster, VRF-aware)
 MODE ?= all
+PRIVATE_RG_MODE ?= $(if $(filter all,$(MODE)),full,$(MODE))
 test-connectivity:
-	./test/incus/test-connectivity.sh $(MODE)
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-connectivity.sh $(MODE)
 
 # Cluster failover test (iperf3 through reboot — requires cluster + iperf3 server)
 test-failover:
-	./test/incus/test-failover.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-failover.sh
 
 # Double failover test (crash fw0 → fw1 takes over → fw0 rejoins → crash fw1 → fw0 takes over)
 test-double-failover:
-	./test/incus/test-double-failover.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-double-failover.sh
 
 # Active/active per-RG failover test (iperf3 through RG split — requires cluster + iperf3 server)
 test-active-active:
-	./test/incus/test-active-active.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-active-active.sh
 
 # Rapid failover stress test (repeated failover cycles — requires cluster + iperf3 server)
 test-stress-failover:
-	./test/incus/test-stress-failover.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-stress-failover.sh
 
 # Hard-crash / hung-node HA test (force-stop + daemon stop + multi-cycle — requires cluster + iperf3 server)
 test-ha-crash:
-	./test/incus/test-ha-crash.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-ha-crash.sh
 
 # Chained hard-reset failover test (fw0 crash → fw1 crash → both rejoin — requires cluster + iperf3 server)
 test-chained-crash:
-	./test/incus/test-chained-crash.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-chained-crash.sh
 
 # Private RG election test (enable/disable private-rg-election, verify VRRP behavior)
 test-private-rg:
-	./test/incus/test-private-rg.sh $(MODE)
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-private-rg.sh $(PRIVATE_RG_MODE)
 
 # Restart connectivity regression test (verify no transient loss during daemon restart — requires cluster + iperf3 server)
 test-restart-connectivity:
-	./test/incus/test-restart-connectivity.sh
+	BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/test-restart-connectivity.sh
 
-# Cluster HA test environment (two-VM chassis cluster)
+# Canonical cluster HA test environment (isolated loss userspace cluster).
+# Override CLUSTER_ENV= to use cluster-setup.sh local xpf-fw0/xpf-fw1 defaults.
 NODE ?= all
+ifeq ($(origin CLUSTER_ENV),undefined)
+ifeq ($(origin BPFRX_CLUSTER_ENV),undefined)
+CLUSTER_ENV := test/incus/loss-userspace-cluster.env
+else
+CLUSTER_ENV := $(BPFRX_CLUSTER_ENV)
+endif
+endif
+LOSS_CLUSTER_ENV ?= test/incus/loss-cluster.env
+CLUSTER_SETUP = BPFRX_CLUSTER_ENV=$(CLUSTER_ENV) ./test/incus/cluster-setup.sh
+LOSS_CLUSTER_SETUP = BPFRX_CLUSTER_ENV=$(LOSS_CLUSTER_ENV) ./test/incus/cluster-setup.sh
 .PHONY: cluster-init cluster-create cluster-deploy cluster-destroy cluster-status cluster-ssh cluster-logs cluster-start cluster-stop cluster-restart
+.PHONY: userspace-cluster-init userspace-cluster-create userspace-cluster-deploy userspace-cluster-destroy userspace-cluster-status userspace-cluster-ssh userspace-cluster-logs userspace-cluster-start userspace-cluster-stop userspace-cluster-restart
 
 cluster-init:
-	./test/incus/cluster-setup.sh init
+	$(CLUSTER_SETUP) init
 
 cluster-create:
-	./test/incus/cluster-setup.sh create
+	$(CLUSTER_SETUP) create
 
 cluster-deploy: build build-ctl
-	./test/incus/cluster-setup.sh deploy $(NODE)
+	$(CLUSTER_SETUP) deploy $(NODE)
 
 cluster-destroy:
-	./test/incus/cluster-setup.sh destroy
+	$(CLUSTER_SETUP) destroy
 
 cluster-status:
-	./test/incus/cluster-setup.sh status
+	$(CLUSTER_SETUP) status
 
 cluster-ssh:
-	./test/incus/cluster-setup.sh ssh $(NODE)
+	$(CLUSTER_SETUP) ssh $(NODE)
 
 cluster-logs:
-	./test/incus/cluster-setup.sh logs $(NODE)
+	$(CLUSTER_SETUP) logs $(NODE)
 
 cluster-start:
-	./test/incus/cluster-setup.sh start $(NODE)
+	$(CLUSTER_SETUP) start $(NODE)
 
 cluster-stop:
-	./test/incus/cluster-setup.sh stop $(NODE)
+	$(CLUSTER_SETUP) stop $(NODE)
 
 cluster-restart:
-	./test/incus/cluster-setup.sh restart $(NODE)
+	$(CLUSTER_SETUP) restart $(NODE)
 
-# Remote cluster on "loss" host (Mellanox SR-IOV VFs)
+userspace-cluster-init: cluster-init
+userspace-cluster-create: cluster-create
+userspace-cluster-deploy: cluster-deploy
+userspace-cluster-destroy: cluster-destroy
+userspace-cluster-status: cluster-status
+userspace-cluster-ssh: cluster-ssh
+userspace-cluster-logs: cluster-logs
+userspace-cluster-start: cluster-start
+userspace-cluster-stop: cluster-stop
+userspace-cluster-restart: cluster-restart
+
+# Legacy remote "loss" cluster using the older xpf-fw0/xpf-fw1 instance names.
 .PHONY: loss-cluster-init loss-cluster-create loss-cluster-deploy loss-cluster-destroy loss-cluster-status loss-cluster-ssh loss-cluster-logs loss-cluster-start loss-cluster-stop loss-cluster-restart
 
 loss-cluster-init:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh init
+	$(LOSS_CLUSTER_SETUP) init
 
 loss-cluster-create:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh create
+	$(LOSS_CLUSTER_SETUP) create
 
 loss-cluster-deploy: build build-ctl
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh deploy $(NODE)
+	$(LOSS_CLUSTER_SETUP) deploy $(NODE)
 
 loss-cluster-destroy:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh destroy
+	$(LOSS_CLUSTER_SETUP) destroy
 
 loss-cluster-status:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh status
+	$(LOSS_CLUSTER_SETUP) status
 
 loss-cluster-ssh:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh ssh $(NODE)
+	$(LOSS_CLUSTER_SETUP) ssh $(NODE)
 
 loss-cluster-logs:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh logs $(NODE)
+	$(LOSS_CLUSTER_SETUP) logs $(NODE)
 
 loss-cluster-start:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh start $(NODE)
+	$(LOSS_CLUSTER_SETUP) start $(NODE)
 
 loss-cluster-stop:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh stop $(NODE)
+	$(LOSS_CLUSTER_SETUP) stop $(NODE)
 
 loss-cluster-restart:
-	BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh restart $(NODE)
+	$(LOSS_CLUSTER_SETUP) restart $(NODE)
 
 # --- DPDK targets (require dpdk-dev, meson, ninja) ---
 

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ make test-vm         # Create VM
 make test-deploy     # Build + deploy + restart service
 make test-logs       # View daemon logs
 
-# Two-VM HA cluster
+# Two-VM HA cluster (defaults to loss userspace cluster)
 make cluster-init    # Create networks + profile
-make cluster-create  # Launch fw0 + fw1 + LAN host
+make cluster-create  # Launch xpf-userspace-fw0 + xpf-userspace-fw1 + LAN host
 make cluster-deploy  # Rolling deploy: secondary first, then primary (preserves traffic)
 ```
 
@@ -259,8 +259,9 @@ Userspace dataplane testing (requires mlx5 NICs on loss cluster):
 
 ```bash
 # Userspace HA cluster
-./scripts/userspace-ha-validation.sh       # Full HA failover validation
-./scripts/userspace-perf-compare.sh        # IPv4/IPv6 throughput + profiling
+make cluster-deploy
+./scripts/userspace-ha-validation.sh --env test/incus/loss-userspace-cluster.env
+./scripts/userspace-perf-compare.sh
 ```
 
 ### Cluster Deployment

--- a/test/incus/cluster-env.sh
+++ b/test/incus/cluster-env.sh
@@ -1,0 +1,66 @@
+# Shared cluster test defaults.
+#
+# Makefile cluster validation is canonicalized on the isolated loss userspace
+# cluster. Set BPFRX_CLUSTER_ENV, or CLUSTER_ENV via make, to point at another
+# cluster env file. Set BPFRX_CLUSTER_ENV= to use cluster-setup.sh local defaults.
+
+_xpf_cluster_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "${_xpf_cluster_script_dir}/../.." && pwd)}"
+
+_xpf_default_cluster_env="${PROJECT_ROOT}/test/incus/loss-userspace-cluster.env"
+if [[ -v BPFRX_CLUSTER_ENV ]]; then
+	_xpf_cluster_env="$BPFRX_CLUSTER_ENV"
+else
+	_xpf_cluster_env="${_xpf_default_cluster_env}"
+fi
+
+if [[ -n "$_xpf_cluster_env" ]]; then
+	case "$_xpf_cluster_env" in
+		/*) ;;
+		*) _xpf_cluster_env="${PROJECT_ROOT}/${_xpf_cluster_env}" ;;
+	esac
+	if [[ ! -f "$_xpf_cluster_env" ]]; then
+		echo "ERROR: BPFRX_CLUSTER_ENV does not exist: $_xpf_cluster_env" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	source "$_xpf_cluster_env"
+	export BPFRX_CLUSTER_ENV="$_xpf_cluster_env"
+fi
+
+if [[ -n "${CLUSTER_CONF:-}" && "$CLUSTER_CONF" != /* ]]; then
+	CLUSTER_CONF="${PROJECT_ROOT}/${CLUSTER_CONF}"
+fi
+
+_xpf_cluster_ref() {
+	local inst="$1"
+	if [[ -n "${INCUS_REMOTE:-}" && "$inst" != *:* ]]; then
+		printf '%s:%s\n' "$INCUS_REMOTE" "$inst"
+	else
+		printf '%s\n' "$inst"
+	fi
+}
+
+FW0_NAME="${FW0_NAME:-${VM0:-xpf-fw0}}"
+FW1_NAME="${FW1_NAME:-${VM1:-xpf-fw1}}"
+CLUSTER_LAN_HOST_NAME="${CLUSTER_LAN_HOST_NAME:-${LAN_HOST:-cluster-lan-host}}"
+
+FW0="${FW0:-$(_xpf_cluster_ref "$FW0_NAME")}"
+FW1="${FW1:-$(_xpf_cluster_ref "$FW1_NAME")}"
+CLUSTER_LAN_HOST="${CLUSTER_LAN_HOST:-$(_xpf_cluster_ref "$CLUSTER_LAN_HOST_NAME")}"
+
+LAN_HOST_IP="${LAN_HOST_IP:-${LAN_ADDR:-}}"
+LAN_HOST_IP="${LAN_HOST_IP%%/*}"
+LAN_HOST_IP="${LAN_HOST_IP:-10.0.60.102}"
+LAN_VIP4="${LAN_VIP4:-${LAN_GW:-10.0.60.1}}"
+LAN_VIP6="${LAN_VIP6:-2001:559:8585:cf01::1}"
+WAN_GW4="${WAN_GW4:-172.16.50.1}"
+WAN_VIP4="${WAN_VIP4:-172.16.50.6}"
+IPERF_TARGET4="${IPERF_TARGET4:-172.16.100.200}"
+IPERF_TARGET6="${IPERF_TARGET6:-2001:559:8585:100::200}"
+
+export PROJECT_ROOT BPFRX_CLUSTER_ENV CLUSTER_CONF
+export FW0 FW1 CLUSTER_LAN_HOST
+export FW0_NAME FW1_NAME CLUSTER_LAN_HOST_NAME
+export LAN_HOST_IP LAN_VIP4 LAN_VIP6 WAN_GW4 WAN_VIP4
+export IPERF_TARGET4 IPERF_TARGET6

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -11,6 +11,7 @@
 # Parameterized via env file — set BPFRX_CLUSTER_ENV to source custom
 # settings (remote host, SR-IOV parents, VF indices, network names, etc.).
 # Without an env file, defaults match the original local cluster.
+# The Makefile cluster-* aliases pass loss-userspace-cluster.env by default.
 #
 # Usage:
 #   ./test/incus/cluster-setup.sh init              # Create networks + profile

--- a/test/incus/loss-cluster.env
+++ b/test/incus/loss-cluster.env
@@ -1,4 +1,5 @@
-# Remote cluster on "loss" host with Mellanox SR-IOV VFs
+# Legacy remote cluster on "loss" host with Mellanox SR-IOV VFs.
+# The canonical Makefile cluster targets now default to loss-userspace-cluster.env.
 #
 # Source via: BPFRX_CLUSTER_ENV=test/incus/loss-cluster.env ./test/incus/cluster-setup.sh <cmd>
 #

--- a/test/incus/loss-userspace-cluster.env
+++ b/test/incus/loss-userspace-cluster.env
@@ -1,3 +1,6 @@
+# Canonical Makefile cluster/test target for userspace dataplane validation.
+# Source via: BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env ./test/incus/cluster-setup.sh <cmd>
+
 INCUS_REMOTE="loss"
 VM0="xpf-userspace-fw0"
 VM1="xpf-userspace-fw1"
@@ -22,3 +25,10 @@ CLUSTER_CONF="docs/ha-cluster-userspace.conf"
 
 LAN_ADDR="10.0.61.102/24"
 LAN_GW="10.0.61.1"
+LAN_HOST_IP="10.0.61.102"
+LAN_VIP4="10.0.61.1"
+LAN_VIP6="2001:559:8585:ef00::1"
+WAN_GW4="172.16.50.1"
+WAN_VIP4="172.16.50.6"
+IPERF_TARGET4="172.16.100.200"
+IPERF_TARGET6="2001:559:8585:100::200"

--- a/test/incus/test-active-active.sh
+++ b/test/incus/test-active-active.sh
@@ -8,8 +8,8 @@
 # LAN (RG2, fw0) must cross the fabric link to exit on the WAN (RG1, fw1)
 # when the RGs are split across nodes.
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   1. Start iperf3 from LAN host through the firewall to WAN target
@@ -31,7 +31,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=90       # seconds — enough to span two failovers + settling
 IPERF_STREAMS=8
 SETTLE_WAIT=3           # seconds to let VRRP + election settle
@@ -55,13 +59,13 @@ instance_running() {
 
 cleanup() {
 	# Kill iperf3 on LAN host
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	# Reset any manual failovers
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
+	incus exec "$FW1" -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
 	# With preempt=false, resetting the flag alone doesn't move VRRP.
 	# Explicitly request RG1 back to fw0 so the next test starts clean.
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
 	sleep 2
 }
 
@@ -71,29 +75,29 @@ trap cleanup EXIT
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
 # Reset any stale manual failover flags from previous test runs.
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
 # Ensure all RGs are on fw0 (request peer failover if needed)
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 for rg in 0 1 2; do
 	rg_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: $rg" | grep "node0" | grep -c "primary" || true)
 	if [[ "$rg_primary" -ne 1 ]]; then
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover redundancy-group $rg node 0" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover redundancy-group $rg node 0" 2>/dev/null || true
 	fi
 done
 sleep 3
 
 # Verify fw0 is primary for all RGs
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 rg0_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: 0" | grep "node0" | grep -c "primary" || true)
 rg1_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: 1" | grep "node0" | grep -c "primary" || true)
 rg2_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: 2" | grep "node0" | grep -c "primary" || true)
@@ -105,27 +109,27 @@ else
 fi
 
 # Verify iperf target reachable
-if incus exec cluster-lan-host -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "iperf3 target reachable ($IPERF_TARGET)"
 else
 	die "Cannot reach iperf3 target $IPERF_TARGET from cluster-lan-host"
 fi
 
 # Kill any stale iperf3
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # ── Phase 1: Start iperf3 ───────────────────────────────────────────
 
 info "Phase 1: Starting iperf3 -P${IPERF_STREAMS} -t${IPERF_DURATION} → ${IPERF_TARGET}"
 
-incus exec cluster-lan-host -- bash -c \
+incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 	"iperf3 --forceflush --connect-timeout 5000 -t ${IPERF_DURATION} -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > /tmp/iperf3-active-active.log 2>&1 &"
 
 sleep 8  # all parallel streams must be fully established before failover
 
 # Verify iperf3 is running
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	pass "iperf3 running"
 else
 	die "iperf3 failed to start — check /tmp/iperf3-active-active.log on cluster-lan-host"
@@ -135,11 +139,11 @@ fi
 
 info "Phase 2: Failover RG1 (WAN) to node1 — creating active/active split"
 
-incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1' 2>/dev/null || true
+incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1' 2>/dev/null || true
 sleep "$SETTLE_WAIT"
 
 # Verify RG split: RG1 on fw1, RG2 on fw0
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 
 rg1_node0=$(echo "$fw0_status" | grep -A2 "Redundancy group: 1" | grep "node0" | awk '{print $3}')
 rg2_node0=$(echo "$fw0_status" | grep -A2 "Redundancy group: 2" | grep "node0" | awk '{print $3}')
@@ -157,7 +161,7 @@ else
 fi
 
 # Verify VRRP states match cluster state
-fw0_vrrp=$(incus exec xpf-fw0 -- cli -c 'show security vrrp' 2>/dev/null)
+fw0_vrrp=$(incus exec "$FW0" -- cli -c 'show security vrrp' 2>/dev/null)
 
 vrrp_101=$(echo "$fw0_vrrp" | grep "101" | head -1)
 vrrp_102=$(echo "$fw0_vrrp" | grep "102" | head -1)
@@ -180,11 +184,11 @@ info "Phase 3: Verify traffic survives active/active split (fabric forwarding)"
 
 sleep 5  # let traffic settle after failover
 
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	# Check last interval of iperf3 output for throughput
 	# With -P N, each interval has N+2 lines (N streams + SUM + separator)
 	tail_lines=$(( IPERF_STREAMS * 2 + 5 ))
-	last_sum=$(incus exec cluster-lan-host -- tail -"$tail_lines" /tmp/iperf3-active-active.log 2>/dev/null | grep "SUM" | tail -1 || true)
+	last_sum=$(incus exec "$CLUSTER_LAN_HOST" -- tail -"$tail_lines" /tmp/iperf3-active-active.log 2>/dev/null | grep "SUM" | tail -1 || true)
 	if echo "$last_sum" | grep -qiE "[0-9]+ [MG]bits/sec"; then
 		bps=$(echo "$last_sum" | grep -oiE "[0-9.]+ [MG]bits/sec" | head -1)
 		pass "iperf3 survived RG split ($bps)"
@@ -205,7 +209,7 @@ info "Phase 3b: Verify new TCP connections work through split cluster"
 # proves the full SYN → SYN-ACK → ACK path works across fabric.
 # The iperf3 server accepts the TCP connection (then sends "busy"),
 # but the 3-way handshake completing is what matters.
-if incus exec cluster-lan-host -- bash -c \
+if incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 	"timeout 5 bash -c 'echo > /dev/tcp/${IPERF_TARGET}/5201'" 2>/dev/null; then
 	pass "new TCP connection through split cluster"
 else
@@ -216,7 +220,7 @@ fi
 
 info "Phase 3c: Verify ping works through split cluster"
 
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "ping through split cluster works"
 else
 	fail "ping through split cluster failed (new connections broken)"
@@ -226,11 +230,11 @@ fi
 
 info "Phase 4: Failover RG1 (WAN) back to node0 — reunifying all RGs"
 
-incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
+incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
 sleep "$SETTLE_WAIT"
 
 # Verify all RGs back on fw0
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 
 rg1_node0=$(echo "$fw0_status" | grep -A2 "Redundancy group: 1" | grep "node0" | awk '{print $3}')
 
@@ -246,9 +250,9 @@ info "Phase 5: Verify traffic survives RG reunification"
 
 sleep 5
 
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	tail_lines=$(( IPERF_STREAMS * 2 + 5 ))
-	last_sum=$(incus exec cluster-lan-host -- tail -"$tail_lines" /tmp/iperf3-active-active.log 2>/dev/null | grep "SUM" | tail -1 || true)
+	last_sum=$(incus exec "$CLUSTER_LAN_HOST" -- tail -"$tail_lines" /tmp/iperf3-active-active.log 2>/dev/null | grep "SUM" | tail -1 || true)
 	if echo "$last_sum" | grep -qiE "[0-9]+ [MG]bits/sec"; then
 		bps=$(echo "$last_sum" | grep -oiE "[0-9.]+ [MG]bits/sec" | head -1)
 		pass "iperf3 survived RG reunification ($bps)"
@@ -264,18 +268,18 @@ fi
 info "Waiting for iperf3 to complete"
 
 for i in $(seq 1 "$IPERF_DURATION"); do
-	if ! incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 		break
 	fi
 	sleep 1
 done
 
 # Check iperf3 completed successfully
-if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-active-active.log 2>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-active-active.log 2>/dev/null; then
 	pass "iperf3 completed successfully"
 
 	# Extract final throughput
-	throughput=$(incus exec cluster-lan-host -- grep '\[SUM\].*sender' /tmp/iperf3-active-active.log 2>/dev/null \
+	throughput=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' /tmp/iperf3-active-active.log 2>/dev/null \
 		| grep -oP '[\d.]+\s+Gbits' | grep -oP '[\d.]+' || echo "0")
 
 	if [[ -n "$throughput" ]] && awk "BEGIN{exit !($throughput >= $MIN_THROUGHPUT)}"; then
@@ -284,14 +288,14 @@ if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-active-active
 		fail "iperf3 throughput too low: ${throughput} Gbps (expected >= ${MIN_THROUGHPUT} Gbps)"
 	fi
 else
-	iperf_log=$(incus exec cluster-lan-host -- tail -5 /tmp/iperf3-active-active.log 2>/dev/null || echo "(no log)")
+	iperf_log=$(incus exec "$CLUSTER_LAN_HOST" -- tail -5 /tmp/iperf3-active-active.log 2>/dev/null || echo "(no log)")
 	fail "iperf3 did not complete: $iperf_log"
 fi
 
 # ── Cleanup & Results ────────────────────────────────────────────────
 
 # Kill iperf3
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/test/incus/test-chained-crash.sh
+++ b/test/incus/test-chained-crash.sh
@@ -9,8 +9,8 @@
 # to simulate abrupt power loss (no graceful shutdown, no priority-0 burst).
 # The stopped VM must be explicitly restarted with `incus start`.
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Phases:
 #   Phase 1: fw0 hard-reset → fw1 becomes primary for all RGs
@@ -32,7 +32,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=300      # seconds — long enough to span both failover cycles
 IPERF_STREAMS=4
 MIN_SESSIONS=4          # minimum established sessions (control + some data streams)
@@ -84,8 +88,8 @@ node_is_primary() {
 	return 0
 }
 
-fw0_is_primary() { node_is_primary xpf-fw0 "node0"; }
-fw1_is_primary() { node_is_primary xpf-fw1 "node1"; }
+fw0_is_primary() { node_is_primary "$FW0" "node0"; }
+fw1_is_primary() { node_is_primary "$FW1" "node1"; }
 
 # Wait for a node to become primary, return elapsed seconds
 wait_for_node_primary() {
@@ -104,7 +108,7 @@ wait_for_node_primary() {
 test_new_tcp() {
 	local label="$1" max="$2"
 	for i in $(seq 1 "$max"); do
-		if incus exec cluster-lan-host -- bash -c \
+		if incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 			"timeout 3 bash -c 'echo > /dev/tcp/${IPERF_TARGET}/5201'" 2>/dev/null; then
 			pass "$label: new TCP connection succeeded (${i}s)"
 			return 0
@@ -119,8 +123,8 @@ test_new_tcp() {
 check_no_dual_active() {
 	local label="$1"
 	local fw0_status fw1_status
-	fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
-	fw1_status=$(incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	fw1_status=$(incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 
 	local dual_active=false
 	for rg in 0 1 2; do
@@ -153,10 +157,10 @@ check_session_sync() {
 
 cleanup() {
 	info "Cleanup: killing iperf3, ensuring both VMs are running"
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 
 	# Ensure both VMs are running
-	for inst in xpf-fw0 xpf-fw1; do
+	for inst in "$FW0" "$FW1"; do
 		if ! instance_running "$inst"; then
 			incus start "$inst" 2>/dev/null || true
 			wait_for_xpfd "$inst" "$VM_RESTART_WAIT" >/dev/null 2>&1 || true
@@ -164,18 +168,18 @@ cleanup() {
 	done
 
 	# Ensure xpfd is running on both
-	incus exec xpf-fw0 -- systemctl start xpfd 2>/dev/null || true
-	incus exec xpf-fw1 -- systemctl start xpfd 2>/dev/null || true
+	incus exec "$FW0" -- systemctl start xpfd 2>/dev/null || true
+	incus exec "$FW1" -- systemctl start xpfd 2>/dev/null || true
 	sleep 5
 
 	# Clear stale sessions
-	incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 
 	# Reset failover flags
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 }
 
@@ -185,14 +189,14 @@ trap cleanup EXIT
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
 # Reset any stale manual failover flags
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
@@ -204,20 +208,20 @@ else
 fi
 
 # Kill any stale iperf3 and clear stale sessions
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
-incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 sleep 3
 
 # Pre-warm ARP on both firewalls
-incus exec xpf-fw0 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
-incus exec xpf-fw1 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+incus exec "$FW0" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+incus exec "$FW1" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
 sleep 1
 
 # Verify iperf target reachable
 target_ok=false
 for i in $(seq 1 15); do
-	if incus exec cluster-lan-host -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null; then
 		target_ok=true
 		break
 	fi
@@ -235,29 +239,29 @@ info "Starting iperf3 -P${IPERF_STREAMS} -t${IPERF_DURATION} → ${IPERF_TARGET}
 
 iperf_started=false
 for attempt in 1 2 3; do
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	sleep 1
-	incus exec cluster-lan-host -- bash -c \
+	incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"iperf3 --forceflush --connect-timeout 5000 -t ${IPERF_DURATION} -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > ${LOG} 2>&1 &"
 
 	sleep 8  # all parallel streams must be fully established
 
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		info "iperf3 exited on attempt $attempt — server may be busy, retrying"
 		sleep $((attempt * 5))
 		continue
 	fi
 
-	fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+	fw0_sessions=$(incus exec "$FW0" -- cli -c \
 		"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 	if [[ "$fw0_sessions" -ge "$IPERF_STREAMS" ]]; then
 		iperf_started=true
 		break
 	fi
 
-	if incus exec cluster-lan-host -- grep -q "unable to connect" "${LOG}" 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "unable to connect" "${LOG}" 2>/dev/null; then
 		info "iperf3 stream connect failed on attempt $attempt — server busy, retrying"
-		incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+		incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 		sleep $((attempt * 10))
 		continue
 	fi
@@ -267,21 +271,21 @@ for attempt in 1 2 3; do
 done
 
 if ! $iperf_started; then
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
-		incus exec cluster-lan-host -- cat "${LOG}" 2>/dev/null || true
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
+		incus exec "$CLUSTER_LAN_HOST" -- cat "${LOG}" 2>/dev/null || true
 		die "iperf3 failed to start after 3 attempts"
 	fi
 fi
 
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 running on cluster-lan-host"
 else
-	incus exec cluster-lan-host -- cat "${LOG}" 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- cat "${LOG}" 2>/dev/null || true
 	die "iperf3 failed to start"
 fi
 
 # Verify sessions on fw0
-fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+fw0_sessions=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw0 has $fw0_sessions established sessions"
@@ -293,7 +297,7 @@ fi
 info "Waiting ${SYNC_WAIT}s for session sync to fw1"
 sleep "$SYNC_WAIT"
 
-fw1_sessions=$(incus exec xpf-fw1 -- cli -c \
+fw1_sessions=$(incus exec "$FW1" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw1_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw1 has $fw1_sessions synced sessions"
@@ -307,7 +311,7 @@ fi
 
 info "Phase 1: Hard-reset fw0 (incus stop --force) — fw1 must take over"
 
-incus stop --force xpf-fw0 2>/dev/null || true
+incus stop --force "$FW0" 2>/dev/null || true
 
 # Wait for fw1 to take over
 takeover_time=$(wait_for_node_primary fw1_is_primary "$TAKEOVER_TIMEOUT" || true)
@@ -318,7 +322,7 @@ else
 fi
 
 # Verify iperf3 survived first failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "phase1: iperf3 survived fw0 hard-reset (failover to fw1)"
 else
 	fail "phase1: iperf3 DIED during fw0 hard-reset"
@@ -328,7 +332,7 @@ fi
 test_new_tcp "phase1" "$CONN_TIMEOUT"
 
 # Verify connectivity via ping
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "phase1: ping through fw1 works"
 else
 	fail "phase1: ping through fw1 failed"
@@ -340,9 +344,9 @@ fi
 
 info "Phase 2: Restarting fw0 — must rejoin as secondary with session sync"
 
-incus start xpf-fw0 2>/dev/null || true
+incus start "$FW0" 2>/dev/null || true
 
-restart_time=$(wait_for_xpfd xpf-fw0 "$VM_RESTART_WAIT" || true)
+restart_time=$(wait_for_xpfd "$FW0" "$VM_RESTART_WAIT" || true)
 if [[ -n "$restart_time" ]]; then
 	pass "phase2: fw0 xpfd restarted (${restart_time}s)"
 else
@@ -353,7 +357,7 @@ fi
 sleep 20
 
 # Verify fw0 is secondary (no auto-preempt)
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw0_status" | grep -q "node0.*secondary"; then
 	pass "phase2: fw0 rejoined as secondary (no auto-preempt)"
 elif echo "$fw0_status" | grep -q "node0.*primary"; then
@@ -377,7 +381,7 @@ info "Phase 2: Waiting for fw0 'Takeover ready: yes' (max ${TAKEOVER_WAIT}s)"
 
 takeover_ready=false
 for i in $(seq 1 "$TAKEOVER_WAIT"); do
-	status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	if echo "$status" | grep -qi "Takeover ready.*yes"; then
 		takeover_ready=true
 		info "Phase 2: fw0 takeover ready after ${i}s"
@@ -395,7 +399,7 @@ fi
 # Verify session sync from fw1 → fw0
 sleep "$SYNC_WAIT"
 
-fw0_synced=$(incus exec xpf-fw0 -- cli -c \
+fw0_synced=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_synced" -ge "$MIN_SESSIONS" ]]; then
 	pass "phase2: fw0 has $fw0_synced synced sessions from fw1"
@@ -404,10 +408,10 @@ else
 fi
 
 # Verify iperf3 still running after fw0 rejoin
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "phase2: iperf3 survived fw0 rejoin"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
 		pass "phase2: iperf3 completed successfully (finished before rejoin check)"
 	else
 		fail "phase2: iperf3 DIED during fw0 rejoin"
@@ -420,7 +424,7 @@ fi
 
 info "Phase 3: Hard-reset fw1 (incus stop --force) — fw0 must take over"
 
-incus stop --force xpf-fw1 2>/dev/null || true
+incus stop --force "$FW1" 2>/dev/null || true
 
 # Wait for fw0 to take over
 takeover_time=$(wait_for_node_primary fw0_is_primary "$TAKEOVER_TIMEOUT" || true)
@@ -431,10 +435,10 @@ else
 fi
 
 # Verify iperf3 survived second failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "phase3: iperf3 survived fw1 hard-reset (failover to fw0)"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
 		pass "phase3: iperf3 completed successfully (finished before second failover check)"
 	else
 		fail "phase3: iperf3 DIED during fw1 hard-reset — session sync round-trip FAILED"
@@ -445,7 +449,7 @@ fi
 test_new_tcp "phase3" "$CONN_TIMEOUT"
 
 # Verify connectivity via ping
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "phase3: ping through fw0 works"
 else
 	fail "phase3: ping through fw0 failed"
@@ -457,9 +461,9 @@ fi
 
 info "Phase 4: Restarting fw1 — cluster must stabilize with both nodes healthy"
 
-incus start xpf-fw1 2>/dev/null || true
+incus start "$FW1" 2>/dev/null || true
 
-restart_time=$(wait_for_xpfd xpf-fw1 "$VM_RESTART_WAIT" || true)
+restart_time=$(wait_for_xpfd "$FW1" "$VM_RESTART_WAIT" || true)
 if [[ -n "$restart_time" ]]; then
 	pass "phase4: fw1 xpfd restarted (${restart_time}s)"
 else
@@ -470,7 +474,7 @@ fi
 sleep 20
 
 # Verify fw1 is secondary (no auto-preempt)
-fw1_status=$(incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw1_status=$(incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw1_status" | grep -q "node1.*secondary"; then
 	pass "phase4: fw1 rejoined as secondary (no auto-preempt)"
 elif echo "$fw1_status" | grep -q "node1.*primary"; then
@@ -490,7 +494,7 @@ fi
 check_no_dual_active "phase4"
 
 # Verify both nodes are healthy
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	if instance_running "$inst"; then
 		pass "phase4: $inst running"
 	else
@@ -498,7 +502,7 @@ for inst in xpf-fw0 xpf-fw1; do
 	fi
 done
 
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	if incus exec "$inst" -- systemctl is-active --quiet xpfd 2>/dev/null; then
 		pass "phase4: xpfd active on $inst"
 	else
@@ -507,7 +511,7 @@ for inst in xpf-fw0 xpf-fw1; do
 done
 
 # Verify connectivity
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "phase4: connectivity OK"
 else
 	fail "phase4: connectivity lost"
@@ -518,7 +522,7 @@ fi
 info "Waiting for iperf3 to complete"
 
 for i in $(seq 1 "$IPERF_DURATION"); do
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		break
 	fi
 	sleep 1
@@ -529,15 +533,15 @@ done
 # streams survived — this produces "control socket has closed unexpectedly"
 # instead of "iperf Done". Accept either outcome as long as the sender
 # [SUM] line shows adequate throughput.
-throughput=$(incus exec cluster-lan-host -- grep '\[SUM\].*sender' "${LOG}" 2>/dev/null \
+throughput=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' "${LOG}" 2>/dev/null \
 	| grep -oP '[\d.]+\s+Gbits' | grep -oP '[\d.]+' || echo "0")
 
-if incus exec cluster-lan-host -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" "${LOG}" 2>/dev/null; then
 	pass "iperf3 completed successfully"
 elif [[ -n "$throughput" ]] && awk "BEGIN{exit !($throughput >= $MIN_THROUGHPUT)}"; then
 	pass "iperf3 data transfer completed (${throughput} Gbps) — control socket disrupted during failover"
 else
-	iperf_log=$(incus exec cluster-lan-host -- tail -5 "${LOG}" 2>/dev/null || echo "(no log)")
+	iperf_log=$(incus exec "$CLUSTER_LAN_HOST" -- tail -5 "${LOG}" 2>/dev/null || echo "(no log)")
 	fail "iperf3 did not complete: $iperf_log"
 fi
 

--- a/test/incus/test-connectivity.sh
+++ b/test/incus/test-connectivity.sh
@@ -27,6 +27,10 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -181,52 +185,52 @@ test_standalone() {
 # ── Cluster Tests ────────────────────────────────────────────────────
 
 test_cluster() {
-	info "Cluster HA (xpf-fw0 + xpf-fw1)"
+	info "Cluster HA (${FW0} + ${FW1})"
 
-	if ! instance_running "xpf-fw0" || ! instance_running "xpf-fw1"; then
-		skip "xpf-fw0 or xpf-fw1 not running — skipping cluster tests"
+	if ! instance_running "$FW0" || ! instance_running "$FW1"; then
+		skip "${FW0} or ${FW1} not running — skipping cluster tests"
 		return
 	fi
 
 	# Service health
-	service_check "xpf-fw0" "cluster: xpfd service active on fw0"
-	service_check "xpf-fw1" "cluster: xpfd service active on fw1"
+	service_check "$FW0" "cluster: xpfd service active on fw0"
+	service_check "$FW1" "cluster: xpfd service active on fw1"
 
 	# Heartbeat connectivity (auto VRF — em0/fab0 may be in vrf-mgmt)
-	ping_test "xpf-fw0" "10.99.0.2" "cluster: fw0 → fw1 heartbeat (10.99.0.2)"
-	ping_test "xpf-fw1" "10.99.0.1" "cluster: fw1 → fw0 heartbeat (10.99.0.1)"
+	ping_test "$FW0" "10.99.0.2" "cluster: fw0 → fw1 heartbeat (10.99.0.2)"
+	ping_test "$FW1" "10.99.0.1" "cluster: fw1 → fw0 heartbeat (10.99.0.1)"
 
 	# Fabric connectivity
-	ping_test "xpf-fw0" "10.99.1.2" "cluster: fw0 → fw1 fabric (10.99.1.2)"
-	ping_test "xpf-fw1" "10.99.1.1" "cluster: fw1 → fw0 fabric (10.99.1.1)"
+	ping_test "$FW0" "10.99.1.2" "cluster: fw0 → fw1 fabric (10.99.1.2)"
+	ping_test "$FW1" "10.99.1.1" "cluster: fw1 → fw0 fabric (10.99.1.1)"
 
 	# WAN gateway
-	ping_test "xpf-fw0" "172.16.50.1" "cluster: fw0 → WAN gateway (172.16.50.1)"
+	ping_test "$FW0" "$WAN_GW4" "cluster: fw0 → WAN gateway (${WAN_GW4})"
 
 	# LAN host connectivity
-	if instance_running "cluster-lan-host"; then
+	if instance_running "$CLUSTER_LAN_HOST"; then
 		# From firewall to LAN host
-		ping_test "xpf-fw0" "10.0.60.102" "cluster: fw0 → LAN host (10.0.60.102)"
+		ping_test "$FW0" "$LAN_HOST_IP" "cluster: fw0 → LAN host (${LAN_HOST_IP})"
 
 		# From LAN host to RETH VIP (proves VRRP is working)
-		ping_test "cluster-lan-host" "10.0.60.1" "cluster: LAN host → RETH VIP (10.0.60.1)"
+		ping_test "$CLUSTER_LAN_HOST" "$LAN_VIP4" "cluster: LAN host → RETH VIP (${LAN_VIP4})"
 
 		# Cross-zone: LAN host through firewall to WAN gateway
-		ping_test "cluster-lan-host" "172.16.50.1" "cluster: LAN host → WAN gateway cross-zone (172.16.50.1)"
+		ping_test "$CLUSTER_LAN_HOST" "$WAN_GW4" "cluster: LAN host → WAN gateway cross-zone (${WAN_GW4})"
 
 		# IPv6 LAN connectivity
-		ping6_test "cluster-lan-host" "2001:559:8585:cf01::1" "cluster: LAN host → RETH VIP IPv6"
+		ping6_test "$CLUSTER_LAN_HOST" "$LAN_VIP6" "cluster: LAN host → RETH VIP IPv6"
 
 		# Internet: LAN host → 1.1.1.1 (proves SNAT + routing through fw to internet)
-		internet_test "cluster-lan-host" "cluster: LAN host → internet (1.1.1.1)"
+		internet_test "$CLUSTER_LAN_HOST" "cluster: LAN host → internet (1.1.1.1)"
 
 		# Internet IPv6: LAN host → Google DNS IPv6 (proves IPv6 routing through fw)
-		ping6_test "cluster-lan-host" "2607:f8b0:4005:80e::200e" \
+		ping6_test "$CLUSTER_LAN_HOST" "2607:f8b0:4005:80e::200e" \
 			"cluster: LAN host → internet IPv6 (2607:f8b0:4005:80e::200e)"
 
 		# IPv6 TCP: iperf3 from LAN host to WAN (proves SNAT v6 + return path)
-		if incus exec cluster-lan-host -- which iperf3 &>/dev/null 2>&1; then
-			if incus exec cluster-lan-host -- timeout 8 iperf3 -6 -c 2001:559:8585:100::200 -t 3 &>/dev/null 2>&1; then
+		if incus exec "$CLUSTER_LAN_HOST" -- which iperf3 &>/dev/null 2>&1; then
+			if incus exec "$CLUSTER_LAN_HOST" -- timeout 8 iperf3 -6 -c "$IPERF_TARGET6" -t 3 &>/dev/null 2>&1; then
 				pass "cluster: LAN host → WAN iperf3 IPv6 TCP"
 			else
 				fail "cluster: LAN host → WAN iperf3 IPv6 TCP (SNAT v6 may be missing)"
@@ -236,8 +240,8 @@ test_cluster() {
 		fi
 
 		# IPv4 TCP: iperf3 from LAN host to WAN
-		if incus exec cluster-lan-host -- which iperf3 &>/dev/null 2>&1; then
-			if incus exec cluster-lan-host -- timeout 8 iperf3 -c 172.16.100.200 -t 3 &>/dev/null 2>&1; then
+		if incus exec "$CLUSTER_LAN_HOST" -- which iperf3 &>/dev/null 2>&1; then
+			if incus exec "$CLUSTER_LAN_HOST" -- timeout 8 iperf3 -c "$IPERF_TARGET4" -t 3 &>/dev/null 2>&1; then
 				pass "cluster: LAN host → WAN iperf3 IPv4 TCP"
 			else
 				fail "cluster: LAN host → WAN iperf3 IPv4 TCP"
@@ -247,22 +251,22 @@ test_cluster() {
 		fi
 
 		# mtr path validation: verify traffic traverses RETH VIP to WAN gateway
-		mtr_test "cluster-lan-host" "172.16.50.1" "10.0.60.1" \
+		mtr_test "$CLUSTER_LAN_HOST" "$WAN_GW4" "$LAN_VIP4" \
 			"cluster: mtr LAN→WAN gateway (path through RETH VIP)"
 
 		# mtr to internet: verify full path (RETH VIP → WAN gateway → internet)
-		mtr_test "cluster-lan-host" "1.1.1.1" "10.0.60.1" \
+		mtr_test "$CLUSTER_LAN_HOST" "1.1.1.1" "$LAN_VIP4" \
 			"cluster: mtr LAN→internet (path through RETH VIP)"
 
 		# mtr to internet IPv6: verify full IPv6 path through RETH VIP
-		mtr_test "cluster-lan-host" "2607:f8b0:4005:80e::200e" "2001:559:8585:cf01::1" \
+		mtr_test "$CLUSTER_LAN_HOST" "2607:f8b0:4005:80e::200e" "$LAN_VIP6" \
 			"cluster: mtr LAN→internet IPv6 (path through RETH VIP)"
 	else
-		skip "cluster: LAN host tests (cluster-lan-host not running)"
+		skip "cluster: LAN host tests (${CLUSTER_LAN_HOST} not running)"
 	fi
 
 	# Internet from firewall directly
-	internet_test "xpf-fw0" "cluster: fw0 → internet (1.1.1.1)"
+	internet_test "$FW0" "cluster: fw0 → internet (1.1.1.1)"
 }
 
 # ── Main ─────────────────────────────────────────────────────────────

--- a/test/incus/test-double-failover.sh
+++ b/test/incus/test-double-failover.sh
@@ -6,8 +6,8 @@
 # This tests session sync in both directions and ensures sessions survive
 # a full round-trip failover cycle.
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   1. Start iperf3 -P4 through the firewall (LAN host → WAN target)
@@ -33,7 +33,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=300      # seconds — long enough to span two full failover cycles
 IPERF_STREAMS=4
 MIN_SESSIONS=4          # minimum established sessions (control + some data streams)
@@ -73,19 +77,19 @@ wait_for_instance() {
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
 # Reset any stale manual failover flags from previous test runs.
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
 # Verify fw0 is primary
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 if echo "$fw0_status" | grep -q "node0.*primary"; then
 	pass "fw0 is primary"
 else
@@ -93,14 +97,14 @@ else
 fi
 
 # Verify iperf target reachable
-if incus exec cluster-lan-host -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "iperf3 target reachable ($IPERF_TARGET)"
 else
 	die "Cannot reach iperf3 target $IPERF_TARGET from cluster-lan-host"
 fi
 
 # Kill any stale iperf3
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # ── Phase 1: Start iperf3 ───────────────────────────────────────────
@@ -109,20 +113,20 @@ info "Starting iperf3 -P${IPERF_STREAMS} -t${IPERF_DURATION} → ${IPERF_TARGET}
 
 iperf_started=false
 for attempt in 1 2 3; do
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	sleep 1
-	incus exec cluster-lan-host -- bash -c \
+	incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"iperf3 --forceflush --connect-timeout 5000 -t ${IPERF_DURATION} -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > /tmp/iperf3-double-failover.log 2>&1 &"
 
 	sleep 8  # all parallel streams must be fully established
 
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		info "iperf3 exited on attempt $attempt — server may be busy, retrying"
 		sleep $((attempt * 5))
 		continue
 	fi
 
-	fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+	fw0_sessions=$(incus exec "$FW0" -- cli -c \
 		"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 	if [[ "$fw0_sessions" -ge "$IPERF_STREAMS" ]]; then
 		iperf_started=true
@@ -130,9 +134,9 @@ for attempt in 1 2 3; do
 	fi
 
 	# iperf3 is running but not enough sessions — streams may have timed out
-	if incus exec cluster-lan-host -- grep -q "unable to connect" /tmp/iperf3-double-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "unable to connect" /tmp/iperf3-double-failover.log 2>/dev/null; then
 		info "iperf3 stream connect failed on attempt $attempt — server busy, retrying"
-		incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+		incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 		sleep $((attempt * 10))
 		continue
 	fi
@@ -142,22 +146,22 @@ for attempt in 1 2 3; do
 done
 
 if ! $iperf_started; then
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
-		incus exec cluster-lan-host -- cat /tmp/iperf3-double-failover.log 2>/dev/null || true
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
+		incus exec "$CLUSTER_LAN_HOST" -- cat /tmp/iperf3-double-failover.log 2>/dev/null || true
 		die "iperf3 failed to start after 3 attempts"
 	fi
 fi
 
 # Verify iperf3 is running
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 running on cluster-lan-host"
 else
-	incus exec cluster-lan-host -- cat /tmp/iperf3-double-failover.log 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- cat /tmp/iperf3-double-failover.log 2>/dev/null || true
 	die "iperf3 failed to start"
 fi
 
 # Verify sessions exist on fw0
-fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+fw0_sessions=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw0 has $fw0_sessions established sessions"
@@ -170,7 +174,7 @@ fi
 info "Waiting ${SYNC_WAIT}s for session sync to fw1"
 sleep "$SYNC_WAIT"
 
-fw1_sessions=$(incus exec xpf-fw1 -- cli -c \
+fw1_sessions=$(incus exec "$FW1" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw1_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw1 has $fw1_sessions synced sessions"
@@ -182,13 +186,13 @@ fi
 
 info "Crashing fw0 (sysrq reboot — unclean shutdown, tests worst-case failover)"
 
-incus exec xpf-fw0 -- bash -c 'echo b > /proc/sysrq-trigger' 2>/dev/null || true
+incus exec "$FW0" -- bash -c 'echo b > /proc/sysrq-trigger' 2>/dev/null || true
 
 # Wait for fw1 to detect failure and become primary
 sleep 5
 
 # Verify fw1 became primary
-fw1_status=$(incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw1_status=$(incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw1_status" | grep -q "node1.*primary"; then
 	pass "fw1 became primary after fw0 crash"
 else
@@ -196,7 +200,7 @@ else
 fi
 
 # Verify iperf3 survived the first failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived first failover (fw0 crash → fw1)"
 else
 	fail "iperf3 DIED during first failover — fw0 crash broke TCP connections"
@@ -208,7 +212,7 @@ info "Waiting for fw0 to reboot and rejoin as secondary (max ${REBOOT_WAIT}s)"
 
 fw0_back=false
 for i in $(seq 1 "$REBOOT_WAIT"); do
-	if wait_for_instance xpf-fw0 1; then
+	if wait_for_instance "$FW0" 1; then
 		fw0_back=true
 		info "fw0 xpfd active after ${i}s"
 		break
@@ -225,7 +229,7 @@ fi
 sleep 20
 
 # Verify fw0 is secondary (no auto-preempt)
-fw0_status_after=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status_after=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 if echo "$fw0_status_after" | grep -q "node0.*secondary"; then
 	pass "fw0 rejoined as secondary (no auto-preempt)"
 elif echo "$fw0_status_after" | grep -q "node0.*primary"; then
@@ -235,10 +239,10 @@ else
 fi
 
 # Verify iperf3 still running after fw0 rejoin
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived fw0 rejoin"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
 		pass "iperf3 completed successfully (finished before rejoin check)"
 	else
 		fail "iperf3 DIED during fw0 rejoin"
@@ -251,7 +255,7 @@ info "Waiting for fw0 to reach 'Takeover ready: yes' (max ${TAKEOVER_WAIT}s)"
 
 takeover_ready=false
 for i in $(seq 1 "$TAKEOVER_WAIT"); do
-	status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	if echo "$status" | grep -qi "Takeover ready.*yes"; then
 		takeover_ready=true
 		info "fw0 takeover ready after ${i}s"
@@ -273,7 +277,7 @@ info "Verifying session sync from fw1 → fw0"
 # Additional wait for session sync to complete after takeover-ready
 sleep "$SYNC_WAIT"
 
-fw0_synced=$(incus exec xpf-fw0 -- cli -c \
+fw0_synced=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_synced" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw0 has $fw0_synced synced sessions from fw1"
@@ -285,13 +289,13 @@ fi
 
 info "Crashing fw1 (sysrq reboot — second failover, fw0 must take over)"
 
-incus exec xpf-fw1 -- bash -c 'echo b > /proc/sysrq-trigger' 2>/dev/null || true
+incus exec "$FW1" -- bash -c 'echo b > /proc/sysrq-trigger' 2>/dev/null || true
 
 # Wait for fw0 to detect failure and become primary
 sleep 5
 
 # Verify fw0 became primary
-fw0_status_second=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw0_status_second=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw0_status_second" | grep -q "node0.*primary"; then
 	pass "fw0 became primary after fw1 crash (second failover)"
 else
@@ -299,10 +303,10 @@ else
 fi
 
 # Verify iperf3 survived the second failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived second failover (fw1 crash → fw0)"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
 		pass "iperf3 completed successfully (finished before second failover check)"
 	else
 		fail "iperf3 DIED during second failover — session sync round-trip FAILED"
@@ -314,7 +318,7 @@ fi
 info "Waiting for iperf3 to complete"
 
 for i in $(seq 1 "$IPERF_DURATION"); do
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		break
 	fi
 	sleep 1
@@ -325,15 +329,15 @@ done
 # streams survived — this produces "control socket has closed unexpectedly"
 # instead of "iperf Done". Accept either outcome as long as the sender
 # [SUM] line shows adequate throughput.
-throughput=$(incus exec cluster-lan-host -- grep '\[SUM\].*sender' /tmp/iperf3-double-failover.log 2>/dev/null \
+throughput=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' /tmp/iperf3-double-failover.log 2>/dev/null \
 	| grep -oP '[\d.]+\s+Gbits' | grep -oP '[\d.]+' || echo "0")
 
-if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-double-failover.log 2>/dev/null; then
 	pass "iperf3 completed successfully"
 elif [[ -n "$throughput" ]] && awk "BEGIN{exit !($throughput >= $MIN_THROUGHPUT)}"; then
 	pass "iperf3 data transfer completed (${throughput} Gbps) — control socket disrupted during failover"
 else
-	iperf_log=$(incus exec cluster-lan-host -- tail -5 /tmp/iperf3-double-failover.log 2>/dev/null || echo "(no log)")
+	iperf_log=$(incus exec "$CLUSTER_LAN_HOST" -- tail -5 /tmp/iperf3-double-failover.log 2>/dev/null || echo "(no log)")
 	fail "iperf3 did not complete: $iperf_log"
 fi
 

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -2,8 +2,8 @@
 # xpf cluster failover test
 #
 # Validates that active TCP connections survive fw0 reboot.
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   1. Start iperf3 -P2 through the firewall (LAN host → WAN target)
@@ -26,7 +26,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=120      # seconds — long enough to span retries + reboot + failback
 IPERF_STREAMS=8
 MIN_SESSIONS=4          # minimum established sessions (control + some data streams)
@@ -65,7 +69,7 @@ wait_for_instance() {
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
@@ -73,13 +77,13 @@ done
 # Without this, fw1 can't take over during the reboot test because
 # ManualFailover blocks election even when the peer is lost.
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
 # Verify fw0 is primary
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 if echo "$fw0_status" | grep -q "node0.*primary"; then
 	pass "fw0 is primary"
 else
@@ -87,14 +91,14 @@ else
 fi
 
 # Verify iperf target reachable
-if incus exec cluster-lan-host -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "iperf3 target reachable ($IPERF_TARGET)"
 else
 	die "Cannot reach iperf3 target $IPERF_TARGET from cluster-lan-host"
 fi
 
 # Kill any stale iperf3
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # ── Phase 1: Start iperf3 ───────────────────────────────────────────
@@ -107,20 +111,20 @@ info "Starting iperf3 -P${IPERF_STREAMS} -t${IPERF_DURATION} → ${IPERF_TARGET}
 # with increasing back-off to wait for the server to become available.
 iperf_started=false
 for attempt in 1 2 3; do
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	sleep 1
-	incus exec cluster-lan-host -- bash -c \
+	incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"iperf3 --forceflush --connect-timeout 5000 -t ${IPERF_DURATION} -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > /tmp/iperf3-failover.log 2>&1 &"
 
 	sleep 8  # all parallel streams must be fully established
 
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		info "iperf3 exited on attempt $attempt — server may be busy, retrying"
 		sleep $((attempt * 5))
 		continue
 	fi
 
-	fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+	fw0_sessions=$(incus exec "$FW0" -- cli -c \
 		"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 	if [[ "$fw0_sessions" -ge "$IPERF_STREAMS" ]]; then
 		iperf_started=true
@@ -128,9 +132,9 @@ for attempt in 1 2 3; do
 	fi
 
 	# iperf3 is running but not enough sessions — streams may have timed out
-	if incus exec cluster-lan-host -- grep -q "unable to connect" /tmp/iperf3-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "unable to connect" /tmp/iperf3-failover.log 2>/dev/null; then
 		info "iperf3 stream connect failed on attempt $attempt — server busy, retrying"
-		incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+		incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 		sleep $((attempt * 10))
 		continue
 	fi
@@ -140,17 +144,17 @@ for attempt in 1 2 3; do
 done
 
 if ! $iperf_started; then
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
-		incus exec cluster-lan-host -- cat /tmp/iperf3-failover.log 2>/dev/null || true
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
+		incus exec "$CLUSTER_LAN_HOST" -- cat /tmp/iperf3-failover.log 2>/dev/null || true
 		die "iperf3 failed to start after 3 attempts"
 	fi
 fi
 
 # Verify iperf3 is running
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 running on cluster-lan-host"
 else
-	incus exec cluster-lan-host -- cat /tmp/iperf3-failover.log 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- cat /tmp/iperf3-failover.log 2>/dev/null || true
 	die "iperf3 failed to start"
 fi
 
@@ -158,7 +162,7 @@ fi
 # iperf3 server is single-client — if a stale session from the previous
 # test lingers, some data streams may not connect. Accept MIN_SESSIONS
 # (control + some data) rather than requiring all IPERF_STREAMS.
-fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+fw0_sessions=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw0 has $fw0_sessions established sessions"
@@ -171,7 +175,7 @@ fi
 info "Waiting ${SYNC_WAIT}s for session sync to fw1"
 sleep "$SYNC_WAIT"
 
-fw1_sessions=$(incus exec xpf-fw1 -- cli -c \
+fw1_sessions=$(incus exec "$FW1" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw1_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw1 has $fw1_sessions synced sessions"
@@ -183,13 +187,13 @@ fi
 
 info "Rebooting fw0 (unclean shutdown — tests worst-case failover)"
 
-incus exec xpf-fw0 -- reboot 2>/dev/null || true
+incus exec "$FW0" -- reboot 2>/dev/null || true
 
 # Wait for fw1 to detect failure and become primary
 sleep 3
 
 # Verify iperf3 survived the failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived fw0 reboot (failover to fw1)"
 else
 	fail "iperf3 DIED during fw0 reboot — failover broke TCP connections"
@@ -201,7 +205,7 @@ info "Waiting for fw0 to reboot and rejoin as secondary (max ${REBOOT_WAIT}s)"
 
 fw0_back=false
 for i in $(seq 1 "$REBOOT_WAIT"); do
-	if wait_for_instance xpf-fw0 1; then
+	if wait_for_instance "$FW0" 1; then
 		fw0_back=true
 		info "fw0 xpfd active after ${i}s"
 		break
@@ -218,7 +222,7 @@ fi
 sleep 20
 
 # Verify fw0 is secondary (NOT primary — no auto-preempt)
-fw0_status_after=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status_after=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 if echo "$fw0_status_after" | grep -q "node0.*secondary"; then
 	pass "fw0 rejoined as secondary (no auto-preempt)"
 elif echo "$fw0_status_after" | grep -q "node0.*primary"; then
@@ -228,17 +232,17 @@ else
 fi
 
 # Verify fw1 is still primary
-if incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null | grep -q "node1.*primary"; then
+if incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null | grep -q "node1.*primary"; then
 	pass "fw1 remains primary after fw0 rejoin"
 else
 	fail "fw1 is not primary after fw0 rejoin"
 fi
 
 # Verify iperf3 still running
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived fw0 rejoin"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
 		pass "iperf3 completed successfully (finished before rejoin check)"
 	else
 		fail "iperf3 DIED during fw0 rejoin"
@@ -253,7 +257,7 @@ info "Manual failover: requesting fw1 to failover all RGs to fw0"
 # Each RG must be explicitly failed over — RG0 alone doesn't move RG1/RG2
 # because per-RG election is independent with non-preempt.
 for rg in 0 1 2; do
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
 done
 
 # Wait for failover to complete
@@ -262,7 +266,7 @@ sleep 5
 # Verify fw0 is now primary for ALL RGs
 all_primary=true
 for rg in 0 1 2; do
-	if ! incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null | grep -A1 "Redundancy group: $rg" | grep -q "node0.*primary"; then
+	if ! incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null | grep -A1 "Redundancy group: $rg" | grep -q "node0.*primary"; then
 		all_primary=false
 		fail "fw0 is not primary for RG$rg after manual failover"
 	fi
@@ -272,10 +276,10 @@ if $all_primary; then
 fi
 
 # Verify iperf3 survived manual failover
-if incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 	pass "iperf3 survived manual failover"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
 		pass "iperf3 completed successfully (finished before manual failover check)"
 	else
 		fail "iperf3 DIED during manual failover"
@@ -287,7 +291,7 @@ fi
 info "Waiting for iperf3 to complete"
 
 for i in $(seq 1 "$IPERF_DURATION"); do
-	if ! incus exec cluster-lan-host -- pgrep iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep iperf3 &>/dev/null; then
 		break
 	fi
 	sleep 1
@@ -298,15 +302,15 @@ done
 # streams survived — this produces "control socket has closed unexpectedly"
 # instead of "iperf Done". Accept either outcome as long as the sender
 # [SUM] line shows adequate throughput.
-throughput=$(incus exec cluster-lan-host -- grep '\[SUM\].*sender' /tmp/iperf3-failover.log 2>/dev/null \
+throughput=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' /tmp/iperf3-failover.log 2>/dev/null \
 	| grep -oP '[\d.]+\s+Gbits' | grep -oP '[\d.]+' || echo "0")
 
-if incus exec cluster-lan-host -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
 	pass "iperf3 completed successfully"
 elif [[ -n "$throughput" ]] && awk "BEGIN{exit !($throughput >= $MIN_THROUGHPUT)}"; then
 	pass "iperf3 data transfer completed (${throughput} Gbps) — control socket disrupted during failover"
 else
-	iperf_log=$(incus exec cluster-lan-host -- tail -5 /tmp/iperf3-failover.log 2>/dev/null || echo "(no log)")
+	iperf_log=$(incus exec "$CLUSTER_LAN_HOST" -- tail -5 /tmp/iperf3-failover.log 2>/dev/null || echo "(no log)")
 	fail "iperf3 did not complete: $iperf_log"
 fi
 

--- a/test/incus/test-ha-crash.sh
+++ b/test/incus/test-ha-crash.sh
@@ -4,8 +4,8 @@
 # Validates that the cluster recovers from hard VM crashes and daemon
 # failures — scenarios not covered by the clean-reboot failover test.
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   Phase 1: Hard VM stop (incus stop --force) — simulates kernel panic / power loss
@@ -40,7 +40,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_STREAMS=4
 CRASH_CYCLES="${CRASH_CYCLES:-3}"          # multi-cycle crash iterations
 TAKEOVER_TIMEOUT=5                          # max seconds for fw1 to take over
@@ -79,7 +83,7 @@ wait_for_xpfd() {
 # Check that fw1 is primary for all RGs (takeover detection)
 fw1_is_primary() {
 	local status
-	status=$(incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	status=$(incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	for rg in 0 1 2; do
 		if ! echo "$status" | grep -A2 "Redundancy group: $rg" | grep -q "node1.*primary"; then
 			return 1
@@ -91,7 +95,7 @@ fw1_is_primary() {
 # Check that fw0 is primary for all RGs
 fw0_is_primary() {
 	local status
-	status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	for rg in 0 1 2; do
 		if ! echo "$status" | grep -A2 "Redundancy group: $rg" | grep -q "node0.*primary"; then
 			return 1
@@ -117,8 +121,8 @@ wait_for_takeover() {
 check_no_dual_active() {
 	local label="$1"
 	local fw0_status fw1_status
-	fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
-	fw1_status=$(incus exec xpf-fw1 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	fw1_status=$(incus exec "$FW1" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 
 	local dual_active=false
 	for rg in 0 1 2; do
@@ -139,7 +143,7 @@ check_no_dual_active() {
 test_new_tcp() {
 	local label="$1" max="$2"
 	for i in $(seq 1 "$max"); do
-		if incus exec cluster-lan-host -- bash -c \
+		if incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 			"timeout 3 bash -c 'echo > /dev/tcp/${IPERF_TARGET}/5201'" 2>/dev/null; then
 			pass "$label: new TCP connection succeeded (${i}s)"
 			return 0
@@ -160,13 +164,13 @@ restore_fw0_primary() {
 	fi
 	# Reset manual failover flags
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 	sleep 1
 	# Manual failover all RGs to fw0 (from fw1 which is current primary)
 	for rg in 0 1 2; do
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
 	done
 	sleep 5
 	if fw0_is_primary; then
@@ -180,22 +184,22 @@ restore_fw0_primary() {
 
 cleanup() {
 	info "Cleanup: killing iperf3, resetting cluster state"
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	# Ensure fw0 is running
-	if ! instance_running xpf-fw0; then
-		incus start xpf-fw0 2>/dev/null || true
-		wait_for_xpfd xpf-fw0 "$VM_RESTART_WAIT" >/dev/null 2>&1 || true
+	if ! instance_running "$FW0"; then
+		incus start "$FW0" 2>/dev/null || true
+		wait_for_xpfd "$FW0" "$VM_RESTART_WAIT" >/dev/null 2>&1 || true
 	fi
 	# Ensure xpfd is running on fw0
-	incus exec xpf-fw0 -- systemctl start xpfd 2>/dev/null || true
+	incus exec "$FW0" -- systemctl start xpfd 2>/dev/null || true
 	sleep 5
 	# Clear stale sessions
-	incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 	# Reset failover flags
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 }
 
@@ -205,14 +209,14 @@ trap cleanup EXIT
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
 # Reset any stale manual failover flags
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
@@ -231,21 +235,21 @@ else
 fi
 
 # Kill any stale iperf3 and clear stale sessions from previous test runs
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
-incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 sleep 3
 
 # Pre-warm ARP on the primary firewall — bpf_fib_lookup returns NO_NEIGH
 # if no ARP entry exists, causing the first through-traffic packet to be slow
-incus exec xpf-fw0 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
-incus exec xpf-fw1 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+incus exec "$FW0" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+incus exec "$FW1" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
 sleep 1
 
 # Verify iperf target reachable (retry — ARP/NDP may need a few seconds after session clear)
 target_ok=false
 for i in $(seq 1 15); do
-	if incus exec cluster-lan-host -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null; then
 		target_ok=true
 		break
 	fi
@@ -265,18 +269,18 @@ info "Phase 1: Hard VM stop — simulating kernel panic / power loss"
 
 # Start iperf3
 info "Phase 1: Starting iperf3 -P${IPERF_STREAMS} → ${IPERF_TARGET}"
-incus exec cluster-lan-host -- bash -c \
+incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 	"iperf3 --forceflush --connect-timeout 5000 -t 120 -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > ${LOG} 2>&1 &"
 sleep 8
 
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	pass "phase1: iperf3 running"
 else
 	die "phase1: iperf3 failed to start"
 fi
 
 # Verify sessions on fw0
-fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+fw0_sessions=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_sessions" -ge "$IPERF_STREAMS" ]]; then
 	pass "phase1: fw0 has $fw0_sessions established sessions"
@@ -289,7 +293,7 @@ sleep 5
 
 # Force-stop fw0 — this is a hard kill, no graceful shutdown
 info "Phase 1: Force-stopping fw0 (incus stop --force)"
-incus stop --force xpf-fw0 2>/dev/null || true
+incus stop --force "$FW0" 2>/dev/null || true
 
 # Wait for fw1 to take over
 takeover_time=$(wait_for_takeover "$TAKEOVER_TIMEOUT" || true)
@@ -303,21 +307,21 @@ fi
 test_new_tcp "phase1" "$CONN_TIMEOUT"
 
 # Verify connectivity via ping
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "phase1: ping through fw1 works"
 else
 	fail "phase1: ping through fw1 failed"
 fi
 
 # Kill iperf3 from phase 1 (sessions are dead — fw0 hard-crashed)
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # Restart fw0
 info "Phase 1: Restarting fw0"
-incus start xpf-fw0 2>/dev/null || true
+incus start "$FW0" 2>/dev/null || true
 
-restart_time=$(wait_for_xpfd xpf-fw0 "$VM_RESTART_WAIT" || true)
+restart_time=$(wait_for_xpfd "$FW0" "$VM_RESTART_WAIT" || true)
 if [[ -n "$restart_time" ]]; then
 	pass "phase1: fw0 xpfd restarted (${restart_time}s)"
 else
@@ -328,7 +332,7 @@ fi
 sleep 10
 
 # Verify fw0 is secondary (no auto-preempt)
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw0_status" | grep -q "node0.*secondary"; then
 	pass "phase1: fw0 rejoined as secondary"
 else
@@ -347,13 +351,13 @@ sleep 5
 # server may hold the stale connection for up to 120s (TCP keepalive).
 # We must wait for it to become available.
 info "Phase 1→2 transition: clearing sessions, waiting for iperf3 server to be ready"
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
-incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 sleep 3
 # Wait for ping connectivity first
 for i in $(seq 1 30); do
-	if incus exec cluster-lan-host -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
 		break
 	fi
 	sleep 1
@@ -361,7 +365,7 @@ done
 # Then wait for iperf3 server to accept connections (TCP 5201)
 info "Phase 1→2: waiting for iperf3 server at ${IPERF_TARGET}:5201"
 for i in $(seq 1 120); do
-	if incus exec cluster-lan-host -- bash -c \
+	if incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"timeout 3 bash -c 'echo > /dev/tcp/${IPERF_TARGET}/5201'" 2>/dev/null; then
 		info "Phase 1→2: iperf3 server ready (${i}s)"
 		break
@@ -383,21 +387,21 @@ fi
 
 # Start iperf3
 info "Phase 2: Starting iperf3 -P${IPERF_STREAMS} → ${IPERF_TARGET}"
-incus exec cluster-lan-host -- bash -c \
+incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 	"iperf3 --forceflush --connect-timeout 5000 -t 120 -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > ${LOG} 2>&1 &"
 sleep 8
 
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	pass "phase2: iperf3 running"
 else
 	# Show the log to diagnose
-	incus exec cluster-lan-host -- cat ${LOG} 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- cat ${LOG} 2>/dev/null || true
 	die "phase2: iperf3 failed to start"
 fi
 
 # Stop xpfd on fw0 (fail-closed: clears rg_active, tears down BPF)
 info "Phase 2: Stopping xpfd on fw0 (systemctl stop)"
-incus exec xpf-fw0 -- systemctl stop xpfd 2>/dev/null || true
+incus exec "$FW0" -- systemctl stop xpfd 2>/dev/null || true
 
 # Wait for fw1 to take over
 takeover_time=$(wait_for_takeover "$TAKEOVER_TIMEOUT" || true)
@@ -411,21 +415,21 @@ fi
 test_new_tcp "phase2" "$CONN_TIMEOUT"
 
 # Verify connectivity via ping
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "phase2: ping through fw1 works"
 else
 	fail "phase2: ping through fw1 failed"
 fi
 
 # Kill iperf3 from phase 2
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # Restart xpfd on fw0
 info "Phase 2: Restarting xpfd on fw0"
-incus exec xpf-fw0 -- systemctl start xpfd 2>/dev/null || true
+incus exec "$FW0" -- systemctl start xpfd 2>/dev/null || true
 
-restart_time=$(wait_for_xpfd xpf-fw0 "$DAEMON_RESTART_WAIT" || true)
+restart_time=$(wait_for_xpfd "$FW0" "$DAEMON_RESTART_WAIT" || true)
 if [[ -n "$restart_time" ]]; then
 	pass "phase2: xpfd restarted (${restart_time}s)"
 else
@@ -436,7 +440,7 @@ fi
 sleep 10
 
 # Verify fw0 is secondary
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 if echo "$fw0_status" | grep -q "node0.*secondary"; then
 	pass "phase2: fw0 rejoined as secondary after daemon restart"
 else
@@ -452,12 +456,12 @@ sleep 5
 
 # Wait for connectivity to stabilize after phase 2
 info "Phase 2→3 transition: clearing sessions and waiting for connectivity"
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
-incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 sleep 3
 for i in $(seq 1 30); do
-	if incus exec cluster-lan-host -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
 		break
 	fi
 	sleep 1
@@ -465,7 +469,7 @@ done
 # Wait for iperf3 server to release stale client
 info "Phase 2→3: waiting for iperf3 server at ${IPERF_TARGET}:5201"
 for i in $(seq 1 120); do
-	if incus exec cluster-lan-host -- bash -c \
+	if incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"timeout 3 bash -c 'echo > /dev/tcp/${IPERF_TARGET}/5201'" 2>/dev/null; then
 		info "Phase 2→3: iperf3 server ready (${i}s)"
 		break
@@ -493,7 +497,7 @@ for cycle in $(seq 1 "$CRASH_CYCLES"); do
 	# Verify connectivity before crash (retry a few times)
 	pre_crash_ok=false
 	for i in $(seq 1 10); do
-		if incus exec cluster-lan-host -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
+		if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
 			pre_crash_ok=true
 			break
 		fi
@@ -506,7 +510,7 @@ for cycle in $(seq 1 "$CRASH_CYCLES"); do
 	fi
 
 	# Force-stop fw0
-	incus stop --force xpf-fw0 2>/dev/null || true
+	incus stop --force "$FW0" 2>/dev/null || true
 
 	# Measure takeover time
 	takeover_time=$(wait_for_takeover "$TAKEOVER_TIMEOUT" || true)
@@ -521,8 +525,8 @@ for cycle in $(seq 1 "$CRASH_CYCLES"); do
 	test_new_tcp "phase3-cycle${cycle}" "$CONN_TIMEOUT" || cycle_failures=$((cycle_failures + 1))
 
 	# Restart fw0
-	incus start xpf-fw0 2>/dev/null || true
-	restart_time=$(wait_for_xpfd xpf-fw0 "$VM_RESTART_WAIT" || true)
+	incus start "$FW0" 2>/dev/null || true
+	restart_time=$(wait_for_xpfd "$FW0" "$VM_RESTART_WAIT" || true)
 	if [[ -n "$restart_time" ]]; then
 		pass "phase3-cycle${cycle}: fw0 restarted (${restart_time}s)"
 	else
@@ -539,7 +543,7 @@ for cycle in $(seq 1 "$CRASH_CYCLES"); do
 
 	# Verify fw0 is in cluster (primary or secondary — after rapid
 	# force-stop cycles, election may resolve either way)
-	fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	if echo "$fw0_status" | grep -q "node0.*secondary"; then
 		pass "phase3-cycle${cycle}: fw0 rejoined as secondary"
 	elif echo "$fw0_status" | grep -q "node0.*primary"; then
@@ -553,11 +557,11 @@ for cycle in $(seq 1 "$CRASH_CYCLES"); do
 	if [[ "$cycle" -lt "$CRASH_CYCLES" ]]; then
 		restore_fw0_primary "phase3-cycle${cycle}" || true
 		# Clear stale sessions and wait for connectivity
-		incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 		sleep 3
 		for i in $(seq 1 15); do
-			if incus exec cluster-lan-host -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
+			if incus exec "$CLUSTER_LAN_HOST" -- ping -c 1 -W 2 "$IPERF_TARGET" &>/dev/null; then
 				break
 			fi
 			sleep 1
@@ -576,12 +580,12 @@ fi
 info "Final health checks"
 
 # Clear stale sessions before final connectivity check
-incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
-incus exec xpf-fw1 -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
+incus exec "$FW1" -- cli -c "clear security flow session all" 2>/dev/null || true
 sleep 3
 
 # Ensure both nodes are running
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	if ! instance_running "$inst"; then
 		# Try to start it
 		incus start "$inst" 2>/dev/null || true
@@ -595,7 +599,7 @@ for inst in xpf-fw0 xpf-fw1; do
 done
 
 # Ensure xpfd active on both (wait briefly for late starters)
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	xpfd_ok=false
 	for i in $(seq 1 15); do
 		if incus exec "$inst" -- systemctl is-active --quiet xpfd 2>/dev/null; then
@@ -612,7 +616,7 @@ for inst in xpf-fw0 xpf-fw1; do
 done
 
 # Verify connectivity
-if incus exec cluster-lan-host -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 "$IPERF_TARGET" &>/dev/null; then
 	pass "final: connectivity OK"
 else
 	fail "final: connectivity lost"

--- a/test/incus/test-private-rg.sh
+++ b/test/incus/test-private-rg.sh
@@ -5,8 +5,8 @@
 # interfaces, using only the heartbeat control link for RG election.
 #
 # Prerequisites:
-#   - Cluster VMs running (make cluster-create)
-#   - iperf3 server at 172.16.100.200 (hades)
+#   - Cluster VMs from BPFRX_CLUSTER_ENV running (make cluster-create)
+#   - iperf3 server at IPERF_TARGET4
 #
 # Usage:
 #   ./test/incus/test-private-rg.sh              # Full test (enable, test, disable, test)
@@ -23,8 +23,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-CONF="${PROJECT_ROOT}/docs/ha-cluster.conf"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+CONF="${CLUSTER_CONF:-${PROJECT_ROOT}/docs/ha-cluster.conf}"
 
 PASS=0
 FAIL=0
@@ -39,8 +42,8 @@ wait_cluster_ready() {
 	local max_wait=30
 	local i=0
 	while [[ $i -lt $max_wait ]]; do
-		if incus exec xpf-fw0 -- systemctl is-active --quiet xpfd 2>/dev/null &&
-		   incus exec xpf-fw1 -- systemctl is-active --quiet xpfd 2>/dev/null; then
+		if incus exec "$FW0" -- systemctl is-active --quiet xpfd 2>/dev/null &&
+		   incus exec "$FW1" -- systemctl is-active --quiet xpfd 2>/dev/null; then
 			sleep 5  # Allow election to settle
 			return 0
 		fi
@@ -55,15 +58,15 @@ wait_cluster_ready() {
 check_no_vrrp_multicast() {
 	info "Checking for VRRP multicast on data interfaces..."
 	local count
-	count=$(incus exec xpf-fw0 -- timeout 3 tcpdump -c 1 -i ge-0-0-1 vrrp 2>&1 | grep -c "packet" || echo "0")
+	count=$(incus exec "$FW0" -- timeout 3 tcpdump -c 1 -i ge-0-0-1 vrrp 2>&1 | grep -c "packet" || echo "0")
 	# tcpdump reports "0 packets captured" if no VRRP seen
-	if incus exec xpf-fw0 -- timeout 3 tcpdump -c 1 -i ge-0-0-1 vrrp 2>&1 | grep -q "0 packets captured"; then
+	if incus exec "$FW0" -- timeout 3 tcpdump -c 1 -i ge-0-0-1 vrrp 2>&1 | grep -q "0 packets captured"; then
 		pass "No VRRP multicast on ge-0-0-1 (WAN)"
 	else
 		fail "VRRP multicast detected on ge-0-0-1 (WAN)"
 	fi
 
-	if incus exec xpf-fw0 -- timeout 3 tcpdump -c 1 -i ge-0-0-0 vrrp 2>&1 | grep -q "0 packets captured"; then
+	if incus exec "$FW0" -- timeout 3 tcpdump -c 1 -i ge-0-0-0 vrrp 2>&1 | grep -q "0 packets captured"; then
 		pass "No VRRP multicast on ge-0-0-0 (LAN)"
 	else
 		fail "VRRP multicast detected on ge-0-0-0 (LAN)"
@@ -73,7 +76,7 @@ check_no_vrrp_multicast() {
 check_vrrp_active() {
 	info "Checking VRRP instances are running..."
 	local log
-	log=$(incus exec xpf-fw0 -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
+	log=$(incus exec "$FW0" -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
 
 	if echo "$log" | grep -q "vrrp: instance starting"; then
 		pass "VRRP instances started on fw0"
@@ -91,7 +94,7 @@ check_vrrp_active() {
 check_no_vrrp_instances() {
 	info "Checking VRRP instances are NOT running (private-rg mode)..."
 	local log
-	log=$(incus exec xpf-fw0 -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
+	log=$(incus exec "$FW0" -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
 
 	if echo "$log" | grep -q "vrrp: instance starting"; then
 		fail "VRRP instances running in private-rg mode"
@@ -103,21 +106,21 @@ check_no_vrrp_instances() {
 check_vips_present() {
 	info "Checking VIPs are present..."
 	local addrs
-	addrs=$(incus exec xpf-fw0 -- ip addr show 2>/dev/null)
+	addrs=$(incus exec "$FW0" -- ip addr show 2>/dev/null)
 
-	if echo "$addrs" | grep -q "172.16.50.6"; then
-		pass "WAN VIP 172.16.50.6 present"
+	if echo "$addrs" | grep -q "$WAN_VIP4"; then
+		pass "WAN VIP ${WAN_VIP4} present"
 	else
-		fail "WAN VIP 172.16.50.6 missing"
+		fail "WAN VIP ${WAN_VIP4} missing"
 	fi
 
-	if echo "$addrs" | grep -q "10.0.60.1"; then
-		pass "LAN VIP 10.0.60.1 present"
+	if echo "$addrs" | grep -q "$LAN_VIP4"; then
+		pass "LAN VIP ${LAN_VIP4} present"
 	else
-		fail "LAN VIP 10.0.60.1 missing"
+		fail "LAN VIP ${LAN_VIP4} missing"
 	fi
 
-	if echo "$addrs" | grep -q "2001:559:8585:cf01::1"; then
+	if echo "$addrs" | grep -q "$LAN_VIP6"; then
 		pass "LAN VIP IPv6 present"
 	else
 		fail "LAN VIP IPv6 missing"
@@ -126,34 +129,34 @@ check_vips_present() {
 
 check_connectivity() {
 	info "Checking connectivity from LAN host..."
-	if ! incus info cluster-lan-host &>/dev/null 2>&1; then
-		warn "cluster-lan-host not running, skipping connectivity"
+	if ! incus info "$CLUSTER_LAN_HOST" &>/dev/null 2>&1; then
+		warn "${CLUSTER_LAN_HOST} not running, skipping connectivity"
 		return
 	fi
 
 	# IPv4 ping to VIP
-	if incus exec cluster-lan-host -- ping -c 3 -W 2 10.0.60.1 &>/dev/null; then
-		pass "LAN host → RETH VIP 10.0.60.1 ping"
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 2 "$LAN_VIP4" &>/dev/null; then
+		pass "LAN host → RETH VIP ${LAN_VIP4} ping"
 	else
-		fail "LAN host → RETH VIP 10.0.60.1 ping"
+		fail "LAN host → RETH VIP ${LAN_VIP4} ping"
 	fi
 
 	# IPv6 ping to VIP
-	if incus exec cluster-lan-host -- ping6 -c 3 -W 2 2001:559:8585:cf01::1 &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping6 -c 3 -W 2 "$LAN_VIP6" &>/dev/null; then
 		pass "LAN host → RETH VIP IPv6 ping"
 	else
 		fail "LAN host → RETH VIP IPv6 ping"
 	fi
 
 	# IPv4 cross-zone
-	if incus exec cluster-lan-host -- ping -c 3 -W 2 172.16.50.1 &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 2 "$WAN_GW4" &>/dev/null; then
 		pass "LAN host → WAN gateway cross-zone"
 	else
 		fail "LAN host → WAN gateway cross-zone"
 	fi
 
 	# Internet
-	if incus exec cluster-lan-host -- ping -c 3 -W 3 1.1.1.1 &>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 3 1.1.1.1 &>/dev/null; then
 		pass "LAN host → internet (1.1.1.1)"
 	else
 		fail "LAN host → internet (1.1.1.1)"
@@ -163,27 +166,27 @@ check_connectivity() {
 check_manual_failover() {
 	info "Testing manual failover..."
 	# Failover RG1 to node1
-	incus exec xpf-fw0 -- bash -c "echo 'request chassis cluster failover redundancy-group 1 node 1' | xpfd cli" &>/dev/null 2>&1 || true
+	incus exec "$FW0" -- bash -c "echo 'request chassis cluster failover redundancy-group 1 node 1' | xpfd cli" &>/dev/null 2>&1 || true
 	sleep 3
 
 	# Check VIPs moved to fw1
 	local fw1_addrs
-	fw1_addrs=$(incus exec xpf-fw1 -- ip addr show 2>/dev/null)
-	if echo "$fw1_addrs" | grep -q "172.16.50.6"; then
+	fw1_addrs=$(incus exec "$FW1" -- ip addr show 2>/dev/null)
+	if echo "$fw1_addrs" | grep -q "$WAN_VIP4"; then
 		pass "Manual failover: VIP moved to fw1"
 	else
 		fail "Manual failover: VIP not on fw1"
 	fi
 
 	# Check connectivity still works
-	if incus exec cluster-lan-host -- ping -c 3 -W 2 172.16.50.1 &>/dev/null 2>&1; then
+	if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 2 "$WAN_GW4" &>/dev/null 2>&1; then
 		pass "Manual failover: connectivity preserved"
 	else
 		fail "Manual failover: connectivity lost"
 	fi
 
 	# Reset failover
-	incus exec xpf-fw0 -- bash -c "echo 'request chassis cluster failover reset redundancy-group 1' | xpfd cli" &>/dev/null 2>&1 || true
+	incus exec "$FW0" -- bash -c "echo 'request chassis cluster failover reset redundancy-group 1' | xpfd cli" &>/dev/null 2>&1 || true
 	sleep 5
 }
 
@@ -245,7 +248,7 @@ main() {
 			;;
 		check)
 			local log
-			log=$(incus exec xpf-fw0 -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
+			log=$(incus exec "$FW0" -- journalctl -u xpfd --no-pager -n 100 2>/dev/null)
 			if echo "$log" | grep -q "vrrp: instance starting"; then
 				info "Mode: VRRP (standard)"
 			else

--- a/test/incus/test-restart-connectivity.sh
+++ b/test/incus/test-restart-connectivity.sh
@@ -5,8 +5,8 @@
 # connectivity loss. This tests the fix for #75 — neighbor prewarm
 # must run after VRRP MASTER (not before VIPs are installed).
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   1. Verify baseline connectivity from cluster-lan-host → IPERF_TARGET
@@ -27,7 +27,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 RESTART_CYCLES="${RESTART_CYCLES:-3}"
 MAX_LOST_PINGS="${MAX_LOST_PINGS:-2}"       # allow 1-2 for VRRP transition
 PING_COUNT=40                                # pings per cycle (0.5s interval = 20s)
@@ -53,7 +57,7 @@ instance_running() {
 
 fw0_is_primary() {
 	local status
-	status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null || true)
+	status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null || true)
 	for rg in 0 1 2; do
 		if ! echo "$status" | grep -A2 "Redundancy group: $rg" | grep -q "node0.*primary"; then
 			return 1
@@ -68,12 +72,12 @@ restore_fw0_primary() {
 		return 0
 	fi
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 	sleep 1
 	for rg in 0 1 2; do
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover redundancy-group $rg" 2>/dev/null || true
 	done
 	sleep 5
 	if fw0_is_primary; then
@@ -86,14 +90,14 @@ restore_fw0_primary() {
 }
 
 cleanup() {
-	incus exec cluster-lan-host -- pkill -9 ping 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 ping 2>/dev/null || true
 	# Ensure fw0 xpfd is running
-	incus exec xpf-fw0 -- systemctl start xpfd 2>/dev/null || true
+	incus exec "$FW0" -- systemctl start xpfd 2>/dev/null || true
 	sleep 5
 	# Reset failover flags
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 }
 
@@ -103,11 +107,11 @@ trap cleanup EXIT
 
 info "Preflight checks"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	if ! incus exec "$inst" -- systemctl is-active --quiet xpfd 2>/dev/null; then
 		die "xpfd not active on $inst"
 	fi
@@ -122,11 +126,11 @@ else
 fi
 
 # Pre-warm ARP
-incus exec xpf-fw0 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+incus exec "$FW0" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
 sleep 1
 
 # Verify baseline connectivity
-if incus exec cluster-lan-host -- ping -c 3 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "baseline connectivity OK ($IPERF_TARGET)"
 else
 	die "no baseline connectivity to $IPERF_TARGET from cluster-lan-host"
@@ -140,24 +144,24 @@ for cycle in $(seq 1 "$RESTART_CYCLES"); do
 	info "Cycle ${cycle}/${RESTART_CYCLES}: restart xpfd on fw0 while pinging"
 
 	# Clear stale sessions
-	incus exec xpf-fw0 -- cli -c "clear security flow session all" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "clear security flow session all" 2>/dev/null || true
 	sleep 1
 
 	# Start continuous ping in background on lan-host
-	incus exec cluster-lan-host -- bash -c \
+	incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 		"ping -c ${PING_COUNT} -i ${PING_INTERVAL} ${IPERF_TARGET} > ${PING_LOG} 2>&1 &"
 
 	# Wait for a few pings to succeed before restart (3s)
 	sleep 3
 
 	# Restart xpfd on fw0
-	incus exec xpf-fw0 -- systemctl restart xpfd 2>/dev/null || true
+	incus exec "$FW0" -- systemctl restart xpfd 2>/dev/null || true
 
 	# Wait for ping to finish (~22s total ping time minus 3s pre-restart + 5s buffer)
 	sleep 22
 
 	# Parse ping results
-	ping_output=$(incus exec cluster-lan-host -- cat "$PING_LOG" 2>/dev/null || true)
+	ping_output=$(incus exec "$CLUSTER_LAN_HOST" -- cat "$PING_LOG" 2>/dev/null || true)
 	transmitted=$(echo "$ping_output" | grep -oP '\d+ packets transmitted' | grep -oP '^\d+' || echo "0")
 	received=$(echo "$ping_output" | grep -oP '\d+ received' | grep -oP '^\d+' || echo "0")
 	lost=$((transmitted - received))
@@ -180,7 +184,7 @@ for cycle in $(seq 1 "$RESTART_CYCLES"); do
 	fi
 
 	# Pre-warm ARP for next cycle
-	incus exec xpf-fw0 -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
+	incus exec "$FW0" -- ping -c 1 -W 3 "$IPERF_TARGET" &>/dev/null || true
 	sleep 1
 done
 
@@ -188,7 +192,7 @@ done
 
 info "Final health checks"
 
-for inst in xpf-fw0 xpf-fw1; do
+for inst in "$FW0" "$FW1"; do
 	if incus exec "$inst" -- systemctl is-active --quiet xpfd 2>/dev/null; then
 		pass "final: xpfd active on $inst"
 	else
@@ -196,7 +200,7 @@ for inst in xpf-fw0 xpf-fw1; do
 	fi
 done
 
-if incus exec cluster-lan-host -- ping -c 3 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 3 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "final: connectivity OK"
 else
 	fail "final: connectivity lost"

--- a/test/incus/test-stress-failover.sh
+++ b/test/incus/test-stress-failover.sh
@@ -8,8 +8,8 @@
 # through dual-inactive windows, RST→CLOSED bugs, and txqueuelen drops.
 # This test codifies the stress scenario as a permanent regression gate.
 #
-# Requires: xpf-fw0, xpf-fw1, cluster-lan-host running.
-# Requires: iperf3 server reachable at IPERF_TARGET (default 172.16.100.200).
+# Requires: cluster nodes from BPFRX_CLUSTER_ENV running (default: loss userspace cluster).
+# Requires: iperf3 server reachable at IPERF_TARGET (default from IPERF_TARGET4).
 #
 # Tests:
 #   1. Start iperf3 through the firewall (LAN host → WAN target)
@@ -32,7 +32,11 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-IPERF_TARGET="${IPERF_TARGET:-172.16.100.200}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/incus/cluster-env.sh
+source "${SCRIPT_DIR}/cluster-env.sh"
+
+IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_STREAMS="${IPERF_STREAMS:-8}"
 FAILOVER_INTERVAL="${FAILOVER_INTERVAL:-60}"   # seconds between failovers
 TOTAL_CYCLES="${TOTAL_CYCLES:-10}"
@@ -63,13 +67,13 @@ check_streams() {
 	local label="$1"
 	local tail_lines=$(( IPERF_STREAMS * 2 + 5 ))
 	local per_stream
-	per_stream=$(incus exec cluster-lan-host -- \
+	per_stream=$(incus exec "$CLUSTER_LAN_HOST" -- \
 		tail -${tail_lines} "$LOG" 2>/dev/null \
 		| grep -E '^\[  [0-9]|^\[ [0-9][0-9]' | tail -"$IPERF_STREAMS")
 	local dead
 	dead=$(echo "$per_stream" | grep -c "0.00 bits/sec" || true)
 	local sum
-	sum=$(incus exec cluster-lan-host -- \
+	sum=$(incus exec "$CLUSTER_LAN_HOST" -- \
 		tail -${tail_lines} "$LOG" 2>/dev/null \
 		| grep 'SUM' | tail -1 || true)
 	local bps
@@ -85,14 +89,14 @@ check_streams() {
 
 cleanup() {
 	info "Cleanup: killing iperf3, resetting failover flags"
-	incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 	for rg in 0 1 2; do
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-		incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+		incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 	done
 	# With preempt=false, resetting the flag alone doesn't move VRRP.
 	# Explicitly request RG1 back to fw0 so the next test starts clean.
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
 	sleep 2
 }
 
@@ -103,29 +107,29 @@ trap cleanup EXIT
 info "Preflight checks"
 info "Config: ${TOTAL_CYCLES} cycles, ${FAILOVER_INTERVAL}s interval, ${IPERF_STREAMS} streams, ${IPERF_DURATION}s iperf3 duration"
 
-for inst in xpf-fw0 xpf-fw1 cluster-lan-host; do
+for inst in "$FW0" "$FW1" "$CLUSTER_LAN_HOST"; do
 	instance_running "$inst" || die "$inst is not running"
 done
 
 # Reset any stale manual failover flags from previous test runs.
 for rg in 0 1 2; do
-	incus exec xpf-fw0 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW0" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
+	incus exec "$FW1" -- cli -c "request chassis cluster failover reset redundancy-group $rg" 2>/dev/null || true
 done
 sleep 2
 
 # Ensure all RGs are on fw0
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 for rg in 0 1 2; do
 	rg_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: $rg" | grep "node0" | grep -c "primary" || true)
 	if [[ "$rg_primary" -ne 1 ]]; then
-		incus exec xpf-fw0 -- cli -c "request chassis cluster failover redundancy-group $rg node 0" 2>/dev/null || true
+		incus exec "$FW0" -- cli -c "request chassis cluster failover redundancy-group $rg node 0" 2>/dev/null || true
 	fi
 done
 sleep 3
 
 # Verify fw0 is primary for all RGs
-fw0_status=$(incus exec xpf-fw0 -- cli -c 'show chassis cluster status' 2>/dev/null)
+fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
 all_primary=true
 for rg in 0 1 2; do
 	rg_primary=$(echo "$fw0_status" | grep -A2 "Redundancy group: $rg" | grep "node0" | grep -c "primary" || true)
@@ -141,35 +145,35 @@ else
 fi
 
 # Verify iperf target reachable
-if incus exec cluster-lan-host -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null; then
 	pass "iperf3 target reachable ($IPERF_TARGET)"
 else
 	die "Cannot reach iperf3 target $IPERF_TARGET from cluster-lan-host"
 fi
 
 # Kill any stale iperf3
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # ── Phase 1: Start iperf3 ───────────────────────────────────────────
 
 info "Phase 1: Starting iperf3 -P${IPERF_STREAMS} -t${IPERF_DURATION} → ${IPERF_TARGET}"
 
-incus exec cluster-lan-host -- bash -c \
+incus exec "$CLUSTER_LAN_HOST" -- bash -c \
 	"iperf3 --forceflush --connect-timeout 5000 -t ${IPERF_DURATION} -c ${IPERF_TARGET} -P ${IPERF_STREAMS} > ${LOG} 2>&1 &"
 
 sleep 8  # all parallel streams must be fully established
 
 # Verify iperf3 is running
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	pass "iperf3 running on cluster-lan-host"
 else
-	incus exec cluster-lan-host -- cat "$LOG" 2>/dev/null || true
+	incus exec "$CLUSTER_LAN_HOST" -- cat "$LOG" 2>/dev/null || true
 	die "iperf3 failed to start"
 fi
 
 # Verify sessions exist on fw0
-fw0_sessions=$(incus exec xpf-fw0 -- cli -c \
+fw0_sessions=$(incus exec "$FW0" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw0_sessions" -ge "$IPERF_STREAMS" ]]; then
 	pass "fw0 has $fw0_sessions established sessions"
@@ -182,7 +186,7 @@ fi
 info "Phase 2: Waiting ${SYNC_WAIT}s for session sync to fw1"
 sleep "$SYNC_WAIT"
 
-fw1_sessions=$(incus exec xpf-fw1 -- cli -c \
+fw1_sessions=$(incus exec "$FW1" -- cli -c \
 	"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
 if [[ "$fw1_sessions" -ge "$IPERF_STREAMS" ]]; then
 	pass "fw1 has $fw1_sessions synced sessions"
@@ -201,7 +205,7 @@ for cycle in $(seq 1 "$TOTAL_CYCLES"); do
 	info "Cycle ${cycle}/${TOTAL_CYCLES}: failover RG1 fw0→fw1"
 
 	# Failover RG1 to fw1
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1' 2>/dev/null || true
 
 	sleep "$half_interval"
 
@@ -211,7 +215,7 @@ for cycle in $(seq 1 "$TOTAL_CYCLES"); do
 	fi
 
 	# Check iperf3 still alive
-	if ! incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 		fail "cycle ${cycle}: iperf3 died after failover"
 		cycle_failed=true
 		break
@@ -220,9 +224,9 @@ for cycle in $(seq 1 "$TOTAL_CYCLES"); do
 	info "Cycle ${cycle}/${TOTAL_CYCLES}: failback RG1 fw1→fw0"
 
 	# Failback RG1 to fw0
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
-	incus exec xpf-fw1 -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
-	incus exec xpf-fw0 -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
+	incus exec "$FW1" -- cli -c 'request chassis cluster failover reset redundancy-group 1' 2>/dev/null || true
+	incus exec "$FW0" -- cli -c 'request chassis cluster failover redundancy-group 1 node 0' 2>/dev/null || true
 
 	sleep "$half_interval"
 
@@ -232,7 +236,7 @@ for cycle in $(seq 1 "$TOTAL_CYCLES"); do
 	fi
 
 	# Check iperf3 still alive
-	if ! incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+	if ! incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 		fail "cycle ${cycle}: iperf3 died after failback"
 		cycle_failed=true
 		break
@@ -248,10 +252,10 @@ fi
 info "Phase 4: Final validation"
 
 # Verify iperf3 still running
-if incus exec cluster-lan-host -- pgrep -x iperf3 &>/dev/null; then
+if incus exec "$CLUSTER_LAN_HOST" -- pgrep -x iperf3 &>/dev/null; then
 	pass "iperf3 still running after all cycles"
 else
-	if incus exec cluster-lan-host -- grep -q "iperf Done" "$LOG" 2>/dev/null; then
+	if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" "$LOG" 2>/dev/null; then
 		pass "iperf3 completed successfully (finished during cycles)"
 	else
 		fail "iperf3 died during stress test"
@@ -261,7 +265,7 @@ fi
 # Count total zero-throughput intervals across the full log.
 # Allow up to 1 per cycle — brief pauses during VRRP transitions are expected
 # (iperf3 reports in 1s intervals; a 60ms failover can cause a 0-byte interval).
-total_zero=$(incus exec cluster-lan-host -- \
+total_zero=$(incus exec "$CLUSTER_LAN_HOST" -- \
 	grep -E '^\[  [0-9]|^\[ [0-9][0-9]' "$LOG" 2>/dev/null \
 	| grep -c "0.00 bits/sec" || true)
 max_zero="$TOTAL_CYCLES"
@@ -274,11 +278,11 @@ else
 fi
 
 # Kill iperf3 — we have all the data we need
-incus exec cluster-lan-host -- pkill -9 iperf3 2>/dev/null || true
+incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
 sleep 1
 
 # Extract throughput from the last SUM line (iperf3 may still be running)
-last_sum=$(incus exec cluster-lan-host -- grep 'SUM' "$LOG" 2>/dev/null | tail -1 || true)
+last_sum=$(incus exec "$CLUSTER_LAN_HOST" -- grep 'SUM' "$LOG" 2>/dev/null | tail -1 || true)
 throughput=""
 if echo "$last_sum" | grep -qiE "[0-9.]+ Gbits"; then
 	throughput=$(echo "$last_sum" | grep -oiE "[0-9.]+ Gbits" | grep -oP '[\d.]+')

--- a/testing-docs/README.md
+++ b/testing-docs/README.md
@@ -34,14 +34,13 @@ cd userspace-dp && cargo test      # 356 Rust tests
 make test-deploy                   # Build + deploy to xpf-fw
 make test-ssh                      # Shell into VM
 
-# HA Cluster (eBPF)
-make cluster-deploy                # Deploy to xpf-fw0 + xpf-fw1
+# HA Cluster (default: loss userspace)
+make cluster-deploy                # Deploy to xpf-userspace-fw0 + xpf-userspace-fw1
 make test-failover                 # Reboot fw0 during iperf3
 make test-ha-crash                 # Force-stop/daemon-stop/multi-cycle
 
-# Userspace HA Cluster
-BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env \
-  ./test/incus/cluster-setup.sh deploy all
+# Explicit userspace HA Cluster invocation
+make userspace-cluster-deploy
 scripts/userspace-ha-validation.sh           # Full validation suite
 scripts/userspace-ha-failover-validation.sh  # Failover-specific
 scripts/userspace-native-gre-validation.sh   # Native GRE transit/failover

--- a/testing-docs/regression-checklist.md
+++ b/testing-docs/regression-checklist.md
@@ -37,7 +37,7 @@ Pre-commit validation checklist. Check the boxes that apply to your change.
 
 ## If You Changed Cluster / VRRP / Session Sync
 
-- [ ] `make cluster-deploy` — deploy to eBPF cluster
+- [ ] `make cluster-deploy` — deploy to canonical loss userspace cluster
 - [ ] `make test-failover` — **MANDATORY** per CLAUDE.md
 - [ ] `make test-ha-crash` — crash recovery works
 - [ ] Session sync: `show security flow session` on secondary shows synced sessions


### PR DESCRIPTION
## Summary
- Make `cluster-*` and HA validation Makefile targets default to `test/incus/loss-userspace-cluster.env`.
- Add explicit `userspace-cluster-*` aliases and keep `loss-cluster-*` as legacy aliases.
- Add shared `test/incus/cluster-env.sh` so HA scripts derive FW/LAN/target names from the selected env file.
- Leave destructive removals of old targets/fixtures for separate PRs.

## Validation
- `bash -n test/incus/cluster-env.sh test/incus/cluster-setup.sh test/incus/test-connectivity.sh test/incus/test-failover.sh test/incus/test-double-failover.sh test/incus/test-active-active.sh test/incus/test-stress-failover.sh test/incus/test-ha-crash.sh test/incus/test-chained-crash.sh test/incus/test-restart-connectivity.sh test/incus/test-private-rg.sh`
- `git diff --check`
- `make -n cluster-status userspace-cluster-status loss-cluster-status test-failover test-ha-crash test-restart-connectivity`

Refs #1373
