### PR TITLE
userspace: expand buffer status pressure reporting

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
@@ -14,6 +14,12 @@ session summaries with the same operator utility as the legacy path.
 - #1386 restores the immediate userspace `show system buffers` parity gaps:
   active-session footer, detail/non-detail distinction, and fallback from sparse
   per-binding capacity gauges to binding-level status.
+- Follow-up implementation after #1386 widens the shared formatter to include
+  all bounded buffer surfaces already present on the helper status wire: AF_XDP
+  UMEM/TX rings plus class-of-service queued-byte capacity. It also adds an
+  unbounded status-counter section for neighbor entries, active flow-cache
+  counts, flow-cache collision evictions, fill/TX ring saturation, pending-TX
+  gauges, and worker queue overflow/drop attribution.
 
 ## Design
 
@@ -26,6 +32,15 @@ for `show system buffers detail`.
 If mixed-version helpers omit a newer capacity surface, Go must fall back to the
 older binding fields or clearly mark the row unavailable. It must not display
 zero capacity for a live binding unless the helper explicitly reported zero.
+
+The current helper status does not publish capacity denominators for the
+session table, dynamic neighbor cache, or per-worker flow cache. `show system
+buffers` therefore reports active sessions through the existing footer and
+renders neighbor/flow-cache pressure as counts/counters, not fill percentages.
+Adding true fill rows for those structures requires new optional helper fields
+such as `session_table_entries/max_sessions`, `flow_cache_capacity`, and
+`neighbor_cache_capacity`; Go must not hard-code Rust private constants to infer
+those denominators.
 
 ## Hot-Path Invariants
 
@@ -46,6 +61,9 @@ zero capacity for a live binding unless the helper explicitly reported zero.
 
 - False-zero capacity: missing fields rendered as zero can hide a compatibility
   problem and send operators chasing nonexistent ring exhaustion.
+- False fill percentages: session, flow-cache, or neighbor-cache counts without
+  matching denominators must remain counters until the helper publishes bounded
+  capacity fields.
 - Status drift: CLI, gRPC, and REST/metrics can diverge if they format different
   DTOs. Tests should use the same fixture through every output path.
 - Sampling cost: overly frequent ring introspection can perturb the hot path;
@@ -61,6 +79,8 @@ zero capacity for a live binding unless the helper explicitly reported zero.
   binding-level capacity instead of rendering false zeroes.
 - Go: gRPC `ShowText` and local CLI use the same userspace buffer fixture and
   produce equivalent text.
+- Go: formatter covers CoS queued-byte capacity plus existing helper pressure
+  counters without turning unbounded counts into utilization percentages.
 - Integration: userspace cluster under forwarding load shows nonzero AF_XDP
   capacities, stable active sessions, and no status command hang.
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -67,7 +67,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager still embeds the eBPF manager for many BPF-shaped map-writer methods; tracked by #1381 |
 | Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
-| `show system buffers` | Userspace helper-status rendering landed in #1386 for AF_XDP UMEM/TX capacity. #1380 still tracks the retirement gate for removing legacy BPF-map buffer reporting and settling the CLI / observability cleanup. |
+| `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, active-session footer, neighbor/flow-cache counts, and worker queue pressure counters. #1380 is narrowed to the Phase 5 cleanup decision about whether operators need new helper capacity denominators for session-table, flow-cache, or neighbor-cache fill percentages before the legacy BPF-map surface is removed. |
 
 ## Retirement Blockers From The 2026-05-16 Audit
 
@@ -82,7 +82,7 @@ The current #1373 audit produced these tracked blockers:
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent | Phase 4 BPF source removal |
 | #1375 | Implement userspace RFC 2697/2698 three-color policers | Phase 4 BPF source removal |
 | #1376 | Implement userspace port mirroring or explicitly retire the feature | Phase 4 BPF source removal |
-| #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface now that #1386 provides userspace helper-status reporting. | Phase 5 CLI / observability cleanup |
+| #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface. Userspace now renders the bounded helper status that exists; only optional new helper capacity denominators for session-table / flow-cache / neighbor-cache fill remain undecided. | Phase 5 CLI / observability cleanup |
 
 Recommended dependency order:
 
@@ -141,6 +141,7 @@ The highest-value remaining work on current `master` is:
    behavior, not full cross-backend parity. Keep #1378 open for the remaining
    policy-scheduler counter/validation/evidence contract after #1396.
 3. close #1374, #1375, and #1376 before any BPF source removal
-4. carry #1380 into the Phase 5 CLI / observability cleanup now that #1386
-   supplies userspace buffer rendering
+4. carry the narrowed #1380 denominator decision into Phase 5; the current
+   userspace command already avoids BPF-map fallback when helper status is
+   available
 5. continue correctness and performance hardening on the active AF_XDP fast path

--- a/pkg/cli/cli_show_system_buffers_test.go
+++ b/pkg/cli/cli_show_system_buffers_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+type systemBuffersCLIUserspaceDP struct {
+	*dataplane.Manager
+	status dpuserspace.ProcessStatus
+	v4     int
+	v6     int
+}
+
+func (f *systemBuffersCLIUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
+	return f.status, nil
+}
+
+func (f *systemBuffersCLIUserspaceDP) SessionCount() (int, int) {
+	return f.v4, f.v6
+}
+
+func TestShowSystemBuffersUsesSharedUserspaceFormatter(t *testing.T) {
+	c := &CLI{
+		dp: &systemBuffersCLIUserspaceDP{
+			Manager: dataplane.New(),
+			v4:      2,
+			v6:      1,
+			status: dpuserspace.ProcessStatus{
+				NeighborEntries: 8,
+				PerBinding: []dpuserspace.BindingCountersSnapshot{
+					{
+						WorkerID:                    1,
+						QueueID:                     2,
+						Ifindex:                     7,
+						UmemTotalFrames:             1000,
+						UmemInflightFrames:          500,
+						TxRingCapacity:              100,
+						OutstandingTX:               20,
+						ActiveFlowCount:             5,
+						FlowCacheCollisionEvictions: 3,
+						DbgTxRingFull:               4,
+					},
+				},
+			},
+		},
+	}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.showSystemBuffers()
+	})
+	if callErr != nil {
+		t.Fatalf("showSystemBuffers() error = %v", callErr)
+	}
+	for _, want := range []string{
+		"Userspace Buffer Utilization:",
+		"AF_XDP UMEM frames",
+		"AF_XDP TX ring",
+		"Userspace Status Counters:",
+		"Neighbor cache entries",
+		"Flow cache active flows",
+		"Flow cache collision evict",
+		"TX ring full events",
+		"Active sessions: 2 IPv4, 1 IPv6, 3 total",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("showSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "worker 1/queue 2") {
+		t.Fatalf("showSystemBuffers included detail scope:\n%s", out)
+	}
+	if strings.Contains(out, "No BPF maps available") {
+		t.Fatalf("showSystemBuffers fell back to BPF map output:\n%s", out)
+	}
+}

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -7,16 +7,30 @@ import (
 )
 
 type systemBufferSample struct {
-	Slot       uint32
-	HasSlot    bool
-	WorkerID   uint32
-	QueueID    uint32
-	Ifindex    int
-	Interface  string
-	UMEMCap    uint32
-	UMEMUsed   uint32
-	TXRingCap  uint32
-	TXRingUsed uint32
+	Slot                        uint32
+	HasSlot                     bool
+	WorkerID                    uint32
+	QueueID                     uint32
+	Ifindex                     int
+	Interface                   string
+	UMEMCap                     uint32
+	UMEMUsed                    uint32
+	TXRingCap                   uint32
+	TXRingUsed                  uint32
+	ActiveFlowCount             uint32
+	FlowCacheCollisionEvictions uint64
+	DebugPendingFillFrames      uint32
+	DebugSpareFillFrames        uint32
+	DebugPendingTXPrepared      uint32
+	DebugPendingTXLocal         uint32
+	DbgTxRingFull               uint64
+	DbgSendtoENOBUFS            uint64
+	DbgBoundPendingOverflow     uint64
+	DbgCoSQueueOverflow         uint64
+	RxFillRingEmptyDescs        uint64
+	RedirectInboxOverflowDrops  uint64
+	PendingTXLocalOverflowDrops uint64
+	TxSubmitErrorDrops          uint64
 }
 
 type systemBufferRow struct {
@@ -26,10 +40,16 @@ type systemBufferRow struct {
 	Used     uint64
 }
 
+type systemBufferCounterRow struct {
+	Name  string
+	Scope string
+	Value uint64
+}
+
 // FormatSystemBuffers renders userspace dataplane buffer capacity telemetry for
-// `show system buffers`. It only uses bounded AF_XDP gauges published in helper
-// status; if those gauges are absent, it reports the missing wire fields rather
-// than falling back to unrelated BPF map occupancy.
+// `show system buffers`. Capacity rows only use bounded gauges published in
+// helper status; unbounded helper counters/gauges render in a separate section
+// so missing denominators are not mistaken for real fill percentages.
 func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	samples := systemBufferSamples(status)
 	var umemCap, umemUsed, txCap, txUsed uint64
@@ -64,6 +84,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 			Used:     txUsed,
 		})
 	}
+	rows = append(rows, systemBufferCoSRows(status, detail)...)
 	if detail {
 		for _, sample := range samples {
 			scope := systemBufferSampleScope(sample)
@@ -85,6 +106,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 			}
 		}
 	}
+	counterRows := systemBufferCounterRows(status, samples, detail)
 
 	var b strings.Builder
 	b.WriteString("Userspace Buffer Utilization:\n")
@@ -92,32 +114,164 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 		b.WriteString("  unavailable: helper status does not include bounded AF_XDP capacity gauges\n")
 		b.WriteString("  required status fields: per_binding[].umem_total_frames, per_binding[].umem_inflight_frames, per_binding[].tx_ring_capacity, per_binding[].outstanding_tx\n")
 		b.WriteString("  bindings[] mirrors with the same fields are also accepted\n")
-		return b.String()
-	}
-
-	fmt.Fprintf(&b, "%-24s %-24s %12s %12s %8s %s\n", "Buffer", "Scope", "Capacity", "Used", "Usage%", "Status")
-	b.WriteString(strings.Repeat("-", 92) + "\n")
-	warnings := 0
-	for _, row := range rows {
-		pct := 0.0
-		if row.Capacity > 0 {
-			pct = float64(row.Used) * 100.0 / float64(row.Capacity)
+	} else {
+		if knownUMEM == 0 && knownTX == 0 {
+			b.WriteString("  AF_XDP unavailable: helper status does not include bounded capacity gauges\n")
 		}
-		status := "OK"
-		if pct >= 90.0 {
-			status = "CRITICAL"
-			warnings++
-		} else if pct >= 80.0 {
-			status = "WARNING"
-			warnings++
+		fmt.Fprintf(&b, "%-24s %-24s %12s %12s %8s %s\n", "Buffer", "Scope", "Capacity", "Used", "Usage%", "Status")
+		b.WriteString(strings.Repeat("-", 92) + "\n")
+		warnings := 0
+		for _, row := range rows {
+			pct := 0.0
+			if row.Capacity > 0 {
+				pct = float64(row.Used) * 100.0 / float64(row.Capacity)
+			}
+			status := "OK"
+			if pct >= 90.0 {
+				status = "CRITICAL"
+				warnings++
+			} else if pct >= 80.0 {
+				status = "WARNING"
+				warnings++
+			}
+			fmt.Fprintf(&b, "%-24s %-24s %12d %12d %7.1f%% %s\n",
+				row.Name, row.Scope, row.Capacity, row.Used, pct, status)
 		}
-		fmt.Fprintf(&b, "%-24s %-24s %12d %12d %7.1f%% %s\n",
-			row.Name, row.Scope, row.Capacity, row.Used, pct, status)
+		if warnings > 0 {
+			fmt.Fprintf(&b, "\n%d userspace buffer row(s) at high utilization\n", warnings)
+		}
 	}
-	if warnings > 0 {
-		fmt.Fprintf(&b, "\n%d userspace buffer row(s) at high utilization\n", warnings)
+	if len(counterRows) > 0 {
+		if !strings.HasSuffix(b.String(), "\n\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString("Userspace Status Counters:\n")
+		fmt.Fprintf(&b, "%-32s %-24s %12s\n", "Counter", "Scope", "Value")
+		b.WriteString(strings.Repeat("-", 70) + "\n")
+		for _, row := range counterRows {
+			fmt.Fprintf(&b, "%-32s %-24s %12d\n", row.Name, row.Scope, row.Value)
+		}
 	}
 	return b.String()
+}
+
+func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {
+	var rows []systemBufferRow
+	var aggregateCap, aggregateUsed uint64
+	var queueCount int
+	for _, iface := range status.CoSInterfaces {
+		for _, queue := range iface.Queues {
+			if queue.BufferBytes == 0 {
+				continue
+			}
+			queueCount++
+			aggregateCap += queue.BufferBytes
+			aggregateUsed += queue.QueuedBytes
+		}
+	}
+	if queueCount == 0 {
+		return rows
+	}
+	rows = append(rows, systemBufferRow{
+		Name:     "CoS queue bytes",
+		Scope:    fmt.Sprintf("aggregate/%d", queueCount),
+		Capacity: aggregateCap,
+		Used:     aggregateUsed,
+	})
+	if !detail {
+		return rows
+	}
+	for _, iface := range status.CoSInterfaces {
+		for _, queue := range iface.Queues {
+			if queue.BufferBytes == 0 {
+				continue
+			}
+			rows = append(rows, systemBufferRow{
+				Name:     "CoS queue bytes",
+				Scope:    systemBufferCoSQueueScope(iface, queue),
+				Capacity: queue.BufferBytes,
+				Used:     queue.QueuedBytes,
+			})
+		}
+	}
+	return rows
+}
+
+func systemBufferCounterRows(status ProcessStatus, samples []systemBufferSample, detail bool) []systemBufferCounterRow {
+	var activeFlowCount uint64
+	var flowCacheCollisionEvictions uint64
+	var debugPendingFillFrames uint64
+	var debugSpareFillFrames uint64
+	var debugPendingTXPrepared uint64
+	var debugPendingTXLocal uint64
+	var dbgTxRingFull uint64
+	var dbgSendtoENOBUFS uint64
+	var dbgBoundPendingOverflow uint64
+	var dbgCoSQueueOverflow uint64
+	var rxFillRingEmptyDescs uint64
+	var redirectInboxOverflowDrops uint64
+	var pendingTXLocalOverflowDrops uint64
+	var txSubmitErrorDrops uint64
+	for _, sample := range samples {
+		activeFlowCount += uint64(sample.ActiveFlowCount)
+		flowCacheCollisionEvictions += sample.FlowCacheCollisionEvictions
+		debugPendingFillFrames += uint64(sample.DebugPendingFillFrames)
+		debugSpareFillFrames += uint64(sample.DebugSpareFillFrames)
+		debugPendingTXPrepared += uint64(sample.DebugPendingTXPrepared)
+		debugPendingTXLocal += uint64(sample.DebugPendingTXLocal)
+		dbgTxRingFull += sample.DbgTxRingFull
+		dbgSendtoENOBUFS += sample.DbgSendtoENOBUFS
+		dbgBoundPendingOverflow += sample.DbgBoundPendingOverflow
+		dbgCoSQueueOverflow += sample.DbgCoSQueueOverflow
+		rxFillRingEmptyDescs += sample.RxFillRingEmptyDescs
+		redirectInboxOverflowDrops += sample.RedirectInboxOverflowDrops
+		pendingTXLocalOverflowDrops += sample.PendingTXLocalOverflowDrops
+		txSubmitErrorDrops += sample.TxSubmitErrorDrops
+	}
+
+	var rows []systemBufferCounterRow
+	appendCounter := func(name, scope string, value uint64) {
+		if value > 0 {
+			rows = append(rows, systemBufferCounterRow{Name: name, Scope: scope, Value: value})
+		}
+	}
+	appendCounter("Neighbor cache entries", "dynamic", uint64(status.NeighborEntries))
+	appendCounter("Flow cache active flows", "active window", activeFlowCount)
+	appendCounter("Flow cache collision evict", "aggregate", flowCacheCollisionEvictions)
+	appendCounter("Pending fill frames", "aggregate", debugPendingFillFrames)
+	appendCounter("Spare fill frames", "aggregate", debugSpareFillFrames)
+	appendCounter("Pending TX prepared", "aggregate", debugPendingTXPrepared)
+	appendCounter("Pending TX local", "aggregate", debugPendingTXLocal)
+	appendCounter("TX ring full events", "aggregate", dbgTxRingFull)
+	appendCounter("sendto ENOBUFS", "aggregate", dbgSendtoENOBUFS)
+	appendCounter("Bound pending overflow", "aggregate", dbgBoundPendingOverflow)
+	appendCounter("CoS queue overflow", "aggregate", dbgCoSQueueOverflow)
+	appendCounter("RX fill-ring empty descs", "aggregate", rxFillRingEmptyDescs)
+	appendCounter("Redirect inbox overflow", "aggregate", redirectInboxOverflowDrops)
+	appendCounter("Pending TX local overflow", "aggregate", pendingTXLocalOverflowDrops)
+	appendCounter("TX submit error drops", "aggregate", txSubmitErrorDrops)
+
+	if !detail {
+		return rows
+	}
+	for _, sample := range samples {
+		scope := systemBufferSampleScope(sample)
+		appendCounter("Flow cache active flows", scope, uint64(sample.ActiveFlowCount))
+		appendCounter("Flow cache collision evict", scope, sample.FlowCacheCollisionEvictions)
+		appendCounter("Pending fill frames", scope, uint64(sample.DebugPendingFillFrames))
+		appendCounter("Spare fill frames", scope, uint64(sample.DebugSpareFillFrames))
+		appendCounter("Pending TX prepared", scope, uint64(sample.DebugPendingTXPrepared))
+		appendCounter("Pending TX local", scope, uint64(sample.DebugPendingTXLocal))
+		appendCounter("TX ring full events", scope, sample.DbgTxRingFull)
+		appendCounter("sendto ENOBUFS", scope, sample.DbgSendtoENOBUFS)
+		appendCounter("Bound pending overflow", scope, sample.DbgBoundPendingOverflow)
+		appendCounter("CoS queue overflow", scope, sample.DbgCoSQueueOverflow)
+		appendCounter("RX fill-ring empty descs", scope, sample.RxFillRingEmptyDescs)
+		appendCounter("Redirect inbox overflow", scope, sample.RedirectInboxOverflowDrops)
+		appendCounter("Pending TX local overflow", scope, sample.PendingTXLocalOverflowDrops)
+		appendCounter("TX submit error drops", scope, sample.TxSubmitErrorDrops)
+	}
+	return rows
 }
 
 func systemBufferSamples(status ProcessStatus) []systemBufferSample {
@@ -141,13 +295,22 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 			}
 			seen[key] = struct{}{}
 			sample := systemBufferSample{
-				WorkerID:   binding.WorkerID,
-				QueueID:    binding.QueueID,
-				Ifindex:    binding.Ifindex,
-				UMEMCap:    binding.UmemTotalFrames,
-				UMEMUsed:   binding.UmemInflightFrames,
-				TXRingCap:  binding.TxRingCapacity,
-				TXRingUsed: binding.OutstandingTX,
+				WorkerID:                    binding.WorkerID,
+				QueueID:                     binding.QueueID,
+				Ifindex:                     binding.Ifindex,
+				UMEMCap:                     binding.UmemTotalFrames,
+				UMEMUsed:                    binding.UmemInflightFrames,
+				TXRingCap:                   binding.TxRingCapacity,
+				TXRingUsed:                  binding.OutstandingTX,
+				ActiveFlowCount:             binding.ActiveFlowCount,
+				FlowCacheCollisionEvictions: binding.FlowCacheCollisionEvictions,
+				DbgTxRingFull:               binding.DbgTxRingFull,
+				DbgSendtoENOBUFS:            binding.DbgSendtoENOBUFS,
+				DbgBoundPendingOverflow:     binding.DbgBoundPendingOverflow,
+				DbgCoSQueueOverflow:         binding.DbgCoSQueueOverflow,
+				RxFillRingEmptyDescs:        binding.RxFillRingEmptyDescs,
+				PendingTXLocalOverflowDrops: binding.PendingTxLocalOverflowDrops,
+				TxSubmitErrorDrops:          binding.TxSubmitErrorDrops,
 			}
 			if full, ok := bindings[key]; ok {
 				sample.Slot = full.Slot
@@ -161,6 +324,7 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 					sample.TXRingCap = full.TxRingCapacity
 					sample.TXRingUsed = full.OutstandingTX
 				}
+				sample.applyBindingStatusFallback(full)
 			}
 			samples = append(samples, sample)
 		}
@@ -175,16 +339,30 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 			continue
 		}
 		samples = append(samples, systemBufferSample{
-			Slot:       binding.Slot,
-			HasSlot:    true,
-			WorkerID:   binding.WorkerID,
-			QueueID:    binding.QueueID,
-			Ifindex:    binding.Ifindex,
-			Interface:  binding.Interface,
-			UMEMCap:    binding.UmemTotalFrames,
-			UMEMUsed:   binding.UmemInflightFrames,
-			TXRingCap:  binding.TxRingCapacity,
-			TXRingUsed: binding.OutstandingTX,
+			Slot:                        binding.Slot,
+			HasSlot:                     true,
+			WorkerID:                    binding.WorkerID,
+			QueueID:                     binding.QueueID,
+			Ifindex:                     binding.Ifindex,
+			Interface:                   binding.Interface,
+			UMEMCap:                     binding.UmemTotalFrames,
+			UMEMUsed:                    binding.UmemInflightFrames,
+			TXRingCap:                   binding.TxRingCapacity,
+			TXRingUsed:                  binding.OutstandingTX,
+			ActiveFlowCount:             binding.ActiveFlowCount,
+			FlowCacheCollisionEvictions: binding.FlowCacheCollisionEvictions,
+			DebugPendingFillFrames:      binding.DebugPendingFillFrames,
+			DebugSpareFillFrames:        binding.DebugSpareFillFrames,
+			DebugPendingTXPrepared:      binding.DebugPendingTXPrepared,
+			DebugPendingTXLocal:         binding.DebugPendingTXLocal,
+			DbgTxRingFull:               binding.DbgTxRingFull,
+			DbgSendtoENOBUFS:            binding.DbgSendtoENOBUFS,
+			DbgBoundPendingOverflow:     binding.DbgBoundPendingOverflow,
+			DbgCoSQueueOverflow:         binding.DbgCoSQueueOverflow,
+			RxFillRingEmptyDescs:        binding.RxFillRingEmptyDescs,
+			RedirectInboxOverflowDrops:  binding.RedirectInboxOverflowDrops,
+			PendingTXLocalOverflowDrops: binding.PendingTXLocalOverflowDrops,
+			TxSubmitErrorDrops:          binding.TxSubmitErrorDrops,
 		})
 	}
 	sort.Slice(samples, func(i, j int) bool {
@@ -206,6 +384,51 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 	return samples
 }
 
+func (sample *systemBufferSample) applyBindingStatusFallback(binding BindingStatus) {
+	if sample.ActiveFlowCount == 0 {
+		sample.ActiveFlowCount = binding.ActiveFlowCount
+	}
+	if sample.FlowCacheCollisionEvictions == 0 {
+		sample.FlowCacheCollisionEvictions = binding.FlowCacheCollisionEvictions
+	}
+	if sample.DebugPendingFillFrames == 0 {
+		sample.DebugPendingFillFrames = binding.DebugPendingFillFrames
+	}
+	if sample.DebugSpareFillFrames == 0 {
+		sample.DebugSpareFillFrames = binding.DebugSpareFillFrames
+	}
+	if sample.DebugPendingTXPrepared == 0 {
+		sample.DebugPendingTXPrepared = binding.DebugPendingTXPrepared
+	}
+	if sample.DebugPendingTXLocal == 0 {
+		sample.DebugPendingTXLocal = binding.DebugPendingTXLocal
+	}
+	if sample.DbgTxRingFull == 0 {
+		sample.DbgTxRingFull = binding.DbgTxRingFull
+	}
+	if sample.DbgSendtoENOBUFS == 0 {
+		sample.DbgSendtoENOBUFS = binding.DbgSendtoENOBUFS
+	}
+	if sample.DbgBoundPendingOverflow == 0 {
+		sample.DbgBoundPendingOverflow = binding.DbgBoundPendingOverflow
+	}
+	if sample.DbgCoSQueueOverflow == 0 {
+		sample.DbgCoSQueueOverflow = binding.DbgCoSQueueOverflow
+	}
+	if sample.RxFillRingEmptyDescs == 0 {
+		sample.RxFillRingEmptyDescs = binding.RxFillRingEmptyDescs
+	}
+	if sample.RedirectInboxOverflowDrops == 0 {
+		sample.RedirectInboxOverflowDrops = binding.RedirectInboxOverflowDrops
+	}
+	if sample.PendingTXLocalOverflowDrops == 0 {
+		sample.PendingTXLocalOverflowDrops = binding.PendingTXLocalOverflowDrops
+	}
+	if sample.TxSubmitErrorDrops == 0 {
+		sample.TxSubmitErrorDrops = binding.TxSubmitErrorDrops
+	}
+}
+
 type systemBufferBindingKey struct {
 	WorkerID uint32
 	QueueID  uint32
@@ -224,6 +447,23 @@ func systemBufferSampleScope(sample systemBufferSample) string {
 		parts = append(parts, sample.Interface)
 	} else if sample.Ifindex != 0 {
 		parts = append(parts, fmt.Sprintf("ifindex %d", sample.Ifindex))
+	}
+	return strings.Join(parts, "/")
+}
+
+func systemBufferCoSQueueScope(iface CoSInterfaceStatus, queue CoSQueueStatus) string {
+	var parts []string
+	if iface.InterfaceName != "" {
+		parts = append(parts, iface.InterfaceName)
+	} else if iface.Ifindex != 0 {
+		parts = append(parts, fmt.Sprintf("ifindex %d", iface.Ifindex))
+	}
+	parts = append(parts, fmt.Sprintf("queue %d", queue.QueueID))
+	if queue.ForwardingClass != "" {
+		parts = append(parts, queue.ForwardingClass)
+	}
+	if queue.OwnerWorkerID != nil {
+		parts = append(parts, fmt.Sprintf("worker %d", *queue.OwnerWorkerID))
 	}
 	return strings.Join(parts, "/")
 }

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -215,3 +215,34 @@ func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatSystemBuffersCoSAggregateSumsCapacityWithUsage(t *testing.T) {
+	status := ProcessStatus{
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Ifindex:       80,
+				InterfaceName: "reth0.80",
+				Queues: []CoSQueueStatus{
+					{QueueID: 4, ForwardingClass: "iperf-a", BufferBytes: 1000, QueuedBytes: 700},
+					{QueueID: 5, ForwardingClass: "iperf-b", BufferBytes: 1000, QueuedBytes: 100},
+				},
+			},
+		},
+	}
+
+	out := FormatSystemBuffers(status, false)
+	for _, want := range []string{
+		"CoS queue bytes",
+		"aggregate/2",
+		"2000",
+		"800",
+		"40.0% OK",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "80.0%") {
+		t.Fatalf("CoS aggregate used max capacity instead of summed capacity:\n%s", out)
+	}
+}

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -136,3 +136,82 @@ func TestFormatSystemBuffersDocumentsMissingStatusFields(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
+	owner := uint32(2)
+	status := ProcessStatus{
+		NeighborEntries: 12,
+		Bindings: []BindingStatus{
+			{
+				Slot:                        4,
+				WorkerID:                    2,
+				QueueID:                     7,
+				Ifindex:                     9,
+				Interface:                   "ge-0-0-9",
+				UmemTotalFrames:             1000,
+				UmemInflightFrames:          100,
+				TxRingCapacity:              100,
+				OutstandingTX:               10,
+				ActiveFlowCount:             29,
+				FlowCacheCollisionEvictions: 31,
+				DebugPendingFillFrames:      3,
+				DebugSpareFillFrames:        5,
+				DebugPendingTXPrepared:      7,
+				DebugPendingTXLocal:         11,
+				DbgTxRingFull:               13,
+				DbgSendtoENOBUFS:            17,
+				DbgBoundPendingOverflow:     19,
+				DbgCoSQueueOverflow:         23,
+				RxFillRingEmptyDescs:        37,
+				RedirectInboxOverflowDrops:  41,
+				PendingTXLocalOverflowDrops: 43,
+				TxSubmitErrorDrops:          47,
+			},
+		},
+		CoSInterfaces: []CoSInterfaceStatus{
+			{
+				Ifindex:       9,
+				InterfaceName: "ge-0-0-9",
+				Queues: []CoSQueueStatus{
+					{
+						QueueID:         2,
+						OwnerWorkerID:   &owner,
+						ForwardingClass: "ef",
+						BufferBytes:     1000,
+						QueuedBytes:     850,
+					},
+				},
+			},
+		},
+	}
+
+	out := FormatSystemBuffers(status, true)
+	for _, want := range []string{
+		"CoS queue bytes",
+		"aggregate/1",
+		"850",
+		"85.0% WARNING",
+		"ge-0-0-9/queue 2/ef/worker 2",
+		"Userspace Status Counters:",
+		"Neighbor cache entries",
+		"Flow cache active flows",
+		"Flow cache collision evict",
+		"Pending fill frames",
+		"Spare fill frames",
+		"Pending TX prepared",
+		"Pending TX local",
+		"TX ring full events",
+		"sendto ENOBUFS",
+		"Bound pending overflow",
+		"CoS queue overflow",
+		"RX fill-ring empty descs",
+		"Redirect inbox overflow",
+		"Pending TX local overflow",
+		"TX submit error drops",
+		"worker 2/queue 7/slot 4/ge-0-0-9",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatSystemBuffers output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -527,21 +527,23 @@ type CoSInterfaceStatus struct {
 }
 
 type CoSQueueStatus struct {
-	QueueID             int     `json:"queue_id,omitempty"`
-	OwnerWorkerID       *uint32 `json:"owner_worker_id,omitempty"`
-	ForwardingClass     string  `json:"forwarding_class,omitempty"`
-	Priority            int     `json:"priority,omitempty"`
-	Exact               bool    `json:"exact,omitempty"`
-	GuaranteeEnabled    *bool   `json:"guarantee_enabled,omitempty"`
-	TransmitRateBytes   uint64  `json:"transmit_rate_bytes,omitempty"`
-	BufferBytes         uint64  `json:"buffer_bytes,omitempty"`
-	WorkerInstances     int     `json:"worker_instances,omitempty"`
-	QueuedPackets       uint64  `json:"queued_packets,omitempty"`
-	QueuedBytes         uint64  `json:"queued_bytes,omitempty"`
-	RunnableInstances   int     `json:"runnable_instances,omitempty"`
-	ParkedInstances     int     `json:"parked_instances,omitempty"`
-	NextWakeupTick      uint64  `json:"next_wakeup_tick,omitempty"`
-	SurplusDeficitBytes uint64  `json:"surplus_deficit_bytes,omitempty"`
+	QueueID           int     `json:"queue_id,omitempty"`
+	OwnerWorkerID     *uint32 `json:"owner_worker_id,omitempty"`
+	ForwardingClass   string  `json:"forwarding_class,omitempty"`
+	Priority          int     `json:"priority,omitempty"`
+	Exact             bool    `json:"exact,omitempty"`
+	GuaranteeEnabled  *bool   `json:"guarantee_enabled,omitempty"`
+	TransmitRateBytes uint64  `json:"transmit_rate_bytes,omitempty"`
+	// BufferBytes is total queue capacity for this status row. Rust status
+	// aggregation sums it with QueuedBytes across worker/binding instances.
+	BufferBytes         uint64 `json:"buffer_bytes,omitempty"`
+	WorkerInstances     int    `json:"worker_instances,omitempty"`
+	QueuedPackets       uint64 `json:"queued_packets,omitempty"`
+	QueuedBytes         uint64 `json:"queued_bytes,omitempty"`
+	RunnableInstances   int    `json:"runnable_instances,omitempty"`
+	ParkedInstances     int    `json:"parked_instances,omitempty"`
+	NextWakeupTick      uint64 `json:"next_wakeup_tick,omitempty"`
+	SurplusDeficitBytes uint64 `json:"surplus_deficit_bytes,omitempty"`
 	// #710/#718: per-queue admission-path counters aggregated across
 	// worker instances by the Rust coordinator. JSON tags MUST match the
 	// Rust serde rename(...) exactly — the wire format is the contract.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -831,6 +831,9 @@ type BindingStatus struct {
 	TXBytes                           uint64 `json:"tx_bytes,omitempty"`
 	TXErrors                          uint64 `json:"tx_errors,omitempty"`
 	TXSharedRecycleUnknownSlotDrops   uint64 `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
+	RedirectInboxOverflowDrops        uint64 `json:"redirect_inbox_overflow_drops,omitempty"`
+	PendingTXLocalOverflowDrops       uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
+	TxSubmitErrorDrops                uint64 `json:"tx_submit_error_drops,omitempty"`
 	TXCompletions                     uint64 `json:"tx_completions,omitempty"`
 	DirectTXPackets                   uint64 `json:"direct_tx_packets,omitempty"`
 	CopyTXPackets                     uint64 `json:"copy_tx_packets,omitempty"`

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -37,6 +37,9 @@ func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
 		QueueID:                         2,
 		TXErrors:                        9,
 		TXSharedRecycleUnknownSlotDrops: 4,
+		RedirectInboxOverflowDrops:      5,
+		PendingTXLocalOverflowDrops:     6,
+		TxSubmitErrorDrops:              7,
 	}
 	raw, err := json.Marshal(&in)
 	if err != nil {
@@ -46,8 +49,15 @@ func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		t.Fatalf("unmarshal obj: %v", err)
 	}
-	if _, ok := obj["tx_shared_recycle_unknown_slot_drops"]; !ok {
-		t.Fatalf("wire key missing from BindingStatus JSON: %s", string(raw))
+	for _, key := range []string{
+		"tx_shared_recycle_unknown_slot_drops",
+		"redirect_inbox_overflow_drops",
+		"pending_tx_local_overflow_drops",
+		"tx_submit_error_drops",
+	} {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from BindingStatus JSON: %s", key, string(raw))
+		}
 	}
 
 	var back BindingStatus
@@ -57,6 +67,18 @@ func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
 	if back.TXSharedRecycleUnknownSlotDrops != in.TXSharedRecycleUnknownSlotDrops {
 		t.Fatalf("TXSharedRecycleUnknownSlotDrops: got %d, want %d",
 			back.TXSharedRecycleUnknownSlotDrops, in.TXSharedRecycleUnknownSlotDrops)
+	}
+	if back.RedirectInboxOverflowDrops != in.RedirectInboxOverflowDrops {
+		t.Fatalf("RedirectInboxOverflowDrops: got %d, want %d",
+			back.RedirectInboxOverflowDrops, in.RedirectInboxOverflowDrops)
+	}
+	if back.PendingTXLocalOverflowDrops != in.PendingTXLocalOverflowDrops {
+		t.Fatalf("PendingTXLocalOverflowDrops: got %d, want %d",
+			back.PendingTXLocalOverflowDrops, in.PendingTXLocalOverflowDrops)
+	}
+	if back.TxSubmitErrorDrops != in.TxSubmitErrorDrops {
+		t.Fatalf("TxSubmitErrorDrops: got %d, want %d",
+			back.TxSubmitErrorDrops, in.TxSubmitErrorDrops)
 	}
 }
 

--- a/pkg/grpcapi/server_show_system_buffers_test.go
+++ b/pkg/grpcapi/server_show_system_buffers_test.go
@@ -34,8 +34,19 @@ func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
 			v4:      3,
 			v6:      2,
 			status: dpuserspace.ProcessStatus{
+				NeighborEntries: 6,
 				PerBinding: []dpuserspace.BindingCountersSnapshot{
-					{WorkerID: 0, QueueID: 0, Ifindex: 5, UmemTotalFrames: 1000, UmemInflightFrames: 800, TxRingCapacity: 100, OutstandingTX: 90},
+					{
+						WorkerID:           0,
+						QueueID:            0,
+						Ifindex:            5,
+						UmemTotalFrames:    1000,
+						UmemInflightFrames: 800,
+						TxRingCapacity:     100,
+						OutstandingTX:      90,
+						ActiveFlowCount:    4,
+						DbgTxRingFull:      2,
+					},
 				},
 			},
 		},
@@ -52,6 +63,10 @@ func TestShowTextSystemBuffersUsesUserspaceStatus(t *testing.T) {
 		"80.0% WARNING",
 		"AF_XDP TX ring",
 		"90.0% CRITICAL",
+		"Userspace Status Counters:",
+		"Neighbor cache entries",
+		"Flow cache active flows",
+		"TX ring full events",
 		"Active sessions: 3 IPv4, 2 IPv6, 5 total",
 	} {
 		if !strings.Contains(out, want) {

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1475,7 +1475,7 @@ pub(super) fn aggregate_cos_statuses_across_workers(
                     q.active_flow_buckets_peak = queue.active_flow_buckets_peak;
                 }
                 q.transmit_rate_bytes = q.transmit_rate_bytes.max(queue.transmit_rate_bytes);
-                q.buffer_bytes = q.buffer_bytes.max(queue.buffer_bytes);
+                q.buffer_bytes = q.buffer_bytes.saturating_add(queue.buffer_bytes);
                 q.worker_instances = q.worker_instances.saturating_add(queue.worker_instances);
                 q.queued_packets = q.queued_packets.saturating_add(queue.queued_packets);
                 q.queued_bytes = q.queued_bytes.saturating_add(queue.queued_bytes);

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -737,6 +737,8 @@ fn aggregate_cos_statuses_sums_drop_counters_across_worker_snapshots() {
         queues: vec![CoSQueueStatus {
             queue_id: 4,
             worker_instances: 1,
+            buffer_bytes: 64 * 1024,
+            queued_bytes: 48 * 1024,
             admission_flow_share_drops: 3,
             admission_buffer_drops: 5,
             admission_ecn_marked: 37,
@@ -756,6 +758,8 @@ fn aggregate_cos_statuses_sums_drop_counters_across_worker_snapshots() {
         queues: vec![CoSQueueStatus {
             queue_id: 4,
             worker_instances: 1,
+            buffer_bytes: 64 * 1024,
+            queued_bytes: 16 * 1024,
             admission_flow_share_drops: 17,
             admission_buffer_drops: 19,
             admission_ecn_marked: 41,
@@ -776,6 +780,8 @@ fn aggregate_cos_statuses_sums_drop_counters_across_worker_snapshots() {
     let q = &iface.queues[0];
     assert_eq!(q.queue_id, 4);
     assert_eq!(q.owner_worker_id, Some(3));
+    assert_eq!(q.buffer_bytes, 128 * 1024);
+    assert_eq!(q.queued_bytes, 64 * 1024);
     // Each counter is non-coprime-prime on both sides to catch
     // accidental re-attribution between counters.
     assert_eq!(q.admission_flow_share_drops, 3 + 17);

--- a/userspace-dp/src/afxdp/worker/cos.rs
+++ b/userspace-dp/src/afxdp/worker/cos.rs
@@ -606,7 +606,9 @@ where
                 status.guarantee_enabled = queue.config.guarantee_enabled;
                 status.transmit_rate_bytes =
                     status.transmit_rate_bytes.max(queue.transmit_rate_bytes());
-                status.buffer_bytes = status.buffer_bytes.max(queue.config.buffer_bytes);
+                status.buffer_bytes = status
+                    .buffer_bytes
+                    .saturating_add(queue.config.buffer_bytes);
                 status.worker_instances = status.worker_instances.saturating_add(1);
                 status.queued_packets = status
                     .queued_packets

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -270,6 +270,7 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
     let queue = &iface.queues[0];
     assert_eq!(queue.queue_id, 4);
     assert_eq!(queue.forwarding_class, "bandwidth-10mb");
+    assert_eq!(queue.buffer_bytes, 2 * 32 * 1024);
     assert_eq!(queue.queued_packets, 2);
     assert_eq!(queue.queued_bytes, 3072);
     assert_eq!(queue.runnable_instances, 1);

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -905,6 +905,9 @@ pub(crate) struct CoSQueueStatus {
     pub guarantee_enabled: bool,
     #[serde(rename = "transmit_rate_bytes", default)]
     pub transmit_rate_bytes: u64,
+    /// Total queue capacity represented by this status row. Worker and
+    /// coordinator aggregation sum this alongside `queued_bytes` so buffer
+    /// fill percentages use matched numerator/denominator populations.
     #[serde(rename = "buffer_bytes", default)]
     pub buffer_bytes: u64,
     #[serde(rename = "worker_instances", default)]


### PR DESCRIPTION
## Summary

Refs #1380.

Expands `show system buffers` for the userspace dataplane so operators can see more than AF_XDP UMEM/TX ring capacity:

- renders bounded CoS queued-byte utilization from `CoSInterfaces[].Queues[]`
- adds a separate `Userspace Status Counters` section for counters/gauges that do not have capacity denominators
- mirrors helper drop counters into Go protocol structs so status output can attribute redirect inbox, pending-local TX, and TX submit failures
- adds CLI/gRPC/shared-formatter regression coverage

This intentionally does not infer capacities for session table, flow cache, or neighbor cache from Rust private constants. Those still need explicit helper-published denominators before they can be rendered as utilization rows.

## Validation

- `go test ./pkg/dataplane/userspace ./pkg/grpcapi ./pkg/cli`
- `git diff --check`
