### PR TITLE
userspace: add bounded dataplane event producer

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -65,6 +65,10 @@ forwarding decision.
 - Use `try_emit_dataplane_event_at()`; a full event queue drops the event and
   increments both the generic producer drop counter and per-event queue-full
   accounting.
+- Dataplane telemetry must not monopolize the shared event-stream queue:
+  in-flight telemetry is capped to a bounded share of the channel, and each
+  event kind has its own cap so one storm leaves capacity for session/control
+  frames and other telemetry kinds.
 - Per-source-zone/per-event token-bucket-equivalent rate limiting must run
   before sequence allocation to prevent deny storms from starving session
   open/close/update events without creating sequence gaps for limiter drops.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -31,6 +31,18 @@ and destination tuple, ingress ifindex/interface name path, zone data,
 policy/rule/application identity, reason, NAT-rewritten tuple when applicable,
 and timestamp.
 
+Current implementation status after #1394 and this infrastructure slice:
+
+- Frame types 11/12/13 are reserved and covered by Rust golden tests.
+- Rust encodes and decodes fixed-size 136-byte RT_FLOW payloads for policy
+  deny, screen drop, and filter log records.
+- Go decodes and dispatches these frames through the existing logging path and
+  exposes daemon-side event/drop counters.
+- Rust helper producer infrastructure now provides
+  `try_emit_dataplane_event_at()` with fixed-size non-blocking queueing,
+  per-event/per-ingress-zone rate limiting, generic producer sent/dropped
+  counters, and per-event loss reason accounting.
+
 Emission points:
 
 - policy deny path in `userspace-dp/src/policy.rs`
@@ -50,9 +62,12 @@ forwarding decision.
 ## Hot-Path Invariants
 
 - Event emission is fixed-size, no heap, copy-by-value, and non-blocking.
-- Use `try_send`; a full event queue drops the event and increments a counter.
-- Add per-source-zone/per-event token buckets to prevent deny storms from
-  starving session open/close/update events.
+- Use `try_emit_dataplane_event_at()`; a full event queue drops the event and
+  increments both the generic producer drop counter and per-event queue-full
+  accounting.
+- Per-source-zone/per-event token-bucket-equivalent rate limiting must run
+  before sequence allocation to prevent deny storms from starving session
+  open/close/update events without creating sequence gaps for limiter drops.
 - Event frames stay within the existing 256-byte-ish event budget unless the
   codec is explicitly resized and tested.
 - Policy evaluation returns enough rule/policy/app metadata for event creation;
@@ -91,7 +106,12 @@ forwarding decision.
 - Cargo: screen drop path emits a rate-limited event and accounts drops when
   the limiter is empty.
 - Cargo: filter log emits only for log/syslog terms, not count-only terms.
-- Cargo: event queue full uses non-blocking drop-and-count behavior.
+- Cargo: producer API queues admitted RT_FLOW events without blocking and
+  accounts per-event sent counts.
+- Cargo: rate limiting is per event kind and ingress zone, and limiter drops do
+  not allocate sequence numbers.
+- Cargo: event queue full and disconnected paths use non-blocking
+  drop-and-count behavior with per-event loss reason accounting.
 - Go: userspace `EventSource` adapter converts each new frame into the expected
   `dataplane.Event`.
 - Go: `pkg/logging/ringbuf_test.go` or equivalent verifies identical
@@ -102,6 +122,18 @@ forwarding decision.
 - Integration: userspace cluster with deny policy, screen drop, and filter log
   term; generated traffic produces matching syslog records with no session
   event starvation under a deny storm.
+
+## Remaining Gaps
+
+- Wire policy deny, screen drop, and filter log runtime producer call sites to
+  the Rust producer API without colliding with #1374/#1375/#1378 workstreams.
+- Surface the helper-side per-event loss reason counters in status JSON,
+  CLI/status formatting, and Prometheus if the follow-up wants operator-visible
+  attribution beyond the existing aggregate `event_stream_dropped` producer
+  counter.
+- Run end-to-end userspace syslog validation for deny policy, screen drop, and
+  filter log traffic, including a deny-storm case that proves session event
+  delivery is not starved.
 
 ## Non-Goals
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -66,7 +66,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. The manager still holds a named eBPF shim manager for XDP/map bootstrap state; tracked by #1381 |
-| Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
+| Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, and filter-log frame types, RT_FLOW codec/Go decode, and Rust non-blocking producer/rate-limit/loss-accounting infrastructure are present; runtime producer call sites and end-to-end syslog evidence remain tracked by #1379. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, active-session footer, neighbor/flow-cache counts, and worker queue pressure counters. #1380 is narrowed to the Phase 5 cleanup decision about whether operators need new helper capacity denominators for session-table, flow-cache, or neighbor-cache fill percentages before the legacy BPF-map surface is removed. |
 
 ## Retirement Blockers From The 2026-05-16 Audit

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -46,6 +46,21 @@ func TestFormatStatusSummary(t *testing.T) {
 		RecentExceptions: []ExceptionStatus{
 			{Timestamp: now, Slot: 1, QueueID: 0, Interface: "ge-0-0-2", Reason: "metadata_parse", PacketLength: 128},
 		},
+		EventStreamSent:    101,
+		EventStreamDropped: 7,
+		EventStream: &EventStreamStatus{
+			FramesRead:        11,
+			FramesWritten:     5,
+			DecodeErrors:      2,
+			SeqGaps:           3,
+			PolicyDenyEvents:  13,
+			ScreenDropEvents:  17,
+			FilterLogEvents:   19,
+			PolicyDenyDrops:   1,
+			ScreenDropDrops:   4,
+			FilterLogDrops:    9,
+			UnknownFrameDrops: 6,
+		},
 	}
 
 	out := FormatStatusSummary(status)
@@ -89,6 +104,10 @@ func TestFormatStatusSummary(t *testing.T) {
 		"Direct TX no-frame fb:     5",
 		"Direct TX build-none fb:   6",
 		"Direct TX disallowed fb:   7",
+		"Event stream frames:       read=11 written=5 decode_errors=2 seq_gaps=3",
+		"Event stream producer:     sent=101 dropped=7",
+		"Event stream events:       policy_deny=13 screen_drop=17 filter_log=19 unknown_drops=6",
+		"Event stream drops:        policy_deny=1 screen_drop=4 filter_log=9",
 		"Pending fill frames:       30",
 		"Spare fill frames:         32",
 		"Free TX frames:            34",

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -60,8 +60,11 @@ cluster-scoped.
   before sequence allocation, increments the generic producer drop
   counter for rate-limited events, and records per-event loss reason
   counters for later status surfacing. It also enforces the telemetry
-  queue budget before touching the shared channel; event budget drops
-  are reported as queue-full drops.
+  queue budget before sequence allocation or shared-channel enqueue;
+  event budget drops are reported as queue-full drops. Accepted
+  telemetry holds that budget while retained for replay, releasing it
+  only when an ACK trims the frame or the helper definitively drops it
+  during replay eviction, enqueue failure, or shutdown.
 - The Go daemon must know every helper→daemon frame type that carries a
   sequence number. For RT_FLOW-style dataplane telemetry, the daemon
   decodes valid frames through the same RT_FLOW adapter used for ringbuf

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -22,7 +22,12 @@ periodic ACK from the daemon.
   telemetry may also populate the non-session metadata slots used by
   the Go adapter for action, rule ID, term ID, reason, owner RG,
   ingress ifindex, and application ID.
-- `codec_tests.rs`, `tests.rs` — co-located.
+- `producer.rs` — non-blocking helper-side producer API for RT_FLOW
+  dataplane telemetry. It rate-limits each `(event type, ingress
+  zone)` bucket, encodes fixed-size frames only after the limiter
+  admits the event, and accounts sent/rate-limited/queue-full/
+  disconnected outcomes per event type.
+- `codec_tests.rs`, `producer_tests.rs`, `tests.rs` — co-located.
 
 ## Why push
 
@@ -46,6 +51,12 @@ cluster-scoped.
   (see `protocol.rs`). Use `push_delta_lossless()` only when
   correctness requires every frame and the producer can tolerate
   back-pressure.
+- RT_FLOW dataplane telemetry producers must use
+  `try_emit_dataplane_event_at()`, not hand-rolled `try_send()`
+  wrappers. The API applies the per-kind/per-ingress-zone limiter
+  before sequence allocation, increments the generic producer drop
+  counter for rate-limited events, and records per-event loss reason
+  counters for later status surfacing.
 - The Go daemon must know every helper→daemon frame type that carries a
   sequence number. For RT_FLOW-style dataplane telemetry, the daemon
   decodes valid frames through the same RT_FLOW adapter used for ringbuf

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -26,7 +26,10 @@ periodic ACK from the daemon.
   dataplane telemetry. It rate-limits each `(event type, ingress
   zone)` bucket, encodes fixed-size frames only after the limiter
   admits the event, and accounts sent/rate-limited/queue-full/
-  disconnected outcomes per event type.
+  disconnected outcomes per event type. Dataplane telemetry can occupy
+  only a bounded share of the shared event-stream channel, and each
+  event type has its own in-flight cap so one deny/drop/log storm cannot
+  monopolize queue capacity.
 - `codec_tests.rs`, `producer_tests.rs`, `tests.rs` — co-located.
 
 ## Why push
@@ -56,7 +59,9 @@ cluster-scoped.
   wrappers. The API applies the per-kind/per-ingress-zone limiter
   before sequence allocation, increments the generic producer drop
   counter for rate-limited events, and records per-event loss reason
-  counters for later status surfacing.
+  counters for later status surfacing. It also enforces the telemetry
+  queue budget before touching the shared channel; event budget drops
+  are reported as queue-full drops.
 - The Go daemon must know every helper→daemon frame type that carries a
   sequence number. For RT_FLOW-style dataplane telemetry, the daemon
   decodes valid frames through the same RT_FLOW adapter used for ringbuf

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -445,6 +445,10 @@ impl EventFrame {
         Some(&self.data[FRAME_HEADER_SIZE..end])
     }
 
+    pub(super) fn dataplane_event_kind(&self) -> Option<DataplaneEventKind> {
+        DataplaneEventKind::from_msg_type(self.data[4])
+    }
+
     #[allow(dead_code)]
     pub(crate) fn decode_dataplane_event(&self) -> Option<DataplaneEventPayload> {
         decode_dataplane_event(self.data[4], self.dataplane_event_payload()?)

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use producer::{
 
 use crate::session::{SessionDelta, SessionDeltaKind};
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
-use producer::{DataplaneEventCounters, DataplaneEventRateLimiter};
+use producer::{DataplaneEventCounters, DataplaneEventQueueBudget, DataplaneEventRateLimiter};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::io;
@@ -81,6 +81,7 @@ struct EventStreamShared {
     dataplane_event_counters: DataplaneEventCounters,
     #[allow(dead_code)] // consumed by producer call sites once they are wired
     dataplane_event_limiter: DataplaneEventRateLimiter,
+    dataplane_event_queue: DataplaneEventQueueBudget,
 }
 
 impl EventStreamShared {
@@ -89,6 +90,13 @@ impl EventStreamShared {
     }
 
     fn new_with_dataplane_event_rate(config: DataplaneEventRateLimitConfig) -> Self {
+        Self::new_with_dataplane_event_rate_and_queue_capacity(config, CHANNEL_CAPACITY)
+    }
+
+    fn new_with_dataplane_event_rate_and_queue_capacity(
+        config: DataplaneEventRateLimitConfig,
+        channel_capacity: usize,
+    ) -> Self {
         Self {
             next_seq: AtomicU64::new(0),
             acked_seq: AtomicU64::new(0),
@@ -99,6 +107,7 @@ impl EventStreamShared {
             frames_replayed: AtomicU64::new(0),
             dataplane_event_counters: DataplaneEventCounters::new(),
             dataplane_event_limiter: DataplaneEventRateLimiter::new(config),
+            dataplane_event_queue: DataplaneEventQueueBudget::new(channel_capacity),
         }
     }
 }
@@ -358,7 +367,7 @@ fn io_thread_main(
     }
 
     // Drain remaining events on shutdown
-    drain_remaining(&rx);
+    drain_remaining(&rx, &shared);
     shared.connected.store(false, Ordering::Release);
     eprintln!("xpf-event-stream: I/O thread exiting");
 }
@@ -464,6 +473,7 @@ fn run_connected_loop(
             match rx.try_recv() {
                 Ok(frame) => {
                     drained_any = true;
+                    release_dataplane_event_queue_budget(shared, &frame);
                     // Add to replay buffer (drop oldest if over capacity)
                     if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
                         replay_buf.pop_front();
@@ -643,6 +653,7 @@ fn handle_drain_request(
         match rx.try_recv() {
             Ok(frame) => {
                 let frame_seq = frame.seq;
+                release_dataplane_event_queue_budget(shared, &frame);
                 if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
                     replay_buf.pop_front();
                 }
@@ -701,12 +712,18 @@ fn handle_drain_request(
 }
 
 /// Drain remaining events from the channel on shutdown.
-fn drain_remaining(rx: &mpsc::Receiver<EventFrame>) {
+fn drain_remaining(rx: &mpsc::Receiver<EventFrame>, shared: &Arc<EventStreamShared>) {
     loop {
         match rx.try_recv() {
-            Ok(_) => {}
+            Ok(frame) => release_dataplane_event_queue_budget(shared, &frame),
             Err(_) => break,
         }
+    }
+}
+
+fn release_dataplane_event_queue_budget(shared: &Arc<EventStreamShared>, frame: &EventFrame) {
+    if let Some(kind) = frame.dataplane_event_kind() {
+        shared.dataplane_event_queue.release(kind);
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -368,6 +368,7 @@ fn io_thread_main(
 
     // Drain remaining events on shutdown
     drain_remaining(&rx, &shared);
+    release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
     shared.connected.store(false, Ordering::Release);
     eprintln!("xpf-event-stream: I/O thread exiting");
 }
@@ -468,21 +469,17 @@ fn run_connected_loop(
         let paused = shared.paused.load(Ordering::Acquire);
         let mut drained_any = false;
 
-        // Drain channel into replay buffer + write buffer
+        // Drain channel into replay buffer + write buffer. Dataplane telemetry
+        // keeps its producer budget while retained for replay; release only
+        // when the frame is ACKed or definitively dropped.
         loop {
             match rx.try_recv() {
                 Ok(frame) => {
                     drained_any = true;
-                    release_dataplane_event_queue_budget(shared, &frame);
-                    // Add to replay buffer (drop oldest if over capacity)
-                    if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
-                        replay_buf.pop_front();
-                    }
-                    replay_buf.push_back(frame.clone());
-
                     if !paused {
                         write_buf.extend_from_slice(frame.as_bytes());
                     }
+                    push_replay_frame(shared, replay_buf, frame);
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => return false,
@@ -604,7 +601,7 @@ fn process_control_frames(
                 // Trim replay buffer: remove frames with seq <= acked
                 while let Some(front) = replay_buf.front() {
                     if front.seq <= seq {
-                        replay_buf.pop_front();
+                        pop_replay_frame(shared, replay_buf);
                     } else {
                         break;
                     }
@@ -653,11 +650,7 @@ fn handle_drain_request(
         match rx.try_recv() {
             Ok(frame) => {
                 let frame_seq = frame.seq;
-                release_dataplane_event_queue_budget(shared, &frame);
-                if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
-                    replay_buf.pop_front();
-                }
-                replay_buf.push_back(frame);
+                push_replay_frame(shared, replay_buf, frame);
                 if frame_seq >= target_seq {
                     break;
                 }
@@ -725,6 +718,35 @@ fn release_dataplane_event_queue_budget(shared: &Arc<EventStreamShared>, frame: 
     if let Some(kind) = frame.dataplane_event_kind() {
         shared.dataplane_event_queue.release(kind);
     }
+}
+
+fn push_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    frame: EventFrame,
+) {
+    if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
+        pop_replay_frame(shared, replay_buf);
+    }
+    replay_buf.push_back(frame);
+}
+
+fn pop_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) -> Option<EventFrame> {
+    let frame = replay_buf.pop_front();
+    if let Some(frame) = frame.as_ref() {
+        release_dataplane_event_queue_budget(shared, frame);
+    }
+    frame
+}
+
+fn release_replay_dataplane_event_queue_budget(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) {
+    while pop_replay_frame(shared, replay_buf).is_some() {}
 }
 
 // ---------------------------------------------------------------------------

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -10,18 +10,25 @@
 //!   Payload: type-specific binary (see codec module)
 
 pub(crate) mod codec;
+mod producer;
 
-pub(crate) use codec::{close_flags, EventFrame};
+pub(crate) use codec::{EventFrame, close_flags};
+#[allow(unused_imports)] // public API for later policy/screen/filter producer wiring
+pub(crate) use producer::{
+    DataplaneEventDropReason, DataplaneEventEmitOutcome, DataplaneEventRateLimitConfig,
+    DataplaneEventStats,
+};
 
 use crate::session::{SessionDelta, SessionDeltaKind};
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
+use producer::{DataplaneEventCounters, DataplaneEventRateLimiter};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::io;
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TryRecvError};
-use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -54,6 +61,8 @@ pub(crate) struct EventStreamStats {
     pub(crate) dropped: u64,
     #[allow(dead_code)] // stats field for future reporting
     pub(crate) replayed: u64,
+    #[allow(dead_code)] // producer-call-site wiring will surface these fields
+    pub(crate) dataplane_events: DataplaneEventStats,
 }
 
 struct EventStreamShared {
@@ -69,10 +78,17 @@ struct EventStreamShared {
     frames_sent: AtomicU64,
     frames_dropped: AtomicU64,
     frames_replayed: AtomicU64,
+    dataplane_event_counters: DataplaneEventCounters,
+    #[allow(dead_code)] // consumed by producer call sites once they are wired
+    dataplane_event_limiter: DataplaneEventRateLimiter,
 }
 
 impl EventStreamShared {
     fn new() -> Self {
+        Self::new_with_dataplane_event_rate(DataplaneEventRateLimitConfig::default())
+    }
+
+    fn new_with_dataplane_event_rate(config: DataplaneEventRateLimitConfig) -> Self {
         Self {
             next_seq: AtomicU64::new(0),
             acked_seq: AtomicU64::new(0),
@@ -81,8 +97,16 @@ impl EventStreamShared {
             frames_sent: AtomicU64::new(0),
             frames_dropped: AtomicU64::new(0),
             frames_replayed: AtomicU64::new(0),
+            dataplane_event_counters: DataplaneEventCounters::new(),
+            dataplane_event_limiter: DataplaneEventRateLimiter::new(config),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EventStreamSendError {
+    Full,
+    Disconnected,
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +165,7 @@ impl EventStreamSender {
             sent: self.shared.frames_sent.load(Ordering::Relaxed),
             dropped: self.shared.frames_dropped.load(Ordering::Relaxed),
             replayed: self.shared.frames_replayed.load(Ordering::Relaxed),
+            dataplane_events: self.shared.dataplane_event_counters.snapshot(),
         }
     }
 
@@ -178,15 +203,22 @@ impl EventStreamWorkerHandle {
 
     /// Non-blocking send. Returns false if the channel is full (event dropped).
     pub(crate) fn try_send(&self, frame: EventFrame) -> bool {
+        self.try_send_frame(frame).is_ok()
+    }
+
+    fn try_send_frame(&self, frame: EventFrame) -> Result<(), EventStreamSendError> {
         match self.tx.try_send(frame) {
-            Ok(()) => true,
+            Ok(()) => {
+                self.shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
             Err(mpsc::TrySendError::Full(_)) => {
                 self.shared.frames_dropped.fetch_add(1, Ordering::Relaxed);
-                false
+                Err(EventStreamSendError::Full)
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
                 self.shared.frames_dropped.fetch_add(1, Ordering::Relaxed);
-                false
+                Err(EventStreamSendError::Disconnected)
             }
         }
     }
@@ -198,7 +230,10 @@ impl EventStreamWorkerHandle {
         let deadline = Instant::now() + LOSSLESS_QUEUE_TIMEOUT;
         loop {
             match self.tx.try_send(frame) {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    self.shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+                    return Ok(());
+                }
                 Err(mpsc::TrySendError::Full(returned)) => {
                     frame = returned;
                     if !self.shared.connected.load(Ordering::Acquire) {
@@ -385,7 +420,6 @@ fn replay_buffered(
         shared
             .frames_replayed
             .fetch_add(replayed, Ordering::Relaxed);
-        shared.frames_sent.fetch_add(replayed, Ordering::Relaxed);
         eprintln!("xpf-event-stream: replayed {replayed} events");
     }
     Ok(())
@@ -455,8 +489,6 @@ fn run_connected_loop(
                     } else {
                         write_buf.clear();
                     }
-                    // Count frames sent (approximate -- count by frames drained)
-                    shared.frames_sent.fetch_add(1, Ordering::Relaxed);
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     // Socket buffer full, keep write_buf for next cycle
@@ -648,7 +680,6 @@ fn handle_drain_request(
             eprintln!("xpf-event-stream: drain write error: {e}");
             break;
         }
-        shared.frames_sent.fetch_add(1, Ordering::Relaxed);
     }
 
     // Send DrainComplete
@@ -656,8 +687,9 @@ fn handle_drain_request(
     let complete_frame = EventFrame::encode_drain_complete(drain_seq);
     if let Err(e) = (&*stream).write_all(complete_frame.as_bytes()) {
         eprintln!("xpf-event-stream: drain complete write error: {e}");
+    } else {
+        shared.frames_sent.fetch_add(1, Ordering::Relaxed);
     }
-    shared.frames_sent.fetch_add(1, Ordering::Relaxed);
     stream.set_nonblocking(true).ok();
 
     // Restore pause state

--- a/userspace-dp/src/event_stream/producer.rs
+++ b/userspace-dp/src/event_stream/producer.rs
@@ -9,6 +9,7 @@ const DATAPLANE_EVENT_KIND_COUNT: usize = 3;
 const DATAPLANE_EVENT_ZONE_BUCKETS: usize = 256;
 const DATAPLANE_EVENT_RATE_BUCKETS: usize =
     DATAPLANE_EVENT_KIND_COUNT * DATAPLANE_EVENT_ZONE_BUCKETS;
+const DATAPLANE_EVENT_QUEUE_SHARE_DIVISOR: usize = 2;
 const NS_PER_SEC: u64 = 1_000_000_000;
 
 const DEFAULT_DATAPLANE_EVENT_RATE_PER_SEC: u64 = 1_000;
@@ -38,19 +39,35 @@ impl DataplaneEventRateLimitConfig {
         self.events_per_second == 0
     }
 
-    fn interval_ns(self) -> u64 {
+    fn runtime(self) -> DataplaneEventRateLimit {
         if self.unlimited() {
-            return 0;
+            return DataplaneEventRateLimit {
+                interval_ns: 0,
+                burst_horizon_ns: 0,
+            };
         }
-        NS_PER_SEC
+
+        let interval_ns = NS_PER_SEC
             .saturating_add(self.events_per_second.saturating_sub(1))
             .saturating_div(self.events_per_second)
-            .max(1)
-    }
-
-    fn burst_horizon_ns(self) -> u64 {
+            .max(1);
         let burst = self.burst.max(1);
-        self.interval_ns().saturating_mul(burst.saturating_sub(1))
+        DataplaneEventRateLimit {
+            interval_ns,
+            burst_horizon_ns: interval_ns.saturating_mul(burst.saturating_sub(1)),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DataplaneEventRateLimit {
+    interval_ns: u64,
+    burst_horizon_ns: u64,
+}
+
+impl DataplaneEventRateLimit {
+    fn unlimited(self) -> bool {
+        self.interval_ns == 0
     }
 }
 
@@ -60,21 +77,19 @@ struct DataplaneEventRateBucket {
 }
 
 impl DataplaneEventRateBucket {
-    fn allow_at(&self, config: DataplaneEventRateLimitConfig, now_ns: u64) -> bool {
-        if config.unlimited() {
+    fn allow_at(&self, limit: DataplaneEventRateLimit, now_ns: u64) -> bool {
+        if limit.unlimited() {
             return true;
         }
 
         // GCRA form of a token bucket: one atomic TAT gives fixed memory,
         // no locks, and no per-packet heap work on the producer path.
-        let interval_ns = config.interval_ns();
-        let burst_horizon_ns = config.burst_horizon_ns();
         let mut tat = self.theoretical_arrival_ns.load(Ordering::Relaxed);
         loop {
-            if tat.saturating_sub(burst_horizon_ns) > now_ns {
+            if tat.saturating_sub(limit.burst_horizon_ns) > now_ns {
                 return false;
             }
-            let next_tat = tat.max(now_ns).saturating_add(interval_ns);
+            let next_tat = tat.max(now_ns).saturating_add(limit.interval_ns);
             match self.theoretical_arrival_ns.compare_exchange_weak(
                 tat,
                 next_tat,
@@ -89,20 +104,73 @@ impl DataplaneEventRateBucket {
 }
 
 pub(super) struct DataplaneEventRateLimiter {
-    config: DataplaneEventRateLimitConfig,
+    limit: DataplaneEventRateLimit,
     buckets: [DataplaneEventRateBucket; DATAPLANE_EVENT_RATE_BUCKETS],
 }
 
 impl DataplaneEventRateLimiter {
     pub(super) fn new(config: DataplaneEventRateLimitConfig) -> Self {
         Self {
-            config,
+            limit: config.runtime(),
             buckets: array::from_fn(|_| DataplaneEventRateBucket::default()),
         }
     }
 
     fn allow_at(&self, kind: DataplaneEventKind, ingress_zone_id: u16, now_ns: u64) -> bool {
-        self.buckets[rate_bucket_index(kind, ingress_zone_id)].allow_at(self.config, now_ns)
+        self.buckets[rate_bucket_index(kind, ingress_zone_id)].allow_at(self.limit, now_ns)
+    }
+}
+
+pub(super) struct DataplaneEventQueueBudget {
+    max_total_queued: u64,
+    max_kind_queued: u64,
+    total_queued: AtomicU64,
+    kind_queued: [AtomicU64; DATAPLANE_EVENT_KIND_COUNT],
+}
+
+impl DataplaneEventQueueBudget {
+    pub(super) fn new(channel_capacity: usize) -> Self {
+        // Dataplane telemetry is lossy by design: bound it to roughly half of
+        // the shared channel for normal capacities, then split that telemetry
+        // share across event kinds so one storm cannot monopolize it.
+        let max_total_queued = (channel_capacity / DATAPLANE_EVENT_QUEUE_SHARE_DIVISOR) as u64;
+        let max_total_queued = if channel_capacity == 0 {
+            0
+        } else {
+            max_total_queued.max(1)
+        };
+        let kind_count = DATAPLANE_EVENT_KIND_COUNT as u64;
+        let max_kind_queued = if max_total_queued == 0 {
+            0
+        } else {
+            max_total_queued
+                .saturating_add(kind_count.saturating_sub(1))
+                .saturating_div(kind_count)
+                .max(1)
+        };
+
+        Self {
+            max_total_queued,
+            max_kind_queued,
+            total_queued: AtomicU64::new(0),
+            kind_queued: array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    fn try_acquire(&self, kind: DataplaneEventKind) -> bool {
+        if !try_increment_below(&self.total_queued, self.max_total_queued) {
+            return false;
+        }
+        if !try_increment_below(&self.kind_queued[kind_index(kind)], self.max_kind_queued) {
+            self.total_queued.fetch_sub(1, Ordering::Relaxed);
+            return false;
+        }
+        true
+    }
+
+    pub(super) fn release(&self, kind: DataplaneEventKind) {
+        decrement_if_positive(&self.kind_queued[kind_index(kind)]);
+        decrement_if_positive(&self.total_queued);
     }
 }
 
@@ -219,12 +287,23 @@ impl EventStreamWorkerHandle {
 
         let seq = self.next_seq();
         let frame = EventFrame::encode_dataplane_event(seq, &event);
+        if !self.shared.dataplane_event_queue.try_acquire(kind) {
+            self.shared
+                .dataplane_event_counters
+                .record_drop(kind, DataplaneEventDropReason::QueueFull);
+            self.shared.frames_dropped.fetch_add(1, Ordering::Relaxed);
+            return DataplaneEventEmitOutcome::Dropped {
+                reason: DataplaneEventDropReason::QueueFull,
+            };
+        }
+
         match self.try_send_frame(frame) {
             Ok(()) => {
                 self.shared.dataplane_event_counters.record_sent(kind);
                 DataplaneEventEmitOutcome::Queued { seq }
             }
             Err(EventStreamSendError::Full) => {
+                self.shared.dataplane_event_queue.release(kind);
                 self.shared
                     .dataplane_event_counters
                     .record_drop(kind, DataplaneEventDropReason::QueueFull);
@@ -233,6 +312,7 @@ impl EventStreamWorkerHandle {
                 }
             }
             Err(EventStreamSendError::Disconnected) => {
+                self.shared.dataplane_event_queue.release(kind);
                 self.shared
                     .dataplane_event_counters
                     .record_drop(kind, DataplaneEventDropReason::Disconnected);
@@ -260,6 +340,43 @@ fn kind_index(kind: DataplaneEventKind) -> usize {
 fn rate_bucket_index(kind: DataplaneEventKind, ingress_zone_id: u16) -> usize {
     let zone_bucket = usize::from(ingress_zone_id).min(DATAPLANE_EVENT_ZONE_BUCKETS - 1);
     kind_index(kind) * DATAPLANE_EVENT_ZONE_BUCKETS + zone_bucket
+}
+
+fn try_increment_below(counter: &AtomicU64, limit: u64) -> bool {
+    let mut current = counter.load(Ordering::Relaxed);
+    loop {
+        if current >= limit {
+            return false;
+        }
+        match counter.compare_exchange_weak(
+            current,
+            current + 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return true,
+            Err(actual) => current = actual,
+        }
+    }
+}
+
+fn decrement_if_positive(counter: &AtomicU64) {
+    let mut current = counter.load(Ordering::Relaxed);
+    loop {
+        if current == 0 {
+            debug_assert!(false, "dataplane event queue budget underflow");
+            return;
+        }
+        match counter.compare_exchange_weak(
+            current,
+            current - 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return,
+            Err(actual) => current = actual,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/userspace-dp/src/event_stream/producer.rs
+++ b/userspace-dp/src/event_stream/producer.rs
@@ -285,8 +285,6 @@ impl EventStreamWorkerHandle {
             };
         }
 
-        let seq = self.next_seq();
-        let frame = EventFrame::encode_dataplane_event(seq, &event);
         if !self.shared.dataplane_event_queue.try_acquire(kind) {
             self.shared
                 .dataplane_event_counters
@@ -297,6 +295,8 @@ impl EventStreamWorkerHandle {
             };
         }
 
+        let seq = self.next_seq();
+        let frame = EventFrame::encode_dataplane_event(seq, &event);
         match self.try_send_frame(frame) {
             Ok(()) => {
                 self.shared.dataplane_event_counters.record_sent(kind);

--- a/userspace-dp/src/event_stream/producer.rs
+++ b/userspace-dp/src/event_stream/producer.rs
@@ -1,0 +1,267 @@
+#![allow(dead_code)] // producer call sites are intentionally wired in later slices
+
+use super::codec::{DataplaneEventKind, DataplaneEventPayload};
+use super::{EventFrame, EventStreamSendError, EventStreamWorkerHandle};
+use std::array;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const DATAPLANE_EVENT_KIND_COUNT: usize = 3;
+const DATAPLANE_EVENT_ZONE_BUCKETS: usize = 256;
+const DATAPLANE_EVENT_RATE_BUCKETS: usize =
+    DATAPLANE_EVENT_KIND_COUNT * DATAPLANE_EVENT_ZONE_BUCKETS;
+const NS_PER_SEC: u64 = 1_000_000_000;
+
+const DEFAULT_DATAPLANE_EVENT_RATE_PER_SEC: u64 = 1_000;
+const DEFAULT_DATAPLANE_EVENT_BURST: u64 = 1_024;
+
+/// Per-kind/per-source-zone rate-limit configuration for dataplane telemetry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DataplaneEventRateLimitConfig {
+    /// Sustained event rate per `(event kind, ingress zone)` bucket. Zero
+    /// disables limiting for tests and emergency builds.
+    pub(crate) events_per_second: u64,
+    /// Instantaneous burst per `(event kind, ingress zone)` bucket.
+    pub(crate) burst: u64,
+}
+
+impl Default for DataplaneEventRateLimitConfig {
+    fn default() -> Self {
+        Self {
+            events_per_second: DEFAULT_DATAPLANE_EVENT_RATE_PER_SEC,
+            burst: DEFAULT_DATAPLANE_EVENT_BURST,
+        }
+    }
+}
+
+impl DataplaneEventRateLimitConfig {
+    fn unlimited(self) -> bool {
+        self.events_per_second == 0
+    }
+
+    fn interval_ns(self) -> u64 {
+        if self.unlimited() {
+            return 0;
+        }
+        NS_PER_SEC
+            .saturating_add(self.events_per_second.saturating_sub(1))
+            .saturating_div(self.events_per_second)
+            .max(1)
+    }
+
+    fn burst_horizon_ns(self) -> u64 {
+        let burst = self.burst.max(1);
+        self.interval_ns().saturating_mul(burst.saturating_sub(1))
+    }
+}
+
+#[derive(Default)]
+struct DataplaneEventRateBucket {
+    theoretical_arrival_ns: AtomicU64,
+}
+
+impl DataplaneEventRateBucket {
+    fn allow_at(&self, config: DataplaneEventRateLimitConfig, now_ns: u64) -> bool {
+        if config.unlimited() {
+            return true;
+        }
+
+        // GCRA form of a token bucket: one atomic TAT gives fixed memory,
+        // no locks, and no per-packet heap work on the producer path.
+        let interval_ns = config.interval_ns();
+        let burst_horizon_ns = config.burst_horizon_ns();
+        let mut tat = self.theoretical_arrival_ns.load(Ordering::Relaxed);
+        loop {
+            if tat.saturating_sub(burst_horizon_ns) > now_ns {
+                return false;
+            }
+            let next_tat = tat.max(now_ns).saturating_add(interval_ns);
+            match self.theoretical_arrival_ns.compare_exchange_weak(
+                tat,
+                next_tat,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => tat = actual,
+            }
+        }
+    }
+}
+
+pub(super) struct DataplaneEventRateLimiter {
+    config: DataplaneEventRateLimitConfig,
+    buckets: [DataplaneEventRateBucket; DATAPLANE_EVENT_RATE_BUCKETS],
+}
+
+impl DataplaneEventRateLimiter {
+    pub(super) fn new(config: DataplaneEventRateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: array::from_fn(|_| DataplaneEventRateBucket::default()),
+        }
+    }
+
+    fn allow_at(&self, kind: DataplaneEventKind, ingress_zone_id: u16, now_ns: u64) -> bool {
+        self.buckets[rate_bucket_index(kind, ingress_zone_id)].allow_at(self.config, now_ns)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DataplaneEventDropReason {
+    RateLimited,
+    QueueFull,
+    Disconnected,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DataplaneEventEmitOutcome {
+    Queued { seq: u64 },
+    Dropped { reason: DataplaneEventDropReason },
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DataplaneEventKindStats {
+    pub(crate) sent: u64,
+    pub(crate) dropped: u64,
+    pub(crate) rate_limited: u64,
+    pub(crate) queue_full: u64,
+    pub(crate) disconnected: u64,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DataplaneEventStats {
+    pub(crate) policy_deny: DataplaneEventKindStats,
+    pub(crate) screen_drop: DataplaneEventKindStats,
+    pub(crate) filter_log: DataplaneEventKindStats,
+}
+
+pub(super) struct DataplaneEventCounters {
+    sent: [AtomicU64; DATAPLANE_EVENT_KIND_COUNT],
+    rate_limited: [AtomicU64; DATAPLANE_EVENT_KIND_COUNT],
+    queue_full: [AtomicU64; DATAPLANE_EVENT_KIND_COUNT],
+    disconnected: [AtomicU64; DATAPLANE_EVENT_KIND_COUNT],
+}
+
+impl DataplaneEventCounters {
+    pub(super) fn new() -> Self {
+        Self {
+            sent: array::from_fn(|_| AtomicU64::new(0)),
+            rate_limited: array::from_fn(|_| AtomicU64::new(0)),
+            queue_full: array::from_fn(|_| AtomicU64::new(0)),
+            disconnected: array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    fn record_sent(&self, kind: DataplaneEventKind) {
+        self.sent[kind_index(kind)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_drop(&self, kind: DataplaneEventKind, reason: DataplaneEventDropReason) {
+        let counters = match reason {
+            DataplaneEventDropReason::RateLimited => &self.rate_limited,
+            DataplaneEventDropReason::QueueFull => &self.queue_full,
+            DataplaneEventDropReason::Disconnected => &self.disconnected,
+        };
+        counters[kind_index(kind)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(super) fn snapshot(&self) -> DataplaneEventStats {
+        DataplaneEventStats {
+            policy_deny: self.kind_snapshot(DataplaneEventKind::PolicyDeny),
+            screen_drop: self.kind_snapshot(DataplaneEventKind::ScreenDrop),
+            filter_log: self.kind_snapshot(DataplaneEventKind::FilterLog),
+        }
+    }
+
+    fn kind_snapshot(&self, kind: DataplaneEventKind) -> DataplaneEventKindStats {
+        let idx = kind_index(kind);
+        let rate_limited = self.rate_limited[idx].load(Ordering::Relaxed);
+        let queue_full = self.queue_full[idx].load(Ordering::Relaxed);
+        let disconnected = self.disconnected[idx].load(Ordering::Relaxed);
+        DataplaneEventKindStats {
+            sent: self.sent[idx].load(Ordering::Relaxed),
+            dropped: rate_limited
+                .saturating_add(queue_full)
+                .saturating_add(disconnected),
+            rate_limited,
+            queue_full,
+            disconnected,
+        }
+    }
+}
+
+impl EventStreamWorkerHandle {
+    /// Fixed-size, non-blocking dataplane telemetry emission.
+    ///
+    /// `now_ns` is a caller-supplied monotonic timestamp used only for rate
+    /// limiting; `event.timestamp_ns` remains the on-wire event timestamp.
+    pub(crate) fn try_emit_dataplane_event_at(
+        &self,
+        event: DataplaneEventPayload,
+        now_ns: u64,
+    ) -> DataplaneEventEmitOutcome {
+        let kind = event.kind;
+        if !self
+            .shared
+            .dataplane_event_limiter
+            .allow_at(kind, event.ingress_zone_id, now_ns)
+        {
+            self.shared
+                .dataplane_event_counters
+                .record_drop(kind, DataplaneEventDropReason::RateLimited);
+            self.shared.frames_dropped.fetch_add(1, Ordering::Relaxed);
+            return DataplaneEventEmitOutcome::Dropped {
+                reason: DataplaneEventDropReason::RateLimited,
+            };
+        }
+
+        let seq = self.next_seq();
+        let frame = EventFrame::encode_dataplane_event(seq, &event);
+        match self.try_send_frame(frame) {
+            Ok(()) => {
+                self.shared.dataplane_event_counters.record_sent(kind);
+                DataplaneEventEmitOutcome::Queued { seq }
+            }
+            Err(EventStreamSendError::Full) => {
+                self.shared
+                    .dataplane_event_counters
+                    .record_drop(kind, DataplaneEventDropReason::QueueFull);
+                DataplaneEventEmitOutcome::Dropped {
+                    reason: DataplaneEventDropReason::QueueFull,
+                }
+            }
+            Err(EventStreamSendError::Disconnected) => {
+                self.shared
+                    .dataplane_event_counters
+                    .record_drop(kind, DataplaneEventDropReason::Disconnected);
+                DataplaneEventEmitOutcome::Dropped {
+                    reason: DataplaneEventDropReason::Disconnected,
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)] // surfaced through EventStreamSender::stats for now
+    pub(crate) fn dataplane_event_stats(&self) -> DataplaneEventStats {
+        self.shared.dataplane_event_counters.snapshot()
+    }
+}
+
+fn kind_index(kind: DataplaneEventKind) -> usize {
+    match kind {
+        DataplaneEventKind::PolicyDeny => 0,
+        DataplaneEventKind::ScreenDrop => 1,
+        DataplaneEventKind::FilterLog => 2,
+    }
+}
+
+fn rate_bucket_index(kind: DataplaneEventKind, ingress_zone_id: u16) -> usize {
+    let zone_bucket = usize::from(ingress_zone_id).min(DATAPLANE_EVENT_ZONE_BUCKETS - 1);
+    kind_index(kind) * DATAPLANE_EVENT_ZONE_BUCKETS + zone_bucket
+}
+
+#[cfg(test)]
+#[path = "producer_tests.rs"]
+mod tests;

--- a/userspace-dp/src/event_stream/producer_tests.rs
+++ b/userspace-dp/src/event_stream/producer_tests.rs
@@ -229,7 +229,7 @@ fn dataplane_event_queue_full_counts_per_kind_drop() {
 
     assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 1);
     assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
-    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 2);
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 1);
 
     let stats = handle.dataplane_event_stats();
     assert_eq!(stats.filter_log.sent, 1);

--- a/userspace-dp/src/event_stream/producer_tests.rs
+++ b/userspace-dp/src/event_stream/producer_tests.rs
@@ -1,0 +1,185 @@
+use super::super::{EventStreamShared, EventStreamWorkerHandle};
+use super::*;
+use crate::event_stream::codec::{DataplaneEventKind, DataplaneEventPayload};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, mpsc};
+
+fn test_handle(
+    capacity: usize,
+    config: DataplaneEventRateLimitConfig,
+) -> (
+    EventStreamWorkerHandle,
+    mpsc::Receiver<crate::event_stream::EventFrame>,
+    Arc<EventStreamShared>,
+) {
+    let (tx, rx) = mpsc::sync_channel(capacity);
+    let shared = Arc::new(EventStreamShared::new_with_dataplane_event_rate(config));
+    (
+        EventStreamWorkerHandle {
+            tx,
+            shared: shared.clone(),
+        },
+        rx,
+        shared,
+    )
+}
+
+fn test_event(kind: DataplaneEventKind, ingress_zone_id: u16) -> DataplaneEventPayload {
+    DataplaneEventPayload {
+        kind,
+        addr_family: libc::AF_INET as u8,
+        protocol: 6,
+        action: 0,
+        src_ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        src_port: 12345,
+        dst_port: 443,
+        nat_src_ip: None,
+        nat_dst_ip: None,
+        nat_src_port: 0,
+        nat_dst_port: 0,
+        ingress_zone_id,
+        egress_zone_id: 9,
+        ingress_ifindex: 42,
+        policy_id: 101,
+        rule_id: 202,
+        term_id: 303,
+        reason: 5,
+        owner_rg_id: 1,
+        application_id: 404,
+        filter_id: 505,
+        screen_id: 606,
+        timestamp_ns: 123_456_789,
+    }
+}
+
+#[test]
+fn dataplane_event_emit_queues_frame_and_counts_sent() {
+    let (handle, rx, shared) = test_handle(4, DataplaneEventRateLimitConfig::default());
+
+    let outcome =
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0);
+
+    assert_eq!(outcome, DataplaneEventEmitOutcome::Queued { seq: 1 });
+    let frame = rx.try_recv().expect("queued event frame");
+    assert_eq!(frame.seq, 1);
+    assert_eq!(
+        frame
+            .decode_dataplane_event()
+            .expect("decode queued dataplane event")
+            .kind,
+        DataplaneEventKind::PolicyDeny
+    );
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 1);
+    assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 0);
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.policy_deny.sent, 1);
+    assert_eq!(stats.policy_deny.dropped, 0);
+}
+
+#[test]
+fn dataplane_event_rate_limit_is_per_kind_and_ingress_zone() {
+    let config = DataplaneEventRateLimitConfig {
+        events_per_second: 1,
+        burst: 1,
+    };
+    let (handle, _rx, shared) = test_handle(8, config);
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0),
+        DataplaneEventEmitOutcome::Queued { seq: 1 }
+    );
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0),
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::RateLimited
+        }
+    );
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::ScreenDrop, 7), 0),
+        DataplaneEventEmitOutcome::Queued { seq: 2 }
+    );
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 8), 0),
+        DataplaneEventEmitOutcome::Queued { seq: 3 }
+    );
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_event(DataplaneEventKind::PolicyDeny, 7),
+            1_000_000_000
+        ),
+        DataplaneEventEmitOutcome::Queued { seq: 4 }
+    );
+
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 4);
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 4);
+    assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.policy_deny.sent, 3);
+    assert_eq!(stats.policy_deny.rate_limited, 1);
+    assert_eq!(stats.policy_deny.dropped, 1);
+    assert_eq!(stats.screen_drop.sent, 1);
+    assert_eq!(stats.screen_drop.dropped, 0);
+}
+
+#[test]
+fn dataplane_event_queue_full_counts_per_kind_drop() {
+    let (handle, _rx, shared) = test_handle(
+        1,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::FilterLog, 7), 0),
+        DataplaneEventEmitOutcome::Queued { seq: 1 }
+    );
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::FilterLog, 7), 0),
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::QueueFull
+        }
+    );
+
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 1);
+    assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 2);
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.filter_log.sent, 1);
+    assert_eq!(stats.filter_log.queue_full, 1);
+    assert_eq!(stats.filter_log.dropped, 1);
+}
+
+#[test]
+fn dataplane_event_disconnected_counts_per_kind_drop() {
+    let (handle, rx, shared) = test_handle(
+        1,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    drop(rx);
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::ScreenDrop, 7), 0),
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::Disconnected
+        }
+    );
+
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 0);
+    assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 1);
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.screen_drop.sent, 0);
+    assert_eq!(stats.screen_drop.disconnected, 1);
+    assert_eq!(stats.screen_drop.dropped, 1);
+}

--- a/userspace-dp/src/event_stream/producer_tests.rs
+++ b/userspace-dp/src/event_stream/producer_tests.rs
@@ -14,7 +14,9 @@ fn test_handle(
     Arc<EventStreamShared>,
 ) {
     let (tx, rx) = mpsc::sync_channel(capacity);
-    let shared = Arc::new(EventStreamShared::new_with_dataplane_event_rate(config));
+    let shared = Arc::new(
+        EventStreamShared::new_with_dataplane_event_rate_and_queue_capacity(config, capacity),
+    );
     (
         EventStreamWorkerHandle {
             tx,
@@ -85,7 +87,7 @@ fn dataplane_event_rate_limit_is_per_kind_and_ingress_zone() {
         events_per_second: 1,
         burst: 1,
     };
-    let (handle, _rx, shared) = test_handle(8, config);
+    let (handle, _rx, shared) = test_handle(16, config);
 
     assert_eq!(
         handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0),
@@ -123,6 +125,85 @@ fn dataplane_event_rate_limit_is_per_kind_and_ingress_zone() {
     assert_eq!(stats.policy_deny.dropped, 1);
     assert_eq!(stats.screen_drop.sent, 1);
     assert_eq!(stats.screen_drop.dropped, 0);
+}
+
+#[test]
+fn dataplane_event_kind_budget_prevents_one_kind_from_monopolizing_shared_queue() {
+    let capacity = 8;
+    let (handle, _rx, shared) = test_handle(
+        capacity,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    let mut admitted_policy_deny = 0usize;
+    for _ in 0..=capacity {
+        match handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0) {
+            DataplaneEventEmitOutcome::Queued { .. } => admitted_policy_deny += 1,
+            DataplaneEventEmitOutcome::Dropped {
+                reason: DataplaneEventDropReason::QueueFull,
+            } => break,
+            other => panic!("unexpected policy deny outcome: {other:?}"),
+        }
+    }
+
+    assert!(
+        admitted_policy_deny < capacity,
+        "one event kind must hit its queue budget before it fills the shared channel"
+    );
+    let seq_before_screen = shared.next_seq.load(Ordering::Relaxed);
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::ScreenDrop, 7), 0),
+        DataplaneEventEmitOutcome::Queued {
+            seq: seq_before_screen + 1
+        }
+    );
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.policy_deny.sent, admitted_policy_deny as u64);
+    assert_eq!(stats.policy_deny.queue_full, 1);
+    assert_eq!(stats.screen_drop.sent, 1);
+}
+
+#[test]
+fn dataplane_event_total_budget_reserves_shared_queue_capacity_for_session_frames() {
+    let capacity = 8;
+    let (handle, _rx, _shared) = test_handle(
+        capacity,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let kinds = [
+        DataplaneEventKind::PolicyDeny,
+        DataplaneEventKind::ScreenDrop,
+        DataplaneEventKind::FilterLog,
+    ];
+
+    let mut admitted_events = 0usize;
+    for idx in 0..=capacity {
+        match handle.try_emit_dataplane_event_at(test_event(kinds[idx % kinds.len()], 7), 0) {
+            DataplaneEventEmitOutcome::Queued { .. } => admitted_events += 1,
+            DataplaneEventEmitOutcome::Dropped {
+                reason: DataplaneEventDropReason::QueueFull,
+            } => break,
+            other => panic!("unexpected dataplane event outcome: {other:?}"),
+        }
+    }
+
+    assert!(
+        admitted_events < capacity,
+        "dataplane telemetry must leave shared queue capacity for non-telemetry frames"
+    );
+    assert!(
+        handle.try_send(crate::event_stream::EventFrame::encode_drain_complete(
+            10_000
+        )),
+        "session/control frames must still fit after telemetry hits its budget"
+    );
 }
 
 #[test]

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -115,6 +115,7 @@ fn test_channel_backpressure() {
 
     // Third send should fail (channel full)
     assert!(!handle.try_send(frame));
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 2);
     assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
 }
 
@@ -171,6 +172,7 @@ fn test_lossless_send_waits_for_capacity() {
     hold_tx.send(()).expect("release consumer thread");
     sender_join.join().expect("sender thread");
     consumer_join.join().expect("consumer thread");
+    assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 2);
     assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 0);
 }
 

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -3,9 +3,10 @@
 // LOC threshold. Loaded as a sibling submodule via
 // `#[path = "tests.rs"]` from mod.rs.
 
-use super::codec::MSG_FULL_RESYNC;
+use super::codec::{DataplaneEventKind, DataplaneEventPayload, MSG_FULL_RESYNC};
 use super::*;
-use std::io::Read;
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr};
 
 fn build_raw_ack_frame(seq: u64) -> [u8; FRAME_HEADER_SIZE] {
     let mut buf = [0u8; FRAME_HEADER_SIZE];
@@ -15,6 +16,35 @@ fn build_raw_ack_frame(seq: u64) -> [u8; FRAME_HEADER_SIZE] {
     // reserved bytes 5..8 stay zero
     buf[8..16].copy_from_slice(&seq.to_le_bytes());
     buf
+}
+
+fn test_dataplane_event(kind: DataplaneEventKind, ingress_zone_id: u16) -> DataplaneEventPayload {
+    DataplaneEventPayload {
+        kind,
+        addr_family: libc::AF_INET as u8,
+        protocol: 6,
+        action: 0,
+        src_ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        src_port: 12345,
+        dst_port: 443,
+        nat_src_ip: None,
+        nat_dst_ip: None,
+        nat_src_port: 0,
+        nat_dst_port: 0,
+        ingress_zone_id,
+        egress_zone_id: 9,
+        ingress_ifindex: 42,
+        policy_id: 101,
+        rule_id: 202,
+        term_id: 303,
+        reason: 5,
+        owner_rg_id: 1,
+        application_id: 404,
+        filter_id: 505,
+        screen_id: 606,
+        timestamp_ns: 123_456_789,
+    }
 }
 
 #[test]
@@ -117,6 +147,166 @@ fn test_channel_backpressure() {
     assert!(!handle.try_send(frame));
     assert_eq!(shared.frames_sent.load(Ordering::Relaxed), 2);
     assert_eq!(shared.frames_dropped.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
+    let (mut daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    daemon_side
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .unwrap();
+    helper_side.set_nonblocking(true).unwrap();
+
+    let capacity = 1;
+    let (tx, rx) = mpsc::sync_channel::<EventFrame>(capacity);
+    let shared = Arc::new(
+        EventStreamShared::new_with_dataplane_event_rate_and_queue_capacity(
+            DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+            capacity,
+        ),
+    );
+    let handle = EventStreamWorkerHandle {
+        tx,
+        shared: shared.clone(),
+    };
+    let stop = Arc::new(AtomicBool::new(false));
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_dataplane_event(DataplaneEventKind::PolicyDeny, 7),
+            0
+        ),
+        DataplaneEventEmitOutcome::Queued { seq: 1 }
+    );
+
+    let loop_shared = shared.clone();
+    let loop_stop = stop.clone();
+    let loop_join = thread::spawn(move || {
+        let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
+        let mut ctrl_read_buf: Vec<u8> = Vec::new();
+        let reconnect = run_connected_loop(
+            &rx,
+            &helper_side,
+            &loop_shared,
+            &loop_stop,
+            &mut replay_buf,
+            &mut ctrl_read_buf,
+        );
+        drain_remaining(&rx, &loop_shared);
+        release_replay_dataplane_event_queue_budget(&loop_shared, &mut replay_buf);
+        reconnect
+    });
+
+    let mut hdr = [0u8; FRAME_HEADER_SIZE];
+    daemon_side
+        .read_exact(&mut hdr)
+        .expect("dataplane frame header");
+    let payload_len = u32::from_le_bytes(hdr[0..4].try_into().unwrap()) as usize;
+    let mut payload = vec![0u8; payload_len];
+    daemon_side
+        .read_exact(&mut payload)
+        .expect("dataplane frame payload");
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_dataplane_event(DataplaneEventKind::PolicyDeny, 7),
+            0
+        ),
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::QueueFull
+        },
+        "draining the mpsc channel into replay must not release telemetry budget"
+    );
+
+    daemon_side
+        .write_all(&build_raw_ack_frame(1))
+        .expect("send ACK");
+    let deadline = Instant::now() + Duration::from_millis(250);
+    loop {
+        match handle
+            .try_emit_dataplane_event_at(test_dataplane_event(DataplaneEventKind::PolicyDeny, 7), 0)
+        {
+            DataplaneEventEmitOutcome::Queued { seq: 2 } => break,
+            DataplaneEventEmitOutcome::Dropped {
+                reason: DataplaneEventDropReason::QueueFull,
+            } if Instant::now() < deadline => thread::sleep(Duration::from_millis(1)),
+            other => panic!("telemetry budget should release after ACK, got {other:?}"),
+        }
+    }
+
+    stop.store(true, Ordering::Release);
+    assert!(
+        !loop_join.join().expect("connected loop thread"),
+        "test loop should stop without requesting reconnect"
+    );
+}
+
+#[test]
+fn dataplane_event_budget_releases_when_replay_eviction_drops_frame() {
+    let capacity = 1;
+    let (tx, rx) = mpsc::sync_channel::<EventFrame>(capacity);
+    let shared = Arc::new(
+        EventStreamShared::new_with_dataplane_event_rate_and_queue_capacity(
+            DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+            capacity,
+        ),
+    );
+    let handle = EventStreamWorkerHandle {
+        tx,
+        shared: shared.clone(),
+    };
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_dataplane_event(DataplaneEventKind::PolicyDeny, 7),
+            0
+        ),
+        DataplaneEventEmitOutcome::Queued { seq: 1 }
+    );
+    let frame = rx.try_recv().expect("queued dataplane frame");
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
+    push_replay_frame(&shared, &mut replay_buf, frame);
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_dataplane_event(DataplaneEventKind::PolicyDeny, 7),
+            0
+        ),
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::QueueFull
+        }
+    );
+
+    for seq in 2..=REPLAY_BUFFER_CAPACITY as u64 {
+        push_replay_frame(
+            &shared,
+            &mut replay_buf,
+            EventFrame::encode_drain_complete(seq),
+        );
+    }
+    push_replay_frame(
+        &shared,
+        &mut replay_buf,
+        EventFrame::encode_drain_complete(REPLAY_BUFFER_CAPACITY as u64 + 1),
+    );
+
+    assert_eq!(
+        handle.try_emit_dataplane_event_at(
+            test_dataplane_event(DataplaneEventKind::PolicyDeny, 7),
+            0
+        ),
+        DataplaneEventEmitOutcome::Queued { seq: 2 },
+        "replay eviction is a definitive drop and must release telemetry budget"
+    );
+
+    drain_remaining(&rx, &shared);
+    release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Refs #1379.

Adds the bounded userspace dataplane event producer infrastructure needed before wiring policy-deny, screen-drop, and filter-log call sites:

- adds fixed-size, non-blocking RT_FLOW event emission from `EventStreamWorkerHandle`
- adds per-event-kind/per-ingress-zone GCRA rate limiting
- adds per-kind sent/drop accounting split by rate-limit, queue-full, and disconnected reasons
- updates event-stream stats/tests and docs to describe the infrastructure/call-site boundary

This intentionally does not claim full #1379 closure. Runtime producer call sites, operator-surfaced helper counters, and end-to-end syslog validation remain open.

## Validation

- `cargo test event_stream`
- `go test ./pkg/dataplane/userspace`
- `go test ./pkg/api`
- `git diff --check`
