### PR TITLE
dataplane: split userspace legacy adapter

### DIFF
--- a/docs/pr/1381-dataplane-interface-split/plan.md
+++ b/docs/pr/1381-dataplane-interface-split/plan.md
@@ -19,11 +19,14 @@ methods. It mixes:
 - runtime session and counter APIs;
 - HA, fabric, scheduler, link-cycle, and event APIs.
 
-`pkg/dataplane/userspace/manager.go` currently embeds `dataplane.DataPlane`
-and keeps `inner *dataplane.Manager`. That makes userspace compile by
-inheriting all eBPF writers. It also makes userspace runtime state depend on
-`m.inner.Map(...)` for XDP shim maps, BPF conntrack mirrors, DNAT bridge maps,
-FIB generation, RG state, and helper control.
+`pkg/dataplane/userspace/manager.go` used to embed `dataplane.DataPlane` and
+compile by inheriting all eBPF writers. The current migration slice has moved
+that legacy interface satisfaction into `userspace.LegacyDataPlaneAdapter` so
+`*userspace.Manager` implements the small `RuntimeDataPlane` contract instead
+of the BPF-shaped root interface. The manager still keeps
+`inner *dataplane.Manager` for XDP shim maps, BPF conntrack mirrors, DNAT bridge
+maps, FIB generation, RG state, and helper control. Removing that named shim
+dependency remains a later #1381 phase.
 
 `pkg/daemon` stores one `dataplane.DataPlane` and calls both generic runtime
 methods and BPF-shaped methods from the same field. The real daemon surface is
@@ -353,9 +356,11 @@ The daemon should migrate in this order:
 7. Replace `NewEventSource` and counter reads with `d.dp.Telemetry()`.
 8. Replace userspace type assertions in fabric/IPVLAN/link-cycle handling with
    `d.dp.Link()` and a narrow userspace binding-ready callback interface.
-9. Delete userspace embedding of `dataplane.DataPlane` and `inner
-   *dataplane.Manager`. At this point the canary added by this PR must be
-   inverted to fail if either dependency returns.
+9. Delete the remaining userspace `inner *dataplane.Manager` dependency once
+   the XDP shim/session/NAT pins have backend owners. The
+   `dataplane.DataPlane` embedding has already been removed; the current
+   canary now fails if it returns and records the named inner manager as the
+   remaining debt.
 
 ## BPF pin ownership
 
@@ -405,6 +410,10 @@ Phase 1: interfaces and adapters.
 - Add compile-time assertions for the new root interface and domains.
 - Add a negative compile/test canary ensuring userspace code cannot call raw
   eBPF `Set*`/`Clear*`/`Map` methods through the new root interface.
+- Current slice: `userspace.LegacyDataPlaneAdapter` is the only userspace type
+  that satisfies the legacy `dataplane.DataPlane`; `*userspace.Manager`
+  satisfies `RuntimeDataPlane` and daemon userspace-specific hooks use narrow
+  interfaces instead of concrete `*userspace.Manager` assertions.
 
 Phase 2: config ownership.
 
@@ -425,9 +434,8 @@ Phase 3: session, NAT, and telemetry ownership.
 
 Phase 4: remove eBPF inheritance.
 
-- Delete `dataplane.DataPlane` embedding and `inner *dataplane.Manager` from
-  userspace `Manager`.
-- Invert the scaffold canary: userspace Manager must not embed
+- Delete `inner *dataplane.Manager` from userspace `Manager`.
+- Keep the inverted scaffold canary strict: userspace Manager must not embed
   `dataplane.DataPlane`, must not name `*dataplane.Manager`, and must not
   import `github.com/cilium/ebpf` outside the XDP shim owner package.
 - Remove daemon access to old BPF-shaped interface.
@@ -478,9 +486,9 @@ Required during the split:
 
 - `go test ./pkg/dataplane/... ./pkg/dataplane/userspace/... ./pkg/daemon/...`
 - `go build ./...`
-- AST canary: userspace `Manager` must not embed `dataplane.DataPlane` or hold
-  `inner *dataplane.Manager` after Phase 4. This PR adds the temporary
-  pre-split form that records the current debt.
+- AST canary: userspace `Manager` must not embed `dataplane.DataPlane`; the
+  remaining named `inner *dataplane.Manager` dependency is recorded as debt and
+  must fail once Phase 4 removes it.
 - Interface method-count canary: the exported root `DataPlane` interface has
   at most 15 methods after Phase 1.
 - Import canary: the abstract dataplane/runtime package must not import

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -65,7 +65,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | Kernel-owned traffic (ARP, local delivery, management, some non-IP) | cpumap or kernel pass-through from XDP |
 | GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
-| DataPlane control-plane contract | Userspace manager still embeds the eBPF manager for many BPF-shaped map-writer methods; tracked by #1381 |
+| DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. The manager still holds a named eBPF shim manager for XDP/map bootstrap state; tracked by #1381 |
 | Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
 | `show system buffers` | Userspace helper-status rendering landed in #1386 for AF_XDP UMEM/TX capacity. #1380 still tracks the retirement gate for removing legacy BPF-map buffer reporting and settling the CLI / observability cleanup. |
 

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -313,7 +313,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		addrs  []string
 	}
 	var deferredOverlays []deferredIPVLAN
-	_, isUserspaceDP := d.dp.(*dpuserspace.Manager)
+	bindingCtrl, isUserspaceDP := d.dp.(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
 		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
 			continue
@@ -332,7 +332,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		// already exists from the OnXSKBound callback and XSK is already
 		// bound, so the xskBoundNotified guard prevents re-deletion.
 		if isUserspaceDP {
-			if um, ok := d.dp.(*dpuserspace.Manager); ok && !um.XSKBoundNotified() {
+			if bindingCtrl != nil && !bindingCtrl.XSKBoundNotified() {
 				// First applyConfig — remove stale IPVLAN so XSK can zerocopy.
 				if link, err := netlink.LinkByName(fabLinux); err == nil {
 					netlink.LinkDel(link)
@@ -370,19 +370,17 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		}
 	}
 	// Register deferred IPVLAN creation callback on the userspace manager.
-	if len(deferredOverlays) > 0 {
-		if um, ok := d.dp.(*dpuserspace.Manager); ok {
-			um.OnXSKBound = func() {
-				for _, ov := range deferredOverlays {
-					slog.Info("XSK bound — creating deferred fabric IPVLAN",
-						"parent", ov.parent, "name", ov.name)
-					if err := ensureFabricIPVLAN(ov.parent, ov.name, ov.addrs); err != nil {
-						slog.Error("deferred fabric IPVLAN creation failed",
-							"parent", ov.parent, "name", ov.name, "err", err)
-					}
+	if len(deferredOverlays) > 0 && bindingCtrl != nil {
+		bindingCtrl.SetOnXSKBound(func() {
+			for _, ov := range deferredOverlays {
+				slog.Info("XSK bound — creating deferred fabric IPVLAN",
+					"parent", ov.parent, "name", ov.name)
+				if err := ensureFabricIPVLAN(ov.parent, ov.name, ov.addrs); err != nil {
+					slog.Error("deferred fabric IPVLAN creation failed",
+						"parent", ov.parent, "name", ov.name, "err", err)
 				}
 			}
-		}
+		})
 	}
 	// Clean up stale fabric IPVLAN overlays not in current config (#128).
 	for _, name := range []string{"fab0", "fab1"} {
@@ -1052,7 +1050,7 @@ func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, ac
 	if d.dp == nil || activeState == nil || compileResult == nil {
 		return
 	}
-	if _, isUserspace := d.dp.(*dpuserspace.Manager); isUserspace {
+	if _, isUserspace := d.dp.(userspaceRuntimeModeReporter); isUserspace {
 		return
 	}
 	d.dp.UpdatePolicyScheduleState(cfg, activeState)

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -50,6 +50,19 @@ type userspaceEventStreamExporter interface {
 	ExportAllSessionsViaEventStream() error
 }
 
+type userspaceRuntimeModeReporter interface {
+	Mode() dpuserspace.DataplaneMode
+}
+
+type userspaceXSKBindingController interface {
+	XSKBoundNotified() bool
+	SetOnXSKBound(func())
+}
+
+type userspaceTakeoverReadiness interface {
+	TakeoverReady() (bool, []string)
+}
+
 func daemonMonotonicSeconds() uint64 {
 	var ts unix.Timespec
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
@@ -998,8 +1011,8 @@ func (d *Daemon) prepareUserspaceRGDemotionWithTimeout(rgID int, barrierTimeout 
 // this to skip eBPF-specific workarounds (blackhole routes) that the
 // userspace pipeline doesn't need.
 func (d *Daemon) userspaceDataplaneActive() bool {
-	if um, ok := d.dp.(*dpuserspace.Manager); ok {
-		return um.Mode() != dpuserspace.ModeEBPFOnly
+	if runtime, ok := d.dp.(userspaceRuntimeModeReporter); ok {
+		return runtime.Mode() != dpuserspace.ModeEBPFOnly
 	}
 	return false
 }
@@ -1029,9 +1042,9 @@ func (d *Daemon) checkUserspaceTakeoverReadiness(rgID int) (bool, []string) {
 	if d.dp == nil {
 		return false, []string{fmt.Sprintf("userspace dataplane not initialized for RG %d", rgID)}
 	}
-	um, ok := d.dp.(*dpuserspace.Manager)
+	ready, ok := d.dp.(userspaceTakeoverReadiness)
 	if !ok {
-		return false, []string{fmt.Sprintf("userspace dataplane manager not available for RG %d", rgID)}
+		return false, []string{fmt.Sprintf("userspace dataplane readiness provider not available for RG %d", rgID)}
 	}
-	return um.TakeoverReady()
+	return ready.TakeoverReady()
 }

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -1,0 +1,371 @@
+package userspace
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpruntime "github.com/psaab/xpf/pkg/dataplane/runtime"
+)
+
+var _ dataplane.DataPlane = (*LegacyDataPlaneAdapter)(nil)
+var _ dataplane.RuntimeDataPlane = (*LegacyDataPlaneAdapter)(nil)
+
+// LegacyDataPlaneAdapter is the compatibility boundary for callers that still
+// depend on the old BPF-shaped dataplane.DataPlane interface.
+//
+// The userspace Manager intentionally does not implement dataplane.DataPlane.
+// Until the daemon and operator surfaces move fully to RuntimeDataPlane domain
+// interfaces, this adapter delegates legacy eBPF-shaped methods to the shim
+// manager and routes userspace-owned behavior back through Manager.
+type LegacyDataPlaneAdapter struct {
+	dataplane.DataPlane
+	manager *Manager
+}
+
+func NewLegacyDataPlaneAdapter(manager *Manager) *LegacyDataPlaneAdapter {
+	if manager == nil {
+		return &LegacyDataPlaneAdapter{}
+	}
+	return &LegacyDataPlaneAdapter{
+		DataPlane: manager.inner,
+		manager:   manager,
+	}
+}
+
+func (a *LegacyDataPlaneAdapter) managerOrErr() (*Manager, error) {
+	if a == nil || a.manager == nil {
+		return nil, errors.New("nil userspace dataplane")
+	}
+	return a.manager, nil
+}
+
+func (a *LegacyDataPlaneAdapter) Start(ctx context.Context) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.Start(ctx)
+}
+
+func (a *LegacyDataPlaneAdapter) ApplyConfig(ctx context.Context, cfg *config.Config) (*dataplane.ApplyResult, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil, err
+	}
+	return m.ApplyConfig(ctx, cfg)
+}
+
+func (a *LegacyDataPlaneAdapter) LastApplyResult() *dataplane.ApplyResult {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.LastApplyResult()
+}
+
+func (a *LegacyDataPlaneAdapter) Link() dataplane.LinkController {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return dataplane.NewDataPlaneLinkController(nil)
+	}
+	return m.Link()
+}
+
+func (a *LegacyDataPlaneAdapter) HA() dataplane.HAController {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return dataplane.NewDataPlaneHAController(nil)
+	}
+	return m.HA()
+}
+
+func (a *LegacyDataPlaneAdapter) Sessions() dataplane.SessionStore {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return dataplane.NewDataPlaneSessionStore(nil)
+	}
+	return m.Sessions()
+}
+
+func (a *LegacyDataPlaneAdapter) SessionDeltas() dpruntime.SessionDeltaSource {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.SessionDeltas()
+}
+
+func (a *LegacyDataPlaneAdapter) RuntimeSessionDeltaSource() dpruntime.SessionDeltaSource {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.RuntimeSessionDeltaSource()
+}
+
+func (a *LegacyDataPlaneAdapter) Telemetry() dataplane.Telemetry {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return dataplane.NewDataPlaneTelemetry(nil)
+	}
+	return m.Telemetry()
+}
+
+func (a *LegacyDataPlaneAdapter) Load() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.Load()
+}
+
+func (a *LegacyDataPlaneAdapter) Close() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.Close()
+}
+
+func (a *LegacyDataPlaneAdapter) Teardown() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.Teardown()
+}
+
+func (a *LegacyDataPlaneAdapter) Compile(cfg *config.Config) (*dataplane.CompileResult, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil, err
+	}
+	return m.Compile(cfg)
+}
+
+func (a *LegacyDataPlaneAdapter) UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.UpdatePolicyScheduleState(cfg, activeState)
+}
+
+func (a *LegacyDataPlaneAdapter) BumpFIBGeneration() uint32 {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return 0
+	}
+	return m.BumpFIBGeneration()
+}
+
+func (a *LegacyDataPlaneAdapter) NotifyLinkCycle() {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.NotifyLinkCycle()
+}
+
+func (a *LegacyDataPlaneAdapter) SyncFabricState() {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.SyncFabricState()
+}
+
+func (a *LegacyDataPlaneAdapter) UpdateRGActive(rgID int, active bool) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.UpdateRGActive(rgID, active)
+}
+
+func (a *LegacyDataPlaneAdapter) UpdateHAWatchdog(rgID int, timestamp uint64) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.UpdateHAWatchdog(rgID, timestamp)
+}
+
+func (a *LegacyDataPlaneAdapter) UpdateFabricFwd(info dataplane.FabricFwdInfo) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.inner.UpdateFabricFwd(info)
+}
+
+func (a *LegacyDataPlaneAdapter) UpdateFabricFwd1(info dataplane.FabricFwdInfo) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.inner.UpdateFabricFwd1(info)
+}
+
+func (a *LegacyDataPlaneAdapter) SetSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.SetSessionV4(key, val)
+}
+
+func (a *LegacyDataPlaneAdapter) SetSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.SetSessionV6(key, val)
+}
+
+func (a *LegacyDataPlaneAdapter) SetClusterSyncedSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.SetClusterSyncedSessionV4(key, val)
+}
+
+func (a *LegacyDataPlaneAdapter) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.SetClusterSyncedSessionV6(key, val)
+}
+
+func (a *LegacyDataPlaneAdapter) DeleteSession(key dataplane.SessionKey) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.DeleteSession(key)
+}
+
+func (a *LegacyDataPlaneAdapter) DeleteSessionV6(key dataplane.SessionKeyV6) error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.DeleteSessionV6(key)
+}
+
+func (a *LegacyDataPlaneAdapter) SetDeferWorkers(v bool) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.SetDeferWorkers(v)
+}
+
+func (a *LegacyDataPlaneAdapter) PrepareLinkCycle() {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.PrepareLinkCycle()
+}
+
+func (a *LegacyDataPlaneAdapter) Status() (ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return m.Status()
+}
+
+func (a *LegacyDataPlaneAdapter) SetForwardingArmed(armed bool) (ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return m.SetForwardingArmed(armed)
+}
+
+func (a *LegacyDataPlaneAdapter) InjectPacket(req InjectPacketRequest) (ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return m.InjectPacket(req)
+}
+
+func (a *LegacyDataPlaneAdapter) DrainSessionDeltas(max uint32) ([]SessionDeltaInfo, ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil, ProcessStatus{}, err
+	}
+	return m.DrainSessionDeltas(max)
+}
+
+func (a *LegacyDataPlaneAdapter) ExportOwnerRGSessions(rgIDs []int, max uint32) ([]SessionDeltaInfo, ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil, ProcessStatus{}, err
+	}
+	return m.ExportOwnerRGSessions(rgIDs, max)
+}
+
+func (a *LegacyDataPlaneAdapter) SessionSyncSweepProfile() (bool, time.Duration, time.Duration) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return false, 0, 0
+	}
+	return m.SessionSyncSweepProfile()
+}
+
+func (a *LegacyDataPlaneAdapter) EventStream() *EventStream {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.EventStream()
+}
+
+func (a *LegacyDataPlaneAdapter) ExportAllSessionsViaEventStream() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.ExportAllSessionsViaEventStream()
+}
+
+func (a *LegacyDataPlaneAdapter) Mode() DataplaneMode {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ModeEBPFOnly
+	}
+	return m.Mode()
+}
+
+func (a *LegacyDataPlaneAdapter) XSKBoundNotified() bool {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return false
+	}
+	return m.XSKBoundNotified()
+}
+
+func (a *LegacyDataPlaneAdapter) SetOnXSKBound(fn func()) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.SetOnXSKBound(fn)
+}
+
+func (a *LegacyDataPlaneAdapter) TakeoverReady() (bool, []string) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return false, []string{err.Error()}
+	}
+	return m.TakeoverReady()
+}

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"context"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -29,10 +30,13 @@ func NewLegacyDataPlaneAdapter(manager *Manager) *LegacyDataPlaneAdapter {
 	if manager == nil {
 		return &LegacyDataPlaneAdapter{}
 	}
-	return &LegacyDataPlaneAdapter{
-		DataPlane: manager.inner,
-		manager:   manager,
+	adapter := &LegacyDataPlaneAdapter{
+		manager: manager,
 	}
+	if manager.inner != nil {
+		adapter.DataPlane = manager.inner
+	}
+	return adapter
 }
 
 func (a *LegacyDataPlaneAdapter) managerOrErr() (*Manager, error) {
@@ -152,6 +156,14 @@ func (a *LegacyDataPlaneAdapter) UpdatePolicyScheduleState(cfg *config.Config, a
 		return
 	}
 	m.UpdatePolicyScheduleState(cfg, activeState)
+}
+
+func (a *LegacyDataPlaneAdapter) SetPolicySchedulerActiveState(activeState map[string]bool) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.SetPolicySchedulerActiveState(activeState)
 }
 
 func (a *LegacyDataPlaneAdapter) BumpFIBGeneration() uint32 {
@@ -274,6 +286,59 @@ func (a *LegacyDataPlaneAdapter) PrepareLinkCycle() {
 	m.PrepareLinkCycle()
 }
 
+func (a *LegacyDataPlaneAdapter) RegenerateNeighborSnapshot() {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.RegenerateNeighborSnapshot()
+}
+
+func (a *LegacyDataPlaneAdapter) LookupSnapshotNeighbor(ifindex int, ip net.IP) *NeighborSnapshot {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.LookupSnapshotNeighbor(ifindex, ip)
+}
+
+func (a *LegacyDataPlaneAdapter) IsMonitoredIfindex(ifindex int) bool {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return false
+	}
+	return m.IsMonitoredIfindex(ifindex)
+}
+
+func (a *LegacyDataPlaneAdapter) ForEachSnapshotNeighbor(fn func(ifindex int, ip net.IP)) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return
+	}
+	m.ForEachSnapshotNeighbor(fn)
+}
+
+func (a *LegacyDataPlaneAdapter) SnapshotHasIfindex(ifindex int) bool {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return false
+	}
+	return m.SnapshotHasIfindex(ifindex)
+}
+
+func (a *LegacyDataPlaneAdapter) SnapshotNeighbors() []struct {
+	Ifindex int
+	IP      net.IP
+	MAC     net.HardwareAddr
+	Family  int
+} {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return nil
+	}
+	return m.SnapshotNeighbors()
+}
+
 func (a *LegacyDataPlaneAdapter) Status() (ProcessStatus, error) {
 	m, err := a.managerOrErr()
 	if err != nil {
@@ -288,6 +353,22 @@ func (a *LegacyDataPlaneAdapter) SetForwardingArmed(armed bool) (ProcessStatus, 
 		return ProcessStatus{}, err
 	}
 	return m.SetForwardingArmed(armed)
+}
+
+func (a *LegacyDataPlaneAdapter) SetQueueState(queueID uint32, registered, armed bool) (ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return m.SetQueueState(queueID, registered, armed)
+}
+
+func (a *LegacyDataPlaneAdapter) SetBindingState(slot uint32, registered, armed bool) (ProcessStatus, error) {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return m.SetBindingState(slot, registered, armed)
 }
 
 func (a *LegacyDataPlaneAdapter) InjectPacket(req InjectPacketRequest) (ProcessStatus, error) {

--- a/pkg/dataplane/userspace/legacy_dataplane_test.go
+++ b/pkg/dataplane/userspace/legacy_dataplane_test.go
@@ -1,0 +1,164 @@
+package userspace
+
+import (
+	"net"
+	"testing"
+)
+
+type legacyPolicySchedulerSeeder interface {
+	SetPolicySchedulerActiveState(map[string]bool)
+}
+
+type legacyNeighborProvider interface {
+	RegenerateNeighborSnapshot()
+	LookupSnapshotNeighbor(ifindex int, ip net.IP) *NeighborSnapshot
+	SnapshotHasIfindex(ifindex int) bool
+	IsMonitoredIfindex(ifindex int) bool
+	ForEachSnapshotNeighbor(fn func(ifindex int, ip net.IP))
+	SnapshotNeighbors() []struct {
+		Ifindex int
+		IP      net.IP
+		MAC     net.HardwareAddr
+		Family  int
+	}
+}
+
+type legacyUserspaceControl interface {
+	Status() (ProcessStatus, error)
+	SetForwardingArmed(bool) (ProcessStatus, error)
+	SetQueueState(uint32, bool, bool) (ProcessStatus, error)
+	SetBindingState(uint32, bool, bool) (ProcessStatus, error)
+	InjectPacket(InjectPacketRequest) (ProcessStatus, error)
+}
+
+var _ legacyPolicySchedulerSeeder = (*LegacyDataPlaneAdapter)(nil)
+var _ legacyNeighborProvider = (*LegacyDataPlaneAdapter)(nil)
+var _ legacyUserspaceControl = (*LegacyDataPlaneAdapter)(nil)
+
+func TestLegacyDataPlaneAdapterForwardsOptionalInterfaces(t *testing.T) {
+	m := New()
+	adapter := NewLegacyDataPlaneAdapter(m)
+
+	seeder, ok := any(adapter).(legacyPolicySchedulerSeeder)
+	if !ok {
+		t.Fatal("adapter does not expose policy scheduler seeding interface")
+	}
+	seeder.SetPolicySchedulerActiveState(map[string]bool{"workhours": true})
+	m.mu.Lock()
+	seeded := m.policySchedulerActive["workhours"]
+	m.mu.Unlock()
+	if !seeded {
+		t.Fatal("adapter did not forward policy scheduler active-state seed")
+	}
+
+	m.mu.Lock()
+	m.lastSnapshot = &ConfigSnapshot{
+		Neighbors: []NeighborSnapshot{
+			{Ifindex: 7, IP: "192.0.2.10", MAC: "02:00:00:00:00:01", State: "reachable"},
+			{Ifindex: 8, IP: "192.0.2.11", MAC: "02:00:00:00:00:02", State: "failed"},
+		},
+	}
+	m.rebuildNeighborIndex()
+	m.monitoredIfindexes = map[int]struct{}{7: {}}
+	m.mu.Unlock()
+
+	neighbors, ok := any(adapter).(legacyNeighborProvider)
+	if !ok {
+		t.Fatal("adapter does not expose neighbor snapshot provider interface")
+	}
+	if !neighbors.IsMonitoredIfindex(7) {
+		t.Fatal("adapter did not forward IsMonitoredIfindex")
+	}
+	if !neighbors.SnapshotHasIfindex(7) {
+		t.Fatal("adapter did not forward SnapshotHasIfindex")
+	}
+	if neighbors.SnapshotHasIfindex(8) {
+		t.Fatal("SnapshotHasIfindex should use publishable neighbor index")
+	}
+	entry := neighbors.LookupSnapshotNeighbor(7, net.ParseIP("192.0.2.10"))
+	if entry == nil || entry.MAC != "02:00:00:00:00:01" {
+		t.Fatalf("LookupSnapshotNeighbor = %+v, want forwarded publishable neighbor", entry)
+	}
+	var enumerated []string
+	neighbors.ForEachSnapshotNeighbor(func(ifindex int, ip net.IP) {
+		enumerated = append(enumerated, ip.String())
+	})
+	if len(enumerated) != 1 || enumerated[0] != "192.0.2.10" {
+		t.Fatalf("ForEachSnapshotNeighbor enumerated %v, want [192.0.2.10]", enumerated)
+	}
+	snapNeighbors := neighbors.SnapshotNeighbors()
+	if len(snapNeighbors) == 0 || !snapNeighbors[0].IP.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("SnapshotNeighbors = %+v, want forwarded snapshot entries", snapNeighbors)
+	}
+	neighbors.RegenerateNeighborSnapshot()
+
+	control, ok := any(adapter).(legacyUserspaceControl)
+	if !ok {
+		t.Fatal("adapter does not expose userspace control interface")
+	}
+	if _, err := control.Status(); err == nil {
+		t.Fatal("Status returned nil error with helper stopped")
+	}
+	if _, err := control.SetForwardingArmed(true); err == nil {
+		t.Fatal("SetForwardingArmed returned nil error with helper stopped")
+	}
+	if _, err := control.SetQueueState(1, true, true); err == nil {
+		t.Fatal("SetQueueState returned nil error with helper stopped")
+	}
+	if _, err := control.SetBindingState(1, true, true); err == nil {
+		t.Fatal("SetBindingState returned nil error with helper stopped")
+	}
+	if _, err := control.InjectPacket(InjectPacketRequest{}); err == nil {
+		t.Fatal("InjectPacket returned nil error with helper stopped")
+	}
+}
+
+func TestLegacyDataPlaneAdapterOptionalInterfacesNilSafe(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		adapter *LegacyDataPlaneAdapter
+	}{
+		{name: "nil receiver"},
+		{name: "nil manager", adapter: NewLegacyDataPlaneAdapter(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seeder legacyPolicySchedulerSeeder = tc.adapter
+			seeder.SetPolicySchedulerActiveState(map[string]bool{"workhours": true})
+
+			var neighbors legacyNeighborProvider = tc.adapter
+			neighbors.RegenerateNeighborSnapshot()
+			if got := neighbors.LookupSnapshotNeighbor(1, net.ParseIP("192.0.2.10")); got != nil {
+				t.Fatalf("LookupSnapshotNeighbor = %+v, want nil", got)
+			}
+			if neighbors.IsMonitoredIfindex(1) {
+				t.Fatal("IsMonitoredIfindex = true, want false")
+			}
+			if neighbors.SnapshotHasIfindex(1) {
+				t.Fatal("SnapshotHasIfindex = true, want false")
+			}
+			neighbors.ForEachSnapshotNeighbor(func(int, net.IP) {
+				t.Fatal("ForEachSnapshotNeighbor callback should not run")
+			})
+			if got := neighbors.SnapshotNeighbors(); got != nil {
+				t.Fatalf("SnapshotNeighbors = %+v, want nil", got)
+			}
+
+			var control legacyUserspaceControl = tc.adapter
+			if _, err := control.Status(); err == nil {
+				t.Fatal("Status returned nil error")
+			}
+			if _, err := control.SetForwardingArmed(true); err == nil {
+				t.Fatal("SetForwardingArmed returned nil error")
+			}
+			if _, err := control.SetQueueState(1, true, true); err == nil {
+				t.Fatal("SetQueueState returned nil error")
+			}
+			if _, err := control.SetBindingState(1, true, true); err == nil {
+				t.Fatal("SetBindingState returned nil error")
+			}
+			if _, err := control.InjectPacket(InjectPacketRequest{}); err == nil {
+				t.Fatal("InjectPacket returned nil error")
+			}
+		})
+	}
+}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var _ dataplane.DataPlane = (*Manager)(nil)
 var _ dataplane.ConfigSink = (*Manager)(nil)
 var _ dataplane.RuntimeDataPlane = (*Manager)(nil)
 
@@ -55,12 +54,11 @@ func (m DataplaneMode) String() string {
 
 func init() {
 	dataplane.RegisterBackend(dataplane.TypeUserspace, func() dataplane.DataPlane {
-		return New()
+		return NewLegacyDataPlaneAdapter(New())
 	})
 }
 
 type Manager struct {
-	dataplane.DataPlane
 	inner *dataplane.Manager
 
 	mu                    sync.Mutex
@@ -156,7 +154,6 @@ func New() *Manager {
 	inner := dataplane.New()
 	inner.XDPEntryProg = "xdp_main_prog"
 	return &Manager{
-		DataPlane:      inner,
 		inner:          inner,
 		configuredMode: ModeUserspaceCompat,
 		haGroups:       make(map[int]HAGroupStatus),
@@ -199,12 +196,12 @@ func (m *Manager) Link() dataplane.LinkController {
 }
 
 func (m *Manager) HA() dataplane.HAController {
-	return userspaceHAController{manager: m}
+	return userspaceHAController{manager: managerHAOps{manager: m}}
 }
 
 func (m *Manager) Sessions() dataplane.SessionStore {
 	return userspaceSessionStore{
-		SessionStore: dataplane.NewDataPlaneSessionStore(m),
+		SessionStore: dataplane.NewDataPlaneSessionStore(NewLegacyDataPlaneAdapter(m)),
 		source:       m.RuntimeSessionDeltaSource(),
 	}
 }
@@ -214,7 +211,7 @@ func (m *Manager) SessionDeltas() dpruntime.SessionDeltaSource {
 }
 
 func (m *Manager) Telemetry() dataplane.Telemetry {
-	return dataplane.NewDataPlaneTelemetry(m)
+	return dataplane.NewDataPlaneTelemetry(NewLegacyDataPlaneAdapter(m))
 }
 
 type userspaceLinkController struct {
@@ -245,6 +242,44 @@ type userspaceHAOps interface {
 	UpdateFabricFwd(dataplane.FabricFwdInfo) error
 	UpdateFabricFwd1(dataplane.FabricFwdInfo) error
 	SyncFabricState()
+}
+
+type managerHAOps struct {
+	manager *Manager
+}
+
+func (o managerHAOps) UpdateRGActive(rgID int, active bool) error {
+	if o.manager == nil {
+		return errors.New("nil userspace dataplane")
+	}
+	return o.manager.UpdateRGActive(rgID, active)
+}
+
+func (o managerHAOps) UpdateHAWatchdog(rgID int, timestamp uint64) error {
+	if o.manager == nil {
+		return errors.New("nil userspace dataplane")
+	}
+	return o.manager.UpdateHAWatchdog(rgID, timestamp)
+}
+
+func (o managerHAOps) UpdateFabricFwd(info dataplane.FabricFwdInfo) error {
+	if o.manager == nil || o.manager.inner == nil {
+		return errors.New("nil userspace dataplane")
+	}
+	return o.manager.inner.UpdateFabricFwd(info)
+}
+
+func (o managerHAOps) UpdateFabricFwd1(info dataplane.FabricFwdInfo) error {
+	if o.manager == nil || o.manager.inner == nil {
+		return errors.New("nil userspace dataplane")
+	}
+	return o.manager.inner.UpdateFabricFwd1(info)
+}
+
+func (o managerHAOps) SyncFabricState() {
+	if o.manager != nil {
+		o.manager.SyncFabricState()
+	}
 }
 
 type userspaceHAController struct {
@@ -366,6 +401,12 @@ func (m *Manager) XSKBoundNotified() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.xskBoundNotified
+}
+
+func (m *Manager) SetOnXSKBound(fn func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.OnXSKBound = fn
 }
 
 // Mode returns the current active dataplane runtime mode.

--- a/pkg/dataplane/userspace/manager_coupling_test.go
+++ b/pkg/dataplane/userspace/manager_coupling_test.go
@@ -6,9 +6,11 @@ import (
 	"go/token"
 	"path/filepath"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
 )
 
-func TestUserspaceManagerBPFShimDebtMatchesSplitPlan(t *testing.T) {
+func TestUserspaceManagerDoesNotEmbedLegacyDataPlane(t *testing.T) {
 	t.Parallel()
 
 	fset := token.NewFileSet()
@@ -45,11 +47,46 @@ func TestUserspaceManagerBPFShimDebtMatchesSplitPlan(t *testing.T) {
 		return false
 	})
 
-	if !hasEmbeddedDataPlane {
-		t.Fatal("userspace Manager no longer embeds dataplane.DataPlane; invert this scaffold canary as part of #1381")
+	if hasEmbeddedDataPlane {
+		t.Fatal("userspace Manager must not embed dataplane.DataPlane; use LegacyDataPlaneAdapter for old callers")
 	}
 	if !hasInnerDataplaneManager {
-		t.Fatal("userspace Manager no longer has inner *dataplane.Manager; invert this scaffold canary as part of #1381")
+		t.Fatal("userspace Manager no longer has inner *dataplane.Manager; update #1381 docs and remove this remaining-debt canary")
+	}
+}
+
+func TestUserspaceManagerRuntimeContractDoesNotExposeLegacyDataPlane(t *testing.T) {
+	t.Parallel()
+
+	var manager any = &Manager{}
+	if _, ok := manager.(dataplane.DataPlane); ok {
+		t.Fatal("userspace Manager unexpectedly implements legacy dataplane.DataPlane")
+	}
+	if _, ok := manager.(dataplane.RuntimeDataPlane); !ok {
+		t.Fatal("userspace Manager does not implement dataplane.RuntimeDataPlane")
+	}
+
+	var adapter any = NewLegacyDataPlaneAdapter(New())
+	if _, ok := adapter.(dataplane.DataPlane); !ok {
+		t.Fatal("LegacyDataPlaneAdapter does not implement dataplane.DataPlane")
+	}
+	if _, ok := adapter.(dataplane.RuntimeDataPlane); !ok {
+		t.Fatal("LegacyDataPlaneAdapter does not implement dataplane.RuntimeDataPlane")
+	}
+}
+
+func TestUserspaceBackendRegistryReturnsLegacyAdapter(t *testing.T) {
+	t.Parallel()
+
+	dp, err := dataplane.NewDataPlane(dataplane.TypeUserspace)
+	if err != nil {
+		t.Fatalf("NewDataPlane(userspace): %v", err)
+	}
+	if _, ok := any(dp).(*LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("NewDataPlane(userspace) = %T, want *LegacyDataPlaneAdapter", dp)
+	}
+	if _, ok := any(dp).(*Manager); ok {
+		t.Fatal("NewDataPlane(userspace) returned *Manager directly")
 	}
 }
 

--- a/pkg/dataplane/userspace/runtime_delta_test.go
+++ b/pkg/dataplane/userspace/runtime_delta_test.go
@@ -143,8 +143,8 @@ func TestRuntimeManagerHAUsesUserspaceController(t *testing.T) {
 	if !ok {
 		t.Fatalf("Manager.HA() = %T, want userspaceHAController", New().HA())
 	}
-	if _, ok := controller.manager.(*Manager); !ok {
-		t.Fatalf("Manager.HA() controller manager = %T, want *Manager", controller.manager)
+	if _, ok := controller.manager.(managerHAOps); !ok {
+		t.Fatalf("Manager.HA() controller manager = %T, want managerHAOps", controller.manager)
 	}
 }
 


### PR DESCRIPTION
## Summary

Refs #1381.

Moves the userspace dataplane one step away from the legacy BPF-shaped `dataplane.DataPlane` contract:

- removes `dataplane.DataPlane` embedding from `userspace.Manager`
- introduces `userspace.LegacyDataPlaneAdapter` as the explicit compatibility boundary for old callers
- keeps userspace-owned operations routed through `Manager` from the adapter while legacy shim methods continue through the inner dataplane manager
- replaces daemon concrete `*userspace.Manager` assertions with narrow interfaces for XSK binding callbacks and userspace runtime mode checks
- inverts the coupling canary so tests fail if `Manager` embeds `dataplane.DataPlane` again

Remaining #1381 work is still broad: `Daemon.dp` is still the legacy interface, `Manager` still has `inner *dataplane.Manager` for bootstrap maps, and CLI/API/GC/session-sync still need migration to narrower runtime interfaces.

## Validation

- `go test ./pkg/dataplane/userspace ./pkg/dataplane ./pkg/daemon`
- `go test ./pkg/dataplane/... ./pkg/daemon/... ./pkg/cluster/...`
- `go test ./pkg/api ./pkg/grpcapi ./pkg/cli ./pkg/conntrack`
- `go test ./...`
- `go build -buildvcs=false ./...`
- `git diff --check`

Plain `go build ./...` failed before compilation due VCS stamping (`error obtaining VCS status: exit status 128`); the same build passed with `-buildvcs=false`.
