### PR TITLE
policy: preserve scheduler rule counters

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -760,3 +760,8 @@
   - **Action**: PR #1407 Codex round-1 follow-up docs correction — replaced a non-existent scheduler test reference in the #1378 plan with the implemented delete/re-add counter lifecycle regression (`hit_counters_reset_after_rule_absent_then_readded`) to match actual coverage.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
   - **Validation**: `go test ./pkg/config ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`; `cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture` (blocked: missing libelf headers/pkg-config in runner)
+
+- **Timestamp**: 2026-05-17T21:28:00Z
+  - **Action**: PR #1407 Codex round-2 follow-up — added regression coverage for helper-backed sparse/global policy counters in gRPC and Prometheus reporting paths, and extended policy-hit metric collection to include global policies (`*`/`*` labels) so userspace/global counter IDs are surfaced consistently.
+  - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `pkg/grpcapi/server_show_zones_test.go`, `_Log.md`
+  - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go pkg/grpcapi/server_show_zones_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`

--- a/_Log.md
+++ b/_Log.md
@@ -755,3 +755,8 @@
 - **Timestamp**: 2026-05-17T18:57:46Z
   - **Action**: Adversarial PR #1374 follow-up: optimize SYN-cookie validated-client cache with map+queue state so insert/take are O(1), while expiry/eviction drain stale queue tokens from the head without whole-cache scans.
   - **File(s)**: `userspace-dp/src/screen.rs`, `userspace-dp/src/screen_tests.rs`, `_Log.md`
+
+- **Timestamp**: 2026-05-17T20:25:00Z
+  - **Action**: PR #1407 Codex round-1 follow-up docs correction — replaced a non-existent scheduler test reference in the #1378 plan with the implemented delete/re-add counter lifecycle regression (`hit_counters_reset_after_rule_absent_then_readded`) to match actual coverage.
+  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/config ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`; `cargo test --manifest-path /home/runner/work/xpf/xpf/userspace-dp/Cargo.toml policy:: -- --nocapture` (blocked: missing libelf headers/pkg-config in runner)

--- a/_Log.md
+++ b/_Log.md
@@ -759,4 +759,4 @@
 - **Timestamp**: 2026-05-17T20:25:00Z
   - **Action**: PR #1407 Codex round-1 follow-up docs correction — replaced a non-existent scheduler test reference in the #1378 plan with the implemented delete/re-add counter lifecycle regression (`hit_counters_reset_after_rule_absent_then_readded`) to match actual coverage.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/config ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`; `cargo test --manifest-path /home/runner/work/xpf/xpf/userspace-dp/Cargo.toml policy:: -- --nocapture` (blocked: missing libelf headers/pkg-config in runner)
+  - **Validation**: `go test ./pkg/config ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`; `cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture` (blocked: missing libelf headers/pkg-config in runner)

--- a/_Log.md
+++ b/_Log.md
@@ -770,3 +770,8 @@
   - **Action**: Addressed automated review follow-up on policy-hit metrics by adding a shared `policyCounterID` helper used by collector/tests and guarding global-policy metric emission against nil policy entries.
   - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
+
+- **Timestamp**: 2026-05-17T21:38:00Z
+  - **Action**: Applied final review nits: reverted unintended zone-policy nil-contract change in Prometheus policy counter loop and documented why global policy IDs use the post-zone-set offset in metrics tests.
+  - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
+  - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`

--- a/_Log.md
+++ b/_Log.md
@@ -765,3 +765,8 @@
   - **Action**: PR #1407 Codex round-2 follow-up — added regression coverage for helper-backed sparse/global policy counters in gRPC and Prometheus reporting paths, and extended policy-hit metric collection to include global policies (`*`/`*` labels) so userspace/global counter IDs are surfaced consistently.
   - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `pkg/grpcapi/server_show_zones_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go pkg/grpcapi/server_show_zones_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
+
+- **Timestamp**: 2026-05-17T21:34:00Z
+  - **Action**: Addressed automated review follow-up on policy-hit metrics by adding a shared `policyCounterID` helper used by collector/tests and guarding global-policy metric emission against nil policy entries.
+  - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
+  - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`

--- a/_Log.md
+++ b/_Log.md
@@ -775,3 +775,7 @@
   - **Action**: Applied final review nits: reverted unintended zone-policy nil-contract change in Prometheus policy counter loop and documented why global policy IDs use the post-zone-set offset in metrics tests.
   - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
+
+- **Timestamp**: 2026-05-17T22:00:00Z
+  - **Action**: Added explicit invariant note in `collectPolicyCounters` clarifying why zone-pair policy loop dereferences `rule.Name` without a nil guard while global policy loop retains defensive nil filtering.
+  - **File(s)**: `pkg/api/metrics.go`, `_Log.md`

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
@@ -108,7 +108,7 @@ existing eBPF behavior that can default missing scheduler state to active.
 - Cargo: `policy::evaluate_policy_skips_inactive_rules`.
 - Cargo: `policy::inactive_rule_falls_through_to_next_match`.
 - Cargo: `policy::hit_counters_survive_scheduler_snapshot_rebuild`.
-- Cargo: `policy::snapshot_publish_applies_inactive_bits_atomically`.
+- Cargo: `policy::hit_counters_reset_after_rule_absent_then_readded`.
 - Go: userspace snapshot round-trip for `SchedulerName`, `Inactive`, and stable
   rule identity.
 - Go: deterministic scheduler clock tests for active/inactive windows at

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
@@ -28,6 +28,15 @@ same active-state map, and runtime scheduler ticks acquire the same semaphore
 before publishing one coherent snapshot delta. Missing scheduler references are
 compile errors.
 
+Closeout update, 2026-05-17: the strict missing-scheduler validator now runs
+inside `CompileConfig`, so zone and global policies that reference undefined
+schedulers fail commit instead of entering the warning-only path. Rust policy
+hit counters are stored behind stable rule-id keyed atomics, so active/inactive
+scheduler snapshot rebuilds reuse the existing counter when the rule identity
+is unchanged. The remaining #1378 blocker is integration/HA failover evidence:
+show that the new active node recomputes scheduler state and publishes the full
+policy snapshot before admitting scheduled-policy traffic.
+
 On scheduler state changes, publish one atomic userspace snapshot delta that
 contains the updated inactive bits for all affected rules. Do not issue
 per-rule fast-path toggles because first-match ordering requires same-instant
@@ -63,8 +72,10 @@ existing eBPF behavior that can default missing scheduler state to active.
   an old helper before the fail-open path can occur. The refusal actively
   disarms helper forwarding with `set_forwarding_state armed=false`; recording
   a compile error while leaving the old helper armed is not fail-closed.
-- Hit counters are keyed by stable rule identity outside rebuilt rule structs so
-  counters survive scheduler snapshot rebuilds.
+- Hit counters are keyed by stable rule identity outside rebuilt rule structs;
+  rebuilt policy snapshots share the same per-rule atomic while a rule identity
+  remains present in the snapshot, so counters survive scheduler active/inactive
+  flips and same-process policy rebuilds.
 - Do not copy the existing eBPF indexing bug in
   `UpdatePolicyScheduleState`; userspace updates must target stable identities.
 
@@ -108,6 +119,12 @@ existing eBPF behavior that can default missing scheduler state to active.
 - Integration: scheduler window spanning multiple 60-second ticks with a policy
   referencing it; new connections pass only during active windows, while
   established sessions retain Junos-default behavior.
+
+Validated in the 2026-05-17 closeout slice:
+
+- `go test ./pkg/config`
+- `go test ./pkg/dataplane/userspace -run 'Test(BuildPolicySnapshots|UpdatePolicyScheduleState)'`
+- `cargo test policy:: -- --nocapture`
 
 ## Non-Goals
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -66,7 +66,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. The manager still holds a named eBPF shim manager for XDP/map bootstrap state; tracked by #1381 |
-| Dataplane event logging | Session open/close/update are emitted by userspace; policy-deny, screen-drop, and filter-log events still depend on the legacy BPF ring buffer; tracked by #1379 |
+| Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, and filter-log frame types, RT_FLOW codec/Go decode, and Rust non-blocking producer/rate-limit/loss-accounting infrastructure are present; runtime producer call sites and end-to-end syslog evidence remain tracked by #1379. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, active-session footer, neighbor/flow-cache counts, and worker queue pressure counters. #1380 is narrowed to the Phase 5 cleanup decision about whether operators need new helper capacity denominators for session-table, flow-cache, or neighbor-cache fill percentages before the legacy BPF-map surface is removed. |
 
 ## Retirement Blockers From The 2026-05-16 Audit
@@ -77,7 +77,7 @@ The current #1373 audit produced these tracked blockers:
 |-------|---------|-----------------|
 | #1381 | Split or replace the BPF-shaped `dataplane.DataPlane` interface so userspace no longer embeds the eBPF manager for map-writer methods | Phase 3 build-system / Go removal |
 | #1377 | Preserve userspace-v1 address-persistent SNAT pool selection with an explicit backend compatibility boundary, then finish per-pool `persistent-nat` semantics and allocation/exhaustion counters. #1385 landed deterministic userspace selection and snapshot omission for missing, empty, or invalid pool inputs, but runtime remains fail-open at the `poll_descriptor.rs` source-NAT call sites and does not provide persistent-NAT lease reuse or cross-backend new-flow parity. | Phase 4 BPF source removal |
-| #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds, strict missing-scheduler commit behavior, and integration/failover validation | Phase 4 BPF source removal |
+| #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice; remaining blocker is integration/failover validation evidence | Phase 4 BPF source removal |
 | #1379 | Emit policy-deny, screen-drop, and filter-log dataplane events from userspace | Phase 4 BPF source removal |
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393 and the 2026-05-17 runtime slice cover deterministic cookie codec/layout, snapshot propagation, fail-closed screen challenge selection, session-miss ACK validation, and a bounded validated-client cache. Lower-layer coverage in `userspace-dp/src/screen_tests.rs` pins 4-way validated-client cache replacement; poll-stage tests only pin the operational invalid-ACK drop/bypass semantics. Remaining: validated-client cache expiration semantics, secret-epoch rotation, bounded SYN-ACK TX, ACK RST emission, HA-safe secret publication/cache survivability, counters/status, integration/failover validation, and userspace capability gate removal. | Phase 4 BPF source removal |
 | #1375 | Implement userspace RFC 2697/2698 three-color policers | Phase 4 BPF source removal |
@@ -94,8 +94,9 @@ Recommended dependency order:
    userspace-v1 selector plus mixed-backend rollback boundary, but per-pool
    `persistent-nat` and allocator exhaustion counters remain #1377 runtime
    gaps. #1378 is no longer missing basic userspace propagation after #1396,
-   but its remaining counter/validation/evidence contract still blocks BPF
-   source removal.
+   and the 2026-05-17 closeout slice added counter continuity plus strict
+   missing-scheduler commit rejection; keep it open for the remaining
+   integration/HA failover evidence.
 3. #1374, #1375, and #1376 before Phase 4, because these are explicit feature
    gaps currently protected by the legacy eBPF fallback.
 4. #1380 in Phase 5, after the dataplane boundary is settled but before the
@@ -141,8 +142,8 @@ The highest-value remaining work on current `master` is:
 2. fix #1377 and #1379 to remove silent correctness and visibility
    regressions; keep #1385 plus the userspace-v1 fixtures as evidence of the
    current AF_XDP SNAT pool selector, not full persistent-NAT parity. Keep
-   #1378 open for the remaining policy-scheduler counter/validation/evidence
-   contract after #1396.
+   #1378 open only for the remaining policy-scheduler integration/HA failover
+   evidence.
 3. close #1374, #1375, and #1376 before any BPF source removal
 4. carry the narrowed #1380 denominator decision into Phase 5; the current
    userspace command already avoids BPF-map fallback when helper status is

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -89,16 +89,16 @@ func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	stats := GlobalStats{
-		RxPackets:       readCounter(dataplane.GlobalCtrRxPackets),
-		TxPackets:       readCounter(dataplane.GlobalCtrTxPackets),
-		Drops:           readCounter(dataplane.GlobalCtrDrops),
-		SessionsCreated: readCounter(dataplane.GlobalCtrSessionsNew),
-		SessionsClosed:  readCounter(dataplane.GlobalCtrSessionsClosed),
-		ScreenDrops:     readCounter(dataplane.GlobalCtrScreenDrops),
-		PolicyDenies:    readCounter(dataplane.GlobalCtrPolicyDeny),
-		NATAllocFails:   readCounter(dataplane.GlobalCtrNATAllocFail),
-		HostInboundDeny:  readCounter(dataplane.GlobalCtrHostInboundDeny),
-		TCEgressPackets:  readCounter(dataplane.GlobalCtrTCEgressPackets),
+		RxPackets:            readCounter(dataplane.GlobalCtrRxPackets),
+		TxPackets:            readCounter(dataplane.GlobalCtrTxPackets),
+		Drops:                readCounter(dataplane.GlobalCtrDrops),
+		SessionsCreated:      readCounter(dataplane.GlobalCtrSessionsNew),
+		SessionsClosed:       readCounter(dataplane.GlobalCtrSessionsClosed),
+		ScreenDrops:          readCounter(dataplane.GlobalCtrScreenDrops),
+		PolicyDenies:         readCounter(dataplane.GlobalCtrPolicyDeny),
+		NATAllocFails:        readCounter(dataplane.GlobalCtrNATAllocFail),
+		HostInboundDeny:      readCounter(dataplane.GlobalCtrHostInboundDeny),
+		TCEgressPackets:      readCounter(dataplane.GlobalCtrTCEgressPackets),
 		FabricRedirects:      readCounter(dataplane.GlobalCtrFabricRedirect),
 		FabricFwdDrops:       readCounter(dataplane.GlobalCtrFabricFwdDrop),
 		FlowCacheHits:        readCounter(dataplane.GlobalCtrFlowCacheHit),
@@ -215,7 +215,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	var policyID uint32
+	var policySetID uint32
 	var result []PolicyInfo
 	for _, zpp := range cfg.Security.Policies {
 		pi := PolicyInfo{
@@ -243,22 +243,22 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 
 			if s.dp != nil && s.dp.IsLoaded() {
+				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(len(pi.Rules))
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				}
 			}
-			policyID++
 			pi.Rules = append(pi.Rules, pr)
 		}
 		if pi.Rules == nil {
 			pi.Rules = []PolicyRule{}
 		}
 		result = append(result, pi)
+		policySetID++
 	}
 	writeOK(w, result)
 }
-
 
 func (s *Server) natSourceHandler(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.store.ActiveConfig()
@@ -575,7 +575,6 @@ func protoName(p uint8) string {
 		return fmt.Sprintf("%d", p)
 	}
 }
-
 
 func screenChecks(p *config.ScreenProfile) []string {
 	var checks []string
@@ -1357,7 +1356,6 @@ func (s *Server) dhcpIdentifiersHandler(w http.ResponseWriter, _ *http.Request) 
 
 // --- Mutation handlers ---
 
-
 func (s *Server) clearCountersHandler(w http.ResponseWriter, _ *http.Request) {
 	if s.dp == nil || !s.dp.IsLoaded() {
 		writeError(w, http.StatusServiceUnavailable, "dataplane not loaded")
@@ -2081,7 +2079,6 @@ func (s *Server) configAnnotateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Session zone-pair summary handler ---
-
 
 func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 	if s.dp == nil || !s.dp.IsLoaded() {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1500,31 +1500,24 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 	if cfg == nil {
 		return
 	}
-	cr := dp.LastCompileResult()
-	if cr == nil {
+	if dp.LastCompileResult() == nil {
 		return
 	}
 
-	// Build reverse zone ID map
-	zoneNames := make(map[uint16]string)
-	for name, id := range cr.ZoneIDs {
-		zoneNames[id] = name
-	}
-
-	var policyID uint32
+	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
 		fromZone := zpp.FromZone
 		toZone := zpp.ToZone
-		for _, rule := range zpp.Policies {
+		for i, rule := range zpp.Policies {
+			policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			ctrs, err := dp.ReadPolicyCounters(policyID)
 			if err != nil {
-				policyID++
 				continue
 			}
 			ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,
 				float64(ctrs.Packets), fromZone, toZone, rule.Name)
-			policyID++
 		}
+		policySetID++
 	}
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1506,7 +1506,10 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 		fromZone := zpp.FromZone
 		toZone := zpp.ToZone
 		for i, rule := range zpp.Policies {
-			policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+			if rule == nil {
+				continue
+			}
+			policyID := policyCounterID(policySetID, i)
 			ctrs, err := dp.ReadPolicyCounters(policyID)
 			if err != nil {
 				continue
@@ -1518,7 +1521,10 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 	}
 
 	for i, rule := range cfg.Security.GlobalPolicies {
-		policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+		if rule == nil {
+			continue
+		}
+		policyID := policyCounterID(policySetID, i)
 		ctrs, err := dp.ReadPolicyCounters(policyID)
 		if err != nil {
 			continue
@@ -1526,6 +1532,10 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 		ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,
 			float64(ctrs.Packets), "*", "*", rule.Name)
 	}
+}
+
+func policyCounterID(policySetID uint32, ruleIndex int) uint32 {
+	return policySetID*dataplane.MaxRulesPerPolicy + uint32(ruleIndex)
 }
 
 func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1500,9 +1500,6 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 	if cfg == nil {
 		return
 	}
-	if dp.LastCompileResult() == nil {
-		return
-	}
 
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
@@ -1518,6 +1515,16 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 				float64(ctrs.Packets), fromZone, toZone, rule.Name)
 		}
 		policySetID++
+	}
+
+	for i, rule := range cfg.Security.GlobalPolicies {
+		policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+		ctrs, err := dp.ReadPolicyCounters(policyID)
+		if err != nil {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,
+			float64(ctrs.Packets), "*", "*", rule.Name)
 	}
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1505,6 +1505,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 	for _, zpp := range cfg.Security.Policies {
 		fromZone := zpp.FromZone
 		toZone := zpp.ToZone
+		// Zone-pair compile output normalizes nil entries out of zpp.Policies.
 		for i, rule := range zpp.Policies {
 			policyID := policyCounterID(policySetID, i)
 			ctrs, err := dp.ReadPolicyCounters(policyID)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1506,9 +1506,6 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dat
 		fromZone := zpp.FromZone
 		toZone := zpp.ToZone
 		for i, rule := range zpp.Policies {
-			if rule == nil {
-				continue
-			}
 			policyID := policyCounterID(policySetID, i)
 			ctrs, err := dp.ReadPolicyCounters(policyID)
 			if err != nil {

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"math"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
 
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
@@ -272,6 +275,116 @@ func TestEmitUserspaceEventStreamMetrics(t *testing.T) {
 	assertCounterClose(t, got, c.userspaceEventStreamDataplaneDropsTotal, map[string]string{"type": "screen_drop"}, 4)
 	assertCounterClose(t, got, c.userspaceEventStreamDataplaneDropsTotal, map[string]string{"type": "filter_log"}, 9)
 	assertCounterClose(t, got, c.userspaceEventStreamUnknownDropsTotal, nil, 10)
+}
+
+func newSchedulerCounterMetricsStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone dmz;
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone dmz {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+        global {
+            policy global-scheduled {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func globalCounterPolicyID(t *testing.T, store *configstore.Store, ruleName string) uint32 {
+	t.Helper()
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	for i, rule := range cfg.Security.GlobalPolicies {
+		if rule != nil && rule.Name == ruleName {
+			return uint32(len(cfg.Security.Policies))*dataplane.MaxRulesPerPolicy + uint32(i)
+		}
+	}
+	t.Fatalf("global policy %q not found", ruleName)
+	return 0
+}
+
+func TestCollectPolicyCountersExposesSparseAndGlobalPolicyIDs(t *testing.T) {
+	store := newSchedulerCounterMetricsStore(t)
+	scheduledID := scheduledCounterPolicyID(t, store)
+	globalID := globalCounterPolicyID(t, store, "global-scheduled")
+	c := &xpfCollector{
+		srv: &Server{store: store},
+		policyHitsTotal: prometheus.NewDesc(
+			"xpf_policy_hits_total",
+			"policy hits",
+			[]string{"from_zone", "to_zone", "policy_name"},
+			nil,
+		),
+	}
+	dp := &schedulerCounterAPIDP{
+		Manager: dataplane.New(),
+		counters: map[uint32]dataplane.CounterValue{
+			1:           {Packets: 99, Bytes: 9900},
+			scheduledID: {Packets: 17, Bytes: 1700},
+			globalID:    {Packets: 31, Bytes: 3100},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.collectPolicyCounters(ch, dp)
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+
+	assertCounterClose(t, got, c.policyHitsTotal, map[string]string{
+		"from_zone":   "trust",
+		"to_zone":     "untrust",
+		"policy_name": "scheduled-allow",
+	}, 17)
+	assertCounterClose(t, got, c.policyHitsTotal, map[string]string{
+		"from_zone":   "*",
+		"to_zone":     "*",
+		"policy_name": "global-scheduled",
+	}, 31)
 }
 
 func metricValuesByWorker(

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -336,6 +336,7 @@ func globalCounterPolicyID(t *testing.T, store *configstore.Store, ruleName stri
 	}
 	for i, rule := range cfg.Security.GlobalPolicies {
 		if rule != nil && rule.Name == ruleName {
+			// Global policy IDs start after all zone-pair policy sets.
 			return policyCounterID(uint32(len(cfg.Security.Policies)), i)
 		}
 	}

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -336,7 +336,7 @@ func globalCounterPolicyID(t *testing.T, store *configstore.Store, ruleName stri
 	}
 	for i, rule := range cfg.Security.GlobalPolicies {
 		if rule != nil && rule.Name == ruleName {
-			return uint32(len(cfg.Security.Policies))*dataplane.MaxRulesPerPolicy + uint32(i)
+			return policyCounterID(uint32(len(cfg.Security.Policies)), i)
 		}
 	}
 	t.Fatalf("global policy %q not found", ruleName)

--- a/pkg/api/policy_counters_test.go
+++ b/pkg/api/policy_counters_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+type schedulerCounterAPIDP struct {
+	*dataplane.Manager
+	counters map[uint32]dataplane.CounterValue
+}
+
+func (d *schedulerCounterAPIDP) IsLoaded() bool {
+	return true
+}
+
+func (d *schedulerCounterAPIDP) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error) {
+	return d.counters[policyID], nil
+}
+
+func newSchedulerCounterAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone dmz;
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone dmz {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func scheduledCounterPolicyID(t *testing.T, store *configstore.Store) uint32 {
+	t.Helper()
+
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	for setID, zpp := range cfg.Security.Policies {
+		for ruleIndex, pol := range zpp.Policies {
+			if zpp.FromZone == "trust" && zpp.ToZone == "untrust" && pol.Name == "scheduled-allow" {
+				if setID == 0 {
+					t.Fatalf("scheduled policy compiled in policy set 0; test needs a nonzero policy set")
+				}
+				return uint32(setID)*dataplane.MaxRulesPerPolicy + uint32(ruleIndex)
+			}
+		}
+	}
+	t.Fatal("scheduled policy not found")
+	return 0
+}
+
+func TestPoliciesHandlerExposesScheduledRuleCounters(t *testing.T) {
+	store := newSchedulerCounterAPIStore(t)
+	policyID := scheduledCounterPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterAPIDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				1:        {Packets: 99, Bytes: 9900},
+				policyID: {Packets: 17, Bytes: 1700},
+			},
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	for _, policy := range resp.Data {
+		if policy.FromZone != "trust" || policy.ToZone != "untrust" {
+			continue
+		}
+		for _, rule := range policy.Rules {
+			if rule.Name != "scheduled-allow" {
+				continue
+			}
+			if !rule.Count {
+				t.Fatal("scheduled-allow Count = false, want true")
+			}
+			if rule.HitPackets != 17 || rule.HitBytes != 1700 {
+				t.Fatalf("scheduled-allow counters = %d packets/%d bytes, want 17/1700",
+					rule.HitPackets, rule.HitBytes)
+			}
+			return
+		}
+	}
+	t.Fatal("scheduled-allow rule not found in API response")
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -221,6 +221,9 @@ func compileExpanded(tree *ConfigTree) (*Config, error) {
 	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
 		return nil, err
 	}
+	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
+		return nil, err
+	}
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {
 		for _, w := range warnings {
 			cfg.Warnings = append(cfg.Warnings, w)
@@ -276,12 +279,15 @@ func validatePolicySchedulerReferencesStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	check := func(pol *Policy) error {
+	check := func(scope string, pol *Policy) error {
 		if pol == nil || pol.SchedulerName == "" {
 			return nil
 		}
 		if _, ok := cfg.Schedulers[pol.SchedulerName]; ok {
 			return nil
+		}
+		if scope != "" {
+			return fmt.Errorf("%s policy %q references undefined scheduler %q", scope, pol.Name, pol.SchedulerName)
 		}
 		return fmt.Errorf("policy %q references undefined scheduler %q", pol.Name, pol.SchedulerName)
 	}
@@ -290,13 +296,13 @@ func validatePolicySchedulerReferencesStrict(cfg *Config) error {
 			continue
 		}
 		for _, pol := range zpp.Policies {
-			if err := check(pol); err != nil {
+			if err := check("", pol); err != nil {
 				return err
 			}
 		}
 	}
 	for _, pol := range cfg.Security.GlobalPolicies {
-		if err := check(pol); err != nil {
+		if err := check("global", pol); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -1504,7 +1504,7 @@ security {
 	}
 }
 
-func TestPolicySchedulerMissingReferenceWarns(t *testing.T) {
+func TestPolicySchedulerMissingReferenceRejectsCommit(t *testing.T) {
 	input := `security {
     policies {
         from-zone trust to-zone untrust {
@@ -1522,17 +1522,16 @@ func TestPolicySchedulerMissingReferenceWarns(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
-	if err != nil {
-		t.Fatalf("CompileConfig returned error for warning-only missing scheduler reference: %v", err)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded, want missing scheduler commit error")
 	}
-	warnings := strings.Join(cfg.Warnings, "\n")
-	if !strings.Contains(warnings, `policy "sched-test": scheduler "missing-sched" not defined`) {
-		t.Fatalf("CompileConfig warnings = %v, want missing scheduler warning", cfg.Warnings)
+	if !strings.Contains(err.Error(), `policy "sched-test" references undefined scheduler "missing-sched"`) {
+		t.Fatalf("CompileConfig error = %v, want missing scheduler commit error", err)
 	}
 }
 
-func TestGlobalPolicySchedulerMissingReferenceWarns(t *testing.T) {
+func TestGlobalPolicySchedulerMissingReferenceRejectsCommit(t *testing.T) {
 	input := `security {
     policies {
         global {
@@ -1550,13 +1549,12 @@ func TestGlobalPolicySchedulerMissingReferenceWarns(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
-	if err != nil {
-		t.Fatalf("CompileConfig returned error for warning-only missing global scheduler reference: %v", err)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded, want missing global scheduler commit error")
 	}
-	warnings := strings.Join(cfg.Warnings, "\n")
-	if !strings.Contains(warnings, `global policy "sched-global": scheduler "missing-sched" not defined`) {
-		t.Fatalf("CompileConfig warnings = %v, want missing global scheduler warning", cfg.Warnings)
+	if !strings.Contains(err.Error(), `global policy "sched-global" references undefined scheduler "missing-sched"`) {
+		t.Fatalf("CompileConfig error = %v, want missing global scheduler commit error", err)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -85,6 +85,71 @@ func TestReadPolicyCountersUsesHelperPolicyRuleCounters(t *testing.T) {
 	}
 }
 
+func TestReadPolicyCountersPreservesScheduledRuleCountersAcrossDeleteReadd(t *testing.T) {
+	cfgWithRule := &config.Config{
+		Schedulers: map[string]*config.SchedulerConfig{
+			"workhours": {Name: "workhours"},
+		},
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "lan",
+				ToZone:   "wan",
+				Policies: []*config.Policy{{
+					Name:          "scheduled-allow",
+					SchedulerName: "workhours",
+					Count:         true,
+				}},
+			}},
+		},
+	}
+	cfgWithoutRule := &config.Config{
+		Schedulers: cfgWithRule.Schedulers,
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "lan",
+				ToZone:   "wan",
+			}},
+		},
+	}
+
+	m := New()
+	m.inner = nil
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{{
+			RuleID:  stablePolicyRuleID("lan", "wan", "scheduled-allow"),
+			Packets: 11,
+			Bytes:   1100,
+		}},
+	}
+
+	m.lastSnapshot = &ConfigSnapshot{Config: cfgWithRule}
+	got, err := m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters before delete: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 11, Bytes: 1100}) {
+		t.Fatalf("counter before delete = %+v, want packets=11 bytes=1100", got)
+	}
+
+	m.lastSnapshot = &ConfigSnapshot{Config: cfgWithoutRule}
+	got, err = m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters after delete: %v", err)
+	}
+	if got != (dataplane.CounterValue{}) {
+		t.Fatalf("counter after delete = %+v, want zero for absent rule", got)
+	}
+
+	m.lastSnapshot = &ConfigSnapshot{Config: cfgWithRule}
+	got, err = m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters after re-add: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 11, Bytes: 1100}) {
+		t.Fatalf("counter after re-add = %+v, want packets=11 bytes=1100", got)
+	}
+}
+
 func TestClearPolicyCountersZerosCachedHelperCountersWithoutHelper(t *testing.T) {
 	m := New()
 	m.inner = nil

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -228,6 +228,82 @@ func TestClearPolicyCountersZerosCachedHelperCountersWithoutHelper(t *testing.T)
 	}
 }
 
+func TestClearPolicyCountersUsesHelperIPCAndRecordsStatus(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	wantRuleID := stablePolicyRuleID("lan", "wan", "allow-web")
+	reqCh := make(chan ControlRequest, 1)
+	done := make(chan struct{}, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req ControlRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			return
+		}
+		reqCh <- req
+		_ = json.NewEncoder(conn).Encode(ControlResponse{
+			OK: true,
+			Status: &ProcessStatus{
+				PolicyRuleCounters: []PolicyRuleCounterStatus{{
+					RuleID: wantRuleID,
+				}},
+			},
+		})
+		done <- struct{}{}
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{{
+			RuleID:  wantRuleID,
+			Packets: 7,
+			Bytes:   700,
+		}},
+	}
+
+	m.mu.Lock()
+	err = m.clearHelperPolicyCountersLocked()
+	m.mu.Unlock()
+	if err != nil {
+		t.Fatalf("clearHelperPolicyCountersLocked: %v", err)
+	}
+	select {
+	case req := <-reqCh:
+		if req.Type != "clear_policy_counters" {
+			t.Fatalf("request type = %q, want clear_policy_counters", req.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("helper did not receive clear_policy_counters request")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("helper did not finish clear_policy_counters response")
+	}
+	if len(m.lastStatus.PolicyRuleCounters) != 1 {
+		t.Fatalf("len(PolicyRuleCounters) = %d, want 1", len(m.lastStatus.PolicyRuleCounters))
+	}
+	if got := m.lastStatus.PolicyRuleCounters[0]; got.RuleID != wantRuleID || got.Packets != 0 || got.Bytes != 0 {
+		t.Fatalf("helper counter after IPC clear = %+v, want rule_id=%q zero packets/bytes", got, wantRuleID)
+	}
+}
+
 func TestConfigEqualIncludesPollMode(t *testing.T) {
 	a := config.UserspaceConfig{
 		Binary:        "/tmp/helper",

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -45,6 +45,63 @@ func TestShouldAttemptRSTSuppression(t *testing.T) {
 	}
 }
 
+func TestReadPolicyCountersUsesHelperPolicyRuleCounters(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "lan",
+				ToZone:   "wan",
+				Policies: []*config.Policy{
+					{Name: "allow-web"},
+					{Name: "allow-dns"},
+				},
+			}},
+			GlobalPolicies: []*config.Policy{{Name: "global-allow"}},
+		},
+	}
+	m := New()
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{
+			{RuleID: stablePolicyRuleID("lan", "wan", "allow-dns"), Packets: 7, Bytes: 700},
+			{RuleID: stablePolicyRuleID("junos-global", "junos-global", "global-allow"), Packets: 9, Bytes: 900},
+		},
+	}
+
+	got, err := m.ReadPolicyCounters(1)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters lan/wan allow-dns: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 7, Bytes: 700}) {
+		t.Fatalf("lan/wan allow-dns counter = %+v, want packets=7 bytes=700", got)
+	}
+
+	got, err = m.ReadPolicyCounters(dataplane.MaxRulesPerPolicy)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters global: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 9, Bytes: 900}) {
+		t.Fatalf("global counter = %+v, want packets=9 bytes=900", got)
+	}
+}
+
+func TestClearPolicyCountersZerosCachedHelperCountersWithoutHelper(t *testing.T) {
+	m := New()
+	m.inner = nil
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{
+			{RuleID: stablePolicyRuleID("lan", "wan", "allow-web"), Packets: 7, Bytes: 700},
+		},
+	}
+
+	if err := m.ClearPolicyCounters(); err != nil {
+		t.Fatalf("ClearPolicyCounters: %v", err)
+	}
+	if got := m.lastStatus.PolicyRuleCounters[0]; got.Packets != 0 || got.Bytes != 0 {
+		t.Fatalf("cached helper counter after clear = %+v, want zero packets and bytes", got)
+	}
+}
+
 func TestConfigEqualIncludesPollMode(t *testing.T) {
 	a := config.UserspaceConfig{
 		Binary:        "/tmp/helper",

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/vishvananda/netlink"
 )
@@ -147,6 +148,66 @@ func TestReadPolicyCountersPreservesScheduledRuleCountersAcrossDeleteReadd(t *te
 	}
 	if got != (dataplane.CounterValue{Packets: 11, Bytes: 1100}) {
 		t.Fatalf("counter after re-add = %+v, want packets=11 bytes=1100", got)
+	}
+}
+
+func TestReadPolicyCountersMapsCommittedScheduledPolicyToHelperIdentity(t *testing.T) {
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if len(cfg.Security.Policies) != 1 || len(cfg.Security.Policies[0].Policies) != 1 {
+		t.Fatalf("unexpected committed policy shape: %+v", cfg.Security.Policies)
+	}
+
+	m := New()
+	m.inner = nil
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{{
+			RuleID:  stablePolicyRuleID("trust", "untrust", "scheduled-allow"),
+			Packets: 17,
+			Bytes:   1700,
+		}},
+	}
+
+	got, err := m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters committed scheduled policy: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 17, Bytes: 1700}) {
+		t.Fatalf("committed scheduled policy counter = %+v, want packets=17 bytes=1700", got)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -314,31 +314,35 @@ func TestReadPolicyCountersUsesStatusIPCPolicyRuleCounters(t *testing.T) {
 	defer ln.Close()
 
 	wantRuleID := stablePolicyRuleID("trust", "untrust", "scheduled-allow")
-	reqCh := make(chan ControlRequest, 1)
-	done := make(chan struct{}, 1)
+	responses := []PolicyRuleCounterStatus{
+		{RuleID: wantRuleID, Packets: 23, Bytes: 2300},
+		{RuleID: wantRuleID, Packets: 31, Bytes: 3100},
+	}
+	reqCh := make(chan ControlRequest, len(responses))
+	done := make(chan struct{}, len(responses))
 	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
+		for _, counter := range responses {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				reqCh <- req
+				_ = json.NewEncoder(conn).Encode(ControlResponse{
+					OK: true,
+					Status: &ProcessStatus{
+						PID:                4321,
+						PolicyRuleCounters: []PolicyRuleCounterStatus{counter},
+					},
+				})
+				done <- struct{}{}
+			}()
 		}
-		defer conn.Close()
-		var req ControlRequest
-		if err := json.NewDecoder(conn).Decode(&req); err != nil {
-			return
-		}
-		reqCh <- req
-		_ = json.NewEncoder(conn).Encode(ControlResponse{
-			OK: true,
-			Status: &ProcessStatus{
-				PID: 4321,
-				PolicyRuleCounters: []PolicyRuleCounterStatus{{
-					RuleID:  wantRuleID,
-					Packets: 23,
-					Bytes:   2300,
-				}},
-			},
-		})
-		done <- struct{}{}
 	}()
 
 	cfg := &config.Config{
@@ -361,37 +365,55 @@ func TestReadPolicyCountersUsesStatusIPCPolicyRuleCounters(t *testing.T) {
 	m.proc = &exec.Cmd{Process: proc}
 	m.cfg.ControlSocket = controlSock
 	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+	m.lastStatus = ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{{
+			RuleID: wantRuleID,
+		}},
+	}
 
-	m.mu.Lock()
-	var status ProcessStatus
-	err = m.requestLocked(ControlRequest{Type: "status"}, &status)
-	if err == nil {
-		m.recordHelperStatusLocked(&status)
-	}
-	m.mu.Unlock()
-	if err != nil {
-		t.Fatalf("status IPC: %v", err)
-	}
-	select {
-	case req := <-reqCh:
-		if req.Type != "status" {
-			t.Fatalf("request type = %q, want status", req.Type)
+	refreshStatus := func() {
+		t.Helper()
+		m.mu.Lock()
+		var status ProcessStatus
+		err = m.requestLocked(ControlRequest{Type: "status"}, &status)
+		if err == nil {
+			m.recordHelperStatusLocked(&status)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("helper did not receive status request")
-	}
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("helper did not finish status response")
+		m.mu.Unlock()
+		if err != nil {
+			t.Fatalf("status IPC: %v", err)
+		}
+		select {
+		case req := <-reqCh:
+			if req.Type != "status" {
+				t.Fatalf("request type = %q, want status", req.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("helper did not receive status request")
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("helper did not finish status response")
+		}
 	}
 
+	refreshStatus()
 	got, err := m.ReadPolicyCounters(0)
 	if err != nil {
 		t.Fatalf("ReadPolicyCounters after status IPC: %v", err)
 	}
 	if got != (dataplane.CounterValue{Packets: 23, Bytes: 2300}) {
 		t.Fatalf("counter after status IPC = %+v, want packets=23 bytes=2300", got)
+	}
+
+	refreshStatus()
+	got, err = m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters after second status IPC: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 31, Bytes: 3100}) {
+		t.Fatalf("counter after second status IPC = %+v, want packets=31 bytes=3100", got)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -304,6 +304,97 @@ func TestClearPolicyCountersUsesHelperIPCAndRecordsStatus(t *testing.T) {
 	}
 }
 
+func TestReadPolicyCountersUsesStatusIPCPolicyRuleCounters(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	wantRuleID := stablePolicyRuleID("trust", "untrust", "scheduled-allow")
+	reqCh := make(chan ControlRequest, 1)
+	done := make(chan struct{}, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req ControlRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			return
+		}
+		reqCh <- req
+		_ = json.NewEncoder(conn).Encode(ControlResponse{
+			OK: true,
+			Status: &ProcessStatus{
+				PID: 4321,
+				PolicyRuleCounters: []PolicyRuleCounterStatus{{
+					RuleID:  wantRuleID,
+					Packets: 23,
+					Bytes:   2300,
+				}},
+			},
+		})
+		done <- struct{}{}
+	}()
+
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Policies: []*config.Policy{{
+					Name:          "scheduled-allow",
+					SchedulerName: "workhours",
+				}},
+			}},
+		},
+	}
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
+
+	m.mu.Lock()
+	var status ProcessStatus
+	err = m.requestLocked(ControlRequest{Type: "status"}, &status)
+	if err == nil {
+		m.recordHelperStatusLocked(&status)
+	}
+	m.mu.Unlock()
+	if err != nil {
+		t.Fatalf("status IPC: %v", err)
+	}
+	select {
+	case req := <-reqCh:
+		if req.Type != "status" {
+			t.Fatalf("request type = %q, want status", req.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("helper did not receive status request")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("helper did not finish status response")
+	}
+
+	got, err := m.ReadPolicyCounters(0)
+	if err != nil {
+		t.Fatalf("ReadPolicyCounters after status IPC: %v", err)
+	}
+	if got != (dataplane.CounterValue{Packets: 23, Bytes: 2300}) {
+		t.Fatalf("counter after status IPC = %+v, want packets=23 bytes=2300", got)
+	}
+}
+
 func TestConfigEqualIncludesPollMode(t *testing.T) {
 	a := config.UserspaceConfig{
 		Binary:        "/tmp/helper",

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -51,6 +51,10 @@ func policyRuleIDForCounter(cfg *config.Config, policyID uint32) string {
 }
 
 func (m *Manager) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error) {
+	// The public DataPlane API is still indexed by legacy policy ID, while the
+	// userspace helper reports counters by stable policy identity. Keep the
+	// translation config-derived so scheduled-rule counters survive delete/re-add
+	// and app-term slot expansion without callers recomputing Rust map slots.
 	var total dataplane.CounterValue
 	var innerErr error
 	if m.inner != nil {

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -1,0 +1,133 @@
+package userspace
+
+import (
+	"errors"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+func buildPolicyRuleCounterIndex(status *ProcessStatus) map[string]PolicyRuleCounterStatus {
+	index := make(map[string]PolicyRuleCounterStatus)
+	if status == nil {
+		return index
+	}
+	for _, counter := range status.PolicyRuleCounters {
+		if counter.RuleID == "" {
+			continue
+		}
+		index[counter.RuleID] = counter
+	}
+	return index
+}
+
+func policyRuleIDForCounter(cfg *config.Config, policyID uint32) string {
+	if cfg == nil {
+		return ""
+	}
+	policySetID := policyID / dataplane.MaxRulesPerPolicy
+	ruleIndex := policyID % dataplane.MaxRulesPerPolicy
+
+	var currentSet uint32
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		if currentSet == policySetID {
+			if int(ruleIndex) >= len(zpp.Policies) || zpp.Policies[ruleIndex] == nil {
+				return ""
+			}
+			return stablePolicyRuleID(zpp.FromZone, zpp.ToZone, zpp.Policies[ruleIndex].Name)
+		}
+		currentSet++
+	}
+	if currentSet == policySetID {
+		if int(ruleIndex) >= len(cfg.Security.GlobalPolicies) || cfg.Security.GlobalPolicies[ruleIndex] == nil {
+			return ""
+		}
+		return stablePolicyRuleID("junos-global", "junos-global", cfg.Security.GlobalPolicies[ruleIndex].Name)
+	}
+	return ""
+}
+
+func (m *Manager) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error) {
+	var total dataplane.CounterValue
+	var innerErr error
+	if m.inner != nil {
+		total, innerErr = m.inner.ReadPolicyCounters(policyID)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cfg := (*config.Config)(nil)
+	if m.lastSnapshot != nil {
+		cfg = m.lastSnapshot.Config
+	}
+	ruleID := policyRuleIDForCounter(cfg, policyID)
+	if ruleID == "" {
+		if innerErr != nil {
+			return dataplane.CounterValue{}, innerErr
+		}
+		return total, nil
+	}
+	counter, ok := buildPolicyRuleCounterIndex(&m.lastStatus)[ruleID]
+	if !ok {
+		if innerErr != nil {
+			return dataplane.CounterValue{}, innerErr
+		}
+		return total, nil
+	}
+	total.Packets += counter.Packets
+	total.Bytes += counter.Bytes
+	return total, nil
+}
+
+func (m *Manager) ClearPolicyCounters() error {
+	var errs []error
+	if m.inner != nil {
+		if err := m.inner.ClearPolicyCounters(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.clearHelperPolicyCountersLocked(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) ClearAllCounters() error {
+	var errs []error
+	if m.inner != nil {
+		if err := m.inner.ClearAllCounters(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.clearHelperPolicyCountersLocked(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) clearHelperPolicyCountersLocked() error {
+	if m.proc == nil || m.proc.Process == nil {
+		for i := range m.lastStatus.PolicyRuleCounters {
+			m.lastStatus.PolicyRuleCounters[i].Packets = 0
+			m.lastStatus.PolicyRuleCounters[i].Bytes = 0
+		}
+		return nil
+	}
+
+	var status ProcessStatus
+	if err := m.requestLocked(ControlRequest{Type: "clear_policy_counters"}, &status); err != nil {
+		return err
+	}
+	m.recordHelperStatusLocked(&status)
+	return nil
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -489,6 +489,7 @@ type ProcessStatus struct {
 	EventStreamSent              uint64                            `json:"event_stream_sent,omitempty"`
 	EventStreamDropped           uint64                            `json:"event_stream_dropped,omitempty"`
 	CoSInterfaces                []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
+	PolicyRuleCounters           []PolicyRuleCounterStatus         `json:"policy_rule_counters,omitempty"`
 	FilterTermCounters           []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
 	LastResolution               *PacketResolution                 `json:"last_resolution,omitempty"`
 	SlowPath                     SlowPathStatus                    `json:"slow_path,omitempty"`
@@ -607,6 +608,12 @@ type FirewallFilterTermCounterStatus struct {
 	TermName   string `json:"term_name,omitempty"`
 	Packets    uint64 `json:"packets,omitempty"`
 	Bytes      uint64 `json:"bytes,omitempty"`
+}
+
+type PolicyRuleCounterStatus struct {
+	RuleID  string `json:"rule_id,omitempty"`
+	Packets uint64 `json:"packets,omitempty"`
+	Bytes   uint64 `json:"bytes,omitempty"`
 }
 
 type HAStateUpdateRequest struct {

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -629,3 +629,32 @@ func TestProcessStatusFlowWorkerMapRoundTrip(t *testing.T) {
 		t.Fatal("CoSActiveFlowCountsTruncated must round-trip true")
 	}
 }
+
+func TestProcessStatusPolicyRuleCountersRoundTrip(t *testing.T) {
+	in := ProcessStatus{
+		PolicyRuleCounters: []PolicyRuleCounterStatus{{
+			RuleID:  "lan->wan/allow-web",
+			Packets: 12,
+			Bytes:   1536,
+		}},
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	if _, ok := obj["policy_rule_counters"]; !ok {
+		t.Fatalf("policy_rule_counters missing from ProcessStatus JSON: %s", string(raw))
+	}
+
+	var back ProcessStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if !reflect.DeepEqual(back.PolicyRuleCounters, in.PolicyRuleCounters) {
+		t.Fatalf("PolicyRuleCounters mismatch: got %+v, want %+v", back.PolicyRuleCounters, in.PolicyRuleCounters)
+	}
+}

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -69,13 +69,13 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 	}
 
 	resp := &pb.GetPoliciesResponse{}
-	var policyID uint32
+	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
 		pi := &pb.PolicyInfo{
 			FromZone: zpp.FromZone,
 			ToZone:   zpp.ToZone,
 		}
-		for _, rule := range zpp.Policies {
+		for i, rule := range zpp.Policies {
 			pr := &pb.PolicyRule{
 				Name:         rule.Name,
 				Description:  rule.Description,
@@ -96,18 +96,19 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				pr.Applications = []string{}
 			}
 			if s.dp != nil && s.dp.IsLoaded() {
+				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				}
 			}
-			policyID++
 			pi.Rules = append(pi.Rules, pr)
 		}
 		if pi.Rules == nil {
 			pi.Rules = []*pb.PolicyRule{}
 		}
 		resp.Policies = append(resp.Policies, pi)
+		policySetID++
 	}
 
 	// Global policies
@@ -116,7 +117,7 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			FromZone: "*",
 			ToZone:   "*",
 		}
-		for _, rule := range cfg.Security.GlobalPolicies {
+		for i, rule := range cfg.Security.GlobalPolicies {
 			pr := &pb.PolicyRule{
 				Name:         rule.Name,
 				Description:  rule.Description,
@@ -137,12 +138,12 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				pr.Applications = []string{}
 			}
 			if s.dp != nil && s.dp.IsLoaded() {
+				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
 				}
 			}
-			policyID++
 			pi.Rules = append(pi.Rules, pr)
 		}
 		if pi.Rules == nil {

--- a/pkg/grpcapi/server_show_zones_test.go
+++ b/pkg/grpcapi/server_show_zones_test.go
@@ -56,6 +56,13 @@ security {
                 scheduler-name workhours;
             }
         }
+        global {
+            policy global-scheduled {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
     }
 }
 `); err != nil {
@@ -96,8 +103,9 @@ func TestGetPoliciesExposesScheduledRuleCounters(t *testing.T) {
 		dp: &schedulerCounterGRPCDP{
 			Manager: dataplane.New(),
 			counters: map[uint32]dataplane.CounterValue{
-				1:        {Packets: 99, Bytes: 9900},
-				policyID: {Packets: 23, Bytes: 2300},
+				1:                               {Packets: 99, Bytes: 9900},
+				policyID:                        {Packets: 23, Bytes: 2300},
+				dataplane.MaxRulesPerPolicy * 2: {Packets: 31, Bytes: 3100},
 			},
 		},
 	}
@@ -125,4 +133,41 @@ func TestGetPoliciesExposesScheduledRuleCounters(t *testing.T) {
 		}
 	}
 	t.Fatal("scheduled-allow rule not found in gRPC response")
+}
+
+func TestGetPoliciesExposesGlobalScheduledRuleCounters(t *testing.T) {
+	store := newSchedulerCounterGRPCStore(t)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				dataplane.MaxRulesPerPolicy * 2: {Packets: 31, Bytes: 3100},
+			},
+		},
+	}
+
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+	for _, policy := range resp.GetPolicies() {
+		if policy.GetFromZone() != "*" || policy.GetToZone() != "*" {
+			continue
+		}
+		for _, rule := range policy.GetRules() {
+			if rule.GetName() != "global-scheduled" {
+				continue
+			}
+			if !rule.GetCount() {
+				t.Fatal("global-scheduled Count = false, want true")
+			}
+			if rule.GetHitPackets() != 31 || rule.GetHitBytes() != 3100 {
+				t.Fatalf("global-scheduled counters = %d packets/%d bytes, want 31/3100",
+					rule.GetHitPackets(), rule.GetHitBytes())
+			}
+			return
+		}
+	}
+	t.Fatal("global-scheduled rule not found in gRPC response")
 }

--- a/pkg/grpcapi/server_show_zones_test.go
+++ b/pkg/grpcapi/server_show_zones_test.go
@@ -1,0 +1,128 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+type schedulerCounterGRPCDP struct {
+	*dataplane.Manager
+	counters map[uint32]dataplane.CounterValue
+}
+
+func (d *schedulerCounterGRPCDP) IsLoaded() bool {
+	return true
+}
+
+func (d *schedulerCounterGRPCDP) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error) {
+	return d.counters[policyID], nil
+}
+
+func newSchedulerCounterGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone dmz;
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone dmz {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func scheduledCounterGRPCPolicyID(t *testing.T, store *configstore.Store) uint32 {
+	t.Helper()
+
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	for setID, zpp := range cfg.Security.Policies {
+		for ruleIndex, pol := range zpp.Policies {
+			if zpp.FromZone == "trust" && zpp.ToZone == "untrust" && pol.Name == "scheduled-allow" {
+				if setID == 0 {
+					t.Fatalf("scheduled policy compiled in policy set 0; test needs a nonzero policy set")
+				}
+				return uint32(setID)*dataplane.MaxRulesPerPolicy + uint32(ruleIndex)
+			}
+		}
+	}
+	t.Fatal("scheduled policy not found")
+	return 0
+}
+
+func TestGetPoliciesExposesScheduledRuleCounters(t *testing.T) {
+	store := newSchedulerCounterGRPCStore(t)
+	policyID := scheduledCounterGRPCPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				1:        {Packets: 99, Bytes: 9900},
+				policyID: {Packets: 23, Bytes: 2300},
+			},
+		},
+	}
+
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+	for _, policy := range resp.GetPolicies() {
+		if policy.GetFromZone() != "trust" || policy.GetToZone() != "untrust" {
+			continue
+		}
+		for _, rule := range policy.GetRules() {
+			if rule.GetName() != "scheduled-allow" {
+				continue
+			}
+			if !rule.GetCount() {
+				t.Fatal("scheduled-allow Count = false, want true")
+			}
+			if rule.GetHitPackets() != 23 || rule.GetHitBytes() != 2300 {
+				t.Fatalf("scheduled-allow counters = %d packets/%d bytes, want 23/2300",
+					rule.GetHitPackets(), rule.GetHitBytes())
+			}
+			return
+		}
+	}
+	t.Fatal("scheduled-allow rule not found in gRPC response")
+}

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -29,6 +29,7 @@ pub struct Coordinator {
     pub(in crate::afxdp) sessions: SessionManager,
     pub(in crate::afxdp) workers: WorkerManager,
     pub(crate) forwarding: ForwardingState,
+    pub(crate) policy_counters: PolicyCounterStore,
     pub(crate) recent_exceptions: Arc<Mutex<VecDeque<ExceptionStatus>>>,
     pub(crate) recent_session_deltas: Arc<Mutex<VecDeque<SessionDeltaInfo>>>,
     pub(crate) last_resolution: Arc<Mutex<Option<PacketResolution>>>,
@@ -65,6 +66,7 @@ impl Coordinator {
             sessions: SessionManager::new(),
             workers: WorkerManager::new(),
             forwarding: ForwardingState::default(),
+            policy_counters: PolicyCounterStore::default(),
             recent_exceptions: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_RECENT_EXCEPTIONS))),
             recent_session_deltas: Arc::new(Mutex::new(VecDeque::with_capacity(
                 MAX_RECENT_SESSION_DELTAS,
@@ -387,6 +389,7 @@ impl Coordinator {
             binding.ready = false;
         }
         let Some(snapshot) = snapshot else {
+            self.policy_counters.reconcile_rules(&[]);
             self.last_reconcile_stage = "no_snapshot".to_string();
             return;
         };
@@ -395,7 +398,9 @@ impl Coordinator {
             config_generation: snapshot.generation,
             fib_generation: snapshot.fib_generation,
         };
-        self.forwarding = build_forwarding_state(snapshot);
+        self.policy_counters.reconcile_rules(&snapshot.policies);
+        self.forwarding =
+            build_forwarding_state_with_policy_counters(snapshot, &self.policy_counters);
         self.shared_validation.store(Arc::new(self.validation));
         self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         self.slow_path = if let Some(slow_path) = preserved_slow_path {
@@ -961,7 +966,9 @@ impl Coordinator {
         // may not include them if the peer MAC wasn't resolved at
         // snapshot build time. Always keep the better-resolved set.
         let preserved_fabrics = self.forwarding.fabrics.clone();
-        self.forwarding = build_forwarding_state(snapshot);
+        self.policy_counters.reconcile_rules(&snapshot.policies);
+        self.forwarding =
+            build_forwarding_state_with_policy_counters(snapshot, &self.policy_counters);
         if self.forwarding.fabrics.is_empty() && !preserved_fabrics.is_empty() {
             self.forwarding.fabrics = preserved_fabrics;
         } else if !preserved_fabrics.is_empty() {
@@ -984,6 +991,14 @@ impl Coordinator {
         self.ha
             .fabrics
             .store(Arc::new(self.forwarding.fabrics.clone()));
+    }
+
+    pub fn policy_rule_counters(&self) -> Vec<crate::protocol::PolicyRuleCounterStatus> {
+        self.forwarding.policy.counter_snapshots()
+    }
+
+    pub fn clear_policy_counters(&self) {
+        self.policy_counters.clear();
     }
 
     fn refresh_cos_owner_worker_map_from_identities(&mut self) {

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -69,6 +69,13 @@ fn build_cos_ieee8021_queue_table(
 }
 
 pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingState {
+    build_forwarding_state_with_policy_counters(snapshot, &PolicyCounterStore::default())
+}
+
+pub(super) fn build_forwarding_state_with_policy_counters(
+    snapshot: &ConfigSnapshot,
+    policy_counters: &PolicyCounterStore,
+) -> ForwardingState {
     let mut state = ForwardingState::default();
     let mut name_to_ifindex = BTreeMap::new();
     let mut linux_to_ifindex = BTreeMap::new();
@@ -365,10 +372,11 @@ pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingSta
             local_mac,
         });
     }
-    state.policy = parse_policy_state(
+    state.policy = parse_policy_state_with_counters(
         &snapshot.default_policy,
         &snapshot.policies,
         &state.zone_name_to_id,
+        policy_counters,
     );
     state.allow_dns_reply = snapshot.flow.allow_dns_reply;
     state.allow_embedded_icmp = snapshot.flow.allow_embedded_icmp;

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -7,7 +7,9 @@ use crate::nat::{
 };
 use crate::nat64::{Nat64ReverseInfo, Nat64State};
 use crate::nptv6::Nptv6State;
-use crate::policy::{PolicyAction, PolicyState, evaluate_policy, parse_policy_state};
+use crate::policy::{
+    PolicyAction, PolicyCounterStore, PolicyState, evaluate_policy, parse_policy_state_with_counters,
+};
 use crate::prefix::{PrefixV4, PrefixV6};
 use crate::screen::{ScreenProfile, ScreenState, ScreenVerdict, extract_screen_info};
 use crate::session::{

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -12,6 +12,7 @@ use super::poll_stages::{
     stage_native_gre_decap, stage_parse_flow_and_learn, stage_screen_check,
     stage_screen_syn_cookie_ack_on_session_miss, FabricIngressOutcome, StageOutcome,
 };
+use crate::policy::evaluate_policy_with_len;
 
 // Per-batch packet processing lifted from `poll_binding` (#678).
 //
@@ -1009,7 +1010,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 // the session-install step below is skipped only when
                                 // the knob matches AND no NAT is required (to avoid
                                 // orphan NAT state without a session anchor).
-                                if let PolicyAction::Permit = evaluate_policy(
+                                if let PolicyAction::Permit = evaluate_policy_with_len(
                                     &worker_ctx.forwarding.policy,
                                     from_zone_id,
                                     to_zone_id,
@@ -1018,6 +1019,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     flow.forward_key.protocol,
                                     flow.forward_key.src_port,
                                     flow.forward_key.dst_port,
+                                    desc.len as u64,
                                 ) {
                                     // NAT64: cross-family translation takes
                                     // priority over same-family SNAT.
@@ -1947,7 +1949,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 // session miss → policy deny (no rule for WAN→LAN).
                                 let mut pending_decision = decision;
                                 if let Some(flow) = flow.as_ref() {
-                                    if let PolicyAction::Permit = evaluate_policy(
+                                    if let PolicyAction::Permit = evaluate_policy_with_len(
                                         &worker_ctx.forwarding.policy,
                                         from_zone_id,
                                         to_zone_id,
@@ -1956,6 +1958,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         flow.forward_key.protocol,
                                         flow.forward_key.src_port,
                                         flow.forward_key.dst_port,
+                                        desc.len as u64,
                                     ) {
                                         let nat_match_flow = flow.with_destination(
                                             pending_decision.nat.rewrite_dst.unwrap_or(flow.dst_ip),

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1,11 +1,11 @@
 use crate::prefix::{PrefixV4, PrefixV6};
 use crate::prefix_set::{PrefixSetV4, PrefixSetV6};
-use crate::{PolicyApplicationSnapshot, PolicyRuleSnapshot};
+use crate::{PolicyApplicationSnapshot, PolicyRuleCounterStatus, PolicyRuleSnapshot};
 use ipnet::IpNet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 /// #922: zone-pair key packed as u32 (`from_id << 16 | to_id`).
 /// Replaces the previous `(String, String)` key that allocated two
@@ -63,7 +63,7 @@ pub(crate) struct PolicyRule {
     /// Precompiled application matcher (protocol-indexed, exact-port sets).
     compiled_apps: CompiledApplications,
     pub(crate) action: PolicyAction,
-    pub(crate) hit_count: Arc<AtomicU64>,
+    pub(crate) hit_counter: Arc<PolicyRuleCounter>,
 }
 
 impl Default for PolicyRule {
@@ -84,7 +84,7 @@ impl Default for PolicyRule {
                 by_protocol: FxHashMap::default(),
             },
             action: PolicyAction::Deny,
-            hit_count: Arc::new(AtomicU64::new(0)),
+            hit_counter: Arc::new(PolicyRuleCounter::default()),
         }
     }
 }
@@ -104,43 +104,72 @@ impl Clone for PolicyRule {
             applications: self.applications.clone(),
             compiled_apps: self.compiled_apps.clone(),
             action: self.action,
-            hit_count: self.hit_count.clone(),
+            hit_counter: self.hit_counter.clone(),
         }
     }
 }
 
-type PolicyCounterRegistry = FxHashMap<String, Arc<AtomicU64>>;
-
-const POLICY_COUNTER_REGISTRY_PRUNE_THRESHOLD: usize = 16_384;
-
-static POLICY_COUNTERS: OnceLock<Mutex<PolicyCounterRegistry>> = OnceLock::new();
-
-fn policy_counter_registry() -> &'static Mutex<PolicyCounterRegistry> {
-    POLICY_COUNTERS.get_or_init(|| Mutex::new(FxHashMap::default()))
+#[derive(Debug, Default)]
+pub(crate) struct PolicyRuleCounter {
+    packets: AtomicU64,
+    bytes: AtomicU64,
 }
 
-fn prune_policy_counter_registry(active_rule_ids: &FxHashSet<String>) {
-    if let Ok(mut counters) = policy_counter_registry().lock() {
-        if counters.len() <= POLICY_COUNTER_REGISTRY_PRUNE_THRESHOLD {
-            return;
+impl PolicyRuleCounter {
+    fn add(&self, packet_len: u64) {
+        self.packets.fetch_add(1, Ordering::Relaxed);
+        if packet_len != 0 {
+            self.bytes.fetch_add(packet_len, Ordering::Relaxed);
         }
-        counters.retain(|rule_id, counter| {
-            active_rule_ids.contains(rule_id) || Arc::strong_count(counter) > 1
-        });
+    }
+
+    fn reset(&self) {
+        self.packets.store(0, Ordering::Relaxed);
+        self.bytes.store(0, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self, rule_id: &str) -> PolicyRuleCounterStatus {
+        PolicyRuleCounterStatus {
+            rule_id: rule_id.to_string(),
+            packets: self.packets.load(Ordering::Relaxed),
+            bytes: self.bytes.load(Ordering::Relaxed),
+        }
     }
 }
 
-fn policy_rule_hit_counter(rule_id: &str) -> Arc<AtomicU64> {
-    let mut counters = policy_counter_registry()
-        .lock()
-        .expect("policy counter registry poisoned");
-    if let Some(counter) = counters.get(rule_id) {
-        return counter.clone();
+type PolicyCounterRegistry = FxHashMap<String, Arc<PolicyRuleCounter>>;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PolicyCounterStore {
+    counters: Arc<Mutex<PolicyCounterRegistry>>,
+}
+
+impl PolicyCounterStore {
+    pub(crate) fn reconcile_rules(&self, rules: &[PolicyRuleSnapshot]) {
+        let active_rule_ids: FxHashSet<String> = rules.iter().map(stable_policy_rule_id).collect();
+        if let Ok(mut counters) = self.counters.lock() {
+            counters.retain(|rule_id, _| active_rule_ids.contains(rule_id));
+        }
     }
 
-    let counter = Arc::new(AtomicU64::new(0));
-    counters.insert(rule_id.to_string(), counter.clone());
-    counter
+    pub(crate) fn clear(&self) {
+        if let Ok(counters) = self.counters.lock() {
+            for counter in counters.values() {
+                counter.reset();
+            }
+        }
+    }
+
+    fn rule_hit_counter(&self, rule_id: &str) -> Arc<PolicyRuleCounter> {
+        let mut counters = self.counters.lock().expect("policy counter store poisoned");
+        if let Some(counter) = counters.get(rule_id) {
+            return counter.clone();
+        }
+
+        let counter = Arc::new(PolicyRuleCounter::default());
+        counters.insert(rule_id.to_string(), counter.clone());
+        counter
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -246,13 +275,30 @@ impl Default for PolicyState {
     }
 }
 
+impl PolicyState {
+    pub(crate) fn counter_snapshots(&self) -> Vec<PolicyRuleCounterStatus> {
+        self.rules
+            .iter()
+            .map(|rule| rule.hit_counter.snapshot(&rule.rule_id))
+            .collect()
+    }
+}
+
 pub(crate) fn parse_policy_state(
     default_policy: &str,
     rules: &[PolicyRuleSnapshot],
     zone_name_to_id: &FxHashMap<String, u16>,
 ) -> PolicyState {
-    let active_rule_ids = rules.iter().map(stable_policy_rule_id).collect();
-    prune_policy_counter_registry(&active_rule_ids);
+    let counter_store = PolicyCounterStore::default();
+    parse_policy_state_with_counters(default_policy, rules, zone_name_to_id, &counter_store)
+}
+
+pub(crate) fn parse_policy_state_with_counters(
+    default_policy: &str,
+    rules: &[PolicyRuleSnapshot],
+    zone_name_to_id: &FxHashMap<String, u16>,
+    counter_store: &PolicyCounterStore,
+) -> PolicyState {
     let mut state = PolicyState {
         default_action: parse_action(default_policy),
         rules: Vec::with_capacity(rules.len()),
@@ -281,7 +327,7 @@ pub(crate) fn parse_policy_state(
             scheduler_name: snap.scheduler_name.clone(),
             inactive: snap.inactive,
             action: parse_action(&snap.action),
-            hit_count: policy_rule_hit_counter(&rule_id),
+            hit_counter: counter_store.rule_hit_counter(&rule_id),
             source_v4: PrefixSetV4::from_prefixes(src_v4),
             source_v6: PrefixSetV6::from_prefixes(src_v6),
             destination_v4: PrefixSetV4::from_prefixes(dst_v4),
@@ -332,6 +378,22 @@ pub(crate) fn evaluate_policy(
     src_port: u16,
     dst_port: u16,
 ) -> PolicyAction {
+    evaluate_policy_with_len(
+        state, from_id, to_id, src_ip, dst_ip, protocol, src_port, dst_port, 0,
+    )
+}
+
+pub(crate) fn evaluate_policy_with_len(
+    state: &PolicyState,
+    from_id: u16,
+    to_id: u16,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    packet_len: u64,
+) -> PolicyAction {
     // Phase 2 optimisation: look up only the rules for this zone-pair
     // instead of scanning all rules. Global rules are checked afterward.
     // #922: zero-allocation key (packed u32).
@@ -345,6 +407,7 @@ pub(crate) fn evaluate_policy(
                 protocol,
                 src_port,
                 dst_port,
+                packet_len,
             ) {
                 return action;
             }
@@ -359,6 +422,7 @@ pub(crate) fn evaluate_policy(
             protocol,
             src_port,
             dst_port,
+            packet_len,
         ) {
             return action;
         }
@@ -376,6 +440,7 @@ fn try_match_rule(
     protocol: u8,
     src_port: u16,
     dst_port: u16,
+    packet_len: u64,
 ) -> Option<PolicyAction> {
     if rule.inactive {
         return None;
@@ -387,13 +452,13 @@ fn try_match_rule(
         (IpAddr::V4(src), IpAddr::V4(dst))
             if rule.source_v4.contains(src) && rule.destination_v4.contains(dst) =>
         {
-            rule.hit_count.fetch_add(1, Ordering::Relaxed);
+            rule.hit_counter.add(packet_len);
             Some(rule.action)
         }
         (IpAddr::V6(src), IpAddr::V6(dst))
             if rule.source_v6.contains(src) && rule.destination_v6.contains(dst) =>
         {
-            rule.hit_count.fetch_add(1, Ordering::Relaxed);
+            rule.hit_counter.add(packet_len);
             Some(rule.action)
         }
         _ => None,

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -2,9 +2,10 @@ use crate::prefix::{PrefixV4, PrefixV6};
 use crate::prefix_set::{PrefixSetV4, PrefixSetV6};
 use crate::{PolicyApplicationSnapshot, PolicyRuleSnapshot};
 use ipnet::IpNet;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// #922: zone-pair key packed as u32 (`from_id << 16 | to_id`).
 /// Replaces the previous `(String, String)` key that allocated two
@@ -62,7 +63,7 @@ pub(crate) struct PolicyRule {
     /// Precompiled application matcher (protocol-indexed, exact-port sets).
     compiled_apps: CompiledApplications,
     pub(crate) action: PolicyAction,
-    pub(crate) hit_count: AtomicU64,
+    pub(crate) hit_count: Arc<AtomicU64>,
 }
 
 impl Default for PolicyRule {
@@ -83,7 +84,7 @@ impl Default for PolicyRule {
                 by_protocol: FxHashMap::default(),
             },
             action: PolicyAction::Deny,
-            hit_count: AtomicU64::new(0),
+            hit_count: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -103,9 +104,43 @@ impl Clone for PolicyRule {
             applications: self.applications.clone(),
             compiled_apps: self.compiled_apps.clone(),
             action: self.action,
-            hit_count: AtomicU64::new(self.hit_count.load(Ordering::Relaxed)),
+            hit_count: self.hit_count.clone(),
         }
     }
+}
+
+type PolicyCounterRegistry = FxHashMap<String, Arc<AtomicU64>>;
+
+const POLICY_COUNTER_REGISTRY_PRUNE_THRESHOLD: usize = 16_384;
+
+static POLICY_COUNTERS: OnceLock<Mutex<PolicyCounterRegistry>> = OnceLock::new();
+
+fn policy_counter_registry() -> &'static Mutex<PolicyCounterRegistry> {
+    POLICY_COUNTERS.get_or_init(|| Mutex::new(FxHashMap::default()))
+}
+
+fn prune_policy_counter_registry(active_rule_ids: &FxHashSet<String>) {
+    if let Ok(mut counters) = policy_counter_registry().lock() {
+        if counters.len() <= POLICY_COUNTER_REGISTRY_PRUNE_THRESHOLD {
+            return;
+        }
+        counters.retain(|rule_id, counter| {
+            active_rule_ids.contains(rule_id) || Arc::strong_count(counter) > 1
+        });
+    }
+}
+
+fn policy_rule_hit_counter(rule_id: &str) -> Arc<AtomicU64> {
+    let mut counters = policy_counter_registry()
+        .lock()
+        .expect("policy counter registry poisoned");
+    if let Some(counter) = counters.get(rule_id) {
+        return counter.clone();
+    }
+
+    let counter = Arc::new(AtomicU64::new(0));
+    counters.insert(rule_id.to_string(), counter.clone());
+    counter
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -216,6 +251,8 @@ pub(crate) fn parse_policy_state(
     rules: &[PolicyRuleSnapshot],
     zone_name_to_id: &FxHashMap<String, u16>,
 ) -> PolicyState {
+    let active_rule_ids = rules.iter().map(stable_policy_rule_id).collect();
+    prune_policy_counter_registry(&active_rule_ids);
     let mut state = PolicyState {
         default_action: parse_action(default_policy),
         rules: Vec::with_capacity(rules.len()),
@@ -236,13 +273,15 @@ pub(crate) fn parse_policy_state(
         for prefix in &snap.destination_addresses {
             parse_address(prefix, &mut dst_v4, &mut dst_v6);
         }
+        let rule_id = stable_policy_rule_id(snap);
         let mut rule = PolicyRule {
-            rule_id: stable_policy_rule_id(snap),
+            rule_id: rule_id.clone(),
             from_zone: snap.from_zone.clone(),
             to_zone: snap.to_zone.clone(),
             scheduler_name: snap.scheduler_name.clone(),
             inactive: snap.inactive,
             action: parse_action(&snap.action),
+            hit_count: policy_rule_hit_counter(&rule_id),
             source_v4: PrefixSetV4::from_prefixes(src_v4),
             source_v6: PrefixSetV6::from_prefixes(src_v6),
             destination_v4: PrefixSetV4::from_prefixes(dst_v4),

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -32,6 +32,14 @@ fn scheduled_allow_snapshot(rule_id: &str, inactive: bool) -> PolicyRuleSnapshot
     }
 }
 
+fn policy_counter(state: &PolicyState, rule_id: &str) -> PolicyRuleCounterStatus {
+    state
+        .counter_snapshots()
+        .into_iter()
+        .find(|counter| counter.rule_id == rule_id)
+        .unwrap_or_else(|| panic!("missing policy counter for {rule_id}"))
+}
+
 #[test]
 fn allow_all_matches_zone_pair() {
     let state = parse_policy_state(
@@ -122,9 +130,7 @@ fn evaluate_policy_skips_inactive_rules() {
         PolicyAction::Deny
     );
     assert_eq!(
-        state.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
+        policy_counter(&state, "security-policy:lan:wan:inactive-allow").packets,
         0
     );
 }
@@ -175,16 +181,9 @@ fn inactive_rule_falls_through_to_next_match() {
         ),
         PolicyAction::Permit
     );
+    assert_eq!(policy_counter(&state, "lan->wan/inactive-deny").packets, 0);
     assert_eq!(
-        state.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        0
-    );
-    assert_eq!(
-        state.rules[1]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
+        policy_counter(&state, "security-policy:lan:wan:active-allow").packets,
         1
     );
 }
@@ -192,15 +191,18 @@ fn inactive_rule_falls_through_to_next_match() {
 #[test]
 fn hit_counters_survive_scheduler_snapshot_rebuild() {
     let rule_id = format!("security-policy:lan:wan:counter-survival-{}", line!());
-    let active = parse_policy_state(
+    let counter_store = PolicyCounterStore::default();
+    counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, false)]);
+    let active = parse_policy_state_with_counters(
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &counter_store,
     );
 
     for _ in 0..2 {
         assert_eq!(
-            evaluate_policy(
+            evaluate_policy_with_len(
                 &active,
                 TEST_LAN_ZONE_ID,
                 TEST_WAN_ZONE_ID,
@@ -209,29 +211,24 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
                 PROTO_TCP,
                 12345,
                 5201,
+                64,
             ),
             PolicyAction::Permit
         );
     }
-    assert_eq!(
-        active.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        2
-    );
+    let active_counter = policy_counter(&active, &rule_id);
+    assert_eq!(active_counter.packets, 2);
+    assert_eq!(active_counter.bytes, 128);
 
-    let inactive = parse_policy_state(
+    counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, true)]);
+    let inactive = parse_policy_state_with_counters(
         "deny",
         &[scheduled_allow_snapshot(&rule_id, true)],
         &test_zone_name_to_id(),
+        &counter_store,
     );
     assert!(inactive.rules[0].inactive);
-    assert_eq!(
-        inactive.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        2
-    );
+    assert_eq!(policy_counter(&inactive, &rule_id).packets, 2);
     assert_eq!(
         evaluate_policy(
             &inactive,
@@ -245,26 +242,18 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
         ),
         PolicyAction::Deny
     );
-    assert_eq!(
-        inactive.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        2
-    );
+    assert_eq!(policy_counter(&inactive, &rule_id).packets, 2);
 
     drop(active);
     drop(inactive);
-    let active_again = parse_policy_state(
+    counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, false)]);
+    let active_again = parse_policy_state_with_counters(
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &counter_store,
     );
-    assert_eq!(
-        active_again.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        2
-    );
+    assert_eq!(policy_counter(&active_again, &rule_id).packets, 2);
     assert_eq!(
         evaluate_policy(
             &active_again,
@@ -278,12 +267,53 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
         ),
         PolicyAction::Permit
     );
-    assert_eq!(
-        active_again.rules[0]
-            .hit_count
-            .load(std::sync::atomic::Ordering::Relaxed),
-        3
+    assert_eq!(policy_counter(&active_again, &rule_id).packets, 3);
+}
+
+#[test]
+fn hit_counters_reset_after_rule_absent_then_readded() {
+    let rule_id = format!("security-policy:lan:wan:counter-reset-{}", line!());
+    let counter_store = PolicyCounterStore::default();
+    counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, false)]);
+    let active = parse_policy_state_with_counters(
+        "deny",
+        &[scheduled_allow_snapshot(&rule_id, false)],
+        &test_zone_name_to_id(),
+        &counter_store,
     );
+    assert_eq!(
+        evaluate_policy_with_len(
+            &active,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "172.16.80.200".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            5201,
+            96,
+        ),
+        PolicyAction::Permit
+    );
+    let active_counter = policy_counter(&active, &rule_id);
+    assert_eq!(active_counter.packets, 1);
+    assert_eq!(active_counter.bytes, 96);
+
+    counter_store.reconcile_rules(&[]);
+    let deleted =
+        parse_policy_state_with_counters("deny", &[], &test_zone_name_to_id(), &counter_store);
+    assert!(deleted.counter_snapshots().is_empty());
+
+    counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, false)]);
+    let active_again = parse_policy_state_with_counters(
+        "deny",
+        &[scheduled_allow_snapshot(&rule_id, false)],
+        &test_zone_name_to_id(),
+        &counter_store,
+    );
+    let reset_counter = policy_counter(&active_again, &rule_id);
+    assert_eq!(reset_counter.packets, 0);
+    assert_eq!(reset_counter.bytes, 0);
 }
 
 #[test]

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -16,6 +16,22 @@ fn test_zone_name_to_id() -> FxHashMap<String, u16> {
     m
 }
 
+fn scheduled_allow_snapshot(rule_id: &str, inactive: bool) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        rule_id: rule_id.to_string(),
+        name: "scheduled-allow".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        scheduler_name: "workhours".to_string(),
+        inactive,
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
 #[test]
 fn allow_all_matches_zone_pair() {
     let state = parse_policy_state(
@@ -170,6 +186,103 @@ fn inactive_rule_falls_through_to_next_match() {
             .hit_count
             .load(std::sync::atomic::Ordering::Relaxed),
         1
+    );
+}
+
+#[test]
+fn hit_counters_survive_scheduler_snapshot_rebuild() {
+    let rule_id = format!("security-policy:lan:wan:counter-survival-{}", line!());
+    let active = parse_policy_state(
+        "deny",
+        &[scheduled_allow_snapshot(&rule_id, false)],
+        &test_zone_name_to_id(),
+    );
+
+    for _ in 0..2 {
+        assert_eq!(
+            evaluate_policy(
+                &active,
+                TEST_LAN_ZONE_ID,
+                TEST_WAN_ZONE_ID,
+                "10.0.61.100".parse().expect("src"),
+                "172.16.80.200".parse().expect("dst"),
+                PROTO_TCP,
+                12345,
+                5201,
+            ),
+            PolicyAction::Permit
+        );
+    }
+    assert_eq!(
+        active.rules[0]
+            .hit_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2
+    );
+
+    let inactive = parse_policy_state(
+        "deny",
+        &[scheduled_allow_snapshot(&rule_id, true)],
+        &test_zone_name_to_id(),
+    );
+    assert!(inactive.rules[0].inactive);
+    assert_eq!(
+        inactive.rules[0]
+            .hit_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2
+    );
+    assert_eq!(
+        evaluate_policy(
+            &inactive,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "172.16.80.200".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            5201,
+        ),
+        PolicyAction::Deny
+    );
+    assert_eq!(
+        inactive.rules[0]
+            .hit_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2
+    );
+
+    drop(active);
+    drop(inactive);
+    let active_again = parse_policy_state(
+        "deny",
+        &[scheduled_allow_snapshot(&rule_id, false)],
+        &test_zone_name_to_id(),
+    );
+    assert_eq!(
+        active_again.rules[0]
+            .hit_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2
+    );
+    assert_eq!(
+        evaluate_policy(
+            &active_again,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "172.16.80.200".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            5201,
+        ),
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        active_again.rules[0]
+            .hit_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        3
     );
 }
 

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -822,6 +822,8 @@ pub(crate) struct ProcessStatus {
     pub recent_exceptions: Vec<ExceptionStatus>,
     #[serde(rename = "cos_interfaces", default)]
     pub cos_interfaces: Vec<CoSInterfaceStatus>,
+    #[serde(rename = "policy_rule_counters", default)]
+    pub policy_rule_counters: Vec<PolicyRuleCounterStatus>,
     #[serde(rename = "filter_term_counters", default)]
     pub filter_term_counters: Vec<FirewallFilterTermCounterStatus>,
     #[serde(rename = "last_resolution", skip_serializing_if = "Option::is_none")]
@@ -1045,6 +1047,16 @@ pub(crate) struct CoSQueueStatus {
     /// per-queue write via an `apply_*` early-return / queue miss.
     #[serde(rename = "drain_sent_bytes_shaped_unconditional", default)]
     pub drain_sent_bytes_shaped_unconditional: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct PolicyRuleCounterStatus {
+    #[serde(rename = "rule_id", default)]
+    pub rule_id: String,
+    #[serde(default)]
+    pub packets: u64,
+    #[serde(default)]
+    pub bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/server/handlers.rs
+++ b/userspace-dp/src/server/handlers.rs
@@ -207,6 +207,11 @@ pub(crate) fn handle_stream(
                     response.error = "missing snapshot".to_string();
                 }
             }
+            "clear_policy_counters" => {
+                guard.afxdp.clear_policy_counters();
+                refresh_status(&mut guard);
+                persist_state = true;
+            }
             "set_queue_state" => {
                 if let Some(queue_req) = request.queue {
                     let mut found = false;

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -78,6 +78,7 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     state.status.recent_session_deltas = state.afxdp.recent_session_deltas();
     state.status.recent_exceptions = state.afxdp.recent_exceptions();
     state.status.cos_interfaces = state.afxdp.cos_statuses();
+    state.status.policy_rule_counters = state.afxdp.policy_rule_counters();
     state.status.filter_term_counters = state.afxdp.filter_term_counters();
     let (flow_worker_map, flow_worker_map_truncated) = state.afxdp.flow_worker_map();
     state.status.flow_worker_map = flow_worker_map;

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -109,6 +109,7 @@ pub(crate) fn run() -> Result<(), String> {
             recent_session_deltas: Vec::new(),
             recent_exceptions: Vec::new(),
             cos_interfaces: Vec::new(),
+            policy_rule_counters: Vec::new(),
             filter_term_counters: Vec::new(),
             last_resolution: None,
             slow_path: SlowPathStatus::default(),


### PR DESCRIPTION
## Summary

Refs #1378.

Narrows the remaining userspace policy-scheduler gap after #1396:

- makes missing policy scheduler references commit-time errors for zone-pair and global policies
- preserves policy rule hit counters across scheduler-driven snapshot rebuilds by keying counters by stable rule ID
- adds Rust coverage showing hit counters survive active/inactive scheduler toggles
- updates the #1378 plan and feature-gap docs to leave only integration/HA validation as the remaining scheduler retirement evidence

## Validation

- `go test ./pkg/config ./pkg/dataplane/userspace`
- `cargo test policy:: -- --nocapture`
- `git diff --check`
