### PR TITLE
userspace: add bounded port mirror runtime slice

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12,6 +12,11 @@
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `userspace-dp/tests/snat_contract_doc_guard.rs`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml --test snat_contract_doc_guard`; `rustfmt --edition 2024 --check userspace-dp/tests/snat_contract_doc_guard.rs`; `git diff --check`
 
+- **Timestamp**: 2026-05-17T22:36:08Z
+  - **Action**: PR #1408 r5 re-review follow-up — corrected mirror counter doc wording so `mirror_drops_no_frame` no longer claims TX-frame-reserve drops (those now have dedicated `mirror_drops_tx_frame_reserve` telemetry).
+  - **File(s)**: `userspace-dp/src/afxdp/umem/mod.rs`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace`; `cargo test --manifest-path userspace-dp/Cargo.toml mirror::` (expected environment failure: missing libelf headers/pkg-config); `git diff --check`
+
 - **Timestamp**: 2026-05-17T15:28:13Z
   - **Action**: PR #1397 follow-up — fixed mouse-latency diagnostics review findings by making `cwnd_settle_ok` tri-state in manifests (unknown/true/false), correcting cwnd byte-unit parsing to 1024-based `K/M/G/TBytes`, recording probe phase timings even on failed/timed-out connect/drain/read attempts, tightening fairness-regimes settle-evidence wording, and extending unit coverage for settle-diagnostics CLI output/status and failure-phase timing counts.
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate.py`, `test/incus/mouse_latency_orchestrate_test.py`, `test/incus/mouse_latency_probe.py`, `test/incus/mouse_latency_probe_test.py`, `test/incus/test_mouse_latency_shell_test.py`, `docs/fairness-regimes.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -779,3 +779,11 @@
 - **Timestamp**: 2026-05-17T22:00:00Z
   - **Action**: Added explicit invariant note in `collectPolicyCounters` clarifying why zone-pair policy loop dereferences `rule.Name` without a nil guard while global policy loop retains defensive nil filtering.
   - **File(s)**: `pkg/api/metrics.go`, `_Log.md`
+
+- **Timestamp**: 2026-05-17T20:20:00Z
+  - **Action**: Edited mirror runtime path to resolve mirror output through bind-ifindex mapping and added production-shape mirror tests.
+  - **File(s)**: userspace-dp/src/afxdp/mirror.rs
+
+- **Timestamp**: 2026-05-17T20:21:00Z
+  - **Action**: Updated mirror counter comments to match actual NoFrame/NoBinding semantics.
+  - **File(s)**: userspace-dp/src/afxdp/umem/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -787,3 +787,11 @@
 - **Timestamp**: 2026-05-17T20:21:00Z
   - **Action**: Updated mirror counter comments to match actual NoFrame/NoBinding semantics.
   - **File(s)**: userspace-dp/src/afxdp/umem/mod.rs
+
+- **Timestamp**: 2026-05-17T21:28:00Z
+  - **Action**: Added cross-worker mirror admission cap path to enforce mirror-specific pending limit before redirect-inbox enqueue.
+  - **File(s)**: userspace-dp/src/afxdp/umem/mod.rs, userspace-dp/src/afxdp/mirror.rs
+
+- **Timestamp**: 2026-05-17T21:29:00Z
+  - **Action**: Updated #1376 plan test/runtime notes to match implemented mirror tests and cross-worker limit semantics.
+  - **File(s)**: docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -58,12 +58,17 @@ that binding.
 ## Current Runtime Slice
 
 The 2026-05-17 runtime slice wires mirror configs into `ForwardingState` and
-mirrors packets that enter the pending-forward TX path while the original frame
-bytes are still available. It samples per ingress binding, copies the full L2
-frame into an output binding TX frame, queues the clone as a prepared TX request,
-and records admitted/no-frame/no-binding/queue-full counters. The clone path
-keeps a TX-frame reserve and a small pending-backlog limit so mirror pressure is
-lossy and does not become a primary forwarding dependency.
+mirrors forwarded packets while the original frame bytes are still available,
+covering the miss/pending-forward path and the self-target flow-cache fast path.
+Mirror selection resolves VLAN ingress to the logical ifindex before falling
+back to the parent ifindex. Same-worker output copies the full L2 frame into an
+output binding TX frame and queues the clone as a prepared TX request;
+cross-worker output uses the target binding's live redirect inbox with an owned
+full-frame clone. Mirror clones carry the output CoS default/classified queue
+without DSCP rewrite, and CoS-bound leftovers are dropped rather than allowed to
+escape through backup TX. The clone path keeps a TX-frame reserve and a small
+pending-backlog limit so mirror pressure is lossy and does not become a primary
+forwarding dependency.
 
 The userspace capability gate remains in place for now. This slice does not yet
 claim complete port-mirroring parity for every ingress disposition or for

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -63,8 +63,9 @@ covering the miss/pending-forward path and the self-target flow-cache fast path.
 Mirror selection resolves VLAN ingress to the logical ifindex before falling
 back to the parent ifindex. Same-worker output copies the full L2 frame into an
 output binding TX frame and queues the clone as a prepared TX request;
-cross-worker output uses the target binding's live redirect inbox with an owned
-full-frame clone. Multi-queue mirror outputs require an exact output queue match;
+ cross-worker output uses the target binding's live redirect inbox with an owned
+ full-frame clone and the same small mirror-specific pending limit used by the
+ same-worker path. Multi-queue mirror outputs require an exact output queue match;
 the single-binding fallback is used only when that output ifindex has no queue
 ambiguity. Mirror clones carry the output CoS default/classified queue without
 DSCP rewrite, and CoS-bound leftovers are dropped rather than allowed to escape
@@ -101,8 +102,9 @@ pressure.
 - Cargo: `mirror::out_of_frame_drops_increment_counter`.
 - Cargo: `mirror::missing_destination_binding_drop_counter`.
 - Cargo: `mirror::queue_full_drop_counter`.
-- Cargo: `mirror::duplicate_ingress_ifindex_rejected`.
-- Cargo: `mirror::ipv4_ipv6_full_frame_preservation`.
+- Cargo: `mirror::cross_worker_live_enqueue_preserves_full_frame`.
+- Cargo: `mirror::mirror_output_logical_ifindex_resolves_parent_binding`.
+- Cargo: `mirror::sampled_live_mirror_resolves_snapshot_logical_ingress_and_output`.
 - Go: userspace snapshot round-trip for mirror config.
 - Go/Rust: status/counter wire round-trips include
   `mirrored_packets`, `mirrored_bytes`, `mirror_drops_no_frame`,

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -64,9 +64,11 @@ Mirror selection resolves VLAN ingress to the logical ifindex before falling
 back to the parent ifindex. Same-worker output copies the full L2 frame into an
 output binding TX frame and queues the clone as a prepared TX request;
 cross-worker output uses the target binding's live redirect inbox with an owned
-full-frame clone. Mirror clones carry the output CoS default/classified queue
-without DSCP rewrite, and CoS-bound leftovers are dropped rather than allowed to
-escape through backup TX. The clone path keeps a TX-frame reserve and a small
+full-frame clone. Multi-queue mirror outputs require an exact output queue match;
+the single-binding fallback is used only when that output ifindex has no queue
+ambiguity. Mirror clones carry the output CoS default/classified queue without
+DSCP rewrite, and CoS-bound leftovers are dropped rather than allowed to escape
+through backup TX. The clone path keeps a TX-frame reserve and a small
 pending-backlog limit so mirror pressure is lossy and does not become a primary
 forwarding dependency.
 
@@ -83,7 +85,8 @@ pressure.
   primary forwarding.
 - Cross-binding ownership: cloned descriptors must use the same recycle/UMEM
   routing discipline as forwarding descriptors; a mirror drop must not return a
-  frame to the wrong binding.
+  frame to the wrong binding. Ambiguous multi-queue output bindings fail closed
+  as `mirror_drops_no_binding` rather than falling back to an arbitrary queue.
 - Full-frame fidelity: mirror output must preserve Ethernet/VLAN bytes. Any
   L3-only fallback path silently breaks packet capture/debug workflows.
 - Sampling ambiguity: per-binding sampling is cheaper than global exact
@@ -93,6 +96,8 @@ pressure.
 
 - Cargo: `mirror::sampling_rate_correctness`.
 - Cargo: `mirror::cross_binding_inject_preserves_full_frame`.
+- Cargo: `mirror::cross_binding_mirror_requires_exact_queue_when_output_is_multiqueue`.
+- Cargo: `mirror::live_mirror_requires_exact_queue_when_output_is_multiqueue`.
 - Cargo: `mirror::out_of_frame_drops_increment_counter`.
 - Cargo: `mirror::missing_destination_binding_drop_counter`.
 - Cargo: `mirror::queue_full_drop_counter`.

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
@@ -49,11 +49,27 @@ that binding.
 - Mirror config is snapshot state and is republished on config changes.
 - Runtime sampling counters are local per binding and reset on worker restart or
   failover.
-- Counters exposed through Rust status, Go protocol, CLI, and Prometheus:
+- Counters exposed through Rust status, Go protocol, and CLI summary:
   `mirrored_packets`, `mirrored_bytes`, `mirror_drops_no_frame`,
   `mirror_drops_no_binding`, and `mirror_drops_queue_full`.
 - On failover, the new active node mirrors according to the current config; no
   mirror clone state is synchronized.
+
+## Current Runtime Slice
+
+The 2026-05-17 runtime slice wires mirror configs into `ForwardingState` and
+mirrors packets that enter the pending-forward TX path while the original frame
+bytes are still available. It samples per ingress binding, copies the full L2
+frame into an output binding TX frame, queues the clone as a prepared TX request,
+and records admitted/no-frame/no-binding/queue-full counters. The clone path
+keeps a TX-frame reserve and a small pending-backlog limit so mirror pressure is
+lossy and does not become a primary forwarding dependency.
+
+The userspace capability gate remains in place for now. This slice does not yet
+claim complete port-mirroring parity for every ingress disposition or for
+prebuilt/deferred transmit paths, and it still needs integration evidence with
+tcpdump on the mirror output plus primary forwarding survival under mirror
+pressure.
 
 ## Risks
 
@@ -71,13 +87,16 @@ that binding.
 ## Exact Tests
 
 - Cargo: `mirror::sampling_rate_correctness`.
-- Cargo: `mirror::cross_binding_inject`.
+- Cargo: `mirror::cross_binding_inject_preserves_full_frame`.
 - Cargo: `mirror::out_of_frame_drops_increment_counter`.
 - Cargo: `mirror::missing_destination_binding_drop_counter`.
 - Cargo: `mirror::queue_full_drop_counter`.
 - Cargo: `mirror::duplicate_ingress_ifindex_rejected`.
 - Cargo: `mirror::ipv4_ipv6_full_frame_preservation`.
 - Go: userspace snapshot round-trip for mirror config.
+- Go/Rust: status/counter wire round-trips include
+  `mirrored_packets`, `mirrored_bytes`, `mirror_drops_no_frame`,
+  `mirror_drops_no_binding`, and `mirror_drops_queue_full`.
 - Go: commit validation rejects duplicate ingress mirror entries and logs/skips
   nonexistent output ifindex consistently with current compiler behavior.
 - Go: `deriveUserspaceCapabilities()` admits port-mirroring configs only after

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -53,7 +53,14 @@ These are the remaining explicit configuration gates in
 | Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
 | Screen behavior requiring SYN cookies | Gated; userspace screen runtime has fail-closed cookie challenge/ACK-validation/cache scaffolding, but no HA key publication or SYN-ACK/RST TX yet | #1374 |
 | Three-color policers | Gated | #1375 |
-| Port mirroring | Gated | #1376 |
+| Port mirroring | Gated; partial runtime | #1376 still needs full path coverage and integration evidence before the gate is removed |
+
+Port mirroring now has snapshot/wire plumbing plus a bounded forwarded-path
+runtime slice that samples and queues discardable full-L2 mirror clones with
+drop counters. The `deriveUserspaceCapabilities()` gate intentionally remains
+until #1376 covers every required ingress/transmit path and has integration
+validation for mirror output fidelity and forwarding survival under mirror
+pressure.
 
 ## Features That Still Use A Mixed Boundary
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -851,6 +851,8 @@ type BindingStatus struct {
 	MirrorDropsTXFrameReserve         uint64 `json:"mirror_drops_tx_frame_reserve,omitempty"`
 	MirrorDropsNoBinding              uint64 `json:"mirror_drops_no_binding,omitempty"`
 	MirrorDropsQueueFull              uint64 `json:"mirror_drops_queue_full,omitempty"`
+	MirrorDropsQueueFullSameWorker    uint64 `json:"mirror_drops_queue_full_same_worker,omitempty"`
+	MirrorDropsQueueFullCrossWorker   uint64 `json:"mirror_drops_queue_full_cross_worker,omitempty"`
 	DirectTXPackets                   uint64 `json:"direct_tx_packets,omitempty"`
 	CopyTXPackets                     uint64 `json:"copy_tx_packets,omitempty"`
 	InPlaceTXPackets                  uint64 `json:"in_place_tx_packets,omitempty"`
@@ -975,6 +977,8 @@ type BindingCountersSnapshot struct {
 	MirrorDropsTXFrameReserve       uint64 `json:"mirror_drops_tx_frame_reserve,omitempty"`
 	MirrorDropsNoBinding            uint64 `json:"mirror_drops_no_binding,omitempty"`
 	MirrorDropsQueueFull            uint64 `json:"mirror_drops_queue_full,omitempty"`
+	MirrorDropsQueueFullSameWorker  uint64 `json:"mirror_drops_queue_full_same_worker,omitempty"`
+	MirrorDropsQueueFullCrossWorker uint64 `json:"mirror_drops_queue_full_cross_worker,omitempty"`
 	// #812: per-queue TX submit→completion latency histogram, pulled
 	// through from BindingStatus so step1-capture consumers can
 	// compute per-queue latency distributions without a second

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -848,6 +848,7 @@ type BindingStatus struct {
 	MirroredPackets                   uint64 `json:"mirrored_packets,omitempty"`
 	MirroredBytes                     uint64 `json:"mirrored_bytes,omitempty"`
 	MirrorDropsNoFrame                uint64 `json:"mirror_drops_no_frame,omitempty"`
+	MirrorDropsTXFrameReserve         uint64 `json:"mirror_drops_tx_frame_reserve,omitempty"`
 	MirrorDropsNoBinding              uint64 `json:"mirror_drops_no_binding,omitempty"`
 	MirrorDropsQueueFull              uint64 `json:"mirror_drops_queue_full,omitempty"`
 	DirectTXPackets                   uint64 `json:"direct_tx_packets,omitempty"`
@@ -971,6 +972,7 @@ type BindingCountersSnapshot struct {
 	MirroredPackets                 uint64 `json:"mirrored_packets,omitempty"`
 	MirroredBytes                   uint64 `json:"mirrored_bytes,omitempty"`
 	MirrorDropsNoFrame              uint64 `json:"mirror_drops_no_frame,omitempty"`
+	MirrorDropsTXFrameReserve       uint64 `json:"mirror_drops_tx_frame_reserve,omitempty"`
 	MirrorDropsNoBinding            uint64 `json:"mirror_drops_no_binding,omitempty"`
 	MirrorDropsQueueFull            uint64 `json:"mirror_drops_queue_full,omitempty"`
 	// #812: per-queue TX submit→completion latency histogram, pulled

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -845,6 +845,11 @@ type BindingStatus struct {
 	PendingTXLocalOverflowDrops       uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
 	TxSubmitErrorDrops                uint64 `json:"tx_submit_error_drops,omitempty"`
 	TXCompletions                     uint64 `json:"tx_completions,omitempty"`
+	MirroredPackets                   uint64 `json:"mirrored_packets,omitempty"`
+	MirroredBytes                     uint64 `json:"mirrored_bytes,omitempty"`
+	MirrorDropsNoFrame                uint64 `json:"mirror_drops_no_frame,omitempty"`
+	MirrorDropsNoBinding              uint64 `json:"mirror_drops_no_binding,omitempty"`
+	MirrorDropsQueueFull              uint64 `json:"mirror_drops_queue_full,omitempty"`
 	DirectTXPackets                   uint64 `json:"direct_tx_packets,omitempty"`
 	CopyTXPackets                     uint64 `json:"copy_tx_packets,omitempty"`
 	InPlaceTXPackets                  uint64 `json:"in_place_tx_packets,omitempty"`
@@ -963,6 +968,11 @@ type BindingCountersSnapshot struct {
 	TXSharedRecycleUnknownSlotDrops uint64 `json:"tx_shared_recycle_unknown_slot_drops,omitempty"`
 	TxSubmitErrorDrops              uint64 `json:"tx_submit_error_drops,omitempty"`
 	PendingTxLocalOverflowDrops     uint64 `json:"pending_tx_local_overflow_drops,omitempty"`
+	MirroredPackets                 uint64 `json:"mirrored_packets,omitempty"`
+	MirroredBytes                   uint64 `json:"mirrored_bytes,omitempty"`
+	MirrorDropsNoFrame              uint64 `json:"mirror_drops_no_frame,omitempty"`
+	MirrorDropsNoBinding            uint64 `json:"mirror_drops_no_binding,omitempty"`
+	MirrorDropsQueueFull            uint64 `json:"mirror_drops_queue_full,omitempty"`
 	// #812: per-queue TX submit→completion latency histogram, pulled
 	// through from BindingStatus so step1-capture consumers can
 	// compute per-queue latency distributions without a second

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -36,6 +36,8 @@ var mirror_counter_wire_keys = []string{
 	"mirror_drops_tx_frame_reserve",
 	"mirror_drops_no_binding",
 	"mirror_drops_queue_full",
+	"mirror_drops_queue_full_same_worker",
+	"mirror_drops_queue_full_cross_worker",
 }
 
 func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
@@ -133,15 +135,17 @@ func TestConfigSnapshotMirrorConfigsRoundTrip(t *testing.T) {
 
 func TestBindingStatusMirrorCountersRoundTrip(t *testing.T) {
 	in := BindingStatus{
-		WorkerID:                  3,
-		Ifindex:                   11,
-		QueueID:                   2,
-		MirroredPackets:           5,
-		MirroredBytes:             640,
-		MirrorDropsNoFrame:        1,
-		MirrorDropsTXFrameReserve: 2,
-		MirrorDropsNoBinding:      3,
-		MirrorDropsQueueFull:      4,
+		WorkerID:                        3,
+		Ifindex:                         11,
+		QueueID:                         2,
+		MirroredPackets:                 5,
+		MirroredBytes:                   640,
+		MirrorDropsNoFrame:              1,
+		MirrorDropsTXFrameReserve:       2,
+		MirrorDropsNoBinding:            3,
+		MirrorDropsQueueFull:            4,
+		MirrorDropsQueueFullSameWorker:  5,
+		MirrorDropsQueueFullCrossWorker: 6,
 	}
 	raw, err := json.Marshal(&in)
 	if err != nil {
@@ -168,15 +172,17 @@ func TestBindingStatusMirrorCountersRoundTrip(t *testing.T) {
 
 func TestBindingCountersSnapshotMirrorCountersRoundTrip(t *testing.T) {
 	in := BindingCountersSnapshot{
-		WorkerID:                  3,
-		Ifindex:                   11,
-		QueueID:                   2,
-		MirroredPackets:           5,
-		MirroredBytes:             640,
-		MirrorDropsNoFrame:        1,
-		MirrorDropsTXFrameReserve: 2,
-		MirrorDropsNoBinding:      3,
-		MirrorDropsQueueFull:      4,
+		WorkerID:                        3,
+		Ifindex:                         11,
+		QueueID:                         2,
+		MirroredPackets:                 5,
+		MirroredBytes:                   640,
+		MirrorDropsNoFrame:              1,
+		MirrorDropsTXFrameReserve:       2,
+		MirrorDropsNoBinding:            3,
+		MirrorDropsQueueFull:            4,
+		MirrorDropsQueueFullSameWorker:  5,
+		MirrorDropsQueueFullCrossWorker: 6,
 	}
 	raw, err := json.Marshal(&in)
 	if err != nil {

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -29,6 +29,14 @@ var tx_completion_ring_wire_keys = []string{
 	"tx_completion_ring_available_max",
 }
 
+var mirror_counter_wire_keys = []string{
+	"mirrored_packets",
+	"mirrored_bytes",
+	"mirror_drops_no_frame",
+	"mirror_drops_no_binding",
+	"mirror_drops_queue_full",
+}
+
 func TestBindingStatusTXSharedRecycleUnknownSlotDropsRoundTrip(t *testing.T) {
 	in := BindingStatus{
 		WorkerID:                        3,
@@ -119,6 +127,74 @@ func TestConfigSnapshotMirrorConfigsRoundTrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(back.MirrorConfigs, in.MirrorConfigs) {
 		t.Fatalf("mirror config round-trip mismatch: got %+v, want %+v", back.MirrorConfigs, in.MirrorConfigs)
+	}
+}
+
+func TestBindingStatusMirrorCountersRoundTrip(t *testing.T) {
+	in := BindingStatus{
+		WorkerID:             3,
+		Ifindex:              11,
+		QueueID:              2,
+		MirroredPackets:      5,
+		MirroredBytes:        640,
+		MirrorDropsNoFrame:   1,
+		MirrorDropsNoBinding: 2,
+		MirrorDropsQueueFull: 3,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range mirror_counter_wire_keys {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from BindingStatus JSON: %s", key, string(raw))
+		}
+	}
+
+	var back BindingStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingStatus: %v", err)
+	}
+	if !reflect.DeepEqual(back, in) {
+		t.Fatalf("mirror counters round-trip mismatch: got %+v, want %+v", back, in)
+	}
+}
+
+func TestBindingCountersSnapshotMirrorCountersRoundTrip(t *testing.T) {
+	in := BindingCountersSnapshot{
+		WorkerID:             3,
+		Ifindex:              11,
+		QueueID:              2,
+		MirroredPackets:      5,
+		MirroredBytes:        640,
+		MirrorDropsNoFrame:   1,
+		MirrorDropsNoBinding: 2,
+		MirrorDropsQueueFull: 3,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range mirror_counter_wire_keys {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from BindingCountersSnapshot JSON: %s", key, string(raw))
+		}
+	}
+
+	var back BindingCountersSnapshot
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal BindingCountersSnapshot: %v", err)
+	}
+	if !reflect.DeepEqual(back, in) {
+		t.Fatalf("mirror counters round-trip mismatch: got %+v, want %+v", back, in)
 	}
 }
 

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -33,6 +33,7 @@ var mirror_counter_wire_keys = []string{
 	"mirrored_packets",
 	"mirrored_bytes",
 	"mirror_drops_no_frame",
+	"mirror_drops_tx_frame_reserve",
 	"mirror_drops_no_binding",
 	"mirror_drops_queue_full",
 }
@@ -132,14 +133,15 @@ func TestConfigSnapshotMirrorConfigsRoundTrip(t *testing.T) {
 
 func TestBindingStatusMirrorCountersRoundTrip(t *testing.T) {
 	in := BindingStatus{
-		WorkerID:             3,
-		Ifindex:              11,
-		QueueID:              2,
-		MirroredPackets:      5,
-		MirroredBytes:        640,
-		MirrorDropsNoFrame:   1,
-		MirrorDropsNoBinding: 2,
-		MirrorDropsQueueFull: 3,
+		WorkerID:                  3,
+		Ifindex:                   11,
+		QueueID:                   2,
+		MirroredPackets:           5,
+		MirroredBytes:             640,
+		MirrorDropsNoFrame:        1,
+		MirrorDropsTXFrameReserve: 2,
+		MirrorDropsNoBinding:      3,
+		MirrorDropsQueueFull:      4,
 	}
 	raw, err := json.Marshal(&in)
 	if err != nil {
@@ -166,14 +168,15 @@ func TestBindingStatusMirrorCountersRoundTrip(t *testing.T) {
 
 func TestBindingCountersSnapshotMirrorCountersRoundTrip(t *testing.T) {
 	in := BindingCountersSnapshot{
-		WorkerID:             3,
-		Ifindex:              11,
-		QueueID:              2,
-		MirroredPackets:      5,
-		MirroredBytes:        640,
-		MirrorDropsNoFrame:   1,
-		MirrorDropsNoBinding: 2,
-		MirrorDropsQueueFull: 3,
+		WorkerID:                  3,
+		Ifindex:                   11,
+		QueueID:                   2,
+		MirroredPackets:           5,
+		MirroredBytes:             640,
+		MirrorDropsNoFrame:        1,
+		MirrorDropsTXFrameReserve: 2,
+		MirrorDropsNoBinding:      3,
+		MirrorDropsQueueFull:      4,
 	}
 	raw, err := json.Marshal(&in)
 	if err != nil {

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -71,6 +71,11 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var bindingLifetimeCoSQueueDrops uint64
 	var txSharedRecycleUnknownSlotDrops uint64
 	var txCompletions uint64
+	var mirroredPackets uint64
+	var mirroredBytes uint64
+	var mirrorDropsNoFrame uint64
+	var mirrorDropsNoBinding uint64
+	var mirrorDropsQueueFull uint64
 	var currentRuntimeCoSFlowShareDrops uint64
 	var currentRuntimeCoSBufferDrops uint64
 	var cosAdmissionEcnMarked uint64
@@ -145,6 +150,11 @@ func FormatStatusSummary(status ProcessStatus) string {
 		bindingLifetimeCoSQueueDrops = saturatingAddU64(bindingLifetimeCoSQueueDrops, binding.DbgCoSQueueOverflow)
 		txSharedRecycleUnknownSlotDrops += binding.TXSharedRecycleUnknownSlotDrops
 		txCompletions += binding.TXCompletions
+		mirroredPackets += binding.MirroredPackets
+		mirroredBytes += binding.MirroredBytes
+		mirrorDropsNoFrame += binding.MirrorDropsNoFrame
+		mirrorDropsNoBinding += binding.MirrorDropsNoBinding
+		mirrorDropsQueueFull += binding.MirrorDropsQueueFull
 		kernelRXDropped += binding.KernelRXDropped
 		kernelRXInvalidDescs += binding.KernelRXInvalidDescs
 		directTXPackets += binding.DirectTXPackets
@@ -316,6 +326,9 @@ func FormatStatusSummary(status ProcessStatus) string {
 	}
 	fmt.Fprintf(&b, "  TX shared recycle unk:     %d\n", txSharedRecycleUnknownSlotDrops)
 	fmt.Fprintf(&b, "  TX completions:            %d\n", txCompletions)
+	fmt.Fprintf(&b, "  Mirrored packets:          %d\n", mirroredPackets)
+	fmt.Fprintf(&b, "  Mirrored bytes:            %d\n", mirroredBytes)
+	fmt.Fprintf(&b, "  Mirror drops:              no-frame=%d no-binding=%d queue-full=%d\n", mirrorDropsNoFrame, mirrorDropsNoBinding, mirrorDropsQueueFull)
 	fmt.Fprintf(&b, "  Kernel RX dropped:         %d\n", kernelRXDropped)
 	fmt.Fprintf(&b, "  Kernel RX invalid descs:   %d\n", kernelRXInvalidDescs)
 	fmt.Fprintf(&b, "  Direct TX packets:         %d\n", directTXPackets)

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -77,6 +77,8 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var mirrorDropsTXFrameReserve uint64
 	var mirrorDropsNoBinding uint64
 	var mirrorDropsQueueFull uint64
+	var mirrorDropsQueueFullSameWorker uint64
+	var mirrorDropsQueueFullCrossWorker uint64
 	var currentRuntimeCoSFlowShareDrops uint64
 	var currentRuntimeCoSBufferDrops uint64
 	var cosAdmissionEcnMarked uint64
@@ -157,6 +159,8 @@ func FormatStatusSummary(status ProcessStatus) string {
 		mirrorDropsTXFrameReserve += binding.MirrorDropsTXFrameReserve
 		mirrorDropsNoBinding += binding.MirrorDropsNoBinding
 		mirrorDropsQueueFull += binding.MirrorDropsQueueFull
+		mirrorDropsQueueFullSameWorker += binding.MirrorDropsQueueFullSameWorker
+		mirrorDropsQueueFullCrossWorker += binding.MirrorDropsQueueFullCrossWorker
 		kernelRXDropped += binding.KernelRXDropped
 		kernelRXInvalidDescs += binding.KernelRXInvalidDescs
 		directTXPackets += binding.DirectTXPackets
@@ -330,7 +334,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX completions:            %d\n", txCompletions)
 	fmt.Fprintf(&b, "  Mirrored packets:          %d\n", mirroredPackets)
 	fmt.Fprintf(&b, "  Mirrored bytes:            %d\n", mirroredBytes)
-	fmt.Fprintf(&b, "  Mirror drops:              no-frame=%d tx-frame-reserve=%d no-binding=%d queue-full=%d\n", mirrorDropsNoFrame, mirrorDropsTXFrameReserve, mirrorDropsNoBinding, mirrorDropsQueueFull)
+	fmt.Fprintf(&b, "  Mirror drops:              no-frame=%d tx-frame-reserve=%d no-binding=%d queue-full=%d same-worker=%d cross-worker=%d\n", mirrorDropsNoFrame, mirrorDropsTXFrameReserve, mirrorDropsNoBinding, mirrorDropsQueueFull, mirrorDropsQueueFullSameWorker, mirrorDropsQueueFullCrossWorker)
 	fmt.Fprintf(&b, "  Kernel RX dropped:         %d\n", kernelRXDropped)
 	fmt.Fprintf(&b, "  Kernel RX invalid descs:   %d\n", kernelRXInvalidDescs)
 	fmt.Fprintf(&b, "  Direct TX packets:         %d\n", directTXPackets)

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -74,6 +74,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	var mirroredPackets uint64
 	var mirroredBytes uint64
 	var mirrorDropsNoFrame uint64
+	var mirrorDropsTXFrameReserve uint64
 	var mirrorDropsNoBinding uint64
 	var mirrorDropsQueueFull uint64
 	var currentRuntimeCoSFlowShareDrops uint64
@@ -153,6 +154,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		mirroredPackets += binding.MirroredPackets
 		mirroredBytes += binding.MirroredBytes
 		mirrorDropsNoFrame += binding.MirrorDropsNoFrame
+		mirrorDropsTXFrameReserve += binding.MirrorDropsTXFrameReserve
 		mirrorDropsNoBinding += binding.MirrorDropsNoBinding
 		mirrorDropsQueueFull += binding.MirrorDropsQueueFull
 		kernelRXDropped += binding.KernelRXDropped
@@ -328,7 +330,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  TX completions:            %d\n", txCompletions)
 	fmt.Fprintf(&b, "  Mirrored packets:          %d\n", mirroredPackets)
 	fmt.Fprintf(&b, "  Mirrored bytes:            %d\n", mirroredBytes)
-	fmt.Fprintf(&b, "  Mirror drops:              no-frame=%d no-binding=%d queue-full=%d\n", mirrorDropsNoFrame, mirrorDropsNoBinding, mirrorDropsQueueFull)
+	fmt.Fprintf(&b, "  Mirror drops:              no-frame=%d tx-frame-reserve=%d no-binding=%d queue-full=%d\n", mirrorDropsNoFrame, mirrorDropsTXFrameReserve, mirrorDropsNoBinding, mirrorDropsQueueFull)
 	fmt.Fprintf(&b, "  Kernel RX dropped:         %d\n", kernelRXDropped)
 	fmt.Fprintf(&b, "  Kernel RX invalid descs:   %d\n", kernelRXInvalidDescs)
 	fmt.Fprintf(&b, "  Direct TX packets:         %d\n", directTXPackets)

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -40,8 +40,8 @@ func TestFormatStatusSummary(t *testing.T) {
 			{QueueID: 1, Armed: false, Ready: false},
 		},
 		Bindings: []BindingStatus{
-			{Slot: 0, Armed: false, Ready: true, Bound: true, XSKRegistered: true, XSKBindMode: "zerocopy", ZeroCopy: true, SharedUMEMMode: "cross-nic", SharedUMEMSocketRole: "owner", SharedUMEMGroup: "cross-nic:w0:ge-0-0-1,ge-0-0-2", RXPackets: 10, ValidatedPackets: 8, ExceptionPackets: 1, TXPackets: 3, TXBytes: 420, TXCompletions: 2, KernelRXDropped: 9, KernelRXInvalidDescs: 1, DirectTXPackets: 2, InPlaceTXPackets: 1, InPlaceVLANPushDescPackets: 8, InPlaceVLANPopDescPackets: 9, InPlaceVLANPushNoHeadroomPackets: 10, InPlaceL2MemmoveFallbackPackets: 11, DirectTXNoFrameFallbackPackets: 5, DirectTXBuildFallbackPackets: 6, DebugPendingFillFrames: 10, DebugSpareFillFrames: 11, DebugFreeTXFrames: 12, DebugPendingTXPrepared: 13, DebugPendingTXLocal: 14, DebugOutstandingTX: 15, DebugInFlightRecycles: 16},
-			{Slot: 1, Armed: false, Ready: false, Bound: true, XSKRegistered: false, RXPackets: 5, ValidatedPackets: 4, ExceptionPackets: 2, TXErrors: 1, TXSharedRecycleUnknownSlotDrops: 1, TXCompletions: 3, KernelRXDropped: 4, KernelRXInvalidDescs: 2, CopyTXPackets: 4, InPlaceVLANPushDescPackets: 3, InPlaceVLANPopDescPackets: 4, InPlaceVLANPushNoHeadroomPackets: 5, InPlaceL2MemmoveFallbackPackets: 6, DirectTXDisallowedFallbackPackets: 7, DebugPendingFillFrames: 20, DebugSpareFillFrames: 21, DebugFreeTXFrames: 22, DebugPendingTXPrepared: 23, DebugPendingTXLocal: 24, DebugOutstandingTX: 25, DebugInFlightRecycles: 26},
+			{Slot: 0, Armed: false, Ready: true, Bound: true, XSKRegistered: true, XSKBindMode: "zerocopy", ZeroCopy: true, SharedUMEMMode: "cross-nic", SharedUMEMSocketRole: "owner", SharedUMEMGroup: "cross-nic:w0:ge-0-0-1,ge-0-0-2", RXPackets: 10, ValidatedPackets: 8, ExceptionPackets: 1, TXPackets: 3, TXBytes: 420, TXCompletions: 2, MirroredPackets: 4, MirroredBytes: 512, MirrorDropsNoFrame: 1, KernelRXDropped: 9, KernelRXInvalidDescs: 1, DirectTXPackets: 2, InPlaceTXPackets: 1, InPlaceVLANPushDescPackets: 8, InPlaceVLANPopDescPackets: 9, InPlaceVLANPushNoHeadroomPackets: 10, InPlaceL2MemmoveFallbackPackets: 11, DirectTXNoFrameFallbackPackets: 5, DirectTXBuildFallbackPackets: 6, DebugPendingFillFrames: 10, DebugSpareFillFrames: 11, DebugFreeTXFrames: 12, DebugPendingTXPrepared: 13, DebugPendingTXLocal: 14, DebugOutstandingTX: 15, DebugInFlightRecycles: 16},
+			{Slot: 1, Armed: false, Ready: false, Bound: true, XSKRegistered: false, RXPackets: 5, ValidatedPackets: 4, ExceptionPackets: 2, TXErrors: 1, TXSharedRecycleUnknownSlotDrops: 1, TXCompletions: 3, MirroredPackets: 6, MirroredBytes: 768, MirrorDropsNoBinding: 2, MirrorDropsQueueFull: 3, KernelRXDropped: 4, KernelRXInvalidDescs: 2, CopyTXPackets: 4, InPlaceVLANPushDescPackets: 3, InPlaceVLANPopDescPackets: 4, InPlaceVLANPushNoHeadroomPackets: 5, InPlaceL2MemmoveFallbackPackets: 6, DirectTXDisallowedFallbackPackets: 7, DebugPendingFillFrames: 20, DebugSpareFillFrames: 21, DebugFreeTXFrames: 22, DebugPendingTXPrepared: 23, DebugPendingTXLocal: 24, DebugOutstandingTX: 25, DebugInFlightRecycles: 26},
 		},
 		RecentExceptions: []ExceptionStatus{
 			{Timestamp: now, Slot: 1, QueueID: 0, Interface: "ge-0-0-2", Reason: "metadata_parse", PacketLength: 128},
@@ -92,6 +92,9 @@ func TestFormatStatusSummary(t *testing.T) {
 		"TX errors:                 1",
 		"TX shared recycle unk:     1",
 		"TX completions:            5",
+		"Mirrored packets:          10",
+		"Mirrored bytes:            1280",
+		"Mirror drops:              no-frame=1 no-binding=2 queue-full=3",
 		"Kernel RX dropped:         13",
 		"Kernel RX invalid descs:   3",
 		"Direct TX packets:         2",

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -94,7 +94,7 @@ func TestFormatStatusSummary(t *testing.T) {
 		"TX completions:            5",
 		"Mirrored packets:          10",
 		"Mirrored bytes:            1280",
-		"Mirror drops:              no-frame=1 no-binding=2 queue-full=3",
+		"Mirror drops:              no-frame=1 tx-frame-reserve=0 no-binding=2 queue-full=3",
 		"Kernel RX dropped:         13",
 		"Kernel RX invalid descs:   3",
 		"Direct TX packets:         2",

--- a/userspace-dp/src/afxdp/coordinator/inject.rs
+++ b/userspace-dp/src/afxdp/coordinator/inject.rs
@@ -121,6 +121,7 @@ impl super::Coordinator {
                             egress_ifindex: resolution.egress_ifindex,
                             cos_queue_id: cos.queue_id,
                             dscp_rewrite: cos.dscp_rewrite,
+                            mirror_clone: false,
                         })?;
                     }
                 } else {

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1222,6 +1222,11 @@ impl Coordinator {
                 binding.redirect_inbox_overflow_drops = snap.redirect_inbox_overflow_drops;
                 binding.pending_tx_local_overflow_drops = snap.pending_tx_local_overflow_drops;
                 binding.tx_submit_error_drops = snap.tx_submit_error_drops;
+                binding.mirrored_packets = snap.mirrored_packets;
+                binding.mirrored_bytes = snap.mirrored_bytes;
+                binding.mirror_drops_no_frame = snap.mirror_drops_no_frame;
+                binding.mirror_drops_no_binding = snap.mirror_drops_no_binding;
+                binding.mirror_drops_queue_full = snap.mirror_drops_queue_full;
                 binding.post_drain_backup_bytes = snap.post_drain_backup_bytes;
                 binding.drain_sent_bytes_shaped_unconditional =
                     snap.drain_sent_bytes_shaped_unconditional;
@@ -1370,6 +1375,11 @@ impl Coordinator {
                 binding.tx_completions = 0;
                 binding.tx_errors = 0;
                 binding.tx_shared_recycle_unknown_slot_drops = 0;
+                binding.mirrored_packets = 0;
+                binding.mirrored_bytes = 0;
+                binding.mirror_drops_no_frame = 0;
+                binding.mirror_drops_no_binding = 0;
+                binding.mirror_drops_queue_full = 0;
                 binding.post_drain_backup_bytes = 0;
                 binding.drain_sent_bytes_shaped_unconditional = 0;
                 binding.post_drain_backup_cos_drops = 0;

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -28,6 +28,7 @@ pub struct Coordinator {
     pub(crate) neighbors: NeighborManager,
     pub(in crate::afxdp) sessions: SessionManager,
     pub(in crate::afxdp) workers: WorkerManager,
+    pub(crate) mirror_targets: Arc<ArcSwap<MirrorTargetMap>>,
     pub(crate) forwarding: ForwardingState,
     pub(crate) policy_counters: PolicyCounterStore,
     pub(crate) recent_exceptions: Arc<Mutex<VecDeque<ExceptionStatus>>>,
@@ -65,6 +66,7 @@ impl Coordinator {
             neighbors: NeighborManager::new(),
             sessions: SessionManager::new(),
             workers: WorkerManager::new(),
+            mirror_targets: Arc::new(ArcSwap::from_pointee(MirrorTargetMap::default())),
             forwarding: ForwardingState::default(),
             policy_counters: PolicyCounterStore::default(),
             recent_exceptions: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_RECENT_EXCEPTIONS))),
@@ -205,6 +207,8 @@ impl Coordinator {
             self.bpf_maps.map_fd.as_ref(),
             self.bpf_maps.heartbeat_map_fd.as_ref(),
         );
+        self.mirror_targets
+            .store(Arc::new(MirrorTargetMap::default()));
         // #925 Phase 1: drop the per-worker panic slots alongside the
         // workers themselves so a long-running daemon that reconciles
         // through many worker-id sets doesn't accumulate stale slots.
@@ -617,6 +621,10 @@ impl Coordinator {
             })
             .collect::<BTreeMap<_, _>>();
         let owner_map = build_cos_owner_worker_by_queue(&self.forwarding, &workers);
+        self.mirror_targets.store(Arc::new(build_mirror_target_map(
+            &self.workers.identities,
+            &self.workers.live,
+        )));
         let active_shards_by_egress_ifindex =
             build_cos_active_shards_by_egress_ifindex_with_fallback_ifindexes(
                 &self.forwarding,
@@ -688,6 +696,7 @@ impl Coordinator {
             let shared_cos_exact_backlogs = self.cos.exact_backlogs.clone();
             let shared_cos_queue_leases = self.cos.queue_leases.clone();
             let shared_cos_queue_vtime_floors = self.cos.queue_vtime_floors.clone();
+            let shared_mirror_targets = self.mirror_targets.clone();
             let runtime_atomics =
                 std::sync::Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new());
             let runtime_atomics_clone = runtime_atomics.clone();
@@ -732,6 +741,7 @@ impl Coordinator {
                         shared_cos_exact_backlogs,
                         shared_cos_queue_leases,
                         shared_cos_queue_vtime_floors,
+                        shared_mirror_targets,
                         cos_status_clone,
                         runtime_atomics_clone,
                     );
@@ -1617,6 +1627,20 @@ fn build_worker_binding_ifindexes_from_identities(
         out.entry(ident.worker_id)
             .or_default()
             .insert(ident.ifindex);
+    }
+    out
+}
+
+fn build_mirror_target_map(
+    identities: &BTreeMap<u32, BindingIdentity>,
+    live: &BTreeMap<u32, Arc<BindingLiveState>>,
+) -> MirrorTargetMap {
+    let mut out = MirrorTargetMap::default();
+    for (slot, ident) in identities {
+        let Some(binding_live) = live.get(slot) else {
+            continue;
+        };
+        out.insert(ident, binding_live.clone());
     }
     out
 }

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1238,6 +1238,10 @@ impl Coordinator {
                 binding.mirror_drops_tx_frame_reserve = snap.mirror_drops_tx_frame_reserve;
                 binding.mirror_drops_no_binding = snap.mirror_drops_no_binding;
                 binding.mirror_drops_queue_full = snap.mirror_drops_queue_full;
+                binding.mirror_drops_queue_full_same_worker =
+                    snap.mirror_drops_queue_full_same_worker;
+                binding.mirror_drops_queue_full_cross_worker =
+                    snap.mirror_drops_queue_full_cross_worker;
                 binding.post_drain_backup_bytes = snap.post_drain_backup_bytes;
                 binding.drain_sent_bytes_shaped_unconditional =
                     snap.drain_sent_bytes_shaped_unconditional;
@@ -1392,6 +1396,8 @@ impl Coordinator {
                 binding.mirror_drops_tx_frame_reserve = 0;
                 binding.mirror_drops_no_binding = 0;
                 binding.mirror_drops_queue_full = 0;
+                binding.mirror_drops_queue_full_same_worker = 0;
+                binding.mirror_drops_queue_full_cross_worker = 0;
                 binding.post_drain_backup_bytes = 0;
                 binding.drain_sent_bytes_shaped_unconditional = 0;
                 binding.post_drain_backup_cos_drops = 0;

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -1235,6 +1235,7 @@ impl Coordinator {
                 binding.mirrored_packets = snap.mirrored_packets;
                 binding.mirrored_bytes = snap.mirrored_bytes;
                 binding.mirror_drops_no_frame = snap.mirror_drops_no_frame;
+                binding.mirror_drops_tx_frame_reserve = snap.mirror_drops_tx_frame_reserve;
                 binding.mirror_drops_no_binding = snap.mirror_drops_no_binding;
                 binding.mirror_drops_queue_full = snap.mirror_drops_queue_full;
                 binding.post_drain_backup_bytes = snap.post_drain_backup_bytes;
@@ -1388,6 +1389,7 @@ impl Coordinator {
                 binding.mirrored_packets = 0;
                 binding.mirrored_bytes = 0;
                 binding.mirror_drops_no_frame = 0;
+                binding.mirror_drops_tx_frame_reserve = 0;
                 binding.mirror_drops_no_binding = 0;
                 binding.mirror_drops_queue_full = 0;
                 binding.post_drain_backup_bytes = 0;

--- a/userspace-dp/src/afxdp/cos/admission_tests.rs
+++ b/userspace-dp/src/afxdp/cos/admission_tests.rs
@@ -813,6 +813,7 @@ fn admission_ecn_skips_prepared_when_umem_slice_out_of_range() {
         egress_ifindex: 42,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     });
 
     let marked =

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -9,14 +9,13 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
+use crate::afxdp::FastMap;
 use crate::afxdp::tx::recycle_prepared_immediately_with_shared;
 use crate::afxdp::types::{
-    PreparedTxRequest, TxRequest, WorkerCommand, WorkerCoSInterfaceFastPath,
-    WorkerCoSQueueFastPath,
+    PreparedTxRequest, TxRequest, WorkerCoSInterfaceFastPath, WorkerCoSQueueFastPath, WorkerCommand,
 };
 use crate::afxdp::umem::BindingLiveState;
 use crate::afxdp::worker::BindingWorker;
-use crate::afxdp::FastMap;
 
 /// #780: Step 1 action variants. Mirrors the action taken inside
 /// `redirect_local_cos_request_to_owner` after the bail checks
@@ -209,7 +208,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: false,
+        mirror_clone: req.mirror_clone,
     };
     if redirect_local_cos_request_to_owner(
         &binding.cos.cos_fast_interfaces,
@@ -267,7 +266,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: false,
+        mirror_clone: req.mirror_clone,
     };
     if owner_live.enqueue_tx(local_req).is_ok() {
         recycle_prepared_immediately_with_shared(binding, &req, shared_recycles);

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -140,7 +140,6 @@ pub(in crate::afxdp) fn redirect_local_cos_request_to_owner(
     }
     Err(req)
 }
-
 #[cfg(test)]
 #[inline]
 pub(in crate::afxdp) fn redirect_local_cos_request_to_owner_binding(
@@ -210,6 +209,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
+        mirror_clone: false,
     };
     if redirect_local_cos_request_to_owner(
         &binding.cos.cos_fast_interfaces,
@@ -267,6 +267,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
+        mirror_clone: false,
     };
     if owner_live.enqueue_tx(local_req).is_ok() {
         recycle_prepared_immediately_with_shared(binding, &req, shared_recycles);
@@ -274,7 +275,6 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
     }
     Err(req)
 }
-
 
 #[cfg(test)]
 #[path = "cross_binding_tests.rs"]

--- a/userspace-dp/src/afxdp/cos/cross_binding.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding.rs
@@ -199,17 +199,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner(
     else {
         return Err(req);
     };
-    let local_req = TxRequest {
-        bytes: frame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key.clone(),
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: req.mirror_clone,
-    };
+    let local_req = req.to_local_request(frame);
     if redirect_local_cos_request_to_owner(
         &binding.cos.cos_fast_interfaces,
         local_req,
@@ -257,17 +247,7 @@ pub(in crate::afxdp) fn redirect_prepared_cos_request_to_owner_binding(
     else {
         return Err(req);
     };
-    let local_req = TxRequest {
-        bytes: frame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key.clone(),
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: req.mirror_clone,
-    };
+    let local_req = req.to_local_request(frame);
     if owner_live.enqueue_tx(local_req).is_ok() {
         recycle_prepared_immediately_with_shared(binding, &req, shared_recycles);
         return Ok(());

--- a/userspace-dp/src/afxdp/cos/cross_binding_tests.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding_tests.rs
@@ -4,10 +4,10 @@
 // `#[path = "cross_binding_tests.rs"]` from cross_binding.rs.
 
 use super::*;
+use crate::afxdp::PROTO_TCP;
 use crate::afxdp::cos::token_bucket::COS_MIN_BURST_BYTES;
 use crate::afxdp::tx::test_support::*;
 use crate::afxdp::types::SharedCoSQueueLease;
-use crate::afxdp::PROTO_TCP;
 
 #[test]
 fn redirect_local_cos_request_to_owner_pushes_worker_command() {
@@ -30,6 +30,7 @@ fn redirect_local_cos_request_to_owner_pushes_worker_command() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -68,6 +69,7 @@ fn redirect_local_cos_request_to_owner_uses_interface_default_queue_owner_when_u
         egress_ifindex: 80,
         cos_queue_id: None,
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -99,6 +101,7 @@ fn redirect_local_cos_request_to_owner_rejects_explicit_queue_miss() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -142,6 +145,7 @@ fn redirect_local_cos_request_to_owner_keeps_exact_queue_on_eligible_worker() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -354,6 +358,7 @@ fn redirect_local_cos_request_to_owner_binding_pushes_owner_live_queue() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -445,6 +450,7 @@ fn redirect_local_cos_request_to_owner_uses_owner_live_queue_when_available() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -492,6 +498,7 @@ fn redirect_local_cos_request_to_owner_redirects_low_rate_exact_queue() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =
@@ -542,6 +549,7 @@ fn redirect_local_exact_cos_request_to_owner_binding_pushes_owner_live_queue() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let redirected =

--- a/userspace-dp/src/afxdp/cos/cross_binding_tests.rs
+++ b/userspace-dp/src/afxdp/cos/cross_binding_tests.rs
@@ -7,7 +7,23 @@ use super::*;
 use crate::afxdp::PROTO_TCP;
 use crate::afxdp::cos::token_bucket::COS_MIN_BURST_BYTES;
 use crate::afxdp::tx::test_support::*;
-use crate::afxdp::types::SharedCoSQueueLease;
+use crate::afxdp::types::{PreparedTxRecycle, PreparedTxRequest, SharedCoSQueueLease};
+
+fn test_prepared_mirror_request(offset: u64, len: u32) -> PreparedTxRequest {
+    PreparedTxRequest {
+        offset,
+        len,
+        recycle: PreparedTxRecycle::FreeTxFrame,
+        expected_ports: None,
+        expected_addr_family: libc::AF_INET as u8,
+        expected_protocol: PROTO_TCP,
+        flow_key: None,
+        egress_ifindex: 80,
+        cos_queue_id: Some(4),
+        dscp_rewrite: None,
+        mirror_clone: true,
+    }
+}
 
 #[test]
 fn redirect_local_cos_request_to_owner_pushes_worker_command() {
@@ -563,4 +579,81 @@ fn redirect_local_exact_cos_request_to_owner_binding_pushes_owner_live_queue() {
     let mut current_queued = VecDeque::new();
     current_live.take_pending_tx_into(&mut current_queued);
     assert!(current_queued.is_empty());
+}
+
+#[test]
+fn redirect_prepared_cos_request_to_owner_preserves_mirror_clone_on_worker_command() {
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let worker_commands_by_id = BTreeMap::from([(7, commands.clone())]);
+    let fast_path = test_cos_fast_interfaces(
+        80,
+        12,
+        4,
+        vec![(4, test_queue_fast_path(false, 7, None, None))],
+        None,
+        None,
+    )
+    .remove(&80)
+    .expect("fast path");
+    let root = test_cos_runtime_with_exact(false);
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 2, 80, root, fast_path);
+    unsafe { binding.umem.area().slice_mut_unchecked(128, 3) }
+        .expect("source frame")
+        .copy_from_slice(&[1, 2, 3]);
+
+    let req = test_prepared_mirror_request(128, 3);
+    let redirected =
+        redirect_prepared_cos_request_to_owner(&mut binding, req, 2, &worker_commands_by_id, None);
+
+    assert!(redirected.is_ok());
+    let pending = commands.lock().unwrap();
+    assert_eq!(pending.len(), 1);
+    match pending.front() {
+        Some(WorkerCommand::EnqueueShapedLocal(req)) => {
+            assert!(
+                req.mirror_clone,
+                "mirror identity must survive worker redirect"
+            );
+            assert_eq!(req.bytes, vec![1, 2, 3]);
+            assert_eq!(req.egress_ifindex, 80);
+            assert_eq!(req.cos_queue_id, Some(4));
+        }
+        other => panic!("unexpected command queued: {other:?}"),
+    }
+}
+
+#[test]
+fn redirect_prepared_cos_request_to_owner_binding_preserves_mirror_clone_on_live_queue() {
+    let owner_live = Arc::new(BindingLiveState::new());
+    let fast_path = test_cos_fast_interfaces(
+        80,
+        12,
+        4,
+        vec![(4, test_queue_fast_path(false, 7, None, None))],
+        Some(owner_live.clone()),
+        None,
+    )
+    .remove(&80)
+    .expect("fast path");
+    let root = test_cos_runtime_with_exact(false);
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 2, 80, root, fast_path);
+    unsafe { binding.umem.area().slice_mut_unchecked(128, 3) }
+        .expect("source frame")
+        .copy_from_slice(&[4, 5, 6]);
+
+    let req = test_prepared_mirror_request(128, 3);
+    let redirected = redirect_prepared_cos_request_to_owner_binding(&mut binding, req, None);
+
+    assert!(redirected.is_ok());
+    let mut queued = VecDeque::new();
+    owner_live.take_pending_tx_into(&mut queued);
+    assert_eq!(queued.len(), 1);
+    let req = queued.front().expect("queued local request");
+    assert!(
+        req.mirror_clone,
+        "mirror identity must survive owner-live redirect"
+    );
+    assert_eq!(req.bytes, vec![4, 5, 6]);
+    assert_eq!(req.egress_ifindex, 80);
+    assert_eq!(req.cos_queue_id, Some(4));
 }

--- a/userspace-dp/src/afxdp/cos/ecn_tests.rs
+++ b/userspace-dp/src/afxdp/cos/ecn_tests.rs
@@ -4,8 +4,8 @@
 // `#[path = "ecn_tests.rs"]` from ecn.rs.
 
 use super::*;
-use crate::afxdp::tx::test_support::*;
 use crate::afxdp::PROTO_TCP;
+use crate::afxdp::tx::test_support::*;
 
 #[test]
 fn mark_ecn_ce_ipv4_converts_ect0_to_ce_and_updates_checksum() {
@@ -154,6 +154,7 @@ fn maybe_mark_ecn_ce_dispatches_by_ethertype() {
         egress_ifindex: 1,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert!(maybe_mark_ecn_ce(&mut req));
     assert_eq!(req.bytes[15] & ECN_MASK, ECN_CE);
@@ -170,6 +171,7 @@ fn maybe_mark_ecn_ce_dispatches_by_ethertype() {
         egress_ifindex: 1,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert!(maybe_mark_ecn_ce(&mut req));
     assert_eq!(ipv6_tclass(&req.bytes), ECN_CE);
@@ -188,6 +190,7 @@ fn maybe_mark_ecn_ce_dispatches_by_ethertype() {
         egress_ifindex: 1,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert!(!maybe_mark_ecn_ce(&mut req));
 }
@@ -208,7 +211,7 @@ fn maybe_mark_ecn_ce_handles_single_vlan_tagged_frame() {
     let mut tagged = Vec::with_capacity(base.len() + 4);
     tagged.extend_from_slice(&base[..12]); // dst + src MAC
     tagged.extend_from_slice(&[0x81, 0x00]); // TPID
-                                             // TCI: priority 5 << 13 | DEI 0 | VID 80.
+    // TCI: priority 5 << 13 | DEI 0 | VID 80.
     let tci: u16 = (5 << 13) | 80;
     tagged.extend_from_slice(&tci.to_be_bytes());
     tagged.extend_from_slice(&[0x08, 0x00]); // inner ethertype (IPv4)
@@ -226,6 +229,7 @@ fn maybe_mark_ecn_ce_handles_single_vlan_tagged_frame() {
         egress_ifindex: 1,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert!(
         maybe_mark_ecn_ce(&mut req),
@@ -261,6 +265,7 @@ fn maybe_mark_ecn_ce_rejects_unknown_ethertype() {
         egress_ifindex: 1,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert_eq!(ethernet_l3(&req.bytes), None);
     assert!(!maybe_mark_ecn_ce(&mut req));
@@ -278,7 +283,7 @@ fn ethernet_l3_rejects_qinq_until_explicitly_supported() {
     let base = build_ipv4_test_packet(ECN_ECT_0);
     let mut qinq = Vec::with_capacity(base.len() + 8);
     qinq.extend_from_slice(&base[..12]); // MACs
-                                         // Outer 802.1ad: TPID 0x88A8, TCI with an outer VID 100.
+    // Outer 802.1ad: TPID 0x88A8, TCI with an outer VID 100.
     qinq.extend_from_slice(&[0x88, 0xA8]);
     let outer_tci: u16 = 100;
     qinq.extend_from_slice(&outer_tci.to_be_bytes());
@@ -305,6 +310,7 @@ fn ethernet_l3_rejects_qinq_until_explicitly_supported() {
         egress_ifindex: 1,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     assert!(!maybe_mark_ecn_ce(&mut req));
 }

--- a/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
@@ -61,6 +61,7 @@ fn cos_queue_rejects_prepared_once_local_items_enter_queue() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }),
     );
     cos_queue_push_back(
@@ -142,6 +143,7 @@ fn exact_local_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut free_tx_frames = VecDeque::from([64, 128, 192]);
@@ -233,6 +235,7 @@ fn drain_exact_prepared_items_to_scratch_recycles_dropped_prepared_frame() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut scratch_prepared_tx = Vec::new();
@@ -257,6 +260,9 @@ fn drain_exact_prepared_items_to_scratch_recycles_dropped_prepared_frame() {
             assert_eq!(dropped_bytes, (tx_frame_capacity() + 1) as u64);
         }
         ExactCoSScratchBuild::Ready => panic!("oversized prepared frame must drop"),
+        ExactCoSScratchBuild::MirrorTxFrameReserve { .. } => {
+            panic!("prepared frame must not trip mirror reserve handling")
+        }
     }
     assert!(scratch_prepared_tx.is_empty());
     assert!(free_tx_frames.is_empty());
@@ -304,6 +310,7 @@ fn exact_prepared_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -319,6 +326,7 @@ fn exact_prepared_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot

--- a/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/tests.rs
@@ -74,6 +74,7 @@ fn cos_queue_rejects_prepared_once_local_items_enter_queue() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }),
     );
 
@@ -111,6 +112,7 @@ fn exact_local_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -124,6 +126,7 @@ fn exact_local_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -329,6 +332,7 @@ fn exact_prepared_fifo_boundary_survives_partial_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut scratch_prepared_tx = Vec::new();
@@ -423,6 +427,7 @@ fn cos_queue_push_and_pop_track_flow_bucket_bytes() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let req_b = TxRequest {
         bytes: vec![0; 1500],
@@ -433,6 +438,7 @@ fn cos_queue_push_and_pop_track_flow_bucket_bytes() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let bucket_a = cos_flow_bucket_index(
         test_flow_fair_state(queue).flow_hash_seed,
@@ -949,6 +955,7 @@ fn cos_exact_drain_throughput_micro_bench() {
                     egress_ifindex: 80,
                     cos_queue_id: Some(5),
                     dscp_rewrite: None,
+                    mirror_clone: false,
                 }));
             queue.hot.queued_bytes += packet.len() as u64;
         }
@@ -1147,6 +1154,7 @@ fn bench_pop_commit_settle_publish() {
                 egress_ifindex: 80,
                 cos_queue_id: Some(0),
                 dscp_rewrite: None,
+                mirror_clone: false,
             };
             let _ = req.bytes.len();
             cos_queue_push_back(queue, CoSPendingTxItem::Local(req));

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
@@ -450,6 +450,7 @@ fn vmin_demote_no_drain_all_leak() {
         len: 1500,
         recycle: PreparedTxRecycle::FreeTxFrame,
         dscp_rewrite: None,
+        mirror_clone: false,
         cos_queue_id: Some(0),
         flow_key: None,
         expected_ports: None,

--- a/userspace-dp/src/afxdp/cos/queue_service/drain.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/drain.rs
@@ -29,9 +29,7 @@ fn compute_drain_target_bps(queue: &CoSQueueRuntime) -> u64 {
     // Convert bytes/sec → bits/sec. u128 intermediate avoids overflow
     // at 100+ Gbps configured rates; clamp to u64::MAX before narrowing
     // so extreme configured rates saturate rather than silently wrap.
-    let queue_bw_bps = (rate_bytes as u128)
-        .saturating_mul(8)
-        .min(u64::MAX as u128) as u64;
+    let queue_bw_bps = (rate_bytes as u128).saturating_mul(8).min(u64::MAX as u128) as u64;
     let denom = ff.active_flow_buckets.max(1) as u64;
     queue_bw_bps / denom
 }
@@ -70,6 +68,16 @@ pub(in crate::afxdp) fn drain_exact_local_fifo_items_to_scratch(
             };
             let len = req.bytes.len() as u64;
             if remaining_root < len || remaining_secondary < len {
+                break;
+            }
+            if req.mirror_clone && free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
+                if scratch_local_tx.is_empty() {
+                    let dropped_bytes = match queue.hot.items.remove(index) {
+                        Some(CoSPendingTxItem::Local(req)) => req.bytes.len() as u64,
+                        Some(CoSPendingTxItem::Prepared(_)) | None => len,
+                    };
+                    return ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes };
+                }
                 break;
             }
             if req.bytes.len() > tx_frame_capacity() {
@@ -206,6 +214,20 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
             CoSPendingTxItem::Prepared(_) => break,
         };
         if remaining_root < len || remaining_secondary < len {
+            break;
+        }
+        if matches!(front, CoSPendingTxItem::Local(req) if req.mirror_clone)
+            && free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE
+        {
+            if scratch_local_tx.is_empty() {
+                let Some(CoSPendingTxItem::Local(_req)) =
+                    cos_queue_pop_front_with_cap(queue, target_bps)
+                else {
+                    break;
+                };
+                cos_queue_clear_orphan_snapshot_after_drop(queue);
+                return ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes: len };
+            }
             break;
         }
         let Some(CoSPendingTxItem::Local(mut req)) =

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -16,6 +16,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
 
 use crate::afxdp::frame::{apply_dscp_rewrite_to_frame, frame_has_tcp_rst};
+use crate::afxdp::mirror::MIRROR_TX_FRAME_RESERVE;
 use crate::afxdp::neighbor::monotonic_nanos;
 use crate::afxdp::types::{
     COS_PRIORITY_LEVELS, CoSInterfaceRuntime, CoSPendingTxItem, CoSQueueRuntime,
@@ -99,6 +100,7 @@ pub(in crate::afxdp) struct ExactCoSQueueSelection {
 pub(in crate::afxdp) enum ExactCoSScratchBuild {
     Ready,
     Drop { error: String, dropped_bytes: u64 },
+    MirrorTxFrameReserve { dropped_bytes: u64 },
 }
 
 /// #751: one drain pass through the binding's CoS interfaces. Returns

--- a/userspace-dp/src/afxdp/cos/queue_service/service.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/service.rs
@@ -90,6 +90,18 @@ pub(super) fn service_exact_local_queue_direct(
             binding.live.set_error(error);
             return false;
         }
+        ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes } => {
+            if dropped_bytes > 0 {
+                subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
+            } else {
+                refresh_cos_interface_activity(binding, root_ifindex);
+            }
+            binding
+                .live
+                .mirror_drops_tx_frame_reserve
+                .fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
     }
     if binding.scratch.scratch_exact_local_tx.is_empty() {
         maybe_wake_tx(binding, true, now_ns);
@@ -250,6 +262,18 @@ fn service_exact_local_queue_direct_flow_fair(
                 .tx_submit_error_drops
                 .fetch_add(1, Ordering::Relaxed);
             binding.live.set_error(error);
+            return false;
+        }
+        ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes } => {
+            if dropped_bytes > 0 {
+                subtract_direct_cos_queue_bytes(binding, root_ifindex, queue_idx, dropped_bytes);
+            } else {
+                refresh_cos_interface_activity(binding, root_ifindex);
+            }
+            binding
+                .live
+                .mirror_drops_tx_frame_reserve
+                .fetch_add(1, Ordering::Relaxed);
             return false;
         }
     }
@@ -423,6 +447,9 @@ pub(super) fn service_exact_prepared_queue_direct(
             binding.live.set_error(error);
             return false;
         }
+        ExactCoSScratchBuild::MirrorTxFrameReserve { .. } => {
+            unreachable!("prepared CoS queues do not drain local mirror clones")
+        }
     }
     if binding.scratch.scratch_exact_prepared_tx.is_empty() {
         return false;
@@ -585,6 +612,9 @@ fn service_exact_prepared_queue_direct_flow_fair(
                 .fetch_add(1, Ordering::Relaxed);
             binding.live.set_error(error);
             return false;
+        }
+        ExactCoSScratchBuild::MirrorTxFrameReserve { .. } => {
+            unreachable!("prepared CoS queues do not drain local mirror clones")
         }
     }
     if binding.scratch.scratch_prepared_tx.is_empty() {

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -5,7 +5,6 @@
 
 use super::*;
 use crate::afxdp::FastMap;
-use crate::afxdp::PROTO_TCP;
 use crate::afxdp::cos::admission::apply_cos_queue_flow_fair_promotion;
 use crate::afxdp::cos::queue_ops::cos_queue_push_back;
 use crate::afxdp::cos::tx_completion::COS_TIMER_WHEEL_TICK_NS;
@@ -15,6 +14,7 @@ use crate::afxdp::types::{
     WorkerCoSInterfaceFastPath,
 };
 use crate::afxdp::worker::BindingWorker;
+use crate::afxdp::{PROTO_TCP, UMEM_FRAME_SHIFT};
 use std::sync::Arc;
 
 const TEST_EPOCH_DURATION_NS: u64 = 200_000;
@@ -1460,6 +1460,7 @@ fn drain_exact_local_fifo_items_to_scratch_keeps_queue_until_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut free_tx_frames = VecDeque::from([64, 128, 192]);
@@ -1488,6 +1489,64 @@ fn drain_exact_local_fifo_items_to_scratch_keeps_queue_until_commit() {
         root.queues[0].hot.items.get(2),
         Some(CoSPendingTxItem::Prepared(_))
     ));
+}
+
+#[test]
+fn drain_exact_local_fifo_drops_mirror_clone_before_tx_reserve() {
+    let area = MmapArea::new(4096).expect("mmap");
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 5,
+            forwarding_class: "mirror".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+        }],
+    );
+    cos_queue_push_back(
+        &mut root.queues[0],
+        CoSPendingTxItem::Local(TxRequest {
+            bytes: vec![1, 2, 3, 4],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 80,
+            cos_queue_id: Some(5),
+            dscp_rewrite: None,
+            mirror_clone: true,
+        }),
+    );
+    let mut free_tx_frames = (0..MIRROR_TX_FRAME_RESERVE as u64)
+        .map(|idx| idx << UMEM_FRAME_SHIFT)
+        .collect::<VecDeque<_>>();
+    let original_free = free_tx_frames.clone();
+    let mut scratch_local_tx = Vec::new();
+
+    let build = drain_exact_local_fifo_items_to_scratch(
+        &mut root.queues[0],
+        &mut free_tx_frames,
+        &mut scratch_local_tx,
+        &area,
+        u64::MAX,
+        u64::MAX,
+        None,
+    );
+
+    assert!(matches!(
+        build,
+        ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes: 4 }
+    ));
+    assert!(scratch_local_tx.is_empty());
+    assert_eq!(free_tx_frames, original_free);
+    assert!(root.queues[0].hot.items.is_empty());
 }
 
 #[test]
@@ -1703,6 +1762,7 @@ fn release_exact_prepared_scratch_preserves_queue_after_failed_submit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     let frame = unsafe { area.slice_mut_unchecked(64, 4) }.expect("frame");
     frame.copy_from_slice(&[1, 2, 3, 4]);
@@ -1765,6 +1825,7 @@ fn settle_exact_prepared_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1780,6 +1841,7 @@ fn settle_exact_prepared_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1795,6 +1857,7 @@ fn settle_exact_prepared_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     let mut scratch_prepared_tx = vec![
         ExactPreparedScratchTxRequest { offset: 64, len: 1 },
@@ -2040,6 +2103,7 @@ fn restore_cos_prepared_items_marks_queue_runnable_after_retry() {
         egress_ifindex: 80,
         cos_queue_id: Some(5),
         dscp_rewrite: None,
+        mirror_clone: false,
     }]);
 
     let retry_bytes = restore_cos_prepared_items_inner(&mut queue, retry);

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -1430,6 +1430,7 @@ fn drain_exact_local_fifo_items_to_scratch_keeps_queue_until_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1443,6 +1444,7 @@ fn drain_exact_local_fifo_items_to_scratch_keeps_queue_until_commit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1519,6 +1521,7 @@ fn release_exact_local_scratch_frames_preserves_queue_after_failed_submit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1532,6 +1535,7 @@ fn release_exact_local_scratch_frames_preserves_queue_after_failed_submit() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     let mut free_tx_frames = VecDeque::from([64, 128]);
     let mut scratch_local_tx = Vec::new();
@@ -1591,6 +1595,7 @@ fn settle_exact_local_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1604,6 +1609,7 @@ fn settle_exact_local_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -1617,6 +1623,7 @@ fn settle_exact_local_fifo_submission_pops_only_committed_prefix() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     let mut free_tx_frames = VecDeque::new();
     let mut scratch_local_tx = vec![
@@ -1851,6 +1858,7 @@ fn assign_local_dscp_rewrite_preserves_existing_filter_rewrite() {
             egress_ifindex: 42,
             cos_queue_id: Some(0),
             dscp_rewrite: None,
+            mirror_clone: false,
         },
         TxRequest {
             bytes: vec![0; 64],
@@ -1861,6 +1869,7 @@ fn assign_local_dscp_rewrite_preserves_existing_filter_rewrite() {
             egress_ifindex: 42,
             cos_queue_id: Some(0),
             dscp_rewrite: Some(0),
+            mirror_clone: false,
         },
     ]);
 
@@ -1964,6 +1973,7 @@ fn restore_cos_local_items_marks_queue_runnable_after_retry() {
         egress_ifindex: 80,
         cos_queue_id: Some(5),
         dscp_rewrite: None,
+        mirror_clone: false,
     }]);
 
     let retry_bytes = restore_cos_local_items_inner(&mut queue, retry);

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -423,6 +423,18 @@ pub(super) fn build_forwarding_state_with_policy_counters(
             }
         })
     });
+    for mirror in &snapshot.mirror_configs {
+        if mirror.ingress_ifindex <= 0 || mirror.output_ifindex <= 0 {
+            continue;
+        }
+        state.mirror_configs.insert(
+            mirror.ingress_ifindex,
+            MirrorRuntimeConfig {
+                output_ifindex: mirror.output_ifindex,
+                rate: mirror.rate,
+            },
+        );
+    }
 
     // Add static NAT external IPs as local delivery targets so inbound
     // traffic destined to external IPs is recognized by the firewall.

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -69,7 +69,8 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
     flow_key: Option<&SessionKey>,
 ) -> MirrorCloneResult {
     let mirror_tx_ifindex = resolve_tx_binding_ifindex(forwarding, config.output_ifindex);
-    let target_binding_index = binding_lookup.target_index(
+    let target_binding_index = mirror_target_binding_index(
+        binding_lookup,
         ingress_index,
         ingress_binding.ifindex,
         ingress_queue_id,
@@ -139,6 +140,26 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
     MirrorCloneResult::Enqueued
 }
 
+fn mirror_target_binding_index(
+    binding_lookup: &WorkerBindingLookup,
+    ingress_index: usize,
+    ingress_ifindex: i32,
+    ingress_queue_id: u32,
+    mirror_tx_ifindex: i32,
+) -> Option<usize> {
+    if ingress_ifindex == mirror_tx_ifindex {
+        return Some(ingress_index);
+    }
+    binding_lookup
+        .by_if_queue
+        .get(&(mirror_tx_ifindex, ingress_queue_id))
+        .copied()
+        .or_else(|| {
+            let indices = binding_lookup.all_by_if.get(&mirror_tx_ifindex)?;
+            (indices.len() == 1).then_some(indices[0])
+        })
+}
+
 pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     mirror_targets: &MirrorTargetMap,
     config: MirrorRuntimeConfig,
@@ -149,15 +170,57 @@ pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     flow_key: Option<&SessionKey>,
     cos_queue_id: Option<u8>,
 ) -> MirrorCloneResult {
-    if frame.len() > tx_frame_capacity() {
-        return MirrorCloneResult::NoFrame;
+    let target_live = match admit_mirror_clone_to_live(
+        mirror_targets,
+        mirror_tx_ifindex,
+        ingress_queue_id,
+        frame.len(),
+    ) {
+        Ok(target_live) => target_live,
+        Err(result) => return result,
+    };
+    enqueue_admitted_mirror_clone_to_live(
+        &target_live,
+        config,
+        frame.to_vec(),
+        meta,
+        flow_key,
+        cos_queue_id,
+    )
+}
+
+pub(in crate::afxdp) fn admit_mirror_clone_to_live(
+    mirror_targets: &MirrorTargetMap,
+    mirror_tx_ifindex: i32,
+    ingress_queue_id: u32,
+    frame_len: usize,
+) -> Result<Arc<BindingLiveState>, MirrorCloneResult> {
+    if frame_len > tx_frame_capacity() {
+        return Err(MirrorCloneResult::NoFrame);
     }
     let Some(target_live) = mirror_targets.target_live(mirror_tx_ifindex, ingress_queue_id)
     else {
-        return MirrorCloneResult::NoBinding;
+        return Err(MirrorCloneResult::NoBinding);
     };
+    if target_live.try_admit_tx_owned().is_err() {
+        return Err(MirrorCloneResult::QueueFull);
+    }
+    Ok(target_live)
+}
+
+pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
+    target_live: &BindingLiveState,
+    config: MirrorRuntimeConfig,
+    frame: Vec<u8>,
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+    cos_queue_id: Option<u8>,
+) -> MirrorCloneResult {
+    if frame.len() > tx_frame_capacity() {
+        return MirrorCloneResult::NoFrame;
+    }
     let req = TxRequest {
-        bytes: frame.to_vec(),
+        bytes: frame,
         expected_ports: None,
         expected_addr_family: meta.addr_family,
         expected_protocol: meta.protocol,
@@ -172,6 +235,7 @@ pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
         .unwrap_or(MirrorCloneResult::QueueFull)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn enqueue_sampled_mirror_clone_to_live(
     live: &BindingLiveState,
     mirror_targets: &MirrorTargetMap,
@@ -238,6 +302,7 @@ pub(in crate::afxdp) fn record_mirror_clone_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::MirrorConfigSnapshot;
 
     fn test_meta() -> ForwardPacketMeta {
         ForwardPacketMeta {
@@ -412,7 +477,6 @@ mod tests {
                 output_ifindex: 22,
                 rate: 0,
             },
-            22,
             3,
             &frame,
             test_meta(),
@@ -425,6 +489,132 @@ mod tests {
         let req = queued.pop_front().expect("cross-worker mirror tx");
         assert_eq!(req.bytes, frame);
         assert_eq!(req.egress_ifindex, 22);
+    }
+
+    #[test]
+    fn cross_binding_mirror_requires_exact_queue_when_output_is_multiqueue() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 3),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+            BindingWorker::new_for_mirror_test(2, 0, 22, 1),
+        ];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let mirror_targets = MirrorTargetMap::default();
+        let (left, rest) = bindings.split_at_mut(0);
+        let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+
+        let result = enqueue_mirror_clone(
+            left,
+            0,
+            ingress,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            3,
+            &[0x5a; 64],
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::NoBinding);
+        assert!(bindings[1].tx_pipeline.pending_tx_prepared.is_empty());
+        assert!(bindings[2].tx_pipeline.pending_tx_prepared.is_empty());
+    }
+
+    #[test]
+    fn live_mirror_requires_exact_queue_when_output_is_multiqueue() {
+        let target_q0 = Arc::new(BindingLiveState::new());
+        let target_q1 = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        for (queue_id, live) in [(0, target_q0.clone()), (1, target_q1.clone())] {
+            mirror_targets.insert(
+                &BindingIdentity {
+                    slot: queue_id + 10,
+                    queue_id,
+                    worker_id: 1,
+                    interface: Arc::<str>::from("mirror-out"),
+                    ifindex: 22,
+                },
+                live,
+            );
+        }
+
+        let result = enqueue_mirror_clone_to_live(
+            &mirror_targets,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            22,
+            3,
+            &[0x6b; 64],
+            test_meta(),
+            None,
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::NoBinding);
+        let mut queued = VecDeque::new();
+        target_q0.take_pending_tx_into(&mut queued);
+        target_q1.take_pending_tx_into(&mut queued);
+        assert!(queued.is_empty());
+    }
+
+    #[test]
+    fn live_mirror_queue_full_drops_before_enqueue() {
+        let target_live = Arc::new(BindingLiveState::new());
+        target_live.set_max_pending_tx(1);
+        assert!(
+            target_live
+                .try_enqueue_tx_owned(TxRequest {
+                    bytes: vec![0x11; 64],
+                    expected_ports: None,
+                    expected_addr_family: libc::AF_INET as u8,
+                    expected_protocol: PROTO_TCP,
+                    flow_key: None,
+                    egress_ifindex: 22,
+                    cos_queue_id: None,
+                    dscp_rewrite: None,
+                })
+                .is_ok()
+        );
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+
+        let result = enqueue_mirror_clone_to_live(
+            &mirror_targets,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            22,
+            0,
+            &[0x22; 64],
+            test_meta(),
+            None,
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::QueueFull);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued.pop_front().expect("original request").bytes, vec![0x11; 64]);
     }
 
     #[test]
@@ -459,7 +649,6 @@ mod tests {
                 output_ifindex: 22,
                 rate: 0,
             },
-            22,
             0,
             &[0xdd; 64],
             test_meta(),
@@ -522,6 +711,52 @@ mod tests {
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.pop_front().expect("mirror tx").bytes, frame);
+    }
+
+    #[test]
+    fn sampled_live_mirror_sampler_denial_does_not_enqueue() {
+        let ingress_live = BindingLiveState::new();
+        let target_live = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let mut forwarding = ForwardingState::default();
+        forwarding.mirror_configs.insert(
+            11,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 4,
+            },
+        );
+        let mut sample_counter = 1;
+
+        let result = enqueue_sampled_mirror_clone_to_live(
+            &ingress_live,
+            &mirror_targets,
+            &forwarding,
+            11,
+            0,
+            0,
+            &mut sample_counter,
+            &[0x44; 80],
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, None);
+        assert_eq!(sample_counter, 2);
+        assert_eq!(ingress_live.mirrored_packets.load(Ordering::Relaxed), 0);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert!(queued.is_empty());
     }
 
     #[test]
@@ -610,6 +845,7 @@ mod tests {
                     ifindex: 22,
                     parent_ifindex: 0,
                     vlan_id: 0,
+                    hardware_addr: "02:00:00:00:00:16".to_string(),
                     ..InterfaceSnapshot::default()
                 },
                 InterfaceSnapshot {

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -15,10 +15,28 @@ pub(in crate::afxdp) enum MirrorCloneResult {
 pub(in crate::afxdp) fn select_mirror_config(
     forwarding: &ForwardingState,
     ingress_ifindex: i32,
+    ingress_vlan_id: u16,
     sample_counter: &mut u64,
 ) -> Option<MirrorRuntimeConfig> {
-    let config = forwarding.mirror_configs.get(&ingress_ifindex).copied()?;
+    let config = resolve_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id)?;
     mirror_sample_allows(config.rate, sample_counter).then_some(config)
+}
+
+#[inline]
+pub(in crate::afxdp) fn resolve_mirror_config(
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    ingress_vlan_id: u16,
+) -> Option<MirrorRuntimeConfig> {
+    let logical_ifindex =
+        resolve_ingress_logical_ifindex(forwarding, ingress_ifindex, ingress_vlan_id)
+            .filter(|ifindex| *ifindex > 0)
+            .unwrap_or(ingress_ifindex);
+    forwarding
+        .mirror_configs
+        .get(&logical_ifindex)
+        .or_else(|| forwarding.mirror_configs.get(&ingress_ifindex))
+        .copied()
 }
 
 #[inline]
@@ -42,11 +60,13 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
     ingress_binding: &mut BindingWorker,
     right: &mut [BindingWorker],
     binding_lookup: &WorkerBindingLookup,
+    mirror_targets: &MirrorTargetMap,
+    forwarding: &ForwardingState,
     config: MirrorRuntimeConfig,
     ingress_queue_id: u32,
     frame: &[u8],
-    expected_addr_family: u8,
-    expected_protocol: u8,
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
 ) -> MirrorCloneResult {
     let target_binding_index = binding_lookup.target_index(
         ingress_index,
@@ -54,10 +74,19 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
         ingress_queue_id,
         config.output_ifindex,
     );
+    let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
     let Some(target_binding) = target_binding_index
         .and_then(|idx| binding_by_index_mut(left, ingress_index, ingress_binding, right, idx))
     else {
-        return MirrorCloneResult::NoBinding;
+        return enqueue_mirror_clone_to_live(
+            mirror_targets,
+            config,
+            ingress_queue_id,
+            frame,
+            meta,
+            flow_key,
+            cos_queue_id,
+        );
     };
 
     if frame.len() > tx_frame_capacity() {
@@ -98,14 +127,84 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
             len: frame.len() as u32,
             recycle: PreparedTxRecycle::FreeTxFrame,
             expected_ports: None,
-            expected_addr_family,
-            expected_protocol,
-            flow_key: None,
+            expected_addr_family: meta.addr_family,
+            expected_protocol: meta.protocol,
+            flow_key: flow_key.cloned(),
             egress_ifindex: config.output_ifindex,
-            cos_queue_id: None,
+            cos_queue_id,
             dscp_rewrite: None,
         });
     MirrorCloneResult::Enqueued
+}
+
+pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
+    mirror_targets: &MirrorTargetMap,
+    config: MirrorRuntimeConfig,
+    ingress_queue_id: u32,
+    frame: &[u8],
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+    cos_queue_id: Option<u8>,
+) -> MirrorCloneResult {
+    if frame.len() > tx_frame_capacity() {
+        return MirrorCloneResult::NoFrame;
+    }
+    let Some(target_live) = mirror_targets.target_live(config.output_ifindex, ingress_queue_id)
+    else {
+        return MirrorCloneResult::NoBinding;
+    };
+    let req = TxRequest {
+        bytes: frame.to_vec(),
+        expected_ports: None,
+        expected_addr_family: meta.addr_family,
+        expected_protocol: meta.protocol,
+        flow_key: flow_key.cloned(),
+        egress_ifindex: config.output_ifindex,
+        cos_queue_id,
+        dscp_rewrite: None,
+    };
+    target_live
+        .try_enqueue_tx_owned(req)
+        .map(|_| MirrorCloneResult::Enqueued)
+        .unwrap_or(MirrorCloneResult::QueueFull)
+}
+
+pub(in crate::afxdp) fn enqueue_sampled_mirror_clone_to_live(
+    live: &BindingLiveState,
+    mirror_targets: &MirrorTargetMap,
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    ingress_vlan_id: u16,
+    ingress_queue_id: u32,
+    sample_counter: &mut u64,
+    frame: &[u8],
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+) -> Option<MirrorCloneResult> {
+    let config =
+        select_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id, sample_counter)?;
+    let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
+    let result = enqueue_mirror_clone_to_live(
+        mirror_targets,
+        config,
+        ingress_queue_id,
+        frame,
+        meta,
+        flow_key,
+        cos_queue_id,
+    );
+    record_mirror_clone_result(live, result, frame.len());
+    Some(result)
+}
+
+#[inline]
+pub(in crate::afxdp) fn mirror_cos_queue_id(
+    forwarding: &ForwardingState,
+    output_ifindex: i32,
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+) -> Option<u8> {
+    resolve_cached_cos_tx_selection(forwarding, output_ifindex, meta.into(), flow_key).queue_id
 }
 
 #[inline]
@@ -136,6 +235,28 @@ pub(in crate::afxdp) fn record_mirror_clone_result(
 mod tests {
     use super::*;
 
+    fn test_meta() -> ForwardPacketMeta {
+        ForwardPacketMeta {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            ..ForwardPacketMeta::default()
+        }
+    }
+
+    fn test_cos_interface(default_queue: u8) -> CoSInterfaceConfig {
+        CoSInterfaceConfig {
+            shaping_rate_bytes: 1_250_000,
+            burst_bytes: 64 * 1024,
+            default_queue,
+            dscp_classifier: String::new(),
+            ieee8021_classifier: String::new(),
+            dscp_queue_by_dscp: [u8::MAX; 64],
+            ieee8021_queue_by_pcp: [u8::MAX; 8],
+            queue_by_forwarding_class: FastMap::default(),
+            queues: Vec::new(),
+        }
+    }
+
     #[test]
     fn sampling_rate_correctness() {
         let mut counter = 0;
@@ -162,12 +283,58 @@ mod tests {
     }
 
     #[test]
+    fn select_mirror_config_prefers_vlan_logical_ifindex() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.ingress_logical_ifindex.insert((6, 80), 20080);
+        forwarding.mirror_configs.insert(
+            20080,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+        );
+        let mut counter = 0;
+
+        assert_eq!(
+            select_mirror_config(&forwarding, 6, 80, &mut counter),
+            Some(MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0
+            })
+        );
+    }
+
+    #[test]
+    fn select_mirror_config_falls_back_to_parent_ifindex() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.ingress_logical_ifindex.insert((6, 80), 20080);
+        forwarding.mirror_configs.insert(
+            6,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+        );
+        let mut counter = 0;
+
+        assert_eq!(
+            select_mirror_config(&forwarding, 6, 80, &mut counter),
+            Some(MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0
+            })
+        );
+    }
+
+    #[test]
     fn cross_binding_inject_preserves_full_frame() {
         let mut bindings = vec![
             BindingWorker::new_for_mirror_test(0, 0, 11, 0),
             BindingWorker::new_for_mirror_test(1, 0, 22, 0),
         ];
         let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let mirror_targets = MirrorTargetMap::default();
         let (left, rest) = bindings.split_at_mut(0);
         let (ingress, right) = rest.split_first_mut().expect("ingress binding");
         let frame: Vec<u8> = (0..96).map(|v| v as u8).collect();
@@ -178,14 +345,16 @@ mod tests {
             ingress,
             right,
             &lookup,
+            &mirror_targets,
+            &forwarding,
             MirrorRuntimeConfig {
                 output_ifindex: 22,
                 rate: 0,
             },
             0,
             &frame,
-            libc::AF_INET as u8,
-            6,
+            test_meta(),
+            None,
         );
         assert_eq!(result, MirrorCloneResult::Enqueued);
         let target = &bindings[1];
@@ -208,24 +377,170 @@ mod tests {
     }
 
     #[test]
+    fn cross_worker_live_enqueue_preserves_full_frame() {
+        let mut ingress = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
+        let bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let target_live = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 3,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let frame: Vec<u8> = (0..96).map(|v| 255u8.wrapping_sub(v as u8)).collect();
+
+        let result = enqueue_mirror_clone(
+            &mut [],
+            0,
+            &mut ingress,
+            &mut [],
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            3,
+            &frame,
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::Enqueued);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        let req = queued.pop_front().expect("cross-worker mirror tx");
+        assert_eq!(req.bytes, frame);
+        assert_eq!(req.egress_ifindex, 22);
+    }
+
+    #[test]
+    fn mirror_live_enqueue_uses_output_cos_default_queue_without_rewrite() {
+        let mut ingress = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
+        let bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mut forwarding = ForwardingState::default();
+        forwarding.cos.interfaces.insert(22, test_cos_interface(7));
+        let target_live = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+
+        let result = enqueue_mirror_clone(
+            &mut [],
+            0,
+            &mut ingress,
+            &mut [],
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            0,
+            &[0xdd; 64],
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::Enqueued);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        let req = queued.pop_front().expect("mirror tx");
+        assert_eq!(req.cos_queue_id, Some(7));
+        assert_eq!(req.dscp_rewrite, None);
+    }
+
+    #[test]
+    fn sampled_live_mirror_enqueue_records_flow_cache_surface() {
+        let ingress_live = BindingLiveState::new();
+        let target_live = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let mut forwarding = ForwardingState::default();
+        forwarding.mirror_configs.insert(
+            11,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+        );
+        let mut sample_counter = 0;
+        let frame = vec![0x44; 80];
+
+        let result = enqueue_sampled_mirror_clone_to_live(
+            &ingress_live,
+            &mirror_targets,
+            &forwarding,
+            11,
+            0,
+            0,
+            &mut sample_counter,
+            &frame,
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, Some(MirrorCloneResult::Enqueued));
+        assert_eq!(ingress_live.mirrored_packets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            ingress_live.mirrored_bytes.load(Ordering::Relaxed),
+            frame.len() as u64
+        );
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert_eq!(queued.pop_front().expect("mirror tx").bytes, frame);
+    }
+
+    #[test]
     fn missing_destination_binding_drop_counter() {
         let mut binding = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
         let bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
         let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let mirror_targets = MirrorTargetMap::default();
         let result = enqueue_mirror_clone(
             &mut [],
             0,
             &mut binding,
             &mut [],
             &lookup,
+            &mirror_targets,
+            &forwarding,
             MirrorRuntimeConfig {
                 output_ifindex: 99,
                 rate: 0,
             },
             0,
             &[0xaa; 64],
-            0,
-            0,
+            test_meta(),
+            None,
         );
         record_mirror_clone_result(&binding.live, result, 64);
         assert_eq!(result, MirrorCloneResult::NoBinding);
@@ -242,6 +557,8 @@ mod tests {
             BindingWorker::new_for_mirror_test(1, 0, 22, 0),
         ];
         let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let mirror_targets = MirrorTargetMap::default();
         bindings[1]
             .tx_pipeline
             .free_tx_frames
@@ -254,14 +571,16 @@ mod tests {
             ingress,
             right,
             &lookup,
+            &mirror_targets,
+            &forwarding,
             MirrorRuntimeConfig {
                 output_ifindex: 22,
                 rate: 0,
             },
             0,
             &[0xbb; 64],
-            0,
-            0,
+            test_meta(),
+            None,
         );
         record_mirror_clone_result(&ingress.live, result, 64);
         assert_eq!(result, MirrorCloneResult::NoFrame);
@@ -295,6 +614,8 @@ mod tests {
                 });
         }
         let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let forwarding = ForwardingState::default();
+        let mirror_targets = MirrorTargetMap::default();
         let (left, rest) = bindings.split_at_mut(0);
         let (ingress, right) = rest.split_first_mut().expect("ingress binding");
         let result = enqueue_mirror_clone(
@@ -303,14 +624,16 @@ mod tests {
             ingress,
             right,
             &lookup,
+            &mirror_targets,
+            &forwarding,
             MirrorRuntimeConfig {
                 output_ifindex: 22,
                 rate: 0,
             },
             0,
             &[0xcc; 64],
-            0,
-            0,
+            test_meta(),
+            None,
         );
         record_mirror_clone_result(&ingress.live, result, 64);
         assert_eq!(result, MirrorCloneResult::QueueFull);

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -202,7 +202,10 @@ pub(in crate::afxdp) fn admit_mirror_clone_to_live(
     else {
         return Err(MirrorCloneResult::NoBinding);
     };
-    if target_live.try_admit_tx_owned().is_err() {
+    if target_live
+        .try_admit_mirror_tx_owned(MIRROR_PENDING_LIMIT)
+        .is_err()
+    {
         return Err(MirrorCloneResult::QueueFull);
     }
     Ok(target_live)
@@ -615,6 +618,58 @@ mod tests {
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.pop_front().expect("original request").bytes, vec![0x11; 64]);
+    }
+
+    #[test]
+    fn live_mirror_queue_full_reserves_headroom_above_mirror_limit() {
+        let target_live = Arc::new(BindingLiveState::new());
+        target_live.set_max_pending_tx((MIRROR_PENDING_LIMIT * 2) as u32);
+        for _ in 0..MIRROR_PENDING_LIMIT {
+            assert!(
+                target_live
+                    .try_enqueue_tx_owned(TxRequest {
+                        bytes: vec![0x11; 64],
+                        expected_ports: None,
+                        expected_addr_family: libc::AF_INET as u8,
+                        expected_protocol: PROTO_TCP,
+                        flow_key: None,
+                        egress_ifindex: 22,
+                        cos_queue_id: None,
+                        dscp_rewrite: None,
+                    })
+                    .is_ok()
+            );
+        }
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+
+        let result = enqueue_mirror_clone_to_live(
+            &mirror_targets,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            22,
+            0,
+            &[0x22; 64],
+            test_meta(),
+            None,
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::QueueFull);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert_eq!(queued.len(), MIRROR_PENDING_LIMIT);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -9,7 +9,8 @@ pub(in crate::afxdp) enum MirrorCloneResult {
     NoBinding,
     NoFrame,
     TxFrameReserve,
-    QueueFull,
+    QueueFullSameWorker,
+    QueueFullCrossWorker,
 }
 
 #[inline]
@@ -185,7 +186,7 @@ fn enqueue_mirror_clone_to_binding(
         .len()
         .saturating_add(target_binding.tx_pipeline.pending_tx_local.len());
     if pending_mirror_pressure >= MIRROR_PENDING_LIMIT {
-        return MirrorCloneResult::QueueFull;
+        return MirrorCloneResult::QueueFullSameWorker;
     }
     if target_binding.tx_pipeline.free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
         return MirrorCloneResult::TxFrameReserve;
@@ -220,6 +221,7 @@ fn enqueue_mirror_clone_to_binding(
             egress_ifindex: config.output_ifindex,
             cos_queue_id,
             dscp_rewrite: None,
+            mirror_clone: true,
         });
     MirrorCloneResult::Enqueued
 }
@@ -287,7 +289,7 @@ pub(in crate::afxdp) fn admit_mirror_clone_to_live(
         return Err(MirrorCloneResult::NoBinding);
     };
     BindingLiveState::try_reserve_mirror_tx_owned(&target_live, MIRROR_PENDING_LIMIT)
-        .map_err(|_| MirrorCloneResult::QueueFull)
+        .map_err(|_| MirrorCloneResult::QueueFullCrossWorker)
 }
 
 pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
@@ -315,7 +317,7 @@ pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
     admission
         .enqueue_owned(req)
         .map(|_| MirrorCloneResult::Enqueued)
-        .unwrap_or(MirrorCloneResult::QueueFull)
+        .unwrap_or(MirrorCloneResult::QueueFullCrossWorker)
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -392,8 +394,15 @@ pub(in crate::afxdp) fn record_mirror_clone_result(
             live.mirror_drops_tx_frame_reserve
                 .fetch_add(1, Ordering::Relaxed);
         }
-        MirrorCloneResult::QueueFull => {
+        MirrorCloneResult::QueueFullSameWorker => {
             live.mirror_drops_queue_full.fetch_add(1, Ordering::Relaxed);
+            live.mirror_drops_queue_full_same_worker
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        MirrorCloneResult::QueueFullCrossWorker => {
+            live.mirror_drops_queue_full.fetch_add(1, Ordering::Relaxed);
+            live.mirror_drops_queue_full_cross_worker
+                .fetch_add(1, Ordering::Relaxed);
         }
     }
 }
@@ -714,7 +723,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(result, MirrorCloneResult::QueueFull);
+        assert_eq!(result, MirrorCloneResult::QueueFullCrossWorker);
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
@@ -809,7 +818,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(result, MirrorCloneResult::QueueFull);
+        assert_eq!(result, MirrorCloneResult::QueueFullCrossWorker);
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), MIRROR_PENDING_LIMIT);
@@ -1001,13 +1010,19 @@ mod tests {
             None,
         );
 
-        assert_eq!(result, Some(MirrorCloneResult::QueueFull));
+        assert_eq!(result, Some(MirrorCloneResult::QueueFullCrossWorker));
         assert_eq!(
             sample_counter, 0,
             "full live target must fail before consuming a mirror sample"
         );
         assert_eq!(
             ingress_live.mirror_drops_queue_full.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ingress_live
+                .mirror_drops_queue_full_cross_worker
+                .load(Ordering::Relaxed),
             1
         );
         assert_eq!(
@@ -1293,6 +1308,7 @@ mod tests {
                     egress_ifindex: 22,
                     cos_queue_id: None,
                     dscp_rewrite: None,
+                    mirror_clone: true,
                 });
         }
         let lookup = WorkerBindingLookup::from_bindings(&bindings);
@@ -1318,9 +1334,16 @@ mod tests {
             None,
         );
         record_mirror_clone_result(&ingress.live, result, 64);
-        assert_eq!(result, MirrorCloneResult::QueueFull);
+        assert_eq!(result, MirrorCloneResult::QueueFullSameWorker);
         assert_eq!(
             ingress.live.mirror_drops_queue_full.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ingress
+                .live
+                .mirror_drops_queue_full_same_worker
+                .load(Ordering::Relaxed),
             1
         );
     }

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -1,0 +1,322 @@
+use super::*;
+
+const MIRROR_TX_FRAME_RESERVE: usize = TX_BATCH_SIZE;
+const MIRROR_PENDING_LIMIT: usize = TX_BATCH_SIZE;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) enum MirrorCloneResult {
+    Enqueued,
+    NoBinding,
+    NoFrame,
+    QueueFull,
+}
+
+#[inline]
+pub(in crate::afxdp) fn select_mirror_config(
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    sample_counter: &mut u64,
+) -> Option<MirrorRuntimeConfig> {
+    let config = forwarding.mirror_configs.get(&ingress_ifindex).copied()?;
+    mirror_sample_allows(config.rate, sample_counter).then_some(config)
+}
+
+#[inline]
+pub(in crate::afxdp) fn mirror_sample_allows(rate: u32, sample_counter: &mut u64) -> bool {
+    if rate <= 1 {
+        return true;
+    }
+    let current = *sample_counter;
+    *sample_counter = sample_counter.wrapping_add(1);
+    let rate = u64::from(rate);
+    if rate.is_power_of_two() {
+        current & (rate - 1) == 0
+    } else {
+        current % rate == 0
+    }
+}
+
+pub(in crate::afxdp) fn enqueue_mirror_clone(
+    left: &mut [BindingWorker],
+    ingress_index: usize,
+    ingress_binding: &mut BindingWorker,
+    right: &mut [BindingWorker],
+    binding_lookup: &WorkerBindingLookup,
+    config: MirrorRuntimeConfig,
+    ingress_queue_id: u32,
+    frame: &[u8],
+    expected_addr_family: u8,
+    expected_protocol: u8,
+) -> MirrorCloneResult {
+    let target_binding_index = binding_lookup.target_index(
+        ingress_index,
+        ingress_binding.ifindex,
+        ingress_queue_id,
+        config.output_ifindex,
+    );
+    let Some(target_binding) = target_binding_index
+        .and_then(|idx| binding_by_index_mut(left, ingress_index, ingress_binding, right, idx))
+    else {
+        return MirrorCloneResult::NoBinding;
+    };
+
+    if frame.len() > tx_frame_capacity() {
+        return MirrorCloneResult::NoFrame;
+    }
+    let pending_mirror_pressure = target_binding
+        .tx_pipeline
+        .pending_tx_prepared
+        .len()
+        .saturating_add(target_binding.tx_pipeline.pending_tx_local.len());
+    if pending_mirror_pressure >= MIRROR_PENDING_LIMIT {
+        return MirrorCloneResult::QueueFull;
+    }
+    if target_binding.tx_pipeline.free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
+        return MirrorCloneResult::NoFrame;
+    }
+    let Some(tx_offset) = target_binding.tx_pipeline.free_tx_frames.pop_front() else {
+        return MirrorCloneResult::NoFrame;
+    };
+    let Some(out) = (unsafe {
+        target_binding
+            .umem
+            .area()
+            .slice_mut_unchecked(tx_offset as usize, frame.len())
+    }) else {
+        target_binding
+            .tx_pipeline
+            .free_tx_frames
+            .push_front(tx_offset);
+        return MirrorCloneResult::NoFrame;
+    };
+    out.copy_from_slice(frame);
+    target_binding
+        .tx_pipeline
+        .pending_tx_prepared
+        .push_back(PreparedTxRequest {
+            offset: tx_offset,
+            len: frame.len() as u32,
+            recycle: PreparedTxRecycle::FreeTxFrame,
+            expected_ports: None,
+            expected_addr_family,
+            expected_protocol,
+            flow_key: None,
+            egress_ifindex: config.output_ifindex,
+            cos_queue_id: None,
+            dscp_rewrite: None,
+        });
+    MirrorCloneResult::Enqueued
+}
+
+#[inline]
+pub(in crate::afxdp) fn record_mirror_clone_result(
+    live: &BindingLiveState,
+    result: MirrorCloneResult,
+    frame_len: usize,
+) {
+    match result {
+        MirrorCloneResult::Enqueued => {
+            live.mirrored_packets.fetch_add(1, Ordering::Relaxed);
+            live.mirrored_bytes
+                .fetch_add(frame_len as u64, Ordering::Relaxed);
+        }
+        MirrorCloneResult::NoBinding => {
+            live.mirror_drops_no_binding.fetch_add(1, Ordering::Relaxed);
+        }
+        MirrorCloneResult::NoFrame => {
+            live.mirror_drops_no_frame.fetch_add(1, Ordering::Relaxed);
+        }
+        MirrorCloneResult::QueueFull => {
+            live.mirror_drops_queue_full.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sampling_rate_correctness() {
+        let mut counter = 0;
+        for _ in 0..8 {
+            assert!(mirror_sample_allows(0, &mut counter));
+            assert!(mirror_sample_allows(1, &mut counter));
+        }
+        assert_eq!(counter, 0, "mirror-all rates must not advance sampler");
+
+        let mut counter = 0;
+        let samples: Vec<bool> = (0..8)
+            .map(|_| mirror_sample_allows(4, &mut counter))
+            .collect();
+        assert_eq!(
+            samples,
+            vec![true, false, false, false, true, false, false, false]
+        );
+
+        let mut counter = 0;
+        let samples: Vec<bool> = (0..7)
+            .map(|_| mirror_sample_allows(3, &mut counter))
+            .collect();
+        assert_eq!(samples, vec![true, false, false, true, false, false, true]);
+    }
+
+    #[test]
+    fn cross_binding_inject_preserves_full_frame() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let (left, rest) = bindings.split_at_mut(0);
+        let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+        let frame: Vec<u8> = (0..96).map(|v| v as u8).collect();
+
+        let result = enqueue_mirror_clone(
+            left,
+            0,
+            ingress,
+            right,
+            &lookup,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            0,
+            &frame,
+            libc::AF_INET as u8,
+            6,
+        );
+        assert_eq!(result, MirrorCloneResult::Enqueued);
+        let target = &bindings[1];
+        assert_eq!(target.tx_pipeline.pending_tx_prepared.len(), 1);
+        let req = target
+            .tx_pipeline
+            .pending_tx_prepared
+            .front()
+            .expect("mirror prepared request");
+        assert_eq!(req.len, frame.len() as u32);
+        assert_eq!(req.egress_ifindex, 22);
+        assert_eq!(
+            target
+                .umem
+                .area()
+                .slice(req.offset as usize, req.len as usize)
+                .expect("mirror frame"),
+            frame.as_slice()
+        );
+    }
+
+    #[test]
+    fn missing_destination_binding_drop_counter() {
+        let mut binding = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
+        let bindings = vec![BindingWorker::new_for_mirror_test(0, 0, 11, 0)];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let result = enqueue_mirror_clone(
+            &mut [],
+            0,
+            &mut binding,
+            &mut [],
+            &lookup,
+            MirrorRuntimeConfig {
+                output_ifindex: 99,
+                rate: 0,
+            },
+            0,
+            &[0xaa; 64],
+            0,
+            0,
+        );
+        record_mirror_clone_result(&binding.live, result, 64);
+        assert_eq!(result, MirrorCloneResult::NoBinding);
+        assert_eq!(
+            binding.live.mirror_drops_no_binding.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn out_of_frame_drops_increment_counter() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        bindings[1]
+            .tx_pipeline
+            .free_tx_frames
+            .truncate(MIRROR_TX_FRAME_RESERVE);
+        let (left, rest) = bindings.split_at_mut(0);
+        let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+        let result = enqueue_mirror_clone(
+            left,
+            0,
+            ingress,
+            right,
+            &lookup,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            0,
+            &[0xbb; 64],
+            0,
+            0,
+        );
+        record_mirror_clone_result(&ingress.live, result, 64);
+        assert_eq!(result, MirrorCloneResult::NoFrame);
+        assert_eq!(
+            ingress.live.mirror_drops_no_frame.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn queue_full_drop_counter() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        for idx in 0..MIRROR_PENDING_LIMIT {
+            bindings[1]
+                .tx_pipeline
+                .pending_tx_prepared
+                .push_back(PreparedTxRequest {
+                    offset: (idx as u64) << UMEM_FRAME_SHIFT,
+                    len: 64,
+                    recycle: PreparedTxRecycle::FreeTxFrame,
+                    expected_ports: None,
+                    expected_addr_family: 0,
+                    expected_protocol: 0,
+                    flow_key: None,
+                    egress_ifindex: 22,
+                    cos_queue_id: None,
+                    dscp_rewrite: None,
+                });
+        }
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let (left, rest) = bindings.split_at_mut(0);
+        let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+        let result = enqueue_mirror_clone(
+            left,
+            0,
+            ingress,
+            right,
+            &lookup,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 0,
+            },
+            0,
+            &[0xcc; 64],
+            0,
+            0,
+        );
+        record_mirror_clone_result(&ingress.live, result, 64);
+        assert_eq!(result, MirrorCloneResult::QueueFull);
+        assert_eq!(
+            ingress.live.mirror_drops_queue_full.load(Ordering::Relaxed),
+            1
+        );
+    }
+}

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-const MIRROR_TX_FRAME_RESERVE: usize = TX_BATCH_SIZE;
+pub(in crate::afxdp) const MIRROR_TX_FRAME_RESERVE: usize = TX_BATCH_SIZE;
 const MIRROR_PENDING_LIMIT: usize = TX_BATCH_SIZE;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -8,6 +8,7 @@ pub(in crate::afxdp) enum MirrorCloneResult {
     Enqueued,
     NoBinding,
     NoFrame,
+    TxFrameReserve,
     QueueFull,
 }
 
@@ -126,9 +127,13 @@ pub(in crate::afxdp) fn enqueue_sampled_mirror_clone(
         if !mirror_sample_allows(config.rate, &mut ingress_binding.mirror_sample_counter) {
             return None;
         }
-        let Some(target_binding) =
-            binding_by_index_mut(left, ingress_index, ingress_binding, right, target_binding_index)
-        else {
+        let Some(target_binding) = binding_by_index_mut(
+            left,
+            ingress_index,
+            ingress_binding,
+            right,
+            target_binding_index,
+        ) else {
             return Some(MirrorCloneResult::NoBinding);
         };
         return Some(enqueue_mirror_clone_to_binding(
@@ -183,10 +188,10 @@ fn enqueue_mirror_clone_to_binding(
         return MirrorCloneResult::QueueFull;
     }
     if target_binding.tx_pipeline.free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
-        return MirrorCloneResult::NoFrame;
+        return MirrorCloneResult::TxFrameReserve;
     }
     let Some(tx_offset) = target_binding.tx_pipeline.free_tx_frames.pop_front() else {
-        return MirrorCloneResult::NoFrame;
+        return MirrorCloneResult::TxFrameReserve;
     };
     let Some(out) = (unsafe {
         target_binding
@@ -305,6 +310,7 @@ pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
         egress_ifindex: config.output_ifindex,
         cos_queue_id,
         dscp_rewrite: None,
+        mirror_clone: true,
     };
     admission
         .enqueue_owned(req)
@@ -382,6 +388,10 @@ pub(in crate::afxdp) fn record_mirror_clone_result(
         MirrorCloneResult::NoFrame => {
             live.mirror_drops_no_frame.fetch_add(1, Ordering::Relaxed);
         }
+        MirrorCloneResult::TxFrameReserve => {
+            live.mirror_drops_tx_frame_reserve
+                .fetch_add(1, Ordering::Relaxed);
+        }
         MirrorCloneResult::QueueFull => {
             live.mirror_drops_queue_full.fetch_add(1, Ordering::Relaxed);
         }
@@ -425,6 +435,7 @@ mod tests {
             egress_ifindex,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         }
     }
 
@@ -1008,7 +1019,10 @@ mod tests {
         );
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
-        assert_eq!(queued.pop_front().expect("original request").bytes, vec![0x33; 64]);
+        assert_eq!(
+            queued.pop_front().expect("original request").bytes,
+            vec![0x33; 64]
+        );
         assert!(queued.is_empty());
     }
 
@@ -1205,10 +1219,56 @@ mod tests {
             None,
         );
         record_mirror_clone_result(&ingress.live, result, 64);
-        assert_eq!(result, MirrorCloneResult::NoFrame);
+        assert_eq!(result, MirrorCloneResult::TxFrameReserve);
         assert_eq!(
-            ingress.live.mirror_drops_no_frame.load(Ordering::Relaxed),
+            ingress
+                .live
+                .mirror_drops_tx_frame_reserve
+                .load(Ordering::Relaxed),
             1
+        );
+    }
+
+    #[test]
+    fn live_mirror_owner_drops_before_consuming_tx_frame_reserve() {
+        let mut binding = BindingWorker::new_for_mirror_test(1, 0, 22, 0);
+        binding
+            .tx_pipeline
+            .free_tx_frames
+            .truncate(MIRROR_TX_FRAME_RESERVE);
+        let free_before = binding.tx_pipeline.free_tx_frames.len();
+        let mut pending = VecDeque::from([TxRequest {
+            bytes: vec![0xdd; 64],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 22,
+            cos_queue_id: None,
+            dscp_rewrite: None,
+            mirror_clone: true,
+        }]);
+        let mut shared_recycles = Vec::new();
+
+        let result = match transmit_batch(&mut binding, &mut pending, 0, &mut shared_recycles) {
+            Ok(result) => result,
+            Err(_) => panic!("mirror reserve drop should not surface as TX retry"),
+        };
+
+        assert_eq!(result, (0, 0));
+        assert!(pending.is_empty());
+        assert_eq!(binding.tx_pipeline.free_tx_frames.len(), free_before);
+        assert_eq!(
+            binding
+                .live
+                .mirror_drops_tx_frame_reserve
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            binding.live.mirror_drops_no_frame.load(Ordering::Relaxed),
+            0,
+            "TX-frame reserve drops must not be conflated with oversize/slice failures"
         );
     }
 

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -12,6 +12,7 @@ pub(in crate::afxdp) enum MirrorCloneResult {
 }
 
 #[inline]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn select_mirror_config(
     forwarding: &ForwardingState,
     ingress_ifindex: i32,
@@ -54,6 +55,7 @@ pub(in crate::afxdp) fn mirror_sample_allows(rate: u32, sample_counter: &mut u64
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn enqueue_mirror_clone(
     left: &mut [BindingWorker],
     ingress_index: usize,
@@ -92,6 +94,83 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
         );
     };
 
+    enqueue_mirror_clone_to_binding(target_binding, config, frame, meta, flow_key, cos_queue_id)
+}
+
+pub(in crate::afxdp) fn enqueue_sampled_mirror_clone(
+    left: &mut [BindingWorker],
+    ingress_index: usize,
+    ingress_binding: &mut BindingWorker,
+    right: &mut [BindingWorker],
+    binding_lookup: &WorkerBindingLookup,
+    mirror_targets: &MirrorTargetMap,
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    ingress_vlan_id: u16,
+    ingress_queue_id: u32,
+    frame: &[u8],
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+) -> Option<MirrorCloneResult> {
+    let config = resolve_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id)?;
+    let mirror_tx_ifindex = resolve_tx_binding_ifindex(forwarding, config.output_ifindex);
+    let target_binding_index = mirror_target_binding_index(
+        binding_lookup,
+        ingress_index,
+        ingress_binding.ifindex,
+        ingress_queue_id,
+        mirror_tx_ifindex,
+    );
+    let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
+    if let Some(target_binding_index) = target_binding_index {
+        if !mirror_sample_allows(config.rate, &mut ingress_binding.mirror_sample_counter) {
+            return None;
+        }
+        let Some(target_binding) =
+            binding_by_index_mut(left, ingress_index, ingress_binding, right, target_binding_index)
+        else {
+            return Some(MirrorCloneResult::NoBinding);
+        };
+        return Some(enqueue_mirror_clone_to_binding(
+            target_binding,
+            config,
+            frame,
+            meta,
+            flow_key,
+            cos_queue_id,
+        ));
+    } else {
+        let admission = match admit_mirror_clone_to_live(
+            mirror_targets,
+            mirror_tx_ifindex,
+            ingress_queue_id,
+            frame.len(),
+        ) {
+            Ok(admission) => admission,
+            Err(result) => return Some(result),
+        };
+        if !mirror_sample_allows(config.rate, &mut ingress_binding.mirror_sample_counter) {
+            return None;
+        }
+        return Some(enqueue_admitted_mirror_clone_to_live(
+            admission,
+            config,
+            frame.to_vec(),
+            meta,
+            flow_key,
+            cos_queue_id,
+        ));
+    }
+}
+
+fn enqueue_mirror_clone_to_binding(
+    target_binding: &mut BindingWorker,
+    config: MirrorRuntimeConfig,
+    frame: &[u8],
+    meta: ForwardPacketMeta,
+    flow_key: Option<&SessionKey>,
+    cos_queue_id: Option<u8>,
+) -> MirrorCloneResult {
     if frame.len() > tx_frame_capacity() {
         return MirrorCloneResult::NoFrame;
     }
@@ -160,6 +239,7 @@ fn mirror_target_binding_index(
         })
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     mirror_targets: &MirrorTargetMap,
     config: MirrorRuntimeConfig,
@@ -170,17 +250,17 @@ pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     flow_key: Option<&SessionKey>,
     cos_queue_id: Option<u8>,
 ) -> MirrorCloneResult {
-    let target_live = match admit_mirror_clone_to_live(
+    let admission = match admit_mirror_clone_to_live(
         mirror_targets,
         mirror_tx_ifindex,
         ingress_queue_id,
         frame.len(),
     ) {
-        Ok(target_live) => target_live,
+        Ok(admission) => admission,
         Err(result) => return result,
     };
     enqueue_admitted_mirror_clone_to_live(
-        &target_live,
+        admission,
         config,
         frame.to_vec(),
         meta,
@@ -194,25 +274,19 @@ pub(in crate::afxdp) fn admit_mirror_clone_to_live(
     mirror_tx_ifindex: i32,
     ingress_queue_id: u32,
     frame_len: usize,
-) -> Result<Arc<BindingLiveState>, MirrorCloneResult> {
+) -> Result<PendingTxAdmission, MirrorCloneResult> {
     if frame_len > tx_frame_capacity() {
         return Err(MirrorCloneResult::NoFrame);
     }
-    let Some(target_live) = mirror_targets.target_live(mirror_tx_ifindex, ingress_queue_id)
-    else {
+    let Some(target_live) = mirror_targets.target_live(mirror_tx_ifindex, ingress_queue_id) else {
         return Err(MirrorCloneResult::NoBinding);
     };
-    if target_live
-        .try_admit_mirror_tx_owned(MIRROR_PENDING_LIMIT)
-        .is_err()
-    {
-        return Err(MirrorCloneResult::QueueFull);
-    }
-    Ok(target_live)
+    BindingLiveState::try_reserve_mirror_tx_owned(&target_live, MIRROR_PENDING_LIMIT)
+        .map_err(|_| MirrorCloneResult::QueueFull)
 }
 
 pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
-    target_live: &BindingLiveState,
+    admission: PendingTxAdmission,
     config: MirrorRuntimeConfig,
     frame: Vec<u8>,
     meta: ForwardPacketMeta,
@@ -232,8 +306,8 @@ pub(in crate::afxdp) fn enqueue_admitted_mirror_clone_to_live(
         cos_queue_id,
         dscp_rewrite: None,
     };
-    target_live
-        .try_enqueue_tx_owned(req)
+    admission
+        .enqueue_owned(req)
         .map(|_| MirrorCloneResult::Enqueued)
         .unwrap_or(MirrorCloneResult::QueueFull)
 }
@@ -251,15 +325,27 @@ pub(in crate::afxdp) fn enqueue_sampled_mirror_clone_to_live(
     meta: ForwardPacketMeta,
     flow_key: Option<&SessionKey>,
 ) -> Option<MirrorCloneResult> {
-    let config =
-        select_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id, sample_counter)?;
+    let config = resolve_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id)?;
     let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
-    let result = enqueue_mirror_clone_to_live(
+    let admission = match admit_mirror_clone_to_live(
         mirror_targets,
-        config,
         resolve_tx_binding_ifindex(forwarding, config.output_ifindex),
         ingress_queue_id,
-        frame,
+        frame.len(),
+    ) {
+        Ok(admission) => admission,
+        Err(result) => {
+            record_mirror_clone_result(live, result, frame.len());
+            return Some(result);
+        }
+    };
+    if !mirror_sample_allows(config.rate, sample_counter) {
+        return None;
+    }
+    let result = enqueue_admitted_mirror_clone_to_live(
+        admission,
+        config,
+        frame.to_vec(),
         meta,
         flow_key,
         cos_queue_id,
@@ -326,6 +412,19 @@ mod tests {
             ieee8021_queue_by_pcp: [u8::MAX; 8],
             queue_by_forwarding_class: FastMap::default(),
             queues: Vec::new(),
+        }
+    }
+
+    fn test_tx_request(payload: u8, egress_ifindex: i32) -> TxRequest {
+        TxRequest {
+            bytes: vec![payload; 64],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex,
+            cos_queue_id: None,
+            dscp_rewrite: None,
         }
     }
 
@@ -575,16 +674,7 @@ mod tests {
         target_live.set_max_pending_tx(1);
         assert!(
             target_live
-                .try_enqueue_tx_owned(TxRequest {
-                    bytes: vec![0x11; 64],
-                    expected_ports: None,
-                    expected_addr_family: libc::AF_INET as u8,
-                    expected_protocol: PROTO_TCP,
-                    flow_key: None,
-                    egress_ifindex: 22,
-                    cos_queue_id: None,
-                    dscp_rewrite: None,
-                })
+                .try_enqueue_tx_owned(test_tx_request(0x11, 22))
                 .is_ok()
         );
         let mut mirror_targets = MirrorTargetMap::default();
@@ -617,26 +707,68 @@ mod tests {
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.len(), 1);
-        assert_eq!(queued.pop_front().expect("original request").bytes, vec![0x11; 64]);
+        assert_eq!(
+            queued.pop_front().expect("original request").bytes,
+            vec![0x11; 64]
+        );
+    }
+
+    #[test]
+    fn live_mirror_admission_reserves_slot_against_interleaving_producer() {
+        let target_live = Arc::new(BindingLiveState::new());
+        target_live.set_max_pending_tx(1);
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let config = MirrorRuntimeConfig {
+            output_ifindex: 22,
+            rate: 0,
+        };
+
+        let admission =
+            admit_mirror_clone_to_live(&mirror_targets, 22, 0, 64).expect("mirror admission");
+        assert!(
+            target_live
+                .try_enqueue_tx_owned(test_tx_request(0x99, 22))
+                .is_err(),
+            "an admitted mirror must own capacity before its clone is allocated"
+        );
+
+        let result = enqueue_admitted_mirror_clone_to_live(
+            admission,
+            config,
+            vec![0x22; 64],
+            test_meta(),
+            None,
+            None,
+        );
+
+        assert_eq!(result, MirrorCloneResult::Enqueued);
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(
+            queued.pop_front().expect("mirror request").bytes,
+            vec![0x22; 64]
+        );
     }
 
     #[test]
     fn live_mirror_queue_full_reserves_headroom_above_mirror_limit() {
         let target_live = Arc::new(BindingLiveState::new());
-        target_live.set_max_pending_tx((MIRROR_PENDING_LIMIT * 2) as u32);
+        target_live.set_max_pending_tx(MIRROR_PENDING_LIMIT * 2);
         for _ in 0..MIRROR_PENDING_LIMIT {
             assert!(
                 target_live
-                    .try_enqueue_tx_owned(TxRequest {
-                        bytes: vec![0x11; 64],
-                        expected_ports: None,
-                        expected_addr_family: libc::AF_INET as u8,
-                        expected_protocol: PROTO_TCP,
-                        flow_key: None,
-                        egress_ifindex: 22,
-                        cos_queue_id: None,
-                        dscp_rewrite: None,
-                    })
+                    .try_enqueue_tx_owned(test_tx_request(0x11, 22))
                     .is_ok()
             );
         }
@@ -811,6 +943,72 @@ mod tests {
         assert_eq!(ingress_live.mirrored_packets.load(Ordering::Relaxed), 0);
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
+        assert!(queued.is_empty());
+    }
+
+    #[test]
+    fn sampled_live_mirror_queue_full_does_not_advance_sampler() {
+        let ingress_live = BindingLiveState::new();
+        let target_live = Arc::new(BindingLiveState::new());
+        target_live.set_max_pending_tx(1);
+        assert!(
+            target_live
+                .try_enqueue_tx_owned(test_tx_request(0x33, 22))
+                .is_ok()
+        );
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let mut forwarding = ForwardingState::default();
+        forwarding.mirror_configs.insert(
+            11,
+            MirrorRuntimeConfig {
+                output_ifindex: 22,
+                rate: 4,
+            },
+        );
+        let mut sample_counter = 0;
+
+        let result = enqueue_sampled_mirror_clone_to_live(
+            &ingress_live,
+            &mirror_targets,
+            &forwarding,
+            11,
+            0,
+            0,
+            &mut sample_counter,
+            &[0x44; 80],
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, Some(MirrorCloneResult::QueueFull));
+        assert_eq!(
+            sample_counter, 0,
+            "full live target must fail before consuming a mirror sample"
+        );
+        assert_eq!(
+            ingress_live.mirror_drops_queue_full.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            target_live
+                .redirect_inbox_overflow_drops
+                .load(Ordering::Relaxed),
+            0,
+            "mirror backpressure must not pollute target redirect overflow counters"
+        );
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        assert_eq!(queued.pop_front().expect("original request").bytes, vec![0x33; 64]);
         assert!(queued.is_empty());
     }
 

--- a/userspace-dp/src/afxdp/mirror.rs
+++ b/userspace-dp/src/afxdp/mirror.rs
@@ -68,11 +68,12 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
     meta: ForwardPacketMeta,
     flow_key: Option<&SessionKey>,
 ) -> MirrorCloneResult {
+    let mirror_tx_ifindex = resolve_tx_binding_ifindex(forwarding, config.output_ifindex);
     let target_binding_index = binding_lookup.target_index(
         ingress_index,
         ingress_binding.ifindex,
         ingress_queue_id,
-        config.output_ifindex,
+        mirror_tx_ifindex,
     );
     let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
     let Some(target_binding) = target_binding_index
@@ -81,6 +82,7 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
         return enqueue_mirror_clone_to_live(
             mirror_targets,
             config,
+            mirror_tx_ifindex,
             ingress_queue_id,
             frame,
             meta,
@@ -140,6 +142,7 @@ pub(in crate::afxdp) fn enqueue_mirror_clone(
 pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     mirror_targets: &MirrorTargetMap,
     config: MirrorRuntimeConfig,
+    mirror_tx_ifindex: i32,
     ingress_queue_id: u32,
     frame: &[u8],
     meta: ForwardPacketMeta,
@@ -149,7 +152,7 @@ pub(in crate::afxdp) fn enqueue_mirror_clone_to_live(
     if frame.len() > tx_frame_capacity() {
         return MirrorCloneResult::NoFrame;
     }
-    let Some(target_live) = mirror_targets.target_live(config.output_ifindex, ingress_queue_id)
+    let Some(target_live) = mirror_targets.target_live(mirror_tx_ifindex, ingress_queue_id)
     else {
         return MirrorCloneResult::NoBinding;
     };
@@ -187,6 +190,7 @@ pub(in crate::afxdp) fn enqueue_sampled_mirror_clone_to_live(
     let result = enqueue_mirror_clone_to_live(
         mirror_targets,
         config,
+        resolve_tx_binding_ifindex(forwarding, config.output_ifindex),
         ingress_queue_id,
         frame,
         meta,
@@ -408,6 +412,7 @@ mod tests {
                 output_ifindex: 22,
                 rate: 0,
             },
+            22,
             3,
             &frame,
             test_meta(),
@@ -454,6 +459,7 @@ mod tests {
                 output_ifindex: 22,
                 rate: 0,
             },
+            22,
             0,
             &[0xdd; 64],
             test_meta(),
@@ -516,6 +522,133 @@ mod tests {
         let mut queued = VecDeque::new();
         target_live.take_pending_tx_into(&mut queued);
         assert_eq!(queued.pop_front().expect("mirror tx").bytes, frame);
+    }
+
+    #[test]
+    fn mirror_output_logical_ifindex_resolves_parent_binding() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mut forwarding = ForwardingState::default();
+        forwarding.egress.insert(
+            200,
+            EgressInterface {
+                bind_ifindex: 22,
+                vlan_id: 80,
+                mtu: 1500,
+                src_mac: [0; 6],
+                zone_id: 1,
+                redundancy_group: 0,
+                primary_v4: None,
+                primary_v6: None,
+            },
+        );
+        let mirror_targets = MirrorTargetMap::default();
+        let (left, rest) = bindings.split_at_mut(0);
+        let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+        let frame: Vec<u8> = (0..96).map(|v| v as u8).collect();
+
+        let result = enqueue_mirror_clone(
+            left,
+            0,
+            ingress,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            MirrorRuntimeConfig {
+                output_ifindex: 200,
+                rate: 0,
+            },
+            0,
+            &frame,
+            test_meta(),
+            None,
+        );
+        assert_eq!(result, MirrorCloneResult::Enqueued);
+        let target = &bindings[1];
+        let req = target
+            .tx_pipeline
+            .pending_tx_prepared
+            .front()
+            .expect("mirror prepared request");
+        assert_eq!(req.egress_ifindex, 200);
+    }
+
+    #[test]
+    fn sampled_live_mirror_resolves_snapshot_logical_ingress_and_output() {
+        let ingress_live = BindingLiveState::new();
+        let target_live = Arc::new(BindingLiveState::new());
+        let mut mirror_targets = MirrorTargetMap::default();
+        mirror_targets.insert(
+            &BindingIdentity {
+                slot: 9,
+                queue_id: 0,
+                worker_id: 1,
+                interface: Arc::<str>::from("mirror-out"),
+                ifindex: 22,
+            },
+            target_live.clone(),
+        );
+        let snapshot = ConfigSnapshot {
+            interfaces: vec![
+                InterfaceSnapshot {
+                    ifindex: 6,
+                    parent_ifindex: 0,
+                    vlan_id: 0,
+                    ..InterfaceSnapshot::default()
+                },
+                InterfaceSnapshot {
+                    ifindex: 20080,
+                    parent_ifindex: 6,
+                    vlan_id: 80,
+                    ..InterfaceSnapshot::default()
+                },
+                InterfaceSnapshot {
+                    ifindex: 22,
+                    parent_ifindex: 0,
+                    vlan_id: 0,
+                    ..InterfaceSnapshot::default()
+                },
+                InterfaceSnapshot {
+                    ifindex: 200,
+                    parent_ifindex: 22,
+                    vlan_id: 90,
+                    ..InterfaceSnapshot::default()
+                },
+            ],
+            mirror_configs: vec![MirrorConfigSnapshot {
+                ingress_ifindex: 20080,
+                output_ifindex: 200,
+                rate: 0,
+            }],
+            ..ConfigSnapshot::default()
+        };
+        let forwarding = build_forwarding_state(&snapshot);
+        let mut sample_counter = 0;
+        let frame = vec![0x88; 80];
+
+        let result = enqueue_sampled_mirror_clone_to_live(
+            &ingress_live,
+            &mirror_targets,
+            &forwarding,
+            6,
+            80,
+            0,
+            &mut sample_counter,
+            &frame,
+            test_meta(),
+            None,
+        );
+
+        assert_eq!(result, Some(MirrorCloneResult::Enqueued));
+        let mut queued = VecDeque::new();
+        target_live.take_pending_tx_into(&mut queued);
+        let req = queued.pop_front().expect("mirror tx");
+        assert_eq!(req.egress_ifindex, 200);
+        assert_eq!(req.bytes, frame);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -32,6 +32,7 @@ use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::fd::AsRawFd;
 use std::rc::Rc;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
 use std::sync::{Arc, Mutex};

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -77,6 +77,8 @@ mod icmp;
 mod icmp_embed;
 #[path = "ethernet.rs"]
 mod ethernet;
+#[path = "mirror.rs"]
+mod mirror;
 #[path = "neighbor.rs"]
 mod neighbor;
 #[path = "parser.rs"]
@@ -141,6 +143,7 @@ use self::icmp_embed::{
     build_nat_reversed_icmp_error_v4, build_nat_reversed_icmp_error_v6,
     finalize_embedded_icmp_resolution, try_embedded_icmp_nat_match,
 };
+use self::mirror::*;
 use self::neighbor::*;
 pub use self::neighbor::{neighbor_state_usable_str, parse_mac_str};
 pub(crate) use self::rst::remove_kernel_rst_suppression;

--- a/userspace-dp/src/afxdp/mpsc_inbox.rs
+++ b/userspace-dp/src/afxdp/mpsc_inbox.rs
@@ -87,6 +87,7 @@ impl<T> MpscInbox<T> {
     /// claimed a slot (advanced `head`) without yet publishing a value,
     /// and the consumer may have consumed a value without readers seeing
     /// the updated `tail`. Safe for observability and soft-cap gating.
+    #[cfg_attr(not(test), allow(dead_code))]
     #[inline]
     pub(super) fn len(&self) -> usize {
         let head = self.head.0.load(Ordering::Relaxed);
@@ -186,4 +187,3 @@ impl<T> Drop for MpscInbox<T> {
 #[cfg(test)]
 #[path = "mpsc_inbox_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -204,6 +204,7 @@ pub(super) fn retry_pending_neigh(
             egress_ifindex: decision.resolution.egress_ifindex,
             cos_queue_id: cos.queue_id,
             dscp_rewrite: cos.dscp_rewrite,
+            mirror_clone: false,
         };
         if target_idx == binding_index {
             binding.tx_pipeline.pending_tx_prepared.push_back(req);

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -261,34 +261,40 @@ pub(super) fn poll_binding_process_descriptor(
                                     if is_self_target && owned_packet_frame.is_none() {
                                         let ingress_slot = binding.slot;
                                         let flow_key = flow.forward_key.clone();
-                                        let mirror_sample = resolve_mirror_config(
+                                        let mirror_config = resolve_mirror_config(
                                             worker_ctx.forwarding,
                                             meta.ingress_ifindex as i32,
                                             meta.ingress_vlan_id,
-                                        )
-                                        .map(|config| {
-                                            let mut next_counter = binding.mirror_sample_counter;
-                                            let selected =
-                                                mirror_sample_allows(config.rate, &mut next_counter);
-                                            (config, next_counter, selected)
+                                        );
+                                        let mut mirror_next_counter = None;
+                                        let mut mirror_admission = mirror_config.and_then(|config| {
+                                            let admission = admit_mirror_clone_to_live(
+                                                worker_ctx.mirror_targets,
+                                                resolve_tx_binding_ifindex(
+                                                    worker_ctx.forwarding,
+                                                    config.output_ifindex,
+                                                ),
+                                                worker_ctx.ident.queue_id,
+                                                packet_frame.len(),
+                                            );
+                                            match admission {
+                                                Ok(admission) => {
+                                                    let mut next_counter =
+                                                        binding.mirror_sample_counter;
+                                                    if mirror_sample_allows(
+                                                        config.rate,
+                                                        &mut next_counter,
+                                                    ) {
+                                                        mirror_next_counter = Some(next_counter);
+                                                        Some((config, Ok(admission)))
+                                                    } else {
+                                                        mirror_next_counter = Some(next_counter);
+                                                        None
+                                                    }
+                                                }
+                                                Err(result) => Some((config, Err(result))),
+                                            }
                                         });
-                                        let mirror_admission = mirror_sample
-                                            .as_ref()
-                                            .filter(|(_, _, selected)| *selected)
-                                            .map(|(config, _, _)| {
-                                                (
-                                                    *config,
-                                                    admit_mirror_clone_to_live(
-                                                        worker_ctx.mirror_targets,
-                                                        resolve_tx_binding_ifindex(
-                                                            worker_ctx.forwarding,
-                                                            config.output_ifindex,
-                                                        ),
-                                                        worker_ctx.ident.queue_id,
-                                                        packet_frame.len(),
-                                                    ),
-                                                )
-                                            });
                                         let mirror_frame_len = packet_frame.len();
                                         let mut mirror_frame = mirror_admission
                                             .as_ref()
@@ -315,16 +321,14 @@ pub(super) fn poll_binding_process_descriptor(
                                             )
                                         });
                                         if let Some(rewrite_result) = rewrite_result {
-                                            if let Some((_, next_counter, _)) =
-                                                mirror_sample.as_ref()
-                                            {
-                                                binding.mirror_sample_counter = *next_counter;
+                                            if let Some(next_counter) = mirror_next_counter {
+                                                binding.mirror_sample_counter = next_counter;
                                             }
                                             if let Some((mirror_config, admission)) =
-                                                mirror_admission.as_ref()
+                                                mirror_admission.take()
                                             {
                                                 let result = match admission {
-                                                    Ok(target_live) => {
+                                                    Ok(admission) => {
                                                         if let Some(mirror_frame) =
                                                             mirror_frame.take()
                                                         {
@@ -335,8 +339,8 @@ pub(super) fn poll_binding_process_descriptor(
                                                                 Some(&flow_key),
                                                             );
                                                             enqueue_admitted_mirror_clone_to_live(
-                                                                target_live.as_ref(),
-                                                                *mirror_config,
+                                                                admission,
+                                                                mirror_config,
                                                                 mirror_frame,
                                                                 meta.into(),
                                                                 Some(&flow_key),
@@ -346,7 +350,7 @@ pub(super) fn poll_binding_process_descriptor(
                                                             MirrorCloneResult::NoFrame
                                                         }
                                                     }
-                                                    Err(result) => *result,
+                                                    Err(result) => result,
                                                 };
                                                 record_mirror_clone_result(
                                                     &binding.live,

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -261,12 +261,39 @@ pub(super) fn poll_binding_process_descriptor(
                                     if is_self_target && owned_packet_frame.is_none() {
                                         let ingress_slot = binding.slot;
                                         let flow_key = flow.forward_key.clone();
-                                        let mirror_frame = resolve_mirror_config(
+                                        let mirror_sample = resolve_mirror_config(
                                             worker_ctx.forwarding,
                                             meta.ingress_ifindex as i32,
                                             meta.ingress_vlan_id,
                                         )
-                                        .map(|_| packet_frame.to_vec());
+                                        .map(|config| {
+                                            let mut next_counter = binding.mirror_sample_counter;
+                                            let selected =
+                                                mirror_sample_allows(config.rate, &mut next_counter);
+                                            (config, next_counter, selected)
+                                        });
+                                        let mirror_admission = mirror_sample
+                                            .as_ref()
+                                            .filter(|(_, _, selected)| *selected)
+                                            .map(|(config, _, _)| {
+                                                (
+                                                    *config,
+                                                    admit_mirror_clone_to_live(
+                                                        worker_ctx.mirror_targets,
+                                                        resolve_tx_binding_ifindex(
+                                                            worker_ctx.forwarding,
+                                                            config.output_ifindex,
+                                                        ),
+                                                        worker_ctx.ident.queue_id,
+                                                        packet_frame.len(),
+                                                    ),
+                                                )
+                                            });
+                                        let mirror_frame_len = packet_frame.len();
+                                        let mut mirror_frame = mirror_admission
+                                            .as_ref()
+                                            .and_then(|(_, admission)| admission.as_ref().ok())
+                                            .map(|_| packet_frame.to_vec());
                                         // Try descriptor-based straight-line rewrite first (no branches
                                         // for AF, NAT type, or checksum recomputation).  Falls back to
                                         // generic rewrite on port mismatch, NAT64, or NPTv6.
@@ -288,18 +315,43 @@ pub(super) fn poll_binding_process_descriptor(
                                             )
                                         });
                                         if let Some(rewrite_result) = rewrite_result {
-                                            if let Some(mirror_frame) = mirror_frame.as_ref() {
-                                                enqueue_sampled_mirror_clone_to_live(
+                                            if let Some((_, next_counter, _)) =
+                                                mirror_sample.as_ref()
+                                            {
+                                                binding.mirror_sample_counter = *next_counter;
+                                            }
+                                            if let Some((mirror_config, admission)) =
+                                                mirror_admission.as_ref()
+                                            {
+                                                let result = match admission {
+                                                    Ok(target_live) => {
+                                                        if let Some(mirror_frame) =
+                                                            mirror_frame.take()
+                                                        {
+                                                            let cos_queue_id = mirror_cos_queue_id(
+                                                                worker_ctx.forwarding,
+                                                                mirror_config.output_ifindex,
+                                                                meta.into(),
+                                                                Some(&flow_key),
+                                                            );
+                                                            enqueue_admitted_mirror_clone_to_live(
+                                                                target_live.as_ref(),
+                                                                *mirror_config,
+                                                                mirror_frame,
+                                                                meta.into(),
+                                                                Some(&flow_key),
+                                                                cos_queue_id,
+                                                            )
+                                                        } else {
+                                                            MirrorCloneResult::NoFrame
+                                                        }
+                                                    }
+                                                    Err(result) => *result,
+                                                };
+                                                record_mirror_clone_result(
                                                     &binding.live,
-                                                    worker_ctx.mirror_targets,
-                                                    worker_ctx.forwarding,
-                                                    meta.ingress_ifindex as i32,
-                                                    meta.ingress_vlan_id,
-                                                    worker_ctx.ident.queue_id,
-                                                    &mut binding.mirror_sample_counter,
-                                                    mirror_frame,
-                                                    meta.into(),
-                                                    Some(&flow.forward_key),
+                                                    result,
+                                                    mirror_frame_len,
                                                 );
                                             }
                                             binding.tx_pipeline.pending_tx_prepared.push_back(

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -261,6 +261,12 @@ pub(super) fn poll_binding_process_descriptor(
                                     if is_self_target && owned_packet_frame.is_none() {
                                         let ingress_slot = binding.slot;
                                         let flow_key = flow.forward_key.clone();
+                                        let mirror_frame = resolve_mirror_config(
+                                            worker_ctx.forwarding,
+                                            meta.ingress_ifindex as i32,
+                                            meta.ingress_vlan_id,
+                                        )
+                                        .map(|_| packet_frame.to_vec());
                                         // Try descriptor-based straight-line rewrite first (no branches
                                         // for AF, NAT type, or checksum recomputation).  Falls back to
                                         // generic rewrite on port mismatch, NAT64, or NPTv6.
@@ -282,6 +288,20 @@ pub(super) fn poll_binding_process_descriptor(
                                             )
                                         });
                                         if let Some(rewrite_result) = rewrite_result {
+                                            if let Some(mirror_frame) = mirror_frame.as_ref() {
+                                                enqueue_sampled_mirror_clone_to_live(
+                                                    &binding.live,
+                                                    worker_ctx.mirror_targets,
+                                                    worker_ctx.forwarding,
+                                                    meta.ingress_ifindex as i32,
+                                                    meta.ingress_vlan_id,
+                                                    worker_ctx.ident.queue_id,
+                                                    &mut binding.mirror_sample_counter,
+                                                    mirror_frame,
+                                                    meta.into(),
+                                                    Some(&flow.forward_key),
+                                                );
+                                            }
                                             binding.tx_pipeline.pending_tx_prepared.push_back(
                                                 PreparedTxRequest {
                                                     offset: rewrite_result.offset,

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -380,6 +380,7 @@ pub(super) fn poll_binding_process_descriptor(
                                                     dscp_rewrite: cached_descriptor
                                                         .tx_selection
                                                         .dscp_rewrite,
+                                                    mirror_clone: false,
                                                 },
                                             );
                                             binding.tx_counters.pending_in_place_tx_packets += 1;

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -497,6 +497,7 @@ mod tests {
             ifindex: 24,
         };
         let binding_lookup = WorkerBindingLookup::default();
+        let mirror_targets = MirrorTargetMap::default();
         let ha_state = BTreeMap::new();
         let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
         let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -512,6 +513,7 @@ mod tests {
         let worker_ctx = WorkerContext {
             ident: &ident,
             binding_lookup: &binding_lookup,
+            mirror_targets: &mirror_targets,
             forwarding: &forwarding,
             ha_state: &ha_state,
             dynamic_neighbors: &dynamic_neighbors,

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -228,6 +228,7 @@ pub(super) fn build_local_origin_tunnel_tx_request(
             egress_ifindex: decision.resolution.egress_ifindex,
             cos_queue_id: cos.queue_id,
             dscp_rewrite: cos.dscp_rewrite,
+            mirror_clone: false,
         },
         session_entry,
         reverse_session_entry,
@@ -429,4 +430,3 @@ pub(super) fn record_local_tunnel_exception(
         );
     }
 }
-

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -537,6 +537,7 @@ pub(super) fn clone_prepared_request_for_cos(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
+        mirror_clone: false,
     })
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -4,6 +4,7 @@
 // atomic ops use `Ordering::Relaxed`.
 
 use super::*;
+use crate::afxdp::mirror::MIRROR_TX_FRAME_RESERVE;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(in crate::afxdp) struct CoSTxSelection {
@@ -440,6 +441,9 @@ pub(super) fn prepare_local_request_for_cos(
     if req.bytes.len() > tx_frame_capacity() {
         return Err(req);
     }
+    if req.mirror_clone && free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
+        return Err(req);
+    }
     let Some(offset) = free_tx_frames.pop_front() else {
         return Err(req);
     };
@@ -460,6 +464,7 @@ pub(super) fn prepare_local_request_for_cos(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
+        mirror_clone: req.mirror_clone,
     })
 }
 
@@ -537,7 +542,7 @@ pub(super) fn clone_prepared_request_for_cos(
         egress_ifindex: req.egress_ifindex,
         cos_queue_id: req.cos_queue_id,
         dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: false,
+        mirror_clone: req.mirror_clone,
     })
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -453,19 +453,7 @@ pub(super) fn prepare_local_request_for_cos(
         return Err(req);
     };
     frame.copy_from_slice(&req.bytes);
-    Ok(PreparedTxRequest {
-        offset,
-        len: req.bytes.len() as u32,
-        recycle: PreparedTxRecycle::FreeTxFrame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key,
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: req.mirror_clone,
-    })
+    Ok(req.into_prepared_request(offset, PreparedTxRecycle::FreeTxFrame))
 }
 
 pub(super) fn enqueue_prepared_into_cos(
@@ -533,17 +521,7 @@ pub(super) fn clone_prepared_request_for_cos(
     req: &PreparedTxRequest,
 ) -> Option<TxRequest> {
     let frame = area.slice(req.offset as usize, req.len as usize)?.to_vec();
-    Some(TxRequest {
-        bytes: frame,
-        expected_ports: req.expected_ports,
-        expected_addr_family: req.expected_addr_family,
-        expected_protocol: req.expected_protocol,
-        flow_key: req.flow_key.clone(),
-        egress_ifindex: req.egress_ifindex,
-        cos_queue_id: req.cos_queue_id,
-        dscp_rewrite: req.dscp_rewrite,
-        mirror_clone: req.mirror_clone,
-    })
+    Some(req.to_local_request(frame))
 }
 
 pub(super) fn resolve_cos_queue_idx(

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -172,6 +172,7 @@ fn prepare_local_request_for_cos_materializes_prepared_frame() {
         egress_ifindex: 80,
         cos_queue_id: Some(5),
         dscp_rewrite: Some(46),
+        mirror_clone: false,
     };
 
     let prepared =
@@ -201,6 +202,7 @@ fn prepare_local_request_for_cos_falls_back_when_no_free_tx_frame_exists() {
         egress_ifindex: 80,
         cos_queue_id: Some(5),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     let req = match prepare_local_request_for_cos(&area, &mut free_tx_frames, req) {

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -113,6 +113,7 @@ fn clone_prepared_request_for_cos_returns_local_copy_with_metadata() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: Some(46),
+        mirror_clone: true,
     };
 
     let local = clone_prepared_request_for_cos(&area, &req).expect("local copy");
@@ -124,6 +125,7 @@ fn clone_prepared_request_for_cos_returns_local_copy_with_metadata() {
     assert_eq!(local.egress_ifindex, 80);
     assert_eq!(local.cos_queue_id, Some(4));
     assert_eq!(local.dscp_rewrite, Some(46));
+    assert!(local.mirror_clone);
     assert_eq!(
         local
             .flow_key
@@ -147,9 +149,38 @@ fn clone_prepared_request_for_cos_rejects_out_of_range_offset() {
         egress_ifindex: 80,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
 
     assert!(clone_prepared_request_for_cos(&area, &req).is_none());
+}
+
+#[test]
+fn prepare_local_request_for_cos_preserves_mirror_tx_frame_reserve() {
+    let area = MmapArea::new(4096).expect("mmap");
+    let mut free_tx_frames = (0..MIRROR_TX_FRAME_RESERVE as u64)
+        .map(|idx| idx << UMEM_FRAME_SHIFT)
+        .collect::<VecDeque<_>>();
+    let original_free = free_tx_frames.clone();
+    let req = TxRequest {
+        bytes: vec![1, 2, 3, 4],
+        expected_ports: None,
+        expected_addr_family: libc::AF_INET as u8,
+        expected_protocol: PROTO_TCP,
+        flow_key: None,
+        egress_ifindex: 80,
+        cos_queue_id: Some(5),
+        dscp_rewrite: None,
+        mirror_clone: true,
+    };
+
+    let req = match prepare_local_request_for_cos(&area, &mut free_tx_frames, req) {
+        Ok(_) => panic!("mirror clones must not consume the last reserved TX frames"),
+        Err(req) => req,
+    };
+
+    assert!(req.mirror_clone);
+    assert_eq!(free_tx_frames, original_free);
 }
 
 #[test]
@@ -246,6 +277,7 @@ fn cos_queue_accepts_prepared_when_queue_is_prepared_only() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     assert!(cos_queue_accepts_prepared(&root, Some(5)));
@@ -291,6 +323,7 @@ fn demote_prepared_cos_queue_to_local_recycles_frames_and_blocks_prepared_append
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
     root.queues[0]
         .hot
@@ -306,6 +339,7 @@ fn demote_prepared_cos_queue_to_local_recycles_frames_and_blocks_prepared_append
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut free_tx_frames = VecDeque::from([512]);
@@ -400,6 +434,7 @@ fn demote_prepared_cos_queue_to_local_preserves_mqfq_frontier() {
             egress_ifindex: 42,
             cos_queue_id: Some(4),
             dscp_rewrite: None,
+            mirror_clone: false,
         }),
     );
     cos_queue_push_back(
@@ -415,6 +450,7 @@ fn demote_prepared_cos_queue_to_local_preserves_mqfq_frontier() {
             egress_ifindex: 42,
             cos_queue_id: Some(4),
             dscp_rewrite: None,
+            mirror_clone: false,
         }),
     );
 
@@ -536,6 +572,7 @@ fn demote_prepared_cos_queue_to_local_skips_non_exact_queue() {
             egress_ifindex: 80,
             cos_queue_id: Some(5),
             dscp_rewrite: None,
+            mirror_clone: false,
         }));
 
     let mut free_tx_frames = VecDeque::new();

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -182,26 +182,21 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
             }
             PendingForwardFrame::Prebuilt(_) => unreachable!(),
         };
-        if let Some(mirror_config) = select_mirror_config(
+        if let Some(result) = enqueue_sampled_mirror_clone(
+            left,
+            ingress_index,
+            ingress_binding,
+            right,
+            binding_lookup,
+            mirror_targets,
             forwarding,
             request.meta.ingress_ifindex as i32,
             request.meta.ingress_vlan_id,
-            &mut ingress_binding.mirror_sample_counter,
+            request.ingress_queue_id,
+            source_frame,
+            request.meta,
+            request.flow_key.as_ref(),
         ) {
-            let result = enqueue_mirror_clone(
-                left,
-                ingress_index,
-                ingress_binding,
-                right,
-                binding_lookup,
-                mirror_targets,
-                forwarding,
-                mirror_config,
-                request.ingress_queue_id,
-                source_frame,
-                request.meta,
-                request.flow_key.as_ref(),
-            );
             record_mirror_clone_result(&ingress_binding.live, result, source_frame.len());
         }
         let expected_ports = request.expected_ports;

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -149,6 +149,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 egress_ifindex: request.decision.resolution.egress_ifindex,
                 cos_queue_id: request.cos_queue_id,
                 dscp_rewrite: request.dscp_rewrite,
+                mirror_clone: false,
             };
             if enqueue_local_request_to_target_or_owner(target_binding, req).is_err() {
                 recycle_ingress_frame(ingress_binding, source_offset, now_ns);
@@ -364,6 +365,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                 egress_ifindex: request.decision.resolution.egress_ifindex,
                                 cos_queue_id: request.cos_queue_id,
                                 dscp_rewrite: request.dscp_rewrite,
+                                mirror_clone: false,
                             });
                         bound_pending_tx_local(target_binding);
                         dbg.enqueue_ok += 1;
@@ -554,6 +556,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
+                                    mirror_clone: false,
                                 };
                                 if enqueue_local_request_to_target_or_owner(target_binding, req)
                                     .is_err()
@@ -832,6 +835,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
+                                    mirror_clone: false,
                                 };
                                 if enqueue_local_request_to_target_or_owner(target_binding, req)
                                     .is_err()

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -74,6 +74,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
     ingress_binding: &mut BindingWorker,
     right: &mut [BindingWorker],
     binding_lookup: &WorkerBindingLookup,
+    mirror_targets: &MirrorTargetMap,
     pending_forwards: &mut Vec<PendingForwardRequest>,
     post_recycles: &mut Vec<(u32, u64)>,
     now_ns: u64,
@@ -184,6 +185,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
         if let Some(mirror_config) = select_mirror_config(
             forwarding,
             request.meta.ingress_ifindex as i32,
+            request.meta.ingress_vlan_id,
             &mut ingress_binding.mirror_sample_counter,
         ) {
             let result = enqueue_mirror_clone(
@@ -192,11 +194,13 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 ingress_binding,
                 right,
                 binding_lookup,
+                mirror_targets,
+                forwarding,
                 mirror_config,
                 request.ingress_queue_id,
                 source_frame,
-                request.meta.addr_family,
-                request.meta.protocol,
+                request.meta,
+                request.flow_key.as_ref(),
             );
             record_mirror_clone_result(&ingress_binding.live, result, source_frame.len());
         }

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -475,6 +475,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     egress_ifindex: request.decision.resolution.egress_ifindex,
                                     cos_queue_id: request.cos_queue_id,
                                     dscp_rewrite: request.dscp_rewrite,
+                                    mirror_clone: false,
                                 },
                             );
                             bound_pending_tx_prepared(target_binding, Some(post_recycles));
@@ -724,6 +725,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                         egress_ifindex: request.decision.resolution.egress_ifindex,
                                         cos_queue_id: request.cos_queue_id,
                                         dscp_rewrite: request.dscp_rewrite,
+                                        mirror_clone: false,
                                     },
                                 );
                                 bound_pending_tx_prepared(target_binding, Some(post_recycles));

--- a/userspace-dp/src/afxdp/tx/dispatch.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch.rs
@@ -181,6 +181,25 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
             }
             PendingForwardFrame::Prebuilt(_) => unreachable!(),
         };
+        if let Some(mirror_config) = select_mirror_config(
+            forwarding,
+            request.meta.ingress_ifindex as i32,
+            &mut ingress_binding.mirror_sample_counter,
+        ) {
+            let result = enqueue_mirror_clone(
+                left,
+                ingress_index,
+                ingress_binding,
+                right,
+                binding_lookup,
+                mirror_config,
+                request.ingress_queue_id,
+                source_frame,
+                request.meta.addr_family,
+                request.meta.protocol,
+            );
+            record_mirror_clone_result(&ingress_binding.live, result, source_frame.len());
+        }
         let expected_ports = request.expected_ports;
         let ingress_umem_ptr = ingress_binding.umem.allocation_ptr();
         let Some(target_binding) = resolve_pending_forward_target_binding(

--- a/userspace-dp/src/afxdp/tx/drain.rs
+++ b/userspace-dp/src/afxdp/tx/drain.rs
@@ -203,7 +203,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
     // CoS is configured (no possible cos_queue_id.is_some() on
     // any item) — keeps the non-CoS hot path allocation-free.
     if !forwarding.cos.interfaces.is_empty() {
-        drop_cos_bound_prepared_leftovers(binding, shared_recycles);
+        drop_cos_bound_prepared_leftovers(binding, forwarding, shared_recycles);
     }
     while !binding.tx_pipeline.pending_tx_prepared.is_empty() {
         match transmit_prepared_batch(binding, now_ns, shared_recycles) {
@@ -333,6 +333,7 @@ pub(in crate::afxdp) fn drain_pending_tx(
 /// local-enqueue failure.
 fn drop_cos_bound_prepared_leftovers(
     binding: &mut BindingWorker,
+    forwarding: &ForwardingState,
     shared_recycles: &mut Vec<(u32, u64)>,
 ) {
     if binding.tx_pipeline.pending_tx_prepared.is_empty() {
@@ -357,7 +358,7 @@ fn drop_cos_bound_prepared_leftovers(
         let Some(req) = binding.tx_pipeline.pending_tx_prepared.pop_front() else {
             break;
         };
-        if req.cos_queue_id.is_some() {
+        if tx_request_targets_cos_interface(forwarding, req.egress_ifindex, req.cos_queue_id) {
             dropped = dropped.saturating_add(1);
             dropped_bytes = dropped_bytes.saturating_add(req.len as u64);
             recycle_prepared_immediately_with_shared(binding, &req, Some(shared_recycles));
@@ -420,11 +421,21 @@ fn drop_cos_bound_prepared_leftovers(
 /// `transmit_batch` backup path, bypassing the CoS cap.
 /// Adversarial reviewers MUST reject any PR that re-introduces
 /// an early-exit on head inspection.
-fn partition_cos_bound_local_with_rescue<F>(
+fn tx_request_targets_cos_interface(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    cos_queue_id: Option<u8>,
+) -> bool {
+    cos_queue_id.is_some() || forwarding.cos.interfaces.contains_key(&egress_ifindex)
+}
+
+fn partition_cos_bound_local_with_rescue<P, F>(
     pending: &mut VecDeque<TxRequest>,
+    mut is_cos_bound: P,
     mut try_rescue: F,
 ) -> (u64, u64)
 where
+    P: FnMut(&TxRequest) -> bool,
     F: FnMut(TxRequest) -> Result<(), TxRequest>,
 {
     let mut dropped = 0u64;
@@ -434,7 +445,7 @@ where
         let Some(req) = pending.pop_front() else {
             break;
         };
-        if req.cos_queue_id.is_some() {
+        if is_cos_bound(&req) {
             let bytes_len = req.bytes.len() as u64;
             match try_rescue(req) {
                 Ok(()) => { /* rescued — do not drop */ }
@@ -460,8 +471,10 @@ fn drop_cos_bound_local_leftovers(
     // Delegate the scan to the pure helper so the mixed-head
     // invariant (Codex review on #784) is unit-testable without
     // constructing a full BindingWorker.
-    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(pending, |req| {
-        match enqueue_local_into_cos(
+    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(
+        pending,
+        |req| tx_request_targets_cos_interface(forwarding, req.egress_ifindex, req.cos_queue_id),
+        |req| match enqueue_local_into_cos(
             binding,
             forwarding,
             req,
@@ -470,8 +483,8 @@ fn drop_cos_bound_local_leftovers(
         ) {
             Ok(()) => Ok(()),
             Err(req) => Err(req),
-        }
-    });
+        },
+    );
     if dropped > 0 {
         binding.live.tx_errors.fetch_add(dropped, Ordering::Relaxed);
         binding

--- a/userspace-dp/src/afxdp/tx/drain_tests.rs
+++ b/userspace-dp/src/afxdp/tx/drain_tests.rs
@@ -60,7 +60,8 @@ fn partition_cos_bound_local_scans_mixed_head_deque() {
     // Rescue stub: always fails (returns Err) so every
     // cos-bound item falls through to drop. Verifies the
     // scan covers the WHOLE deque, not just the head.
-    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(&mut pending, Err);
+    let (dropped, dropped_bytes) =
+        partition_cos_bound_local_with_rescue(&mut pending, |req| req.cos_queue_id.is_some(), Err);
     assert_eq!(
         dropped, 2,
         "both cos-bound items must be dropped (scan covers tail)"
@@ -99,13 +100,54 @@ fn partition_cos_bound_local_rescues_when_try_rescue_ok() {
     };
     let mut pending: VecDeque<TxRequest> = VecDeque::from([non_cos, cos_bound]);
     // Rescue always succeeds — CoS items must NOT count as drops.
-    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(&mut pending, |_| Ok(()));
+    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(
+        &mut pending,
+        |req| req.cos_queue_id.is_some(),
+        |_| Ok(()),
+    );
     assert_eq!(dropped, 0);
     assert_eq!(dropped_bytes, 0);
     // Survivor set: only the non-CoS item (rescued CoS item
     // was consumed by try_rescue closure).
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].bytes[0], 0xAA);
+}
+
+#[test]
+fn partition_cos_bound_local_treats_default_queue_on_cos_interface_as_bound() {
+    let mut pending: VecDeque<TxRequest> = VecDeque::from([
+        TxRequest {
+            bytes: vec![0x11; 64],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 14,
+            cos_queue_id: None,
+            dscp_rewrite: None,
+        },
+        TxRequest {
+            bytes: vec![0x22; 64],
+            expected_ports: None,
+            expected_addr_family: libc::AF_INET as u8,
+            expected_protocol: PROTO_TCP,
+            flow_key: None,
+            egress_ifindex: 99,
+            cos_queue_id: None,
+            dscp_rewrite: None,
+        },
+    ]);
+
+    let (dropped, dropped_bytes) = partition_cos_bound_local_with_rescue(
+        &mut pending,
+        |req| req.egress_ifindex == 14 || req.cos_queue_id.is_some(),
+        Err,
+    );
+
+    assert_eq!(dropped, 1);
+    assert_eq!(dropped_bytes, 64);
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].egress_ifindex, 99);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/drain_tests.rs
+++ b/userspace-dp/src/afxdp/tx/drain_tests.rs
@@ -39,6 +39,7 @@ fn partition_cos_bound_local_scans_mixed_head_deque() {
         egress_ifindex: 99,
         cos_queue_id: None,
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let cos_bound = |payload: u8| TxRequest {
         bytes: vec![payload; 64],
@@ -49,6 +50,7 @@ fn partition_cos_bound_local_scans_mixed_head_deque() {
         egress_ifindex: 14,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let mut pending: VecDeque<TxRequest> = VecDeque::from([
         non_cos(1),
@@ -87,6 +89,7 @@ fn partition_cos_bound_local_rescues_when_try_rescue_ok() {
         egress_ifindex: 99,
         cos_queue_id: None,
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let cos_bound = TxRequest {
         bytes: vec![0xBB; 64],
@@ -97,6 +100,7 @@ fn partition_cos_bound_local_rescues_when_try_rescue_ok() {
         egress_ifindex: 14,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     };
     let mut pending: VecDeque<TxRequest> = VecDeque::from([non_cos, cos_bound]);
     // Rescue always succeeds — CoS items must NOT count as drops.
@@ -125,6 +129,7 @@ fn partition_cos_bound_local_treats_default_queue_on_cos_interface_as_bound() {
             egress_ifindex: 14,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         },
         TxRequest {
             bytes: vec![0x22; 64],
@@ -135,6 +140,7 @@ fn partition_cos_bound_local_treats_default_queue_on_cos_interface_as_bound() {
             egress_ifindex: 99,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         },
     ]);
 

--- a/userspace-dp/src/afxdp/tx/tcp_segmentation.rs
+++ b/userspace-dp/src/afxdp/tx/tcp_segmentation.rs
@@ -270,6 +270,7 @@ pub(super) fn segment_forwarded_tcp_frames_into_prepared(
             egress_ifindex: decision.resolution.egress_ifindex,
             cos_queue_id,
             dscp_rewrite,
+            mirror_clone: false,
         });
         total_bytes += frame_len as u64;
         max_frame = max_frame.max(frame_len as u32);

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -156,6 +156,7 @@ pub(in crate::afxdp) fn test_cos_item(len: usize) -> CoSPendingTxItem {
         egress_ifindex: 42,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     })
 }
 
@@ -169,6 +170,7 @@ pub(in crate::afxdp) fn test_flow_cos_item(src_port: u16, len: usize) -> CoSPend
         egress_ifindex: 42,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     })
 }
 
@@ -399,6 +401,7 @@ pub(in crate::afxdp) fn test_local_ipv4_item(tos: u8) -> CoSPendingTxItem {
         egress_ifindex: 42,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     })
 }
 

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -190,6 +190,7 @@ pub(in crate::afxdp) fn test_flow_prepared_cos_item(
         egress_ifindex: 42,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     })
 }
 
@@ -523,6 +524,7 @@ pub(in crate::afxdp) fn test_prepared_item_in_umem(
         egress_ifindex: 42,
         cos_queue_id: Some(0),
         dscp_rewrite: None,
+        mirror_clone: false,
     })
 }
 

--- a/userspace-dp/src/afxdp/tx/transmit.rs
+++ b/userspace-dp/src/afxdp/tx/transmit.rs
@@ -8,7 +8,7 @@ use crate::afxdp::frame::{apply_dscp_rewrite_to_frame, decode_frame_summary, fra
 use crate::afxdp::neighbor::monotonic_nanos;
 use crate::afxdp::types::{FastMap, PreparedTxRecycle, PreparedTxRequest, TxRequest};
 use crate::afxdp::worker::BindingWorker;
-use crate::afxdp::{TX_BATCH_SIZE, tx_frame_capacity};
+use crate::afxdp::{MIRROR_TX_FRAME_RESERVE, TX_BATCH_SIZE, tx_frame_capacity};
 use crate::xsk_ffi::xdp::XdpDesc;
 
 use super::rings::{maybe_wake_tx, reap_tx_completions};
@@ -94,10 +94,19 @@ pub(in crate::afxdp) fn transmit_batch(
     }
 
     binding.scratch.scratch_local_tx.clear();
+    let mut dropped_mirror_reserve = false;
     while binding.scratch.scratch_local_tx.len() < batch_size {
         let Some(mut req) = pending.pop_front() else {
             break;
         };
+        if req.mirror_clone && binding.tx_pipeline.free_tx_frames.len() <= MIRROR_TX_FRAME_RESERVE {
+            binding
+                .live
+                .mirror_drops_tx_frame_reserve
+                .fetch_add(1, Ordering::Relaxed);
+            dropped_mirror_reserve = true;
+            continue;
+        }
         if let Some(dscp_rewrite) = req.dscp_rewrite {
             let _ = apply_dscp_rewrite_to_frame(&mut req.bytes, dscp_rewrite);
         }
@@ -171,6 +180,9 @@ pub(in crate::afxdp) fn transmit_batch(
     }
 
     if binding.scratch.scratch_local_tx.is_empty() {
+        if dropped_mirror_reserve {
+            return Ok((0, 0));
+        }
         maybe_wake_tx(binding, true, now_ns);
         return Err(TxError::Retry("no prepared TX frame available".to_string()));
     }

--- a/userspace-dp/src/afxdp/tx/transmit_tests.rs
+++ b/userspace-dp/src/afxdp/tx/transmit_tests.rs
@@ -23,6 +23,7 @@ fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {
             egress_ifindex: 0,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         },
     );
     remember_prepared_recycle(
@@ -38,6 +39,7 @@ fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {
             egress_ifindex: 0,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         },
     );
     remember_prepared_recycle(
@@ -56,6 +58,7 @@ fn remember_prepared_recycle_tracks_only_shared_fill_recycles() {
             egress_ifindex: 0,
             cos_queue_id: None,
             dscp_rewrite: None,
+            mirror_clone: false,
         },
     );
 

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -54,10 +54,17 @@ pub(in crate::afxdp) struct ForwardingState {
     #[allow(dead_code)]
     pub(in crate::afxdp) gre_acceleration: bool,
     pub(in crate::afxdp) flow_export_config: Option<crate::flowexport::FlowExportConfig>,
+    pub(in crate::afxdp) mirror_configs: FastMap<i32, MirrorRuntimeConfig>,
     pub(in crate::afxdp) tcp_mss_all_tcp: u16,
     pub(in crate::afxdp) tcp_mss_ipsec_vpn: u16,
     pub(in crate::afxdp) tcp_mss_gre_in: u16,
     pub(in crate::afxdp) tcp_mss_gre_out: u16,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::afxdp) struct MirrorRuntimeConfig {
+    pub(in crate::afxdp) output_ifindex: i32,
+    pub(in crate::afxdp) rate: u32,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -335,7 +335,13 @@ pub(in crate::afxdp) struct TelemetryContext<'a> {
 #[derive(Clone, Default)]
 pub(crate) struct MirrorTargetMap {
     by_if_queue: FastMap<(i32, u32), Arc<BindingLiveState>>,
-    first_by_if: FastMap<i32, Arc<BindingLiveState>>,
+    by_if: FastMap<i32, MirrorTargetIfEntry>,
+}
+
+#[derive(Clone)]
+struct MirrorTargetIfEntry {
+    live: Arc<BindingLiveState>,
+    count: usize,
 }
 
 impl MirrorTargetMap {
@@ -346,7 +352,10 @@ impl MirrorTargetMap {
     ) {
         self.by_if_queue
             .insert((ident.ifindex, ident.queue_id), live.clone());
-        self.first_by_if.entry(ident.ifindex).or_insert(live);
+        self.by_if
+            .entry(ident.ifindex)
+            .and_modify(|entry| entry.count = entry.count.saturating_add(1))
+            .or_insert(MirrorTargetIfEntry { live, count: 1 });
     }
 
     pub(in crate::afxdp) fn target_live(
@@ -357,6 +366,11 @@ impl MirrorTargetMap {
         self.by_if_queue
             .get(&(egress_ifindex, ingress_queue_id))
             .cloned()
-            .or_else(|| self.first_by_if.get(&egress_ifindex).cloned())
+            .or_else(|| {
+                self.by_if
+                    .get(&egress_ifindex)
+                    .filter(|entry| entry.count == 1)
+                    .map(|entry| entry.live.clone())
+            })
     }
 }

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -306,6 +306,7 @@ pub(in crate::afxdp) struct DebugPollCounters {
 pub(in crate::afxdp) struct WorkerContext<'a> {
     pub(in crate::afxdp) ident: &'a BindingIdentity,
     pub(in crate::afxdp) binding_lookup: &'a WorkerBindingLookup,
+    pub(in crate::afxdp) mirror_targets: &'a MirrorTargetMap,
     pub(in crate::afxdp) forwarding: &'a ForwardingState,
     pub(in crate::afxdp) ha_state: &'a BTreeMap<i32, HAGroupRuntime>,
     pub(in crate::afxdp) dynamic_neighbors: &'a Arc<super::sharded_neighbor::ShardedNeighborMap>,
@@ -329,4 +330,33 @@ pub(in crate::afxdp) struct WorkerContext<'a> {
 pub(in crate::afxdp) struct TelemetryContext<'a> {
     pub(in crate::afxdp) dbg: &'a mut DebugPollCounters,
     pub(in crate::afxdp) counters: &'a mut BatchCounters,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MirrorTargetMap {
+    by_if_queue: FastMap<(i32, u32), Arc<BindingLiveState>>,
+    first_by_if: FastMap<i32, Arc<BindingLiveState>>,
+}
+
+impl MirrorTargetMap {
+    pub(in crate::afxdp) fn insert(
+        &mut self,
+        ident: &BindingIdentity,
+        live: Arc<BindingLiveState>,
+    ) {
+        self.by_if_queue
+            .insert((ident.ifindex, ident.queue_id), live.clone());
+        self.first_by_if.entry(ident.ifindex).or_insert(live);
+    }
+
+    pub(in crate::afxdp) fn target_live(
+        &self,
+        egress_ifindex: i32,
+        ingress_queue_id: u32,
+    ) -> Option<Arc<BindingLiveState>> {
+        self.by_if_queue
+            .get(&(egress_ifindex, ingress_queue_id))
+            .cloned()
+            .or_else(|| self.first_by_if.get(&egress_ifindex).cloned())
+    }
 }

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -66,6 +66,7 @@ pub(in crate::afxdp) struct PreparedTxRequest {
     pub(in crate::afxdp) egress_ifindex: i32,
     pub(in crate::afxdp) cos_queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
+    pub(in crate::afxdp) mirror_clone: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -24,6 +24,29 @@ pub(in crate::afxdp) struct TxRequest {
     pub(in crate::afxdp) mirror_clone: bool,
 }
 
+impl TxRequest {
+    #[inline]
+    pub(in crate::afxdp) fn into_prepared_request(
+        self,
+        offset: u64,
+        recycle: PreparedTxRecycle,
+    ) -> PreparedTxRequest {
+        PreparedTxRequest {
+            offset,
+            len: self.bytes.len() as u32,
+            recycle,
+            expected_ports: self.expected_ports,
+            expected_addr_family: self.expected_addr_family,
+            expected_protocol: self.expected_protocol,
+            flow_key: self.flow_key,
+            egress_ifindex: self.egress_ifindex,
+            cos_queue_id: self.cos_queue_id,
+            dscp_rewrite: self.dscp_rewrite,
+            mirror_clone: self.mirror_clone,
+        }
+    }
+}
+
 pub(in crate::afxdp) enum PendingForwardFrame {
     Live,
     Owned(Vec<u8>),
@@ -67,6 +90,23 @@ pub(in crate::afxdp) struct PreparedTxRequest {
     pub(in crate::afxdp) cos_queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
     pub(in crate::afxdp) mirror_clone: bool,
+}
+
+impl PreparedTxRequest {
+    #[inline]
+    pub(in crate::afxdp) fn to_local_request(&self, bytes: Vec<u8>) -> TxRequest {
+        TxRequest {
+            bytes,
+            expected_ports: self.expected_ports,
+            expected_addr_family: self.expected_addr_family,
+            expected_protocol: self.expected_protocol,
+            flow_key: self.flow_key.clone(),
+            egress_ifindex: self.egress_ifindex,
+            cos_queue_id: self.cos_queue_id,
+            dscp_rewrite: self.dscp_rewrite,
+            mirror_clone: self.mirror_clone,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -21,6 +21,7 @@ pub(in crate::afxdp) struct TxRequest {
     pub(in crate::afxdp) egress_ifindex: i32,
     pub(in crate::afxdp) cos_queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
+    pub(in crate::afxdp) mirror_clone: bool,
 }
 
 pub(in crate::afxdp) enum PendingForwardFrame {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -386,6 +386,13 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// #1376: mirror clone dropped because the output binding already
     /// had mirror/primary TX backlog. Mirrors are lossy under pressure.
     pub(super) mirror_drops_queue_full: AtomicU64,
+    /// #1376: same-worker mirror queue-full drops. Split from
+    /// cross-worker live-inbox drops so operators can localize mirror
+    /// pressure to the ingress/owner worker boundary.
+    pub(super) mirror_drops_queue_full_same_worker: AtomicU64,
+    /// #1376: cross-worker mirror queue-full drops at the target live
+    /// inbox/admission boundary.
+    pub(super) mirror_drops_queue_full_cross_worker: AtomicU64,
     /// #710: packets dropped in `apply_worker_shaped_tx_requests`
     /// because the worker could not locate any binding for the
     /// request's egress_ifindex. Happens when a cross-worker CoS
@@ -616,6 +623,8 @@ impl BindingLiveState {
             mirror_drops_tx_frame_reserve: AtomicU64::new(0),
             mirror_drops_no_binding: AtomicU64::new(0),
             mirror_drops_queue_full: AtomicU64::new(0),
+            mirror_drops_queue_full_same_worker: AtomicU64::new(0),
+            mirror_drops_queue_full_cross_worker: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
             // #709 / #746: owner-profile telemetry, split by writer
             // into two cacheline-isolated groups. Histograms are zero-
@@ -937,6 +946,12 @@ impl BindingLiveState {
                 .load(Ordering::Relaxed),
             mirror_drops_no_binding: self.mirror_drops_no_binding.load(Ordering::Relaxed),
             mirror_drops_queue_full: self.mirror_drops_queue_full.load(Ordering::Relaxed),
+            mirror_drops_queue_full_same_worker: self
+                .mirror_drops_queue_full_same_worker
+                .load(Ordering::Relaxed),
+            mirror_drops_queue_full_cross_worker: self
+                .mirror_drops_queue_full_cross_worker
+                .load(Ordering::Relaxed),
             post_drain_backup_bytes: self
                 .owner_profile_owner
                 .post_drain_backup_bytes

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1106,6 +1106,22 @@ impl BindingLiveState {
         Ok(())
     }
 
+    pub(super) fn try_admit_mirror_tx_owned(&self, mirror_pending_limit: usize) -> Result<(), ()> {
+        let pending_len = self.pending_tx.len();
+        let mut admission_cap = self.pending_tx.capacity();
+        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
+        if max_pending > 0 {
+            admission_cap = admission_cap.min(max_pending);
+        }
+        if mirror_pending_limit > 0 {
+            admission_cap = admission_cap.min(mirror_pending_limit);
+        }
+        if pending_len >= admission_cap {
+            return Err(());
+        }
+        Ok(())
+    }
+
     /// Shared push path for `enqueue_tx` and `enqueue_tx_owned`.
     /// Drop-newest on overflow: if the soft cap or ring hard cap is hit,
     /// drop the incoming request and bump the overflow counters. This is

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -366,6 +366,20 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// non-zero value usually indicates a frame-building bug upstream
     /// or a legitimate oversize packet. Subset of `tx_errors`.
     pub(super) tx_submit_error_drops: AtomicU64,
+    /// #1376: ingress mirror clone packets successfully admitted to a
+    /// mirror output binding. Written by the ingress binding's worker.
+    pub(super) mirrored_packets: AtomicU64,
+    /// #1376: full L2 bytes copied into admitted mirror clones.
+    pub(super) mirrored_bytes: AtomicU64,
+    /// #1376: mirror clone dropped because the output binding did not
+    /// have enough reserved TX frames available.
+    pub(super) mirror_drops_no_frame: AtomicU64,
+    /// #1376: mirror clone dropped because the output ifindex has no
+    /// live binding on this worker.
+    pub(super) mirror_drops_no_binding: AtomicU64,
+    /// #1376: mirror clone dropped because the output binding already
+    /// had mirror/primary TX backlog. Mirrors are lossy under pressure.
+    pub(super) mirror_drops_queue_full: AtomicU64,
     /// #710: packets dropped in `apply_worker_shaped_tx_requests`
     /// because the worker could not locate any binding for the
     /// request's egress_ifindex. Happens when a cross-worker CoS
@@ -559,6 +573,11 @@ impl BindingLiveState {
             redirect_inbox_overflow_drops: AtomicU64::new(0),
             pending_tx_local_overflow_drops: AtomicU64::new(0),
             tx_submit_error_drops: AtomicU64::new(0),
+            mirrored_packets: AtomicU64::new(0),
+            mirrored_bytes: AtomicU64::new(0),
+            mirror_drops_no_frame: AtomicU64::new(0),
+            mirror_drops_no_binding: AtomicU64::new(0),
+            mirror_drops_queue_full: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
             // #709 / #746: owner-profile telemetry, split by writer
             // into two cacheline-isolated groups. Histograms are zero-
@@ -871,6 +890,11 @@ impl BindingLiveState {
                 .pending_tx_local_overflow_drops
                 .load(Ordering::Relaxed),
             tx_submit_error_drops: self.tx_submit_error_drops.load(Ordering::Relaxed),
+            mirrored_packets: self.mirrored_packets.load(Ordering::Relaxed),
+            mirrored_bytes: self.mirrored_bytes.load(Ordering::Relaxed),
+            mirror_drops_no_frame: self.mirror_drops_no_frame.load(Ordering::Relaxed),
+            mirror_drops_no_binding: self.mirror_drops_no_binding.load(Ordering::Relaxed),
+            mirror_drops_queue_full: self.mirror_drops_queue_full.load(Ordering::Relaxed),
             post_drain_backup_bytes: self
                 .owner_profile_owner
                 .post_drain_backup_bytes

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1094,6 +1094,18 @@ impl BindingLiveState {
         self.try_push_redirect_inbox(req)
     }
 
+    pub(super) fn try_admit_tx_owned(&self) -> Result<(), ()> {
+        let pending_len = self.pending_tx.len();
+        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
+        if (max_pending > 0 && pending_len >= max_pending)
+            || pending_len >= self.pending_tx.capacity()
+        {
+            self.record_redirect_inbox_overflow();
+            return Err(());
+        }
+        Ok(())
+    }
+
     /// Shared push path for `enqueue_tx` and `enqueue_tx_owned`.
     /// Drop-newest on overflow: if the soft cap or ring hard cap is hit,
     /// drop the incoming request and bump the overflow counters. This is

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -1089,6 +1089,10 @@ impl BindingLiveState {
         Ok(())
     }
 
+    pub(super) fn try_enqueue_tx_owned(&self, req: TxRequest) -> Result<(), TxRequest> {
+        self.try_push_redirect_inbox(req)
+    }
+
     /// Shared push path for `enqueue_tx` and `enqueue_tx_owned`.
     /// Drop-newest on overflow: if the soft cap or ring hard cap is hit,
     /// drop the incoming request and bump the overflow counters. This is
@@ -1113,6 +1117,20 @@ impl BindingLiveState {
             // unlimited → hard cap is the only brake).
             self.record_redirect_inbox_overflow();
         }
+    }
+
+    #[inline]
+    fn try_push_redirect_inbox(&self, req: TxRequest) -> Result<(), TxRequest> {
+        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
+        if max_pending > 0 && self.pending_tx.len() >= max_pending {
+            self.record_redirect_inbox_overflow();
+            return Err(req);
+        }
+        if let Err(req) = self.pending_tx.push(req) {
+            self.record_redirect_inbox_overflow();
+            return Err(req);
+        }
+        Ok(())
     }
 
     #[inline]

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -372,8 +372,8 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// #1376: full L2 bytes copied into admitted mirror clones.
     pub(super) mirrored_bytes: AtomicU64,
     /// #1376: mirror clone dropped for frame-unavailable outcomes:
-    /// oversized packet (`len > tx_frame_capacity()`), TX-frame
-    /// reserve exhausted, or UMEM slice failure while cloning.
+    /// oversized packet (`len > tx_frame_capacity()`) or UMEM slice
+    /// failure while cloning.
     pub(super) mirror_drops_no_frame: AtomicU64,
     /// #1376: mirror clone dropped specifically to preserve the
     /// output binding's owner-local TX-frame reserve. Split from

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -371,11 +371,12 @@ pub(in crate::afxdp) struct BindingLiveState {
     pub(super) mirrored_packets: AtomicU64,
     /// #1376: full L2 bytes copied into admitted mirror clones.
     pub(super) mirrored_bytes: AtomicU64,
-    /// #1376: mirror clone dropped because the output binding did not
-    /// have enough reserved TX frames available.
+    /// #1376: mirror clone dropped for frame-unavailable outcomes:
+    /// oversized packet (`len > tx_frame_capacity()`), TX-frame
+    /// reserve exhausted, or UMEM slice failure while cloning.
     pub(super) mirror_drops_no_frame: AtomicU64,
-    /// #1376: mirror clone dropped because the output ifindex has no
-    /// live binding on this worker.
+    /// #1376: mirror clone dropped because no live mirror target
+    /// binding was available for the resolved output TX ifindex.
     pub(super) mirror_drops_no_binding: AtomicU64,
     /// #1376: mirror clone dropped because the output binding already
     /// had mirror/primary TX backlog. Mirrors are lossy under pressure.

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -375,6 +375,11 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// oversized packet (`len > tx_frame_capacity()`), TX-frame
     /// reserve exhausted, or UMEM slice failure while cloning.
     pub(super) mirror_drops_no_frame: AtomicU64,
+    /// #1376: mirror clone dropped specifically to preserve the
+    /// output binding's owner-local TX-frame reserve. Split from
+    /// `mirror_drops_no_frame` so operators can distinguish an
+    /// oversize/slice failure from pressure that would starve normal TX.
+    pub(super) mirror_drops_tx_frame_reserve: AtomicU64,
     /// #1376: mirror clone dropped because no live mirror target
     /// binding was available for the resolved output TX ifindex.
     pub(super) mirror_drops_no_binding: AtomicU64,
@@ -608,6 +613,7 @@ impl BindingLiveState {
             mirrored_packets: AtomicU64::new(0),
             mirrored_bytes: AtomicU64::new(0),
             mirror_drops_no_frame: AtomicU64::new(0),
+            mirror_drops_tx_frame_reserve: AtomicU64::new(0),
             mirror_drops_no_binding: AtomicU64::new(0),
             mirror_drops_queue_full: AtomicU64::new(0),
             no_owner_binding_drops: AtomicU64::new(0),
@@ -926,6 +932,9 @@ impl BindingLiveState {
             mirrored_packets: self.mirrored_packets.load(Ordering::Relaxed),
             mirrored_bytes: self.mirrored_bytes.load(Ordering::Relaxed),
             mirror_drops_no_frame: self.mirror_drops_no_frame.load(Ordering::Relaxed),
+            mirror_drops_tx_frame_reserve: self
+                .mirror_drops_tx_frame_reserve
+                .load(Ordering::Relaxed),
             mirror_drops_no_binding: self.mirror_drops_no_binding.load(Ordering::Relaxed),
             mirror_drops_queue_full: self.mirror_drops_queue_full.load(Ordering::Relaxed),
             post_drain_backup_bytes: self

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -496,6 +496,10 @@ pub(in crate::afxdp) struct BindingLiveState {
     pub(super) rx_fill_ring_empty_descs: AtomicU64,
     pub(super) last_heartbeat: AtomicU64,
     pub(super) max_pending_tx: AtomicU32,
+    /// Atomic admission count for `pending_tx`: queued requests plus
+    /// producer-held reservations that have not committed yet. This is the
+    /// linearizable capacity gate; `pending_tx.len()` remains observational.
+    pub(super) pending_tx_admitted: AtomicUsize,
     pub(super) last_error: Mutex<String>,
     /// Cross-worker redirect inbox (#706). N producer workers push
     /// redirected `TxRequest`s; the single owner worker drains. Bounded
@@ -504,6 +508,33 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// against the owner's drain.
     pub(super) pending_tx: MpscInbox<TxRequest>,
     pub(super) pending_session_deltas: Mutex<VecDeque<SessionDeltaInfo>>,
+}
+
+pub(in crate::afxdp) struct PendingTxAdmission {
+    live: Arc<BindingLiveState>,
+    active: bool,
+}
+
+impl PendingTxAdmission {
+    #[inline]
+    pub(in crate::afxdp) fn enqueue_owned(mut self, req: TxRequest) -> Result<(), TxRequest> {
+        match self.live.pending_tx.push(req) {
+            Ok(()) => {
+                self.active = false;
+                Ok(())
+            }
+            Err(req) => Err(req),
+        }
+    }
+}
+
+impl Drop for PendingTxAdmission {
+    #[inline]
+    fn drop(&mut self) {
+        if self.active {
+            self.live.release_pending_tx_admission();
+        }
+    }
 }
 
 impl BindingLiveState {
@@ -627,6 +658,7 @@ impl BindingLiveState {
             rx_fill_ring_empty_descs: AtomicU64::new(0),
             last_heartbeat: AtomicU64::new(0),
             max_pending_tx: AtomicU32::new(0),
+            pending_tx_admitted: AtomicUsize::new(0),
             last_error: Mutex::new(String::new()),
             pending_tx: MpscInbox::new(PENDING_TX_INBOX_HARD_CAP),
             pending_session_deltas: Mutex::new(VecDeque::new()),
@@ -1094,32 +1126,15 @@ impl BindingLiveState {
         self.try_push_redirect_inbox(req)
     }
 
-    pub(super) fn try_admit_tx_owned(&self) -> Result<(), ()> {
-        let pending_len = self.pending_tx.len();
-        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-        if (max_pending > 0 && pending_len >= max_pending)
-            || pending_len >= self.pending_tx.capacity()
-        {
-            self.record_redirect_inbox_overflow();
-            return Err(());
-        }
-        Ok(())
-    }
-
-    pub(super) fn try_admit_mirror_tx_owned(&self, mirror_pending_limit: usize) -> Result<(), ()> {
-        let pending_len = self.pending_tx.len();
-        let mut admission_cap = self.pending_tx.capacity();
-        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-        if max_pending > 0 {
-            admission_cap = admission_cap.min(max_pending);
-        }
-        if mirror_pending_limit > 0 {
-            admission_cap = admission_cap.min(mirror_pending_limit);
-        }
-        if pending_len >= admission_cap {
-            return Err(());
-        }
-        Ok(())
+    pub(in crate::afxdp) fn try_reserve_mirror_tx_owned(
+        live: &Arc<Self>,
+        mirror_pending_limit: usize,
+    ) -> Result<PendingTxAdmission, ()> {
+        live.try_acquire_pending_tx_admission(Some(mirror_pending_limit), false)?;
+        Ok(PendingTxAdmission {
+            live: Arc::clone(live),
+            active: true,
+        })
     }
 
     /// Shared push path for `enqueue_tx` and `enqueue_tx_owned`.
@@ -1132,34 +1147,74 @@ impl BindingLiveState {
     /// `redirect_inbox_overflow_drops` as the dedicated view) is preserved.
     #[inline]
     fn push_redirect_inbox(&self, req: TxRequest) {
-        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-        if max_pending > 0 && self.pending_tx.len() >= max_pending {
-            self.record_redirect_inbox_overflow();
+        if self.try_acquire_pending_tx_admission(None, true).is_err() {
             return;
         }
         if self.pending_tx.push(req).is_err() {
-            // Hard cap hit — ring is full. Rare: the hard cap sits at
-            // `PENDING_TX_INBOX_HARD_CAP`, so a non-zero soft cap
-            // normally fires first. This branch is reachable only under
-            // concurrent producers racing past the soft-cap check, or
-            // when the caller has set `max_pending_tx = 0` (treat as
-            // unlimited → hard cap is the only brake).
+            self.release_pending_tx_admission();
             self.record_redirect_inbox_overflow();
         }
     }
 
     #[inline]
     fn try_push_redirect_inbox(&self, req: TxRequest) -> Result<(), TxRequest> {
-        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
-        if max_pending > 0 && self.pending_tx.len() >= max_pending {
-            self.record_redirect_inbox_overflow();
+        if self.try_acquire_pending_tx_admission(None, true).is_err() {
             return Err(req);
         }
         if let Err(req) = self.pending_tx.push(req) {
+            self.release_pending_tx_admission();
             self.record_redirect_inbox_overflow();
             return Err(req);
         }
         Ok(())
+    }
+
+    #[inline]
+    fn pending_tx_admission_cap(&self, extra_limit: Option<usize>) -> usize {
+        let mut admission_cap = self.pending_tx.capacity();
+        let max_pending = self.max_pending_tx.load(Ordering::Relaxed) as usize;
+        if max_pending > 0 {
+            admission_cap = admission_cap.min(max_pending);
+        }
+        if let Some(limit) = extra_limit {
+            if limit > 0 {
+                admission_cap = admission_cap.min(limit);
+            }
+        }
+        admission_cap
+    }
+
+    #[inline]
+    fn try_acquire_pending_tx_admission(
+        &self,
+        extra_limit: Option<usize>,
+        record_overflow: bool,
+    ) -> Result<(), ()> {
+        let admission_cap = self.pending_tx_admission_cap(extra_limit);
+        let mut admitted = self.pending_tx_admitted.load(Ordering::Relaxed);
+        loop {
+            if admitted >= admission_cap {
+                if record_overflow {
+                    self.record_redirect_inbox_overflow();
+                }
+                return Err(());
+            }
+            match self.pending_tx_admitted.compare_exchange_weak(
+                admitted,
+                admitted + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(actual) => admitted = actual,
+            }
+        }
+    }
+
+    #[inline]
+    fn release_pending_tx_admission(&self) {
+        let previous = self.pending_tx_admitted.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "pending_tx_admitted underflow");
     }
 
     #[inline]
@@ -1190,6 +1245,7 @@ impl BindingLiveState {
         // of `take_pending_tx_into`. Enforced by convention (see the doc
         // comment on `pending_tx` in `BindingLiveState`).
         while let Some(req) = unsafe { self.pending_tx.pop() } {
+            self.release_pending_tx_admission();
             out.push_back(req);
         }
     }

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -25,6 +25,7 @@ fn test_tx_request_for_inbox(payload: u8) -> TxRequest {
         egress_ifindex: 0,
         cos_queue_id: None,
         dscp_rewrite: None,
+        mirror_clone: false,
     }
 }
 

--- a/userspace-dp/src/afxdp/worker/cos_tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos_tests.rs
@@ -31,6 +31,7 @@ fn test_tx_request(ifindex: i32) -> TxRequest {
         egress_ifindex: ifindex,
         cos_queue_id: Some(4),
         dscp_rewrite: None,
+        mirror_clone: false,
     }
 }
 

--- a/userspace-dp/src/afxdp/worker/lifecycle.rs
+++ b/userspace-dp/src/afxdp/worker/lifecycle.rs
@@ -18,6 +18,7 @@ pub(super) fn poll_binding(
     binding_index: usize,
     bindings: &mut [BindingWorker],
     binding_lookup: &WorkerBindingLookup,
+    mirror_targets: &MirrorTargetMap,
     sessions: &mut SessionTable,
     screen: &mut ScreenState,
     validation: ValidationState,
@@ -168,6 +169,7 @@ pub(super) fn poll_binding(
         let worker_ctx = WorkerContext {
             ident,
             binding_lookup,
+            mirror_targets,
             forwarding,
             ha_state,
             dynamic_neighbors,
@@ -245,6 +247,7 @@ pub(super) fn poll_binding(
                 binding,
                 right,
                 binding_lookup,
+                mirror_targets,
                 &mut pending_forwards,
                 &mut scratch_post_recycles,
                 now_ns,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -138,6 +138,9 @@ pub(crate) struct BindingWorker {
     /// `WorkerFlowCacheState`. Field semantics unchanged; access
     /// via `binding.flow.flow_cache` and `binding.flow.flow_cache_session_touch`.
     pub(crate) flow: WorkerFlowCacheState,
+    /// #1376: per-worker/per-binding mirror sampler. Reset on worker
+    /// restart and intentionally not synchronized across workers.
+    pub(crate) mirror_sample_counter: u64,
     /// #959 Phase 8: 3 binding registration / identity fields
     /// (bind_time_ns, bind_mode, xsk_rx_confirmed) extracted into
     /// `WorkerBindMeta`. Field semantics unchanged; access via
@@ -421,6 +424,7 @@ impl BindingWorker {
                 flow_cache: FlowCache::new(),
                 flow_cache_session_touch: 0,
             },
+            mirror_sample_counter: 0,
             bind_meta: WorkerBindMeta {
                 bind_time_ns: {
                     let mut ts = libc::timespec {
@@ -548,6 +552,116 @@ impl BindingWorker {
                 flow_cache: FlowCache::new(),
                 flow_cache_session_touch: 0,
             },
+            mirror_sample_counter: 0,
+            bind_meta: WorkerBindMeta {
+                bind_time_ns: init_now,
+                bind_mode: XskBindMode::Copy,
+                xsk_rx_confirmed: false,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::afxdp) fn new_for_mirror_test(
+        slot: u32,
+        worker_id: u32,
+        ifindex: i32,
+        queue_id: u32,
+    ) -> Self {
+        let ring_entries = 128;
+        let total_frames = 256;
+        let live = Arc::new(BindingLiveState::new());
+        live.set_bound(-1);
+        live.set_bind_mode(XskBindMode::Copy);
+        live.set_socket_binding(ifindex, queue_id, 0);
+        live.set_max_pending_tx(pending_tx_capacity(ring_entries));
+        live.umem_total_frames
+            .store(total_frames, std::sync::atomic::Ordering::Relaxed);
+        live.tx_ring_capacity
+            .store(ring_entries, std::sync::atomic::Ordering::Relaxed);
+        let init_now = monotonic_nanos();
+        Self {
+            slot,
+            queue_id,
+            worker_id,
+            interface: Arc::<str>::from("mirror-test"),
+            ifindex,
+            live,
+            user: User::new_for_test(-1),
+            xsk: WorkerXskRings {
+                device: crate::xsk_ffi::DeviceQueue::new_for_test(-1, ring_entries),
+                rx: crate::xsk_ffi::RingRx::new_for_test(-1, ring_entries),
+                tx: crate::xsk_ffi::RingTx::new_for_test(-1, ring_entries),
+            },
+            umem: WorkerUmem::new_for_test(total_frames).expect("test worker umem"),
+            tx_pipeline: WorkerTxPipeline {
+                free_tx_frames: (0..total_frames)
+                    .map(|idx| (idx as u64) << UMEM_FRAME_SHIFT)
+                    .collect(),
+                pending_tx_prepared: VecDeque::new(),
+                pending_tx_local: VecDeque::new(),
+                max_pending_tx: pending_tx_capacity(ring_entries),
+                outstanding_tx: 0,
+                pending_fill_frames: VecDeque::new(),
+                in_flight_prepared_recycles: FastMap::default(),
+                tx_submit_ns: vec![TX_SIDECAR_UNSTAMPED; total_frames as usize].into_boxed_slice(),
+            },
+            cos: WorkerCos {
+                cos_fast_interfaces: FastMap::default(),
+                cos_interfaces: FastMap::default(),
+                cos_interface_order: Vec::new(),
+                cos_interface_rr: 0,
+                cos_nonempty_interfaces: 0,
+                cos_queue_lease_acquire_v8_calls: 0,
+                cos_queue_lease_acquire_v8_granted_bytes: 0,
+            },
+            scratch: WorkerScratch {
+                scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_forwards: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_fill: Vec::with_capacity(FILL_BATCH_SIZE),
+                scratch_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_exact_prepared_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_exact_local_tx: Vec::with_capacity(TX_BATCH_SIZE),
+                scratch_completed_offsets: Vec::with_capacity(ring_entries as usize),
+                scratch_post_recycles: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_cross_binding_tx: Vec::with_capacity(RX_BATCH_SIZE as usize),
+                scratch_rst_teardowns: Vec::with_capacity(16),
+            },
+            pending_neigh: VecDeque::new(),
+            bpf_maps: WorkerBpfMaps {
+                heartbeat_map_fd: -1,
+                session_map_fd: -1,
+                conntrack_v4_fd: -1,
+                conntrack_v6_fd: -1,
+            },
+            timers: WorkerTimers {
+                last_heartbeat_update_ns: init_now,
+                debug_state_counter: 0,
+                last_idle_debug_publish_ns: init_now,
+                last_rx_wake_ns: init_now,
+                last_tx_wake_ns: init_now,
+                empty_rx_polls: 0,
+            },
+            last_learned_neighbor: None,
+            telemetry: WorkerTelemetry::default(),
+            tx_counters: WorkerTxCounters {
+                pending_direct_tx_packets: 0,
+                pending_copy_tx_packets: 0,
+                pending_in_place_tx_packets: 0,
+                pending_in_place_vlan_push_desc_packets: 0,
+                pending_in_place_vlan_pop_desc_packets: 0,
+                pending_in_place_vlan_push_no_headroom_packets: 0,
+                pending_in_place_l2_memmove_fallback_packets: 0,
+                pending_direct_tx_no_frame_fallback_packets: 0,
+                pending_direct_tx_build_fallback_packets: 0,
+                pending_direct_tx_disallowed_fallback_packets: 0,
+            },
+            flow: WorkerFlowCacheState {
+                flow_cache: FlowCache::new(),
+                flow_cache_session_touch: 0,
+            },
+            mirror_sample_counter: 0,
             bind_meta: WorkerBindMeta {
                 bind_time_ns: init_now,
                 bind_mode: XskBindMode::Copy,
@@ -2280,6 +2394,11 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) redirect_inbox_overflow_drops: u64,
     pub(crate) pending_tx_local_overflow_drops: u64,
     pub(crate) tx_submit_error_drops: u64,
+    pub(crate) mirrored_packets: u64,
+    pub(crate) mirrored_bytes: u64,
+    pub(crate) mirror_drops_no_frame: u64,
+    pub(crate) mirror_drops_no_binding: u64,
+    pub(crate) mirror_drops_queue_full: u64,
     // #760 triage: surfaced on BindingStatus so operators can
     // compare binding-level vs per-queue drain accounting.
     pub(crate) post_drain_backup_bytes: u64,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -2403,6 +2403,7 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) mirrored_packets: u64,
     pub(crate) mirrored_bytes: u64,
     pub(crate) mirror_drops_no_frame: u64,
+    pub(crate) mirror_drops_tx_frame_reserve: u64,
     pub(crate) mirror_drops_no_binding: u64,
     pub(crate) mirror_drops_queue_full: u64,
     // #760 triage: surfaced on BindingStatus so operators can

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1025,6 +1025,7 @@ pub(crate) fn worker_loop(
     shared_cos_exact_backlogs: Arc<ArcSwap<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>>,
     shared_cos_queue_leases: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>>,
     shared_cos_queue_vtime_floors: Arc<ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>>>,
+    shared_mirror_targets: Arc<ArcSwap<MirrorTargetMap>>,
     cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
     // #869: worker-runtime telemetry publish slot.  Worker writes its
     // local counters here on a ~1s cadence; coordinator reads for status.
@@ -1042,6 +1043,7 @@ pub(crate) fn worker_loop(
     let mut cos_shared_exact_backlogs = shared_cos_exact_backlogs.load_full();
     let mut cos_shared_queue_leases = shared_cos_queue_leases.load_full();
     let mut cos_shared_queue_vtime_floors = shared_cos_queue_vtime_floors.load_full();
+    let mut mirror_targets = shared_mirror_targets.load_full();
     let mut sessions = SessionTable::new();
     let mut screen_state = ScreenState::new();
     screen_state.update_profiles(forwarding.screen_profiles.clone());
@@ -1286,6 +1288,9 @@ pub(crate) fn worker_loop(
                 rebuild_cos_fast_interfaces = true;
             }
         }
+        if let Some(new_x) = load_arc_if_changed(&mirror_targets, &shared_mirror_targets) {
+            mirror_targets = new_x;
+        }
         if let Some(new_x) = load_arc_if_changed(
             &cos_owner_worker_by_queue,
             &shared_cos_owner_worker_by_queue,
@@ -1500,6 +1505,7 @@ pub(crate) fn worker_loop(
                 idx,
                 &mut bindings,
                 &binding_lookup,
+                mirror_targets.as_ref(),
                 &mut sessions,
                 &mut screen_state,
                 validation,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -2406,6 +2406,8 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) mirror_drops_tx_frame_reserve: u64,
     pub(crate) mirror_drops_no_binding: u64,
     pub(crate) mirror_drops_queue_full: u64,
+    pub(crate) mirror_drops_queue_full_same_worker: u64,
+    pub(crate) mirror_drops_queue_full_cross_worker: u64,
     // #760 triage: surfaced on BindingStatus so operators can
     // compare binding-level vs per-queue drain accounting.
     pub(crate) post_drain_backup_bytes: u64,

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -724,6 +724,8 @@ fn binding_counters_snapshot_projects_ring_pressure_fields() {
         tx_shared_recycle_unknown_slot_drops: 43,
         tx_submit_error_drops: 31,
         pending_tx_local_overflow_drops: 37,
+        mirror_drops_queue_full_same_worker: 47,
+        mirror_drops_queue_full_cross_worker: 49,
         // #918 / #943: pin per-set LRU collision and V_min telemetry
         // through the projection so a future refactor that drops
         // either assignment surfaces here.
@@ -751,6 +753,8 @@ fn binding_counters_snapshot_projects_ring_pressure_fields() {
     assert_eq!(snap.tx_shared_recycle_unknown_slot_drops, 43);
     assert_eq!(snap.tx_submit_error_drops, 31);
     assert_eq!(snap.pending_tx_local_overflow_drops, 37);
+    assert_eq!(snap.mirror_drops_queue_full_same_worker, 47);
+    assert_eq!(snap.mirror_drops_queue_full_cross_worker, 49);
     assert_eq!(snap.flow_cache_collision_evictions, 53);
     // #1219: pin active_flow_count projection through the From impl.
     assert_eq!(snap.active_flow_count, 71);
@@ -790,6 +794,8 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         mirror_drops_tx_frame_reserve: 35,
         mirror_drops_no_binding: 36,
         mirror_drops_queue_full: 37,
+        mirror_drops_queue_full_same_worker: 38,
+        mirror_drops_queue_full_cross_worker: 39,
         // #812: populated so wire-key assertions below also cover
         // the new TX submit-latency fields.
         tx_submit_latency_hist: vec![13, 14, 15],
@@ -847,6 +853,8 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         "mirror_drops_tx_frame_reserve",
         "mirror_drops_no_binding",
         "mirror_drops_queue_full",
+        "mirror_drops_queue_full_same_worker",
+        "mirror_drops_queue_full_cross_worker",
         // #812: new wire keys — absence from BindingCountersSnapshot
         // JSON breaks the Go-side step1-capture consumer.
         "tx_submit_latency_hist",
@@ -1097,6 +1105,8 @@ fn tx_latency_hist_serialization_roundtrip() {
         mirror_drops_tx_frame_reserve: 0,
         mirror_drops_no_binding: 0,
         mirror_drops_queue_full: 0,
+        mirror_drops_queue_full_same_worker: 0,
+        mirror_drops_queue_full_cross_worker: 0,
         // Hand-built plausible histogram — bucket 0 heavy,
         // tail in buckets 6-7, saturation bucket 15 empty.
         tx_submit_latency_hist: vec![9001, 123, 45, 30, 12, 4, 8, 2, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -787,8 +787,9 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         mirrored_packets: 32,
         mirrored_bytes: 33,
         mirror_drops_no_frame: 34,
-        mirror_drops_no_binding: 35,
-        mirror_drops_queue_full: 36,
+        mirror_drops_tx_frame_reserve: 35,
+        mirror_drops_no_binding: 36,
+        mirror_drops_queue_full: 37,
         // #812: populated so wire-key assertions below also cover
         // the new TX submit-latency fields.
         tx_submit_latency_hist: vec![13, 14, 15],
@@ -843,6 +844,7 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         "mirrored_packets",
         "mirrored_bytes",
         "mirror_drops_no_frame",
+        "mirror_drops_tx_frame_reserve",
         "mirror_drops_no_binding",
         "mirror_drops_queue_full",
         // #812: new wire keys — absence from BindingCountersSnapshot
@@ -1092,6 +1094,7 @@ fn tx_latency_hist_serialization_roundtrip() {
         mirrored_packets: 0,
         mirrored_bytes: 0,
         mirror_drops_no_frame: 0,
+        mirror_drops_tx_frame_reserve: 0,
         mirror_drops_no_binding: 0,
         mirror_drops_queue_full: 0,
         // Hand-built plausible histogram — bucket 0 heavy,

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -784,6 +784,11 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         tx_shared_recycle_unknown_slot_drops: 14,
         tx_submit_error_drops: 10,
         pending_tx_local_overflow_drops: 11,
+        mirrored_packets: 32,
+        mirrored_bytes: 33,
+        mirror_drops_no_frame: 34,
+        mirror_drops_no_binding: 35,
+        mirror_drops_queue_full: 36,
         // #812: populated so wire-key assertions below also cover
         // the new TX submit-latency fields.
         tx_submit_latency_hist: vec![13, 14, 15],
@@ -835,6 +840,11 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
         "tx_shared_recycle_unknown_slot_drops",
         "tx_submit_error_drops",
         "pending_tx_local_overflow_drops",
+        "mirrored_packets",
+        "mirrored_bytes",
+        "mirror_drops_no_frame",
+        "mirror_drops_no_binding",
+        "mirror_drops_queue_full",
         // #812: new wire keys — absence from BindingCountersSnapshot
         // JSON breaks the Go-side step1-capture consumer.
         "tx_submit_latency_hist",
@@ -1079,6 +1089,11 @@ fn tx_latency_hist_serialization_roundtrip() {
         tx_shared_recycle_unknown_slot_drops: 0,
         tx_submit_error_drops: 0,
         pending_tx_local_overflow_drops: 0,
+        mirrored_packets: 0,
+        mirrored_bytes: 0,
+        mirror_drops_no_frame: 0,
+        mirror_drops_no_binding: 0,
+        mirror_drops_queue_full: 0,
         // Hand-built plausible histogram — bucket 0 heavy,
         // tail in buckets 6-7, saturation bucket 15 empty.
         tx_submit_latency_hist: vec![9001, 123, 45, 30, 12, 4, 8, 2, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1558,6 +1558,16 @@ pub(crate) struct BindingStatus {
     // the flow-fair admission / redirect-inbox / pending-FIFO drops.
     #[serde(rename = "tx_submit_error_drops", default)]
     pub tx_submit_error_drops: u64,
+    #[serde(rename = "mirrored_packets", default)]
+    pub mirrored_packets: u64,
+    #[serde(rename = "mirrored_bytes", default)]
+    pub mirrored_bytes: u64,
+    #[serde(rename = "mirror_drops_no_frame", default)]
+    pub mirror_drops_no_frame: u64,
+    #[serde(rename = "mirror_drops_no_binding", default)]
+    pub mirror_drops_no_binding: u64,
+    #[serde(rename = "mirror_drops_queue_full", default)]
+    pub mirror_drops_queue_full: u64,
     // #760 instrumentation: post-CoS backup transmit bytes
     // (drain_pending_tx fallbacks (tx/drain.rs::drain_pending_tx)) that bypass
     // any CoS queue's token gate.
@@ -1820,6 +1830,16 @@ pub(crate) struct BindingCountersSnapshot {
     pub tx_submit_error_drops: u64,
     #[serde(rename = "pending_tx_local_overflow_drops", default)]
     pub pending_tx_local_overflow_drops: u64,
+    #[serde(rename = "mirrored_packets", default)]
+    pub mirrored_packets: u64,
+    #[serde(rename = "mirrored_bytes", default)]
+    pub mirrored_bytes: u64,
+    #[serde(rename = "mirror_drops_no_frame", default)]
+    pub mirror_drops_no_frame: u64,
+    #[serde(rename = "mirror_drops_no_binding", default)]
+    pub mirror_drops_no_binding: u64,
+    #[serde(rename = "mirror_drops_queue_full", default)]
+    pub mirror_drops_queue_full: u64,
     // #812: TX submit→completion latency histogram, pulled through
     // from BindingStatus so step1-capture consumers can compute
     // per-queue latency distributions without a second join.
@@ -1918,6 +1938,11 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             tx_shared_recycle_unknown_slot_drops: b.tx_shared_recycle_unknown_slot_drops,
             tx_submit_error_drops: b.tx_submit_error_drops,
             pending_tx_local_overflow_drops: b.pending_tx_local_overflow_drops,
+            mirrored_packets: b.mirrored_packets,
+            mirrored_bytes: b.mirrored_bytes,
+            mirror_drops_no_frame: b.mirror_drops_no_frame,
+            mirror_drops_no_binding: b.mirror_drops_no_binding,
+            mirror_drops_queue_full: b.mirror_drops_queue_full,
             // #812: clone the histogram Vec<u64> by value (owned
             // copy). Avoids any shared-reference aliasing against
             // the `BindingStatus` owner and satisfies the
@@ -2282,6 +2307,64 @@ mod tests {
         assert_eq!(
             snap.tx_completion_ring_available_max,
             status.tx_completion_ring_available_max
+        );
+    }
+
+    #[test]
+    fn mirror_counters_binding_status_wire_roundtrip_and_projection() {
+        let status = BindingStatus {
+            worker_id: 7,
+            slot: 1,
+            ifindex: 11,
+            queue_id: 2,
+            mirrored_packets: 5,
+            mirrored_bytes: 640,
+            mirror_drops_no_frame: 1,
+            mirror_drops_no_binding: 2,
+            mirror_drops_queue_full: 3,
+            ..Default::default()
+        };
+
+        let value: serde_json::Value =
+            serde_json::to_value(&status).expect("serialize BindingStatus to Value");
+        let obj = value
+            .as_object()
+            .expect("BindingStatus serializes as a JSON object");
+        for key in [
+            "mirrored_packets",
+            "mirrored_bytes",
+            "mirror_drops_no_frame",
+            "mirror_drops_no_binding",
+            "mirror_drops_queue_full",
+        ] {
+            assert!(
+                obj.contains_key(key),
+                "BindingStatus wire key `{key}` missing: {value}"
+            );
+        }
+
+        let json = serde_json::to_string(&status).expect("serialize BindingStatus");
+        let back: BindingStatus = serde_json::from_str(&json).expect("deserialize BindingStatus");
+        assert_eq!(back.mirrored_packets, status.mirrored_packets);
+        assert_eq!(back.mirrored_bytes, status.mirrored_bytes);
+        assert_eq!(back.mirror_drops_no_frame, status.mirror_drops_no_frame);
+        assert_eq!(
+            back.mirror_drops_no_binding,
+            status.mirror_drops_no_binding
+        );
+        assert_eq!(back.mirror_drops_queue_full, status.mirror_drops_queue_full);
+
+        let snap: BindingCountersSnapshot = (&status).into();
+        assert_eq!(snap.mirrored_packets, status.mirrored_packets);
+        assert_eq!(snap.mirrored_bytes, status.mirrored_bytes);
+        assert_eq!(snap.mirror_drops_no_frame, status.mirror_drops_no_frame);
+        assert_eq!(
+            snap.mirror_drops_no_binding,
+            status.mirror_drops_no_binding
+        );
+        assert_eq!(
+            snap.mirror_drops_queue_full,
+            status.mirror_drops_queue_full
         );
     }
 

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1564,6 +1564,8 @@ pub(crate) struct BindingStatus {
     pub mirrored_bytes: u64,
     #[serde(rename = "mirror_drops_no_frame", default)]
     pub mirror_drops_no_frame: u64,
+    #[serde(rename = "mirror_drops_tx_frame_reserve", default)]
+    pub mirror_drops_tx_frame_reserve: u64,
     #[serde(rename = "mirror_drops_no_binding", default)]
     pub mirror_drops_no_binding: u64,
     #[serde(rename = "mirror_drops_queue_full", default)]
@@ -1836,6 +1838,8 @@ pub(crate) struct BindingCountersSnapshot {
     pub mirrored_bytes: u64,
     #[serde(rename = "mirror_drops_no_frame", default)]
     pub mirror_drops_no_frame: u64,
+    #[serde(rename = "mirror_drops_tx_frame_reserve", default)]
+    pub mirror_drops_tx_frame_reserve: u64,
     #[serde(rename = "mirror_drops_no_binding", default)]
     pub mirror_drops_no_binding: u64,
     #[serde(rename = "mirror_drops_queue_full", default)]
@@ -1941,6 +1945,7 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             mirrored_packets: b.mirrored_packets,
             mirrored_bytes: b.mirrored_bytes,
             mirror_drops_no_frame: b.mirror_drops_no_frame,
+            mirror_drops_tx_frame_reserve: b.mirror_drops_tx_frame_reserve,
             mirror_drops_no_binding: b.mirror_drops_no_binding,
             mirror_drops_queue_full: b.mirror_drops_queue_full,
             // #812: clone the histogram Vec<u64> by value (owned
@@ -2320,8 +2325,9 @@ mod tests {
             mirrored_packets: 5,
             mirrored_bytes: 640,
             mirror_drops_no_frame: 1,
-            mirror_drops_no_binding: 2,
-            mirror_drops_queue_full: 3,
+            mirror_drops_tx_frame_reserve: 2,
+            mirror_drops_no_binding: 3,
+            mirror_drops_queue_full: 4,
             ..Default::default()
         };
 
@@ -2334,6 +2340,7 @@ mod tests {
             "mirrored_packets",
             "mirrored_bytes",
             "mirror_drops_no_frame",
+            "mirror_drops_tx_frame_reserve",
             "mirror_drops_no_binding",
             "mirror_drops_queue_full",
         ] {
@@ -2349,9 +2356,10 @@ mod tests {
         assert_eq!(back.mirrored_bytes, status.mirrored_bytes);
         assert_eq!(back.mirror_drops_no_frame, status.mirror_drops_no_frame);
         assert_eq!(
-            back.mirror_drops_no_binding,
-            status.mirror_drops_no_binding
+            back.mirror_drops_tx_frame_reserve,
+            status.mirror_drops_tx_frame_reserve
         );
+        assert_eq!(back.mirror_drops_no_binding, status.mirror_drops_no_binding);
         assert_eq!(back.mirror_drops_queue_full, status.mirror_drops_queue_full);
 
         let snap: BindingCountersSnapshot = (&status).into();
@@ -2359,13 +2367,11 @@ mod tests {
         assert_eq!(snap.mirrored_bytes, status.mirrored_bytes);
         assert_eq!(snap.mirror_drops_no_frame, status.mirror_drops_no_frame);
         assert_eq!(
-            snap.mirror_drops_no_binding,
-            status.mirror_drops_no_binding
+            snap.mirror_drops_tx_frame_reserve,
+            status.mirror_drops_tx_frame_reserve
         );
-        assert_eq!(
-            snap.mirror_drops_queue_full,
-            status.mirror_drops_queue_full
-        );
+        assert_eq!(snap.mirror_drops_no_binding, status.mirror_drops_no_binding);
+        assert_eq!(snap.mirror_drops_queue_full, status.mirror_drops_queue_full);
     }
 
     // #943 Copilot round-2 finding #3: the rich BindingStatus wire

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -1570,6 +1570,10 @@ pub(crate) struct BindingStatus {
     pub mirror_drops_no_binding: u64,
     #[serde(rename = "mirror_drops_queue_full", default)]
     pub mirror_drops_queue_full: u64,
+    #[serde(rename = "mirror_drops_queue_full_same_worker", default)]
+    pub mirror_drops_queue_full_same_worker: u64,
+    #[serde(rename = "mirror_drops_queue_full_cross_worker", default)]
+    pub mirror_drops_queue_full_cross_worker: u64,
     // #760 instrumentation: post-CoS backup transmit bytes
     // (drain_pending_tx fallbacks (tx/drain.rs::drain_pending_tx)) that bypass
     // any CoS queue's token gate.
@@ -1844,6 +1848,10 @@ pub(crate) struct BindingCountersSnapshot {
     pub mirror_drops_no_binding: u64,
     #[serde(rename = "mirror_drops_queue_full", default)]
     pub mirror_drops_queue_full: u64,
+    #[serde(rename = "mirror_drops_queue_full_same_worker", default)]
+    pub mirror_drops_queue_full_same_worker: u64,
+    #[serde(rename = "mirror_drops_queue_full_cross_worker", default)]
+    pub mirror_drops_queue_full_cross_worker: u64,
     // #812: TX submit→completion latency histogram, pulled through
     // from BindingStatus so step1-capture consumers can compute
     // per-queue latency distributions without a second join.
@@ -1948,6 +1956,8 @@ impl From<&BindingStatus> for BindingCountersSnapshot {
             mirror_drops_tx_frame_reserve: b.mirror_drops_tx_frame_reserve,
             mirror_drops_no_binding: b.mirror_drops_no_binding,
             mirror_drops_queue_full: b.mirror_drops_queue_full,
+            mirror_drops_queue_full_same_worker: b.mirror_drops_queue_full_same_worker,
+            mirror_drops_queue_full_cross_worker: b.mirror_drops_queue_full_cross_worker,
             // #812: clone the histogram Vec<u64> by value (owned
             // copy). Avoids any shared-reference aliasing against
             // the `BindingStatus` owner and satisfies the


### PR DESCRIPTION
## Summary

Refs #1376.

Adds a bounded forwarded-path port-mirror runtime slice for the userspace dataplane:

- wires mirror config into `ForwardingState`
- samples per ingress binding and clones the full L2 frame while original bytes are still available
- queues the clone as a discardable prepared TX request to the configured output binding
- keeps clone pressure lossy via TX-frame reserve and pending-backlog limit
- records admitted/no-frame/no-binding/queue-full mirror counters through Rust status, Go protocol, and Go status formatting

This intentionally leaves the userspace capability gate in place. Full #1376 closure still needs ingress/transmit-path parity beyond pending-forward TX, prebuilt/deferred path coverage, tcpdump validation on the mirror output, and pressure evidence proving mirror load does not hurt primary forwarding.

## Validation

- `go test ./pkg/dataplane/userspace`
- `cargo test --manifest-path userspace-dp/Cargo.toml mirror::`
- `cargo test --manifest-path userspace-dp/Cargo.toml binding_counters_snapshot_serializes_with_expected_wire_keys`
- `cargo test --manifest-path userspace-dp/Cargo.toml config_snapshot_mirror_configs_roundtrip`
- `cargo test --manifest-path userspace-dp/Cargo.toml mirror_counters_binding_status_wire_roundtrip_and_projection`
- `git diff --check`
