### PR TITLE
Pin userspace buffer denominator contract

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
@@ -37,10 +37,13 @@ The current helper status does not publish capacity denominators for the
 session table, dynamic neighbor cache, or per-worker flow cache. `show system
 buffers` therefore reports active sessions through the existing footer and
 renders neighbor/flow-cache pressure as counts/counters, not fill percentages.
-Adding true fill rows for those structures requires new optional helper fields
-such as `session_table_entries/max_sessions`, `flow_cache_capacity`, and
+This is now the Phase 5 contract, not an undecided gap: adding true fill rows
+for those structures requires new optional helper fields such as
+`session_table_entries/max_sessions`, `flow_cache_capacity`, and
 `neighbor_cache_capacity`; Go must not hard-code Rust private constants to infer
-those denominators.
+those denominators. `TestFormatSystemBuffersKeepsDynamicCountsOutOfUtilizationTable`
+pins the contract so dynamic counts cannot drift into the utilization table
+without real denominators.
 
 ## Hot-Path Invariants
 
@@ -80,7 +83,9 @@ those denominators.
 - Go: gRPC `ShowText` and local CLI use the same userspace buffer fixture and
   produce equivalent text.
 - Go: formatter covers CoS queued-byte capacity plus existing helper pressure
-  counters without turning unbounded counts into utilization percentages.
+  counters without turning unbounded counts into utilization percentages; the
+  dynamic-count regression test must fail if neighbor/flow-cache counters gain
+  a `Usage%` row before helper capacity fields exist.
 - Integration: userspace cluster under forwarding load shows nonzero AF_XDP
   capacities, stable active sessions, and no status command hang.
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -74,7 +74,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. The manager still holds a named eBPF shim manager for XDP/map bootstrap state; tracked by #1381 |
 | Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, and filter-log frame types, RT_FLOW codec/Go decode, and Rust non-blocking producer/rate-limit/loss-accounting infrastructure are present; runtime producer call sites and end-to-end syslog evidence remain tracked by #1379. |
-| `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, active-session footer, neighbor/flow-cache counts, and worker queue pressure counters. #1380 is narrowed to the Phase 5 cleanup decision about whether operators need new helper capacity denominators for session-table, flow-cache, or neighbor-cache fill percentages before the legacy BPF-map surface is removed. |
+| `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, active-session footer, neighbor/flow-cache counts, and worker queue pressure counters. The Phase 5 denominator decision is explicit: session-table, flow-cache, and neighbor-cache values remain counters, not fill percentages, until the helper publishes bounded capacity fields. A formatter test pins that these dynamic counts cannot move into the utilization table without real denominators. |
 
 ## Retirement Blockers From The 2026-05-16 Audit
 
@@ -89,7 +89,7 @@ The current #1373 audit produced these tracked blockers:
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393 and the 2026-05-17 runtime slice cover deterministic cookie codec/layout, snapshot propagation, fail-closed screen challenge selection, session-miss ACK validation, and a bounded validated-client cache. Lower-layer coverage in `userspace-dp/src/screen_tests.rs` pins 4-way validated-client cache replacement; poll-stage tests only pin the operational invalid-ACK drop/bypass semantics. Remaining: validated-client cache expiration semantics, secret-epoch rotation, bounded SYN-ACK TX, ACK RST emission, HA-safe secret publication/cache survivability, counters/status, integration/failover validation, and userspace capability gate removal. | Phase 4 BPF source removal |
 | #1375 | Finish userspace RFC 2697/2698 three-color policer hardening: sharded/packed state decision, cross-snapshot counter continuity decision, non-drop color action handling, and integration/failover/performance evidence | Phase 4 BPF source removal |
 | #1376 | Implement userspace port mirroring or explicitly retire the feature | Phase 4 BPF source removal |
-| #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface. Userspace now renders the bounded helper status that exists; only optional new helper capacity denominators for session-table / flow-cache / neighbor-cache fill remain undecided. | Phase 5 CLI / observability cleanup |
+| #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface. Userspace now renders the bounded helper status that exists and intentionally keeps session-table / flow-cache / neighbor-cache as counters rather than synthetic utilization rows until the helper exports true capacity fields. | Phase 5 CLI / observability cleanup |
 
 Recommended dependency order:
 
@@ -155,7 +155,7 @@ The highest-value remaining work on current `master` is:
    hardening/evidence checklist. The three-color capability gate is removed
    only for the current color-blind `then discard` slice; color-aware and
    non-drop treatments stay fail-closed.
-4. carry the narrowed #1380 denominator decision into Phase 5; the current
-   userspace command already avoids BPF-map fallback when helper status is
-   available
+4. carry #1380 into Phase 5 only if operators need new helper capacity fields;
+   the current userspace command already avoids BPF-map fallback when helper
+   status is available and does not synthesize percentages for dynamic tables
 5. continue correctness and performance hardening on the active AF_XDP fast path

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -6,6 +6,30 @@ import (
 	"strings"
 )
 
+const (
+	systemBufferUtilizationHeading = "Userspace Buffer Utilization:"
+	systemBufferCountersHeading    = "Userspace Status Counters:"
+
+	systemBufferLabelAFXDPUMEMFrames       = "AF_XDP UMEM frames"
+	systemBufferLabelAFXDPTXRing           = "AF_XDP TX ring"
+	systemBufferLabelCoSQueueBytes         = "CoS queue bytes"
+	systemBufferLabelNeighborCacheEntries  = "Neighbor cache entries"
+	systemBufferLabelFlowCacheActiveFlows  = "Flow cache active flows"
+	systemBufferLabelFlowCacheEvictions    = "Flow cache collision evict"
+	systemBufferLabelPendingFillFrames     = "Pending fill frames"
+	systemBufferLabelSpareFillFrames       = "Spare fill frames"
+	systemBufferLabelPendingTXPrepared     = "Pending TX prepared"
+	systemBufferLabelPendingTXLocal        = "Pending TX local"
+	systemBufferLabelTXRingFullEvents      = "TX ring full events"
+	systemBufferLabelSendtoENOBUFS         = "sendto ENOBUFS"
+	systemBufferLabelBoundPendingOverflow  = "Bound pending overflow"
+	systemBufferLabelCoSQueueOverflow      = "CoS queue overflow"
+	systemBufferLabelRXFillRingEmptyDescs  = "RX fill-ring empty descs"
+	systemBufferLabelRedirectInboxOverflow = "Redirect inbox overflow"
+	systemBufferLabelPendingTXLocalOver    = "Pending TX local overflow"
+	systemBufferLabelTXSubmitErrorDrops    = "TX submit error drops"
+)
+
 type systemBufferSample struct {
 	Slot                        uint32
 	HasSlot                     bool
@@ -70,7 +94,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	var rows []systemBufferRow
 	if knownUMEM > 0 {
 		rows = append(rows, systemBufferRow{
-			Name:     "AF_XDP UMEM frames",
+			Name:     systemBufferLabelAFXDPUMEMFrames,
 			Scope:    fmt.Sprintf("aggregate/%d", knownUMEM),
 			Capacity: umemCap,
 			Used:     umemUsed,
@@ -78,7 +102,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	}
 	if knownTX > 0 {
 		rows = append(rows, systemBufferRow{
-			Name:     "AF_XDP TX ring",
+			Name:     systemBufferLabelAFXDPTXRing,
 			Scope:    fmt.Sprintf("aggregate/%d", knownTX),
 			Capacity: txCap,
 			Used:     txUsed,
@@ -90,7 +114,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 			scope := systemBufferSampleScope(sample)
 			if sample.UMEMCap > 0 {
 				rows = append(rows, systemBufferRow{
-					Name:     "AF_XDP UMEM frames",
+					Name:     systemBufferLabelAFXDPUMEMFrames,
 					Scope:    scope,
 					Capacity: uint64(sample.UMEMCap),
 					Used:     uint64(sample.UMEMUsed),
@@ -98,7 +122,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 			}
 			if sample.TXRingCap > 0 {
 				rows = append(rows, systemBufferRow{
-					Name:     "AF_XDP TX ring",
+					Name:     systemBufferLabelAFXDPTXRing,
 					Scope:    scope,
 					Capacity: uint64(sample.TXRingCap),
 					Used:     uint64(sample.TXRingUsed),
@@ -109,7 +133,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	counterRows := systemBufferCounterRows(status, samples, detail)
 
 	var b strings.Builder
-	b.WriteString("Userspace Buffer Utilization:\n")
+	b.WriteString(systemBufferUtilizationHeading + "\n")
 	if len(rows) == 0 {
 		b.WriteString("  unavailable: helper status does not include bounded AF_XDP capacity gauges\n")
 		b.WriteString("  required status fields: per_binding[].umem_total_frames, per_binding[].umem_inflight_frames, per_binding[].tx_ring_capacity, per_binding[].outstanding_tx\n")
@@ -145,7 +169,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 		if !strings.HasSuffix(b.String(), "\n\n") {
 			b.WriteString("\n")
 		}
-		b.WriteString("Userspace Status Counters:\n")
+		b.WriteString(systemBufferCountersHeading + "\n")
 		fmt.Fprintf(&b, "%-32s %-24s %12s\n", "Counter", "Scope", "Value")
 		b.WriteString(strings.Repeat("-", 70) + "\n")
 		for _, row := range counterRows {
@@ -173,7 +197,7 @@ func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {
 		return rows
 	}
 	rows = append(rows, systemBufferRow{
-		Name:     "CoS queue bytes",
+		Name:     systemBufferLabelCoSQueueBytes,
 		Scope:    fmt.Sprintf("aggregate/%d", queueCount),
 		Capacity: aggregateCap,
 		Used:     aggregateUsed,
@@ -187,7 +211,7 @@ func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {
 				continue
 			}
 			rows = append(rows, systemBufferRow{
-				Name:     "CoS queue bytes",
+				Name:     systemBufferLabelCoSQueueBytes,
 				Scope:    systemBufferCoSQueueScope(iface, queue),
 				Capacity: queue.BufferBytes,
 				Used:     queue.QueuedBytes,
@@ -235,41 +259,41 @@ func systemBufferCounterRows(status ProcessStatus, samples []systemBufferSample,
 			rows = append(rows, systemBufferCounterRow{Name: name, Scope: scope, Value: value})
 		}
 	}
-	appendCounter("Neighbor cache entries", "dynamic", uint64(status.NeighborEntries))
-	appendCounter("Flow cache active flows", "active window", activeFlowCount)
-	appendCounter("Flow cache collision evict", "aggregate", flowCacheCollisionEvictions)
-	appendCounter("Pending fill frames", "aggregate", debugPendingFillFrames)
-	appendCounter("Spare fill frames", "aggregate", debugSpareFillFrames)
-	appendCounter("Pending TX prepared", "aggregate", debugPendingTXPrepared)
-	appendCounter("Pending TX local", "aggregate", debugPendingTXLocal)
-	appendCounter("TX ring full events", "aggregate", dbgTxRingFull)
-	appendCounter("sendto ENOBUFS", "aggregate", dbgSendtoENOBUFS)
-	appendCounter("Bound pending overflow", "aggregate", dbgBoundPendingOverflow)
-	appendCounter("CoS queue overflow", "aggregate", dbgCoSQueueOverflow)
-	appendCounter("RX fill-ring empty descs", "aggregate", rxFillRingEmptyDescs)
-	appendCounter("Redirect inbox overflow", "aggregate", redirectInboxOverflowDrops)
-	appendCounter("Pending TX local overflow", "aggregate", pendingTXLocalOverflowDrops)
-	appendCounter("TX submit error drops", "aggregate", txSubmitErrorDrops)
+	appendCounter(systemBufferLabelNeighborCacheEntries, "dynamic", uint64(status.NeighborEntries))
+	appendCounter(systemBufferLabelFlowCacheActiveFlows, "active window", activeFlowCount)
+	appendCounter(systemBufferLabelFlowCacheEvictions, "aggregate", flowCacheCollisionEvictions)
+	appendCounter(systemBufferLabelPendingFillFrames, "aggregate", debugPendingFillFrames)
+	appendCounter(systemBufferLabelSpareFillFrames, "aggregate", debugSpareFillFrames)
+	appendCounter(systemBufferLabelPendingTXPrepared, "aggregate", debugPendingTXPrepared)
+	appendCounter(systemBufferLabelPendingTXLocal, "aggregate", debugPendingTXLocal)
+	appendCounter(systemBufferLabelTXRingFullEvents, "aggregate", dbgTxRingFull)
+	appendCounter(systemBufferLabelSendtoENOBUFS, "aggregate", dbgSendtoENOBUFS)
+	appendCounter(systemBufferLabelBoundPendingOverflow, "aggregate", dbgBoundPendingOverflow)
+	appendCounter(systemBufferLabelCoSQueueOverflow, "aggregate", dbgCoSQueueOverflow)
+	appendCounter(systemBufferLabelRXFillRingEmptyDescs, "aggregate", rxFillRingEmptyDescs)
+	appendCounter(systemBufferLabelRedirectInboxOverflow, "aggregate", redirectInboxOverflowDrops)
+	appendCounter(systemBufferLabelPendingTXLocalOver, "aggregate", pendingTXLocalOverflowDrops)
+	appendCounter(systemBufferLabelTXSubmitErrorDrops, "aggregate", txSubmitErrorDrops)
 
 	if !detail {
 		return rows
 	}
 	for _, sample := range samples {
 		scope := systemBufferSampleScope(sample)
-		appendCounter("Flow cache active flows", scope, uint64(sample.ActiveFlowCount))
-		appendCounter("Flow cache collision evict", scope, sample.FlowCacheCollisionEvictions)
-		appendCounter("Pending fill frames", scope, uint64(sample.DebugPendingFillFrames))
-		appendCounter("Spare fill frames", scope, uint64(sample.DebugSpareFillFrames))
-		appendCounter("Pending TX prepared", scope, uint64(sample.DebugPendingTXPrepared))
-		appendCounter("Pending TX local", scope, uint64(sample.DebugPendingTXLocal))
-		appendCounter("TX ring full events", scope, sample.DbgTxRingFull)
-		appendCounter("sendto ENOBUFS", scope, sample.DbgSendtoENOBUFS)
-		appendCounter("Bound pending overflow", scope, sample.DbgBoundPendingOverflow)
-		appendCounter("CoS queue overflow", scope, sample.DbgCoSQueueOverflow)
-		appendCounter("RX fill-ring empty descs", scope, sample.RxFillRingEmptyDescs)
-		appendCounter("Redirect inbox overflow", scope, sample.RedirectInboxOverflowDrops)
-		appendCounter("Pending TX local overflow", scope, sample.PendingTXLocalOverflowDrops)
-		appendCounter("TX submit error drops", scope, sample.TxSubmitErrorDrops)
+		appendCounter(systemBufferLabelFlowCacheActiveFlows, scope, uint64(sample.ActiveFlowCount))
+		appendCounter(systemBufferLabelFlowCacheEvictions, scope, sample.FlowCacheCollisionEvictions)
+		appendCounter(systemBufferLabelPendingFillFrames, scope, uint64(sample.DebugPendingFillFrames))
+		appendCounter(systemBufferLabelSpareFillFrames, scope, uint64(sample.DebugSpareFillFrames))
+		appendCounter(systemBufferLabelPendingTXPrepared, scope, uint64(sample.DebugPendingTXPrepared))
+		appendCounter(systemBufferLabelPendingTXLocal, scope, uint64(sample.DebugPendingTXLocal))
+		appendCounter(systemBufferLabelTXRingFullEvents, scope, sample.DbgTxRingFull)
+		appendCounter(systemBufferLabelSendtoENOBUFS, scope, sample.DbgSendtoENOBUFS)
+		appendCounter(systemBufferLabelBoundPendingOverflow, scope, sample.DbgBoundPendingOverflow)
+		appendCounter(systemBufferLabelCoSQueueOverflow, scope, sample.DbgCoSQueueOverflow)
+		appendCounter(systemBufferLabelRXFillRingEmptyDescs, scope, sample.RxFillRingEmptyDescs)
+		appendCounter(systemBufferLabelRedirectInboxOverflow, scope, sample.RedirectInboxOverflowDrops)
+		appendCounter(systemBufferLabelPendingTXLocalOver, scope, sample.PendingTXLocalOverflowDrops)
+		appendCounter(systemBufferLabelTXSubmitErrorDrops, scope, sample.TxSubmitErrorDrops)
 	}
 	return rows
 }

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -19,9 +19,9 @@ func TestFormatSystemBuffersUsesPerBindingAggregatesBeforeDetails(t *testing.T) 
 
 	out := FormatSystemBuffers(status, true)
 	for _, want := range []string{
-		"Userspace Buffer Utilization:",
-		"AF_XDP UMEM frames",
-		"AF_XDP TX ring",
+		systemBufferUtilizationHeading,
+		systemBufferLabelAFXDPUMEMFrames,
+		systemBufferLabelAFXDPTXRing,
 		"aggregate/2",
 		"2000",
 		"900",
@@ -54,7 +54,7 @@ func TestFormatSystemBuffersFallsBackToBindingsAndWarnsAtEighty(t *testing.T) {
 
 	out := FormatSystemBuffers(status, false)
 	for _, want := range []string{
-		"AF_XDP UMEM frames",
+		systemBufferLabelAFXDPUMEMFrames,
 		"aggregate/1",
 		"80.0% WARNING",
 	} {
@@ -187,27 +187,27 @@ func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 
 	out := FormatSystemBuffers(status, true)
 	for _, want := range []string{
-		"CoS queue bytes",
+		systemBufferLabelCoSQueueBytes,
 		"aggregate/1",
 		"850",
 		"85.0% WARNING",
 		"ge-0-0-9/queue 2/ef/worker 2",
-		"Userspace Status Counters:",
-		"Neighbor cache entries",
-		"Flow cache active flows",
-		"Flow cache collision evict",
-		"Pending fill frames",
-		"Spare fill frames",
-		"Pending TX prepared",
-		"Pending TX local",
-		"TX ring full events",
-		"sendto ENOBUFS",
-		"Bound pending overflow",
-		"CoS queue overflow",
-		"RX fill-ring empty descs",
-		"Redirect inbox overflow",
-		"Pending TX local overflow",
-		"TX submit error drops",
+		systemBufferCountersHeading,
+		systemBufferLabelNeighborCacheEntries,
+		systemBufferLabelFlowCacheActiveFlows,
+		systemBufferLabelFlowCacheEvictions,
+		systemBufferLabelPendingFillFrames,
+		systemBufferLabelSpareFillFrames,
+		systemBufferLabelPendingTXPrepared,
+		systemBufferLabelPendingTXLocal,
+		systemBufferLabelTXRingFullEvents,
+		systemBufferLabelSendtoENOBUFS,
+		systemBufferLabelBoundPendingOverflow,
+		systemBufferLabelCoSQueueOverflow,
+		systemBufferLabelRXFillRingEmptyDescs,
+		systemBufferLabelRedirectInboxOverflow,
+		systemBufferLabelPendingTXLocalOver,
+		systemBufferLabelTXSubmitErrorDrops,
 		"worker 2/queue 7/slot 4/ge-0-0-9",
 	} {
 		if !strings.Contains(out, want) {
@@ -228,12 +228,12 @@ func TestFormatSystemBuffersKeepsDynamicCountsOutOfUtilizationTable(t *testing.T
 	}
 
 	out := FormatSystemBuffers(status, false)
-	sections := strings.SplitN(out, "Userspace Status Counters:", 2)
+	sections := strings.SplitN(out, systemBufferCountersHeading, 2)
 	if len(sections) != 2 {
 		t.Fatalf("FormatSystemBuffers missing status counter section:\n%s", out)
 	}
 	utilSection, counterSection := sections[0], sections[1]
-	for _, dynamic := range []string{"Neighbor cache entries", "Flow cache active flows"} {
+	for _, dynamic := range []string{systemBufferLabelNeighborCacheEntries, systemBufferLabelFlowCacheActiveFlows} {
 		if strings.Contains(utilSection, dynamic) {
 			t.Fatalf("%s appeared in utilization table without a bounded capacity:\n%s", dynamic, out)
 		}
@@ -262,7 +262,7 @@ func TestFormatSystemBuffersCoSAggregateSumsCapacityWithUsage(t *testing.T) {
 
 	out := FormatSystemBuffers(status, false)
 	for _, want := range []string{
-		"CoS queue bytes",
+		systemBufferLabelCoSQueueBytes,
 		"aggregate/2",
 		"2000",
 		"800",

--- a/pkg/dataplane/userspace/buffersfmt_test.go
+++ b/pkg/dataplane/userspace/buffersfmt_test.go
@@ -216,6 +216,36 @@ func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 	}
 }
 
+func TestFormatSystemBuffersKeepsDynamicCountsOutOfUtilizationTable(t *testing.T) {
+	status := ProcessStatus{
+		NeighborEntries: 42,
+		Bindings: []BindingStatus{
+			{Slot: 1, WorkerID: 0, QueueID: 0, Interface: "ge-0-0-0", UmemTotalFrames: 1000, UmemInflightFrames: 250},
+		},
+		PerBinding: []BindingCountersSnapshot{
+			{WorkerID: 0, QueueID: 0, ActiveFlowCount: 128},
+		},
+	}
+
+	out := FormatSystemBuffers(status, false)
+	sections := strings.SplitN(out, "Userspace Status Counters:", 2)
+	if len(sections) != 2 {
+		t.Fatalf("FormatSystemBuffers missing status counter section:\n%s", out)
+	}
+	utilSection, counterSection := sections[0], sections[1]
+	for _, dynamic := range []string{"Neighbor cache entries", "Flow cache active flows"} {
+		if strings.Contains(utilSection, dynamic) {
+			t.Fatalf("%s appeared in utilization table without a bounded capacity:\n%s", dynamic, out)
+		}
+		if !strings.Contains(counterSection, dynamic) {
+			t.Fatalf("%s missing from status counter section:\n%s", dynamic, out)
+		}
+	}
+	if strings.Contains(counterSection, "%") {
+		t.Fatalf("status counters rendered a fill percentage without a denominator:\n%s", out)
+	}
+}
+
 func TestFormatSystemBuffersCoSAggregateSumsCapacityWithUsage(t *testing.T) {
 	status := ProcessStatus{
 		CoSInterfaces: []CoSInterfaceStatus{


### PR DESCRIPTION
## Summary
- codify that session, flow-cache, and neighbor-cache values remain counters until helper status publishes true denominators
- add a formatter regression test proving dynamic counts stay out of the utilization table
- update the #1380 plan and feature-gap docs to remove the undecided-denominator ambiguity

## Tests
- go test ./pkg/dataplane/userspace ./pkg/cli ./pkg/grpcapi

Refs #1380