### PR TITLE
Fail closed unsupported three-color policer snapshots

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
@@ -20,6 +20,11 @@ The bounded runtime slice is implemented after #1395:
   per-color/drop counters.
 - `deriveUserspaceCapabilities()` admits the current color-blind `then
   discard` runtime slice for `firewall three-color-policer` configs.
+- Rust snapshot parsing now also fails closed for bypassed or malformed
+  three-color snapshots that request color-aware mode, non-`discard`
+  actions, unknown modes, or invalid token parameters. Matching traffic is
+  metered by an explicit unsupported runtime that returns red/drop, rather
+  than silently unlinking the policer.
 
 Remaining #1375 work is validation and hardening rather than admission:
 
@@ -78,6 +83,9 @@ packet to green.
   decision that accounts tokens.
 - Per-color counters are attached to the stable policer runtime. The current
   counters use relaxed atomics per logical policer/color.
+- Unsupported snapshot shapes that bypass Go admission must fail closed in
+  Rust: terms still link a runtime handle, and every matching packet receives
+  a red/drop decision.
 
 ## State and HA Behavior
 
@@ -99,8 +107,9 @@ packet to green.
 - Color semantics: color-aware mode must never promote incoming yellow/red
   traffic; one wrong branch turns a security control into a bandwidth grant.
 - Counter attribution: green/yellow/red/drop counters are stable inside a
-  compiled runtime. Carrying them across snapshot rebuilds remains a follow-up
-  if operators need continuity across commits.
+  compiled runtime. Carrying them across snapshot rebuilds remains a follow-up;
+  this slice deliberately preserves the existing token/counter rebuild
+  behavior and hardens unsupported-shape handling instead.
 
 ## Exact Tests
 
@@ -113,6 +122,8 @@ packet to green.
 - Cargo: `policer::three_color_dscp_rewrite`.
 - Cargo: `filter::tests::three_color_runtime_ids_and_miss_path_counters_are_stable`.
 - Cargo: `filter::tests::flow_cache_hits_run_three_color_policer`.
+- Cargo: `filter::tests::unsupported_three_color_snapshots_fail_closed_in_rust_compiler`.
+- Cargo: `filter::tests::three_color_empty_then_action_uses_default_discard`.
 - Go: userspace snapshot round-trip for three-color policer fields, per-color
   actions, and `ColorBlind`.
 - Go: compiler validation rejects zero rates/bursts, `PIR < CIR`, and

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -35,7 +35,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | NPTv6 | Implemented | Stateless prefix translation |
 | Firewall filters | Implemented | Filter snapshots and evaluation in Rust |
 | Flow export | Implemented | Userspace flow export snapshot and runtime |
-| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters. Sharded state, cross-snapshot continuity, non-drop color actions, and integration evidence remain #1375 follow-up work. |
+| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters. Unsupported color-aware, non-`discard`, and malformed snapshots now fail closed in Rust if they bypass Go admission. Sharded state, cross-snapshot continuity, full non-drop action propagation, and integration evidence remain #1375 follow-up work. |
 | TCP MSS clamping | Implemented | Flow snapshot fields are delivered and used in Rust |
 | Embedded ICMP NAT reversal | Implemented | Includes reverse-session repair paths |
 | Configurable session timeouts | Implemented | Snapshot-driven timeouts in `session.rs` |
@@ -87,7 +87,7 @@ The current #1373 audit produced these tracked blockers:
 | #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice; remaining blocker is integration/failover validation evidence | Phase 4 BPF source removal |
 | #1379 | Emit policy-deny, screen-drop, and filter-log dataplane events from userspace | Phase 4 BPF source removal |
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393 and the 2026-05-17 runtime slice cover deterministic cookie codec/layout, snapshot propagation, fail-closed screen challenge selection, session-miss ACK validation, and a bounded validated-client cache. Lower-layer coverage in `userspace-dp/src/screen_tests.rs` pins 4-way validated-client cache replacement; poll-stage tests only pin the operational invalid-ACK drop/bypass semantics. Remaining: validated-client cache expiration semantics, secret-epoch rotation, bounded SYN-ACK TX, ACK RST emission, HA-safe secret publication/cache survivability, counters/status, integration/failover validation, and userspace capability gate removal. | Phase 4 BPF source removal |
-| #1375 | Finish userspace RFC 2697/2698 three-color policer hardening: sharded/packed state decision, cross-snapshot counter continuity decision, non-drop color action handling, and integration/failover/performance evidence | Phase 4 BPF source removal |
+| #1375 | Finish userspace RFC 2697/2698 three-color policer hardening. The current runtime admits the color-blind `then discard` slice and now fails closed for unsupported snapshot shapes that bypass Go admission. Remaining work: sharded/packed state decision, cross-snapshot counter continuity decision, full non-drop color action propagation, and integration/failover/performance evidence | Phase 4 BPF source removal |
 | #1376 | Implement userspace port mirroring or explicitly retire the feature | Phase 4 BPF source removal |
 | #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface. Userspace now renders the bounded helper status that exists and intentionally keeps session-table / flow-cache / neighbor-cache as counters rather than synthetic utilization rows until the helper exports true capacity fields. | Phase 5 CLI / observability cleanup |
 
@@ -154,7 +154,8 @@ The highest-value remaining work on current `master` is:
 3. close #1374 and #1376 before any BPF source removal, and finish the #1375
    hardening/evidence checklist. The three-color capability gate is removed
    only for the current color-blind `then discard` slice; color-aware and
-   non-drop treatments stay fail-closed.
+   non-drop treatments stay fail-closed in both Go admission and Rust snapshot
+   parsing.
 4. carry #1380 into Phase 5 only if operators need new helper capacity fields;
    the current userspace command already avoids BPF-map fallback when helper
    status is available and does not synthesize percentages for dynamic tables

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -65,6 +65,11 @@ Implemented here:
   handle in the cached TX-selection descriptor and meter before cached
   forwarding. Packets buffered for missing-neighbor retry carry their
   session key and meter at retry dispatch time before prepared TX.
+- The Rust snapshot compiler also fail-closes unsupported or malformed
+  three-color policer snapshots. If color-aware mode, non-`discard`
+  treatment, an unknown mode, or invalid token parameters bypass Go
+  admission, matching traffic still links to an explicit unsupported runtime
+  that returns red/drop instead of silently forwarding unmetered.
 - Rust status, Go status, CLI status formatting, and Prometheus export
   expose green/yellow/red packet and byte counters plus drop counters.
 - `deriveUserspaceCapabilities()` no longer rejects the color-blind `then

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -199,8 +199,24 @@ fn parse_three_color_policer(
     snap: &ThreeColorPolicerSnapshot,
     id: usize,
 ) -> Option<Arc<ThreeColorPolicerRuntime>> {
+    let state = build_three_color_policer_state(snap)
+        .unwrap_or_else(|| ThreeColorPolicerState::fail_closed(snap.color_blind));
+    Some(Arc::new(ThreeColorPolicerRuntime::new(
+        id as u32,
+        snap.name.clone(),
+        state,
+    )))
+}
+
+fn build_three_color_policer_state(
+    snap: &ThreeColorPolicerSnapshot,
+) -> Option<ThreeColorPolicerState> {
+    if !snapshot_three_color_shape_supported(snap) {
+        return None;
+    }
+
     let treatments = treatments_from_then_action(&snap.then_action);
-    let state = match snap.mode.as_str() {
+    match snap.mode.as_str() {
         "single-rate" => ThreeColorPolicerState::sr_tcm_with_treatments(
             snap.committed_rate_bytes_per_sec,
             snap.committed_burst_bytes,
@@ -208,7 +224,7 @@ fn parse_three_color_policer(
             snap.color_blind,
             treatments,
         )
-        .ok()?,
+        .ok(),
         "two-rate" => ThreeColorPolicerState::tr_tcm_with_treatments(
             snap.committed_rate_bytes_per_sec,
             snap.committed_burst_bytes,
@@ -217,18 +233,17 @@ fn parse_three_color_policer(
             snap.color_blind,
             treatments,
         )
-        .ok()?,
-        _ => return None,
-    };
-    Some(Arc::new(ThreeColorPolicerRuntime::new(
-        id as u32,
-        snap.name.clone(),
-        state,
-    )))
+        .ok(),
+        _ => None,
+    }
+}
+
+fn snapshot_three_color_shape_supported(snap: &ThreeColorPolicerSnapshot) -> bool {
+    snap.color_blind && (snap.then_action.is_empty() || snap.then_action == "discard")
 }
 
 fn treatments_from_then_action(action: &str) -> ThreeColorTreatments {
-    if action == "discard" {
+    if action.is_empty() || action == "discard" {
         return ThreeColorTreatments {
             red: ColorTreatment::drop(),
             ..ThreeColorTreatments::default()

--- a/userspace-dp/src/filter/policer.rs
+++ b/userspace-dp/src/filter/policer.rs
@@ -97,6 +97,7 @@ pub(crate) enum PacketColor {
 enum ThreeColorMode {
     SingleRate,
     TwoRate,
+    Unsupported,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -173,6 +174,22 @@ pub(crate) struct ThreeColorPolicerState {
 }
 
 impl ThreeColorPolicerState {
+    pub(crate) fn fail_closed(color_blind: bool) -> Self {
+        Self {
+            mode: ThreeColorMode::Unsupported,
+            color_blind,
+            committed_rate_bytes_per_sec: 0,
+            committed_burst_bytes: 0,
+            peak_or_excess_rate_bytes_per_sec: 0,
+            peak_or_excess_burst_bytes: 0,
+            committed_tokens: 0,
+            peak_or_excess_tokens: 0,
+            last_refill_ns: 0,
+            initialized: true,
+            treatments: ThreeColorTreatments::default(),
+        }
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn sr_tcm(
         committed_rate_bytes_per_sec: u64,
@@ -279,6 +296,13 @@ impl ThreeColorPolicerState {
         packet_bytes: u64,
         incoming_color: PacketColor,
     ) -> ThreeColorDecision {
+        if self.mode == ThreeColorMode::Unsupported {
+            return ThreeColorDecision {
+                color: PacketColor::Red,
+                dscp_rewrite: None,
+                drop: true,
+            };
+        }
         self.refill(now_ns);
         let effective_incoming_color = if self.color_blind {
             PacketColor::Green
@@ -288,6 +312,7 @@ impl ThreeColorPolicerState {
         let color = match self.mode {
             ThreeColorMode::SingleRate => self.meter_sr_tcm(packet_bytes, effective_incoming_color),
             ThreeColorMode::TwoRate => self.meter_tr_tcm(packet_bytes, effective_incoming_color),
+            ThreeColorMode::Unsupported => PacketColor::Red,
         };
         let treatment = self.treatments.treatment_for(color);
         ThreeColorDecision {
@@ -301,6 +326,7 @@ impl ThreeColorPolicerState {
         match self.mode {
             ThreeColorMode::SingleRate => "single-rate",
             ThreeColorMode::TwoRate => "two-rate",
+            ThreeColorMode::Unsupported => "unsupported",
         }
     }
 
@@ -324,6 +350,7 @@ impl ThreeColorPolicerState {
         match self.mode {
             ThreeColorMode::SingleRate => self.refill_sr_tcm(elapsed_ns),
             ThreeColorMode::TwoRate => self.refill_tr_tcm(elapsed_ns),
+            ThreeColorMode::Unsupported => return,
         }
         self.last_refill_ns = now_ns;
     }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -474,6 +474,111 @@ fn unsupported_three_color_snapshots_fail_closed_in_rust_compiler() {
                 ..Default::default()
             },
         ),
+        (
+            "mode-drift",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "single_rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_burst_bytes: 50,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "pir-below-cir",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "two-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_rate_bytes_per_sec: 999,
+                peak_or_excess_burst_bytes: 100,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "zero-pir-two-rate",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "two-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_rate_bytes_per_sec: 0,
+                peak_or_excess_burst_bytes: 100,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "zero-committed-burst-two-rate",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "two-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 0,
+                peak_or_excess_rate_bytes_per_sec: 2_000,
+                peak_or_excess_burst_bytes: 100,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "peak-burst-below-committed-burst",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "two-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_rate_bytes_per_sec: 2_000,
+                peak_or_excess_burst_bytes: 99,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "zero-peak-burst-two-rate",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "two-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_rate_bytes_per_sec: 2_000,
+                peak_or_excess_burst_bytes: 0,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "zero-excess-burst",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "single-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_burst_bytes: 0,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "serde-defaulted-malformed",
+            serde_json::from_value(serde_json::json!({
+                "name": "bad-pol",
+                "color_blind": true,
+                "then_action": "discard"
+            }))
+            .expect("defaulted malformed snapshot decodes"),
+        ),
     ];
 
     for (name, snapshot) in cases {

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -433,6 +433,156 @@ fn flow_cache_hits_run_three_color_policer() {
 }
 
 #[test]
+fn unsupported_three_color_snapshots_fail_closed_in_rust_compiler() {
+    let cases = vec![
+        (
+            "color-aware",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "single-rate".into(),
+                color_blind: false,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_burst_bytes: 50,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "non-discard-action",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "single-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 1_000,
+                committed_burst_bytes: 100,
+                peak_or_excess_burst_bytes: 50,
+                then_action: "loss-priority high".into(),
+                ..Default::default()
+            },
+        ),
+        (
+            "invalid-token-shape",
+            ThreeColorPolicerSnapshot {
+                name: "bad-pol".into(),
+                mode: "single-rate".into(),
+                color_blind: true,
+                committed_rate_bytes_per_sec: 0,
+                committed_burst_bytes: 100,
+                peak_or_excess_burst_bytes: 50,
+                then_action: "discard".into(),
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (name, snapshot) in cases {
+        let state = make_filter_state_with_three_color(
+            &[FirewallFilterSnapshot {
+                name: format!("policed-{name}"),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "meter".into(),
+                    action: "accept".into(),
+                    policer: "bad-pol".into(),
+                    ..Default::default()
+                }],
+            }],
+            &[snapshot],
+        );
+
+        let filter = state
+            .filters
+            .get(&format!("inet:policed-{name}"))
+            .expect("compiled filter");
+        assert!(
+            filter.has_three_color_policer_terms,
+            "{name}: unsupported snapshot must still link a fail-closed runtime"
+        );
+
+        let result = evaluate_filter_ref_tx_selection_runtime_counted(
+            filter,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            PROTO_UDP,
+            12345,
+            5000,
+            0,
+            1,
+            0,
+        );
+
+        assert!(
+            result.policer_drop,
+            "{name}: unsupported snapshot must drop matching traffic"
+        );
+        let status = state.three_color_policer_statuses();
+        assert_eq!(status.len(), 1, "{name}: status should expose runtime");
+        assert_eq!(status[0].mode, "unsupported", "{name}: mode");
+        assert_eq!(status[0].red_packets, 1, "{name}: red packets");
+        assert_eq!(status[0].drop_packets, 1, "{name}: drop packets");
+    }
+}
+
+#[test]
+fn three_color_empty_then_action_uses_default_discard() {
+    let state = make_filter_state_with_three_color(
+        &[FirewallFilterSnapshot {
+            name: "policed".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "meter".into(),
+                action: "accept".into(),
+                policer: "default-action-pol".into(),
+                ..Default::default()
+            }],
+        }],
+        &[ThreeColorPolicerSnapshot {
+            name: "default-action-pol".into(),
+            mode: "single-rate".into(),
+            color_blind: true,
+            committed_rate_bytes_per_sec: 1,
+            committed_burst_bytes: 100,
+            peak_or_excess_burst_bytes: 50,
+            then_action: String::new(),
+            ..Default::default()
+        }],
+    );
+
+    let filter = state.filters.get("inet:policed").unwrap();
+    let green = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    let red = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        51,
+        0,
+    );
+
+    assert!(!green.policer_drop);
+    assert!(red.policer_drop);
+    let status = state.three_color_policer_statuses();
+    assert_eq!(status[0].mode, "single-rate");
+    assert_eq!(status[0].green_packets, 1);
+    assert_eq!(status[0].red_packets, 1);
+    assert_eq!(status[0].drop_packets, 1);
+}
+
+#[test]
 fn cached_three_color_descriptor_dedupes_without_vec_allocation() {
     let state = make_filter_state_with_three_color(
         &[


### PR DESCRIPTION
## Summary
- fail closed unsupported or malformed userspace three-color policer snapshots instead of silently unlinking them
- treat empty then-action as the default discard treatment
- add Rust regression tests for unsupported snapshots and default discard behavior
- update #1375 docs and feature-gap status with the remaining hardening/evidence work

## Tests
- cargo test --manifest-path userspace-dp/Cargo.toml three_color -- --nocapture
- cargo check --manifest-path userspace-dp/Cargo.toml
- go test ./pkg/dataplane/userspace -run TestDeriveUserspaceCapabilitiesRejectsUnsupportedThreeColorPolicerActions
- git diff --check

Refs #1375