### PR TITLE
Add userspace policy scheduler evidence validator

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,12 @@
 # Action Log
 
+## 2026-05-18
+
+- **Timestamp**: 2026-05-18T03:59:26Z
+  - **Action**: #1378 policy-scheduler closeout slice — added a deterministic userspace scheduler evidence validator for active/rebuild/inactive/failover artifacts, pinned the userspace apply seed path so initial scheduled-policy snapshots do not rely on legacy policy-map updates, and narrowed the #1378 docs to live HA artifact capture only.
+  - **File(s)**: `test/incus/policy_scheduler_validate.py`, `test/incus/policy_scheduler_validate_test.py`, `pkg/daemon/policy_scheduler_apply_test.go`, `docs/userspace-dataplane-gaps.md`, `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
+  - **Validation**: `python3 test/incus/policy_scheduler_validate_test.py`; `go test ./pkg/daemon -run 'TestPolicyScheduler|TestApplyConfig.*Scheduler|TestApplyConfig.*Protocol'`; `go test ./pkg/config -run 'Test.*PolicyScheduler.*ReferenceRejectsCommit'`; `go test ./pkg/dataplane/userspace -run 'Test(BuildPolicySnapshotsRoundTripsSchedulerInactiveAndRuleID|UpdatePolicyScheduleState)'`; `cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture`
+
 ## 2026-05-17
 
 - **Timestamp**: 2026-05-17T21:25:00Z

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -12,7 +12,7 @@ land before their listed #1373 retirement phase.
 | #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | #1373 Phase 4 | Yes |
 | #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | #1373 Phase 4 | Yes |
 | #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | #1373 Phase 4 | Partly covered by #1385; runtime fail-closed work still needed |
-| #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | Yes |
+| #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | No code gap known; live HA evidence pending |
 | #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | #1373 Phase 4 | Yes |
 | #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | #1373 Phase 5 | Partly covered by #1386 |
 

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md
@@ -37,6 +37,18 @@ is unchanged. The remaining #1378 blocker is integration/HA failover evidence:
 show that the new active node recomputes scheduler state and publishes the full
 policy snapshot before admitting scheduled-policy traffic.
 
+Closeout update, 2026-05-18: `test/incus/policy_scheduler_validate.py` now
+defines the deterministic evidence contract for that remaining lab gate. It
+requires helper/control-socket status from the userspace runtime, protocol
+version >= 2, `forwarding_supported=true`, `forwarding_armed=true`, policy
+rule counters that advance while the scheduler is active, survive a full
+snapshot rebuild, stay unchanged while the scheduler is inactive, advance again
+after RG failover on the new userspace owner, and a captured commit failure for
+an undefined scheduler. `pkg/daemon/policy_scheduler_apply_test.go` also pins
+the non-eBPF apply path: scheduler state is seeded before userspace compile and
+the initial userspace apply does not fall back to `UpdatePolicyScheduleState`
+legacy map updates.
+
 On scheduler state changes, publish one atomic userspace snapshot delta that
 contains the updated inactive bits for all affected rules. Do not issue
 per-rule fast-path toggles because first-match ordering requires same-instant
@@ -115,16 +127,56 @@ existing eBPF behavior that can default missing scheduler state to active.
   60-second granularity.
 - Go: `UpdatePolicyScheduleState` in userspace mode republishes one snapshot
   delta with updated inactive bits.
+- Go: userspace apply seed test proves initial scheduled-policy snapshots are
+  built from daemon-computed active state without invoking legacy eBPF policy
+  map updates.
 - Go: missing scheduler reference is a commit error.
+- Python: `test/incus/policy_scheduler_validate.py` validates the live artifact
+  set for active, rebuild, inactive, failover, and missing-scheduler rejection.
 - Integration: scheduler window spanning multiple 60-second ticks with a policy
   referencing it; new connections pass only during active windows, while
   established sessions retain Junos-default behavior.
+
+## Integration Evidence Harness
+
+The #1378 live evidence directory must contain:
+
+- `active-status.json`: helper `{"type":"status"}` response after active
+  scheduled-policy traffic increments the stable rule counter.
+- `rebuild-status.json`: helper status after a full snapshot rebuild with the
+  same rule identity; the counter must not go backward.
+- `inactive-status.json`: helper status after the scheduler is inactive and a
+  new connection attempt was made; the scheduled rule counter must remain equal
+  to `rebuild-status.json`.
+- `failover-status.json`: helper status from the new RG owner after failover
+  and post-failover scheduled-policy traffic; the counter must advance.
+- `missing-scheduler-commit.txt`: `commit check` or `commit` output for a
+  policy referencing an undefined scheduler; it must contain the strict
+  undefined-scheduler rejection and no commit-success text.
+
+Validate the directory from the repo root:
+
+```bash
+python3 test/incus/policy_scheduler_validate.py \
+  <artifact-dir> \
+  --rule-id 'trust->untrust/scheduled-allow'
+```
+
+The validator intentionally fails if the artifacts show `ebpf_only`, missing
+protocol v2 support, unarmed/unsupported userspace forwarding, counter reset on
+rebuild, counter growth while inactive, no post-failover counter growth, or a
+successful missing-scheduler commit.
 
 Validated in the 2026-05-17 closeout slice:
 
 - `go test ./pkg/config`
 - `go test ./pkg/dataplane/userspace -run 'Test(BuildPolicySnapshots|UpdatePolicyScheduleState)'`
 - `cargo test policy:: -- --nocapture`
+
+Validated in the 2026-05-18 closeout slice:
+
+- `go test ./pkg/daemon -run 'TestPolicyScheduler|TestApplyConfig.*Scheduler|TestApplyConfig.*Protocol'`
+- `python3 test/incus/policy_scheduler_validate_test.py`
 
 ## Non-Goals
 

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -5,7 +5,7 @@ AF_XDP userspace dataplane. It is not a full bug tracker and it is not a
 historical branch plan. For active debugging entry points, use
 [`userspace-debug-map.md`](userspace-debug-map.md).
 
-Last updated: 2026-05-17
+Last updated: 2026-05-18
 
 ## Deprecation Context
 
@@ -26,6 +26,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 |---------|---------------|-------|
 | Stateful forwarding | Implemented | Per-worker sessions plus shared session tables |
 | Zone + global policies | Implemented | Address and application terms are pre-expanded by the daemon |
+| Policy schedulers | Implemented with evidence pending | Scheduled-policy `scheduler_name` and `inactive` bits are published in userspace snapshots, old helper protocol mismatches disarm forwarding, missing policy-scheduler references are commit errors, and Rust hit counters survive active/inactive snapshot rebuilds by stable rule ID. #1378 is narrowed to collecting live userspace HA artifacts with `test/incus/policy_scheduler_validate.py`. |
 | Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
 | Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
 | Source NAT (pool mode) | Implemented with caveats | IPv4/IPv6 pool address and port allocation; wrong-family pools are skipped so later compatible rules can match. Global `source address-persistent` uses the documented userspace-v1 SHA-256 source-IP hash and is stable only within the AF_XDP backend, pool family, pool order, and pool size. Legacy eBPF and current DPDK use C-word IPv4 modulo / IPv6 lane-XOR selection, so new-flow pool address parity is not promised across backend rollback. Pool-mode rules omitted for missing pools, empty pools, or invalid port ranges are not a runtime fail-closed gate yet: the current `poll_descriptor.rs` source-NAT call sites can fall through to the default empty NAT decision and forward without SNAT. Per-pool `persistent-nat` is not a userspace-v1 runtime contract yet: the snapshot has no persistence-mode fields, Rust does not consult the Go `PersistentNATTable`, and the allocator has no live-port exhaustion counter. |
@@ -84,7 +85,7 @@ The current #1373 audit produced these tracked blockers:
 |-------|---------|-----------------|
 | #1381 | Split or replace the BPF-shaped `dataplane.DataPlane` interface so userspace no longer embeds the eBPF manager for map-writer methods | Phase 3 build-system / Go removal |
 | #1377 | Preserve userspace-v1 address-persistent SNAT pool selection with an explicit backend compatibility boundary, then finish per-pool `persistent-nat` semantics and allocation/exhaustion counters. #1385 landed deterministic userspace selection and snapshot omission for missing, empty, or invalid pool inputs, but runtime remains fail-open at the `poll_descriptor.rs` source-NAT call sites and does not provide persistent-NAT lease reuse or cross-backend new-flow parity. | Phase 4 BPF source removal |
-| #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice; remaining blocker is integration/failover validation evidence | Phase 4 BPF source removal |
+| #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice. The 2026-05-18 closeout slice adds a deterministic userspace evidence checker and pins the non-eBPF apply path; remaining blocker is only the live HA artifact capture accepted by `test/incus/policy_scheduler_validate.py`. | Phase 4 BPF source removal |
 | #1379 | Emit policy-deny, screen-drop, and filter-log dataplane events from userspace | Phase 4 BPF source removal |
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393 and the 2026-05-17 runtime slice cover deterministic cookie codec/layout, snapshot propagation, fail-closed screen challenge selection, session-miss ACK validation, and a bounded validated-client cache. Lower-layer coverage in `userspace-dp/src/screen_tests.rs` pins 4-way validated-client cache replacement; poll-stage tests only pin the operational invalid-ACK drop/bypass semantics. Remaining: validated-client cache expiration semantics, secret-epoch rotation, bounded SYN-ACK TX, ACK RST emission, HA-safe secret publication/cache survivability, counters/status, integration/failover validation, and userspace capability gate removal. | Phase 4 BPF source removal |
 | #1375 | Finish userspace RFC 2697/2698 three-color policer hardening: sharded/packed state decision, cross-snapshot counter continuity decision, non-drop color action handling, and integration/failover/performance evidence | Phase 4 BPF source removal |
@@ -105,7 +106,9 @@ Recommended dependency order:
    source removal.
 3. #1374 and #1376 before Phase 4, because these are explicit feature gaps
    currently protected by the legacy eBPF fallback. Keep #1375 on the Phase 4
-   list for validation and hardening evidence, not as a capability gate.
+   list for validation and hardening evidence, not as a capability gate. #1378
+   now needs the scripted scheduler artifact capture only; no additional
+   scheduler runtime code is known from the current audit.
 4. #1380 in Phase 5, after the dataplane boundary is settled but before the
    remaining operator-facing BPF map surface disappears.
 
@@ -149,8 +152,8 @@ The highest-value remaining work on current `master` is:
 2. fix #1377 and #1379 to remove silent correctness and visibility
    regressions; keep #1385 plus the userspace-v1 fixtures as evidence of the
    current AF_XDP SNAT pool selector, not full persistent-NAT parity. Keep
-   #1378 open for the remaining policy-scheduler counter/validation/evidence
-   contract after #1396.
+   #1378 on the closeout list until the scripted userspace HA scheduler
+   evidence artifact set is captured.
 3. close #1374 and #1376 before any BPF source removal, and finish the #1375
    hardening/evidence checklist. The three-color capability gate is removed
    only for the current color-blind `then discard` slice; color-aware and

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -173,10 +173,49 @@ func TestApplyConfigPublishesScheduleStateToNonUserspaceDataplane(t *testing.T) 
 	}
 }
 
-func TestPolicySchedulerStateSeedsUserspaceCompileWithoutLegacyMapUpdate(t *testing.T) {
+func TestApplyConfigSeedsUserspacePolicySchedulerStateBeforeCompile(t *testing.T) {
+	dp := &userspacePolicySchedulerApplyTestDP{}
+	dp.compileErr = dpuserspace.ErrPolicySchedulerProtocolIncompatible
+	d := &Daemon{dp: dp}
+	cfg := testPolicySchedulerApplyConfig()
+
+	if err := d.applyConfigLocked(cfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("applyConfigLocked error = %v, want protocol incompatibility", err)
+	}
+
+	if dp.seedCalls != 1 {
+		t.Fatalf("SetPolicySchedulerActiveState calls = %d, want 1", dp.seedCalls)
+	}
+	if dp.compileCalls != 1 {
+		t.Fatalf("Compile calls = %d, want 1", dp.compileCalls)
+	}
+	if got, ok := dp.compileStateSeen["workhours"]; !ok || !got {
+		t.Fatalf("compile saw workhours active = %t, present=%t; want active true", got, ok)
+	}
+	if dp.compileCfgPolicy != "scheduled-allow" || dp.compileCfgSchedule != "workhours" {
+		t.Fatalf("compile cfg policy=%q scheduler=%q, want scheduled-allow/workhours",
+			dp.compileCfgPolicy, dp.compileCfgSchedule)
+	}
+	if dp.updateCalls != 0 {
+		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 0 before aborted apply publishes", dp.updateCalls)
+	}
+}
+
+func TestPolicySchedulerInitialPublishSkipsUserspaceLegacyMapUpdate(t *testing.T) {
 	dp := &userspacePolicySchedulerApplyTestDP{}
 	d := &Daemon{dp: dp}
-	cfg := &config.Config{
+	cfg := testPolicySchedulerApplyConfig()
+	activeState := d.policySchedulerActiveStateForApplyLocked(cfg, testPolicySchedulerApplyNow())
+
+	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, &dataplane.CompileResult{})
+
+	if dp.updateCalls != 0 {
+		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 0 for userspace initial apply", dp.updateCalls)
+	}
+}
+
+func testPolicySchedulerApplyConfig() *config.Config {
+	return &config.Config{
 		Schedulers: map[string]*config.SchedulerConfig{
 			"workhours": {Name: "workhours"},
 		},
@@ -191,28 +230,6 @@ func TestPolicySchedulerStateSeedsUserspaceCompileWithoutLegacyMapUpdate(t *test
 				}},
 			}},
 		},
-	}
-
-	activeState := d.policySchedulerActiveStateForApplyLocked(cfg, testPolicySchedulerApplyNow())
-	d.seedPolicySchedulerActiveStateLocked(activeState)
-	compileResult, err := dp.Compile(cfg)
-	if err != nil {
-		t.Fatalf("Compile: %v", err)
-	}
-	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, compileResult)
-
-	if dp.seedCalls != 1 {
-		t.Fatalf("SetPolicySchedulerActiveState calls = %d, want 1", dp.seedCalls)
-	}
-	if got, ok := dp.compileStateSeen["workhours"]; !ok || !got {
-		t.Fatalf("compile saw workhours active = %t, present=%t; want active true", got, ok)
-	}
-	if dp.compileCfgPolicy != "scheduled-allow" || dp.compileCfgSchedule != "workhours" {
-		t.Fatalf("compile cfg policy=%q scheduler=%q, want scheduled-allow/workhours",
-			dp.compileCfgPolicy, dp.compileCfgSchedule)
-	}
-	if dp.updateCalls != 0 {
-		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 0 for userspace initial apply", dp.updateCalls)
 	}
 }
 

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -39,6 +39,50 @@ func (d *policySchedulerApplyTestDP) UpdatePolicyScheduleState(_ *config.Config,
 	d.updateStateSeen = activeState
 }
 
+type userspacePolicySchedulerApplyTestDP struct {
+	policySchedulerApplyTestDP
+
+	seedCalls          int
+	seedStateSeen      map[string]bool
+	compileStateSeen   map[string]bool
+	compileCfgPolicy   string
+	compileCfgSchedule string
+}
+
+func (d *userspacePolicySchedulerApplyTestDP) SetPolicySchedulerActiveState(activeState map[string]bool) {
+	d.seedCalls++
+	d.seedStateSeen = copyPolicySchedulerApplyState(activeState)
+}
+
+func (d *userspacePolicySchedulerApplyTestDP) Compile(cfg *config.Config) (*dataplane.CompileResult, error) {
+	d.compileCalls++
+	d.compileStateSeen = copyPolicySchedulerApplyState(d.seedStateSeen)
+	if cfg != nil && len(cfg.Security.Policies) > 0 && len(cfg.Security.Policies[0].Policies) > 0 {
+		pol := cfg.Security.Policies[0].Policies[0]
+		d.compileCfgPolicy = pol.Name
+		d.compileCfgSchedule = pol.SchedulerName
+	}
+	if d.compileErr != nil {
+		return nil, d.compileErr
+	}
+	return &dataplane.CompileResult{}, nil
+}
+
+func (d *userspacePolicySchedulerApplyTestDP) Mode() dpuserspace.DataplaneMode {
+	return dpuserspace.ModeUserspaceStrict
+}
+
+func copyPolicySchedulerApplyState(in map[string]bool) map[string]bool {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
 func TestApplyConfigClearsDeferWorkersOnAbortCompileError(t *testing.T) {
 	dp := &policySchedulerApplyTestDP{
 		compileErr: dpuserspace.ErrPolicySchedulerProtocolIncompatible,
@@ -126,6 +170,49 @@ func TestApplyConfigPublishesScheduleStateToNonUserspaceDataplane(t *testing.T) 
 	}
 	if got, ok := dp.updateStateSeen["workhours"]; !ok || !got {
 		t.Fatalf("active state for workhours = %t, present=%t; want active true", got, ok)
+	}
+}
+
+func TestPolicySchedulerStateSeedsUserspaceCompileWithoutLegacyMapUpdate(t *testing.T) {
+	dp := &userspacePolicySchedulerApplyTestDP{}
+	d := &Daemon{dp: dp}
+	cfg := &config.Config{
+		Schedulers: map[string]*config.SchedulerConfig{
+			"workhours": {Name: "workhours"},
+		},
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Policies: []*config.Policy{{
+					Name:          "scheduled-allow",
+					SchedulerName: "workhours",
+					Action:        config.PolicyPermit,
+				}},
+			}},
+		},
+	}
+
+	activeState := d.policySchedulerActiveStateForApplyLocked(cfg, testPolicySchedulerApplyNow())
+	d.seedPolicySchedulerActiveStateLocked(activeState)
+	compileResult, err := dp.Compile(cfg)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, compileResult)
+
+	if dp.seedCalls != 1 {
+		t.Fatalf("SetPolicySchedulerActiveState calls = %d, want 1", dp.seedCalls)
+	}
+	if got, ok := dp.compileStateSeen["workhours"]; !ok || !got {
+		t.Fatalf("compile saw workhours active = %t, present=%t; want active true", got, ok)
+	}
+	if dp.compileCfgPolicy != "scheduled-allow" || dp.compileCfgSchedule != "workhours" {
+		t.Fatalf("compile cfg policy=%q scheduler=%q, want scheduled-allow/workhours",
+			dp.compileCfgPolicy, dp.compileCfgSchedule)
+	}
+	if dp.updateCalls != 0 {
+		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 0 for userspace initial apply", dp.updateCalls)
 	}
 }
 

--- a/test/incus/policy_scheduler_validate.py
+++ b/test/incus/policy_scheduler_validate.py
@@ -76,11 +76,12 @@ def _require_userspace_runtime(label: str, status: dict[str, Any]) -> None:
         raise ValidationFailure(f"{label}: dataplane_mode is ebpf_only")
 
     programs = status.get("entry_programs")
-    if isinstance(programs, dict) and programs:
-        if not any("xdp_userspace" in str(name) for name in programs.values()):
-            raise ValidationFailure(
-                f"{label}: entry_programs do not show xdp_userspace attachment"
-            )
+    if not isinstance(programs, dict) or not programs:
+        raise ValidationFailure(f"{label}: entry_programs must be a non-empty object")
+    if not any("xdp_userspace" in str(name) for name in programs.values()):
+        raise ValidationFailure(
+            f"{label}: entry_programs do not show xdp_userspace attachment"
+        )
 
 
 def _policy_counter(label: str, status: dict[str, Any], rule_id: str) -> PolicyCounter:

--- a/test/incus/policy_scheduler_validate.py
+++ b/test/incus/policy_scheduler_validate.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ValidationFailure(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class PolicyCounter:
+    packets: int
+    bytes: int
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            value = json.load(f)
+    except FileNotFoundError as exc:
+        raise ValidationFailure(f"missing artifact: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationFailure(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationFailure(f"{path}: top-level JSON must be an object")
+    return value
+
+
+def _status_from_doc(path: Path) -> dict[str, Any]:
+    doc = _load_json(path)
+    if "ok" in doc and doc.get("ok") is not True:
+        raise ValidationFailure(f"{path}: control response ok != true")
+    status = doc.get("status", doc)
+    if not isinstance(status, dict):
+        raise ValidationFailure(f"{path}: status must be an object")
+    return status
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _require_userspace_runtime(label: str, status: dict[str, Any]) -> None:
+    version = _as_int(status.get("config_snapshot_protocol_version"))
+    if version < 2:
+        raise ValidationFailure(
+            f"{label}: config_snapshot_protocol_version={version}, want >= 2"
+        )
+
+    capabilities = status.get("capabilities", {})
+    if not isinstance(capabilities, dict):
+        raise ValidationFailure(f"{label}: capabilities must be an object")
+    if capabilities.get("forwarding_supported") is not True:
+        raise ValidationFailure(f"{label}: forwarding_supported is not true")
+    if status.get("forwarding_armed") is not True:
+        raise ValidationFailure(f"{label}: forwarding_armed is not true")
+    if status.get("enabled") is not True:
+        raise ValidationFailure(f"{label}: userspace helper enabled is not true")
+
+    mode = status.get("dataplane_mode")
+    if mode == "ebpf_only":
+        raise ValidationFailure(f"{label}: dataplane_mode is ebpf_only")
+
+    programs = status.get("entry_programs")
+    if isinstance(programs, dict) and programs:
+        if not any("xdp_userspace" in str(name) for name in programs.values()):
+            raise ValidationFailure(
+                f"{label}: entry_programs do not show xdp_userspace attachment"
+            )
+
+
+def _policy_counter(label: str, status: dict[str, Any], rule_id: str) -> PolicyCounter:
+    counters = status.get("policy_rule_counters", [])
+    if not isinstance(counters, list):
+        raise ValidationFailure(f"{label}: policy_rule_counters must be a list")
+    for counter in counters:
+        if isinstance(counter, dict) and counter.get("rule_id") == rule_id:
+            return PolicyCounter(
+                packets=_as_int(counter.get("packets")),
+                bytes=_as_int(counter.get("bytes")),
+            )
+    raise ValidationFailure(f"{label}: missing policy_rule_counters entry {rule_id!r}")
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError as exc:
+        raise ValidationFailure(f"missing artifact: {path}") from exc
+
+
+def validate_artifacts(
+    root: Path,
+    *,
+    rule_id: str,
+    active_status: str = "active-status.json",
+    rebuild_status: str = "rebuild-status.json",
+    inactive_status: str = "inactive-status.json",
+    failover_status: str | None = "failover-status.json",
+    missing_scheduler_output: str = "missing-scheduler-commit.txt",
+    min_active_packets: int = 1,
+    min_failover_packet_delta: int = 1,
+) -> dict[str, Any]:
+    active = _status_from_doc(root / active_status)
+    rebuild = _status_from_doc(root / rebuild_status)
+    inactive = _status_from_doc(root / inactive_status)
+    statuses = [
+        ("active", active),
+        ("rebuild", rebuild),
+        ("inactive", inactive),
+    ]
+    failover: dict[str, Any] | None = None
+    if failover_status is not None:
+        failover = _status_from_doc(root / failover_status)
+        statuses.append(("failover", failover))
+
+    for label, status in statuses:
+        _require_userspace_runtime(label, status)
+
+    active_counter = _policy_counter("active", active, rule_id)
+    rebuild_counter = _policy_counter("rebuild", rebuild, rule_id)
+    inactive_counter = _policy_counter("inactive", inactive, rule_id)
+
+    if active_counter.packets < min_active_packets:
+        raise ValidationFailure(
+            f"active: packets={active_counter.packets}, want >= {min_active_packets}"
+        )
+    if rebuild_counter.packets < active_counter.packets:
+        raise ValidationFailure(
+            "rebuild: policy counter went backward "
+            f"({rebuild_counter.packets} < {active_counter.packets})"
+        )
+    if rebuild_counter.bytes < active_counter.bytes:
+        raise ValidationFailure(
+            "rebuild: policy bytes went backward "
+            f"({rebuild_counter.bytes} < {active_counter.bytes})"
+        )
+    if inactive_counter != rebuild_counter:
+        raise ValidationFailure(
+            "inactive: scheduled rule counter changed while scheduler was inactive "
+            f"(inactive={inactive_counter}, rebuild={rebuild_counter})"
+        )
+
+    failover_counter: PolicyCounter | None = None
+    if failover is not None:
+        failover_counter = _policy_counter("failover", failover, rule_id)
+        required = rebuild_counter.packets + min_failover_packet_delta
+        if failover_counter.packets < required:
+            raise ValidationFailure(
+                "failover: policy counter did not advance on the new userspace owner "
+                f"({failover_counter.packets} < {required})"
+            )
+
+    missing_text = _read_text(root / missing_scheduler_output)
+    if not re.search(r"references undefined scheduler|scheduler .+ not defined", missing_text):
+        raise ValidationFailure(
+            "missing scheduler commit artifact does not contain the strict rejection"
+        )
+    if re.search(r"\bcommit complete\b|\bcommit successful\b", missing_text, re.I):
+        raise ValidationFailure(
+            "missing scheduler commit artifact looks like a successful commit"
+        )
+
+    summary: dict[str, Any] = {
+        "verdict": "PASS",
+        "rule_id": rule_id,
+        "active": active_counter.__dict__,
+        "rebuild": rebuild_counter.__dict__,
+        "inactive": inactive_counter.__dict__,
+    }
+    if failover_counter is not None:
+        summary["failover"] = failover_counter.__dict__
+    return summary
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate #1378 userspace policy scheduler evidence artifacts."
+    )
+    parser.add_argument("artifact_dir", type=Path)
+    parser.add_argument(
+        "--rule-id",
+        default="trust->untrust/scheduled-allow",
+        help="stable userspace policy rule_id to validate",
+    )
+    parser.add_argument("--active-status", default="active-status.json")
+    parser.add_argument("--rebuild-status", default="rebuild-status.json")
+    parser.add_argument("--inactive-status", default="inactive-status.json")
+    parser.add_argument("--failover-status", default="failover-status.json")
+    parser.add_argument(
+        "--no-failover",
+        action="store_true",
+        help="skip failover-status.json validation",
+    )
+    parser.add_argument(
+        "--missing-scheduler-output",
+        default="missing-scheduler-commit.txt",
+    )
+    parser.add_argument("--min-active-packets", type=int, default=1)
+    parser.add_argument("--min-failover-packet-delta", type=int, default=1)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    try:
+        summary = validate_artifacts(
+            args.artifact_dir,
+            rule_id=args.rule_id,
+            active_status=args.active_status,
+            rebuild_status=args.rebuild_status,
+            inactive_status=args.inactive_status,
+            failover_status=None if args.no_failover else args.failover_status,
+            missing_scheduler_output=args.missing_scheduler_output,
+            min_active_packets=args.min_active_packets,
+            min_failover_packet_delta=args.min_failover_packet_delta,
+        )
+    except ValidationFailure as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/incus/policy_scheduler_validate_test.py
+++ b/test/incus/policy_scheduler_validate_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("policy_scheduler_validate.py")
+SPEC = importlib.util.spec_from_file_location("policy_scheduler_validate", MODULE_PATH)
+assert SPEC is not None
+policy_validate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["policy_scheduler_validate"] = policy_validate
+SPEC.loader.exec_module(policy_validate)
+
+
+RULE_ID = "trust->untrust/scheduled-allow"
+
+
+def _status(packets: int, bytes_: int | None = None) -> dict:
+    if bytes_ is None:
+        bytes_ = packets * 64
+    return {
+        "ok": True,
+        "status": {
+            "config_snapshot_protocol_version": 2,
+            "enabled": True,
+            "forwarding_armed": True,
+            "dataplane_mode": "userspace_strict",
+            "capabilities": {"forwarding_supported": True},
+            "entry_programs": {"4": "xdp_userspace_prog"},
+            "policy_rule_counters": [
+                {"rule_id": RULE_ID, "packets": packets, "bytes": bytes_}
+            ],
+        },
+    }
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+def _write_artifacts(
+    root: Path,
+    *,
+    active_packets: int = 3,
+    rebuild_packets: int = 3,
+    inactive_packets: int = 3,
+    failover_packets: int = 4,
+    missing_text: str = 'policy "scheduled-allow" references undefined scheduler "missing"',
+) -> None:
+    _write_json(root / "active-status.json", _status(active_packets))
+    _write_json(root / "rebuild-status.json", _status(rebuild_packets))
+    _write_json(root / "inactive-status.json", _status(inactive_packets))
+    _write_json(root / "failover-status.json", _status(failover_packets))
+    (root / "missing-scheduler-commit.txt").write_text(
+        missing_text + "\n", encoding="utf-8"
+    )
+
+
+class PolicySchedulerValidateTests(unittest.TestCase):
+    def test_passes_full_userspace_scheduler_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root)
+
+            summary = policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+            self.assertEqual(summary["verdict"], "PASS")
+            self.assertEqual(summary["active"]["packets"], 3)
+            self.assertEqual(summary["inactive"]["packets"], 3)
+            self.assertEqual(summary["failover"]["packets"], 4)
+
+    def test_fails_when_inactive_scheduler_allows_counter_increment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root, rebuild_packets=3, inactive_packets=4)
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "counter changed while scheduler was inactive",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+    def test_fails_when_runtime_is_legacy_ebpf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root)
+            active = _status(3)
+            active["status"]["dataplane_mode"] = "ebpf_only"
+            _write_json(root / "active-status.json", active)
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "dataplane_mode is ebpf_only",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+    def test_fails_when_rebuild_resets_counter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root, active_packets=3, rebuild_packets=0, inactive_packets=0)
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "policy counter went backward",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+    def test_fails_when_missing_scheduler_commit_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root, missing_text="commit complete")
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "strict rejection",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/policy_scheduler_validate_test.py
+++ b/test/incus/policy_scheduler_validate_test.py
@@ -101,6 +101,34 @@ class PolicySchedulerValidateTests(unittest.TestCase):
             ):
                 policy_validate.validate_artifacts(root, rule_id=RULE_ID)
 
+    def test_fails_when_entry_programs_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root)
+            active = _status(3)
+            del active["status"]["entry_programs"]
+            _write_json(root / "active-status.json", active)
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "entry_programs must be a non-empty object",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
+    def test_fails_when_entry_programs_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_artifacts(root)
+            active = _status(3)
+            active["status"]["entry_programs"] = {}
+            _write_json(root / "active-status.json", active)
+
+            with self.assertRaisesRegex(
+                policy_validate.ValidationFailure,
+                "entry_programs must be a non-empty object",
+            ):
+                policy_validate.validate_artifacts(root, rule_id=RULE_ID)
+
     def test_fails_when_rebuild_resets_counter(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -115,11 +143,17 @@ class PolicySchedulerValidateTests(unittest.TestCase):
     def test_fails_when_missing_scheduler_commit_succeeds(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            _write_artifacts(root, missing_text="commit complete")
+            _write_artifacts(
+                root,
+                missing_text=(
+                    'policy "scheduled-allow" references undefined scheduler "missing"\n'
+                    "commit complete"
+                ),
+            )
 
             with self.assertRaisesRegex(
                 policy_validate.ValidationFailure,
-                "strict rejection",
+                "looks like a successful commit",
             ):
                 policy_validate.validate_artifacts(root, rule_id=RULE_ID)
 


### PR DESCRIPTION
## Summary
- add a deterministic validator for #1378 userspace scheduler active/rebuild/inactive/failover artifacts
- pin the userspace apply path so scheduler state seeds compile without legacy policy-map updates
- narrow #1378 docs to the remaining live HA artifact capture gate

## Tests
- python3 test/incus/policy_scheduler_validate_test.py
- go test ./pkg/daemon -run 'TestPolicyScheduler|TestApplyConfig.*Scheduler|TestApplyConfig.*Protocol'
- go test ./pkg/config -run 'Test.*PolicyScheduler.*ReferenceRejectsCommit'
- go test ./pkg/dataplane/userspace -run 'Test(BuildPolicySnapshotsRoundTripsSchedulerInactiveAndRuleID|UpdatePolicyScheduleState)'
- cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture
- git diff --check

Refs #1378