### PR TITLE
filter: reuse three-color policer runtimes on refresh

### DIFF
--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -318,8 +318,8 @@ xpf has firewall filters with source/dest addresses, prefix-lists (with except),
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
-| **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/DPDK token-bucket policer support exists; userspace supports the admitted filter path but three-color behavior remains gated by #1375. |
-| **Three-Color Policer** | `firewall three-color-policer ...` | RFC 2697/2698 metering with green/yellow/red marking based on CIR/CBS/EBS or CIR/PIR | Medium | Legacy eBPF/DPDK done; userspace AF_XDP support remains a #1375 retirement blocker. |
+| **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/DPDK token-bucket policer support exists; userspace supports the admitted filter path and the color-blind `then discard` three-color slice. #1375 still tracks unsupported color-aware/non-drop behavior and evidence. |
+| **Three-Color Policer** | `firewall three-color-policer ...` | RFC 2697/2698 metering with green/yellow/red marking based on CIR/CBS/EBS or CIR/PIR | Medium | Legacy eBPF/DPDK done; userspace AF_XDP supports color-blind `then discard` with compatible snapshot continuity. #1375 remains a retirement blocker for color-aware/non-drop action parity and integration/failover/perf evidence. |
 | **Interface Policer** | `firewall policer ... logical-interface-policer` | Aggregate rate limiting across all protocol families on a logical interface | Low | Missing |
 | **Flexible Match Conditions** | `firewall filter ... term ... from flexible-match-range ...` | Match on arbitrary byte offsets within packet header for custom protocol matching | Low | Missing |
 | **Firewall Filter on lo0** | `interfaces lo0 unit 0 family inet filter input ...` | Host-bound traffic filtering — config parsed, compiled to filter IDs, evaluated natively in xdp_forward for host-bound packets, plus kernel nftables fallback | Medium | Done |
@@ -434,7 +434,7 @@ Features most commonly used in production vSRX deployments:
 
 1. ~~**Proxy ARP/NDP for NAT**~~ - **Done** (proxy ARP with GARP; proxy NDP still missing)
 2. ~~**Session Limiting (source/dest-ip)**~~ - **Done** on the legacy BPF path (GC sweep + BPF LRU maps + xdp_screen enforcement); userspace admission is tracked in `userspace-dataplane-gaps.md`.
-3. ~~**Firewall Filter Policers**~~ - **Legacy done** (token bucket: single-rate, two-rate RFC 2698, single-rate-3c RFC 2697; eBPF + DPDK). Userspace three-color policers remain #1375.
+3. ~~**Firewall Filter Policers**~~ - **Legacy done** (token bucket: single-rate, two-rate RFC 2698, single-rate-3c RFC 2697; eBPF + DPDK). Userspace supports the color-blind `then discard` three-color slice; #1375 tracks the remaining parity/evidence work.
 4. ~~**BFD**~~ - **Done** (OSPF/IS-IS/BGP BFD via FRR profiles)
 5. **NETCONF/YANG** - Industry-standard management, enables automation tooling
 6. **Unified Policies / AppID** - Foundation of modern NGFW (long-term, high complexity)
@@ -511,8 +511,9 @@ work tracked by the linked issue.
 
 ### Firewall Filter Policers (Tier 1) -- LEGACY DONE
 - Token bucket policer with single-rate two-color, two-rate three-color (RFC 2698), and single-rate three-color (RFC 2697) modes
-- eBPF and DPDK parity; userspace three-color policers remain a #1375
-  retirement blocker
+- eBPF and DPDK parity; userspace supports the color-blind `then discard`
+  three-color slice while #1375 tracks color-aware/non-drop parity and
+  evidence
 
 ### BFD (Tier 1) -- DONE
 - OSPF BFD with interval/multiplier via FRR profiles

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -9,7 +9,7 @@ land before their listed #1373 retirement phase.
 | Issue | Plan | Required before | Code PR still needed |
 |---|---|---|---|
 | #1374 SYN cookie flood protection | [plan-1374-syn-cookies.md](plan-1374-syn-cookies.md) | #1373 Phase 4 | Runtime challenge/ACK/cache/counters landed; bounded SYN-ACK/RST TX, HA-safe secrets, integration evidence, and gate removal still needed |
-| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | #1373 Phase 4 | Color-blind `then discard` runtime landed; sharded/packed state, counter continuity, non-drop color actions, and integration/perf evidence still needed |
+| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | #1373 Phase 4 | Color-blind `then discard` runtime plus compatible snapshot continuity landed; sharded/packed state decision, HA/restart continuity decision, non-drop color actions, and integration/perf evidence still needed |
 | #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | #1373 Phase 4 | Snapshot/wire plus bounded forwarded-path runtime landed; remaining ingress/transmit surfaces, mirror-fidelity evidence, pressure survival, and gate removal still needed |
 | #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | #1373 Phase 4 | Userspace-v1 selector and unusable-pool fail-closed runtime landed; persistent NAT lease reuse and allocator/exhaustion counters still needed |
 | #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | No known runtime code gap; live HA artifact capture accepted by `policy_scheduler_validate.py` still needed |

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md
@@ -25,6 +25,10 @@ The bounded runtime slice is implemented after #1395:
   actions, unknown modes, or invalid token parameters. Matching traffic is
   metered by an explicit unsupported runtime that returns red/drop, rather
   than silently unlinking the policer.
+- Equivalent snapshot refreshes preserve token buckets and per-color counters
+  by reusing the same runtime handle when the name-derived runtime ID and shape
+  are unchanged. A changed mode, color mode, rate, burst, or treatment creates
+  a fresh runtime.
 
 Remaining #1375 work is validation and hardening rather than admission:
 
@@ -33,8 +37,8 @@ Remaining #1375 work is validation and hardening rather than admission:
   promoting yellow/red traffic to green.
 - Replace the per-policer mutex runtime with the approved sharded or packed
   atomic state if throughput testing shows contention.
-- Preserve counters and token state across snapshot rebuilds if operator
-  continuity is required for #1373 removal.
+- Decide whether #1373 needs HA/process-restart token continuity. Current
+  continuity is local to compatible in-process snapshot refreshes.
 - Wire non-drop per-color actions, especially loss-priority propagation, into
   the downstream forwarding/CoS path. Until then, non-`discard` three-color
   actions remain fail-closed.
@@ -89,11 +93,13 @@ packet to green.
 
 ## State and HA Behavior
 
-- Policer token state is local runtime state; failover may restart token buckets
-  from configured burst values unless a broader HA state-sync PR explicitly
-  adds token sync.
-- Config snapshots carry stable policer/rule identity so counters can survive
-  snapshot rebuilds where practical.
+- Policer token state is local runtime state. Compatible in-process snapshot
+  refreshes preserve token and counter state by reusing the same runtime handle
+  for the name-derived policer ID; failover or process restart may restart
+  token buckets from configured burst values unless a broader HA state-sync PR
+  explicitly adds token sync.
+- Config snapshots carry stable policer/rule identity so counters survive
+  compatible snapshot rebuilds where practical.
 - Status exposes green/yellow/red packet and byte counters plus red drops
   through Rust status, Go protocol, CLI, and Prometheus.
 
@@ -107,9 +113,10 @@ packet to green.
 - Color semantics: color-aware mode must never promote incoming yellow/red
   traffic; one wrong branch turns a security control into a bandwidth grant.
 - Counter attribution: green/yellow/red/drop counters are stable inside a
-  compiled runtime. Carrying them across snapshot rebuilds remains a follow-up;
-  this slice deliberately preserves the existing token/counter rebuild
-  behavior and hardens unsupported-shape handling instead.
+  compiled runtime and across compatible in-process snapshot refreshes. Changed
+  runtime shapes intentionally reset counters with the new rate/burst contract;
+  failover/restart continuity remains out of scope until userspace owns a
+  broader HA state-sync surface.
 
 ## Exact Tests
 
@@ -124,6 +131,8 @@ packet to green.
 - Cargo: `filter::tests::flow_cache_hits_run_three_color_policer`.
 - Cargo: `filter::tests::unsupported_three_color_snapshots_fail_closed_in_rust_compiler`.
 - Cargo: `filter::tests::three_color_empty_then_action_uses_default_discard`.
+- Cargo: `filter::tests::equivalent_snapshot_refresh_preserves_three_color_state_and_counters`.
+- Cargo: `filter::tests::changed_snapshot_shape_resets_three_color_runtime_state`.
 - Go: userspace snapshot round-trip for three-color policer fields, per-color
   actions, and `ColorBlind`.
 - Go: compiler validation rejects zero rates/bursts, `PIR < CIR`, and

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -18,7 +18,7 @@ present until later phase PRs.
 | #1378 | Scheduler state, counter survival, strict missing-scheduler behavior, and deterministic evidence validation now exist for userspace; remaining work is live HA artifact capture | Before Phase 4 |
 | #1379 | Policy-deny, screen-drop, and logged PBR filter events now emit from userspace; remaining work is syslog evidence, broader non-PBR filter-log call sites, and richer identity mapping | Before Phase 4 |
 | #1374 | Userspace SYN-cookie validation/admission semantics and counters exist; remaining blockers are bounded SYN-ACK/RST TX, HA-safe secrets, integration/failover validation, and gate removal | Before Phase 4 |
-| #1375 | Userspace supports the color-blind `then discard` srTCM/trTCM slice and fails closed for unsupported shapes; remaining work is state/counter continuity, non-drop color actions, and integration/perf evidence | Before Phase 4 |
+| #1375 | Userspace supports the color-blind `then discard` srTCM/trTCM slice, fails closed for unsupported shapes, and preserves token/counter state across compatible in-process snapshot refreshes; remaining work is HA/restart continuity decision, non-drop color actions, and integration/perf evidence | Before Phase 4 |
 | #1376 | Userspace port mirroring has snapshot/wire plumbing plus bounded forwarded-path runtime; remaining work is ingress/transmit surface coverage, fidelity/pressure evidence, and gate removal | Before Phase 4 |
 | #1380 | Userspace `show system buffers` can render helper status; remaining work is Phase 5 cleanup of BPF-map-oriented fallback and optional true-capacity fields | Phase 5 |
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -562,9 +562,11 @@ is [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
   boundary.
 - SYN-cookie flood protection closeout: #1374 still owns bounded SYN-ACK/RST
   TX, HA-safe secrets, integration evidence, and gate removal.
-- RFC 2697/2698 three-color policer closeout: #1375 still owns the remaining
-  state/counter continuity, non-drop color actions, and integration/perf
-  evidence beyond the admitted color-blind `then discard` slice.
+- RFC 2697/2698 three-color policer closeout: #1375 now preserves
+  token/counter state across compatible in-process snapshot refreshes. It still
+  owns the sharded/packed state decision, HA/restart continuity decision,
+  non-drop color actions, and integration/perf evidence beyond the admitted
+  color-blind `then discard` slice.
 - Port mirroring closeout: #1376 still owns remaining ingress/transmit
   surfaces, mirror-fidelity evidence, pressure survival, and gate removal.
 - Dataplane event closeout: #1379 still owns end-to-end syslog evidence,

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -36,7 +36,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | NPTv6 | Implemented | Stateless prefix translation |
 | Firewall filters | Implemented | Filter snapshots and evaluation in Rust |
 | Flow export | Implemented | Userspace flow export snapshot and runtime |
-| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters. Unsupported color-aware, non-`discard`, and malformed snapshots now fail closed in Rust if they bypass Go admission. Sharded state, cross-snapshot continuity, full non-drop action propagation, and integration evidence remain #1375 follow-up work. |
+| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters, and compatible in-process snapshot continuity. Unsupported color-aware, non-`discard`, and malformed snapshots now fail closed in Rust if they bypass Go admission. Sharded state, HA/restart continuity decision, full non-drop action propagation, and integration evidence remain #1375 follow-up work. |
 | TCP MSS clamping | Implemented | Flow snapshot fields are delivered and used in Rust |
 | Embedded ICMP NAT reversal | Implemented | Includes reverse-session repair paths |
 | Configurable session timeouts | Implemented | Snapshot-driven timeouts in `session.rs` |
@@ -90,7 +90,7 @@ The current #1373 audit produced these tracked blockers:
 | #1378 | Finish the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice. The 2026-05-18 closeout slice adds a deterministic userspace evidence checker and pins the non-eBPF apply path; remaining blocker is only the live HA artifact capture accepted by `test/incus/policy_scheduler_validate.py`. | Phase 4 BPF source removal |
 | #1379 | Complete dataplane event closeout: policy-deny, screen-drop, and logged PBR filter hits emit from userspace; remaining work is end-to-end syslog evidence, broader non-PBR filter-log call sites, and richer policy/filter identity mapping | Phase 4 BPF source removal |
 | #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393, the 2026-05-17 runtime slice, and the 2026-05-18 closeout slice cover deterministic cookie codec/layout, snapshot propagation, fail-closed screen challenge selection, session-miss ACK validation, bounded validated-client cache behavior, TTL-bound single-use validated-client expiration, current/previous cookie-epoch ACK validation, explicit validated-client bypass verdicts, userspace helper status counters, and legacy global sync for valid/invalid/bypass counters. Remaining: bounded SYN-ACK TX and sent/budget counters, ACK RST emission, HA-safe secret publication/cache survivability, integration/failover validation, and userspace capability gate removal. | Phase 4 BPF source removal |
-| #1375 | Finish userspace RFC 2697/2698 three-color policer hardening. The current runtime admits the color-blind `then discard` slice and now fails closed for unsupported snapshot shapes that bypass Go admission. Remaining work: sharded/packed state decision, cross-snapshot counter continuity decision, full non-drop color action propagation, and integration/failover/performance evidence | Phase 4 BPF source removal |
+| #1375 | Finish userspace RFC 2697/2698 three-color policer hardening. The current runtime admits the color-blind `then discard` slice, fails closed for unsupported snapshot shapes that bypass Go admission, and preserves token/counter state across compatible in-process snapshot refreshes. Remaining work: sharded/packed state decision, HA/restart continuity decision, full non-drop color action propagation, and integration/failover/performance evidence | Phase 4 BPF source removal |
 | #1376 | Finish userspace port mirroring closeout. Snapshot/wire plumbing and a bounded forwarded-path runtime slice now exist, including pending-forward, self-target flow-cache, and deferred-neighbor retry surfaces. Remaining work is ingress/transmit surface coverage, mirror-fidelity evidence, forwarding survival under mirror pressure, and capability-gate removal. | Phase 4 BPF source removal |
 | #1380 | Retire the remaining BPF-map-oriented `show system buffers` operator surface. Userspace now renders the bounded helper status that exists and intentionally keeps session-table / flow-cache / neighbor-cache as counters rather than synthetic utilization rows until the helper exports true capacity fields. | Phase 5 CLI / observability cleanup |
 
@@ -159,9 +159,9 @@ The highest-value remaining work on current `master` is:
    evidence artifact set is captured.
 3. close #1374 and #1376 before any BPF source removal, and finish the #1375
    hardening/evidence checklist. The three-color capability gate is removed
-   only for the current color-blind `then discard` slice; color-aware and
-   non-drop treatments stay fail-closed in both Go admission and Rust snapshot
-   parsing.
+   only for the current color-blind `then discard` slice with compatible
+   in-process snapshot continuity; color-aware and non-drop treatments stay
+   fail-closed in both Go admission and Rust snapshot parsing.
 4. carry #1380 into Phase 5 only if operators need new helper capacity fields;
    the current userspace command already avoids BPF-map fallback when helper
    status is available and does not synthesize percentages for dynamic tables

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -403,8 +403,11 @@ impl Coordinator {
             fib_generation: snapshot.fib_generation,
         };
         self.policy_counters.reconcile_rules(&snapshot.policies);
-        self.forwarding =
-            build_forwarding_state_with_policy_counters(snapshot, &self.policy_counters);
+        self.forwarding = build_forwarding_state_with_policy_counters_and_previous(
+            snapshot,
+            &self.policy_counters,
+            Some(&self.forwarding),
+        );
         self.shared_validation.store(Arc::new(self.validation));
         self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         self.slow_path = if let Some(slow_path) = preserved_slow_path {
@@ -977,8 +980,11 @@ impl Coordinator {
         // snapshot build time. Always keep the better-resolved set.
         let preserved_fabrics = self.forwarding.fabrics.clone();
         self.policy_counters.reconcile_rules(&snapshot.policies);
-        self.forwarding =
-            build_forwarding_state_with_policy_counters(snapshot, &self.policy_counters);
+        self.forwarding = build_forwarding_state_with_policy_counters_and_previous(
+            snapshot,
+            &self.policy_counters,
+            Some(&self.forwarding),
+        );
         if self.forwarding.fabrics.is_empty() && !preserved_fabrics.is_empty() {
             self.forwarding.fabrics = preserved_fabrics;
         } else if !preserved_fabrics.is_empty() {

--- a/userspace-dp/src/afxdp/forwarding_build.rs
+++ b/userspace-dp/src/afxdp/forwarding_build.rs
@@ -76,6 +76,14 @@ pub(super) fn build_forwarding_state_with_policy_counters(
     snapshot: &ConfigSnapshot,
     policy_counters: &PolicyCounterStore,
 ) -> ForwardingState {
+    build_forwarding_state_with_policy_counters_and_previous(snapshot, policy_counters, None)
+}
+
+pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
+    snapshot: &ConfigSnapshot,
+    policy_counters: &PolicyCounterStore,
+    previous: Option<&ForwardingState>,
+) -> ForwardingState {
     let mut state = ForwardingState::default();
     let mut name_to_ifindex = BTreeMap::new();
     let mut linux_to_ifindex = BTreeMap::new();
@@ -396,13 +404,14 @@ pub(super) fn build_forwarding_state_with_policy_counters(
     state.tcp_mss_gre_in = snapshot.flow.tcp_mss_gre_in;
     state.tcp_mss_gre_out = snapshot.flow.tcp_mss_gre_out;
     // Build filter state from snapshot
-    state.filter_state = crate::filter::parse_filter_state_with_three_color(
+    state.filter_state = crate::filter::parse_filter_state_with_three_color_preserving(
         &snapshot.filters,
         &snapshot.policers,
         &snapshot.three_color_policers,
         &snapshot.interfaces,
         &snapshot.flow.lo0_filter_input_v4,
         &snapshot.flow.lo0_filter_input_v6,
+        previous.map(|state| &state.filter_state),
     );
     state.cos = build_cos_state(snapshot);
     let has_cos_interfaces = !state.cos.interfaces.is_empty();

--- a/userspace-dp/src/afxdp/forwarding_build_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build_tests.rs
@@ -4,12 +4,93 @@
 // `#[path = "forwarding_build_tests.rs"]` from forwarding_build.rs.
 
 use super::*;
+use crate::filter::evaluate_filter_ref_tx_selection_runtime_counted;
 use crate::{
     ClassOfServiceSnapshot, CoSDSCPClassifierEntrySnapshot, CoSDSCPClassifierSnapshot,
     CoSDSCPRewriteRuleEntrySnapshot, CoSDSCPRewriteRuleSnapshot, CoSForwardingClassSnapshot,
     CoSIEEE8021ClassifierEntrySnapshot, CoSIEEE8021ClassifierSnapshot,
     CoSSchedulerMapEntrySnapshot, CoSSchedulerMapSnapshot, CoSSchedulerSnapshot,
+    FirewallFilterSnapshot, FirewallTermSnapshot, ThreeColorPolicerSnapshot,
 };
+use std::net::{IpAddr, Ipv4Addr};
+
+fn three_color_snapshot(burst: u64) -> ConfigSnapshot {
+    ConfigSnapshot {
+        filters: vec![FirewallFilterSnapshot {
+            name: "policed".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "meter".into(),
+                action: "accept".into(),
+                policer: "stable-pol".into(),
+                ..Default::default()
+            }],
+        }],
+        three_color_policers: vec![ThreeColorPolicerSnapshot {
+            name: "stable-pol".into(),
+            mode: "single-rate".into(),
+            color_blind: true,
+            committed_rate_bytes_per_sec: 1,
+            committed_burst_bytes: burst,
+            peak_or_excess_burst_bytes: 50,
+            then_action: "discard".into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn forwarding_state_refresh_preserves_three_color_runtime_state() {
+    let policy_counters = PolicyCounterStore::default();
+    let snapshot = three_color_snapshot(100);
+    let state = build_forwarding_state_with_policy_counters(&snapshot, &policy_counters);
+    let refreshed = build_forwarding_state_with_policy_counters_and_previous(
+        &snapshot,
+        &policy_counters,
+        Some(&state),
+    );
+    assert!(std::sync::Arc::ptr_eq(
+        &state.filter_state.three_color_policers[0],
+        &refreshed.filter_state.three_color_policers[0]
+    ));
+
+    let filter = state.filter_state.filters.get("inet:policed").unwrap();
+    let first = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    assert!(!first.policer_drop);
+
+    let refreshed_filter = refreshed.filter_state.filters.get("inet:policed").unwrap();
+    let second = evaluate_filter_ref_tx_selection_runtime_counted(
+        refreshed_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        51,
+        0,
+    );
+
+    assert!(
+        second.policer_drop,
+        "production refresh must share runtime state during publication"
+    );
+    let status = refreshed.filter_state.three_color_policer_statuses();
+    assert_eq!(status[0].green_packets, 1);
+    assert_eq!(status[0].red_packets, 1);
+    assert_eq!(status[0].drop_packets, 1);
+}
 
 #[test]
 fn build_cos_state_translates_scheduler_map_entries() {
@@ -755,18 +836,14 @@ fn build_forwarding_state_rejects_reserved_zone_ids() {
     assert_eq!(state.zone_name_to_id.get("ok").copied(), Some(5));
     assert!(state.zone_name_to_id.get("reserved-edge").is_none());
     assert!(state.zone_name_to_id.get("global-sentinel").is_none());
-    assert!(
-        state
-            .zone_id_to_name
-            .get(&crate::policy::ZONE_ID_RESERVED_MIN)
-            .is_none()
-    );
-    assert!(
-        state
-            .zone_id_to_name
-            .get(&crate::policy::JUNOS_GLOBAL_ZONE_ID)
-            .is_none()
-    );
+    assert!(state
+        .zone_id_to_name
+        .get(&crate::policy::ZONE_ID_RESERVED_MIN)
+        .is_none());
+    assert!(state
+        .zone_id_to_name
+        .get(&crate::policy::JUNOS_GLOBAL_ZONE_ID)
+        .is_none());
 }
 
 /// #921: ifindex_to_zone_id is populated at config build time

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -16,7 +16,8 @@ Mirrors the BPF firewall-filter pipeline in userspace.
 - `compiler.rs` — parses the typed config's filter terms and lowers
   them to `FilterTerm`s (prefix vectors, protocol bitmap, port
   matcher, DSCP bitmap). Three-color policer snapshots are sorted by
-  name and compiled into stable runtime IDs before terms are linked.
+  name for deterministic iteration and compiled into name-derived
+  stable runtime IDs before terms are linked.
 - `engine.rs` — per-term evaluation, first-match-wins. It carries the
   matched `then policer ...` name in the filter result. Routing-instance
   evaluation can also return log/action/filter/term metadata so AF_XDP
@@ -87,13 +88,16 @@ Remaining limitations:
 - Runtime token state is one `Mutex` per logical policer, not a sharded
   or packed atomic implementation. This preserves correctness and
   stable identity but is not the final high-throughput contention model.
-- Counters and token buckets are rebuilt on snapshot replacement; they
-  are stable within one compiled runtime but not yet carried across
-  config rebuilds.
+- Equivalent snapshot replacements preserve token buckets and per-color
+  counters by reusing the same runtime handle when the name-derived runtime ID
+  and shape are unchanged. Shape changes intentionally create a fresh runtime
+  so old tokens cannot leak across a different rate/burst contract. HA
+  failover and process restart still rebuild from configured bursts until a
+  broader state-sync design exists.
 - Snapshot `then_action` handling currently wires red drop for
   `then discard`. Other actions, such as loss-priority propagation, stay
   fail-closed until downstream loss-priority behavior is wired. Color-aware
   mode also stays fail-closed until inherited packet color is carried through
   trusted metadata.
-- Traffic-level integration, failover, and performance evidence still
-  need to be collected before treating #1375 as fully retired.
+- Traffic-level integration, failover, and performance evidence still need to
+  be collected before treating #1375 as fully retired.

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -32,6 +32,28 @@ pub(crate) fn parse_filter_state_with_three_color(
     lo0_filter_v4: &str,
     lo0_filter_v6: &str,
 ) -> FilterState {
+    parse_filter_state_with_three_color_preserving(
+        filters,
+        policers,
+        three_color_policers,
+        interfaces,
+        lo0_filter_v4,
+        lo0_filter_v6,
+        None,
+    )
+}
+
+/// Build the complete FilterState while preserving compatible three-color
+/// policer token/counter state across snapshot refreshes.
+pub(crate) fn parse_filter_state_with_three_color_preserving(
+    filters: &[FirewallFilterSnapshot],
+    policers: &[PolicerSnapshot],
+    three_color_policers: &[ThreeColorPolicerSnapshot],
+    interfaces: &[crate::InterfaceSnapshot],
+    lo0_filter_v4: &str,
+    lo0_filter_v6: &str,
+    previous: Option<&FilterState>,
+) -> FilterState {
     let mut state = FilterState::default();
 
     // Parse legacy token-bucket policers.
@@ -47,13 +69,15 @@ pub(crate) fn parse_filter_state_with_three_color(
         );
     }
 
-    // Parse three-color policers by stable name order. Terms store Arc
-    // handles, so cache-hit enforcement uses the same logical runtime.
+    // Parse three-color policers by stable name order. Runtime IDs are
+    // name-derived so inserting a lower-sorted policer does not reset
+    // unchanged existing runtimes.
     let mut three_color = three_color_policers.iter().collect::<Vec<_>>();
     three_color.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut used_three_color_ids = rustc_hash::FxHashSet::default();
     for snap in three_color {
-        let Some(runtime) = parse_three_color_policer(snap, state.three_color_policers.len() + 1)
-        else {
+        let id = unique_three_color_policer_runtime_id(&snap.name, &mut used_three_color_ids);
+        let Some(runtime) = parse_three_color_policer(snap, id, previous) else {
             continue;
         };
         state
@@ -199,15 +223,54 @@ pub(crate) fn parse_filter_state_with_three_color(
 
 fn parse_three_color_policer(
     snap: &ThreeColorPolicerSnapshot,
-    id: usize,
+    id: u32,
+    previous: Option<&FilterState>,
 ) -> Option<Arc<ThreeColorPolicerRuntime>> {
     let state = build_three_color_policer_state(snap)
         .unwrap_or_else(|| ThreeColorPolicerState::fail_closed(snap.color_blind));
+    if let Some(previous_runtime) =
+        previous.and_then(|prev| prev.three_color_policer_by_name.get(&snap.name))
+    {
+        if previous_runtime.reusable_for(id, &state) {
+            return Some(Arc::clone(previous_runtime));
+        }
+    }
     Some(Arc::new(ThreeColorPolicerRuntime::new(
-        id as u32,
+        id,
         snap.name.clone(),
         state,
     )))
+}
+
+fn unique_three_color_policer_runtime_id(
+    name: &str,
+    used_ids: &mut rustc_hash::FxHashSet<u32>,
+) -> u32 {
+    let mut id = three_color_policer_runtime_id(name);
+    while !used_ids.insert(id) {
+        id = id.wrapping_add(1);
+        if id == 0 {
+            id = 1;
+        }
+    }
+    id
+}
+
+pub(crate) fn three_color_policer_runtime_id(name: &str) -> u32 {
+    const FNV_OFFSET_BASIS: u32 = 0x811c_9dc5;
+    const FNV_PRIME: u32 = 0x0100_0193;
+    const NAMESPACE: &[u8] = b"xpf-three-color-policer-v1:";
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in NAMESPACE.iter().chain(name.as_bytes()) {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    if hash == 0 {
+        1
+    } else {
+        hash
+    }
 }
 
 fn build_three_color_policer_state(

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -252,6 +252,16 @@ impl ThreeColorPolicerRuntime {
         decision
     }
 
+    pub(crate) fn reusable_for(&self, id: u32, next_shape: &ThreeColorPolicerState) -> bool {
+        if self.id != id {
+            return false;
+        }
+        self.state
+            .lock()
+            .ok()
+            .is_some_and(|state| state.same_runtime_shape(next_shape))
+    }
+
     pub(crate) fn status(&self) -> crate::protocol::ThreeColorPolicerStatus {
         let (mode, color_blind) = self
             .state
@@ -375,7 +385,7 @@ pub(crate) struct FilterState {
     /// Stable three-color policer runtimes keyed by policer name.
     pub(crate) three_color_policer_by_name:
         rustc_hash::FxHashMap<String, Arc<ThreeColorPolicerRuntime>>,
-    /// Stable ID-indexed three-color policer runtimes.
+    /// Name-derived ID-indexed three-color policer runtimes.
     pub(crate) three_color_policers: Vec<Arc<ThreeColorPolicerRuntime>>,
     /// Per-interface (ifindex) input filter key for inet.
     pub(crate) iface_filter_v4: rustc_hash::FxHashMap<i32, String>,

--- a/userspace-dp/src/filter/policer.rs
+++ b/userspace-dp/src/filter/policer.rs
@@ -334,6 +334,16 @@ impl ThreeColorPolicerState {
         self.color_blind
     }
 
+    pub(crate) fn same_runtime_shape(&self, other: &Self) -> bool {
+        self.mode == other.mode
+            && self.color_blind == other.color_blind
+            && self.committed_rate_bytes_per_sec == other.committed_rate_bytes_per_sec
+            && self.committed_burst_bytes == other.committed_burst_bytes
+            && self.peak_or_excess_rate_bytes_per_sec == other.peak_or_excess_rate_bytes_per_sec
+            && self.peak_or_excess_burst_bytes == other.peak_or_excess_burst_bytes
+            && self.treatments == other.treatments
+    }
+
     fn refill(&mut self, now_ns: u64) {
         if !self.initialized {
             self.initialized = true;

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -342,7 +342,13 @@ fn three_color_runtime_ids_and_miss_path_counters_are_stable() {
         .iter()
         .map(|runtime| (runtime.id, runtime.name.as_ref().to_string()))
         .collect::<Vec<_>>();
-    assert_eq!(ids, vec![(1, "alpha".into()), (2, "zeta".into())]);
+    assert_eq!(
+        ids,
+        vec![
+            (three_color_policer_runtime_id("alpha"), "alpha".into()),
+            (three_color_policer_runtime_id("zeta"), "zeta".into()),
+        ]
+    );
 
     let filter = state.filters.get("inet:policed").unwrap();
     assert!(filter.has_three_color_policer_terms);
@@ -430,6 +436,320 @@ fn flow_cache_hits_run_three_color_policer() {
     assert_eq!(status[0].green_packets, 1);
     assert_eq!(status[0].red_packets, 1);
     assert_eq!(status[0].drop_packets, 1);
+}
+
+#[test]
+fn equivalent_snapshot_refresh_preserves_three_color_state_and_counters() {
+    let filters = [FirewallFilterSnapshot {
+        name: "policed".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "meter".into(),
+            action: "accept".into(),
+            policer: "stable-pol".into(),
+            ..Default::default()
+        }],
+    }];
+    let policers = [ThreeColorPolicerSnapshot {
+        name: "stable-pol".into(),
+        mode: "single-rate".into(),
+        color_blind: true,
+        committed_rate_bytes_per_sec: 1,
+        committed_burst_bytes: 100,
+        peak_or_excess_burst_bytes: 50,
+        then_action: "discard".into(),
+        ..Default::default()
+    }];
+
+    let state = make_filter_state_with_three_color(&filters, &policers);
+    let filter = state.filters.get("inet:policed").unwrap();
+    let green = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    assert!(!green.policer_drop);
+
+    let refreshed = parse_filter_state_with_three_color_preserving(
+        &filters,
+        &[],
+        &policers,
+        &[],
+        "",
+        "",
+        Some(&state),
+    );
+    assert!(
+        std::sync::Arc::ptr_eq(
+            &state.three_color_policers[0],
+            &refreshed.three_color_policers[0]
+        ),
+        "compatible refresh must reuse the live runtime, not clone state"
+    );
+    let refreshed_filter = refreshed.filters.get("inet:policed").unwrap();
+    let red = evaluate_filter_ref_tx_selection_runtime_counted(
+        refreshed_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        51,
+        0,
+    );
+
+    assert!(
+        red.policer_drop,
+        "equivalent snapshot refresh must preserve consumed token state"
+    );
+    let status = refreshed.three_color_policer_statuses();
+    assert_eq!(status[0].green_packets, 1);
+    assert_eq!(status[0].green_bytes, 100);
+    assert_eq!(status[0].red_packets, 1);
+    assert_eq!(status[0].red_bytes, 51);
+    assert_eq!(status[0].drop_packets, 1);
+    assert_eq!(status[0].drop_bytes, 51);
+}
+
+#[test]
+fn three_color_adding_lower_sorted_policer_does_not_reset_existing_runtime() {
+    let filters = [FirewallFilterSnapshot {
+        name: "policed".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "meter".into(),
+            action: "accept".into(),
+            policer: "stable-pol".into(),
+            ..Default::default()
+        }],
+    }];
+    let stable = ThreeColorPolicerSnapshot {
+        name: "stable-pol".into(),
+        mode: "single-rate".into(),
+        color_blind: true,
+        committed_rate_bytes_per_sec: 1,
+        committed_burst_bytes: 100,
+        peak_or_excess_burst_bytes: 50,
+        then_action: "discard".into(),
+        ..Default::default()
+    };
+    let inserted = ThreeColorPolicerSnapshot {
+        name: "aaa-new-pol".into(),
+        ..stable.clone()
+    };
+
+    let state = make_filter_state_with_three_color(&filters, &[stable.clone()]);
+    let filter = state.filters.get("inet:policed").unwrap();
+    let first = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    assert!(!first.policer_drop);
+
+    let refreshed = parse_filter_state_with_three_color_preserving(
+        &filters,
+        &[],
+        &[inserted, stable],
+        &[],
+        "",
+        "",
+        Some(&state),
+    );
+    let previous_runtime = state
+        .three_color_policer_by_name
+        .get("stable-pol")
+        .expect("previous runtime");
+    let refreshed_runtime = refreshed
+        .three_color_policer_by_name
+        .get("stable-pol")
+        .expect("refreshed runtime");
+    assert!(
+        std::sync::Arc::ptr_eq(previous_runtime, refreshed_runtime),
+        "adding an alphabetically earlier policer must not reset stable-pol"
+    );
+    assert_eq!(
+        refreshed_runtime.id,
+        three_color_policer_runtime_id("stable-pol")
+    );
+
+    let refreshed_filter = refreshed.filters.get("inet:policed").unwrap();
+    let second = evaluate_filter_ref_tx_selection_runtime_counted(
+        refreshed_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        51,
+        0,
+    );
+    assert!(
+        second.policer_drop,
+        "refreshed stable-pol must retain tokens consumed before insertion"
+    );
+}
+
+#[test]
+fn three_color_compatible_refresh_observes_old_runtime_mutations_after_rebuild() {
+    let filters = [FirewallFilterSnapshot {
+        name: "policed".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "meter".into(),
+            action: "accept".into(),
+            policer: "stable-pol".into(),
+            ..Default::default()
+        }],
+    }];
+    let policers = [ThreeColorPolicerSnapshot {
+        name: "stable-pol".into(),
+        mode: "single-rate".into(),
+        color_blind: true,
+        committed_rate_bytes_per_sec: 1,
+        committed_burst_bytes: 100,
+        peak_or_excess_burst_bytes: 50,
+        then_action: "discard".into(),
+        ..Default::default()
+    }];
+
+    let state = make_filter_state_with_three_color(&filters, &policers);
+    let refreshed = parse_filter_state_with_three_color_preserving(
+        &filters,
+        &[],
+        &policers,
+        &[],
+        "",
+        "",
+        Some(&state),
+    );
+    assert!(std::sync::Arc::ptr_eq(
+        &state.three_color_policers[0],
+        &refreshed.three_color_policers[0]
+    ));
+
+    let old_filter = state.filters.get("inet:policed").unwrap();
+    let old_green = evaluate_filter_ref_tx_selection_runtime_counted(
+        old_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    assert!(!old_green.policer_drop);
+
+    let refreshed_filter = refreshed.filters.get("inet:policed").unwrap();
+    let refreshed_red = evaluate_filter_ref_tx_selection_runtime_counted(
+        refreshed_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        51,
+        0,
+    );
+
+    assert!(
+        refreshed_red.policer_drop,
+        "post-rebuild mutations through the old handle must be visible"
+    );
+    let status = refreshed.three_color_policer_statuses();
+    assert_eq!(status[0].green_packets, 1);
+    assert_eq!(status[0].red_packets, 1);
+    assert_eq!(status[0].drop_packets, 1);
+}
+
+#[test]
+fn changed_snapshot_shape_resets_three_color_runtime_state() {
+    let filters = [FirewallFilterSnapshot {
+        name: "policed".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "meter".into(),
+            action: "accept".into(),
+            policer: "stable-pol".into(),
+            ..Default::default()
+        }],
+    }];
+    let original = [ThreeColorPolicerSnapshot {
+        name: "stable-pol".into(),
+        mode: "single-rate".into(),
+        color_blind: true,
+        committed_rate_bytes_per_sec: 1,
+        committed_burst_bytes: 100,
+        peak_or_excess_burst_bytes: 50,
+        then_action: "discard".into(),
+        ..Default::default()
+    }];
+    let changed = [ThreeColorPolicerSnapshot {
+        committed_burst_bytes: 200,
+        ..original[0].clone()
+    }];
+
+    let state = make_filter_state_with_three_color(&filters, &original);
+    let filter = state.filters.get("inet:policed").unwrap();
+    let first = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        100,
+        0,
+    );
+    assert!(!first.policer_drop);
+
+    let refreshed = parse_filter_state_with_three_color_preserving(
+        &filters,
+        &[],
+        &changed,
+        &[],
+        "",
+        "",
+        Some(&state),
+    );
+    let refreshed_filter = refreshed.filters.get("inet:policed").unwrap();
+    let second = evaluate_filter_ref_tx_selection_runtime_counted(
+        refreshed_filter,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        12345,
+        5000,
+        0,
+        200,
+        0,
+    );
+
+    assert!(
+        !second.policer_drop,
+        "changed token shape should create a fresh runtime with new burst"
+    );
+    let status = refreshed.three_color_policer_statuses();
+    assert_eq!(status[0].green_packets, 1);
+    assert_eq!(status[0].green_bytes, 200);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Refs #1375.

This closes the remaining in-process refresh continuity gap for the
userspace three-color policer runtime:

- reuses the existing `Arc<ThreeColorPolicerRuntime>` when stable runtime
  identity and runtime shape are unchanged
- uses name-derived runtime IDs so adding an alphabetically earlier policer
  does not reset an unchanged existing runtime
- resets the runtime intentionally when mode, color mode, rate, burst,
  treatment, or runtime ID changes
- threads the previous `ForwardingState` through the coordinator reconcile and
  refresh paths so the production builder can reuse compatible runtimes
- updates the #1375 docs to distinguish compatible in-process handle reuse
  from HA/process-restart token sync and non-drop/color-aware parity

The r1 review found that copying token/counter state into a new runtime was
not atomic with live packet processing. This revision removes that copy path:
old cached descriptors and the newly published snapshot share the same runtime
handle during compatible refreshes.

The r2 follow-up found that dense sorted-position IDs could reset a policer
when another policer was inserted before it. IDs are now derived from a fixed
namespace plus policer name, with deterministic collision probing inside a
snapshot.

## Validation

- `cargo test --manifest-path userspace-dp/Cargo.toml three_color -- --nocapture`
- `cargo test --manifest-path userspace-dp/Cargo.toml forwarding_state_refresh_preserves_three_color_runtime_state -- --nocapture`
- `go test ./pkg/dataplane/userspace ./pkg/api ./pkg/config ./pkg/configstore`
- `git diff --check`
