### PR TITLE
daemon: migrate from DataPlane to RuntimeDataPlane

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -59,7 +59,7 @@ const nodeIDFile = "/etc/xpf/node-id"
 type Daemon struct {
 	opts                       Options
 	store                      *configstore.Store
-	dp                         dataplane.DataPlane
+	dp  dataplane.RuntimeDataPlane
 	networkd                   *networkd.Manager
 	routing                    *routing.Manager
 	frr                        *frr.Manager
@@ -340,4 +340,17 @@ func New(opts Options) *Daemon {
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 		applySem:                   semaphore.NewWeighted(1),
 	}
+}
+
+// legacyDP returns the daemon's underlying dataplane.DataPlane for call sites
+// that have not yet migrated to RuntimeDataPlane domain interfaces.
+// Returns nil if d.dp is nil or the concrete type does not implement DataPlane.
+func (d *Daemon) legacyDP() dataplane.DataPlane {
+	if d.dp == nil {
+		return nil
+	}
+	if lp, ok := d.dp.(dataplane.DataPlane); ok {
+		return lp
+	}
+	return nil
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -313,7 +313,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		addrs  []string
 	}
 	var deferredOverlays []deferredIPVLAN
-	bindingCtrl, isUserspaceDP := d.dp.(userspaceXSKBindingController)
+		bindingCtrl, isUserspaceDP := d.legacyDP().(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
 		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
 			continue
@@ -421,20 +421,22 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 				break
 			}
 		}
-		if rethMACPending {
-			type deferSetter interface{ SetDeferWorkers(bool) }
-			if ds, ok := d.dp.(deferSetter); ok {
-				ds.SetDeferWorkers(true)
-				deferWorkersActive = true
-				clearDeferWorkers = func() {
-					ds.SetDeferWorkers(false)
-				}
-				defer func() {
-					if deferWorkersActive {
-						clearDeferWorkers()
-					}
-				}()
+	if rethMACPending {
+		type deferSetter interface{ SetDeferWorkers(bool) }
+		if ds, ok := d.legacyDP().(deferSetter); ok {
+			ds.SetDeferWorkers(true)
+		}
+		deferWorkersActive = true
+		clearDeferWorkers = func() {
+			if ds, ok := d.legacyDP().(deferSetter); ok {
+				ds.SetDeferWorkers(false)
 			}
+		}
+			defer func() {
+				if deferWorkersActive {
+					clearDeferWorkers()
+				}
+			}()
 		}
 	}
 
@@ -446,7 +448,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	var compileResult *dataplane.CompileResult
 	if d.dp != nil {
 		var err error
-		if compileResult, err = d.dp.Compile(cfg); err != nil {
+		if compileResult, err = d.legacyDP().Compile(cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
 				return err
@@ -552,11 +554,8 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 				// been accessing UMEM during the DOWN/UP). The rebind
 				// in NotifyLinkCycle will restart them.
 				if d.dp != nil {
-					type linkCyclePreparer interface{ PrepareLinkCycle() }
-					if preparer, ok := d.dp.(linkCyclePreparer); ok {
-						slog.Info("userspace: stopping workers after RETH MAC link cycle")
-						preparer.PrepareLinkCycle()
-					}
+					slog.Info("userspace: stopping workers after RETH MAC link cycle")
+					d.dp.Link().PrepareLinkCycle()
 				}
 			}
 			needLinkCycleRecovery = needLinkCycleRecovery || linkCycled
@@ -655,7 +654,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	if d.dp != nil && needLinkCycleRecovery {
 		// Actual link DOWN/UP occurred — old XSK sockets are dead.
 		// Rebind to create fresh sockets on the reinitialized queues.
-		d.dp.NotifyLinkCycle()
+		d.dp.Link().NotifyLinkCycle()
 		if d.ra != nil {
 			d.ra.ResendBurst()
 		}
@@ -663,7 +662,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		// MAC set live (no link cycle) but workers were deferred.
 		// Trigger a re-Compile to start workers with the now-correct MAC.
 		// This is cheaper than NotifyLinkCycle (no stop_workers/rebind).
-		if _, err := d.dp.Compile(cfg); err != nil {
+		if _, err := d.legacyDP().Compile(cfg); err != nil {
 			slog.Warn("failed to re-compile after deferred MAC", "err", err)
 		}
 	}
@@ -1050,8 +1049,8 @@ func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, ac
 	if d.dp == nil || activeState == nil || compileResult == nil {
 		return
 	}
-	if _, isUserspace := d.dp.(userspaceRuntimeModeReporter); isUserspace {
+	if _, isUserspace := d.legacyDP().(userspaceRuntimeModeReporter); isUserspace {
 		return
 	}
-	d.dp.UpdatePolicyScheduleState(cfg, activeState)
+	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
 }

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -211,7 +211,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				// already superseded this transition.
 				if tr.Changed && d.dp != nil {
 					cur, _ := s.CurrentDesired()
-					if err := d.dp.UpdateRGActive(ev.GroupID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
@@ -279,7 +279,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 					if !cur && !clusterDemotionEdge {
 						d.tryPrepareUserspaceRGDemotion(ev.GroupID)
 					}
-					if err := d.dp.UpdateRGActive(ev.GroupID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
@@ -400,7 +400,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 					// Only activate when ALL VRRP instances in the RG
 					// are MASTER — prevents partial ownership (#132).
 					cur, _ := s.CurrentDesired()
-					if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, rgID, cur); err != nil {
 						slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 					} else {
 						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
@@ -434,7 +434,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 						if !cur {
 							d.tryPrepareUserspaceRGDemotion(rgID)
 						}
-						if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
+						if err := d.dp.HA().SetRGActive(ctx, rgID, cur); err != nil {
 							slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 						} else {
 							recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
@@ -581,7 +581,7 @@ func (d *Daemon) reconcileRGState() {
 			if tr.Active {
 				// Activation ordering: set rg_active FIRST, then
 				// remove blackholes.
-				if err := d.dp.UpdateRGActive(rgID, true); err != nil {
+				if err := d.dp.HA().SetRGActive(context.Background(), rgID, true); err != nil {
 					if s.ShouldLogApplyError(err.Error()) {
 						slog.Warn("reconcile: failed to update rg_active",
 							"rg", rgID, "active", true, "err", err)
@@ -597,7 +597,7 @@ func (d *Daemon) reconcileRGState() {
 				// clear rg_active.
 				d.injectBlackholeRoutes(rgID)
 				d.tryPrepareUserspaceRGDemotion(rgID)
-				if err := d.dp.UpdateRGActive(rgID, false); err != nil {
+				if err := d.dp.HA().SetRGActive(context.Background(), rgID, false); err != nil {
 					if s.ShouldLogApplyError(err.Error()) {
 						slog.Warn("reconcile: failed to update rg_active",
 							"rg", rgID, "active", false, "err", err)
@@ -1086,7 +1086,7 @@ func (d *Daemon) warmNeighborCache() {
 	// Iterate IPv4 sessions: collect unique dst IPs (forward entries
 	// need ARP for the next-hop toward the destination) and unique src IPs
 	// (return entries need ARP for the on-link client).
-	_ = d.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	_ = d.dp.Sessions().ForEachV4(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -1100,7 +1100,7 @@ func (d *Daemon) warmNeighborCache() {
 	})
 
 	// Iterate IPv6 sessions.
-	_ = d.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	_ = d.dp.Sessions().ForEachV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -210,7 +210,7 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 		// Actively probe for neighbor entry on the overlay (#129).
 		d.probeFabricNeighbor(ctx, overlay, peerIP)
 
-		if d.refreshFabricFwd(fabIface, overlay, peerIP, i == 0) {
+		if d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, i == 0) {
 			break
 		}
 		if i == 9 {
@@ -227,9 +227,9 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, false)
 		case <-d.fabricRefreshCh:
-			d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, false)
 		}
 	}
 }
@@ -391,19 +391,19 @@ func (d *Daemon) retainFabricFwdOnNeighborMiss(slot int, peerIP net.IP, overlay 
 // population and periodic drift correction.
 // fabIface is the physical parent (for ifindex/MAC); overlay is the IPVLAN
 // child where the sync IP lives (for neighbor resolution, #129).
-func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
+func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
 	link, err := netlink.LinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (link not found)",
 			"interface", fabIface, "err", err)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 	localMAC := link.Attrs().HardwareAddr
 	if len(localMAC) != 6 {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (invalid local mac)",
 			"interface", fabIface, "local_mac", localMAC)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -412,7 +412,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	if operState != netlink.OperUp && operState != netlink.OperUnknown {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (link not operational)",
 			"interface", fabIface, "oper_state", operState)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -444,7 +444,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 	var peerMAC net.HardwareAddr
@@ -501,7 +501,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 		if d.retainFabricFwdOnNeighborMiss(0, peerIP, overlay, logWaiting) {
 			return true
 		}
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -527,7 +527,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (dataplane not ready)")
 		return false
 	}
-	if err := d.dp.UpdateFabricFwd(info); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(0), info); err != nil {
 		slog.Warn("cluster: failed to update fabric_fwd map", "err", err)
 		return false
 	}
@@ -545,7 +545,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	// cross-chassis fabric redirect. The initial snapshot may have
 	// been built before the peer MAC was resolved.
 	if d.dp != nil {
-		d.dp.SyncFabricState()
+		d.dp.HA().SyncFabricState(ctx)
 	}
 
 	return true
@@ -553,14 +553,14 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 
 // clearFabricFwd0 writes a zeroed FabricFwdInfo to key=0 if a valid entry
 // was previously written, ensuring the dataplane falls back (#121).
-func (d *Daemon) clearFabricFwd0() {
+func (d *Daemon) clearFabricFwd0(ctx context.Context) {
 	d.fabricMu.RLock()
 	populated := d.fabricPopulated
 	d.fabricMu.RUnlock()
 	if !populated || d.dp == nil {
 		return
 	}
-	if err := d.dp.UpdateFabricFwd(dataplane.FabricFwdInfo{}); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(0), dataplane.FabricFwdInfo{}); err != nil {
 		slog.Warn("cluster: failed to clear fabric_fwd[0]", "err", err)
 		return
 	}
@@ -603,7 +603,7 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 		// Probe on the overlay (#129).
 		d.probeFabricNeighbor(ctx, overlay, peerIP)
 
-		if d.refreshFabricFwd1(fabIface, overlay, peerIP, i == 0) {
+		if d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, i == 0) {
 			break
 		}
 		if i == 9 {
@@ -620,9 +620,9 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.refreshFabricFwd1(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
 		case <-d.fabricRefreshCh:
-			d.refreshFabricFwd1(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
 		}
 	}
 }
@@ -630,19 +630,19 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 // refreshFabricFwd1 resolves secondary fabric link/neighbor state and updates
 // the fabric_fwd BPF map at key=1. Returns true on success.
 // fabIface is the physical parent; overlay is the IPVLAN child (#129).
-func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
+func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
 	link, err := netlink.LinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (link not found)",
 			"interface", fabIface, "err", err)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 	localMAC := link.Attrs().HardwareAddr
 	if len(localMAC) != 6 {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (invalid local mac)",
 			"interface", fabIface, "local_mac", localMAC)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -651,7 +651,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 	if operState != netlink.OperUp && operState != netlink.OperUnknown {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (link not operational)",
 			"interface", fabIface, "oper_state", operState)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -678,7 +678,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 	var peerMAC net.HardwareAddr
@@ -693,7 +693,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 		if d.retainFabricFwdOnNeighborMiss(1, peerIP, overlay, logWaiting) {
 			return true
 		}
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -712,7 +712,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (dataplane not ready)")
 		return false
 	}
-	if err := d.dp.UpdateFabricFwd1(info); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(1), info); err != nil {
 		slog.Warn("cluster: failed to update fabric1_fwd map", "err", err)
 		return false
 	}
@@ -730,14 +730,14 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 
 // clearFabricFwd1 writes a zeroed FabricFwdInfo to key=1 if a valid entry
 // was previously written, ensuring the dataplane falls back (#121).
-func (d *Daemon) clearFabricFwd1() {
+func (d *Daemon) clearFabricFwd1(ctx context.Context) {
 	d.fabricMu.RLock()
 	populated := d.fabric1Populated
 	d.fabricMu.RUnlock()
 	if !populated || d.dp == nil {
 		return
 	}
-	if err := d.dp.UpdateFabricFwd1(dataplane.FabricFwdInfo{}); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(1), dataplane.FabricFwdInfo{}); err != nil {
 		slog.Warn("cluster: failed to clear fabric_fwd[1]", "err", err)
 		return
 	}
@@ -770,7 +770,7 @@ func (d *Daemon) RefreshFabricFwd() {
 			}
 			d.fabricMu.Unlock()
 		}
-		d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+		d.refreshFabricFwd(context.Background(), fabIface, overlay, peerIP, false)
 	}
 	if fabIface1 != "" && peerIP1 != nil {
 		if time.Since(probeAt1) >= 2*time.Second {
@@ -781,7 +781,7 @@ func (d *Daemon) RefreshFabricFwd() {
 			}
 			d.fabricMu.Unlock()
 		}
-		d.refreshFabricFwd1(fabIface1, overlay1, peerIP1, false)
+		d.refreshFabricFwd1(context.Background(), fabIface1, overlay1, peerIP1, false)
 	}
 }
 

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -268,7 +268,7 @@ func (d *Daemon) startSessionSyncPrimeRetry(gen uint64) {
 // callback into QueueSessionV4/V6). Falls back to the old BulkSync path
 // (iterating BPF maps from Go) when the event stream isn't available.
 func (d *Daemon) bulkSyncViaEventStreamOrFallback(ss *cluster.SessionSync) error {
-	if exporter, ok := d.dp.(userspaceEventStreamExporter); ok {
+	if exporter, ok := d.legacyDP().(userspaceEventStreamExporter); ok {
 		slog.Info("cluster: using event stream export for bulk sync")
 		if err := exporter.ExportAllSessionsViaEventStream(); err != nil {
 			slog.Warn("cluster: event stream bulk export failed, falling back to BulkSync", "err", err)
@@ -278,7 +278,7 @@ func (d *Daemon) bulkSyncViaEventStreamOrFallback(ss *cluster.SessionSync) error
 		}
 	}
 	slog.Info("cluster: event stream export not available, falling back to BulkSync",
-		"dp_type", fmt.Sprintf("%T", d.dp))
+		"dp_type", fmt.Sprintf("%T", d.legacyDP()))
 	if ss == nil {
 		return fmt.Errorf("session sync not initialized")
 	}
@@ -400,7 +400,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 					now := uint64(ts.Sec)
 					for _, rg := range cc.RedundancyGroups {
-						if err := d.dp.UpdateHAWatchdog(rg.ID, now); err != nil {
+						if err := d.dp.HA().SetHAWatchdog(commsCtx, rg.ID, now); err != nil {
 							slog.Warn("ha watchdog write failed", "rg", rg.ID, "err", err)
 						}
 					}
@@ -667,7 +667,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				slog.Warn("cluster: fence received from peer, disabling all RGs")
 				if cfg.Chassis.Cluster != nil {
 					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-						if err := d.dp.UpdateRGActive(rg.ID, false); err != nil {
+						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {
 							slog.Warn("cluster: fence: failed to disable rg_active",
 								"rg", rg.ID, "err", err)
 						}
@@ -679,7 +679,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			var streamProvider userspaceEventStreamProvider
 			streamCallbacksWired := false
 			if d.dp != nil {
-				if provider, ok := d.dp.(userspaceEventStreamProvider); ok {
+				if provider, ok := d.legacyDP().(userspaceEventStreamProvider); ok {
 					streamProvider = provider
 					wireCtx, cancel := context.WithTimeout(commsCtx, 5*time.Second)
 					streamCallbacksWired = d.wireUserspaceEventStreamCallbacks(wireCtx, provider)
@@ -715,7 +715,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				// Must happen here (not in Run) because d.sessionSync is
 				// created asynchronously in this goroutine.
 				if d.dp != nil {
-					d.sessionSync.SetDataPlane(d.dp)
+					d.sessionSync.SetDataPlane(d.legacyDP())
 					d.sessionSync.IsPrimaryFn = func() bool {
 						return d.cluster != nil && d.cluster.IsLocalPrimary(0)
 					}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -247,18 +247,24 @@ func (d *Daemon) Run(ctx context.Context) error {
 			slog.Error("failed to create dataplane", "type", dpType, "err", err)
 			return fmt.Errorf("create dataplane: %w", err)
 		}
-		d.dp = dp
-		if err := d.dp.Load(); err != nil {
-			slog.Warn("failed to load dataplane programs, running in config-only mode",
+		var ok bool
+		d.dp, ok = dp.(dataplane.RuntimeDataPlane)
+		if !ok {
+			return fmt.Errorf("dataplane type %q does not implement RuntimeDataPlane", dpType)
+		}
+		if err := d.dp.Start(ctx); err != nil {
+			slog.Warn("failed to start dataplane, running in config-only mode",
 				"err", err)
 			d.dp = nil
 		} else {
-			d.dp.SeedNATPortCounters()
-			nodeID := 0
-			if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
-				nodeID = cfg.Chassis.Cluster.NodeID
+			if lp := d.legacyDP(); lp != nil {
+				lp.SeedNATPortCounters()
+				nodeID := 0
+				if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
+					nodeID = cfg.Chassis.Cluster.NodeID
+				}
+				lp.SeedSessionIDCounter(nodeID)
 			}
-			d.dp.SeedSessionIDCounter(nodeID)
 		}
 		// Apply current config — needed even in config-only mode so that
 		// VRFs, interfaces, and routing are configured before cluster comms.
@@ -300,9 +306,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	var er *logging.EventReader
 	if d.dp != nil {
 		// Start FIB sync (DPDK: background route populator; eBPF: no-op)
-		d.dp.StartFIBSync(ctx)
+		if lp := d.legacyDP(); lp != nil {
+			lp.StartFIBSync(ctx)
+		}
 
-		gc := conntrack.NewGC(d.dp, 10*time.Second)
+		gc := conntrack.NewGC(d.legacyDP(), 10*time.Second)
 		d.gc = gc
 
 		// When the userspace dataplane is active, skip BPF session map
@@ -345,7 +353,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			gc.Run(ctx)
 		}()
 
-		evSrc, evErr := d.dp.NewEventSource()
+		evSrc, evErr := d.dp.Telemetry().NewEventSource()
 		if evErr != nil {
 			slog.Warn("failed to create event source", "err", evErr)
 		}
@@ -382,7 +390,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.SrcPort = binary.BigEndian.Uint16(raw[40:42])
 						key.DstPort = binary.BigEndian.Uint16(raw[42:44])
 						key.Protocol = proto
-						if val, err := d.dp.GetSessionV6(key); err == nil && val.IsReverse == 0 {
+						if val, err := d.dp.Sessions().GetV6(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
 								d.sessionSync.QueueSessionV6(key, val)
 							}
@@ -394,7 +402,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.SrcPort = binary.BigEndian.Uint16(raw[40:42])
 						key.DstPort = binary.BigEndian.Uint16(raw[42:44])
 						key.Protocol = proto
-						if val, err := d.dp.GetSessionV4(key); err == nil && val.IsReverse == 0 {
+						if val, err := d.dp.Sessions().GetV4(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
 								d.sessionSync.QueueSessionV4(key, val)
 							}
@@ -643,7 +651,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		apiCfg := api.Config{
 			Addr:     d.opts.APIAddr,
 			Store:    d.store,
-			DP:       d.dp,
+			DP:       d.legacyDP(),
 			EventBuf: eventBuf,
 			GC:       d.gc,
 			Routing:  d.routing,
@@ -722,14 +730,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// `show chassis forwarding`).  Shared between the gRPC server
 	// and the local CLI; both paths call Snapshot() at query time.
 	// Started here so the ring is populated before the first CLI.
-	fwdSampler := fwdstatus.NewSampler(d.dp, fwdstatus.OSProcReader{})
+	fwdSampler := fwdstatus.NewSampler(d.legacyDP(), fwdstatus.OSProcReader{})
 	fwdSampler.Start(ctx)
 
 	// Start gRPC API server.
 	{
 		grpcSrv := grpcapi.NewServer(d.opts.GRPCAddr, grpcapi.Config{
 			Store:      d.store,
-			DP:         d.dp,
+			DP:         d.legacyDP(),
 			EventBuf:   eventBuf,
 			GC:         d.gc,
 			Routing:    d.routing,
@@ -815,7 +823,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start interactive CLI or block in daemon mode
 	var runErr error
 	if isInteractive() {
-		shell := cli.New(d.store, d.dp, eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
+		shell := cli.New(d.store, d.legacyDP(), eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
 		shell.SetVersion(d.opts.Version)
 		shell.SetForwardingSampler(fwdSampler)
 		// #797 H2 / #846: route in-process CLI commits through the
@@ -958,10 +966,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if !hitless && d.dp != nil && cfg.Chassis.Cluster != nil {
 		slog.Info("HA shutdown: clearing rg_active for all RGs")
 		for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-			if err := d.dp.UpdateRGActive(rg.ID, false); err != nil {
+			if err := d.dp.HA().SetRGActive(ctx, rg.ID, false); err != nil {
 				slog.Warn("failed to clear rg_active on shutdown", "rg", rg.ID, "err", err)
 			}
-			if err := d.dp.UpdateHAWatchdog(rg.ID, 0); err != nil {
+			if err := d.dp.HA().SetHAWatchdog(ctx, rg.ID, 0); err != nil {
 				slog.Warn("failed to clear ha_watchdog on shutdown", "rg", rg.ID, "err", err)
 			}
 		}
@@ -1001,7 +1009,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	if d.dp != nil {
-		logFinalStats(d.dp)
+		logFinalStats(d.legacyDP())
 		if hitless {
 			// Hitless: close Go handles only — BPF programs keep running.
 			slog.Info("hitless shutdown: preserving BPF state")

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -132,7 +132,7 @@ func (d *Daemon) publishPolicyScheduleState(epoch uint64, activeState map[string
 		return
 	}
 	d.seedPolicySchedulerActiveStateLocked(activeState)
-	d.dp.UpdatePolicyScheduleState(cfg, activeState)
+	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
 }
 
 func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]bool) {


### PR DESCRIPTION
## Summary

Change `Daemon.dp` field type from `dataplane.DataPlane` to `dataplane.RuntimeDataPlane`, adding a `legacyDP()` helper for call sites yet to migrate.

Closes #1381.

## What changed

### Field type and helper
- `Daemon.dp` → `dataplane.RuntimeDataPlane`
- New `legacyDP()` method type-asserts back to `dataplane.DataPlane` for backward compat

### Migration by domain interface

| Domain | Old API | New API |
|--------|---------|---------|
| ConfigSink | `Compile(cfg)` | `legacyDP().Compile(cfg)` |
| Link | `NotifyLinkCycle()`, `PrepareLinkCycle()` | `d.dp.Link().NotifyLinkCycle()` etc |
| Link | type-assert `deferSetter` | `legacyDP().(deferSetter)` (preserves test mock) |
| HA | `UpdateRGActive()` | `d.dp.HA().SetRGActive(ctx, ...)` |
| HA | `UpdateHAWatchdog()` | `d.dp.HA().SetHAWatchdog(ctx, ...)` |
| HA | `UpdateFabricFwd/1()` | `d.dp.HA().SetFabricForwarding(id, info)` |
| HA | `SyncFabricState()` | `d.dp.HA().SyncFabricState(ctx)` |
| Sessions | `IterateSessions()` | `d.dp.Sessions().ForEachV4/V6()` |
| Sessions | `GetSessionV4/V6()` | `d.dp.Sessions().GetV4/V6()` |
| Telemetry | `NewEventSource()` | `d.dp.Telemetry().NewEventSource()` |
| Startup | `Load()` | `d.dp.Start(ctx)` |

### Files touched
- `pkg/daemon/daemon.go` — field type, `legacyDP()` helper
- `pkg/daemon/daemon_run.go` — startup, seeds, FIBSync, GC, event source, shutdown
- `pkg/daemon/daemon_apply.go` — compile, link cycle, defer workers
- `pkg/daemon/daemon_ha.go` — RG active, session iteration
- `pkg/daemon/daemon_ha_sync.go` — watchdog, fencing, session sync
- `pkg/daemon/daemon_ha_fabric.go` — fabric forwarding tables
- `pkg/daemon/daemon_scheduler.go` — policy schedule state

### Not changed in this PR
- `daemon_ha_userspace.go`, `daemon_neighbor_listener.go` — type assertions to userspace-specific interfaces continue to work because concrete types are unchanged behind `RuntimeDataPlane`
- Downstream packages (API, gRPC, CLI, GC, `conntrack`) — still receive `legacyDP()`; their own migration is deferred to follow-up PRs

## Verification
- `go build ./...` — clean
- `go test ./pkg/daemon/...` — all pass
- `go test ./pkg/dataplane/...` — all pass
- `go test ./pkg/...` — all unit tests pass

## Next steps (follow-up PRs)
- Move GC to `SessionStore`
- Move cluster session sync to `SessionStore`
- Move API/gRPC/CLI to `Telemetry`/`SessionStore`
- Move daemon compile to `ApplyConfig()` on `ConfigSink`