### PR TITLE
screen: add SYN-cookie reply frame builders

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md
@@ -33,11 +33,13 @@ SYN cookie behavior in `userspace-dp`.
   sync mirrors valid ACK, invalid ACK, and bypass deltas. Challenge decisions are
   deliberately not mapped to the legacy sent counter until bounded SYN-ACK TX
   exists.
-- This PR is therefore a SYN-cookie validation/admission runtime slice, not the
-  full SYN-ACK/RST TX implementation.
-- The userspace capability gate remains in place until bounded SYN-ACK TX, ACK
-  RST emission, HA-safe secret publication/cache survivability, sent/budget TX
-  counters, and integration/failover validation land.
+- The 2026-05-19 construction slice adds pure SYN-cookie SYN-ACK and validated
+  ACK RST frame builders. The builders swap Ethernet/IP/TCP identity, preserve
+  VLAN headers, emit minimal TCP replies, and recompute IPv4/IPv6 checksums
+  from scratch. This intentionally stops before TX-ring integration.
+- The userspace capability gate remains in place until bounded SYN-ACK TX,
+  bounded ACK RST emission, HA-safe secret publication/cache survivability,
+  sent/budget TX counters, and integration/failover validation land.
 
 ## Design
 
@@ -145,6 +147,8 @@ On returning ACK:
 - Cargo: `screen::syn_cookie_validated_cache_refresh_extends_ttl`.
 - Cargo: `screen::syn_cookie_ack_validation_accepts_previous_epoch_after_rotation`.
 - Cargo: `afxdp::poll_stages::session_miss_ack_stage_invokes_syn_cookie_runtime_validation`.
+- Cargo: `afxdp::frame::tests::syn_cookie_syn_ack_builder_swaps_tuple_and_preserves_vlan`.
+- Cargo: `afxdp::frame::tests::syn_cookie_ack_rst_builder_uses_received_ack_as_rst_seq`.
 - Cargo: `afxdp::tests::syn_cookie_counters_hot_path_accumulate_in_batch`.
 - Cargo: `afxdp::umem::tests::binding_live_snapshot_propagates_710_drop_counters`.
 - Cargo: `afxdp::coordinator::tests::refresh_bindings_bridges_v_min_counters_into_binding_status`.

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -51,7 +51,10 @@ pub(super) use inspect::{
 //     callers continue to see it via the wider re-export path.
 //   - the remaining helpers stay at pub(super) (or fn-private for
 //     the clamp helpers, which are only used inside frame/mod.rs).
-pub(in crate::afxdp) use tcp::frame_has_tcp_rst;
+#[allow(unused_imports)]
+pub(in crate::afxdp) use tcp::{
+    build_syn_cookie_ack_rst_frame, build_syn_cookie_syn_ack_frame, frame_has_tcp_rst,
+};
 pub(super) use tcp::{extract_tcp_flags_and_window, extract_tcp_window, tcp_flags_str};
 use tcp::clamp_tcp_mss_frame;
 

--- a/userspace-dp/src/afxdp/frame/tcp.rs
+++ b/userspace-dp/src/afxdp/frame/tcp.rs
@@ -32,6 +32,8 @@ const SYN_COOKIE_REPLY_HOP_LIMIT: u8 = 64;
 #[cfg_attr(not(test), allow(dead_code))]
 const SYN_COOKIE_TCP_WINDOW: u16 = 64240;
 #[cfg_attr(not(test), allow(dead_code))]
+const ETHERNET_MIN_FRAME_LEN: usize = 60;
+#[cfg_attr(not(test), allow(dead_code))]
 const TCP_FLAG_ACK: u8 = 0x10;
 #[cfg_attr(not(test), allow(dead_code))]
 const TCP_FLAG_RST: u8 = 0x04;
@@ -415,7 +417,10 @@ fn build_syn_cookie_tcp_reply_v4(
     let src = Ipv4Addr::new(ip[12], ip[13], ip[14], ip[15]);
     let dst = Ipv4Addr::new(ip[16], ip[17], ip[18], ip[19]);
     let total_len = 20usize.checked_add(tcp_len)?;
-    let frame_len = parsed.l3.checked_add(total_len)?;
+    let frame_len = parsed
+        .l3
+        .checked_add(total_len)?
+        .max(ETHERNET_MIN_FRAME_LEN);
     let mut out = vec![0u8; frame_len];
     write_reply_eth_header(frame, &mut out, parsed.l3)?;
     let ip_out = out.get_mut(parsed.l3..parsed.l3 + total_len)?;

--- a/userspace-dp/src/afxdp/frame/tcp.rs
+++ b/userspace-dp/src/afxdp/frame/tcp.rs
@@ -25,6 +25,23 @@
 
 use super::*;
 
+#[cfg_attr(not(test), allow(dead_code))]
+const SYN_COOKIE_REPLY_TTL: u8 = 64;
+#[cfg_attr(not(test), allow(dead_code))]
+const SYN_COOKIE_REPLY_HOP_LIMIT: u8 = 64;
+#[cfg_attr(not(test), allow(dead_code))]
+const SYN_COOKIE_TCP_WINDOW: u16 = 64240;
+#[cfg_attr(not(test), allow(dead_code))]
+const TCP_FLAG_ACK: u8 = 0x10;
+#[cfg_attr(not(test), allow(dead_code))]
+const TCP_FLAG_RST: u8 = 0x04;
+#[cfg_attr(not(test), allow(dead_code))]
+const TCP_FLAG_SYN: u8 = 0x02;
+#[cfg_attr(not(test), allow(dead_code))]
+const TCP_MIN_HEADER_LEN: usize = 20;
+#[cfg_attr(not(test), allow(dead_code))]
+const TCP_MSS_OPTION_LEN: usize = 4;
+
 /// Check if a frame contains a TCP RST flag.
 #[inline(always)]
 pub(in crate::afxdp) fn frame_has_tcp_rst(frame: &[u8]) -> bool {
@@ -249,6 +266,254 @@ pub(super) fn clamp_tcp_mss(packet: &mut [u8], max_mss: u16) -> bool {
         pos += opt_len;
     }
     false
+}
+
+/// Build the SYN-cookie challenge reply for a threshold-exceeded SYN.
+///
+/// The caller still owns admission and TX-frame budgeting. This builder is a
+/// pure byte-construction primitive: it swaps L2/L3/L4 identity, emits a
+/// minimal SYN+ACK with the encoded cookie as the sequence number, advertises
+/// the selected MSS when present, and recomputes checksums from scratch.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(in crate::afxdp) fn build_syn_cookie_syn_ack_frame(
+    frame: &[u8],
+    cookie_isn: u32,
+    advertised_mss: u16,
+) -> Option<Vec<u8>> {
+    let parsed = parse_tcp_reply_source(frame)?;
+    if (parsed.flags & TCP_FLAG_SYN) == 0 || (parsed.flags & TCP_FLAG_ACK) != 0 {
+        return None;
+    }
+    let tcp_len = if advertised_mss > 0 {
+        TCP_MIN_HEADER_LEN + TCP_MSS_OPTION_LEN
+    } else {
+        TCP_MIN_HEADER_LEN
+    };
+    build_syn_cookie_tcp_reply(
+        frame,
+        parsed,
+        tcp_len,
+        cookie_isn,
+        parsed.seq.wrapping_add(1),
+        TCP_FLAG_SYN | TCP_FLAG_ACK,
+        advertised_mss,
+    )
+}
+
+/// Build the RST reply for a validated SYN-cookie ACK.
+///
+/// The current userspace contract mirrors the eBPF behavior: a valid cookie ACK
+/// is consumed, a RST is sent, and the client's next SYN takes the normal
+/// policy/NAT/session path. For ACK-bearing segments RFC 793 sets the RST
+/// sequence number from the received ACK and does not include an ACK field.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(in crate::afxdp) fn build_syn_cookie_ack_rst_frame(frame: &[u8]) -> Option<Vec<u8>> {
+    let parsed = parse_tcp_reply_source(frame)?;
+    if (parsed.flags & TCP_FLAG_ACK) == 0 || (parsed.flags & TCP_FLAG_SYN) != 0 {
+        return None;
+    }
+    build_syn_cookie_tcp_reply(
+        frame,
+        parsed,
+        TCP_MIN_HEADER_LEN,
+        parsed.ack,
+        0,
+        TCP_FLAG_RST,
+        0,
+    )
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Copy)]
+struct TcpReplySource {
+    l3: usize,
+    addr_family: u8,
+    src_port: u16,
+    dst_port: u16,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn parse_tcp_reply_source(frame: &[u8]) -> Option<TcpReplySource> {
+    let l3 = frame_l3_offset(frame)?;
+    let ip = frame.get(l3..)?;
+    let addr_family = match ip.first()? >> 4 {
+        4 => libc::AF_INET as u8,
+        6 => libc::AF_INET6 as u8,
+        _ => return None,
+    };
+    let l4 = frame_l4_offset(frame, addr_family)?;
+    let tcp = frame.get(l4..l4 + TCP_MIN_HEADER_LEN)?;
+    let protocol = match addr_family as i32 {
+        libc::AF_INET => *ip.get(9)?,
+        libc::AF_INET6 => {
+            let (_, protocol) = packet_rel_l4_offset_and_protocol(ip, addr_family)?;
+            protocol
+        }
+        _ => return None,
+    };
+    if protocol != PROTO_TCP {
+        return None;
+    }
+    Some(TcpReplySource {
+        l3,
+        addr_family,
+        src_port: u16::from_be_bytes([tcp[0], tcp[1]]),
+        dst_port: u16::from_be_bytes([tcp[2], tcp[3]]),
+        seq: u32::from_be_bytes([tcp[4], tcp[5], tcp[6], tcp[7]]),
+        ack: u32::from_be_bytes([tcp[8], tcp[9], tcp[10], tcp[11]]),
+        flags: tcp[13],
+    })
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn build_syn_cookie_tcp_reply(
+    frame: &[u8],
+    parsed: TcpReplySource,
+    tcp_len: usize,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+    advertised_mss: u16,
+) -> Option<Vec<u8>> {
+    match parsed.addr_family as i32 {
+        libc::AF_INET => build_syn_cookie_tcp_reply_v4(
+            frame,
+            parsed,
+            tcp_len,
+            seq,
+            ack,
+            flags,
+            advertised_mss,
+        ),
+        libc::AF_INET6 => build_syn_cookie_tcp_reply_v6(
+            frame,
+            parsed,
+            tcp_len,
+            seq,
+            ack,
+            flags,
+            advertised_mss,
+        ),
+        _ => None,
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn build_syn_cookie_tcp_reply_v4(
+    frame: &[u8],
+    parsed: TcpReplySource,
+    tcp_len: usize,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+    advertised_mss: u16,
+) -> Option<Vec<u8>> {
+    let ip = frame.get(parsed.l3..parsed.l3 + 20)?;
+    let src = Ipv4Addr::new(ip[12], ip[13], ip[14], ip[15]);
+    let dst = Ipv4Addr::new(ip[16], ip[17], ip[18], ip[19]);
+    let total_len = 20usize.checked_add(tcp_len)?;
+    let frame_len = parsed.l3.checked_add(total_len)?;
+    let mut out = vec![0u8; frame_len];
+    write_reply_eth_header(frame, &mut out, parsed.l3)?;
+    let ip_out = out.get_mut(parsed.l3..parsed.l3 + total_len)?;
+    ip_out[0] = 0x45;
+    ip_out[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+    ip_out[8] = SYN_COOKIE_REPLY_TTL;
+    ip_out[9] = PROTO_TCP;
+    ip_out[12..16].copy_from_slice(&dst.octets());
+    ip_out[16..20].copy_from_slice(&src.octets());
+    let ip_sum = checksum16(&ip_out[..20]);
+    ip_out[10..12].copy_from_slice(&ip_sum.to_be_bytes());
+    write_syn_cookie_tcp_header(
+        &mut ip_out[20..20 + tcp_len],
+        parsed,
+        seq,
+        ack,
+        flags,
+        advertised_mss,
+    )?;
+    recompute_l4_checksum_ipv4(ip_out, 20, PROTO_TCP, false)?;
+    Some(out)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn build_syn_cookie_tcp_reply_v6(
+    frame: &[u8],
+    parsed: TcpReplySource,
+    tcp_len: usize,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+    advertised_mss: u16,
+) -> Option<Vec<u8>> {
+    let ip = frame.get(parsed.l3..parsed.l3 + 40)?;
+    let src = ip.get(8..24)?;
+    let dst = ip.get(24..40)?;
+    let frame_len = parsed.l3.checked_add(40)?.checked_add(tcp_len)?;
+    let mut out = vec![0u8; frame_len];
+    write_reply_eth_header(frame, &mut out, parsed.l3)?;
+    let ip_out = out.get_mut(parsed.l3..frame_len)?;
+    ip_out[0] = 0x60;
+    ip_out[4..6].copy_from_slice(&(tcp_len as u16).to_be_bytes());
+    ip_out[6] = PROTO_TCP;
+    ip_out[7] = SYN_COOKIE_REPLY_HOP_LIMIT;
+    ip_out[8..24].copy_from_slice(dst);
+    ip_out[24..40].copy_from_slice(src);
+    write_syn_cookie_tcp_header(
+        &mut ip_out[40..40 + tcp_len],
+        parsed,
+        seq,
+        ack,
+        flags,
+        advertised_mss,
+    )?;
+    recompute_l4_checksum_ipv6(ip_out, PROTO_TCP)?;
+    Some(out)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn write_reply_eth_header(frame: &[u8], out: &mut [u8], l3: usize) -> Option<()> {
+    if l3 != 14 && l3 != 18 {
+        return None;
+    }
+    out.get_mut(0..6)?.copy_from_slice(frame.get(6..12)?);
+    out.get_mut(6..12)?.copy_from_slice(frame.get(0..6)?);
+    if l3 == 18 {
+        out.get_mut(12..18)?.copy_from_slice(frame.get(12..18)?);
+    } else {
+        out.get_mut(12..14)?.copy_from_slice(frame.get(12..14)?);
+    }
+    Some(())
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn write_syn_cookie_tcp_header(
+    tcp: &mut [u8],
+    parsed: TcpReplySource,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+    advertised_mss: u16,
+) -> Option<()> {
+    if tcp.len() != TCP_MIN_HEADER_LEN && tcp.len() != TCP_MIN_HEADER_LEN + TCP_MSS_OPTION_LEN {
+        return None;
+    }
+    tcp[0..2].copy_from_slice(&parsed.dst_port.to_be_bytes());
+    tcp[2..4].copy_from_slice(&parsed.src_port.to_be_bytes());
+    tcp[4..8].copy_from_slice(&seq.to_be_bytes());
+    tcp[8..12].copy_from_slice(&ack.to_be_bytes());
+    tcp[12] = ((tcp.len() / 4) as u8) << 4;
+    tcp[13] = flags;
+    tcp[14..16].copy_from_slice(&SYN_COOKIE_TCP_WINDOW.to_be_bytes());
+    if tcp.len() == TCP_MIN_HEADER_LEN + TCP_MSS_OPTION_LEN {
+        tcp[20] = 2;
+        tcp[21] = 4;
+        tcp[22..24].copy_from_slice(&advertised_mss.to_be_bytes());
+    }
+    Some(())
 }
 
 /// Clamp TCP MSS in a full Ethernet frame starting at `l3_offset`.

--- a/userspace-dp/src/afxdp/frame/tcp.rs
+++ b/userspace-dp/src/afxdp/frame/tcp.rs
@@ -276,6 +276,7 @@ pub(super) fn clamp_tcp_mss(packet: &mut [u8], max_mss: u16) -> bool {
 /// pure byte-construction primitive: it swaps L2/L3/L4 identity, emits a
 /// minimal SYN+ACK with the encoded cookie as the sequence number, advertises
 /// the selected MSS when present, and recomputes checksums from scratch.
+#[inline]
 #[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn build_syn_cookie_syn_ack_frame(
     frame: &[u8],
@@ -319,8 +320,8 @@ pub(in crate::afxdp) fn build_syn_cookie_ack_rst_frame(frame: &[u8]) -> Option<V
         parsed,
         TCP_MIN_HEADER_LEN,
         parsed.ack,
-        0,
-        TCP_FLAG_RST,
+        parsed.seq.wrapping_add(1),
+        TCP_FLAG_RST | TCP_FLAG_ACK,
         0,
     )
 }
@@ -512,7 +513,12 @@ fn write_syn_cookie_tcp_header(
     tcp[8..12].copy_from_slice(&ack.to_be_bytes());
     tcp[12] = ((tcp.len() / 4) as u8) << 4;
     tcp[13] = flags;
-    tcp[14..16].copy_from_slice(&SYN_COOKIE_TCP_WINDOW.to_be_bytes());
+    let window: u16 = if flags & TCP_FLAG_RST != 0 {
+        0
+    } else {
+        SYN_COOKIE_TCP_WINDOW
+    };
+    tcp[14..16].copy_from_slice(&window.to_be_bytes());
     if tcp.len() == TCP_MIN_HEADER_LEN + TCP_MSS_OPTION_LEN {
         tcp[20] = 2;
         tcp[21] = 4;

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -944,6 +944,110 @@ fn tcp_ports_ipv4(packet: &[u8]) -> (u16, u16) {
     )
 }
 
+#[test]
+fn syn_cookie_syn_ack_builder_swaps_tuple_and_preserves_vlan() {
+    let client = Ipv4Addr::new(192, 0, 2, 10);
+    let server = Ipv4Addr::new(198, 51, 100, 20);
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        80,
+        0x0800,
+    );
+    frame.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00,
+    ]);
+    frame.extend_from_slice(&client.octets());
+    frame.extend_from_slice(&server.octets());
+    let ip_csum = checksum16(&frame[18..38]);
+    frame[28..30].copy_from_slice(&ip_csum.to_be_bytes());
+    frame.extend_from_slice(&49152u16.to_be_bytes());
+    frame.extend_from_slice(&443u16.to_be_bytes());
+    frame.extend_from_slice(&0x0102_0304u32.to_be_bytes());
+    frame.extend_from_slice(&0u32.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x50,
+        TCP_FLAG_SYN,
+        0x20,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    ]);
+    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, false).expect("tcp sum");
+
+    let out = build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460)
+        .expect("syn-cookie syn-ack");
+
+    assert_eq!(&out[0..6], &[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+    assert_eq!(&out[6..12], &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    assert_eq!(&out[12..18], &frame[12..18]);
+    assert_eq!(&out[30..34], &server.octets());
+    assert_eq!(&out[34..38], &client.octets());
+    assert_eq!(u16::from_be_bytes([out[20], out[21]]), 44);
+    assert_eq!(u16::from_be_bytes([out[38], out[39]]), 443);
+    assert_eq!(u16::from_be_bytes([out[40], out[41]]), 49152);
+    assert_eq!(
+        u32::from_be_bytes([out[42], out[43], out[44], out[45]]),
+        0xaabb_ccdd
+    );
+    assert_eq!(
+        u32::from_be_bytes([out[46], out[47], out[48], out[49]]),
+        0x0102_0305
+    );
+    assert_eq!(out[50] >> 4, 6);
+    assert_eq!(out[51], TCP_FLAG_SYN | 0x10);
+    assert_eq!(&out[58..62], &[2, 4, 0x05, 0xb4]);
+    assert_eq!(checksum16(&out[18..38]), 0);
+    assert!(tcp_checksum_ok_ipv4(&out[18..]));
+}
+
+#[test]
+fn syn_cookie_ack_rst_builder_uses_received_ack_as_rst_seq() {
+    let client = Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 10);
+    let server = Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 20);
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
+        0,
+        0x86dd,
+    );
+    frame.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]);
+    frame.extend_from_slice(&20u16.to_be_bytes());
+    frame.push(PROTO_TCP);
+    frame.push(64);
+    frame.extend_from_slice(&client.octets());
+    frame.extend_from_slice(&server.octets());
+    frame.extend_from_slice(&49152u16.to_be_bytes());
+    frame.extend_from_slice(&443u16.to_be_bytes());
+    frame.extend_from_slice(&0x1111_2222u32.to_be_bytes());
+    frame.extend_from_slice(&0x3333_4444u32.to_be_bytes());
+    frame.extend_from_slice(&[0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    recompute_l4_checksum_ipv6(&mut frame[14..], PROTO_TCP).expect("tcp sum");
+
+    let out = build_syn_cookie_ack_rst_frame(&frame).expect("syn-cookie rst");
+
+    assert_eq!(&out[0..6], &[0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
+    assert_eq!(&out[6..12], &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    assert_eq!(&out[22..38], &server.octets());
+    assert_eq!(&out[38..54], &client.octets());
+    assert_eq!(u16::from_be_bytes([out[18], out[19]]), 20);
+    assert_eq!(u16::from_be_bytes([out[54], out[55]]), 443);
+    assert_eq!(u16::from_be_bytes([out[56], out[57]]), 49152);
+    assert_eq!(
+        u32::from_be_bytes([out[58], out[59], out[60], out[61]]),
+        0x3333_4444
+    );
+    assert_eq!(u32::from_be_bytes([out[62], out[63], out[64], out[65]]), 0);
+    assert_eq!(out[67], 0x04);
+    assert!(tcp_checksum_ok_ipv6(&out[14..]));
+}
+
 fn icmpv6_checksum_ok(packet: &[u8]) -> bool {
     let src = Ipv6Addr::from(<[u8; 16]>::try_from(&packet[8..24]).expect("src"));
     let dst = Ipv6Addr::from(<[u8; 16]>::try_from(&packet[24..40]).expect("dst"));

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -1086,7 +1086,12 @@ fn syn_cookie_ipv4_rst_builder_pads_to_ethernet_minimum() {
         u32::from_be_bytes([out[38], out[39], out[40], out[41]]),
         0x3333_4444
     );
-    assert_eq!(out[47], TCP_FLAG_RST);
+    assert_eq!(
+        u32::from_be_bytes([out[42], out[43], out[44], out[45]]),
+        0x1111_2223
+    );
+    assert_eq!(out[47], TCP_FLAG_RST | 0x10);
+    assert_eq!(&out[48..50], &[0, 0]);
     assert_eq!(&out[54..60], &[0, 0, 0, 0, 0, 0]);
     assert_eq!(checksum16(&out[14..34]), 0);
     assert!(tcp_checksum_ok_ipv4(&out[14..]));
@@ -1131,7 +1136,12 @@ fn syn_cookie_vlan_ipv4_rst_builder_pads_to_ethernet_minimum() {
         u32::from_be_bytes([out[42], out[43], out[44], out[45]]),
         0x3333_4444
     );
-    assert_eq!(out[51], TCP_FLAG_RST);
+    assert_eq!(
+        u32::from_be_bytes([out[46], out[47], out[48], out[49]]),
+        0x1111_2223
+    );
+    assert_eq!(out[51], TCP_FLAG_RST | 0x10);
+    assert_eq!(&out[52..54], &[0, 0]);
     assert_eq!(&out[58..60], &[0, 0]);
     assert_eq!(checksum16(&out[18..38]), 0);
     assert!(tcp_checksum_ok_ipv4(&out[18..]));
@@ -1175,8 +1185,12 @@ fn syn_cookie_ack_rst_builder_uses_received_ack_as_rst_seq() {
         u32::from_be_bytes([out[58], out[59], out[60], out[61]]),
         0x3333_4444
     );
-    assert_eq!(u32::from_be_bytes([out[62], out[63], out[64], out[65]]), 0);
-    assert_eq!(out[67], 0x04);
+    assert_eq!(
+        u32::from_be_bytes([out[62], out[63], out[64], out[65]]),
+        0x1111_2223
+    );
+    assert_eq!(out[67], TCP_FLAG_RST | 0x10);
+    assert_eq!(&out[68..70], &[0, 0]);
     assert!(tcp_checksum_ok_ipv6(&out[14..]));
 }
 
@@ -1191,7 +1205,7 @@ fn apply_nat_ipv4_recomputes_tcp_checksum() {
     let mut packet = vec![
         0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
         102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
+        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
         b'a', b't', b'a',
     ];
     let ip_sum = checksum16(&packet[..20]);
@@ -1326,7 +1340,7 @@ fn build_forwarded_frame_keeps_tcp_checksum_valid_after_snat() {
     frame.extend_from_slice(&[
         0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
         102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
+        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
         b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
@@ -1800,7 +1814,7 @@ fn enforce_expected_ports_repairs_ipv4_tcp_ports_and_checksum() {
         0x0800,
     );
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x34, 0x00, 0x01, 0x00, 0x00, 63, PROTO_TCP, 0x00, 0x00,
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 63, PROTO_TCP, 0x00, 0x00,
     ]);
     frame.extend_from_slice(&src_ip.octets());
     frame.extend_from_slice(&dst_ip.octets());
@@ -4081,7 +4095,7 @@ fn rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_snat() {
     frame.extend_from_slice(&[
         0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
         102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x50, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
+        0x00, 0x00, 0x50, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
         b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
@@ -4156,7 +4170,7 @@ fn rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_dnat() {
     frame.extend_from_slice(&[
         0x45, 0x00, 0x00, 0x30, 0x00, 0x02, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 172, 16, 80,
         200, 172, 16, 80, 8, 0x14, 0x51, 0x9c, 0x40, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
-        0x02, 0x50, 0x12, 0x20, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a',
+        0x02, 0x50, 0x12, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a',
         b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[18..38]);

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -931,9 +931,10 @@ fn build_forwarded_frame_from_frame_clamps_tcp_mss_for_native_gre() {
 }
 fn tcp_checksum_ok_ipv4(packet: &[u8]) -> bool {
     let ihl = usize::from(packet[0] & 0x0f) * 4;
+    let total_len = usize::from(u16::from_be_bytes([packet[2], packet[3]]));
     let src = Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]);
     let dst = Ipv4Addr::new(packet[16], packet[17], packet[18], packet[19]);
-    checksum16_ipv4(src, dst, PROTO_TCP, &packet[ihl..]) == 0
+    checksum16_ipv4(src, dst, PROTO_TCP, &packet[ihl..total_len]) == 0
 }
 
 fn tcp_ports_ipv4(packet: &[u8]) -> (u16, u16) {
@@ -942,6 +943,39 @@ fn tcp_ports_ipv4(packet: &[u8]) -> (u16, u16) {
         u16::from_be_bytes([packet[ihl], packet[ihl + 1]]),
         u16::from_be_bytes([packet[ihl + 2], packet[ihl + 3]]),
     )
+}
+
+fn build_ipv4_tcp_frame(
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    seq: u32,
+    ack: u32,
+    flags: u8,
+) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        0,
+        0x0800,
+    );
+    frame.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00,
+    ]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    let ip_csum = checksum16(&frame[14..34]);
+    frame[24..26].copy_from_slice(&ip_csum.to_be_bytes());
+    frame.extend_from_slice(&src_port.to_be_bytes());
+    frame.extend_from_slice(&dst_port.to_be_bytes());
+    frame.extend_from_slice(&seq.to_be_bytes());
+    frame.extend_from_slice(&ack.to_be_bytes());
+    frame.extend_from_slice(&[0x50, flags, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false).expect("tcp sum");
+    frame
 }
 
 #[test]
@@ -1003,6 +1037,59 @@ fn syn_cookie_syn_ack_builder_swaps_tuple_and_preserves_vlan() {
     assert_eq!(&out[58..62], &[2, 4, 0x05, 0xb4]);
     assert_eq!(checksum16(&out[18..38]), 0);
     assert!(tcp_checksum_ok_ipv4(&out[18..]));
+}
+
+#[test]
+fn syn_cookie_ipv4_syn_ack_builder_pads_to_ethernet_minimum() {
+    let client = Ipv4Addr::new(192, 0, 2, 10);
+    let server = Ipv4Addr::new(198, 51, 100, 20);
+    let frame = build_ipv4_tcp_frame(
+        client,
+        server,
+        49152,
+        443,
+        0x0102_0304,
+        0,
+        TCP_FLAG_SYN,
+    );
+
+    let out = build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460)
+        .expect("syn-cookie syn-ack");
+
+    assert_eq!(out.len(), 60);
+    assert_eq!(u16::from_be_bytes([out[16], out[17]]), 44);
+    assert_eq!(&out[54..58], &[2, 4, 0x05, 0xb4]);
+    assert_eq!(&out[58..60], &[0, 0]);
+    assert_eq!(checksum16(&out[14..34]), 0);
+    assert!(tcp_checksum_ok_ipv4(&out[14..]));
+}
+
+#[test]
+fn syn_cookie_ipv4_rst_builder_pads_to_ethernet_minimum() {
+    let client = Ipv4Addr::new(192, 0, 2, 10);
+    let server = Ipv4Addr::new(198, 51, 100, 20);
+    let frame = build_ipv4_tcp_frame(
+        client,
+        server,
+        49152,
+        443,
+        0x1111_2222,
+        0x3333_4444,
+        0x10,
+    );
+
+    let out = build_syn_cookie_ack_rst_frame(&frame).expect("syn-cookie rst");
+
+    assert_eq!(out.len(), 60);
+    assert_eq!(u16::from_be_bytes([out[16], out[17]]), 40);
+    assert_eq!(
+        u32::from_be_bytes([out[38], out[39], out[40], out[41]]),
+        0x3333_4444
+    );
+    assert_eq!(out[47], TCP_FLAG_RST);
+    assert_eq!(&out[54..60], &[0, 0, 0, 0, 0, 0]);
+    assert_eq!(checksum16(&out[14..34]), 0);
+    assert!(tcp_checksum_ok_ipv4(&out[14..]));
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -1093,6 +1093,51 @@ fn syn_cookie_ipv4_rst_builder_pads_to_ethernet_minimum() {
 }
 
 #[test]
+fn syn_cookie_vlan_ipv4_rst_builder_pads_to_ethernet_minimum() {
+    let client = Ipv4Addr::new(192, 0, 2, 10);
+    let server = Ipv4Addr::new(198, 51, 100, 20);
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        80,
+        0x0800,
+    );
+    frame.extend_from_slice(&[
+        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00,
+        64, PROTO_TCP, 0x00, 0x00,
+    ]);
+    frame.extend_from_slice(&client.octets());
+    frame.extend_from_slice(&server.octets());
+    let ip_csum = checksum16(&frame[18..38]);
+    frame[28..30].copy_from_slice(&ip_csum.to_be_bytes());
+    frame.extend_from_slice(&49152u16.to_be_bytes());
+    frame.extend_from_slice(&443u16.to_be_bytes());
+    frame.extend_from_slice(&0x1111_2222u32.to_be_bytes());
+    frame.extend_from_slice(&0x3333_4444u32.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, false)
+        .expect("tcp sum");
+
+    let out = build_syn_cookie_ack_rst_frame(&frame).expect("syn-cookie rst");
+
+    assert_eq!(out.len(), 60);
+    assert_eq!(&out[12..18], &frame[12..18]);
+    assert_eq!(u16::from_be_bytes([out[20], out[21]]), 40);
+    assert_eq!(
+        u32::from_be_bytes([out[42], out[43], out[44], out[45]]),
+        0x3333_4444
+    );
+    assert_eq!(out[51], TCP_FLAG_RST);
+    assert_eq!(&out[58..60], &[0, 0]);
+    assert_eq!(checksum16(&out[18..38]), 0);
+    assert!(tcp_checksum_ok_ipv4(&out[18..]));
+}
+
+#[test]
 fn syn_cookie_ack_rst_builder_uses_received_ack_as_rst_seq() {
     let client = Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 10);
     let server = Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 20);


### PR DESCRIPTION
## Summary

- Add pure userspace-dp builders for SYN-cookie SYN-ACK replies
  and validated-ACK RST replies.
- Preserve Ethernet/VLAN identity, reverse IPv4/IPv6/TCP tuples,
  and recompute IP/TCP checksums from scratch.
- Update the #1374 retirement plan to mark construction as landed
  while keeping bounded TX integration, HA-safe secrets, counters,
  and failover validation as explicit remaining blockers.

## Validation

- `cargo test afxdp::frame::tests::syn_cookie_ -- --nocapture`
- `git diff --check`
- `git show -s --format=%B HEAD | awk 'length($0)>72 { print length($0) \":\" $0 }'`\n\n## Notes\n\nThis intentionally does not remove the userspace capability gate. The\nbuilders provide the packet construction primitive for the next slice;\nthe dataplane still needs bounded TX-frame reservation and HA-safe secret\npublication before syn-cookie configs can be admitted.\n\nRefs #1374\nRefs #1373