### PR TITLE
daemon: migrate from DataPlane to RuntimeDataPlane

### DIFF
--- a/docs/pr/1381-dataplane-interface-split/plan.md
+++ b/docs/pr/1381-dataplane-interface-split/plan.md
@@ -1,11 +1,13 @@
 # #1381 dataplane interface split plan
 
-Status: design/scaffold PR for #1381, prerequisite to #1373 Phase 4.
+Status: implementation closeout for #1381's daemon-facing runtime split,
+prerequisite to #1373 Phase 4.
 
-This PR does not remove the eBPF dataplane. It makes the split actionable by
-pinning the target interfaces, the daemon migration order, and the state
-ownership decisions that must hold before the BPF-shaped `dataplane.DataPlane`
-surface can disappear.
+This PR does not remove the eBPF dataplane or the userspace XDP shim maps.
+It makes the split operational by moving daemon startup and runtime control
+onto `RuntimeDataPlane` plus domain interfaces. The old BPF-shaped
+`dataplane.DataPlane` remains as a legacy compatibility surface for eBPF/DPDK
+and isolated adapters, not as the daemon root contract.
 
 ## Current coupling
 
@@ -20,19 +22,17 @@ methods. It mixes:
 - HA, fabric, scheduler, link-cycle, and event APIs.
 
 `pkg/dataplane/userspace/manager.go` used to embed `dataplane.DataPlane` and
-compile by inheriting all eBPF writers. The current migration slice has moved
-that legacy interface satisfaction into `userspace.LegacyDataPlaneAdapter` so
-`*userspace.Manager` implements the small `RuntimeDataPlane` contract instead
-of the BPF-shaped root interface. The manager still keeps
-`inner *dataplane.Manager` for XDP shim maps, BPF conntrack mirrors, DNAT bridge
-maps, FIB generation, RG state, and helper control. Removing that named shim
-dependency remains a later #1381 phase.
+compile by inheriting all eBPF writers. The implementation now registers
+userspace only through `RegisterRuntimeBackend`, so daemon startup constructs
+`*userspace.Manager` directly with `NewRuntimeDataPlane`. The compatibility
+adapter remains available for old `DataPlane` consumers, but it is no longer
+the userspace backend registry entry.
 
-`pkg/daemon` stores one `dataplane.DataPlane` and calls both generic runtime
-methods and BPF-shaped methods from the same field. The real daemon surface is
-smaller than the current interface: lifecycle/config, HA/fabric, session
-lookup/iteration, events, scheduler state, link-cycle hooks, and a few
-userspace-only optional interfaces.
+`pkg/daemon` now stores `dataplane.RuntimeDataPlane` and creates it through
+`NewRuntimeDataPlane`. Runtime work uses config, HA/fabric, session,
+telemetry, scheduler, and link-cycle domains. Remaining `legacyDP()` calls are
+explicit compatibility bridges for old eBPF/DPDK surfaces rather than the
+daemon's root dataplane contract.
 
 ## Current caller inventory
 
@@ -359,11 +359,10 @@ The daemon should migrate in this order:
 7. Replace `NewEventSource` and counter reads with `d.dp.Telemetry()`.
 8. Replace userspace type assertions in fabric/IPVLAN/link-cycle handling with
    `d.dp.Link()` and a narrow userspace binding-ready callback interface.
-9. Delete the remaining userspace `inner *dataplane.Manager` dependency once
-   the XDP shim/session/NAT pins have backend owners. The
-   `dataplane.DataPlane` embedding has already been removed; the current
-   canary now fails if it returns and records the named inner manager as the
-   remaining debt.
+9. Keep the userspace XDP shim dependency explicit as `bpfShim`, not as
+   inherited `dataplane.DataPlane` behavior. The shim owns AF_XDP control,
+   redirect, heartbeat, local-delivery, and mirror pins that intentionally
+   remain below the userspace helper boundary.
 
 ## BPF pin ownership
 
@@ -402,9 +401,8 @@ Phase 0: scaffold and canaries.
 
 - Land this plan.
 - Keep current behavior unchanged.
-- Add AST canary documenting the current userspace embedding and `inner`
-  dependency so future work cannot claim the split is done without updating
-  the test.
+- Add AST canary proving the userspace manager does not embed
+  `dataplane.DataPlane` and that the XDP shim is an explicit field.
 
 Phase 1: interfaces and adapters.
 
@@ -437,11 +435,11 @@ Phase 3: session, NAT, and telemetry ownership.
 
 Phase 4: remove eBPF inheritance.
 
-- Delete `inner *dataplane.Manager` from userspace `Manager`.
 - Keep the inverted scaffold canary strict: userspace Manager must not embed
-  `dataplane.DataPlane`, must not name `*dataplane.Manager`, and must not
-  import `github.com/cilium/ebpf` outside the XDP shim owner package.
-- Remove daemon access to old BPF-shaped interface.
+  `dataplane.DataPlane`; the only allowed eBPF manager reference is the
+  explicitly named userspace XDP shim owner.
+- Remove daemon dependence on the old BPF-shaped interface as its root
+  dataplane contract.
 
 Phase 5: eBPF source retirement gate for #1373.
 
@@ -490,8 +488,8 @@ Required during the split:
 - `go test ./pkg/dataplane/... ./pkg/dataplane/userspace/... ./pkg/daemon/...`
 - `go build ./...`
 - AST canary: userspace `Manager` must not embed `dataplane.DataPlane`; the
-  remaining named `inner *dataplane.Manager` dependency is recorded as debt and
-  must fail once Phase 4 removes it.
+  explicit `bpfShim` field documents the userspace XDP shim owner and prevents
+  accidental reintroduction of root-interface inheritance.
 - Interface method-count canary: the exported root `DataPlane` interface has
   at most 15 methods after Phase 1.
 - Import canary: the abstract dataplane/runtime package must not import
@@ -538,7 +536,8 @@ Operational canaries:
 - Removing eBPF programs or generated BPF Go files.
 - Replacing AF_XDP/XDP shim attachment.
 - Implementing #1374 through #1380 feature parity.
-- Making userspace manager independent of `*dataplane.Manager` in this patch.
+- Removing the userspace XDP shim maps/programs that still intentionally use
+  `*dataplane.Manager` as their owner.
 
 ## Phase 1 acceptance gate
 
@@ -597,11 +596,17 @@ interface in place and adds the new contract beside it:
   `DataPlane` for compatibility, but immediately adapt it with
   `SessionStoreOf`/`TelemetryOf`.
 
-Remaining Phase 1 work is still explicit: daemon/API/gRPC/CLI operator metadata
-callers now read `LastApplyResult()` and a canary prevents those packages from
-regressing to `LastCompileResult()`. GC and HA session sync have moved to the
-runtime session/telemetry domains. Remaining work is API/gRPC/CLI session and
-counter readers, daemon control paths, userspace-specific diagnostic/control
-extensions, and the final userspace `inner *dataplane.Manager` shim removal.
-The legacy `DataPlane` method-count canary can only flip after those callers no
-longer need the BPF-shaped surface.
+The closeout slice moves daemon startup to `NewRuntimeDataPlane`, registers
+userspace only as a runtime backend, keeps `legacyDP()` as an explicit
+compatibility bridge for old eBPF/DPDK surfaces, and documents the userspace
+XDP shim maps as the remaining intentional eBPF manager owner. Apply-time
+config now goes through `ConfigSink.ApplyConfig`, not
+`legacyDP().Compile`, so a bare userspace `*Manager` can receive commits
+without pretending to implement the legacy BPF writer surface. Runtime policy
+scheduler updates likewise use the runtime updater interface when present and
+fall back to `legacyDP()` only for compatibility backends.
+
+HA fail-closed shutdown now wraps controller calls in one daemon-owned
+deadline. Userspace helper RPCs still retain their internal dial/read
+deadlines, but daemon shutdown proceeds when the outer deadline expires rather
+than waiting for those nested RPC timers to finish.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -10,11 +10,16 @@ together.
 This is the package `cmd/xpfd` instantiates. It depends on essentially
 every other internal package.
 
-The daemon currently stores dataplane backends behind the transitional
-BPF-shaped `dataplane.DataPlane` interface. #1381 will replace that with
-domain interfaces for config, HA/fabric, sessions, telemetry, and link-cycle
-hooks; the actionable plan is in
-`docs/pr/1381-dataplane-interface-split/plan.md`.
+The daemon stores dataplane backends behind `dataplane.RuntimeDataPlane` and
+uses the split config, HA/fabric, sessions, telemetry, and link-cycle domains.
+Legacy `dataplane.DataPlane` access is isolated behind `legacyDP()` for
+callers that still need eBPF/DPDK compatibility while their domain adapters
+are completed.
+
+Config apply uses the runtime `ConfigSink.ApplyConfig` path. This is required
+for userspace AF_XDP, which is intentionally not exposed as a legacy
+`DataPlane`; apply-time callers must not reintroduce `legacyDP().Compile` as
+the primary compile/apply gate.
 
 ## Entry points
 
@@ -57,3 +62,7 @@ Any interface not declared in the active config is brought down and given
 - FRR reload runs with a 15 s context timeout to keep `systemctl reload
   frr` from hanging. The systemd unit has `TimeoutStopSec=20` as a safety
   net.
+- HA fail-closed shutdown clears `rg_active` and watchdog state through the
+  runtime HA controller under one daemon-owned deadline. Controller
+  implementations may have their own RPC deadlines, but daemon shutdown does
+  not wait past the outer deadline for those calls to return.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -59,7 +59,7 @@ const nodeIDFile = "/etc/xpf/node-id"
 type Daemon struct {
 	opts                       Options
 	store                      *configstore.Store
-	dp                         dataplane.DataPlane
+	dp  dataplane.RuntimeDataPlane
 	networkd                   *networkd.Manager
 	routing                    *routing.Manager
 	frr                        *frr.Manager
@@ -340,4 +340,17 @@ func New(opts Options) *Daemon {
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 		applySem:                   semaphore.NewWeighted(1),
 	}
+}
+
+// legacyDP returns the daemon's underlying dataplane.DataPlane for call sites
+// that have not yet migrated to RuntimeDataPlane domain interfaces.
+// Returns nil if d.dp is nil or the concrete type does not implement DataPlane.
+func (d *Daemon) legacyDP() dataplane.DataPlane {
+	if d.dp == nil {
+		return nil
+	}
+	if lp, ok := d.dp.(dataplane.DataPlane); ok {
+		return lp
+	}
+	return nil
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -313,7 +313,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		addrs  []string
 	}
 	var deferredOverlays []deferredIPVLAN
-	bindingCtrl, isUserspaceDP := d.dp.(userspaceXSKBindingController)
+		bindingCtrl, isUserspaceDP := d.legacyDP().(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
 		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
 			continue
@@ -421,20 +421,22 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 				break
 			}
 		}
-		if rethMACPending {
-			type deferSetter interface{ SetDeferWorkers(bool) }
-			if ds, ok := d.dp.(deferSetter); ok {
-				ds.SetDeferWorkers(true)
-				deferWorkersActive = true
-				clearDeferWorkers = func() {
-					ds.SetDeferWorkers(false)
-				}
-				defer func() {
-					if deferWorkersActive {
-						clearDeferWorkers()
-					}
-				}()
+	if rethMACPending {
+		type deferSetter interface{ SetDeferWorkers(bool) }
+		if ds, ok := d.legacyDP().(deferSetter); ok {
+			ds.SetDeferWorkers(true)
+		}
+		deferWorkersActive = true
+		clearDeferWorkers = func() {
+			if ds, ok := d.legacyDP().(deferSetter); ok {
+				ds.SetDeferWorkers(false)
 			}
+		}
+			defer func() {
+				if deferWorkersActive {
+					clearDeferWorkers()
+				}
+			}()
 		}
 	}
 
@@ -446,7 +448,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	var compileResult *dataplane.CompileResult
 	if d.dp != nil {
 		var err error
-		if compileResult, err = d.dp.Compile(cfg); err != nil {
+		if compileResult, err = d.legacyDP().Compile(cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
 				return err
@@ -552,11 +554,8 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 				// been accessing UMEM during the DOWN/UP). The rebind
 				// in NotifyLinkCycle will restart them.
 				if d.dp != nil {
-					type linkCyclePreparer interface{ PrepareLinkCycle() }
-					if preparer, ok := d.dp.(linkCyclePreparer); ok {
-						slog.Info("userspace: stopping workers after RETH MAC link cycle")
-						preparer.PrepareLinkCycle()
-					}
+					slog.Info("userspace: stopping workers after RETH MAC link cycle")
+					d.dp.Link().PrepareLinkCycle()
 				}
 			}
 			needLinkCycleRecovery = needLinkCycleRecovery || linkCycled
@@ -655,7 +654,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	if d.dp != nil && needLinkCycleRecovery {
 		// Actual link DOWN/UP occurred — old XSK sockets are dead.
 		// Rebind to create fresh sockets on the reinitialized queues.
-		d.dp.NotifyLinkCycle()
+		d.dp.Link().NotifyLinkCycle()
 		if d.ra != nil {
 			d.ra.ResendBurst()
 		}
@@ -663,7 +662,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		// MAC set live (no link cycle) but workers were deferred.
 		// Trigger a re-Compile to start workers with the now-correct MAC.
 		// This is cheaper than NotifyLinkCycle (no stop_workers/rebind).
-		if _, err := d.dp.Compile(cfg); err != nil {
+		if _, err := d.legacyDP().Compile(cfg); err != nil {
 			slog.Warn("failed to re-compile after deferred MAC", "err", err)
 		}
 	}
@@ -1050,8 +1049,8 @@ func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, ac
 	if d.dp == nil || activeState == nil || compileResult == nil {
 		return
 	}
-	if _, isUserspace := d.dp.(userspaceRuntimeModeReporter); isUserspace {
+	if _, isUserspace := d.legacyDP().(userspaceRuntimeModeReporter); isUserspace {
 		return
 	}
-	d.dp.UpdatePolicyScheduleState(cfg, activeState)
+	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -448,7 +448,11 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	var compileResult *dataplane.CompileResult
 	if d.dp != nil {
 		var err error
-		if compileResult, err = d.legacyDP().Compile(cfg); err != nil {
+		lp := d.legacyDP()
+		if lp == nil {
+			return errors.New("cannot compile: legacy dataplane not available")
+		}
+		if compileResult, err = lp.Compile(cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
 				return err
@@ -662,8 +666,10 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		// MAC set live (no link cycle) but workers were deferred.
 		// Trigger a re-Compile to start workers with the now-correct MAC.
 		// This is cheaper than NotifyLinkCycle (no stop_workers/rebind).
-		if _, err := d.legacyDP().Compile(cfg); err != nil {
-			slog.Warn("failed to re-compile after deferred MAC", "err", err)
+		if lp := d.legacyDP(); lp != nil {
+			if _, err := lp.Compile(cfg); err != nil {
+				slog.Warn("failed to re-compile after deferred MAC", "err", err)
+			}
 		}
 	}
 
@@ -1046,11 +1052,12 @@ func compileErrorMustAbortApply(err error) bool {
 }
 
 func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, compileResult *dataplane.CompileResult) {
-	if d.dp == nil || activeState == nil || compileResult == nil {
+	lp := d.legacyDP()
+	if lp == nil || activeState == nil || compileResult == nil {
 		return
 	}
-	if _, isUserspace := d.legacyDP().(userspaceRuntimeModeReporter); isUserspace {
+	if _, isUserspace := lp.(userspaceRuntimeModeReporter); isUserspace {
 		return
 	}
-	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
+	lp.UpdatePolicyScheduleState(cfg, activeState)
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -313,7 +313,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		addrs  []string
 	}
 	var deferredOverlays []deferredIPVLAN
-		bindingCtrl, isUserspaceDP := d.legacyDP().(userspaceXSKBindingController)
+	bindingCtrl, isUserspaceDP := d.dp.(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
 		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
 			continue
@@ -397,7 +397,7 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 
 	// 1.9. Pre-check: will RETH MAC programming require a link cycle?
 	// If yes, tell the userspace DP to skip initial worker startup during
-	// Compile(). Workers will be started by NotifyLinkCycle() after MAC
+	// ApplyConfig(). Workers will be started by NotifyLinkCycle() after MAC
 	// programming is done. This avoids the double-bind that causes EBUSY
 	// on mlx5 zero-copy queues.
 	rethMACPending := false
@@ -421,17 +421,12 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 				break
 			}
 		}
-	if rethMACPending {
-		type deferSetter interface{ SetDeferWorkers(bool) }
-		if ds, ok := d.legacyDP().(deferSetter); ok {
-			ds.SetDeferWorkers(true)
-		}
-		deferWorkersActive = true
-		clearDeferWorkers = func() {
-			if ds, ok := d.legacyDP().(deferSetter); ok {
-				ds.SetDeferWorkers(false)
+		if rethMACPending {
+			d.setDataplaneDeferWorkers(true)
+			deferWorkersActive = true
+			clearDeferWorkers = func() {
+				d.setDataplaneDeferWorkers(false)
 			}
-		}
 			defer func() {
 				if deferWorkersActive {
 					clearDeferWorkers()
@@ -444,15 +439,11 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	policySchedulerActiveState := d.policySchedulerActiveStateForApplyLocked(cfg, policySchedulerApplyTime)
 	d.seedPolicySchedulerActiveStateLocked(policySchedulerActiveState)
 
-	// 2. Compile eBPF dataplane
-	var compileResult *dataplane.CompileResult
+	// 2. Apply dataplane config through the runtime config sink.
+	var applyResult *dataplane.ApplyResult
 	if d.dp != nil {
 		var err error
-		lp := d.legacyDP()
-		if lp == nil {
-			return errors.New("cannot compile: legacy dataplane not available")
-		}
-		if compileResult, err = lp.Compile(cfg); err != nil {
+		if applyResult, err = d.dp.ApplyConfig(context.Background(), cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
 				return err
@@ -462,9 +453,9 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		}
 	}
 	policySchedulerActiveState = d.reconcilePolicySchedulerLockedAt(cfg, policySchedulerApplyTime)
-	d.publishInitialPolicySchedulerStateLocked(cfg, policySchedulerActiveState, compileResult)
+	d.publishInitialPolicySchedulerStateLocked(cfg, policySchedulerActiveState, applyResult)
 
-	// Clear defer flag after Compile so subsequent recompiles (where MAC
+	// Clear defer flag after ApplyConfig so subsequent applies (where MAC
 	// is already set) don't skip workers.
 	if deferWorkersActive {
 		clearDeferWorkers()
@@ -491,13 +482,13 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	}
 
 	// 2.2. Build zone→RG map for per-RG session sync.
-	if d.sessionSync != nil && compileResult != nil {
-		d.sessionSync.SetZoneRGMap(buildZoneRGMap(cfg, compileResult.ZoneIDs))
+	if d.sessionSync != nil && applyResult != nil {
+		d.sessionSync.SetZoneRGMap(buildZoneRGMap(cfg, applyResult.ZoneIDs))
 	}
 
 	// 2.5. Write systemd-networkd config for managed interfaces
-	if d.networkd != nil && compileResult != nil && len(compileResult.ManagedInterfaces) > 0 {
-		if err := d.networkd.Apply(compileResult.ManagedInterfaces); err != nil {
+	if d.networkd != nil && applyResult != nil && len(applyResult.ManagedInterfaces) > 0 {
+		if err := d.networkd.Apply(applyResult.ManagedInterfaces); err != nil {
 			slog.Warn("failed to apply networkd config", "err", err)
 		}
 	}
@@ -664,12 +655,10 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		}
 	} else if d.dp != nil && rethMACPending && !needLinkCycleRecovery {
 		// MAC set live (no link cycle) but workers were deferred.
-		// Trigger a re-Compile to start workers with the now-correct MAC.
+		// Trigger a re-apply to start workers with the now-correct MAC.
 		// This is cheaper than NotifyLinkCycle (no stop_workers/rebind).
-		if lp := d.legacyDP(); lp != nil {
-			if _, err := lp.Compile(cfg); err != nil {
-				slog.Warn("failed to re-compile after deferred MAC", "err", err)
-			}
+		if _, err := d.dp.ApplyConfig(context.Background(), cfg); err != nil {
+			slog.Warn("failed to re-apply after deferred MAC", "err", err)
 		}
 	}
 
@@ -1051,13 +1040,24 @@ func compileErrorMustAbortApply(err error) bool {
 	return errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible)
 }
 
-func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, compileResult *dataplane.CompileResult) {
-	lp := d.legacyDP()
-	if lp == nil || activeState == nil || compileResult == nil {
+func (d *Daemon) setDataplaneDeferWorkers(deferWorkers bool) {
+	if d.dp == nil {
 		return
 	}
-	if _, isUserspace := lp.(userspaceRuntimeModeReporter); isUserspace {
+	type deferSetter interface{ SetDeferWorkers(bool) }
+	if setter, ok := d.dp.(deferSetter); ok {
+		setter.SetDeferWorkers(deferWorkers)
 		return
 	}
-	lp.UpdatePolicyScheduleState(cfg, activeState)
+	d.dp.Link().SetDeferWorkers(deferWorkers)
+}
+
+func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, applyResult *dataplane.ApplyResult) {
+	if d.dp == nil || activeState == nil || applyResult == nil {
+		return
+	}
+	if _, isUserspace := d.dp.(userspaceRuntimeModeReporter); isUserspace {
+		return
+	}
+	d.updatePolicyScheduleStateLocked(cfg, activeState)
 }

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+func TestApplyConfigRuntimeResultDrivesDownstreamConsumers(t *testing.T) {
+	networkDir := t.TempDir()
+	installFakeNetworkctl(t)
+
+	dp := &runtimeOnlyApplyTestDP{
+		applyResult: &dataplane.ApplyResult{
+			ZoneIDs: map[string]uint16{"trust": 7},
+			ManagedInterfaces: []networkd.InterfaceConfig{{
+				Name:      "ge-0-0-0",
+				Addresses: []string{"192.0.2.1/24"},
+			}},
+		},
+	}
+	ss := cluster.NewSessionSync(":0", "127.0.0.1:4785", nil)
+	ss.IsPrimaryFn = func() bool { return false }
+	ss.IsPrimaryForRGFn = func(rgID int) bool { return rgID == 2 }
+	d := &Daemon{
+		dp:          dp,
+		networkd:    networkd.NewInDir(networkDir),
+		sessionSync: ss,
+		store:       configstore.New(filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:     vrrp.NewManager(),
+		opts:        Options{NoDataplane: true},
+	}
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name:            "reth0",
+					RedundancyGroup: 2,
+				},
+			},
+		},
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust": {
+					Name:       "trust",
+					Interfaces: []string{"reth0.0"},
+				},
+			},
+		},
+	}
+
+	if err := d.applyConfigLocked(cfg); err != nil {
+		t.Fatalf("applyConfigLocked: %v", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("ApplyConfig calls = %d, want 1", dp.applyCalls)
+	}
+	if !ss.ShouldSyncZone(7) {
+		t.Fatal("session sync did not use runtime ApplyResult ZoneIDs")
+	}
+	if ss.ShouldSyncZone(8) {
+		t.Fatal("session sync unexpectedly owns unmapped zone 8")
+	}
+
+	networkPath := filepath.Join(networkDir, "10-xpf-ge-0-0-0.network")
+	data, err := os.ReadFile(networkPath)
+	if err != nil {
+		t.Fatalf("read generated networkd file: %v", err)
+	}
+	if !strings.Contains(string(data), "Address=192.0.2.1/24") {
+		t.Fatalf("networkd file missing runtime managed address:\n%s", string(data))
+	}
+}
+
+func installFakeNetworkctl(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	networkctl := filepath.Join(binDir, "networkctl")
+	if err := os.WriteFile(networkctl, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake networkctl: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -211,7 +211,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				// already superseded this transition.
 				if tr.Changed && d.dp != nil {
 					cur, _ := s.CurrentDesired()
-					if err := d.dp.UpdateRGActive(ev.GroupID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
@@ -279,7 +279,7 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 					if !cur && !clusterDemotionEdge {
 						d.tryPrepareUserspaceRGDemotion(ev.GroupID)
 					}
-					if err := d.dp.UpdateRGActive(ev.GroupID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
 						slog.Warn("failed to update rg_active from cluster event",
 							"rg", ev.GroupID, "active", cur, "err", err)
 					} else {
@@ -400,7 +400,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 					// Only activate when ALL VRRP instances in the RG
 					// are MASTER — prevents partial ownership (#132).
 					cur, _ := s.CurrentDesired()
-					if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
+					if err := d.dp.HA().SetRGActive(ctx, rgID, cur); err != nil {
 						slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 					} else {
 						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
@@ -434,7 +434,7 @@ func (d *Daemon) watchVRRPEvents(ctx context.Context) {
 						if !cur {
 							d.tryPrepareUserspaceRGDemotion(rgID)
 						}
-						if err := d.dp.UpdateRGActive(rgID, cur); err != nil {
+						if err := d.dp.HA().SetRGActive(ctx, rgID, cur); err != nil {
 							slog.Warn("failed to update rg_active", "rg", rgID, "err", err)
 						} else {
 							recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
@@ -581,7 +581,7 @@ func (d *Daemon) reconcileRGState() {
 			if tr.Active {
 				// Activation ordering: set rg_active FIRST, then
 				// remove blackholes.
-				if err := d.dp.UpdateRGActive(rgID, true); err != nil {
+				if err := d.dp.HA().SetRGActive(context.Background(), rgID, true); err != nil {
 					if s.ShouldLogApplyError(err.Error()) {
 						slog.Warn("reconcile: failed to update rg_active",
 							"rg", rgID, "active", true, "err", err)
@@ -597,7 +597,7 @@ func (d *Daemon) reconcileRGState() {
 				// clear rg_active.
 				d.injectBlackholeRoutes(rgID)
 				d.tryPrepareUserspaceRGDemotion(rgID)
-				if err := d.dp.UpdateRGActive(rgID, false); err != nil {
+				if err := d.dp.HA().SetRGActive(context.Background(), rgID, false); err != nil {
 					if s.ShouldLogApplyError(err.Error()) {
 						slog.Warn("reconcile: failed to update rg_active",
 							"rg", rgID, "active", false, "err", err)
@@ -1086,7 +1086,7 @@ func (d *Daemon) warmNeighborCache() {
 	// Iterate IPv4 sessions: collect unique dst IPs (forward entries
 	// need ARP for the next-hop toward the destination) and unique src IPs
 	// (return entries need ARP for the on-link client).
-	_ = d.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	_ = d.dp.Sessions().ForEachV4(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -1100,7 +1100,7 @@ func (d *Daemon) warmNeighborCache() {
 	})
 
 	// Iterate IPv6 sessions.
-	_ = d.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	_ = d.dp.Sessions().ForEachV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -210,7 +210,7 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 		// Actively probe for neighbor entry on the overlay (#129).
 		d.probeFabricNeighbor(ctx, overlay, peerIP)
 
-		if d.refreshFabricFwd(fabIface, overlay, peerIP, i == 0) {
+		if d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, i == 0) {
 			break
 		}
 		if i == 9 {
@@ -227,9 +227,9 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, false)
 		case <-d.fabricRefreshCh:
-			d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd(ctx, fabIface, overlay, peerIP, false)
 		}
 	}
 }
@@ -391,19 +391,19 @@ func (d *Daemon) retainFabricFwdOnNeighborMiss(slot int, peerIP net.IP, overlay 
 // population and periodic drift correction.
 // fabIface is the physical parent (for ifindex/MAC); overlay is the IPVLAN
 // child where the sync IP lives (for neighbor resolution, #129).
-func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
+func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
 	link, err := netlink.LinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (link not found)",
 			"interface", fabIface, "err", err)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 	localMAC := link.Attrs().HardwareAddr
 	if len(localMAC) != 6 {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (invalid local mac)",
 			"interface", fabIface, "local_mac", localMAC)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -412,7 +412,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	if operState != netlink.OperUp && operState != netlink.OperUnknown {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (link not operational)",
 			"interface", fabIface, "oper_state", operState)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -444,7 +444,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 	var peerMAC net.HardwareAddr
@@ -501,7 +501,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 		if d.retainFabricFwdOnNeighborMiss(0, peerIP, overlay, logWaiting) {
 			return true
 		}
-		d.clearFabricFwd0()
+		d.clearFabricFwd0(ctx)
 		return false
 	}
 
@@ -527,7 +527,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (dataplane not ready)")
 		return false
 	}
-	if err := d.dp.UpdateFabricFwd(info); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(0), info); err != nil {
 		slog.Warn("cluster: failed to update fabric_fwd map", "err", err)
 		return false
 	}
@@ -545,7 +545,7 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 	// cross-chassis fabric redirect. The initial snapshot may have
 	// been built before the peer MAC was resolved.
 	if d.dp != nil {
-		d.dp.SyncFabricState()
+		d.dp.HA().SyncFabricState(ctx)
 	}
 
 	return true
@@ -553,14 +553,14 @@ func (d *Daemon) refreshFabricFwd(fabIface, overlay string, peerIP net.IP, logWa
 
 // clearFabricFwd0 writes a zeroed FabricFwdInfo to key=0 if a valid entry
 // was previously written, ensuring the dataplane falls back (#121).
-func (d *Daemon) clearFabricFwd0() {
+func (d *Daemon) clearFabricFwd0(ctx context.Context) {
 	d.fabricMu.RLock()
 	populated := d.fabricPopulated
 	d.fabricMu.RUnlock()
 	if !populated || d.dp == nil {
 		return
 	}
-	if err := d.dp.UpdateFabricFwd(dataplane.FabricFwdInfo{}); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(0), dataplane.FabricFwdInfo{}); err != nil {
 		slog.Warn("cluster: failed to clear fabric_fwd[0]", "err", err)
 		return
 	}
@@ -603,7 +603,7 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 		// Probe on the overlay (#129).
 		d.probeFabricNeighbor(ctx, overlay, peerIP)
 
-		if d.refreshFabricFwd1(fabIface, overlay, peerIP, i == 0) {
+		if d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, i == 0) {
 			break
 		}
 		if i == 9 {
@@ -620,9 +620,9 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.refreshFabricFwd1(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
 		case <-d.fabricRefreshCh:
-			d.refreshFabricFwd1(fabIface, overlay, peerIP, false)
+			d.refreshFabricFwd1(ctx, fabIface, overlay, peerIP, false)
 		}
 	}
 }
@@ -630,19 +630,19 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 // refreshFabricFwd1 resolves secondary fabric link/neighbor state and updates
 // the fabric_fwd BPF map at key=1. Returns true on success.
 // fabIface is the physical parent; overlay is the IPVLAN child (#129).
-func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
+func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
 	link, err := netlink.LinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (link not found)",
 			"interface", fabIface, "err", err)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 	localMAC := link.Attrs().HardwareAddr
 	if len(localMAC) != 6 {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (invalid local mac)",
 			"interface", fabIface, "local_mac", localMAC)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -651,7 +651,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 	if operState != netlink.OperUp && operState != netlink.OperUnknown {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (link not operational)",
 			"interface", fabIface, "oper_state", operState)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -678,7 +678,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 	var peerMAC net.HardwareAddr
@@ -693,7 +693,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 		if d.retainFabricFwdOnNeighborMiss(1, peerIP, overlay, logWaiting) {
 			return true
 		}
-		d.clearFabricFwd1()
+		d.clearFabricFwd1(ctx)
 		return false
 	}
 
@@ -712,7 +712,7 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (dataplane not ready)")
 		return false
 	}
-	if err := d.dp.UpdateFabricFwd1(info); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(1), info); err != nil {
 		slog.Warn("cluster: failed to update fabric1_fwd map", "err", err)
 		return false
 	}
@@ -730,14 +730,14 @@ func (d *Daemon) refreshFabricFwd1(fabIface, overlay string, peerIP net.IP, logW
 
 // clearFabricFwd1 writes a zeroed FabricFwdInfo to key=1 if a valid entry
 // was previously written, ensuring the dataplane falls back (#121).
-func (d *Daemon) clearFabricFwd1() {
+func (d *Daemon) clearFabricFwd1(ctx context.Context) {
 	d.fabricMu.RLock()
 	populated := d.fabric1Populated
 	d.fabricMu.RUnlock()
 	if !populated || d.dp == nil {
 		return
 	}
-	if err := d.dp.UpdateFabricFwd1(dataplane.FabricFwdInfo{}); err != nil {
+	if err := d.dp.HA().SetFabricForwarding(ctx, dataplane.FabricID(1), dataplane.FabricFwdInfo{}); err != nil {
 		slog.Warn("cluster: failed to clear fabric_fwd[1]", "err", err)
 		return
 	}
@@ -770,7 +770,7 @@ func (d *Daemon) RefreshFabricFwd() {
 			}
 			d.fabricMu.Unlock()
 		}
-		d.refreshFabricFwd(fabIface, overlay, peerIP, false)
+		d.refreshFabricFwd(context.Background(), fabIface, overlay, peerIP, false)
 	}
 	if fabIface1 != "" && peerIP1 != nil {
 		if time.Since(probeAt1) >= 2*time.Second {
@@ -781,7 +781,7 @@ func (d *Daemon) RefreshFabricFwd() {
 			}
 			d.fabricMu.Unlock()
 		}
-		d.refreshFabricFwd1(fabIface1, overlay1, peerIP1, false)
+		d.refreshFabricFwd1(context.Background(), fabIface1, overlay1, peerIP1, false)
 	}
 }
 

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -268,7 +268,7 @@ func (d *Daemon) startSessionSyncPrimeRetry(gen uint64) {
 // callback into QueueSessionV4/V6). Falls back to the old BulkSync path
 // (iterating BPF maps from Go) when the event stream isn't available.
 func (d *Daemon) bulkSyncViaEventStreamOrFallback(ss *cluster.SessionSync) error {
-	if exporter, ok := d.dp.(userspaceEventStreamExporter); ok {
+	if exporter, ok := d.legacyDP().(userspaceEventStreamExporter); ok {
 		slog.Info("cluster: using event stream export for bulk sync")
 		if err := exporter.ExportAllSessionsViaEventStream(); err != nil {
 			slog.Warn("cluster: event stream bulk export failed, falling back to BulkSync", "err", err)
@@ -278,7 +278,7 @@ func (d *Daemon) bulkSyncViaEventStreamOrFallback(ss *cluster.SessionSync) error
 		}
 	}
 	slog.Info("cluster: event stream export not available, falling back to BulkSync",
-		"dp_type", fmt.Sprintf("%T", d.dp))
+		"dp_type", fmt.Sprintf("%T", d.legacyDP()))
 	if ss == nil {
 		return fmt.Errorf("session sync not initialized")
 	}
@@ -400,7 +400,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 					now := uint64(ts.Sec)
 					for _, rg := range cc.RedundancyGroups {
-						if err := d.dp.UpdateHAWatchdog(rg.ID, now); err != nil {
+						if err := d.dp.HA().SetHAWatchdog(commsCtx, rg.ID, now); err != nil {
 							slog.Warn("ha watchdog write failed", "rg", rg.ID, "err", err)
 						}
 					}
@@ -667,7 +667,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				slog.Warn("cluster: fence received from peer, disabling all RGs")
 				if cfg.Chassis.Cluster != nil {
 					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-						if err := d.dp.UpdateRGActive(rg.ID, false); err != nil {
+						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {
 							slog.Warn("cluster: fence: failed to disable rg_active",
 								"rg", rg.ID, "err", err)
 						}
@@ -679,7 +679,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			var streamProvider userspaceEventStreamProvider
 			streamCallbacksWired := false
 			if d.dp != nil {
-				if provider, ok := d.dp.(userspaceEventStreamProvider); ok {
+				if provider, ok := d.legacyDP().(userspaceEventStreamProvider); ok {
 					streamProvider = provider
 					wireCtx, cancel := context.WithTimeout(commsCtx, 5*time.Second)
 					streamCallbacksWired = d.wireUserspaceEventStreamCallbacks(wireCtx, provider)
@@ -715,7 +715,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				// Must happen here (not in Run) because d.sessionSync is
 				// created asynchronously in this goroutine.
 				if d.dp != nil {
-					d.sessionSync.SetDataPlane(d.dp)
+					d.sessionSync.SetDataPlane(d.legacyDP())
 					d.sessionSync.IsPrimaryFn = func() bool {
 						return d.cluster != nil && d.cluster.IsLocalPrimary(0)
 					}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -247,18 +247,24 @@ func (d *Daemon) Run(ctx context.Context) error {
 			slog.Error("failed to create dataplane", "type", dpType, "err", err)
 			return fmt.Errorf("create dataplane: %w", err)
 		}
-		d.dp = dp
-		if err := d.dp.Load(); err != nil {
-			slog.Warn("failed to load dataplane programs, running in config-only mode",
+		var ok bool
+		d.dp, ok = dp.(dataplane.RuntimeDataPlane)
+		if !ok {
+			return fmt.Errorf("dataplane type %q does not implement RuntimeDataPlane", dpType)
+		}
+		if err := d.dp.Start(ctx); err != nil {
+			slog.Warn("failed to start dataplane, running in config-only mode",
 				"err", err)
 			d.dp = nil
 		} else {
-			d.dp.SeedNATPortCounters()
-			nodeID := 0
-			if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
-				nodeID = cfg.Chassis.Cluster.NodeID
+			if lp := d.legacyDP(); lp != nil {
+				lp.SeedNATPortCounters()
+				nodeID := 0
+				if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
+					nodeID = cfg.Chassis.Cluster.NodeID
+				}
+				lp.SeedSessionIDCounter(nodeID)
 			}
-			d.dp.SeedSessionIDCounter(nodeID)
 		}
 		// Apply current config — needed even in config-only mode so that
 		// VRFs, interfaces, and routing are configured before cluster comms.
@@ -300,9 +306,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	var er *logging.EventReader
 	if d.dp != nil {
 		// Start FIB sync (DPDK: background route populator; eBPF: no-op)
-		d.dp.StartFIBSync(ctx)
+		if lp := d.legacyDP(); lp != nil {
+			lp.StartFIBSync(ctx)
+		}
 
-		gc := conntrack.NewGC(d.dp, 10*time.Second)
+		gc := conntrack.NewGC(d.legacyDP(), 10*time.Second)
 		d.gc = gc
 
 		// When the userspace dataplane is active, skip BPF session map
@@ -345,7 +353,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			gc.Run(ctx)
 		}()
 
-		evSrc, evErr := d.dp.NewEventSource()
+		evSrc, evErr := d.dp.Telemetry().NewEventSource()
 		if evErr != nil {
 			slog.Warn("failed to create event source", "err", evErr)
 		}
@@ -382,7 +390,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.SrcPort = binary.BigEndian.Uint16(raw[40:42])
 						key.DstPort = binary.BigEndian.Uint16(raw[42:44])
 						key.Protocol = proto
-						if val, err := d.dp.GetSessionV6(key); err == nil && val.IsReverse == 0 {
+						if val, err := d.dp.Sessions().GetV6(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
 								d.sessionSync.QueueSessionV6(key, val)
 							}
@@ -394,7 +402,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 						key.SrcPort = binary.BigEndian.Uint16(raw[40:42])
 						key.DstPort = binary.BigEndian.Uint16(raw[42:44])
 						key.Protocol = proto
-						if val, err := d.dp.GetSessionV4(key); err == nil && val.IsReverse == 0 {
+						if val, err := d.dp.Sessions().GetV4(key); err == nil && val.IsReverse == 0 {
 							if d.sessionSync.ShouldSyncZone(val.IngressZone) {
 								d.sessionSync.QueueSessionV4(key, val)
 							}
@@ -643,7 +651,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		apiCfg := api.Config{
 			Addr:     d.opts.APIAddr,
 			Store:    d.store,
-			DP:       d.dp,
+			DP:       d.legacyDP(),
 			EventBuf: eventBuf,
 			GC:       d.gc,
 			Routing:  d.routing,
@@ -722,14 +730,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// `show chassis forwarding`).  Shared between the gRPC server
 	// and the local CLI; both paths call Snapshot() at query time.
 	// Started here so the ring is populated before the first CLI.
-	fwdSampler := fwdstatus.NewSampler(d.dp, fwdstatus.OSProcReader{})
+	fwdSampler := fwdstatus.NewSampler(d.legacyDP(), fwdstatus.OSProcReader{})
 	fwdSampler.Start(ctx)
 
 	// Start gRPC API server.
 	{
 		grpcSrv := grpcapi.NewServer(d.opts.GRPCAddr, grpcapi.Config{
 			Store:      d.store,
-			DP:         d.dp,
+			DP:         d.legacyDP(),
 			EventBuf:   eventBuf,
 			GC:         d.gc,
 			Routing:    d.routing,
@@ -815,7 +823,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start interactive CLI or block in daemon mode
 	var runErr error
 	if isInteractive() {
-		shell := cli.New(d.store, d.dp, eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
+		shell := cli.New(d.store, d.legacyDP(), eventBuf, er, d.routing, d.frr, d.ipsec, d.dhcp, d.dhcpRelay, d.cluster)
 		shell.SetVersion(d.opts.Version)
 		shell.SetForwardingSampler(fwdSampler)
 		// #797 H2 / #846: route in-process CLI commits through the
@@ -958,10 +966,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if !hitless && d.dp != nil && cfg.Chassis.Cluster != nil {
 		slog.Info("HA shutdown: clearing rg_active for all RGs")
 		for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-			if err := d.dp.UpdateRGActive(rg.ID, false); err != nil {
+			if err := d.dp.HA().SetRGActive(ctx, rg.ID, false); err != nil {
 				slog.Warn("failed to clear rg_active on shutdown", "rg", rg.ID, "err", err)
 			}
-			if err := d.dp.UpdateHAWatchdog(rg.ID, 0); err != nil {
+			if err := d.dp.HA().SetHAWatchdog(ctx, rg.ID, 0); err != nil {
 				slog.Warn("failed to clear ha_watchdog on shutdown", "rg", rg.ID, "err", err)
 			}
 		}
@@ -1001,7 +1009,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	if d.dp != nil {
-		logFinalStats(d.dp)
+		logFinalStats(d.legacyDP())
 		if hitless {
 			// Hitless: close Go handles only — BPF programs keep running.
 			slog.Info("hitless shutdown: preserving BPF state")

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1009,7 +1009,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	if d.dp != nil {
-		logFinalStats(d.legacyDP())
+		if lp := d.legacyDP(); lp != nil {
+			logFinalStats(lp)
+		}
 		if hitless {
 			// Hitless: close Go handles only — BPF programs keep running.
 			slog.Info("hitless shutdown: preserving BPF state")

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -242,16 +242,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		if cfg := d.store.ActiveConfig(); cfg != nil {
 			dpType = cfg.System.DataplaneType
 		}
-		dp, err := dataplane.NewDataPlane(dpType)
+		dp, err := dataplane.NewRuntimeDataPlane(dpType)
 		if err != nil {
 			slog.Error("failed to create dataplane", "type", dpType, "err", err)
 			return fmt.Errorf("create dataplane: %w", err)
 		}
-		var ok bool
-		d.dp, ok = dp.(dataplane.RuntimeDataPlane)
-		if !ok {
-			return fmt.Errorf("dataplane type %q does not implement RuntimeDataPlane", dpType)
-		}
+		d.dp = dp
 		if err := d.dp.Start(ctx); err != nil {
 			slog.Warn("failed to start dataplane, running in config-only mode",
 				"err", err)
@@ -310,7 +306,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 			lp.StartFIBSync(ctx)
 		}
 
-		gc := conntrack.NewGC(d.legacyDP(), 10*time.Second)
+		gc := conntrack.NewGCWithDomains(
+			d.dp.Sessions(),
+			d.dp.Telemetry(),
+			nil,
+			nil,
+			10*time.Second,
+		)
 		d.gc = gc
 
 		// When the userspace dataplane is active, skip BPF session map
@@ -965,11 +967,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// BPF stops forwarding traffic even if subsequent cleanup steps hang.
 	if !hitless && d.dp != nil && cfg.Chassis.Cluster != nil {
 		slog.Info("HA shutdown: clearing rg_active for all RGs")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
 		for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-			if err := d.dp.HA().SetRGActive(ctx, rg.ID, false); err != nil {
+			err := runHAShutdownUpdate(shutdownCtx, func(ctx context.Context) error {
+				return d.dp.HA().SetRGActive(ctx, rg.ID, false)
+			})
+			if err != nil {
 				slog.Warn("failed to clear rg_active on shutdown", "rg", rg.ID, "err", err)
 			}
-			if err := d.dp.HA().SetHAWatchdog(ctx, rg.ID, 0); err != nil {
+			err = runHAShutdownUpdate(shutdownCtx, func(ctx context.Context) error {
+				return d.dp.HA().SetHAWatchdog(ctx, rg.ID, 0)
+			})
+			if err != nil {
 				slog.Warn("failed to clear ha_watchdog on shutdown", "rg", rg.ID, "err", err)
 			}
 		}
@@ -1224,4 +1234,20 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 		addRoutes(vrfName, ri.Inet6StaticRoutes)
 	}
 	return resolved
+}
+
+func runHAShutdownUpdate(ctx context.Context, update func(context.Context) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- update(ctx)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/pkg/daemon/daemon_run_test.go
+++ b/pkg/daemon/daemon_run_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunHAShutdownUpdateReturnsOnContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	begin := time.Now()
+	err := runHAShutdownUpdate(ctx, func(context.Context) error {
+		close(started)
+		<-release
+		return nil
+	})
+	elapsed := time.Since(begin)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runHAShutdownUpdate error = %v, want deadline exceeded", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("runHAShutdownUpdate elapsed = %s, want hard deadline return", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("shutdown update was not invoked before deadline")
+	}
+}

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -132,7 +132,7 @@ func (d *Daemon) publishPolicyScheduleState(epoch uint64, activeState map[string
 		return
 	}
 	d.seedPolicySchedulerActiveStateLocked(activeState)
-	d.dp.UpdatePolicyScheduleState(cfg, activeState)
+	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
 }
 
 func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]bool) {

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -15,6 +15,10 @@ type policySchedulerActiveStateSetter interface {
 	SetPolicySchedulerActiveState(map[string]bool)
 }
 
+type policyScheduleStateUpdater interface {
+	UpdatePolicyScheduleState(*config.Config, map[string]bool)
+}
+
 // reconcilePolicySchedulerLocked runs under applySem. It makes the scheduler
 // lifecycle follow committed config instead of only daemon startup, and returns
 // the active-state map that must be used for the same apply transaction.
@@ -132,7 +136,7 @@ func (d *Daemon) publishPolicyScheduleState(epoch uint64, activeState map[string
 		return
 	}
 	d.seedPolicySchedulerActiveStateLocked(activeState)
-	d.legacyDP().UpdatePolicyScheduleState(cfg, activeState)
+	d.updatePolicyScheduleStateLocked(cfg, activeState)
 }
 
 func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]bool) {
@@ -141,5 +145,18 @@ func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]boo
 	}
 	if setter, ok := d.dp.(policySchedulerActiveStateSetter); ok {
 		setter.SetPolicySchedulerActiveState(activeState)
+	}
+}
+
+func (d *Daemon) updatePolicyScheduleStateLocked(cfg *config.Config, activeState map[string]bool) {
+	if d.dp == nil {
+		return
+	}
+	if updater, ok := d.dp.(policyScheduleStateUpdater); ok {
+		updater.UpdatePolicyScheduleState(cfg, activeState)
+		return
+	}
+	if lp := d.legacyDP(); lp != nil {
+		lp.UpdatePolicyScheduleState(cfg, activeState)
 	}
 }

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpruntime "github.com/psaab/xpf/pkg/dataplane/runtime"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/scheduler"
 )
@@ -30,6 +32,19 @@ func (d *policySchedulerApplyTestDP) Compile(*config.Config) (*dataplane.Compile
 	return &dataplane.CompileResult{}, nil
 }
 
+func (d *policySchedulerApplyTestDP) ApplyConfig(ctx context.Context, cfg *config.Config) (*dataplane.ApplyResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	result, err := d.Compile(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return dataplane.ApplyResultFromCompileResult(result), nil
+}
+
 func (d *policySchedulerApplyTestDP) SetDeferWorkers(v bool) {
 	d.deferStates = append(d.deferStates, v)
 }
@@ -49,6 +64,73 @@ type userspacePolicySchedulerApplyTestDP struct {
 	compileCfgSchedule string
 }
 
+type runtimeOnlyApplyTestDP struct {
+	applyCalls  int
+	applyErr    error
+	applyResult *dataplane.ApplyResult
+}
+
+func (d *runtimeOnlyApplyTestDP) Start(context.Context) error { return nil }
+func (d *runtimeOnlyApplyTestDP) Close() error                { return nil }
+func (d *runtimeOnlyApplyTestDP) Teardown() error             { return nil }
+
+func (d *runtimeOnlyApplyTestDP) ApplyConfig(ctx context.Context, _ *config.Config) (*dataplane.ApplyResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	d.applyCalls++
+	if d.applyErr != nil {
+		return nil, d.applyErr
+	}
+	if d.applyResult != nil {
+		return d.applyResult.Clone(), nil
+	}
+	return &dataplane.ApplyResult{ZoneIDs: map[string]uint16{}}, nil
+}
+
+func (d *runtimeOnlyApplyTestDP) LastApplyResult() *dataplane.ApplyResult {
+	return &dataplane.ApplyResult{ZoneIDs: map[string]uint16{}}
+}
+
+func (d *runtimeOnlyApplyTestDP) Link() dataplane.LinkController {
+	return noopLinkController{}
+}
+
+func (d *runtimeOnlyApplyTestDP) HA() dataplane.HAController {
+	return dataplane.NewDataPlaneHAController(nil)
+}
+
+func (d *runtimeOnlyApplyTestDP) Sessions() dataplane.SessionStore {
+	return dataplane.SessionStoreOf(nil)
+}
+
+func (d *runtimeOnlyApplyTestDP) Telemetry() dataplane.Telemetry {
+	return dataplane.TelemetryOf(nil)
+}
+
+func (d *runtimeOnlyApplyTestDP) SessionDeltas() dpruntime.SessionDeltaSource {
+	return nil
+}
+
+type noopLinkController struct{}
+
+func (noopLinkController) SetDeferWorkers(bool) {}
+func (noopLinkController) PrepareLinkCycle()    {}
+func (noopLinkController) NotifyLinkCycle()     {}
+
+type runtimeOnlyPolicyUpdaterTestDP struct {
+	runtimeOnlyApplyTestDP
+	updateCalls int
+	stateSeen   map[string]bool
+}
+
+func (d *runtimeOnlyPolicyUpdaterTestDP) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) {
+	d.updateCalls++
+	d.stateSeen = copyPolicySchedulerApplyState(activeState)
+}
+
 func (d *userspacePolicySchedulerApplyTestDP) SetPolicySchedulerActiveState(activeState map[string]bool) {
 	d.seedCalls++
 	d.seedStateSeen = copyPolicySchedulerApplyState(activeState)
@@ -66,6 +148,19 @@ func (d *userspacePolicySchedulerApplyTestDP) Compile(cfg *config.Config) (*data
 		return nil, d.compileErr
 	}
 	return &dataplane.CompileResult{}, nil
+}
+
+func (d *userspacePolicySchedulerApplyTestDP) ApplyConfig(ctx context.Context, cfg *config.Config) (*dataplane.ApplyResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	result, err := d.Compile(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return dataplane.ApplyResultFromCompileResult(result), nil
 }
 
 func (d *userspacePolicySchedulerApplyTestDP) Mode() dpuserspace.DataplaneMode {
@@ -163,13 +258,51 @@ func TestApplyConfigPublishesScheduleStateToNonUserspaceDataplane(t *testing.T) 
 	cfg := &config.Config{}
 	activeState := map[string]bool{"workhours": true}
 
-	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, &dataplane.CompileResult{})
+	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, &dataplane.ApplyResult{})
 
 	if dp.updateCalls != 1 {
 		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 1", dp.updateCalls)
 	}
 	if got, ok := dp.updateStateSeen["workhours"]; !ok || !got {
 		t.Fatalf("active state for workhours = %t, present=%t; want active true", got, ok)
+	}
+}
+
+func TestApplyConfigUsesRuntimeConfigSinkWithoutLegacyDataplane(t *testing.T) {
+	dp := &runtimeOnlyApplyTestDP{
+		applyErr: dpuserspace.ErrPolicySchedulerProtocolIncompatible,
+	}
+	if _, ok := any(dp).(dataplane.DataPlane); ok {
+		t.Fatal("test dataplane unexpectedly implements legacy DataPlane")
+	}
+	d := &Daemon{
+		dp:   dp,
+		opts: Options{NoDataplane: true},
+	}
+
+	err := d.applyConfigLocked(&config.Config{})
+	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("applyConfigLocked error = %v, want runtime apply error", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("ApplyConfig calls = %d, want 1", dp.applyCalls)
+	}
+}
+
+func TestPolicySchedulerUpdateUsesRuntimeUpdaterWithoutLegacyDataplane(t *testing.T) {
+	dp := &runtimeOnlyPolicyUpdaterTestDP{}
+	if _, ok := any(dp).(dataplane.DataPlane); ok {
+		t.Fatal("test dataplane unexpectedly implements legacy DataPlane")
+	}
+	d := &Daemon{dp: dp}
+
+	d.updatePolicyScheduleStateLocked(&config.Config{}, map[string]bool{"workhours": true})
+
+	if dp.updateCalls != 1 {
+		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 1", dp.updateCalls)
+	}
+	if got, ok := dp.stateSeen["workhours"]; !ok || !got {
+		t.Fatalf("stateSeen[workhours] = %t, present=%t; want true", got, ok)
 	}
 }
 
@@ -207,7 +340,7 @@ func TestPolicySchedulerInitialPublishSkipsUserspaceLegacyMapUpdate(t *testing.T
 	cfg := testPolicySchedulerApplyConfig()
 	activeState := d.policySchedulerActiveStateForApplyLocked(cfg, testPolicySchedulerApplyNow())
 
-	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, &dataplane.CompileResult{})
+	d.publishInitialPolicySchedulerStateLocked(cfg, activeState, &dataplane.ApplyResult{})
 
 	if dp.updateCalls != 0 {
 		t.Fatalf("UpdatePolicyScheduleState calls = %d, want 0 for userspace initial apply", dp.updateCalls)

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -3,20 +3,18 @@
 > Deprecation notice (#1373): the legacy eBPF backend in this package is being
 > retired in favor of the Rust AF_XDP userspace dataplane. Phase 1 updates
 > active docs and migration targeting only; no BPF source, loader code, or
-> bindings are removed in this phase. The DataPlane interface cleanup is tracked
-> by #1381.
+> bindings are removed in this phase.
 
 Abstract dataplane interface plus the legacy eBPF backend. Compiles the typed
 config from `pkg/config` into BPF-map entries (zones, policies, NAT,
 filters, applications), attaches the 14 BPF programs (9 XDP + 5 TC), and
 exposes session iteration to GC, the CLI, and the metrics surface.
 
-Pluggable: alternative backends (DPDK in `pkg/dataplane/dpdk`, userspace
-AF_XDP in `pkg/dataplane/userspace`) register via `RegisterBackend`. The
-userspace AF_XDP backend is the primary #1373 target, but the current
-`DataPlane` interface is still BPF-shaped and is scheduled to split under
-#1381; see `docs/pr/1381-dataplane-interface-split/plan.md` before adding new
-methods to it.
+Pluggable: eBPF/DPDK legacy backends register through `RegisterBackend` for
+the old `DataPlane` surface. Runtime backends register through
+`RegisterRuntimeBackend`; the daemon uses `NewRuntimeDataPlane` so userspace
+AF_XDP starts as `RuntimeDataPlane` directly instead of through a fake
+BPF-shaped compatibility adapter.
 
 The userspace backend's status wire format is mirrored here for CLI/API
 consumers. CoS queue status includes queue-scoped drain-phase counters so
@@ -25,14 +23,17 @@ sent while exact queues were still backlogged.
 
 ## Entry points
 
-- `DataPlane` — `dataplane.go`. Transitional abstract interface; #1381 will
-  replace it with a small root interface plus config, HA, session, telemetry,
-  and link-control domains.
+- `DataPlane` — `dataplane.go`. Legacy BPF-shaped interface kept for the
+  eBPF/DPDK compiler and compatibility adapters. New daemon-facing code should
+  not add methods here.
 - `RuntimeDataPlane`, `ConfigSink`, `SessionStore`, `Telemetry`,
   `HAController`, and `LinkController` — `apply.go` and `session_store.go`.
-  These are the #1381 split-domain interfaces. New daemon/runtime code should
-  depend on these domains rather than adding methods to the BPF-shaped
-  `DataPlane` root.
+  These are the split-domain interfaces used by daemon startup and runtime
+  subsystems. `ConfigSink.ApplyConfig` is the daemon's apply-time
+  compile/config entry point; userspace AF_XDP does not need to implement the
+  legacy BPF-shaped `Compile` method just to receive committed config.
+- `NewRuntimeDataPlane(dpType)` — `dataplane.go`. Runtime-domain constructor
+  used by `pkg/daemon`; userspace registers only on this path.
 - `Manager` — `loader.go`. eBPF implementation.
 - `New() *Manager` — `loader.go`.
 - `Compile(cfg *config.Config) (*CompileResult, error)` — multi-phase

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -80,10 +80,16 @@ func UserspaceTracePinPath() string {
 // backendRegistry holds constructors for non-eBPF dataplane backends.
 // Sub-packages register themselves via RegisterBackend in their init().
 var backendRegistry = map[string]func() DataPlane{}
+var runtimeBackendRegistry = map[string]func() RuntimeDataPlane{}
 
 // RegisterBackend registers a dataplane constructor for the given type.
 func RegisterBackend(dpType string, ctor func() DataPlane) {
 	backendRegistry[dpType] = ctor
+}
+
+// RegisterRuntimeBackend registers a runtime-domain dataplane constructor.
+func RegisterRuntimeBackend(dpType string, ctor func() RuntimeDataPlane) {
+	runtimeBackendRegistry[dpType] = ctor
 }
 
 // NewDataPlane creates a DataPlane backend based on the given type string.
@@ -97,6 +103,29 @@ func NewDataPlane(dpType string) (DataPlane, error) {
 			return ctor(), nil
 		}
 		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, dpdk, userspace)", dpType)
+	}
+}
+
+// NewRuntimeDataPlane creates a daemon-facing runtime dataplane backend.
+// Userspace registers here directly so daemon startup does not require a
+// legacy BPF-shaped DataPlane compatibility adapter.
+func NewRuntimeDataPlane(dpType string) (RuntimeDataPlane, error) {
+	switch dpType {
+	case "", TypeEBPF:
+		return New(), nil
+	default:
+		if ctor, ok := runtimeBackendRegistry[dpType]; ok {
+			return ctor(), nil
+		}
+		dp, err := NewDataPlane(dpType)
+		if err != nil {
+			return nil, err
+		}
+		runtimeDP, ok := dp.(RuntimeDataPlane)
+		if !ok {
+			return nil, fmt.Errorf("dataplane type %q does not implement RuntimeDataPlane", dpType)
+		}
+		return runtimeDP, nil
 	}
 }
 

--- a/pkg/dataplane/dpdk/manager.go
+++ b/pkg/dataplane/dpdk/manager.go
@@ -19,6 +19,9 @@ func init() {
 	dataplane.RegisterBackend(dataplane.TypeDPDK, func() dataplane.DataPlane {
 		return New()
 	})
+	dataplane.RegisterRuntimeBackend(dataplane.TypeDPDK, func() dataplane.RuntimeDataPlane {
+		return New()
+	})
 }
 
 // Manager is the DPDK dataplane backend (stub implementation).

--- a/pkg/dataplane/userspace/inject_test.go
+++ b/pkg/dataplane/userspace/inject_test.go
@@ -123,7 +123,7 @@ func TestInjectPacketEmitOnWireFailsClosedBeforeHelperIPCWithoutTupleProtocol(t 
 		t.Fatalf("FindProcess: %v", err)
 	}
 	m := New()
-	m.inner = nil
+	m.bpfShim = nil
 	m.proc = &exec.Cmd{Process: proc}
 	m.cfg.ControlSocket = "/tmp/xpf-test-inject-packet-must-not-dial.sock"
 	m.lastStatus = ProcessStatus{}
@@ -156,7 +156,7 @@ func TestInjectPacketEmitOnWireRejectsLegacyRemoteRequestMetadata(t *testing.T) 
 		t.Fatalf("FindProcess: %v", err)
 	}
 	m := New()
-	m.inner = nil
+	m.bpfShim = nil
 	m.proc = &exec.Cmd{Process: proc}
 	m.cfg.ControlSocket = "/tmp/xpf-test-inject-packet-must-not-dial.sock"
 	m.lastStatus = ProcessStatus{

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -33,8 +33,8 @@ func NewLegacyDataPlaneAdapter(manager *Manager) *LegacyDataPlaneAdapter {
 	adapter := &LegacyDataPlaneAdapter{
 		manager: manager,
 	}
-	if manager.inner != nil {
-		adapter.DataPlane = manager.inner
+	if manager.bpfShim != nil {
+		adapter.DataPlane = manager.bpfShim
 	}
 	return adapter
 }
@@ -211,7 +211,7 @@ func (a *LegacyDataPlaneAdapter) UpdateFabricFwd(info dataplane.FabricFwdInfo) e
 	if err != nil {
 		return err
 	}
-	return m.inner.UpdateFabricFwd(info)
+	return m.bpfShim.UpdateFabricFwd(info)
 }
 
 func (a *LegacyDataPlaneAdapter) UpdateFabricFwd1(info dataplane.FabricFwdInfo) error {
@@ -219,7 +219,7 @@ func (a *LegacyDataPlaneAdapter) UpdateFabricFwd1(info dataplane.FabricFwdInfo) 
 	if err != nil {
 		return err
 	}
-	return m.inner.UpdateFabricFwd1(info)
+	return m.bpfShim.UpdateFabricFwd1(info)
 }
 
 func (a *LegacyDataPlaneAdapter) SetSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -54,13 +54,13 @@ func (m DataplaneMode) String() string {
 }
 
 func init() {
-	dataplane.RegisterBackend(dataplane.TypeUserspace, func() dataplane.DataPlane {
-		return NewLegacyDataPlaneAdapter(New())
+	dataplane.RegisterRuntimeBackend(dataplane.TypeUserspace, func() dataplane.RuntimeDataPlane {
+		return New()
 	})
 }
 
 type Manager struct {
-	inner *dataplane.Manager
+	bpfShim *dataplane.Manager
 
 	mu                    sync.Mutex
 	sessionMu             sync.Mutex // separate lock for session sync requests (Phase 3)
@@ -152,10 +152,10 @@ func shouldAttemptRSTSuppression(
 }
 
 func New() *Manager {
-	inner := dataplane.New()
-	inner.XDPEntryProg = "xdp_main_prog"
+	bpfShim := dataplane.New()
+	bpfShim.XDPEntryProg = "xdp_main_prog"
 	return &Manager{
-		inner:          inner,
+		bpfShim:        bpfShim,
 		configuredMode: ModeUserspaceCompat,
 		haGroups:       make(map[int]HAGroupStatus),
 	}
@@ -264,17 +264,17 @@ func (o managerHAOps) UpdateHAWatchdog(rgID int, timestamp uint64) error {
 }
 
 func (o managerHAOps) UpdateFabricFwd(info dataplane.FabricFwdInfo) error {
-	if o.manager == nil || o.manager.inner == nil {
+	if o.manager == nil || o.manager.bpfShim == nil {
 		return errors.New("nil userspace dataplane")
 	}
-	return o.manager.inner.UpdateFabricFwd(info)
+	return o.manager.bpfShim.UpdateFabricFwd(info)
 }
 
 func (o managerHAOps) UpdateFabricFwd1(info dataplane.FabricFwdInfo) error {
-	if o.manager == nil || o.manager.inner == nil {
+	if o.manager == nil || o.manager.bpfShim == nil {
 		return errors.New("nil userspace dataplane")
 	}
-	return o.manager.inner.UpdateFabricFwd1(info)
+	return o.manager.bpfShim.UpdateFabricFwd1(info)
 }
 
 func (o managerHAOps) SyncFabricState() {
@@ -442,21 +442,21 @@ func (m *Manager) SessionSyncSweepProfile() (bool, time.Duration, time.Duration)
 }
 
 func (m *Manager) Load() error {
-	return m.inner.Load()
+	return m.bpfShim.Load()
 }
 
 func (m *Manager) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stopLocked()
-	return m.inner.Close()
+	return m.bpfShim.Close()
 }
 
 func (m *Manager) Teardown() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stopLocked()
-	return m.inner.Teardown()
+	return m.bpfShim.Teardown()
 }
 
 // SetDeferWorkers tells the manager to skip worker startup during the next
@@ -470,7 +470,7 @@ func (m *Manager) SetDeferWorkers(v bool) {
 }
 
 func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) {
-	// Delete XDP link pins BEFORE inner.Compile() so AttachXDP does
+	// Delete XDP link pins BEFORE bpfShim.Compile() so AttachXDP does
 	// a fresh attach. This is critical for zero-copy: fresh attach
 	// triggers mlx5 to initialize XSK buffer pool from fill ring.
 	// Pinned link reuse (l.Update) only swaps the program without
@@ -492,13 +492,13 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	// XSK socket creation is deferred by the arm delay (45s) to avoid
 	// segfaults from __xsk_setup_xdp_prog during link cycles.
 	if m.xskLivenessFailed {
-		m.inner.XDPEntryProg = "xdp_main_prog"
+		m.bpfShim.XDPEntryProg = "xdp_main_prog"
 	} else if caps.ForwardingSupported {
-		m.inner.XDPEntryProg = "xdp_userspace_prog"
+		m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	} else {
-		m.inner.XDPEntryProg = "xdp_main_prog"
+		m.bpfShim.XDPEntryProg = "xdp_main_prog"
 	}
-	result, err := m.inner.Compile(cfg)
+	result, err := m.bpfShim.Compile(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -703,26 +703,26 @@ func (m *Manager) syncInterfaceAttachments(result *dataplane.CompileResult, snap
 	for _, ifindex := range buildUserspaceIngressIfindexes(snapshot) {
 		allowed[int(ifindex)] = true
 	}
-	for ifindex := range m.inner.XDPLinks() {
+	for ifindex := range m.bpfShim.XDPLinks() {
 		if allowed[ifindex] {
 			continue
 		}
-		if err := m.inner.DetachXDP(ifindex); err != nil {
+		if err := m.bpfShim.DetachXDP(ifindex); err != nil {
 			slog.Warn("userspace: detach XDP from non-data interface failed", "ifindex", ifindex, "err", err)
 		}
 	}
-	for ifindex := range m.inner.TCLinks() {
+	for ifindex := range m.bpfShim.TCLinks() {
 		if allowed[ifindex] {
 			continue
 		}
-		if err := m.inner.DetachTC(ifindex); err != nil {
+		if err := m.bpfShim.DetachTC(ifindex); err != nil {
 			slog.Warn("userspace: detach TC from non-data interface failed", "ifindex", ifindex, "err", err)
 		}
 	}
 }
 
 func (m *Manager) readFIBGeneration() uint32 {
-	fibGenMap := m.inner.Map("fib_gen_map")
+	fibGenMap := m.bpfShim.Map("fib_gen_map")
 	if fibGenMap == nil {
 		return 0
 	}
@@ -864,7 +864,7 @@ func (m *Manager) bumpGeneration() uint64 {
 // This avoids the full buildSnapshot() + apply_snapshot round-trip that was the
 // primary source of control socket contention during route convergence.
 func (m *Manager) BumpFIBGeneration() uint32 {
-	newGen := m.inner.BumpFIBGeneration()
+	newGen := m.bpfShim.BumpFIBGeneration()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/dataplane/userspace/manager_coupling_test.go
+++ b/pkg/dataplane/userspace/manager_coupling_test.go
@@ -20,7 +20,7 @@ func TestUserspaceManagerDoesNotEmbedLegacyDataPlane(t *testing.T) {
 	}
 
 	var hasEmbeddedDataPlane bool
-	var hasInnerDataplaneManager bool
+	var hasExplicitBPFShim bool
 	ast.Inspect(file, func(n ast.Node) bool {
 		typeSpec, ok := n.(*ast.TypeSpec)
 		if !ok || typeSpec.Name.Name != "Manager" {
@@ -38,8 +38,8 @@ func TestUserspaceManagerDoesNotEmbedLegacyDataPlane(t *testing.T) {
 				}
 			case "*dataplane.Manager":
 				for _, name := range field.Names {
-					if name.Name == "inner" {
-						hasInnerDataplaneManager = true
+					if name.Name == "bpfShim" {
+						hasExplicitBPFShim = true
 					}
 				}
 			}
@@ -50,8 +50,8 @@ func TestUserspaceManagerDoesNotEmbedLegacyDataPlane(t *testing.T) {
 	if hasEmbeddedDataPlane {
 		t.Fatal("userspace Manager must not embed dataplane.DataPlane; use LegacyDataPlaneAdapter for old callers")
 	}
-	if !hasInnerDataplaneManager {
-		t.Fatal("userspace Manager no longer has inner *dataplane.Manager; update #1381 docs and remove this remaining-debt canary")
+	if !hasExplicitBPFShim {
+		t.Fatal("userspace Manager must keep an explicit bpfShim field for userspace XDP maps")
 	}
 }
 
@@ -75,18 +75,19 @@ func TestUserspaceManagerRuntimeContractDoesNotExposeLegacyDataPlane(t *testing.
 	}
 }
 
-func TestUserspaceBackendRegistryReturnsLegacyAdapter(t *testing.T) {
+func TestUserspaceBackendRegistryReturnsRuntimeManagerOnly(t *testing.T) {
 	t.Parallel()
 
-	dp, err := dataplane.NewDataPlane(dataplane.TypeUserspace)
+	if dp, err := dataplane.NewDataPlane(dataplane.TypeUserspace); err == nil {
+		t.Fatalf("NewDataPlane(userspace) = %T, want legacy registry miss", dp)
+	}
+
+	dp, err := dataplane.NewRuntimeDataPlane(dataplane.TypeUserspace)
 	if err != nil {
-		t.Fatalf("NewDataPlane(userspace): %v", err)
+		t.Fatalf("NewRuntimeDataPlane(userspace): %v", err)
 	}
-	if _, ok := any(dp).(*LegacyDataPlaneAdapter); !ok {
-		t.Fatalf("NewDataPlane(userspace) = %T, want *LegacyDataPlaneAdapter", dp)
-	}
-	if _, ok := any(dp).(*Manager); ok {
-		t.Fatal("NewDataPlane(userspace) returned *Manager directly")
+	if _, ok := any(dp).(*Manager); !ok {
+		t.Fatalf("NewRuntimeDataPlane(userspace) = %T, want *Manager", dp)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -107,11 +107,11 @@ func (m *Manager) ExportAllSessionsViaEventStream() error {
 }
 
 func (m *Manager) refreshHAStateFromMapsLocked() error {
-	rgMap := m.inner.Map("rg_active")
+	rgMap := m.bpfShim.Map("rg_active")
 	if rgMap == nil {
 		return errors.New("rg_active map not loaded")
 	}
-	wdMap := m.inner.Map("ha_watchdog")
+	wdMap := m.bpfShim.Map("ha_watchdog")
 	if wdMap == nil {
 		return errors.New("ha_watchdog map not loaded")
 	}
@@ -151,7 +151,7 @@ func (m *Manager) seedHAGroupInventoryLocked(cfg *config.Config) {
 // UpdateRGActive. This avoids the race where re-reading Active from BPF
 // causes the helper to miss demotion deltas.
 func (m *Manager) refreshHAWatchdogOnlyFromMapsLocked() error {
-	wdMap := m.inner.Map("ha_watchdog")
+	wdMap := m.bpfShim.Map("ha_watchdog")
 	if wdMap == nil {
 		return nil
 	}
@@ -383,7 +383,7 @@ func (m *Manager) UpdateRGActive(rgID int, active bool) error {
 	// Update BPF rg_active UNDER the lock so the periodic poll can't
 	// read the new BPF value and sync to the helper before we do.
 	// This prevents the race where the poll eats the demotion delta.
-	if err := m.inner.UpdateRGActive(rgID, active); err != nil {
+	if err := m.bpfShim.UpdateRGActive(rgID, active); err != nil {
 		return err
 	}
 
@@ -462,7 +462,7 @@ func (m *Manager) UpdateRGActive(rgID int, active bool) error {
 }
 
 func (m *Manager) UpdateHAWatchdog(rgID int, timestamp uint64) error {
-	if err := m.inner.UpdateHAWatchdog(rgID, timestamp); err != nil {
+	if err := m.bpfShim.UpdateHAWatchdog(rgID, timestamp); err != nil {
 		return err
 	}
 	m.mu.Lock()
@@ -547,7 +547,7 @@ func (m *Manager) syncBPFCountersLocked(status *ProcessStatus) {
 		if d.delta == 0 {
 			continue
 		}
-		if err := m.inner.IncrementGlobalCounter(d.index, d.delta); err != nil {
+		if err := m.bpfShim.IncrementGlobalCounter(d.index, d.delta); err != nil {
 			slog.Debug("userspace: failed to increment BPF global counter",
 				"index", d.index, "delta", d.delta, "err", err)
 		}
@@ -564,7 +564,7 @@ func safeDelta(cur, prev uint64) uint64 {
 }
 
 func (m *Manager) SetSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
-	if err := m.inner.SetSessionV4(key, val); err != nil {
+	if err := m.bpfShim.SetSessionV4(key, val); err != nil {
 		return err
 	}
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
@@ -600,7 +600,7 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 	installVal.FibDmac = [6]byte{}
 	installVal.FibSmac = [6]byte{}
 	installVal.FibGen = 0
-	if err := m.inner.SetSessionV4(key, installVal); err != nil {
+	if err := m.bpfShim.SetSessionV4(key, installVal); err != nil {
 		return err
 	}
 	// The helper already synthesizes the correct reverse companion from the
@@ -621,7 +621,7 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 }
 
 func (m *Manager) SetSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
-	if err := m.inner.SetSessionV6(key, val); err != nil {
+	if err := m.bpfShim.SetSessionV6(key, val); err != nil {
 		return err
 	}
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
@@ -657,7 +657,7 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 	installVal.FibDmac = [6]byte{}
 	installVal.FibSmac = [6]byte{}
 	installVal.FibGen = 0
-	if err := m.inner.SetSessionV6(key, installVal); err != nil {
+	if err := m.bpfShim.SetSessionV6(key, installVal); err != nil {
 		return err
 	}
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
@@ -680,9 +680,9 @@ func shouldMirrorUserspaceSession(isReverse uint8) bool {
 func (m *Manager) DeleteSession(key dataplane.SessionKey) error {
 	// Look up the session value BEFORE deleting from the BPF map so we
 	// can retrieve the ReverseKey for the pre-installed companion (#351).
-	val, valErr := m.inner.GetSessionV4(key)
+	val, valErr := m.bpfShim.GetSessionV4(key)
 
-	if err := m.inner.DeleteSession(key); err != nil {
+	if err := m.bpfShim.DeleteSession(key); err != nil {
 		return err
 	}
 	m.mu.Lock()
@@ -698,9 +698,9 @@ func (m *Manager) DeleteSession(key dataplane.SessionKey) error {
 func (m *Manager) DeleteSessionV6(key dataplane.SessionKeyV6) error {
 	// Look up the session value BEFORE deleting from the BPF map so we
 	// can retrieve the ReverseKey for the pre-installed companion (#351).
-	val, valErr := m.inner.GetSessionV6(key)
+	val, valErr := m.bpfShim.GetSessionV6(key)
 
-	if err := m.inner.DeleteSessionV6(key); err != nil {
+	if err := m.bpfShim.DeleteSessionV6(key); err != nil {
 		return err
 	}
 	m.mu.Lock()
@@ -890,7 +890,7 @@ func (m *Manager) zoneNameByID(zoneID uint16) string {
 	if zoneID == 0 {
 		return ""
 	}
-	if cr := m.inner.LastCompileResult(); cr != nil {
+	if cr := m.bpfShim.LastCompileResult(); cr != nil {
 		for name, id := range cr.ZoneIDs {
 			if id == zoneID {
 				return name

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -115,7 +115,7 @@ func TestReadPolicyCountersPreservesScheduledRuleCountersAcrossDeleteReadd(t *te
 	}
 
 	m := New()
-	m.inner = nil
+	m.bpfShim = nil
 	m.lastStatus = ProcessStatus{
 		PolicyRuleCounters: []PolicyRuleCounterStatus{{
 			RuleID:  stablePolicyRuleID("lan", "wan", "scheduled-allow"),
@@ -193,7 +193,7 @@ security {
 	}
 
 	m := New()
-	m.inner = nil
+	m.bpfShim = nil
 	m.lastSnapshot = &ConfigSnapshot{Config: cfg}
 	m.lastStatus = ProcessStatus{
 		PolicyRuleCounters: []PolicyRuleCounterStatus{{
@@ -214,7 +214,7 @@ security {
 
 func TestClearPolicyCountersZerosCachedHelperCountersWithoutHelper(t *testing.T) {
 	m := New()
-	m.inner = nil
+	m.bpfShim = nil
 	m.lastStatus = ProcessStatus{
 		PolicyRuleCounters: []PolicyRuleCounterStatus{
 			{RuleID: stablePolicyRuleID("lan", "wan", "allow-web"), Packets: 7, Bytes: 700},
@@ -535,28 +535,28 @@ func hostToNetwork16(v uint16) uint16 {
 	return binary.NativeEndian.Uint16(raw[:])
 }
 
-func injectInnerMap(t *testing.T, inner *dataplane.Manager, name string, m *ebpf.Map) {
+func injectShimMap(t *testing.T, bpfShim *dataplane.Manager, name string, m *ebpf.Map) {
 	t.Helper()
-	if inner == nil {
-		t.Fatal("injectInnerMap: inner manager is nil")
+	if bpfShim == nil {
+		t.Fatal("injectShimMap: bpfShim manager is nil")
 	}
-	managerValue := reflect.ValueOf(inner)
+	managerValue := reflect.ValueOf(bpfShim)
 	if managerValue.Kind() != reflect.Ptr || managerValue.IsNil() {
-		t.Fatalf("injectInnerMap: expected non-nil pointer to dataplane.Manager, got %T", inner)
+		t.Fatalf("injectShimMap: expected non-nil pointer to dataplane.Manager, got %T", bpfShim)
 	}
 	managerElem := managerValue.Elem()
 	if !managerElem.IsValid() || managerElem.Kind() != reflect.Struct {
-		t.Fatalf("injectInnerMap: expected dataplane.Manager struct, got kind %s", managerElem.Kind())
+		t.Fatalf("injectShimMap: expected dataplane.Manager struct, got kind %s", managerElem.Kind())
 	}
 	rv := managerElem.FieldByName("maps")
 	if !rv.IsValid() {
-		t.Fatal("injectInnerMap: dataplane.Manager has no field named \"maps\"")
+		t.Fatal("injectShimMap: dataplane.Manager has no field named \"maps\"")
 	}
 	if !rv.CanAddr() {
-		t.Fatal("injectInnerMap: dataplane.Manager.maps is not addressable")
+		t.Fatal("injectShimMap: dataplane.Manager.maps is not addressable")
 	}
 	if rv.Kind() != reflect.Map {
-		t.Fatalf("injectInnerMap: dataplane.Manager.maps has kind %s, want map", rv.Kind())
+		t.Fatalf("injectShimMap: dataplane.Manager.maps has kind %s, want map", rv.Kind())
 	}
 	rm := reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem()
 	if rm.IsNil() {
@@ -565,10 +565,10 @@ func injectInnerMap(t *testing.T, inner *dataplane.Manager, name string, m *ebpf
 	key := reflect.ValueOf(name)
 	value := reflect.ValueOf(m)
 	if !key.Type().AssignableTo(rv.Type().Key()) {
-		t.Fatalf("injectInnerMap: cannot use key type %s for map key type %s", key.Type(), rv.Type().Key())
+		t.Fatalf("injectShimMap: cannot use key type %s for map key type %s", key.Type(), rv.Type().Key())
 	}
 	if !value.Type().AssignableTo(rv.Type().Elem()) {
-		t.Fatalf("injectInnerMap: cannot use value type %s for map element type %s", value.Type(), rv.Type().Elem())
+		t.Fatalf("injectShimMap: cannot use value type %s for map element type %s", value.Type(), rv.Type().Elem())
 	}
 	rm.SetMapIndex(key, value)
 }
@@ -585,7 +585,7 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 		t.Fatalf("new sessions map: %v", err)
 	}
 	t.Cleanup(func() { sessionsMap.Close() })
-	injectInnerMap(t, m.inner, "sessions", sessionsMap)
+	injectShimMap(t, m.bpfShim, "sessions", sessionsMap)
 	sessionsMapV6, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKeyV6{})),
@@ -596,7 +596,7 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 		t.Fatalf("new sessions_v6 map: %v", err)
 	}
 	t.Cleanup(func() { sessionsMapV6.Close() })
-	injectInnerMap(t, m.inner, "sessions_v6", sessionsMapV6)
+	injectShimMap(t, m.bpfShim, "sessions_v6", sessionsMapV6)
 }
 
 func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
@@ -611,7 +611,7 @@ func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
 		t.Fatalf("new userspace_ctrl map: %v", err)
 	}
 	t.Cleanup(func() { ctrlMap.Close() })
-	injectInnerMap(t, m.inner, "userspace_ctrl", ctrlMap)
+	injectShimMap(t, m.bpfShim, "userspace_ctrl", ctrlMap)
 
 	bindingsMap, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -623,7 +623,7 @@ func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
 		t.Fatalf("new userspace_bindings map: %v", err)
 	}
 	t.Cleanup(func() { bindingsMap.Close() })
-	injectInnerMap(t, m.inner, "userspace_bindings", bindingsMap)
+	injectShimMap(t, m.bpfShim, "userspace_bindings", bindingsMap)
 	return ctrlMap, bindingsMap
 }
 
@@ -639,7 +639,7 @@ func injectUserspaceSessionMap(t *testing.T, m *Manager) *ebpf.Map {
 		t.Fatalf("new userspace_sessions map: %v", err)
 	}
 	t.Cleanup(func() { usMap.Close() })
-	injectInnerMap(t, m.inner, "userspace_sessions", usMap)
+	injectShimMap(t, m.bpfShim, "userspace_sessions", usMap)
 	return usMap
 }
 
@@ -757,7 +757,7 @@ func TestSessionSyncTunnelEndpointIDLockedMatchesLogicalTunnelIfindex(t *testing
 
 func TestBuildSessionSyncRequestV4ConvertsPortsToHostOrder(t *testing.T) {
 	m := &Manager{
-		inner: dataplane.New(),
+		bpfShim: dataplane.New(),
 		lastSnapshot: &ConfigSnapshot{
 			Interfaces: []InterfaceSnapshot{{
 				Name:            "reth0.80",
@@ -798,7 +798,7 @@ func TestBuildSessionSyncRequestV4ConvertsPortsToHostOrder(t *testing.T) {
 }
 
 func TestBuildSessionSyncRequestV4PreservesBothNatLegs(t *testing.T) {
-	m := &Manager{inner: dataplane.New()}
+	m := &Manager{bpfShim: dataplane.New()}
 	key := dataplane.SessionKey{
 		SrcIP:    [4]byte{198, 51, 100, 10},
 		DstIP:    [4]byte{172, 16, 80, 8},
@@ -824,7 +824,7 @@ func TestBuildSessionSyncRequestV4PreservesBothNatLegs(t *testing.T) {
 
 func TestBuildSessionSyncRequestV4PreservesTunnelEndpointIdentity(t *testing.T) {
 	m := &Manager{
-		inner: dataplane.New(),
+		bpfShim: dataplane.New(),
 		lastSnapshot: &ConfigSnapshot{
 			Interfaces: []InterfaceSnapshot{{
 				Name:            "gr-0/0/0.0",
@@ -878,7 +878,7 @@ func TestBuildSessionSyncRequestV4PreservesTunnelEndpointIdentity(t *testing.T) 
 
 func TestBuildSessionSyncRequestV6PreservesTunnelEndpointIdentity(t *testing.T) {
 	m := &Manager{
-		inner: dataplane.New(),
+		bpfShim: dataplane.New(),
 		lastSnapshot: &ConfigSnapshot{
 			Interfaces: []InterfaceSnapshot{{
 				Name:            "gr-0/0/0.0",
@@ -926,7 +926,7 @@ func TestBuildSessionSyncRequestV6PreservesTunnelEndpointIdentity(t *testing.T) 
 
 func TestBuildSessionSyncRequestV6ConvertsPortsToHostOrder(t *testing.T) {
 	m := &Manager{
-		inner: dataplane.New(),
+		bpfShim: dataplane.New(),
 		lastSnapshot: &ConfigSnapshot{
 			Interfaces: []InterfaceSnapshot{{
 				Name:            "reth0.80",
@@ -972,7 +972,7 @@ func TestBuildSessionSyncRequestV6ConvertsPortsToHostOrder(t *testing.T) {
 }
 
 func TestBuildSessionSyncRequestV6PreservesBothNatLegs(t *testing.T) {
-	m := &Manager{inner: dataplane.New()}
+	m := &Manager{bpfShim: dataplane.New()}
 	var srcIP, dstIP, natSrc, natDst [16]byte
 	copy(srcIP[:], net.ParseIP("2001:db8::10").To16())
 	copy(dstIP[:], net.ParseIP("2001:db8:80::8").To16())
@@ -1061,7 +1061,7 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 		t.Fatalf("new sessions map: %v", err)
 	}
 	defer sessionsMap.Close()
-	injectInnerMap(t, m.inner, "sessions", sessionsMap)
+	injectShimMap(t, m.bpfShim, "sessions", sessionsMap)
 	sessionsMapV6, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKeyV6{})),
@@ -1072,7 +1072,7 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 		t.Fatalf("new sessions_v6 map: %v", err)
 	}
 	defer sessionsMapV6.Close()
-	injectInnerMap(t, m.inner, "sessions_v6", sessionsMapV6)
+	injectShimMap(t, m.bpfShim, "sessions_v6", sessionsMapV6)
 
 	key := dataplane.SessionKey{
 		SrcIP:    [4]byte{172, 16, 80, 200},
@@ -1384,7 +1384,7 @@ func TestApplyHelperStatusInitialCtrlCleanupRunsOnlyOnce(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	injectCtrlAndBindingMaps(t, m)
 	usMap := injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -1491,7 +1491,7 @@ func TestUpdateRGActiveActivationKeepsCtrlEnabledAfterAckedStatus(t *testing.T) 
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
 	m.cfg.ControlSocket = controlSock
 	m.clusterHA = true
-	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	m.neighborsPrewarmed = true
 	m.xskLivenessProven = true
 	m.ctrlWasEnabled = true
@@ -1512,7 +1512,7 @@ func TestUpdateRGActiveActivationKeepsCtrlEnabledAfterAckedStatus(t *testing.T) 
 		t.Fatalf("new rg_active map: %v", err)
 	}
 	t.Cleanup(func() { rgMap.Close() })
-	injectInnerMap(t, m.inner, "rg_active", rgMap)
+	injectShimMap(t, m.bpfShim, "rg_active", rgMap)
 
 	if err := m.UpdateRGActive(1, true); err != nil {
 		t.Fatalf("UpdateRGActive: %v", err)

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -62,23 +62,23 @@ type userspaceLocalAddressEntry struct {
 }
 
 func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg config.UserspaceConfig) error {
-	ctrlMap := m.inner.Map("userspace_ctrl")
+	ctrlMap := m.bpfShim.Map("userspace_ctrl")
 	if ctrlMap == nil {
 		return errors.New("userspace_ctrl map not loaded")
 	}
-	bindingsMap := m.inner.Map("userspace_bindings")
+	bindingsMap := m.bpfShim.Map("userspace_bindings")
 	if bindingsMap == nil {
 		return errors.New("userspace_bindings map not loaded")
 	}
-	heartbeatMap := m.inner.Map("userspace_heartbeat")
+	heartbeatMap := m.bpfShim.Map("userspace_heartbeat")
 	if heartbeatMap == nil {
 		return errors.New("userspace_heartbeat map not loaded")
 	}
-	fallbackMap := m.inner.Map("userspace_fallback_progs")
+	fallbackMap := m.bpfShim.Map("userspace_fallback_progs")
 	if fallbackMap == nil {
 		return errors.New("userspace_fallback_progs map not loaded")
 	}
-	fallbackProg := m.inner.Program("xdp_main_prog")
+	fallbackProg := m.bpfShim.Program("xdp_main_prog")
 	if fallbackProg == nil {
 		return errors.New("xdp_main_prog not loaded")
 	}
@@ -144,7 +144,7 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 // instead of XDP_PASS, which is required for zero-copy AF_XDP (XDP_PASS in
 // zero-copy mode permanently leaks UMEM frames).
 func (m *Manager) setupUserspaceCPUMapLocked() bool {
-	cpuMap := m.inner.Map("userspace_cpumap")
+	cpuMap := m.bpfShim.Map("userspace_cpumap")
 	if cpuMap == nil {
 		slog.Warn("userspace_cpumap not found, zero-copy cpumap redirect disabled")
 		return false
@@ -173,11 +173,11 @@ func (m *Manager) setupUserspaceCPUMapLocked() bool {
 }
 
 func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
-	ctrlMap := m.inner.Map("userspace_ctrl")
+	ctrlMap := m.bpfShim.Map("userspace_ctrl")
 	if ctrlMap == nil {
 		return errors.New("userspace_ctrl map not loaded")
 	}
-	bindingsMap := m.inner.Map("userspace_bindings")
+	bindingsMap := m.bpfShim.Map("userspace_bindings")
 	if bindingsMap == nil {
 		return errors.New("userspace_bindings map not loaded")
 	}
@@ -187,7 +187,7 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 
 	// Preserve cpumap flag if cpumap is populated.
 	var ctrlFlags uint32
-	if cpuMap := m.inner.Map("userspace_cpumap"); cpuMap != nil {
+	if cpuMap := m.bpfShim.Map("userspace_cpumap"); cpuMap != nil {
 		ctrlFlags |= userspaceCtrlFlagCPUMap
 	}
 	if snapshotHasNativeGRE(m.lastSnapshot) {
@@ -295,7 +295,7 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 			"lastXSKRX", m.lastXSKRX,
 			"neighborsPrewarmed", m.neighborsPrewarmed,
 			"xskLivenessFailed", m.xskLivenessFailed,
-			"xdpEntryProg", m.inner.XDPEntryProg)
+			"xdpEntryProg", m.bpfShim.XDPEntryProg)
 		if m.xskLivenessFailed {
 			// XSK proven broken — ctrl disabled.
 			// In compat mode, the entry program was already swapped to
@@ -306,23 +306,23 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 		} else if probeBindingsReady && neighborSyncReady {
 			ctrl.Enabled = 1
 			if m.xskLivenessProven {
-				if m.inner.XDPEntryProg != "xdp_userspace_prog" {
-					if err := m.inner.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
+				if m.bpfShim.XDPEntryProg != "xdp_userspace_prog" {
+					if err := m.bpfShim.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
 						slog.Warn("userspace: failed to restore XDP shim after liveness success", "err", err)
 					}
 				}
 			} else if xskReceiveLive {
 				m.xskLivenessProven = true
 				m.xskProbeStart = time.Time{}
-				if m.inner.XDPEntryProg != "xdp_userspace_prog" {
-					if err := m.inner.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
+				if m.bpfShim.XDPEntryProg != "xdp_userspace_prog" {
+					if err := m.bpfShim.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
 						slog.Warn("userspace: failed to swap XDP shim after XSK RX became live", "err", err)
 					}
 				}
 				slog.Info("userspace: XSK liveness proven")
 			} else {
-				if m.inner.XDPEntryProg != "xdp_userspace_prog" {
-					if err := m.inner.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
+				if m.bpfShim.XDPEntryProg != "xdp_userspace_prog" {
+					if err := m.bpfShim.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
 						slog.Warn("userspace: failed to activate XDP shim for XSK liveness probe", "err", err)
 					}
 				}
@@ -333,8 +333,8 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 					if m.shouldAutoProveIdleStandbyXSKLocked(currentRX, allBindingsBound) {
 						m.xskLivenessProven = true
 						m.xskProbeStart = time.Time{}
-						if m.inner.XDPEntryProg != "xdp_userspace_prog" {
-							if err := m.inner.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
+						if m.bpfShim.XDPEntryProg != "xdp_userspace_prog" {
+							if err := m.bpfShim.SwapXDPEntryProg("xdp_userspace_prog"); err != nil {
 								slog.Warn("userspace: failed to restore XDP shim after idle standby liveness success", "err", err)
 							}
 						}
@@ -358,7 +358,7 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 						slog.Error("userspace: XSK liveness probe failed in strict mode — dataplane degraded, no eBPF fallback")
 					} else {
 						slog.Warn("userspace: XSK liveness probe failed, falling back to eBPF pipeline")
-						if err := m.inner.SwapXDPEntryProg("xdp_main_prog"); err != nil {
+						if err := m.bpfShim.SwapXDPEntryProg("xdp_main_prog"); err != nil {
 							slog.Warn("userspace: failed to swap to eBPF pipeline after XSK liveness failure", "err", err)
 						}
 					}
@@ -395,7 +395,7 @@ ctrlReady:
 	// at generation 1 indefinitely; later ctrl re-enables during RG moves
 	// would then retrigger the startup flush and destroy synced sessions.
 	if ctrl.Enabled == 1 && !m.ctrlWasEnabled && !m.initialCtrlCleanupDone {
-		if usMap := m.inner.Map("userspace_sessions"); usMap != nil {
+		if usMap := m.bpfShim.Map("userspace_sessions"); usMap != nil {
 			var key, nextKey []byte
 			key = make([]byte, usMap.KeySize())
 			nextKey = make([]byte, usMap.KeySize())
@@ -434,7 +434,7 @@ ctrlReady:
 		// nanoseconds, so convert to seconds for comparison.
 		cutoffSec := m.ctrlDisabledAt / 1_000_000_000
 		for _, mapName := range []string{"sessions", "sessions_v6"} {
-			if ctMap := m.inner.Map(mapName); ctMap != nil {
+			if ctMap := m.bpfShim.Map(mapName); ctMap != nil {
 				keySize := ctMap.KeySize()
 				valSize := ctMap.ValueSize()
 				var key, nextKey []byte
@@ -635,7 +635,7 @@ var fallbackReasonNames = [16]string{
 // and returns a map of reason name -> cumulative count. Entries with zero
 // count are omitted.
 func (m *Manager) readFallbackStatsLocked() map[string]uint64 {
-	statsMap := m.inner.Map("userspace_fallback_stats")
+	statsMap := m.bpfShim.Map("userspace_fallback_stats")
 	if statsMap == nil {
 		return nil
 	}
@@ -661,18 +661,18 @@ func (m *Manager) readFallbackStatsLocked() map[string]uint64 {
 }
 
 // entryProgramsLocked returns a map of ifindex -> attached XDP program name
-// by inspecting the inner dataplane manager's link state.
+// by inspecting the bpfShim dataplane manager's link state.
 // Note: VLAN sub-interfaces are skipped during SwapXDPEntryProg and may
 // retain the parent's program; they are excluded from this map.
 func (m *Manager) entryProgramsLocked() map[int]string {
-	links := m.inner.XDPLinks()
+	links := m.bpfShim.XDPLinks()
 	if len(links) == 0 {
 		return nil
 	}
-	progName := m.inner.XDPEntryProg
+	progName := m.bpfShim.XDPEntryProg
 	result := make(map[int]string, len(links))
 	for ifindex := range links {
-		if m.inner.VlanSubInterfaces[ifindex] {
+		if m.bpfShim.VlanSubInterfaces[ifindex] {
 			continue // VLAN sub-interfaces use parent's XDP program
 		}
 		result[ifindex] = progName
@@ -684,7 +684,7 @@ func (m *Manager) entryProgramsLocked() map[int]string {
 }
 
 func (m *Manager) syncIngressIfaceMapLocked(snapshot *ConfigSnapshot) error {
-	ifaceMap := m.inner.Map("userspace_ingress_ifaces")
+	ifaceMap := m.bpfShim.Map("userspace_ingress_ifaces")
 	if ifaceMap == nil {
 		return errors.New("userspace_ingress_ifaces map not loaded")
 	}
@@ -715,11 +715,11 @@ func (m *Manager) syncIngressIfaceMapLocked(snapshot *ConfigSnapshot) error {
 }
 
 func (m *Manager) syncLocalAddressMapsLocked(snapshot *ConfigSnapshot) error {
-	localV4Map := m.inner.Map("userspace_local_v4")
+	localV4Map := m.bpfShim.Map("userspace_local_v4")
 	if localV4Map == nil {
 		return errors.New("userspace_local_v4 map not loaded")
 	}
-	localV6Map := m.inner.Map("userspace_local_v6")
+	localV6Map := m.bpfShim.Map("userspace_local_v6")
 	if localV6Map == nil {
 		return errors.New("userspace_local_v6 map not loaded")
 	}
@@ -793,11 +793,11 @@ func (m *Manager) syncLocalAddressMapsLocked(snapshot *ConfigSnapshot) error {
 }
 
 func (m *Manager) syncInterfaceNATAddressMapsLocked(snapshot *ConfigSnapshot) error {
-	natV4Map := m.inner.Map("userspace_interface_nat_v4")
+	natV4Map := m.bpfShim.Map("userspace_interface_nat_v4")
 	if natV4Map == nil {
 		return errors.New("userspace_interface_nat_v4 map not loaded")
 	}
-	natV6Map := m.inner.Map("userspace_interface_nat_v6")
+	natV6Map := m.bpfShim.Map("userspace_interface_nat_v6")
 	if natV6Map == nil {
 		return errors.New("userspace_interface_nat_v6 map not loaded")
 	}
@@ -888,7 +888,7 @@ func (m *Manager) syncInterfaceNATAddressMapsLocked(snapshot *ConfigSnapshot) er
 // programBootstrapMapsLocked() which zeros the bindings map, and then either:
 //   - applyHelperStatusLocked didn't run (error path)
 //   - another Compile() ran concurrently and re-zeroed the map
-//   - the inner eBPF compile recreated the map from a fresh pin
+//   - the bpfShim eBPF compile recreated the map from a fresh pin
 //
 // When a mismatch is detected, this method rewrites the BPF map entries from
 // the helper's reported state — the same logic as applyHelperStatusLocked but
@@ -908,7 +908,7 @@ func (m *Manager) verifyBindingsMapLocked() bool {
 	if len(bindings) == 0 {
 		return false
 	}
-	bindingsMap := m.inner.Map("userspace_bindings")
+	bindingsMap := m.bpfShim.Map("userspace_bindings")
 	if bindingsMap == nil {
 		return false
 	}

--- a/pkg/dataplane/userspace/maps_sync_cap_test.go
+++ b/pkg/dataplane/userspace/maps_sync_cap_test.go
@@ -20,7 +20,7 @@ func TestApplyHelperStatusRejectsOverCapIfindex(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	injectCtrlAndBindingMaps(t, m)
 	injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -70,7 +70,7 @@ func TestApplyHelperStatusAcceptsIfindexWithinCap(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	injectCtrlAndBindingMaps(t, m)
 	injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -108,7 +108,7 @@ func TestVerifyBindingsWatchdogSkipsOverCapIfindex(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.inner.XDPEntryProg = "xdp_userspace_prog"
+	m.bpfShim.XDPEntryProg = "xdp_userspace_prog"
 	injectCtrlAndBindingMaps(t, m)
 	m.ctrlWasEnabled = true
 	// verifyBindingsMapLocked early-returns on m.proc == nil or

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -57,8 +57,8 @@ func (m *Manager) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, e
 	// and app-term slot expansion without callers recomputing Rust map slots.
 	var total dataplane.CounterValue
 	var innerErr error
-	if m.inner != nil {
-		total, innerErr = m.inner.ReadPolicyCounters(policyID)
+	if m.bpfShim != nil {
+		total, innerErr = m.bpfShim.ReadPolicyCounters(policyID)
 	}
 
 	m.mu.Lock()
@@ -89,8 +89,8 @@ func (m *Manager) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, e
 
 func (m *Manager) ClearPolicyCounters() error {
 	var errs []error
-	if m.inner != nil {
-		if err := m.inner.ClearPolicyCounters(); err != nil {
+	if m.bpfShim != nil {
+		if err := m.bpfShim.ClearPolicyCounters(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -105,8 +105,8 @@ func (m *Manager) ClearPolicyCounters() error {
 
 func (m *Manager) ClearAllCounters() error {
 	var errs []error
-	if m.inner != nil {
-		if err := m.inner.ClearAllCounters(); err != nil {
+	if m.bpfShim != nil {
+		if err := m.bpfShim.ClearAllCounters(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -63,7 +63,7 @@ func (m *Manager) ensureProcessLocked(cfg config.UserspaceConfig) error {
 	m.eventStreamCancel = esCancel
 	// Clear stale XSKMAP entries from previous helper instance.
 	// Old entries point to dead socket fds; new helper will repopulate.
-	if xskMap := m.inner.Map("userspace_xsk_map"); xskMap != nil {
+	if xskMap := m.bpfShim.Map("userspace_xsk_map"); xskMap != nil {
 		for i := uint32(0); i < 4096; i++ {
 			_ = xskMap.Delete(i)
 		}
@@ -907,7 +907,7 @@ func proactiveNeighborResolveAsync(cfg *config.Config) {
 // shim stops redirecting packets to XSK. This MUST be called before the
 // helper exits to prevent packets being sent to dead socket fds.
 func (m *Manager) disableUserspaceCtrlLocked() {
-	ctrlMap := m.inner.Map("userspace_ctrl")
+	ctrlMap := m.bpfShim.Map("userspace_ctrl")
 	if ctrlMap == nil {
 		return
 	}
@@ -925,7 +925,7 @@ func (m *Manager) disableUserspaceCtrlLocked() {
 // reEnableUserspaceCtrlLocked sets ctrl.enabled=1 in the BPF map.
 // Used to rollback a ctrl disable when the subsequent operation fails.
 func (m *Manager) reEnableUserspaceCtrlLocked() {
-	ctrlMap := m.inner.Map("userspace_ctrl")
+	ctrlMap := m.bpfShim.Map("userspace_ctrl")
 	if ctrlMap == nil {
 		return
 	}
@@ -955,8 +955,8 @@ func (m *Manager) DisableAndStopHelper() {
 	m.disableUserspaceCtrlLocked()
 	// Swap to eBPF pipeline so packets go through xdp_main_prog
 	// even if the XDP shim was previously attached.
-	if m.inner.XDPEntryProg != "xdp_main_prog" {
-		_ = m.inner.SwapXDPEntryProg("xdp_main_prog")
+	if m.bpfShim.XDPEntryProg != "xdp_main_prog" {
+		_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
 	}
 }
 
@@ -976,8 +976,8 @@ func (m *Manager) PrepareLinkCycle() {
 		return
 	}
 	m.disableUserspaceCtrlLocked()
-	if m.inner.XDPEntryProg != "xdp_main_prog" {
-		_ = m.inner.SwapXDPEntryProg("xdp_main_prog")
+	if m.bpfShim.XDPEntryProg != "xdp_main_prog" {
+		_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
 	}
 	// Tell the Rust helper to stop all workers. This joins worker
 	// threads so they stop touching UMEM before the NIC unmaps pages
@@ -1002,7 +1002,7 @@ func configEqual(a, b config.UserspaceConfig) bool {
 }
 
 func (m *Manager) StartFIBSync(ctx context.Context) {
-	m.inner.StartFIBSync(ctx)
+	m.bpfShim.StartFIBSync(ctx)
 }
 
 // NotifyLinkCycle tells the userspace helper to rebind all AF_XDP sockets.
@@ -1035,8 +1035,8 @@ func (m *Manager) NotifyLinkCycle() {
 	// Ensure ctrl is disabled (PrepareLinkCycle should have done this,
 	// but guard against callers that skip it).
 	m.disableUserspaceCtrlLocked()
-	if m.inner.XDPEntryProg != "xdp_main_prog" {
-		_ = m.inner.SwapXDPEntryProg("xdp_main_prog")
+	if m.bpfShim.XDPEntryProg != "xdp_main_prog" {
+		_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
 	}
 	// Reset the ctrl enable gate so the fill-ring bootstrap delay
 	// restarts from scratch after rebind.  Without this, ctrl stays

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -12,6 +12,9 @@ changed.
 - `InterfaceConfig` — `networkd.go`. MAC, addresses, bonding, VLAN
   parent, VRF binding, description.
 - `New()` — `networkd.go`.
+- `NewInDir(dir)` — `networkd.go`. Test/offline renderer constructor that
+  writes xpf-managed files under a caller-provided directory instead of
+  `/etc/systemd/network`.
 - `Apply(...)` — `networkd.go`.
 - `Clear()` — `networkd.go`.
 - `FindExternallyManaged(dir string) map[string]bool` — `networkd.go`. Detects networkd files

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -54,8 +54,17 @@ type Manager struct {
 
 // New creates a new networkd manager.
 func New() *Manager {
+	return NewInDir(DefaultNetworkDir)
+}
+
+// NewInDir creates a networkd manager rooted at networkDir. Production callers
+// use New(); tests and offline renderers use this to avoid touching /etc.
+func NewInDir(networkDir string) *Manager {
+	if networkDir == "" {
+		networkDir = DefaultNetworkDir
+	}
 	return &Manager{
-		networkDir: DefaultNetworkDir,
+		networkDir: networkDir,
 	}
 }
 


### PR DESCRIPTION
Closes #1381.

## Summary

Moves the daemon-facing dataplane contract from the legacy BPF-shaped `dataplane.DataPlane` interface to the split `dataplane.RuntimeDataPlane` domains.

This PR now closes the daemon side of #1381 rather than only reshaping the field type. It touches the daemon, dataplane runtime interfaces, userspace compatibility adapter, DPDK registration, networkd test constructor, tests, and the relevant module/PR docs.

- Adds `RegisterRuntimeBackend` / `NewRuntimeDataPlane` beside the legacy `RegisterBackend` / `NewDataPlane` path.
- Starts daemon dataplanes through `NewRuntimeDataPlane`, so daemon startup no longer constructs a legacy `DataPlane` and casts it back to runtime domains.
- Registers userspace only as a runtime backend. `system dataplane-type userspace` now creates `*userspace.Manager` directly; it no longer goes through `LegacyDataPlaneAdapter` as the backend registry entry.
- Routes `applyConfigLocked` through `ConfigSink.ApplyConfig`, so userspace receives committed config without implementing the legacy BPF writer/compile surface.
- Keeps `NewDataPlane` as the old eBPF/DPDK compatibility constructor.
- Leaves `legacyDP()` only as an explicit compatibility bridge for old eBPF/DPDK surfaces that still need the BPF-shaped interface.
- Renames the userspace manager's BPF owner from `inner` to `bpfShim` and updates the AST canary/docs so the remaining `*dataplane.Manager` field is documented as the intentional userspace XDP shim owner, not inherited `DataPlane` coupling.

## Review Fixes

- Fixed the userspace apply regression: `applyConfigLocked` no longer fails with `cannot compile config without dataplane` when the active backend is a bare userspace runtime manager.
- Runtime apply results now feed the existing apply-time consumers: zone-to-RG sync mapping, networkd managed-interface output, and initial policy-scheduler publish gating.
- Added the r3 happy-path regression test proving `ApplyResult.ZoneIDs` reaches session sync and `ApplyResult.ManagedInterfaces` reaches networkd.
- Fixed live scheduler updates for userspace mode by publishing through a runtime updater interface before falling back to legacy `DataPlane` compatibility.
- Fixed related runtime split leaks in XSK/IPVLAN deferral and deferred RETH MAC reapply, which were still capability-checking through `legacyDP()`.
- Made fail-closed HA shutdown use one daemon-owned deadline. Helper RPCs may still have their own dial/read timers, but daemon shutdown returns when the outer deadline expires.
- Ran gofmt and added regression coverage for runtime-only apply, runtime scheduler update, userspace scheduler seeding before apply, happy-path downstream apply consumers, and hard-return HA shutdown timeout behavior.

## Non-goals

This does not remove eBPF programs or the userspace XDP shim maps. The `bpfShim` owner remains by design for AF_XDP control, redirect, heartbeat, local-delivery, and mirror pins.

## Validation

- `go test ./pkg/daemon ./pkg/networkd`
- `go test ./pkg/dataplane/... ./pkg/dataplane/userspace/... ./pkg/daemon/... ./pkg/api ./pkg/cli ./pkg/grpcapi ./pkg/conntrack ./pkg/cluster ./pkg/networkd`
- `git diff --check`