### PR TITLE
events: close filter-log enforcement gaps

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -47,18 +47,47 @@ Current implementation status after the 2026-05-19 closeout slice:
   and lo0/local-delivery filter logs. Non-PBR input filter-log matching runs
   only on the slow path after a flow-cache miss. Non-PBR input filter
   `discard`/`reject` actions are terminal before route lookup and policy
-  evaluation; logged terminal actions emit `source=input` with deny/reject RT_FLOW
-  action. If the first permitted packet installs a flow-cache entry, the matched
-  input log term and ingress-zone ID are stored in that entry and cached hits
-  re-emit `source=input` without rescanning filter terms.
-- Policy deny records carry the userspace snapshot's numeric policy ID. Filter
-  log records carry the compiled filter ID, term ID, action, and source
-  (`pbr`, `input`, `output`, `cached-output`, or `lo0`). These IDs are
-  deterministic inside the compiled snapshot and intentionally avoid invented
-  names or unstable runtime-only identifiers.
+  evaluation; logged terminal actions emit `source=input` with deny RT_FLOW
+  action because this userspace path fails closed without synthesizing an
+  ICMP/RST reject packet yet. If the first permitted packet installs a
+  flow-cache entry,
+  the matched input log term and ingress-zone ID are stored in that entry and
+  cached hits re-emit `source=input` without rescanning filter terms.
+- Input/output filters with DSCP match terms are deliberately not
+  flow-cached because DSCP is per-packet metadata outside the session cache
+  key. Established session hits re-evaluate DSCP-sensitive input filters, and
+  forwarding rotations that add, remove, or change DSCP-sensitive input
+  filters purge existing sessions for that packet family so traffic returns
+  to the miss path. The rotation comparison ignores compiler-positional
+  filter IDs and includes three-color policer runtime shape so unrelated
+  filter reordering does not over-purge while policer-shape changes still
+  force revalidation.
+- Output filter `discard`/`reject` terms are terminal in the TX-selection
+  path. The helper carries the matched action alongside forwarding-class,
+  DSCP, policer, counter, and filter-log metadata, so a live or cached
+  output-filter deny record cannot describe a packet that still enqueues for
+  TX. Output `reject` also fails closed as a silent drop until per-path
+  ICMP/RST synthesis exists.
+- Policy deny records carry the userspace snapshot's numeric policy ID. Policy
+  `reject` is logged as deny until the userspace PolicyDenied path synthesizes
+  ICMP/RST reject packets. Filter log records carry the compiled filter ID,
+  term ID, action, and source (`pbr`, `input`, `output`, `cached-output`, or
+  `lo0`). These IDs are deterministic inside the compiled snapshot and
+  intentionally avoid invented names or unstable runtime-only identifiers.
 - The `lo0` source label means a userspace local-delivery packet matched the
-  configured lo0 log term. It does not claim that kernel/nft lo0 ingress
-  enforcement moved into the AF_XDP helper.
+  configured lo0 log term. Userspace local-delivery `discard`/`reject` actions
+  are terminal and prevent slow-path reinjection; `reject` is logged as deny
+  until reject packet generation exists on this path. Local-delivery session
+  hits also re-run lo0 enforcement, and HA-published local-delivery BPF map
+  entries use the userspace-visible redirect path while a lo0 filter is
+  configured so cached `PASS_TO_KERNEL` state cannot bypass the filter. This
+  does not claim that kernel/nft lo0 ingress enforcement moved into the AF_XDP
+  helper. If a lo0 filter is removed, already-demoted local-delivery sessions
+  can stay on the userspace-visible helper path until they age out; that is a
+  bounded performance cost, not a forwarding bypass. NAT64 local-delivery
+  traffic is evaluated using the pre-translation packet family, so operators
+  that use NAT64 and want uniform local-delivery filtering must configure both
+  inet and inet6 lo0 filters.
 - The event-stream wire format is a helper/daemon lockstep contract. For
   `MSG_FILTER_LOG`, the RT_FLOW reason byte carries the source label above;
   close events continue to interpret the same byte as a close reason. This is

--- a/pkg/dataplane/userspace/eventstream_test.go
+++ b/pkg/dataplane/userspace/eventstream_test.go
@@ -792,7 +792,7 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 	dir := t.TempDir()
 	sockPath := filepath.Join(dir, "test-events.sock")
 	es := NewEventStream(sockPath)
-	rawProcessed := make(chan bool, 3)
+	rawProcessed := make(chan bool, 4)
 	es.SetOnRawDataplaneEvent(func(_ uint64, payload []byte) {
 		rawProcessed <- reader.ProcessRawEvent(payload)
 	})
@@ -826,6 +826,7 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 	}
 
 	frames := []struct {
+		label     string
 		typ       uint8
 		seq       uint64
 		payload   []byte
@@ -833,8 +834,9 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 		wantExtra string
 	}{
 		{
-			typ: EventFrameTypePolicyDeny,
-			seq: 31,
+			label: "policy-deny",
+			typ:   EventFrameTypePolicyDeny,
+			seq:   31,
 			payload: buildTypedDataplaneEventV4Payload(
 				dataplane.EventTypePolicyDeny,
 				dataplane.ActionDeny,
@@ -854,8 +856,9 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 			want: "RT_FLOW POLICY_DENY",
 		},
 		{
-			typ: EventFrameTypeScreenDrop,
-			seq: 32,
+			label: "screen-drop",
+			typ:   EventFrameTypeScreenDrop,
+			seq:   32,
 			payload: buildTypedDataplaneEventV4Payload(
 				dataplane.EventTypeScreenDrop,
 				dataplane.ActionDeny,
@@ -875,8 +878,9 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 			want: "RT_FLOW SCREEN_DROP",
 		},
 		{
-			typ: EventFrameTypeFilterLog,
-			seq: 33,
+			label: "pbr-filter-log",
+			typ:   EventFrameTypeFilterLog,
+			seq:   33,
 			payload: buildTypedDataplaneEventV4Payload(
 				dataplane.EventTypeFilterLog,
 				dataplane.ActionPermit,
@@ -895,6 +899,29 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 			),
 			want:      "RT_FLOW FILTER_LOG",
 			wantExtra: "source=pbr",
+		},
+		{
+			label: "input-filter-log-deny",
+			typ:   EventFrameTypeFilterLog,
+			seq:   34,
+			payload: buildTypedDataplaneEventV4Payload(
+				dataplane.EventTypeFilterLog,
+				dataplane.ActionDeny,
+				6,
+				4444, 22,
+				[4]byte{10, 0, 1, 7}, [4]byte{198, 51, 100, 30},
+				[4]byte{},
+				0,
+				1, 0,
+				42,
+				0,
+				9,
+				0,
+				2,
+				0,
+			),
+			want:      "RT_FLOW FILTER_LOG",
+			wantExtra: "source=input",
 		},
 	}
 	for _, frame := range frames {
@@ -921,8 +948,9 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 		msg := string(buf[:n])
 		for _, frame := range frames {
 			if strings.Contains(msg, frame.want) &&
-				(frame.wantExtra == "" || strings.Contains(msg, frame.wantExtra)) {
-				seen[frame.want] = true
+				(frame.wantExtra == "" || strings.Contains(msg, frame.wantExtra)) &&
+				(frame.label != "input-filter-log-deny" || strings.Contains(msg, "action=deny")) {
+				seen[frame.label] = true
 			}
 		}
 	}
@@ -943,8 +971,8 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 	if got := es.ScreenDropEvents.Load(); got != 1 {
 		t.Fatalf("ScreenDropEvents = %d, want 1", got)
 	}
-	if got := es.FilterLogEvents.Load(); got != 1 {
-		t.Fatalf("FilterLogEvents = %d, want 1", got)
+	if got := es.FilterLogEvents.Load(); got != 2 {
+		t.Fatalf("FilterLogEvents = %d, want 2", got)
 	}
 }
 

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -845,7 +845,7 @@ const (
 //	  [3:5]     Total record length (uint16 big-endian, includes header)
 //	  [5]       EventType
 //	  [6]       Protocol number
-//	  [7]       Action (0=permit, 1=deny, 2=reject)
+//	  [7]       Action (0=deny, 1=permit, 2=reject)
 //	  [8]       AddrFamily (2=IPv4, 10=IPv6)
 //	  [9]       Severity (syslog level)
 //	  [10:18]   Timestamp (uint64 LE, Unix nanoseconds)

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -33,6 +33,12 @@ sync.
   non-PBR input/output/lo0 filter logs. Output filter-log identity is
   carried through live TX selection and cached forwarding so flow-cache
   hits emit the same compiled filter/term/action metadata as live paths.
+  Terminal output `discard`/`reject` terms are carried in the TX selection
+  descriptor and drop before enqueue; filter-log deny records must not
+  describe traffic that still forwards. DSCP-matched input/output filters
+  are intentionally not flow-cached because DSCP is packet metadata, not
+  part of the session cache key; session hits re-evaluate DSCP-sensitive
+  input filters per packet.
   Producers must use the event-stream worker handle so rate limiting,
   queue-budget accounting, replay, and daemon callback ACK behavior stay
   centralized in `event_stream/`.

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::event_stream::codec::{DataplaneEventKind, DataplaneEventPayload};
 use crate::event_stream::EventStreamWorkerHandle;
+use crate::event_stream::codec::{DataplaneEventKind, DataplaneEventPayload};
 use crate::filter::FilterAction;
 use crate::policy::PolicyAction;
 use crate::screen::ScreenPacketInfo;
@@ -192,7 +192,10 @@ fn policy_action_to_rt_flow(action: PolicyAction) -> u8 {
     match action {
         PolicyAction::Permit => RT_FLOW_ACTION_PERMIT,
         PolicyAction::Deny => RT_FLOW_ACTION_DENY,
-        PolicyAction::Reject => RT_FLOW_ACTION_REJECT,
+        // Userspace policy reject is currently fail-closed as a terminal
+        // drop. Until policy-deny paths synthesize ICMP/RST rejects, log
+        // deny rather than claiming a reject packet was generated.
+        PolicyAction::Reject => RT_FLOW_ACTION_DENY,
     }
 }
 
@@ -201,7 +204,10 @@ fn filter_action_to_rt_flow(action: FilterAction) -> u8 {
     match action {
         FilterAction::Accept => RT_FLOW_ACTION_PERMIT,
         FilterAction::Discard => RT_FLOW_ACTION_DENY,
-        FilterAction::Reject => RT_FLOW_ACTION_REJECT,
+        // Userspace filter reject is currently fail-closed as a terminal
+        // drop. Until per-path reject packet synthesis is wired, RT_FLOW
+        // must report deny rather than claiming an ICMP/RST reject happened.
+        FilterAction::Reject => RT_FLOW_ACTION_DENY,
     }
 }
 
@@ -326,6 +332,34 @@ mod tests {
     }
 
     #[test]
+    fn policy_deny_event_emit_fails_closed_reject_as_deny() {
+        let (handle, rx) = unlimited_handle();
+        let flow = test_flow();
+
+        emit_policy_deny_event(
+            Some(&handle),
+            &flow,
+            test_meta(),
+            7,
+            9,
+            3,
+            101,
+            PolicyAction::Reject,
+            123,
+        );
+
+        let event = rx
+            .try_recv()
+            .expect("policy event frame")
+            .decode_dataplane_event()
+            .expect("policy event payload");
+        assert_eq!(event.kind, DataplaneEventKind::PolicyDeny);
+        assert_eq!(event.action, RT_FLOW_ACTION_DENY);
+        assert_eq!(event.reason, RT_FLOW_CLOSE_REASON_POLICY);
+        assert_eq!(handle.dataplane_event_stats().policy_deny.sent, 1);
+    }
+
+    #[test]
     fn screen_drop_event_emit_uses_screen_reason_flag() {
         let (handle, rx) = unlimited_handle();
         let pkt = ScreenPacketInfo {
@@ -427,6 +461,37 @@ mod tests {
         assert_eq!(event.reason, FilterLogSource::Input.wire_reason());
         assert_eq!(event.ingress_zone_id, 7);
         assert_eq!(event.egress_zone_id, 0);
+        assert_eq!(handle.dataplane_event_stats().filter_log.sent, 1);
+    }
+
+    #[test]
+    fn filter_log_event_emit_fails_closed_reject_as_deny() {
+        let (handle, rx) = unlimited_handle();
+        let flow = test_flow();
+
+        emit_filter_log_event(
+            Some(&handle),
+            &flow,
+            test_meta(),
+            7,
+            0,
+            23,
+            6,
+            FilterAction::Reject,
+            FilterLogSource::Lo0,
+            789,
+        );
+
+        let event = rx
+            .try_recv()
+            .expect("filter event frame")
+            .decode_dataplane_event()
+            .expect("filter event payload");
+        assert_eq!(event.kind, DataplaneEventKind::FilterLog);
+        assert_eq!(event.action, RT_FLOW_ACTION_DENY);
+        assert_eq!(event.filter_id, 23);
+        assert_eq!(event.term_id, 6);
+        assert_eq!(event.reason, FilterLogSource::Lo0.wire_reason());
         assert_eq!(handle.dataplane_event_stats().filter_log.sent, 1);
     }
 }

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -27,6 +27,7 @@ pub(super) const MAX_RG_EPOCHS: usize = 16;
 pub(super) struct CachedTxSelectionDescriptor {
     pub(super) queue_id: Option<u8>,
     pub(super) dscp_rewrite: Option<u8>,
+    pub(super) drop: bool,
     pub(super) filter_counter: Option<Arc<crate::filter::FilterTermCounter>>,
     pub(super) three_color_policers: crate::filter::CachedThreeColorPolicers,
     pub(super) filter_log: Option<crate::filter::FilterLogMatch>,
@@ -275,6 +276,32 @@ impl FlowCacheEntry {
                  rewrite_src={:?} rewrite_dst={:?}",
                 meta.addr_family, decision.nat.rewrite_src, decision.nat.rewrite_dst,
             );
+            return None;
+        }
+        // The flow-cache key is a 5-tuple and does not include DSCP.
+        // DSCP-sensitive filters must be re-evaluated on every packet,
+        // otherwise a first-packet accept/drop/log/classification
+        // decision could be replayed for later packets in the same flow
+        // with a different DSCP value.
+        let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
+        let ingress_ifindex = resolve_ingress_logical_ifindex(
+            forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        if crate::filter::interface_input_filter_has_dscp_match(
+            &forwarding.filter_state,
+            ingress_ifindex,
+            is_v6,
+        ) {
+            return None;
+        }
+        if crate::filter::interface_output_filter_has_dscp_match(
+            &forwarding.filter_state,
+            decision.resolution.egress_ifindex,
+            is_v6,
+        ) {
             return None;
         }
         // Keep cache invalidation tied to the flow owner RG, not the current

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use crate::test_zone_ids::*;
+use crate::{FirewallFilterSnapshot, FirewallTermSnapshot, InterfaceSnapshot};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::atomic::AtomicU32;
 
@@ -637,6 +638,110 @@ fn make_v4_round_trip_inputs() -> (
         },
     )]);
     (flow, meta, validation, decision, forwarding, ha_state)
+}
+
+#[test]
+fn from_forward_decision_skips_cache_for_dscp_matched_output_filter() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, mut meta, validation, decision, mut forwarding, ha_state) =
+        make_v4_round_trip_inputs();
+    meta.dscp = 0;
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "wan-drop-ef".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-ef-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                dscp_values: vec![46],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: decision.resolution.egress_ifindex,
+            filter_output_v4: "wan-drop-ef".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "DSCP-matched output filters depend on per-packet state outside \
+         the flow-cache key",
+    );
+}
+
+#[test]
+fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, mut meta, validation, decision, mut forwarding, ha_state) =
+        make_v4_round_trip_inputs();
+    meta.dscp = 0;
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "lan-drop-ef".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-ef-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                dscp_values: vec![46],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: meta.ingress_ifindex as i32,
+            filter_input_v4: "lan-drop-ef".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "DSCP-matched input filters depend on per-packet state outside \
+         the flow-cache key",
+    );
 }
 
 /// Build a self-consistent v6-meta + v6-NAT scenario for the

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -122,7 +122,7 @@ pub(super) fn build_live_forward_request_from_frame(
         .map(|selection| CoSTxSelection {
             queue_id: selection.queue_id,
             dscp_rewrite: selection.dscp_rewrite,
-            drop: false,
+            drop: selection.drop,
             filter_log: selection.filter_log,
         })
         .unwrap_or_else(|| {

--- a/userspace-dp/src/afxdp/poll_descriptor.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor.rs
@@ -190,6 +190,36 @@ fn evaluate_non_pbr_input_filter_log_only(
 }
 
 #[inline]
+fn evaluate_dscp_sensitive_input_filter_on_session_hit(
+    forwarding: &ForwardingState,
+    flow: Option<&SessionFlow>,
+    meta: UserspaceDpMeta,
+    ingress_zone_override: Option<u16>,
+) -> Option<NonPbrInputFilterEval> {
+    let flow = flow?;
+    let ingress_ifindex = resolve_ingress_logical_ifindex(
+        forwarding,
+        meta.ingress_ifindex as i32,
+        meta.ingress_vlan_id,
+    )
+    .unwrap_or(meta.ingress_ifindex as i32);
+    let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
+    if !crate::filter::interface_input_filter_has_dscp_match(
+        &forwarding.filter_state,
+        ingress_ifindex,
+        is_v6,
+    ) {
+        return None;
+    }
+    Some(evaluate_non_pbr_input_filter(
+        forwarding,
+        Some(flow),
+        meta,
+        ingress_zone_override,
+    ))
+}
+
+#[inline]
 fn emit_input_filter_log_match(
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     flow: &SessionFlow,
@@ -260,22 +290,19 @@ fn emit_cached_output_filter_log(
 }
 
 #[inline]
-fn emit_lo0_filter_log(
+fn apply_lo0_filter_action(
     forwarding: &ForwardingState,
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
     now_ns: u64,
-) {
-    if event_stream.is_none() {
-        return;
-    }
+) -> bool {
     let Some(flow) = flow else {
-        return;
+        return false;
     };
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
-    let Some(log_match) = crate::filter::evaluate_lo0_filter_log_match(
+    let result = crate::filter::evaluate_lo0_filter_counted(
         &forwarding.filter_state,
         is_v6,
         flow.src_ip,
@@ -284,26 +311,28 @@ fn emit_lo0_filter_log(
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
         meta.dscp,
-    ) else {
-        return;
-    };
-    emit_filter_log_event(
-        event_stream,
-        flow,
-        meta,
-        filter_log_ingress_zone_id(
-            forwarding,
-            meta,
-            ingress_zone_override,
-            meta.ingress_ifindex as i32,
-        ),
-        0,
-        log_match.filter_id,
-        log_match.term_id,
-        log_match.action,
-        FilterLogSource::Lo0,
-        now_ns,
+        meta.pkt_len as u64,
     );
+    if let Some(log_match) = result.log_match {
+        emit_filter_log_event(
+            event_stream,
+            flow,
+            meta,
+            filter_log_ingress_zone_id(
+                forwarding,
+                meta,
+                ingress_zone_override,
+                meta.ingress_ifindex as i32,
+            ),
+            0,
+            log_match.filter_id,
+            log_match.term_id,
+            log_match.action,
+            FilterLogSource::Lo0,
+            now_ns,
+        );
+    }
+    !matches!(result.action, crate::filter::FilterAction::Accept)
 }
 
 // Per-batch packet processing lifted from `poll_binding` (#678).
@@ -494,7 +523,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     cached_metadata,
                                     now_ns,
                                 );
-                                if policer_action.drop {
+                                if cached_descriptor.tx_selection.drop || policer_action.drop {
                                     binding.scratch.scratch_recycle.push(desc.addr);
                                     continue;
                                 }
@@ -717,6 +746,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             CachedTxSelectionDescriptor {
                                                 queue_id: cached_queue_id,
                                                 dscp_rewrite: cached_dscp_rewrite,
+                                                drop: cached_descriptor.tx_selection.drop,
                                                 ..CachedTxSelectionDescriptor::default()
                                             };
                                         if let Some(mut request) =
@@ -830,6 +860,61 @@ pub(super) fn poll_binding_process_descriptor(
                             session_ingress_zone = Some(resolved.metadata.ingress_zone);
                             flow_cache_owner_rg_id = resolved.metadata.owner_rg_id;
                             apply_nat_on_fabric = true;
+                            if let Some(input_filter_eval) =
+                                evaluate_dscp_sensitive_input_filter_on_session_hit(
+                                    worker_ctx.forwarding,
+                                    Some(flow),
+                                    meta,
+                                    Some(resolved.metadata.ingress_zone),
+                                )
+                            {
+                                if let Some(cached_log) = input_filter_eval.cached_log {
+                                    emit_input_filter_log_match(
+                                        worker_ctx.event_stream,
+                                        flow,
+                                        meta,
+                                        cached_log,
+                                        now_ns,
+                                    );
+                                }
+                                if input_filter_eval.action
+                                    != crate::filter::FilterAction::Accept
+                                {
+                                    binding.scratch.scratch_recycle.push(desc.addr);
+                                    continue;
+                                }
+                            }
+                            if resolved.decision.resolution.disposition
+                                == ForwardingDisposition::LocalDelivery
+                                && apply_lo0_filter_action(
+                                    worker_ctx.forwarding,
+                                    worker_ctx.event_stream,
+                                    Some(flow),
+                                    meta,
+                                    Some(resolved.metadata.ingress_zone),
+                                    now_ns,
+                                )
+                            {
+                                delete_terminal_filtered_session(
+                                    sessions,
+                                    binding.bpf_maps.session_map_fd,
+                                    conntrack_v4_fd,
+                                    conntrack_v6_fd,
+                                    worker_ctx.shared_sessions,
+                                    worker_ctx.shared_nat_sessions,
+                                    worker_ctx.shared_forward_wire_sessions,
+                                    &worker_ctx.shared_owner_rg_indexes,
+                                    worker_ctx.peer_worker_commands,
+                                    &resolved.key,
+                                    resolved.decision,
+                                    &resolved.metadata,
+                                    resolved.origin,
+                                );
+                                telemetry.dbg.local += 1;
+                                telemetry.dbg.policy_deny += 1;
+                                binding.scratch.scratch_recycle.push(desc.addr);
+                                continue;
+                            }
                             // TTL/hop-limit check on session-hit path: generate
                             // ICMP Time Exceeded for packets that would expire
                             // after decrement. The session-miss path handles this
@@ -1238,6 +1323,21 @@ pub(super) fn poll_binding_process_descriptor(
                             } else {
                                 false
                             };
+                            if resolution.disposition == ForwardingDisposition::LocalDelivery
+                                && apply_lo0_filter_action(
+                                    worker_ctx.forwarding,
+                                    worker_ctx.event_stream,
+                                    Some(flow),
+                                    meta,
+                                    ingress_zone_override,
+                                    now_ns,
+                                )
+                            {
+                                telemetry.dbg.local += 1;
+                                telemetry.dbg.policy_deny += 1;
+                                binding.scratch.scratch_recycle.push(desc.addr);
+                                continue;
+                            }
                             if resolution.disposition == ForwardingDisposition::LocalDelivery
                                 && !is_embedded_icmp_error
                                 && should_cache_local_delivery_session_on_miss(
@@ -2365,14 +2465,6 @@ pub(super) fn poll_binding_process_descriptor(
                         match decision.resolution.disposition {
                             ForwardingDisposition::LocalDelivery => {
                                 telemetry.dbg.local += 1;
-                                emit_lo0_filter_log(
-                                    worker_ctx.forwarding,
-                                    worker_ctx.event_stream,
-                                    flow.as_ref(),
-                                    meta,
-                                    ingress_zone_override,
-                                    now_ns,
-                                );
                                 // Reinject to slow-path TUN so the kernel
                                 // processes host-bound traffic (NDP, ICMP echo,
                                 // BGP, etc.).  The first packet creates a BPF

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -220,8 +220,102 @@ fn force_live_redirect_for_worker_synced_entry(
     allow_replace_local && uses_kernel_local_session_map_entry(decision, metadata, origin)
 }
 
+pub(super) fn session_key_has_lo0_filter(forwarding: &ForwardingState, key: &SessionKey) -> bool {
+    match key.addr_family {
+        family if family == libc::AF_INET as u8 => {
+            forwarding.filter_state.lo0_filter_v4_fast.is_some()
+        }
+        family if family == libc::AF_INET6 as u8 => {
+            forwarding.filter_state.lo0_filter_v6_fast.is_some()
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn republish_local_delivery_sessions_for_lo0_filter(
+    sessions: &SessionTable,
+    session_map_fd: c_int,
+    forwarding: &ForwardingState,
+) -> usize {
+    let mut republished = 0usize;
+    sessions.iter_with_origin(|key, decision, metadata, _origin| {
+        if metadata.is_reverse
+            || decision.resolution.disposition != ForwardingDisposition::LocalDelivery
+            || !session_key_has_lo0_filter(forwarding, key)
+        {
+            return;
+        }
+        if session_map_fd >= 0 {
+            let _ = publish_live_session_entry(
+                session_map_fd,
+                key,
+                decision.nat,
+                metadata.is_reverse,
+            );
+        }
+        republished += 1;
+    });
+    republished
+}
+
+pub(super) fn purge_sessions_for_input_dscp_filter_revalidation(
+    sessions: &mut SessionTable,
+    session_map_fd: c_int,
+    conntrack_v4_fd: c_int,
+    conntrack_v6_fd: c_int,
+    shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_forward_wire_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
+    peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
+    forwarding: &ForwardingState,
+    purge_v4: bool,
+    purge_v6: bool,
+    now_ns: u64,
+) -> usize {
+    if !purge_v4 && !purge_v6 {
+        return 0;
+    }
+    let mut stale = Vec::new();
+    sessions.iter_with_origin(|key, decision, metadata, origin| {
+        let family_matches =
+            (purge_v4 && key.addr_family == libc::AF_INET as u8)
+                || (purge_v6 && key.addr_family == libc::AF_INET6 as u8);
+        if family_matches {
+            stale.push((key.clone(), decision, metadata.clone(), origin));
+        }
+    });
+    let purged = stale.len();
+    for (key, decision, metadata, origin) in stale {
+        release_source_nat_allocation(
+            &forwarding.source_nat_rules,
+            &key,
+            decision.nat,
+            metadata.is_reverse,
+            now_ns,
+        );
+        delete_terminal_filtered_session(
+            sessions,
+            session_map_fd,
+            conntrack_v4_fd,
+            conntrack_v6_fd,
+            shared_sessions,
+            shared_nat_sessions,
+            shared_forward_wire_sessions,
+            shared_owner_rg_indexes,
+            peer_worker_commands,
+            &key,
+            decision,
+            &metadata,
+            origin,
+        );
+    }
+    purged
+}
+
 fn publish_worker_session_map_entry(
     session_map_fd: c_int,
+    forwarding: &ForwardingState,
     key: &SessionKey,
     decision: SessionDecision,
     metadata: &SessionMetadata,
@@ -231,7 +325,16 @@ fn publish_worker_session_map_entry(
     if session_map_fd < 0 {
         return;
     }
+    let has_lo0_filter = session_key_has_lo0_filter(forwarding, key);
     let uses_kernel_local = uses_kernel_local_session_map_entry(decision, metadata, origin);
+    if uses_kernel_local && has_lo0_filter {
+        // A PASS_TO_KERNEL session-map entry cannot re-run userspace lo0
+        // filters. Keep the packet visible to the helper while lo0
+        // filtering is configured; the session-hit path enforces the
+        // current lo0 terms before reinjection.
+        let _ = publish_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse);
+        return;
+    }
     let _ = if force_live_redirect_for_worker_synced_entry(
         decision,
         metadata,
@@ -251,6 +354,47 @@ fn publish_worker_session_map_entry(
             origin,
         )
     };
+}
+
+pub(super) fn delete_terminal_filtered_session(
+    sessions: &mut SessionTable,
+    session_map_fd: c_int,
+    conntrack_v4_fd: c_int,
+    conntrack_v6_fd: c_int,
+    shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_forward_wire_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
+    peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+) {
+    delete_session_map_entry_for_removed_session_with_origin(
+        session_map_fd,
+        key,
+        decision,
+        metadata,
+        origin,
+        conntrack_v4_fd,
+        conntrack_v6_fd,
+    );
+    sessions.delete(key);
+    remove_shared_session(
+        shared_sessions,
+        shared_nat_sessions,
+        shared_forward_wire_sessions,
+        shared_owner_rg_indexes,
+        key,
+    );
+    replicate_session_delete(peer_worker_commands, key);
+    sessions.emit_close_delta_with_origin(
+        key.clone(),
+        decision,
+        metadata.clone(),
+        origin,
+    );
 }
 
 fn export_forward_sessions_for_owner_rgs(sessions: &mut SessionTable, owner_rgs: &[i32]) {
@@ -399,6 +543,7 @@ pub(super) fn apply_worker_commands(
                         };
                         publish_worker_session_map_entry(
                             session_map_fd,
+                            forwarding,
                             &demoted_key,
                             publish_decision,
                             &publish_metadata,
@@ -483,6 +628,7 @@ pub(super) fn apply_worker_commands(
                     ) {
                         publish_worker_session_map_entry(
                             session_map_fd,
+                            forwarding,
                             &key,
                             refreshed_decision,
                             &refreshed_metadata,
@@ -561,6 +707,7 @@ pub(super) fn apply_worker_commands(
                 ) {
                     publish_worker_session_map_entry(
                         session_map_fd,
+                        forwarding,
                         &key,
                         entry.decision,
                         &metadata,
@@ -1123,8 +1270,10 @@ pub(super) fn resolve_flow_session_decision(
             )
         };
         return Some(ResolvedFlowSessionDecision {
+            key: resolved_key.clone(),
             decision,
             metadata,
+            origin: hit_origin,
             created: false,
         });
     }
@@ -1199,8 +1348,10 @@ pub(super) fn resolve_flow_session_decision(
         tcp_flags,
     );
     Some(ResolvedFlowSessionDecision {
+        key: flow.forward_key.clone(),
         decision,
         metadata,
+        origin: SessionOrigin::ReverseFlow,
         created: true,
     })
 }

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -6,8 +6,12 @@
 // session_glue/mod.rs.
 
 use super::*;
+use crate::filter::Filter;
 use crate::test_zone_ids::*;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+
+const TCP_FLAG_ACK: u8 = 0x10;
 
 fn active_ha_runtime(now_secs: u64) -> HAGroupRuntime {
     HAGroupRuntime {
@@ -57,6 +61,22 @@ fn test_decision() -> SessionDecision {
     }
 }
 
+fn empty_filter(name: &str, family: &str) -> Arc<Filter> {
+    Arc::new(Filter {
+        id: 1,
+        name: name.to_string(),
+        family: family.to_string(),
+        terms: Vec::new(),
+        affects_tx_selection: false,
+        affects_route_lookup: false,
+        has_counter_terms: false,
+        has_log_terms: false,
+        has_terminal_action_terms: false,
+        has_dscp_match_terms: false,
+        has_three_color_policer_terms: false,
+    })
+}
+
 fn test_forwarding_state() -> ForwardingState {
     let mut forwarding = ForwardingState::default();
     forwarding.connected_v4.push(ConnectedRouteV4 {
@@ -97,6 +117,135 @@ fn test_forwarding_state() -> ForwardingState {
         },
     );
     forwarding
+}
+
+#[test]
+fn session_key_has_lo0_filter_matches_packet_family() {
+    let mut forwarding = ForwardingState::default();
+    let v4_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1)),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    let v6_key = SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+        dst_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+
+    assert!(!session_key_has_lo0_filter(&forwarding, &v4_key));
+    forwarding.filter_state.lo0_filter_v4_fast = Some(empty_filter("lo0-v4", "inet"));
+    assert!(session_key_has_lo0_filter(&forwarding, &v4_key));
+    assert!(!session_key_has_lo0_filter(&forwarding, &v6_key));
+
+    forwarding.filter_state.lo0_filter_v6_fast = Some(empty_filter("lo0-v6", "inet6"));
+    assert!(session_key_has_lo0_filter(&forwarding, &v6_key));
+}
+
+#[test]
+fn republish_local_delivery_sessions_for_lo0_filter_selects_existing_hits() {
+    let mut forwarding = ForwardingState::default();
+    forwarding.filter_state.lo0_filter_v4_fast = Some(empty_filter("lo0-v4", "inet"));
+    let key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1)),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    let mut sessions = SessionTable::new();
+    assert!(sessions.install_with_protocol_with_origin(
+        key,
+        test_local_delivery_decision(),
+        test_metadata(),
+        SessionOrigin::SyncImport,
+        1,
+        PROTO_TCP,
+        TCP_FLAG_SYN,
+    ));
+
+    assert_eq!(
+        republish_local_delivery_sessions_for_lo0_filter(&sessions, -1, &forwarding),
+        1
+    );
+
+    forwarding.filter_state.lo0_filter_v4_fast = None;
+    assert_eq!(
+        republish_local_delivery_sessions_for_lo0_filter(&sessions, -1, &forwarding),
+        0
+    );
+}
+
+#[test]
+fn purge_sessions_for_input_dscp_filter_revalidation_removes_family() {
+    let forwarding = ForwardingState::default();
+    let mut sessions = SessionTable::new();
+    let v4_key = test_key();
+    let v6_key = SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+        dst_ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    assert!(sessions.install_with_protocol_with_origin(
+        v4_key.clone(),
+        test_decision(),
+        test_metadata(),
+        SessionOrigin::ForwardFlow,
+        1,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    assert!(sessions.install_with_protocol_with_origin(
+        v6_key.clone(),
+        test_decision(),
+        test_metadata(),
+        SessionOrigin::ForwardFlow,
+        1,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    let _ = sessions.drain_deltas(16);
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+
+    assert_eq!(
+        purge_sessions_for_input_dscp_filter_revalidation(
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            true,
+            false,
+            2,
+        ),
+        1
+    );
+
+    assert!(sessions.entry_with_origin(&v4_key).is_none());
+    assert!(sessions.entry_with_origin(&v6_key).is_some());
+    let deltas = sessions.drain_deltas(16);
+    assert_eq!(deltas.len(), 1);
+    assert_eq!(deltas[0].kind, SessionDeltaKind::Close);
+    assert_eq!(deltas[0].key, v4_key);
 }
 
 fn test_local_delivery_decision() -> SessionDecision {

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -352,8 +352,10 @@ impl ResolvedSessionLookup {
 
 #[derive(Clone, Debug)]
 pub(super) struct ResolvedFlowSessionDecision {
+    pub(super) key: SessionKey,
     pub(super) decision: SessionDecision,
     pub(super) metadata: SessionMetadata,
+    pub(super) origin: SessionOrigin,
     pub(super) created: bool,
 }
 

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -257,6 +257,122 @@ fn build_live_forward_request_from_frame_uses_precomputed_hints() {
 }
 
 #[test]
+fn build_live_forward_request_from_frame_drops_logged_output_filter_discard() {
+    let lookup = WorkerBindingLookup::default();
+    let ingress_ident = BindingIdentity {
+        slot: 7,
+        queue_id: 3,
+        worker_id: 0,
+        interface: Arc::<str>::from("ge-0-0-1"),
+        ifindex: 10,
+    };
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex: 10,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        pkt_len: 60,
+        ..UserspaceDpMeta::default()
+    };
+    let decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 80,
+        },
+        nat: NatDecision::default(),
+    };
+    let flow = SessionFlow {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 443,
+        },
+    };
+    let forwarding = build_forwarding_state(&ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 12,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    });
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    let req = build_live_forward_request_from_frame(
+        &lookup,
+        2,
+        &ingress_ident,
+        XdpDesc {
+            addr: 0,
+            len: 0,
+            options: 0,
+        },
+        &[],
+        meta,
+        &decision,
+        &forwarding,
+        Some(&flow),
+        None,
+        false,
+        123,
+        Some(&event_handle),
+        None,
+        None,
+    );
+
+    assert!(req.is_none(), "terminal output filter must not forward");
+    let event = event_rx
+        .try_recv()
+        .expect("output filter-log frame")
+        .decode_dataplane_event()
+        .expect("filter-log payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::FilterLog
+    );
+    assert_eq!(event.action, 0, "discard must encode RT_FLOW deny");
+    assert_eq!(
+        event.reason,
+        FilterLogSource::Output.wire_reason(),
+        "live output filter source must not be mislabeled",
+    );
+}
+
+#[test]
 fn icmp_reverse_key_keeps_identifier_position() {
     let flow = SessionFlow {
         src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
@@ -2539,6 +2655,15 @@ fn build_policy_deny_tcp_syn_frame() -> Vec<u8> {
     frame
 }
 
+fn set_ipv4_dst(frame: &mut [u8], dst: Ipv4Addr) {
+    frame[24] = 0;
+    frame[25] = 0;
+    frame[30..34].copy_from_slice(&dst.octets());
+    let ip_sum = checksum16(&frame[14..34]);
+    frame[24] = (ip_sum >> 8) as u8;
+    frame[25] = ip_sum as u8;
+}
+
 #[test]
 fn poll_descriptor_policy_deny_path_emits_rt_flow_event() {
     let mut snapshot = policy_deny_snapshot();
@@ -3053,6 +3178,618 @@ fn poll_descriptor_input_filter_discard_drops_and_logs() {
     assert_eq!(event.ingress_zone_id, TEST_LAN_ZONE_ID);
     assert!(binding.scratch.scratch_forwards.is_empty());
     assert_eq!(sessions.len(), 0);
+    assert_eq!(event_handle.dataplane_event_stats().filter_log.sent, 1);
+}
+
+#[test]
+fn poll_descriptor_session_hit_rechecks_dscp_input_filter() {
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.default_policy = "permit".to_string();
+    snapshot.policies.clear();
+    snapshot.zones = vec![
+        ZoneSnapshot {
+            name: "lan".to_string(),
+            id: TEST_LAN_ZONE_ID,
+        },
+        ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        },
+    ];
+    snapshot.interfaces[0].filter_input_v4 = "drop-ef-input".to_string();
+    snapshot.filters = vec![FirewallFilterSnapshot {
+        name: "drop-ef-input".to_string(),
+        family: "inet".to_string(),
+        terms: vec![FirewallTermSnapshot {
+            name: "drop-ef-web".to_string(),
+            action: "discard".to_string(),
+            destination_ports: vec!["5201".to_string()],
+            dscp_values: vec![46],
+            log: true,
+            ..Default::default()
+        }],
+    }];
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut frame = build_policy_deny_tcp_syn_frame();
+    frame[47] = 0x10;
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: meta_len as u16,
+        ingress_ifindex: 24,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        dscp: 46,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    };
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(&frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(&binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding: &forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+    };
+    let mut sessions = SessionTable::new();
+    let flow_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    let decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 12,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: Some([0, 0xaa, 0xbb, 0xcc, 0xdd, 0xee]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 80,
+        },
+        nat: NatDecision::default(),
+    };
+    let metadata = SessionMetadata {
+        ingress_zone: TEST_LAN_ZONE_ID,
+        egress_zone: TEST_WAN_ZONE_ID,
+        owner_rg_id: 0,
+        fabric_ingress: false,
+        is_reverse: false,
+        nat64_reverse: None,
+    };
+    assert!(sessions.install_with_protocol_with_origin(
+        flow_key.clone(),
+        decision,
+        metadata,
+        SessionOrigin::ForwardFlow,
+        123_000_000_000,
+        PROTO_TCP,
+        0x10,
+    ));
+    assert_eq!(sessions.drain_deltas(16).len(), 1, "initial open delta");
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+
+    poll_binding_process_descriptor(
+        &mut binding,
+        0,
+        area_ptr,
+        1,
+        &mut sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        123_000_000_000,
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("DSCP input filter-log event from session hit")
+        .decode_dataplane_event()
+        .expect("DSCP input filter-log payload");
+    assert_eq!(event.reason, FilterLogSource::Input.wire_reason());
+    assert_eq!(event.action, 0);
+    assert_eq!(event.ingress_zone_id, TEST_LAN_ZONE_ID);
+    assert!(binding.scratch.scratch_forwards.is_empty());
+    assert_eq!(sessions.len(), 1, "per-packet input drop keeps session");
+    assert_eq!(event_handle.dataplane_event_stats().filter_log.sent, 1);
+}
+
+#[test]
+fn poll_descriptor_lo0_filter_discard_drops_without_reinject() {
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.default_policy = "permit".to_string();
+    snapshot.policies.clear();
+    snapshot.zones = vec![
+        ZoneSnapshot {
+            name: "lan".to_string(),
+            id: TEST_LAN_ZONE_ID,
+        },
+        ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        },
+    ];
+    snapshot.interfaces[0].addresses = vec![InterfaceAddressSnapshot {
+        family: "inet".to_string(),
+        address: "10.0.61.1/24".to_string(),
+        scope: 0,
+    }];
+    snapshot.flow.lo0_filter_input_v4 = "protect-re".to_string();
+    snapshot.filters = vec![FirewallFilterSnapshot {
+        name: "protect-re".to_string(),
+        family: "inet".to_string(),
+        terms: vec![FirewallTermSnapshot {
+            name: "drop-web".to_string(),
+            action: "discard".to_string(),
+            destination_ports: vec!["5201".to_string()],
+            log: true,
+            ..Default::default()
+        }],
+    }];
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut frame = build_policy_deny_tcp_syn_frame();
+    set_ipv4_dst(&mut frame, Ipv4Addr::new(10, 0, 61, 1));
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: meta_len as u16,
+        ingress_ifindex: 24,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    };
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(&frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(&binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding: &forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+    };
+    let mut sessions = SessionTable::new();
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+
+    poll_binding_process_descriptor(
+        &mut binding,
+        0,
+        area_ptr,
+        1,
+        &mut sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        123_000_000_000,
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("lo0 filter-log event from poll descriptor")
+        .decode_dataplane_event()
+        .expect("lo0 filter-log payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::FilterLog
+    );
+    assert_eq!(event.reason, FilterLogSource::Lo0.wire_reason());
+    assert_eq!(event.action, 0);
+    assert_eq!(event.ingress_zone_id, TEST_LAN_ZONE_ID);
+    assert!(binding.scratch.scratch_forwards.is_empty());
+    assert_eq!(sessions.len(), 0);
+    assert_eq!(binding.live.slow_path_drops.load(Ordering::Relaxed), 0);
+    assert!(recent_exceptions.lock().unwrap().is_empty());
+    assert_eq!(event_handle.dataplane_event_stats().filter_log.sent, 1);
+}
+
+#[test]
+fn poll_descriptor_lo0_filter_drops_cached_local_delivery_session_hit() {
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.default_policy = "permit".to_string();
+    snapshot.policies.clear();
+    snapshot.zones = vec![
+        ZoneSnapshot {
+            name: "lan".to_string(),
+            id: TEST_LAN_ZONE_ID,
+        },
+        ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        },
+    ];
+    snapshot.interfaces[0].addresses = vec![InterfaceAddressSnapshot {
+        family: "inet".to_string(),
+        address: "10.0.61.1/24".to_string(),
+        scope: 0,
+    }];
+    snapshot.flow.lo0_filter_input_v4 = "protect-re".to_string();
+    snapshot.filters = vec![FirewallFilterSnapshot {
+        name: "protect-re".to_string(),
+        family: "inet".to_string(),
+        terms: vec![FirewallTermSnapshot {
+            name: "drop-web".to_string(),
+            action: "discard".to_string(),
+            destination_ports: vec!["5201".to_string()],
+            log: true,
+            ..Default::default()
+        }],
+    }];
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut frame = build_policy_deny_tcp_syn_frame();
+    set_ipv4_dst(&mut frame, Ipv4Addr::new(10, 0, 61, 1));
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: meta_len as u16,
+        ingress_ifindex: 24,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    };
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(&frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(&binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding: &forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+    };
+    let mut sessions = SessionTable::new();
+    let flow_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1)),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    let local_decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::LocalDelivery,
+            local_ifindex: 24,
+            egress_ifindex: 24,
+            tx_ifindex: 24,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: None,
+            src_mac: None,
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    };
+    let local_metadata = SessionMetadata {
+        ingress_zone: TEST_LAN_ZONE_ID,
+        egress_zone: TEST_LAN_ZONE_ID,
+        owner_rg_id: 0,
+        fabric_ingress: false,
+        is_reverse: false,
+        nat64_reverse: None,
+    };
+    assert!(sessions.install_with_protocol_with_origin(
+        flow_key.clone(),
+        local_decision,
+        local_metadata.clone(),
+        SessionOrigin::LocalMiss,
+        123_000_000_000,
+        PROTO_TCP,
+        TCP_FLAG_SYN,
+    ));
+    let shared_entry = SyncedSessionEntry {
+        key: flow_key.clone(),
+        decision: local_decision,
+        metadata: local_metadata,
+        origin: SessionOrigin::LocalMiss,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+    };
+    publish_shared_session(
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &shared_entry,
+    );
+    assert_eq!(sessions.drain_deltas(16).len(), 1, "initial open delta");
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+
+    poll_binding_process_descriptor(
+        &mut binding,
+        0,
+        area_ptr,
+        1,
+        &mut sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        123_000_000_000,
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("lo0 filter-log event from cached local session hit")
+        .decode_dataplane_event()
+        .expect("lo0 filter-log payload");
+    assert_eq!(event.reason, FilterLogSource::Lo0.wire_reason());
+    assert_eq!(event.action, 0);
+    assert!(binding.scratch.scratch_forwards.is_empty());
+    assert_eq!(sessions.len(), 0);
+    assert!(shared_sessions.lock().expect("shared sessions").is_empty());
+    assert!(shared_nat_sessions.lock().expect("shared nat").is_empty());
+    assert!(
+        shared_forward_wire_sessions
+            .lock()
+            .expect("shared forward wire")
+            .is_empty()
+    );
+    let deltas = sessions.drain_deltas(16);
+    assert_eq!(deltas.len(), 1);
+    assert_eq!(deltas[0].kind, SessionDeltaKind::Close);
+    assert_eq!(deltas[0].key, flow_key);
+    assert_eq!(binding.live.slow_path_drops.load(Ordering::Relaxed), 0);
+    assert!(recent_exceptions.lock().unwrap().is_empty());
     assert_eq!(event_handle.dataplane_event_stats().filter_log.sent, 1);
 }
 

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -32,6 +32,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
         return CachedTxSelectionDescriptor {
             queue_id: iface.map(|iface| iface.default_queue),
             dscp_rewrite: None,
+            drop: false,
             filter_counter: None,
             three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
             filter_log: None,
@@ -77,6 +78,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             filter.affects_tx_selection
                 || filter.has_counter_terms
                 || filter.has_log_terms
+                || filter.has_terminal_action_terms
                 || filter.has_three_color_policer_terms
         })
         .map(|filter| {
@@ -156,6 +158,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
     CachedTxSelectionDescriptor {
         queue_id,
         dscp_rewrite: effective_dscp_rewrite,
+        drop: output_result.action != crate::filter::FilterAction::Accept,
         filter_counter,
         three_color_policers,
         filter_log,
@@ -288,6 +291,7 @@ fn resolve_cos_tx_selection_internal(
         filter.affects_tx_selection
             || filter.has_counter_terms
             || filter.has_log_terms
+            || filter.has_terminal_action_terms
             || filter.has_three_color_policer_terms
     }) {
         if let Some(now_ns) = now_ns {
@@ -318,7 +322,8 @@ fn resolve_cos_tx_selection_internal(
         crate::filter::TxSelectionFilterResult::default()
     };
     let mut effective_dscp_rewrite = output_result.dscp_rewrite;
-    let mut policer_drop = output_result.policer_drop;
+    let mut drop =
+        output_result.policer_drop || output_result.action != crate::filter::FilterAction::Accept;
     let mut ingress_forwarding_class = None;
     let filter_log = output_result.log_match;
     if let Some(ingress_filter) = ingress_filter.filter(|filter| {
@@ -349,7 +354,7 @@ fn resolve_cos_tx_selection_internal(
             )
         };
         effective_dscp_rewrite = effective_dscp_rewrite.or(ingress_result.dscp_rewrite);
-        policer_drop |= ingress_result.policer_drop;
+        drop |= ingress_result.policer_drop;
         if !has_output_filter {
             ingress_forwarding_class = ingress_result.forwarding_class;
         }
@@ -358,7 +363,7 @@ fn resolve_cos_tx_selection_internal(
         return CoSTxSelection {
             queue_id: None,
             dscp_rewrite: effective_dscp_rewrite,
-            drop: policer_drop,
+            drop,
             filter_log,
         };
     };
@@ -367,7 +372,7 @@ fn resolve_cos_tx_selection_internal(
             return CoSTxSelection {
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
-                drop: policer_drop,
+                drop,
                 filter_log,
             };
         }
@@ -377,7 +382,7 @@ fn resolve_cos_tx_selection_internal(
             return CoSTxSelection {
                 queue_id: Some(*queue_id),
                 dscp_rewrite: effective_dscp_rewrite,
-                drop: policer_drop,
+                drop,
                 filter_log,
             };
         }
@@ -386,7 +391,7 @@ fn resolve_cos_tx_selection_internal(
         return CoSTxSelection {
             queue_id: Some(queue_id),
             dscp_rewrite: effective_dscp_rewrite,
-            drop: policer_drop,
+            drop,
             filter_log,
         };
     }
@@ -398,14 +403,14 @@ fn resolve_cos_tx_selection_internal(
         return CoSTxSelection {
             queue_id: Some(queue_id),
             dscp_rewrite: effective_dscp_rewrite,
-            drop: policer_drop,
+            drop,
             filter_log,
         };
     }
     CoSTxSelection {
         queue_id: Some(iface.default_queue),
         dscp_rewrite: effective_dscp_rewrite,
-        drop: policer_drop,
+        drop,
         filter_log,
     }
 }

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1371,6 +1371,110 @@ fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
 }
 
 #[test]
+fn resolve_cos_tx_selection_drops_terminal_output_filter_without_log() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let selection = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        UserspaceDpMeta {
+            ingress_ifindex: 5,
+            ingress_vlan_id: 0,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            dscp: 0,
+            pkt_len: 1514,
+            ..Default::default()
+        },
+        Some(&SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 443,
+        }),
+    );
+
+    assert!(selection.drop);
+    assert_eq!(selection.queue_id, None);
+    assert_eq!(selection.filter_log, None);
+}
+
+#[test]
+fn resolve_cos_tx_selection_drops_reject_output_filter_without_log() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-reject".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-reject".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "reject".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let selection = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        UserspaceDpMeta {
+            ingress_ifindex: 5,
+            ingress_vlan_id: 0,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            dscp: 0,
+            pkt_len: 1514,
+            ..Default::default()
+        },
+        Some(&SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 443,
+        }),
+    );
+
+    assert!(selection.drop);
+    assert_eq!(selection.queue_id, None);
+    assert_eq!(selection.filter_log, None);
+}
+
+#[test]
 fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filter_exists() {
     let snapshot = ConfigSnapshot {
         interfaces: vec![

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1473,6 +1473,7 @@ fn active_flow_debug_test_entry(
             tx_selection: CachedTxSelectionDescriptor {
                 queue_id: Some(2),
                 dscp_rewrite: Some(46),
+                drop: false,
                 filter_counter: None,
                 three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
                 filter_log: None,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1270,6 +1270,11 @@ pub(crate) fn worker_loop(
             // Compare BEFORE assignment — needs both old and new.
             let cos_changed =
                 cos_runtime_config_changed(forwarding.as_ref(), new_forwarding.as_ref());
+            let (purge_input_dscp_v4, purge_input_dscp_v6) =
+                crate::filter::input_dscp_filter_families_changed(
+                    &forwarding.filter_state,
+                    &new_forwarding.filter_state,
+                );
 
             // Use NEW values for dependent state updates (forwarding-site
             // ordering — old `forwarding` is stale once rotated).
@@ -1277,6 +1282,40 @@ pub(crate) fn worker_loop(
             sessions.set_timeouts(new_forwarding.session_timeouts);
 
             forwarding = new_forwarding;
+            let purged_input_dscp = purge_sessions_for_input_dscp_filter_revalidation(
+                &mut sessions,
+                session_map_fd,
+                conntrack_v4_fd,
+                conntrack_v6_fd,
+                &shared_sessions,
+                &shared_nat_sessions,
+                &shared_forward_wire_sessions,
+                &shared_owner_rg_indexes,
+                &peer_worker_commands,
+                &forwarding,
+                purge_input_dscp_v4,
+                purge_input_dscp_v6,
+                loop_now_ns,
+            );
+            if purged_input_dscp > 0 {
+                debug_log!(
+                    "INPUT_DSCP_FILTER_PURGE: worker={} sessions={}",
+                    worker_id,
+                    purged_input_dscp,
+                );
+            }
+            let republished = republish_local_delivery_sessions_for_lo0_filter(
+                &sessions,
+                session_map_fd,
+                &forwarding,
+            );
+            if republished > 0 {
+                debug_log!(
+                    "LO0_FILTER_REPUBLISH: worker={} local_delivery_sessions={}",
+                    worker_id,
+                    republished,
+                );
+            }
 
             if cos_changed {
                 reset_worker_cos_runtimes(&mut bindings, &mut shared_recycles);

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -45,6 +45,8 @@ const RT_FLOW_EVENT_SCREEN_DROP: u8 = 4;
 const RT_FLOW_EVENT_FILTER_LOG: u8 = 6;
 const RT_FLOW_ACTION_DENY: u8 = 0;
 const RT_FLOW_ACTION_PERMIT: u8 = 1;
+#[allow(dead_code)]
+const RT_FLOW_ACTION_REJECT: u8 = 2;
 
 /// Disposition encoding for the wire format.
 const DISP_FORWARD_CANDIDATE: u8 = 0;

--- a/userspace-dp/src/event_stream/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec_tests.rs
@@ -284,6 +284,24 @@ fn test_filter_log_can_encode_discard_action() {
 }
 
 #[test]
+fn test_policy_event_can_encode_reject_action() {
+    let mut event = test_dataplane_event_v4(DataplaneEventKind::PolicyDeny);
+    event.action = RT_FLOW_ACTION_REJECT;
+    let frame = EventFrame::encode_dataplane_event(322, &event);
+    let payload = frame
+        .dataplane_event_payload()
+        .expect("security event payload");
+    assert_eq!(payload[54], RT_FLOW_ACTION_REJECT);
+    assert_eq!(
+        frame
+            .decode_dataplane_event()
+            .expect("decoded security event frame")
+            .action,
+        RT_FLOW_ACTION_REJECT
+    );
+}
+
+#[test]
 fn test_encode_session_open_v4() {
     let zones = test_zone_map();
     let frame = EventFrame::encode_session_open(

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -25,8 +25,17 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   or allocating on the packet path. No-count helper evaluation returns the
   first logged non-PBR input or lo0 match while skipping routing-instance
   terms to avoid double-emitting PBR logs. TX-selection evaluation meters
-  three-color policers and carries output filter-log identity through live
-  forwarding and cached flow-cache hits.
+  three-color policers, carries output filter-log identity through live
+  forwarding and cached flow-cache hits, and preserves terminal
+  `discard`/`reject` actions so output filters cannot log deny while
+  forwarding. Input/output filters with DSCP match terms force the
+  flow-cache insertion path to decline caching because DSCP is not part
+  of the session key. Established session hits still re-evaluate
+  DSCP-sensitive input filters per packet. Forwarding rotations compare
+  DSCP-sensitive input filter content by stable names, terms, and
+  three-color policer runtime shape, not by compiler-positional filter
+  IDs, before deciding whether existing sessions need a conservative
+  packet-family purge.
 - `policer.rs` — token-bucket implementation plus the #1375 RFC
   2697/2698 three-color meter core. Token math is integer-only:
   the legacy token bucket keeps its bits/sec constructor contract, and

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -105,6 +105,10 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             affects_route_lookup: terms.iter().any(|term| !term.routing_instance.is_empty()),
             has_counter_terms: terms.iter().any(|term| term.has_count),
             has_log_terms: terms.iter().any(|term| term.log),
+            has_terminal_action_terms: terms
+                .iter()
+                .any(|term| term.action != FilterAction::Accept),
+            has_dscp_match_terms: terms.iter().any(|term| term.dscp_match_enabled),
             has_three_color_policer_terms: terms
                 .iter()
                 .any(|term| term.three_color_policer.is_some()),
@@ -135,6 +139,9 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                         .iface_filter_v4_affects_route_lookup
                         .insert(iface.ifindex);
                 }
+                if filter.has_dscp_match_terms {
+                    state.iface_filter_v4_has_dscp_match.insert(iface.ifindex);
+                }
                 state
                     .iface_filter_v4_fast
                     .insert(iface.ifindex, filter.clone());
@@ -147,6 +154,7 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 if filter.affects_tx_selection
                     || filter.has_counter_terms
                     || filter.has_log_terms
+                    || filter.has_terminal_action_terms
                     || filter.has_three_color_policer_terms
                 {
                     state
@@ -179,6 +187,9 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                         .iface_filter_v6_affects_route_lookup
                         .insert(iface.ifindex);
                 }
+                if filter.has_dscp_match_terms {
+                    state.iface_filter_v6_has_dscp_match.insert(iface.ifindex);
+                }
                 state
                     .iface_filter_v6_fast
                     .insert(iface.ifindex, filter.clone());
@@ -191,6 +202,7 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 if filter.affects_tx_selection
                     || filter.has_counter_terms
                     || filter.has_log_terms
+                    || filter.has_terminal_action_terms
                     || filter.has_three_color_policer_terms
                 {
                     state

--- a/userspace-dp/src/filter/engine.rs
+++ b/userspace-dp/src/filter/engine.rs
@@ -377,6 +377,7 @@ fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
         }
         let policer_action = apply_term_three_color_policer(term, now_ns, packet_bytes);
         return TxSelectionFilterResult {
+            action: term.action,
             forwarding_class: (!term.forwarding_class.is_empty())
                 .then_some(term.forwarding_class.as_ref()),
             dscp_rewrite: policer_action.dscp_rewrite.or(term.dscp_rewrite),
@@ -408,6 +409,7 @@ fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
         }
         let policer_action = apply_term_three_color_policer(term, now_ns, packet_bytes);
         return TxSelectionFilterResult {
+            action: term.action,
             forwarding_class: (!term.forwarding_class.is_empty())
                 .then_some(term.forwarding_class.as_ref()),
             dscp_rewrite: policer_action.dscp_rewrite.or(term.dscp_rewrite),
@@ -465,6 +467,7 @@ fn evaluate_filter_ref_tx_selection_cached_v4(
             continue;
         }
         return CachedTxSelectionFilterResult {
+            action: term.action,
             forwarding_class: (!term.forwarding_class.is_empty())
                 .then(|| term.forwarding_class.clone()),
             dscp_rewrite: term.dscp_rewrite,
@@ -492,6 +495,7 @@ fn evaluate_filter_ref_tx_selection_cached_v6(
             continue;
         }
         return CachedTxSelectionFilterResult {
+            action: term.action,
             forwarding_class: (!term.forwarding_class.is_empty())
                 .then(|| term.forwarding_class.clone()),
             dscp_rewrite: term.dscp_rewrite,
@@ -1014,6 +1018,18 @@ pub(crate) fn interface_filter_affects_route_lookup(
     }
 }
 
+pub(crate) fn interface_input_filter_has_dscp_match(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    if is_v6 {
+        state.iface_filter_v6_has_dscp_match.contains(&ifindex)
+    } else {
+        state.iface_filter_v4_has_dscp_match.contains(&ifindex)
+    }
+}
+
 pub(crate) fn interface_output_filter_needs_tx_eval(
     state: &FilterState,
     ifindex: i32,
@@ -1024,6 +1040,103 @@ pub(crate) fn interface_output_filter_needs_tx_eval(
     } else {
         state.iface_filter_out_v4_needs_tx_eval.contains(&ifindex)
     }
+}
+
+pub(crate) fn interface_output_filter_has_dscp_match(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    let filter = if is_v6 {
+        state.iface_filter_out_v6_fast.get(&ifindex)
+    } else {
+        state.iface_filter_out_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.has_dscp_match_terms)
+}
+
+fn three_color_policer_semantics_match(
+    old: &Option<Arc<ThreeColorPolicerRuntime>>,
+    new: &Option<Arc<ThreeColorPolicerRuntime>>,
+) -> bool {
+    match (old.as_ref(), new.as_ref()) {
+        (None, None) => true,
+        (Some(old), Some(new)) => Arc::ptr_eq(old, new) || old.same_runtime_shape_as(new),
+        _ => false,
+    }
+}
+
+fn filter_term_semantics_match(old: &FilterTerm, new: &FilterTerm) -> bool {
+    old.name == new.name
+        && old.source_v4 == new.source_v4
+        && old.source_v6 == new.source_v6
+        && old.dest_v4 == new.dest_v4
+        && old.dest_v6 == new.dest_v6
+        && old.protocol_bitmap == new.protocol_bitmap
+        && old.protocol_match_enabled == new.protocol_match_enabled
+        && old.source_ports == new.source_ports
+        && old.dest_ports == new.dest_ports
+        && old.dscp_bitmap == new.dscp_bitmap
+        && old.dscp_match_enabled == new.dscp_match_enabled
+        && old.action == new.action
+        && old.count == new.count
+        && old.has_count == new.has_count
+        && old.log == new.log
+        && old.policer_name == new.policer_name
+        && three_color_policer_semantics_match(&old.three_color_policer, &new.three_color_policer)
+        && old.routing_instance == new.routing_instance
+        && old.forwarding_class == new.forwarding_class
+        && old.dscp_rewrite == new.dscp_rewrite
+}
+
+fn dscp_sensitive_filter_semantics_match(old: &Filter, new: &Filter) -> bool {
+    old.name == new.name
+        && old.family == new.family
+        && old.affects_tx_selection == new.affects_tx_selection
+        && old.affects_route_lookup == new.affects_route_lookup
+        && old.has_counter_terms == new.has_counter_terms
+        && old.has_log_terms == new.has_log_terms
+        && old.has_terminal_action_terms == new.has_terminal_action_terms
+        && old.has_dscp_match_terms == new.has_dscp_match_terms
+        && old.has_three_color_policer_terms == new.has_three_color_policer_terms
+        && old.terms.len() == new.terms.len()
+        && old
+            .terms
+            .iter()
+            .zip(new.terms.iter())
+            .all(|(old, new)| filter_term_semantics_match(old, new))
+}
+
+fn input_dscp_filter_family_changed(
+    old_filters: &rustc_hash::FxHashMap<i32, Arc<Filter>>,
+    new_filters: &rustc_hash::FxHashMap<i32, Arc<Filter>>,
+) -> bool {
+    old_filters
+        .iter()
+        .filter(|(_, filter)| filter.has_dscp_match_terms)
+        .any(|(ifindex, old)| {
+            new_filters
+                .get(ifindex)
+                .is_none_or(|new| !dscp_sensitive_filter_semantics_match(old, new))
+        })
+        || new_filters
+            .iter()
+            .filter(|(_, filter)| filter.has_dscp_match_terms)
+            .any(|(ifindex, new)| {
+                old_filters
+                    .get(ifindex)
+                    .is_none_or(|old| !dscp_sensitive_filter_semantics_match(old, new))
+            })
+}
+
+pub(crate) fn input_dscp_filter_families_changed(
+    old: &FilterState,
+    new: &FilterState,
+) -> (bool, bool) {
+    (
+        input_dscp_filter_family_changed(&old.iface_filter_v4_fast, &new.iface_filter_v4_fast),
+        input_dscp_filter_family_changed(&old.iface_filter_v6_fast, &new.iface_filter_v6_fast),
+    )
 }
 
 #[inline]

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -37,7 +37,10 @@ pub(crate) enum FilterAction {
     Accept,
     /// Silently drop the packet.
     Discard,
-    /// Drop with ICMP unreachable.
+    /// Request reject behavior.
+    ///
+    /// Callers that cannot synthesize the reject packet must fail closed as a
+    /// silent drop and must not log that an ICMP/RST reject was generated.
     Reject,
 }
 
@@ -110,6 +113,8 @@ pub(crate) struct Filter {
     pub(crate) affects_route_lookup: bool,
     pub(crate) has_counter_terms: bool,
     pub(crate) has_log_terms: bool,
+    pub(crate) has_terminal_action_terms: bool,
+    pub(crate) has_dscp_match_terms: bool,
     pub(crate) has_three_color_policer_terms: bool,
 }
 
@@ -263,6 +268,20 @@ impl ThreeColorPolicerRuntime {
             .is_some_and(|state| state.same_runtime_shape(next_shape))
     }
 
+    pub(crate) fn same_runtime_shape_as(&self, other: &Self) -> bool {
+        if self.id != other.id || self.name != other.name {
+            return false;
+        }
+        let Ok(state) = self.state.lock() else {
+            return false;
+        };
+        other
+            .state
+            .lock()
+            .ok()
+            .is_some_and(|other| state.same_runtime_shape(&other))
+    }
+
     pub(crate) fn status(&self) -> crate::protocol::ThreeColorPolicerStatus {
         let (mode, color_blind) = self
             .state
@@ -400,6 +419,8 @@ pub(crate) struct FilterState {
     pub(crate) has_input_three_color_policer_v4: bool,
     /// Per-interface inet input filters that can affect route-table selection.
     pub(crate) iface_filter_v4_affects_route_lookup: rustc_hash::FxHashSet<i32>,
+    /// Per-interface inet input filters with DSCP match terms.
+    pub(crate) iface_filter_v4_has_dscp_match: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) input filter key for inet6.
     pub(crate) iface_filter_v6: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet6 filter reference for packet hot-path evaluation.
@@ -412,6 +433,8 @@ pub(crate) struct FilterState {
     pub(crate) has_input_three_color_policer_v6: bool,
     /// Per-interface inet6 input filters that can affect route-table selection.
     pub(crate) iface_filter_v6_affects_route_lookup: rustc_hash::FxHashSet<i32>,
+    /// Per-interface inet6 input filters with DSCP match terms.
+    pub(crate) iface_filter_v6_has_dscp_match: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) output filter key for inet.
     pub(crate) iface_filter_out_v4: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet output filter reference for packet hot-path evaluation.
@@ -480,16 +503,18 @@ pub(crate) struct FilterLogMatch {
     pub(crate) action: FilterAction,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct TxSelectionFilterResult<'a> {
+    pub(crate) action: FilterAction,
     pub(crate) forwarding_class: Option<&'a str>,
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) policer_drop: bool,
     pub(crate) log_match: Option<FilterLogMatch>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct CachedTxSelectionFilterResult {
+    pub(crate) action: FilterAction,
     pub(crate) forwarding_class: Option<Arc<str>>,
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) counter: Option<Arc<FilterTermCounter>>,
@@ -512,6 +537,31 @@ impl Default for FilterResult {
             routing_instance: String::new(),
             forwarding_class: Arc::<str>::from(""),
             log: false,
+            log_match: None,
+        }
+    }
+}
+
+impl Default for TxSelectionFilterResult<'_> {
+    fn default() -> Self {
+        Self {
+            action: FilterAction::Accept,
+            forwarding_class: None,
+            dscp_rewrite: None,
+            policer_drop: false,
+            log_match: None,
+        }
+    }
+}
+
+impl Default for CachedTxSelectionFilterResult {
+    fn default() -> Self {
+        Self {
+            action: FilterAction::Accept,
+            forwarding_class: None,
+            dscp_rewrite: None,
+            counter: None,
+            three_color_policers: CachedThreeColorPolicers::default(),
             log_match: None,
         }
     }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -1728,3 +1728,192 @@ fn dscp_match_in_term() {
     );
     assert_eq!(result.action, FilterAction::Discard);
 }
+
+#[test]
+fn input_dscp_filter_families_changed_detects_same_ifindex_content_change() {
+    let iface = crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 10,
+        filter_input_v4: "dscp-filter".into(),
+        ..Default::default()
+    };
+    let old = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "dscp-filter".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "dscp-term".into(),
+                dscp_values: vec![0],
+                action: "accept".into(),
+                ..Default::default()
+            }],
+        }],
+        std::slice::from_ref(&iface),
+    );
+    let new = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "dscp-filter".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "dscp-term".into(),
+                dscp_values: vec![46],
+                action: "discard".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        &[iface],
+    );
+
+    assert_eq!(
+        input_dscp_filter_families_changed(&old, &new),
+        (true, false)
+    );
+}
+
+#[test]
+fn input_dscp_filter_families_changed_ignores_unchanged_filter() {
+    let iface = crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 10,
+        filter_input_v4: "dscp-filter".into(),
+        ..Default::default()
+    };
+    let filter = FirewallFilterSnapshot {
+        name: "dscp-filter".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "dscp-term".into(),
+            dscp_values: vec![46],
+            action: "discard".into(),
+            log: true,
+            ..Default::default()
+        }],
+    };
+    let old = make_filter_state_with_interfaces(
+        std::slice::from_ref(&filter),
+        std::slice::from_ref(&iface),
+    );
+    let new = make_filter_state_with_interfaces(&[filter], &[iface]);
+
+    assert_eq!(
+        input_dscp_filter_families_changed(&old, &new),
+        (false, false)
+    );
+}
+
+#[test]
+fn input_dscp_filter_families_changed_ignores_positional_filter_id_change() {
+    let iface = crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 10,
+        filter_input_v4: "dscp-filter".into(),
+        ..Default::default()
+    };
+    let unrelated = FirewallFilterSnapshot {
+        name: "unrelated".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "accept".into(),
+            action: "accept".into(),
+            ..Default::default()
+        }],
+    };
+    let dscp_filter = FirewallFilterSnapshot {
+        name: "dscp-filter".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "dscp-term".into(),
+            dscp_values: vec![46],
+            action: "discard".into(),
+            log: true,
+            ..Default::default()
+        }],
+    };
+    let old = make_filter_state_with_interfaces(
+        &[unrelated.clone(), dscp_filter.clone()],
+        std::slice::from_ref(&iface),
+    );
+    let new = make_filter_state_with_interfaces(&[dscp_filter, unrelated], &[iface]);
+
+    assert_ne!(
+        old.iface_filter_v4_fast.get(&10).unwrap().id,
+        new.iface_filter_v4_fast.get(&10).unwrap().id,
+        "test setup must shift the compiler-positional filter id"
+    );
+    assert_eq!(
+        input_dscp_filter_families_changed(&old, &new),
+        (false, false)
+    );
+}
+
+#[test]
+fn input_dscp_filter_families_changed_detects_three_color_shape_change() {
+    let iface = crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 10,
+        filter_input_v4: "dscp-filter".into(),
+        ..Default::default()
+    };
+    let filters = [FirewallFilterSnapshot {
+        name: "dscp-filter".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "dscp-term".into(),
+            dscp_values: vec![46],
+            action: "accept".into(),
+            policer: "stable-pol".into(),
+            ..Default::default()
+        }],
+    }];
+    let original = [ThreeColorPolicerSnapshot {
+        name: "stable-pol".into(),
+        mode: "single-rate".into(),
+        color_blind: true,
+        committed_rate_bytes_per_sec: 1,
+        committed_burst_bytes: 100,
+        peak_or_excess_burst_bytes: 50,
+        then_action: "discard".into(),
+        ..Default::default()
+    }];
+    let changed = [ThreeColorPolicerSnapshot {
+        committed_burst_bytes: 200,
+        ..original[0].clone()
+    }];
+
+    let old = parse_filter_state_with_three_color(
+        &filters,
+        &[],
+        &original,
+        std::slice::from_ref(&iface),
+        "",
+        "",
+    );
+    let new = parse_filter_state_with_three_color_preserving(
+        &filters,
+        &[],
+        &changed,
+        &[iface],
+        "",
+        "",
+        Some(&old),
+    );
+
+    assert!(
+        !std::sync::Arc::ptr_eq(
+            old.iface_filter_v4_fast.get(&10).unwrap().terms[0]
+                .three_color_policer
+                .as_ref()
+                .unwrap(),
+            new.iface_filter_v4_fast.get(&10).unwrap().terms[0]
+                .three_color_policer
+                .as_ref()
+                .unwrap(),
+        ),
+        "test setup must create a new runtime for the changed policer shape"
+    );
+    assert_eq!(
+        input_dscp_filter_families_changed(&old, &new),
+        (true, false)
+    );
+}

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -948,6 +948,26 @@ impl SessionTable {
         });
     }
 
+    pub fn emit_close_delta_with_origin(
+        &mut self,
+        key: SessionKey,
+        decision: SessionDecision,
+        metadata: SessionMetadata,
+        origin: SessionOrigin,
+    ) {
+        if metadata.is_reverse {
+            return;
+        }
+        self.push_delta(SessionDelta {
+            kind: SessionDeltaKind::Close,
+            key,
+            decision,
+            metadata,
+            origin,
+            fabric_redirect_sync: false,
+        });
+    }
+
     pub fn delete(&mut self, key: &SessionKey) {
         self.remove_entry(key);
     }


### PR DESCRIPTION
## Summary

- Enforce lo0/local-delivery terminal filter actions before a local pass-to-kernel session can be installed or reinjected to the slow path.
- Pin FILTER_LOG reject action handling in the Rust encoder, Rust event-stream codec, and Go syslog fanout path.
- Update the #1379 event plan so the documented lo0 behavior matches runtime: userspace local-delivery discard/reject actions are terminal.

## Why

#1428 was merged at `f967a112` before the round-4 review findings were fully closed. This fix-forward PR carries the follow-up commit that closes the three verified blockers:

- M2 Go syslog test gap
- Reject log/wire action contract gap
- lo0 filter action bypass before slow-path reinjection

## Validation

- `RUSTFLAGS='-Awarnings' cargo test input_filter -- --nocapture`
- `RUSTFLAGS='-Awarnings' cargo test lo0_filter -- --nocapture`
- `RUSTFLAGS='-Awarnings' cargo test filter_log_can_encode_reject_action -- --nocapture`
- `RUSTFLAGS='-Awarnings' cargo test filter_log_event_emit_preserves_reject_action -- --nocapture`
- `go test ./pkg/dataplane/userspace ./pkg/logging -run 'TestEventStreamRawDataplaneEventsFeedSyslogFanout|TestDecodeDataplaneEventPolicyDenyRTFlow|TestFormatBinaryRecord_Basic'`
- `git diff --check HEAD^`
- commit-message line-length check

Refs #1379
Refs #1373