### PR TITLE
snat: bound persistent pool allocator cleanup

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
@@ -197,10 +197,13 @@ per-address atomic counters because it does not create a tracked session.
 The per-pool allocator state is bounded by the smaller of pool port capacity and
 `262144` tracked live flows. This prevents attacker-controlled unbounded growth
 in the packet path. Fresh port claims use a per-address cursor and a recycled
-port stack, and persistent lease expiry uses a replace-in-place ordered expiry
-index bounded by the number of retained leases. Near-full allocation and
-timeout cleanup do not scan the whole port range or lease map on every new
-flow. The allocator reports exhaustion when:
+port stack, and persistent lease expiry uses replace-in-place ordered expiry
+indexes bounded by the number of retained leases. Allocation-time expiry cleanup
+is budgeted, not a full sweep. When a selected pool address is out of fresh or
+recycled ports, the allocator runs bounded cleanup against that address's expiry
+index before reporting exhaustion. Near-full allocation and timeout cleanup do
+not scan the whole port range or lease map on every new flow. The allocator
+reports exhaustion when:
 
 - the selected address-persistent pool address has no free port;
 - a non-address-persistent family has no free port on any family-compatible
@@ -274,6 +277,12 @@ Covered by #1385 and this closeout:
   expiry and rollback release the actual allocated tuple.
 - Cargo: repeated persistent lease refresh/release churn keeps the expiry index
   bounded by retained leases rather than by allocation count.
+- Cargo: allocation-time persistent lease cleanup is budgeted when the pool is
+  not under pressure, so one new flow cannot drain an arbitrary expired run under
+  the allocator mutex.
+- Cargo: address-persistent pressure cleanup reclaims expired leases for the
+  selected pool address even when the global allocation cleanup budget was spent
+  on older expirations from other addresses.
 - Cargo: protocol round-trip covers persistent source-NAT snapshot/status
   fields.
 

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -196,6 +196,7 @@ struct LiveAllocation {
 #[derive(Clone, Copy, Debug)]
 struct PersistentLease {
     translated: TranslatedTuple,
+    addr_index: usize,
     expires_at_ns: u64,
     timeout_ns: u64,
     active_flows: u32,
@@ -208,6 +209,7 @@ struct PortAllocatorLiveState {
     addr_index_by_translated: FxHashMap<TranslatedTuple, usize>,
     persistent_by_source: FxHashMap<PersistentSourceKey, PersistentLease>,
     lease_expirations: BTreeSet<(u64, PersistentSourceKey)>,
+    lease_expirations_by_addr: Vec<BTreeSet<(u64, PersistentSourceKey)>>,
     next_port_offset_by_addr: Vec<u32>,
     recycled_ports_by_addr: Vec<Vec<u16>>,
     gc_counter: u32,
@@ -216,6 +218,7 @@ struct PortAllocatorLiveState {
 impl PortAllocatorLiveState {
     fn new(addr_count: usize) -> Self {
         Self {
+            lease_expirations_by_addr: vec![BTreeSet::new(); addr_count],
             next_port_offset_by_addr: vec![0; addr_count],
             recycled_ports_by_addr: vec![Vec::new(); addr_count],
             ..Self::default()
@@ -223,8 +226,11 @@ impl PortAllocatorLiveState {
     }
 }
 
-/// Run full lease-expiration GC every N release_flow calls.
+/// Run bounded lease-expiration GC every N release_flow calls.
 const GC_PERIOD: u32 = 10;
+const ALLOCATION_GC_BUDGET: usize = 8;
+const RELEASE_GC_BUDGET: usize = 64;
+const PRESSURE_GC_BUDGET: usize = 64;
 
 #[derive(Debug)]
 struct PortAllocatorShared {
@@ -358,7 +364,7 @@ impl PortAllocator {
         }
 
         let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
-        self.gc_expired_locked(&mut live, now_ns);
+        self.gc_expired_locked(&mut live, now_ns, ALLOCATION_GC_BUDGET);
 
         if let Some(existing) = live.live_by_flow.get(&flow) {
             self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
@@ -391,11 +397,22 @@ impl PortAllocator {
                         lease.expires_at_ns = expires_at_ns;
                         reusable = Some(translated);
                     } else {
-                        expired = Some(lease.translated);
+                        expired = Some((lease.translated, lease.addr_index, lease.expires_at_ns));
                     }
                 }
                 if let Some(expires_at_ns) = remove_expiry {
-                    live.lease_expirations.remove(&(expires_at_ns, key));
+                    if let Some(addr_index) = live
+                        .persistent_by_source
+                        .get(&key)
+                        .map(|lease| lease.addr_index)
+                    {
+                        Self::remove_lease_expiration_locked(
+                            &mut live,
+                            addr_index,
+                            expires_at_ns,
+                            key,
+                        );
+                    }
                 }
                 if let Some(translated) = reusable {
                     live.live_by_flow.insert(
@@ -411,14 +428,11 @@ impl PortAllocator {
                     self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
                     return Ok(translated);
                 }
-                if let Some(translated) = expired {
+                if let Some((translated, addr_index, expires_at_ns)) = expired {
+                    Self::remove_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
                     self.release_translated_locked(&mut live, translated);
                     live.persistent_by_source.remove(&key);
                 }
-            }
-            if live.persistent_by_source.len() >= self.shared.max_tracked_flows {
-                self.shared.exhaustion_total.fetch_add(1, Ordering::Relaxed);
-                return Err(SourceNatFailureReason::AllocatorExhausted);
             }
         }
 
@@ -430,9 +444,28 @@ impl PortAllocator {
             let rel = (start_rel + offset) % family_len;
             let abs = family_offset + rel;
             let translated_ip = family_addresses.ip_at(rel);
-            let Some(translated) =
-                self.claim_free_port_locked(&mut live, abs, translated_ip, flow, persistent_key)
-            else {
+            if persistent_key.is_some()
+                && live.persistent_by_source.len() >= self.shared.max_tracked_flows
+            {
+                self.gc_expired_locked(&mut live, now_ns, PRESSURE_GC_BUDGET);
+                if live.persistent_by_source.len() >= self.shared.max_tracked_flows {
+                    continue;
+                }
+            }
+
+            let mut translated =
+                self.claim_free_port_locked(&mut live, abs, translated_ip, flow, persistent_key);
+            if translated.is_none() {
+                self.gc_expired_for_addr_locked(&mut live, abs, now_ns, PRESSURE_GC_BUDGET);
+                translated = self.claim_free_port_locked(
+                    &mut live,
+                    abs,
+                    translated_ip,
+                    flow,
+                    persistent_key,
+                );
+            }
+            let Some(translated) = translated else {
                 continue;
             };
             if let Some(key) = persistent_key {
@@ -442,6 +475,7 @@ impl PortAllocator {
                     key,
                     PersistentLease {
                         translated,
+                        addr_index: abs,
                         expires_at_ns,
                         timeout_ns: persistent_nat_timeout_ns.max(NS_PER_SEC),
                         active_flows: 1,
@@ -545,6 +579,30 @@ impl PortAllocator {
         true
     }
 
+    fn insert_lease_expiration_locked(
+        live: &mut PortAllocatorLiveState,
+        addr_index: usize,
+        expires_at_ns: u64,
+        key: PersistentSourceKey,
+    ) {
+        live.lease_expirations.insert((expires_at_ns, key));
+        if let Some(by_addr) = live.lease_expirations_by_addr.get_mut(addr_index) {
+            by_addr.insert((expires_at_ns, key));
+        }
+    }
+
+    fn remove_lease_expiration_locked(
+        live: &mut PortAllocatorLiveState,
+        addr_index: usize,
+        expires_at_ns: u64,
+        key: PersistentSourceKey,
+    ) {
+        live.lease_expirations.remove(&(expires_at_ns, key));
+        if let Some(by_addr) = live.lease_expirations_by_addr.get_mut(addr_index) {
+            by_addr.remove(&(expires_at_ns, key));
+        }
+    }
+
     fn release_flow(
         &self,
         flow: SourceNatFlowKey,
@@ -566,18 +624,18 @@ impl PortAllocator {
                 if lease.active_flows == 0 {
                     let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
                     lease.expires_at_ns = expires_at_ns;
-                    insert_expiry = Some(expires_at_ns);
+                    insert_expiry = Some((lease.addr_index, expires_at_ns));
                 }
             }
-            if let Some(expires_at_ns) = insert_expiry {
-                live.lease_expirations.insert((expires_at_ns, key));
+            if let Some((addr_index, expires_at_ns)) = insert_expiry {
+                Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
             }
         } else {
             self.release_translated_locked(&mut live, translated);
         }
         live.gc_counter = live.gc_counter.wrapping_add(1);
         if live.gc_counter % GC_PERIOD == 0 {
-            self.gc_expired_locked(&mut live, now_ns);
+            self.gc_expired_locked(&mut live, now_ns, RELEASE_GC_BUDGET);
         }
         true
     }
@@ -598,9 +656,10 @@ impl PortAllocator {
             } else if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                 lease.active_flows = existing.persistent_previous_active_flows;
                 lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
-                let insert_expiry = (lease.active_flows == 0).then_some(lease.expires_at_ns);
-                if let Some(expires_at_ns) = insert_expiry {
-                    live.lease_expirations.insert((expires_at_ns, key));
+                let insert_expiry =
+                    (lease.active_flows == 0).then_some((lease.addr_index, lease.expires_at_ns));
+                if let Some((addr_index, expires_at_ns)) = insert_expiry {
+                    Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
                 }
             }
         } else {
@@ -622,29 +681,86 @@ impl PortAllocator {
         }
     }
 
-    fn gc_expired_locked(&self, live: &mut PortAllocatorLiveState, now_ns: u64) {
-        if now_ns == 0 {
-            return;
+    fn gc_expired_locked(
+        &self,
+        live: &mut PortAllocatorLiveState,
+        now_ns: u64,
+        budget: usize,
+    ) -> usize {
+        if now_ns == 0 || budget == 0 {
+            return 0;
         }
-        while let Some((expires_at_ns, key)) = live.lease_expirations.iter().next().copied() {
+        let mut reclaimed = 0;
+        for _ in 0..budget {
+            let Some((expires_at_ns, key)) = live.lease_expirations.iter().next().copied() else {
+                break;
+            };
             if expires_at_ns > now_ns {
                 break;
             }
             live.lease_expirations.remove(&(expires_at_ns, key));
-            let Some(lease) = live.persistent_by_source.get(&key).copied() else {
-                continue;
-            };
-            if lease.active_flows != 0 || lease.expires_at_ns != expires_at_ns {
-                continue;
-            }
-            let translated = lease.translated;
-            live.persistent_by_source.remove(&key);
-            match live.owner_by_translated.get(&translated) {
-                Some(AllocationOwner::Persistent(owner)) if *owner == key => {
-                    self.release_translated_locked(live, translated);
+            if let Some(lease) = live.persistent_by_source.get(&key).copied() {
+                if let Some(by_addr) = live.lease_expirations_by_addr.get_mut(lease.addr_index) {
+                    by_addr.remove(&(expires_at_ns, key));
                 }
-                _ => {}
             }
+            if self.release_expired_lease_locked(live, key, expires_at_ns) {
+                reclaimed += 1;
+            }
+        }
+        reclaimed
+    }
+
+    fn gc_expired_for_addr_locked(
+        &self,
+        live: &mut PortAllocatorLiveState,
+        addr_index: usize,
+        now_ns: u64,
+        budget: usize,
+    ) -> usize {
+        if now_ns == 0 || budget == 0 || addr_index >= live.lease_expirations_by_addr.len() {
+            return 0;
+        }
+        let mut reclaimed = 0;
+        for _ in 0..budget {
+            let Some((expires_at_ns, key)) = live.lease_expirations_by_addr[addr_index]
+                .iter()
+                .next()
+                .copied()
+            else {
+                break;
+            };
+            if expires_at_ns > now_ns {
+                break;
+            }
+            live.lease_expirations_by_addr[addr_index].remove(&(expires_at_ns, key));
+            live.lease_expirations.remove(&(expires_at_ns, key));
+            if self.release_expired_lease_locked(live, key, expires_at_ns) {
+                reclaimed += 1;
+            }
+        }
+        reclaimed
+    }
+
+    fn release_expired_lease_locked(
+        &self,
+        live: &mut PortAllocatorLiveState,
+        key: PersistentSourceKey,
+        expires_at_ns: u64,
+    ) -> bool {
+        let Some(lease) = live.persistent_by_source.get(&key).copied() else {
+            return false;
+        };
+        if lease.active_flows != 0 || lease.expires_at_ns != expires_at_ns {
+            return false;
+        }
+        let translated = lease.translated;
+        live.persistent_by_source.remove(&key);
+        match live.owner_by_translated.get(&translated) {
+            Some(AllocationOwner::Persistent(owner)) if *owner == key => {
+                self.release_translated_locked(live, translated)
+            }
+            _ => false,
         }
     }
 }

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -857,15 +857,35 @@ fn pool_snat_multiple_addresses_round_robin() {
 }
 
 fn persistent_pool_rules(timeout_secs: i64, port_low: u16, port_high: u16) -> Vec<SourceNatRule> {
+    persistent_pool_rules_with_options(
+        timeout_secs,
+        port_low,
+        port_high,
+        vec!["203.0.113.10"],
+        false,
+    )
+}
+
+fn persistent_pool_rules_with_options(
+    timeout_secs: i64,
+    port_low: u16,
+    port_high: u16,
+    pool_addresses: Vec<&str>,
+    address_persistent: bool,
+) -> Vec<SourceNatRule> {
     parse_source_nat_rules(&[SourceNATRuleSnapshot {
         name: "persistent-snat".to_string(),
         from_zone: "lan".to_string(),
         to_zone: "wan".to_string(),
         source_addresses: vec!["0.0.0.0/0".to_string()],
         pool_name: "persistent-pool".to_string(),
-        pool_addresses: vec!["203.0.113.10".to_string()],
+        pool_addresses: pool_addresses
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
         port_low,
         port_high,
+        address_persistent,
         persistent_nat: true,
         persistent_nat_permit_any_remote_host: true,
         persistent_nat_inactivity_timeout: timeout_secs,
@@ -880,11 +900,22 @@ fn tuple_snat_lookup(
     dst_port: u16,
     now_ns: u64,
 ) -> SourceNatLookup {
+    tuple_snat_lookup_from_src(rules, "10.0.1.100", src_port, dst_ip, dst_port, now_ns)
+}
+
+fn tuple_snat_lookup_from_src(
+    rules: &[SourceNatRule],
+    src_ip: &str,
+    src_port: u16,
+    dst_ip: &str,
+    dst_port: u16,
+    now_ns: u64,
+) -> SourceNatLookup {
     match_source_nat_result_for_tuple(
         rules,
         "lan",
         "wan",
-        "10.0.1.100".parse().unwrap(),
+        src_ip.parse().unwrap(),
         dst_ip.parse().unwrap(),
         6,
         src_port,
@@ -903,10 +934,19 @@ fn expect_snat_decision(lookup: SourceNatLookup) -> NatDecision {
 }
 
 fn session_key(src_port: u16, dst_ip: &str, dst_port: u16) -> crate::session::SessionKey {
+    session_key_from_src("10.0.1.100", src_port, dst_ip, dst_port)
+}
+
+fn session_key_from_src(
+    src_ip: &str,
+    src_port: u16,
+    dst_ip: &str,
+    dst_port: u16,
+) -> crate::session::SessionKey {
     crate::session::SessionKey {
         addr_family: libc::AF_INET as u8,
         protocol: 6,
-        src_ip: "10.0.1.100".parse().unwrap(),
+        src_ip: src_ip.parse().unwrap(),
         dst_ip: dst_ip.parse().unwrap(),
         src_port,
         dst_port,
@@ -1229,6 +1269,161 @@ fn pool_snat_persistent_expiry_index_is_bounded_by_leases() {
         .unwrap_or_else(|e| e.into_inner());
     assert_eq!(live.persistent_by_source.len(), 1);
     assert_eq!(live.lease_expirations.len(), 1);
+    assert_eq!(live.lease_expirations_by_addr[0].len(), 1);
+}
+
+#[test]
+fn pool_snat_allocation_gc_is_bounded_when_not_under_pressure() {
+    let rules = persistent_pool_rules(1, 40000, 40099);
+    let expired_lease_count = ALLOCATION_GC_BUDGET + 12;
+    for i in 0..expired_lease_count {
+        let src_port = 10000 + i as u16;
+        let now_ns = 1_000_000_000 + i as u64;
+        let decision =
+            expect_snat_decision(tuple_snat_lookup(&rules, src_port, "8.8.8.8", 53, now_ns));
+        release_source_nat_allocation(
+            &rules,
+            &session_key(src_port, "8.8.8.8", 53),
+            decision,
+            false,
+            now_ns + 1,
+        );
+    }
+
+    let before = source_nat_pool_statuses(&rules);
+    assert_eq!(before[0].persistent_leases, expired_lease_count as u64);
+
+    let decision = expect_snat_decision(tuple_snat_lookup(
+        &rules,
+        20000,
+        "1.1.1.1",
+        53,
+        5_000_000_000,
+    ));
+    assert_eq!(
+        decision.rewrite_src_port,
+        Some(40000 + expired_lease_count as u16)
+    );
+
+    let after = source_nat_pool_statuses(&rules);
+    assert_eq!(
+        after[0].persistent_leases,
+        (expired_lease_count - ALLOCATION_GC_BUDGET + 1) as u64
+    );
+    let live = rules[0]
+        .pool_allocator
+        .shared
+        .live
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    assert_eq!(
+        live.lease_expirations.len(),
+        expired_lease_count - ALLOCATION_GC_BUDGET
+    );
+    assert_eq!(
+        live.lease_expirations_by_addr[0].len(),
+        expired_lease_count - ALLOCATION_GC_BUDGET
+    );
+}
+
+#[test]
+fn pool_snat_pressure_gc_reclaims_expired_lease_for_selected_address() {
+    let rules = persistent_pool_rules_with_options(
+        1,
+        40000,
+        40007,
+        vec!["203.0.113.10", "203.0.113.11"],
+        true,
+    );
+    let src_addr_0 = source_for_sticky_pool_index(0, 2);
+    let src_addr_1 = source_for_sticky_pool_index(1, 2);
+
+    for i in 0..ALLOCATION_GC_BUDGET {
+        let src_port = 10000 + i as u16;
+        let now_ns = 1_000_000_000 + i as u64;
+        let decision = expect_snat_decision(tuple_snat_lookup_from_src(
+            &rules,
+            &src_addr_0,
+            src_port,
+            "8.8.8.8",
+            53,
+            now_ns,
+        ));
+        release_source_nat_allocation(
+            &rules,
+            &session_key_from_src(&src_addr_0, src_port, "8.8.8.8", 53),
+            decision,
+            false,
+            now_ns + 1,
+        );
+    }
+    for i in 0..ALLOCATION_GC_BUDGET {
+        let src_port = 11000 + i as u16;
+        let now_ns = 1_100_000_000 + i as u64;
+        let decision = expect_snat_decision(tuple_snat_lookup_from_src(
+            &rules,
+            &src_addr_1,
+            src_port,
+            "8.8.4.4",
+            53,
+            now_ns,
+        ));
+        release_source_nat_allocation(
+            &rules,
+            &session_key_from_src(&src_addr_1, src_port, "8.8.4.4", 53),
+            decision,
+            false,
+            now_ns + 1,
+        );
+    }
+
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            live.lease_expirations_by_addr[0].len(),
+            ALLOCATION_GC_BUDGET
+        );
+        assert_eq!(
+            live.lease_expirations_by_addr[1].len(),
+            ALLOCATION_GC_BUDGET
+        );
+    }
+
+    let decision = expect_snat_decision(tuple_snat_lookup_from_src(
+        &rules,
+        &src_addr_1,
+        12000,
+        "1.1.1.1",
+        53,
+        5_000_000_000,
+    ));
+
+    assert_eq!(decision.rewrite_src, Some("203.0.113.11".parse().unwrap()));
+    assert!(matches!(decision.rewrite_src_port, Some(40000..=40007)));
+    let live = rules[0]
+        .pool_allocator
+        .shared
+        .live
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    assert_eq!(live.lease_expirations_by_addr[0].len(), 0);
+    assert!(live.lease_expirations_by_addr[1].len() < ALLOCATION_GC_BUDGET);
+}
+
+fn source_for_sticky_pool_index(want: usize, pool_len: usize) -> String {
+    for octet in 1..=254 {
+        let candidate = format!("10.0.1.{octet}");
+        let ip = candidate.parse().unwrap();
+        if sticky_pool_index(ip, pool_len) == want {
+            return candidate;
+        }
+    }
+    panic!("no source address found for sticky index {want}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace unbounded persistent-lease cleanup on the allocation path with
  budgeted expiry work
- add per-address expiry indexes so near-full address-persistent pools can
  reclaim expired leases for the selected pool address before reporting
  exhaustion
- keep translated-port claims on monotonic fresh cursors and recycled-port
  stacks instead of scanning the configured port range while the per-pool
  mutex is held
- update the #1377 plan with the bounded-cleanup contract and the remaining
  non-goals around helper-restart persistence, HA lease sync, and
  cross-backend selector parity

## Validation

- `cd userspace-dp && cargo test pool_snat_`
- `cd userspace-dp && cargo test snat_contract_documents_current_fail_closed_runtime`
- `cd userspace-dp && cargo test nat::tests::`
- `git diff --check`

Refs #1377.
