### PR TITLE
snat: preserve shared persistent leases on rollback

### DIFF
--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -188,9 +188,6 @@ enum AllocationOwner {
 struct LiveAllocation {
     translated: TranslatedTuple,
     persistent_key: Option<PersistentSourceKey>,
-    persistent_lease_created: bool,
-    persistent_previous_expires_at_ns: u64,
-    persistent_previous_active_flows: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -201,6 +198,11 @@ struct PersistentLease {
     timeout_ns: u64,
     active_flows: u32,
     completed_flows: u32,
+    // Baseline for the current active epoch. Rollback needs to distinguish
+    // completions in this reactivation from lifetime persistent-NAT history.
+    activation_completed_flows_baseline: u32,
+    activation_previous_expires_at_ns: u64,
+    activation_had_previous_lease: bool,
 }
 
 #[derive(Debug, Default)]
@@ -381,16 +383,15 @@ impl PortAllocator {
             if live.persistent_by_source.contains_key(&key) {
                 let mut reusable = None;
                 let mut expired = None;
-                let mut previous_expires_at_ns = 0;
-                let mut previous_active_flows = 0;
                 let mut remove_expiry = None;
                 if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                     if lease.active_flows > 0 || lease.expires_at_ns > now_ns {
                         let translated = lease.translated;
-                        previous_expires_at_ns = lease.expires_at_ns;
-                        previous_active_flows = lease.active_flows;
                         if lease.active_flows == 0 {
                             remove_expiry = Some(lease.expires_at_ns);
+                            lease.activation_completed_flows_baseline = lease.completed_flows;
+                            lease.activation_previous_expires_at_ns = lease.expires_at_ns;
+                            lease.activation_had_previous_lease = true;
                         }
                         lease.active_flows = lease.active_flows.saturating_add(1);
                         let expires_at_ns =
@@ -421,9 +422,6 @@ impl PortAllocator {
                         LiveAllocation {
                             translated,
                             persistent_key: Some(key),
-                            persistent_lease_created: false,
-                            persistent_previous_expires_at_ns: previous_expires_at_ns,
-                            persistent_previous_active_flows: previous_active_flows,
                         },
                     );
                     self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
@@ -481,6 +479,9 @@ impl PortAllocator {
                         timeout_ns: persistent_nat_timeout_ns.max(NS_PER_SEC),
                         active_flows: 1,
                         completed_flows: 0,
+                        activation_completed_flows_baseline: 0,
+                        activation_previous_expires_at_ns: 0,
+                        activation_had_previous_lease: false,
                     },
                 );
             }
@@ -489,9 +490,6 @@ impl PortAllocator {
                 LiveAllocation {
                     translated,
                     persistent_key,
-                    persistent_lease_created: persistent_key.is_some(),
-                    persistent_previous_expires_at_ns: 0,
-                    persistent_previous_active_flows: 0,
                 },
             );
             self.shared
@@ -663,23 +661,15 @@ impl PortAllocator {
             if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
-                    if existing.persistent_lease_created {
-                        if lease.completed_flows == 0 {
-                            remove_lease = true;
-                        } else {
-                            let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
-                            lease.expires_at_ns = expires_at_ns;
-                            insert_expiry = Some((lease.addr_index, expires_at_ns));
-                        }
-                    } else if existing.persistent_previous_active_flows == 0 {
-                        lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
-                        insert_expiry = Some((lease.addr_index, lease.expires_at_ns));
-                    } else if lease.completed_flows == 0 {
-                        remove_lease = true;
-                    } else {
+                    if lease.completed_flows > lease.activation_completed_flows_baseline {
                         let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
                         lease.expires_at_ns = expires_at_ns;
                         insert_expiry = Some((lease.addr_index, expires_at_ns));
+                    } else if lease.activation_had_previous_lease {
+                        lease.expires_at_ns = lease.activation_previous_expires_at_ns;
+                        insert_expiry = Some((lease.addr_index, lease.expires_at_ns));
+                    } else {
+                        remove_lease = true;
                     }
                 }
             }

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -200,6 +200,7 @@ struct PersistentLease {
     expires_at_ns: u64,
     timeout_ns: u64,
     active_flows: u32,
+    completed_flows: u32,
 }
 
 #[derive(Debug, Default)]
@@ -479,6 +480,7 @@ impl PortAllocator {
                         expires_at_ns,
                         timeout_ns: persistent_nat_timeout_ns.max(NS_PER_SEC),
                         active_flows: 1,
+                        completed_flows: 0,
                     },
                 );
             }
@@ -620,6 +622,7 @@ impl PortAllocator {
         if let Some(key) = existing.persistent_key {
             let mut insert_expiry = None;
             if let Some(lease) = live.persistent_by_source.get_mut(&key) {
+                lease.completed_flows = lease.completed_flows.saturating_add(1);
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
                     let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
@@ -661,7 +664,13 @@ impl PortAllocator {
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
                     if existing.persistent_lease_created {
-                        remove_lease = true;
+                        if lease.completed_flows == 0 {
+                            remove_lease = true;
+                        } else {
+                            let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
+                            lease.expires_at_ns = expires_at_ns;
+                            insert_expiry = Some((lease.addr_index, expires_at_ns));
+                        }
                     } else if existing.persistent_previous_active_flows == 0 {
                         lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
                         insert_expiry = Some((lease.addr_index, lease.expires_at_ns));

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -674,6 +674,8 @@ impl PortAllocator {
                     } else if existing.persistent_previous_active_flows == 0 {
                         lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
                         insert_expiry = Some((lease.addr_index, lease.expires_at_ns));
+                    } else if lease.completed_flows == 0 {
+                        remove_lease = true;
                     } else {
                         let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
                         lease.expires_at_ns = expires_at_ns;

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -640,7 +640,12 @@ impl PortAllocator {
         true
     }
 
-    fn rollback_flow(&self, flow: SourceNatFlowKey, translated: TranslatedTuple) -> bool {
+    fn rollback_flow(
+        &self,
+        flow: SourceNatFlowKey,
+        translated: TranslatedTuple,
+        now_ns: u64,
+    ) -> bool {
         let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
         let Some(existing) = live.live_by_flow.get(&flow).copied() else {
             return false;
@@ -650,17 +655,29 @@ impl PortAllocator {
         }
         live.live_by_flow.remove(&flow);
         if let Some(key) = existing.persistent_key {
-            if existing.persistent_lease_created {
+            let mut remove_lease = false;
+            let mut insert_expiry = None;
+            if let Some(lease) = live.persistent_by_source.get_mut(&key) {
+                lease.active_flows = lease.active_flows.saturating_sub(1);
+                if lease.active_flows == 0 {
+                    if existing.persistent_lease_created {
+                        remove_lease = true;
+                    } else if existing.persistent_previous_active_flows == 0 {
+                        lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
+                        insert_expiry = Some((lease.addr_index, lease.expires_at_ns));
+                    } else {
+                        let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
+                        lease.expires_at_ns = expires_at_ns;
+                        insert_expiry = Some((lease.addr_index, expires_at_ns));
+                    }
+                }
+            }
+            if remove_lease {
                 live.persistent_by_source.remove(&key);
                 self.release_translated_locked(&mut live, translated);
-            } else if let Some(lease) = live.persistent_by_source.get_mut(&key) {
-                lease.active_flows = existing.persistent_previous_active_flows;
-                lease.expires_at_ns = existing.persistent_previous_expires_at_ns;
-                let insert_expiry =
-                    (lease.active_flows == 0).then_some((lease.addr_index, lease.expires_at_ns));
-                if let Some((addr_index, expires_at_ns)) = insert_expiry {
-                    Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
-                }
+            }
+            if let Some((addr_index, expires_at_ns)) = insert_expiry {
+                Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
             }
         } else {
             self.release_translated_locked(&mut live, translated);
@@ -1036,7 +1053,7 @@ fn release_source_nat_allocation_with_mode(
     key: &crate::session::SessionKey,
     nat: NatDecision,
     is_reverse: bool,
-    _now_ns: u64,
+    now_ns: u64,
     rollback: bool,
 ) {
     if is_reverse {
@@ -1064,9 +1081,9 @@ fn release_source_nat_allocation_with_mode(
             continue;
         }
         let released = if rollback {
-            rule.pool_allocator.rollback_flow(flow, translated)
+            rule.pool_allocator.rollback_flow(flow, translated, now_ns)
         } else {
-            rule.pool_allocator.release_flow(flow, translated, _now_ns)
+            rule.pool_allocator.release_flow(flow, translated, now_ns)
         };
         if released {
             break;

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -197,10 +197,11 @@ struct PersistentLease {
     expires_at_ns: u64,
     timeout_ns: u64,
     active_flows: u32,
-    completed_flows: u32,
-    // Baseline for the current active epoch. Rollback needs to distinguish
-    // completions in this reactivation from lifetime persistent-NAT history.
-    activation_completed_flows_baseline: u32,
+    completed_flows: u64,
+    // Rollback needs per-activation completion state, not a comparison
+    // against lifetime completion counters. The latter can saturate over
+    // long-lived persistent leases and make a fresh completion invisible.
+    activation_saw_completion: bool,
     activation_previous_expires_at_ns: u64,
     activation_had_previous_lease: bool,
 }
@@ -389,7 +390,7 @@ impl PortAllocator {
                         let translated = lease.translated;
                         if lease.active_flows == 0 {
                             remove_expiry = Some(lease.expires_at_ns);
-                            lease.activation_completed_flows_baseline = lease.completed_flows;
+                            lease.activation_saw_completion = false;
                             lease.activation_previous_expires_at_ns = lease.expires_at_ns;
                             lease.activation_had_previous_lease = true;
                         }
@@ -479,7 +480,7 @@ impl PortAllocator {
                         timeout_ns: persistent_nat_timeout_ns.max(NS_PER_SEC),
                         active_flows: 1,
                         completed_flows: 0,
-                        activation_completed_flows_baseline: 0,
+                        activation_saw_completion: false,
                         activation_previous_expires_at_ns: 0,
                         activation_had_previous_lease: false,
                     },
@@ -621,6 +622,7 @@ impl PortAllocator {
             let mut insert_expiry = None;
             if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                 lease.completed_flows = lease.completed_flows.saturating_add(1);
+                lease.activation_saw_completion = true;
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
                     let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
@@ -661,7 +663,7 @@ impl PortAllocator {
             if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
-                    if lease.completed_flows > lease.activation_completed_flows_baseline {
+                    if lease.activation_saw_completion {
                         let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
                         lease.expires_at_ns = expires_at_ns;
                         insert_expiry = Some((lease.addr_index, expires_at_ns));

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -1289,6 +1289,35 @@ fn pool_snat_persistent_rollback_preserves_lease_after_reuser_release() {
 }
 
 #[test]
+fn pool_snat_persistent_double_rollback_removes_unused_lease() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 2));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    rollback_source_nat_allocation(&rules, &session_key(10000, "8.8.8.8", 53), first, false, 3);
+    rollback_source_nat_allocation(&rules, &session_key(10000, "1.1.1.1", 53), second, false, 4);
+
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].live_flows, 0);
+    assert_eq!(status[0].used_ports, 0);
+    assert_eq!(status[0].persistent_leases, 0);
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert!(live.persistent_by_source.is_empty());
+        assert!(live.lease_expirations.is_empty());
+        assert!(live.lease_expirations_by_addr[0].is_empty());
+        assert_eq!(live.recycled_ports_by_addr[0], vec![40000]);
+    }
+}
+
+#[test]
 fn pool_snat_release_uses_rewritten_dnat_destination_key() {
     let rules = persistent_pool_rules(300, 40000, 40000);
     let translated_dst: IpAddr = "10.0.0.5".parse().unwrap();

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -937,6 +937,14 @@ fn session_key(src_port: u16, dst_ip: &str, dst_port: u16) -> crate::session::Se
     session_key_from_src("10.0.1.100", src_port, dst_ip, dst_port)
 }
 
+fn lease_key(src_port: u16) -> PersistentSourceKey {
+    PersistentSourceKey {
+        protocol: 6,
+        src_ip: "10.0.1.100".parse().unwrap(),
+        src_port,
+    }
+}
+
 fn session_key_from_src(
     src_ip: &str,
     src_port: u16,
@@ -1314,6 +1322,136 @@ fn pool_snat_persistent_double_rollback_removes_unused_lease() {
         assert!(live.lease_expirations.is_empty());
         assert!(live.lease_expirations_by_addr[0].is_empty());
         assert_eq!(live.recycled_ports_by_addr[0], vec![40000]);
+    }
+}
+
+#[test]
+fn pool_snat_persistent_reactivation_uses_fresh_expiry_after_success() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let timeout_ns = 300 * NS_PER_SEC;
+    let original = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        original,
+        false,
+        2,
+    );
+
+    let old_expiry = 2 + timeout_ns;
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.expires_at_ns, old_expiry);
+        assert!(live
+            .lease_expirations
+            .contains(&(old_expiry, lease_key(10000))));
+    }
+
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 3));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "9.9.9.9", 53, 4));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "9.9.9.9", 53),
+        second,
+        false,
+        5,
+    );
+    rollback_source_nat_allocation(
+        &rules,
+        &session_key(10000, "1.1.1.1", 53),
+        first,
+        false,
+        6,
+    );
+
+    let fresh_expiry = 6 + timeout_ns;
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].live_flows, 0);
+    assert_eq!(status[0].used_ports, 1);
+    assert_eq!(status[0].persistent_leases, 1);
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.active_flows, 0);
+        assert_eq!(lease.completed_flows, 2);
+        assert_eq!(lease.expires_at_ns, fresh_expiry);
+        assert_eq!(live.lease_expirations.len(), 1);
+        assert!(live
+            .lease_expirations
+            .contains(&(fresh_expiry, lease_key(10000))));
+        assert!(!live
+            .lease_expirations
+            .contains(&(old_expiry, lease_key(10000))));
+    }
+}
+
+#[test]
+fn pool_snat_persistent_reactivation_double_rollback_restores_old_expiry() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let timeout_ns = 300 * NS_PER_SEC;
+    let original = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        original,
+        false,
+        2,
+    );
+
+    let old_expiry = 2 + timeout_ns;
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 3));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "9.9.9.9", 53, 4));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    rollback_source_nat_allocation(
+        &rules,
+        &session_key(10000, "1.1.1.1", 53),
+        first,
+        false,
+        5,
+    );
+    rollback_source_nat_allocation(
+        &rules,
+        &session_key(10000, "9.9.9.9", 53),
+        second,
+        false,
+        6,
+    );
+
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].live_flows, 0);
+    assert_eq!(status[0].used_ports, 1);
+    assert_eq!(status[0].persistent_leases, 1);
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.active_flows, 0);
+        assert_eq!(lease.completed_flows, 1);
+        assert_eq!(lease.expires_at_ns, old_expiry);
+        assert_eq!(live.lease_expirations.len(), 1);
+        assert!(live
+            .lease_expirations
+            .contains(&(old_expiry, lease_key(10000))));
     }
 }
 

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -1400,6 +1400,73 @@ fn pool_snat_persistent_reactivation_uses_fresh_expiry_after_success() {
 }
 
 #[test]
+fn pool_snat_persistent_reactivation_completion_survives_saturated_counter() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let timeout_ns = 300 * NS_PER_SEC;
+    let original = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        original,
+        false,
+        2,
+    );
+
+    let old_expiry = 2 + timeout_ns;
+    {
+        let mut live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values_mut().next().unwrap();
+        lease.completed_flows = u64::MAX;
+        assert_eq!(lease.expires_at_ns, old_expiry);
+    }
+
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 3));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "9.9.9.9", 53, 4));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "9.9.9.9", 53),
+        second,
+        false,
+        5,
+    );
+    rollback_source_nat_allocation(
+        &rules,
+        &session_key(10000, "1.1.1.1", 53),
+        first,
+        false,
+        6,
+    );
+
+    let fresh_expiry = 6 + timeout_ns;
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.active_flows, 0);
+        assert_eq!(lease.completed_flows, u64::MAX);
+        assert_eq!(lease.expires_at_ns, fresh_expiry);
+        assert!(live
+            .lease_expirations
+            .contains(&(fresh_expiry, lease_key(10000))));
+        assert!(!live
+            .lease_expirations
+            .contains(&(old_expiry, lease_key(10000))));
+    }
+}
+
+#[test]
 fn pool_snat_persistent_reactivation_double_rollback_restores_old_expiry() {
     let rules = persistent_pool_rules(300, 40000, 40001);
     let timeout_ns = 300 * NS_PER_SEC;

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -1255,6 +1255,40 @@ fn pool_snat_persistent_rollback_keeps_lease_reused_by_another_flow() {
 }
 
 #[test]
+fn pool_snat_persistent_rollback_preserves_lease_after_reuser_release() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 2));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    release_source_nat_allocation(&rules, &session_key(10000, "1.1.1.1", 53), second, false, 3);
+    rollback_source_nat_allocation(&rules, &session_key(10000, "8.8.8.8", 53), first, false, 4);
+
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].live_flows, 0);
+    assert_eq!(status[0].used_ports, 1);
+    assert_eq!(status[0].persistent_leases, 1);
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.active_flows, 0);
+        assert_eq!(lease.completed_flows, 1);
+        assert_eq!(live.lease_expirations.len(), 1);
+        assert_eq!(live.lease_expirations_by_addr[0].len(), 1);
+    }
+
+    let third = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "9.9.9.9", 53, 5));
+    assert_eq!(third.rewrite_src, first.rewrite_src);
+    assert_eq!(third.rewrite_src_port, first.rewrite_src_port);
+}
+
+#[test]
 fn pool_snat_release_uses_rewritten_dnat_destination_key() {
     let rules = persistent_pool_rules(300, 40000, 40000);
     let translated_dst: IpAddr = "10.0.0.5".parse().unwrap();

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -1224,6 +1224,37 @@ fn pool_snat_persistent_rollback_removes_fresh_lease() {
 }
 
 #[test]
+fn pool_snat_persistent_rollback_keeps_lease_reused_by_another_flow() {
+    let rules = persistent_pool_rules(300, 40000, 40001);
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1));
+    let second = expect_snat_decision(tuple_snat_lookup(&rules, 10000, "1.1.1.1", 53, 2));
+    assert_eq!(second.rewrite_src, first.rewrite_src);
+    assert_eq!(second.rewrite_src_port, first.rewrite_src_port);
+
+    rollback_source_nat_allocation(&rules, &session_key(10000, "8.8.8.8", 53), first, false, 3);
+
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].live_flows, 1);
+    assert_eq!(status[0].used_ports, 1);
+    assert_eq!(status[0].persistent_leases, 1);
+    {
+        let live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let lease = live.persistent_by_source.values().next().unwrap();
+        assert_eq!(lease.active_flows, 1);
+        assert!(live.lease_expirations.is_empty());
+        assert!(live.lease_expirations_by_addr[0].is_empty());
+    }
+
+    let third = expect_snat_decision(tuple_snat_lookup(&rules, 10001, "9.9.9.9", 53, 4));
+    assert_ne!(third.rewrite_src_port, first.rewrite_src_port);
+}
+
+#[test]
 fn pool_snat_release_uses_rewritten_dnat_destination_key() {
     let rules = persistent_pool_rules(300, 40000, 40000);
     let translated_dst: IpAddr = "10.0.0.5".parse().unwrap();


### PR DESCRIPTION
## Summary

Fixes the persistent SNAT rollback corruption reported in #1455.

The original rollback bug let one failed session install remove a
persistent lease and release its translated tuple while another live flow
still depended on that tuple. The fix keeps rollback reference-aware: a
rollback decrements one active lease reference and only removes the lease
when no live flow and no completed flow in the current activation justify
keeping the persistent lease.

Round-1 review found the complementary ordering where a reuser releases
successfully before the original creator rolls back. The allocator tracks
whether any flow has completed through the active lease. A creator
rollback only removes a fresh lease if no other flow has ever completed
on it; otherwise rollback preserves the lease and installs the normal
inactivity expiry.

Round-2 review found the double-rollback ordering: F1 creates a
persistent lease, F2 reuses it, F1 rolls back, and F2 then rolls back.
The reused-active rollback arm now also checks for zero completed flows.
If the last active flow rolls back and no flow ever completed, the lease
is removed, expiry indexes are empty, and the translated tuple is
returned to the free pool.

Round-3 review found that `completed_flows` is lifetime state, while
rollback needs per-reactivation state. An old inactive lease can have
prior completions from F0. If F1 reactivates it and F2 reuses it, final
rollback must distinguish "F2 completed in this activation" from "only
F0 completed before this activation." The allocator snapshots previous
expiry state and restores it only when this activation saw no completion.

Round-4 review found that comparing completion counters is still brittle
under saturation. The allocator now tracks activation_saw_completion as a
boolean fact and keeps completed_flows as u64 accounting/debug state
only. The new saturation regression forces completed_flows to u64::MAX,
then proves a completion in the current activation still installs a fresh
expiry on peer rollback.

## Regression coverage

Covered traces:

1. F1 creates persistent lease L.
2. F2 reuses L for the same persistent source key.
3. F1 rolls back while F2 is still live.
4. L remains owned by F2 and is not returned to the free pool.

Codex round-1 ordering:

1. F1 creates persistent lease L.
2. F2 reuses L for the same persistent source key.
3. F2 releases successfully before F1 rolls back.
4. F1 rollback preserves L with inactivity expiry.
5. A subsequent same-source flow reuses the same translated tuple.

Codex round-2 ordering:

1. F1 creates persistent lease L.
2. F2 reuses L for the same persistent source key.
3. F1 rolls back, leaving F2 as the only active flow.
4. F2 rolls back before any flow completes.
5. L is removed, all expiry indexes are empty, and the translated tuple
   is returned to the recycled-port list.

Codex round-3 inactive-reactivation orderings:

1. F0 completes and leaves an inactive persistent lease with expiry E0.
2. F1 reactivates that lease and F2 reuses it.
3. If F2 completes before F1 rolls back, rollback installs a fresh
   inactivity expiry for this activation.
4. If F1 and F2 both roll back, rollback restores E0 instead of extending
   the lease with a fresh inactivity timeout.

Codex round-4 saturation ordering:

1. F0 leaves an inactive persistent lease whose completed_flows counter
   has saturated.
2. F1 reactivates the lease and F2 reuses it.
3. F2 completes while the saturated counter cannot numerically increase.
4. F1 rollback still observes activation_saw_completion=true and installs
   a fresh inactivity expiry.

## Validation

- `git diff --check`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_reactivation_completion_survives_saturated_counter`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_reactivation_uses_fresh_expiry_after_success`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_reactivation_double_rollback_restores_old_expiry`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_double_rollback_removes_unused_lease`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_rollback_keeps_lease_reused_by_another_flow`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_persistent_rollback_preserves_lease_after_reuser_release`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_`

Fixes #1455.