### PR TITLE
snat: replace stale persistent lease expirations on release

### DIFF
--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -618,16 +618,18 @@ impl PortAllocator {
         }
         live.live_by_flow.remove(&flow);
         if let Some(key) = existing.persistent_key {
-            let mut insert_expiry = None;
+            let mut refresh_expiry = None;
             if let Some(lease) = live.persistent_by_source.get_mut(&key) {
                 lease.active_flows = lease.active_flows.saturating_sub(1);
                 if lease.active_flows == 0 {
+                    let old_expires_at_ns = lease.expires_at_ns;
                     let expires_at_ns = now_ns.saturating_add(lease.timeout_ns);
                     lease.expires_at_ns = expires_at_ns;
-                    insert_expiry = Some((lease.addr_index, expires_at_ns));
+                    refresh_expiry = Some((lease.addr_index, old_expires_at_ns, expires_at_ns));
                 }
             }
-            if let Some((addr_index, expires_at_ns)) = insert_expiry {
+            if let Some((addr_index, old_expires_at_ns, expires_at_ns)) = refresh_expiry {
+                Self::remove_lease_expiration_locked(&mut live, addr_index, old_expires_at_ns, key);
                 Self::insert_lease_expiration_locked(&mut live, addr_index, expires_at_ns, key);
             }
         } else {

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -1273,6 +1273,63 @@ fn pool_snat_persistent_expiry_index_is_bounded_by_leases() {
 }
 
 #[test]
+fn pool_snat_persistent_release_replaces_stale_expiry_tuple() {
+    let rules = persistent_pool_rules(300, 40000, 40000);
+    let decision =
+        expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1_000));
+    let stale_expires_at_ns = {
+        let mut live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (key, lease) = live
+            .persistent_by_source
+            .iter()
+            .next()
+            .map(|(key, lease)| (*key, *lease))
+            .unwrap();
+        assert_eq!(lease.active_flows, 1);
+        live.lease_expirations.insert((lease.expires_at_ns, key));
+        live.lease_expirations_by_addr[lease.addr_index].insert((lease.expires_at_ns, key));
+        lease.expires_at_ns
+    };
+
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        decision,
+        false,
+        2_000,
+    );
+
+    let live = rules[0]
+        .pool_allocator
+        .shared
+        .live
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let (key, lease) = live
+        .persistent_by_source
+        .iter()
+        .next()
+        .map(|(key, lease)| (*key, *lease))
+        .unwrap();
+    assert_ne!(lease.expires_at_ns, stale_expires_at_ns);
+    assert_eq!(live.lease_expirations.len(), 1);
+    assert!(live.lease_expirations.contains(&(lease.expires_at_ns, key)));
+    assert!(!live.lease_expirations.contains(&(stale_expires_at_ns, key)));
+    assert_eq!(live.lease_expirations_by_addr[lease.addr_index].len(), 1);
+    assert!(
+        live.lease_expirations_by_addr[lease.addr_index].contains(&(lease.expires_at_ns, key))
+    );
+    assert!(
+        !live.lease_expirations_by_addr[lease.addr_index].contains(&(stale_expires_at_ns, key))
+    );
+}
+
+#[test]
 fn pool_snat_allocation_gc_is_bounded_when_not_under_pressure() {
     let rules = persistent_pool_rules(1, 40000, 40099);
     let expired_lease_count = ALLOCATION_GC_BUDGET + 12;


### PR DESCRIPTION
## Summary

Fixes the persistent SNAT expiry-index cleanup gap tracked in #1456.

`release_flow` now removes the prior `(expires_at, key)` tuple from both
the global and per-address expiry indexes before inserting the refreshed
expiration. The normal reuse path already removes inactive expiry tuples,
but release now defends the invariant locally instead of depending on all
callers to preserve it.

## Regression covered

Adds a test that seeds the stale-index state directly, releases the active
flow, and verifies both expiry indexes contain only the refreshed tuple.

## Validation

- `git diff --check`
- `cargo test -q pool_snat_persistent_release_replaces_stale_expiry_tuple`
- `cargo test -q pool_snat_`

Fixes #1456.