### PR TITLE
snat: assert persistent lease expiry index invariants

### DIFF
--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -953,6 +953,40 @@ fn session_key_from_src(
     }
 }
 
+fn assert_persistent_expiry_indexes_consistent(rule: &SourceNatRule) {
+    let live = rule
+        .pool_allocator
+        .shared
+        .live
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let mut expected_global = BTreeSet::new();
+    let mut expected_by_addr = vec![BTreeSet::new(); live.lease_expirations_by_addr.len()];
+
+    for (key, lease) in &live.persistent_by_source {
+        let entry = (lease.expires_at_ns, *key);
+        if lease.active_flows == 0 {
+            assert!(
+                lease.addr_index < expected_by_addr.len(),
+                "persistent lease addr index {} out of range {}",
+                lease.addr_index,
+                expected_by_addr.len()
+            );
+            expected_global.insert(entry);
+            expected_by_addr[lease.addr_index].insert(entry);
+        }
+    }
+
+    assert_eq!(
+        live.lease_expirations, expected_global,
+        "persistent expiry index mismatch"
+    );
+    assert_eq!(
+        live.lease_expirations_by_addr, expected_by_addr,
+        "per-address persistent expiry index mismatch"
+    );
+}
+
 #[test]
 fn pool_snat_persistent_reuses_same_source_tuple() {
     let rules = persistent_pool_rules(300, 40000, 40010);
@@ -967,6 +1001,7 @@ fn pool_snat_persistent_reuses_same_source_tuple() {
     assert_eq!(status[0].reuses_total, 1);
     assert_eq!(status[0].persistent_leases, 1);
     assert_eq!(status[0].live_flows, 2);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 #[test]
@@ -1012,6 +1047,7 @@ fn pool_snat_persistent_reassigns_after_timeout() {
     ));
     assert_eq!(reassigned.rewrite_src, first.rewrite_src);
     assert_ne!(reassigned.rewrite_src_port, first.rewrite_src_port);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 #[test]
@@ -1217,6 +1253,7 @@ fn pool_snat_persistent_rollback_removes_fresh_lease() {
     assert_eq!(status[0].live_flows, 0);
     assert_eq!(status[0].used_ports, 0);
     assert_eq!(status[0].persistent_leases, 0);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 
     let second = expect_snat_decision(tuple_snat_lookup(&rules, 10001, "1.1.1.1", 53, 3));
     assert_eq!(second.rewrite_src, first.rewrite_src);
@@ -1243,6 +1280,7 @@ fn pool_snat_release_uses_rewritten_dnat_destination_key() {
     assert_eq!(status[0].live_flows, 0);
     assert_eq!(status[0].used_ports, 1);
     assert_eq!(status[0].persistent_leases, 1);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 #[test]
@@ -1270,6 +1308,43 @@ fn pool_snat_persistent_expiry_index_is_bounded_by_leases() {
     assert_eq!(live.persistent_by_source.len(), 1);
     assert_eq!(live.lease_expirations.len(), 1);
     assert_eq!(live.lease_expirations_by_addr[0].len(), 1);
+    drop(live);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
+}
+
+#[test]
+#[should_panic(expected = "persistent expiry index mismatch")]
+fn pool_snat_expiry_invariant_rejects_stale_entry() {
+    let rules = persistent_pool_rules(300, 40000, 40000);
+    let decision =
+        expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1_000));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        decision,
+        false,
+        2_000,
+    );
+    {
+        let mut live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (key, lease) = live
+            .persistent_by_source
+            .iter()
+            .next()
+            .map(|(key, lease)| (*key, *lease))
+            .unwrap();
+        live.lease_expirations
+            .insert((lease.expires_at_ns + 1, key));
+        live.lease_expirations_by_addr[lease.addr_index]
+            .insert((lease.expires_at_ns + 1, key));
+    }
+
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 #[test]
@@ -1324,6 +1399,8 @@ fn pool_snat_allocation_gc_is_bounded_when_not_under_pressure() {
         live.lease_expirations_by_addr[0].len(),
         expired_lease_count - ALLOCATION_GC_BUDGET
     );
+    drop(live);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 #[test]
@@ -1393,6 +1470,7 @@ fn pool_snat_pressure_gc_reclaims_expired_lease_for_selected_address() {
             ALLOCATION_GC_BUDGET
         );
     }
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 
     let decision = expect_snat_decision(tuple_snat_lookup_from_src(
         &rules,
@@ -1413,6 +1491,8 @@ fn pool_snat_pressure_gc_reclaims_expired_lease_for_selected_address() {
         .unwrap_or_else(|e| e.into_inner());
     assert_eq!(live.lease_expirations_by_addr[0].len(), 0);
     assert!(live.lease_expirations_by_addr[1].len() < ALLOCATION_GC_BUDGET);
+    drop(live);
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
 }
 
 fn source_for_sticky_pool_index(want: usize, pool_len: usize) -> String {

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -965,13 +965,25 @@ fn assert_persistent_expiry_indexes_consistent(rule: &SourceNatRule) {
 
     for (key, lease) in &live.persistent_by_source {
         let entry = (lease.expires_at_ns, *key);
+        assert!(
+            lease.addr_index < expected_by_addr.len(),
+            "persistent lease addr index {} out of range {}",
+            lease.addr_index,
+            expected_by_addr.len()
+        );
+        assert_eq!(
+            live.addr_index_by_translated
+                .get(&lease.translated)
+                .copied(),
+            Some(lease.addr_index),
+            "persistent lease addr index mismatch"
+        );
+        assert_eq!(
+            pool_ip_for_addr_index(rule, lease.addr_index),
+            Some(lease.translated.ip),
+            "persistent lease translated address mismatch"
+        );
         if lease.active_flows == 0 {
-            assert!(
-                lease.addr_index < expected_by_addr.len(),
-                "persistent lease addr index {} out of range {}",
-                lease.addr_index,
-                expected_by_addr.len()
-            );
             expected_global.insert(entry);
             expected_by_addr[lease.addr_index].insert(entry);
         }
@@ -979,12 +991,23 @@ fn assert_persistent_expiry_indexes_consistent(rule: &SourceNatRule) {
 
     assert_eq!(
         live.lease_expirations, expected_global,
-        "persistent expiry index mismatch"
+        "global persistent expiry index mismatch"
     );
     assert_eq!(
         live.lease_expirations_by_addr, expected_by_addr,
         "per-address persistent expiry index mismatch"
     );
+}
+
+fn pool_ip_for_addr_index(rule: &SourceNatRule, addr_index: usize) -> Option<IpAddr> {
+    if addr_index < rule.pool_addresses_v4.len() {
+        return Some(IpAddr::V4(rule.pool_addresses_v4[addr_index]));
+    }
+    let v6_index = addr_index.checked_sub(rule.pool_addresses_v4.len())?;
+    rule.pool_addresses_v6
+        .get(v6_index)
+        .copied()
+        .map(IpAddr::V6)
 }
 
 #[test]
@@ -1313,8 +1336,8 @@ fn pool_snat_persistent_expiry_index_is_bounded_by_leases() {
 }
 
 #[test]
-#[should_panic(expected = "persistent expiry index mismatch")]
-fn pool_snat_expiry_invariant_rejects_stale_entry() {
+#[should_panic(expected = "global persistent expiry index mismatch")]
+fn pool_snat_expiry_invariant_rejects_stale_global_entry() {
     let rules = persistent_pool_rules(300, 40000, 40000);
     let decision =
         expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1_000));
@@ -1340,8 +1363,87 @@ fn pool_snat_expiry_invariant_rejects_stale_entry() {
             .unwrap();
         live.lease_expirations
             .insert((lease.expires_at_ns + 1, key));
+    }
+
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
+}
+
+#[test]
+#[should_panic(expected = "per-address persistent expiry index mismatch")]
+fn pool_snat_expiry_invariant_rejects_stale_per_address_entry() {
+    let rules = persistent_pool_rules(300, 40000, 40000);
+    let decision =
+        expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1_000));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        decision,
+        false,
+        2_000,
+    );
+    {
+        let mut live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (key, lease) = live
+            .persistent_by_source
+            .iter()
+            .next()
+            .map(|(key, lease)| (*key, *lease))
+            .unwrap();
         live.lease_expirations_by_addr[lease.addr_index]
             .insert((lease.expires_at_ns + 1, key));
+    }
+
+    assert_persistent_expiry_indexes_consistent(&rules[0]);
+}
+
+#[test]
+#[should_panic(expected = "persistent lease addr index mismatch")]
+fn pool_snat_expiry_invariant_rejects_wrong_addr_index() {
+    let rules = persistent_pool_rules_with_options(
+        300,
+        40000,
+        40000,
+        vec!["203.0.113.10", "203.0.113.11"],
+        false,
+    );
+    let decision =
+        expect_snat_decision(tuple_snat_lookup(&rules, 10000, "8.8.8.8", 53, 1_000));
+    release_source_nat_allocation(
+        &rules,
+        &session_key(10000, "8.8.8.8", 53),
+        decision,
+        false,
+        2_000,
+    );
+    {
+        let mut live = rules[0]
+            .pool_allocator
+            .shared
+            .live
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (key, lease) = live
+            .persistent_by_source
+            .iter()
+            .next()
+            .map(|(key, lease)| (*key, *lease))
+            .unwrap();
+        let wrong_addr_index = if lease.addr_index == 0 { 1 } else { 0 };
+        let entry = (lease.expires_at_ns, key);
+        live.lease_expirations_by_addr[lease.addr_index].remove(&entry);
+        live.lease_expirations_by_addr[wrong_addr_index].insert(entry);
+        live.persistent_by_source.insert(
+            key,
+            PersistentLease {
+                addr_index: wrong_addr_index,
+                ..lease
+            },
+        );
     }
 
     assert_persistent_expiry_indexes_consistent(&rules[0]);


### PR DESCRIPTION
## Summary

Adds the expiry-index invariant coverage requested in #1458.

The new helper derives the expected global and per-address expiry indexes
from the live persistent lease table, then checks that the runtime indexes
match exactly. It is used across tests that exercise persistent reuse,
release, rollback, allocation-time GC, and selected-address pressure cleanup.

A negative test injects a stale expiry tuple and verifies the helper rejects
it, so stale global/per-address index entries are pinned as test failures.

## Validation

- `git diff --check`
- `cargo test -q pool_snat_expiry_invariant_rejects_stale_entry`
- `cargo test -q pool_snat_`

Fixes #1458.