### PR TITLE
api: serve userspace system buffers from helper status

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
@@ -32,8 +32,8 @@ helper publishes per-binding/ring capacity, available fill frames, completion
 backlog, RX/TX ring occupancy, and drop/error counters. Go formatting keeps a
 stable aggregate view for `show system buffers` and only emits per-binding rows
 for `show system buffers detail`. REST uses the same helper-backed bounded
-rows for JSON so userspace mode never falls back to eBPF map occupancy for
-operator buffer warnings.
+rows and status counters for JSON so userspace mode never falls back to eBPF
+map occupancy for operator buffer warnings.
 
 If mixed-version helpers omit a newer capacity surface, Go must fall back to the
 older binding fields or clearly mark the row unavailable. It must not display

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md
@@ -3,9 +3,10 @@
 ## Goal
 
 Keep operational buffer/status visibility intact after the eBPF dataplane is
-retired. `show system buffers`, gRPC `ShowText`, and related status/metrics
-must expose userspace AF_XDP ring capacity, fill/comp pressure, and active
-session summaries with the same operator utility as the legacy path.
+retired. `show system buffers`, gRPC `ShowText`, REST
+`/api/v1/system/buffers`, and related status/metrics must expose userspace
+AF_XDP ring capacity, fill/comp pressure, and active session summaries with
+the same operator utility as the legacy path.
 
 ## Dependencies
 
@@ -30,7 +31,9 @@ Treat buffer visibility as runtime telemetry, not config state. The userspace
 helper publishes per-binding/ring capacity, available fill frames, completion
 backlog, RX/TX ring occupancy, and drop/error counters. Go formatting keeps a
 stable aggregate view for `show system buffers` and only emits per-binding rows
-for `show system buffers detail`.
+for `show system buffers detail`. REST uses the same helper-backed bounded
+rows for JSON so userspace mode never falls back to eBPF map occupancy for
+operator buffer warnings.
 
 If mixed-version helpers omit a newer capacity surface, Go must fall back to the
 older binding fields or clearly mark the row unavailable. It must not display
@@ -83,8 +86,9 @@ without real denominators.
   them, and both preserve the active-session footer.
 - Go: mixed-version status with sparse per-binding capacity falls back to
   binding-level capacity instead of rendering false zeroes.
-- Go: gRPC `ShowText` and local CLI use the same userspace buffer fixture and
-  produce equivalent text.
+- Go: gRPC `ShowText`, local CLI, and REST `/api/v1/system/buffers` use the
+  same userspace buffer fixture and do not fall back to BPF map statistics when
+  helper status is present.
 - Go: formatter covers CoS queued-byte capacity plus existing helper pressure
   counters without turning unbounded counts into utilization percentages; the
   dynamic-count regression test must fail if neighbor/flow-cache counters gain

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -59,9 +59,10 @@ helper status path when the active dataplane implements
 `Status() (userspace.ProcessStatus, error)`; they do not depend on BPF map
 occupancy for userspace mode. The rendered rows are aggregate AF_XDP UMEM
 frame and TX-ring utilization, with `WARNING` at >=80% and `CRITICAL` at
->=90%. `show system buffers detail` adds per-binding rows after the aggregates
-so a hot binding is visible even when total aggregate usage is low. Both
-userspace buffer commands preserve the legacy `Active sessions` footer.
+>=90%, plus the same dynamic userspace status counters. `show system buffers
+detail` adds per-binding rows after the aggregates so a hot binding is visible
+even when total aggregate usage is low. Both userspace buffer commands preserve
+the legacy `Active sessions` footer.
 
 The bounded source fields are
 `ProcessStatus.PerBinding[].umem_total_frames`,

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -54,14 +54,14 @@ debugging entry points, use [`userspace-debug-map.md`](userspace-debug-map.md).
 
 ### 0. Operator Buffer Telemetry
 
-`show system buffers` uses the userspace helper status path when the
-active dataplane implements `Status() (userspace.ProcessStatus, error)`;
-it does not depend on BPF map occupancy for userspace mode. The rendered
-rows are aggregate AF_XDP UMEM frame and TX-ring utilization, with
-`WARNING` at >=80% and `CRITICAL` at >=90%. `show system buffers detail`
-adds per-binding rows after the aggregates so a hot binding is visible
-even when total aggregate usage is low. Both userspace buffer commands
-preserve the legacy `Active sessions` footer.
+`show system buffers` and REST `/api/v1/system/buffers` use the userspace
+helper status path when the active dataplane implements
+`Status() (userspace.ProcessStatus, error)`; they do not depend on BPF map
+occupancy for userspace mode. The rendered rows are aggregate AF_XDP UMEM
+frame and TX-ring utilization, with `WARNING` at >=80% and `CRITICAL` at
+>=90%. `show system buffers detail` adds per-binding rows after the aggregates
+so a hot binding is visible even when total aggregate usage is low. Both
+userspace buffer commands preserve the legacy `Active sessions` footer.
 
 The bounded source fields are
 `ProcessStatus.PerBinding[].umem_total_frames`,

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/psaab/xpf/pkg/vrrp"
@@ -2087,6 +2088,32 @@ func (s *Server) configAnnotateHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 	if s.dp == nil || !s.dp.IsLoaded() {
 		writeOK(w, []BufferInfo{})
+		return
+	}
+
+	if provider, ok := s.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		status, err := provider.Status()
+		if err != nil {
+			msg := fmt.Sprintf("userspace buffer status unavailable: %v", err)
+			writeError(w, http.StatusServiceUnavailable, msg)
+			return
+		}
+		rows := dpuserspace.SystemBufferUtilizationRows(status, false)
+		buffers := make([]BufferInfo, 0, len(rows))
+		for _, row := range rows {
+			buffers = append(buffers, BufferInfo{
+				Name:         row.Name,
+				Type:         "Userspace",
+				Scope:        row.Scope,
+				MaxEntries:   int(row.Capacity),
+				UsedCount:    int(row.Used),
+				UsagePercent: row.UsagePercent,
+				Status:       row.Status,
+			})
+		}
+		writeOK(w, buffers)
 		return
 	}
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -2100,17 +2100,31 @@ func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, msg)
 			return
 		}
-		rows := dpuserspace.SystemBufferUtilizationRows(status, false)
-		buffers := make([]BufferInfo, 0, len(rows))
-		for _, row := range rows {
+		rows := dpuserspace.StructuredSystemBufferRows(status, false)
+		if len(rows.Utilization) == 0 {
+			msg := "userspace buffer status missing bounded capacity fields"
+			writeError(w, http.StatusServiceUnavailable, msg)
+			return
+		}
+		buffers := make([]BufferInfo, 0, len(rows.Utilization)+len(rows.Counters))
+		for _, row := range rows.Utilization {
 			buffers = append(buffers, BufferInfo{
 				Name:         row.Name,
 				Type:         "Userspace",
 				Scope:        row.Scope,
-				MaxEntries:   int(row.Capacity),
-				UsedCount:    int(row.Used),
+				MaxEntries:   row.Capacity,
+				UsedCount:    row.Used,
 				UsagePercent: row.UsagePercent,
 				Status:       row.Status,
+			})
+		}
+		for _, row := range rows.Counters {
+			buffers = append(buffers, BufferInfo{
+				Name:   row.Name,
+				Type:   "UserspaceCounter",
+				Scope:  row.Scope,
+				Value:  row.Value,
+				Status: "OK",
 			})
 		}
 		writeOK(w, buffers)
@@ -2133,8 +2147,8 @@ func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 		buffers = append(buffers, BufferInfo{
 			Name:         st.Name,
 			Type:         st.Type,
-			MaxEntries:   int(st.MaxEntries),
-			UsedCount:    int(st.UsedCount),
+			MaxEntries:   uint64(st.MaxEntries),
+			UsedCount:    uint64(st.UsedCount),
 			UsagePercent: usage,
 			Status:       status,
 		})

--- a/pkg/api/system_buffers_test.go
+++ b/pkg/api/system_buffers_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+type systemBuffersAPIUserspaceDP struct {
+	*dataplane.Manager
+	status         dpuserspace.ProcessStatus
+	statusErr      error
+	getMapStatsHit bool
+}
+
+func (f *systemBuffersAPIUserspaceDP) IsLoaded() bool {
+	return true
+}
+
+func (f *systemBuffersAPIUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
+	return f.status, f.statusErr
+}
+
+func (f *systemBuffersAPIUserspaceDP) GetMapStats() []dataplane.MapStats {
+	f.getMapStatsHit = true
+	return []dataplane.MapStats{
+		{Name: "legacy_bpf_map", Type: "Hash", MaxEntries: 10, UsedCount: 9},
+	}
+}
+
+func TestSystemBuffersHandlerUsesUserspaceStatusRows(t *testing.T) {
+	dp := &systemBuffersAPIUserspaceDP{
+		Manager: dataplane.New(),
+		status: dpuserspace.ProcessStatus{
+			PerBinding: []dpuserspace.BindingCountersSnapshot{
+				{
+					WorkerID:           0,
+					QueueID:            1,
+					Ifindex:            5,
+					UmemTotalFrames:    1000,
+					UmemInflightFrames: 800,
+					TxRingCapacity:     100,
+					OutstandingTX:      95,
+				},
+			},
+		},
+	}
+	s := &Server{dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/system/buffers", nil)
+	s.systemBuffersHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if dp.getMapStatsHit {
+		t.Fatal("systemBuffersHandler fell back to BPF map stats for userspace dataplane")
+	}
+
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []BufferInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("len(resp.Data) = %d, want 2; data: %+v", len(resp.Data), resp.Data)
+	}
+
+	rows := make(map[string]BufferInfo, len(resp.Data))
+	for _, row := range resp.Data {
+		rows[row.Name] = row
+		if row.Type != "Userspace" {
+			t.Fatalf("row %q type = %q, want Userspace", row.Name, row.Type)
+		}
+		if row.Scope != "aggregate/1" {
+			t.Fatalf("row %q scope = %q, want aggregate/1", row.Name, row.Scope)
+		}
+	}
+	umem := rows["AF_XDP UMEM frames"]
+	if umem.MaxEntries != 1000 || umem.UsedCount != 800 ||
+		umem.UsagePercent != 80.0 || umem.Status != "WARNING" {
+		t.Fatalf("UMEM row = %+v, want 1000/800 80%% WARNING", umem)
+	}
+	tx := rows["AF_XDP TX ring"]
+	if tx.MaxEntries != 100 || tx.UsedCount != 95 ||
+		tx.UsagePercent != 95.0 || tx.Status != "CRITICAL" {
+		t.Fatalf("TX row = %+v, want 100/95 95%% CRITICAL", tx)
+	}
+}
+
+func TestSystemBuffersHandlerDoesNotFallbackToMapsOnUserspaceStatusError(t *testing.T) {
+	dp := &systemBuffersAPIUserspaceDP{
+		Manager:   dataplane.New(),
+		statusErr: errors.New("helper offline"),
+	}
+	s := &Server{dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/system/buffers", nil)
+	s.systemBuffersHandler(rr, req)
+
+	if rr.Code != 503 {
+		t.Fatalf("status = %d, want 503; body: %s", rr.Code, rr.Body.String())
+	}
+	if dp.getMapStatsHit {
+		t.Fatal("systemBuffersHandler used BPF map stats after userspace status error")
+	}
+
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("success = true, want false; body: %s", rr.Body.String())
+	}
+}

--- a/pkg/api/system_buffers_test.go
+++ b/pkg/api/system_buffers_test.go
@@ -32,10 +32,27 @@ func (f *systemBuffersAPIUserspaceDP) GetMapStats() []dataplane.MapStats {
 	}
 }
 
+type systemBuffersAPILegacyDP struct {
+	*dataplane.Manager
+	getMapStatsHit bool
+}
+
+func (f *systemBuffersAPILegacyDP) IsLoaded() bool {
+	return true
+}
+
+func (f *systemBuffersAPILegacyDP) GetMapStats() []dataplane.MapStats {
+	f.getMapStatsHit = true
+	return []dataplane.MapStats{
+		{Name: "session_map", Type: "Hash", MaxEntries: 100, UsedCount: 85},
+	}
+}
+
 func TestSystemBuffersHandlerUsesUserspaceStatusRows(t *testing.T) {
 	dp := &systemBuffersAPIUserspaceDP{
 		Manager: dataplane.New(),
 		status: dpuserspace.ProcessStatus{
+			NeighborEntries: 7,
 			PerBinding: []dpuserspace.BindingCountersSnapshot{
 				{
 					WorkerID:           0,
@@ -45,6 +62,7 @@ func TestSystemBuffersHandlerUsesUserspaceStatusRows(t *testing.T) {
 					UmemInflightFrames: 800,
 					TxRingCapacity:     100,
 					OutstandingTX:      95,
+					ActiveFlowCount:    11,
 				},
 			},
 		},
@@ -72,17 +90,14 @@ func TestSystemBuffersHandlerUsesUserspaceStatusRows(t *testing.T) {
 	if !resp.Success {
 		t.Fatalf("success = false; body: %s", rr.Body.String())
 	}
-	if len(resp.Data) != 2 {
-		t.Fatalf("len(resp.Data) = %d, want 2; data: %+v", len(resp.Data), resp.Data)
+	if len(resp.Data) != 4 {
+		t.Fatalf("len(resp.Data) = %d, want 4; data: %+v", len(resp.Data), resp.Data)
 	}
 
 	rows := make(map[string]BufferInfo, len(resp.Data))
 	for _, row := range resp.Data {
 		rows[row.Name] = row
-		if row.Type != "Userspace" {
-			t.Fatalf("row %q type = %q, want Userspace", row.Name, row.Type)
-		}
-		if row.Scope != "aggregate/1" {
+		if row.Type == "Userspace" && row.Scope != "aggregate/1" {
 			t.Fatalf("row %q scope = %q, want aggregate/1", row.Name, row.Scope)
 		}
 	}
@@ -95,6 +110,16 @@ func TestSystemBuffersHandlerUsesUserspaceStatusRows(t *testing.T) {
 	if tx.MaxEntries != 100 || tx.UsedCount != 95 ||
 		tx.UsagePercent != 95.0 || tx.Status != "CRITICAL" {
 		t.Fatalf("TX row = %+v, want 100/95 95%% CRITICAL", tx)
+	}
+	neighbor := rows["Neighbor cache entries"]
+	if neighbor.Type != "UserspaceCounter" || neighbor.Scope != "dynamic" ||
+		neighbor.Value != 7 || neighbor.UsagePercent != 0 {
+		t.Fatalf("neighbor counter row = %+v, want dynamic counter value 7", neighbor)
+	}
+	flows := rows["Flow cache active flows"]
+	if flows.Type != "UserspaceCounter" || flows.Scope != "active window" ||
+		flows.Value != 11 || flows.UsagePercent != 0 {
+		t.Fatalf("flow-cache counter row = %+v, want active-window counter value 11", flows)
 	}
 }
 
@@ -122,5 +147,57 @@ func TestSystemBuffersHandlerDoesNotFallbackToMapsOnUserspaceStatusError(t *test
 	}
 	if resp.Success {
 		t.Fatalf("success = true, want false; body: %s", rr.Body.String())
+	}
+}
+
+func TestSystemBuffersHandlerRejectsUserspaceStatusWithoutCapacityRows(t *testing.T) {
+	dp := &systemBuffersAPIUserspaceDP{
+		Manager: dataplane.New(),
+		status:  dpuserspace.ProcessStatus{NeighborEntries: 3},
+	}
+	s := &Server{dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/system/buffers", nil)
+	s.systemBuffersHandler(rr, req)
+
+	if rr.Code != 503 {
+		t.Fatalf("status = %d, want 503; body: %s", rr.Code, rr.Body.String())
+	}
+	if dp.getMapStatsHit {
+		t.Fatal("systemBuffersHandler used BPF map stats for missing userspace capacity fields")
+	}
+}
+
+func TestSystemBuffersHandlerKeepsLegacyMapStatsFallback(t *testing.T) {
+	dp := &systemBuffersAPILegacyDP{Manager: dataplane.New()}
+	s := &Server{dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/system/buffers", nil)
+	s.systemBuffersHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if !dp.getMapStatsHit {
+		t.Fatal("systemBuffersHandler did not use GetMapStats for legacy dataplane")
+	}
+
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []BufferInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("len(resp.Data) = %d, want 1; data: %+v", len(resp.Data), resp.Data)
+	}
+	row := resp.Data[0]
+	if row.Name != "session_map" || row.Type != "Hash" ||
+		row.MaxEntries != 100 || row.UsedCount != 85 ||
+		row.UsagePercent != 85.0 || row.Status != "WARNING" {
+		t.Fatalf("legacy map row = %+v, want session_map 85/100 WARNING", row)
 	}
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -324,10 +324,11 @@ type ZonePairSessionSummary struct {
 	Total    int    `json:"total"`
 }
 
-// BufferInfo holds BPF map utilization information.
+// BufferInfo holds dataplane buffer utilization information.
 type BufferInfo struct {
 	Name         string  `json:"name"`
 	Type         string  `json:"type"`
+	Scope        string  `json:"scope,omitempty"`
 	MaxEntries   int     `json:"max_entries"`
 	UsedCount    int     `json:"used_count"`
 	UsagePercent float64 `json:"usage_percent"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -329,8 +329,9 @@ type BufferInfo struct {
 	Name         string  `json:"name"`
 	Type         string  `json:"type"`
 	Scope        string  `json:"scope,omitempty"`
-	MaxEntries   int     `json:"max_entries"`
-	UsedCount    int     `json:"used_count"`
+	MaxEntries   uint64  `json:"max_entries"`
+	UsedCount    uint64  `json:"used_count"`
+	Value        uint64  `json:"value,omitempty"`
 	UsagePercent float64 `json:"usage_percent"`
 	Status       string  `json:"status"`
 }

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -80,10 +80,42 @@ type systemBufferRow struct {
 	Used     uint64
 }
 
+// SystemBufferUtilizationRow is a bounded userspace buffer row suitable for
+// non-text renderers such as REST. It intentionally excludes dynamic counters
+// that do not have helper-published capacity denominators.
+type SystemBufferUtilizationRow struct {
+	Name         string
+	Scope        string
+	Capacity     uint64
+	Used         uint64
+	UsagePercent float64
+	Status       string
+}
+
 type systemBufferCounterRow struct {
 	Name  string
 	Scope string
 	Value uint64
+}
+
+// SystemBufferUtilizationRows returns the same bounded helper-status capacity
+// rows used by FormatSystemBuffers. Missing helper capacity fields produce no
+// synthetic fill rows rather than falling back to BPF map statistics.
+func SystemBufferUtilizationRows(status ProcessStatus, detail bool) []SystemBufferUtilizationRow {
+	rows, _, _ := systemBufferRows(status, detail)
+	out := make([]SystemBufferUtilizationRow, 0, len(rows))
+	for _, row := range rows {
+		usage, state := systemBufferUsage(row)
+		out = append(out, SystemBufferUtilizationRow{
+			Name:         row.Name,
+			Scope:        row.Scope,
+			Capacity:     row.Capacity,
+			Used:         row.Used,
+			UsagePercent: usage,
+			Status:       state,
+		})
+	}
+	return out
 }
 
 // FormatSystemBuffers renders userspace dataplane buffer capacity telemetry for
@@ -91,9 +123,53 @@ type systemBufferCounterRow struct {
 // helper status; unbounded helper counters/gauges render in a separate section
 // so missing denominators are not mistaken for real fill percentages.
 func FormatSystemBuffers(status ProcessStatus, detail bool) string {
+	rows, knownUMEM, knownTX := systemBufferRows(status, detail)
 	samples := systemBufferSamples(status)
+	counterRows := systemBufferCounterRows(status, samples, detail)
+
+	var b strings.Builder
+	b.WriteString(systemBufferUtilizationHeading + "\n")
+	if len(rows) == 0 {
+		b.WriteString("  unavailable: helper status does not include bounded AF_XDP capacity gauges\n")
+		b.WriteString("  required status fields: per_binding[].umem_total_frames, per_binding[].umem_inflight_frames, per_binding[].tx_ring_capacity, per_binding[].outstanding_tx\n")
+		b.WriteString("  bindings[] mirrors with the same fields are also accepted\n")
+	} else {
+		if knownUMEM == 0 && knownTX == 0 {
+			b.WriteString("  AF_XDP unavailable: helper status does not include bounded capacity gauges\n")
+		}
+		fmt.Fprintf(&b, "%-24s %-24s %12s %12s %8s %s\n", "Buffer", "Scope", "Capacity", "Used", "Usage%", "Status")
+		b.WriteString(strings.Repeat("-", 92) + "\n")
+		warnings := 0
+		for _, row := range rows {
+			pct, status := systemBufferUsage(row)
+			if status != "OK" {
+				warnings++
+			}
+			fmt.Fprintf(&b, "%-24s %-24s %12d %12d %7.1f%% %s\n",
+				row.Name, row.Scope, row.Capacity, row.Used, pct, status)
+		}
+		if warnings > 0 {
+			fmt.Fprintf(&b, "\n%d userspace buffer row(s) at high utilization\n", warnings)
+		}
+	}
+	if len(counterRows) > 0 {
+		if !strings.HasSuffix(b.String(), "\n\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString(systemBufferCountersHeading + "\n")
+		fmt.Fprintf(&b, "%-32s %-24s %12s\n", "Counter", "Scope", "Value")
+		b.WriteString(strings.Repeat("-", 70) + "\n")
+		for _, row := range counterRows {
+			fmt.Fprintf(&b, "%-32s %-24s %12d\n", row.Name, row.Scope, row.Value)
+		}
+	}
+	return b.String()
+}
+
+func systemBufferRows(status ProcessStatus, detail bool) ([]systemBufferRow, int, int) {
 	var umemCap, umemUsed, txCap, txUsed uint64
 	var knownUMEM, knownTX int
+	samples := systemBufferSamples(status)
 	for _, sample := range samples {
 		if sample.UMEMCap > 0 {
 			knownUMEM++
@@ -146,53 +222,22 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 			}
 		}
 	}
-	counterRows := systemBufferCounterRows(status, samples, detail)
+	return rows, knownUMEM, knownTX
+}
 
-	var b strings.Builder
-	b.WriteString(systemBufferUtilizationHeading + "\n")
-	if len(rows) == 0 {
-		b.WriteString("  unavailable: helper status does not include bounded AF_XDP capacity gauges\n")
-		b.WriteString("  required status fields: per_binding[].umem_total_frames, per_binding[].umem_inflight_frames, per_binding[].tx_ring_capacity, per_binding[].outstanding_tx\n")
-		b.WriteString("  bindings[] mirrors with the same fields are also accepted\n")
-	} else {
-		if knownUMEM == 0 && knownTX == 0 {
-			b.WriteString("  AF_XDP unavailable: helper status does not include bounded capacity gauges\n")
-		}
-		fmt.Fprintf(&b, "%-24s %-24s %12s %12s %8s %s\n", "Buffer", "Scope", "Capacity", "Used", "Usage%", "Status")
-		b.WriteString(strings.Repeat("-", 92) + "\n")
-		warnings := 0
-		for _, row := range rows {
-			pct := 0.0
-			if row.Capacity > 0 {
-				pct = float64(row.Used) * 100.0 / float64(row.Capacity)
-			}
-			status := "OK"
-			if pct >= 90.0 {
-				status = "CRITICAL"
-				warnings++
-			} else if pct >= 80.0 {
-				status = "WARNING"
-				warnings++
-			}
-			fmt.Fprintf(&b, "%-24s %-24s %12d %12d %7.1f%% %s\n",
-				row.Name, row.Scope, row.Capacity, row.Used, pct, status)
-		}
-		if warnings > 0 {
-			fmt.Fprintf(&b, "\n%d userspace buffer row(s) at high utilization\n", warnings)
-		}
+func systemBufferUsage(row systemBufferRow) (float64, string) {
+	pct := 0.0
+	if row.Capacity > 0 {
+		pct = float64(row.Used) * 100.0 / float64(row.Capacity)
 	}
-	if len(counterRows) > 0 {
-		if !strings.HasSuffix(b.String(), "\n\n") {
-			b.WriteString("\n")
-		}
-		b.WriteString(systemBufferCountersHeading + "\n")
-		fmt.Fprintf(&b, "%-32s %-24s %12s\n", "Counter", "Scope", "Value")
-		b.WriteString(strings.Repeat("-", 70) + "\n")
-		for _, row := range counterRows {
-			fmt.Fprintf(&b, "%-32s %-24s %12d\n", row.Name, row.Scope, row.Value)
-		}
+	switch {
+	case pct >= 90.0:
+		return pct, "CRITICAL"
+	case pct >= 80.0:
+		return pct, "WARNING"
+	default:
+		return pct, "OK"
 	}
-	return b.String()
 }
 
 func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {

--- a/pkg/dataplane/userspace/buffersfmt.go
+++ b/pkg/dataplane/userspace/buffersfmt.go
@@ -92,6 +92,24 @@ type SystemBufferUtilizationRow struct {
 	Status       string
 }
 
+// SystemBufferCounterRow is an unbounded userspace pressure/status counter.
+// These rows deliberately have no capacity denominator and must not be
+// rendered as fill percentages.
+type SystemBufferCounterRow struct {
+	Name  string
+	Scope string
+	Value uint64
+}
+
+// SystemBufferRows contains all structured userspace buffer/status rows that
+// non-text renderers need to mirror FormatSystemBuffers.
+type SystemBufferRows struct {
+	Utilization       []SystemBufferUtilizationRow
+	Counters          []SystemBufferCounterRow
+	KnownUMEMBindings int
+	KnownTXRings      int
+}
+
 type systemBufferCounterRow struct {
 	Name  string
 	Scope string
@@ -102,7 +120,25 @@ type systemBufferCounterRow struct {
 // rows used by FormatSystemBuffers. Missing helper capacity fields produce no
 // synthetic fill rows rather than falling back to BPF map statistics.
 func SystemBufferUtilizationRows(status ProcessStatus, detail bool) []SystemBufferUtilizationRow {
-	rows, _, _ := systemBufferRows(status, detail)
+	return StructuredSystemBufferRows(status, detail).Utilization
+}
+
+// StructuredSystemBufferRows returns helper-backed userspace buffer rows and
+// unbounded status counters using the same sampling and fallback logic as the
+// CLI/gRPC text formatter.
+func StructuredSystemBufferRows(status ProcessStatus, detail bool) SystemBufferRows {
+	samples := systemBufferSamples(status)
+	rows, knownUMEM, knownTX := systemBufferRows(status, samples, detail)
+	counterRows := systemBufferCounterRows(status, samples, detail)
+	return SystemBufferRows{
+		Utilization:       exportedSystemBufferRows(rows),
+		Counters:          exportedSystemBufferCounterRows(counterRows),
+		KnownUMEMBindings: knownUMEM,
+		KnownTXRings:      knownTX,
+	}
+}
+
+func exportedSystemBufferRows(rows []systemBufferRow) []SystemBufferUtilizationRow {
 	out := make([]SystemBufferUtilizationRow, 0, len(rows))
 	for _, row := range rows {
 		usage, state := systemBufferUsage(row)
@@ -118,13 +154,25 @@ func SystemBufferUtilizationRows(status ProcessStatus, detail bool) []SystemBuff
 	return out
 }
 
+func exportedSystemBufferCounterRows(rows []systemBufferCounterRow) []SystemBufferCounterRow {
+	out := make([]SystemBufferCounterRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, SystemBufferCounterRow{
+			Name:  row.Name,
+			Scope: row.Scope,
+			Value: row.Value,
+		})
+	}
+	return out
+}
+
 // FormatSystemBuffers renders userspace dataplane buffer capacity telemetry for
 // `show system buffers`. Capacity rows only use bounded gauges published in
 // helper status; unbounded helper counters/gauges render in a separate section
 // so missing denominators are not mistaken for real fill percentages.
 func FormatSystemBuffers(status ProcessStatus, detail bool) string {
-	rows, knownUMEM, knownTX := systemBufferRows(status, detail)
 	samples := systemBufferSamples(status)
+	rows, knownUMEM, knownTX := systemBufferRows(status, samples, detail)
 	counterRows := systemBufferCounterRows(status, samples, detail)
 
 	var b strings.Builder
@@ -166,10 +214,13 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 	return b.String()
 }
 
-func systemBufferRows(status ProcessStatus, detail bool) ([]systemBufferRow, int, int) {
+func systemBufferRows(
+	status ProcessStatus,
+	samples []systemBufferSample,
+	detail bool,
+) ([]systemBufferRow, int, int) {
 	var umemCap, umemUsed, txCap, txUsed uint64
 	var knownUMEM, knownTX int
-	samples := systemBufferSamples(status)
 	for _, sample := range samples {
 		if sample.UMEMCap > 0 {
 			knownUMEM++


### PR DESCRIPTION
## Summary

Fixes the REST gap from #1452. `/api/v1/system/buffers` now uses the
userspace helper status path when the active dataplane exposes
`Status() (userspace.ProcessStatus, error)` instead of unconditionally
rendering BPF map statistics.

The implementation exports structured userspace buffer/status rows from
the shared formatter used by CLI/gRPC. REST consumes those rows and
returns helper-backed capacity, usage, scope, WARNING/CRITICAL state, and
unbounded userspace status counters. If helper status is reachable but no
bounded capacity rows are present, REST returns a userspace-specific 503
instead of silently returning `200 []`.

The legacy eBPF map-stat fallback remains intact and is pinned by an API
test. REST capacity and usage fields are now uint64 so large CoS byte
capacities cannot overflow an int.

Docs now include REST in the #1380 userspace buffer parity contract.

## Validation

- `go test ./pkg/dataplane/userspace ./pkg/api ./pkg/cli ./pkg/grpcapi`
- `git diff --check`

Fixes #1452.
