### PR TITLE
SNAT selector userspace-v1 contract

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
@@ -108,6 +108,12 @@ algorithm version and would require explicit migration tests.
 
 ## Cross-Backend Compatibility Boundary
 
+#1450 is closed by choosing a backend-specific selector contract, not by
+standardizing the retained backends in this slice. Operators should treat
+AF_XDP userspace `address-persistent` pool selection as deterministic only
+while new allocations stay on the AF_XDP userspace backend and the pool shape
+is unchanged.
+
 The retained backends do not share an address-persistent selector today:
 
 - legacy eBPF IPv4 uses the packet-order `src_ip` word modulo the IPv4 pool
@@ -132,6 +138,11 @@ Phase 4 eBPF source removal must not use a mixed-backend rollback test that
 expects newly allocated userspace flows to match legacy eBPF/DPDK
 address-persistent pool choices unless a later PR standardizes a shared
 algorithm for all retained backends.
+
+Operationally, backend rollback is expected to preserve already-synced active
+sessions by carrying their translated tuple in session state. It is allowed to
+remap later new flows from the same client source IP to a different pool
+address after the backend changes.
 
 ## Persistent NAT Boundary
 
@@ -300,7 +311,8 @@ Covered by #1385 and this closeout:
   ranges, wrong-family-only pools, or allocation failures fail closed at all
   four `poll_descriptor.rs` source-NAT call sites instead of becoming an
   untranslated forward.
-- Cargo: userspace-v1 fixtures pin IPv4/IPv6 sticky hash outputs.
+- Cargo: userspace-v1 fixtures pin IPv4/IPv6 sticky hash outputs and selected
+  pool addresses through the source-NAT rule path.
 - Cargo: one source keeps one pool address across repeated allocations.
 - Cargo: many sources spread across the pool and do not collapse to a single
   address.

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -2331,6 +2331,67 @@ fn pool_snat_address_persistent_userspace_v1_contract_fixtures() {
 }
 
 #[test]
+fn pool_snat_address_persistent_userspace_v1_selects_pool_addresses() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "userspace-v1-selection".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string(), "::/0".to_string()],
+        pool_name: "userspace-v1-pool".to_string(),
+        pool_addresses: vec![
+            "203.0.113.10".to_string(),
+            "203.0.113.11".to_string(),
+            "203.0.113.12".to_string(),
+            "203.0.113.13".to_string(),
+            "2001:db8:ffff::10".to_string(),
+            "2001:db8:ffff::11".to_string(),
+            "2001:db8:ffff::12".to_string(),
+            "2001:db8:ffff::13".to_string(),
+        ],
+        port_low: 40000,
+        port_high: 40010,
+        address_persistent: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let cases = [
+        ("10.0.1.100", "8.8.8.8", 50000, "203.0.113.13"),
+        ("10.0.1.101", "8.8.4.4", 50001, "203.0.113.10"),
+        (
+            "2001:db8::1",
+            "2001:4860:4860::8888",
+            50002,
+            "2001:db8:ffff::12",
+        ),
+        (
+            "fd00::1234",
+            "2001:4860:4860::8844",
+            50003,
+            "2001:db8:ffff::11",
+        ),
+    ];
+
+    for (src, dst, src_port, want_src) in cases {
+        let decision = expect_snat_decision(match_source_nat_result_for_tuple(
+            &rules,
+            "lan",
+            "wan",
+            src.parse().unwrap(),
+            dst.parse().unwrap(),
+            6,
+            src_port,
+            443,
+            None,
+            None,
+            0,
+        ));
+
+        assert_eq!(decision.rewrite_src, Some(want_src.parse().unwrap()));
+        assert_eq!(decision.rewrite_src_port, Some(40000));
+    }
+}
+
+#[test]
 fn pool_snat_address_persistent_differs_from_legacy_backend_algorithms() {
     let v4: Ipv4Addr = "10.0.1.100".parse().unwrap();
     assert_eq!(sticky_pool_index(IpAddr::V4(v4), 4), 3);


### PR DESCRIPTION
## Summary

- Resolves #1450 by making the cross-backend decision explicit: AF_XDP
  userspace keeps the userspace-v1 address-persistent selector, while retained
  eBPF/DPDK new-flow choices are allowed to differ during backend rollback.
- Adds an end-to-end golden fixture through the source-NAT rule path for fixed
  IPv4 and IPv6 source-to-pool-address selections.
- Updates the #1377 SNAT pool plan with operator-facing rollback wording that
  separates synced active-session continuity from later new allocations.

## Tests

- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_address_persistent_userspace_v1`
- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_`
- `git diff --check`

Fixes #1450.
