### PR TITLE
Document SNAT restart reset boundary

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md
@@ -35,10 +35,12 @@ runtime lease reuse, and operator-visible allocation failures.
   duplicate rules cannot overbook the same translated tuple. In-process
   snapshot refreshes preserve allocator state only when the helper keeps the
   same binding-plan entries and the allocator key is unchanged. Helper restart,
-  binding-plan changes that force helper replan, and pool-shape edits reset
-  allocator state. #1449 closes the HA question by treating persistent source
-  NAT in HA as an admission boundary: userspace forwarding is blocked with an
-  explicit unsupported reason because persistent leases are not synchronized.
+  binding-plan changes that force helper replan, and pool-shape edits are
+  explicit reset boundaries: live tuple ownership, persistent leases, and
+  allocator counters are not replayed. #1449 closes the HA question by treating
+  persistent source NAT in HA as an admission boundary: userspace forwarding is
+  blocked with an explicit unsupported reason because persistent leases are not
+  synchronized.
 
 ## Current Fail-Closed Runtime Boundary
 
@@ -194,8 +196,12 @@ contract is helper-local:
 - compatible in-process snapshot refreshes preserve allocator state only when
   the helper keeps the same binding-plan entries and the concrete allocator key
   is unchanged;
-- helper restart and binding-plan changes that force helper replan reset
-  allocator live state even when the pool key is unchanged;
+- helper restart, helper cold start, and binding-plan changes that force helper
+  replan reset allocator live state even when the pool key is unchanged;
+- reset boundaries do not replay live tuple ownership, persistent leases, or
+  allocator counters. New flows allocate from fresh helper-local state; they may
+  happen to receive the same translated tuple, but that is a fresh allocation,
+  not lease continuity;
 - edits to pool name, IPv4/IPv6 address lists, address order, or port range
   replace allocator state and can reset persistent lease continuity;
 - HA configs using persistent source-NAT pools are gated before userspace
@@ -228,6 +234,13 @@ contract because the config is not admitted to userspace forwarding in the
 first place. A future PR that removes this gate must implement full lease sync
 or replay with tuple-conflict and stale-entry tests before claiming HA
 persistent-NAT support.
+
+Operators can audit the boundary through existing status and Prometheus
+counters. `Source NAT pools` status rows and the
+`xpf_userspace_source_nat_pool_*` metrics report helper-local `live_flows`,
+`used_ports`, `persistent_leases`, `allocations_total`, `reuses_total`, and
+`exhaustions_total`; after helper restart or replan these values start again
+from the new helper runtime state.
 
 The compatible-refresh boundary has two parts. First, the helper must keep the
 same binding-plan entries; binding-plan changes cause helper replan and rebuild
@@ -370,6 +383,11 @@ Covered by #1385 and this closeout:
 - Cargo: address-persistent pressure cleanup reclaims expired leases for the
   selected pool address even when the global allocation cleanup budget was spent
   on older expirations from other addresses.
+- Cargo: compatible in-process snapshot refresh preserves persistent leases,
+  tuple ownership, and allocator counters for an unchanged source-NAT pool key.
+- Cargo: helper cold start with the same snapshot resets persistent leases,
+  tuple ownership, and allocator counters; the next same-source flow is counted
+  as a new allocation rather than a lease reuse.
 - Cargo: protocol round-trip covers persistent source-NAT snapshot/status
   fields.
 
@@ -378,7 +396,7 @@ Still outside the current supported contract:
 - Integration: active userspace SNAT pool sessions preserve return traffic
   across failover, while new-flow mixed-backend rollback tests accept the
   documented selector boundary.
-- Helper-restart persistence for the persistent-NAT lease table.
+- Helper-restart lease replay beyond the documented reset boundary.
 - HA synchronization for persistent-NAT leases. The current #1449 contract is
   the explicit HA capability gate above, not partial lease replay.
 - A shared selector algorithm across eBPF, DPDK, and userspace for new-flow

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -109,6 +109,51 @@ impl super::Coordinator {
         crate::nat::source_nat_pool_statuses(&self.forwarding.source_nat_rules)
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_match_source_nat_result_for_tuple(
+        &self,
+        from_zone: &str,
+        to_zone: &str,
+        src_ip: IpAddr,
+        dst_ip: IpAddr,
+        protocol: u8,
+        src_port: u16,
+        dst_port: u16,
+        egress_v4: Option<Ipv4Addr>,
+        egress_v6: Option<Ipv6Addr>,
+        now_ns: u64,
+    ) -> crate::nat::SourceNatLookup {
+        crate::nat::match_source_nat_result_for_tuple(
+            &self.forwarding.source_nat_rules,
+            from_zone,
+            to_zone,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            egress_v4,
+            egress_v6,
+            now_ns,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_release_source_nat_allocation(
+        &self,
+        key: &crate::session::SessionKey,
+        nat: crate::nat::NatDecision,
+        now_ns: u64,
+    ) {
+        crate::nat::release_source_nat_allocation(
+            &self.forwarding.source_nat_rules,
+            key,
+            nat,
+            false,
+            now_ns,
+        );
+    }
+
     pub fn flow_worker_map(&self) -> (Vec<crate::protocol::FlowWorkerStatus>, bool) {
         const FLOW_WORKER_MAP_MAX_ROWS: usize = 4096;
         let mut out = Vec::new();

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -1072,6 +1072,181 @@ fn apply_snapshot_rejects_unsupported_protocol_version() {
         .expect("handler result");
 }
 
+fn apply_snapshot_for_test(
+    state: Arc<Mutex<ServerState>>,
+    snapshot: ConfigSnapshot,
+) -> ControlResponse {
+    let (mut client, server) = std::os::unix::net::UnixStream::pair().expect("control socket pair");
+    let running = Arc::new(AtomicBool::new(true));
+    let state_file = format!(
+        "{}/xpf-apply-snapshot-test-{}-{}.json",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        snapshot.generation
+    );
+    let handle = {
+        let state = state.clone();
+        let running = running.clone();
+        let state_file = state_file.clone();
+        std::thread::spawn(move || handle_stream(server, &state_file, state, running))
+    };
+
+    let request = ControlRequest {
+        request_type: "apply_snapshot".to_string(),
+        snapshot: Some(snapshot),
+        ..ControlRequest::default()
+    };
+    serde_json::to_writer(&mut client, &request).expect("write request");
+    std::io::Write::write_all(&mut client, b"\n").expect("newline");
+
+    let response: ControlResponse =
+        serde_json::from_reader(std::io::BufReader::new(client)).expect("read response");
+    handle
+        .join()
+        .expect("handler thread")
+        .expect("handler result");
+    let _ = std::fs::remove_file(state_file);
+    response
+}
+
+fn persistent_snat_apply_snapshot(generation: u64) -> ConfigSnapshot {
+    ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generated_at: Utc::now(),
+        generation,
+        capabilities: UserspaceCapabilities {
+            forwarding_supported: true,
+            ..UserspaceCapabilities::default()
+        },
+        source_nat_rules: vec![SourceNATRuleSnapshot {
+            name: "persistent-snat".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            pool_name: "persistent-pool".to_string(),
+            pool_addresses: vec!["203.0.113.10".to_string()],
+            port_low: 40000,
+            port_high: 40001,
+            persistent_nat: true,
+            persistent_nat_permit_any_remote_host: true,
+            persistent_nat_inactivity_timeout: 300,
+            ..SourceNATRuleSnapshot::default()
+        }],
+        ..ConfigSnapshot::default()
+    }
+}
+
+fn apply_path_persistent_snat_key(
+    src_port: u16,
+    dst_ip: std::net::IpAddr,
+    dst_port: u16,
+) -> crate::session::SessionKey {
+    crate::session::SessionKey {
+        addr_family: 2,
+        protocol: 17,
+        src_ip: "192.0.2.10".parse().unwrap(),
+        dst_ip,
+        src_port,
+        dst_port,
+    }
+}
+
+#[test]
+fn apply_snapshot_same_plan_preserves_persistent_snat_lease_state() {
+    let state = Arc::new(Mutex::new(ServerState {
+        status: ProcessStatus {
+            forwarding_armed: true,
+            capabilities: UserspaceCapabilities {
+                forwarding_supported: true,
+                ..UserspaceCapabilities::default()
+            },
+            ..ProcessStatus::default()
+        },
+        snapshot: None,
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    let initial = apply_snapshot_for_test(state.clone(), persistent_snat_apply_snapshot(1));
+    assert!(initial.ok, "initial apply failed: {}", initial.error);
+
+    let first_dst: std::net::IpAddr = "8.8.8.8".parse().unwrap();
+    let first_nat = {
+        let guard = state.lock().expect("server state");
+        match guard.afxdp.test_match_source_nat_result_for_tuple(
+            "lan",
+            "wan",
+            "192.0.2.10".parse().unwrap(),
+            first_dst,
+            17,
+            12345,
+            53,
+            None,
+            None,
+            1,
+        ) {
+            crate::nat::SourceNatLookup::Matched(decision) => decision,
+            other => panic!("unexpected first SNAT lookup result: {other:?}"),
+        }
+    };
+    {
+        let guard = state.lock().expect("server state");
+        guard.afxdp.test_release_source_nat_allocation(
+            &apply_path_persistent_snat_key(12345, first_dst, 53),
+            first_nat,
+            2,
+        );
+        let status = guard.afxdp.source_nat_pool_statuses();
+        assert_eq!(status[0].live_flows, 0);
+        assert_eq!(status[0].used_ports, 1);
+        assert_eq!(status[0].persistent_leases, 1);
+        assert_eq!(status[0].allocations_total, 1);
+        assert_eq!(status[0].reuses_total, 0);
+    }
+
+    let refresh = apply_snapshot_for_test(state.clone(), persistent_snat_apply_snapshot(2));
+    assert!(refresh.ok, "same-plan apply failed: {}", refresh.error);
+    {
+        let guard = state.lock().expect("server state");
+        let status = guard.afxdp.source_nat_pool_statuses();
+        assert_eq!(status[0].live_flows, 0);
+        assert_eq!(status[0].used_ports, 1);
+        assert_eq!(status[0].persistent_leases, 1);
+        assert_eq!(status[0].allocations_total, 1);
+        assert_eq!(status[0].reuses_total, 0);
+    }
+
+    let second_dst: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+    let reused = {
+        let guard = state.lock().expect("server state");
+        match guard.afxdp.test_match_source_nat_result_for_tuple(
+            "lan",
+            "wan",
+            "192.0.2.10".parse().unwrap(),
+            second_dst,
+            17,
+            12345,
+            443,
+            None,
+            None,
+            3,
+        ) {
+            crate::nat::SourceNatLookup::Matched(decision) => decision,
+            other => panic!("unexpected reused SNAT lookup result: {other:?}"),
+        }
+    };
+    assert_eq!(reused.rewrite_src, first_nat.rewrite_src);
+    assert_eq!(reused.rewrite_src_port, first_nat.rewrite_src_port);
+    {
+        let guard = state.lock().expect("server state");
+        let status = guard.afxdp.source_nat_pool_statuses();
+        assert_eq!(status[0].live_flows, 1);
+        assert_eq!(status[0].used_ports, 1);
+        assert_eq!(status[0].persistent_leases, 1);
+        assert_eq!(status[0].allocations_total, 1);
+        assert_eq!(status[0].reuses_total, 1);
+    }
+}
+
 #[test]
 fn binding_counters_snapshot_tolerates_pre_split_wire() {
     // #804: a helper snapshot that pre-dates the

--- a/userspace-dp/src/nat.rs
+++ b/userspace-dp/src/nat.rs
@@ -916,6 +916,11 @@ pub(crate) fn parse_source_nat_rules_with_previous(
     snaps: &[SourceNATRuleSnapshot],
     previous: Option<&[SourceNatRule]>,
 ) -> Vec<SourceNatRule> {
+    // Persistent SNAT allocator state is helper-local runtime state. A
+    // compatible in-process refresh may reuse the previous allocator below,
+    // but a helper cold start passes `None` here and intentionally resets live
+    // tuple ownership, persistent leases, and allocator counters instead of
+    // replaying unproven translated tuple ownership.
     let mut out = Vec::with_capacity(snaps.len());
     let mut previous_allocators = FxHashMap::<SourceNatPoolAllocatorKey, PortAllocator>::default();
     if let Some(prev_rules) = previous {

--- a/userspace-dp/src/nat_tests.rs
+++ b/userspace-dp/src/nat_tests.rs
@@ -873,7 +873,23 @@ fn persistent_pool_rules_with_options(
     pool_addresses: Vec<&str>,
     address_persistent: bool,
 ) -> Vec<SourceNatRule> {
-    parse_source_nat_rules(&[SourceNATRuleSnapshot {
+    parse_source_nat_rules(&[persistent_pool_snapshot(
+        timeout_secs,
+        port_low,
+        port_high,
+        pool_addresses,
+        address_persistent,
+    )])
+}
+
+fn persistent_pool_snapshot(
+    timeout_secs: i64,
+    port_low: u16,
+    port_high: u16,
+    pool_addresses: Vec<&str>,
+    address_persistent: bool,
+) -> SourceNATRuleSnapshot {
+    SourceNATRuleSnapshot {
         name: "persistent-snat".to_string(),
         from_zone: "lan".to_string(),
         to_zone: "wan".to_string(),
@@ -890,7 +906,7 @@ fn persistent_pool_rules_with_options(
         persistent_nat_permit_any_remote_host: true,
         persistent_nat_inactivity_timeout: timeout_secs,
         ..SourceNATRuleSnapshot::default()
-    }])
+    }
 }
 
 fn tuple_snat_lookup(
@@ -1079,6 +1095,79 @@ fn pool_snat_persistent_reassigns_after_timeout() {
     assert_eq!(reassigned.rewrite_src, first.rewrite_src);
     assert_ne!(reassigned.rewrite_src_port, first.rewrite_src_port);
     assert_persistent_expiry_indexes_consistent(&rules[0]);
+}
+
+#[test]
+fn pool_snat_persistent_compatible_refresh_preserves_lease_state() {
+    let snapshot = persistent_pool_snapshot(300, 40000, 40001, vec!["203.0.113.10"], false);
+    let rules = parse_source_nat_rules(&[snapshot.clone()]);
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 12345, "8.8.8.8", 53, 1));
+    release_source_nat_allocation(&rules, &session_key(12345, "8.8.8.8", 53), first, false, 2);
+
+    let before = source_nat_pool_statuses(&rules);
+    assert_eq!(before[0].live_flows, 0);
+    assert_eq!(before[0].used_ports, 1);
+    assert_eq!(before[0].persistent_leases, 1);
+    assert_eq!(before[0].allocations_total, 1);
+    assert_eq!(before[0].reuses_total, 0);
+
+    let refreshed = parse_source_nat_rules_with_previous(&[snapshot], Some(&rules));
+    let after_refresh = source_nat_pool_statuses(&refreshed);
+    assert_eq!(after_refresh[0].live_flows, 0);
+    assert_eq!(after_refresh[0].used_ports, 1);
+    assert_eq!(after_refresh[0].persistent_leases, 1);
+    assert_eq!(after_refresh[0].allocations_total, 1);
+    assert_eq!(after_refresh[0].reuses_total, 0);
+
+    let reused = expect_snat_decision(tuple_snat_lookup(&refreshed, 12345, "1.1.1.1", 443, 3));
+    assert_eq!(reused.rewrite_src, first.rewrite_src);
+    assert_eq!(reused.rewrite_src_port, first.rewrite_src_port);
+
+    let after_reuse = source_nat_pool_statuses(&refreshed);
+    assert_eq!(after_reuse[0].live_flows, 1);
+    assert_eq!(after_reuse[0].used_ports, 1);
+    assert_eq!(after_reuse[0].persistent_leases, 1);
+    assert_eq!(after_reuse[0].allocations_total, 1);
+    assert_eq!(after_reuse[0].reuses_total, 1);
+    assert_persistent_expiry_indexes_consistent(&refreshed[0]);
+}
+
+#[test]
+fn pool_snat_persistent_helper_restart_resets_lease_state() {
+    let snapshot = persistent_pool_snapshot(300, 40000, 40001, vec!["203.0.113.10"], false);
+    let rules = parse_source_nat_rules(&[snapshot.clone()]);
+    let first = expect_snat_decision(tuple_snat_lookup(&rules, 12345, "8.8.8.8", 53, 1));
+    release_source_nat_allocation(&rules, &session_key(12345, "8.8.8.8", 53), first, false, 2);
+
+    let before = source_nat_pool_statuses(&rules);
+    assert_eq!(before[0].live_flows, 0);
+    assert_eq!(before[0].used_ports, 1);
+    assert_eq!(before[0].persistent_leases, 1);
+    assert_eq!(before[0].allocations_total, 1);
+
+    // A helper restart has no previous in-process allocator to reuse. The
+    // lease table and allocator counters reset even when the snapshot is
+    // byte-identical.
+    let restarted = parse_source_nat_rules(&[snapshot]);
+    let reset = source_nat_pool_statuses(&restarted);
+    assert_eq!(reset[0].live_flows, 0);
+    assert_eq!(reset[0].used_ports, 0);
+    assert_eq!(reset[0].persistent_leases, 0);
+    assert_eq!(reset[0].allocations_total, 0);
+    assert_eq!(reset[0].reuses_total, 0);
+    assert_eq!(reset[0].exhaustion_total, 0);
+
+    let fresh = expect_snat_decision(tuple_snat_lookup(&restarted, 12345, "1.1.1.1", 443, 3));
+    assert_eq!(fresh.rewrite_src, Some("203.0.113.10".parse().unwrap()));
+    assert!(fresh.rewrite_src_port.is_some());
+
+    let after_fresh = source_nat_pool_statuses(&restarted);
+    assert_eq!(after_fresh[0].live_flows, 1);
+    assert_eq!(after_fresh[0].used_ports, 1);
+    assert_eq!(after_fresh[0].persistent_leases, 1);
+    assert_eq!(after_fresh[0].allocations_total, 1);
+    assert_eq!(after_fresh[0].reuses_total, 0);
+    assert_persistent_expiry_indexes_consistent(&restarted[0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

#1448 asks whether userspace persistent SNAT leases survive helper restart.
This PR closes the issue by making restart a documented reset boundary instead
of adding a partial persistence/replay mechanism without tuple-ownership proof.

## Implementation

- Documents that persistent SNAT allocator state is helper-local runtime state.
- Clarifies that compatible in-process refreshes may preserve allocator state,
  while helper cold start, restart, replan, and pool-shape edits reset live
  tuple ownership, persistent leases, and allocator counters.
- Documents existing operator-visible status and Prometheus counters that show
  helper-local live flows, used ports, persistent leases, allocations, reuses,
  and exhaustions after the reset.
- Adds Rust regression coverage for both sides of the boundary: unchanged
  in-process refresh preserves persistent lease state, while restart with the
  same snapshot resets leases and makes the next same-source flow a new
  allocation rather than a lease reuse.

## Tests

- `cargo test --manifest-path userspace-dp/Cargo.toml -q pool_snat_`
- `git diff --check`

Fixes #1448
