### PR TITLE
Add runtime-boundary retirement canaries

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -30,8 +30,8 @@ forwarding-source removal gate by itself.
 ## #1451 Runtime Boundary Canaries
 
 `pkg/dataplane/retirement_boundary_canary_test.go` pins the current retirement
-boundary for #1451. It is intentionally narrow and deterministic: it parses
-production Go files in the operator/runtime packages and fails if a new direct
+boundary for #1451. It discovers every top-level `cmd/*` and `pkg/*`
+production Go package except `pkg/dataplane` itself, then fails if a new direct
 `github.com/psaab/xpf/pkg/dataplane` import appears outside the allowlist below,
 or if a listed bridge disappears without shrinking this documentation.
 
@@ -39,7 +39,9 @@ The same canary also keeps operator packages away from direct BPF artifacts:
 they may not import `github.com/cilium/ebpf`, and the DPDK backend import stays
 limited to `cmd/xpfd/main.go` for backend registration. Daemon startup must keep
 owning `dataplane.RuntimeDataPlane` and must call
-`dataplane.NewRuntimeDataPlane`, not `dataplane.NewDataPlane`.
+`dataplane.NewRuntimeDataPlane`, not `dataplane.NewDataPlane`. This is a
+production-code canary; `_test.go` files may still import lower-level helpers
+when they need backend fixtures for regression coverage.
 
 ### Allowlisted Legacy Bridges
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -27,6 +27,89 @@ and BPF build rules can be removed. #1380 is a Phase 5 CLI/observability cleanup
 item, now closed for the current helper schema; it does not block the Phase 4
 forwarding-source removal gate by itself.
 
+## #1451 Runtime Boundary Canaries
+
+`pkg/dataplane/retirement_boundary_canary_test.go` pins the current retirement
+boundary for #1451. It is intentionally narrow and deterministic: it parses
+production Go files in the operator/runtime packages and fails if a new direct
+`github.com/psaab/xpf/pkg/dataplane` import appears outside the allowlist below,
+or if a listed bridge disappears without shrinking this documentation.
+
+The same canary also keeps operator packages away from direct BPF artifacts:
+they may not import `github.com/cilium/ebpf`, and the DPDK backend import stays
+limited to `cmd/xpfd/main.go` for backend registration. Daemon startup must keep
+owning `dataplane.RuntimeDataPlane` and must call
+`dataplane.NewRuntimeDataPlane`, not `dataplane.NewDataPlane`.
+
+### Allowlisted Legacy Bridges
+
+These files are the current production direct-import allowlist for root
+`pkg/dataplane`. New migration PRs should remove entries from this table as
+surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
+`Telemetry`, or package-local accessor interfaces. Adding a new entry means
+#1451 is moving backward and requires an explicit design reason.
+
+| File | Current blocker |
+|---|---|
+| `cmd/xpfd/main.go` | Backend selection, cleanup, and backend registration still cross the root package. |
+| `pkg/api/handlers.go` | REST handlers still receive the legacy dataplane bridge. |
+| `pkg/api/handlers_sessions.go` | REST session reads still use legacy session types. |
+| `pkg/api/metrics.go` | Prometheus telemetry still reads legacy counters and metadata. |
+| `pkg/api/server.go` | REST server construction still stores the legacy bridge. |
+| `pkg/cli/cli.go` | Embedded CLI construction still stores the legacy bridge. |
+| `pkg/cli/cli_clear.go` | Clear commands still delete legacy session entries. |
+| `pkg/cli/cli_show_cluster.go` | Cluster display still reads legacy dataplane state. |
+| `pkg/cli/cli_show_flow.go` | Flow display still uses legacy session keys and values. |
+| `pkg/cli/cli_show_nat.go` | NAT display still uses legacy NAT/session metadata. |
+| `pkg/cli/cli_show_security.go` | Security display still uses legacy counters and filter types. |
+| `pkg/cluster/sync.go` | Session sync still installs sessions through the legacy bridge. |
+| `pkg/cluster/sync_bulk.go` | Bulk sync still serializes legacy session entries. |
+| `pkg/cluster/sync_conn.go` | Sync connection code still references legacy session types. |
+| `pkg/cluster/sync_protocol.go` | Wire protocol still carries legacy session records. |
+| `pkg/conntrack/gc.go` | GC compatibility construction still adapts legacy sessions. |
+| `pkg/daemon/daemon.go` | Daemon owns `RuntimeDataPlane` and exposes `legacyDP()` for unmigrated callers. |
+| `pkg/daemon/daemon_apply.go` | Apply path still adapts legacy compile/apply metadata. |
+| `pkg/daemon/daemon_flow.go` | Flow logging still formats legacy dataplane counters. |
+| `pkg/daemon/daemon_ha.go` | HA state updates still call legacy bridge methods. |
+| `pkg/daemon/daemon_ha_fabric.go` | Fabric HA updates still call legacy bridge methods. |
+| `pkg/daemon/daemon_ha_userspace.go` | Userspace HA control still crosses the legacy bridge. |
+| `pkg/daemon/daemon_run.go` | Runtime wiring still passes `legacyDP()` to unmigrated services. |
+| `pkg/fwdstatus/builder.go` | Forwarding status still reads legacy map stats. |
+| `pkg/grpcapi/apply_result.go` | gRPC apply metadata still adapts legacy apply results. |
+| `pkg/grpcapi/server.go` | gRPC server construction still stores the legacy bridge. |
+| `pkg/grpcapi/server_helpers.go` | gRPC helpers still format legacy dataplane types. |
+| `pkg/grpcapi/server_nat.go` | gRPC NAT output still reads legacy NAT/session metadata. |
+| `pkg/grpcapi/server_sessions.go` | gRPC session RPCs still use legacy session types. |
+| `pkg/grpcapi/server_show.go` | gRPC show dispatcher still reaches legacy dataplane state. |
+| `pkg/grpcapi/server_show_cluster_text.go` | Cluster text output still reads legacy dataplane state. |
+| `pkg/grpcapi/server_show_flow.go` | Flow text output still uses legacy session keys and values. |
+| `pkg/grpcapi/server_show_nat.go` | NAT text output still uses legacy NAT/session metadata. |
+| `pkg/grpcapi/server_show_policies_text.go` | Policy text output still uses legacy counters. |
+| `pkg/grpcapi/server_show_security_text.go` | Security text output still uses legacy counters and filter types. |
+| `pkg/grpcapi/server_show_status.go` | Status output still reads legacy dataplane state. |
+| `pkg/grpcapi/server_show_zones.go` | Zone output still uses legacy dataplane types. |
+| `pkg/logging/ringbuf.go` | Event reader still consumes the legacy `EventSource`. |
+| `pkg/monitoriface/monitor.go` | Interface monitor still reads legacy interface counters. |
+
+### Safe-Delete Blockers
+
+- `pkg/dataplane.DataPlane` is still load-bearing for API, gRPC, CLI, status,
+  monitor, logging, cluster session sync, conntrack GC, daemon HA, daemon flow,
+  and daemon apply bridges listed above.
+- `pkg/dataplane/userspace.LegacyDataPlaneAdapter` is still required because
+  userspace runtime construction returns a legacy-compatible adapter while
+  unmigrated operator services consume old session, telemetry, and control
+  methods. The userspace `Manager` itself must not implement `DataPlane`.
+- DPDK still implements both `DataPlane` and `RuntimeDataPlane`; the only
+  direct DPDK backend import outside `pkg/dataplane` should remain the blank
+  registration import in `cmd/xpfd/main.go`.
+- BPF source and build artifacts are not safe to delete in #1451 canary work:
+  `bpf/`, `pkg/dataplane/loader_ebpf.go`,
+  `pkg/dataplane/*_bpfel.go`, `pkg/dataplane/*_bpfel.o`,
+  `pkg/dataplane/userspace_xdp_bpfel.o`,
+  `pkg/dataplane/build-userspace-xdp.sh`, and the `Makefile generate` path
+  remain tied to the eBPF backend and userspace XDP shim.
+
 ## Phase 1/2 Smoke Gates
 
 Use [smoke-gates.md](smoke-gates.md) for the repeatable Phase 1/2 operator

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -19,20 +19,6 @@ const (
 	retirementBoundaryDocsForCanary = "../../docs/pr/1373-retire-ebpf-dataplane/README.md"
 )
 
-var operatorRuntimeBoundaryRoots = []string{
-	"../../cmd/cli",
-	"../../cmd/xpfd",
-	"../api",
-	"../cli",
-	"../cluster",
-	"../conntrack",
-	"../daemon",
-	"../fwdstatus",
-	"../grpcapi",
-	"../logging",
-	"../monitoriface",
-}
-
 var legacyDataplaneImportAllowlist = map[string]string{
 	"cmd/xpfd/main.go":                         "backend selection, cleanup, and backend registration",
 	"pkg/api/handlers.go":                      "REST handlers still receive the legacy dataplane bridge",
@@ -80,7 +66,7 @@ func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
 
 	found := map[string]bool{}
 	var unexpected []string
-	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots) {
+	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots(t)) {
 		for _, imp := range importPaths(t, path) {
 			if imp != rootDataplaneImportForCanary {
 				continue
@@ -104,7 +90,7 @@ func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
 		sort.Strings(unexpected)
 		sort.Strings(stale)
 		t.Fatalf(
-			"legacy pkg/dataplane import allowlist drift\nunexpected imports: %v\nstale allowlist entries: %v\nupdate the #1451 runtime-boundary docs with any intentional change",
+			"legacy pkg/dataplane import allowlist drift\nunexpected imports: %v\nstale allowlist entries: %v\nupdate legacyDataplaneImportAllowlist and the #1451 docs table with any intentional change",
 			unexpected,
 			stale,
 		)
@@ -115,7 +101,7 @@ func TestOperatorPackagesDoNotImportBPFArtifactsDirectly(t *testing.T) {
 	t.Parallel()
 
 	var violations []string
-	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots) {
+	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots(t)) {
 		rel := repoRelativePath(t, path)
 		for _, imp := range importPaths(t, path) {
 			if imp == ciliumEBPFImportForCanary || strings.HasPrefix(imp, ciliumEBPFImportForCanary+"/") {
@@ -140,15 +126,11 @@ func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
 
 	assertDaemonDPFieldIsRuntimeDataPlane(t)
 
-	data, err := os.ReadFile(filepath.Join("..", "daemon", "daemon_run.go"))
-	if err != nil {
-		t.Fatalf("read daemon_run.go: %v", err)
-	}
-	text := string(data)
-	if strings.Contains(text, "dataplane.NewDataPlane(") {
+	daemonRun := filepath.Join("..", "daemon", "daemon_run.go")
+	if hasDaemonRuntimeConstructorCall(t, daemonRun, "NewDataPlane") {
 		t.Fatal("daemon runtime startup must call NewRuntimeDataPlane, not NewDataPlane")
 	}
-	if !strings.Contains(text, "dataplane.NewRuntimeDataPlane(") {
+	if !hasDaemonRuntimeConstructorCall(t, daemonRun, "NewRuntimeDataPlane") {
 		t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")
 	}
 }
@@ -172,6 +154,36 @@ func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
 	if len(missing) > 0 {
 		t.Fatalf("retirement docs do not mention allowlisted legacy imports: %v", missing)
 	}
+}
+
+func operatorRuntimeBoundaryRoots(t *testing.T) []string {
+	t.Helper()
+
+	var roots []string
+	for _, pattern := range []string{
+		filepath.Join(repoRootForBoundaryCanary, "cmd", "*"),
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "*"),
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			t.Fatalf("glob %s: %v", pattern, err)
+		}
+		for _, path := range matches {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s: %v", path, err)
+			}
+			if !info.IsDir() {
+				continue
+			}
+			if repoRelativePath(t, path) == "pkg/dataplane" {
+				continue
+			}
+			roots = append(roots, path)
+		}
+	}
+	sort.Strings(roots)
+	return roots
 }
 
 func productionGoFilesUnder(t *testing.T, roots []string) []string {
@@ -235,6 +247,31 @@ func repoRelativePath(t *testing.T, path string) string {
 		t.Fatalf("rel path for %s: %v", path, err)
 	}
 	return filepath.ToSlash(rel)
+}
+
+func hasDaemonRuntimeConstructorCall(t *testing.T, path, name string) bool {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	want := "dataplane." + name
+	var found bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if canaryExprString(call.Fun) == want {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func assertDaemonDPFieldIsRuntimeDataPlane(t *testing.T) {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -1,0 +1,289 @@
+package dataplane
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	repoRootForBoundaryCanary       = "../.."
+	rootDataplaneImportForCanary    = "github.com/psaab/xpf/pkg/dataplane"
+	ciliumEBPFImportForCanary       = "github.com/cilium/ebpf"
+	dpdkBackendImportForCanary      = "github.com/psaab/xpf/pkg/dataplane/dpdk"
+	retirementBoundaryDocsForCanary = "../../docs/pr/1373-retire-ebpf-dataplane/README.md"
+)
+
+var operatorRuntimeBoundaryRoots = []string{
+	"../../cmd/cli",
+	"../../cmd/xpfd",
+	"../api",
+	"../cli",
+	"../cluster",
+	"../conntrack",
+	"../daemon",
+	"../fwdstatus",
+	"../grpcapi",
+	"../logging",
+	"../monitoriface",
+}
+
+var legacyDataplaneImportAllowlist = map[string]string{
+	"cmd/xpfd/main.go":                         "backend selection, cleanup, and backend registration",
+	"pkg/api/handlers.go":                      "REST handlers still receive the legacy dataplane bridge",
+	"pkg/api/handlers_sessions.go":             "REST session reads still use legacy session types",
+	"pkg/api/metrics.go":                       "Prometheus telemetry still reads legacy counters and metadata",
+	"pkg/api/server.go":                        "REST server constructor still stores the legacy bridge",
+	"pkg/cli/cli.go":                           "embedded CLI constructor still stores the legacy bridge",
+	"pkg/cli/cli_clear.go":                     "clear commands still delete legacy session entries",
+	"pkg/cli/cli_show_cluster.go":              "cluster display still reads legacy dataplane state",
+	"pkg/cli/cli_show_flow.go":                 "flow display still uses legacy session keys and values",
+	"pkg/cli/cli_show_nat.go":                  "NAT display still uses legacy NAT/session metadata",
+	"pkg/cli/cli_show_security.go":             "security display still uses legacy counters and filter types",
+	"pkg/cluster/sync.go":                      "session sync still installs sessions through the legacy bridge",
+	"pkg/cluster/sync_bulk.go":                 "bulk sync still serializes legacy session entries",
+	"pkg/cluster/sync_conn.go":                 "sync connection code still references legacy session types",
+	"pkg/cluster/sync_protocol.go":             "wire protocol still carries legacy session records",
+	"pkg/conntrack/gc.go":                      "GC compatibility constructor still adapts legacy sessions",
+	"pkg/daemon/daemon.go":                     "daemon owns RuntimeDataPlane and exposes legacyDP for unmigrated callers",
+	"pkg/daemon/daemon_apply.go":               "apply path still adapts legacy compile/apply metadata",
+	"pkg/daemon/daemon_flow.go":                "flow logging still formats legacy dataplane counters",
+	"pkg/daemon/daemon_ha.go":                  "HA state updates still call legacy bridge methods",
+	"pkg/daemon/daemon_ha_fabric.go":           "fabric HA updates still call legacy bridge methods",
+	"pkg/daemon/daemon_ha_userspace.go":        "userspace HA control still crosses the legacy bridge",
+	"pkg/daemon/daemon_run.go":                 "runtime wiring still passes legacyDP to unmigrated services",
+	"pkg/fwdstatus/builder.go":                 "forwarding status still reads legacy map stats",
+	"pkg/grpcapi/apply_result.go":              "gRPC apply metadata still adapts legacy apply results",
+	"pkg/grpcapi/server.go":                    "gRPC server constructor still stores the legacy bridge",
+	"pkg/grpcapi/server_helpers.go":            "gRPC helpers still format legacy dataplane types",
+	"pkg/grpcapi/server_nat.go":                "gRPC NAT output still reads legacy NAT/session metadata",
+	"pkg/grpcapi/server_sessions.go":           "gRPC session RPCs still use legacy session types",
+	"pkg/grpcapi/server_show.go":               "gRPC show dispatcher still reaches legacy dataplane state",
+	"pkg/grpcapi/server_show_cluster_text.go":  "cluster text output still reads legacy dataplane state",
+	"pkg/grpcapi/server_show_flow.go":          "flow text output still uses legacy session keys and values",
+	"pkg/grpcapi/server_show_nat.go":           "NAT text output still uses legacy NAT/session metadata",
+	"pkg/grpcapi/server_show_policies_text.go": "policy text output still uses legacy counters",
+	"pkg/grpcapi/server_show_security_text.go": "security text output still uses legacy counters and filter types",
+	"pkg/grpcapi/server_show_status.go":        "status output still reads legacy dataplane state",
+	"pkg/grpcapi/server_show_zones.go":         "zone output still uses legacy dataplane types",
+	"pkg/logging/ringbuf.go":                   "event reader still consumes the legacy EventSource",
+	"pkg/monitoriface/monitor.go":              "interface monitor still reads legacy interface counters",
+}
+
+func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
+	t.Parallel()
+
+	found := map[string]bool{}
+	var unexpected []string
+	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots) {
+		for _, imp := range importPaths(t, path) {
+			if imp != rootDataplaneImportForCanary {
+				continue
+			}
+			rel := repoRelativePath(t, path)
+			found[rel] = true
+			if _, ok := legacyDataplaneImportAllowlist[rel]; !ok {
+				unexpected = append(unexpected, rel)
+			}
+		}
+	}
+
+	var stale []string
+	for rel := range legacyDataplaneImportAllowlist {
+		if !found[rel] {
+			stale = append(stale, rel)
+		}
+	}
+
+	if len(unexpected) > 0 || len(stale) > 0 {
+		sort.Strings(unexpected)
+		sort.Strings(stale)
+		t.Fatalf(
+			"legacy pkg/dataplane import allowlist drift\nunexpected imports: %v\nstale allowlist entries: %v\nupdate the #1451 runtime-boundary docs with any intentional change",
+			unexpected,
+			stale,
+		)
+	}
+}
+
+func TestOperatorPackagesDoNotImportBPFArtifactsDirectly(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	for _, path := range productionGoFilesUnder(t, operatorRuntimeBoundaryRoots) {
+		rel := repoRelativePath(t, path)
+		for _, imp := range importPaths(t, path) {
+			if imp == ciliumEBPFImportForCanary || strings.HasPrefix(imp, ciliumEBPFImportForCanary+"/") {
+				violations = append(violations, rel+" imports "+imp)
+			}
+			if imp == dpdkBackendImportForCanary || strings.HasPrefix(imp, dpdkBackendImportForCanary+"/") {
+				if rel != "cmd/xpfd/main.go" {
+					violations = append(violations, rel+" imports "+imp)
+				}
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("operator packages must stay behind RuntimeDataPlane/BPF artifact boundaries: %v", violations)
+	}
+}
+
+func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
+	t.Parallel()
+
+	assertDaemonDPFieldIsRuntimeDataPlane(t)
+
+	data, err := os.ReadFile(filepath.Join("..", "daemon", "daemon_run.go"))
+	if err != nil {
+		t.Fatalf("read daemon_run.go: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "dataplane.NewDataPlane(") {
+		t.Fatal("daemon runtime startup must call NewRuntimeDataPlane, not NewDataPlane")
+	}
+	if !strings.Contains(text, "dataplane.NewRuntimeDataPlane(") {
+		t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")
+	}
+}
+
+func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
+	if err != nil {
+		t.Fatalf("read retirement boundary docs: %v", err)
+	}
+	text := string(data)
+
+	var missing []string
+	for rel := range legacyDataplaneImportAllowlist {
+		if !strings.Contains(text, rel) {
+			missing = append(missing, rel)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("retirement docs do not mention allowlisted legacy imports: %v", missing)
+	}
+}
+
+func productionGoFilesUnder(t *testing.T, roots []string) []string {
+	t.Helper()
+
+	var files []string
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			files = append(files, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+func importPaths(t *testing.T, path string) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse imports for %s: %v", path, err)
+	}
+
+	imports := make([]string, 0, len(file.Imports))
+	for _, imp := range file.Imports {
+		imports = append(imports, strings.Trim(imp.Path.Value, `"`))
+	}
+	return imports
+}
+
+func repoRelativePath(t *testing.T, path string) string {
+	t.Helper()
+
+	root, err := filepath.Abs(repoRootForBoundaryCanary)
+	if err != nil {
+		t.Fatalf("abs repo root: %v", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("abs path for %s: %v", path, err)
+	}
+	rel, err := filepath.Rel(root, absPath)
+	if err != nil {
+		t.Fatalf("rel path for %s: %v", path, err)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func assertDaemonDPFieldIsRuntimeDataPlane(t *testing.T) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join("..", "daemon", "daemon.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse daemon.go: %v", err)
+	}
+
+	var found bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		typeSpec, ok := n.(*ast.TypeSpec)
+		if !ok || typeSpec.Name.Name != "Daemon" {
+			return true
+		}
+		st, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			t.Fatalf("Daemon is %T, want struct", typeSpec.Type)
+		}
+		for _, field := range st.Fields.List {
+			for _, name := range field.Names {
+				if name.Name != "dp" {
+					continue
+				}
+				found = true
+				if got := canaryExprString(field.Type); got != "dataplane.RuntimeDataPlane" {
+					t.Fatalf("Daemon.dp = %s, want dataplane.RuntimeDataPlane", got)
+				}
+			}
+		}
+		return false
+	})
+
+	if !found {
+		t.Fatal("Daemon.dp field not found")
+	}
+}
+
+func canaryExprString(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return canaryExprString(e.X) + "." + e.Sel.Name
+	case *ast.StarExpr:
+		return "*" + canaryExprString(e.X)
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Refs #1451.

## Summary
- add a deterministic Go canary that pins the current production direct-import allowlist for root `pkg/dataplane` across operator/runtime packages
- fail on new undocumented legacy imports, stale allowlist entries, direct operator imports of `cilium/ebpf`, or DPDK backend imports outside `cmd/xpfd/main.go`
- guard the migrated daemon startup boundary by asserting `Daemon.dp` remains `RuntimeDataPlane` and startup uses `NewRuntimeDataPlane`
- document the current #1451 allowlist and safe-delete blockers for the next migration PRs

## What this protects
- prevents new API/gRPC/CLI/status/daemon/cluster/GC/logging/monitor bridges from growing direct `pkg/dataplane.DataPlane` dependencies silently
- keeps BPF source/build artifacts isolated behind the root dataplane backend instead of leaking into operator packages
- keeps the userspace runtime path on the domain-facing `RuntimeDataPlane` entry point while legacy bridges are retired incrementally

## Remaining #1451 work
- migrate the allowlisted API, gRPC, CLI, status, session sync, GC, logging, monitor, HA, flow, and apply bridges to domain-specific interfaces
- retire `userspace.LegacyDataPlaneAdapter` only after unmigrated operator services stop requiring the old BPF-shaped surface
- remove BPF source/generated artifacts only after the legacy root dataplane surface is no longer load-bearing

## Validation
- `go test ./pkg/dataplane`
- `go test ./pkg/api ./pkg/cli ./pkg/grpcapi ./pkg/daemon ./pkg/fwdstatus ./pkg/conntrack ./pkg/cluster ./pkg/logging ./pkg/monitoriface`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
