### PR TITLE
Reconcile deferred workers on same-plan snapshots

### DIFF
--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -903,6 +903,126 @@ fn binding_counters_snapshot_serializes_with_expected_wire_keys() {
     assert_eq!(round, snap);
 }
 
+fn run_control_request(
+    state: Arc<Mutex<ServerState>>,
+    state_file: &str,
+    request: ControlRequest,
+) -> ControlResponse {
+    let (mut client, server) = std::os::unix::net::UnixStream::pair().expect("control socket pair");
+    let running = Arc::new(AtomicBool::new(true));
+    let state_file = state_file.to_string();
+    let handle = std::thread::spawn(move || handle_stream(server, &state_file, state, running));
+
+    serde_json::to_writer(&mut client, &request).expect("write request");
+    std::io::Write::write_all(&mut client, b"\n").expect("newline");
+
+    let response: ControlResponse =
+        serde_json::from_reader(std::io::BufReader::new(client)).expect("read response");
+    handle
+        .join()
+        .expect("handler thread")
+        .expect("handler result");
+    response
+}
+
+#[test]
+fn apply_snapshot_same_plan_clearing_defer_workers_reconciles_bindings() {
+    let state = Arc::new(Mutex::new(ServerState {
+        status: ProcessStatus {
+            workers: 1,
+            ring_entries: 64,
+            forwarding_armed: true,
+            capabilities: UserspaceCapabilities {
+                forwarding_supported: true,
+                unsupported_reasons: Vec::new(),
+            },
+            ..ProcessStatus::default()
+        },
+        snapshot: None,
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+    let state_file = format!(
+        "{}/xpf-defer-workers-reconcile-{}.json",
+        std::env::temp_dir().display(),
+        std::process::id()
+    );
+    let _ = std::fs::remove_file(&state_file);
+
+    let deferred_snapshot = ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 1,
+        fib_generation: 1,
+        generated_at: Utc::now(),
+        capabilities: UserspaceCapabilities {
+            forwarding_supported: true,
+            unsupported_reasons: Vec::new(),
+        },
+        userspace: serde_json::json!({
+            "workers": 1,
+            "ring_entries": 64,
+        }),
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/1.0".to_string(),
+            zone: "lan".to_string(),
+            linux_name: "ge-0-0-1".to_string(),
+            ifindex: 11,
+            rx_queues: 1,
+            ..InterfaceSnapshot::default()
+        }],
+        defer_workers: true,
+        ..ConfigSnapshot::default()
+    };
+
+    let response = run_control_request(
+        state.clone(),
+        &state_file,
+        ControlRequest {
+            request_type: "apply_snapshot".to_string(),
+            snapshot: Some(deferred_snapshot.clone()),
+            ..ControlRequest::default()
+        },
+    );
+    assert!(response.ok, "unexpected error: {}", response.error);
+    let status = response.status.expect("status response");
+    assert_eq!(status.debug_reconcile_calls, 0);
+    assert_eq!(status.bindings.len(), 1);
+    assert!(status.bindings[0].registered);
+    assert!(status.bindings[0].last_error.is_empty());
+
+    let mut resumed_snapshot = deferred_snapshot.clone();
+    resumed_snapshot.generation = 2;
+    resumed_snapshot.fib_generation = 2;
+    resumed_snapshot.generated_at = Utc::now();
+    resumed_snapshot.defer_workers = false;
+    assert!(same_binding_plan(&deferred_snapshot, &resumed_snapshot));
+
+    let response = run_control_request(
+        state.clone(),
+        &state_file,
+        ControlRequest {
+            request_type: "apply_snapshot".to_string(),
+            snapshot: Some(resumed_snapshot),
+            ..ControlRequest::default()
+        },
+    );
+    assert!(response.ok, "unexpected error: {}", response.error);
+    let status = response.status.expect("status response");
+    assert_eq!(status.debug_reconcile_calls, 1);
+    assert_eq!(status.debug_reconcile_stage, "missing_xsk_pin");
+    assert!(
+        !state
+            .lock()
+            .expect("state poisoned")
+            .snapshot
+            .as_ref()
+            .expect("snapshot")
+            .defer_workers
+    );
+
+    let _ = std::fs::remove_file(&state_file);
+}
+
 #[test]
 fn apply_snapshot_rejects_unsupported_protocol_version() {
     let (mut client, server) = std::os::unix::net::UnixStream::pair().expect("control socket pair");

--- a/userspace-dp/src/server/handlers.rs
+++ b/userspace-dp/src/server/handlers.rs
@@ -70,8 +70,11 @@ pub(crate) fn handle_stream(
                         guard.status.last_snapshot_at = Some(snapshot.generated_at);
                         guard.status.capabilities = snapshot.capabilities.clone();
                         let existing_bindings = guard.status.bindings.clone();
-                        let previous_snapshot = guard.snapshot.as_ref();
-                        let same_plan = previous_snapshot.is_some_and(|prev| {
+                        let previous_defer_workers = guard
+                            .snapshot
+                            .as_ref()
+                            .is_some_and(|prev| prev.defer_workers);
+                        let same_plan = guard.snapshot.as_ref().is_some_and(|prev| {
                             let prev_key = snapshot_binding_plan_key(prev);
                             let next_key = snapshot_binding_plan_key(&snapshot);
                             let same = prev_key == next_key;
@@ -84,8 +87,21 @@ pub(crate) fn handle_stream(
                             same
                         });
                         if same_plan {
-                            guard.afxdp.refresh_runtime_snapshot(&snapshot);
-                            guard.snapshot = Some(snapshot);
+                            let needs_reconcile = same_plan_apply_needs_binding_reconcile(
+                                &guard,
+                                previous_defer_workers,
+                                snapshot.defer_workers,
+                            );
+                            if needs_reconcile {
+                                eprintln!(
+                                    "CTRL_REQ: same-plan apply_snapshot reconciling deferred bindings"
+                                );
+                                guard.snapshot = Some(snapshot);
+                                reconcile_status_bindings(&mut guard);
+                            } else {
+                                guard.afxdp.refresh_runtime_snapshot(&snapshot);
+                                guard.snapshot = Some(snapshot);
+                            }
                             refresh_status(&mut guard);
                             persist_state = true;
                         } else {

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -289,6 +289,39 @@ pub(crate) fn should_run_afxdp(status: &ProcessStatus) -> bool {
     status.forwarding_armed && status.capabilities.forwarding_supported
 }
 
+pub(crate) fn same_plan_apply_needs_binding_reconcile(
+    state: &ServerState,
+    previous_defer_workers: bool,
+    next_defer_workers: bool,
+) -> bool {
+    if next_defer_workers || !should_run_afxdp(&state.status) {
+        return false;
+    }
+
+    let runnable_bindings = state
+        .status
+        .bindings
+        .iter()
+        .filter(|binding| binding.registered && binding.ifindex > 0)
+        .count();
+    if runnable_bindings == 0 {
+        return false;
+    }
+    if previous_defer_workers {
+        return true;
+    }
+
+    let (_, planned_bindings) = state.afxdp.planned_counts();
+    let live_bindings = state.afxdp.live_count();
+    (planned_bindings < runnable_bindings || live_bindings < runnable_bindings)
+        && state.status.bindings.iter().any(|binding| {
+            binding.registered
+                && binding.ifindex > 0
+                && binding.last_error.is_empty()
+                && (!binding.bound || !binding.xsk_registered)
+        })
+}
+
 pub(crate) fn set_bindings_forwarding_armed(status: &mut ProcessStatus, armed: bool) {
     for binding in &mut status.bindings {
         binding.armed = armed && binding.registered;


### PR DESCRIPTION
## Summary
- Fix userspace-dp apply_snapshot when defer_workers clears without a binding-plan key change.
- Reconcile same-plan snapshots if the previous snapshot deferred workers or registered bindings still have no planned/live AF_XDP state.
- Preserve the cheap refresh_runtime_snapshot path for normal same-plan config updates.

## Tests
- cargo test apply_snapshot_same_plan_clearing_defer_workers_reconciles_bindings -- --nocapture
- cargo test apply_snapshot -- --nocapture
- git diff --check

Fixes #1466
