### PR TITLE
Shrink fwdstatus dataplane bridge

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -76,7 +76,6 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/daemon/daemon_ha_fabric.go` | Fabric HA updates still call legacy bridge methods. |
 | `pkg/daemon/daemon_ha_userspace.go` | Userspace HA control still crosses the legacy bridge. |
 | `pkg/daemon/daemon_run.go` | Runtime wiring still passes `legacyDP()` to unmigrated services. |
-| `pkg/fwdstatus/builder.go` | Forwarding status still reads legacy map stats. |
 | `pkg/grpcapi/apply_result.go` | gRPC apply metadata still adapts legacy apply results. |
 | `pkg/grpcapi/server.go` | gRPC server construction still stores the legacy bridge. |
 | `pkg/grpcapi/server_helpers.go` | gRPC helpers still format legacy dataplane types. |

--- a/pkg/cli/cli_show_chassis.go
+++ b/pkg/cli/cli_show_chassis.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/fwdstatus"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/metadata"
@@ -56,7 +57,7 @@ func (c *CLI) buildLocalForwarding() (string, error) {
 		snap = c.fwdSampler.Snapshot()
 	}
 	fs, err := fwdstatus.Build(
-		c.dp,
+		c.forwardingStatusDataplane(),
 		fwdstatus.OSProcReader{},
 		c.startTime,
 		snap,
@@ -65,6 +66,51 @@ func (c *CLI) buildLocalForwarding() (string, error) {
 		return "", fmt.Errorf("build forwarding status: %w", err)
 	}
 	return fwdstatus.Format(fs), nil
+}
+
+type forwardingStatusCLIDataPlane struct {
+	cli *CLI
+}
+
+func (a forwardingStatusCLIDataPlane) IsLoaded() bool {
+	return a.cli != nil && a.cli.dp != nil && a.cli.dp.IsLoaded()
+}
+
+func (a forwardingStatusCLIDataPlane) GetMapStats() []fwdstatus.MapStats {
+	if a.cli == nil || a.cli.dp == nil {
+		return nil
+	}
+	stats := a.cli.dp.GetMapStats()
+	out := make([]fwdstatus.MapStats, 0, len(stats))
+	for _, ms := range stats {
+		out = append(out, fwdstatus.MapStats{
+			Type:       ms.Type,
+			MaxEntries: ms.MaxEntries,
+			UsedCount:  ms.UsedCount,
+		})
+	}
+	return out
+}
+
+type forwardingStatusCLIUserspaceDataPlane struct {
+	forwardingStatusCLIDataPlane
+}
+
+func (a forwardingStatusCLIUserspaceDataPlane) Status() (dpuserspace.ProcessStatus, error) {
+	return a.cli.userspaceDataplaneStatus()
+}
+
+func (c *CLI) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
+	if c == nil || c.dp == nil {
+		return nil
+	}
+	base := forwardingStatusCLIDataPlane{cli: c}
+	if _, ok := c.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		return forwardingStatusCLIUserspaceDataPlane{forwardingStatusCLIDataPlane: base}
+	}
+	return base
 }
 
 // dialAndShowForwarding queries the cluster peer for its single-node

--- a/pkg/cli/cli_show_chassis_adapter_test.go
+++ b/pkg/cli/cli_show_chassis_adapter_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/fwdstatus"
+)
+
+type forwardingStatusCLITestDP struct {
+	dataplane.DataPlane
+
+	loaded   bool
+	mapStats []dataplane.MapStats
+}
+
+func (f *forwardingStatusCLITestDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *forwardingStatusCLITestDP) GetMapStats() []dataplane.MapStats {
+	return f.mapStats
+}
+
+type forwardingStatusCLIUserspaceTestDP struct {
+	*forwardingStatusCLITestDP
+
+	status      dpuserspace.ProcessStatus
+	statusCalls int
+}
+
+func (f *forwardingStatusCLIUserspaceTestDP) Status() (dpuserspace.ProcessStatus, error) {
+	f.statusCalls++
+	return f.status, nil
+}
+
+func TestForwardingStatusDataplaneProjectsMapStats(t *testing.T) {
+	dp := &forwardingStatusCLITestDP{
+		loaded: true,
+		mapStats: []dataplane.MapStats{
+			{
+				Name:       "sessions",
+				Type:       "Hash",
+				MaxEntries: 128,
+				UsedCount:  32,
+				KeySize:    16,
+				ValueSize:  64,
+			},
+			{
+				Name:       "zone_configs",
+				Type:       "Array",
+				MaxEntries: 4,
+				UsedCount:  4,
+				KeySize:    4,
+				ValueSize:  32,
+			},
+		},
+	}
+	c := &CLI{dp: dp}
+
+	accessor := c.forwardingStatusDataplane()
+	if accessor == nil {
+		t.Fatal("forwardingStatusDataplane() returned nil")
+	}
+	if !accessor.IsLoaded() {
+		t.Fatal("IsLoaded() = false, want true")
+	}
+
+	got := accessor.GetMapStats()
+	want := []fwdstatus.MapStats{
+		{Type: "Hash", MaxEntries: 128, UsedCount: 32},
+		{Type: "Array", MaxEntries: 4, UsedCount: 4},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetMapStats() = %#v, want %#v", got, want)
+	}
+}
+
+func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
+	dp := &forwardingStatusCLIUserspaceTestDP{
+		forwardingStatusCLITestDP: &forwardingStatusCLITestDP{loaded: true},
+		status: dpuserspace.ProcessStatus{
+			WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{{
+				ThreadCPUNS: 123,
+				WallNS:      456,
+			}},
+		},
+	}
+	c := &CLI{dp: dp}
+
+	accessor := c.forwardingStatusDataplane()
+	statusAccessor, ok := accessor.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		t.Fatalf("forwardingStatusDataplane() = %T, want userspace Status adapter", accessor)
+	}
+
+	got, err := statusAccessor.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if dp.statusCalls != 1 {
+		t.Fatalf("Status() calls = %d, want 1", dp.statusCalls)
+	}
+	if len(got.WorkerRuntime) != 1 || got.WorkerRuntime[0].ThreadCPUNS != 123 {
+		t.Fatalf("Status() = %#v, want injected userspace status", got)
+	}
+}

--- a/pkg/daemon/daemon_forwarding_status.go
+++ b/pkg/daemon/daemon_forwarding_status.go
@@ -43,16 +43,24 @@ func (a forwardingStatusDaemonDataPlane) GetMapStats() []fwdstatus.MapStats {
 
 type forwardingStatusDaemonUserspaceDataPlane struct {
 	forwardingStatusDaemonDataPlane
-	statusProvider interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}
 }
 
 func (a forwardingStatusDaemonUserspaceDataPlane) Status() (dpuserspace.ProcessStatus, error) {
-	if a.statusProvider == nil {
+	if a.daemon == nil {
 		return dpuserspace.ProcessStatus{}, errors.New("userspace status unavailable")
 	}
-	return a.statusProvider.Status()
+	return a.daemon.userspaceDataplaneStatus()
+}
+
+func (d *Daemon) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
+	dp := d.legacyDP()
+	provider, ok := dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		return dpuserspace.ProcessStatus{}, errors.New("userspace status unavailable")
+	}
+	return provider.Status()
 }
 
 func (d *Daemon) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
@@ -64,13 +72,10 @@ func (d *Daemon) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
 		return nil
 	}
 	base := forwardingStatusDaemonDataPlane{daemon: d}
-	if statusProvider, ok := dp.(interface {
+	if _, ok := dp.(interface {
 		Status() (dpuserspace.ProcessStatus, error)
 	}); ok {
-		return forwardingStatusDaemonUserspaceDataPlane{
-			forwardingStatusDaemonDataPlane: base,
-			statusProvider:                  statusProvider,
-		}
+		return forwardingStatusDaemonUserspaceDataPlane{forwardingStatusDaemonDataPlane: base}
 	}
 	return base
 }

--- a/pkg/daemon/daemon_forwarding_status.go
+++ b/pkg/daemon/daemon_forwarding_status.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"errors"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/fwdstatus"
+)
+
+var _ fwdstatus.DataPlaneAccessor = forwardingStatusDaemonDataPlane{}
+
+type forwardingStatusDaemonDataPlane struct {
+	daemon *Daemon
+}
+
+func (a forwardingStatusDaemonDataPlane) IsLoaded() bool {
+	if a.daemon == nil {
+		return false
+	}
+	dp := a.daemon.legacyDP()
+	return dp != nil && dp.IsLoaded()
+}
+
+func (a forwardingStatusDaemonDataPlane) GetMapStats() []fwdstatus.MapStats {
+	if a.daemon == nil {
+		return nil
+	}
+	dp := a.daemon.legacyDP()
+	if dp == nil {
+		return nil
+	}
+	stats := dp.GetMapStats()
+	out := make([]fwdstatus.MapStats, 0, len(stats))
+	for _, ms := range stats {
+		out = append(out, fwdstatus.MapStats{
+			Type:       ms.Type,
+			MaxEntries: ms.MaxEntries,
+			UsedCount:  ms.UsedCount,
+		})
+	}
+	return out
+}
+
+type forwardingStatusDaemonUserspaceDataPlane struct {
+	forwardingStatusDaemonDataPlane
+	statusProvider interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}
+}
+
+func (a forwardingStatusDaemonUserspaceDataPlane) Status() (dpuserspace.ProcessStatus, error) {
+	if a.statusProvider == nil {
+		return dpuserspace.ProcessStatus{}, errors.New("userspace status unavailable")
+	}
+	return a.statusProvider.Status()
+}
+
+func (d *Daemon) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
+	if d == nil {
+		return nil
+	}
+	dp := d.legacyDP()
+	if dp == nil {
+		return nil
+	}
+	base := forwardingStatusDaemonDataPlane{daemon: d}
+	if statusProvider, ok := dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		return forwardingStatusDaemonUserspaceDataPlane{
+			forwardingStatusDaemonDataPlane: base,
+			statusProvider:                  statusProvider,
+		}
+	}
+	return base
+}

--- a/pkg/daemon/daemon_forwarding_status_test.go
+++ b/pkg/daemon/daemon_forwarding_status_test.go
@@ -118,3 +118,68 @@ func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
 		t.Fatalf("Status() = %#v, want injected userspace status", got)
 	}
 }
+
+func TestForwardingStatusDataplaneUsesCurrentDataplaneAfterSwap(t *testing.T) {
+	first := &forwardingStatusDaemonUserspaceTestDP{
+		forwardingStatusDaemonTestDP: &forwardingStatusDaemonTestDP{
+			loaded: true,
+			mapStats: []dataplane.MapStats{{
+				Type:       "Hash",
+				MaxEntries: 16,
+				UsedCount:  4,
+			}},
+		},
+		status: dpuserspace.ProcessStatus{
+			WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{{
+				ThreadCPUNS: 111,
+				WallNS:      222,
+			}},
+		},
+	}
+	second := &forwardingStatusDaemonUserspaceTestDP{
+		forwardingStatusDaemonTestDP: &forwardingStatusDaemonTestDP{
+			loaded: true,
+			mapStats: []dataplane.MapStats{{
+				Type:       "LPMTrie",
+				MaxEntries: 32,
+				UsedCount:  8,
+			}},
+		},
+		status: dpuserspace.ProcessStatus{
+			WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{{
+				ThreadCPUNS: 333,
+				WallNS:      444,
+			}},
+		},
+	}
+	d := &Daemon{dp: first}
+
+	accessor := d.forwardingStatusDataplane()
+	statusAccessor, ok := accessor.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		t.Fatalf("forwardingStatusDataplane() = %T, want userspace Status adapter", accessor)
+	}
+
+	d.dp = second
+
+	if got, want := accessor.GetMapStats(), []fwdstatus.MapStats{
+		{Type: "LPMTrie", MaxEntries: 32, UsedCount: 8},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetMapStats() after dp swap = %#v, want %#v", got, want)
+	}
+	got, err := statusAccessor.Status()
+	if err != nil {
+		t.Fatalf("Status() after dp swap error = %v", err)
+	}
+	if first.statusCalls != 0 {
+		t.Fatalf("first Status() calls = %d, want 0", first.statusCalls)
+	}
+	if second.statusCalls != 1 {
+		t.Fatalf("second Status() calls = %d, want 1", second.statusCalls)
+	}
+	if len(got.WorkerRuntime) != 1 || got.WorkerRuntime[0].ThreadCPUNS != 333 {
+		t.Fatalf("Status() after dp swap = %#v, want second dataplane status", got)
+	}
+}

--- a/pkg/daemon/daemon_forwarding_status_test.go
+++ b/pkg/daemon/daemon_forwarding_status_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/fwdstatus"
+)
+
+type forwardingStatusDaemonTestDP struct {
+	runtimeOnlyApplyTestDP
+	dataplane.DataPlane
+
+	loaded   bool
+	mapStats []dataplane.MapStats
+}
+
+func (f *forwardingStatusDaemonTestDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *forwardingStatusDaemonTestDP) Close() error {
+	return nil
+}
+
+func (f *forwardingStatusDaemonTestDP) Teardown() error {
+	return nil
+}
+
+func (f *forwardingStatusDaemonTestDP) GetMapStats() []dataplane.MapStats {
+	return f.mapStats
+}
+
+type forwardingStatusDaemonUserspaceTestDP struct {
+	*forwardingStatusDaemonTestDP
+
+	status      dpuserspace.ProcessStatus
+	statusCalls int
+}
+
+func (f *forwardingStatusDaemonUserspaceTestDP) Status() (dpuserspace.ProcessStatus, error) {
+	f.statusCalls++
+	return f.status, nil
+}
+
+func TestForwardingStatusDataplaneProjectsMapStats(t *testing.T) {
+	dp := &forwardingStatusDaemonTestDP{
+		loaded: true,
+		mapStats: []dataplane.MapStats{
+			{
+				Name:       "sessions",
+				Type:       "Hash",
+				MaxEntries: 512,
+				UsedCount:  128,
+				KeySize:    16,
+				ValueSize:  64,
+			},
+			{
+				Name:       "policy",
+				Type:       "PerCPUArray",
+				MaxEntries: 8,
+				UsedCount:  8,
+				KeySize:    4,
+				ValueSize:  128,
+			},
+		},
+	}
+	d := &Daemon{dp: dp}
+
+	accessor := d.forwardingStatusDataplane()
+	if accessor == nil {
+		t.Fatal("forwardingStatusDataplane() returned nil")
+	}
+	if !accessor.IsLoaded() {
+		t.Fatal("IsLoaded() = false, want true")
+	}
+
+	got := accessor.GetMapStats()
+	want := []fwdstatus.MapStats{
+		{Type: "Hash", MaxEntries: 512, UsedCount: 128},
+		{Type: "PerCPUArray", MaxEntries: 8, UsedCount: 8},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetMapStats() = %#v, want %#v", got, want)
+	}
+}
+
+func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
+	dp := &forwardingStatusDaemonUserspaceTestDP{
+		forwardingStatusDaemonTestDP: &forwardingStatusDaemonTestDP{loaded: true},
+		status: dpuserspace.ProcessStatus{
+			WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{{
+				ThreadCPUNS: 987,
+				WallNS:      654,
+			}},
+		},
+	}
+	d := &Daemon{dp: dp}
+
+	accessor := d.forwardingStatusDataplane()
+	statusAccessor, ok := accessor.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		t.Fatalf("forwardingStatusDataplane() = %T, want userspace Status adapter", accessor)
+	}
+
+	got, err := statusAccessor.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if dp.statusCalls != 1 {
+		t.Fatalf("Status() calls = %d, want 1", dp.statusCalls)
+	}
+	if len(got.WorkerRuntime) != 1 || got.WorkerRuntime[0].ThreadCPUNS != 987 {
+		t.Fatalf("Status() = %#v, want injected userspace status", got)
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -732,7 +732,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// `show chassis forwarding`).  Shared between the gRPC server
 	// and the local CLI; both paths call Snapshot() at query time.
 	// Started here so the ring is populated before the first CLI.
-	fwdSampler := fwdstatus.NewSampler(d.legacyDP(), fwdstatus.OSProcReader{})
+	fwdSampler := fwdstatus.NewSampler(d.forwardingStatusDataplane(), fwdstatus.OSProcReader{})
 	fwdSampler.Start(ctx)
 
 	// Start gRPC API server.

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -43,7 +43,6 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/daemon/daemon_ha_fabric.go":           "fabric HA updates still call legacy bridge methods",
 	"pkg/daemon/daemon_ha_userspace.go":        "userspace HA control still crosses the legacy bridge",
 	"pkg/daemon/daemon_run.go":                 "runtime wiring still passes legacyDP to unmigrated services",
-	"pkg/fwdstatus/builder.go":                 "forwarding status still reads legacy map stats",
 	"pkg/grpcapi/apply_result.go":              "gRPC apply metadata still adapts legacy apply results",
 	"pkg/grpcapi/server.go":                    "gRPC server constructor still stores the legacy bridge",
 	"pkg/grpcapi/server_helpers.go":            "gRPC helpers still format legacy dataplane types",

--- a/pkg/fwdstatus/README.md
+++ b/pkg/fwdstatus/README.md
@@ -19,10 +19,10 @@ fixed-width table.
 
 ## Dependencies
 
-`pkg/dataplane` and `pkg/dataplane/userspace` (used by `Sampler` and
-`builder.go` for live BPF map / userspace-helper stats). The package
-deliberately avoids importing `pkg/cli` or `pkg/grpcapi` to prevent
-circular imports — those are the consumers, not dependencies.
+`pkg/dataplane/userspace` for userspace-helper status. Callers adapt
+their runtime dataplane map telemetry into the package-local
+`MapStats` shape; `pkg/fwdstatus` deliberately avoids importing the
+root `pkg/dataplane` package, `pkg/cli`, or `pkg/grpcapi`.
 
 ## Gotchas
 

--- a/pkg/fwdstatus/builder.go
+++ b/pkg/fwdstatus/builder.go
@@ -3,7 +3,6 @@ package fwdstatus
 import (
 	"time"
 
-	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
@@ -26,13 +25,19 @@ const followupUMEMBuffer = 878
 // want to suppress the reference.
 func UMEMBufferFollowup() int { return followupUMEMBuffer }
 
-// DataPlaneAccessor is the small surface Build needs from the
-// dataplane.  Both `dataplane.DataPlane` and mocks in tests satisfy
-// it.  Package keeps the interface narrow so tests don't have to
-// stub dozens of unrelated methods.
+// MapStats is the package-local BPF map utilization shape Build needs.
+type MapStats struct {
+	Type       string
+	MaxEntries uint32
+	UsedCount  uint32
+}
+
+// DataPlaneAccessor is the small surface Build needs from the dataplane.
+// Callers adapt broader runtime or legacy dataplane implementations to this
+// shape so this package does not depend on root dataplane telemetry types.
 type DataPlaneAccessor interface {
 	IsLoaded() bool
-	GetMapStats() []dataplane.MapStats
+	GetMapStats() []MapStats
 }
 
 // Build gathers all fields of a ForwardingStatus.  Nil `dp` is

--- a/pkg/fwdstatus/fwdstatus_test.go
+++ b/pkg/fwdstatus/fwdstatus_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
@@ -16,14 +15,14 @@ import (
 
 func TestFormat_LabelsAndOrderEBPF(t *testing.T) {
 	fs := &ForwardingStatus{
-		State: StateOnline,
-		DaemonCPUWindows: [numCPUWindows]float64{4, 3, 2},
+		State:                StateOnline,
+		DaemonCPUWindows:     [numCPUWindows]float64{4, 3, 2},
 		DaemonCPUWindowValid: [numCPUWindows]bool{true, true, true},
-		WorkerCPUMode:  CPUModeEBPFNoWorkers,
-		HeapPercent:    72.0,
-		BufferPercent:  83.0,
-		BufferKnown:    true,
-		Uptime:         474635 * time.Second,
+		WorkerCPUMode:        CPUModeEBPFNoWorkers,
+		HeapPercent:          72.0,
+		BufferPercent:        83.0,
+		BufferKnown:          true,
+		Uptime:               474635 * time.Second,
 	}
 	out := Format(fs)
 	wantLabelsInOrder := []string{
@@ -59,12 +58,12 @@ func TestFormat_LabelsAndOrderEBPF(t *testing.T) {
 
 func TestFormat_BufferUnknownUserspace(t *testing.T) {
 	fs := &ForwardingStatus{
-		State:              StateOnline,
-		WorkerCPUMode:      CPUModeWorkers,
-		WorkerCPUWindows:   [numCPUWindows]float64{45, 40, 35},
+		State:                StateOnline,
+		WorkerCPUMode:        CPUModeWorkers,
+		WorkerCPUWindows:     [numCPUWindows]float64{45, 40, 35},
 		WorkerCPUWindowValid: [numCPUWindows]bool{true, true, true},
-		BufferKnown:        false,
-		BufferFollowupRef:  878,
+		BufferKnown:          false,
+		BufferFollowupRef:    878,
 	}
 	out := Format(fs)
 	if !strings.Contains(out, "unknown (see #878)") {
@@ -161,11 +160,11 @@ func TestFormat_HeapAndBufferClampButCPUDoesNot(t *testing.T) {
 // make Build treat it as userspace-dp (adds the Status method).
 type fakeDP struct {
 	loaded   bool
-	mapStats []dataplane.MapStats
+	mapStats []MapStats
 }
 
-func (f *fakeDP) IsLoaded() bool                   { return f.loaded }
-func (f *fakeDP) GetMapStats() []dataplane.MapStats { return f.mapStats }
+func (f *fakeDP) IsLoaded() bool          { return f.loaded }
+func (f *fakeDP) GetMapStats() []MapStats { return f.mapStats }
 
 type fakeUserspaceDP struct {
 	fakeDP
@@ -179,16 +178,16 @@ func (f *fakeUserspaceDP) Status() (userspace.ProcessStatus, error) {
 
 // fakeProcReader injects canned /proc contents.
 type fakeProcReader struct {
-	selfStat    ProcSelfStat
-	selfStatErr error
-	selfStatm   ProcSelfStatm
+	selfStat     ProcSelfStat
+	selfStatErr  error
+	selfStatm    ProcSelfStatm
 	selfStatmErr error
-	stat        ProcStat
-	statErr     error
-	memInfo     ProcMemInfo
-	memInfoErr  error
-	cgroupMax   uint64
-	cgroupErr   error
+	stat         ProcStat
+	statErr      error
+	memInfo      ProcMemInfo
+	memInfoErr   error
+	cgroupMax    uint64
+	cgroupErr    error
 }
 
 func (f *fakeProcReader) ReadSelfStat() (ProcSelfStat, error) {
@@ -224,8 +223,8 @@ func freshProcReader() *fakeProcReader {
 }
 
 func TestBuild_Online_eBPF(t *testing.T) {
-	dp := &fakeDP{loaded: true, mapStats: []dataplane.MapStats{
-		{Name: "sessions", MaxEntries: 100, UsedCount: 30},
+	dp := &fakeDP{loaded: true, mapStats: []MapStats{
+		{MaxEntries: 100, UsedCount: 30},
 	}}
 	fs, err := Build(dp, freshProcReader(), time.Now(), SamplerSnapshot{})
 	if err != nil {

--- a/pkg/grpcapi/server_show_forwarding.go
+++ b/pkg/grpcapi/server_show_forwarding.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/fwdstatus"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/metadata"
@@ -16,7 +17,7 @@ func (s *Server) buildLocalForwarding() string {
 		snap = s.fwdSampler.Snapshot()
 	}
 	fs, err := fwdstatus.Build(
-		s.dp,
+		s.forwardingStatusDataplane(),
 		fwdstatus.OSProcReader{},
 		s.startTime,
 		snap,
@@ -25,6 +26,51 @@ func (s *Server) buildLocalForwarding() string {
 		return fmt.Sprintf("FWDD status:\n  (build failed: %s)\n", err)
 	}
 	return fwdstatus.Format(fs)
+}
+
+type forwardingStatusServerDataPlane struct {
+	server *Server
+}
+
+func (a forwardingStatusServerDataPlane) IsLoaded() bool {
+	return a.server != nil && a.server.dp != nil && a.server.dp.IsLoaded()
+}
+
+func (a forwardingStatusServerDataPlane) GetMapStats() []fwdstatus.MapStats {
+	if a.server == nil || a.server.dp == nil {
+		return nil
+	}
+	stats := a.server.dp.GetMapStats()
+	out := make([]fwdstatus.MapStats, 0, len(stats))
+	for _, ms := range stats {
+		out = append(out, fwdstatus.MapStats{
+			Type:       ms.Type,
+			MaxEntries: ms.MaxEntries,
+			UsedCount:  ms.UsedCount,
+		})
+	}
+	return out
+}
+
+type forwardingStatusServerUserspaceDataPlane struct {
+	forwardingStatusServerDataPlane
+}
+
+func (a forwardingStatusServerUserspaceDataPlane) Status() (dpuserspace.ProcessStatus, error) {
+	return a.server.userspaceDataplaneStatus()
+}
+
+func (s *Server) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
+	if s == nil || s.dp == nil {
+		return nil
+	}
+	base := forwardingStatusServerDataPlane{server: s}
+	if _, ok := s.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		return forwardingStatusServerUserspaceDataPlane{forwardingStatusServerDataPlane: base}
+	}
+	return base
 }
 
 func (s *Server) dialAndShowForwarding(ctx context.Context) (string, error) {

--- a/pkg/grpcapi/server_show_forwarding_adapter_test.go
+++ b/pkg/grpcapi/server_show_forwarding_adapter_test.go
@@ -1,0 +1,111 @@
+package grpcapi
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/fwdstatus"
+)
+
+type forwardingStatusServerTestDP struct {
+	dataplane.DataPlane
+
+	loaded   bool
+	mapStats []dataplane.MapStats
+}
+
+func (f *forwardingStatusServerTestDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *forwardingStatusServerTestDP) GetMapStats() []dataplane.MapStats {
+	return f.mapStats
+}
+
+type forwardingStatusServerUserspaceTestDP struct {
+	*forwardingStatusServerTestDP
+
+	status      dpuserspace.ProcessStatus
+	statusCalls int
+}
+
+func (f *forwardingStatusServerUserspaceTestDP) Status() (dpuserspace.ProcessStatus, error) {
+	f.statusCalls++
+	return f.status, nil
+}
+
+func TestForwardingStatusDataplaneProjectsMapStats(t *testing.T) {
+	dp := &forwardingStatusServerTestDP{
+		loaded: true,
+		mapStats: []dataplane.MapStats{
+			{
+				Name:       "sessions",
+				Type:       "Hash",
+				MaxEntries: 256,
+				UsedCount:  64,
+				KeySize:    16,
+				ValueSize:  64,
+			},
+			{
+				Name:       "lpm_trie",
+				Type:       "LPMTrie",
+				MaxEntries: 1024,
+				UsedCount:  7,
+				KeySize:    8,
+				ValueSize:  8,
+			},
+		},
+	}
+	s := &Server{dp: dp}
+
+	accessor := s.forwardingStatusDataplane()
+	if accessor == nil {
+		t.Fatal("forwardingStatusDataplane() returned nil")
+	}
+	if !accessor.IsLoaded() {
+		t.Fatal("IsLoaded() = false, want true")
+	}
+
+	got := accessor.GetMapStats()
+	want := []fwdstatus.MapStats{
+		{Type: "Hash", MaxEntries: 256, UsedCount: 64},
+		{Type: "LPMTrie", MaxEntries: 1024, UsedCount: 7},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetMapStats() = %#v, want %#v", got, want)
+	}
+}
+
+func TestForwardingStatusDataplaneUsesUserspaceStatusAdapter(t *testing.T) {
+	dp := &forwardingStatusServerUserspaceTestDP{
+		forwardingStatusServerTestDP: &forwardingStatusServerTestDP{loaded: true},
+		status: dpuserspace.ProcessStatus{
+			WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{{
+				ThreadCPUNS: 321,
+				WallNS:      654,
+			}},
+		},
+	}
+	s := &Server{dp: dp}
+
+	accessor := s.forwardingStatusDataplane()
+	statusAccessor, ok := accessor.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		t.Fatalf("forwardingStatusDataplane() = %T, want userspace Status adapter", accessor)
+	}
+
+	got, err := statusAccessor.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if dp.statusCalls != 1 {
+		t.Fatalf("Status() calls = %d, want 1", dp.statusCalls)
+	}
+	if len(got.WorkerRuntime) != 1 || got.WorkerRuntime[0].ThreadCPUNS != 321 {
+		t.Fatalf("Status() = %#v, want injected userspace status", got)
+	}
+}


### PR DESCRIPTION
## Summary
- migrate pkg/fwdstatus/builder.go off the root dataplane MapStats type
- adapt CLI and gRPC forwarding-status callers at their existing boundaries
- remove pkg/fwdstatus/builder.go from the #1451 allowlist and docs

## Tests
- go test ./pkg/fwdstatus
- go test ./pkg/cli
- go test ./pkg/grpcapi
- go test ./pkg/dataplane -run 'TestOperatorPackages|TestDaemonRuntime|TestRetirementBoundary' -count=1