### PR TITLE
Pin DPDK backend policy for eBPF retirement

### DIFF
--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -4,6 +4,13 @@ Note: This is an architecture/planning document. For the current project-level
 decision and recommendation between DPDK and VPP, see
 `docs/dataplane-decision-dpdk-vs-vpp.md`.
 
+Current #1475 policy: DPDK remains a separately supported backend for binaries
+built with `-tags dpdk`, but it is outside the #1373 eBPF source-removal path
+until it migrates off the root `dataplane.DataPlane` interface. The legacy
+bridge is confined to `pkg/dataplane/dpdk`, with only the blank registration
+import in `cmd/xpfd/main.go` outside that package. Non-DPDK builds reject DPDK
+startup explicitly instead of running a no-op stub.
+
 ## Overview
 
 Add a DPDK-based dataplane as an alternative to the current XDP/TC eBPF pipeline. The existing `pkg/dataplane.Manager` API is already well-abstracted — the daemon, CLI, gRPC, config system, and all subsystems interact through this interface, not through BPF-specific code. A DPDK implementation would swap the packet processing engine while keeping everything else unchanged.

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -43,6 +43,40 @@ owning `dataplane.RuntimeDataPlane` and must call
 production-code canary; `_test.go` files may still import lower-level helpers
 when they need backend fixtures for regression coverage.
 
+## #1475 DPDK Backend Policy
+
+DPDK remains a separately supported backend for DPDK-specific binaries, but it
+is explicitly outside the eBPF source-removal path until it migrates off the
+root `DataPlane` interface. The current DPDK implementation still satisfies
+both `dataplane.DataPlane` and `dataplane.RuntimeDataPlane`; that is a
+backend-local compatibility exception, not a reason for userspace retirement
+work to grow new dependencies on the legacy BPF-shaped surface.
+
+The allowed production boundary is narrow:
+
+- `pkg/dataplane/dpdk` may import root `pkg/dataplane` types and helpers while
+  it owns the DPDK compatibility bridge.
+- `cmd/xpfd/main.go` may keep the blank DPDK import for backend registration.
+- No other production `cmd/*` or `pkg/*` package may import
+  `pkg/dataplane/dpdk`.
+- The only allowed DPDK import of `github.com/cilium/ebpf` is the existing
+  `pkg/dataplane/dpdk/manager.go` adapter for the legacy `Map(string)
+  *ebpf.Map` method. Adding more eBPF artifact imports to DPDK requires an
+  explicit backend-policy update.
+
+The default non-DPDK build keeps the package present so registration and tests
+compile, but `system dataplane-type dpdk` does not silently start a stub
+dataplane: `pkg/dataplane/dpdk` returns a clear startup error unless the daemon
+binary was built with `-tags dpdk` and libdpdk support. Config validation still
+accepts `dpdk` as a valid backend name and rejects unknown backend names before
+daemon startup.
+
+The #1475 canaries in `pkg/dataplane/retirement_boundary_canary_test.go` enforce
+the import boundary above and require this policy text to stay present. DPDK
+builds remain blocked on migrating away from root `DataPlane`; userspace-only
+production source removal must not depend on solving that DPDK migration in the
+same PR.
+
 ### Allowlisted Legacy Bridges
 
 These files are the current production direct-import allowlist for root
@@ -102,9 +136,11 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
   userspace runtime construction returns a legacy-compatible adapter while
   unmigrated operator services consume old session, telemetry, and control
   methods. The userspace `Manager` itself must not implement `DataPlane`.
-- DPDK still implements both `DataPlane` and `RuntimeDataPlane`; the only
-  direct DPDK backend import outside `pkg/dataplane` should remain the blank
-  registration import in `cmd/xpfd/main.go`.
+- DPDK still implements both `DataPlane` and `RuntimeDataPlane`. That
+  compatibility is intentionally confined to `pkg/dataplane/dpdk`, with the
+  only direct DPDK backend import outside the package being the blank
+  registration import in `cmd/xpfd/main.go`. Non-`-tags dpdk` binaries fail
+  DPDK startup explicitly rather than running a no-op stub.
 - BPF source and build artifacts are not safe to delete in #1451 canary work:
   `bpf/`, `pkg/dataplane/loader_ebpf.go`,
   `pkg/dataplane/*_bpfel.go`, `pkg/dataplane/*_bpfel.o`,

--- a/docs/pr/1381-dataplane-interface-split/plan.md
+++ b/docs/pr/1381-dataplane-interface-split/plan.md
@@ -582,6 +582,10 @@ interface in place and adds the new contract beside it:
   session surfaces; userspace keeps backend-specific link and HA controllers so
   link-cycle prepare/defer/rebind semantics and fabric-state helper sync stay
   intact.
+- #1475 pins DPDK as a separately supported DPDK-build backend outside the
+  userspace eBPF source-removal path. Its current root `DataPlane` dependency
+  is confined to `pkg/dataplane/dpdk` plus the `cmd/xpfd/main.go` registration
+  import until DPDK gets its own migration off the legacy interface.
 - Cluster stale-bulk reconciliation now routes through
   `dataplane.SessionStore.ReconcileClusterBulk`, whose companion-delete path
   owns forward, reverse, and DNAT/DNATv6 cleanup. A canary fails if

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -18,6 +18,13 @@ below are closed, the legacy eBPF dataplane remains present as the
 compatibility and rollback path for configurations the AF_XDP userspace
 dataplane cannot yet own.
 
+DPDK is not part of the userspace retirement path. It remains a separately
+supported DPDK-build backend, but #1475 confines its root `DataPlane`
+dependency to `pkg/dataplane/dpdk` and the `cmd/xpfd/main.go` registration
+import until that backend gets its own migration off the legacy interface.
+Non-`-tags dpdk` binaries reject DPDK startup explicitly instead of admitting a
+no-op stub dataplane.
+
 ## Implemented In The Current Runtime
 
 These capabilities exist in the current Rust userspace dataplane code path:
@@ -80,6 +87,7 @@ These are not "missing", but they are not pure userspace forwarding either:
 | GRE / ESP / explicit early filters | Tail-call back into the legacy XDP pipeline |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
 | DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. Operator metadata reads in API/gRPC/CLI/daemon now use `LastApplyResult()` instead of `LastCompileResult()`, with a canary preventing those surfaces from regressing to compile-result metadata. GC and HA session sync now use `SessionStore`/`Telemetry`. The manager still holds a named eBPF shim manager for XDP/map bootstrap state, and API/gRPC/CLI session/counter readers plus daemon control paths still need to move fully to domain interfaces; tracked by #1381 |
+| DPDK backend | Separately supported backend outside userspace source-removal scope. Its current root `DataPlane` dependency is pinned as a backend-local #1475 exception until DPDK migrates to runtime/domain interfaces or gets a separate retirement decision. |
 | Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, logged routing-instance filter hits, non-PBR input filter logs, output filter logs, cached output-filter hits, and lo0 filter logs now enqueue RT_FLOW frames through the non-blocking Rust event-stream producer with existing per-event rate-limit/loss accounting. Go decode/status handling feeds raw userspace RT_FLOW frames through the same `EventReader.ProcessRawEvent` syslog/local-log path as eBPF, with a deterministic UDP syslog fanout harness for policy deny, screen drop, and filter log. Policy-deny events now carry the snapshot's compiled numeric policy ID; filter-log events carry filter/term/action identity from the matched compiled term. Remaining #1379 evidence is live userspace-cluster syslog capture, including deny-storm starvation checks, if Phase 4 requires operator artifacts beyond the deterministic local harness. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, helper-published session-table and flow-cache capacity, active-session footer, neighbor counts, and worker queue pressure counters. The Phase 5 denominator decision is explicit: session-table and flow-cache values become fill percentages only from Rust-owned helper fields; neighbor-cache entries remain counters until Rust owns a bounded neighbor-cache capacity. Formatter tests pin that dynamic counts cannot move into the utilization table without real denominators. |
 

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -17,6 +17,9 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			break
 		}
 	}
+	if err := validateSystemDataplaneType(sys.DataplaneType); err != nil {
+		return err
+	}
 	for _, child := range node.Children {
 		switch child.Name() {
 		case "host-name":
@@ -366,6 +369,15 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	}
 
 	return nil
+}
+
+func validateSystemDataplaneType(dpType string) error {
+	switch dpType {
+	case "", "ebpf", "dpdk", "userspace":
+		return nil
+	default:
+		return fmt.Errorf("dataplane-type %q is invalid; valid values are ebpf, dpdk, userspace", dpType)
+	}
 }
 
 func hasDNSProxyChild(node *Node) bool {

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -11,15 +11,12 @@ import (
 const sharedUMEMPhase0ArtifactMaxBytes = 16 << 20
 
 func compileSystem(node *Node, sys *SystemConfig) error {
-	for _, child := range node.Children {
-		if child.Name() == "dataplane-type" && len(child.Keys) >= 2 {
-			sys.DataplaneType = child.Keys[1]
-			break
-		}
-	}
-	if err := validateSystemDataplaneType(sys.DataplaneType); err != nil {
+	dpType, err := resolveSystemDataplaneType(node)
+	if err != nil {
 		return err
 	}
+	sys.DataplaneType = dpType
+
 	for _, child := range node.Children {
 		switch child.Name() {
 		case "host-name":
@@ -27,9 +24,8 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 				sys.HostName = child.Keys[1]
 			}
 		case "dataplane-type":
-			if len(child.Keys) >= 2 {
-				sys.DataplaneType = child.Keys[1]
-			}
+			// Resolved before the main pass so a dataplane block uses the
+			// same validated type regardless of sibling order.
 		case "domain-name":
 			if len(child.Keys) >= 2 {
 				sys.DomainName = child.Keys[1]
@@ -369,6 +365,21 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	}
 
 	return nil
+}
+
+func resolveSystemDataplaneType(node *Node) (string, error) {
+	var dpType string
+	for _, child := range node.Children {
+		if child.Name() != "dataplane-type" || len(child.Keys) < 2 {
+			continue
+		}
+		value := child.Keys[1]
+		if err := validateSystemDataplaneType(value); err != nil {
+			return "", err
+		}
+		dpType = value
+	}
+	return dpType, nil
 }
 
 func validateSystemDataplaneType(dpType string) error {

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -2707,6 +2707,55 @@ func TestDataplaneTypeValidationRejectsUnknownBackend(t *testing.T) {
 	}
 }
 
+func TestDataplaneTypeValidationRejectsHierarchicalDuplicateUnknownBackend(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "valid then unknown",
+			input: `system {
+    dataplane-type ebpf;
+    dataplane-type vpp;
+    host-name fw1;
+}`,
+		},
+		{
+			name: "unknown then valid",
+			input: `system {
+    dataplane-type vpp;
+    dataplane-type ebpf;
+    host-name fw1;
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewParser(tt.input)
+			tree, errs := parser.Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse errors: %v", errs)
+			}
+			system := tree.FindChild("system")
+			if system == nil {
+				t.Fatal("missing system node")
+			}
+			if got := len(system.FindChildren("dataplane-type")); got != 2 {
+				t.Fatalf("dataplane-type sibling count = %d, want 2", got)
+			}
+
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatal("CompileConfig succeeded for duplicate hierarchical unknown dataplane type")
+			}
+			if !strings.Contains(err.Error(), `dataplane-type "vpp" is invalid`) {
+				t.Fatalf("CompileConfig error = %v", err)
+			}
+		})
+	}
+}
+
 func TestUserspaceDataplaneConfig(t *testing.T) {
 	lines := []string{"set system dataplane-type userspace", "set system dataplane binary /usr/local/bin/xpf-userspace-dp", "set system dataplane control-socket /run/xpf/userspace-dp.sock", "set system dataplane state-file /run/xpf/userspace-dp.json", "set system dataplane workers 4", "set system dataplane ring-entries 2048"}
 	tree := &ConfigTree{}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -2688,6 +2688,25 @@ func TestDPDKConfig(t *testing.T) {
 	}
 }
 
+func TestDataplaneTypeValidationRejectsUnknownBackend(t *testing.T) {
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand("set system dataplane-type vpp")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+
+	_, err = CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded for an unknown dataplane type")
+	}
+	if !strings.Contains(err.Error(), `dataplane-type "vpp" is invalid`) {
+		t.Fatalf("CompileConfig error = %v", err)
+	}
+}
+
 func TestUserspaceDataplaneConfig(t *testing.T) {
 	lines := []string{"set system dataplane-type userspace", "set system dataplane binary /usr/local/bin/xpf-userspace-dp", "set system dataplane control-socket /run/xpf/userspace-dp.sock", "set system dataplane state-file /run/xpf/userspace-dp.json", "set system dataplane workers 4", "set system dataplane ring-entries 2048"}
 	tree := &ConfigTree{}

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -19,6 +19,14 @@ userspace runtime constructor returns `LegacyDataPlaneAdapter`: the userspace
 daemon status, CLI, and cluster-sync callers that have not moved to domain
 interfaces still receive a temporary compatibility handle.
 
+#1475 policy: DPDK is retained as a separately supported DPDK-build backend,
+but it is outside the eBPF source-removal path until it migrates off the root
+`DataPlane` interface. Its legacy bridge must stay inside
+`pkg/dataplane/dpdk`; the only production import outside that package is the
+blank registration import in `cmd/xpfd/main.go`. Non-`-tags dpdk` binaries keep
+the package compiling but fail DPDK startup explicitly instead of running a
+no-op stub.
+
 The userspace backend's status wire format is mirrored here for CLI/API
 consumers. CoS queue status includes queue-scoped drain-phase counters so
 operators can separate guarantee bytes, surplus bytes, and non-exact bytes
@@ -29,6 +37,9 @@ sent while exact queues were still backlogged.
 - `DataPlane` — `dataplane.go`. Legacy BPF-shaped interface kept for the
   eBPF/DPDK compiler and compatibility adapters. New daemon-facing code should
   not add methods here.
+- `pkg/dataplane/dpdk.Manager` — DPDK implementation. It currently satisfies
+  both `DataPlane` and `RuntimeDataPlane`; that is the #1475 backend-local
+  exception and not a template for new runtime code.
 - `RuntimeDataPlane`, `ConfigSink`, `SessionStore`, `Telemetry`,
   `HAController`, and `LinkController` — `apply.go` and `session_store.go`.
   These are the split-domain interfaces used by daemon startup and runtime

--- a/pkg/dataplane/dpdk/dpdk_stub.go
+++ b/pkg/dataplane/dpdk/dpdk_stub.go
@@ -4,6 +4,7 @@ package dpdk
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -13,12 +14,12 @@ import (
 
 type platformState struct{}
 
+var errDPDKBuildTagRequired = errors.New("DPDK dataplane requires a binary built with -tags dpdk and libdpdk support")
+
 // --- Lifecycle ---
 
 func (m *Manager) Load() error {
-	slog.Info("DPDK dataplane loaded (stub)")
-	m.loaded = true
-	return nil
+	return errDPDKBuildTagRequired
 }
 
 func (m *Manager) Close() error {

--- a/pkg/dataplane/dpdk/dpdk_stub.go
+++ b/pkg/dataplane/dpdk/dpdk_stub.go
@@ -61,6 +61,9 @@ func (m *Manager) AddTxPort(ifindex int) error {
 // --- Compilation ---
 
 func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) {
+	if !m.loaded {
+		return nil, errDPDKBuildTagRequired
+	}
 	result, err := dataplane.CompileConfig(m, cfg, m.lastCompile != nil)
 	if err != nil {
 		return nil, err

--- a/pkg/dataplane/dpdk/dpdk_stub_test.go
+++ b/pkg/dataplane/dpdk/dpdk_stub_test.go
@@ -1,0 +1,44 @@
+//go:build !dpdk
+
+package dpdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+func TestDPDKConstructorsRemainRegistered(t *testing.T) {
+	legacy, err := dataplane.NewDataPlane(dataplane.TypeDPDK)
+	if err != nil {
+		t.Fatalf("NewDataPlane(dpdk): %v", err)
+	}
+	if _, ok := legacy.(*Manager); !ok {
+		t.Fatalf("NewDataPlane(dpdk) = %T, want *dpdk.Manager", legacy)
+	}
+
+	runtime, err := dataplane.NewRuntimeDataPlane(dataplane.TypeDPDK)
+	if err != nil {
+		t.Fatalf("NewRuntimeDataPlane(dpdk): %v", err)
+	}
+	if _, ok := runtime.(*Manager); !ok {
+		t.Fatalf("NewRuntimeDataPlane(dpdk) = %T, want *dpdk.Manager", runtime)
+	}
+}
+
+func TestDPDKStubRequiresDPDKBuildTag(t *testing.T) {
+	m := New()
+
+	if err := m.Load(); !errors.Is(err, errDPDKBuildTagRequired) {
+		t.Fatalf("Load() error = %v, want %v", err, errDPDKBuildTagRequired)
+	}
+	if m.IsLoaded() {
+		t.Fatal("stub Load marked DPDK loaded without the dpdk build tag")
+	}
+
+	if err := m.Start(context.Background()); !errors.Is(err, errDPDKBuildTagRequired) {
+		t.Fatalf("Start() error = %v, want %v", err, errDPDKBuildTagRequired)
+	}
+}

--- a/pkg/dataplane/dpdk/dpdk_stub_test.go
+++ b/pkg/dataplane/dpdk/dpdk_stub_test.go
@@ -41,4 +41,12 @@ func TestDPDKStubRequiresDPDKBuildTag(t *testing.T) {
 	if err := m.Start(context.Background()); !errors.Is(err, errDPDKBuildTagRequired) {
 		t.Fatalf("Start() error = %v, want %v", err, errDPDKBuildTagRequired)
 	}
+
+	if _, err := m.Compile(nil); !errors.Is(err, errDPDKBuildTagRequired) {
+		t.Fatalf("Compile() error = %v, want %v", err, errDPDKBuildTagRequired)
+	}
+
+	if _, err := m.ApplyConfig(context.Background(), nil); !errors.Is(err, errDPDKBuildTagRequired) {
+		t.Fatalf("ApplyConfig() error = %v, want %v", err, errDPDKBuildTagRequired)
+	}
 }

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -61,6 +61,10 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/monitoriface/monitor.go":              "interface monitor still reads legacy interface counters",
 }
 
+var dpdkEBPFImportAllowlist = map[string]string{
+	"pkg/dataplane/dpdk/manager.go": "legacy DataPlane Map method returns *ebpf.Map until DPDK migrates off root DataPlane",
+}
+
 func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +125,69 @@ func TestOperatorPackagesDoNotImportBPFArtifactsDirectly(t *testing.T) {
 	}
 }
 
+func TestDPDKBackendImportStaysBackendLocal(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	for _, path := range productionGoFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "cmd"),
+		filepath.Join(repoRootForBoundaryCanary, "pkg"),
+	}) {
+		rel := repoRelativePath(t, path)
+		if rel == "cmd/xpfd/main.go" || strings.HasPrefix(rel, "pkg/dataplane/dpdk/") {
+			continue
+		}
+		for _, imp := range importPaths(t, path) {
+			if imp == dpdkBackendImportForCanary || strings.HasPrefix(imp, dpdkBackendImportForCanary+"/") {
+				violations = append(violations, rel+" imports "+imp)
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("DPDK backend imports must stay limited to pkg/dataplane/dpdk and cmd/xpfd registration: %v", violations)
+	}
+}
+
+func TestDPDKEBPFArtifactImportsStayAtLegacyAdapter(t *testing.T) {
+	t.Parallel()
+
+	found := map[string]bool{}
+	var unexpected []string
+	for _, path := range productionGoFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "dpdk"),
+	}) {
+		rel := repoRelativePath(t, path)
+		for _, imp := range importPaths(t, path) {
+			if imp != ciliumEBPFImportForCanary && !strings.HasPrefix(imp, ciliumEBPFImportForCanary+"/") {
+				continue
+			}
+			found[rel] = true
+			if _, ok := dpdkEBPFImportAllowlist[rel]; !ok {
+				unexpected = append(unexpected, rel+" imports "+imp)
+			}
+		}
+	}
+
+	var stale []string
+	for rel := range dpdkEBPFImportAllowlist {
+		if !found[rel] {
+			stale = append(stale, rel)
+		}
+	}
+
+	if len(unexpected) > 0 || len(stale) > 0 {
+		sort.Strings(unexpected)
+		sort.Strings(stale)
+		t.Fatalf(
+			"DPDK eBPF artifact import policy drift\nunexpected imports: %v\nstale allowlist entries: %v",
+			unexpected,
+			stale,
+		)
+	}
+}
+
 func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +199,35 @@ func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
 	}
 	if !hasDaemonRuntimeConstructorCall(t, daemonRun, "NewRuntimeDataPlane") {
 		t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")
+	}
+}
+
+func TestRetirementBoundaryDocsMentionDPDKPolicy(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
+	if err != nil {
+		t.Fatalf("read retirement boundary docs: %v", err)
+	}
+	text := string(data)
+
+	want := []string{
+		"## #1475 DPDK Backend Policy",
+		"DPDK remains a separately supported backend",
+		"outside the eBPF source-removal path",
+		"`pkg/dataplane/dpdk`",
+		"`cmd/xpfd/main.go`",
+		"`-tags dpdk`",
+		"root `DataPlane`",
+	}
+	var missing []string
+	for _, token := range want {
+		if !strings.Contains(text, token) {
+			missing = append(missing, token)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("retirement docs do not mention DPDK policy tokens: %v", missing)
 	}
 }
 

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -65,6 +65,10 @@ var dpdkEBPFImportAllowlist = map[string]string{
 	"pkg/dataplane/dpdk/manager.go": "legacy DataPlane Map method returns *ebpf.Map until DPDK migrates off root DataPlane",
 }
 
+var dpdkBackendImportAllowlist = map[string]string{
+	"cmd/xpfd/main.go": "backend registration and cleanup entry point",
+}
+
 func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
 	t.Parallel()
 
@@ -134,7 +138,10 @@ func TestDPDKBackendImportStaysBackendLocal(t *testing.T) {
 		filepath.Join(repoRootForBoundaryCanary, "pkg"),
 	}) {
 		rel := repoRelativePath(t, path)
-		if rel == "cmd/xpfd/main.go" || strings.HasPrefix(rel, "pkg/dataplane/dpdk/") {
+		if strings.HasPrefix(rel, "pkg/dataplane/dpdk/") {
+			continue
+		}
+		if _, ok := dpdkBackendImportAllowlist[rel]; ok {
 			continue
 		}
 		for _, imp := range importPaths(t, path) {


### PR DESCRIPTION
## Summary
- Retain DPDK as a separate DPDK-build backend while keeping it outside the eBPF source-removal path until it migrates off root `DataPlane`.
- Add retirement-boundary canaries for DPDK import confinement and the single legacy `cilium/ebpf` adapter use.
- Make non-`dpdk` builds reject DPDK startup explicitly and validate unknown `system dataplane-type` values during config compilation.
- Update #1373, #1381, dataplane, userspace-gap, and DPDK docs with the precise policy.

## Tests
- `go test ./pkg/config`
- `go test ./pkg/dataplane`
- `go test ./pkg/dataplane/dpdk`

Closes #1475.