### PR TITLE
Default omitted dataplane type to userspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # xpf - Junos-Style Firewall With AF_XDP Userspace Dataplane
 
 > Deprecation notice (#1373): the Rust AF_XDP userspace dataplane is now the
-> primary/default target for dataplane development and validation. The legacy
-> eBPF dataplane remains in-tree for compatibility, rollback, and regression
-> coverage during the staged retirement. Phase 1 updates active documentation;
-> later phases own source, loader, build, and CLI removals.
+> primary/default target for dataplane development, validation, and omitted
+> runtime configuration. The legacy eBPF dataplane remains in-tree for explicit
+> compatibility and regression coverage during the staged retirement. Later
+> phases own source, loader, build, and CLI removals.
 
 ## Working Style
 - Think before acting. Read existing files before writing code.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Stateful firewall with native Junos configuration syntax.
 
 > Deprecation notice (#1373): the Rust AF_XDP userspace dataplane is now the
-> primary/default target for dataplane development and validation. The legacy
-> eBPF dataplane remains in-tree for compatibility, rollback, and regression
-> coverage during the staged retirement. Phase 1 updates active documentation;
-> later phases own source, loader, build, and CLI removals.
+> primary/default target for dataplane development, validation, and omitted
+> runtime configuration. The legacy eBPF dataplane remains in-tree for
+> explicit compatibility and regression coverage during the staged retirement.
+> Later phases own source, loader, build, and CLI removals.
 
 xpf is a high-performance stateful firewall that replicates Juniper vSRX
 capabilities. It uses the familiar Junos hierarchical configuration syntax and
@@ -18,11 +18,12 @@ xpf provides dataplane backends selectable via configuration. Both share the
 same Go control plane (config, HA, routing, CLI, APIs); only the packet
 forwarding path differs.
 
-The userspace AF_XDP backend is the primary retirement target. It is still
-selected explicitly with `system dataplane-type userspace`; if that knob is
-omitted, the current code falls back to the legacy eBPF backend until a later
-cutover phase changes runtime defaults. New dataplane feature work should use
-the userspace path and close blockers tracked in
+The userspace AF_XDP backend is the default runtime target. Operators may still
+set `system dataplane-type userspace` explicitly, but omitting that knob also
+selects the userspace runtime path. The legacy eBPF backend remains available
+only through an explicit `system dataplane-type ebpf` selection until the later
+source-removal phase. New dataplane feature work should use the userspace path
+and close blockers tracked in
 [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
 
 ### Userspace Dataplane (primary target)
@@ -42,15 +43,15 @@ NIC → XDP shim (live-session + new-flow redirect, kernel pass-through, explici
 - **Per-worker architecture**: one worker per queue shard, with session/NAT/policy/FIB handled in Rust
 - **AF_XDP fast path**: current code supports both copy and zero-copy modes depending on driver/path behavior
 - **Kernel pass-through**: cpumap-assisted delivery keeps local/kernel-owned traffic out of the AF_XDP fast path
-- **Automatic fallback**: unsupported configs and explicit error paths still fall back to the legacy eBPF dataplane
+- **Fail-closed admission**: unsupported userspace configs should be gated or
+  fail closed rather than silently falling back to legacy eBPF
 - **Best for**: new dataplane development, primary validation, and high-throughput transit forwarding on supported configs
 - **See**: [`docs/userspace-dataplane-architecture.md`](docs/userspace-dataplane-architecture.md) for the current architecture and [`docs/userspace-debug-map.md`](docs/userspace-debug-map.md) for the active debugging map
 
-**To select the userspace dataplane:**
+**To tune the userspace dataplane:**
 
 ```junos
 system {
-    dataplane-type userspace;
     dataplane {
         binary /usr/local/sbin/xpf-userspace-dp;
         workers 6;
@@ -151,7 +152,7 @@ admission boundary is documented in
 - **IPsec SA sync**: shared IKE/ESP state across cluster nodes
 - **Dual fabric links**: independent fab0/fab1 for redundancy (no bonding)
 - **Fabric cross-chassis forwarding**: `try_fabric_redirect()` redirects to peer when FIB fails for synced sessions
-- **Dataplane watchdogs**: legacy BPF pins and userspace heartbeat checks fail closed on daemon/helper failure
+- **Dataplane watchdogs**: userspace heartbeat checks fail closed on daemon/helper failure; legacy BPF pins remain for explicitly selected eBPF compatibility
 - **Readiness gate**: per-RG readiness (interfaces + VRRP) + hold timer gates election
 - **Planned shutdown**: near-instant takeover (priority-0 burst), failback ~130ms
 - **ISSU**: in-service software upgrade with rolling deploy

--- a/cmd/xpfd/main.go
+++ b/cmd/xpfd/main.go
@@ -1,7 +1,6 @@
 // xpfd is the xpf firewall daemon.
 //
-// It provides a Junos-style CLI for configuring an eBPF-based firewall
-// that replicates Juniper vSRX capabilities.
+// It provides a Junos-style CLI for configuring the xpf firewall.
 package main
 
 import (
@@ -54,7 +53,7 @@ func main() {
 	}
 
 	configFile := flag.String("config", "/etc/xpf/xpf.conf", "configuration file path")
-	noDataplane := flag.Bool("no-dataplane", false, "run without eBPF (config-only mode)")
+	noDataplane := flag.Bool("no-dataplane", false, "run without a dataplane (config-only mode)")
 	apiAddr := flag.String("api-addr", "127.0.0.1:8080", "HTTP API listen address (empty to disable)")
 	grpcAddr := flag.String("grpc-addr", "127.0.0.1:50051", "gRPC API listen address")
 	debug := flag.Bool("debug", false, "enable debug logging")

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,10 +1,10 @@
 # Development workflow — plan, review, code, review, merge
 
 > Deprecation notice (#1373): new dataplane work and routine forwarding
-> validation target the Rust AF_XDP userspace dataplane by default. The legacy
-> eBPF dataplane remains in-tree for compatibility, rollback, and explicit
-> regression coverage during the staged retirement. Phase 1 updates active
-> documentation; later phases own source, loader, build, and CLI removals.
+> validation target the Rust AF_XDP userspace dataplane by default. Omitted
+> runtime configuration now selects userspace. The legacy eBPF dataplane
+> remains in-tree for explicit compatibility and regression coverage during the
+> staged retirement. Later phases own source, loader, build, and CLI removals.
 
 How non-trivial changes land in this repo. Roles and agent-boundary
 rules are in `AGENTS.md`; read that first. This doc is the process

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -131,6 +131,9 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 - `pkg/dataplane.DataPlane` is still load-bearing for API, gRPC, CLI, status,
   monitor, logging, cluster session sync, conntrack GC, daemon HA, daemon flow,
   and daemon apply bridges listed above.
+- Omitted `system dataplane-type` now resolves to the userspace runtime path.
+  Explicit `system dataplane-type ebpf` remains available only as a temporary
+  compatibility setting until source removal.
 - `pkg/dataplane/userspace.LegacyDataPlaneAdapter` is still required because
   userspace runtime construction returns a legacy-compatible adapter while
   unmigrated operator services consume old session, telemetry, and control

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,10 +1,10 @@
 # Testing & Performance Guide
 
 > Deprecation notice (#1373): routine dataplane validation now targets the
-> userspace AF_XDP cluster by default. The legacy eBPF dataplane remains
-> available for compatibility, rollback, and explicit regression coverage during
-> the staged retirement. Phase 1 updates active documentation; later phases own
-> source, loader, build, and CLI removals.
+> userspace AF_XDP cluster by default, and omitted runtime configuration now
+> selects userspace. The legacy eBPF dataplane remains available for explicit
+> compatibility and regression coverage during the staged retirement. Later
+> phases own source, loader, build, and CLI removals.
 
 This page still contains legacy eBPF standalone/HA procedures and historical
 performance notes. Treat them as regression context unless a workstream

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -9,14 +9,13 @@ Last updated: 2026-05-21
 
 ## Deprecation Context
 
-Issue #1373 retires the legacy eBPF dataplane in staged phases. As of Phase 1,
-the Rust AF_XDP userspace dataplane is the primary/default target for
-dataplane development and routine validation. Phase 1 is still documentation
-and migration-targeting work only: no BPF source, bpf2go bindings, loader code,
-test targets, or CLI surfaces are removed in this phase. Until the blockers
-below are closed, the legacy eBPF dataplane remains present as the
-compatibility and rollback path for configurations the AF_XDP userspace
-dataplane cannot yet own.
+Issue #1373 retires the legacy eBPF dataplane in staged phases. The Rust
+AF_XDP userspace dataplane is now the effective runtime default when
+`system dataplane-type` is omitted, and it remains the primary target for
+dataplane development and routine validation. No BPF source, bpf2go bindings,
+loader code, test targets, or CLI surfaces are removed in this phase. The
+legacy eBPF dataplane remains present only for explicit compatibility and
+regression use while the source-removal blockers close.
 
 DPDK is not part of the userspace retirement path. It remains a separately
 supported DPDK-build backend, but #1475 confines its root `DataPlane`
@@ -150,14 +149,16 @@ Those are separate questions. Use:
 There are two distinct fallback boundaries:
 
 1. **Compile-time / reconcile-time gate**
-   - The Go manager chooses `xdp_userspace_prog` or `xdp_main_prog`
-     depending on `deriveUserspaceCapabilities()`.
+   - The Go manager chooses the userspace runtime path by default. Explicit
+     legacy eBPF selection can still use `xdp_main_prog` while #1373 source
+     removal is staged.
 
 2. **Runtime XDP decision**
    - Even when `xdp_userspace_prog` is active, the XDP shim can still:
      - redirect to AF_XDP
      - send kernel-owned traffic to cpumap / kernel
-     - tail-call back into the legacy XDP pipeline for explicit fallback reasons
+     - tail-call back into the legacy XDP pipeline only for remaining explicit
+       compatibility fallback paths tracked by #1473
      - drop on dead/missing userspace bindings to fail closed
 
 ## Priority Work

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -924,7 +924,11 @@ func ValidateConfig(cfg *Config) []string {
 				}
 			}
 		}
-		if (len(cos.Interfaces) > 0 || len(cos.DSCPClassifiers) > 0 || len(cos.IEEE8021Classifiers) > 0 || len(cos.DSCPRewriteRules) > 0) && cfg.System.DataplaneType != "userspace" {
+		hasCoSRuntimeConfig := len(cos.Interfaces) > 0 ||
+			len(cos.DSCPClassifiers) > 0 ||
+			len(cos.IEEE8021Classifiers) > 0 ||
+			len(cos.DSCPRewriteRules) > 0
+		if hasCoSRuntimeConfig && effectiveDataplaneType(cfg.System.DataplaneType) != "userspace" {
 			warnings = append(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane; configuration is accepted but will not take effect on this dataplane")
 		}
 	}
@@ -932,8 +936,15 @@ func ValidateConfig(cfg *Config) []string {
 	return warnings
 }
 
+func effectiveDataplaneType(dpType string) string {
+	if dpType == "" {
+		return "userspace"
+	}
+	return dpType
+}
+
 func userspaceSynCookieProtectionActive(cfg *Config) bool {
-	if cfg == nil || cfg.System.DataplaneType != "userspace" ||
+	if cfg == nil || effectiveDataplaneType(cfg.System.DataplaneType) != "userspace" ||
 		cfg.Security.Flow.SynFloodProtectionMode != "syn-cookie" {
 		return false
 	}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -928,7 +928,7 @@ func ValidateConfig(cfg *Config) []string {
 			len(cos.DSCPClassifiers) > 0 ||
 			len(cos.IEEE8021Classifiers) > 0 ||
 			len(cos.DSCPRewriteRules) > 0
-		if hasCoSRuntimeConfig && effectiveDataplaneType(cfg.System.DataplaneType) != "userspace" {
+		if hasCoSRuntimeConfig && effectiveDataplaneType(cfg.System.DataplaneType) != dataplaneTypeUserspace {
 			warnings = append(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane; configuration is accepted but will not take effect on this dataplane")
 		}
 	}
@@ -936,15 +936,30 @@ func ValidateConfig(cfg *Config) []string {
 	return warnings
 }
 
+const (
+	dataplaneTypeEBPF      = "ebpf"
+	dataplaneTypeDPDK      = "dpdk"
+	dataplaneTypeUserspace = "userspace"
+)
+
 func effectiveDataplaneType(dpType string) string {
 	if dpType == "" {
-		return "userspace"
+		return dataplaneTypeUserspace
 	}
 	return dpType
 }
 
+func validDataplaneType(dpType string) bool {
+	switch dpType {
+	case dataplaneTypeEBPF, dataplaneTypeDPDK, dataplaneTypeUserspace:
+		return true
+	default:
+		return false
+	}
+}
+
 func userspaceSynCookieProtectionActive(cfg *Config) bool {
-	if cfg == nil || effectiveDataplaneType(cfg.System.DataplaneType) != "userspace" ||
+	if cfg == nil || effectiveDataplaneType(cfg.System.DataplaneType) != dataplaneTypeUserspace ||
 		cfg.Security.Flow.SynFloodProtectionMode != "syn-cookie" {
 		return false
 	}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -11,7 +11,7 @@ import (
 const sharedUMEMPhase0ArtifactMaxBytes = 16 << 20
 
 func compileSystem(node *Node, sys *SystemConfig) error {
-	dpType, err := resolveSystemDataplaneType(node)
+	dpType, err := compileSystemDataplaneType(node)
 	if err != nil {
 		return err
 	}
@@ -24,8 +24,8 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 				sys.HostName = child.Keys[1]
 			}
 		case "dataplane-type":
-			// Resolved before the main pass so a dataplane block uses the
-			// same validated type regardless of sibling order.
+			// Already resolved before child compilation so system dataplane
+			// dispatch is independent of statement ordering.
 		case "domain-name":
 			if len(child.Keys) >= 2 {
 				sys.DomainName = child.Keys[1]
@@ -225,21 +225,24 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 				sys.InternetOptions.NoIPv6RejectZeroHopLimit = true
 			}
 		case "dataplane":
-			switch sys.DataplaneType {
-			case "userspace":
+			switch effectiveDataplaneType(sys.DataplaneType) {
+			case dataplaneTypeUserspace:
 				if sys.UserspaceDataplane == nil {
 					sys.UserspaceDataplane = &UserspaceConfig{}
 				}
 				if err := compileUserspaceDataplane(child, sys.UserspaceDataplane); err != nil {
 					return err
 				}
-			default:
+			case dataplaneTypeDPDK:
 				if sys.DPDKDataplane == nil {
 					sys.DPDKDataplane = &DPDKConfig{}
 				}
 				if err := compileDPDKDataplane(child, sys.DPDKDataplane); err != nil {
 					return err
 				}
+			case dataplaneTypeEBPF:
+				// The legacy eBPF dataplane has no system dataplane
+				// sub-stanza. Do not route it through DPDK.
 			}
 		case "syslog":
 			sys.Syslog = &SystemSyslogConfig{}
@@ -367,28 +370,21 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	return nil
 }
 
-func resolveSystemDataplaneType(node *Node) (string, error) {
+func compileSystemDataplaneType(node *Node) (string, error) {
 	var dpType string
 	for _, child := range node.Children {
 		if child.Name() != "dataplane-type" || len(child.Keys) < 2 {
 			continue
 		}
-		value := child.Keys[1]
-		if err := validateSystemDataplaneType(value); err != nil {
-			return "", err
+		next := child.Keys[1]
+		if !validDataplaneType(next) {
+			return "", fmt.Errorf(
+				"unknown dataplane-type %q; dataplane-type %q is invalid; valid values are ebpf, dpdk, userspace",
+				next, next)
 		}
-		dpType = value
+		dpType = next
 	}
 	return dpType, nil
-}
-
-func validateSystemDataplaneType(dpType string) error {
-	switch dpType {
-	case "", "ebpf", "dpdk", "userspace":
-		return nil
-	default:
-		return fmt.Errorf("dataplane-type %q is invalid; valid values are ebpf, dpdk, userspace", dpType)
-	}
 }
 
 func hasDNSProxyChild(node *Node) bool {

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -960,8 +960,8 @@ func TestValidateClassOfServiceWarnings(t *testing.T) {
 	if !strings.Contains(warnings, "dscp rewrite-rule loss-priority is accepted for compatibility but not yet enforced") {
 		t.Fatalf("expected rewrite-rule loss-priority warning, got: %s", warnings)
 	}
-	if !strings.Contains(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane") {
-		t.Fatalf("expected dataplane warning, got: %s", warnings)
+	if strings.Contains(warnings, "class-of-service shaping, classifier attachment, and dscp rewrite-rule attachment are only implemented in the userspace dataplane") {
+		t.Fatalf("unexpected dataplane warning for default userspace path: %s", warnings)
 	}
 }
 

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -2400,7 +2400,7 @@ func TestValidateConfigDoesNotWarnDormantSynCookieWithoutRootSecret(t *testing.T
 	}
 }
 
-func TestValidateConfigDoesNotWarnDefaultDataplaneSynCookieWithoutRootSecret(t *testing.T) {
+func TestValidateConfigWarnsDefaultUserspaceSynCookieWithoutRootSecret(t *testing.T) {
 	tree := &ConfigTree{}
 	setCommands := []string{
 		"set security flow syn-flood-protection-mode syn-cookie",
@@ -2422,8 +2422,8 @@ func TestValidateConfigDoesNotWarnDefaultDataplaneSynCookieWithoutRootSecret(t *
 	}
 
 	warnings := strings.Join(cfg.Warnings, "\n")
-	if strings.Contains(warnings, "active userspace-dp SYN-cookie screen profiles require") {
-		t.Fatalf("unexpected default-dataplane SYN-cookie warning: %s", warnings)
+	if !strings.Contains(warnings, "active userspace-dp SYN-cookie screen profiles require") {
+		t.Fatalf("expected default-userspace SYN-cookie warning, got: %s", warnings)
 	}
 }
 

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -391,13 +391,14 @@ system {
 //   - hierarchical nested: archive-sites { "<url>" { password "..."; } }
 //   - hierarchical leaf:   archive-sites { "<url>" password "..."; }
 //   - flat-set:            set system archival ... archive-sites "<url>" password "..."
+//
 // The existing ValidateConfig test pre-populates the slice; this test
 // exercises the compile-time extraction so regressions in how Junos
 // shapes enter ArchiveSitesWithPassword are caught at the parser level.
 func TestArchiveSitesPasswordParsed(t *testing.T) {
 	type want struct {
-		urls        []string
-		withPasswd  []string
+		urls       []string
+		withPasswd []string
 	}
 
 	cases := []struct {
@@ -1358,4 +1359,93 @@ func TestDataplaneWorkersCanonicalPathParses(t *testing.T) {
 	if cfg.System.UserspaceDataplane.Workers != 7 {
 		t.Errorf("Workers: got %d, want 7", cfg.System.UserspaceDataplane.Workers)
 	}
+}
+
+func TestDataplaneWorkersOmittedTypeUsesUserspaceDefault(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set system dataplane workers 8",
+	} {
+		fields := strings.Fields(cmd)
+		if err := tree.SetPath(fields[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.DataplaneType != "" {
+		t.Fatalf("DataplaneType = %q, want omitted empty value", cfg.System.DataplaneType)
+	}
+	if cfg.System.DPDKDataplane != nil {
+		t.Fatalf("DPDKDataplane = %+v, want nil for omitted dataplane-type", cfg.System.DPDKDataplane)
+	}
+	if cfg.System.UserspaceDataplane == nil {
+		t.Fatal("expected UserspaceDataplane to be populated")
+	}
+	if cfg.System.UserspaceDataplane.Workers != 8 {
+		t.Fatalf("Workers = %d, want 8", cfg.System.UserspaceDataplane.Workers)
+	}
+}
+
+func TestDataplaneTypeValidationRejectsUnknownDuplicateValues(t *testing.T) {
+	t.Run("unknown", func(t *testing.T) {
+		tree := &ConfigTree{}
+		for _, cmd := range []string{
+			"set system dataplane-type mystery",
+			"set system dataplane workers 8",
+		} {
+			fields := strings.Fields(cmd)
+			if err := tree.SetPath(fields[1:]); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+
+		_, err := CompileConfig(tree)
+		if err == nil || !strings.Contains(err.Error(), `unknown dataplane-type "mystery"`) {
+			t.Fatalf("CompileConfig error = %v, want unknown dataplane-type rejection", err)
+		}
+	})
+
+	t.Run("valid then unknown", func(t *testing.T) {
+		parser := NewParser(`
+system {
+    dataplane-type userspace;
+    dataplane-type mystery;
+    dataplane {
+        workers 8;
+    }
+}`)
+		tree, parseErrs := parser.Parse()
+		if len(parseErrs) > 0 {
+			t.Fatalf("Parse errors: %v", parseErrs)
+		}
+
+		_, err := CompileConfig(tree)
+		if err == nil || !strings.Contains(err.Error(), `unknown dataplane-type "mystery"`) {
+			t.Fatalf("CompileConfig error = %v, want unknown dataplane-type rejection", err)
+		}
+	})
+
+	t.Run("unknown then valid", func(t *testing.T) {
+		parser := NewParser(`
+system {
+    dataplane-type mystery;
+    dataplane-type userspace;
+    dataplane {
+        workers 8;
+    }
+}`)
+		tree, parseErrs := parser.Parse()
+		if len(parseErrs) > 0 {
+			t.Fatalf("Parse errors: %v", parseErrs)
+		}
+
+		_, err := CompileConfig(tree)
+		if err == nil || !strings.Contains(err.Error(), `unknown dataplane-type "mystery"`) {
+			t.Fatalf("CompileConfig error = %v, want unknown dataplane-type rejection", err)
+		}
+	})
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -433,7 +433,7 @@ type SystemConfig struct {
 	BackupRouterDst          string   // backup router destination prefix
 	Lo0FilterInputV4         string   // lo0 unit 0 family inet filter input (host-bound filtering)
 	Lo0FilterInputV6         string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
-	DataplaneType            string   // "ebpf" (default), "dpdk", or "userspace"
+	DataplaneType            string   // empty defaults to "userspace"; explicit "ebpf" is legacy
 	DPDKDataplane            *DPDKConfig
 	UserspaceDataplane       *UserspaceConfig
 	InternetOptions          *InternetOptionsConfig

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -43,7 +43,7 @@ import (
 // Options configures the daemon.
 type Options struct {
 	ConfigFile  string
-	NoDataplane bool   // set to true to run without eBPF (config-only mode)
+	NoDataplane bool   // set to true to run without a dataplane (config-only mode)
 	APIAddr     string // HTTP API listen address (empty = disabled)
 	GRPCAddr    string // gRPC API listen address (empty = disabled)
 	Version     string // software version string
@@ -59,7 +59,7 @@ const nodeIDFile = "/etc/xpf/node-id"
 type Daemon struct {
 	opts                       Options
 	store                      *configstore.Store
-	dp  dataplane.RuntimeDataPlane
+	dp                         dataplane.RuntimeDataPlane
 	networkd                   *networkd.Manager
 	routing                    *routing.Manager
 	frr                        *frr.Manager

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1010,7 +1010,8 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 			coalesceExplicit  bool
 			claimHostTunables bool
 		)
-		if cfg.System.DataplaneType == "userspace" && cfg.System.UserspaceDataplane != nil {
+		if dataplane.EffectiveType(cfg.System.DataplaneType) == dataplane.TypeUserspace &&
+			cfg.System.UserspaceDataplane != nil {
 			userspaceDP = true
 			workers = cfg.System.UserspaceDataplane.Workers
 			if cfg.System.UserspaceDataplane.RSSIndirectionDisabled {

--- a/pkg/daemon/daemon_gc.go
+++ b/pkg/daemon/daemon_gc.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/psaab/xpf/pkg/conntrack"
+)
+
+func (d *Daemon) newConntrackGC(interval time.Duration) *conntrack.GC {
+	if d.dp == nil {
+		return conntrack.NewGCWithDomains(nil, nil, nil, nil, interval)
+	}
+
+	sessions := d.dp.Sessions()
+	telemetry := d.dp.Telemetry()
+	if lp := d.legacyDP(); lp != nil {
+		// Legacy eBPF keeps session-count publishing and persistent-NAT
+		// ownership on the DataPlane surface while sessions/telemetry are
+		// migrated to runtime domains.
+		return conntrack.NewGCWithDomains(sessions, telemetry, lp, lp, interval)
+	}
+	return conntrack.NewGCWithDomains(sessions, telemetry, nil, nil, interval)
+}

--- a/pkg/daemon/daemon_gc_test.go
+++ b/pkg/daemon/daemon_gc_test.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpruntime "github.com/psaab/xpf/pkg/dataplane/runtime"
+)
+
+func TestDaemonConntrackGCPreservesLegacyDomains(t *testing.T) {
+	dp := &legacyRuntimeGCDomainTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			{
+				SrcIP:    [4]byte{10, 0, 0, 1},
+				DstIP:    [4]byte{10, 0, 0, 2},
+				SrcPort:  10001,
+				DstPort:  443,
+				Protocol: 6,
+			}: {
+				State:       dataplane.SessStateEstablished,
+				LastSeen:    1 << 60,
+				Timeout:     3600,
+				IngressZone: 7,
+			},
+		},
+	}
+	d := &Daemon{dp: dp}
+	gc := d.newConntrackGC(time.Millisecond)
+	gc.SetSessionLimitEnabled(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		gc.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if dp.srcUpdates.Load() > 0 && dp.dstUpdates.Load() > 0 && dp.persistentCalls.Load() > 0 {
+			cancel()
+			<-done
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	t.Fatalf(
+		"GC legacy domain calls: srcUpdates=%d dstUpdates=%d persistentCalls=%d, want all > 0",
+		dp.srcUpdates.Load(),
+		dp.dstUpdates.Load(),
+		dp.persistentCalls.Load(),
+	)
+}
+
+type legacyRuntimeGCDomainTestDP struct {
+	dataplane.DataPlane
+
+	v4              map[dataplane.SessionKey]dataplane.SessionValue
+	srcUpdates      atomic.Int32
+	dstUpdates      atomic.Int32
+	persistentCalls atomic.Int32
+}
+
+func (d *legacyRuntimeGCDomainTestDP) Start(context.Context) error { return nil }
+func (d *legacyRuntimeGCDomainTestDP) Close() error                { return nil }
+func (d *legacyRuntimeGCDomainTestDP) Teardown() error             { return nil }
+
+func (d *legacyRuntimeGCDomainTestDP) ApplyConfig(context.Context, *config.Config) (*dataplane.ApplyResult, error) {
+	return &dataplane.ApplyResult{}, nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) LastApplyResult() *dataplane.ApplyResult {
+	return &dataplane.ApplyResult{}
+}
+
+func (d *legacyRuntimeGCDomainTestDP) Link() dataplane.LinkController {
+	return noopLinkController{}
+}
+
+func (d *legacyRuntimeGCDomainTestDP) HA() dataplane.HAController {
+	return dataplane.NewDataPlaneHAController(nil)
+}
+
+func (d *legacyRuntimeGCDomainTestDP) Sessions() dataplane.SessionStore {
+	return dataplane.NewDataPlaneSessionStore(d)
+}
+
+func (d *legacyRuntimeGCDomainTestDP) Telemetry() dataplane.Telemetry {
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) SessionDeltas() dpruntime.SessionDeltaSource {
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) UpdateSessionCountSrc(dataplane.SessionCountKey, uint32) error {
+	d.srcUpdates.Add(1)
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) UpdateSessionCountDst(dataplane.SessionCountKey, uint32) error {
+	d.dstUpdates.Add(1)
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) ClearSessionCounts() error {
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) GetPersistentNAT() *dataplane.PersistentNATTable {
+	d.persistentCalls.Add(1)
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) BatchIterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for key, val := range d.v4 {
+		if !fn(key, val) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *legacyRuntimeGCDomainTestDP) BatchIterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -65,7 +65,10 @@ func strictVIPOwnershipByDefault(cc *config.ClusterConfig, cfg *config.Config) b
 	// already being forwarding-ready before VIP/MAC ownership moves. Waiting
 	// for the VRRP MASTER event to derive rg_active leaves a cutover window
 	// where reply packets can hit the promoted node before userspace is active.
-	return cfg == nil || cfg.System.DataplaneType != dataplane.TypeUserspace
+	if cfg == nil {
+		return false
+	}
+	return dataplane.EffectiveType(cfg.System.DataplaneType) != dataplane.TypeUserspace
 }
 
 func (d *Daemon) setLocalFailoverCommitReady(rgID int, ready bool) {

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -1018,7 +1018,7 @@ func (d *Daemon) userspaceDataplaneActive() bool {
 }
 
 func userspaceRGConfigured(cfg *config.Config, rgID int) bool {
-	if cfg == nil || cfg.System.DataplaneType != dataplane.TypeUserspace || rgID <= 0 {
+	if cfg == nil || dataplane.EffectiveType(cfg.System.DataplaneType) != dataplane.TypeUserspace || rgID <= 0 {
 		return false
 	}
 	for _, ifc := range cfg.Interfaces.Interfaces {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -46,7 +46,7 @@ func collectAppliedTunnels(cfg *config.Config) []*config.TunnelConfig {
 	if cfg == nil {
 		return nil
 	}
-	anchorOnly := cfg.System.DataplaneType == dataplane.TypeUserspace
+	anchorOnly := dataplane.EffectiveType(cfg.System.DataplaneType) == dataplane.TypeUserspace
 	var tunnels []*config.TunnelConfig
 	for _, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
@@ -131,7 +131,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// reshape mlx5 RSS indirection before any AF_XDP bind. Zero
 			// when userspace dataplane is not in use — applyRSSIndirection
 			// treats that as a no-op.
-			if cfg.System.DataplaneType == "userspace" && cfg.System.UserspaceDataplane != nil {
+			if dataplane.EffectiveType(cfg.System.DataplaneType) == dataplane.TypeUserspace &&
+				cfg.System.UserspaceDataplane != nil {
 				userspaceDP = true
 				userspaceWorkers = cfg.System.UserspaceDataplane.Workers
 				if cfg.System.UserspaceDataplane.RSSIndirectionDisabled {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/psaab/xpf/pkg/cli"
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
-	"github.com/psaab/xpf/pkg/conntrack"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/dhcprelay"
@@ -307,13 +306,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			lp.StartFIBSync(ctx)
 		}
 
-		gc := conntrack.NewGCWithDomains(
-			d.dp.Sessions(),
-			d.dp.Telemetry(),
-			nil,
-			nil,
-			10*time.Second,
-		)
+		gc := d.newConntrackGC(10 * time.Second)
 		d.gc = gc
 
 		// When the userspace dataplane is active, skip BPF session map

--- a/pkg/daemon/per_rg_test.go
+++ b/pkg/daemon/per_rg_test.go
@@ -107,26 +107,26 @@ func TestRethMasterState_MultiRG(t *testing.T) {
 	}
 }
 
-func TestStrictVIPOwnershipByDefault_DefaultsToStrictInVRRPMode(t *testing.T) {
+func TestStrictVIPOwnershipByDefault_DefaultUserspaceKeepsVRRPLoose(t *testing.T) {
 	cc := &config.ClusterConfig{
 		RedundancyGroups: []*config.RedundancyGroup{{ID: 1}},
 	}
 	cfg := &config.Config{}
 
-	if !strictVIPOwnershipByDefault(cc, cfg) {
-		t.Fatal("expected strict VIP ownership to default on in VRRP mode")
+	if strictVIPOwnershipByDefault(cc, cfg) {
+		t.Fatal("expected strict VIP ownership off for default userspace dataplane")
 	}
 }
 
-func TestStrictVIPOwnershipByDefault_DisabledInUserspaceVRRPMode(t *testing.T) {
+func TestStrictVIPOwnershipByDefault_EnabledInLegacyEBPFVRRPMode(t *testing.T) {
 	cc := &config.ClusterConfig{
 		RedundancyGroups: []*config.RedundancyGroup{{ID: 1}},
 	}
 	cfg := &config.Config{}
-	cfg.System.DataplaneType = dataplane.TypeUserspace
+	cfg.System.DataplaneType = dataplane.TypeEBPF
 
-	if strictVIPOwnershipByDefault(cc, cfg) {
-		t.Fatal("expected strict VIP ownership to stay off in userspace VRRP mode")
+	if !strictVIPOwnershipByDefault(cc, cfg) {
+		t.Fatal("expected strict VIP ownership on for explicit legacy eBPF VRRP mode")
 	}
 }
 

--- a/pkg/daemon/tunnel_anchor_test.go
+++ b/pkg/daemon/tunnel_anchor_test.go
@@ -30,6 +30,28 @@ func TestCollectAppliedTunnelsUsesAnchorModeForUserspace(t *testing.T) {
 	}
 }
 
+func TestCollectAppliedTunnelsUsesAnchorModeForDefaultDataplane(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"gr-0/0/0": {
+			Tunnel: &config.TunnelConfig{
+				Name:        "gr-0-0-0",
+				Mode:        "gre",
+				Source:      "2001:db8::1",
+				Destination: "2001:db8::2",
+			},
+		},
+	}
+
+	tunnels := collectAppliedTunnels(cfg)
+	if len(tunnels) != 1 {
+		t.Fatalf("len(tunnels) = %d, want 1", len(tunnels))
+	}
+	if !tunnels[0].AnchorOnly {
+		t.Fatal("default userspace tunnel should be anchor-only")
+	}
+}
+
 func TestCollectAppliedTunnelsKeepsKernelModeForLegacyDataplane(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.System.DataplaneType = dataplane.TypeEBPF

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -317,7 +317,7 @@ func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 func TestUserspaceRGConfigured(t *testing.T) {
 	cfg := &config.Config{
 		System: config.SystemConfig{
-			DataplaneType: dataplane.TypeUserspace,
+			DataplaneType: "",
 		},
 		Interfaces: config.InterfacesConfig{
 			Interfaces: map[string]*config.InterfaceConfig{
@@ -347,5 +347,10 @@ func TestUserspaceRGConfigured(t *testing.T) {
 	}
 	if userspaceRGConfigured(nil, 1) {
 		t.Fatal("expected nil config not configured")
+	}
+
+	cfg.System.DataplaneType = dataplane.TypeEBPF
+	if userspaceRGConfigured(cfg, 1) {
+		t.Fatal("expected explicit legacy eBPF config not configured for userspace RG")
 	}
 }

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -47,9 +47,11 @@ sent while exact queues were still backlogged.
   compile/config entry point; userspace AF_XDP does not need to implement the
   legacy BPF-shaped `Compile` method just to receive committed config.
 - `NewRuntimeDataPlane(dpType)` — `dataplane.go`. Runtime-domain constructor
-  used by `pkg/daemon`; userspace registers only on this path. The current
-  userspace constructor returns a compatibility adapter around `*userspace.Manager`
-  until the remaining status/session-sync callers stop requiring `DataPlane`.
+  used by `pkg/daemon`; an empty `dpType` now resolves to userspace instead
+  of silently selecting legacy eBPF. Userspace registers only on this path. The
+  current userspace constructor returns a compatibility adapter around
+  `*userspace.Manager` until the remaining status/session-sync callers stop
+  requiring `DataPlane`.
 - `Manager` — `loader.go`. eBPF implementation.
 - `New() *Manager` — `loader.go`.
 - `Compile(cfg *config.Config) (*CompileResult, error)` — multi-phase

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -16,10 +16,20 @@ var _ RuntimeDataPlane = (*Manager)(nil)
 
 // Dataplane type constants used in system { dataplane-type <type>; }.
 const (
-	TypeEBPF      = "ebpf" // default
+	TypeEBPF      = "ebpf"
 	TypeDPDK      = "dpdk"
 	TypeUserspace = "userspace"
 )
+
+// EffectiveType resolves the operator-facing dataplane type.  The empty
+// config value now means the userspace runtime path; callers must not treat an
+// omitted value as legacy eBPF fallback.
+func EffectiveType(dpType string) string {
+	if dpType == "" {
+		return TypeUserspace
+	}
+	return dpType
+}
 
 func UserspaceCtrlPinPath() string {
 	return filepath.Join(bpfPinPath, "userspace_ctrl")
@@ -92,11 +102,18 @@ func RegisterRuntimeBackend(dpType string, ctor func() RuntimeDataPlane) {
 	runtimeBackendRegistry[dpType] = ctor
 }
 
-// NewDataPlane creates a DataPlane backend based on the given type string.
-// An empty string defaults to eBPF.
+// NewDataPlane creates a legacy DataPlane backend based on the given type
+// string.  It intentionally does not accept the empty default: daemon startup
+// must use NewRuntimeDataPlane so omitted config resolves to userspace instead
+// of silently falling back to legacy eBPF.
 func NewDataPlane(dpType string) (DataPlane, error) {
 	switch dpType {
-	case "", TypeEBPF:
+	case "":
+		return nil, fmt.Errorf(
+			"empty dataplane type defaults to %q; use NewRuntimeDataPlane for default selection",
+			TypeUserspace,
+		)
+	case TypeEBPF:
 		return New(), nil
 	default:
 		if ctor, ok := backendRegistry[dpType]; ok {
@@ -110,12 +127,16 @@ func NewDataPlane(dpType string) (DataPlane, error) {
 // Userspace registers here directly so daemon startup does not require a
 // legacy BPF-shaped DataPlane compatibility adapter.
 func NewRuntimeDataPlane(dpType string) (RuntimeDataPlane, error) {
+	dpType = EffectiveType(dpType)
 	switch dpType {
-	case "", TypeEBPF:
+	case TypeEBPF:
 		return New(), nil
 	default:
 		if ctor, ok := runtimeBackendRegistry[dpType]; ok {
 			return ctor(), nil
+		}
+		if dpType == TypeUserspace {
+			return nil, fmt.Errorf("dataplane type %q runtime backend is not registered", dpType)
 		}
 		dp, err := NewDataPlane(dpType)
 		if err != nil {

--- a/pkg/dataplane/default_test.go
+++ b/pkg/dataplane/default_test.go
@@ -1,0 +1,41 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEffectiveTypeDefaultsToUserspace(t *testing.T) {
+	t.Parallel()
+
+	if got := EffectiveType(""); got != TypeUserspace {
+		t.Fatalf("EffectiveType(\"\") = %q, want %q", got, TypeUserspace)
+	}
+	if got := EffectiveType(TypeEBPF); got != TypeEBPF {
+		t.Fatalf("EffectiveType(%q) = %q, want %q", TypeEBPF, got, TypeEBPF)
+	}
+}
+
+func TestNewDataPlaneRejectsEmptyDefault(t *testing.T) {
+	t.Parallel()
+
+	dp, err := NewDataPlane("")
+	if err == nil {
+		t.Fatalf("NewDataPlane(\"\") = %T, nil error; want explicit default rejection", dp)
+	}
+	if !strings.Contains(err.Error(), "defaults to \"userspace\"") {
+		t.Fatalf("NewDataPlane(\"\") error = %q, want userspace default hint", err)
+	}
+}
+
+func TestNewRuntimeDataPlaneMissingUserspaceBackendDoesNotUseEBPF(t *testing.T) {
+	t.Parallel()
+
+	dp, err := NewRuntimeDataPlane("")
+	if err == nil {
+		t.Fatalf("NewRuntimeDataPlane(\"\") = %T, nil error; want missing userspace backend", dp)
+	}
+	if !strings.Contains(err.Error(), "userspace") {
+		t.Fatalf("NewRuntimeDataPlane(\"\") error = %q, want userspace backend error", err)
+	}
+}

--- a/pkg/dataplane/userspace/manager_coupling_test.go
+++ b/pkg/dataplane/userspace/manager_coupling_test.go
@@ -92,6 +92,14 @@ func TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers(t *testin
 	if _, ok := any(dp).(dataplane.DataPlane); !ok {
 		t.Fatalf("NewRuntimeDataPlane(userspace) = %T, want legacy-compatible adapter", dp)
 	}
+
+	defaultDP, err := dataplane.NewRuntimeDataPlane("")
+	if err != nil {
+		t.Fatalf("NewRuntimeDataPlane(default): %v", err)
+	}
+	if _, ok := any(defaultDP).(*LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("NewRuntimeDataPlane(default) = %T, want *LegacyDataPlaneAdapter", defaultDP)
+	}
 }
 
 func exprString(expr ast.Expr) string {


### PR DESCRIPTION
## Summary

This advances #1474 by making omitted `system dataplane-type` select the
userspace AF_XDP runtime path instead of silently constructing the legacy eBPF
manager.

Changes:

- adds `dataplane.EffectiveType`, with empty config resolving to `userspace`
- makes legacy `NewDataPlane("")` fail with a default-selection hint so daemon
  startup must use `NewRuntimeDataPlane`
- updates daemon/config branches that previously compared raw
  `DataplaneType == "userspace"`
- updates docs to describe explicit `dataplane-type ebpf` as the temporary
  compatibility path until source removal
- adds tests for constructor defaulting, SYN-cookie warnings, CoS warning
  behavior, tunnel anchor mode, VRRP ownership, and RG userspace detection

This does not remove explicit `dataplane-type ebpf`; final source/config
removal remains part of #1476 and the later #1373 deletion phase.

## Validation

- `go test ./pkg/config ./pkg/daemon ./pkg/dataplane ./pkg/dataplane/userspace ./cmd/xpfd`
- `git diff --check`

Refs #1373
Refs #1474