### PR TITLE
Retire stale eBPF firewall branding

### DIFF
--- a/cmd/xpfd/README.md
+++ b/cmd/xpfd/README.md
@@ -1,8 +1,8 @@
 # cmd/xpfd
 
-The xpfd daemon — the firewall control plane. Loads eBPF (or spawns the
-Rust AF_XDP helper), applies compiled config to every subsystem,
-handles signals, and exposes gRPC + HTTP REST + an interactive CLI.
+The xpfd daemon — the firewall control plane. Starts the configured
+dataplane, applies compiled config to every subsystem, handles signals,
+and exposes gRPC + HTTP REST + an interactive CLI.
 
 ## Entry
 
@@ -13,8 +13,8 @@ manager from `pkg/*` and runs them under an errgroup.
 ## Flags
 
 - `-config` — config file path. Default `/etc/xpf/xpf.conf`.
-- `-no-dataplane` — config-only mode (parse + validate without loading
-  BPF). Useful for offline checks.
+- `-no-dataplane` — config-only mode (parse + validate without starting
+  the dataplane). Useful for offline checks.
 - `-api-addr` — HTTP REST listener. Default `127.0.0.1:8080`.
 - `-grpc-addr` — gRPC listener. Default `127.0.0.1:50051`.
 - `-debug` — verbose logging.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -626,7 +626,7 @@ func (c *CLI) Run() error {
 		fmt.Fprintf(os.Stderr, "\ncommit confirmed timed out, configuration has been rolled back\n")
 	})
 
-	fmt.Println("xpf firewall - Junos-style eBPF firewall")
+	fmt.Println("xpf stateful firewall - Junos-style CLI")
 	fmt.Println("Type '?' for help")
 	fmt.Println()
 

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -744,7 +744,7 @@ func (c *CLI) showVersion() error {
 	if ver == "" {
 		ver = "dev"
 	}
-	fmt.Printf("xpf eBPF firewall %s\n", ver)
+	fmt.Printf("xpf stateful firewall %s\n", ver)
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err == nil {
 		sysname := strings.TrimRight(string(uts.Sysname[:]), "\x00")

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -39,7 +39,7 @@ func (s *Server) showVersion(buf *strings.Builder) {
 	if ver == "" {
 		ver = "dev"
 	}
-	fmt.Fprintf(buf, "xpf eBPF firewall %s\n", ver)
+	fmt.Fprintf(buf, "xpf stateful firewall %s\n", ver)
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err == nil {
 		sysname := strings.TrimRight(string(uts.Sysname[:]), "\x00")

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -76,7 +76,7 @@ func TestEncodeTTL(t *testing.T) {
 
 func TestBuildFrame(t *testing.T) {
 	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
-	frame := BuildFrame(mac, "trust0", 120, "xpf", "eBPF firewall")
+	frame := BuildFrame(mac, "trust0", 120, "xpf", "stateful firewall")
 
 	// Check Ethernet header.
 	if len(frame) < ethHdrLen {
@@ -118,8 +118,8 @@ func TestBuildFrame(t *testing.T) {
 	if neighbor.SystemName != "xpf" {
 		t.Errorf("system name: got %s, want xpf", neighbor.SystemName)
 	}
-	if neighbor.SystemDesc != "eBPF firewall" {
-		t.Errorf("system desc: got %s, want 'eBPF firewall'", neighbor.SystemDesc)
+	if neighbor.SystemDesc != "stateful firewall" {
+		t.Errorf("system desc: got %s, want 'stateful firewall'", neighbor.SystemDesc)
 	}
 	if neighbor.PortDesc != "trust0" {
 		t.Errorf("port desc: got %s, want trust0", neighbor.PortDesc)

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -415,7 +415,7 @@ func (a *Agent) isValidCommunity(community string) bool {
 func (a *Agent) getOIDValue(oid []int) ([]byte, byte) {
 	// System MIB group
 	if oidEqual(oid, oidSysDescr) {
-		desc := "xpf eBPF firewall"
+		desc := "xpf stateful firewall"
 		if a.cfg != nil && a.cfg.Description != "" {
 			desc = a.cfg.Description
 		}

--- a/pkg/snmp/agent_test.go
+++ b/pkg/snmp/agent_test.go
@@ -271,7 +271,7 @@ func TestGetOIDValue_SysDescr(t *testing.T) {
 func TestGetOIDValue_SysDescr_Default(t *testing.T) {
 	a := NewAgent(&config.SNMPConfig{})
 	val, tag := a.getOIDValue(oidSysDescr)
-	if tag != tagOctetString || string(val) != "xpf eBPF firewall" {
+	if tag != tagOctetString || string(val) != "xpf stateful firewall" {
 		t.Errorf("sysDescr default: tag=%d val=%q", tag, val)
 	}
 }

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -2,7 +2,7 @@
 # xpf Incus test environment management
 #
 # Creates an isolated VM or privileged container with multiple network
-# interfaces for testing the xpf eBPF firewall.
+# interfaces for testing the xpf userspace dataplane firewall.
 #
 # Usage:
 #   ./test/incus/setup.sh init        # Install incus, create networks + profiles

--- a/test/incus/xpfd.service
+++ b/test/incus/xpfd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=xpf eBPF Firewall Daemon
+Description=xpf Stateful Firewall Daemon
 After=network-online.target frr.service
 Wants=network-online.target
 


### PR DESCRIPTION
## Summary

- replace current operator-facing eBPF firewall branding with neutral stateful firewall wording
- update CLI, gRPC show version, SNMP sysDescr, LLDP fixture expectations, xpfd README, and Incus test surfaces
- leave historical issue, PR, and session archives unchanged

## Validation

- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/snmp
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/snmp ./pkg/lldp ./pkg/cli ./pkg/grpcapi
- git diff --check
- rg -n -i "ebpf firewall|xpf ebpf|junos-style ebpf|loads ebpf|loading bpf|without loading bpf|spawns? (the )?(rust )?af_xdp helper" -g '!docs/issues/**' -g '!docs/pr/**' -g '!docs/session-history.md' .
