### PR TITLE
config: warn on explicit legacy ebpf dataplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Stateful firewall with native Junos configuration syntax.
 > Deprecation notice (#1373): the Rust AF_XDP userspace dataplane is now the
 > primary/default target for dataplane development, validation, and omitted
 > runtime configuration. The legacy eBPF dataplane remains in-tree for
-> explicit compatibility and regression coverage during the staged retirement.
-> Later phases own source, loader, build, and CLI removals.
+> explicit compatibility and regression coverage during the staged retirement;
+> explicit `system dataplane-type ebpf` now emits a compile warning. Later
+> phases own source, loader, build, and CLI removals.
 
 xpf is a high-performance stateful firewall that replicates Juniper vSRX
 capabilities. It uses the familiar Junos hierarchical configuration syntax and
@@ -21,9 +22,9 @@ forwarding path differs.
 The userspace AF_XDP backend is the default runtime target. Operators may still
 set `system dataplane-type userspace` explicitly, but omitting that knob also
 selects the userspace runtime path. The legacy eBPF backend remains available
-only through an explicit `system dataplane-type ebpf` selection until the later
-source-removal phase. New dataplane feature work should use the userspace path
-and close blockers tracked in
+only through an explicit, warned `system dataplane-type ebpf` selection until
+the later source-removal phase. New dataplane feature work should use the
+userspace path and close blockers tracked in
 [`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
 
 ### Userspace Dataplane (primary target)
@@ -74,7 +75,7 @@ XDP Ingress: main -> screen -> zone -> conntrack -> policy -> nat -> nat64 -> fo
 TC Egress:   main -> screen_egress -> conntrack -> nat -> forward
 ```
 
-- **Legacy coverage**: compatibility, rollback, and targeted regression tests
+- **Legacy coverage**: explicit compatibility and targeted regression tests
 - **Historical performance**: 25+ Gbps on native XDP (mlx5, i40e, ice)
 - **Best for**: reproducing legacy behavior while #1373 retirement blockers are being closed
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -152,7 +152,8 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
   and daemon apply bridges listed above.
 - Omitted `system dataplane-type` now resolves to the userspace runtime path.
   Explicit `system dataplane-type ebpf` remains available only as a temporary
-  compatibility setting until source removal.
+  compatibility setting until source removal, and config compile emits a
+  deprecation warning when it is selected.
 - `pkg/dataplane/userspace.LegacyDataPlaneAdapter` is still required because
   userspace runtime construction returns a legacy-compatible adapter while
   unmigrated operator services consume old session, telemetry, and control

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -15,7 +15,9 @@ AF_XDP userspace dataplane is now the effective runtime default when
 dataplane development and routine validation. No BPF source, bpf2go bindings,
 loader code, test targets, or CLI surfaces are removed in this phase. The
 legacy eBPF dataplane remains present only for explicit compatibility and
-regression use while the source-removal blockers close.
+regression use while the source-removal blockers close. Explicit
+`system dataplane-type ebpf` is accepted only with a compile warning; it is not
+the omitted/default dataplane path.
 
 DPDK is not part of the userspace retirement path. It remains a separately
 supported DPDK-build backend, but #1475 confines its root `DataPlane`
@@ -35,7 +37,7 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | Policy schedulers | Implemented; live HA evidence captured | Scheduled-policy `scheduler_name` and `inactive` bits are published in userspace snapshots, old helper protocol mismatches disarm forwarding, missing policy-scheduler references are commit errors, and Rust hit counters survive active/inactive snapshot rebuilds by stable rule ID. The 2026-05-19 #1378 live artifact set is accepted by `test/incus/policy_scheduler_validate.py` for `lan->wan/scheduled-allow`. |
 | Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
 | Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
-| Source NAT (pool mode) | Implemented with scoped caveats | IPv4/IPv6 pool address and port allocation. Global `source address-persistent` uses the documented userspace-v1 SHA-256 source-IP hash and is stable only within the AF_XDP backend, pool family, pool order, and pool size. Legacy eBPF and current DPDK use C-word IPv4 modulo / IPv6 lane-XOR selection, so new-flow pool address parity is not promised across backend rollback. Pool-mode rules with missing pools, empty pools, invalid port ranges, malformed addresses, no address for the packet family, or exhausted live translated tuples fail closed at the `poll_descriptor.rs` source-NAT call sites before session creation or forwarding, with recent-exception reasons such as `source_nat_pool_missing`, `source_nat_pool_empty`, `source_nat_pool_invalid_port_range`, and `source_nat_pool_exhausted`. Per-pool `persistent-nat` now has snapshot fields and runtime lease reuse keyed by source tuple `(protocol, source IP, source port)` to translated tuple. The lease table is bounded in helper memory, survives compatible in-process snapshot refreshes, and expires after the configured inactivity timeout once no live flow uses the lease. It does not consult Go `PersistentNATTable` and does not survive helper restart. #1449 closes HA behavior as an explicit userspace capability gate: HA configs that reference persistent source-NAT pools are not admitted because leases are not synchronized, and status reports `userspace persistent-nat source pool leases are not HA-synchronized`. Userspace status, CLI summary, and Prometheus expose live-flow, used-port, persistent-lease, allocation, reuse, and exhaustion counters for admitted non-HA pools. |
+| Source NAT (pool mode) | Implemented with scoped caveats | IPv4/IPv6 pool address and port allocation. Global `source address-persistent` uses the documented userspace-v1 SHA-256 source-IP hash and is stable only within the AF_XDP backend, pool family, pool order, and pool size. Legacy eBPF and current DPDK use C-word IPv4 modulo / IPv6 lane-XOR selection, so new-flow pool address parity is not promised across backend transitions. Pool-mode rules with missing pools, empty pools, invalid port ranges, malformed addresses, no address for the packet family, or exhausted live translated tuples fail closed at the `poll_descriptor.rs` source-NAT call sites before session creation or forwarding, with recent-exception reasons such as `source_nat_pool_missing`, `source_nat_pool_empty`, `source_nat_pool_invalid_port_range`, and `source_nat_pool_exhausted`. Per-pool `persistent-nat` now has snapshot fields and runtime lease reuse keyed by source tuple `(protocol, source IP, source port)` to translated tuple. The lease table is bounded in helper memory, survives compatible in-process snapshot refreshes, and expires after the configured inactivity timeout once no live flow uses the lease. It does not consult Go `PersistentNATTable` and does not survive helper restart. #1449 closes HA behavior as an explicit userspace capability gate: HA configs that reference persistent source-NAT pools are not admitted because leases are not synchronized, and status reports `userspace persistent-nat source pool leases are not HA-synchronized`. Userspace status, CLI summary, and Prometheus expose live-flow, used-port, persistent-lease, allocation, reuse, and exhaustion counters for admitted non-HA pools. |
 | Destination NAT | Implemented | Pre-expanded tuple snapshots from Go |
 | Static NAT | Implemented | Bidirectional 1:1 translation |
 | NAT64 | Implemented | Forward and reverse translation with reverse-session state |
@@ -112,7 +114,7 @@ Recommended dependency order:
 2. #1377 and #1379 next, because they are silent correctness or
    security-visibility regressions in configurations that may otherwise appear
    admitted. #1377 now has fail-closed pool runtime handling for unusable
-   pool snapshots, the userspace-v1 selector and mixed-backend rollback
+   pool snapshots, the userspace-v1 selector and mixed-backend transition
    boundary are explicit, and the non-HA helper-local persistent-NAT allocator
    slice is implemented with live counters. Remaining #1377 caveats are
    helper-restart persistence and any future decision to standardize new-flow
@@ -151,7 +153,8 @@ There are two distinct fallback boundaries:
 1. **Compile-time / reconcile-time gate**
    - The Go manager chooses the userspace runtime path by default. Explicit
      legacy eBPF selection can still use `xdp_main_prog` while #1373 source
-     removal is staged.
+     removal is staged, but config compile emits a deprecation warning for
+     that explicit selection.
    - The Go manager keeps `xdp_userspace_prog` as the userspace-mode
      XDP entry. Capability gates disarm helper forwarding rather than
      swapping userspace runtime traffic into `xdp_main_prog`.

--- a/pkg/api/config_commit_test.go
+++ b/pkg/api/config_commit_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+func newAPICommitWarningStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet("set system dataplane-type ebpf"); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	return store
+}
+
+func TestConfigCommitCheckHandlerReturnsWarnings(t *testing.T) {
+	s := &Server{store: newAPICommitWarningStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/commit-check", nil)
+	s.configCommitCheckHandler(rr, req)
+
+	resp := decodeConfigCommitResponse(t, rr)
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	if !containsWarning(resp.Data.Warnings, "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.Data.Warnings)
+	}
+}
+
+func TestConfigCommitHandlerReturnsWarnings(t *testing.T) {
+	store := newAPICommitWarningStore(t)
+	s := &Server{
+		store: store,
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			return store.Commit()
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/commit", nil)
+	s.configCommitHandler(rr, req)
+
+	resp := decodeConfigCommitResponse(t, rr)
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	if !containsWarning(resp.Data.Warnings, "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.Data.Warnings)
+	}
+}
+
+func TestConfigCommitConfirmedHandlerReturnsWarnings(t *testing.T) {
+	store := newAPICommitWarningStore(t)
+	s := &Server{
+		store: store,
+		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+			return store.CommitConfirmed(10)
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/commit-confirmed",
+		strings.NewReader(`{"minutes":10}`))
+	s.configCommitConfirmedHandler(rr, req)
+
+	resp := decodeConfigCommitResponse(t, rr)
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	if !containsWarning(resp.Data.Warnings, "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.Data.Warnings)
+	}
+}
+
+func decodeConfigCommitResponse(t *testing.T, rr *httptest.ResponseRecorder) struct {
+	Success bool                 `json:"success"`
+	Data    configCommitResponse `json:"data"`
+} {
+	t.Helper()
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool                 `json:"success"`
+		Data    configCommitResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; body: %s", err, rr.Body.String())
+	}
+	return resp
+}
+
+func containsWarning(warnings []string, needle string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -57,6 +57,19 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, Response{Success: false, Error: msg})
 }
 
+type configCommitResponse struct {
+	Status   string   `json:"status"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+func commitResponseFromConfig(cfg *config.Config) configCommitResponse {
+	resp := configCommitResponse{Status: "ok"}
+	if cfg != nil && len(cfg.Warnings) > 0 {
+		resp.Warnings = append([]string(nil), cfg.Warnings...)
+	}
+	return resp
+}
+
 // healthHandler surfaces dataplane compile health (#758) alongside the
 // simple "ok" probe. When the dataplane compile has failed and has
 // never succeeded since startup, return 503 with a structured "status:
@@ -1554,7 +1567,8 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "commit handler not wired")
 		return
 	}
-	if _, err := s.commitFn(r.Context(), ""); err != nil {
+	compiled, err := s.commitFn(r.Context(), "")
+	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			writeError(w, http.StatusServiceUnavailable, "commit busy: "+err.Error())
@@ -1563,15 +1577,16 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	writeOK(w, map[string]string{"status": "ok"})
+	writeOK(w, commitResponseFromConfig(compiled))
 }
 
 func (s *Server) configCommitCheckHandler(w http.ResponseWriter, _ *http.Request) {
-	if _, err := s.store.CommitCheck(); err != nil {
+	compiled, err := s.store.CommitCheck()
+	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeOK(w, map[string]string{"status": "ok"})
+	writeOK(w, commitResponseFromConfig(compiled))
 }
 
 func (s *Server) configRollbackHandler(w http.ResponseWriter, r *http.Request) {
@@ -1716,7 +1731,8 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, "commit-confirmed handler not wired")
 		return
 	}
-	if _, err := s.commitConfirmedFn(r.Context(), req.Minutes); err != nil {
+	compiled, err := s.commitConfirmedFn(r.Context(), req.Minutes)
+	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			writeError(w, http.StatusServiceUnavailable, "commit busy: "+err.Error())
@@ -1725,7 +1741,7 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		}
 		return
 	}
-	writeOK(w, map[string]string{"status": "ok"})
+	writeOK(w, commitResponseFromConfig(compiled))
 }
 
 func (s *Server) configConfirmHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -175,10 +175,11 @@ func (c *CLI) handleLoad(args []string) error {
 
 func (c *CLI) handleCommit(args []string) error {
 	if len(args) > 0 && args[0] == "check" {
-		_, err := c.store.CommitCheck()
+		compiled, err := c.store.CommitCheck()
 		if err != nil {
 			return fmt.Errorf("commit check failed: %w", err)
 		}
+		printConfigWarnings(compiled.Warnings)
 		fmt.Println("configuration check succeeds")
 		return nil
 	}
@@ -200,6 +201,7 @@ func (c *CLI) handleCommit(args []string) error {
 		c.reloadSyslog(compiled)
 		c.refreshPrompt()
 
+		printConfigWarnings(compiled.Warnings)
 		if diffSummary != "" {
 			fmt.Printf("commit complete: %s\n", diffSummary)
 		} else {
@@ -224,6 +226,7 @@ func (c *CLI) handleCommit(args []string) error {
 		c.reloadSyslog(compiled)
 		c.refreshPrompt()
 
+		printConfigWarnings(compiled.Warnings)
 		fmt.Printf("commit confirmed will be automatically rolled back in %d minutes unless confirmed\n", minutes)
 		return nil
 	}
@@ -249,12 +252,19 @@ func (c *CLI) handleCommit(args []string) error {
 	c.reloadSyslog(compiled)
 	c.refreshPrompt()
 
+	printConfigWarnings(compiled.Warnings)
 	if diffSummary != "" {
 		fmt.Printf("commit complete: %s\n", diffSummary)
 	} else {
 		fmt.Println("commit complete")
 	}
 	return nil
+}
+
+func printConfigWarnings(warnings []string) {
+	for _, warning := range warnings {
+		fmt.Printf("warning: %s\n", warning)
+	}
 }
 
 // runCommit dispatches to the daemon's atomic commit+apply when

--- a/pkg/cli/cli_config_test.go
+++ b/pkg/cli/cli_config_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+func newCLICommitWarningStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet("set system dataplane-type ebpf"); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	return store
+}
+
+func TestCommitCheckPrintsValidationWarnings(t *testing.T) {
+	c := &CLI{store: newCLICommitWarningStore(t)}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.handleCommit([]string{"check"})
+	})
+	if callErr != nil {
+		t.Fatalf("handleCommit(check) error = %v", callErr)
+	}
+	if !strings.Contains(out, "warning: system dataplane-type ebpf selects") {
+		t.Fatalf("commit check output missing warning: %q", out)
+	}
+	if !strings.Contains(out, "configuration check succeeds") {
+		t.Fatalf("commit check output missing success line: %q", out)
+	}
+}
+
+func TestCommitPrintsValidationWarnings(t *testing.T) {
+	c := &CLI{store: newCLICommitWarningStore(t)}
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.handleCommit(nil)
+	})
+	if callErr != nil {
+		t.Fatalf("handleCommit() error = %v", callErr)
+	}
+	if !strings.Contains(out, "warning: system dataplane-type ebpf selects") {
+		t.Fatalf("commit output missing warning: %q", out)
+	}
+	if !strings.Contains(out, "commit complete") {
+		t.Fatalf("commit output missing success line: %q", out)
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -377,10 +377,19 @@ func validateClassOfServiceStrict(cos *ClassOfServiceConfig) error {
 	return nil
 }
 
-// ValidateConfig performs cross-reference validation on a compiled config.
-// Returns a list of warnings (non-fatal) for references that don't resolve.
+// ValidateConfig performs non-fatal validation on a compiled config.
+// Returns warnings for unresolved references and operator-visible
+// compatibility/deprecation conditions.
 func ValidateConfig(cfg *Config) []string {
 	var warnings []string
+
+	if cfg.System.DataplaneType == dataplaneTypeEBPF {
+		warnings = append(warnings,
+			"system dataplane-type ebpf selects the deprecated legacy eBPF "+
+				"dataplane explicitly; this is temporary compatibility "+
+				"while legacy source removal is staged. Omitting "+
+				"system dataplane-type selects the userspace dataplane.")
+	}
 
 	// #653: when `services application-identification` is enabled,
 	// emit a one-line warning at commit time so operators see what

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -1388,6 +1388,63 @@ func TestDataplaneWorkersOmittedTypeUsesUserspaceDefault(t *testing.T) {
 	if cfg.System.UserspaceDataplane.Workers != 8 {
 		t.Fatalf("Workers = %d, want 8", cfg.System.UserspaceDataplane.Workers)
 	}
+	warnings := strings.Join(cfg.Warnings, "\n")
+	if strings.Contains(warnings, "system dataplane-type ebpf selects") {
+		t.Fatalf("unexpected eBPF deprecation warning for omitted dataplane-type: %s", warnings)
+	}
+}
+
+func TestDataplaneTypeExplicitEBPFWarnsDeprecatedCompatibility(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set system dataplane-type ebpf",
+	} {
+		fields := strings.Fields(cmd)
+		if err := tree.SetPath(fields[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.DataplaneType != "ebpf" {
+		t.Fatalf("DataplaneType = %q, want ebpf", cfg.System.DataplaneType)
+	}
+	warnings := strings.Join(cfg.Warnings, "\n")
+	if !strings.Contains(warnings, "system dataplane-type ebpf selects the deprecated legacy eBPF dataplane explicitly") {
+		t.Fatalf("missing explicit eBPF deprecation warning, got: %s", warnings)
+	}
+	if !strings.Contains(warnings, "Omitting system dataplane-type selects the userspace dataplane") {
+		t.Fatalf("missing userspace default note in explicit eBPF warning, got: %s", warnings)
+	}
+}
+
+func TestDataplaneTypeNonLegacyValuesDoNotWarnDeprecatedCompatibility(t *testing.T) {
+	for _, dataplaneType := range []string{"userspace", "dpdk"} {
+		t.Run(dataplaneType, func(t *testing.T) {
+			tree := &ConfigTree{}
+			cmd := "set system dataplane-type " + dataplaneType
+			fields := strings.Fields(cmd)
+			if err := tree.SetPath(fields[1:]); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			if cfg.System.DataplaneType != dataplaneType {
+				t.Fatalf("DataplaneType = %q, want %q",
+					cfg.System.DataplaneType, dataplaneType)
+			}
+			warnings := strings.Join(cfg.Warnings, "\n")
+			if strings.Contains(warnings, "deprecated legacy eBPF") {
+				t.Fatalf("unexpected eBPF deprecation warning: %s", warnings)
+			}
+		})
+	}
 }
 
 func TestDataplaneTypeValidationRejectsUnknownDuplicateValues(t *testing.T) {

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -21,9 +21,8 @@ const (
 	TypeUserspace = "userspace"
 )
 
-// EffectiveType resolves the operator-facing dataplane type.  The empty
-// config value now means the userspace runtime path; callers must not treat an
-// omitted value as legacy eBPF fallback.
+// EffectiveType resolves the operator-facing dataplane type. The empty config
+// value means the userspace runtime path.
 func EffectiveType(dpType string) string {
 	if dpType == "" {
 		return TypeUserspace

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -155,7 +156,8 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 	if s.commitFn == nil {
 		return nil, status.Errorf(codes.Internal, "commit handler not wired")
 	}
-	if _, err := s.commitFn(ctx, req.Comment); err != nil {
+	compiled, err := s.commitFn(ctx, req.Comment)
+	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled):
 			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
@@ -165,21 +167,23 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 	}
-	return &pb.CommitResponse{Summary: summary}, nil
+	return &pb.CommitResponse{Summary: summary, Warnings: configWarnings(compiled)}, nil
 }
 
 func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.CommitCheckResponse, error) {
-	if _, err := s.store.CommitCheck(); err != nil {
+	compiled, err := s.store.CommitCheck()
+	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	return &pb.CommitCheckResponse{}, nil
+	return &pb.CommitCheckResponse{Warnings: configWarnings(compiled)}, nil
 }
 
 func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
 	if s.commitConfirmedFn == nil {
 		return nil, status.Errorf(codes.Internal, "commit-confirmed handler not wired")
 	}
-	if _, err := s.commitConfirmedFn(ctx, int(req.Minutes)); err != nil {
+	compiled, err := s.commitConfirmedFn(ctx, int(req.Minutes))
+	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled):
 			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
@@ -189,7 +193,7 @@ func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedReq
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 	}
-	return &pb.CommitConfirmedResponse{}, nil
+	return &pb.CommitConfirmedResponse{Warnings: configWarnings(compiled)}, nil
 }
 
 func (s *Server) ConfirmCommit(_ context.Context, _ *pb.ConfirmCommitRequest) (*pb.ConfirmCommitResponse, error) {
@@ -204,6 +208,13 @@ func (s *Server) Rollback(_ context.Context, req *pb.RollbackRequest) (*pb.Rollb
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	return &pb.RollbackResponse{}, nil
+}
+
+func configWarnings(cfg *config.Config) []string {
+	if cfg == nil || len(cfg.Warnings) == 0 {
+		return nil
+	}
+	return append([]string(nil), cfg.Warnings...)
 }
 
 func (s *Server) ShowConfig(_ context.Context, req *pb.ShowConfigRequest) (*pb.ShowConfigResponse, error) {

--- a/pkg/grpcapi/server_config_test.go
+++ b/pkg/grpcapi/server_config_test.go
@@ -1,0 +1,82 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+func newGRPCCommitWarningStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet("set system dataplane-type ebpf"); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	return store
+}
+
+func TestCommitCheckReturnsValidationWarnings(t *testing.T) {
+	s := &Server{store: newGRPCCommitWarningStore(t)}
+
+	resp, err := s.CommitCheck(context.Background(), &pb.CommitCheckRequest{})
+	if err != nil {
+		t.Fatalf("CommitCheck() error = %v", err)
+	}
+	if !grpcWarningsContain(resp.GetWarnings(), "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.GetWarnings())
+	}
+}
+
+func TestCommitReturnsValidationWarnings(t *testing.T) {
+	store := newGRPCCommitWarningStore(t)
+	s := &Server{
+		store: store,
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			return store.Commit()
+		},
+	}
+
+	resp, err := s.Commit(context.Background(), &pb.CommitRequest{})
+	if err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if !grpcWarningsContain(resp.GetWarnings(), "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.GetWarnings())
+	}
+}
+
+func TestCommitConfirmedReturnsValidationWarnings(t *testing.T) {
+	store := newGRPCCommitWarningStore(t)
+	s := &Server{
+		store: store,
+		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+			return store.CommitConfirmed(10)
+		},
+	}
+
+	resp, err := s.CommitConfirmed(context.Background(), &pb.CommitConfirmedRequest{Minutes: 10})
+	if err != nil {
+		t.Fatalf("CommitConfirmed() error = %v", err)
+	}
+	if !grpcWarningsContain(resp.GetWarnings(), "system dataplane-type ebpf selects") {
+		t.Fatalf("warnings = %v, want explicit ebpf warning", resp.GetWarnings())
+	}
+}
+
+func grpcWarningsContain(warnings []string, needle string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -719,7 +719,8 @@ func (x *CommitRequest) GetComment() string {
 
 type CommitResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Summary       string                 `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"` // human-readable diff summary (e.g. "3 statement(s) changed (2 added, 1 removed)")
+	Summary       string                 `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"`   // human-readable diff summary (e.g. "3 statement(s) changed (2 added, 1 removed)")
+	Warnings      []string               `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"` // non-fatal validation warnings surfaced at commit time
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -761,6 +762,13 @@ func (x *CommitResponse) GetSummary() string {
 	return ""
 }
 
+func (x *CommitResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
 type CommitCheckRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -799,6 +807,7 @@ func (*CommitCheckRequest) Descriptor() ([]byte, []int) {
 
 type CommitCheckResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Warnings      []string               `protobuf:"bytes,1,rep,name=warnings,proto3" json:"warnings,omitempty"` // non-fatal validation warnings surfaced by commit check
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -831,6 +840,13 @@ func (x *CommitCheckResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CommitCheckResponse.ProtoReflect.Descriptor instead.
 func (*CommitCheckResponse) Descriptor() ([]byte, []int) {
 	return file_xpf_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CommitCheckResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
 }
 
 type CommitConfirmedRequest struct {
@@ -879,6 +895,7 @@ func (x *CommitConfirmedRequest) GetMinutes() int32 {
 
 type CommitConfirmedResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Warnings      []string               `protobuf:"bytes,1,rep,name=warnings,proto3" json:"warnings,omitempty"` // non-fatal validation warnings surfaced at commit-confirmed time
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -911,6 +928,13 @@ func (x *CommitConfirmedResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CommitConfirmedResponse.ProtoReflect.Descriptor instead.
 func (*CommitConfirmedResponse) Descriptor() ([]byte, []int) {
 	return file_xpf_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *CommitConfirmedResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
 }
 
 type ConfirmCommitRequest struct {
@@ -6922,14 +6946,17 @@ const file_xpf_proto_rawDesc = "" +
 	"\acontent\x18\x02 \x01(\tR\acontent\"\x0e\n" +
 	"\fLoadResponse\")\n" +
 	"\rCommitRequest\x12\x18\n" +
-	"\acomment\x18\x01 \x01(\tR\acomment\"*\n" +
+	"\acomment\x18\x01 \x01(\tR\acomment\"F\n" +
 	"\x0eCommitResponse\x12\x18\n" +
-	"\asummary\x18\x01 \x01(\tR\asummary\"\x14\n" +
-	"\x12CommitCheckRequest\"\x15\n" +
-	"\x13CommitCheckResponse\"2\n" +
+	"\asummary\x18\x01 \x01(\tR\asummary\x12\x1a\n" +
+	"\bwarnings\x18\x02 \x03(\tR\bwarnings\"\x14\n" +
+	"\x12CommitCheckRequest\"1\n" +
+	"\x13CommitCheckResponse\x12\x1a\n" +
+	"\bwarnings\x18\x01 \x03(\tR\bwarnings\"2\n" +
 	"\x16CommitConfirmedRequest\x12\x18\n" +
-	"\aminutes\x18\x01 \x01(\x05R\aminutes\"\x19\n" +
-	"\x17CommitConfirmedResponse\"\x16\n" +
+	"\aminutes\x18\x01 \x01(\x05R\aminutes\"5\n" +
+	"\x17CommitConfirmedResponse\x12\x1a\n" +
+	"\bwarnings\x18\x01 \x03(\tR\bwarnings\"\x16\n" +
 	"\x14ConfirmCommitRequest\"\x17\n" +
 	"\x15ConfirmCommitResponse\"\x1f\n" +
 	"\x0fRollbackRequest\x12\f\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -109,13 +109,18 @@ message CommitRequest {
 }
 message CommitResponse {
   string summary = 1; // human-readable diff summary (e.g. "3 statement(s) changed (2 added, 1 removed)")
+  repeated string warnings = 2; // non-fatal validation warnings surfaced at commit time
 }
 
 message CommitCheckRequest {}
-message CommitCheckResponse {}
+message CommitCheckResponse {
+  repeated string warnings = 1; // non-fatal validation warnings surfaced by commit check
+}
 
 message CommitConfirmedRequest { int32 minutes = 1; }
-message CommitConfirmedResponse {}
+message CommitConfirmedResponse {
+  repeated string warnings = 1; // non-fatal validation warnings surfaced at commit-confirmed time
+}
 
 message ConfirmCommitRequest {}
 message ConfirmCommitResponse {}


### PR DESCRIPTION
## Summary

- Emit a compiled validation warning only when operators explicitly set `system dataplane-type ebpf`.
- Keep omitted, `userspace`, and `dpdk` dataplane-type configs free of the legacy warning.
- Surface compiled warnings through CLI commit/check, REST commit/check/commit-confirmed, and gRPC Commit/CommitCheck/CommitConfirmed.
- Remove the issue number from the operator-facing warning while keeping the retirement docs aligned with #1474.

Fixes #1474.

## Validation

- `GOFLAGS=-buildvcs=false go test -count=1 ./pkg/config ./pkg/cli ./pkg/api ./pkg/grpcapi`
- `git diff --check`

## Self-review

Adversarial pass checked the mixed-version/API shape and warning scope: protobuf adds only new repeated fields, JSON preserves `status: "ok"`, confirm-pending paths still avoid fake warnings because they do not compile, and explicit `ebpf` is the only dataplane value that emits the deprecation warning.
