### PR TITLE
Split userspace XDP shim generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,26 @@ LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime
 # eBPF compilation flags
 BPF_CFLAGS := -O2 -g -Wall -Werror -target bpf
 
-.PHONY: all generate build build-ctl build-userspace-dp proto install clean test test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity build-dpdk-worker build-dpdk clean-dpdk
+.PHONY: all generate generate-legacy-bpf generate-userspace-xdp build-userspace-xdp build build-ctl build-userspace-dp proto install clean test test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity build-dpdk-worker build-dpdk clean-dpdk
 
 all: generate build build-ctl
 
-# Generate Go bindings from eBPF C programs via bpf2go
+# Generate all dataplane artifacts: legacy XDP/TC bpf2go outputs plus the
+# retained Rust userspace XDP shim object.
 generate:
 	$(GO) generate ./pkg/dataplane/...
+
+# Generate only legacy XDP/TC eBPF dataplane bindings, leaving the retained
+# Rust userspace XDP shim object untouched.
+generate-legacy-bpf:
+	$(GO) generate -skip '^//go:generate bash build-userspace-xdp\.sh$$' ./pkg/dataplane/...
+
+# Generate only the retained Rust userspace XDP shim object. This target is the
+# #1473 source-removal canary: it must not invoke legacy xdp_main/tc bpf2go.
+generate-userspace-xdp:
+	$(GO) generate -run '^//go:generate bash build-userspace-xdp\.sh$$' ./pkg/dataplane
+
+build-userspace-xdp: generate-userspace-xdp
 
 # Build the daemon binary
 build:

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -10,6 +10,24 @@ How non-trivial changes land in this repo. Roles and agent-boundary
 rules are in `AGENTS.md`; read that first. This doc is the process
 layer on top of those roles.
 
+## Dataplane generation split
+
+The retained userspace XDP shim is a separate build artifact from the legacy
+XDP/TC dataplane programs:
+
+- `make generate-userspace-xdp` rebuilds only
+  `pkg/dataplane/userspace_xdp_bpfel.o` through
+  `go generate -run '^//go:generate bash build-userspace-xdp\.sh$' ./pkg/dataplane`.
+- `make build-userspace-xdp` is an alias for the shim-only generation target.
+- `make generate` remains the full compatibility path and still regenerates
+  the legacy bpf2go XDP/TC artifacts as well as the retained shim.
+- `make generate-legacy-bpf` runs the legacy XDP/TC bpf2go directives while
+  leaving the retained shim object untouched.
+
+Do not treat the retained shim as evidence that legacy `xdp_main` or TC
+dataplane program generation is required. The shim-only target is the #1473
+canary for that boundary.
+
 The workflow has two distinct review cycles — one on the plan, one
 on the code — each with the same rule: **land when both reviewers
 agree, not before**.

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -77,6 +77,28 @@ builds remain blocked on migrating away from root `DataPlane`; userspace-only
 production source removal must not depend on solving that DPDK migration in the
 same PR.
 
+## #1473 Userspace XDP Shim Build Split
+
+The retained Rust userspace XDP shim is still required for the AF_XDP userspace
+runtime, but its generation path is now explicit and separate from the legacy
+XDP/TC dataplane bpf2go batch:
+
+- `make generate-userspace-xdp` rebuilds only
+  `pkg/dataplane/userspace_xdp_bpfel.o` through the
+  `pkg/dataplane/build-userspace-xdp.sh` go:generate directive.
+- `make build-userspace-xdp` is an alias for the shim-only generation target.
+- `make generate` remains the full compatibility target: legacy XDP/TC bpf2go
+  artifacts plus the retained userspace shim.
+- `make generate-legacy-bpf` regenerates legacy XDP/TC bpf2go artifacts while
+  skipping the retained shim.
+
+The userspace shim target must not depend on legacy `xdp_main` or TC program
+generation. `pkg/dataplane/retirement_boundary_canary_test.go` reads the
+Makefile and fails if `generate-userspace-xdp` gains legacy bpf2go tokens,
+recursive Make dependencies, or the broad `./pkg/dataplane/...` generate path.
+This keeps the retained shim visible without implying that deleting legacy
+dataplane program generation is blocked by the shim itself.
+
 ### Allowlisted Legacy Bridges
 
 These files are the current production direct-import allowlist for root
@@ -143,12 +165,16 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
   only direct DPDK backend import outside the package being the blank
   registration import in `cmd/xpfd/main.go`. Non-`-tags dpdk` binaries fail
   DPDK startup explicitly rather than running a no-op stub.
-- BPF source and build artifacts are not safe to delete in #1451 canary work:
-  `bpf/`, `pkg/dataplane/loader_ebpf.go`,
-  `pkg/dataplane/*_bpfel.go`, `pkg/dataplane/*_bpfel.o`,
-  `pkg/dataplane/userspace_xdp_bpfel.o`,
-  `pkg/dataplane/build-userspace-xdp.sh`, and the `Makefile generate` path
-  remain tied to the eBPF backend and userspace XDP shim.
+- Legacy BPF source and generated artifacts are not safe to delete in #1451
+  canary work: `bpf/`, `pkg/dataplane/loader_ebpf.go`,
+  `pkg/dataplane/*_bpfel.go`, `pkg/dataplane/*_bpfel.o`, and the legacy side
+  of the `Makefile generate` path remain tied to the eBPF backend until the
+  loader/map-bootstrap split is finished.
+- Retained userspace XDP shim artifacts are tracked separately:
+  `pkg/dataplane/userspace_xdp_bpfel.o` and
+  `pkg/dataplane/build-userspace-xdp.sh` remain required for userspace runtime
+  startup, but `make generate-userspace-xdp` rebuilds them without legacy
+  `xdp_main` or TC dataplane program generation.
 
 ## Phase 1/2 Smoke Gates
 

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -16,8 +16,11 @@ import (
 
 const linkPinPath = "/sys/fs/bpf/xpf/links"
 
-// go:generate directives -- run "make generate" with clang + libbpf-dev installed.
-// These produce the *_bpfel.go files with embedded ELF objects.
+// go:generate directives.
+// Run "make generate" with clang + libbpf-dev installed for the full legacy
+// XDP/TC bpf2go batch plus the retained Rust userspace XDP shim object.
+// Run "make generate-userspace-xdp" to rebuild only the retained shim without
+// invoking legacy xdp_main/tc bpf2go generation.
 //
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -strip llvm-strip-21 -cflags "-O2 -g -Wall" -target amd64 xpfXdpMain ../../bpf/xdp/xdp_main.c -- -I../../bpf/headers -I/usr/include/x86_64-linux-gnu
 //go:generate bash build-userspace-xdp.sh

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ const (
 	rootDataplaneImportForCanary    = "github.com/psaab/xpf/pkg/dataplane"
 	ciliumEBPFImportForCanary       = "github.com/cilium/ebpf"
 	dpdkBackendImportForCanary      = "github.com/psaab/xpf/pkg/dataplane/dpdk"
+	makefileForCanary               = "../../Makefile"
 	retirementBoundaryDocsForCanary = "../../docs/pr/1373-retire-ebpf-dataplane/README.md"
 )
 
@@ -194,6 +196,62 @@ func TestDPDKEBPFArtifactImportsStayAtLegacyAdapter(t *testing.T) {
 	}
 }
 
+func TestUserspaceXDPGenerateTargetStaysDecoupledFromLegacyBPF(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(makefileForCanary)
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	prereqs, recipe := makeTargetDefinition(t, string(data), "generate-userspace-xdp")
+	if strings.TrimSpace(prereqs) != "" {
+		t.Fatalf("generate-userspace-xdp must not depend on other Make targets, got prerequisites %q", prereqs)
+	}
+	if len(recipe) == 0 {
+		t.Fatal("generate-userspace-xdp has no recipe")
+	}
+	body := strings.Join(recipe, "\n")
+	for _, token := range []string{"generate", "-run", "build-userspace-xdp"} {
+		if !strings.Contains(body, token) {
+			t.Fatalf("generate-userspace-xdp recipe %q missing required token %q", body, token)
+		}
+	}
+	for _, token := range []string{
+		"bpf2go",
+		"xdp_main",
+		"tc_main",
+		"bpf/xdp",
+		"bpf/tc",
+		"./pkg/dataplane/...",
+		"generate-legacy-bpf",
+		"$(MAKE)",
+	} {
+		if strings.Contains(body, token) {
+			t.Fatalf("generate-userspace-xdp must not invoke legacy dataplane generation; recipe %q contains %q", body, token)
+		}
+	}
+}
+
+func TestUserspaceXDPGoGenerateRunSelectsOnlyShim(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "generate", "-n", "-run", "^//go:generate bash build-userspace-xdp\\.sh$", "./pkg/dataplane")
+	cmd.Dir = repoRootForBoundaryCanary
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go generate dry-run failed: %v\n%s", err, out)
+	}
+	var lines []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	if len(lines) != 1 || lines[0] != "bash build-userspace-xdp.sh" {
+		t.Fatalf("go generate shim dry-run selected %v, want only build-userspace-xdp.sh", lines)
+	}
+}
+
 func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
 	t.Parallel()
 
@@ -286,6 +344,66 @@ func operatorRuntimeBoundaryRoots(t *testing.T) []string {
 	}
 	sort.Strings(roots)
 	return roots
+}
+
+func makeTargetDefinition(t *testing.T, makefile, target string) (string, []string) {
+	t.Helper()
+
+	lines := strings.Split(makefile, "\n")
+	for i, line := range lines {
+		targets, prereqs, ok := parseMakeTargetLine(line)
+		if !ok {
+			continue
+		}
+		found := false
+		for _, name := range targets {
+			if name == target {
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+
+		var recipe []string
+		for _, next := range lines[i+1:] {
+			trimmed := strings.TrimSpace(next)
+			switch {
+			case strings.HasPrefix(next, "\t"):
+				recipe = append(recipe, strings.TrimSpace(next))
+			case trimmed == "" || strings.HasPrefix(trimmed, "#"):
+				if len(recipe) == 0 {
+					continue
+				}
+				return prereqs, recipe
+			default:
+				return prereqs, recipe
+			}
+		}
+		return prereqs, recipe
+	}
+	t.Fatalf("Makefile target %q not found", target)
+	return "", nil
+}
+
+func parseMakeTargetLine(line string) ([]string, string, bool) {
+	if strings.HasPrefix(line, "\t") {
+		return nil, "", false
+	}
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return nil, "", false
+	}
+	idx := strings.Index(trimmed, ":")
+	if idx < 0 {
+		return nil, "", false
+	}
+	targets := strings.Fields(strings.TrimSpace(trimmed[:idx]))
+	if len(targets) == 0 || targets[0] == ".PHONY" {
+		return nil, "", false
+	}
+	return targets, strings.TrimSpace(trimmed[idx+1:]), true
 }
 
 func productionGoFilesUnder(t *testing.T, roots []string) []string {


### PR DESCRIPTION
## Summary

- Add `make generate-userspace-xdp` and `make build-userspace-xdp` for the retained Rust userspace XDP shim only.
- Add `make generate-legacy-bpf` for the inverse legacy XDP/TC bpf2go-only path while keeping `make generate` as the full compatibility target.
- Add dataplane canaries that reject legacy `xdp_main`/TC/bpf2go drift in the shim target and verify the exact `go generate` dry run selects only `build-userspace-xdp.sh`.
- Update the development and #1373 retirement docs to describe the retained shim vs legacy dataplane generation split.

## Validation

- `make -n generate-userspace-xdp`
- `go generate -n -run '^//go:generate bash build-userspace-xdp\.sh$' ./pkg/dataplane`
- `go generate -n -skip '^//go:generate bash build-userspace-xdp\.sh$' ./pkg/dataplane`
- `make -n build-userspace-xdp`
- `go test ./pkg/dataplane`
- `make generate-userspace-xdp`
- `git diff --check`

## Adversarial Review

- Confirmed the shim-only target has no prerequisites and no broad `./pkg/dataplane/...` generation path.
- Confirmed `pkg/dataplane/build-userspace-xdp.sh` does not invoke bpf2go, `xdp_main`, or TC generation; it still reads `bpf/headers/xpf_common.h` for `MAX_INTERFACES` drift lock.
- Full `make generate` remains unchanged as the legacy compatibility batch.

Refs #1473.