### PR TITLE
docs: reconcile SNAT retirement closeouts

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -1,31 +1,43 @@
 # #1373 Retire eBPF Dataplane Blocker Plans
 
-Status: design-plan bundle for #1373 blockers. These docs convert the
-reviewed issue contracts into implementation plans for the code PRs that must
-land before their listed #1373 retirement phase.
+Status: closeout and removal-plan bundle for #1373. The original #1374-#1381
+feature-gap plans are kept here as design history and documented runtime
+contracts, but those feature-gap blockers are closed. Current removal work is
+tracked by #1451 and the removal-phase child issues below.
 
-## Blocker Index
+## Feature Gap Closeout Index
 
-| Issue | Plan | Required before | Code PR still needed |
+| Issue | Plan | Retirement state | Notes |
 |---|---|---|---|
-| #1374 SYN cookie flood protection | [plan-1374-syn-cookies.md](plan-1374-syn-cookies.md) | #1373 Phase 4 | Runtime challenge/ACK/cache/counters, root-auth-derived snapshot key, bounded SYN-ACK/RST TX, status counters, and gate removal landed; live HA/flood evidence still needed before BPF source removal |
-| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | #1373 Phase 4 | Color-blind `then discard` runtime plus compatible snapshot continuity landed; sharded/packed state decision, HA/restart continuity decision, non-drop color actions, and integration/perf evidence still needed |
-| #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | #1373 Phase 4 | Snapshot/wire plus bounded runtime admission landed; mirror-fidelity and pressure-survival evidence still needed |
-| #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | #1373 Phase 4 | Userspace-v1 selector, unusable-pool fail-closed runtime, helper-local persistent-NAT lease reuse, per-pool allocator sharing, and allocator counters landed; #1449 closes HA lease behavior as an explicit userspace capability gate; helper-restart persistence, integration evidence, and cross-backend new-flow parity remain outside the current contract |
-| #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | #1373 Phase 4 | Closed by live HA artifact capture accepted by `policy_scheduler_validate.py`; no known #1378 runtime or evidence gap remains |
-| #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | #1373 Phase 4 | Policy-deny, screen-drop, PBR filter logs, non-PBR input/output/lo0 filter logs, cached input-log replay without filter rescans, source-disambiguated FILTER_LOG syslog, and deterministic fanout coverage landed; live cluster evidence remains if Phase 4 requires operator artifacts |
-| #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | #1373 Phase 5 | Helper-status rendering is active; Rust-owned session-table and flow-cache denominators are helper-published, while neighbor entries remain counters until Rust owns a bounded neighbor-cache capacity |
+| #1374 SYN cookie flood protection | [plan-1374-syn-cookies.md](plan-1374-syn-cookies.md) | Closed | Runtime challenge/ACK/cache/counters, root-auth-derived snapshot key, bounded SYN-ACK/RST TX, status counters, and gate removal landed; final source-removal evidence rolls into #1477 if required. |
+| #1375 three-color policers | [plan-1375-three-color-policers.md](plan-1375-three-color-policers.md) | Closed | Color-blind `then discard` runtime plus compatible snapshot continuity landed; future hardening is production follow-up work, not an active feature-gap blocker. |
+| #1376 port mirroring | [plan-1376-port-mirroring.md](plan-1376-port-mirroring.md) | Closed | Snapshot/wire plus bounded runtime admission landed; final mirror-fidelity evidence rolls into #1477 if required. |
+| #1377 persistent SNAT pool address selection | [plan-1377-snat-pools.md](plan-1377-snat-pools.md) | Closed | Userspace-v1 selector, unusable-pool fail-closed runtime, helper-local persistent-NAT lease reuse, per-pool allocator sharing, and allocator counters landed. #1448, #1449, and #1450 are closed documented contracts for helper restart reset, HA admission gating, and backend-specific selector behavior. |
+| #1378 policy schedulers | [plan-1378-policy-schedulers.md](plan-1378-policy-schedulers.md) | Closed | Closed by live HA artifact capture accepted by `policy_scheduler_validate.py`; no known #1378 runtime or evidence gap remains. |
+| #1379 dataplane events | [plan-1379-dataplane-events.md](plan-1379-dataplane-events.md) | Closed | Policy-deny, screen-drop, PBR filter logs, non-PBR input/output/lo0 filter logs, cached input-log replay without filter rescans, source-disambiguated FILTER_LOG syslog, and deterministic fanout coverage landed. |
+| #1380 userspace buffer/status parity | [plan-1380-userspace-buffers.md](plan-1380-userspace-buffers.md) | Closed | Helper-status rendering is active; Rust-owned session-table and flow-cache denominators are helper-published, while neighbor entries remain counters until Rust owns a bounded neighbor-cache capacity. |
+| #1381 DataPlane split | [plan.md](plan.md) | Closed | The blocking userspace-apply/interface split closed; the broader source-removal migration continues under #1451. |
 
-## Shared Dependency
+## Current Removal Work
 
-#1381 is the common plumbing dependency for the blocker set. The userspace
-manager no longer embeds the old `DataPlane` interface directly for the first
-operator metadata surfaces, and a userspace legacy adapter owns the compatibility
-boundary. Remaining Phase 3 work is to move session, telemetry, GC, and control
-callers off the old BPF-shaped surface before generated bindings, loader code,
-and BPF build rules can be removed. #1380 is a Phase 5 CLI/observability cleanup
-item, now closed for the current helper schema; it does not block the Phase 4
-forwarding-source removal gate by itself.
+| Issue | Scope |
+|---|---|
+| #1451 | Migrate remaining legacy eBPF-shaped runtime and operator surfaces before source/generated artifact deletion. |
+| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. |
+| #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the blockers close. |
+| #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate. |
+
+#1474 is closed: omitted `system dataplane-type` selects userspace, while
+explicit `system dataplane-type ebpf` remains temporary warned compatibility
+until legacy source removal.
+
+## Removal-Phase Dependency
+
+#1451 is the current common migration umbrella. The userspace manager no longer
+embeds the old `DataPlane` interface directly, and a userspace legacy adapter
+owns the compatibility boundary while unmigrated callers move to domain
+interfaces. #1380 is a Phase 5 CLI/observability cleanup item, now closed for
+the current helper schema; it does not block the source-removal gate by itself.
 
 ## #1451 Runtime Boundary Canaries
 

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -2,38 +2,53 @@
 
 Phase 0 is a documentation and audit PR for #1373. It announces that new
 dataplane development targets `userspace-dp`, refreshes the userspace gap audit,
-and records the blockers that must close before later retirement phases remove
-legacy eBPF code.
+and records the feature-gap blockers that have since closed before later
+retirement phases remove legacy eBPF code.
 
 No BPF source is removed in Phase 0. The `bpf/` tree, bpf2go-generated Go
 bindings, eBPF loader, legacy test targets, and BPF-backed CLI surfaces remain
 present until later phase PRs.
 
-## Blockers
+## Feature Gap Closeout
 
-| Issue | Summary | Phase dependency |
-|-------|---------|------------------|
-| #1381 | Runtime interface split is underway; userspace no longer embeds the old interface directly for the first operator metadata surfaces, but session/telemetry/GC/control callers still need to leave the BPF-shaped contract | Must land first; blocks Phase 3 |
-| #1377 | Userspace-v1 address-persistent SNAT pool selection, fail-closed runtime handling for unusable pool rules, helper-local per-pool `persistent-nat`, live-port exhaustion observability, and allocator counters are implemented; #1449 closes HA persistent-lease behavior as an explicit userspace capability gate; remaining work is helper-restart persistence, integration evidence, and documented mixed-backend rollback behavior | Before Phase 4 |
-| #1378 | Scheduler state, counter survival, strict missing-scheduler behavior, deterministic evidence validation, and live HA artifact capture are complete for userspace; no known #1378 blocker remains | Before Phase 4 |
-| #1379 | Policy-deny, screen-drop, PBR filter logs, non-PBR input/output/lo0 filter logs, cached input-log replay without filter rescans, source-disambiguated FILTER_LOG syslog, and deterministic fanout coverage now emit from userspace; remaining work is live userspace-cluster syslog evidence if Phase 4 requires operator artifacts | Before Phase 4 |
-| #1374 | Userspace SYN-cookie validation/admission semantics, root-auth-derived snapshot key publication, bounded SYN-ACK/RST TX replies, counters, and gate removal exist; remaining blocker is live HA/flood validation evidence before BPF source removal | Before Phase 4 |
-| #1375 | Userspace supports the color-blind `then discard` srTCM/trTCM slice, fails closed for unsupported shapes, and preserves token/counter state across compatible in-process snapshot refreshes; remaining work is HA/restart continuity decision, non-drop color actions, and integration/perf evidence | Before Phase 4 |
-| #1376 | Userspace port mirroring has snapshot/wire plumbing plus bounded runtime admission; remaining work is mirror-fidelity and pressure-survival evidence before BPF source removal | Before Phase 4 |
-| #1380 | Userspace `show system buffers` renders helper status; Rust-owned session and flow-cache denominators are helper-published, and neighbor entries remain counters until Rust owns a bounded neighbor-cache capacity | Phase 5 closeout recorded |
+The original #1374-#1381 Phase 0 blocker set is closed. This tracker keeps the
+closeout state visible because the detailed plan files still define important
+runtime contracts, but those issues are no longer the active source-removal
+backlog.
+
+| Issue | Disposition |
+|-------|-------------|
+| #1374 | SYN-cookie runtime support is implemented; final source-removal evidence belongs with #1477 if required. |
+| #1375 | The admitted userspace three-color policer slice is implemented; future hardening is production follow-up work. |
+| #1376 | Userspace port mirroring runtime support is implemented; final mirror evidence belongs with #1477 if required. |
+| #1377 | Userspace-v1 address-persistent SNAT selection, fail-closed pool runtime, helper-local per-pool `persistent-nat`, live-port exhaustion observability, and allocator counters are implemented. #1448, #1449, and #1450 are closed as documented helper-restart, HA-gate, and cross-backend selector contracts, not active #1373/#1451 blockers. |
+| #1378 | Scheduler state, counter survival, strict missing-scheduler behavior, deterministic evidence validation, and live HA artifact capture are complete for userspace. |
+| #1379 | Policy-deny, screen-drop, filter-log, source-disambiguated FILTER_LOG syslog, and deterministic fanout coverage now emit from userspace. |
+| #1380 | Userspace `show system buffers` renders helper status; Rust-owned session and flow-cache denominators are helper-published, and neighbor entries remain counters until Rust owns a bounded neighbor-cache capacity. |
+| #1381 | The blocking interface split is closed; remaining runtime/operator surface migration is tracked by #1451. |
+
+## Current Removal Trackers
+
+| Issue | Scope |
+|-------|-------|
+| #1451 | Move remaining runtime and operator callers off the legacy eBPF-shaped dataplane surfaces before source/generated artifact deletion. |
+| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. |
+| #1476 | Remove legacy BPF source, generated artifacts, and build hooks after migration blockers close. |
+| #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate. |
+
+#1474 is closed: omitted `system dataplane-type` selects userspace, while
+explicit `system dataplane-type ebpf` remains temporary warned compatibility
+until legacy source removal.
 
 ## Recommended Order
 
-1. Land #1381 first so the daemon and dataplane interface stop assuming BPF
-   map-writer methods as the abstract contract.
-2. Land #1377 and #1379 next because these are silent correctness or
-   security-visibility gaps; #1378 is now closed by live HA evidence.
-3. Land #1375 and collect #1374/#1376 live evidence before Phase 4. #1374 is
-   no longer protected by a capability fallback; it still needs the flood/HA
-   artifact set before BPF source removal.
-4. Treat #1380 as closed for the current helper schema. Neighbor-cache
-   utilization rows still require a new helper-published bounded capacity and
-   should be tracked as new issues, not as #1380 blockers.
+1. Land #1451 first so remaining runtime and operator surfaces no longer depend
+   on the legacy eBPF-shaped `dataplane.DataPlane` contract.
+2. Land #1473 before source deletion so the retained userspace shim is
+   explicit and separate from legacy `xdp_main_prog` fallback.
+3. Land #1476 as the source/generated-artifact removal PR after those blockers
+   close.
+4. Attach #1477 validation artifacts to the exact #1476 candidate.
 
 ## Phase Boundaries
 
@@ -41,9 +56,9 @@ present until later phase PRs.
 - Phase 1: broad documentation migration. Historical PR-plan docs are preserved
   as history; add banners only where needed instead of rewriting old plans.
 - Phase 2: test environment consolidation.
-- Phase 3: build-system and Go dataplane interface removal work, after #1381.
-- Phase 4: BPF source removal, only after #1374-#1379 and any production
-  blockers from the audit are closed.
+- Phase 3: runtime and operator surface migration under #1451.
+- Phase 4: BPF source removal under #1476, only after #1451, #1473, and
+  the required #1477 validation artifacts are ready.
 - Phase 5: CLI and observability cleanup. The current #1380 helper-status
   contract is closed; future neighbor-cache fill-percentage rows need
   helper-owned denominators before they can enter the utilization table.
@@ -61,7 +76,7 @@ Phase 0 is complete only when:
   preserving stale "not implemented" claims for features already implemented in
   Rust;
 - rollback remains documented as the legacy eBPF dataplane staying present and
-  selectable until later phases; and
+  explicitly selectable until later phases; and
 - no BPF source, generated bindings, loader code, legacy tests, or CLI surfaces
   are removed by the Phase 0 PR.
 
@@ -71,8 +86,9 @@ The Phase 0 rollback path is deliberately simple because this PR is docs/audit
 only:
 
 1. keep the legacy eBPF backend in the tree and in build/test targets;
-2. remove or avoid `system dataplane-type userspace` on affected deployments, or
-   set `system dataplane-type ebpf` where an explicit backend is required;
+2. set `system dataplane-type ebpf` where an explicit legacy backend is
+   required, acknowledging the compile warning emitted for that temporary
+   compatibility selection;
 3. restart/re-apply `xpfd` so the manager selects the eBPF backend and legacy
    XDP/TC programs; and
 4. do not remove existing BPF pins or source until the later retirement phases

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -5,7 +5,7 @@ AF_XDP userspace dataplane. It is not a full bug tracker and it is not a
 historical branch plan. For active debugging entry points, use
 [`userspace-debug-map.md`](userspace-debug-map.md).
 
-Last updated: 2026-05-21
+Last updated: 2026-05-22
 
 ## Deprecation Context
 
@@ -37,14 +37,14 @@ These capabilities exist in the current Rust userspace dataplane code path:
 | Policy schedulers | Implemented; live HA evidence captured | Scheduled-policy `scheduler_name` and `inactive` bits are published in userspace snapshots, old helper protocol mismatches disarm forwarding, missing policy-scheduler references are commit errors, and Rust hit counters survive active/inactive snapshot rebuilds by stable rule ID. The 2026-05-19 #1378 live artifact set is accepted by `test/incus/policy_scheduler_validate.py` for `lan->wan/scheduled-allow`. |
 | Application matching | Implemented | Protocol + port terms, including expanded multi-term apps |
 | Source NAT (interface mode) | Implemented | IPv4 and IPv6 egress interface rewrite |
-| Source NAT (pool mode) | Implemented with scoped caveats | IPv4/IPv6 pool address and port allocation. Global `source address-persistent` uses the documented userspace-v1 SHA-256 source-IP hash and is stable only within the AF_XDP backend, pool family, pool order, and pool size. Legacy eBPF and current DPDK use C-word IPv4 modulo / IPv6 lane-XOR selection, so new-flow pool address parity is not promised across backend transitions. Pool-mode rules with missing pools, empty pools, invalid port ranges, malformed addresses, no address for the packet family, or exhausted live translated tuples fail closed at the `poll_descriptor.rs` source-NAT call sites before session creation or forwarding, with recent-exception reasons such as `source_nat_pool_missing`, `source_nat_pool_empty`, `source_nat_pool_invalid_port_range`, and `source_nat_pool_exhausted`. Per-pool `persistent-nat` now has snapshot fields and runtime lease reuse keyed by source tuple `(protocol, source IP, source port)` to translated tuple. The lease table is bounded in helper memory, survives compatible in-process snapshot refreshes, and expires after the configured inactivity timeout once no live flow uses the lease. It does not consult Go `PersistentNATTable` and does not survive helper restart. #1449 closes HA behavior as an explicit userspace capability gate: HA configs that reference persistent source-NAT pools are not admitted because leases are not synchronized, and status reports `userspace persistent-nat source pool leases are not HA-synchronized`. Userspace status, CLI summary, and Prometheus expose live-flow, used-port, persistent-lease, allocation, reuse, and exhaustion counters for admitted non-HA pools. |
+| Source NAT (pool mode) | Implemented with scoped caveats | IPv4/IPv6 pool address and port allocation. Global `source address-persistent` uses the documented userspace-v1 SHA-256 source-IP hash and is stable only within the AF_XDP backend, pool family, pool order, and pool size. Legacy eBPF and current DPDK use C-word IPv4 modulo / IPv6 lane-XOR selection, so new-flow pool address parity is not promised across retained backend transitions. Pool-mode rules with missing pools, empty pools, invalid port ranges, malformed addresses, no address for the packet family, or exhausted live translated tuples fail closed at the `poll_descriptor.rs` source-NAT call sites before session creation or forwarding, with recent-exception reasons such as `source_nat_pool_missing`, `source_nat_pool_empty`, `source_nat_pool_invalid_port_range`, and `source_nat_pool_exhausted`. Per-pool `persistent-nat` now has snapshot fields and runtime lease reuse keyed by source tuple `(protocol, source IP, source port)` to translated tuple. The lease table is bounded in helper memory, survives compatible in-process snapshot refreshes, and expires after the configured inactivity timeout once no live flow uses the lease. It does not consult Go `PersistentNATTable` and does not survive helper restart. The closed #1449 contract gates HA behavior explicitly: HA configs that reference persistent source-NAT pools are not admitted because leases are not synchronized, and status reports `userspace persistent-nat source pool leases are not HA-synchronized`. Userspace status, CLI summary, and Prometheus expose live-flow, used-port, persistent-lease, allocation, reuse, and exhaustion counters for admitted non-HA pools. |
 | Destination NAT | Implemented | Pre-expanded tuple snapshots from Go |
 | Static NAT | Implemented | Bidirectional 1:1 translation |
 | NAT64 | Implemented | Forward and reverse translation with reverse-session state |
 | NPTv6 | Implemented | Stateless prefix translation |
 | Firewall filters | Implemented | Filter snapshots and evaluation in Rust |
 | Flow export | Implemented | Userspace flow export snapshot and runtime |
-| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters, and compatible in-process snapshot continuity. Unsupported color-aware, non-`discard`, and malformed snapshots now fail closed in Rust if they bypass Go admission. Sharded state, HA/restart continuity decision, full non-drop action propagation, and integration evidence remain #1375 follow-up work. |
+| Three-color policers | Implemented with caveats | srTCM/trTCM runtime, forwarding-path and flow-cache-hit metering, red drops for `then discard`, status/CLI/Prometheus counters, and compatible in-process snapshot continuity. Unsupported color-aware, non-`discard`, and malformed snapshots now fail closed in Rust if they bypass Go admission. Sharded state, HA/restart continuity decision, full non-drop action propagation, and integration evidence remain production hardening work, not active feature-gap blockers. |
 | TCP MSS clamping | Implemented | Flow snapshot fields are delivered and used in Rust |
 | Embedded ICMP NAT reversal | Implemented | Includes reverse-session repair paths |
 | Configurable session timeouts | Implemented | Snapshot-driven timeouts in `session.rs` |
@@ -60,22 +60,22 @@ features that still need operator evidence before BPF source removal. The
 explicit gates live in
 [`pkg/dataplane/userspace/manager.go`](../pkg/dataplane/userspace/manager.go).
 
-| Feature/config shape | Userspace status | Retirement blocker |
+| Feature/config shape | Userspace status | Tracker / disposition |
 |----------------------|-------------|--------------------|
 | Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
-| Screen behavior requiring SYN cookies | Supported; live HA/flood evidence pending before BPF source removal | #1374 |
-| HA with per-pool source NAT `persistent-nat` | Gated | #1449 closed as an explicit userspace capability gate because helper-memory persistent-NAT leases are not HA-synchronized |
-| Port mirroring | Supported; evidence pending | #1376 still needs mirror-fidelity and pressure evidence before BPF source removal |
+| Screen behavior requiring SYN cookies | Supported; final source-removal evidence, if required, belongs with #1477 | Closed feature-gap; #1477 final validation |
+| HA with per-pool source NAT `persistent-nat` | Gated | Closed/documented contract: helper-memory persistent-NAT leases are not HA-synchronized, so HA configs that reference persistent source-NAT pools are not admitted |
+| Port mirroring | Supported; final source-removal evidence, if required, belongs with #1477 | Closed feature-gap; #1477 final validation |
 
 Port mirroring now has snapshot/wire plumbing plus a bounded runtime slice
 that samples and queues discardable full-L2 mirror clones with drop counters.
 Runtime coverage includes the pending-forward path, self-target flow-cache
 mirror surface, deferred neighbor-resolution retry path, CoS-bound reserve
 handling, and mirror-specific counter attribution. The
-`deriveUserspaceCapabilities()` gate has been removed; #1376 remains open for
-integration evidence that tcpdump on the mirror output sees full-frame clones
-at the expected sample rate and that primary forwarding survives mirror
-pressure.
+`deriveUserspaceCapabilities()` gate has been removed; #1376 is closed for the
+feature-gap audit. If source removal needs final mirror-fidelity and
+pressure-survival artifacts, they belong with the #1477 validation set for the
+exact removal candidate.
 
 ## Features That Still Use A Mixed Boundary
 
@@ -83,52 +83,50 @@ These are not "missing", but they are not pure userspace forwarding either:
 
 | Area | Current boundary |
 |------|------------------|
-| SYN cookie flood protection | Userspace now publishes a snapshot key when cluster-synced root encrypted-password material exists, mints/validates cookies against the Unix wall-clock epoch, sends bounded SYN-ACK and validated-ACK RST replies through the AF_XDP TX path, and reports challenge/no-secret/SYN-ACK/ACK-RST/budget/valid/invalid/bypass counters. Active SYN-cookie screen profiles require that secret material at userspace capability admission; missing secret material also fails closed at runtime. Remaining #1374 work is live HA/flood evidence before BPF source removal. |
+| SYN cookie flood protection | Userspace now publishes a snapshot key when cluster-synced root encrypted-password material exists, mints/validates cookies against the Unix wall-clock epoch, sends bounded SYN-ACK and validated-ACK RST replies through the AF_XDP TX path, and reports challenge/no-secret/SYN-ACK/ACK-RST/budget/valid/invalid/bypass counters. Active SYN-cookie screen profiles require that secret material at userspace capability admission; missing secret material also fails closed at runtime. #1374 is closed for the feature-gap audit; any final live HA/flood proof belongs with #1477. |
 | Kernel-owned traffic (ARP, local delivery, management, some non-IP) | cpumap or kernel pass-through from XDP |
 | GRE / ESP / explicit early filters | Live kernel-owned/tunnel-control cases use cpumap or pass-through; degraded helper/XSK states pass only proven local/control traffic and drop non-local transit |
 | IPsec / XFRM handling | Userspace detects and punts to kernel/slow-path as needed |
-| DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. Operator metadata reads in API/gRPC/CLI/daemon now use `LastApplyResult()` instead of `LastCompileResult()`, with a canary preventing those surfaces from regressing to compile-result metadata. GC and HA session sync now use `SessionStore`/`Telemetry`. The manager still holds a named eBPF shim manager for XDP/map bootstrap state, and API/gRPC/CLI session/counter readers plus daemon control paths still need to move fully to domain interfaces; tracked by #1381 |
+| DataPlane control-plane contract | Userspace manager no longer embeds the legacy `dataplane.DataPlane`; a userspace `LegacyDataPlaneAdapter` owns old-interface compatibility while callers migrate. Operator metadata reads in API/gRPC/CLI/daemon now use `LastApplyResult()` instead of `LastCompileResult()`, with a canary preventing those surfaces from regressing to compile-result metadata. GC and HA session sync now use `SessionStore`/`Telemetry`. The manager still holds a named eBPF shim manager for XDP/map bootstrap state, and API/gRPC/CLI session/counter readers plus daemon control paths still need to move fully to domain interfaces; tracked by the #1451 removal-phase migration |
 | DPDK backend | Separately supported backend outside userspace source-removal scope. Its current root `DataPlane` dependency is pinned as a backend-local #1475 exception until DPDK migrates to runtime/domain interfaces or gets a separate retirement decision. |
-| Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, logged routing-instance filter hits, non-PBR input filter logs, output filter logs, cached output-filter hits, and lo0 filter logs now enqueue RT_FLOW frames through the non-blocking Rust event-stream producer with existing per-event rate-limit/loss accounting. Go decode/status handling feeds raw userspace RT_FLOW frames through the same `EventReader.ProcessRawEvent` syslog/local-log path as eBPF, with a deterministic UDP syslog fanout harness for policy deny, screen drop, and filter log. Policy-deny events now carry the snapshot's compiled numeric policy ID; filter-log events carry filter/term/action identity from the matched compiled term. Remaining #1379 evidence is live userspace-cluster syslog capture, including deny-storm starvation checks, if Phase 4 requires operator artifacts beyond the deterministic local harness. |
+| Dataplane event logging | Session open/close/update are emitted by userspace. Policy-deny, screen-drop, logged routing-instance filter hits, non-PBR input filter logs, output filter logs, cached output-filter hits, and lo0 filter logs now enqueue RT_FLOW frames through the non-blocking Rust event-stream producer with existing per-event rate-limit/loss accounting. Go decode/status handling feeds raw userspace RT_FLOW frames through the same `EventReader.ProcessRawEvent` syslog/local-log path as eBPF, with a deterministic UDP syslog fanout harness for policy deny, screen drop, and filter log. Policy-deny events now carry the snapshot's compiled numeric policy ID; filter-log events carry filter/term/action identity from the matched compiled term. #1379 is closed for the feature-gap audit; any final live cluster syslog proof belongs with #1477 if the source-removal candidate requires it. |
 | `show system buffers` | Userspace helper-status rendering covers AF_XDP UMEM/TX capacity, CoS queued-byte capacity, helper-published session-table and flow-cache capacity, active-session footer, neighbor counts, and worker queue pressure counters. The Phase 5 denominator decision is explicit: session-table and flow-cache values become fill percentages only from Rust-owned helper fields; neighbor-cache entries remain counters until Rust owns a bounded neighbor-cache capacity. Formatter tests pin that dynamic counts cannot move into the utilization table without real denominators. |
 
-## Retirement Blockers From The 2026-05-16 Audit
+## Current Retirement Work After Feature-Gap Closeout
 
-The current #1373 audit produced these tracked blockers:
+The original #1374-#1381 feature-gap audit is closed. The remaining #1373 work
+is no longer "implement missing userspace feature parity"; it is the removal
+phase that migrates or deletes the legacy eBPF runtime surfaces safely.
 
-| Issue | Blocker | Required before |
-|-------|---------|-----------------|
-| #1381 | Split or replace the BPF-shaped `dataplane.DataPlane` interface so userspace no longer embeds the eBPF manager for map-writer methods. Current progress: userspace no longer embeds the legacy interface, neutral `RuntimeDataPlane` domains exist, operator metadata reads use `ApplyResult`, and GC plus HA session sync use `SessionStore`/`Telemetry` for session/counter work; remaining work is API/gRPC/CLI session/counter readers, daemon control paths, userspace-specific diagnostics/control adapters, and the final userspace shim removal. | Phase 3 build-system / Go removal |
-| #1377 | Preserve userspace-v1 address-persistent SNAT pool selection with an explicit backend compatibility boundary, and own non-HA userspace source-NAT pool allocation at runtime. The current runtime fails closed for source-NAT pool rules with missing pools, empty pools, invalid pool inputs, wrong-family-only pools, or live allocator exhaustion at the `poll_descriptor.rs` source-NAT call sites. It provides bounded helper-local persistent-NAT lease reuse and live allocator counters, but does not provide helper-restart persistence or cross-backend new-flow parity. HA-synchronized persistent leases are intentionally not implemented; #1449 closes that behavior as the capability gate above. | Phase 4 BPF source removal |
-| #1378 | Closed for the policy-scheduler retirement contract after #1396 userspace propagation: hit-counter survival across scheduler snapshot rebuilds and strict missing-scheduler commit behavior landed in the 2026-05-17 closeout slice, the 2026-05-18 closeout slice added the deterministic evidence checker and non-eBPF apply-path pin, and the 2026-05-19 live HA artifact set passed `test/incus/policy_scheduler_validate.py`. | Phase 4 BPF source removal |
-| #1379 | Complete dataplane event closeout: policy-deny, screen-drop, logged PBR filter hits, non-PBR input/output/lo0 filter logs, cached output-filter logs, policy numeric IDs, and filter/term identities now emit from userspace through the RT_FLOW stream. Deterministic Go syslog fanout coverage exists for policy deny, screen drop, and filter log. Remaining blocker is live userspace-cluster syslog evidence, including deny-storm starvation checks, if #1373 Phase 4 requires external artifacts. | Phase 4 BPF source removal |
-| #1374 | Implement userspace SYN-cookie flood protection or an approved equivalent. #1393, the 2026-05-17 runtime slice, the 2026-05-18 closeout slice, and the 2026-05-19 TX closeout cover deterministic cookie codec/layout, snapshot propagation, root-auth-derived key publication with fail-closed missing-secret behavior, capability admission for active SYN-cookie screen profiles, fail-closed screen challenge selection, bounded SYN-ACK TX, validated-ACK RST emission, session-miss ACK validation, bounded validated-client cache behavior, TTL-bound single-use validated-client expiration, current/previous/next Unix wall-clock cookie-epoch ACK validation with standby prefilter/rate-limiting, explicit validated-client bypass verdicts, userspace helper status counters, and legacy global sync for sent/valid/invalid/bypass counters. Remaining: live HA/flood validation evidence before BPF source removal. | Phase 4 BPF source removal |
-| #1375 | Finish userspace RFC 2697/2698 three-color policer hardening. The current runtime admits the color-blind `then discard` slice, fails closed for unsupported snapshot shapes that bypass Go admission, and preserves token/counter state across compatible in-process snapshot refreshes. Remaining work: sharded/packed state decision, HA/restart continuity decision, full non-drop color action propagation, and integration/failover/performance evidence | Phase 4 BPF source removal |
-| #1376 | Finish userspace port mirroring evidence. Snapshot/wire plumbing, bounded runtime delivery, pending-forward, self-target flow-cache, deferred-neighbor retry, CoS reserve handling, counter attribution, and capability admission now exist. Remaining work is mirror-fidelity evidence and forwarding survival under mirror pressure. | Phase 4 BPF source removal |
-| #1380 | Userspace `show system buffers` renders bounded helper status, including Rust-owned session-table and flow-cache denominators. Neighbor entries remain counters until Rust owns a bounded neighbor-cache capacity. | Phase 5 CLI / observability cleanup |
+#1377 is also closed for source-NAT pool retirement. Its SNAT follow-ups
+#1448, #1449, and #1450 are closed as documented contracts: helper restart
+resets helper-local persistent-NAT leases, HA configurations with persistent
+source-NAT pools are gated because leases are not synchronized, and new-flow
+pool-address parity is not promised across retained backend changes.
+
+The current tracked removal work is:
+
+| Issue | Removal-phase role |
+|-------|--------------------|
+| #1451 | Migrate remaining API, gRPC, CLI, status, metrics, session, GC, cluster, daemon-control, and userspace shim callers away from the legacy eBPF-shaped `dataplane.DataPlane` surface before deleting source/generated artifacts. |
+| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback so the shim can remain while legacy XDP/TC programs are removed. |
+| #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the migration blockers close, while preserving the retained AF_XDP userspace shim path. |
+| #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate, including cluster, screen/flood, CoS, HA, and fallback-proof evidence. |
+
+#1474 is closed: omitted `system dataplane-type` selects userspace, and
+explicit `system dataplane-type ebpf` emits an operator-visible compile warning
+while legacy source removal is staged.
 
 Recommended dependency order:
 
-1. #1381 first, because it defines the control-plane interface boundary that
-   every later removal phase depends on.
-2. #1377 and #1379 next, because they are silent correctness or
-   security-visibility regressions in configurations that may otherwise appear
-   admitted. #1377 now has fail-closed pool runtime handling for unusable
-   pool snapshots, the userspace-v1 selector and mixed-backend transition
-   boundary are explicit, and the non-HA helper-local persistent-NAT allocator
-   slice is implemented with live counters. Remaining #1377 caveats are
-   helper-restart persistence and any future decision to standardize new-flow
-   selector parity across retained backends. #1449 closes HA persistent-lease
-   behavior as an explicit userspace capability gate, not as lease replay.
-   #1378 is closed after the accepted 2026-05-19 live HA artifact set.
-3. #1374 and #1376 evidence before Phase 4, because SYN-cookie and mirroring
-   are now admitted userspace runtime features that still need live operator
-   artifacts before BPF source removal. Keep #1375 on the Phase 4 list for
-   validation and hardening evidence, not as a capability gate. No additional
-   #1378 scheduler runtime or evidence work is known from the current audit.
-4. #1380 is closed for the current helper schema. Future true utilization rows
-   for neighbor-cache state need a helper-published bounded capacity and should
-   be tracked as a separate issue.
+1. #1451 first, because it defines the runtime and operator interface boundary
+   that every source-removal slice depends on.
+2. #1473 next, because the retained userspace XDP shim must be explicit before
+   legacy source is deleted.
+3. #1476 after #1451 and #1473 close, as the auditable source/generated-artifact
+   removal PR.
+4. #1477 on the exact #1476 candidate, so the final validation artifacts match
+   the code that removes the legacy eBPF path.
 
 ## What This Document Does Not Mean
 
@@ -171,14 +169,14 @@ There are two distinct fallback boundaries:
 
 The highest-value remaining work on current `master` is:
 
-1. finish the #1377 disposition around helper-restart persistence, HA lease
-   synchronization, and cross-backend selector parity. The current userspace
-   contract is fail-closed for unusable pools and uses the active AF_XDP
-   selector, not full persistent-NAT parity.
-2. collect any Phase 4 operator evidence still required for admitted userspace
-   features before BPF source removal. The #1378 scheduler runtime is closed by
-   the accepted userspace HA artifact set.
-3. keep #1380 closed for the current command contract. Open a narrower
-   follow-up only if operators need a helper-published bounded capacity for
-   neighbor-cache utilization percentages.
+1. complete #1451's runtime-surface migration so source removal no longer
+   depends on legacy `dataplane.DataPlane` callers.
+2. complete #1473's userspace XDP shim split.
+3. land #1476 only after those blockers close, then attach the #1477
+   userspace-only validation artifact set to the exact source-removal
+   candidate.
 4. continue correctness and performance hardening on the active AF_XDP fast path
+
+Keep #1377, #1448, #1449, and #1450 closed. SNAT helper-restart reset
+behavior, HA persistent-lease gating, and cross-backend selector divergence
+remain documented userspace contract limits, not active #1373/#1451 blockers.


### PR DESCRIPTION
## Summary

- Record #1377/#1448/#1449/#1450 as closed SNAT contracts, not active #1373/#1451 blockers.
- Move the active retirement backlog to #1451, #1473, #1474, #1476, and #1477.
- Keep helper restart, HA persistent-lease gating, and cross-backend selector divergence documented as current userspace contract limits.
- Align the fallback wording with #1474: omitted dataplane-type selects userspace, while explicit `ebpf` is temporary compatibility and warns.

Fixes #1484.

## Validation

- `git diff --check`
- Stale-active grep for #1377/#1448/#1449/#1450 priority/blocker phrasing.
- SNAT limitation grep confirming helper restart, HA, and cross-backend selector limits remain documented.

## Self-review

Adversarial pass checked for the previous contradiction: the docs no longer describe SNAT helper-restart persistence, HA lease sync, or cross-backend selector parity as work that must close #1377, while still keeping those limitations visible so operators do not infer stronger persistent-NAT guarantees than the runtime provides.
