### PR TITLE
api: narrow REST dataplane runtime surface

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -88,10 +88,9 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | File | Current blocker |
 |---|---|
 | `cmd/xpfd/main.go` | Backend selection, cleanup, and backend registration still cross the root package. |
-| `pkg/api/handlers.go` | REST handlers still receive the legacy dataplane bridge. |
+| `pkg/api/handlers.go` | REST handlers still reference legacy dataplane counters and types. |
 | `pkg/api/handlers_sessions.go` | REST session reads still use legacy session types. |
 | `pkg/api/metrics.go` | Prometheus telemetry still reads legacy counters and metadata. |
-| `pkg/api/server.go` | REST server construction still stores the legacy bridge. |
 | `pkg/cli/cli.go` | Embedded CLI construction still stores the legacy bridge. |
 | `pkg/cli/cli_clear.go` | Clear commands still delete legacy session entries. |
 | `pkg/cli/cli_show_cluster.go` | Cluster display still reads legacy dataplane state. |

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -22,6 +22,27 @@ import (
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
+// apiRuntimeDataPlane is the API server's legacy-compatible runtime surface.
+// It intentionally stays narrower than dataplane.DataPlane while REST handlers
+// still migrate one domain at a time.
+type apiRuntimeDataPlane interface {
+	IsLoaded() bool
+	IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	ClearAllSessions() (int, int, error)
+
+	ReadGlobalCounter(uint32) (uint64, error)
+	ReadInterfaceCounters(int) (dataplane.InterfaceCounterValue, error)
+	ReadZoneCounters(uint16, int) (dataplane.CounterValue, error)
+	ReadPolicyCounters(uint32) (dataplane.CounterValue, error)
+	ReadFilterConfig(uint32) (dataplane.FilterConfig, error)
+	ReadFilterCounters(uint32) (dataplane.CounterValue, error)
+	ReadNATRuleCounter(uint32) (dataplane.CounterValue, error)
+	ReadNATPortCounter(uint32) (uint64, error)
+	ClearAllCounters() error
+	GetMapStats() []dataplane.MapStats
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -926,7 +926,7 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 // CoS owner profile + worker runtime collectors.  Both features need
 // the same ProcessStatus; calling Status() twice per scrape is
 // wasteful on the userspace-dp control socket.
-func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	provider, ok := dp.(interface {
 		Status() (dpuserspace.ProcessStatus, error)
 	})
@@ -1644,7 +1644,7 @@ func bucketUpperBoundNs(i int) uint64 {
 	return uint64(1) << uint(i+10)
 }
 
-func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	readCounter := func(idx uint32) float64 {
 		v, _ := dp.ReadGlobalCounter(idx)
 		return float64(v)
@@ -1692,7 +1692,7 @@ func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp dat
 		readCounter(dataplane.GlobalCtrFlowCacheInvalidate), "invalidate")
 }
 
-func (c *xpfCollector) collectInterfaceCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectInterfaceCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -1718,7 +1718,7 @@ func (c *xpfCollector) collectInterfaceCounters(ch chan<- prometheus.Metric, dp 
 	}
 }
 
-func (c *xpfCollector) collectZoneCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectZoneCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -1748,7 +1748,7 @@ func (c *xpfCollector) collectZoneCounters(ch chan<- prometheus.Metric, dp datap
 	}
 }
 
-func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -1789,7 +1789,7 @@ func policyCounterID(policySetID uint32, ruleIndex int) uint32 {
 	return policySetID*dataplane.MaxRulesPerPolicy + uint32(ruleIndex)
 }
 
-func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return
@@ -1843,7 +1843,7 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp dat
 	emitFilters("inet6", cfg.Firewall.FiltersInet6)
 }
 
-func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	if c.srv.gc == nil {
 		return
 	}
@@ -1887,7 +1887,7 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp data
 	ch <- prometheus.MustNewConstMetric(c.sessionsDNAT, prometheus.GaugeValue, float64(dnat))
 }
 
-func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp dataplane.DataPlane) {
+func (c *xpfCollector) collectNATPoolMetrics(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	cfg := c.srv.store.ActiveConfig()
 	if cfg == nil {
 		return

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
-	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/frr"
 	"github.com/psaab/xpf/pkg/ipsec"
@@ -47,7 +46,7 @@ type Config struct {
 	TLS       bool   // enable HTTPS with auto-generated certificate
 	Auth      *AuthConfig // nil = no authentication
 	Store     *configstore.Store
-	DP        dataplane.DataPlane
+	DP        apiRuntimeDataPlane
 	EventBuf  *logging.EventBuffer
 	GC        *conntrack.GC
 	Routing   *routing.Manager
@@ -75,7 +74,7 @@ type Server struct {
 	httpServer  *http.Server
 	httpsServer *http.Server
 	store       *configstore.Store
-	dp          dataplane.DataPlane
+	dp          apiRuntimeDataPlane
 	eventBuf    *logging.EventBuffer
 	gc          *conntrack.GC
 	routing     *routing.Manager

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -21,10 +21,9 @@ const (
 
 var legacyDataplaneImportAllowlist = map[string]string{
 	"cmd/xpfd/main.go":                         "backend selection, cleanup, and backend registration",
-	"pkg/api/handlers.go":                      "REST handlers still receive the legacy dataplane bridge",
+	"pkg/api/handlers.go":                      "REST handlers still reference legacy dataplane counters and types",
 	"pkg/api/handlers_sessions.go":             "REST session reads still use legacy session types",
 	"pkg/api/metrics.go":                       "Prometheus telemetry still reads legacy counters and metadata",
-	"pkg/api/server.go":                        "REST server constructor still stores the legacy bridge",
 	"pkg/cli/cli.go":                           "embedded CLI constructor still stores the legacy bridge",
 	"pkg/cli/cli_clear.go":                     "clear commands still delete legacy session entries",
 	"pkg/cli/cli_show_cluster.go":              "cluster display still reads legacy dataplane state",


### PR DESCRIPTION
## Summary
- replace pkg/api server storage with a package-local runtime subset instead of dataplane.DataPlane
- keep REST handler and metrics behavior on the same dynamic runtime object
- remove pkg/api/server.go from the #1451 root dataplane import allowlist and docs

## Validation
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/api ./pkg/dataplane
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/daemon
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/dataplane -run 'TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports|TestRetirementBoundaryDocsMentionLegacyImportAllowlist'\n- git diff --check