### PR TITLE
cli: move cluster fabric stats behind telemetry

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -94,7 +94,6 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/api/server.go` | REST server construction still stores the legacy bridge. |
 | `pkg/cli/cli.go` | Embedded CLI construction still stores the legacy bridge. |
 | `pkg/cli/cli_clear.go` | Clear commands still delete legacy session entries. |
-| `pkg/cli/cli_show_cluster.go` | Cluster display still reads legacy dataplane state. |
 | `pkg/cli/cli_show_flow.go` | Flow display still uses legacy session keys and values. |
 | `pkg/cli/cli_show_nat.go` | NAT display still uses legacy NAT/session metadata. |
 | `pkg/cli/cli_show_security.go` | Security display still uses legacy counters and filter types. |

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -139,6 +139,36 @@ func (c *CLI) applyResult() *dataplane.ApplyResult {
 	return dataplane.LastApplyResultOf(c.dp)
 }
 
+func (c *CLI) dataplaneLoaded() bool {
+	return c != nil && c.dp != nil && c.dp.IsLoaded()
+}
+
+type fabricRedirectCounters struct {
+	total uint64
+	fab0  uint64
+	fab1  uint64
+	zone  uint64
+	drops uint64
+}
+
+func (c *CLI) readFabricRedirectCounters() (fabricRedirectCounters, bool) {
+	if !c.dataplaneLoaded() {
+		return fabricRedirectCounters{}, false
+	}
+	telemetry := dataplane.TelemetryOf(c.dp)
+	read := func(index uint32) uint64 {
+		v, _ := telemetry.GlobalCounter(index)
+		return v
+	}
+	return fabricRedirectCounters{
+		total: read(dataplane.GlobalCtrFabricRedirect),
+		fab0:  read(dataplane.GlobalCtrFabricRedirectFab0),
+		fab1:  read(dataplane.GlobalCtrFabricRedirectFab1),
+		zone:  read(dataplane.GlobalCtrFabricRedirectZone),
+		drops: read(dataplane.GlobalCtrFabricFwdDrop),
+	}, true
+}
+
 // SetForwardingSampler wires the pkg/fwdstatus Sampler into the CLI
 // so `show chassis forwarding` can read 5s/1m/5m CPU windows.
 // Pass nil to disable windowed CPU display (Build falls back to

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/cmdtree"
-	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -166,22 +165,18 @@ func (c *CLI) showChassisClusterStatistics() error {
 }
 
 func (c *CLI) showChassisClusterFabricStatistics() error {
-	if c.dp == nil || !c.dp.IsLoaded() {
+	counters, ok := c.readFabricRedirectCounters()
+	if !ok {
 		fmt.Println("Dataplane not loaded")
 		return nil
 	}
-	total, _ := c.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirect)
-	fab0, _ := c.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab0)
-	fab1, _ := c.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab1)
-	zone, _ := c.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectZone)
-	drops, _ := c.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricFwdDrop)
 
 	fmt.Println("Fabric redirect statistics:")
-	fmt.Printf("    Total redirects:          %d\n", total)
-	fmt.Printf("    fab0 redirects:           %d\n", fab0)
-	fmt.Printf("    fab1 redirects:           %d\n", fab1)
-	fmt.Printf("    Zone-encoded redirects:   %d\n", zone)
-	fmt.Printf("    Redirect drops:           %d\n", drops)
+	fmt.Printf("    Total redirects:          %d\n", counters.total)
+	fmt.Printf("    fab0 redirects:           %d\n", counters.fab0)
+	fmt.Printf("    fab1 redirects:           %d\n", counters.fab1)
+	fmt.Printf("    Zone-encoded redirects:   %d\n", counters.zone)
+	fmt.Printf("    Redirect drops:           %d\n", counters.drops)
 	fmt.Println()
 	fmt.Println("Note: XDP-redirected packets bypass AF_PACKET (tcpdump).")
 	fmt.Println("Use these counters or 'monitor interface <fab>' for fabric telemetry.")

--- a/pkg/cli/cli_show_cluster_test.go
+++ b/pkg/cli/cli_show_cluster_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+type fabricStatsCLIDP struct {
+	dataplane.DataPlane
+
+	loaded  bool
+	reads   []uint32
+	counter map[uint32]uint64
+}
+
+func (f *fabricStatsCLIDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *fabricStatsCLIDP) ReadGlobalCounter(index uint32) (uint64, error) {
+	f.reads = append(f.reads, index)
+	return f.counter[index], nil
+}
+
+func TestShowChassisClusterFabricStatisticsReadsTelemetryCounters(t *testing.T) {
+	dp := &fabricStatsCLIDP{
+		loaded: true,
+		counter: map[uint32]uint64{
+			dataplane.GlobalCtrFabricRedirect:     100,
+			dataplane.GlobalCtrFabricRedirectFab0: 40,
+			dataplane.GlobalCtrFabricRedirectFab1: 50,
+			dataplane.GlobalCtrFabricRedirectZone: 10,
+			dataplane.GlobalCtrFabricFwdDrop:      3,
+		},
+	}
+	c := &CLI{dp: dp}
+
+	out := captureStdout(t, func() {
+		if err := c.showChassisClusterFabricStatistics(); err != nil {
+			t.Fatalf("showChassisClusterFabricStatistics() error = %v", err)
+		}
+	})
+
+	wantReads := []uint32{
+		dataplane.GlobalCtrFabricRedirect,
+		dataplane.GlobalCtrFabricRedirectFab0,
+		dataplane.GlobalCtrFabricRedirectFab1,
+		dataplane.GlobalCtrFabricRedirectZone,
+		dataplane.GlobalCtrFabricFwdDrop,
+	}
+	if !reflect.DeepEqual(dp.reads, wantReads) {
+		t.Fatalf("counter reads = %#v, want %#v", dp.reads, wantReads)
+	}
+	for _, want := range []string{
+		"Total redirects:          100",
+		"fab0 redirects:           40",
+		"fab1 redirects:           50",
+		"Zone-encoded redirects:   10",
+		"Redirect drops:           3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestShowChassisClusterFabricStatisticsSkipsUnloadedDataplane(t *testing.T) {
+	dp := &fabricStatsCLIDP{loaded: false}
+	c := &CLI{dp: dp}
+
+	out := captureStdout(t, func() {
+		if err := c.showChassisClusterFabricStatistics(); err != nil {
+			t.Fatalf("showChassisClusterFabricStatistics() error = %v", err)
+		}
+	})
+
+	if strings.TrimSpace(out) != "Dataplane not loaded" {
+		t.Fatalf("output = %q, want unloaded message", out)
+	}
+	if len(dp.reads) != 0 {
+		t.Fatalf("counter reads = %#v, want none", dp.reads)
+	}
+}

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -27,7 +27,6 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/api/server.go":                        "REST server constructor still stores the legacy bridge",
 	"pkg/cli/cli.go":                           "embedded CLI constructor still stores the legacy bridge",
 	"pkg/cli/cli_clear.go":                     "clear commands still delete legacy session entries",
-	"pkg/cli/cli_show_cluster.go":              "cluster display still reads legacy dataplane state",
 	"pkg/cli/cli_show_flow.go":                 "flow display still uses legacy session keys and values",
 	"pkg/cli/cli_show_nat.go":                  "NAT display still uses legacy NAT/session metadata",
 	"pkg/cli/cli_show_security.go":             "security display still uses legacy counters and filter types",


### PR DESCRIPTION
## Summary

- move the CLI cluster fabric statistics display off its direct root dataplane import by reading counters through the telemetry domain adapter owned from cli.go
- remove pkg/cli/cli_show_cluster.go from the #1451 legacy import allowlist and retirement tracker docs
- add focused CLI regression coverage for the migrated fabric statistics path and unloaded dataplane gate

## Validation

- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/cli -run TestShowChassisClusterFabricStatistics
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/cli ./pkg/dataplane
- GOFLAGS=-buildvcs=false go test -count=1 ./pkg/dataplane -run TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports
- git diff --check
- git diff --cached --check

## Self-review

- Checked that pkg/cli/cli_show_cluster.go no longer imports root pkg/dataplane and no longer reaches c.dp directly.
- Preserved existing operator output and the prior behavior of ignoring individual counter read errors.
- Kept the legacy bridge centralized in the already-allowlisted CLI owner instead of broadening the boundary.