### PR TITLE
docs: retire stale HA xdp fallback runbook

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,103 @@
 # Action Log
 
+## 2026-05-22
+
+- **Timestamp**: 2026-05-22T20:20:00Z
+  - **Action**: PR #1491 r6 review closeout — removed the remaining
+    supported-runtime `FW0` arm fallback, made supported-runtime owner
+    waits fail closed on ambiguous ownership, and converted status summary
+    counter reads from `__ERR__` sentinel math to explicit fail-closed
+    delta helpers.
+  - **File(s)**: `scripts/userspace-ha-validation.sh`,
+    `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `shellcheck
+    scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T20:02:00Z
+  - **Action**: PR #1491 copilot follow-up — clarified unmatched-interface
+    parser failures to include the count of malformed binding rows that were
+    ignored, so diagnostics no longer imply a pure regex mismatch when row
+    shape is also broken.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-failover-validation.sh`;
+    `git diff --check`
+
+- **Timestamp**: 2026-05-22T19:55:00Z
+  - **Action**: PR #1491 copilot follow-up — tightened userspace binding
+    parser diagnostics so malformed short rows are tracked separately from
+    valid rows, avoiding misleading "no interface match" errors when the
+    binding table format is broken.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-failover-validation.sh`;
+    `git diff --check`
+
+- **Timestamp**: 2026-05-22T18:45:00Z
+  - **Action**: PR #1491 r4 closeout — made userspace RG owner
+    selection reject split-brain, require the post-failover owner to match
+    the requested target VM, keep owner selection ambiguous while either
+    peer cannot be queried, and make the startup arm path refuse split-brain
+    states. Removed the remaining transition-window sample `|| true`
+    masking and negative-delta clamps.
+  - **File(s)**: `scripts/userspace-ha-validation.sh`,
+    `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T16:20:00Z
+  - **Action**: PR #1491 review cleanup — made the explicit legacy-HA
+    validation override require an unambiguous active firewall owner instead
+    of falling back to `FW0` when owner detection fails.
+  - **File(s)**: `scripts/userspace-ha-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T16:00:00Z
+  - **Action**: PR #1491 review cleanup — normalized userspace bindings
+    parse error text casing to match the CLI section header terminology.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T15:55:00Z
+  - **Action**: PR #1491 review closeout — renamed standby WAN baseline
+    snapshot variable for clarity, tightened userspace-binding parser
+    diagnostics for empty vs unmatched rows, and moved WAN counter delta
+    monotonicity checks to Python integer math to avoid shell
+    signed-arithmetic edge cases.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T15:45:00Z
+  - **Action**: PR #1491 review polish — added explicit
+    empty-userspace-bindings detection in standby WAN counter parsing and
+    simplified standby WAN snapshot-stage failure messages to high-level
+    baseline/post-validation diagnostics.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T15:35:00Z
+  - **Action**: PR #1491 review polish — clarified standby WAN TX snapshot
+    failure messages for post-failover baseline vs post-validation captures
+    and tightened userspace-binding parse failure checks to fail once with
+    explicit context.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
+- **Timestamp**: 2026-05-22T15:10:10Z
+  - **Action**: PR #1491 follow-up — fixed standby WAN TX failover
+    gating by measuring from post-failover baseline snapshots, failing closed
+    when userspace binding counters are unavailable, and treating standby WAN
+    TX counter resets as validation failures instead of clamping negative
+    deltas to zero.
+  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
+  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
+    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
+
 ## 2026-05-21
 
 - **Timestamp**: 2026-05-21T23:30:00Z

--- a/docs/userspace-ha-validation.md
+++ b/docs/userspace-ha-validation.md
@@ -123,7 +123,8 @@ The validator does this in order:
 
 1. uses the tracked env/config in the repo, not `/tmp`
 2. waits for CLI availability on both firewalls
-3. checks whether the runtime settled into supported userspace forwarding or legacy fallback
+3. fails unless the runtime settled into supported userspace forwarding; legacy
+   eBPF fallback requires explicit `ALLOW_LEGACY_EBPF_HA_VALIDATION=1`
 4. pins the validation RGs to the preferred node, retrying transient failover
    precondition failures while userspace XSK liveness propagates into RG
    readiness
@@ -148,12 +149,14 @@ The validator does this in order:
 16. retries one marginal near-threshold miss once
 17. optionally records `perf` data on the active firewall
 
-The dedicated RG failover validator now adds two stricter HA gates:
+The dedicated RG failover validator now adds stricter HA gates:
 
 1. a steady-state pre-failover observation window after session sync completes
 2. `0.00 bits/sec` enforcement during that window for both:
    - aggregate `[SUM]` output
    - individual `iperf3` streams
+3. standby userspace readiness checks after each RG move
+4. flat standby WAN TX deltas during stale-owner fabric redirect checks
 
 For standard HA failover stress on `loss`, use:
 
@@ -194,10 +197,11 @@ That is the target, not a guarantee of the current tree state.
 Current `master` reality:
 
 - the isolated HA lab is used for both active userspace-forwarding work and
-  safe fallback verification, depending on the active config and runtime gate
-- the validator must therefore first determine whether the node settled into:
-  - active userspace forwarding, or
-  - legacy eBPF fallback
+  explicit legacy regression coverage, depending on the active config and
+  runtime gate
+- the userspace validator fails by default if the node settled into legacy eBPF
+  fallback; set `ALLOW_LEGACY_EBPF_HA_VALIDATION=1` only for a deliberately
+  scoped legacy regression run
 - the tree is still under active forwarding-correctness and performance work on
   the AF_XDP fast path
 - it is normal for the validator to fail while a phase is in progress

--- a/scripts/userspace-ha-failover-validation.sh
+++ b/scripts/userspace-ha-failover-validation.sh
@@ -24,8 +24,6 @@ if [[ -z "${IPERF_DURATION:-}" ]]; then
 	else
 		IPERF_DURATION=60
 	fi
-else
-	IPERF_DURATION="${IPERF_DURATION}"
 fi
 IPERF_STREAMS="${IPERF_STREAMS:-4}"
 MIN_SESSIONS="${MIN_SESSIONS:-4}"
@@ -54,6 +52,8 @@ MAX_TRANSITION_DIRECT_TX_NOFRAME_DELTA="${MAX_TRANSITION_DIRECT_TX_NOFRAME_DELTA
 TRANSITION_PATH_TRIGGER_PKTS="${TRANSITION_PATH_TRIGGER_PKTS:-1000}"
 MIN_TRANSITION_FABRIC_RX_DELTA="${MIN_TRANSITION_FABRIC_RX_DELTA:-32}"
 MIN_TRANSITION_WAN_TX_DELTA="${MIN_TRANSITION_WAN_TX_DELTA:-32}"
+MAX_STANDBY_WAN_TX_DELTA="${MAX_STANDBY_WAN_TX_DELTA:-0}"
+STANDBY_WAN_IFACE_REGEX="${STANDBY_WAN_IFACE_REGEX:-ge-[0-9]+-0-2}"
 RESTORE_SOURCE_NODE="${RESTORE_SOURCE_NODE:-1}"
 ALLOW_STALE_SESSIONS="${ALLOW_STALE_SESSIONS:-0}"
 IPERF_COMPLETION_GRACE_SEC="${IPERF_COMPLETION_GRACE_SEC:-2}"
@@ -213,15 +213,33 @@ enabled_userspace_rg_vm() {
 
 wait_for_userspace_rg_owner() {
 	local rg="$1"
+	local expected_vm="${2:-}"
 	local tries=45
 	while (( tries > 0 )); do
-		local owner_vm
+		local active=()
+		local owner_vm stats query_failed=0
 		for owner_vm in "$FW0" "$FW1"; do
-			if enabled_userspace_rg_vm "$owner_vm" "$rg" >/dev/null 2>&1; then
-				printf '%s\n' "$owner_vm"
-				return 0
+			if ! stats="$(run_vm "$owner_vm" 'cli -c "show chassis cluster data-plane statistics"' 2>/dev/null)"; then
+				query_failed=1
+				continue
+			fi
+			if grep -Eq 'Enabled:[[:space:]]+true' <<<"$stats" &&
+				grep -Eq 'Forwarding supported:[[:space:]]+true' <<<"$stats" &&
+				grep -Eq "rg${rg} active=true" <<<"$stats" &&
+				grep -Eq 'Ready bindings:[[:space:]]+[1-9][0-9]*/[0-9]+' <<<"$stats"; then
+				active+=("$owner_vm")
 			fi
 		done
+		if (( ${#active[@]} > 1 )); then
+			printf 'split-brain userspace RG%s owners: %s\n' "$rg" "${active[*]}" >&2
+			return 2
+		fi
+		if (( query_failed == 0 && ${#active[@]} == 1 )); then
+			if [[ -z "$expected_vm" || "${active[0]}" == "$expected_vm" ]]; then
+				printf '%s\n' "${active[0]}"
+				return 0
+			fi
+		fi
 		sleep 1
 		tries=$((tries - 1))
 	done
@@ -230,17 +248,28 @@ wait_for_userspace_rg_owner() {
 
 arm_userspace_runtime() {
 	local owner_vm
+	local settle_status
 	owner_vm="$(vm_for_node "$SOURCE_NODE")"
 	info "waiting for userspace forwarding on RG${RG}"
 	if ACTIVE_FW="$(wait_for_userspace_rg_owner "$RG")"; then
 		info "active RG${RG} userspace firewall: ${ACTIVE_FW}"
 		return 0
+	else
+		settle_status=$?
+		if (( settle_status == 2 )); then
+			die "userspace forwarding for RG${RG} is split-brain; refusing to arm"
+		fi
 	fi
 	info "forcing userspace arm on ${owner_vm}"
 	run_vm "$owner_vm" 'cli -c "request chassis cluster data-plane userspace forwarding arm" >/tmp/userspace-arm.out'
 	if ACTIVE_FW="$(wait_for_userspace_rg_owner "$RG")"; then
 		info "active RG${RG} userspace firewall: ${ACTIVE_FW}"
 		return 0
+	else
+		settle_status=$?
+		if (( settle_status == 2 )); then
+			die "userspace forwarding for RG${RG} is split-brain after arm request"
+		fi
 	fi
 	die "userspace forwarding did not become active for RG${RG}"
 }
@@ -316,9 +345,8 @@ import sys
 path = pathlib.Path(sys.argv[1])
 label = sys.argv[2]
 if not path.exists():
-    print(f"WARN: status_summary_value: '{path}' missing", file=sys.stderr)
-    print("__ERR__")
-    raise SystemExit(0)
+    print(f"status summary snapshot missing: {path}", file=sys.stderr)
+    raise SystemExit(2)
 
 pattern = f"  {label}:"
 for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -328,13 +356,35 @@ for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
     if match:
         print(match.group(1))
     else:
-        print(f"WARN: status_summary_value: unparseable value for '{label}' in '{path}'", file=sys.stderr)
-        print("__ERR__")
+        print(f"unparseable status summary value for {label!r} in {path}", file=sys.stderr)
+        raise SystemExit(2)
     break
 else:
-    print(f"WARN: status_summary_value: label '{label}' not found in '{path}'", file=sys.stderr)
-    print("__ERR__")
+    print(f"status summary label {label!r} not found in {path}", file=sys.stderr)
+    raise SystemExit(2)
 PY
+}
+
+status_summary_delta() {
+	local post_path="$1"
+	local pre_path="$2"
+	local label="$3"
+	local context="$4"
+	local pre post delta
+
+	if ! pre="$(status_summary_value "$pre_path" "$label")"; then
+		fail "${context}: unable to read pre ${label}"
+		return 1
+	fi
+	if ! post="$(status_summary_value "$post_path" "$label")"; then
+		fail "${context}: unable to read post ${label}"
+		return 1
+	fi
+	if ! delta="$(nondecreasing_counter_delta "$pre" "$post")"; then
+		fail "${context}: ${label} counter decreased from ${pre} to ${post}"
+		return 1
+	fi
+	printf '%s\n' "$delta"
 }
 
 sync_stats_value() {
@@ -404,8 +454,12 @@ wait_for_session_sync_idle() {
 		local source_sent target_recv target_pending target_drained
 		source_sent="$(sync_stats_value "$source_path" "Session create" sent)"
 		target_recv="$(sync_stats_value "$target_path" "Session create" received)"
-		target_pending="$(status_summary_value "$target_path" "Session delta pending")"
-		target_drained="$(status_summary_value "$target_path" "Session delta drained")"
+		if ! target_pending="$(status_summary_value "$target_path" "Session delta pending")"; then
+			target_pending="__ERR__"
+		fi
+		if ! target_drained="$(status_summary_value "$target_path" "Session delta drained")"; then
+			target_drained="__ERR__"
+		fi
 		if [[ "$source_sent" != "__ERR__" && "$target_recv" != "__ERR__" && "$target_pending" != "__ERR__" && "$target_drained" != "__ERR__" && "$source_sent" == "$target_recv" && "$target_pending" == "0" ]]; then
 			stable=$((stable + 1))
 			if (( stable >= stable_needed )); then
@@ -497,12 +551,15 @@ iface_regex = re.compile(sys.argv[2])
 direction = sys.argv[3]
 idx = 10 if direction == "rx" else 11
 if not path.exists():
-    print("0")
-    raise SystemExit(0)
+    print(f"missing interface snapshot: {path}", file=sys.stderr)
+    raise SystemExit(2)
 
 in_bindings = False
 skip_header = False
 total = 0
+matched = False
+bindings_rows = 0
+malformed_rows = 0
 for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
     stripped = raw_line.strip()
     if stripped == "Userspace bindings:":
@@ -518,16 +575,62 @@ for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         continue
     parts = stripped.split()
     if len(parts) < 20:
+        malformed_rows += 1
         continue
+    bindings_rows += 1
     iface = parts[19]
     if not iface_regex.fullmatch(iface):
         continue
+    matched = True
     try:
         total += int(parts[idx])
     except ValueError:
-        pass
+        print(f"invalid {direction} counter for {iface} in {path}", file=sys.stderr)
+        raise SystemExit(2)
+
+if not in_bindings:
+    print(f"userspace bindings section not found in {path}", file=sys.stderr)
+    raise SystemExit(2)
+elif not matched:
+    if bindings_rows == 0:
+        if malformed_rows > 0:
+            print(
+                f"userspace bindings rows malformed in {path} "
+                f"({malformed_rows} short rows)",
+                file=sys.stderr,
+            )
+        else:
+            print(f"userspace bindings section empty in {path}", file=sys.stderr)
+    else:
+        detail = ""
+        if malformed_rows > 0:
+            detail = f" ({malformed_rows} malformed rows ignored)"
+        print(
+            f"no interfaces matching /{iface_regex.pattern}/ in {path}{detail}",
+            file=sys.stderr,
+        )
+    raise SystemExit(2)
 
 print(total)
+PY
+}
+
+nondecreasing_counter_delta() {
+	local baseline="$1"
+	local post="$2"
+	python3 - "$baseline" "$post" <<'PY'
+import sys
+
+try:
+    baseline = int(sys.argv[1])
+    post = int(sys.argv[2])
+except ValueError:
+    print(f"invalid counter values: {sys.argv[1]!r} {sys.argv[2]!r}", file=sys.stderr)
+    raise SystemExit(2)
+if post < baseline:
+    print(f"{baseline} {post}", file=sys.stderr)
+    raise SystemExit(2)
+print(post - baseline)
 PY
 }
 
@@ -559,8 +662,9 @@ validate_phase_fabric_path() {
 	local to_vm="$5"
 	local to_name="$6"
 	local from_pre from_post to_pre to_post
-	local from_if_pre from_if_post
+	local from_if_baseline from_if_post
 	local from_fabric_pre from_fabric_post from_fabric_delta
+	local from_wan_tx_base from_wan_tx_post from_wan_tx_delta
 	local from_session_delta to_session_delta session_delta
 	local from_neighbor_delta to_neighbor_delta neighbor_delta
 	local from_route_delta to_route_delta route_delta
@@ -571,14 +675,37 @@ validate_phase_fabric_path() {
 	from_post="$(cycle_stats_path "$cycle" "${phase}-post" "$from_vm")"
 	to_pre="$(cycle_stats_path "$cycle" "${phase}-pre" "$to_vm")"
 	to_post="$(cycle_stats_path "$cycle" "${phase}-post" "$to_vm")"
-	from_if_pre="$(cycle_interfaces_path "$cycle" "${phase}-pre" "$from_vm")"
+	from_if_baseline="$(cycle_interfaces_path "$cycle" "$phase" "$from_vm")"
 	from_if_post="$(cycle_interfaces_path "$cycle" "${phase}-post" "$from_vm")"
 
-	from_fabric_pre="$(status_fabric_tx_packets "$from_if_pre")"
+	from_fabric_pre="$(status_fabric_tx_packets "$from_if_baseline")"
 	from_fabric_post="$(status_fabric_tx_packets "$from_if_post")"
 	from_fabric_delta=$(( from_fabric_post - from_fabric_pre ))
-	from_session_delta=$(( $(status_summary_value "$from_post" "Session misses") - $(status_summary_value "$from_pre" "Session misses") ))
-	to_session_delta=$(( $(status_summary_value "$to_post" "Session misses") - $(status_summary_value "$to_pre" "Session misses") ))
+	if ! from_wan_tx_base="$(interface_packets_value "$from_if_baseline" "$STANDBY_WAN_IFACE_REGEX" tx)"; then
+		fail "cycle ${cycle} ${phase}: unable to read standby ${from_name} WAN TX post-failover baseline counters"
+		return
+	fi
+	if ! from_wan_tx_post="$(interface_packets_value "$from_if_post" "$STANDBY_WAN_IFACE_REGEX" tx)"; then
+		fail "cycle ${cycle} ${phase}: unable to read standby ${from_name} WAN TX post-validation counters"
+		return
+	fi
+	if ! from_wan_tx_delta="$(nondecreasing_counter_delta "$from_wan_tx_base" "$from_wan_tx_post")"; then
+		fail "cycle ${cycle} ${phase}: standby ${from_name} WAN TX counter decreased" \
+			"from ${from_wan_tx_base} to ${from_wan_tx_post}; failing closed"
+		return
+	fi
+	from_session_delta="$(
+		status_summary_delta "$from_post" "$from_pre" "Session misses" \
+			"cycle ${cycle} ${phase}: ${from_name}"
+	)" || {
+		return
+	}
+	to_session_delta="$(
+		status_summary_delta "$to_post" "$to_pre" "Session misses" \
+			"cycle ${cycle} ${phase}: ${to_name}"
+	)" || {
+		return
+	}
 	session_delta=$(( from_session_delta + to_session_delta ))
 	if (( session_delta <= MAX_FAILOVER_SESSION_MISS_DELTA )); then
 		pass "cycle ${cycle} ${phase}: session miss delta ${session_delta} (source=${from_session_delta} target=${to_session_delta})"
@@ -586,8 +713,18 @@ validate_phase_fabric_path() {
 		fail "cycle ${cycle} ${phase}: session miss delta ${session_delta} (source=${from_session_delta} target=${to_session_delta}) exceeds ${MAX_FAILOVER_SESSION_MISS_DELTA}"
 	fi
 
-	from_neighbor_delta=$(( $(status_summary_value "$from_post" "Neighbor misses") - $(status_summary_value "$from_pre" "Neighbor misses") ))
-	to_neighbor_delta=$(( $(status_summary_value "$to_post" "Neighbor misses") - $(status_summary_value "$to_pre" "Neighbor misses") ))
+	from_neighbor_delta="$(
+		status_summary_delta "$from_post" "$from_pre" "Neighbor misses" \
+			"cycle ${cycle} ${phase}: ${from_name}"
+	)" || {
+		return
+	}
+	to_neighbor_delta="$(
+		status_summary_delta "$to_post" "$to_pre" "Neighbor misses" \
+			"cycle ${cycle} ${phase}: ${to_name}"
+	)" || {
+		return
+	}
 	neighbor_delta=$(( from_neighbor_delta + to_neighbor_delta ))
 	if (( neighbor_delta <= MAX_FAILOVER_NEIGHBOR_MISS_DELTA )); then
 		pass "cycle ${cycle} ${phase}: neighbor miss delta ${neighbor_delta} (source=${from_neighbor_delta} target=${to_neighbor_delta})"
@@ -595,8 +732,18 @@ validate_phase_fabric_path() {
 		fail "cycle ${cycle} ${phase}: neighbor miss delta ${neighbor_delta} (source=${from_neighbor_delta} target=${to_neighbor_delta}) exceeds ${MAX_FAILOVER_NEIGHBOR_MISS_DELTA}"
 	fi
 
-	from_route_delta=$(( $(status_summary_value "$from_post" "Route misses") - $(status_summary_value "$from_pre" "Route misses") ))
-	to_route_delta=$(( $(status_summary_value "$to_post" "Route misses") - $(status_summary_value "$to_pre" "Route misses") ))
+	from_route_delta="$(
+		status_summary_delta "$from_post" "$from_pre" "Route misses" \
+			"cycle ${cycle} ${phase}: ${from_name}"
+	)" || {
+		return
+	}
+	to_route_delta="$(
+		status_summary_delta "$to_post" "$to_pre" "Route misses" \
+			"cycle ${cycle} ${phase}: ${to_name}"
+	)" || {
+		return
+	}
 	route_delta=$(( from_route_delta + to_route_delta ))
 	if (( route_delta <= MAX_FAILOVER_ROUTE_MISS_DELTA )); then
 		pass "cycle ${cycle} ${phase}: route miss delta ${route_delta} (source=${from_route_delta} target=${to_route_delta})"
@@ -604,8 +751,18 @@ validate_phase_fabric_path() {
 		fail "cycle ${cycle} ${phase}: route miss delta ${route_delta} (source=${from_route_delta} target=${to_route_delta}) exceeds ${MAX_FAILOVER_ROUTE_MISS_DELTA}"
 	fi
 
-	from_policy_delta=$(( $(status_summary_value "$from_post" "Policy denied packets") - $(status_summary_value "$from_pre" "Policy denied packets") ))
-	to_policy_delta=$(( $(status_summary_value "$to_post" "Policy denied packets") - $(status_summary_value "$to_pre" "Policy denied packets") ))
+	from_policy_delta="$(
+		status_summary_delta "$from_post" "$from_pre" "Policy denied packets" \
+			"cycle ${cycle} ${phase}: ${from_name}"
+	)" || {
+		return
+	}
+	to_policy_delta="$(
+		status_summary_delta "$to_post" "$to_pre" "Policy denied packets" \
+			"cycle ${cycle} ${phase}: ${to_name}"
+	)" || {
+		return
+	}
 	policy_delta=$(( from_policy_delta + to_policy_delta ))
 	if (( policy_delta <= MAX_FAILOVER_POLICY_DENIED_DELTA )); then
 		pass "cycle ${cycle} ${phase}: policy denied delta ${policy_delta} (source=${from_policy_delta} target=${to_policy_delta})"
@@ -633,22 +790,41 @@ validate_phase_fabric_path() {
 			fail "cycle ${cycle} ${phase}: standby ${from_name} lost userspace readiness"
 		fi
 	fi
+
+	if (( from_wan_tx_delta <= MAX_STANDBY_WAN_TX_DELTA )); then
+		pass "cycle ${cycle} ${phase}: standby ${from_name} WAN TX delta ${from_wan_tx_delta}"
+	else
+		fail "cycle ${cycle} ${phase}: standby ${from_name} WAN TX delta" \
+			"${from_wan_tx_delta} exceeds ${MAX_STANDBY_WAN_TX_DELTA}"
+	fi
 }
 
 capture_transition_window() {
 	local cycle="$1"
 	local phase="$2"
 	local seconds="$3"
-	local sample
+	local sample stats_path interfaces_path
 	for (( sample = 1; sample <= seconds; sample++ )); do
 		if ! cycle_sleep 1 0; then
 			fail "cycle ${cycle} ${phase}: iperf3 exited during transition sample ${sample}/${seconds}"
 			break
 		fi
-		run_vm "$FW0" 'cli -c "show chassis cluster data-plane statistics"' >"$(transition_stats_path "$cycle" "$phase" "$sample" "$FW0")" 2>&1 || true
-		run_vm "$FW1" 'cli -c "show chassis cluster data-plane statistics"' >"$(transition_stats_path "$cycle" "$phase" "$sample" "$FW1")" 2>&1 || true
-		run_vm "$FW0" 'cli -c "show chassis cluster data-plane interfaces"' >"$(transition_interfaces_path "$cycle" "$phase" "$sample" "$FW0")" 2>&1 || true
-		run_vm "$FW1" 'cli -c "show chassis cluster data-plane interfaces"' >"$(transition_interfaces_path "$cycle" "$phase" "$sample" "$FW1")" 2>&1 || true
+		stats_path="$(transition_stats_path "$cycle" "$phase" "$sample" "$FW0")"
+		if ! run_vm "$FW0" 'cli -c "show chassis cluster data-plane statistics"' >"$stats_path" 2>&1; then
+			fail "cycle ${cycle} ${phase}: failed to capture ${FW0} transition statistics sample ${sample}"
+		fi
+		stats_path="$(transition_stats_path "$cycle" "$phase" "$sample" "$FW1")"
+		if ! run_vm "$FW1" 'cli -c "show chassis cluster data-plane statistics"' >"$stats_path" 2>&1; then
+			fail "cycle ${cycle} ${phase}: failed to capture ${FW1} transition statistics sample ${sample}"
+		fi
+		interfaces_path="$(transition_interfaces_path "$cycle" "$phase" "$sample" "$FW0")"
+		if ! run_vm "$FW0" 'cli -c "show chassis cluster data-plane interfaces"' >"$interfaces_path" 2>&1; then
+			fail "cycle ${cycle} ${phase}: failed to capture ${FW0} transition interface sample ${sample}"
+		fi
+		interfaces_path="$(transition_interfaces_path "$cycle" "$phase" "$sample" "$FW1")"
+		if ! run_vm "$FW1" 'cli -c "show chassis cluster data-plane interfaces"' >"$interfaces_path" 2>&1; then
+			fail "cycle ${cycle} ${phase}: failed to capture ${FW1} transition interface sample ${sample}"
+		fi
 	done
 }
 
@@ -673,16 +849,22 @@ suffix = sys.argv[5]
 iface_regex = re.compile(sys.argv[6])
 direction = sys.argv[7]
 agg = sys.argv[8]
+if direction not in {"rx", "tx"}:
+    print(f"invalid packet direction: {direction}", file=sys.stderr)
+    raise SystemExit(2)
 idx = 10 if direction == "rx" else 11
 values = []
 
 for sample in range(1, seconds + 1):
     path = artifact_dir / f"cycle{cycle}-{phase}-watch{sample:02d}-{suffix}-dp-interfaces.txt"
     if not path.exists():
-        continue
+        print(f"missing transition interface snapshot: {path}", file=sys.stderr)
+        raise SystemExit(2)
     total = 0
     in_bindings = False
     skip_header = False
+    matched = False
+    bindings_rows = 0
     for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         stripped = raw_line.strip()
         if stripped == "Userspace bindings:":
@@ -696,20 +878,33 @@ for sample in range(1, seconds + 1):
         if skip_header:
             skip_header = False
             continue
+        bindings_rows += 1
         parts = stripped.split()
         if len(parts) < 20:
             continue
         iface = parts[19]
         if not iface_regex.fullmatch(iface):
             continue
+        matched = True
         try:
             total += int(parts[idx])
-        except ValueError:
-            pass
+        except (IndexError, ValueError):
+            print(f"invalid {direction} counter for {iface} in {path}", file=sys.stderr)
+            raise SystemExit(2)
+    if not in_bindings:
+        print(f"userspace bindings section not found in {path}", file=sys.stderr)
+        raise SystemExit(2)
+    if not matched:
+        if bindings_rows == 0:
+            print(f"userspace bindings section empty in {path}", file=sys.stderr)
+        else:
+            print(f"no interfaces matching /{iface_regex.pattern}/ in {path}", file=sys.stderr)
+        raise SystemExit(2)
     values.append(total)
 
 if not values:
-    print("0")
+    print("no transition interface samples collected", file=sys.stderr)
+    raise SystemExit(2)
 elif agg == "max":
     print(max(values))
 else:
@@ -741,17 +936,24 @@ values = []
 for sample in range(1, seconds + 1):
     path = artifact_dir / f"cycle{cycle}-{phase}-watch{sample:02d}-{suffix}-dp-stats.txt"
     if not path.exists():
-        continue
+        print(f"missing transition statistics snapshot: {path}", file=sys.stderr)
+        raise SystemExit(2)
+    found = False
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         if not line.startswith(pattern):
             continue
         match = re.search(r"(-?\d+)", line.split(":", 1)[1])
         if match:
             values.append(int(match.group(1)))
+            found = True
         break
+    if not found:
+        print(f"label {label!r} not found in {path}", file=sys.stderr)
+        raise SystemExit(2)
 
 if not values:
-    print("0")
+    print("no transition statistics samples collected", file=sys.stderr)
+    raise SystemExit(2)
 elif agg == "max":
     print(max(values))
 else:
@@ -770,10 +972,12 @@ validate_transition_window() {
 	local from_pre to_pre
 	local from_if_pre to_if_pre
 	local to_kernel_rx_dropped_max from_no_frame_max
+	local to_kernel_rx_dropped_pre from_no_frame_pre
 	local to_kernel_rx_dropped_delta from_no_frame_delta
 	local from_pending_local_max to_pending_local_max
 	local from_outstanding_max to_outstanding_max
 	local from_lan_rx_max from_fabric_tx_max to_fabric_rx_max to_wan_tx_max
+	local from_lan_rx_pre from_fabric_tx_pre to_fabric_rx_pre to_wan_tx_pre
 	local from_lan_rx_delta from_fabric_tx_delta to_fabric_rx_delta to_wan_tx_delta
 
 	from_pre="$(cycle_stats_path "$cycle" "${phase}-pre" "$from_vm")"
@@ -781,31 +985,111 @@ validate_transition_window() {
 	from_if_pre="$(cycle_interfaces_path "$cycle" "${phase}-pre" "$from_vm")"
 	to_if_pre="$(cycle_interfaces_path "$cycle" "${phase}-pre" "$to_vm")"
 
-	to_kernel_rx_dropped_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Kernel RX dropped" max)"
-	from_no_frame_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Direct TX no-frame fb" max)"
-	from_pending_local_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Pending TX local" max)"
-	to_pending_local_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Pending TX local" max)"
-	from_outstanding_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Outstanding TX" max)"
-	to_outstanding_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Outstanding TX" max)"
-	from_lan_rx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$from_vm" 'ge-[0-9]+-0-1' rx max)"
-	from_fabric_tx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$from_vm" 'ge-[0-9]+-0-0' tx max)"
-	to_fabric_rx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$to_vm" 'ge-[0-9]+-0-0' rx max)"
-	to_wan_tx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$to_vm" 'ge-[0-9]+-0-2' tx max)"
+	to_kernel_rx_dropped_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Kernel RX dropped" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} transition kernel RX drop samples"
+		return
+	}
+	from_no_frame_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Direct TX no-frame fb" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} transition direct no-frame samples"
+		return
+	}
+	from_pending_local_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Pending TX local" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} pending-local transition samples"
+		return
+	}
+	to_pending_local_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Pending TX local" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} pending-local transition samples"
+		return
+	}
+	from_outstanding_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$from_vm" "Outstanding TX" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} outstanding-TX transition samples"
+		return
+	}
+	to_outstanding_max="$(sample_window_value "$cycle" "$phase" "$seconds" "$to_vm" "Outstanding TX" max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} outstanding-TX transition samples"
+		return
+	}
+	from_lan_rx_max="$(
+		sample_window_interface_packets "$cycle" "$phase" "$seconds" "$from_vm" \
+			'ge-[0-9]+-0-1' rx max
+	)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} LAN RX transition samples"
+		return
+	}
+	from_fabric_tx_max="$(
+		sample_window_interface_packets "$cycle" "$phase" "$seconds" "$from_vm" \
+			'ge-[0-9]+-0-0' tx max
+	)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} fabric TX transition samples"
+		return
+	}
+	to_fabric_rx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$to_vm" 'ge-[0-9]+-0-0' rx max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} fabric RX transition samples"
+		return
+	}
+	to_wan_tx_max="$(sample_window_interface_packets "$cycle" "$phase" "$seconds" "$to_vm" 'ge-[0-9]+-0-2' tx max)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} WAN TX transition samples"
+		return
+	}
 
-	# Clamp deltas at 0: counter resets (helper restart/rebind) can produce
-	# negative values that silently pass the threshold checks.
-	to_kernel_rx_dropped_delta=$(( to_kernel_rx_dropped_max - $(status_summary_value "$to_pre" "Kernel RX dropped") ))
-	(( to_kernel_rx_dropped_delta < 0 )) && to_kernel_rx_dropped_delta=0
-	from_no_frame_delta=$(( from_no_frame_max - $(status_summary_value "$from_pre" "Direct TX no-frame fb") ))
-	(( from_no_frame_delta < 0 )) && from_no_frame_delta=0
-	from_lan_rx_delta=$(( from_lan_rx_max - $(interface_packets_value "$from_if_pre" 'ge-[0-9]+-0-1' rx) ))
-	(( from_lan_rx_delta < 0 )) && from_lan_rx_delta=0
-	from_fabric_tx_delta=$(( from_fabric_tx_max - $(interface_packets_value "$from_if_pre" 'ge-[0-9]+-0-0' tx) ))
-	(( from_fabric_tx_delta < 0 )) && from_fabric_tx_delta=0
-	to_fabric_rx_delta=$(( to_fabric_rx_max - $(interface_packets_value "$to_if_pre" 'ge-[0-9]+-0-0' rx) ))
-	(( to_fabric_rx_delta < 0 )) && to_fabric_rx_delta=0
-	to_wan_tx_delta=$(( to_wan_tx_max - $(interface_packets_value "$to_if_pre" 'ge-[0-9]+-0-2' tx) ))
-	(( to_wan_tx_delta < 0 )) && to_wan_tx_delta=0
+	to_kernel_rx_dropped_pre="$(status_summary_value "$to_pre" "Kernel RX dropped")" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} pre-transition kernel RX drop baseline"
+		return
+	}
+	from_no_frame_pre="$(status_summary_value "$from_pre" "Direct TX no-frame fb")" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} pre-transition direct no-frame baseline"
+		return
+	}
+	from_lan_rx_pre="$(interface_packets_value "$from_if_pre" 'ge-[0-9]+-0-1' rx)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} pre-transition LAN RX baseline"
+		return
+	}
+	from_fabric_tx_pre="$(interface_packets_value "$from_if_pre" 'ge-[0-9]+-0-0' tx)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${from_name} pre-transition fabric TX baseline"
+		return
+	}
+	to_fabric_rx_pre="$(interface_packets_value "$to_if_pre" 'ge-[0-9]+-0-0' rx)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} pre-transition fabric RX baseline"
+		return
+	}
+	to_wan_tx_pre="$(interface_packets_value "$to_if_pre" 'ge-[0-9]+-0-2' tx)" || {
+		fail "cycle ${cycle} ${phase}: unable to read ${to_name} pre-transition WAN TX baseline"
+		return
+	}
+
+	to_kernel_rx_dropped_delta="$(
+		nondecreasing_counter_delta "$to_kernel_rx_dropped_pre" \
+			"$to_kernel_rx_dropped_max"
+	)" || {
+		fail "cycle ${cycle} ${phase}: ${to_name} transition kernel RX dropped counter decreased" \
+			"from ${to_kernel_rx_dropped_pre} to ${to_kernel_rx_dropped_max}; failing closed"
+		return
+	}
+	from_no_frame_delta="$(nondecreasing_counter_delta "$from_no_frame_pre" "$from_no_frame_max")" || {
+		fail "cycle ${cycle} ${phase}: ${from_name} transition direct no-frame counter decreased" \
+			"from ${from_no_frame_pre} to ${from_no_frame_max}; failing closed"
+		return
+	}
+	from_lan_rx_delta="$(nondecreasing_counter_delta "$from_lan_rx_pre" "$from_lan_rx_max")" || {
+		fail "cycle ${cycle} ${phase}: ${from_name} transition LAN RX counter decreased" \
+			"from ${from_lan_rx_pre} to ${from_lan_rx_max}; failing closed"
+		return
+	}
+	from_fabric_tx_delta="$(nondecreasing_counter_delta "$from_fabric_tx_pre" "$from_fabric_tx_max")" || {
+		fail "cycle ${cycle} ${phase}: ${from_name} transition fabric TX counter decreased" \
+			"from ${from_fabric_tx_pre} to ${from_fabric_tx_max}; failing closed"
+		return
+	}
+	to_fabric_rx_delta="$(nondecreasing_counter_delta "$to_fabric_rx_pre" "$to_fabric_rx_max")" || {
+		fail "cycle ${cycle} ${phase}: ${to_name} transition fabric RX counter decreased" \
+			"from ${to_fabric_rx_pre} to ${to_fabric_rx_max}; failing closed"
+		return
+	}
+	to_wan_tx_delta="$(nondecreasing_counter_delta "$to_wan_tx_pre" "$to_wan_tx_max")" || {
+		fail "cycle ${cycle} ${phase}: ${to_name} transition WAN TX counter decreased" \
+			"from ${to_wan_tx_pre} to ${to_wan_tx_max}; failing closed"
+		return
+	}
 
 	if (( to_kernel_rx_dropped_delta <= MAX_TRANSITION_KERNEL_RX_DROPPED_DELTA )); then
 		pass "cycle ${cycle} ${phase}: ${to_name} transition kernel RX dropped delta ${to_kernel_rx_dropped_delta}"
@@ -1273,7 +1557,9 @@ run_failover_phase() {
 	run_vm "$from_vm" "cli -c \"request chassis cluster failover redundancy-group ${RG} node ${to_node}\" >/tmp/userspace-rg${RG}-${phase}-cycle${cycle}.out"
 	wait_for_rg_owner "$RG" "$to_node" "$FAILOVER_WAIT" || die "RG${RG} did not move to ${to_name} during cycle ${cycle} ${phase}"
 	pass "cycle ${cycle} ${phase}: RG${RG} moved to ${to_name}"
-	ACTIVE_FW="$(wait_for_userspace_rg_owner "$RG")" || die "userspace forwarding did not settle on ${to_name} during cycle ${cycle} ${phase}"
+	ACTIVE_FW="$(wait_for_userspace_rg_owner "$RG" "$to_vm")" ||
+		die "userspace forwarding did not settle on ${to_name}" \
+			"during cycle ${cycle} ${phase}"
 	pass "cycle ${cycle} ${phase}: userspace forwarding active on ${ACTIVE_FW}"
 	capture_cycle_state "$cycle" "$phase"
 	validate_target_connectivity "cycle ${cycle} ${phase}"

--- a/scripts/userspace-ha-validation.sh
+++ b/scripts/userspace-ha-validation.sh
@@ -25,6 +25,7 @@ MTR_V6_TARGET="${MTR_V6_TARGET:-2607:f8b0:4005:814::200e}"
 MTR_REPORT_CYCLES="${MTR_REPORT_CYCLES:-1}"
 WAN_TEST_IFACE="${WAN_TEST_IFACE:-}"
 IPERF_METRICS="${PROJECT_ROOT}/scripts/iperf-json-metrics.py"
+ALLOW_LEGACY_EBPF_HA_VALIDATION="${ALLOW_LEGACY_EBPF_HA_VALIDATION:-0}"
 WITH_PERF=0
 DEPLOY=0
 
@@ -126,14 +127,29 @@ enabled_userspace_vm() {
 }
 
 active_owner_vm() {
-	local vm stats
+	local active=()
+	local vm stats query_failed=0
 	for vm in "$FW0" "$FW1"; do
-		stats="$(run_vm "$vm" 'cli -c "show chassis cluster data-plane statistics"' 2>/dev/null || true)"
+		if ! stats="$(run_vm "$vm" 'cli -c "show chassis cluster data-plane statistics"' 2>/dev/null)"; then
+			printf 'failed to query data-plane statistics from %s\n' "$vm" >&2
+			query_failed=1
+			continue
+		fi
 		if grep -Eq 'HA groups:[[:space:]].*rg[1-9][0-9]* active=true' <<<"$stats"; then
-			printf '%s\n' "$vm"
-			return 0
+			active+=("$vm")
 		fi
 	done
+	if (( query_failed != 0 )); then
+		return 2
+	fi
+	if (( ${#active[@]} == 1 )); then
+		printf '%s\n' "${active[0]}"
+		return 0
+	fi
+	if (( ${#active[@]} > 1 )); then
+		printf 'split-brain active owners: %s\n' "${active[*]}" >&2
+		return 2
+	fi
 	return 1
 }
 
@@ -155,10 +171,8 @@ rg_primary_node() {
 }
 
 ensure_preferred_active_node() {
-	local preferred_vm="$FW0"
 	local preferred_name="node0"
 	if [[ "$PREFERRED_ACTIVE_NODE" == "1" ]]; then
-		preferred_vm="$FW1"
 		preferred_name="node1"
 	fi
 	info "pinning userspace validation to ${preferred_name} for RGs:${PREFERRED_ACTIVE_RGS}"
@@ -189,11 +203,17 @@ ensure_preferred_active_node() {
 wait_for_active_supported_runtime() {
 	local tries=30
 	while (( tries > 0 )); do
-		local owner
-		owner="$(active_owner_vm || true)"
-		if [[ -n "$owner" ]] && enabled_userspace_vm "$owner" >/dev/null 2>&1; then
-			printf '%s\n' "$owner"
-			return 0
+		local owner owner_status
+		if owner="$(active_owner_vm)"; then
+			if enabled_userspace_vm "$owner" >/dev/null 2>&1; then
+				printf '%s\n' "$owner"
+				return 0
+			fi
+		else
+			owner_status=$?
+			if (( owner_status == 2 )); then
+				return 2
+			fi
 		fi
 		sleep 1
 		tries=$((tries - 1))
@@ -202,21 +222,34 @@ wait_for_active_supported_runtime() {
 }
 
 arm_supported_runtime() {
-	local owner
-	owner="$(active_owner_vm || true)"
-	if [[ -z "$owner" ]]; then
-		owner="$FW0"
-	fi
+	local owner owner_status runtime_status
 	info "waiting for userspace forwarding to auto-arm on the active node"
 	if ACTIVE_FW="$(wait_for_active_supported_runtime)"; then
 		info "active userspace firewall: ${ACTIVE_FW}"
 		return 0
+	else
+		runtime_status=$?
+		if (( runtime_status == 2 )); then
+			die "supported userspace runtime requires an unambiguous active firewall owner"
+		fi
+	fi
+	if ! owner="$(active_owner_vm)"; then
+		owner_status=$?
+		if (( owner_status == 2 )); then
+			die "cannot force userspace arm with an ambiguous active firewall owner"
+		fi
+		die "cannot force userspace arm before an active firewall owner is reported"
 	fi
 	info "auto-arm did not settle, forcing forwarding arm on ${owner}"
 	run_vm "$owner" 'cli -c "request chassis cluster data-plane userspace forwarding arm" >/tmp/userspace-arm.out'
 	if ACTIVE_FW="$(wait_for_active_supported_runtime)"; then
 		info "active userspace firewall: ${ACTIVE_FW}"
 		return 0
+	else
+		runtime_status=$?
+		if (( runtime_status == 2 )); then
+			die "supported userspace runtime became ambiguous after forced arm"
+		fi
 	fi
 	run_vm "$owner" 'cli -c "show chassis cluster data-plane statistics" >&2 || true'
 	die "userspace forwarding did not become enabled on the active node"
@@ -357,7 +390,16 @@ info "detecting userspace runtime mode"
 MODE="$(runtime_mode)" || die "userspace runtime mode did not settle in time"
 info "runtime mode: ${MODE}"
 if [[ "${MODE}" == "legacy" ]]; then
-	info "validating legacy fallback state"
+	if [[ "${ALLOW_LEGACY_EBPF_HA_VALIDATION}" == "1" ]]; then
+		info "legacy eBPF fallback accepted by ALLOW_LEGACY_EBPF_HA_VALIDATION=1"
+		ACTIVE_FW="$(active_owner_vm)" ||
+			die "legacy fallback override requires an unambiguous active firewall owner"
+		info "active legacy fallback firewall: ${ACTIVE_FW}"
+	else
+		die "legacy eBPF fallback detected; userspace HA validation requires" \
+			"xdp_userspace_prog; set ALLOW_LEGACY_EBPF_HA_VALIDATION=1" \
+			"only for legacy regression runs"
+	fi
 else
 	info "supported userspace runtime detected"
 	ensure_preferred_active_node

--- a/testing-docs/README.md
+++ b/testing-docs/README.md
@@ -24,6 +24,12 @@ AF_XDP dataplane plus legacy eBPF regression coverage.
 | [performance.md](performance.md) | Throughput, latency, perf profiling | `scripts/userspace-perf-compare.sh` |
 | [regression-checklist.md](regression-checklist.md) | Pre-commit validation checklist | Manual |
 
+## Historical References
+
+| Document | Status |
+|----------|--------|
+| [ha-failover-validation.md](ha-failover-validation.md) | Historical March 2026 HA investigation notes only. Current userspace HA validation must use `failover-testing.md`, `userspace-fabric-failover.md`, `scripts/userspace-ha-validation.sh`, and `scripts/userspace-ha-failover-validation.sh`; legacy `xdp_main_prog` fallback is not a userspace pass condition. |
+
 ## Quick Reference
 
 ```bash

--- a/testing-docs/ha-failover-validation.md
+++ b/testing-docs/ha-failover-validation.md
@@ -1,16 +1,52 @@
-# HA Failover Validation -- Loss Userspace Cluster
+# Historical HA Failover Validation -- Loss Userspace Cluster
 
 Date: 2026-03-24
 
-This document records the bugs found, fixes applied, and test procedures
-used to validate HA failover on the isolated userspace AF_XDP cluster
-running mlx5 ConnectX SR-IOV VFs. It is self-contained: another engineer
-can reproduce every result using only the commands and environment
-described here.
+Status: historical archive. Do not use this file as the active userspace HA
+runbook.
+
+This document records the bugs found, fixes applied, and test procedures used
+for the March 2026 HA investigation on the isolated userspace AF_XDP cluster
+running mlx5 ConnectX SR-IOV VFs. It preserves useful history, but the legacy
+eBPF dataplane fallback described here is not an accepted userspace validation
+result.
+
+For current userspace HA validation, use:
+
+- [failover-testing.md](failover-testing.md)
+- [userspace-fabric-failover.md](userspace-fabric-failover.md)
+- `scripts/userspace-ha-validation.sh`
+- `scripts/userspace-ha-failover-validation.sh`
+
+Current userspace validation must stay on the userspace dataplane. An
+attachment or auto-swap to the legacy `xdp_main_prog` path is historical
+fallback behavior only; treat it as a userspace validation failure unless the
+test is explicitly scoped as a legacy eBPF regression.
+
+## Current Userspace HA Gate
+
+The active pass criteria are maintained in
+[failover-testing.md](failover-testing.md) and
+[userspace-fabric-failover.md](userspace-fabric-failover.md). In summary, a
+current userspace HA run must show:
+
+- `scripts/userspace-ha-validation.sh` passes steady-state reachability and
+  throughput checks before failover testing starts.
+- `scripts/userspace-ha-failover-validation.sh` passes RG move and failback
+  under established load.
+- The active and standby userspace helpers remain armed: userspace forwarding
+  is supported, active RGs are enabled, forwarding is armed where expected, and
+  ready bindings stay non-zero.
+- The XDP userspace shim/helper path remains attached on userspace data
+  interfaces; the legacy `xdp_main_prog` fallback is not counted as success.
+- Failover artifacts show external IPv4 and IPv6 reachability, no
+  zero-throughput collapse, positive old-owner fabric TX deltas when stale-MAC
+  traffic is expected, flat standby WAN TX deltas during fabric redirect, and
+  bounded session/neighbor/route/policy deltas.
 
 ---
 
-## 1. Summary of Fixes Applied
+## 1. Historical Summary of Fixes Applied
 
 Ten commits, listed in dependency order. Each commit addresses a distinct
 failure mode discovered during HA failover testing on the loss cluster.
@@ -22,7 +58,7 @@ failure mode discovered during HA failover testing on the loss cluster.
 | `00dc648d` | NAPI bootstrap with varying probes (multi-queue coverage) | `manager.go` |
 | `8d4bb7ce` | Standalone AF_XDP XSK rebind test proving two bugs | `test/xsk-repro/` |
 | `b95a8dd8` | Avoid link DOWN/UP on RETH MAC change | `linksetup.go`, `garp.go` |
-| `e83d4d3a` | XSK liveness gate + auto-swap to eBPF pipeline | `manager.go` |
+| `e83d4d3a` | Historical XSK liveness gate + legacy eBPF fallback | `manager.go` |
 | `2e237a7e` | Suppress stable link-local EADDRNOTAVAIL log spam | `reconcile.go` |
 | `375be885` | Replace xdpilone with libxdp C bridge | `csrc/xsk_bridge.c`, `xsk_ffi.rs`, `bind.rs`, `Cargo.toml`, `build.rs` |
 | `807ae01a` | eBPF fabric redirect re-FIB for split-RG failover | `bpf/xdp/xdp_zone.c` |
@@ -88,19 +124,21 @@ occurs and AF_XDP sockets are preserved. Falls back to DOWN/UP only if
 the live change fails. When no link cycle occurs, VIP reconcile, AF_XDP
 rebind, and RA re-burst are all skipped (not needed).
 
-### 1.6 `e83d4d3a` -- XSK liveness gate + auto-swap to eBPF pipeline
+### 1.6 `e83d4d3a` -- Historical XSK liveness gate + legacy fallback
 
-Two changes:
+This was a historical defense-in-depth change from the March 2026 debugging
+window, not a current userspace HA success condition. Two changes were made:
 
 1. `ctrl.enabled` is only set to 1 if at least one binding has
    `rx_packets > 0`. Prevents routing transit traffic into a black hole
    when XSK cannot deliver packets.
 
 2. After 30 seconds of XSK bindings being ready but `rx_packets == 0`,
-   the manager calls `SwapXDPEntryProg("xdp_main_prog")` to replace the
-   XDP shim with the direct eBPF pipeline. This restores full 15+ Gbps
-   forwarding with zone/policy/SNAT instead of the broken XDP_PASS
-   fallback (~129 Mbps, no SNAT).
+   the manager called `SwapXDPEntryProg("xdp_main_prog")` as a legacy fallback
+   to replace the XDP shim with the direct legacy eBPF pipeline. That
+   historical fallback restored forwarding during this investigation, but an
+   active userspace validation run must treat this attachment as failure unless
+   it is deliberately testing legacy eBPF regression coverage.
 
 ### 1.7 `2e237a7e` -- Suppress stable link-local log spam
 
@@ -132,19 +170,18 @@ a session exists, attempt a re-FIB in the main routing table
 normally. If it also fails (true dual-inactive), drop with
 `GLOBAL_CTR_FABRIC_FWD_DROP`.
 
-### 1.10 `4ddf371f` -- Persist XSK liveness failure across config reconciles
+### 1.10 `4ddf371f` -- Persist historical XSK liveness failure across config reconciles
 
-The XSK liveness swap to `xdp_main_prog` was being overridden by config
-reconciles which re-set `XDPEntryProg` to `xdp_userspace_prog`. Added
-`xskLivenessFailed` flag that persists and prevents `Compile` from
-switching back to the broken XDP shim. Also added `delta-rx` check:
-the liveness gate now compares current `rx_packets` against a snapshot
-taken at gate start, so transient initial packets do not mask a
-subsequent stall.
+The historical XSK liveness swap to `xdp_main_prog` was being overridden by
+config reconciles which re-set `XDPEntryProg` to `xdp_userspace_prog`. Added
+`xskLivenessFailed` flag that persists and prevents `Compile` from switching
+back to the broken XDP shim. Also added `delta-rx` check: the liveness gate now
+compares current `rx_packets` against a snapshot taken at gate start, so
+transient initial packets do not mask a subsequent stall.
 
 ---
 
-## 2. Test Environment
+## 2. Historical Test Environment
 
 ### 2.1 Cluster Topology
 
@@ -212,7 +249,7 @@ subsequent stall.
 
 ---
 
-## 3. Bugs Found and Proven
+## 3. Historical Bugs Found and Proven
 
 ### 3.1 Router Flag Bug (RFC 4861 section 7.2.5)
 
@@ -294,11 +331,13 @@ rx_xsk_packets: 0              # never delivered
 rx_xsk_congst_umr: 3           # UMR issue
 ```
 
-**Workaround.** Two-layer defense:
+**Historical workaround.** Two-layer defense:
 1. `b95a8dd8`: Avoid link DOWN/UP entirely during RETH MAC change
    (live MAC change with `IFF_LIVE_ADDR_CHANGE`).
-2. `e83d4d3a` + `4ddf371f`: XSK liveness gate detects rx=0 and
-   auto-swaps to `xdp_main_prog` (eBPF pipeline) as fallback.
+2. `e83d4d3a` + `4ddf371f`: XSK liveness gate detects rx=0 and performs a
+   historical auto-swap to `xdp_main_prog` (legacy eBPF pipeline) as fallback.
+   Current userspace HA validation must not count that legacy fallback as a
+   pass.
 
 ### 3.4 eBPF Fabric Redirect Drops on Split-RG
 
@@ -328,11 +367,12 @@ handled it without SNAT.
 the XDP shim context. The tail-call instruction is emitted but the
 program array lookup fails silently.
 
-**Workaround.** The XSK liveness gate (`e83d4d3a` + `4ddf371f`) detects
-that XSK is broken and replaces `xdp_userspace_prog` with
-`xdp_main_prog` directly. This eliminates the shim entirely -- traffic
-goes through the full eBPF pipeline (zone, conntrack, policy, NAT,
-forward) at 15+ Gbps.
+**Historical workaround.** The XSK liveness gate (`e83d4d3a` + `4ddf371f`)
+detects that XSK is broken and uses the legacy `xdp_main_prog` fallback. This
+eliminates the shim entirely and sends traffic through the full legacy eBPF
+pipeline (zone, conntrack, policy, NAT, forward) at 15+ Gbps. That behavior is
+kept here as history; current userspace HA validation must fail on this legacy
+fallback unless the run is explicitly a legacy eBPF regression.
 
 ### 3.6 Ctrl Enable Never Fires (Rebind Timeout Reset)
 
@@ -376,7 +416,7 @@ entries on the ctrl 0-to-1 transition.
 
 ---
 
-## 4. Test Results
+## 4. Historical Test Results
 
 ### 4.1 Baseline Throughput (All RGs on Same Node)
 
@@ -430,172 +470,90 @@ failed over to node1 during an active iperf3 session.
 
 ---
 
-## 5. Test Procedures
+## 5. Current Validation Entry Points
 
-### 5.1 Deploy
+This section replaces the old active-looking procedure that waited for an XSK
+liveness failure and then verified the legacy eBPF program. That procedure was
+valid only for the historical investigation above.
+
+For current userspace HA validation, run the maintained docs and scripts:
+
+- [failover-testing.md](failover-testing.md) for the end-to-end failover
+  runbook and pass criteria.
+- [userspace-fabric-failover.md](userspace-fabric-failover.md) for
+  stale-owner fabric-path interpretation and artifact review.
+- `scripts/userspace-ha-validation.sh` before failover, to prove steady-state
+  userspace forwarding.
+- `scripts/userspace-ha-failover-validation.sh` for RG move and failback under
+  load.
+
+### 5.1 Deploy And Preflight
 
 ```bash
 BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env \
   ./test/incus/cluster-setup.sh deploy all
 ```
 
-Wait for the XSK liveness check to complete and the eBPF pipeline swap
-to occur. This takes 15-45 seconds after deploy depending on the NAPI
-prewarm timing.
+After deploy, do not wait for a legacy fallback swap. Preflight the live
+userspace dataplane:
 
 ```bash
-# Wait for swap (conservative)
-sleep 70
+BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env \
+RUNS=3 DURATION=5 PARALLEL=4 \
+PREFERRED_ACTIVE_NODE=0 \
+PREFERRED_ACTIVE_RGS="1 2" \
+scripts/userspace-ha-validation.sh
 ```
 
-### 5.2 Verify XDP Program
+### 5.2 Verify Userspace Attachment
 
-After the liveness gate fires, each node should be running
-`xdp_main_prog` (not `xdp_userspace_prog`) on data interfaces.
+On userspace data interfaces, the userspace XDP shim/helper path must remain
+attached and the helper must be ready. A legacy `xdp_main_prog` attachment on a
+userspace data interface is a failure for active userspace validation unless
+the run is explicitly a legacy eBPF regression.
 
 ```bash
-# Node 0 -- check WAN interface
+# Node 0 -- example WAN interface
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
   ip link show ge-0-0-2 | grep prog"
-# Expected: prog/xdp id <N> ...
 
-# Node 1 -- check LAN interface
+# Node 1 -- example LAN interface
 sg incus-admin -c "incus exec loss:xpf-userspace-fw1 -- \
   ip link show ge-7-0-1 | grep prog"
-# Expected: prog/xdp id <N> ...
 ```
 
-Verify the program is the eBPF pipeline, not the XDP shim:
+Use CLI state, the script artifacts, and `monitor interface <fabric-parent>` to
+confirm:
+
+- userspace forwarding is supported
+- active RGs are enabled
+- forwarding is armed where expected
+- ready bindings are non-zero
+- old-owner stale-MAC traffic redirects across fabric instead of egressing the
+  standby WAN
+
+### 5.3 Hardened RG Move Under Load
+
+Run the hardened failover validator:
 
 ```bash
-sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
-  bpftool prog show | grep -A1 'xdp_main_prog'"
+BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env \
+IPERF_TARGET=172.16.80.200 \
+TOTAL_CYCLES=3 CYCLE_INTERVAL=10 \
+scripts/userspace-ha-failover-validation.sh --duration 90 --parallel 4
 ```
 
-### 5.3 Basic Connectivity
+Pass/fail comes from the current script and the current runbooks, not from the
+historical manual thresholds in this file. The run must preserve IPv4 and IPv6
+reachability, avoid zero-throughput collapse, keep failover deltas within
+threshold, prove expected fabric TX on the old owner, and keep standby WAN TX
+flat during stale-owner fabric redirect checks.
 
-```bash
-# IPv4
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping -c 5 -W 2 172.16.80.200"
-
-# IPv6
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping6 -c 5 -W 2 2001:559:8585:80::200"
-```
-
-Both must succeed (allow 1 cold-start loss on IPv4).
-
-### 5.4 Throughput Baseline
-
-```bash
-# IPv4
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  iperf3 -c 172.16.80.200 -t 10 -P 4"
-
-# IPv6
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  iperf3 -c 2001:559:8585:80::200 -t 10 -P 4"
-```
-
-Expected: 20+ Gbps for both protocols when all RGs are on the same
-node. If throughput is significantly lower, check which XDP program is
-attached (section 5.2) and the ctrl map state (section 7.2).
-
-### 5.5 Failover Test (THE CRITICAL TEST)
-
-This is the primary acceptance gate. It tests that existing TCP sessions
-survive a per-RG failover and that new connections work immediately
-after.
-
-```bash
-# Step 1: Move all RGs to node 0
-for rg in 0 1 2; do
-  sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
-    /usr/local/sbin/cli -c \
-    'request chassis cluster failover redundancy-group $rg node 0'"
-  sleep 1
-done
-sleep 5
-
-# Step 2: Verify cluster state
-sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
-  /usr/local/sbin/cli -c 'show chassis cluster status'"
-# All three RGs should show node0 as primary
-
-# Step 3: Start iperf3 in background (25-second run)
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  bash -c 'iperf3 -c 2001:559:8585:80::200 -t 25 -P 4 2>&1'" &
-PID=$!
-
-# Step 4: Wait for baseline to establish
-sleep 8
-
-# Step 5: Failover RG2 (LAN) to node 1
-sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
-  /usr/local/sbin/cli -c \
-  'request chassis cluster failover redundancy-group 2 node 1'"
-
-# Step 6: Wait for iperf3 to finish
-wait $PID
-
-# Step 7: Test new connections after split-RG
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping -c 5 -W 2 172.16.80.200"
-
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping6 -c 5 -W 2 2001:559:8585:80::200"
-```
-
-**Pass criteria:**
-
-| Criterion | Threshold |
-|-----------|-----------|
-| iperf3 drops to 0 Gbps | NEVER (hard fail) |
-| Transition dip duration | < 3 seconds |
-| Recovery throughput (fabric path) | > 8 Gbps |
-| New IPv4 connections (ping) | >= 4/5 |
-| New IPv6 connections (ping) | >= 4/5 |
-| IPv6 default route on host after failover | Present |
-
-### 5.6 Failover Test -- IPv4 Variant
-
-Same procedure as 5.5 but using IPv4 iperf3:
-
-```bash
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  bash -c 'iperf3 -c 172.16.80.200 -t 25 -P 4 2>&1'" &
-```
-
-Pass criteria are the same.
-
-### 5.7 Full Reset and Re-Verify
-
-After failover testing, reset all RGs to node 0 and verify clean
-recovery:
-
-```bash
-for rg in 0 1 2; do
-  sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- \
-    /usr/local/sbin/cli -c \
-    'request chassis cluster failover redundancy-group $rg node 0'"
-  sleep 1
-done
-sleep 5
-
-# Full connectivity check
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping -c 5 -W 2 172.16.80.200"
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  ping6 -c 5 -W 2 2001:559:8585:80::200"
-sg incus-admin -c "incus exec loss:cluster-userspace-host -- \
-  iperf3 -c 172.16.80.200 -t 5 -P 4"
-```
-
-### 5.8 Standalone XSK Rebind Test
+### 5.4 Standalone XSK Rebind Test
 
 This is the standalone test used to bisect AF_XDP bugs independently
-of xpfd. Run directly on one of the firewall VMs.
+of xpfd. It is useful for driver/library regression investigation, not as the
+active HA acceptance gate. Run directly on one of the firewall VMs.
 
 ```bash
 # SSH into a firewall node
@@ -626,14 +584,18 @@ is suspected to fix or break XSK behavior:
 
 ---
 
-## 6. Known Limitations
+## 6. Historical Limitations
 
-### 6.1 XSK Liveness Swap Window
+These limitations describe the March 2026 investigation. They are not current
+userspace HA pass criteria.
 
-After deploy, the daemon takes 15-45 seconds to detect that XSK is
-broken and swap to `xdp_main_prog`. During this window, traffic goes
-through kernel fallback (`XDP_PASS`) at reduced throughput and without
-SNAT. The window consists of:
+### 6.1 Historical XSK Liveness Swap Window
+
+During the historical fallback design, the daemon took 15-45 seconds to detect
+that XSK was broken and swap to legacy `xdp_main_prog`. During this window,
+traffic went through kernel fallback (`XDP_PASS`) at reduced throughput and
+without SNAT. This legacy fallback is no longer an accepted result for active
+userspace HA validation. The historical window consisted of:
 
 1. Binding setup + NAPI prewarm: ~5-10s
 2. Liveness check period: up to 30s (configurable)
@@ -641,11 +603,11 @@ SNAT. The window consists of:
 
 ### 6.2 mlx5 Zero-Copy After Link DOWN/UP
 
-This is an upstream kernel/driver bug. The workaround (live MAC change
-via `IFF_LIVE_ADDR_CHANGE`) avoids triggering it during normal
-operation. If a future event forces a link cycle (e.g., driver reload,
-PCI reset), the XSK liveness gate will detect it and auto-swap to the
-eBPF pipeline.
+This is an upstream kernel/driver bug. The workaround (live MAC change via
+`IFF_LIVE_ADDR_CHANGE`) avoids triggering it during normal operation. If a
+future event forces a link cycle (e.g., driver reload, PCI reset), active
+userspace validation should catch the resulting helper/binding failure. Do not
+treat a legacy eBPF fallback as userspace success.
 
 ### 6.3 libxdp Dynamic Linking
 
@@ -663,10 +625,10 @@ to the fabric architecture, not a bug.
 
 ### 6.5 aya-ebpf Tail-Call Bug
 
-The XDP shim's `fallback_to_main()` tail-call silently fails in
-aya-ebpf. This is worked around by the XSK liveness gate (which
-replaces the shim entirely), but the root cause in aya-ebpf has not
-been fixed upstream.
+The XDP shim's `fallback_to_main()` tail-call silently failed in aya-ebpf
+during this investigation. The historical workaround replaced the shim
+entirely, but that is legacy fallback behavior and not a current userspace HA
+success condition.
 
 ---
 
@@ -674,16 +636,16 @@ been fixed upstream.
 
 ### 7.1 XDP Program Attached
 
-Check which XDP program is attached to each data interface:
+Check which XDP program is attached to each data interface. For active
+userspace HA validation, the userspace shim/helper path is expected. A legacy
+`xdp_main_prog` attachment is historical fallback or legacy-regression evidence,
+not userspace success.
 
 ```bash
 # On firewall VM
 ip link show ge-0-0-2 | grep prog
 # or
 bpftool net list
-
-# Expected after liveness swap:
-#   xdp_main_prog (not xdp_userspace_prog)
 ```
 
 List all loaded XDP programs:
@@ -848,7 +810,7 @@ When a kernel update claims to fix mlx5 XSK zero-copy reinit:
 
 ---
 
-## 9. Commit Dependency Graph
+## 9. Historical Commit Dependency Graph
 
 The fixes have the following logical dependencies (commits higher in
 the graph must be applied before commits lower):
@@ -883,20 +845,29 @@ e83d4d3a  (XSK liveness gate -- defense-in-depth for 3.2+3.3+3.5)
 
 ---
 
-## 10. Validation Checklist
+## 10. Current Userspace Validation Checklist
 
-Use this checklist after each deploy to confirm all fixes are working:
+Use the maintained checklist in [failover-testing.md](failover-testing.md) and
+[userspace-fabric-failover.md](userspace-fabric-failover.md) for active runs.
+The short checklist below exists only to prevent the historical fallback in
+this archive from being mistaken for current success:
 
-- [ ] `xdp_main_prog` attached on both nodes (not `xdp_userspace_prog`)
-- [ ] `ctrl.enabled` map shows 0 (ctrl disabled is expected after liveness swap)
-- [ ] IPv4 ping to `172.16.80.200`: >= 4/5
-- [ ] IPv6 ping to `2001:559:8585:80::200`: 5/5
-- [ ] IPv6 default route present on `cluster-userspace-host`
-- [ ] IPv4 iperf3 baseline: > 15 Gbps
-- [ ] IPv6 iperf3 baseline: > 15 Gbps
-- [ ] Failover test: zero seconds at 0 Gbps
-- [ ] Failover test: transition dip < 3 seconds
-- [ ] Post-failover new IPv4 connections: >= 4/5
-- [ ] Post-failover new IPv6 connections: >= 4/5
-- [ ] No `EADDRNOTAVAIL` WARN spam in journal
-- [ ] `show chassis cluster status` shows expected RG ownership
+- [ ] `scripts/userspace-ha-validation.sh` passes before failover testing.
+- [ ] `scripts/userspace-ha-failover-validation.sh` passes RG move and
+      failback under load.
+- [ ] The userspace shim/helper path remains attached on userspace data
+      interfaces; legacy `xdp_main_prog` attachment is historical fallback or
+      legacy eBPF regression evidence only.
+- [ ] Active RGs show userspace forwarding enabled and ready bindings
+      non-zero.
+- [ ] Standby helpers stay armed where stale-owner fabric redirect is expected.
+- [ ] IPv4 and IPv6 external reachability pass before, during, and after
+      failover phases.
+- [ ] Throughput has no zero-collapse interval.
+- [ ] Old-owner fabric TX deltas are positive when stale-MAC traffic should
+      cross fabric.
+- [ ] Standby WAN TX deltas stay flat during stale-owner fabric redirect.
+- [ ] Session, neighbor, route, and policy deltas stay within the current
+      validator thresholds.
+- [ ] `show chassis cluster status` shows expected RG ownership after each
+      phase.


### PR DESCRIPTION
## Summary

- Reframe `testing-docs/ha-failover-validation.md` as historical
  March 2026 investigation material instead of an active userspace
  pass/fail runbook.
- Point active HA validation to `failover-testing.md`,
  `userspace-fabric-failover.md`, `scripts/userspace-ha-validation.sh`,
  and `scripts/userspace-ha-failover-validation.sh`.
- Make `scripts/userspace-ha-validation.sh` fail by default on legacy
  eBPF fallback. The explicit legacy-regression override and the normal
  supported-userspace arm path now require an unambiguous active firewall
  owner; neither path falls back to `FW0` when owner detection is missing,
  ambiguous, or partially unreadable.
- Harden the RG failover validator so standby WAN TX flatness is measured
  after demotion, userspace owner settle requires the requested target VM,
  missing counter evidence fails closed, transition-window captures fail
  closed, malformed binding rows are reported, and counter regressions fail
  instead of being clamped to zero.

Fixes #1490.

## Validation

- `bash -n scripts/userspace-ha-validation.sh scripts/userspace-ha-failover-validation.sh`
- `shellcheck scripts/userspace-ha-validation.sh scripts/userspace-ha-failover-validation.sh`
- `git diff --check master..HEAD`
- Commit-message wrap audit: no body lines over 72 columns.
- Grep audit for stale `FW0` fallback, stale legacy fallback strings,
  split-brain handling, target-owner settle, transition-window `|| true`,
  `__ERR__` status-summary math, and negative-delta clamps.

## Self-review

Adversarial pass checked that the scripts now fail the actual review
failure modes instead of only adding assertions. Legacy fallback no longer
passes by default or falls back to `FW0`. The supported userspace arm path
also no longer forces arm on `FW0` when ownership cannot be proven. Userspace
RG settle no longer accepts the old owner, split-brain, or a single visible
owner while the peer cannot be queried. Standby WAN and transition-window
deltas now require real snapshots and nondecreasing counters.
