### PR TITLE
dataplane: pin userspace shim retirement boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ TC Egress:   main -> screen_egress -> conntrack -> nat -> forward
 | NAT64 (IPv6↔IPv4) | Yes | Yes |
 | NPTv6 (RFC 6296) | Yes | Yes |
 | Screen/IDS (11 checks) | Yes | Yes; userspace SYN-cookie runtime is wired |
-| Firewall filters + policers | Yes | Filters yes; three-color policers admitted for color-blind `then discard` slice, with remaining #1375 hardening still open |
+| Firewall filters + policers | Yes | Filters yes; three-color policers admitted for the reviewed color-blind `then discard` slice; broader color-aware and non-drop action work is production hardening, not an active #1375 feature-gap blocker |
 | TCP MSS clamping | Yes | Yes |
 | GRE tunnel transit | Yes | Yes (passthrough) |
 | IPsec / XFRM | Yes | Yes (passthrough) |
@@ -108,9 +108,11 @@ runs in userspace with bounded SYN-ACK/RST replies and userspace status
 counters; live HA/flood evidence is still required before BPF source removal.
 Port mirroring has bounded userspace runtime admission, but still needs
 mirror-fidelity and pressure
-evidence before BPF source removal. Three-color policers are admitted only for
-the bounded color-blind `then discard` runtime slice while #1375 hardening
-remains. Pool-mode SNAT is admitted, #1385 added userspace-v1
+evidence before BPF source removal. Three-color policers are admitted for the
+bounded color-blind `then discard` runtime slice; remaining color-aware,
+non-drop action, and HA/restart continuity decisions are production follow-up
+work rather than active #1375 feature-gap blockers. Pool-mode SNAT is admitted,
+#1385 added userspace-v1
 `address-persistent` selection, and the runtime now fails closed for unusable
 or exhausted source-NAT pool rules before forwarding. Non-HA per-pool
 `persistent-nat` lease reuse is helper-local userspace state; it does not

--- a/_Log.md
+++ b/_Log.md
@@ -47,6 +47,14 @@
   - **Validation**: `go build ./pkg/dataplane/...`;
     `go test ./pkg/dataplane/... -count=1`
 
+- **Timestamp**: 2026-05-23T04:58:00Z
+  - **Action**: PR #1494 copilot round-5 follow-up — hardened the canary
+    walker to treat wrapped SwapXDPEntryProg callees as direct calls and added
+    bypass fixtures for parenthesized/method-expression/slice-indexed calls.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-23T03:45:00Z
   - **Action**: PR #1494 copilot re-review hardening — made the userspace
     entry-program canary reject shadowed local identifiers so only the package

--- a/_Log.md
+++ b/_Log.md
@@ -39,6 +39,24 @@
 
 ## 2026-05-23
 
+- **Timestamp**: 2026-05-23T17:01:19Z
+  - **Action**: PR #1494 round-9 follow-up — encapsulated the retained shim
+    entry-program state by unexporting `XDPEntryProg`, removed the arbitrary
+    `SwapXDPEntryProg(name)` production surface, and added narrow userspace-shim
+    selection/swap methods plus a JSON-mutability canary. Updated userspace
+    call sites and docs to describe the structural boundary instead of relying
+    on decoder-shape blocklists.
+  - **File(s)**: `pkg/dataplane/loader.go`,
+    `pkg/dataplane/retirement_boundary_canary_test.go`,
+    `pkg/dataplane/userspace/manager.go`,
+    `pkg/dataplane/userspace/maps_sync.go`,
+    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestBPFShimEntryProgramStateIsNotJSONMutable|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture|TestUserspaceXDPEntryProgramConstantNamesRetainedShim'
+    -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace
+    -count=1`; `go test ./pkg/dataplane/... -count=1`; `go test ./...
+    -count=1`; `git diff --check`
+
 - **Timestamp**: 2026-05-23T15:58:00Z
   - **Action**: PR #1494 round-8 follow-up — hardened JSON decoder canary
     laundering checks for stored decoder receivers, function-variable

--- a/_Log.md
+++ b/_Log.md
@@ -47,6 +47,14 @@
   - **Validation**: `go build ./pkg/dataplane/...`;
     `go test ./pkg/dataplane/... -count=1`
 
+- **Timestamp**: 2026-05-23T03:45:00Z
+  - **Action**: PR #1494 copilot re-review hardening — made the userspace
+    entry-program canary reject shadowed local identifiers so only the package
+    constant `userspaceXDPEntryProg` can satisfy XDP entry assignments/calls.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
+    `git diff --check`
+
 ## 2026-05-22
 
 - **Timestamp**: 2026-05-22T20:20:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,22 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T15:14:30Z
+  - **Action**: PR #1494 round-11 follow-up — collapsed the retained
+    userspace XDP shim entry-program name onto one dataplane constant and
+    routed both full-loader and shim-loader registrations through it. This
+    removes the duplicate `xdp_userspace_prog` constants that reviewers
+    flagged as a drift risk.
+  - **File(s)**: `pkg/dataplane/loader.go`,
+    `pkg/dataplane/loader_ebpf.go`,
+    `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestBPFShimEntryProgramStateIsNotJSONMutable|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceXDPEntryProgramConstantNamesRetainedShim'`;
+    `go test ./pkg/dataplane/userspace -run
+    'TestUserspaceShimLoaderDoesNotReferenceLegacyObjects|TestUserspaceStartupUsesShimLoaderBoundary'`;
+    `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-24T04:08:49Z
   - **Action**: PR #1497 round-3 follow-up — fixed the checker/schema
     parity nits from review: boolean `schema_version` rejection, JSON

--- a/_Log.md
+++ b/_Log.md
@@ -39,6 +39,18 @@
 
 ## 2026-05-23
 
+- **Timestamp**: 2026-05-23T15:58:00Z
+  - **Action**: PR #1494 round-8 follow-up — hardened JSON decoder canary
+    laundering checks for stored decoder receivers, function-variable
+    `Unmarshal` callees, tuple-return spread into `Unmarshal`, and default
+    import-name resolution for versioned import paths (e.g. `encoding/json/v2`);
+    added dedicated fixtures for each bypass shape.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture'
+    -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-23T09:52:00Z
   - **Action**: PR #1494 r7 copilot re-review follow-up — hardened
     `encoding/json` canary detection to catch decode targets laundered through

--- a/_Log.md
+++ b/_Log.md
@@ -39,6 +39,17 @@
 
 ## 2026-05-23
 
+- **Timestamp**: 2026-05-23T09:52:00Z
+  - **Action**: PR #1494 r7 copilot re-review follow-up — hardened
+    `encoding/json` canary detection to catch decode targets laundered through
+    local aliases of `bpfShim`, and added fixture coverage for unmarshal/decode
+    alias bypass shapes.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture'
+    -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-23T09:31:43Z
   - **Action**: PR #1493 r2 copilot follow-up — restored `"impact"` slog key
     on native-XDP fallback warning in `attachUserspaceShimXDP` so operator

--- a/_Log.md
+++ b/_Log.md
@@ -47,6 +47,17 @@
   - **Validation**: `go build ./pkg/dataplane/...`;
     `go test ./pkg/dataplane/... -count=1`
 
+- **Timestamp**: 2026-05-23T06:12:00Z
+  - **Action**: PR #1494 r7 copilot re-review follow-up — hardened the
+    retirement-boundary canary to catch `encoding/json` decode mutations via
+    dot-import `Unmarshal` and `NewDecoder(...).Decode` paths, including
+    `encoding/json/v2`, and added fixture coverage for each bypass shape.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram'
+    -count=1`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-23T04:58:00Z
   - **Action**: PR #1494 copilot round-5 follow-up — hardened the canary
     walker to treat wrapped SwapXDPEntryProg callees as direct calls and added

--- a/docs/archived/userspace-forwarding-and-failover-gap-audit.md
+++ b/docs/archived/userspace-forwarding-and-failover-gap-audit.md
@@ -72,7 +72,7 @@ The userspace manager still chooses between `xdp_userspace_prog` and
 `xdp_main_prog`:
 
 - `pkg/dataplane/userspace/manager.go:Compile()`
-- `pkg/dataplane/loader.go:SwapXDPEntryProg()`
+- `pkg/dataplane/loader.go` userspace-shim swap path
 
 Current behavior:
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -123,10 +123,12 @@ generation. `pkg/dataplane/retirement_boundary_canary_test.go` reads the
 Makefile and fails if `generate-userspace-xdp` gains legacy bpf2go tokens,
 recursive Make dependencies, or the broad `./pkg/dataplane/...` generate path.
 The same canary allowlists the retained Rust shim's source-level and built-object
-maps/programs, rejects tail-call plumbing in that shim, and requires production
-userspace manager writes to `XDPEntryProg` or calls to `SwapXDPEntryProg` to use
-`userspaceXDPEntryProg`. This keeps the retained shim visible without implying
-that degraded userspace mode can bypass back into the legacy pipeline.
+maps/programs, rejects tail-call plumbing in that shim, and requires the retained
+Go shim manager to keep its entry-program state unexported so JSON/reflection
+cannot select the legacy XDP entry point. Production userspace code may only use
+the narrow userspace-shim selection/swap methods. This keeps the retained shim
+visible without implying that degraded userspace mode can bypass back into the
+legacy pipeline.
 
 The remaining #1473/#1451 blocker is #1493's loader/bootstrap shape, not runtime
 fallback semantics. `pkg/dataplane/userspace.Manager` still creates a named

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -106,8 +106,8 @@ same PR.
 ## #1473 Userspace XDP Shim Build Split
 
 The retained Rust userspace XDP shim is still required for the AF_XDP userspace
-runtime, but its generation path is now explicit and separate from the legacy
-XDP/TC dataplane bpf2go batch:
+runtime. Its runtime fallback behavior and generation path are now explicit and
+separate from the legacy XDP/TC dataplane:
 
 - `make generate-userspace-xdp` rebuilds only
   `pkg/dataplane/userspace_xdp_bpfel.o` through the
@@ -122,8 +122,19 @@ The userspace shim target must not depend on legacy `xdp_main` or TC program
 generation. `pkg/dataplane/retirement_boundary_canary_test.go` reads the
 Makefile and fails if `generate-userspace-xdp` gains legacy bpf2go tokens,
 recursive Make dependencies, or the broad `./pkg/dataplane/...` generate path.
-This keeps the retained shim visible without implying that deleting legacy
-dataplane program generation is blocked by the shim itself.
+The same canary allowlists the retained Rust shim's source-level and built-object
+maps/programs, rejects tail-call plumbing in that shim, and requires production
+userspace manager writes to `XDPEntryProg` or calls to `SwapXDPEntryProg` to use
+`userspaceXDPEntryProg`. This keeps the retained shim visible without implying
+that degraded userspace mode can bypass back into the legacy pipeline.
+
+The remaining #1473/#1451 blocker is #1493's loader/bootstrap shape, not runtime
+fallback semantics. `pkg/dataplane/userspace.Manager` still creates a named
+legacy shim manager for shared maps and XDP attachment plumbing, and that
+manager still loads the full legacy object set before the retained shim. The
+final source-removal path needs a userspace-only loader/bootstrap boundary that
+loads the retained shim plus required shared maps without loading legacy XDP/TC
+programs.
 
 ## #1493 Userspace Shim Loader Split
 

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -130,13 +130,9 @@ the narrow userspace-shim selection/swap methods. This keeps the retained shim
 visible without implying that degraded userspace mode can bypass back into the
 legacy pipeline.
 
-The remaining #1473/#1451 blocker is #1493's loader/bootstrap shape, not runtime
-fallback semantics. `pkg/dataplane/userspace.Manager` still creates a named
-legacy shim manager for shared maps and XDP attachment plumbing, and that
-manager still loads the full legacy object set before the retained shim. The
-final source-removal path needs a userspace-only loader/bootstrap boundary that
-loads the retained shim plus required shared maps without loading legacy XDP/TC
-programs.
+The #1493 loader/bootstrap split keeps normal userspace startup on the
+userspace-only shim loader below. Source removal still waits for #1451's
+remaining operator/runtime surface migration and #1476's deletion candidate.
 
 ## #1493 Userspace Shim Loader Split
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -384,9 +384,10 @@ ConfigSnapshot {
 
 #### Capability Check
 
-The manager evaluates the active config to determine if the userspace
-dataplane can handle it. Unsupported features cause automatic fallback
-to the legacy kernel BPF pipeline:
+The manager evaluates the active config to determine whether the userspace
+dataplane can handle it. Unsupported userspace features fail closed or disarm
+helper forwarding; userspace runtime traffic must not silently fall back into
+the legacy kernel BPF pipeline.
 
 The current supported/gated split is maintained in
 [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md). In broad terms,
@@ -395,18 +396,15 @@ matching, interface-mode SNAT, DNAT, static NAT, NAT64, NPTv6, firewall
 filters, flow export, TCP MSS clamping, configurable timeouts, VLAN handling,
 route/neighbor lookup, and HA/session-delta ingestion.
 
-Remaining explicit gates include three-color policers, dataplane event parity,
-and the residual #1377 SNAT pool contract for helper-restart persistence and
-mixed-backend rollback constraints.
-SYN-cookie-dependent screen behavior is admitted in userspace; #1374 still
-needs live HA/flood evidence before BPF source removal. Port mirroring is no
-longer a
-`deriveUserspaceCapabilities()` gate; its remaining #1376 work is operator
-evidence for mirror fidelity and primary-forwarding survival under mirror
-pressure before BPF source removal. HA persistent-SNAT configs remain gated
-with the status reason `userspace persistent-nat source pool leases are not
-HA-synchronized`; non-HA per-pool persistent-NAT lease reuse is helper-local
-userspace state.
+The original #1374-#1381 userspace feature-gap blockers are closed. Remaining
+eBPF retirement work is source-removal plumbing rather than feature admission:
+#1451 is migrating the remaining operator/runtime surfaces off the legacy
+`dataplane.DataPlane` bridge, #1473 keeps the retained XDP shim separate from
+legacy fallback behavior, #1493 owns the remaining userspace-only loader split,
+#1476 owns the final source/generated-artifact deletion, and #1477 owns live
+evidence for the exact deletion candidate.
+SYN-cookie, port-mirroring, dataplane-event, and CoS/fairness live artifacts
+belong in #1477 if the final source-removal candidate requires them.
 
 Policy scheduler state is no longer a propagation gap: #1396 carries scheduler
 state into the userspace snapshot and Rust policy evaluator, and the 2026-05-19
@@ -582,29 +580,30 @@ system {
 This section is a high-level architecture note. The authoritative current gate
 is [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
 
-**Still explicitly gated or incomplete for eBPF retirement:**
+**Still explicitly tracked for eBPF retirement:**
 - Source NAT pool mode: userspace-v1 deterministic pool selection and
   fail-closed runtime handling for missing pools, empty pools, invalid pool
   inputs, wrong-family-only pools, and allocator failures have landed.
   Helper-local non-HA per-pool `persistent-nat` lease reuse and pool
   allocation/exhaustion counters have landed. #1449 closes HA behavior as an
   explicit userspace capability gate because persistent leases are not
-  synchronized. #1377 is still required for helper-restart persistence and the
-  mixed-backend rollback test boundary.
+  synchronized. Helper-restart reset and mixed-backend selector parity are
+  documented contracts, not active #1377 blockers.
 - SYN-cookie flood protection closeout: bounded SYN-ACK/RST TX,
   root-auth-derived snapshot key publication, fail-closed missing-secret
-  behavior, status counters, and gate removal are wired. #1374 still owns the
-  live HA/flood artifact set before BPF source removal.
+  behavior, status counters, and gate removal are wired. Any final live
+  HA/flood artifact belongs with #1477 on the source-removal candidate.
 - RFC 2697/2698 three-color policer closeout: #1375 now preserves
-  token/counter state across compatible in-process snapshot refreshes. It still
-  owns the sharded/packed state decision, HA/restart continuity decision,
-  non-drop color actions, and integration/perf evidence beyond the admitted
-  color-blind `then discard` slice.
+  token/counter state across compatible in-process snapshot refreshes and
+  admits the reviewed color-blind `then discard` runtime slice. Sharded/packed
+  state, HA/restart continuity, non-drop color actions, and broader perf
+  evidence are production follow-ups, not active feature-gap blockers.
 - Port mirroring closeout: #1376 now has bounded userspace runtime admission,
-  but still owns mirror-fidelity evidence and forwarding survival under mirror
-  pressure before BPF source removal.
-- Dataplane event closeout: #1379 still owns end-to-end syslog evidence,
-  broader non-PBR filter-log call sites, and richer identity mapping.
+  with final mirror-fidelity or pressure-survival artifacts belonging in #1477
+  if the source-removal candidate needs them.
+- Dataplane event closeout: #1379 is closed for policy-deny, screen-drop, and
+  filter-log emission. Final live syslog proof, if required, belongs with
+  #1477.
 - `show system buffers` BPF-map display retirement: #1380 is closed for the
   current helper schema. Userspace mode uses helper status, preserves the
   active-session footer, renders session/flow utilization from Rust-owned

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -400,7 +400,7 @@ The original #1374-#1381 userspace feature-gap blockers are closed. Remaining
 eBPF retirement work is source-removal plumbing rather than feature admission:
 #1451 is migrating the remaining operator/runtime surfaces off the legacy
 `dataplane.DataPlane` bridge, #1473 keeps the retained XDP shim separate from
-legacy fallback behavior, #1493 owns the remaining userspace-only loader split,
+legacy fallback behavior, #1493 documents the userspace-only loader split,
 #1476 owns the final source/generated-artifact deletion, and #1477 owns live
 evidence for the exact deletion candidate.
 SYN-cookie, port-mirroring, dataplane-event, and CoS/fairness live artifacts

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -109,7 +109,7 @@ The current tracked removal work is:
 | Issue | Removal-phase role |
 |-------|--------------------|
 | #1451 | Migrate remaining API, gRPC, CLI, status, metrics, session, GC, cluster, daemon-control, and userspace shim callers away from the legacy eBPF-shaped `dataplane.DataPlane` surface before deleting source/generated artifacts. |
-| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback so the shim can remain while legacy XDP/TC programs are removed. |
+| #1473 / #1493 | Runtime fallback and shim-only generation are split from legacy `xdp_main_prog`; the remaining blocker is the userspace load graph still going through the legacy manager until #1451/#1476 split shared map bootstrap from legacy object loading. |
 | #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the migration blockers close, while preserving the retained AF_XDP userspace shim path. |
 | #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate, including cluster, screen/flood, CoS, HA, and fallback-proof evidence. |
 
@@ -121,8 +121,9 @@ Recommended dependency order:
 
 1. #1451 first, because it defines the runtime and operator interface boundary
    that every source-removal slice depends on.
-2. #1473 next, because the retained userspace XDP shim must be explicit before
-   legacy source is deleted.
+2. Finish the #1493 loader side after the runtime fallback/generation split:
+   userspace must be able to load the retained shim and required shared maps
+   without loading legacy XDP/TC programs.
 3. #1476 after #1451 and #1473 close, as the auditable source/generated-artifact
    removal PR.
 4. #1477 on the exact #1476 candidate, so the final validation artifacts match

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -109,7 +109,7 @@ The current tracked removal work is:
 | Issue | Removal-phase role |
 |-------|--------------------|
 | #1451 | Migrate remaining API, gRPC, CLI, status, metrics, session, GC, cluster, daemon-control, and userspace shim callers away from the legacy eBPF-shaped `dataplane.DataPlane` surface before deleting source/generated artifacts. |
-| #1473 / #1493 | Runtime fallback and shim-only generation are split from legacy `xdp_main_prog`; the remaining blocker is the userspace load graph still going through the legacy manager until #1451/#1476 split shared map bootstrap from legacy object loading. |
+| #1473 / #1493 | Runtime fallback, shim-only generation, and userspace shim loader/bootstrap are split from legacy `xdp_main_prog` / `loadAllObjects()` so the retained shim can remain while legacy XDP/TC programs are removed. |
 | #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the migration blockers close, while preserving the retained AF_XDP userspace shim path. |
 | #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate, including cluster, screen/flood, CoS, HA, and fallback-proof evidence. |
 
@@ -121,9 +121,8 @@ Recommended dependency order:
 
 1. #1451 first, because it defines the runtime and operator interface boundary
    that every source-removal slice depends on.
-2. Finish the #1493 loader side after the runtime fallback/generation split:
-   userspace must be able to load the retained shim and required shared maps
-   without loading legacy XDP/TC programs.
+2. Keep the #1473/#1493/#1494 retained-shim boundary pinned while #1451
+   finishes moving remaining runtime/operator surfaces off legacy bridges.
 3. #1476 after #1451 and #1473 close, as the auditable source/generated-artifact
    removal PR.
 4. #1477 on the exact #1476 candidate, so the final validation artifacts match

--- a/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
+++ b/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
@@ -45,7 +45,7 @@ The compiler attaches XDP programs to VLAN sub-interfaces (`ge-0-0-2.50`, `ge-0-
 
 Evidence: `ping6` to the LAN interface (non-VLAN `ge-0-0-1`) worked perfectly. `ping6` to any VLAN interface was 100% loss. Removing generic XDP from the VLAN sub-interface immediately fixed NDP.
 
-**Fix:** Skip XDP attachment on VLAN sub-interfaces when the userspace shim is active (`pkg/dataplane/compiler.go`). The parent's native XDP handles all VLAN-tagged traffic. New `VlanSubInterfaces` map in `loader.go` tracks which ifindexes to skip during `SwapXDPEntryProg()`.
+**Fix:** Skip XDP attachment on VLAN sub-interfaces when the userspace shim is active (`pkg/dataplane/compiler.go`). The parent's native XDP handles all VLAN-tagged traffic. New `VlanSubInterfaces` map in `loader.go` tracks which ifindexes to skip during userspace-shim swaps.
 
 ### 3. VIPs Missing from `userspace_local_v6` BPF Map
 
@@ -102,7 +102,7 @@ With both nodes running the new code, fw1 takes over in ~2.25s and forwards traf
 | `userspace-xdp/src/lib.rs` | Local/control kernel delivery and degraded transit drop paths |
 | `userspace-dp/src/afxdp.rs` | `xsk_rx_confirmed`, `add_kernel_neighbor()` via netlink, ARP/NDP reinject, grace period tuning |
 | `pkg/dataplane/compiler.go` | Skip XDP on VLAN sub-interfaces with userspace shim, `VlanSubInterfaces` tracking |
-| `pkg/dataplane/loader.go` | `VlanSubInterfaces` field, skip in `SwapXDPEntryProg()` |
+| `pkg/dataplane/loader.go` | `VlanSubInterfaces` field, skip during userspace-shim swaps |
 | `pkg/dataplane/userspace/manager.go` | Kernel address enumeration for local map, ctrl delay 3s |
 | `pkg/daemon/daemon.go` | Session sync timeout 5s |
 | `pkg/dataplane/userspace_xdp_bpfel.o` | Rebuilt XDP shim object |

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -369,7 +369,7 @@ func (m *Manager) Compile(cfg *config.Config) (*CompileResult, error) {
 		// can create a kernel-level conflict on the parent (EEXIST).
 		// Also skip with the userspace XDP shim — XDP_PASS on generic mode
 		// doesn't properly deliver NDP to kernel on VLAN devices.
-		isUserspaceShim := m.XDPEntryProg == "xdp_userspace_prog"
+		isUserspaceShim := m.UsingUserspaceXDPShimEntryProgram()
 		for _, ifidx := range result.pendingXDP {
 			forceGeneric := failedNativeXDP[ifidx] || result.tunnelIfindexes[ifidx] || result.genericXDPIfindexes[ifidx]
 			if !forceGeneric {
@@ -394,7 +394,7 @@ func (m *Manager) Compile(cfg *config.Config) (*CompileResult, error) {
 		}
 	}
 
-	// Record VLAN sub-interfaces so SwapXDPEntryProg can skip them.
+	// Record VLAN sub-interfaces so userspace-shim swaps can skip them.
 	// The shim on VLAN sub-interfaces breaks NDP because generic XDP
 	// + XDP_PASS doesn't deliver properly to kernel NDP on VLAN devices.
 	for ifidx := range result.genericXDPIfindexes {

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -19,6 +19,11 @@ import (
 const linkPinPath = "/sys/fs/bpf/xpf/links"
 const userspaceShimEntryProg = "xdp_userspace_prog"
 
+const (
+	defaultXDPEntryProg       = "xdp_main_prog"
+	userspaceShimXDPEntryProg = "xdp_userspace_prog"
+)
+
 // go:generate directives.
 // Run "make generate" with clang + libbpf-dev installed for the full legacy
 // XDP/TC bpf2go batch plus the retained Rust userspace XDP shim object.
@@ -54,7 +59,7 @@ type Manager struct {
 	lastApply               *ApplyResult
 	PersistentNAT           *PersistentNATTable
 	EnableCPUMap            bool // Enable cpumap multi-CPU distribution (adds startup overhead)
-	XDPEntryProg            string
+	xdpEntryProg            string
 	VlanSubInterfaces       map[int]bool      // VLAN sub-interface ifindexes (skip XDP swap for these)
 	mu                      sync.Mutex        // protects userspaceCounterOffsets
 	userspaceCounterOffsets map[uint32]uint64 // userspace counter deltas merged in ReadGlobalCounter
@@ -79,10 +84,31 @@ func New() *Manager {
 		xdpLinks:          make(map[int]link.Link),
 		tcLinks:           make(map[int]link.Link),
 		PersistentNAT:     NewPersistentNATTable(),
-		XDPEntryProg:      "xdp_main_prog",
+		xdpEntryProg:      defaultXDPEntryProg,
 		VlanSubInterfaces: make(map[int]bool),
 		xdpFlagClaims:     make(map[IfaceZoneKey]map[int]bool),
 	}
+}
+
+// XDPEntryProgram returns the entry program selected for future XDP
+// attachments and currently swapped links.
+func (m *Manager) XDPEntryProgram() string {
+	if m.xdpEntryProg == "" {
+		return defaultXDPEntryProg
+	}
+	return m.xdpEntryProg
+}
+
+// SelectUserspaceXDPShimEntryProgram selects the retained userspace shim for
+// future XDP attachments without touching already attached links.
+func (m *Manager) SelectUserspaceXDPShimEntryProgram() {
+	m.xdpEntryProg = userspaceShimXDPEntryProg
+}
+
+// UsingUserspaceXDPShimEntryProgram reports whether the retained userspace
+// shim is selected for XDP attachments and swapped links.
+func (m *Manager) UsingUserspaceXDPShimEntryProgram() bool {
+	return m.XDPEntryProgram() == userspaceShimXDPEntryProg
 }
 
 // Load loads all eBPF programs and maps. Returns an error if eBPF
@@ -440,10 +466,7 @@ func (m *Manager) AttachXDP(ifindex int, forceGeneric bool) error {
 		return fmt.Errorf("eBPF programs not loaded")
 	}
 
-	entryProg := m.XDPEntryProg
-	if entryProg == "" {
-		entryProg = "xdp_main_prog"
-	}
+	entryProg := m.XDPEntryProgram()
 	prog, ok := m.programs[entryProg]
 	if !ok {
 		return fmt.Errorf("%s not found", entryProg)
@@ -549,15 +572,20 @@ func (m *Manager) seedInterfaceCounter(ifindex int) {
 	_ = ic.Update(uint32(ifindex), zero, ebpf.UpdateNoExist)
 }
 
-// SwapXDPEntryProg atomically replaces the XDP entry program on all attached
-// interfaces. Userspace mode keeps the userspace XDP shim attached for normal
-// operation and degraded local/control handling.
-func (m *Manager) SwapXDPEntryProg(name string) error {
+// SwapToUserspaceXDPShimEntryProgram atomically replaces the XDP entry
+// program on all attached interfaces with the retained userspace XDP shim.
+// Userspace mode keeps this shim attached for normal operation and degraded
+// local/control handling.
+func (m *Manager) SwapToUserspaceXDPShimEntryProgram() error {
+	return m.swapXDPEntryProg(userspaceShimXDPEntryProg)
+}
+
+func (m *Manager) swapXDPEntryProg(name string) error {
 	prog, ok := m.programs[name]
 	if !ok {
 		return fmt.Errorf("XDP program %q not found", name)
 	}
-	if m.XDPEntryProg == name {
+	if m.XDPEntryProgram() == name {
 		return nil // already using this program
 	}
 	var errs []error
@@ -576,7 +604,7 @@ func (m *Manager) SwapXDPEntryProg(name string) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	m.XDPEntryProg = name
+	m.xdpEntryProg = name
 	slog.Info("swapped XDP entry program", "program", name, "interfaces", len(m.xdpLinks))
 	return nil
 }

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -91,7 +91,7 @@ func New() *Manager {
 }
 
 // XDPEntryProgram returns the entry program selected for future XDP
-// attachments and currently swapped links.
+// attachments and non-VLAN-subinterface link swaps.
 func (m *Manager) XDPEntryProgram() string {
 	if m.xdpEntryProg == "" {
 		return defaultXDPEntryProg
@@ -133,7 +133,7 @@ func (m *Manager) Load() error {
 // and TC objects.
 func (m *Manager) LoadUserspaceShim() error {
 	slog.Info("loading userspace XDP shim")
-	m.XDPEntryProg = userspaceShimEntryProg
+	m.SelectUserspaceXDPShimEntryProgram()
 	if err := cleanupUserspaceShimLegacyTCLinks(); err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (m *Manager) CompileUserspaceShim(cfg *config.Config) (*CompileResult, erro
 		return nil, err
 	}
 
-	m.XDPEntryProg = userspaceShimEntryProg
+	m.SelectUserspaceXDPShimEntryProgram()
 	compilerDP := userspaceShimCompileDataplane{Manager: m}
 	result, err := CompileConfig(compilerDP, cfg, m.lastCompile != nil)
 	if err != nil {

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -16,12 +16,10 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const linkPinPath = "/sys/fs/bpf/xpf/links"
-const userspaceShimEntryProg = "xdp_userspace_prog"
-
 const (
-	defaultXDPEntryProg       = "xdp_main_prog"
-	userspaceShimXDPEntryProg = "xdp_userspace_prog"
+	linkPinPath            = "/sys/fs/bpf/xpf/links"
+	defaultXDPEntryProg    = "xdp_main_prog"
+	userspaceShimEntryProg = "xdp_userspace_prog"
 )
 
 // go:generate directives.
@@ -102,13 +100,13 @@ func (m *Manager) XDPEntryProgram() string {
 // SelectUserspaceXDPShimEntryProgram selects the retained userspace shim for
 // future XDP attachments without touching already attached links.
 func (m *Manager) SelectUserspaceXDPShimEntryProgram() {
-	m.xdpEntryProg = userspaceShimXDPEntryProg
+	m.xdpEntryProg = userspaceShimEntryProg
 }
 
 // UsingUserspaceXDPShimEntryProgram reports whether the retained userspace
 // shim is selected for XDP attachments and swapped links.
 func (m *Manager) UsingUserspaceXDPShimEntryProgram() bool {
-	return m.XDPEntryProgram() == userspaceShimXDPEntryProg
+	return m.XDPEntryProgram() == userspaceShimEntryProg
 }
 
 // Load loads all eBPF programs and maps. Returns an error if eBPF
@@ -577,7 +575,7 @@ func (m *Manager) seedInterfaceCounter(ifindex int) {
 // Userspace mode keeps this shim attached for normal operation and degraded
 // local/control handling.
 func (m *Manager) SwapToUserspaceXDPShimEntryProgram() error {
-	return m.swapXDPEntryProg(userspaceShimXDPEntryProg)
+	return m.swapXDPEntryProg(userspaceShimEntryProg)
 }
 
 func (m *Manager) swapXDPEntryProg(name string) error {

--- a/pkg/dataplane/loader_ebpf.go
+++ b/pkg/dataplane/loader_ebpf.go
@@ -150,7 +150,7 @@ func (m *Manager) loadAllObjects() error {
 	m.maps["snat_egress_ips"] = mainObjs.SnatEgressIps
 
 	// Store main program.
-	m.programs["xdp_main_prog"] = mainObjs.XdpMainProg
+	m.programs[defaultXDPEntryProg] = mainObjs.XdpMainProg
 
 	// Build map replacements so tail call programs share the same maps.
 	replaceOpts := &ebpf.CollectionOptions{
@@ -255,9 +255,9 @@ func (m *Manager) loadAllObjects() error {
 	if err != nil {
 		return fmt.Errorf("load Rust xdp_userspace collection: %w", err)
 	}
-	userspaceProg, ok := userspaceCollection.Programs["xdp_userspace_prog"]
+	userspaceProg, ok := userspaceCollection.Programs[userspaceShimEntryProg]
 	if !ok {
-		return fmt.Errorf("Rust xdp_userspace_prog not found")
+		return fmt.Errorf("Rust %s not found", userspaceShimEntryProg)
 	}
 	userspaceCtrl, ok := userspaceCollection.Maps["userspace_ctrl"]
 	if !ok {
@@ -304,7 +304,7 @@ func (m *Manager) loadAllObjects() error {
 			return err
 		}
 	}
-	m.programs["xdp_userspace_prog"] = userspaceProg
+	m.programs[userspaceShimEntryProg] = userspaceProg
 	// Register all userspace maps from the Rust XDP collection.
 	for name, umap := range userspaceCollection.Maps {
 		m.maps[name] = umap

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -1,6 +1,7 @@
 package dataplane
 
 import (
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -476,6 +478,59 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	}
 }
 
+func TestBPFShimEntryProgramStateIsNotJSONMutable(t *testing.T) {
+	t.Parallel()
+
+	if userspaceShimXDPEntryProg != userspaceXDPEntryProgForCanary {
+		t.Fatalf(
+			"userspace shim entry-program constant = %q, want %q",
+			userspaceShimXDPEntryProg,
+			userspaceXDPEntryProgForCanary,
+		)
+	}
+
+	managerType := reflect.TypeOf(Manager{})
+	if _, ok := managerType.FieldByName("XDPEntryProg"); ok {
+		t.Fatal("dataplane.Manager must not export XDPEntryProg")
+	}
+	field, ok := managerType.FieldByName("xdpEntryProg")
+	if !ok {
+		t.Fatal("dataplane.Manager lost xdpEntryProg state field")
+	}
+	if field.PkgPath == "" {
+		t.Fatal("dataplane.Manager.xdpEntryProg must stay unexported")
+	}
+
+	managerPtrType := reflect.TypeOf((*Manager)(nil))
+	if _, ok := managerPtrType.MethodByName("SwapXDPEntryProg"); ok {
+		t.Fatal("dataplane.Manager must not expose arbitrary SwapXDPEntryProg")
+	}
+	if _, ok := managerPtrType.MethodByName("SwapToUserspaceXDPShimEntryProgram"); !ok {
+		t.Fatal("dataplane.Manager lost narrow userspace shim swap method")
+	}
+
+	data, err := json.Marshal(&Manager{xdpEntryProg: "xdp_bypassed"})
+	if err != nil {
+		t.Fatalf("marshal Manager: %v", err)
+	}
+	if strings.Contains(string(data), "xdp_bypassed") ||
+		strings.Contains(string(data), "XDPEntryProg") ||
+		strings.Contains(string(data), "xdpEntryProg") {
+		t.Fatalf("xdpEntryProg leaked into JSON: %s", data)
+	}
+
+	var decoded Manager
+	if err := json.Unmarshal(
+		[]byte(`{"XDPEntryProg":"xdp_bypassed","xdpEntryProg":"xdp_bypassed"}`),
+		&decoded,
+	); err != nil {
+		t.Fatalf("unmarshal Manager: %v", err)
+	}
+	if got := decoded.XDPEntryProgram(); got == "xdp_bypassed" {
+		t.Fatalf("JSON mutated xdpEntryProg to %q", got)
+	}
+}
+
 func TestUserspaceManagerDoesNotImportReflectOrUnsafe(t *testing.T) {
 	t.Parallel()
 
@@ -519,18 +574,17 @@ package userspace
 
 const userspaceXDPEntryProg = "xdp_userspace_prog"
 
-type shim struct { XDPEntryProg string }
-func (s *shim) SwapXDPEntryProg(name string) error { return nil }
+type shim struct{}
+func (s *shim) SelectUserspaceXDPShimEntryProgram() {}
+func (s *shim) SwapToUserspaceXDPShimEntryProgram() error { return nil }
 type manager struct { bpfShim *shim }
 `,
 		"use.go": `
 package userspace
 
 func valid(m *manager) {
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
-	_ = m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg)
-	_ = (m.bpfShim.SwapXDPEntryProg)(userspaceXDPEntryProg)
-	_ = ((*shim).SwapXDPEntryProg)(m.bpfShim, userspaceXDPEntryProg)
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
+	_ = m.bpfShim.SwapToUserspaceXDPShimEntryProgram()
 }
 `,
 	})
@@ -1030,15 +1084,13 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 					if len(node.Rhs) == len(node.Lhs) {
 						rhs = node.Rhs[i]
 					}
-					if !isUserspaceXDPEntryProgExpr(rhs) {
-						pos := fset.Position(lhs.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d assigns XDPEntryProg from %q",
-							rel,
-							pos.Line,
-							canaryExprString(rhs),
-						))
-					}
+					pos := fset.Position(lhs.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d assigns XDPEntryProg from %q",
+						rel,
+						pos.Line,
+						canaryExprString(rhs),
+					))
 				}
 			case *ast.CompositeLit:
 				for _, elt := range node.Elts {
@@ -1046,15 +1098,13 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 					if !ok || !isXDPEntryProgField(kv.Key) {
 						continue
 					}
-					if !isUserspaceXDPEntryProgExpr(kv.Value) {
-						pos := fset.Position(kv.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d initializes XDPEntryProg from %q",
-							rel,
-							pos.Line,
-							canaryExprString(kv.Value),
-						))
-					}
+					pos := fset.Position(kv.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d initializes XDPEntryProg from %q",
+						rel,
+						pos.Line,
+						canaryExprString(kv.Value),
+					))
 				}
 			case *ast.CallExpr:
 				if isJSONDecoderIntoBPFShim(node, jsonImports, jsonDotImport) {
@@ -1743,13 +1793,8 @@ func containsBPFShimFromIdent(ident *ast.Ident, seen map[*ast.Object]bool) bool 
 func swapXDPEntryProgSelectorViolation(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node, fset *token.FileSet, rel string) string {
 	if call, methodExpr, ok := enclosingDirectSwapXDPEntryProgCall(sel, parents); ok {
 		argIndex := 0
-		wantArgs := 1
 		if methodExpr {
 			argIndex = 1
-			wantArgs = 2
-		}
-		if len(call.Args) == wantArgs && isUserspaceXDPEntryProgExpr(call.Args[argIndex]) {
-			return ""
 		}
 		var got string
 		if len(call.Args) > argIndex {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -569,6 +569,22 @@ func directBadCall(m *manager) {
 	_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
 }
 
+func parenBadCall(m *manager) {
+	_ = (m.bpfShim.SwapXDPEntryProg)("xdp_main_prog")
+}
+
+func methodExprBadCall(m *manager) {
+	_ = ((*shim).SwapXDPEntryProg)(m.bpfShim, "xdp_main_prog")
+}
+
+func sliceIndexBadCall(m *manager) {
+	_ = ([]func(string) error{m.bpfShim.SwapXDPEntryProg})[0]("xdp_main_prog")
+}
+
+func doubleParenBadCall(m *manager) {
+	_ = ((m.bpfShim.SwapXDPEntryProg))("xdp_main_prog")
+}
+
 func reflectionName() {
 	_ = "XDPEntryProg"
 }
@@ -587,6 +603,9 @@ func reflectionName() {
 		"calls SwapXDPEntryProg with",
 		"uses XDPEntryProg string literal",
 	})
+	if got := countViolationsContaining(violations, "calls SwapXDPEntryProg with"); got < 5 {
+		t.Fatalf("expected at least 5 SwapXDPEntryProg call violations, got %d: %v", got, violations)
+	}
 }
 
 func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
@@ -724,8 +743,7 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 					}
 				}
 			case *ast.CallExpr:
-				sel, ok := node.Fun.(*ast.SelectorExpr)
-				if ok && sel.Sel.Name == "SwapXDPEntryProg" {
+				if invokesSwapXDPEntryProg(node.Fun) {
 					if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
 						var got string
 						if len(node.Args) == 1 {
@@ -1073,7 +1091,7 @@ func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
 		}
 		switch node := n.(type) {
 		case *ast.CallExpr:
-			if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "SwapXDPEntryProg" {
+			if invokesSwapXDPEntryProg(node.Fun) {
 				for _, arg := range node.Args {
 					if containsSwapXDPEntryProgMethodValue(arg) {
 						found = true
@@ -1091,6 +1109,13 @@ func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
 		return true
 	})
 	return found
+}
+
+func invokesSwapXDPEntryProg(expr ast.Expr) bool {
+	return containsExpr(expr, func(e ast.Expr) bool {
+		sel, ok := e.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "SwapXDPEntryProg"
+	})
 }
 
 func containsExpr(expr ast.Expr, match func(ast.Expr) bool) bool {
@@ -1113,6 +1138,16 @@ func containsExpr(expr ast.Expr, match func(ast.Expr) bool) bool {
 		return true
 	})
 	return found
+}
+
+func countViolationsContaining(violations []string, needle string) int {
+	count := 0
+	for _, violation := range violations {
+		if strings.Contains(violation, needle) {
+			count++
+		}
+	}
+	return count
 }
 
 func operatorRuntimeBoundaryRoots(t *testing.T) []string {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -476,7 +476,7 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	}
 }
 
-func TestUserspaceManagerAvoidsReflectionAndUnsafeMutationEscapes(t *testing.T) {
+func TestUserspaceManagerDoesNotImportReflectOrUnsafe(t *testing.T) {
 	t.Parallel()
 
 	var violations []string
@@ -530,6 +530,7 @@ func valid(m *manager) {
 	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
 	_ = m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg)
 	_ = (m.bpfShim.SwapXDPEntryProg)(userspaceXDPEntryProg)
+	_ = ((*shim).SwapXDPEntryProg)(m.bpfShim, userspaceXDPEntryProg)
 }
 `,
 	})
@@ -662,7 +663,18 @@ func methodExprBadCall(m *manager) {
 	_ = ((*shim).SwapXDPEntryProg)(m.bpfShim, "xdp_main_prog")
 }
 `,
-			want: []string{"calls through SwapXDPEntryProg method value"},
+			want: []string{"calls SwapXDPEntryProg with", "xdp_main_prog"},
+		},
+		{
+			name: "raw_string_bad_call",
+			body: `
+package userspace
+
+func rawStringBadCall(m *manager) {
+	_ = m.bpfShim.SwapXDPEntryProg(` + "`xdp_main_prog`" + `)
+}
+`,
+			want: []string{"calls SwapXDPEntryProg with", "xdp_main_prog"},
 		},
 		{
 			name: "slice_index_bad_call",
@@ -697,6 +709,70 @@ func wrappedMethodValueCallee(m *manager) {
 }
 `,
 			want: []string{"calls through SwapXDPEntryProg method value"},
+		},
+		{
+			name: "send_stmt_method_value",
+			body: `
+package userspace
+
+func sendStmtBypass(m *manager) {
+	ch := make(chan func(string) error, 1)
+	ch <- m.bpfShim.SwapXDPEntryProg
+}
+`,
+			want: []string{"sends SwapXDPEntryProg method value"},
+		},
+		{
+			name: "range_stmt_method_value",
+			body: `
+package userspace
+
+func rangeStmtBypass(m *manager) {
+	for _, fn := range []func(string) error{m.bpfShim.SwapXDPEntryProg} {
+		_ = fn(userspaceXDPEntryProg)
+	}
+}
+`,
+			want: []string{"ranges over SwapXDPEntryProg method value"},
+		},
+		{
+			name: "map_key_method_value",
+			body: `
+package userspace
+
+func mapKeyBypass(m *manager) {
+	mapOfFuncs := make(map[any]bool)
+	mapOfFuncs[m.bpfShim.SwapXDPEntryProg] = true
+}
+`,
+			want: []string{"uses SwapXDPEntryProg method value"},
+		},
+		{
+			name: "switch_tag_method_value",
+			body: `
+package userspace
+
+func switchTagBypass(m *manager) {
+	switch m.bpfShim.SwapXDPEntryProg {
+	case nil:
+	default:
+	}
+}
+`,
+			want: []string{"switches on SwapXDPEntryProg method value"},
+		},
+		{
+			name: "json_unmarshal_bpf_shim",
+			body: `
+package userspace
+
+import "encoding/json"
+
+func jsonBypass(m *manager) {
+	_ = json.Unmarshal([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim)
+}
+`,
+			want: []string{"json.Unmarshal into bpfShim"},
 		},
 		{
 			name: "reflection_field_name",
@@ -799,19 +875,11 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 	var violations []string
 	for _, parsed := range files {
 		rel := repoRelativePath(t, parsed.path)
+		parents := astParentMap(parsed.file)
+		jsonImports := importNamesForPath(parsed.file, "encoding/json")
 		ast.Inspect(parsed.file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.AssignStmt:
-				for _, rhs := range node.Rhs {
-					if containsSwapXDPEntryProgMethodValue(rhs) {
-						pos := fset.Position(rhs.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d captures SwapXDPEntryProg method value",
-							rel,
-							pos.Line,
-						))
-					}
-				}
 				for i, lhs := range node.Lhs {
 					if !isXDPEntryProgField(lhs) {
 						continue
@@ -846,62 +914,14 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 						))
 					}
 				}
-			case *ast.ValueSpec:
-				for _, value := range node.Values {
-					if containsSwapXDPEntryProgMethodValue(value) {
-						pos := fset.Position(value.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d stores SwapXDPEntryProg method value",
-							rel,
-							pos.Line,
-						))
-					}
-				}
 			case *ast.CallExpr:
-				if isDirectSwapXDPEntryProgCall(node.Fun) {
-					if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
-						var got string
-						if len(node.Args) == 1 {
-							got = canaryExprString(node.Args[0])
-						}
-						pos := fset.Position(node.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d calls SwapXDPEntryProg with %q",
-							rel,
-							pos.Line,
-							got,
-						))
-					}
-					return true
-				}
-				if containsSwapXDPEntryProgMethodValue(node.Fun) {
-					pos := fset.Position(node.Fun.Pos())
+				if isJSONUnmarshalIntoBPFShim(node, jsonImports) {
+					pos := fset.Position(node.Pos())
 					violations = append(violations, fmt.Sprintf(
-						"%s:%d calls through SwapXDPEntryProg method value",
+						"%s:%d json.Unmarshal into bpfShim can mutate XDPEntryProg",
 						rel,
 						pos.Line,
 					))
-				}
-				for _, arg := range node.Args {
-					if containsSwapXDPEntryProgMethodValue(arg) {
-						pos := fset.Position(arg.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d passes SwapXDPEntryProg method value",
-							rel,
-							pos.Line,
-						))
-					}
-				}
-			case *ast.ReturnStmt:
-				for _, result := range node.Results {
-					if containsSwapXDPEntryProgMethodValue(result) {
-						pos := fset.Position(result.Pos())
-						violations = append(violations, fmt.Sprintf(
-							"%s:%d returns SwapXDPEntryProg method value",
-							rel,
-							pos.Line,
-						))
-					}
 				}
 			case *ast.UnaryExpr:
 				if node.Op == token.AND && containsXDPEntryProgField(node.X) {
@@ -924,6 +944,13 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 						rel,
 						pos.Line,
 					))
+				}
+			case *ast.SelectorExpr:
+				if node.Sel.Name != "SwapXDPEntryProg" {
+					return true
+				}
+				if violation := swapXDPEntryProgSelectorViolation(node, parents, fset, rel); violation != "" {
+					violations = append(violations, violation)
 				}
 			}
 			return true
@@ -1057,6 +1084,50 @@ func productionGoPackageFilesUnder(t *testing.T, roots []string) (*token.FileSet
 	}
 	resolveUserspaceXDPEntryProgramIdents(packageFiles)
 	return fset, files
+}
+
+func astParentMap(root ast.Node) map[ast.Node]ast.Node {
+	parents := map[ast.Node]ast.Node{}
+	var stack []ast.Node
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			return false
+		}
+		if len(stack) > 0 {
+			parents[n] = stack[len(stack)-1]
+		}
+		stack = append(stack, n)
+		return true
+	})
+	return parents
+}
+
+func importNamesForPath(file *ast.File, importPath string) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name != "_" && imp.Name.Name != "." {
+				names[imp.Name.Name] = true
+			}
+			continue
+		}
+		names[defaultImportName(importPath)] = true
+	}
+	return names
+}
+
+func defaultImportName(importPath string) string {
+	if idx := strings.LastIndex(importPath, "/"); idx >= 0 {
+		return importPath[idx+1:]
+	}
+	return importPath
 }
 
 func resolveUserspaceXDPEntryProgramIdents(files map[string]*ast.File) {
@@ -1210,47 +1281,132 @@ func containsXDPEntryProgField(expr ast.Expr) bool {
 	return containsExpr(expr, isXDPEntryProgField)
 }
 
-func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
-	if expr == nil {
+func isJSONUnmarshalIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool) bool {
+	if len(jsonImports) == 0 || len(call.Args) < 2 {
 		return false
 	}
-	var found bool
-	ast.Inspect(expr, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch node := n.(type) {
-		case *ast.CallExpr:
-			if isDirectSwapXDPEntryProgCall(node.Fun) {
-				for _, arg := range node.Args {
-					if containsSwapXDPEntryProgMethodValue(arg) {
-						found = true
-						return false
-					}
-				}
-				return false
-			}
-		case *ast.SelectorExpr:
-			if node.Sel.Name == "SwapXDPEntryProg" {
-				found = true
-				return false
-			}
-		}
-		return true
-	})
-	return found
+	sel, ok := unparenExpr(call.Fun).(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Unmarshal" {
+		return false
+	}
+	pkg, ok := unparenExpr(sel.X).(*ast.Ident)
+	if !ok || !jsonImports[pkg.Name] {
+		return false
+	}
+	return containsBPFShimSelector(call.Args[1])
 }
 
-func isDirectSwapXDPEntryProgCall(expr ast.Expr) bool {
-	sel, ok := unparenExpr(expr).(*ast.SelectorExpr)
-	if !ok || sel.Sel.Name != "SwapXDPEntryProg" {
-		return false
+func containsBPFShimSelector(expr ast.Expr) bool {
+	return containsExpr(expr, func(e ast.Expr) bool {
+		sel, ok := e.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "bpfShim"
+	})
+}
+
+func swapXDPEntryProgSelectorViolation(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node, fset *token.FileSet, rel string) string {
+	if call, methodExpr, ok := enclosingDirectSwapXDPEntryProgCall(sel, parents); ok {
+		argIndex := 0
+		wantArgs := 1
+		if methodExpr {
+			argIndex = 1
+			wantArgs = 2
+		}
+		if len(call.Args) == wantArgs && isUserspaceXDPEntryProgExpr(call.Args[argIndex]) {
+			return ""
+		}
+		var got string
+		if len(call.Args) > argIndex {
+			got = canaryExprString(call.Args[argIndex])
+		}
+		pos := fset.Position(call.Pos())
+		return fmt.Sprintf("%s:%d calls SwapXDPEntryProg with %q", rel, pos.Line, got)
 	}
-	switch unparenExpr(sel.X).(type) {
-	case *ast.StarExpr:
-		return false
+
+	pos := fset.Position(sel.Pos())
+	return fmt.Sprintf("%s:%d %s", rel, pos.Line, swapXDPEntryProgMethodValueContext(sel, parents))
+}
+
+func enclosingDirectSwapXDPEntryProgCall(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node) (*ast.CallExpr, bool, bool) {
+	var expr ast.Node = sel
+	for {
+		parent := parents[expr]
+		if paren, ok := parent.(*ast.ParenExpr); ok && paren.X == expr {
+			expr = paren
+			continue
+		}
+		call, ok := parent.(*ast.CallExpr)
+		if !ok || call.Fun != expr {
+			return nil, false, false
+		}
+		return call, isSwapXDPEntryProgMethodExpression(sel), true
 	}
-	return true
+}
+
+func isSwapXDPEntryProgMethodExpression(sel *ast.SelectorExpr) bool {
+	_, ok := unparenExpr(sel.X).(*ast.StarExpr)
+	return ok
+}
+
+func swapXDPEntryProgMethodValueContext(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node) string {
+	if selectorInsideCallFun(sel, parents) {
+		return "calls through SwapXDPEntryProg method value"
+	}
+
+	for child := ast.Node(sel); child != nil; {
+		parent := parents[child]
+		switch node := parent.(type) {
+		case *ast.AssignStmt:
+			if exprListContainsNode(node.Rhs, child) {
+				return "captures SwapXDPEntryProg method value"
+			}
+		case *ast.ValueSpec:
+			if exprListContainsNode(node.Values, child) {
+				return "stores SwapXDPEntryProg method value"
+			}
+		case *ast.ReturnStmt:
+			if exprListContainsNode(node.Results, child) {
+				return "returns SwapXDPEntryProg method value"
+			}
+		case *ast.CallExpr:
+			if exprListContainsNode(node.Args, child) {
+				return "passes SwapXDPEntryProg method value"
+			}
+		case *ast.SendStmt:
+			if node.Value == child {
+				return "sends SwapXDPEntryProg method value"
+			}
+		case *ast.RangeStmt:
+			if node.X == child {
+				return "ranges over SwapXDPEntryProg method value"
+			}
+		case *ast.SwitchStmt:
+			if node.Tag == child {
+				return "switches on SwapXDPEntryProg method value"
+			}
+		}
+		child = parent
+	}
+	return "uses SwapXDPEntryProg method value"
+}
+
+func selectorInsideCallFun(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node) bool {
+	for child := ast.Node(sel); child != nil; {
+		parent := parents[child]
+		if call, ok := parent.(*ast.CallExpr); ok && call.Fun == child {
+			return true
+		}
+		child = parent
+	}
+	return false
+}
+
+func exprListContainsNode(exprs []ast.Expr, node ast.Node) bool {
+	for _, expr := range exprs {
+		if expr == node {
+			return true
+		}
+	}
+	return false
 }
 
 func unparenExpr(expr ast.Expr) ast.Expr {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -782,7 +782,13 @@ func isXDPEntryProgField(expr ast.Expr) bool {
 
 func isUserspaceXDPEntryProgExpr(expr ast.Expr) bool {
 	ident, ok := expr.(*ast.Ident)
-	return ok && ident.Name == "userspaceXDPEntryProg"
+	if !ok || ident.Name != "userspaceXDPEntryProg" {
+		return false
+	}
+	if ident.Obj == nil {
+		return true
+	}
+	return ident.Obj.Kind == ast.Con
 }
 
 func operatorRuntimeBoundaryRoots(t *testing.T) []string {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -851,6 +851,67 @@ func jsonDecodeAliasBypass(m *manager) {
 			want: []string{"encoding/json decode into bpfShim"},
 		},
 		{
+			name: "json_stored_decoder_decode_bpf_shim",
+			body: `
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func jsonStoredDecoderBypass(m *manager) {
+	dec := json.NewDecoder(strings.NewReader(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `))
+	_ = dec.Decode(m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_func_var_unmarshal_bpf_shim",
+			body: `
+package userspace
+
+import "encoding/json"
+
+func jsonFuncVarBypass(m *manager) {
+	decode := json.Unmarshal
+	_ = decode([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_tuple_spread_bpf_shim",
+			body: `
+package userspace
+
+import "encoding/json"
+
+func tupleDecodeArgs(m *manager) ([]byte, *bpfShim) {
+	return []byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim
+}
+
+func jsonTupleSpreadBypass(m *manager) {
+	_ = json.Unmarshal(tupleDecodeArgs(m))
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_v2_unmarshal_bpf_shim",
+			body: `
+package userspace
+
+import "encoding/json/v2"
+
+func jsonV2Bypass(m *manager) {
+	_ = json.Unmarshal([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
 			name: "reflection_field_name",
 			body: `
 package userspace
@@ -1209,6 +1270,26 @@ func importNamesForPath(file *ast.File, importPath string) (map[string]bool, boo
 }
 
 func defaultImportName(importPath string) string {
+	last := importPath
+	if idx := strings.LastIndex(last, "/"); idx >= 0 {
+		last = last[idx+1:]
+	}
+	if strings.HasPrefix(last, "v") && len(last) > 1 {
+		allDigits := true
+		for _, r := range last[1:] {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			trimmed := strings.TrimSuffix(importPath, "/"+last)
+			if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+				return trimmed[idx+1:]
+			}
+			return trimmed
+		}
+	}
 	if idx := strings.LastIndex(importPath, "/"); idx >= 0 {
 		return importPath[idx+1:]
 	}
@@ -1371,39 +1452,92 @@ func isJSONDecoderIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool, j
 		return false
 	}
 
-	switch fun := unparenExpr(call.Fun).(type) {
-	case *ast.SelectorExpr:
-		switch fun.Sel.Name {
-		case "Unmarshal":
-			if len(call.Args) < 2 {
-				return false
-			}
-			pkg, ok := unparenExpr(fun.X).(*ast.Ident)
-			if !ok || !jsonImports[pkg.Name] {
-				return false
-			}
+	if isJSONUnmarshalCallee(call.Fun, jsonImports, jsonDotImport) {
+		switch len(call.Args) {
+		case 0:
+			return false
+		case 1:
+			return callReturnsBPFShimTuple(call.Args[0], map[*ast.Object]bool{})
+		default:
 			return containsBPFShimReference(call.Args[1])
-		case "Decode":
-			if len(call.Args) != 1 {
-				return false
-			}
-			if !isJSONNewDecoderCall(fun.X, jsonImports, jsonDotImport) {
-				return false
-			}
-			return containsBPFShimReference(call.Args[0])
 		}
-	case *ast.Ident:
-		if !jsonDotImport || fun.Name != "Unmarshal" || len(call.Args) < 2 {
+	}
+
+	if len(call.Args) != 1 {
+		return false
+	}
+	if sel, ok := unparenExpr(call.Fun).(*ast.SelectorExpr); ok && sel.Sel.Name == "Decode" {
+		if !isJSONNewDecoderReceiver(sel.X, jsonImports, jsonDotImport, map[*ast.Object]bool{}) {
 			return false
 		}
-		return containsBPFShimReference(call.Args[1])
+		return containsBPFShimReference(call.Args[0])
 	}
 	return false
 }
 
-func isJSONNewDecoderCall(expr ast.Expr, jsonImports map[string]bool, jsonDotImport bool) bool {
-	call, ok := unparenExpr(expr).(*ast.CallExpr)
-	if !ok {
+func isJSONUnmarshalCallee(expr ast.Expr, jsonImports map[string]bool, jsonDotImport bool) bool {
+	switch fun := unparenExpr(expr).(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := unparenExpr(fun.X).(*ast.Ident)
+		return ok && fun.Sel.Name == "Unmarshal" && jsonImports[pkg.Name]
+	case *ast.Ident:
+		if jsonDotImport && fun.Name == "Unmarshal" {
+			return true
+		}
+		return identResolvesToJSONUnmarshal(fun, jsonImports, jsonDotImport, map[*ast.Object]bool{})
+	default:
+		return false
+	}
+}
+
+func identResolvesToJSONUnmarshal(ident *ast.Ident, jsonImports map[string]bool, jsonDotImport bool, seen map[*ast.Object]bool) bool {
+	if ident == nil || ident.Obj == nil {
+		return false
+	}
+	obj := ident.Obj
+	if seen[obj] {
+		return false
+	}
+	seen[obj] = true
+	defer delete(seen, obj)
+
+	switch decl := obj.Decl.(type) {
+	case *ast.AssignStmt:
+		if len(decl.Rhs) != len(decl.Lhs) {
+			return false
+		}
+		for i, lhs := range decl.Lhs {
+			lhsIdent, ok := lhs.(*ast.Ident)
+			if ok && lhsIdent.Obj == obj {
+				return isJSONUnmarshalCallee(decl.Rhs[i], jsonImports, jsonDotImport)
+			}
+		}
+	case *ast.ValueSpec:
+		if len(decl.Values) != len(decl.Names) {
+			return false
+		}
+		for i, name := range decl.Names {
+			if name.Obj == obj {
+				return isJSONUnmarshalCallee(decl.Values[i], jsonImports, jsonDotImport)
+			}
+		}
+	}
+	return false
+}
+
+func isJSONNewDecoderReceiver(expr ast.Expr, jsonImports map[string]bool, jsonDotImport bool, seen map[*ast.Object]bool) bool {
+	switch e := unparenExpr(expr).(type) {
+	case *ast.CallExpr:
+		return isJSONNewDecoderCall(e, jsonImports, jsonDotImport)
+	case *ast.Ident:
+		return identResolvesToJSONNewDecoder(e, jsonImports, jsonDotImport, seen)
+	default:
+		return false
+	}
+}
+
+func isJSONNewDecoderCall(call *ast.CallExpr, jsonImports map[string]bool, jsonDotImport bool) bool {
+	if call == nil {
 		return false
 	}
 	switch fun := unparenExpr(call.Fun).(type) {
@@ -1415,6 +1549,115 @@ func isJSONNewDecoderCall(expr ast.Expr, jsonImports map[string]bool, jsonDotImp
 	default:
 		return false
 	}
+}
+
+func identResolvesToJSONNewDecoder(ident *ast.Ident, jsonImports map[string]bool, jsonDotImport bool, seen map[*ast.Object]bool) bool {
+	if ident == nil || ident.Obj == nil {
+		return false
+	}
+	obj := ident.Obj
+	if seen[obj] {
+		return false
+	}
+	seen[obj] = true
+	defer delete(seen, obj)
+
+	switch decl := obj.Decl.(type) {
+	case *ast.AssignStmt:
+		if len(decl.Rhs) != len(decl.Lhs) {
+			return false
+		}
+		for i, lhs := range decl.Lhs {
+			lhsIdent, ok := lhs.(*ast.Ident)
+			if ok && lhsIdent.Obj == obj {
+				return isJSONNewDecoderReceiver(decl.Rhs[i], jsonImports, jsonDotImport, seen)
+			}
+		}
+	case *ast.ValueSpec:
+		if len(decl.Values) != len(decl.Names) {
+			return false
+		}
+		for i, name := range decl.Names {
+			if name.Obj == obj {
+				return isJSONNewDecoderReceiver(decl.Values[i], jsonImports, jsonDotImport, seen)
+			}
+		}
+	}
+	return false
+}
+
+func callReturnsBPFShimTuple(expr ast.Expr, seen map[*ast.Object]bool) bool {
+	call, ok := unparenExpr(expr).(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	switch fun := unparenExpr(call.Fun).(type) {
+	case *ast.FuncLit:
+		return blockReturnsBPFShimTuple(fun.Body, seen)
+	case *ast.Ident:
+		return identReturnsBPFShimTuple(fun, seen)
+	default:
+		return false
+	}
+}
+
+func identReturnsBPFShimTuple(ident *ast.Ident, seen map[*ast.Object]bool) bool {
+	if ident == nil || ident.Obj == nil {
+		return false
+	}
+	obj := ident.Obj
+	if seen[obj] {
+		return false
+	}
+	seen[obj] = true
+	defer delete(seen, obj)
+
+	switch decl := obj.Decl.(type) {
+	case *ast.FuncDecl:
+		return blockReturnsBPFShimTuple(decl.Body, seen)
+	case *ast.AssignStmt:
+		if len(decl.Rhs) != len(decl.Lhs) {
+			return false
+		}
+		for i, lhs := range decl.Lhs {
+			lhsIdent, ok := lhs.(*ast.Ident)
+			if ok && lhsIdent.Obj == obj {
+				return callReturnsBPFShimTuple(decl.Rhs[i], seen)
+			}
+		}
+	case *ast.ValueSpec:
+		if len(decl.Values) != len(decl.Names) {
+			return false
+		}
+		for i, name := range decl.Names {
+			if name.Obj == obj {
+				return callReturnsBPFShimTuple(decl.Values[i], seen)
+			}
+		}
+	}
+	return false
+}
+
+func blockReturnsBPFShimTuple(block *ast.BlockStmt, seen map[*ast.Object]bool) bool {
+	if block == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, result := range ret.Results {
+			if containsBPFShimReferenceExpr(result, seen) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 func containsBPFShimSelector(expr ast.Expr) bool {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -1,15 +1,20 @@
 package dataplane
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf"
 )
 
 const (
@@ -19,6 +24,7 @@ const (
 	dpdkBackendImportForCanary      = "github.com/psaab/xpf/pkg/dataplane/dpdk"
 	makefileForCanary               = "../../Makefile"
 	retirementBoundaryDocsForCanary = "../../docs/pr/1373-retire-ebpf-dataplane/README.md"
+	userspaceXDPEntryProgForCanary  = "xdp_userspace_prog"
 )
 
 var legacyDataplaneImportAllowlist = map[string]string{
@@ -65,6 +71,32 @@ var dpdkEBPFImportAllowlist = map[string]string{
 var dpdkBackendImportAllowlist = map[string]string{
 	"cmd/xpfd/main.go": "backend registration and cleanup entry point",
 }
+
+var userspaceShimAllowedMapTypes = map[string]ebpf.MapType{
+	"dnat_table":                 ebpf.Hash,
+	"userspace_bindings":         ebpf.Array,
+	"userspace_cpumap":           ebpf.CPUMap,
+	"userspace_ctrl":             ebpf.Array,
+	"userspace_fallback_stats":   ebpf.Array,
+	"userspace_heartbeat":        ebpf.Array,
+	"userspace_ingress_ifaces":   ebpf.Hash,
+	"userspace_interface_nat_v4": ebpf.Hash,
+	"userspace_interface_nat_v6": ebpf.Hash,
+	"userspace_local_v4":         ebpf.Hash,
+	"userspace_local_v6":         ebpf.Hash,
+	"userspace_sessions":         ebpf.Hash,
+	"userspace_trace":            ebpf.Hash,
+	"userspace_xsk_map":          ebpf.XSKMap,
+}
+
+var userspaceShimAllowedProgramTypes = map[string]ebpf.ProgramType{
+	userspaceXDPEntryProgForCanary: ebpf.XDP,
+}
+
+var (
+	rustMapAnnotationRE = regexp.MustCompile(`#\[\s*map\s*\(\s*name\s*=\s*"([^"]+)"\s*\)\s*\]`)
+	rustXDPFunctionRE   = regexp.MustCompile(`#\[\s*xdp\s*\]\s*(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)`)
+)
 
 func TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports(t *testing.T) {
 	t.Parallel()
@@ -318,6 +350,232 @@ func TestUserspaceShimSharedMapsAreExplicitCompatibilitySet(t *testing.T) {
 	}
 }
 
+func TestUserspaceXDPShimSourceMatchesRetainedObjectAllowlist(t *testing.T) {
+	t.Parallel()
+
+	foundMaps := map[string]string{}
+	foundPrograms := map[string]string{}
+	var forbidden []string
+
+	for _, path := range rustSourceFilesUnder(t, filepath.Join(repoRootForBoundaryCanary, "userspace-xdp", "src")) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read userspace XDP shim source %s: %v", path, err)
+		}
+		text := string(data)
+		rel := repoRelativePath(t, path)
+		for _, token := range []string{
+			"ProgramArray",
+			".tail_call(",
+			"bpf_tail_call",
+		} {
+			if strings.Contains(text, token) {
+				forbidden = append(forbidden, fmt.Sprintf("%s contains %q", rel, token))
+			}
+		}
+		for _, match := range rustMapAnnotationRE.FindAllStringSubmatchIndex(text, -1) {
+			name := text[match[2]:match[3]]
+			foundMaps[name] = fmt.Sprintf("%s at %s:%d", name, rel, lineForOffset(text, match[0]))
+		}
+		for _, match := range rustXDPFunctionRE.FindAllStringSubmatchIndex(text, -1) {
+			name := text[match[2]:match[3]]
+			foundPrograms[name] = fmt.Sprintf("%s at %s:%d", name, rel, lineForOffset(text, match[0]))
+		}
+	}
+
+	unexpectedMaps, missingMaps := compareStringSetToAllowed(foundMaps, keysOfMapTypeAllowlist(userspaceShimAllowedMapTypes))
+	unexpectedPrograms, missingPrograms := compareStringSetToAllowed(foundPrograms, keysOfProgramTypeAllowlist(userspaceShimAllowedProgramTypes))
+	if len(forbidden) > 0 || len(unexpectedMaps) > 0 || len(missingMaps) > 0 ||
+		len(unexpectedPrograms) > 0 || len(missingPrograms) > 0 {
+		sort.Strings(forbidden)
+		sort.Strings(unexpectedMaps)
+		sort.Strings(missingMaps)
+		sort.Strings(unexpectedPrograms)
+		sort.Strings(missingPrograms)
+		t.Fatalf(
+			"userspace XDP shim source allowlist drift\nforbidden tail-call tokens: %v\nunexpected maps: %v\nmissing maps: %v\nunexpected programs: %v\nmissing programs: %v",
+			forbidden,
+			unexpectedMaps,
+			missingMaps,
+			unexpectedPrograms,
+			missingPrograms,
+		)
+	}
+}
+
+func TestUserspaceXDPShimObjectMatchesRetainedCollectionAllowlist(t *testing.T) {
+	t.Parallel()
+
+	spec, err := loadRustUserspaceXDP()
+	if err != nil {
+		t.Fatalf("load userspace XDP shim object: %v", err)
+	}
+
+	foundMaps := map[string]string{}
+	var wrongMaps []string
+	for name, mapSpec := range spec.Maps {
+		foundMaps[name] = name
+		if want, ok := userspaceShimAllowedMapTypes[name]; ok && mapSpec.Type != want {
+			wrongMaps = append(wrongMaps, fmt.Sprintf("%s type %s, want %s", name, mapSpec.Type, want))
+		}
+	}
+	foundPrograms := map[string]string{}
+	var wrongPrograms []string
+	for name, programSpec := range spec.Programs {
+		foundPrograms[name] = name
+		if want, ok := userspaceShimAllowedProgramTypes[name]; ok && programSpec.Type != want {
+			wrongPrograms = append(wrongPrograms, fmt.Sprintf("%s type %s, want %s", name, programSpec.Type, want))
+		}
+	}
+
+	unexpectedMaps, missingMaps := compareStringSetToAllowed(foundMaps, keysOfMapTypeAllowlist(userspaceShimAllowedMapTypes))
+	unexpectedPrograms, missingPrograms := compareStringSetToAllowed(foundPrograms, keysOfProgramTypeAllowlist(userspaceShimAllowedProgramTypes))
+	if len(wrongMaps) > 0 || len(unexpectedMaps) > 0 || len(missingMaps) > 0 ||
+		len(wrongPrograms) > 0 || len(unexpectedPrograms) > 0 || len(missingPrograms) > 0 {
+		sort.Strings(wrongMaps)
+		sort.Strings(unexpectedMaps)
+		sort.Strings(missingMaps)
+		sort.Strings(wrongPrograms)
+		sort.Strings(unexpectedPrograms)
+		sort.Strings(missingPrograms)
+		t.Fatalf(
+			"userspace XDP shim object allowlist drift\nwrong map types: %v\nunexpected maps: %v\nmissing maps: %v\nwrong program types: %v\nunexpected programs: %v\nmissing programs: %v",
+			wrongMaps,
+			unexpectedMaps,
+			missingMaps,
+			wrongPrograms,
+			unexpectedPrograms,
+			missingPrograms,
+		)
+	}
+}
+
+func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	for _, path := range productionGoFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	}) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for i, lhs := range node.Lhs {
+					if !isXDPEntryProgField(lhs) {
+						continue
+					}
+					var rhs ast.Expr
+					if len(node.Rhs) == len(node.Lhs) {
+						rhs = node.Rhs[i]
+					}
+					if !isUserspaceXDPEntryProgExpr(rhs) {
+						pos := fset.Position(lhs.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d assigns XDPEntryProg from %q",
+							repoRelativePath(t, path),
+							pos.Line,
+							canaryExprString(rhs),
+						))
+					}
+				}
+			case *ast.CompositeLit:
+				for _, elt := range node.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok || !isXDPEntryProgField(kv.Key) {
+						continue
+					}
+					if !isUserspaceXDPEntryProgExpr(kv.Value) {
+						pos := fset.Position(kv.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d initializes XDPEntryProg from %q",
+							repoRelativePath(t, path),
+							pos.Line,
+							canaryExprString(kv.Value),
+						))
+					}
+				}
+			case *ast.CallExpr:
+				sel, ok := node.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "SwapXDPEntryProg" {
+					return true
+				}
+				if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
+					var got string
+					if len(node.Args) == 1 {
+						got = canaryExprString(node.Args[0])
+					}
+					pos := fset.Position(node.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d calls SwapXDPEntryProg with %q",
+						repoRelativePath(t, path),
+						pos.Line,
+						got,
+					))
+				}
+			}
+			return true
+		})
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("userspace manager production code must only select userspaceXDPEntryProg: %v", violations)
+	}
+}
+
+func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
+	t.Parallel()
+
+	var found []string
+	var violations []string
+	for _, path := range productionGoFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	}) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			valueSpec, ok := n.(*ast.ValueSpec)
+			if !ok {
+				return true
+			}
+			for i, name := range valueSpec.Names {
+				if name.Name != "userspaceXDPEntryProg" {
+					continue
+				}
+				pos := fset.Position(name.Pos())
+				location := fmt.Sprintf("%s:%d", repoRelativePath(t, path), pos.Line)
+				found = append(found, location)
+				if len(valueSpec.Values) != len(valueSpec.Names) {
+					violations = append(violations, location+" uses implicit or tuple value")
+					continue
+				}
+				lit, ok := valueSpec.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING || lit.Value != strconv.Quote(userspaceXDPEntryProgForCanary) {
+					violations = append(violations, fmt.Sprintf(
+						"%s sets userspaceXDPEntryProg to %q, want %q",
+						location,
+						canaryExprString(valueSpec.Values[i]),
+						userspaceXDPEntryProgForCanary,
+					))
+				}
+			}
+			return true
+		})
+	}
+	if len(found) != 1 || len(violations) > 0 {
+		sort.Strings(found)
+		sort.Strings(violations)
+		t.Fatalf("userspaceXDPEntryProg constant drift\nfound: %v\nviolations: %v", found, violations)
+	}
+}
+
 func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
 	t.Parallel()
 
@@ -447,6 +705,84 @@ func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
 	if len(missing) > 0 {
 		t.Fatalf("retirement docs do not mention allowlisted legacy imports: %v", missing)
 	}
+}
+
+func rustSourceFilesUnder(t *testing.T, root string) []string {
+	t.Helper()
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".rs") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk Rust source under %s: %v", root, err)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func compareStringSetToAllowed(found map[string]string, allowed map[string]bool) ([]string, []string) {
+	var unexpected []string
+	for name, location := range found {
+		if !allowed[name] {
+			unexpected = append(unexpected, location)
+		}
+	}
+	var missing []string
+	for name := range allowed {
+		if _, ok := found[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return unexpected, missing
+}
+
+func keysOfMapTypeAllowlist(values map[string]ebpf.MapType) map[string]bool {
+	keys := make(map[string]bool, len(values))
+	for name := range values {
+		keys[name] = true
+	}
+	return keys
+}
+
+func keysOfProgramTypeAllowlist(values map[string]ebpf.ProgramType) map[string]bool {
+	keys := make(map[string]bool, len(values))
+	for name := range values {
+		keys[name] = true
+	}
+	return keys
+}
+
+func lineForOffset(text string, offset int) int {
+	if offset > len(text) {
+		offset = len(text)
+	}
+	return strings.Count(text[:offset], "\n") + 1
+}
+
+func isXDPEntryProgField(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "XDPEntryProg"
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "XDPEntryProg"
+	default:
+		return false
+	}
+}
+
+func isUserspaceXDPEntryProgExpr(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "userspaceXDPEntryProg"
 }
 
 func operatorRuntimeBoundaryRoots(t *testing.T) []string {
@@ -673,6 +1009,8 @@ func canaryExprString(expr ast.Expr) string {
 		return canaryExprString(e.X) + "." + e.Sel.Name
 	case *ast.StarExpr:
 		return "*" + canaryExprString(e.X)
+	case *ast.BasicLit:
+		return e.Value
 	default:
 		return ""
 	}

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -772,7 +772,52 @@ func jsonBypass(m *manager) {
 	_ = json.Unmarshal([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim)
 }
 `,
-			want: []string{"json.Unmarshal into bpfShim"},
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_dot_import_unmarshal_bpf_shim",
+			body: `
+package userspace
+
+import . "encoding/json"
+
+func jsonDotImportBypass(m *manager) {
+	_ = Unmarshal([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_new_decoder_decode_bpf_shim",
+			body: `
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func jsonDecoderBypass(m *manager) {
+	_ = json.NewDecoder(strings.NewReader(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `)).Decode(m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_dot_import_new_decoder_decode_bpf_shim",
+			body: `
+package userspace
+
+import (
+	. "encoding/json"
+	"strings"
+)
+
+func jsonDotDecoderBypass(m *manager) {
+	_ = NewDecoder(strings.NewReader(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `)).Decode(m.bpfShim)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
 		},
 		{
 			name: "reflection_field_name",
@@ -876,7 +921,12 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 	for _, parsed := range files {
 		rel := repoRelativePath(t, parsed.path)
 		parents := astParentMap(parsed.file)
-		jsonImports := importNamesForPath(parsed.file, "encoding/json")
+		jsonImports, jsonDotImport := importNamesForPath(parsed.file, "encoding/json")
+		jsonV2Imports, jsonV2DotImport := importNamesForPath(parsed.file, "encoding/json/v2")
+		for name := range jsonV2Imports {
+			jsonImports[name] = true
+		}
+		jsonDotImport = jsonDotImport || jsonV2DotImport
 		ast.Inspect(parsed.file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.AssignStmt:
@@ -915,10 +965,10 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 					}
 				}
 			case *ast.CallExpr:
-				if isJSONUnmarshalIntoBPFShim(node, jsonImports) {
+				if isJSONDecoderIntoBPFShim(node, jsonImports, jsonDotImport) {
 					pos := fset.Position(node.Pos())
 					violations = append(violations, fmt.Sprintf(
-						"%s:%d json.Unmarshal into bpfShim can mutate XDPEntryProg",
+						"%s:%d encoding/json decode into bpfShim can mutate XDPEntryProg",
 						rel,
 						pos.Line,
 					))
@@ -1105,14 +1155,18 @@ func astParentMap(root ast.Node) map[ast.Node]ast.Node {
 	return parents
 }
 
-func importNamesForPath(file *ast.File, importPath string) map[string]bool {
+func importNamesForPath(file *ast.File, importPath string) (map[string]bool, bool) {
 	names := map[string]bool{}
+	dotImport := false
 	for _, imp := range file.Imports {
 		path, err := strconv.Unquote(imp.Path.Value)
 		if err != nil || path != importPath {
 			continue
 		}
 		if imp.Name != nil {
+			if imp.Name.Name == "." {
+				dotImport = true
+			}
 			if imp.Name.Name != "_" && imp.Name.Name != "." {
 				names[imp.Name.Name] = true
 			}
@@ -1120,7 +1174,7 @@ func importNamesForPath(file *ast.File, importPath string) map[string]bool {
 		}
 		names[defaultImportName(importPath)] = true
 	}
-	return names
+	return names, dotImport
 }
 
 func defaultImportName(importPath string) string {
@@ -1281,19 +1335,55 @@ func containsXDPEntryProgField(expr ast.Expr) bool {
 	return containsExpr(expr, isXDPEntryProgField)
 }
 
-func isJSONUnmarshalIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool) bool {
-	if len(jsonImports) == 0 || len(call.Args) < 2 {
+func isJSONDecoderIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool, jsonDotImport bool) bool {
+	if (len(jsonImports) == 0 && !jsonDotImport) || len(call.Args) == 0 {
 		return false
 	}
-	sel, ok := unparenExpr(call.Fun).(*ast.SelectorExpr)
-	if !ok || sel.Sel.Name != "Unmarshal" {
+
+	switch fun := unparenExpr(call.Fun).(type) {
+	case *ast.SelectorExpr:
+		switch fun.Sel.Name {
+		case "Unmarshal":
+			if len(call.Args) < 2 {
+				return false
+			}
+			pkg, ok := unparenExpr(fun.X).(*ast.Ident)
+			if !ok || !jsonImports[pkg.Name] {
+				return false
+			}
+			return containsBPFShimSelector(call.Args[1])
+		case "Decode":
+			if len(call.Args) != 1 {
+				return false
+			}
+			if !isJSONNewDecoderCall(fun.X, jsonImports, jsonDotImport) {
+				return false
+			}
+			return containsBPFShimSelector(call.Args[0])
+		}
+	case *ast.Ident:
+		if !jsonDotImport || fun.Name != "Unmarshal" || len(call.Args) < 2 {
+			return false
+		}
+		return containsBPFShimSelector(call.Args[1])
+	}
+	return false
+}
+
+func isJSONNewDecoderCall(expr ast.Expr, jsonImports map[string]bool, jsonDotImport bool) bool {
+	call, ok := unparenExpr(expr).(*ast.CallExpr)
+	if !ok {
 		return false
 	}
-	pkg, ok := unparenExpr(sel.X).(*ast.Ident)
-	if !ok || !jsonImports[pkg.Name] {
+	switch fun := unparenExpr(call.Fun).(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := unparenExpr(fun.X).(*ast.Ident)
+		return ok && fun.Sel.Name == "NewDecoder" && jsonImports[pkg.Name]
+	case *ast.Ident:
+		return jsonDotImport && fun.Name == "NewDecoder"
+	default:
 		return false
 	}
-	return containsBPFShimSelector(call.Args[1])
 }
 
 func containsBPFShimSelector(expr ast.Expr) bool {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -161,6 +161,7 @@ func TestOperatorPackagesDoNotImportBPFArtifactsDirectly(t *testing.T) {
 func TestDPDKBackendImportStaysBackendLocal(t *testing.T) {
 	t.Parallel()
 
+	found := map[string]bool{}
 	var violations []string
 	for _, path := range productionGoFilesUnder(t, []string{
 		filepath.Join(repoRootForBoundaryCanary, "cmd"),
@@ -170,19 +171,32 @@ func TestDPDKBackendImportStaysBackendLocal(t *testing.T) {
 		if strings.HasPrefix(rel, "pkg/dataplane/dpdk/") {
 			continue
 		}
-		if _, ok := dpdkBackendImportAllowlist[rel]; ok {
-			continue
-		}
 		for _, imp := range importPaths(t, path) {
 			if imp == dpdkBackendImportForCanary || strings.HasPrefix(imp, dpdkBackendImportForCanary+"/") {
-				violations = append(violations, rel+" imports "+imp)
+				if _, ok := dpdkBackendImportAllowlist[rel]; ok {
+					found[rel] = true
+				} else {
+					violations = append(violations, rel+" imports "+imp)
+				}
 			}
 		}
 	}
 
-	if len(violations) > 0 {
+	var stale []string
+	for rel := range dpdkBackendImportAllowlist {
+		if !found[rel] {
+			stale = append(stale, rel)
+		}
+	}
+
+	if len(violations) > 0 || len(stale) > 0 {
 		sort.Strings(violations)
-		t.Fatalf("DPDK backend imports must stay limited to pkg/dataplane/dpdk and cmd/xpfd registration: %v", violations)
+		sort.Strings(stale)
+		t.Fatalf(
+			"DPDK backend import allowlist drift\nunexpected imports: %v\nstale allowlist entries: %v",
+			violations,
+			stale,
+		)
 	}
 }
 
@@ -453,18 +467,25 @@ func TestUserspaceXDPShimObjectMatchesRetainedCollectionAllowlist(t *testing.T) 
 func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	t.Parallel()
 
-	var violations []string
-	for _, path := range productionGoFilesUnder(t, []string{
+	fset, files := productionGoPackageFilesUnder(t, []string{
 		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
-	}) {
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
-		}
-		ast.Inspect(file, func(n ast.Node) bool {
+	})
+	var violations []string
+	for _, parsed := range files {
+		rel := repoRelativePath(t, parsed.path)
+		ast.Inspect(parsed.file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.AssignStmt:
+				for _, rhs := range node.Rhs {
+					if containsSwapXDPEntryProgMethodValue(rhs) {
+						pos := fset.Position(rhs.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d captures SwapXDPEntryProg method value",
+							rel,
+							pos.Line,
+						))
+					}
+				}
 				for i, lhs := range node.Lhs {
 					if !isXDPEntryProgField(lhs) {
 						continue
@@ -477,7 +498,7 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 						pos := fset.Position(lhs.Pos())
 						violations = append(violations, fmt.Sprintf(
 							"%s:%d assigns XDPEntryProg from %q",
-							repoRelativePath(t, path),
+							rel,
 							pos.Line,
 							canaryExprString(rhs),
 						))
@@ -493,28 +514,69 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 						pos := fset.Position(kv.Pos())
 						violations = append(violations, fmt.Sprintf(
 							"%s:%d initializes XDPEntryProg from %q",
-							repoRelativePath(t, path),
+							rel,
 							pos.Line,
 							canaryExprString(kv.Value),
 						))
 					}
 				}
+			case *ast.ValueSpec:
+				for _, value := range node.Values {
+					if containsSwapXDPEntryProgMethodValue(value) {
+						pos := fset.Position(value.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d stores SwapXDPEntryProg method value",
+							rel,
+							pos.Line,
+						))
+					}
+				}
 			case *ast.CallExpr:
 				sel, ok := node.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "SwapXDPEntryProg" {
+				if ok && sel.Sel.Name == "SwapXDPEntryProg" {
+					if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
+						var got string
+						if len(node.Args) == 1 {
+							got = canaryExprString(node.Args[0])
+						}
+						pos := fset.Position(node.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d calls SwapXDPEntryProg with %q",
+							rel,
+							pos.Line,
+							got,
+						))
+					}
 					return true
 				}
-				if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
-					var got string
-					if len(node.Args) == 1 {
-						got = canaryExprString(node.Args[0])
+				for _, arg := range node.Args {
+					if containsSwapXDPEntryProgMethodValue(arg) {
+						pos := fset.Position(arg.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d passes SwapXDPEntryProg method value",
+							rel,
+							pos.Line,
+						))
 					}
+				}
+			case *ast.ReturnStmt:
+				for _, result := range node.Results {
+					if containsSwapXDPEntryProgMethodValue(result) {
+						pos := fset.Position(result.Pos())
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d returns SwapXDPEntryProg method value",
+							rel,
+							pos.Line,
+						))
+					}
+				}
+			case *ast.UnaryExpr:
+				if node.Op == token.AND && containsXDPEntryProgField(node.X) {
 					pos := fset.Position(node.Pos())
 					violations = append(violations, fmt.Sprintf(
-						"%s:%d calls SwapXDPEntryProg with %q",
-						repoRelativePath(t, path),
+						"%s:%d takes XDPEntryProg address",
+						rel,
 						pos.Line,
-						got,
 					))
 				}
 			}
@@ -530,17 +592,13 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 	t.Parallel()
 
+	fset, files := productionGoPackageFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	})
 	var found []string
 	var violations []string
-	for _, path := range productionGoFilesUnder(t, []string{
-		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
-	}) {
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
-		}
-		ast.Inspect(file, func(n ast.Node) bool {
+	for _, parsed := range files {
+		ast.Inspect(parsed.file, func(n ast.Node) bool {
 			valueSpec, ok := n.(*ast.ValueSpec)
 			if !ok {
 				return true
@@ -550,7 +608,7 @@ func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 					continue
 				}
 				pos := fset.Position(name.Pos())
-				location := fmt.Sprintf("%s:%d", repoRelativePath(t, path), pos.Line)
+				location := fmt.Sprintf("%s:%d", repoRelativePath(t, parsed.path), pos.Line)
 				found = append(found, location)
 				if len(valueSpec.Values) != len(valueSpec.Names) {
 					violations = append(violations, location+" uses implicit or tuple value")
@@ -707,6 +765,33 @@ func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
 	}
 }
 
+type canaryParsedGoFile struct {
+	path string
+	file *ast.File
+}
+
+func productionGoPackageFilesUnder(t *testing.T, roots []string) (*token.FileSet, []canaryParsedGoFile) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	packageFiles := map[string]*ast.File{}
+	var files []canaryParsedGoFile
+	for _, path := range productionGoFilesUnder(t, roots) {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		packageFiles[path] = file
+		files = append(files, canaryParsedGoFile{path: path, file: file})
+	}
+	// NewPackage resolves same-package identifiers across files. It also reports
+	// unrelated predeclared/imported identifiers because this canary does not
+	// provide a full importer or universe scope, so the error is intentionally
+	// ignored after the resolver has linked package-level objects.
+	_, _ = ast.NewPackage(fset, packageFiles, nil, nil)
+	return fset, files
+}
+
 func rustSourceFilesUnder(t *testing.T, root string) []string {
 	t.Helper()
 
@@ -785,10 +870,64 @@ func isUserspaceXDPEntryProgExpr(expr ast.Expr) bool {
 	if !ok || ident.Name != "userspaceXDPEntryProg" {
 		return false
 	}
-	if ident.Obj == nil {
-		return true
+	return ident.Obj != nil && ident.Obj.Kind == ast.Con
+}
+
+func containsXDPEntryProgField(expr ast.Expr) bool {
+	return containsExpr(expr, isXDPEntryProgField)
+}
+
+func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
+	if expr == nil {
+		return false
 	}
-	return ident.Obj.Kind == ast.Con
+	var found bool
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "SwapXDPEntryProg" {
+				for _, arg := range node.Args {
+					if containsSwapXDPEntryProgMethodValue(arg) {
+						found = true
+						return false
+					}
+				}
+				return false
+			}
+		case *ast.SelectorExpr:
+			if node.Sel.Name == "SwapXDPEntryProg" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func containsExpr(expr ast.Expr, match func(ast.Expr) bool) bool {
+	if expr == nil {
+		return false
+	}
+	var found bool
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		expr, ok := n.(ast.Expr)
+		if !ok {
+			return true
+		}
+		if match(expr) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func operatorRuntimeBoundaryRoots(t *testing.T) []string {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -94,7 +94,7 @@ var userspaceShimAllowedProgramTypes = map[string]ebpf.ProgramType{
 }
 
 var (
-	rustMapAnnotationRE = regexp.MustCompile(`#\[\s*map\s*\(\s*name\s*=\s*"([^"]+)"\s*\)\s*\]`)
+	rustMapAnnotationRE = regexp.MustCompile(`#\[\s*map\s*\([^)]*\bname\s*=\s*"([^"]+)"[^)]*\)\s*\]`)
 	rustXDPFunctionRE   = regexp.MustCompile(`#\[\s*xdp\s*\]\s*(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)`)
 )
 
@@ -467,9 +467,201 @@ func TestUserspaceXDPShimObjectMatchesRetainedCollectionAllowlist(t *testing.T) 
 func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	t.Parallel()
 
-	fset, files := productionGoPackageFilesUnder(t, []string{
+	violations := userspaceXDPEntryProgramViolations(t, []string{
 		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
 	})
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("userspace manager production code must only select userspaceXDPEntryProg: %v", violations)
+	}
+}
+
+func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
+	t.Parallel()
+
+	found, violations := userspaceXDPEntryProgramConstantDrift(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	})
+	if len(found) != 1 || len(violations) > 0 {
+		sort.Strings(found)
+		sort.Strings(violations)
+		t.Fatalf("userspaceXDPEntryProg constant drift\nfound: %v\nviolations: %v", found, violations)
+	}
+}
+
+func TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture(t *testing.T) {
+	t.Parallel()
+
+	root := writeUserspaceEntryProgramFixture(t, map[string]string{
+		"const.go": `
+package userspace
+
+const userspaceXDPEntryProg = "xdp_userspace_prog"
+
+type shim struct { XDPEntryProg string }
+func (s *shim) SwapXDPEntryProg(name string) error { return nil }
+type manager struct { bpfShim *shim }
+`,
+		"use.go": `
+package userspace
+
+func valid(m *manager) {
+	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	_ = m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg)
+}
+`,
+	})
+
+	if got := userspaceXDPEntryProgramViolations(t, []string{root}); len(got) > 0 {
+		t.Fatalf("valid cross-file constant fixture produced violations: %v", got)
+	}
+	found, drift := userspaceXDPEntryProgramConstantDrift(t, []string{root})
+	if len(found) != 1 || len(drift) > 0 {
+		t.Fatalf("valid cross-file constant drift\nfound: %v\nviolations: %v", found, drift)
+	}
+}
+
+func TestUserspaceEntryProgramCanaryRejectsBypassFixtures(t *testing.T) {
+	t.Parallel()
+
+	root := writeUserspaceEntryProgramFixture(t, map[string]string{
+		"base.go": `
+package userspace
+
+const userspaceXDPEntryProg = "xdp_userspace_prog"
+
+type shim struct { XDPEntryProg string }
+func (s *shim) SwapXDPEntryProg(name string) error { return nil }
+type manager struct { bpfShim *shim }
+func consume(v interface{}) {}
+`,
+		"bypass.go": `
+package userspace
+
+func literalAssign(m *manager) {
+	m.bpfShim.XDPEntryProg = "xdp_main_prog"
+}
+
+func shadowedConstName(m *manager) {
+	userspaceXDPEntryProg := "xdp_main_prog"
+	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+}
+
+func pointerAlias(m *manager) {
+	p := &m.bpfShim.XDPEntryProg
+	_ = p
+}
+
+func methodValueCapture(m *manager) {
+	swap := m.bpfShim.SwapXDPEntryProg
+	_ = swap
+}
+
+func methodValuePass(m *manager) {
+	consume(m.bpfShim.SwapXDPEntryProg)
+}
+
+func methodValueReturn(m *manager) func(string) error {
+	return m.bpfShim.SwapXDPEntryProg
+}
+
+func directBadCall(m *manager) {
+	_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
+}
+
+func reflectionName() {
+	_ = "XDPEntryProg"
+}
+`,
+	})
+
+	violations := userspaceXDPEntryProgramViolations(t, []string{root})
+	assertCanaryViolationsContain(t, violations, []string{
+		"assigns XDPEntryProg from",
+		"xdp_main_prog",
+		"assigns XDPEntryProg from \"userspaceXDPEntryProg\"",
+		"takes XDPEntryProg address",
+		"captures SwapXDPEntryProg method value",
+		"passes SwapXDPEntryProg method value",
+		"returns SwapXDPEntryProg method value",
+		"calls SwapXDPEntryProg with",
+		"uses XDPEntryProg string literal",
+	})
+}
+
+func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
+	t.Parallel()
+
+	assertDaemonDPFieldIsRuntimeDataPlane(t)
+
+	daemonRun := filepath.Join("..", "daemon", "daemon_run.go")
+	if hasDaemonRuntimeConstructorCall(t, daemonRun, "NewDataPlane") {
+		t.Fatal("daemon runtime startup must call NewRuntimeDataPlane, not NewDataPlane")
+	}
+	if !hasDaemonRuntimeConstructorCall(t, daemonRun, "NewRuntimeDataPlane") {
+		t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")
+	}
+}
+
+func TestRetirementBoundaryDocsMentionDPDKPolicy(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
+	if err != nil {
+		t.Fatalf("read retirement boundary docs: %v", err)
+	}
+	text := string(data)
+
+	want := []string{
+		"## #1475 DPDK Backend Policy",
+		"DPDK remains a separately supported backend",
+		"outside the eBPF source-removal path",
+		"`pkg/dataplane/dpdk`",
+		"`cmd/xpfd/main.go`",
+		"`-tags dpdk`",
+		"root `DataPlane`",
+	}
+	var missing []string
+	for _, token := range want {
+		if !strings.Contains(text, token) {
+			missing = append(missing, token)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("retirement docs do not mention DPDK policy tokens: %v", missing)
+	}
+}
+
+func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
+	if err != nil {
+		t.Fatalf("read retirement boundary docs: %v", err)
+	}
+	text := string(data)
+
+	var missing []string
+	for rel := range legacyDataplaneImportAllowlist {
+		if !strings.Contains(text, rel) {
+			missing = append(missing, rel)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("retirement docs do not mention allowlisted legacy imports: %v", missing)
+	}
+}
+
+type canaryParsedGoFile struct {
+	path string
+	file *ast.File
+}
+
+func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
+	t.Helper()
+
+	fset, files := productionGoPackageFilesUnder(t, roots)
 	var violations []string
 	for _, parsed := range files {
 		rel := repoRelativePath(t, parsed.path)
@@ -579,22 +771,31 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 						pos.Line,
 					))
 				}
+			case *ast.BasicLit:
+				if node.Kind != token.STRING {
+					return true
+				}
+				value, err := strconv.Unquote(node.Value)
+				if err == nil && value == "XDPEntryProg" {
+					pos := fset.Position(node.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d uses XDPEntryProg string literal",
+						rel,
+						pos.Line,
+					))
+				}
 			}
 			return true
 		})
 	}
-	if len(violations) > 0 {
-		sort.Strings(violations)
-		t.Fatalf("userspace manager production code must only select userspaceXDPEntryProg: %v", violations)
-	}
+	sort.Strings(violations)
+	return violations
 }
 
-func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
-	t.Parallel()
+func userspaceXDPEntryProgramConstantDrift(t *testing.T, roots []string) ([]string, []string) {
+	t.Helper()
 
-	fset, files := productionGoPackageFilesUnder(t, []string{
-		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
-	})
+	fset, files := productionGoPackageFilesUnder(t, roots)
 	var found []string
 	var violations []string
 	for _, parsed := range files {
@@ -627,25 +828,9 @@ func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 			return true
 		})
 	}
-	if len(found) != 1 || len(violations) > 0 {
-		sort.Strings(found)
-		sort.Strings(violations)
-		t.Fatalf("userspaceXDPEntryProg constant drift\nfound: %v\nviolations: %v", found, violations)
-	}
-}
-
-func TestDaemonRuntimeEntryPointUsesRuntimeDataPlane(t *testing.T) {
-	t.Parallel()
-
-	assertDaemonDPFieldIsRuntimeDataPlane(t)
-
-	daemonRun := filepath.Join("..", "daemon", "daemon_run.go")
-	if hasDaemonRuntimeConstructorCall(t, daemonRun, "NewDataPlane") {
-		t.Fatal("daemon runtime startup must call NewRuntimeDataPlane, not NewDataPlane")
-	}
-	if !hasDaemonRuntimeConstructorCall(t, daemonRun, "NewRuntimeDataPlane") {
-		t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")
-	}
+	sort.Strings(found)
+	sort.Strings(violations)
+	return found, violations
 }
 
 func compilerDataplaneCalls(t *testing.T) map[string]bool {
@@ -715,61 +900,6 @@ func receiverTypeName(expr ast.Expr) string {
 	}
 }
 
-func TestRetirementBoundaryDocsMentionDPDKPolicy(t *testing.T) {
-	t.Parallel()
-
-	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
-	if err != nil {
-		t.Fatalf("read retirement boundary docs: %v", err)
-	}
-	text := string(data)
-
-	want := []string{
-		"## #1475 DPDK Backend Policy",
-		"DPDK remains a separately supported backend",
-		"outside the eBPF source-removal path",
-		"`pkg/dataplane/dpdk`",
-		"`cmd/xpfd/main.go`",
-		"`-tags dpdk`",
-		"root `DataPlane`",
-	}
-	var missing []string
-	for _, token := range want {
-		if !strings.Contains(text, token) {
-			missing = append(missing, token)
-		}
-	}
-	if len(missing) > 0 {
-		t.Fatalf("retirement docs do not mention DPDK policy tokens: %v", missing)
-	}
-}
-
-func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
-	t.Parallel()
-
-	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
-	if err != nil {
-		t.Fatalf("read retirement boundary docs: %v", err)
-	}
-	text := string(data)
-
-	var missing []string
-	for rel := range legacyDataplaneImportAllowlist {
-		if !strings.Contains(text, rel) {
-			missing = append(missing, rel)
-		}
-	}
-	sort.Strings(missing)
-	if len(missing) > 0 {
-		t.Fatalf("retirement docs do not mention allowlisted legacy imports: %v", missing)
-	}
-}
-
-type canaryParsedGoFile struct {
-	path string
-	file *ast.File
-}
-
 func productionGoPackageFilesUnder(t *testing.T, roots []string) (*token.FileSet, []canaryParsedGoFile) {
 	t.Helper()
 
@@ -784,12 +914,67 @@ func productionGoPackageFilesUnder(t *testing.T, roots []string) (*token.FileSet
 		packageFiles[path] = file
 		files = append(files, canaryParsedGoFile{path: path, file: file})
 	}
-	// NewPackage resolves same-package identifiers across files. It also reports
-	// unrelated predeclared/imported identifiers because this canary does not
-	// provide a full importer or universe scope, so the error is intentionally
-	// ignored after the resolver has linked package-level objects.
-	_, _ = ast.NewPackage(fset, packageFiles, nil, nil)
+	resolveUserspaceXDPEntryProgramIdents(packageFiles)
 	return fset, files
+}
+
+func resolveUserspaceXDPEntryProgramIdents(files map[string]*ast.File) {
+	var packageConst *ast.Object
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range valueSpec.Names {
+					if name.Name == "userspaceXDPEntryProg" && name.Obj != nil && name.Obj.Kind == ast.Con {
+						packageConst = name.Obj
+					}
+				}
+			}
+		}
+	}
+	if packageConst == nil {
+		return
+	}
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if ok && ident.Name == "userspaceXDPEntryProg" && ident.Obj == nil {
+				ident.Obj = packageConst
+			}
+			return true
+		})
+	}
+}
+
+func writeUserspaceEntryProgramFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, []byte(strings.TrimSpace(body)+"\n"), 0o644); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+func assertCanaryViolationsContain(t *testing.T, violations []string, want []string) {
+	t.Helper()
+
+	joined := strings.Join(violations, "\n")
+	for _, needle := range want {
+		if !strings.Contains(joined, needle) {
+			t.Fatalf("violations missing %q\nall violations:\n%s", needle, joined)
+		}
+	}
 }
 
 func rustSourceFilesUnder(t *testing.T, root string) []string {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -481,10 +481,10 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 func TestBPFShimEntryProgramStateIsNotJSONMutable(t *testing.T) {
 	t.Parallel()
 
-	if userspaceShimXDPEntryProg != userspaceXDPEntryProgForCanary {
+	if userspaceShimEntryProg != userspaceXDPEntryProgForCanary {
 		t.Fatalf(
 			"userspace shim entry-program constant = %q, want %q",
-			userspaceShimXDPEntryProg,
+			userspaceShimEntryProg,
 			userspaceXDPEntryProgForCanary,
 		)
 	}

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -820,6 +820,37 @@ func jsonDotDecoderBypass(m *manager) {
 			want: []string{"encoding/json decode into bpfShim"},
 		},
 		{
+			name: "json_unmarshal_alias_bpf_shim",
+			body: `
+package userspace
+
+import "encoding/json"
+
+func jsonUnmarshalAliasBypass(m *manager) {
+	alias := m.bpfShim
+	_ = json.Unmarshal([]byte(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `), alias)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
+			name: "json_new_decoder_alias_bpf_shim",
+			body: `
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func jsonDecodeAliasBypass(m *manager) {
+	alias := m.bpfShim
+	_ = json.NewDecoder(strings.NewReader(` + "`{\"XDPEntryProg\":\"xdp_bypassed\"}`" + `)).Decode(alias)
+}
+`,
+			want: []string{"encoding/json decode into bpfShim"},
+		},
+		{
 			name: "reflection_field_name",
 			body: `
 package userspace
@@ -1351,7 +1382,7 @@ func isJSONDecoderIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool, j
 			if !ok || !jsonImports[pkg.Name] {
 				return false
 			}
-			return containsBPFShimSelector(call.Args[1])
+			return containsBPFShimReference(call.Args[1])
 		case "Decode":
 			if len(call.Args) != 1 {
 				return false
@@ -1359,13 +1390,13 @@ func isJSONDecoderIntoBPFShim(call *ast.CallExpr, jsonImports map[string]bool, j
 			if !isJSONNewDecoderCall(fun.X, jsonImports, jsonDotImport) {
 				return false
 			}
-			return containsBPFShimSelector(call.Args[0])
+			return containsBPFShimReference(call.Args[0])
 		}
 	case *ast.Ident:
 		if !jsonDotImport || fun.Name != "Unmarshal" || len(call.Args) < 2 {
 			return false
 		}
-		return containsBPFShimSelector(call.Args[1])
+		return containsBPFShimReference(call.Args[1])
 	}
 	return false
 }
@@ -1391,6 +1422,79 @@ func containsBPFShimSelector(expr ast.Expr) bool {
 		sel, ok := e.(*ast.SelectorExpr)
 		return ok && sel.Sel.Name == "bpfShim"
 	})
+}
+
+func containsBPFShimReference(expr ast.Expr) bool {
+	return containsBPFShimReferenceExpr(expr, map[*ast.Object]bool{})
+}
+
+func containsBPFShimReferenceExpr(expr ast.Expr, seen map[*ast.Object]bool) bool {
+	if expr == nil {
+		return false
+	}
+	if containsBPFShimSelector(expr) {
+		return true
+	}
+
+	switch e := unparenExpr(expr).(type) {
+	case *ast.Ident:
+		return containsBPFShimFromIdent(e, seen)
+	case *ast.SelectorExpr:
+		return containsBPFShimReferenceExpr(e.X, seen)
+	case *ast.StarExpr:
+		return containsBPFShimReferenceExpr(e.X, seen)
+	case *ast.UnaryExpr:
+		return containsBPFShimReferenceExpr(e.X, seen)
+	case *ast.IndexExpr:
+		return containsBPFShimReferenceExpr(e.X, seen) || containsBPFShimReferenceExpr(e.Index, seen)
+	case *ast.IndexListExpr:
+		if containsBPFShimReferenceExpr(e.X, seen) {
+			return true
+		}
+		for _, idx := range e.Indices {
+			if containsBPFShimReferenceExpr(idx, seen) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func containsBPFShimFromIdent(ident *ast.Ident, seen map[*ast.Object]bool) bool {
+	if ident == nil || ident.Obj == nil {
+		return false
+	}
+	obj := ident.Obj
+	if seen[obj] {
+		return false
+	}
+	seen[obj] = true
+	defer delete(seen, obj)
+
+	switch decl := obj.Decl.(type) {
+	case *ast.AssignStmt:
+		if len(decl.Rhs) != len(decl.Lhs) {
+			return false
+		}
+		for i, lhs := range decl.Lhs {
+			lhsIdent, ok := lhs.(*ast.Ident)
+			if ok && lhsIdent.Obj == obj {
+				return containsBPFShimReferenceExpr(decl.Rhs[i], seen)
+			}
+		}
+	case *ast.ValueSpec:
+		if len(decl.Values) != len(decl.Names) {
+			return false
+		}
+		for i, name := range decl.Names {
+			if name.Obj == obj {
+				return containsBPFShimReferenceExpr(decl.Values[i], seen)
+			}
+		}
+	}
+
+	return false
 }
 
 func swapXDPEntryProgSelectorViolation(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node, fset *token.FileSet, rel string) string {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -476,6 +476,27 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	}
 }
 
+func TestUserspaceManagerAvoidsReflectionAndUnsafeMutationEscapes(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	for _, path := range productionGoFilesUnder(t, []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	}) {
+		rel := repoRelativePath(t, path)
+		for _, imp := range importPaths(t, path) {
+			switch imp {
+			case "reflect", "unsafe":
+				violations = append(violations, rel+" imports "+imp)
+			}
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("userspace production code must not use reflection/unsafe to bypass entry-program canaries: %v", violations)
+	}
+}
+
 func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 	t.Parallel()
 
@@ -508,6 +529,7 @@ package userspace
 func valid(m *manager) {
 	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
 	_ = m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg)
+	_ = (m.bpfShim.SwapXDPEntryProg)(userspaceXDPEntryProg)
 }
 `,
 	})
@@ -524,8 +546,7 @@ func valid(m *manager) {
 func TestUserspaceEntryProgramCanaryRejectsBypassFixtures(t *testing.T) {
 	t.Parallel()
 
-	root := writeUserspaceEntryProgramFixture(t, map[string]string{
-		"base.go": `
+	base := `
 package userspace
 
 const userspaceXDPEntryProg = "xdp_userspace_prog"
@@ -534,77 +555,171 @@ type shim struct { XDPEntryProg string }
 func (s *shim) SwapXDPEntryProg(name string) error { return nil }
 type manager struct { bpfShim *shim }
 func consume(v interface{}) {}
-`,
-		"bypass.go": `
+`
+
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "literal_assignment",
+			body: `
 package userspace
 
 func literalAssign(m *manager) {
 	m.bpfShim.XDPEntryProg = "xdp_main_prog"
 }
+`,
+			want: []string{"assigns XDPEntryProg from", "xdp_main_prog"},
+		},
+		{
+			name: "shadowed_constant_name",
+			body: `
+package userspace
 
 func shadowedConstName(m *manager) {
 	userspaceXDPEntryProg := "xdp_main_prog"
 	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
 }
+`,
+			want: []string{"assigns XDPEntryProg from \"userspaceXDPEntryProg\""},
+		},
+		{
+			name: "pointer_alias",
+			body: `
+package userspace
 
 func pointerAlias(m *manager) {
 	p := &m.bpfShim.XDPEntryProg
 	_ = p
 }
+`,
+			want: []string{"takes XDPEntryProg address"},
+		},
+		{
+			name: "method_value_capture",
+			body: `
+package userspace
 
 func methodValueCapture(m *manager) {
 	swap := m.bpfShim.SwapXDPEntryProg
 	_ = swap
 }
+`,
+			want: []string{"captures SwapXDPEntryProg method value"},
+		},
+		{
+			name: "method_value_pass",
+			body: `
+package userspace
 
 func methodValuePass(m *manager) {
 	consume(m.bpfShim.SwapXDPEntryProg)
 }
+`,
+			want: []string{"passes SwapXDPEntryProg method value"},
+		},
+		{
+			name: "method_value_return",
+			body: `
+package userspace
 
 func methodValueReturn(m *manager) func(string) error {
 	return m.bpfShim.SwapXDPEntryProg
 }
+`,
+			want: []string{"returns SwapXDPEntryProg method value"},
+		},
+		{
+			name: "direct_bad_call",
+			body: `
+package userspace
 
 func directBadCall(m *manager) {
 	_ = m.bpfShim.SwapXDPEntryProg("xdp_main_prog")
 }
+`,
+			want: []string{"calls SwapXDPEntryProg with", "xdp_main_prog"},
+		},
+		{
+			name: "parenthesized_bad_call",
+			body: `
+package userspace
 
 func parenBadCall(m *manager) {
 	_ = (m.bpfShim.SwapXDPEntryProg)("xdp_main_prog")
 }
+`,
+			want: []string{"calls SwapXDPEntryProg with", "xdp_main_prog"},
+		},
+		{
+			name: "method_expression_bad_call",
+			body: `
+package userspace
 
 func methodExprBadCall(m *manager) {
 	_ = ((*shim).SwapXDPEntryProg)(m.bpfShim, "xdp_main_prog")
 }
+`,
+			want: []string{"calls through SwapXDPEntryProg method value"},
+		},
+		{
+			name: "slice_index_bad_call",
+			body: `
+package userspace
 
 func sliceIndexBadCall(m *manager) {
 	_ = ([]func(string) error{m.bpfShim.SwapXDPEntryProg})[0]("xdp_main_prog")
 }
+`,
+			want: []string{"calls through SwapXDPEntryProg method value"},
+		},
+		{
+			name: "double_parenthesized_bad_call",
+			body: `
+package userspace
 
 func doubleParenBadCall(m *manager) {
 	_ = ((m.bpfShim.SwapXDPEntryProg))("xdp_main_prog")
 }
+`,
+			want: []string{"calls SwapXDPEntryProg with", "xdp_main_prog"},
+		},
+		{
+			name: "wrapped_method_value_callee",
+			body: `
+package userspace
+
+func wrap(fn func(string) error) func(string) error { return fn }
+func wrappedMethodValueCallee(m *manager) {
+	_ = wrap(m.bpfShim.SwapXDPEntryProg)(userspaceXDPEntryProg)
+}
+`,
+			want: []string{"calls through SwapXDPEntryProg method value"},
+		},
+		{
+			name: "reflection_field_name",
+			body: `
+package userspace
 
 func reflectionName() {
 	_ = "XDPEntryProg"
 }
 `,
-	})
+			want: []string{"uses XDPEntryProg string literal"},
+		},
+	}
 
-	violations := userspaceXDPEntryProgramViolations(t, []string{root})
-	assertCanaryViolationsContain(t, violations, []string{
-		"assigns XDPEntryProg from",
-		"xdp_main_prog",
-		"assigns XDPEntryProg from \"userspaceXDPEntryProg\"",
-		"takes XDPEntryProg address",
-		"captures SwapXDPEntryProg method value",
-		"passes SwapXDPEntryProg method value",
-		"returns SwapXDPEntryProg method value",
-		"calls SwapXDPEntryProg with",
-		"uses XDPEntryProg string literal",
-	})
-	if got := countViolationsContaining(violations, "calls SwapXDPEntryProg with"); got < 5 {
-		t.Fatalf("expected at least 5 SwapXDPEntryProg call violations, got %d: %v", got, violations)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeUserspaceEntryProgramFixture(t, map[string]string{
+				"base.go":   base,
+				"bypass.go": tc.body,
+			})
+			violations := userspaceXDPEntryProgramViolations(t, []string{root})
+			assertCanaryViolationContains(t, violations, tc.want...)
+		})
 	}
 }
 
@@ -743,7 +858,7 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 					}
 				}
 			case *ast.CallExpr:
-				if invokesSwapXDPEntryProg(node.Fun) {
+				if isDirectSwapXDPEntryProgCall(node.Fun) {
 					if len(node.Args) != 1 || !isUserspaceXDPEntryProgExpr(node.Args[0]) {
 						var got string
 						if len(node.Args) == 1 {
@@ -758,6 +873,14 @@ func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
 						))
 					}
 					return true
+				}
+				if containsSwapXDPEntryProgMethodValue(node.Fun) {
+					pos := fset.Position(node.Fun.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d calls through SwapXDPEntryProg method value",
+						rel,
+						pos.Line,
+					))
 				}
 				for _, arg := range node.Args {
 					if containsSwapXDPEntryProgMethodValue(arg) {
@@ -984,15 +1107,22 @@ func writeUserspaceEntryProgramFixture(t *testing.T, files map[string]string) st
 	return root
 }
 
-func assertCanaryViolationsContain(t *testing.T, violations []string, want []string) {
+func assertCanaryViolationContains(t *testing.T, violations []string, needles ...string) {
 	t.Helper()
 
-	joined := strings.Join(violations, "\n")
-	for _, needle := range want {
-		if !strings.Contains(joined, needle) {
-			t.Fatalf("violations missing %q\nall violations:\n%s", needle, joined)
+	for _, violation := range violations {
+		matches := true
+		for _, needle := range needles {
+			if !strings.Contains(violation, needle) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
 		}
 	}
+	t.Fatalf("no violation contains all of %q\nall violations:\n%s", needles, strings.Join(violations, "\n"))
 }
 
 func rustSourceFilesUnder(t *testing.T, root string) []string {
@@ -1091,7 +1221,7 @@ func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
 		}
 		switch node := n.(type) {
 		case *ast.CallExpr:
-			if invokesSwapXDPEntryProg(node.Fun) {
+			if isDirectSwapXDPEntryProgCall(node.Fun) {
 				for _, arg := range node.Args {
 					if containsSwapXDPEntryProgMethodValue(arg) {
 						found = true
@@ -1111,11 +1241,26 @@ func containsSwapXDPEntryProgMethodValue(expr ast.Expr) bool {
 	return found
 }
 
-func invokesSwapXDPEntryProg(expr ast.Expr) bool {
-	return containsExpr(expr, func(e ast.Expr) bool {
-		sel, ok := e.(*ast.SelectorExpr)
-		return ok && sel.Sel.Name == "SwapXDPEntryProg"
-	})
+func isDirectSwapXDPEntryProgCall(expr ast.Expr) bool {
+	sel, ok := unparenExpr(expr).(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "SwapXDPEntryProg" {
+		return false
+	}
+	switch unparenExpr(sel.X).(type) {
+	case *ast.StarExpr:
+		return false
+	}
+	return true
+}
+
+func unparenExpr(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
 }
 
 func containsExpr(expr ast.Expr, match func(ast.Expr) bool) bool {
@@ -1138,16 +1283,6 @@ func containsExpr(expr ast.Expr, match func(ast.Expr) bool) bool {
 		return true
 	})
 	return found
-}
-
-func countViolationsContaining(violations []string, needle string) int {
-	count := 0
-	for _, violation := range violations {
-		if strings.Contains(violation, needle) {
-			count++
-		}
-	}
-	return count
 }
 
 func operatorRuntimeBoundaryRoots(t *testing.T) []string {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -159,7 +159,7 @@ func shouldAttemptRSTSuppression(
 
 func New() *Manager {
 	bpfShim := dataplane.New()
-	bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	bpfShim.SelectUserspaceXDPShimEntryProgram()
 	return &Manager{
 		bpfShim:        bpfShim,
 		configuredMode: ModeUserspaceCompat,
@@ -497,7 +497,7 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	// local/control traffic to the kernel and drops transit. Do not swap to
 	// xdp_main_prog for unsupported capabilities or failed XSK liveness: the
 	// userspace runtime must not require the legacy main XDP pipeline.
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	result, err := m.bpfShim.CompileUserspaceShim(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -1417,7 +1417,7 @@ func TestApplyHelperStatusInitialCtrlCleanupRunsOnlyOnce(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	injectCtrlAndBindingMaps(t, m)
 	usMap := injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -1524,7 +1524,7 @@ func TestUpdateRGActiveActivationKeepsCtrlEnabledAfterAckedStatus(t *testing.T) 
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
 	m.cfg.ControlSocket = controlSock
 	m.clusterHA = true
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	m.neighborsPrewarmed = true
 	m.xskLivenessProven = true
 	m.ctrlWasEnabled = true

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -380,7 +380,7 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 			"lastXSKRX", m.lastXSKRX,
 			"neighborsPrewarmed", m.neighborsPrewarmed,
 			"xskLivenessFailed", m.xskLivenessFailed,
-			"xdpEntryProg", m.bpfShim.XDPEntryProg)
+			"xdpEntryProg", m.bpfShim.XDPEntryProgram())
 		if m.xskLivenessFailed {
 			// XSK proven broken: ctrl stays disabled. The shim only passes
 			// proven local/control packets and drops transit.
@@ -388,23 +388,23 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 		} else if probeBindingsReady && neighborSyncReady {
 			ctrl.Enabled = 1
 			if m.xskLivenessProven {
-				if m.bpfShim.XDPEntryProg != userspaceXDPEntryProg {
-					if err := m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg); err != nil {
+				if !m.bpfShim.UsingUserspaceXDPShimEntryProgram() {
+					if err := m.bpfShim.SwapToUserspaceXDPShimEntryProgram(); err != nil {
 						slog.Warn("userspace: failed to restore XDP shim after liveness success", "err", err)
 					}
 				}
 			} else if xskReceiveLive {
 				m.xskLivenessProven = true
 				m.xskProbeStart = time.Time{}
-				if m.bpfShim.XDPEntryProg != userspaceXDPEntryProg {
-					if err := m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg); err != nil {
+				if !m.bpfShim.UsingUserspaceXDPShimEntryProgram() {
+					if err := m.bpfShim.SwapToUserspaceXDPShimEntryProgram(); err != nil {
 						slog.Warn("userspace: failed to swap XDP shim after XSK RX became live", "err", err)
 					}
 				}
 				slog.Info("userspace: XSK liveness proven")
 			} else {
-				if m.bpfShim.XDPEntryProg != userspaceXDPEntryProg {
-					if err := m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg); err != nil {
+				if !m.bpfShim.UsingUserspaceXDPShimEntryProgram() {
+					if err := m.bpfShim.SwapToUserspaceXDPShimEntryProgram(); err != nil {
 						slog.Warn("userspace: failed to activate XDP shim for XSK liveness probe", "err", err)
 					}
 				}
@@ -415,8 +415,8 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 					if m.shouldAutoProveIdleStandbyXSKLocked(currentRX, allBindingsBound) {
 						m.xskLivenessProven = true
 						m.xskProbeStart = time.Time{}
-						if m.bpfShim.XDPEntryProg != userspaceXDPEntryProg {
-							if err := m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg); err != nil {
+						if !m.bpfShim.UsingUserspaceXDPShimEntryProgram() {
+							if err := m.bpfShim.SwapToUserspaceXDPShimEntryProgram(); err != nil {
 								slog.Warn("userspace: failed to restore XDP shim after idle standby liveness success", "err", err)
 							}
 						}
@@ -438,8 +438,8 @@ func (m *Manager) applyHelperStatusLocked(status *ProcessStatus) error {
 						slog.Error("userspace: XSK liveness probe failed in strict mode; dataplane degraded fail-closed")
 					} else {
 						slog.Warn("userspace: XSK liveness probe failed; keeping shim disabled with transit fail-closed")
-						if m.bpfShim.XDPEntryProg != userspaceXDPEntryProg {
-							if err := m.bpfShim.SwapXDPEntryProg(userspaceXDPEntryProg); err != nil {
+						if !m.bpfShim.UsingUserspaceXDPShimEntryProgram() {
+							if err := m.bpfShim.SwapToUserspaceXDPShimEntryProgram(); err != nil {
 								slog.Warn("userspace: failed to restore XDP shim after XSK liveness failure", "err", err)
 							}
 						}
@@ -754,14 +754,14 @@ func (m *Manager) readFallbackStatsLocked() map[string]uint64 {
 
 // entryProgramsLocked returns a map of ifindex -> attached XDP program name
 // by inspecting the bpfShim dataplane manager's link state.
-// Note: VLAN sub-interfaces are skipped during SwapXDPEntryProg and may
+// Note: VLAN sub-interfaces are skipped during userspace-shim swaps and may
 // retain the parent's program; they are excluded from this map.
 func (m *Manager) entryProgramsLocked() map[int]string {
 	links := m.bpfShim.XDPLinks()
 	if len(links) == 0 {
 		return nil
 	}
-	progName := m.bpfShim.XDPEntryProg
+	progName := m.bpfShim.XDPEntryProgram()
 	result := make(map[int]string, len(links))
 	for ifindex := range links {
 		if m.bpfShim.VlanSubInterfaces[ifindex] {

--- a/pkg/dataplane/userspace/maps_sync_cap_test.go
+++ b/pkg/dataplane/userspace/maps_sync_cap_test.go
@@ -25,7 +25,7 @@ func TestApplyHelperStatusRejectsOverCapIfindex(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	ctrlMap, _ := injectCtrlAndBindingMaps(t, m)
 	injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -572,7 +572,7 @@ func TestApplyHelperStatusAcceptsIfindexWithinCap(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	injectCtrlAndBindingMaps(t, m)
 	injectUserspaceSessionMap(t, m)
 	m.neighborsPrewarmed = true
@@ -610,7 +610,7 @@ func TestVerifyBindingsWatchdogSkipsOverCapIfindex(t *testing.T) {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
 	m := New()
-	m.bpfShim.XDPEntryProg = userspaceXDPEntryProg
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
 	injectCtrlAndBindingMaps(t, m)
 	m.ctrlWasEnabled = true
 	// verifyBindingsMapLocked early-returns on m.proc == nil or

--- a/pkg/dataplane/userspace/xdp_shim_decouple_test.go
+++ b/pkg/dataplane/userspace/xdp_shim_decouple_test.go
@@ -33,8 +33,11 @@ func TestXSKLivenessFailureRestoresUserspaceShimEntry(t *testing.T) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		t.Skipf("RemoveMemlock: %v", err)
 	}
-	m := New()
-	m.bpfShim.XDPEntryProg = "xdp_main_prog"
+	m := &Manager{
+		bpfShim:        dataplane.New(),
+		configuredMode: ModeUserspaceCompat,
+		haGroups:       make(map[int]HAGroupStatus),
+	}
 	injectShimProgramName(t, m.bpfShim, userspaceXDPEntryProg)
 	injectCtrlAndBindingMaps(t, m)
 	m.neighborsPrewarmed = true
@@ -63,8 +66,8 @@ func TestXSKLivenessFailureRestoresUserspaceShimEntry(t *testing.T) {
 	if !m.xskLivenessFailed {
 		t.Fatal("xskLivenessFailed = false, want true after expired liveness probe")
 	}
-	if got := m.bpfShim.XDPEntryProg; got != userspaceXDPEntryProg {
-		t.Fatalf("XDPEntryProg = %q, want %q", got, userspaceXDPEntryProg)
+	if got := m.bpfShim.XDPEntryProgram(); got != userspaceXDPEntryProg {
+		t.Fatalf("XDPEntryProgram() = %q, want %q", got, userspaceXDPEntryProg)
 	}
 }
 
@@ -330,7 +333,7 @@ func injectShimProgramName(t *testing.T, bpfShim *dataplane.Manager, name string
 	if rm.IsNil() {
 		rm.Set(reflect.MakeMap(rv.Type()))
 	}
-	// SwapXDPEntryProg only needs the name to exist when no links are
+	// SwapToUserspaceXDPShimEntryProgram only needs the name to exist when no links are
 	// attached, so a nil *ebpf.Program is sufficient for this unit test.
 	rm.SetMapIndex(reflect.ValueOf(name), reflect.Zero(rv.Type().Elem()))
 }

--- a/testing-docs/ha-failover-validation.md
+++ b/testing-docs/ha-failover-validation.md
@@ -134,7 +134,7 @@ window, not a current userspace HA success condition. Two changes were made:
    when XSK cannot deliver packets.
 
 2. After 30 seconds of XSK bindings being ready but `rx_packets == 0`,
-   the manager called `SwapXDPEntryProg("xdp_main_prog")` as a legacy fallback
+   the manager historically selected `xdp_main_prog` as a legacy fallback
    to replace the XDP shim with the direct legacy eBPF pipeline. That
    historical fallback restored forwarding during this investigation, but an
    active userspace validation run must treat this attachment as failure unless
@@ -173,7 +173,7 @@ normally. If it also fails (true dual-inactive), drop with
 ### 1.10 `4ddf371f` -- Persist historical XSK liveness failure across config reconciles
 
 The historical XSK liveness swap to `xdp_main_prog` was being overridden by
-config reconciles which re-set `XDPEntryProg` to `xdp_userspace_prog`. Added
+config reconciles which re-selected `xdp_userspace_prog`. Added
 `xskLivenessFailed` flag that persists and prevents `Compile` from switching
 back to the broken XDP shim. Also added `delta-rx` check: the liveness gate now
 compares current `rx_packets` against a snapshot taken at gate start, so

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -109,5 +109,5 @@ Remaining limitations:
   fail-closed until downstream loss-priority behavior is wired. Color-aware
   mode also stays fail-closed until inherited packet color is carried through
   trusted metadata.
-- Traffic-level integration, failover, and performance evidence still need to
-  be collected before treating #1375 as fully retired.
+- Traffic-level integration, failover, and performance evidence remain
+  production-hardening follow-ups for #1375, not active feature-gap blockers.


### PR DESCRIPTION
## Summary

- add allowlist canaries for the already-merged userspace XDP shim split
- reconcile active #1373 docs now that #1374-#1381 feature gaps are closed
- document #1493 as the remaining userspace loader/bootstrap blocker before
  legacy BPF source deletion

## Details

The userspace runtime no longer degrades back into `xdp_main_prog`, but the
source-removal path is not done: userspace still reaches the legacy manager's
`loadAllObjects()` path for shared map bootstrap. This PR makes that distinction
explicit so #1476 cannot be interpreted as ready just because the runtime
fallback behavior was fixed.

The canaries guard the regression-prone pieces of the #1473 split:

- the Rust shim source and embedded BPF object must contain only the retained
  allowlisted map/program set, and the Rust shim source must stay free of
  tail-call plumbing
- production code under `pkg/dataplane/userspace` may write `XDPEntryProg` or
  call `SwapXDPEntryProg` only with the package-level
  `userspaceXDPEntryProg` constant, and that constant itself must remain
  `xdp_userspace_prog`
- every `SwapXDPEntryProg` selector is classified from the selector leaf upward
  through a parent map; only bare/parenthesized direct calls and pointer method
  expressions with the correct program argument are allowed
- method-value escapes through assignment, call arguments, returns, sends,
  ranges, map keys, switch tags, indexed/composite callees, wrapper callees, and
  other non-direct parent paths are rejected structurally instead of through a
  statement-container allowlist
- indirect mutation paths are rejected: the canary fails on `XDPEntryProg`
  address-taking, `XDPEntryProg` reflection field-name strings,
  `json.Unmarshal` into `bpfShim`, and production `reflect` or `unsafe` imports
- fixture tests pin the canary walker against valid cross-file const usage and
  each reviewed bypass shape independently, with per-violation-line assertions
  instead of aggregate substring matching
- the DPDK backend import allowlist now fails on both unexpected imports and
  stale allowed entries

## New Issue

Opened #1493 for the remaining loader/bootstrap split:
`eBPF retirement: split userspace shim loader from legacy loadAllObjects`.

## Validation

- `go test ./pkg/dataplane -run 'TestUserspaceEntryProgramCanary|TestUserspaceManager|TestUserspaceXDPEntryProgramConstant' -count=1 -v`
- `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`
- `git diff --check`

## Adversarial Self-Review

I re-read the full r6 synthesis and rebuilt the canary around the structural
issue it identified: the code now switches on `*ast.SelectorExpr` for
`SwapXDPEntryProg` and walks upward through a parent map, rather than switching
on a finite list of statement containers.

The r6 reproduced bypasses are all pinned as fixtures: channel send, range over
function slices, map-key LHS, switch tag, and `encoding/json.Unmarshal` into the
shim. The B4 false positive is also pinned by allowing a valid pointer method
expression with `userspaceXDPEntryProg` as the explicit program argument.

I also re-grepped the userspace and loader paths after the changes. The
remaining `xdp_main_prog` hits are limited to the legacy loader, the legacy
default manager, comments, and tests. That is intentional and now tracked by
#1493; this PR does not claim the legacy object load graph is removed.
