### PR TITLE
Move monitor interface off root dataplane imports

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -155,13 +155,14 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/grpcapi/server_show_status.go` | Status output still reads legacy dataplane state. |
 | `pkg/grpcapi/server_show_zones.go` | Zone output still uses legacy dataplane types. |
 | `pkg/logging/ringbuf.go` | Event reader still consumes the legacy `EventSource`. |
-| `pkg/monitoriface/monitor.go` | Interface monitor still reads legacy interface counters. |
 
 ### Safe-Delete Blockers
 
 - `pkg/dataplane.DataPlane` is still load-bearing for API, gRPC, CLI, status,
-  monitor, logging, cluster session sync, conntrack GC, daemon HA, daemon flow,
-  and daemon apply bridges listed above.
+  logging, cluster session sync, conntrack GC, daemon HA, daemon flow, and
+  daemon apply bridges listed above. `pkg/monitoriface` now uses a
+  package-local `RuntimeDataPlane`/`CounterReader` shape; CLI and gRPC adapt
+  their wider dataplane fields before entering the monitor-interface package.
 - Omitted `system dataplane-type` now resolves to the userspace runtime path.
   Explicit `system dataplane-type ebpf` remains available only as a temporary
   compatibility setting until source removal, and config compile emits a

--- a/pkg/cli/monitor_interface.go
+++ b/pkg/cli/monitor_interface.go
@@ -16,6 +16,32 @@ import (
 type ifaceSnapshot = monitoriface.Snapshot
 type userspaceIfaceSnapshot = monitoriface.UserspaceSnapshot
 
+var _ monitoriface.RuntimeDataPlane = monitorInterfaceRuntimeDataPlane{}
+
+type monitorInterfaceRuntimeDataPlane struct {
+	cli *CLI
+}
+
+func (a monitorInterfaceRuntimeDataPlane) IsLoaded() bool {
+	return a.cli != nil && a.cli.dp != nil && a.cli.dp.IsLoaded()
+}
+
+func (a monitorInterfaceRuntimeDataPlane) ReadInterfaceCounters(ifindex int) (monitoriface.InterfaceCounters, error) {
+	if a.cli == nil || a.cli.dp == nil {
+		return monitoriface.InterfaceCounters{}, fmt.Errorf("dataplane unavailable")
+	}
+	ctrs, err := a.cli.dp.ReadInterfaceCounters(ifindex)
+	if err != nil {
+		return monitoriface.InterfaceCounters{}, err
+	}
+	return monitoriface.InterfaceCounters{
+		RxPackets: ctrs.RxPackets,
+		RxBytes:   ctrs.RxBytes,
+		TxPackets: ctrs.TxPackets,
+		TxBytes:   ctrs.TxBytes,
+	}, nil
+}
+
 // setRawMode puts the terminal into raw mode for single-character reads.
 func setRawMode(fd int) (*unix.Termios, error) {
 	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
@@ -141,7 +167,14 @@ func (c *CLI) resolveToKernel(cfgName string) string {
 }
 
 func (c *CLI) readMonitorSnapshot(kernelName string) (monitoriface.Snapshot, error) {
-	return monitoriface.ReadSnapshot(c.dp, c.userspaceDataplaneStatus, kernelName)
+	return monitoriface.ReadSnapshot(c.monitorInterfaceDataplane(), c.userspaceDataplaneStatus, kernelName)
+}
+
+func (c *CLI) monitorInterfaceDataplane() monitoriface.RuntimeDataPlane {
+	if c == nil || c.dp == nil {
+		return nil
+	}
+	return monitorInterfaceRuntimeDataPlane{cli: c}
 }
 
 // monitorInterfaceSingle shows full-screen stats for a single interface.

--- a/pkg/cli/monitor_test.go
+++ b/pkg/cli/monitor_test.go
@@ -7,9 +7,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/logging"
+	"github.com/psaab/xpf/pkg/monitoriface"
 )
+
+type monitorInterfaceCLITestDP struct {
+	dataplane.DataPlane
+
+	loaded     bool
+	counters   dataplane.InterfaceCounterValue
+	gotIfindex int
+}
+
+func (f *monitorInterfaceCLITestDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *monitorInterfaceCLITestDP) ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error) {
+	f.gotIfindex = ifindex
+	return f.counters, nil
+}
 
 func TestMonitorFlowFilter_MatchesAll(t *testing.T) {
 	f := &monitorFlowFilter{Name: "empty"}
@@ -20,6 +39,41 @@ func TestMonitorFlowFilter_MatchesAll(t *testing.T) {
 	}
 	if !f.matches(rec) {
 		t.Fatal("empty filter should match everything")
+	}
+}
+
+func TestMonitorInterfaceDataplaneProjectsCounters(t *testing.T) {
+	dp := &monitorInterfaceCLITestDP{
+		loaded: true,
+		counters: dataplane.InterfaceCounterValue{
+			RxPackets: 10,
+			RxBytes:   20,
+			TxPackets: 30,
+			TxBytes:   40,
+		},
+	}
+	cli := &CLI{dp: dp}
+
+	accessor := cli.monitorInterfaceDataplane()
+	if accessor == nil {
+		t.Fatal("monitorInterfaceDataplane() returned nil")
+	}
+	if _, ok := accessor.(monitoriface.RuntimeDataPlane); !ok {
+		t.Fatalf("monitorInterfaceDataplane() = %T, want monitoriface.RuntimeDataPlane", accessor)
+	}
+	if !accessor.IsLoaded() {
+		t.Fatal("IsLoaded() = false, want true")
+	}
+
+	got, err := accessor.ReadInterfaceCounters(42)
+	if err != nil {
+		t.Fatalf("ReadInterfaceCounters() error = %v", err)
+	}
+	if dp.gotIfindex != 42 {
+		t.Fatalf("ReadInterfaceCounters ifindex = %d, want 42", dp.gotIfindex)
+	}
+	if got != (monitoriface.InterfaceCounters{RxPackets: 10, RxBytes: 20, TxPackets: 30, TxBytes: 40}) {
+		t.Fatalf("ReadInterfaceCounters() = %+v, want projected monitor counters", got)
 	}
 }
 

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -56,7 +56,6 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/grpcapi/server_show_status.go":        "status output still reads legacy dataplane state",
 	"pkg/grpcapi/server_show_zones.go":         "zone output still uses legacy dataplane types",
 	"pkg/logging/ringbuf.go":                   "event reader still consumes the legacy EventSource",
-	"pkg/monitoriface/monitor.go":              "interface monitor still reads legacy interface counters",
 }
 
 var dpdkEBPFImportAllowlist = map[string]string{

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -28,6 +28,39 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var _ monitoriface.RuntimeDataPlane = monitorInterfaceServerDataPlane{}
+
+type monitorInterfaceServerDataPlane struct {
+	server *Server
+}
+
+func (a monitorInterfaceServerDataPlane) IsLoaded() bool {
+	return a.server != nil && a.server.dp != nil && a.server.dp.IsLoaded()
+}
+
+func (a monitorInterfaceServerDataPlane) ReadInterfaceCounters(ifindex int) (monitoriface.InterfaceCounters, error) {
+	if a.server == nil || a.server.dp == nil {
+		return monitoriface.InterfaceCounters{}, fmt.Errorf("dataplane unavailable")
+	}
+	ctrs, err := a.server.dp.ReadInterfaceCounters(ifindex)
+	if err != nil {
+		return monitoriface.InterfaceCounters{}, err
+	}
+	return monitoriface.InterfaceCounters{
+		RxPackets: ctrs.RxPackets,
+		RxBytes:   ctrs.RxBytes,
+		TxPackets: ctrs.TxPackets,
+		TxBytes:   ctrs.TxBytes,
+	}, nil
+}
+
+func (s *Server) monitorInterfaceDataplane() monitoriface.RuntimeDataPlane {
+	if s == nil || s.dp == nil {
+		return nil
+	}
+	return monitorInterfaceServerDataPlane{server: s}
+}
+
 // --- Diagnostic RPCs ---
 
 func (s *Server) Ping(req *pb.PingRequest, stream grpc.ServerStreamingServer[pb.PingResponse]) error {
@@ -377,7 +410,7 @@ func (s *Server) MonitorInterface(req *pb.MonitorInterfaceRequest, stream grpc.S
 	prevAll := make(map[string]*monitoriface.Snapshot)
 
 	readSnap := func(name string) *monitoriface.Snapshot {
-		snap, err := monitoriface.ReadSnapshot(s.dp, s.userspaceDataplaneStatus, name)
+		snap, err := monitoriface.ReadSnapshot(s.monitorInterfaceDataplane(), s.userspaceDataplaneStatus, name)
 		if err != nil {
 			return nil
 		}

--- a/pkg/grpcapi/server_diag_monitor_test.go
+++ b/pkg/grpcapi/server_diag_monitor_test.go
@@ -1,0 +1,60 @@
+package grpcapi
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/monitoriface"
+)
+
+type monitorInterfaceServerTestDP struct {
+	dataplane.DataPlane
+
+	loaded     bool
+	counters   dataplane.InterfaceCounterValue
+	gotIfindex int
+}
+
+func (f *monitorInterfaceServerTestDP) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *monitorInterfaceServerTestDP) ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error) {
+	f.gotIfindex = ifindex
+	return f.counters, nil
+}
+
+func TestMonitorInterfaceDataplaneProjectsCounters(t *testing.T) {
+	dp := &monitorInterfaceServerTestDP{
+		loaded: true,
+		counters: dataplane.InterfaceCounterValue{
+			RxPackets: 100,
+			RxBytes:   200,
+			TxPackets: 300,
+			TxBytes:   400,
+		},
+	}
+	s := &Server{dp: dp}
+
+	accessor := s.monitorInterfaceDataplane()
+	if accessor == nil {
+		t.Fatal("monitorInterfaceDataplane() returned nil")
+	}
+	if _, ok := accessor.(monitoriface.RuntimeDataPlane); !ok {
+		t.Fatalf("monitorInterfaceDataplane() = %T, want monitoriface.RuntimeDataPlane", accessor)
+	}
+	if !accessor.IsLoaded() {
+		t.Fatal("IsLoaded() = false, want true")
+	}
+
+	got, err := accessor.ReadInterfaceCounters(84)
+	if err != nil {
+		t.Fatalf("ReadInterfaceCounters() error = %v", err)
+	}
+	if dp.gotIfindex != 84 {
+		t.Fatalf("ReadInterfaceCounters ifindex = %d, want 84", dp.gotIfindex)
+	}
+	if got != (monitoriface.InterfaceCounters{RxPackets: 100, RxBytes: 200, TxPackets: 300, TxBytes: 400}) {
+		t.Fatalf("ReadInterfaceCounters() = %+v, want projected monitor counters", got)
+	}
+}

--- a/pkg/monitoriface/README.md
+++ b/pkg/monitoriface/README.md
@@ -10,8 +10,9 @@ packets, bytes, delta, rate.
 - `Snapshot` — `monitor.go`. Kernel counters (Rx/TxBytes, errors,
   collisions, etc.).
 - `UserspaceSnapshot` — `monitor.go`. Per-binding XSK stats.
-- `CounterReader` interface — `monitor.go`. Abstracts BPF map access
-  so tests can inject a fake.
+- `RuntimeDataPlane` / `CounterReader` interface — `monitor.go`.
+  Abstracts monitor-interface counter reads so callers adapt broader
+  dataplanes at their package boundary and tests can inject a fake.
 - `ReadSnapshot(counterReader CounterReader, statusReader StatusReader, kernelName string) (Snapshot, error)` — `monitor.go`.
 - `RenderSingleInterface(w io.Writer, hostname, displayName, kernelName string, snap, prev, baseline *Snapshot, startTime time.Time)` — `monitor.go`.
 - `RenderTrafficSummary(w io.Writer, hostname string, names []string, kernelNames map[string]string, snaps, prevSnaps map[string]*Snapshot, mode SummaryMode, startTime time.Time)` — `monitor.go`.
@@ -22,7 +23,7 @@ packets, bytes, delta, rate.
 
 ## Dependencies
 
-`pkg/config`, `pkg/dataplane`, `pkg/dataplane/userspace`.
+`pkg/config`, `pkg/dataplane/userspace`.
 
 ## Gotchas
 

--- a/pkg/monitoriface/monitor.go
+++ b/pkg/monitoriface/monitor.go
@@ -10,15 +10,31 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
-	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/vishvananda/netlink"
 )
 
-type CounterReader interface {
-	IsLoaded() bool
-	ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error)
+// InterfaceCounters is the monitor-interface package's local counter shape.
+// Callers adapt broader dataplane implementations to this struct so this
+// package stays independent of root dataplane telemetry types.
+type InterfaceCounters struct {
+	RxPackets uint64
+	RxBytes   uint64
+	TxPackets uint64
+	TxBytes   uint64
 }
+
+// RuntimeDataPlane is the small dataplane surface ReadSnapshot needs.
+// It is intentionally narrower than the legacy root dataplane.DataPlane
+// interface.
+type RuntimeDataPlane interface {
+	IsLoaded() bool
+	ReadInterfaceCounters(ifindex int) (InterfaceCounters, error)
+}
+
+// CounterReader is kept as the older name for callers and docs that describe
+// the monitor package's interface-counter dependency.
+type CounterReader = RuntimeDataPlane
 
 type StatusReader func() (dpuserspace.ProcessStatus, error)
 

--- a/pkg/monitoriface/monitor_test.go
+++ b/pkg/monitoriface/monitor_test.go
@@ -2,12 +2,32 @@ package monitoriface
 
 import (
 	"bytes"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
+
+var _ RuntimeDataPlane = (*fakeRuntimeDataPlane)(nil)
+
+type fakeRuntimeDataPlane struct {
+	loaded       bool
+	counters     InterfaceCounters
+	gotIfindex   int
+	readCounters bool
+}
+
+func (f *fakeRuntimeDataPlane) IsLoaded() bool {
+	return f.loaded
+}
+
+func (f *fakeRuntimeDataPlane) ReadInterfaceCounters(ifindex int) (InterfaceCounters, error) {
+	f.gotIfindex = ifindex
+	f.readCounters = true
+	return f.counters, nil
+}
 
 func TestParseSummaryMode(t *testing.T) {
 	cases := map[string]SummaryMode{
@@ -30,6 +50,38 @@ func TestParseSummaryMode(t *testing.T) {
 	}
 	if _, ok := ParseSummaryMode("bogus"); ok {
 		t.Fatal("ParseSummaryMode accepted invalid mode")
+	}
+}
+
+func TestReadSnapshotUsesRuntimeDataPlaneCounters(t *testing.T) {
+	iface, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("loopback interface unavailable: %v", err)
+	}
+	dp := &fakeRuntimeDataPlane{
+		loaded: true,
+		counters: InterfaceCounters{
+			RxPackets: 11,
+			RxBytes:   22,
+			TxPackets: 33,
+			TxBytes:   44,
+		},
+	}
+
+	snap, err := ReadSnapshot(dp, nil, "lo")
+	if err != nil {
+		t.Fatalf("ReadSnapshot: %v", err)
+	}
+
+	if !dp.readCounters {
+		t.Fatal("ReadSnapshot did not read counters from RuntimeDataPlane")
+	}
+	if dp.gotIfindex != iface.Index {
+		t.Fatalf("ReadInterfaceCounters ifindex = %d, want %d", dp.gotIfindex, iface.Index)
+	}
+	if snap.RxPkts != 11 || snap.RxBytes != 22 || snap.TxPkts != 33 || snap.TxBytes != 44 {
+		t.Fatalf("ReadSnapshot counters = rxPkts=%d rxBytes=%d txPkts=%d txBytes=%d, want 11/22/33/44",
+			snap.RxPkts, snap.RxBytes, snap.TxPkts, snap.TxBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Move `pkg/monitoriface` to a package-local `RuntimeDataPlane` / `CounterReader` interface with a local `InterfaceCounters` shape.
- Adapt CLI and gRPC monitor-interface callers at their package boundary before calling `monitoriface.ReadSnapshot`.
- Remove `pkg/monitoriface/monitor.go` from the #1451 root dataplane import allowlist and the #1373 docs table.

Refs #1451
Refs #1373

## Validation
- `go test ./pkg/monitoriface ./pkg/cli ./pkg/grpcapi ./pkg/dataplane`
- `go test ./pkg/dataplane -run 'TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports|TestRetirementBoundaryDocsMentionLegacyImportAllowlist'`