### PR TITLE
docs: add legacy BPF deletion manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ To deploy to a single node: `make cluster-deploy NODE=0` or `make cluster-deploy
 | `proto/xpf/v1/` | Protobuf service definition |
 | `cmd/xpfd/` | Daemon main binary |
 | `cmd/cli/` | Remote CLI client binary |
-| `userspace-xdp/` | XDP shim for AF_XDP packet steering (Rust/eBPF) |
 | `userspace-dp/` | Rust AF_XDP userspace dataplane binary |
 | `docs/` | Protocol docs, test plans, feature gaps |
 | `test/incus/` | Test environment scripts and configs |

--- a/README.md
+++ b/README.md
@@ -322,14 +322,15 @@ To deploy to a single node: `make cluster-deploy NODE=0` or `make cluster-deploy
 
 | Path | Description |
 |------|-------------|
-| `bpf/headers/*.h` | Shared C structs (common, maps, helpers, conntrack, nat) |
-| `bpf/xdp/*.c` | Legacy XDP ingress programs (includes cpumap entry) |
-| `bpf/tc/*.c` | Legacy TC egress programs |
+| `bpf/headers/*.h` | Shared constants and C structs retained until userspace/DPDK replacements exist |
+| `bpf/xdp/*.c` | Legacy XDP ingress programs pending #1476 source removal |
+| `bpf/tc/*.c` | Legacy TC egress programs pending #1476 source removal |
 | `pkg/config/` | Junos parser, AST, typed config, compiler |
 | `pkg/cmdtree/` | Single source of truth for all CLI command trees |
 | `pkg/configstore/` | Candidate/active/commit/rollback, atomic DB persistence |
-| `pkg/dataplane/` | Legacy eBPF loader, map management, bpf2go bindings, shared dataplane interface |
+| `pkg/dataplane/` | Runtime contracts, retained userspace shim embed, and temporary legacy eBPF compatibility |
 | `pkg/dataplane/userspace/` | Go manager for the Rust userspace dataplane |
+| `userspace-xdp/` | Retained Rust XDP shim that redirects packets into the AF_XDP userspace runtime |
 | `pkg/daemon/` | Daemon lifecycle, reconciliation, interface management |
 | `pkg/cluster/` | Chassis cluster HA (state machine, session sync, config sync) |
 | `pkg/vrrp/` | Native VRRPv3 state machine (30ms RETH advertisements) |

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -24,6 +24,8 @@ tracked by #1451 and the removal-phase child issues below.
 |---|---|
 | #1451 | Migrate remaining legacy eBPF-shaped runtime and operator surfaces before source/generated artifact deletion. |
 | #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. |
+| #1493 | Split userspace shim loader/bootstrap from the legacy `loadAllObjects()` path. |
+| #1494 | Pin the retained userspace shim boundary with source/object/manager canaries before source deletion. |
 | #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the blockers close. |
 | #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate. |
 
@@ -33,7 +35,19 @@ until legacy source removal.
 
 ## Removal-Phase Dependency
 
-#1451 is the current common migration umbrella. The userspace manager no longer
+The source-removal order is now explicit:
+
+1. #1494 canary: merge the retained userspace XDP shim boundary canaries.
+2. #1493 loader split: remove userspace startup's dependency on the legacy
+   `loadAllObjects()` graph.
+3. #1451 surface shrink: finish moving runtime/operator callers off the legacy
+   eBPF-shaped `dataplane.DataPlane` bridge.
+4. #1476 deletion: remove legacy source, generated artifacts, and stale build
+   hooks using [source-removal-manifest-1476.md](source-removal-manifest-1476.md).
+5. #1477 final evidence: publish validation artifacts for the exact deletion
+   candidate.
+
+#1451 remains the common migration umbrella. The userspace manager no longer
 embeds the old `DataPlane` interface directly, and a userspace legacy adapter
 owns the compatibility boundary while unmigrated callers move to domain
 interfaces. #1380 is a Phase 5 CLI/observability cleanup item, now closed for

--- a/docs/pr/1373-retire-ebpf-dataplane/plan.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan.md
@@ -33,6 +33,8 @@ backlog.
 |-------|-------|
 | #1451 | Move remaining runtime and operator callers off the legacy eBPF-shaped dataplane surfaces before source/generated artifact deletion. |
 | #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. |
+| #1493 | Split userspace shim loader/bootstrap from the legacy `loadAllObjects()` path. |
+| #1494 | Pin the retained userspace shim boundary with canaries before source deletion. |
 | #1476 | Remove legacy BPF source, generated artifacts, and build hooks after migration blockers close. |
 | #1477 | Publish final userspace-only validation artifacts for the exact source-removal candidate. |
 
@@ -42,13 +44,16 @@ until legacy source removal.
 
 ## Recommended Order
 
-1. Land #1451 first so remaining runtime and operator surfaces no longer depend
+1. Land #1494 canary first so the retained userspace XDP shim boundary is
+   guarded before source-removal work starts.
+2. Land #1493 loader split so userspace startup no longer depends on the
+   legacy `loadAllObjects()` path.
+3. Finish #1451 surface shrink so runtime and operator callers no longer depend
    on the legacy eBPF-shaped `dataplane.DataPlane` contract.
-2. Land #1473 before source deletion so the retained userspace shim is
-   explicit and separate from legacy `xdp_main_prog` fallback.
-3. Land #1476 as the source/generated-artifact removal PR after those blockers
-   close.
-4. Attach #1477 validation artifacts to the exact #1476 candidate.
+4. Land #1476 as the source/generated-artifact removal PR, using
+   [source-removal-manifest-1476.md](source-removal-manifest-1476.md) as the
+   deletion boundary.
+5. Attach #1477 final evidence artifacts to the exact #1476 candidate.
 
 ## Phase Boundaries
 
@@ -57,8 +62,9 @@ until legacy source removal.
   as history; add banners only where needed instead of rewriting old plans.
 - Phase 2: test environment consolidation.
 - Phase 3: runtime and operator surface migration under #1451.
-- Phase 4: BPF source removal under #1476, only after #1451, #1473, and
-  the required #1477 validation artifacts are ready.
+- Phase 4: BPF source removal under #1476, only after #1494, #1493, and
+  #1451 have landed and the #1477 validation plan is ready for the exact
+  deletion candidate.
 - Phase 5: CLI and observability cleanup. The current #1380 helper-status
   contract is closed; future neighbor-cache fill-percentage rows need
   helper-owned denominators before they can enter the utilization table.

--- a/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
@@ -1,0 +1,201 @@
+# #1476 Legacy BPF Source-Removal Manifest
+
+Status: manifest-only preparation for #1476. This document records the
+intended deletion boundary for the later source-removal PR. No source,
+generated object, loader hook, or Makefile generation path is deleted by this
+slice.
+
+## Dependency Order
+
+The removal path must land in this order:
+
+1. #1494 canary: merge the userspace shim boundary canaries so the retained
+   Rust XDP shim cannot silently grow legacy fallback behavior.
+2. #1493 loader split: make userspace startup load only the retained Rust XDP
+   shim and the shared AF_XDP maps it requires, without calling the legacy
+   `loadAllObjects()` graph.
+3. #1451 surface shrink: finish moving runtime and operator callers off the
+   legacy eBPF-shaped `dataplane.DataPlane` surface, leaving no source-removal
+   dependency on the root legacy manager.
+4. #1476 deletion: remove the legacy BPF source, generated artifacts, and stale
+   build hooks listed here.
+5. #1477 final evidence: publish userspace-only validation artifacts for the
+   exact #1476 deletion candidate.
+
+## Delete Manifest
+
+### Legacy XDP Source
+
+Delete these legacy ingress dataplane programs after the dependency order above
+is satisfied:
+
+- `bpf/xdp/xdp_conntrack.c`
+- `bpf/xdp/xdp_cpumap.c`
+- `bpf/xdp/xdp_forward.c`
+- `bpf/xdp/xdp_main.c`
+- `bpf/xdp/xdp_nat.c`
+- `bpf/xdp/xdp_nat64.c`
+- `bpf/xdp/xdp_policy.c`
+- `bpf/xdp/xdp_screen.c`
+- `bpf/xdp/xdp_zone.c`
+- `bpf/xdp/README.md`
+
+### Legacy TC Source
+
+Delete these legacy egress dataplane programs after #1493 proves userspace
+startup no longer needs TC program objects or the `tc_progs` tail-call map:
+
+- `bpf/tc/tc_conntrack.c`
+- `bpf/tc/tc_forward.c`
+- `bpf/tc/tc_main.c`
+- `bpf/tc/tc_nat.c`
+- `bpf/tc/tc_screen_egress.c`
+- `bpf/tc/README.md`
+
+### Generated Legacy bpf2go Artifacts
+
+Delete every tracked legacy `xpf*` bpf2go Go wrapper and embedded object. The
+current tree has 14 generated Go/object pairs:
+
+- `pkg/dataplane/xpftcconntrack_x86_bpfel.go`
+- `pkg/dataplane/xpftcconntrack_x86_bpfel.o`
+- `pkg/dataplane/xpftcforward_x86_bpfel.go`
+- `pkg/dataplane/xpftcforward_x86_bpfel.o`
+- `pkg/dataplane/xpftcmain_x86_bpfel.go`
+- `pkg/dataplane/xpftcmain_x86_bpfel.o`
+- `pkg/dataplane/xpftcnat_x86_bpfel.go`
+- `pkg/dataplane/xpftcnat_x86_bpfel.o`
+- `pkg/dataplane/xpftcscreenegress_x86_bpfel.go`
+- `pkg/dataplane/xpftcscreenegress_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpconntrack_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpconntrack_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpcpumap_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpcpumap_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpforward_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpforward_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpmain_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpmain_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpnat64_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpnat64_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpnat_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpnat_x86_bpfel.o`
+- `pkg/dataplane/xpfxdppolicy_x86_bpfel.go`
+- `pkg/dataplane/xpfxdppolicy_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpscreen_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpscreen_x86_bpfel.o`
+- `pkg/dataplane/xpfxdpzone_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpzone_x86_bpfel.o`
+
+The eventual deletion PR must rerun the manifest canary before and after the
+delete. If any additional tracked `pkg/dataplane/*_bpfel.go`,
+`pkg/dataplane/*_bpfel.o`, `pkg/dataplane/*_bpfeb.go`, or
+`pkg/dataplane/*_bpfeb.o` file exists and is not explicitly retained, it must
+be added to this section before deletion.
+
+### Legacy Build Hooks
+
+Remove or rewrite these build hooks in the deletion PR:
+
+- `pkg/dataplane/loader.go`: remove the legacy bpf2go `go:generate`
+  directives that target `bpf/xdp/*.c` and `bpf/tc/*.c`.
+- `pkg/dataplane/loader_ebpf.go`: remove references to the generated
+  `xpfXdp*` and `xpfTc*` loader types once #1493 has supplied the userspace
+  shim bootstrap path.
+- `pkg/dataplane/loader_stub.go`: remove the stale ignored generated-binding
+  stub if no replacement uses it.
+- `Makefile`: remove the legacy `generate-legacy-bpf` target, stop using broad
+  generation to rebuild deleted programs, and remove unused legacy BPF
+  variables such as `BPF_CFLAGS` if no remaining target consumes them.
+- `Makefile clean`: narrow the generated-artifact cleanup so it no longer
+  erases retained shim artifacts.
+
+### Legacy Tests and Active Docs
+
+Do not blanket-delete `pkg/dataplane` tests. The deletion PR should remove or
+rewrite only tests that directly exercise the deleted legacy loader, generated
+legacy objects, XDP/TC attach graph, or stale generation commands. Tests for
+shared structs, userspace map sync, retained shim loading, and runtime boundary
+canaries must stay unless they are replaced by narrower userspace-only tests.
+
+Active docs and workflow references that describe legacy bpf2go generation as
+the normal path must be rewritten. Historical plans under `docs/archived/`,
+`docs/issues/`, and old `docs/pr/*` directories may keep legacy references when
+they are clearly historical. Current docs must not instruct developers to run a
+deleted XDP/TC generation path.
+
+## Retain Manifest
+
+These paths are not part of the #1476 legacy source deletion:
+
+- `userspace-xdp/`: Rust source for the retained AF_XDP entry shim.
+- `pkg/dataplane/userspace_xdp_bpfel.o`: retained embedded Rust XDP shim
+  object.
+- `pkg/dataplane/userspace_xdp_rust.go`: retained Go embed/load wrapper for the
+  Rust shim object.
+- `pkg/dataplane/build-userspace-xdp.sh`: retained shim-only build script until
+  a replacement generation path exists.
+- `test/xsk-repro/`: AF_XDP/XSK lab tooling, not the legacy forwarding
+  dataplane.
+- `pkg/dataplane/userspace/`: userspace manager, map sync, status, and shim
+  tests.
+- `pkg/dataplane/runtime/`: runtime-facing contracts that must stay independent
+  from BPF artifacts.
+
+Retain `bpf/headers/*.h` until each shared constant, struct, and helper
+dependency is either moved to a userspace-owned schema or explicitly retired:
+
+- `bpf/headers/xpf_common.h`
+- `bpf/headers/xpf_conntrack.h`
+- `bpf/headers/xpf_helpers.h`
+- `bpf/headers/xpf_maps.h`
+- `bpf/headers/xpf_nat.h`
+- `bpf/headers/xpf_trace.h`
+- `bpf/headers/README.md`
+
+The headers are not all dead with the XDP/TC source. The current tree still
+uses or cites them for `MAX_INTERFACES`, Go constants, userspace shim build
+inputs, userspace-dp struct parity tests, and DPDK shared-memory parity. A
+future PR may move these definitions, but that is a separate reviewed boundary.
+
+## Proof Required Before Deletion
+
+Before the #1476 deletion PR removes any source or generated artifact, it must
+show all of the following:
+
+- #1494 is merged and the userspace shim boundary canaries pass.
+- #1493 is merged and userspace startup no longer calls `loadAllObjects()`,
+  `loadXpfXdpMain()`, any legacy XDP/TC tail-call loader, or the legacy
+  `xdp_main_prog`/`tc_main_prog` program-map bootstrap.
+- #1451 has shrunk the root `dataplane.DataPlane` compatibility surface so API,
+  gRPC, CLI, status, monitor, logging, cluster sync, conntrack GC, and daemon
+  runtime paths do not require the legacy eBPF manager.
+- DPDK remains confined to its documented backend policy or has its own explicit
+  migration result; userspace-only source removal must not delete DPDK-required
+  shared definitions by accident.
+- `go test ./pkg/dataplane -run 'Test.*Manifest|Test.*Boundary|Test.*UserspaceXDP' -count=1`
+  passes with this manifest and the then-current canaries.
+- `go generate -n -run '^//go:generate bash build-userspace-xdp\.sh$' ./pkg/dataplane`
+  selects only the retained shim build.
+- A post-delete `rg` scan finds no production references to deleted generated
+  symbols such as `xpfXdp*`, `xpfTc*`, `loadXpfXdp*`, or `loadXpfTc*`.
+- A post-delete `rg` scan finds no active workflow instruction that still
+  requires legacy `bpf/xdp`, `bpf/tc`, or bpf2go generation.
+- The full userspace test gate and the #1477 cluster validation bundle pass on
+  the exact deletion candidate.
+
+## Adversarial Review Checklist
+
+Reviewers of the deletion PR should explicitly check these failure modes:
+
+- retained shim artifacts are not included in the deletion list or removed by
+  `make clean`;
+- tracked generated legacy artifacts are all covered by this manifest, and no
+  untracked `_bpfel`/`_bpfeb` leftovers are hiding outside Git;
+- stale `go:generate`, `make generate`, `make clean`, README, and development
+  workflow references are removed or rewritten;
+- DPDK policy remains explicit and no DPDK-only shared struct dependency is
+  lost as collateral damage;
+- `bpf/headers/*.h` consumers have either been moved to a userspace-owned
+  source of truth or are still retained intentionally; and
+- historical docs remain historical, while active docs no longer describe the
+  deleted legacy dataplane as the normal build or rollback path.

--- a/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
@@ -24,6 +24,12 @@ The removal path must land in this order:
 
 ## Delete Manifest
 
+### Legacy BPF Root Docs
+
+Delete the root legacy BPF tree README with the source tree it describes:
+
+- `bpf/README.md`
+
 ### Legacy XDP Source
 
 Delete these legacy ingress dataplane programs after the dependency order above
@@ -156,6 +162,9 @@ The headers are not all dead with the XDP/TC source. The current tree still
 uses or cites them for `MAX_INTERFACES`, Go constants, userspace shim build
 inputs, userspace-dp struct parity tests, and DPDK shared-memory parity. A
 future PR may move these definitions, but that is a separate reviewed boundary.
+`xpf_helpers.h` and `xpf_trace.h` have weaker current non-legacy consumers than
+the struct/constant headers; keep them conservatively until the deletion PR can
+prove they are orphaned after the legacy source is removed.
 
 ## Proof Required Before Deletion
 

--- a/pkg/dataplane/legacy_bpf_manifest_canary_test.go
+++ b/pkg/dataplane/legacy_bpf_manifest_canary_test.go
@@ -1,0 +1,171 @@
+package dataplane
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	legacyBPFManifestRepoRoot = "../.."
+	legacyBPFManifestPath     = "../../docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md"
+)
+
+var retainedUserspaceShimManifestPaths = []string{
+	"userspace-xdp/",
+	"pkg/dataplane/userspace_xdp_bpfel.o",
+	"pkg/dataplane/userspace_xdp_rust.go",
+	"pkg/dataplane/build-userspace-xdp.sh",
+	"test/xsk-repro/",
+}
+
+func TestLegacyBPFRemovalManifestCoversTrackedGeneratedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	manifest := readLegacyBPFManifest(t)
+	generated := gitTrackedFilesForLegacyBPFManifest(t,
+		"pkg/dataplane/*_bpfel.go",
+		"pkg/dataplane/*_bpfel.o",
+		"pkg/dataplane/*_bpfeb.go",
+		"pkg/dataplane/*_bpfeb.o",
+	)
+
+	var missing []string
+	for _, rel := range generated {
+		if isRetainedUserspaceShimManifestPath(rel) {
+			continue
+		}
+		if !strings.Contains(manifest, "`"+rel+"`") {
+			missing = append(missing, rel)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("legacy generated artifacts missing from #1476 manifest: %v", missing)
+	}
+}
+
+func TestLegacyBPFRemovalManifestKeepsRetainedShimOutOfDeleteScope(t *testing.T) {
+	t.Parallel()
+
+	manifest := readLegacyBPFManifest(t)
+	deleteSection := markdownSectionForLegacyBPFManifest(t, manifest, "## Delete Manifest")
+	retainSection := markdownSectionForLegacyBPFManifest(t, manifest, "## Retain Manifest")
+
+	var deleteViolations []string
+	var missingRetained []string
+	for _, rel := range retainedUserspaceShimManifestPaths {
+		if strings.Contains(deleteSection, rel) {
+			deleteViolations = append(deleteViolations, rel)
+		}
+		if !strings.Contains(retainSection, "`"+rel+"`") {
+			missingRetained = append(missingRetained, rel)
+		}
+	}
+	if len(deleteViolations) > 0 || len(missingRetained) > 0 {
+		sort.Strings(deleteViolations)
+		sort.Strings(missingRetained)
+		t.Fatalf(
+			"retained userspace shim manifest drift\ndelete-scope violations: %v\nmissing retain entries: %v",
+			deleteViolations,
+			missingRetained,
+		)
+	}
+}
+
+func TestLegacyBPFRemovalManifestDocumentsDependencyOrder(t *testing.T) {
+	t.Parallel()
+
+	manifest := readLegacyBPFManifest(t)
+	section := markdownSectionForLegacyBPFManifest(t, manifest, "## Dependency Order")
+	wantOrder := []string{
+		"#1494 canary",
+		"#1493 loader split",
+		"#1451 surface shrink",
+		"#1476 deletion",
+		"#1477 final evidence",
+	}
+
+	last := -1
+	for _, token := range wantOrder {
+		idx := strings.Index(section, token)
+		if idx < 0 {
+			t.Fatalf("#1476 manifest dependency order missing %q", token)
+		}
+		if idx <= last {
+			t.Fatalf("#1476 manifest dependency order has %q out of order", token)
+		}
+		last = idx
+	}
+}
+
+func readLegacyBPFManifest(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile(legacyBPFManifestPath)
+	if err != nil {
+		t.Fatalf("read #1476 source-removal manifest: %v", err)
+	}
+	return string(data)
+}
+
+func gitTrackedFilesForLegacyBPFManifest(t *testing.T, patterns ...string) []string {
+	t.Helper()
+
+	args := append([]string{"ls-files", "--"}, patterns...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = legacyBPFManifestRepoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git ls-files %v: %v\n%s", patterns, err, out)
+	}
+
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" {
+			continue
+		}
+		files = append(files, filepath.ToSlash(rel))
+	}
+	sort.Strings(files)
+	return files
+}
+
+func isRetainedUserspaceShimManifestPath(rel string) bool {
+	for _, retained := range retainedUserspaceShimManifestPaths {
+		if rel == strings.TrimSuffix(retained, "/") || strings.HasPrefix(rel, retained) {
+			return true
+		}
+	}
+	return false
+}
+
+func markdownSectionForLegacyBPFManifest(t *testing.T, text, heading string) string {
+	t.Helper()
+
+	lines := strings.Split(text, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == heading {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("manifest section %q not found", heading)
+	}
+
+	end := len(lines)
+	for i := start; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "## ") && line != heading {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}

--- a/pkg/dataplane/legacy_bpf_manifest_canary_test.go
+++ b/pkg/dataplane/legacy_bpf_manifest_canary_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -22,10 +23,20 @@ var retainedUserspaceShimManifestPaths = []string{
 	"test/xsk-repro/",
 }
 
+var legacyBPFManifestCodeSpanRE = regexp.MustCompile("`([^`]+)`")
+
 func TestLegacyBPFRemovalManifestCoversTrackedGeneratedArtifacts(t *testing.T) {
 	t.Parallel()
 
 	manifest := readLegacyBPFManifest(t)
+	deletePaths := markdownPathSetForLegacyBPFManifest(
+		t,
+		markdownSectionForLegacyBPFManifest(t, manifest, "## Delete Manifest"),
+	)
+	retainPaths := markdownPathSetForLegacyBPFManifest(
+		t,
+		markdownSectionForLegacyBPFManifest(t, manifest, "## Retain Manifest"),
+	)
 	generated := gitTrackedFilesForLegacyBPFManifest(t,
 		"pkg/dataplane/*_bpfel.go",
 		"pkg/dataplane/*_bpfel.o",
@@ -34,17 +45,88 @@ func TestLegacyBPFRemovalManifestCoversTrackedGeneratedArtifacts(t *testing.T) {
 	)
 
 	var missing []string
+	var wronglyRetained []string
 	for _, rel := range generated {
 		if isRetainedUserspaceShimManifestPath(rel) {
 			continue
 		}
-		if !strings.Contains(manifest, "`"+rel+"`") {
+		if !deletePaths[rel] {
 			missing = append(missing, rel)
+		}
+		if retainPaths[rel] {
+			wronglyRetained = append(wronglyRetained, rel)
+		}
+	}
+	if len(missing) > 0 || len(wronglyRetained) > 0 {
+		sort.Strings(missing)
+		sort.Strings(wronglyRetained)
+		t.Fatalf(
+			"legacy generated artifact manifest drift\nmissing from delete section: %v\nwrongly retained: %v",
+			missing,
+			wronglyRetained,
+		)
+	}
+}
+
+func TestLegacyBPFRemovalManifestCoversTrackedBPFSourceTree(t *testing.T) {
+	t.Parallel()
+
+	manifest := readLegacyBPFManifest(t)
+	deletePaths := markdownPathSetForLegacyBPFManifest(
+		t,
+		markdownSectionForLegacyBPFManifest(t, manifest, "## Delete Manifest"),
+	)
+	retainPaths := markdownPathSetForLegacyBPFManifest(
+		t,
+		markdownSectionForLegacyBPFManifest(t, manifest, "## Retain Manifest"),
+	)
+	tracked := gitTrackedFilesForLegacyBPFManifest(t, "bpf/**")
+
+	var missing []string
+	var doubleListed []string
+	for _, rel := range tracked {
+		inDelete := deletePaths[rel]
+		inRetain := retainPaths[rel]
+		switch {
+		case !inDelete && !inRetain:
+			missing = append(missing, rel)
+		case inDelete && inRetain:
+			doubleListed = append(doubleListed, rel)
+		}
+	}
+	if len(missing) > 0 || len(doubleListed) > 0 {
+		sort.Strings(missing)
+		sort.Strings(doubleListed)
+		t.Fatalf(
+			"tracked bpf/ source tree manifest drift\nmissing entries: %v\ndouble-listed entries: %v",
+			missing,
+			doubleListed,
+		)
+	}
+}
+
+func TestLegacyBPFRemovalManifestEntriesResolveToTrackedFiles(t *testing.T) {
+	t.Parallel()
+
+	manifest := readLegacyBPFManifest(t)
+	tracked := stringSet(gitTrackedFilesForLegacyBPFManifest(t))
+
+	sections := map[string]string{
+		"delete": markdownSectionForLegacyBPFManifest(t, manifest, "## Delete Manifest"),
+		"retain": markdownSectionForLegacyBPFManifest(t, manifest, "## Retain Manifest"),
+	}
+
+	var missing []string
+	for name, section := range sections {
+		for rel := range markdownPathSetForLegacyBPFManifest(t, section) {
+			if !manifestPathExistsInTrackedFiles(rel, tracked) {
+				missing = append(missing, name+":"+rel)
+			}
 		}
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		t.Fatalf("legacy generated artifacts missing from #1476 manifest: %v", missing)
+		t.Fatalf("#1476 manifest references paths not tracked at HEAD: %v", missing)
 	}
 }
 
@@ -82,11 +164,11 @@ func TestLegacyBPFRemovalManifestDocumentsDependencyOrder(t *testing.T) {
 	manifest := readLegacyBPFManifest(t)
 	section := markdownSectionForLegacyBPFManifest(t, manifest, "## Dependency Order")
 	wantOrder := []string{
-		"#1494 canary",
-		"#1493 loader split",
-		"#1451 surface shrink",
-		"#1476 deletion",
-		"#1477 final evidence",
+		"#1494",
+		"#1493",
+		"#1451",
+		"#1476",
+		"#1477",
 	}
 
 	last := -1
@@ -115,6 +197,7 @@ func readLegacyBPFManifest(t *testing.T) string {
 func gitTrackedFilesForLegacyBPFManifest(t *testing.T, patterns ...string) []string {
 	t.Helper()
 
+	requireGitForLegacyBPFManifest(t)
 	args := append([]string{"ls-files", "--"}, patterns...)
 	cmd := exec.Command("git", args...)
 	cmd.Dir = legacyBPFManifestRepoRoot
@@ -133,6 +216,70 @@ func gitTrackedFilesForLegacyBPFManifest(t *testing.T, patterns ...string) []str
 	}
 	sort.Strings(files)
 	return files
+}
+
+func requireGitForLegacyBPFManifest(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available; skipping #1476 manifest canary: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(legacyBPFManifestRepoRoot, ".git")); err != nil {
+		t.Skipf("not a git checkout; skipping #1476 manifest canary: %v", err)
+	}
+}
+
+func markdownPathSetForLegacyBPFManifest(t *testing.T, section string) map[string]bool {
+	t.Helper()
+
+	paths := map[string]bool{}
+	for _, match := range legacyBPFManifestCodeSpanRE.FindAllStringSubmatch(section, -1) {
+		value := strings.TrimSpace(match[1])
+		if legacyBPFManifestPathCandidate(value) {
+			paths[value] = true
+		}
+	}
+	return paths
+}
+
+func legacyBPFManifestPathCandidate(value string) bool {
+	if value == "" || strings.ContainsAny(value, "* ") {
+		return false
+	}
+	switch {
+	case value == "Makefile":
+		return true
+	case strings.HasPrefix(value, "bpf/"):
+		return true
+	case strings.HasPrefix(value, "pkg/dataplane/"):
+		return true
+	case strings.HasPrefix(value, "userspace-xdp/"):
+		return true
+	case strings.HasPrefix(value, "test/xsk-repro/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func stringSet(values []string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
+}
+
+func manifestPathExistsInTrackedFiles(rel string, tracked map[string]bool) bool {
+	if strings.HasSuffix(rel, "/") {
+		for path := range tracked {
+			if strings.HasPrefix(path, rel) {
+				return true
+			}
+		}
+		return false
+	}
+	return tracked[rel]
 }
 
 func isRetainedUserspaceShimManifestPath(rel string) bool {


### PR DESCRIPTION
## Summary

- add the #1476 legacy BPF source-removal manifest without deleting source
- enumerate the future delete set for legacy XDP/TC source, bpf2go Go/object
  artifacts, loader hooks, Makefile hooks, tests, and active docs
- enumerate retained userspace shim artifacts, AF_XDP lab tooling, and shared
  headers that must not be removed blindly
- document the dependency order: #1494 canary, #1493 loader split, #1451
  surface shrink, #1476 deletion, then #1477 final evidence
- add a static manifest canary for tracked generated artifacts, retained shim
  exclusions, and dependency-order drift

## Manifest Boundary

The delete manifest names the current 14 legacy bpf2go Go/object pairs and the
legacy `bpf/xdp` and `bpf/tc` C sources. The retain manifest keeps
`userspace-xdp/`, `pkg/dataplane/userspace_xdp_bpfel.o`,
`pkg/dataplane/userspace_xdp_rust.go`,
`pkg/dataplane/build-userspace-xdp.sh`, `test/xsk-repro/`, and
`bpf/headers/*.h` until their shared userspace/DPDK dependencies are moved or
explicitly retired.

## Adversarial Self-Review

- retained shim diff check: no diffs under `userspace-xdp`, retained shim
  object/embed/build script, `test/xsk-repro`, or `bpf/headers`
- untracked generated check: no untracked or ignored `_bpfel`/`_bpfeb`
  generated files in `pkg/dataplane`, `userspace-xdp/target`, or XSK repro
  object paths
- stale build hooks: manifest explicitly calls out the future `loader.go`,
  `loader_ebpf.go`, `loader_stub.go`, `Makefile generate`, and `Makefile
  clean` cleanup boundary
- DPDK policy: active retirement docs and the manifest keep DPDK outside the
  userspace source-removal path unless its backend policy is explicitly updated
- shared headers: current scans still show `bpf/headers` consumers in the
  userspace shim build, Go constants/tests, userspace-dp parity tests, and DPDK
  shared-memory parity, so headers are retained

## Validation

- `go test ./pkg/dataplane -run 'Test.*Manifest|Test.*Boundary|Test.*UserspaceXDP' -count=1 -v`
- `go test ./pkg/dataplane -count=1`
- `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`
- `git diff --check`

Refs #1476.
Refs #1493.
Refs #1451.
Refs #1373.
