### PR TITLE
Prepare #1477 retirement validation artifacts

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,24 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T04:08:49Z
+  - **Action**: PR #1497 round-3 follow-up — fixed the checker/schema
+    parity nits from review: boolean `schema_version` rejection, JSON
+    integer float issue acceptance, RFC3339 lowercase/leap-second
+    acceptance, reachable empty `config_files` validation, parsed fallback
+    JSON artifacts, and Unicode decode failures reported as validation
+    errors instead of tracebacks.
+  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
+    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
+  - **Validation**: `python3 -m unittest discover -s test/incus -p
+    retire_ebpf_artifact_schema_test.py`;
+    `python3 test/incus/retire_ebpf_artifact_schema_test.py`;
+    `python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py
+    test/incus/retire_ebpf_artifact_schema_test.py`;
+    `python3 -m json.tool
+    docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
+    >/dev/null`; `git diff --check`
+
 - **Timestamp**: 2026-05-24T03:46:48Z
   - **Action**: PR #1497 round-2 follow-up — aligned the Python #1477
     artifact checker with the manifest schema's required-field, uniqueness,

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,24 @@
 # Action Log
 
+## 2026-05-24
+
+- **Timestamp**: 2026-05-24T03:46:48Z
+  - **Action**: PR #1497 round-2 follow-up — aligned the Python #1477
+    artifact checker with the manifest schema's required-field, uniqueness,
+    non-empty string, command artifact, and RFC3339 date-time constraints.
+    Added hostile regression tests for the schema/checker drift cases raised
+    in PR review.
+  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
+    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
+  - **Validation**: `python3 -m unittest discover -s test/incus -p
+    retire_ebpf_artifact_schema_test.py`;
+    `python3 test/incus/retire_ebpf_artifact_schema_test.py`;
+    `python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py
+    test/incus/retire_ebpf_artifact_schema_test.py`;
+    `python3 -m json.tool
+    docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
+    >/dev/null`; `git diff --check`
+
 ## 2026-05-23
 
 - **Timestamp**: 2026-05-23T09:31:43Z

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -245,6 +245,14 @@ checklist: CoS-off IPv4/IPv6 push and reverse, screen/flood baseline,
 CoS-on 5200..5211 class sweeps, 6200..6211 TCP echo probes, and the
 existing HA Makefile gates.
 
+## #1477 Final Artifact Contract
+
+Use [final-validation/README.md](final-validation/README.md) for the final
+source-removal candidate artifact layout. The structural checker at
+`test/incus/retire_ebpf_artifact_schema.py` verifies that the evidence bundle is
+complete, consistently named, and tied to the exact 40-character candidate SHA;
+it does not replace live-result review.
+
 ## Shared Non-Goals
 
 - Do not remove `bpf/` in these blocker implementation PRs; that remains #1373

--- a/docs/pr/1373-retire-ebpf-dataplane/final-validation/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/final-validation/README.md
@@ -95,15 +95,16 @@ syn-cookie/
   final-cluster-status.txt
 cos-on-5200-5211-push/
 cos-on-5200-5211-reverse/
-  summary.tsv
-  summary.md
-  dataplane/status-before.json
-  dataplane/status-after.json
-  dataplane/counter-delta.json
-  dataplane/journal-since.txt
-  dataplane-summary.tsv
-  equal-flow-summary.tsv
-  q0-best-effort-root/... q11-iperf-uncapped-root/...
+  Each directory contains:
+    summary.tsv
+    summary.md
+    dataplane/status-before.json
+    dataplane/status-after.json
+    dataplane/counter-delta.json
+    dataplane/journal-since.txt
+    dataplane-summary.tsv
+    equal-flow-summary.tsv
+    q0-best-effort-root/... q11-iperf-uncapped-root/...
 echo-6200-6211/
   summary.tsv
   latency-summary.tsv

--- a/docs/pr/1373-retire-ebpf-dataplane/final-validation/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/final-validation/README.md
@@ -1,0 +1,187 @@
+# #1477 Final Userspace-Only Validation Artifacts
+
+This directory defines the artifact contract for #1477. Do not populate the
+final evidence bundle until the exact #1476 source-removal candidate exists.
+The structural checker below is a completeness gate only: it verifies names,
+sections, JSON parseability, and commit binding. It does not decide whether the
+live cluster results are acceptable.
+
+## Candidate Binding
+
+Create the final artifact root from the source-removal candidate commit:
+
+```bash
+CANDIDATE_COMMIT="$(git rev-parse HEAD)"
+ARTIFACT_ROOT="docs/pr/1373-retire-ebpf-dataplane/evidence-1477-source-removal-$(date +%Y%m%d)-${CANDIDATE_COMMIT:0:12}"
+mkdir -p "$ARTIFACT_ROOT"
+```
+
+The root name, `manifest.json`, `metadata/git-rev-parse-head.txt`, and
+`summary.md` must all name the same full 40-character commit SHA. The bundle is
+not reusable across rebases or amended source-removal candidates.
+
+## Required Top-Level Files
+
+- `manifest.json`: machine-readable run manifest matching
+  [manifest.schema.json](manifest.schema.json).
+- `summary.md`: human-readable report with these required `##` sections:
+  `Candidate`, `Cluster And Binaries`,
+  `CoS-Off IPv4/IPv6 Push And Reverse`, `Screen/Flood Baseline`,
+  `SYN-Cookie Proof`, `CoS 5200-5211 Sweeps`, `TCP Echo 6200-6211`,
+  `HA Gates`, `Fallback Exclusion`, `Command Exit Status`, and
+  `Remaining Exceptions`.
+- `metadata/`: exact commit, dirty status, cluster env, config, IPv6 RA route
+  proof, and binary SHA-256 hashes.
+
+## Required Artifact Layout
+
+```text
+cos-off/
+  v4-push.json
+  v4-push.stderr
+  v4-push.metrics.json
+  v4-reverse.json
+  v4-reverse.stderr
+  v4-reverse.metrics.json
+  v6-push.json
+  v6-push.stderr
+  v6-push.metrics.json
+  v6-reverse.json
+  v6-reverse.stderr
+  v6-reverse.metrics.json
+screen-flood/
+  land-before.txt
+  land-after.txt
+  land-configure.stdout
+  land-configure.stderr
+  syn-before.txt
+  syn-after.txt
+  syn-configure.stdout
+  syn-configure.stderr
+  icmp-before.txt
+  icmp-after.txt
+  icmp-configure.stdout
+  icmp-configure.stderr
+  udp-before.txt
+  udp-after.txt
+  udp-configure.stdout
+  udp-configure.stderr
+  restore.stdout
+  restore.stderr
+syn-cookie/
+  summary.md
+  applied-config.txt
+  challenge-hping3.stdout
+  challenge-hping3.stderr
+  challenge-tcpdump.txt
+  challenge-counters-before.txt
+  challenge-counters-after.txt
+  valid-ack-rst-tcpdump.txt
+  valid-ack-rst-counters-before.txt
+  valid-ack-rst-counters-after.txt
+  random-ack-drop-tcpdump.txt
+  random-ack-drop-counters-before.txt
+  random-ack-drop-counters-after.txt
+  retransmitted-syn-admission-tcpdump.txt
+  retransmitted-syn-admission-counters-before.txt
+  retransmitted-syn-admission-counters-after.txt
+  reply-budget-counters.txt
+  failover-before-cluster-status.txt
+  failover-after-cluster-status.txt
+  failover-cookie-ack-tcpdump.txt
+  failover-counters-node1.txt
+  cleanup.stdout
+  cleanup.stderr
+  final-cluster-status.txt
+cos-on-5200-5211-push/
+cos-on-5200-5211-reverse/
+  summary.tsv
+  summary.md
+  dataplane/status-before.json
+  dataplane/status-after.json
+  dataplane/counter-delta.json
+  dataplane/journal-since.txt
+  dataplane-summary.tsv
+  equal-flow-summary.tsv
+  q0-best-effort-root/... q11-iperf-uncapped-root/...
+echo-6200-6211/
+  summary.tsv
+  latency-summary.tsv
+  6200.stdout
+  6200.stderr
+  ...
+  6211.stdout
+  6211.stderr
+userspace-phase-cycle.log
+userspace-ha-failover.log
+userspace-ha-failover/
+  iperf3.log
+  iperf3.metrics.json
+  before-source-status.txt
+  before-target-status.txt
+  cycle*-failover-*-dp-stats.txt
+  cycle*-failback-*-dp-stats.txt
+  cycle*-failover-*-dp-interfaces.txt
+  cycle*-failback-*-dp-interfaces.txt
+ha-test-failover.log
+ha-test-ha-crash.log
+ha-test-restart-connectivity.log
+fallback-exclusion/
+  fw0-ip-link.txt
+  fw1-ip-link.txt
+  fw0-dp-stats.txt
+  fw1-dp-stats.txt
+  fw0-userspace-dp.json
+  fw1-userspace-dp.json
+  legacy-map-counter-audit.txt
+```
+
+Each CoS sweep class directory must preserve `wrapper.stdout`,
+`wrapper.stderr`, `samples/summary.json`, `equal-flow/summary.json`,
+`dataplane/status-before.json`, and `dataplane/status-after.json` for every
+canonical class from `q0-best-effort-root` through `q11-iperf-uncapped-root`.
+
+## Structural Check
+
+After copying the final live artifacts into the root:
+
+```bash
+python3 test/incus/retire_ebpf_artifact_schema.py \
+  "$ARTIFACT_ROOT" \
+  --candidate-commit "$CANDIDATE_COMMIT"
+```
+
+The command prints `STRUCTURE_OK` only when required artifacts and sections are
+present. A structural success is not a live-result PASS. The final #1477 report
+still needs a human review of throughput, retransmits, screen deltas,
+SYN-cookie packet captures, HA loss windows, fallback exclusion text, and any
+exceptions listed in `summary.md`.
+
+## Metadata Capture Checklist
+
+Record these before running destructive HA gates:
+
+```bash
+git rev-parse HEAD >"$ARTIFACT_ROOT/metadata/git-rev-parse-head.txt"
+git status --short >"$ARTIFACT_ROOT/metadata/git-status-short.txt"
+cp test/incus/loss-userspace-cluster.env "$ARTIFACT_ROOT/metadata/cluster-env.txt"
+cp docs/ha-cluster-userspace.conf "$ARTIFACT_ROOT/metadata/ha-cluster-userspace.conf"
+```
+
+Record binary hashes from both userspace firewalls and the helper binary paths
+actually deployed. Save the cluster host IPv6 default route after the
+router-advertisement gate in `metadata/cluster-userspace-host-ipv6-route.txt`.
+
+## Fallback Exclusion Checklist
+
+Capture both firewall peers after the source-removal candidate is deployed:
+
+- `ip -details link show` for the data interfaces.
+- `show chassis cluster data-plane statistics`.
+- `/run/xpf/userspace-dp.json`.
+- A short legacy map-counter audit explaining why no legacy BPF map counter
+  source is present in the source-removal candidate.
+
+The checker requires those files so a report cannot claim a userspace-only
+run while omitting the status needed to rule out `xdp_main_prog` or legacy
+counter fallback.

--- a/docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
+++ b/docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/psaab/xpf/docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json",
+  "title": "#1477 Final Userspace-Only Validation Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "issues",
+    "candidate_commit",
+    "cluster",
+    "binaries",
+    "commands"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "allOf": [
+        {
+          "contains": {
+            "const": 1373
+          }
+        },
+        {
+          "contains": {
+            "const": 1477
+          }
+        }
+      ],
+      "minItems": 2,
+      "uniqueItems": true
+    },
+    "candidate_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "candidate_branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "cluster": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "env_file",
+        "config_files"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "env_file": {
+          "const": "test/incus/loss-userspace-cluster.env"
+        },
+        "config_files": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "contains": {
+            "const": "docs/ha-cluster-userspace.conf"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "binaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "host",
+          "path",
+          "sha256"
+        ],
+        "properties": {
+          "host": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "gate",
+          "command",
+          "exit_status"
+        ],
+        "properties": {
+          "gate": {
+            "type": "string",
+            "enum": [
+              "cos-off",
+              "screen-flood",
+              "syn-cookie",
+              "cos-on-5200-5211-push",
+              "cos-on-5200-5211-reverse",
+              "echo-6200-6211",
+              "userspace-phase-cycle",
+              "userspace-ha-failover",
+              "ha-test-failover",
+              "ha-test-ha-crash",
+              "ha-test-restart-connectivity",
+              "fallback-exclusion"
+            ]
+          },
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "exit_status": {
+            "type": "integer"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finished_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md
@@ -110,16 +110,17 @@ This gate proves the userspace cluster still exercises screen paths before BPF
 retirement work proceeds. The userspace status path currently publishes an
 aggregate `screen_drops` counter, so this gate isolates each configured check
 instead of summing unrelated statistics: LAND-only, then SYN-flood-only, then
-ICMP-flood-only. Each subcheck requires the aggregate counter to advance after
-its matching probe. It always redeploys the baseline config on exit so the low
-thresholds do not contaminate reruns or later CoS measurements.
+ICMP-flood-only, then UDP-flood-only. Each subcheck requires the aggregate
+counter to advance after its matching probe. It always redeploys the baseline
+config on exit so the low thresholds do not contaminate reruns or later CoS
+measurements.
 
 This is not the #1374 SYN-cookie proof. SYN-cookie runtime support is now wired
 in userspace, but BPF source removal still needs a dedicated #1374 artifact set
 showing SYN-ACK replies, validated-ACK RST replies, retransmitted-SYN
 admission, random-ACK drops, reply-budget accounting, and HA failover
-acceptance. This section covers the LAND, SYN-flood, and ICMP-flood screen
-plumbing baseline.
+acceptance. This section covers the LAND, SYN-flood, ICMP-flood, and UDP-flood
+screen plumbing baseline.
 
 ```bash
 set -euo pipefail
@@ -234,6 +235,13 @@ for i in $(seq 1 80); do ping -c 1 -W 1 172.16.50.1 >/dev/null 2>&1 || true; don
 icmp_after=$(capture_screen_total icmp-after)
 assert_advanced ICMP-flood "$icmp_before" "$icmp_after"
 
+apply_screen_profile udp pr1373-udp 'set security screen ids-option pr1373-udp udp flood threshold 1'
+udp_before=$(capture_screen_total udp-before)
+run_loss_host 'set -euo pipefail
+for i in $(seq 1 80); do printf pr1373-udp > /dev/udp/172.16.50.1/65000 || true; done'
+udp_after=$(capture_screen_total udp-after)
+assert_advanced UDP-flood "$udp_before" "$udp_after"
+
 BPFRX_CLUSTER_ENV="$BPFRX_CLUSTER_ENV" ./test/incus/cluster-setup.sh deploy all
 SCREEN_RESTORE_NEEDED=0
 trap - EXIT
@@ -294,22 +302,27 @@ two sweep commands. Do not use that shortened run as the Phase 1/2 gate.
 ## Gate 4: CoS-On TCP Echo 6200-6211
 
 This checks that the TCP echo service for each CoS class accepts a connection
-through the userspace dataplane and returns the payload.
+through the userspace dataplane, returns the payload, and records one
+connect-plus-echo latency sample per port.
 
 ```bash
 set -euo pipefail
 mkdir -p "$ARTIFACT_ROOT/echo-6200-6211"
 SUMMARY_TSV="$ARTIFACT_ROOT/echo-6200-6211/summary.tsv"
-: >"$SUMMARY_TSV"
+LATENCY_TSV="$ARTIFACT_ROOT/echo-6200-6211/latency-summary.tsv"
+printf 'port\tverdict\tlatency_ns\n' >"$SUMMARY_TSV"
+cp "$SUMMARY_TSV" "$LATENCY_TSV"
 failed=0
 for port in $(seq 6200 6211); do
   payload="pr1373-${port}"
-  if run_loss_host "timeout 4 bash -lc 'payload=${payload}; exec 3<>/dev/tcp/172.16.80.200/${port}; printf %s \"\$payload\" >&3; IFS= read -r -N \${#payload} reply <&3; [[ \"\$reply\" == \"\$payload\" ]]'" \
+  if run_loss_host "timeout 4 bash -lc 'payload=${payload}; start=\$(date +%s%N); exec 3<>/dev/tcp/172.16.80.200/${port}; printf %s \"\$payload\" >&3; IFS= read -r -N \${#payload} reply <&3; end=\$(date +%s%N); [[ \"\$reply\" == \"\$payload\" ]]; printf \"latency_ns=%s\n\" \"\$((end - start))\"'" \
     >"$ARTIFACT_ROOT/echo-6200-6211/${port}.stdout" \
     2>"$ARTIFACT_ROOT/echo-6200-6211/${port}.stderr"; then
-    printf '%s\tPASS\n' "$port" | tee -a "$SUMMARY_TSV"
+    latency_ns="$(sed -n 's/^latency_ns=//p' "$ARTIFACT_ROOT/echo-6200-6211/${port}.stdout" | tail -n1)"
+    : "${latency_ns:=unknown}"
+    printf '%s\tPASS\t%s\n' "$port" "$latency_ns" | tee -a "$SUMMARY_TSV" >>"$LATENCY_TSV"
   else
-    printf '%s\tFAIL\n' "$port" | tee -a "$SUMMARY_TSV"
+    printf '%s\tFAIL\t-\n' "$port" | tee -a "$SUMMARY_TSV" >>"$LATENCY_TSV"
     failed=1
   fi
 done
@@ -381,3 +394,24 @@ BPFRX_CLUSTER_ENV="$BPFRX_CLUSTER_ENV" make test-restart-connectivity \
 
 Record the final `git rev-parse HEAD`, `$ARTIFACT_ROOT`, and the exit status
 of every command in the validation report.
+
+## Gate 8: Final #1477 Artifact Packaging
+
+For the final source-removal candidate, copy or run the gates into the schema
+defined by
+[final-validation/README.md](final-validation/README.md). This packaging gate
+does not validate live result quality; it blocks incomplete or stale evidence
+sets before review.
+
+```bash
+set -euo pipefail
+CANDIDATE_COMMIT="$(git rev-parse HEAD)"
+python3 test/incus/retire_ebpf_artifact_schema.py \
+  "$ARTIFACT_ROOT" \
+  --candidate-commit "$CANDIDATE_COMMIT"
+```
+
+The checker intentionally requires a full 40-character SHA in the manifest,
+matching `metadata/git-rev-parse-head.txt` and the artifact root name. If the
+source-removal branch is rebased or amended, rebuild the artifact directory
+instead of reusing the old one.

--- a/docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md
@@ -315,7 +315,7 @@ cp "$SUMMARY_TSV" "$LATENCY_TSV"
 failed=0
 for port in $(seq 6200 6211); do
   payload="pr1373-${port}"
-  if run_loss_host "timeout 4 bash -lc 'payload=${payload}; start=\$(date +%s%N); exec 3<>/dev/tcp/172.16.80.200/${port}; printf %s \"\$payload\" >&3; IFS= read -r -N \${#payload} reply <&3; end=\$(date +%s%N); [[ \"\$reply\" == \"\$payload\" ]]; printf \"latency_ns=%s\n\" \"\$((end - start))\"'" \
+  if run_loss_host "timeout 4 bash -lc 'payload=${payload}; start=\$(date +%s%N); exec 3<>/dev/tcp/172.16.80.200/${port}; printf %s \"\$payload\" >&3; IFS= read -r -N \${#payload} reply <&3; end=\$(date +%s%N); [[ \"\$reply\" == \"\$payload\" ]] && printf \"latency_ns=%s\n\" \"\$((end - start))\"'" \
     >"$ARTIFACT_ROOT/echo-6200-6211/${port}.stdout" \
     2>"$ARTIFACT_ROOT/echo-6200-6211/${port}.stderr"; then
     latency_ns="$(sed -n 's/^latency_ns=//p' "$ARTIFACT_ROOT/echo-6200-6211/${port}.stdout" | tail -n1)"

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -53,6 +53,29 @@ REQUIRED_COMMAND_GATES = {
     "fallback-exclusion",
 }
 
+MANIFEST_FIELDS = {
+    "schema_version",
+    "issues",
+    "candidate_commit",
+    "candidate_branch",
+    "artifact_created_at",
+    "cluster",
+    "binaries",
+    "commands",
+    "notes",
+}
+
+CLUSTER_FIELDS = {"name", "env_file", "config_files"}
+BINARY_FIELDS = {"host", "path", "sha256", "version"}
+COMMAND_FIELDS = {
+    "gate",
+    "command",
+    "exit_status",
+    "started_at",
+    "finished_at",
+    "artifacts",
+}
+
 SUMMARY_HEADINGS = (
     "Candidate",
     "Cluster And Binaries",
@@ -128,12 +151,24 @@ class ArtifactChecker:
             self.error("manifest.json must contain a JSON object")
             return {}
 
+        self.validate_known_fields("manifest.json", manifest, MANIFEST_FIELDS)
+
         if manifest.get("schema_version") != 1:
             self.error("manifest.json schema_version must be 1")
 
         issues = manifest.get("issues")
-        if not isinstance(issues, list) or not {1373, 1477}.issubset(set(issues)):
+        if not isinstance(issues, list):
             self.error("manifest.json issues must include 1373 and 1477")
+        else:
+            bad_issue_types = [
+                issue
+                for issue in issues
+                if isinstance(issue, bool) or not isinstance(issue, int)
+            ]
+            if bad_issue_types:
+                self.error("manifest.json issues must be integer issue numbers")
+            elif not {1373, 1477}.issubset(set(issues)):
+                self.error("manifest.json issues must include 1373 and 1477")
 
         raw_commit = manifest.get("candidate_commit")
         if not isinstance(raw_commit, str) or not FULL_SHA_RE.match(raw_commit):
@@ -156,6 +191,7 @@ class ArtifactChecker:
         if not isinstance(cluster, dict):
             self.error("manifest.json cluster must be an object")
         else:
+            self.validate_known_fields("manifest.json cluster", cluster, CLUSTER_FIELDS)
             if cluster.get("env_file") != "test/incus/loss-userspace-cluster.env":
                 self.error(
                     "manifest.json cluster.env_file must be "
@@ -169,6 +205,8 @@ class ArtifactChecker:
                     "manifest.json cluster.config_files must include "
                     "docs/ha-cluster-userspace.conf"
                 )
+            elif any(not isinstance(item, str) for item in config_files):
+                self.error("manifest.json cluster.config_files entries must be strings")
 
         binaries = manifest.get("binaries")
         if not isinstance(binaries, list) or not binaries:
@@ -178,6 +216,9 @@ class ArtifactChecker:
                 if not isinstance(binary, dict):
                     self.error(f"manifest.json binaries[{idx}] must be an object")
                     continue
+                self.validate_known_fields(
+                    f"manifest.json binaries[{idx}]", binary, BINARY_FIELDS
+                )
                 for field in ("host", "path"):
                     if not isinstance(binary.get(field), str) or not binary[field]:
                         self.error(f"manifest.json binaries[{idx}].{field} is required")
@@ -196,12 +237,21 @@ class ArtifactChecker:
                 if not isinstance(command, dict):
                     self.error(f"manifest.json commands[{idx}] must be an object")
                     continue
+                self.validate_known_fields(
+                    f"manifest.json commands[{idx}]", command, COMMAND_FIELDS
+                )
                 gate = command.get("gate")
                 if isinstance(gate, str):
-                    gates.add(gate)
+                    if gate in REQUIRED_COMMAND_GATES:
+                        gates.add(gate)
+                    else:
+                        self.error(f"manifest.json commands[{idx}].gate is unknown: {gate}")
                 else:
                     self.error(f"manifest.json commands[{idx}].gate is required")
-                if not isinstance(command.get("exit_status"), int):
+                if not isinstance(command.get("command"), str) or not command["command"]:
+                    self.error(f"manifest.json commands[{idx}].command is required")
+                exit_status = command.get("exit_status")
+                if isinstance(exit_status, bool) or not isinstance(exit_status, int):
                     self.error(
                         f"manifest.json commands[{idx}].exit_status must be recorded as an integer"
                     )
@@ -210,6 +260,13 @@ class ArtifactChecker:
                 self.error("manifest.json commands missing gates: " + ", ".join(missing))
 
         return manifest
+
+    def validate_known_fields(
+        self, context: str, value: dict[str, Any], allowed: set[str]
+    ) -> None:
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            self.error(f"{context} has unknown fields: {', '.join(unknown)}")
 
     def validate_metadata(self) -> None:
         self.require_file("metadata/git-rev-parse-head.txt")

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Validate the #1477 final retirement artifact layout.
+
+This checker is intentionally structural. It proves that the final evidence
+bundle is complete, consistently named, and tied to one full source-removal
+commit. It does not decide whether the live cluster results are acceptable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+COS_OFF_CASES = ("v4-push", "v4-reverse", "v6-push", "v6-reverse")
+SCREEN_PROBES = ("land", "syn", "icmp", "udp")
+ECHO_PORTS = range(6200, 6212)
+COS_CLASSES = (
+    "q0-best-effort-root",
+    "q1-iperf-100m",
+    "q2-iperf-1g",
+    "q3-iperf-3g",
+    "q4-iperf-6g",
+    "q5-iperf-9g",
+    "q6-iperf-12g",
+    "q7-iperf-15g",
+    "q8-iperf-18g",
+    "q9-iperf-21g",
+    "q10-iperf-24g",
+    "q11-iperf-uncapped-root",
+)
+COS_SWEEP_DIRS = ("cos-on-5200-5211-push", "cos-on-5200-5211-reverse")
+
+REQUIRED_COMMAND_GATES = {
+    "cos-off",
+    "screen-flood",
+    "syn-cookie",
+    "cos-on-5200-5211-push",
+    "cos-on-5200-5211-reverse",
+    "echo-6200-6211",
+    "userspace-phase-cycle",
+    "userspace-ha-failover",
+    "ha-test-failover",
+    "ha-test-ha-crash",
+    "ha-test-restart-connectivity",
+    "fallback-exclusion",
+}
+
+SUMMARY_HEADINGS = (
+    "Candidate",
+    "Cluster And Binaries",
+    "CoS-Off IPv4/IPv6 Push And Reverse",
+    "Screen/Flood Baseline",
+    "SYN-Cookie Proof",
+    "CoS 5200-5211 Sweeps",
+    "TCP Echo 6200-6211",
+    "HA Gates",
+    "Fallback Exclusion",
+    "Command Exit Status",
+    "Remaining Exceptions",
+)
+
+SYN_COOKIE_HEADINGS = (
+    "Temporary Config",
+    "SYN-ACK Challenge",
+    "Valid ACK RST",
+    "Random ACK Drop",
+    "Retransmitted SYN Admission",
+    "Reply Budget Accounting",
+    "HA Failover Acceptance",
+    "Cleanup",
+)
+
+
+class ValidationFailure(Exception):
+    """Raised when the artifact directory fails structural validation."""
+
+
+def _display(path: Path) -> str:
+    return path.as_posix()
+
+
+class ArtifactChecker:
+    def __init__(self, root: Path, *, candidate_commit: str | None = None) -> None:
+        self.root = root
+        self.expected_commit = candidate_commit.lower() if candidate_commit else None
+        self.errors: list[str] = []
+        self.checked = 0
+        self.candidate_commit = ""
+
+    def validate(self) -> dict[str, Any]:
+        if not self.root.exists():
+            raise ValidationFailure(f"artifact root does not exist: {self.root}")
+        if not self.root.is_dir():
+            raise ValidationFailure(f"artifact root is not a directory: {self.root}")
+
+        manifest = self.validate_manifest()
+        self.validate_metadata()
+        self.validate_summary("summary.md", SUMMARY_HEADINGS, self.candidate_commit)
+        self.validate_cos_off()
+        self.validate_screen_flood()
+        self.validate_syn_cookie()
+        self.validate_cos_sweeps()
+        self.validate_echo()
+        self.validate_ha()
+        self.validate_fallback_exclusion()
+
+        if self.errors:
+            raise ValidationFailure("\n".join(self.errors))
+        return {
+            "verdict": "STRUCTURE_OK",
+            "artifact_root": str(self.root),
+            "candidate_commit": self.candidate_commit,
+            "checked": self.checked,
+            "manifest_schema_version": manifest.get("schema_version"),
+        }
+
+    def validate_manifest(self) -> dict[str, Any]:
+        manifest = self.require_json("manifest.json")
+        if not isinstance(manifest, dict):
+            self.error("manifest.json must contain a JSON object")
+            return {}
+
+        if manifest.get("schema_version") != 1:
+            self.error("manifest.json schema_version must be 1")
+
+        issues = manifest.get("issues")
+        if not isinstance(issues, list) or not {1373, 1477}.issubset(set(issues)):
+            self.error("manifest.json issues must include 1373 and 1477")
+
+        raw_commit = manifest.get("candidate_commit")
+        if not isinstance(raw_commit, str) or not FULL_SHA_RE.match(raw_commit):
+            self.error("manifest.json candidate_commit must be a full 40-character SHA")
+        else:
+            self.candidate_commit = raw_commit.lower()
+            if self.expected_commit and self.expected_commit != self.candidate_commit:
+                self.error(
+                    "candidate commit mismatch: "
+                    f"expected {self.expected_commit}, manifest has {self.candidate_commit}"
+                )
+            short = self.candidate_commit[:12]
+            if short not in self.root.name:
+                self.error(
+                    "artifact root name must include the first 12 characters of "
+                    f"candidate_commit ({short})"
+                )
+
+        cluster = manifest.get("cluster")
+        if not isinstance(cluster, dict):
+            self.error("manifest.json cluster must be an object")
+        else:
+            if cluster.get("env_file") != "test/incus/loss-userspace-cluster.env":
+                self.error(
+                    "manifest.json cluster.env_file must be "
+                    "test/incus/loss-userspace-cluster.env"
+                )
+            config_files = cluster.get("config_files")
+            if not isinstance(config_files, list) or (
+                "docs/ha-cluster-userspace.conf" not in config_files
+            ):
+                self.error(
+                    "manifest.json cluster.config_files must include "
+                    "docs/ha-cluster-userspace.conf"
+                )
+
+        binaries = manifest.get("binaries")
+        if not isinstance(binaries, list) or not binaries:
+            self.error("manifest.json binaries must be a non-empty list")
+        else:
+            for idx, binary in enumerate(binaries):
+                if not isinstance(binary, dict):
+                    self.error(f"manifest.json binaries[{idx}] must be an object")
+                    continue
+                for field in ("host", "path"):
+                    if not isinstance(binary.get(field), str) or not binary[field]:
+                        self.error(f"manifest.json binaries[{idx}].{field} is required")
+                digest = binary.get("sha256")
+                if not isinstance(digest, str) or not SHA256_RE.match(digest):
+                    self.error(
+                        f"manifest.json binaries[{idx}].sha256 must be a 64-character hex digest"
+                    )
+
+        commands = manifest.get("commands")
+        if not isinstance(commands, list):
+            self.error("manifest.json commands must be a list")
+        else:
+            gates: set[str] = set()
+            for idx, command in enumerate(commands):
+                if not isinstance(command, dict):
+                    self.error(f"manifest.json commands[{idx}] must be an object")
+                    continue
+                gate = command.get("gate")
+                if isinstance(gate, str):
+                    gates.add(gate)
+                else:
+                    self.error(f"manifest.json commands[{idx}].gate is required")
+                if not isinstance(command.get("exit_status"), int):
+                    self.error(
+                        f"manifest.json commands[{idx}].exit_status must be recorded as an integer"
+                    )
+            missing = sorted(REQUIRED_COMMAND_GATES - gates)
+            if missing:
+                self.error("manifest.json commands missing gates: " + ", ".join(missing))
+
+        return manifest
+
+    def validate_metadata(self) -> None:
+        self.require_file("metadata/git-rev-parse-head.txt")
+        self.require_file("metadata/git-status-short.txt", non_empty=False)
+        self.require_file("metadata/cluster-env.txt")
+        self.require_file("metadata/ha-cluster-userspace.conf")
+        self.require_file("metadata/binary-sha256sums.txt")
+        self.require_file("metadata/cluster-userspace-host-ipv6-route.txt")
+
+        head_path = self.root / "metadata/git-rev-parse-head.txt"
+        if self.candidate_commit and head_path.exists():
+            head = head_path.read_text(encoding="utf-8", errors="replace").strip()
+            if head != self.candidate_commit:
+                self.error(
+                    "metadata/git-rev-parse-head.txt must match manifest candidate_commit"
+                )
+
+    def validate_summary(
+        self, rel: str, headings: tuple[str, ...], required_text: str | None = None
+    ) -> None:
+        path = self.require_file(rel)
+        if not path.exists():
+            return
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if required_text and required_text not in text:
+            self.error(f"{rel} must contain the full candidate commit {required_text}")
+        for heading in headings:
+            pattern = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
+            if not pattern.search(text):
+                self.error(f"{rel} missing required section: ## {heading}")
+
+    def validate_cos_off(self) -> None:
+        for label in COS_OFF_CASES:
+            self.require_json(f"cos-off/{label}.json")
+            self.require_file(f"cos-off/{label}.stderr", non_empty=False)
+            self.require_json(f"cos-off/{label}.metrics.json")
+
+    def validate_screen_flood(self) -> None:
+        for probe in SCREEN_PROBES:
+            self.require_file(f"screen-flood/{probe}-before.txt")
+            self.require_file(f"screen-flood/{probe}-after.txt")
+            self.require_file(f"screen-flood/{probe}-configure.stdout")
+            self.require_file(f"screen-flood/{probe}-configure.stderr", non_empty=False)
+        self.require_file("screen-flood/restore.stdout")
+        self.require_file("screen-flood/restore.stderr", non_empty=False)
+
+    def validate_syn_cookie(self) -> None:
+        self.validate_summary("syn-cookie/summary.md", SYN_COOKIE_HEADINGS)
+        for rel in (
+            "syn-cookie/applied-config.txt",
+            "syn-cookie/challenge-hping3.stdout",
+            "syn-cookie/challenge-hping3.stderr",
+            "syn-cookie/challenge-tcpdump.txt",
+            "syn-cookie/challenge-counters-before.txt",
+            "syn-cookie/challenge-counters-after.txt",
+            "syn-cookie/valid-ack-rst-tcpdump.txt",
+            "syn-cookie/valid-ack-rst-counters-before.txt",
+            "syn-cookie/valid-ack-rst-counters-after.txt",
+            "syn-cookie/random-ack-drop-tcpdump.txt",
+            "syn-cookie/random-ack-drop-counters-before.txt",
+            "syn-cookie/random-ack-drop-counters-after.txt",
+            "syn-cookie/retransmitted-syn-admission-tcpdump.txt",
+            "syn-cookie/retransmitted-syn-admission-counters-before.txt",
+            "syn-cookie/retransmitted-syn-admission-counters-after.txt",
+            "syn-cookie/reply-budget-counters.txt",
+            "syn-cookie/failover-before-cluster-status.txt",
+            "syn-cookie/failover-after-cluster-status.txt",
+            "syn-cookie/failover-cookie-ack-tcpdump.txt",
+            "syn-cookie/failover-counters-node1.txt",
+            "syn-cookie/cleanup.stdout",
+            "syn-cookie/cleanup.stderr",
+            "syn-cookie/final-cluster-status.txt",
+        ):
+            self.require_file(rel, non_empty=not rel.endswith(".stderr"))
+
+    def validate_cos_sweeps(self) -> None:
+        for sweep_dir in COS_SWEEP_DIRS:
+            self.require_file(f"{sweep_dir}/summary.tsv")
+            self.require_file(f"{sweep_dir}/summary.md")
+            self.require_json(f"{sweep_dir}/dataplane/status-before.json")
+            self.require_json(f"{sweep_dir}/dataplane/status-after.json")
+            self.require_json(f"{sweep_dir}/dataplane/counter-delta.json")
+            self.require_file(f"{sweep_dir}/dataplane/journal-since.txt")
+            self.require_file(f"{sweep_dir}/dataplane-summary.tsv")
+            self.require_file(f"{sweep_dir}/equal-flow-summary.tsv")
+            for class_name in COS_CLASSES:
+                base = f"{sweep_dir}/{class_name}"
+                self.require_file(f"{base}/wrapper.stdout")
+                self.require_file(f"{base}/wrapper.stderr", non_empty=False)
+                self.require_json(f"{base}/samples/summary.json")
+                self.require_json(f"{base}/equal-flow/summary.json")
+                self.require_json(f"{base}/dataplane/status-before.json")
+                self.require_json(f"{base}/dataplane/status-after.json")
+
+    def validate_echo(self) -> None:
+        self.require_file("echo-6200-6211/summary.tsv")
+        self.require_file("echo-6200-6211/latency-summary.tsv")
+        for port in ECHO_PORTS:
+            self.require_file(f"echo-6200-6211/{port}.stdout")
+            self.require_file(f"echo-6200-6211/{port}.stderr", non_empty=False)
+
+    def validate_ha(self) -> None:
+        self.require_file("userspace-phase-cycle.log")
+        self.require_file("userspace-ha-failover.log")
+        self.require_file("ha-test-failover.log")
+        self.require_file("ha-test-ha-crash.log")
+        self.require_file("ha-test-restart-connectivity.log")
+        self.require_file("userspace-ha-failover/iperf3.log")
+        self.require_json("userspace-ha-failover/iperf3.metrics.json")
+        self.require_file("userspace-ha-failover/before-source-status.txt")
+        self.require_file("userspace-ha-failover/before-target-status.txt")
+        self.require_glob(
+            "userspace-ha-failover/cycle*-failover-*-dp-stats.txt",
+            "HA failover dataplane stats",
+        )
+        self.require_glob(
+            "userspace-ha-failover/cycle*-failback-*-dp-stats.txt",
+            "HA failback dataplane stats",
+        )
+        self.require_glob(
+            "userspace-ha-failover/cycle*-failover-*-dp-interfaces.txt",
+            "HA failover dataplane interface stats",
+        )
+        self.require_glob(
+            "userspace-ha-failover/cycle*-failback-*-dp-interfaces.txt",
+            "HA failback dataplane interface stats",
+        )
+
+    def validate_fallback_exclusion(self) -> None:
+        for rel in (
+            "fallback-exclusion/fw0-ip-link.txt",
+            "fallback-exclusion/fw1-ip-link.txt",
+            "fallback-exclusion/fw0-dp-stats.txt",
+            "fallback-exclusion/fw1-dp-stats.txt",
+            "fallback-exclusion/fw0-userspace-dp.json",
+            "fallback-exclusion/fw1-userspace-dp.json",
+            "fallback-exclusion/legacy-map-counter-audit.txt",
+        ):
+            self.require_file(rel)
+
+    def require_file(self, rel: str, *, non_empty: bool = True) -> Path:
+        self.checked += 1
+        path = self.root / rel
+        if not path.exists():
+            self.error(f"missing required artifact: {rel}")
+            return path
+        if not path.is_file():
+            self.error(f"required artifact is not a file: {rel}")
+            return path
+        if non_empty and path.stat().st_size == 0:
+            self.error(f"required artifact is empty: {rel}")
+        return path
+
+    def require_json(self, rel: str) -> Any:
+        path = self.require_file(rel)
+        if not path.exists() or not path.is_file():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            self.error(f"invalid JSON artifact {rel}: {exc}")
+            return None
+
+    def require_glob(self, pattern: str, description: str) -> None:
+        self.checked += 1
+        matches = sorted(self.root.glob(pattern))
+        if not matches:
+            self.error(f"missing required artifact pattern for {description}: {pattern}")
+            return
+        if not any(path.is_file() and path.stat().st_size > 0 for path in matches):
+            self.error(f"artifact pattern has no non-empty files for {description}: {pattern}")
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+def validate_artifact_root(
+    root: Path | str, *, candidate_commit: str | None = None
+) -> dict[str, Any]:
+    checker = ArtifactChecker(Path(root), candidate_commit=candidate_commit)
+    return checker.validate()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check the #1477 final userspace-only artifact directory shape."
+    )
+    parser.add_argument("artifact_root", type=Path)
+    parser.add_argument(
+        "--candidate-commit",
+        help="Full 40-character source-removal commit SHA expected in the artifact set.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable summary.")
+    args = parser.parse_args(argv)
+
+    try:
+        result = validate_artifact_root(
+            args.artifact_root, candidate_commit=args.candidate_commit
+        )
+    except ValidationFailure as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            "STRUCTURE_OK "
+            f"candidate_commit={result['candidate_commit']} "
+            f"checked={result['checked']} "
+            f"artifact_root={_display(Path(result['artifact_root']))}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -12,12 +12,16 @@ import argparse
 import json
 import re
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+DATE_TIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
 
 COS_OFF_CASES = ("v4-push", "v4-reverse", "v6-push", "v6-reverse")
 SCREEN_PROBES = ("land", "syn", "icmp", "udp")
@@ -65,8 +69,19 @@ MANIFEST_FIELDS = {
     "notes",
 }
 
+REQUIRED_MANIFEST_FIELDS = {
+    "schema_version",
+    "issues",
+    "candidate_commit",
+    "cluster",
+    "binaries",
+    "commands",
+}
+
 CLUSTER_FIELDS = {"name", "env_file", "config_files"}
+REQUIRED_CLUSTER_FIELDS = {"name", "env_file", "config_files"}
 BINARY_FIELDS = {"host", "path", "sha256", "version"}
+REQUIRED_BINARY_FIELDS = {"host", "path", "sha256"}
 COMMAND_FIELDS = {
     "gate",
     "command",
@@ -75,6 +90,7 @@ COMMAND_FIELDS = {
     "finished_at",
     "artifacts",
 }
+REQUIRED_COMMAND_FIELDS = {"gate", "command", "exit_status"}
 
 SUMMARY_HEADINGS = (
     "Candidate",
@@ -152,6 +168,9 @@ class ArtifactChecker:
             return {}
 
         self.validate_known_fields("manifest.json", manifest, MANIFEST_FIELDS)
+        self.validate_required_fields(
+            "manifest.json", manifest, REQUIRED_MANIFEST_FIELDS
+        )
 
         if manifest.get("schema_version") != 1:
             self.error("manifest.json schema_version must be 1")
@@ -167,6 +186,8 @@ class ArtifactChecker:
             ]
             if bad_issue_types:
                 self.error("manifest.json issues must be integer issue numbers")
+            elif len(set(issues)) != len(issues):
+                self.error("manifest.json issues must not contain duplicates")
             elif not {1373, 1477}.issubset(set(issues)):
                 self.error("manifest.json issues must include 1373 and 1477")
 
@@ -187,11 +208,28 @@ class ArtifactChecker:
                     f"candidate_commit ({short})"
                 )
 
+        if "candidate_branch" in manifest:
+            self.validate_non_empty_string(
+                "manifest.json candidate_branch", manifest.get("candidate_branch")
+            )
+        if "artifact_created_at" in manifest:
+            self.validate_date_time_string(
+                "manifest.json artifact_created_at", manifest.get("artifact_created_at")
+            )
+        if "notes" in manifest and not isinstance(manifest.get("notes"), str):
+            self.error("manifest.json notes must be a string")
+
         cluster = manifest.get("cluster")
         if not isinstance(cluster, dict):
             self.error("manifest.json cluster must be an object")
         else:
             self.validate_known_fields("manifest.json cluster", cluster, CLUSTER_FIELDS)
+            self.validate_required_fields(
+                "manifest.json cluster", cluster, REQUIRED_CLUSTER_FIELDS
+            )
+            self.validate_non_empty_string(
+                "manifest.json cluster.name", cluster.get("name")
+            )
             if cluster.get("env_file") != "test/incus/loss-userspace-cluster.env":
                 self.error(
                     "manifest.json cluster.env_file must be "
@@ -205,8 +243,18 @@ class ArtifactChecker:
                     "manifest.json cluster.config_files must include "
                     "docs/ha-cluster-userspace.conf"
                 )
-            elif any(not isinstance(item, str) for item in config_files):
-                self.error("manifest.json cluster.config_files entries must be strings")
+            elif len(config_files) == 0:
+                self.error("manifest.json cluster.config_files must not be empty")
+            else:
+                self.validate_unique_list(
+                    "manifest.json cluster.config_files", config_files
+                )
+                for item in config_files:
+                    if not isinstance(item, str) or not item:
+                        self.error(
+                            "manifest.json cluster.config_files entries must be non-empty strings"
+                        )
+                        break
 
         binaries = manifest.get("binaries")
         if not isinstance(binaries, list) or not binaries:
@@ -219,18 +267,26 @@ class ArtifactChecker:
                 self.validate_known_fields(
                     f"manifest.json binaries[{idx}]", binary, BINARY_FIELDS
                 )
+                self.validate_required_fields(
+                    f"manifest.json binaries[{idx}]",
+                    binary,
+                    REQUIRED_BINARY_FIELDS,
+                )
                 for field in ("host", "path"):
-                    if not isinstance(binary.get(field), str) or not binary[field]:
-                        self.error(f"manifest.json binaries[{idx}].{field} is required")
+                    self.validate_non_empty_string(
+                        f"manifest.json binaries[{idx}].{field}", binary.get(field)
+                    )
                 digest = binary.get("sha256")
                 if not isinstance(digest, str) or not SHA256_RE.match(digest):
                     self.error(
                         f"manifest.json binaries[{idx}].sha256 must be a 64-character hex digest"
                     )
+                if "version" in binary and not isinstance(binary.get("version"), str):
+                    self.error(f"manifest.json binaries[{idx}].version must be a string")
 
         commands = manifest.get("commands")
-        if not isinstance(commands, list):
-            self.error("manifest.json commands must be a list")
+        if not isinstance(commands, list) or not commands:
+            self.error("manifest.json commands must be a non-empty list")
         else:
             gates: set[str] = set()
             for idx, command in enumerate(commands):
@@ -240,8 +296,13 @@ class ArtifactChecker:
                 self.validate_known_fields(
                     f"manifest.json commands[{idx}]", command, COMMAND_FIELDS
                 )
+                self.validate_required_fields(
+                    f"manifest.json commands[{idx}]",
+                    command,
+                    REQUIRED_COMMAND_FIELDS,
+                )
                 gate = command.get("gate")
-                if isinstance(gate, str):
+                if isinstance(gate, str) and gate:
                     if gate in REQUIRED_COMMAND_GATES:
                         gates.add(gate)
                     else:
@@ -255,6 +316,28 @@ class ArtifactChecker:
                     self.error(
                         f"manifest.json commands[{idx}].exit_status must be recorded as an integer"
                     )
+                for field in ("started_at", "finished_at"):
+                    if field in command:
+                        self.validate_date_time_string(
+                            f"manifest.json commands[{idx}].{field}",
+                            command.get(field),
+                        )
+                if "artifacts" in command:
+                    artifacts = command.get("artifacts")
+                    if not isinstance(artifacts, list):
+                        self.error(
+                            f"manifest.json commands[{idx}].artifacts must be a list"
+                        )
+                    else:
+                        self.validate_unique_list(
+                            f"manifest.json commands[{idx}].artifacts", artifacts
+                        )
+                        for artifact in artifacts:
+                            if not isinstance(artifact, str) or not artifact:
+                                self.error(
+                                    f"manifest.json commands[{idx}].artifacts entries must be non-empty strings"
+                                )
+                                break
             missing = sorted(REQUIRED_COMMAND_GATES - gates)
             if missing:
                 self.error("manifest.json commands missing gates: " + ", ".join(missing))
@@ -267,6 +350,42 @@ class ArtifactChecker:
         unknown = sorted(set(value) - allowed)
         if unknown:
             self.error(f"{context} has unknown fields: {', '.join(unknown)}")
+
+    def validate_required_fields(
+        self, context: str, value: dict[str, Any], required: set[str]
+    ) -> None:
+        missing = sorted(required - set(value))
+        if missing:
+            self.error(f"{context} missing required fields: {', '.join(missing)}")
+
+    def validate_non_empty_string(self, context: str, value: Any) -> None:
+        if not isinstance(value, str) or not value:
+            self.error(f"{context} must be a non-empty string")
+
+    def validate_unique_list(self, context: str, value: list[Any]) -> None:
+        try:
+            unique_count = len(set(value))
+        except TypeError:
+            self.error(f"{context} entries must be scalar values")
+            return
+        if unique_count != len(value):
+            self.error(f"{context} must not contain duplicates")
+
+    def validate_date_time_string(self, context: str, value: Any) -> None:
+        if not isinstance(value, str) or not value:
+            self.error(f"{context} must be a date-time string")
+            return
+        if not DATE_TIME_RE.match(value):
+            self.error(f"{context} must be an RFC3339 date-time string")
+            return
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            self.error(f"{context} must be an RFC3339 date-time string")
+            return
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            self.error(f"{context} must include a timezone offset")
 
     def validate_metadata(self) -> None:
         self.require_file("metadata/git-rev-parse-head.txt")

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -20,7 +20,9 @@ from typing import Any
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 DATE_TIME_RE = re.compile(
-    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+    r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})"
+    r"[Tt](?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})"
+    r"(?P<fraction>\.\d+)?(?P<zone>[Zz]|[+-]\d{2}:\d{2})$"
 )
 
 COS_OFF_CASES = ("v4-push", "v4-reverse", "v6-push", "v6-reverse")
@@ -172,23 +174,20 @@ class ArtifactChecker:
             "manifest.json", manifest, REQUIRED_MANIFEST_FIELDS
         )
 
-        if manifest.get("schema_version") != 1:
+        schema_version = manifest.get("schema_version")
+        if isinstance(schema_version, bool) or schema_version != 1:
             self.error("manifest.json schema_version must be 1")
 
         issues = manifest.get("issues")
         if not isinstance(issues, list):
             self.error("manifest.json issues must include 1373 and 1477")
         else:
-            bad_issue_types = [
-                issue
-                for issue in issues
-                if isinstance(issue, bool) or not isinstance(issue, int)
-            ]
-            if bad_issue_types:
+            issue_numbers = [self.issue_number(issue) for issue in issues]
+            if any(issue is None for issue in issue_numbers):
                 self.error("manifest.json issues must be integer issue numbers")
-            elif len(set(issues)) != len(issues):
+            elif len(set(issue_numbers)) != len(issue_numbers):
                 self.error("manifest.json issues must not contain duplicates")
-            elif not {1373, 1477}.issubset(set(issues)):
+            elif not {1373, 1477}.issubset(set(issue_numbers)):
                 self.error("manifest.json issues must include 1373 and 1477")
 
         raw_commit = manifest.get("candidate_commit")
@@ -236,13 +235,8 @@ class ArtifactChecker:
                     "test/incus/loss-userspace-cluster.env"
                 )
             config_files = cluster.get("config_files")
-            if not isinstance(config_files, list) or (
-                "docs/ha-cluster-userspace.conf" not in config_files
-            ):
-                self.error(
-                    "manifest.json cluster.config_files must include "
-                    "docs/ha-cluster-userspace.conf"
-                )
+            if not isinstance(config_files, list):
+                self.error("manifest.json cluster.config_files must be a list")
             elif len(config_files) == 0:
                 self.error("manifest.json cluster.config_files must not be empty")
             else:
@@ -255,6 +249,11 @@ class ArtifactChecker:
                             "manifest.json cluster.config_files entries must be non-empty strings"
                         )
                         break
+                if "docs/ha-cluster-userspace.conf" not in config_files:
+                    self.error(
+                        "manifest.json cluster.config_files must include "
+                        "docs/ha-cluster-userspace.conf"
+                    )
 
         binaries = manifest.get("binaries")
         if not isinstance(binaries, list) or not binaries:
@@ -362,6 +361,15 @@ class ArtifactChecker:
         if not isinstance(value, str) or not value:
             self.error(f"{context} must be a non-empty string")
 
+    def issue_number(self, value: Any) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return None
+
     def validate_unique_list(self, context: str, value: list[Any]) -> None:
         try:
             unique_count = len(set(value))
@@ -375,10 +383,21 @@ class ArtifactChecker:
         if not isinstance(value, str) or not value:
             self.error(f"{context} must be a date-time string")
             return
-        if not DATE_TIME_RE.match(value):
+        match = DATE_TIME_RE.match(value)
+        if not match:
             self.error(f"{context} must be an RFC3339 date-time string")
             return
-        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        second = int(match.group("second"))
+        if second > 60:
+            self.error(f"{context} must be an RFC3339 date-time string")
+            return
+        normalized = value
+        normalized = normalized[:10] + "T" + normalized[11:]
+        if normalized.endswith(("Z", "z")):
+            normalized = normalized[:-1] + "+00:00"
+        if second == 60:
+            start, end = match.span("second")
+            normalized = normalized[:start] + "59" + normalized[end:]
         try:
             parsed = datetime.fromisoformat(normalized)
         except ValueError:
@@ -515,6 +534,10 @@ class ArtifactChecker:
         )
 
     def validate_fallback_exclusion(self) -> None:
+        json_artifacts = {
+            "fallback-exclusion/fw0-userspace-dp.json",
+            "fallback-exclusion/fw1-userspace-dp.json",
+        }
         for rel in (
             "fallback-exclusion/fw0-ip-link.txt",
             "fallback-exclusion/fw1-ip-link.txt",
@@ -524,7 +547,10 @@ class ArtifactChecker:
             "fallback-exclusion/fw1-userspace-dp.json",
             "fallback-exclusion/legacy-map-counter-audit.txt",
         ):
-            self.require_file(rel)
+            if rel in json_artifacts:
+                self.require_json(rel)
+            else:
+                self.require_file(rel)
 
     def require_file(self, rel: str, *, non_empty: bool = True) -> Path:
         self.checked += 1
@@ -545,6 +571,9 @@ class ArtifactChecker:
             return None
         try:
             return json.loads(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError as exc:
+            self.error(f"invalid UTF-8 JSON artifact {rel}: {exc}")
+            return None
         except json.JSONDecodeError as exc:
             self.error(f"invalid JSON artifact {rel}: {exc}")
             return None

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -295,6 +295,27 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             with self.assertRaisesRegex(schema.ValidationFailure, "exit_status"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
+    def test_rejects_boolean_schema_version(self) -> None:
+        self.assert_manifest_mutation_rejected(
+            lambda manifest: manifest.__setitem__("schema_version", True),
+            "schema_version must be 1",
+        )
+
+    def test_accepts_json_integer_float_issue_numbers(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            manifest["issues"] = [1373.0, 1477.0]
+            write_json(root, "manifest.json", manifest)
+            summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
+            self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+
+    def test_rejects_boolean_issue_number(self) -> None:
+        self.assert_manifest_mutation_rejected(
+            lambda manifest: manifest.__setitem__("issues", [True, 1373, 1477]),
+            "issues must be integer issue numbers",
+        )
+
     def test_rejects_unknown_command_gate(self) -> None:
         tmp, root = self.with_fixture()
         with tmp:
@@ -354,6 +375,13 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
                 "duplicate_command_artifacts",
                 duplicate_artifacts,
                 "commands\\[0\\].artifacts must not contain duplicates",
+            ),
+            (
+                "empty_config_files",
+                lambda manifest: manifest["cluster"].__setitem__(
+                    "config_files", []
+                ),
+                "cluster.config_files must not be empty",
             ),
         )
 
@@ -423,6 +451,18 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             mutate, "commands\\[0\\].artifacts entries must be non-empty strings"
         )
 
+    def test_accepts_rfc3339_lowercase_tz_and_leap_second(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            manifest["artifact_created_at"] = "2026-05-24t03:00:00z"
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["started_at"] = "2026-06-30T23:59:60Z"
+            write_json(root, "manifest.json", manifest)
+            summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
+            self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+
     def test_rejects_additional_command_fields(self) -> None:
         tmp, root = self.with_fixture()
         with tmp:
@@ -432,6 +472,21 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             commands[0]["unexpected"] = "not in schema"
             write_json(root, "manifest.json", manifest)
             with self.assertRaisesRegex(schema.ValidationFailure, "unknown fields"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_invalid_fallback_json_artifact(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            write_text(root, "fallback-exclusion/fw0-userspace-dp.json", "{bad")
+            with self.assertRaisesRegex(schema.ValidationFailure, "invalid JSON"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_non_utf8_json_artifact_without_traceback(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            path = root / "fallback-exclusion/fw1-userspace-dp.json"
+            path.write_bytes(b"\xff\xfe{")
+            with self.assertRaisesRegex(schema.ValidationFailure, "invalid UTF-8 JSON"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
 if __name__ == "__main__":

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("retire_ebpf_artifact_schema.py")
+SPEC = importlib.util.spec_from_file_location("retire_ebpf_artifact_schema", MODULE_PATH)
+assert SPEC is not None
+schema = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["retire_ebpf_artifact_schema"] = schema
+SPEC.loader.exec_module(schema)
+
+
+COMMIT = "a" * 40
+OTHER_COMMIT = "b" * 40
+
+
+def write_text(root: Path, rel: str, text: str = "artifact\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(root: Path, rel: str, value: object | None = None) -> None:
+    if value is None:
+        value = {"ok": True}
+    write_text(root, rel, json.dumps(value) + "\n")
+
+
+def command(gate: str) -> dict[str, object]:
+    return {"gate": gate, "command": f"run {gate}", "exit_status": 0}
+
+
+def make_manifest(commit: str = COMMIT) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "issues": [1373, 1477],
+        "candidate_commit": commit,
+        "cluster": {
+            "name": "loss",
+            "env_file": "test/incus/loss-userspace-cluster.env",
+            "config_files": ["docs/ha-cluster-userspace.conf"],
+        },
+        "binaries": [
+            {
+                "host": "xpf-userspace-fw0",
+                "path": "/usr/local/sbin/xpfd",
+                "sha256": "1" * 64,
+            },
+            {
+                "host": "xpf-userspace-fw0",
+                "path": "/usr/local/bin/xpf-userspace-dp",
+                "sha256": "2" * 64,
+            },
+        ],
+        "commands": [command(gate) for gate in sorted(schema.REQUIRED_COMMAND_GATES)],
+    }
+
+
+def make_summary(commit: str = COMMIT) -> str:
+    lines = ["# #1477 Source-Removal Validation Summary", "", commit, ""]
+    for heading in schema.SUMMARY_HEADINGS:
+        lines.extend([f"## {heading}", "Recorded in fixture.", ""])
+    return "\n".join(lines)
+
+
+def make_syn_cookie_summary() -> str:
+    lines = ["# SYN-Cookie Proof", ""]
+    for heading in schema.SYN_COOKIE_HEADINGS:
+        lines.extend([f"## {heading}", "Recorded in fixture.", ""])
+    return "\n".join(lines)
+
+
+def build_complete_artifact(root: Path, commit: str = COMMIT) -> None:
+    write_json(root, "manifest.json", make_manifest(commit))
+    write_text(root, "summary.md", make_summary(commit))
+
+    write_text(root, "metadata/git-rev-parse-head.txt", commit + "\n")
+    write_text(root, "metadata/git-status-short.txt", "")
+    write_text(root, "metadata/cluster-env.txt")
+    write_text(root, "metadata/ha-cluster-userspace.conf")
+    write_text(root, "metadata/binary-sha256sums.txt")
+    write_text(root, "metadata/cluster-userspace-host-ipv6-route.txt")
+
+    for label in schema.COS_OFF_CASES:
+        write_json(root, f"cos-off/{label}.json")
+        write_text(root, f"cos-off/{label}.stderr", "")
+        write_json(root, f"cos-off/{label}.metrics.json", {"completed": True})
+
+    for probe in schema.SCREEN_PROBES:
+        write_text(root, f"screen-flood/{probe}-before.txt")
+        write_text(root, f"screen-flood/{probe}-after.txt")
+        write_text(root, f"screen-flood/{probe}-configure.stdout")
+        write_text(root, f"screen-flood/{probe}-configure.stderr", "")
+    write_text(root, "screen-flood/restore.stdout")
+    write_text(root, "screen-flood/restore.stderr", "")
+
+    write_text(root, "syn-cookie/summary.md", make_syn_cookie_summary())
+    for rel in (
+        "syn-cookie/applied-config.txt",
+        "syn-cookie/challenge-hping3.stdout",
+        "syn-cookie/challenge-hping3.stderr",
+        "syn-cookie/challenge-tcpdump.txt",
+        "syn-cookie/challenge-counters-before.txt",
+        "syn-cookie/challenge-counters-after.txt",
+        "syn-cookie/valid-ack-rst-tcpdump.txt",
+        "syn-cookie/valid-ack-rst-counters-before.txt",
+        "syn-cookie/valid-ack-rst-counters-after.txt",
+        "syn-cookie/random-ack-drop-tcpdump.txt",
+        "syn-cookie/random-ack-drop-counters-before.txt",
+        "syn-cookie/random-ack-drop-counters-after.txt",
+        "syn-cookie/retransmitted-syn-admission-tcpdump.txt",
+        "syn-cookie/retransmitted-syn-admission-counters-before.txt",
+        "syn-cookie/retransmitted-syn-admission-counters-after.txt",
+        "syn-cookie/reply-budget-counters.txt",
+        "syn-cookie/failover-before-cluster-status.txt",
+        "syn-cookie/failover-after-cluster-status.txt",
+        "syn-cookie/failover-cookie-ack-tcpdump.txt",
+        "syn-cookie/failover-counters-node1.txt",
+        "syn-cookie/cleanup.stdout",
+        "syn-cookie/cleanup.stderr",
+        "syn-cookie/final-cluster-status.txt",
+    ):
+        write_text(root, rel, "" if rel.endswith(".stderr") else "artifact\n")
+
+    for sweep in schema.COS_SWEEP_DIRS:
+        write_text(root, f"{sweep}/summary.tsv")
+        write_text(root, f"{sweep}/summary.md")
+        write_json(root, f"{sweep}/dataplane/status-before.json")
+        write_json(root, f"{sweep}/dataplane/status-after.json")
+        write_json(root, f"{sweep}/dataplane/counter-delta.json")
+        write_text(root, f"{sweep}/dataplane/journal-since.txt")
+        write_text(root, f"{sweep}/dataplane-summary.tsv")
+        write_text(root, f"{sweep}/equal-flow-summary.tsv")
+        for class_name in schema.COS_CLASSES:
+            base = f"{sweep}/{class_name}"
+            write_text(root, f"{base}/wrapper.stdout")
+            write_text(root, f"{base}/wrapper.stderr", "")
+            write_json(root, f"{base}/samples/summary.json")
+            write_json(root, f"{base}/equal-flow/summary.json")
+            write_json(root, f"{base}/dataplane/status-before.json")
+            write_json(root, f"{base}/dataplane/status-after.json")
+
+    write_text(root, "echo-6200-6211/summary.tsv")
+    write_text(root, "echo-6200-6211/latency-summary.tsv")
+    for port in schema.ECHO_PORTS:
+        write_text(root, f"echo-6200-6211/{port}.stdout")
+        write_text(root, f"echo-6200-6211/{port}.stderr", "")
+
+    write_text(root, "userspace-phase-cycle.log")
+    write_text(root, "userspace-ha-failover.log")
+    write_text(root, "ha-test-failover.log")
+    write_text(root, "ha-test-ha-crash.log")
+    write_text(root, "ha-test-restart-connectivity.log")
+    write_text(root, "userspace-ha-failover/iperf3.log")
+    write_json(root, "userspace-ha-failover/iperf3.metrics.json")
+    write_text(root, "userspace-ha-failover/before-source-status.txt")
+    write_text(root, "userspace-ha-failover/before-target-status.txt")
+    write_text(root, "userspace-ha-failover/cycle1-failover-fw1-dp-stats.txt")
+    write_text(root, "userspace-ha-failover/cycle1-failback-fw0-dp-stats.txt")
+    write_text(root, "userspace-ha-failover/cycle1-failover-fw1-dp-interfaces.txt")
+    write_text(root, "userspace-ha-failover/cycle1-failback-fw0-dp-interfaces.txt")
+
+    for rel in (
+        "fallback-exclusion/fw0-ip-link.txt",
+        "fallback-exclusion/fw1-ip-link.txt",
+        "fallback-exclusion/fw0-dp-stats.txt",
+        "fallback-exclusion/fw1-dp-stats.txt",
+        "fallback-exclusion/fw0-userspace-dp.json",
+        "fallback-exclusion/fw1-userspace-dp.json",
+        "fallback-exclusion/legacy-map-counter-audit.txt",
+    ):
+        if rel.endswith(".json"):
+            write_json(root, rel)
+        else:
+            write_text(root, rel)
+
+
+class RetireEbpfArtifactSchemaTests(unittest.TestCase):
+    def with_fixture(self):
+        tmp = tempfile.TemporaryDirectory()
+        root = Path(tmp.name) / f"evidence-1477-source-removal-20260522-{COMMIT[:12]}"
+        build_complete_artifact(root)
+        return tmp, root
+
+    def test_complete_candidate_schema_passes(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
+            self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+            self.assertEqual(summary["candidate_commit"], COMMIT)
+
+    def test_rejects_missing_reverse_ipv6_cos_off_artifact(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            (root / "cos-off/v6-reverse.metrics.json").unlink()
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "cos-off/v6-reverse.metrics.json"
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_omitted_echo_port(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            (root / "echo-6200-6211/6211.stdout").unlink()
+            with self.assertRaisesRegex(schema.ValidationFailure, "6211.stdout"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_missing_echo_latency_summary(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            (root / "echo-6200-6211/latency-summary.tsv").unlink()
+            with self.assertRaisesRegex(schema.ValidationFailure, "latency-summary.tsv"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_missing_udp_screen_probe(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            (root / "screen-flood/udp-after.txt").unlink()
+            with self.assertRaisesRegex(schema.ValidationFailure, "udp-after.txt"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_missing_ha_failback_leg(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            for path in (root / "userspace-ha-failover").glob(
+                "cycle*-failback-*-dp-stats.txt"
+            ):
+                path.unlink()
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "HA failback dataplane stats"
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_stale_commit_mismatch(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            with self.assertRaisesRegex(schema.ValidationFailure, "candidate commit mismatch"):
+                schema.validate_artifact_root(root, candidate_commit=OTHER_COMMIT)
+
+    def test_rejects_short_manifest_commit(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest("a" * 12)
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "full 40-character SHA"
+            ):
+                schema.validate_artifact_root(root)
+
+    def test_rejects_missing_summary_section(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            text = make_summary().replace("## HA Gates\n", "")
+            write_text(root, "summary.md", text)
+            with self.assertRaisesRegex(schema.ValidationFailure, "## HA Gates"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -264,5 +264,58 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             with self.assertRaisesRegex(schema.ValidationFailure, "## HA Gates"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
+    def test_rejects_non_integer_issue_value_without_crashing(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            manifest["issues"] = [1373, {"bad": 1}, 1477]
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "issues must be integer"
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_boolean_exit_status(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["exit_status"] = True
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(schema.ValidationFailure, "exit_status"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_unknown_command_gate(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands.append(command("unknown-gate"))
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(schema.ValidationFailure, "unknown-gate"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_additional_manifest_fields(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            manifest["extra"] = "not in schema"
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(schema.ValidationFailure, "unknown fields"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_additional_command_fields(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["unexpected"] = "not in schema"
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(schema.ValidationFailure, "unknown fields"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -191,6 +191,15 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
         build_complete_artifact(root)
         return tmp, root
 
+    def assert_manifest_mutation_rejected(self, mutate, pattern: str) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            mutate(manifest)
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(schema.ValidationFailure, pattern):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
     def test_complete_candidate_schema_passes(self) -> None:
         tmp, root = self.with_fixture()
         with tmp:
@@ -305,6 +314,114 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             write_json(root, "manifest.json", manifest)
             with self.assertRaisesRegex(schema.ValidationFailure, "unknown fields"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_schema_required_and_uniqueness_drifts(self) -> None:
+        def duplicate_artifacts(manifest: dict[str, object]) -> None:
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["artifacts"] = ["summary.md", "summary.md"]
+
+        cases = (
+            (
+                "missing_top_level_required",
+                lambda manifest: manifest.pop("schema_version"),
+                "missing required fields: schema_version",
+            ),
+            (
+                "missing_cluster_name",
+                lambda manifest: manifest["cluster"].pop("name"),
+                "cluster missing required fields: name",
+            ),
+            (
+                "duplicate_issues",
+                lambda manifest: manifest.__setitem__(
+                    "issues", [1373, 1373, 1477, 1477]
+                ),
+                "issues must not contain duplicates",
+            ),
+            (
+                "duplicate_config_files",
+                lambda manifest: manifest["cluster"].__setitem__(
+                    "config_files",
+                    [
+                        "docs/ha-cluster-userspace.conf",
+                        "docs/ha-cluster-userspace.conf",
+                    ],
+                ),
+                "cluster.config_files must not contain duplicates",
+            ),
+            (
+                "duplicate_command_artifacts",
+                duplicate_artifacts,
+                "commands\\[0\\].artifacts must not contain duplicates",
+            ),
+        )
+
+        for name, mutate, pattern in cases:
+            with self.subTest(name=name):
+                self.assert_manifest_mutation_rejected(mutate, pattern)
+
+    def test_rejects_schema_minlength_and_datetime_drifts(self) -> None:
+        def empty_config_file(manifest: dict[str, object]) -> None:
+            cluster = manifest["cluster"]
+            assert isinstance(cluster, dict)
+            cluster["config_files"] = ["docs/ha-cluster-userspace.conf", ""]
+
+        def bad_command_timestamp(manifest: dict[str, object]) -> None:
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["started_at"] = "not-a-date"
+
+        cases = (
+            (
+                "empty_cluster_name",
+                lambda manifest: manifest["cluster"].__setitem__("name", ""),
+                "cluster.name must be a non-empty string",
+            ),
+            (
+                "empty_candidate_branch",
+                lambda manifest: manifest.__setitem__("candidate_branch", ""),
+                "candidate_branch must be a non-empty string",
+            ),
+            (
+                "empty_config_file",
+                empty_config_file,
+                "cluster.config_files entries must be non-empty strings",
+            ),
+            (
+                "bad_artifact_created_at",
+                lambda manifest: manifest.__setitem__(
+                    "artifact_created_at", "not-a-date"
+                ),
+                "artifact_created_at must be an RFC3339 date-time string",
+            ),
+            (
+                "artifact_created_at_without_timezone",
+                lambda manifest: manifest.__setitem__(
+                    "artifact_created_at", "2026-05-24T03:00:00"
+                ),
+                "artifact_created_at must be an RFC3339 date-time string",
+            ),
+            (
+                "bad_command_timestamp",
+                bad_command_timestamp,
+                "commands\\[0\\].started_at must be an RFC3339 date-time string",
+            ),
+        )
+
+        for name, mutate, pattern in cases:
+            with self.subTest(name=name):
+                self.assert_manifest_mutation_rejected(mutate, pattern)
+
+    def test_rejects_empty_command_artifact_path(self) -> None:
+        def mutate(manifest: dict[str, object]) -> None:
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["artifacts"] = ["summary.md", ""]
+
+        self.assert_manifest_mutation_rejected(
+            mutate, "commands\\[0\\].artifacts entries must be non-empty strings"
+        )
 
     def test_rejects_additional_command_fields(self) -> None:
         tmp, root = self.with_fixture()


### PR DESCRIPTION
## Summary

- define the final #1477 artifact directory contract and manifest schema under the #1373 retirement docs
- add a reusable structural checker for required artifact names, sections, JSON files, full candidate SHA binding, CoS, screen/flood, SYN-cookie, echo latency, HA, and fallback-exclusion evidence
- update the smoke gate runbook with UDP-flood coverage, echo latency output, and the final packaging check

## Notes

This does not claim live cluster validation for #1477. The final evidence still has to be captured against the exact #1476 source-removal candidate. The checker only prevents incomplete or stale artifact bundles from being treated as reviewable evidence.

Refs #1477
Refs #1373

## Validation

- python3 -m unittest discover -s test/incus -p 'retire_ebpf_artifact_schema_test.py'
- python3 test/incus/retire_ebpf_artifact_schema_test.py
- python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py test/incus/retire_ebpf_artifact_schema_test.py
- python3 -m json.tool docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json >/dev/null
- git diff --check