### PR TITLE
WireGuard clean-room dataplane termination (snow-based)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,34 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T23:30:00Z
+  - **Action**: PR #1499 r-final-5 step 4 — final mechanical sweep
+    pass. After the previous step's edits shifted lines in
+    engine.rs (+4 from the jumbo-MTU comment expansion), scratch.rs
+    (+2 from the doc-comment rewrite), and session.rs (+5 from the
+    local_index doc-comment rewrite), the plan's own line citations
+    that I had just "fixed" were already stale. Cross-grepped every
+    remaining plan.md file:line citation:
+    - `scratch.rs:17-21` → `scratch.rs:18-25` (struct field
+      definitions shifted by +1..+4 lines)
+    - `scratch.rs:25-30` → `scratch.rs:27-33` (constructor)
+    - `engine.rs:258` → `engine.rs:262` (`table: ArcSwap<PeerTable>`)
+    - `engine.rs:506-510` → `engine.rs:510-514` (`peer.current.read()`)
+    - `engine.rs:643-649` → `engine.rs:647-653`
+      (`sessions_by_local_index.read()` in try_decap)
+    - `engine.rs:671-676` → `engine.rs:675-680` (pre-AEAD replay
+      precheck-lock block)
+    - `engine.rs:695` → `engine.rs:699-718` (post-AEAD replay
+      update-lock block — now cites the actual block range)
+    - `session.rs:72` → `session.rs:77`
+      (`replay: Mutex<ReplayState>`)
+    All other citations (afxdp/mod.rs:175, mod.rs:86-91/95/98,
+    framing.rs:32-46, outer.rs:23-45, protocol.rs:417-450,
+    types/forwarding.rs:129-140, forwarding/mod.rs:751,
+    tx/dispatch.rs:430/785-792/1458-1459, frame/mod.rs:212,
+    frame/tcp_segmentation.rs:309, tunnel.rs:189) re-verified.
+  - **File(s)**: docs/pr/wireguard-clean/plan.md
+
 - **Timestamp**: 2026-05-24T23:15:00Z
   - **Action**: PR #1499 r-final-5 fix step 3 — line-citation offsets
     + stale field-name drift + scratch.rs MAX_FRAME doc-comment.

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,21 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T23:00:00Z
+  - **Action**: PR #1499 r-final-5 fix pass start — exhaustive mechanical
+    plan.md sweep against actual source. Step 1 fixed: WG data-record
+    header described as 20 bytes in plan.md:74-78 (handshake scope) and
+    plan.md:282-286 (MSS section). Actual is 16 bytes: 1B type + 3B
+    reserved + 4B receiver_index + 8B counter, as defined by
+    `WG_DATA_HEADER_LEN = 1 + 3 + 4 + 8` in
+    `userspace-dp/src/afxdp/wg/mod.rs:91` and the byte-exact layout in
+    `userspace-dp/src/afxdp/wg/framing.rs:32-46`. Rewrote the on-wire
+    framing description with explicit byte offsets and a per-row table;
+    updated the handshake-scope bullet to match; fixed the IPv4/IPv6
+    outer overhead breakdown to call out the `WG_DATA_HEADER_LEN` /
+    `POLY1305_TAG_LEN` constants directly.
+  - **File(s)**: docs/pr/wireguard-clean/plan.md
+
 - **Timestamp**: 2026-05-24T22:00:00Z
   - **Action**: PR #1499 r-final-4 fix — closed Codex MAJOR (5 plan.md
     drifts) and Copilot 2 inline findings on the r-final-3 commit

--- a/_Log.md
+++ b/_Log.md
@@ -1364,3 +1364,7 @@
 - **Timestamp**: 2026-05-23T21:30:00Z
   - **Action**: Hoisted PADDED_PLAINTEXT_MAX guard above next_tx_counter + header write so encap-overflow returns BufferTooSmall without observable side effects; removed dead fn peer_index; pruned r5 leftover duplicate comment block in try_encap; added install_session_serializes_with_reconcile_removal and encap_padded_plaintext_overflow_leaves_counter_and_buffer_untouched regression tests.
   - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs
+
+- **Timestamp**: 2026-05-24T04:00:00Z
+  - **Action**: r8: strengthened install_session_serializes_with_reconcile_removal with an `ok > 0` gate so the race test cannot pass tautologically when the reconciler always wins (Codex r7 finding); added debug_assert! on duplicate peer pubkey in reconcile_peers so engine-side surface flags Go-control-plane validation gaps (r6 Claude nit 4 / Codex r7).
+  - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,39 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T23:15:00Z
+  - **Action**: PR #1499 r-final-5 fix step 3 — line-citation offsets
+    + stale field-name drift + scratch.rs MAX_FRAME doc-comment.
+    Updated plan.md:104 to spell out `wg_peer_pubkey_hex` (was the
+    pre-r4 stale `wg_peer_pubkey`) and added a `protocol.rs:437-438`
+    pointer. Updated plan.md hot-path lock-read citations from
+    `engine.rs:499-503` → `engine.rs:506-510` (encap-side
+    `peer.current.read()`) and `engine.rs:636-642` →
+    `engine.rs:643-649` (decap-side `sessions_by_local_index.read()`),
+    matching the actual line numbers after the truncated-record DoS
+    guard landed at engine.rs:664-666. Updated protocol.go:250 to
+    cite `engine.rs:271` instead of `engine.rs:264` for
+    `sessions_by_local_index`. Updated engine.rs:194 jumbo-MTU
+    comment to drop the fragile `engine.rs:539` line citation and
+    point at the `if padded_len > PADDED_PLAINTEXT_MAX` guard by
+    pattern instead (actual line 546). Rewrote session.rs:62-69
+    `local_index` doc comment so it no longer says inbound demux is
+    `(listen_port, local_index)` — the engine map is keyed by
+    `local_index` alone. Rewrote allowed_ips.rs:11-19 to spell out
+    `wg_peer_pubkey_hex` (was `wg_peer_pubkey`) and to drop the
+    false claim that the field lives on the runtime `TunnelEndpoint`
+    — the snapshot has it; the runtime type extension is integration-
+    PR scope. Rewrote scratch.rs:3-10 to drop the false
+    `MAX_FRAME = 2048` constant (no such constant exists — the
+    UMEM constant is `UMEM_FRAME_SIZE = 4096` in `afxdp/mod.rs:175`)
+    and to make the parameter-passed `max_frame` explicit.
+  - **File(s)**: docs/pr/wireguard-clean/plan.md,
+    userspace-dp/src/afxdp/wg/engine.rs,
+    userspace-dp/src/afxdp/wg/session.rs,
+    userspace-dp/src/afxdp/wg/allowed_ips.rs,
+    userspace-dp/src/afxdp/wg/scratch.rs,
+    pkg/dataplane/userspace/protocol.go
+
 - **Timestamp**: 2026-05-24T23:05:00Z
   - **Action**: PR #1499 r-final-5 fix step 2 — integration-PR pointer
     rewritten. plan.md "Encap call site" claimed dispatch.rs:430 was

--- a/_Log.md
+++ b/_Log.md
@@ -304,6 +304,28 @@
   - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
     `git diff --check`
+## 2026-05-23
+
+- **Timestamp**: 2026-05-23T06:32:50Z
+  - **Action**: PR #1499 @copilot review follow-up — fixed WireGuard
+    engine conformance and robustness issues by switching to IKpsk2
+    with zero-PSK mixing, enforcing reject-after-messages on encap,
+    preserving overlapping AllowedIPs per-peer validation, pruning
+    stale demux sessions across rekeys, tightening the overlapping
+    cryptokey-routing test to exercise both live peers, and removing
+    the unused `rand` dependency.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/mod.rs`,
+    `userspace-dp/src/afxdp/wg/engine.rs`,
+    `userspace-dp/src/afxdp/wg/session.rs`,
+    `userspace-dp/src/afxdp/wg/allowed_ips.rs`,
+    `userspace-dp/src/afxdp/wg/peer.rs`,
+    `userspace-dp/src/afxdp/wg/framing.rs`,
+    `userspace-dp/src/afxdp/wg/tests.rs`,
+    `userspace-dp/Cargo.toml`, `userspace-dp/Cargo.lock`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace/...`;
+    `cargo test --release afxdp::wg::`
+    (fails in this runner as expected: missing `libelf`/`gelf` headers
+    for `libbpf-sys` build); `git diff --check`
 
 ## 2026-05-22
 

--- a/_Log.md
+++ b/_Log.md
@@ -1679,3 +1679,22 @@
 - **Timestamp**: 2026-05-24T04:00:00Z
   - **Action**: r8: strengthened install_session_serializes_with_reconcile_removal with an `ok > 0` gate so the race test cannot pass tautologically when the reconciler always wins (Codex r7 finding); added debug_assert! on duplicate peer pubkey in reconcile_peers so engine-side surface flags Go-control-plane validation gaps (r6 Claude nit 4 / Codex r7).
   - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs
+
+- **Timestamp**: 2026-05-24T21:30:12-07:00
+  - **Action**: PR #1499 final nit: corrected the nonce-layout comment
+    in `framing.rs` to match snow 0.10's default ChaCha20-Poly1305
+    resolver and the WireGuard whitepaper §5.4.6. The prior comment
+    stated `counter.to_le_bytes() || [0,0,0,0]` (counter first, zeros
+    trailing); snow actually builds `[0,0,0,0] || counter.to_le_bytes()`
+    (4 zero bytes prepended, counter LE in bytes [4..12]) per
+    `snow-0.10.0/src/resolvers/default.rs:380-381`. Wire behavior was
+    already correct — snow's u64 nonce parameter is passed straight
+    through — only the in-code rationalization was inverted. Added an
+    explicit "do not invert this" warning anchoring the snow source
+    citation so a future maintainer cannot regress to the wrong layout.
+    The deferred zeroize-at-construction for
+    `WgEngineConfig.local_private_key` remains an integration-PR
+    follow-up and is not addressed here.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/framing.rs`, `_Log.md`
+  - **Validation**: cargo build --release; cargo test --release --bin
+    xpf-userspace-dp afxdp::wg.

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,36 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-25T00:30:00Z
+  - **Action**: PR #1499 r-final-6 fix — rebased onto current
+    `origin/master` after PR #1511 merged. Resolved chronological
+    `_Log.md` conflicts across two rebased PR commits (`d379c9d9`
+    r-final-3 and `95fc992f` r-final-4) by interleaving the new
+    `pkg/logging/binary_test.go` PR #1451 review-follow-up entries
+    from master with the existing PR #1499 entries. All other
+    commits replayed cleanly with no code conflicts. Mechanical
+    plan.md citation sweep on the rebased tree produced two residual
+    minor citation drifts (the same two Copilot flagged as non-
+    blocking on `183bc394`): (1)
+    `pkg/dataplane/userspace/protocol.go:250` cited
+    `afxdp/wg/engine.rs:271` for the `sessions_by_local_index`
+    field — actual field declaration is at line 275 (line 271 is
+    inside the `/// ` doc block that introduces it). Corrected
+    citation to `engine.rs:275`. (2) `docs/pr/wireguard-clean/plan.md`
+    cited `mod.rs:86-91` for "the engine constants" describing both
+    `WG_DATA_HEADER_LEN` and `POLY1305_TAG_LEN`; the cited range
+    only covers the data-header constant. `POLY1305_TAG_LEN` is at
+    line 84. Widened both citations (lines 76 and 444) to
+    `mod.rs:84-91` so the range covers both constants the
+    surrounding prose names. No code changes.
+  - **File(s)**: `pkg/dataplane/userspace/protocol.go`,
+    `docs/pr/wireguard-clean/plan.md`, `_Log.md`
+  - **Validation**: rebase clean after manual `_Log.md` resolution
+    on commits `d379c9d9` + `95fc992f`; `cargo build --release`
+    clean (114 warnings, all pre-existing); `cargo test --release
+    --bin xpf-userspace-dp afxdp::wg` — 78/78 pass; `go test
+    ./pkg/dataplane/...` — 4/4 packages pass.
+
 - **Timestamp**: 2026-05-24T23:30:00Z
   - **Action**: PR #1499 r-final-5 step 4 — final mechanical sweep
     pass. After the previous step's edits shifted lines in

--- a/_Log.md
+++ b/_Log.md
@@ -1360,3 +1360,7 @@
     retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
     test/incus/retire_ebpf_artifact_schema.py
     test/incus/retire_ebpf_artifact_schema_test.py`; `git diff --check`
+
+- **Timestamp**: 2026-05-23T21:30:00Z
+  - **Action**: Hoisted PADDED_PLAINTEXT_MAX guard above next_tx_counter + header write so encap-overflow returns BufferTooSmall without observable side effects; removed dead fn peer_index; pruned r5 leftover duplicate comment block in try_encap; added install_session_serializes_with_reconcile_removal and encap_padded_plaintext_overflow_leaves_counter_and_buffer_untouched regression tests.
+  - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,22 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T23:05:00Z
+  - **Action**: PR #1499 r-final-5 fix step 2 — integration-PR pointer
+    rewritten. plan.md "Encap call site" claimed dispatch.rs:430 was
+    the egress encap point that unconditionally called
+    `encapsulate_native_gre_frame`. Actual: dispatch.rs:430 only
+    computes the `uses_native_tunnel = tunnel_endpoint_id != 0` gate;
+    the real `encapsulate_native_gre_frame` calls live in
+    `frame/mod.rs:212` (copy path, invoked from dispatch at
+    `tx/dispatch.rs:785-792`), `frame/tcp_segmentation.rs:309`
+    (TCP segmentation), and `tunnel.rs:189` (local origination).
+    Rewrote the section to enumerate all three sites and clarified
+    that dispatch.rs:430 *computes the gate*, it does not itself
+    encap. Also updated the "What's OUT" bullet that referenced
+    `tx/dispatch.rs` activation to enumerate the same three sites.
+  - **File(s)**: docs/pr/wireguard-clean/plan.md
+
 - **Timestamp**: 2026-05-24T23:00:00Z
   - **Action**: PR #1499 r-final-5 fix pass start — exhaustive mechanical
     plan.md sweep against actual source. Step 1 fixed: WG data-record

--- a/_Log.md
+++ b/_Log.md
@@ -306,6 +306,17 @@
     `git diff --check`
 ## 2026-05-23
 
+- **Timestamp**: 2026-05-23T21:25:00Z
+  - **Action**: PR #1499 @copilot round-6 follow-up — serialized
+    WireGuard `install_session` with `reconcile_peers` using the
+    existing slow-path reconcile mutex to eliminate stale-Arc
+    orphaning when a peer is removed concurrently with session install.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/engine.rs`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace/...`;
+    `cargo test --release afxdp::wg::`
+    (fails in this runner as expected: missing `libelf`/`gelf` headers
+    for `libbpf-sys` build); `git diff --check`
+
 - **Timestamp**: 2026-05-23T07:07:56Z
   - **Action**: PR #1499 @copilot review round-3 follow-up — corrected
     WireGuard `REJECT_AFTER_MESSAGES` to the WG spec value, changed

--- a/_Log.md
+++ b/_Log.md
@@ -20,6 +20,40 @@
   - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
     `git diff --check`
 
+- **Timestamp**: 2026-05-24T20:30:00Z
+  - **Action**: PR #1499 r-final-3 fix — rebased onto current
+    `origin/master` (resolved `_Log.md` conflicts chronologically across
+    four rebased PR commits) and closed the Codex MINOR finding from the
+    r-final-2 synthesis plus three residual plan.md drifts Codex did not
+    catch but a wider sweep surfaced. (1) `docs/pr/wireguard-clean/plan.md`
+    Performance Architecture (hot-path layout) replay-locking bullet:
+    rewrote to describe the as-shipped `std::sync::Mutex<ReplayState>` and
+    the unconditional pre-AEAD precheck-lock + post-AEAD update-lock
+    pattern at `engine.rs:664`/`engine.rs:688`. The earlier "AtomicU64
+    bitmap + counter", "parking_lot::Mutex", and "only on the
+    duplicate/out-of-window arms" wording is now flagged as the stale
+    pre-implementation sketch. (2) `Replay window` subsection: same
+    correction — replaced the `(highest: AtomicU64, bitmap: AtomicU64)`
+    description with `std::sync::Mutex<ReplayState>` and made the two
+    decap locks explicit. (3) `Engine keying` ingress demux: was
+    `(listen_port, receiver_index)`, actual implementation is
+    `sessions_by_local_index` keyed by `receiver_index` alone — fixed.
+    (4) `Hot-path layout` ephemerals bullet: claimed a slow-path SPSC
+    pre-generation ring exists; no such ring is implemented in this PR
+    (snow generates ephemerals inside `build_*_handshake` on the control
+    thread). Reworded to describe the actual control-thread-only ephemeral
+    generation and the unimplemented SPSC ring as a future-revisit. (5)
+    `VLAN safety` section: claimed `try_encap` takes `tx_vlan_id` and
+    emits 802.1Q outer L2; actual `try_encap` signature is `(peer_pubkey,
+    inner_ip, out)` and outer L2 (with VLAN) is built by
+    `outer.rs::write_outer_eth`. Rewrote to match the as-shipped split.
+  - **File(s)**: `docs/pr/wireguard-clean/plan.md`, `_Log.md`
+  - **Validation**: rebase clean after manual `_Log.md` merges (15/15
+    commits replayed); `cargo build --release` clean; `cargo test
+    --release --bin xpf-userspace-dp afxdp::wg` — 78/78 pass (same as
+    pre-rebase; doc-only changes for this commit on top of the rebased
+    crypto changes); `git diff --check` clean.
+
 - **Timestamp**: 2026-05-24T19:26:45Z
   - **Action**: #1451 logging boundary shrink — moved the logging event
     reader to a package-local `EventSource` interface and RT_FLOW event wire

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,61 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T22:00:00Z
+  - **Action**: PR #1499 r-final-4 fix — closed Codex MAJOR (5 plan.md
+    drifts) and Copilot 2 inline findings on the r-final-3 commit
+    `d379c9d9`, plus a mechanical doc-sync sweep that tightened several
+    file:line citations. (1) plan.md hot-path layout `WgWorkerScratch`
+    bullet rewritten to describe `encap_out`/`decap_out:
+    RefCell<Vec<u8>>` (was `encap_buf: Vec<u8>`) per `scratch.rs:17-21`.
+    (2) plan.md hot-path "never under a lock on the hot path" claim
+    rewritten: engine peer routing is `ArcSwap<PeerTable>` (lock-free
+    load), but per-peer `current`/`previous` are `RwLock<Option<Arc<
+    WgSession>>>` and `sessions_by_local_index` is `RwLock<FxHashMap>`,
+    so encap takes `peer.current.read()` at `engine.rs:499-503` and
+    decap takes `sessions_by_local_index.read()` at `engine.rs:636-642`.
+    (3) plan.md protocol-extension field block: renamed `wg_local_privkey:
+    [u8; 32]` / `wg_peer_pubkey: [u8; 32]` to `wg_local_privkey_hex:
+    String` / `wg_peer_pubkey_hex: String` per `protocol.rs:417-450`
+    and deleted the false claim that the snapshot mirrors into the
+    runtime `TunnelEndpoint` in this PR — runtime mirror is integration-
+    PR scope (`afxdp/types/forwarding.rs:129-140` confirms no WG fields).
+    (4) plan.md MSS section: corrected the claim that `wg_tcp_mss` is
+    wired as a sibling of `native_gre_tcp_mss` and that `dispatch.rs:1458`
+    branches on `endpoint.mode`. Actual `dispatch.rs:1458-1459` short-
+    circuits TCP segmentation for ANY `tunnel_endpoint_id != 0`;
+    `wg_tcp_mss` exists only as a standalone helper in `afxdp/wg/mss.rs`.
+    Dispatch-side wiring is integration-PR scope. (5) plan.md VLAN-safety
+    section: reordered `write_outer_eth` arg list from `(out, src_mac,
+    dst_mac, vlan_id, ethertype)` to `(out, dst_mac, src_mac, vlan_id,
+    ethertype)` per `outer.rs:23-45`. (6) Copilot finding 1 (Go-side
+    comment): updated `pkg/dataplane/userspace/protocol.go` `WgListenPort`
+    comment that claimed WG demux is `(listen_port, receiver_index)` —
+    the engine demuxes by `receiver_index` alone, listen-port selection
+    is integration-layer UDP dispatch. (7) Copilot finding 2 (boundary
+    comment): tightened the `PADDED_PLAINTEXT_MAX` doc in `engine.rs:198`
+    to describe the actual `padded_len <= PADDED_PLAINTEXT_MAX` boundary
+    — accepted range is `inner_ip.len() ∈ [0, 4096]`, not "> 4080
+    rejected". A 4081..=4096-byte inner is ACCEPTED because
+    `pad_to_16(4096) == 4096 == PADDED_PLAINTEXT_MAX`. Mechanical-sweep
+    extras: (a) `allowed_ips.rs` "LPM trie" label corrected to flat
+    sorted-by-prefix-length-descending `Vec<Entry>` (LPM lookup, not LPM
+    trie). (b) `engine.rs:251` citation for `ArcSwap<PeerTable>` updated
+    to `engine.rs:258`. (c) Replay-lock citations updated from
+    `engine.rs:664`/`engine.rs:688` to `engine.rs:671-676` (pre-AEAD
+    precheck) and `engine.rs:695` onward (post-AEAD update). (d)
+    `protocol.rs:432-450` widened to `protocol.rs:417-450`. Verified by
+    `cargo build --release` (clean), 5×`cargo test ... afxdp::wg` runs
+    (78 pass each), and `go test ./pkg/dataplane/...` (all 4 packages
+    pass). One initial test flake on
+    `install_session_serializes_with_reconcile_removal` did not
+    reproduce on any of 5 follow-up runs — same class as the documented
+    pre-existing `reconcile_peers_snapshot_is_atomic_under_concurrent_load`
+    flake from `a5664f85`, not introduced by this fix.
+    - **File(s)**: `docs/pr/wireguard-clean/plan.md`,
+      `pkg/dataplane/userspace/protocol.go`,
+      `userspace-dp/src/afxdp/wg/engine.rs`, `_Log.md`.
+
 - **Timestamp**: 2026-05-24T20:58:00Z
   - **Action**: PR #1451 review follow-up — extended the RT_FLOW
     wire-offset canary across the full raw event layout and tightened

--- a/_Log.md
+++ b/_Log.md
@@ -306,6 +306,20 @@
     `git diff --check`
 ## 2026-05-23
 
+- **Timestamp**: 2026-05-23T07:07:56Z
+  - **Action**: PR #1499 @copilot review round-3 follow-up — corrected
+    WireGuard `REJECT_AFTER_MESSAGES` to the WG spec value, changed
+    TX counter reservation to atomic `fetch_update` so rejection does
+    not advance/wrap counters, restored demux-before-rotate install
+    ordering to eliminate the new-session decap gap, and clarified
+    replay precheck concurrency semantics.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/session.rs`,
+    `userspace-dp/src/afxdp/wg/engine.rs`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/userspace/...`;
+    `cargo test --release afxdp::wg::`
+    (fails in this runner as expected: missing `libelf`/`gelf` headers
+    for `libbpf-sys` build); `git diff --check`
+
 - **Timestamp**: 2026-05-23T06:32:50Z
   - **Action**: PR #1499 @copilot review follow-up — fixed WireGuard
     engine conformance and robustness issues by switching to IKpsk2

--- a/_Log.md
+++ b/_Log.md
@@ -132,6 +132,49 @@
     `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
     `git diff --check`
 
+- **Timestamp**: 2026-05-24T19:30:00Z
+  - **Action**: PR #1499 r-final-fix — close the four findings Codex
+    final pre-merge review surfaced after nine prior review rounds
+    missed them, plus two Copilot inline findings that surfaced on
+    the same pass. (1) Set the WireGuard protocol prologue
+    "WireGuard v1 zx2c4 Jason@zx2c4.com" on both initiator and
+    responder Noise builders so the initial transcript hash matches
+    kernel WireGuard / wireguard-go; the engine was previously
+    "WireGuard-shaped" but not interoperable. (2) Added responder
+    key-confirmation gating: WgSession carries a SessionRole +
+    confirmed AtomicBool; responder sessions block try_encap until
+    a successful inbound try_decap flips the flag, restoring the WG
+    anti-reflection invariant. (3) Made Peer.endpoint and
+    persistent_keepalive interior-mutable (RwLock + AtomicU16) so
+    reconcile_peers updates an existing peer's config in place
+    instead of silently keeping stale values. (4) Clarified the
+    plan doc to scope the runtime TunnelEndpoint propagation
+    (forwarding.rs + forwarding_build.rs) into the integration PR;
+    only the wire surface TunnelEndpointSnapshot ships here.
+    (5) Strengthened inner_ip_len_after_decap to validate IPv4
+    IHL>=5 and total_length>=ihl*4 — Copilot inline finding.
+    (6) Made TunnelEndpointSnapshot.wg_local_privkey_hex
+    skip_serializing and gave the snapshot a manual Debug impl
+    that redacts the field; write_state used to leak the WG
+    private key into the on-disk state JSON — Copilot inline
+    finding. Added five regression tests covering the prologue
+    (counter-example proof), responder confirmation gating,
+    in-place peer reconcile, malformed IPv4 rejection, and the
+    privkey serialization/Debug contract.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/mod.rs`,
+    `userspace-dp/src/afxdp/wg/engine.rs`,
+    `userspace-dp/src/afxdp/wg/session.rs`,
+    `userspace-dp/src/afxdp/wg/peer.rs`,
+    `userspace-dp/src/afxdp/wg/tests.rs`,
+    `userspace-dp/src/protocol.rs`,
+    `docs/pr/wireguard-clean/plan.md`, `_Log.md`
+  - **Validation**: `cargo build --release`: clean (114 pre-existing
+    warnings); `cargo test --release --bin xpf-userspace-dp
+    afxdp::wg`: 76/76 pass (was 71; +5 new regressions);
+    `cargo test --release --bin xpf-userspace-dp`: 1413/1413 pass
+    (was 1408; the same +5 new tests); each new test passes 5/5
+    runs in isolation.
+
 - **Timestamp**: 2026-05-24T15:14:30Z
   - **Action**: PR #1494 round-11 follow-up — collapsed the retained
     userspace XDP shim entry-program name onto one dataplane constant and

--- a/_Log.md
+++ b/_Log.md
@@ -132,6 +132,63 @@
     `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
     `git diff --check`
 
+- **Timestamp**: 2026-05-24T18:00:00Z
+  - **Action**: PR #1499 r-final-2 fix — address every actionable
+    finding from the round-final triple-review on `62d2353c`. (1)
+    Truncated-record remote DoS in `try_decap`: a 16..31-byte UDP
+    datagram with a valid `receiver_index` could panic the AF_XDP
+    worker because `parse_data_header` accepted any record >= 16
+    bytes, leaving a sub-Poly1305-tag ciphertext that snow 0.10's
+    ChaCha decrypt cannot handle safely (`ciphertext.len() - TAGLEN`
+    underflow). Added `DecapError::ShortRecord`, a one-line guard
+    before `read_message`, and a regression test that walks
+    `ciphertext.len()` ∈ {0,1,8,14,15} plus a boundary check at
+    `ciphertext.len() == POLY1305_TAG_LEN` to assert the cutoff is
+    strict `<`. (2) Copilot inline #5: replay-lock comment claimed
+    decap "only takes the replay-window lock on cold arms"; the
+    precheck unconditionally locks. Updated the module docstring to
+    describe the actual two-lock pattern and explain why the
+    precheck is held (skip snow AEAD on already-stale counters,
+    bounded contention because each session is demuxed onto a
+    single worker). (3) Copilot inline #6: `established_pair`
+    installed the responder via `WgSession::new` (Initiator-role,
+    pre-confirmed); not faithful to the responder-role gate this PR
+    shipped. Converted `established_pair` to build the responder
+    session as `SessionRole::Responder` then explicitly
+    `mark_confirmed()` so existing round-trip tests still pass, and
+    added a new test
+    `established_pair_responder_confirmation_flips_via_decap_path`
+    that exercises the full handshake → install (unconfirmed) →
+    decap-flips-confirmation flow without any `mark_confirmed` test
+    helper. (4) Copilot inline #1..#4: plan.md doc drift — updated
+    to say `Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s` (PSK2 step
+    matters for WG wire framing), to acknowledge that `ring 0.17.x`
+    is pulled in transitively through snow's resolver (and is
+    clean of open RustSec advisories, not the
+    RUSTSEC-2025-0010 0.16.x version that boringtun dragged in),
+    to update the `try_encap` signature snippet to match the
+    `&mut [u8]` engine API, and to clarify that
+    `complete_handshake_*` is `build_initiator_handshake` /
+    `build_responder_handshake` + `install_session`. (5) Codex
+    scope item: the engine ships Noise sub-message bytes only; the
+    WG handshake outer framing (MessageInitiation/MessageResponse
+    + MAC1/MAC2 + TAI64N) is the integration PR's scope. Made the
+    boundary explicit in both the engine module docstring and a
+    new "On-wire handshake framing scope" section in plan.md plus
+    a new bullet in "What's OUT". The pre-existing
+    `snat_contract_documents_current_fail_closed_runtime`
+    integration-test failure on `userspace-dp/tests/snat_contract_doc_guard.rs`
+    is from `docs/userspace-dataplane-gaps.md` lacking the literal
+    string `fail-closed`; verified the test fails on origin/master
+    `0b837165` (the PR base) just as it does on the PR head, with
+    identical doc and test bytes — entirely unrelated to wg work
+    and out of scope for this PR. New tests: 78/78 wg tests pass
+    (was 76 — added 2 regression tests). All cargo --bin tests
+    pass; 5/5 flake check clean on both new tests. Go suite clean.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/engine.rs`,
+    `userspace-dp/src/afxdp/wg/tests.rs`,
+    `docs/pr/wireguard-clean/plan.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-24T19:30:00Z
   - **Action**: PR #1499 r-final-fix — close the four findings Codex
     final pre-merge review surfaced after nine prior review rounds

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -45,17 +45,31 @@ integration-level and tracked as IN/OUT scope below.
 
 ### Crypto: snow, not boringtun
 
-Use [`snow`](https://crates.io/crates/snow) for Noise IK
-(`Noise_IK_25519_ChaChaPoly_BLAKE2s`). snow has:
+Use [`snow`](https://crates.io/crates/snow) for Noise IK with PSK2
+(`Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s` — see `WG_NOISE_PATTERN` in
+`userspace-dp/src/afxdp/wg/mod.rs`). The PSK2 step matches WireGuard's
+on-wire framing: WG always feeds an all-zero 32-byte PSK in the PSK2
+position when no explicit pre-shared key is configured. The earlier
+draft of this section listed `Noise_IK_25519_ChaChaPoly_BLAKE2s` (no
+PSK2); that did not match the implementation and would have failed
+to interoperate with kernel WireGuard / wireguard-go. snow has:
 
 - Explicit state machine — no hidden output queues.
 - Caller-driven I/O: `read_message` / `write_message` return exactly
   the bytes they produce. There is nothing to "drain".
 - Audited core (snow has been independently audited and is widely
   used).
-- No `ring` dependency on the default feature set — uses pure-Rust
-  `chacha20-poly1305`, `curve25519-dalek` (a current, non-vulnerable
-  version), and `blake2`.
+- `ring 0.17.x` is pulled in transitively via snow's resolver. (The
+  earlier draft of this section claimed "no `ring` dependency on the
+  default feature set"; that was wrong — `Cargo.lock` shows `ring
+  0.17.14` reachable through snow.) `ring 0.17.x` is not the
+  RUSTSEC-2025-0010 version that boringtun 0.6.0 dragged in via
+  pre-0.17 ring; the current `ring 0.17.x` line is clean of open
+  RustSec advisories as of 2026-05-24. The dalek crates also resolve
+  to a non-RUSTSEC-2024-0344-vulnerable version. The vulnerability
+  story from PR #1492 (root cause 3 above) is therefore addressed
+  by snow's choice of vetted crypto crates, not by avoiding `ring`
+  outright.
 
 WireGuard's transport-data record format (4-byte type, 4-byte
 receiver index, 8-byte counter, encrypted payload || 16-byte Poly1305
@@ -69,14 +83,22 @@ The forwarding decision is the **sole** source of truth for which
 peer to encrypt to on egress. The engine exposes:
 
 ```rust
-pub fn try_encap(
+// Engine-level API as actually shipped in this PR.
+pub(crate) fn try_encap(
     &self,
-    virtual_ifindex: i32,   // logical WG interface
     peer_pubkey: &[u8; 32], // explicit; from the forwarding decision
-    inner: &[u8],           // inner IP packet
-    out: &mut Vec<u8>,      // pre-allocated worker scratch
+    inner_ip: &[u8],        // inner IP packet
+    out: &mut [u8],         // caller's pre-sized scratch (NOT Vec — no realloc allowed)
 ) -> Result<EncapOutcome, EncapError>;
 ```
+
+The integration PR will thread `virtual_ifindex` through a wrapper at
+the dispatch call site — the engine itself does not need it because
+peer selection is by `peer_pubkey` alone. The earlier draft of this
+section included `virtual_ifindex` and used `&mut Vec<u8>`; that
+was the original integration-layer sketch, not the engine's contract.
+The engine takes `&mut [u8]` precisely so the hot path never has the
+opportunity to realloc.
 
 The control plane delivers `peer_pubkey` via a new field on
 `TunnelEndpointSnapshot` (`wg_peer_pubkey`). AllowedIPs is **only**
@@ -286,10 +308,37 @@ existing pattern of `recycle_ingress_frame(...)` before every
   outer L2, DSCP propagation, peer-pubkey gate (cryptokey routing).
 - `userspace-dp/src/afxdp/mod.rs` — `mod wg;` declaration.
 
+### On-wire handshake framing scope (explicit boundary)
+
+This engine does NOT build or parse the WireGuard handshake message
+on-wire framing (type-1 MessageInitiation, type-2 MessageResponse,
+type-3 CookieReply, MAC1/MAC2 fields, the TAI64N timestamp slot, the
+encrypted-static and encrypted-identity blocks that surround the
+Noise IK sub-message). The engine only:
+
+- Builds and consumes the snow `HandshakeState` Noise sub-message
+  bytes via `read_message` / `write_message`, with the WG prologue
+  mixed into the transcript hash.
+- Builds and consumes the WG transport-data record on the wire (see
+  `framing.rs`): 4-byte type + 4-byte reserved + 4-byte
+  receiver_index + 8-byte counter + ciphertext || Poly1305 tag.
+
+The integration PR will add a layer that wraps the engine's Noise
+sub-message bytes inside the WG handshake outer framing (with MAC1
+over a hash of the responder's static pubkey, MAC2 cookie-reply
+under load, and TAI64N replay protection inside the identity
+payload). A reader of this engine alone should not conclude the
+handshake on-wire framing is "almost done" — `framing.rs` covers the
+data record only.
+
 ## What's OUT (tracked as follow-ups)
 
 - Activation in `tx/dispatch.rs` and `poll_descriptor.rs`. Engine
   exists and is tested but is not on the hot path yet.
+- WG handshake outer-framing layer (MessageInitiation/MessageResponse
+  outer bytes around the Noise sub-message, MAC1/MAC2, TAI64N).
+  Engine ships the Noise sub-message bytes only; the integration
+  PR will wrap them.
 - Go control-plane mapping from Junos `set security ipsec ...` /
   `set interfaces st0...` to WG snapshot fields.
 - HA / RG-aware session migration on failover.

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -71,11 +71,28 @@ to interoperate with kernel WireGuard / wireguard-go. snow has:
   by snow's choice of vetted crypto crates, not by avoiding `ring`
   outright.
 
-WireGuard's transport-data record format (4-byte type, 4-byte
-receiver index, 8-byte counter, encrypted payload || 16-byte Poly1305
-tag) is implemented directly on top of snow's transport session — it
-maps 1:1 to snow's `into_transport_mode()` `StatelessTransportState`.
-We do not depend on snow doing any WG framing for us.
+WireGuard's transport-data record format is a 16-byte header followed
+by ciphertext || 16-byte Poly1305 tag. The header layout, byte-exact,
+matches the engine constants in `userspace-dp/src/afxdp/wg/mod.rs:86-91`
+and `userspace-dp/src/afxdp/wg/framing.rs:32-46`:
+
+| offset | bytes | field          |
+|-------:|------:|----------------|
+|      0 |     1 | type = 4       |
+|      1 |     3 | reserved (zero on send; accepted as zero on recv for interop) |
+|      4 |     4 | receiver_index (little-endian u32) |
+|      8 |     8 | counter (little-endian u64) |
+|     16 |     N | encrypted payload \|\| 16-byte Poly1305 tag |
+
+Total fixed transport overhead is therefore **`WG_DATA_HEADER_LEN`
+(16) + `POLY1305_TAG_LEN` (16) = 32 bytes** per data record. (Earlier
+drafts described the header as "4-byte type + 4-byte reserved + 4-byte
+receiver_index + 8-byte counter" = 20 bytes; that mis-stated the
+type+reserved layout — `type` is a single byte, `reserved` is 3 bytes,
+together a single 4-byte word.) The header is implemented directly on
+top of snow's transport session and maps 1:1 to snow's
+`into_transport_mode()` `StatelessTransportState`. We do not depend
+on snow doing any WG framing for us.
 
 ### Engine keying
 
@@ -280,9 +297,11 @@ the wire and are populated only by tests.
 
 WG-specific overhead, per draft-ietf-wireguard / the WG whitepaper:
 
-- IPv4 outer: 20 (outer IP) + 8 (UDP) + 4 (type+reserved) + 4
-  (receiver index) + 8 (counter) + 16 (Poly1305 tag) = **60 bytes**.
-- IPv6 outer: 40 (outer IP) + 8 (UDP) + 4 + 4 + 8 + 16 = **80 bytes**.
+- IPv4 outer: 20 (outer IP) + 8 (UDP) + 16 (WG data header:
+  `WG_DATA_HEADER_LEN`) + 16 (Poly1305 tag: `POLY1305_TAG_LEN`) =
+  **60 bytes** (matches `WG_OVERHEAD_V4` in `mod.rs:95`).
+- IPv6 outer: 40 (outer IP) + 8 (UDP) + 16 + 16 = **80 bytes**
+  (matches `WG_OVERHEAD_V6` in `mod.rs:98`).
 
 WG §5.4.6 also requires the inner-IP plaintext to be zero-padded
 to a 16-byte multiple before AEAD. That adds **0..15** bytes per
@@ -293,9 +312,10 @@ frame larger than the MTU, regardless of how the inner segment's
 total length lands modulo 16. See `mss.rs` for the byte table.
 
 Note: the task brief gave 68/88 by counting "WG type 4 hdr (16)"
-which already includes type+reserved+receiver+counter. The numbers
-agree once you don't double-count. I'm using the byte-exact
-breakdown: **60 / 80** plus the **15** padding allowance.
+which already includes the 1-byte type + 3-byte reserved + 4-byte
+receiver_index + 8-byte counter that make up `WG_DATA_HEADER_LEN`.
+The numbers agree once you don't double-count. I'm using the
+byte-exact breakdown: **60 / 80** plus the **15** padding allowance.
 
 This engine PR ships `wg_tcp_mss` as a standalone helper in
 `afxdp/wg/mss.rs` (signature
@@ -403,8 +423,11 @@ Noise IK sub-message). The engine only:
   bytes via `read_message` / `write_message`, with the WG prologue
   mixed into the transcript hash.
 - Builds and consumes the WG transport-data record on the wire (see
-  `framing.rs`): 4-byte type + 4-byte reserved + 4-byte
-  receiver_index + 8-byte counter + ciphertext || Poly1305 tag.
+  `framing.rs:32-46` and `mod.rs:86-91`): 1-byte type=4 + 3-byte
+  reserved + 4-byte little-endian `receiver_index` + 8-byte
+  little-endian `counter` + ciphertext || 16-byte Poly1305 tag.
+  Fixed header = `WG_DATA_HEADER_LEN` (16); fixed AEAD tag =
+  `POLY1305_TAG_LEN` (16); 32 bytes of transport overhead total.
 
 The integration PR will add a layer that wraps the engine's Noise
 sub-message bytes inside the WG handshake outer framing (with MAC1

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -263,11 +263,22 @@ existing pattern of `recycle_ingress_frame(...)` before every
 - `userspace-dp/Cargo.toml` — adds `snow` and supporting crates.
 - `userspace-dp/src/protocol.rs` — adds WG fields to
   `TunnelEndpointSnapshot`. Backward-compatible (all new fields are
-  `#[serde(default)]`).
-- `userspace-dp/src/afxdp/types/forwarding.rs` — adds WG fields to
-  `TunnelEndpoint`.
-- `userspace-dp/src/afxdp/forwarding_build.rs` — propagates WG fields
-  from snapshot to runtime.
+  `#[serde(default)]`). The `wg_local_privkey_hex` field is
+  `#[serde(skip_serializing)]` so it never lands in the persisted
+  state file; a manual `Debug` impl on the snapshot redacts the
+  private key.
+- (Deferred to integration PR) `userspace-dp/src/afxdp/types/forwarding.rs`
+  — extend the runtime `TunnelEndpoint` with WG fields. This PR
+  intentionally lands the wire surface (`TunnelEndpointSnapshot`)
+  without the runtime mirror; the integration PR will wire the
+  reconcile path from snapshot into the runtime `TunnelEndpoint` and
+  the WG hot path at the same time so the runtime type stays out of
+  the dataplane until it is actually consumed. Codex final pre-merge
+  finding 4 flagged the earlier plan text that claimed both landed
+  here.
+- (Deferred to integration PR) `userspace-dp/src/afxdp/forwarding_build.rs`
+  — propagation from snapshot to the runtime `TunnelEndpoint`. Lands
+  alongside the runtime type extension above, in the integration PR.
 - `pkg/dataplane/userspace/protocol.go` — Go-side mirror.
 - Unit tests: handshake roundtrip, encap matches snow output,
   decap recovers plaintext, replay window in-order / repeat /

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -73,7 +73,7 @@ to interoperate with kernel WireGuard / wireguard-go. snow has:
 
 WireGuard's transport-data record format is a 16-byte header followed
 by ciphertext || 16-byte Poly1305 tag. The header layout, byte-exact,
-matches the engine constants in `userspace-dp/src/afxdp/wg/mod.rs:86-91`
+matches the engine constants in `userspace-dp/src/afxdp/wg/mod.rs:84-91`
 and `userspace-dp/src/afxdp/wg/framing.rs:32-46`:
 
 | offset | bytes | field          |
@@ -441,7 +441,7 @@ Noise IK sub-message). The engine only:
   bytes via `read_message` / `write_message`, with the WG prologue
   mixed into the transcript hash.
 - Builds and consumes the WG transport-data record on the wire (see
-  `framing.rs:32-46` and `mod.rs:86-91`): 1-byte type=4 + 3-byte
+  `framing.rs:32-46` and `mod.rs:84-91`): 1-byte type=4 + 3-byte
   reserved + 4-byte little-endian `receiver_index` + 8-byte
   little-endian `counter` + ciphertext || 16-byte Poly1305 tag.
   Fixed header = `WG_DATA_HEADER_LEN` (16); fixed AEAD tag =

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -118,7 +118,8 @@ The engine takes `&mut [u8]` precisely so the hot path never has the
 opportunity to realloc.
 
 The control plane delivers `peer_pubkey` via a new field on
-`TunnelEndpointSnapshot` (`wg_peer_pubkey`). AllowedIPs is **only**
+`TunnelEndpointSnapshot` (`wg_peer_pubkey_hex`; see
+`userspace-dp/src/protocol.rs:437-438`). AllowedIPs is **only**
 consulted on the decap path to gate inbound plaintext — "is this src
 IP in AllowedIPs for the session's peer?" — never to choose a peer
 on egress.
@@ -156,7 +157,10 @@ message and at most one output message. Nothing to "drain".
 
 - Worker holds a `WgWorkerScratch` with `encap_out: RefCell<Vec<u8>>`
   and `decap_out: RefCell<Vec<u8>>` (see `scratch.rs:17-21`), each
-  sized to `MAX_FRAME` at startup. Separate per-direction buffers
+  sized to the worker's `max_frame` at startup
+  (`WgWorkerScratch::new(max_frame)` in `scratch.rs:25-30`; the
+  integration PR will pass `UMEM_FRAME_SIZE` from
+  `afxdp/mod.rs:175`, currently 4096). Separate per-direction buffers
   with `RefCell` interior mutability — never reallocated; the cells
   are entered exclusively per packet because each worker is
   single-threaded inside its poll loop.
@@ -168,8 +172,8 @@ message and at most one output message. Nothing to "drain".
   `RwLock<Option<Arc<WgSession>>>` and ingress demux
   (`sessions_by_local_index`) is `RwLock<FxHashMap<u32, Arc<WgSession>>>`,
   so encap takes one `RwLock::read` on `peer.current`
-  (`engine.rs:499-503`) and decap takes one `RwLock::read` on
-  `sessions_by_local_index` (`engine.rs:636-642`). Both are
+  (`engine.rs:506-510`) and decap takes one `RwLock::read` on
+  `sessions_by_local_index` (`engine.rs:643-649`). Both are
   uncontended in steady state (single-writer at slow-path session
   install / rotate), but they ARE RwLock reads, not lock-free. The
   earlier draft of this bullet claimed "never under a lock on the

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -137,11 +137,28 @@ message and at most one output message. Nothing to "drain".
 
 ### Hot-path layout
 
-- Worker holds a `WgWorkerScratch` with `encap_buf: Vec<u8>` sized
-  to `MAX_FRAME` at startup. Never reallocated.
-- Engine internals (peer table, session table) live in an
-  `Arc<WgEngine>` and use `arc-swap` for reconfiguration — the worker
-  reads a snapshot per poll, never under a lock on the hot path.
+- Worker holds a `WgWorkerScratch` with `encap_out: RefCell<Vec<u8>>`
+  and `decap_out: RefCell<Vec<u8>>` (see `scratch.rs:17-21`), each
+  sized to `MAX_FRAME` at startup. Separate per-direction buffers
+  with `RefCell` interior mutability — never reallocated; the cells
+  are entered exclusively per packet because each worker is
+  single-threaded inside its poll loop.
+- Engine peer routing (peers vec + pubkey→index map + AllowedIPs)
+  lives in a single `ArcSwap<PeerTable>` (`engine.rs:258`) so the
+  hot path observes the three sub-fields as one atomic snapshot
+  (`peer_arc` does an `ArcSwap::load` only — no lock). Per-peer
+  session state (`peer.current` / `peer.previous`) is
+  `RwLock<Option<Arc<WgSession>>>` and ingress demux
+  (`sessions_by_local_index`) is `RwLock<FxHashMap<u32, Arc<WgSession>>>`,
+  so encap takes one `RwLock::read` on `peer.current`
+  (`engine.rs:499-503`) and decap takes one `RwLock::read` on
+  `sessions_by_local_index` (`engine.rs:636-642`). Both are
+  uncontended in steady state (single-writer at slow-path session
+  install / rotate), but they ARE RwLock reads, not lock-free. The
+  earlier draft of this bullet claimed "never under a lock on the
+  hot path"; that overstated the invariant — the lock-free property
+  applies to the peer-table snapshot via `ArcSwap`, not to the
+  per-session current/previous slots or the inbound demux map.
 - Replay windows are per-session, tracked by a `ReplayState`
   (single counter + 64-bit sliding bitmap, RFC 6479) guarded by a
   `std::sync::Mutex` on the session. Encap is lock-free on the
@@ -158,8 +175,9 @@ message and at most one output message. Nothing to "drain".
   the lock as `parking_lot::Mutex` taken "only on the
   duplicate/out-of-window arms"; that did not match the
   implementation (`session.rs:72` — `std::sync::Mutex<ReplayState>`,
-  `engine.rs:664`/`engine.rs:688` — unconditional precheck-lock
-  followed by post-AEAD update-lock).
+  `engine.rs:671-676` — unconditional pre-AEAD precheck-lock; and
+  `engine.rs:695` onward — post-AEAD update-lock that calls
+  `replay.check_and_update`).
 - Ephemerals: handshakes are slow-path only — snow's `Builder`
   generates the ephemeral keypair inside `build_initiator_handshake`
   / `build_responder_handshake`, which the engine deliberately
@@ -233,13 +251,26 @@ Add to `TunnelEndpointSnapshot` (both `userspace-dp/src/protocol.rs`
 and `pkg/dataplane/userspace/protocol.go`):
 
 - `wg_listen_port: u16` — UDP port for inbound demux.
-- `wg_local_privkey: [u8; 32]` (hex on the wire) — our static key.
-- `wg_peer_pubkey: [u8; 32]` (hex on the wire) — peer's static key.
+- `wg_local_privkey_hex: String` — our static X25519 private key as
+  hex (64 chars). `#[serde(skip_serializing)]` so it never lands in
+  the persisted state file; the custom `Debug` impl on
+  `TunnelEndpointSnapshot` redacts it.
+- `wg_peer_pubkey_hex: String` — peer's static X25519 public key as
+  hex. The engine uses THIS as the encap key, not AllowedIPs LPM.
 - `wg_allowed_ips: Vec<String>` — allowed-IPs CIDRs.
 - `wg_endpoint: String` — optional peer endpoint for initiator role.
 - `wg_keepalive_secs: u16` — optional persistent keepalive.
 
-These mirror in `TunnelEndpoint` in `types/forwarding.rs`.
+Field names match the as-shipped types in `protocol.rs:417-450`
+(`wg_local_privkey_hex` / `wg_peer_pubkey_hex` — hex strings, not
+`[u8; 32]`). The runtime `TunnelEndpoint` in
+`afxdp/types/forwarding.rs:129-140` is NOT extended in this PR;
+the integration PR will mirror the snapshot fields onto the
+runtime type alongside the dispatch/poll wiring (see the "What's
+IN this PR" deferred-to-integration bullet for the explicit
+boundary). The earlier draft claimed the snapshot mirrored into
+`TunnelEndpoint` in this PR; that was the original integration
+sketch, not the engine PR's contract.
 
 We do NOT (yet) extend the Go control plane to populate these from
 Junos config. That's a follow-up PR. For now the fields exist on
@@ -266,11 +297,18 @@ which already includes type+reserved+receiver+counter. The numbers
 agree once you don't double-count. I'm using the byte-exact
 breakdown: **60 / 80** plus the **15** padding allowance.
 
-The MSS gate in `forwarding/mod.rs:751` (`native_gre_tcp_mss`) is
-extended with a sibling `wg_tcp_mss` and the call site
-(`dispatch.rs:1458`) branches on `endpoint.mode`. WG endpoints
-read `wg_tcp_mss`; everything else keeps GRE semantics. No GRE
-clamp is reused.
+This engine PR ships `wg_tcp_mss` as a standalone helper in
+`afxdp/wg/mss.rs` (signature
+`fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u16`)
+alongside the existing `native_gre_tcp_mss` in
+`afxdp/forwarding/mod.rs:751`. The dispatch-side wiring — branching
+`forwarded_tcp_may_need_segmentation` at
+`afxdp/tx/dispatch.rs:1458` on `endpoint.mode` so WG endpoints
+read `wg_tcp_mss` while GRE endpoints keep `native_gre_tcp_mss`
+— is deferred to the integration PR (the current call site at
+`dispatch.rs:1458-1459` short-circuits TCP segmentation for ANY
+`tunnel_endpoint_id != 0`, so no MSS path is hit yet). No GRE
+clamp is reused; the byte table lives in `mss.rs`.
 
 ## DSCP and ECN
 
@@ -286,7 +324,9 @@ the ECN bits and document it as a known gap with a tracking issue.
 ## VLAN safety
 
 VLAN-aware outer L2 is built by `outer.rs::write_outer_eth(out,
-src_mac, dst_mac, vlan_id, ethertype)`: an 18-byte 802.1Q tagged
+dst_mac, src_mac, vlan_id, ethertype)` (see `outer.rs:23-45` — the
+destination MAC is the second argument, source MAC the third,
+matching the on-wire Ethernet header order): an 18-byte 802.1Q tagged
 header when `vlan_id != 0`, otherwise the 14-byte untagged
 Ethernet header. `outer_l2_len(vlan_id)` returns the matching
 length so the caller can size its scratch correctly. `try_encap`
@@ -313,7 +353,12 @@ existing pattern of `recycle_ingress_frame(...)` before every
   - `engine.rs` — engine state, peer table, session table
   - `peer.rs` — peer state + AllowedIPs
   - `session.rs` — transport session + replay window
-  - `allowed_ips.rs` — LPM trie (in-tree, no extra deps)
+  - `allowed_ips.rs` — AllowedIPs lookup as a flat sorted-by-
+    prefix-length-descending `Vec<Entry>` (in-tree, no extra deps).
+    Linear-scan LPM; reconciled at config-commit time, not on the
+    hot path, so the linear scan is fine and cache-friendly. The
+    earlier draft labelled this an "LPM trie"; the implementation is
+    a sorted Vec.
   - `framing.rs` — WG transport-data record encode/decode
   - `mss.rs` — WG MSS arithmetic
   - `dscp.rs` — DSCP→TOS shifting

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -1,0 +1,291 @@
+# WireGuard clean-room dataplane termination — plan
+
+Status: WIP. Tracks #1492's architectural failures and rebuilds from
+origin/master without reusing code from #1492 (`cleanroom/wireguard`)
+or #1433 (`feature/wireguard-support`).
+
+## Why a clean room
+
+The 33+ CRIT findings against PR #1492 collapse into a small set of
+root causes that are architectural, not local:
+
+1. **Hidden state machine in boringtun.** boringtun's `Tunn` queues
+   handshake material internally and surfaces it via successive
+   `update_timers` / `decapsulate` calls. The #1492 author filtered
+   "non-data" outputs out of the encapsulate path and never drained
+   the queues, so handshakes silently stalled.
+2. **Cryptokey-routing security flaw.** The forwarding decision tells
+   the dataplane "send to tunnel-endpoint K via peer pubkey P". #1492
+   ignored P and re-derived the peer via AllowedIPs longest-prefix
+   match. With overlapping AllowedIPs across peers, this routes
+   plaintext to the wrong peer's session keys — a textbook WG
+   cryptokey-routing misuse.
+3. **Stale crypto via boringtun 0.6.0.** Pulls a vulnerable `ring`
+   (RUSTSEC-2025-0010) and `curve25519-dalek` (RUSTSEC-2024-0344).
+4. **Aliasing UB in the poll path.** Held `&mut [u8]` over the same
+   UMEM region as a live `&[u8]`.
+5. **`getrandom` on the hot path.** Per-handshake ephemerals
+   generated under the worker's poll loop.
+6. **`vec![]` per packet** in encap/decap.
+7. **Hardcoded L2 dst/src MACs** in the outer encap.
+8. **GRE-overhead MSS clamp reused for WG.** Off by 48–68 bytes.
+9. **DSCP wiring confused 6-bit vs 8-bit TOS placement.**
+10. **VLAN-unsafe encap** — outer L2 emitted without the binding's
+    `tx_vlan_id` even when set.
+11. **Bare `continue;` in drop paths** leaked ingress UMEM frames.
+12. **Silent drops on enqueue-fail** with no exception counter bump.
+13. **Replay-window wipes on control-plane restart.**
+14. **No cookie/rate-limit reply path** when the engine is under load.
+
+Items 1–6 are foundational. They have to be designed out before any
+wiring touches the dispatch / poll fast path. Items 7–14 are
+integration-level and tracked as IN/OUT scope below.
+
+## Architecture
+
+### Crypto: snow, not boringtun
+
+Use [`snow`](https://crates.io/crates/snow) for Noise IK
+(`Noise_IK_25519_ChaChaPoly_BLAKE2s`). snow has:
+
+- Explicit state machine — no hidden output queues.
+- Caller-driven I/O: `read_message` / `write_message` return exactly
+  the bytes they produce. There is nothing to "drain".
+- Audited core (snow has been independently audited and is widely
+  used).
+- No `ring` dependency on the default feature set — uses pure-Rust
+  `chacha20-poly1305`, `curve25519-dalek` (a current, non-vulnerable
+  version), and `blake2`.
+
+WireGuard's transport-data record format (4-byte type, 4-byte
+receiver index, 8-byte counter, encrypted payload || 16-byte Poly1305
+tag) is implemented directly on top of snow's transport session — it
+maps 1:1 to snow's `into_transport_mode()` `StatelessTransportState`.
+We do not depend on snow doing any WG framing for us.
+
+### Engine keying
+
+The forwarding decision is the **sole** source of truth for which
+peer to encrypt to on egress. The engine exposes:
+
+```rust
+pub fn try_encap(
+    &self,
+    virtual_ifindex: i32,   // logical WG interface
+    peer_pubkey: &[u8; 32], // explicit; from the forwarding decision
+    inner: &[u8],           // inner IP packet
+    out: &mut Vec<u8>,      // pre-allocated worker scratch
+) -> Result<EncapOutcome, EncapError>;
+```
+
+The control plane delivers `peer_pubkey` via a new field on
+`TunnelEndpointSnapshot` (`wg_peer_pubkey`). AllowedIPs is **only**
+consulted on the decap path to gate inbound plaintext — "is this src
+IP in AllowedIPs for the session's peer?" — never to choose a peer
+on egress.
+
+On ingress the engine demuxes by `(listen_port, receiver_index)`
+extracted from the WG transport header. The receiver index is
+chosen by the local side at handshake time, so it identifies the
+session unambiguously without depending on a tuple-match.
+
+### Pump pattern
+
+snow has no hidden output queue. The pattern is strictly:
+
+```
+loop {
+    // Hot path: try transport-mode read/write. If the session is
+    // not yet in transport mode, fall to the slow path.
+}
+```
+
+Handshake transitions happen entirely on the slow path:
+
+- Initiator: build `MessageInitiation` (snow `write_message(b"", out)`),
+  send on the outer UDP socket, wait for `MessageResponse`, finalize
+  with `into_stateless_transport_mode`.
+- Responder: receive `MessageInitiation`, `read_message`, produce
+  `MessageResponse` via `write_message(b"", out)`, finalize.
+
+There is no third state. Every transition has exactly one input
+message and at most one output message. Nothing to "drain".
+
+### Hot-path layout
+
+- Worker holds a `WgWorkerScratch` with `encap_buf: Vec<u8>` sized
+  to `MAX_FRAME` at startup. Never reallocated.
+- Engine internals (peer table, session table) live in an
+  `Arc<WgEngine>` and use `arc-swap` for reconfiguration — the worker
+  reads a snapshot per poll, never under a lock on the hot path.
+- Replay windows are per-session, accessed via `&AtomicU64`
+  bitmap + counter pair (sliding window of 64). Encap is lock-free
+  (single producer per session — the owning worker). Decap acquires
+  an inexpensive per-session `parking_lot::Mutex` only on the
+  duplicate/out-of-window arms.
+- Ephemerals: a slow-path producer thread pre-generates 64
+  ephemeral keypairs into a bounded SPSC ring. Slow-path handshake
+  drains; hot path never calls `getrandom`.
+
+### Replay window
+
+Single-counter sliding bitmap, 64 bits, RFC 6479 algorithm. Stored
+in the session struct as `(highest: AtomicU64, bitmap: AtomicU64)`.
+Encap increments `highest` (we are the only writer). Decap CAS-loops
+or locks briefly on the dup/oow path.
+
+### Replay-state across restart
+
+Out of scope for this PR. Documented: when the userspace helper
+restarts, in-flight sessions are torn down by the engine init path,
+and the responder will renegotiate within `REKEY_TIMEOUT`. A future
+PR will persist (counter, bitmap) per session in the slow-path
+control socket so we survive restart without rekey.
+
+## Integration
+
+Two call sites. Both are **clearly marked WIP** in this PR and
+**do not** activate in production paths.
+
+### Encap call site: tx/dispatch.rs
+
+The tunnel-endpoint branch at `dispatch.rs:430` (`uses_native_tunnel
+= tunnel_endpoint_id != 0`) is the only egress encap point. Today it
+unconditionally calls `encapsulate_native_gre_frame`. The change is
+small and local:
+
+```rust
+let endpoint = forwarding.tunnel_endpoints.get(&id)?;
+let bytes = match endpoint.mode.as_str() {
+    "wireguard" => wg_engine.try_encap(...)?,
+    _ => encapsulate_native_gre_frame(...)?,
+};
+```
+
+This PR does NOT make that call. It lands the engine + tests + the
+protocol extension and stops there. Wiring is the next PR — gated
+behind a thorough triple-review of the engine as-is.
+
+### Decap call site: poll_descriptor.rs
+
+WG ingress is `UDP/<listen_port>` on any RG-aware ifindex. The
+decap point sits in the ingress packet classifier (poll_descriptor)
+where we already strip outer L2/L3/L4 to expose payload. The same
+"wire it up later" comment applies — engine builds and tests in this
+PR; activation lands separately.
+
+### Protocol extension
+
+Add to `TunnelEndpointSnapshot` (both `userspace-dp/src/protocol.rs`
+and `pkg/dataplane/userspace/protocol.go`):
+
+- `wg_listen_port: u16` — UDP port for inbound demux.
+- `wg_local_privkey: [u8; 32]` (hex on the wire) — our static key.
+- `wg_peer_pubkey: [u8; 32]` (hex on the wire) — peer's static key.
+- `wg_allowed_ips: Vec<String>` — allowed-IPs CIDRs.
+- `wg_endpoint: String` — optional peer endpoint for initiator role.
+- `wg_keepalive_secs: u16` — optional persistent keepalive.
+
+These mirror in `TunnelEndpoint` in `types/forwarding.rs`.
+
+We do NOT (yet) extend the Go control plane to populate these from
+Junos config. That's a follow-up PR. For now the fields exist on
+the wire and are populated only by tests.
+
+## MSS clamp
+
+WG-specific overhead, per draft-ietf-wireguard / the WG whitepaper:
+
+- IPv4 outer: 20 (outer IP) + 8 (UDP) + 4 (type+reserved) + 4
+  (receiver index) + 8 (counter) + 16 (Poly1305 tag) = **60 bytes**.
+- IPv6 outer: 40 (outer IP) + 8 (UDP) + 4 + 4 + 8 + 16 = **80 bytes**.
+
+Note: the task brief gave 68/88 by counting "WG type 4 hdr (16)"
+which already includes type+reserved+receiver+counter. The numbers
+agree once you don't double-count. I'm using the byte-exact
+breakdown: **60 / 80**.
+
+The MSS gate in `forwarding/mod.rs:751` (`native_gre_tcp_mss`) is
+extended with a sibling `wg_tcp_mss` and the call site
+(`dispatch.rs:1458`) branches on `endpoint.mode`. WG endpoints
+read `wg_tcp_mss`; everything else keeps GRE semantics. No GRE
+clamp is reused.
+
+## DSCP and ECN
+
+`meta.dscp` is 6-bit right-justified. Outer TOS byte:
+
+```rust
+let outer_tos = (meta.dscp & 0x3F) << 2; // ECN bits 0 (cleared)
+```
+
+ECN propagation per RFC 6040 is a follow-up. For this PR we clear
+the ECN bits and document it as a known gap with a tracking issue.
+
+## VLAN safety
+
+`try_encap` takes `tx_vlan_id: u16` and emits 802.1Q outer L2 when
+`tx_vlan_id != 0`, mirroring `encapsulate_native_gre_frame`. The
+neighbor MAC is supplied by the caller (resolved by the existing
+FIB/neighbor pipeline before the encap call). Engine does NOT do
+its own neighbor lookup.
+
+## Recycle discipline
+
+Every drop path in the eventual integration must recycle the
+ingress UMEM frame. This PR does not touch dispatch/poll, so there
+is no recycle code here. The integration PR will follow the
+existing pattern of `recycle_ingress_frame(...)` before every
+`continue;` — encap is just one more arm of the existing match.
+
+## What's IN this PR
+
+- `userspace-dp/src/afxdp/wg/` new module:
+  - `mod.rs` — public API + `WgEngine`
+  - `engine.rs` — engine state, peer table, session table
+  - `peer.rs` — peer state + AllowedIPs
+  - `session.rs` — transport session + replay window
+  - `allowed_ips.rs` — LPM trie (in-tree, no extra deps)
+  - `framing.rs` — WG transport-data record encode/decode
+  - `mss.rs` — WG MSS arithmetic
+  - `dscp.rs` — DSCP→TOS shifting
+  - `outer.rs` — outer IPv4/UDP/L2 (+VLAN) header builder
+  - `scratch.rs` — preallocated worker scratch type
+  - `tests.rs` — unit tests
+- `userspace-dp/Cargo.toml` — adds `snow` and supporting crates.
+- `userspace-dp/src/protocol.rs` — adds WG fields to
+  `TunnelEndpointSnapshot`. Backward-compatible (all new fields are
+  `#[serde(default)]`).
+- `userspace-dp/src/afxdp/types/forwarding.rs` — adds WG fields to
+  `TunnelEndpoint`.
+- `userspace-dp/src/afxdp/forwarding_build.rs` — propagates WG fields
+  from snapshot to runtime.
+- `pkg/dataplane/userspace/protocol.go` — Go-side mirror.
+- Unit tests: handshake roundtrip, encap matches snow output,
+  decap recovers plaintext, replay window in-order / repeat /
+  out-of-window / gap-fill, AllowedIPs LPM, MSS clamp math, VLAN
+  outer L2, DSCP propagation, peer-pubkey gate (cryptokey routing).
+- `userspace-dp/src/afxdp/mod.rs` — `mod wg;` declaration.
+
+## What's OUT (tracked as follow-ups)
+
+- Activation in `tx/dispatch.rs` and `poll_descriptor.rs`. Engine
+  exists and is tested but is not on the hot path yet.
+- Go control-plane mapping from Junos `set security ipsec ...` /
+  `set interfaces st0...` to WG snapshot fields.
+- HA / RG-aware session migration on failover.
+- FIB/neighbor lookup hint for outer next-hop MAC (caller-supplied
+  in this PR).
+- RFC 7901-style cookie / rate-limit DoS reply path.
+- IPv6 outer encap (engine supports v4 outer only in this PR;
+  framing is family-agnostic but `outer.rs` builds v4 headers only).
+- Persistent replay window across control-plane restart.
+- RFC 6040 ECN propagation (cleared today).
+- Cluster smoke matrix.
+
+## Validation in this PR
+
+- `cargo build --release` clean.
+- `cargo test --release` for new tests clean.
+- `go test ./pkg/...` clean (protocol.go round-trip).
+- No changes to existing tests; no changes to existing hot paths.

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -235,12 +235,25 @@ control socket so we survive restart without rekey.
 Two call sites. Both are **clearly marked WIP** in this PR and
 **do not** activate in production paths.
 
-### Encap call site: tx/dispatch.rs
+### Encap call sites (integration PR boundary)
 
-The tunnel-endpoint branch at `dispatch.rs:430` (`uses_native_tunnel
-= tunnel_endpoint_id != 0`) is the only egress encap point. Today it
-unconditionally calls `encapsulate_native_gre_frame`. The change is
-small and local:
+The egress encap path is gated on `tunnel_endpoint_id != 0` at
+`tx/dispatch.rs:430` (the `uses_native_tunnel` boolean — note this
+line *computes* the gate; it does not itself call the encap builder).
+The actual `encapsulate_native_gre_frame` call sites the integration
+PR has to teach about WireGuard are:
+
+- `userspace-dp/src/afxdp/frame/mod.rs:212` — `build_forwarded_frame_from_frame`
+  branches on `decision.resolution.tunnel_endpoint_id != 0` and
+  unconditionally calls `encapsulate_native_gre_frame`. This is the
+  primary copy-path encap builder invoked by dispatch at
+  `tx/dispatch.rs:785-792`.
+- `userspace-dp/src/afxdp/frame/tcp_segmentation.rs:309` — TCP-
+  segmentation path that emits one GRE-encapped frame per segment.
+- `userspace-dp/src/afxdp/tunnel.rs:189` — local-tunnel-origination
+  path (packets sourced by the firewall itself, not just transit).
+
+The shape of the integration change is the same at each site:
 
 ```rust
 let endpoint = forwarding.tunnel_endpoints.get(&id)?;
@@ -250,9 +263,10 @@ let bytes = match endpoint.mode.as_str() {
 };
 ```
 
-This PR does NOT make that call. It lands the engine + tests + the
-protocol extension and stops there. Wiring is the next PR — gated
-behind a thorough triple-review of the engine as-is.
+This PR does NOT make those calls. It lands the engine + tests + the
+protocol extension and stops there. Wiring all three sites is the
+integration PR — gated behind a thorough triple-review of the engine
+as-is.
 
 ### Decap call site: poll_descriptor.rs
 
@@ -439,8 +453,13 @@ data record only.
 
 ## What's OUT (tracked as follow-ups)
 
-- Activation in `tx/dispatch.rs` and `poll_descriptor.rs`. Engine
-  exists and is tested but is not on the hot path yet.
+- Activation in the egress encap call sites
+  (`afxdp/frame/mod.rs:212`, `afxdp/frame/tcp_segmentation.rs:309`,
+  `afxdp/tunnel.rs:189`, gated by the
+  `tunnel_endpoint_id != 0` branch computed at
+  `afxdp/tx/dispatch.rs:430`) and in the ingress decap classifier
+  in `poll_descriptor.rs`. Engine exists and is tested but is not on
+  the hot path yet.
 - WG handshake outer-framing layer (MessageInitiation/MessageResponse
   outer bytes around the Noise sub-message, MAC1/MAC2, TAI64N).
   Engine ships the Noise sub-message bytes only; the integration

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -156,24 +156,24 @@ message and at most one output message. Nothing to "drain".
 ### Hot-path layout
 
 - Worker holds a `WgWorkerScratch` with `encap_out: RefCell<Vec<u8>>`
-  and `decap_out: RefCell<Vec<u8>>` (see `scratch.rs:17-21`), each
+  and `decap_out: RefCell<Vec<u8>>` (see `scratch.rs:18-25`), each
   sized to the worker's `max_frame` at startup
-  (`WgWorkerScratch::new(max_frame)` in `scratch.rs:25-30`; the
+  (`WgWorkerScratch::new(max_frame)` in `scratch.rs:27-33`; the
   integration PR will pass `UMEM_FRAME_SIZE` from
   `afxdp/mod.rs:175`, currently 4096). Separate per-direction buffers
   with `RefCell` interior mutability — never reallocated; the cells
   are entered exclusively per packet because each worker is
   single-threaded inside its poll loop.
 - Engine peer routing (peers vec + pubkey→index map + AllowedIPs)
-  lives in a single `ArcSwap<PeerTable>` (`engine.rs:258`) so the
+  lives in a single `ArcSwap<PeerTable>` (`engine.rs:262`) so the
   hot path observes the three sub-fields as one atomic snapshot
   (`peer_arc` does an `ArcSwap::load` only — no lock). Per-peer
   session state (`peer.current` / `peer.previous`) is
   `RwLock<Option<Arc<WgSession>>>` and ingress demux
   (`sessions_by_local_index`) is `RwLock<FxHashMap<u32, Arc<WgSession>>>`,
   so encap takes one `RwLock::read` on `peer.current`
-  (`engine.rs:506-510`) and decap takes one `RwLock::read` on
-  `sessions_by_local_index` (`engine.rs:643-649`). Both are
+  (`engine.rs:510-514`) and decap takes one `RwLock::read` on
+  `sessions_by_local_index` (`engine.rs:647-653`). Both are
   uncontended in steady state (single-writer at slow-path session
   install / rotate), but they ARE RwLock reads, not lock-free. The
   earlier draft of this bullet claimed "never under a lock on the
@@ -195,9 +195,9 @@ message and at most one output message. Nothing to "drain".
   cross-worker traffic. The earlier draft of this bullet described
   the lock as `parking_lot::Mutex` taken "only on the
   duplicate/out-of-window arms"; that did not match the
-  implementation (`session.rs:72` — `std::sync::Mutex<ReplayState>`,
-  `engine.rs:671-676` — unconditional pre-AEAD precheck-lock; and
-  `engine.rs:695` onward — post-AEAD update-lock that calls
+  implementation (`session.rs:77` — `std::sync::Mutex<ReplayState>`,
+  `engine.rs:675-680` — unconditional pre-AEAD precheck-lock; and
+  `engine.rs:699-718` — post-AEAD update-lock that calls
   `replay.check_and_update`).
 - Ephemerals: handshakes are slow-path only — snow's `Builder`
   generates the ephemeral keypair inside `build_initiator_handshake`

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -200,10 +200,18 @@ WG-specific overhead, per draft-ietf-wireguard / the WG whitepaper:
   (receiver index) + 8 (counter) + 16 (Poly1305 tag) = **60 bytes**.
 - IPv6 outer: 40 (outer IP) + 8 (UDP) + 4 + 4 + 8 + 16 = **80 bytes**.
 
+WG §5.4.6 also requires the inner-IP plaintext to be zero-padded
+to a 16-byte multiple before AEAD. That adds **0..15** bytes per
+data record on top of the fixed transport overhead. `wg_tcp_mss`
+therefore subtracts an additional 15 bytes (worst-case padding)
+so that a sender advertising the clamp can never produce an outer
+frame larger than the MTU, regardless of how the inner segment's
+total length lands modulo 16. See `mss.rs` for the byte table.
+
 Note: the task brief gave 68/88 by counting "WG type 4 hdr (16)"
 which already includes type+reserved+receiver+counter. The numbers
 agree once you don't double-count. I'm using the byte-exact
-breakdown: **60 / 80**.
+breakdown: **60 / 80** plus the **15** padding allowance.
 
 The MSS gate in `forwarding/mod.rs:751` (`native_gre_tcp_mss`) is
 extended with a sibling `wg_tcp_mss` and the call site

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -106,10 +106,12 @@ consulted on the decap path to gate inbound plaintext — "is this src
 IP in AllowedIPs for the session's peer?" — never to choose a peer
 on egress.
 
-On ingress the engine demuxes by `(listen_port, receiver_index)`
-extracted from the WG transport header. The receiver index is
-chosen by the local side at handshake time, so it identifies the
-session unambiguously without depending on a tuple-match.
+On ingress the engine demuxes by `receiver_index` alone, extracted
+from the WG transport header (`sessions_by_local_index` in
+`engine.rs`). The receiver index is chosen by the local side at
+handshake time, so it identifies the session unambiguously without
+depending on a tuple-match — listen-port selection happens one
+layer up in the integration PR's UDP-socket dispatch.
 
 ### Pump pattern
 
@@ -140,21 +142,50 @@ message and at most one output message. Nothing to "drain".
 - Engine internals (peer table, session table) live in an
   `Arc<WgEngine>` and use `arc-swap` for reconfiguration — the worker
   reads a snapshot per poll, never under a lock on the hot path.
-- Replay windows are per-session, accessed via `&AtomicU64`
-  bitmap + counter pair (sliding window of 64). Encap is lock-free
-  (single producer per session — the owning worker). Decap acquires
-  an inexpensive per-session `parking_lot::Mutex` only on the
-  duplicate/out-of-window arms.
-- Ephemerals: a slow-path producer thread pre-generates 64
-  ephemeral keypairs into a bounded SPSC ring. Slow-path handshake
-  drains; hot path never calls `getrandom`.
+- Replay windows are per-session, tracked by a `ReplayState`
+  (single counter + 64-bit sliding bitmap, RFC 6479) guarded by a
+  `std::sync::Mutex` on the session. Encap is lock-free on the
+  replay path — the owning worker is the only producer and bumps a
+  separate `AtomicU64` tx counter. Decap takes the per-session
+  replay mutex twice per packet: a pre-AEAD precheck
+  (`definitely_out_of_window`) so a hostile flood cannot burn the
+  snow ChaCha20-Poly1305 cost on counters that are already
+  provably stale, and a post-AEAD `check_and_update` to commit the
+  authenticated counter into the window. Contention is bounded
+  because each session is demuxed onto a single worker — the mutex
+  is effectively a per-session-per-worker SPSC lock with no
+  cross-worker traffic. The earlier draft of this bullet described
+  the lock as `parking_lot::Mutex` taken "only on the
+  duplicate/out-of-window arms"; that did not match the
+  implementation (`session.rs:72` — `std::sync::Mutex<ReplayState>`,
+  `engine.rs:664`/`engine.rs:688` — unconditional precheck-lock
+  followed by post-AEAD update-lock).
+- Ephemerals: handshakes are slow-path only — snow's `Builder`
+  generates the ephemeral keypair inside `build_initiator_handshake`
+  / `build_responder_handshake`, which the engine deliberately
+  reserves for the control thread. The hot encap/decap paths never
+  build a `HandshakeState` and never call `getrandom`. The
+  originally-planned SPSC pre-generation ring is not implemented in
+  this PR (and not needed while handshakes stay off the worker poll
+  loop); revisit if a future profile shows handshake-driven
+  getrandom contention on slow path.
 
 ### Replay window
 
 Single-counter sliding bitmap, 64 bits, RFC 6479 algorithm. Stored
-in the session struct as `(highest: AtomicU64, bitmap: AtomicU64)`.
-Encap increments `highest` (we are the only writer). Decap CAS-loops
-or locks briefly on the dup/oow path.
+on the session as `replay: std::sync::Mutex<ReplayState>`, where
+`ReplayState` carries the highest accepted counter and a 64-bit
+bitmap (see `session.rs`). Encap bumps a separate `AtomicU64`
+`tx_counter` field — the encap path never touches the replay
+mutex. Decap takes the mutex twice per packet: an unconditional
+pre-AEAD `definitely_out_of_window` precheck to skip snow's AEAD
+for provably stale counters, and a post-AEAD `check_and_update`
+that commits an authenticated counter into the window or returns
+`ReplayDuplicate` / `ReplayOutOfWindow`. The earlier draft of
+this section described the storage as
+`(highest: AtomicU64, bitmap: AtomicU64)` with a CAS loop /
+brief lock; the implementation is the mutex-guarded `ReplayState`
+described above.
 
 ### Replay-state across restart
 
@@ -254,8 +285,15 @@ the ECN bits and document it as a known gap with a tracking issue.
 
 ## VLAN safety
 
-`try_encap` takes `tx_vlan_id: u16` and emits 802.1Q outer L2 when
-`tx_vlan_id != 0`, mirroring `encapsulate_native_gre_frame`. The
+VLAN-aware outer L2 is built by `outer.rs::write_outer_eth(out,
+src_mac, dst_mac, vlan_id, ethertype)`: an 18-byte 802.1Q tagged
+header when `vlan_id != 0`, otherwise the 14-byte untagged
+Ethernet header. `outer_l2_len(vlan_id)` returns the matching
+length so the caller can size its scratch correctly. `try_encap`
+itself takes only `(peer_pubkey, inner_ip, out)` and writes the
+WG transport record (header + ciphertext + Poly1305 tag) into
+`out[0..]` — outer L2 / L3 / L4 are entirely the integration
+caller's responsibility and use `outer.rs` to stay VLAN-safe. The
 neighbor MAC is supplied by the caller (resolved by the existing
 FIB/neighbor pipeline before the encap call). Engine does NOT do
 its own neighbor lookup.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -248,7 +248,7 @@ type TunnelEndpointSnapshot struct {
 	// layer's UDP-socket dispatch (one layer above the engine); the
 	// engine itself demuxes by `receiver_index` alone via the
 	// `sessions_by_local_index` map (see userspace-dp
-	// afxdp/wg/engine.rs:264). The receiver index is chosen by the
+	// afxdp/wg/engine.rs:271). The receiver index is chosen by the
 	// local side at handshake time, so it identifies the session
 	// unambiguously without a (port, index) tuple match.
 	WgListenPort uint16 `json:"wg_listen_port,omitempty"`

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -236,6 +236,33 @@ type TunnelEndpointSnapshot struct {
 	Key             uint32 `json:"key,omitempty"`
 	TTL             int    `json:"ttl,omitempty"`
 	TransportTable  string `json:"transport_table,omitempty"`
+
+	// WireGuard clean-room termination (see docs/pr/wireguard-clean/plan.md).
+	// All fields are wire-compatible additions: a daemon built before the
+	// plan landed will simply omit them, and the Rust side defaults each
+	// field via #[serde(default)]. The control plane only populates them
+	// when Mode == "wireguard".
+	//
+	// WgListenPort is the local UDP port we listen on for inbound WG
+	// transport. Demuxed against (listen_port, receiver_index) by the
+	// engine.
+	WgListenPort uint16 `json:"wg_listen_port,omitempty"`
+	// WgLocalPrivkeyHex is the local static X25519 private key as
+	// hex (64 chars). Control-plane-internal; never logged.
+	WgLocalPrivkeyHex string `json:"wg_local_privkey_hex,omitempty"`
+	// WgPeerPubkeyHex is the peer's static X25519 public key as
+	// hex. The engine uses THIS, not AllowedIPs LPM, to choose the
+	// encryption peer on egress — see plan §"Engine keying".
+	WgPeerPubkeyHex string `json:"wg_peer_pubkey_hex,omitempty"`
+	// WgAllowedIPs is the peer's AllowedIPs as CIDR strings. Only
+	// consulted on the decap path (inner src-IP gate).
+	WgAllowedIPs []string `json:"wg_allowed_ips,omitempty"`
+	// WgEndpoint is the optional peer endpoint (IP:port). Empty
+	// for responder-only.
+	WgEndpoint string `json:"wg_endpoint,omitempty"`
+	// WgKeepaliveSecs is the optional persistent-keepalive
+	// interval. 0 means disabled.
+	WgKeepaliveSecs uint16 `json:"wg_keepalive_secs,omitempty"`
 }
 
 type SourceNATRuleSnapshot struct {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -244,8 +244,13 @@ type TunnelEndpointSnapshot struct {
 	// when Mode == "wireguard".
 	//
 	// WgListenPort is the local UDP port we listen on for inbound WG
-	// transport. Demuxed against (listen_port, receiver_index) by the
-	// engine.
+	// transport. Listen-port selection happens at the integration
+	// layer's UDP-socket dispatch (one layer above the engine); the
+	// engine itself demuxes by `receiver_index` alone via the
+	// `sessions_by_local_index` map (see userspace-dp
+	// afxdp/wg/engine.rs:264). The receiver index is chosen by the
+	// local side at handshake time, so it identifies the session
+	// unambiguously without a (port, index) tuple match.
 	WgListenPort uint16 `json:"wg_listen_port,omitempty"`
 	// WgLocalPrivkeyHex is the local static X25519 private key as
 	// hex (64 chars). Control-plane-internal; never logged.

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -248,7 +248,7 @@ type TunnelEndpointSnapshot struct {
 	// layer's UDP-socket dispatch (one layer above the engine); the
 	// engine itself demuxes by `receiver_index` alone via the
 	// `sessions_by_local_index` map (see userspace-dp
-	// afxdp/wg/engine.rs:271). The receiver index is chosen by the
+	// afxdp/wg/engine.rs:275). The receiver index is chosen by the
 	// local side at handshake time, so it identifies the session
 	// unambiguously without a (port, index) tuple match.
 	WgListenPort uint16 `json:"wg_listen_port,omitempty"`

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "sha2",
  "slab",
  "snow",
+ "zeroize",
 ]
 
 [[package]]
@@ -1178,6 +1179,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -1179,20 +1179,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +87,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -106,6 +150,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +212,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -237,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,7 +332,32 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -255,6 +368,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -276,6 +390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +409,39 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -333,6 +486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +519,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -463,10 +625,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -484,6 +684,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -516,10 +752,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -535,6 +794,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -603,6 +868,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "snow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599b506ccc4aff8cf7844bc42cf783009a434c1e26c964432560fb6d6ad02d82"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "getrandom 0.3.4",
+ "ring",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +924,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +953,21 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -702,7 +1021,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -766,12 +1085,91 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xpf-userspace-dp"
@@ -786,11 +1184,13 @@ dependencies = [
  "ipnet",
  "libbpf-sys",
  "libc",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
  "sha2",
  "slab",
+ "snow",
 ]
 
 [[package]]
@@ -812,6 +1212,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -660,15 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,36 +682,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "regex"
@@ -1184,7 +1145,6 @@ dependencies = [
  "ipnet",
  "libbpf-sys",
  "libc",
- "rand",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -22,13 +22,9 @@ sha2 = "0.10"
 slab = "0.4"
 # WireGuard clean-room termination (docs/pr/wireguard-clean/plan.md):
 # snow provides Noise IK with explicit state machine and no hidden
-# output queues. default-resolver pulls in pure-Rust crypto
-# (chacha20poly1305, curve25519-dalek current, blake2) — no ring.
+# output queues. The transitive crypto set includes
+# chacha20poly1305/curve25519-dalek/blake2 and ring.
 snow = "0.10"
-# Used by the slow-path ephemeral pre-generation thread to source
-# X25519 private bytes once at handshake-init time. Never called
-# from the worker hot path.
-rand = "0.8"
 
 [build-dependencies]
 cc = "1.2"

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -25,6 +25,11 @@ slab = "0.4"
 # output queues. The transitive crypto set includes
 # chacha20poly1305/curve25519-dalek/blake2 and ring.
 snow = "0.10"
+# zeroize is already pulled transitively by curve25519-dalek/snow; we
+# pin the version we use directly for the engine's static-key state
+# so the WG private key is wiped on engine drop. Cost: zero — just a
+# Drop impl on a 32-byte field.
+zeroize = { version = "1.8", features = ["derive"] }
 
 [build-dependencies]
 cc = "1.2"

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -20,6 +20,15 @@ serde_json = "1.0"
 rustc-hash = "2.1"
 sha2 = "0.10"
 slab = "0.4"
+# WireGuard clean-room termination (docs/pr/wireguard-clean/plan.md):
+# snow provides Noise IK with explicit state machine and no hidden
+# output queues. default-resolver pulls in pure-Rust crypto
+# (chacha20poly1305, curve25519-dalek current, blake2) — no ring.
+snow = "0.10"
+# Used by the slow-path ephemeral pre-generation thread to source
+# X25519 private bytes once at handshake-init time. Never called
+# from the worker hot path.
+rand = "0.8"
 
 [build-dependencies]
 cc = "1.2"

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -29,7 +29,7 @@ snow = "0.10"
 # pin the version we use directly for the engine's static-key state
 # so the WG private key is wiped on engine drop. Cost: zero — just a
 # Drop impl on a 32-byte field.
-zeroize = { version = "1.8", features = ["derive"] }
+zeroize = "1.8"
 
 [build-dependencies]
 cc = "1.2"

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -112,6 +112,11 @@ mod tx;
 mod types;
 #[path = "umem/mod.rs"]
 mod umem;
+// Clean-room WireGuard tunnel termination — see
+// docs/pr/wireguard-clean/plan.md. Engine + tests only in this PR;
+// hot-path activation lands in a follow-up.
+#[path = "wg/mod.rs"]
+mod wg;
 
 #[cfg(test)]
 use self::bind::bind_flag_candidates_for_driver;

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -149,6 +149,7 @@ pub(super) fn native_gre_snapshot(include_neighbor: bool) -> ConfigSnapshot {
             key: 0,
             ttl: 64,
             transport_table: "inet6.0".to_string(),
+            ..Default::default()
         }],
         routes: vec![
             RouteSnapshot {

--- a/userspace-dp/src/afxdp/wg/allowed_ips.rs
+++ b/userspace-dp/src/afxdp/wg/allowed_ips.rs
@@ -22,6 +22,7 @@
 //! storms that bit #923's prefix-set code at large fanout. The
 //! scan is also branch-predictable and cache-friendly.
 
+use rustc_hash::FxHashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// A single AllowedIPs entry: `(prefix, prefix_len, peer_index)`.
@@ -46,6 +47,14 @@ pub(crate) struct AllowedIps {
     /// IPv4 and IPv6 entries are interleaved — `lookup` dispatches
     /// on the query family.
     entries: Vec<Entry>,
+    /// Auxiliary index: `peer_index → indices into `entries` belonging
+    /// to that peer`. Lets `matches_for_peer` skip over entries owned
+    /// by other peers without scanning the whole table — important
+    /// when many peers share an engine (the original linear scan was
+    /// O(N) per decap and showed up in profiles at 50+-peer configs).
+    /// Rebuilt on every `insert` / `remove_peer` call; the LPM
+    /// reconcile path is slow-path so the rebuild cost is irrelevant.
+    by_peer: FxHashMap<u32, Vec<usize>>,
 }
 
 impl AllowedIps {
@@ -77,12 +86,24 @@ impl AllowedIps {
         });
         self.entries.push(entry);
         self.entries.sort_by(|a, b| b.prefix_len.cmp(&a.prefix_len));
+        self.rebuild_by_peer();
     }
 
     /// Remove every entry for a peer. Used when the peer is dropped
     /// from the config snapshot.
     pub(crate) fn remove_peer(&mut self, peer_index: u32) {
         self.entries.retain(|e| e.peer_index != peer_index);
+        self.rebuild_by_peer();
+    }
+
+    /// Rebuild the `by_peer` auxiliary index from `entries`. O(N)
+    /// over the entry count; only called from the slow-path
+    /// reconcile.
+    fn rebuild_by_peer(&mut self) {
+        self.by_peer.clear();
+        for (idx, entry) in self.entries.iter().enumerate() {
+            self.by_peer.entry(entry.peer_index).or_default().push(idx);
+        }
     }
 
     /// Longest-prefix-match lookup. Returns the peer_index of the
@@ -129,13 +150,14 @@ impl AllowedIps {
     /// `peer_index` covers `addr` — in which case the packet must
     /// be dropped.
     pub(crate) fn matches_for_peer(&self, addr: IpAddr, peer_index: u32) -> bool {
+        let Some(indices) = self.by_peer.get(&peer_index) else {
+            return false;
+        };
         match addr {
             IpAddr::V4(ip) => {
                 let bytes = ip.octets();
-                for entry in &self.entries {
-                    if entry.peer_index != peer_index {
-                        continue;
-                    }
+                for &i in indices {
+                    let entry = &self.entries[i];
                     if let PrefixBits::V4(prefix) = entry.prefix
                         && prefix_matches(&bytes, &prefix, entry.prefix_len)
                     {
@@ -146,10 +168,8 @@ impl AllowedIps {
             }
             IpAddr::V6(ip) => {
                 let bytes = ip.octets();
-                for entry in &self.entries {
-                    if entry.peer_index != peer_index {
-                        continue;
-                    }
+                for &i in indices {
+                    let entry = &self.entries[i];
                     if let PrefixBits::V6(prefix) = entry.prefix
                         && prefix_matches(&bytes, &prefix, entry.prefix_len)
                     {

--- a/userspace-dp/src/afxdp/wg/allowed_ips.rs
+++ b/userspace-dp/src/afxdp/wg/allowed_ips.rs
@@ -22,7 +22,6 @@
 //! storms that bit #923's prefix-set code at large fanout. The
 //! scan is also branch-predictable and cache-friendly.
 
-use rustc_hash::FxHashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// A single AllowedIPs entry: `(prefix, prefix_len, peer_index)`.
@@ -46,15 +45,16 @@ pub(crate) struct AllowedIps {
     /// Sorted by `prefix_len` descending so the first match wins.
     /// IPv4 and IPv6 entries are interleaved — `lookup` dispatches
     /// on the query family.
+    ///
+    /// `matches_for_peer` is implemented as a global LPM lookup
+    /// followed by a peer-identity compare, because WG cryptokey
+    /// routing requires the global LPM semantic (see the
+    /// `matches_for_peer` doc for details). An earlier revision
+    /// kept a per-peer auxiliary index for O(per-peer) scanning;
+    /// that micro-optimization was incorrect by construction
+    /// against overlapping cross-peer prefixes and has been
+    /// removed.
     entries: Vec<Entry>,
-    /// Auxiliary index: `peer_index → indices into `entries` belonging
-    /// to that peer`. Lets `matches_for_peer` skip over entries owned
-    /// by other peers without scanning the whole table — important
-    /// when many peers share an engine (the original linear scan was
-    /// O(N) per decap and showed up in profiles at 50+-peer configs).
-    /// Rebuilt on every `insert` / `remove_peer` call; the LPM
-    /// reconcile path is slow-path so the rebuild cost is irrelevant.
-    by_peer: FxHashMap<u32, Vec<usize>>,
 }
 
 impl AllowedIps {
@@ -86,24 +86,12 @@ impl AllowedIps {
         });
         self.entries.push(entry);
         self.entries.sort_by(|a, b| b.prefix_len.cmp(&a.prefix_len));
-        self.rebuild_by_peer();
     }
 
     /// Remove every entry for a peer. Used when the peer is dropped
     /// from the config snapshot.
     pub(crate) fn remove_peer(&mut self, peer_index: u32) {
         self.entries.retain(|e| e.peer_index != peer_index);
-        self.rebuild_by_peer();
-    }
-
-    /// Rebuild the `by_peer` auxiliary index from `entries`. O(N)
-    /// over the entry count; only called from the slow-path
-    /// reconcile.
-    fn rebuild_by_peer(&mut self) {
-        self.by_peer.clear();
-        for (idx, entry) in self.entries.iter().enumerate() {
-            self.by_peer.entry(entry.peer_index).or_default().push(idx);
-        }
     }
 
     /// Longest-prefix-match lookup. Returns the peer_index of the
@@ -141,44 +129,25 @@ impl AllowedIps {
         None
     }
 
-    /// Verify that `addr` is covered by *some* prefix belonging to
-    /// `peer_index`. This is the gate used on decap: after we know
-    /// which peer decrypted the packet, we check the inner src IP
-    /// against that peer's AllowedIPs.
+    /// Cryptokey-routing gate used on decap: after we know which
+    /// peer decrypted the packet, verify that a global LPM lookup of
+    /// the inner src IP across the entire AllowedIPs trie resolves
+    /// to that same peer.
     ///
-    /// Returns true on a match. Returns false if no entry for
-    /// `peer_index` covers `addr` — in which case the packet must
-    /// be dropped.
+    /// WG spec §5.4.6 requires the global LPM semantic, NOT a
+    /// per-peer "is the address covered by any of this peer's
+    /// prefixes" check. The distinction matters when AllowedIPs
+    /// overlap across peers: e.g. peer A owns `10.0.0.0/8` and peer
+    /// B owns `10.1.1.0/24`. A packet authenticated by A with inner
+    /// src `10.1.1.5` must be dropped, because the global LPM
+    /// resolves `10.1.1.5` to B's more-specific /24 — even though
+    /// A's /8 also covers it. The per-peer-only check (which an
+    /// earlier r4 revision implemented) silently violated this and
+    /// allowed A to spoof source addresses inside B's prefix.
+    ///
+    /// Returns true iff `lookup(addr) == Some(peer_index)`.
     pub(crate) fn matches_for_peer(&self, addr: IpAddr, peer_index: u32) -> bool {
-        let Some(indices) = self.by_peer.get(&peer_index) else {
-            return false;
-        };
-        match addr {
-            IpAddr::V4(ip) => {
-                let bytes = ip.octets();
-                for &i in indices {
-                    let entry = &self.entries[i];
-                    if let PrefixBits::V4(prefix) = entry.prefix
-                        && prefix_matches(&bytes, &prefix, entry.prefix_len)
-                    {
-                        return true;
-                    }
-                }
-                false
-            }
-            IpAddr::V6(ip) => {
-                let bytes = ip.octets();
-                for &i in indices {
-                    let entry = &self.entries[i];
-                    if let PrefixBits::V6(prefix) = entry.prefix
-                        && prefix_matches(&bytes, &prefix, entry.prefix_len)
-                    {
-                        return true;
-                    }
-                }
-                false
-            }
-        }
+        self.lookup(addr) == Some(peer_index)
     }
 }
 
@@ -246,15 +215,23 @@ mod allowed_ips_tests {
         assert!(!t.matches_for_peer(ip("10.1.0.5"), 1));
     }
 
+    /// Cryptokey routing: when peer A owns a less-specific prefix
+    /// and peer B owns a more-specific one within it, an inner-src
+    /// inside B's prefix that arrives over A's session MUST be
+    /// rejected — the global LPM resolves to B, so A is not the
+    /// authoritative owner. This is the WG §5.4.6 semantic.
     #[test]
-    fn duplicate_insert_replaces() {
+    fn matches_for_peer_overlapping_lpm_picks_most_specific() {
         let mut t = AllowedIps::new();
-        t.insert(net("10.0.0.0/8"), 1);
-        t.insert(net("10.0.0.0/8"), 2);
-        // Same prefix, different peers can coexist so decap can
-        // validate by explicit peer identity.
-        assert!(t.matches_for_peer(ip("10.1.1.1"), 1));
-        assert!(t.matches_for_peer(ip("10.1.1.1"), 2));
+        t.insert(net("10.0.0.0/8"), 1); // peer A owns 10/8
+        t.insert(net("10.1.1.0/24"), 2); // peer B owns 10.1.1/24
+        // 10.1.1.5 globally resolves to peer B; only B may
+        // authoritatively use that source.
+        assert!(!t.matches_for_peer(ip("10.1.1.5"), 1));
+        assert!(t.matches_for_peer(ip("10.1.1.5"), 2));
+        // 10.2.0.5 globally resolves to peer A; only A may use it.
+        assert!(t.matches_for_peer(ip("10.2.0.5"), 1));
+        assert!(!t.matches_for_peer(ip("10.2.0.5"), 2));
     }
 
     #[test]
@@ -265,13 +242,24 @@ mod allowed_ips_tests {
         assert_eq!(t.lookup(ip("10.1.1.1")), Some(1));
     }
 
+    /// Cross-peer identical prefixes are a misconfiguration in WG
+    /// cryptokey routing: only one peer can own a given address.
+    /// The data structure tolerates the insert but global LPM picks
+    /// a single winner (insertion-order tie-breaking via the stable
+    /// sort), and `matches_for_peer` reflects that — the loser
+    /// cannot authoritatively use any address inside the prefix.
+    /// This test pins the behavior so a future change can't
+    /// accidentally return true for both peers.
     #[test]
-    fn matches_for_peer_with_overlapping_prefixes() {
+    fn duplicate_cross_peer_prefix_only_one_peer_wins() {
         let mut t = AllowedIps::new();
-        t.insert(net("10.0.0.0/24"), 1);
-        t.insert(net("10.0.0.0/24"), 2);
-        assert!(t.matches_for_peer(ip("10.0.0.5"), 1));
-        assert!(t.matches_for_peer(ip("10.0.0.5"), 2));
+        t.insert(net("10.0.0.0/8"), 1);
+        t.insert(net("10.0.0.0/8"), 2);
+        let winner = t.lookup(ip("10.1.1.1")).unwrap();
+        assert!(winner == 1 || winner == 2);
+        assert!(t.matches_for_peer(ip("10.1.1.1"), winner));
+        let loser = if winner == 1 { 2 } else { 1 };
+        assert!(!t.matches_for_peer(ip("10.1.1.1"), loser));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/wg/allowed_ips.rs
+++ b/userspace-dp/src/afxdp/wg/allowed_ips.rs
@@ -1,0 +1,229 @@
+//! AllowedIPs LPM table.
+//!
+//! WireGuard's AllowedIPs is a longest-prefix-match table from
+//! `IpAddr → peer`. It is used by the WG reference implementation
+//! for **both** directions:
+//!
+//! - Outbound: pick which peer to encrypt to from the inner dst IP.
+//! - Inbound: verify the decrypted inner src IP belongs to the
+//!   peer whose key decrypted the packet.
+//!
+//! In **xpf** we deliberately use it only for the second purpose.
+//! The forwarding decision tells dispatch.rs which peer to encrypt
+//! to (via the `wg_peer_pubkey` field on `TunnelEndpoint`), so the
+//! outbound LPM is never consulted. This eliminates the
+//! cryptokey-routing flaw that PR #1492 r11 was tripped up by:
+//! overlapping AllowedIPs across peers can never route plaintext
+//! to the wrong session.
+//!
+//! Implementation: a flat sorted-by-prefix-length-descending list.
+//! AllowedIPs is reconciled at config-commit time, not on the hot
+//! path, so a linear scan is fine and avoids the trie-allocation
+//! storms that bit #923's prefix-set code at large fanout. The
+//! scan is also branch-predictable and cache-friendly.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// A single AllowedIPs entry: `(prefix, prefix_len, peer_index)`.
+/// `peer_index` is an opaque handle into `WgEngine::peers`; the
+/// engine maps it back to the peer pubkey.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Entry {
+    prefix: PrefixBits,
+    prefix_len: u8,
+    peer_index: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrefixBits {
+    V4([u8; 4]),
+    V6([u8; 16]),
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct AllowedIps {
+    /// Sorted by `prefix_len` descending so the first match wins.
+    /// IPv4 and IPv6 entries are interleaved — `lookup` dispatches
+    /// on the query family.
+    entries: Vec<Entry>,
+}
+
+impl AllowedIps {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a CIDR for a peer. Re-sorts. Slow path only.
+    pub(crate) fn insert(&mut self, cidr: ipnet::IpNet, peer_index: u32) {
+        let entry = match cidr {
+            ipnet::IpNet::V4(net) => Entry {
+                prefix: PrefixBits::V4(net.network().octets()),
+                prefix_len: net.prefix_len(),
+                peer_index,
+            },
+            ipnet::IpNet::V6(net) => Entry {
+                prefix: PrefixBits::V6(net.network().octets()),
+                prefix_len: net.prefix_len(),
+                peer_index,
+            },
+        };
+        // Replace exact-prefix duplicates; this keeps reconciliation
+        // idempotent across config refreshes.
+        self.entries.retain(|e| !(e.prefix == entry.prefix && e.prefix_len == entry.prefix_len));
+        self.entries.push(entry);
+        self.entries.sort_by(|a, b| b.prefix_len.cmp(&a.prefix_len));
+    }
+
+    /// Remove every entry for a peer. Used when the peer is dropped
+    /// from the config snapshot.
+    pub(crate) fn remove_peer(&mut self, peer_index: u32) {
+        self.entries.retain(|e| e.peer_index != peer_index);
+    }
+
+    /// Longest-prefix-match lookup. Returns the peer_index of the
+    /// most specific covering prefix, or `None` if no entry covers
+    /// `addr`.
+    pub(crate) fn lookup(&self, addr: IpAddr) -> Option<u32> {
+        match addr {
+            IpAddr::V4(ip) => self.lookup_v4(ip),
+            IpAddr::V6(ip) => self.lookup_v6(ip),
+        }
+    }
+
+    fn lookup_v4(&self, ip: Ipv4Addr) -> Option<u32> {
+        let bytes = ip.octets();
+        // Entries are sorted by prefix_len descending. First match wins.
+        for entry in &self.entries {
+            if let PrefixBits::V4(prefix) = entry.prefix {
+                if prefix_matches(&bytes, &prefix, entry.prefix_len) {
+                    return Some(entry.peer_index);
+                }
+            }
+        }
+        None
+    }
+
+    fn lookup_v6(&self, ip: Ipv6Addr) -> Option<u32> {
+        let bytes = ip.octets();
+        for entry in &self.entries {
+            if let PrefixBits::V6(prefix) = entry.prefix {
+                if prefix_matches(&bytes, &prefix, entry.prefix_len) {
+                    return Some(entry.peer_index);
+                }
+            }
+        }
+        None
+    }
+
+    /// Verify that `addr` is covered by *some* prefix belonging to
+    /// `peer_index`. This is the gate used on decap: after we know
+    /// which peer decrypted the packet, we check the inner src IP
+    /// against that peer's AllowedIPs.
+    ///
+    /// Returns true on a match. Returns false if no entry for
+    /// `peer_index` covers `addr` — in which case the packet must
+    /// be dropped.
+    pub(crate) fn matches_for_peer(&self, addr: IpAddr, peer_index: u32) -> bool {
+        match self.lookup(addr) {
+            Some(idx) => idx == peer_index,
+            None => false,
+        }
+    }
+}
+
+fn prefix_matches(addr: &[u8], prefix: &[u8], len: u8) -> bool {
+    let full_bytes = (len / 8) as usize;
+    if addr[..full_bytes] != prefix[..full_bytes] {
+        return false;
+    }
+    let bits = len % 8;
+    if bits == 0 {
+        return true;
+    }
+    let mask = 0xffu8 << (8 - bits);
+    (addr[full_bytes] & mask) == (prefix[full_bytes] & mask)
+}
+
+#[cfg(test)]
+mod allowed_ips_tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn net(s: &str) -> ipnet::IpNet {
+        ipnet::IpNet::from_str(s).unwrap()
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        IpAddr::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn longest_prefix_wins() {
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/8"), 1);
+        t.insert(net("10.1.0.0/16"), 2);
+        t.insert(net("10.1.2.0/24"), 3);
+        assert_eq!(t.lookup(ip("10.1.2.5")), Some(3));
+        assert_eq!(t.lookup(ip("10.1.3.5")), Some(2));
+        assert_eq!(t.lookup(ip("10.2.0.5")), Some(1));
+        assert_eq!(t.lookup(ip("11.0.0.0")), None);
+    }
+
+    #[test]
+    fn ipv6_lookup() {
+        let mut t = AllowedIps::new();
+        t.insert(net("2001:db8::/32"), 1);
+        t.insert(net("2001:db8:1::/48"), 2);
+        assert_eq!(t.lookup(ip("2001:db8:1::1")), Some(2));
+        assert_eq!(t.lookup(ip("2001:db8:2::1")), Some(1));
+        assert_eq!(t.lookup(ip("2001:db9::1")), None);
+    }
+
+    #[test]
+    fn matches_for_peer_rejects_wrong_peer() {
+        // The core safety property: a peer's AllowedIPs gate must
+        // reject inner src IPs that belong to a *different* peer.
+        // This is what the inbound side relies on.
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/24"), 1);
+        t.insert(net("10.0.1.0/24"), 2);
+        assert!(t.matches_for_peer(ip("10.0.0.5"), 1));
+        assert!(!t.matches_for_peer(ip("10.0.0.5"), 2));
+        assert!(t.matches_for_peer(ip("10.0.1.5"), 2));
+        assert!(!t.matches_for_peer(ip("10.0.1.5"), 1));
+        // No matching prefix → reject for any peer.
+        assert!(!t.matches_for_peer(ip("10.1.0.5"), 1));
+    }
+
+    #[test]
+    fn duplicate_insert_replaces() {
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/8"), 1);
+        t.insert(net("10.0.0.0/8"), 2);
+        // Same prefix, different peer — the latter wins.
+        assert_eq!(t.lookup(ip("10.1.1.1")), Some(2));
+    }
+
+    #[test]
+    fn remove_peer_clears_entries() {
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/8"), 1);
+        t.insert(net("192.168.0.0/16"), 1);
+        t.insert(net("172.16.0.0/12"), 2);
+        t.remove_peer(1);
+        assert_eq!(t.lookup(ip("10.1.1.1")), None);
+        assert_eq!(t.lookup(ip("192.168.1.1")), None);
+        assert_eq!(t.lookup(ip("172.16.1.1")), Some(2));
+    }
+
+    #[test]
+    fn slash_zero_matches_everything() {
+        let mut t = AllowedIps::new();
+        t.insert(net("0.0.0.0/0"), 9);
+        t.insert(net("10.0.0.0/8"), 1);
+        // /8 wins for 10/8
+        assert_eq!(t.lookup(ip("10.0.0.1")), Some(1));
+        // /0 catches everything else
+        assert_eq!(t.lookup(ip("8.8.8.8")), Some(9));
+    }
+}

--- a/userspace-dp/src/afxdp/wg/allowed_ips.rs
+++ b/userspace-dp/src/afxdp/wg/allowed_ips.rs
@@ -67,9 +67,14 @@ impl AllowedIps {
                 peer_index,
             },
         };
-        // Replace exact-prefix duplicates; this keeps reconciliation
-        // idempotent across config refreshes.
-        self.entries.retain(|e| !(e.prefix == entry.prefix && e.prefix_len == entry.prefix_len));
+        // Replace exact duplicates for the same peer; this keeps
+        // reconciliation idempotent across config refreshes while
+        // still allowing overlapping prefixes across different peers.
+        self.entries.retain(|e| {
+            !(e.prefix == entry.prefix
+                && e.prefix_len == entry.prefix_len
+                && e.peer_index == entry.peer_index)
+        });
         self.entries.push(entry);
         self.entries.sort_by(|a, b| b.prefix_len.cmp(&a.prefix_len));
     }
@@ -124,9 +129,35 @@ impl AllowedIps {
     /// `peer_index` covers `addr` — in which case the packet must
     /// be dropped.
     pub(crate) fn matches_for_peer(&self, addr: IpAddr, peer_index: u32) -> bool {
-        match self.lookup(addr) {
-            Some(idx) => idx == peer_index,
-            None => false,
+        match addr {
+            IpAddr::V4(ip) => {
+                let bytes = ip.octets();
+                for entry in &self.entries {
+                    if entry.peer_index != peer_index {
+                        continue;
+                    }
+                    if let PrefixBits::V4(prefix) = entry.prefix
+                        && prefix_matches(&bytes, &prefix, entry.prefix_len)
+                    {
+                        return true;
+                    }
+                }
+                false
+            }
+            IpAddr::V6(ip) => {
+                let bytes = ip.octets();
+                for entry in &self.entries {
+                    if entry.peer_index != peer_index {
+                        continue;
+                    }
+                    if let PrefixBits::V6(prefix) = entry.prefix
+                        && prefix_matches(&bytes, &prefix, entry.prefix_len)
+                    {
+                        return true;
+                    }
+                }
+                false
+            }
         }
     }
 }
@@ -200,8 +231,27 @@ mod allowed_ips_tests {
         let mut t = AllowedIps::new();
         t.insert(net("10.0.0.0/8"), 1);
         t.insert(net("10.0.0.0/8"), 2);
-        // Same prefix, different peer — the latter wins.
-        assert_eq!(t.lookup(ip("10.1.1.1")), Some(2));
+        // Same prefix, different peers can coexist so decap can
+        // validate by explicit peer identity.
+        assert!(t.matches_for_peer(ip("10.1.1.1"), 1));
+        assert!(t.matches_for_peer(ip("10.1.1.1"), 2));
+    }
+
+    #[test]
+    fn duplicate_insert_same_peer_is_idempotent() {
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/8"), 1);
+        t.insert(net("10.0.0.0/8"), 1);
+        assert_eq!(t.lookup(ip("10.1.1.1")), Some(1));
+    }
+
+    #[test]
+    fn matches_for_peer_with_overlapping_prefixes() {
+        let mut t = AllowedIps::new();
+        t.insert(net("10.0.0.0/24"), 1);
+        t.insert(net("10.0.0.0/24"), 2);
+        assert!(t.matches_for_peer(ip("10.0.0.5"), 1));
+        assert!(t.matches_for_peer(ip("10.0.0.5"), 2));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/wg/allowed_ips.rs
+++ b/userspace-dp/src/afxdp/wg/allowed_ips.rs
@@ -10,11 +10,15 @@
 //!
 //! In **xpf** we deliberately use it only for the second purpose.
 //! The forwarding decision tells dispatch.rs which peer to encrypt
-//! to (via the `wg_peer_pubkey` field on `TunnelEndpoint`), so the
-//! outbound LPM is never consulted. This eliminates the
-//! cryptokey-routing flaw that PR #1492 r11 was tripped up by:
-//! overlapping AllowedIPs across peers can never route plaintext
-//! to the wrong session.
+//! to (via the `wg_peer_pubkey_hex` field on
+//! `TunnelEndpointSnapshot` — see
+//! `userspace-dp/src/protocol.rs:437-438`; the runtime
+//! `TunnelEndpoint` in `afxdp/types/forwarding.rs:129-140` is NOT
+//! yet extended with WG fields, the integration PR will mirror them
+//! across), so the outbound LPM is never consulted. This eliminates
+//! the cryptokey-routing flaw that PR #1492 r11 was tripped up by:
+//! overlapping AllowedIPs across peers can never route plaintext to
+//! the wrong session.
 //!
 //! Implementation: a flat sorted-by-prefix-length-descending list.
 //! AllowedIPs is reconciled at config-commit time, not on the hot

--- a/userspace-dp/src/afxdp/wg/dscp.rs
+++ b/userspace-dp/src/afxdp/wg/dscp.rs
@@ -1,0 +1,52 @@
+//! DSCP and ECN handling for the WG outer header.
+//!
+//! `UserspaceDpMeta::dscp` is 6-bit right-justified in xpf (matches
+//! the existing dataplane convention — see `forwarding/mod.rs` for
+//! the same placement on the GRE encap). The outer IP TOS byte
+//! holds DSCP in the high 6 bits and ECN in the low 2 bits.
+//!
+//! Conversion is `dscp << 2`. ECN is **cleared** by this PR; RFC
+//! 6040 (ECN propagation across tunnels) is a tracked follow-up.
+
+/// Build the outer IPv4 TOS / IPv6 Traffic Class byte from a
+/// 6-bit DSCP value. ECN bits are cleared.
+#[inline]
+pub(crate) fn tos_from_dscp(dscp: u8) -> u8 {
+    // Defensive mask: callers should pass 6-bit values, but a
+    // stray high bit would corrupt the ECN field, which is the
+    // sort of bug that's invisible in unit tests and shows up as
+    // mysterious congestion behavior on the wire.
+    (dscp & 0x3F) << 2
+}
+
+#[cfg(test)]
+mod dscp_tests {
+    use super::*;
+
+    #[test]
+    fn dscp_shifted_two_left() {
+        // CS0 / EF / AF41 sanity checks.
+        assert_eq!(tos_from_dscp(0), 0); // CS0
+        assert_eq!(tos_from_dscp(46), 46 << 2); // EF = 0xB8 = 184
+        assert_eq!(tos_from_dscp(34), 34 << 2); // AF41 = 0x88 = 136
+    }
+
+    #[test]
+    fn ecn_bits_always_clear() {
+        // Even with a max-valued DSCP, the low 2 bits (ECN) must
+        // be zero. This is the property the RFC 6040 follow-up
+        // will lift.
+        for d in 0u8..=63u8 {
+            assert_eq!(tos_from_dscp(d) & 0x03, 0);
+        }
+    }
+
+    #[test]
+    fn rejects_overflow_into_ecn() {
+        // If a caller mistakenly passes an 8-bit value with bits
+        // in positions 6-7, those must NOT bleed into the TOS
+        // byte. (Equivalent: ECN is preserved at zero.)
+        assert_eq!(tos_from_dscp(0xFF), 0x3F << 2);
+        assert_eq!(tos_from_dscp(0xC0), 0); // upper bits only
+    }
+}

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -31,7 +31,7 @@ use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};
 use super::peer::Peer;
 use super::session::{ReplayDecision, WgSession};
-use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN};
+use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_ZERO_PSK};
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -50,6 +50,8 @@ pub(crate) enum EncapError {
     /// snow rejected the encryption — most likely nonce exhaustion
     /// (counter approaching 2^64). Caller MUST drop and re-key.
     CryptoFailed,
+    /// Session exceeded WG's reject-after-messages bound.
+    RekeyRequired,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -205,17 +207,17 @@ impl WgEngine {
     /// register it for inbound demux. Called from the slow-path
     /// handshake-complete code.
     pub(crate) fn install_session(&self, pubkey: &[u8; 32], session: Arc<WgSession>) {
-        // Register for inbound demux first — the worker may start
-        // receiving traffic immediately on this new session.
-        self.sessions_by_local_index
-            .write()
-            .unwrap()
-            .insert(session.local_index, session.clone());
-        // Then rotate it onto the peer. The previous session (if
-        // any) lives on as `peer.previous` for in-flight tail
-        // decrypts.
-        if let Some(peer) = self.peer_arc(pubkey) {
-            peer.rotate_session(session);
+        let Some(peer) = self.peer_arc(pubkey) else {
+            return;
+        };
+        // Rotate first so concurrent encap picks up the newest
+        // session as soon as possible. Keep only current+previous in
+        // the demux map by deleting the session that falls off.
+        let dropped_previous = peer.rotate_session(session.clone());
+        let mut by_index = self.sessions_by_local_index.write().unwrap();
+        by_index.insert(session.local_index, session);
+        if let Some(old) = dropped_previous {
+            by_index.remove(&old.local_index);
         }
     }
 
@@ -247,7 +249,7 @@ impl WgEngine {
         if out.len() < required {
             return Err(EncapError::BufferTooSmall);
         }
-        let counter = session.next_tx_counter();
+        let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
         let _ = encode_data_header(out, session.peer_index, counter)
             .ok_or(EncapError::BufferTooSmall)?;
         // snow writes ciphertext||tag into the payload region.
@@ -285,6 +287,12 @@ impl WgEngine {
         let plaintext_len_max = hdr.ciphertext.len().saturating_sub(POLY1305_TAG_LEN);
         if out.len() < plaintext_len_max {
             return Err(DecapError::BufferTooSmall);
+        }
+        {
+            let replay = session.replay.lock().unwrap();
+            if replay.definitely_out_of_window(hdr.counter) {
+                return Err(DecapError::ReplayOutOfWindow);
+            }
         }
         let n = session
             .transport
@@ -336,6 +344,7 @@ impl WgEngine {
         Builder::new(WG_NOISE_PATTERN.parse()?)
             .local_private_key(&self.local_private_key)?
             .remote_public_key(peer_pubkey)?
+            .psk(2, &WG_ZERO_PSK)?
             .build_initiator()
     }
 
@@ -344,6 +353,7 @@ impl WgEngine {
     pub(crate) fn build_responder_handshake(&self) -> Result<HandshakeState, snow::Error> {
         Builder::new(WG_NOISE_PATTERN.parse()?)
             .local_private_key(&self.local_private_key)?
+            .psk(2, &WG_ZERO_PSK)?
             .build_responder()
     }
 }
@@ -358,7 +368,9 @@ fn inner_src_ip(pkt: &[u8]) -> Option<IpAddr> {
             if pkt.len() < 20 {
                 return None;
             }
-            Some(IpAddr::V4(Ipv4Addr::new(pkt[12], pkt[13], pkt[14], pkt[15])))
+            Some(IpAddr::V4(Ipv4Addr::new(
+                pkt[12], pkt[13], pkt[14], pkt[15],
+            )))
         }
         6 => {
             if pkt.len() < 40 {
@@ -375,6 +387,19 @@ fn inner_src_ip(pkt: &[u8]) -> Option<IpAddr> {
 #[cfg(test)]
 mod engine_internal_tests {
     use super::*;
+    use std::str::FromStr;
+    use std::sync::atomic::Ordering;
+
+    fn keypair() -> ([u8; 32], [u8; 32]) {
+        let kp = Builder::new(WG_NOISE_PATTERN.parse().unwrap())
+            .generate_keypair()
+            .unwrap();
+        let mut priv_k = [0u8; 32];
+        let mut pub_k = [0u8; 32];
+        priv_k.copy_from_slice(&kp.private);
+        pub_k.copy_from_slice(&kp.public);
+        (priv_k, pub_k)
+    }
 
     #[test]
     fn inner_src_ip_v4() {
@@ -410,5 +435,56 @@ mod engine_internal_tests {
     #[test]
     fn inner_src_ip_rejects_unknown_version() {
         assert!(inner_src_ip(&[0x05u8; 40]).is_none()); // bogus version 0
+    }
+
+    #[test]
+    fn encap_rejects_after_message_limit() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let resp = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let mut init_hs = engine.build_initiator_handshake(&peer_pub).unwrap();
+        let mut resp_hs = resp.build_responder_handshake().unwrap();
+        let mut buf = [0u8; 1024];
+        let mut sink = [0u8; 1024];
+        let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+        resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+        let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+        init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+        let session = Arc::new(WgSession::new(
+            init_hs.into_stateless_transport_mode().unwrap(),
+            1,
+            2,
+            peer_pub,
+        ));
+        session.tx_counter.store(
+            super::super::session::REJECT_AFTER_MESSAGES + 1,
+            Ordering::Relaxed,
+        );
+        engine.install_session(&peer_pub, session);
+        let inner = [
+            0x45u8, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 10, 0, 0, 1, 10, 0, 0, 2,
+        ];
+        let mut out = [0u8; 128];
+        let err = engine.try_encap(&peer_pub, &inner, &mut out).unwrap_err();
+        assert_eq!(err, EncapError::RekeyRequired);
     }
 }

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -341,10 +341,6 @@ impl WgEngine {
         table.peers.get(idx as usize).cloned()
     }
 
-    fn peer_index(&self, pubkey: &[u8; 32]) -> Option<u32> {
-        self.load_table().peer_index_by_pubkey.get(pubkey).copied()
-    }
-
     /// Install a freshly-completed transport session on a peer and
     /// register it for inbound demux. Called from the slow-path
     /// handshake-complete code.
@@ -445,25 +441,26 @@ impl WgEngine {
         // kernel WG / wireguard-go. Compute the padded length and
         // ensure the output buffer can hold header + ciphertext +
         // tag at the padded size.
+        //
+        // All bound checks fire BEFORE any observable side effect
+        // (counter advance, header write into `out`). Callers can
+        // therefore rely on the contract "on Err, the output buffer
+        // and the session's tx_counter are untouched". An oversized
+        // `out` paired with an oversized `inner_ip` previously tripped
+        // the PADDED_PLAINTEXT_MAX guard AFTER `next_tx_counter()`
+        // had already advanced the counter; the staging guard is
+        // hoisted above the counter consume to close that hole.
         let padded_len = pad_to_16(inner_ip.len());
         let required = WG_DATA_HEADER_LEN + padded_len + POLY1305_TAG_LEN;
         if out.len() < required {
             return Err(EncapError::BufferTooSmall);
         }
-        let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
-        let _ = encode_data_header(out, session.peer_index, counter)
-            .ok_or(EncapError::BufferTooSmall)?;
-        // Stage the padded plaintext on the stack. We use
-        // `MaybeUninit` and only initialize the bytes snow will read
-        // (`inner_ip.len()` of payload + the worst-case 15 padding
-        // bytes), which avoids the 4112-byte memset-per-call that a
-        // `[0u8; N]` array initializer would force LLVM to emit on
-        // the hot path. snow's `write_message` requires
-        // non-overlapping plaintext and ciphertext slices, so we
-        // cannot stage the plaintext inside `out`.
         if padded_len > PADDED_PLAINTEXT_MAX {
             return Err(EncapError::BufferTooSmall);
         }
+        let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
+        let _ = encode_data_header(out, session.peer_index, counter)
+            .ok_or(EncapError::BufferTooSmall)?;
         // Stage the padded plaintext on the stack. We use
         // `MaybeUninit` to skip the 4096-byte zero-init that a
         // `[0u8; PADDED_PLAINTEXT_MAX]` literal would force on every
@@ -1323,5 +1320,237 @@ mod engine_internal_tests {
         // (On a heavily loaded CI box this could be 1; we don't
         // tighten it.)
         assert!(n >= 1, "reader thread observed no snapshots");
+    }
+
+    /// r6 regression: `install_session` and `reconcile_peers` must
+    /// serialize so a removed peer cannot orphan a freshly-installed
+    /// demux entry.
+    ///
+    /// Race (pre-fix):
+    ///   1. install_session(P) loads `peer` via `peer_arc(P)` from
+    ///      `PeerTable_v1` and drops the snapshot reference.
+    ///   2. reconcile_peers(&[]) publishes `PeerTable_v2` without P.
+    ///      Its drain loop reads `peer.current.read()` and
+    ///      `peer.previous.read()` — both `None` because step (1)
+    ///      hasn't called `rotate_session` yet.
+    ///   3. install_session continues against the orphan Arc<Peer>,
+    ///      inserts the demux entry, and calls rotate_session. The
+    ///      demux entry now references a peer pubkey absent from
+    ///      every future `peer_index_by_pubkey`, so subsequent
+    ///      reconciles cannot drain it.
+    ///
+    /// Fix: `install_session` takes `reconcile_lock` for the entire
+    /// critical region. The lookup-then-mutate sequence is then
+    /// serialized against any concurrent `reconcile_peers`, and if
+    /// the peer is removed before the install acquires the lock, the
+    /// `peer_arc(pubkey)` lookup returns None and the install fails
+    /// with `UnknownPeer` — no demux mutation occurs.
+    ///
+    /// Invariant verified across the race: every entry in
+    /// `sessions_by_local_index` has its `session.peer_pubkey`
+    /// present in the currently published `peer_index_by_pubkey`.
+    /// Under the pre-fix code path, this invariant would fail
+    /// whenever the orphan interleaving fires.
+    #[test]
+    fn install_session_serializes_with_reconcile_removal() {
+        use std::sync::atomic::{AtomicBool, Ordering as AOrd};
+        use std::thread;
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = Arc::new(WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        }));
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let cfg_with_peer = vec![WgPeerConfig {
+            pubkey: peer_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+        }];
+        // Pre-build a batch of sessions off the hot path. Each one
+        // gets a fresh local_index so installs never collide on the
+        // demux map for the wrong reason.
+        let iterations = 400u32;
+        let mut sessions: Vec<Arc<WgSession>> = Vec::with_capacity(iterations as usize);
+        for i in 0..iterations {
+            sessions.push(make_session_for(
+                &engine,
+                peer_pub,
+                &peer_engine,
+                0xcafe_0000 + i,
+                100 + i,
+            ));
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        // Thread A: install_session in a tight loop, alternating
+        // with reconciles that re-add the peer so installs can
+        // succeed sometimes.
+        let installer = {
+            let engine = engine.clone();
+            thread::spawn(move || {
+                let mut ok = 0u32;
+                let mut unknown = 0u32;
+                let mut collision = 0u32;
+                for s in sessions {
+                    match engine.install_session(&peer_pub, s) {
+                        Ok(()) => ok += 1,
+                        Err(InstallSessionError::UnknownPeer) => unknown += 1,
+                        Err(InstallSessionError::LocalIndexCollision) => collision += 1,
+                    }
+                    thread::yield_now();
+                }
+                (ok, unknown, collision)
+            })
+        };
+        // Thread B: alternate removing and re-adding the peer.
+        let reconciler = {
+            let engine = engine.clone();
+            let stop = stop.clone();
+            let cfg = cfg_with_peer.clone();
+            thread::spawn(move || {
+                let mut iters = 0u32;
+                while !stop.load(AOrd::Relaxed) {
+                    engine.reconcile_peers(&[]);
+                    engine.reconcile_peers(&cfg);
+                    iters += 1;
+                    thread::yield_now();
+                }
+                iters
+            })
+        };
+        let (ok, unknown, collision) = installer.join().unwrap();
+        stop.store(true, AOrd::Relaxed);
+        let reconcile_iters = reconciler.join().unwrap();
+        // We made progress on both sides — otherwise the test is
+        // not actually exercising the race window.
+        assert!(
+            ok + unknown + collision == iterations,
+            "every install attempt accounted for"
+        );
+        assert!(
+            reconcile_iters >= 1,
+            "reconcile loop must have completed at least one full add/remove cycle"
+        );
+        // Post-condition invariant: every entry in
+        // `sessions_by_local_index` must reference a peer pubkey
+        // that is present in the currently published table. An
+        // orphan demux entry (the race the fix closes) would have a
+        // `session.peer_pubkey` that is not in the index map of any
+        // future snapshot — and we can detect it by re-reconciling
+        // the peer back in and checking the index map directly.
+        engine.reconcile_peers(&cfg_with_peer);
+        let table = engine.load_table();
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        for (local_index, session) in by_index.iter() {
+            assert!(
+                table.peer_index_by_pubkey.contains_key(&session.peer_pubkey),
+                "demux entry {local_index:#x} references unknown peer pubkey \
+                 — orphan from install/reconcile race"
+            );
+        }
+        // Now flip the peer out one more time. Reconcile's drain
+        // path must remove every session belonging to that peer; any
+        // surviving entry would prove the orphan slipped through.
+        engine.reconcile_peers(&[]);
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        assert!(
+            by_index.is_empty(),
+            "after removing the only peer, no demux entries should remain; \
+             found {} — install/reconcile race left orphans",
+            by_index.len()
+        );
+    }
+
+    /// r6 regression for the MINOR Codex finding: `try_encap` must
+    /// not consume a tx counter (or write the WG header) when it
+    /// returns `BufferTooSmall` because the inner IP would overflow
+    /// the PADDED_PLAINTEXT_MAX staging buffer.
+    ///
+    /// Pre-fix sequence at engine.rs:
+    ///   1. `out.len() < required` check (fires for small `out`).
+    ///   2. `next_tx_counter()` — counter advances.
+    ///   3. `encode_data_header(out, ...)` — 16 bytes written.
+    ///   4. `padded_len > PADDED_PLAINTEXT_MAX` check — fires here.
+    /// Result on the failure path: counter consumed, header dirty,
+    /// and the caller sees BufferTooSmall but cannot rely on
+    /// "Err leaves state untouched".
+    ///
+    /// Post-fix: the PADDED_PLAINTEXT_MAX guard is hoisted above
+    /// `next_tx_counter()` (and above the header write), so the
+    /// failure path leaves both the counter and `out` untouched.
+    #[test]
+    fn encap_padded_plaintext_overflow_leaves_counter_and_buffer_untouched() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let session = make_session_for(&engine, peer_pub, &peer_engine, 0xdead_0001, 2);
+        engine.install_session(&peer_pub, session).unwrap();
+        // inner_ip = 4097 bytes → pad_to_16(4097) = 4112 >
+        // PADDED_PLAINTEXT_MAX (4096). `out` is sized large enough to
+        // hold header + 4112 + 16 so it cleanly passes the
+        // `out.len() < required` guard and only the staging guard
+        // can fire.
+        let inner = vec![0x45u8; 4097];
+        let mut out = vec![0xa5u8; WG_DATA_HEADER_LEN + 4112 + POLY1305_TAG_LEN];
+        // Snapshot the per-session counter pre-encap.
+        let counter_before = session_tx_counter(&engine, &peer_pub);
+        let err = engine.try_encap(&peer_pub, &inner, &mut out).unwrap_err();
+        assert_eq!(err, EncapError::BufferTooSmall);
+        let counter_after = session_tx_counter(&engine, &peer_pub);
+        assert_eq!(
+            counter_before, counter_after,
+            "BufferTooSmall on PADDED_PLAINTEXT_MAX overflow must NOT advance tx counter"
+        );
+        // First 16 bytes of `out` must remain the 0xa5 sentinel — no
+        // partial header write on the failure path.
+        assert!(
+            out[..WG_DATA_HEADER_LEN].iter().all(|&b| b == 0xa5),
+            "BufferTooSmall must NOT write the WG header into `out`"
+        );
+    }
+
+    /// Helper for the BufferTooSmall counter-leak test: read the
+    /// `current` session's tx_counter for `pubkey`.
+    fn session_tx_counter(engine: &WgEngine, pubkey: &[u8; 32]) -> u64 {
+        let table = engine.load_table();
+        let idx = *table.peer_index_by_pubkey.get(pubkey).unwrap();
+        let peer = table.peers[idx as usize].clone();
+        let cur = peer.current.read().unwrap().clone().unwrap();
+        cur.tx_counter.load(Ordering::Relaxed)
     }
 }

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -15,17 +15,42 @@
 //!     `(receiver_index)`, finds the session, decrypts, then checks
 //!     the decrypted inner src IP against the owning peer's
 //!     AllowedIPs.
-//!   - `complete_handshake_initiator` / `complete_handshake_responder`
-//!     — slow path. Drive a snow `HandshakeState` to completion and
-//!     install the resulting `StatelessTransportState` on the peer.
+//!   - `build_initiator_handshake` / `build_responder_handshake` —
+//!     slow path. Construct a snow `HandshakeState` configured with
+//!     the WG protocol prologue and (for the initiator) the peer's
+//!     remote static key. The caller pumps the handshake by feeding
+//!     wire bytes through `read_message` / `write_message`, converts
+//!     to a `StatelessTransportState` via `into_stateless_transport_mode`,
+//!     and installs the resulting session via `install_session`.
+//!
+//! Out of scope for this engine (integration PR owns these):
+//!   - Building / parsing the on-wire WG handshake framing
+//!     (MessageInitiation/MessageResponse: MAC1 over a hash of the
+//!     responder's public key, MAC2 cookie reply when under load,
+//!     TAI64N timestamp inside the IK payload). This engine only
+//!     builds and consumes the snow sub-message bytes — the integration
+//!     PR will wrap them in the WG type-1/type-2 outer framing.
+//!   - Data-record on-wire framing extras beyond `framing.rs`
+//!     (cookie messages, keepalives that double as data records).
+//!   - Outer-UDP IO and routing.
 //!
 //! Hot path discipline:
 //!   - No allocations. snow's `write_message` / `read_message` take
 //!     pre-sized slices.
 //!   - No locks held across crypto operations on the encrypt path
 //!     (we clone the `Arc<WgSession>` and release the peer lock).
-//!   - Decrypt path takes a per-session replay-window lock only on
-//!     the cold (Repeat / OutOfWindow) arms.
+//!   - Decrypt path takes the per-session replay-window mutex twice:
+//!     once for the pre-AEAD `definitely_out_of_window` precheck, and
+//!     once for the post-AEAD `check_and_update`. The precheck is
+//!     held to avoid paying for a snow decrypt on counters that are
+//!     already provably stale — a hostile or replayed flood would
+//!     otherwise burn the AEAD cost per packet. Contention is bounded
+//!     because each session is demuxed onto a single worker, so the
+//!     mutex is effectively a per-session-per-worker SPSC lock with
+//!     no cross-worker traffic. (An earlier draft of this comment
+//!     claimed the precheck-lock was taken "only on cold arms"; that
+//!     was wrong — `try_decap` unconditionally locks the replay
+//!     mutex before snow.read_message.)
 
 use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -31,7 +31,9 @@ use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};
 use super::peer::Peer;
 use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
-use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_ZERO_PSK};
+use super::{
+    POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES, WG_ZERO_PSK,
+};
 use arc_swap::ArcSwap;
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
@@ -278,7 +280,18 @@ impl WgEngine {
                 .get(&cfg.pubkey)
                 .and_then(|old_idx| old.peers.get(*old_idx as usize).cloned());
             let peer = match existing {
-                Some(p) => p,
+                Some(p) => {
+                    // Apply mutable-field updates in place. The peer
+                    // Arc is reused so the (current, previous) session
+                    // pair survives the commit. Without this in-place
+                    // update, config changes to endpoint or persistent-
+                    // keepalive on an existing pubkey would be silently
+                    // ignored until the integration layer dropped and
+                    // recreated the peer (which it does not). Codex
+                    // final pre-merge finding 3.
+                    p.update_config(cfg.endpoint, cfg.persistent_keepalive);
+                    p
+                }
                 None => Arc::new(Peer::new(
                     cfg.pubkey,
                     cfg.endpoint,
@@ -345,6 +358,15 @@ impl WgEngine {
     /// long as the caller holds it.
     fn load_table(&self) -> Arc<PeerTable> {
         self.table.load_full()
+    }
+
+    /// Test-only accessor: same as `load_table`, exposed at module
+    /// visibility so tests can reach `peer.endpoint()` /
+    /// `peer.persistent_keepalive()` for the reconcile-updates-
+    /// existing-peer regression. Not used on the hot path.
+    #[cfg(test)]
+    pub(crate) fn table_for_test(&self) -> Arc<PeerTable> {
+        self.load_table()
     }
 
     fn peer_arc(&self, pubkey: &[u8; 32]) -> Option<Arc<Peer>> {
@@ -446,6 +468,19 @@ impl WgEngine {
             .unwrap()
             .clone()
             .ok_or(EncapError::NoSession)?;
+        // WG key-confirmation: the responder MUST NOT send transport
+        // data on a fresh session until it has authenticated the
+        // initiator's first data packet. Treat an unconfirmed session
+        // as `NoSession` so the caller falls through to its slow path
+        // (typically: queue the packet, wait for the initiator to
+        // send first). Initiator-role sessions are installed
+        // pre-confirmed, so this gate only fires on the responder
+        // side and only until the first valid inbound record. See
+        // `WgSession::confirmed` doc for the rationale and Codex
+        // final pre-merge finding 2 for the missed invariant.
+        if !session.is_confirmed() {
+            return Err(EncapError::NoSession);
+        }
 
         // WG spec §5.4.6 mandates the plaintext be zero-padded to a
         // 16-byte multiple before AEAD. This obscures inner packet
@@ -585,6 +620,15 @@ impl WgEngine {
             .transport
             .read_message(hdr.counter, hdr.ciphertext, out)
             .map_err(|_| DecapError::CryptoFailed)?;
+        // WG key-confirmation: a successful AEAD authenticate is
+        // proof that the peer has the session keys, so a responder-
+        // role session can now be used for egress. Initiator-role
+        // sessions install pre-confirmed; this is a no-op for them.
+        // Set the flag BEFORE the replay/LPM gates so a packet that
+        // authenticates but fails AllowedIPs still flips the
+        // confirmation — the authentication is what the WG spec
+        // ties confirmation to, not downstream policy gates.
+        session.mark_confirmed();
         // Check the replay window AFTER successful decrypt — per
         // RFC 6479 / the WG paper, we mustn't update the window
         // for packets that fail authentication, or an attacker
@@ -679,7 +723,16 @@ impl WgEngine {
         &self,
         peer_pubkey: &[u8; 32],
     ) -> Result<HandshakeState, snow::Error> {
+        // `.prologue(WG_PROTOCOL_ID_BYTES)` is mandatory for wire
+        // interoperability with kernel WireGuard and wireguard-go. The
+        // WG protocol mixes the ASCII identifier
+        // "WireGuard v1 zx2c4 Jason@zx2c4.com" into the initial Noise
+        // hash. Omitting the prologue produces a "WireGuard-shaped"
+        // transcript that no real peer will authenticate. Codex final
+        // pre-merge review caught this after nine prior review rounds
+        // missed it; see WG_PROTOCOL_ID_BYTES doc in mod.rs.
         Builder::new(WG_NOISE_PATTERN.parse()?)
+            .prologue(WG_PROTOCOL_ID_BYTES)?
             .local_private_key(self.local_private_key.as_slice())?
             .remote_public_key(peer_pubkey)?
             .psk(2, &WG_ZERO_PSK)?
@@ -699,7 +752,11 @@ impl WgEngine {
     /// to the snow message-bytes parser which is integration-layer
     /// concern. Tracked for the integration PR.
     pub(crate) fn build_responder_handshake(&self) -> Result<HandshakeState, snow::Error> {
+        // See `build_initiator_handshake` for the prologue rationale.
+        // Both sides must mix the same identifier into the Noise
+        // initial hash or the transcripts diverge from byte one.
         Builder::new(WG_NOISE_PATTERN.parse()?)
+            .prologue(WG_PROTOCOL_ID_BYTES)?
             .local_private_key(self.local_private_key.as_slice())?
             .psk(2, &WG_ZERO_PSK)?
             .build_responder()
@@ -727,7 +784,27 @@ fn inner_ip_len_after_decap(pkt: &[u8]) -> Option<usize> {
             if pkt.len() < 20 {
                 return None;
             }
-            u16::from_be_bytes([pkt[2], pkt[3]]) as usize
+            // RFC 791: IHL is the IP header length in 32-bit words.
+            // Valid values are 5..=15 (20..=60 bytes of header). An
+            // IHL < 5 means there isn't even room for the fixed IPv4
+            // header. Copilot inline review: an AEAD-authenticated
+            // payload with a bogus IHL would otherwise let
+            // `total_length` claim a value < ihl*4 and `DecapOutcome
+            // .len` could be < 20 — a downstream parser that
+            // assumes "len >= 20 ⇒ valid IPv4 header" would
+            // mis-interpret the bytes. Reject these here so the
+            // post-decap consumer never sees a structurally bogus
+            // inner header.
+            let ihl = (pkt[0] & 0x0f) as usize;
+            if ihl < 5 {
+                return None;
+            }
+            let header_len = ihl * 4;
+            let total_length = u16::from_be_bytes([pkt[2], pkt[3]]) as usize;
+            if total_length < header_len {
+                return None;
+            }
+            total_length
         }
         6 => {
             if pkt.len() < 40 {

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -1,0 +1,414 @@
+//! WgEngine: the per-WG-interface state container and API surface.
+//!
+//! The engine owns:
+//!   - The local static key (X25519 private).
+//!   - The peer table, keyed by peer pubkey.
+//!   - The AllowedIPs LPM trie (used ONLY for inbound src-IP gate).
+//!   - The session-by-receiver-index demux map for inbound.
+//!
+//! API shape:
+//!   - `try_encap` — egress fast path. Caller supplies peer pubkey
+//!     explicitly (from the forwarding decision). Engine does NOT
+//!     consult AllowedIPs for peer selection. This is the
+//!     cryptokey-routing safety property the prior PR violated.
+//!   - `try_decap` — ingress fast path. Engine demuxes by
+//!     `(receiver_index)`, finds the session, decrypts, then checks
+//!     the decrypted inner src IP against the owning peer's
+//!     AllowedIPs.
+//!   - `complete_handshake_initiator` / `complete_handshake_responder`
+//!     — slow path. Drive a snow `HandshakeState` to completion and
+//!     install the resulting `StatelessTransportState` on the peer.
+//!
+//! Hot path discipline:
+//!   - No allocations. snow's `write_message` / `read_message` take
+//!     pre-sized slices.
+//!   - No locks held across crypto operations on the encrypt path
+//!     (we clone the `Arc<WgSession>` and release the peer lock).
+//!   - Decrypt path takes a per-session replay-window lock only on
+//!     the cold (Repeat / OutOfWindow) arms.
+
+use super::allowed_ips::AllowedIps;
+use super::framing::{encode_data_header, parse_data_header};
+use super::peer::Peer;
+use super::session::{ReplayDecision, WgSession};
+use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN};
+use rustc_hash::FxHashMap;
+use snow::{Builder, HandshakeState};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::{Arc, RwLock};
+
+/// Errors that can fail the egress path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EncapError {
+    /// The caller-supplied peer pubkey is not in the engine table.
+    UnknownPeer,
+    /// The peer has no completed handshake yet. The caller should
+    /// kick the slow path to initiate a handshake.
+    NoSession,
+    /// The output buffer is too small for the encapsulated frame.
+    BufferTooSmall,
+    /// snow rejected the encryption — most likely nonce exhaustion
+    /// (counter approaching 2^64). Caller MUST drop and re-key.
+    CryptoFailed,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EncapOutcome {
+    /// Number of bytes written to the output buffer. The
+    /// encapsulated wire image starts at offset 0.
+    pub(crate) len: usize,
+    /// The receiver_index used (peer-chosen). Useful for tracing.
+    pub(crate) receiver_index: u32,
+    /// The counter value used (engine-chosen). Useful for tracing.
+    pub(crate) counter: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DecapError {
+    /// Header was malformed (too short, wrong type, etc.)
+    MalformedHeader,
+    /// No session with the parsed receiver_index.
+    UnknownSession,
+    /// snow rejected the decryption — tag verify or nonce reuse.
+    CryptoFailed,
+    /// Replay window said this counter is a duplicate.
+    ReplayDuplicate,
+    /// Replay window said this counter is too old.
+    ReplayOutOfWindow,
+    /// Decrypted plaintext did not parse as IPv4/IPv6.
+    MalformedInner,
+    /// Inner src IP is not in this peer's AllowedIPs — cryptokey-
+    /// routing violation; drop per WG spec §5.4.6.
+    AllowedIpsViolation,
+    /// Output buffer too small for plaintext.
+    BufferTooSmall,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DecapOutcome {
+    /// Number of bytes of decrypted inner-IP plaintext written.
+    pub(crate) len: usize,
+    /// The peer that owned this session (so the caller can route
+    /// the inner packet onward — typically into the LAN-side
+    /// pipeline as if it had arrived on the WG virtual interface).
+    pub(crate) peer_pubkey: [u8; 32],
+}
+
+/// Per-peer config passed to `WgEngine::reconcile`.
+#[derive(Debug, Clone)]
+pub(crate) struct WgPeerConfig {
+    pub(crate) pubkey: [u8; 32],
+    pub(crate) endpoint: Option<std::net::SocketAddr>,
+    pub(crate) persistent_keepalive: u16,
+    pub(crate) allowed_ips: Vec<ipnet::IpNet>,
+}
+
+/// Per-engine config.
+#[derive(Debug, Clone)]
+pub(crate) struct WgEngineConfig {
+    pub(crate) local_private_key: [u8; 32],
+    pub(crate) listen_port: u16,
+    pub(crate) peers: Vec<WgPeerConfig>,
+}
+
+/// The engine.
+pub(crate) struct WgEngine {
+    /// Local X25519 private key. Held in the engine because every
+    /// slow-path handshake needs it.
+    local_private_key: [u8; 32],
+    /// UDP port we listen on for inbound. Stored for diagnostics
+    /// and for the slow-path responder.
+    listen_port: u16,
+    /// peer_pubkey → index in `peers`.
+    peer_index_by_pubkey: RwLock<FxHashMap<[u8; 32], u32>>,
+    /// peer slab — one entry per configured peer. Indexed by the
+    /// `peer_index` referenced from `allowed_ips`.
+    peers: RwLock<Vec<Arc<Peer>>>,
+    /// AllowedIPs LPM. Only consulted on the decap path.
+    allowed_ips: RwLock<AllowedIps>,
+    /// Demux map: receiver_index → session. Receiver indices are
+    /// chosen locally at handshake time so they uniquely identify
+    /// a session for as long as it lives.
+    sessions_by_local_index: RwLock<FxHashMap<u32, Arc<WgSession>>>,
+}
+
+impl WgEngine {
+    pub(crate) fn new(config: WgEngineConfig) -> Self {
+        let engine = Self {
+            local_private_key: config.local_private_key,
+            listen_port: config.listen_port,
+            peer_index_by_pubkey: RwLock::new(FxHashMap::default()),
+            peers: RwLock::new(Vec::new()),
+            allowed_ips: RwLock::new(AllowedIps::new()),
+            sessions_by_local_index: RwLock::new(FxHashMap::default()),
+        };
+        engine.reconcile_peers(&config.peers);
+        engine
+    }
+
+    pub(crate) fn listen_port(&self) -> u16 {
+        self.listen_port
+    }
+
+    /// Reconcile the engine's peer table against a new config
+    /// snapshot. Slow path only.
+    pub(crate) fn reconcile_peers(&self, configs: &[WgPeerConfig]) {
+        let mut peers = self.peers.write().unwrap();
+        let mut index_by_pubkey = self.peer_index_by_pubkey.write().unwrap();
+        let mut allowed = self.allowed_ips.write().unwrap();
+        // Build a fresh AllowedIPs from scratch. Old peer Arcs are
+        // preserved where pubkeys overlap, which preserves the
+        // post-handshake session state across config refreshes.
+        let mut new_peers: Vec<Arc<Peer>> = Vec::with_capacity(configs.len());
+        let mut new_index: FxHashMap<[u8; 32], u32> = FxHashMap::default();
+        let mut new_allowed = AllowedIps::new();
+        for (i, cfg) in configs.iter().enumerate() {
+            let idx = i as u32;
+            let existing = index_by_pubkey
+                .get(&cfg.pubkey)
+                .and_then(|old_idx| peers.get(*old_idx as usize).cloned());
+            let peer = match existing {
+                Some(p) => p,
+                None => Arc::new(Peer::new(
+                    cfg.pubkey,
+                    cfg.endpoint,
+                    cfg.persistent_keepalive,
+                )),
+            };
+            new_peers.push(peer);
+            new_index.insert(cfg.pubkey, idx);
+            for cidr in &cfg.allowed_ips {
+                new_allowed.insert(*cidr, idx);
+            }
+        }
+        *peers = new_peers;
+        *index_by_pubkey = new_index;
+        *allowed = new_allowed;
+    }
+
+    fn peer_arc(&self, pubkey: &[u8; 32]) -> Option<Arc<Peer>> {
+        let idx_map = self.peer_index_by_pubkey.read().unwrap();
+        let idx = *idx_map.get(pubkey)?;
+        let peers = self.peers.read().unwrap();
+        peers.get(idx as usize).cloned()
+    }
+
+    fn peer_index(&self, pubkey: &[u8; 32]) -> Option<u32> {
+        self.peer_index_by_pubkey
+            .read()
+            .unwrap()
+            .get(pubkey)
+            .copied()
+    }
+
+    /// Install a freshly-completed transport session on a peer and
+    /// register it for inbound demux. Called from the slow-path
+    /// handshake-complete code.
+    pub(crate) fn install_session(&self, pubkey: &[u8; 32], session: Arc<WgSession>) {
+        // Register for inbound demux first — the worker may start
+        // receiving traffic immediately on this new session.
+        self.sessions_by_local_index
+            .write()
+            .unwrap()
+            .insert(session.local_index, session.clone());
+        // Then rotate it onto the peer. The previous session (if
+        // any) lives on as `peer.previous` for in-flight tail
+        // decrypts.
+        if let Some(peer) = self.peer_arc(pubkey) {
+            peer.rotate_session(session);
+        }
+    }
+
+    /// Hot-path encap.
+    ///
+    /// `inner_ip` is the inner IP packet (starts at the IP header;
+    /// no L2). `out` is the worker's preallocated scratch buffer;
+    /// the WG transport record (header + ciphertext + tag) is
+    /// written starting at `out[0]`. Outer L2/L3/L4 headers are
+    /// the caller's responsibility (`outer.rs` builders).
+    pub(crate) fn try_encap(
+        &self,
+        peer_pubkey: &[u8; 32],
+        inner_ip: &[u8],
+        out: &mut [u8],
+    ) -> Result<EncapOutcome, EncapError> {
+        // Cryptokey-routing safety: the forwarding decision tells
+        // us which peer to encrypt to. We do NOT consult
+        // AllowedIPs to pick a peer on egress.
+        let peer = self.peer_arc(peer_pubkey).ok_or(EncapError::UnknownPeer)?;
+        let session = peer
+            .current
+            .read()
+            .unwrap()
+            .clone()
+            .ok_or(EncapError::NoSession)?;
+
+        let required = WG_DATA_HEADER_LEN + inner_ip.len() + POLY1305_TAG_LEN;
+        if out.len() < required {
+            return Err(EncapError::BufferTooSmall);
+        }
+        let counter = session.next_tx_counter();
+        let _ = encode_data_header(out, session.peer_index, counter)
+            .ok_or(EncapError::BufferTooSmall)?;
+        // snow writes ciphertext||tag into the payload region.
+        let (_hdr, payload) = out.split_at_mut(WG_DATA_HEADER_LEN);
+        let n = session
+            .transport
+            .write_message(counter, inner_ip, payload)
+            .map_err(|_| EncapError::CryptoFailed)?;
+        Ok(EncapOutcome {
+            len: WG_DATA_HEADER_LEN + n,
+            receiver_index: session.peer_index,
+            counter,
+        })
+    }
+
+    /// Hot-path decap.
+    ///
+    /// `wg_record` is the WG transport record extracted from the
+    /// outer UDP payload (starts at the WG type byte). `out` is
+    /// the worker's preallocated scratch; decrypted inner-IP
+    /// plaintext is written starting at `out[0]`.
+    pub(crate) fn try_decap(
+        &self,
+        wg_record: &[u8],
+        out: &mut [u8],
+    ) -> Result<DecapOutcome, DecapError> {
+        let hdr = parse_data_header(wg_record).ok_or(DecapError::MalformedHeader)?;
+        let session = self
+            .sessions_by_local_index
+            .read()
+            .unwrap()
+            .get(&hdr.receiver_index)
+            .cloned()
+            .ok_or(DecapError::UnknownSession)?;
+        let plaintext_len_max = hdr.ciphertext.len().saturating_sub(POLY1305_TAG_LEN);
+        if out.len() < plaintext_len_max {
+            return Err(DecapError::BufferTooSmall);
+        }
+        let n = session
+            .transport
+            .read_message(hdr.counter, hdr.ciphertext, out)
+            .map_err(|_| DecapError::CryptoFailed)?;
+        // Check the replay window AFTER successful decrypt — per
+        // RFC 6479 / the WG paper, we mustn't update the window
+        // for packets that fail authentication, or an attacker
+        // could DoS the window by injecting bogus high-counter
+        // ciphertexts.
+        {
+            let mut replay = session.replay.lock().unwrap();
+            match replay.check_and_update(hdr.counter) {
+                ReplayDecision::Accept => {}
+                ReplayDecision::Repeat => return Err(DecapError::ReplayDuplicate),
+                ReplayDecision::OutOfWindow => return Err(DecapError::ReplayOutOfWindow),
+            }
+        }
+        // AllowedIPs gate on the inner src IP. WG spec §5.4.6:
+        // "After decryption, the receiver verifies that the source
+        // IP of the inner packet belongs to the peer who sent it.
+        // If not, drop." This is the cryptokey-routing safety
+        // invariant on the receive side.
+        let inner_src = inner_src_ip(&out[..n]).ok_or(DecapError::MalformedInner)?;
+        let peer_idx = self
+            .peer_index(&session.peer_pubkey)
+            .ok_or(DecapError::UnknownSession)?;
+        let allowed = self.allowed_ips.read().unwrap();
+        if !allowed.matches_for_peer(inner_src, peer_idx) {
+            return Err(DecapError::AllowedIpsViolation);
+        }
+        Ok(DecapOutcome {
+            len: n,
+            peer_pubkey: session.peer_pubkey,
+        })
+    }
+
+    /// Build a snow `HandshakeState` configured as the initiator
+    /// toward `peer_pubkey`. The caller drives the handshake to
+    /// completion (write init, read response) and then uses
+    /// `into_stateless_transport_mode` to obtain the
+    /// `StatelessTransportState` that `install_session` wraps.
+    ///
+    /// Slow path only.
+    pub(crate) fn build_initiator_handshake(
+        &self,
+        peer_pubkey: &[u8; 32],
+    ) -> Result<HandshakeState, snow::Error> {
+        Builder::new(WG_NOISE_PATTERN.parse()?)
+            .local_private_key(&self.local_private_key)?
+            .remote_public_key(peer_pubkey)?
+            .build_initiator()
+    }
+
+    /// Build a snow `HandshakeState` configured as the responder.
+    /// Slow path only.
+    pub(crate) fn build_responder_handshake(&self) -> Result<HandshakeState, snow::Error> {
+        Builder::new(WG_NOISE_PATTERN.parse()?)
+            .local_private_key(&self.local_private_key)?
+            .build_responder()
+    }
+}
+
+/// Extract the source IP from the front of an inner-IP packet.
+/// Used for the AllowedIPs receive-side gate. Returns `None` for
+/// unsupported / malformed inputs.
+fn inner_src_ip(pkt: &[u8]) -> Option<IpAddr> {
+    let version = pkt.first()? >> 4;
+    match version {
+        4 => {
+            if pkt.len() < 20 {
+                return None;
+            }
+            Some(IpAddr::V4(Ipv4Addr::new(pkt[12], pkt[13], pkt[14], pkt[15])))
+        }
+        6 => {
+            if pkt.len() < 40 {
+                return None;
+            }
+            let mut bytes = [0u8; 16];
+            bytes.copy_from_slice(&pkt[8..24]);
+            Some(IpAddr::V6(Ipv6Addr::from(bytes)))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod engine_internal_tests {
+    use super::*;
+
+    #[test]
+    fn inner_src_ip_v4() {
+        let mut pkt = [0u8; 40];
+        pkt[0] = 0x45;
+        pkt[12..16].copy_from_slice(&[10, 0, 0, 1]);
+        assert_eq!(
+            inner_src_ip(&pkt),
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+    }
+
+    #[test]
+    fn inner_src_ip_v6() {
+        let mut pkt = [0u8; 40];
+        pkt[0] = 0x60;
+        pkt[8] = 0xfe;
+        pkt[9] = 0x80;
+        let got = inner_src_ip(&pkt).unwrap();
+        match got {
+            IpAddr::V6(v6) => assert_eq!(v6.segments()[0], 0xfe80),
+            _ => panic!("expected v6"),
+        }
+    }
+
+    #[test]
+    fn inner_src_ip_rejects_short() {
+        assert!(inner_src_ip(&[0x45u8; 10]).is_none());
+        assert!(inner_src_ip(&[0x60u8; 20]).is_none());
+        assert!(inner_src_ip(&[]).is_none());
+    }
+
+    #[test]
+    fn inner_src_ip_rejects_unknown_version() {
+        assert!(inner_src_ip(&[0x05u8; 40]).is_none()); // bogus version 0
+    }
+}

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -190,9 +190,16 @@ pub(crate) struct WgEngineConfig {
 /// (LLVM cannot elide the zero-init because snow reads the trailing
 /// pad bytes, which must be zero by spec).
 ///
-/// Note on jumbo MTU: the value is 4080 + 16 padding = 4096. Inner
-/// packets larger than 4080 bytes will return `EncapError::BufferTooSmall`.
-/// Jumbo MTU configurations (>4080 inner) are not currently
+/// Note on jumbo MTU: the value is 4080 + 16 = 4096. The bound is
+/// enforced at `engine.rs:539` as `padded_len > PADDED_PLAINTEXT_MAX`
+/// where `padded_len = pad_to_16(inner_ip.len())` — i.e. the post-
+/// WG-§5.4.6-padding length. The accepted range is therefore
+/// `inner_ip.len() ∈ [0, 4096]` (any inner whose 16-byte-padded
+/// length is ≤ 4096): a 4080-byte inner pads to 4080 (already a
+/// multiple of 16, accepted), a 4081..=4096-byte inner pads to 4096
+/// (accepted, since `pad_to_16(4096) == 4096`), and a 4097-byte inner
+/// pads to 4112 and is rejected with `EncapError::BufferTooSmall`.
+/// Jumbo MTU configurations (>4096 inner) are not currently
 /// supported by this engine; raising the bound is a one-line change
 /// when the integration layer needs it.
 const PADDED_PLAINTEXT_MAX: usize = 4080 + 16;

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -210,14 +210,20 @@ impl WgEngine {
         let Some(peer) = self.peer_arc(pubkey) else {
             return;
         };
-        // Rotate first so concurrent encap picks up the newest
-        // session as soon as possible. Keep only current+previous in
-        // the demux map by deleting the session that falls off.
-        let dropped_previous = peer.rotate_session(session.clone());
-        let mut by_index = self.sessions_by_local_index.write().unwrap();
-        by_index.insert(session.local_index, session);
+        // Register for inbound demux before rotation so decap can
+        // resolve the new local index immediately. Keep only
+        // current+previous in the demux map by deleting the session
+        // that falls off.
+        {
+            let mut by_index = self.sessions_by_local_index.write().unwrap();
+            by_index.insert(session.local_index, session.clone());
+        }
+        let dropped_previous = peer.rotate_session(session);
         if let Some(old) = dropped_previous {
-            by_index.remove(&old.local_index);
+            self.sessions_by_local_index
+                .write()
+                .unwrap()
+                .remove(&old.local_index);
         }
     }
 
@@ -476,7 +482,7 @@ mod engine_internal_tests {
             peer_pub,
         ));
         session.tx_counter.store(
-            super::super::session::REJECT_AFTER_MESSAGES + 1,
+            super::super::session::REJECT_AFTER_MESSAGES,
             Ordering::Relaxed,
         );
         engine.install_session(&peer_pub, session);

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -107,6 +107,15 @@ pub(crate) enum DecapError {
     AllowedIpsViolation,
     /// Output buffer too small for plaintext.
     BufferTooSmall,
+    /// Record's ciphertext field is shorter than the Poly1305 tag
+    /// length. Snow's AEAD decrypt has no short-tag guard internally;
+    /// passing a sub-tag ciphertext underflows `ciphertext.len() -
+    /// TAGLEN` and panics on the subsequent slice op (release build)
+    /// or directly via `usize` underflow assert (debug). Reject the
+    /// record before invoking snow so a hostile peer cannot crash the
+    /// AF_XDP worker by sending 16..31-byte UDP datagrams with a
+    /// valid `receiver_index`.
+    ShortRecord,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -606,7 +615,24 @@ impl WgEngine {
             .get(&hdr.receiver_index)
             .cloned()
             .ok_or(DecapError::UnknownSession)?;
-        let plaintext_len_max = hdr.ciphertext.len().saturating_sub(POLY1305_TAG_LEN);
+        // Truncated-record DoS guard. `parse_data_header` only checks
+        // that the buffer has at least WG_DATA_HEADER_LEN (16) bytes;
+        // it does not enforce that the trailing ciphertext field is
+        // at least one Poly1305 tag wide. Snow 0.10's ChaCha-Poly1305
+        // decrypt computes `ciphertext.len() - TAGLEN` with no short-
+        // tag guard — for `ciphertext.len() < POLY1305_TAG_LEN` this
+        // wraps to a huge usize and panics on the subsequent slice op
+        // (or underflows directly in debug builds). A hostile peer
+        // with a known live `receiver_index` could crash the AF_XDP
+        // worker by sending 16..31-byte UDP datagrams; remote
+        // dataplane DoS. Reject sub-tag records here, before any of
+        // the replay-window / snow code runs. Caught by Codex on the
+        // r-final-2 review (the truncated-record class was missed by
+        // all 9 prior review rounds).
+        if hdr.ciphertext.len() < POLY1305_TAG_LEN {
+            return Err(DecapError::ShortRecord);
+        }
+        let plaintext_len_max = hdr.ciphertext.len() - POLY1305_TAG_LEN;
         if out.len() < plaintext_len_max {
             return Err(DecapError::BufferTooSmall);
         }

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -191,7 +191,11 @@ pub(crate) struct WgEngineConfig {
 /// pad bytes, which must be zero by spec).
 ///
 /// Note on jumbo MTU: the value is 4080 + 16 = 4096. The bound is
-/// enforced at `engine.rs:539` as `padded_len > PADDED_PLAINTEXT_MAX`
+/// enforced inside `try_encap` (search for the
+/// `if padded_len > PADDED_PLAINTEXT_MAX` guard, which is hoisted
+/// above the `next_tx_counter()` consume so a failed staging guard
+/// cannot leave the session's counter advanced) as
+/// `padded_len > PADDED_PLAINTEXT_MAX`
 /// where `padded_len = pad_to_16(inner_ip.len())` — i.e. the post-
 /// WG-§5.4.6-padding length. The accepted range is therefore
 /// `inner_ip.len() ∈ [0, 4096]` (any inner whose 16-byte-padded

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -32,6 +32,7 @@ use super::framing::{encode_data_header, parse_data_header};
 use super::peer::Peer;
 use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
 use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_ZERO_PSK};
+use arc_swap::ArcSwap;
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
 use std::mem::MaybeUninit;
@@ -166,6 +167,38 @@ const fn pad_to_16(n: usize) -> usize {
     (n + 15) & !15
 }
 
+/// Atomically-swappable triple of peer-routing tables. The three
+/// fields are reconciled together (a new config snapshot rebuilds
+/// all three) and a hot-path reader must observe them as a unit, or
+/// else it can pair a `peer_index` from the old map with a `peers`
+/// entry from the new vec and route to the wrong peer. Holding three
+/// independent RwLocks does NOT give that property: a reader can
+/// release the index lock, the reconciler can swap, and then the
+/// reader can acquire the peers lock on the new state. Bundling all
+/// three behind a single `ArcSwap<PeerTable>` gives the reader an
+/// atomic snapshot — every load returns an `Arc<PeerTable>` that is
+/// internally consistent for its lifetime, and the writer publishes
+/// the next snapshot in one release-store.
+pub(crate) struct PeerTable {
+    /// peer slab — one entry per configured peer. Indexed by the
+    /// `peer_index` referenced from `allowed_ips`.
+    pub(crate) peers: Vec<Arc<Peer>>,
+    /// peer_pubkey → index in `peers`.
+    pub(crate) peer_index_by_pubkey: FxHashMap<[u8; 32], u32>,
+    /// AllowedIPs LPM. Only consulted on the decap path.
+    pub(crate) allowed_ips: AllowedIps,
+}
+
+impl PeerTable {
+    fn empty() -> Self {
+        Self {
+            peers: Vec::new(),
+            peer_index_by_pubkey: FxHashMap::default(),
+            allowed_ips: AllowedIps::new(),
+        }
+    }
+}
+
 /// The engine.
 pub(crate) struct WgEngine {
     /// Local X25519 private key. Held in the engine because every
@@ -177,16 +210,19 @@ pub(crate) struct WgEngine {
     /// UDP port we listen on for inbound. Stored for diagnostics
     /// and for the slow-path responder.
     listen_port: u16,
-    /// peer_pubkey → index in `peers`.
-    peer_index_by_pubkey: RwLock<FxHashMap<[u8; 32], u32>>,
-    /// peer slab — one entry per configured peer. Indexed by the
-    /// `peer_index` referenced from `allowed_ips`.
-    peers: RwLock<Vec<Arc<Peer>>>,
-    /// AllowedIPs LPM. Only consulted on the decap path.
-    allowed_ips: RwLock<AllowedIps>,
+    /// Combined peer-routing table behind a single ArcSwap. See
+    /// `PeerTable` doc for the atomicity rationale.
+    table: ArcSwap<PeerTable>,
+    /// Mutex held by reconcile_peers so concurrent reconciles
+    /// serialize. Hot path does NOT take this lock — readers only
+    /// touch `table` via `.load()`. Reconcile is slow path.
+    reconcile_lock: std::sync::Mutex<()>,
     /// Demux map: receiver_index → session. Receiver indices are
     /// chosen locally at handshake time so they uniquely identify
-    /// a session for as long as it lives.
+    /// a session for as long as it lives. Kept out of `PeerTable`
+    /// because session install / rotation is independent of peer
+    /// reconcile; only peer REMOVAL touches both (we drain a
+    /// dropped peer's sessions out of this map during reconcile).
     sessions_by_local_index: RwLock<FxHashMap<u32, Arc<WgSession>>>,
 }
 
@@ -195,9 +231,8 @@ impl WgEngine {
         let engine = Self {
             local_private_key: Zeroizing::new(config.local_private_key),
             listen_port: config.listen_port,
-            peer_index_by_pubkey: RwLock::new(FxHashMap::default()),
-            peers: RwLock::new(Vec::new()),
-            allowed_ips: RwLock::new(AllowedIps::new()),
+            table: ArcSwap::from_pointee(PeerTable::empty()),
+            reconcile_lock: std::sync::Mutex::new(()),
             sessions_by_local_index: RwLock::new(FxHashMap::default()),
         };
         engine.reconcile_peers(&config.peers);
@@ -210,21 +245,36 @@ impl WgEngine {
 
     /// Reconcile the engine's peer table against a new config
     /// snapshot. Slow path only.
+    ///
+    /// Atomicity contract:
+    ///   1. Build a fresh `PeerTable` off-line (no readers see partial
+    ///      state).
+    ///   2. Identify peers present in the old table but absent in the
+    ///      new one. Drain their `(current, previous)` session
+    ///      `local_index` entries from `sessions_by_local_index`
+    ///      before publishing the new table — otherwise an inbound
+    ///      packet targeting a removed peer's session would decrypt
+    ///      successfully (the session Arc is still in the demux map),
+    ///      then fail the AllowedIPs gate because the peer is no
+    ///      longer in the index, and the demux entry would leak
+    ///      forever.
+    ///   3. `ArcSwap::store` publishes the new `PeerTable` in one
+    ///      release-store. Subsequent `.load()` calls observe either
+    ///      the entire old table or the entire new one — never a mix.
     pub(crate) fn reconcile_peers(&self, configs: &[WgPeerConfig]) {
-        let mut peers = self.peers.write().unwrap();
-        let mut index_by_pubkey = self.peer_index_by_pubkey.write().unwrap();
-        let mut allowed = self.allowed_ips.write().unwrap();
-        // Build a fresh AllowedIPs from scratch. Old peer Arcs are
-        // preserved where pubkeys overlap, which preserves the
-        // post-handshake session state across config refreshes.
+        // Serialize concurrent reconciles. The lock does NOT gate the
+        // hot path (readers take only the ArcSwap load).
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let old = self.table.load_full();
         let mut new_peers: Vec<Arc<Peer>> = Vec::with_capacity(configs.len());
         let mut new_index: FxHashMap<[u8; 32], u32> = FxHashMap::default();
         let mut new_allowed = AllowedIps::new();
         for (i, cfg) in configs.iter().enumerate() {
             let idx = i as u32;
-            let existing = index_by_pubkey
+            let existing = old
+                .peer_index_by_pubkey
                 .get(&cfg.pubkey)
-                .and_then(|old_idx| peers.get(*old_idx as usize).cloned());
+                .and_then(|old_idx| old.peers.get(*old_idx as usize).cloned());
             let peer = match existing {
                 Some(p) => p,
                 None => Arc::new(Peer::new(
@@ -239,24 +289,58 @@ impl WgEngine {
                 new_allowed.insert(*cidr, idx);
             }
         }
-        *peers = new_peers;
-        *index_by_pubkey = new_index;
-        *allowed = new_allowed;
+        // Drain demux entries for peers that exist in `old` but not
+        // in `new`. Walk old peers and check absence from new_index.
+        // We collect `local_index` values under read locks on the
+        // peer's `current`/`previous`, then drop those locks before
+        // taking the demux write lock — this keeps the demux write
+        // hold short and avoids any lock-order coupling with peer
+        // session rotation.
+        let mut dropped_indices: Vec<u32> = Vec::new();
+        for (pubkey, old_idx) in old.peer_index_by_pubkey.iter() {
+            if new_index.contains_key(pubkey) {
+                continue;
+            }
+            let Some(peer) = old.peers.get(*old_idx as usize) else {
+                continue;
+            };
+            if let Some(cur) = peer.current.read().unwrap().as_ref() {
+                dropped_indices.push(cur.local_index);
+            }
+            if let Some(prev) = peer.previous.read().unwrap().as_ref() {
+                dropped_indices.push(prev.local_index);
+            }
+        }
+        if !dropped_indices.is_empty() {
+            let mut by_index = self.sessions_by_local_index.write().unwrap();
+            for li in &dropped_indices {
+                by_index.remove(li);
+            }
+        }
+        // Publish the new table. Atomic release-store; any reader
+        // doing `.load()` after this point sees the new table whole.
+        self.table.store(Arc::new(PeerTable {
+            peers: new_peers,
+            peer_index_by_pubkey: new_index,
+            allowed_ips: new_allowed,
+        }));
+    }
+
+    /// Take an atomic snapshot of the peer-routing table. Hot path.
+    /// The returned `Arc<PeerTable>` is internally consistent for as
+    /// long as the caller holds it.
+    fn load_table(&self) -> Arc<PeerTable> {
+        self.table.load_full()
     }
 
     fn peer_arc(&self, pubkey: &[u8; 32]) -> Option<Arc<Peer>> {
-        let idx_map = self.peer_index_by_pubkey.read().unwrap();
-        let idx = *idx_map.get(pubkey)?;
-        let peers = self.peers.read().unwrap();
-        peers.get(idx as usize).cloned()
+        let table = self.load_table();
+        let idx = *table.peer_index_by_pubkey.get(pubkey)?;
+        table.peers.get(idx as usize).cloned()
     }
 
     fn peer_index(&self, pubkey: &[u8; 32]) -> Option<u32> {
-        self.peer_index_by_pubkey
-            .read()
-            .unwrap()
-            .get(pubkey)
-            .copied()
+        self.load_table().peer_index_by_pubkey.get(pubkey).copied()
     }
 
     /// Install a freshly-completed transport session on a peer and
@@ -368,27 +452,65 @@ impl WgEngine {
         if padded_len > PADDED_PLAINTEXT_MAX {
             return Err(EncapError::BufferTooSmall);
         }
+        // Stage the padded plaintext on the stack. We use
+        // `MaybeUninit` to skip the 4096-byte zero-init that a
+        // `[0u8; PADDED_PLAINTEXT_MAX]` literal would force on every
+        // call. snow's `write_message` requires non-overlapping
+        // plaintext and ciphertext slices, so we cannot stage the
+        // plaintext inside `out`.
+        //
+        // Soundness: we NEVER materialize a `&mut [u8; N]` (or
+        // `&mut [u8]`) over the uninitialized backing store —
+        // creating a Rust reference to uninitialized memory is UB
+        // even if the bytes are never read, because references carry
+        // a validity invariant over their entire pointee. We only
+        // write through the raw `*mut u8` returned by
+        // `MaybeUninit::as_mut_ptr`, initializing exactly
+        // `[0..padded_len]`. Once that range is initialized via raw
+        // pointer writes, we hand snow a `&[u8]` (read-only slice)
+        // limited to that initialized range — at which point the
+        // reference covers fully-initialized memory and is sound.
         let mut plaintext_uninit: MaybeUninit<[u8; PADDED_PLAINTEXT_MAX]> = MaybeUninit::uninit();
-        // SAFETY: we cast the `MaybeUninit<[u8; N]>` to `&mut [u8; N]`
-        // before writing every byte we intend to read. The bytes
-        // outside `[0..padded_len]` are never read (snow only
-        // touches `[..padded_len]`), so leaving them uninitialized
-        // is sound. We initialize:
-        //   - `[0..inner_ip.len()]` with the caller's payload
-        //   - `[inner_ip.len()..padded_len]` with zeros (WG spec
-        //     §5.4.6 requires the padding be zero bytes)
-        let plaintext_ref: &mut [u8; PADDED_PLAINTEXT_MAX] =
-            unsafe { &mut *plaintext_uninit.as_mut_ptr() };
-        plaintext_ref[..inner_ip.len()].copy_from_slice(inner_ip);
-        // Trailing padding: at most 15 bytes. WG spec §5.4.6 requires
-        // the padding be zero.
-        for b in &mut plaintext_ref[inner_ip.len()..padded_len] {
-            *b = 0;
+        let plaintext_ptr = plaintext_uninit.as_mut_ptr() as *mut u8;
+        // SAFETY:
+        //   - `plaintext_ptr` is the start of a writable, properly
+        //     aligned `[u8; PADDED_PLAINTEXT_MAX]` backing store on
+        //     the current stack frame; it is unique (no aliasing
+        //     reference exists — we never created one).
+        //   - `inner_ip.len() <= padded_len <= PADDED_PLAINTEXT_MAX`,
+        //     so `[0..inner_ip.len())` and
+        //     `[inner_ip.len()..padded_len)` are non-overlapping
+        //     in-bounds ranges of that store.
+        //   - `inner_ip` is `&[u8]`, distinct from our local
+        //     `plaintext_uninit`, so the copy source/dest do not
+        //     alias.
+        //   - After both calls, bytes `[0..padded_len)` are fully
+        //     initialized: the payload from `inner_ip`, then
+        //     `(padded_len - inner_ip.len()) <= 15` zero bytes (WG
+        //     spec §5.4.6 padding).
+        //   - Bytes `[padded_len..PADDED_PLAINTEXT_MAX)` remain
+        //     uninitialized but are never read: we only borrow the
+        //     initialized prefix below, and `plaintext_uninit` is
+        //     dropped at end of scope without any further access.
+        unsafe {
+            std::ptr::copy_nonoverlapping(inner_ip.as_ptr(), plaintext_ptr, inner_ip.len());
+            std::ptr::write_bytes(
+                plaintext_ptr.add(inner_ip.len()),
+                0u8,
+                padded_len - inner_ip.len(),
+            );
         }
-        // SAFETY: `[0..padded_len]` is fully initialized (payload +
-        // zero padding above); we hand snow a slice limited to that
-        // range, which is the only memory it reads.
-        let plaintext = &plaintext_ref[..padded_len];
+        // SAFETY: `plaintext_ptr` is valid for `padded_len` bytes
+        // (proved above) and those bytes are now initialized
+        // (`copy_nonoverlapping` + `write_bytes`). Building a `&[u8]`
+        // (immutable) over an initialized range is the standard
+        // MaybeUninit "assume_init_ref-equivalent" pattern; we use
+        // `from_raw_parts` here rather than `MaybeUninit::slice_assume_init_ref`
+        // because the latter wants a `&[MaybeUninit<u8>]` source
+        // slice which itself crosses the same validity boundary we
+        // are avoiding. The returned slice is read-only and lives
+        // only until snow consumes it on this line.
+        let plaintext: &[u8] = unsafe { std::slice::from_raw_parts(plaintext_ptr, padded_len) };
         let (_hdr, payload) = out.split_at_mut(WG_DATA_HEADER_LEN);
         let n = session
             .transport
@@ -489,11 +611,18 @@ impl WgEngine {
         // sees only the un-padded inner-IP packet.
         let outcome = (|| -> Result<(IpAddr, u32, usize), DecapError> {
             let inner_src = inner_src_ip(&out[..n]).ok_or(DecapError::MalformedInner)?;
-            let peer_idx = self
-                .peer_index(&session.peer_pubkey)
+            // Single atomic snapshot for both peer-index lookup and
+            // AllowedIPs gate. Taking these from separate ArcSwap
+            // loads would re-introduce the reconcile race window
+            // — between the two loads, a config refresh could swap
+            // the peer table and we'd pair a peer_idx from the old
+            // snapshot with allowed_ips from the new one.
+            let table = self.load_table();
+            let peer_idx = *table
+                .peer_index_by_pubkey
+                .get(&session.peer_pubkey)
                 .ok_or(DecapError::UnknownSession)?;
-            let allowed = self.allowed_ips.read().unwrap();
-            if !allowed.matches_for_peer(inner_src, peer_idx) {
+            if !table.allowed_ips.matches_for_peer(inner_src, peer_idx) {
                 return Err(DecapError::AllowedIpsViolation);
             }
             let inner_len = inner_ip_len_after_decap(&out[..n])
@@ -949,5 +1078,238 @@ mod engine_internal_tests {
         let mut out = [0u8; 128];
         let err = engine.try_encap(&peer_pub, &inner, &mut out).unwrap_err();
         assert_eq!(err, EncapError::RekeyRequired);
+    }
+
+    /// r5 regression: when `reconcile_peers` drops a peer whose
+    /// pubkey is absent in the new config, the peer's
+    /// `(current, previous)` session entries MUST be drained from
+    /// `sessions_by_local_index`. Codex r5 finding: without the
+    /// drain, every config refresh that removes a peer leaks that
+    /// peer's session Arcs in the demux map forever (until engine
+    /// drop). The Arcs also keep `WgSession` (transport key
+    /// material) alive past peer removal, which violates the
+    /// expectation that removing a peer immediately revokes its
+    /// session material from the live state.
+    #[test]
+    fn reconcile_peers_drains_dropped_peer_sessions_from_demux() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        // Install two sessions on the peer (current + previous).
+        let s1 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 2);
+        engine.install_session(&peer_pub, s1).unwrap();
+        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0002, 3);
+        engine.install_session(&peer_pub, s2).unwrap();
+        // Both indices must be in the demux pre-reconcile.
+        {
+            let by_index = engine.sessions_by_local_index.read().unwrap();
+            assert!(by_index.contains_key(&0xaaaa_0001));
+            assert!(by_index.contains_key(&0xaaaa_0002));
+        }
+        // Reconcile with the peer removed.
+        engine.reconcile_peers(&[]);
+        // Both demux entries must now be gone — the leak is fixed.
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        assert!(
+            !by_index.contains_key(&0xaaaa_0001),
+            "dropped peer's `previous` session must be drained from demux"
+        );
+        assert!(
+            !by_index.contains_key(&0xaaaa_0002),
+            "dropped peer's `current` session must be drained from demux"
+        );
+        assert!(
+            by_index.is_empty(),
+            "no stray demux entries should remain after peer removal"
+        );
+    }
+
+    /// r5 regression: peer removal must NOT touch unrelated peers'
+    /// sessions. A reconcile that drops peer A while keeping peer B
+    /// must drain A's demux entries and leave B's intact.
+    #[test]
+    fn reconcile_peers_leaves_kept_peer_sessions_intact() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_a_priv, peer_a_pub) = keypair();
+        let (peer_b_priv, peer_b_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![
+                WgPeerConfig {
+                    pubkey: peer_a_pub,
+                    endpoint: None,
+                    persistent_keepalive: 0,
+                    allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+                },
+                WgPeerConfig {
+                    pubkey: peer_b_pub,
+                    endpoint: None,
+                    persistent_keepalive: 0,
+                    allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+                },
+            ],
+        });
+        let peer_a_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_a_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_b_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_b_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+            }],
+        });
+        let s_a = make_session_for(&engine, peer_a_pub, &peer_a_engine, 0xaaaa_0001, 2);
+        engine.install_session(&peer_a_pub, s_a).unwrap();
+        let s_b = make_session_for(&engine, peer_b_pub, &peer_b_engine, 0xbbbb_0001, 4);
+        engine.install_session(&peer_b_pub, s_b).unwrap();
+        // Reconcile dropping only peer A.
+        engine.reconcile_peers(&[WgPeerConfig {
+            pubkey: peer_b_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+        }]);
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        assert!(
+            !by_index.contains_key(&0xaaaa_0001),
+            "peer A's session must be drained"
+        );
+        assert!(
+            by_index.contains_key(&0xbbbb_0001),
+            "peer B's session must remain — unrelated peer reconcile must not touch it"
+        );
+    }
+
+    /// r5 regression: hot-path readers must observe a torn-free
+    /// snapshot across `reconcile_peers`. A concurrent
+    /// reconcile/hot-read interleaving where the reader sees
+    /// `peer_index_by_pubkey` from the new snapshot but `peers`
+    /// from the old (or vice versa) would route to the wrong peer.
+    /// We hammer reconcile in one thread and assert internal
+    /// consistency from another.
+    ///
+    /// Invariant verified: every snapshot returned by `load_table()`
+    /// is internally consistent — for every (pubkey, idx) entry in
+    /// `peer_index_by_pubkey`, `peers[idx].pubkey == pubkey`. The
+    /// invariant would fail under torn snapshots if reconcile
+    /// published the index map and peer vec via separate stores.
+    #[test]
+    fn reconcile_peers_snapshot_is_atomic_under_concurrent_load() {
+        use std::sync::atomic::{AtomicBool, Ordering as AOrd};
+        use std::thread;
+        let (init_priv, _init_pub) = keypair();
+        let (peer_a_priv, peer_a_pub) = keypair();
+        let (peer_b_priv, peer_b_pub) = keypair();
+        let (_peer_c_priv, peer_c_pub) = keypair();
+        let _ = (peer_a_priv, peer_b_priv);
+        let engine = Arc::new(WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_a_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        }));
+        let stop = Arc::new(AtomicBool::new(false));
+        let config_alt = vec![
+            WgPeerConfig {
+                pubkey: peer_b_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.1.0/24").unwrap()],
+            },
+            WgPeerConfig {
+                pubkey: peer_c_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.2.0/24").unwrap()],
+            },
+        ];
+        let config_orig = vec![WgPeerConfig {
+            pubkey: peer_a_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+        }];
+        let writer = {
+            let engine = engine.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                for i in 0..2000 {
+                    if i % 2 == 0 {
+                        engine.reconcile_peers(&config_alt);
+                    } else {
+                        engine.reconcile_peers(&config_orig);
+                    }
+                }
+                stop.store(true, AOrd::Relaxed);
+            })
+        };
+        let reader = {
+            let engine = engine.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                let mut observed = 0u64;
+                while !stop.load(AOrd::Relaxed) {
+                    let snapshot = engine.load_table();
+                    // The invariant: every (pubkey, idx) pair in
+                    // the index map must map to a peer in `peers`
+                    // whose pubkey matches. A torn snapshot would
+                    // pair an old-config pubkey with a new-config
+                    // peer slot (or vice versa) — different pubkey.
+                    for (pubkey, idx) in snapshot.peer_index_by_pubkey.iter() {
+                        let peer = snapshot
+                            .peers
+                            .get(*idx as usize)
+                            .expect("idx must be in bounds within a snapshot");
+                        assert_eq!(
+                            &peer.pubkey, pubkey,
+                            "torn snapshot: index map and peer vec disagree"
+                        );
+                    }
+                    observed += 1;
+                }
+                observed
+            })
+        };
+        writer.join().unwrap();
+        let n = reader.join().unwrap();
+        // Sanity: the reader must have done at least one full pass.
+        // (On a heavily loaded CI box this could be 1; we don't
+        // tighten it.)
+        assert!(n >= 1, "reader thread observed no snapshots");
     }
 }

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -34,6 +34,7 @@ use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
 use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_ZERO_PSK};
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
+use std::mem::MaybeUninit;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Arc, RwLock};
 use zeroize::Zeroizing;
@@ -72,9 +73,12 @@ pub(crate) enum InstallSessionError {
     /// The caller-supplied peer pubkey is not in the engine table.
     UnknownPeer,
     /// The caller-supplied `local_index` is already mapped to a
-    /// different live session. The caller must retry handshake
+    /// live session (any peer). The caller must retry handshake
     /// completion with a fresh `local_index`. Silently overwriting
-    /// the existing session would blackhole its inbound traffic.
+    /// the existing session — even for the same peer — would
+    /// blackhole the in-flight ciphertexts of the rotated-out
+    /// `previous` session, which the demux map would no longer be
+    /// able to resolve.
     LocalIndexCollision,
 }
 
@@ -104,7 +108,12 @@ pub(crate) enum DecapError {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DecapOutcome {
-    /// Number of bytes of decrypted inner-IP plaintext written.
+    /// Length of the un-padded inner-IP packet written at the front
+    /// of the caller's `out` buffer. This is the IPv4 `total_length`
+    /// / IPv6 `40 + payload_length`, NOT the WG §5.4.6 padded
+    /// plaintext length that snow authenticated. The bytes beyond
+    /// `len` and before `len + padding` (0..15 bytes) are zero
+    /// padding bytes that the receive path has already verified.
     pub(crate) len: usize,
     /// The peer that owned this session (so the caller can route
     /// the inner packet onward — typically into the LAN-side
@@ -129,13 +138,27 @@ pub(crate) struct WgEngineConfig {
     pub(crate) peers: Vec<WgPeerConfig>,
 }
 
-/// Stack scratch for the padded plaintext on the encap path. Sized
-/// to cover a 4 KiB jumbo-MTU inner packet plus the worst-case 15
-/// bytes of padding. We use a fixed stack buffer rather than the
-/// caller's `out` because `out` is the post-AEAD destination — snow
-/// requires non-overlapping plaintext/ciphertext slices. Stack
-/// allocation has zero per-packet cost.
-const PADDED_PLAINTEXT_MAX: usize = 4096 + 16;
+/// Stack scratch capacity for the padded plaintext on the encap
+/// path. Sized to cover an inner IP packet up to `PADDED_PLAINTEXT_MAX
+/// - 15` bytes plus the worst-case 15 bytes of WG spec §5.4.6
+/// padding. We stage the padded plaintext on the stack rather than
+/// inside the caller's `out` buffer because snow's `write_message`
+/// requires non-overlapping plaintext and ciphertext slices.
+///
+/// The buffer is materialized as `MaybeUninit<[u8; PADDED_PLAINTEXT_MAX]>`
+/// and only the bytes that snow actually reads are initialized
+/// (the `inner_ip.len()` bytes copied from the caller plus the
+/// trailing 0..15 padding bytes). This avoids the 4112-byte memset
+/// per call that a `[0u8; N]` array-init would force LLVM to emit
+/// (LLVM cannot elide the zero-init because snow reads the trailing
+/// pad bytes, which must be zero by spec).
+///
+/// Note on jumbo MTU: the value is 4080 + 16 padding = 4096. Inner
+/// packets larger than 4080 bytes will return `EncapError::BufferTooSmall`.
+/// Jumbo MTU configurations (>4080 inner) are not currently
+/// supported by this engine; raising the bound is a one-line change
+/// when the integration layer needs it.
+const PADDED_PLAINTEXT_MAX: usize = 4080 + 16;
 
 /// Round `n` up to the nearest multiple of 16. WG spec §5.4.6.
 #[inline]
@@ -242,12 +265,14 @@ impl WgEngine {
     ///
     /// Returns `Err(InstallSessionError::LocalIndexCollision)` if the
     /// caller's chosen `local_index` is already in the demux map for
-    /// a *different* session (different `Arc` identity). The slow-path
-    /// integration must retry handshake completion with a fresh
-    /// receiver_index when this fires; silently overwriting an
-    /// existing session would blackhole all of its inbound traffic.
-    /// See `try_decap` path for why the demux key must be unique
-    /// across live sessions.
+    /// any live session — regardless of which peer owns the existing
+    /// entry. WG local indices must be globally unique across every
+    /// live (current, previous) session this engine owns; same-peer
+    /// rekey collisions are just as fatal as cross-peer collisions
+    /// because rotation moves the existing current into `previous`,
+    /// and the demux map can only carry one entry per index. The
+    /// slow-path installer must retry handshake completion with a
+    /// fresh receiver_index when this fires.
     pub(crate) fn install_session(
         &self,
         pubkey: &[u8; 32],
@@ -256,42 +281,39 @@ impl WgEngine {
         let Some(peer) = self.peer_arc(pubkey) else {
             return Err(InstallSessionError::UnknownPeer);
         };
-        // Register for inbound demux BEFORE rotation so decap can
-        // resolve the new local index immediately (closes the decap-
-        // blackhole window that earlier rotate-first ordering had).
+        // Refuse ANY same-key collision in the demux map. Local
+        // indices must be unique across every live session this
+        // engine owns — same-peer collisions are just as fatal as
+        // cross-peer ones because rotation moves the existing
+        // current session into `previous`, and inbound packets that
+        // still address the previous session would demux to the new
+        // session, fail AEAD, and silently drop. The slow-path
+        // session installer is responsible for picking a fresh
+        // `local_index` (the 32-bit random allocator already does
+        // this trivially in expectation; a collision means the
+        // caller must regenerate and retry).
         //
-        // Three concerns:
-        //   (a) If the same `local_index` is already mapped to a
-        //       different session, refuse the install rather than
-        //       silently overwriting it.
-        //   (b) After rotation, the dropped-previous session must be
-        //       removed from the demux map — but ONLY if its
-        //       `local_index` differs from the new session's (the
-        //       re-handshake-on-same-index case), otherwise the
-        //       remove kills the entry we just inserted.
-        //   (c) The demux insert and rotate must be visible together.
-        //       Holding the demux write lock across rotate_session is
-        //       safe (peer.current/previous have separate locks) and
-        //       gives a single atomic transition.
+        // After the demux insert, rotate_session() returns whichever
+        // session falls off the (current, previous) pair. That
+        // dropped session MUST then be removed from the demux map,
+        // and because the new session's local_index is now unique by
+        // construction, the remove cannot accidentally evict the
+        // entry we just inserted. The single-locked-region pattern
+        // keeps the (demux, current, previous) triple visible
+        // together to any subsequent decap.
         let new_local_index = session.local_index;
         let mut by_index = self.sessions_by_local_index.write().unwrap();
-        // Collision check: an existing entry with the same local_index
-        // is only acceptable if it belongs to the SAME peer (i.e. a
-        // re-handshake / rekey landed on the same caller-chosen
-        // receiver_index, which is benign — the new session simply
-        // replaces the old one). An entry owned by a DIFFERENT peer
-        // is a real collision and we must refuse the install rather
-        // than silently overwrite the other peer's live session.
-        if let Some(existing) = by_index.get(&new_local_index)
-            && existing.peer_pubkey != session.peer_pubkey
-        {
+        if by_index.contains_key(&new_local_index) {
             return Err(InstallSessionError::LocalIndexCollision);
         }
         by_index.insert(new_local_index, session.clone());
         let dropped_previous = peer.rotate_session(session);
-        if let Some(old) = dropped_previous
-            && old.local_index != new_local_index
-        {
+        if let Some(old) = dropped_previous {
+            // `old.local_index != new_local_index` is guaranteed by
+            // the uniqueness check above; the explicit assert keeps
+            // the invariant visible if a future change ever relaxes
+            // the collision rule.
+            debug_assert_ne!(old.local_index, new_local_index);
             by_index.remove(&old.local_index);
         }
         Ok(())
@@ -335,32 +357,42 @@ impl WgEngine {
         let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
         let _ = encode_data_header(out, session.peer_index, counter)
             .ok_or(EncapError::BufferTooSmall)?;
-        // Stage the padded plaintext in the output buffer immediately
-        // after the (eventual) ciphertext region. We do NOT allocate;
-        // we reuse a scratch zone at the END of `out` that is past
-        // `required`. If the caller sized `out` exactly to `required`
-        // (the worker scratch path always does this), we instead pad
-        // in-place at the front of the payload region BEFORE handing
-        // it to snow. Strategy: write zeros after `inner_ip` into the
-        // pre-AEAD slot, then have snow encrypt the padded region.
-        //
-        // Implementation: pre-AEAD plaintext lives in `out[WG_DATA_HEADER_LEN..WG_DATA_HEADER_LEN+padded_len]`.
-        // We can't overlap with snow's output of the same range, so
-        // we use a small stack-allocated scratch for the padded
-        // plaintext. The WG MTU bound puts the inner packet at
-        // <=1500 bytes; we use a 4 KiB stack buffer to cover jumbo
-        // MTU configurations comfortably.
-        let mut plaintext = [0u8; PADDED_PLAINTEXT_MAX];
-        if padded_len > plaintext.len() {
+        // Stage the padded plaintext on the stack. We use
+        // `MaybeUninit` and only initialize the bytes snow will read
+        // (`inner_ip.len()` of payload + the worst-case 15 padding
+        // bytes), which avoids the 4112-byte memset-per-call that a
+        // `[0u8; N]` array initializer would force LLVM to emit on
+        // the hot path. snow's `write_message` requires
+        // non-overlapping plaintext and ciphertext slices, so we
+        // cannot stage the plaintext inside `out`.
+        if padded_len > PADDED_PLAINTEXT_MAX {
             return Err(EncapError::BufferTooSmall);
         }
-        plaintext[..inner_ip.len()].copy_from_slice(inner_ip);
-        // Bytes [inner_ip.len()..padded_len] are already zero from
-        // the array initializer.
+        let mut plaintext_uninit: MaybeUninit<[u8; PADDED_PLAINTEXT_MAX]> = MaybeUninit::uninit();
+        // SAFETY: we cast the `MaybeUninit<[u8; N]>` to `&mut [u8; N]`
+        // before writing every byte we intend to read. The bytes
+        // outside `[0..padded_len]` are never read (snow only
+        // touches `[..padded_len]`), so leaving them uninitialized
+        // is sound. We initialize:
+        //   - `[0..inner_ip.len()]` with the caller's payload
+        //   - `[inner_ip.len()..padded_len]` with zeros (WG spec
+        //     §5.4.6 requires the padding be zero bytes)
+        let plaintext_ref: &mut [u8; PADDED_PLAINTEXT_MAX] =
+            unsafe { &mut *plaintext_uninit.as_mut_ptr() };
+        plaintext_ref[..inner_ip.len()].copy_from_slice(inner_ip);
+        // Trailing padding: at most 15 bytes. WG spec §5.4.6 requires
+        // the padding be zero.
+        for b in &mut plaintext_ref[inner_ip.len()..padded_len] {
+            *b = 0;
+        }
+        // SAFETY: `[0..padded_len]` is fully initialized (payload +
+        // zero padding above); we hand snow a slice limited to that
+        // range, which is the only memory it reads.
+        let plaintext = &plaintext_ref[..padded_len];
         let (_hdr, payload) = out.split_at_mut(WG_DATA_HEADER_LEN);
         let n = session
             .transport
-            .write_message(counter, &plaintext[..padded_len], payload)
+            .write_message(counter, plaintext, payload)
             .map_err(|_| EncapError::CryptoFailed)?;
         Ok(EncapOutcome {
             len: WG_DATA_HEADER_LEN + n,
@@ -441,33 +473,49 @@ impl WgEngine {
         // If not, drop." This is the cryptokey-routing safety
         // invariant on the receive side.
         //
-        // WG transport messages are zero-padded to 16-byte multiples
-        // before AEAD on send; strip trailing zero padding before we
-        // hand the plaintext to the inner-IP parser, otherwise an
-        // IPv4 packet whose `total_length` is shorter than the
-        // padded ciphertext will still parse correctly (we parse the
-        // src IP from the IPv4 header at byte offset 12..16, which
-        // is well before any padding) but downstream consumers will
-        // see trailing zero bytes that aren't part of the original
-        // packet. We do not truncate `n` here — the caller is
-        // expected to consult the inner IP header's length field —
-        // but the parse below is robust to extra trailing bytes.
-        let inner_src = inner_src_ip(&out[..n]).ok_or(DecapError::MalformedInner)?;
-        let peer_idx = self
-            .peer_index(&session.peer_pubkey)
-            .ok_or(DecapError::UnknownSession)?;
-        let allowed = self.allowed_ips.read().unwrap();
-        if !allowed.matches_for_peer(inner_src, peer_idx) {
-            // Defensive: zero the plaintext we just authenticated
-            // but cannot deliver, to keep the contract "on Err the
-            // caller MUST NOT inspect `out`" tight.
-            out[..n].fill(0);
-            return Err(DecapError::AllowedIpsViolation);
+        // Every error arm past `read_message` MUST zero `out[..n]`
+        // before returning so the contract "on Err the caller MUST
+        // NOT inspect `out`" is structurally enforced. We use a
+        // single fall-through with the helper below; adding a new
+        // post-AEAD error arm cannot accidentally skip the wipe.
+        //
+        // The plaintext is the padded form (WG §5.4.6 zero-padded
+        // to a 16-byte multiple at the sender). We parse src IP
+        // from the IPv4/IPv6 header's fixed offset, which is well
+        // before any padding bytes. The returned `inner_ip_len`
+        // truncates `n` down to the real inner-IP packet length;
+        // see `inner_ip_len_after_decap` for the IPv4
+        // `total_length` / IPv6 `payload_length` math. The caller
+        // sees only the un-padded inner-IP packet.
+        let outcome = (|| -> Result<(IpAddr, u32, usize), DecapError> {
+            let inner_src = inner_src_ip(&out[..n]).ok_or(DecapError::MalformedInner)?;
+            let peer_idx = self
+                .peer_index(&session.peer_pubkey)
+                .ok_or(DecapError::UnknownSession)?;
+            let allowed = self.allowed_ips.read().unwrap();
+            if !allowed.matches_for_peer(inner_src, peer_idx) {
+                return Err(DecapError::AllowedIpsViolation);
+            }
+            let inner_len = inner_ip_len_after_decap(&out[..n])
+                .ok_or(DecapError::MalformedInner)?;
+            Ok((inner_src, peer_idx, inner_len))
+        })();
+        match outcome {
+            Ok((_inner_src, _peer_idx, inner_len)) => {
+                debug_assert!(inner_len <= n);
+                Ok(DecapOutcome {
+                    len: inner_len,
+                    peer_pubkey: session.peer_pubkey,
+                })
+            }
+            Err(e) => {
+                // Defensive: zero the plaintext we just authenticated
+                // but cannot deliver. Covers MalformedInner,
+                // UnknownSession, and AllowedIpsViolation uniformly.
+                out[..n].fill(0);
+                Err(e)
+            }
         }
-        Ok(DecapOutcome {
-            len: n,
-            peer_pubkey: session.peer_pubkey,
-        })
     }
 
     /// Build a snow `HandshakeState` configured as the initiator
@@ -506,6 +554,49 @@ impl WgEngine {
             .psk(2, &WG_ZERO_PSK)?
             .build_responder()
     }
+}
+
+/// Read the inner-IP packet's total length from its own header, so
+/// the caller of `try_decap` receives the un-padded inner-IP packet
+/// length (not the §5.4.6 padded plaintext length that snow
+/// authenticated). The decrypted plaintext is `padded_inner_ip ||
+/// zeros_up_to_16_byte_multiple`; trimming to the on-the-wire
+/// inner-IP length here means downstream consumers never see WG's
+/// padding bytes.
+///
+/// Returns `None` if:
+///   - the buffer is too short for an IPv4/IPv6 header,
+///   - the IP `version` nibble is something other than 4 or 6,
+///   - the header-declared length exceeds the decrypted buffer
+///     (the sender lied or the AEAD verified a malformed packet —
+///     either way, drop).
+fn inner_ip_len_after_decap(pkt: &[u8]) -> Option<usize> {
+    let version = pkt.first()? >> 4;
+    let claimed = match version {
+        4 => {
+            if pkt.len() < 20 {
+                return None;
+            }
+            u16::from_be_bytes([pkt[2], pkt[3]]) as usize
+        }
+        6 => {
+            if pkt.len() < 40 {
+                return None;
+            }
+            // IPv6 header fixed at 40; payload_length is bytes 4..6.
+            40 + u16::from_be_bytes([pkt[4], pkt[5]]) as usize
+        }
+        _ => return None,
+    };
+    // The claimed length must fit inside what we decrypted, and the
+    // remaining bytes (the §5.4.6 padding) must all be zero.
+    if claimed > pkt.len() {
+        return None;
+    }
+    if pkt[claimed..].iter().any(|&b| b != 0) {
+        return None;
+    }
+    Some(claimed)
 }
 
 /// Extract the source IP from the front of an inner-IP packet.
@@ -610,13 +701,106 @@ mod engine_internal_tests {
         Arc::new(WgSession::new(xport, local_index, peer_index, peer_pub))
     }
 
-    /// Regression: re-handshake on the SAME `local_index` must keep
-    /// the new session in the demux map, not get it nuked by the
-    /// dropped-previous cleanup. r3 introduced a same-index aliasing
-    /// bug where remove(&old.local_index) silently deleted the entry
-    /// the new session had just installed.
+    /// Same-peer same-local-index collision must be refused. Letting
+    /// it through would move the existing current session into
+    /// `previous`, but rewrite its demux entry to point at the new
+    /// session — in-flight ciphertexts addressed to the previous
+    /// session (which legitimately still decode against its key
+    /// during the rotation grace window) would demux to the new
+    /// session, fail AEAD, and drop silently. Codex r4 finding 1 /
+    /// Gemini r4 finding B. r3's test (now removed) blessed this
+    /// wrong behavior.
     #[test]
-    fn install_session_same_local_index_keeps_new_session_in_demux() {
+    fn install_session_same_peer_same_local_index_is_collision() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let s1 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 2);
+        let s1_ptr = Arc::as_ptr(&s1);
+        engine.install_session(&peer_pub, s1).unwrap();
+        // Re-handshake with the SAME local_index for the SAME peer
+        // must be rejected with LocalIndexCollision.
+        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 3);
+        let err = engine.install_session(&peer_pub, s2).unwrap_err();
+        assert_eq!(err, InstallSessionError::LocalIndexCollision);
+        // The original session must still be the demux target.
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        assert_eq!(
+            Arc::as_ptr(by_index.get(&0xaaaa_0001).unwrap()),
+            s1_ptr,
+            "collision must NOT overwrite the existing same-peer session"
+        );
+    }
+
+    /// Successful same-peer rekey on a FRESH `local_index` must:
+    ///   (a) succeed,
+    ///   (b) leave the new session as the demux target for the new
+    ///       index,
+    ///   (c) leave the old session still demuxable on its old index
+    ///       (it has rotated to `previous` and continues to receive
+    ///       in-flight ciphertexts until the next rotation).
+    #[test]
+    fn install_session_fresh_index_rekey_preserves_previous_demux() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let s1 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 2);
+        let s1_ptr = Arc::as_ptr(&s1);
+        engine.install_session(&peer_pub, s1).unwrap();
+        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0002, 3);
+        let s2_ptr = Arc::as_ptr(&s2);
+        engine.install_session(&peer_pub, s2).unwrap();
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        // New session is demuxable on the new index.
+        assert_eq!(Arc::as_ptr(by_index.get(&0xaaaa_0002).unwrap()), s2_ptr);
+        // Old session is still demuxable on the old index (rotated
+        // to `previous`, not dropped yet).
+        assert_eq!(Arc::as_ptr(by_index.get(&0xaaaa_0001).unwrap()), s1_ptr);
+    }
+
+    /// A second rekey (s3 on a third fresh index) drops s1 out of
+    /// (current, previous). The engine must then remove s1's demux
+    /// entry so its index can be reused for future handshakes.
+    #[test]
+    fn install_session_second_rekey_evicts_dropped_session() {
         let (init_priv, _init_pub) = keypair();
         let (peer_priv, peer_pub) = keypair();
         let engine = WgEngine::new(WgEngineConfig {
@@ -641,16 +825,17 @@ mod engine_internal_tests {
         });
         let s1 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 2);
         engine.install_session(&peer_pub, s1).unwrap();
-        // Re-handshake with the SAME local_index (e.g. rekey
-        // happened to land on the same caller-chosen receiver_index).
-        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 3);
-        let s2_ptr = Arc::as_ptr(&s2);
+        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0002, 3);
         engine.install_session(&peer_pub, s2).unwrap();
+        let s3 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0003, 4);
+        engine.install_session(&peer_pub, s3).unwrap();
         let by_index = engine.sessions_by_local_index.read().unwrap();
-        let live = by_index
-            .get(&0xaaaa_0001)
-            .expect("new session must still be in demux map");
-        assert_eq!(Arc::as_ptr(live), s2_ptr);
+        assert!(
+            by_index.get(&0xaaaa_0001).is_none(),
+            "s1 must be evicted from demux after second rotation drops it"
+        );
+        assert!(by_index.get(&0xaaaa_0002).is_some());
+        assert!(by_index.get(&0xaaaa_0003).is_some());
     }
 
     /// Collision detection: installing two distinct sessions with the

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -213,9 +213,11 @@ pub(crate) struct WgEngine {
     /// Combined peer-routing table behind a single ArcSwap. See
     /// `PeerTable` doc for the atomicity rationale.
     table: ArcSwap<PeerTable>,
-    /// Mutex held by reconcile_peers so concurrent reconciles
-    /// serialize. Hot path does NOT take this lock — readers only
-    /// touch `table` via `.load()`. Reconcile is slow path.
+    /// Slow-path serialization lock for peer-table mutation.
+    /// `reconcile_peers` and `install_session` both take it to
+    /// prevent stale-Arc install races across peer removal. Hot path
+    /// does NOT take this lock — readers only touch `table` via
+    /// `.load()`.
     reconcile_lock: std::sync::Mutex<()>,
     /// Demux map: receiver_index → session. Receiver indices are
     /// chosen locally at handshake time so they uniquely identify
@@ -362,6 +364,16 @@ impl WgEngine {
         pubkey: &[u8; 32],
         session: Arc<WgSession>,
     ) -> Result<(), InstallSessionError> {
+        // Serialize session installs with reconcile to avoid the
+        // stale-Arc orphaning race:
+        //   1) install loads `peer` from old snapshot
+        //   2) reconcile removes that peer and publishes new snapshot
+        //   3) install inserts demux entry against orphan peer Arc
+        // Without serialization, that orphan demux entry can survive
+        // future reconciles because the peer pubkey no longer exists
+        // in published tables. This is slow path, so mutex cost is
+        // acceptable and keeps install/reconcile linearizable.
+        let _reconcile_guard = self.reconcile_lock.lock().unwrap();
         let Some(peer) = self.peer_arc(pubkey) else {
             return Err(InstallSessionError::UnknownPeer);
         };

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -286,7 +286,19 @@ impl WgEngine {
                 )),
             };
             new_peers.push(peer);
-            new_index.insert(cfg.pubkey, idx);
+            // r7 Codex/Claude nit: duplicate pubkeys in `configs`
+            // leave an orphan `Peer` in `new_peers` (unreachable via
+            // pubkey lookup) and make `new_allowed` carry entries
+            // indexed at the earlier duplicate's slot. The Go control
+            // plane is supposed to reject duplicate pubkeys at config
+            // validation; this `debug_assert` keeps the engine-side
+            // invariant visible during development without panicking
+            // production builds if the validation layer is bypassed.
+            let prior = new_index.insert(cfg.pubkey, idx);
+            debug_assert!(
+                prior.is_none(),
+                "duplicate peer pubkey in reconcile_peers configs (prior idx={prior:?}, new idx={idx})"
+            );
             for cidr in &cfg.allowed_ips {
                 new_allowed.insert(*cidr, idx);
             }
@@ -1446,6 +1458,24 @@ mod engine_internal_tests {
         assert!(
             reconcile_iters >= 1,
             "reconcile loop must have completed at least one full add/remove cycle"
+        );
+        // r7 Codex hostile finding: a tautological pass shape exists
+        // if the reconciler always wins the lock — every install
+        // returns UnknownPeer, demux stays empty, and the post-loop
+        // invariants are trivially satisfied even with the lock
+        // removed. Require at least one Ok install so the lock-
+        // protected path (peer_arc-then-rotate_session under the
+        // same guard) is actually exercised. With 400 iterations and
+        // reconcile alternating add/remove on a separate thread, the
+        // installer typically lands 50-300 Ok results in practice;
+        // requiring just `ok > 0` is conservative against schedule
+        // skew while keeping the gate non-vacuous.
+        assert!(
+            ok > 0,
+            "race regression must exercise at least one successful install \
+             (ok={ok}, unknown={unknown}, collision={collision}); without an \
+             Ok the lock-protected demux insert path is not on the test \
+             trajectory and the gate is tautological"
         );
         // Post-condition invariant: every entry in
         // `sessions_by_local_index` must reference a peer pubkey

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -30,12 +30,13 @@
 use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};
 use super::peer::Peer;
-use super::session::{ReplayDecision, WgSession};
+use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
 use super::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_ZERO_PSK};
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Arc, RwLock};
+use zeroize::Zeroizing;
 
 /// Errors that can fail the egress path.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,6 +66,18 @@ pub(crate) struct EncapOutcome {
     pub(crate) counter: u64,
 }
 
+/// Errors that can fail the slow-path session install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InstallSessionError {
+    /// The caller-supplied peer pubkey is not in the engine table.
+    UnknownPeer,
+    /// The caller-supplied `local_index` is already mapped to a
+    /// different live session. The caller must retry handshake
+    /// completion with a fresh `local_index`. Silently overwriting
+    /// the existing session would blackhole its inbound traffic.
+    LocalIndexCollision,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DecapError {
     /// Header was malformed (too short, wrong type, etc.)
@@ -77,6 +90,9 @@ pub(crate) enum DecapError {
     ReplayDuplicate,
     /// Replay window said this counter is too old.
     ReplayOutOfWindow,
+    /// Counter is at or above `REJECT_AFTER_MESSAGES`. Per WG spec
+    /// §6.5 the receiver MUST reject these without attempting AEAD.
+    CounterRejectAfterMessages,
     /// Decrypted plaintext did not parse as IPv4/IPv6.
     MalformedInner,
     /// Inner src IP is not in this peer's AllowedIPs — cryptokey-
@@ -113,11 +129,28 @@ pub(crate) struct WgEngineConfig {
     pub(crate) peers: Vec<WgPeerConfig>,
 }
 
+/// Stack scratch for the padded plaintext on the encap path. Sized
+/// to cover a 4 KiB jumbo-MTU inner packet plus the worst-case 15
+/// bytes of padding. We use a fixed stack buffer rather than the
+/// caller's `out` because `out` is the post-AEAD destination — snow
+/// requires non-overlapping plaintext/ciphertext slices. Stack
+/// allocation has zero per-packet cost.
+const PADDED_PLAINTEXT_MAX: usize = 4096 + 16;
+
+/// Round `n` up to the nearest multiple of 16. WG spec §5.4.6.
+#[inline]
+const fn pad_to_16(n: usize) -> usize {
+    (n + 15) & !15
+}
+
 /// The engine.
 pub(crate) struct WgEngine {
     /// Local X25519 private key. Held in the engine because every
-    /// slow-path handshake needs it.
-    local_private_key: [u8; 32],
+    /// slow-path handshake needs it. Wrapped in `Zeroizing` so the
+    /// 32 bytes of key material are wiped on engine drop — kernel
+    /// WG and wireguard-go both do this. snow internally zeroizes
+    /// its own copies; this is for the engine's persistent copy.
+    local_private_key: Zeroizing<[u8; 32]>,
     /// UDP port we listen on for inbound. Stored for diagnostics
     /// and for the slow-path responder.
     listen_port: u16,
@@ -137,7 +170,7 @@ pub(crate) struct WgEngine {
 impl WgEngine {
     pub(crate) fn new(config: WgEngineConfig) -> Self {
         let engine = Self {
-            local_private_key: config.local_private_key,
+            local_private_key: Zeroizing::new(config.local_private_key),
             listen_port: config.listen_port,
             peer_index_by_pubkey: RwLock::new(FxHashMap::default()),
             peers: RwLock::new(Vec::new()),
@@ -206,25 +239,62 @@ impl WgEngine {
     /// Install a freshly-completed transport session on a peer and
     /// register it for inbound demux. Called from the slow-path
     /// handshake-complete code.
-    pub(crate) fn install_session(&self, pubkey: &[u8; 32], session: Arc<WgSession>) {
+    ///
+    /// Returns `Err(InstallSessionError::LocalIndexCollision)` if the
+    /// caller's chosen `local_index` is already in the demux map for
+    /// a *different* session (different `Arc` identity). The slow-path
+    /// integration must retry handshake completion with a fresh
+    /// receiver_index when this fires; silently overwriting an
+    /// existing session would blackhole all of its inbound traffic.
+    /// See `try_decap` path for why the demux key must be unique
+    /// across live sessions.
+    pub(crate) fn install_session(
+        &self,
+        pubkey: &[u8; 32],
+        session: Arc<WgSession>,
+    ) -> Result<(), InstallSessionError> {
         let Some(peer) = self.peer_arc(pubkey) else {
-            return;
+            return Err(InstallSessionError::UnknownPeer);
         };
-        // Register for inbound demux before rotation so decap can
-        // resolve the new local index immediately. Keep only
-        // current+previous in the demux map by deleting the session
-        // that falls off.
+        // Register for inbound demux BEFORE rotation so decap can
+        // resolve the new local index immediately (closes the decap-
+        // blackhole window that earlier rotate-first ordering had).
+        //
+        // Three concerns:
+        //   (a) If the same `local_index` is already mapped to a
+        //       different session, refuse the install rather than
+        //       silently overwriting it.
+        //   (b) After rotation, the dropped-previous session must be
+        //       removed from the demux map — but ONLY if its
+        //       `local_index` differs from the new session's (the
+        //       re-handshake-on-same-index case), otherwise the
+        //       remove kills the entry we just inserted.
+        //   (c) The demux insert and rotate must be visible together.
+        //       Holding the demux write lock across rotate_session is
+        //       safe (peer.current/previous have separate locks) and
+        //       gives a single atomic transition.
+        let new_local_index = session.local_index;
+        let mut by_index = self.sessions_by_local_index.write().unwrap();
+        // Collision check: an existing entry with the same local_index
+        // is only acceptable if it belongs to the SAME peer (i.e. a
+        // re-handshake / rekey landed on the same caller-chosen
+        // receiver_index, which is benign — the new session simply
+        // replaces the old one). An entry owned by a DIFFERENT peer
+        // is a real collision and we must refuse the install rather
+        // than silently overwrite the other peer's live session.
+        if let Some(existing) = by_index.get(&new_local_index)
+            && existing.peer_pubkey != session.peer_pubkey
         {
-            let mut by_index = self.sessions_by_local_index.write().unwrap();
-            by_index.insert(session.local_index, session.clone());
+            return Err(InstallSessionError::LocalIndexCollision);
         }
+        by_index.insert(new_local_index, session.clone());
         let dropped_previous = peer.rotate_session(session);
-        if let Some(old) = dropped_previous {
-            self.sessions_by_local_index
-                .write()
-                .unwrap()
-                .remove(&old.local_index);
+        if let Some(old) = dropped_previous
+            && old.local_index != new_local_index
+        {
+            by_index.remove(&old.local_index);
         }
+        Ok(())
     }
 
     /// Hot-path encap.
@@ -251,18 +321,46 @@ impl WgEngine {
             .clone()
             .ok_or(EncapError::NoSession)?;
 
-        let required = WG_DATA_HEADER_LEN + inner_ip.len() + POLY1305_TAG_LEN;
+        // WG spec §5.4.6 mandates the plaintext be zero-padded to a
+        // 16-byte multiple before AEAD. This obscures inner packet
+        // lengths and is required for wire interoperability with
+        // kernel WG / wireguard-go. Compute the padded length and
+        // ensure the output buffer can hold header + ciphertext +
+        // tag at the padded size.
+        let padded_len = pad_to_16(inner_ip.len());
+        let required = WG_DATA_HEADER_LEN + padded_len + POLY1305_TAG_LEN;
         if out.len() < required {
             return Err(EncapError::BufferTooSmall);
         }
         let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
         let _ = encode_data_header(out, session.peer_index, counter)
             .ok_or(EncapError::BufferTooSmall)?;
-        // snow writes ciphertext||tag into the payload region.
+        // Stage the padded plaintext in the output buffer immediately
+        // after the (eventual) ciphertext region. We do NOT allocate;
+        // we reuse a scratch zone at the END of `out` that is past
+        // `required`. If the caller sized `out` exactly to `required`
+        // (the worker scratch path always does this), we instead pad
+        // in-place at the front of the payload region BEFORE handing
+        // it to snow. Strategy: write zeros after `inner_ip` into the
+        // pre-AEAD slot, then have snow encrypt the padded region.
+        //
+        // Implementation: pre-AEAD plaintext lives in `out[WG_DATA_HEADER_LEN..WG_DATA_HEADER_LEN+padded_len]`.
+        // We can't overlap with snow's output of the same range, so
+        // we use a small stack-allocated scratch for the padded
+        // plaintext. The WG MTU bound puts the inner packet at
+        // <=1500 bytes; we use a 4 KiB stack buffer to cover jumbo
+        // MTU configurations comfortably.
+        let mut plaintext = [0u8; PADDED_PLAINTEXT_MAX];
+        if padded_len > plaintext.len() {
+            return Err(EncapError::BufferTooSmall);
+        }
+        plaintext[..inner_ip.len()].copy_from_slice(inner_ip);
+        // Bytes [inner_ip.len()..padded_len] are already zero from
+        // the array initializer.
         let (_hdr, payload) = out.split_at_mut(WG_DATA_HEADER_LEN);
         let n = session
             .transport
-            .write_message(counter, inner_ip, payload)
+            .write_message(counter, &plaintext[..padded_len], payload)
             .map_err(|_| EncapError::CryptoFailed)?;
         Ok(EncapOutcome {
             len: WG_DATA_HEADER_LEN + n,
@@ -283,6 +381,14 @@ impl WgEngine {
         out: &mut [u8],
     ) -> Result<DecapOutcome, DecapError> {
         let hdr = parse_data_header(wg_record).ok_or(DecapError::MalformedHeader)?;
+        // WG spec §6.5: drop inbound data packets whose counter is
+        // at or above REJECT_AFTER_MESSAGES without doing AEAD. The
+        // counter-space ceiling is symmetric across encap/decap;
+        // the encap-side guard alone is not sufficient because a
+        // malicious or buggy sender may send arbitrary high counters.
+        if hdr.counter >= REJECT_AFTER_MESSAGES {
+            return Err(DecapError::CounterRejectAfterMessages);
+        }
         let session = self
             .sessions_by_local_index
             .read()
@@ -313,8 +419,20 @@ impl WgEngine {
             let mut replay = session.replay.lock().unwrap();
             match replay.check_and_update(hdr.counter) {
                 ReplayDecision::Accept => {}
-                ReplayDecision::Repeat => return Err(DecapError::ReplayDuplicate),
-                ReplayDecision::OutOfWindow => return Err(DecapError::ReplayOutOfWindow),
+                ReplayDecision::Repeat => {
+                    // Authentic but replayed: snow has already written
+                    // plaintext into `out[..n]`. Zero the staging
+                    // region before returning so a caller that
+                    // mishandles the error path cannot leak the
+                    // plaintext upstream. Cost is one memset per
+                    // replay-reject — the rare path.
+                    out[..n].fill(0);
+                    return Err(DecapError::ReplayDuplicate);
+                }
+                ReplayDecision::OutOfWindow => {
+                    out[..n].fill(0);
+                    return Err(DecapError::ReplayOutOfWindow);
+                }
             }
         }
         // AllowedIPs gate on the inner src IP. WG spec §5.4.6:
@@ -322,12 +440,28 @@ impl WgEngine {
         // IP of the inner packet belongs to the peer who sent it.
         // If not, drop." This is the cryptokey-routing safety
         // invariant on the receive side.
+        //
+        // WG transport messages are zero-padded to 16-byte multiples
+        // before AEAD on send; strip trailing zero padding before we
+        // hand the plaintext to the inner-IP parser, otherwise an
+        // IPv4 packet whose `total_length` is shorter than the
+        // padded ciphertext will still parse correctly (we parse the
+        // src IP from the IPv4 header at byte offset 12..16, which
+        // is well before any padding) but downstream consumers will
+        // see trailing zero bytes that aren't part of the original
+        // packet. We do not truncate `n` here — the caller is
+        // expected to consult the inner IP header's length field —
+        // but the parse below is robust to extra trailing bytes.
         let inner_src = inner_src_ip(&out[..n]).ok_or(DecapError::MalformedInner)?;
         let peer_idx = self
             .peer_index(&session.peer_pubkey)
             .ok_or(DecapError::UnknownSession)?;
         let allowed = self.allowed_ips.read().unwrap();
         if !allowed.matches_for_peer(inner_src, peer_idx) {
+            // Defensive: zero the plaintext we just authenticated
+            // but cannot deliver, to keep the contract "on Err the
+            // caller MUST NOT inspect `out`" tight.
+            out[..n].fill(0);
             return Err(DecapError::AllowedIpsViolation);
         }
         Ok(DecapOutcome {
@@ -348,7 +482,7 @@ impl WgEngine {
         peer_pubkey: &[u8; 32],
     ) -> Result<HandshakeState, snow::Error> {
         Builder::new(WG_NOISE_PATTERN.parse()?)
-            .local_private_key(&self.local_private_key)?
+            .local_private_key(self.local_private_key.as_slice())?
             .remote_public_key(peer_pubkey)?
             .psk(2, &WG_ZERO_PSK)?
             .build_initiator()
@@ -356,9 +490,19 @@ impl WgEngine {
 
     /// Build a snow `HandshakeState` configured as the responder.
     /// Slow path only.
+    ///
+    /// TODO(#1499 r4 / responder-peer-id): the integration layer
+    /// needs a thin helper that (a) builds this responder state,
+    /// (b) reads the init message, (c) calls
+    /// `HandshakeState::get_remote_static` to learn which peer sent
+    /// the init, and (d) looks up the peer in the engine table.
+    /// snow already supports step (c); we just haven't surfaced a
+    /// convenience API yet. Adding it here would couple the engine
+    /// to the snow message-bytes parser which is integration-layer
+    /// concern. Tracked for the integration PR.
     pub(crate) fn build_responder_handshake(&self) -> Result<HandshakeState, snow::Error> {
         Builder::new(WG_NOISE_PATTERN.parse()?)
-            .local_private_key(&self.local_private_key)?
+            .local_private_key(self.local_private_key.as_slice())?
             .psk(2, &WG_ZERO_PSK)?
             .build_responder()
     }
@@ -443,6 +587,134 @@ mod engine_internal_tests {
         assert!(inner_src_ip(&[0x05u8; 40]).is_none()); // bogus version 0
     }
 
+    /// Drive a real IK handshake between two engines and return the
+    /// initiator-side transport session. Helper used by the
+    /// install_session unit tests below — going through snow is
+    /// cheaper than a separate mock and keeps the test honest.
+    fn make_session_for(
+        engine: &WgEngine,
+        peer_pub: [u8; 32],
+        peer_engine: &WgEngine,
+        local_index: u32,
+        peer_index: u32,
+    ) -> Arc<WgSession> {
+        let mut init_hs = engine.build_initiator_handshake(&peer_pub).unwrap();
+        let mut resp_hs = peer_engine.build_responder_handshake().unwrap();
+        let mut buf = [0u8; 1024];
+        let mut sink = [0u8; 1024];
+        let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+        resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+        let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+        init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+        let xport = init_hs.into_stateless_transport_mode().unwrap();
+        Arc::new(WgSession::new(xport, local_index, peer_index, peer_pub))
+    }
+
+    /// Regression: re-handshake on the SAME `local_index` must keep
+    /// the new session in the demux map, not get it nuked by the
+    /// dropped-previous cleanup. r3 introduced a same-index aliasing
+    /// bug where remove(&old.local_index) silently deleted the entry
+    /// the new session had just installed.
+    #[test]
+    fn install_session_same_local_index_keeps_new_session_in_demux() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_priv, peer_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: peer_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let s1 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 2);
+        engine.install_session(&peer_pub, s1).unwrap();
+        // Re-handshake with the SAME local_index (e.g. rekey
+        // happened to land on the same caller-chosen receiver_index).
+        let s2 = make_session_for(&engine, peer_pub, &peer_engine, 0xaaaa_0001, 3);
+        let s2_ptr = Arc::as_ptr(&s2);
+        engine.install_session(&peer_pub, s2).unwrap();
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        let live = by_index
+            .get(&0xaaaa_0001)
+            .expect("new session must still be in demux map");
+        assert_eq!(Arc::as_ptr(live), s2_ptr);
+    }
+
+    /// Collision detection: installing two distinct sessions with the
+    /// same `local_index` for DIFFERENT peers (or stale handshake
+    /// race) must return LocalIndexCollision rather than silently
+    /// overwriting the existing entry.
+    #[test]
+    fn install_session_rejects_local_index_collision_across_peers() {
+        let (init_priv, _init_pub) = keypair();
+        let (peer_a_priv, peer_a_pub) = keypair();
+        let (peer_b_priv, peer_b_pub) = keypair();
+        let engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![
+                WgPeerConfig {
+                    pubkey: peer_a_pub,
+                    endpoint: None,
+                    persistent_keepalive: 0,
+                    allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+                },
+                WgPeerConfig {
+                    pubkey: peer_b_pub,
+                    endpoint: None,
+                    persistent_keepalive: 0,
+                    allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+                },
+            ],
+        });
+        let peer_a_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_a_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let peer_b_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: peer_b_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: [0u8; 32],
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec![ipnet::IpNet::from_str("10.0.0.0/24").unwrap()],
+            }],
+        });
+        let sa = make_session_for(&engine, peer_a_pub, &peer_a_engine, 0x1234_5678, 2);
+        let sa_ptr = Arc::as_ptr(&sa);
+        engine.install_session(&peer_a_pub, sa).unwrap();
+        let sb = make_session_for(&engine, peer_b_pub, &peer_b_engine, 0x1234_5678, 3);
+        let err = engine.install_session(&peer_b_pub, sb).unwrap_err();
+        assert_eq!(err, InstallSessionError::LocalIndexCollision);
+        // Peer A's session must still be the one in the demux map.
+        let by_index = engine.sessions_by_local_index.read().unwrap();
+        assert_eq!(
+            Arc::as_ptr(by_index.get(&0x1234_5678).unwrap()),
+            sa_ptr,
+            "collision must NOT overwrite the existing session"
+        );
+    }
+
     #[test]
     fn encap_rejects_after_message_limit() {
         let (init_priv, _init_pub) = keypair();
@@ -485,7 +757,7 @@ mod engine_internal_tests {
             super::super::session::REJECT_AFTER_MESSAGES,
             Ordering::Relaxed,
         );
-        engine.install_session(&peer_pub, session);
+        engine.install_session(&peer_pub, session).unwrap();
         let inner = [
             0x45u8, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 10, 0, 0, 1, 10, 0, 0, 2,
         ];

--- a/userspace-dp/src/afxdp/wg/framing.rs
+++ b/userspace-dp/src/afxdp/wg/framing.rs
@@ -68,9 +68,9 @@ pub(crate) fn parse_data_header(buf: &[u8]) -> Option<ParsedDataHeader<'_>> {
     if buf[0] != WG_TYPE_DATA {
         return None;
     }
-    // Bytes 1..4 are "reserved" per the WG spec; whitepaper §5.4.6
-    // says they MUST be zero on transmit, but a receiver MUST NOT
-    // reject non-zero values. We mirror that — ignore them.
+    // Bytes 1..4 are reserved and transmitted as zero by
+    // `encode_data_header`. We accept non-zero values here for
+    // interoperability robustness.
     let receiver_index = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
     let counter = u64::from_le_bytes([
         buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
@@ -124,8 +124,7 @@ mod framing_tests {
 
     #[test]
     fn ignores_reserved_bytes_on_parse() {
-        // Whitepaper §5.4.6: receiver MUST NOT reject non-zero
-        // reserved bytes. Mirror that — accept them.
+        // Parse accepts non-zero reserved bytes for robustness.
         let mut buf = [0u8; WG_DATA_HEADER_LEN];
         buf[0] = 4;
         buf[1] = 0xaa;

--- a/userspace-dp/src/afxdp/wg/framing.rs
+++ b/userspace-dp/src/afxdp/wg/framing.rs
@@ -19,8 +19,23 @@
 //!
 //! `receiver_index` and `counter` are little-endian. The encrypted
 //! payload is ChaCha20-Poly1305 with a 96-bit nonce of
-//! `counter.to_le_bytes() || [0,0,0,0]`. snow's u64 nonce parameter
-//! produces this exact layout, so we pass `counter` straight through.
+//! `[0,0,0,0] || counter.to_le_bytes()` (4 zero bytes prepended,
+//! then the 64-bit counter little-endian in bytes [4..12]), per the
+//! WireGuard whitepaper §5.4.6 (`0^32 || counter_LE_64`). snow 0.10's
+//! default ChaCha20-Poly1305 resolver builds this exact layout from
+//! its u64 nonce parameter — see `snow-0.10.0/src/resolvers/default.rs`
+//! lines 380-381:
+//!
+//! ```text
+//!   let mut nonce_bytes = [0_u8; 12];
+//!   copy_slices!(nonce.to_le_bytes(), &mut nonce_bytes[4..]);
+//! ```
+//!
+//! so we pass `counter` straight through to snow without manual
+//! padding. A future maintainer must not "match what snow does" by
+//! constructing `counter_LE || [0,0,0,0]` — that order is the inverse
+//! of what snow and the WG whitepaper specify and would be silently
+//! non-interoperable.
 
 use super::{WG_DATA_HEADER_LEN, WG_TYPE_DATA};
 

--- a/userspace-dp/src/afxdp/wg/framing.rs
+++ b/userspace-dp/src/afxdp/wg/framing.rs
@@ -1,0 +1,137 @@
+//! WireGuard transport-data record framing.
+//!
+//! On the wire (per WireGuard whitepaper §5.4.6):
+//!
+//! ```text
+//!   0       1       2       3       4
+//!   +-------+-------+-------+-------+
+//!   | type=4|       reserved        |
+//!   +-------+-------+-------+-------+
+//!   |        receiver_index         |
+//!   +-------+-------+-------+-------+
+//!   |                               |
+//!   +          counter              +
+//!   |                               |
+//!   +-------+-------+-------+-------+
+//!   |  encrypted_payload || tag16   |
+//!   +-------------------------------+
+//! ```
+//!
+//! `receiver_index` and `counter` are little-endian. The encrypted
+//! payload is ChaCha20-Poly1305 with a 96-bit nonce of
+//! `counter.to_le_bytes() || [0,0,0,0]`. snow's u64 nonce parameter
+//! produces this exact layout, so we pass `counter` straight through.
+
+use super::{WG_DATA_HEADER_LEN, WG_TYPE_DATA};
+
+/// Encode the WG transport-data header (16 bytes) into the front
+/// of `out`. Returns the header length so the caller can fill the
+/// rest with the ciphertext.
+///
+/// Pure byte-shuffling. No allocations.
+#[inline]
+pub(crate) fn encode_data_header(
+    out: &mut [u8],
+    receiver_index: u32,
+    counter: u64,
+) -> Option<usize> {
+    let hdr = out.get_mut(..WG_DATA_HEADER_LEN)?;
+    hdr[0] = WG_TYPE_DATA;
+    hdr[1] = 0;
+    hdr[2] = 0;
+    hdr[3] = 0;
+    hdr[4..8].copy_from_slice(&receiver_index.to_le_bytes());
+    hdr[8..16].copy_from_slice(&counter.to_le_bytes());
+    Some(WG_DATA_HEADER_LEN)
+}
+
+/// Parsed WG data record. Borrows from the input buffer; the
+/// `ciphertext` includes the Poly1305 tag (snow's `read_message`
+/// expects ciphertext||tag as its input).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParsedDataHeader<'a> {
+    pub receiver_index: u32,
+    pub counter: u64,
+    pub ciphertext: &'a [u8],
+}
+
+/// Parse the WG transport-data header from the front of `buf`.
+///
+/// Returns `None` if `buf` is too short or the type byte is not 4.
+/// All errors return `None` rather than a typed enum so that the
+/// hot path can just `?` the result; callers track failure counts.
+#[inline]
+pub(crate) fn parse_data_header(buf: &[u8]) -> Option<ParsedDataHeader<'_>> {
+    if buf.len() < WG_DATA_HEADER_LEN {
+        return None;
+    }
+    if buf[0] != WG_TYPE_DATA {
+        return None;
+    }
+    // Bytes 1..4 are "reserved" per the WG spec; whitepaper §5.4.6
+    // says they MUST be zero on transmit, but a receiver MUST NOT
+    // reject non-zero values. We mirror that — ignore them.
+    let receiver_index = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    let counter = u64::from_le_bytes([
+        buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
+    ]);
+    Some(ParsedDataHeader {
+        receiver_index,
+        counter,
+        ciphertext: &buf[WG_DATA_HEADER_LEN..],
+    })
+}
+
+#[cfg(test)]
+mod framing_tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_header() {
+        let mut buf = [0u8; 32];
+        let n = encode_data_header(&mut buf, 0xdeadbeef, 0x0102030405060708).unwrap();
+        assert_eq!(n, WG_DATA_HEADER_LEN);
+        let parsed = parse_data_header(&buf[..WG_DATA_HEADER_LEN]).unwrap();
+        assert_eq!(parsed.receiver_index, 0xdeadbeef);
+        assert_eq!(parsed.counter, 0x0102030405060708);
+        assert_eq!(parsed.ciphertext.len(), 0);
+    }
+
+    #[test]
+    fn rejects_wrong_type() {
+        let mut buf = [0u8; WG_DATA_HEADER_LEN];
+        buf[0] = 1; // initiation, not data
+        assert!(parse_data_header(&buf).is_none());
+    }
+
+    #[test]
+    fn rejects_short_buf() {
+        let buf = [4u8; 8];
+        assert!(parse_data_header(&buf).is_none());
+    }
+
+    #[test]
+    fn little_endian_counter() {
+        // Spec: counter is little-endian on the wire. Verify byte
+        // layout matches what an interoperating implementation
+        // would expect (and what snow's ChaCha20 nonce builder
+        // consumes when we pass the same u64).
+        let mut buf = [0u8; WG_DATA_HEADER_LEN];
+        encode_data_header(&mut buf, 0, 1).unwrap();
+        assert_eq!(buf[8], 1);
+        assert_eq!(&buf[9..16], &[0u8; 7]);
+    }
+
+    #[test]
+    fn ignores_reserved_bytes_on_parse() {
+        // Whitepaper §5.4.6: receiver MUST NOT reject non-zero
+        // reserved bytes. Mirror that — accept them.
+        let mut buf = [0u8; WG_DATA_HEADER_LEN];
+        buf[0] = 4;
+        buf[1] = 0xaa;
+        buf[2] = 0xbb;
+        buf[3] = 0xcc;
+        buf[4..8].copy_from_slice(&7u32.to_le_bytes());
+        assert!(parse_data_header(&buf).is_some());
+    }
+}

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -1,0 +1,69 @@
+//! Clean-room WireGuard tunnel termination for the userspace AF_XDP
+//! dataplane. See `docs/pr/wireguard-clean/plan.md` for the design
+//! and the explicit list of architectural choices that diverge from
+//! the prior attempt in PR #1492.
+//!
+//! Scope of this PR: engine, framing, allowed-IPs trie, helpers,
+//! and unit tests. Hot-path activation in `tx/dispatch.rs` and
+//! `poll_descriptor.rs` is intentionally deferred — see the plan
+//! doc for the rationale.
+//!
+//! ### Why this module exists in isolation
+//!
+//! The WireGuard surface area is small and self-contained — handshake,
+//! framing, encap, decap, AllowedIPs LPM, replay window, MSS math.
+//! Keeping the engine free of `pub(in crate::afxdp)` types from the
+//! rest of `afxdp/` means we can unit-test it end-to-end and audit
+//! its security-critical paths without dragging in the dataplane's
+//! global type web. The integration PR will add a thin adapter
+//! layer that bridges the engine API to the dispatch/poll types.
+
+#![allow(dead_code)] // Most of this module is not yet wired into the hot path.
+
+pub(crate) mod allowed_ips;
+pub(crate) mod dscp;
+pub(crate) mod engine;
+pub(crate) mod framing;
+pub(crate) mod mss;
+pub(crate) mod outer;
+pub(crate) mod peer;
+pub(crate) mod scratch;
+pub(crate) mod session;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+pub(crate) use engine::{
+    EncapError, EncapOutcome, DecapError, DecapOutcome, WgEngine, WgEngineConfig, WgPeerConfig,
+};
+pub(crate) use scratch::WgWorkerScratch;
+
+/// X25519 public/private key length (bytes).
+pub(crate) const WG_KEY_LEN: usize = 32;
+
+/// Noise IK pattern with WG primitives.
+pub(crate) const WG_NOISE_PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+
+/// WireGuard packet type codes (over UDP outer).
+pub(crate) const WG_TYPE_INITIATION: u8 = 1;
+pub(crate) const WG_TYPE_RESPONSE: u8 = 2;
+pub(crate) const WG_TYPE_COOKIE: u8 = 3;
+pub(crate) const WG_TYPE_DATA: u8 = 4;
+
+/// Poly1305 authentication tag length.
+pub(crate) const POLY1305_TAG_LEN: usize = 16;
+
+/// Transport data header on the wire:
+///   - type        u8  = 4
+///   - reserved    [u8; 3]
+///   - receiver_id u32 (little-endian)
+///   - counter     u64 (little-endian)
+pub(crate) const WG_DATA_HEADER_LEN: usize = 1 + 3 + 4 + 8;
+
+/// Total per-packet WG overhead for IPv4 outer:
+///   outer IP (20) + UDP (8) + WG data header (16) + Poly1305 tag (16).
+pub(crate) const WG_OVERHEAD_V4: usize = 20 + 8 + WG_DATA_HEADER_LEN + POLY1305_TAG_LEN;
+
+/// Total per-packet WG overhead for IPv6 outer.
+pub(crate) const WG_OVERHEAD_V6: usize = 40 + 8 + WG_DATA_HEADER_LEN + POLY1305_TAG_LEN;

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -18,6 +18,13 @@
 //! global type web. The integration PR will add a thin adapter
 //! layer that bridges the engine API to the dispatch/poll types.
 
+// TODO(#1499 r4 / integration PR): tighten this to per-item
+// `#[allow(dead_code)]` once tx/dispatch.rs and poll_descriptor.rs
+// consume the engine API. The module-wide allow exists because the
+// engine surface is intentionally complete-but-unused in this PR;
+// the integration PR will exercise most of it and the remaining
+// dead symbols (e.g. cookie-message helpers) can be allow-listed
+// individually.
 #![allow(dead_code)] // Most of this module is not yet wired into the hot path.
 
 pub(crate) mod allowed_ips;
@@ -35,7 +42,8 @@ pub(crate) mod session;
 mod tests;
 
 pub(crate) use engine::{
-    DecapError, DecapOutcome, EncapError, EncapOutcome, WgEngine, WgEngineConfig, WgPeerConfig,
+    DecapError, DecapOutcome, EncapError, EncapOutcome, InstallSessionError, WgEngine,
+    WgEngineConfig, WgPeerConfig,
 };
 pub(crate) use scratch::WgWorkerScratch;
 

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -61,6 +61,19 @@ pub(crate) const WG_NOISE_PATTERN: &str = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s
 /// WG handshake behavior.
 pub(crate) const WG_ZERO_PSK: [u8; WG_KEY_LEN] = [0u8; WG_KEY_LEN];
 
+/// WireGuard protocol identifier mixed into the Noise prologue so the
+/// initial transcript hash matches the kernel WireGuard / wireguard-go
+/// implementations on the wire. See the WireGuard protocol page
+/// (https://www.wireguard.com/protocol/) and the kernel source at
+/// `drivers/net/wireguard/noise.c` (search for "WireGuard v1 zx2c4").
+///
+/// The bytes are the ASCII string "WireGuard v1 zx2c4 Jason@zx2c4.com"
+/// (34 bytes, no trailing NUL — the kernel passes the same string
+/// through `BLAKE2s` without terminator). Without this prologue the
+/// Noise hash diverges from byte one and this engine is not
+/// interoperable with any real WG peer.
+pub(crate) const WG_PROTOCOL_ID_BYTES: &[u8] = b"WireGuard v1 zx2c4 Jason@zx2c4.com";
+
 /// WireGuard packet type codes (over UDP outer).
 pub(crate) const WG_TYPE_INITIATION: u8 = 1;
 pub(crate) const WG_TYPE_RESPONSE: u8 = 2;

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -35,15 +35,23 @@ pub(crate) mod session;
 mod tests;
 
 pub(crate) use engine::{
-    EncapError, EncapOutcome, DecapError, DecapOutcome, WgEngine, WgEngineConfig, WgPeerConfig,
+    DecapError, DecapOutcome, EncapError, EncapOutcome, WgEngine, WgEngineConfig, WgPeerConfig,
 };
 pub(crate) use scratch::WgWorkerScratch;
 
 /// X25519 public/private key length (bytes).
 pub(crate) const WG_KEY_LEN: usize = 32;
 
-/// Noise IK pattern with WG primitives.
-pub(crate) const WG_NOISE_PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+/// Noise IKpsk2 pattern with WG primitives.
+///
+/// WireGuard always uses IKpsk2. When no explicit PSK is configured,
+/// the protocol still mixes an all-zero 32-byte PSK in the `psk2`
+/// step.
+pub(crate) const WG_NOISE_PATTERN: &str = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+
+/// All-zero PSK used for the standard "no explicit PSK configured"
+/// WG handshake behavior.
+pub(crate) const WG_ZERO_PSK: [u8; WG_KEY_LEN] = [0u8; WG_KEY_LEN];
 
 /// WireGuard packet type codes (over UDP outer).
 pub(crate) const WG_TYPE_INITIATION: u8 = 1;

--- a/userspace-dp/src/afxdp/wg/mss.rs
+++ b/userspace-dp/src/afxdp/wg/mss.rs
@@ -1,0 +1,118 @@
+//! WireGuard MSS-clamp arithmetic.
+//!
+//! Lives separately from `forwarding/mod.rs::native_gre_tcp_mss`
+//! because the byte overhead differs from GRE and because reusing
+//! the GRE function (as PR #1492 did) was a 48-byte error.
+//!
+//! Per-packet overhead, end-to-end, from inner-TCP payload back
+//! out to the wire:
+//!
+//! ```text
+//!   inner TCP header      20
+//!   inner IPv4 header     20    (or 40 for v6)
+//!   ----------------
+//!   inner IP packet       40 (v4) / 60 (v6)
+//!
+//!   WG data record:
+//!     type+reserved        4
+//!     receiver_index       4
+//!     counter              8
+//!     Poly1305 tag        16
+//!   ----------------
+//!   WG transport         32
+//!
+//!   outer UDP             8
+//!   outer IP             20 (v4) / 40 (v6)
+//!   ----------------
+//!   outer encap          28 (v4) / 48 (v6)
+//! ```
+//!
+//! Maximum permitted inner-TCP MSS at MTU `M` for an IPv4 outer
+//! tunnel carrying an IPv4 inner TCP segment:
+//!
+//! ```text
+//!   max_inner_tcp_payload = M - outer_encap_v4 - wg_transport
+//!                             - inner_ip_v4 - inner_tcp_header
+//!                         = M - 28 - 32 - 20 - 20
+//!                         = M - 100
+//! ```
+//!
+//! For a 1500-byte outer link MTU, this gives MSS = 1400. (Compare
+//! to vanilla TCP-over-Ethernet at MSS = 1460 — the 60-byte delta
+//! is the WG + outer-IP+UDP overhead.)
+
+use super::{WG_OVERHEAD_V4, WG_OVERHEAD_V6};
+
+/// Inner-TCP MSS for the given outer-link MTU and inner+outer IP
+/// families. Returns 0 if `mtu` is too small to accommodate any
+/// inner TCP payload (in which case the caller MUST NOT advertise
+/// the MSS — leave the TCP option as-is).
+///
+/// `outer_family` is one of `libc::AF_INET` or `libc::AF_INET6`;
+/// `inner_family` ditto. The cross-family combos (v4-inner in
+/// v6-outer, etc.) are valid: the WG inner payload is an IP packet
+/// of whichever family the originator chose.
+pub(crate) fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u16 {
+    let outer_overhead = match outer_family {
+        x if x == libc::AF_INET => WG_OVERHEAD_V4,
+        x if x == libc::AF_INET6 => WG_OVERHEAD_V6,
+        _ => return 0,
+    };
+    let inner_ip_header = match inner_family {
+        x if x == libc::AF_INET => 20usize,
+        x if x == libc::AF_INET6 => 40usize,
+        _ => return 0,
+    };
+    let inner_tcp_header = 20usize;
+    mtu.checked_sub(outer_overhead + inner_ip_header + inner_tcp_header)
+        .and_then(|n| u16::try_from(n).ok())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod mss_tests {
+    use super::*;
+
+    // The numbers below come from the table at the top of this file.
+    // If they change, the table is the source of truth — update it
+    // first.
+
+    #[test]
+    fn v4_outer_v4_inner_1500_mtu() {
+        // 1500 - 60 (outer encap+WG) - 20 (inner IPv4) - 20 (TCP) = 1400.
+        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1400);
+    }
+
+    #[test]
+    fn v6_outer_v4_inner_1500_mtu() {
+        // 1500 - 80 (outer encap+WG) - 20 (inner IPv4) - 20 (TCP) = 1380.
+        assert_eq!(wg_tcp_mss(libc::AF_INET6, libc::AF_INET, 1500), 1380);
+    }
+
+    #[test]
+    fn v4_outer_v6_inner_1500_mtu() {
+        // 1500 - 60 - 40 (inner IPv6) - 20 (TCP) = 1380.
+        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET6, 1500), 1380);
+    }
+
+    #[test]
+    fn under_minimum_mtu_returns_zero() {
+        // 60-byte outer + 40-byte inner IP+TCP = 100 bytes minimum.
+        // An MTU of 50 cannot carry any inner TCP payload.
+        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 50), 0);
+    }
+
+    #[test]
+    fn unknown_family_returns_zero() {
+        assert_eq!(wg_tcp_mss(99, libc::AF_INET, 1500), 0);
+        assert_eq!(wg_tcp_mss(libc::AF_INET, 99, 1500), 0);
+    }
+
+    #[test]
+    fn matches_byte_breakdown_constant() {
+        // Cross-check: the IPv4-outer overhead must equal the
+        // constants used by the framing code.
+        assert_eq!(WG_OVERHEAD_V4, 60);
+        assert_eq!(WG_OVERHEAD_V6, 80);
+    }
+}

--- a/userspace-dp/src/afxdp/wg/mss.rs
+++ b/userspace-dp/src/afxdp/wg/mss.rs
@@ -17,9 +17,10 @@
 //!     type+reserved        4
 //!     receiver_index       4
 //!     counter              8
+//!     §5.4.6 padding       0..15  (round inner up to 16-byte multiple)
 //!     Poly1305 tag        16
 //!   ----------------
-//!   WG transport         32
+//!   WG transport         32..47
 //!
 //!   outer UDP             8
 //!   outer IP             20 (v4) / 40 (v6)
@@ -28,20 +29,36 @@
 //! ```
 //!
 //! Maximum permitted inner-TCP MSS at MTU `M` for an IPv4 outer
-//! tunnel carrying an IPv4 inner TCP segment:
+//! tunnel carrying an IPv4 inner TCP segment, accounting for the
+//! worst-case 15 bytes of WG §5.4.6 padding that the encap side
+//! will add to a non-16-aligned inner length:
 //!
 //! ```text
 //!   max_inner_tcp_payload = M - outer_encap_v4 - wg_transport
+//!                             - max_padding
 //!                             - inner_ip_v4 - inner_tcp_header
-//!                         = M - 28 - 32 - 20 - 20
-//!                         = M - 100
+//!                         = M - 28 - 32 - 15 - 20 - 20
+//!                         = M - 115
 //! ```
 //!
-//! For a 1500-byte outer link MTU, this gives MSS = 1400. (Compare
-//! to vanilla TCP-over-Ethernet at MSS = 1460 — the 60-byte delta
-//! is the WG + outer-IP+UDP overhead.)
+//! For a 1500-byte outer link MTU, this gives MSS = 1385. (Compare
+//! to vanilla TCP-over-Ethernet at MSS = 1460 — the 75-byte delta
+//! is the WG + padding + outer-IP+UDP overhead.)
+//!
+//! The 15-byte subtraction is conservative: a real inner segment
+//! of MSS bytes will need padding only if the resulting inner IP
+//! packet length is not a multiple of 16. Subtracting the worst
+//! case keeps the outer frame at or under MTU regardless of how
+//! the inner payload length lands, which is the property a sender
+//! MUST be able to advertise. Carrying tight per-packet math here
+//! would require knowing the exact inner-IP+TCP+payload length at
+//! TCP-option-rewrite time, which we don't.
 
 use super::{WG_OVERHEAD_V4, WG_OVERHEAD_V6};
+
+/// Worst-case bytes of WG §5.4.6 padding (round inner-IP packet up
+/// to a 16-byte multiple before AEAD).
+const WG_MAX_PADDING: usize = 15;
 
 /// Inner-TCP MSS for the given outer-link MTU and inner+outer IP
 /// families. Returns 0 if `mtu` is too small to accommodate any
@@ -52,6 +69,14 @@ use super::{WG_OVERHEAD_V4, WG_OVERHEAD_V6};
 /// `inner_family` ditto. The cross-family combos (v4-inner in
 /// v6-outer, etc.) are valid: the WG inner payload is an IP packet
 /// of whichever family the originator chose.
+///
+/// The returned MSS accounts for the worst-case 15 bytes of WG
+/// §5.4.6 transport-padding that the encap side may add to align
+/// the inner-IP packet length to a 16-byte multiple — see the
+/// module-level doc for the byte-by-byte derivation. The sender
+/// advertising this MSS will never produce an outer frame that
+/// exceeds `mtu`, regardless of how the inner segment's total
+/// length aligns modulo 16.
 pub(crate) fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u16 {
     let outer_overhead = match outer_family {
         x if x == libc::AF_INET => WG_OVERHEAD_V4,
@@ -64,7 +89,7 @@ pub(crate) fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u1
         _ => return 0,
     };
     let inner_tcp_header = 20usize;
-    mtu.checked_sub(outer_overhead + inner_ip_header + inner_tcp_header)
+    mtu.checked_sub(outer_overhead + WG_MAX_PADDING + inner_ip_header + inner_tcp_header)
         .and_then(|n| u16::try_from(n).ok())
         .unwrap_or(0)
 }
@@ -79,26 +104,67 @@ mod mss_tests {
 
     #[test]
     fn v4_outer_v4_inner_1500_mtu() {
-        // 1500 - 60 (outer encap+WG) - 20 (inner IPv4) - 20 (TCP) = 1400.
-        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1400);
+        // 1500 - 60 (outer encap+WG) - 15 (worst-case padding)
+        //      - 20 (inner IPv4) - 20 (TCP) = 1385.
+        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1385);
     }
 
     #[test]
     fn v6_outer_v4_inner_1500_mtu() {
-        // 1500 - 80 (outer encap+WG) - 20 (inner IPv4) - 20 (TCP) = 1380.
-        assert_eq!(wg_tcp_mss(libc::AF_INET6, libc::AF_INET, 1500), 1380);
+        // 1500 - 80 (outer encap+WG) - 15 (worst-case padding)
+        //      - 20 (inner IPv4) - 20 (TCP) = 1365.
+        assert_eq!(wg_tcp_mss(libc::AF_INET6, libc::AF_INET, 1500), 1365);
     }
 
     #[test]
     fn v4_outer_v6_inner_1500_mtu() {
-        // 1500 - 60 - 40 (inner IPv6) - 20 (TCP) = 1380.
-        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET6, 1500), 1380);
+        // 1500 - 60 - 15 (worst-case padding) - 40 (inner IPv6) - 20 (TCP) = 1365.
+        assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET6, 1500), 1365);
+    }
+
+    #[test]
+    fn padded_inner_never_exceeds_mtu() {
+        // Property check: at MSS, the worst-case padded inner IP
+        // packet plus WG transport plus outer encap must fit in
+        // the MTU. This is the contract that justifies the
+        // WG_MAX_PADDING subtraction in the MSS formula.
+        for mtu in [576usize, 1280, 1500, 9000] {
+            for (outer, inner, outer_enc, inner_ip) in [
+                (libc::AF_INET, libc::AF_INET, WG_OVERHEAD_V4, 20),
+                (libc::AF_INET, libc::AF_INET6, WG_OVERHEAD_V4, 40),
+                (libc::AF_INET6, libc::AF_INET, WG_OVERHEAD_V6, 20),
+                (libc::AF_INET6, libc::AF_INET6, WG_OVERHEAD_V6, 40),
+            ] {
+                let mss = wg_tcp_mss(outer, inner, mtu) as usize;
+                if mss == 0 {
+                    continue;
+                }
+                // Worst-case inner IP packet at MSS, with the padding
+                // rounded up to a 16-byte multiple.
+                let inner_total = inner_ip + 20 + mss;
+                let padded = (inner_total + 15) & !15;
+                // padded inner + WG transport overhead (data header
+                // 16 + tag 16 = 32 already inside outer_enc - outer IP
+                // and UDP, so we add 0) — outer_enc already includes
+                // WG_DATA_HEADER_LEN + POLY1305_TAG_LEN per mod.rs.
+                let outer_total = outer_enc + (padded - inner_total) + inner_total;
+                // The above simplifies to outer_enc + padded; assert
+                // it directly to be unambiguous.
+                assert_eq!(outer_total, outer_enc + padded);
+                assert!(
+                    outer_enc + padded <= mtu,
+                    "MTU {mtu} outer={outer} inner={inner}: outer_enc {outer_enc} + padded {padded} = {} > MTU",
+                    outer_enc + padded
+                );
+            }
+        }
     }
 
     #[test]
     fn under_minimum_mtu_returns_zero() {
-        // 60-byte outer + 40-byte inner IP+TCP = 100 bytes minimum.
-        // An MTU of 50 cannot carry any inner TCP payload.
+        // 60-byte outer + 15-byte padding + 40-byte inner IP+TCP =
+        // 115 bytes minimum. An MTU of 50 cannot carry any inner
+        // TCP payload.
         assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 50), 0);
     }
 

--- a/userspace-dp/src/afxdp/wg/outer.rs
+++ b/userspace-dp/src/afxdp/wg/outer.rs
@@ -1,0 +1,218 @@
+//! Outer L2 + IPv4 + UDP header construction for WG encap.
+//!
+//! Scope: IPv4 outer only in this PR. The framing module is
+//! family-agnostic but the outer-header builder is not — adding
+//! v6 outer is a follow-up.
+//!
+//! All builders write into a caller-provided slice. No allocations.
+
+use std::net::Ipv4Addr;
+
+/// Length of an outer L2 header with optional 802.1Q tag.
+#[inline]
+pub(crate) fn outer_l2_len(vlan_id: u16) -> usize {
+    if vlan_id != 0 { 18 } else { 14 }
+}
+
+/// Write the outer Ethernet header (with optional 802.1Q tag) into
+/// `out`. `ethertype` should be 0x0800 for IPv4 (this PR's only
+/// supported outer).
+///
+/// Returns the number of bytes written. Returns `None` if the slice
+/// is too short.
+pub(crate) fn write_outer_eth(
+    out: &mut [u8],
+    dst_mac: [u8; 6],
+    src_mac: [u8; 6],
+    vlan_id: u16,
+    ethertype: u16,
+) -> Option<usize> {
+    let len = outer_l2_len(vlan_id);
+    let hdr = out.get_mut(..len)?;
+    hdr[0..6].copy_from_slice(&dst_mac);
+    hdr[6..12].copy_from_slice(&src_mac);
+    if vlan_id != 0 {
+        // 802.1Q TPID 0x8100, then PCP=0 DEI=0 VID=vlan_id, then
+        // inner ethertype.
+        hdr[12..14].copy_from_slice(&0x8100u16.to_be_bytes());
+        let tci = vlan_id & 0x0FFF;
+        hdr[14..16].copy_from_slice(&tci.to_be_bytes());
+        hdr[16..18].copy_from_slice(&ethertype.to_be_bytes());
+    } else {
+        hdr[12..14].copy_from_slice(&ethertype.to_be_bytes());
+    }
+    Some(len)
+}
+
+/// Write the outer IPv4 + UDP header for a WG-encapsulated payload.
+///
+/// `payload_len` is the length of the WG transport record
+/// (header + ciphertext + tag) that follows the UDP header.
+///
+/// The IPv4 checksum is computed over the IPv4 header only;
+/// per RFC 768 the UDP checksum on IPv4 is optional. We set it to
+/// zero (skip) for now — UDP checksum offload semantics differ
+/// across NICs and we want a known-baseline behavior. A future
+/// PR can wire it through if needed.
+pub(crate) fn write_outer_ipv4_udp(
+    out: &mut [u8],
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    tos: u8,
+    ttl: u8,
+    payload_len: usize,
+) -> Option<usize> {
+    const IP_HDR_LEN: usize = 20;
+    const UDP_HDR_LEN: usize = 8;
+    let total = IP_HDR_LEN + UDP_HDR_LEN + payload_len;
+    let total_len = u16::try_from(total).ok()?;
+    let udp_len = u16::try_from(UDP_HDR_LEN + payload_len).ok()?;
+    let hdr = out.get_mut(..IP_HDR_LEN + UDP_HDR_LEN)?;
+    // IPv4 header.
+    hdr[0] = 0x45;
+    hdr[1] = tos;
+    hdr[2..4].copy_from_slice(&total_len.to_be_bytes());
+    hdr[4..6].copy_from_slice(&0u16.to_be_bytes()); // ID = 0
+    hdr[6..8].copy_from_slice(&0u16.to_be_bytes()); // flags / frag
+    hdr[8] = if ttl == 0 { 64 } else { ttl };
+    hdr[9] = 17; // UDP
+    hdr[10..12].copy_from_slice(&[0, 0]); // checksum placeholder
+    hdr[12..16].copy_from_slice(&src.octets());
+    hdr[16..20].copy_from_slice(&dst.octets());
+    let ip_csum = checksum_be(&hdr[..IP_HDR_LEN]);
+    hdr[10..12].copy_from_slice(&ip_csum.to_be_bytes());
+    // UDP header.
+    hdr[20..22].copy_from_slice(&src_port.to_be_bytes());
+    hdr[22..24].copy_from_slice(&dst_port.to_be_bytes());
+    hdr[24..26].copy_from_slice(&udp_len.to_be_bytes());
+    hdr[26..28].copy_from_slice(&0u16.to_be_bytes()); // checksum = 0
+    Some(IP_HDR_LEN + UDP_HDR_LEN)
+}
+
+/// 16-bit ones-complement Internet checksum, returned in host-byte
+/// order ready to splat into a network-byte-order field. Same shape
+/// as `gre.rs::checksum16` but local — keeping the WG module free
+/// of dependencies on the rest of `afxdp/`.
+fn checksum_be(bytes: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        sum = sum.wrapping_add(u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32);
+        i += 2;
+    }
+    if i < bytes.len() {
+        sum = sum.wrapping_add((bytes[i] as u32) << 8);
+    }
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+#[cfg(test)]
+mod outer_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn outer_eth_no_vlan() {
+        let mut out = [0u8; 32];
+        let n = write_outer_eth(
+            &mut out,
+            [1, 2, 3, 4, 5, 6],
+            [7, 8, 9, 10, 11, 12],
+            0,
+            0x0800,
+        )
+        .unwrap();
+        assert_eq!(n, 14);
+        assert_eq!(&out[0..6], &[1, 2, 3, 4, 5, 6]);
+        assert_eq!(&out[6..12], &[7, 8, 9, 10, 11, 12]);
+        assert_eq!(&out[12..14], &[0x08, 0x00]);
+    }
+
+    #[test]
+    fn outer_eth_with_vlan() {
+        // VLAN-safe encap was one of the #1492 misses. Verify the
+        // 802.1Q layout is correct: TPID, then PCP/VID, then the
+        // inner ethertype.
+        let mut out = [0u8; 32];
+        let n = write_outer_eth(
+            &mut out,
+            [0; 6],
+            [0; 6],
+            0x123, // VID 0x123
+            0x0800,
+        )
+        .unwrap();
+        assert_eq!(n, 18);
+        assert_eq!(&out[12..14], &[0x81, 0x00]);
+        assert_eq!(&out[14..16], &[0x01, 0x23]);
+        assert_eq!(&out[16..18], &[0x08, 0x00]);
+    }
+
+    #[test]
+    fn ipv4_udp_header_layout() {
+        let mut out = [0u8; 40];
+        let n = write_outer_ipv4_udp(
+            &mut out,
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+            51820,
+            51820,
+            0,
+            64,
+            100,
+        )
+        .unwrap();
+        assert_eq!(n, 28);
+        assert_eq!(out[0], 0x45);
+        // Total length = 20 + 8 + 100 = 128.
+        assert_eq!(u16::from_be_bytes([out[2], out[3]]), 128);
+        assert_eq!(out[8], 64); // TTL
+        assert_eq!(out[9], 17); // UDP
+        // UDP length = 8 + 100 = 108
+        assert_eq!(u16::from_be_bytes([out[24], out[25]]), 108);
+    }
+
+    #[test]
+    fn ipv4_checksum_is_correct() {
+        // Round-trip: the checksum field is set such that a fresh
+        // checksum over the full header (with the checksum present)
+        // is zero. This is the standard self-check for an IPv4
+        // header's correctness.
+        let mut out = [0u8; 28];
+        write_outer_ipv4_udp(
+            &mut out,
+            Ipv4Addr::new(192, 0, 2, 1),
+            Ipv4Addr::new(198, 51, 100, 1),
+            12345,
+            51820,
+            0xb8, // EF
+            64,
+            500,
+        )
+        .unwrap();
+        let cs = checksum_be(&out[..20]);
+        assert_eq!(cs, 0, "header self-check failed (cs={:#06x})", cs);
+    }
+
+    #[test]
+    fn tos_is_threaded_through() {
+        let mut out = [0u8; 28];
+        write_outer_ipv4_udp(
+            &mut out,
+            Ipv4Addr::new(0, 0, 0, 0),
+            Ipv4Addr::new(0, 0, 0, 0),
+            0,
+            0,
+            0xb8, // EF (DSCP=46 << 2)
+            64,
+            0,
+        )
+        .unwrap();
+        assert_eq!(out[1], 0xb8);
+    }
+}

--- a/userspace-dp/src/afxdp/wg/outer.rs
+++ b/userspace-dp/src/afxdp/wg/outer.rs
@@ -52,8 +52,21 @@ pub(crate) fn write_outer_eth(
 /// The IPv4 checksum is computed over the IPv4 header only;
 /// per RFC 768 the UDP checksum on IPv4 is optional. We set it to
 /// zero (skip) for now — UDP checksum offload semantics differ
-/// across NICs and we want a known-baseline behavior. A future
-/// PR can wire it through if needed.
+/// across NICs and we want a known-baseline behavior.
+///
+/// TODO(#1499 r4 / udp-checksum): kernel WG and wireguard-go emit a
+/// non-zero UDP checksum on IPv4. Some commercial firewalls and
+/// midboxes silently drop UDPv4 with cs=0. The integration PR
+/// should:
+///   - Either compute the UDP checksum here (pseudo-header + UDP
+///     header + payload — ones-complement sum, like the IP checksum
+///     above), or
+///   - Delegate to a NIC TX checksum-offload flag in the AF_XDP
+///     descriptor and surface the option through `outer_l2_len` /
+///     metadata.
+/// This is the only outer-header gap that affects wire interop with
+/// commercial midboxes; tracked separately from the engine-correctness
+/// fixes in this PR.
 pub(crate) fn write_outer_ipv4_udp(
     out: &mut [u8],
     src: Ipv4Addr,

--- a/userspace-dp/src/afxdp/wg/peer.rs
+++ b/userspace-dp/src/afxdp/wg/peer.rs
@@ -14,12 +14,22 @@
 
 use super::session::WgSession;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, RwLock};
 
 #[derive(Debug)]
 pub(crate) struct Peer {
     pub(crate) pubkey: [u8; 32],
-    /// Optional outbound endpoint. None means responder-only.
+    /// Optional outbound endpoint. `None` means responder-only.
+    ///
+    /// Interior-mutable so `WgEngine::reconcile_peers` can update an
+    /// existing peer's endpoint when the control plane commits a new
+    /// config without forcing the engine to drop and recreate the
+    /// peer Arc (which would tear down active sessions). Codex final
+    /// pre-merge finding 3: prior revisions kept this immutable, so
+    /// config commits that changed the endpoint silently kept the
+    /// stale value once the integration layer started forwarding
+    /// config updates.
     ///
     /// TODO(#1499 r4 / roaming): the WG spec mandates that when a
     /// peer sends a valid authenticated packet from a new source
@@ -27,12 +37,14 @@ pub(crate) struct Peer {
     /// source so subsequent egress traffic follows the roam. This
     /// requires an `update_endpoint_if_verified` API on `Peer` and a
     /// call site in `WgEngine::try_decap` after the AllowedIPs gate
-    /// passes. Adding the API surface is mechanical; the data path
-    /// to invoke it requires the integration layer to thread the
-    /// outer UDP source through to the engine. Tracked as part of
-    /// the integration PR.
-    pub(crate) endpoint: Option<SocketAddr>,
+    /// passes. The interior mutability here makes that future
+    /// in-place update possible; the data path to invoke it requires
+    /// the integration layer to thread the outer UDP source through
+    /// to the engine. Tracked as part of the integration PR.
+    pub(crate) endpoint: RwLock<Option<SocketAddr>>,
     /// Optional keepalive interval in seconds (per WG: 0 = off).
+    /// Interior-mutable so config updates apply in place — see the
+    /// `endpoint` doc for the rationale.
     ///
     /// TODO(#1499 r4 / timers): paired with `REJECT_AFTER_TIME` and
     /// `REKEY_AFTER_TIME`, persistent-keepalive needs a timer-driven
@@ -45,7 +57,7 @@ pub(crate) struct Peer {
     /// exhaustion (2^64-2^13-1 packets ≈ 39 thousand years at
     /// 10 Gbps line rate, but the AEAD key never rotates without
     /// the timer).
-    pub(crate) persistent_keepalive: u16,
+    pub(crate) persistent_keepalive: AtomicU16,
     /// The current transport session, if a handshake has completed.
     /// RwLock because rekey is a slow-path replacement and the hot
     /// path only takes a read guard to encrypt/decrypt.
@@ -64,11 +76,34 @@ impl Peer {
     ) -> Self {
         Self {
             pubkey,
-            endpoint,
-            persistent_keepalive,
+            endpoint: RwLock::new(endpoint),
+            persistent_keepalive: AtomicU16::new(persistent_keepalive),
             current: RwLock::new(None),
             previous: RwLock::new(None),
         }
+    }
+
+    /// Update the mutable per-peer config fields in place. Called
+    /// from `WgEngine::reconcile_peers` when the new config snapshot
+    /// reuses an existing peer Arc (same pubkey). Keeping the peer
+    /// Arc alive preserves the (current, previous) session pair across
+    /// the commit; only the operator-facing fields shift.
+    pub(crate) fn update_config(&self, endpoint: Option<SocketAddr>, persistent_keepalive: u16) {
+        *self.endpoint.write().unwrap() = endpoint;
+        self.persistent_keepalive
+            .store(persistent_keepalive, Ordering::Relaxed);
+    }
+
+    /// Snapshot the current endpoint. Slow path only.
+    #[allow(dead_code)] // Consumed by integration PR + tests.
+    pub(crate) fn endpoint(&self) -> Option<SocketAddr> {
+        *self.endpoint.read().unwrap()
+    }
+
+    /// Snapshot the current persistent-keepalive interval. Slow path.
+    #[allow(dead_code)] // Consumed by integration PR + tests.
+    pub(crate) fn persistent_keepalive(&self) -> u16 {
+        self.persistent_keepalive.load(Ordering::Relaxed)
     }
 
     /// Replace `current` with `new`, moving the old current to

--- a/userspace-dp/src/afxdp/wg/peer.rs
+++ b/userspace-dp/src/afxdp/wg/peer.rs
@@ -20,8 +20,31 @@ use std::sync::{Arc, RwLock};
 pub(crate) struct Peer {
     pub(crate) pubkey: [u8; 32],
     /// Optional outbound endpoint. None means responder-only.
+    ///
+    /// TODO(#1499 r4 / roaming): the WG spec mandates that when a
+    /// peer sends a valid authenticated packet from a new source
+    /// IP:port the receiver MUST update its known endpoint to that
+    /// source so subsequent egress traffic follows the roam. This
+    /// requires an `update_endpoint_if_verified` API on `Peer` and a
+    /// call site in `WgEngine::try_decap` after the AllowedIPs gate
+    /// passes. Adding the API surface is mechanical; the data path
+    /// to invoke it requires the integration layer to thread the
+    /// outer UDP source through to the engine. Tracked as part of
+    /// the integration PR.
     pub(crate) endpoint: Option<SocketAddr>,
     /// Optional keepalive interval in seconds (per WG: 0 = off).
+    ///
+    /// TODO(#1499 r4 / timers): paired with `REJECT_AFTER_TIME` and
+    /// `REKEY_AFTER_TIME`, persistent-keepalive needs a timer-driven
+    /// slow-path worker. Currently the engine has zero time-based
+    /// state; the integration PR will introduce a coordinator-side
+    /// ticker that calls into the engine to (a) emit keepalive
+    /// records, (b) tear down sessions past REJECT_AFTER_TIME, and
+    /// (c) request rekey at REKEY_AFTER_TIME. Forward secrecy is
+    /// degraded until that timer ships — sessions live until counter
+    /// exhaustion (2^64-2^13-1 packets ≈ 39 thousand years at
+    /// 10 Gbps line rate, but the AEAD key never rotates without
+    /// the timer).
     pub(crate) persistent_keepalive: u16,
     /// The current transport session, if a handshake has completed.
     /// RwLock because rekey is a slow-path replacement and the hot

--- a/userspace-dp/src/afxdp/wg/peer.rs
+++ b/userspace-dp/src/afxdp/wg/peer.rs
@@ -50,12 +50,12 @@ impl Peer {
 
     /// Replace `current` with `new`, moving the old current to
     /// `previous`. Called from the slow-path handshake-complete code.
-    pub(crate) fn rotate_session(&self, new: Arc<WgSession>) {
+    pub(crate) fn rotate_session(&self, new: Arc<WgSession>) -> Option<Arc<WgSession>> {
         let old_current = {
             let mut cur = self.current.write().unwrap();
             cur.replace(new)
         };
         let mut prev = self.previous.write().unwrap();
-        *prev = old_current;
+        std::mem::replace(&mut *prev, old_current)
     }
 }

--- a/userspace-dp/src/afxdp/wg/peer.rs
+++ b/userspace-dp/src/afxdp/wg/peer.rs
@@ -1,0 +1,61 @@
+//! Per-peer state.
+//!
+//! A peer holds:
+//!   - Its static public key (the identity used by the engine table).
+//!   - Optionally an endpoint (UDP `IP:port`) for outbound handshake.
+//!   - Active and previous transport sessions (current + prior, to
+//!     allow in-flight rekey handover).
+//!
+//! Reconciliation: the engine rebuilds the peer set from the config
+//! snapshot whenever a new snapshot lands. Existing peer state is
+//! preserved across snapshots (same pubkey → same `Arc<Peer>`); the
+//! AllowedIPs trie is rebuilt fresh because its index space is
+//! tied to the snapshot.
+
+use super::session::WgSession;
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug)]
+pub(crate) struct Peer {
+    pub(crate) pubkey: [u8; 32],
+    /// Optional outbound endpoint. None means responder-only.
+    pub(crate) endpoint: Option<SocketAddr>,
+    /// Optional keepalive interval in seconds (per WG: 0 = off).
+    pub(crate) persistent_keepalive: u16,
+    /// The current transport session, if a handshake has completed.
+    /// RwLock because rekey is a slow-path replacement and the hot
+    /// path only takes a read guard to encrypt/decrypt.
+    pub(crate) current: RwLock<Option<Arc<WgSession>>>,
+    /// The previous transport session, retained across rekey so
+    /// in-flight ciphertexts decrypt successfully. Same lock
+    /// discipline as `current`.
+    pub(crate) previous: RwLock<Option<Arc<WgSession>>>,
+}
+
+impl Peer {
+    pub(crate) fn new(
+        pubkey: [u8; 32],
+        endpoint: Option<SocketAddr>,
+        persistent_keepalive: u16,
+    ) -> Self {
+        Self {
+            pubkey,
+            endpoint,
+            persistent_keepalive,
+            current: RwLock::new(None),
+            previous: RwLock::new(None),
+        }
+    }
+
+    /// Replace `current` with `new`, moving the old current to
+    /// `previous`. Called from the slow-path handshake-complete code.
+    pub(crate) fn rotate_session(&self, new: Arc<WgSession>) {
+        let old_current = {
+            let mut cur = self.current.write().unwrap();
+            cur.replace(new)
+        };
+        let mut prev = self.previous.write().unwrap();
+        *prev = old_current;
+    }
+}

--- a/userspace-dp/src/afxdp/wg/scratch.rs
+++ b/userspace-dp/src/afxdp/wg/scratch.rs
@@ -2,9 +2,12 @@
 //!
 //! No `vec![]` in encap/decap. The buffers are sized once at
 //! worker init and reused for every packet. Capacity is taken
-//! from the worker's max-frame size — currently `MAX_FRAME = 2048`
-//! across the dataplane; the WG module is told the size explicitly
-//! so it does not have to import the rest of `afxdp/`.
+//! from the worker's max-frame size — the UMEM frame is
+//! `UMEM_FRAME_SIZE` (4096) in `afxdp/mod.rs:175`; the WG module
+//! takes the size as an explicit `max_frame: usize` parameter so it
+//! does not have to import the rest of `afxdp/`. The integration PR
+//! will wire `WgWorkerScratch::new(UMEM_FRAME_SIZE as usize)` (or a
+//! smaller worker-specific cap) from the dispatch side.
 
 use std::cell::RefCell;
 

--- a/userspace-dp/src/afxdp/wg/scratch.rs
+++ b/userspace-dp/src/afxdp/wg/scratch.rs
@@ -1,0 +1,60 @@
+//! Preallocated per-worker scratch buffers for the WG hot path.
+//!
+//! No `vec![]` in encap/decap. The buffers are sized once at
+//! worker init and reused for every packet. Capacity is taken
+//! from the worker's max-frame size — currently `MAX_FRAME = 2048`
+//! across the dataplane; the WG module is told the size explicitly
+//! so it does not have to import the rest of `afxdp/`.
+
+use std::cell::RefCell;
+
+/// One-per-worker scratch. Holds buffers used by `try_encap` and
+/// `try_decap`. The cells are entered exclusively per packet
+/// (worker is single-threaded inside its poll loop), so `RefCell`
+/// is sufficient and avoids any `unsafe`.
+pub(crate) struct WgWorkerScratch {
+    /// Output buffer for `try_encap`. Sized to `max_frame`.
+    pub(crate) encap_out: RefCell<Vec<u8>>,
+    /// Output buffer for `try_decap` (decrypted plaintext). Sized
+    /// to `max_frame` (decap output is strictly smaller than the
+    /// input, but a single sizing keeps the allocator quiet).
+    pub(crate) decap_out: RefCell<Vec<u8>>,
+}
+
+impl WgWorkerScratch {
+    pub(crate) fn new(max_frame: usize) -> Self {
+        Self {
+            encap_out: RefCell::new(vec![0u8; max_frame]),
+            decap_out: RefCell::new(vec![0u8; max_frame]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod scratch_tests {
+    use super::*;
+
+    #[test]
+    fn sizes_match_max_frame() {
+        let s = WgWorkerScratch::new(2048);
+        assert_eq!(s.encap_out.borrow().len(), 2048);
+        assert_eq!(s.decap_out.borrow().len(), 2048);
+    }
+
+    #[test]
+    fn reuse_does_not_reallocate() {
+        // The contract is that we never reallocate. We verify by
+        // capturing the buffer's pointer and checking it after a
+        // sequence of in-place writes — if the Vec ever grew via
+        // a reallocation, the pointer would change.
+        let s = WgWorkerScratch::new(1500);
+        let initial_ptr = s.encap_out.borrow().as_ptr();
+        for _ in 0..32 {
+            let mut buf = s.encap_out.borrow_mut();
+            buf[0] = 0xaa;
+            buf[1499] = 0xbb;
+        }
+        let after_ptr = s.encap_out.borrow().as_ptr();
+        assert_eq!(initial_ptr, after_ptr);
+    }
+}

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -25,7 +25,20 @@ pub(crate) const REPLAY_WINDOW: u64 = 64;
 ///
 /// Per the protocol, a session must stop encrypting after this many
 /// transport messages and rekey.
-pub(crate) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1u64 << 13) - 1;
+pub(crate) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1u64 << 13);
+
+#[inline]
+fn reserve_next_counter(counter: &AtomicU64) -> Option<u64> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            if current >= REJECT_AFTER_MESSAGES {
+                None
+            } else {
+                Some(current + 1)
+            }
+        })
+        .ok()
+}
 
 /// A live, post-handshake WG transport session.
 ///
@@ -42,9 +55,7 @@ pub(crate) struct WgSession {
     /// Receiver index that *we* put in the WG data header when
     /// sending to the peer. Peer-chosen at handshake time.
     pub(crate) peer_index: u32,
-    /// Monotonic outbound counter. We are the only writer (the
-    /// worker that owns this session for egress), so a single
-    /// fetch_add is sufficient.
+    /// Monotonic outbound counter.
     pub(crate) tx_counter: AtomicU64,
     /// Replay tracker for inbound packets.
     pub(crate) replay: Mutex<ReplayState>,
@@ -85,11 +96,7 @@ impl WgSession {
     /// Atomically reserve the next outbound counter value.
     #[inline]
     pub(crate) fn next_tx_counter(&self) -> Option<u64> {
-        let counter = self.tx_counter.fetch_add(1, Ordering::Relaxed);
-        if counter > REJECT_AFTER_MESSAGES {
-            return None;
-        }
-        Some(counter)
+        reserve_next_counter(&self.tx_counter)
     }
 }
 
@@ -117,8 +124,11 @@ pub(crate) struct ReplayState {
 impl ReplayState {
     /// Cheap pre-crypto reject for trivially stale counters.
     ///
-    /// This never rejects in-window candidates, so it is safe to run
-    /// before AEAD without creating false drops.
+    /// This never rejects in-window candidates for the current replay
+    /// state snapshot, so it is safe to run before AEAD without
+    /// creating false drops. Under concurrent decap another packet may
+    /// advance `highest` between this check and post-decrypt update,
+    /// so this is a best-effort CPU guard rather than a hard guarantee.
     #[inline]
     pub(crate) fn definitely_out_of_window(&self, c: u64) -> bool {
         self.started && c.saturating_add(REPLAY_WINDOW) <= self.highest
@@ -260,5 +270,22 @@ mod session_tests {
         assert_eq!(r.check_and_update(1000), ReplayDecision::Accept);
         assert!(!r.definitely_out_of_window(937));
         assert!(r.definitely_out_of_window(936));
+    }
+
+    #[test]
+    fn reject_after_messages_constant_matches_wireguard_spec() {
+        assert_eq!(REJECT_AFTER_MESSAGES, 0xffff_ffff_ffff_dfff);
+    }
+
+    #[test]
+    fn tx_counter_stops_at_reject_after_messages_without_advancing() {
+        let counter = AtomicU64::new(REJECT_AFTER_MESSAGES - 1);
+        assert_eq!(
+            reserve_next_counter(&counter),
+            Some(REJECT_AFTER_MESSAGES - 1)
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), REJECT_AFTER_MESSAGES);
+        assert_eq!(reserve_next_counter(&counter), None);
+        assert_eq!(counter.load(Ordering::Relaxed), REJECT_AFTER_MESSAGES);
     }
 }

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -15,7 +15,7 @@
 
 use snow::StatelessTransportState;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Width of the replay window in packets. 64 is a tight fit for a
 /// single u64 bitmap; if we widen to 128 in the future we can swap
@@ -38,6 +38,17 @@ fn reserve_next_counter(counter: &AtomicU64) -> Option<u64> {
             }
         })
         .ok()
+}
+
+/// Which side of the handshake produced this session. Determines the
+/// initial value of `confirmed` (initiator-side sessions are confirmed
+/// at install because the initiator is the side that sends first;
+/// responder-side sessions start unconfirmed and must observe a valid
+/// inbound data record before egress is allowed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionRole {
+    Initiator,
+    Responder,
 }
 
 /// A live, post-handshake WG transport session.
@@ -63,6 +74,18 @@ pub(crate) struct WgSession {
     /// Stored so the engine can route demuxed packets back through
     /// the peer's AllowedIPs gate.
     pub(crate) peer_pubkey: [u8; 32],
+    /// WireGuard key-confirmation flag. WG spec: the responder MUST
+    /// NOT send encrypted transport data on a fresh session until it
+    /// has authenticated the initiator's first transport packet. This
+    /// is the anti-reflection / key-confirmation invariant that
+    /// prevents the responder from acting as a one-shot amplifier
+    /// against a forged handshake response. Initiator-role sessions
+    /// are installed with `confirmed = true` (the initiator is the
+    /// side that sends first by definition). Responder-role sessions
+    /// are installed with `confirmed = false`; egress through such a
+    /// session is treated as no-usable-session until a successful
+    /// inbound `read_message` flips the flag.
+    pub(crate) confirmed: AtomicBool,
 }
 
 impl std::fmt::Debug for WgSession {
@@ -77,12 +100,40 @@ impl std::fmt::Debug for WgSession {
 }
 
 impl WgSession {
+    /// Create a session in initiator role — confirmed at install
+    /// (the initiator is the side that sends first per the WG spec).
+    /// Existing callers used `WgSession::new`; that constructor maps
+    /// to this initiator behavior to preserve backward compatibility
+    /// for the in-tree tests that drive both sides through the
+    /// engine's slow path. Callers that handle a responder session
+    /// (after reading the initiator's first handshake message) MUST
+    /// use `new_with_role(SessionRole::Responder, ...)`.
     pub(crate) fn new(
         transport: StatelessTransportState,
         local_index: u32,
         peer_index: u32,
         peer_pubkey: [u8; 32],
     ) -> Self {
+        Self::new_with_role(
+            transport,
+            local_index,
+            peer_index,
+            peer_pubkey,
+            SessionRole::Initiator,
+        )
+    }
+
+    /// Create a session and record its role for key-confirmation
+    /// gating. See the `confirmed` field doc on `WgSession` for the
+    /// initiator-vs-responder contract.
+    pub(crate) fn new_with_role(
+        transport: StatelessTransportState,
+        local_index: u32,
+        peer_index: u32,
+        peer_pubkey: [u8; 32],
+        role: SessionRole,
+    ) -> Self {
+        let confirmed = matches!(role, SessionRole::Initiator);
         Self {
             transport,
             local_index,
@@ -90,6 +141,7 @@ impl WgSession {
             tx_counter: AtomicU64::new(0),
             replay: Mutex::new(ReplayState::default()),
             peer_pubkey,
+            confirmed: AtomicBool::new(confirmed),
         }
     }
 
@@ -97,6 +149,23 @@ impl WgSession {
     #[inline]
     pub(crate) fn next_tx_counter(&self) -> Option<u64> {
         reserve_next_counter(&self.tx_counter)
+    }
+
+    /// Returns true once the session has authenticated at least one
+    /// inbound transport packet. Initiator-role sessions return true
+    /// from install onward.
+    #[inline]
+    pub(crate) fn is_confirmed(&self) -> bool {
+        self.confirmed.load(Ordering::Acquire)
+    }
+
+    /// Mark the session as confirmed. Called from `try_decap` after a
+    /// successful AEAD authentication of an inbound transport record.
+    /// `Release` pairs with the `Acquire` load in `is_confirmed` so
+    /// any subsequent egress reader sees a `true` flag.
+    #[inline]
+    pub(crate) fn mark_confirmed(&self) {
+        self.confirmed.store(true, Ordering::Release);
     }
 }
 

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -21,6 +21,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// single u64 bitmap; if we widen to 128 in the future we can swap
 /// the type without touching the API.
 pub(crate) const REPLAY_WINDOW: u64 = 64;
+/// WireGuard reject-after-messages limit.
+///
+/// Per the protocol, a session must stop encrypting after this many
+/// transport messages and rekey.
+pub(crate) const REJECT_AFTER_MESSAGES: u64 = u64::MAX - (1u64 << 13) - 1;
 
 /// A live, post-handshake WG transport session.
 ///
@@ -79,8 +84,12 @@ impl WgSession {
 
     /// Atomically reserve the next outbound counter value.
     #[inline]
-    pub(crate) fn next_tx_counter(&self) -> u64 {
-        self.tx_counter.fetch_add(1, Ordering::Relaxed)
+    pub(crate) fn next_tx_counter(&self) -> Option<u64> {
+        let counter = self.tx_counter.fetch_add(1, Ordering::Relaxed);
+        if counter > REJECT_AFTER_MESSAGES {
+            return None;
+        }
+        Some(counter)
     }
 }
 
@@ -106,6 +115,15 @@ pub(crate) struct ReplayState {
 }
 
 impl ReplayState {
+    /// Cheap pre-crypto reject for trivially stale counters.
+    ///
+    /// This never rejects in-window candidates, so it is safe to run
+    /// before AEAD without creating false drops.
+    #[inline]
+    pub(crate) fn definitely_out_of_window(&self, c: u64) -> bool {
+        self.started && c.saturating_add(REPLAY_WINDOW) <= self.highest
+    }
+
     /// Check-and-update for inbound counter `c`. Returns
     /// `ReplayDecision::Accept` if the counter is fresh (and the
     /// window is updated atomically with the accept), or one of
@@ -234,5 +252,13 @@ mod session_tests {
         // One more step pushes 0 out: highest = 64, age = 64 = REPLAY_WINDOW.
         assert_eq!(r.check_and_update(64), ReplayDecision::Accept);
         assert_eq!(r.check_and_update(0), ReplayDecision::OutOfWindow);
+    }
+
+    #[test]
+    fn precheck_out_of_window_matches_window_width() {
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(1000), ReplayDecision::Accept);
+        assert!(!r.definitely_out_of_window(937));
+        assert!(r.definitely_out_of_window(936));
     }
 }

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -1,0 +1,238 @@
+//! WG transport session: snow `StatelessTransportState` plus a
+//! sliding-window replay tracker.
+//!
+//! The transport state is derived from a completed Noise IK
+//! handshake. snow's `StatelessTransportState` is `Sync` because
+//! it holds no mutable per-message state — the counter and the
+//! replay window are entirely the caller's responsibility, which is
+//! exactly what we want for AF_XDP worker integration.
+//!
+//! Replay window: RFC 6479-style 64-bit sliding bitmap. Single
+//! `Mutex` covers `(highest, bitmap)` — contention is bounded
+//! because we only ever decap from the worker that owns the binding
+//! the session was demuxed onto. Encap uses a separate `AtomicU64`
+//! counter because we are the sole producer.
+
+use snow::StatelessTransportState;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Width of the replay window in packets. 64 is a tight fit for a
+/// single u64 bitmap; if we widen to 128 in the future we can swap
+/// the type without touching the API.
+pub(crate) const REPLAY_WINDOW: u64 = 64;
+
+/// A live, post-handshake WG transport session.
+///
+/// Debug-impl is hand-rolled because snow's `StatelessTransportState`
+/// doesn't expose useful Debug (it would leak keys anyway).
+pub(crate) struct WgSession {
+    /// snow transport state. Stateless w.r.t. nonce — we drive the
+    /// counter ourselves on both directions.
+    pub(crate) transport: StatelessTransportState,
+    /// Receiver index that the *peer* will put in the WG data
+    /// header when sending to us. Locally chosen at handshake time.
+    /// Used for inbound demux: `(listen_port, local_index) → WgSession`.
+    pub(crate) local_index: u32,
+    /// Receiver index that *we* put in the WG data header when
+    /// sending to the peer. Peer-chosen at handshake time.
+    pub(crate) peer_index: u32,
+    /// Monotonic outbound counter. We are the only writer (the
+    /// worker that owns this session for egress), so a single
+    /// fetch_add is sufficient.
+    pub(crate) tx_counter: AtomicU64,
+    /// Replay tracker for inbound packets.
+    pub(crate) replay: Mutex<ReplayState>,
+    /// Identifier of the peer this session belongs to (peer pubkey).
+    /// Stored so the engine can route demuxed packets back through
+    /// the peer's AllowedIPs gate.
+    pub(crate) peer_pubkey: [u8; 32],
+}
+
+impl std::fmt::Debug for WgSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgSession")
+            .field("local_index", &self.local_index)
+            .field("peer_index", &self.peer_index)
+            .field("tx_counter", &self.tx_counter)
+            .field("peer_pubkey_first4", &&self.peer_pubkey[..4])
+            .finish_non_exhaustive()
+    }
+}
+
+impl WgSession {
+    pub(crate) fn new(
+        transport: StatelessTransportState,
+        local_index: u32,
+        peer_index: u32,
+        peer_pubkey: [u8; 32],
+    ) -> Self {
+        Self {
+            transport,
+            local_index,
+            peer_index,
+            tx_counter: AtomicU64::new(0),
+            replay: Mutex::new(ReplayState::default()),
+            peer_pubkey,
+        }
+    }
+
+    /// Atomically reserve the next outbound counter value.
+    #[inline]
+    pub(crate) fn next_tx_counter(&self) -> u64 {
+        self.tx_counter.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Sliding-window replay tracker. Tracks the most recent 64
+/// counters seen, anchored at `highest`.
+///
+/// State invariant after the first accepted counter: `bitmap` bit 0
+/// always corresponds to `highest`. A counter `c` is fresh iff
+///   - `c > highest`, OR
+///   - `highest - c < REPLAY_WINDOW` AND the corresponding bit is
+///     unset.
+///
+/// `started == false` means no counters have been seen yet, which
+/// is distinguishable from "the all-zero state happens to be the
+/// post-first-accept state for counter 0". Without this flag the
+/// `c == highest` arm would incorrectly accept the duplicate of
+/// counter 0 immediately after the first accept.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ReplayState {
+    pub(crate) highest: u64,
+    pub(crate) bitmap: u64,
+    pub(crate) started: bool,
+}
+
+impl ReplayState {
+    /// Check-and-update for inbound counter `c`. Returns
+    /// `ReplayDecision::Accept` if the counter is fresh (and the
+    /// window is updated atomically with the accept), or one of
+    /// the reject variants otherwise.
+    ///
+    /// Algorithm: RFC 6479 (anti-replay window). Worth reading the
+    /// RFC if you're changing this — the test suite covers the
+    /// in-order / repeat / out-of-window / gap-fill arms explicitly.
+    pub(crate) fn check_and_update(&mut self, c: u64) -> ReplayDecision {
+        if !self.started {
+            self.started = true;
+            self.highest = c;
+            self.bitmap = 1;
+            return ReplayDecision::Accept;
+        }
+        if c > self.highest {
+            // New high water mark — shift the bitmap left by the
+            // gap and set bit 0 for the newly-accepted counter.
+            let gap = c - self.highest;
+            if gap >= 64 {
+                self.bitmap = 1;
+            } else {
+                self.bitmap = (self.bitmap << gap) | 1;
+            }
+            self.highest = c;
+            ReplayDecision::Accept
+        } else {
+            // c <= highest: this is either a repeat of `highest`
+            // (which post-init is always already-seen because we
+            // marked bit 0 on accept) or a strictly older counter.
+            let age = self.highest - c;
+            if age >= REPLAY_WINDOW {
+                ReplayDecision::OutOfWindow
+            } else {
+                let mask = 1u64 << age;
+                if self.bitmap & mask != 0 {
+                    ReplayDecision::Repeat
+                } else {
+                    // In-window gap fill: accept and mark the bit.
+                    self.bitmap |= mask;
+                    ReplayDecision::Accept
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplayDecision {
+    Accept,
+    Repeat,
+    OutOfWindow,
+}
+
+#[cfg(test)]
+mod session_tests {
+    use super::*;
+
+    #[test]
+    fn in_order_accepts() {
+        let mut r = ReplayState::default();
+        for c in 0u64..200 {
+            assert_eq!(r.check_and_update(c), ReplayDecision::Accept, "c={}", c);
+        }
+    }
+
+    #[test]
+    fn exact_repeat_rejects() {
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(10), ReplayDecision::Accept);
+        // Replay of the same counter must be rejected as Repeat,
+        // not silently accepted as a no-op.
+        assert_eq!(r.check_and_update(10), ReplayDecision::Repeat);
+    }
+
+    #[test]
+    fn out_of_window_rejects() {
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(1000), ReplayDecision::Accept);
+        // Counter 1000 - 64 = 936 is exactly at the window edge;
+        // anything <= that is out-of-window.
+        assert_eq!(r.check_and_update(936), ReplayDecision::OutOfWindow);
+        assert_eq!(r.check_and_update(0), ReplayDecision::OutOfWindow);
+    }
+
+    #[test]
+    fn gap_fill_in_window_accepts() {
+        let mut r = ReplayState::default();
+        // Receive 0, 2, 4 — accept all. Then receive the gap-filled
+        // 1 and 3. WG explicitly allows in-window gap fill; this
+        // is the whole point of the sliding bitmap (NAT/reorder).
+        assert_eq!(r.check_and_update(0), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(2), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(4), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(1), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(3), ReplayDecision::Accept);
+        // But the gap fills themselves now repeat.
+        assert_eq!(r.check_and_update(1), ReplayDecision::Repeat);
+        assert_eq!(r.check_and_update(3), ReplayDecision::Repeat);
+    }
+
+    #[test]
+    fn jump_ahead_resets_bitmap() {
+        // Counter jumping forward by more than the window width
+        // resets the bitmap to "only the new counter seen".
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(10), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(1000), ReplayDecision::Accept);
+        // The old counter 10 is now far out of window.
+        assert_eq!(r.check_and_update(10), ReplayDecision::OutOfWindow);
+        // The new counter 1000 is at the head and must repeat-fail.
+        assert_eq!(r.check_and_update(1000), ReplayDecision::Repeat);
+    }
+
+    #[test]
+    fn window_edge_repeat() {
+        // The bit at the trailing edge of the window must reject a
+        // repeat. This is the most common off-by-one in replay
+        // window code.
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(0), ReplayDecision::Accept);
+        // Move the window so 0 is at the trailing edge but still
+        // in-window: highest = 63, age = 63 < 64.
+        assert_eq!(r.check_and_update(63), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(0), ReplayDecision::Repeat);
+        // One more step pushes 0 out: highest = 64, age = 64 = REPLAY_WINDOW.
+        assert_eq!(r.check_and_update(64), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(0), ReplayDecision::OutOfWindow);
+    }
+}

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -61,7 +61,12 @@ pub(crate) struct WgSession {
     pub(crate) transport: StatelessTransportState,
     /// Receiver index that the *peer* will put in the WG data
     /// header when sending to us. Locally chosen at handshake time.
-    /// Used for inbound demux: `(listen_port, local_index) → WgSession`.
+    /// Used for inbound demux: the engine's
+    /// `sessions_by_local_index: RwLock<FxHashMap<u32, Arc<WgSession>>>`
+    /// is keyed by `local_index` alone, not by `(listen_port,
+    /// local_index)`. Listen-port selection happens one layer up in
+    /// the integration PR's UDP-socket dispatch, before the record
+    /// reaches the engine.
     pub(crate) local_index: u32,
     /// Receiver index that *we* put in the WG data header when
     /// sending to the peer. Peer-chosen at handshake time.

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -146,11 +146,11 @@ fn handshake_completes_and_roundtrip_encap_decap() {
     let mut plain = [0u8; 2048];
     let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
     assert_eq!(dec.peer_pubkey, init_pub);
-    // Decrypted plaintext is the padded form. The first `inner.len()`
-    // bytes must equal the original inner packet; trailing bytes are
-    // zero padding.
-    assert_eq!(&plain[..inner.len()], &inner[..]);
-    assert!(plain[inner.len()..dec.len].iter().all(|&b| b == 0));
+    // `dec.len` is the un-padded inner-IP packet length read from
+    // the IPv4 `total_length` field. It must equal the original
+    // sent inner packet length, not the padded plaintext length.
+    assert_eq!(dec.len, inner.len());
+    assert_eq!(&plain[..dec.len], &inner[..]);
 }
 
 #[test]
@@ -381,11 +381,13 @@ fn outer_ipv4_tos_propagates_dscp() {
 
 #[test]
 fn mss_clamp_matches_byte_breakdown() {
-    // Sanity: 1500-byte outer MTU, v4-in-v4, MSS = 1400. See
-    // mss.rs for the byte-by-byte derivation. Repeated here in
-    // the integration tests because review-time errors on MSS
-    // math are the kind of bug that ships and silently fragments.
-    assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1400);
+    // Sanity: 1500-byte outer MTU, v4-in-v4, MSS = 1385. The 1385
+    // (vs the pre-padding-fix 1400) leaves room for the worst-case
+    // 15 bytes of WG §5.4.6 padding the encap side may add. See
+    // mss.rs for the byte-by-byte derivation. Repeated here in the
+    // integration tests because review-time errors on MSS math
+    // ship and silently fragment.
+    assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1385);
 }
 
 #[test]
@@ -444,11 +446,17 @@ fn transport_plaintext_is_padded_to_16_byte_multiple() {
             ciphertext_len, expected_padded,
             "padding mismatch at inner_len={inner_len}: got {ciphertext_len}, want {expected_padded}",
         );
-        // Roundtrip: decap and verify the original prefix survives.
+        // Roundtrip: decap returns the un-padded inner-IP length.
+        // The first `inner_len` bytes of `plain` must equal the
+        // original inner packet; `dec.len` must equal `inner_len`,
+        // NOT `expected_padded`.
         let mut plain = [0u8; 4096];
         let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
         assert_eq!(&plain[..inner_len], &inner[..]);
-        assert_eq!(dec.len, expected_padded);
+        assert_eq!(
+            dec.len, inner_len,
+            "DecapOutcome.len must be the inner-IP packet length, not the padded plaintext length",
+        );
     }
 }
 
@@ -471,6 +479,181 @@ fn decap_rejects_counter_at_reject_after_messages() {
     let mut plain = [0u8; 128];
     let err = resp_engine.try_decap(&wire[..32], &mut plain).unwrap_err();
     assert_eq!(err, DecapError::CounterRejectAfterMessages);
+}
+
+/// Cross-peer overlapping AllowedIPs MUST honor WG §5.4.6 global
+/// LPM cryptokey routing. If peer A owns `10.0.0.0/8` and peer B
+/// owns `10.1.1.0/24`, a packet authenticated by A with inner src
+/// `10.1.1.5` must be rejected — the global LPM resolves that
+/// address to B, not A. An earlier r4 revision used a per-peer
+/// "any prefix covers" check that wrongly accepted A's spoofed
+/// source; this regression test fails under that semantic.
+#[test]
+fn decap_lpm_rejects_spoofed_source_inside_more_specific_peer_prefix() {
+    let (init_priv, init_pub) = keypair();
+    let (peer_a_priv, peer_a_pub) = keypair();
+    let (peer_b_priv, peer_b_pub) = keypair();
+
+    // Initiator engine owns AllowedIPs for both peers: A=/8 (less
+    // specific) and B=/24 (more specific, inside A's prefix).
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![
+            WgPeerConfig {
+                pubkey: peer_a_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["10.0.0.0/8".parse().unwrap()],
+            },
+            WgPeerConfig {
+                pubkey: peer_b_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["10.1.1.0/24".parse().unwrap()],
+            },
+        ],
+    });
+    // Responder engines mirror that view from each peer's side.
+    let resp_a = WgEngine::new(WgEngineConfig {
+        local_private_key: peer_a_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/8".parse().unwrap()],
+        }],
+    });
+    let _resp_b = WgEngine::new(WgEngineConfig {
+        local_private_key: peer_b_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.1.1.0/24".parse().unwrap()],
+        }],
+    });
+
+    // We want to demonstrate: a packet that AUTHENTICATES under
+    // peer A's session (because A's session was used to encrypt)
+    // but whose inner src lies inside peer B's /24 must be
+    // rejected by the DECAP-side AllowedIPs gate. Drive the
+    // handshake init↔A, install sessions, and have A encrypt a
+    // packet with src `10.1.1.5`. The init engine must then
+    // verify on receive that the inner src doesn't belong to A.
+    let mut init_hs = init_engine.build_initiator_handshake(&peer_a_pub).unwrap();
+    let mut resp_hs = resp_a.build_responder_handshake().unwrap();
+    let mut buf = [0u8; 1024];
+    let mut sink = [0u8; 1024];
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+    let init_idx = 0x1111_aaaa;
+    let resp_idx = 0x2222_aaaa;
+    init_engine
+        .install_session(
+            &peer_a_pub,
+            Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_a_pub)),
+        )
+        .unwrap();
+    resp_a
+        .install_session(
+            &init_pub,
+            Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
+        )
+        .unwrap();
+
+    // A sends a packet with src 10.1.1.5 (inside B's /24, NOT
+    // authoritative for A under global LPM) to init_engine.
+    let inner = ipv4_packet(Ipv4Addr::new(10, 1, 1, 5), Ipv4Addr::new(10, 0, 0, 9));
+    let mut wire = [0u8; 2048];
+    let enc = resp_a.try_encap(&init_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    let err = init_engine
+        .try_decap(&wire[..enc.len], &mut plain)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        DecapError::AllowedIpsViolation,
+        "global LPM resolves 10.1.1.5 to peer B; A's /8 must NOT authorize that source"
+    );
+}
+
+/// On every post-AEAD error arm, `out[..n]` must be wiped before
+/// returning so the contract "on Err the caller MUST NOT inspect
+/// `out`" is structurally enforced. Earlier r4 revisions covered
+/// only 3 of 5 error arms; Codex r4 finding 3 / Gemini r4 finding F.
+#[test]
+fn decap_zeros_plaintext_on_allowed_ips_violation() {
+    // Set the AllowedIPs trie so the responder's view of the
+    // initiator covers `10.0.0.0/24` only. The initiator then
+    // sends with inner src `10.0.99.99` — authenticates, fails
+    // AllowedIPs gate, must return AllowedIpsViolation AND wipe.
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 99, 99), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    // Pre-fill `plain` with a recognizable pattern; the wipe must
+    // overwrite any decrypted bytes back to zero by the time we
+    // observe `plain` after the error return.
+    plain.fill(0xa5);
+    let err = resp_engine
+        .try_decap(&wire[..enc.len], &mut plain)
+        .unwrap_err();
+    assert_eq!(err, DecapError::AllowedIpsViolation);
+    // The plaintext-bearing region — the first `padded_inner_len`
+    // bytes that snow decrypted into `out` — must be all zeros.
+    // Bytes past that region were never touched by the engine and
+    // still hold the 0xa5 pre-fill. snow writes
+    // `(inner.len() + 15) & !15` bytes (the padded plaintext).
+    let padded_inner_len = (inner.len() + 15) & !15;
+    assert!(
+        plain[..padded_inner_len].iter().all(|&b| b == 0),
+        "AllowedIpsViolation must zero out[..n] ({} bytes); first {} bytes are {:?}",
+        padded_inner_len,
+        padded_inner_len,
+        &plain[..padded_inner_len],
+    );
+}
+
+#[test]
+fn decap_zeros_plaintext_on_malformed_inner() {
+    // Force a `MalformedInner` arm: encap a payload whose first
+    // byte has IP version != 4/6 so `inner_src_ip` returns None.
+    // The packet authenticates (it's just bytes to the AEAD) but
+    // the post-decrypt parse fails, and the engine must wipe.
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    // 32-byte payload, first nibble = 0 (no valid IP version).
+    let mut inner = vec![0u8; 32];
+    inner[0] = 0x05;
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    plain.fill(0xa5);
+    let err = resp_engine
+        .try_decap(&wire[..enc.len], &mut plain)
+        .unwrap_err();
+    assert_eq!(err, DecapError::MalformedInner);
+    let padded_inner_len = (inner.len() + 15) & !15;
+    assert!(
+        plain[..padded_inner_len].iter().all(|&b| b == 0),
+        "MalformedInner must zero out[..n] ({} bytes); first {} bytes are {:?}",
+        padded_inner_len,
+        padded_inner_len,
+        &plain[..padded_inner_len],
+    );
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1191,3 +1191,77 @@ fn allowed_ips_unit_check() {
     assert_eq!(t.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))), Some(0));
     assert_eq!(t.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 200))), Some(1));
 }
+
+/// Regression test for the truncated-record remote DoS that Codex
+/// caught on the r-final-2 review (all 9 prior review rounds missed
+/// it). A hostile peer that observes a valid `receiver_index` for a
+/// live session can send 16..31-byte UDP datagrams; `parse_data_header`
+/// accepts any record ≥ 16 bytes, leaving a sub-Poly1305-tag
+/// ciphertext that snow 0.10's ChaCha-Poly1305 decrypt cannot handle
+/// safely (the internal `ciphertext.len() - TAGLEN` either underflows
+/// to a debug-assert or wraps to a huge usize that panics on the
+/// subsequent slice op). The fix: reject sub-tag records with
+/// `DecapError::ShortRecord` before invoking snow.
+///
+/// This test installs a live session, then walks `ciphertext.len()`
+/// across {0, 1, 8, 14, 15} and asserts the engine returns the new
+/// error variant rather than panicking. The assertion is on the
+/// returned error — if the bug regressed, the test would panic
+/// instead of failing with a wrong-error.
+#[test]
+fn try_decap_rejects_sub_poly1305_tag_records_without_panicking() {
+    use super::framing::encode_data_header;
+
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+
+    // Encrypt one real packet through the engine to learn what
+    // `receiver_index` the responder demuxes on. We extract that
+    // index from the encrypted record so the hostile-attacker probe
+    // uses a live session's index.
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine
+        .try_encap(&resp_pub, &inner, &mut wire)
+        .expect("baseline encap should succeed");
+    let receiver_index = enc.receiver_index;
+
+    // Walk ciphertext lengths from 0 through 15 (i.e. record lengths
+    // 16..31). Every one of these must return ShortRecord, NOT panic.
+    for ct_len in [0usize, 1, 8, 14, 15] {
+        let mut probe = vec![0u8; super::WG_DATA_HEADER_LEN + ct_len];
+        encode_data_header(&mut probe, receiver_index, 0xdead_beef).unwrap();
+        // The header counter we used (0xdeadbeef) is well below
+        // REJECT_AFTER_MESSAGES — so the rejection MUST come from the
+        // short-record guard, not from the counter-ceiling guard or
+        // from a panic inside snow.
+        let mut plain = [0u8; 2048];
+        let err = resp_engine.try_decap(&probe, &mut plain).unwrap_err();
+        assert_eq!(
+            err,
+            DecapError::ShortRecord,
+            "record with ciphertext.len()={ct_len} must reject as ShortRecord; \
+             got {err:?}. If this test panics instead of asserting, the \
+             truncated-record DoS has regressed and snow is being handed \
+             a sub-tag ciphertext."
+        );
+    }
+
+    // Boundary case: ciphertext.len() == POLY1305_TAG_LEN (16) is no
+    // longer ShortRecord — it's an empty-payload record. Snow will
+    // reject it for failing the AEAD tag (we haven't crafted a real
+    // tag), which surfaces as CryptoFailed. Important contract: the
+    // short-record guard's cutoff is `< POLY1305_TAG_LEN`, not `<=`.
+    let mut sixteen_byte_ct = vec![0u8; super::WG_DATA_HEADER_LEN + super::POLY1305_TAG_LEN];
+    encode_data_header(&mut sixteen_byte_ct, receiver_index, 0xdead_beef).unwrap();
+    let mut plain = [0u8; 2048];
+    let err = resp_engine.try_decap(&sixteen_byte_ct, &mut plain).unwrap_err();
+    assert_ne!(
+        err,
+        DecapError::ShortRecord,
+        "a ciphertext.len() == POLY1305_TAG_LEN record is NOT short — must \
+         reach snow and reject as CryptoFailed (or similar) instead"
+    );
+}

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -188,7 +188,9 @@ fn encap_unknown_peer_returns_error_not_random_session() {
     let bogus = [0xcd; 32];
     let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
     let mut wire = [0u8; 2048];
-    let err = init_engine.try_encap(&bogus, &inner, &mut wire).unwrap_err();
+    let err = init_engine
+        .try_encap(&bogus, &inner, &mut wire)
+        .unwrap_err();
     assert_eq!(err, EncapError::UnknownPeer);
 }
 
@@ -197,7 +199,6 @@ fn cryptokey_routing_overlapping_allowed_ips() {
     let (init_priv, init_pub) = keypair();
     let (peer_a_priv, peer_a_pub) = keypair();
     let (peer_b_priv, peer_b_pub) = keypair();
-    let _ = peer_a_priv;
 
     let init_engine = WgEngine::new(WgEngineConfig {
         local_private_key: init_priv,
@@ -217,7 +218,17 @@ fn cryptokey_routing_overlapping_allowed_ips() {
             },
         ],
     });
-    // Stand up a real engine for peer B only and handshake into it.
+    // Stand up real engines for both peers.
+    let resp_a = WgEngine::new(WgEngineConfig {
+        local_private_key: peer_a_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
     let resp_b = WgEngine::new(WgEngineConfig {
         local_private_key: peer_b_priv,
         listen_port: 51820,
@@ -229,9 +240,9 @@ fn cryptokey_routing_overlapping_allowed_ips() {
         }],
     });
 
-    // Drive IK init→B, B→init.
-    let mut init_hs = init_engine.build_initiator_handshake(&peer_b_pub).unwrap();
-    let mut resp_hs = resp_b.build_responder_handshake().unwrap();
+    // Drive IK init↔A.
+    let mut init_hs = init_engine.build_initiator_handshake(&peer_a_pub).unwrap();
+    let mut resp_hs = resp_a.build_responder_handshake().unwrap();
     let mut buf = [0u8; 1024];
     let mut sink = [0u8; 1024];
     let n1 = init_hs.write_message(&[], &mut buf).unwrap();
@@ -244,6 +255,26 @@ fn cryptokey_routing_overlapping_allowed_ips() {
     let init_idx = 0x1111_2222;
     let resp_idx = 0x3333_4444;
     init_engine.install_session(
+        &peer_a_pub,
+        Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_a_pub)),
+    );
+    resp_a.install_session(
+        &init_pub,
+        Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
+    );
+
+    // Drive IK init↔B.
+    let mut init_hs = init_engine.build_initiator_handshake(&peer_b_pub).unwrap();
+    let mut resp_hs = resp_b.build_responder_handshake().unwrap();
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+    let init_idx = 0x5555_6666;
+    let resp_idx = 0x7777_8888;
+    init_engine.install_session(
         &peer_b_pub,
         Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_b_pub)),
     );
@@ -255,15 +286,20 @@ fn cryptokey_routing_overlapping_allowed_ips() {
     let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 9));
     let mut wire = [0u8; 2048];
 
-    // Asking for A: A has no session installed. Must error, not
-    // silently fall back to B's session (which the LPM would
-    // happily resolve to).
-    let err = init_engine.try_encap(&peer_a_pub, &inner, &mut wire).unwrap_err();
-    assert_eq!(err, EncapError::NoSession);
-
-    // Asking for B: works, and the wire image decrypts at B's engine.
-    let enc = init_engine.try_encap(&peer_b_pub, &inner, &mut wire).unwrap();
+    // Asking for A must use A's session, not silently route to B.
+    let enc = init_engine
+        .try_encap(&peer_a_pub, &inner, &mut wire)
+        .unwrap();
     let mut plain = [0u8; 2048];
+    let dec = resp_a.try_decap(&wire[..enc.len], &mut plain).unwrap();
+    assert_eq!(dec.peer_pubkey, init_pub);
+    let err = resp_b.try_decap(&wire[..enc.len], &mut plain).unwrap_err();
+    assert_eq!(err, DecapError::UnknownSession);
+
+    // Asking for B still works and decrypts only at B.
+    let enc = init_engine
+        .try_encap(&peer_b_pub, &inner, &mut wire)
+        .unwrap();
     let dec = resp_b.try_decap(&wire[..enc.len], &mut plain).unwrap();
     assert_eq!(dec.peer_pubkey, init_pub);
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -89,18 +89,34 @@ fn established_pair(
     // chose.
     let init_local_index = 0xaaaa_0001;
     let resp_local_index = 0xbbbb_0001;
-    let init_session = Arc::new(WgSession::new(
+    // Initiator session is created with Initiator-role (confirmed at
+    // install per WG spec — the initiator is the side that sends
+    // first). Responder session is created with Responder-role to be
+    // faithful to the wire contract; we then pre-confirm it so existing
+    // round-trip tests that encap from the responder side continue
+    // to function. The key-confirmation invariant itself is exercised
+    // by `responder_session_blocks_encap_until_initiator_data_authenticated`
+    // and `established_pair_responder_confirmation_flips_via_decap_path`
+    // — see Copilot inline finding on the prior round of this PR.
+    let init_session = Arc::new(WgSession::new_with_role(
         init_xport,
         init_local_index,
         resp_local_index,
         resp_pub,
+        super::session::SessionRole::Initiator,
     ));
-    let resp_session = Arc::new(WgSession::new(
+    let resp_session = Arc::new(WgSession::new_with_role(
         resp_xport,
         resp_local_index,
         init_local_index,
         init_pub,
+        super::session::SessionRole::Responder,
     ));
+    // Pre-confirm the responder so callers that don't want to drive
+    // the gate (the bulk of the tests in this file) can encap from
+    // either side immediately. The gate tests do NOT call this
+    // helper and manage confirmation explicitly.
+    resp_session.mark_confirmed();
     init_engine
         .install_session(&resp_pub, init_session)
         .unwrap();
@@ -1264,4 +1280,100 @@ fn try_decap_rejects_sub_poly1305_tag_records_without_panicking() {
         "a ciphertext.len() == POLY1305_TAG_LEN record is NOT short — must \
          reach snow and reject as CryptoFailed (or similar) instead"
     );
+}
+
+/// Builds an `established_pair` where the responder session starts
+/// unconfirmed (responder-role) and is confirmed by the engine's
+/// own `try_decap` rather than by a manual `mark_confirmed` test
+/// helper. This is what a real responder integration path will do
+/// — the first authenticated inbound data record flips the gate.
+///
+/// Addresses the Copilot inline finding on `established_pair`: the
+/// bulk of the file's round-trip tests use the helper which
+/// pre-confirms the responder, so the key-confirmation gate is not
+/// exercised by them. This test exercises it end-to-end without
+/// touching `mark_confirmed`.
+#[test]
+fn established_pair_responder_confirmation_flips_via_decap_path() {
+    use super::session::SessionRole;
+
+    let (init_priv, init_pub) = keypair();
+    let (resp_priv, resp_pub) = keypair();
+
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+    let resp_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: resp_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+
+    let mut init_hs = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+    let mut resp_hs = resp_engine.build_responder_handshake().unwrap();
+    let mut buf = [0u8; 1024];
+    let mut sink = [0u8; 1024];
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+    let init_local = 0xc0de_4001;
+    let resp_local = 0xc0de_4002;
+
+    init_engine
+        .install_session(
+            &resp_pub,
+            Arc::new(WgSession::new_with_role(
+                init_xport,
+                init_local,
+                resp_local,
+                resp_pub,
+                SessionRole::Initiator,
+            )),
+        )
+        .unwrap();
+    let resp_session = Arc::new(WgSession::new_with_role(
+        resp_xport,
+        resp_local,
+        init_local,
+        init_pub,
+        SessionRole::Responder,
+    ));
+    resp_engine
+        .install_session(&init_pub, resp_session.clone())
+        .unwrap();
+    assert!(!resp_session.is_confirmed());
+
+    // Initiator sends; engine `try_decap` MUST flip confirmation.
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 9));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
+    assert!(
+        resp_session.is_confirmed(),
+        "successful AEAD via try_decap must flip confirmation without any test-only mark_confirmed call"
+    );
+
+    // Responder can now encap; the gate is open.
+    let reply = ipv4_packet(Ipv4Addr::new(10, 0, 0, 9), Ipv4Addr::new(10, 0, 0, 5));
+    let mut wire2 = [0u8; 2048];
+    resp_engine
+        .try_encap(&init_pub, &reply, &mut wire2)
+        .expect("post-confirmation encap must succeed");
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -101,8 +101,12 @@ fn established_pair(
         init_local_index,
         init_pub,
     ));
-    init_engine.install_session(&resp_pub, init_session);
-    resp_engine.install_session(&init_pub, resp_session);
+    init_engine
+        .install_session(&resp_pub, init_session)
+        .unwrap();
+    resp_engine
+        .install_session(&init_pub, resp_session)
+        .unwrap();
 
     (init_engine, resp_engine, init_pub, resp_pub)
 }
@@ -131,13 +135,22 @@ fn handshake_completes_and_roundtrip_encap_decap() {
     let mut wire = [0u8; 2048];
     let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
 
-    // Wire image should be: header (16) + ciphertext (inner.len()) + tag (16).
-    assert_eq!(enc.len, 16 + inner.len() + 16);
+    // Wire image: header (16) + padded_plaintext (16-byte multiple
+    // >= inner.len()) + tag (16). WG spec §5.4.6 mandates the
+    // plaintext be zero-padded to a 16-byte multiple before AEAD.
+    let padded = (inner.len() + 15) & !15;
+    assert_eq!(enc.len, 16 + padded + 16);
+    assert!(padded >= inner.len());
+    assert_eq!(padded % 16, 0);
 
     let mut plain = [0u8; 2048];
     let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
     assert_eq!(dec.peer_pubkey, init_pub);
-    assert_eq!(&plain[..dec.len], &inner[..]);
+    // Decrypted plaintext is the padded form. The first `inner.len()`
+    // bytes must equal the original inner packet; trailing bytes are
+    // zero padding.
+    assert_eq!(&plain[..inner.len()], &inner[..]);
+    assert!(plain[inner.len()..dec.len].iter().all(|&b| b == 0));
 }
 
 #[test]
@@ -254,14 +267,18 @@ fn cryptokey_routing_overlapping_allowed_ips() {
     let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
     let init_idx = 0x1111_2222;
     let resp_idx = 0x3333_4444;
-    init_engine.install_session(
-        &peer_a_pub,
-        Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_a_pub)),
-    );
-    resp_a.install_session(
-        &init_pub,
-        Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
-    );
+    init_engine
+        .install_session(
+            &peer_a_pub,
+            Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_a_pub)),
+        )
+        .unwrap();
+    resp_a
+        .install_session(
+            &init_pub,
+            Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
+        )
+        .unwrap();
 
     // Drive IK init↔B.
     let mut init_hs = init_engine.build_initiator_handshake(&peer_b_pub).unwrap();
@@ -274,14 +291,18 @@ fn cryptokey_routing_overlapping_allowed_ips() {
     let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
     let init_idx = 0x5555_6666;
     let resp_idx = 0x7777_8888;
-    init_engine.install_session(
-        &peer_b_pub,
-        Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_b_pub)),
-    );
-    resp_b.install_session(
-        &init_pub,
-        Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
-    );
+    init_engine
+        .install_session(
+            &peer_b_pub,
+            Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_b_pub)),
+        )
+        .unwrap();
+    resp_b
+        .install_session(
+            &init_pub,
+            Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
+        )
+        .unwrap();
 
     let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 9));
     let mut wire = [0u8; 2048];
@@ -381,8 +402,75 @@ fn worker_scratch_no_realloc_under_repeated_encap() {
         let _ = init_engine.try_encap(&resp_pub, &inner, &mut buf).unwrap();
     }
     // No reallocation across 256 encaps. If a future change adds
-    // a per-packet vec![], this test will catch it.
+    // a per-packet `vec![]` on the scratch buffer, this test will
+    // catch it.
+    //
+    // TODO(#1499 r4 / hot-path-discipline): this test only proves
+    // the scratch `Vec` doesn't grow. It does NOT prove that
+    // `try_encap` itself avoids internal allocation (e.g. an
+    // accidental `Vec::with_capacity` inside snow or the engine).
+    // The proper instrumentation is `assert_no_alloc` or a custom
+    // `GlobalAlloc` that panics on alloc during the hot section.
+    // Adding it now would change crate-level test infra; deferred
+    // to a follow-up PR that introduces the harness once the
+    // integration PR has the full hot path under test.
     assert_eq!(scratch.encap_out.borrow().as_ptr(), initial_ptr);
+}
+
+#[test]
+fn transport_plaintext_is_padded_to_16_byte_multiple() {
+    // WG spec §5.4.6 — every plaintext input to the data-AEAD must
+    // be zero-padded to a multiple of 16 before encryption. Test
+    // several inner-packet lengths to cover both the "exact
+    // multiple" and "needs padding" arms.
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    for inner_len in [20usize, 32, 33, 47, 48, 49, 1500] {
+        let mut inner = vec![0u8; inner_len];
+        inner[0] = 0x45; // IPv4
+        inner[2..4].copy_from_slice(&(inner_len as u16).to_be_bytes());
+        inner[9] = 17; // UDP
+        inner[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        inner[16..20].copy_from_slice(&[10, 0, 1, 5]);
+        let mut wire = [0u8; 4096];
+        let enc = init_engine
+            .try_encap(&resp_pub, &inner, &mut wire)
+            .unwrap_or_else(|e| panic!("inner_len={inner_len}: {e:?}"));
+        let expected_padded = (inner_len + 15) & !15;
+        let ciphertext_len = enc.len - 16 /* hdr */ - 16 /* tag */;
+        assert_eq!(
+            ciphertext_len, expected_padded,
+            "padding mismatch at inner_len={inner_len}: got {ciphertext_len}, want {expected_padded}",
+        );
+        // Roundtrip: decap and verify the original prefix survives.
+        let mut plain = [0u8; 4096];
+        let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
+        assert_eq!(&plain[..inner_len], &inner[..]);
+        assert_eq!(dec.len, expected_padded);
+    }
+}
+
+#[test]
+fn decap_rejects_counter_at_reject_after_messages() {
+    // WG spec §6.5 — receiver MUST refuse data messages whose
+    // counter is at or above REJECT_AFTER_MESSAGES, without
+    // attempting AEAD. Symmetric to the encap-side guard.
+    use super::framing::encode_data_header;
+    use super::session::REJECT_AFTER_MESSAGES;
+    let (_init_engine, resp_engine, _init_pub, _resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    // Hand-craft a record with a counter at the spec limit. We
+    // don't need real ciphertext — the counter check fires before
+    // the demux lookup or AEAD attempt.
+    let mut wire = [0u8; 64];
+    encode_data_header(&mut wire, /*receiver_idx*/ 0xdead_beef, REJECT_AFTER_MESSAGES).unwrap();
+    let mut plain = [0u8; 128];
+    let err = resp_engine.try_decap(&wire[..32], &mut plain).unwrap_err();
+    assert_eq!(err, DecapError::CounterRejectAfterMessages);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -656,6 +656,136 @@ fn decap_zeros_plaintext_on_malformed_inner() {
     );
 }
 
+/// r5 regression: the encap path stages plaintext through a
+/// stack `MaybeUninit<[u8; PADDED_PLAINTEXT_MAX]>` and writes it
+/// via raw pointer (not via a `&mut [u8; N]` reference) to keep
+/// the un-padded bytes truly uninitialized without crossing the
+/// reference-validity invariant. This test bombards the path with
+/// a range of inner-IP sizes (covering 0-byte padding, full-15-byte
+/// padding, and the PADDED_PLAINTEXT_MAX upper bound) and verifies
+/// every roundtrip succeeds with the correct un-padded length —
+/// any UB in the raw-pointer write or any miscounted padding
+/// boundary would either corrupt the AEAD (decap returns
+/// CryptoFailed) or produce a wrong `dec.len`.
+#[test]
+fn encap_decap_varied_inner_sizes_roundtrip() {
+    let (init_engine, resp_engine, init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    // Sizes chosen to span:
+    //   - 20: minimum IPv4 header, padding = 12
+    //   - 32: padding boundary, padding = 0
+    //   - 33: padding = 15 (worst case)
+    //   - 1280, 1500: typical MTU sizes
+    //   - 4080: the PADDED_PLAINTEXT_MAX inner-payload cap (padded
+    //     to 4080 + 0 = 4080, exercises the upper boundary of the
+    //     raw-pointer write region)
+    for size in [20usize, 32, 33, 64, 100, 256, 1280, 1500, 4080] {
+        let mut inner = vec![0u8; size];
+        // IPv4 header: version 4, IHL 5, total_length = size.
+        inner[0] = 0x45;
+        let len_be = (size as u16).to_be_bytes();
+        inner[2] = len_be[0];
+        inner[3] = len_be[1];
+        // src 10.0.0.5 → must match the responder's allowed_ips for the initiator.
+        inner[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        // dst 10.0.1.5
+        inner[16..20].copy_from_slice(&[10, 0, 1, 5]);
+        // Fill the rest with a non-zero marker so any uninitialized-
+        // memory leak would visibly perturb the decapped output.
+        for (i, b) in inner.iter_mut().enumerate().skip(20) {
+            *b = ((i * 31) & 0xff) as u8;
+        }
+
+        // Pre-fill the output buffer with a non-zero marker — if the
+        // raw-pointer write accidentally left a "hole" in the padded
+        // plaintext, the AEAD would authenticate the marker bytes
+        // and decap would either fail or return mismatched plaintext.
+        let mut wire = [0xa5u8; 6000];
+        let enc = init_engine
+            .try_encap(&resp_pub, &inner, &mut wire)
+            .unwrap_or_else(|e| panic!("encap failed at size={}: {:?}", size, e));
+        let padded = (size + 15) & !15;
+        assert_eq!(enc.len, 16 + padded + 16, "wire len off at size={}", size);
+
+        let mut plain = [0u8; 6000];
+        let dec = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_or_else(|e| panic!("decap failed at size={}: {:?}", size, e));
+        assert_eq!(dec.peer_pubkey, init_pub, "wrong peer at size={}", size);
+        assert_eq!(dec.len, size, "wrong un-padded len at size={}", size);
+        assert_eq!(
+            &plain[..dec.len],
+            &inner[..],
+            "plaintext mismatch at size={}",
+            size
+        );
+        // Bytes beyond the un-padded inner-IP length up to the
+        // padded length must be zero — WG §5.4.6. The decap already
+        // verifies this; we assert it explicitly here to anchor the
+        // padding contract under the raw-pointer write path.
+        for j in dec.len..padded {
+            assert_eq!(
+                plain[j], 0,
+                "padding byte at plain[{}] should be 0, was 0x{:02x} (size={})",
+                j, plain[j], size
+            );
+        }
+    }
+}
+
+/// r5 regression: encap with an inner_ip whose padded length lands
+/// exactly at PADDED_PLAINTEXT_MAX = 4096 must succeed; one byte
+/// over must fail with `BufferTooSmall`. The boundary fixes the
+/// raw-pointer write to the exact `[0..padded_len)` range — an
+/// off-by-one would either write past the staging buffer (UB) or
+/// fail to write enough padding bytes (mismatched AEAD tag).
+#[test]
+fn encap_padded_plaintext_max_boundary() {
+    let (init_engine, resp_engine, init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+
+    let make = |size: usize| -> Vec<u8> {
+        let mut inner = vec![0u8; size];
+        inner[0] = 0x45;
+        let len_be = (size as u16).to_be_bytes();
+        inner[2] = len_be[0];
+        inner[3] = len_be[1];
+        inner[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        inner[16..20].copy_from_slice(&[10, 0, 1, 5]);
+        for (i, b) in inner.iter_mut().enumerate().skip(20) {
+            *b = ((i * 17) & 0xff) as u8;
+        }
+        inner
+    };
+
+    // 4096 → padded to 4096 = PADDED_PLAINTEXT_MAX → fits at the
+    // exact boundary. The raw-pointer write fills bytes
+    // `[0..4096)` of the staging store, which is the maximum
+    // legal range.
+    let inner = make(4096);
+    let mut wire = [0u8; 8000];
+    let enc = init_engine
+        .try_encap(&resp_pub, &inner, &mut wire)
+        .expect("4096 must encap (at PADDED_PLAINTEXT_MAX boundary)");
+    assert_eq!(enc.len, 16 + 4096 + 16);
+    let mut plain = [0u8; 8000];
+    let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
+    assert_eq!(dec.len, 4096);
+    assert_eq!(dec.peer_pubkey, init_pub);
+
+    // 4097 → padded to 4112 > PADDED_PLAINTEXT_MAX; the engine
+    // refuses with BufferTooSmall, preventing any write past the
+    // staging buffer.
+    let inner = make(4097);
+    let mut wire = [0u8; 8000];
+    let err = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap_err();
+    assert_eq!(err, EncapError::BufferTooSmall);
+}
+
 #[test]
 fn allowed_ips_unit_check() {
     // Direct AllowedIps test — extra coverage on top of the

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -786,6 +786,400 @@ fn encap_padded_plaintext_max_boundary() {
     assert_eq!(err, EncapError::BufferTooSmall);
 }
 
+/// r-final-fix regression for Codex final pre-merge finding 1:
+/// `build_initiator_handshake` and `build_responder_handshake` MUST
+/// call `.prologue(WG_PROTOCOL_ID_BYTES)` so the initial Noise hash
+/// matches kernel WireGuard and wireguard-go. We can't reach inside
+/// snow's `HandshakeState` to read the hash directly, but we CAN
+/// prove the prologue is actually consumed by showing that two
+/// engines that disagree on the prologue fail to authenticate each
+/// other while two engines that agree complete the handshake.
+///
+/// The control engine in this test bypasses `WgEngine::build_*` and
+/// constructs the `Builder` directly with an empty prologue. If our
+/// production builders silently dropped the prologue, the control
+/// peer would still authenticate them; with the prologue actually
+/// mixed into the hash, the control peer's `read_message` rejects
+/// the production initiator with a snow error.
+#[test]
+fn handshake_prologue_is_required_for_authentication() {
+    use super::{WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES, WG_ZERO_PSK};
+    use snow::Builder;
+
+    let (init_priv, init_pub) = keypair();
+    let (resp_priv, resp_pub) = keypair();
+
+    // Production initiator: prologue set via our `build_initiator_handshake`.
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+    let mut init_hs = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+
+    // Bad responder: prologue OMITTED. If our engine doesn't actually
+    // mix the prologue into the hash, this responder would still
+    // authenticate the init message; with the prologue properly
+    // mixed in, snow rejects.
+    let mut bad_resp_hs = Builder::new(WG_NOISE_PATTERN.parse().unwrap())
+        .local_private_key(&resp_priv)
+        .unwrap()
+        .psk(2, &WG_ZERO_PSK)
+        .unwrap()
+        .build_responder()
+        .unwrap();
+
+    let mut buf = [0u8; 1024];
+    let mut sink = [0u8; 1024];
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    let res = bad_resp_hs.read_message(&buf[..n1], &mut sink);
+    assert!(
+        res.is_err(),
+        "responder without prologue must reject an initiator that mixed the WG prologue \
+         (otherwise the prologue is silently dropped and the engine is not WireGuard-compat)"
+    );
+
+    // Sanity: a responder built via `build_responder_handshake`
+    // (which sets the prologue) does authenticate the same init
+    // message. This shows the rejection above is the prologue
+    // difference, not some unrelated handshake mismatch.
+    let good_resp_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: resp_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+    let mut init_hs2 = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+    let mut good_resp_hs = good_resp_engine.build_responder_handshake().unwrap();
+    let n1 = init_hs2.write_message(&[], &mut buf).unwrap();
+    good_resp_hs
+        .read_message(&buf[..n1], &mut sink)
+        .expect("matched-prologue responder must authenticate the initiator");
+
+    // Verify the prologue bytes are exactly the WireGuard protocol
+    // identifier — 34 bytes, no trailing NUL. The kernel WG source
+    // (`drivers/net/wireguard/noise.c`) uses the same byte string.
+    assert_eq!(WG_PROTOCOL_ID_BYTES.len(), 34);
+    assert_eq!(WG_PROTOCOL_ID_BYTES, b"WireGuard v1 zx2c4 Jason@zx2c4.com");
+}
+
+/// r-final-fix regression for Codex final pre-merge finding 2:
+/// responder key-confirmation. A responder-role session MUST NOT be
+/// usable for `try_encap` until it has authenticated at least one
+/// inbound transport packet (the initiator's first data record).
+/// Initiator-role sessions are confirmed at install. After the
+/// responder authenticates the initiator's first packet, the
+/// responder's session flips to confirmed and egress is allowed.
+#[test]
+fn responder_session_blocks_encap_until_initiator_data_authenticated() {
+    use super::session::SessionRole;
+
+    let (init_priv, init_pub) = keypair();
+    let (resp_priv, resp_pub) = keypair();
+
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+    let resp_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: resp_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+
+    // Drive the IK handshake.
+    let mut init_hs = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+    let mut resp_hs = resp_engine.build_responder_handshake().unwrap();
+    let mut buf = [0u8; 1024];
+    let mut sink = [0u8; 1024];
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+    let init_local = 0xc0de_0001;
+    let resp_local = 0xc0de_0002;
+
+    // Install the initiator session as Initiator-role → confirmed.
+    init_engine
+        .install_session(
+            &resp_pub,
+            Arc::new(WgSession::new_with_role(
+                init_xport,
+                init_local,
+                resp_local,
+                resp_pub,
+                SessionRole::Initiator,
+            )),
+        )
+        .unwrap();
+    // Install the responder session as Responder-role → unconfirmed.
+    let resp_session = Arc::new(WgSession::new_with_role(
+        resp_xport,
+        resp_local,
+        init_local,
+        init_pub,
+        SessionRole::Responder,
+    ));
+    assert!(
+        !resp_session.is_confirmed(),
+        "responder session must start unconfirmed"
+    );
+    resp_engine
+        .install_session(&init_pub, resp_session.clone())
+        .unwrap();
+
+    // The responder MUST refuse to encap before the initiator's
+    // first data record arrives — this is the WG anti-reflection
+    // invariant. The caller sees `NoSession` and falls through to
+    // its slow path.
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 9));
+    let mut wire_pre = [0u8; 2048];
+    let err = resp_engine
+        .try_encap(&init_pub, &inner, &mut wire_pre)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        EncapError::NoSession,
+        "responder MUST NOT encap before authenticating initiator's first data record"
+    );
+
+    // Initiator sends the first transport packet. Responder
+    // authenticates it — that flips `confirmed = true`.
+    let mut wire_first = [0u8; 2048];
+    let enc = init_engine
+        .try_encap(&resp_pub, &inner, &mut wire_first)
+        .unwrap();
+    let mut plain = [0u8; 2048];
+    let dec = resp_engine
+        .try_decap(&wire_first[..enc.len], &mut plain)
+        .unwrap();
+    assert_eq!(dec.peer_pubkey, init_pub);
+    assert!(
+        resp_session.is_confirmed(),
+        "successful AEAD authentication of inbound data must flip the responder \
+         session's confirmation flag (WG key-confirmation invariant)"
+    );
+
+    // Responder can now encap to the initiator.
+    let inner_reply = ipv4_packet(Ipv4Addr::new(10, 0, 0, 9), Ipv4Addr::new(10, 0, 0, 5));
+    let mut wire_post = [0u8; 2048];
+    let enc_post = resp_engine
+        .try_encap(&init_pub, &inner_reply, &mut wire_post)
+        .expect("responder must be able to encap after confirmation flips");
+    assert!(enc_post.len > 0);
+}
+
+/// r-final-fix regression for Codex final pre-merge finding 3:
+/// `reconcile_peers` must update mutable per-peer config fields
+/// (endpoint, persistent_keepalive) in place on an existing peer
+/// Arc rather than silently keeping stale values. Pre-fix: the Peer
+/// struct held immutable `endpoint` / `persistent_keepalive`, so a
+/// config commit that changed those values for an existing pubkey
+/// was lost.
+#[test]
+fn reconcile_peers_updates_endpoint_and_keepalive_for_existing_peer() {
+    use std::net::SocketAddr;
+    let (init_priv, _init_pub) = keypair();
+    let (_peer_priv, peer_pub) = keypair();
+    let engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: peer_pub,
+            endpoint: Some(SocketAddr::from(([192, 0, 2, 1], 51820))),
+            persistent_keepalive: 25,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+
+    // Sanity: initial fields applied.
+    {
+        let table = engine.table_for_test();
+        let idx = *table.peer_index_by_pubkey.get(&peer_pub).unwrap();
+        let peer = table.peers[idx as usize].clone();
+        assert_eq!(peer.endpoint(), Some(SocketAddr::from(([192, 0, 2, 1], 51820))));
+        assert_eq!(peer.persistent_keepalive(), 25);
+    }
+
+    // Commit a new config that changes the endpoint AND keepalive
+    // for the SAME pubkey. The engine reuses the existing peer Arc
+    // (same pubkey) but must apply the field updates in place.
+    engine.reconcile_peers(&[WgPeerConfig {
+        pubkey: peer_pub,
+        endpoint: Some(SocketAddr::from(([198, 51, 100, 7], 51900))),
+        persistent_keepalive: 60,
+        allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+    }]);
+
+    let table = engine.table_for_test();
+    let idx = *table.peer_index_by_pubkey.get(&peer_pub).unwrap();
+    let peer = table.peers[idx as usize].clone();
+    assert_eq!(
+        peer.endpoint(),
+        Some(SocketAddr::from(([198, 51, 100, 7], 51900))),
+        "reconcile must apply endpoint update to the reused peer Arc"
+    );
+    assert_eq!(
+        peer.persistent_keepalive(),
+        60,
+        "reconcile must apply persistent_keepalive update to the reused peer Arc"
+    );
+
+    // Clearing the endpoint (responder-only) must also propagate.
+    engine.reconcile_peers(&[WgPeerConfig {
+        pubkey: peer_pub,
+        endpoint: None,
+        persistent_keepalive: 0,
+        allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+    }]);
+    let table = engine.table_for_test();
+    let idx = *table.peer_index_by_pubkey.get(&peer_pub).unwrap();
+    let peer = table.peers[idx as usize].clone();
+    assert_eq!(peer.endpoint(), None);
+    assert_eq!(peer.persistent_keepalive(), 0);
+}
+
+/// r-final-fix regression for Copilot inline finding on
+/// `inner_ip_len_after_decap`: an IPv4 inner packet with a bogus
+/// IHL (< 5) or a `total_length` shorter than the header length
+/// MUST be rejected as `MalformedInner`. Pre-fix the engine
+/// returned `Some(claimed)` for any `total_length <= pkt.len()`,
+/// so a downstream parser could see `DecapOutcome.len < 20` and
+/// mis-parse the bytes as a real IPv4 header.
+#[test]
+fn decap_rejects_inner_ipv4_with_invalid_ihl_or_total_length() {
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+
+    // Case 1: IHL = 4 (impossible — < 5 means no room for the fixed
+    // header). The first byte's low nibble holds IHL. version=4,
+    // IHL=4 → byte 0 = 0x44.
+    {
+        let mut inner = vec![0u8; 32];
+        inner[0] = 0x44; // version=4, IHL=4 (invalid)
+        inner[2..4].copy_from_slice(&32u16.to_be_bytes());
+        // Need a valid src for AllowedIPs gate to PASS so the
+        // failure attributes to inner_ip_len_after_decap, not the
+        // AllowedIPs gate. inner_src_ip reads bytes 12..16
+        // unconditionally.
+        inner[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        inner[16..20].copy_from_slice(&[10, 0, 1, 5]);
+        let mut wire = [0u8; 2048];
+        let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        let err = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DecapError::MalformedInner,
+            "IHL < 5 must be rejected as MalformedInner"
+        );
+    }
+
+    // Case 2: IHL = 5, total_length = 10 (claims fewer bytes than
+    // the fixed header). Must reject.
+    {
+        let mut inner = vec![0u8; 32];
+        inner[0] = 0x45; // version=4, IHL=5
+        inner[2..4].copy_from_slice(&10u16.to_be_bytes());
+        inner[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        inner[16..20].copy_from_slice(&[10, 0, 1, 5]);
+        let mut wire = [0u8; 2048];
+        let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        let err = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DecapError::MalformedInner,
+            "total_length < ihl*4 must be rejected as MalformedInner"
+        );
+    }
+}
+
+/// r-final-fix regression for Copilot inline finding on
+/// `TunnelEndpointSnapshot::wg_local_privkey_hex`: the private key
+/// field MUST NOT be serialized into the on-disk state file, and a
+/// `Debug` impl MUST redact it so accidental log calls cannot leak
+/// key material.
+#[test]
+fn tunnel_endpoint_snapshot_private_key_is_skipped_and_redacted() {
+    use crate::protocol::TunnelEndpointSnapshot;
+
+    let snap = TunnelEndpointSnapshot {
+        wg_local_privkey_hex: "deadbeef".repeat(8), // 64 hex chars = "private key"
+        wg_peer_pubkey_hex: "abc123".to_string(),
+        wg_listen_port: 51820,
+        ..Default::default()
+    };
+
+    // Serialization must NOT include the private key — this is the
+    // surface that ends up in the state file on disk.
+    let json = serde_json::to_string(&snap).expect("snapshot must serialize");
+    assert!(
+        !json.contains(&snap.wg_local_privkey_hex),
+        "wg_local_privkey_hex must NOT appear in serialized output (state file would leak); \
+         got: {json}"
+    );
+
+    // Debug must redact — accidental {:?} log lines can't leak.
+    let debug_str = format!("{snap:?}");
+    assert!(
+        !debug_str.contains(&snap.wg_local_privkey_hex),
+        "Debug for TunnelEndpointSnapshot must NOT include the raw private key bytes; \
+         got: {debug_str}"
+    );
+    assert!(
+        debug_str.contains("<redacted>"),
+        "Debug for TunnelEndpointSnapshot must show <redacted> placeholder; got: {debug_str}"
+    );
+
+    // Empty-key case: must show <unset> placeholder.
+    let empty = TunnelEndpointSnapshot::default();
+    let debug_str = format!("{empty:?}");
+    assert!(
+        debug_str.contains("<unset>"),
+        "empty privkey must Debug as <unset>; got: {debug_str}"
+    );
+
+    // Deserialization still accepts the field — the control plane
+    // delivers the key on the control socket.
+    let wire = serde_json::json!({
+        "wg_local_privkey_hex": "0123456789abcdef".repeat(4),
+        "wg_listen_port": 51820,
+    });
+    let snap: TunnelEndpointSnapshot = serde_json::from_value(wire).unwrap();
+    assert_eq!(snap.wg_local_privkey_hex.len(), 64);
+    assert_eq!(snap.wg_listen_port, 51820);
+}
+
 #[test]
 fn allowed_ips_unit_check() {
     // Direct AllowedIps test — extra coverage on top of the

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1,0 +1,362 @@
+//! End-to-end tests for the WG engine.
+//!
+//! These tests build two engines (one initiator, one responder),
+//! drive a Noise IK handshake between them, install the resulting
+//! transport sessions, then verify encap/decap roundtrip and the
+//! AllowedIPs / replay / VLAN / DSCP / MSS properties.
+
+use super::allowed_ips::AllowedIps;
+use super::dscp::tos_from_dscp;
+use super::engine::{DecapError, EncapError, WgEngine, WgEngineConfig, WgPeerConfig};
+use super::framing::{encode_data_header, parse_data_header};
+use super::mss::wg_tcp_mss;
+use super::outer::{outer_l2_len, write_outer_eth, write_outer_ipv4_udp};
+use super::scratch::WgWorkerScratch;
+use super::session::WgSession;
+use snow::Builder;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+
+/// Generate a fresh X25519 keypair using snow's resolver. Slow
+/// path — fine for tests.
+fn keypair() -> ([u8; 32], [u8; 32]) {
+    let kp = Builder::new(super::WG_NOISE_PATTERN.parse().unwrap())
+        .generate_keypair()
+        .unwrap();
+    let mut priv_k = [0u8; 32];
+    let mut pub_k = [0u8; 32];
+    priv_k.copy_from_slice(&kp.private);
+    pub_k.copy_from_slice(&kp.public);
+    (priv_k, pub_k)
+}
+
+/// Set up two engines and drive the IK handshake between them.
+/// Returns `(initiator_engine, responder_engine, init_pub, resp_pub)`.
+///
+/// The handshake is driven entirely on the slow path of both
+/// sides — exactly the pattern a real worker would use to install
+/// sessions for the hot path.
+fn established_pair(
+    init_allowed_for_resp: Vec<ipnet::IpNet>,
+    resp_allowed_for_init: Vec<ipnet::IpNet>,
+) -> (WgEngine, WgEngine, [u8; 32], [u8; 32]) {
+    let (init_priv, init_pub) = keypair();
+    let (resp_priv, resp_pub) = keypair();
+
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: init_allowed_for_resp,
+        }],
+    });
+    let resp_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: resp_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: resp_allowed_for_init,
+        }],
+    });
+
+    // Drive the IK handshake. Two messages: init→resp, then
+    // resp→init. No further pumping needed; snow has no hidden
+    // queues to drain.
+    let mut init_hs = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+    let mut resp_hs = resp_engine.build_responder_handshake().unwrap();
+    let mut buf = [0u8; 1024];
+
+    // Initiation.
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    let mut sink = [0u8; 1024];
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+
+    // Response.
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+
+    // Choose receiver indices. In real WG they're chosen at
+    // handshake-message build time. For the engine tests we pick
+    // them deterministically here and tell each side what the peer
+    // chose.
+    let init_local_index = 0xaaaa_0001;
+    let resp_local_index = 0xbbbb_0001;
+    let init_session = Arc::new(WgSession::new(
+        init_xport,
+        init_local_index,
+        resp_local_index,
+        resp_pub,
+    ));
+    let resp_session = Arc::new(WgSession::new(
+        resp_xport,
+        resp_local_index,
+        init_local_index,
+        init_pub,
+    ));
+    init_engine.install_session(&resp_pub, init_session);
+    resp_engine.install_session(&init_pub, resp_session);
+
+    (init_engine, resp_engine, init_pub, resp_pub)
+}
+
+/// Build a minimal IPv4 packet with the given src/dst and a 20-byte
+/// payload. Returns the IP-header-onward bytes (no L2).
+fn ipv4_packet(src: Ipv4Addr, dst: Ipv4Addr) -> Vec<u8> {
+    let mut p = vec![0u8; 40];
+    p[0] = 0x45;
+    p[2..4].copy_from_slice(&40u16.to_be_bytes());
+    p[8] = 64;
+    p[9] = 17;
+    p[12..16].copy_from_slice(&src.octets());
+    p[16..20].copy_from_slice(&dst.octets());
+    p
+}
+
+#[test]
+fn handshake_completes_and_roundtrip_encap_decap() {
+    let resp_allowed = vec!["10.0.0.0/24".parse().unwrap()];
+    let init_allowed = vec!["10.0.1.0/24".parse().unwrap()];
+    let (init_engine, resp_engine, init_pub, resp_pub) =
+        established_pair(init_allowed, resp_allowed);
+
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+
+    // Wire image should be: header (16) + ciphertext (inner.len()) + tag (16).
+    assert_eq!(enc.len, 16 + inner.len() + 16);
+
+    let mut plain = [0u8; 2048];
+    let dec = resp_engine.try_decap(&wire[..enc.len], &mut plain).unwrap();
+    assert_eq!(dec.peer_pubkey, init_pub);
+    assert_eq!(&plain[..dec.len], &inner[..]);
+}
+
+#[test]
+fn decap_rejects_inner_src_outside_allowed_ips() {
+    // The responder's peer (the initiator) is allowed 10.0.0.0/24.
+    // The initiator sends a packet with src 10.0.99.99 — must be
+    // dropped by the AllowedIPs gate, NOT silently accepted.
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 99, 99), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    let err = resp_engine
+        .try_decap(&wire[..enc.len], &mut plain)
+        .unwrap_err();
+    assert_eq!(err, DecapError::AllowedIpsViolation);
+}
+
+#[test]
+fn replay_window_rejects_duplicate_ciphertext() {
+    let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    assert!(resp_engine.try_decap(&wire[..enc.len], &mut plain).is_ok());
+    let err = resp_engine
+        .try_decap(&wire[..enc.len], &mut plain)
+        .unwrap_err();
+    assert_eq!(err, DecapError::ReplayDuplicate);
+}
+
+#[test]
+fn encap_unknown_peer_returns_error_not_random_session() {
+    // The cryptokey-routing safety property — if the caller asks
+    // us to encrypt to a peer we don't have, we must error, NOT
+    // fall back to some other peer.
+    let (init_engine, _resp_engine, _init_pub, _resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let bogus = [0xcd; 32];
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let err = init_engine.try_encap(&bogus, &inner, &mut wire).unwrap_err();
+    assert_eq!(err, EncapError::UnknownPeer);
+}
+
+#[test]
+fn cryptokey_routing_overlapping_allowed_ips() {
+    let (init_priv, init_pub) = keypair();
+    let (peer_a_priv, peer_a_pub) = keypair();
+    let (peer_b_priv, peer_b_pub) = keypair();
+    let _ = peer_a_priv;
+
+    let init_engine = WgEngine::new(WgEngineConfig {
+        local_private_key: init_priv,
+        listen_port: 51820,
+        peers: vec![
+            WgPeerConfig {
+                pubkey: peer_a_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+            },
+            WgPeerConfig {
+                pubkey: peer_b_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+            },
+        ],
+    });
+    // Stand up a real engine for peer B only and handshake into it.
+    let resp_b = WgEngine::new(WgEngineConfig {
+        local_private_key: peer_b_priv,
+        listen_port: 51820,
+        peers: vec![WgPeerConfig {
+            pubkey: init_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["10.0.0.0/24".parse().unwrap()],
+        }],
+    });
+
+    // Drive IK init→B, B→init.
+    let mut init_hs = init_engine.build_initiator_handshake(&peer_b_pub).unwrap();
+    let mut resp_hs = resp_b.build_responder_handshake().unwrap();
+    let mut buf = [0u8; 1024];
+    let mut sink = [0u8; 1024];
+    let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+    resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+    let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+    init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+
+    let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+    let resp_xport = resp_hs.into_stateless_transport_mode().unwrap();
+    let init_idx = 0x1111_2222;
+    let resp_idx = 0x3333_4444;
+    init_engine.install_session(
+        &peer_b_pub,
+        Arc::new(WgSession::new(init_xport, init_idx, resp_idx, peer_b_pub)),
+    );
+    resp_b.install_session(
+        &init_pub,
+        Arc::new(WgSession::new(resp_xport, resp_idx, init_idx, init_pub)),
+    );
+
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 9));
+    let mut wire = [0u8; 2048];
+
+    // Asking for A: A has no session installed. Must error, not
+    // silently fall back to B's session (which the LPM would
+    // happily resolve to).
+    let err = init_engine.try_encap(&peer_a_pub, &inner, &mut wire).unwrap_err();
+    assert_eq!(err, EncapError::NoSession);
+
+    // Asking for B: works, and the wire image decrypts at B's engine.
+    let enc = init_engine.try_encap(&peer_b_pub, &inner, &mut wire).unwrap();
+    let mut plain = [0u8; 2048];
+    let dec = resp_b.try_decap(&wire[..enc.len], &mut plain).unwrap();
+    assert_eq!(dec.peer_pubkey, init_pub);
+}
+
+#[test]
+fn framing_layout_matches_spec() {
+    // Belt-and-braces check that what try_encap emits has the
+    // expected on-wire shape: type=4 in byte 0, receiver_index
+    // little-endian in bytes 4..8, counter little-endian in 8..16.
+    let (init_engine, _resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let mut wire = [0u8; 2048];
+    let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+    let parsed = parse_data_header(&wire[..enc.len]).unwrap();
+    assert_eq!(parsed.receiver_index, enc.receiver_index);
+    assert_eq!(parsed.counter, enc.counter);
+    assert_eq!(wire[0], 4);
+}
+
+#[test]
+fn outer_l2_with_vlan_when_set() {
+    // VLAN-safe encap: when tx_vlan_id != 0, the outer L2 carries
+    // an 802.1Q tag. This was the #1492 VLAN-unsafe miss.
+    let mut buf = [0u8; 64];
+    let n_no_vlan = write_outer_eth(&mut buf, [0; 6], [0; 6], 0, 0x0800).unwrap();
+    assert_eq!(n_no_vlan, 14);
+    let n_vlan = write_outer_eth(&mut buf, [0; 6], [0; 6], 100, 0x0800).unwrap();
+    assert_eq!(n_vlan, 18);
+    assert_eq!(&buf[12..14], &[0x81, 0x00]);
+    assert_eq!(outer_l2_len(0), 14);
+    assert_eq!(outer_l2_len(100), 18);
+}
+
+#[test]
+fn outer_ipv4_tos_propagates_dscp() {
+    // EF (DSCP 46) must show up in the outer TOS byte as 0xb8.
+    // ECN bits remain cleared.
+    let mut buf = [0u8; 64];
+    let tos = tos_from_dscp(46);
+    assert_eq!(tos, 0xb8);
+    let _ = write_outer_ipv4_udp(
+        &mut buf,
+        Ipv4Addr::new(10, 0, 0, 1),
+        Ipv4Addr::new(10, 0, 0, 2),
+        51820,
+        51820,
+        tos,
+        64,
+        100,
+    )
+    .unwrap();
+    assert_eq!(buf[1], 0xb8);
+    assert_eq!(buf[1] & 0x03, 0); // ECN cleared
+}
+
+#[test]
+fn mss_clamp_matches_byte_breakdown() {
+    // Sanity: 1500-byte outer MTU, v4-in-v4, MSS = 1400. See
+    // mss.rs for the byte-by-byte derivation. Repeated here in
+    // the integration tests because review-time errors on MSS
+    // math are the kind of bug that ships and silently fragments.
+    assert_eq!(wg_tcp_mss(libc::AF_INET, libc::AF_INET, 1500), 1400);
+}
+
+#[test]
+fn worker_scratch_no_realloc_under_repeated_encap() {
+    let (init_engine, _resp_engine, _init_pub, resp_pub) = established_pair(
+        vec!["10.0.1.0/24".parse().unwrap()],
+        vec!["10.0.0.0/24".parse().unwrap()],
+    );
+    let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 1, 5));
+    let scratch = WgWorkerScratch::new(2048);
+    let initial_ptr = scratch.encap_out.borrow().as_ptr();
+    for _ in 0..256 {
+        let mut buf = scratch.encap_out.borrow_mut();
+        let _ = init_engine.try_encap(&resp_pub, &inner, &mut buf).unwrap();
+    }
+    // No reallocation across 256 encaps. If a future change adds
+    // a per-packet vec![], this test will catch it.
+    assert_eq!(scratch.encap_out.borrow().as_ptr(), initial_ptr);
+}
+
+#[test]
+fn allowed_ips_unit_check() {
+    // Direct AllowedIps test — extra coverage on top of the
+    // module's own unit tests, exercising the same API the engine
+    // uses on the decap path.
+    let mut t = AllowedIps::new();
+    t.insert("10.0.0.0/24".parse().unwrap(), 0);
+    t.insert("10.0.0.128/25".parse().unwrap(), 1);
+    assert_eq!(t.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))), Some(0));
+    assert_eq!(t.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 200))), Some(1));
+}

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -381,7 +381,7 @@ pub(crate) struct FabricSnapshot {
     pub peer_mac: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub(crate) struct TunnelEndpointSnapshot {
     #[serde(default)]
     pub id: u16,
@@ -418,8 +418,18 @@ pub(crate) struct TunnelEndpointSnapshot {
     pub wg_listen_port: u16,
     /// Local static private key for the WG interface, hex-encoded
     /// (64 chars for 32 bytes). Empty when `mode != "wireguard"`.
-    /// CONTROL-PLANE-INTERNAL only — never logged.
-    #[serde(rename = "wg_local_privkey_hex", default)]
+    ///
+    /// This field is intentionally `skip_serializing` so it CANNOT
+    /// be written back out via any `serde_json` round-trip. The
+    /// userspace dataplane persists a JSON snapshot of `ServerState`
+    /// to disk via `server::helpers::write_state`, which used to
+    /// include this private key in plaintext (Copilot inline review
+    /// caught this on the final pre-merge round). Deserialization
+    /// still works — the control plane delivers the key on the
+    /// control socket via the `default` path. The custom Debug impl
+    /// on `TunnelEndpointSnapshot` redacts this field to keep any
+    /// future accidental `{:?}` log line from leaking key material.
+    #[serde(rename = "wg_local_privkey_hex", default, skip_serializing)]
     pub wg_local_privkey_hex: String,
     /// Peer's static public key, hex-encoded. The WG engine uses
     /// this as the encap key — not AllowedIPs LPM. See plan §
@@ -438,6 +448,41 @@ pub(crate) struct TunnelEndpointSnapshot {
     /// Optional persistent keepalive in seconds. 0 = off.
     #[serde(rename = "wg_keepalive_secs", default)]
     pub wg_keepalive_secs: u16,
+}
+
+impl std::fmt::Debug for TunnelEndpointSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Manually redact `wg_local_privkey_hex`. Use a placeholder
+        // that records only whether a key was set so debug logs
+        // remain useful for triage without leaking key material.
+        let privkey_state = if self.wg_local_privkey_hex.is_empty() {
+            "<unset>"
+        } else {
+            "<redacted>"
+        };
+        f.debug_struct("TunnelEndpointSnapshot")
+            .field("id", &self.id)
+            .field("interface", &self.interface)
+            .field("linux_name", &self.linux_name)
+            .field("ifindex", &self.ifindex)
+            .field("zone", &self.zone)
+            .field("redundancy_group", &self.redundancy_group)
+            .field("mtu", &self.mtu)
+            .field("mode", &self.mode)
+            .field("outer_family", &self.outer_family)
+            .field("source", &self.source)
+            .field("destination", &self.destination)
+            .field("key", &self.key)
+            .field("ttl", &self.ttl)
+            .field("transport_table", &self.transport_table)
+            .field("wg_listen_port", &self.wg_listen_port)
+            .field("wg_local_privkey_hex", &privkey_state)
+            .field("wg_peer_pubkey_hex", &self.wg_peer_pubkey_hex)
+            .field("wg_allowed_ips", &self.wg_allowed_ips)
+            .field("wg_endpoint", &self.wg_endpoint)
+            .field("wg_keepalive_secs", &self.wg_keepalive_secs)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol.rs
+++ b/userspace-dp/src/protocol.rs
@@ -411,6 +411,33 @@ pub(crate) struct TunnelEndpointSnapshot {
     pub ttl: i32,
     #[serde(rename = "transport_table", default)]
     pub transport_table: String,
+    // WireGuard fields. All `#[serde(default)]` so this stays
+    // wire-compatible with old daemons that don't populate them.
+    // See docs/pr/wireguard-clean/plan.md for the design.
+    #[serde(rename = "wg_listen_port", default)]
+    pub wg_listen_port: u16,
+    /// Local static private key for the WG interface, hex-encoded
+    /// (64 chars for 32 bytes). Empty when `mode != "wireguard"`.
+    /// CONTROL-PLANE-INTERNAL only — never logged.
+    #[serde(rename = "wg_local_privkey_hex", default)]
+    pub wg_local_privkey_hex: String,
+    /// Peer's static public key, hex-encoded. The WG engine uses
+    /// this as the encap key — not AllowedIPs LPM. See plan §
+    /// "Engine keying" for why this matters.
+    #[serde(rename = "wg_peer_pubkey_hex", default)]
+    pub wg_peer_pubkey_hex: String,
+    /// Peer AllowedIPs, as CIDR strings. Only consulted on the
+    /// decap path (inner src-IP gate); never used to choose a peer
+    /// on egress.
+    #[serde(rename = "wg_allowed_ips", default)]
+    pub wg_allowed_ips: Vec<String>,
+    /// Optional peer endpoint (`IP:port`) for initiator-role
+    /// handshakes. Empty for responder-only.
+    #[serde(rename = "wg_endpoint", default)]
+    pub wg_endpoint: String,
+    /// Optional persistent keepalive in seconds. 0 = off.
+    #[serde(rename = "wg_keepalive_secs", default)]
+    pub wg_keepalive_secs: u16,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Clean-room WireGuard tunnel termination engine for the userspace
AF_XDP dataplane. Does not reuse code from #1492 (`cleanroom/wireguard`)
or #1433 (`feature/wireguard-support`). Starts from `origin/master`.

**This PR lands the engine + tests + protocol extension only.** Hot-path
activation in `tx/dispatch.rs` and `poll_descriptor.rs` is deliberately
deferred to a follow-up so reviewers can audit the engine in isolation.

Full design in `docs/pr/wireguard-clean/plan.md`.

## Architectural choices (vs prior attempts)

- **snow (Noise IK), not boringtun** — explicit state machine, no hidden
  output queues. snow 0.10 ships with `curve25519-dalek 4.1.3`
  (post-RUSTSEC-2024-0344) and `ring 0.17.14`
  (post-RUSTSEC-2025-0010).
- **Engine keyed by explicit peer pubkey on encap** — the forwarding
  decision tells dispatch.rs which peer to encrypt to. AllowedIPs is
  consulted **only** on the decap path as a receive-side gate on the
  inner src IP. The `cryptokey_routing_overlapping_allowed_ips` test
  exercises this with two peers sharing the same `/24` — asking to
  encrypt to the peer without an installed session must error, not
  silently encrypt with the other peer's keys.
- **No allocations on the hot path** — `WgWorkerScratch` holds a single
  preallocated `Vec<u8>` per worker; the `worker_scratch_no_realloc_under_repeated_encap`
  test pins the buffer pointer across 256 encaps.
- **Replay window updated after decrypt** — per RFC 6479 / WG paper, to
  prevent attacker-controlled high-counter junk from DoSing the window.
- **`started` flag in `ReplayState`** — fixes the off-by-one where the
  first accept of counter 0 would falsely re-accept on the next call.
- **VLAN-safe outer L2** — `write_outer_eth` emits 802.1Q tags when
  `tx_vlan_id != 0` (PR #1492 missed this).
- **DSCP → outer TOS via `dscp << 2`** with ECN bits cleared (RFC 6040
  propagation is a tracked follow-up).
- **WG-specific MSS math** — 60-byte v4-outer overhead / 80-byte
  v6-outer, NOT the GRE overhead PR #1492 reused. Derivation in the
  `mss.rs` file header.

## Module layout

```
userspace-dp/src/afxdp/wg/
  mod.rs         — public API + per-packet overhead constants
  framing.rs     — WG transport-data header encode/decode
  engine.rs      — WgEngine + try_encap/try_decap + handshake build
  peer.rs        — per-peer state, current/previous sessions
  session.rs     — WgSession + ReplayState
  allowed_ips.rs — LPM table (in-tree, no extra deps)
  mss.rs         — wg_tcp_mss with byte breakdown
  dscp.rs        — tos_from_dscp
  outer.rs       — outer L2 / IPv4 / UDP header builders
  scratch.rs     — preallocated per-worker buffers
  tests.rs       — handshake → encap → decap end-to-end
```

Protocol extension: `TunnelEndpointSnapshot` gains six WG fields
(listen_port, local privkey, peer pubkey, AllowedIPs, endpoint,
keepalive). All `#[serde(default)]` / `omitempty` so wire-compatible
with old daemons.

## Scope IN this PR

- Handshake (Noise IK init/response), transport keys, encap/decap.
- AllowedIPs LPM with peer-pubkey gate.
- MSS clamp + VLAN-safe encap + DSCP propagation.
- Replay window (RFC 6479).
- Protocol extension (Rust + Go), backward-compatible.
- 48 unit tests: handshake roundtrip, AllowedIPs LPM, peer-pubkey
  gate (cryptokey-routing), replay window arms, MSS, VLAN, DSCP,
  no-realloc, framing layout.

## Scope OUT (follow-ups; tracked in `docs/pr/wireguard-clean/plan.md`)

- Hot-path wiring in `tx/dispatch.rs` and `poll_descriptor.rs`.
- Go control-plane mapping from Junos config to WG fields.
- HA / RG-aware session migration on failover.
- FIB/neighbor lookup hint for outer next-hop MAC.
- RFC 7901-style cookie / rate-limit DoS reply path.
- IPv6 outer encap (engine is family-agnostic; outer.rs is v4 only).
- Persistent replay-window state across daemon restart.
- RFC 6040 ECN propagation.

## Validation

- `cargo build --release`: clean.
- `cargo test --release`: 1455 tests pass (1385 bin + 46 lib + 8 + 16
  integration), 0 new failures. The pre-existing `snat_contract_doc_guard`
  test is verified to fail identically on `origin/master`
  under the same toolchain — not caused by this PR.
- `go build ./...`: clean.
- `go test ./pkg/dataplane/userspace/...`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)