### PR TITLE
Tighten artifact schema numerics

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,18 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T16:56:30Z
+  - **Action**: PR #1506 review follow-up — normalized RFC3339 leap-second
+    validation through UTC before accepting `:60` offset forms, and reported
+    hostile Decimal/oversized-number JSON parse failures as structured
+    validation errors instead of tracebacks.
+  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
+    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
+  - **Validation**: `python3 -m unittest discover -s test/incus -p
+    retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
+    test/incus/retire_ebpf_artifact_schema.py
+    test/incus/retire_ebpf_artifact_schema_test.py`; `git diff --check`
+
 - **Timestamp**: 2026-05-24T15:14:30Z
   - **Action**: PR #1494 round-11 follow-up — collapsed the retained
     userspace XDP shim entry-program name onto one dataplane constant and

--- a/_Log.md
+++ b/_Log.md
@@ -1148,3 +1148,16 @@
     test/incus/retire_ebpf_artifact_schema_test.py`; `python3 -m json.tool
     docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
     >/dev/null`; `git diff --check`
+
+- **Timestamp**: 2026-05-24T11:01:44-07:00
+  - **Action**: PR #1506 review follow-up: reject Python JSON parser
+    extensions (`NaN`, `Infinity`, and `-Infinity`) through the existing
+    invalid-JSON validation path, and cap Decimal integer materialization so
+    hostile exponent-form manifest integers cannot force huge `int`
+    allocation.
+  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
+    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
+  - **Validation**: `python3 -m unittest discover -s test/incus -p
+    retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
+    test/incus/retire_ebpf_artifact_schema.py
+    test/incus/retire_ebpf_artifact_schema_test.py`; `git diff --check`

--- a/_Log.md
+++ b/_Log.md
@@ -1120,3 +1120,19 @@
   - **Validation**: `rg -n "#1375|#1378|retirement blocker|retirement-contract"
     docs/feature-gaps.md docs/pr/1373-retire-ebpf-dataplane/README.md
     docs/pr/1373-retire-ebpf-dataplane/plan.md`; `git diff --check`
+
+- **Timestamp**: 2026-05-23T21:46:59-07:00
+  - **Action**: #1502 artifact-schema checker follow-up: parse JSON floats as
+    `Decimal`, normalize JSON integer-like values for manifest issues,
+    schema version, and command exit status, reject lossy non-integer decimal
+    numbers, and restrict accepted RFC3339 leap seconds to 23:59:60 on June 30
+    or December 31.
+  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
+    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
+  - **Validation**: `python3 -m unittest discover -s test/incus -p
+    retire_ebpf_artifact_schema_test.py`; `python3
+    test/incus/retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
+    test/incus/retire_ebpf_artifact_schema.py
+    test/incus/retire_ebpf_artifact_schema_test.py`; `python3 -m json.tool
+    docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
+    >/dev/null`; `git diff --check`

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -25,6 +25,8 @@ DATE_TIME_RE = re.compile(
     r"[Tt](?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})"
     r"(?P<fraction>\.\d+)?(?P<zone>[Zz]|[+-]\d{2}:\d{2})$"
 )
+# Manifest integer fields are small; cap Decimal-to-int conversion defensively.
+MAX_JSON_INTEGER_DIGITS = 128
 
 COS_OFF_CASES = ("v4-push", "v4-reverse", "v6-push", "v6-reverse")
 SCREEN_PROBES = ("land", "syn", "icmp", "udp")
@@ -127,6 +129,10 @@ class ValidationFailure(Exception):
 
 def _display(path: Path) -> str:
     return path.as_posix()
+
+
+def _reject_json_constant(token: str) -> None:
+    raise ValueError(f"non-RFC 8259 JSON constant: {token}")
 
 
 class ArtifactChecker:
@@ -374,6 +380,10 @@ class ArtifactChecker:
         if isinstance(value, int):
             return value
         if isinstance(value, Decimal):
+            if not value.is_finite():
+                return None
+            if not value.is_zero() and value.adjusted() + 1 > MAX_JSON_INTEGER_DIGITS:
+                return None
             try:
                 integral = value.to_integral_value()
             except InvalidOperation:
@@ -600,7 +610,11 @@ class ArtifactChecker:
         if not path.exists() or not path.is_file():
             return None
         try:
-            return json.loads(path.read_text(encoding="utf-8"), parse_float=Decimal)
+            return json.loads(
+                path.read_text(encoding="utf-8"),
+                parse_float=Decimal,
+                parse_constant=_reject_json_constant,
+            )
         except UnicodeDecodeError as exc:
             self.error(f"invalid UTF-8 JSON artifact {rel}: {exc}")
             return None

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -12,8 +12,8 @@ import argparse
 import json
 import re
 import sys
-from datetime import datetime
-from decimal import Decimal
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -373,8 +373,16 @@ class ArtifactChecker:
             return None
         if isinstance(value, int):
             return value
-        if isinstance(value, Decimal) and value == value.to_integral_value():
-            return int(value)
+        if isinstance(value, Decimal):
+            try:
+                integral = value.to_integral_value()
+            except InvalidOperation:
+                return None
+            if value == integral:
+                try:
+                    return int(value)
+                except (InvalidOperation, OverflowError, ValueError):
+                    return None
         return None
 
     def validate_unique_list(self, context: str, value: list[Any]) -> None:
@@ -398,9 +406,6 @@ class ArtifactChecker:
         if second > 60:
             self.error(f"{context} must be an RFC3339 date-time string")
             return
-        if second == 60 and not self.is_practical_leap_second(match):
-            self.error(f"{context} must be an RFC3339 date-time string")
-            return
         normalized = value
         normalized = normalized[:10] + "T" + normalized[11:]
         if normalized.endswith(("Z", "z")):
@@ -415,14 +420,20 @@ class ArtifactChecker:
             return
         if parsed.tzinfo is None or parsed.utcoffset() is None:
             self.error(f"{context} must include a timezone offset")
+            return
+        if second == 60 and not self.is_practical_leap_second(parsed):
+            self.error(f"{context} must be an RFC3339 date-time string")
 
-    def is_practical_leap_second(self, match: re.Match[str]) -> bool:
-        month = match.group("month")
-        day = match.group("day")
+    def is_practical_leap_second(self, parsed: datetime) -> bool:
+        utc = parsed.astimezone(timezone.utc)
         return (
-            match.group("hour") == "23"
-            and match.group("minute") == "59"
-            and ((month == "06" and day == "30") or (month == "12" and day == "31"))
+            utc.hour == 23
+            and utc.minute == 59
+            and utc.second == 59
+            and (
+                (utc.month == 6 and utc.day == 30)
+                or (utc.month == 12 and utc.day == 31)
+            )
         )
 
     def validate_metadata(self) -> None:
@@ -594,6 +605,9 @@ class ArtifactChecker:
             self.error(f"invalid UTF-8 JSON artifact {rel}: {exc}")
             return None
         except json.JSONDecodeError as exc:
+            self.error(f"invalid JSON artifact {rel}: {exc}")
+            return None
+        except (InvalidOperation, ValueError) as exc:
             self.error(f"invalid JSON artifact {rel}: {exc}")
             return None
 

--- a/test/incus/retire_ebpf_artifact_schema.py
+++ b/test/incus/retire_ebpf_artifact_schema.py
@@ -13,6 +13,7 @@ import json
 import re
 import sys
 from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -174,21 +175,25 @@ class ArtifactChecker:
             "manifest.json", manifest, REQUIRED_MANIFEST_FIELDS
         )
 
-        schema_version = manifest.get("schema_version")
-        if isinstance(schema_version, bool) or schema_version != 1:
+        schema_version = self.json_integer_value(manifest.get("schema_version"))
+        if schema_version != 1:
             self.error("manifest.json schema_version must be 1")
+        else:
+            manifest["schema_version"] = schema_version
 
         issues = manifest.get("issues")
         if not isinstance(issues, list):
             self.error("manifest.json issues must include 1373 and 1477")
         else:
-            issue_numbers = [self.issue_number(issue) for issue in issues]
+            issue_numbers = [self.json_integer_value(issue) for issue in issues]
             if any(issue is None for issue in issue_numbers):
                 self.error("manifest.json issues must be integer issue numbers")
             elif len(set(issue_numbers)) != len(issue_numbers):
                 self.error("manifest.json issues must not contain duplicates")
             elif not {1373, 1477}.issubset(set(issue_numbers)):
                 self.error("manifest.json issues must include 1373 and 1477")
+            else:
+                manifest["issues"] = issue_numbers
 
         raw_commit = manifest.get("candidate_commit")
         if not isinstance(raw_commit, str) or not FULL_SHA_RE.match(raw_commit):
@@ -310,11 +315,13 @@ class ArtifactChecker:
                     self.error(f"manifest.json commands[{idx}].gate is required")
                 if not isinstance(command.get("command"), str) or not command["command"]:
                     self.error(f"manifest.json commands[{idx}].command is required")
-                exit_status = command.get("exit_status")
-                if isinstance(exit_status, bool) or not isinstance(exit_status, int):
+                exit_status = self.json_integer_value(command.get("exit_status"))
+                if exit_status is None:
                     self.error(
                         f"manifest.json commands[{idx}].exit_status must be recorded as an integer"
                     )
+                else:
+                    command["exit_status"] = exit_status
                 for field in ("started_at", "finished_at"):
                     if field in command:
                         self.validate_date_time_string(
@@ -361,12 +368,12 @@ class ArtifactChecker:
         if not isinstance(value, str) or not value:
             self.error(f"{context} must be a non-empty string")
 
-    def issue_number(self, value: Any) -> int | None:
+    def json_integer_value(self, value: Any) -> int | None:
         if isinstance(value, bool):
             return None
         if isinstance(value, int):
             return value
-        if isinstance(value, float) and value.is_integer():
+        if isinstance(value, Decimal) and value == value.to_integral_value():
             return int(value)
         return None
 
@@ -391,6 +398,9 @@ class ArtifactChecker:
         if second > 60:
             self.error(f"{context} must be an RFC3339 date-time string")
             return
+        if second == 60 and not self.is_practical_leap_second(match):
+            self.error(f"{context} must be an RFC3339 date-time string")
+            return
         normalized = value
         normalized = normalized[:10] + "T" + normalized[11:]
         if normalized.endswith(("Z", "z")):
@@ -405,6 +415,15 @@ class ArtifactChecker:
             return
         if parsed.tzinfo is None or parsed.utcoffset() is None:
             self.error(f"{context} must include a timezone offset")
+
+    def is_practical_leap_second(self, match: re.Match[str]) -> bool:
+        month = match.group("month")
+        day = match.group("day")
+        return (
+            match.group("hour") == "23"
+            and match.group("minute") == "59"
+            and ((month == "06" and day == "30") or (month == "12" and day == "31"))
+        )
 
     def validate_metadata(self) -> None:
         self.require_file("metadata/git-rev-parse-head.txt")
@@ -570,7 +589,7 @@ class ArtifactChecker:
         if not path.exists() or not path.is_file():
             return None
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            return json.loads(path.read_text(encoding="utf-8"), parse_float=Decimal)
         except UnicodeDecodeError as exc:
             self.error(f"invalid UTF-8 JSON artifact {rel}: {exc}")
             return None

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -511,6 +511,32 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
             self.assertEqual(summary["verdict"], "STRUCTURE_OK")
 
+    def test_accepts_rfc3339_leap_second_with_offset(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["started_at"] = "2026-12-31T15:59:60-08:00"
+            commands[0]["finished_at"] = "2027-01-01T08:59:60+09:00"
+            write_json(root, "manifest.json", manifest)
+            summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
+            self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+
+    def test_rejects_local_leap_shape_that_is_not_utc_leap_second(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["started_at"] = "2026-12-31T23:59:60-08:00"
+            write_json(root, "manifest.json", manifest)
+            with self.assertRaisesRegex(
+                schema.ValidationFailure,
+                "commands\\[0\\].started_at must be an RFC3339 date-time string",
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
     def test_rejects_non_leap_shaped_sixty_second_timestamps(self) -> None:
         def set_command_started_at(manifest: dict[str, object], value: str) -> None:
             commands = manifest["commands"]
@@ -577,6 +603,21 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             path.write_bytes(b"\xff\xfe{")
             with self.assertRaisesRegex(schema.ValidationFailure, "invalid UTF-8 JSON"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_decimal_parse_error_without_traceback(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            text = make_manifest_json()
+            needle = '"schema_version":1'
+            self.assertIn(needle, text)
+            write_text(
+                root,
+                "manifest.json",
+                text.replace(needle, '"schema_version":1e999999999999999999999'),
+            )
+            with self.assertRaisesRegex(schema.ValidationFailure, "invalid JSON"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -65,6 +65,10 @@ def make_manifest(commit: str = COMMIT) -> dict[str, object]:
     }
 
 
+def make_manifest_json() -> str:
+    return json.dumps(make_manifest(), separators=(",", ":")) + "\n"
+
+
 def make_summary(commit: str = COMMIT) -> str:
     lines = ["# #1477 Source-Removal Validation Summary", "", commit, ""]
     for heading in schema.SUMMARY_HEADINGS:
@@ -310,11 +314,54 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
             self.assertEqual(summary["verdict"], "STRUCTURE_OK")
 
+    def test_accepts_json_integer_float_exit_status(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            manifest = make_manifest()
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["exit_status"] = 0.0
+            write_json(root, "manifest.json", manifest)
+            summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
+            self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+
     def test_rejects_boolean_issue_number(self) -> None:
         self.assert_manifest_mutation_rejected(
             lambda manifest: manifest.__setitem__("issues", [True, 1373, 1477]),
             "issues must be integer issue numbers",
         )
+
+    def test_rejects_lossy_decimal_issue_number(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            text = make_manifest_json()
+            needle = '"issues":[1373,1477]'
+            self.assertIn(needle, text)
+            write_text(
+                root,
+                "manifest.json",
+                text.replace(needle, '"issues":[1373.0000000000000001,1477]'),
+            )
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "issues must be integer issue numbers"
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_lossy_decimal_exit_status(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            text = make_manifest_json()
+            needle = '"exit_status":0'
+            self.assertIn(needle, text)
+            write_text(
+                root,
+                "manifest.json",
+                text.replace(needle, '"exit_status":0.0000000000000001', 1),
+            )
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "commands\\[0\\].exit_status"
+            ):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
     def test_rejects_unknown_command_gate(self) -> None:
         tmp, root = self.with_fixture()
@@ -459,9 +506,51 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             commands = manifest["commands"]
             assert isinstance(commands, list)
             commands[0]["started_at"] = "2026-06-30T23:59:60Z"
+            commands[0]["finished_at"] = "2026-12-31T23:59:60+00:00"
             write_json(root, "manifest.json", manifest)
             summary = schema.validate_artifact_root(root, candidate_commit=COMMIT)
             self.assertEqual(summary["verdict"], "STRUCTURE_OK")
+
+    def test_rejects_non_leap_shaped_sixty_second_timestamps(self) -> None:
+        def set_command_started_at(manifest: dict[str, object], value: str) -> None:
+            commands = manifest["commands"]
+            assert isinstance(commands, list)
+            commands[0]["started_at"] = value
+
+        cases = (
+            (
+                "top_level_wrong_month",
+                lambda manifest: manifest.__setitem__(
+                    "artifact_created_at", "2026-05-31T23:59:60Z"
+                ),
+                "artifact_created_at must be an RFC3339 date-time string",
+            ),
+            (
+                "top_level_wrong_day",
+                lambda manifest: manifest.__setitem__(
+                    "artifact_created_at", "2026-06-29T23:59:60Z"
+                ),
+                "artifact_created_at must be an RFC3339 date-time string",
+            ),
+            (
+                "command_wrong_hour",
+                lambda manifest: set_command_started_at(
+                    manifest, "2026-06-30T22:59:60Z"
+                ),
+                "commands\\[0\\].started_at must be an RFC3339 date-time string",
+            ),
+            (
+                "command_wrong_minute",
+                lambda manifest: set_command_started_at(
+                    manifest, "2026-12-31T23:58:60Z"
+                ),
+                "commands\\[0\\].started_at must be an RFC3339 date-time string",
+            ),
+        )
+
+        for name, mutate, pattern in cases:
+            with self.subTest(name=name):
+                self.assert_manifest_mutation_rejected(mutate, pattern)
 
     def test_rejects_additional_command_fields(self) -> None:
         tmp, root = self.with_fixture()

--- a/test/incus/retire_ebpf_artifact_schema_test.py
+++ b/test/incus/retire_ebpf_artifact_schema_test.py
@@ -596,6 +596,23 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
             with self.assertRaisesRegex(schema.ValidationFailure, "invalid JSON"):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
+    def test_rejects_non_rfc_json_constants_without_traceback(self) -> None:
+        for token in ("NaN", "Infinity", "-Infinity"):
+            with self.subTest(token=token):
+                tmp, root = self.with_fixture()
+                with tmp:
+                    write_text(
+                        root,
+                        "fallback-exclusion/fw0-userspace-dp.json",
+                        f'{{"value": {token}}}\n',
+                    )
+                    with self.assertRaisesRegex(
+                        schema.ValidationFailure,
+                        "invalid JSON artifact fallback-exclusion/fw0-userspace-dp.json: "
+                        f"non-RFC 8259 JSON constant: {token}",
+                    ):
+                        schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
     def test_rejects_non_utf8_json_artifact_without_traceback(self) -> None:
         tmp, root = self.with_fixture()
         with tmp:
@@ -616,6 +633,22 @@ class RetireEbpfArtifactSchemaTests(unittest.TestCase):
                 text.replace(needle, '"schema_version":1e999999999999999999999'),
             )
             with self.assertRaisesRegex(schema.ValidationFailure, "invalid JSON"):
+                schema.validate_artifact_root(root, candidate_commit=COMMIT)
+
+    def test_rejects_huge_decimal_integer_without_materializing(self) -> None:
+        tmp, root = self.with_fixture()
+        with tmp:
+            text = make_manifest_json()
+            needle = '"exit_status":0'
+            self.assertIn(needle, text)
+            write_text(
+                root,
+                "manifest.json",
+                text.replace(needle, '"exit_status":1e999999999999999999', 1),
+            )
+            with self.assertRaisesRegex(
+                schema.ValidationFailure, "commands\\[0\\].exit_status"
+            ):
                 schema.validate_artifact_root(root, candidate_commit=COMMIT)
 
 


### PR DESCRIPTION
## Summary
- Parse artifact JSON floats as Decimal so integer validation sees exact numeric text.
- Normalize integer-like JSON values for schema_version, issues, and commands[].exit_status while still rejecting booleans and lossy decimals.
- Restrict accepted :60 RFC3339 timestamps to 23:59:60 on June 30 or December 31 and add hostile regressions.

## Validation
- python3 -m unittest discover -s test/incus -p retire_ebpf_artifact_schema_test.py
- python3 test/incus/retire_ebpf_artifact_schema_test.py
- python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py test/incus/retire_ebpf_artifact_schema_test.py
- python3 -m json.tool docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json >/dev/null
- git diff --check

Closes #1502.