### PR TITLE
Narrow conntrack GC construction

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -194,7 +194,7 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/cluster/sync_bulk.go` | Bulk sync still serializes legacy session entries. |
 | `pkg/cluster/sync_conn.go` | Sync connection code still references legacy session types. |
 | `pkg/cluster/sync_protocol.go` | Wire protocol still carries legacy session records. |
-| `pkg/conntrack/gc.go` | GC compatibility construction still adapts legacy sessions. |
+| `pkg/conntrack/gc.go` | GC still uses root package session-domain types until those move out of `pkg/dataplane`; constructors no longer accept `DataPlane`. |
 | `pkg/daemon/daemon.go` | Daemon owns `RuntimeDataPlane` and exposes `legacyDP()` for unmigrated callers. |
 | `pkg/daemon/daemon_apply.go` | Apply path still adapts legacy compile/apply metadata. |
 | `pkg/daemon/daemon_flow.go` | Flow logging still formats legacy dataplane counters. |
@@ -219,8 +219,9 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 ### Safe-Delete Blockers
 
 - `pkg/dataplane.DataPlane` is still load-bearing for API, gRPC, CLI, status,
-  logging, cluster session sync, conntrack GC, daemon HA, daemon flow, and
-  daemon apply bridges listed above. `pkg/monitoriface` now uses a
+  logging, cluster session sync, daemon HA, daemon flow, and daemon apply
+  bridges listed above. Conntrack GC now enters through `SessionStore` and
+  `Telemetry` runtime-domain providers. `pkg/monitoriface` now uses a
   package-local `RuntimeDataPlane`/`CounterReader` shape; CLI and gRPC adapt
   their wider dataplane fields before entering the monitor-interface package.
 - Omitted `system dataplane-type` now resolves to the userspace runtime path.

--- a/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md
@@ -176,8 +176,9 @@ show all of the following:
   `loadXpfXdpMain()`, any legacy XDP/TC tail-call loader, or the legacy
   `xdp_main_prog`/`tc_main_prog` program-map bootstrap.
 - #1451 has shrunk the root `dataplane.DataPlane` compatibility surface so API,
-  gRPC, CLI, status, monitor, logging, cluster sync, conntrack GC, and daemon
-  runtime paths do not require the legacy eBPF manager.
+  gRPC, CLI, status, monitor, logging, cluster sync, and daemon runtime paths
+  do not require the legacy eBPF manager. Conntrack GC already enters through
+  runtime-domain session and telemetry providers.
 - DPDK remains confined to its documented backend policy or has its own explicit
   migration result; userspace-only source removal must not delete DPDK-required
   shared definitions by accident.

--- a/docs/pr/1381-dataplane-interface-split/plan.md
+++ b/docs/pr/1381-dataplane-interface-split/plan.md
@@ -590,12 +590,12 @@ interface in place and adds the new contract beside it:
   `dataplane.SessionStore.ReconcileClusterBulk`, whose companion-delete path
   owns forward, reverse, and DNAT/DNATv6 cleanup. A canary fails if
   `pkg/cluster/sync.go` reintroduces local `DeleteDNATEntry*` cleanup.
-- GC now routes through `SessionStore` and `Telemetry`. The legacy
-  `NewGC(dataplane.DataPlane, ...)` constructor is only an adapter boundary;
-  the sweep body uses session-domain iteration, domain-owned
-  known-value batched companion deletes, and telemetry global counters. A
-  domain-only unit test pins that GC can expire sessions without a
-  `DataPlane`.
+- GC now routes through `SessionStore` and `Telemetry`. `NewGC` accepts a
+  `RuntimeDomainProvider` with `Sessions()` and `Telemetry()` instead of the
+  legacy `DataPlane`; the sweep body uses session-domain iteration,
+  domain-owned known-value batched companion deletes, and telemetry global
+  counters. A canary pins that GC construction does not regain a `DataPlane`
+  parameter.
 - Session sync now routes receive, sweep, bulk export, and stale-reconcile
   through `SessionStore`/`Telemetry`. The legacy constructors still accept a
   `DataPlane` for compatibility, but immediately adapt it with

--- a/pkg/conntrack/README.md
+++ b/pkg/conntrack/README.md
@@ -10,9 +10,10 @@ owns the empty-table change counters.
 ## Entry points
 
 - `GC` — `gc.go`.
-- `NewGC(dp dataplane.DataPlane, interval time.Duration) *GC` — `gc.go`.
-  Compatibility adapter for legacy callers; internally converts the dataplane
-  to `SessionStore`/`Telemetry` domains.
+- `NewGC(provider RuntimeDomainProvider, interval time.Duration) *GC` —
+  `gc.go`. Convenience adapter for callers that expose `Sessions()` and
+  `Telemetry()` runtime domains without accepting the legacy root
+  `dataplane.DataPlane` surface.
 - `NewGCWithDomains(sessions, telemetry, sessionCount, persistent, interval)`
   — `gc.go`. Preferred constructor for callers that already own the split
   runtime interfaces.
@@ -33,9 +34,10 @@ owns the empty-table change counters.
 
 ## Dependencies
 
-`dataplane` runtime-domain interfaces. The compatibility constructor still
-accepts the transitional `dataplane.DataPlane` root interface, but the sweep
-body must not reach through raw BPF session/counter methods directly.
+`dataplane` runtime-domain interfaces and session value types. Constructors no
+longer accept the transitional `dataplane.DataPlane` root interface; callers
+that still own a legacy bridge must adapt it before entering this package. The
+sweep body must not reach through raw BPF session/counter methods directly.
 
 ## Gotchas
 

--- a/pkg/conntrack/gc.go
+++ b/pkg/conntrack/gc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 
@@ -37,6 +38,13 @@ type sessionCountPublisher interface {
 
 type persistentNATProvider interface {
 	GetPersistentNAT() *dataplane.PersistentNATTable
+}
+
+// RuntimeDomainProvider exposes the runtime-domain surfaces GC needs at
+// construction time without requiring the legacy BPF-shaped DataPlane.
+type RuntimeDomainProvider interface {
+	dataplane.SessionStoreProvider
+	dataplane.TelemetryProvider
 }
 
 // GC performs periodic garbage collection on the session table.
@@ -92,20 +100,51 @@ type GC struct {
 	SkipSweep func() bool
 }
 
-// NewGC creates a new session garbage collector.
-func NewGC(dp dataplane.DataPlane, interval time.Duration) *GC {
+// NewGC creates a new session garbage collector from runtime-domain providers.
+func NewGC(provider RuntimeDomainProvider, interval time.Duration) *GC {
+	if runtimeDomainProviderIsNil(provider) {
+		return NewGCWithDomains(
+			dataplane.SessionStoreOf(nil),
+			dataplane.TelemetryOf(nil),
+			nil,
+			nil,
+			interval,
+		)
+	}
+
+	var sessionCount sessionCountPublisher
+	var persistent persistentNATProvider
+	if p, ok := provider.(sessionCountPublisher); ok {
+		sessionCount = p
+	}
+	if p, ok := provider.(persistentNATProvider); ok {
+		persistent = p
+	}
 	return NewGCWithDomains(
-		dataplane.SessionStoreOf(dp),
-		dataplane.TelemetryOf(dp),
-		dp,
-		dp,
+		dataplane.SessionStoreOf(provider),
+		dataplane.TelemetryOf(provider),
+		sessionCount,
+		persistent,
 		interval,
 	)
 }
 
+func runtimeDomainProviderIsNil(provider RuntimeDomainProvider) bool {
+	if provider == nil {
+		return true
+	}
+	value := reflect.ValueOf(provider)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
 // NewGCWithDomains creates a garbage collector from the runtime-domain
-// interfaces used by #1381. The legacy NewGC constructor adapts existing
-// dataplanes into these surfaces so callers can migrate independently.
+// interfaces used by #1381. NewGC adapts runtime providers into these surfaces
+// so callers can migrate independently.
 func NewGCWithDomains(
 	sessions dataplane.SessionStore,
 	telemetry dataplane.Telemetry,

--- a/pkg/conntrack/gc_test.go
+++ b/pkg/conntrack/gc_test.go
@@ -12,16 +12,138 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// mockGCDP is a minimal mock dataplane for GC testing.
-// Embeds DataPlane interface to satisfy the full contract; only the methods
-// used by sweep() are implemented — others will panic if called.
+// mockGCDP is a minimal runtime-domain provider for GC testing.
 type mockGCDP struct {
-	dataplane.DataPlane // embedded interface satisfies all methods
-	mu                  sync.Mutex
-	v4sessions          map[dataplane.SessionKey]dataplane.SessionValue
-	v6sessions          map[dataplane.SessionKeyV6]dataplane.SessionValueV6
-	deleted             []dataplane.SessionKey
-	deletedV6           []dataplane.SessionKeyV6
+	mu         sync.Mutex
+	v4sessions map[dataplane.SessionKey]dataplane.SessionValue
+	v6sessions map[dataplane.SessionKeyV6]dataplane.SessionValueV6
+	deleted    []dataplane.SessionKey
+	deletedV6  []dataplane.SessionKeyV6
+}
+
+type mockGCTelemetry struct {
+	dataplane.Telemetry
+}
+
+func (mockGCTelemetry) GlobalCounter(uint32) (uint64, error) {
+	return 1, nil
+}
+
+type nilRuntimeProvider struct{}
+
+func (*nilRuntimeProvider) Sessions() dataplane.SessionStore {
+	panic("typed nil provider should not be adapted")
+}
+
+func (*nilRuntimeProvider) Telemetry() dataplane.Telemetry {
+	panic("typed nil provider should not be adapted")
+}
+
+func (m *mockGCDP) Sessions() dataplane.SessionStore {
+	return m
+}
+
+func (m *mockGCDP) Telemetry() dataplane.Telemetry {
+	return mockGCTelemetry{}
+}
+
+func (m *mockGCDP) ForEachV4(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return m.IterateSessions(fn)
+}
+
+func (m *mockGCDP) ForEachV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return m.IterateSessionsV6(fn)
+}
+
+func (m *mockGCDP) GetV4(key dataplane.SessionKey) (dataplane.SessionValue, error) {
+	return m.GetSessionV4(key)
+}
+
+func (m *mockGCDP) GetV6(key dataplane.SessionKeyV6) (dataplane.SessionValueV6, error) {
+	return m.GetSessionV6(key)
+}
+
+func (m *mockGCDP) PutClusterSyncedV4(dataplane.SessionKey, dataplane.SessionValue) error {
+	return nil
+}
+
+func (m *mockGCDP) PutClusterSyncedV6(dataplane.SessionKeyV6, dataplane.SessionValueV6) error {
+	return nil
+}
+
+func (m *mockGCDP) DeleteV4(key dataplane.SessionKey) error {
+	return m.DeleteSession(key)
+}
+
+func (m *mockGCDP) DeleteV6(key dataplane.SessionKeyV6) error {
+	return m.DeleteSessionV6(key)
+}
+
+func (m *mockGCDP) DeleteKnownV4(key dataplane.SessionKey, val dataplane.SessionValue, reason dataplane.DeleteReason) error {
+	_, err := m.DeleteBatchKnownV4([]dataplane.SessionEntryV4{{Key: key, Value: val}}, reason)
+	return err
+}
+
+func (m *mockGCDP) DeleteKnownV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, reason dataplane.DeleteReason) error {
+	_, err := m.DeleteBatchKnownV6([]dataplane.SessionEntryV6{{Key: key, Value: val}}, reason)
+	return err
+}
+
+func (m *mockGCDP) DeleteBatchKnownV4(entries []dataplane.SessionEntryV4, _ dataplane.DeleteReason) (int, error) {
+	for _, entry := range entries {
+		if entry.Value.ReverseKey.Protocol != 0 {
+			m.DeleteSession(entry.Value.ReverseKey)
+		}
+		m.DeleteSession(entry.Key)
+	}
+	return len(entries), nil
+}
+
+func (m *mockGCDP) DeleteBatchKnownV6(entries []dataplane.SessionEntryV6, _ dataplane.DeleteReason) (int, error) {
+	for _, entry := range entries {
+		if entry.Value.ReverseKey.Protocol != 0 {
+			m.DeleteSessionV6(entry.Value.ReverseKey)
+		}
+		m.DeleteSessionV6(entry.Key)
+	}
+	return len(entries), nil
+}
+
+func (m *mockGCDP) DeleteWithCompanionsV4(key dataplane.SessionKey, reason dataplane.DeleteReason) error {
+	val, err := m.GetSessionV4(key)
+	if err != nil {
+		return err
+	}
+	return m.DeleteKnownV4(key, val, reason)
+}
+
+func (m *mockGCDP) DeleteWithCompanionsV6(key dataplane.SessionKeyV6, reason dataplane.DeleteReason) error {
+	val, err := m.GetSessionV6(key)
+	if err != nil {
+		return err
+	}
+	return m.DeleteKnownV6(key, val, reason)
+}
+
+func (m *mockGCDP) ReconcileClusterBulk(dataplane.ClusterBulkReconcileInput) (dataplane.ClusterBulkReconcileResult, error) {
+	return dataplane.ClusterBulkReconcileResult{}, nil
+}
+
+func (m *mockGCDP) SessionDeltas() dpruntime.SessionDeltaSource {
+	return nil
+}
+
+func (m *mockGCDP) Count() (int, int) {
+	return len(m.v4sessions), len(m.v6sessions)
+}
+
+func (m *mockGCDP) Clear() (int, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v4, v6 := len(m.v4sessions), len(m.v6sessions)
+	m.v4sessions = map[dataplane.SessionKey]dataplane.SessionValue{}
+	m.v6sessions = map[dataplane.SessionKeyV6]dataplane.SessionValueV6{}
+	return v4, v6, nil
 }
 
 func (m *mockGCDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
@@ -116,7 +238,7 @@ func (m *mockGCDP) UpdateSessionCountDst(_ dataplane.SessionCountKey, _ uint32) 
 }
 func (m *mockGCDP) ClearSessionCounts() error { return nil }
 
-func TestNewGCAdaptsLegacyDataplaneToRuntimeDomains(t *testing.T) {
+func TestNewGCAdaptsRuntimeProviderToDomains(t *testing.T) {
 	dp := &mockGCDP{
 		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{},
 		v6sessions: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{},
@@ -141,6 +263,41 @@ func TestNewGCAdaptsLegacyDataplaneToRuntimeDomains(t *testing.T) {
 	}
 	if gc.lastV6Count != -1 {
 		t.Fatalf("lastV6Count = %d, want -1", gc.lastV6Count)
+	}
+}
+
+func TestNewGCNilProviderKeepsAdapterBehavior(t *testing.T) {
+	gc := NewGC(nil, 10*time.Second)
+
+	if gc.sessions == nil {
+		t.Fatal("NewGC nil provider did not install nil session adapter")
+	}
+	if gc.telemetry == nil {
+		t.Fatal("NewGC nil provider did not install nil telemetry adapter")
+	}
+	if gc.sessionCount != nil {
+		t.Fatal("NewGC nil provider retained session-count publisher")
+	}
+	if gc.persistent != nil {
+		t.Fatal("NewGC nil provider retained persistent NAT provider")
+	}
+}
+
+func TestNewGCTypedNilProviderKeepsAdapterBehavior(t *testing.T) {
+	var provider *nilRuntimeProvider
+	gc := NewGC(provider, 10*time.Second)
+
+	if gc.sessions == nil {
+		t.Fatal("NewGC typed nil provider did not install nil session adapter")
+	}
+	if gc.telemetry == nil {
+		t.Fatal("NewGC typed nil provider did not install nil telemetry adapter")
+	}
+	if gc.sessionCount != nil {
+		t.Fatal("NewGC typed nil provider retained session-count publisher")
+	}
+	if gc.persistent != nil {
+		t.Fatal("NewGC typed nil provider retained persistent NAT provider")
 	}
 }
 

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -43,7 +43,7 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/cluster/sync_bulk.go":                 "bulk sync still serializes legacy session entries",
 	"pkg/cluster/sync_conn.go":                 "sync connection code still references legacy session types",
 	"pkg/cluster/sync_protocol.go":             "wire protocol still carries legacy session records",
-	"pkg/conntrack/gc.go":                      "GC compatibility constructor still adapts legacy sessions",
+	"pkg/conntrack/gc.go":                      "GC still uses root session-domain types until those move out of pkg/dataplane",
 	"pkg/daemon/daemon.go":                     "daemon owns RuntimeDataPlane and exposes legacyDP for unmigrated callers",
 	"pkg/daemon/daemon_apply.go":               "apply path still adapts legacy compile/apply metadata",
 	"pkg/daemon/daemon_flow.go":                "flow logging still formats legacy dataplane counters",
@@ -1191,6 +1191,44 @@ func userspaceXDPEntryProgramConstantDrift(t *testing.T, roots []string) ([]stri
 	sort.Strings(found)
 	sort.Strings(violations)
 	return found, violations
+}
+
+func TestConntrackGCConstructorDoesNotAcceptLegacyDataPlane(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join("..", "conntrack", "gc.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse conntrack/gc.go: %v", err)
+	}
+
+	var foundNewGC bool
+	var legacyRefs []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && canaryExprString(sel) == "dataplane.DataPlane" {
+			legacyRefs = append(legacyRefs, fset.Position(sel.Pos()).String())
+		}
+
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "NewGC" {
+			return true
+		}
+		foundNewGC = true
+		if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+			t.Fatal("conntrack.NewGC has no provider parameter")
+		}
+		if got := canaryExprString(fn.Type.Params.List[0].Type); got != "RuntimeDomainProvider" {
+			t.Fatalf("conntrack.NewGC provider = %s, want RuntimeDomainProvider", got)
+		}
+		return true
+	})
+
+	if !foundNewGC {
+		t.Fatal("conntrack.NewGC not found")
+	}
+	if len(legacyRefs) > 0 {
+		t.Fatalf("conntrack GC must not reference dataplane.DataPlane: %v", legacyRefs)
+	}
 }
 
 func compilerDataplaneCalls(t *testing.T) map[string]bool {


### PR DESCRIPTION
Refs #1451.

## Summary
- Replace conntrack.NewGC(dataplane.DataPlane, ...) with NewGC(RuntimeDomainProvider, ...) over Sessions and Telemetry.
- Keep NewGCWithDomains as the exact explicit domain constructor and retain optional session-count/persistent-NAT extensions.
- Update conntrack and retirement docs, plus add a canary preventing the legacy DataPlane constructor from returning.

## Validation
- go test ./pkg/conntrack
- go test ./pkg/dataplane
- go test ./pkg/daemon -run 'Test.*ConntrackGC|TestNewConntrackGC' -count=1
- git diff --check

## Self-review
- pkg/conntrack/gc.go has no production dataplane.DataPlane reference; only root session-domain types remain.
- Nil and typed-nil provider construction is pinned so construction does not silently shift nil behavior.
- Daemon GC wiring still uses NewGCWithDomains, so DPDK/userspace runtime behavior remains deterministic.