### PR TITLE
Shrink logging event source boundary

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,16 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T20:58:00Z
+  - **Action**: PR #1451 review follow-up — extended the RT_FLOW
+    wire-offset canary across the full raw event layout and tightened
+    short-record boundary tests with nil, empty, short, and exact-size cases.
+  - **File(s)**: `pkg/logging/binary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
+    `go test ./pkg/logging -run
+    'TestRawEventFieldOffsetsMatchWireFormat|TestDecodeRawEventRecordRejectsShortRecord|TestProcessRawEventRejectsShortRecord'
+    -count=1`; `git diff --check`
+
 - **Timestamp**: 2026-05-24T20:47:00Z
   - **Action**: PR #1451 review follow-up — added direct RT_FLOW wire-offset
     assertions and explicit short-record rejection tests for the logging event

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,14 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T20:47:00Z
+  - **Action**: PR #1451 review follow-up — added direct RT_FLOW wire-offset
+    assertions and explicit short-record rejection tests for the logging event
+    decoder/reader without widening the production boundary again.
+  - **File(s)**: `pkg/logging/binary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-24T19:26:45Z
   - **Action**: #1451 logging boundary shrink — moved the logging event
     reader to a package-local `EventSource` interface and RT_FLOW event wire

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,20 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T19:26:45Z
+  - **Action**: #1451 logging boundary shrink — moved the logging event
+    reader to a package-local `EventSource` interface and RT_FLOW event wire
+    contract so `pkg/logging/ringbuf.go` no longer imports root
+    `pkg/dataplane`, then removed the stale #1451 allowlist/documentation
+    entry.
+  - **File(s)**: `pkg/logging/ringbuf.go`,
+    `pkg/logging/binary_test.go`,
+    `pkg/dataplane/retirement_boundary_canary_test.go`,
+    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
+    `go test ./pkg/daemon ./pkg/dataplane/userspace -count=1`;
+    `git diff --check`
+
 - **Timestamp**: 2026-05-24T18:47:00Z
   - **Action**: PR #1508 copilot follow-up — moved `IPERF_TIMEOUT` defaulting
     after argument parsing and env-file sourcing so the default tracks the

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -214,14 +214,13 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/grpcapi/server_show_security_text.go` | Security text output still uses legacy counters and filter types. |
 | `pkg/grpcapi/server_show_status.go` | Status output still reads legacy dataplane state. |
 | `pkg/grpcapi/server_show_zones.go` | Zone output still uses legacy dataplane types. |
-| `pkg/logging/ringbuf.go` | Event reader still consumes the legacy `EventSource`. |
 
 ### Safe-Delete Blockers
 
 - `pkg/dataplane.DataPlane` is still load-bearing for API, gRPC, CLI, status,
-  logging, cluster session sync, daemon HA, daemon flow, and daemon apply
-  bridges listed above. Conntrack GC now enters through `SessionStore` and
-  `Telemetry` runtime-domain providers. `pkg/monitoriface` now uses a
+  cluster session sync, daemon HA, daemon flow, and daemon apply bridges listed
+  above. Conntrack GC now enters through `SessionStore` and `Telemetry`
+  runtime-domain providers. `pkg/monitoriface` now uses a
   package-local `RuntimeDataPlane`/`CounterReader` shape; CLI and gRPC adapt
   their wider dataplane fields before entering the monitor-interface package.
 - Omitted `system dataplane-type` now resolves to the userspace runtime path.

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -63,7 +63,6 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/grpcapi/server_show_security_text.go": "security text output still uses legacy counters and filter types",
 	"pkg/grpcapi/server_show_status.go":        "status output still reads legacy dataplane state",
 	"pkg/grpcapi/server_show_zones.go":         "zone output still uses legacy dataplane types",
-	"pkg/logging/ringbuf.go":                   "event reader still consumes the legacy EventSource",
 }
 
 var dpdkEBPFImportAllowlist = map[string]string{

--- a/pkg/logging/binary_test.go
+++ b/pkg/logging/binary_test.go
@@ -5,18 +5,20 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
 func TestFormatBinaryRecord_Basic(t *testing.T) {
-	evt := &dataplane.Event{
-		EventType:   dataplane.EventTypeSessionOpen,
+	evt := &rawEvent{
+		EventType:   eventTypeSessionOpen,
 		Protocol:    6, // TCP
-		Action:      dataplane.ActionPermit,
-		AddrFamily:  dataplane.AFInet,
+		Action:      actionPermit,
+		AddrFamily:  addrFamilyInet,
 		SrcPort:     12345,
 		DstPort:     443,
 		PolicyID:    42,
@@ -54,17 +56,17 @@ func TestFormatBinaryRecord_Basic(t *testing.T) {
 	}
 
 	// Verify event fields
-	if buf[5] != dataplane.EventTypeSessionOpen {
-		t.Errorf("event type = %d, want %d", buf[5], dataplane.EventTypeSessionOpen)
+	if buf[5] != eventTypeSessionOpen {
+		t.Errorf("event type = %d, want %d", buf[5], eventTypeSessionOpen)
 	}
 	if buf[6] != 6 {
 		t.Errorf("protocol = %d, want 6", buf[6])
 	}
-	if buf[7] != dataplane.ActionPermit {
-		t.Errorf("action = %d, want %d", buf[7], dataplane.ActionPermit)
+	if buf[7] != actionPermit {
+		t.Errorf("action = %d, want %d", buf[7], actionPermit)
 	}
-	if buf[8] != dataplane.AFInet {
-		t.Errorf("addr family = %d, want %d", buf[8], dataplane.AFInet)
+	if buf[8] != addrFamilyInet {
+		t.Errorf("addr family = %d, want %d", buf[8], addrFamilyInet)
 	}
 	if buf[9] != uint8(SyslogInfo) {
 		t.Errorf("severity = %d, want %d", buf[9], SyslogInfo)
@@ -132,12 +134,155 @@ func TestFormatBinaryRecord_Basic(t *testing.T) {
 	}
 }
 
+func TestRawEventWireContractSize(t *testing.T) {
+	if rawEventWireSize != 136 {
+		t.Fatalf("rawEventWireSize = %d, want 136", rawEventWireSize)
+	}
+	if rawEventStructSize != rawEventWireSize {
+		t.Fatalf("rawEventStructSize = %d, want wire size %d",
+			rawEventStructSize, rawEventWireSize)
+	}
+}
+
+func TestRawEventContractMatchesDataplaneEvent(t *testing.T) {
+	if rawEventWireSize != int(unsafe.Sizeof(dataplane.Event{})) {
+		t.Fatalf("rawEventWireSize = %d, dataplane.Event size = %d",
+			rawEventWireSize, unsafe.Sizeof(dataplane.Event{}))
+	}
+	if eventTypeSessionOpen != dataplane.EventTypeSessionOpen {
+		t.Fatalf("eventTypeSessionOpen = %d, want %d",
+			eventTypeSessionOpen, dataplane.EventTypeSessionOpen)
+	}
+	if eventTypeSessionClose != dataplane.EventTypeSessionClose {
+		t.Fatalf("eventTypeSessionClose = %d, want %d",
+			eventTypeSessionClose, dataplane.EventTypeSessionClose)
+	}
+	if eventTypePolicyDeny != dataplane.EventTypePolicyDeny {
+		t.Fatalf("eventTypePolicyDeny = %d, want %d",
+			eventTypePolicyDeny, dataplane.EventTypePolicyDeny)
+	}
+	if eventTypeScreenDrop != dataplane.EventTypeScreenDrop {
+		t.Fatalf("eventTypeScreenDrop = %d, want %d",
+			eventTypeScreenDrop, dataplane.EventTypeScreenDrop)
+	}
+	if eventTypeFilterLog != dataplane.EventTypeFilterLog {
+		t.Fatalf("eventTypeFilterLog = %d, want %d",
+			eventTypeFilterLog, dataplane.EventTypeFilterLog)
+	}
+	if actionDeny != dataplane.ActionDeny ||
+		actionPermit != dataplane.ActionPermit ||
+		actionReject != dataplane.ActionReject {
+		t.Fatalf("action constants drifted: logging=(%d,%d,%d) dataplane=(%d,%d,%d)",
+			actionDeny, actionPermit, actionReject,
+			dataplane.ActionDeny, dataplane.ActionPermit, dataplane.ActionReject)
+	}
+	if addrFamilyInet != dataplane.AFInet || addrFamilyInet6 != dataplane.AFInet6 {
+		t.Fatalf("address family constants drifted: logging=(%d,%d) dataplane=(%d,%d)",
+			addrFamilyInet, addrFamilyInet6, dataplane.AFInet, dataplane.AFInet6)
+	}
+	if closeReasonNone != dataplane.CloseReasonNone ||
+		closeReasonTimeout != dataplane.CloseReasonTimeout ||
+		closeReasonTCPFIN != dataplane.CloseReasonTCPFIN ||
+		closeReasonTCPRST != dataplane.CloseReasonTCPRST ||
+		closeReasonAgeOut != dataplane.CloseReasonAgeOut ||
+		closeReasonPolicy != dataplane.CloseReasonPolicy {
+		t.Fatalf("close reason constants drifted")
+	}
+	if len(screenFlagNames) != len(dataplane.ScreenFlagNames) {
+		t.Fatalf("screen flag count = %d, want %d",
+			len(screenFlagNames), len(dataplane.ScreenFlagNames))
+	}
+	for flag, name := range dataplane.ScreenFlagNames {
+		if screenFlagNames[flag] != name {
+			t.Fatalf("screen flag %d = %q, want %q",
+				flag, screenFlagNames[flag], name)
+		}
+	}
+}
+
+func TestRawEventContractMatchesBPFHeader(t *testing.T) {
+	fields := eventStructFieldsFromXPFCommon(t)
+	want := []string{
+		"__u64 timestamp",
+		"__u8 src_ip[16]",
+		"__u8 dst_ip[16]",
+		"__be16 src_port",
+		"__be16 dst_port",
+		"__u32 policy_id",
+		"__u16 ingress_zone",
+		"__u16 egress_zone",
+		"__u8 event_type",
+		"__u8 protocol",
+		"__u8 action",
+		"__u8 addr_family",
+		"__u64 session_packets",
+		"__u64 session_bytes",
+		"__u8 nat_src_ip[16]",
+		"__u8 nat_dst_ip[16]",
+		"__be16 nat_src_port",
+		"__be16 nat_dst_port",
+		"__u32 created",
+		"__u64 rev_packets",
+		"__u64 rev_bytes",
+		"__u32 ingress_ifindex",
+		"__u16 app_id",
+		"__u8 close_reason",
+		"__u8 pad_event",
+	}
+	if len(fields) != len(want) {
+		t.Fatalf("struct event field count = %d, want %d\nfields: %v",
+			len(fields), len(want), fields)
+	}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Fatalf("struct event field %d = %q, want %q\nfields: %v",
+				i, fields[i], want[i], fields)
+		}
+	}
+}
+
+func eventStructFieldsFromXPFCommon(t *testing.T) []string {
+	t.Helper()
+	path := filepath.Join("..", "..", "bpf", "headers", "xpf_common.h")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(data)
+	start := strings.Index(text, "struct event {")
+	if start < 0 {
+		t.Fatalf("%s missing struct event", path)
+	}
+	bodyStart := start + len("struct event {")
+	end := strings.Index(text[bodyStart:], "\n};")
+	if end < 0 {
+		t.Fatalf("%s struct event missing terminator", path)
+	}
+	body := text[bodyStart : bodyStart+end]
+	var fields []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "/*") || strings.HasPrefix(line, "*") {
+			continue
+		}
+		if idx := strings.Index(line, "/*"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		line = strings.TrimSuffix(line, ";")
+		line = strings.Join(strings.Fields(line), " ")
+		if line != "" {
+			fields = append(fields, line)
+		}
+	}
+	return fields
+}
+
 func TestFormatBinaryRecord_SessionClose(t *testing.T) {
-	evt := &dataplane.Event{
-		EventType:   dataplane.EventTypeSessionClose,
+	evt := &rawEvent{
+		EventType:   eventTypeSessionClose,
 		Protocol:    6,
-		Action:      dataplane.ActionPermit,
-		AddrFamily:  dataplane.AFInet,
+		Action:      actionPermit,
+		AddrFamily:  addrFamilyInet,
 		SrcPort:     54321,
 		DstPort:     80,
 		PolicyID:    10,
@@ -162,7 +307,7 @@ func TestFormatBinaryRecord_SessionClose(t *testing.T) {
 		IngressIface:    "trust0",
 	}
 
-	buf := formatBinaryRecord(evt, rec, SyslogInfo, dataplane.CloseReasonTCPFIN)
+	buf := formatBinaryRecord(evt, rec, SyslogInfo, closeReasonTCPFIN)
 
 	// Verify session stats
 	pkts := binary.LittleEndian.Uint64(buf[98:106])
@@ -189,8 +334,8 @@ func TestFormatBinaryRecord_SessionClose(t *testing.T) {
 	}
 
 	// Verify close reason
-	if buf[142] != dataplane.CloseReasonTCPFIN {
-		t.Errorf("close reason = %d, want %d", buf[142], dataplane.CloseReasonTCPFIN)
+	if buf[142] != closeReasonTCPFIN {
+		t.Errorf("close reason = %d, want %d", buf[142], closeReasonTCPFIN)
 	}
 
 	// Verify ingress iface in variable section
@@ -206,11 +351,11 @@ func TestFormatBinaryRecord_SessionClose(t *testing.T) {
 }
 
 func TestFormatBinaryRecord_IPv6(t *testing.T) {
-	evt := &dataplane.Event{
-		EventType:   dataplane.EventTypeSessionOpen,
+	evt := &rawEvent{
+		EventType:   eventTypeSessionOpen,
 		Protocol:    6,
-		Action:      dataplane.ActionPermit,
-		AddrFamily:  dataplane.AFInet6,
+		Action:      actionPermit,
+		AddrFamily:  addrFamilyInet6,
 		SrcPort:     8080,
 		DstPort:     443,
 		IngressZone: 1,
@@ -231,8 +376,8 @@ func TestFormatBinaryRecord_IPv6(t *testing.T) {
 	buf := formatBinaryRecord(evt, rec, SyslogInfo, 0)
 
 	// Verify IPv6 addresses
-	if buf[8] != dataplane.AFInet6 {
-		t.Errorf("addr family = %d, want %d", buf[8], dataplane.AFInet6)
+	if buf[8] != addrFamilyInet6 {
+		t.Errorf("addr family = %d, want %d", buf[8], addrFamilyInet6)
 	}
 	gotSrc := net.IP(buf[18:34])
 	if !gotSrc.Equal(srcV6) {
@@ -245,10 +390,10 @@ func TestFormatBinaryRecord_IPv6(t *testing.T) {
 }
 
 func TestFormatBinaryRecord_EmptyStrings(t *testing.T) {
-	evt := &dataplane.Event{
-		EventType: dataplane.EventTypePolicyDeny,
+	evt := &rawEvent{
+		EventType: eventTypePolicyDeny,
 		Protocol:  17,
-		Action:    dataplane.ActionDeny,
+		Action:    actionDeny,
 	}
 	rec := &EventRecord{
 		Time:      time.Now(),
@@ -273,19 +418,19 @@ func TestFormatBinaryRecord_EmptyStrings(t *testing.T) {
 
 func TestFormatBinaryRecord_SelfFraming(t *testing.T) {
 	// Verify the record length field matches actual data — needed for TCP stream parsing
-	evt := &dataplane.Event{
-		EventType:   dataplane.EventTypeSessionOpen,
+	evt := &rawEvent{
+		EventType:   eventTypeSessionOpen,
 		Protocol:    6,
 		IngressZone: 1,
 	}
 	rec := &EventRecord{
-		Time:        time.Now(),
-		InZoneName:  "very-long-zone-name-for-testing",
-		OutZoneName: "another-zone",
-		PolicyName:  "my-policy",
-		AppName:     "custom-app",
+		Time:         time.Now(),
+		InZoneName:   "very-long-zone-name-for-testing",
+		OutZoneName:  "another-zone",
+		PolicyName:   "my-policy",
+		AppName:      "custom-app",
 		IngressIface: "ge-0/0/0",
-		SessionID:   99,
+		SessionID:    99,
 	}
 
 	buf := formatBinaryRecord(evt, rec, SyslogInfo, 0)
@@ -340,8 +485,8 @@ func TestSyslogSendBinary_UDP(t *testing.T) {
 	defer client.Close()
 
 	// Create a minimal binary record
-	evt := &dataplane.Event{
-		EventType: dataplane.EventTypeSessionOpen,
+	evt := &rawEvent{
+		EventType: eventTypeSessionOpen,
 		Protocol:  6,
 	}
 	rec := &EventRecord{
@@ -400,8 +545,8 @@ func TestSyslogSendBinary_TCP(t *testing.T) {
 	}
 	defer client.Close()
 
-	evt := &dataplane.Event{
-		EventType: dataplane.EventTypeSessionOpen,
+	evt := &rawEvent{
+		EventType: eventTypeSessionOpen,
 		Protocol:  17,
 	}
 	rec := &EventRecord{
@@ -439,10 +584,10 @@ func TestLocalLogWriterSendBinary(t *testing.T) {
 	}
 	defer lw.Close()
 
-	evt := &dataplane.Event{
-		EventType:   dataplane.EventTypeSessionClose,
+	evt := &rawEvent{
+		EventType:   eventTypeSessionClose,
 		Protocol:    6,
-		Action:      dataplane.ActionPermit,
+		Action:      actionPermit,
 		IngressZone: 1,
 		EgressZone:  2,
 	}
@@ -456,7 +601,7 @@ func TestLocalLogWriterSendBinary(t *testing.T) {
 		SessionID:    10,
 	}
 
-	binData := formatBinaryRecord(evt, rec, SyslogInfo, dataplane.CloseReasonTimeout)
+	binData := formatBinaryRecord(evt, rec, SyslogInfo, closeReasonTimeout)
 
 	if err := lw.SendBinary(binData); err != nil {
 		t.Fatal(err)
@@ -496,7 +641,7 @@ func TestLocalLogWriterSendBinary_Rotation(t *testing.T) {
 	}
 	defer lw.Close()
 
-	evt := &dataplane.Event{EventType: dataplane.EventTypeSessionOpen}
+	evt := &rawEvent{EventType: eventTypeSessionOpen}
 	rec := &EventRecord{Time: time.Now(), SessionID: 1}
 	binData := formatBinaryRecord(evt, rec, SyslogInfo, 0)
 

--- a/pkg/logging/binary_test.go
+++ b/pkg/logging/binary_test.go
@@ -241,6 +241,34 @@ func TestRawEventContractMatchesBPFHeader(t *testing.T) {
 	}
 }
 
+func TestRawEventFieldOffsetsMatchWireFormat(t *testing.T) {
+	var evt rawEvent
+	tests := []struct {
+		name string
+		got  uintptr
+		want uintptr
+	}{
+		{name: "SessionPackets", got: unsafe.Offsetof(evt.SessionPackets), want: 56},
+		{name: "SessionBytes", got: unsafe.Offsetof(evt.SessionBytes), want: 64},
+		{name: "NATSrcIP", got: unsafe.Offsetof(evt.NATSrcIP), want: 72},
+		{name: "NATDstIP", got: unsafe.Offsetof(evt.NATDstIP), want: 88},
+		{name: "NATSrcPort", got: unsafe.Offsetof(evt.NATSrcPort), want: 104},
+		{name: "NATDstPort", got: unsafe.Offsetof(evt.NATDstPort), want: 106},
+		{name: "Created", got: unsafe.Offsetof(evt.Created), want: 108},
+		{name: "RevPackets", got: unsafe.Offsetof(evt.RevPackets), want: 112},
+		{name: "RevBytes", got: unsafe.Offsetof(evt.RevBytes), want: 120},
+		{name: "IngressIfindex", got: unsafe.Offsetof(evt.IngressIfindex), want: 128},
+		{name: "AppID", got: unsafe.Offsetof(evt.AppID), want: 132},
+		{name: "CloseReason", got: unsafe.Offsetof(evt.CloseReason), want: 134},
+		{name: "PadEvent", got: unsafe.Offsetof(evt.PadEvent), want: 135},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Fatalf("%s offset = %d, want %d", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
 func eventStructFieldsFromXPFCommon(t *testing.T) []string {
 	t.Helper()
 	path := filepath.Join("..", "..", "bpf", "headers", "xpf_common.h")
@@ -275,6 +303,23 @@ func eventStructFieldsFromXPFCommon(t *testing.T) []string {
 		}
 	}
 	return fields
+}
+
+func TestDecodeRawEventRecordRejectsShortRecord(t *testing.T) {
+	if _, ok := DecodeRawEventRecord(make([]byte, rawEventWireSize-1)); ok {
+		t.Fatal("DecodeRawEventRecord accepted a short record")
+	}
+}
+
+func TestProcessRawEventRejectsShortRecord(t *testing.T) {
+	buffer := NewEventBuffer(4)
+	reader := NewEventReader(nil, buffer)
+	if reader.ProcessRawEvent(make([]byte, rawEventWireSize-1)) {
+		t.Fatal("ProcessRawEvent accepted a short record")
+	}
+	if got := buffer.Latest(1); got != nil {
+		t.Fatalf("buffer = %+v, want empty", got)
+	}
 }
 
 func TestFormatBinaryRecord_SessionClose(t *testing.T) {

--- a/pkg/logging/binary_test.go
+++ b/pkg/logging/binary_test.go
@@ -248,6 +248,18 @@ func TestRawEventFieldOffsetsMatchWireFormat(t *testing.T) {
 		got  uintptr
 		want uintptr
 	}{
+		{name: "Timestamp", got: unsafe.Offsetof(evt.Timestamp), want: 0},
+		{name: "SrcIP", got: unsafe.Offsetof(evt.SrcIP), want: 8},
+		{name: "DstIP", got: unsafe.Offsetof(evt.DstIP), want: 24},
+		{name: "SrcPort", got: unsafe.Offsetof(evt.SrcPort), want: 40},
+		{name: "DstPort", got: unsafe.Offsetof(evt.DstPort), want: 42},
+		{name: "PolicyID", got: unsafe.Offsetof(evt.PolicyID), want: 44},
+		{name: "IngressZone", got: unsafe.Offsetof(evt.IngressZone), want: 48},
+		{name: "EgressZone", got: unsafe.Offsetof(evt.EgressZone), want: 50},
+		{name: "EventType", got: unsafe.Offsetof(evt.EventType), want: 52},
+		{name: "Protocol", got: unsafe.Offsetof(evt.Protocol), want: 53},
+		{name: "Action", got: unsafe.Offsetof(evt.Action), want: 54},
+		{name: "AddrFamily", got: unsafe.Offsetof(evt.AddrFamily), want: 55},
 		{name: "SessionPackets", got: unsafe.Offsetof(evt.SessionPackets), want: 56},
 		{name: "SessionBytes", got: unsafe.Offsetof(evt.SessionBytes), want: 64},
 		{name: "NATSrcIP", got: unsafe.Offsetof(evt.NATSrcIP), want: 72},
@@ -305,20 +317,65 @@ func eventStructFieldsFromXPFCommon(t *testing.T) []string {
 	return fields
 }
 
+func minimallyValidRawEventData() []byte {
+	data := make([]byte, rawEventWireSize)
+	data[40] = 0x30 // src port 12345
+	data[41] = 0x39
+	data[42] = 0x01 // dst port 443
+	data[43] = 0xbb
+	data[52] = eventTypeSessionOpen
+	data[53] = 6
+	data[54] = actionPermit
+	data[55] = addrFamilyInet
+	copy(data[8:12], net.ParseIP("10.0.1.1").To4())
+	copy(data[24:28], net.ParseIP("10.0.2.1").To4())
+	return data
+}
+
 func TestDecodeRawEventRecordRejectsShortRecord(t *testing.T) {
-	if _, ok := DecodeRawEventRecord(make([]byte, rawEventWireSize-1)); ok {
-		t.Fatal("DecodeRawEventRecord accepted a short record")
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{name: "nil", data: nil, want: false},
+		{name: "empty", data: []byte{}, want: false},
+		{name: "short", data: make([]byte, rawEventWireSize-1), want: false},
+		{name: "exact", data: minimallyValidRawEventData(), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := DecodeRawEventRecord(tt.data)
+			if ok != tt.want {
+				t.Fatalf("DecodeRawEventRecord(%s) ok = %v, want %v", tt.name, ok, tt.want)
+			}
+		})
 	}
 }
 
 func TestProcessRawEventRejectsShortRecord(t *testing.T) {
-	buffer := NewEventBuffer(4)
-	reader := NewEventReader(nil, buffer)
-	if reader.ProcessRawEvent(make([]byte, rawEventWireSize-1)) {
-		t.Fatal("ProcessRawEvent accepted a short record")
+	tests := []struct {
+		name      string
+		data      []byte
+		wantOK    bool
+		wantCount int
+	}{
+		{name: "nil", data: nil, wantOK: false, wantCount: 0},
+		{name: "empty", data: []byte{}, wantOK: false, wantCount: 0},
+		{name: "short", data: make([]byte, rawEventWireSize-1), wantOK: false, wantCount: 0},
+		{name: "exact", data: minimallyValidRawEventData(), wantOK: true, wantCount: 1},
 	}
-	if got := buffer.Latest(1); got != nil {
-		t.Fatalf("buffer = %+v, want empty", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := NewEventBuffer(4)
+			reader := NewEventReader(nil, buffer)
+			if ok := reader.ProcessRawEvent(tt.data); ok != tt.wantOK {
+				t.Fatalf("ProcessRawEvent(%s) ok = %v, want %v", tt.name, ok, tt.wantOK)
+			}
+			if got := len(buffer.Latest(4)); got != tt.wantCount {
+				t.Fatalf("buffer count = %d, want %d", got, tt.wantCount)
+			}
+		})
 	}
 }
 

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -11,16 +11,128 @@ import (
 	"sync/atomic"
 	"time"
 	"unsafe"
-
-	"github.com/psaab/xpf/pkg/dataplane"
 )
 
 // EventCallback is called for each processed event record.
 type EventCallback func(rec EventRecord, raw []byte)
 
-// EventReader reads events from a dataplane EventSource.
+// EventSource reads raw RT_FLOW event records from a runtime source.
+type EventSource interface {
+	ReadEvent() ([]byte, error)
+	Close() error
+}
+
+// rawEvent mirrors the fixed 136-byte RT_FLOW event wire shape produced by the
+// runtime event sources. The decoder below still reads by offset so that port
+// byte order stays explicit.
+type rawEvent struct {
+	Timestamp      uint64
+	SrcIP          [16]byte
+	DstIP          [16]byte
+	SrcPort        uint16
+	DstPort        uint16
+	PolicyID       uint32
+	IngressZone    uint16
+	EgressZone     uint16
+	EventType      uint8
+	Protocol       uint8
+	Action         uint8
+	AddrFamily     uint8
+	SessionPackets uint64
+	SessionBytes   uint64
+	NATSrcIP       [16]byte
+	NATDstIP       [16]byte
+	NATSrcPort     uint16
+	NATDstPort     uint16
+	Created        uint32
+	RevPackets     uint64
+	RevBytes       uint64
+	IngressIfindex uint32
+	AppID          uint16
+	CloseReason    uint8
+	PadEvent       uint8
+}
+
+const (
+	rawEventWireSize   = 136
+	rawEventStructSize = int(unsafe.Sizeof(rawEvent{}))
+)
+
+var _ [rawEventWireSize]struct{} = [rawEventStructSize]struct{}{}
+
+const (
+	closeReasonNone    = 0
+	closeReasonTimeout = 1
+	closeReasonTCPFIN  = 2
+	closeReasonTCPRST  = 3
+	closeReasonAgeOut  = 4
+	closeReasonPolicy  = 5
+)
+
+const (
+	actionDeny   = 0
+	actionPermit = 1
+	actionReject = 2
+)
+
+const (
+	eventTypeSessionOpen  = 1
+	eventTypeSessionClose = 2
+	eventTypePolicyDeny   = 3
+	eventTypeScreenDrop   = 4
+	eventTypeFilterLog    = 6
+)
+
+const (
+	addrFamilyInet  = 2
+	addrFamilyInet6 = 10
+)
+
+const protoICMPv6 = 58
+
+const (
+	screenSynFlood        = 1 << 0
+	screenICMPFlood       = 1 << 1
+	screenUDPFlood        = 1 << 2
+	screenPortScan        = 1 << 3
+	screenIPSweep         = 1 << 4
+	screenLandAttack      = 1 << 5
+	screenPingOfDeath     = 1 << 6
+	screenTearDrop        = 1 << 7
+	screenTCPSynFin       = 1 << 8
+	screenTCPNoFlag       = 1 << 9
+	screenTCPFinNoAck     = 1 << 10
+	screenWinNuke         = 1 << 11
+	screenIPSourceRoute   = 1 << 12
+	screenSynFrag         = 1 << 13
+	screenSynCookie       = 1 << 14
+	screenSessionLimitSrc = 1 << 15
+	screenSessionLimitDst = 1 << 16
+)
+
+var screenFlagNames = map[uint32]string{
+	screenSynFlood:        "SYN flood",
+	screenICMPFlood:       "ICMP flood",
+	screenUDPFlood:        "UDP flood",
+	screenPortScan:        "port scan",
+	screenIPSweep:         "IP sweep",
+	screenLandAttack:      "LAND attack",
+	screenPingOfDeath:     "ping of death",
+	screenTearDrop:        "tear drop",
+	screenTCPSynFin:       "TCP SYN+FIN",
+	screenTCPNoFlag:       "TCP no-flag",
+	screenTCPFinNoAck:     "TCP FIN-no-ACK",
+	screenWinNuke:         "WinNuke",
+	screenIPSourceRoute:   "IP source-route",
+	screenSynFrag:         "SYN fragment",
+	screenSynCookie:       "SYN cookie",
+	screenSessionLimitSrc: "session limit (source)",
+	screenSessionLimitDst: "session limit (destination)",
+}
+
+// EventReader reads events from an EventSource.
 type EventReader struct {
-	source        dataplane.EventSource
+	source        EventSource
 	buffer        *EventBuffer
 	syslogMu      sync.RWMutex
 	syslogClients []*SyslogClient
@@ -40,7 +152,7 @@ type EventReader struct {
 }
 
 // NewEventReader creates a new event reader for the given event source.
-func NewEventReader(source dataplane.EventSource, buffer *EventBuffer) *EventReader {
+func NewEventReader(source EventSource, buffer *EventBuffer) *EventReader {
 	return &EventReader{
 		source: source,
 		buffer: buffer,
@@ -217,7 +329,7 @@ func (er *EventReader) Run(ctx context.Context) {
 			}
 		}
 
-		if len(data) < int(unsafe.Sizeof(dataplane.Event{})) {
+		if len(data) < rawEventWireSize {
 			continue
 		}
 
@@ -225,12 +337,12 @@ func (er *EventReader) Run(ctx context.Context) {
 	}
 }
 
-// ProcessRawEvent feeds an RT_FLOW-format dataplane.Event record through the
+// ProcessRawEvent feeds an RT_FLOW-format event record through the
 // same enrichment, buffering, callback, and syslog/local-log fanout path used
 // by the eBPF ring-buffer reader. Userspace transports should call this rather
 // than adding decoded records directly to EventBuffer.
 func (er *EventReader) ProcessRawEvent(data []byte) bool {
-	if len(data) < int(unsafe.Sizeof(dataplane.Event{})) {
+	if len(data) < rawEventWireSize {
 		return false
 	}
 	er.logEvent(data)
@@ -238,7 +350,7 @@ func (er *EventReader) ProcessRawEvent(data []byte) bool {
 }
 
 func (er *EventReader) logEvent(data []byte) {
-	var evt dataplane.Event
+	var evt rawEvent
 	evt.Timestamp = binary.LittleEndian.Uint64(data[0:8])
 	copy(evt.SrcIP[:], data[8:24])
 	copy(evt.DstIP[:], data[24:40])
@@ -262,7 +374,7 @@ func (er *EventReader) logEvent(data []byte) {
 	}
 
 	var srcStr, dstStr, natSrcStr, natDstStr string
-	if evt.AddrFamily == dataplane.AFInet6 {
+	if evt.AddrFamily == addrFamilyInet6 {
 		srcIP := net.IP(evt.SrcIP[:])
 		dstIP := net.IP(evt.DstIP[:])
 		srcStr = fmt.Sprintf("[%s]:%d", srcIP, evt.SrcPort)
@@ -303,7 +415,7 @@ func (er *EventReader) logEvent(data []byte) {
 		OutZoneName: er.resolveZoneName(evt.EgressZone),
 	}
 
-	if evt.EventType == dataplane.EventTypeSessionClose {
+	if evt.EventType == eventTypeSessionClose {
 		rec.SessionPkts = binary.LittleEndian.Uint64(data[56:64])
 		rec.SessionBytes = binary.LittleEndian.Uint64(data[64:72])
 		// Compute elapsed time from session creation
@@ -314,23 +426,23 @@ func (er *EventReader) logEvent(data []byte) {
 			}
 		}
 	}
-	if evt.EventType == dataplane.EventTypeScreenDrop {
+	if evt.EventType == eventTypeScreenDrop {
 		rec.ScreenCheck = screenFlagName(evt.PolicyID)
 	}
-	if evt.EventType != dataplane.EventTypeSessionClose && len(data) >= 136 {
+	if evt.EventType != eventTypeSessionClose && len(data) >= rawEventWireSize {
 		rec.RuleID = binary.LittleEndian.Uint32(data[56:60])
 		rec.TermID = binary.LittleEndian.Uint32(data[60:64])
 		rec.OwnerRGID = int16(binary.LittleEndian.Uint16(data[64:66]))
-		if evt.EventType == dataplane.EventTypeFilterLog && data[134] != 0 {
+		if evt.EventType == eventTypeFilterLog && data[134] != 0 {
 			rec.Reason = filterLogSourceName(data[134])
-		} else if data[134] != dataplane.CloseReasonNone {
+		} else if data[134] != closeReasonNone {
 			rec.Reason = closeReasonName(data[134])
 		}
 	}
 
 	// Parse extended fields (offset 112+)
 	var closeReasonCode uint8
-	if len(data) >= 136 {
+	if len(data) >= rawEventWireSize {
 		rec.RevSessionPkts = binary.LittleEndian.Uint64(data[112:120])
 		rec.RevSessionBytes = binary.LittleEndian.Uint64(data[120:128])
 		ifindex := binary.LittleEndian.Uint32(data[128:132])
@@ -343,7 +455,7 @@ func (er *EventReader) logEvent(data []byte) {
 	}
 
 	// Resolve policy name (skip for screen drops which repurpose policy_id)
-	if evt.EventType != dataplane.EventTypeScreenDrop {
+	if evt.EventType != eventTypeScreenDrop {
 		rec.PolicyName = er.resolvePolicyName(evt.PolicyID)
 	}
 
@@ -372,7 +484,7 @@ func (er *EventReader) logEvent(data []byte) {
 	if outZone == "" {
 		outZone = fmt.Sprintf("%d", evt.EgressZone)
 	}
-	if evt.EventType == dataplane.EventTypeSessionClose {
+	if evt.EventType == eventTypeSessionClose {
 		slog.Info("firewall event",
 			"type", eventName,
 			"src", srcStr,
@@ -384,7 +496,7 @@ func (er *EventReader) logEvent(data []byte) {
 			"egress_zone", outZone,
 			"session_packets", rec.SessionPkts,
 			"session_bytes", rec.SessionBytes)
-	} else if evt.EventType == dataplane.EventTypeScreenDrop {
+	} else if evt.EventType == eventTypeScreenDrop {
 		slog.Info("firewall event",
 			"type", eventName,
 			"screen_check", rec.ScreenCheck,
@@ -480,16 +592,16 @@ func (er *EventReader) logEvent(data []byte) {
 	}
 }
 
-// DecodeRawEventRecord decodes the fixed dataplane.Event RT_FLOW wire shape
+// DecodeRawEventRecord decodes the fixed RT_FLOW event wire shape
 // used by the eBPF ring buffer and by the userspace event-stream adapter.
 // It is decode-only; transports that need EventBuffer, callback, local-log,
 // and syslog fanout must call EventReader.ProcessRawEvent instead.
 func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
-	if len(data) < int(unsafe.Sizeof(dataplane.Event{})) {
+	if len(data) < rawEventWireSize {
 		return EventRecord{}, false
 	}
 
-	var evt dataplane.Event
+	var evt rawEvent
 	evt.Timestamp = binary.LittleEndian.Uint64(data[0:8])
 	copy(evt.SrcIP[:], data[8:24])
 	copy(evt.DstIP[:], data[24:40])
@@ -517,7 +629,7 @@ func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
 
 	var srcStr, dstStr, natSrcStr, natDstStr string
 	switch evt.AddrFamily {
-	case dataplane.AFInet6:
+	case addrFamilyInet6:
 		srcIP := net.IP(evt.SrcIP[:])
 		dstIP := net.IP(evt.DstIP[:])
 		srcStr = fmt.Sprintf("[%s]:%d", srcIP, evt.SrcPort)
@@ -526,7 +638,7 @@ func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
 		natDstIP := net.IP(evt.NATDstIP[:])
 		natSrcStr = fmt.Sprintf("[%s]:%d", natSrcIP, evt.NATSrcPort)
 		natDstStr = fmt.Sprintf("[%s]:%d", natDstIP, evt.NATDstPort)
-	case dataplane.AFInet:
+	case addrFamilyInet:
 		srcIP := net.IP(evt.SrcIP[:4])
 		dstIP := net.IP(evt.DstIP[:4])
 		srcStr = fmt.Sprintf("%s:%d", srcIP, evt.SrcPort)
@@ -557,22 +669,22 @@ func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
 		RevSessionBytes: evt.RevBytes,
 		CloseReason:     closeReasonName(evt.CloseReason),
 	}
-	if evt.EventType != dataplane.EventTypeSessionClose {
+	if evt.EventType != eventTypeSessionClose {
 		rec.SessionPkts = 0
 		rec.SessionBytes = 0
 		rec.RuleID = binary.LittleEndian.Uint32(data[56:60])
 		rec.TermID = binary.LittleEndian.Uint32(data[60:64])
 		rec.OwnerRGID = int16(binary.LittleEndian.Uint16(data[64:66]))
-		if evt.EventType == dataplane.EventTypeFilterLog && evt.CloseReason != 0 {
+		if evt.EventType == eventTypeFilterLog && evt.CloseReason != 0 {
 			rec.Reason = filterLogSourceName(evt.CloseReason)
-		} else if evt.CloseReason != dataplane.CloseReasonNone {
+		} else if evt.CloseReason != closeReasonNone {
 			rec.Reason = closeReasonName(evt.CloseReason)
 		}
 	}
 	if evt.Timestamp > 0 && evt.Timestamp <= uint64(1<<63-1) {
 		rec.Time = time.Unix(0, int64(evt.Timestamp))
 	}
-	if evt.EventType == dataplane.EventTypeScreenDrop {
+	if evt.EventType == eventTypeScreenDrop {
 		rec.ScreenCheck = screenFlagName(evt.PolicyID)
 	}
 	return rec, true
@@ -581,13 +693,13 @@ func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
 // eventCategory maps event types to category bitmask values.
 func eventCategory(eventType uint8) uint8 {
 	switch eventType {
-	case dataplane.EventTypeSessionOpen, dataplane.EventTypeSessionClose:
+	case eventTypeSessionOpen, eventTypeSessionClose:
 		return CategorySession
-	case dataplane.EventTypePolicyDeny:
+	case eventTypePolicyDeny:
 		return CategoryPolicy
-	case dataplane.EventTypeScreenDrop:
+	case eventTypeScreenDrop:
 		return CategoryScreen
-	case dataplane.EventTypeFilterLog:
+	case eventTypeFilterLog:
 		return CategoryFirewall
 	default:
 		return CategoryAll // unknown events pass all category filters
@@ -597,11 +709,11 @@ func eventCategory(eventType uint8) uint8 {
 // eventSeverity maps event types to syslog severity levels.
 func eventSeverity(eventType uint8) int {
 	switch eventType {
-	case dataplane.EventTypeScreenDrop:
+	case eventTypeScreenDrop:
 		return SyslogError
-	case dataplane.EventTypePolicyDeny:
+	case eventTypePolicyDeny:
 		return SyslogWarning
-	case dataplane.EventTypeFilterLog:
+	case eventTypeFilterLog:
 		return SyslogInfo
 	default:
 		return SyslogInfo
@@ -760,15 +872,15 @@ func splitAddrPort(addr string) (string, string) {
 
 func eventTypeName(t uint8) string {
 	switch t {
-	case dataplane.EventTypeSessionOpen:
+	case eventTypeSessionOpen:
 		return "SESSION_OPEN"
-	case dataplane.EventTypeSessionClose:
+	case eventTypeSessionClose:
 		return "SESSION_CLOSE"
-	case dataplane.EventTypePolicyDeny:
+	case eventTypePolicyDeny:
 		return "POLICY_DENY"
-	case dataplane.EventTypeScreenDrop:
+	case eventTypeScreenDrop:
 		return "SCREEN_DROP"
-	case dataplane.EventTypeFilterLog:
+	case eventTypeFilterLog:
 		return "FILTER_LOG"
 	default:
 		return fmt.Sprintf("UNKNOWN(%d)", t)
@@ -794,11 +906,11 @@ func filterLogSourceName(reason uint8) string {
 
 func actionName(a uint8) string {
 	switch a {
-	case dataplane.ActionPermit:
+	case actionPermit:
 		return "permit"
-	case dataplane.ActionDeny:
+	case actionDeny:
 		return "deny"
-	case dataplane.ActionReject:
+	case actionReject:
 		return "reject"
 	default:
 		return fmt.Sprintf("unknown(%d)", a)
@@ -813,7 +925,7 @@ func protoName(p uint8) string {
 		return "UDP"
 	case 1:
 		return "ICMP"
-	case dataplane.ProtoICMPv6:
+	case protoICMPv6:
 		return "ICMPv6"
 	default:
 		return fmt.Sprintf("%d", p)
@@ -821,7 +933,7 @@ func protoName(p uint8) string {
 }
 
 func screenFlagName(flag uint32) string {
-	if name, ok := dataplane.ScreenFlagNames[flag]; ok {
+	if name, ok := screenFlagNames[flag]; ok {
 		return name
 	}
 	return fmt.Sprintf("screen(0x%x)", flag)
@@ -869,7 +981,7 @@ const (
 //	  [142]     CloseReason code
 //	Variable section (uint8 length + UTF-8 bytes each):
 //	  InZoneName, OutZoneName, PolicyName, AppName, IngressIface
-func formatBinaryRecord(evt *dataplane.Event, rec *EventRecord, severity int, closeReason uint8) []byte {
+func formatBinaryRecord(evt *rawEvent, rec *EventRecord, severity int, closeReason uint8) []byte {
 	inZone := truncStr(rec.InZoneName, 255)
 	outZone := truncStr(rec.OutZoneName, 255)
 	policyName := truncStr(rec.PolicyName, 255)
@@ -951,15 +1063,15 @@ func putLenStr(buf []byte, off int, s string) int {
 
 func closeReasonName(reason uint8) string {
 	switch reason {
-	case dataplane.CloseReasonTimeout:
+	case closeReasonTimeout:
 		return "idle Timeout"
-	case dataplane.CloseReasonTCPFIN:
+	case closeReasonTCPFIN:
 		return "TCP FIN"
-	case dataplane.CloseReasonTCPRST:
+	case closeReasonTCPRST:
 		return "TCP RST"
-	case dataplane.CloseReasonAgeOut:
+	case closeReasonAgeOut:
 		return "aged out"
-	case dataplane.CloseReasonPolicy:
+	case closeReasonPolicy:
 		return "Rejected by policy"
 	default:
 		return "N/A"


### PR DESCRIPTION
## Summary
- Replace logging's root dataplane EventSource dependency with a
  package-local interface.
- Keep RT_FLOW event decoding behavior in logging with a local wire
  contract, fixed `rawEventWireSize`, and a compile-time local layout check.
- Add test canaries against `pkg/dataplane.Event` and the C `struct event`
  declaration in `bpf/headers/xpf_common.h`.
- Remove `pkg/logging/ringbuf.go` from the #1451 allowlist/docs and update
  `_Log.md`.

## Validation
- `go test ./pkg/logging ./pkg/dataplane -count=1`
- `go test ./pkg/daemon ./pkg/dataplane/userspace -count=1`
- `git diff --check`

Refs #1451
