### PR TITLE
dataplane: harden userspace shim boundary canary

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -32,6 +32,22 @@
     `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
   - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
     `go test ./pkg/daemon ./pkg/dataplane/userspace -count=1`;
+
+- **Timestamp**: 2026-05-24T19:29:17Z
+  - **Action**: Issue #1504 implementation — hardened the retained
+    userspace shim boundary canary against positional package-local
+    `dataplane.Manager` literals, production CGo imports, `go:linkname`,
+    `go:cgo_*` compiler directives, direct assembly and `.syso` object
+    files, and unallowlisted build tags while keeping DPDK CGo outside the
+    scanner. Documented the exact #1504 boundary
+    assumptions and allowlisted only generated legacy bpf2go architecture
+    tags plus the ignored loader stub.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`,
+    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane -run
+    'TestRetainedUserspaceShimBoundaryCanary|TestRetirementBoundaryDocsMentionShimEscapeAssumptions'
+    -count=1`; `go test ./pkg/dataplane -run
+    'Retirement|Canary|Userspace.*Entry|BPFShim' -count=1`;
     `git diff --check`
 
 - **Timestamp**: 2026-05-24T18:47:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,21 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T21:45:00Z
+  - **Action**: PR #1512 review follow-up — tightened the positional
+    `dataplane.Manager` literal canary on two axes. (a) Recurse into nested
+    composite literals whose `Type` is nil when the enclosing slice / array /
+    map container's element/value type is a package-local Manager named type,
+    closing the `[]Manager{{false, nil, "..."}}` / array / map bypass.
+    (b) Only flag when the element at `xdpEntryProgIndex` is positional
+    (not `*ast.KeyValueExpr`), so fully-keyed and mixed-where-xdpEntryProg-
+    is-keyed literals stop producing empty-string false-positive violations.
+    Added six fixture sub-tests pinning each direction.
+  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane/ -count=1`;
+    `go test ./pkg/dataplane/ -count=1 -run
+    'TestRetainedUserspaceShimBoundary|TestPositionalDataplaneManager' -v`
+
 - **Timestamp**: 2026-05-24T20:58:00Z
   - **Action**: PR #1451 review follow-up — extended the RT_FLOW
     wire-offset canary across the full raw event layout and tightened

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -145,6 +145,53 @@ The #1493 loader/bootstrap split keeps normal userspace startup on the
 userspace-only shim loader below. Source removal still waits for #1451's
 remaining operator/runtime surface migration and #1476's deletion candidate.
 
+## #1504 Userspace Shim Boundary Escape Assumptions
+
+The retained userspace shim boundary canary scans direct production files in
+`pkg/dataplane` and `pkg/dataplane/userspace`. It deliberately does not recurse
+into `pkg/dataplane/dpdk`; DPDK remains governed by the #1475 backend policy,
+including its `-tags dpdk` CGo files, and is not part of the userspace-only shim
+escape scan.
+
+Package-local `dataplane.Manager` construction must not use positional
+composite literals. The entry-program state lives in the unexported
+`xdpEntryProg` field, so positional `dataplane.Manager` literals can silently
+populate that field if the struct order changes or a local caller supplies all
+fields. Production code must use `dataplane.New()` plus the narrow
+userspace-shim selection/swap methods. Package-local tests may keep keyed
+literals when they intentionally need direct field setup.
+
+The same direct boundary packages must not add production `import "C"`,
+`//go:linkname`, `//go:cgo_*` compiler directives, `.s` / `.S` assembly files,
+or `.syso` precompiled object files. Those mechanisms can mutate Go state or
+hide alternate entry paths outside the AST selectors pinned by the entry-program
+canary. Production build constraints are also rejected unless they are
+explicitly allowlisted and documented here. The only current allowlist
+entries are the generated legacy bpf2go `*_bpfel.go` artifacts with the exact
+`//go:build 386 || amd64` architecture constraint, and
+`pkg/dataplane/loader_stub.go` with `//go:build ignore`, an ignored fallback
+stub for trees without generated legacy artifacts that is not part of normal
+builds. Any new boundary build tag, assembly or object file, CGo import, or Go
+compiler directive requires a matching canary allowlist rationale before it can
+land.
+
+Current generated legacy bpf2go build-tag allowlist:
+
+- `pkg/dataplane/xpftcconntrack_x86_bpfel.go`
+- `pkg/dataplane/xpftcforward_x86_bpfel.go`
+- `pkg/dataplane/xpftcmain_x86_bpfel.go`
+- `pkg/dataplane/xpftcnat_x86_bpfel.go`
+- `pkg/dataplane/xpftcscreenegress_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpconntrack_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpcpumap_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpforward_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpmain_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpnat64_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpnat_x86_bpfel.go`
+- `pkg/dataplane/xpfxdppolicy_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpscreen_x86_bpfel.go`
+- `pkg/dataplane/xpfxdpzone_x86_bpfel.go`
+
 ## #1493 Userspace Shim Loader Split
 
 Normal AF_XDP userspace startup now enters `LoadUserspaceShim()` and

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -73,6 +73,29 @@ var dpdkBackendImportAllowlist = map[string]string{
 	"cmd/xpfd/main.go": "backend registration and cleanup entry point",
 }
 
+var retainedShimBoundaryBuildTagAllowlist = map[string][]string{
+	// Generated legacy bpf2go artifacts keep bpf2go's architecture constraint
+	// until #1476 removes the legacy source/generated artifact set.
+	"pkg/dataplane/xpftcconntrack_x86_bpfel.go":    {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpftcforward_x86_bpfel.go":      {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpftcmain_x86_bpfel.go":         {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpftcnat_x86_bpfel.go":          {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpftcscreenegress_x86_bpfel.go": {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpconntrack_x86_bpfel.go":   {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpcpumap_x86_bpfel.go":      {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpforward_x86_bpfel.go":     {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpmain_x86_bpfel.go":        {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpnat64_x86_bpfel.go":       {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpnat_x86_bpfel.go":         {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdppolicy_x86_bpfel.go":      {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpscreen_x86_bpfel.go":      {"//go:build 386 || amd64"},
+	"pkg/dataplane/xpfxdpzone_x86_bpfel.go":        {"//go:build 386 || amd64"},
+
+	// Ignored fallback stub for trees without generated legacy artifacts; it is
+	// deliberately not part of any normal build.
+	"pkg/dataplane/loader_stub.go": {"//go:build ignore"},
+}
+
 var userspaceShimAllowedMapTypes = map[string]ebpf.MapType{
 	"dnat_table":                 ebpf.Hash,
 	"userspace_bindings":         ebpf.Array,
@@ -601,6 +624,16 @@ func TestUserspaceManagerDoesNotImportReflectOrUnsafe(t *testing.T) {
 	}
 }
 
+func TestRetainedUserspaceShimBoundaryCanaryRejectsExoticEscapes(t *testing.T) {
+	t.Parallel()
+
+	violations := retainedUserspaceShimBoundaryViolations(t, retainedUserspaceShimBoundaryPackageRoots(), true)
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("retained userspace shim boundary has exotic escape paths: %v", violations)
+	}
+}
+
 func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 	t.Parallel()
 
@@ -611,6 +644,160 @@ func TestUserspaceXDPEntryProgramConstantNamesRetainedShim(t *testing.T) {
 		sort.Strings(found)
 		sort.Strings(violations)
 		t.Fatalf("userspaceXDPEntryProg constant drift\nfound: %v\nviolations: %v", found, violations)
+	}
+}
+
+func TestRetainedUserspaceShimBoundaryCanaryRejectsExoticEscapeFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  []string
+	}{
+		{
+			name: "positional_dataplane_manager_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func hostile() *Manager {
+	return &Manager{false, nil, "xdp_main_prog"}
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
+			name: "positional_dataplane_manager_alias_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+type managerAlias = Manager
+
+func hostileAlias() managerAlias {
+	return managerAlias{false, nil, "xdp_main_prog"}
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
+			name: "positional_dataplane_manager_defined_type_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+type managerCopy Manager
+
+func hostileDefinedType() Manager {
+	return Manager(managerCopy{false, nil, "xdp_main_prog"})
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
+			name: "cgo_import",
+			files: map[string]string{
+				"cgo.go": `
+package userspace
+
+import "C"
+`,
+			},
+			want: []string{`imports "C"`},
+		},
+		{
+			name: "go_linkname",
+			files: map[string]string{
+				"linkname.go": `
+package userspace
+
+//go:linkname hostile github.com/psaab/xpf/pkg/dataplane.(*Manager).xdpEntryProg
+func hostile()
+`,
+			},
+			want: []string{"uses //go:linkname"},
+		},
+		{
+			name: "assembly_file",
+			files: map[string]string{
+				"escape.s": `
+TEXT ·hostile(SB),$0-0
+	RET
+`,
+			},
+			want: []string{"has assembly file"},
+		},
+		{
+			name: "precompiled_object_file",
+			files: map[string]string{
+				"escape.syso": "opaque object bytes",
+			},
+			want: []string{"has precompiled object file"},
+		},
+		{
+			name: "go_cgo_compiler_directive",
+			files: map[string]string{
+				"directive.go": `
+package userspace
+
+//go:cgo_import_dynamic libc_malloc malloc "libc.so"
+func hostile()
+`,
+			},
+			want: []string{"uses //go:cgo_ compiler directive"},
+		},
+		{
+			name: "go_build_tagged_file",
+			files: map[string]string{
+				"hidden.go": `
+//go:build linux
+
+package userspace
+`,
+			},
+			want: []string{"has unallowlisted build constraint", "//go:build linux"},
+		},
+		{
+			name: "legacy_build_tagged_file",
+			files: map[string]string{
+				"hidden_legacy.go": `
+// +build legacy
+
+package userspace
+`,
+			},
+			want: []string{"has unallowlisted build constraint", "// +build legacy"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeBoundaryFixture(t, tc.files)
+			violations := retainedUserspaceShimBoundaryViolations(t, []string{root}, false)
+			assertCanaryViolationContains(t, violations, tc.want...)
+		})
 	}
 }
 
@@ -1082,6 +1269,54 @@ func TestRetirementBoundaryDocsMentionDPDKPolicy(t *testing.T) {
 	}
 }
 
+func TestRetirementBoundaryDocsMentionShimEscapeAssumptions(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(retirementBoundaryDocsForCanary)
+	if err != nil {
+		t.Fatalf("read retirement boundary docs: %v", err)
+	}
+	text := string(data)
+
+	want := []string{
+		"## #1504 Userspace Shim Boundary Escape Assumptions",
+		"does not recurse",
+		"positional `dataplane.Manager`",
+		"`import \"C\"`",
+		"`//go:linkname`",
+		"`//go:cgo_*`",
+		"`.s` / `.S`",
+		"`.syso`",
+		"`*_bpfel.go`",
+		"`//go:build 386 || amd64`",
+		"`pkg/dataplane/loader_stub.go`",
+		"`//go:build ignore`",
+	}
+	for _, root := range retainedUserspaceShimBoundaryPackageRoots() {
+		want = append(want, "`"+repoRelativePath(t, root)+"`")
+	}
+	var allowlistPaths []string
+	for rel := range retainedShimBoundaryBuildTagAllowlist {
+		allowlistPaths = append(allowlistPaths, rel)
+	}
+	sort.Strings(allowlistPaths)
+	for _, rel := range allowlistPaths {
+		want = append(want, "`"+rel+"`")
+		for _, constraint := range retainedShimBoundaryBuildTagAllowlist[rel] {
+			want = append(want, "`"+constraint+"`")
+		}
+	}
+	var missing []string
+	for _, token := range want {
+		if !strings.Contains(text, token) {
+			missing = append(missing, token)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("retirement docs do not mention shim escape assumptions: %v", missing)
+	}
+}
+
 func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
 	t.Parallel()
 
@@ -1106,6 +1341,307 @@ func TestRetirementBoundaryDocsMentionLegacyImportAllowlist(t *testing.T) {
 type canaryParsedGoFile struct {
 	path string
 	file *ast.File
+}
+
+func retainedUserspaceShimBoundaryPackageRoots() []string {
+	return []string{
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane"),
+		filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace"),
+	}
+}
+
+func retainedUserspaceShimBoundaryViolations(t *testing.T, roots []string, checkAllowlists bool) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	var parsedFiles []canaryParsedGoFile
+	var violations []string
+	foundBuildTagAllowlist := map[string]bool{}
+
+	for _, path := range retainedUserspaceShimBoundaryFilesUnder(t, roots) {
+		rel := repoRelativePath(t, path)
+		if isGoAssemblyFile(path) {
+			violations = append(violations, rel+" has assembly file")
+			continue
+		}
+		if isGoObjectFile(path) {
+			violations = append(violations, rel+" has precompiled object file")
+			continue
+		}
+		if !strings.HasSuffix(path, ".go") {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(data)
+		buildConstraints := buildConstraintLines(text)
+		if len(buildConstraints) > 0 {
+			if _, ok := retainedShimBoundaryBuildTagAllowlist[rel]; ok {
+				foundBuildTagAllowlist[rel] = true
+			}
+			if !buildConstraintLinesAllowed(rel, buildConstraints) {
+				violations = append(violations, fmt.Sprintf(
+					"%s has unallowlisted build constraint %q",
+					rel,
+					strings.Join(buildConstraints, "; "),
+				))
+			}
+		}
+		for _, line := range goCompilerDirectiveLines(text) {
+			violations = append(violations, fmt.Sprintf("%s uses %s compiler directive %q", rel, goCompilerDirectiveKind(line), line))
+		}
+
+		file, err := parser.ParseFile(fset, path, data, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		parsedFiles = append(parsedFiles, canaryParsedGoFile{path: path, file: file})
+		for _, imp := range file.Imports {
+			if importPathLiteral(imp) == "C" {
+				pos := fset.Position(imp.Pos())
+				violations = append(violations, fmt.Sprintf("%s:%d imports \"C\"", rel, pos.Line))
+			}
+		}
+	}
+
+	violations = append(violations, positionalDataplaneManagerLiteralViolations(t, fset, parsedFiles)...)
+
+	if checkAllowlists {
+		for rel := range retainedShimBoundaryBuildTagAllowlist {
+			if !foundBuildTagAllowlist[rel] {
+				violations = append(violations, rel+" stale retained shim boundary build-tag allowlist entry")
+			}
+		}
+	}
+
+	sort.Strings(violations)
+	return violations
+}
+
+func retainedUserspaceShimBoundaryFilesUnder(t *testing.T, roots []string) []string {
+	t.Helper()
+
+	var files []string
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatalf("read boundary dir %s: %v", root, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			if strings.HasSuffix(name, ".go") || isGoAssemblyFile(name) || isGoObjectFile(name) {
+				files = append(files, filepath.Join(root, name))
+			}
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+func isGoAssemblyFile(path string) bool {
+	return strings.HasSuffix(path, ".s") || strings.HasSuffix(path, ".S")
+}
+
+func isGoObjectFile(path string) bool {
+	return strings.HasSuffix(path, ".syso")
+}
+
+func buildConstraintLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//go:build") || strings.HasPrefix(trimmed, "// +build") {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
+func buildConstraintLinesAllowed(rel string, got []string) bool {
+	allowed, ok := retainedShimBoundaryBuildTagAllowlist[rel]
+	if !ok || len(allowed) != len(got) {
+		return false
+	}
+	for i := range allowed {
+		if allowed[i] != got[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func goCompilerDirectiveLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//go:linkname") || strings.HasPrefix(trimmed, "//go:cgo_") {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
+func goCompilerDirectiveKind(line string) string {
+	switch {
+	case strings.HasPrefix(line, "//go:linkname"):
+		return "//go:linkname"
+	case strings.HasPrefix(line, "//go:cgo_"):
+		return "//go:cgo_"
+	default:
+		return "//go:"
+	}
+}
+
+func importPathLiteral(imp *ast.ImportSpec) string {
+	if imp == nil || imp.Path == nil {
+		return ""
+	}
+	path, err := strconv.Unquote(imp.Path.Value)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func positionalDataplaneManagerLiteralViolations(t *testing.T, fset *token.FileSet, files []canaryParsedGoFile) []string {
+	t.Helper()
+
+	xdpEntryProgIndex := dataplaneManagerFieldIndex(files, "xdpEntryProg")
+	if xdpEntryProgIndex < 0 {
+		return nil
+	}
+	managerTypeNames := packageLocalDataplaneManagerTypeNames(files)
+
+	var violations []string
+	for _, parsed := range files {
+		if parsed.file.Name == nil || parsed.file.Name.Name != "dataplane" {
+			continue
+		}
+		rel := repoRelativePath(t, parsed.path)
+		ast.Inspect(parsed.file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || !isPackageLocalDataplaneManagerLiteralType(lit.Type, managerTypeNames) {
+				return true
+			}
+			if len(lit.Elts) <= xdpEntryProgIndex || allCompositeLiteralElementsKeyed(lit) {
+				return true
+			}
+
+			pos := fset.Position(lit.Pos())
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d uses positional dataplane.Manager literal that can set xdpEntryProg from %q",
+				rel,
+				pos.Line,
+				canaryExprString(lit.Elts[xdpEntryProgIndex]),
+			))
+			return true
+		})
+	}
+	return violations
+}
+
+func dataplaneManagerFieldIndex(files []canaryParsedGoFile, fieldName string) int {
+	for _, parsed := range files {
+		if parsed.file.Name == nil || parsed.file.Name.Name != "dataplane" {
+			continue
+		}
+		for _, decl := range parsed.file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok || typeSpec.Name.Name != "Manager" {
+					continue
+				}
+				st, ok := typeSpec.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
+					continue
+				}
+				index := 0
+				for _, field := range st.Fields.List {
+					names := field.Names
+					if len(names) == 0 {
+						if fieldName == canaryExprString(field.Type) {
+							return index
+						}
+						index++
+						continue
+					}
+					for _, name := range names {
+						if name.Name == fieldName {
+							return index
+						}
+						index++
+					}
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func packageLocalDataplaneManagerTypeNames(files []canaryParsedGoFile) map[string]bool {
+	names := map[string]bool{"Manager": true}
+	for changed := true; changed; {
+		changed = false
+		for _, parsed := range files {
+			if parsed.file.Name == nil || parsed.file.Name.Name != "dataplane" {
+				continue
+			}
+			for _, decl := range parsed.file.Decls {
+				genDecl, ok := decl.(*ast.GenDecl)
+				if !ok || genDecl.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range genDecl.Specs {
+					typeSpec, ok := spec.(*ast.TypeSpec)
+					if !ok || names[typeSpec.Name.Name] {
+						continue
+					}
+					if names[typeIdentName(typeSpec.Type)] {
+						names[typeSpec.Name.Name] = true
+						changed = true
+					}
+				}
+			}
+		}
+	}
+	return names
+}
+
+func typeIdentName(expr ast.Expr) string {
+	ident, ok := unparenExpr(expr).(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
+}
+
+func isPackageLocalDataplaneManagerLiteralType(expr ast.Expr, managerTypeNames map[string]bool) bool {
+	return managerTypeNames[typeIdentName(expr)]
+}
+
+func allCompositeLiteralElementsKeyed(lit *ast.CompositeLit) bool {
+	if lit == nil {
+		return false
+	}
+	for _, elt := range lit.Elts {
+		if _, ok := elt.(*ast.KeyValueExpr); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {
@@ -1469,6 +2005,12 @@ func resolveUserspaceXDPEntryProgramIdents(files map[string]*ast.File) {
 }
 
 func writeUserspaceEntryProgramFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	return writeBoundaryFixture(t, files)
+}
+
+func writeBoundaryFixture(t *testing.T, files map[string]string) string {
 	t.Helper()
 
 	root := t.TempDir()

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -717,6 +717,63 @@ func hostileDefinedType() Manager {
 			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
 		},
 		{
+			name: "positional_dataplane_manager_in_slice_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func hostileSlice() []Manager {
+	return []Manager{{false, nil, "xdp_main_prog"}}
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
+			name: "positional_dataplane_manager_in_array_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func hostileArray() [1]Manager {
+	return [1]Manager{{false, nil, "xdp_main_prog"}}
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
+			name: "positional_dataplane_manager_in_map_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func hostileMap() map[string]Manager {
+	return map[string]Manager{"k": {false, nil, "xdp_main_prog"}}
+}
+`,
+			},
+			want: []string{"positional dataplane.Manager literal", "xdpEntryProg", "xdp_main_prog"},
+		},
+		{
 			name: "cgo_import",
 			files: map[string]string{
 				"cgo.go": `
@@ -797,6 +854,83 @@ package userspace
 			root := writeBoundaryFixture(t, tc.files)
 			violations := retainedUserspaceShimBoundaryViolations(t, []string{root}, false)
 			assertCanaryViolationContains(t, violations, tc.want...)
+		})
+	}
+}
+
+func TestPositionalDataplaneManagerLiteralCanaryAllowsKeyedFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "fully_keyed_dataplane_manager_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func keyedFull() Manager {
+	return Manager{loaded: true, programs: nil, xdpEntryProg: "xdp_userspace_prog"}
+}
+`,
+			},
+		},
+		{
+			name: "mixed_keyed_xdp_entry_prog_keyed_dataplane_manager_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func keyedSparse() Manager {
+	return Manager{loaded: true, xdpEntryProg: "xdp_userspace_prog"}
+}
+`,
+			},
+		},
+		{
+			name: "keyed_dataplane_manager_in_slice_literal",
+			files: map[string]string{
+				"manager.go": `
+package dataplane
+
+type Manager struct {
+	loaded bool
+	programs map[string]any
+	xdpEntryProg string
+}
+
+func keyedSlice() []Manager {
+	return []Manager{{loaded: true, programs: nil, xdpEntryProg: "xdp_userspace_prog"}}
+}
+`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeBoundaryFixture(t, tc.files)
+			violations := retainedUserspaceShimBoundaryViolations(t, []string{root}, false)
+			for _, v := range violations {
+				if strings.Contains(v, "positional dataplane.Manager literal") {
+					t.Fatalf("keyed Manager literal produced positional canary violation: %s\nall violations:\n%s",
+						v, strings.Join(violations, "\n"))
+				}
+			}
 		})
 	}
 }
@@ -1527,24 +1661,90 @@ func positionalDataplaneManagerLiteralViolations(t *testing.T, fset *token.FileS
 			continue
 		}
 		rel := repoRelativePath(t, parsed.path)
-		ast.Inspect(parsed.file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok || !isPackageLocalDataplaneManagerLiteralType(lit.Type, managerTypeNames) {
-				return true
+		var walk func(node ast.Node, inferredManager bool)
+		walk = func(node ast.Node, inferredManager bool) {
+			if node == nil {
+				return
 			}
-			if len(lit.Elts) <= xdpEntryProgIndex || allCompositeLiteralElementsKeyed(lit) {
-				return true
+			lit, isLit := node.(*ast.CompositeLit)
+			if !isLit {
+				ast.Inspect(node, func(n ast.Node) bool {
+					if n == node {
+						return true
+					}
+					if inner, ok := n.(*ast.CompositeLit); ok {
+						walk(inner, false)
+						return false
+					}
+					return true
+				})
+				return
 			}
 
-			pos := fset.Position(lit.Pos())
-			violations = append(violations, fmt.Sprintf(
-				"%s:%d uses positional dataplane.Manager literal that can set xdpEntryProg from %q",
-				rel,
-				pos.Line,
-				canaryExprString(lit.Elts[xdpEntryProgIndex]),
-			))
-			return true
-		})
+			// Decide whether this CompositeLit's element type is a
+			// package-local dataplane.Manager. The explicit lit.Type form
+			// covers the common `Manager{...}` and `aliasManager{...}`
+			// shape; the inferred form covers nested literals inside a
+			// slice / array / map container whose element / value type is
+			// Manager, e.g. `[]Manager{{false, nil, "..."}}`. In the
+			// inferred case Go omits the inner literal's type and we have
+			// to propagate it from the enclosing container.
+			isManagerLit := false
+			switch {
+			case lit.Type != nil && isPackageLocalDataplaneManagerLiteralType(lit.Type, managerTypeNames):
+				isManagerLit = true
+			case lit.Type == nil && inferredManager:
+				isManagerLit = true
+			}
+
+			// Compute the inferred element / value type for nested literals
+			// inside this CompositeLit so the recursive walk can decide
+			// whether they should be treated as Manager literals.
+			childInferred := false
+			if lit.Type != nil {
+				switch ty := lit.Type.(type) {
+				case *ast.ArrayType:
+					childInferred = isPackageLocalDataplaneManagerLiteralType(ty.Elt, managerTypeNames)
+				case *ast.MapType:
+					childInferred = isPackageLocalDataplaneManagerLiteralType(ty.Value, managerTypeNames)
+				}
+			}
+
+			if isManagerLit && len(lit.Elts) > xdpEntryProgIndex {
+				target := lit.Elts[xdpEntryProgIndex]
+				// Only positional elements at xdpEntryProgIndex can leak
+				// the program name. A keyed element at that slot is by
+				// definition not setting xdpEntryProg positionally; if it
+				// is the xdpEntryProg= keyed form the per-field canary in
+				// userspaceXDPEntryProgramViolations catches it. Skipping
+				// here avoids confusing empty-string violations on mixed
+				// keyed / positional literals.
+				if _, keyed := target.(*ast.KeyValueExpr); !keyed {
+					pos := fset.Position(lit.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d uses positional dataplane.Manager literal that can set xdpEntryProg from %q",
+						rel,
+						pos.Line,
+						canaryExprString(target),
+					))
+				}
+			}
+
+			for _, elt := range lit.Elts {
+				switch e := elt.(type) {
+				case *ast.CompositeLit:
+					walk(e, childInferred)
+				case *ast.KeyValueExpr:
+					// Map-keyed: `"k": {...}` — value inherits container
+					// value type; key does not.
+					walk(e.Key, false)
+					walk(e.Value, childInferred)
+				default:
+					walk(elt, false)
+				}
+			}
+		}
+		walk(parsed.file, false)
 	}
 	return violations
 }
@@ -1630,18 +1830,6 @@ func typeIdentName(expr ast.Expr) string {
 
 func isPackageLocalDataplaneManagerLiteralType(expr ast.Expr, managerTypeNames map[string]bool) bool {
 	return managerTypeNames[typeIdentName(expr)]
-}
-
-func allCompositeLiteralElementsKeyed(lit *ast.CompositeLit) bool {
-	if lit == nil {
-		return false
-	}
-	for _, elt := range lit.Elts {
-		if _, ok := elt.(*ast.KeyValueExpr); !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func userspaceXDPEntryProgramViolations(t *testing.T, roots []string) []string {


### PR DESCRIPTION
## Summary
- Harden the retained userspace shim boundary canary against positional
  package-local `dataplane.Manager` literals, CGo imports, `go:linkname`,
  direct assembly files, and unallowlisted build tags.
- Keep DPDK/CGo outside the scanner and exact-allowlist only the current
  generated legacy bpf2go arch tags plus `loader_stub.go`'s ignored tag.
- Add hostile fixtures for both `//go:build` and legacy `// +build`, and
  make README parity assertions iterate the scanner roots and build-tag
  allowlist.

## Validation
- `go test ./pkg/dataplane -run 'TestRetainedUserspaceShimBoundaryCanaryRejectsExoticEscapeFixtures|TestRetirementBoundaryDocsMentionShimEscapeAssumptions|TestRetainedUserspaceShimBoundaryCanaryRejectsExoticEscapes' -count=1`
- `go test ./pkg/dataplane -run 'Retirement|Canary|Userspace.*Entry|BPFShim' -count=1`
- `git diff --check`

Fixes #1504
