### PR TITLE
Cover userspace link-cycle control-plane regressions

### DIFF
--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -527,6 +527,400 @@ func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	}
 }
 
+func TestUserspaceLinkCycleDoesNotReenterLegacyLoader(t *testing.T) {
+	t.Parallel()
+
+	violations, missing := linkCycleLegacyLoaderTargetViolations(t, productionLinkCycleLegacyLoaderTargets())
+	if len(missing) > 0 {
+		t.Fatalf("userspace link-cycle methods not found: %v", missing)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("userspace link-cycle code must not reference legacy loader or xdp_main_prog controls: %v", violations)
+	}
+}
+
+type linkCycleLegacyLoaderTarget struct {
+	path     string
+	receiver string
+	methods  map[string]bool
+}
+
+func productionLinkCycleLegacyLoaderTargets() []linkCycleLegacyLoaderTarget {
+	return []linkCycleLegacyLoaderTarget{
+		{
+			path:     filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace", "process.go"),
+			receiver: "Manager",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+		{
+			path:     filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace", "manager.go"),
+			receiver: "userspaceLinkController",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+		{
+			path:     filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace", "legacy_dataplane.go"),
+			receiver: "LegacyDataPlaneAdapter",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+	}
+}
+
+func linkCycleLegacyLoaderTargetViolations(
+	t *testing.T,
+	targets []linkCycleLegacyLoaderTarget,
+) ([]string, []string) {
+	t.Helper()
+
+	var violations []string
+	var missing []string
+	for _, target := range targets {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, target.path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", target.path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || receiverTypeName(fn.Recv.List[0].Type) != target.receiver {
+				continue
+			}
+			if _, ok := target.methods[fn.Name.Name]; !ok {
+				continue
+			}
+			target.methods[fn.Name.Name] = true
+			violations = append(violations, linkCycleLegacyLoaderFunctionViolations(
+				t,
+				fset,
+				target.path,
+				target.receiver,
+				fn,
+			)...)
+		}
+		for method, found := range target.methods {
+			if !found {
+				missing = append(missing, repoRelativePath(t, target.path)+":"+method)
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+	}
+	sort.Strings(violations)
+	return violations, missing
+}
+
+func linkCycleLegacyLoaderFunctionViolations(
+	t *testing.T,
+	fset *token.FileSet,
+	path string,
+	receiver string,
+	fn *ast.FuncDecl,
+) []string {
+	t.Helper()
+
+	aliases := linkCycleLegacyLoaderRootAliases(receiver, receiverValueName(fn.Recv.List[0]))
+	var violations []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, rhs := range node.Rhs {
+				if i < len(node.Lhs) {
+					linkCycleRecordLegacyLoaderAlias(node.Lhs[i], rhs, aliases)
+				}
+			}
+		case *ast.ValueSpec:
+			for i, rhs := range node.Values {
+				if i < len(node.Names) {
+					linkCycleRecordLegacyLoaderAlias(node.Names[i], rhs, aliases)
+				}
+			}
+		case *ast.SelectorExpr:
+			if !linkCycleLegacyLoaderSelector(node, aliases) {
+				return true
+			}
+			pos := fset.Position(node.Pos())
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d %s references %s.%s during userspace link-cycle handling",
+				repoRelativePath(t, path),
+				pos.Line,
+				fn.Name.Name,
+				linkCycleSelectorReceiverString(node.X),
+				node.Sel.Name,
+			))
+		}
+		return true
+	})
+	return violations
+}
+
+func receiverValueName(recv *ast.Field) string {
+	if recv != nil && len(recv.Names) > 0 {
+		return recv.Names[0].Name
+	}
+	return ""
+}
+
+func linkCycleLegacyLoaderRootAliases(receiver, name string) map[string]bool {
+	aliases := map[string]bool{}
+	if name == "" {
+		return aliases
+	}
+	switch receiver {
+	case "Manager":
+		aliases[name] = true
+		aliases[name+".bpfShim"] = true
+	case "userspaceLinkController":
+		aliases[name+".manager"] = true
+		aliases[name+".manager.bpfShim"] = true
+	case "LegacyDataPlaneAdapter":
+		aliases[name] = true
+		aliases[name+".DataPlane"] = true
+	}
+	return aliases
+}
+
+func linkCycleRecordLegacyLoaderAlias(lhs ast.Expr, rhs ast.Expr, aliases map[string]bool) {
+	id, ok := lhs.(*ast.Ident)
+	if !ok || id.Name == "_" {
+		return
+	}
+	if linkCycleLegacyLoaderExpr(rhs, aliases) {
+		aliases[id.Name] = true
+		aliases[id.Name+".bpfShim"] = true
+		aliases[id.Name+".DataPlane"] = true
+	}
+}
+
+func linkCycleLegacyLoaderSelector(sel *ast.SelectorExpr, aliases map[string]bool) bool {
+	if !linkCycleLegacyLoaderMethod(sel.Sel.Name) {
+		return false
+	}
+	return linkCycleLegacyLoaderExpr(sel.X, aliases) || linkCycleLegacyManagerTypeExpr(sel.X)
+}
+
+func linkCycleLegacyLoaderMethod(name string) bool {
+	switch name {
+	case "Load", "Compile",
+		"LoadUserspaceShim", "CompileUserspaceShim",
+		"AttachXDP", "SelectUserspaceXDPShimEntryProgram",
+		"SwapToUserspaceXDPShimEntryProgram", "SwapXDPEntryProg":
+		return true
+	default:
+		return false
+	}
+}
+
+func linkCycleLegacyLoaderExpr(expr ast.Expr, aliases map[string]bool) bool {
+	expr = unparenCanaryExpr(expr)
+	if aliases[canaryExprString(expr)] {
+		return true
+	}
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		switch e.Sel.Name {
+		case "bpfShim", "DataPlane":
+			return linkCycleLegacyLoaderExpr(e.X, aliases)
+		default:
+			return false
+		}
+	case *ast.TypeAssertExpr:
+		return linkCycleLegacyLoaderExpr(e.X, aliases) && linkCycleLegacyManagerTypeExpr(e.Type)
+	case *ast.CallExpr:
+		sel, ok := unparenCanaryExpr(e.Fun).(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "managerOrErr" && linkCycleLegacyLoaderExpr(sel.X, aliases)
+	default:
+		return false
+	}
+}
+
+func linkCycleLegacyManagerTypeExpr(expr ast.Expr) bool {
+	expr = unparenCanaryExpr(expr)
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "Manager"
+	case *ast.SelectorExpr:
+		return canaryExprString(e) == "dataplane.Manager"
+	case *ast.StarExpr:
+		return linkCycleLegacyManagerTypeExpr(e.X)
+	default:
+		return false
+	}
+}
+
+func linkCycleSelectorReceiverString(expr ast.Expr) string {
+	if got := canaryExprString(unparenCanaryExpr(expr)); got != "" {
+		return got
+	}
+	return fmt.Sprintf("%T", expr)
+}
+
+func unparenCanaryExpr(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
+func TestLinkCycleLegacyLoaderSelectorCatchesLegacyReceivers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		{expr: "m.Load", want: true},
+		{expr: "c.manager.CompileUserspaceShim", want: true},
+		{expr: "a.Load", want: true},
+		{expr: "m.bpfShim.LoadUserspaceShim", want: true},
+		{expr: "c.manager.bpfShim.SelectUserspaceXDPShimEntryProgram", want: true},
+		{expr: "a.DataPlane.Load", want: true},
+		{expr: "mgr.Load", want: true},
+		{expr: "shim.AttachXDP", want: true},
+		{expr: "(*Manager).Load", want: true},
+		{expr: "atomic.Load", want: false},
+		{expr: "m.rgTransitionInFlight.Load", want: false},
+		{expr: "m.somethingNew.Load", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tt.expr)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tt.expr, err)
+			}
+			sel, ok := expr.(*ast.SelectorExpr)
+			if !ok {
+				t.Fatalf("%s parsed as %T, want *ast.SelectorExpr", tt.expr, expr)
+			}
+			aliases := map[string]bool{
+				"m":                 true,
+				"m.bpfShim":         true,
+				"c.manager":         true,
+				"c.manager.bpfShim": true,
+				"a":                 true,
+				"a.DataPlane":       true,
+				"mgr":               true,
+				"mgr.bpfShim":       true,
+				"shim":              true,
+				"dp":                true,
+				"dp.DataPlane":      true,
+			}
+			if got := linkCycleLegacyLoaderSelector(sel, aliases); got != tt.want {
+				t.Fatalf("linkCycleLegacyLoaderSelector(%s) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserspaceLinkCycleCanaryRejectsLegacyLoaderFixtures(t *testing.T) {
+	t.Parallel()
+
+	root := writeUserspaceEntryProgramFixture(t, map[string]string{
+		"link_cycle.go": `
+package userspace
+
+import "github.com/psaab/xpf/pkg/dataplane"
+
+type Manager struct {
+	bpfShim shim
+	rgTransitionInFlight counter
+	somethingNew counter
+}
+type shim struct{}
+type counter struct{}
+
+func (m *Manager) PrepareLinkCycle() {
+	m.somethingNew.Load()
+}
+
+func (m *Manager) NotifyLinkCycle() {
+	mgr := m
+	mgr.Load()
+	m.bpfShim.LoadUserspaceShim()
+	(*Manager).Load(m)
+}
+
+type userspaceLinkController struct {
+	manager *Manager
+}
+
+func (c userspaceLinkController) PrepareLinkCycle() {
+	mgr := c.manager
+	mgr.Compile()
+	shim := c.manager.bpfShim
+	shim.CompileUserspaceShim(nil)
+}
+
+func (c userspaceLinkController) NotifyLinkCycle() {}
+
+type LegacyDataPlaneAdapter struct {
+	DataPlane any
+}
+
+func (a *LegacyDataPlaneAdapter) PrepareLinkCycle() {
+	dp := a.DataPlane
+	dp.Compile(nil)
+	a.DataPlane.(*dataplane.Manager).Load()
+}
+
+func (a *LegacyDataPlaneAdapter) NotifyLinkCycle() {
+	a.DataPlane.Load()
+}
+`,
+	})
+	path := filepath.Join(root, "link_cycle.go")
+	targets := []linkCycleLegacyLoaderTarget{
+		{
+			path:     path,
+			receiver: "Manager",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+		{
+			path:     path,
+			receiver: "userspaceLinkController",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+		{
+			path:     path,
+			receiver: "LegacyDataPlaneAdapter",
+			methods: map[string]bool{
+				"PrepareLinkCycle": false,
+				"NotifyLinkCycle":  false,
+			},
+		},
+	}
+	violations, missing := linkCycleLegacyLoaderTargetViolations(t, targets)
+	if len(missing) > 0 {
+		t.Fatalf("fixture link-cycle methods not found: %v", missing)
+	}
+	assertCanaryViolationContains(t, violations, "NotifyLinkCycle", "mgr.Load")
+	assertCanaryViolationContains(t, violations, "NotifyLinkCycle", "m.bpfShim.LoadUserspaceShim")
+	assertCanaryViolationContains(t, violations, "NotifyLinkCycle", "*Manager.Load")
+	assertCanaryViolationContains(t, violations, "PrepareLinkCycle", "mgr.Compile")
+	assertCanaryViolationContains(t, violations, "PrepareLinkCycle", "shim.CompileUserspaceShim")
+	assertCanaryViolationContains(t, violations, "PrepareLinkCycle", "dp.Compile")
+	assertCanaryViolationContains(t, violations, "PrepareLinkCycle", "*ast.TypeAssertExpr.Load")
+	assertCanaryViolationContains(t, violations, "NotifyLinkCycle", "a.DataPlane.Load")
+}
+
 func TestBPFShimEntryProgramStateIsNotJSONMutable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dataplane/userspace/link_cycle_test.go
+++ b/pkg/dataplane/userspace/link_cycle_test.go
@@ -1,0 +1,412 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+type linkCycleControlEvent struct {
+	Request       ControlRequest
+	Ctrl          userspaceCtrlValue
+	CtrlLookupErr error
+	Err           error
+}
+
+func TestPrepareLinkCycleDisablesCtrlBeforeStopWorkers(t *testing.T) {
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+	m, ctrlMap, _ := newLinkCycleTestManager(t, controlSock)
+	seedUserspaceCtrl(t, ctrlMap, userspaceCtrlValue{
+		Enabled:            1,
+		MetadataVersion:    userspaceMetadataVersion,
+		Workers:            2,
+		QueueCount:         2,
+		Flags:              userspaceCtrlFlagStrict,
+		ConfigGeneration:   41,
+		FIBGeneration:      7,
+		HeartbeatTimeoutMS: 30000,
+	})
+
+	events := startLinkCycleControlServer(t, controlSock, ctrlMap, []ProcessStatus{{
+		PID:      4242,
+		Bindings: []BindingStatus{{Slot: 3, Ifindex: 2, QueueID: 1, Ready: true}},
+	}})
+
+	m.PrepareLinkCycle()
+
+	ev := nextLinkCycleControlEvent(t, events)
+	if ev.Request.Type != "stop_workers" {
+		t.Fatalf("request type = %q, want stop_workers", ev.Request.Type)
+	}
+	if ev.CtrlLookupErr != nil {
+		t.Fatalf("lookup userspace_ctrl at stop_workers: %v", ev.CtrlLookupErr)
+	}
+	if ev.Ctrl.Enabled != 0 {
+		t.Fatalf("userspace_ctrl.Enabled at stop_workers = %d, want 0", ev.Ctrl.Enabled)
+	}
+	ctrl := lookupUserspaceCtrl(t, ctrlMap)
+	if ctrl.Enabled != 0 {
+		t.Fatalf("userspace_ctrl.Enabled after PrepareLinkCycle = %d, want 0", ctrl.Enabled)
+	}
+	if ctrl.Flags != userspaceCtrlFlagStrict {
+		t.Fatalf("userspace_ctrl.Flags after PrepareLinkCycle = %#x, want strict flag preserved", ctrl.Flags)
+	}
+	if got := m.bpfShim.XDPEntryProgram(); got != userspaceXDPEntryProg {
+		t.Fatalf("XDPEntryProgram() = %q, want %q", got, userspaceXDPEntryProg)
+	}
+}
+
+func TestNotifyLinkCycleRebindsAndAppliesHelperStatusCompat(t *testing.T) {
+	skipLinkCycleRebindSleep(t)
+
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+	m, ctrlMap, bindingsMap := newLinkCycleTestManager(t, controlSock)
+	seedUserspaceCtrl(t, ctrlMap, userspaceCtrlValue{
+		Enabled:            1,
+		MetadataVersion:    userspaceMetadataVersion,
+		Workers:            2,
+		QueueCount:         2,
+		ConfigGeneration:   11,
+		FIBGeneration:      3,
+		HeartbeatTimeoutMS: 30000,
+	})
+	m.configuredMode = ModeUserspaceCompat
+	m.neighborsPrewarmed = true
+	m.ctrlWasEnabled = true
+	m.xskLivenessProven = true
+	m.xskLivenessFailed = true
+	m.xskProbeStart = time.Now().Add(-20 * time.Second)
+	m.lastXSKRX = 99
+
+	rebindStatus := ProcessStatus{
+		PID:                    5150,
+		Workers:                4,
+		Enabled:                true,
+		ForwardingArmed:        true,
+		Capabilities:           UserspaceCapabilities{ForwardingSupported: true},
+		LastSnapshotGeneration: 88,
+		LastFIBGeneration:      13,
+		NeighborGeneration:     21,
+		Bindings: []BindingStatus{{
+			Slot:       5,
+			Ifindex:    2,
+			QueueID:    1,
+			Registered: true,
+			Armed:      true,
+			Bound:      true,
+			RXPackets:  17,
+		}},
+	}
+	events := startLinkCycleControlServer(t, controlSock, ctrlMap, []ProcessStatus{rebindStatus})
+
+	m.NotifyLinkCycle()
+
+	ev := nextLinkCycleControlEvent(t, events)
+	if ev.Request.Type != "rebind" {
+		t.Fatalf("request type = %q, want rebind", ev.Request.Type)
+	}
+	if ev.CtrlLookupErr != nil {
+		t.Fatalf("lookup userspace_ctrl at rebind: %v", ev.CtrlLookupErr)
+	}
+	if ev.Ctrl.Enabled != 0 {
+		t.Fatalf("userspace_ctrl.Enabled at rebind = %d, want 0", ev.Ctrl.Enabled)
+	}
+
+	ctrl := lookupUserspaceCtrl(t, ctrlMap)
+	if ctrl.Enabled != 1 {
+		t.Fatalf("userspace_ctrl.Enabled after NotifyLinkCycle = %d, want 1", ctrl.Enabled)
+	}
+	if ctrl.Flags&userspaceCtrlFlagStrict != 0 {
+		t.Fatalf("userspace_ctrl.Flags = %#x, want compat mode without strict flag", ctrl.Flags)
+	}
+	if ctrl.Workers != 4 || ctrl.QueueCount != 2 || ctrl.ConfigGeneration != 88 || ctrl.FIBGeneration != 13 {
+		t.Fatalf("userspace_ctrl after NotifyLinkCycle = %+v, want helper status applied", ctrl)
+	}
+	if !m.xskLivenessProven || m.xskLivenessFailed || !m.xskProbeStart.IsZero() || m.lastXSKRX != 17 {
+		t.Fatalf(
+			"XSK liveness after NotifyLinkCycle = proven=%v failed=%v probe=%v lastRX=%d, want fresh live state from rebind status",
+			m.xskLivenessProven,
+			m.xskLivenessFailed,
+			m.xskProbeStart,
+			m.lastXSKRX,
+		)
+	}
+	if got := m.lastStatus.PID; got != rebindStatus.PID {
+		t.Fatalf("lastStatus.PID = %d, want %d", got, rebindStatus.PID)
+	}
+	binding := lookupUserspaceBinding(t, bindingsMap, 2*bindingQueuesPerIface+1)
+	if binding.Slot != 5 || binding.Flags != userspaceBindingReady {
+		t.Fatalf("userspace_bindings[ifindex=2 queue=1] = %+v, want slot=5 ready", binding)
+	}
+	if got := m.bpfShim.XDPEntryProgram(); got != userspaceXDPEntryProg {
+		t.Fatalf("XDPEntryProgram() = %q, want %q", got, userspaceXDPEntryProg)
+	}
+}
+
+func TestNotifyLinkCycleStrictModePublishesFailClosedCtrlFlags(t *testing.T) {
+	skipLinkCycleRebindSleep(t)
+
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+	m, ctrlMap, _ := newLinkCycleTestManager(t, controlSock)
+	seedUserspaceCtrl(t, ctrlMap, userspaceCtrlValue{
+		Enabled:            1,
+		MetadataVersion:    userspaceMetadataVersion,
+		Workers:            1,
+		QueueCount:         1,
+		ConfigGeneration:   4,
+		FIBGeneration:      2,
+		HeartbeatTimeoutMS: 30000,
+	})
+	m.configuredMode = ModeUserspaceStrict
+	m.mode = ModeUserspaceCompat
+	m.neighborsPrewarmed = true
+	m.ctrlWasEnabled = true
+	m.xskLivenessProven = true
+	m.xskLivenessFailed = true
+	m.xskProbeStart = time.Now().Add(-20 * time.Second)
+	m.lastXSKRX = 44
+
+	rebindStatus := ProcessStatus{
+		PID:                    6161,
+		Workers:                2,
+		Enabled:                false,
+		ForwardingArmed:        false,
+		Capabilities:           UserspaceCapabilities{ForwardingSupported: true},
+		LastSnapshotGeneration: 91,
+		LastFIBGeneration:      14,
+		NeighborGeneration:     0,
+		Bindings: []BindingStatus{{
+			Slot:       7,
+			Ifindex:    3,
+			QueueID:    0,
+			Registered: true,
+			Armed:      true,
+			Bound:      false,
+		}},
+	}
+	events := startLinkCycleControlServer(t, controlSock, ctrlMap, []ProcessStatus{rebindStatus})
+
+	m.NotifyLinkCycle()
+
+	ev := nextLinkCycleControlEvent(t, events)
+	if ev.Request.Type != "rebind" {
+		t.Fatalf("request type = %q, want rebind", ev.Request.Type)
+	}
+	if ev.CtrlLookupErr != nil {
+		t.Fatalf("lookup userspace_ctrl at rebind: %v", ev.CtrlLookupErr)
+	}
+	if ev.Ctrl.Enabled != 0 {
+		t.Fatalf("userspace_ctrl.Enabled at rebind = %d, want 0", ev.Ctrl.Enabled)
+	}
+
+	ctrl := lookupUserspaceCtrl(t, ctrlMap)
+	if ctrl.Enabled != 0 {
+		t.Fatalf("userspace_ctrl.Enabled after strict NotifyLinkCycle = %d, want fail-closed", ctrl.Enabled)
+	}
+	if ctrl.Flags&userspaceCtrlFlagStrict == 0 {
+		t.Fatalf("userspace_ctrl.Flags = %#x, want strict fail-closed flag", ctrl.Flags)
+	}
+	if ctrl.Workers != 2 || ctrl.QueueCount != 1 || ctrl.ConfigGeneration != 91 || ctrl.FIBGeneration != 14 {
+		t.Fatalf("userspace_ctrl after strict NotifyLinkCycle = %+v, want helper status applied", ctrl)
+	}
+	if m.xskLivenessProven || m.xskLivenessFailed || !m.xskProbeStart.IsZero() || m.lastXSKRX != 0 {
+		t.Fatalf(
+			"XSK liveness after strict NotifyLinkCycle = proven=%v failed=%v probe=%v lastRX=%d, want reset fail-closed state",
+			m.xskLivenessProven,
+			m.xskLivenessFailed,
+			m.xskProbeStart,
+			m.lastXSKRX,
+		)
+	}
+	if m.mode != ModeUserspaceStrict {
+		t.Fatalf("mode after strict NotifyLinkCycle = %s, want %s", m.mode, ModeUserspaceStrict)
+	}
+	if got := m.lastStatus.PID; got != rebindStatus.PID {
+		t.Fatalf("lastStatus.PID = %d, want %d", got, rebindStatus.PID)
+	}
+	if got := m.bpfShim.XDPEntryProgram(); got != userspaceXDPEntryProg {
+		t.Fatalf("XDPEntryProgram() = %q, want %q", got, userspaceXDPEntryProg)
+	}
+}
+
+func TestLegacyDataPlaneAdapterLinkForwardsLinkCycleToUserspaceManager(t *testing.T) {
+	skipLinkCycleRebindSleep(t)
+
+	controlSock := filepath.Join(t.TempDir(), "control.sock")
+	m := newLinkCycleProcessOnlyManager(t, controlSock)
+
+	events := startLinkCycleControlServer(t, controlSock, nil, []ProcessStatus{
+		{PID: 7001, Bindings: []BindingStatus{{Slot: 1, Ifindex: 2, QueueID: 0, Ready: true}}},
+		{
+			PID:                    7002,
+			Workers:                2,
+			Enabled:                false,
+			Capabilities:           UserspaceCapabilities{ForwardingSupported: true},
+			LastSnapshotGeneration: 5,
+			LastFIBGeneration:      6,
+		},
+	})
+
+	link := NewLegacyDataPlaneAdapter(m).Link()
+	link.PrepareLinkCycle()
+	first := nextLinkCycleControlEvent(t, events)
+	if first.Request.Type != "stop_workers" {
+		t.Fatalf("first request type = %q, want stop_workers", first.Request.Type)
+	}
+
+	link.NotifyLinkCycle()
+	second := nextLinkCycleControlEvent(t, events)
+	if second.Request.Type != "rebind" {
+		t.Fatalf("second request type = %q, want rebind", second.Request.Type)
+	}
+	if got := m.bpfShim.XDPEntryProgram(); got != userspaceXDPEntryProg {
+		t.Fatalf("XDPEntryProgram() = %q, want %q", got, userspaceXDPEntryProg)
+	}
+}
+
+func newLinkCycleTestManager(t *testing.T, controlSock string) (*Manager, *ebpf.Map, *ebpf.Map) {
+	t.Helper()
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	m := newLinkCycleProcessOnlyManager(t, controlSock)
+	ctrlMap, bindingsMap := injectCtrlAndBindingMaps(t, m)
+	injectUserspaceBootstrapMaps(t, m)
+	return m, ctrlMap, bindingsMap
+}
+
+func newLinkCycleProcessOnlyManager(t *testing.T, controlSock string) *Manager {
+	t.Helper()
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+	m.bpfShim.SelectUserspaceXDPShimEntryProgram()
+	m.lastRSTAttempt = time.Now()
+	m.lastRSTInstallOK = true
+	return m
+}
+
+func startLinkCycleControlServer(
+	t *testing.T,
+	controlSock string,
+	ctrlMap *ebpf.Map,
+	responses []ProcessStatus,
+) <-chan linkCycleControlEvent {
+	t.Helper()
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// Each response can publish at most one request event and one encode
+	// failure. The non-blocking send below keeps future edits from turning a
+	// fixture failure into a wedged server goroutine.
+	events := make(chan linkCycleControlEvent, len(responses)*2)
+	sendEvent := func(ev linkCycleControlEvent) bool {
+		select {
+		case events <- ev:
+			return true
+		default:
+			t.Errorf("helper control event buffer exhausted")
+			return false
+		}
+	}
+	go func() {
+		defer close(events)
+		for _, status := range responses {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					sendEvent(linkCycleControlEvent{Err: err})
+					return
+				}
+				ev := linkCycleControlEvent{Request: req}
+				if ctrlMap != nil {
+					var zero uint32
+					ev.CtrlLookupErr = ctrlMap.Lookup(zero, &ev.Ctrl)
+				}
+				if !sendEvent(ev) {
+					return
+				}
+				if err := json.NewEncoder(conn).Encode(ControlResponse{
+					OK:     true,
+					Status: &status,
+				}); err != nil {
+					sendEvent(linkCycleControlEvent{Err: err})
+					return
+				}
+			}()
+		}
+	}()
+	return events
+}
+
+func skipLinkCycleRebindSleep(t *testing.T) {
+	t.Helper()
+	oldSleep := linkCycleRebindSleep
+	linkCycleRebindSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		linkCycleRebindSleep = oldSleep
+	})
+}
+
+func nextLinkCycleControlEvent(t *testing.T, events <-chan linkCycleControlEvent) linkCycleControlEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-events:
+		if !ok {
+			t.Fatal("helper control server exited before receiving request")
+		}
+		if ev.Err != nil {
+			t.Fatalf("helper control server decode request: %v", ev.Err)
+		}
+		return ev
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for helper control request")
+		return linkCycleControlEvent{}
+	}
+}
+
+func seedUserspaceCtrl(t *testing.T, ctrlMap *ebpf.Map, ctrl userspaceCtrlValue) {
+	t.Helper()
+	var zero uint32
+	if err := ctrlMap.Update(zero, ctrl, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed userspace_ctrl: %v", err)
+	}
+}
+
+func lookupUserspaceCtrl(t *testing.T, ctrlMap *ebpf.Map) userspaceCtrlValue {
+	t.Helper()
+	var zero uint32
+	var ctrl userspaceCtrlValue
+	if err := ctrlMap.Lookup(zero, &ctrl); err != nil {
+		t.Fatalf("lookup userspace_ctrl: %v", err)
+	}
+	return ctrl
+}
+
+func lookupUserspaceBinding(t *testing.T, bindingsMap *ebpf.Map, idx uint32) userspaceBindingValue {
+	t.Helper()
+	var binding userspaceBindingValue
+	if err := bindingsMap.Lookup(idx, &binding); err != nil {
+		t.Fatalf("lookup userspace_bindings[%d]: %v", idx, err)
+	}
+	return binding
+}

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func TestShouldAttemptRSTSuppression(t *testing.T) {
@@ -591,7 +592,7 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 		MaxEntries: 1024,
 	})
 	if err != nil {
-		t.Fatalf("new sessions map: %v", err)
+		skipIfBPFMapUnavailable(t, "new sessions map", err)
 	}
 	t.Cleanup(func() { sessionsMap.Close() })
 	injectShimMap(t, m.bpfShim, "sessions", sessionsMap)
@@ -602,7 +603,7 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 		MaxEntries: 1024,
 	})
 	if err != nil {
-		t.Fatalf("new sessions_v6 map: %v", err)
+		skipIfBPFMapUnavailable(t, "new sessions_v6 map", err)
 	}
 	t.Cleanup(func() { sessionsMapV6.Close() })
 	injectShimMap(t, m.bpfShim, "sessions_v6", sessionsMapV6)
@@ -617,7 +618,7 @@ func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
 		MaxEntries: 16,
 	})
 	if err != nil {
-		t.Fatalf("new userspace_ctrl map: %v", err)
+		skipIfBPFMapUnavailable(t, "new userspace_ctrl map", err)
 	}
 	t.Cleanup(func() { ctrlMap.Close() })
 	injectShimMap(t, m.bpfShim, "userspace_ctrl", ctrlMap)
@@ -629,7 +630,7 @@ func injectCtrlAndBindingMaps(t *testing.T, m *Manager) (*ebpf.Map, *ebpf.Map) {
 		MaxEntries: 256,
 	})
 	if err != nil {
-		t.Fatalf("new userspace_bindings map: %v", err)
+		skipIfBPFMapUnavailable(t, "new userspace_bindings map", err)
 	}
 	t.Cleanup(func() { bindingsMap.Close() })
 	injectShimMap(t, m.bpfShim, "userspace_bindings", bindingsMap)
@@ -645,11 +646,24 @@ func injectUserspaceSessionMap(t *testing.T, m *Manager) *ebpf.Map {
 		MaxEntries: 256,
 	})
 	if err != nil {
-		t.Fatalf("new userspace_sessions map: %v", err)
+		skipIfBPFMapUnavailable(t, "new userspace_sessions map", err)
 	}
 	t.Cleanup(func() { usMap.Close() })
 	injectShimMap(t, m.bpfShim, "userspace_sessions", usMap)
 	return usMap
+}
+
+func skipIfBPFMapUnavailable(t *testing.T, context string, err error) {
+	t.Helper()
+	msg := strings.ToLower(err.Error())
+	if errors.Is(err, unix.EPERM) ||
+		errors.Is(err, unix.EACCES) ||
+		strings.Contains(msg, "operation not permitted") ||
+		strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "memlock") {
+		t.Skipf("%s requires BPF map privileges: %v", context, err)
+	}
+	t.Fatalf("%s: %v", context, err)
 }
 
 func TestFindUserspaceEgressInterfaceSnapshotPrefersVLANUnit(t *testing.T) {

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -997,6 +997,8 @@ func (m *Manager) StartFIBSync(ctx context.Context) {
 	m.bpfShim.StartFIBSync(ctx)
 }
 
+var linkCycleRebindSleep = time.Sleep
+
 // NotifyLinkCycle tells the userspace helper to rebind all AF_XDP sockets.
 // In mlx5 (and other drivers), a link DOWN/UP cycle destroys the kernel-side
 // XSK receive queue.  The sockets remain open but no longer receive packets.
@@ -1004,10 +1006,10 @@ func (m *Manager) StartFIBSync(ctx context.Context) {
 //
 // PrepareLinkCycle should have been called BEFORE the link cycle to stop
 // workers (so they don't access UMEM during link DOWN). This method
-// waits 200ms for NIC reinitialization then sends "rebind" to recreate
+// waits 1s for NIC reinitialization then sends "rebind" to recreate
 // workers with fresh AF_XDP sockets.
 //
-// The 200ms delay lets the mlx5 NIC fully reinitialize its UMR (User
+// The 1s delay lets the mlx5 NIC fully reinitialize its UMR (User
 // Memory Region) subsystem after link reactivation. Without this, the
 // NIC's UMR WQE queue overflows when all XSK sockets are recreated
 // simultaneously (rx_xsk_congst_umr), causing UMEM pages to not be mapped
@@ -1017,7 +1019,7 @@ func (m *Manager) NotifyLinkCycle() {
 	// sockets. mlx5 releases zero-copy queue resources asynchronously after
 	// socket close — binding a new socket to the same queue before teardown
 	// completes returns EBUSY. 1s gives the driver ample time.
-	time.Sleep(1 * time.Second)
+	linkCycleRebindSleep(1 * time.Second)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/dataplane/userspace/xdp_shim_decouple_test.go
+++ b/pkg/dataplane/userspace/xdp_shim_decouple_test.go
@@ -312,7 +312,7 @@ func injectShimMapSpec(t *testing.T, bpfShim *dataplane.Manager, name string, sp
 	t.Helper()
 	m, err := ebpf.NewMap(spec)
 	if err != nil {
-		t.Fatalf("new %s map: %v", name, err)
+		skipIfBPFMapUnavailable(t, "new "+name+" map", err)
 	}
 	t.Cleanup(func() { m.Close() })
 	injectShimMap(t, bpfShim, name, m)


### PR DESCRIPTION
## Summary

- Add control-plane regression tests for userspace link-cycle handling:
  `PrepareLinkCycle`, `NotifyLinkCycle`, strict-mode fail-closed state,
  helper status projection, binding publication, and XSK liveness reset.
- Verify the legacy adapter `Link()` path forwards into the userspace
  manager instead of the legacy dataplane controller.
- Harden the retirement canary around the actual
  `userspaceLinkController` dispatch methods and receiver-qualified
  legacy loader references.
- Add a test sleep seam for the production rebind delay and skip
  map-backed tests cleanly when BPF map creation is unavailable.

## Scope

This PR covers the link-cycle control plane using fake helper and map
fixtures. It does not claim to run a real AF_XDP socket or namespace
link DOWN/UP smoke test.

## Validation

- `go test ./pkg/dataplane/userspace -run 'LinkCycle|PrepareLinkCycle|NotifyLinkCycle|LegacyDataPlaneAdapter' -count=1`
- `go test ./pkg/dataplane -run 'UserspaceLinkCycleDoesNotReenterLegacyLoader|UserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|BPFShimEntryProgramStateIsNotJSONMutable' -count=1`
- `git diff --check`

Refs #1510.
