### PR TITLE
Rename userspace degraded path counters

### DIFF
--- a/docs/afxdp-packet-processing.md
+++ b/docs/afxdp-packet-processing.md
@@ -34,7 +34,7 @@ The shim checks several conditions before redirecting a packet to userspace:
 8. When helper/XSK state is degraded (`ctrl.enabled=0`, missing/not-ready
    binding, stale heartbeat, redirect failure), only the local/control cases
    above may reach the kernel. Transit drops and increments
-   `transit_drop` in `userspace_fallback_stats`.
+   `transit_drop` in `degraded_path_counters`.
 
 Packets that pass all checks get a `UserspaceDpMeta` header prepended via
 `bpf_xdp_adjust_meta` and are redirected to the AF_XDP socket with
@@ -213,9 +213,11 @@ The remaining work is now cleaner:
 | Without `debug-log` | Zero-overhead production build. `debug_log!()` compiles to nothing. |
 | With `debug-log` | Per-packet TCP flag parsing, RST detection, hex dumps, checksum verification, session dumps, stall detection, ring diagnostics. |
 
-**XDP fallback stats**: The shim maintains per-reason counters in
-`userspace_fallback_stats` (array map with `USERSPACE_FALLBACK_REASON_MAX`
-entries).  The worker reads and logs these as `DBG w{}: XDP_FALLBACK: ...`.
+**XDP degraded path counters**: The shim maintains per-reason counters for
+retained-shim degraded actions. Go exposes them in status JSON as
+`degraded_path_counters`. The pinned BPF map remains
+`userspace_fallback_stats` as an internal mixed-version compatibility
+exception.
 
 **Binding debug state**: Each `BindingWorker` tracks live ring state
 (`debug_pending_fill_frames`, `debug_free_tx_frames`,

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -130,6 +130,14 @@ the narrow userspace-shim selection/swap methods. This keeps the retained shim
 visible without implying that degraded userspace mode can bypass back into the
 legacy pipeline.
 
+#1509 renames the retained-shim degraded action counters on the Go/status and
+operator documentation surface to `degraded_path_counters`. The pinned BPF map
+name `userspace_fallback_stats` remains an internal mixed-version compatibility
+exception until the final retained-shim ABI boundary is removed. New daemons
+also emit `fallback_counters` as a legacy JSON alias for one compatibility
+window so old status readers do not silently zero these counters during rolling
+upgrades; new code should read `degraded_path_counters`.
+
 The #1493 loader/bootstrap split keeps normal userspace startup on the
 userspace-only shim loader below. Source removal still waits for #1451's
 remaining operator/runtime surface migration and #1476's deletion candidate.

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -136,7 +136,10 @@ name `userspace_fallback_stats` remains an internal mixed-version compatibility
 exception until the final retained-shim ABI boundary is removed. New daemons
 also emit `fallback_counters` as a legacy JSON alias for one compatibility
 window so old status readers do not silently zero these counters during rolling
-upgrades; new code should read `degraded_path_counters`.
+upgrades; new code should read `degraded_path_counters`. The dual-emit window
+is intentionally short and the legacy alias should be removed with the next
+userspace helper status protocol bump after the retained-shim ABI boundary is
+retired.
 
 The #1493 loader/bootstrap split keeps normal userspace startup on the
 userspace-only shim loader below. Source removal still waits for #1451's

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -120,9 +120,11 @@ Packet arrives at NIC
 - **Fail closed on dead bindings**: if a binding is missing, not ready, or
   its heartbeat is stale on a userspace-managed interface, the shim passes
   only proven local/control traffic to the kernel. Non-local transit drops in
-  compat and strict modes and increments the `transit_drop` fallback counter.
-  The userspace runtime does not require the legacy `xdp_main_prog` fallback
-  path.
+  compat and strict modes and increments the `transit_drop` degraded-path
+  counter. Go exposes the per-reason map as `degraded_path_counters`; the
+  pinned BPF map keeps the internal compatibility name
+  `userspace_fallback_stats` until the mixed-version boundary is retired. The
+  userspace runtime does not require the legacy `xdp_main_prog` fallback path.
 
 - **Heartbeat watchdog**: Each worker writes a timestamp to a BPF array
   map every 250ms. The shim checks freshness (5s timeout) and refuses

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -163,7 +163,9 @@ There are two distinct fallback boundaries:
      - send kernel-owned traffic to cpumap / kernel
      - pass proven local/control traffic while helper/XSK is degraded
      - drop degraded non-local transit in both compat and strict modes
-     - count those drops as `transit_drop` in `userspace_fallback_stats`
+     - count those drops as `transit_drop` in `degraded_path_counters`; the
+       pinned BPF map keeps the internal compatibility name
+       `userspace_fallback_stats` until the mixed-version boundary is retired
 
 ## Priority Work
 

--- a/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
+++ b/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
@@ -25,7 +25,9 @@ array being correctly populated (verified via `bpftool map dump`).
 Issue #1473 removed this runtime dependency: the retained userspace shim now
 passes only proven local/control traffic to the kernel when helper/XSK state is
 degraded. Non-local transit drops in both compat and strict modes and is counted
-as `transit_drop` in `userspace_fallback_stats`.
+as `transit_drop` in `degraded_path_counters`. The pinned BPF map still uses the
+internal compatibility name `userspace_fallback_stats` during mixed-version
+upgrades.
 
 When the tail call failed, the function fell through to `return Ok(xdp_action::XDP_DROP)`, silently dropping all fallback packets. This affected three code paths:
 

--- a/docs/xpf-userspace-fw-deploy-verification.md
+++ b/docs/xpf-userspace-fw-deploy-verification.md
@@ -177,9 +177,10 @@ again after a 30 s run. Compute deltas.
   aggressively that TCP can't progress.
 - `peer_pps` / `owner_pps` both zero while traffic was flowing —
   the queue isn't actually being serviced by the userspace-dp worker;
-  the packets went via fallback. Check `userspace_fallback_stats`
-  (`bpftool map dump pinned /sys/fs/bpf/xpf/userspace_fallback_stats`)
-  for which fallback reason fired.
+  check `degraded_path_counters` in userspace status for retained-shim
+  degraded actions. If direct BPF inspection is required, the internal
+  mixed-version compatibility map is still pinned at
+  `/sys/fs/bpf/xpf/userspace_fallback_stats`.
 
 ## Pass criteria (summary)
 

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -465,6 +465,56 @@ func TestUserspaceXDPShimObjectMatchesRetainedCollectionAllowlist(t *testing.T) 
 	}
 }
 
+func TestUserspaceDegradedPathCounterStatusStructAvoidsFallbackField(t *testing.T) {
+	t.Parallel()
+
+	tags := processStatusJSONTags(t)
+	if !tags["degraded_path_counters"] {
+		t.Fatal("ProcessStatus JSON tags missing degraded_path_counters")
+	}
+	if tags["fallback_counters"] {
+		t.Fatal("ProcessStatus must not expose fallback_counters as a primary status field")
+	}
+}
+
+func TestActiveDocsDescribeRetainedShimCountersAsDegradedPath(t *testing.T) {
+	t.Parallel()
+
+	docs := []string{
+		filepath.Join(repoRootForBoundaryCanary, "docs", "afxdp-packet-processing.md"),
+		filepath.Join(repoRootForBoundaryCanary, "docs", "userspace-xdp-pass-bootstrap-and-ipv6.md"),
+		filepath.Join(repoRootForBoundaryCanary, "docs", "userspace-dataplane-architecture.md"),
+		filepath.Join(repoRootForBoundaryCanary, "docs", "userspace-dataplane-gaps.md"),
+		filepath.Join(repoRootForBoundaryCanary, "docs", "xpf-userspace-fw-deploy-verification.md"),
+		retirementBoundaryDocsForCanary,
+	}
+	for _, path := range docs {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		lines := strings.Split(string(data), "\n")
+		for idx, line := range lines {
+			lower := strings.ToLower(line)
+			switch {
+			case strings.Contains(line, "fallback_counters") &&
+				!lineWindowContains(lines, idx, "compatibility"):
+				t.Fatalf("%s:%d exposes legacy fallback_counters JSON name", repoRelativePath(t, path), idx+1)
+			case strings.Contains(lower, "xdp fallback stats"),
+				strings.Contains(lower, "fallback counters"),
+				strings.Contains(lower, "fallback reason"),
+				strings.Contains(lower, "went via fallback"):
+				t.Fatalf("%s:%d describes retained-shim counters with fallback wording: %s",
+					repoRelativePath(t, path), idx+1, strings.TrimSpace(line))
+			case strings.Contains(line, "userspace_fallback_stats") &&
+				!lineWindowContains(lines, idx, "compatibility"):
+				t.Fatalf("%s:%d mentions userspace_fallback_stats without compatibility context: %s",
+					repoRelativePath(t, path), idx+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
 func TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram(t *testing.T) {
 	t.Parallel()
 
@@ -1509,6 +1559,70 @@ func lineForOffset(text string, offset int) int {
 		offset = len(text)
 	}
 	return strings.Count(text[:offset], "\n") + 1
+}
+
+func lineWindowContains(lines []string, idx int, needle string) bool {
+	start := idx - 2
+	if start < 0 {
+		start = 0
+	}
+	end := idx + 2
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+	needle = strings.ToLower(needle)
+	for i := start; i <= end; i++ {
+		if strings.Contains(strings.ToLower(lines[i]), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func processStatusJSONTags(t *testing.T) map[string]bool {
+	t.Helper()
+
+	path := filepath.Join(repoRootForBoundaryCanary, "pkg", "dataplane", "userspace", "protocol.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != "ProcessStatus" {
+				continue
+			}
+			st, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				t.Fatalf("ProcessStatus in %s is not a struct", path)
+			}
+			tags := map[string]bool{}
+			for _, field := range st.Fields.List {
+				if field.Tag == nil {
+					continue
+				}
+				rawTag, err := strconv.Unquote(field.Tag.Value)
+				if err != nil {
+					t.Fatalf("unquote ProcessStatus tag %s: %v", field.Tag.Value, err)
+				}
+				jsonTag := reflect.StructTag(rawTag).Get("json")
+				name, _, _ := strings.Cut(jsonTag, ",")
+				if name != "" && name != "-" {
+					tags[name] = true
+				}
+			}
+			return tags
+		}
+	}
+	t.Fatalf("ProcessStatus not found in %s", path)
+	return nil
 }
 
 func isXDPEntryProgField(expr ast.Expr) bool {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -801,7 +801,7 @@ func (m *Manager) recordHelperStatusLocked(status *ProcessStatus) {
 	status.DataplaneMode = m.mode.String()
 	status.ConfiguredMode = m.configuredMode.String()
 	status.EntryPrograms = m.entryProgramsLocked()
-	status.FallbackCounters = m.readFallbackStatsLocked()
+	status.DegradedPathCounters = m.readDegradedPathStatsLocked()
 	if m.eventStream != nil {
 		es := m.eventStream.Status()
 		status.EventStream = &es

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -702,9 +702,11 @@ ctrlReady:
 // userspaceCounterSnapshot holds cumulative counter totals from the helper,
 // used to compute deltas between status polls.
 
-// fallbackReasonNames maps BPF array index to a human-readable name.
+const userspaceShimDegradedStatsMapName = "userspace_fallback_stats"
+
+// degradedPathReasonNames maps BPF array index to a human-readable name.
 // Must stay in sync with USERSPACE_FALLBACK_REASON_* in userspace-xdp/src/lib.rs.
-var fallbackReasonNames = [16]string{
+var degradedPathReasonNames = [16]string{
 	0:  "ctrl_disabled",
 	1:  "parse_fail",
 	2:  "binding_missing",
@@ -723,16 +725,20 @@ var fallbackReasonNames = [16]string{
 	15: "transit_drop",
 }
 
-// readFallbackStatsLocked reads the userspace_fallback_stats BPF array map
-// and returns a map of reason name -> cumulative count. Entries with zero
-// count are omitted.
-func (m *Manager) readFallbackStatsLocked() map[string]uint64 {
-	statsMap := m.bpfShim.Map("userspace_fallback_stats")
+// readDegradedPathStatsLocked reads retained-shim degraded-path counters and
+// returns a map of reason name -> cumulative count. Entries with zero count are
+// omitted.
+//
+// The pinned BPF map name remains userspace_fallback_stats as an internal
+// mixed-version compatibility exception. Operator-facing Go status, JSON, and
+// docs must use degraded-path terminology instead.
+func (m *Manager) readDegradedPathStatsLocked() map[string]uint64 {
+	statsMap := m.bpfShim.Map(userspaceShimDegradedStatsMapName)
 	if statsMap == nil {
 		return nil
 	}
 	result := make(map[string]uint64)
-	for i := uint32(0); i < uint32(len(fallbackReasonNames)); i++ {
+	for i := uint32(0); i < uint32(len(degradedPathReasonNames)); i++ {
 		var val uint64
 		if err := statsMap.Lookup(i, &val); err != nil {
 			continue
@@ -740,7 +746,7 @@ func (m *Manager) readFallbackStatsLocked() map[string]uint64 {
 		if val == 0 {
 			continue
 		}
-		name := fallbackReasonNames[i]
+		name := degradedPathReasonNames[i]
 		if name == "" {
 			name = fmt.Sprintf("reason_%d", i)
 		}

--- a/pkg/dataplane/userspace/maps_sync_cap_test.go
+++ b/pkg/dataplane/userspace/maps_sync_cap_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+func TestDegradedPathReasonNamesCoverRetainedShimActions(t *testing.T) {
+	found := map[string]bool{}
+	for _, name := range degradedPathReasonNames {
+		found[name] = true
+	}
+
+	for _, name := range []string{
+		"ctrl_disabled",
+		"pass_to_kernel",
+		"transit_drop",
+		"strict_drop",
+		"redirect_err",
+		"binding_missing",
+		"binding_not_ready",
+		"heartbeat_missing",
+		"heartbeat_stale",
+		"adjust_meta",
+		"meta_bounds",
+	} {
+		if !found[name] {
+			t.Fatalf("degraded path reason %q missing from %v", name, degradedPathReasonNames)
+		}
+	}
+	if got, want := len(degradedPathReasonNames), 16; got != want {
+		t.Fatalf("degradedPathReasonNames length = %d, want %d", got, want)
+	}
+	if got := userspaceShimDegradedStatsMapName; got != "userspace_fallback_stats" {
+		t.Fatalf("userspaceShimDegradedStatsMapName = %q, want pinned compatibility map name", got)
+	}
+	for idx, name := range degradedPathReasonNames {
+		if name == "" {
+			t.Fatalf("degradedPathReasonNames[%d] is empty", idx)
+		}
+	}
+}
+
 // TestApplyHelperStatusRejectsOverCapIfindex verifies that a binding
 // whose ifindex overflows the userspace_bindings Array cap is caught
 // at the call site with a legible error rather than bubbling up the

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1,6 +1,7 @@
 package userspace
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -508,11 +509,49 @@ type ProcessStatus struct {
 	SourceNATPools               []SourceNATPoolStatus             `json:"source_nat_pools,omitempty"`
 	LastResolution               *PacketResolution                 `json:"last_resolution,omitempty"`
 	SlowPath                     SlowPathStatus                    `json:"slow_path,omitempty"`
-	LastCacheFlushAt             uint64                            `json:"last_cache_flush_at,omitempty"` // monotonic secs (#312)
-	DataplaneMode                string                            `json:"dataplane_mode,omitempty"`      // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
-	ConfiguredMode               string                            `json:"configured_mode,omitempty"`     // Desired mode from config
-	EntryPrograms                map[int]string                    `json:"entry_programs,omitempty"`      // ifindex -> attached XDP program name
-	FallbackCounters             map[string]uint64                 `json:"fallback_counters,omitempty"`   // reason_name -> count
+	LastCacheFlushAt             uint64                            `json:"last_cache_flush_at,omitempty"`    // monotonic secs (#312)
+	DataplaneMode                string                            `json:"dataplane_mode,omitempty"`         // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
+	ConfiguredMode               string                            `json:"configured_mode,omitempty"`        // Desired mode from config
+	EntryPrograms                map[int]string                    `json:"entry_programs,omitempty"`         // ifindex -> attached XDP program name
+	DegradedPathCounters         map[string]uint64                 `json:"degraded_path_counters,omitempty"` // reason_name -> count
+}
+
+func (s ProcessStatus) MarshalJSON() ([]byte, error) {
+	type processStatusAlias ProcessStatus
+	aux := struct {
+		*processStatusAlias
+		LegacyFallbackCounters map[string]uint64 `json:"fallback_counters,omitempty"`
+	}{
+		processStatusAlias: (*processStatusAlias)(&s),
+	}
+	if len(s.DegradedPathCounters) > 0 {
+		aux.LegacyFallbackCounters = s.DegradedPathCounters
+	}
+	return json.Marshal(aux)
+}
+
+func (s *ProcessStatus) UnmarshalJSON(data []byte) error {
+	type processStatusAlias ProcessStatus
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var aux processStatusAlias
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*s = ProcessStatus(aux)
+	if _, ok := raw["degraded_path_counters"]; ok {
+		return nil
+	}
+	if legacyRaw, ok := raw["fallback_counters"]; ok {
+		var legacy map[string]uint64
+		if err := json.Unmarshal(legacyRaw, &legacy); err != nil {
+			return err
+		}
+		s.DegradedPathCounters = legacy
+	}
+	return nil
 }
 
 type SourceNATPoolStatus struct {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -516,6 +516,9 @@ type ProcessStatus struct {
 	DegradedPathCounters         map[string]uint64                 `json:"degraded_path_counters,omitempty"` // reason_name -> count
 }
 
+// MarshalJSON intentionally uses a value receiver so both ProcessStatus values
+// and *ProcessStatus pointers emit the temporary legacy alias during the
+// rolling-upgrade window.
 func (s ProcessStatus) MarshalJSON() ([]byte, error) {
 	type processStatusAlias ProcessStatus
 	aux := struct {
@@ -525,6 +528,8 @@ func (s ProcessStatus) MarshalJSON() ([]byte, error) {
 		processStatusAlias: (*processStatusAlias)(&s),
 	}
 	if len(s.DegradedPathCounters) > 0 {
+		// encoding/json never mutates input maps, so sharing the map keeps the
+		// legacy alias byte-for-byte consistent with the primary field.
 		aux.LegacyFallbackCounters = s.DegradedPathCounters
 	}
 	return json.Marshal(aux)

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -538,6 +538,14 @@ func TestProcessStatusDegradedPathCountersJSON(t *testing.T) {
 	if _, ok := obj["fallback_counters"]; !ok {
 		t.Fatalf("legacy fallback_counters alias missing from ProcessStatus JSON: %s", string(raw))
 	}
+	var legacyAlias map[string]uint64
+	if err := json.Unmarshal(obj["fallback_counters"], &legacyAlias); err != nil {
+		t.Fatalf("unmarshal legacy fallback_counters alias: %v", err)
+	}
+	if !reflect.DeepEqual(legacyAlias, in.DegradedPathCounters) {
+		t.Fatalf("fallback_counters alias = %+v, want %+v",
+			legacyAlias, in.DegradedPathCounters)
+	}
 
 	var back ProcessStatus
 	if err := json.Unmarshal(raw, &back); err != nil {

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -513,6 +513,60 @@ func TestProcessStatusThreeColorPolicerCountersRoundTrip(t *testing.T) {
 	}
 }
 
+func TestProcessStatusDegradedPathCountersJSON(t *testing.T) {
+	in := ProcessStatus{
+		DegradedPathCounters: map[string]uint64{
+			"ctrl_disabled":  1,
+			"pass_to_kernel": 2,
+			"redirect_err":   3,
+			"strict_drop":    4,
+			"transit_drop":   5,
+		},
+	}
+
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	if _, ok := obj["degraded_path_counters"]; !ok {
+		t.Fatalf("degraded_path_counters missing from ProcessStatus JSON: %s", string(raw))
+	}
+	if _, ok := obj["fallback_counters"]; !ok {
+		t.Fatalf("legacy fallback_counters alias missing from ProcessStatus JSON: %s", string(raw))
+	}
+
+	var back ProcessStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if !reflect.DeepEqual(back.DegradedPathCounters, in.DegradedPathCounters) {
+		t.Fatalf("DegradedPathCounters = %+v, want %+v",
+			back.DegradedPathCounters, in.DegradedPathCounters)
+	}
+
+	var legacy ProcessStatus
+	if err := json.Unmarshal([]byte(`{"fallback_counters":{"transit_drop":9}}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy ProcessStatus: %v", err)
+	}
+	if got := legacy.DegradedPathCounters["transit_drop"]; got != 9 {
+		t.Fatalf("legacy fallback_counters decode transit_drop = %d, want 9", got)
+	}
+
+	var both ProcessStatus
+	if err := json.Unmarshal([]byte(
+		`{"degraded_path_counters":{},"fallback_counters":{"transit_drop":9}}`,
+	), &both); err != nil {
+		t.Fatalf("unmarshal mixed ProcessStatus: %v", err)
+	}
+	if got := both.DegradedPathCounters["transit_drop"]; got != 0 {
+		t.Fatalf("new empty degraded_path_counters should not be overridden, got transit_drop=%d", got)
+	}
+}
+
 func TestProcessStatusInjectPacketTupleVersionRoundTrip(t *testing.T) {
 	in := ProcessStatus{
 		InjectPacketTupleProtocolVersion: InjectPacketTupleProtocolVersion,

--- a/pkg/dataplane/userspace/statusfmt.go
+++ b/pkg/dataplane/userspace/statusfmt.go
@@ -85,6 +85,19 @@ func localHAForwardingRole(status ProcessStatus) string {
 	return "standby"
 }
 
+func formatStatusCounterMap(counters map[string]uint64) string {
+	keys := make([]string, 0, len(counters))
+	for name := range counters {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, name := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", name, counters[name]))
+	}
+	return strings.Join(parts, " ")
+}
+
 func FormatStatusSummary(status ProcessStatus) string {
 	var b strings.Builder
 	now := time.Now()
@@ -337,6 +350,9 @@ func FormatStatusSummary(status ProcessStatus) string {
 			parts = append(parts, part)
 		}
 		fmt.Fprintf(&b, "  Fabric links:              %s\n", strings.Join(parts, "; "))
+	}
+	if len(status.DegradedPathCounters) > 0 {
+		fmt.Fprintf(&b, "  Degraded path counters:    %s\n", formatStatusCounterMap(status.DegradedPathCounters))
 	}
 	if status.LastResolution != nil {
 		fmt.Fprintf(&b, "  Last resolution:           %s", status.LastResolution.Disposition)

--- a/pkg/dataplane/userspace/statusfmt_test.go
+++ b/pkg/dataplane/userspace/statusfmt_test.go
@@ -156,6 +156,25 @@ func TestFormatStatusSummaryShowsPersistentSourceNATHABoundary(t *testing.T) {
 	}
 }
 
+func TestFormatStatusSummaryShowsDegradedPathCounters(t *testing.T) {
+	status := ProcessStatus{
+		DegradedPathCounters: map[string]uint64{
+			"transit_drop":  5,
+			"ctrl_disabled": 1,
+			"redirect_err":  3,
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	want := "Degraded path counters:    ctrl_disabled=1 redirect_err=3 transit_drop=5"
+	if !strings.Contains(out, want) {
+		t.Fatalf("summary missing degraded path counters %q:\n%s", want, out)
+	}
+	if strings.Contains(out, "fallback_counters") {
+		t.Fatalf("summary exposed legacy fallback_counters field:\n%s", out)
+	}
+}
+
 func TestFormatSYNCookieCounterRows(t *testing.T) {
 	status := ProcessStatus{
 		Bindings: []BindingStatus{

--- a/pkg/dataplane/userspace/xdp_shim_decouple_test.go
+++ b/pkg/dataplane/userspace/xdp_shim_decouple_test.go
@@ -88,8 +88,8 @@ func TestUserspaceXDPDegradedCtrlDisabledDropsTransit(t *testing.T) {
 	if ret != xdpActionDrop {
 		t.Fatalf("ctrl-disabled transit action = %d, want XDP_DROP", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "ctrl_disabled")
-	assertUserspaceXDPFallbackStat(t, coll, "transit_drop")
+	assertUserspaceXDPDegradedPathStat(t, coll, "ctrl_disabled")
+	assertUserspaceXDPDegradedPathStat(t, coll, "transit_drop")
 }
 
 func TestUserspaceXDPDegradedCtrlDisabledPassesLocalControl(t *testing.T) {
@@ -111,9 +111,9 @@ func TestUserspaceXDPDegradedCtrlDisabledPassesLocalControl(t *testing.T) {
 	if ret != xdpActionPass {
 		t.Fatalf("ctrl-disabled local action = %d, want XDP_PASS", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "ctrl_disabled")
-	assertUserspaceXDPFallbackStat(t, coll, "pass_to_kernel")
-	assertUserspaceXDPFallbackStatAbsent(t, coll, "transit_drop")
+	assertUserspaceXDPDegradedPathStat(t, coll, "ctrl_disabled")
+	assertUserspaceXDPDegradedPathStat(t, coll, "pass_to_kernel")
+	assertUserspaceXDPDegradedPathStatAbsent(t, coll, "transit_drop")
 }
 
 func TestUserspaceXDPBindingNotReadyDropsTransitButPassesLocalControl(t *testing.T) {
@@ -163,8 +163,8 @@ func TestUserspaceXDPBindingNotReadyDropsTransitButPassesLocalControl(t *testing
 			if ret != tc.want {
 				t.Fatalf("binding-not-ready %s action = %d, want %d", tc.name, ret, tc.want)
 			}
-			assertUserspaceXDPFallbackStat(t, coll, "binding_not_ready")
-			assertUserspaceXDPFallbackStat(t, coll, tc.statName)
+			assertUserspaceXDPDegradedPathStat(t, coll, "binding_not_ready")
+			assertUserspaceXDPDegradedPathStat(t, coll, tc.statName)
 		})
 	}
 }
@@ -190,9 +190,9 @@ func TestUserspaceXDPIPLocalControlUsesCPUMapWhenAvailable(t *testing.T) {
 	if ret != xdpActionRedirect {
 		t.Fatalf("ctrl-disabled local action with cpumap = %d, want XDP_REDIRECT", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "ctrl_disabled")
-	assertUserspaceXDPFallbackStat(t, coll, "pass_to_kernel")
-	assertUserspaceXDPFallbackStatAbsent(t, coll, "transit_drop")
+	assertUserspaceXDPDegradedPathStat(t, coll, "ctrl_disabled")
+	assertUserspaceXDPDegradedPathStat(t, coll, "pass_to_kernel")
+	assertUserspaceXDPDegradedPathStatAbsent(t, coll, "transit_drop")
 }
 
 func TestUserspaceXDPNDPUsesCPUMapWhenAvailable(t *testing.T) {
@@ -220,8 +220,8 @@ func TestUserspaceXDPNDPUsesCPUMapWhenAvailable(t *testing.T) {
 	if ret != xdpActionRedirect {
 		t.Fatalf("NDP action with cpumap = %d, want XDP_REDIRECT", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "early_filter")
-	assertUserspaceXDPFallbackStat(t, coll, "pass_to_kernel")
+	assertUserspaceXDPDegradedPathStat(t, coll, "early_filter")
+	assertUserspaceXDPDegradedPathStat(t, coll, "pass_to_kernel")
 }
 
 func TestUserspaceXDPDegradedESPToInterfaceNATPassesLocalControl(t *testing.T) {
@@ -243,9 +243,9 @@ func TestUserspaceXDPDegradedESPToInterfaceNATPassesLocalControl(t *testing.T) {
 	if ret != xdpActionPass {
 		t.Fatalf("ctrl-disabled ESP to interface NAT action = %d, want XDP_PASS", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "ctrl_disabled")
-	assertUserspaceXDPFallbackStat(t, coll, "pass_to_kernel")
-	assertUserspaceXDPFallbackStatAbsent(t, coll, "transit_drop")
+	assertUserspaceXDPDegradedPathStat(t, coll, "ctrl_disabled")
+	assertUserspaceXDPDegradedPathStat(t, coll, "pass_to_kernel")
+	assertUserspaceXDPDegradedPathStatAbsent(t, coll, "transit_drop")
 }
 
 func TestUserspaceXDPDegradedNonIPL2PassesDirect(t *testing.T) {
@@ -263,9 +263,9 @@ func TestUserspaceXDPDegradedNonIPL2PassesDirect(t *testing.T) {
 	if ret != xdpActionPass {
 		t.Fatalf("ctrl-disabled ARP action = %d, want XDP_PASS", ret)
 	}
-	assertUserspaceXDPFallbackStat(t, coll, "ctrl_disabled")
-	assertUserspaceXDPFallbackStat(t, coll, "pass_to_kernel")
-	assertUserspaceXDPFallbackStatAbsent(t, coll, "transit_drop")
+	assertUserspaceXDPDegradedPathStat(t, coll, "ctrl_disabled")
+	assertUserspaceXDPDegradedPathStat(t, coll, "pass_to_kernel")
+	assertUserspaceXDPDegradedPathStatAbsent(t, coll, "transit_drop")
 }
 
 func injectUserspaceBootstrapMaps(t *testing.T, m *Manager) {
@@ -433,42 +433,42 @@ func runUserspaceXDPTestPacket(t *testing.T, coll *ebpf.Collection, packet []byt
 	return ret
 }
 
-func assertUserspaceXDPFallbackStat(t *testing.T, coll *ebpf.Collection, name string) {
+func assertUserspaceXDPDegradedPathStat(t *testing.T, coll *ebpf.Collection, name string) {
 	t.Helper()
-	if got := userspaceXDPFallbackStat(t, coll, name); got == 0 {
-		t.Fatalf("fallback stat %q = 0, want incremented", name)
+	if got := userspaceXDPDegradedPathStat(t, coll, name); got == 0 {
+		t.Fatalf("degraded path stat %q = 0, want incremented", name)
 	}
 }
 
-func assertUserspaceXDPFallbackStatAbsent(t *testing.T, coll *ebpf.Collection, name string) {
+func assertUserspaceXDPDegradedPathStatAbsent(t *testing.T, coll *ebpf.Collection, name string) {
 	t.Helper()
-	if got := userspaceXDPFallbackStat(t, coll, name); got != 0 {
-		t.Fatalf("fallback stat %q = %d, want 0", name, got)
+	if got := userspaceXDPDegradedPathStat(t, coll, name); got != 0 {
+		t.Fatalf("degraded path stat %q = %d, want 0", name, got)
 	}
 }
 
-func userspaceXDPFallbackStat(t *testing.T, coll *ebpf.Collection, name string) uint64 {
+func userspaceXDPDegradedPathStat(t *testing.T, coll *ebpf.Collection, name string) uint64 {
 	t.Helper()
 	stats := coll.Maps["userspace_fallback_stats"]
 	if stats == nil {
-		t.Fatal("userspace_fallback_stats map not loaded")
+		t.Fatal("userspace_fallback_stats compatibility map not loaded")
 	}
-	idx := fallbackReasonIndex(t, name)
+	idx := degradedPathReasonIndex(t, name)
 	var got uint64
 	if err := stats.Lookup(idx, &got); err != nil {
-		t.Fatalf("lookup userspace_fallback_stats[%d] (%s): %v", idx, name, err)
+		t.Fatalf("lookup userspace_fallback_stats compatibility map[%d] (%s): %v", idx, name, err)
 	}
 	return got
 }
 
-func fallbackReasonIndex(t *testing.T, name string) uint32 {
+func degradedPathReasonIndex(t *testing.T, name string) uint32 {
 	t.Helper()
-	for idx, candidate := range fallbackReasonNames {
+	for idx, candidate := range degradedPathReasonNames {
 		if candidate == name {
 			return uint32(idx)
 		}
 	}
-	t.Fatalf("fallback reason %q not found", name)
+	t.Fatalf("degraded path reason %q not found", name)
 	return 0
 }
 

--- a/test/incus/analyze-userspace-traces.sh
+++ b/test/incus/analyze-userspace-traces.sh
@@ -747,21 +747,21 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════
-# Section 14: BPF Fallback Stats
+# Section 14: Retained-shim Degraded Path Stats
 # ═══════════════════════════════════════════════════════════════════════
-hdr "BPF Fallback Stats"
+hdr "Retained-shim Degraded Path Stats"
 
 # Check if bpftool is available on the instance
 if incus exec "${REMOTE}:${INSTANCE}" -- which bpftool >/dev/null 2>&1; then
     # Try to dump the userspace_fallback_stats map
     FALLBACK_OUT=$(incus exec "${REMOTE}:${INSTANCE}" -- bpftool map dump pinned /sys/fs/bpf/xpf/userspace_fallback_stats 2>/dev/null || echo "")
     if [ -n "$FALLBACK_OUT" ] && [ "$FALLBACK_OUT" != "" ]; then
-        note "BPF fallback stats map:"
+        note "Retained-shim degraded-path stats map:"
         echo "$FALLBACK_OUT" | head -30 | while IFS= read -r line; do
             note "  ${line}"
         done
     else
-        note "Fallback stats map not available or empty."
+        note "Degraded-path stats map not available or empty."
     fi
 
     # Check userspace_ctrl map for enabled/disabled state

--- a/userspace-dp/src/afxdp/bpf_map.rs
+++ b/userspace-dp/src/afxdp/bpf_map.rs
@@ -1019,25 +1019,31 @@ pub(super) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "debug-log")]
 static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
 
-pub(super) const FALLBACK_STATS_PIN_PATH: &str = "/sys/fs/bpf/xpf/userspace_fallback_stats";
-pub(super) const FALLBACK_REASON_NAMES: &[&str] = &[
-    "ctrl_disabled",     // 0
-    "parse_fail",        // 1
-    "binding_missing",   // 2
-    "binding_not_ready", // 3
-    "hb_missing",        // 4
-    "hb_stale",          // 5
-    "icmp",              // 6
-    "early_filter",      // 7
-    "adjust_meta",       // 8
-    "meta_bounds",       // 9
-    "redirect_err",      // 10
-    "iface_nat_no_sess", // 11
-    "no_session",        // 12
+// The pinned map path keeps the historical "fallback" spelling for
+// mixed-version shim compatibility. Operator-facing names use
+// degraded-path terminology.
+pub(super) const DEGRADED_PATH_STATS_PIN_PATH: &str = "/sys/fs/bpf/xpf/userspace_fallback_stats";
+pub(super) const DEGRADED_PATH_REASON_NAMES: &[&str] = &[
+    "ctrl_disabled",            // 0
+    "parse_fail",               // 1
+    "binding_missing",          // 2
+    "binding_not_ready",        // 3
+    "heartbeat_missing",        // 4
+    "heartbeat_stale",          // 5
+    "icmp",                     // 6
+    "early_filter",             // 7
+    "adjust_meta",              // 8
+    "meta_bounds",              // 9
+    "redirect_err",             // 10
+    "interface_nat_no_session", // 11
+    "no_session",               // 12
+    "strict_drop",              // 13
+    "pass_to_kernel",           // 14
+    "transit_drop",             // 15
 ];
 
-pub(super) fn read_fallback_stats() -> Option<Vec<(String, u64)>> {
-    let fd = OwnedFd::open_bpf_map(FALLBACK_STATS_PIN_PATH).ok()?;
+pub(super) fn read_degraded_path_stats() -> Option<Vec<(String, u64)>> {
+    let fd = OwnedFd::open_bpf_map(DEGRADED_PATH_STATS_PIN_PATH).ok()?;
     let mut result = Vec::new();
     for idx in 0u32..16 {
         let mut value = 0u64;
@@ -1049,7 +1055,7 @@ pub(super) fn read_fallback_stats() -> Option<Vec<(String, u64)>> {
             )
         };
         if rc == 0 && value > 0 {
-            let name = FALLBACK_REASON_NAMES
+            let name = DEGRADED_PATH_REASON_NAMES
                 .get(idx as usize)
                 .copied()
                 .unwrap_or("unknown");
@@ -1183,4 +1189,3 @@ pub(super) fn delete_session_map_entry_for_removed_session_with_origin(
 #[cfg(test)]
 #[path = "bpf_map_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/afxdp/bpf_map_tests.rs
+++ b/userspace-dp/src/afxdp/bpf_map_tests.rs
@@ -83,6 +83,17 @@ fn kernel_local_session_map_entry_rejects_non_kernel_local_cases() {
 }
 
 #[test]
+fn degraded_path_reason_names_cover_retained_shim_actions() {
+    assert_eq!(DEGRADED_PATH_REASON_NAMES.len(), 16);
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[4], "heartbeat_missing");
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[5], "heartbeat_stale");
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[11], "interface_nat_no_session");
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[13], "strict_drop");
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[14], "pass_to_kernel");
+    assert_eq!(DEGRADED_PATH_REASON_NAMES[15], "transit_drop");
+}
+
+#[test]
 fn bpf_conntrack_struct_sizes_match_c() {
     // Must match C struct sizes from xpf_conntrack.h exactly.
     assert_eq!(core::mem::size_of::<BpfSessionKeyV4>(), 16);

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1929,14 +1929,14 @@ pub(crate) fn worker_loop(
                     binding_summary,
                 );
                 // Non-debug builds: no per-second stats dump (use debug-log feature for verbose output).
-                // Print XDP shim fallback stats — tells us WHY packets stop
-                // being redirected to XSK.
+                // Print retained-shim degraded-path stats — tells us WHY
+                // packets stop being redirected to XSK.
                 if cfg!(feature = "debug-log") {
-                    if let Some(stats) = read_fallback_stats() {
+                    if let Some(stats) = read_degraded_path_stats() {
                         if !stats.is_empty() {
                             let s: Vec<String> =
                                 stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
-                            eprintln!("DBG w{}: XDP_FALLBACK: {}", worker_id, s.join(" "));
+                            eprintln!("DBG w{}: XDP_DEGRADED: {}", worker_id, s.join(" "));
                         }
                     }
                 }
@@ -2073,12 +2073,12 @@ pub(crate) fn worker_loop(
                         if !sess_dump.is_empty() {
                             eprintln!("DBG STALL_SESSIONS:{sess_dump}");
                         }
-                        // Dump fallback stats at stall time
-                        if let Some(stats) = read_fallback_stats() {
+                        // Dump degraded-path stats at stall time.
+                        if let Some(stats) = read_degraded_path_stats() {
                             if !stats.is_empty() {
                                 let s: Vec<String> =
                                     stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
-                                eprintln!("DBG STALL_FALLBACK: {}", s.join(" "));
+                                eprintln!("DBG STALL_DEGRADED: {}", s.join(" "));
                             }
                         }
                         // Also dump BPF session count

--- a/userspace-xdp/src/lib.rs
+++ b/userspace-xdp/src/lib.rs
@@ -37,6 +37,9 @@ const NEXTHDR_FRAGMENT: u8 = 44;
 const NEXTHDR_AUTH: u8 = 51;
 const NEXTHDR_DEST: u8 = 60;
 const NEXTHDR_NONE: u8 = 59;
+// The BPF-side symbol names retain FALLBACK for index/map compatibility. The
+// Go/operator surface exposes these retained-shim actions as degraded-path
+// counters.
 const USERSPACE_FALLBACK_REASON_CTRL_DISABLED: u32 = 0;
 const USERSPACE_FALLBACK_REASON_PARSE_FAIL: u32 = 1;
 const USERSPACE_FALLBACK_REASON_BINDING_MISSING: u32 = 2;
@@ -317,6 +320,8 @@ static USERSPACE_SESSIONS: HashMap<UserspaceSessionKey, u8> = HashMap::with_max_
 const USERSPACE_SESSION_ACTION_REDIRECT: u8 = 1;
 const USERSPACE_SESSION_ACTION_PASS_TO_KERNEL: u8 = 2;
 
+// Pinned-map compatibility exception: Go still reads this map name during
+// mixed-version upgrades, but status/docs expose it as degraded_path_counters.
 #[map(name = "userspace_fallback_stats")]
 static USERSPACE_FALLBACK_STATS: Array<u64> =
     Array::with_max_entries(USERSPACE_FALLBACK_REASON_MAX, 0);


### PR DESCRIPTION
## Summary

- Rename the retained userspace XDP shim counters to
  `degraded_path_counters` on the primary Go/status/operator surface.
- Keep the pinned BPF map path `userspace_fallback_stats` as an internal
  mixed-version compatibility exception.
- Emit `fallback_counters` as a temporary legacy JSON alias so older
  status readers do not silently zero the counters during rolling
  upgrades.
- Decode legacy `fallback_counters` only when the new
  `degraded_path_counters` key is absent, preserving explicit new empty
  maps.
- Align the Rust helper reason-name table with the Go table for all 16
  retained-shim buckets, including `strict_drop`, `pass_to_kernel`, and
  `transit_drop`.
- Pin the Rust reason-name table with a unit test.
- Rename Rust debug-log strings and the trace analysis script away from
  fallback wording.

## Compatibility

No protocol-version bump is needed because the daemon emits both the new
primary field and the legacy JSON alias. New code should read
`degraded_path_counters`; `fallback_counters` is retained only for the
mixed-version window.

## Validation

- `go test ./pkg/dataplane/userspace -run 'ProcessStatusDegradedPathCountersJSON|DegradedPath|Status' -count=1`
- `go test ./pkg/dataplane -run 'UserspaceDegradedPathCounterStatusStructAvoidsFallbackField|ActiveDocsDescribeRetainedShimCountersAsDegradedPath' -count=1`
- `cargo test --manifest-path userspace-dp/Cargo.toml degraded_path_reason_names_cover_retained_shim_actions`
- `cargo check --manifest-path userspace-dp/Cargo.toml`
- `rustfmt --edition 2024 userspace-dp/src/afxdp/bpf_map.rs userspace-dp/src/afxdp/worker/mod.rs userspace-dp/src/afxdp/bpf_map_tests.rs`
- `git diff --check`

Refs #1509.
