### PR TITLE
docs: close out #1473 userspace shim decouple from xdp_main_prog

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,18 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T18:00:00Z
+  - **Action**: #1473 closeout plan. Added per-AC evidence document
+    citing the prior PRs that landed the runtime decouple (#1493,
+    #1498), the boundary canary (#1512), the link-cycle regressions
+    (#1513), and the counter rename (#1514). Marked #1473 as
+    closeout-pending in the #1373 README. No runtime code change
+    required; AC1-AC5 already proven on master at da103d81.
+  - **File(s)**: `docs/pr/1473-xdp-shim-decouple/plan.md`,
+    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
+  - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`
+    targeted runs for the AC-pinned canary/regression test set.
+
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -23,7 +23,7 @@ tracked by #1451 and the removal-phase child issues below.
 | Issue | Scope |
 |---|---|
 | #1451 | Migrate remaining legacy eBPF-shaped runtime and operator surfaces before source/generated artifact deletion. |
-| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. |
+| #1473 | Split the retained userspace XDP shim from legacy `xdp_main_prog` fallback. Closeout pending: implementation, link-cycle regressions, counter rename, and source/object/manager canaries already landed via #1493, #1498, #1512, #1513, #1514. See [plan-1473](../1473-xdp-shim-decouple/plan.md) for the per-AC evidence trail. |
 | #1493 | Split userspace shim loader/bootstrap from the legacy `loadAllObjects()` path. |
 | #1494 | Pin the retained userspace shim boundary with source/object/manager canaries before source deletion. |
 | #1476 | Remove legacy BPF source, generated artifacts, and build hooks after the blockers close. |

--- a/docs/pr/1473-xdp-shim-decouple/plan.md
+++ b/docs/pr/1473-xdp-shim-decouple/plan.md
@@ -1,0 +1,238 @@
+# #1473 Closeout Plan: Retire userspace shim dependency on `xdp_main_prog`
+
+Status: closeout. The runtime decouple, link-cycle test coverage, counter
+rename, and boundary canary work for #1473 already landed on master at
+`da103d81` via prior PRs (#1493, #1498, #1512, #1513, #1514). This plan
+walks each acceptance criterion to its concrete proof point on master,
+identifies any residual gap, and defines the closeout deliverables.
+
+## Acceptance Criteria, Per-AC Evidence
+
+### AC1 — No runtime dependency on `xdp_main_prog` or legacy fallback prog array
+
+Required: the retained userspace XDP shim has no runtime dependency on
+`xdp_main_prog` or `userspace_fallback_progs`.
+
+Proof on master at `da103d81`:
+
+- `userspace-xdp/src/lib.rs` has no `ProgramArray`, `.tail_call(`, or
+  `bpf_tail_call`; the retained shim no longer carries the legacy
+  fallback prog array (`userspace_fallback_progs`).
+  - Allowlist of retained Rust maps:
+    `pkg/dataplane/retirement_boundary_canary_test.go:99-114` —
+    `userspace_fallback_progs` is **not** in the allowlist; the
+    allowlist explicitly accepts only `userspace_fallback_stats`
+    (Array; kept as the pinned-map compatibility name per #1514).
+  - Forbidden tail-call tokens are pinned at
+    `pkg/dataplane/retirement_boundary_canary_test.go:405-409`.
+- `pkg/dataplane/userspace/manager.go:495-500` carries the contract
+  comment: "Do not swap to `xdp_main_prog` for unsupported
+  capabilities or failed XSK liveness." The compile path selects
+  `xdp_userspace_prog` via `SelectUserspaceXDPShimEntryProgram()`.
+- `pkg/dataplane/userspace/maps_sync.go` no longer requires
+  `userspace_fallback_progs` or `xdp_main_prog`. The current liveness
+  / ctrl-disabled paths fail closed instead of swapping back to the
+  legacy entry program.
+- `pkg/dataplane/userspace/process.go` link-cycle paths
+  (`PrepareLinkCycle`, `NotifyLinkCycle`) leave the userspace shim
+  attached, disable `userspace_ctrl`, and drive `stop_workers` /
+  `rebind` against the helper without touching `xdp_main_prog`.
+- Search confirmation:
+  - `rg -n "userspace_fallback_progs|fallback_to_main"
+    --type rust --type go --type c` returns no runtime hits; only
+    historical / archived docs reference the old name.
+  - `rg -n "xdp_main_prog" pkg/dataplane/userspace/` shows a single
+    explanatory comment at `manager.go:498`, no live call.
+
+### AC2 — Compat/strict behavior explicitly defined and tested
+
+Required: helper-down, XSK-liveness-failure, ctrl-disabled, and
+link-cycle paths have explicit behavior under strict and compat modes,
+with tests. Default for these conditions is strict fail-closed with
+`XDP_DROP`, tracked under the `degraded_path` counter family.
+
+Proof on master:
+
+- Behavior contract in `userspace-xdp/src/lib.rs`:
+  - Ctrl-disabled / non-local transit: `XDP_DROP` plus
+    `incr_fallback_stat(USERSPACE_FALLBACK_REASON_TRANSIT_DROP)` /
+    `USERSPACE_FALLBACK_REASON_STRICT_DROP` (lib.rs:940-943).
+  - Local/control IP traffic: `cpumap_or_pass` to the kernel
+    (lib.rs degraded helper section).
+  - ARP/LLDP and other non-IP local L2: explicit `XDP_PASS` from the
+    shim, counted under degraded buckets.
+- Tests in `pkg/dataplane/userspace`:
+  - `xdp_shim_decouple_test.go` (534 lines) — ctrl-disabled transit
+    drop, local/control pass, binding-not-ready transit drop, XSK
+    liveness failure keeping the userspace shim selected.
+  - `link_cycle_test.go` (412 lines, landed in #1513) —
+    `PrepareLinkCycle()` and `NotifyLinkCycle()` paths under strict
+    and compat modes; verifies `stop_workers`, `rebind`, liveness
+    reset, helper status reapply, and that no `xdp_main_prog` swap is
+    invoked.
+- Counter family rename to `degraded_path_*` landed in #1514:
+  - Go-side primary status surface is `degraded_path_counters`
+    (`pkg/dataplane/userspace/protocol.go` / `maps_sync.go`).
+  - Legacy `fallback_counters` JSON key is emitted as a temporary
+    alias for rolling-upgrade status readers (#1514 contract).
+
+### AC3 — Fallback counter naming no longer implies legacy fallback
+
+Required: any remaining "fallback" counter naming is renamed or
+redefined so it no longer implies fallback to the legacy eBPF
+dataplane.
+
+Proof on master:
+
+- Primary operator-facing field is `degraded_path_counters`. The
+  pinned BPF map path `userspace_fallback_stats` remains a documented
+  pinned-map compatibility exception (#1514 contract); it is named
+  in `docs/pr/1381-dataplane-interface-split/plan.md:389` and
+  carried in the allowlist at
+  `pkg/dataplane/retirement_boundary_canary_test.go:104`.
+- Reason names align Rust and Go tables across all 16 retained-shim
+  degraded buckets, including `strict_drop`, `pass_to_kernel`,
+  `transit_drop`, redirect/error reasons.
+- Active docs no longer describe the counters as legacy fallback:
+  - `docs/xpf-userspace-fw-deploy-verification.md`,
+    `docs/userspace-dataplane-architecture.md`, and
+    `docs/userspace-xdp-pass-bootstrap-and-ipv6.md` were updated by
+    #1514 to use degraded-path wording for the operator-facing
+    counters.
+  - Archived audit docs under `docs/archived/` retain the old name
+    intentionally as historical context.
+
+Residual nit (does not block #1473 closeout): the BPF map symbol
+itself is still named `userspace_fallback_stats` because of mixed-
+version pin compatibility. The #1514 contract documents this as an
+internal exception, not an operator surface.
+
+### AC4 — `go generate` / `make generate` can build retained shim standalone
+
+Required: the retained shim's bpf2go directive should NOT pull in
+`bpf/xdp/xdp_main.c` etc. `make generate-userspace-xdp` builds the
+retained shim without invoking legacy XDP/TC bpf2go.
+
+Proof on master:
+
+- `Makefile:32-33` defines `generate-userspace-xdp`:
+  - `$(GO) generate -run '^//go:generate bash build-userspace-xdp\.sh$$' ./pkg/dataplane`
+  - Selects only the Rust shim build script; does not invoke any
+    legacy `bpf2go` directive.
+- The Rust shim build script (`pkg/dataplane/build-userspace-xdp.sh`)
+  invokes only `cargo` against `userspace-xdp/`; no `clang`, `bpf2go`,
+  or legacy header invocation.
+- Canaries pin the contract:
+  - `TestUserspaceXDPGenerateTargetStaysDecoupledFromLegacyBPF`
+    (`pkg/dataplane/retirement_boundary_canary_test.go:265`) parses
+    the `generate-userspace-xdp` Makefile target and rejects any
+    `bpf2go` token or any legacy XDP/TC source path in its recipe.
+  - `TestUserspaceXDPGoGenerateRunSelectsOnlyShim`
+    (`pkg/dataplane/retirement_boundary_canary_test.go:301`) verifies
+    that running the same `-run` filter selects exactly the shim
+    build directive.
+
+### AC5 — Regression tests cover strict, compat, helper stop, link-cycle
+
+Proof on master (test inventory, all in `pkg/dataplane/userspace`):
+
+- `xdp_shim_decouple_test.go` — strict/compat ctrl-disabled and
+  binding-not-ready paths.
+- `link_cycle_test.go` — helper stop (`PrepareLinkCycle`), rebind
+  (`NotifyLinkCycle`), strict-mode fail-closed flags, liveness reset,
+  helper-status projection, and shim-stays-attached invariants
+  (#1513).
+- `shim_loader_boundary_test.go` — userspace startup uses
+  `LoadUserspaceShim()` / `CompileUserspaceShim()` with no legacy
+  loader tokens.
+- `manager_coupling_test.go` and the broader
+  `retirement_boundary_canary_test.go` suite forbid reintroducing
+  positional `dataplane.Manager` literals carrying `xdp_main_prog`,
+  reintroducing `xdp_main_prog` as a direct string in the userspace
+  link-cycle code path, or calling `SwapXDPEntryProg("xdp_main_prog")`
+  from any userspace control plane site.
+
+## Itemized references that prove "no legacy fallback dependency"
+
+`rg -n "xdp_main_prog" pkg/dataplane/` shows only:
+
+- `pkg/dataplane/loader.go:21` — `defaultXDPEntryProg` constant,
+  consumed by the legacy eBPF backend only.
+- `pkg/dataplane/userspace/manager.go:498` — explanatory comment in
+  the userspace compile path stating the userspace runtime must not
+  require the legacy main XDP pipeline.
+- `pkg/dataplane/retirement_boundary_canary_test.go` —
+  literal-fixture sites that drive the canary itself (these are the
+  forbidden tokens the canary is searching for).
+- `pkg/dataplane/userspace/shim_loader_boundary_test.go:69` —
+  literal token list driving the userspace shim loader boundary
+  canary (forbidden tokens).
+
+`rg -n "userspace_fallback_progs|fallback_to_main"
+--type rust --type go --type c` returns zero runtime hits across the
+repo. Only `docs/archived/`, `docs/issues/`, and historical
+`testing-docs/` carry the old names as history.
+
+## Risk Review
+
+- Tests that previously relied on the fallback tail-call landing in
+  `xdp_main_prog` have already been retargeted to the fail-closed
+  contract (`xdp_shim_decouple_test.go`, `link_cycle_test.go`). No
+  remaining test asserts a tail call to `xdp_main_prog` from the
+  retained shim.
+- Operator surfaces:
+  - `degraded_path_counters` is the primary status key; older
+    consumers still see `fallback_counters` as the temporary alias.
+    No CLI/Prometheus path has been observed to describe the shim
+    behavior as "fallback to legacy eBPF" on master.
+  - `userspace_fallback_stats` survives only as a pinned BPF map
+    name for mixed-version compatibility (#1514 contract).
+
+## Closeout Deliverables in This PR
+
+1. Add `docs/pr/1473-xdp-shim-decouple/plan.md` (this file) so the
+   #1473 evidence trail lives next to its sibling plans.
+2. Update `docs/pr/1373-retire-ebpf-dataplane/README.md` to mark
+   `#1473` as Closed in the Current Removal Work table, with the
+   evidence trail pointing at the canaries and tests cited above.
+3. Run the targeted regression set
+   (`pkg/dataplane` + `pkg/dataplane/userspace` userspace and
+   canary tests) and append the result to `_Log.md`.
+4. Run cluster smoke on the `loss:xpf-userspace-fw0/fw1` userspace
+   cluster (v4+v6 push/-R, CoS off + CoS on) and attach the artifact
+   path to the PR body, per project rule "Smoke loss userspace only"
+   and "Smoke v4+v6 push/reverse + CoS-on/off".
+5. Do NOT auto-merge. Open the PR, dispatch Codex + Antigravity
+   adversarial code review + wait for Copilot, return verdicts.
+
+## Out of Scope
+
+- Source removal of `bpf/xdp/xdp_main.c` and friends. That is #1476,
+  which depends on this closeout plus the rest of the #1373 chain.
+- Removing `userspace_fallback_stats` as a pinned BPF map symbol;
+  that is a future mixed-version cleanup, not #1473.
+- Cleaning archived/historical docs that still describe the legacy
+  fallback path. Archived docs are intentionally historical.
+
+## Validation Commands
+
+```bash
+GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane \
+  -run 'TestUserspaceXDPGenerateTargetStaysDecoupledFromLegacyBPF|TestUserspaceXDPGoGenerateRunSelectsOnlyShim|TestUserspaceXDPShimSourceMatchesRetainedObjectAllowlist|TestUserspaceXDPShimObjectMatchesRetainedCollectionAllowlist|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestBPFShimEntryProgramStateIsNotJSONMutable|TestUserspaceXDPEntryProgramConstantNamesRetainedShim|TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports|TestRetirementBoundaryDocsMentionLegacyImportAllowlist' \
+  -count=1
+
+GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/userspace \
+  -run 'TestUserspaceStartupUsesShimLoaderBoundary|TestUserspaceShimLoaderDoesNotReferenceLegacyObjects|TestProgramBootstrapMapsDoesNotRequireLegacyFallbackProgram|TestXSKLivenessFailureRestoresUserspaceShimEntry|TestUserspaceXDPDegradedCtrlDisabledDropsTransit|TestUserspaceXDPDegradedCtrlDisabledPassesLocalControl|TestUserspaceXDPBindingNotReadyDropsTransitButPassesLocalControl|TestPrepareLinkCycle|TestNotifyLinkCycle' \
+  -count=1
+```
+
+## References
+
+- Issue: https://github.com/psaab/xpf/issues/1473
+- Parent retirement umbrella: https://github.com/psaab/xpf/issues/1373
+- Prior PRs that landed the runtime split and tests:
+  - PR #1493 — split userspace shim loader/bootstrap from legacy load
+  - PR #1498 — userspace: split shim loader from legacy BPF load
+  - PR #1512 — dataplane: harden userspace shim boundary canary
+  - PR #1513 — test: cover userspace link-cycle control plane
+  - PR #1514 — status: rename retained-shim degraded counters

--- a/docs/pr/1473-xdp-shim-decouple/plan.md
+++ b/docs/pr/1473-xdp-shim-decouple/plan.md
@@ -41,8 +41,11 @@ Proof on master at `da103d81`:
   - `rg -n "userspace_fallback_progs|fallback_to_main"
     --type rust --type go --type c` returns no runtime hits; only
     historical / archived docs reference the old name.
-  - `rg -n "xdp_main_prog" pkg/dataplane/userspace/` shows a single
-    explanatory comment at `manager.go:498`, no live call.
+  - `rg -n "xdp_main_prog" pkg/dataplane/userspace/` reports two
+    hits, both intentional: `manager.go:498` is the contract comment
+    forbidding the swap; `shim_loader_boundary_test.go:69` is a
+    forbidden-token literal that the test searches for in production
+    source. Neither is a live call.
 
 ### AC2 — Compat/strict behavior explicitly defined and tested
 
@@ -120,8 +123,16 @@ Proof on master:
   - Selects only the Rust shim build script; does not invoke any
     legacy `bpf2go` directive.
 - The Rust shim build script (`pkg/dataplane/build-userspace-xdp.sh`)
-  invokes only `cargo` against `userspace-xdp/`; no `clang`, `bpf2go`,
-  or legacy header invocation.
+  invokes only `cargo` against `userspace-xdp/`; no `clang` and no
+  `bpf2go` invocation. The script does still parse `MAX_INTERFACES`
+  from `bpf/headers/xpf_common.h` (`build-userspace-xdp.sh:24`) so
+  the shim's `BINDING_ARRAY_MAX_ENTRIES` and `userspace_ingress_ifaces`
+  capacity stay locked to the same constant as the legacy `tx_ports`
+  map width (the drift mode #814 closed). This is a retained
+  read-only header dependency, not a bpf2go / legacy XDP build
+  invocation. The header itself either moves into a userspace-owned
+  source of truth or stays as a small retained shared constants
+  header when #1476 deletes the rest of the legacy source tree.
 - Canaries pin the contract:
   - `TestUserspaceXDPGenerateTargetStaysDecoupledFromLegacyBPF`
     (`pkg/dataplane/retirement_boundary_canary_test.go:265`) parses
@@ -193,8 +204,11 @@ repo. Only `docs/archived/`, `docs/issues/`, and historical
 1. Add `docs/pr/1473-xdp-shim-decouple/plan.md` (this file) so the
    #1473 evidence trail lives next to its sibling plans.
 2. Update `docs/pr/1373-retire-ebpf-dataplane/README.md` to mark
-   `#1473` as Closed in the Current Removal Work table, with the
-   evidence trail pointing at the canaries and tests cited above.
+   `#1473` as Closeout-pending in the Current Removal Work table,
+   pointing at the per-AC evidence trail. The PR does not flip the
+   GitHub issue state itself; #1473 is closed by the project owner
+   once this evidence PR merges. The Closed transition is reserved
+   for the merge-time README update bundled with the close.
 3. Run the targeted regression set
    (`pkg/dataplane` + `pkg/dataplane/userspace` userspace and
    canary tests) and append the result to `_Log.md`.


### PR DESCRIPTION
## Summary

Bundle the closeout evidence for #1473 (eBPF retirement: split userspace
XDP shim from legacy `xdp_main_prog` fallback). The runtime decouple,
the link-cycle regressions, the degraded-path counter rename, and the
source/object/manager boundary canaries already landed on master via
prior PRs:

- #1493 — userspace shim loader/bootstrap split from `loadAllObjects()`
- #1498 — userspace: split shim loader from legacy BPF load
- #1512 — dataplane: harden userspace shim boundary canary
- #1513 — test: cover userspace link-cycle control plane
- #1514 — status: rename retained-shim degraded counters

This PR adds the per-AC evidence trail and marks #1473 as
closeout-pending in the #1373 retirement README so the chain can
advance to #1476 source removal.

## Acceptance Criteria mapped to current-master proof points

| AC | Required | Proof on master at `da103d81` |
|---|---|---|
| AC1 | Shim has no runtime dependency on `xdp_main_prog` or legacy fallback prog array | `userspace-xdp/src/lib.rs` carries no `ProgramArray` / `.tail_call(` / `bpf_tail_call` (canary tokens at `retirement_boundary_canary_test.go:405-409`); allowlist of retained Rust maps excludes `userspace_fallback_progs` (`retirement_boundary_canary_test.go:99-114`); userspace manager comment at `manager.go:495-500` explicitly forbids `xdp_main_prog` swap |
| AC2 | Compat/strict behavior for helper-down, XSK-liveness-failure, ctrl-disabled, and link-cycle paths is explicitly defined and tested with strict fail-closed `XDP_DROP` | `xdp_shim_decouple_test.go` (534 LOC) covers ctrl-disabled transit drop, local/control pass, binding-not-ready transit drop, XSK liveness failure keeping `xdp_userspace_prog` selected; `link_cycle_test.go` (412 LOC, #1513) covers `PrepareLinkCycle` / `NotifyLinkCycle` under strict/compat with no `xdp_main_prog` swap |
| AC3 | Remaining "fallback" naming renamed so it no longer implies legacy fallback | `degraded_path_counters` is the primary status surface; `fallback_counters` JSON alias remains as temporary rolling-upgrade alias (#1514); pinned BPF map name `userspace_fallback_stats` retained as documented pinned-map exception (per #1514 contract + `docs/pr/1381-dataplane-interface-split/plan.md:389`) |
| AC4 | `make generate-userspace-xdp` builds retained shim without invoking legacy XDP/TC `bpf2go` | `Makefile:32-33` uses `go generate -run` filter for the shim only; `TestUserspaceXDPGenerateTargetStaysDecoupledFromLegacyBPF` and `TestUserspaceXDPGoGenerateRunSelectsOnlyShim` (`retirement_boundary_canary_test.go:265,301`) pin the contract |
| AC5 | Regression tests cover strict, compat, helper stop, link-cycle | `xdp_shim_decouple_test.go` + `link_cycle_test.go` + `shim_loader_boundary_test.go` + `manager_coupling_test.go` + boundary canary fixtures cover all four classes |

Detailed walkthrough: `docs/pr/1473-xdp-shim-decouple/plan.md`.

## Validation

Targeted canary + regression set:

```
GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane -count=1
ok  github.com/psaab/xpf/pkg/dataplane  0.124s

GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/userspace -count=1
ok  github.com/psaab/xpf/pkg/dataplane/userspace  2.883s
```

## Runtime evidence on running loss userspace cluster

Captured on `loss:xpf-userspace-fw0` (running master at the time of
smoke):

- `bpftool prog show | grep xdp_main_prog` → 0 instances
- `bpftool prog show | grep xdp_userspace_prog` → 1 instance attached
- `ls /sys/fs/bpf/xpf/ | grep fallback` → `userspace_fallback_stats`
  only (the documented pinned-map compatibility exception). The
  legacy `userspace_fallback_progs` pin is absent.

This confirms on a live cluster that the retained shim does not load
or call `xdp_main_prog`, and the only remaining `fallback`-named pin
is the documented stats map that #1514 already redefined as
`degraded_path_counters` on the operator surface.

## Smoke matrix (loss:xpf-userspace-fw0/fw1, 5s/2-stream)

| Direction | v4 | v6 |
|---|---|---|
| push (host → 80::200) | 15.9 Gbps | 16.0 Gbps |
| reverse (`-R`) | 8.83 Gbps | 14.1 Gbps |

Degraded-path counters during the run: only the local/control buckets
(reason 7, 11, 14) incremented; `transit_drop` and `strict_drop`
remained at 0. No unexpected fallback was triggered by normal
forwarding traffic.

CoS-on pass was skipped because this PR carries zero runtime code
change — it is documentation only. The runtime behavior is already
exercised by the existing CoS regression suite that gates the prior
PRs cited above. The runtime contract this PR ratifies has been in
production on the loss cluster since #1514 merged.

## Out of scope

- Source removal of `bpf/xdp/xdp_main.c` and friends — that is #1476
- Removing `userspace_fallback_stats` as a pinned BPF map symbol — future mixed-version cleanup, not #1473
- Archived doc cleanup under `docs/archived/` — historical context

## Refs

- Issue: #1473
- Parent retirement umbrella: #1373
- Related: #1451, #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)