### PR TITLE
wg: document outer IPv4 UDP cs=0 default + add wire-byte regression gate (#1501 A2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20,7 +20,18 @@
     PLAN-READY) both agreed before code touched.
   - **File(s)**: `userspace-dp/src/afxdp/wg/outer.rs`,
     `docs/pr/1501-a2-outer-udp-cs/plan.md`, `_Log.md`
-  - **Validation**: cargo build clean; cargo test pending.
+  - **Validation**: cargo build --release clean; cargo test
+    --release for `afxdp::wg::outer` 6/6 pass (5x flake-checked);
+    full cargo suite 1417 passed modulo two pre-existing flaky
+    tests on origin/master da103d81 baseline
+    (`snat_contract_documents_current_fail_closed_runtime`
+    fails consistently on master too;
+    `reconcile_peers_snapshot_is_atomic_under_concurrent_load`
+    is a 1-in-5 load flake on master too); `go test ./...`
+    clean; smoke on loss userspace cluster Pass A (CoS off)
+    0-retrans single-stream + 23 Gb/s 12-stream `-R`, and
+    Pass B (CoS on) 24-cell per-class shaper smoke 5201-5206 ×
+    v4+v6 × push+rev with shape rates hit cleanly.
 
 ## 2026-05-24
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,27 @@
 # Action Log
 
+## 2026-05-25
+
+- **Timestamp**: 2026-05-25T05:00:00Z
+  - **Action**: #1501 A2 — replaced the stale TODO + contradictory
+    doc comment on `write_outer_ipv4_udp` with an honest
+    RFC-grounded comment explaining that the engine intentionally
+    emits outer IPv4 UDP cs=0 (legal per RFC 768) and that this
+    DIFFERS from kernel WireGuard / wireguard-go which compute
+    the outer UDP checksum. Added two byte-level regression
+    assertions on `out[26..28] == [0, 0]` (one new dedicated
+    `udp_checksum_is_zero_on_ipv4_outer` test + a strengthened
+    `ipv4_checksum_is_correct`) with 0xff sentinel pre-fill so
+    the assertion proves the function wrote zero rather than
+    leaving the buffer zero-initialized. Triple-review:
+    Antigravity (round-1 PLAN-NEEDS-MINOR for sentinel pre-fill;
+    round-2 PLAN-READY) and Codex (round-1 PLAN-NEEDS-MAJOR for
+    factually-wrong "matches kernel WG" claim; round-2
+    PLAN-READY) both agreed before code touched.
+  - **File(s)**: `userspace-dp/src/afxdp/wg/outer.rs`,
+    `docs/pr/1501-a2-outer-udp-cs/plan.md`, `_Log.md`
+  - **Validation**: cargo build clean; cargo test pending.
+
 ## 2026-05-24
 
 - **Timestamp**: 2026-05-25T00:45:00Z

--- a/docs/pr/1501-a2-outer-udp-cs/plan.md
+++ b/docs/pr/1501-a2-outer-udp-cs/plan.md
@@ -2,7 +2,26 @@
 
 ## Status
 
-DRAFT v1 — pending adversarial plan review (Codex + Antigravity).
+DRAFT v2 — Antigravity PLAN-NEEDS-MINOR addressed (sentinel buffer
+pre-fill so the regression gate proves the function *wrote* cs=0
+rather than relying on zero-initialized memory). Codex plan review
+still pending.
+
+## Round-1 plan-review verdicts
+
+- **Antigravity (job adversarial-review-mpkq2awd-e66pif):**
+  **PLAN-NEEDS-MINOR.** Confirmed RFC 768 / RFC 8200 accuracy, code
+  reality (outer.rs:103 writes 0; lines 57-69 hold the stale TODO),
+  caller analysis (test-only), receive-side analysis (try_decap
+  takes post-strip wg_record), and perf framing. Sole minor: the
+  proposed `udp_checksum_is_zero_on_ipv4_outer` test would silently
+  pass under regression because `let mut out = [0u8; 40]` is
+  already zero. Required correction: pre-fill the buffer with
+  non-zero sentinel bytes (e.g. `0xff`) so the assertion proves
+  the function actively wrote zero. v2 applies this discipline to
+  both the new test and the strengthened `ipv4_checksum_is_correct`
+  test.
+- **Codex:** pending.
 
 ## Issue framing
 
@@ -146,17 +165,50 @@ block at the bottom of `outer.rs`:
    This is the byte-level regression gate that fails if anyone
    "fixes" the TODO by adding a UDP checksum compute step.
 
-2. `ipv4_udp_cs_zero_round_trips_through_existing_tests` —
-   leave-or-strengthen the existing `ipv4_checksum_is_correct`
-   test by adding the same UDP cs assertion to it (so the
-   self-check covers both fields). Specifically: after the
-   IPv4-header self-check, also assert
-   `out[26..28] == [0, 0]`.
+   **CRITICAL: pre-fill the output buffer with non-zero
+   sentinel bytes (`0xff`) before the call.** Per Antigravity
+   plan-review v1: a zero-initialized buffer would silently
+   pass even if a future commit deleted the cs=0 write — the
+   sentinel forces the assertion to prove the function
+   *actively wrote* zero rather than left the bytes
+   pre-zeroed. Same discipline applies to the strengthened
+   `ipv4_checksum_is_correct` assertion below.
 
-If the reviewer wants the second test as a separate `#[test]`
-fn rather than as an extension of the existing self-check fn,
-that's a minor I'll accept; the byte-level assertion is what
-matters.
+   Test skeleton (note `[0xffu8; 40]`, NOT `[0u8; 40]`):
+
+   ```rust
+   #[test]
+   fn udp_checksum_is_zero_on_ipv4_outer() {
+       let mut out = [0xffu8; 40]; // sentinel — prove the
+                                   // function wrote zero,
+                                   // not that init left zero.
+       write_outer_ipv4_udp(
+           &mut out,
+           Ipv4Addr::new(10, 0, 0, 1),
+           Ipv4Addr::new(10, 0, 0, 2),
+           51820, 51820, 0, 64, 100,
+       ).unwrap();
+       assert_eq!(&out[26..28], &[0, 0]);
+   }
+   ```
+
+2. Strengthen the existing `ipv4_checksum_is_correct` test by
+   adding `out[26..28] == [0, 0]` as a second assertion, AND
+   change its buffer init from `[0u8; 28]` to `[0xffu8; 28]`
+   so the same sentinel discipline applies to the existing
+   self-check. The IPv4 header self-check still works under
+   sentinel init because the function overwrites every
+   IPv4-header byte; the UDP cs assertion is what needs the
+   sentinel.
+
+   Alternatively, the assertion can live in its own new
+   `#[test]` fn — what matters is that the wire-byte UDP cs
+   assertion exists with a non-zero pre-fill.
+
+If the reviewer wants the second assertion as a separate
+`#[test]` fn rather than as an extension of the existing
+self-check fn, that's a minor I'll accept; the byte-level
+assertion with sentinel pre-fill is what matters.
 
 ### What the PR does NOT change
 

--- a/docs/pr/1501-a2-outer-udp-cs/plan.md
+++ b/docs/pr/1501-a2-outer-udp-cs/plan.md
@@ -1,0 +1,287 @@
+# #1501 A2 — Outer IPv4 UDP cs=0 by default
+
+## Status
+
+DRAFT v1 — pending adversarial plan review (Codex + Antigravity).
+
+## Issue framing
+
+#1501 is the follow-up minors tracker for the clean-room WireGuard
+engine merged in #1499. Item A2 is the mechanical engine-side
+follow-up:
+
+> "Outer UDP IPv4 checksum can be left as 0 (RFC 768 §"UDP CHECKSUM
+> IS NULL"). Source: r8 commit message deferred list —
+> `userspace-dp/src/afxdp/wg/outer.rs:57`. The current code always
+> computes the outer UDP IPv4 checksum… Recommended change: emit
+> `cs=0` on the outer IPv4 UDP header by default; leave IPv6 outer
+> untouched. Add a config knob (`outer-udp-checksum compute|zero`,
+> default `zero` for v4) if behavior needs to be tunable for
+> receivers that drop `cs=0`. Mechanical 1-line change in
+> `write_outer_ipv4_udp` plus 2 tests."
+
+The issue body is **wrong on a load-bearing fact**: the current
+code already emits `cs=0`. `userspace-dp/src/afxdp/wg/outer.rs:103`
+reads:
+
+```rust
+hdr[26..28].copy_from_slice(&0u16.to_be_bytes()); // checksum = 0
+```
+
+What the file is internally inconsistent about:
+
+- Lines 52-55: doc comment correctly explains we set UDP cs to 0
+  (RFC 768) and why — "UDP checksum offload semantics differ across
+  NICs and we want a known-baseline behavior".
+- Lines 57-69: a `TODO(#1499 r4 / udp-checksum)` block claims the
+  opposite — that the integration PR should compute the UDP
+  checksum or delegate to offload, citing "kernel WG and
+  wireguard-go emit a non-zero UDP checksum on IPv4".
+
+The TODO's premise is contradicted by RFC 768 (cs=0 is legal IPv4
+UDP) AND by the issue body's own assertion that "kernel WG does
+[cs=0] for outer-IPv4 traffic" (#1501 A2 body, paragraph 2). The
+TODO is stale guidance left over from the #1499 r4 review
+discussion that subsequently resolved in favor of emitting cs=0.
+
+**Therefore the real A2 work is:**
+
+1. Resolve the contradiction in `outer.rs` doc/TODO: remove the
+   stale "compute it" TODO, tighten the kept comment to cite the
+   RFC and explain the v4-vs-v6 asymmetry.
+2. Add an explicit wire-byte test that the UDP checksum field is
+   zero on the IPv4 outer (currently nothing asserts byte 26-27).
+3. Add a code-level guard so the `cs=0` invariant cannot silently
+   regress (e.g., assertion inside an existing test, since the
+   only callers are tests today).
+
+## Honest scope/value framing
+
+A2 as described in the issue body would be a true per-packet perf
+win (~20-30 cycles, material at line rate) if the code currently
+computed the UDP checksum. **It does not** — the code already
+emits `cs=0`. So the *runtime* perf delta of this PR is **zero**.
+
+The actual value is:
+
+- **Doc correctness.** Future contributors reading `outer.rs:57`
+  would see a TODO directing them to add UDP-checksum compute or
+  offload and might act on it, regressing the wire behavior we
+  intentionally have. The TODO is a landmine.
+- **Test coverage.** Today nothing asserts `cs==0` on the wire.
+  Anyone "fixing" the cs=0 to compute (the TODO's instruction)
+  would not trip any existing test. That's the silent-regression
+  surface this PR closes.
+- **#1501 close-out.** A2 is in the tracker; closing it via
+  doc/test cleanup is the honest disposition since the code half
+  already shipped.
+
+If reviewers conclude the perf gain is too small to justify the
+churn, PLAN-KILL is an acceptable verdict. The honest framing
+here is that the "perf gain" line in the issue body does not
+apply to this PR because the perf win already shipped silently
+with #1499 — this PR is documentation + a regression gate.
+
+## What's already shipped / partially batched
+
+- #1499 merged with `write_outer_ipv4_udp` writing `cs=0` at
+  line 103. Both the inline comment at 52-55 (correct) and the
+  TODO at 57-69 (now stale) landed together.
+- IPv6 outer is not implemented at all — only IPv4 outer is
+  supported in #1499 scope. RFC 8200 §8.1 (non-zero UDP cs
+  required for IPv6) only matters when the v6 outer ships, and
+  the v6 builder is a separate follow-up out of scope here.
+- The engine's `try_decap` operates on the WG transport record
+  AFTER the outer UDP/IP has been stripped by the AF_XDP shim
+  caller. There is no receive-side outer UDP checksum
+  verification in the engine. (Verified by reading engine.rs:633
+  signature — `wg_record: &[u8]`.)
+
+## Concrete design
+
+### Source change in `userspace-dp/src/afxdp/wg/outer.rs`
+
+Replace the 23-line comment block at lines 47-69 with a tighter,
+non-contradictory doc comment. The function body is unchanged
+(it already sets cs=0). The new comment explains:
+
+1. RFC 768 §"UDP CHECKSUM IS NULL" allows IPv4 UDP cs=0.
+2. Kernel WireGuard emits cs=0 on outer IPv4 — we match that.
+3. RFC 8200 §8.1 forbids cs=0 on IPv6 UDP; the v6 outer
+   builder (when it ships, separate follow-up) must NOT take
+   the same shortcut.
+4. The IPv4 header checksum (mandatory) is computed; the UDP
+   checksum (optional on IPv4) is zero.
+
+Proposed replacement comment:
+
+```rust
+/// Write the outer IPv4 + UDP header for a WG-encapsulated payload.
+///
+/// `payload_len` is the length of the WG transport record
+/// (header + ciphertext + tag) that follows the UDP header.
+///
+/// IPv4 header checksum: mandatory — computed here over the
+/// IPv4 header only.
+///
+/// UDP checksum: emitted as 0 ("not computed") per RFC 768
+/// §"UDP CHECKSUM IS NULL". This matches kernel WireGuard's
+/// behavior for outer-IPv4 traffic and saves the per-packet
+/// pseudo-header + payload sum. RFC 8200 §8.1 requires a
+/// non-zero UDP checksum on IPv6 — when the v6 outer builder
+/// ships it MUST compute the UDP checksum (cannot take this
+/// shortcut). Some commercial midboxes drop UDPv4 with cs=0;
+/// if a deployment encounters one, the integration layer can
+/// surface an `outer-udp-checksum compute|zero` config knob
+/// — out of scope for this engine-side PR.
+```
+
+### Test additions in the existing `outer_tests` mod
+
+Add two unit tests to the existing `#[cfg(test)] mod outer_tests`
+block at the bottom of `outer.rs`:
+
+1. `udp_checksum_is_zero_on_ipv4_outer` — calls
+   `write_outer_ipv4_udp` and asserts `out[26..28] == [0, 0]`.
+   This is the byte-level regression gate that fails if anyone
+   "fixes" the TODO by adding a UDP checksum compute step.
+
+2. `ipv4_udp_cs_zero_round_trips_through_existing_tests` —
+   leave-or-strengthen the existing `ipv4_checksum_is_correct`
+   test by adding the same UDP cs assertion to it (so the
+   self-check covers both fields). Specifically: after the
+   IPv4-header self-check, also assert
+   `out[26..28] == [0, 0]`.
+
+If the reviewer wants the second test as a separate `#[test]`
+fn rather than as an extension of the existing self-check fn,
+that's a minor I'll accept; the byte-level assertion is what
+matters.
+
+### What the PR does NOT change
+
+- No config knob in this PR. The issue body proposed
+  `outer-udp-checksum compute|zero` as optional; since the
+  default is already cs=0 and we have no reported midbox-drop
+  case in the test lab, deferring the knob to the integration
+  PR (where the Junos config compiler lives anyway) is the
+  smaller-scope path.
+- No IPv6 outer change — the v6 builder doesn't exist yet.
+- No engine.rs changes — `try_encap` doesn't call
+  `write_outer_ipv4_udp`; only test code does today.
+- No receive-side UDP cs verify path — none exists, and adding
+  one would be a behavior change (kernel WG accepts cs=0; we
+  do too because the shim hands us the record post-UDP-strip).
+
+## Public API preservation
+
+- `pub(crate) fn write_outer_ipv4_udp(...) -> Option<usize>` —
+  signature unchanged.
+- `pub(crate) fn write_outer_eth(...)` — untouched.
+- `pub(crate) fn outer_l2_len(...)` — untouched.
+- No new public exports. No new config fields. No new enums.
+
+The crate-internal `outer.rs` module is consumed only by
+`afxdp/wg/tests.rs` and by `outer.rs`'s own test module.
+There are no daemon callers and no Go callers. Verified by
+`grep -rn "write_outer_ipv4_udp"` returning 6 hits, all
+within `userspace-dp/src/afxdp/wg/`.
+
+## Hidden invariants the change must preserve
+
+1. **Wire-byte position of the UDP checksum field.** Bytes
+   26..28 of the emitted `out` slice carry the UDP cs field
+   (IP_HDR_LEN=20 + UDP cs offset 6 = 26). The new assertion
+   is anchored on this offset and must remain accurate.
+2. **IPv4 header checksum still computed and self-checks to
+   zero.** The existing `ipv4_checksum_is_correct` test must
+   still pass; we are NOT skipping the IPv4 header cs (which
+   is mandatory per RFC 791).
+3. **Total length and UDP length fields unchanged.** This PR
+   does not touch `total_len`, `udp_len`, TTL, TOS, or any
+   IPv4 header field other than the doc comment.
+4. **No allocation introduced.** The function is already
+   no-alloc; the doc edit cannot introduce allocations.
+5. **IPv6 path unchanged.** There is no IPv6 outer builder
+   today; the doc explicitly forbids carrying this shortcut
+   over when the v6 builder ships.
+
+## Risk assessment
+
+| Risk class | Level | Rationale |
+|------------|-------|-----------|
+| Behavioral regression | NONE | Code body unchanged; only comment + tests added. Wire bytes are identical to master. |
+| Lifetime / borrow-checker | NONE | No new code. |
+| Performance regression | NONE | Code body unchanged; cs=0 already shipping. |
+| Architectural mismatch (#961 / #946 Phase 2) | NONE | Engine-internal doc + test addition. No cross-cutting state. No batched-pipeline implications. |
+| Wire-interop regression with midboxes | NONE — pre-existing | We are not changing the wire. If a midbox drops cs=0, it dropped today's master too. The integration PR can add an opt-in knob if a real deployment hits one. |
+
+## Test plan
+
+- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build --release` clean.
+- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo test --release` — all userspace-dp tests pass, including the two new assertions.
+- 5/5 flake check on the named `outer_tests::udp_checksum_is_zero_on_ipv4_outer`.
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` — 30 packages, no regressions (Go side does not touch this code, so the gate is purely "we didn't break the build").
+- Smoke on `loss:xpf-userspace-fw0/fw1`:
+  - **Pass A — CoS disabled:** v4+v6 × push+reverse single-stream + 12-stream `-R` reproducer.
+  - **Pass B — CoS enabled:** 5201-5206 × v4+v6 × push+reverse (24 cells).
+  - Pass criterion: 0 retrans on saturated cells. WG dataplane is not actually wired up in this cluster (engine is library-only at master; integration PR ships separately), so smoke is really catching "we didn't break the AF_XDP boundary or the build pipeline". Reviewers should call this honestly — the smoke matrix here is gating *build + non-WG* dataplane correctness.
+
+## Out of scope (explicitly)
+
+- A1 (deterministic race-test gate) — separate follow-up.
+- A3 (tighten blanket `#[allow(dead_code)]`) — separate follow-up;
+  also depends on integration PR.
+- A4 (hot-path no-alloc instrumentation harness) — separate
+  follow-up.
+- B1-B4 (integration-PR items) — out of scope by tracker design.
+- IPv6 outer builder + UDP cs compute for v6 — no v6 outer exists.
+- `outer-udp-checksum compute|zero` config knob — integration PR.
+- Receive-side outer UDP cs verify — no such path exists.
+
+## Open questions for adversarial review
+
+1. **Is the perf framing honest?** The issue body claims ~20-30
+   cycles saved per packet, but the code already does cs=0 today.
+   PR-as-described is doc+test only with zero runtime delta. Does
+   the reviewer agree this is the right disposition (close A2 via
+   doc/test cleanup) vs. closing the tracker item as "already
+   shipped" with no PR? If the latter is preferred, PLAN-KILL is
+   the right call and I'll comment on the issue.
+2. **Stale TODO removal.** Is the TODO at lines 57-69 truly
+   stale, or is there a real wire-interop case in the test lab
+   today (e.g., a known midbox path) where cs=0 has been
+   observed to be dropped? If so, the TODO should stay (perhaps
+   restated) and the integration PR should still be expected to
+   add the knob. Quote the line of evidence either way.
+3. **Test placement.** Should the new byte-level cs=0 assertion
+   go in `outer.rs`'s own `outer_tests` module (smaller blast
+   radius, no integration dependency) or in
+   `afxdp/wg/tests.rs::outer_ipv4_*` (next to the existing
+   integration-level outer-header tests)? Both are valid; the
+   plan picks `outer.rs` because it doesn't drag in
+   `WgEngine`. Push back if you disagree.
+4. **Config knob: defer to integration vs. land now.** Plan
+   defers the `outer-udp-checksum compute|zero` knob. Reviewer
+   should confirm there is no real-world receiver in our test
+   lab (or known production target) that drops cs=0, otherwise
+   the knob may need to land in this PR. The default (`zero`)
+   matches today's behavior either way.
+5. **Documentation update reach.** Are there other docs (README,
+   protocol doc under `docs/`, engineering-style.md) that
+   reference outer UDP cs behavior and would now be stale?
+   Quick `grep` shows the only mention is the TODO inside
+   `outer.rs` itself, so no other docs need updating — confirm
+   this finding.
+6. **IPv6 forward-compat.** When the v6 outer builder ships,
+   it MUST compute UDP cs. The plan adds a forward-looking
+   comment but no compile-time guard. Should a `const _: () =
+   assert!(...)` or `#[deprecated]` marker be added now to
+   force the v6 author to confront the asymmetry? Plan says
+   no (comment is sufficient; the v6 author will write a v6
+   function and the v6 test suite will catch a missing cs);
+   reviewer may push back.
+7. **#1373 retirement coupling.** The eBPF dataplane is being
+   retired; does any retirement-phase doc reference outer UDP
+   cs behavior that this PR would now contradict? Plan says
+   no (eBPF dataplane has no WG outer; WG is userspace-only).

--- a/docs/pr/1501-a2-outer-udp-cs/plan.md
+++ b/docs/pr/1501-a2-outer-udp-cs/plan.md
@@ -12,8 +12,11 @@ unchanged.
 
 - **Antigravity (job adversarial-review-mpkq2awd-e66pif):**
   **PLAN-NEEDS-MINOR.** Confirmed RFC 768 / RFC 8200 accuracy, code
-  reality (outer.rs:103 writes 0; lines 57-69 hold the stale TODO),
-  caller analysis (test-only), receive-side analysis (try_decap
+  reality (the `hdr[26..28].copy_from_slice(&0u16.to_be_bytes())`
+  write at the end of `write_outer_ipv4_udp` writes 0; the doc
+  block immediately above holds the stale `TODO(#1499 r4 /
+  udp-checksum)`), caller analysis (test-only), receive-side
+  analysis (try_decap
   takes post-strip wg_record), and perf framing. Sole minor: the
   proposed `udp_checksum_is_zero_on_ipv4_outer` test would silently
   pass under regression because `let mut out = [0u8; 40]` is
@@ -79,19 +82,24 @@ follow-up:
 > `write_outer_ipv4_udp` plus 2 tests."
 
 The issue body is **wrong on a load-bearing fact**: the current
-code already emits `cs=0`. `userspace-dp/src/afxdp/wg/outer.rs:103`
-reads:
+code already emits `cs=0`. The bottom of `write_outer_ipv4_udp` in
+`userspace-dp/src/afxdp/wg/outer.rs` reads (writing zero into the
+UDP checksum field at bytes 26..27 of the emitted header):
 
 ```rust
 hdr[26..28].copy_from_slice(&0u16.to_be_bytes()); // checksum = 0
 ```
 
-What the file is internally inconsistent about:
+What the file is internally inconsistent about (at the pre-change
+HEAD of `master`, before this PR's edits — line numbers drifted
+once the doc comment was rewritten):
 
-- Lines 52-55: doc comment correctly explains we set UDP cs to 0
-  (RFC 768) and why — "UDP checksum offload semantics differ across
-  NICs and we want a known-baseline behavior".
-- Lines 57-69: a `TODO(#1499 r4 / udp-checksum)` block claims the
+- The inline doc comment immediately above the function correctly
+  explains we set UDP cs to 0 (RFC 768) and why — "UDP checksum
+  offload semantics differ across NICs and we want a
+  known-baseline behavior".
+- A `TODO(#1499 r4 / udp-checksum)` block immediately below that
+  comment claims the
   opposite — that the integration PR should compute the UDP
   checksum or delegate to offload, citing "kernel WG and
   wireguard-go emit a non-zero UDP checksum on IPv4".
@@ -137,14 +145,15 @@ emits `cs=0`. So the *runtime* perf delta of this PR is **zero**.
 
 The actual value is:
 
-- **Doc correctness.** Future contributors reading `outer.rs:57`
-  would see a TODO directing them to add UDP-checksum compute or
-  offload and might act on it, regressing the wire behavior we
-  intentionally have. The TODO is a landmine.
-- **Test coverage.** Today nothing asserts `cs==0` on the wire.
-  Anyone "fixing" the cs=0 to compute (the TODO's instruction)
-  would not trip any existing test. That's the silent-regression
-  surface this PR closes.
+- **Doc correctness.** Before this PR, the `TODO(#1499 r4 /
+  udp-checksum)` block on `write_outer_ipv4_udp` directed future
+  contributors to add UDP-checksum compute or NIC offload. Acting
+  on it would have regressed the wire behavior we intentionally
+  have. This PR removes the landmine.
+- **Test coverage.** Before this PR nothing asserts `cs==0` on the
+  wire. Anyone "fixing" the cs=0 to compute (the now-removed
+  TODO's instruction) would not have tripped any existing test.
+  That's the silent-regression surface this PR closes.
 - **#1501 close-out.** A2 is in the tracker; closing it via
   doc/test cleanup is the honest disposition since the code half
   already shipped.
@@ -157,8 +166,10 @@ with #1499 — this PR is documentation + a regression gate.
 
 ## What's already shipped / partially batched
 
-- #1499 merged with `write_outer_ipv4_udp` writing `cs=0` at
-  line 103. Both the inline comment at 52-55 (correct) and the
+- #1499 merged with `write_outer_ipv4_udp` writing `cs=0` (the
+  `hdr[26..28].copy_from_slice(&0u16.to_be_bytes())` statement at
+  the end of the function). Both the inline cs=0 doc comment
+  (correct) and the
   TODO at 57-69 (now stale) landed together.
 - IPv6 outer is not implemented at all — only IPv4 outer is
   supported in #1499 scope. RFC 8200 §8.1 (non-zero UDP cs
@@ -380,7 +391,8 @@ within `userspace-dp/src/afxdp/wg/`.
    doc/test cleanup) vs. closing the tracker item as "already
    shipped" with no PR? If the latter is preferred, PLAN-KILL is
    the right call and I'll comment on the issue.
-2. **Stale TODO removal.** Is the TODO at lines 57-69 truly
+2. **Stale TODO removal.** Is the `TODO(#1499 r4 /
+   udp-checksum)` block on `write_outer_ipv4_udp` truly
    stale, or is there a real wire-interop case in the test lab
    today (e.g., a known midbox path) where cs=0 has been
    observed to be dropped? If so, the TODO should stay (perhaps

--- a/docs/pr/1501-a2-outer-udp-cs/plan.md
+++ b/docs/pr/1501-a2-outer-udp-cs/plan.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-DRAFT v2 — Antigravity PLAN-NEEDS-MINOR addressed (sentinel buffer
-pre-fill so the regression gate proves the function *wrote* cs=0
-rather than relying on zero-initialized memory). Codex plan review
-still pending.
+DRAFT v3 — Codex PLAN-NEEDS-MAJOR addressed (kernel WG claim was
+factually wrong + RFC wording tightened); Antigravity
+PLAN-NEEDS-MINOR addressed in v2 (sentinel buffer pre-fill). Both
+v3 changes are documentation-only — implementation surface area is
+unchanged.
 
 ## Round-1 plan-review verdicts
 
@@ -18,10 +19,48 @@ still pending.
   pass under regression because `let mut out = [0u8; 40]` is
   already zero. Required correction: pre-fill the buffer with
   non-zero sentinel bytes (e.g. `0xff`) so the assertion proves
-  the function actively wrote zero. v2 applies this discipline to
-  both the new test and the strengthened `ipv4_checksum_is_correct`
-  test.
-- **Codex:** pending.
+  the function actively wrote zero. v2 applied this discipline.
+- **Codex (job task-mpkq4ty9-0sn4c0):** **PLAN-NEEDS-MAJOR.**
+  Material finding: the v1/v2 proposed doc comment claims "kernel
+  WireGuard emits cs=0 on outer IPv4 — we match that". This is
+  **factually wrong**. Linux kernel WireGuard's IPv4 send path
+  calls `udp_tunnel_xmit_skb(..., nocheck: false)` and socket
+  init sets `port4.use_udp_checksums = true`; the kernel
+  *computes* the UDP checksum on outer IPv4. The issue body
+  (#1501 A2 paragraph 2) is the source of this claim and is
+  itself wrong on the kernel-WG behavior. Baking the false
+  claim into our doc would mislead future readers.
+
+  Secondary findings:
+  1. RFC 768 has no real section titled "UDP CHECKSUM IS NULL"
+     — that's an informal header in the spec body. Cite "the
+     checksum field semantics" / "all-zero checksum signals
+     no-checksum" instead of a fictitious section number.
+  2. RFC 8200 §8.1 has a tunnel-mode exception path (RFC 6935 /
+     6936) so "forbids cs=0" is too absolute. The v6 builder
+     should compute a checksum unless a separate
+     RFC6936-style zero-checksum tunnel design is explicitly
+     approved.
+
+  Codex confirmed all other A-G checks (code reality, callers,
+  try_decap, perf framing, no-KILL). PLAN-READY pending the
+  wording fixes.
+
+## v3 corrections vs v2
+
+1. Replace "matches kernel WireGuard" with the honest framing:
+   IPv4 cs=0 is RFC-legal, this engine *intentionally* defaults
+   to it, this *differs* from kernel WG / wireguard-go / typical
+   UDP stacks, and a midbox-compat config knob is the integration
+   PR's escape valve. The cs=0 choice trades cycles for a known
+   wire-interop risk that the integration layer can manage.
+2. Drop the fake RFC 768 section title; cite "RFC 768, UDP
+   checksum field semantics — an all-zero transmitted checksum
+   signals that no checksum was computed."
+3. Soften RFC 8200 wording: "RFC 8200 §8.1 requires a non-zero
+   UDP checksum on IPv6 by default; the RFC 6935 / 6936
+   zero-checksum tunnel exception requires an explicit deployment
+   design and is out of scope for this engine."
 
 ## Issue framing
 
@@ -57,11 +96,26 @@ What the file is internally inconsistent about:
   checksum or delegate to offload, citing "kernel WG and
   wireguard-go emit a non-zero UDP checksum on IPv4".
 
-The TODO's premise is contradicted by RFC 768 (cs=0 is legal IPv4
-UDP) AND by the issue body's own assertion that "kernel WG does
-[cs=0] for outer-IPv4 traffic" (#1501 A2 body, paragraph 2). The
-TODO is stale guidance left over from the #1499 r4 review
-discussion that subsequently resolved in favor of emitting cs=0.
+Reality check (per Codex plan-review v1):
+
+- **The TODO's kernel/wireguard-go claim is factually
+  correct.** Linux kernel WireGuard's IPv4 send path calls
+  `udp_tunnel_xmit_skb(..., nocheck: false)` with
+  `port4.use_udp_checksums = true`. Wireguard-go likewise
+  computes the outer UDP checksum.
+- **The issue body's claim that "kernel WG does [cs=0] for
+  outer-IPv4 traffic" (#1501 A2 body, paragraph 2) is
+  factually wrong** about kernel WG behavior. RFC 768 still
+  *permits* cs=0; the kernel just chooses not to use that
+  permission.
+- The contradiction in `outer.rs` is therefore not "TODO is
+  stale" but "doc and TODO encode two different design
+  positions, both internally consistent". The chosen runtime
+  behavior (cs=0) is intentional, RFC-legal, and *different*
+  from kernel WG / wireguard-go. The doc needs to say so
+  honestly: we are not "matching kernel WG"; we are diverging
+  for a per-packet cycle win, accepting a known midbox risk
+  the integration layer can manage.
 
 **Therefore the real A2 work is:**
 
@@ -124,13 +178,27 @@ Replace the 23-line comment block at lines 47-69 with a tighter,
 non-contradictory doc comment. The function body is unchanged
 (it already sets cs=0). The new comment explains:
 
-1. RFC 768 §"UDP CHECKSUM IS NULL" allows IPv4 UDP cs=0.
-2. Kernel WireGuard emits cs=0 on outer IPv4 — we match that.
-3. RFC 8200 §8.1 forbids cs=0 on IPv6 UDP; the v6 outer
-   builder (when it ships, separate follow-up) must NOT take
-   the same shortcut.
-4. The IPv4 header checksum (mandatory) is computed; the UDP
-   checksum (optional on IPv4) is zero.
+1. RFC 768 UDP checksum field semantics — an all-zero
+   transmitted checksum signals "no checksum computed";
+   this is legal for IPv4 UDP.
+2. This engine *intentionally* defaults to cs=0 on outer
+   IPv4 to save the per-packet pseudo-header + payload sum.
+   **This differs from kernel WireGuard and wireguard-go**,
+   both of which compute the outer UDP checksum on IPv4
+   (kernel WG: `udp_tunnel_xmit_skb(..., nocheck: false)`
+   with `port4.use_udp_checksums = true`).
+3. RFC 8200 §8.1 requires a non-zero UDP checksum on IPv6 by
+   default; the RFC 6935 / 6936 zero-checksum tunnel
+   exception requires an explicit deployment design and is
+   out of scope for this engine. The future v6 outer builder
+   MUST compute the UDP checksum.
+4. The IPv4 header checksum (mandatory per RFC 791) is
+   computed; the UDP checksum (optional on IPv4 per RFC 768)
+   is zero.
+5. Wire-interop risk: some commercial midboxes drop UDPv4
+   with cs=0. The integration layer can surface an
+   `outer-udp-checksum compute|zero` config knob — out of
+   scope for this engine-side PR.
 
 Proposed replacement comment:
 
@@ -140,19 +208,31 @@ Proposed replacement comment:
 /// `payload_len` is the length of the WG transport record
 /// (header + ciphertext + tag) that follows the UDP header.
 ///
-/// IPv4 header checksum: mandatory — computed here over the
-/// IPv4 header only.
+/// IPv4 header checksum: mandatory per RFC 791 — computed
+/// here over the IPv4 header only.
 ///
-/// UDP checksum: emitted as 0 ("not computed") per RFC 768
-/// §"UDP CHECKSUM IS NULL". This matches kernel WireGuard's
-/// behavior for outer-IPv4 traffic and saves the per-packet
-/// pseudo-header + payload sum. RFC 8200 §8.1 requires a
-/// non-zero UDP checksum on IPv6 — when the v6 outer builder
-/// ships it MUST compute the UDP checksum (cannot take this
-/// shortcut). Some commercial midboxes drop UDPv4 with cs=0;
-/// if a deployment encounters one, the integration layer can
+/// UDP checksum: emitted as 0 ("no checksum computed"),
+/// which RFC 768 permits for IPv4 UDP via the checksum
+/// field semantics ("an all-zero transmitted checksum value
+/// means that the transmitter generated no checksum").
+///
+/// This engine intentionally defaults to cs=0 to save the
+/// per-packet pseudo-header + payload sum. NOTE: this
+/// differs from kernel WireGuard and wireguard-go — both of
+/// those compute the outer UDP checksum on IPv4 (kernel WG
+/// uses `udp_tunnel_xmit_skb(..., nocheck: false)` with
+/// `use_udp_checksums = true`). Some commercial midboxes
+/// have been reported to drop UDPv4 datagrams with cs=0; if
+/// a deployment encounters one, the integration layer can
 /// surface an `outer-udp-checksum compute|zero` config knob
-/// — out of scope for this engine-side PR.
+/// (out of scope for this engine-side PR).
+///
+/// IPv6 outer (not yet implemented): RFC 8200 §8.1 requires
+/// a non-zero UDP checksum on IPv6 by default. The RFC 6935
+/// / 6936 zero-checksum tunnel exception requires an
+/// explicit deployment design and is out of scope. The
+/// future v6 outer builder MUST compute the UDP checksum
+/// and MUST NOT take the IPv4 shortcut.
 ```
 
 ### Test additions in the existing `outer_tests` mod

--- a/userspace-dp/src/afxdp/wg/outer.rs
+++ b/userspace-dp/src/afxdp/wg/outer.rs
@@ -227,10 +227,11 @@ mod outer_tests {
         assert_eq!(cs, 0, "header self-check failed (cs={:#06x})", cs);
         // Wire-byte gate: UDP checksum field MUST be zero per
         // RFC 768 / this engine's intentional cs=0 default. If a
-        // future commit deletes the cs=0 write at line ~103 of
-        // this file, this assertion fails. The 0xff pre-fill
-        // ensures the assertion proves the function *wrote* zero,
-        // not that the buffer was already zero-initialized.
+        // future commit deletes the `hdr[26..28]` zero-checksum
+        // write in `write_outer_ipv4_udp`, this assertion fails.
+        // The 0xff pre-fill ensures the assertion proves the
+        // function *wrote* zero, not that the buffer was already
+        // zero-initialized.
         assert_eq!(
             &out[26..28],
             &[0, 0],

--- a/userspace-dp/src/afxdp/wg/outer.rs
+++ b/userspace-dp/src/afxdp/wg/outer.rs
@@ -255,6 +255,15 @@ mod outer_tests {
         // zero-initialized field untouched. Without the sentinel
         // this assertion would silently pass if the cs=0 write
         // were removed.
+        //
+        // Layout contract assumed here: `write_outer_ipv4_udp`
+        // writes the outer IPv4 + UDP header starting at byte 0
+        // of `out` (NO preceding Ethernet header). With
+        // IP_HDR_LEN = 20 and UDP cs at UDP offset 6, the wire
+        // byte position of the UDP checksum is 20 + 6 = 26..28.
+        // If a future refactor prepends an Ethernet prefix to
+        // the same buffer, this assertion needs to shift to
+        // 40..42 (14-byte Ethernet) or 44..46 (18-byte 802.1Q).
         let mut out = [0xffu8; 40];
         let n = write_outer_ipv4_udp(
             &mut out,
@@ -267,7 +276,10 @@ mod outer_tests {
             100,
         )
         .unwrap();
-        assert_eq!(n, 28);
+        // The return value is the number of bytes written:
+        // IP_HDR_LEN + UDP_HDR_LEN = 28. This pins the layout
+        // contract for the assertion below.
+        assert_eq!(n, 28, "write_outer_ipv4_udp must write IP+UDP = 28 bytes");
         assert_eq!(
             &out[26..28],
             &[0, 0],

--- a/userspace-dp/src/afxdp/wg/outer.rs
+++ b/userspace-dp/src/afxdp/wg/outer.rs
@@ -49,24 +49,34 @@ pub(crate) fn write_outer_eth(
 /// `payload_len` is the length of the WG transport record
 /// (header + ciphertext + tag) that follows the UDP header.
 ///
-/// The IPv4 checksum is computed over the IPv4 header only;
-/// per RFC 768 the UDP checksum on IPv4 is optional. We set it to
-/// zero (skip) for now — UDP checksum offload semantics differ
-/// across NICs and we want a known-baseline behavior.
+/// IPv4 header checksum: mandatory per RFC 791 — computed here over
+/// the IPv4 header only.
 ///
-/// TODO(#1499 r4 / udp-checksum): kernel WG and wireguard-go emit a
-/// non-zero UDP checksum on IPv4. Some commercial firewalls and
-/// midboxes silently drop UDPv4 with cs=0. The integration PR
-/// should:
-///   - Either compute the UDP checksum here (pseudo-header + UDP
-///     header + payload — ones-complement sum, like the IP checksum
-///     above), or
-///   - Delegate to a NIC TX checksum-offload flag in the AF_XDP
-///     descriptor and surface the option through `outer_l2_len` /
-///     metadata.
-/// This is the only outer-header gap that affects wire interop with
-/// commercial midboxes; tracked separately from the engine-correctness
-/// fixes in this PR.
+/// UDP checksum: emitted as 0 ("no checksum computed"), which RFC 768
+/// permits for IPv4 UDP via the checksum field semantics — an
+/// all-zero transmitted checksum signals that the transmitter
+/// generated no checksum.
+///
+/// This engine intentionally defaults to cs=0 on outer IPv4 to save
+/// the per-packet pseudo-header + payload sum. NOTE: this differs
+/// from kernel WireGuard and wireguard-go — both of those compute
+/// the outer UDP checksum on IPv4 (kernel WG uses
+/// `udp_tunnel_xmit_skb(..., nocheck: false)` with
+/// `port4.use_udp_checksums = true` in `drivers/net/wireguard/socket.c`).
+/// We accept the divergence: RFC 768 makes it legal, the cycle win
+/// is material at line rate, and the inner WG ciphertext is already
+/// AEAD-authenticated so the outer UDP checksum carries no
+/// integrity value over the inner construction. Some commercial
+/// midboxes have been reported to drop UDPv4 datagrams with cs=0; if
+/// a deployment encounters one, the integration layer can surface an
+/// `outer-udp-checksum compute|zero` config knob — out of scope for
+/// this engine-side code. See #1501 A2.
+///
+/// IPv6 outer (not yet implemented): RFC 8200 §8.1 requires a
+/// non-zero UDP checksum on IPv6 by default. The RFC 6935 / 6936
+/// zero-checksum tunnel exception requires an explicit deployment
+/// design and is out of scope. The future v6 outer builder MUST
+/// compute the UDP checksum and MUST NOT take the IPv4 shortcut.
 pub(crate) fn write_outer_ipv4_udp(
     out: &mut [u8],
     src: Ipv4Addr,
@@ -195,8 +205,13 @@ mod outer_tests {
         // Round-trip: the checksum field is set such that a fresh
         // checksum over the full header (with the checksum present)
         // is zero. This is the standard self-check for an IPv4
-        // header's correctness.
-        let mut out = [0u8; 28];
+        // header's correctness. Buffer is pre-filled with a non-zero
+        // sentinel so the assertion proves the function actively
+        // wrote the header bytes rather than left them zero-init.
+        // The UDP checksum field assertion below is the
+        // load-bearing regression gate — see
+        // `udp_checksum_is_zero_on_ipv4_outer` for rationale.
+        let mut out = [0xffu8; 28];
         write_outer_ipv4_udp(
             &mut out,
             Ipv4Addr::new(192, 0, 2, 1),
@@ -210,6 +225,53 @@ mod outer_tests {
         .unwrap();
         let cs = checksum_be(&out[..20]);
         assert_eq!(cs, 0, "header self-check failed (cs={:#06x})", cs);
+        // Wire-byte gate: UDP checksum field MUST be zero per
+        // RFC 768 / this engine's intentional cs=0 default. If a
+        // future commit deletes the cs=0 write at line ~103 of
+        // this file, this assertion fails. The 0xff pre-fill
+        // ensures the assertion proves the function *wrote* zero,
+        // not that the buffer was already zero-initialized.
+        assert_eq!(
+            &out[26..28],
+            &[0, 0],
+            "outer UDP checksum must be 0 (RFC 768; #1501 A2)"
+        );
+    }
+
+    #[test]
+    fn udp_checksum_is_zero_on_ipv4_outer() {
+        // Dedicated regression gate for the cs=0 default
+        // (#1501 A2). This is the wire-byte invariant that future
+        // contributors must not silently regress when "fixing" the
+        // checksum behavior to match kernel WireGuard. If you are
+        // adding outer UDP checksum compute, please update both
+        // this test AND the doc comment on `write_outer_ipv4_udp`,
+        // and surface a config knob — do not just delete the
+        // assertion.
+        //
+        // 0xff sentinel pre-fill (not 0): proves the function
+        // ACTIVELY wrote two zero bytes rather than left a
+        // zero-initialized field untouched. Without the sentinel
+        // this assertion would silently pass if the cs=0 write
+        // were removed.
+        let mut out = [0xffu8; 40];
+        let n = write_outer_ipv4_udp(
+            &mut out,
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+            51820,
+            51820,
+            0,
+            64,
+            100,
+        )
+        .unwrap();
+        assert_eq!(n, 28);
+        assert_eq!(
+            &out[26..28],
+            &[0, 0],
+            "outer UDP checksum must be 0 (RFC 768; #1501 A2)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`userspace-dp/src/afxdp/wg/outer.rs::write_outer_ipv4_udp` already emits the outer IPv4 UDP checksum as 0 (line 103, shipped in #1499). The file carried two contradictory doc blocks above that line: a correct inline comment explaining cs=0 + RFC 768, and a 13-line stale TODO directing the integration PR to add UDP-checksum compute or NIC offload. This PR replaces the TODO with an honest RFC-grounded comment that admits the engine intentionally diverges from kernel WireGuard + wireguard-go (both of which DO compute the outer UDP cs on IPv4) for a per-packet cycle win, and adds a byte-level wire assertion so the cs=0 invariant cannot silently regress.

Runtime behavior is unchanged. Wire bytes are identical to master. This is strictly documentation + a regression gate.

## Why divergent framing (not "matches kernel WG")

Linux kernel WireGuard uses `udp_tunnel_xmit_skb(..., nocheck: false)` with `port4.use_udp_checksums = true` in `drivers/net/wireguard/socket.c` — the kernel computes the outer UDP cs on IPv4. The #1501 A2 issue body claim that "kernel WG does cs=0 for outer-IPv4 traffic" is factually wrong about kernel WG behavior. RFC 768 permits the choice; this engine takes it intentionally, accepting the known midbox-compat risk the integration layer can manage via an `outer-udp-checksum compute|zero` knob.

The inner WG ciphertext is already AEAD-authenticated, so the outer UDP checksum carries no integrity value over the inner construction.

## What changes

- **`userspace-dp/src/afxdp/wg/outer.rs`**:
  - Stale 13-line TODO at lines 57-69 → replaced with honest doc explaining the intentional divergence from kernel WG + the forward-warning for the future IPv6 outer builder (RFC 8200 §8.1 requires non-zero UDP cs by default; RFC 6935/6936 tunnel exception is out of scope).
  - New `udp_checksum_is_zero_on_ipv4_outer` test asserts `out[26..28] == [0, 0]` with `[0xffu8; 40]` sentinel pre-fill — load-bearing so the assertion proves the function actively wrote zero rather than left the buffer zero-initialized.
  - `ipv4_checksum_is_correct` test strengthened: buffer init `[0u8; 28]` → `[0xffu8; 28]`, plus the same UDP-cs assertion alongside the IPv4-header self-check.
- **`_Log.md`**: action entry.

## Plan + adversarial review

Plan doc: `docs/pr/1501-a2-outer-udp-cs/plan.md` (DRAFT v3).

- **Codex round-1** (task-mpkq4ty9-0sn4c0): **PLAN-NEEDS-MAJOR.** Flagged the factually-wrong "matches kernel WG" wording, the fake RFC 768 section title, and the too-absolute RFC 8200 §8.1 wording.
- **Antigravity round-1** (adversarial-review-mpkq2awd-e66pif): **PLAN-NEEDS-MINOR.** Required 0xff sentinel buffer pre-fill so the regression gate proves the function wrote zero rather than relied on zero-init.
- **Codex round-2** (task-mpkqfv45-s6g4mw): **PLAN-READY.**
- **Antigravity round-2** (adversarial-review-mpkqg5b8-svu7uz): **PLAN-READY.** Independently verified `.use_udp_checksums = true` in `drivers/net/wireguard/socket.c`.

## Test plan

- [x] cargo build --release: clean.
- [x] cargo test --release for `afxdp::wg::outer`: 6/6 pass.
- [x] 5×5 flake check on new outer tests: 5/5 pass each run.
- [x] Full cargo suite: 1417 passed, modulo 2 PRE-EXISTING flaky tests on `origin/master da103d81` baseline:
  - `snat_contract_documents_current_fail_closed_runtime` — fails on master too (Antigravity flagged in round-1).
  - `afxdp::wg::engine::engine_internal_tests::reconcile_peers_snapshot_is_atomic_under_concurrent_load` — 1-in-5 load-related flake on master too.
  - Neither is caused by this PR (comment + test-only change cannot affect engine concurrency or SNAT docs).
- [x] Go suite (`go test ./...`): clean.
- [x] Deploy on loss userspace cluster (`xpf-userspace-fw0/fw1`).
- [x] **Pass A — CoS disabled** (best-effort fast path):
  - v4 push: 8.33 Gb/s, 0 retrans (172.16.80.200)
  - v4 reverse (-R): 7.31 Gb/s, 0 retrans
  - v6 push: 8.97 Gb/s, 0 retrans (2001:559:8585:80::200)
  - v6 reverse (-R): 9.06 Gb/s, 0 retrans
  - v4 -P 12 -R: **23.1 Gb/s, 0 retrans** (line rate at this lab's ceiling)
  - v6 -P 12 -R: **22.9 Gb/s, 0 retrans**
- [x] **Pass B — CoS enabled** (per-class shaper):
  - 24 per-class measurements (5201 iperf-a 100M, 5202 iperf-b 1G, 5203 iperf-c 3G, 5204 iperf-d 6G, 5205 iperf-e 9G, 5206 iperf-f 12G × v4+v6 × push+rev).
  - Shaped push cells hit configured rate cleanly: 83Mb/844Mb/2.5G/4.9G/6G/6.6G.
  - All cells 0 retr except iperf-b reverse (109 v4 / 218 v6) — unrelated to this comment-only change.

The smoke matrix is gating the AF_XDP boundary + build pipeline (the WG engine is library-only at master — integration ships separately), not WG-specific wire behavior.

## Out of scope

- A1 (race-test gate), A3 (allow-dead-code audit), A4 (alloc instrumentation harness) from #1501 — separate follow-ups.
- B1-B4 — integration PR.
- IPv6 outer builder + the `outer-udp-checksum compute|zero` config knob — integration PR.

Closes #1501 item A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)