### PR TITLE
docs: retire DPDK dataplane recommendations (#1531)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56,7 +56,7 @@
     retirement notices pointing at #1525.
   - **File(s)**: `docs/pr/1531-dpdk-docs-retire/plan.md`
 
-## 2026-05-24 (prior)
+## 2026-05-25
 
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,15 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T00:00:00Z
+  - **Action**: PR #1531 plan v1 drafted. Retire DPDK
+    recommendations in `docs/dataplane-decision-dpdk-vs-vpp.md`
+    and `docs/dpdk-dataplane.md`; rewrite both as short
+    retirement notices pointing at #1525.
+  - **File(s)**: `docs/pr/1531-dpdk-docs-retire/plan.md`
+
+## 2026-05-24 (prior)
+
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested

--- a/_Log.md
+++ b/_Log.md
@@ -20,11 +20,12 @@
     been superseded by #1525.
   - **File(s)**: `docs/dataplane-decision-dpdk-vs-vpp.md`,
     `docs/dpdk-dataplane.md`, `_Log.md`
-  - **Validation**: pure-docs + log scope — `git diff --stat
-    origin/master..HEAD` touches only `docs/` paths and the root
-    `_Log.md` action log. No source files, build inputs, or test
-    fixtures modified, so smoke is intentionally skipped per
-    pure-docs PR discipline.
+  - **Validation**: docs + log + userspace-dp README scope —
+    `git diff --stat origin/master..HEAD` touches `docs/` paths,
+    the root `_Log.md` action log, and `userspace-dp/README.md`
+    (the README wording fix is the only file outside `docs/`).
+    No `.go` / `.rs` / `.c` source, no build inputs, no test
+    fixtures modified.
 
 - **Timestamp**: 2026-05-24T06:35:00Z
   - **Action**: PR #1531 implementation v2 — applied retirement

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,28 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T (PR #1534 Copilot nit pass)
+  - **Action**: Addressed Copilot's 4 nits on PR #1534 (DPDK
+    operator docs retirement, #1531). Harmonized retirement banners
+    in `docs/dataplane-decision-dpdk-vs-vpp.md` and
+    `docs/dpdk-dataplane.md` from "is being retired" to "is retired"
+    so banners and Current State sections agree. Converted bare
+    code span ``` `docs/vpp-dataplane-assessment.md` ``` to a
+    proper markdown link in the Related Documents section.
+    Tightened the "underlay-NIC XSK" wording in the encrypted
+    tunnel revisit trigger to "userspace-dp's AF_XDP socket on
+    the physical NIC cannot see inner payloads of kernel-managed
+    tunnels", which avoids conflating the NIC XDP hook with the
+    AF_XDP socket. Folded the awkward "The previous header read:"
+    preamble in `docs/dpdk-dataplane.md` into a single narrative
+    paragraph describing the prior #1475 policy and noting it has
+    been superseded by #1525.
+  - **File(s)**: `docs/dataplane-decision-dpdk-vs-vpp.md`,
+    `docs/dpdk-dataplane.md`, `_Log.md`
+  - **Validation**: docs-only diff — `git diff --stat
+    origin/master..HEAD` touches only docs paths. No source files
+    modified.
+
 - **Timestamp**: 2026-05-24T06:35:00Z
   - **Action**: PR #1531 implementation v2 — applied retirement
     banner + Current State + reframed VPP revisit trigger +

--- a/_Log.md
+++ b/_Log.md
@@ -1,6 +1,6 @@
 # Action Log
 
-## 2026-05-24
+## 2026-05-25
 
 - **Timestamp**: 2026-05-25T05:30:00Z
   - **Action**: Addressed Copilot's 4 nits on PR #1534 (DPDK
@@ -26,6 +26,8 @@
     (the README wording fix is the only file outside `docs/`).
     No `.go` / `.rs` / `.c` source, no build inputs, no test
     fixtures modified.
+
+## 2026-05-24
 
 - **Timestamp**: 2026-05-24T06:35:00Z
   - **Action**: PR #1531 implementation v2 — applied retirement

--- a/_Log.md
+++ b/_Log.md
@@ -8,7 +8,7 @@
     in `docs/dataplane-decision-dpdk-vs-vpp.md` and
     `docs/dpdk-dataplane.md` from "is being retired" to "is retired"
     so banners and Current State sections agree. Converted bare
-    code span ``` `docs/vpp-dataplane-assessment.md` ``` to a
+    code span around `docs/vpp-dataplane-assessment.md` to a
     proper markdown link in the Related Documents section.
     Tightened the "underlay-NIC XSK" wording in the encrypted
     tunnel revisit trigger to "userspace-dp's AF_XDP socket on

--- a/_Log.md
+++ b/_Log.md
@@ -61,7 +61,7 @@
     retirement notices pointing at #1525.
   - **File(s)**: `docs/pr/1531-dpdk-docs-retire/plan.md`
 
-## 2026-05-25
+## 2026-05-25 (earlier — prior PR follow-ups)
 
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional

--- a/_Log.md
+++ b/_Log.md
@@ -2,7 +2,7 @@
 
 ## 2026-05-24
 
-- **Timestamp**: 2026-05-24T (PR #1534 Copilot nit pass)
+- **Timestamp**: 2026-05-25T05:30:00Z
   - **Action**: Addressed Copilot's 4 nits on PR #1534 (DPDK
     operator docs retirement, #1531). Harmonized retirement banners
     in `docs/dataplane-decision-dpdk-vs-vpp.md` and
@@ -20,9 +20,11 @@
     been superseded by #1525.
   - **File(s)**: `docs/dataplane-decision-dpdk-vs-vpp.md`,
     `docs/dpdk-dataplane.md`, `_Log.md`
-  - **Validation**: docs-only diff — `git diff --stat
-    origin/master..HEAD` touches only docs paths. No source files
-    modified.
+  - **Validation**: pure-docs + log scope — `git diff --stat
+    origin/master..HEAD` touches only `docs/` paths and the root
+    `_Log.md` action log. No source files, build inputs, or test
+    fixtures modified, so smoke is intentionally skipped per
+    pure-docs PR discipline.
 
 - **Timestamp**: 2026-05-24T06:35:00Z
   - **Action**: PR #1531 implementation v2 — applied retirement

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,31 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T06:35:00Z
+  - **Action**: PR #1531 implementation v2 — applied retirement
+    banner + Current State + reframed VPP revisit trigger +
+    [Retired] Historical block to both
+    `docs/dataplane-decision-dpdk-vs-vpp.md` and
+    `docs/dpdk-dataplane.md`; updated
+    `docs/vpp-dataplane-assessment.md` inbound-pointer header to
+    note DPDK / decision doc retirement and explicitly preserve
+    "still useful" architectural threads (encrypted-tunnel
+    reasoning + native Go VRRP decision). Then addressed Codex
+    plan-review v2 findings: (a) sharpened the VPP revisit
+    trigger in the decision doc to specify "physical NIC XDP /
+    AF_XDP hook sees only outer encrypted packets when kernel
+    WireGuard/XFRM performs crypto" plus post-crypto interface
+    hook options; (b) updated `userspace-dp/README.md` "still
+    selected ... until later cutover" wording to reflect that
+    `EffectiveType` now defaults to userspace today.
+    Historical sections kept verbatim under bold-block retired
+    banners with all original H2 headings demoted to H3 inside
+    the retired wrapper.
+  - **File(s)**: `docs/dataplane-decision-dpdk-vs-vpp.md`,
+    `docs/dpdk-dataplane.md`,
+    `docs/vpp-dataplane-assessment.md`,
+    `userspace-dp/README.md`
+
 - **Timestamp**: 2026-05-24T00:00:00Z
   - **Action**: PR #1531 plan v1 drafted. Retire DPDK
     recommendations in `docs/dataplane-decision-dpdk-vs-vpp.md`

--- a/docs/dataplane-decision-dpdk-vs-vpp.md
+++ b/docs/dataplane-decision-dpdk-vs-vpp.md
@@ -1,10 +1,73 @@
 # Dataplane Decision: DPDK vs VPP
 
+> **Status: Retired.** The DPDK dataplane is being retired under
+> umbrella issue #1525. The userspace AF_XDP dataplane
+> (`userspace-dp/`) is the primary/default backend. Migrate with
+> `set system dataplane-type userspace`, or simply omit
+> `system dataplane-type` (userspace is the default). See
+> [`userspace-dp/README.md`](../userspace-dp/README.md) for the
+> active design.
+
+## Current State (2026-05)
+
+- DPDK is retired under #1525. There is no in-tree dataplane
+  competition between DPDK and VPP today; the userspace AF_XDP
+  dataplane (`userspace-dp/`) is the primary/default backend, and
+  the legacy eBPF dataplane is being retired in parallel under
+  #1373.
+- The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
+  remains in-tree until Phase 3 of #1525 deletes it. Commit-time
+  rejection of `set system dataplane-type dpdk` lands in Phase 1
+  (#1526). Builds with `-tags dpdk` are not supported for
+  production.
+- VPP was never implemented in xpf. There is no current plan to
+  add a VPP backend. If one becomes interesting in the future, a
+  fresh decision document will be filed at that time; the section
+  below captures the trigger we would use to make that call.
+
+## Revisit Trigger for VPP
+
+Re-open VPP assessment if all are true:
+
+- Encrypted tunnel (IPsec / WireGuard) throughput becomes a
+  primary product driver. The physical NIC XDP / AF_XDP hook
+  sees only the outer encrypted packets when kernel
+  WireGuard/XFRM performs crypto, so the underlay-NIC XSK cannot
+  inspect inner payloads of kernel-managed IPsec or WireGuard
+  tunnels directly. xpf can still hook decrypted traffic via TC
+  BPF on the post-crypto interface (e.g. `wgN` or an XFRM
+  interface), or via XDP on a veth on the decrypted side, but
+  both add per-packet cost relative to VPP's userspace-crypto
+  pipeline. VPP terminates crypto in userspace and avoids the
+  underlay/inner-packet split entirely.
+- Throughput goals materially exceed what the userspace AF_XDP
+  backend can deliver on target hardware.
+- Team is willing to own VPP integration and long-term plugin /
+  API maintenance.
+
+## Related (Active) Documents
+
+- Active userspace dataplane design:
+  [`userspace-dp/README.md`](../userspace-dp/README.md).
+- Retirement umbrella: #1525.
+- VPP architectural reference (kept as historical analysis, not
+  current direction): `docs/vpp-dataplane-assessment.md`.
+
+---
+
+## [Retired] Historical Decision
+
+> **Retired** — preserved for reference only. The text below was
+> the active decision as of 2026-03-02 when DPDK was a live
+> in-tree backend candidate. It does NOT reflect current
+> direction. The DPDK dataplane is retired under #1525; see the
+> banner at the top of this file for the active path.
+
 Date: 2026-03-02
-Status: Active
+Status: Active (at the time)
 Scope: xpf dataplane strategy
 
-## Decision Summary
+### Decision Summary
 
 For this project today, **DPDK is the better next dataplane path than VPP**.
 
@@ -16,12 +79,12 @@ Why:
 When VPP could become better:
 - If product direction prioritizes very high-end encrypted throughput (especially IPsec/WireGuard) at 40/100G scale over short-term delivery and architectural continuity.
 
-## Current Repo Reality
+### Current Repo Reality
 
-### eBPF/XDP-TC path (primary)
+#### eBPF/XDP-TC path (primary)
 - Production path with broad feature coverage and HA behavior implemented around existing xpf design.
 
-### DPDK path (secondary backend, in-tree)
+#### DPDK path (secondary backend, in-tree)
 - Implemented worker pipeline in C (`parse -> filter -> screen -> zone -> conntrack -> policy -> nat -> nat64 -> forward`).
 - Go backend exists and is wired through `dataplane.DataPlane`.
 - DPDK worker builds cleanly with current tree.
@@ -35,11 +98,11 @@ Known DPDK gaps visible in code:
 - `pkg/dataplane/dpdk/fib.go`
   - ifindex -> DPDK `port_id` mapping still TODO
 
-### VPP path
+#### VPP path
 - No in-tree VPP dataplane implementation exists.
 - Existing assessment doc is extensive, but implementation would still start from zero in this repo.
 
-## What Matters Most for xpf
+### What Matters Most for xpf
 
 1. Preserve Junos-like behavior:
 - Zone-pair policy semantics, NAT behavior, screens, session model, CLI/runtime parity.
@@ -55,9 +118,9 @@ Known DPDK gaps visible in code:
 
 DPDK aligns better with these constraints than VPP right now.
 
-## Option Comparison
+### Option Comparison
 
-### Option A: Continue DPDK backend evolution (recommended)
+#### Option A: Continue DPDK backend evolution (recommended)
 
 Pros:
 - Reuses existing xpf pipeline model and compiler outputs.
@@ -73,7 +136,7 @@ Cons:
 Effort profile:
 - Incremental and bounded; most work is finishing known TODOs and behavior parity.
 
-### Option B: Build VPP backend now (not recommended now)
+#### Option B: Build VPP backend now (not recommended now)
 
 Pros:
 - Strong high-end packet processing and mature routing dataplane framework.
@@ -88,22 +151,22 @@ Cons:
 Effort profile:
 - Multi-phase rewrite/integration project with significant validation burden.
 
-## Recommendation
+### Recommendation
 
-### Primary recommendation
+#### Primary recommendation
 - **Invest in completing and hardening the DPDK backend first.**
 
-### Explicit non-recommendation (for now)
+#### Explicit non-recommendation (for now)
 - Do **not** start a full VPP dataplane migration now.
 
-### Revisit trigger for VPP
+#### Revisit trigger for VPP
 Re-open VPP if all are true:
 - DPDK backend is functionally complete/parity-acceptable.
 - Throughput goals materially exceed what eBPF+DPDK path can deliver on target hardware.
 - Encrypted tunnel throughput becomes a primary product driver.
 - Team is willing to own VPP integration and long-term plugin/API maintenance.
 
-## Execution Plan (DPDK-first)
+### Execution Plan (DPDK-first)
 
 1. Close known DPDK functional gaps:
 - Implement app range support
@@ -121,9 +184,11 @@ Re-open VPP if all are true:
 4. Only after 1-3:
 - Decide whether VPP is still needed for next performance envelope.
 
-## Related Docs
+### Related Docs (as written 2026-03-02; some are now retired)
 
-- DPDK architecture plan: `docs/dpdk-dataplane.md`
-- VPP assessment: `docs/vpp-dataplane-assessment.md`
-- Performance context: `docs/optimizations.md`
-- HA behavior context: `docs/active-active-new-connections.md`
+- DPDK architecture plan: `docs/dpdk-dataplane.md` (now retired —
+  see retirement banner at top of that file).
+- VPP assessment: `docs/vpp-dataplane-assessment.md` (kept as
+  historical analysis; not current direction).
+- Performance context: `docs/optimizations.md`.
+- HA behavior context: `docs/active-active-new-connections.md`.

--- a/docs/dataplane-decision-dpdk-vs-vpp.md
+++ b/docs/dataplane-decision-dpdk-vs-vpp.md
@@ -1,6 +1,6 @@
 # Dataplane Decision: DPDK vs VPP
 
-> **Status: Retired.** The DPDK dataplane is being retired under
+> **Status: Retired.** The DPDK dataplane is retired under
 > umbrella issue #1525. The userspace AF_XDP dataplane
 > (`userspace-dp/`) is the primary/default backend. Migrate with
 > `set system dataplane-type userspace`, or simply omit
@@ -30,16 +30,15 @@
 Re-open VPP assessment if all are true:
 
 - Encrypted tunnel (IPsec / WireGuard) throughput becomes a
-  primary product driver. The physical NIC XDP / AF_XDP hook
-  sees only the outer encrypted packets when kernel
-  WireGuard/XFRM performs crypto, so the underlay-NIC XSK cannot
-  inspect inner payloads of kernel-managed IPsec or WireGuard
-  tunnels directly. xpf can still hook decrypted traffic via TC
-  BPF on the post-crypto interface (e.g. `wgN` or an XFRM
-  interface), or via XDP on a veth on the decrypted side, but
-  both add per-packet cost relative to VPP's userspace-crypto
-  pipeline. VPP terminates crypto in userspace and avoids the
-  underlay/inner-packet split entirely.
+  primary product driver. When kernel WireGuard/XFRM performs
+  crypto, userspace-dp's AF_XDP socket on the physical NIC
+  cannot see inner payloads of kernel-managed tunnels — it only
+  observes the outer encrypted packets. xpf can still hook
+  decrypted traffic via TC BPF on the post-crypto interface
+  (e.g. `wgN` or an XFRM interface), or via XDP on a veth on
+  the decrypted side, but both add per-packet cost relative to
+  VPP's userspace-crypto pipeline. VPP terminates crypto in
+  userspace and avoids the underlay/inner-packet split entirely.
 - Throughput goals materially exceed what the userspace AF_XDP
   backend can deliver on target hardware.
 - Team is willing to own VPP integration and long-term plugin /
@@ -51,7 +50,7 @@ Re-open VPP assessment if all are true:
   [`userspace-dp/README.md`](../userspace-dp/README.md).
 - Retirement umbrella: #1525.
 - VPP architectural reference (kept as historical analysis, not
-  current direction): `docs/vpp-dataplane-assessment.md`.
+  current direction): [`vpp-dataplane-assessment.md`](vpp-dataplane-assessment.md).
 
 ---
 

--- a/docs/dataplane-decision-dpdk-vs-vpp.md
+++ b/docs/dataplane-decision-dpdk-vs-vpp.md
@@ -17,9 +17,9 @@
   #1373.
 - The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
   remains in-tree until Phase 3 of #1525 deletes it. Commit-time
-  rejection of `set system dataplane-type dpdk` lands in Phase 1
-  (#1526). Builds with `-tags dpdk` are not supported for
-  production.
+  rejection of `set system dataplane-type dpdk` is planned in
+  Phase 1 (#1526; not yet on master). Per #1525, builds with
+  `-tags dpdk` are not supported for production.
 - VPP was never implemented in xpf. There is no current plan to
   add a VPP backend. If one becomes interesting in the future, a
   fresh decision document will be filed at that time; the section

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -1,21 +1,64 @@
 # DPDK Dataplane for xpf — Architecture Plan
 
-Note: This is an architecture/planning document. For the current project-level
-decision and recommendation between DPDK and VPP, see
-`docs/dataplane-decision-dpdk-vs-vpp.md`.
+> **Status: Retired.** This document was an architecture plan for
+> a DPDK-based xpf dataplane. The DPDK dataplane is being retired
+> under umbrella issue #1525. The userspace AF_XDP dataplane
+> (`userspace-dp/`) is the primary/default backend. Migrate with
+> `set system dataplane-type userspace`, or simply omit
+> `system dataplane-type` (userspace is the default). See
+> [`userspace-dp/README.md`](../userspace-dp/README.md) for the
+> active design.
 
-Current #1475 policy: DPDK remains a separately supported backend for binaries
-built with `-tags dpdk`, but it is outside the #1373 eBPF source-removal path
-until it migrates off the root `dataplane.DataPlane` interface. The legacy
-bridge is confined to `pkg/dataplane/dpdk`, with only the blank registration
-import in `cmd/xpfd/main.go` outside that package. Non-DPDK builds reject DPDK
-startup explicitly instead of running a no-op stub.
+## Current State (2026-05)
 
-## Overview
+- DPDK is retired under #1525. The userspace AF_XDP dataplane
+  (`userspace-dp/`) is the primary/default backend, and the legacy
+  eBPF dataplane is being retired in parallel under #1373.
+- The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
+  remains in-tree until Phase 3 of #1525 deletes it. Builds with
+  `-tags dpdk` are not supported for production.
+- Commit-time rejection of `set system dataplane-type dpdk` lands
+  in Phase 1 (#1526). Operators should migrate with
+  `set system dataplane-type userspace`, or simply omit
+  `system dataplane-type` entirely (userspace is the default).
+- For the project-level retirement context, see
+  [`docs/dataplane-decision-dpdk-vs-vpp.md`](dataplane-decision-dpdk-vs-vpp.md)
+  (also carrying a retirement banner).
+
+The architecture material below is preserved verbatim for
+reference only — it describes a code path that is being removed
+and does not reflect current direction.
+
+---
+
+## [Retired] Historical Design Details
+
+> **Retired** — preserved for reference only. The text below was
+> the active architecture plan when DPDK was a live in-tree
+> backend candidate. It does NOT reflect current direction. The
+> DPDK dataplane is retired under #1525; see the banner at the
+> top of this file for the active path.
+
+The previous header read:
+
+> Note: This is an architecture/planning document. For the current
+> project-level decision and recommendation between DPDK and VPP,
+> see `docs/dataplane-decision-dpdk-vs-vpp.md`.
+>
+> Current #1475 policy: DPDK remains a separately supported
+> backend for binaries built with `-tags dpdk`, but it is outside
+> the #1373 eBPF source-removal path until it migrates off the
+> root `dataplane.DataPlane` interface. The legacy bridge is
+> confined to `pkg/dataplane/dpdk`, with only the blank
+> registration import in `cmd/xpfd/main.go` outside that package.
+> Non-DPDK builds reject DPDK startup explicitly instead of
+> running a no-op stub.
+
+### Overview
 
 Add a DPDK-based dataplane as an alternative to the current XDP/TC eBPF pipeline. The existing `pkg/dataplane.Manager` API is already well-abstracted — the daemon, CLI, gRPC, config system, and all subsystems interact through this interface, not through BPF-specific code. A DPDK implementation would swap the packet processing engine while keeping everything else unchanged.
 
-## Why DPDK?
+### Why DPDK?
 
 | | XDP/TC (current) | DPDK (proposed) |
 |---|---|---|
@@ -30,9 +73,9 @@ Add a DPDK-based dataplane as an alternative to the current XDP/TC eBPF pipeline
 
 **Target use case:** High-throughput deployments (40G/100G NICs) where dedicating CPU cores to packet processing is acceptable. An interrupt-driven mode is also available for power-sensitive deployments.
 
-## Architecture
+### Architecture
 
-### Current Architecture (XDP/TC)
+#### Current Architecture (XDP/TC)
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -67,7 +110,7 @@ Add a DPDK-based dataplane as an alternative to the current XDP/TC eBPF pipeline
     └─────────────────────────────────┘
 ```
 
-### Proposed Architecture (DPDK)
+#### Proposed Architecture (DPDK)
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -106,9 +149,9 @@ Add a DPDK-based dataplane as an alternative to the current XDP/TC eBPF pipeline
                               └───────────┘
 ```
 
-## Implementation Plan
+### Implementation Plan
 
-### Phase 1: Define Manager Interface (Go)
+#### Phase 1: Define Manager Interface (Go)
 
 Extract an interface from the current concrete `Manager` struct. All existing callers already use it as a concrete type, so this is a refactoring step.
 
@@ -167,7 +210,7 @@ type DataPlane interface {
 
 **Estimated effort:** 1-2 days. Mechanical refactoring, no behavior change.
 
-### Phase 2: DPDK Worker Process (C)
+#### Phase 2: DPDK Worker Process (C)
 
 Write the DPDK packet processing pipeline in C (or Rust). This replicates the 14 BPF programs as userspace functions.
 
@@ -267,7 +310,7 @@ drop:
 
 **Estimated effort:** 3-4 weeks. This is the bulk of the work — replicating all packet processing logic.
 
-### Phase 3: Go ↔ DPDK Communication
+#### Phase 3: Go ↔ DPDK Communication
 
 The Go control plane needs to update DPDK data structures (zones, policies, sessions) and read counters/sessions back.
 
@@ -343,7 +386,7 @@ func (m *DPDKManager) SetZone(ifindex int, vlanID uint16, zoneID uint16, routing
 
 **Estimated effort:** 2-3 weeks. CGo wrappers for all map operations + shared memory setup.
 
-### Phase 4: Go DPDKManager Implementation
+#### Phase 4: Go DPDKManager Implementation
 
 Implement the `DataPlane` interface for DPDK.
 
@@ -401,7 +444,7 @@ func (m *DPDKManager) AttachXDP(ifindex int, forceGeneric bool) error {
 
 **Estimated effort:** 2 weeks. Most logic from compiler.go can be shared; only the "write to map" calls change.
 
-### Phase 5: Build System & Configuration
+#### Phase 5: Build System & Configuration
 
 ```go
 // cmd/xpfd/main.go
@@ -455,9 +498,9 @@ build-ebpf:
 
 **Estimated effort:** 1 week.
 
-## Data Structure Replication Details
+### Data Structure Replication Details
 
-### Session Table
+#### Session Table
 
 BPF: `HASH` with `SessionKey` → `SessionValue` (40 + 120 bytes)
 
@@ -476,7 +519,7 @@ struct rte_hash_parameters session_params = {
 
 **Lock-free update:** DPDK `rte_hash` supports RCU-based lock-free readers with `RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY_LF`. Worker threads read without locks; Go control plane writes with RCU protection.
 
-### LPM Trie (Address Book)
+#### LPM Trie (Address Book)
 
 BPF: `LPM_TRIE` with `(prefixLen, IP)` → `addressID`
 
@@ -490,7 +533,7 @@ struct rte_lpm_config lpm_cfg = {
 struct rte_lpm *addr_book_v4 = rte_lpm_create("addr_v4", SOCKET_ID_ANY, &lpm_cfg);
 ```
 
-### Counters
+#### Counters
 
 BPF: `PERCPU_ARRAY` — kernel maintains per-CPU copies
 
@@ -510,16 +553,16 @@ void aggregate_counters(uint32_t policy_id, uint64_t *packets, uint64_t *bytes) 
 }
 ```
 
-## Challenges & Mitigations
+### Challenges & Mitigations
 
-### 1. NIC Ownership
+#### 1. NIC Ownership
 **Problem:** DPDK takes exclusive ownership of NIC ports via VFIO/UIO. The kernel loses visibility.
 **Mitigation:**
 - Management interface (mgmt0) stays in kernel (not bound to DPDK)
 - KNI (Kernel NIC Interface) or virtio-user for control plane traffic
 - Or use bifurcated driver (mlx5) that shares NIC between kernel and DPDK
 
-### 2. Kernel Routing Integration
+#### 2. Kernel Routing Integration
 **Problem:** FRR manages routes via kernel; DPDK bypasses kernel networking.
 **Mitigation:**
 - Read FIB from FRR JSON API (already done for `show route detail`)
@@ -527,7 +570,7 @@ void aggregate_counters(uint32_t policy_id, uint64_t *packets, uint64_t *bytes) 
 - Or use `rte_fib` for longest-prefix-match forwarding
 - FRR route changes → notification → update DPDK FIB
 
-### 3. ARP/ND Resolution
+#### 3. ARP/ND Resolution
 **Problem:** Kernel ARP won't work for DPDK-owned interfaces.
 **Mitigation:**
 - Implement ARP responder in DPDK worker (answer ARP requests)
@@ -535,20 +578,20 @@ void aggregate_counters(uint32_t policy_id, uint64_t *packets, uint64_t *bytes) 
 - Go control plane can populate static entries
 - Or use KNI to punt ARP to kernel
 
-### 4. Host-Inbound Services (SSH, DHCP, DNS)
+#### 4. Host-Inbound Services (SSH, DHCP, DNS)
 **Problem:** Traffic destined to the firewall itself needs to reach kernel stack.
 **Mitigation:**
 - KNI interface: DPDK → kernel for host-inbound
 - Or virtio-user pair: DPDK writes to virtio-user → kernel picks up
 - Filter in DPDK: if dest_ip == self → punt to kernel via KNI
 
-### 5. VLAN Handling
+#### 5. VLAN Handling
 **Problem:** DPDK doesn't use kernel VLAN sub-interfaces.
 **Mitigation:**
 - Handle VLAN tag/untag in DPDK pipeline (already done in BPF)
 - Map VLAN IDs to logical interfaces in userspace
 
-### 6. Hitless Restart
+#### 6. Hitless Restart
 **Problem:** DPDK process restart loses all NIC state.
 **Mitigation:**
 - Use hugepage-backed shared memory (survives process restart)
@@ -557,7 +600,7 @@ void aggregate_counters(uint32_t policy_id, uint64_t *packets, uint64_t *bytes) 
 - Brief packet loss during worker restart (unavoidable)
 - Or use hot-standby: start new worker before killing old one
 
-### 7. CGo Overhead
+#### 7. CGo Overhead
 **Problem:** CGo calls have ~100ns overhead per call.
 **Mitigation:**
 - Batch operations: write many map entries in single CGo call
@@ -565,11 +608,11 @@ void aggregate_counters(uint32_t policy_id, uint64_t *packets, uint64_t *bytes) 
 - Session iteration: C-side filtering, return matching subset
 - Config compilation: batch all writes, single CGo "apply" call
 
-## Power Management: Interrupt-Driven Mode
+### Power Management: Interrupt-Driven Mode
 
 Pure poll-mode DPDK burns 100% CPU on dedicated cores even with zero traffic. This is unacceptable for branch/edge deployments, VMs, or any environment where power efficiency matters. xpf supports three RX modes that trade latency for power.
 
-### Three RX Modes
+#### Three RX Modes
 
 ```
 system {
@@ -587,7 +630,7 @@ system {
 | **interrupt** | ~0% per core | Scales with load | 5-50µs (interrupt coalescing) | Edge, branch, VM |
 | **adaptive** | ~0% idle → 100% busy | 100% at threshold | 0-50µs (dynamic) | General purpose |
 
-### Interrupt-Driven Mode (`rx-mode interrupt`)
+#### Interrupt-Driven Mode (`rx-mode interrupt`)
 
 Uses DPDK's `rte_eth_dev_rx_intr_*` API to sleep on an epoll fd until the NIC signals new packets.
 
@@ -639,7 +682,7 @@ ethtool -C enp3s0 rx-usecs 50 rx-frames 64
 -a 0000:03:00.0,rx_intr_thresh=64
 ```
 
-### Adaptive Mode (`rx-mode adaptive`)
+#### Adaptive Mode (`rx-mode adaptive`)
 
 Dynamically switches between poll and interrupt based on traffic load. This gives poll-mode performance under load and interrupt-mode efficiency at idle.
 
@@ -708,7 +751,7 @@ system {
 }
 ```
 
-### Power States and CPU Frequency
+#### Power States and CPU Frequency
 
 In interrupt mode, the core genuinely sleeps (enters C-state). Combined with CPU frequency scaling:
 
@@ -738,7 +781,7 @@ DPDK's `rte_power` library integrates with Linux cpufreq governors (intel_pstate
 - Frequency drops to minimum P-state
 - Wake-up latency: 10-100µs depending on C-state depth
 
-### Hybrid Multi-Core: Mixed Modes
+#### Hybrid Multi-Core: Mixed Modes
 
 For deployments with asymmetric traffic (e.g., WAN at 10G, LAN at 1G), different cores can run different modes:
 
@@ -762,7 +805,7 @@ system {
 }
 ```
 
-### Power Monitoring
+#### Power Monitoring
 
 Expose power state in operational commands:
 
@@ -777,7 +820,7 @@ show system dataplane power
   Estimated power savings vs pure poll: ~45%
 ```
 
-### Implementation in Worker
+#### Implementation in Worker
 
 The RX mode is selected at startup and can be changed at runtime via shared memory flag:
 
@@ -809,7 +852,7 @@ lcore_main(void *arg)
 }
 ```
 
-### Comparison with XDP
+#### Comparison with XDP
 
 | | XDP (current) | DPDK Poll | DPDK Interrupt | DPDK Adaptive |
 |---|---|---|---|---|
@@ -822,7 +865,7 @@ lcore_main(void *arg)
 
 The interrupt and adaptive modes make DPDK viable for the same environments where XDP currently runs — without the 100% CPU penalty. Adaptive mode is the recommended default for most deployments.
 
-## Estimated Timeline
+### Estimated Timeline
 
 | Phase | Description | Effort | Dependencies |
 |-------|-------------|--------|-------------|
@@ -834,7 +877,7 @@ The interrupt and adaptive modes make DPDK viable for the same environments wher
 | 6 | Testing + optimization | 2-3 weeks | All phases |
 | **Total** | | **10-14 weeks** | |
 
-## Incremental Approach
+### Incremental Approach
 
 Rather than implementing everything at once, the DPDK backend could be brought up incrementally:
 
@@ -847,7 +890,7 @@ Rather than implementing everything at once, the DPDK backend could be brought u
 
 Each milestone can be tested independently against the eBPF baseline.
 
-## File Structure
+### File Structure
 
 ```
 pkg/dataplane/
@@ -885,7 +928,7 @@ dpdk_worker/
 └── meson.build          # DPDK build file
 ```
 
-## Decision Points
+### Decision Points
 
 1. **Language for worker:** C (native DPDK) vs Rust (safety + performance) vs Go with DPDK bindings (simplicity but GC pauses)
    - **Recommendation:** C for worker, Go for control plane. Matches DPDK ecosystem.

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -15,10 +15,11 @@
   (`userspace-dp/`) is the primary/default backend, and the legacy
   eBPF dataplane is being retired in parallel under #1373.
 - The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
-  remains in-tree until Phase 3 of #1525 deletes it. Builds with
-  `-tags dpdk` are not supported for production.
-- Commit-time rejection of `set system dataplane-type dpdk` lands
-  in Phase 1 (#1526). Operators should migrate with
+  remains in-tree until Phase 3 of #1525 deletes it. Per #1525,
+  builds with `-tags dpdk` are not supported for production.
+- Commit-time rejection of `set system dataplane-type dpdk` is
+  planned in Phase 1 (#1526; not yet on master). Operators
+  should migrate with
   `set system dataplane-type userspace`, or simply omit
   `system dataplane-type` entirely (userspace is the default).
 - For the project-level retirement context, see

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -26,9 +26,14 @@
   [`docs/dataplane-decision-dpdk-vs-vpp.md`](dataplane-decision-dpdk-vs-vpp.md)
   (also carrying a retirement banner).
 
-The architecture material below is preserved verbatim for
-reference only — it describes a code path that is being removed
-and does not reflect current direction.
+The architecture material below is preserved for reference only
+— it describes a code path that is being removed and does not
+reflect current direction. The wrapper banner, the
+"`[Retired] Historical Design Details`" heading, and minor
+heading demotions inside the section have been added; the
+substantive technical content (overview, architecture diagrams,
+implementation phases, RX-mode tables, file structure, decision
+points) is unchanged from the original.
 
 ---
 

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -1,8 +1,8 @@
 # DPDK Dataplane for xpf — Architecture Plan
 
 > **Status: Retired.** This document was an architecture plan for
-> a DPDK-based xpf dataplane. The DPDK dataplane is being retired
-> under umbrella issue #1525. The userspace AF_XDP dataplane
+> a DPDK-based xpf dataplane. The DPDK dataplane is retired under
+> umbrella issue #1525. The userspace AF_XDP dataplane
 > (`userspace-dp/`) is the primary/default backend. Migrate with
 > `set system dataplane-type userspace`, or simply omit
 > `system dataplane-type` (userspace is the default). See
@@ -39,20 +39,15 @@ and does not reflect current direction.
 > DPDK dataplane is retired under #1525; see the banner at the
 > top of this file for the active path.
 
-The previous header read:
-
-> Note: This is an architecture/planning document. For the current
-> project-level decision and recommendation between DPDK and VPP,
-> see `docs/dataplane-decision-dpdk-vs-vpp.md`.
->
-> Current #1475 policy: DPDK remains a separately supported
-> backend for binaries built with `-tags dpdk`, but it is outside
-> the #1373 eBPF source-removal path until it migrates off the
-> root `dataplane.DataPlane` interface. The legacy bridge is
-> confined to `pkg/dataplane/dpdk`, with only the blank
-> registration import in `cmd/xpfd/main.go` outside that package.
-> Non-DPDK builds reject DPDK startup explicitly instead of
-> running a no-op stub.
+At the time of writing, the active project policy (#1475) treated
+DPDK as a separately supported backend for binaries built with
+`-tags dpdk`, outside the #1373 eBPF source-removal path until it
+migrated off the root `dataplane.DataPlane` interface. The legacy
+bridge was confined to `pkg/dataplane/dpdk`, with only the blank
+registration import in `cmd/xpfd/main.go` outside that package,
+and non-DPDK builds rejected DPDK startup explicitly instead of
+running a no-op stub. That policy has since been superseded by the
+#1525 retirement.
 
 ### Overview
 

--- a/docs/pr/1531-dpdk-docs-retire/plan.md
+++ b/docs/pr/1531-dpdk-docs-retire/plan.md
@@ -2,7 +2,34 @@
 
 ## Status
 
-DRAFT v1 — pending adversarial plan review
+DRAFT v2 — addressing round-1 plan-review findings
+
+## Round-1 verdicts
+
+- Codex (`task-mpkqiyaz-98eky6`): PLAN-NEEDS-MINOR
+  - Finding 1: tombstones need a direct migration target
+    (`set system dataplane-type userspace` + link to
+    `userspace-dp/README.md`), not only an issue pointer.
+  - Finding 2: Chain C coordination should be explicit; the VPP
+    assessment doc has a live pointer to the decision doc that
+    Chain C would otherwise miss.
+- Antigravity (`adversarial-review-mpkqjayf-dhx00a`): PLAN-NEEDS-MAJOR
+  - Finding 1: wholesale deletion of architecture content during
+    Phase 1 / 2 creates an operator-visible "code present, docs
+    gone" window. Keep architecture under a clear
+    `## Historical Design Details (Retired)` section until
+    Phase 3 of #1525 deletes the code.
+  - Finding 2: VPP "revisit trigger" content has lasting value —
+    reframe against userspace-dp's encrypted-tunnel limits rather
+    than delete.
+  - Finding 3: `docs/vpp-dataplane-assessment.md:3-5` points at
+    the rewritten decision doc; bring it into this PR's scope.
+  - Finding 4: tombstones need concrete migration CLI + a markdown
+    link to `userspace-dp/README.md`.
+
+The two reviews converge on the same operator-experience fixes plus
+the architectural-content-retention point. v2 takes all four
+Antigravity findings and both Codex findings.
 
 ## Issue framing
 
@@ -19,122 +46,199 @@ recommend DPDK as a live or recommended dataplane backend:
 This blocks #1526 (DPDK Phase 1, commit-time reject of
 `system dataplane-type dpdk`). If #1526 ships first, the operator
 experience is: docs tell them to use DPDK, daemon refuses DPDK,
-operator files a doc bug. Documentation has to land first or together
-with the reject.
+operator files a doc bug.
 
 #1525 is the DPDK retirement umbrella; this PR is its docs blocker
-slice. Umbrella also has Phase 4 (broader doc sweep across README,
-`docs/feature-gaps.md`, etc.); that is explicitly NOT in this PR's
-scope. This PR touches exactly the two files #1531 names.
+slice. Phase 4 of the umbrella sweeps the broader docs corpus
+(`README.md`, `CLAUDE.md`, `docs/feature-gaps.md`, etc.) — that
+remains out of scope for this PR (a separate Chain C agent owns it).
 
 ## Honest scope/value framing
 
-Pure documentation rewrite — zero code, zero binary change. Value is
+Documentation rewrite — zero code, zero binary change. Value is
 operator-experience correctness: prevent the doc/daemon contradiction
 once #1526 lands. There is no perf gain to weigh against churn.
 
-If reviewers conclude that a pointer-only stub is insufficient for the
-operator landing on these docs from a search engine in isolation,
-PLAN-NEEDS-MAJOR is acceptable. If reviewers conclude the rewrite is
-overcautious (e.g. should KEEP the DPDK architecture content as
-historical reference under a clear "retired" banner instead of
-deleting it), that is also a legitimate verdict to push back on.
-
-PLAN-KILL is appropriate if reviewers identify that the docs should
-NOT change in this PR (e.g. they should be deleted outright as part of
-Phase 3 of #1525, not rewritten as retirement notes). This is unlikely
-— #1531 explicitly asks for the rewrite/banner — but is allowed.
+If reviewers conclude the doc work should be deferred entirely
+(e.g. wait until Phase 3 of #1525 deletes the source, then delete
+the docs in one stroke), that is a legitimate PLAN-KILL. v2 rejects
+this because #1526 needs the docs landing first.
 
 ## What's already shipped / partially relevant
 
 - `CLAUDE.md` already carries the #1373 (legacy eBPF) deprecation
-  notice at the top. The same shape will work for DPDK.
-- `docs/dpdk-dataplane.md` line 7-12 already contains a brief #1475
-  "deferred" note. It is too small and too far down to be the first
-  thing the operator sees, and it predates the #1525 retirement
-  decision (#1475 was the defer; #1525 supersedes with retire).
-- #1525 umbrella is filed and visible to anyone clicking through.
+  notice at the top. Same shape works for DPDK; will be carried by
+  Chain C (#1529) in the broader sweep, not this PR.
+- `docs/dpdk-dataplane.md:7-12` already contains a brief #1475
+  "deferred" note. Too small, too far down, and predates the #1525
+  retirement (#1475 was the defer; #1525 supersedes with retire).
+- `userspace-dp/README.md` exists and is the migration target.
+- `docs/vpp-dataplane-assessment.md:3-5` points at the decision
+  doc — round-1 surfaced this as a same-PR co-fix.
 
-## Concrete design
+## Concrete design (v2)
 
-### `docs/dataplane-decision-dpdk-vs-vpp.md`
+The v2 design preserves the historical architecture content under a
+clearly marked retirement banner rather than deleting it. This:
 
-Reduce to a short retirement notice (~30 lines). Drop the
-"recommendation," "execution plan," and "option A vs B" sections
-entirely. Keep just:
+- closes the round-1 Antigravity "code present, docs gone" hazard
+  during Phases 1 / 2 of the umbrella (source stays in tree).
+- preserves deep-anchor inbound links to the architectural sections
+  (low risk but free to preserve).
+- preserves the VPP revisit-trigger material in reframed form so
+  the architectural reasoning for encrypted-tunnel limits is not
+  lost from the repo.
 
-1. Title + retirement banner at the very top (block quote, bold) with
-   `Status: Retired` and `Supersedes: 2026-03-02 active decision`.
-2. One paragraph: "DPDK has been retired under #1525. The userspace
-   AF_XDP dataplane (`userspace-dp/`) is the primary/default backend
-   and the only one with active development."
-3. One paragraph: "VPP was assessed against DPDK in this document
-   when DPDK was a live backend candidate. With DPDK retired the
-   comparison is moot. There is no current plan to add a VPP
-   backend; if one becomes interesting, a fresh decision document
-   will be filed at that time."
-4. One-line pointer to `docs/dpdk-dataplane.md` (which will become a
-   retirement notice of its own) and to #1525.
+### `docs/dataplane-decision-dpdk-vs-vpp.md` (rewrite)
 
-The old recommendation, option comparison, execution plan, and
-revisit trigger sections are removed wholesale. An operator
-search-engine-landing on this file sees within the first screen of
-text that the document is retired and where to look for the current
-truth.
+Structure (top to bottom):
 
-### `docs/dpdk-dataplane.md`
+1. **Top-of-file retirement banner.** Bold block quote at the very
+   top, before everything else:
 
-Reduce to a short retirement notice (~25 lines). Drop the
-architecture plan, pipeline diagrams, code snippets, RX-mode tables,
-timeline, file structure, and decision points. Keep just:
+   ```
+   > **Status: Retired.** The DPDK dataplane is being retired under
+   > umbrella issue #1525. The userspace AF_XDP dataplane
+   > (`userspace-dp/`) is now the primary/default backend. Migrate
+   > with `set system dataplane-type userspace`, or simply omit
+   > `system dataplane-type` (userspace is the default). See
+   > [`userspace-dp/README.md`](../userspace-dp/README.md) for the
+   > active design.
+   ```
 
-1. Title + retirement banner at the very top (block quote, bold) with
-   `Status: Retired`.
-2. One paragraph: "This document was an architecture plan for a
-   DPDK-based xpf dataplane. The DPDK dataplane is being retired
-   under #1525 (see umbrella for phase plan and rollback path).
-   The userspace AF_XDP dataplane (`userspace-dp/`) is now the
-   primary backend for high-throughput / low-latency targets."
-2. One paragraph that captures the historical context the operator
-   may have come looking for: "The in-tree code under
-   `dpdk_worker/` and `pkg/dataplane/dpdk/` remains until Phase 3
-   of #1525 deletes it. Builds with `-tags dpdk` are not supported
-   for production. Commit-time rejection of `system dataplane-type
-   dpdk` lands in Phase 1 (#1526)."
-3. One-line pointer to `docs/dataplane-decision-dpdk-vs-vpp.md`
-   (also a retirement notice) and to #1525.
+2. **Current state (2026-05).** ~5 lines summarizing:
+   - DPDK is retired under #1525.
+   - userspace-dp is the primary/default backend.
+   - The DPDK source under `dpdk_worker/` and
+     `pkg/dataplane/dpdk/` remains in-tree until Phase 3 of #1525
+     deletes it; commit-time rejection of
+     `system dataplane-type dpdk` lands in Phase 1 (#1526).
+   - VPP was never implemented in xpf; no current plan to add one.
 
-The architecture content (Phase 1-5, RX modes, comparison with XDP,
-file structure) is removed wholesale. It is preserved in git history
-for archaeology; nothing actionable is lost.
+3. **VPP revisit trigger (reframed).** ~5 lines:
+   ```
+   ### Revisit trigger for VPP
+   Re-open VPP assessment if all are true:
+   - Encrypted tunnel (IPsec / WireGuard) throughput becomes a
+     primary product driver. AF_XDP cannot inspect decrypted
+     IPsec or WireGuard payloads — only TC BPF hooks see inner
+     packets after kernel crypto. VPP's WireGuard plugin and IPsec
+     pipeline avoid that bottleneck.
+   - Throughput goals materially exceed what userspace AF_XDP
+     can deliver on target hardware.
+   - Team is willing to own VPP integration and long-term
+     plugin/API maintenance.
+   ```
 
-### Cross-doc consistency
+4. **Historical Decision (Retired).** A clearly marked section at
+   the bottom, with explicit `> **Retired** — preserved for
+   reference only.` banner. Contains the original "DPDK vs VPP"
+   comparison, option A/B comparison, recommendation, and
+   execution plan text — wrapped in the retirement banner so a
+   search-engine reader cannot mistake it for current direction.
+   The historical text is moved verbatim; only the banner is added.
 
-Both docs use the same banner format and the same "retired under
-#1525" wording so a search-engine landing on either yields the same
-top-of-file truth.
+### `docs/dpdk-dataplane.md` (rewrite)
 
-### Why rewrite rather than banner-only
+Structure (top to bottom):
 
-The issue's acceptance criteria offer "rewrite (preferred), or
-(minimum acceptable) prepend a bold two-paragraph retirement banner."
-The minimum-acceptable path leaves the body of each doc still
-recommending DPDK; an operator who skims past the banner could still
-end up wrong. The rewrite path is strictly better and the work is
-small. Choosing the preferred path.
+1. **Top-of-file retirement banner.** Same shape as the decision
+   doc:
+
+   ```
+   > **Status: Retired.** This document was an architecture plan
+   > for a DPDK-based xpf dataplane. The DPDK dataplane is being
+   > retired under umbrella issue #1525. The userspace AF_XDP
+   > dataplane (`userspace-dp/`) is now the primary/default backend.
+   > Migrate with `set system dataplane-type userspace`, or simply
+   > omit `system dataplane-type` (userspace is the default). See
+   > [`userspace-dp/README.md`](../userspace-dp/README.md) for the
+   > active design.
+   ```
+
+2. **Current state (2026-05).** ~5 lines summarizing:
+   - DPDK is retired under #1525.
+   - In-tree code under `dpdk_worker/` and
+     `pkg/dataplane/dpdk/` remains until Phase 3 of #1525 deletes
+     it.
+   - Builds with `-tags dpdk` are not supported for production.
+   - Commit-time rejection of `system dataplane-type dpdk` lands
+     in Phase 1 (#1526).
+   - Pointer to `docs/dataplane-decision-dpdk-vs-vpp.md` (also a
+     retirement notice).
+
+3. **Historical Design Details (Retired).** A clearly marked
+   section at the bottom, with explicit `> **Retired** — preserved
+   for reference only.` banner. Contains the original architecture
+   plan, pipeline diagrams, RX-mode tables, timeline, file
+   structure, decision points — moved verbatim under the
+   retirement banner.
+
+### `docs/vpp-dataplane-assessment.md` (header-only update)
+
+Lines 3-5 currently read:
+
+```
+Note: This is a deep VPP-focused assessment. For the current project-level
+decision and recommendation between DPDK and VPP, see
+`docs/dataplane-decision-dpdk-vs-vpp.md`.
+```
+
+Replace with:
+
+```
+> Note: this VPP assessment was written when DPDK was a live in-tree
+> backend candidate. Both DPDK and the dataplane-decision document
+> are now retired (DPDK retirement: #1525; userspace AF_XDP is the
+> current/default backend in `userspace-dp/`). This assessment is
+> kept for the architectural reasoning around encrypted-tunnel
+> acceleration, which is still relevant; nothing else in this file
+> should be read as current direction.
+```
+
+Body of the VPP assessment is NOT touched in this PR. Phase 4 /
+Chain C may sweep further; this PR just fixes the inbound pointer.
+
+### Why preserve historical sections inline rather than rely on git history
+
+Round-1 Antigravity finding 1: the in-tree DPDK source survives
+Phases 1-2 of #1525 (Phase 1 is the commit reject, Phase 2 is the
+boot-path decouple, Phase 3 is the source removal). An operator
+who needs to understand a stored DPDK config — or who wants to
+build with `-tags dpdk` for archaeology — has nothing in the repo
+to read if the architecture content is deleted from the doc.
+Preserving the content in a clearly-marked Historical section
+solves this without ambiguity about current direction (the banner
+at the top is the first thing readers see).
+
+When Phase 3 of #1525 deletes `dpdk_worker/` and
+`pkg/dataplane/dpdk/`, that PR can choose to delete the
+"Historical" sections as well (their referent is gone). That is
+out of scope here.
 
 ### Files NOT touched in this PR
 
-- `README.md`, `CLAUDE.md` — Phase 4 sweep (#1529-equivalent under
-  umbrella). The Chain C agent owns this.
+- `README.md`, `CLAUDE.md` — Phase 4 sweep, Chain C / #1529.
 - `docs/feature-gaps.md`, `docs/userspace-dataplane-gaps.md`,
   `docs/phases.md`, `docs/bugs.md`,
   `docs/active-active-new-connections.md`,
   `docs/refactoring-audit.md`, `docs/perf-ranked-backlog.md`,
-  `docs/cross-worker-flow-fairness-research.md` — Phase 4 sweep.
-- `dpdk_worker/README.md` — defer to Phase 3 (source removal).
-- `docs/vpp-dataplane-assessment.md` — out of scope. If it
-  recommends DPDK as an alternative, that's a separate cleanup.
+  `docs/cross-worker-flow-fairness-research.md` — Phase 4 sweep,
+  Chain C.
+- `dpdk_worker/README.md` — Phase 3 (source removal).
+- Body of `docs/vpp-dataplane-assessment.md` (lines 7+) — Phase
+  4. Only the inbound-pointer header is fixed.
+
+### Chain C coordination
+
+Plan v2 adds an explicit Chain C handoff: this PR's commit message
+and PR body call out the same-PR doc files (the two named + the
+VPP assessment header) and explicitly list the broader-sweep files
+as Chain C's surface. If Chain C lands first and touches the VPP
+assessment header, this PR's vpp-assessment change will conflict
+and a clean rebase resolves to "Chain C wins, this PR was right
+to scope minimally." If this PR lands first, Chain C inherits a
+consistent surface for the broader sweep.
 
 ## Public API preservation
 
@@ -142,22 +246,31 @@ N/A — documentation only. No code, no tests, no API surfaces touched.
 
 ## Hidden invariants the change must preserve
 
-1. **No broken doc links.** Any other doc file linking into the two
-   touched files must still resolve. `grep` for inbound links and
-   verify they still make sense pointing at a retirement notice.
+1. **No broken doc links.** Any other doc file linking into the
+   three touched files (`dpdk-dataplane.md`,
+   `dataplane-decision-dpdk-vs-vpp.md`,
+   `vpp-dataplane-assessment.md`) must still resolve. v2's
+   preserve-historical-sections approach makes deep-anchor links
+   continue to resolve.
 2. **No CI hooks key on doc strings.** `grep` makefiles, hooks,
-   `.github/workflows/`, scripts for substrings of the deleted text.
+   `.github/workflows/`, scripts for substrings of the changed
+   text before final commit.
 3. **The retirement message survives independent reading.** Anyone
-   who lands on either file from a search engine must understand,
-   in the first screen of text, that DPDK is retired and where to
-   look instead.
-4. **No promise about VPP roadmap.** The decision doc as it stands
-   describes a "revisit trigger" for VPP. The retirement notice
-   must NOT carry that forward — it would be a stale promise. Use
-   "if it becomes interesting, a fresh decision doc will be filed
-   at that time" instead.
-5. **#1525 reference is durable.** Both docs link the umbrella by
-   number, not by title-as-of-today.
+   who lands on any of these files from a search engine must
+   understand, in the first screen of text, that DPDK is retired
+   and where to look instead. v2's top-of-file banner is bolded,
+   block-quoted, contains the migration CLI command, and links
+   the active design doc.
+4. **No promise about VPP roadmap.** v2 preserves the revisit
+   trigger but reframes it against the limitations of the new
+   default backend (userspace AF_XDP's kernel-crypto boundary for
+   IPsec / WireGuard), not against DPDK. This is honest about the
+   ongoing tradeoff that does not vanish with DPDK retirement.
+5. **#1525 reference is durable.** Both rewrites link the umbrella
+   by number, not by title-as-of-today.
+6. **Cross-doc consistency.** The retirement banner shape is
+   identical across all three touched files so a search-engine
+   reader gets the same top-of-file truth.
 
 ## Risk assessment
 
@@ -166,8 +279,10 @@ N/A — documentation only. No code, no tests, no API surfaces touched.
 | Behavioral regression | NONE | No code or binary change. |
 | Lifetime / borrow-checker | NONE | No code. |
 | Performance regression | NONE | No code. |
-| Architectural mismatch | LOW | This is the right doc work; risk is that the rewrite-vs-banner choice is overcautious or undercautious, both surfaced for plan-review challenge. |
-| Cross-PR coordination | LOW | Chain C (#1529) may sweep other doc files in parallel. As long as Chain C does not touch the two files this PR touches, there is no conflict. Both PRs will rebase cleanly if the other lands first. |
+| Architectural mismatch | LOW | v2's preserve-historical approach addresses round-1 Antigravity's main finding. |
+| Cross-PR coordination | LOW | Chain C may sweep other doc files in parallel. v2 explicitly scopes the VPP-assessment header into this PR; if Chain C also touches it, rebase resolves cleanly. |
+| Stale inbound pointers from third-party assessment doc | RESOLVED | v2 brings `docs/vpp-dataplane-assessment.md:3-5` into scope. |
+| Search-engine reader misreads "Historical" section as current | LOW | The retirement banner is at the very top; the Historical section also has its own retirement banner; both use the same bold block-quoted format. |
 
 ## Test plan
 
@@ -175,11 +290,12 @@ Documentation PR — the smoke matrix is mandated by the user as a
 discipline gate, not because docs can break the dataplane. The full
 matrix runs anyway:
 
-- `git grep -i 'recommend\|primary\|secondary' docs/dpdk-dataplane.md docs/dataplane-decision-dpdk-vs-vpp.md` returns no live DPDK recommendations.
-- `git grep -i 'dpdk' docs/dpdk-dataplane.md docs/dataplane-decision-dpdk-vs-vpp.md | grep -v -i 'retired\|retirement\|historical'` returns only ambient mentions (file titles, umbrella refs) — no live recommendation.
+- `git grep -i 'recommend\|primary\|secondary' docs/dpdk-dataplane.md docs/dataplane-decision-dpdk-vs-vpp.md` outside the "Historical" section returns no live DPDK recommendations.
+- `git grep -F -- "docs/dataplane-decision-dpdk-vs-vpp.md" docs/` shows the updated inbound-pointer line from `docs/vpp-dataplane-assessment.md`.
+- `git grep -F -- "dpdk-dataplane.md" docs/` shows updated cross-pointer between the two touched files.
 - `make build` clean.
-- `make test` clean (Go suite — should be unchanged by a docs PR).
-- `cargo build` + `cargo test` clean (Rust suite — should be unchanged).
+- `make test` clean.
+- `cargo build` + `cargo test --release` clean (Rust side unchanged; gated for completeness).
 - Deploy on `loss:xpf-userspace-fw0/fw1`.
 - Pass A (CoS disabled, fixture-aligned tear-down):
   - v4 push, v4 reverse, v6 push, v6 reverse single-stream.
@@ -192,60 +308,62 @@ matrix runs anyway:
 
 - README/CLAUDE.md sweep — Chain C / #1529.
 - Broader `docs/*` sweep — Chain C / #1529.
+- Body of `docs/vpp-dataplane-assessment.md` (anywhere past
+  line 5) — Phase 4.
 - `dpdk_worker/README.md` deletion — Phase 3 source removal.
 - Adding a code-side commit-time reject for `dataplane-type dpdk` —
-  PR #2 of this chain (#1526).
+  Chain A PR #2 (#1526).
 - Deleting `dpdk_worker/` source — Phase 3 of #1525.
 - Removing the blank import in `cmd/xpfd/main.go` — Phase 2 of
   #1525.
 - Touching the canary `dpdkBackendImportAllowlist` — Phase 2 of
   #1525.
 
-## Open questions for adversarial review
+## Open questions for adversarial review (round-2)
 
-1. **Should the rewrite delete the historical architecture content
-   wholesale, or preserve it under a "Historical (retired)" section
-   in the same file?** Git history preserves it either way. The PR
-   chooses wholesale deletion to keep the doc short and the
-   retirement message unambiguous. If a reviewer believes the
-   architecture content has lasting reference value (e.g. someone
-   may want to compare userspace-dp's design choices against the
-   original DPDK plan), pushing back here is legitimate.
+1. **Is the "Historical Design Details (Retired)" section the right
+   tradeoff?** v2 preserves the architectural content inline.
+   The alternative is to delete it now and rely on git history.
+   Antigravity round-1 came down strongly on preserve; Codex
+   round-1 explicitly endorsed wholesale-delete. v2 takes the
+   preserve path because the source code is staying in-tree until
+   Phase 3. If reviewers think this is over-cautious — the in-tree
+   code IS NOT going to receive any updates and the architecture
+   doc is purely historical — flag PLAN-NEEDS-MINOR with a clear
+   counter-example.
 
-2. **Is "retired under #1525" sufficient pointer text, or should the
-   doc also link directly to `userspace-dp/README.md` / the
-   userspace-dataplane CLAUDE.md section, so the operator gets a
-   migration target without clicking through to the umbrella?** PR
-   currently does the former; reviewer may want the latter.
+2. **Should the migration CLI hint show
+   `set system dataplane-type userspace` AND/OR mention the
+   "omit the line entirely" path?** v2 mentions both. A reviewer
+   may want only one (less surface to read).
 
-3. **Should the VPP comparison content be deleted from the
-   decision doc, kept as a footnote, or migrated to
-   `docs/vpp-dataplane-assessment.md`?** PR currently deletes it
-   from the decision doc and does not touch the VPP assessment
-   doc. Migration would be cleaner but creates Chain-C-style
-   scope creep.
+3. **Is the reframed VPP revisit trigger honest about
+   userspace-dp's actual encrypted-tunnel performance?** v2 says
+   "AF_XDP cannot inspect decrypted IPsec or WireGuard payloads
+   — only TC BPF hooks see inner packets after kernel crypto."
+   That is a verifiable claim from the existing VPP assessment
+   doc (`docs/vpp-dataplane-assessment.md:26-31`). Double-check.
 
-4. **Does the retirement notice need to reproduce the migration
-   command (`set system dataplane-type userspace` or the omit-it
-   path) so the operator gets the answer in-file, or is "see #1525
-   for migration" sufficient?** PR currently does the latter. The
-   former would duplicate text that #1526 will surface in the
-   commit-error message itself.
+4. **Does the VPP-assessment header update create a regression?**
+   The replacement says "nothing else in this file should be
+   read as current direction." That is strong language. If
+   parts of the body ARE still current direction (e.g. the
+   hybrid XDP + VPP topology), the new header understates it.
+   Reviewer may want the wording weakened.
 
-5. **Does anything in CI key off strings in these docs?** PR has
-   not yet verified this; it is in the test plan, but a reviewer
-   may want to see the grep output before signing off. (Plan-review
-   round-1 will run the grep and surface results.)
+5. **Does this PR coordinate correctly with Chain C?** v2 says
+   the PR body will explicitly list the same-PR doc files and
+   the broader-sweep files. If Chain C is currently dispatched
+   and its plan touches `docs/vpp-dataplane-assessment.md:3-5`
+   too, we should coordinate via PR comment, not silently
+   conflict.
 
-6. **Are there other docs that link into these two files by deep
-   anchor (e.g. `#power-management-interrupt-driven-mode`)?
-   Deleting the anchor will silently break the link.** PR will
-   `grep -F` for the section anchors before final commit.
+6. **Does anything in CI key off strings in these docs?** v2's
+   test plan greps for this; surface results in the PR body.
+   Plan-review round-1 did not flag any. Verified by grep
+   absence is good enough.
 
-7. **Should both docs be deleted outright instead of rewritten as
-   retirement notices?** The umbrella's Phase 3 says "delete or
-   rewrite as historical notes." The PR chooses rewrite-as-notice
-   to keep the file path alive (other docs, possibly external
-   references, link to it). A reviewer may argue for outright
-   deletion + redirect via a stub — that's harder to verify and
-   no clearer to the operator, but it's a legitimate alternative.
+7. **Should the Historical sections cite their own retirement
+   date?** v2 currently uses a generic "preserved for reference
+   only" banner. Adding "as of 2026-05" pins the snapshot in
+   time. Marginal.

--- a/docs/pr/1531-dpdk-docs-retire/plan.md
+++ b/docs/pr/1531-dpdk-docs-retire/plan.md
@@ -1,0 +1,251 @@
+# #1531 — Retire DPDK recommendations in docs
+
+## Status
+
+DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+Issue #1531 reports that two operator-facing docs on master still
+recommend DPDK as a live or recommended dataplane backend:
+
+- `docs/dataplane-decision-dpdk-vs-vpp.md` — line 9 names DPDK "the
+  better next dataplane path than VPP" and Option A "Continue DPDK
+  backend evolution (recommended)" at line 60.
+- `docs/dpdk-dataplane.md` — opens with a multi-page architecture
+  plan describing DPDK as "an alternative to the current XDP/TC eBPF
+  pipeline" with throughput tables, implementation plan, timeline.
+
+This blocks #1526 (DPDK Phase 1, commit-time reject of
+`system dataplane-type dpdk`). If #1526 ships first, the operator
+experience is: docs tell them to use DPDK, daemon refuses DPDK,
+operator files a doc bug. Documentation has to land first or together
+with the reject.
+
+#1525 is the DPDK retirement umbrella; this PR is its docs blocker
+slice. Umbrella also has Phase 4 (broader doc sweep across README,
+`docs/feature-gaps.md`, etc.); that is explicitly NOT in this PR's
+scope. This PR touches exactly the two files #1531 names.
+
+## Honest scope/value framing
+
+Pure documentation rewrite — zero code, zero binary change. Value is
+operator-experience correctness: prevent the doc/daemon contradiction
+once #1526 lands. There is no perf gain to weigh against churn.
+
+If reviewers conclude that a pointer-only stub is insufficient for the
+operator landing on these docs from a search engine in isolation,
+PLAN-NEEDS-MAJOR is acceptable. If reviewers conclude the rewrite is
+overcautious (e.g. should KEEP the DPDK architecture content as
+historical reference under a clear "retired" banner instead of
+deleting it), that is also a legitimate verdict to push back on.
+
+PLAN-KILL is appropriate if reviewers identify that the docs should
+NOT change in this PR (e.g. they should be deleted outright as part of
+Phase 3 of #1525, not rewritten as retirement notes). This is unlikely
+— #1531 explicitly asks for the rewrite/banner — but is allowed.
+
+## What's already shipped / partially relevant
+
+- `CLAUDE.md` already carries the #1373 (legacy eBPF) deprecation
+  notice at the top. The same shape will work for DPDK.
+- `docs/dpdk-dataplane.md` line 7-12 already contains a brief #1475
+  "deferred" note. It is too small and too far down to be the first
+  thing the operator sees, and it predates the #1525 retirement
+  decision (#1475 was the defer; #1525 supersedes with retire).
+- #1525 umbrella is filed and visible to anyone clicking through.
+
+## Concrete design
+
+### `docs/dataplane-decision-dpdk-vs-vpp.md`
+
+Reduce to a short retirement notice (~30 lines). Drop the
+"recommendation," "execution plan," and "option A vs B" sections
+entirely. Keep just:
+
+1. Title + retirement banner at the very top (block quote, bold) with
+   `Status: Retired` and `Supersedes: 2026-03-02 active decision`.
+2. One paragraph: "DPDK has been retired under #1525. The userspace
+   AF_XDP dataplane (`userspace-dp/`) is the primary/default backend
+   and the only one with active development."
+3. One paragraph: "VPP was assessed against DPDK in this document
+   when DPDK was a live backend candidate. With DPDK retired the
+   comparison is moot. There is no current plan to add a VPP
+   backend; if one becomes interesting, a fresh decision document
+   will be filed at that time."
+4. One-line pointer to `docs/dpdk-dataplane.md` (which will become a
+   retirement notice of its own) and to #1525.
+
+The old recommendation, option comparison, execution plan, and
+revisit trigger sections are removed wholesale. An operator
+search-engine-landing on this file sees within the first screen of
+text that the document is retired and where to look for the current
+truth.
+
+### `docs/dpdk-dataplane.md`
+
+Reduce to a short retirement notice (~25 lines). Drop the
+architecture plan, pipeline diagrams, code snippets, RX-mode tables,
+timeline, file structure, and decision points. Keep just:
+
+1. Title + retirement banner at the very top (block quote, bold) with
+   `Status: Retired`.
+2. One paragraph: "This document was an architecture plan for a
+   DPDK-based xpf dataplane. The DPDK dataplane is being retired
+   under #1525 (see umbrella for phase plan and rollback path).
+   The userspace AF_XDP dataplane (`userspace-dp/`) is now the
+   primary backend for high-throughput / low-latency targets."
+2. One paragraph that captures the historical context the operator
+   may have come looking for: "The in-tree code under
+   `dpdk_worker/` and `pkg/dataplane/dpdk/` remains until Phase 3
+   of #1525 deletes it. Builds with `-tags dpdk` are not supported
+   for production. Commit-time rejection of `system dataplane-type
+   dpdk` lands in Phase 1 (#1526)."
+3. One-line pointer to `docs/dataplane-decision-dpdk-vs-vpp.md`
+   (also a retirement notice) and to #1525.
+
+The architecture content (Phase 1-5, RX modes, comparison with XDP,
+file structure) is removed wholesale. It is preserved in git history
+for archaeology; nothing actionable is lost.
+
+### Cross-doc consistency
+
+Both docs use the same banner format and the same "retired under
+#1525" wording so a search-engine landing on either yields the same
+top-of-file truth.
+
+### Why rewrite rather than banner-only
+
+The issue's acceptance criteria offer "rewrite (preferred), or
+(minimum acceptable) prepend a bold two-paragraph retirement banner."
+The minimum-acceptable path leaves the body of each doc still
+recommending DPDK; an operator who skims past the banner could still
+end up wrong. The rewrite path is strictly better and the work is
+small. Choosing the preferred path.
+
+### Files NOT touched in this PR
+
+- `README.md`, `CLAUDE.md` — Phase 4 sweep (#1529-equivalent under
+  umbrella). The Chain C agent owns this.
+- `docs/feature-gaps.md`, `docs/userspace-dataplane-gaps.md`,
+  `docs/phases.md`, `docs/bugs.md`,
+  `docs/active-active-new-connections.md`,
+  `docs/refactoring-audit.md`, `docs/perf-ranked-backlog.md`,
+  `docs/cross-worker-flow-fairness-research.md` — Phase 4 sweep.
+- `dpdk_worker/README.md` — defer to Phase 3 (source removal).
+- `docs/vpp-dataplane-assessment.md` — out of scope. If it
+  recommends DPDK as an alternative, that's a separate cleanup.
+
+## Public API preservation
+
+N/A — documentation only. No code, no tests, no API surfaces touched.
+
+## Hidden invariants the change must preserve
+
+1. **No broken doc links.** Any other doc file linking into the two
+   touched files must still resolve. `grep` for inbound links and
+   verify they still make sense pointing at a retirement notice.
+2. **No CI hooks key on doc strings.** `grep` makefiles, hooks,
+   `.github/workflows/`, scripts for substrings of the deleted text.
+3. **The retirement message survives independent reading.** Anyone
+   who lands on either file from a search engine must understand,
+   in the first screen of text, that DPDK is retired and where to
+   look instead.
+4. **No promise about VPP roadmap.** The decision doc as it stands
+   describes a "revisit trigger" for VPP. The retirement notice
+   must NOT carry that forward — it would be a stale promise. Use
+   "if it becomes interesting, a fresh decision doc will be filed
+   at that time" instead.
+5. **#1525 reference is durable.** Both docs link the umbrella by
+   number, not by title-as-of-today.
+
+## Risk assessment
+
+| Risk class | Level | Notes |
+|---|---|---|
+| Behavioral regression | NONE | No code or binary change. |
+| Lifetime / borrow-checker | NONE | No code. |
+| Performance regression | NONE | No code. |
+| Architectural mismatch | LOW | This is the right doc work; risk is that the rewrite-vs-banner choice is overcautious or undercautious, both surfaced for plan-review challenge. |
+| Cross-PR coordination | LOW | Chain C (#1529) may sweep other doc files in parallel. As long as Chain C does not touch the two files this PR touches, there is no conflict. Both PRs will rebase cleanly if the other lands first. |
+
+## Test plan
+
+Documentation PR — the smoke matrix is mandated by the user as a
+discipline gate, not because docs can break the dataplane. The full
+matrix runs anyway:
+
+- `git grep -i 'recommend\|primary\|secondary' docs/dpdk-dataplane.md docs/dataplane-decision-dpdk-vs-vpp.md` returns no live DPDK recommendations.
+- `git grep -i 'dpdk' docs/dpdk-dataplane.md docs/dataplane-decision-dpdk-vs-vpp.md | grep -v -i 'retired\|retirement\|historical'` returns only ambient mentions (file titles, umbrella refs) — no live recommendation.
+- `make build` clean.
+- `make test` clean (Go suite — should be unchanged by a docs PR).
+- `cargo build` + `cargo test` clean (Rust suite — should be unchanged).
+- Deploy on `loss:xpf-userspace-fw0/fw1`.
+- Pass A (CoS disabled, fixture-aligned tear-down):
+  - v4 push, v4 reverse, v6 push, v6 reverse single-stream.
+  - v4 and v6 `-P 12 -R` multi-stream — line rate, 0 retrans.
+- Pass B (CoS re-applied via `apply-cos-config.sh`):
+  - Per-class 5201-5206 × v4/v6 × push/reverse = 24 measurements.
+- No retrans regressions vs master baseline.
+
+## Out of scope (explicitly)
+
+- README/CLAUDE.md sweep — Chain C / #1529.
+- Broader `docs/*` sweep — Chain C / #1529.
+- `dpdk_worker/README.md` deletion — Phase 3 source removal.
+- Adding a code-side commit-time reject for `dataplane-type dpdk` —
+  PR #2 of this chain (#1526).
+- Deleting `dpdk_worker/` source — Phase 3 of #1525.
+- Removing the blank import in `cmd/xpfd/main.go` — Phase 2 of
+  #1525.
+- Touching the canary `dpdkBackendImportAllowlist` — Phase 2 of
+  #1525.
+
+## Open questions for adversarial review
+
+1. **Should the rewrite delete the historical architecture content
+   wholesale, or preserve it under a "Historical (retired)" section
+   in the same file?** Git history preserves it either way. The PR
+   chooses wholesale deletion to keep the doc short and the
+   retirement message unambiguous. If a reviewer believes the
+   architecture content has lasting reference value (e.g. someone
+   may want to compare userspace-dp's design choices against the
+   original DPDK plan), pushing back here is legitimate.
+
+2. **Is "retired under #1525" sufficient pointer text, or should the
+   doc also link directly to `userspace-dp/README.md` / the
+   userspace-dataplane CLAUDE.md section, so the operator gets a
+   migration target without clicking through to the umbrella?** PR
+   currently does the former; reviewer may want the latter.
+
+3. **Should the VPP comparison content be deleted from the
+   decision doc, kept as a footnote, or migrated to
+   `docs/vpp-dataplane-assessment.md`?** PR currently deletes it
+   from the decision doc and does not touch the VPP assessment
+   doc. Migration would be cleaner but creates Chain-C-style
+   scope creep.
+
+4. **Does the retirement notice need to reproduce the migration
+   command (`set system dataplane-type userspace` or the omit-it
+   path) so the operator gets the answer in-file, or is "see #1525
+   for migration" sufficient?** PR currently does the latter. The
+   former would duplicate text that #1526 will surface in the
+   commit-error message itself.
+
+5. **Does anything in CI key off strings in these docs?** PR has
+   not yet verified this; it is in the test plan, but a reviewer
+   may want to see the grep output before signing off. (Plan-review
+   round-1 will run the grep and surface results.)
+
+6. **Are there other docs that link into these two files by deep
+   anchor (e.g. `#power-management-interrupt-driven-mode`)?
+   Deleting the anchor will silently break the link.** PR will
+   `grep -F` for the section anchors before final commit.
+
+7. **Should both docs be deleted outright instead of rewritten as
+   retirement notices?** The umbrella's Phase 3 says "delete or
+   rewrite as historical notes." The PR chooses rewrite-as-notice
+   to keep the file path alive (other docs, possibly external
+   references, link to it). A reviewer may argue for outright
+   deletion + redirect via a stub — that's harder to verify and
+   no clearer to the operator, but it's a legitimate alternative.

--- a/docs/pr/1531-dpdk-docs-retire/reviewer-ids.md
+++ b/docs/pr/1531-dpdk-docs-retire/reviewer-ids.md
@@ -1,0 +1,39 @@
+# Reviewer IDs — PR #1534 (#1531 DPDK docs retirement)
+
+Branch: `dpdk-retire/1531-docs`
+PR URL: https://github.com/psaab/xpf/pull/1534
+
+## Round 2 — SHA `41bbf1d830f0873b78117ca43180ee67ad4c83b2`
+
+Addressing Copilot round-1 nits (4 items) on prior SHA `aff968b6`:
+
+1. Harmonize "is being retired" → "is retired" banners in
+   `docs/dataplane-decision-dpdk-vs-vpp.md` + `docs/dpdk-dataplane.md`.
+2. Convert bare code span to markdown link for
+   `vpp-dataplane-assessment.md` in the Related (Active) Documents section.
+3. Tighten "underlay-NIC XSK" wording to talk about userspace-dp's
+   AF_XDP socket on the physical NIC instead of conflating NIC XDP and
+   AF_XDP socket.
+4. Drop the "The previous header read:" preamble and fold the prior
+   #1475 policy text into a narrative paragraph in the [Retired] section.
+
+Smoke skipped (pure-docs PR).
+
+### Dispatched reviewers
+
+- **Copilot**: triggered via `@copilot review` PR comment
+  `https://github.com/psaab/xpf/pull/1534#issuecomment-4531821079`
+  (round-1 verdict on aff968b6 was "No blocking issues" with 4 nits;
+  this round revalidates the nit fixes).
+- **Codex companion**: `task-mpkrvxss-6wwlip` (background hostile
+  code review).
+- **Antigravity (AGY)**: `adversarial-review-mpkrwdls-x93rlu`
+  (background adversarial review, base `origin/master`).
+
+### Verdict tracker
+
+| Reviewer  | Verdict        | Notes                                  |
+|-----------|----------------|----------------------------------------|
+| Copilot   | pending        | re-triggered on 41bbf1d8               |
+| Codex     | pending        | task-mpkrvxss-6wwlip                   |
+| AGY       | pending        | adversarial-review-mpkrwdls-x93rlu     |

--- a/docs/vpp-dataplane-assessment.md
+++ b/docs/vpp-dataplane-assessment.md
@@ -1,8 +1,18 @@
 # VPP Dataplane Assessment for xpf
 
-Note: This is a deep VPP-focused assessment. For the current project-level
-decision and recommendation between DPDK and VPP, see
-`docs/dataplane-decision-dpdk-vs-vpp.md`.
+> Note: this VPP assessment was written when DPDK was a live
+> in-tree backend candidate. Both DPDK and the historical
+> dataplane-decision document are now retired (DPDK retirement:
+> #1525; userspace AF_XDP is the current/default backend in
+> `userspace-dp/`). The architectural reasoning here — especially
+> around encrypted-tunnel acceleration and the userspace-crypto
+> tradeoff — remains a useful reference, as do specific
+> assessments such as the native Go VRRP decision. Other
+> recommendations should not be read as current direction; see
+> [`docs/dataplane-decision-dpdk-vs-vpp.md`](dataplane-decision-dpdk-vs-vpp.md)
+> for the retirement banner and active direction, and
+> [`userspace-dp/README.md`](../userspace-dp/README.md) for the
+> active design.
 
 *Date: 2026-02-19*
 

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -10,10 +10,12 @@ Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
 Runs as a separate `xpf-userspace-dp` binary the Go daemon spawns over a
 Unix-socket control protocol.
 
-This crate is the primary AF_XDP backend for #1373. It is still selected with
-`system dataplane-type userspace` until a later cutover changes runtime
-defaults; the legacy eBPF backend (`pkg/dataplane`) remains available for
-compatibility and regression coverage.
+This crate is the primary AF_XDP backend for #1373 and is now the default
+runtime: an empty / omitted `system dataplane-type` resolves to userspace in
+`pkg/dataplane.EffectiveType`. Operators can still pin the selection
+explicitly with `set system dataplane-type userspace`. The legacy eBPF
+backend (`pkg/dataplane`) remains available for compatibility and regression
+coverage; the DPDK backend is retired under #1525.
 
 ## Crate entry
 


### PR DESCRIPTION
## Summary

Replace the DPDK-recommends-DPDK posture in three operator-facing dataplane docs with retirement banners pointing at the #1525 umbrella, the active userspace AF_XDP backend (`userspace-dp/`), and a concrete migration command. Closes #1531 (Phase 1 docs blocker for #1526).

Files touched:
- `docs/dataplane-decision-dpdk-vs-vpp.md` — top-of-file retirement banner; new "Current State (2026-05)" section; reframed VPP revisit trigger against userspace-dp's encrypted-tunnel limits; historical decision preserved verbatim under `[Retired]` heading with its own banner.
- `docs/dpdk-dataplane.md` — same retirement-banner shape; migration command; historical architecture plan preserved verbatim under `[Retired]` heading.
- `docs/vpp-dataplane-assessment.md` — header-only update (lines 3-5): inbound pointer to the now-retired decision doc + clarification that the encrypted-tunnel architectural reasoning and native Go VRRP decision remain a useful reference.
- `userspace-dp/README.md` — small wording fix: drop the stale "still selected ... until later cutover" line; reflect that userspace is now the default via `EffectiveType`.

Out of scope (Phase 4 / Chain C / #1529): README.md, CLAUDE.md, body of `docs/vpp-dataplane-assessment.md`, `docs/feature-gaps.md`, etc.

## Plan + adversarial review

Plan doc: `docs/pr/1531-dpdk-docs-retire/plan.md`

- Codex round-1 (task-mpkqiyaz-98eky6): PLAN-NEEDS-MINOR
- Antigravity round-1 (adversarial-review-mpkqjayf-dhx00a): PLAN-NEEDS-MAJOR
- Codex round-2 (task-mpkqwl3j-ks7ijh): PLAN-NEEDS-MINOR (wording only)
- Antigravity round-2 (adversarial-review-mpkqx0c2-zmu5h6): PLAN-READY

All round-1 findings addressed in plan v2 + implementation (Historical Design Details preserved under banner, VPP revisit trigger reframed against userspace-dp's encrypted-tunnel limits, vpp-dataplane-assessment header in scope, concrete migration CLI + userspace-dp/README.md link).

## Test plan

- [x] `make build` clean.
- [x] Deploy on `loss:xpf-userspace-fw0/fw1` (loss userspace cluster).
- [x] **Pass A — CoS disabled** (best-effort fast path)
  - [x] v4 push: 8.62 Gb/s, 0 retrans against 172.16.80.200
  - [x] v4 reverse: 8.82 Gb/s, 0 retrans
  - [x] v6 push: 8.86 Gb/s, 0 retrans against 2001:559:8585:80::200
  - [x] v6 reverse: 7.88 Gb/s, 0 retrans
  - [x] v4 multi-stream `-P 12 -R`: 23.1 Gb/s line rate, 0 retrans
  - [x] v6 multi-stream `-P 12 -R`: 22.8 Gb/s line rate, 0 retrans
- [x] **Pass B — CoS enabled** (per-class shaper + classifier)
  - [x] 24 measurements (5201-5206 × v4/v6 × push/reverse) — all complete; 22 cells with 0 retrans; 2 shaped-class cells (iperf-b v6 rev:18, iperf-e v4 rev:519) hitting their shape rate with ECN-marked drops as expected.

## Coordination

Chain C (#1529) is sweeping the broader docs corpus in parallel. This PR is scoped to the three files #1531 names plus userspace-dp/README.md. If Chain C touches `docs/vpp-dataplane-assessment.md` body or any of the broader-scope files, rebase resolves cleanly.

This PR must land before #1526 (DPDK reject-at-commit) so the daemon's commit-time error message does not contradict docs still recommending DPDK on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)