### PR TITLE
dataplane: decouple DPDK from boot path and registration (#1527)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -3,13 +3,26 @@
 ## 2026-05-25
 
 - **Timestamp**: 2026-05-25T07:05:00Z
-  - **Action**: #1527 follow-up re-review fix — corrected
-    `NewDataPlane` unknown-type guidance in `pkg/dataplane/dataplane.go`
-    to stop advertising `userspace` as a valid legacy `DataPlane` type.
-    `userspace` is runtime-only through `NewRuntimeDataPlane`, so the old
-    message was misleading during operator/debug triage.
-    Baseline + post-change dataplane tests run clean.
-  - **File(s)**: `pkg/dataplane/dataplane.go`, `_Log.md`
+  - **Action**: #1527 round-7 Copilot follow-up. Copilot review on
+    9b4e9e24 (COMMENTED, 5 inline comments) flagged two new
+    consistency nits on top of the 3 already-resolved ones:
+    (1) `pkg/dataplane/dataplane.go:160` — `NewDataPlane`'s
+    unknown-type error listed "userspace" as valid even though
+    legacy `NewDataPlane(TypeUserspace)` falls through to the
+    registry lookup and errors out; the message is now
+    `"unknown dataplane type %q (valid via NewDataPlane: ebpf; use NewRuntimeDataPlane for userspace)"`
+    with a clarifying comment;
+    (2) `pkg/daemon/daemon_ha_sync.go:684` — the "disabling all
+    RGs" log fired even when `cfg.Chassis.Cluster == nil`, which is
+    misleading. Moved it inside the cluster-cfg-non-nil branch with
+    an `rg_count` slog kv field. The neutral "fence received from
+    peer" log at line 667 stays as the unconditional entry point.
+    Both fixes are comment-only consistency nits, no behavior
+    change.
+  - **File(s)**: `pkg/dataplane/dataplane.go`,
+    `pkg/daemon/daemon_ha_sync.go`, `_Log.md`
+  - **Validation**: `go build ./...` clean; `go test
+    ./pkg/dataplane/... ./pkg/daemon/... -count=1` clean.
 
 - **Timestamp**: 2026-05-25T05:55:15Z
   - **Action**: #1527 final Copilot re-review follow-up — resolved three

--- a/_Log.md
+++ b/_Log.md
@@ -1910,3 +1910,16 @@
   - **File(s)**: `userspace-dp/src/afxdp/wg/framing.rs`, `_Log.md`
   - **Validation**: cargo build --release; cargo test --release --bin
     xpf-userspace-dp afxdp::wg.
+
+- **Timestamp**: 2026-05-25T06:20Z
+- **Action**: Harmonize ErrDPDKBackendRetired + slog.Warn wording with config sentinel (AGY #1536 review finding)
+- **File(s)**: pkg/dataplane/dataplane.go, pkg/daemon/daemon_run.go
+- **Why**: Antigravity adversarial-review-mpksyrj1-f1mid9 (against #1536) noted a
+  cross-PR consistency gap: the config-time sentinel ErrDPDKDataplaneRetired
+  starts with "the DPDK..." while the runtime-time ErrDPDKBackendRetired (this
+  PR) starts with "DPDK..." (no leading article). errors.Is matching is
+  unaffected but log monitoring tools using exact string matches across both
+  layers would mismatch. Aligned both the sentinel and the daemon_run.go
+  slog.Warn wording to "the DPDK dataplane backend has been retired".
+- **Validation**: pkg/dataplane test suite green; no other in-tree strings
+  pinned the old wording.

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,21 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T05:55:15Z
+  - **Action**: #1527 final Copilot re-review follow-up — resolved three
+    remaining consistency nits from the latest Copilot inline pass:
+    (1) `compiler_system.go` invalid dataplane-type guidance now
+    matches current parser acceptance (`ebpf, dpdk, userspace`);
+    (2) peer-fence logging in `daemon_ha_sync.go` now logs a neutral
+    receive message before the nil-dataplane guard and emits
+    "disabling all RGs" only when deactivation will actually run;
+    (3) plan status header in
+    `docs/pr/1527-dpdk-boot-decouple/plan.md` corrected from v3 to v4.
+    Ran focused package tests for dataplane/config/daemon.
+  - **File(s)**: `pkg/config/compiler_system.go`,
+    `pkg/daemon/daemon_ha_sync.go`,
+    `docs/pr/1527-dpdk-boot-decouple/plan.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-25T06:50:00Z
   - **Action**: #1527 reviewer re-dispatch on 878bcbdd after my
     earlier v3 NPE-fix commit landed. Codex hostile re-review

--- a/_Log.md
+++ b/_Log.md
@@ -13,6 +13,23 @@
     Chain A (#1526) and Chain C (#1528/#1529) lanes clean.
   - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
 
+- **Timestamp**: 2026-05-24T18:30:00Z
+  - **Action**: #1527 plan v2 — incorporated Codex hostile plan
+    review (task-mpkqsgf5-j2yag1, PLAN-NEEDS-MINOR). Three MUST-FIX
+    items applied: (1) require Chain A #1526 to land BEFORE this PR
+    (was "either order works" — Codex showed today's UX is
+    config-only fallback with slog.Warn but this PR makes the same
+    config fatal at startup); (2) dropped Change 5 docs edit — the
+    required canary tokens are already present in
+    docs/pr/1373-retire-ebpf-dataplane/README.md, so docs prose is
+    Chain C #1529 scope only; (3) acknowledged that
+    ErrDPDKBackendRetired cannot be used by pkg/config (Chain A)
+    due to dataplane->config import cycle. Also corrected
+    errDPDKBuildTagRequired claim (it's !dpdk-gated, not a
+    defense-in-depth for -tags dpdk). Antigravity PLAN-READY
+    (adversarial-review-mpkqkzkm-qfa19j) verdict preserved.
+  - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
+
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested

--- a/_Log.md
+++ b/_Log.md
@@ -45,6 +45,24 @@
     `go test ./pkg/dataplane/... ./pkg/daemon/...` clean.
   - **File(s)**: `pkg/daemon/daemon_run.go`
 
+- **Timestamp**: 2026-05-25T06:30:00Z
+  - **Action**: #1527 second Copilot review pass — addressed MUST FIX
+    and SHOULD FIX items from prior adversarial review: (1) Added
+    TypeDPDK panic guard to RegisterBackend and RegisterRuntimeBackend
+    so silent re-registration is immediately visible rather than
+    permanently silently unreachable. (2) Added
+    TestRegisterDPDKBackendPanics to dpdk_stub_test.go to pin the
+    panic behavior. (3) Cleaned stale DPDK references from DataPlane
+    interface docstrings (lines 185-186, 338, 341-343, 347, 381-382,
+    386). (4) Fixed compiler_system.go error string to say "valid:
+    ebpf, userspace" instead of "valid: ebpf, dpdk, userspace".
+    Build clean, go test ./pkg/dataplane/... ./pkg/daemon/...
+    ./pkg/config/... clean.
+  - **File(s)**: `pkg/dataplane/dataplane.go`,
+    `pkg/dataplane/dpdk/dpdk_stub_test.go`,
+    `pkg/config/compiler_system.go`, `_Log.md`
+
+
 ## 2026-05-24
 
 - **Timestamp**: 2026-05-24T12:00:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,27 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T06:50:00Z
+  - **Action**: #1527 reviewer re-dispatch on 878bcbdd after my
+    earlier v3 NPE-fix commit landed. Codex hostile re-review
+    (task-mpks5yrq-4h7ia5) and Antigravity adversarial re-review
+    (adversarial-review-mpks62um-g47sg4) dispatched with explicit
+    context that the OnFenceReceived NPE is now guarded at
+    daemon_ha_sync.go:676-679, and that stale docs prose is
+    intentionally deferred to Chain C #1529 — the canary test still
+    passes because every pinned token still exists in the README.
+    Copilot re-triggered via @copilot review (issue-comment
+    4531855093). Ran the full smoke matrix on the loss userspace
+    cluster after make cluster-deploy: Pass A (CoS-off) v4 push 8.81
+    Gb/s / v6 push 8.75 Gb/s / v4 reverse 8.65 Gb/s / v6 reverse 8.87
+    Gb/s / -P 12 -R v4 23.0 Gb/s / v6 22.6 Gb/s, all zero-retrans;
+    Pass B (CoS-on) 24-cell per-class matrix all shaped correctly on
+    push (100m→83/82 Mb/s, 1g→844/832 Mb/s, ..., 12g→6.54/6.37 Gb/s)
+    and reverse unshaped 7.4-8.2 Gb/s. Reviewer-ids recorded in
+    docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md. Smoke posted as
+    PR comment 4531859958.
+  - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md`
+
 - **Timestamp**: 2026-05-25T06:40:00Z
   - **Action**: #1527 v4 — Codex hostile code review v3
     (task-mpkrwbtk-pd6nnw MERGE-NEEDS-MAJOR) and Antigravity

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,31 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T06:40:00Z
+  - **Action**: #1527 v4 — Codex hostile code review v3
+    (task-mpkrwbtk-pd6nnw MERGE-NEEDS-MAJOR) and Antigravity
+    adversarial review v3 (adversarial-review-mpkrwmkk-2k24v4
+    MAJOR) both independently caught a nil-pointer crash exposed
+    by the v3 soft-fallback: `pkg/daemon/daemon_ha_sync.go:670`
+    `OnFenceReceived` callback unconditionally called
+    `d.dp.HA().SetRGActive(...)`. With `d.dp = nil` after the
+    `ErrDPDKBackendRetired` soft-fallback, the next peer-fence
+    message would panic the daemon. Pre-existing latent bug
+    (also reachable via Start() failure) but newly exposed by
+    v3's more-reachable nil-dp path. Added a `d.dp == nil`
+    early-return with structured log explaining the
+    config-only-mode rationale. Codex v3 also flagged that
+    `docs/pr/1373-retire-ebpf-dataplane/README.md` lines 64 and
+    85 contain factually stale claims about `cmd/xpfd/main.go`
+    keeping the DPDK blank import. The pinned canary tokens
+    still pass literally, but the prose now describes a
+    pre-#1527 reality. Intentionally left untouched per the
+    Chain C (#1529) scope boundary; flagged in plan v4 + PR
+    description as a Chain C TODO. Build clean, full Go test
+    suite clean.
+  - **File(s)**: `pkg/daemon/daemon_ha_sync.go`,
+    `docs/pr/1527-dpdk-boot-decouple/plan.md`
+
 - **Timestamp**: 2026-05-25T06:00:00Z
   - **Action**: #1527 Copilot review response — Copilot flagged on
     `47a4278c` that returning `ErrDPDKBackendRetired` at construction

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,25 @@
 # Action Log
 
+## 2026-05-25
+
+- **Timestamp**: 2026-05-25T06:00:00Z
+  - **Action**: #1527 Copilot review response — Copilot flagged on
+    `47a4278c` that returning `ErrDPDKBackendRetired` at construction
+    time in `NewRuntimeDataPlane` is now fatal in
+    `pkg/daemon/daemon_run.go` (the "create dataplane" error path
+    exits the daemon), whereas a `Start()` failure falls back to
+    config-only mode with a warning. Nodes that still have a
+    persisted `set system dataplane-type dpdk` would be bricked on
+    restart even before Chain A (#1526) blocks the commit. Addressed
+    by special-casing `errors.Is(err, ErrDPDKBackendRetired)` in
+    `daemon_run.go`: log a structured warning with remediation
+    guidance, set `d.dp = nil`, and fall through to config-only mode
+    (same posture as a `Start()` failure). The hard fatal branch is
+    preserved for genuinely unknown dataplane types. No new imports
+    needed (`errors` already imported). Build clean,
+    `go test ./pkg/dataplane/... ./pkg/daemon/...` clean.
+  - **File(s)**: `pkg/daemon/daemon_run.go`
+
 ## 2026-05-24
 
 - **Timestamp**: 2026-05-24T12:00:00Z

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,15 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T07:05:00Z
+  - **Action**: #1527 follow-up re-review fix — corrected
+    `NewDataPlane` unknown-type guidance in `pkg/dataplane/dataplane.go`
+    to stop advertising `userspace` as a valid legacy `DataPlane` type.
+    `userspace` is runtime-only through `NewRuntimeDataPlane`, so the old
+    message was misleading during operator/debug triage.
+    Baseline + post-change dataplane tests run clean.
+  - **File(s)**: `pkg/dataplane/dataplane.go`, `_Log.md`
+
 - **Timestamp**: 2026-05-25T05:55:15Z
   - **Action**: #1527 final Copilot re-review follow-up — resolved three
     remaining consistency nits from the latest Copilot inline pass:

--- a/_Log.md
+++ b/_Log.md
@@ -30,6 +30,38 @@
     (adversarial-review-mpkqkzkm-qfa19j) verdict preserved.
   - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
 
+- **Timestamp**: 2026-05-24T19:00:00Z
+  - **Action**: #1527 implementation. Removed the
+    `_ "github.com/psaab/xpf/pkg/dataplane/dpdk"` blank import
+    from cmd/xpfd/main.go. Deleted the init() block in
+    pkg/dataplane/dpdk/manager.go that registered the backend with
+    both dataplane.RegisterBackend and
+    dataplane.RegisterRuntimeBackend; replaced it with a comment
+    pointing at #1527/#1525/#1528. Added exported sentinel
+    `dataplane.ErrDPDKBackendRetired` in pkg/dataplane/dataplane.go
+    plus TypeDPDK reject arms in NewDataPlane (errors before the
+    registry fallback) and NewRuntimeDataPlane (errors after
+    EffectiveType normalization so the empty-default path stays
+    on userspace). Removed "dpdk" from the NewDataPlane
+    unknown-type error message. Shrunk dpdkBackendImportAllowlist
+    to an empty map and removed the cmd/xpfd/main.go DPDK
+    exemption from
+    TestOperatorPackagesDoNotImportBPFArtifactsDirectly. Rewrote
+    dpdk_stub_test.go's TestDPDKConstructorsRemainRegistered as
+    TestDPDKConstructorsReturnRetirementError, asserting
+    errors.Is(err, ErrDPDKBackendRetired) for both factories;
+    TestDPDKStubRequiresDPDKBuildTag retained unchanged. Per Codex
+    round-1 MUST-FIX (3): docs/pr/1373-retire-ebpf-dataplane/README.md
+    NOT touched — Chain C (#1529) scope, and the docs-token canary
+    stays green untouched. Updated legacyDataplaneImportAllowlist
+    description for cmd/xpfd/main.go to reflect post-#1527 reality
+    (cleanup only, no registration).
+  - **File(s)**: `cmd/xpfd/main.go`,
+    `pkg/dataplane/dpdk/manager.go`,
+    `pkg/dataplane/dataplane.go`,
+    `pkg/dataplane/retirement_boundary_canary_test.go`,
+    `pkg/dataplane/dpdk/dpdk_stub_test.go`
+
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,17 @@
 
 ## 2026-05-24
 
+- **Timestamp**: 2026-05-24T12:00:00Z
+  - **Action**: #1527 DPDK retirement Phase 2 (boot-path decouple) —
+    drafted plan v1 covering blank-import removal, init()
+    registration deletion, retirement-error returns from
+    NewDataPlane / NewRuntimeDataPlane factories, canary allowlist
+    shrink, Phase-1373 README DPDK-policy prose update, and
+    package-local test rewrite. Plan includes 8 open questions for
+    adversarial review and explicit out-of-scope list to keep
+    Chain A (#1526) and Chain C (#1528/#1529) lanes clean.
+  - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
+
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested

--- a/cmd/xpfd/main.go
+++ b/cmd/xpfd/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/psaab/xpf/pkg/daemon"
 	"github.com/psaab/xpf/pkg/dataplane"
-	_ "github.com/psaab/xpf/pkg/dataplane/dpdk"
 	_ "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/frr"
 )

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-v3 — IMPLEMENTATION COMPLETE.
+v4 — IMPLEMENTATION COMPLETE.
 
 v1 → v2 (Codex plan review task-mpkqsgf5-j2yag1, PLAN-NEEDS-MINOR):
 1. Require Chain A (#1526) to land BEFORE this PR (sequencing

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -27,10 +27,29 @@ v2 → v3 (Copilot inline review on PR #1535):
 5. Clean up stale plan v1 prose still referencing docs edits and
    token-list trims (Codex code review task-mpkrohgl-dow3kd).
 
+v3 → v4 (Codex + Antigravity hostile code reviews on a00d9111):
+6. Fix nil-pointer panic in `daemon_ha_sync.go::OnFenceReceived`.
+   The v3 soft-fallback path sets `d.dp = nil` but the peer-fence
+   callback at line 670 unconditionally called `d.dp.HA().SetRGActive(...)`.
+   A clustered node booted into config-only mode would panic on
+   the next peer fence (heartbeat-timeout-driven). Added a
+   `d.dp == nil` early-return with structured log.
+7. Acknowledge the docs-prose drift Codex v3 flagged.  After this
+   PR, `docs/pr/1373-retire-ebpf-dataplane/README.md` lines 64
+   and 85 contain factually stale claims about
+   `cmd/xpfd/main.go` keeping the DPDK blank import. The pinned
+   canary tokens still pass (the literal tokens remain in the
+   file), but the prose now describes a pre-#1527 reality. This
+   PR intentionally leaves docs untouched per Chain C (#1529)
+   scope boundary. The PR description and this plan flag the
+   drift as a Chain C TODO.
+
 Earlier verdicts preserved:
 - Antigravity plan review: adversarial-review-mpkqkzkm-qfa19j → PLAN-READY.
 - Codex plan review: task-mpkqsgf5-j2yag1 → PLAN-NEEDS-MINOR (resolved in v2).
 - Codex code review v2: task-mpkrohgl-dow3kd → MERGE-NEEDS-MINOR (resolved in v3).
+- Codex code review v3: task-mpkrwbtk-pd6nnw → MERGE-NEEDS-MAJOR (NPE + docs drift; NPE resolved in v4, docs drift acknowledged out-of-scope).
+- Antigravity code review v3: adversarial-review-mpkrwmkk-2k24v4 → MERGE-NEEDS-MAJOR (same NPE; resolved in v4).
 
 ## Issue framing
 

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -1,0 +1,381 @@
+# #1527 — DPDK retirement Phase 2: boot-path decouple and registration removal
+
+## Status
+
+DRAFT v1 — pending adversarial plan review.
+
+## Issue framing
+
+Umbrella #1525 retires the DPDK dataplane backend in a staged
+sequence (reject-at-commit → boot-path decouple → mechanical source
+removal → docs sweep → final validation).
+
+This issue (#1527) is **Phase 2**: stop the xpfd binary from pulling
+`pkg/dataplane/dpdk` into its boot path, stop the package from
+registering itself as a backend factory, and shrink the retirement-
+boundary canary so the import is forbidden everywhere outside the
+DPDK package itself. The DPDK source tree (`dpdk_worker/` and
+`pkg/dataplane/dpdk/`) stays in place for Phase 3 (#1528) to delete
+mechanically. After this PR, the package compiles but nothing in the
+production binary references it, so its deletion is a pure no-link
+file removal.
+
+The user-facing commit-time rejection for `system dataplane-type
+dpdk` is sibling Chain A (#1526). This PR assumes Phase 1 either
+lands first or is independent enough that the runtime "DPDK backend
+retired" error here covers the post-#1527, pre-#1526 window if Chain
+A is still in flight.
+
+## Honest scope/value framing
+
+This PR's value is purely **link-time** and **canary-discipline**:
+
+- Removes one blank import (`cmd/xpfd/main.go:15`).
+- Removes two `init()` registrations (`pkg/dataplane/dpdk/manager.go:18-25`).
+- Shrinks one canary allowlist entry (`dpdkBackendImportAllowlist`
+  in `pkg/dataplane/retirement_boundary_canary_test.go:71-73`).
+- Adds a structured `errDPDKBackendRetired` return from
+  `NewDataPlane(TypeDPDK)` / `NewRuntimeDataPlane(TypeDPDK)` so any
+  remaining call site (there are none in production now, only the
+  package-local test) sees a clear retirement error rather than the
+  generic "unknown dataplane type" message.
+
+The runtime payoff is:
+
+1. The default `make build` no longer link-edits `pkg/dataplane/dpdk`,
+   `pkg/dataplane/dpdk` no longer self-registers, and the boundary
+   canary forbids any other production package re-introducing the
+   import.
+2. Phase 3 (#1528) can delete `dpdk_worker/` and `pkg/dataplane/dpdk/`
+   without dangling imports.
+3. The canary's purpose was to *sanction* the boot-path import. With
+   the import gone, the sanction must go too — otherwise the canary
+   silently allows a future regression to re-add it.
+
+If reviewers conclude the perf gain is too small to justify the
+churn, PLAN-KILL is an acceptable verdict. (For this PR there is no
+perf claim — the value is discipline gate, not throughput.)
+
+## What's already shipped / partially batched
+
+- The `errDPDKBuildTagRequired` startup error
+  (`pkg/dataplane/dpdk/dpdk_stub.go:17`) already prevents a non-
+  `-tags dpdk` build from running DPDK at runtime. With this PR's
+  changes, that error path is unreachable from the boot path (no
+  registration) but stays in place as defense-in-depth for the
+  `-tags dpdk` build path.
+- The retirement-boundary canary
+  (`pkg/dataplane/retirement_boundary_canary_test.go`) already
+  enforces the *narrow* policy that only `cmd/xpfd/main.go` may
+  import the DPDK package. This PR shrinks that to "no production
+  package may import the DPDK package."
+- The `pkg/dataplane/runtime/import_canary_test.go` already forbids
+  the runtime package from importing DPDK. No change required.
+- Sibling Chain A (#1526) is preparing the user-facing commit-time
+  rejection in `pkg/config/compiler.go validDataplaneType()`. This
+  PR does **not** touch config validation; it touches only the
+  Go boot path.
+
+## Concrete design
+
+### Change 1 — Remove blank import in `cmd/xpfd/main.go`
+
+```diff
+ import (
+ 	"context"
+ 	"flag"
+ 	"fmt"
+ 	"log/slog"
+ 	"os"
+
+ 	"github.com/psaab/xpf/pkg/daemon"
+ 	"github.com/psaab/xpf/pkg/dataplane"
+-	_ "github.com/psaab/xpf/pkg/dataplane/dpdk"
+ 	_ "github.com/psaab/xpf/pkg/dataplane/userspace"
+ 	"github.com/psaab/xpf/pkg/frr"
+ )
+```
+
+### Change 2 — Drop backend registration in `pkg/dataplane/dpdk/manager.go`
+
+```diff
+ // Compile-time assertion.
+ var _ dataplane.DataPlane = (*Manager)(nil)
+ var _ dataplane.ConfigSink = (*Manager)(nil)
+ var _ dataplane.RuntimeDataPlane = (*Manager)(nil)
+
+-func init() {
+-	dataplane.RegisterBackend(dataplane.TypeDPDK, func() dataplane.DataPlane {
+-		return New()
+-	})
+-	dataplane.RegisterRuntimeBackend(dataplane.TypeDPDK, func() dataplane.RuntimeDataPlane {
+-		return New()
+-	})
+-}
+```
+
+The compile-time interface assertions stay so that the package
+keeps building cleanly even though nothing uses it.
+
+### Change 3 — Make `NewDataPlane(TypeDPDK)` / `NewRuntimeDataPlane(TypeDPDK)` return a retirement error
+
+In `pkg/dataplane/dataplane.go`, before the registry fallback,
+return a structured retirement error:
+
+```go
+// ErrDPDKBackendRetired is returned from NewDataPlane and
+// NewRuntimeDataPlane when caller code still asks for the DPDK
+// backend after Phase 2 of #1525.
+var ErrDPDKBackendRetired = errors.New(
+    "DPDK dataplane backend has been retired; use 'set system " +
+    "dataplane-type userspace' (see #1525)")
+```
+
+Both factory functions check `dpType == TypeDPDK` early and return
+`ErrDPDKBackendRetired`. `TypeDPDK` stays as a string constant so
+the runtime path can detect it; the constant's docstring is updated
+to mark it as a retired sentinel.
+
+The `NewDataPlane` error message updates to remove `dpdk` from the
+"valid: ..." list:
+
+```diff
+-		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, dpdk, userspace)", dpType)
++		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, userspace)", dpType)
+```
+
+### Change 4 — Shrink the canary allowlist
+
+```diff
+-var dpdkBackendImportAllowlist = map[string]string{
+-	"cmd/xpfd/main.go": "backend registration and cleanup entry point",
+-}
++// dpdkBackendImportAllowlist is intentionally empty after Phase 2 of
++// #1525.  The DPDK package may still exist in tree but no production
++// package outside it may import it.  Phase 3 (#1528) removes the
++// package entirely.
++var dpdkBackendImportAllowlist = map[string]string{}
+```
+
+`TestDPDKBackendImportStaysBackendLocal` is rewritten so that *any*
+import of `pkg/dataplane/dpdk` from outside `pkg/dataplane/dpdk/`
+is a violation. The test still ignores files under
+`pkg/dataplane/dpdk/` itself. The "stale allowlist entry" logic
+collapses to a non-issue because the map is empty.
+
+`TestOperatorPackagesDoNotImportBPFArtifactsDirectly`
+(line 137-159) currently allows `cmd/xpfd/main.go` to import DPDK.
+That exemption is removed (the import is gone).
+
+### Change 5 — Update Phase-1373 README DPDK policy section
+
+The retirement-boundary docs at
+`docs/pr/1373-retire-ebpf-dataplane/README.md` contain a `#1475
+DPDK Backend Policy` section whose tokens are pinned by
+`TestRetirementBoundaryDocsMentionDPDKPolicy`. Update the prose so
+the canary still passes while reflecting Phase 2 reality:
+
+- "DPDK remains a separately supported backend" → "DPDK backend
+  registration has been retired (#1527 / #1525); the package is
+  unreferenced and Phase 3 (#1528) will delete it."
+- Drop the "blank DPDK import in `cmd/xpfd/main.go`" sentence.
+- Keep the `-tags dpdk` token and `root DataPlane` mention (still
+  enforced by the canary).
+
+Update the canary's required tokens to match. The required token
+list at lines 832-839 of the canary test is hand-curated; this PR
+trims it to the tokens that still describe accurate post-#1527
+policy.
+
+### Change 6 — Adjust the DPDK package-local test
+
+`pkg/dataplane/dpdk/dpdk_stub_test.go` lines 13-29 currently
+exercises the registration path with
+`dataplane.NewDataPlane(dataplane.TypeDPDK)`. After this PR the
+registration is gone and the factory returns
+`ErrDPDKBackendRetired`. The test is rewritten as
+`TestDPDKConstructorsReturnRetirementError` and asserts the error
+is `ErrDPDKBackendRetired`. The stub-build-tag test
+`TestDPDKStubRequiresDPDKBuildTag` stays unchanged — `m := New()`
+still exercises the stub directly without going through the
+registry.
+
+## Public API preservation
+
+- `pkg/dataplane.DataPlane` interface — unchanged.
+- `pkg/dataplane.RuntimeDataPlane` interface — unchanged.
+- `pkg/dataplane.NewDataPlane(string)` signature — unchanged; the
+  error return shape changes for the DPDK case.
+- `pkg/dataplane.NewRuntimeDataPlane(string)` signature — unchanged;
+  same.
+- `pkg/dataplane.TypeDPDK` constant — preserved (so #1526's
+  commit-time rejection path can reference it if it wants a typed
+  sentinel; otherwise the constant's only consumer is the
+  retirement error path here).
+- `pkg/dataplane/dpdk.Manager` type — unchanged; still compiles.
+- `pkg/dataplane/dpdk.New()` constructor — unchanged; still
+  callable but no longer registered.
+- `errDPDKBuildTagRequired` — unchanged; still the stub's runtime
+  error.
+
+## Hidden invariants the change must preserve
+
+1. **No production code path can construct a DPDK Manager.** After
+   this PR, the only way to get a `*dpdk.Manager` is to call
+   `pkg/dataplane/dpdk.New()` directly. No production package
+   outside `pkg/dataplane/dpdk/` is allowed to import it. The
+   canary enforces this.
+
+2. **Canary tests stay green.** `TestDPDKBackendImportStaysBackendLocal`
+   gets stricter (empty allowlist) but must still pass on this PR's
+   tree. `TestOperatorPackagesDoNotImportBPFArtifactsDirectly`
+   loses one exemption and must still pass.
+   `TestRetirementBoundaryDocsMentionDPDKPolicy` requires the docs
+   text edits to keep the right tokens present.
+
+3. **`-tags dpdk` build path still works as a no-op-from-boot.**
+   Even with `-tags dpdk`, removing the blank import means the
+   `init()` registration never runs (since this PR also deletes
+   the `init()`). That's intentional. A `-tags dpdk` build today
+   would compile but the daemon would still reject DPDK selection
+   via the Phase 1 commit-time rejection (Chain A) and via
+   `ErrDPDKBackendRetired` from the factory.
+
+4. **Test-side import of DPDK is still allowed.** The boundary
+   canary scans production Go files only (`*.go` excluding
+   `*_test.go`), per `productionGoFilesUnder()` at line 1591.
+   That means `dpdk_stub_test.go` can still call
+   `dataplane.NewDataPlane(dataplane.TypeDPDK)` to verify the
+   retirement error.
+
+5. **Runtime canary stays green.**
+   `pkg/dataplane/runtime/import_canary_test.go` already forbids
+   runtime from importing DPDK. No change.
+
+6. **Phase 3 (#1528) blast radius shrinks but does not grow.**
+   This PR does not delete any DPDK source. It only changes one
+   `init()` and removes one import. Phase 3's manifest can stay
+   exactly as planned.
+
+## Risk assessment
+
+| Class | Risk | Why |
+|---|---|---|
+| Behavioral regression | LOW | The default build never registered DPDK as a backend that could actually run packets (the stub always returned `errDPDKBuildTagRequired`). Removing the registration just means the rejection happens earlier (at factory call) rather than at `Load()`. |
+| Lifetime / borrow-checker (Go) | NONE | This is Go, not Rust. No lifetime concerns. No new goroutines, channels, or state. |
+| Performance regression | NONE | Pure link-time change. No hot-path code touched. |
+| Architectural mismatch | LOW | Same shape as #1473 retirement Phase 1 — shrink canary allowlist, remove registration, leave package compilable for later deletion. |
+| Canary drift | MED | The canary tests are fiddly. The `stale allowlist entry` branch of `TestDPDKBackendImportStaysBackendLocal` triggers if the map empties without the test logic understanding that empty-is-OK. The plan accounts for that by reading the test code, not just the allowlist. |
+| Docs-token canary drift | MED | `TestRetirementBoundaryDocsMentionDPDKPolicy` pins 7 token strings. The plan touches that prose and must keep the canary-required tokens present (or update the canary token list in lockstep). |
+| #1526 ordering | LOW-MED | If #1526 (commit-time rejection) lands after this PR, there is a window where the daemon accepts `system dataplane-type dpdk` at commit but rejects it at runtime via `ErrDPDKBackendRetired`. The error message is the same as Chain A's, so operator UX is acceptable. If #1526 lands first, this PR has no effect on the commit path. |
+
+## Test plan
+
+### Build / unit
+- `go build ./...` from worktree root — clean.
+- `go build -tags dpdk ./...` — clean (with `-tags dpdk` ldflags
+  fixed at link).
+- `go test ./pkg/dataplane/...` — full canary + unit test pass.
+- `go test ./...` from worktree root — all 30 Go packages pass.
+- `cargo build` and `cargo test --release` from `userspace-dp/` —
+  Rust side is untouched but smoke gates require it green.
+
+### Cluster smoke (loss userspace cluster)
+
+Standard skill matrix:
+
+- Pass A (CoS-off): 4 single-stream baselines + 2 multi-stream
+  reverse reproducers = 6 measurements.
+- Pass B (CoS-on): per-class 5201-5206 × v4/v6 × push/reverse = 24
+  measurements.
+
+Total: 30 measurements per the skill's discipline. Required:
+0 retrans for unshaped, shaped classes hit configured rate.
+
+### Verification of canary
+
+- `go test -run 'TestDPDKBackendImportStaysBackendLocal' ./pkg/dataplane/`
+  — passes with empty allowlist.
+- Manually re-add the import to a throwaway test file: canary
+  fails with "unexpected imports".
+- `go test -run 'TestOperatorPackagesDoNotImportBPFArtifactsDirectly' ./pkg/dataplane/`
+  — passes (no DPDK production imports left).
+- `go test -run 'TestRetirementBoundaryDocsMentionDPDKPolicy' ./pkg/dataplane/`
+  — passes after docs edits + token-list trim.
+
+## Out of scope (explicitly)
+
+- **Deletion of `dpdk_worker/`, `pkg/dataplane/dpdk/`, Makefile
+  targets, and `DPDKConfig` schema** — Phase 3 (#1528).
+- **Commit-time rejection of `system dataplane-type dpdk`** —
+  Chain A (#1526).
+- **Docs sweep across README.md, CLAUDE.md, `docs/feature-gaps.md`,
+  etc.** — Chain C wave 2 (#1529).
+- **Removing the `dpdkEBPFImportAllowlist`** — Phase 3 (#1528),
+  since the file it points at (`pkg/dataplane/dpdk/manager.go`)
+  goes away.
+- **`TypeDPDK` constant deletion** — left to Chain C wave 2 once
+  no caller references it (this PR is the last production user of
+  it; the constant could in principle be deleted but doing so
+  ripples into `dpdk_stub_test.go` which Chain C will delete anyway).
+- **`-tags dpdk` build path full removal** — Chain C wave 2 when
+  the DPDK source goes.
+- **Any `pkg/config/types.go` `DPDKConfig` schema change** —
+  Chain A / Chain C.
+
+## Open questions for adversarial review
+
+1. **Should `TypeDPDK` be deleted now rather than preserved as a
+   sentinel?** Argument for delete: removes one more thing Chain C
+   has to sweep. Argument against: Chain A (#1526) might want a
+   typed sentinel in `validDataplaneType()` rather than a magic
+   string `"dpdk"`. Default plan: keep it, document it as retired.
+   PLAN-NEEDS-MAJOR if reviewer thinks it must go now.
+
+2. **Should `init()` be removed or kept as a no-op with a comment?**
+   Removed cleans up the file. Kept-as-no-op signals "this package
+   used to register itself; Phase 3 will delete the package." Default
+   plan: remove. Reviewer may push for keep-with-comment.
+
+3. **Is the canary docs-token edit too aggressive?** The docs
+   currently say "DPDK remains a separately supported backend." That
+   sentence is *no longer accurate* after this PR. The plan rewrites
+   it. Does the reviewer want a softer edit — e.g., "DPDK backend
+   registration has been retired pending Phase 3 deletion" — that
+   preserves more existing prose?
+
+4. **Should `NewRuntimeDataPlane(TypeDPDK)` short-circuit before the
+   `EffectiveType` rewrite?** Currently it normalizes empty→userspace
+   first, then dispatches. The plan adds a `dpType == TypeDPDK` check
+   after normalization. If empty config still defaults to userspace
+   (which it should), this is fine. But if a future caller passes
+   `TypeDPDK` directly, does the order of operations matter? Default
+   plan: check after `EffectiveType` so the empty-default path is
+   unaffected.
+
+5. **Does this PR need to land before or after #1526?** Plan says
+   "either order works." But if #1526 lands first and then this PR
+   lands, is there a window where the commit-time rejection passes
+   but a stale-import canary fires because Chain A added a typed
+   reference? Reviewer should verify the dependency graph.
+
+6. **The `-tags dpdk` build path: leave it as zombie code or
+   actively break it?** Removing the `init()` means `-tags dpdk`
+   builds still link the DPDK CGo code but the daemon won't invoke
+   it. Should this PR also gate the CGo code behind an additional
+   compile error to force Chain C to clean it up? Default plan: no
+   — leave it as dead code for Chain C to delete in one batch.
+
+7. **Is the package-local test `TestDPDKConstructorsReturnRetirementError`
+   actually exercising real behavior, or is it just a tautology?**
+   After this PR, the only consumer of `TypeDPDK` going through
+   `NewDataPlane` is that test. Without the test, the entire
+   retirement-error code path is unreached. The test prevents a
+   future maintainer from silently weakening the error to "unknown
+   dataplane type". That seems worth keeping; reviewer may disagree.
+
+8. **Should the retirement error be `errors.Is`-comparable or just a
+   formatted string?** Plan uses `errors.New` so callers can
+   `errors.Is(err, dataplane.ErrDPDKBackendRetired)`. If Chain A
+   (#1526) wants to wrap this at the config layer, sentinel-error
+   shape is the right choice.

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -2,10 +2,9 @@
 
 ## Status
 
-v2 — PLAN-READY after Antigravity PLAN-READY
-(adversarial-review-mpkqkzkm-qfa19j) and Codex PLAN-NEEDS-MINOR
-(task-mpkqsgf5-j2yag1). v2 incorporates the three MUST-FIX items:
+v3 — IMPLEMENTATION COMPLETE.
 
+v1 → v2 (Codex plan review task-mpkqsgf5-j2yag1, PLAN-NEEDS-MINOR):
 1. Require Chain A (#1526) to land BEFORE this PR (sequencing
    constraint, was previously "either order works").
 2. Drop Change 5 (docs edit) entirely. The required canary tokens
@@ -15,6 +14,23 @@ v2 — PLAN-READY after Antigravity PLAN-READY
    `pkg/config` for Chain A because `pkg/dataplane` already imports
    `pkg/config` (import cycle).  The sentinel is for runtime factory
    callers only.
+
+v2 → v3 (Copilot inline review on PR #1535):
+4. Soften the runtime-fatal behavior.  v2's `NewRuntimeDataPlane`
+   returning `ErrDPDKBackendRetired` would `os.Exit(1)` the daemon
+   on the next restart for any node that still had a persisted
+   `system dataplane-type dpdk` from before Chain A landed.  v3
+   adds an `errors.Is` branch in `pkg/daemon/daemon_run.go` that
+   treats this sentinel the same as a `Start()` failure: `slog.Warn`
+   plus config-only fallback.  Sequencing dependency on #1526 is
+   downgraded from HARD to STRONGLY PREFERRED.
+5. Clean up stale plan v1 prose still referencing docs edits and
+   token-list trims (Codex code review task-mpkrohgl-dow3kd).
+
+Earlier verdicts preserved:
+- Antigravity plan review: adversarial-review-mpkqkzkm-qfa19j → PLAN-READY.
+- Codex plan review: task-mpkqsgf5-j2yag1 → PLAN-NEEDS-MINOR (resolved in v2).
+- Codex code review v2: task-mpkrohgl-dow3kd → MERGE-NEEDS-MINOR (resolved in v3).
 
 ## Issue framing
 
@@ -302,8 +318,8 @@ registry.
 | Performance regression | NONE | Pure link-time change. No hot-path code touched. |
 | Architectural mismatch | LOW | Same shape as #1473 retirement Phase 1 — shrink canary allowlist, remove registration, leave package compilable for later deletion. |
 | Canary drift | MED | The canary tests are fiddly. The `stale allowlist entry` branch of `TestDPDKBackendImportStaysBackendLocal` triggers if the map empties without the test logic understanding that empty-is-OK. The plan accounts for that by reading the test code, not just the allowlist. |
-| Docs-token canary drift | MED | `TestRetirementBoundaryDocsMentionDPDKPolicy` pins 7 token strings. The plan touches that prose and must keep the canary-required tokens present (or update the canary token list in lockstep). |
-| #1526 ordering | HIGH if #1527 lands first | Today's daemon currently runs in config-only mode on `set system dataplane-type dpdk` (slog.Warn). After this PR, the same config kills the daemon at startup. **Therefore #1526 must land first** so the config never reaches the runtime in the first place. The sequencing is a HARD prerequisite, not a soft recommendation. |
+| Docs-token canary drift | NONE | `TestRetirementBoundaryDocsMentionDPDKPolicy` pins 7 token strings. This PR does NOT touch the docs prose at all — every required token already appears in `docs/pr/1373-retire-ebpf-dataplane/README.md` untouched. Chain C (#1529) will update the prose after Phase 3 deletion. |
+| #1526 ordering | LOW (mitigated in v3) | Plan v2 required #1526 first because today's daemon falls through to config-only on stub Start() failure but this PR made the same config fatal at constructor time. **v3 mitigates this in `pkg/daemon/daemon_run.go`**: `NewRuntimeDataPlane(...)` returning `ErrDPDKBackendRetired` is detected via `errors.Is` and treated the same as a `Start()` failure — `slog.Warn` plus config-only fallback. Operators with a persisted `system dataplane-type dpdk` get a clear remediation log and a running daemon rather than an `os.Exit(1)` loop. The sequencing dependency on Chain A is no longer hard; #1526 still strongly preferred because it gives the same operator UX at commit time instead of startup time. |
 
 ## Test plan
 
@@ -337,7 +353,9 @@ Total: 30 measurements per the skill's discipline. Required:
 - `go test -run 'TestOperatorPackagesDoNotImportBPFArtifactsDirectly' ./pkg/dataplane/`
   — passes (no DPDK production imports left).
 - `go test -run 'TestRetirementBoundaryDocsMentionDPDKPolicy' ./pkg/dataplane/`
-  — passes after docs edits + token-list trim.
+  — passes untouched (the required tokens already appear in
+  `docs/pr/1373-retire-ebpf-dataplane/README.md`; Chain C #1529
+  owns the docs prose sweep).
 
 ## Out of scope (explicitly)
 

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -68,29 +68,44 @@ production binary references it, so its deletion is a pure no-link
 file removal.
 
 The user-facing commit-time rejection for `system dataplane-type
-dpdk` is sibling Chain A (#1526). **This PR REQUIRES #1526 to land
-first.** Today's behavior on a running daemon that loads a config
-with `system dataplane-type dpdk` is:
+dpdk` is sibling Chain A (#1526). **Sequencing v4 (final): Chain A
+is STRONGLY PREFERRED but no longer required to land first.** v2
+of this plan required Chain A first; v3 added the
+`errors.Is(ErrDPDKBackendRetired)` soft-fallback at
+`pkg/daemon/daemon_run.go:247` so an operator with a persisted
+`set system dataplane-type dpdk` config sees a structured
+`slog.Warn` plus config-only fallback rather than `os.Exit(1)` on
+restart.
 
-- `dataplane.NewRuntimeDataPlane("dpdk")` succeeds (stub registers
-  the backend, `pkg/daemon/daemon_run.go:245`).
-- `d.dp.Start(ctx)` returns `errDPDKBuildTagRequired`, daemon logs
-  `slog.Warn("failed to start dataplane, running in config-only
-  mode")` and continues running (`daemon_run.go:251-254`).
+Today's behavior on a running daemon that loads a config with
+`system dataplane-type dpdk`:
 
-After this PR's changes:
+- Before this PR: `dataplane.NewRuntimeDataPlane("dpdk")` succeeds
+  (the DPDK stub self-registered via the now-removed `init()`
+  block), `d.dp.Start(ctx)` returns `errDPDKBuildTagRequired`,
+  daemon logs `slog.Warn("failed to start dataplane, running in
+  config-only mode")` and continues running.
+- After this PR: `dataplane.NewRuntimeDataPlane("dpdk")` returns
+  `ErrDPDKBackendRetired`. `pkg/daemon/daemon_run.go:247` detects
+  the sentinel via `errors.Is`, emits a structured `slog.Warn`
+  with remediation guidance (`use 'set system dataplane-type
+  userspace'`), sets `d.dp = nil`, and the daemon continues
+  running in config-only mode. Operator UX is the same as a
+  generic `Start()` failure.
 
-- `dataplane.NewRuntimeDataPlane("dpdk")` returns
-  `ErrDPDKBackendRetired`.
-- `daemon_run.go:248` returns `fmt.Errorf("create dataplane: %w",
-  err)`, daemon exits with `os.Exit(1)`.
+With Chain A landed first, the config never accepts `dpdk` at
+commit time and this PR's runtime sentinel becomes defense-in-
+depth for malformed-by-hand configs only. Without Chain A landed
+first, an operator's existing `set system dataplane-type dpdk`
+keeps the daemon reachable from the CLI / gRPC to fix the config
+in place.
 
-Without #1526 landing first, an operator who already committed
-`set system dataplane-type dpdk` on the running config would see
-their daemon refuse to start after the next restart. With #1526
-landed first, the config never accepts `dpdk` at commit time, so
-this PR's runtime path is only reachable via a malformed config
-file written by hand (which is acceptable as a fatal error).
+The compiler-side error string at
+`pkg/config/compiler_system.go:391` still lists `dpdk` as a known
+value (annotated `(retired in #1527)`) because `validDataplaneType`
+at `pkg/config/compiler.go:961` still accepts the token. That
+accept-and-defer is intentional: Chain A owns the commit-time
+rejection lockstep with the validator.
 
 ## Honest scope/value framing
 

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -164,21 +164,14 @@ perf claim — the value is discipline gate, not throughput.)
 
 ### Change 1 — Remove blank import in `cmd/xpfd/main.go`
 
-```diff
- import (
- 	"context"
- 	"flag"
- 	"fmt"
- 	"log/slog"
- 	"os"
+Delete line 15 of `cmd/xpfd/main.go`:
 
- 	"github.com/psaab/xpf/pkg/daemon"
- 	"github.com/psaab/xpf/pkg/dataplane"
--	_ "github.com/psaab/xpf/pkg/dataplane/dpdk"
- 	_ "github.com/psaab/xpf/pkg/dataplane/userspace"
- 	"github.com/psaab/xpf/pkg/frr"
- )
-```
+    _ "github.com/psaab/xpf/pkg/dataplane/dpdk"
+
+Leaves `_ "github.com/psaab/xpf/pkg/dataplane/userspace"` as the
+only blank backend-registration import. (Plain code snippet rather
+than a ```diff fence so the context lines don't carry a
+space-before-tab pattern that trips `git diff --check`.)
 
 ### Change 2 — Drop backend registration in `pkg/dataplane/dpdk/manager.go`
 

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -426,13 +426,21 @@ Total: 30 measurements per the skill's discipline. Required:
    plan: check after `EffectiveType` so the empty-default path is
    unaffected.
 
-5. **Does this PR need to land before or after #1526?** RESOLVED:
-   #1526 must land first. Codex plan review (task-mpkqsgf5-j2yag1)
-   correctly showed that today's behavior is `slog.Warn` + config-
-   only fallback, while this PR makes the same config fatal at
-   daemon startup. Without Chain A landing first, an existing
-   `system dataplane-type dpdk` config would kill the daemon on
-   next restart.
+5. **Does this PR need to land before or after #1526?** RESOLVED in
+   v4: #1526 is STRONGLY PREFERRED but NOT required.  v2 of this
+   plan required #1526 first because today's daemon falls through
+   to config-only mode on a stub `Start()` failure while this PR
+   originally made the same config fatal at daemon startup.  v3
+   added an `errors.Is(ErrDPDKBackendRetired)` soft-fallback to
+   `pkg/daemon/daemon_run.go:247` so the daemon now treats the
+   sentinel exactly like a `Start()` failure: structured
+   `slog.Warn` plus config-only fallback.  An operator with a
+   stale `system dataplane-type dpdk` config no longer hits an
+   `os.Exit(1)` loop on restart — the daemon stays up and is
+   reachable from the CLI / gRPC to edit the config in place.
+   With #1526 also landed, the runtime path is unreachable for
+   legitimate configs (commit-time rejection).  Without #1526 the
+   soft-fallback covers the gap.
 
 6. **The `-tags dpdk` build path: leave it as zombie code or
    actively break it?** Removing the `init()` means `-tags dpdk`

--- a/docs/pr/1527-dpdk-boot-decouple/plan.md
+++ b/docs/pr/1527-dpdk-boot-decouple/plan.md
@@ -2,7 +2,19 @@
 
 ## Status
 
-DRAFT v1 — pending adversarial plan review.
+v2 — PLAN-READY after Antigravity PLAN-READY
+(adversarial-review-mpkqkzkm-qfa19j) and Codex PLAN-NEEDS-MINOR
+(task-mpkqsgf5-j2yag1). v2 incorporates the three MUST-FIX items:
+
+1. Require Chain A (#1526) to land BEFORE this PR (sequencing
+   constraint, was previously "either order works").
+2. Drop Change 5 (docs edit) entirely. The required canary tokens
+   are already present in `docs/pr/1373-retire-ebpf-dataplane/README.md`
+   and Chain C (#1529) owns the docs sweep.
+3. Acknowledge that `ErrDPDKBackendRetired` cannot be re-used by
+   `pkg/config` for Chain A because `pkg/dataplane` already imports
+   `pkg/config` (import cycle).  The sentinel is for runtime factory
+   callers only.
 
 ## Issue framing
 
@@ -21,10 +33,29 @@ production binary references it, so its deletion is a pure no-link
 file removal.
 
 The user-facing commit-time rejection for `system dataplane-type
-dpdk` is sibling Chain A (#1526). This PR assumes Phase 1 either
-lands first or is independent enough that the runtime "DPDK backend
-retired" error here covers the post-#1527, pre-#1526 window if Chain
-A is still in flight.
+dpdk` is sibling Chain A (#1526). **This PR REQUIRES #1526 to land
+first.** Today's behavior on a running daemon that loads a config
+with `system dataplane-type dpdk` is:
+
+- `dataplane.NewRuntimeDataPlane("dpdk")` succeeds (stub registers
+  the backend, `pkg/daemon/daemon_run.go:245`).
+- `d.dp.Start(ctx)` returns `errDPDKBuildTagRequired`, daemon logs
+  `slog.Warn("failed to start dataplane, running in config-only
+  mode")` and continues running (`daemon_run.go:251-254`).
+
+After this PR's changes:
+
+- `dataplane.NewRuntimeDataPlane("dpdk")` returns
+  `ErrDPDKBackendRetired`.
+- `daemon_run.go:248` returns `fmt.Errorf("create dataplane: %w",
+  err)`, daemon exits with `os.Exit(1)`.
+
+Without #1526 landing first, an operator who already committed
+`set system dataplane-type dpdk` on the running config would see
+their daemon refuse to start after the next restart. With #1526
+landed first, the config never accepts `dpdk` at commit time, so
+this PR's runtime path is only reachable via a malformed config
+file written by hand (which is acceptable as a fatal error).
 
 ## Honest scope/value framing
 
@@ -59,11 +90,14 @@ perf claim — the value is discipline gate, not throughput.)
 ## What's already shipped / partially batched
 
 - The `errDPDKBuildTagRequired` startup error
-  (`pkg/dataplane/dpdk/dpdk_stub.go:17`) already prevents a non-
-  `-tags dpdk` build from running DPDK at runtime. With this PR's
-  changes, that error path is unreachable from the boot path (no
-  registration) but stays in place as defense-in-depth for the
-  `-tags dpdk` build path.
+  (`pkg/dataplane/dpdk/dpdk_stub.go:17`) is gated behind
+  `//go:build !dpdk` and only exists in non-`-tags dpdk` builds.
+  After this PR's changes, the boot path no longer registers the
+  DPDK backend at all (registration removed in both stub and
+  `-tags dpdk` builds, since `manager.go` has no build tag). The
+  package-local test `TestDPDKStubRequiresDPDKBuildTag` still
+  exercises this sentinel directly (no factory path needed), so
+  it stays in place until Phase 3 deletes the package.
 - The retirement-boundary canary
   (`pkg/dataplane/retirement_boundary_canary_test.go`) already
   enforces the *narrow* policy that only `cmd/xpfd/main.go` may
@@ -167,25 +201,23 @@ collapses to a non-issue because the map is empty.
 (line 137-159) currently allows `cmd/xpfd/main.go` to import DPDK.
 That exemption is removed (the import is gone).
 
-### Change 5 — Update Phase-1373 README DPDK policy section
+### Change 5 — REMOVED (Chain C scope)
 
-The retirement-boundary docs at
-`docs/pr/1373-retire-ebpf-dataplane/README.md` contain a `#1475
-DPDK Backend Policy` section whose tokens are pinned by
-`TestRetirementBoundaryDocsMentionDPDKPolicy`. Update the prose so
-the canary still passes while reflecting Phase 2 reality:
+The original plan v1 proposed editing
+`docs/pr/1373-retire-ebpf-dataplane/README.md`'s `#1475 DPDK
+Backend Policy` section. Codex round-1 plan review correctly
+flagged that this is Chain C (#1529) scope.
 
-- "DPDK remains a separately supported backend" → "DPDK backend
-  registration has been retired (#1527 / #1525); the package is
-  unreferenced and Phase 3 (#1528) will delete it."
-- Drop the "blank DPDK import in `cmd/xpfd/main.go`" sentence.
-- Keep the `-tags dpdk` token and `root DataPlane` mention (still
-  enforced by the canary).
-
-Update the canary's required tokens to match. The required token
-list at lines 832-839 of the canary test is hand-curated; this PR
-trims it to the tokens that still describe accurate post-#1527
-policy.
+The required canary tokens at
+`pkg/dataplane/retirement_boundary_canary_test.go:1780-1788`
+(`## #1475 DPDK Backend Policy`, `DPDK remains a separately
+supported backend`, `outside the eBPF source-removal path`,
+`` `pkg/dataplane/dpdk` ``, `` `cmd/xpfd/main.go` ``, `` `-tags
+dpdk` ``, `` root `DataPlane` ``) are all still present in the
+README untouched (verified by grep). The docs-token canary stays
+green without any edit in this PR. Chain C will update the prose
+to reflect the post-Phase-2 reality once Phase 3 (#1528) has
+deleted the package.
 
 ### Change 6 — Adjust the DPDK package-local test
 
@@ -208,10 +240,14 @@ registry.
   error return shape changes for the DPDK case.
 - `pkg/dataplane.NewRuntimeDataPlane(string)` signature — unchanged;
   same.
-- `pkg/dataplane.TypeDPDK` constant — preserved (so #1526's
-  commit-time rejection path can reference it if it wants a typed
-  sentinel; otherwise the constant's only consumer is the
-  retirement error path here).
+- `pkg/dataplane.TypeDPDK` constant — preserved. (Chain A
+  (#1526) cannot import `dataplane.ErrDPDKBackendRetired` from
+  `pkg/config/compiler.go` without creating an import cycle —
+  `pkg/dataplane/dataplane.go:9` already imports `pkg/config`.
+  Chain A will keep its own string literal or local sentinel.
+  The `TypeDPDK` constant is still useful as a typed token for
+  the retirement-error code path in `NewDataPlane` /
+  `NewRuntimeDataPlane`.)
 - `pkg/dataplane/dpdk.Manager` type — unchanged; still compiles.
 - `pkg/dataplane/dpdk.New()` constructor — unchanged; still
   callable but no longer registered.
@@ -267,7 +303,7 @@ registry.
 | Architectural mismatch | LOW | Same shape as #1473 retirement Phase 1 — shrink canary allowlist, remove registration, leave package compilable for later deletion. |
 | Canary drift | MED | The canary tests are fiddly. The `stale allowlist entry` branch of `TestDPDKBackendImportStaysBackendLocal` triggers if the map empties without the test logic understanding that empty-is-OK. The plan accounts for that by reading the test code, not just the allowlist. |
 | Docs-token canary drift | MED | `TestRetirementBoundaryDocsMentionDPDKPolicy` pins 7 token strings. The plan touches that prose and must keep the canary-required tokens present (or update the canary token list in lockstep). |
-| #1526 ordering | LOW-MED | If #1526 (commit-time rejection) lands after this PR, there is a window where the daemon accepts `system dataplane-type dpdk` at commit but rejects it at runtime via `ErrDPDKBackendRetired`. The error message is the same as Chain A's, so operator UX is acceptable. If #1526 lands first, this PR has no effect on the commit path. |
+| #1526 ordering | HIGH if #1527 lands first | Today's daemon currently runs in config-only mode on `set system dataplane-type dpdk` (slog.Warn). After this PR, the same config kills the daemon at startup. **Therefore #1526 must land first** so the config never reaches the runtime in the first place. The sequencing is a HARD prerequisite, not a soft recommendation. |
 
 ## Test plan
 
@@ -353,11 +389,13 @@ Total: 30 measurements per the skill's discipline. Required:
    plan: check after `EffectiveType` so the empty-default path is
    unaffected.
 
-5. **Does this PR need to land before or after #1526?** Plan says
-   "either order works." But if #1526 lands first and then this PR
-   lands, is there a window where the commit-time rejection passes
-   but a stale-import canary fires because Chain A added a typed
-   reference? Reviewer should verify the dependency graph.
+5. **Does this PR need to land before or after #1526?** RESOLVED:
+   #1526 must land first. Codex plan review (task-mpkqsgf5-j2yag1)
+   correctly showed that today's behavior is `slog.Warn` + config-
+   only fallback, while this PR makes the same config fatal at
+   daemon startup. Without Chain A landing first, an existing
+   `system dataplane-type dpdk` config would kill the daemon on
+   next restart.
 
 6. **The `-tags dpdk` build path: leave it as zombie code or
    actively break it?** Removing the `init()` means `-tags dpdk`

--- a/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
+++ b/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
@@ -1,0 +1,37 @@
+# Reviewer task / job IDs — PR #1535 (#1527 boot-path decouple)
+
+## Plan review (v2)
+
+- Codex plan review: `task-mpkqsgf5-j2yag1` — PLAN-NEEDS-MINOR (resolved in v2/v3)
+- Antigravity plan review: `adversarial-review-mpkqkzkm-qfa19j` — PLAN-READY
+
+## Code review — commit 47a4278c (original push)
+
+- Codex code review: `task-mpkrohgl-dow3kd` — MERGE-NEEDS-MINOR (sequencing + plan cleanup; resolved in v3 + a00d9111)
+- Copilot inline review on PR: posted 2026-05-25T05:32:08Z with 1 inline comment on `dataplane.go:155-164` (fatal-at-startup brick-restart concern). Addressed by `a00d9111`.
+
+## Code review — commit a00d9111 (force-push 2026-05-25)
+
+- Codex hostile code review: `task-mpkrwbtk-pd6nnw` — MAJOR
+  - (1) NPE on `OnFenceReceived` when `d.dp == nil` after soft-fallback
+  - (2) Stale docs prose at `docs/pr/1373-retire-ebpf-dataplane/README.md:66,85` (canary still passes)
+- Antigravity adversarial review: `adversarial-review-mpkrwmkk-2k24v4` — MAJOR
+  - Same NPE finding (independently identified)
+- Copilot: re-triggered (issue-comment 4531824507), original `47a4278c` review was already addressed by `a00d9111`
+
+## Code review — commit 878bcbdd (force-push 2026-05-25)
+
+Resolves Codex+Antigravity MAJOR (NPE on fence callback) via nil guard in
+`pkg/daemon/daemon_ha_sync.go:676-679`. Docs prose update deferred to Chain C
+(#1529) — canary `TestRetirementBoundaryDocsMentionDPDKPolicy` still PASS.
+
+- Codex re-review: `task-mpks5yrq-4h7ia5` — DISPATCHED
+- Antigravity re-review: `adversarial-review-mpks62um-g47sg4` — DISPATCHED
+- Copilot re-trigger: issue-comment 4531855093
+
+Verification scope (see prompt for full list): (a) blank-import removal completeness,
+(b) NewRuntimeDataPlane reject placement vs EffectiveType, (c) errors.Is wrapping
+chain, (d) empty allowlist canary behavior, (e) docs-token canary integrity,
+(f) build + tests without -tags dpdk, (g) daemon_run.go soft-fallback correctness
+(d.dp = nil safety, branch ordering), (h) scope-creep into #1528, (i) restart-race
+adversarial probe.

--- a/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
+++ b/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
@@ -66,3 +66,13 @@ chain, (d) empty allowlist canary behavior, (e) docs-token canary integrity,
 (f) build + tests without -tags dpdk, (g) daemon_run.go soft-fallback correctness
 (d.dp = nil safety, branch ordering), (h) scope-creep into #1528, (i) restart-race
 adversarial probe.
+
+## Cross-PR alignment round on SHA `51948aae`
+
+Aligns ErrDPDKBackendRetired wording with PR #1536's ErrDPDKDataplaneRetired
+("DPDK ..." → "the DPDK ...") per AGY adversarial-review-mpksyrj1-f1mid9
+finding against #1536.
+
+Codex: `task-mpktkfxm-vqe9xe`
+AGY: `adversarial-review-mpktkg6j-mlah42`
+Copilot: re-triggered in PR comment

--- a/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
+++ b/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
@@ -25,9 +25,21 @@ Resolves Codex+Antigravity MAJOR (NPE on fence callback) via nil guard in
 `pkg/daemon/daemon_ha_sync.go:676-679`. Docs prose update deferred to Chain C
 (#1529) — canary `TestRetirementBoundaryDocsMentionDPDKPolicy` still PASS.
 
-- Codex re-review: `task-mpks5yrq-4h7ia5` — DISPATCHED
-- Antigravity re-review: `adversarial-review-mpks62um-g47sg4` — DISPATCHED
+- Codex re-review: `task-mpks5yrq-4h7ia5` — MERGE-READY (1 NIT: structure the
+  nil-dp fence slog.Warn with kv fields; fixed in fe82ac74)
+- Antigravity re-review: `adversarial-review-mpks62um-g47sg4` — MERGE-READY
 - Copilot re-trigger: issue-comment 4531855093
+
+## Code review — commit fe82ac74 (force-push 2026-05-25)
+
+Includes the second-agent commits `e7f199f1` (panic guards on TypeDPDK
+registration + cleanup), `ee83e972` (allowlist comment refresh), `8c475d4a`
+(StartFIBSync stale ref fix), plus my `fe82ac74` (structured slog kv on
+nil-dp fence warning, addresses Codex NIT).
+
+- Codex re-re-review: `task-mpksgyz9-45ib7t` — DISPATCHED
+- Antigravity re-re-review: `adversarial-review-mpksh5km-1mf7rz` — DISPATCHED
+- Copilot re-trigger: issue-comment 4531892202
 
 Verification scope (see prompt for full list): (a) blank-import removal completeness,
 (b) NewRuntimeDataPlane reject placement vs EffectiveType, (c) errors.Is wrapping

--- a/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
+++ b/docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md
@@ -37,9 +37,28 @@ registration + cleanup), `ee83e972` (allowlist comment refresh), `8c475d4a`
 (StartFIBSync stale ref fix), plus my `fe82ac74` (structured slog kv on
 nil-dp fence warning, addresses Codex NIT).
 
-- Codex re-re-review: `task-mpksgyz9-45ib7t` — DISPATCHED
-- Antigravity re-re-review: `adversarial-review-mpksh5km-1mf7rz` — DISPATCHED
-- Copilot re-trigger: issue-comment 4531892202
+- Codex re-re-review: `task-mpksgyz9-45ib7t` — MERGE-READY with NIT
+  (stale FIB sync comment at `daemon_run.go:326`; fixed in `9b4e9e24`)
+- Antigravity re-re-review: `adversarial-review-mpksh5km-1mf7rz` — MERGE-READY
+- Copilot re-trigger: issue-comment 4531892202 → Copilot fresh review on `d5fa4838`
+  returned 3 inline findings (compiler_system error string, fence log ordering,
+  plan v3/v4 inconsistency); all 3 fixed in `9aa96c3e` + `dd959112`.
+
+## Parallel session reviews captured
+
+- Codex `task-mpksf0nq-eeuxc3` (other agent, on `ee83e972`): MERGE-NEEDS-MINOR.
+  Findings: (1) error string vs validator (fixed in `9aa96c3e`), (2) plan
+  sequencing inconsistency (fixed in `dd959112`), (3) plan whitespace NIT
+  (acknowledged out-of-scope).
+
+## Code review — commit dd959112 (final convergence)
+
+Final round addresses all 3 remaining Copilot inline findings on the prior
+SHA plus the Codex `task-mpksf0nq-eeuxc3` minor findings.
+
+- Codex final re-review: `task-mpksus16-sel08z` — DISPATCHED
+- Antigravity final re-review: `adversarial-review-mpksuwyo-tlgd91` — DISPATCHED
+- Copilot final re-trigger: issue-comment 4531937401
 
 Verification scope (see prompt for full list): (a) blank-import removal completeness,
 (b) NewRuntimeDataPlane reject placement vs EffectiveType, (c) errors.Is wrapping

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -379,7 +379,7 @@ func compileSystemDataplaneType(node *Node) (string, error) {
 		next := child.Keys[1]
 		if !validDataplaneType(next) {
 			return "", fmt.Errorf(
-				"unknown dataplane-type %q; dataplane-type %q is invalid; valid values are ebpf, userspace",
+				"unknown dataplane-type %q; dataplane-type %q is invalid; valid values are ebpf, dpdk, userspace",
 				next, next)
 		}
 		dpType = next

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -379,7 +379,7 @@ func compileSystemDataplaneType(node *Node) (string, error) {
 		next := child.Keys[1]
 		if !validDataplaneType(next) {
 			return "", fmt.Errorf(
-				"unknown dataplane-type %q; dataplane-type %q is invalid; valid values are ebpf, dpdk, userspace",
+				"unknown dataplane-type %q; dataplane-type %q is invalid; valid values are ebpf, userspace",
 				next, next)
 		}
 		dpType = next

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -664,7 +664,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// fence via sync; on receive, disable all local RGs.
 			d.cluster.SetPeerFenceFunc(d.sessionSync.SendFence)
 			d.sessionSync.OnFenceReceived = func() {
-				slog.Warn("cluster: fence received from peer, disabling all RGs")
+				slog.Warn("cluster: fence received from peer")
 				// Guard d.dp: the daemon can run in config-only mode
 				// (d.dp == nil) when the runtime dataplane factory rejects
 				// the configured backend — for example, a stale
@@ -681,6 +681,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					)
 					return
 				}
+				slog.Warn("cluster: fence received from peer, disabling all RGs")
 				if cfg.Chassis.Cluster != nil {
 					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
 						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -674,7 +674,11 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				// panic on a nil pointer dereference. The same applies to
 				// any future Start() failure that leaves d.dp == nil.
 				if d.dp == nil {
-					slog.Warn("cluster: fence: dataplane is nil (config-only mode); skipping RG deactivation")
+					slog.Warn("cluster: fence received but dataplane is nil; skipping RG deactivation",
+						"mode", "config-only",
+						"action", "skip_rg_deactivation",
+						"remediation", "set system dataplane-type userspace and restart xpfd",
+					)
 					return
 				}
 				if cfg.Chassis.Cluster != nil {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -681,8 +681,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					)
 					return
 				}
-				slog.Warn("cluster: fence received from peer, disabling all RGs")
 				if cfg.Chassis.Cluster != nil {
+					slog.Warn("cluster: fence: disabling all RGs",
+						"rg_count", len(cfg.Chassis.Cluster.RedundancyGroups))
 					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
 						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {
 							slog.Warn("cluster: fence: failed to disable rg_active",

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -665,6 +665,18 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFenceFunc(d.sessionSync.SendFence)
 			d.sessionSync.OnFenceReceived = func() {
 				slog.Warn("cluster: fence received from peer, disabling all RGs")
+				// Guard d.dp: the daemon can run in config-only mode
+				// (d.dp == nil) when the runtime dataplane factory rejects
+				// the configured backend — for example, a stale
+				// "system dataplane-type dpdk" config triggers
+				// dataplane.ErrDPDKBackendRetired and daemon_run.go falls
+				// back to nil dp. Without this guard a peer fence would
+				// panic on a nil pointer dereference. The same applies to
+				// any future Start() failure that leaves d.dp == nil.
+				if d.dp == nil {
+					slog.Warn("cluster: fence: dataplane is nil (config-only mode); skipping RG deactivation")
+					return
+				}
 				if cfg.Chassis.Cluster != nil {
 					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
 						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -256,7 +256,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// config from the CLI / gRPC. The hard fatal-at-
 			// startup branch is reserved for genuinely unknown
 			// dataplane types (the default branch below).
-			slog.Warn("DPDK dataplane backend has been retired; running in config-only mode until config is updated",
+			slog.Warn("the DPDK dataplane backend has been retired; running in config-only mode until config is updated",
 				"type", dpType,
 				"err", err,
 				"remediation", "set system dataplane-type userspace",

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -323,7 +323,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start background services if dataplane is loaded
 	var er *logging.EventReader
 	if d.dp != nil {
-		// Start FIB sync (DPDK: background route populator; eBPF: no-op)
+		// Start FIB sync (userspace: background route populator; eBPF: no-op).
+		// The DPDK reference was retired in #1527 (Phase 2).
 		if lp := d.legacyDP(); lp != nil {
 			lp.StartFIBSync(ctx)
 		}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -4,6 +4,7 @@ package daemon
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -243,23 +244,44 @@ func (d *Daemon) Run(ctx context.Context) error {
 			dpType = cfg.System.DataplaneType
 		}
 		dp, err := dataplane.NewRuntimeDataPlane(dpType)
-		if err != nil {
+		if errors.Is(err, dataplane.ErrDPDKBackendRetired) {
+			// #1527 Phase 2 of the DPDK retirement (umbrella
+			// #1525): the runtime DPDK backend is gone, but a
+			// node may still have "set system dataplane-type
+			// dpdk" persisted in the active config from before
+			// Chain A (#1526) blocked the commit. Treat this
+			// the same way as a Start() failure: log a warning
+			// and fall through to config-only mode so the
+			// daemon stays up and the operator can fix the
+			// config from the CLI / gRPC. The hard fatal-at-
+			// startup branch is reserved for genuinely unknown
+			// dataplane types (the default branch below).
+			slog.Warn("DPDK dataplane backend has been retired; running in config-only mode until config is updated",
+				"type", dpType,
+				"err", err,
+				"remediation", "set system dataplane-type userspace",
+			)
+			d.dp = nil
+		} else if err != nil {
 			slog.Error("failed to create dataplane", "type", dpType, "err", err)
 			return fmt.Errorf("create dataplane: %w", err)
-		}
-		d.dp = dp
-		if err := d.dp.Start(ctx); err != nil {
-			slog.Warn("failed to start dataplane, running in config-only mode",
-				"err", err)
-			d.dp = nil
 		} else {
-			if lp := d.legacyDP(); lp != nil {
-				lp.SeedNATPortCounters()
-				nodeID := 0
-				if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
-					nodeID = cfg.Chassis.Cluster.NodeID
+			d.dp = dp
+		}
+		if d.dp != nil {
+			if err := d.dp.Start(ctx); err != nil {
+				slog.Warn("failed to start dataplane, running in config-only mode",
+					"err", err)
+				d.dp = nil
+			} else {
+				if lp := d.legacyDP(); lp != nil {
+					lp.SeedNATPortCounters()
+					nodeID := 0
+					if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
+						nodeID = cfg.Chassis.Cluster.NodeID
+					}
+					lp.SeedSessionIDCounter(nodeID)
 				}
-				lp.SeedSessionIDCounter(nodeID)
 			}
 		}
 		// Apply current config — needed even in config-only mode so that

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -323,8 +323,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start background services if dataplane is loaded
 	var er *logging.EventReader
 	if d.dp != nil {
-		// Start FIB sync (userspace: background route populator; eBPF: no-op).
-		// The DPDK reference was retired in #1527 (Phase 2).
+		// StartFIBSync is a no-op on every in-tree backend: eBPF
+		// resolves FIB queries via bpf_fib_lookup in-kernel and the
+		// userspace AF_XDP runtime wraps that no-op through the
+		// legacy adapter.  Call site retained for backends that
+		// need a userspace route populator (DPDK had one; retired
+		// in #1527 / #1525).
 		if lp := d.legacyDP(); lp != nil {
 			lp.StartFIBSync(ctx)
 		}

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -109,18 +109,32 @@ func UserspaceTracePinPath() string {
 	return filepath.Join(bpfPinPath, "userspace_trace")
 }
 
-// backendRegistry holds constructors for non-eBPF dataplane backends.
-// Sub-packages register themselves via RegisterBackend in their init().
+// backendRegistry holds constructors for non-eBPF, non-DPDK dataplane
+// backends.  After the Phase 2 DPDK retirement (#1527, umbrella #1525)
+// userspace is the sole remaining registrant and it uses
+// RegisterRuntimeBackend, not RegisterBackend.  RegisterBackend remains
+// for forward-compatibility with hypothetical future backends.
 var backendRegistry = map[string]func() DataPlane{}
 var runtimeBackendRegistry = map[string]func() RuntimeDataPlane{}
 
 // RegisterBackend registers a dataplane constructor for the given type.
+// Panics if dpType is TypeDPDK: the DPDK backend was retired in Phase 2
+// of #1525 (#1527).  NewDataPlane intercepts TypeDPDK before consulting
+// the registry, so any registered DPDK constructor would be silently
+// unreachable; the panic makes the programming error immediately visible.
 func RegisterBackend(dpType string, ctor func() DataPlane) {
+	if dpType == TypeDPDK {
+		panic("TypeDPDK backend registration rejected: DPDK retired in #1527 (umbrella #1525)")
+	}
 	backendRegistry[dpType] = ctor
 }
 
 // RegisterRuntimeBackend registers a runtime-domain dataplane constructor.
+// Panics if dpType is TypeDPDK for the same reason as RegisterBackend.
 func RegisterRuntimeBackend(dpType string, ctor func() RuntimeDataPlane) {
+	if dpType == TypeDPDK {
+		panic("TypeDPDK runtime backend registration rejected: DPDK retired in #1527 (umbrella #1525)")
+	}
 	runtimeBackendRegistry[dpType] = ctor
 }
 
@@ -182,8 +196,8 @@ func NewRuntimeDataPlane(dpType string) (RuntimeDataPlane, error) {
 }
 
 // DataPlane defines the abstract interface for a packet-processing dataplane.
-// The eBPF Manager is the primary implementation; a DPDK implementation can
-// be added as an alternative backend.
+// The eBPF Manager is the legacy implementation; the userspace AF_XDP
+// backend is the primary/default target after Phase 2 of the DPDK retirement.
 type DataPlane interface {
 	// Lifecycle
 	Load() error
@@ -335,16 +349,16 @@ type DataPlane interface {
 
 	// FIB
 	BumpFIBGeneration() uint32
-	StartFIBSync(ctx context.Context) // DPDK: background route sync; eBPF: no-op
+	StartFIBSync(ctx context.Context) // DPDK: background route sync; eBPF/userspace: no-op
 
 	// NotifyLinkCycle signals that data-plane interfaces were taken DOWN/UP
 	// (e.g. during RETH MAC programming).  The userspace dataplane uses this
 	// to rebind AF_XDP sockets whose kernel-side RQ was destroyed by the
-	// link cycle.  No-op for the eBPF-only and DPDK dataplanes.
+	// link cycle.  No-op for the eBPF-only dataplane.
 	NotifyLinkCycle()
 
 	// SyncFabricState pushes updated fabric MACs to the userspace helper.
-	// No-op for eBPF-only and DPDK dataplanes.
+	// No-op for the eBPF-only dataplane.
 	SyncFabricState()
 
 	// Map statistics
@@ -378,12 +392,13 @@ type DataPlane interface {
 	// Event source for reading pipeline events (session open/close, deny, etc.)
 	NewEventSource() (EventSource, error)
 
-	// Raw map access (eBPF-specific; DPDK implementations may return nil)
+	// Raw map access (eBPF-specific; non-eBPF implementations return nil)
 	Map(name string) *ebpf.Map
 }
 
 // EventSource reads raw event records from the dataplane.
-// The eBPF implementation wraps a ring buffer reader; DPDK uses rte_ring.
+// The eBPF implementation wraps a ring buffer reader; the userspace
+// AF_XDP implementation uses the control-socket event stream.
 type EventSource interface {
 	// ReadEvent blocks until an event is available and returns raw bytes.
 	// Returns an error on close or failure.

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -157,7 +157,13 @@ func NewDataPlane(dpType string) (DataPlane, error) {
 		if ctor, ok := backendRegistry[dpType]; ok {
 			return ctor(), nil
 		}
-		return nil, fmt.Errorf("unknown dataplane type %q (valid built-in legacy type: ebpf)", dpType)
+		// Legacy NewDataPlane only accepts TypeEBPF directly; TypeUserspace
+		// has no legacy DataPlane shape and must go through
+		// NewRuntimeDataPlane.  TypeDPDK is caught above as
+		// ErrDPDKBackendRetired.  Operators selecting userspace at the
+		// config layer never reach this branch because daemon startup
+		// uses NewRuntimeDataPlane.
+		return nil, fmt.Errorf("unknown dataplane type %q (valid via NewDataPlane: ebpf; use NewRuntimeDataPlane for userspace)", dpType)
 	}
 }
 

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -349,7 +349,7 @@ type DataPlane interface {
 
 	// FIB
 	BumpFIBGeneration() uint32
-	StartFIBSync(ctx context.Context) // DPDK: background route sync; eBPF/userspace: no-op
+	StartFIBSync(ctx context.Context) // userspace: background route sync; eBPF: no-op
 
 	// NotifyLinkCycle signals that data-plane interfaces were taken DOWN/UP
 	// (e.g. during RETH MAC programming).  The userspace dataplane uses this

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -2,11 +2,28 @@ package dataplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/psaab/xpf/pkg/config"
+)
+
+// ErrDPDKBackendRetired is returned from NewDataPlane and
+// NewRuntimeDataPlane when caller code still asks for the DPDK
+// backend after Phase 2 of the DPDK retirement (#1527, umbrella
+// #1525).  Operators must migrate to "set system dataplane-type
+// userspace" (or omit the directive entirely for the default).
+//
+// Chain A (#1526) handles user-facing rejection at commit time;
+// this sentinel covers the runtime factory path for callers that
+// still pass TypeDPDK through, including the package-local test
+// in pkg/dataplane/dpdk that guards against silent registry
+// resurrection.
+var ErrDPDKBackendRetired = errors.New(
+	"DPDK dataplane backend has been retired; use " +
+		"'set system dataplane-type userspace' (see #1525)",
 )
 
 // Compile-time assertion that Manager implements DataPlane.
@@ -15,6 +32,12 @@ var _ ConfigSink = (*Manager)(nil)
 var _ RuntimeDataPlane = (*Manager)(nil)
 
 // Dataplane type constants used in system { dataplane-type <type>; }.
+//
+// TypeDPDK is preserved as a typed token for the retirement-error
+// code path in NewDataPlane / NewRuntimeDataPlane after Phase 2 of
+// #1525.  No production code path may construct a DPDK backend
+// through the registry — see ErrDPDKBackendRetired and the
+// retirement-boundary canary in retirement_boundary_canary_test.go.
 const (
 	TypeEBPF      = "ebpf"
 	TypeDPDK      = "dpdk"
@@ -114,11 +137,13 @@ func NewDataPlane(dpType string) (DataPlane, error) {
 		)
 	case TypeEBPF:
 		return New(), nil
+	case TypeDPDK:
+		return nil, ErrDPDKBackendRetired
 	default:
 		if ctor, ok := backendRegistry[dpType]; ok {
 			return ctor(), nil
 		}
-		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, dpdk, userspace)", dpType)
+		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, userspace)", dpType)
 	}
 }
 
@@ -130,6 +155,13 @@ func NewRuntimeDataPlane(dpType string) (RuntimeDataPlane, error) {
 	switch dpType {
 	case TypeEBPF:
 		return New(), nil
+	case TypeDPDK:
+		// EffectiveType only rewrites empty -> userspace, never
+		// -> dpdk, so this branch cannot intercept legitimate
+		// empty-default callers.  Any TypeDPDK that reaches here
+		// is an explicit "set system dataplane-type dpdk" that
+		// must be rejected after Phase 2 of #1525.
+		return nil, ErrDPDKBackendRetired
 	default:
 		if ctor, ok := runtimeBackendRegistry[dpType]; ok {
 			return ctor(), nil

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -157,7 +157,7 @@ func NewDataPlane(dpType string) (DataPlane, error) {
 		if ctor, ok := backendRegistry[dpType]; ok {
 			return ctor(), nil
 		}
-		return nil, fmt.Errorf("unknown dataplane type %q (valid: ebpf, userspace)", dpType)
+		return nil, fmt.Errorf("unknown dataplane type %q (valid built-in legacy type: ebpf)", dpType)
 	}
 }
 

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -22,7 +22,7 @@ import (
 // in pkg/dataplane/dpdk that guards against silent registry
 // resurrection.
 var ErrDPDKBackendRetired = errors.New(
-	"DPDK dataplane backend has been retired; use " +
+	"the DPDK dataplane backend has been retired; use " +
 		"'set system dataplane-type userspace' (see #1525)",
 )
 

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -355,7 +355,13 @@ type DataPlane interface {
 
 	// FIB
 	BumpFIBGeneration() uint32
-	StartFIBSync(ctx context.Context) // userspace: background route sync; eBPF: no-op
+	// StartFIBSync is a no-op on every in-tree backend: eBPF resolves
+	// FIB queries via bpf_fib_lookup in-kernel and the userspace
+	// AF_XDP runtime wraps the eBPF no-op through the legacy
+	// adapter.  The hook is retained on the interface for backends
+	// that need a userspace route populator (DPDK had one; retired
+	// in #1527 / #1525).
+	StartFIBSync(ctx context.Context)
 
 	// NotifyLinkCycle signals that data-plane interfaces were taken DOWN/UP
 	// (e.g. during RETH MAC programming).  The userspace dataplane uses this

--- a/pkg/dataplane/dpdk/dpdk_stub_test.go
+++ b/pkg/dataplane/dpdk/dpdk_stub_test.go
@@ -36,6 +36,32 @@ func TestDPDKConstructorsReturnRetirementError(t *testing.T) {
 	}
 }
 
+// TestRegisterDPDKBackendPanics guards against silent resurrection of
+// the DPDK backend via RegisterBackend or RegisterRuntimeBackend.
+// NewDataPlane and NewRuntimeDataPlane intercept TypeDPDK before
+// reaching the registry, so any successfully-registered DPDK
+// constructor would be permanently unreachable.  The panic makes the
+// programming error visible at init() time rather than silently at
+// runtime.
+func TestRegisterDPDKBackendPanics(t *testing.T) {
+	assertPanics := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("%s: expected panic, got none", name)
+			}
+		}()
+		fn()
+	}
+
+	assertPanics("RegisterBackend(TypeDPDK)", func() {
+		dataplane.RegisterBackend(dataplane.TypeDPDK, func() dataplane.DataPlane { return nil })
+	})
+	assertPanics("RegisterRuntimeBackend(TypeDPDK)", func() {
+		dataplane.RegisterRuntimeBackend(dataplane.TypeDPDK, func() dataplane.RuntimeDataPlane { return nil })
+	})
+}
+
 // TestDPDKStubRequiresDPDKBuildTag still covers the direct stub
 // path (Load/Start/Compile/ApplyConfig on a Manager constructed via
 // New()) so that any caller that gets a *Manager through a

--- a/pkg/dataplane/dpdk/dpdk_stub_test.go
+++ b/pkg/dataplane/dpdk/dpdk_stub_test.go
@@ -10,24 +10,39 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
-func TestDPDKConstructorsRemainRegistered(t *testing.T) {
+// TestDPDKConstructorsReturnRetirementError pins the post-#1527
+// behavior: both NewDataPlane(TypeDPDK) and
+// NewRuntimeDataPlane(TypeDPDK) must return
+// dataplane.ErrDPDKBackendRetired rather than the generic
+// "unknown dataplane type" error or — worse — a working stub
+// Manager.  The test guards against silent registry resurrection
+// (someone re-adding the init() block in manager.go) and against
+// the retirement error being weakened to a non-sentinel message.
+func TestDPDKConstructorsReturnRetirementError(t *testing.T) {
 	legacy, err := dataplane.NewDataPlane(dataplane.TypeDPDK)
-	if err != nil {
-		t.Fatalf("NewDataPlane(dpdk): %v", err)
+	if !errors.Is(err, dataplane.ErrDPDKBackendRetired) {
+		t.Fatalf("NewDataPlane(dpdk) error = %v, want errors.Is(ErrDPDKBackendRetired)", err)
 	}
-	if _, ok := legacy.(*Manager); !ok {
-		t.Fatalf("NewDataPlane(dpdk) = %T, want *dpdk.Manager", legacy)
+	if legacy != nil {
+		t.Fatalf("NewDataPlane(dpdk) = %T, want nil", legacy)
 	}
 
 	runtime, err := dataplane.NewRuntimeDataPlane(dataplane.TypeDPDK)
-	if err != nil {
-		t.Fatalf("NewRuntimeDataPlane(dpdk): %v", err)
+	if !errors.Is(err, dataplane.ErrDPDKBackendRetired) {
+		t.Fatalf("NewRuntimeDataPlane(dpdk) error = %v, want errors.Is(ErrDPDKBackendRetired)", err)
 	}
-	if _, ok := runtime.(*Manager); !ok {
-		t.Fatalf("NewRuntimeDataPlane(dpdk) = %T, want *dpdk.Manager", runtime)
+	if runtime != nil {
+		t.Fatalf("NewRuntimeDataPlane(dpdk) = %T, want nil", runtime)
 	}
 }
 
+// TestDPDKStubRequiresDPDKBuildTag still covers the direct stub
+// path (Load/Start/Compile/ApplyConfig on a Manager constructed via
+// New()) so that any caller that gets a *Manager through a
+// non-registry path still sees the build-tag rejection.  After
+// #1527 the registry path is gone, so this test is the only place
+// errDPDKBuildTagRequired is exercised — that is intentional until
+// Phase 3 (#1528) deletes the package.
 func TestDPDKStubRequiresDPDKBuildTag(t *testing.T) {
 	m := New()
 

--- a/pkg/dataplane/dpdk/manager.go
+++ b/pkg/dataplane/dpdk/manager.go
@@ -15,14 +15,12 @@ var _ dataplane.DataPlane = (*Manager)(nil)
 var _ dataplane.ConfigSink = (*Manager)(nil)
 var _ dataplane.RuntimeDataPlane = (*Manager)(nil)
 
-func init() {
-	dataplane.RegisterBackend(dataplane.TypeDPDK, func() dataplane.DataPlane {
-		return New()
-	})
-	dataplane.RegisterRuntimeBackend(dataplane.TypeDPDK, func() dataplane.RuntimeDataPlane {
-		return New()
-	})
-}
+// NOTE: backend registration via dataplane.RegisterBackend /
+// dataplane.RegisterRuntimeBackend was removed in #1527 (Phase 2 of
+// the DPDK retirement, umbrella #1525).  After this change the
+// package remains compilable but no production code path constructs
+// a Manager through the dataplane registry.  Phase 3 (#1528) will
+// delete the package outright.
 
 // Manager is the DPDK dataplane backend (stub implementation).
 type Manager struct {

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -66,7 +66,14 @@ var legacyDataplaneImportAllowlist = map[string]string{
 }
 
 var dpdkEBPFImportAllowlist = map[string]string{
-	"pkg/dataplane/dpdk/manager.go": "legacy DataPlane Map method returns *ebpf.Map until DPDK migrates off root DataPlane",
+	// After #1527 (Phase 2) the DPDK package is no longer linked
+	// into the default xpfd binary and has no production callers
+	// outside test code.  Phase 3 (#1528) deletes the package
+	// entirely.  The retained allowlist entry covers the in-tree
+	// retired stub's legacy DataPlane Map(string) *ebpf.Map
+	// signature so the package still compiles cleanly until Phase
+	// 3 removes it.
+	"pkg/dataplane/dpdk/manager.go": "retired in-tree DPDK stub keeps legacy DataPlane Map() *ebpf.Map signature until Phase 3 (#1528) deletes the package",
 }
 
 // dpdkBackendImportAllowlist is intentionally empty after Phase 2

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 var legacyDataplaneImportAllowlist = map[string]string{
-	"cmd/xpfd/main.go":                         "backend selection, cleanup, and backend registration",
+	"cmd/xpfd/main.go":                         "cleanup entry point (backend registration removed in #1527)",
 	"pkg/api/handlers.go":                      "REST handlers still reference legacy dataplane counters and types",
 	"pkg/api/handlers_sessions.go":             "REST session reads still use legacy session types",
 	"pkg/api/metrics.go":                       "Prometheus telemetry still reads legacy counters and metadata",
@@ -69,9 +69,12 @@ var dpdkEBPFImportAllowlist = map[string]string{
 	"pkg/dataplane/dpdk/manager.go": "legacy DataPlane Map method returns *ebpf.Map until DPDK migrates off root DataPlane",
 }
 
-var dpdkBackendImportAllowlist = map[string]string{
-	"cmd/xpfd/main.go": "backend registration and cleanup entry point",
-}
+// dpdkBackendImportAllowlist is intentionally empty after Phase 2
+// of the DPDK retirement (#1527, umbrella #1525).  The DPDK package
+// remains in-tree but no production package outside
+// pkg/dataplane/dpdk/ may import it.  Phase 3 (#1528) removes the
+// package entirely.
+var dpdkBackendImportAllowlist = map[string]string{}
 
 var retainedShimBoundaryBuildTagAllowlist = map[string][]string{
 	// Generated legacy bpf2go artifacts keep bpf2go's architecture constraint
@@ -169,9 +172,11 @@ func TestOperatorPackagesDoNotImportBPFArtifactsDirectly(t *testing.T) {
 				violations = append(violations, rel+" imports "+imp)
 			}
 			if imp == dpdkBackendImportForCanary || strings.HasPrefix(imp, dpdkBackendImportForCanary+"/") {
-				if rel != "cmd/xpfd/main.go" {
-					violations = append(violations, rel+" imports "+imp)
-				}
+				// After Phase 2 of #1525 (boot-path decouple,
+				// #1527) no operator-runtime production file may
+				// import pkg/dataplane/dpdk.  The previous
+				// cmd/xpfd/main.go exemption is removed.
+				violations = append(violations, rel+" imports "+imp)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Phase 2 of the DPDK retirement (umbrella #1525, sibling #1373) decouples the DPDK backend from the daemon boot path so the default `xpfd` binary no longer link-edits `pkg/dataplane/dpdk` and the package no longer self-registers as a backend factory. After this PR the package compiles but no production code path references it, so Phase 3 (#1528) source deletion is a no-link mechanical removal.

- Drop `_ "github.com/psaab/xpf/pkg/dataplane/dpdk"` blank import from `cmd/xpfd/main.go`.
- Delete the `init()` block in `pkg/dataplane/dpdk/manager.go` that registered the backend with `dataplane.RegisterBackend` and `dataplane.RegisterRuntimeBackend` (both stub and `-tags dpdk` builds — `manager.go` has no build tag).
- Add exported sentinel `dataplane.ErrDPDKBackendRetired` plus `TypeDPDK` reject arms in `NewDataPlane` and `NewRuntimeDataPlane` so any caller that still passes `TypeDPDK` gets a clear retirement error.
- Shrink `dpdkBackendImportAllowlist` to an empty map and remove the `cmd/xpfd/main.go` DPDK exemption from `TestOperatorPackagesDoNotImportBPFArtifactsDirectly`.
- Rewrite `dpdk_stub_test.go::TestDPDKConstructorsRemainRegistered` as `TestDPDKConstructorsReturnRetirementError`, asserting both factories return `errors.Is(err, ErrDPDKBackendRetired)` and nil interfaces.
- v3 (Copilot inline fix): handle `ErrDPDKBackendRetired` in `pkg/daemon/daemon_run.go` like a `Start()` failure (`slog.Warn` + config-only fallback) instead of `os.Exit(1)`. Preserves UX for nodes with a persisted `system dataplane-type dpdk` from before Chain A (#1526) lands.
- v4 (Codex + Antigravity NPE fix): guard `OnFenceReceived` in `pkg/daemon/daemon_ha_sync.go` against `d.dp == nil`. The v3 soft-fallback exposed a pre-existing latent nil-pointer panic when a peer fence arrived in config-only mode.

## Sequencing

**Chain A (#1526) strongly preferred to land first** (downgraded from HARD in v3). v4's nil-guard fix means the daemon survives a stale `system dataplane-type dpdk` even without Chain A, but the operator UX is cleaner if the config never accepts `dpdk` at commit time.

`ErrDPDKBackendRetired` cannot be re-used by `pkg/config` for Chain A — `pkg/dataplane/dataplane.go:10` already imports `pkg/config`, so the reverse import would cycle. Chain A keeps its own local message.

## Scope boundaries

- `docs/pr/1373-retire-ebpf-dataplane/README.md` and other docs/*.md files are **not** touched — Chain C (#1529) owns the docs prose sweep. Required canary tokens at `retirement_boundary_canary_test.go:1780-1788` are all still present in the README literally, so `TestRetirementBoundaryDocsMentionDPDKPolicy` stays green.
- **Known docs drift (Chain C TODO):** Codex v3 hostile review correctly noted that `docs/pr/1373-retire-ebpf-dataplane/README.md:64` and `:85` now contain factually stale claims about `cmd/xpfd/main.go` keeping the DPDK blank import. The canary tokens match the literal text in the README so the test passes, but the prose describes a pre-#1527 reality. Chain C (#1529) will rewrite the prose to match post-Phase-2 facts.
- DPDK source deletion (`dpdk_worker/`, `pkg/dataplane/dpdk/`) is Phase 3 (#1528) — this PR only removes the import and registration.

Plan doc: `docs/pr/1527-dpdk-boot-decouple/plan.md` (v4).

Reviewer history:
- Antigravity plan review (v1): `adversarial-review-mpkqkzkm-qfa19j` → PLAN-READY.
- Codex plan review (v1→v2): `task-mpkqsgf5-j2yag1` → PLAN-NEEDS-MINOR (3 MUST-FIX resolved in v2).
- Codex code review (v2→v3): `task-mpkrohgl-dow3kd` → MERGE-NEEDS-MINOR (plan-prose cleanup, resolved in v3; sequencing concern was inflight via Copilot inline fix).
- Copilot code review (v2→v3): 1 inline fatal-at-startup concern, resolved in v3 via `daemon_run.go` soft-fallback.
- Codex code review (v3→v4): `task-mpkrwbtk-pd6nnw` → MERGE-NEEDS-MAJOR (NPE in `OnFenceReceived` + docs-prose drift). NPE resolved in v4; docs drift acknowledged as Chain C scope.
- Antigravity code review (v3→v4): `adversarial-review-mpkrwmkk-2k24v4` → MAJOR (same NPE, resolved in v4).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (full Go suite)
- [x] `go test ./pkg/dataplane/... -run TestDPDKBackendImport -count=1 -race` passes (empty allowlist + boundary canary)
- [x] `go test ./pkg/dataplane/... -run TestDPDKConstructorsReturnRetirementError -count=1 -race` passes (sentinel guard)
- [x] `go test ./pkg/dataplane/dpdk/ -run TestDPDKStubRequiresDPDKBuildTag -count=1 -race` passes (stub direct path)
- [x] `go test ./pkg/dataplane/... -run TestRetirementBoundary -count=1 -race` passes (docs-token canary still green)
- [x] `cargo build --release` in `userspace-dp/` clean
- [x] Cluster smoke matrix on `loss:xpf-userspace-fw0/fw1` userspace cluster — Pass A (CoS-off) v4/v6 push and `-P 12 -t 10 -R` reverse: ~8.3-9.4 Gbps, 0 retrans on reverse; Pass B (CoS-on) full 24-cell matrix (5201-5206 × v4/v6 × push/reverse) — push shaped per-class as expected (5201/100m → 82 Mbps, 5206/12g → 10.1 Gbps), reverse 14-23 Gbps unshaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)