### PR TITLE
cli: migrate off legacy dataplane.DataPlane (#1517, sub-#1451 S2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2235,3 +2235,14 @@
 - **File(s)**: docs/pr/1517-cli-migration/plan.md
 - **Why**: Triple-review methodology — plan first, code never first. Dispatch
   Codex + Antigravity adversarial plan review before any code touches.
+
+- **Timestamp**: 2026-05-24 (1517 plan v2 PLAN-READY)
+- **Action**: Folded Codex PLAN-NEEDS-MINOR findings into plan v2. AGY
+  PLAN-READY against v1 stands. Both reviewers now agree — proceeding to
+  implementation.
+- **File(s)**: docs/pr/1517-cli-migration/plan.md, reviewer-ids.md
+- **Why**: Codex r1 (task-mpkukwfs-gl3fv4) identified Q1 over-engineering
+  (LastApplyResultOf is already `any`-typed at apply.go:54, so neither
+  Option B shadow field nor Option C interface widening is needed) and a
+  scope-doc citation hygiene issue. AGY r1 (adversarial-review-mpkuldhp-mnlp6x)
+  was PLAN-READY across all seven hostile checks.

--- a/_Log.md
+++ b/_Log.md
@@ -2276,3 +2276,12 @@
   handleRequestChassisClusterDataPlane in cli_request.go. Recorded
   reviewer-ids for code-review round 1.
 - **File(s)**: pkg/cli/runtime.go, docs/pr/1517-cli-migration/reviewer-ids.md
+
+- **Timestamp**: 2026-05-25 (1517 code review final verdicts)
+- **Action**: All three reviewers MERGE-READY. Recording verdicts;
+  not merging (per project policy).
+- **File(s)**: docs/pr/1517-cli-migration/reviewer-ids.md
+- **Validation**: Codex r3 task-mpkvl9cn-3we3in MERGE-READY (after two
+  sandbox-FS-blocked retries); AGY adversarial-review-mpkvctz4-xk8x46
+  MERGE-READY (exhaustive 10-check report with byte-for-byte evidence);
+  Copilot COMMENTED with 1 minor inline finding, addressed in 91e1da9f.

--- a/_Log.md
+++ b/_Log.md
@@ -2228,3 +2228,10 @@
   slog.Warn wording to "the DPDK dataplane backend has been retired".
 - **Validation**: pkg/dataplane test suite green; no other in-tree strings
   pinned the old wording.
+
+- **Timestamp**: 2026-05-24 (1517 plan draft)
+- **Action**: Wrote plan v1 (DRAFT) for #1517 — migrate pkg/cli off legacy
+  dataplane.DataPlane (sub-#1451 S2). Mirrors apiRuntimeDataPlane pattern.
+- **File(s)**: docs/pr/1517-cli-migration/plan.md
+- **Why**: Triple-review methodology — plan first, code never first. Dispatch
+  Codex + Antigravity adversarial plan review before any code touches.

--- a/_Log.md
+++ b/_Log.md
@@ -2268,3 +2268,11 @@
   show chassis forwarding, request chassis cluster data-plane
   userspace) all work — the named provider-probe interfaces resolve
   correctly against the userspace LegacyDataPlaneAdapter.
+
+- **Timestamp**: 2026-05-25 (1517 code-review r1 minor folds)
+- **Action**: Folded Copilot inline finding on cliUserspaceControlProvider
+  doc comment — said "request security flow" but correct CLI path is
+  "request chassis cluster data-plane userspace" handled by
+  handleRequestChassisClusterDataPlane in cli_request.go. Recorded
+  reviewer-ids for code-review round 1.
+- **File(s)**: pkg/cli/runtime.go, docs/pr/1517-cli-migration/reviewer-ids.md

--- a/_Log.md
+++ b/_Log.md
@@ -2285,3 +2285,13 @@
   sandbox-FS-blocked retries); AGY adversarial-review-mpkvctz4-xk8x46
   MERGE-READY (exhaustive 10-check report with byte-for-byte evidence);
   Copilot COMMENTED with 1 minor inline finding, addressed in 91e1da9f.
+
+- **Timestamp**: 2026-05-25T07:30Z
+- **Action**: PR #1549 — fix stale plan.md snippet per Copilot d9545813 review
+- **File(s)**: docs/pr/1517-cli-migration/plan.md
+- **Why**: Copilot review on d9545813 left 1 inline comment that the plan.md
+  snippet for cliUserspaceControlProvider still references `request security
+  flow ...` while the actual source comment (fixed in 91e1da9f) and the actual
+  handler path are `request chassis cluster data-plane userspace` via
+  cli_request.go:handleRequestChassisClusterDataPlane. Updated plan snippet
+  in lockstep so docs match implementation. No code change.

--- a/_Log.md
+++ b/_Log.md
@@ -2246,3 +2246,25 @@
   Option B shadow field nor Option C interface widening is needed) and a
   scope-doc citation hygiene issue. AGY r1 (adversarial-review-mpkuldhp-mnlp6x)
   was PLAN-READY across all seven hostile checks.
+
+- **Timestamp**: 2026-05-25 (1517 implementation)
+- **Action**: Implemented #1517 — added pkg/cli/runtime.go with cliRuntime
+  interface (25 methods), cliUserspaceStatusProvider, and
+  cliUserspaceControlProvider. Changed cli.dp from dataplane.DataPlane to
+  cliRuntime; cli.New parameter type updated. Five inline interface{}
+  provider probes consolidated into named interfaces.
+- **File(s)**: pkg/cli/runtime.go (new), pkg/cli/cli.go,
+  pkg/cli/cli_helpers.go, pkg/cli/cli_show_chassis.go,
+  pkg/cli/cli_show_system.go, pkg/dataplane/retirement_boundary_canary_test.go
+  (add runtime.go to legacy allowlist), docs/pr/1373-retire-ebpf-dataplane/README.md
+  (add runtime.go row to migration table).
+- **Validation**: cargo+go build clean; ./pkg/cli/... 5/5 flake pass;
+  full Go suite green. Deployed to loss userspace cluster:
+  Pass A 6/6 baseline cells 0 retrans, multi-stream -P 12 -R hit
+  22.6/20.3 Gbps with 0 retrans. Pass B all 24 cells passed; shaped
+  classes hit configured rates cleanly. Interactive CLI smoke
+  (show security flow session brief, show security flow statistics,
+  clear security flow session all, show system buffers,
+  show chassis forwarding, request chassis cluster data-plane
+  userspace) all work — the named provider-probe interfaces resolve
+  correctly against the userspace LegacyDataPlaneAdapter.

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -260,6 +260,7 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/cli/cli_show_flow.go` | Flow display still uses legacy session keys and values. |
 | `pkg/cli/cli_show_nat.go` | NAT display still uses legacy NAT/session metadata. |
 | `pkg/cli/cli_show_security.go` | Security display still uses legacy counters and filter types. |
+| `pkg/cli/runtime.go` | #1517 — `cliRuntime` interface declares the narrow CLI dataplane surface; still depends on root `pkg/dataplane` type names (`SessionKey`, `CounterValue`, etc.) until those types move to a domain package. |
 | `pkg/cluster/sync.go` | Session sync still installs sessions through the legacy bridge. |
 | `pkg/cluster/sync_bulk.go` | Bulk sync still serializes legacy session entries. |
 | `pkg/cluster/sync_conn.go` | Sync connection code still references legacy session types. |

--- a/docs/pr/1517-cli-migration/plan.md
+++ b/docs/pr/1517-cli-migration/plan.md
@@ -1,11 +1,17 @@
 # #1517 — Migrate pkg/cli off legacy `dataplane.DataPlane` (sub-#1451 S2)
 
-**Status:** DRAFT v1 — pending adversarial plan review.
+**Status:** v2 — PLAN-READY per AGY adversarial-review-mpkuldhp-mnlp6x;
+Codex task-mpkukwfs-gl3fv4 PLAN-NEEDS-MINOR fixes folded in (LastApplyResultOf
+is already `any`-typed at `pkg/dataplane/apply.go:54`, so neither Option B
+nor Option C is required — Q1 reframed; scope-doc citation softened
+because the canonical doc lives on branch `1451-migration-scope`,
+commit `135ae0e0`, not yet on master).
 
 Refs: #1517 (this), #1451 (parent), #1373 (eBPF retirement). Sub-issue
-scope doc: `docs/pr/1451-migration-scope/scope.md`. Parallels sub-#1516
-(grpcapi) — sibling agent driving that PR in parallel; this branch
-touches **only** `pkg/cli/`.
+scope doc lives at commit `135ae0e0` on branch `1451-migration-scope`
+(`docs/pr/1451-migration-scope/scope.md`, not yet merged to master).
+Parallels sub-#1516 (grpcapi) — sibling agent driving that PR in
+parallel; this branch touches **only** `pkg/cli/`.
 
 ## 1. Issue framing
 
@@ -14,12 +20,14 @@ takes a `dataplane.DataPlane` parameter. The interactive Junos CLI is
 the second of two large operator surfaces still importing the full
 legacy interface directly (the first is `pkg/grpcapi`, sub-#1516).
 
-Per #1451 scope doc, the standard migration target is: replace the
-`dataplane.DataPlane` parameter/field with a narrow, domain-specific
-interface declared inside the consumer package, mirroring the pattern
-already shipped by `pkg/api` (`apiRuntimeDataPlane`),
-`pkg/fwdstatus` (`DataPlaneAccessor`), `pkg/monitoriface`
-(`RuntimeDataPlane`), and `pkg/conntrack` (`RuntimeDomainProvider`).
+Per the #1451 scope doc (commit `135ae0e0` on branch
+`1451-migration-scope`, §S2), the standard migration target is:
+replace the `dataplane.DataPlane` parameter/field with a narrow,
+domain-specific interface declared inside the consumer package,
+mirroring the pattern already shipped by `pkg/api`
+(`apiRuntimeDataPlane`), `pkg/fwdstatus` (`DataPlaneAccessor`),
+`pkg/monitoriface` (`RuntimeDataPlane`), and `pkg/conntrack`
+(`RuntimeDomainProvider`).
 
 Once this lands and S1/S3 are done, the daemon's `legacyDP()`
 accessor can shrink to the narrowest union and ultimately be removed
@@ -112,7 +120,7 @@ type cliRuntime interface {
     ReadPolicyCounters(ruleID uint32) (dataplane.CounterValue, error)
     ReadFilterConfig(filterID uint32) (dataplane.FilterConfig, error)
     ReadFilterCounters(filterID uint32) (dataplane.CounterValue, error)
-    ReadFloodCounters(zoneID uint16) (dataplane.FloodCounters, error)
+    ReadFloodCounters(zoneID uint16) (dataplane.FloodState, error)
     ReadNATPortCounter(id uint32) (uint64, error)
     ReadNATRuleCounter(id uint32) (dataplane.CounterValue, error)
 
@@ -253,21 +261,26 @@ out of scope for this PR.)
    returns either a non-nil adapter or interface-nil today — verified
    by reading `pkg/daemon/daemon.go:345-`.)
 3. **`dataplane.LastApplyResultOf(c.dp)` in `applyResult()`**
-   (`cli.go:139`) takes a `dataplane.DataPlane`. After the field
-   becomes `cliRuntime` this won't compile. Two options:
-   - **Option A (preferred):** widen `LastApplyResultOf` to take
-     `any` and runtime-detect. But that touches `pkg/dataplane`, out
-     of scope.
-   - **Option B (chosen):** keep `c.dp` typed as `cliRuntime`, but
-     **also** keep a `c.dpLegacy dataplane.DataPlane` field for the
-     one call site that needs it. Pass both at `New()`. This is a
-     pragmatic interim — `LastApplyResultOf` is itself slated for
-     refactor in S4 (`docs/pr/1451-migration-scope/scope.md`
-     identifies the legacy accessor cleanup as the same step).
-   - **Option C (alternative):** add `LastApplyResult() *ApplyResult`
-     to `cliRuntime`. The legacy DataPlane has this method (verify);
-     this is the cleanest fix. **Open question for review** —
-     §11 Q3.
+   (`cli.go:139`) — non-issue verified. `LastApplyResultOf` is
+   defined at `pkg/dataplane/apply.go:54` as
+   `func LastApplyResultOf(provider any) *ApplyResult`. It already
+   takes `any` and runtime-detects the optional
+   `ApplyResultReader` interface via type assertion on the
+   underlying concrete value. Both concrete dataplanes implement
+   `LastApplyResult()`:
+   `pkg/dataplane/userspace/legacy_dataplane.go:73` and
+   `pkg/dataplane/userspace/manager.go:182`. Therefore passing
+   `c.dp` (typed as `cliRuntime`) to `LastApplyResultOf` compiles
+   cleanly (interface→`any` widening) and the runtime assertion
+   succeeds against the concrete value behind the interface.
+   **No Option B (shadow field) is needed and no Option C (widen
+   cliRuntime) is needed.** This was the central question in
+   plan-v1 and is now settled.
+
+   Same reasoning applies to `dataplane.TelemetryOf(c.dp)` if it
+   exists (`pkg/dataplane/apply.go`: similar `any`-typed helper).
+   Confirmed by grep: no CLI callsite passes `c.dp` to a function
+   typed `dataplane.DataPlane`.
 4. **HA paths.** The CLI does not touch session-sync or HA itself.
    `cluster.Manager` is a separate field (`cli.cluster`). The
    `request chassis cluster failover` paths use `cm.*` not `dp.*`,
@@ -342,14 +355,13 @@ out of scope for this PR.)
 Each question is invitable to a **PLAN-KILL** verdict if the answer
 exposes a wrong-target architecture.
 
-1. **Q1: Is `Option C` (add `LastApplyResult()` to `cliRuntime`)
-   actually viable?** The CLI calls `dataplane.LastApplyResultOf(c.dp)`
-   in `applyResult()`. Either we add `LastApplyResult()` to
-   `cliRuntime` (clean — verify the underlying types expose it as a
-   method, not as a top-level free function), or we keep a
-   `c.dpLegacy dataplane.DataPlane` shadow field for that one call
-   site (ugly but localised). **Reviewers, please pick one before
-   PLAN-READY.**
+1. **Q1: RESOLVED (Codex r1).** `dataplane.LastApplyResultOf` is
+   defined as `func(provider any) *ApplyResult` and uses a runtime
+   type assertion on the concrete value. Both backends implement
+   `LastApplyResult()` as a method on the concrete type, so
+   passing a `cliRuntime`-typed value works at both compile and
+   run time without any Option B / Option C trickery. Plan §6.3
+   updated accordingly.
 2. **Q2: Is dropping the inline provider probes in favour of named
    interfaces actually behaviour-preserving?** Specifically: the
    `cli_show_chassis.go:108` probe is `Status() (...)` only, while
@@ -393,4 +405,14 @@ exposes a wrong-target architecture.
 
 ---
 
-End of plan v1.
+End of plan.
+
+## Revision history
+
+- **v1** (2026-05-24, commit 713997fc): initial draft.
+- **v2** (2026-05-24): folded Codex task-mpkukwfs-gl3fv4 PLAN-NEEDS-MINOR
+  findings — reframed §6.3/Q1 since `LastApplyResultOf` is already
+  `any`-typed; softened scope.md citation to point at branch
+  `1451-migration-scope` (not yet merged); fixed FloodCounters →
+  FloodState type in §4.1. AGY adversarial-review-mpkuldhp-mnlp6x
+  already PLAN-READY against v1; v2 is strictly tighter.

--- a/docs/pr/1517-cli-migration/plan.md
+++ b/docs/pr/1517-cli-migration/plan.md
@@ -1,0 +1,396 @@
+# #1517 — Migrate pkg/cli off legacy `dataplane.DataPlane` (sub-#1451 S2)
+
+**Status:** DRAFT v1 — pending adversarial plan review.
+
+Refs: #1517 (this), #1451 (parent), #1373 (eBPF retirement). Sub-issue
+scope doc: `docs/pr/1451-migration-scope/scope.md`. Parallels sub-#1516
+(grpcapi) — sibling agent driving that PR in parallel; this branch
+touches **only** `pkg/cli/`.
+
+## 1. Issue framing
+
+`pkg/cli/cli.go` stores `cli.dp dataplane.DataPlane` and `New(...)`
+takes a `dataplane.DataPlane` parameter. The interactive Junos CLI is
+the second of two large operator surfaces still importing the full
+legacy interface directly (the first is `pkg/grpcapi`, sub-#1516).
+
+Per #1451 scope doc, the standard migration target is: replace the
+`dataplane.DataPlane` parameter/field with a narrow, domain-specific
+interface declared inside the consumer package, mirroring the pattern
+already shipped by `pkg/api` (`apiRuntimeDataPlane`),
+`pkg/fwdstatus` (`DataPlaneAccessor`), `pkg/monitoriface`
+(`RuntimeDataPlane`), and `pkg/conntrack` (`RuntimeDomainProvider`).
+
+Once this lands and S1/S3 are done, the daemon's `legacyDP()`
+accessor can shrink to the narrowest union and ultimately be removed
+when the legacy adapter goes away (S4/S7).
+
+## 2. Honest scope/value framing
+
+This is a **pure decoupling refactor**. There is no perf delta and no
+new feature. The value is structural:
+
+- `pkg/cli` stops importing `dataplane.DataPlane` as a field type, so
+  the eBPF retirement removal phases (#1476/#1477) no longer have
+  `pkg/cli` as a blocker.
+- The migrated `cliRuntime` interface documents exactly what the CLI
+  uses of the dataplane (25 named methods + a handful of provider
+  probes), so future map/program retirements can prove which CLI
+  paths they break.
+- Daemon `d.legacyDP()` no longer needs to satisfy the entire
+  legacy interface to feed the CLI; it satisfies only `cliRuntime`.
+
+**Cost**: ~25 method signatures copied into a new `runtime.go`,
+five inline `interface{...}` provider probes consolidated into named
+interfaces, ~7 production files touched, no behaviour change. About
+the same scope as `pkg/api`'s prior `apiRuntimeDataPlane` extraction
+(~45 LOC of interface decl + sed-style replacement of `dp dataplane.DataPlane`
+→ `dp cliRuntime` at field sites).
+
+If reviewers conclude this churn is not worth it because some other
+plan (e.g. delete `pkg/cli` entirely now that remote CLI exists) is
+preferable, **PLAN-KILL is an acceptable verdict**. The prior shipped
+migrations on `pkg/api`/`pkg/fwdstatus`/`pkg/monitoriface`/`pkg/conntrack`
+plus the explicit acceptance criteria in #1517 are the rationale for
+proceeding; if Codex or Antigravity sees a flaw in that rationale,
+say so.
+
+## 3. What's already shipped / partially batched
+
+Pre-existing, in master @ `fcd53beb`:
+
+- **`pkg/api`** uses `apiRuntimeDataPlane` (`pkg/api/handlers.go:25-44`)
+  — the canonical pattern to copy. 13 methods total. CLI's set is
+  a superset (25 methods plus 5 provider probes — see below).
+- **`pkg/fwdstatus`** uses `DataPlaneAccessor` (`builder.go:35`).
+- **`pkg/monitoriface`** uses `RuntimeDataPlane` (`monitor.go:30`).
+- **`pkg/conntrack`** uses `RuntimeDomainProvider` (already migrated
+  off `DataPlane`).
+- **`pkg/dataplane/userspace/legacy_dataplane.go`** is the
+  compatibility adapter (`LegacyDataPlaneAdapter`) that satisfies the
+  full `dataplane.DataPlane` interface and forwards to the userspace
+  manager. The daemon's `legacyDP()` returns this on the userspace
+  path. **Important**: this adapter already implements every method
+  the CLI uses, so the migration cannot break the userspace path as
+  long as `cliRuntime` is a strict subset of `dataplane.DataPlane`.
+- **`docs/pr/1451-migration-scope/scope.md`** §S2 lists this work
+  with target interface name `cliRuntime` and target file
+  `pkg/cli/runtime.go`.
+
+## 4. Concrete design
+
+### 4.1 New file: `pkg/cli/runtime.go`
+
+```go
+// Package cli — runtime interface used by the interactive Junos CLI.
+package cli
+
+import (
+    "github.com/psaab/xpf/pkg/config"
+    "github.com/psaab/xpf/pkg/dataplane"
+    dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// cliRuntime is the narrow, CLI-specific view of the dataplane.
+// It lists exactly the methods called via cli.dp.*; do NOT widen it
+// without a callsite reason.
+//
+// All concrete dataplanes (legacy eBPF Manager, LegacyDataPlaneAdapter
+// over the userspace manager, DPDK manager) already satisfy this
+// because it is a strict subset of dataplane.DataPlane.
+type cliRuntime interface {
+    // Lifecycle / health
+    IsLoaded() bool
+
+    // Compilation (used by candidate-config "show | compare" preview path)
+    Compile(cfg *config.Config) (*dataplane.CompileResult, error)
+
+    // Counters
+    ReadGlobalCounter(idx uint32) (uint64, error)
+    ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error)
+    ReadZoneCounters(zoneID uint16, direction int) (dataplane.CounterValue, error)
+    ReadPolicyCounters(ruleID uint32) (dataplane.CounterValue, error)
+    ReadFilterConfig(filterID uint32) (dataplane.FilterConfig, error)
+    ReadFilterCounters(filterID uint32) (dataplane.CounterValue, error)
+    ReadFloodCounters(zoneID uint16) (dataplane.FloodCounters, error)
+    ReadNATPortCounter(id uint32) (uint64, error)
+    ReadNATRuleCounter(id uint32) (dataplane.CounterValue, error)
+
+    // Sessions
+    SessionCount() (v4, v6 int)
+    IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+    IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+    DeleteSession(key dataplane.SessionKey) error
+    DeleteSessionV6(key dataplane.SessionKeyV6) error
+
+    // DNAT static entry delete (used by filtered clear)
+    DeleteDNATEntry(key dataplane.DNATKey) error
+    DeleteDNATEntryV6(key dataplane.DNATKeyV6) error
+
+    // Clear-counter / clear-session bulk ops
+    ClearAllCounters() error
+    ClearAllSessions() (v4, v6 int, err error)
+    ClearFilterCounters() error
+    ClearNATRuleCounters() error
+    ClearPolicyCounters() error
+
+    // Map stats + persistent NAT table (used by show + clear NAT bindings)
+    GetMapStats() []dataplane.MapStats
+    GetPersistentNAT() *dataplane.PersistentNATTable
+}
+
+// Provider probes — small, named interfaces that replace the inline
+// `c.dp.(interface{...})` type assertions in cli_helpers.go,
+// cli_show_chassis.go, and cli_show_system.go. The intent is unchanged
+// (these are userspace-only capabilities); naming them makes the
+// surface searchable and lets the daemon pass a single capability-
+// rich object.
+
+// cliUserspaceStatusProvider is implemented by dataplanes that expose
+// the userspace helper's `ProcessStatus` snapshot (queue/binding/CoS).
+type cliUserspaceStatusProvider interface {
+    Status() (dpuserspace.ProcessStatus, error)
+}
+
+// cliUserspaceControlProvider extends the status provider with the
+// mutating control operations used by `request security flow ...`
+// and similar diag commands.
+type cliUserspaceControlProvider interface {
+    cliUserspaceStatusProvider
+    SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
+    SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+    SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+    InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
+}
+```
+
+### 4.2 Field + constructor rewrite in `pkg/cli/cli.go`
+
+```go
+type CLI struct {
+    ...
+    dp              cliRuntime   // was: dataplane.DataPlane
+    ...
+}
+
+func New(store *configstore.Store, dp cliRuntime, ...) *CLI {
+    ...
+}
+```
+
+All other `c.dp.*` call sites compile unchanged because every method
+they call is in `cliRuntime`. The five inline provider probes change
+shape:
+
+```go
+// cli_helpers.go (was: inline anonymous interface)
+provider, ok := c.dp.(cliUserspaceStatusProvider)
+...
+provider, ok := c.dp.(cliUserspaceControlProvider)
+...
+
+// cli_show_chassis.go (was: inline anonymous interface, status-only)
+if _, ok := c.dp.(cliUserspaceStatusProvider); ok { ... }
+
+// cli_show_system.go (two sites — both status-only)
+if provider, ok := c.dp.(cliUserspaceStatusProvider); ok { ... }
+```
+
+Behaviour is bit-identical: Go interface satisfaction by structural
+matching means anything that satisfied the inline interface still
+satisfies the named one.
+
+### 4.3 Daemon callsite
+
+`pkg/daemon/daemon_run.go:849`:
+
+```go
+// before:
+shell := cli.New(d.store, d.legacyDP(), eventBuf, er, ...)
+// after:
+shell := cli.New(d.store, d.legacyDP(), eventBuf, er, ...)
+```
+
+Source line is **unchanged**; the daemon still passes the same
+adapter. Type assignment compiles because `d.legacyDP()` returns
+`dataplane.DataPlane`, which is a strict superset of `cliRuntime`,
+and Go assigns interface→interface freely when the source contains
+all required methods.
+
+(After S1 + S3 + S4 land, the daemon can have a typed
+`d.cliRuntime()` accessor that returns a narrower object. That is
+out of scope for this PR.)
+
+## 5. Public API preservation
+
+- `cli.New` signature changes only the type of its second parameter:
+  `dataplane.DataPlane` → `cliRuntime`. Both interfaces are
+  satisfied by every concrete dataplane (legacy eBPF, userspace
+  adapter, DPDK) in the tree today, so every caller compiles.
+- The only `cli.New` caller in the tree is `pkg/daemon/daemon_run.go`;
+  it passes `d.legacyDP()` which still works (see §4.3).
+- `cli.CLI` is unexported field-wise; the type alias for `c.dp` is
+  package-internal. No other package depends on the type of `c.dp`.
+- All `(*CLI).Show*`/`Clear*`/`Handle*` exported methods keep their
+  signatures.
+
+## 6. Hidden invariants the change must preserve
+
+1. **Provider probe semantics.** The five inline `c.dp.(interface{...})`
+   probes detect whether the underlying dataplane is the userspace
+   path. Replacing them with named interfaces must preserve the same
+   structural method set bit-for-bit (no widening, no narrowing) or
+   a previously-supported dataplane will silently lose the capability
+   probe. Verify by reading the existing inline interface vs the new
+   named interface side by side; method count + signatures must
+   match.
+2. **Nil-safety.** Every existing `if c.dp == nil` and
+   `if c.dp != nil && c.dp.IsLoaded()` guard must keep working. Since
+   `cliRuntime` is an interface and the daemon already passes a
+   non-nil interface value, `c.dp == nil` still does the right thing.
+   (Subtle: if `d.legacyDP()` returned a typed nil pointer wrapped in
+   an interface, the comparison would not work; but `d.legacyDP()`
+   returns either a non-nil adapter or interface-nil today — verified
+   by reading `pkg/daemon/daemon.go:345-`.)
+3. **`dataplane.LastApplyResultOf(c.dp)` in `applyResult()`**
+   (`cli.go:139`) takes a `dataplane.DataPlane`. After the field
+   becomes `cliRuntime` this won't compile. Two options:
+   - **Option A (preferred):** widen `LastApplyResultOf` to take
+     `any` and runtime-detect. But that touches `pkg/dataplane`, out
+     of scope.
+   - **Option B (chosen):** keep `c.dp` typed as `cliRuntime`, but
+     **also** keep a `c.dpLegacy dataplane.DataPlane` field for the
+     one call site that needs it. Pass both at `New()`. This is a
+     pragmatic interim — `LastApplyResultOf` is itself slated for
+     refactor in S4 (`docs/pr/1451-migration-scope/scope.md`
+     identifies the legacy accessor cleanup as the same step).
+   - **Option C (alternative):** add `LastApplyResult() *ApplyResult`
+     to `cliRuntime`. The legacy DataPlane has this method (verify);
+     this is the cleanest fix. **Open question for review** —
+     §11 Q3.
+4. **HA paths.** The CLI does not touch session-sync or HA itself.
+   `cluster.Manager` is a separate field (`cli.cluster`). The
+   `request chassis cluster failover` paths use `cm.*` not `dp.*`,
+   so no HA invariant is at risk from this PR.
+5. **Test files (`*_test.go`).** Tests under `pkg/cli/` that
+   construct fake dataplanes do so via a minimal interface or via
+   nil — count and fix any test whose fake implements only the
+   minimal set. See §9.
+6. **Pure refactor — no behavioural change.** The CLI must produce
+   bit-identical output for every supported command. Smoke (§9)
+   covers interactive bring-up + the specific show/clear paths
+   listed in #1517 acceptance criteria.
+
+## 7. Risk assessment
+
+| Class | Risk | Mitigation |
+|---|---|---|
+| Behavioural regression | LOW | Pure type rename; interface is strict subset. `make test ./pkg/cli/...` + smoke covers all touched commands. |
+| Lifetime / borrow-checker | N/A | Go, not Rust. Interface satisfaction is structural and checked at compile time. |
+| Performance regression | NONE | Adds one virtual call indirection at the same spot it already exists. Operator-path code, not hot path. |
+| Architectural mismatch (#961 / #946 Phase 2 pattern) | LOW | Pattern shipped four times already on this codebase (`pkg/api`, `pkg/fwdstatus`, `pkg/monitoriface`, `pkg/conntrack`). Scope doc explicitly endorses it. No data-flow inversion, no batch-boundary churn. |
+
+## 8. What the PR does NOT do (out of scope)
+
+- **No daemon `legacyDP()` shrinkage.** That is S4. After this PR
+  lands, `d.legacyDP()` still returns the full legacy interface; it
+  just gets implicitly downcast to `cliRuntime` at the CLI boundary.
+- **No shared `pkg/dpiface` extraction.** The scope doc mentions it as
+  a possible follow-up if S1 + S2 land in tight succession. Sibling
+  agent on #1516 is migrating `pkg/grpcapi` in parallel — neither PR
+  should try to extract a shared package; do that **after** both land
+  in a separate PR with both consumers visible.
+- **No removal of `dataplane.DataPlane` import from `pkg/cli`.** The
+  package still imports `dataplane` for type names
+  (`dataplane.SessionKey`, `dataplane.SessionValue`,
+  `dataplane.CounterValue`, etc.) and for `dataplane.LastApplyResultOf`.
+  The goal is only to stop treating `dataplane.DataPlane` as a field
+  type / parameter type.
+- **No changes to `pkg/grpcapi`, `pkg/daemon`, `pkg/cluster`, or any
+  file outside `pkg/cli/`** — sibling agents own those.
+- **No README/doc updates outside `pkg/cli/`** if doc text in other
+  packages still mentions the old shape; that's an unrelated drift.
+
+## 9. Test plan
+
+1. `make build` — daemon + CLI compile.
+2. `make build-ctl` — remote CLI compiles.
+3. `make test ./pkg/cli/...` — all CLI unit tests pass.
+4. `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` — full Go
+   suite passes (30+ packages).
+5. **5× flake check** on `pkg/cli` package tests
+   (`go test -count=1 ./pkg/cli/...` 5×).
+6. Smoke matrix on **loss userspace cluster only** (per CLAUDE.md):
+   - Pass A (CoS disabled): v4 + v6, push + reverse, plus 12-stream
+     `-P 12 -R` reproducer.
+   - Pass B (CoS enabled): 24-cell per-class smoke
+     (ports 5201–5206 × v4/v6 × push/reverse).
+7. **Interactive CLI smoke** per #1517 acceptance criteria:
+   - `cli` boots cleanly.
+   - `show flow session brief` returns sessions seen by smoke.
+   - `show security flow statistics` returns counters.
+   - `clear security flow session all` clears sessions.
+   - Tab completion, `?` help, pipe filters work.
+8. **No failover smoke required** — CLI does not touch session sync,
+   VRRP, or RG state. `cluster.Manager` is a separate field. The
+   scope doc and #1517 do not list `make test-failover` for S2.
+   (#1517 Smoke evidence section asks for the loss userspace cluster
+   smoke matrix only.)
+
+## 10. Open questions for adversarial review
+
+Each question is invitable to a **PLAN-KILL** verdict if the answer
+exposes a wrong-target architecture.
+
+1. **Q1: Is `Option C` (add `LastApplyResult()` to `cliRuntime`)
+   actually viable?** The CLI calls `dataplane.LastApplyResultOf(c.dp)`
+   in `applyResult()`. Either we add `LastApplyResult()` to
+   `cliRuntime` (clean — verify the underlying types expose it as a
+   method, not as a top-level free function), or we keep a
+   `c.dpLegacy dataplane.DataPlane` shadow field for that one call
+   site (ugly but localised). **Reviewers, please pick one before
+   PLAN-READY.**
+2. **Q2: Is dropping the inline provider probes in favour of named
+   interfaces actually behaviour-preserving?** Specifically: the
+   `cli_show_chassis.go:108` probe is `Status() (...)` only, while
+   `cli_helpers.go:183` probe is `Status + SetForwardingArmed +
+   SetQueueState + SetBindingState + InjectPacket`. The plan proposes
+   `cliUserspaceStatusProvider` for the first and
+   `cliUserspaceControlProvider` (extending the first) for the
+   second. **Verify by reading both inline interfaces and confirming
+   no method is added or dropped silently.** A subtle drift (e.g.,
+   forgetting `InjectPacket`) would silently disable a CLI command on
+   the userspace path.
+3. **Q3: Should we wait for #1516 to land first and extract a shared
+   `pkg/dpiface`?** The scope doc says "if both land in close
+   succession, extract a shared `pkg/dataplane/runtime` package."
+   Doing both in parallel risks merge conflicts on the shared
+   interface. Plan picks "two independent interfaces now, factor
+   later" — is that right, or should this PR block on #1516?
+4. **Q4: Are there CLI callsites that pass `c.dp` to a function
+   typed `dataplane.DataPlane`?** Beyond `LastApplyResultOf`, find
+   any helper that takes the full interface and would now reject a
+   `cliRuntime`. `grep -n 'dataplane\.DataPlane' pkg/cli/*.go`.
+5. **Q5: Is the test plan adequate?** The CLI has many code paths
+   (`show flow session`, `show security policies`, `show interfaces
+   extensive`, `show system buffers`, etc.). Smoke covers interactive
+   bring-up + the three commands #1517 names. Should the test plan
+   require additional commands (e.g. `show chassis forwarding`,
+   `show system buffers`, `show security flow status`) to exercise
+   each `c.dp.(interface{...})` probe path? Recommend yes; explicit
+   smoke commands are added in §9 step 7 — confirm or expand.
+6. **Q6: Does the `c.dp == nil` guard still work?** With
+   `cliRuntime` as an interface, a typed-nil concrete pointer
+   wrapped in `cliRuntime` would not equal `nil`. Verify the
+   daemon's `legacyDP()` never returns a typed-nil and add a test
+   if needed.
+7. **Q7 (architectural-kill candidate): Is there a reason to
+   consolidate `pkg/cli` and `pkg/grpcapi` *before* the migration —
+   e.g., is there a plan to delete `pkg/cli` once remote CLI is
+   feature-complete?** If so, this migration is wasted work.
+   #1517's existence and #1451 scope doc both presuppose `pkg/cli`
+   stays. Confirm.
+
+---
+
+End of plan v1.

--- a/docs/pr/1517-cli-migration/plan.md
+++ b/docs/pr/1517-cli-migration/plan.md
@@ -161,8 +161,9 @@ type cliUserspaceStatusProvider interface {
 }
 
 // cliUserspaceControlProvider extends the status provider with the
-// mutating control operations used by `request security flow ...`
-// and similar diag commands.
+// mutating control operations used by `request chassis cluster
+// data-plane userspace ...` (the sole CLI consumer, handled in
+// cli_request.go:handleRequestChassisClusterDataPlane).
 type cliUserspaceControlProvider interface {
     cliUserspaceStatusProvider
     SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)

--- a/docs/pr/1517-cli-migration/reviewer-ids.md
+++ b/docs/pr/1517-cli-migration/reviewer-ids.md
@@ -13,10 +13,30 @@ All Codex findings were non-blocking corrections to plan text; AGY
 PLAN-READY stands. v2 changes are strictly informational/typo-level;
 proceeding to implementation.
 
-## Code review round 1 (PR #1549, head e46f88ee)
+## Code review round 1 (PR #1549, head e46f88ee → 91e1da9f)
 
-- Codex: `task-mpkvc5y5-w0s3by` (dispatched 2026-05-25) — BLOCKED (couldn't access worktree shell).
-- Codex retry: `task-mpkvefey-0uj7su` (dispatched 2026-05-25 against main repo).
-- Antigravity: `adversarial-review-mpkvctz4-xk8x46` (dispatched 2026-05-25)
-- Copilot: requested via `gh pr edit --add-reviewer Copilot` and
-  `@copilot review` comment (#issuecomment-4532299929)
+- **Codex 1st attempt:** `task-mpkvc5y5-w0s3by` — BLOCKED (couldn't access worktree shell).
+- **Codex 2nd attempt:** `task-mpkvefey-0uj7su` — BLOCKED (same sandbox issue against main repo).
+- **Codex 3rd attempt (inline diff):** `task-mpkvl9cn-3we3in` — **MERGE-READY**.
+  - 25-method `cliRuntime` set verified; 5 inline probe replacements byte-identical;
+    Go structural subtyping reasoning sound; canary/docs updates lockstep;
+    smoke numbers plausible for a CLI-only refactor.
+  - Caveat: FS access still failed at sandbox; couldn't independently grep all 25
+    callsites. AGY filled the gap (see below).
+- **Antigravity:** `adversarial-review-mpkvctz4-xk8x46` — **MERGE-READY**.
+  - All 10 hostile checks verified with file:line evidence including byte-for-byte
+    quote of each `c.dp.<X>` callsite mapped to its `cliRuntime` declaration.
+  - Independently confirmed all 25 method completeness, provider-probe match,
+    daemon caller compatibility, LastApplyResultOf compile/runtime correctness,
+    test-fake compatibility, allowlist+README lockstep, no leakage across pkg
+    boundary, sibling-conflict-free.
+- **Copilot:** review COMMENTED (#issuecomment-4532299929) with 1 minor inline
+  finding on `cliUserspaceControlProvider` doc comment (path mismatch — said
+  `request security flow` but the actual CLI path is `request chassis cluster
+  data-plane userspace`). **Addressed in commit 91e1da9f**; re-review requested
+  via #issuecomment-4532367623.
+
+## Final verdict
+
+All three reviewers MERGE-READY. **Do NOT auto-merge** — author decides per
+project memory policy `feedback_no_autonomous_merge.md`.

--- a/docs/pr/1517-cli-migration/reviewer-ids.md
+++ b/docs/pr/1517-cli-migration/reviewer-ids.md
@@ -1,0 +1,14 @@
+# Reviewer task/job IDs for #1517 plan + code review rounds
+
+## Plan review round 1 (plan v1, commit 713997fc)
+
+- Codex: `task-mpkukwfs-gl3fv4` — **PLAN-NEEDS-MINOR** (dispatched 2026-05-24; bg wrapper `bgmk1kuun`)
+  - Q1 reframe (LastApplyResultOf already `any`); scope.md citation fix; FloodState type fix.
+- Antigravity: `adversarial-review-mpkuldhp-mnlp6x` — **PLAN-READY** (dispatched 2026-05-24)
+  - No findings; verified all seven hostile checks pass.
+
+## Plan v2 (folded Codex minor findings) — no re-dispatch needed
+
+All Codex findings were non-blocking corrections to plan text; AGY
+PLAN-READY stands. v2 changes are strictly informational/typo-level;
+proceeding to implementation.

--- a/docs/pr/1517-cli-migration/reviewer-ids.md
+++ b/docs/pr/1517-cli-migration/reviewer-ids.md
@@ -12,3 +12,11 @@
 All Codex findings were non-blocking corrections to plan text; AGY
 PLAN-READY stands. v2 changes are strictly informational/typo-level;
 proceeding to implementation.
+
+## Code review round 1 (PR #1549, head e46f88ee)
+
+- Codex: `task-mpkvc5y5-w0s3by` (dispatched 2026-05-25) — BLOCKED (couldn't access worktree shell).
+- Codex retry: `task-mpkvefey-0uj7su` (dispatched 2026-05-25 against main repo).
+- Antigravity: `adversarial-review-mpkvctz4-xk8x46` (dispatched 2026-05-25)
+- Copilot: requested via `gh pr edit --add-reviewer Copilot` and
+  `@copilot review` comment (#issuecomment-4532299929)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -47,7 +47,7 @@ import (
 type CLI struct {
 	rl              *readline.Instance
 	store           *configstore.Store
-	dp              dataplane.DataPlane
+	dp              cliRuntime
 	eventBuf        *logging.EventBuffer
 	eventReader     *logging.EventReader
 	routing         *routing.Manager
@@ -105,7 +105,7 @@ type CLI struct {
 }
 
 // New creates a new CLI.
-func New(store *configstore.Store, dp dataplane.DataPlane, eventBuf *logging.EventBuffer, eventReader *logging.EventReader, rm *routing.Manager, fm *frr.Manager, im *ipsec.Manager, dm *dhcp.Manager, dr *dhcprelay.Manager, cm *cluster.Manager) *CLI {
+func New(store *configstore.Store, dp cliRuntime, eventBuf *logging.EventBuffer, eventReader *logging.EventReader, rm *routing.Manager, fm *frr.Manager, im *ipsec.Manager, dm *dhcp.Manager, dr *dhcprelay.Manager, cm *cluster.Manager) *CLI {
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "xpf"

--- a/pkg/cli/cli_helpers.go
+++ b/pkg/cli/cli_helpers.go
@@ -164,29 +164,15 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 }
 
 func (c *CLI) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
-	provider, ok := c.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	})
+	provider, ok := c.dp.(cliUserspaceStatusProvider)
 	if !ok {
 		return dpuserspace.ProcessStatus{}, fmt.Errorf("userspace status unavailable")
 	}
 	return provider.Status()
 }
 
-func (c *CLI) userspaceDataplaneControl() (interface {
-	Status() (dpuserspace.ProcessStatus, error)
-	SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
-	SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-	SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-	InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
-}, error) {
-	provider, ok := c.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-		SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
-		SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-		SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-		InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
-	})
+func (c *CLI) userspaceDataplaneControl() (cliUserspaceControlProvider, error) {
+	provider, ok := c.dp.(cliUserspaceControlProvider)
 	if !ok {
 		return nil, fmt.Errorf("userspace dataplane control unavailable")
 	}

--- a/pkg/cli/cli_show_chassis.go
+++ b/pkg/cli/cli_show_chassis.go
@@ -105,9 +105,7 @@ func (c *CLI) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
 		return nil
 	}
 	base := forwardingStatusCLIDataPlane{cli: c}
-	if _, ok := c.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}); ok {
+	if _, ok := c.dp.(cliUserspaceStatusProvider); ok {
 		return forwardingStatusCLIUserspaceDataPlane{forwardingStatusCLIDataPlane: base}
 	}
 	return base

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -23,9 +23,7 @@ func (c *CLI) showSystemBuffers() error {
 		fmt.Println("Dataplane not loaded")
 		return nil
 	}
-	if provider, ok := c.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}); ok {
+	if provider, ok := c.dp.(cliUserspaceStatusProvider); ok {
 		status, err := provider.Status()
 		if err != nil {
 			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)
@@ -85,9 +83,7 @@ func (c *CLI) showSystemBuffersDetail() error {
 		fmt.Println("Dataplane not loaded")
 		return nil
 	}
-	if provider, ok := c.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}); ok {
+	if provider, ok := c.dp.(cliUserspaceStatusProvider); ok {
 		status, err := provider.Status()
 		if err != nil {
 			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -1,0 +1,87 @@
+// Package cli — runtime interface used by the interactive Junos CLI.
+//
+// The migration target for #1517 (sub-#1451 S2): replace the legacy
+// dataplane.DataPlane parameter/field with cliRuntime, a narrow
+// CLI-specific surface that lists exactly the methods pkg/cli/*.go
+// invokes via c.dp.*. This mirrors the pattern already shipped by
+// pkg/api (apiRuntimeDataPlane), pkg/fwdstatus (DataPlaneAccessor),
+// pkg/monitoriface (RuntimeDataPlane), and pkg/conntrack
+// (RuntimeDomainProvider).
+//
+// cliRuntime is a strict subset of dataplane.DataPlane. Every concrete
+// dataplane in the tree today (the legacy eBPF Manager, the userspace
+// LegacyDataPlaneAdapter, the DPDK manager) already satisfies it.
+package cli
+
+import (
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// cliRuntime is the narrow, CLI-specific view of the dataplane.
+//
+// Do NOT widen this set without a callsite reason. If a new c.dp.<X>
+// invocation appears in pkg/cli, add it here and audit whether it
+// truly needs to be on the operator-CLI surface, or whether it should
+// be served via a typed domain provider on c instead.
+type cliRuntime interface {
+	// Lifecycle / health
+	IsLoaded() bool
+
+	// Compilation (used by candidate-config preview)
+	Compile(cfg *config.Config) (*dataplane.CompileResult, error)
+
+	// Counters
+	ReadGlobalCounter(idx uint32) (uint64, error)
+	ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error)
+	ReadZoneCounters(zoneID uint16, direction int) (dataplane.CounterValue, error)
+	ReadPolicyCounters(ruleID uint32) (dataplane.CounterValue, error)
+	ReadFilterConfig(filterID uint32) (dataplane.FilterConfig, error)
+	ReadFilterCounters(filterID uint32) (dataplane.CounterValue, error)
+	ReadFloodCounters(zoneID uint16) (dataplane.FloodState, error)
+	ReadNATPortCounter(id uint32) (uint64, error)
+	ReadNATRuleCounter(id uint32) (dataplane.CounterValue, error)
+
+	// Sessions
+	SessionCount() (v4, v6 int)
+	IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	DeleteSession(key dataplane.SessionKey) error
+	DeleteSessionV6(key dataplane.SessionKeyV6) error
+
+	// DNAT static entry delete (used by filtered session clear)
+	DeleteDNATEntry(key dataplane.DNATKey) error
+	DeleteDNATEntryV6(key dataplane.DNATKeyV6) error
+
+	// Clear-counter / clear-session bulk ops
+	ClearAllCounters() error
+	ClearAllSessions() (v4, v6 int, err error)
+	ClearFilterCounters() error
+	ClearNATRuleCounters() error
+	ClearPolicyCounters() error
+
+	// Map stats + persistent NAT table (used by show + clear NAT bindings)
+	GetMapStats() []dataplane.MapStats
+	GetPersistentNAT() *dataplane.PersistentNATTable
+}
+
+// cliUserspaceStatusProvider is implemented by dataplanes that expose
+// the userspace helper's ProcessStatus snapshot (queue/binding/CoS).
+// Replaces the inline `c.dp.(interface{ Status() ... })` probes in
+// cli_show_chassis.go and cli_show_system.go.
+type cliUserspaceStatusProvider interface {
+	Status() (dpuserspace.ProcessStatus, error)
+}
+
+// cliUserspaceControlProvider extends the status provider with the
+// mutating control operations used by `request security flow ...`
+// and similar diag commands. Replaces the larger inline interface
+// probe in cli_helpers.go used by `requestSecurityFlow*` paths.
+type cliUserspaceControlProvider interface {
+	cliUserspaceStatusProvider
+	SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
+	SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+	SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+	InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
+}

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -75,9 +75,11 @@ type cliUserspaceStatusProvider interface {
 }
 
 // cliUserspaceControlProvider extends the status provider with the
-// mutating control operations used by `request security flow ...`
-// and similar diag commands. Replaces the larger inline interface
-// probe in cli_helpers.go used by `requestSecurityFlow*` paths.
+// mutating control operations used by `request chassis cluster
+// data-plane userspace ...` (the sole CLI consumer, handled in
+// cli_request.go:handleRequestChassisClusterDataPlane). Replaces the
+// larger inline anonymous interface probe in cli_helpers.go's
+// userspaceDataplaneControl helper.
 type cliUserspaceControlProvider interface {
 	cliUserspaceStatusProvider
 	SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -36,6 +36,7 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/api/metrics.go":                       "Prometheus telemetry still reads legacy counters and metadata",
 	"pkg/cli/cli.go":                           "embedded CLI constructor still stores the legacy bridge",
 	"pkg/cli/cli_clear.go":                     "clear commands still delete legacy session entries",
+	"pkg/cli/runtime.go":                       "#1517 cliRuntime interface declares the narrow CLI surface; still depends on root pkg/dataplane type names (SessionKey, CounterValue, etc.) until those types move to a domain package",
 	"pkg/cli/cli_show_flow.go":                 "flow display still uses legacy session keys and values",
 	"pkg/cli/cli_show_nat.go":                  "NAT display still uses legacy NAT/session metadata",
 	"pkg/cli/cli_show_security.go":             "security display still uses legacy counters and filter types",


### PR DESCRIPTION
## Summary

Replace `cli.dp` and `cli.New`'s second parameter (typed
`dataplane.DataPlane`) with a narrow `cliRuntime` interface declared
in a new `pkg/cli/runtime.go`. Mirrors the pattern already shipped
by `pkg/api`/`pkg/fwdstatus`/`pkg/monitoriface`/`pkg/conntrack`. Five
inline anonymous `interface{...}` provider probes consolidate into
two named interfaces (`cliUserspaceStatusProvider` +
`cliUserspaceControlProvider`).

Pure decoupling refactor; zero behavioural change. `cliRuntime` is
a strict subset of `dataplane.DataPlane`, so the daemon still passes
`d.legacyDP()` unchanged.

Closes #1517. Refs #1451, #1373.

## Plan + adversarial review

Plan doc: [`docs/pr/1517-cli-migration/plan.md`](https://github.com/psaab/xpf/blob/refactor/1517-cli-migration/docs/pr/1517-cli-migration/plan.md)

- Codex round-1 (`task-mpkukwfs-gl3fv4`): **PLAN-NEEDS-MINOR** — minor framing fixes (`LastApplyResultOf` is already `any`-typed at `apply.go:54`, so no Option B shadow field or Option C interface widening is needed; scope.md citation softened; FloodState type typo). All folded into plan v2.
- Antigravity round-1 (`adversarial-review-mpkuldhp-mnlp6x`): **PLAN-READY** across all seven hostile checks (byte-for-byte provider-probe match, 25-method completeness, test-fake compatibility under interface subset rule, no HA touchpoint, no architectural mismatch).

Reviewer IDs recorded at `docs/pr/1517-cli-migration/reviewer-ids.md`.

## Test plan

- [x] cargo + Go build clean
- [x] `go test ./pkg/cli/...` 5/5 flake pass
- [x] `go test -count=1 ./...` full suite green (30+ packages)
- [x] Deploy on loss userspace cluster (`xpf-userspace-fw0/fw1`)
- [x] **Pass A — CoS disabled** (best-effort fast path)
  - [x] v4 push: 7.88 Gb/s, **0 retr** (172.16.80.200)
  - [x] v4 reverse (`-R`): 8.12 Gb/s, **0 retr**
  - [x] v6 push: 7.99 Gb/s, **0 retr** (2001:559:8585:80::200)
  - [x] v6 reverse (`-R`): 8.15 Gb/s, **0 retr**
  - [x] v4 multi-stream `-P 12 -R`: **22.6 Gb/s, 0 retr**
  - [x] v6 multi-stream `-P 12 -R`: **20.3 Gb/s, 0 retr**
- [x] **Pass B — CoS enabled** (per-class shaper + classifier)
  - [x] All 24 cells (5201–5206 × v4/v6 × push/reverse) connectivity confirmed
  - [x] Shaped classes hit configured rates cleanly:
    - iperf-a (100m): 83/82 Mbps push (shaped)
    - iperf-b (1g): 839/828 Mbps push (shaped)
    - iperf-c (3g): 2.51/2.48 Gbps push (shaped)
    - iperf-d/e/f (6/9/12g): 4.8/5.5/6.0 Gbps push
- [x] **Interactive CLI smoke** (#1517 acceptance criteria)
  - [x] `cli` boots, tab + `?` work
  - [x] `show security flow session brief` shows sessions during smoke
  - [x] `show security flow statistics` returns counters
  - [x] `clear security flow session all` clears
  - [x] `show system buffers` exercises `cliUserspaceStatusProvider`
  - [x] `show chassis forwarding` exercises `cliUserspaceStatusProvider`
  - [x] `request chassis cluster data-plane userspace` exercises `cliUserspaceControlProvider`

No `make test-failover` required: CLI touches neither session-sync, VRRP, nor failover state machines; `cluster.Manager` is a separate field on `cli` and is unchanged by this PR (verified by grep — no `SessionSync`/`SetSessionV4`/`SetSessionV6` references anywhere in `pkg/cli/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)