### PR TITLE
dataplane: extract userspace daemon boot path from legacy factory (#1520)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,18 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T20:00:00Z
+  - **Action**: #1520 plan v1 DRAFT — extract userspace boot path
+    from legacy `dataplane.New()` (sub-#1451 S5). Adds
+    `userspace.Boot()` constructor + daemon `buildRuntimeDataPlane`
+    wrapper that fences the legacy registry off to the
+    `dataplane-type ebpf` rollback. Plan explicitly out-of-scopes
+    the `bpfShim` field rename (forbidden by existing AST canary)
+    and the `maps_sync.go` map-name decoupling (#1521 sibling work).
+  - **File(s)**:
+    `docs/pr/1520-userspace-boot-extraction/plan.md`,
+    `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
+
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR
     (load merge syntax in plan recovery) + 3 Copilot nits:

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,20 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T15:20:00Z
+  - **Action**: PR #1550 round-2 Copilot wording drift follow-up.
+    Updated the `userspace.Boot()` doc/canary comments to name the
+    actual remaining legacy `dataplane.DataPlane` consumers
+    (`daemon.legacyDP()` handoffs into CLI, gRPC, and cluster
+    session-sync) instead of stale pkg/api/pkg/conntrack/pkg/fwdstatus
+    examples. Also fixed `pkg/dataplane/README.md` so the
+    `NewRuntimeDataPlane` fall-through text matches the code's
+    non-userspace branch, including unknown/custom type error
+    propagation.
+  - **File(s)**: `pkg/dataplane/userspace/manager.go`,
+    `pkg/dataplane/userspace/userspace_boot_canary_test.go`,
+    `pkg/dataplane/README.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-25T23:30:00Z
   - **Action**: PR #1550 round-1 doc + wording follow-ups merged.
     Copilot agent pushed be8a7b6d updating

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,22 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-26T01:00:00Z
+  - **Action**: Round-3 reviewer verdicts complete on PR #1550 HEAD
+    444a1959. Codex MERGE-READY (no findings). AGY MERGE-READY
+    (8/8 invariants verified, 3 Copilot round-2 nits resolved).
+    Copilot round-3 COMMENTED with no new comments — implicit
+    MERGE-READY. 4-of-4 reviewers agree (including Claude SMR).
+    Smoke matrix on loss userspace cluster: PASS — per-class v4/v6
+    × push/-R matrix consistent and healthy. Best-effort port 5201
+    ~80 Mbps push is expected (low-priority CoS surplus floor
+    under concurrent class load). All other classes shaped
+    correctly per their CIR + surplus. Reverse direction 6-8 Gbps
+    across all classes. Smoke results posted as PR comment. PR
+    ready for author merge.
+  - **File(s)**: smoke matrix on loss:xpf-userspace-fw0/fw1; no
+    code changes.
+
 - **Timestamp**: 2026-05-26T00:30:00Z
   - **Action**: PR #1550 round-2 reviews landed. Codex MERGE-READY
     (no findings; all wording fixes confirmed). AGY MERGE-READY

--- a/_Log.md
+++ b/_Log.md
@@ -2,14 +2,34 @@
 
 ## 2026-05-25
 
-- **Timestamp**: 2026-05-25T15:25:00Z
-  - **Action**: PR #1520 follow-up doc fix after Copilot review request.
-    Updated `pkg/dataplane/README.md` and `pkg/daemon/README.md` so the
-    documented boot path matches the landed code: daemon startup now picks
-    `userspace.Boot()` directly for default / explicit userspace and keeps
-    `dataplane.NewRuntimeDataPlane()` only for the explicit legacy eBPF
-    rollback and the retired-DPDK sentinel path.
-  - **File(s)**: `pkg/dataplane/README.md`, `pkg/daemon/README.md`, `_Log.md`
+- **Timestamp**: 2026-05-25T23:30:00Z
+  - **Action**: PR #1550 round-1 doc + wording follow-ups merged.
+    Copilot agent pushed be8a7b6d updating
+    `pkg/dataplane/README.md` and `pkg/daemon/README.md` to align
+    doc text with the landed code (boot path via
+    `userspace.Boot()`; legacy factory only for ebpf rollback +
+    DPDK sentinel). Rebased local round-1 review fixes on top.
+  - **File(s)**: `pkg/dataplane/README.md`, `pkg/daemon/README.md`
+
+- **Timestamp**: 2026-05-25T23:00:00Z
+  - **Action**: PR #1550 round-1 code review feedback addressed.
+    Copilot inline nits: (1) Boot() doc misdescribed the userspace
+    registry path as "rollback" — clarified that the userspace
+    registry entry is the compatibility/test seam and the ebpf
+    rollback goes through the legacy factory's TypeEBPF switch,
+    not the userspace registry; (2) buildRuntimeDataPlane doc said
+    the default branch is "only" for ebpf/dpdk — rewrote to
+    acknowledge unknown/custom types also flow through and surface
+    the legacy factory's error verbatim. AGY minor coverage gap:
+    added TestBuildRuntimeDataPlaneUnknownTypePropagatesError to
+    lock in the unknown-type error propagation and to assert
+    ErrDPDKBackendRetired stays reserved for "dpdk". AGY code
+    review verdict: MERGE-READY (8 findings clean).
+  - **File(s)**:
+    `pkg/dataplane/userspace/manager.go`,
+    `pkg/daemon/daemon_run.go`,
+    `pkg/daemon/dataplane_boot_test.go`,
+    `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
 
 - **Timestamp**: 2026-05-25T22:30:00Z
   - **Action**: #1520 plan v4 + implementation. v2 added Claude SMR

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,15 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T15:25:00Z
+  - **Action**: PR #1520 follow-up doc fix after Copilot review request.
+    Updated `pkg/dataplane/README.md` and `pkg/daemon/README.md` so the
+    documented boot path matches the landed code: daemon startup now picks
+    `userspace.Boot()` directly for default / explicit userspace and keeps
+    `dataplane.NewRuntimeDataPlane()` only for the explicit legacy eBPF
+    rollback and the retired-DPDK sentinel path.
+  - **File(s)**: `pkg/dataplane/README.md`, `pkg/daemon/README.md`, `_Log.md`
+
 - **Timestamp**: 2026-05-25T22:30:00Z
   - **Action**: #1520 plan v4 + implementation. v2 added Claude SMR
     refinements (no-arg Boot, behavioral canaries). v3 addressed

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,31 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T22:30:00Z
+  - **Action**: #1520 plan v4 + implementation. v2 added Claude SMR
+    refinements (no-arg Boot, behavioral canaries). v3 addressed
+    Codex round-2 PLAN-NEEDS-MAJOR (9 findings: structural value
+    statement, default-route invariant, dropped text-shape canary,
+    behavioral helper tests, BootOptions dropped, rollback/test-seam
+    wording). v4 addressed AGY round-2 CRITICAL: existing AST canary
+    `TestDaemonRuntimeEntryPointUsesRuntimeDataPlane` requires
+    `daemon_run.go` to literally reference
+    `dataplane.NewRuntimeDataPlane(...)`; pinned the helper inside
+    `daemon_run.go` and kept the non-userspace branch routed through
+    that factory call to preserve the canary. Codex round-3
+    PLAN-NEEDS-MINOR confirmed two stale strings ("BootOptions{}"
+    in §8.5 and "rollback" in §4.3 heading) — both fixed in v4.
+    Implementation: added `userspace.Boot()` + helper
+    `buildRuntimeDataPlane` in daemon_run.go + two canary test
+    files. Full Go suite green; 5x flake stable.
+  - **File(s)**:
+    `docs/pr/1520-userspace-boot-extraction/plan.md`,
+    `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`,
+    `pkg/dataplane/userspace/manager.go`,
+    `pkg/daemon/daemon_run.go`,
+    `pkg/dataplane/userspace/userspace_boot_canary_test.go`,
+    `pkg/daemon/dataplane_boot_test.go`
+
 - **Timestamp**: 2026-05-25T20:00:00Z
   - **Action**: #1520 plan v1 DRAFT — extract userspace boot path
     from legacy `dataplane.New()` (sub-#1451 S5). Adds

--- a/_Log.md
+++ b/_Log.md
@@ -2,19 +2,23 @@
 
 ## 2026-05-25
 
-- **Timestamp**: 2026-05-25T15:20:00Z
-  - **Action**: PR #1550 round-2 Copilot wording drift follow-up.
-    Updated the `userspace.Boot()` doc/canary comments to name the
-    actual remaining legacy `dataplane.DataPlane` consumers
-    (`daemon.legacyDP()` handoffs into CLI, gRPC, and cluster
-    session-sync) instead of stale pkg/api/pkg/conntrack/pkg/fwdstatus
-    examples. Also fixed `pkg/dataplane/README.md` so the
-    `NewRuntimeDataPlane` fall-through text matches the code's
-    non-userspace branch, including unknown/custom type error
-    propagation.
-  - **File(s)**: `pkg/dataplane/userspace/manager.go`,
+- **Timestamp**: 2026-05-26T00:30:00Z
+  - **Action**: PR #1550 round-2 reviews landed. Codex MERGE-READY
+    (no findings; all wording fixes confirmed). AGY MERGE-READY
+    (8/8 invariants verified). Copilot round-2 surfaced 3 doc-only
+    nits: stale legacy-caller list (pkg/api/pkg/conntrack/
+    pkg/fwdstatus → actual: pkg/cli, pkg/grpcapi, pkg/cluster via
+    daemon.legacyDP()), in both Boot() docstring and
+    userspace_boot_canary_test.go; plus README "only ebpf/dpdk"
+    wording missing unknown-type pass-through. Copilot agent
+    pushed fffe3e41 ("docs: fix PR #1550 wording drift") with the
+    same fixes; rebased local 3ea74518 on top — same content, took
+    Copilot agent's version verbatim during rebase since the two
+    wordings are equivalent.
+  - **File(s)**:
+    `pkg/dataplane/userspace/manager.go`,
     `pkg/dataplane/userspace/userspace_boot_canary_test.go`,
-    `pkg/dataplane/README.md`, `_Log.md`
+    `pkg/dataplane/README.md`
 
 - **Timestamp**: 2026-05-25T23:30:00Z
   - **Action**: PR #1550 round-1 doc + wording follow-ups merged.

--- a/docs/pr/1520-userspace-boot-extraction/plan.md
+++ b/docs/pr/1520-userspace-boot-extraction/plan.md
@@ -1,0 +1,492 @@
+# #1520 Plan: Extract Userspace Boot Path From Legacy `dataplane.New()`
+
+**Status:** DRAFT v1 — pending adversarial plan review.
+
+**Scope (one line):** sub-#1451 S5; provide a userspace-native
+constructor that does not require the legacy `dataplane.New()`
+registry round-trip for daemon startup, while keeping the explicit
+retained AF_XDP XDP-shim subset of the legacy `dataplane.Manager`
+that the userspace runtime intentionally still uses.
+
+If reviewers conclude the extraction does not meaningfully reduce
+coupling — e.g., because the surviving `bpfShim` field still ties
+the userspace runtime to the legacy Manager type by AST canary —
+PLAN-KILL is an acceptable verdict.
+
+## 1. Issue framing
+
+`pkg/dataplane/userspace/manager.go` constructs the userspace
+backend through `dataplane.RegisterRuntimeBackend(TypeUserspace, …)`
+in an `init()`, and daemon startup reaches the userspace runtime
+through `dataplane.NewRuntimeDataPlane(dpType)` which:
+
+1. routes empty default (`EffectiveType("")` → `"userspace"`) to
+   the userspace registry constructor;
+2. calls the registry closure, which calls `userspace.New()`;
+3. wraps the result in `*LegacyDataPlaneAdapter` for legacy callers.
+
+`userspace.New()` in turn calls `dataplane.New()` to build a full
+legacy `*dataplane.Manager`, then calls
+`SelectUserspaceXDPShimEntryProgram()` to retarget the XDP entry
+program for future attachments. The userspace runtime only uses a
+narrow subset of that Manager — the retained AF_XDP XDP-shim
+loader (`LoadUserspaceShim`/`CompileUserspaceShim`), the shared
+shim/session maps (`userspace_ctrl`, `userspace_bindings`,
+`userspace_xsk_map`, `sessions`, `sessions_v6`, `fib_gen_map`,
+…), and a handful of HA/fabric/counter helpers — but the registry
+indirection and the `New()`-shaped construction hide that.
+
+The acceptance criteria from #1520 say:
+
+> - A new `userspace.Boot()` (or equivalent) constructs the
+>   userspace manager without going through
+>   `dataplane.New(TypeUserspace)`.
+> - The `xdp_main_prog` / `xdp_userspace_prog` swap path either
+>   moves into the dedicated userspace-XDP shim (per #1473) or is
+>   documented as the explicit retained fallback with a structured
+>   config gate.
+> - Backend registration via `RegisterBackend(TypeUserspace, …)`
+>   either remains for the rollback path (`dataplane-type ebpf`) or
+>   is documented as removed in coordination with #1474.
+
+#1474 is closed; explicit `dataplane-type ebpf` is the only
+remaining rollback. #1473 is still open and #1493/#1494 already
+landed (loader split + canary).
+
+## 2. Honest scope / value framing
+
+This is **not** a performance change. The retained `bpfShim` field
+in `userspace.Manager` is intentionally kept under an AST canary
+(`TestUserspaceManagerDoesNotEmbedLegacyDataPlane`) that requires
+the field to remain — see
+`pkg/dataplane/userspace/manager_coupling_test.go:53`:
+
+```go
+if !hasExplicitBPFShim {
+    t.Fatal("userspace Manager must keep an explicit bpfShim field for userspace XDP maps")
+}
+```
+
+So the structural value of #1520 is **not** to remove the typed
+`*dataplane.Manager` field from `userspace.Manager`. It is to:
+
+1. give the **construction call chain** in `cmd/xpfd/main.go` →
+   `pkg/daemon/daemon_run.go` a userspace-native entry point that
+   does not require `dataplane.NewRuntimeDataPlane(TypeUserspace)`
+   to detour through the legacy registry, while still resolving the
+   default (empty `dataplane-type`) the same way at the
+   configuration layer;
+2. give the codebase a single named seam — `userspace.Boot()` — for
+   future #1521 (maps-name decoupling) and #1473 (XDP shim split)
+   to thread their narrower types through, rather than each one
+   re-deriving the construction chain;
+3. classify the `dataplane-type ebpf` rollback path explicitly so
+   the legacy `dataplane.New()` constructor and the
+   `xdp_main_prog`/`xdp_userspace_prog` swap stay clearly fenced off
+   to that one branch.
+
+If reviewers feel that adding `userspace.Boot()` is a thin rename
+of `userspace.New()` plus a tiny daemon wiring change, **that is
+exactly the scope this slice intends**. We are not chasing a Manager
+type split here; the canary explicitly forbids it. #1520 is a
+construction-chain seam, not an internal Manager split.
+
+The Manager-shape split — moving `bpfShim` to a typed
+`UserspaceXDPShimLoader` that only owns the XDP shim
+programs/maps — is intentionally **out of scope** for this slice
+because it touches six files (`manager.go`, `manager_ha.go`,
+`maps_sync.go`, `policycounters.go`, `process.go`,
+`legacy_dataplane.go`) and overlaps with the in-flight #1521
+maps_sync rename. Doing it here would collide with the sibling
+agent's work and require re-running the smoke matrix twice.
+
+## 3. What's already shipped
+
+- **#1494** (PR merged): canary that keeps the retained userspace
+  shim boundary stable.
+- **#1493** (closed): userspace shim loader split. The current code
+  already has `LoadUserspaceShim()` and `CompileUserspaceShim()`
+  that bypass `loadAllObjects()`. `userspace.Manager.Load()` calls
+  `bpfShim.LoadUserspaceShim()`, not the legacy `Load()`.
+- **#1474** (closed): omitted `dataplane-type` already resolves to
+  userspace via `EffectiveType("")`.
+- **#1381** (closed for blocking interface split): `RuntimeDataPlane`
+  interface exists; `userspace.Manager` implements it.
+- **Existing AST canary** in
+  `pkg/dataplane/userspace/manager_coupling_test.go` enforces:
+  - `Manager` does not embed `dataplane.DataPlane`;
+  - `Manager` keeps a typed `bpfShim *dataplane.Manager` field
+    (load-bearing — do not remove);
+  - `*Manager` does NOT implement `dataplane.DataPlane`;
+  - `*Manager` DOES implement `dataplane.RuntimeDataPlane`;
+  - `NewRuntimeDataPlane(TypeUserspace)` returns
+    `*LegacyDataPlaneAdapter` (the legacy-compatibility wrapper).
+
+The existing factory path is at `pkg/dataplane/dataplane.go:173`:
+
+```go
+func NewRuntimeDataPlane(dpType string) (RuntimeDataPlane, error) {
+    dpType = EffectiveType(dpType)
+    switch dpType {
+    case TypeEBPF:
+        return New(), nil
+    case TypeDPDK:
+        return nil, ErrDPDKBackendRetired
+    default:
+        if ctor, ok := runtimeBackendRegistry[dpType]; ok {
+            return ctor(), nil
+        }
+        ...
+    }
+}
+```
+
+And the registry side at `pkg/dataplane/userspace/manager.go:60`:
+
+```go
+func init() {
+    dataplane.RegisterRuntimeBackend(dataplane.TypeUserspace, func() dataplane.RuntimeDataPlane {
+        return NewLegacyDataPlaneAdapter(New())
+    })
+}
+```
+
+## 4. Concrete design
+
+### 4.1 Add `userspace.Boot()` as the userspace-native constructor
+
+In `pkg/dataplane/userspace/manager.go`, add:
+
+```go
+// BootOptions configure userspace-native boot. Empty options select
+// the userspace AF_XDP runtime in its current compat-mode default.
+type BootOptions struct {
+    // Reserved for future use (e.g., explicit mode override, fail-closed
+    // helper unavailability handling). Empty today; we add the struct
+    // up-front so signature churn does not propagate when #1521 / #1473
+    // need to thread additional config in.
+}
+
+// Boot constructs the userspace AF_XDP runtime and returns it as a
+// dataplane.RuntimeDataPlane wrapped in the legacy-compatible adapter.
+//
+// Daemon startup MUST prefer Boot() over dataplane.NewRuntimeDataPlane(
+// TypeUserspace) for the default and explicit userspace selections.
+// The legacy registry path is retained for the explicit
+// `dataplane-type ebpf` rollback only, because that branch deliberately
+// resolves through dataplane.New() and the legacy program loader.
+//
+// The returned value still implements dataplane.DataPlane via the
+// adapter, so unmigrated callers (pkg/cli, pkg/api, pkg/conntrack,
+// pkg/fwdstatus) continue to compile until #1451 finishes the surface
+// shrink.
+func Boot(opts BootOptions) dataplane.RuntimeDataPlane {
+    _ = opts // reserved
+    return NewLegacyDataPlaneAdapter(New())
+}
+```
+
+This is intentionally close to a typed rename. The new value is in
+the **call site** — daemon startup no longer needs to consult the
+runtime backend registry for the userspace path.
+
+### 4.2 Daemon startup chooses Boot() for userspace, registry for legacy
+
+In `pkg/daemon/daemon_run.go`, replace:
+
+```go
+dpType := ""
+if cfg := d.store.ActiveConfig(); cfg != nil {
+    dpType = cfg.System.DataplaneType
+}
+dp, err := dataplane.NewRuntimeDataPlane(dpType)
+```
+
+with:
+
+```go
+dpType := ""
+if cfg := d.store.ActiveConfig(); cfg != nil {
+    dpType = cfg.System.DataplaneType
+}
+dp, err := buildRuntimeDataPlane(dpType)
+```
+
+and add a small helper in `pkg/daemon/daemon_run.go` (or a new
+`pkg/daemon/dataplane_boot.go` if cleaner):
+
+```go
+// buildRuntimeDataPlane selects the userspace-native Boot() path for
+// the default and explicit userspace selections, and falls through to
+// dataplane.NewRuntimeDataPlane only for the explicit legacy eBPF
+// rollback (and the retired-DPDK error case). Keeping the legacy
+// branch routed through the dataplane factory preserves the
+// ErrDPDKBackendRetired sentinel handling unchanged.
+func buildRuntimeDataPlane(dpType string) (dataplane.RuntimeDataPlane, error) {
+    switch dataplane.EffectiveType(dpType) {
+    case dataplane.TypeUserspace:
+        return userspace.Boot(userspace.BootOptions{}), nil
+    default:
+        return dataplane.NewRuntimeDataPlane(dpType)
+    }
+}
+```
+
+### 4.3 Keep the runtime backend registration as the rollback / test
+seam
+
+The `init()` in `pkg/dataplane/userspace/manager.go` continues to
+register a userspace runtime backend so that
+`dataplane.NewRuntimeDataPlane("userspace")` still works for
+callers (tests, future operator surfaces) that go through the
+registry. The registry path stays a thin alias for the canonical
+`userspace.Boot()` constructor:
+
+```go
+func init() {
+    dataplane.RegisterRuntimeBackend(dataplane.TypeUserspace, func() dataplane.RuntimeDataPlane {
+        return Boot(BootOptions{})
+    })
+}
+```
+
+This satisfies #1520 acceptance criterion 3 ("Backend registration
+… either remains for the rollback path"): registration remains, and
+its presence is documented in code as the test/rollback seam, not
+the canonical daemon startup path.
+
+### 4.4 `xdp_main_prog` / `xdp_userspace_prog` swap path documentation
+
+Add a short doc paragraph in
+`docs/pr/1373-retire-ebpf-dataplane/source-removal-manifest-1476.md`
+under a new "Userspace boot path classification" section, and a
+shorter pointer comment at
+`pkg/dataplane/loader.go:100` (above
+`SelectUserspaceXDPShimEntryProgram`) that:
+
+- `xdp_main_prog` is the legacy entry program used **only** by the
+  explicit `dataplane-type ebpf` rollback;
+- `xdp_userspace_prog` is the retained AF_XDP shim entry that
+  userspace.Boot() selects via `bpfShim.SelectUserspaceXDPShimEntryProgram()`;
+- the userspace boot path never calls
+  `bpfShim.Load()` (which would invoke `loadAllObjects()` and load
+  the legacy XDP/TC tail-call objects); it calls
+  `bpfShim.LoadUserspaceShim()` exclusively;
+- the swap-back path in
+  `pkg/dataplane/userspace/maps_sync.go` calls
+  `bpfShim.SwapToUserspaceXDPShimEntryProgram()` defensively after
+  a link cycle that the kernel observed an attachment to
+  `xdp_main_prog`. This is the structured config gate (compat mode,
+  observable in `show system buffers` and userspace status). The
+  swap NEVER goes the other direction in normal userspace startup.
+
+This documentation satisfies #1520 acceptance criterion 2 ("documented
+as the explicit retained fallback with a structured config gate").
+
+### 4.5 New AST canary: `Boot()` is the daemon entry point
+
+Add a canary test in
+`pkg/dataplane/userspace/userspace_boot_canary_test.go` that:
+
+- parses `pkg/daemon/daemon_run.go` and asserts the file references
+  `buildRuntimeDataPlane` or `userspace.Boot` (not just
+  `dataplane.NewRuntimeDataPlane`). The intent: prevent silent
+  regression to the registry-only path.
+- parses `pkg/dataplane/userspace/manager.go` and asserts that
+  `Boot` is an exported function. (Cheap structural check.)
+- still asserts the registry indirection works:
+  `dataplane.NewRuntimeDataPlane(TypeUserspace)` returns
+  `*LegacyDataPlaneAdapter` (already covered by
+  `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`).
+
+## 5. Public API preservation
+
+- `userspace.New()`: unchanged signature and behavior. It remains
+  the lower-level constructor (returns `*Manager`).
+- `userspace.NewLegacyDataPlaneAdapter(*Manager) *LegacyDataPlaneAdapter`:
+  unchanged. Still used by `Boot()`.
+- `dataplane.NewRuntimeDataPlane(string) (RuntimeDataPlane, error)`:
+  unchanged signature and behavior.
+- `dataplane.NewDataPlane(string) (DataPlane, error)`: unchanged.
+- AST canaries in
+  `pkg/dataplane/userspace/manager_coupling_test.go`: must remain
+  green. The `bpfShim *dataplane.Manager` field stays.
+- The runtime backend registry still has a userspace entry.
+
+## 6. Hidden invariants the change must preserve
+
+1. **Side-effect ordering on startup.** `userspace.New()` calls
+   `bpfShim.SelectUserspaceXDPShimEntryProgram()` BEFORE returning.
+   Daemon then calls `d.dp.Start(ctx)` which calls
+   `Manager.Load()` → `bpfShim.LoadUserspaceShim()` → which
+   re-selects the userspace entry program inside `LoadUserspaceShim`.
+   Both call sites must continue to hold. `Boot()` must not skip
+   the pre-Load entry-program selection because `Compile()` may run
+   before `Load()` in some non-default code paths.
+
+2. **`init()` ordering.** The `RegisterRuntimeBackend` call must
+   still run at package init time. `Boot()` must be safe to call
+   either before or after the registry init runs (no shared
+   mutable state).
+
+3. **Adapter identity.** The daemon `legacyDP()` helper depends on
+   the runtime dp being type-assertable to `dataplane.DataPlane`.
+   `*LegacyDataPlaneAdapter` satisfies that. `Boot()` MUST return
+   the adapter, not the bare `*Manager`. (Without the adapter,
+   `legacyDP()` returns nil and CLI / API status paths silently
+   degrade.)
+
+4. **No stray legacy-loader hop.** `Boot()` must not call
+   `bpfShim.Load()` or invoke the legacy `loadAllObjects()` path
+   transitively. The retained shim loader path must remain the only
+   load call.
+
+5. **HA fabric forwarding.** `manager.go:276,283` still call
+   `bpfShim.UpdateFabricFwd`/`UpdateFabricFwd1` directly through
+   the kept `bpfShim` field. `Boot()` must preserve the `bpfShim`
+   identity and not introduce a different Manager instance for
+   fabric forwarding vs. the rest of the userspace runtime.
+
+6. **Rollback path.** `dataplane-type ebpf` still constructs a
+   bare `*dataplane.Manager` (legacy) via the
+   `dataplane.NewRuntimeDataPlane` → `New()` switch case. The
+   daemon wrapper must continue to route TypeEBPF through
+   `dataplane.NewRuntimeDataPlane`, not through `userspace.Boot()`.
+
+7. **DPDK retirement sentinel.** `dataplane-type dpdk` still
+   returns `ErrDPDKBackendRetired`. The daemon wrapper MUST
+   propagate that sentinel unchanged so the existing
+   `errors.Is(err, dataplane.ErrDPDKBackendRetired)` branch in
+   `daemon_run.go` keeps working.
+
+## 7. Risk assessment
+
+| Risk class | Level | Notes |
+|---|---|---|
+| Behavioral regression risk | LOW | `Boot()` is a thin constructor wrapping `New()` + `LegacyDataPlaneAdapter`. Daemon wrapper preserves all existing sentinel error handling. |
+| Lifetime / borrow-checker risk | N/A | Go; no borrow checker concerns. |
+| Performance regression risk | NONE | Boot() runs once at daemon startup. No hot-path change. |
+| Architectural mismatch risk | MEDIUM | The AST canary forbids removing the `bpfShim` field. If reviewers want the slice to also peel `bpfShim` off into a smaller type, they should PLAN-KILL this slice and open a new issue that updates the canary. This slice deliberately does NOT touch the Manager shape. |
+| Sibling-PR collision risk | LOW | Touches `pkg/dataplane/userspace/manager.go` and `pkg/daemon/daemon_run.go`. #1521 (maps_sync) touches `pkg/dataplane/userspace/maps_sync.go`. No file overlap. |
+
+## 8. Test plan
+
+1. **Build clean.** `make build` succeeds.
+2. **Cargo unaffected.** `cd userspace-dp && cargo build --release`
+   succeeds (no Rust changes — sanity check only).
+3. **Existing AST canaries green.**
+   `go test ./pkg/dataplane/userspace/... -run TestUserspaceManager`
+   passes — the existing
+   `TestUserspaceManagerDoesNotEmbedLegacyDataPlane`,
+   `TestUserspaceManagerRuntimeContractDoesNotExposeLegacyDataPlane`,
+   and
+   `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`
+   must continue to pass.
+4. **New canary.** `TestDaemonRunBuildsUserspaceViaBoot` and
+   `TestUserspaceBootIsExportedConstructor` pass.
+5. **Boot() return-shape canary.** `TestUserspaceBootReturnsAdapter`
+   asserts `Boot(BootOptions{})` returns
+   `*LegacyDataPlaneAdapter` and that the adapter still implements
+   both `dataplane.DataPlane` and `dataplane.RuntimeDataPlane`.
+6. **Rollback path canary.** `TestBuildRuntimeDataPlaneRoutesEBPFThroughLegacyFactory`
+   asserts the daemon helper still routes `dataplane-type ebpf`
+   through the legacy factory and returns the legacy
+   `*dataplane.Manager` (not `*LegacyDataPlaneAdapter`).
+7. **DPDK sentinel canary.**
+   `TestBuildRuntimeDataPlaneDPDKReturnsRetired` asserts the helper
+   still propagates `ErrDPDKBackendRetired` unchanged.
+8. **5×flake** for the new canaries.
+9. **Full Go suite.** `make test`.
+10. **Loss userspace cluster smoke matrix (mandatory):**
+    - `make cluster-deploy` (deploys loss:xpf-userspace-fw0/fw1).
+    - Pass A (CoS disabled): v4+v6 × push+reverse single-stream
+      baseline (8 cells) and 12-stream `-R` reproducer on v4 + v6.
+    - Pass B (CoS enabled): per-class smoke ports 5201-5206 ×
+      v4+v6 × push+reverse (24 cells).
+11. **Link-cycle smoke.** Run the cluster's link-cycle path
+    (the PR #1513 test infrastructure) and confirm userspace
+    rebinds XSK sockets cleanly after a kernel link DOWN/UP.
+
+## 9. Out of scope (explicitly)
+
+The following are deferred to other slices and MUST NOT be
+attempted in this PR:
+
+- Renaming `bpfShim` or moving it to a smaller typed loader. The
+  AST canary forbids removing the field, and a rename would
+  require updating six files plus the canary in one go. Defer to
+  a future "Manager shape split" issue if one is opened.
+- Moving `userspace_ctrl`/`userspace_bindings`/`userspace_xsk_map`
+  map name lookups off `bpfShim.Map(...)`. That's #1521's scope.
+- Splitting the retained AF_XDP XDP shim from the legacy
+  `xdp_main` fallback at the Rust shim level. That's #1473's scope.
+- Removing the runtime backend registration. Acceptance criterion
+  3 explicitly allows keeping registration as the rollback /
+  test seam.
+- Touching the legacy `dataplane.NewDataPlane` switch case for
+  TypeEBPF. The eBPF rollback path stays exactly as it is.
+- Adding a new config flag. No new operator surface in this
+  slice; no Junos CLI change.
+
+## 10. Open questions for adversarial review
+
+1. **Is `userspace.Boot()` meaningfully different from
+   `userspace.New()` + `NewLegacyDataPlaneAdapter(...)`?** If
+   reviewers feel the constructor is just a typed rename without
+   architectural value, PLAN-KILL the slice and add a doc comment
+   to the existing registry init instead. The slice's value is
+   the daemon wrapper that fences the legacy registry off to the
+   rollback branch.
+
+2. **Should the daemon wrapper be in `pkg/daemon/` or moved into
+   `pkg/dataplane/` as a factory that knows about backend
+   selection?** Putting the wrapper at the daemon layer keeps
+   `pkg/dataplane/` free of daemon-only construction policy.
+   Putting it in `pkg/dataplane/` centralizes the registry / Boot
+   choice but couples the dataplane package to userspace
+   selection policy. The plan picks the daemon-layer wrapper.
+   Reviewers may prefer otherwise.
+
+3. **Does the new daemon wrapper change `ErrDPDKBackendRetired`
+   handling at all?** It must not — the daemon already has a
+   `errors.Is(err, dataplane.ErrDPDKBackendRetired)` branch. The
+   wrapper for TypeUserspace cannot produce that error (Boot()
+   doesn't fail). For TypeEBPF and TypeDPDK and other types, the
+   wrapper falls through to `dataplane.NewRuntimeDataPlane()`
+   which returns the sentinel unchanged. Reviewers should verify
+   this is preserved end-to-end.
+
+4. **Is the new AST canary brittle?** Parsing `daemon_run.go` for
+   a literal `buildRuntimeDataPlane`/`userspace.Boot` reference
+   will fail if a later refactor moves the call into a different
+   file (e.g., `dataplane_boot.go`). The canary should be
+   directory-scoped or interface-shaped. PLAN-NEEDS-MINOR if so.
+
+5. **Is the BootOptions struct premature future-proofing?** It's
+   empty today. The alternative is a no-arg `Boot()` until #1521
+   needs an option. The plan chose the struct up-front to avoid
+   churn when #1521 lands. PLAN-NEEDS-MINOR if reviewers prefer
+   `Boot()` with no args.
+
+6. **#1521 collision.** #1521 is decoupling `maps_sync.go` from
+   hard-coded BPF map name string literals. #1520 does not touch
+   `maps_sync.go`. There is no file overlap. Reviewers should
+   verify by walking the diff that no `maps_sync.go` line is
+   touched.
+
+7. **Does the `RegisterRuntimeBackend` rollback path stay
+   reachable?** A test must call
+   `dataplane.NewRuntimeDataPlane(dataplane.TypeUserspace)` and
+   confirm it still returns `*LegacyDataPlaneAdapter`. If `Boot`
+   replaces the registry constructor body, the test must still
+   pass.
+
+## 11. Reviewer note
+
+Reviewers are encouraged to treat PLAN-KILL as a real option. The
+methodology has used it before to stop slices whose architectural
+premise was wrong (#946 Phase 2, #961 PacketContext). #1520's
+premise is bounded — give the daemon a userspace-native
+construction seam and fence the legacy factory off to the
+rollback branch — but if reviewers conclude the seam adds no
+structural value over a doc comment, PLAN-KILL is correct.

--- a/docs/pr/1520-userspace-boot-extraction/plan.md
+++ b/docs/pr/1520-userspace-boot-extraction/plan.md
@@ -1,6 +1,44 @@
 # #1520 Plan: Extract Userspace Boot Path From Legacy `dataplane.New()`
 
-**Status:** DRAFT v1 — pending adversarial plan review.
+**Status:** v4 — addresses AGY round-2 CRITICAL (existing AST canary
+collision) and Codex round-3 stragglers. v3 addressed Codex
+round-2 PLAN-NEEDS-MAJOR (9 findings).
+
+v4 changes:
+- §4.2: pin helper location to `pkg/daemon/daemon_run.go` and
+  document the load-bearing
+  `dataplane.NewRuntimeDataPlane(dpType)` reference required by
+  `retirement_boundary_canary_test.go::TestDaemonRuntimeEntryPointUsesRuntimeDataPlane`.
+- §4.3: rename "rollback / test seam" → "compatibility / test
+  seam" (Codex round-3 finding 8).
+- §8.5: drop the stale `Boot(BootOptions{})` reference (Codex
+  round-3 finding 7).
+
+v3 changes were: Changes from v1/v2:
+
+- Drop premature `BootOptions{}` — use no-arg `Boot()` (finding 7).
+- Drop the parse-text canary that targets a literal filename
+  (findings 4 and 6) and replace with behavioral canaries on the
+  daemon helper.
+- Add behavioral test for `buildRuntimeDataPlane("")` AND
+  `buildRuntimeDataPlane(TypeUserspace)` returning the adapter and
+  for both producing the same concrete type (finding 5).
+- §6 now requires that BOTH empty default and explicit
+  `TypeUserspace` route through `Boot()` (finding 2).
+- Strike the "structured config gate" wording — §4.4 is documentation
+  only; the rollback gate is the existing `dataplane-type` config
+  knob (finding 3).
+- Call the registry path a "compatibility/test seam," not "rollback"
+  (finding 8) — rollback is `dataplane-type ebpf` through
+  `NewRuntimeDataPlane()`, not through the userspace registry.
+- Sharpen the structural value statement (finding 1): the
+  enforceable delta is that `pkg/daemon` no longer compiles against
+  the registry indirection for the userspace path. Future #1521
+  threads typed options through the new `Boot()` signature; today
+  there is no opt struct.
+- #1521 coordination: this slice does NOT add `BootOptions`, so
+  there is no API surface for #1521 to extend yet (finding 9).
+  Semantic coordination is now stated explicitly in §7.
 
 **Scope (one line):** sub-#1451 S5; provide a userspace-native
 constructor that does not require the legacy `dataplane.New()`
@@ -158,15 +196,6 @@ func init() {
 In `pkg/dataplane/userspace/manager.go`, add:
 
 ```go
-// BootOptions configure userspace-native boot. Empty options select
-// the userspace AF_XDP runtime in its current compat-mode default.
-type BootOptions struct {
-    // Reserved for future use (e.g., explicit mode override, fail-closed
-    // helper unavailability handling). Empty today; we add the struct
-    // up-front so signature churn does not propagate when #1521 / #1473
-    // need to thread additional config in.
-}
-
 // Boot constructs the userspace AF_XDP runtime and returns it as a
 // dataplane.RuntimeDataPlane wrapped in the legacy-compatible adapter.
 //
@@ -179,9 +208,11 @@ type BootOptions struct {
 // The returned value still implements dataplane.DataPlane via the
 // adapter, so unmigrated callers (pkg/cli, pkg/api, pkg/conntrack,
 // pkg/fwdstatus) continue to compile until #1451 finishes the surface
-// shrink.
-func Boot(opts BootOptions) dataplane.RuntimeDataPlane {
-    _ = opts // reserved
+// shrink. When #1521 / #1473 need to thread additional construction
+// configuration in, they should add a typed options argument here —
+// not pre-emptively. See Claude SMR review feedback rejecting empty
+// `BootOptions{}` as premature YAGNI.
+func Boot() dataplane.RuntimeDataPlane {
     return NewLegacyDataPlaneAdapter(New())
 }
 ```
@@ -191,6 +222,20 @@ the **call site** — daemon startup no longer needs to consult the
 runtime backend registry for the userspace path.
 
 ### 4.2 Daemon startup chooses Boot() for userspace, registry for legacy
+
+The helper `buildRuntimeDataPlane()` **MUST** live inside
+`pkg/daemon/daemon_run.go` and the helper body **MUST** contain the
+literal call `dataplane.NewRuntimeDataPlane(dpType)` for the
+non-userspace fall-through. This is load-bearing: the existing AST
+canary
+`pkg/dataplane/retirement_boundary_canary_test.go::TestDaemonRuntimeEntryPointUsesRuntimeDataPlane`
+parses `pkg/daemon/daemon_run.go` and fails if
+`dataplane.NewRuntimeDataPlane` is no longer referenced in that file
+(see `hasDaemonRuntimeConstructorCall` at
+`retirement_boundary_canary_test.go:3366`). Splitting the helper
+into a new file or replacing the legacy-path call with a different
+constructor would trigger
+`t.Fatal("daemon runtime startup no longer calls dataplane.NewRuntimeDataPlane")`.
 
 In `pkg/daemon/daemon_run.go`, replace:
 
@@ -212,8 +257,7 @@ if cfg := d.store.ActiveConfig(); cfg != nil {
 dp, err := buildRuntimeDataPlane(dpType)
 ```
 
-and add a small helper in `pkg/daemon/daemon_run.go` (or a new
-`pkg/daemon/dataplane_boot.go` if cleaner):
+and add the helper inside `pkg/daemon/daemon_run.go`:
 
 ```go
 // buildRuntimeDataPlane selects the userspace-native Boot() path for
@@ -221,19 +265,23 @@ and add a small helper in `pkg/daemon/daemon_run.go` (or a new
 // dataplane.NewRuntimeDataPlane only for the explicit legacy eBPF
 // rollback (and the retired-DPDK error case). Keeping the legacy
 // branch routed through the dataplane factory preserves the
-// ErrDPDKBackendRetired sentinel handling unchanged.
+// ErrDPDKBackendRetired sentinel handling unchanged AND preserves
+// the existing retirement_boundary_canary_test.go AST canary that
+// requires daemon_run.go to reference dataplane.NewRuntimeDataPlane.
+//
+// This helper MUST stay in daemon_run.go for the AST canary above.
+// Do not split into pkg/daemon/dataplane_boot.go.
 func buildRuntimeDataPlane(dpType string) (dataplane.RuntimeDataPlane, error) {
     switch dataplane.EffectiveType(dpType) {
     case dataplane.TypeUserspace:
-        return userspace.Boot(userspace.BootOptions{}), nil
+        return userspace.Boot(), nil
     default:
         return dataplane.NewRuntimeDataPlane(dpType)
     }
 }
 ```
 
-### 4.3 Keep the runtime backend registration as the rollback / test
-seam
+### 4.3 Keep the runtime backend registration as the compatibility / test seam
 
 The `init()` in `pkg/dataplane/userspace/manager.go` continues to
 register a userspace runtime backend so that
@@ -245,15 +293,20 @@ registry. The registry path stays a thin alias for the canonical
 ```go
 func init() {
     dataplane.RegisterRuntimeBackend(dataplane.TypeUserspace, func() dataplane.RuntimeDataPlane {
-        return Boot(BootOptions{})
+        return Boot()
     })
 }
 ```
 
 This satisfies #1520 acceptance criterion 3 ("Backend registration
 … either remains for the rollback path"): registration remains, and
-its presence is documented in code as the test/rollback seam, not
-the canonical daemon startup path.
+its presence is documented in code as the **compatibility/test
+seam**, not the canonical daemon startup path and not the operator
+rollback path. The operator rollback path is
+`dataplane-type ebpf` which goes through
+`dataplane.NewRuntimeDataPlane()` → `New()` (legacy
+`*dataplane.Manager`) and never touches the userspace registry
+entry.
 
 ### 4.4 `xdp_main_prog` / `xdp_userspace_prog` swap path documentation
 
@@ -275,29 +328,54 @@ shorter pointer comment at
 - the swap-back path in
   `pkg/dataplane/userspace/maps_sync.go` calls
   `bpfShim.SwapToUserspaceXDPShimEntryProgram()` defensively after
-  a link cycle that the kernel observed an attachment to
-  `xdp_main_prog`. This is the structured config gate (compat mode,
-  observable in `show system buffers` and userspace status). The
+  a link cycle. This is operationally observable in
+  `show system buffers` and userspace status but is **not** a new
+  config gate — the only operator-facing dataplane gate is the
+  existing `set system dataplane-type {ebpf|userspace}` knob. The
   swap NEVER goes the other direction in normal userspace startup.
 
-This documentation satisfies #1520 acceptance criterion 2 ("documented
-as the explicit retained fallback with a structured config gate").
+This documentation satisfies #1520 acceptance criterion 2
+("documented as the explicit retained fallback with a structured
+config gate"): the structured gate is the existing
+`dataplane-type` knob, not a new flag introduced by this slice.
 
 ### 4.5 New AST canary: `Boot()` is the daemon entry point
 
-Add a canary test in
-`pkg/dataplane/userspace/userspace_boot_canary_test.go` that:
+Add behavioral canary tests in two places:
 
-- parses `pkg/daemon/daemon_run.go` and asserts the file references
-  `buildRuntimeDataPlane` or `userspace.Boot` (not just
-  `dataplane.NewRuntimeDataPlane`). The intent: prevent silent
-  regression to the registry-only path.
-- parses `pkg/dataplane/userspace/manager.go` and asserts that
-  `Boot` is an exported function. (Cheap structural check.)
-- still asserts the registry indirection works:
-  `dataplane.NewRuntimeDataPlane(TypeUserspace)` returns
-  `*LegacyDataPlaneAdapter` (already covered by
-  `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`).
+In `pkg/dataplane/userspace/userspace_boot_canary_test.go`:
+
+- asserts behavior of `Boot()`: returns a value that
+  - implements `dataplane.RuntimeDataPlane`,
+  - implements `dataplane.DataPlane` (adapter identity preserved),
+  - is concretely `*LegacyDataPlaneAdapter`,
+  - has the same concrete type as
+    `dataplane.NewRuntimeDataPlane(dataplane.TypeUserspace)`.
+- the existing registry canary
+  `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`
+  is kept and continues to assert
+  `dataplane.NewRuntimeDataPlane(TypeUserspace)` returns the same
+  shape.
+
+In `pkg/daemon/dataplane_boot_test.go` (new test file in the
+daemon package so the helper is directly exercised):
+
+- `TestBuildRuntimeDataPlaneDefaultUsesUserspaceBoot` asserts that
+  `buildRuntimeDataPlane("")` returns the userspace adapter (same
+  concrete type as `userspace.Boot()`).
+- `TestBuildRuntimeDataPlaneUserspaceUsesUserspaceBoot` asserts the
+  same for `buildRuntimeDataPlane(dataplane.TypeUserspace)`.
+- `TestBuildRuntimeDataPlaneEBPFRoutesToLegacyManager` asserts
+  `buildRuntimeDataPlane(dataplane.TypeEBPF)` returns the legacy
+  `*dataplane.Manager` shape (NOT `*LegacyDataPlaneAdapter`).
+- `TestBuildRuntimeDataPlaneDPDKReturnsRetired` asserts
+  `buildRuntimeDataPlane(dataplane.TypeDPDK)` propagates
+  `ErrDPDKBackendRetired` unchanged.
+
+No file is parsed for a literal text reference — the canary that
+v2 proposed against `pkg/daemon/daemon_run.go` is dropped per
+Codex round-2 finding 4/6 (brittle text-shape check that breaks
+under a future file rename without any behavioral regression).
 
 ## 5. Public API preservation
 
@@ -314,6 +392,13 @@ Add a canary test in
 - The runtime backend registry still has a userspace entry.
 
 ## 6. Hidden invariants the change must preserve
+
+0. **Default routing.** Both `dpType == ""` and
+   `dpType == TypeUserspace` MUST route through `userspace.Boot()`,
+   not through `dataplane.NewRuntimeDataPlane()`. The daemon
+   helper resolves the empty default itself via
+   `dataplane.EffectiveType()` and dispatches accordingly. This
+   is the load-bearing structural delta of #1520.
 
 1. **Side-effect ordering on startup.** `userspace.New()` calls
    `bpfShim.SelectUserspaceXDPShimEntryProgram()` BEFORE returning.
@@ -367,7 +452,7 @@ Add a canary test in
 | Lifetime / borrow-checker risk | N/A | Go; no borrow checker concerns. |
 | Performance regression risk | NONE | Boot() runs once at daemon startup. No hot-path change. |
 | Architectural mismatch risk | MEDIUM | The AST canary forbids removing the `bpfShim` field. If reviewers want the slice to also peel `bpfShim` off into a smaller type, they should PLAN-KILL this slice and open a new issue that updates the canary. This slice deliberately does NOT touch the Manager shape. |
-| Sibling-PR collision risk | LOW | Touches `pkg/dataplane/userspace/manager.go` and `pkg/daemon/daemon_run.go`. #1521 (maps_sync) touches `pkg/dataplane/userspace/maps_sync.go`. No file overlap. |
+| Sibling-PR collision risk | LOW | Touches `pkg/dataplane/userspace/manager.go` (init + new Boot), `pkg/daemon/daemon_run.go` (one call-site change + new helper inline), and adds `pkg/dataplane/userspace/userspace_boot_canary_test.go` + `pkg/daemon/dataplane_boot_test.go`. #1521 touches `pkg/dataplane/userspace/maps_sync.go`. No file overlap. Semantic coordination: #1521 does NOT consume any new exported type from this slice. This slice does NOT add a `BootOptions` API for #1521 to extend. Future #1521 / #1473 may add a typed options argument to `Boot()` at that time. |
 
 ## 8. Test plan
 
@@ -382,12 +467,13 @@ Add a canary test in
    and
    `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`
    must continue to pass.
-4. **New canary.** `TestDaemonRunBuildsUserspaceViaBoot` and
-   `TestUserspaceBootIsExportedConstructor` pass.
+4. **New canary.** Behavioral tests in
+   `pkg/daemon/dataplane_boot_test.go` pass (default, userspace,
+   ebpf, dpdk routes — see §4.5).
 5. **Boot() return-shape canary.** `TestUserspaceBootReturnsAdapter`
-   asserts `Boot(BootOptions{})` returns
-   `*LegacyDataPlaneAdapter` and that the adapter still implements
-   both `dataplane.DataPlane` and `dataplane.RuntimeDataPlane`.
+   asserts `Boot()` returns `*LegacyDataPlaneAdapter` and that the
+   adapter still implements both `dataplane.DataPlane` and
+   `dataplane.RuntimeDataPlane`.
 6. **Rollback path canary.** `TestBuildRuntimeDataPlaneRoutesEBPFThroughLegacyFactory`
    asserts the daemon helper still routes `dataplane-type ebpf`
    through the legacy factory and returns the legacy
@@ -456,17 +542,15 @@ attempted in this PR:
    which returns the sentinel unchanged. Reviewers should verify
    this is preserved end-to-end.
 
-4. **Is the new AST canary brittle?** Parsing `daemon_run.go` for
-   a literal `buildRuntimeDataPlane`/`userspace.Boot` reference
-   will fail if a later refactor moves the call into a different
-   file (e.g., `dataplane_boot.go`). The canary should be
-   directory-scoped or interface-shaped. PLAN-NEEDS-MINOR if so.
+4. **Is the new AST canary brittle?** RESOLVED in v3: the
+   text-shape canary on `daemon_run.go` is dropped. The new tests
+   are behavioral — they call `buildRuntimeDataPlane()` directly
+   and assert returned types — and are stable across file
+   renames.
 
-5. **Is the BootOptions struct premature future-proofing?** It's
-   empty today. The alternative is a no-arg `Boot()` until #1521
-   needs an option. The plan chose the struct up-front to avoid
-   churn when #1521 lands. PLAN-NEEDS-MINOR if reviewers prefer
-   `Boot()` with no args.
+5. **Is the BootOptions struct premature future-proofing?**
+   RESOLVED in v3: `Boot()` takes no arguments. Future slices that
+   need to thread options can add them at that point.
 
 6. **#1521 collision.** #1521 is decoupling `maps_sync.go` from
    hard-coded BPF map name string literals. #1520 does not touch

--- a/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
+++ b/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
@@ -32,11 +32,19 @@ Per-round reviewer task / job IDs for the triple-review skill.
 - Antigravity job ID: `adversarial-review-mplcf05h-abqou8` — VERDICT MERGE-READY (8/8 invariants verified; clean rebase assessment)
 - Copilot review: COMMENTED — 3 doc nits (stale legacy-caller list in Boot() doc + canary test docstring; README "only" wording); all addressed in round-3 commit
 
-### Round 3 (after Copilot round-2 doc nits)
+### Round 3 (after Copilot round-2 doc nits, HEAD 444a1959)
 
-- Codex task ID: _pending re-dispatch_
-- Antigravity job ID: _pending re-dispatch_
-- Copilot review: triggered via `@copilot review` PR comment
+- Codex task ID: _bg task bzjreb3hv (codex exec)_ — VERDICT MERGE-READY (no findings; only docs/comments changed; targeted tests pass)
+- Antigravity job ID: `adversarial-review-mplcpbnz-5avtoo` — VERDICT MERGE-READY (3 Copilot round-2 nits resolved; 8/8 invariants intact; doc-only change scope)
+- Copilot review: COMMENTED with no new comments — implicit MERGE-READY
+
+## Smoke matrix outcome
+
+PASS — per-class v4/v6 × push/-R matrix on loss userspace cluster
+on HEAD 444a1959. Best-effort 5201 at ~80 Mbps push (expected
+low-priority CoS surplus floor); per-class shaping consistent
+across v4/v6; reverse direction 6-8 Gbps across all classes. No
+data-path regression observable.
 
 ## Notes
 

--- a/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
+++ b/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
@@ -26,10 +26,16 @@ Per-round reviewer task / job IDs for the triple-review skill.
 - Antigravity job ID: `adversarial-review-mplc57vw-e6chtv` — VERDICT MERGE-READY (8 findings clean, 1 minor coverage gap)
 - Copilot review: COMMENTED — 2 inline wording nits (Boot() doc + buildRuntimeDataPlane doc); both addressed in round-2 commit
 
-### Round 2 (after wording + coverage gap fixes)
+### Round 2 (after wording + coverage gap fixes, HEAD 9c532b05)
 
-- Codex task ID: _pending re-dispatch after force-push_
-- Antigravity job ID: _pending re-dispatch after force-push_
+- Codex task ID: _bg task bodqke6ph (codex exec)_ — VERDICT MERGE-READY (no findings; all wording fixes confirmed; 3 quoted-line evidence items; all targeted tests pass)
+- Antigravity job ID: `adversarial-review-mplcf05h-abqou8` — VERDICT MERGE-READY (8/8 invariants verified; clean rebase assessment)
+- Copilot review: COMMENTED — 3 doc nits (stale legacy-caller list in Boot() doc + canary test docstring; README "only" wording); all addressed in round-3 commit
+
+### Round 3 (after Copilot round-2 doc nits)
+
+- Codex task ID: _pending re-dispatch_
+- Antigravity job ID: _pending re-dispatch_
 - Copilot review: triggered via `@copilot review` PR comment
 
 ## Notes

--- a/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
+++ b/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
@@ -1,0 +1,33 @@
+# #1520 Reviewer IDs
+
+Per-round reviewer task / job IDs for the triple-review skill.
+
+## Plan review
+
+### Round 1
+
+- Codex task ID: _pending dispatch_
+- Antigravity job ID: _pending dispatch_
+
+### Round 2
+
+- Codex task ID: _n/a_
+- Antigravity job ID: _n/a_
+
+## Code review (post-PR)
+
+### Round 1
+
+- Codex task ID: _pending_
+- Antigravity job ID: _pending_
+- Copilot review: _pending_
+
+## Notes
+
+- Worktree: `/home/ps/git/bpfrx/.claude/worktrees/1520-userspace-boot-extraction`
+- Branch: `refactor/1520-userspace-boot-extraction` (off `origin/master`)
+- Sibling agents in flight: #1516, #1517, #1518, #1519, #1521.
+  #1520 touches `pkg/dataplane/userspace/manager.go` (init + new
+  Boot constructor) and `pkg/daemon/daemon_run.go` (wrapper).
+  #1521 touches `pkg/dataplane/userspace/maps_sync.go`. No file
+  overlap expected; reviewers should verify by walking the diff.

--- a/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
+++ b/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
@@ -6,13 +6,17 @@ Per-round reviewer task / job IDs for the triple-review skill.
 
 ### Round 1
 
-- Codex task ID: _pending dispatch_
-- Antigravity job ID: _pending dispatch_
+- Codex task ID: `task-mpkuoz5b-87r2ey`
+- Antigravity job ID: `adversarial-review-mpkuphrt-q6d0tm`
 
-### Round 2
+### Round 2 (fresh dispatch on c9d54271)
 
-- Codex task ID: _n/a_
-- Antigravity job ID: _n/a_
+- Codex task ID: _bg task bf381q00x (codex exec, default model)_ — VERDICT PLAN-NEEDS-MAJOR, 9 findings; addressed in plan v3
+- Antigravity job ID: `adversarial-review-mplbs7le-wwyo78` — VERDICT PLAN-NEEDS-MINOR (1 CRITICAL: existing AST canary collision); addressed in plan v4
+
+### Round 3 (re-review on plan v3)
+
+- Codex task ID: _bg task bwio39fci (codex exec)_ — VERDICT PLAN-NEEDS-MINOR (2 stale string findings); addressed in plan v4
 
 ## Code review (post-PR)
 

--- a/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
+++ b/docs/pr/1520-userspace-boot-extraction/reviewer-ids.md
@@ -20,11 +20,17 @@ Per-round reviewer task / job IDs for the triple-review skill.
 
 ## Code review (post-PR)
 
-### Round 1
+### Round 1 (PR #1550, HEAD e0a694ca)
 
-- Codex task ID: _pending_
-- Antigravity job ID: _pending_
-- Copilot review: _pending_
+- Codex task ID: _bg task bq4nf4oer (codex exec)_ — output empty (Codex CLI errored); re-dispatched as bqz009mtr (also empty); will re-dispatch round-2 on new HEAD
+- Antigravity job ID: `adversarial-review-mplc57vw-e6chtv` — VERDICT MERGE-READY (8 findings clean, 1 minor coverage gap)
+- Copilot review: COMMENTED — 2 inline wording nits (Boot() doc + buildRuntimeDataPlane doc); both addressed in round-2 commit
+
+### Round 2 (after wording + coverage gap fixes)
+
+- Codex task ID: _pending re-dispatch after force-push_
+- Antigravity job ID: _pending re-dispatch after force-push_
+- Copilot review: triggered via `@copilot review` PR comment
 
 ## Notes
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -19,6 +19,12 @@ are completed (DPDK retired #1525). Userspace currently reaches those old caller
 runtime-domain type, and the adapter is only the transition boundary for
 status, CLI, and cluster-sync paths that still call `legacyDP()`.
 
+Dataplane construction in `daemon_run.go` goes through
+`buildRuntimeDataPlane()`: omitted `system dataplane-type` and explicit
+`userspace` select `userspace.Boot()` directly, while explicit `ebpf` still
+falls through `dataplane.NewRuntimeDataPlane()` so the legacy rollback path
+and retired-DPDK sentinel handling stay unchanged.
+
 Config apply uses the runtime `ConfigSink.ApplyConfig` path. This is required
 for userspace AF_XDP, which is intentionally not exposed as a legacy
 `DataPlane`; apply-time callers must not reintroduce `legacyDP().Compile` as

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -44,10 +44,17 @@ import (
 
 // buildRuntimeDataPlane selects the userspace-native Boot() path for the
 // default and explicit userspace selections, and falls through to
-// dataplane.NewRuntimeDataPlane only for the explicit legacy eBPF rollback
-// (and the retired-DPDK error case). Keeping the legacy branch routed
-// through the dataplane factory preserves the ErrDPDKBackendRetired sentinel
-// handling unchanged AND preserves the existing AST canary in
+// dataplane.NewRuntimeDataPlane for every other type. The two
+// operator-facing cases on the fall-through branch today are the
+// explicit legacy eBPF rollback ("dataplane-type ebpf") and the
+// retired-DPDK sentinel ("dataplane-type dpdk" → ErrDPDKBackendRetired).
+// Unknown/custom types and any future registry-backed types also flow
+// through the same default branch and surface the legacy factory's
+// error (including "unknown dataplane type") verbatim.
+//
+// Keeping the legacy branch routed through the dataplane factory
+// preserves the ErrDPDKBackendRetired sentinel handling unchanged AND
+// preserves the existing AST canary in
 // pkg/dataplane/retirement_boundary_canary_test.go
 // (TestDaemonRuntimeEntryPointUsesRuntimeDataPlane) that requires
 // daemon_run.go to reference dataplane.NewRuntimeDataPlane.

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -42,6 +42,32 @@ import (
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
+// buildRuntimeDataPlane selects the userspace-native Boot() path for the
+// default and explicit userspace selections, and falls through to
+// dataplane.NewRuntimeDataPlane only for the explicit legacy eBPF rollback
+// (and the retired-DPDK error case). Keeping the legacy branch routed
+// through the dataplane factory preserves the ErrDPDKBackendRetired sentinel
+// handling unchanged AND preserves the existing AST canary in
+// pkg/dataplane/retirement_boundary_canary_test.go
+// (TestDaemonRuntimeEntryPointUsesRuntimeDataPlane) that requires
+// daemon_run.go to reference dataplane.NewRuntimeDataPlane.
+//
+// This helper MUST stay in daemon_run.go for the canary above. Do not
+// split into a separate file in pkg/daemon/ without updating the canary.
+//
+// #1520 (sub-#1451 S5): userspace daemon construction no longer detours
+// through the runtime backend registry. The registry entry is retained
+// as a compatibility / test seam (see pkg/dataplane/userspace/manager.go
+// init()).
+func buildRuntimeDataPlane(dpType string) (dataplane.RuntimeDataPlane, error) {
+	switch dataplane.EffectiveType(dpType) {
+	case dataplane.TypeUserspace:
+		return dpuserspace.Boot(), nil
+	default:
+		return dataplane.NewRuntimeDataPlane(dpType)
+	}
+}
+
 func collectAppliedTunnels(cfg *config.Config) []*config.TunnelConfig {
 	if cfg == nil {
 		return nil
@@ -243,7 +269,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		if cfg := d.store.ActiveConfig(); cfg != nil {
 			dpType = cfg.System.DataplaneType
 		}
-		dp, err := dataplane.NewRuntimeDataPlane(dpType)
+		dp, err := buildRuntimeDataPlane(dpType)
 		if errors.Is(err, dataplane.ErrDPDKBackendRetired) {
 			// #1527 Phase 2 of the DPDK retirement (umbrella
 			// #1525): the runtime DPDK backend is gone, but a

--- a/pkg/daemon/dataplane_boot_test.go
+++ b/pkg/daemon/dataplane_boot_test.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestBuildRuntimeDataPlaneDefaultUsesUserspaceBoot asserts that the
+// empty default dataplane type ("" → userspace per
+// dataplane.EffectiveType) routes through userspace.Boot(), not through
+// the runtime backend registry. This is the load-bearing structural
+// delta of #1520 (sub-#1451 S5).
+func TestBuildRuntimeDataPlaneDefaultUsesUserspaceBoot(t *testing.T) {
+	t.Parallel()
+
+	dp, err := buildRuntimeDataPlane("")
+	if err != nil {
+		t.Fatalf("buildRuntimeDataPlane(\"\"): %v", err)
+	}
+	if _, ok := any(dp).(*dpuserspace.LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("buildRuntimeDataPlane(\"\") = %T, want *userspace.LegacyDataPlaneAdapter", dp)
+	}
+}
+
+// TestBuildRuntimeDataPlaneUserspaceUsesUserspaceBoot asserts the same
+// invariant for the explicit "userspace" selection.
+func TestBuildRuntimeDataPlaneUserspaceUsesUserspaceBoot(t *testing.T) {
+	t.Parallel()
+
+	dp, err := buildRuntimeDataPlane(dataplane.TypeUserspace)
+	if err != nil {
+		t.Fatalf("buildRuntimeDataPlane(userspace): %v", err)
+	}
+	if _, ok := any(dp).(*dpuserspace.LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("buildRuntimeDataPlane(userspace) = %T, want *userspace.LegacyDataPlaneAdapter", dp)
+	}
+}
+
+// TestBuildRuntimeDataPlaneEBPFRoutesToLegacyManager asserts that the
+// explicit "ebpf" rollback selection still constructs the legacy
+// *dataplane.Manager via the dataplane factory, NOT the userspace
+// adapter. The rollback path must not silently land on the userspace
+// runtime.
+func TestBuildRuntimeDataPlaneEBPFRoutesToLegacyManager(t *testing.T) {
+	t.Parallel()
+
+	dp, err := buildRuntimeDataPlane(dataplane.TypeEBPF)
+	if err != nil {
+		t.Fatalf("buildRuntimeDataPlane(ebpf): %v", err)
+	}
+	if _, ok := any(dp).(*dataplane.Manager); !ok {
+		t.Fatalf("buildRuntimeDataPlane(ebpf) = %T, want *dataplane.Manager (legacy rollback)", dp)
+	}
+	if _, ok := any(dp).(*dpuserspace.LegacyDataPlaneAdapter); ok {
+		t.Fatal("buildRuntimeDataPlane(ebpf) returned userspace adapter; rollback path is broken")
+	}
+}
+
+// TestBuildRuntimeDataPlaneDPDKReturnsRetired asserts that the helper
+// propagates dataplane.ErrDPDKBackendRetired unchanged for the retired
+// DPDK selection. The daemon outer loop has an errors.Is branch that
+// depends on this sentinel.
+func TestBuildRuntimeDataPlaneDPDKReturnsRetired(t *testing.T) {
+	t.Parallel()
+
+	dp, err := buildRuntimeDataPlane(dataplane.TypeDPDK)
+	if err == nil {
+		t.Fatalf("buildRuntimeDataPlane(dpdk) = %T, nil; want ErrDPDKBackendRetired", dp)
+	}
+	if !errors.Is(err, dataplane.ErrDPDKBackendRetired) {
+		t.Fatalf("buildRuntimeDataPlane(dpdk) err = %v; want errors.Is(ErrDPDKBackendRetired)", err)
+	}
+	if dp != nil {
+		t.Fatalf("buildRuntimeDataPlane(dpdk) returned non-nil dp = %T", dp)
+	}
+}
+
+// TestBuildRuntimeDataPlaneMatchesBootShape sanity-checks that the
+// userspace branch returns the same concrete type as userspace.Boot()
+// directly. Guards against a future refactor that silently re-introduces
+// the runtime backend registry wrapper.
+func TestBuildRuntimeDataPlaneMatchesBootShape(t *testing.T) {
+	t.Parallel()
+
+	helper, err := buildRuntimeDataPlane(dataplane.TypeUserspace)
+	if err != nil {
+		t.Fatalf("buildRuntimeDataPlane(userspace): %v", err)
+	}
+	direct := dpuserspace.Boot()
+
+	if hType, dType := fmt.Sprintf("%T", helper), fmt.Sprintf("%T", direct); hType != dType {
+		t.Fatalf("buildRuntimeDataPlane(userspace) = %s, want %s (Boot() shape)", hType, dType)
+	}
+}

--- a/pkg/daemon/dataplane_boot_test.go
+++ b/pkg/daemon/dataplane_boot_test.go
@@ -79,6 +79,27 @@ func TestBuildRuntimeDataPlaneDPDKReturnsRetired(t *testing.T) {
 	}
 }
 
+// TestBuildRuntimeDataPlaneUnknownTypePropagatesError asserts that the
+// helper does not silently swallow an unknown dataplane type (e.g., an
+// operator typo). The error must be surfaced from the legacy factory so
+// daemon startup logs it via the existing slog.Error("failed to create
+// dataplane", ...) branch. Also asserts the unknown-type error is NOT
+// the DPDK retirement sentinel (sentinel reserved for "dpdk" only).
+func TestBuildRuntimeDataPlaneUnknownTypePropagatesError(t *testing.T) {
+	t.Parallel()
+
+	dp, err := buildRuntimeDataPlane("totally-unknown-type")
+	if err == nil {
+		t.Fatalf("buildRuntimeDataPlane(unknown) = %T, nil; want error", dp)
+	}
+	if dp != nil {
+		t.Fatalf("buildRuntimeDataPlane(unknown) returned non-nil dp = %T", dp)
+	}
+	if errors.Is(err, dataplane.ErrDPDKBackendRetired) {
+		t.Fatalf("buildRuntimeDataPlane(unknown) returned ErrDPDKBackendRetired; sentinel must be reserved for dpdk")
+	}
+}
+
 // TestBuildRuntimeDataPlaneMatchesBootShape sanity-checks that the
 // userspace branch returns the same concrete type as userspace.Boot()
 // directly. Guards against a future refactor that silently re-introduces

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -14,12 +14,14 @@ Pluggable: the legacy eBPF backend registers through `RegisterBackend` for
 the old `DataPlane` surface (DPDK retired #1525; removed in #1527/#1528).
 Runtime backends register through `RegisterRuntimeBackend`; daemon startup now
 selects `userspace.Boot()` directly for the default and explicit userspace
-paths and falls through to `NewRuntimeDataPlane` only for the explicit legacy
-eBPF rollback / retired-DPDK sentinel path. During the #1381 migration, the
-userspace runtime constructor returns `LegacyDataPlaneAdapter`: the userspace
-`Manager` itself still does not implement the BPF-shaped `DataPlane`, but
-daemon status, CLI, and cluster-sync callers that have not moved to domain
-interfaces still receive a temporary compatibility handle.
+paths and falls through to `NewRuntimeDataPlane` for every other effective
+type. Today the operator-facing cases on that branch are the explicit legacy
+eBPF rollback and retired-DPDK sentinel; unknown/custom types still surface the
+legacy factory's error path verbatim. During the #1381 migration, the userspace
+runtime constructor returns `LegacyDataPlaneAdapter`: the userspace `Manager`
+itself still does not implement the BPF-shaped `DataPlane`, but daemon status,
+CLI, and cluster-sync callers that have not moved to domain interfaces still
+receive a temporary compatibility handle.
 
 DPDK retirement (#1525): the historical #1475 policy that retained DPDK as
 a separately supported DPDK-build backend applied pre-retirement; the

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -12,9 +12,10 @@ exposes session iteration to GC, the CLI, and the metrics surface.
 
 Pluggable: the legacy eBPF backend registers through `RegisterBackend` for
 the old `DataPlane` surface (DPDK retired #1525; removed in #1527/#1528).
-Runtime backends register through
-`RegisterRuntimeBackend`; the daemon uses `NewRuntimeDataPlane` so userspace
-AF_XDP starts through the runtime path. During the #1381 migration, the
+Runtime backends register through `RegisterRuntimeBackend`; daemon startup now
+selects `userspace.Boot()` directly for the default and explicit userspace
+paths and falls through to `NewRuntimeDataPlane` only for the explicit legacy
+eBPF rollback / retired-DPDK sentinel path. During the #1381 migration, the
 userspace runtime constructor returns `LegacyDataPlaneAdapter`: the userspace
 `Manager` itself still does not implement the BPF-shaped `DataPlane`, but
 daemon status, CLI, and cluster-sync callers that have not moved to domain
@@ -47,9 +48,11 @@ sent while exact queues were still backlogged.
   compile/config entry point; userspace AF_XDP does not need to implement the
   legacy BPF-shaped `Compile` method just to receive committed config.
 - `NewRuntimeDataPlane(dpType)` — `dataplane.go`. Runtime-domain constructor
-  used by `pkg/daemon`; an empty `dpType` now resolves to userspace instead
-  of silently selecting legacy eBPF. Userspace registers only on this path. The
-  current userspace constructor returns a compatibility adapter around
+  kept for the explicit legacy eBPF rollback, the retired-DPDK sentinel, and
+  compatibility/test seams such as the userspace runtime registry round-trip.
+  The daemon's default and explicit userspace boot path now goes through
+  `userspace.Boot()` via `pkg/daemon/buildRuntimeDataPlane()`. The current
+  userspace constructor still returns a compatibility adapter around
   `*userspace.Manager` until the remaining status/session-sync callers stop
   requiring `DataPlane`.
 - `Manager` — `loader.go`. eBPF implementation.

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -76,9 +76,15 @@ func init() {
 //
 // Daemon startup prefers Boot() over dataplane.NewRuntimeDataPlane(
 // TypeUserspace) for the default and explicit userspace selections.
-// The legacy registry path is retained for the explicit
-// "dataplane-type ebpf" rollback only, because that branch deliberately
-// resolves through dataplane.New() and the legacy program loader.
+// The runtime backend registry entry for TypeUserspace (see init()
+// above) is retained as a compatibility / test seam — it remains
+// reachable via dataplane.NewRuntimeDataPlane(TypeUserspace) but is
+// no longer the canonical daemon boot path.
+//
+// The explicit "dataplane-type ebpf" rollback does NOT use the
+// userspace registry entry at all; it goes through the
+// dataplane.NewRuntimeDataPlane → TypeEBPF switch which constructs
+// a bare *dataplane.Manager (legacy) via the legacy program loader.
 //
 // The returned value still implements dataplane.DataPlane via the
 // adapter, so unmigrated callers (pkg/cli, pkg/api, pkg/conntrack,

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -58,9 +58,36 @@ func (m DataplaneMode) String() string {
 }
 
 func init() {
+	// RegisterRuntimeBackend retains the userspace runtime as a
+	// compatibility / test seam for callers that go through the legacy
+	// dataplane.NewRuntimeDataPlane(...) factory (and for the existing
+	// canaries that exercise the registry round-trip). Daemon startup
+	// prefers userspace.Boot() directly via the pkg/daemon helper, so
+	// this registry entry is no longer the canonical boot path.
+	// Removing it is out of scope for #1520; #1474 already permits its
+	// presence as the test / compatibility seam.
 	dataplane.RegisterRuntimeBackend(dataplane.TypeUserspace, func() dataplane.RuntimeDataPlane {
-		return NewLegacyDataPlaneAdapter(New())
+		return Boot()
 	})
+}
+
+// Boot constructs the userspace AF_XDP runtime and returns it as a
+// dataplane.RuntimeDataPlane wrapped in the legacy-compatible adapter.
+//
+// Daemon startup prefers Boot() over dataplane.NewRuntimeDataPlane(
+// TypeUserspace) for the default and explicit userspace selections.
+// The legacy registry path is retained for the explicit
+// "dataplane-type ebpf" rollback only, because that branch deliberately
+// resolves through dataplane.New() and the legacy program loader.
+//
+// The returned value still implements dataplane.DataPlane via the
+// adapter, so unmigrated callers (pkg/cli, pkg/api, pkg/conntrack,
+// pkg/fwdstatus) continue to compile until #1451 finishes the surface
+// shrink. When #1521 / #1473 need to thread additional construction
+// configuration in, they should add a typed options argument here.
+// No empty options struct is added pre-emptively (YAGNI).
+func Boot() dataplane.RuntimeDataPlane {
+	return NewLegacyDataPlaneAdapter(New())
 }
 
 type Manager struct {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -87,11 +87,12 @@ func init() {
 // a bare *dataplane.Manager (legacy) via the legacy program loader.
 //
 // The returned value still implements dataplane.DataPlane via the
-// adapter, so unmigrated callers (pkg/cli, pkg/api, pkg/conntrack,
-// pkg/fwdstatus) continue to compile until #1451 finishes the surface
-// shrink. When #1521 / #1473 need to thread additional construction
-// configuration in, they should add a typed options argument here.
-// No empty options struct is added pre-emptively (YAGNI).
+// adapter, so daemon.legacyDP() can keep handing a compatibility handle
+// to the remaining CLI, gRPC, and cluster session-sync call sites until
+// #1451 finishes the surface shrink. When #1521 / #1473 need to thread
+// additional construction configuration in, they should add a typed
+// options argument here. No empty options struct is added pre-emptively
+// (YAGNI).
 func Boot() dataplane.RuntimeDataPlane {
 	return NewLegacyDataPlaneAdapter(New())
 }

--- a/pkg/dataplane/userspace/userspace_boot_canary_test.go
+++ b/pkg/dataplane/userspace/userspace_boot_canary_test.go
@@ -9,14 +9,16 @@ import (
 
 // TestUserspaceBootReturnsAdapter asserts that Boot() returns an
 // adapter-wrapped userspace runtime that satisfies both
-// dataplane.DataPlane (the legacy compatibility surface still consumed
-// by pkg/cli, pkg/api, pkg/conntrack, pkg/fwdstatus) and
-// dataplane.RuntimeDataPlane (the daemon-facing runtime surface).
+// dataplane.DataPlane (the legacy compatibility surface still handed out
+// by daemon.legacyDP() to CLI, gRPC, and cluster session-sync call
+// sites) and dataplane.RuntimeDataPlane (the daemon-facing runtime
+// surface).
 //
 // This is the load-bearing invariant for #1520 (sub-#1451 S5): the
 // daemon's legacyDP() helper depends on the runtime dataplane being
 // type-assertable to dataplane.DataPlane. Without the adapter,
-// legacyDP() returns nil and CLI / API status paths silently degrade.
+// legacyDP() returns nil and those compatibility handoff paths silently
+// degrade.
 func TestUserspaceBootReturnsAdapter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dataplane/userspace/userspace_boot_canary_test.go
+++ b/pkg/dataplane/userspace/userspace_boot_canary_test.go
@@ -1,0 +1,72 @@
+package userspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestUserspaceBootReturnsAdapter asserts that Boot() returns an
+// adapter-wrapped userspace runtime that satisfies both
+// dataplane.DataPlane (the legacy compatibility surface still consumed
+// by pkg/cli, pkg/api, pkg/conntrack, pkg/fwdstatus) and
+// dataplane.RuntimeDataPlane (the daemon-facing runtime surface).
+//
+// This is the load-bearing invariant for #1520 (sub-#1451 S5): the
+// daemon's legacyDP() helper depends on the runtime dataplane being
+// type-assertable to dataplane.DataPlane. Without the adapter,
+// legacyDP() returns nil and CLI / API status paths silently degrade.
+func TestUserspaceBootReturnsAdapter(t *testing.T) {
+	t.Parallel()
+
+	dp := Boot()
+	if dp == nil {
+		t.Fatal("Boot() returned nil")
+	}
+
+	if _, ok := any(dp).(*LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("Boot() = %T, want *LegacyDataPlaneAdapter", dp)
+	}
+	if _, ok := any(dp).(dataplane.RuntimeDataPlane); !ok {
+		t.Fatalf("Boot() = %T, does not implement dataplane.RuntimeDataPlane", dp)
+	}
+	if _, ok := any(dp).(dataplane.DataPlane); !ok {
+		t.Fatalf("Boot() = %T, does not implement dataplane.DataPlane (legacy adapter surface lost)", dp)
+	}
+}
+
+// TestUserspaceBootMatchesRegistryShape asserts that the value returned
+// by Boot() has the same concrete type as the value returned by the
+// runtime backend registry round-trip
+// (dataplane.NewRuntimeDataPlane(TypeUserspace)). #1520 retains the
+// registry entry as a compatibility / test seam, and the two paths must
+// produce indistinguishable concrete types.
+func TestUserspaceBootMatchesRegistryShape(t *testing.T) {
+	t.Parallel()
+
+	direct := Boot()
+	registry, err := dataplane.NewRuntimeDataPlane(dataplane.TypeUserspace)
+	if err != nil {
+		t.Fatalf("NewRuntimeDataPlane(userspace): %v", err)
+	}
+
+	if _, ok := any(registry).(*LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("NewRuntimeDataPlane(userspace) = %T, want *LegacyDataPlaneAdapter", registry)
+	}
+	if _, ok := any(direct).(*LegacyDataPlaneAdapter); !ok {
+		t.Fatalf("Boot() = %T, want *LegacyDataPlaneAdapter", direct)
+	}
+
+	// Same concrete type for both paths.
+	if dt := fmtType(direct); dt != fmtType(registry) {
+		t.Fatalf("Boot() and NewRuntimeDataPlane(userspace) returned different concrete types: %s vs %s", dt, fmtType(registry))
+	}
+}
+
+func fmtType(v any) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%T", v)
+}


### PR DESCRIPTION
## Summary

Sub-#1451 S5 (eBPF retirement, #1373 umbrella). Daemon startup no
longer detours through the runtime backend registry for the default
and explicit userspace selections. New `userspace.Boot()` is the
userspace-native constructor; a new daemon-side helper
`buildRuntimeDataPlane()` selects `Boot()` for the userspace path and
falls through to `dataplane.NewRuntimeDataPlane(dpType)` for the
explicit legacy `dataplane-type ebpf` rollback (and the retired-DPDK
sentinel).

The helper lives inline in `pkg/daemon/daemon_run.go` because the
existing AST canary
`TestDaemonRuntimeEntryPointUsesRuntimeDataPlane`
(in `pkg/dataplane/retirement_boundary_canary_test.go`) requires
that file to literally reference `dataplane.NewRuntimeDataPlane`.
Splitting the helper into a separate file would break that canary
without any behavioral regression.

The userspace runtime backend registry entry remains as the
compatibility / test seam.

### Acceptance criteria status

1. New `userspace.Boot()` constructs the userspace runtime without
   going through `dataplane.NewRuntimeDataPlane(TypeUserspace)`.
2. The `xdp_main_prog`/`xdp_userspace_prog` swap path is documented
   as the explicit retained fallback. Existing `dataplane-type`
   knob remains the only operator-facing gate — no new flag.
3. Backend registration remains for the test/compatibility seam;
   the operator rollback path goes through the legacy factory.

### Files

- `pkg/dataplane/userspace/manager.go` — new `Boot()` exported
  constructor; `init()` registry now calls `Boot()` so both paths
  produce identical shape.
- `pkg/daemon/daemon_run.go` — new inline `buildRuntimeDataPlane()`
  helper; switch from `dataplane.NewRuntimeDataPlane(dpType)` to
  `buildRuntimeDataPlane(dpType)` at the single boot call site.
- `pkg/dataplane/userspace/userspace_boot_canary_test.go` — new.
- `pkg/daemon/dataplane_boot_test.go` — new behavioral tests for
  default / userspace / ebpf / dpdk routes.
- `docs/pr/1520-userspace-boot-extraction/plan.md` — v4 plan.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` green (all 30 packages).
- [x] 5x flake on the new canaries — stable.
- [x] Existing canary
      `TestDaemonRuntimeEntryPointUsesRuntimeDataPlane` continues
      to pass.
- [x] Existing canaries
      `TestUserspaceManagerDoesNotEmbedLegacyDataPlane`,
      `TestUserspaceManagerRuntimeContractDoesNotExposeLegacyDataPlane`,
      and
      `TestUserspaceBackendRegistryReturnsRuntimeAdapterForLegacyCallers`
      continue to pass.
- [ ] Full smoke matrix on loss userspace cluster
      (v4+v6 x push+reverse x CoS-off+CoS-on) — owned by
      smoke-runner singleton per per-agent rules.

## Review status

Plan-review iterations:

| Round | Reviewer | Verdict | Resolved in |
|---|---|---|---|
| 1 | Codex (round-1 pre-handoff) | unknown | plan v1 |
| 1 | Antigravity (round-1 pre-handoff) | unknown | plan v1 |
| 2 | Codex | PLAN-NEEDS-MAJOR (9 findings) | plan v3 |
| 2 | Antigravity | PLAN-NEEDS-MINOR (1 CRITICAL on existing canary collision) | plan v4 |
| 3 | Codex | PLAN-NEEDS-MINOR (2 stragglers) | plan v4 |

Reviewer IDs in `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`.

## Coordination

Sibling agents in flight: #1516, #1517, #1518, #1519, #1521.
This PR touches `pkg/dataplane/userspace/manager.go` (init + new
`Boot`) and `pkg/daemon/daemon_run.go` (one call-site change + new
inline helper). #1521 (maps_sync decoupling) touches
`pkg/dataplane/userspace/maps_sync.go` — zero line overlap, no
semantic API surface contributed by this slice for #1521 to extend.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)