### PR TITLE
cluster: migrate session-sync off legacy dataplane.DataPlane (#1518, sub-#1451 S3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2599,3 +2599,22 @@
   dataplane.DataPlane. Keep SetDataPlane as a deprecated alias for one cycle.
   HA-touching scope: must pass make test-failover.
 - **Validation**: pending Codex + Antigravity adversarial plan review.
+- **Timestamp**: 2026-05-25T08:05Z
+- **Action**: Implement #1518 (cluster session-sync off legacy dataplane.DataPlane)
+- **File(s)**: pkg/cluster/runtime.go (NEW), pkg/cluster/sync.go,
+  pkg/cluster/sync_test.go, pkg/daemon/daemon_ha_sync.go,
+  pkg/dataplane/retirement_boundary_canary_test.go,
+  docs/pr/1373-retire-ebpf-dataplane/README.md, pkg/cluster/README.md
+- **Why**: Sub-#1451 S3. Introduce narrow clusterRuntime interface
+  (Sessions/Telemetry); NewSessionSync, NewDualSessionSync now take
+  clusterRuntime instead of dataplane.DataPlane. New SetRuntime setter
+  populates both runtime domains via the same SessionStoreOf/TelemetryOf
+  adapters the legacy SetDataPlane uses. SetDataPlane kept as a
+  deprecated alias for one release cycle. Daemon call-site in
+  daemon_ha_sync.go now calls SetRuntime(d.dp) directly — no legacyDP()
+  cast required at this seam.
+- **Validation**: go build ./... clean; go test ./pkg/cluster/ green
+  (TestSetRuntime added); go test ./pkg/daemon/ green; full suite
+  go test ./... green (32 packages); retirement boundary canary updated
+  with pkg/cluster/runtime.go allowlist entry + 1373 README + cluster
+  README. Smoke + test-failover pending (HA-sensitive scope per CLAUDE.md).

--- a/_Log.md
+++ b/_Log.md
@@ -2590,3 +2590,12 @@
   validation outcome. All three are purely cosmetic; no diff to
   pkg/logging/README.md.
 - **Validation**: cosmetic-only; no test/build rerun needed.
+
+- **Timestamp**: 2026-05-24T12:00Z
+- **Action**: Draft #1518 plan v1 (cluster session-sync off legacy dataplane.DataPlane)
+- **File(s)**: docs/pr/1518-cluster-session-sync-migration/plan.md, reviewer-ids.md
+- **Why**: Sub-#1451 S3 — narrow pkg/cluster boundary to a backend-neutral
+  clusterRuntime interface; constructors + setter no longer name
+  dataplane.DataPlane. Keep SetDataPlane as a deprecated alias for one cycle.
+  HA-touching scope: must pass make test-failover.
+- **Validation**: pending Codex + Antigravity adversarial plan review.

--- a/_Log.md
+++ b/_Log.md
@@ -2,6 +2,15 @@
 
 ## 2026-05-25
 
+- **Timestamp**: 2026-05-25T15:45:00Z
+  - **Action**: Addressed PR #1551 Copilot round-3 doc-comment nits by
+    fully qualifying dataplane helper names in cluster session-sync
+    comments (`dataplane.TelemetryOf`, `dataplane.NewDataPlaneTelemetry`).
+  - **File(s)**:
+    `pkg/cluster/sync.go`,
+    `pkg/cluster/sync_test.go`,
+    `_Log.md`
+
 - **Timestamp**: 2026-05-26T01:00:00Z
   - **Action**: Round-3 reviewer verdicts complete on PR #1550 HEAD
     444a1959. Codex MERGE-READY (no findings). AGY MERGE-READY

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -261,7 +261,8 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/cli/cli_show_nat.go` | NAT display still uses legacy NAT/session metadata. |
 | `pkg/cli/cli_show_security.go` | Security display still uses legacy counters and filter types. |
 | `pkg/cli/runtime.go` | #1517 — `cliRuntime` interface declares the narrow CLI dataplane surface; still depends on root `pkg/dataplane` type names (`SessionKey`, `CounterValue`, etc.) until those types move to a domain package. |
-| `pkg/cluster/sync.go` | Session sync still installs sessions through the legacy bridge. |
+| `pkg/cluster/runtime.go` | `clusterRuntime` interface still names `dataplane.SessionStore`/`Telemetry` domain types from `pkg/dataplane`; no longer references `dataplane.DataPlane` after #1518. |
+| `pkg/cluster/sync.go` | Session sync still installs sessions through the legacy bridge (deprecated `SetDataPlane` alias retained one cycle per #1518; constructors now take the narrow `clusterRuntime` instead of `dataplane.DataPlane`). |
 | `pkg/cluster/sync_bulk.go` | Bulk sync still serializes legacy session entries. |
 | `pkg/cluster/sync_conn.go` | Sync connection code still references legacy session types. |
 | `pkg/cluster/sync_protocol.go` | Wire protocol still carries legacy session records. |

--- a/docs/pr/1518-cluster-session-sync-migration/plan.md
+++ b/docs/pr/1518-cluster-session-sync-migration/plan.md
@@ -1,0 +1,335 @@
+# #1518 Plan — Migrate pkg/cluster Session-Sync Off Legacy dataplane.DataPlane
+
+**Status:** DRAFT v1 — pending hostile plan review (Codex + Antigravity)
+
+## Issue framing
+
+Sub-#1451 step S3 of the eBPF retirement (#1373). `pkg/cluster/sync.go`
+currently exposes `NewSessionSync`, `NewDualSessionSync`, and
+`SetDataPlane` whose signatures take `dataplane.DataPlane` — the wide
+legacy BPF-shaped interface. The internals of `SessionSync` no longer
+need that full surface: a prior step already split the stored fields
+into `s.sessions dataplane.SessionStore` and `s.telemetry
+dataplane.Telemetry`, populated via `SetRuntimeDomains(...)` from
+`dataplane.SessionStoreOf/TelemetryOf(dp)`.
+
+What still couples the cluster package to the legacy shape is only the
+**boundary**: the public constructor and setter parameter types. This
+step removes that residual coupling so the HA hot path no longer names
+`dataplane.DataPlane` at all, then renames `SetDataPlane` to
+`SetRuntime` (with a one-release alias).
+
+This unblocks #1476 (drop the legacy `DataPlane` interface from the
+daemon shrink set per `docs/pr/1451-migration-scope/scope.md` once all
+S1-S5 land).
+
+## Honest scope / value framing
+
+- **No runtime behavior change.** Pure type-narrowing at a single
+  package boundary plus a constructor rename.
+- **Win:** removes the last cluster→legacy-DP type dependency. Lets
+  the userspace runtime feed `SessionSync` without going through the
+  `legacyDP()` cast in `daemon_ha_sync.go:718`. Keeps eBPF and
+  userspace dataplanes symmetric at this seam.
+- **Cost:** small surface change but ~80 test call-sites in
+  `pkg/cluster/sync_test.go` plus two daemon call-sites and three
+  daemon-test call-sites.
+- **Risk if wrong:** This touches HA session-sync wiring. A subtle
+  miswire (e.g. passing nil where Sessions are needed, or losing the
+  type assertion against `userspaceEventStreamProvider` next to the
+  setter) silently kills bulk sync, GC delete propagation, or fabric
+  forwarding.
+
+If reviewers conclude the type-narrowing churn is too small to justify
+the test-surface change, **PLAN-KILL is an acceptable verdict** — the
+two-cycle alias and the existing `SessionStoreOf` adapter mean the
+boundary is already neutral at runtime; the rename is the principal
+deliverable.
+
+## What is already shipped / partially migrated
+
+`SessionSync` already stores the narrow domain interfaces:
+
+- `pkg/cluster/sync.go:153` `sessions dataplane.SessionStore`
+- `pkg/cluster/sync.go:154` `telemetry dataplane.Telemetry`
+- `pkg/cluster/sync.go:405` `SetRuntimeDomains(sessions, telemetry)` —
+  backend-neutral domain setter
+- `pkg/cluster/sync.go:393` `SetDataPlane(dp dataplane.DataPlane)` —
+  the legacy-shaped setter; today it adapts via
+  `dataplane.SessionStoreOf(dp)` + `TelemetryOf(dp)` and calls
+  `SetRuntimeDomains`.
+
+All the actual hot paths inside the cluster package already use
+`s.sessions.*` / `s.telemetry.*` (see `sync.go:570`, `sync_bulk.go:121,
+160`, `sync_conn.go:34, 49, 64, 74, 330, 384, 385, 399, 417, 447,
+448`). There is **no remaining hot-path use** of `dataplane.DataPlane`
+inside the cluster package. The boundary is the only thing left.
+
+## Concrete design
+
+### 1. New `pkg/cluster/runtime.go`
+
+```go
+package cluster
+
+import "github.com/psaab/xpf/pkg/dataplane"
+
+// clusterRuntime is the backend-neutral runtime surface required by
+// SessionSync. It captures exactly the domains the HA hot path needs
+// (session-store install/delete/iterate + telemetry counters used by
+// the sweep). Both pkg/dataplane.Manager (legacy eBPF) and
+// pkg/dataplane/userspace.Manager satisfy it via their existing
+// Sessions()/Telemetry() methods.
+type clusterRuntime interface {
+    Sessions() dataplane.SessionStore
+    Telemetry() dataplane.Telemetry
+}
+```
+
+Notes:
+- Lower-case (package-private) interface name. The constructors are
+  public; the type bound is satisfied structurally.
+- Identical method set to the relevant slice of
+  `dataplane.RuntimeDataPlane` so any current/future runtime that
+  implements `RuntimeDataPlane` satisfies `clusterRuntime` for free.
+- Does **not** include `SessionDeltas()` because today's sweep reaches
+  it via `s.sessions.SessionDeltas()` (see `sync_conn.go:330`),
+  consistent with how the rest of the hot path uses `s.sessions`.
+
+### 2. Constructor signatures
+
+```go
+func NewSessionSync(localAddr, peerAddr string, rt clusterRuntime) *SessionSync
+func NewDualSessionSync(local, peer, local1, peer1 string, rt clusterRuntime) *SessionSync
+```
+
+Both constructors call `s.SetRuntime(rt)` instead of
+`s.SetDataPlane(dp)`.
+
+### 3. New `SetRuntime` + deprecated `SetDataPlane` alias
+
+```go
+// SetRuntime sets the backend-neutral runtime used by SessionSync.
+// Passing nil clears both domains.
+func (s *SessionSync) SetRuntime(rt clusterRuntime) {
+    if rt == nil {
+        s.SetRuntimeDomains(nil, nil)
+        return
+    }
+    s.SetRuntimeDomains(rt.Sessions(), rt.Telemetry())
+}
+
+// Deprecated: use SetRuntime. Kept for one release cycle for any
+// out-of-tree caller still passing dataplane.DataPlane. The legacy
+// dataplane satisfies clusterRuntime via Manager.Sessions()/Telemetry().
+func (s *SessionSync) SetDataPlane(dp dataplane.DataPlane) {
+    if dp == nil {
+        s.SetRuntimeDomains(nil, nil)
+        return
+    }
+    s.SetRuntimeDomains(dataplane.SessionStoreOf(dp), dataplane.TelemetryOf(dp))
+}
+```
+
+`SessionStoreOf` already handles the case where a `DataPlane`
+implementation also exposes `Sessions()`/`Telemetry()` directly
+(`apply.go:65`), so the alias does not regress behavior versus the
+new path.
+
+### 4. Daemon fan-out
+
+- `pkg/daemon/daemon_ha_sync.go:525, 527` — pass `nil` for the runtime
+  at construction time (unchanged) because the daemon wires the
+  runtime later via `SetRuntime` (kept asynchronous, see lines
+  693-731).
+- `pkg/daemon/daemon_ha_sync.go:718` — change
+  `d.sessionSync.SetDataPlane(d.legacyDP())` to
+  `d.sessionSync.SetRuntime(d.dp)`. `d.dp` is already typed
+  `dataplane.RuntimeDataPlane`; both the legacy `*dataplane.Manager`
+  and the userspace `*userspace.Manager` implement
+  `Sessions()/Telemetry()`.
+- Keep the existing `legacyDP()` callers nearby (event-stream
+  provider type assertion at line 682, exporter at line 271). Those
+  are **not** session-sync wiring; they are userspace-specific
+  capability probes. **Do not touch them in this PR** — they are
+  owned by #1520/#1521.
+
+### 5. Test fan-out
+
+- `pkg/cluster/sync_test.go` — 80 call-sites. Half pass `nil`
+  (continues to compile under the new signature). The other half pass
+  `*mockSweepDP` which today embeds `dataplane.DataPlane`. Two options:
+  - **(a)** Add `Sessions()` / `Telemetry()` methods to `mockSweepDP`
+    that return `dataplane.SessionStoreOf(m)` / `TelemetryOf(m)`. Then
+    `*mockSweepDP` satisfies `clusterRuntime` directly.
+  - **(b)** Continue using the deprecated `SetDataPlane` path in
+    tests during the alias window.
+  Chosen approach: **(a)**. It exercises the real production path,
+  keeps the deprecated alias's only purpose being out-of-tree callers,
+  and avoids accidentally regressing if the alias is removed.
+- `pkg/daemon/daemon_apply_runtime_test.go:30`,
+  `pkg/daemon/session_sync_readiness_test.go:152` — pass `nil`
+  (continues to compile under the new signature).
+- `TestSetDataPlane` at `sync_test.go:505` is renamed to
+  `TestSetRuntime` and tests `SetRuntime`. A small `TestSetDataPlane`
+  is kept for the alias surface so the deprecation window is covered.
+
+## Public API preservation
+
+| Identifier | Before | After |
+|---|---|---|
+| `NewSessionSync(localAddr, peerAddr string, dp dataplane.DataPlane)` | takes `dataplane.DataPlane` | takes `clusterRuntime` |
+| `NewDualSessionSync(local, peer, local1, peer1 string, dp dataplane.DataPlane)` | same | same |
+| `SetDataPlane(dp dataplane.DataPlane)` | active API | deprecated alias, kept one cycle |
+| `SetRuntime(rt clusterRuntime)` | not present | new primary setter |
+| `SetRuntimeDomains(sessions, telemetry)` | active | unchanged |
+
+The exported function names of `NewSessionSync`,
+`NewDualSessionSync`, and `SetDataPlane` are preserved per the issue
+("keep an alias for one release cycle if any external caller exists").
+Only the parameter type of the constructors changes; existing callers
+passing `dataplane.DataPlane` will fail to compile and need a one-line
+fix at the boundary. This is acceptable because all in-tree callers
+already pass `nil` at construction.
+
+## Hidden invariants the change must preserve
+
+1. **Construction is decoupled from runtime wiring.** The daemon
+   constructs `SessionSync` early (`daemon_ha_sync.go:525-528`), but
+   only attaches the runtime later in a retry loop (line 718). The new
+   `SetRuntime` must accept `nil` and clear both domains, matching the
+   existing `SetDataPlane(nil)` contract.
+2. **`s.sessions == nil` and `s.telemetry == nil` guards.** Code paths
+   like `sweepIntervals()` (`sync_conn.go:328`),
+   `syncSweep()` (`sync_conn.go:369-379`), and the bulk reconcile
+   (`sync.go:570`) all check for nil. Preserve nil-tolerance through
+   the new setter.
+3. **Adapter equivalence with the legacy boundary.** Today,
+   `SetDataPlane(legacyDP)` calls `SessionStoreOf(legacyDP)` and
+   `TelemetryOf(legacyDP)`. The new `SetRuntime(d.dp)` calls
+   `d.dp.Sessions()` and `d.dp.Telemetry()`. For the legacy manager
+   these return identical implementations (both reach the same
+   `dataPlaneSessionStore`); for the userspace manager they reach the
+   in-process userspace session store. Verify by reading
+   `apply.go:225-237` and `userspace/manager.go:209, 220`.
+4. **`writeMu` serialization.** Unchanged — this PR does not touch
+   any conn.Write path.
+5. **GC delete-callback hooks.** Unchanged — `daemon_run.go:333-344`
+   already calls `d.sessionSync.QueueDeleteV4/V6`, which has no
+   dataplane dependency. The dataplane is only consulted on receive
+   (`sync_conn.go:34-79`), which already routes through
+   `s.sessions.PutClusterSyncedV4/V6` etc.
+6. **Ring-buffer SESSION_OPEN forward-sync.** `daemon_run.go:367-408`
+   already uses `d.dp.Sessions().GetV4/V6` directly. Unchanged.
+7. **Sweep profiler detection.** `sweepIntervalsForDataPlane` at
+   `sync_conn.go:336` does `dp.(sessionSyncSweepProfiler)` against the
+   `SessionDeltaSource` returned by `s.sessions.SessionDeltas()`. That
+   contract is independent of the boundary type and stays intact.
+8. **Compile-time interface conformance.** The plan does **not** add
+   any `var _ clusterRuntime = (*dataplane.Manager)(nil)` assertion in
+   `pkg/cluster` because that would create an upward dependency from
+   `cluster` to `dataplane`'s concrete Manager type. Conformance is
+   instead asserted at the daemon call-site by the compiler at line
+   718 (assigning `d.dp` to a `clusterRuntime` parameter).
+
+## Risk assessment
+
+| Class | Level | Justification |
+|---|---|---|
+| Behavioral regression | LOW | No runtime path changes. Boundary uses identical accessors (`Sessions()`/`Telemetry()`) that the legacy adapter already returns. |
+| Lifetime / borrow-checker | N/A | Pure Go interface change. |
+| Performance regression | LOW | One fewer indirection on the runtime wire-up (skip the `SessionStoreOf`/`TelemetryOf` switch table in the hot setter). Construction-time only; no per-packet effect. |
+| Architectural mismatch (#946 Phase 2 / #961 dead-end pattern) | LOW | The narrow interface already exists in production (`SetRuntimeDomains`). This PR just changes the constructor parameter type to match the steady-state design. |
+| HA hot path — failover timing | LOW | No changes to VRRP, RETH, sync hold, heartbeat. Same `writeMu` serialization; same `IsLocalPrimary` gating; same fabric forwarding glue. |
+| HA hot path — session reconciliation | LOW | `ReconcileClusterBulk` is invoked the same way (`sync.go:570`) and still goes through `s.sessions`. |
+| Test surface | MED | 80 call-sites in `sync_test.go`. Risk is mechanical churn, not semantic regression. The chosen approach (a) makes `*mockSweepDP` implement `clusterRuntime` via two new methods so we only touch `mockSweepDP` itself, not every call-site. |
+| Deprecation alias drift | LOW | `SetDataPlane(nil)` and `SetRuntime(nil)` both call `SetRuntimeDomains(nil, nil)`; behavior identical. |
+
+## Test plan
+
+1. `go build ./...` clean.
+2. `go test ./pkg/cluster/...` green (full suite, ~640 tests).
+3. `go test ./pkg/daemon/...` green.
+4. Full Go suite: `make test` (30 packages).
+5. Named-test 5× flake check on:
+   - `TestSetRuntime` (new)
+   - `TestSetDataPlane` (alias coverage)
+   - One representative bulk-sync test (e.g. `TestSyncSweepV4`).
+6. **`make test-failover` on the local regression cluster** with
+   `CLUSTER_ENV=` (see CLAUDE.md HA section). This is the explicit
+   requirement on cluster/VRRP/session-sync/failover changes.
+7. Smoke matrix on the **loss userspace cluster** per the standard
+   triple-review skill:
+   - Pass A (CoS off): v4 + v6 × push + reverse single-stream; v4
+     + v6 multi-stream `-P 12 -R`.
+   - Pass B (CoS on): per-class smoke 5201-5206 × v4+v6 × push+rev.
+8. After Pass A on the loss userspace cluster, trigger at least
+   one cluster failover cycle (`request chassis cluster failover
+   redundancy-group 1`) and verify:
+   - Bulk session sync replays primary→secondary,
+   - `show chassis cluster status` reports symmetric state,
+   - `show chassis cluster information` shows no fabric/sync error
+     counters incrementing.
+
+## Out of scope (explicitly)
+
+- Removing `dataplane.SessionStoreOf` / `TelemetryOf`. Other migration
+  steps (e.g. #1519 daemon-legacydp-shrink) need them.
+- Removing the `userspaceEventStreamProvider` / `userspaceEventStreamExporter`
+  type assertions at `daemon_ha_sync.go:271, 682`. Those are owned by
+  #1520 (userspace boot extraction) and #1521 (maps sync decouple).
+- Renaming `SetRuntimeDomains`. Keeping it gives test code a direct
+  knob.
+- Touching `cmd/cli/`, `pkg/grpcapi/`, or anything outside
+  `pkg/cluster/`, `pkg/daemon/`. Sibling agents on #1516/#1517 own
+  those.
+- Removing the `legacyDP()` helper at `daemon.go:348`. Other
+  call-sites still need it during the staged retirement.
+
+## Open questions for adversarial plan review
+
+1. **Is the deprecated `SetDataPlane` alias actually necessary?** The
+   issue body says "keep an alias for one release cycle if any
+   external caller exists." Are there any out-of-tree consumers of
+   `cluster.NewSessionSync`/`SetDataPlane`? If not, removing the alias
+   immediately is simpler and avoids the `dataplane.DataPlane`
+   parameter type lingering. **Argue for or against keeping the
+   alias.**
+2. **Should `clusterRuntime` be exported (capital `R` `Runtime`)?**
+   Lower-case keeps the interface package-private which prevents
+   accidental dependence; capital makes mocking from external test
+   code easier. Pick one with reasoning.
+3. **`mockSweepDP` migration approach.** Plan picks option (a) — make
+   the mock implement `clusterRuntime` directly. Is option (b) — keep
+   tests on the deprecated `SetDataPlane` alias path — safer because
+   it exercises the alias too? Or does (a) better future-proof when
+   the alias is deleted?
+4. **`SetRuntime(nil)` semantics.** The plan clears both domains on
+   nil. Is there any code path in the daemon that could re-wire
+   midway and expect partial domains? Audit `sessionSync.SetRuntime`
+   call sites for re-entrancy.
+5. **`d.dp` typing at the call-site.** `d.dp` is
+   `dataplane.RuntimeDataPlane`. Are there any concrete dataplane
+   implementations registered through the boot path that do **not**
+   implement `Sessions()` and `Telemetry()` returning non-nil values?
+   If a backend can return nil from `Sessions()`, the new path
+   silently disables session sync — whereas the old path went through
+   `SessionStoreOf` which returns a no-op store wrapper. **Worked
+   trace: walk both userspace.Manager.Sessions() and the legacy
+   dataplane.Manager.Sessions() and confirm neither returns nil during
+   normal operation.**
+6. **`make test-failover` runs on the local regression cluster (not
+   the loss userspace cluster).** That cluster runs the **legacy
+   eBPF** dataplane. After this PR, the legacy boundary at line 718
+   becomes `SetRuntime(d.dp)`. Is the legacy `dataplane.Manager`
+   guaranteed to be the type of `d.dp` on that cluster? If `d.dp` is
+   constructed differently in either cluster (e.g. the regression
+   cluster wraps it in `LegacyDataPlaneAdapter`), the call-site swap
+   could route to a different `Sessions()` implementation. Walk
+   `pkg/daemon/dataplane_setup*.go` (or equivalent) for both branches.
+7. **Architectural mismatch check.** Does this fit the
+   #1451 migration scope's promise to remove `dataplane.DataPlane`
+   from `pkg/cluster/`? If a later step depends on `cluster.SessionSync`
+   exposing a wider runtime (e.g. `LinkController` for fabric address
+   reconciliation), then `clusterRuntime` is too narrow and we'll add
+   methods to it later. Confirm or rebut.

--- a/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
+++ b/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
@@ -4,3 +4,8 @@
 |-------|----------|-------|---------------|---------|
 | r1 | Codex | plan | task-mpkumx0v-srz2o7 | pending |
 | r1 | Antigravity | plan | adversarial-review-mpkunhov-n7yx8g | pending |
+| code-r1 | Codex | code | local-bue7g8rx7 | MERGE-READY ("No actionable correctness regressions") |
+| code-r1 | Antigravity | code | adversarial-review-mplc6cht-teg6ke | NEEDS-MINOR (pre-existing race; alias removal) |
+| code-r1 | Copilot | code | PRR_kwDORLJrbM8AAAABA7o4Jw | COMMENTED 3 minor doc items (folded in 6326a4e0) |
+| code-r1 | Claude SMR | code | comment-4535250997 | MERGE-READY |
+| code-r2 | Antigravity | code | adversarial-review-mplclsh5-hnglon | pending |

--- a/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
+++ b/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
@@ -2,5 +2,5 @@
 
 | Round | Reviewer | Phase | Task / Job ID | Verdict |
 |-------|----------|-------|---------------|---------|
-| r1 | Codex | plan | TBD | TBD |
-| r1 | Antigravity | plan | TBD | TBD |
+| r1 | Codex | plan | task-mpkumx0v-srz2o7 | pending |
+| r1 | Antigravity | plan | adversarial-review-mpkunhov-n7yx8g | pending |

--- a/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
+++ b/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md
@@ -1,0 +1,6 @@
+# Reviewer task IDs for #1518
+
+| Round | Reviewer | Phase | Task / Job ID | Verdict |
+|-------|----------|-------|---------------|---------|
+| r1 | Codex | plan | TBD | TBD |
+| r1 | Antigravity | plan | TBD | TBD |

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -17,11 +17,16 @@ sync.
   `pkg/daemon/daemon_ha.go`, which fans events out (HA sync, status
   publish, etc.). `pkg/cluster/reth.go::HandleStateChange` is a
   state-handler method, not the event-channel consumer.
-- `SessionSync` — `sync.go`, `sync_conn.go`, `sync_bulk.go`. HA session
-  replication. Legacy constructors still accept a transitional
-  `dataplane.DataPlane`, but they immediately adapt it to `SessionStore` and
-  `Telemetry`. The receive, sweep, bulk export, and stale-reconcile paths must
-  stay on those runtime-domain interfaces.
+- `SessionSync` — `sync.go`, `sync_conn.go`, `sync_bulk.go`, `runtime.go`. HA
+  session replication. After #1518, `NewSessionSync`, `NewDualSessionSync`,
+  and `SetRuntime` accept the narrow `clusterRuntime` (see `runtime.go`) —
+  `Sessions() dataplane.SessionStore` plus `Telemetry() dataplane.Telemetry`.
+  Both the legacy `*dataplane.Manager` and the userspace
+  `LegacyDataPlaneAdapter` satisfy `clusterRuntime` directly. The deprecated
+  `SetDataPlane(dataplane.DataPlane)` setter is retained one release cycle
+  for any out-of-tree caller and routes through the same
+  `SessionStoreOf`/`TelemetryOf` adapters. The receive, sweep, bulk export,
+  and stale-reconcile paths must stay on those runtime-domain interfaces.
 
 ## Callers
 

--- a/pkg/cluster/runtime.go
+++ b/pkg/cluster/runtime.go
@@ -8,11 +8,12 @@
 // matching boundary type so the public constructor signatures no
 // longer name the legacy bridge.
 //
-// Both pkg/dataplane.Manager (legacy eBPF) and the userspace
-// dataplane.LegacyDataPlaneAdapter satisfy clusterRuntime via their
-// existing Sessions()/Telemetry() methods, which already participate
-// in dataplane.RuntimeDataPlane. Keeping clusterRuntime package-
-// private (lower-case 'r') prevents accidental upward dependence and
+// Both *pkg/dataplane.Manager (legacy eBPF) and
+// *pkg/dataplane/userspace.LegacyDataPlaneAdapter (userspace) satisfy
+// clusterRuntime via their existing Sessions()/Telemetry() methods,
+// which already participate in dataplane.RuntimeDataPlane. Keeping
+// clusterRuntime package-private (lower-case 'r') prevents accidental
+// upward dependence and
 // matches the pattern used by pkg/cli/runtime.go (#1517) and
 // pkg/api / pkg/conntrack / pkg/fwdstatus / pkg/monitoriface earlier
 // in the #1451 migration sequence.

--- a/pkg/cluster/runtime.go
+++ b/pkg/cluster/runtime.go
@@ -1,0 +1,32 @@
+// Package cluster — backend-neutral runtime surface for SessionSync.
+//
+// Introduced as part of #1518 (sub-#1451 step S3) to remove the legacy
+// dataplane.DataPlane parameter type from NewSessionSync /
+// NewDualSessionSync / SetDataPlane. The cluster session-sync hot path
+// already stores narrow domain interfaces (dataplane.SessionStore /
+// dataplane.Telemetry) via SetRuntimeDomains; clusterRuntime is the
+// matching boundary type so the public constructor signatures no
+// longer name the legacy bridge.
+//
+// Both pkg/dataplane.Manager (legacy eBPF) and the userspace
+// dataplane.LegacyDataPlaneAdapter satisfy clusterRuntime via their
+// existing Sessions()/Telemetry() methods, which already participate
+// in dataplane.RuntimeDataPlane. Keeping clusterRuntime package-
+// private (lower-case 'r') prevents accidental upward dependence and
+// matches the pattern used by pkg/cli/runtime.go (#1517) and
+// pkg/api / pkg/conntrack / pkg/fwdstatus / pkg/monitoriface earlier
+// in the #1451 migration sequence.
+package cluster
+
+import "github.com/psaab/xpf/pkg/dataplane"
+
+// clusterRuntime is the backend-neutral runtime surface required by
+// SessionSync. It captures exactly the domains the HA hot path needs:
+// the session store (install/delete/iterate) and telemetry counters
+// used by the sweep. The interface is intentionally narrow — adding
+// methods here means SessionSync gains a new runtime dependency and
+// requires a fresh adversarial review.
+type clusterRuntime interface {
+	Sessions() dataplane.SessionStore
+	Telemetry() dataplane.Telemetry
+}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -342,7 +342,14 @@ type clusterSyncedSessionInstaller interface {
 const deleteJournalDefaultCap = 10000
 
 // NewSessionSync creates a new single-fabric session synchronization manager.
-func NewSessionSync(localAddr, peerAddr string, dp dataplane.DataPlane) *SessionSync {
+//
+// The runtime parameter is backend-neutral (see clusterRuntime in runtime.go).
+// Callers that still hold a legacy dataplane.DataPlane can either pass nil at
+// construction time and wire the runtime later via SetRuntime (the daemon's
+// pattern, see daemon_ha_sync.go), or pass any value that exposes
+// Sessions()/Telemetry() — both *dataplane.Manager and the userspace
+// LegacyDataPlaneAdapter satisfy this contract.
+func NewSessionSync(localAddr, peerAddr string, rt clusterRuntime) *SessionSync {
 	s := &SessionSync{
 		localAddr:                  localAddr,
 		peerAddr:                   peerAddr,
@@ -353,13 +360,14 @@ func NewSessionSync(localAddr, peerAddr string, dp dataplane.DataPlane) *Session
 		failoverBatchWaiters:       make(map[string]failoverWaiter),
 		failoverBatchCommitWaiters: make(map[string]failoverWaiter),
 	}
-	s.SetDataPlane(dp)
+	s.SetRuntime(rt)
 	return s
 }
 
 // NewDualSessionSync creates a session sync manager with dual-fabric transport.
-// If local1 or peer1 is empty, it falls back to single-fabric behavior.
-func NewDualSessionSync(local, peer, local1, peer1 string, dp dataplane.DataPlane) *SessionSync {
+// If local1 or peer1 is empty, it falls back to single-fabric behavior. See
+// NewSessionSync for the runtime parameter contract.
+func NewDualSessionSync(local, peer, local1, peer1 string, rt clusterRuntime) *SessionSync {
 	s := &SessionSync{
 		localAddr:                  local,
 		peerAddr:                   peer,
@@ -372,7 +380,7 @@ func NewDualSessionSync(local, peer, local1, peer1 string, dp dataplane.DataPlan
 		failoverBatchWaiters:       make(map[string]failoverWaiter),
 		failoverBatchCommitWaiters: make(map[string]failoverWaiter),
 	}
-	s.SetDataPlane(dp)
+	s.SetRuntime(rt)
 	return s
 }
 
@@ -389,7 +397,29 @@ func (s *SessionSync) SetZoneRGMap(m map[uint16]int) {
 	s.zoneRGMu.Unlock()
 }
 
-// SetDataPlane sets the dataplane used for installing received sessions.
+// SetRuntime wires the backend-neutral runtime used by SessionSync.
+//
+// Passing nil clears both runtime domains, matching the existing nil-
+// tolerance contract (see SetRuntimeDomains and the sweep / bulk
+// reconcile paths in sync_conn.go and sync_bulk.go that check for
+// s.sessions == nil / s.telemetry == nil before touching the
+// dataplane).
+func (s *SessionSync) SetRuntime(rt clusterRuntime) {
+	if rt == nil {
+		s.SetRuntimeDomains(nil, nil)
+		return
+	}
+	s.SetRuntimeDomains(rt.Sessions(), rt.Telemetry())
+}
+
+// SetDataPlane is the deprecated alias for SetRuntime. It is kept for one
+// release cycle so any out-of-tree caller still passing the legacy
+// dataplane.DataPlane bridge continues to compile. In-tree callers were
+// migrated to SetRuntime as part of #1518.
+//
+// Deprecated: use SetRuntime. Both legacy *dataplane.Manager and the
+// userspace LegacyDataPlaneAdapter satisfy clusterRuntime via Sessions()/
+// Telemetry(); no adapter is needed.
 func (s *SessionSync) SetDataPlane(dp dataplane.DataPlane) {
 	if dp == nil {
 		s.SetRuntimeDomains(nil, nil)

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -344,11 +344,14 @@ const deleteJournalDefaultCap = 10000
 // NewSessionSync creates a new single-fabric session synchronization manager.
 //
 // The runtime parameter is backend-neutral (see clusterRuntime in runtime.go).
-// Callers that still hold a legacy dataplane.DataPlane can either pass nil at
-// construction time and wire the runtime later via SetRuntime (the daemon's
-// pattern, see daemon_ha_sync.go), or pass any value that exposes
-// Sessions()/Telemetry() — both *dataplane.Manager and the userspace
-// LegacyDataPlaneAdapter satisfy this contract.
+// In-tree callers either pass nil at construction time and wire the runtime
+// later via SetRuntime (the daemon's pattern, see daemon_ha_sync.go) or pass a
+// runtime that already implements Sessions()/Telemetry() — both
+// *dataplane.Manager and the userspace LegacyDataPlaneAdapter satisfy that
+// contract. Out-of-tree callers that still hold a value typed as
+// dataplane.DataPlane (which does NOT expose Sessions()/Telemetry() directly)
+// must pass nil here and use the deprecated SetDataPlane alias, which adapts
+// the legacy bridge via dataplane.SessionStoreOf / TelemetryOf.
 func NewSessionSync(localAddr, peerAddr string, rt clusterRuntime) *SessionSync {
 	s := &SessionSync{
 		localAddr:                  localAddr,

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -351,7 +351,8 @@ const deleteJournalDefaultCap = 10000
 // that contract. Callers that hold only a value typed as dataplane.DataPlane
 // (the legacy bridge does NOT expose Sessions()/Telemetry() directly) can
 // either: (a) wrap it in a small local type that adds Sessions() and
-// Telemetry() returning dataplane.SessionStoreOf(dp) / TelemetryOf(dp) and
+// Telemetry() returning dataplane.SessionStoreOf(dp) /
+// dataplane.TelemetryOf(dp) and
 // pass that wrapper here — Go structural typing accepts any value with the
 // right method set even though clusterRuntime is package-private — or (b)
 // pass nil and use the deprecated SetDataPlane alias, which performs the

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -347,11 +347,15 @@ const deleteJournalDefaultCap = 10000
 // In-tree callers either pass nil at construction time and wire the runtime
 // later via SetRuntime (the daemon's pattern, see daemon_ha_sync.go) or pass a
 // runtime that already implements Sessions()/Telemetry() — both
-// *dataplane.Manager and the userspace LegacyDataPlaneAdapter satisfy that
-// contract. Out-of-tree callers that still hold a value typed as
-// dataplane.DataPlane (which does NOT expose Sessions()/Telemetry() directly)
-// must pass nil here and use the deprecated SetDataPlane alias, which adapts
-// the legacy bridge via dataplane.SessionStoreOf / TelemetryOf.
+// *dataplane.Manager and *dataplane/userspace.LegacyDataPlaneAdapter satisfy
+// that contract. Callers that hold only a value typed as dataplane.DataPlane
+// (the legacy bridge does NOT expose Sessions()/Telemetry() directly) can
+// either: (a) wrap it in a small local type that adds Sessions() and
+// Telemetry() returning dataplane.SessionStoreOf(dp) / TelemetryOf(dp) and
+// pass that wrapper here — Go structural typing accepts any value with the
+// right method set even though clusterRuntime is package-private — or (b)
+// pass nil and use the deprecated SetDataPlane alias, which performs the
+// same adaptation internally.
 func NewSessionSync(localAddr, peerAddr string, rt clusterRuntime) *SessionSync {
 	s := &SessionSync{
 		localAddr:                  localAddr,

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -699,17 +699,22 @@ func TestHandleMessageDeleteV6RemovesCompanions(t *testing.T) {
 
 // --- Sync sweep tests ---
 
-// mockSweepDP is a minimal mock for testing sync sweep.
-// Embeds DataPlane interface; only IterateSessions/V6 are implemented.
+// mockSweepDP is the test mock backing the cluster session-sync suite.
+// It embeds the legacy dataplane.DataPlane interface so the few methods
+// this mock does not override fall through to a nil receiver, and
+// implements the surface the cluster hot path actually exercises:
+// Get/Set/Delete session, sync + batch Iterate for v4 and v6,
+// ReadGlobalCounter, and the cluster-DNAT delete tracking used by the
+// reverse-NAT teardown tests.
 //
-// After #1518 (sub-#1451 S3) the cluster constructors take clusterRuntime
-// (Sessions()/Telemetry()) instead of dataplane.DataPlane. mockSweepDP
-// satisfies clusterRuntime by adapting itself via
-// dataplane.NewDataPlaneSessionStore / NewDataPlaneTelemetry — the exact
-// same adapter the old SetDataPlane path used. This keeps the production
-// wiring under test and exercises the same SessionStoreOf / TelemetryOf
-// adapter the deprecated alias still uses, so we do not have to touch the
-// ~40 NewSessionSync(... dp) call-sites.
+// After #1518 (sub-#1451 S3) the cluster constructors take
+// clusterRuntime (Sessions()/Telemetry()) instead of dataplane.DataPlane.
+// mockSweepDP satisfies clusterRuntime by adapting itself via
+// dataplane.NewDataPlaneSessionStore / NewDataPlaneTelemetry — the
+// exact same adapter the legacy SetDataPlane path used. This keeps the
+// production wiring under test and exercises the same SessionStoreOf /
+// TelemetryOf adapter the deprecated alias still uses, so the existing
+// NewSessionSync(... dp) call-sites compile unchanged.
 type mockSweepDP struct {
 	dataplane.DataPlane
 	v4sessions     map[dataplane.SessionKey]dataplane.SessionValue

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -700,12 +700,18 @@ func TestHandleMessageDeleteV6RemovesCompanions(t *testing.T) {
 // --- Sync sweep tests ---
 
 // mockSweepDP is the test mock backing the cluster session-sync suite.
-// It embeds the legacy dataplane.DataPlane interface so the few methods
-// this mock does not override fall through to a nil receiver, and
-// implements the surface the cluster hot path actually exercises:
+// It embeds the dataplane.DataPlane interface as a method-set
+// placeholder so the type satisfies dataplane.DataPlane at compile
+// time without spelling out every unused method; the embedded
+// interface field is left nil, so any method that is NOT overridden
+// below will panic with a nil-interface dispatch if invoked. In
+// practice the cluster sweep / install / iterate paths only call the
+// overridden subset, which this type implements explicitly:
 // Get/Set/Delete session, sync + batch Iterate for v4 and v6,
 // ReadGlobalCounter, and the cluster-DNAT delete tracking used by the
-// reverse-NAT teardown tests.
+// reverse-NAT teardown tests. Adding a sweep call-site that touches a
+// non-overridden method will fail-fast with a clear runtime panic on
+// the first test that exercises it.
 //
 // After #1518 (sub-#1451 S3) the cluster constructors take
 // clusterRuntime (Sessions()/Telemetry()) instead of dataplane.DataPlane.

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -716,7 +716,7 @@ func TestHandleMessageDeleteV6RemovesCompanions(t *testing.T) {
 // After #1518 (sub-#1451 S3) the cluster constructors take
 // clusterRuntime (Sessions()/Telemetry()) instead of dataplane.DataPlane.
 // mockSweepDP satisfies clusterRuntime by adapting itself via
-// dataplane.NewDataPlaneSessionStore / NewDataPlaneTelemetry — the
+// dataplane.NewDataPlaneSessionStore / dataplane.NewDataPlaneTelemetry — the
 // exact same adapter the legacy SetDataPlane path used. This keeps the
 // production wiring under test and exercises the same SessionStoreOf /
 // TelemetryOf adapter the deprecated alias still uses, so the existing

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -522,6 +522,53 @@ func TestSetDataPlane(t *testing.T) {
 	}
 }
 
+// TestSetRuntime exercises the new clusterRuntime-shaped setter introduced
+// in #1518 (sub-#1451 S3). It covers three things:
+//
+//  1. SetRuntime(nil) clears both runtime domains and preserves the
+//     pre-existing nil-tolerance contract.
+//  2. SetRuntime with a clusterRuntime-implementing value populates both
+//     s.sessions and s.telemetry.
+//  3. The installed runtime actually receives sessions from the wire (the
+//     deprecated SetDataPlane alias has no functional regression).
+func TestSetRuntime(t *testing.T) {
+	ss := NewSessionSync(":4785", "10.0.0.2:4785", nil)
+	if ss.sessions != nil || ss.telemetry != nil {
+		t.Fatal("runtime domains should be nil initially")
+	}
+
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss.SetRuntime(dp)
+	if ss.sessions == nil || ss.telemetry == nil {
+		t.Fatal("SetRuntime should populate both runtime domains")
+	}
+
+	// Round-trip a session through the wire-decode path; the installed
+	// runtime should receive it.
+	key := dataplane.SessionKey{Protocol: 6, SrcIP: [4]byte{1, 2, 3, 4}, DstIP: [4]byte{5, 6, 7, 8}, SrcPort: 1000, DstPort: 2000}
+	val := dataplane.SessionValue{State: dataplane.SessStateEstablished}
+	payload := encodeSessionV4Payload(key, val)
+	ss.handleMessage(nil, syncMsgSessionV4, payload)
+	if ss.stats.SessionsInstalled.Load() != 1 {
+		t.Fatalf("SessionsInstalled = %d, want 1", ss.stats.SessionsInstalled.Load())
+	}
+	if _, ok := dp.v4sessions[key]; !ok {
+		t.Fatal("runtime should have received the installed session")
+	}
+
+	// nil clears both domains; subsequent installs must not crash and must
+	// not be counted as installed.
+	ss.SetRuntime(nil)
+	if ss.sessions != nil || ss.telemetry != nil {
+		t.Fatal("SetRuntime(nil) should clear both runtime domains")
+	}
+	before := ss.stats.SessionsInstalled.Load()
+	ss.handleMessage(nil, syncMsgSessionV4, payload)
+	if ss.stats.SessionsInstalled.Load() != before {
+		t.Fatal("SetRuntime(nil) should disable installs")
+	}
+}
+
 func TestInstallClusterSyncedV4DoesNotCountRolledBackCompanionFailure(t *testing.T) {
 	forward := dataplane.SessionKey{Protocol: 6, SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2}, SrcPort: 1234, DstPort: 80}
 	reverse := dataplane.SessionKey{Protocol: 6, SrcIP: [4]byte{10, 0, 0, 2}, DstIP: [4]byte{10, 0, 0, 1}, SrcPort: 80, DstPort: 1234}
@@ -654,6 +701,15 @@ func TestHandleMessageDeleteV6RemovesCompanions(t *testing.T) {
 
 // mockSweepDP is a minimal mock for testing sync sweep.
 // Embeds DataPlane interface; only IterateSessions/V6 are implemented.
+//
+// After #1518 (sub-#1451 S3) the cluster constructors take clusterRuntime
+// (Sessions()/Telemetry()) instead of dataplane.DataPlane. mockSweepDP
+// satisfies clusterRuntime by adapting itself via
+// dataplane.NewDataPlaneSessionStore / NewDataPlaneTelemetry — the exact
+// same adapter the old SetDataPlane path used. This keeps the production
+// wiring under test and exercises the same SessionStoreOf / TelemetryOf
+// adapter the deprecated alias still uses, so we do not have to touch the
+// ~40 NewSessionSync(... dp) call-sites.
 type mockSweepDP struct {
 	dataplane.DataPlane
 	v4sessions     map[dataplane.SessionKey]dataplane.SessionValue
@@ -663,6 +719,20 @@ type mockSweepDP struct {
 	deletedDNATV6  []dataplane.DNATKeyV6
 	failSetV4      map[dataplane.SessionKey]error
 	failSetV6      map[dataplane.SessionKeyV6]error
+}
+
+// Sessions implements clusterRuntime by wrapping the mock in the same
+// session-store adapter the legacy SetDataPlane path used. Returning a
+// fresh adapter on each call mirrors the production cost (negligible —
+// only called once per SetRuntime).
+func (m *mockSweepDP) Sessions() dataplane.SessionStore {
+	return dataplane.NewDataPlaneSessionStore(m)
+}
+
+// Telemetry implements clusterRuntime by wrapping the mock in the same
+// telemetry adapter the legacy SetDataPlane path used.
+func (m *mockSweepDP) Telemetry() dataplane.Telemetry {
+	return dataplane.NewDataPlaneTelemetry(m)
 }
 
 func (m *mockSweepDP) ReadGlobalCounter(index uint32) (uint64, error) {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -731,9 +731,14 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 
 				// Wire dataplane into session sync and start the sweep.
 				// Must happen here (not in Run) because d.sessionSync is
-				// created asynchronously in this goroutine.
+				// created asynchronously in this goroutine. d.dp is a
+				// dataplane.RuntimeDataPlane; both the legacy *Manager and
+				// the userspace LegacyDataPlaneAdapter implement
+				// Sessions()/Telemetry() so they satisfy the cluster
+				// package's narrow clusterRuntime contract directly. The
+				// legacyDP() cast is no longer required at this seam (#1518).
 				if d.dp != nil {
-					d.sessionSync.SetDataPlane(d.legacyDP())
+					d.sessionSync.SetRuntime(d.dp)
 					d.sessionSync.IsPrimaryFn = func() bool {
 						return d.cluster != nil && d.cluster.IsLocalPrimary(0)
 					}

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -40,6 +40,7 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/cli/cli_show_flow.go":                 "flow display still uses legacy session keys and values",
 	"pkg/cli/cli_show_nat.go":                  "NAT display still uses legacy NAT/session metadata",
 	"pkg/cli/cli_show_security.go":             "security display still uses legacy counters and filter types",
+	"pkg/cluster/runtime.go":                   "clusterRuntime interface still names dataplane.SessionStore/Telemetry domain types from pkg/dataplane (#1518)",
 	"pkg/cluster/sync.go":                      "session sync still installs sessions through the legacy bridge",
 	"pkg/cluster/sync_bulk.go":                 "bulk sync still serializes legacy session entries",
 	"pkg/cluster/sync_conn.go":                 "sync connection code still references legacy session types",


### PR DESCRIPTION
## Summary

Replace `dataplane.DataPlane` parameter type on `NewSessionSync`,
`NewDualSessionSync`, and the session-sync runtime setter with a
narrow, package-private `clusterRuntime` interface in a new
`pkg/cluster/runtime.go`. Mirrors the pattern shipped by
`pkg/api`/`pkg/fwdstatus`/`pkg/monitoriface`/`pkg/conntrack`/`pkg/cli`
(#1517) earlier in the #1451 migration sequence.

`clusterRuntime` is a strict subset of `dataplane.RuntimeDataPlane`:

```go
type clusterRuntime interface {
    Sessions()  dataplane.SessionStore
    Telemetry() dataplane.Telemetry
}
```

Both `*dataplane.Manager` (legacy eBPF) and the userspace
`LegacyDataPlaneAdapter` satisfy it directly. The session-sync hot path
already stored these narrow domains via `SetRuntimeDomains`; only the
boundary still named the legacy bridge. This PR removes that residual
coupling and renames `SetDataPlane` to `SetRuntime`.
`SetDataPlane(dataplane.DataPlane)` is retained one release cycle as a
deprecated alias.

Daemon call-site at `pkg/daemon/daemon_ha_sync.go:735` now calls
`SetRuntime(d.dp)` directly — the `legacyDP()` cast is no longer
needed at this seam.

Pure decoupling refactor; zero behavioural change.

Closes #1518. Refs #1476, #1451, #1373.

## Plan + adversarial review

Plan doc: [`docs/pr/1518-cluster-session-sync-migration/plan.md`](https://github.com/psaab/xpf/blob/refactor/1518-cluster-session-sync-migration/docs/pr/1518-cluster-session-sync-migration/plan.md)

Reviewer IDs tracked at [`docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md`](https://github.com/psaab/xpf/blob/refactor/1518-cluster-session-sync-migration/docs/pr/1518-cluster-session-sync-migration/reviewer-ids.md).

Code-phase Codex + Antigravity + Claude SMR adversarial reviews will be
dispatched post-PR-open per `/triple-review` SKILL.md.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/cluster/...` green
- [x] `go test ./pkg/cluster/ -run 'TestSetRuntime|TestSetDataPlane|TestSyncSweep' -count=5` no flake
- [x] `go test ./pkg/daemon/...` green
- [x] `go test ./...` green (32 packages)
- [x] `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports` green (canary updated)
- [ ] **Smoke matrix (loss userspace cluster) — pending serialized smoke-runner queue**
  - [ ] Pass A (CoS off): v4 + v6 × push + `-R` single-stream; v4 + v6 multi-stream `-P 12 -R`
  - [ ] Pass B (CoS on): per-class smoke 5201-5206 × v4+v6 × push+rev
- [ ] **`make test-failover` (HA-sensitive scope per CLAUDE.md)**
- [ ] Cluster failover cycle: `request chassis cluster failover redundancy-group 1`; verify bulk session sync replays primary→secondary; `show chassis cluster status` symmetric; no fabric/sync error counters incrementing

HA-sensitive — smoke-runner will add `make test-failover` regression
per coordinator policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)