### PR TITLE
config: #1539 guard against AST leakage of retired DPDK sub-tree

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -758,6 +758,23 @@
     PLAN-KILL grounds.
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
     `_Log.md`
+- **Timestamp**: 2026-05-25T15:50:00Z
+  - **Action**: #1539 code-review on PR #1553 + lint fix
+    (commit 6a7d0649). Codex MERGE-READY directly on 8c5a4ced
+    (session 019e5fa4 continued). AGY initially MERGE-WITH-MAJOR
+    flagging HIGH (multi-LHS bypass: `dummy, sys.DPDKDataplane
+    = nil, &cfg{}` would escape canary because original isLHSOfAssignToNil
+    checked "any RHS nil" not positional pairing) + MEDIUM
+    (hand-rolled itoa OOB for >=12 digits, MinInt negation
+    overflow). My local lint pass on the file produced the same
+    positional-LHS fix AGY recommended; committed as 6a7d0649
+    with the new TestDPDKSubtreeLeakageCanary_NegativeRejects
+    MultiVariableBypass test fixture. AGY final verdict MERGE-READY.
+    Both reviewers now MERGE-READY on 6a7d0649. Hand-rolled itoa
+    swapped for strconv.Itoa. All 10 canary tests pass; full
+    `go test ./...` clean.
+  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
+    docs/pr/1539-ast-leakage-guard/reviewer-ids.md, _Log.md
 - **Timestamp**: 2026-05-25T15:25:00Z
   - **Action**: #1539 implementation — Option A + Option B per
     plan v3. Option A: `cfg.System.DPDKDataplane = nil` clear at

--- a/_Log.md
+++ b/_Log.md
@@ -758,6 +758,24 @@
     PLAN-KILL grounds.
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
     `_Log.md`
+- **Timestamp**: 2026-05-25T15:25:00Z
+  - **Action**: #1539 implementation — Option A + Option B per
+    plan v3. Option A: `cfg.System.DPDKDataplane = nil` clear at
+    end of `compileExpanded` after `validateDataplaneTypeStrict`
+    succeeds and before `return cfg, nil`. Option B: new
+    pkg/config/dpdk_subtree_leakage_canary_test.go (~600 LOC
+    including ~200 LOC walker + fixtures + 9 tests). Canary uses
+    parent-stack maintained via ast.Inspect nil-callback
+    semantics, walks parent chain to enclosing FuncDecl (AGY
+    round-2 MEDIUM nested-conditional fix), recognizes IfStmt
+    `==` gates and switch single-entry case-clause gates (AGY
+    round-2 HIGH multi-case fix), and rejects negation idiom
+    (Codex round-2 contradictory-paragraph fix). LHS-of-assign-
+    to-nil is recognized so Option A's clear is not flagged.
+    Real-repo scan returns zero findings; 5x flake-clean on
+    named tests; `go test ./...` passes across all 30 packages.
+  - **File(s)**: pkg/config/compiler.go,
+    pkg/config/dpdk_subtree_leakage_canary_test.go, _Log.md
 - **Timestamp**: 2026-05-25T14:50:00Z
   - **Action**: #1539 plan v3 — applied round-2 plan review
     feedback. Codex round-2 PLAN-MINOR (session

--- a/_Log.md
+++ b/_Log.md
@@ -758,6 +758,21 @@
     PLAN-KILL grounds.
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
     `_Log.md`
+- **Timestamp**: 2026-05-25T14:50:00Z
+  - **Action**: #1539 plan v3 — applied round-2 plan review
+    feedback. Codex round-2 PLAN-MINOR (session
+    019e5fa4-0552-7823-915d-79eaf79b1c55), AGY round-2 PLAN-MINOR
+    (adversarial-review-mplbulo0-y014py). Window-of-value KILL
+    no longer operative on both sides. v3 changes: section 4.2
+    walks parent chain to FuncDecl (AGY MEDIUM nested-conditional
+    fix); SwitchStmt CaseClause requires `len(List)==1` (AGY HIGH
+    multi-case bypass fix); negation idiom explicitly rejected
+    (Codex contradictory-paragraph fix); two new fixtures
+    (positive nested, negative multi-case, negative negation);
+    stale #1536 stacking text corrected — #1536 merged at
+    fcd53beb. Reviewer-IDs file updated.
+  - **File(s)**: docs/pr/1539-ast-leakage-guard/plan.md,
+    docs/pr/1539-ast-leakage-guard/reviewer-ids.md
 
 - **Timestamp**: 2026-05-25T05:00:00Z
   - **Action**: #1501 A2 — replaced the stale TODO + contradictory
@@ -813,120 +828,6 @@
     (the README wording fix is the only file outside `docs/`).
     No `.go` / `.rs` / `.c` source, no build inputs, no test
     fixtures modified.
-
-- **Timestamp**: 2026-05-25T09:45:00Z
-  - **Action**: PR #1532 — address Copilot review on 510fe7dd
-    (7 nits). Copilot caught a contradiction between the godoc /
-    plan / log claims (generics + type aliases "deferred") and the
-    actual catch-all sweep behaviour (those ARE caught when the
-    selector is spelled literally). True deferred bypasses are
-    only those where the selector vanishes from the AST: transitive
-    alias use, import renames, dot imports, external-package
-    wrappers. Updated godoc on the test func, on
-    findLegacyDataPlaneOffenders, on isLegacyDataPlaneType, and on
-    the *ast.ArrayType slice branch comment. Also added a
-    receiverTypeName helper so funcDeclName includes the receiver
-    on methods ("(*S).Foo parameter is dataplane.DataPlane")
-    addressing Copilot's ambiguity concern, with a new
-    method-receiver-named-in-offender test subcase to lock the
-    behaviour. plan.md got the same scope-clarification + the
-    stale "~80 LOC" claim updated to ~615 LOC.
-  - **File(s)**:
-    `pkg/conntrack/legacy_dataplane_canary_test.go`,
-    `docs/pr/1515-conntrack-gc-canary/plan.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/conntrack -count=1 -race` green
-    (34 subcases now); new method-receiver test fixture asserts
-    "(*S).Foo parameter is dataplane.DataPlane" produced.
-
-- **Timestamp**: 2026-05-25T09:15:00Z
-  - **Action**: PR #1532 round-N — close all AGY-flagged bypass
-    vectors via two-pass walker. AGY KILL verdict on 78b8a38a
-    identified 5 trivial-bypass categories not in the documented
-    deferred list: package-level var, local var, closure param,
-    composite literal, type definition. Codex high finding also
-    flagged `[N]T` fixed array as undocumented. Fix:
-    (a) refactored the AST walker into a shared
-    `findLegacyDataPlaneOffenders(file, name)` helper invoked by
-    both the main canary AND the synthetic tests — addresses Codex
-    "tautological test" finding.
-    (b) added `*ast.ArrayType` arm (Len != nil for fixed arrays) to
-    `isLegacyDataPlaneType` — catches `[N]dataplane.DataPlane`.
-    (c) added pass-2 catch-all selector sweep that walks every
-    `*ast.SelectorExpr` and flags any `dataplane.DataPlane` not
-    already attributed by the structural pass. Closes
-    package-level var, local var, closure, composite literal, type
-    def, AND the previously #1548-deferred compound shapes (`[]T`,
-    `map[K]T`, `chan T`, `func(T)`). Tracked via token.Pos in a
-    structuralHits set so the sweep doesn't double-report.
-    (d) updated godoc scope block to reflect the two-pass design.
-    Remaining #1548-deferred bypasses all share one property: the
-    `dataplane.DataPlane` selector disappears from the AST —
-    transitive alias use (`var x DPAlias` after the alias decl),
-    import renames (`dp.DataPlane`), dot imports (bare `DataPlane`
-    ident), and external-package wrapper types. Generic
-    constraints/instantiations are NOT deferred — the sweep
-    catches them because they still spell the selector literally.
-
-    New tests (33 total subcases): `TestLegacyDataPlaneTypeMatcher`
-    9 cases including new fixed-array + slice-deferred;
-    `TestProductionWalkerCatchesCanaryShapes` 12 structural-pass
-    fixtures parsed via `parser.ParseFile`;
-    `TestProductionWalkerIgnoresUnrelatedTypes` confirms
-    dataplane.SessionStore/Telemetry/Sessions/context.Context don't
-    trip the sweep; new
-    `TestProductionWalkerCatchAllSweepClosesAGYBypasses` 9 cases
-    proving every AGY-flagged bypass + compound type IS now caught.
-
-  - **File(s)**:
-    `pkg/conntrack/legacy_dataplane_canary_test.go`,
-    `docs/pr/1515-conntrack-gc-canary/plan.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/conntrack -count=1 -race` green
-    (33 new subcases pass);
-    `grep -rn 'dataplane\.DataPlane' pkg/conntrack/*.go` finds
-    only the canary test file itself, confirming production tree
-    still clean.
-
-- **Timestamp**: 2026-05-25T08:30:00Z
-  - **Action**: PR #1532 round — address Copilot review on 77baa235.
-    Copilot flagged that `method.Type` is `*ast.FuncType` and that
-    `isLegacyDataPlaneType(method.Type)` could never detect interface
-    method param/result. The existing code at lines 102-132 already
-    type-switches on `*ast.FuncType` and extracts `mt.Params` and
-    `mt.Results` correctly — Copilot misread the implementation. To
-    refute the finding with code-level evidence, added
-    `TestLegacyDataPlaneTypeMatcher` and
-    `TestInterfaceMethodCanaryScansFuncTypeParamsAndResults`
-    subtests that build synthetic ASTs and confirm the walker fires
-    on (a) direct param, (b) pointer param, (c) variadic, (d)
-    paren-wrapped, (e) result; and that it ignores a clean
-    interface. Also addressed Copilot's plan-vs-implementation
-    wording mismatches in
-    `docs/pr/1515-conntrack-gc-canary/plan.md` (scope is all
-    FuncDecls not exported-only; matcher is
-    `isLegacyDataPlaneType()` not `exprString()`).
-  - **File(s)**:
-    `pkg/conntrack/legacy_dataplane_canary_test.go`,
-    `docs/pr/1515-conntrack-gc-canary/plan.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/conntrack -run
-    TestConntrackHasNoLegacyDataPlaneDependency -count=1 -race`
-    green; new subtests assert the interface-method scan against
-    synthetic AST fixtures.
-
-- **Timestamp**: 2026-05-25T01:30:00Z
-  - **Action**: #1515 (#1451 S8) — add regression canary that fences
-    `pkg/conntrack` production code against future re-introduction of
-    `dataplane.DataPlane` as a parameter, result, struct field, or
-    interface method. Mirrors the AST canary pattern from
-    `pkg/dataplane/userspace/manager_coupling_test.go`. Confirmed
-    canary fires by hand-flipping a dummy `func _canaryNegativeTest(dp
-    dataplane.DataPlane) {}` into the package (revert verified clean).
-    No production code change; the conntrack GC is already migrated
-    to `RuntimeDomainProvider`.
-  - **File(s)**: `pkg/conntrack/legacy_dataplane_canary_test.go`
-    (new), `docs/pr/1515-conntrack-gc-canary/plan.md` (new), `_Log.md`
-  - **Validation**: `go test ./pkg/conntrack/ -count=1 -race` green;
-    `go vet ./pkg/conntrack/...` clean; negative-case hand-flip
-    confirms canary fires.
 
 ## 2026-05-24
 
@@ -1199,8 +1100,6 @@
     clean (114 warnings, all pre-existing); `cargo test --release
     --bin xpf-userspace-dp afxdp::wg` — 78/78 pass; `go test
     ./pkg/dataplane/...` — 4/4 packages pass.
-
-## 2026-05-24
 
 - **Timestamp**: 2026-05-24T23:30:00Z
   - **Action**: PR #1499 r-final-5 step 4 — final mechanical sweep
@@ -2885,74 +2784,6 @@
   - **Validation**: cargo build --release; cargo test --release --bin
     xpf-userspace-dp afxdp::wg.
 
-- **Timestamp**: 2026-05-25T06:35Z
-  - **Action**: PR #1532 — document known canary bypass vectors per AGY
-    review; file #1548 hardening follow-up.
-  - **File(s)**: `pkg/conntrack/legacy_dataplane_canary_test.go`
-  - **Why**: AGY adversarial review
-    (`adversarial-review-mpktubut-ogkp1e`) flagged five categories of
-    bypass the current AST walker doesn't catch (compound types,
-    generics, type aliases, import renames, anonymous-struct context).
-    The canary as shipped catches the most common naive-reintroduction
-    mode (direct param/result/field/embed/interface-method of
-    dataplane.DataPlane), which is the realistic regression risk.
-    Hardening for the bypasses is tracked in #1548 (substantial work
-    needing go/types-level import resolution). Comment block updated to
-    make the scope explicit so a future reader doesn't mistake this for
-    an exhaustive fence.
-  - **Validation**:
-    `TestConntrackHasNoLegacyDataPlaneDependency` still passes on the
-    current `pkg/conntrack/` production tree.
-
-- **Timestamp**: 2026-05-25T06:47Z
-  - **Action**: PR #1532 follow-up — fix interface method signature
-    traversal in the conntrack legacy dataplane canary and normalize
-    malformed `_Log.md` list formatting flagged by review.
-  - **File(s)**: `pkg/conntrack/legacy_dataplane_canary_test.go`,
-    `_Log.md`
-  - **Validation**: `go test ./pkg/conntrack/ -count=1 -race`; `go vet
-    ./pkg/conntrack/...`.
-
-- **Timestamp**: 2026-05-25T07:55Z
-  - **Action**: PR #1532 — close Codex MINOR (ellipsis + paren bypasses)
-  - **File(s)**: pkg/conntrack/legacy_dataplane_canary_test.go
-  - **Why**: Codex task-mpktubkn-r9llzq flagged `...dataplane.DataPlane`
-    (variadic params, *ast.Ellipsis) and `(dataplane.DataPlane)`
-    (paren-wrapped, *ast.ParenExpr) as bypass vectors. Both are common Go
-    AST disguises that the prior matcher missed. Added two case arms to
-    isLegacyDataPlaneType to recursively unwrap each.
-  - **Validation**: canary still passes on current pkg/conntrack/
-    production tree.
-
-- **Timestamp**: 2026-05-25T05:58Z
-  - **Action**: PR #1536 — add ErrDPDKDataplaneRetired sentinel +
-    errors.Is test (AGY round-N feedback)
-  - **File(s)**: pkg/config/compiler.go, pkg/config/parser_ast_test.go
-- **Why**: Antigravity adversarial-review-mpksjr0e-f3mjrn flagged the lack of a
-  structured sentinel error as an API design gap. External consumers (gRPC
-  orchestration, REST wrappers, CLI tooling) cannot programmatically match
-  the DPDK retirement reject without substring-searching the error text.
-  Adding `var ErrDPDKDataplaneRetired = errors.New(...)` and returning it
-  from validateDataplaneTypeStrict preserves the verbatim message contract
-  (existing tests still pass via strings.Contains) and adds programmatic
-  matching via errors.Is. Mirrors the runtime-side
-  dataplane.ErrDPDKBackendRetired sentinel introduced by #1527 / PR #1535.
-- **Validation**: TestDPDKConfigCompileRejects extended with errors.Is
-  assertion; full pkg/config + pkg/configstore suites green.
-- **Timestamp**: 2026-05-25T05:41:23Z
-  - **Action**: Review fix (#1529) — inline DPDK annotation pass on
-    `docs/feature-gaps.md`. The initial sweep used a blanket header
-    note to cover all table rows, but several "Done" status cells still
-    contained present-tense DPDK language that implies the backend is
-    an active target. Fixed inline: line 169 (Twice NAT — "across eBPF,
-    DPDK, and userspace"), line 173 (Port Randomization — "XDP and DPDK
-    SNAT allocators"), lines 203/205 (TCP No-SYN-Check / TCP RST —
-    "eBPF + DPDK"), line 315 (Dual Fabric — "DPDK still lacks...parity"),
-    line 326 (Policer), line 327 (Three-Color Policer), line 407 (system
-    caps listing "DPDK config"), line 442 (policer tier list), line 516
-    (policer section). No source code changed; pure doc fixes.
-  - **File(s)**: `docs/feature-gaps.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane/... -run 'TestRetirementBoundary|TestLegacyBPF' -count=1`
 - **Timestamp**: 2026-05-25T06:20Z
 - **Action**: Harmonize ErrDPDKBackendRetired + slog.Warn wording with config sentinel (AGY #1536 review finding)
 - **File(s)**: pkg/dataplane/dataplane.go, pkg/daemon/daemon_run.go

--- a/_Log.md
+++ b/_Log.md
@@ -764,13 +764,32 @@
     `DPDKDataplane` selector or helper pass-through at package
     scope is reported immediately instead of being skipped when
     no enclosing `FuncDecl` exists. Added
+- **Timestamp**: 2026-05-25T16:00:00Z
+  - **Action**: #1539 Copilot findings on PR #1553 — 5 valid
+    findings on HEAD 12237f12 addressed across two commits
+    (Copilot SWE bot fixed findings 1/5 + I rebased on top
+    with findings 2/3/4). (1+5) package-scope init bypass:
+    SelectorExpr and CallExpr branches treated `fn == nil`
+    as silent skip — `var leaked = cfg.System.DPDKDataplane`
+    at file scope escaped the canary; both fixed by treating
+    nil enclosing FuncDecl as an automatic finding with
+    distinct `package-scope read/passthrough of ...` why
+    text. New
     `TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer`
-    with a fixture covering both a package-scope read and a
-    package-scope helper pass-through. Updated the canary's file
-    contract comments to document that package scope is always
-    ungated.
+    exercises both kinds.
+    (2) RepoRoot inconsistency: `dpdkSubtreeLeakageCanaryRepoRoot
+    = ".."` then joined with "config" was confusing; replaced
+    with `dpdkSubtreeLeakageCanaryProductionScanRoot = "."`.
+    (3) Allowlist key drift: comment said "strip leading ../"
+    but code didn't. Replaced with proper `filepath.Rel(root,
+    path)` normalization so future allowlist keys are
+    package-relative regardless of walk root.
+    (4) Duplicate "Plan v1" header in reviewer-ids.md removed.
+    All 11 canary tests pass; 5x flake-clean; full pkg/config
+    suite green.
   - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
     _Log.md
+    docs/pr/1539-ast-leakage-guard/reviewer-ids.md, _Log.md
 - **Timestamp**: 2026-05-25T15:50:00Z
   - **Action**: #1539 code-review on PR #1553 + lint fix
     (commit 6a7d0649). Codex MERGE-READY directly on 8c5a4ced

--- a/_Log.md
+++ b/_Log.md
@@ -758,6 +758,19 @@
     PLAN-KILL grounds.
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
     `_Log.md`
+- **Timestamp**: 2026-05-25T15:15:18Z
+  - **Action**: #1539 Copilot follow-up on PR #1553. Tightened
+    `pkg/config/dpdk_subtree_leakage_canary_test.go` so a
+    `DPDKDataplane` selector or helper pass-through at package
+    scope is reported immediately instead of being skipped when
+    no enclosing `FuncDecl` exists. Added
+    `TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer`
+    with a fixture covering both a package-scope read and a
+    package-scope helper pass-through. Updated the canary's file
+    contract comments to document that package scope is always
+    ungated.
+  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
+    _Log.md
 - **Timestamp**: 2026-05-25T15:50:00Z
   - **Action**: #1539 code-review on PR #1553 + lint fix
     (commit 6a7d0649). Codex MERGE-READY directly on 8c5a4ced

--- a/_Log.md
+++ b/_Log.md
@@ -764,6 +764,24 @@
     `DPDKDataplane` selector or helper pass-through at package
     scope is reported immediately instead of being skipped when
     no enclosing `FuncDecl` exists. Added
+- **Timestamp**: 2026-05-25T16:25:00Z
+  - **Action**: #1539 Copilot round-3 finding addressed. After
+    HEAD f90125b3 + docs commit 4a1c8726, Copilot's re-review
+    re-anchored the original 4 findings to the new SHA (all
+    already addressed) but issued ONE new finding (15:22:25Z,
+    inline at line 112 of the new tree): the
+    `dpdkSubtreeLeakageCanaryExcludeDirs["dpdk"]` bare-dirname
+    skip would silently hide a future `pkg/config/dpdk/...`
+    sub-directory — exactly the leakage class the canary is
+    supposed to catch. Fixed: the exclusion map now uses
+    paths RELATIVE to the walk root (computed via `filepath.Rel`
+    + `filepath.ToSlash`), and the v3 default is empty since
+    the production scan root is `pkg/config/` only and there
+    is no `pkg/config/dpdk/` today. Future canary scope
+    extensions add explicit relative paths (e.g.
+    `pkg/dataplane/dpdk`).
+  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
+    _Log.md
 - **Timestamp**: 2026-05-25T16:00:00Z
   - **Action**: #1539 Copilot findings on PR #1553 — 5 valid
     findings on HEAD 12237f12 addressed across two commits

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,29 @@
 # Action Log
 
+## 2026-05-26
+
+- **Timestamp**: 2026-05-26T02:50:00Z
+  - **Action**: #1539 PR #1553 — rebased onto origin/master (5
+    PRs ahead, including #1556 multierror refactor). Conflict
+    on `_Log.md` resolved via /tmp/log-merge.py (union of HEAD
+    + incoming on each conflict region). Conflict on
+    `pkg/config/compiler.go` auto-resolved by git's 3-way merge;
+    semantically verified by inspection: Option A's nil clear at
+    L281-294 now sits AFTER (a) `validateDataplaneTypeStrict`
+    (fail-fast on retired DPDK) AND (b) the new `errors.Join`
+    multierror accumulator added by #1556, so it only runs on
+    the full success path. Codex round-5 MERGE-READY (session
+    019e5fa*), AGY round-5 adversarial-review-mpm18y6x-ii447j
+    MERGE-READY. Formal copilot-pull-request-reviewer re-ran on
+    new HEAD 4d24d592 and flagged 3 LOW-priority items: (a)
+    unused `dpdkSubtreeLeakageCanaryScanRoots` declaration —
+    removed; (b) redundant `if cfg != nil` guard around Option
+    A's nil clear (cfg is always non-nil in compileExpanded) —
+    guard removed, comment updated; (c) truncated _Log entry
+    at line 766 ending with bare "Added" — completed.
+  - **File(s)**: pkg/config/compiler.go,
+    pkg/config/dpdk_subtree_leakage_canary_test.go, _Log.md
+
 ## 2026-05-25
 
 - **Timestamp**: 2026-05-25T19:30:00Z
@@ -764,6 +788,15 @@
     `DPDKDataplane` selector or helper pass-through at package
     scope is reported immediately instead of being skipped when
     no enclosing `FuncDecl` exists. Added
+    `TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer`
+    with `negativePackageScopeInitializerFixture` covering both a
+    package-scope read and a package-scope helper pass-through.
+    Closing-sentence truncation flagged in a later Copilot pass
+    is restored here (the previous trailing "Added" was an
+    artifact of an over-aggressive _Log.md rebase-union helper).
+  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
+    _Log.md
+
 - **Timestamp**: 2026-05-25T16:25:00Z
   - **Action**: #1539 Copilot round-3 finding addressed. After
     HEAD f90125b3 + docs commit 4a1c8726, Copilot's re-review

--- a/docs/pr/1539-ast-leakage-guard/plan.md
+++ b/docs/pr/1539-ast-leakage-guard/plan.md
@@ -1,6 +1,8 @@
 # #1539 — Guard against AST leakage / shadow execution of retired DPDK sub-tree fields
 
-Status: DRAFT v2 — round-1 plan-review applied; pending round-2
+Status: PLAN-READY v3 — round-2 plan-review applied (Codex
+PLAN-MINOR + AGY PLAN-MINOR, both agree window-of-value KILL no
+longer operative; structural fixes folded in below).
 
 ## Round-1 plan-review summary
 
@@ -85,11 +87,13 @@ before #1528 lands.
   { case dataplaneTypeDPDK: ... }`.
 - `pkg/config/compiler.go:954-958` — `effectiveDataplaneType`
   canonical helper.
-- PR #1536 (`dpdk-retire/1526-reject`) adds
-  `validateDataplaneTypeStrict` at `pkg/config/compiler.go`.
-  **HARD PRECONDITION:** this PR must stack ATOP #1536.
-  Implementation will not merge until #1536 has merged into
-  master OR this PR rebases on top of the merged commit.
+- PR #1536 (`dpdk-retire/1526-reject`) added
+  `validateDataplaneTypeStrict` at `pkg/config/compiler.go:319` and
+  the call from `compileExpanded` at `pkg/config/compiler.go:241`.
+  **PR #1536 has MERGED into master at fcd53beb**, so the
+  precondition that prompted v1's stacking discipline is already
+  satisfied; this branch only needs to base on master at/after
+  fcd53beb.
 - `pkg/dataplane/retirement_boundary_canary_test.go` — 3442-line
   precedent for `go/parser` + `ast.Inspect` canaries. Note
   per Antigravity round-1: the precedent uses package-level
@@ -126,11 +130,11 @@ Specifically, right before `return cfg, nil` in the success
 path. If `compileExpanded` has multiple success-paths, the
 nil clear must precede ALL of them.
 
-**Why placement matters per Codex finding 3:** the strict
-validator on master today does NOT exist. Option A only makes
-sense AFTER `validateDataplaneTypeStrict` has run. The plan
-explicitly stacks atop #1536; the nil clear is placed in the
-same function and AFTER the same validator that #1536 added.
+**Why placement matters per Codex finding 3:** Option A only
+makes sense AFTER `validateDataplaneTypeStrict` has run. That
+validator is now on master at `pkg/config/compiler.go:319`,
+called from `compileExpanded` at line 241; the nil clear is
+placed in the same function and AFTER the same validator.
 
 **Edge case:** an internal compile path that bypasses
 `compileExpanded` and calls a lower helper directly would
@@ -159,11 +163,17 @@ Single new file: `pkg/config/dpdk_subtree_leakage_canary_test.go`.
      anchor (`// #1539 writer exception: typed-sub-tree
      population gated by switch effectiveDataplaneType`).
 
-2. **AST-structural gate recognition** (Codex finding 2):
+2. **AST-structural gate recognition** (Codex finding 2,
+   AGY round-2 HIGH + MEDIUM):
    - For each `SelectorExpr` of the form `<X>.DPDKDataplane`,
-     ascend to the nearest enclosing `*ast.IfStmt` OR
-     `*ast.SwitchStmt` (or `*ast.TypeSwitchStmt` — out of
-     scope, none today).
+     walk the parent-chain ALL THE WAY UP to the enclosing
+     `*ast.FuncDecl` (AGY round-2 MEDIUM). Accept the read iff
+     ANY ancestor `*ast.IfStmt` OR `*ast.SwitchStmt` is a valid
+     DPDK gate. Stopping at the "nearest" enclosing conditional
+     would false-positive on
+     `if effectiveDataplaneType(...) == dataplaneTypeDPDK { if x
+     { _ = sys.DPDKDataplane.Cores } }` where the inner `if x`
+     is the nearest but does not contain the gate.
    - For `IfStmt`: walk the `Cond` AST and require a
      `BinaryExpr{Op: ==, X: <call to effectiveDataplaneType>,
      Y: <Ident: dataplaneTypeDPDK> | <BasicLit: "dpdk">}` OR
@@ -172,19 +182,23 @@ Single new file: `pkg/config/dpdk_subtree_leakage_canary_test.go`.
    - For `SwitchStmt`: require the `Tag` to be a
      `CallExpr{Fun: effectiveDataplaneType, ...}`, then find
      the enclosing `*ast.CaseClause` of the selector and
-     require one of its `List` entries to be `dataplaneTypeDPDK`.
+     require BOTH (a) `len(CaseClause.List) == 1` AND (b) the
+     sole list entry is `dataplaneTypeDPDK` or `"dpdk"`. The
+     single-entry rule (AGY round-2 HIGH) blocks
+     `case dataplaneTypeDPDK, dataplaneTypeUserspace:`
+     which executes for userspace traffic but contains
+     `dataplaneTypeDPDK` in its list.
    - Reject the unsound recognizer that accepts
      `effectiveDataplaneType(...) == dataplaneTypeUserspace`
      followed by a DPDK read (Codex finding 2's counterexample).
-   - **Negation form:** `if effectiveDataplaneType(...) !=
-     dataplaneTypeDPDK { ... return ... }` followed by a
-     post-block read is also a valid gate. Implementation
-     detail: if the ascended IfStmt has body that ends in an
-     unconditional return/continue/break AND the read is
-     in the sibling/parent block, accept. Simpler v2 stance:
-     **do NOT support the early-return idiom in v2**; force
-     callers to use the positive `==` form OR fall through
-     to the allowlist. Document this as a known limitation.
+   - **Negation form is NOT a valid gate in v3.** A future
+     extension could accept
+     `if effectiveDataplaneType(...) != dataplaneTypeDPDK { return }`
+     followed by a post-block read, but the unconditional-exit
+     analysis adds AST surface for marginal value. Force callers
+     to use the positive `==` form OR `switch { case
+     dataplaneTypeDPDK: }`. Documented limitation; canary fires
+     on the negation idiom and the developer must convert.
 
 3. **Switch-statement support** (Codex finding 4, AGY finding 3):
    The writer's pattern at `compiler_system.go:228` IS the
@@ -197,16 +211,30 @@ Single new file: `pkg/config/dpdk_subtree_leakage_canary_test.go`.
 4. **Helper-function pass-through detection** (AGY finding 2):
    Additionally walk for `CallExpr` whose arg list contains
    a SelectorExpr matching `<X>.DPDKDataplane`. Apply the
-   same gate analysis to the call site. This catches:
+   same parent-chain gate analysis to the call site. This catches:
    ```go
    func useIt(d *DPDKConfig) { d.Cores }
    // ungated call site — canary fires:
    useIt(cfg.System.DPDKDataplane)
    ```
-   It does NOT catch the case where the pointer is
-   stored in a struct field and accessed later through that
-   field. Document this as a known limitation; mitigation
-   is Option A's nil guarantee.
+   It does NOT catch:
+   - Storage in a struct field then later access through that
+     field.
+   - Local-variable rebinding via assignment inside the gate
+     used outside the gate, e.g.:
+     ```go
+     var dpdkConf *DPDKConfig
+     if effectiveDataplaneType(...) == dataplaneTypeDPDK {
+         dpdkConf = cfg.System.DPDKDataplane // gated — canary
+                                              // passes
+     }
+     useIt(dpdkConf) // ungated use — canary cannot see
+     ```
+     (AGY round-2 LOW). Both are acceptable boundaries because
+     Option A's nil guarantee makes the intermediate
+     variable/field nil at runtime, so an ungated reader either
+     no-ops via `if d != nil { ... }` or panics safely rather
+     than executing shadow DPDK logic.
 
 5. **Empty allowlist by default** — `dpdkSubtreeReaderAllowlist`
    map is empty. The single in-package writer is recognized
@@ -236,6 +264,20 @@ the same pattern:
   Codex finding 2's counterexample: `if effectiveDataplaneType
   (...) == dataplaneTypeUserspace { _ = cfg.System.DPDKDataplane }`;
   assert canary fires.
+- `TestDPDKSubtreeLeakageCanary_NegativeRejectsSwitchMultipleCases`
+  (AGY round-2 HIGH) — fixture with
+  `switch effectiveDataplaneType(...) { case dataplaneTypeDPDK,
+  dataplaneTypeUserspace: _ = sys.DPDKDataplane.Cores }`;
+  assert canary fires.
+- `TestDPDKSubtreeLeakageCanary_PositiveAcceptsNestedGatedRead`
+  (AGY round-2 MEDIUM) — fixture with
+  `if effectiveDataplaneType(...) == dataplaneTypeDPDK { if x
+  { _ = sys.DPDKDataplane.Cores } }`; assert canary accepts.
+- `TestDPDKSubtreeLeakageCanary_NegativeRejectsNegationIdiom` —
+  fixture with `if effectiveDataplaneType(...) !=
+  dataplaneTypeDPDK { return }; _ = sys.DPDKDataplane.Cores`;
+  assert canary fires (we explicitly do not accept the
+  early-return negation form in v3).
 - `TestDPDKSubtreeLeakageCanary_RealRepoIsClean` — runs the
   walker against the real repo at `repoRoot = "../.."`; today
   asserts zero findings (writer is recognized; no other
@@ -355,8 +397,24 @@ Option B: zero API surface. New `*_test.go` file only.
    state cleared. Is the placement correct, or should it run
    even on validator failure (to harden against partial-state
    leakage in error paths)?
-7. **Stacking discipline.** v2 names #1536 as a hard
-   precondition. If #1536 is still iterating in review, we
-   either (a) wait, or (b) cherry-pick the validator into this
-   branch with a clear rebase commitment. Round-2 reviewer
-   preference?
+7. **Stacking discipline.** RESOLVED in v3 — PR #1536 merged at
+   fcd53beb on master. This branch rebases on master at/after
+   that commit; no special stacking required.
+
+## 11. Round-2 verdict summary (recorded for round-3 / merge)
+
+- Codex round-2: **PLAN-MINOR** — all four round-1 findings
+  materially addressed; stale #1536 process text and contradictory
+  negation-gate paragraph called out; window-of-value YES.
+- Antigravity round-2: **PLAN-MINOR** — KILL no longer
+  operative; HIGH (multi-case switch bypass), MEDIUM (nested
+  conditional false-positive) folded into section 4.2; LOW
+  (local-variable rebinding) documented in section 4.2 as a
+  bounded limitation mitigated by Option A.
+
+v3 changes from v2: section 4.2 walks parent-chain to FuncDecl;
+SwitchStmt CaseClause requires `len(List)==1`; negation idiom
+explicitly rejected (was contradictory in v2); two new fixtures
+(positive-nested, negative-multi-case, negative-negation);
+stale #1536 stacking and "validator on master today does NOT
+exist" wording corrected.

--- a/docs/pr/1539-ast-leakage-guard/plan.md
+++ b/docs/pr/1539-ast-leakage-guard/plan.md
@@ -1,0 +1,287 @@
+# #1539 — Guard against AST leakage / shadow execution of retired DPDK sub-tree fields
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## 1. Issue framing
+
+PR #1536 ("config: reject `system dataplane-type dpdk` at commit")
+adds `validateDataplaneTypeStrict` to `compileExpanded` in
+`pkg/config/compiler.go`. That validator hard-rejects
+`cfg.System.DataplaneType == "dpdk"` so an active config never
+carries the retired dataplane type.
+
+The parser, however, still accepts the full sub-tree under
+`system dataplane-type dpdk` (cores, memory, socket-mem, ports, etc.)
+so a pre-retirement config does not syntax-error on
+`load merge` / `load override` — only the compile step rejects it.
+Practically, the typed sub-tree `cfg.System.DPDKDataplane` is only
+populated when `effectiveDataplaneType(sys.DataplaneType) ==
+dataplaneTypeDPDK` (see `pkg/config/compiler_system.go:228-246`),
+and #1536's strict validator rejects exactly that case before
+the compiled config ever reaches a downstream consumer.
+
+So today, on a committed config:
+- `cfg.System.DataplaneType` is never `"dpdk"` (rejected by
+  `validateDataplaneTypeStrict`).
+- `cfg.System.DPDKDataplane` is therefore never populated
+  (the only writer is the `case dataplaneTypeDPDK` branch).
+
+Issue #1539 names the future risk: a developer adds a new strict
+validator for some DPDK sub-field, OR adds a backend hook that
+reads a DPDK sub-field, AND forgets to gate on
+`effectiveDataplaneType(...) == dpdk`. The unconditional read
+would then evaluate / instantiate DPDK-specific state on a
+userspace backend — "AST leakage" / "shadow execution".
+
+AGY's adversarial review of #1536 proposed two defenses:
+
+- **Option A** — at the end of `compileExpanded` (after
+  `validateDataplaneTypeStrict` has passed), explicitly clear
+  `cfg.System.DPDKDataplane = nil` so the structural invariant
+  "no `dataplane-type dpdk` ⇒ DPDK sub-fields are zeroed" is
+  guaranteed independent of compiler-system population logic.
+
+- **Option B** — add an invariant canary test that statically
+  walks the Go AST of every production package and asserts that
+  any read of `cfg.System.DPDKDataplane` (or a field on its
+  pointee) is dominated by an `effectiveDataplaneType(...) ==
+  dpdk` (or equivalent) gate.
+
+The issue recommends Option B as the long-term defense — Option
+A is only useful if some downstream code already reads DPDK
+sub-fields unconditionally (it does not, today).
+
+## 2. Honest scope/value framing
+
+This work has no runtime perf impact (Option B is a test-only
+addition; Option A is an O(1) nil assignment at config commit
+time). The value is purely **defense in depth against a future
+regression class**.
+
+Concrete pre-existing facts that bound the value:
+1. Across the entire repo, the only readers of
+   `cfg.System.DPDKDataplane` are inside `pkg/config/` itself
+   (the writer + tests). `grep -rn "DPDKDataplane" --include='*.go'
+   | grep -v "^pkg/config/"` returns zero matches.
+2. #1536 hard-rejects `dataplane-type == dpdk` at commit, so the
+   `case dataplaneTypeDPDK` writer at
+   `compiler_system.go:236-242` is unreachable on a committed
+   config today.
+3. #1525 Phase 3 (#1528) will delete `pkg/dataplane/dpdk/` and
+   the `DPDKConfig` schema fields entirely. After #1528 lands,
+   the canary becomes tautological — there is no struct to read.
+
+The window in which this canary provides real value is
+**between #1536 merge and #1528 merge** — the period when
+`DPDKConfig` still exists as a parsed schema but no production
+code should read it. Issue body explicitly frames this as the
+target window.
+
+**If reviewers conclude the perf gain is too small to justify
+the churn, PLAN-KILL is an acceptable verdict.** The
+counter-argument is "Option B costs ~150 lines of test code and
+catches a regression class that already bit #1536 conceptually."
+If a reviewer thinks #1528 lands soon enough that this is
+wasted work, that is a legitimate KILL.
+
+## 3. What is already shipped / partially overlapping
+
+- `pkg/config/compiler_system.go:228-246` — typed-sub-tree
+  population is already gated on `effectiveDataplaneType ==
+  dpdk`. The leakage risk requires a *new* unguarded reader.
+- `pkg/config/compiler.go:954-958` — `effectiveDataplaneType`
+  is the canonical normalization helper that empty-defaults to
+  `userspace`. Any gate must call this, not raw
+  `cfg.System.DataplaneType`.
+- `pkg/dataplane/retirement_boundary_canary_test.go` — 3442-line
+  precedent canary that uses `go/parser` + `ast.Inspect` to
+  walk production source. Same toolkit; same allowlist /
+  build-tag patterns.
+- PR #1536 itself adds `validateDataplaneTypeStrict`. This plan
+  assumes #1536 lands first; the canary references the typed
+  field name `cfg.System.DPDKDataplane`, which exists today
+  regardless of #1536's reject path.
+
+## 4. Concrete design
+
+### 4.1 Recommended path — Option B only
+
+Add a single test file:
+`pkg/config/dpdk_subtree_leakage_canary_test.go`.
+
+Structural shape (modelled on the precedent canary):
+
+```go
+package config
+
+import (
+    "go/ast"
+    "go/parser"
+    "go/token"
+    "path/filepath"
+    "strings"
+    "testing"
+)
+
+// dpdkSubtreeReaderAllowlist names production source files
+// (outside pkg/config/) that may legitimately reference
+// cfg.System.DPDKDataplane WITHOUT the canonical
+// effectiveDataplaneType()==dpdk gate. Empty after #1528 lands;
+// at plan-v1 time it is also empty.
+var dpdkSubtreeReaderAllowlist = map[string]string{}
+
+// gatePredicates is the set of expression shapes the canary
+// accepts as proof that a DPDKDataplane read is gated. We
+// match against the source text of the dominating if-statement
+// condition.
+var gatePredicates = []string{
+    "effectiveDataplaneType",
+    "EffectiveType",
+    "DataplaneType == dataplaneTypeDPDK",
+    "DataplaneType == \"dpdk\"",
+}
+
+func TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType(t *testing.T) {
+    // Walk every .go file in the repo (excluding _test.go,
+    // pkg/config/ itself, and pkg/dataplane/dpdk/) and
+    // collect SelectorExpr nodes whose RHS identifier is
+    // "DPDKDataplane".
+    //
+    // For each such node, ascend the AST to the nearest
+    // enclosing if-statement; assert its condition source
+    // text contains at least one gatePredicates entry.
+    //
+    // Failure mode: report file:line plus the bare selector,
+    // with a remediation hint pointing to
+    // effectiveDataplaneType().
+}
+```
+
+### 4.2 What gets excluded from the walk
+
+- `*_test.go` (tests legitimately probe DPDK fields).
+- `pkg/config/` itself (the writer at
+  `compiler_system.go:236-242` populates the field; the canary
+  would otherwise fire on its own writer).
+- `pkg/dataplane/dpdk/` — the retired in-tree backend that
+  reads its own sub-tree for compat until #1528 deletes it.
+- Anything with a `//go:build ignore` build tag.
+
+### 4.3 What the canary catches
+
+- A new file `pkg/foo/bar.go` that contains
+  `cfg.System.DPDKDataplane.Cores` without a dominating
+  `effectiveDataplaneType(cfg.System.DataplaneType) ==
+  dataplaneTypeDPDK` guard.
+- A range loop over `cfg.System.DPDKDataplane.Ports` outside
+  a gated branch.
+- A pointer-receiver method on a struct that stores
+  `DPDKDataplane *DPDKConfig` and dereferences it unconditionally.
+
+### 4.4 What the canary does NOT catch
+
+- Indirect reads via a wrapper helper that takes
+  `*DPDKConfig` directly. The canary only catches the
+  selector pattern `<X>.DPDKDataplane`. If a developer
+  passes `cfg.System.DPDKDataplane` (possibly nil) into a
+  helper that then reads `.Cores` unconditionally, the
+  helper-side dereference is invisible to the canary.
+  **Documented mitigation:** the SelectorExpr walk catches
+  the call-site `something(cfg.System.DPDKDataplane)`, so
+  the canary still fires at the boundary unless the call is
+  inside a gated branch.
+- Reflective access (`reflect.ValueOf(cfg).FieldByName(...)`).
+  Documented as out-of-scope; reflective access into config
+  is already a project-wide anti-pattern caught by other
+  canary tests.
+
+### 4.5 Why NOT Option A (or Option A in addition)
+
+Option A clears `cfg.System.DPDKDataplane = nil` at the end of
+`compileExpanded`. Pros: structural invariant. Cons:
+
+1. Today, the field is already only populated under the
+   `case dataplaneTypeDPDK` branch in `compiler_system.go:236`,
+   which is unreachable after #1536 hard-rejects that
+   `DataplaneType`. The clear is provably a no-op on
+   committed configs.
+2. It does NOT defend against the bug class the issue is
+   actually worried about — a future reader that *uses*
+   `cfg.System.DPDKDataplane` unconditionally would still
+   panic on `nil` dereference if the strict validator path
+   were ever bypassed (e.g., by a future code path that
+   compiles a candidate without going through
+   `compileExpanded`).
+3. After #1528 deletes `DPDKConfig`, Option A becomes a
+   delete-this-line followup; Option B becomes a delete-this-file
+   followup. Same churn either way.
+
+Option A is rejected as the primary defense. We MAY still want
+it as belt-and-braces (one-line nil assignment); decision
+deferred to round-2 plan review.
+
+## 5. Public API preservation
+
+This plan adds zero production code. The only diff is one new
+`*_test.go` file under `pkg/config/`. Public API is unchanged.
+
+If round-2 review insists on Option A, the change is a 3-line
+addition to `compileExpanded` clearing
+`cfg.System.DPDKDataplane = nil` after the strict validator
+passes. No API surface added; the field is already nil in the
+common path.
+
+## 6. Hidden invariants the canary must preserve
+
+1. **Existing precedent canary in `pkg/dataplane/`** uses
+   `go/parser` + `ast.Inspect`. Our new canary lives under
+   `pkg/config/`; it should follow the same structural pattern
+   (path constants, allowlist map, ascent-to-enclosing-if).
+2. **Build tags** — files under `//go:build ignore` (e.g.
+   `pkg/dataplane/loader_stub.go`) must be skipped. The
+   precedent canary excludes them via path; we will do the
+   same.
+3. **Generated files** — `bpf2go`-generated `*_bpfel.go` files
+   live under `pkg/dataplane/` not `pkg/config/`; they do not
+   reference `DPDKDataplane`. No special handling needed, but
+   the walk's exclusion list documents this.
+4. **`go list` vs direct filepath walk** — the precedent
+   canary walks the filesystem directly with `filepath.Walk`
+   relative to a `repoRootForBoundaryCanary = "../.."` constant.
+   We will do the same with
+   `repoRootForDPDKLeakageCanary = "../.."`.
+
+## 7. Risk assessment
+
+| Class | Level | Justification |
+|---|---|---|
+| Behavioral regression | LOW | Test-only addition. No production code path changed. |
+| Lifetime / borrow-checker | N/A | Go, no Rust changes. |
+| Performance regression | LOW | Canary runs at `go test` time only. |
+| Architectural mismatch (#946-Phase-2 / #961 pattern) | MEDIUM | If #1528 deletes `DPDKConfig` within weeks, this canary becomes tautological — the work is wasted. KILL is appropriate if reviewers think the window is too small. |
+| False positives | MEDIUM | The "dominating if-statement" heuristic can miss switch-statements and ternary-equivalent assignments. Mitigated by a clear remediation message and an allowlist for any legitimate cross-package reader. |
+
+## 8. Test plan
+
+- `go test ./pkg/config/ -run TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType` — passes against current master.
+- `go test ./pkg/config/ -run TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType -count=5` — 5× flake check.
+- `go test ./...` — full Go suite (30 packages), no regression.
+- Negative fixture: introduce a temporary `pkg/config/canary_fixture_test.go`-style file (build-tag-gated `//go:build ignore`) that has an ungated read, prove the canary fires on it. **Do not commit the fixture**; round-2 may ask to commit it as a `//go:build canaryselftest` file.
+- Smoke matrix on the loss userspace cluster is OPTIONAL because no runtime code changes — but we will still run a single v4 + v6 push + reverse pair to confirm `cluster-deploy` does not regress on the head SHA. No per-class CoS sweep needed; this is a pure-test PR.
+
+## 9. Out of scope (explicit)
+
+- **Option A (sub-tree clear at commit)** — deferred to a round-2 decision. Default is Option B only.
+- **Static analysis of helper functions taking `*DPDKConfig` directly** — the canary only walks selector expressions of the form `<X>.DPDKDataplane`. Indirect access through a helper that accepts `*DPDKConfig` is documented as out-of-scope.
+- **Reflective access (`reflect.ValueOf(...).FieldByName(...)`)** — out-of-scope; covered by other repo-wide reflective-access canaries.
+- **Deleting `DPDKConfig` itself** — that's #1528 / Phase 3 work. This canary is the bridge between #1536 (reject) and #1528 (delete).
+- **Adding the same canary for `UserspaceDataplane`** — `UserspaceDataplane` is the *active* sub-tree, not retired, so the inverse invariant ("only read when effectiveType == userspace") is the normal happy path. Out of scope; a separate issue if anyone cares.
+
+## 10. Open questions for adversarial review
+
+1. **Window value** — Is the (#1536-merge → #1528-merge) window long enough to justify a 100-200 line test? If #1528 is already in flight, PLAN-KILL is appropriate.
+2. **Option A vs Option B** — Is Option A's one-line clear enough actual defense to NOT bother with Option B? Or are both worth shipping together?
+3. **Indirect access** — How much do reviewers care about the helper-function escape hatch (caller passes `cfg.System.DPDKDataplane` to a function that derefs it)? If this is the realistic future regression vector, Option B is incomplete and we need a stricter type wrapper.
+4. **`switch effectiveDataplaneType(...)` pattern recognition** — The canary's "dominating if-statement" heuristic does not natively understand `switch` statements. The existing writer at `compiler_system.go:228-246` uses a `switch` and would be excluded by the pkg/config/ exclusion, but a future cross-package reader could also use `switch`. Should the canary recognize `case dataplaneTypeDPDK:` inside a switch as a valid gate?
+5. **Should the canary live in `pkg/config/` or `pkg/dataplane/`?** — The precedent is in `pkg/dataplane/`. But this canary asserts a property of the `*Config` typed schema; `pkg/config/` is more natural. Either is defensible; calling it out for reviewer input.
+6. **Self-test fixture commit** — Should we commit a `//go:build canaryselftest` negative fixture that proves the canary actually rejects an ungated read? Or is the inline test enough?

--- a/docs/pr/1539-ast-leakage-guard/plan.md
+++ b/docs/pr/1539-ast-leakage-guard/plan.md
@@ -1,287 +1,362 @@
 # #1539 — Guard against AST leakage / shadow execution of retired DPDK sub-tree fields
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: DRAFT v2 — round-1 plan-review applied; pending round-2
 
-## 1. Issue framing
+## Round-1 plan-review summary
 
-PR #1536 ("config: reject `system dataplane-type dpdk` at commit")
-adds `validateDataplaneTypeStrict` to `compileExpanded` in
-`pkg/config/compiler.go`. That validator hard-rejects
-`cfg.System.DataplaneType == "dpdk"` so an active config never
-carries the retired dataplane type.
+- **Codex (task-mpku5dam-crjpoi):** PLAN-NEEDS-MAJOR. Canary
+  excludes `pkg/config/` (which is exactly where a future strict
+  validator would land); substring-based gate recognizer is
+  unsound; switch-statement blind spot becomes structural once
+  `pkg/config/` is included; plan must state hard precondition
+  that #1536 is merged first. Recommends shipping Option A
+  alongside a corrected canary.
+- **Antigravity (adversarial-review-mpku5cqj-z1v7o3):** PLAN-KILL
+  on Option B alone, recommends Option A as the correct defense:
+  the bug class is *shadow execution* of DPDK logic on a userspace
+  backend; if `cfg.System.DPDKDataplane` is guaranteed nil after
+  the strict validator passes, the standard `if d != nil { ... }`
+  guard pattern at any future reader cleanly skips the shadow
+  block at runtime regardless of whether the reader gates on
+  `effectiveDataplaneType`. Helper-function escape hatch makes
+  Option B's call-site analysis incomplete; switch-statement
+  blind spot forces unidiomatic if-chains.
 
-The parser, however, still accepts the full sub-tree under
-`system dataplane-type dpdk` (cores, memory, socket-mem, ports, etc.)
-so a pre-retirement config does not syntax-error on
-`load merge` / `load override` — only the compile step rejects it.
-Practically, the typed sub-tree `cfg.System.DPDKDataplane` is only
-populated when `effectiveDataplaneType(sys.DataplaneType) ==
-dataplaneTypeDPDK` (see `pkg/config/compiler_system.go:228-246`),
-and #1536's strict validator rejects exactly that case before
-the compiled config ever reaches a downstream consumer.
+**Synthesis adopted in v2:** ship BOTH Option A (primary defense)
+AND a Codex-corrected canary (defense in depth). Option A
+addresses Antigravity's runtime-safety argument; the corrected
+canary addresses Codex's compile-time invariant argument and
+catches the helper-function escape hatch by analyzing the
+production-source call sites where the field is read OR passed.
 
-So today, on a committed config:
-- `cfg.System.DataplaneType` is never `"dpdk"` (rejected by
-  `validateDataplaneTypeStrict`).
-- `cfg.System.DPDKDataplane` is therefore never populated
-  (the only writer is the `case dataplaneTypeDPDK` branch).
+## 1. Issue framing (unchanged)
 
-Issue #1539 names the future risk: a developer adds a new strict
-validator for some DPDK sub-field, OR adds a backend hook that
-reads a DPDK sub-field, AND forgets to gate on
+PR #1536 adds `validateDataplaneTypeStrict` to `compileExpanded`
+that hard-rejects `cfg.System.DataplaneType == "dpdk"`. The
+parser still accepts the full `system dataplane-type dpdk`
+sub-tree so a pre-retirement config does not syntax-error on
+`load merge`. Typed sub-tree `cfg.System.DPDKDataplane` is only
+populated when `effectiveDataplaneType(...) == dpdk` (see
+`pkg/config/compiler_system.go:228-246`), which post-#1536 is
+unreachable on a committed config.
+
+Issue #1539 names the future risk: a developer adds a new
+strict validator for some DPDK sub-field, OR a backend hook
+that reads a DPDK sub-field, AND forgets to gate on
 `effectiveDataplaneType(...) == dpdk`. The unconditional read
-would then evaluate / instantiate DPDK-specific state on a
-userspace backend — "AST leakage" / "shadow execution".
-
-AGY's adversarial review of #1536 proposed two defenses:
-
-- **Option A** — at the end of `compileExpanded` (after
-  `validateDataplaneTypeStrict` has passed), explicitly clear
-  `cfg.System.DPDKDataplane = nil` so the structural invariant
-  "no `dataplane-type dpdk` ⇒ DPDK sub-fields are zeroed" is
-  guaranteed independent of compiler-system population logic.
-
-- **Option B** — add an invariant canary test that statically
-  walks the Go AST of every production package and asserts that
-  any read of `cfg.System.DPDKDataplane` (or a field on its
-  pointee) is dominated by an `effectiveDataplaneType(...) ==
-  dpdk` (or equivalent) gate.
-
-The issue recommends Option B as the long-term defense — Option
-A is only useful if some downstream code already reads DPDK
-sub-fields unconditionally (it does not, today).
+would then evaluate DPDK-specific state on a userspace backend
+— "AST leakage" / "shadow execution".
 
 ## 2. Honest scope/value framing
 
-This work has no runtime perf impact (Option B is a test-only
-addition; Option A is an O(1) nil assignment at config commit
-time). The value is purely **defense in depth against a future
-regression class**.
+This work has no runtime perf impact. Option A is a one-line
+nil assignment in the commit path. Option B is a test-only
+addition (~200 LOC including self-test fixtures).
 
-Concrete pre-existing facts that bound the value:
-1. Across the entire repo, the only readers of
-   `cfg.System.DPDKDataplane` are inside `pkg/config/` itself
-   (the writer + tests). `grep -rn "DPDKDataplane" --include='*.go'
-   | grep -v "^pkg/config/"` returns zero matches.
-2. #1536 hard-rejects `dataplane-type == dpdk` at commit, so the
-   `case dataplaneTypeDPDK` writer at
-   `compiler_system.go:236-242` is unreachable on a committed
-   config today.
-3. #1525 Phase 3 (#1528) will delete `pkg/dataplane/dpdk/` and
-   the `DPDKConfig` schema fields entirely. After #1528 lands,
-   the canary becomes tautological — there is no struct to read.
+Concrete bounds on the value:
+1. Today there are ZERO cross-package readers of
+   `cfg.System.DPDKDataplane`. `grep -rn "DPDKDataplane"
+   --include='*.go' | grep -v "^pkg/config/" | grep -v _test.go`
+   returns empty.
+2. #1527 (Phase 2, boot decoupling) has already merged into
+   master at commit `541b3ea1`.
+3. #1528 (Phase 3) is an OPEN issue with no PR yet; its
+   acceptance criteria include deleting `DPDKConfig`,
+   `DPDKAdaptiveConfig`, `DPDKPort`, and the `DPDKDataplane`
+   field on `SystemConfig`. After #1528 lands, the canary
+   becomes tautological (no symbol to read) AND Option A
+   becomes dead-code-deletion (no field to nil).
 
-The window in which this canary provides real value is
-**between #1536 merge and #1528 merge** — the period when
-`DPDKConfig` still exists as a parsed schema but no production
-code should read it. Issue body explicitly frames this as the
-target window.
+The window of value is **(#1536 merge → #1528 merge)**.
 
-**If reviewers conclude the perf gain is too small to justify
-the churn, PLAN-KILL is an acceptable verdict.** The
-counter-argument is "Option B costs ~150 lines of test code and
-catches a regression class that already bit #1536 conceptually."
-If a reviewer thinks #1528 lands soon enough that this is
-wasted work, that is a legitimate KILL.
+**Round-2 reviewers: if you conclude that #1528 is close
+enough to landing that this defense is wasted work, PLAN-KILL
+is still on the table.** Antigravity already cast a KILL on
+those grounds in round-1. The argument FOR shipping anyway:
+(a) #1528 is unscheduled and has no draft PR, (b) Option A is
+literally one line of production code, (c) the canary catches
+new code that lands in the window between #1536 and #1528
+before #1528 lands.
 
 ## 3. What is already shipped / partially overlapping
 
-- `pkg/config/compiler_system.go:228-246` — typed-sub-tree
-  population is already gated on `effectiveDataplaneType ==
-  dpdk`. The leakage risk requires a *new* unguarded reader.
+- `pkg/config/compiler_system.go:228-246` — typed sub-tree
+  population gated on `switch effectiveDataplaneType(...)
+  { case dataplaneTypeDPDK: ... }`.
 - `pkg/config/compiler.go:954-958` — `effectiveDataplaneType`
-  is the canonical normalization helper that empty-defaults to
-  `userspace`. Any gate must call this, not raw
-  `cfg.System.DataplaneType`.
+  canonical helper.
+- PR #1536 (`dpdk-retire/1526-reject`) adds
+  `validateDataplaneTypeStrict` at `pkg/config/compiler.go`.
+  **HARD PRECONDITION:** this PR must stack ATOP #1536.
+  Implementation will not merge until #1536 has merged into
+  master OR this PR rebases on top of the merged commit.
 - `pkg/dataplane/retirement_boundary_canary_test.go` — 3442-line
-  precedent canary that uses `go/parser` + `ast.Inspect` to
-  walk production source. Same toolkit; same allowlist /
-  build-tag patterns.
-- PR #1536 itself adds `validateDataplaneTypeStrict`. This plan
-  assumes #1536 lands first; the canary references the typed
-  field name `cfg.System.DPDKDataplane`, which exists today
-  regardless of #1536's reject path.
+  precedent for `go/parser` + `ast.Inspect` canaries. Note
+  per Antigravity round-1: the precedent uses package-level
+  symbol/import scans (`parser.ImportsOnly` style), NOT
+  control-flow domination. This canary is structurally more
+  complex than the precedent.
 
-## 4. Concrete design
+## 4. Concrete design — Option A + Option B together
 
-### 4.1 Recommended path — Option B only
+### 4.1 Option A — one-line structural invariant in compileExpanded
 
-Add a single test file:
-`pkg/config/dpdk_subtree_leakage_canary_test.go`.
-
-Structural shape (modelled on the precedent canary):
+After `validateDataplaneTypeStrict(cfg)` returns nil (i.e., the
+config is NOT retired-DPDK) and at the end of `compileExpanded`,
+add:
 
 ```go
-package config
-
-import (
-    "go/ast"
-    "go/parser"
-    "go/token"
-    "path/filepath"
-    "strings"
-    "testing"
-)
-
-// dpdkSubtreeReaderAllowlist names production source files
-// (outside pkg/config/) that may legitimately reference
-// cfg.System.DPDKDataplane WITHOUT the canonical
-// effectiveDataplaneType()==dpdk gate. Empty after #1528 lands;
-// at plan-v1 time it is also empty.
-var dpdkSubtreeReaderAllowlist = map[string]string{}
-
-// gatePredicates is the set of expression shapes the canary
-// accepts as proof that a DPDKDataplane read is gated. We
-// match against the source text of the dominating if-statement
-// condition.
-var gatePredicates = []string{
-    "effectiveDataplaneType",
-    "EffectiveType",
-    "DataplaneType == dataplaneTypeDPDK",
-    "DataplaneType == \"dpdk\"",
-}
-
-func TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType(t *testing.T) {
-    // Walk every .go file in the repo (excluding _test.go,
-    // pkg/config/ itself, and pkg/dataplane/dpdk/) and
-    // collect SelectorExpr nodes whose RHS identifier is
-    // "DPDKDataplane".
-    //
-    // For each such node, ascend the AST to the nearest
-    // enclosing if-statement; assert its condition source
-    // text contains at least one gatePredicates entry.
-    //
-    // Failure mode: report file:line plus the bare selector,
-    // with a remediation hint pointing to
-    // effectiveDataplaneType().
-}
+// #1539: explicit structural invariant — after the strict
+// validator rejects retired backends, no committed config
+// retains DPDK sub-tree state. This nil makes "no
+// dataplane-type dpdk" mean "DPDK sub-fields are zeroed" at
+// the type-system level so any future helper of the form
+//   if cfg.System.DPDKDataplane != nil { ... use it ... }
+// is statically dead on every committed config without
+// requiring the helper to gate on effectiveDataplaneType.
+//
+// This is dead code after #1528 (Phase 3) deletes the
+// DPDKDataplane field entirely; remove this line in #1528.
+cfg.System.DPDKDataplane = nil
 ```
 
-### 4.2 What gets excluded from the walk
+**Placement:** end of `compileExpanded`, after every error
+return path has run including `validateDataplaneTypeStrict`.
+Specifically, right before `return cfg, nil` in the success
+path. If `compileExpanded` has multiple success-paths, the
+nil clear must precede ALL of them.
 
-- `*_test.go` (tests legitimately probe DPDK fields).
-- `pkg/config/` itself (the writer at
-  `compiler_system.go:236-242` populates the field; the canary
-  would otherwise fire on its own writer).
-- `pkg/dataplane/dpdk/` — the retired in-tree backend that
-  reads its own sub-tree for compat until #1528 deletes it.
-- Anything with a `//go:build ignore` build tag.
+**Why placement matters per Codex finding 3:** the strict
+validator on master today does NOT exist. Option A only makes
+sense AFTER `validateDataplaneTypeStrict` has run. The plan
+explicitly stacks atop #1536; the nil clear is placed in the
+same function and AFTER the same validator that #1536 added.
 
-### 4.3 What the canary catches
+**Edge case:** an internal compile path that bypasses
+`compileExpanded` and calls a lower helper directly would
+skip both the validator and the nil clear. Audit:
+`grep -n "compileExpanded\|compileSystemConfig" pkg/config/`
+shows `compileExpanded` is the sole entry point used by
+`CompileConfig` and `CompileConfigForNode`. No bypass path
+exists today; if a future commit introduces one, it must
+also call the validator + nil clear (a canary item below
+asserts this).
 
-- A new file `pkg/foo/bar.go` that contains
-  `cfg.System.DPDKDataplane.Cores` without a dominating
-  `effectiveDataplaneType(cfg.System.DataplaneType) ==
-  dataplaneTypeDPDK` guard.
-- A range loop over `cfg.System.DPDKDataplane.Ports` outside
-  a gated branch.
-- A pointer-receiver method on a struct that stores
-  `DPDKDataplane *DPDKConfig` and dereferences it unconditionally.
+### 4.2 Option B — corrected canary test
 
-### 4.4 What the canary does NOT catch
+Single new file: `pkg/config/dpdk_subtree_leakage_canary_test.go`.
 
-- Indirect reads via a wrapper helper that takes
-  `*DPDKConfig` directly. The canary only catches the
-  selector pattern `<X>.DPDKDataplane`. If a developer
-  passes `cfg.System.DPDKDataplane` (possibly nil) into a
-  helper that then reads `.Cores` unconditionally, the
-  helper-side dereference is invisible to the canary.
-  **Documented mitigation:** the SelectorExpr walk catches
-  the call-site `something(cfg.System.DPDKDataplane)`, so
-  the canary still fires at the boundary unless the call is
-  inside a gated branch.
-- Reflective access (`reflect.ValueOf(cfg).FieldByName(...)`).
-  Documented as out-of-scope; reflective access into config
-  is already a project-wide anti-pattern caught by other
-  canary tests.
+**Structural improvements over v1, per Codex findings 1, 2, 4:**
 
-### 4.5 Why NOT Option A (or Option A in addition)
+1. **Scan `pkg/config/` production source TOO** (Codex finding 1).
+   Walk excludes:
+   - `*_test.go`
+   - Files under `pkg/dataplane/dpdk/` (retired backend reads
+     its own sub-tree)
+   - Files with `//go:build ignore`
+   - The single writer at `pkg/config/compiler_system.go`
+     line range 228-246 — narrowly allowlisted with a comment
+     anchor (`// #1539 writer exception: typed-sub-tree
+     population gated by switch effectiveDataplaneType`).
 
-Option A clears `cfg.System.DPDKDataplane = nil` at the end of
-`compileExpanded`. Pros: structural invariant. Cons:
+2. **AST-structural gate recognition** (Codex finding 2):
+   - For each `SelectorExpr` of the form `<X>.DPDKDataplane`,
+     ascend to the nearest enclosing `*ast.IfStmt` OR
+     `*ast.SwitchStmt` (or `*ast.TypeSwitchStmt` — out of
+     scope, none today).
+   - For `IfStmt`: walk the `Cond` AST and require a
+     `BinaryExpr{Op: ==, X: <call to effectiveDataplaneType>,
+     Y: <Ident: dataplaneTypeDPDK> | <BasicLit: "dpdk">}` OR
+     the reverse operand order. Substring matching is
+     forbidden.
+   - For `SwitchStmt`: require the `Tag` to be a
+     `CallExpr{Fun: effectiveDataplaneType, ...}`, then find
+     the enclosing `*ast.CaseClause` of the selector and
+     require one of its `List` entries to be `dataplaneTypeDPDK`.
+   - Reject the unsound recognizer that accepts
+     `effectiveDataplaneType(...) == dataplaneTypeUserspace`
+     followed by a DPDK read (Codex finding 2's counterexample).
+   - **Negation form:** `if effectiveDataplaneType(...) !=
+     dataplaneTypeDPDK { ... return ... }` followed by a
+     post-block read is also a valid gate. Implementation
+     detail: if the ascended IfStmt has body that ends in an
+     unconditional return/continue/break AND the read is
+     in the sibling/parent block, accept. Simpler v2 stance:
+     **do NOT support the early-return idiom in v2**; force
+     callers to use the positive `==` form OR fall through
+     to the allowlist. Document this as a known limitation.
 
-1. Today, the field is already only populated under the
-   `case dataplaneTypeDPDK` branch in `compiler_system.go:236`,
-   which is unreachable after #1536 hard-rejects that
-   `DataplaneType`. The clear is provably a no-op on
-   committed configs.
-2. It does NOT defend against the bug class the issue is
-   actually worried about — a future reader that *uses*
-   `cfg.System.DPDKDataplane` unconditionally would still
-   panic on `nil` dereference if the strict validator path
-   were ever bypassed (e.g., by a future code path that
-   compiles a candidate without going through
-   `compileExpanded`).
-3. After #1528 deletes `DPDKConfig`, Option A becomes a
-   delete-this-line followup; Option B becomes a delete-this-file
-   followup. Same churn either way.
+3. **Switch-statement support** (Codex finding 4, AGY finding 3):
+   The writer's pattern at `compiler_system.go:228` IS the
+   recommended idiom. Canary must accept it. Implementation:
+   walk parent chain; if the nearest enclosing block is a
+   `*ast.CaseClause` and the `*ast.SwitchStmt` parent's `Tag`
+   is `effectiveDataplaneType(...)`, accept iff the case
+   clause's `List` contains `dataplaneTypeDPDK`.
 
-Option A is rejected as the primary defense. We MAY still want
-it as belt-and-braces (one-line nil assignment); decision
-deferred to round-2 plan review.
+4. **Helper-function pass-through detection** (AGY finding 2):
+   Additionally walk for `CallExpr` whose arg list contains
+   a SelectorExpr matching `<X>.DPDKDataplane`. Apply the
+   same gate analysis to the call site. This catches:
+   ```go
+   func useIt(d *DPDKConfig) { d.Cores }
+   // ungated call site — canary fires:
+   useIt(cfg.System.DPDKDataplane)
+   ```
+   It does NOT catch the case where the pointer is
+   stored in a struct field and accessed later through that
+   field. Document this as a known limitation; mitigation
+   is Option A's nil guarantee.
+
+5. **Empty allowlist by default** — `dpdkSubtreeReaderAllowlist`
+   map is empty. The single in-package writer is recognized
+   structurally (its switch is the canonical gate), not via
+   allowlist.
+
+### 4.3 Self-test fixtures (committed)
+
+Per Codex finding: a committed inline negative self-test is
+mandatory. The precedent canary uses temp fixtures written to
+disk during the test then walked
+(`retirement_boundary_canary_test.go:1377`, `:2607`). We follow
+the same pattern:
+
+- `TestDPDKSubtreeLeakageCanary_PositiveAcceptsGatedReads` —
+  hand-rolled fixture string with `effectiveDataplaneType(...)
+  == dataplaneTypeDPDK` if-gate and `switch effectiveDataplaneType
+  { case dataplaneTypeDPDK: }`; write to `t.TempDir()`, walk
+  it, assert canary returns no findings.
+- `TestDPDKSubtreeLeakageCanary_NegativeRejectsUngatedRead` —
+  fixture with bare `_ = cfg.System.DPDKDataplane.Cores`;
+  assert canary fires with the expected file:line.
+- `TestDPDKSubtreeLeakageCanary_NegativeRejectsHelperPassthrough` —
+  fixture with `useIt(cfg.System.DPDKDataplane)` at ungated
+  call site; assert canary fires.
+- `TestDPDKSubtreeLeakageCanary_NegativeRejectsWrongTypeBranch` —
+  Codex finding 2's counterexample: `if effectiveDataplaneType
+  (...) == dataplaneTypeUserspace { _ = cfg.System.DPDKDataplane }`;
+  assert canary fires.
+- `TestDPDKSubtreeLeakageCanary_RealRepoIsClean` — runs the
+  walker against the real repo at `repoRoot = "../.."`; today
+  asserts zero findings (writer is recognized; no other
+  references exist).
 
 ## 5. Public API preservation
 
-This plan adds zero production code. The only diff is one new
-`*_test.go` file under `pkg/config/`. Public API is unchanged.
+Option A: zero API surface. The field already accepted nil; we
+just nil it explicitly.
 
-If round-2 review insists on Option A, the change is a 3-line
-addition to `compileExpanded` clearing
-`cfg.System.DPDKDataplane = nil` after the strict validator
-passes. No API surface added; the field is already nil in the
-common path.
+Option B: zero API surface. New `*_test.go` file only.
 
-## 6. Hidden invariants the canary must preserve
+## 6. Hidden invariants the change must preserve
 
-1. **Existing precedent canary in `pkg/dataplane/`** uses
-   `go/parser` + `ast.Inspect`. Our new canary lives under
-   `pkg/config/`; it should follow the same structural pattern
-   (path constants, allowlist map, ascent-to-enclosing-if).
-2. **Build tags** — files under `//go:build ignore` (e.g.
-   `pkg/dataplane/loader_stub.go`) must be skipped. The
-   precedent canary excludes them via path; we will do the
-   same.
-3. **Generated files** — `bpf2go`-generated `*_bpfel.go` files
-   live under `pkg/dataplane/` not `pkg/config/`; they do not
-   reference `DPDKDataplane`. No special handling needed, but
-   the walk's exclusion list documents this.
-4. **`go list` vs direct filepath walk** — the precedent
-   canary walks the filesystem directly with `filepath.Walk`
-   relative to a `repoRootForBoundaryCanary = "../.."` constant.
-   We will do the same with
-   `repoRootForDPDKLeakageCanary = "../.."`.
+1. **`compileExpanded` is the sole entry point** to a committed
+   config. Audit confirmed (`CompileConfig`,
+   `CompileConfigForNode`); if a future PR adds a bypass, the
+   nil clear must also be added there. Optional: add a tiny
+   canary item `TestCompileConfigEntryPointsClearDPDKSubtree`
+   that scans for top-level functions returning `*Config`
+   from `pkg/config/` and asserts each ends in either a call
+   to `compileExpanded` OR an explicit `DPDKDataplane = nil`.
+   **Round-2 reviewers: decide whether this extra canary is
+   worth the additional test surface.**
+2. **Stacking discipline** (Codex finding 3): this PR must
+   rebase atop the merged #1536 commit. Implementation
+   commits in this branch must not merge until #1536 has
+   merged. The plan doc states this; CI is not enforcing it.
+3. **#1528 dead-code window** — both Option A's nil clear and
+   Option B's canary become dead code after #1528 lands.
+   #1528's acceptance criteria already list deleting
+   `DPDKConfig`; we add a TODO comment near both pointing at
+   "#1528 removes this."
+4. **Generated files / build tags** — `bpf2go`-generated files
+   live in `pkg/dataplane/`, do not reference `DPDKDataplane`,
+   not in scope.
+5. **No `reflect.ValueOf(cfg).FieldByName("DPDKDataplane")` access** — out of scope; reflective config access is an
+   anti-pattern not addressed here.
 
 ## 7. Risk assessment
 
 | Class | Level | Justification |
 |---|---|---|
-| Behavioral regression | LOW | Test-only addition. No production code path changed. |
-| Lifetime / borrow-checker | N/A | Go, no Rust changes. |
-| Performance regression | LOW | Canary runs at `go test` time only. |
-| Architectural mismatch (#946-Phase-2 / #961 pattern) | MEDIUM | If #1528 deletes `DPDKConfig` within weeks, this canary becomes tautological — the work is wasted. KILL is appropriate if reviewers think the window is too small. |
-| False positives | MEDIUM | The "dominating if-statement" heuristic can miss switch-statements and ternary-equivalent assignments. Mitigated by a clear remediation message and an allowlist for any legitimate cross-package reader. |
+| Behavioral regression (Option A) | LOW | One-line nil clear at end of `compileExpanded`. The field is already nil in the common path post-#1536; this just makes it structurally guaranteed. |
+| Behavioral regression (Option B) | NONE | Test-only. |
+| Lifetime / borrow-checker | N/A | Go. |
+| Performance regression | LOW | Canary runs at `go test` only. Option A is one pointer assignment per Commit() call. |
+| Architectural mismatch (#946 / #961 pattern) | LOW-MEDIUM | The risk Antigravity flagged in round-1 (#1528 makes the work tautological) is real but bounded. Antigravity round-2 may still PLAN-KILL on the window value alone — that is a legitimate outcome. |
+| False positives (canary) | LOW | AST-structural recognition (not substring); writer accepted via structural recognition (not allowlist); committed self-test fixtures lock the recognition logic. |
+| Switch-statement blind spot | RESOLVED | v2 design explicitly handles `*ast.SwitchStmt` parent chain with `Tag` matching `effectiveDataplaneType(...)` and `CaseClause.List` containing `dataplaneTypeDPDK`. |
+| Helper-function escape hatch | PARTIALLY RESOLVED | v2 catches `CallExpr` whose arg is `<X>.DPDKDataplane`. Does NOT catch storage-then-access through an intermediate field. Mitigation: Option A guarantees nil so the intermediate field is also nil at runtime. |
 
 ## 8. Test plan
 
-- `go test ./pkg/config/ -run TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType` — passes against current master.
-- `go test ./pkg/config/ -run TestDPDKSubtreeReadsAreGatedOnEffectiveDataplaneType -count=5` — 5× flake check.
+- `go test ./pkg/config/` — full package suite passes.
+- `go test ./pkg/config/ -run TestDPDKSubtreeLeakageCanary
+  -count=5` — 5× flake-clean on the named test suite.
 - `go test ./...` — full Go suite (30 packages), no regression.
-- Negative fixture: introduce a temporary `pkg/config/canary_fixture_test.go`-style file (build-tag-gated `//go:build ignore`) that has an ungated read, prove the canary fires on it. **Do not commit the fixture**; round-2 may ask to commit it as a `//go:build canaryselftest` file.
-- Smoke matrix on the loss userspace cluster is OPTIONAL because no runtime code changes — but we will still run a single v4 + v6 push + reverse pair to confirm `cluster-deploy` does not regress on the head SHA. No per-class CoS sweep needed; this is a pure-test PR.
+- Negative-fixture sub-tests assert the canary fires on each
+  of the four documented escape paths (ungated read, helper
+  pass-through, wrong-type branch, switch with wrong case).
+- Smoke matrix on the loss userspace cluster — SKIPPED for
+  this PR because it has zero runtime impact. Justification:
+  Option A is a nil clear in the commit path that runs once
+  per `Store.Commit`; Option B is test-only. Round-2 reviewers
+  may demand at least a v4+v6 push/reverse single-stream
+  sanity check to confirm `cluster-deploy` does not regress
+  with the head SHA; we will run it on request.
 
 ## 9. Out of scope (explicit)
 
-- **Option A (sub-tree clear at commit)** — deferred to a round-2 decision. Default is Option B only.
-- **Static analysis of helper functions taking `*DPDKConfig` directly** — the canary only walks selector expressions of the form `<X>.DPDKDataplane`. Indirect access through a helper that accepts `*DPDKConfig` is documented as out-of-scope.
-- **Reflective access (`reflect.ValueOf(...).FieldByName(...)`)** — out-of-scope; covered by other repo-wide reflective-access canaries.
-- **Deleting `DPDKConfig` itself** — that's #1528 / Phase 3 work. This canary is the bridge between #1536 (reject) and #1528 (delete).
-- **Adding the same canary for `UserspaceDataplane`** — `UserspaceDataplane` is the *active* sub-tree, not retired, so the inverse invariant ("only read when effectiveType == userspace") is the normal happy path. Out of scope; a separate issue if anyone cares.
+- Storage-then-access via an intermediate struct field — the
+  canary cannot statically resolve this and we are not adding
+  type-system rework to do so. Option A's nil guarantee is the
+  mitigation.
+- Reflective access via `reflect.ValueOf(...).FieldByName(...)`.
+- Adding the inverse canary for `UserspaceDataplane` (the
+  active sub-tree). Separate issue.
+- Detecting helper functions that take a `*DPDKConfig`
+  directly and dereference it inside — the canary catches the
+  call site, not the helper body. Helper-body analysis would
+  require call-graph reachability, beyond scope.
+- Optional `TestCompileConfigEntryPointsClearDPDKSubtree`
+  canary (open question for round-2).
 
-## 10. Open questions for adversarial review
+## 10. Open questions for adversarial round-2
 
-1. **Window value** — Is the (#1536-merge → #1528-merge) window long enough to justify a 100-200 line test? If #1528 is already in flight, PLAN-KILL is appropriate.
-2. **Option A vs Option B** — Is Option A's one-line clear enough actual defense to NOT bother with Option B? Or are both worth shipping together?
-3. **Indirect access** — How much do reviewers care about the helper-function escape hatch (caller passes `cfg.System.DPDKDataplane` to a function that derefs it)? If this is the realistic future regression vector, Option B is incomplete and we need a stricter type wrapper.
-4. **`switch effectiveDataplaneType(...)` pattern recognition** — The canary's "dominating if-statement" heuristic does not natively understand `switch` statements. The existing writer at `compiler_system.go:228-246` uses a `switch` and would be excluded by the pkg/config/ exclusion, but a future cross-package reader could also use `switch`. Should the canary recognize `case dataplaneTypeDPDK:` inside a switch as a valid gate?
-5. **Should the canary live in `pkg/config/` or `pkg/dataplane/`?** — The precedent is in `pkg/dataplane/`. But this canary asserts a property of the `*Config` typed schema; `pkg/config/` is more natural. Either is defensible; calling it out for reviewer input.
-6. **Self-test fixture commit** — Should we commit a `//go:build canaryselftest` negative fixture that proves the canary actually rejects an ungated read? Or is the inline test enough?
+1. **Window value, again.** Antigravity round-1 PLAN-KILLed on
+   the grounds that #1528 makes this tautological soon. v2 keeps
+   the work because (a) #1528 has no PR yet, (b) Option A is
+   one line, (c) the canary's ~200 LOC is the bridge defense.
+   Is round-2 satisfied by this framing, or does the window
+   argument still kill the work?
+2. **Option A alone vs Option A + Option B.** v2 ships both.
+   If round-2 thinks Option A alone is sufficient, we can drop
+   Option B. The argument for keeping Option B: it catches
+   compile-time errors before a regression ever ships, whereas
+   Option A only prevents runtime shadow execution given a
+   subsequent `if d != nil` guard at the reader.
+3. **Switch-statement recognition complexity.** v2 supports
+   the switch idiom explicitly. The implementation walks the
+   parent chain to find `*ast.SwitchStmt` whose `Tag` is a
+   `CallExpr{Fun: effectiveDataplaneType, ...}`. Is this AST
+   recognition robust enough, or does it create a fragility
+   surface in itself?
+4. **Helper-function detection limit.** v2 catches the call
+   site `useIt(cfg.System.DPDKDataplane)` but not
+   `s.D = cfg.System.DPDKDataplane; ... s.D.Cores`. The plan
+   defers the storage-through-field case to Option A's nil
+   guarantee. Is that an acceptable boundary, or does round-2
+   want stronger detection?
+5. **Optional entry-point canary** (section 6 item 1). Worth
+   shipping or extra surface?
+6. **`compileExpanded` placement of Option A.** The nil clear
+   goes AFTER `validateDataplaneTypeStrict` so a config that
+   legitimately fails validation never silently has its DPDK
+   state cleared. Is the placement correct, or should it run
+   even on validator failure (to harden against partial-state
+   leakage in error paths)?
+7. **Stacking discipline.** v2 names #1536 as a hard
+   precondition. If #1536 is still iterating in review, we
+   either (a) wait, or (b) cherry-pick the validator into this
+   branch with a clear rebase commitment. Round-2 reviewer
+   preference?

--- a/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
+++ b/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
@@ -1,5 +1,27 @@
 # #1539 reviewer IDs
 
+## Code review (PR #1553)
+
+- HEAD at code-review: 8c5a4ced, then 6a7d0649 (linter fix +
+  multi-LHS bypass test).
+- Codex: session 019e5fa4-... (continued) — **MERGE-READY**.
+  Reasoning: "The nil clear is placed after strict dataplane
+  validation and before the successful compileExpanded return,
+  preserving the intended runtime invariant for committed
+  configs. The canary structurally scans production pkg/config
+  sources and has focused positive/negative fixtures for the
+  important gate shapes and known bypass classes from review."
+- Antigravity: adversarial-review-mplcczw9-21ub1p — initially
+  **MERGE-WITH-MAJOR** on HEAD 8c5a4ced with HIGH (multi-LHS
+  bypass in isLHSOfAssignToNil) + MEDIUM (hand-rolled itoa
+  out-of-bounds on >=12 digit input, MinInt overflow).
+  AGY then applied the fix in the worktree (same as my lint
+  pass had already produced); final verdict **MERGE-READY**
+  with all findings addressed in 6a7d0649.
+- Claude SMR: examined diff hostile-style, noted parenthesized
+  `&&` gate would be silently rejected (fail-closed style
+  choice, documented).
+
 ## Plan v2 (commit 7f0cdacd) — round-2 verdicts
 
 - Codex round-2: session 019e5fa4-0552-7823-915d-79eaf79b1c55

--- a/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
+++ b/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
@@ -2,6 +2,21 @@
 
 ## Code review (PR #1553)
 
+- HEAD final: f90125b3 (rebased on top of 1e31242d Copilot SWE
+  bot commit that fixed findings 1+5).
+- Round-3 re-verify (HEAD f90125b3):
+  - Codex: session 019e5fa* — **MERGE-READY**.
+    "Diff is scoped, validated, and no blocking correctness or
+    test gaps remain."
+  - Antigravity: adversarial-review-mplcritr-oschjy —
+    **MERGE-READY**. "Package-scope AST leakage detection
+    successfully closes the initializer bypass; Option A write
+    correctly enclosed by func compileExpanded so isLHSOfAssignToNil
+    handles it; allowlist key drift resolved cleanly via
+    filepath.Rel + ToSlash."
+  - Copilot: re-review requested via @copilot review comment;
+    awaiting verdict on f90125b3.
+
 - HEAD at code-review: 8c5a4ced, then 6a7d0649 (linter fix +
   multi-LHS bypass test).
 - Codex: session 019e5fa4-... (continued) — **MERGE-READY**.

--- a/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
+++ b/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
@@ -1,5 +1,39 @@
 # #1539 reviewer IDs
 
+## Plan v2 (commit 7f0cdacd) — round-2 verdicts
+
+- Codex round-2: session 019e5fa4-0552-7823-915d-79eaf79b1c55
+  (rerun after initial dispatch returned no agent message) —
+  **PLAN-MINOR**.
+  - F1 (pkg/config inclusion): ADDRESSED (line 151).
+  - F2 (AST-structural gate): ADDRESSED (lines 162/170, substring
+    matching explicitly forbidden).
+  - F3 (#1536 stacking): substantively ADDRESSED; stale wording at
+    lines 90 + 130 + 358-361 referring to #1536 as a precondition
+    or "iterating in review" — #1536 merged at fcd53beb on master.
+    Fix the wording.
+  - F4 (switch-statement): ADDRESSED (lines 189-194).
+  - New: contradictory negation-gate paragraph (lines 179 vs 185);
+    pick one stance.
+  - Window-of-value: YES, bridge defense justified.
+
+- Antigravity round-2: adversarial-review-mplbulo0-y014py —
+  **PLAN-MINOR**.
+  - Window-of-value: KILL no longer operative.
+  - HIGH: switch-statement multi-case bypass —
+    `case dataplaneTypeDPDK, dataplaneTypeUserspace:` would pass
+    the v2 recognizer. Require `len(CaseClause.List) == 1`.
+  - MEDIUM: nested-conditional false-positive — "nearest enclosing"
+    rejects a read inside `if effectiveDataplaneType(...) ==
+    dataplaneTypeDPDK { if x { _ = sys.DPDKDataplane.Cores } }`.
+    Walk parent chain to FuncDecl, accept if ANY ancestor gates.
+  - LOW: local-variable bypass — `dpdkConf = cfg.System.DPDKDataplane`
+    inside gate, used outside. Acceptable boundary because Option A
+    nil clears at runtime. Document explicitly.
+  - Two extra negative/positive fixtures recommended.
+
+## Plan v1 (commit cf9c1518)
+
 ## Plan v1 (commit cf9c1518)
 
 - Codex round-1: task-mpku5dam-crjpoi — PLAN-NEEDS-MAJOR

--- a/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
+++ b/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
@@ -56,8 +56,6 @@
 
 ## Plan v1 (commit cf9c1518)
 
-## Plan v1 (commit cf9c1518)
-
 - Codex round-1: task-mpku5dam-crjpoi — PLAN-NEEDS-MAJOR
   - 1. Canary excludes pkg/config/ but a future strict validator
     lands in pkg/config/ — primary regression class.

--- a/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
+++ b/docs/pr/1539-ast-leakage-guard/reviewer-ids.md
@@ -1,0 +1,35 @@
+# #1539 reviewer IDs
+
+## Plan v1 (commit cf9c1518)
+
+- Codex round-1: task-mpku5dam-crjpoi — PLAN-NEEDS-MAJOR
+  - 1. Canary excludes pkg/config/ but a future strict validator
+    lands in pkg/config/ — primary regression class.
+  - 2. Gate recognizer is substring-based and unsound; would
+    pass `if effectiveDataplaneType(...) == dataplaneTypeUserspace`
+    followed by a DPDK read. Must be AST-structural.
+  - 3. Plan must state hard precondition: stack ATOP #1536
+    (validateDataplaneTypeStrict not on master yet).
+  - 4. Switch-statement blind spot becomes structural once pkg/config
+    is included; canary must understand `switch effectiveDataplaneType
+    { case dataplaneTypeDPDK: ... }`.
+  - Other: ship Option A alongside the fixed canary as belt-and-braces.
+    Self-test fixtures: inline temp-fixture pattern (not //go:build).
+- Antigravity round-1: adversarial-review-mpku5cqj-z1v7o3 — PLAN-KILL
+  - 1. Window of value too small (#1527 merged; #1528 deletes the schema).
+  - 2. Helper-function escape hatch makes canary architecturally
+    incomplete.
+  - 3. Switch-statement blind spot forces unidiomatic if-chains.
+  - 4. Option A (one-line `cfg.System.DPDKDataplane = nil` in
+    compileExpanded) is the correct defense — guaranteed-nil cleanly
+    skips `if cfg.System.DPDKDataplane != nil { ... shadow ... }`
+    branches at runtime.
+  - 5. Precedent canary in pkg/dataplane/ only checks imports
+    (ImportsOnly), not control flow; this canary's domination
+    analysis is a class jump in complexity.
+
+Synthesis: ship Option A as primary defense (both reviewers point at
+it for different reasons — AGY as preferred, Codex as belt-and-braces),
+AND ship a Codex-corrected canary as defense in depth: scan pkg/config
+production source, AST-structural gate recognition, switch-statement
+support, committed inline self-test.

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -278,6 +278,23 @@ func compileExpanded(tree *ConfigTree) (*Config, error) {
 		}
 	}
 
+	// #1539: structural invariant against AST leakage / shadow
+	// execution of retired DPDK sub-tree fields.
+	// validateDataplaneTypeStrict above has already rejected every
+	// committed config that selects the retired DPDK backend; on the
+	// success path the only way cfg.System.DPDKDataplane could still
+	// be non-nil is if a future compiler entry path forgets to call
+	// the strict validator. Force the field to nil here so that any
+	// future helper / reader of the form
+	//   if cfg.System.DPDKDataplane != nil { /* DPDK-only logic */ }
+	// is statically dead on every committed config without requiring
+	// the caller to also gate on effectiveDataplaneType. This is dead
+	// code after #1528 (Phase 3) deletes the field entirely; remove
+	// this line in #1528.
+	if cfg != nil {
+		cfg.System.DPDKDataplane = nil
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -290,10 +290,10 @@ func compileExpanded(tree *ConfigTree) (*Config, error) {
 	// is statically dead on every committed config without requiring
 	// the caller to also gate on effectiveDataplaneType. This is dead
 	// code after #1528 (Phase 3) deletes the field entirely; remove
-	// this line in #1528.
-	if cfg != nil {
-		cfg.System.DPDKDataplane = nil
-	}
+	// this line in #1528. `cfg` is initialized via `cfg := &Config{...}`
+	// at the top of compileExpanded and never reassigned, so a nil
+	// guard would be dead defense (Copilot finding on PR #1553).
+	cfg.System.DPDKDataplane = nil
 
 	return cfg, nil
 }

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -102,14 +102,18 @@ var dpdkSubtreeLeakageCanaryScanRoots = []string{
 	".",
 }
 
-// dpdkSubtreeLeakageCanaryExcludeDirs are directory names that
-// the walker skips entirely. The DPDK backend manager reads its
-// own sub-tree; that is a backend-local internal coupling, not
-// an "AST leakage" event a future config-package commit would
-// introduce.
-var dpdkSubtreeLeakageCanaryExcludeDirs = map[string]struct{}{
-	"dpdk": {}, // pkg/dataplane/dpdk — backend-local
-}
+// dpdkSubtreeLeakageCanaryExcludeDirs maps a directory's path
+// RELATIVE to the walk root to a skip marker. Empty by default:
+// the v3 scan root is `pkg/config/` only, and there is no
+// `pkg/config/dpdk/` today — adding one (e.g.,
+// `pkg/config/dpdk/parser.go`) would be exactly the new ungated
+// reader the canary needs to fire on, so a bare dirname-based
+// skip like `"dpdk": {}` would hide the very class of leakage
+// this canary is supposed to catch (Copilot finding on PR #1553).
+// If a future canary iteration legitimately needs to skip a
+// backend-local directory (e.g., scope extends to
+// `pkg/dataplane/`), add the relative path here.
+var dpdkSubtreeLeakageCanaryExcludeDirs = map[string]struct{}{}
 
 // dpdkSubtreeLeakageCanaryFileAllowlist allows a small set of
 // files to read the sub-tree without a gate check. Today this is
@@ -171,8 +175,18 @@ func scanForDPDKSubtreeLeakage(t *testing.T, root string) []dpdkSubtreeLeakageFi
 			return walkErr
 		}
 		if d.IsDir() {
-			if _, skip := dpdkSubtreeLeakageCanaryExcludeDirs[d.Name()]; skip {
-				return filepath.SkipDir
+			// Skip directories by RELATIVE path (not bare
+			// dirname). A bare-dirname check like
+			// `d.Name() == "dpdk"` would silently skip a future
+			// `pkg/config/dpdk/parser.go` — exactly the leakage
+			// class the canary is supposed to catch (Copilot
+			// finding on PR #1553).
+			relDir, relErr := filepath.Rel(root, path)
+			if relErr == nil {
+				relDir = filepath.ToSlash(relDir)
+				if _, skip := dpdkSubtreeLeakageCanaryExcludeDirs[relDir]; skip {
+					return filepath.SkipDir
+				}
 			}
 			return nil
 		}

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -140,21 +140,15 @@ const dpdkSubtreeLeakageCanaryDPDKConstName = "dataplaneTypeDPDK"
 // the canary accepts in place of the typed constant.
 const dpdkSubtreeLeakageCanaryDPDKLiteral = `"dpdk"`
 
-// dpdkSubtreeLeakageCanaryRepoRoot is the path the canary walks
-// when invoked against the real production tree. The test
-// package compiles from `pkg/config/`, so the repo root is two
-// directories up.
-const dpdkSubtreeLeakageCanaryRepoRoot = ".."
-
 // dpdkSubtreeLeakageCanaryProductionScanRoot is the production
 // source root the canary scans for the
 // `TestDPDKSubtreeLeakageCanary_RealRepoIsClean` test. v3 scope
-// is just `pkg/config/` per the round-2 plan (Codex round-1 F1).
-// Future canary iterations may expand to scan other packages
-// that grow `DPDKDataplane` readers.
-var dpdkSubtreeLeakageCanaryProductionScanRoot = filepath.Join(
-	dpdkSubtreeLeakageCanaryRepoRoot, "config",
-)
+// is just `pkg/config/` per the round-2 plan (Codex round-1 F1):
+// future canary iterations may expand to scan other packages
+// that grow `DPDKDataplane` readers. The Go test binary runs
+// with the package source as its working directory, so the
+// production scan root is just ".".
+const dpdkSubtreeLeakageCanaryProductionScanRoot = "."
 
 // dpdkSubtreeLeakageFinding records a single ungated read or
 // pass-through. The test prints findings in stable file:line
@@ -188,10 +182,18 @@ func scanForDPDKSubtreeLeakage(t *testing.T, root string) []dpdkSubtreeLeakageFi
 		if strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		// Strip the leading "../" pair when the caller passes
-		// `dpdkSubtreeLeakageCanaryProductionScanRoot` so the
-		// allowlist key is package-relative.
-		relKey := filepath.ToSlash(path)
+		// Allowlist keys are paths relative to the walk root,
+		// in forward-slash form so the canary's contract does
+		// not silently break on a future Windows port. Use
+		// `filepath.Rel` rather than the raw walked path so an
+		// allowlist key like `"compiler_system.go"` matches
+		// regardless of whether `root` is "." (production scan)
+		// or a `t.TempDir()` (fixture scan).
+		relKey, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			relKey = path
+		}
+		relKey = filepath.ToSlash(relKey)
 		if _, allowed := dpdkSubtreeLeakageCanaryFileAllowlist[relKey]; allowed {
 			return nil
 		}
@@ -309,6 +311,12 @@ func scanFileForDPDKSubtreeLeakage(t *testing.T, path string) []dpdkSubtreeLeaka
 			// CallExpr we will also visit the CallExpr branch
 			// below. We still want to fire on a bare read like
 			// `_ = sys.DPDKDataplane.Cores`.
+			//
+			// A nil enclosing FuncDecl means the selector lives in
+			// package scope (var/const initializer). That site
+			// runs unconditionally at init time and cannot be
+			// gated by `if effectiveDataplaneType ...`, so it is
+			// always an ungated read.
 			fn := enclosingFuncDecl(node)
 			if fn == nil {
 				pos := fset.Position(node.Pos())
@@ -345,6 +353,10 @@ func scanFileForDPDKSubtreeLeakage(t *testing.T, path string) []dpdkSubtreeLeaka
 			if passthroughArg == nil {
 				return true
 			}
+			// As with the SelectorExpr branch, a CallExpr in
+			// package scope (e.g. a var initializer that calls a
+			// helper with `cfg.System.DPDKDataplane`) cannot be
+			// gated and must fire.
 			fn := enclosingFuncDecl(node)
 			if fn == nil {
 				pos := fset.Position(passthroughArg.Pos())
@@ -626,7 +638,8 @@ func TestDPDKSubtreeLeakageCanary_NegativeRejectsMultiVariableBypass(t *testing.
 
 // TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer
 // asserts the canary fires on package-scope reads and helper pass-throughs.
-// Package scope has no enclosing FuncDecl, so there is no valid gate context.
+// Package scope has no enclosing FuncDecl, so there is no valid gate context
+// (Copilot finding on PR #1553).
 func TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer(t *testing.T) {
 	root := writeLeakageCanaryFixture(t, map[string]string{
 		"a.go": negativePackageScopeInitializerFixture,

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -94,14 +94,6 @@ import (
 	"testing"
 )
 
-// dpdkSubtreeLeakageCanaryScanRoots are the directories the
-// canary walks for production Go source. Test files and the
-// DPDK backend itself (which legitimately reads its own
-// sub-tree) are excluded inside the walker.
-var dpdkSubtreeLeakageCanaryScanRoots = []string{
-	".",
-}
-
 // dpdkSubtreeLeakageCanaryExcludeDirs maps a directory's path
 // RELATIVE to the walk root to a skip marker. Empty by default:
 // the v3 scan root is `pkg/config/` only, and there is no

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -1,0 +1,822 @@
+package config
+
+// #1539: structural canary against AST leakage / shadow execution
+// of the retired DPDK sub-tree.
+//
+// Background
+//
+// After #1525 (the DPDK retirement umbrella) and #1536
+// (`validateDataplaneTypeStrict`, see compiler.go:319), no
+// committed config can select the DPDK backend, so on the success
+// path of `compileExpanded` the `cfg.System.DPDKDataplane` pointer
+// is structurally nil (Option A in `docs/pr/1539-ast-leakage-guard/
+// plan.md` clears it explicitly right before `return cfg, nil`).
+//
+// What is left to defend against is "AST leakage": a future
+// commit adds a new strict validator, a new compile helper, or a
+// new dataplane hook that reads a field on `*DPDKConfig` (or
+// passes the `*DPDKConfig` to a helper) WITHOUT first gating on
+// `effectiveDataplaneType(...) == dataplaneTypeDPDK`. Such code
+// would silently execute DPDK-specific logic on a userspace
+// backend. Option A's nil clear protects the runtime semantics;
+// this canary catches the bug at `go test` time so the reviewer
+// learns about the missing gate before the code merges.
+//
+// Scope of the AST gate
+//
+// The canary walks every non-test Go file under `pkg/config/`
+// (the package that owns the DPDK sub-tree) and rejects any
+// SelectorExpr of the form `<X>.DPDKDataplane` (read) AND any
+// CallExpr whose argument list contains such a SelectorExpr
+// (helper pass-through), unless the read sits under a valid
+// `effectiveDataplaneType(...)` gate somewhere on its AST
+// ancestor chain up to the enclosing function.
+//
+// "Valid gate" means one of:
+//
+//   1. An `*ast.IfStmt` ancestor whose Cond is a
+//      `BinaryExpr{Op: ==, X|Y: effectiveDataplaneType(...),
+//      Y|X: dataplaneTypeDPDK | "dpdk"}` (either operand order).
+//   2. An `*ast.SwitchStmt` ancestor whose `Tag` is a
+//      `CallExpr{Fun: effectiveDataplaneType, ...}` AND the
+//      enclosing `*ast.CaseClause` has `len(List) == 1` AND the
+//      sole entry is `dataplaneTypeDPDK` or the string literal
+//      `"dpdk"`. Single-entry is required because a multi-case
+//      clause like `case dataplaneTypeDPDK, dataplaneTypeUserspace:`
+//      executes for userspace traffic and would otherwise pass
+//      a "list contains DPDK" check.
+//
+// Walking all the way up to the FuncDecl (not just the nearest
+// enclosing block) is deliberate: it lets a developer nest more
+// conditionals inside a valid outer gate without false-positive
+// canary failures. The negation idiom
+// `if effectiveDataplaneType(...) != dataplaneTypeDPDK { return }`
+// is NOT a valid gate in v3 — the early-exit analysis adds AST
+// surface for marginal value; convert to the positive `==` form.
+//
+// Acceptable known limitations (Option A is the runtime
+// mitigation for both):
+//
+//   - Storing the pointer in a local variable inside a valid
+//     gate and using the local variable outside the gate. The
+//     canary cannot statically follow the def-use chain through
+//     local assignment.
+//   - Storing the pointer in a struct field then accessing the
+//     struct field later.
+//
+// In both cases Option A guarantees the dereferenced field is
+// nil at runtime, so an `if x != nil { ... }` reader skips the
+// shadow logic and a missing nil check panics safely rather than
+// silently executing DPDK code on userspace traffic.
+//
+// The writer at `pkg/config/compiler_system.go` line ~237
+// (`sys.DPDKDataplane = &DPDKConfig{}`) and the call
+// `compileDPDKDataplane(child, sys.DPDKDataplane)` are accepted
+// by the canary because they live inside
+// `switch effectiveDataplaneType(sys.DataplaneType) { case
+// dataplaneTypeDPDK: ... }` which is the canonical single-entry
+// gate.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// dpdkSubtreeLeakageCanaryScanRoots are the directories the
+// canary walks for production Go source. Test files and the
+// DPDK backend itself (which legitimately reads its own
+// sub-tree) are excluded inside the walker.
+var dpdkSubtreeLeakageCanaryScanRoots = []string{
+	".",
+}
+
+// dpdkSubtreeLeakageCanaryExcludeDirs are directory names that
+// the walker skips entirely. The DPDK backend manager reads its
+// own sub-tree; that is a backend-local internal coupling, not
+// an "AST leakage" event a future config-package commit would
+// introduce.
+var dpdkSubtreeLeakageCanaryExcludeDirs = map[string]struct{}{
+	"dpdk": {}, // pkg/dataplane/dpdk — backend-local
+}
+
+// dpdkSubtreeLeakageCanaryFileAllowlist allows a small set of
+// files to read the sub-tree without a gate check. Today this is
+// empty: the in-package writer is recognized structurally via
+// the canonical single-entry switch gate, and there are no other
+// production readers in pkg/config/ (see
+// `TestDPDKSubtreeLeakageCanary_RealRepoIsClean`).
+var dpdkSubtreeLeakageCanaryFileAllowlist = map[string]struct{}{}
+
+// dpdkSubtreeLeakageCanarySelectorName is the field selector the
+// canary looks for. It matches any expression of the form
+// `<X>.DPDKDataplane`, regardless of receiver identifier
+// (`cfg.System.DPDKDataplane`, `sys.DPDKDataplane`, …).
+const dpdkSubtreeLeakageCanarySelectorName = "DPDKDataplane"
+
+// dpdkSubtreeLeakageCanaryGateFnName is the name of the
+// canonical helper that returns the effective dataplane type.
+// The canary only accepts gates whose condition / switch tag is
+// a CallExpr to this exact identifier.
+const dpdkSubtreeLeakageCanaryGateFnName = "effectiveDataplaneType"
+
+// dpdkSubtreeLeakageCanaryDPDKConstName is the name of the
+// canonical typed constant the canary accepts on the RHS of an
+// equality gate or as a CaseClause label.
+const dpdkSubtreeLeakageCanaryDPDKConstName = "dataplaneTypeDPDK"
+
+// dpdkSubtreeLeakageCanaryDPDKLiteral is the bare string literal
+// the canary accepts in place of the typed constant.
+const dpdkSubtreeLeakageCanaryDPDKLiteral = `"dpdk"`
+
+// dpdkSubtreeLeakageCanaryRepoRoot is the path the canary walks
+// when invoked against the real production tree. The test
+// package compiles from `pkg/config/`, so the repo root is two
+// directories up.
+const dpdkSubtreeLeakageCanaryRepoRoot = ".."
+
+// dpdkSubtreeLeakageCanaryProductionScanRoot is the production
+// source root the canary scans for the
+// `TestDPDKSubtreeLeakageCanary_RealRepoIsClean` test. v3 scope
+// is just `pkg/config/` per the round-2 plan (Codex round-1 F1).
+// Future canary iterations may expand to scan other packages
+// that grow `DPDKDataplane` readers.
+var dpdkSubtreeLeakageCanaryProductionScanRoot = filepath.Join(
+	dpdkSubtreeLeakageCanaryRepoRoot, "config",
+)
+
+// dpdkSubtreeLeakageFinding records a single ungated read or
+// pass-through. The test prints findings in stable file:line
+// order so failures are easy to triage.
+type dpdkSubtreeLeakageFinding struct {
+	path string
+	line int
+	kind string // "read" or "passthrough"
+	why  string
+}
+
+// scanForDPDKSubtreeLeakage walks `root` and returns every
+// ungated `<X>.DPDKDataplane` read or CallExpr pass-through.
+func scanForDPDKSubtreeLeakage(t *testing.T, root string) []dpdkSubtreeLeakageFinding {
+	t.Helper()
+
+	var findings []dpdkSubtreeLeakageFinding
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if _, skip := dpdkSubtreeLeakageCanaryExcludeDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// Strip the leading "../" pair when the caller passes
+		// `dpdkSubtreeLeakageCanaryProductionScanRoot` so the
+		// allowlist key is package-relative.
+		relKey := filepath.ToSlash(path)
+		if _, allowed := dpdkSubtreeLeakageCanaryFileAllowlist[relKey]; allowed {
+			return nil
+		}
+		findings = append(findings, scanFileForDPDKSubtreeLeakage(t, path)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].path == findings[j].path {
+			return findings[i].line < findings[j].line
+		}
+		return findings[i].path < findings[j].path
+	})
+	return findings
+}
+
+// scanFileForDPDKSubtreeLeakage parses one Go file and returns
+// every ungated read / pass-through.
+func scanFileForDPDKSubtreeLeakage(t *testing.T, path string) []dpdkSubtreeLeakageFinding {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	// Build a parent map so we can walk ancestors of any node.
+	// ast.Inspect uses a nil callback on the way back up the
+	// tree which lets us maintain a parent stack: push on
+	// non-nil visit, pop on nil visit. The element at the top
+	// of the stack at any non-nil visit is the immediate parent
+	// of the current node.
+	parents := map[ast.Node]ast.Node{}
+	var stack []ast.Node
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			return false
+		}
+		if len(stack) > 0 {
+			parents[n] = stack[len(stack)-1]
+		}
+		stack = append(stack, n)
+		return true
+	})
+
+	var findings []dpdkSubtreeLeakageFinding
+
+	// Find the enclosing FuncDecl for a node by walking parents.
+	enclosingFuncDecl := func(n ast.Node) *ast.FuncDecl {
+		for cur := n; cur != nil; {
+			parent, ok := parents[cur]
+			if !ok {
+				return nil
+			}
+			if fn, isFn := parent.(*ast.FuncDecl); isFn {
+				return fn
+			}
+			cur = parent
+		}
+		return nil
+	}
+
+	// isGatedByDPDK walks every ancestor of `n` up to (but not
+	// past) `stopAt` and returns true if any IfStmt / SwitchStmt
+	// in that path is a valid single-DPDK gate that contains
+	// `n` in its accepting body.
+	isGatedByDPDK := func(n ast.Node, stopAt ast.Node) bool {
+		cur := n
+		for {
+			parent, ok := parents[cur]
+			if !ok || parent == stopAt {
+				return false
+			}
+			switch p := parent.(type) {
+			case *ast.IfStmt:
+				// Accept iff `cur` lies inside p.Body AND the
+				// Cond is a valid DPDK equality gate.
+				if nodeWithinBlock(cur, p.Body, parents) && isDPDKEqualityCond(p.Cond) {
+					return true
+				}
+			case *ast.CaseClause:
+				// We need to find p's enclosing SwitchStmt,
+				// confirm its Tag is effectiveDataplaneType(...),
+				// AND confirm p.List has exactly one entry that
+				// is `dataplaneTypeDPDK` or `"dpdk"`.
+				if isDPDKSingleCaseClause(p, parents) {
+					return true
+				}
+			}
+			cur = parent
+		}
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			// Skip the writer-side selectors at LHS of an
+			// assignment to nil (Option A's clear) — that is a
+			// write of zero value and is not a read of DPDK
+			// state. The walker also accepts any SelectorExpr
+			// gated by a valid ancestor.
+			if node.Sel == nil || node.Sel.Name != dpdkSubtreeLeakageCanarySelectorName {
+				return true
+			}
+			if isLHSOfAssignToNil(node, parents) {
+				return true
+			}
+			// If this SelectorExpr is itself the argument of a
+			// CallExpr we will also visit the CallExpr branch
+			// below. We still want to fire on a bare read like
+			// `_ = sys.DPDKDataplane.Cores`.
+			fn := enclosingFuncDecl(node)
+			if fn == nil {
+				return true
+			}
+			if !isGatedByDPDK(node, fn) {
+				pos := fset.Position(node.Pos())
+				findings = append(findings, dpdkSubtreeLeakageFinding{
+					path: pos.Filename,
+					line: pos.Line,
+					kind: "read",
+					why: "ungated read of " +
+						dpdkSubtreeLeakageCanarySelectorName,
+				})
+			}
+		case *ast.CallExpr:
+			// Helper-function pass-through: any CallExpr whose
+			// arg list contains a SelectorExpr ending in
+			// DPDKDataplane must itself sit under a valid gate.
+			var passthroughArg *ast.SelectorExpr
+			for _, arg := range node.Args {
+				if sel, ok := arg.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == dpdkSubtreeLeakageCanarySelectorName {
+					passthroughArg = sel
+					break
+				}
+			}
+			if passthroughArg == nil {
+				return true
+			}
+			fn := enclosingFuncDecl(node)
+			if fn == nil {
+				return true
+			}
+			if !isGatedByDPDK(node, fn) {
+				pos := fset.Position(passthroughArg.Pos())
+				findings = append(findings, dpdkSubtreeLeakageFinding{
+					path: pos.Filename,
+					line: pos.Line,
+					kind: "passthrough",
+					why: "ungated helper pass-through of " +
+						dpdkSubtreeLeakageCanarySelectorName,
+				})
+			}
+		}
+		return true
+	})
+
+	return findings
+}
+
+// nodeWithinBlock returns true if `n` is contained in `block`
+// per the AST parent chain. A nil block (e.g. else-less if)
+// returns false.
+func nodeWithinBlock(n ast.Node, block *ast.BlockStmt, parents map[ast.Node]ast.Node) bool {
+	if block == nil {
+		return false
+	}
+	for cur := n; cur != nil; {
+		if cur == block {
+			return true
+		}
+		parent, ok := parents[cur]
+		if !ok {
+			return false
+		}
+		cur = parent
+	}
+	return false
+}
+
+// isDPDKEqualityCond returns true iff cond is
+// `effectiveDataplaneType(...) == dataplaneTypeDPDK` or its
+// operand-reversed sibling. The string literal `"dpdk"` is also
+// accepted on the constant side. The negation `!=` is NOT
+// accepted (v3 stance).
+func isDPDKEqualityCond(cond ast.Expr) bool {
+	be, ok := cond.(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	if be.Op != token.EQL {
+		return false
+	}
+	return (isEffectiveDataplaneTypeCall(be.X) && isDPDKConstOrLit(be.Y)) ||
+		(isEffectiveDataplaneTypeCall(be.Y) && isDPDKConstOrLit(be.X))
+}
+
+// isEffectiveDataplaneTypeCall returns true iff expr is a
+// CallExpr whose Fun is the bare identifier
+// `effectiveDataplaneType`.
+func isEffectiveDataplaneTypeCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == dpdkSubtreeLeakageCanaryGateFnName
+}
+
+// isDPDKConstOrLit returns true iff expr is the identifier
+// `dataplaneTypeDPDK` or the string literal `"dpdk"`.
+func isDPDKConstOrLit(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == dpdkSubtreeLeakageCanaryDPDKConstName
+	case *ast.BasicLit:
+		return e.Kind == token.STRING && e.Value == dpdkSubtreeLeakageCanaryDPDKLiteral
+	}
+	return false
+}
+
+// isDPDKSingleCaseClause returns true iff `cc` is enclosed by an
+// `*ast.SwitchStmt` whose Tag is `effectiveDataplaneType(...)`
+// AND `cc.List` has exactly one entry that is
+// `dataplaneTypeDPDK` or `"dpdk"`. Single-entry is required so
+// that a multi-case clause like
+// `case dataplaneTypeDPDK, dataplaneTypeUserspace:` does NOT
+// accept a DPDK read (the block executes for userspace too).
+func isDPDKSingleCaseClause(cc *ast.CaseClause, parents map[ast.Node]ast.Node) bool {
+	if len(cc.List) != 1 {
+		return false
+	}
+	if !isDPDKConstOrLit(cc.List[0]) {
+		return false
+	}
+	// Walk up to the enclosing SwitchStmt and check Tag.
+	for cur := ast.Node(cc); cur != nil; {
+		parent, ok := parents[cur]
+		if !ok {
+			return false
+		}
+		if sw, isSw := parent.(*ast.SwitchStmt); isSw {
+			return isEffectiveDataplaneTypeCall(sw.Tag)
+		}
+		cur = parent
+	}
+	return false
+}
+
+// isLHSOfAssignToNil returns true iff `sel` appears as the LHS
+// of an `AssignStmt` whose RHS is the identifier `nil`. This
+// covers Option A's `cfg.System.DPDKDataplane = nil` clear.
+func isLHSOfAssignToNil(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node) bool {
+	parent, ok := parents[sel]
+	if !ok {
+		return false
+	}
+	as, ok := parent.(*ast.AssignStmt)
+	if !ok {
+		return false
+	}
+	// LHS check: at least one LHS must equal `sel`.
+	onLHS := false
+	for _, lhs := range as.Lhs {
+		if lhs == sel {
+			onLHS = true
+			break
+		}
+	}
+	if !onLHS {
+		return false
+	}
+	// RHS check: at least one RHS expression must be `nil`.
+	for _, rhs := range as.Rhs {
+		if ident, ok := rhs.(*ast.Ident); ok && ident.Name == "nil" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDPDKSubtreeLeakageCanary_RealRepoIsClean asserts the
+// production source under `pkg/config/` has zero ungated reads
+// or pass-throughs of the DPDK sub-tree. Today the only writer
+// is the canonical single-entry switch gate in
+// `compiler_system.go`; Option A's nil clear in `compiler.go`
+// is recognized as an LHS-of-assign-to-nil and therefore
+// excluded. Adding a new ungated reader without a gate will
+// fire this test.
+func TestDPDKSubtreeLeakageCanary_RealRepoIsClean(t *testing.T) {
+	findings := scanForDPDKSubtreeLeakage(t, dpdkSubtreeLeakageCanaryProductionScanRoot)
+	if len(findings) == 0 {
+		return
+	}
+	var lines []string
+	for _, f := range findings {
+		lines = append(lines, formatLeakageFinding(f))
+	}
+	t.Fatalf("real-repo scan returned %d unexpected DPDK sub-tree leakage finding(s):\n%s",
+		len(findings), strings.Join(lines, "\n"))
+}
+
+// TestDPDKSubtreeLeakageCanary_PositiveAcceptsIfGate writes a
+// fixture with a positive `==` if-gate around the read and
+// asserts the canary returns zero findings.
+func TestDPDKSubtreeLeakageCanary_PositiveAcceptsIfGate(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": positiveIfGateFixture,
+	})
+	if findings := scanForDPDKSubtreeLeakage(t, root); len(findings) != 0 {
+		t.Fatalf("positive if-gate fixture should be clean, got: %s",
+			renderLeakageFindings(findings))
+	}
+}
+
+// TestDPDKSubtreeLeakageCanary_PositiveAcceptsSwitchGate writes
+// a fixture with the canonical `switch effectiveDataplaneType
+// { case dataplaneTypeDPDK: }` single-entry gate.
+func TestDPDKSubtreeLeakageCanary_PositiveAcceptsSwitchGate(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": positiveSwitchGateFixture,
+	})
+	if findings := scanForDPDKSubtreeLeakage(t, root); len(findings) != 0 {
+		t.Fatalf("positive switch-gate fixture should be clean, got: %s",
+			renderLeakageFindings(findings))
+	}
+}
+
+// TestDPDKSubtreeLeakageCanary_PositiveAcceptsNestedGatedRead
+// asserts that a read nested inside a second inner conditional
+// is still accepted because the outer gate is on the ancestor
+// chain (AGY round-2 MEDIUM).
+func TestDPDKSubtreeLeakageCanary_PositiveAcceptsNestedGatedRead(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": positiveNestedGatedReadFixture,
+	})
+	if findings := scanForDPDKSubtreeLeakage(t, root); len(findings) != 0 {
+		t.Fatalf("nested-gated-read fixture should be clean, got: %s",
+			renderLeakageFindings(findings))
+	}
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsUngatedRead
+// asserts the canary fires on a bare ungated read.
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsUngatedRead(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeUngatedReadFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsHelperPassthrough
+// asserts the canary fires on an ungated helper pass-through
+// `useIt(cfg.System.DPDKDataplane)`.
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsHelperPassthrough(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeHelperPassthroughFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "passthrough")
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsWrongTypeBranch
+// asserts the canary fires on a read inside an
+// `effectiveDataplaneType(...) == dataplaneTypeUserspace`
+// branch (Codex round-1 F2 counterexample).
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsWrongTypeBranch(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeWrongTypeBranchFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsSwitchMultipleCases
+// asserts the canary fires on
+// `case dataplaneTypeDPDK, dataplaneTypeUserspace: _ = ...DPDKDataplane`
+// (AGY round-2 HIGH multi-case bypass).
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsSwitchMultipleCases(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeSwitchMultiCaseFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsNegationIdiom
+// asserts the canary fires on the early-return negation idiom
+// `if effectiveDataplaneType(...) != dataplaneTypeDPDK { return };
+// _ = ...DPDKDataplane`. v3 explicitly does not accept this
+// form; the developer must convert to the positive `==`.
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsNegationIdiom(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeNegationIdiomFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
+}
+
+// Fixtures: each is a self-contained Go source file written to
+// a `t.TempDir()` directory and then walked by the canary. The
+// fixtures DO NOT compile against the real config package; the
+// canary only parses them.
+
+const positiveIfGateFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+const dataplaneTypeDPDK = "dpdk"
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	if effectiveDataplaneType(sys.DataplaneType) == dataplaneTypeDPDK {
+		return sys.DPDKDataplane.Cores
+	}
+	return 0
+}
+`
+
+const positiveSwitchGateFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+const dataplaneTypeDPDK = "dpdk"
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	switch effectiveDataplaneType(sys.DataplaneType) {
+	case dataplaneTypeDPDK:
+		return sys.DPDKDataplane.Cores
+	}
+	return 0
+}
+`
+
+const positiveNestedGatedReadFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+	Other         bool
+}
+
+const dataplaneTypeDPDK = "dpdk"
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	if effectiveDataplaneType(sys.DataplaneType) == dataplaneTypeDPDK {
+		if sys.Other {
+			return sys.DPDKDataplane.Cores
+		}
+	}
+	return 0
+}
+`
+
+const negativeUngatedReadFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+func use(sys *sysT) int {
+	return sys.DPDKDataplane.Cores
+}
+`
+
+const negativeHelperPassthroughFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+func useIt(d *DPDKConfig) int { return d.Cores }
+
+func use(sys *sysT) int {
+	return useIt(sys.DPDKDataplane)
+}
+`
+
+const negativeWrongTypeBranchFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+const dataplaneTypeUserspace = "userspace"
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	if effectiveDataplaneType(sys.DataplaneType) == dataplaneTypeUserspace {
+		return sys.DPDKDataplane.Cores
+	}
+	return 0
+}
+`
+
+const negativeSwitchMultiCaseFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+const (
+	dataplaneTypeDPDK      = "dpdk"
+	dataplaneTypeUserspace = "userspace"
+)
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	switch effectiveDataplaneType(sys.DataplaneType) {
+	case dataplaneTypeDPDK, dataplaneTypeUserspace:
+		return sys.DPDKDataplane.Cores
+	}
+	return 0
+}
+`
+
+const negativeNegationIdiomFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+const dataplaneTypeDPDK = "dpdk"
+
+func effectiveDataplaneType(s string) string { return s }
+
+func use(sys *sysT) int {
+	if effectiveDataplaneType(sys.DataplaneType) != dataplaneTypeDPDK {
+		return 0
+	}
+	return sys.DPDKDataplane.Cores
+}
+`
+
+// writeLeakageCanaryFixture writes each fixture string to a
+// fresh temp dir and returns the dir path.
+func writeLeakageCanaryFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, []byte(strings.TrimSpace(body)+"\n"), 0o644); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+// requireLeakageFindingKind fails the test if no finding of the
+// expected `kind` ("read" or "passthrough") appears in the set.
+func requireLeakageFindingKind(t *testing.T, findings []dpdkSubtreeLeakageFinding, kind string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.kind == kind {
+			return
+		}
+	}
+	t.Fatalf("expected at least one canary finding of kind %q, got: %s",
+		kind, renderLeakageFindings(findings))
+}
+
+// renderLeakageFindings formats every finding for failure
+// messages.
+func renderLeakageFindings(findings []dpdkSubtreeLeakageFinding) string {
+	if len(findings) == 0 {
+		return "<no findings>"
+	}
+	parts := make([]string, 0, len(findings))
+	for _, f := range findings {
+		parts = append(parts, formatLeakageFinding(f))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// formatLeakageFinding formats a single finding as
+// `file:line [kind] why`.
+func formatLeakageFinding(f dpdkSubtreeLeakageFinding) string {
+	return f.path + ":" + itoa(f.line) + " [" + f.kind + "] " + f.why
+}
+
+// itoa is a tiny local int-to-string so the canary does not need
+// to drag in strconv just to format a line number.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	pos := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -30,7 +30,9 @@ package config
 // CallExpr whose argument list contains such a SelectorExpr
 // (helper pass-through), unless the read sits under a valid
 // `effectiveDataplaneType(...)` gate somewhere on its AST
-// ancestor chain up to the enclosing function.
+// ancestor chain up to the enclosing function. Package-scope
+// initializers have no enclosing function and are therefore
+// always findings.
 //
 // "Valid gate" means one of:
 //
@@ -49,7 +51,10 @@ package config
 // Walking all the way up to the FuncDecl (not just the nearest
 // enclosing block) is deliberate: it lets a developer nest more
 // conditionals inside a valid outer gate without false-positive
-// canary failures. The negation idiom
+// canary failures. Package scope is treated separately: because
+// there is no enclosing FuncDecl, there is also no valid runtime
+// gate context, so a package-scope read/pass-through is always a
+// canary finding. The negation idiom
 // `if effectiveDataplaneType(...) != dataplaneTypeDPDK { return }`
 // is NOT a valid gate in v3 — the early-exit analysis adds AST
 // surface for marginal value; convert to the positive `==` form.
@@ -306,6 +311,14 @@ func scanFileForDPDKSubtreeLeakage(t *testing.T, path string) []dpdkSubtreeLeaka
 			// `_ = sys.DPDKDataplane.Cores`.
 			fn := enclosingFuncDecl(node)
 			if fn == nil {
+				pos := fset.Position(node.Pos())
+				findings = append(findings, dpdkSubtreeLeakageFinding{
+					path: pos.Filename,
+					line: pos.Line,
+					kind: "read",
+					why: "package-scope read of " +
+						dpdkSubtreeLeakageCanarySelectorName,
+				})
 				return true
 			}
 			if !isGatedByDPDK(node, fn) {
@@ -334,6 +347,14 @@ func scanFileForDPDKSubtreeLeakage(t *testing.T, path string) []dpdkSubtreeLeaka
 			}
 			fn := enclosingFuncDecl(node)
 			if fn == nil {
+				pos := fset.Position(passthroughArg.Pos())
+				findings = append(findings, dpdkSubtreeLeakageFinding{
+					path: pos.Filename,
+					line: pos.Line,
+					kind: "passthrough",
+					why: "package-scope helper pass-through of " +
+						dpdkSubtreeLeakageCanarySelectorName,
+				})
 				return true
 			}
 			if !isGatedByDPDK(node, fn) {
@@ -603,6 +624,18 @@ func TestDPDKSubtreeLeakageCanary_NegativeRejectsMultiVariableBypass(t *testing.
 	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
 }
 
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer
+// asserts the canary fires on package-scope reads and helper pass-throughs.
+// Package scope has no enclosing FuncDecl, so there is no valid gate context.
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativePackageScopeInitializerFixture,
+	})
+	findings := scanForDPDKSubtreeLeakage(t, root)
+	requireLeakageFindingKind(t, findings, "read")
+	requireLeakageFindingKind(t, findings, "passthrough")
+}
+
 // Fixtures: each is a self-contained Go source file written to
 // a `t.TempDir()` directory and then walked by the canary. The
 // fixtures DO NOT compile against the real config package; the
@@ -776,6 +809,22 @@ func use(sys *sysT) {
 	var dummy *DPDKConfig
 	dummy, sys.DPDKDataplane = nil, &DPDKConfig{Cores: 4}
 }
+`
+
+const negativePackageScopeInitializerFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+var singleton = &sysT{}
+
+func useIt(d *DPDKConfig) int { return d.Cores }
+
+var _ = singleton.DPDKDataplane
+var _ = useIt(singleton.DPDKDataplane)
 `
 
 // writeLeakageCanaryFixture writes each fixture string to a

--- a/pkg/config/dpdk_subtree_leakage_canary_test.go
+++ b/pkg/config/dpdk_subtree_leakage_canary_test.go
@@ -84,6 +84,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -456,24 +457,25 @@ func isLHSOfAssignToNil(sel *ast.SelectorExpr, parents map[ast.Node]ast.Node) bo
 	if !ok {
 		return false
 	}
-	// LHS check: at least one LHS must equal `sel`.
-	onLHS := false
-	for _, lhs := range as.Lhs {
+	// Find which LHS index matches our selector.
+	lhsIndex := -1
+	for i, lhs := range as.Lhs {
 		if lhs == sel {
-			onLHS = true
+			lhsIndex = i
 			break
 		}
 	}
-	if !onLHS {
+	if lhsIndex == -1 {
 		return false
 	}
-	// RHS check: at least one RHS expression must be `nil`.
-	for _, rhs := range as.Rhs {
-		if ident, ok := rhs.(*ast.Ident); ok && ident.Name == "nil" {
-			return true
-		}
+	// In Go, if len(Rhs) != len(Lhs), it must be a multi-value expression (e.g. call or map read),
+	// which cannot be a bare 'nil'.
+	if len(as.Rhs) != len(as.Lhs) {
+		return false
 	}
-	return false
+	// Check if the corresponding RHS expression is exactly the identifier "nil".
+	ident, ok := as.Rhs[lhsIndex].(*ast.Ident)
+	return ok && ident.Name == "nil"
 }
 
 // TestDPDKSubtreeLeakageCanary_RealRepoIsClean asserts the
@@ -586,6 +588,17 @@ func TestDPDKSubtreeLeakageCanary_NegativeRejectsSwitchMultipleCases(t *testing.
 func TestDPDKSubtreeLeakageCanary_NegativeRejectsNegationIdiom(t *testing.T) {
 	root := writeLeakageCanaryFixture(t, map[string]string{
 		"a.go": negativeNegationIdiomFixture,
+	})
+	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
+}
+
+// TestDPDKSubtreeLeakageCanary_NegativeRejectsMultiVariableBypass
+// asserts the canary fires when attempting to bypass the write-to-nil
+// exclusion using a multi-variable assignment where nil is not mapped to
+// DPDKDataplane.
+func TestDPDKSubtreeLeakageCanary_NegativeRejectsMultiVariableBypass(t *testing.T) {
+	root := writeLeakageCanaryFixture(t, map[string]string{
+		"a.go": negativeMultiVariableBypassFixture,
 	})
 	requireLeakageFindingKind(t, scanForDPDKSubtreeLeakage(t, root), "read")
 }
@@ -751,6 +764,20 @@ func use(sys *sysT) int {
 }
 `
 
+const negativeMultiVariableBypassFixture = `package fixture
+
+type DPDKConfig struct{ Cores int }
+type sysT struct {
+	DataplaneType string
+	DPDKDataplane *DPDKConfig
+}
+
+func use(sys *sysT) {
+	var dummy *DPDKConfig
+	dummy, sys.DPDKDataplane = nil, &DPDKConfig{Cores: 4}
+}
+`
+
 // writeLeakageCanaryFixture writes each fixture string to a
 // fresh temp dir and returns the dir path.
 func writeLeakageCanaryFixture(t *testing.T, files map[string]string) string {
@@ -794,29 +821,5 @@ func renderLeakageFindings(findings []dpdkSubtreeLeakageFinding) string {
 // formatLeakageFinding formats a single finding as
 // `file:line [kind] why`.
 func formatLeakageFinding(f dpdkSubtreeLeakageFinding) string {
-	return f.path + ":" + itoa(f.line) + " [" + f.kind + "] " + f.why
-}
-
-// itoa is a tiny local int-to-string so the canary does not need
-// to drag in strconv just to format a line number.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [12]byte
-	pos := len(buf)
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		pos--
-		buf[pos] = '-'
-	}
-	return string(buf[pos:])
+	return f.path + ":" + strconv.Itoa(f.line) + " [" + f.kind + "] " + f.why
 }


### PR DESCRIPTION
## Summary

- **Option A** — single-line structural invariant in
  `compileExpanded`: after `validateDataplaneTypeStrict` (PR
  #1536) and the accumulated strict validators (PR #1556's
  `errors.Join({CoS, three-color, scheduler-refs})`) succeed,
  force `cfg.System.DPDKDataplane = nil` before the success
  `return cfg, nil`. Any future helper of the form
  `if cfg.System.DPDKDataplane != nil { ... DPDK-only logic }`
  is statically dead on every committed config without needing
  the caller to gate on `effectiveDataplaneType`.
- **Option B** — compile-time canary
  (`pkg/config/dpdk_subtree_leakage_canary_test.go`): walks
  `pkg/config/` production source and rejects any ungated read
  of `<X>.DPDKDataplane` or any ungated `CallExpr` passing such
  a SelectorExpr as an argument. AST-structural (no substring
  matching), walks the parent chain all the way up to the
  enclosing `FuncDecl`, requires `len(CaseClause.List) == 1` for
  switch gates (blocks the `case dataplaneTypeDPDK,
  dataplaneTypeUserspace:` multi-case bypass), and explicitly
  rejects the negation `!=` idiom.

## Scope

This PR touches runtime config-compilation code (Option A's
one-line nil clear in `compileExpanded`) plus a new test-only
AST canary. **Scope: full** — runtime smoke verification is
appropriate because the nil clear executes on every successful
`commit` / `commit check`.

Diff stat (vs master at 1f39f79d):
- `pkg/config/compiler.go` +12 lines (Option A nil clear + comment).
- `pkg/config/dpdk_subtree_leakage_canary_test.go` +893 lines (new canary).
- `docs/pr/1539-ast-leakage-guard/plan.md` +420 lines (new plan).
- `docs/pr/1539-ast-leakage-guard/reviewer-ids.md` +104 lines (new reviewer trail).
- `_Log.md` action-log entries.

No dataplane / userspace-dp / BPF code touched.

## Review trail

Both Codex + Antigravity returned `PLAN-MINOR` on plan v3 (see
`docs/pr/1539-ast-leakage-guard/plan.md` +
`docs/pr/1539-ast-leakage-guard/reviewer-ids.md`):

- Codex plan round-2: PLAN-MINOR — all four round-1 findings
  addressed; window-of-value YES.
- Antigravity plan round-2: PLAN-MINOR — KILL no longer
  operative; HIGH multi-case bypass + MEDIUM nested-conditional
  false-positive folded into v3; LOW local-var rebinding
  documented as bounded limitation mitigated by Option A.

Code review on `7bfbf21d` (post-rebase + Copilot-3 fixes):
- Codex round-6: MERGE-READY.
- Antigravity round-6 (`adversarial-review-mpm1ffyf-fs9k1j`):
  MERGE-READY.
- Formal `copilot-pull-request-reviewer`: previously raised 3
  LOW items on `4d24d592` (unused `dpdkSubtreeLeakageCanaryScanRoots`,
  redundant `if cfg != nil` guard, truncated `_Log` entry); all
  three fixed in `7bfbf21d`. Re-review pending.
- Claude SMR posted at `7bfbf21d`: MERGE-READY.

## Window of value

- PR #1536 (`validateDataplaneTypeStrict`) merged at fcd53beb on
  master.
- PR #1556 (multierror strict-validator refactor) merged at
  b7466f5d on master. Option A's nil clear is placed AFTER both
  `validateDataplaneTypeStrict` (fail-fast) AND
  `errors.Join(strictErrs...)` (multierror) in `compileExpanded`,
  so it runs only on the full success path.
- Issue #1528 (Phase 3 mechanical removal of `DPDKConfig`,
  `DPDKDataplane` field, `pkg/dataplane/dpdk/`, `dpdk_worker/`)
  is OPEN with no PR drafted yet.

Until #1528 lands, the AST-leakage class is reachable. After
#1528 lands, both Option A's nil clear and the entire canary
file become dead code and are removed mechanically with the
schema deletion.

## Acceptable bounded limitations (Option A mitigates both)

- Local-variable rebinding: a gated assign to a local followed
  by an ungated use of the local. The canary cannot follow
  def-use through local vars; Option A guarantees the local is
  nil at runtime.
- Struct-field storage: storing the pointer in a struct field
  and accessing the field later. Same mitigation.

## Test plan

- [x] `go test ./pkg/config/` — full pkg/config suite (cached pass).
- [x] `go test ./pkg/config/ -run TestDPDKSubtreeLeakageCanary -count=5` — 5x flake-clean.
- [x] `go test ./...` — all 30 packages pass.
- [x] `go vet ./pkg/config/` — clean (pre-existing vet warnings in flowexport / cli / daemon unrelated).
- [x] Negative-fixture sub-tests fire on each documented escape path (ungated read, helper pass-through, wrong-type branch, multi-case switch, negation idiom, multi-LHS bypass, package-scope initializer).
- [x] Positive-fixture sub-tests accept the canonical if-gate, switch single-case-gate, and nested-gated read.
- [x] `TestDPDKSubtreeLeakageCanary_RealRepoIsClean` — real `pkg/config/` scan returns zero findings.
- [ ] Smoke matrix (smoke-runner: Pass A + Pass B) — runtime
  verification that Option A's nil clear does not regress
  dataplane behavior on commit / commit-check.

## Refs

Closes #1539. Refs #1525, #1536, #1556, #1528.

Plan: `docs/pr/1539-ast-leakage-guard/plan.md` (v3 PLAN-READY).
Reviewer-IDs: `docs/pr/1539-ast-leakage-guard/reviewer-ids.md`.

Generated with [Claude Code](https://claude.com/claude-code)
