### PR TITLE
grpcapi: migrate off legacy dataplane.DataPlane (#1516, sub-#1451 S1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -3161,3 +3161,18 @@
   green. Smoke matrix delegated to serialized smoke-runner singleton
   per feedback_smoke_serialized_single_agent rule (AWAITING-SMOKE
   marker posted on PR).
+
+- **Timestamp**: 2026-05-25T16:05Z
+- **Action**: #1554 r3 Copilot finding fold — cross-package compile-time
+  interface-satisfaction guard. The userspace-side compile-time check
+  is method-shape-only (inline anonymous interface) and can't catch
+  drift if the unexported pkg/grpcapi interfaces (grpcRuntime,
+  sessionCursorIterator, userspaceStatusProvider,
+  userspaceControlProvider) acquire a new method. Adding the asymmetric
+  guard in pkg/grpcapi/runtime_canary_test.go: `var _ grpcRuntime =
+  (*dpuserspace.LegacyDataPlaneAdapter)(nil)` plus the same for each
+  named provider interface. _test.go scope keeps the assertions out
+  of the production binary.
+- **File(s)**: pkg/grpcapi/runtime_canary_test.go (new), _Log.md
+- **Validation**: go test ./pkg/grpcapi/... -count=1 green; full Go
+  suite green.

--- a/_Log.md
+++ b/_Log.md
@@ -584,8 +584,6 @@
   - **File(s)**: `docs/pr/1516-grpcapi-migration/plan.md`,
     `_Log.md`.
 
-## 2026-05-25
-
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR
     (load merge syntax in plan recovery) + 3 Copilot nits:

--- a/_Log.md
+++ b/_Log.md
@@ -3132,3 +3132,34 @@
   registry so #1476 can retire legacy pinning without grep-and-pray. Plan
   preserves PR #1514's documented `userspace_fallback_stats` mixed-version
   compatibility exception verbatim. Pending Codex + AGY plan review.
+- **Timestamp**: 2026-05-25T15:10Z
+- **Action**: #1516 (sub-#1451 S1) — implement plan v2 migrating
+  pkg/grpcapi off legacy dataplane.DataPlane. New
+  pkg/grpcapi/runtime.go declares grpcRuntime narrow interface plus
+  userspaceStatusProvider/userspaceControlProvider/sessionCursorIterator
+  named providers. server.go field type Config.DP and Server.dp swap
+  dataplane.DataPlane → grpcRuntime; inline anonymous interface
+  assertions in server.go, server_show_forwarding.go, server_show.go
+  collapse to the named provider assertions. server_sessions.go
+  sessionIteratorFrom renamed to sessionCursorIterator and moved to
+  runtime.go. AGY r1 PLAN-NEEDS-MAJOR finding (userspace cursor
+  pagination silently degrades because LegacyDataPlaneAdapter does
+  not implement IterateSessionsFrom/V6From) addressed by adding
+  delegation methods on LegacyDataPlaneAdapter (assert embedded
+  a.DataPlane against cursor-iterator interface and forward to
+  bpfShim). Canary allowlist + retirement docs table updated:
+  pkg/grpcapi/runtime.go added, pkg/grpcapi/server.go removed (no
+  longer imports pkg/dataplane).
+- **File(s)**: pkg/grpcapi/runtime.go (new), pkg/grpcapi/server.go,
+  pkg/grpcapi/server_sessions.go, pkg/grpcapi/server_show.go,
+  pkg/grpcapi/server_show_forwarding.go,
+  pkg/dataplane/userspace/legacy_dataplane.go,
+  pkg/dataplane/retirement_boundary_canary_test.go,
+  docs/pr/1373-retire-ebpf-dataplane/README.md,
+  docs/pr/1516-grpcapi-migration/plan.md (v2).
+- **Validation**: GOCACHE/GOTMPDIR full Go suite green (30+ packages),
+  pkg/grpcapi 5/5 race flake check clean, cargo --release build
+  clean (114 pre-existing warnings only). Boundary canary tests
+  green. Smoke matrix delegated to serialized smoke-runner singleton
+  per feedback_smoke_serialized_single_agent rule (AWAITING-SMOKE
+  marker posted on PR).

--- a/_Log.md
+++ b/_Log.md
@@ -570,6 +570,21 @@
   - **Validation**: go build ./... clean; go test
     ./pkg/dataplane/userspace/... ok; canaries 5/5 pass;
     go test ./... — all 30 packages green.
+- **Timestamp**: 2026-05-25T08:00:00Z
+  - **Action**: #1516 plan v1 — sub-#1451 S1 migration scope.
+    Drafted `docs/pr/1516-grpcapi-migration/plan.md`: new
+    `pkg/grpcapi/runtime.go` declaring `grpcRuntime` interface
+    (~25 methods) plus named provider interfaces
+    (`sessionCursorIterator`, `userspaceStatusProvider`,
+    `userspaceControlProvider`). `Config.DP` and `Server.dp`
+    move from `dataplane.DataPlane` to `grpcRuntime`. Issue
+    body's `ReadNATPortCounter` and `Compile` are stale — not
+    consumed on master @ fcd53beb. Pending Codex + AGY plan-
+    review.
+  - **File(s)**: `docs/pr/1516-grpcapi-migration/plan.md`,
+    `_Log.md`.
+
+## 2026-05-25
 
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR

--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -275,7 +275,7 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/daemon/daemon_ha_userspace.go` | Userspace HA control still crosses the legacy bridge. |
 | `pkg/daemon/daemon_run.go` | Runtime wiring still passes `legacyDP()` to unmigrated services. |
 | `pkg/grpcapi/apply_result.go` | gRPC apply metadata still adapts legacy apply results. |
-| `pkg/grpcapi/server.go` | gRPC server construction still stores the legacy bridge. |
+| `pkg/grpcapi/runtime.go` | #1516 — `grpcRuntime` interface declares the narrow gRPC dataplane surface; still depends on root `pkg/dataplane` type names (`SessionKey`, `CounterValue`, etc.) until those types move to a domain package. |
 | `pkg/grpcapi/server_helpers.go` | gRPC helpers still format legacy dataplane types and bridge runtime accessors. |
 | `pkg/grpcapi/server_sessions.go` | gRPC session RPCs still use legacy session types. |
 | `pkg/grpcapi/server_show.go` | gRPC show dispatcher still reaches legacy dataplane state. |

--- a/docs/pr/1516-grpcapi-migration/plan.md
+++ b/docs/pr/1516-grpcapi-migration/plan.md
@@ -1,0 +1,381 @@
+# #1516 plan — migrate `pkg/grpcapi` off legacy `dataplane.DataPlane`
+
+**Status:** DRAFT v1 — pending adversarial plan review.
+
+## 1. Issue framing
+
+Issue #1516 asks: stop exposing the full `dataplane.DataPlane`
+interface across `pkg/grpcapi`. Replace `Config.DP` and `Server.dp`
+with a narrow, package-local `grpcRuntime` interface declared in a
+new `pkg/grpcapi/runtime.go`, sized to exactly the methods the gRPC
+server actually consumes. Fold the existing inline
+`s.dp.(interface{...})` provider-probe type assertions into named
+provider interfaces declared in the same file. The daemon continues
+to pass the same `*userspace.LegacyDataPlaneAdapter` (or the legacy
+eBPF dataplane during regression runs) into the new typed field
+without any boot-side rewiring.
+
+This is sub-issue S1 of #1451 — the eBPF retirement decomposition.
+The migration target and pattern come directly from
+`docs/pr/1451-migration-scope/scope.md` and the already-shipped
+`pkg/api` precedent (`apiRuntimeDataPlane` in
+`pkg/api/handlers.go:28`).
+
+## 2. Honest scope / value framing
+
+This is **boundary tightening, not behavioral change**. The win
+is purely structural:
+
+- Removes one of the two large remaining direct importers of
+  `dataplane.DataPlane` (the other is `pkg/cli`, sub-issue #1517).
+- Lets future deletions of legacy interface methods compile-fail at
+  the `pkg/grpcapi/runtime.go` boundary rather than scatter across
+  ~15 handler files.
+- Makes the userspace-specific provider extensions
+  (`Status`, `SetForwardingArmed`, `SetQueueState`,
+  `SetBindingState`, `InjectPacket`) explicit named interfaces
+  rather than inline anonymous type assertions, so they can be
+  evolved independently of the legacy shape.
+
+No measurable runtime impact at all — the same concrete type is
+still passed in, the same methods are still called, the call graph
+is identical. The dispatch path goes through a Go interface today
+and still goes through a Go interface tomorrow; the only thing
+that changes is the static type the gRPC server sees.
+
+*If reviewers conclude the structural win is too small to justify
+the churn, or that the methodology violates a constraint not visible
+in the scope doc, PLAN-KILL is an acceptable verdict.*
+
+## 3. What's already shipped / partially done
+
+- **`pkg/api`** — `apiRuntimeDataPlane` in `pkg/api/handlers.go:28`
+  (10-method subset). Canonical pattern for this migration.
+- **`pkg/fwdstatus`** — `DataPlaneAccessor` in `builder.go:35`.
+- **`pkg/monitoriface`** — `RuntimeDataPlane` in `monitor.go:30`.
+- **`pkg/conntrack`** — `NewGC(provider RuntimeDomainProvider, …)`
+  with no `DataPlane` parameter on either constructor.
+- The daemon already exposes the legacy interface via
+  `Daemon.legacyDP() dataplane.DataPlane`
+  (`pkg/daemon/daemon.go:348`); the userspace backend already
+  bridges through `pkg/dataplane/userspace/legacy_dataplane.go`.
+  No daemon-side rewiring is needed for this step beyond changing
+  the field type on `grpcapi.Config.DP`.
+
+## 4. Concrete design
+
+### 4.1 New file `pkg/grpcapi/runtime.go`
+
+Declares one main runtime interface plus four named provider
+interfaces.
+
+```go
+package grpcapi
+
+import (
+    "github.com/psaab/xpf/pkg/dataplane"
+    dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// grpcRuntime is the gRPC server's domain-specific dataplane
+// surface. Listed exactly to the methods the gRPC handlers
+// consume on master @ fcd53beb. Narrower than
+// dataplane.DataPlane; intentionally not exported.
+type grpcRuntime interface {
+    // Liveness probe — guards every counter / iter call site.
+    IsLoaded() bool
+
+    // Counters (read).
+    ReadGlobalCounter(index uint32) (uint64, error)
+    ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error)
+    ReadZoneCounters(zoneID uint16, direction int) (dataplane.CounterValue, error)
+    ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error)
+    ReadFilterConfig(filterID uint32) (dataplane.FilterConfig, error)
+    ReadFilterCounters(ruleIdx uint32) (dataplane.CounterValue, error)
+    ReadFloodCounters(zoneID uint16) (dataplane.FloodState, error)
+    ReadNATRuleCounter(counterID uint32) (dataplane.CounterValue, error)
+
+    // Counters (clear) — diag/clear paths.
+    ClearPolicyCounters() error
+    ClearFilterCounters() error
+    ClearNATRuleCounters() error
+    ClearAllCounters() error
+
+    // Session store (read).
+    IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+    IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+    GetSessionV4(key dataplane.SessionKey) (dataplane.SessionValue, error)
+    GetSessionV6(key dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
+    SessionCount() (v4, v6 int)
+
+    // Session store (clear / delete) — `clear security flow session ...`.
+    ClearAllSessions() (v4 int, v6 int, err error)
+    DeleteSession(key dataplane.SessionKey) error
+    DeleteSessionV6(key dataplane.SessionKeyV6) error
+    DeleteDNATEntry(key dataplane.DNATKey) error
+    DeleteDNATEntryV6(key dataplane.DNATKeyV6) error
+
+    // NAT bindings / system buffers.
+    GetPersistentNAT() *dataplane.PersistentNATTable
+    GetMapStats() []dataplane.MapStats
+}
+
+// sessionCursorIterator: optional cursor-based iteration; consumed via
+// type assertion in server_sessions.go:getSessionsCursor. Userspace
+// adapter implements it; legacy eBPF does not. Falls through to
+// legacy full-table scan when absent.
+type sessionCursorIterator interface {
+    IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+    IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+}
+
+// userspaceStatusProvider: probe for the userspace-specific Status()
+// call. Used by:
+//   - userspaceDataplaneStatus() in server.go
+//   - forwardingStatusDataplane() in server_show_forwarding.go
+//   - server_show.go "buffers" / "buffers-detail" topics
+type userspaceStatusProvider interface {
+    Status() (dpuserspace.ProcessStatus, error)
+}
+
+// userspaceControlProvider: superset of statusProvider used by the
+// diag/control path (queue/binding admin, forwarding-armed, inject).
+// Used by userspaceDataplaneControl() in server.go.
+type userspaceControlProvider interface {
+    userspaceStatusProvider
+    SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
+    SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+    SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+    InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
+}
+```
+
+### 4.2 `server.go` edits
+
+```go
+type Config struct {
+    Store     *configstore.Store
+    DP        grpcRuntime   // was dataplane.DataPlane
+    ...
+}
+
+type Server struct {
+    pb.UnimplementedBpfrxServiceServer
+    store *configstore.Store
+    dp    grpcRuntime       // was dataplane.DataPlane
+    ...
+}
+
+func (s *Server) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
+    provider, ok := s.dp.(userspaceStatusProvider)
+    if !ok {
+        return dpuserspace.ProcessStatus{}, fmt.Errorf("userspace status unavailable")
+    }
+    return provider.Status()
+}
+
+func (s *Server) userspaceDataplaneControl() (userspaceControlProvider, error) {
+    provider, ok := s.dp.(userspaceControlProvider)
+    if !ok {
+        return nil, fmt.Errorf("userspace dataplane control unavailable")
+    }
+    return provider, nil
+}
+```
+
+### 4.3 Inline `interface{…}` consolidations
+
+- `server_show_forwarding.go:68` `s.dp.(interface { Status() … })`
+  → `s.dp.(userspaceStatusProvider)`.
+- `server_show.go:1730` and `:1786` `s.dp.(interface { Status() … })`
+  → `s.dp.(userspaceStatusProvider)`.
+- `server_sessions.go:46` keep the local `sessionIteratorFrom`
+  declaration but rename to `sessionCursorIterator` and move it into
+  `pkg/grpcapi/runtime.go` so the cursor-iteration provider is in
+  one place with the others. The type assertion at
+  `server_sessions.go:56` becomes `s.dp.(sessionCursorIterator)`.
+
+### 4.4 Daemon wiring (no change required)
+
+`pkg/daemon/daemon_run.go:763` already does `DP: d.legacyDP()`.
+`d.legacyDP()` returns `dataplane.DataPlane` — the concrete adapter
+type satisfies `grpcRuntime` plus the optional providers because
+`dataplane.DataPlane` is a strict superset of `grpcRuntime`'s method
+set. No daemon-side edit is needed. (Compile will catch it if I'm
+wrong about the superset claim.)
+
+## 5. Public API preservation
+
+- `grpcapi.Config` and `grpcapi.NewServer(addr, cfg)` keep the same
+  exported names and the same positional fields. The only API change
+  is the **declared type** of `Config.DP`. Existing callers
+  (`pkg/daemon/daemon_run.go` only) compile unchanged because the
+  concrete value passed in (`d.legacyDP()`) satisfies the narrower
+  interface.
+- gRPC wire surface (`proto/xpf/v1`) — untouched.
+- `grpcapi.Server` is opaque to external callers (its fields are
+  unexported); the change to `dp` field type is invisible.
+
+## 6. Hidden invariants the change must preserve
+
+1. **Liveness gating.** Every counter/iter call site that today
+   reads `if s.dp == nil || !s.dp.IsLoaded() { ... }` keeps that
+   exact gate. The new `grpcRuntime` interface intentionally
+   exposes `IsLoaded()` so the nil-guard pattern compiles
+   unchanged.
+
+2. **Provider-probe semantics.** Today's anonymous
+   `interface{ Status() (ProcessStatus, error) }` type assertion
+   matches the userspace adapter at runtime. The named
+   `userspaceStatusProvider` interface in the new file MUST have
+   exactly the same method signature so the assertion result is
+   identical. (Go interface satisfaction is structural; renaming the
+   interface doesn't change which concrete types satisfy it as long
+   as the method set is identical.)
+
+3. **Cursor-iteration fallback.** `getSessionsCursor` falls through
+   to `getSessionsLegacy` when the type assertion fails. The
+   userspace adapter must continue to satisfy the renamed
+   `sessionCursorIterator`; verify by grep against
+   `pkg/dataplane/userspace/legacy_dataplane.go`.
+
+4. **Clear-counter side effects.** `ClearAllCounters`,
+   `ClearPolicyCounters`, `ClearFilterCounters`,
+   `ClearNATRuleCounters`, and `ClearAllSessions` all mutate
+   dataplane state. They are reached via `clear` RPCs through
+   `server_diag.go`, `server_cluster.go`, `server_sessions.go`. The
+   migration does not move these methods or alter their semantics;
+   it only changes the static type they're called on.
+
+5. **DeleteDNATEntry / DeleteSession ordering.** In
+   `server_sessions.go` around line 740–820 the filtered-clear
+   path issues `DeleteSession` then `DeleteDNATEntry` per matched
+   entry. The ordering is preserved because the migration is
+   signature-only.
+
+## 7. Risk assessment
+
+| Class | Risk | Notes |
+|---|---|---|
+| Behavioral regression | LOW | No runtime path changes; signature-only. |
+| Lifetime / borrow-checker | N/A | Go, no lifetimes. |
+| Performance regression | LOW | Same interface dispatch (one method-table indirection); narrower interfaces can in principle be marginally faster but the win is unmeasurable. |
+| Architectural mismatch (#961 / #946-Phase-2 dead-end) | LOW | This isn't an architecture change — it's a boundary tightening that already shipped in three sibling packages with identical shape. The wrong-target pattern is paint-by-numbers, not invention. |
+
+The only non-trivial risk is **method-set drift between the issue
+body and master**. The issue body lists `ReadNATPortCounter` and
+`Compile` as consumed via `s.dp`, but `grep -rn` on master @
+fcd53beb finds neither. The new interface lists what the code
+actually uses today; if reviewers want a strict superset of "what
+the issue body says," that's a different design and they can ask
+me to add the two stale methods. I'd argue against — an unused
+method on the interface defeats the boundary's purpose.
+
+## 8. Test plan
+
+- `make build` — package compiles, no Go vet warnings.
+- `make test ./pkg/grpcapi/...` — full `pkg/grpcapi` test suite
+  green. (Issue acceptance.)
+- `make test ./pkg/api/... ./pkg/cli/... ./pkg/daemon/... ./pkg/conntrack/...`
+  — adjacent packages still build because nothing outside `pkg/grpcapi`
+  imports `grpcapi.grpcRuntime`.
+- `make test` — full Go suite to confirm no incidental breakage.
+- 5× named-test flake check on `TestSessionsCursorIteration` and
+  `TestForwardingStatusAdapter` (the two test files that pin the
+  provider-probe behavior, per `server_sessions_test.go` and
+  `server_show_forwarding_adapter_test.go`).
+- Deploy on `loss:xpf-userspace-fw0/fw1`.
+- **Pass A (CoS disabled):** v4 + v6 × push + reverse on port
+  5201, plus 12-stream `-R` reproducer on v4 and v6.
+- **Pass B (CoS enabled):** per-class 5201-5206 × v4 + v6 ×
+  push + reverse = 24 measurements.
+- Manual gRPC-surface validation from the remote CLI on the loss
+  cluster:
+  - `show security flow session` — exercises
+    `IterateSessions{,V6}` + `GetSessionV4/V6`.
+  - `show security flow statistics` — exercises
+    `ReadGlobalCounter`.
+  - `clear security flow session all` — exercises
+    `ClearAllSessions`.
+  - `show system buffers` — exercises the
+    `userspaceStatusProvider` and `GetMapStats` fallback.
+  - `show chassis forwarding` — exercises the
+    `userspaceStatusProvider` path in
+    `forwardingStatusDataplane()`.
+
+## 9. Out of scope (explicitly)
+
+- `pkg/cli` migration (sub-issue #1517).
+- `pkg/cluster` session-sync migration (sub-issue #1518).
+- Removing `Daemon.legacyDP()` accessor (sub-issue #1519).
+- `pkg/dataplane.New()` boot-path extraction (sub-issue #1520).
+- `pkg/dataplane/userspace/maps_sync.go` BPF map name decoupling
+  (sub-issue #1521).
+- Splitting `grpcRuntime` into multiple smaller domain interfaces
+  (counter-reader, session-store-clear, diag-clear) within
+  `pkg/grpcapi`. The scope doc mentions this as a possible follow-up
+  if S1 itself feels too large; I'm not doing it here because the
+  whole-package interface is what already shipped for `pkg/api`.
+
+## 10. Open questions for adversarial review
+
+Each of these is a legitimate basis to vote PLAN-KILL.
+
+1. **Is one whole-package `grpcRuntime` interface the right shape,
+   or should it be split into named sub-interfaces by domain
+   (counters, session-store, NAT bindings, diag-clear) so the
+   coupling is even narrower?** Codex/AGY should walk
+   `server_show_*.go` files and decide whether the sub-interface
+   split would make handler signatures more honest (a show handler
+   doesn't need clear methods).
+
+2. **Stale-method handling.** The issue body lists
+   `ReadNATPortCounter` and `Compile` as consumed via `s.dp` but
+   master doesn't actually use them. Should the new interface
+   include them anyway for forward compatibility, or drop them
+   because the boundary's job is to reflect actual coupling?
+
+3. **`sessionCursorIterator` placement.** It's used only inside
+   `server_sessions.go`. Moving it to `runtime.go` consolidates it
+   with the other provider interfaces but may obscure its
+   single-call-site relationship. Keep it local, move it global, or
+   inline-define both at every call site?
+
+4. **`userspaceControlProvider` shape.** The control interface
+   includes five methods that are called from a single handler each
+   (queue/binding state, forwarding-armed, inject). Is it cleaner
+   to define five micro-interfaces (one per control method) or one
+   superset like the plan shows?
+
+5. **Boundary regression canary.** `pkg/dataplane/userspace/manager_coupling_test.go`
+   uses an AST-walking canary to enforce the eBPF/userspace
+   boundary. Should this PR add a similar canary for
+   `pkg/grpcapi/runtime.go` to prevent a future regression that
+   re-imports `dataplane.DataPlane` into `grpcapi.Config.DP`? I am
+   not adding one in this PR because it's a meta-concern that
+   applies equally to every #1451 sub-issue; if you think it should
+   land here, justify why this sub-issue is the right place rather
+   than #1476.
+
+6. **Architectural mismatch risk.** Is there any reason this
+   tightening is the wrong move — e.g. an in-flight change that
+   wants the gRPC server to stay coupled to the full interface, or
+   a future plan where the legacy `DataPlane` shape is the only
+   thing that survives and the domain interfaces get deleted?
+
+7. **Test coverage adequacy.** Existing `server_sessions_test.go`
+   and `server_show_forwarding_adapter_test.go` test the
+   provider-probe behavior with concrete fakes. Is that sufficient
+   coverage, or should the PR add explicit "fake satisfies
+   `grpcRuntime`" compile-time assertions in test code?
+
+## References
+
+- `docs/pr/1451-migration-scope/scope.md` — sub-issue boundary
+  definition.
+- `pkg/api/handlers.go:28` — `apiRuntimeDataPlane` precedent.
+- `pkg/fwdstatus/builder.go:35` — `DataPlaneAccessor` precedent.
+- `pkg/monitoriface/monitor.go:30` — `RuntimeDataPlane` precedent.
+- `pkg/conntrack` — `RuntimeDomainProvider` precedent.
+
+Refs: #1516, #1451, #1373.

--- a/docs/pr/1516-grpcapi-migration/plan.md
+++ b/docs/pr/1516-grpcapi-migration/plan.md
@@ -1,6 +1,8 @@
 # #1516 plan — migrate `pkg/grpcapi` off legacy `dataplane.DataPlane`
 
-**Status:** DRAFT v1 — pending adversarial plan review.
+**Status:** v2 — folds AGY round-1 PLAN-NEEDS-MAJOR finding on
+userspace cursor pagination plus the omitted canary/docs touchpoint.
+Codex round-1 retry pending (`task-mplca3od-d7w9gy`).
 
 ## 1. Issue framing
 
@@ -203,6 +205,38 @@ type satisfies `grpcRuntime` plus the optional providers because
 `dataplane.DataPlane` is a strict superset of `grpcRuntime`'s method
 set. No daemon-side edit is needed. (Compile will catch it if I'm
 wrong about the superset claim.)
+
+### 4.5 Userspace cursor-pagination repair (AGY r1 finding)
+
+AGY r1 found that the cursor pagination type assertion at
+`server_sessions.go:56` silently fails under the userspace dataplane
+because `LegacyDataPlaneAdapter` embeds the `dataplane.DataPlane`
+interface, not the concrete `*dataplane.Manager`. `IterateSessionsFrom`
+and `IterateSessionsV6From` are concrete methods on `*Manager` that
+are NOT part of the `dataplane.DataPlane` interface, so Go's method
+promotion does not lift them onto `LegacyDataPlaneAdapter`. Today the
+gRPC server's cursor pagination handler in
+`server_sessions.go:getSessionsCursor` already falls through to the
+legacy full-table scan when the assertion fails — under userspace
+this is the silent default.
+
+For boundary tightening to be honest, this fallback should be
+visible-or-fixed. The plan now ships the fix: add
+`IterateSessionsFrom` and `IterateSessionsV6From` as delegation
+methods on `LegacyDataPlaneAdapter`, asserting the embedded
+`a.DataPlane` against the cursor-iterator interface and forwarding
+to `bpfShim`. If the embedded interface field is non-nil and the
+underlying concrete value is `*dataplane.Manager`, the assertion
+succeeds and the cursor path runs as designed. If it does not (e.g.
+the userspace manager is constructed without a bpfShim, as in some
+unit tests), the method returns a typed error and `getSessionsCursor`
+still falls through to `getSessionsLegacy`.
+
+The added methods are paint-by-numbers delegation; they do not
+introduce any new dataplane behavior. They are intentionally scoped
+to this sub-issue because the alternative (extending the
+`dataplane.DataPlane` interface) widens the very surface #1516 is
+narrowing.
 
 ## 5. Public API preservation
 

--- a/docs/pr/1516-grpcapi-migration/reviewer-ids.md
+++ b/docs/pr/1516-grpcapi-migration/reviewer-ids.md
@@ -29,3 +29,20 @@ so a fresh session can `result <id>` without re-dispatching.
 - Copilot: `@copilot review` posted to PR #1554; awaiting.
 - Claude SMR review: posted as PR comment 4535284297, verdict MERGE-READY.
 - Dispatched: 2026-05-25T15:25Z (approx).
+- **r1 verdicts** (head `bace61ac`):
+  - AGY adversarial-review-mplcffbz-bwa6fo: **MERGE-NEEDS-MINOR** (cursor fallback regression + missing tests).
+  - Codex task-mplcj462-u4wie3: **MERGE-NEEDS-MINOR** (same cursor finding + same test gap).
+  - Copilot: COMMENTED with 3 inline comments (grammar nit, README.md request, _Log.md duplicate header).
+  - Claude SMR: MERGE-READY (acknowledged the test-coverage minor but ruled it acceptable).
+
+## Code review round 2 (head `d74e2805` — r1 follow-up)
+
+- Codex task: `task-mplcuy5p-63l4qu` — **MERGE-READY**, no findings. Verified sentinel identity flow, production-delegation path, fallback semantics, compile-time guard, and r1 test coverage.
+- AGY job: `adversarial-review-mplcugio-dm2nh7` — **MERGE-READY**, all 5 hostile checks PASS.
+- Copilot review #2 (2026-05-25T15:24Z) — COMMENTED with no new findings (all 3 r1 inline comments addressed; reviewed 13/13 files).
+- Claude SMR — MERGE-READY across all three lenses (verified inline above).
+- Dispatched: 2026-05-25T16:00Z (approx).
+
+## Final state
+
+All four reviewers converged MERGE-READY on head `d74e2805`. PR-body checklist still has the AWAITING-SMOKE box unchecked; explicit `<!-- AWAITING-SMOKE -->` marker posted as PR comment 4535361953 for the serialized smoke-runner singleton per `feedback_smoke_serialized_single_agent`. Auto-merge fires on smoke-pass per `feedback_auto_merge_on_clean_triple`.

--- a/docs/pr/1516-grpcapi-migration/reviewer-ids.md
+++ b/docs/pr/1516-grpcapi-migration/reviewer-ids.md
@@ -1,0 +1,21 @@
+# #1516 reviewer task / job IDs
+
+Codex session state and AGY jobs are short-lived and have been lost
+multiple times in this session — record every reviewer task/job here
+so a fresh session can `result <id>` without re-dispatching.
+
+## Plan review round 1
+
+- Plan commit: `b24920843e24397f368ea9ebb7ee6f0347498995` on branch
+  `refactor/1516-grpcapi-migration`.
+- Codex task: `task-mpkukwdq-22oq22` — INFRA-BLOCKED (sandbox/process spawn errors); no PLAN verdict.
+- AGY job: `adversarial-review-mpkulcas-lijmxg` — not found in `agy status` (likely expired with session); no verdict captured.
+- Dispatched: 2026-05-25T08:05Z
+
+## Plan review round 1 — retry (continuation agent)
+
+- Plan commit: same `b24920843e24397f368ea9ebb7ee6f0347498995`.
+- Codex task: `task-mplby5sb-3pe41w` (retry attempt 1) — not visible in `codex:status` (dispatched from wrong cwd in companion; never reached runtime).
+- Codex task: `task-mplca3od-d7w9gy` (retry attempt 2 — tracked, running).
+- AGY job: `adversarial-review-mplbyiom-1hw3em` — **PLAN-NEEDS-MAJOR**: cursor pagination silently degrades to full-table scan on userspace because `LegacyDataPlaneAdapter` does NOT implement `IterateSessionsFrom/V6From`. AGY proactively applied the fix (delegation through `a.DataPlane.(interface{...})` assertion onto bpfShim). Verified against master: finding is correct; AGY's edit accepted.
+- Dispatched: 2026-05-25T14:55Z (approx).

--- a/docs/pr/1516-grpcapi-migration/reviewer-ids.md
+++ b/docs/pr/1516-grpcapi-migration/reviewer-ids.md
@@ -16,6 +16,16 @@ so a fresh session can `result <id>` without re-dispatching.
 
 - Plan commit: same `b24920843e24397f368ea9ebb7ee6f0347498995`.
 - Codex task: `task-mplby5sb-3pe41w` (retry attempt 1) — not visible in `codex:status` (dispatched from wrong cwd in companion; never reached runtime).
-- Codex task: `task-mplca3od-d7w9gy` (retry attempt 2 — tracked, running).
+- Codex task: `task-mplca3od-d7w9gy` (retry attempt 2): infra-blocked, sandbox spawn ENOENT.
+- Codex task: `task-mplccf45-mqpegg` (retry attempt 3 — inline plan/runtime embedded to bypass sandbox file-read failures): **PLAN-READY**. Only caveat — make sure the LegacyDataPlaneAdapter delegation error path doesn't surface a new user-visible error vs the master behavior. Codex notes "execution detail, not a plan blocker." Accepted: in production (bpfShim non-nil + *dataplane.Manager concrete) the assertion succeeds and the methods return without error; in test/edge configurations the error path is logged via grpc Internal status, which is a strict improvement over the silent-legacy-fallback behavior on master.
 - AGY job: `adversarial-review-mplbyiom-1hw3em` — **PLAN-NEEDS-MAJOR**: cursor pagination silently degrades to full-table scan on userspace because `LegacyDataPlaneAdapter` does NOT implement `IterateSessionsFrom/V6From`. AGY proactively applied the fix (delegation through `a.DataPlane.(interface{...})` assertion onto bpfShim). Verified against master: finding is correct; AGY's edit accepted.
 - Dispatched: 2026-05-25T14:55Z (approx).
+
+## Code review round 1 (PR #1554, head `bace61ac`)
+
+- Codex task: `task-mplcfzo7-gz2wgj` (dispatched from worktree cwd — not tracked by companion runtime).
+- Codex task: `task-mplcj462-u4wie3` (re-dispatched from /home/ps/git/bpfrx root with inline diff to bypass sandbox file-read failures).
+- AGY job: `adversarial-review-mplcffbz-bwa6fo`.
+- Copilot: `@copilot review` posted to PR #1554; awaiting.
+- Claude SMR review: posted as PR comment 4535284297, verdict MERGE-READY.
+- Dispatched: 2026-05-25T15:25Z (approx).

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -54,7 +54,7 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/daemon/daemon_ha_userspace.go":        "userspace HA control still crosses the legacy bridge",
 	"pkg/daemon/daemon_run.go":                 "runtime wiring still passes legacyDP to unmigrated services",
 	"pkg/grpcapi/apply_result.go":              "gRPC apply metadata still adapts legacy apply results",
-	"pkg/grpcapi/server.go":                    "gRPC server constructor still stores the legacy bridge",
+	"pkg/grpcapi/runtime.go":                   "#1516 grpcRuntime interface declares the narrow gRPC dataplane surface; still depends on root pkg/dataplane type names (SessionKey, CounterValue, etc.) until those types move to a domain package",
 	"pkg/grpcapi/server_helpers.go":            "gRPC helpers still format legacy dataplane types and bridge runtime accessors",
 	"pkg/grpcapi/server_sessions.go":           "gRPC session RPCs still use legacy session types",
 	"pkg/grpcapi/server_show.go":               "gRPC show dispatcher still reaches legacy dataplane state",

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -458,3 +458,28 @@ func (a *LegacyDataPlaneAdapter) TakeoverReady() (bool, []string) {
 	}
 	return m.TakeoverReady()
 }
+
+func (a *LegacyDataPlaneAdapter) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	if a == nil || a.DataPlane == nil {
+		return errors.New("nil dataplane")
+	}
+	if iter, ok := a.DataPlane.(interface {
+		IterateSessionsFrom(*dataplane.SessionKey, func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	}); ok {
+		return iter.IterateSessionsFrom(cursor, fn)
+	}
+	return errors.New("underlying dataplane does not support IterateSessionsFrom")
+}
+
+func (a *LegacyDataPlaneAdapter) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	if a == nil || a.DataPlane == nil {
+		return errors.New("nil dataplane")
+	}
+	if iter, ok := a.DataPlane.(interface {
+		IterateSessionsV6From(*dataplane.SessionKeyV6, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	}); ok {
+		return iter.IterateSessionsV6From(cursor, fn)
+	}
+	return errors.New("underlying dataplane does not support IterateSessionsV6From")
+}
+

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -474,27 +474,45 @@ func (a *LegacyDataPlaneAdapter) TakeoverReady() (bool, []string) {
 	return m.TakeoverReady()
 }
 
+// ErrCursorIterationUnsupported is returned by
+// LegacyDataPlaneAdapter.IterateSessionsFrom and
+// IterateSessionsV6From when the underlying wrapped dataplane does
+// not expose cursor-based iteration. Callers that probe for cursor
+// support via type assertion (e.g. gRPC pagination) MUST detect
+// this error and fall back to non-cursor iteration so the user-
+// visible behavior matches the master/pre-#1516 path on
+// dataplanes that lack cursor support.
+//
+// In production the wrapped dataplane is a *dataplane.Manager (set
+// by NewLegacyDataPlaneAdapter from manager.bpfShim) which does
+// implement cursor iteration, so the production code path never
+// returns this sentinel. The sentinel guards test/edge
+// configurations where the adapter is constructed with a nil
+// manager or with an embedded DataPlane that does not implement
+// cursor iteration.
+var ErrCursorIterationUnsupported = errors.New("underlying dataplane does not support cursor iteration")
+
 func (a *LegacyDataPlaneAdapter) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
 	if a == nil || a.DataPlane == nil {
-		return errors.New("nil dataplane")
+		return ErrCursorIterationUnsupported
 	}
 	if iter, ok := a.DataPlane.(interface {
 		IterateSessionsFrom(*dataplane.SessionKey, func(dataplane.SessionKey, dataplane.SessionValue) bool) error
 	}); ok {
 		return iter.IterateSessionsFrom(cursor, fn)
 	}
-	return errors.New("underlying dataplane does not support IterateSessionsFrom")
+	return ErrCursorIterationUnsupported
 }
 
 func (a *LegacyDataPlaneAdapter) IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
 	if a == nil || a.DataPlane == nil {
-		return errors.New("nil dataplane")
+		return ErrCursorIterationUnsupported
 	}
 	if iter, ok := a.DataPlane.(interface {
 		IterateSessionsV6From(*dataplane.SessionKeyV6, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
 	}); ok {
 		return iter.IterateSessionsV6From(cursor, fn)
 	}
-	return errors.New("underlying dataplane does not support IterateSessionsV6From")
+	return ErrCursorIterationUnsupported
 }
 

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -14,6 +14,21 @@ import (
 var _ dataplane.DataPlane = (*LegacyDataPlaneAdapter)(nil)
 var _ dataplane.RuntimeDataPlane = (*LegacyDataPlaneAdapter)(nil)
 
+// #1516 sub-#1451 S1 — guard against signature drift on the
+// LegacyDataPlaneAdapter cursor-pagination delegation methods. The
+// gRPC server's session-pagination handler (server_sessions.go)
+// performs a runtime type assertion against an unexported
+// `sessionCursorIterator` interface declared in pkg/grpcapi. If
+// either of the signatures below drifts away from that interface,
+// the assertion would silently fail at runtime and the handler
+// would fall through to the full-table scan path under userspace —
+// exactly the silent-degradation hazard #1516 closed. This compile-
+// time assertion catches the drift at build time instead.
+var _ interface {
+	IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+} = (*LegacyDataPlaneAdapter)(nil)
+
 // LegacyDataPlaneAdapter is the compatibility boundary for callers that still
 // depend on the old BPF-shaped dataplane.DataPlane interface.
 //

--- a/pkg/dataplane/userspace/legacy_dataplane_test.go
+++ b/pkg/dataplane/userspace/legacy_dataplane_test.go
@@ -1,8 +1,11 @@
 package userspace
 
 import (
+	"errors"
 	"net"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
 )
 
 type legacyPolicySchedulerSeeder interface {
@@ -161,4 +164,66 @@ func TestLegacyDataPlaneAdapterOptionalInterfacesNilSafe(t *testing.T) {
 			}
 		})
 	}
+}
+
+// #1516 sub-#1451 S1 — verify the cursor-iteration delegation
+// methods (added so the gRPC pagination handler type assertion
+// against an unexported sessionCursorIterator interface succeeds on
+// userspace). Asserts both the production path (production bpfShim
+// is a *dataplane.Manager, so the underlying type satisfies the
+// cursor interface and the call delegates cleanly) and the
+// nil/edge fallback path (sentinel ErrCursorIterationUnsupported
+// is returned so the grpcapi handler can fall back to
+// getSessionsLegacy instead of surfacing codes.Internal).
+type legacyCursorIterator interface {
+	IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+}
+
+var _ legacyCursorIterator = (*LegacyDataPlaneAdapter)(nil)
+
+func TestLegacyDataPlaneAdapterCursorIterationDelegation(t *testing.T) {
+	t.Run("production manager satisfies cursor interface", func(t *testing.T) {
+		m := New()
+		adapter := NewLegacyDataPlaneAdapter(m)
+		// The wrapped DataPlane is *dataplane.Manager which does
+		// implement IterateSessionsFrom/V6From — the delegation
+		// calls reach a real (unloaded) BPF manager and either
+		// succeed (empty iteration) or return a non-sentinel error
+		// from the underlying BPF map iter.  Either is acceptable;
+		// what matters is the sentinel is NOT what we get back
+		// when the wrapped manager DOES support cursor iteration.
+		err4 := adapter.IterateSessionsFrom(nil, func(dataplane.SessionKey, dataplane.SessionValue) bool { return true })
+		if errors.Is(err4, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsFrom returned sentinel %v even though wrapped DataPlane is *dataplane.Manager", err4)
+		}
+		err6 := adapter.IterateSessionsV6From(nil, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool { return true })
+		if errors.Is(err6, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsV6From returned sentinel %v even though wrapped DataPlane is *dataplane.Manager", err6)
+		}
+	})
+
+	t.Run("nil manager returns sentinel", func(t *testing.T) {
+		adapter := NewLegacyDataPlaneAdapter(nil)
+		err4 := adapter.IterateSessionsFrom(nil, func(dataplane.SessionKey, dataplane.SessionValue) bool { return true })
+		if !errors.Is(err4, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsFrom on nil-manager adapter = %v, want ErrCursorIterationUnsupported", err4)
+		}
+		err6 := adapter.IterateSessionsV6From(nil, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool { return true })
+		if !errors.Is(err6, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsV6From on nil-manager adapter = %v, want ErrCursorIterationUnsupported", err6)
+		}
+	})
+
+	t.Run("nil receiver returns sentinel", func(t *testing.T) {
+		var adapter *LegacyDataPlaneAdapter
+		err4 := adapter.IterateSessionsFrom(nil, func(dataplane.SessionKey, dataplane.SessionValue) bool { return true })
+		if !errors.Is(err4, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsFrom on nil receiver = %v, want ErrCursorIterationUnsupported", err4)
+		}
+		err6 := adapter.IterateSessionsV6From(nil, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool { return true })
+		if !errors.Is(err6, ErrCursorIterationUnsupported) {
+			t.Fatalf("IterateSessionsV6From on nil receiver = %v, want ErrCursorIterationUnsupported", err6)
+		}
+	})
 }

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -26,6 +26,25 @@ bridge in `pkg/api`.
 `dhcpserver`, `feeds`, `frr`, `ipsec`, `logging`, `fwdstatus`, `ra`,
 `routing`, `rpm`, `vrrp`, plus most of the rest of `pkg/`.
 
+The dataplane dependency is intentionally narrow: `Config.DP` and
+`Server.dp` are typed against the unexported `grpcRuntime`
+interface declared in `runtime.go`, **not** the full
+`dataplane.DataPlane`. `grpcRuntime` lists exactly the methods the
+gRPC handlers invoke via `s.dp.*` (counters, session-read,
+session-clear, map-stats, persistent-NAT) and is a strict subset
+of `dataplane.DataPlane`, so any concrete dataplane that satisfies
+the legacy interface also satisfies `grpcRuntime`. The userspace-
+specific provider capabilities (`Status`, `SetForwardingArmed`,
+`SetQueueState`, `SetBindingState`, `InjectPacket`) live on named
+provider interfaces (`userspaceStatusProvider`,
+`userspaceControlProvider`) in the same file; the gRPC server
+probes them via type assertion on `s.dp`. Cursor-based session
+pagination uses the `sessionCursorIterator` probe, also in
+`runtime.go`. This is the boundary that the #1373 eBPF retirement
+narrows; see `docs/pr/1373-retire-ebpf-dataplane/README.md` and
+`docs/pr/1516-grpcapi-migration/plan.md` for the migration
+contract.
+
 ## Gotchas
 
 - Configure mode is **exclusive on the secondary node** in cluster mode.

--- a/pkg/grpcapi/runtime.go
+++ b/pkg/grpcapi/runtime.go
@@ -6,9 +6,9 @@ import (
 )
 
 // grpcRuntime is the gRPC server's domain-specific dataplane
-// surface. Listed exactly to the methods the gRPC handlers
-// consume on master. Narrower than dataplane.DataPlane;
-// intentionally not exported.
+// surface. Lists exactly the methods the gRPC handlers consume on
+// master. Narrower than dataplane.DataPlane; intentionally not
+// exported.
 type grpcRuntime interface {
 	// Liveness probe — guards every counter / iter call site.
 	IsLoaded() bool

--- a/pkg/grpcapi/runtime.go
+++ b/pkg/grpcapi/runtime.go
@@ -1,0 +1,71 @@
+package grpcapi
+
+import (
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// grpcRuntime is the gRPC server's domain-specific dataplane
+// surface. Listed exactly to the methods the gRPC handlers
+// consume on master. Narrower than dataplane.DataPlane;
+// intentionally not exported.
+type grpcRuntime interface {
+	// Liveness probe — guards every counter / iter call site.
+	IsLoaded() bool
+
+	// Counters (read).
+	ReadGlobalCounter(index uint32) (uint64, error)
+	ReadInterfaceCounters(ifindex int) (dataplane.InterfaceCounterValue, error)
+	ReadZoneCounters(zoneID uint16, direction int) (dataplane.CounterValue, error)
+	ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error)
+	ReadFilterConfig(filterID uint32) (dataplane.FilterConfig, error)
+	ReadFilterCounters(ruleIdx uint32) (dataplane.CounterValue, error)
+	ReadFloodCounters(zoneID uint16) (dataplane.FloodState, error)
+	ReadNATRuleCounter(counterID uint32) (dataplane.CounterValue, error)
+
+	// Counters (clear) — diag/clear paths.
+	ClearPolicyCounters() error
+	ClearFilterCounters() error
+	ClearNATRuleCounters() error
+	ClearAllCounters() error
+
+	// Session store (read).
+	IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	GetSessionV4(key dataplane.SessionKey) (dataplane.SessionValue, error)
+	GetSessionV6(key dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
+	SessionCount() (v4, v6 int)
+
+	// Session store (clear / delete) — `clear security flow session ...`.
+	ClearAllSessions() (v4 int, v6 int, err error)
+	DeleteSession(key dataplane.SessionKey) error
+	DeleteSessionV6(key dataplane.SessionKeyV6) error
+	DeleteDNATEntry(key dataplane.DNATKey) error
+	DeleteDNATEntryV6(key dataplane.DNATKeyV6) error
+
+	// NAT bindings / system buffers.
+	GetPersistentNAT() *dataplane.PersistentNATTable
+	GetMapStats() []dataplane.MapStats
+}
+
+// sessionCursorIterator: optional cursor-based iteration; consumed via
+// type assertion in server_sessions.go:getSessionsCursor.
+type sessionCursorIterator interface {
+	IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+}
+
+// userspaceStatusProvider: probe for the userspace-specific Status() call.
+type userspaceStatusProvider interface {
+	Status() (dpuserspace.ProcessStatus, error)
+}
+
+// userspaceControlProvider: superset of statusProvider used by the
+// diag/control path (queue/binding admin, forwarding-armed, inject).
+type userspaceControlProvider interface {
+	userspaceStatusProvider
+	SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
+	SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+	SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
+	InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
+}

--- a/pkg/grpcapi/runtime_canary_test.go
+++ b/pkg/grpcapi/runtime_canary_test.go
@@ -1,0 +1,30 @@
+package grpcapi
+
+import (
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// Cross-package compile-time interface-satisfaction guards (#1516
+// Copilot r3 finding). The compile-time assertion in
+// pkg/dataplane/userspace/legacy_dataplane.go only verifies that
+// LegacyDataPlaneAdapter has the method shape of an inline
+// anonymous interface. It does NOT detect drift if the unexported
+// pkg/grpcapi interfaces (grpcRuntime, sessionCursorIterator,
+// userspaceStatusProvider, userspaceControlProvider) acquire a new
+// method that LegacyDataPlaneAdapter no longer satisfies — the
+// userspace package can't import grpcapi for that interface name.
+//
+// pkg/grpcapi CAN import pkg/dataplane/userspace (the dependency
+// already exists via Config.DP's runtime type and the named
+// provider probes), so the asymmetric guard lives here: pin the
+// adapter against each unexported interface so a build failure
+// here makes the drift impossible to miss.
+//
+// These are *_test.go-scoped to avoid bloating the production
+// binary's symbol table with assertion-only references.
+var (
+	_ grpcRuntime              = (*dpuserspace.LegacyDataPlaneAdapter)(nil)
+	_ sessionCursorIterator    = (*dpuserspace.LegacyDataPlaneAdapter)(nil)
+	_ userspaceStatusProvider  = (*dpuserspace.LegacyDataPlaneAdapter)(nil)
+	_ userspaceControlProvider = (*dpuserspace.LegacyDataPlaneAdapter)(nil)
+)

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
-	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcpserver"
@@ -37,7 +36,7 @@ import (
 // Config configures the gRPC server.
 type Config struct {
 	Store            *configstore.Store
-	DP               dataplane.DataPlane
+	DP               grpcRuntime
 	EventBuf         *logging.EventBuffer
 	GC               *conntrack.GC
 	Routing          *routing.Manager
@@ -69,7 +68,7 @@ type Config struct {
 type Server struct {
 	pb.UnimplementedBpfrxServiceServer
 	store              *configstore.Store
-	dp                 dataplane.DataPlane
+	dp                 grpcRuntime
 	eventBuf           *logging.EventBuffer
 	gc                 *conntrack.GC
 	routing            *routing.Manager
@@ -95,29 +94,15 @@ type Server struct {
 }
 
 func (s *Server) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {
-	provider, ok := s.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	})
+	provider, ok := s.dp.(userspaceStatusProvider)
 	if !ok {
 		return dpuserspace.ProcessStatus{}, fmt.Errorf("userspace status unavailable")
 	}
 	return provider.Status()
 }
 
-func (s *Server) userspaceDataplaneControl() (interface {
-	Status() (dpuserspace.ProcessStatus, error)
-	SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
-	SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-	SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-	InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
-}, error) {
-	provider, ok := s.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-		SetForwardingArmed(bool) (dpuserspace.ProcessStatus, error)
-		SetQueueState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-		SetBindingState(uint32, bool, bool) (dpuserspace.ProcessStatus, error)
-		InjectPacket(dpuserspace.InjectPacketRequest) (dpuserspace.ProcessStatus, error)
-	})
+func (s *Server) userspaceDataplaneControl() (userspaceControlProvider, error) {
+	provider, ok := s.dp.(userspaceControlProvider)
 	if !ok {
 		return nil, fmt.Errorf("userspace dataplane control unavailable")
 	}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -41,19 +41,17 @@ func (s *Server) GetSessions(ctx context.Context, req *pb.GetSessionsRequest) (*
 	return s.getSessionsLegacy(ctx, req)
 }
 
-// sessionIteratorFrom is implemented by dataplane.Manager to support
-// cursor-based BPF map iteration.
-type sessionIteratorFrom interface {
-	IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
-	IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
-}
-
 // getSessionsCursor implements cursor-based pagination.
 // It iterates only up to page_size matching entries, avoids full-table
 // scans for the total count (uses SessionCount instead), and skips
 // enrichment when no_enrich is set.
+//
+// The cursor-iteration provider interface (sessionCursorIterator)
+// lives in runtime.go alongside grpcRuntime and the userspace
+// provider probes; we fall through to the legacy full-table scan
+// when the underlying dataplane does not satisfy it.
 func (s *Server) getSessionsCursor(ctx context.Context, req *pb.GetSessionsRequest) (*pb.GetSessionsResponse, error) {
-	iterDP, ok := s.dp.(sessionIteratorFrom)
+	iterDP, ok := s.dp.(sessionCursorIterator)
 	if !ok {
 		// Dataplane doesn't support cursor iteration; fall back to legacy.
 		return s.getSessionsLegacy(ctx, req)

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -19,6 +20,7 @@ import (
 	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
@@ -112,6 +114,16 @@ func (s *Server) getSessionsCursor(ctx context.Context, req *pb.GetSessionsReque
 	v6Exhausted := true // set to false when we start v6
 
 	// Phase 1: iterate v4 sessions from cursor.
+	//
+	// The adapter's cursor delegation can return
+	// dpuserspace.ErrCursorIterationUnsupported when the embedded
+	// dataplane is nil or does not implement cursor iteration
+	// (test/edge configurations only — production
+	// LegacyDataPlaneAdapter wraps a *dataplane.Manager which does
+	// implement it). Detecting that sentinel and falling back to
+	// the legacy offset/limit pagination preserves the master/
+	// pre-#1516 user-visible behavior in those edge cases instead
+	// of surfacing a codes.Internal to the client.
 	if startV4 {
 		if err := iterDP.IterateSessionsFrom(cursorV4, func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 			if len(all) >= pageSize {
@@ -136,6 +148,9 @@ func (s *Server) getSessionsCursor(ctx context.Context, req *pb.GetSessionsReque
 			lastV4Key = key
 			return true
 		}); err != nil {
+			if errors.Is(err, dpuserspace.ErrCursorIterationUnsupported) {
+				return s.getSessionsLegacy(ctx, req)
+			}
 			return nil, status.Errorf(codes.Internal, "v4 session iteration: %v", err)
 		}
 		if len(all) >= pageSize {
@@ -179,6 +194,9 @@ func (s *Server) getSessionsCursor(ctx context.Context, req *pb.GetSessionsReque
 			lastV6Key = key
 			return true
 		}); err != nil {
+			if errors.Is(err, dpuserspace.ErrCursorIterationUnsupported) {
+				return s.getSessionsLegacy(ctx, req)
+			}
 			return nil, status.Errorf(codes.Internal, "v6 session iteration: %v", err)
 		}
 		if len(all) >= pageSize {

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -1727,9 +1727,7 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "buffers":
 		if s.dp != nil {
-			if provider, ok := s.dp.(interface {
-				Status() (dpuserspace.ProcessStatus, error)
-			}); ok {
+			if provider, ok := s.dp.(userspaceStatusProvider); ok {
 				status, err := provider.Status()
 				if err != nil {
 					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)
@@ -1783,9 +1781,7 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "buffers-detail":
 		if s.dp != nil {
-			if provider, ok := s.dp.(interface {
-				Status() (dpuserspace.ProcessStatus, error)
-			}); ok {
+			if provider, ok := s.dp.(userspaceStatusProvider); ok {
 				status, err := provider.Status()
 				if err != nil {
 					fmt.Fprintf(&buf, "Userspace buffer metrics unavailable: %v\n", err)

--- a/pkg/grpcapi/server_show_forwarding.go
+++ b/pkg/grpcapi/server_show_forwarding.go
@@ -65,9 +65,7 @@ func (s *Server) forwardingStatusDataplane() fwdstatus.DataPlaneAccessor {
 		return nil
 	}
 	base := forwardingStatusServerDataPlane{server: s}
-	if _, ok := s.dp.(interface {
-		Status() (dpuserspace.ProcessStatus, error)
-	}); ok {
+	if _, ok := s.dp.(userspaceStatusProvider); ok {
 		return forwardingStatusServerUserspaceDataPlane{forwardingStatusServerDataPlane: base}
 	}
 	return base


### PR DESCRIPTION
## Summary

Replace `grpcapi.Config.DP` and `grpcapi.Server.dp` (typed as
`dataplane.DataPlane`) with `grpcRuntime`, a narrow gRPC-server-
specific interface declared in the new `pkg/grpcapi/runtime.go`.
Mirrors the pattern already shipped by `pkg/cli` (#1517 PR #1549,
`cliRuntime`), `pkg/api` (`apiRuntimeDataPlane`), `pkg/fwdstatus`
(`DataPlaneAccessor`), `pkg/monitoriface` (`RuntimeDataPlane`), and
`pkg/conntrack` (`RuntimeDomainProvider`).

`grpcRuntime` lists exactly the 25 methods the gRPC handlers
invoke via `s.dp.*` (counters / clear-counter / session-read /
session-clear / map-stats / persistent-NAT). It is a strict subset
of `dataplane.DataPlane`, so every concrete dataplane in the tree
already satisfies it; the daemon caller passes `d.legacyDP()`
unchanged.

The four inline `s.dp.(interface{...})` provider probes in
`server.go`, `server_show_forwarding.go`, and `server_show.go`
collapse into two named provider interfaces in `runtime.go`:
`userspaceStatusProvider` and `userspaceControlProvider`.

The local `sessionIteratorFrom` interface in `server_sessions.go`
is renamed `sessionCursorIterator` and moved into `runtime.go`.

## Userspace cursor-pagination repair (AGY plan-review r1 finding)

`LegacyDataPlaneAdapter` embeds the `dataplane.DataPlane` interface
(not the concrete `*dataplane.Manager`). `IterateSessionsFrom` and
`IterateSessionsV6From` are concrete methods on `*Manager` that
are NOT part of the `DataPlane` interface, so Go's method promotion
does not lift them onto `LegacyDataPlaneAdapter`. On master, the
gRPC cursor-pagination type assertion silently fails under
userspace and the handler falls back to the legacy full-table scan
— a real operational degradation for large session tables.

The fix adds `IterateSessionsFrom` and `IterateSessionsV6From` as
delegation methods on `LegacyDataPlaneAdapter`; each asserts the
embedded `a.DataPlane` against the cursor-iterator interface and
forwards to the bpfShim's `*dataplane.Manager`. Paint-by-numbers
delegation; no new dataplane behavior.

## Plan + adversarial review

Plan doc: `docs/pr/1516-grpcapi-migration/plan.md` (v2)

- AGY adversarial-review-mplbyiom-1hw3em (plan v1):
  PLAN-NEEDS-MAJOR; userspace cursor-pagination finding folded
  into v2 + implementation.
- Codex plan review: 3× infra-blocked attempts (sandbox spawn
  ENOENT). Per `feedback_codex_infra_must_retry`, will dispatch
  hostile code review on PR head SHA `bace61ac` for verdict on
  shipped code.

## Test plan

- [x] cargo build clean (114 pre-existing warnings only)
- [x] full Go suite: 30+ packages pass
- [x] `pkg/grpcapi` 5/5 race flake check clean
- [x] boundary canary suite green
- [ ] **AWAITING-SMOKE** (delegated to serialized smoke-runner per
  `feedback_smoke_serialized_single_agent`)

Refs #1516, #1451, #1373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1516.
