### PR TITLE
config: accumulate strict-validator family errors into a multierror (#1538)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -110,6 +110,33 @@
   - **File(s)**:
     `docs/pr/1520-userspace-boot-extraction/plan.md`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
+- **Timestamp**: 2026-05-25T09:00:00Z
+  - **Action**: #1538 code-review round-1 follow-up — addresses
+    Codex code-review NEEDS-MINOR (3 findings; AGY MERGE-READY,
+    Copilot PASS, Claude SMR PASS):
+    1. Rewrote `TestCompileSingleStrictErrorJoinPath` to drive
+       through `CompileConfig` rather than inline-duplicating
+       the accumulator pattern. New fixture uses ONLY the CoS
+       `equal-flow-enforcement` set line (no policer), so the
+       accumulator slice ends up length-1 and the test now
+       genuinely exercises the production path. Asserts
+       byte-identity vs a direct validator call on an
+       equivalent stub `*ClassOfServiceConfig`, zero '\n'
+       separators on the single-error path, and incidental
+       wrap-chain traversal (`errors.Is(err,
+       ErrDPDKDataplaneRetired) == false`).
+    2. Dropped stale `file:line` citations from compiler_test.go
+       and plan.md; switched to symbol references that survive
+       rebase drift.
+    3. Updated reviewer-ids.md with round-4 PLAN-READY
+       verdicts and recorded the code-review verdicts.
+    Re-ran the three new tests + the DPDK no-leak test
+    locally; all clean.
+  - **File(s)**: `pkg/config/compiler_test.go`,
+    `docs/pr/1538-multierror-validation/plan.md`,
+    `docs/pr/1538-multierror-validation/reviewer-ids.md`,
+    `_Log.md`
+
 - **Timestamp**: 2026-05-25T08:45:00Z
   - **Action**: #1538 implementation (plan v4 PLAN-READY 4/4).
     Plan-review summary: r1 Codex PLAN-NEEDS-MAJOR / AGY

--- a/_Log.md
+++ b/_Log.md
@@ -110,6 +110,67 @@
   - **File(s)**:
     `docs/pr/1520-userspace-boot-extraction/plan.md`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
+- **Timestamp**: 2026-05-25T08:45:00Z
+  - **Action**: #1538 implementation (plan v4 PLAN-READY 4/4).
+    Plan-review summary: r1 Codex PLAN-NEEDS-MAJOR / AGY
+    PLAN-READY; r2 Codex PLAN-NEEDS-MINOR / AGY PLAN-READY;
+    r3 Codex PLAN-NEEDS-MINOR / AGY PLAN-NEEDS-MINOR; r4
+    Codex PLAN-READY / AGY PLAN-READY. v4 is the final plan.
+
+    Code change: `compileExpanded` in
+    `pkg/config/compiler.go:244-272` now accumulates the three
+    independent strict-validator family errors
+    (`validateClassOfServiceStrict`,
+    `validateThreeColorPolicersStrict`,
+    `validatePolicySchedulerReferencesStrict`) into a single
+    `errors.Join` return so `commit check` surfaces ONE error
+    per family in a single response. The
+    `validateDataplaneTypeStrict` precheck (added by #1536)
+    stays fail-fast and runs FIRST so the brittle-by-design
+    `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` no-leak
+    contract (parser_ast_test.go:2909+2913) keeps passing
+    byte-identically.
+
+    Tests added (3):
+    - `pkg/config/compiler_test.go::TestCompileMultipleStrictErrorsAccumulated`
+      — parser-driven via `CompileConfig` + `ParseSetCommand` /
+      `tree.SetPath` loop. Fixture: `equal-flow-enforcement`
+      on a scheduler without `transmit-rate exact` (parser-
+      reachable CoS error) + `single-rate color-blind` on a
+      three-color-policer without `committed-information-rate`
+      (parser-reachable policer error). Asserts both error
+      substrings present in the joined Error(), exactly one
+      '\n' separator, and `errors.Is(err,
+      ErrDPDKDataplaneRetired) == false` (defense-in-depth).
+    - `pkg/config/compiler_test.go::TestCompileSingleStrictErrorJoinPath`
+      — direct accumulator-pattern call with a hand-built
+      *Config that triggers only the CoS family. Pins
+      `errors.Join`'s single-element byte-identity semantics
+      (Go std lib pin at /usr/lib/go-1.24/src/errors/join.go:47-48
+      per Codex round-2 verification).
+    - `pkg/grpcapi/server_config_test.go::TestCompileCheckMultiErrorRendersThroughGRPC`
+      — exercises the actual operator-facing gRPC rendering
+      via `status.Errorf(codes.InvalidArgument, "%v", err)`
+      at `server_config.go:176`. Direct-handler style
+      (no bufconn) per existing pattern at lines 15-25.
+      Asserts `codes.InvalidArgument` + both substrings +
+      one '\n' separator on the rendered status.Message().
+
+    Local validation: `go build ./...` clean, `go test
+    ./...` clean (30 packages), 5× flake loop on the three
+    new tests + the DPDK no-leak test all clean.
+
+    Also tidied two cosmetic stale-wording items Codex r4
+    called out as non-blocking: "Land plan v2" → "Land plan
+    ... v4 is the final" and "Open questions ... (round 2)"
+    → "(historical)".
+  - **File(s)**: `pkg/config/compiler.go`,
+    `pkg/config/compiler_test.go` (new),
+    `pkg/grpcapi/server_config_test.go`,
+    `docs/pr/1538-multierror-validation/plan.md`,
+    `docs/pr/1538-multierror-validation/reviewer-ids.md` (new),
+    `_Log.md`
+
 - **Timestamp**: 2026-05-25T08:30:00Z
   - **Action**: #1538 plan v4 — addresses Codex round-3
     PLAN-NEEDS-MINOR (3 findings) + AGY round-3

--- a/_Log.md
+++ b/_Log.md
@@ -2820,3 +2820,11 @@
   go test ./... green (32 packages); retirement boundary canary updated
   with pkg/cluster/runtime.go allowlist entry + 1373 README + cluster
   README. Smoke + test-failover pending (HA-sensitive scope per CLAUDE.md).
+
+- **Timestamp**: 2026-05-25T15:31Z
+- **Action**: PR #1538 Copilot code-review round-2 — fix `want` variable
+  shadowing in TestCompileSingleStrictErrorJoinPath and add
+  TestCompileAllThreeStrictValidatorsAccumulated to close the
+  third-family (validatePolicySchedulerReferencesStrict) coverage gap
+  flagged in round-1 review.
+- **File(s)**: pkg/config/compiler_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -110,6 +110,31 @@
   - **File(s)**:
     `docs/pr/1520-userspace-boot-extraction/plan.md`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
+- **Timestamp**: 2026-05-25T09:15:00Z
+  - **Action**: #1538 code-review round-2 doc cleanup —
+    Codex code review round 2 verdict was NEEDS-MINOR with
+    two doc-only findings (AGY round-2 was MERGE-READY,
+    Copilot pending):
+    1. plan.md still described the OLD
+       TestCompileSingleStrictErrorJoinPath design (hand-built
+       *Config / direct helper). Rewrote the description to
+       match the actual implementation (ParseSetCommand →
+       SetPath → CompileConfig path with single-CoS-only
+       fixture, byte-identity vs direct validator call as
+       reference, defense-in-depth zero-newline + wrap-chain
+       traversal assertions).
+    2. Many `file:line` citations remained in plan.md after
+       the first cleanup pass (compiler.go:244/247/250,
+       :363+, :241, :234-243, :262+, :82-153, store.go:681,
+       ast_edit.go:151-152, etc). Stripped all of them via
+       sed to use durable symbol references instead.
+    Also fixed a couple of leftover sed artifacts manually
+    (`/`:681`` artifact at line 414; the `at :363+`
+    construction at line 103).
+    Re-ran ./pkg/config/ + ./pkg/grpcapi/ tests: clean.
+  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
+    `_Log.md`
+
 - **Timestamp**: 2026-05-25T09:00:00Z
   - **Action**: #1538 code-review round-1 follow-up — addresses
     Codex code-review NEEDS-MINOR (3 findings; AGY MERGE-READY,

--- a/_Log.md
+++ b/_Log.md
@@ -110,6 +110,72 @@
   - **File(s)**:
     `docs/pr/1520-userspace-boot-extraction/plan.md`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
+- **Timestamp**: 2026-05-25T08:30:00Z
+  - **Action**: #1538 plan v4 — addresses Codex round-3
+    PLAN-NEEDS-MINOR (3 findings) + AGY round-3
+    PLAN-NEEDS-MINOR (1 finding). Changes:
+    (1) drop "REQUIRED" rationale for `set system
+        dataplane-type userspace` (no-op — unset == userspace
+        per `effectiveDataplaneType` and validateDataplaneTypeStrict
+        only rejects explicit `dpdk`); line stays as
+        self-documenting future-proof;
+    (2) fix test-count "two" → "three" throughout the plan;
+    (3) replace bad-syntax three-color-policer line
+        `action loss-priority high then discard` (parses via
+        schema-less fallback, silently ignored by compiler)
+        with schema-clean `then discard`;
+    (4) rewrite gRPC test plan to match existing
+        direct-handler style at server_config_test.go:15-25
+        (no bufconn; use `store.LoadSet` per existing
+        pattern, not nonexistent `LoadCandidate`/`Edit`).
+    Sanity-checked the fixture locally with a throw-away
+    test: under current fail-fast, only CoS error surfaces;
+    under accumulator both surface separated by one '\n'.
+  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
+    `_Log.md`
+
+- **Timestamp**: 2026-05-25T08:15:00Z
+  - **Action**: #1538 plan v3 — addresses Codex round-2
+    PLAN-NEEDS-MINOR on plan v2. AGY round-2 was PLAN-READY.
+    Minor fix: v2's CoS fixture used "both buffer-size bytes
+    AND percent set" which is NOT parser-reachable
+    (`pkg/config/compiler_class_of_service.go:239` clears the
+    alternate field; validator at `pkg/config/compiler.go:386`
+    documents the state arises only from constructed configs).
+    v3 switches the parser-driven tests to use
+    `equal-flow-enforcement` without `transmit-rate exact` as
+    the parser-reachable CoS error and `single-rate
+    color-blind` without `committed-information-rate` as the
+    parser-reachable policer error. Also clarifies that there
+    are THREE new tests (not two) and splits fixture-build
+    technique per-test (parser for tests 1+3, direct-helper
+    for the byte-identity test 2).
+  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
+    `_Log.md`
+
+- **Timestamp**: 2026-05-25T08:00:00Z
+  - **Action**: #1538 plan v2 — addresses Codex round-1
+    PLAN-NEEDS-MAJOR (4 findings) on plan v1. Changes:
+    (a) keep `validateDataplaneTypeStrict` as a separate
+    fail-fast precheck BEFORE the accumulator — preserves
+    #1536's DPDK-first / no-leak contract pinned by
+    `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
+    (`pkg/config/parser_ast_test.go:2855,:2909,:2913`);
+    (b) drop the "matches Junos commit check" overclaim and
+    frame the change as an xpf UX choice grounded in
+    upgrade-friction reduction; (c) tighten wording from
+    "all structural errors" to "one error per validator
+    family" since each strict family still fail-fasts
+    internally; (d) add a third test
+    `TestCompileCheckMultiErrorRendersThroughGRPC` covering
+    the multi-line rendering through `pkg/grpcapi`.
+    AGY round-1 verdict was PLAN-READY; v2 preserves the
+    audit it confirmed (validator independence, substring
+    + sentinel preservation, wrap-chain mechanics).
+    Rebased onto current master (which now has #1536).
+  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
+    `_Log.md`
+ 9a0e7012 (config: plan #1538 — accumulate strict validation errors via errors.Join)
 
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR
@@ -283,7 +349,21 @@
     is deferred to #1527/#1528. This PR adds a leading retirement
     note above it instead.
   - **File(s)**: `docs/pr/1529-dpdk-docs-sweep/plan.md`, `_Log.md`
-## 2026-05-25
+
+- **Timestamp**: 2026-05-25T07:30:00Z
+  - **Action**: #1538 plan v1 (DRAFT) — accumulate strict validation
+    errors via `errors.Join` in `compileExpanded` so `commit check`
+    surfaces every dormant structural finding in one pass instead
+    of forcing whack-a-mole CLI round-trips. Plan composes with the
+    in-flight #1536 (validateDataplaneTypeStrict) under either merge
+    order. Walks Junos UX (Junos itself accumulates), validator
+    independence (each strict validator reads its own typed sub-
+    struct, all nil-safe), substring/sentinel contract preservation
+    (`strings.Contains` + `errors.Is` traverse `errors.Join`), and
+    risk table. Calls out 7 hostile reviewer questions including
+    PLAN-KILL grounds.
+  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
+    `_Log.md`
 
 - **Timestamp**: 2026-05-25T05:00:00Z
   - **Action**: #1501 A2 — replaced the stale TODO + contradictory

--- a/_Log.md
+++ b/_Log.md
@@ -288,7 +288,6 @@
     Rebased onto current master (which now has #1536).
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
     `_Log.md`
- 9a0e7012 (config: plan #1538 — accumulate strict validation errors via errors.Join)
 
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR
@@ -2822,9 +2821,9 @@
   README. Smoke + test-failover pending (HA-sensitive scope per CLAUDE.md).
 
 - **Timestamp**: 2026-05-25T15:31Z
-- **Action**: PR #1538 Copilot code-review round-2 — fix `want` variable
-  shadowing in TestCompileSingleStrictErrorJoinPath and add
-  TestCompileAllThreeStrictValidatorsAccumulated to close the
-  third-family (validatePolicySchedulerReferencesStrict) coverage gap
-  flagged in round-1 review.
-- **File(s)**: pkg/config/compiler_test.go
+  - **Action**: PR #1538 Copilot code-review round-2 — fix `want`
+    variable shadowing in TestCompileSingleStrictErrorJoinPath and
+    add TestCompileAllThreeStrictValidatorsAccumulated to close the
+    third-family (validatePolicySchedulerReferencesStrict) coverage
+    gap flagged in round-1 review.
+  - **File(s)**: `pkg/config/compiler_test.go`

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -12,8 +12,9 @@ AGY round-3 PLAN-NEEDS-MINOR (1 finding):
   (pinned by `TestDataplaneTypeOmittedCompilesCleanly` at
   `pkg/config/parser_ast_test.go`). Line stays as
   self-documenting future-proofing.
-- Fix test-count to three throughout (was "two" at v3
-  plan.md:69 and :86).
+- Fix test-count to three throughout (was "two" in two spots in
+  the v3 plan body — surface-area paragraph and PLAN-KILL
+  paragraph).
 - Replace bad three-color-policer syntax
   `action loss-priority high then discard` with schema-clean
   `then discard` — the `action` form parses via the
@@ -326,7 +327,9 @@ drive through `CompileConfig` we use parser-reachable conditions:
   `firewall three-color-policer %q requires positive
   committed-information-rate` in `validateThreeColorPolicersStrict`.
 
-For the byte-identity test we call the helper directly (no parser).
+For the byte-identity test we also drive through `CompileConfig`
+with a single-family fixture (only the CoS line) and compare
+against a direct validator call as the reference value.
 
 ---
 

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -471,7 +471,8 @@ repeat), not a regression.
 
 ## Implementation order
 
-1. Land plan v2; iterate to PLAN-READY across Codex + AGY.
+1. Land plan; iterate to PLAN-READY across Codex + AGY (took 4
+   rounds; plan v4 is the final).
 2. Edit `compileExpanded` per the design above (keep DPDK
    precheck; accumulate the remaining 3).
 3. Add the three new tests.
@@ -484,7 +485,7 @@ repeat), not a regression.
    + AGY + Copilot). Auto-merge when 4-of-4 agree.
 10. Report PR URL + verdicts.
 
-## Open questions for adversarial reviewers (round 2)
+## Open questions for adversarial reviewers (historical)
 
 1. **Test placement for the gRPC rendering test.** Is
    `pkg/grpcapi/server_config_test.go` the right home, or

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -10,18 +10,18 @@ AGY round-3 PLAN-NEEDS-MINOR (1 finding):
   rejects explicit `dpdk`, and unset == userspace via
   `effectiveDataplaneType` in `pkg/config/compiler.go`
   (pinned by `TestDataplaneTypeOmittedCompilesCleanly` at
-  `pkg/config/parser_ast_test.go:2983`). Line stays as
+  `pkg/config/parser_ast_test.go`). Line stays as
   self-documenting future-proofing.
 - Fix test-count to three throughout (was "two" at v3
   plan.md:69 and :86).
 - Replace bad three-color-policer syntax
   `action loss-priority high then discard` with schema-clean
   `then discard` — the `action` form parses via the
-  schema-less fallback at `pkg/config/ast_edit.go:151-152` but
-  is silently ignored by `compiler_firewall.go:144-155` which
+  schema-less fallback in `pkg/config/ast_edit.go` but
+  is silently ignored by `compiler_firewall.go` which
   only traverses the `then` child.
 - Rewrite the gRPC test plan to match the existing direct-handler
-  test style at `pkg/grpcapi/server_config_test.go:15-25`
+  test style at `pkg/grpcapi/server_config_test.go`
   (no bufconn — the existing tests construct `*Server`
   directly with a temp-dir Store and call handlers). Use
   `store.LoadSet(...)` per existing pattern, not nonexistent
@@ -54,9 +54,9 @@ The strict-validator block in `pkg/config/compiler.go::compileExpanded`
 currently short-circuits on the first failure across three independent
 validator families:
 
-- `validateClassOfServiceStrict`   (compiler.go:244)
-- `validateThreeColorPolicersStrict` (compiler.go:247)
-- `validatePolicySchedulerReferencesStrict` (compiler.go:250)
+- `validateClassOfServiceStrict`   (compiler.go)
+- `validateThreeColorPolicersStrict` (compiler.go)
+- `validatePolicySchedulerReferencesStrict` (compiler.go)
 
 In an upgrade scenario where a legacy candidate carries multiple
 dormant structural errors (e.g., a malformed CoS scheduler-map
@@ -98,10 +98,10 @@ Absolute scale of the win:
 
 **Honest caveat on "one error per family."** Each existing
 strict validator still fail-fasts INTERNALLY (e.g.,
-`validateThreeColorPolicersStrict` in `pkg/config/compiler.go`
-returns on the first bad policer; `validateClassOfServiceStrict`
-at `:363+` returns on the first bad scheduler; same for
-`validatePolicySchedulerReferencesStrict`). This PR does NOT
+`validateThreeColorPolicersStrict` returns on the first bad
+policer; `validateClassOfServiceStrict` returns on the first
+bad scheduler; same for `validatePolicySchedulerReferencesStrict`
+— all in `pkg/config/compiler.go`). This PR does NOT
 expand intra-validator accumulation. The operator gets at most
 ONE error from each family in a single response — a maximum of
 three findings, not "every dormant error." Future work could
@@ -120,19 +120,19 @@ upgrade-friction win, PLAN-KILL.
 ## DPDK precheck contract — preserved verbatim
 
 PR #1536 (merged as commit cdad3c31 / merge 4508d714) installed
-`validateDataplaneTypeStrict` at `pkg/config/compiler.go:241`
+`validateDataplaneTypeStrict` at `pkg/config/compiler.go`
 BEFORE the other strict validators with explicit UX intent
-(`compiler.go:234-243`): the operator must see the migration
+(`compiler.go`): the operator must see the migration
 message FIRST when a candidate has both a retired dataplane-type
 AND any unrelated structural error.
 
 The brittle-by-design test `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
-at `pkg/config/parser_ast_test.go:2855` asserts BOTH:
+at `pkg/config/parser_ast_test.go` asserts BOTH:
 
 1. The DPDK retirement substring is present in the error
-   (`parser_ast_test.go:2909`).
+   (`parser_ast_test.go`).
 2. The string "three-color-policer" does NOT leak through
-   (`parser_ast_test.go:2913`).
+   (`parser_ast_test.go`).
 
 #1538 must NOT break either assertion. The clean answer is to
 KEEP `validateDataplaneTypeStrict` as a separate fail-fast
@@ -239,7 +239,7 @@ similar.
    a `joinError` with `Unwrap() []error`, traversed by
    `errors.Is` since Go 1.20.
 3. **Wrap chain.** `fmt.Errorf("commit check failed: %w", join)`
-   at `pkg/configstore/store.go:681` wraps the join into a
+   at `pkg/configstore/store.go` wraps the join into a
    single `%w` chain; `errors.Is/As` traverse through that
    wrap AND the underlying join.
 4. **Substring contracts.** `strings.Contains(join.Error(), substr)`
@@ -259,7 +259,7 @@ similar.
      reads `cos.Schedulers` and `cos.SchedulerMaps` only. Nil-safe
      on `cos == nil`, each `sched == nil`, each `schedMap == nil`,
      missing scheduler reference.
-   - `validateThreeColorPolicersStrict` (`compiler.go:262+`) —
+   - `validateThreeColorPolicersStrict` (`compiler.go`) —
      reads `cfg.Firewall.ThreeColorPolicers` map only. Nil-safe
      on each `pol == nil`.
    - `validatePolicySchedulerReferencesStrict` (`compiler.go`) —
@@ -268,7 +268,7 @@ similar.
      `zpp == nil`, `pol == nil || pol.SchedulerName == ""`.
 
    `compileExpanded` only reaches the strict block after all
-   compile_* phases succeed (`compiler.go:82-153`), so the
+   compile_* phases succeed (`compiler.go`), so the
    typed sub-structs are independently populated regardless of
    whether any one validator returns an error. Cross-contamination
    is impossible: validators are pure functions over the typed
@@ -309,7 +309,7 @@ similar.
 **Fixture choice — parser-reachable strict-validator errors.**
 
 The CoS "both buffer-size bytes AND percent set" condition is
-NOT parser-reachable: `pkg/config/compiler_class_of_service.go:239`
+NOT parser-reachable: `pkg/config/compiler_class_of_service.go`
 clears the alternate field, and the validator at
 the comment in `pkg/config/compiler.go` notes the state "can only arise in
 constructed or externally-assembled configs." For tests that
@@ -375,26 +375,31 @@ For the byte-identity test we call the helper directly (no parser).
      not in play; defense-in-depth).
 
 2. **`TestCompileSingleStrictErrorJoinPath`** —
-   `pkg/config/compiler_test.go`. Call the new
-   accumulator helper (`accumulateStrictValidators` or
-   inline-equivalent depending on implementation choice) with a
-   hand-built `*Config` that triggers only ONE family. Assert
-   `err.Error()` is byte-identical to the single underlying
-   validator return. The hand-built path is fine here because
-   the goal is to pin `errors.Join`'s single-element semantics
-   (Go std lib documents byte-identity at
-   `/usr/lib/go-1.24/src/errors/join.go:47-48`, confirmed by
-   Codex round-2). This protects against any future
-   helper-wrapper drift; the bare-`*Config` route makes the
-   test independent of parser/compiler shape changes.
+   `pkg/config/compiler_test.go`. Drives through the production
+   path `ParseSetCommand` → `tree.SetPath` → `CompileConfig`
+   with a fixture that triggers ONLY the CoS family (no policer
+   lines), so the accumulator slice ends up length-1. Asserts
+   `err.Error()` is byte-identical to a direct
+   `validateClassOfServiceStrict` call on an equivalent stub
+   `*ClassOfServiceConfig` (the direct call is the reference
+   value; the test only USES it for comparison, not as the
+   production path). Plus zero-`\n`-separator and an incidental
+   `errors.Is(err, ErrDPDKDataplaneRetired) == false`
+   wrap-chain traversal assertion. Pins `errors.Join`'s
+   single-element semantics (Go std lib documents
+   byte-identity in the std `errors.Join` source). Exercising
+   the production `CompileConfig` path catches any future
+   regression that wraps or reformats the single-error result
+   inside `compileExpanded` (per Codex code-review round-1
+   finding on the original test design).
 
 3. **`TestCompileCheckMultiErrorRendersThroughGRPC`** —
    `pkg/grpcapi/server_config_test.go`. Construct a `*Server`
    directly with a temp-dir-backed `configstore.Store` per the
-   existing pattern at
-   `pkg/grpcapi/server_config_test.go:15-25` (no bufconn — the
-   existing tests call handlers directly). Seed the candidate
-   via `store.EnterConfigure()` + repeated `store.LoadSet(...)`
+   existing pattern in that file (no bufconn — the existing
+   tests construct handlers directly with a `*Server` value
+   plus a `*configstore.Store`). Seed the candidate via
+   `store.EnterConfigure()` + repeated `store.LoadSet(...)`
    with the same fixture lines as test 1 (CoS
    `equal-flow-enforcement` + policer `single-rate color-blind`
    + `then discard`). Call `s.CommitCheck(...)`; assert the
@@ -404,9 +409,10 @@ For the byte-identity test we call the helper directly (no parser).
    `\n`.
 
    Rationale (Codex r2 agreed): the rendering layer being
-   tested is `pkg/grpcapi/server_config.go:176`, not
+   tested is `pkg/grpcapi/server_config.go`, not
    configstore. Configstore only emits raw/wrapped errors via
-   `pkg/configstore/store.go:661`/`:681`. Testing at the gRPC
+   `pkg/configstore/store.go` (`Commit` wraps the compile
+   error). Testing at the gRPC
    boundary captures the actual operator-facing surface, and
    doing it via direct-handler call (not bufconn) matches the
    existing test style.
@@ -414,14 +420,14 @@ For the byte-identity test we call the helper directly (no parser).
 ### Existing test gates (must not regress)
 
 - `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
-  (`pkg/config/parser_ast_test.go:2855`) — DPDK contract.
+  (`pkg/config/parser_ast_test.go`) — DPDK contract.
 - `TestDPDKConfigCompileRejects`
   (`pkg/config/parser_ast_test.go`) — DPDK substring + sentinel.
 - `TestCompileClassOfServiceBothBufferFieldsRejected`
   (`pkg/config/parser_class_of_service_test.go`) — direct
   validator call, unaffected.
 - `TestCommit_RejectsDPDKDataplaneType`
-  (`pkg/configstore/store_test.go:1460`) — wrapped DPDK
+  (`pkg/configstore/store_test.go`) — wrapped DPDK
   substring through Commit, unaffected.
 - All other commit/commit-check substring tests in
   `pkg/configstore/store_test.go`.

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -92,10 +92,10 @@ Absolute scale of the win:
   single pass). For the upgrade scenario the issue body lays out
   explicitly, it's 2–3 (one error per family, capped at 3).
 - Surface area touched: ~6 lines of compile-driver code in
-  `compileExpanded` plus three new tests (accumulator multi-error,
-  single-element byte-identity, gRPC rendering). No new public
-  API, no new config knob, no change to individual validator
-  signatures or messages.
+  `compileExpanded` plus four new tests (two-family accumulator,
+  three-family accumulator, single-element byte-identity, gRPC
+  rendering). No new public API, no new config knob, no change
+  to individual validator signatures or messages.
 
 **Honest caveat on "one error per family."** Each existing
 strict validator still fail-fasts INTERNALLY (e.g.,
@@ -111,7 +111,7 @@ of scope (separate signatures + per-validator test rewrites).
 
 **If reviewers conclude the UX gain (one round-trip saved on a
 rare upgrade path) is too small to justify even ~6 LOC plus
-three tests, PLAN-KILL is an acceptable verdict.** The counter-position
+four tests, PLAN-KILL is an acceptable verdict.** The counter-position
 worth taking seriously: "fail-fast is simpler to reason about;
 trains the operator to fix one thing at a time; multi-error
 responses risk confusing operators about which finding is the
@@ -484,7 +484,10 @@ repeat), not a regression.
    rounds; plan v4 is the final).
 2. Edit `compileExpanded` per the design above (keep DPDK
    precheck; accumulate the remaining 3).
-3. Add the three new tests.
+3. Add the four new tests (two-family accumulator, three-family
+   accumulator, single-element byte-identity, gRPC rendering).
+   Note: the three-family accumulator test was added in the
+   code-review round via a Copilot-bot follow-up.
 4. `go test ./...` clean.
 5. 5× flake loop on the new tests.
 6. cargo build sanity.

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -1,0 +1,527 @@
+# #1538 — Accumulate strict validation errors into a multierror
+
+## Status
+
+v4 — addresses Codex round-3 PLAN-NEEDS-MINOR (3 findings) and
+AGY round-3 PLAN-NEEDS-MINOR (1 finding):
+- Drop the "REQUIRED to prevent short-circuiting" rationale for
+  `set system dataplane-type userspace`; it's harmless
+  explicitness because `validateDataplaneTypeStrict` only
+  rejects explicit `dpdk`, and unset == userspace via
+  `effectiveDataplaneType` at `pkg/config/compiler.go:1005`
+  (pinned by `TestDataplaneTypeOmittedCompilesCleanly` at
+  `pkg/config/parser_ast_test.go:2983`). Line stays as
+  self-documenting future-proofing.
+- Fix test-count to three throughout (was "two" at v3
+  plan.md:69 and :86).
+- Replace bad three-color-policer syntax
+  `action loss-priority high then discard` with schema-clean
+  `then discard` — the `action` form parses via the
+  schema-less fallback at `pkg/config/ast_edit.go:151-152` but
+  is silently ignored by `compiler_firewall.go:144-155` which
+  only traverses the `then` child.
+- Rewrite the gRPC test plan to match the existing direct-handler
+  test style at `pkg/grpcapi/server_config_test.go:15-25`
+  (no bufconn — the existing tests construct `*Server`
+  directly with a temp-dir Store and call handlers). Use
+  `store.LoadSet(...)` per existing pattern, not nonexistent
+  `LoadCandidate` / `Edit` APIs.
+
+v3 — addresses Codex round-2 PLAN-NEEDS-MINOR. AGY round-2 was
+PLAN-READY. The minor: the v2 fixture for
+`TestCompileMultipleStrictErrorsAccumulated` used the "both
+buffer-size bytes AND percent set" condition which is NOT
+parser-reachable (the parser's compile_class_of_service.go clears
+the alternate buffer field; `validateClassOfServiceStrict`
+explicitly documents that the both-set state can only arise from
+constructed configs). v3 fixes by:
+(a) using `equal-flow-enforcement` without `transmit-rate exact`
+as the parser-reachable CoS strict-validator error; and
+(b) clarifying the test count (three new tests, not two) and
+splitting fixture-build technique by test (parser-driven for the
+accumulator tests; direct-helper-call for the byte-identity test).
+
+v2 — addresses Codex round-1 PLAN-NEEDS-MAJOR (4 findings). AGY
+round-1 was PLAN-READY. Refactored to (a) preserve #1536's
+DPDK-first / no-leak contract by keeping `validateDataplaneTypeStrict`
+as a separate fail-fast precheck, (b) drop the "matches Junos"
+overclaim and frame as an xpf UX choice, (c) tighten wording to
+"one error per validator family," (d) add a gRPC rendering test.
+
+## Issue framing
+
+The strict-validator block in `pkg/config/compiler.go::compileExpanded`
+currently short-circuits on the first failure across three independent
+validator families:
+
+- `validateClassOfServiceStrict`   (compiler.go:244)
+- `validateThreeColorPolicersStrict` (compiler.go:247)
+- `validatePolicySchedulerReferencesStrict` (compiler.go:250)
+
+In an upgrade scenario where a legacy candidate carries multiple
+dormant structural errors (e.g., a malformed CoS scheduler-map
+plus a misconfigured three-color-policer that was committed
+months ago and never re-validated), the operator hits a
+whack-a-mole cycle: each `commit` surfaces one finding, they
+fix it, commit again, surface the next, and so on.
+
+Issue #1538 asks the strict-validator block to accumulate
+failures across these three families via `errors.Join` (Go 1.20+)
+and return one combined error so the operator sees the full
+picture from a single `commit check` response.
+
+**Scope is exactly three validator families.** The
+`validateDataplaneTypeStrict` precheck (added by #1536) is
+explicitly EXCLUDED — see "DPDK precheck contract" below.
+
+## Honest scope/value framing
+
+This is a UX/operator-friction change, not a perf or correctness
+change. The benefit is concentrated on **first-touch upgrade** and
+**rare bulk-import** flows; once an operator has done one `commit`
+cycle, the day-to-day "edit one stanza, commit, fix typo, commit"
+loop is unchanged.
+
+Absolute scale of the win:
+
+- Affected user population: operators upgrading a multi-year-old
+  candidate that survived through a feature deprecation window.
+- Round-trips saved per first-touch upgrade: O(number of dormant
+  strict-family errors). For most upgrades this is 1 (already a
+  single pass). For the upgrade scenario the issue body lays out
+  explicitly, it's 2–3 (one error per family, capped at 3).
+- Surface area touched: ~6 lines of compile-driver code in
+  `compileExpanded` plus three new tests (accumulator multi-error,
+  single-element byte-identity, gRPC rendering). No new public
+  API, no new config knob, no change to individual validator
+  signatures or messages.
+
+**Honest caveat on "one error per family."** Each existing
+strict validator still fail-fasts INTERNALLY (e.g.,
+`validateThreeColorPolicersStrict` at `pkg/config/compiler.go:262-303`
+returns on the first bad policer; `validateClassOfServiceStrict`
+at `:363+` returns on the first bad scheduler; same for
+`validatePolicySchedulerReferencesStrict`). This PR does NOT
+expand intra-validator accumulation. The operator gets at most
+ONE error from each family in a single response — a maximum of
+three findings, not "every dormant error." Future work could
+extend per-validator accumulation but that's deliberately out
+of scope (separate signatures + per-validator test rewrites).
+
+**If reviewers conclude the UX gain (one round-trip saved on a
+rare upgrade path) is too small to justify even ~6 LOC plus
+three tests, PLAN-KILL is an acceptable verdict.** The counter-position
+worth taking seriously: "fail-fast is simpler to reason about;
+trains the operator to fix one thing at a time; multi-error
+responses risk confusing operators about which finding is the
+root cause." If reviewers weight this argument over the
+upgrade-friction win, PLAN-KILL.
+
+## DPDK precheck contract — preserved verbatim
+
+PR #1536 (merged as commit cdad3c31 / merge 4508d714) installed
+`validateDataplaneTypeStrict` at `pkg/config/compiler.go:241`
+BEFORE the other strict validators with explicit UX intent
+(`compiler.go:234-243`): the operator must see the migration
+message FIRST when a candidate has both a retired dataplane-type
+AND any unrelated structural error.
+
+The brittle-by-design test `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
+at `pkg/config/parser_ast_test.go:2855` asserts BOTH:
+
+1. The DPDK retirement substring is present in the error
+   (`parser_ast_test.go:2909`).
+2. The string "three-color-policer" does NOT leak through
+   (`parser_ast_test.go:2913`).
+
+#1538 must NOT break either assertion. The clean answer is to
+KEEP `validateDataplaneTypeStrict` as a separate fail-fast
+precheck and only accumulate errors across the remaining three
+families. This is exactly the resolution path Codex round-1
+asked for ("keep DPDK as a separate pre-accumulator fail-fast
+gate").
+
+Concrete `compileExpanded` shape:
+
+```go
+// DPDK retirement is a migration message: it must surface FIRST
+// and alone when a candidate also has unrelated structural errors,
+// per #1526/#1536 UX intent and TestDataplaneTypeDPDKRejectedAtCommitFiresFirst.
+if err := validateDataplaneTypeStrict(cfg); err != nil {
+    return nil, err
+}
+
+// Remaining independent strict-validator families accumulate so
+// `commit check` returns one error per family in a single
+// response — saves operator round-trips on first-touch upgrades
+// from legacy candidates carrying multiple dormant findings.
+//
+// Validators in this group MUST be independent of each other:
+// each one reads its own typed sub-struct of *Config and does
+// not depend on any other validator's having succeeded. If a
+// future validator depends on another's success it must be
+// added as a SEPARATE post-accumulator step with its own guard.
+//
+// Note: each accumulated validator still fail-fasts INTERNALLY
+// (returns on its first finding within its own family). The
+// accumulator surfaces at most one error per family.
+var strictErrs []error
+if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
+    strictErrs = append(strictErrs, err)
+}
+if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
+    strictErrs = append(strictErrs, err)
+}
+if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
+    strictErrs = append(strictErrs, err)
+}
+if err := errors.Join(strictErrs...); err != nil {
+    return nil, err
+}
+```
+
+`errors.Join` with no args returns nil; the guard handles the
+empty case naturally. We use a slice + explicit `Join(...)`
+rather than a helper struct because:
+
+- It's a 6-line pattern, no new package surface.
+- The `errors` package is already imported in compiler.go
+  (verified at implementation time; added if not).
+
+## Junos semantics — framing as xpf UX, not parity claim
+
+Codex round-1 correctly observed that the v1 plan's
+"matches Junos commit check accumulation" framing was an
+overclaim: Junos's official documentation shows the
+`[edit ...]` rendering format but does NOT provide a public
+transcript proving accumulation across the specific validator
+classes touched here (CoS scheduler-map + three-color-policer
++ scheduler-reference). It is plausible Junos accumulates;
+plan v2 does NOT claim this without evidence.
+
+**Plan v2 framing:** this PR makes the xpf strict-validator
+block accumulate errors across three independent families as
+an xpf UX choice grounded in operator-friction reduction on
+upgrade flows. We do NOT claim Junos parity. The DPDK
+precheck remains fail-fast per #1536's explicit intent. If
+operators report Junos-divergence pain, a follow-up issue can
+add a `set system commit fail-fast-strict-validators` knob or
+similar.
+
+## Public API preservation
+
+- `CompileConfig(tree *ConfigTree) (*Config, error)` —
+  signature unchanged; return semantics unchanged (`(nil, err)`
+  on any strict validation failure, where the err is now an
+  `errors.Join` of up to 3 family errors when DPDK is NOT in
+  play; or the DPDK error alone when it is).
+- `CompileConfigForNode(tree *ConfigTree, nodeID int) (*Config, error)`
+  — same.
+- Individual validator signatures
+  (`validateDataplaneTypeStrict(*Config) error`,
+  `validateClassOfServiceStrict(*ClassOfServiceConfig) error`,
+  `validateThreeColorPolicersStrict(map[string]*ThreeColorPolicerConfig) error`,
+  `validatePolicySchedulerReferencesStrict(*Config) error`) —
+  unchanged.
+- `Store.Commit()` / `Store.CommitCheck()` /
+  `Store.CommitWithDescription()` / `Store.CommitConfirmed()` —
+  signatures unchanged; wrap-text unchanged.
+- gRPC `CommitCheck` / `Commit` — signatures unchanged.
+  `status.Errorf(codes.InvalidArgument, "%v", err)` renders the
+  joined multi-line text inside the gRPC error message.
+
+## errors.Join semantics — verified properties
+
+1. **`Error()` rendering.** `errors.Join(a, b).Error()` ==
+   `a.Error() + "\n" + b.Error()` (Go std lib spec).
+2. **`Is()` traversal.** `errors.Is(join, target)` returns true
+   if `errors.Is(any-joined-err, target)`. `errors.Join` returns
+   a `joinError` with `Unwrap() []error`, traversed by
+   `errors.Is` since Go 1.20.
+3. **Wrap chain.** `fmt.Errorf("commit check failed: %w", join)`
+   at `pkg/configstore/store.go:681` wraps the join into a
+   single `%w` chain; `errors.Is/As` traverse through that
+   wrap AND the underlying join.
+4. **Substring contracts.** `strings.Contains(join.Error(), substr)`
+   works because `errors.Join` preserves each constituent's
+   bytes; the only added bytes are `\n` separators between
+   children. No existing test in `pkg/config/*_test.go` or
+   `pkg/configstore/*_test.go` uses byte-exact `==` matching
+   on these errors (audited by Gemini/AGY rounds).
+
+## Hidden invariants the change must preserve
+
+1. **DPDK fail-fast + no-leak.** Documented above. Verified by
+   `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`.
+
+2. **Validator independence within the accumulator.**
+   - `validateClassOfServiceStrict` (`compiler.go:363+`) —
+     reads `cos.Schedulers` and `cos.SchedulerMaps` only. Nil-safe
+     on `cos == nil`, each `sched == nil`, each `schedMap == nil`,
+     missing scheduler reference.
+   - `validateThreeColorPolicersStrict` (`compiler.go:262+`) —
+     reads `cfg.Firewall.ThreeColorPolicers` map only. Nil-safe
+     on each `pol == nil`.
+   - `validatePolicySchedulerReferencesStrict` (`compiler.go:329+`) —
+     reads `cfg.Schedulers` and `cfg.Security.Policies` /
+     `cfg.Security.GlobalPolicies` only. Nil-safe on `cfg == nil`,
+     `zpp == nil`, `pol == nil || pol.SchedulerName == ""`.
+
+   `compileExpanded` only reaches the strict block after all
+   compile_* phases succeed (`compiler.go:82-153`), so the
+   typed sub-structs are independently populated regardless of
+   whether any one validator returns an error. Cross-contamination
+   is impossible: validators are pure functions over the typed
+   `*Config`.
+
+3. **Error message bytes preserved.** Each validator's
+   `fmt.Errorf(...)` call site is unchanged. Only the calling
+   block is restructured.
+
+4. **Ordering preserved when reported.** The slice append order
+   is CoS → policers → policy-scheduler-references. `errors.Join`
+   prints in slice order. This matches the v1 fail-fast order
+   so existing operator muscle memory (and any external runbook
+   pinning the visual order) is preserved.
+
+5. **No silent drop on the "no errors" path.** The
+   `if err := errors.Join(strictErrs...); err != nil { return nil, err }`
+   guard handles the empty-slice case (returns nil) and the
+   all-nil case. Happy path returns `(cfg, nil)` exactly as
+   before.
+
+## Risk assessment
+
+| Risk class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Validator outputs unchanged; only caller assembly differs. Existing per-validator tests continue to pass. |
+| DPDK contract break | NONE | DPDK precheck kept as separate fail-fast; `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` continues to pass. |
+| Performance regression | NONE | `commit check` runs once per commit; running 3 validators vs short-circuiting is microseconds. |
+| `errors.Join` semantics | LOW | Pattern already established (10+ existing sites). Go 1.20+ std lib. |
+| Substring contract drift | LOW | Audited — only `strings.Contains` matches exist on these errors; `\n` separators are inert. |
+| Junos UX divergence | UNKNOWN | We're not claiming parity. If operators report pain a fail-fast knob can be added in a follow-up. |
+| AST/parser interaction | NONE | Parser unaffected. |
+
+## Test plan
+
+### New tests — three total
+
+**Fixture choice — parser-reachable strict-validator errors.**
+
+The CoS "both buffer-size bytes AND percent set" condition is
+NOT parser-reachable: `pkg/config/compiler_class_of_service.go:239`
+clears the alternate field, and the validator at
+`pkg/config/compiler.go:386` notes the state "can only arise in
+constructed or externally-assembled configs." For tests that
+drive through `CompileConfig` we use parser-reachable conditions:
+
+- **CoS family error (parser-reachable):**
+  `set class-of-service schedulers <name> equal-flow-enforcement`
+  WITHOUT a `transmit-rate exact` setter — triggers
+  `class-of-service scheduler %q equal-flow-enforcement requires
+  positive transmit-rate exact` at `pkg/config/compiler.go:371-374`.
+- **Policer family error (parser-reachable):**
+  `set firewall three-color-policer <name> single-rate color-blind`
+  WITHOUT a `committed-information-rate` setter — triggers
+  `firewall three-color-policer %q requires positive
+  committed-information-rate` at `pkg/config/compiler.go:277-278`.
+
+For the byte-identity test we call the helper directly (no parser).
+
+---
+
+1. **`TestCompileMultipleStrictErrorsAccumulated`** —
+   `pkg/config/compiler_test.go` (new file, or appended to
+   `parser_class_of_service_test.go` if size allows). Drive via
+   `CompileConfig`. Construct a `ConfigTree` via
+   `ParseSetCommand` + `tree.SetPath` loop per CLAUDE.md "Parser
+   Dual AST Shape & Set Syntax Testing":
+
+   ```
+   set system dataplane-type userspace
+   set class-of-service schedulers bad-sched equal-flow-enforcement
+   set firewall three-color-policer bad-pol single-rate color-blind
+   set firewall three-color-policer bad-pol then discard
+   ```
+
+   The `set system dataplane-type userspace` line is harmless
+   explicitness (unset == userspace via `effectiveDataplaneType`
+   at `pkg/config/compiler.go:1005`, so the precheck at
+   `:319` returns nil either way — see
+   `TestDataplaneTypeOmittedCompilesCleanly` at
+   `pkg/config/parser_ast_test.go:2983`). Keeping the line in
+   the fixture makes the test self-documenting and guards
+   against any future change to the default-dataplane behavior.
+
+   The `then discard` line uses the schema-supported action
+   syntax for three-color-policer per
+   `pkg/config/ast.go:1237`; an earlier draft used the
+   schema-less `action loss-priority high then discard` which
+   parses (via the fallback path at `ast_edit.go:151-152`) but
+   is silently ignored by `compiler_firewall.go:144-155` since
+   the compiler only traverses the `then` child. Schema-clean
+   syntax keeps the test honest.
+
+   Assertions:
+   - `err != nil`.
+   - `strings.Contains(err.Error(), "equal-flow-enforcement")` —
+     CoS family error present.
+   - `strings.Contains(err.Error(), "committed-information-rate")` —
+     policer family error present.
+   - `strings.Count(err.Error(), "\n") == 1` — exactly one
+     newline between the two joined errors (verifies multi-error
+     rendering, not one validator winning by ordering).
+   - `errors.Is(err, ErrDPDKDataplaneRetired) == false` (DPDK
+     not in play; defense-in-depth).
+
+2. **`TestCompileSingleStrictErrorJoinPath`** —
+   `pkg/config/compiler_test.go`. Call the new
+   accumulator helper (`accumulateStrictValidators` or
+   inline-equivalent depending on implementation choice) with a
+   hand-built `*Config` that triggers only ONE family. Assert
+   `err.Error()` is byte-identical to the single underlying
+   validator return. The hand-built path is fine here because
+   the goal is to pin `errors.Join`'s single-element semantics
+   (Go std lib documents byte-identity at
+   `/usr/lib/go-1.24/src/errors/join.go:47-48`, confirmed by
+   Codex round-2). This protects against any future
+   helper-wrapper drift; the bare-`*Config` route makes the
+   test independent of parser/compiler shape changes.
+
+3. **`TestCompileCheckMultiErrorRendersThroughGRPC`** —
+   `pkg/grpcapi/server_config_test.go`. Construct a `*Server`
+   directly with a temp-dir-backed `configstore.Store` per the
+   existing pattern at
+   `pkg/grpcapi/server_config_test.go:15-25` (no bufconn — the
+   existing tests call handlers directly). Seed the candidate
+   via `store.EnterConfigure()` + repeated `store.LoadSet(...)`
+   with the same fixture lines as test 1 (CoS
+   `equal-flow-enforcement` + policer `single-rate color-blind`
+   + `then discard`). Call `s.CommitCheck(...)`; assert the
+   returned gRPC error has `status.Code() == codes.InvalidArgument`
+   and `status.Message()` contains BOTH error substrings (CoS
+   family + policer family) verbatim, separated by a single
+   `\n`.
+
+   Rationale (Codex r2 agreed): the rendering layer being
+   tested is `pkg/grpcapi/server_config.go:176`, not
+   configstore. Configstore only emits raw/wrapped errors via
+   `pkg/configstore/store.go:661`/`:681`. Testing at the gRPC
+   boundary captures the actual operator-facing surface, and
+   doing it via direct-handler call (not bufconn) matches the
+   existing test style.
+
+### Existing test gates (must not regress)
+
+- `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
+  (`pkg/config/parser_ast_test.go:2855`) — DPDK contract.
+- `TestDPDKConfigCompileRejects`
+  (`pkg/config/parser_ast_test.go`) — DPDK substring + sentinel.
+- `TestCompileClassOfServiceBothBufferFieldsRejected`
+  (`pkg/config/parser_class_of_service_test.go`) — direct
+  validator call, unaffected.
+- `TestCommit_RejectsDPDKDataplaneType`
+  (`pkg/configstore/store_test.go:1460`) — wrapped DPDK
+  substring through Commit, unaffected.
+- All other commit/commit-check substring tests in
+  `pkg/configstore/store_test.go`.
+
+### Flake check
+
+5× loop on `TestCompileMultipleStrictErrorsAccumulated`,
+`TestCompileSingleStrictErrorJoinPath`, and
+`TestCompileCheckMultiErrorRendersThroughGRPC` after
+implementation. Per standing rule.
+
+### Build / test cycle
+
+- `go build ./...` clean.
+- `go test ./pkg/config/... ./pkg/configstore/... ./pkg/grpcapi/...` clean.
+- `go test ./...` clean.
+- `cargo build --release` clean (no Rust touched).
+
+### Smoke matrix
+
+Full per-standing-rule matrix on `loss:xpf-userspace-fw0/fw1`:
+v4 + v6 × push + reverse × CoS-off + CoS-on. Per-standing rule
+the smoke is a sanity gate (config-compile-side only — no
+dataplane/Rust/FRR/networkd touched). Any throughput deviation
+vs master baseline is a smoke-environment issue (re-apply CoS,
+repeat), not a regression.
+
+## Out of scope (explicitly)
+
+- `set system commit fail-fast-strict-validators` knob —
+  follow-up if operator pain materializes.
+- Intra-validator accumulation. Each strict family still
+  fail-fasts internally; the PR only accumulates ACROSS
+  families.
+- Touching `validateDataplaneTypeStrict` — fail-fast precheck
+  intentionally preserved per #1536.
+- Touching the `ValidateConfig` warnings path.
+- Touching parse-phase errors (already fail-fast; parser bails
+  on lexer-level errors so the AST is incomplete and
+  subsequent validation would crash anyway).
+- Rendering changes to the CLI / gRPC `commit check` output
+  format. `%v` over an `errors.Join` renders newline-separated
+  by default; we accept that and don't add a custom formatter.
+- Adding a sentinel for "multiple validation errors." Callers
+  still match individual findings via `errors.Is` and substring;
+  no aggregate sentinel needed.
+
+## Implementation order
+
+1. Land plan v2; iterate to PLAN-READY across Codex + AGY.
+2. Edit `compileExpanded` per the design above (keep DPDK
+   precheck; accumulate the remaining 3).
+3. Add the three new tests.
+4. `go test ./...` clean.
+5. 5× flake loop on the new tests.
+6. cargo build sanity.
+7. Smoke matrix on loss userspace cluster.
+8. Open PR, dispatch Codex + AGY code review, wait for Copilot.
+9. Iterate to MERGE-READY across all four (Claude SMR + Codex
+   + AGY + Copilot). Auto-merge when 4-of-4 agree.
+10. Report PR URL + verdicts.
+
+## Open questions for adversarial reviewers (round 2)
+
+1. **Test placement for the gRPC rendering test.** Is
+   `pkg/grpcapi/server_config_test.go` the right home, or
+   should it live in `pkg/configstore/store_test.go` since
+   that's where the wrap chain originates? Plan picks
+   `pkg/grpcapi` because that's where the rendering layer
+   tested (`%v` of a `status.Errorf`) actually lives. Open
+   to alternative if reviewer prefers configstore.
+
+2. **One-element Join byte-identity guarantee.** Plan asserts
+   `errors.Join(singleErr).Error() == singleErr.Error()` per
+   Go std lib spec. Is there a documented edge case where
+   the joinError adds framing for the one-element case?
+   The Go `errors.Join` docstring says it returns nil if
+   every error is nil and otherwise concatenates with `\n`;
+   for a single non-nil input the concatenation is
+   single-element so no separator is emitted. Verify against
+   Go 1.20+ source if in doubt.
+
+3. **`errors.Is` traversal through Join + %w wrap.** Plan
+   relies on Go 1.20's multi-unwrap behavior. The wrap chain
+   here is `fmt.Errorf("commit check failed: %w", join)` →
+   `join.Unwrap() []error` → individual validator errors.
+   `errors.Is` traverses both. If a reviewer has evidence of
+   Go-version-specific behavior or a particular sentinel
+   that won't traverse, flag.
+
+4. **Smoke is a sanity gate, not a regression gate.** This is
+   a Go-only config-side change. Per standing-rule smoke we
+   still run the full 6-port v4+v6 × push+reverse × CoS
+   matrix, but expectations are byte-identical throughput
+   vs master. Reviewers concerned about hidden coupling
+   should call it out.
+
+5. **PLAN-KILL grounds.** The UX win is one round-trip saved
+   on the rare upgrade path. Codex round-1 did NOT
+   PLAN-KILL but the counter-argument ("fail-fast is simpler
+   to reason about") is still valid. Reviewers who weight
+   the simplicity argument over the upgrade-friction one
+   should PLAN-KILL explicitly.

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -305,7 +305,11 @@ similar.
 
 ## Test plan
 
-### New tests — three total
+### New tests — four total
+
+(The fourth, `TestCompileAllThreeStrictValidatorsAccumulated`, was
+added in the code-review round via a Copilot-bot follow-up to
+close third-family coverage. It is described under test #4 below.)
 
 **Fixture choice — parser-reachable strict-validator errors.**
 
@@ -420,6 +424,31 @@ against a direct validator call as the reference value.
    doing it via direct-handler call (not bufconn) matches the
    existing test style.
 
+4. **`TestCompileAllThreeStrictValidatorsAccumulated`** —
+   `pkg/config/compiler_test.go`. Added in the code-review round
+   via a Copilot-bot follow-up to close third-family coverage
+   (the original three planned tests covered two families plus
+   gRPC rendering; the third family —
+   `validatePolicySchedulerReferencesStrict` — was not exercised
+   by any of them). Same parser-driven `CompileConfig` style as
+   test 1, with a triple-family fixture:
+
+   ```
+   set system dataplane-type userspace
+   set class-of-service schedulers bad-sched equal-flow-enforcement
+   set firewall three-color-policer bad-pol single-rate color-blind
+   set firewall three-color-policer bad-pol then discard
+   set security policies from-zone trust to-zone untrust policy sched-test ...
+   set security policies from-zone trust to-zone untrust policy sched-test scheduler-name missing-sched
+   ```
+
+   Assertions:
+   - All three substrings present (`equal-flow-enforcement`,
+     `committed-information-rate`,
+     `references undefined scheduler`).
+   - `strings.Count(err.Error(), "\n") == 2` (three errors →
+     two newlines per `errors.Join` semantics).
+
 ### Existing test gates (must not regress)
 
 - `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`
@@ -438,9 +467,10 @@ against a direct validator call as the reference value.
 ### Flake check
 
 5× loop on `TestCompileMultipleStrictErrorsAccumulated`,
-`TestCompileSingleStrictErrorJoinPath`, and
-`TestCompileCheckMultiErrorRendersThroughGRPC` after
-implementation. Per standing rule.
+`TestCompileSingleStrictErrorJoinPath`,
+`TestCompileAllThreeStrictValidatorsAccumulated` (added in the
+code-review round), and `TestCompileCheckMultiErrorRendersThroughGRPC`
+after implementation. Per standing rule.
 
 ### Build / test cycle
 

--- a/docs/pr/1538-multierror-validation/plan.md
+++ b/docs/pr/1538-multierror-validation/plan.md
@@ -8,7 +8,7 @@ AGY round-3 PLAN-NEEDS-MINOR (1 finding):
   `set system dataplane-type userspace`; it's harmless
   explicitness because `validateDataplaneTypeStrict` only
   rejects explicit `dpdk`, and unset == userspace via
-  `effectiveDataplaneType` at `pkg/config/compiler.go:1005`
+  `effectiveDataplaneType` in `pkg/config/compiler.go`
   (pinned by `TestDataplaneTypeOmittedCompilesCleanly` at
   `pkg/config/parser_ast_test.go:2983`). Line stays as
   self-documenting future-proofing.
@@ -98,7 +98,7 @@ Absolute scale of the win:
 
 **Honest caveat on "one error per family."** Each existing
 strict validator still fail-fasts INTERNALLY (e.g.,
-`validateThreeColorPolicersStrict` at `pkg/config/compiler.go:262-303`
+`validateThreeColorPolicersStrict` in `pkg/config/compiler.go`
 returns on the first bad policer; `validateClassOfServiceStrict`
 at `:363+` returns on the first bad scheduler; same for
 `validatePolicySchedulerReferencesStrict`). This PR does NOT
@@ -255,14 +255,14 @@ similar.
    `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst`.
 
 2. **Validator independence within the accumulator.**
-   - `validateClassOfServiceStrict` (`compiler.go:363+`) —
+   - `validateClassOfServiceStrict` (`compiler.go`) —
      reads `cos.Schedulers` and `cos.SchedulerMaps` only. Nil-safe
      on `cos == nil`, each `sched == nil`, each `schedMap == nil`,
      missing scheduler reference.
    - `validateThreeColorPolicersStrict` (`compiler.go:262+`) —
      reads `cfg.Firewall.ThreeColorPolicers` map only. Nil-safe
      on each `pol == nil`.
-   - `validatePolicySchedulerReferencesStrict` (`compiler.go:329+`) —
+   - `validatePolicySchedulerReferencesStrict` (`compiler.go`) —
      reads `cfg.Schedulers` and `cfg.Security.Policies` /
      `cfg.Security.GlobalPolicies` only. Nil-safe on `cfg == nil`,
      `zpp == nil`, `pol == nil || pol.SchedulerName == ""`.
@@ -311,7 +311,7 @@ similar.
 The CoS "both buffer-size bytes AND percent set" condition is
 NOT parser-reachable: `pkg/config/compiler_class_of_service.go:239`
 clears the alternate field, and the validator at
-`pkg/config/compiler.go:386` notes the state "can only arise in
+the comment in `pkg/config/compiler.go` notes the state "can only arise in
 constructed or externally-assembled configs." For tests that
 drive through `CompileConfig` we use parser-reachable conditions:
 
@@ -319,12 +319,12 @@ drive through `CompileConfig` we use parser-reachable conditions:
   `set class-of-service schedulers <name> equal-flow-enforcement`
   WITHOUT a `transmit-rate exact` setter — triggers
   `class-of-service scheduler %q equal-flow-enforcement requires
-  positive transmit-rate exact` at `pkg/config/compiler.go:371-374`.
+  positive transmit-rate exact` in `validateClassOfServiceStrict`.
 - **Policer family error (parser-reachable):**
   `set firewall three-color-policer <name> single-rate color-blind`
   WITHOUT a `committed-information-rate` setter — triggers
   `firewall three-color-policer %q requires positive
-  committed-information-rate` at `pkg/config/compiler.go:277-278`.
+  committed-information-rate` in `validateThreeColorPolicersStrict`.
 
 For the byte-identity test we call the helper directly (no parser).
 
@@ -346,21 +346,21 @@ For the byte-identity test we call the helper directly (no parser).
 
    The `set system dataplane-type userspace` line is harmless
    explicitness (unset == userspace via `effectiveDataplaneType`
-   at `pkg/config/compiler.go:1005`, so the precheck at
-   `:319` returns nil either way — see
-   `TestDataplaneTypeOmittedCompilesCleanly` at
-   `pkg/config/parser_ast_test.go:2983`). Keeping the line in
-   the fixture makes the test self-documenting and guards
-   against any future change to the default-dataplane behavior.
+   in `pkg/config/compiler.go`, so `validateDataplaneTypeStrict`
+   returns nil either way — see
+   `TestDataplaneTypeOmittedCompilesCleanly` in
+   `pkg/config/parser_ast_test.go`). Keeping the line in the
+   fixture makes the test self-documenting and guards against
+   any future change to the default-dataplane behavior.
 
    The `then discard` line uses the schema-supported action
-   syntax for three-color-policer per
-   `pkg/config/ast.go:1237`; an earlier draft used the
+   syntax for three-color-policer per the `three-color-policer`
+   entry in `pkg/config/ast.go`; an earlier draft used the
    schema-less `action loss-priority high then discard` which
-   parses (via the fallback path at `ast_edit.go:151-152`) but
-   is silently ignored by `compiler_firewall.go:144-155` since
-   the compiler only traverses the `then` child. Schema-clean
-   syntax keeps the test honest.
+   parses (via the fallback path in `ast_edit.go`) but is
+   silently ignored by the three-color-policer compile block in
+   `compiler_firewall.go` because the compiler only traverses
+   the `then` child. Schema-clean syntax keeps the test honest.
 
    Assertions:
    - `err != nil`.

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -25,4 +25,26 @@
 ## Round 4 (plan v4 @ commit 9a0e7012)
 
 - Codex: `task-mplcd8yt-ne3g43`
+  - Verdict: PLAN-READY
 - Antigravity: `adversarial-review-mplcdckp-lp3qxi`
+  - Verdict: PLAN-READY
+
+## Code review (HEAD 15c217f0 — PR #1556)
+
+- Codex: `task-mplcmpc3-iq7iho`
+  - Verdict: NEEDS-MINOR
+    1. `TestCompileSingleStrictErrorJoinPath` should exercise
+       production path (not inline-duplicate the accumulator).
+    2. Stale `file:line` citations after rebase
+       (`compiler.go:371-374`, `:277-278`, `:1005`).
+    3. `reviewer-ids.md` round-4 missing PLAN-READY verdicts.
+- Antigravity: `adversarial-review-mplcmu4f-k9ph8t`
+  - Verdict: MERGE-READY
+- Copilot: review at PR #1556 comment
+  - Verdict: PASS (state COMMENTED, zero inline comments)
+- Claude SMR: self-review of diff; matches plan v4 exactly.
+  Verdict: PASS
+
+## Code review round 2 (after Codex r1 NEEDS-MINOR fixes)
+
+- Pending dispatch after this commit.

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -4,14 +4,16 @@ This worktree is named after the issue (#1538). The pull request
 opened from this branch is #1556. Reviewer IDs below cover both
 plan-review (no PR yet) and code-review (PR #1556) phases.
 
-## Round 1 (plan v1 @ commit 6f8864a2)
+## Plan review
+
+### Round 1 (plan v1 @ commit 6f8864a2)
 
 - Codex: `task-mpkud1hj-h55qgf`
   - Verdict: PLAN-NEEDS-MAJOR (DPDK contract, Junos-overclaim, "all errors" tightening, gRPC render test)
 - Antigravity: `adversarial-review-mpkudfan-ktnk1o`
   - Verdict: PLAN-READY
 
-## Round 2 (plan v2 @ commit a6e1ff2f, rebased onto master with #1536 in)
+### Round 2 (plan v2 @ commit a6e1ff2f, rebased onto master with #1536 in)
 
 - Codex: `task-mplbyp5a-tuv7or` (failed: gpt-5.4-codex model unsupported)
 - Codex retry: `task-mplc1eqx-xii412`
@@ -19,28 +21,29 @@ plan-review (no PR yet) and code-review (PR #1556) phases.
 - Antigravity: `adversarial-review-mplbyvjc-dllwcq`
   - Verdict: PLAN-READY
 
-## Round 3 (plan v3 @ commit c56d329f)
+### Round 3 (plan v3 @ commit c56d329f)
 
 - Codex: `task-mplc5x4p-u5n85r`
   - Verdict: PLAN-NEEDS-MINOR (REQUIRED-rationale wrong; test count; gRPC API names)
 - Antigravity: `adversarial-review-mplc60nw-pbk1jd`
   - Verdict: PLAN-NEEDS-MINOR (action vs then syntax)
 
-## Round 4 (plan v4 @ commit 9a0e7012)
+### Round 4 (plan v4 @ commit 9a0e7012)
 
 - Codex: `task-mplcd8yt-ne3g43`
   - Verdict: PLAN-READY
 - Antigravity: `adversarial-review-mplcdckp-lp3qxi`
   - Verdict: PLAN-READY
 
-## Code review (HEAD 15c217f0 — PR #1556)
+## Code review (PR #1556)
+
+### Round 1 (HEAD 15c217f0 — initial implementation)
 
 - Codex: `task-mplcmpc3-iq7iho`
   - Verdict: NEEDS-MINOR
     1. `TestCompileSingleStrictErrorJoinPath` should exercise
        production path (not inline-duplicate the accumulator).
-    2. Stale `file:line` citations after rebase
-       (`compiler.go:371-374`, `:277-278`, `:1005`).
+    2. Stale `file:line` citations after rebase.
     3. `reviewer-ids.md` round-4 missing PLAN-READY verdicts.
 - Antigravity: `adversarial-review-mplcmu4f-k9ph8t`
   - Verdict: MERGE-READY
@@ -49,6 +52,41 @@ plan-review (no PR yet) and code-review (PR #1556) phases.
 - Claude SMR: self-review of diff; matches plan v4 exactly.
   Verdict: PASS
 
-## Code review round 2 (after Codex r1 NEEDS-MINOR fixes)
+### Round 2 (HEAD 09fc2ab4 — Codex r1 fixes)
 
-- Pending dispatch after this commit.
+- Codex: `task-mplcumi6-yb0v8e`
+  - Verdict: NEEDS-MINOR (two doc-only inconsistencies in plan.md —
+    old test design description and stale citations)
+- Antigravity: `adversarial-review-mplcunur-jzqbh8`
+  - Verdict: MERGE-READY
+- Copilot SWE bot: commit b4f173a0 (variable shadowing fix in
+  `TestCompileMultipleStrictErrorsAccumulated`)
+
+### Round 3 (HEAD d1ec917c — Codex r2 doc fixes)
+
+- Codex: `task-mpld19rt-whyw2l`
+  - Verdict: NEEDS-MINOR (two residual doc inconsistencies in plan.md)
+- Antigravity: `adversarial-review-mpld1ayz-46l2lp`
+  - Verdict: MERGE-READY
+- Copilot: review at PR #1556
+  - Verdict: 1 inline comment (issue #1538 vs PR #1556 header
+    clarification) — addressed in ec42a333
+- Copilot SWE bot: commit 66e07247 (variable shadowing fix in
+  `TestCompileSingleStrictErrorJoinPath` + adds
+  `TestCompileAllThreeStrictValidatorsAccumulated` for third-family
+  coverage)
+
+### Round 4 (HEAD 06d493fd — final doc cleanup + bot test additions)
+
+- Codex: `task-mpldctxh-xd4e5r`
+  - Verdict: NEEDS-MINOR (plan.md still said "three tests" after bot
+    added a fourth — addressed in 135ac2dd)
+- Antigravity: `adversarial-review-mpldcv4t-z618w9`
+  - Verdict: MERGE-READY
+- Copilot: review at PR #1556
+  - Verdict: PASS (no new comments)
+
+### Round 5 (HEAD 135ac2dd — final test-count update)
+
+- Codex: `task-mpldgaxh-3uhgjm`
+  - Verdict: pending

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -89,4 +89,15 @@ plan-review (no PR yet) and code-review (PR #1556) phases.
 ### Round 5 (HEAD 135ac2dd — final test-count update)
 
 - Codex: `task-mpldgaxh-3uhgjm`
-  - Verdict: pending
+  - Verdict: NEEDS-MINOR ("New tests — three total" section
+    header + flake-check list still said three; addressed in
+    f16fd64e)
+- Antigravity: not dispatched (no code change, only doc;
+  r4 MERGE-READY still applies to the code)
+
+### Round 6 (HEAD f16fd64e — complete four-tests update)
+
+- Codex: `task-mpldivmf-wqx812`
+  - Verdict: NEEDS-MINOR (reviewer-ids.md r5 entry said
+    "pending"; addressed in this commit)
+- Antigravity: `adversarial-review-mpldix4e-vyjru7`

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -111,6 +111,19 @@ plan-review (no PR yet) and code-review (PR #1556) phases.
   - Verdict: NEEDS-MINOR (round 6 AGY verdict missing —
     addressed in this commit)
 
-### Round 8 (after this commit)
+### Round 8 (HEAD a4151a6b — final lock)
 
-- Pending re-verification after this commit lands.
+- Codex: `task-mpldog0j-876c1w`
+  - Verdict: MERGE-READY
+- Antigravity: r5 MERGE-READY still applies (no code change)
+- Copilot: r5 PASS still applies (no code change)
+
+## Final consensus
+
+All four reviewers MERGE-READY at HEAD a4151a6b:
+  - Codex: MERGE-READY (r8)
+  - Antigravity: MERGE-READY (r5)
+  - Copilot: PASS (r5, no inline comments)
+  - Claude SMR: PASS
+
+Posting AWAITING-SMOKE per standing rule.

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -1,4 +1,8 @@
-# Reviewer Job IDs — #1538 multierror validation
+# Reviewer Job IDs — issue #1538 / PR #1556 (multierror validation)
+
+This worktree is named after the issue (#1538). The pull request
+opened from this branch is #1556. Reviewer IDs below cover both
+plan-review (no PR yet) and code-review (PR #1556) phases.
 
 ## Round 1 (plan v1 @ commit 6f8864a2)
 

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -99,5 +99,18 @@ plan-review (no PR yet) and code-review (PR #1556) phases.
 
 - Codex: `task-mpldivmf-wqx812`
   - Verdict: NEEDS-MINOR (reviewer-ids.md r5 entry said
-    "pending"; addressed in this commit)
+    "pending"; addressed in 68c2327c)
 - Antigravity: `adversarial-review-mpldix4e-vyjru7`
+  - Verdict: MERGE-READY
+- Copilot: review at PR #1556
+  - Verdict: PASS (no new comments)
+
+### Round 7 (HEAD 68c2327c — reviewer-ids fix)
+
+- Codex: `task-mpldlvnx-dfu9bd`
+  - Verdict: NEEDS-MINOR (round 6 AGY verdict missing —
+    addressed in this commit)
+
+### Round 8 (after this commit)
+
+- Pending re-verification after this commit lands.

--- a/docs/pr/1538-multierror-validation/reviewer-ids.md
+++ b/docs/pr/1538-multierror-validation/reviewer-ids.md
@@ -1,0 +1,28 @@
+# Reviewer Job IDs — #1538 multierror validation
+
+## Round 1 (plan v1 @ commit 6f8864a2)
+
+- Codex: `task-mpkud1hj-h55qgf`
+  - Verdict: PLAN-NEEDS-MAJOR (DPDK contract, Junos-overclaim, "all errors" tightening, gRPC render test)
+- Antigravity: `adversarial-review-mpkudfan-ktnk1o`
+  - Verdict: PLAN-READY
+
+## Round 2 (plan v2 @ commit a6e1ff2f, rebased onto master with #1536 in)
+
+- Codex: `task-mplbyp5a-tuv7or` (failed: gpt-5.4-codex model unsupported)
+- Codex retry: `task-mplc1eqx-xii412`
+  - Verdict: PLAN-NEEDS-MINOR (parser-reachability of fixture; test count)
+- Antigravity: `adversarial-review-mplbyvjc-dllwcq`
+  - Verdict: PLAN-READY
+
+## Round 3 (plan v3 @ commit c56d329f)
+
+- Codex: `task-mplc5x4p-u5n85r`
+  - Verdict: PLAN-NEEDS-MINOR (REQUIRED-rationale wrong; test count; gRPC API names)
+- Antigravity: `adversarial-review-mplc60nw-pbk1jd`
+  - Verdict: PLAN-NEEDS-MINOR (action vs then syntax)
+
+## Round 4 (plan v4 @ commit 9a0e7012)
+
+- Codex: `task-mplcd8yt-ne3g43`
+- Antigravity: `adversarial-review-mplcdckp-lp3qxi`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -237,17 +237,39 @@ func compileExpanded(tree *ConfigTree) (*Config, error) {
 	// an unrelated structural error (CoS, policers, scheduler-map)
 	// sees the migration message first. The retirement is the
 	// documented migration path; the other errors only become
-	// actionable after migration.
+	// actionable after migration. This precheck stays fail-fast
+	// (the no-leak contract is pinned by
+	// TestDataplaneTypeDPDKRejectedAtCommitFiresFirst in
+	// parser_ast_test.go).
 	if err := validateDataplaneTypeStrict(cfg); err != nil {
 		return nil, err
 	}
+
+	// #1538 — accumulate independent strict-validator families so
+	// `commit check` surfaces one error per family in a single
+	// response. This saves operator round-trips on first-touch
+	// upgrades from legacy candidates that carry several dormant
+	// structural findings at once. Validators in this group MUST
+	// remain independent: each reads its own typed sub-struct of
+	// *Config and does not depend on another's success. Each
+	// validator still fail-fasts INTERNALLY (one error per family
+	// in a single response), which is sufficient for the upgrade
+	// UX win; full intra-validator accumulation is deliberately
+	// out of scope. If a future validator depends on another's
+	// success it must be added as a separate post-accumulator
+	// step with its own guard rather than slotted in alongside
+	// the independent set.
+	var strictErrs []error
 	if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
-		return nil, err
+		strictErrs = append(strictErrs, err)
 	}
 	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
-		return nil, err
+		strictErrs = append(strictErrs, err)
 	}
 	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := errors.Join(strictErrs...); err != nil {
 		return nil, err
 	}
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {

--- a/pkg/config/compiler_test.go
+++ b/pkg/config/compiler_test.go
@@ -142,9 +142,10 @@ func TestCompileSingleStrictErrorJoinPath(t *testing.T) {
 
 	// Byte-identity assertion: errors.Join with exactly one
 	// non-nil child must emit the child's text verbatim.
-	if got, want := err.Error(), want.Error(); got != want {
+	gotStr, wantStr := err.Error(), want.Error()
+	if gotStr != wantStr {
 		t.Errorf("single-element errors.Join in compileExpanded produced framing drift:\n  got  = %q\n  want = %q",
-			got, want)
+			gotStr, wantStr)
 	}
 
 	// Defense-in-depth: no '\n' separator on the single-family
@@ -161,5 +162,75 @@ func TestCompileSingleStrictErrorJoinPath(t *testing.T) {
 	// join path.
 	if errors.Is(err, ErrDPDKDataplaneRetired) {
 		t.Errorf("errors.Is(err, ErrDPDKDataplaneRetired) = true; DPDK not in fixture: %q", err.Error())
+	}
+}
+
+// TestCompileAllThreeStrictValidatorsAccumulated closes the coverage
+// gap identified in the Copilot code review: the 2-family test
+// (TestCompileMultipleStrictErrorsAccumulated) does not exercise
+// validatePolicySchedulerReferencesStrict, so a silent removal of
+// that validator's append call from the accumulator would go
+// undetected. This test fires all three independent strict-validator
+// families simultaneously and pins the count of accumulated errors.
+//
+// Fixture:
+//   - CoS: equal-flow-enforcement without transmit-rate exact
+//     (validateClassOfServiceStrict).
+//   - Policer: single-rate color-blind with CIR=0
+//     (validateThreeColorPolicersStrict).
+//   - Scheduler-ref: a zone policy referencing a scheduler name not
+//     present in the compiled schedulers map
+//     (validatePolicySchedulerReferencesStrict).
+//
+// All three set commands are parser-reachable (same path as
+// the existing single-family tests in parser_ast_test.go).
+func TestCompileAllThreeStrictValidatorsAccumulated(t *testing.T) {
+	lines := []string{
+		"set system dataplane-type userspace",
+		// CoS family
+		"set class-of-service schedulers bad-sched equal-flow-enforcement",
+		// Policer family
+		"set firewall three-color-policer bad-pol single-rate color-blind",
+		"set firewall three-color-policer bad-pol then discard",
+		// Scheduler-reference family: zone policy referencing a
+		// scheduler that is not defined in the compiled config.
+		"set security policies from-zone trust to-zone untrust policy sched-test match source-address any",
+		"set security policies from-zone trust to-zone untrust policy sched-test match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy sched-test match application any",
+		"set security policies from-zone trust to-zone untrust policy sched-test then permit",
+		"set security policies from-zone trust to-zone untrust policy sched-test scheduler-name missing-sched",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded; expected all three strict-validator families to error")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "equal-flow-enforcement") {
+		t.Errorf("error missing CoS-family substring 'equal-flow-enforcement': %q", errStr)
+	}
+	if !strings.Contains(errStr, "committed-information-rate") {
+		t.Errorf("error missing policer-family substring 'committed-information-rate': %q", errStr)
+	}
+	if !strings.Contains(errStr, "references undefined scheduler") {
+		t.Errorf("error missing scheduler-ref-family substring 'references undefined scheduler': %q", errStr)
+	}
+	// Three errors → two '\n' separators (N errors → N-1 newlines
+	// per errors.Join semantics). A regression that drops one
+	// append call reduces this to 1; a fail-fast regression reduces
+	// it to 0.
+	if nc := strings.Count(errStr, "\n"); nc != 2 {
+		t.Errorf("newline count = %d, want 2 (two '\\n' between three joined errors): %q", nc, errStr)
 	}
 }

--- a/pkg/config/compiler_test.go
+++ b/pkg/config/compiler_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestCompileMultipleStrictErrorsAccumulated verifies that #1538's
+// accumulator surfaces ONE error per independent strict-validator
+// family in a single `CompileConfig` response — saving operator
+// round-trips on first-touch upgrades that carry several dormant
+// findings at once.
+//
+// Fixture (parser-reachable):
+//   - CoS family: `class-of-service schedulers <name>
+//     equal-flow-enforcement` without `transmit-rate exact`
+//     triggers validateClassOfServiceStrict at
+//     compiler.go:371-374.
+//   - Policer family: `firewall three-color-policer <name>
+//     single-rate color-blind` (with the schema-clean `then
+//     discard` action) leaves CIR=0, triggering
+//     validateThreeColorPolicersStrict at compiler.go:277-278.
+//
+// The `set system dataplane-type userspace` line is harmless
+// explicitness: unset == userspace via effectiveDataplaneType
+// (compiler.go:1005) and validateDataplaneTypeStrict only rejects
+// explicit `dpdk`. Keeping the line self-documents the test and
+// guards against future default-dataplane behavior changes.
+//
+// The DPDK precheck stays fail-fast (#1526 contract pinned by
+// TestDataplaneTypeDPDKRejectedAtCommitFiresFirst); this test
+// proves the *post-precheck* accumulator block does the right
+// thing.
+func TestCompileMultipleStrictErrorsAccumulated(t *testing.T) {
+	lines := []string{
+		"set system dataplane-type userspace",
+		"set class-of-service schedulers bad-sched equal-flow-enforcement",
+		"set firewall three-color-policer bad-pol single-rate color-blind",
+		"set firewall three-color-policer bad-pol then discard",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded; expected accumulated strict-validator errors")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "equal-flow-enforcement") {
+		t.Errorf("error missing CoS-family substring 'equal-flow-enforcement': %q", got)
+	}
+	if !strings.Contains(got, "committed-information-rate") {
+		t.Errorf("error missing policer-family substring 'committed-information-rate': %q", got)
+	}
+	// Exactly one '\n' separator → exactly two joined errors.
+	// A regression to fail-fast (or to leaking ALL family errors
+	// where none were intended) trips this gate.
+	if got, want := strings.Count(got, "\n"), 1; got != want {
+		t.Errorf("newline count = %d, want %d (one '\\n' between two joined errors): %q",
+			got, want, err.Error())
+	}
+	// Defense-in-depth: DPDK sentinel must not surface — DPDK was
+	// not in the fixture, so the precheck cannot fire.
+	if errors.Is(err, ErrDPDKDataplaneRetired) {
+		t.Errorf("errors.Is(err, ErrDPDKDataplaneRetired) = true; DPDK was not in fixture: %q", got)
+	}
+}
+
+// TestCompileSingleStrictErrorJoinPath pins errors.Join's
+// single-element byte-identity semantics: when only ONE strict-
+// validator family fires under the accumulator, the returned
+// error's Error() must be byte-identical to the underlying
+// validator's return — no leading/trailing newline, no header
+// framing. This protects against any future helper-wrapper drift
+// (custom multierror type, prefix, etc.) that would silently
+// change operator-facing error text on the single-error path.
+//
+// Verified against /usr/lib/go-1.24/src/errors/join.go:47-48
+// per Codex round-2 verification. The hand-built *Config route
+// keeps the test independent of parser/compiler-shape changes.
+func TestCompileSingleStrictErrorJoinPath(t *testing.T) {
+	// Hand-build a *Config that triggers only the CoS family.
+	// We invoke the validators inline (mirroring compileExpanded's
+	// post-precheck accumulator block) so the test is independent
+	// of the parse + compile pipeline.
+	cfg := &Config{
+		ClassOfService: &ClassOfServiceConfig{
+			Schedulers: map[string]*CoSScheduler{
+				"bad-sched": {
+					Name:                 "bad-sched",
+					EqualFlowEnforcement: true,
+					// TransmitRateExact=false, TransmitRateBytes=0:
+					// triggers the validator.
+				},
+			},
+			SchedulerMaps:       make(map[string]*CoSSchedulerMap),
+			ForwardingClasses:   make(map[string]*CoSForwardingClass),
+			DSCPClassifiers:     make(map[string]*CoSDSCPClassifier),
+			IEEE8021Classifiers: make(map[string]*CoSIEEE8021Classifier),
+			DSCPRewriteRules:    make(map[string]*CoSDSCPRewriteRule),
+			Interfaces:          make(map[string]*CoSInterface),
+		},
+		Firewall: FirewallConfig{
+			ThreeColorPolicers: map[string]*ThreeColorPolicerConfig{},
+		},
+	}
+
+	// Reference: what does the single underlying validator return?
+	direct := validateClassOfServiceStrict(cfg.ClassOfService)
+	if direct == nil {
+		t.Fatal("validateClassOfServiceStrict returned nil; fixture is broken")
+	}
+
+	// Apply the same accumulator pattern compileExpanded uses.
+	var strictErrs []error
+	if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
+		strictErrs = append(strictErrs, err)
+	}
+	joined := errors.Join(strictErrs...)
+	if joined == nil {
+		t.Fatal("errors.Join over single non-nil err returned nil")
+	}
+
+	// Byte-identity assertion: errors.Join with exactly one
+	// non-nil child must emit the child's text verbatim.
+	if got, want := joined.Error(), direct.Error(); got != want {
+		t.Errorf("single-element errors.Join produced framing drift:\n  got  = %q\n  want = %q",
+			got, want)
+	}
+}

--- a/pkg/config/compiler_test.go
+++ b/pkg/config/compiler_test.go
@@ -56,24 +56,26 @@ func TestCompileMultipleStrictErrorsAccumulated(t *testing.T) {
 		t.Fatal("CompileConfig succeeded; expected accumulated strict-validator errors")
 	}
 
-	got := err.Error()
-	if !strings.Contains(got, "equal-flow-enforcement") {
-		t.Errorf("error missing CoS-family substring 'equal-flow-enforcement': %q", got)
+	errStr := err.Error()
+	if !strings.Contains(errStr, "equal-flow-enforcement") {
+		t.Errorf("error missing CoS-family substring 'equal-flow-enforcement': %q", errStr)
 	}
-	if !strings.Contains(got, "committed-information-rate") {
-		t.Errorf("error missing policer-family substring 'committed-information-rate': %q", got)
+	if !strings.Contains(errStr, "committed-information-rate") {
+		t.Errorf("error missing policer-family substring 'committed-information-rate': %q", errStr)
 	}
-	// Exactly one '\n' separator → exactly two joined errors.
-	// A regression to fail-fast (or to leaking ALL family errors
-	// where none were intended) trips this gate.
-	if got, want := strings.Count(got, "\n"), 1; got != want {
-		t.Errorf("newline count = %d, want %d (one '\\n' between two joined errors): %q",
-			got, want, err.Error())
+	// Exactly one '\n' separator because this fixture fires exactly
+	// two validator families (CoS + policer). errors.Join places
+	// one '\n' between N joined errors, so N-errors → N-1 newlines.
+	// A regression to fail-fast (one family silently swallowed)
+	// drops the count to 0; full-accumulation leak (all sub-errors
+	// from inside a single family) raises it above 1.
+	if nc := strings.Count(errStr, "\n"); nc != 1 {
+		t.Errorf("newline count = %d, want 1 (one '\\n' between two joined errors): %q", nc, errStr)
 	}
 	// Defense-in-depth: DPDK sentinel must not surface — DPDK was
 	// not in the fixture, so the precheck cannot fire.
 	if errors.Is(err, ErrDPDKDataplaneRetired) {
-		t.Errorf("errors.Is(err, ErrDPDKDataplaneRetired) = true; DPDK was not in fixture: %q", got)
+		t.Errorf("errors.Is(err, ErrDPDKDataplaneRetired) = true; DPDK was not in fixture: %q", errStr)
 	}
 }
 

--- a/pkg/config/compiler_test.go
+++ b/pkg/config/compiler_test.go
@@ -15,18 +15,19 @@ import (
 // Fixture (parser-reachable):
 //   - CoS family: `class-of-service schedulers <name>
 //     equal-flow-enforcement` without `transmit-rate exact`
-//     triggers validateClassOfServiceStrict at
-//     compiler.go:371-374.
+//     triggers validateClassOfServiceStrict at the
+//     equal-flow-enforcement guard in compiler.go.
 //   - Policer family: `firewall three-color-policer <name>
 //     single-rate color-blind` (with the schema-clean `then
 //     discard` action) leaves CIR=0, triggering
-//     validateThreeColorPolicersStrict at compiler.go:277-278.
+//     validateThreeColorPolicersStrict at the
+//     committed-information-rate guard in compiler.go.
 //
 // The `set system dataplane-type userspace` line is harmless
 // explicitness: unset == userspace via effectiveDataplaneType
-// (compiler.go:1005) and validateDataplaneTypeStrict only rejects
-// explicit `dpdk`. Keeping the line self-documents the test and
-// guards against future default-dataplane behavior changes.
+// and validateDataplaneTypeStrict only rejects explicit `dpdk`.
+// Keeping the line self-documents the test and guards against
+// future default-dataplane behavior changes.
 //
 // The DPDK precheck stays fail-fast (#1526 contract pinned by
 // TestDataplaneTypeDPDKRejectedAtCommitFiresFirst); this test
@@ -78,69 +79,85 @@ func TestCompileMultipleStrictErrorsAccumulated(t *testing.T) {
 
 // TestCompileSingleStrictErrorJoinPath pins errors.Join's
 // single-element byte-identity semantics: when only ONE strict-
-// validator family fires under the accumulator, the returned
-// error's Error() must be byte-identical to the underlying
-// validator's return — no leading/trailing newline, no header
-// framing. This protects against any future helper-wrapper drift
-// (custom multierror type, prefix, etc.) that would silently
-// change operator-facing error text on the single-error path.
+// validator family fires under compileExpanded's accumulator,
+// the returned error's Error() must be byte-identical to the
+// underlying validator's return — no leading/trailing newline,
+// no header framing, no '\n' separators. This protects against
+// any future helper-wrapper drift (custom multierror type, added
+// prefix, etc.) that would silently change operator-facing error
+// text on the single-error path.
 //
-// Verified against /usr/lib/go-1.24/src/errors/join.go:47-48
-// per Codex round-2 verification. The hand-built *Config route
-// keeps the test independent of parser/compiler-shape changes.
+// Exercises the PRODUCTION path through CompileConfig so the
+// assertion fails if compileExpanded later wraps or reformats
+// the single-error result (Codex code-review round-1 finding —
+// the prior version of this test inlined the accumulator and
+// would not have caught that class of regression).
+//
+// Fixture only triggers the CoS family (no policer config), so
+// the accumulator slice ends up length-1 and errors.Join must
+// emit byte-identical bytes per Go 1.20+ std lib spec (see
+// `joinError.Error()` in the std errors package).
 func TestCompileSingleStrictErrorJoinPath(t *testing.T) {
-	// Hand-build a *Config that triggers only the CoS family.
-	// We invoke the validators inline (mirroring compileExpanded's
-	// post-precheck accumulator block) so the test is independent
-	// of the parse + compile pipeline.
-	cfg := &Config{
-		ClassOfService: &ClassOfServiceConfig{
-			Schedulers: map[string]*CoSScheduler{
-				"bad-sched": {
-					Name:                 "bad-sched",
-					EqualFlowEnforcement: true,
-					// TransmitRateExact=false, TransmitRateBytes=0:
-					// triggers the validator.
-				},
+	// Single-family fixture: only CoS equal-flow-enforcement.
+	// No firewall stanza means three-color policers map is empty
+	// and validateThreeColorPolicersStrict returns nil; same for
+	// the policy-scheduler-references validator.
+	lines := []string{
+		"set system dataplane-type userspace",
+		"set class-of-service schedulers bad-sched equal-flow-enforcement",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded; expected single CoS strict-validator error")
+	}
+
+	// Reference: what does the underlying validator return when
+	// called directly on the same configured value? Build an
+	// equivalent CoSScheduler stub matching the fixture.
+	want := validateClassOfServiceStrict(&ClassOfServiceConfig{
+		Schedulers: map[string]*CoSScheduler{
+			"bad-sched": {
+				Name:                 "bad-sched",
+				EqualFlowEnforcement: true,
+				// TransmitRateExact=false, TransmitRateBytes=0
 			},
-			SchedulerMaps:       make(map[string]*CoSSchedulerMap),
-			ForwardingClasses:   make(map[string]*CoSForwardingClass),
-			DSCPClassifiers:     make(map[string]*CoSDSCPClassifier),
-			IEEE8021Classifiers: make(map[string]*CoSIEEE8021Classifier),
-			DSCPRewriteRules:    make(map[string]*CoSDSCPRewriteRule),
-			Interfaces:          make(map[string]*CoSInterface),
 		},
-		Firewall: FirewallConfig{
-			ThreeColorPolicers: map[string]*ThreeColorPolicerConfig{},
-		},
-	}
-
-	// Reference: what does the single underlying validator return?
-	direct := validateClassOfServiceStrict(cfg.ClassOfService)
-	if direct == nil {
-		t.Fatal("validateClassOfServiceStrict returned nil; fixture is broken")
-	}
-
-	// Apply the same accumulator pattern compileExpanded uses.
-	var strictErrs []error
-	if err := validateClassOfServiceStrict(cfg.ClassOfService); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validateThreeColorPolicersStrict(cfg.Firewall.ThreeColorPolicers); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
-		strictErrs = append(strictErrs, err)
-	}
-	joined := errors.Join(strictErrs...)
-	if joined == nil {
-		t.Fatal("errors.Join over single non-nil err returned nil")
+	})
+	if want == nil {
+		t.Fatal("validateClassOfServiceStrict returned nil for the reference fixture; test setup is broken")
 	}
 
 	// Byte-identity assertion: errors.Join with exactly one
 	// non-nil child must emit the child's text verbatim.
-	if got, want := joined.Error(), direct.Error(); got != want {
-		t.Errorf("single-element errors.Join produced framing drift:\n  got  = %q\n  want = %q",
+	if got, want := err.Error(), want.Error(); got != want {
+		t.Errorf("single-element errors.Join in compileExpanded produced framing drift:\n  got  = %q\n  want = %q",
 			got, want)
+	}
+
+	// Defense-in-depth: no '\n' separator on the single-family
+	// path. Catches any regression where compileExpanded begins
+	// emitting framing around single-element joins.
+	if n := strings.Count(err.Error(), "\n"); n != 0 {
+		t.Errorf("single-error path has %d '\\n' separators, want 0: %q", n, err.Error())
+	}
+
+	// Defense-in-depth: errors.Is must still traverse from the
+	// CompileConfig return through to ErrDPDKDataplaneRetired ==
+	// false (DPDK not in this fixture). This is incidental
+	// coverage of the wrap-chain traversal for the single-element
+	// join path.
+	if errors.Is(err, ErrDPDKDataplaneRetired) {
+		t.Errorf("errors.Is(err, ErrDPDKDataplaneRetired) = true; DPDK not in fixture: %q", err.Error())
 	}
 }

--- a/pkg/grpcapi/server_config_test.go
+++ b/pkg/grpcapi/server_config_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
@@ -79,4 +82,65 @@ func grpcWarningsContain(warnings []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestCompileCheckMultiErrorRendersThroughGRPC verifies that
+// #1538's accumulator multi-error renders correctly through the
+// gRPC CommitCheck handler. Two independent strict-validator
+// families (CoS equal-flow-enforcement + three-color-policer
+// missing committed-information-rate) must produce one
+// codes.InvalidArgument status whose message contains BOTH
+// validator substrings separated by exactly one '\n'. Captures
+// the actual operator-facing surface rendered by
+// pkg/grpcapi/server_config.go:176 (`status.Errorf(codes.
+// InvalidArgument, "%v", err)`).
+//
+// Direct-handler style per the existing pattern in this file —
+// no bufconn. Same fixture as
+// pkg/config/compiler_test.go::TestCompileMultipleStrictErrorsAccumulated
+// so the two tests pin the same UX contract at two layers.
+func TestCompileCheckMultiErrorRendersThroughGRPC(t *testing.T) {
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	setLines := []string{
+		"set system dataplane-type userspace",
+		"set class-of-service schedulers bad-sched equal-flow-enforcement",
+		"set firewall three-color-policer bad-pol single-rate color-blind",
+		"set firewall three-color-policer bad-pol then discard",
+	}
+	for _, line := range setLines {
+		if _, err := store.LoadSet(line); err != nil {
+			t.Fatalf("LoadSet(%q) error = %v", line, err)
+		}
+	}
+
+	s := &Server{store: store}
+	_, err := s.CommitCheck(context.Background(), &pb.CommitCheckRequest{})
+	if err == nil {
+		t.Fatal("CommitCheck() succeeded; expected accumulated strict-validator error")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("CommitCheck() error is not a *status.Status: %T (%v)", err, err)
+	}
+	if got, want := st.Code(), codes.InvalidArgument; got != want {
+		t.Errorf("status.Code() = %v, want %v", got, want)
+	}
+
+	msg := st.Message()
+	if !strings.Contains(msg, "equal-flow-enforcement") {
+		t.Errorf("status.Message() missing CoS substring 'equal-flow-enforcement': %q", msg)
+	}
+	if !strings.Contains(msg, "committed-information-rate") {
+		t.Errorf("status.Message() missing policer substring 'committed-information-rate': %q", msg)
+	}
+	// Exactly one '\n' separator → exactly two joined errors
+	// rendered into the gRPC status message via %v.
+	if got, want := strings.Count(msg, "\n"), 1; got != want {
+		t.Errorf("newline count = %d, want %d (one '\\n' between two joined errors): %q",
+			got, want, msg)
+	}
 }


### PR DESCRIPTION
## Summary

Replace the three sequential fail-fast calls to `validateClassOfServiceStrict` / `validateThreeColorPolicersStrict` / `validatePolicySchedulerReferencesStrict` in `compileExpanded` with a single `errors.Join` accumulator so `commit check` surfaces ONE error per independent strict-validator family in a single response — saving operator round-trips on first-touch upgrades that carry several dormant structural findings at once.

The `validateDataplaneTypeStrict` precheck (added by #1536) stays fail-fast and runs FIRST so the brittle-by-design no-leak contract pinned by `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` keeps passing byte-identically.

This change resolves the upgrade-friction concern AGY raised during adversarial review of #1536: an operator carrying `dataplane-type dpdk` + dormant CoS + dormant policer issues would otherwise hit a whack-a-mole cycle.

## Scope guarantees

- **#1536 DPDK contract preserved.** DPDK precheck is a separate fail-fast gate — DPDK retirement message wins, other family errors do NOT leak. `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` (`pkg/config/parser_ast_test.go:2855`) keeps passing byte-identically.
- **One error per family, not every dormant error.** Each accumulated validator still fail-fasts internally. The operator gets at most three errors (CoS + policer + scheduler-reference). Full intra-validator accumulation is deliberately out of scope.
- **No Junos-parity claim.** Framed as an xpf UX choice grounded in upgrade-friction reduction. No public-API change.
- **No new sentinel, no new knob, no signature change.** Individual validators are untouched.

## Plan iteration history

| Round | Codex verdict | AGY verdict |
|---|---|---|
| 1 (v1) | PLAN-NEEDS-MAJOR (DPDK contract, Junos overclaim, "all errors" wording, no rendering test) | PLAN-READY |
| 2 (v2) | PLAN-NEEDS-MINOR (fixture not parser-reachable; test count) | PLAN-READY |
| 3 (v3) | PLAN-NEEDS-MINOR ("REQUIRED" wording; test count; gRPC API names) | PLAN-NEEDS-MINOR (action vs then syntax) |
| 4 (v4) | **PLAN-READY** | **PLAN-READY** |

Full reviewer-ids and per-round verdicts: `docs/pr/1538-multierror-validation/reviewer-ids.md`. Plan: `docs/pr/1538-multierror-validation/plan.md`.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` clean across 30 packages.
- [x] 5x flake loop on `TestCompileMultipleStrictErrorsAccumulated`, `TestCompileSingleStrictErrorJoinPath`, `TestCompileCheckMultiErrorRendersThroughGRPC`, and `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` — all clean.
- [ ] Smoke matrix on `loss:xpf-userspace-fw0/fw1` (v4+v6 × push+reverse × CoS-off+CoS-on) — pending serialized smoke-runner.

This is a Go-only config-compile-side change; expected to be byte-identical throughput vs master on the smoke.

Closes #1538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)