### PR TITLE
#1355: split cos_queue_push_front along snapshot-axis

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -162,6 +162,23 @@
   docs/pr/1355-cos-push-split/plan.md (round-2 minor fixes folded),
   docs/pr/1355-cos-push-split/reviewer-ids.md
 
+## 2026-05-26 — #1355 PR #1590 4-of-4 MERGE-READY; AWAITING-BATCH-MERGE
+
+- **Timestamp**: 2026-05-26 21:50 UTC
+- **Action**: Code-review round 1 returned 4-of-4 MERGE-READY:
+  - Codex (task-mpn5jy3w-gq92x5): MERGE-READY, no blocking findings.
+    Confirmed byte-for-byte parity vs origin/master 63dfe02a, SessionKey
+    borrow fix, NLL re-borrow shape correct, state ordering preserved,
+    codegen-gate empty, snat_contract_doc_guard pre-existing.
+  - Gemini (task-mpn5kiig-rqk14a): MERGE-READY. Confirmed all invariants
+    + active-bucket-by-absence + was_idle short-circuit reorder
+    semantically identical.
+  - Copilot (PRR_kwDORLJrbM8AAAABBFVlLw): COMMENTED, 0 inline findings
+    on 4/4 files.
+  - Claude SMR: gates all pass; pre-existing failure documented.
+- **Posture**: AWAITING-BATCH-MERGE per user mandate (do not auto-merge).
+- **File(s)**: docs/pr/1355-cos-push-split/reviewer-ids.md, _Log.md
+
 ## 2026-05-26 — #1325 implementation pushed
 
 - **Timestamp**: 2026-05-26T (UTC)

--- a/_Log.md
+++ b/_Log.md
@@ -119,6 +119,17 @@
 - **File(s)**: docs/pr/1355-cos-push-split/plan.md,
   docs/pr/1355-cos-push-split/reviewer-ids.md
 
+## 2026-05-26 — #1355 plan v1 unanimous PLAN-KILL; v2 re-targeted
+
+- **Timestamp**: 2026-05-26 20:32 UTC
+- **Action**: Codex (task-mpn2tomp-5t6oam) and Gemini
+  (task-mpn2u791-tq1zkx) both PLAN-KILL on the flow_fair() axis.
+  Re-targeted plan v2 along the snapshot-present/absent axis with
+  seven extracted helpers; fixed v1 SessionKey-not-Copy defect by
+  pre-computing bucket via a short &ff borrow before item is moved.
+- **File(s)**: docs/pr/1355-cos-push-split/plan.md (rewrite),
+  docs/pr/1355-cos-push-split/reviewer-ids.md
+
 ## 2026-05-26 — #1325 implementation pushed
 
 - **Timestamp**: 2026-05-26T (UTC)

--- a/_Log.md
+++ b/_Log.md
@@ -130,6 +130,38 @@
 - **File(s)**: docs/pr/1355-cos-push-split/plan.md (rewrite),
   docs/pr/1355-cos-push-split/reviewer-ids.md
 
+## 2026-05-26 — #1355 plan v2 PLAN-NEEDS-MINOR x2; implementation pushed
+
+- **Timestamp**: 2026-05-26 20:55 UTC
+- **Action**: Round-2 reviewers Codex (task-mpn35b09-ztxsth) and
+  Gemini (task-mpn35twr-zfl64q) both PLAN-NEEDS-MINOR with no
+  PLAN-KILL findings. Minor fixes (codegen-gate widened, panic-
+  message unicode arrow, was_idle short-circuit ack) rolled into
+  plan.md. Implementation: cos_queue_push_front decomposed into
+  seven #[inline] private helpers per plan §Concrete design.
+- **Validation**:
+  - `cargo build`: clean (122 pre-existing warnings, 0 new).
+  - `cargo test --release`: 1433+ tests pass; only pre-existing
+    failure is snat_contract_doc_guard which fails on origin/master
+    base 63dfe02a (docs/userspace-dataplane-gaps.md missing
+    "fail-closed" string — unrelated to this refactor; see #1476
+    follow-up).
+  - 5/5 flake check on `mqfq_push_front_*` family in pop_tests.rs
+    (the two named push_front tests): 2/2 pass per iteration.
+  - `go test ./...`: all packages pass.
+  - Codegen gate: `objdump -Cd xpf-userspace-dp` shows zero call
+    edges to push_front_flow_fair_v8, pop_matching_snapshot,
+    restore_queue_vtime, republish_worker_vtime_slot,
+    push_front_drained_bucket_{with,no}_snapshot,
+    mirror_lease_active_flow_increment, or
+    push_front_active_bucket_head_rebase. All seven helpers fully
+    inlined into cos_queue_push_front and other call sites. The 16
+    push_front-named call sites in the binary are all stdlib
+    `VecDeque::push_front_mut`.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_ops/push.rs,
+  docs/pr/1355-cos-push-split/plan.md (round-2 minor fixes folded),
+  docs/pr/1355-cos-push-split/reviewer-ids.md
+
 ## 2026-05-26 — #1325 implementation pushed
 
 - **Timestamp**: 2026-05-26T (UTC)

--- a/_Log.md
+++ b/_Log.md
@@ -111,6 +111,13 @@
 - **22:05 UTC 2026-05-26** — 5/5 flake check on `afxdp::cos::queue_service::*` post-rebase (49 tests pass each iteration).
 - **22:05 UTC 2026-05-26** — force-pushed rebased branch; new HEAD 90e97b29994a.
 - **22:06 UTC 2026-05-26** — posted re-attestation marker on PR #1585 with prior 4-of-4 carry-forward (delta is _Log.md-only).
+## 2026-05-26 — #1355 cos_queue_push_front split kicked off
+
+- **Timestamp**: 2026-05-26 20:14 UTC
+- **Action**: Worktree off origin/master; plan v1 drafted at
+  docs/pr/1355-cos-push-split/plan.md; reviewer-ids tracker created.
+- **File(s)**: docs/pr/1355-cos-push-split/plan.md,
+  docs/pr/1355-cos-push-split/reviewer-ids.md
 
 ## 2026-05-26 — #1325 implementation pushed
 

--- a/docs/pr/1355-cos-push-split/plan.md
+++ b/docs/pr/1355-cos-push-split/plan.md
@@ -1,6 +1,9 @@
 # #1355 — Split 218-LOC `cos_queue_push_front` along the snapshot-axis
 
-**Status:** DRAFT v2 — re-targeted after unanimous v1 PLAN-KILL
+**Status:** PLAN-READY (v2 — after Codex task-mpn35b09-ztxsth
+PLAN-NEEDS-MINOR and Gemini task-mpn35twr-zfl64q PLAN-NEEDS-MINOR;
+all minors recorded in §Round-2 minor fixes below and rolled into
+implementation). Re-targeted after unanimous v1 PLAN-KILL
 (Codex task-mpn2tomp-5t6oam, Gemini task-mpn2u791-tq1zkx).
 Both reviewers said the same thing: the `flow_fair()` config branch
 is the wrong axis. The cyclomatic complexity lives in the
@@ -216,7 +219,7 @@ fn pop_matching_snapshot(
                 "pop_snapshot_stack bucket mismatch on push_front: \
                  top entry's bucket {} != target bucket {}; a \
                  caller pop+dropped an item without §3.4 cleanup, \
-                 or violated the pop->push_front-same-item contract",
+                 or violated the pop→push_front-same-item contract",
                 top, bucket,
             );
             unreachable!()
@@ -408,14 +411,27 @@ pattern as the monolith, made explicit.
 
 - `cargo build` clean.
 - `cargo test --release` — full suite passes.
-- 5/5 flake check on `test_push_front_*` family in
-  `cos/queue_ops/tests.rs`.
+- 5/5 flake check on the push-front-touching tests in
+  `cos/queue_ops/pop_tests.rs` (e.g. line ~1230 — `pop_tests.rs`
+  carries the push_front pins by name) and
+  `cos/queue_ops/v_min_tests.rs:329` (republish slot test).
 - `go test ./...` — 30 Go packages pass.
-- **Codegen gate (Codex #4):** `objdump -d
-  /dev/shm/cargo/release/libuserspace_dp.so | awk
-  '/<.*cos_queue_push_front>:/,/^$/' | grep -E 'call +[0-9a-f]+
-  <push_front_'` should be empty (no call edges). If non-empty,
-  downgrade perf claim and rely on smoke.
+- **Codegen gate (Codex round-1 #4 + round-2 codegen finding):**
+  use `objdump -Cd` (demangled) so Rust-mangled symbol targets
+  aren't masked by the literal `<push_front_` grep, and grep the
+  WHOLE `.so` for call edges to the helpers, not just the block
+  scoped to `cos_queue_push_front`. The vacuous-pass scenario
+  (helper inlined into _other_ callers but still emitted as a
+  standalone symbol that nothing calls) is also covered by
+  grepping for any `call +[0-9a-f]+ +.*push_front_(flow_fair_v8|
+  drained_bucket|active_bucket|matching_snapshot|lease_active_
+  flow_increment|drained_bucket_no_snapshot|drained_bucket_with_
+  snapshot)` across the entire `.so`. Empty output ⇒ INLINED OK.
+  Non-empty ⇒ downgrade perf claim and rely on multi-stream
+  `-P 12 -R` smoke. Codex round-2 follow-up: also assert the
+  searched block exists (the `awk` extraction is not vacuous)
+  by sanity-checking the symbol is present in `nm -C` output
+  for the `.so` before running the grep.
 - Deploy on loss userspace cluster.
 - **Pass A — CoS disabled:** v4 + v6 × push + reverse; multi-stream
   `-P 12 -R` reproducers. Line rate, 0 retrans on multi-stream.
@@ -434,6 +450,34 @@ pattern as the monolith, made explicit.
   PLAN-KILL if test colocation is required.
 - Any change to snapshot stack contract, v8 epoch handoff, or
   head-finish rebase arithmetic.
+
+## Round-2 minor fixes folded into the implementation
+
+Both round-2 reviewers returned PLAN-NEEDS-MINOR; the minors below
+are rolled into the implementation, not deferred:
+
+- **Codex round-2 medium — codegen gate inadequate as written.**
+  Plan §Test plan now uses `objdump -Cd` (demangled) and greps the
+  whole `.so` for calls to any of the seven helper names. Vacuous
+  pass guarded by an `nm -C` symbol-presence assertion.
+- **Codex round-2 low — test-plan names wrong file.** Plan §Test
+  plan now points at `pop_tests.rs:1230` and `v_min_tests.rs:329`
+  (the actual push-front-pinned tests) instead of the imagined
+  `tests.rs::test_push_front_*` family.
+- **Both round-2 reviewers low — panic-message Unicode parity.**
+  The `pop_matching_snapshot` sketch in §Concrete design now uses
+  `→` (U+2192) instead of `->`, matching `push.rs:119` byte-for-
+  byte for operator-grep parity.
+- **Gemini round-2 acknowledgment — `was_idle` short-circuit
+  reorder.** The original code wraps `was_idle` inside the
+  `if let Some(lease)` block; v2 pre-computes `was_idle` as a
+  return value from `push_front_drained_bucket_no_snapshot` and
+  branches on it BEFORE the lease check at the call site. This
+  is harmless (potentially faster on non-v8 queues because we
+  skip the lease load entirely when `!was_idle`) but is
+  technically a reorder. Acknowledged; semantic identity
+  preserved because the lease bump only fires when `was_idle`
+  was already true under the original code path.
 
 ## Open questions for adversarial review
 

--- a/docs/pr/1355-cos-push-split/plan.md
+++ b/docs/pr/1355-cos-push-split/plan.md
@@ -1,66 +1,127 @@
-# #1355 — Split 218-LOC `cos_queue_push_front` along `flow_fair()` branch
+# #1355 — Split 218-LOC `cos_queue_push_front` along the snapshot-axis
 
-**Status:** DRAFT v1 — pending adversarial plan review.
+**Status:** DRAFT v2 — re-targeted after unanimous v1 PLAN-KILL
+(Codex task-mpn2tomp-5t6oam, Gemini task-mpn2u791-tq1zkx).
+Both reviewers said the same thing: the `flow_fair()` config branch
+is the wrong axis. The cyclomatic complexity lives in the
+snapshot-state machine inside the flow-fair body. v2 re-targets the
+split along that axis. v1 also got the helper signatures wrong:
+`SessionKey` is `Clone` (not `Copy`), and `cos_item_flow_key`
+returns `Option<&SessionKey>` (not `SessionKey`). v2 fixes both.
 
-## Issue framing
+## v1 PLAN-KILL findings preserved verbatim
 
-`userspace-dp/src/afxdp/cos/queue_ops/push.rs` is 271 production LOC,
-but the single function `cos_queue_push_front` (push.rs:54) is a
-218-LOC body sitting on the hot per-packet CoS enqueue path. Issue
-#1355 asks for a pure code-motion split along the `flow_fair()`
-config-time branch, so the two paths are reviewed independently:
+### Codex (task-mpn2tomp-5t6oam)
 
-- Non-`flow_fair` fast path (~10 LOC).
-- `flow_fair` path with v8 v_min epoch accounting, snapshot-rollback,
-  disjoint-borrow lease handoff, head-finish rebase (~150+ LOC).
+> 1. **The sketched helper signature is not valid pure code motion.**
+>    `cos_item_flow_key` returns `Option<&SessionKey>`, and
+>    `SessionKey` is `Clone`, not `Copy`. The plan says helpers take
+>    `flow_key: SessionKey` and that it is `Copy`; both are false.
+>    Passing a borrow into `item` plus moving `item` into the helper
+>    changes the current NLL shape and likely will not compile
+>    without either cloning the key or computing the bucket before
+>    moving `item`. That is no longer "helper bodies move verbatim."
+>
+> 2. **The split axis is too weak.** The non-flow-fair path is
+>    already isolated as a 4-line early return. Moving it to
+>    `push_front_non_flow_fair` does not address the real review
+>    pain: snapshot match/empty-stack/mismatch, drained-bucket
+>    restore, idle-bucket rebuild, active-bucket head rebase, V_min
+>    republish, and v8 lease mirrors.
+>
+> 3. **The claimed test-strength win is not real.** Private helpers
+>    in push.rs will not be directly exercised by sibling tests.
+>
+> 4. **Perf validation is underspecified.** `#[inline]` is a hint.
+>    End-to-end iperf is too coarse to catch a 1-5% hot-path
+>    regression. The plan needs an explicit codegen gate.
+>
+> 5. **Hidden invariant list is incomplete.** Misses
+>    borrowed-`flow_key`/moved-`item`, `was_empty` vs `was_idle`
+>    ordering, active-bucket "no rr reinsert / no tail update /
+>    no lease mirror" behavior, zero-length item behavior.
 
-`docs/engineering-style.md` flags >100 LOC as a refactor cue; the
-function is 2.18× the threshold and is a Tier-1 hard hit (>200 LOC).
-All callers go through `pub(in crate::afxdp)` re-exports from
-`queue_ops/mod.rs`, so the public boundary stays at the parent module.
+### Gemini (task-mpn2u791-tq1zkx)
+
+> 1. The config-time `flow_fair()` branch is the wrong target.
+>    Extracting two lines into a 4-argument helper adds zero net-new
+>    test capability. The `flow_fair` body is **206 LOC**, not just
+>    "150+". Shoving it unmodified into `push_front_flow_fair_v8`
+>    fails the engineering-style >100 LOC rule. The cyclomatic
+>    complexity is entirely concentrated in the snapshot vs.
+>    no-snapshot logic, which v1 ignored.
+>
+> 2. Missing invariant: the **active-bucket path** (push.rs:219-271)
+>    explicitly relies on **skipping** the `active_flow_buckets` and
+>    `queue_lease_v8` increments because the bucket is already
+>    actively tracked. v1 omitted this.
+>
+> 3. Test colocation deferral is unacceptable for a "test-win" PR.
+>
+> 4. Required action: **KILL.** Re-target along the snapshot-axis.
+
+## Issue framing (v2)
+
+`cos_queue_push_front` decomposes naturally into FIVE pieces, three
+of which sit inside the flow-fair branch:
+
+1. **Common prelude** — `cos_item_len`, `cos_item_flow_key`,
+   `local_item_count` saturating add, branch on `!flow_fair()`.
+   Stays in the outer fn.
+2. **Non-flow-fair fast path** — `account_cos_queue_flow_enqueue` +
+   `hot.items.push_front`. Stays in the outer fn — too small to
+   extract per Codex/Gemini.
+3. **Flow-fair snapshot resolution** — `worker_id` capture, take
+   `&mut ff`, compute `bucket`, pop the snapshot stack, run the
+   mismatch panic, restore `queue_vtime`, republish the v_min slot.
+4. **Flow-fair drained-bucket rebuild** — `was_empty == true` arm:
+   (4a) matched-snapshot restore; (4b) no-snapshot anchor.
+5. **Flow-fair active-bucket head rebase** — `was_empty == false`
+   arm. No rr reinsert, no tail update, no lease mirror — bucket
+   is already tracked.
+
+v2 extracts seven `#[inline]` private helpers covering (3), (4a),
+(4b), the republish, the lease mirror, the snapshot pop with the
+mismatch panic, and (5).
 
 ## Honest scope/value framing
 
-Pure code motion. **No** algorithmic change. Hot-path codegen is
-preserved by keeping `#[inline]` on the outer fn AND the two helpers.
-LLVM should lower the post-split call graph to the same instructions
-as the pre-split body — verified by smoke (line rate, 0 retrans) on
-the loss userspace cluster, not by IR diffing.
+Pure code motion within the flow-fair body. Algorithmic semantics
+preserved byte-for-byte. The win is **reviewability + named
+contracts** for the snapshot-axis branches Gemini #2 flagged as
+missing:
 
-The win is **reviewability + tests**:
+- The active-bucket helper's "no rr reinsert / no tail update / no
+  lease mirror" contract becomes explicit by absence.
+- The snapshot-restore vs no-snapshot-anchor arms become named
+  helpers with distinct invariants.
 
-- Non-flow-fair branch and flow-fair branch can be exercised by
-  separate cargo tests rather than through the union-fn.
-- The 150-LOC flow-fair body (snapshot rollback, vtime restore, lease
-  handoff) sits in its own helper, not entangled with the trivial
-  non-flow-fair branch.
+Codegen: `#[inline]` is a hint. v2 adds an explicit
+release-mode `objdump` gate proving no direct-call edge to the
+private helpers in the emitted `.so`. If the disassembly check
+fails, the perf claim downgrades to "no measurable iperf
+regression."
 
-*If reviewers conclude the refactor delivers no reviewability or
-test-strength win that justifies the churn, PLAN-KILL is an
-acceptable verdict.*
+*If reviewers conclude the refactor still delivers no reviewability
+win that justifies the churn, PLAN-KILL is an acceptable verdict.*
 
 ## What's already shipped / partially batched
 
-- `cos_queue_push_back` already lives alongside in `push.rs` (51 LOC).
-  Both are `#[inline]` and cross-module-inline through the
-  `pub(in crate::afxdp)` re-export at `queue_ops/mod.rs:43`.
-- Sibling extractions (`accounting.rs`, `drain.rs`, `pop.rs`,
-  `v_min.rs`, `active_buckets.rs`) already split out from the
-  pre-#1034 monolith. This PR follows the same module/foo convention.
-- Pop+push-front contract pairing is already documented at
-  `push.rs:78-124` (#913 peek-then-pop snapshot consumption); the
-  helper extraction MUST preserve this contract byte-for-byte.
+- `cos_queue_push_back` (51 LOC) in the same file uses a much
+  simpler path — no snapshot, no rollback, no rebase. Not touched.
+- Sibling extractions in `queue_ops/` (`accounting.rs`, `drain.rs`,
+  `pop.rs`, `v_min.rs`, `active_buckets.rs`) already split out
+  from the pre-#1034 monolith. v2 follows the same convention.
+- `cos_queue_pop_front_no_snapshot` in `pop.rs` is the producer
+  for the snapshot stack consumed in (3). Contract unchanged.
 
 ## Concrete design
 
-**Layout option chosen:** sibling files inside `queue_ops/` (no
-`push/` sub-dir). Rationale: `queue_ops/` is already a directory of
-sibling files (`pop.rs`, `drain.rs`, `accounting.rs`, etc.), and the
-non-`flow_fair` branch is too small (~10 LOC) to deserve its own
-file. Both helpers live in the same `push.rs` so the matched
-push_back/push_front pair stays colocated.
+**Layout:** keep everything in `push.rs` as sibling private
+helpers. Same convention as the rest of `queue_ops/`.
 
-After the split, `push.rs` contains:
+**Signatures (compile-checked against actual types — `SessionKey:
+Clone`, `cos_item_flow_key -> Option<&SessionKey>`):**
 
 ```rust
 #[inline]
@@ -69,180 +130,329 @@ pub(in crate::afxdp) fn cos_queue_push_front(
     item: CoSPendingTxItem,
 ) {
     let item_len = cos_item_len(&item);
-    let flow_key = cos_item_flow_key(&item);
+    let flow_key = cos_item_flow_key(&item); // Option<&SessionKey>
     if matches!(item, CoSPendingTxItem::Local(_)) {
         queue.hot.local_item_count =
             queue.hot.local_item_count.saturating_add(1);
     }
     if !queue.flow_fair() {
-        push_front_non_flow_fair(queue, flow_key, item_len, item);
+        account_cos_queue_flow_enqueue(queue, flow_key, item_len);
+        queue.hot.items.push_front(item);
         return;
     }
-    push_front_flow_fair_v8(queue, flow_key, item_len, item);
-}
-
-#[inline]
-fn push_front_non_flow_fair(
-    queue: &mut CoSQueueRuntime,
-    flow_key: SessionKey,
-    item_len: u64,
-    item: CoSPendingTxItem,
-) {
-    account_cos_queue_flow_enqueue(queue, flow_key, item_len);
-    queue.hot.items.push_front(item);
+    // Codex #1: compute bucket via a short &ff borrow BEFORE item
+    // is moved. bucket is usize (Copy) so it crosses the helper
+    // boundary cleanly; flow_key (which borrows into item) is
+    // dropped here.
+    let worker_id = queue.v_min.worker_id as usize;
+    let bucket = {
+        let ff = queue.flow_fair_state.as_ref().expect(
+            "cos_queue_push_front: flow_fair queue without \
+             flow_fair_state",
+        );
+        cos_flow_bucket_index(ff.flow_hash_seed, flow_key)
+    };
+    push_front_flow_fair_v8(queue, bucket, item_len, item, worker_id);
 }
 
 #[inline]
 fn push_front_flow_fair_v8(
     queue: &mut CoSQueueRuntime,
-    flow_key: SessionKey,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+    worker_id: usize,
+) {
+    let snapshot = {
+        let ff = queue.flow_fair_state.as_mut().expect(
+            "cos_queue_push_front: flow_fair queue without \
+             flow_fair_state",
+        );
+        let snap = pop_matching_snapshot(ff, bucket);
+        restore_queue_vtime(ff, snap.as_ref(), item_len);
+        snap
+    };
+    // ff &mut borrow ends. v_min republish needs queue.v_min
+    // (disjoint field) — same NLL pattern as the monolith.
+    republish_worker_vtime_slot(queue);
+    let ff = queue.flow_fair_state.as_mut().expect(
+        "cos_queue_push_front: flow_fair queue without \
+         flow_fair_state",
+    );
+    let was_empty = ff.flow_bucket_items[bucket].is_empty();
+    if was_empty {
+        if let Some(snap) = snapshot {
+            push_front_drained_bucket_with_snapshot(
+                ff, bucket, item_len, item, snap,
+            );
+            // ff borrow ends here (last use above).
+            mirror_lease_active_flow_increment(queue, worker_id);
+        } else {
+            let was_idle = push_front_drained_bucket_no_snapshot(
+                ff, bucket, item_len, item,
+            );
+            if was_idle {
+                mirror_lease_active_flow_increment(queue, worker_id);
+            }
+        }
+        return;
+    }
+    push_front_active_bucket_head_rebase(ff, bucket, item_len, item);
+}
+
+#[inline]
+fn pop_matching_snapshot(
+    ff: &mut FlowFairState,
+    bucket: usize,
+) -> Option<CoSQueuePopSnapshot> {
+    let stack_top_bucket =
+        ff.pop_snapshot_stack.last().map(|s| usize::from(s.bucket));
+    match stack_top_bucket {
+        None => None,
+        Some(top) if top == bucket => ff.pop_snapshot_stack.pop(),
+        Some(top) => {
+            assert!(
+                false,
+                "pop_snapshot_stack bucket mismatch on push_front: \
+                 top entry's bucket {} != target bucket {}; a \
+                 caller pop+dropped an item without §3.4 cleanup, \
+                 or violated the pop->push_front-same-item contract",
+                top, bucket,
+            );
+            unreachable!()
+        }
+    }
+}
+
+#[inline]
+fn restore_queue_vtime(
+    ff: &mut FlowFairState,
+    snapshot: Option<&CoSQueuePopSnapshot>,
+    item_len: u64,
+) {
+    match snapshot {
+        Some(snap) => ff.queue_vtime = snap.pre_pop_queue_vtime,
+        None => {
+            ff.queue_vtime =
+                ff.queue_vtime.saturating_sub(item_len);
+        }
+    }
+}
+
+#[inline]
+fn republish_worker_vtime_slot(queue: &CoSQueueRuntime) {
+    let ff = match queue.flow_fair_state.as_ref() {
+        Some(f) => f,
+        None => return,
+    };
+    if let Some(floor) = queue.v_min.vtime_floor.as_ref() {
+        if let Some(slot) =
+            floor.slots.get(queue.v_min.worker_id as usize)
+        {
+            slot.publish(ff.queue_vtime);
+        }
+    }
+}
+
+#[inline]
+fn push_front_drained_bucket_with_snapshot(
+    ff: &mut FlowFairState,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+    snap: CoSQueuePopSnapshot,
+) {
+    ff.flow_bucket_bytes[bucket] =
+        ff.flow_bucket_bytes[bucket].saturating_add(item_len);
+    ff.flow_bucket_head_finish_bytes[bucket] = snap.pre_pop_head_finish;
+    ff.flow_bucket_tail_finish_bytes[bucket] = snap.pre_pop_tail_finish;
+    ff.active_flow_buckets =
+        ff.active_flow_buckets.saturating_add(1);
+    if ff.active_flow_buckets > ff.active_flow_buckets_peak {
+        ff.active_flow_buckets_peak = ff.active_flow_buckets;
+    }
+    ff.flow_bucket_items[bucket].push_front(item);
+    ff.flow_rr_buckets.push_front(bucket as u16);
+}
+
+#[inline]
+fn push_front_drained_bucket_no_snapshot(
+    ff: &mut FlowFairState,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+) -> bool {
+    let was_idle = ff.flow_bucket_bytes[bucket] == 0;
+    if was_idle {
+        ff.active_flow_buckets =
+            ff.active_flow_buckets.saturating_add(1);
+        if ff.active_flow_buckets > ff.active_flow_buckets_peak {
+            ff.active_flow_buckets_peak = ff.active_flow_buckets;
+        }
+    }
+    ff.flow_bucket_bytes[bucket] =
+        ff.flow_bucket_bytes[bucket].saturating_add(item_len);
+    let new_tail = ff.flow_bucket_tail_finish_bytes[bucket]
+        .max(ff.queue_vtime)
+        .saturating_add(item_len);
+    ff.flow_bucket_tail_finish_bytes[bucket] = new_tail;
+    if was_idle {
+        ff.flow_bucket_head_finish_bytes[bucket] = new_tail;
+    }
+    ff.flow_bucket_items[bucket].push_front(item);
+    ff.flow_rr_buckets.push_front(bucket as u16);
+    was_idle
+}
+
+#[inline]
+fn mirror_lease_active_flow_increment(
+    queue: &CoSQueueRuntime,
+    worker_id: usize,
+) {
+    if let Some(lease) = queue.queue_lease_v8.as_ref() {
+        if let Some(slot) =
+            lease.worker_active_flow_buckets_for(worker_id)
+        {
+            slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
+
+#[inline]
+fn push_front_active_bucket_head_rebase(
+    ff: &mut FlowFairState,
+    bucket: usize,
     item_len: u64,
     item: CoSPendingTxItem,
 ) {
-    // <existing 150+ LOC verbatim from push.rs:65-271>
+    let current_head_bytes = ff.flow_bucket_items[bucket]
+        .front()
+        .map(cos_item_len)
+        .unwrap_or(0);
+    ff.flow_bucket_head_finish_bytes[bucket] = ff
+        .flow_bucket_head_finish_bytes[bucket]
+        .saturating_sub(current_head_bytes);
+    ff.flow_bucket_bytes[bucket] =
+        ff.flow_bucket_bytes[bucket].saturating_add(item_len);
+    ff.flow_bucket_items[bucket].push_front(item);
 }
 ```
 
-**Critical:** the helper bodies are moved verbatim. The outer fn
-shape is preserved 1:1 with the original prelude:
-
-1. `cos_item_len(&item)` (line 55).
-2. `cos_item_flow_key(&item)` (line 56).
-3. `local_item_count` saturating add for `Local(_)` (lines 57-59).
-4. Branch on `!queue.flow_fair()`.
-5. Non-flow-fair branch: `account_cos_queue_flow_enqueue` +
-   `push_front` (lines 61-62).
-6. Flow-fair branch: capture `worker_id`, take `&mut ff`, run the
-   snapshot/rollback/lease state machine (lines 65-270).
-
-The flow-fair helper takes ownership of `item` and re-runs the
-existing `cos_item_len` / `cos_item_flow_key` for its own use? **No.**
-We pass `item_len` and `flow_key` as parameters from the outer fn so
-the helper does no redundant work. `item` is moved in by value.
-
-`worker_id` capture stays *inside* the flow-fair helper because the
-NLL borrow comment (`push.rs:65-69`) explicitly requires the capture
-to happen before the `flow_fair_state.as_mut()` mutable borrow. The
-helper boundary does not interfere — the helper has its own scope.
+**Borrow shape — Codex finding #1 addressed:** the bucket index is
+computed via a short `&ff` borrow in the outer fn before `item` is
+moved; `flow_key` (which borrows into `item`) is dropped after
+`cos_flow_bucket_index` returns. The only thing crossing the helper
+boundary is `bucket: usize` (Copy). Inside the flow-fair helper, the
+`&mut ff` borrow is taken in two discrete blocks separated by the
+disjoint-field access for `republish_worker_vtime_slot` — same NLL
+pattern as the monolith, made explicit.
 
 ## Public API preservation
 
 - `pub(in crate::afxdp) fn cos_queue_push_front(...)` — signature
   unchanged.
 - `pub(in crate::afxdp) fn cos_queue_push_back(...)` — untouched.
-- The two new helpers are **module-private** (`fn`, no `pub`). They
-  are only callable from within `push.rs`. No re-export from
-  `queue_ops/mod.rs`.
+- All 7 new helpers are module-private (`fn`, no `pub`).
+- `queue_ops/mod.rs:43` re-export unchanged.
 
-## Hidden invariants the change must preserve
+## Hidden invariants the change must preserve (complete list)
 
-1. **`cos_item_len` and `cos_item_flow_key` evaluation order** — read
-   BEFORE the `matches!(Local(_))` arm. The current code reads them
-   first, then mutates `local_item_count`. Preserved.
-2. **`local_item_count` bump fires on BOTH branches** (flow-fair and
-   non-flow-fair). The mutation lives in the outer fn before the
-   `!flow_fair()` branch, so both helpers inherit it. Preserved by
-   leaving the mutation in the outer fn.
-3. **`account_cos_queue_flow_enqueue` is called ONLY on the
-   non-flow-fair path** (line 61). The flow-fair branch does its own
-   bucket-level accounting via the snapshot machinery. Preserved by
-   moving the call into `push_front_non_flow_fair`.
-4. **`worker_id` capture before `flow_fair_state.as_mut()`** — NLL
-   discipline (push.rs:65-69) mandates this order. Preserved
-   because the capture moves with the flow-fair body intact.
-5. **Snapshot stack contract** — top-entry bucket mismatch panics in
-   both dev and release via `assert!(false) + unreachable!()`.
-   Preserved verbatim.
-6. **`flow_fair_state` expect message** — current message says
-   `"cos_queue_push_front: flow_fair queue without flow_fair_state"`.
-   Helper retains the same message string so panics still grep with
-   the same operator-facing text.
-7. **v_min slot republish after vtime restore** — block at lines
-   144-148 must run on every flow-fair invocation. Moves verbatim
-   into the helper.
-8. **v8 lease per-worker counter mirror on both rollback paths**
-   (lines 171-175 and 209-215). Moves verbatim.
-9. **`#[inline]`** on outer fn AND both helpers, so cross-module
-   inlining at the `pub(in crate::afxdp)` boundary still folds the
-   call graph flat at -O3.
-10. **No new allocation** on either branch. Helpers receive `item` by
-    value, `flow_key` (`SessionKey` — `Copy`), `item_len` (`u64`).
+1. `cos_item_len(&item)` and `cos_item_flow_key(&item)` evaluated
+   **before** `matches!(Local(_))`. Preserved in outer fn.
+2. `local_item_count` saturating-add fires on **both** branches.
+   Preserved in outer fn.
+3. `account_cos_queue_flow_enqueue` called **only** on the
+   non-flow-fair path.
+4. **Bucket index computed before `item` is moved** (Codex #1).
+   Outer fn computes via short `&ff` borrow.
+5. `worker_id` captured **before** the `&mut ff` borrow (NLL
+   discipline from push.rs:65-69).
+6. `flow_fair_state` `expect` message preserved verbatim for
+   operator-grep parity.
+7. **v_min slot republish** fires after vtime restore, before
+   bucket arms. Preserved as `republish_worker_vtime_slot`.
+8. **v8 lease mirror on snapshot-restore path** —
+   unconditionally bumps when `was_empty && Some(snap)`.
+9. **v8 lease mirror on no-snapshot anchor path** — fires **only
+   when `was_idle`** (Gemini #2). Helper returns `was_idle`;
+   call site gates the mirror.
+10. **Active-bucket path does NOT bump `active_flow_buckets`, NOT
+    push to `flow_rr_buckets`, NOT update tail, NOT mirror lease**
+    (Gemini #2). Preserved by absence in
+    `push_front_active_bucket_head_rebase`.
+11. **`was_empty` vs `was_idle` ordering** (Codex #5). `was_empty`
+    read on the queue before any mutation; `was_idle` read on
+    `flow_bucket_bytes` before byte mutation. Both helpers
+    preserve read-before-mutate.
+12. **Snapshot stack mismatch panic** preserved verbatim
+    (`assert!(false) + unreachable!()`) inside
+    `pop_matching_snapshot`. Same blast radius.
+13. **No new allocation** on either branch. All helpers take
+    `&mut` references, owned items, primitives, and
+    `Option<&CoSQueuePopSnapshot>` / owned snapshot.
+14. **`#[inline]`** on outer fn and all 7 helpers.
+15. **Zero-length item behavior** (Codex #5) preserved —
+    saturating math is no-op for `item_len == 0`; helpers do not
+    special-case.
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | Pure code motion. Outer-fn prelude (cos_item_len, cos_item_flow_key, local_item_count, branch) preserved 1:1. Helper bodies moved verbatim. |
-| Lifetime / borrow-checker | LOW | `worker_id` capture stays inside the flow-fair helper before the `&mut ff` borrow; the helper has its own scope so NLL discipline is identical. `item` moves by value through the helper boundary. |
-| Performance regression | LOW | `#[inline]` on outer + both helpers; LLVM should produce identical machine code. Smoke gate (line rate, 0 retrans on the multi-stream `-P 12 -R` reverse reproducer) is the live verification. |
-| Architectural mismatch (#946 Phase 2 / #961) | LOW | Not a pipeline change. Not a data-structure change. No cross-packet state introduced. The split is along a config-time boolean — the same dimension issue #1355 itself proposes. |
+| Behavioral regression | LOW | Pure code motion within the flow-fair body. Outer-fn prelude preserved 1:1. Bucket pre-computation is the only new operation; ordering preserved. |
+| Lifetime / borrow-checker | MED | Helper boundary forces the `{&mut ff}` - `{&queue access}` - `{&mut ff}` structure to be made explicit via re-borrows. Compile-tested by `cargo build`. |
+| Performance regression | LOW-MED | `#[inline]` is a hint. v2 adds an `objdump` codegen gate. If it shows call edges, downgrade to "no measurable iperf regression" and rely on the multi-stream `-P 12 -R` smoke. |
+| Architectural mismatch | LOW | v2 IS the snapshot-axis split both v1 reviewers demanded. |
 
 ## Test plan
 
-- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build` clean.
-- `cargo test --release` — full cargo suite passes (target current
-  count after rebases).
-- 5/5 flake check on the most affected named test in
-  `cos/queue_ops/tests.rs` (push-related — likely
-  `test_push_front_rollback_*` family).
-- `go test ./...` — all 30 Go packages pass.
+- `cargo build` clean.
+- `cargo test --release` — full suite passes.
+- 5/5 flake check on `test_push_front_*` family in
+  `cos/queue_ops/tests.rs`.
+- `go test ./...` — 30 Go packages pass.
+- **Codegen gate (Codex #4):** `objdump -d
+  /dev/shm/cargo/release/libuserspace_dp.so | awk
+  '/<.*cos_queue_push_front>:/,/^$/' | grep -E 'call +[0-9a-f]+
+  <push_front_'` should be empty (no call edges). If non-empty,
+  downgrade perf claim and rely on smoke.
 - Deploy on loss userspace cluster.
-- **Pass A — CoS disabled:** v4 + v6 × push + reverse, plus
-  multi-stream `-P 12 -R` reverse reproducers. Line rate, 0 retrans
-  on the multi-stream cells.
+- **Pass A — CoS disabled:** v4 + v6 × push + reverse; multi-stream
+  `-P 12 -R` reproducers. Line rate, 0 retrans on multi-stream.
 - **Pass B — CoS enabled:** per-class smoke 5201-5206 × v4/v6 ×
-  push/reverse = 24 cells. Shaped classes hit shape rate cleanly.
+  push/reverse = 24 cells.
 
 ## Out of scope (explicitly)
 
-- Splitting the flow-fair body further (e.g.,
-  `account_then_push_front_flow_fair` sub-extraction the issue body
-  suggests). The flow-fair helper will still be over 100 LOC after
-  this split; a second extraction can land as a follow-up PR once
-  the snapshot-vs-no-snapshot decomposition is reviewed in isolation.
-- Migrating push-specific tests from `cos/queue_ops/tests.rs` /
-  `cos/queue_ops/pop_tests.rs` into a new `push_tests.rs` file. Test
-  colocation is a separate refactor (test files >2000 LOC tracked
-  elsewhere).
-- Any change to the snapshot stack contract, the v8 epoch handoff,
-  or the head-finish rebase arithmetic. All settled in #1229 / #913.
+- Splitting `cos_queue_push_back` (51 LOC; under threshold).
+- Migrating push tests out of `cos/queue_ops/tests.rs`. **Gemini #3
+  wanted this in the same PR; v2 still defers.** Rationale: tests
+  already exercise `cos_queue_push_front` through its public
+  surface; helpers are private and exercised transitively. Test
+  reorg is a separate concern from function decomposition.
+  Reviewer escalation lever: PLAN-NEEDS-MAJOR rather than
+  PLAN-KILL if test colocation is required.
+- Any change to snapshot stack contract, v8 epoch handoff, or
+  head-finish rebase arithmetic.
 
 ## Open questions for adversarial review
 
-1. **Is splitting along `flow_fair()` the right axis?** The
-   alternative is splitting by "snapshot present / absent" inside the
-   flow-fair body — that's where the actual cyclomatic complexity
-   lives. Is the config-time-branch split the right *first* split, or
-   should we go straight for the snapshot-axis split? PLAN-KILL if the
-   config-axis split adds no test-strength and the real refactor is
-   the snapshot-axis one.
-2. **`#[inline]` discipline + cross-module inlining.** The current
-   `cos_queue_push_front` is `#[inline]` and `pub(in crate::afxdp)`.
-   After the split the *helpers* are private to `push.rs`, so
-   cross-module inlining doesn't apply to them — but they're called
-   only from within the same crate root. Is `#[inline]` even needed
-   on intra-module-private fns? Or does LLVM inline them by default
-   at `-O3`?
-3. **Parameter passing vs re-reading `cos_item_len`/`flow_key` in
-   helpers.** Plan passes them as `u64` + `SessionKey`. If the helper
-   bodies are inlined, this is free. If for some reason LLVM declines
-   to inline, we pay 16 bytes of stack per helper call. Acceptable?
-4. **Helper signature shape.** Should the helpers take
-   `&mut CoSQueueRuntime` and pull `item_len` / `flow_key` from
-   already-captured locals at the top of the helper, or should the
-   outer fn pass them by value? Plan picks the latter to avoid a
-   second `cos_item_len(&item)` call after `item` is moved. Right
-   choice?
-5. **Test colocation deferral.** The issue body explicitly says
-   `push_tests.rs` does not exist and tests live in
-   `pop_tests.rs` (1996 LOC). Should the test split land in this PR
-   or a follow-up? Plan defers. PLAN-KILL or PLAN-NEEDS-MAJOR if
-   reviewers think test colocation must land *with* the code split.
-6. **Architectural mismatch / wrong-target risk.** #1355 is a
-   "Refactor: <Pattern>" issue. Recent history (#946 Phase 2, #961,
-   #1144) shows these can be architecturally misdirected. Is this
-   refactor's *target* (push.rs single-function) right, or is the
-   real review-pain elsewhere in `cos/queue_ops/` (e.g.,
-   `pop_tests.rs` 1996 LOC, or the snapshot machinery split across
-   `push.rs` + `drain.rs` + `accounting.rs`)?
-
+1. **Snapshot-axis split — right granularity?** Seven helpers
+   for ~150 LOC. Coarser cut (e.g., merge 4a+4b into one
+   `push_front_drained_bucket` switch on `Option<snap>`) or
+   finer cut?
+2. **Borrow-shape explicit re-borrow** of `&mut ff` separated by
+   `republish_worker_vtime_slot`. Cleaner pattern via
+   `worker_id` + cached slot ref?
+3. **`#[inline]` on private fns + `objdump` codegen gate.**
+   Acceptable, or should it be `cargo asm`-based?
+4. **Test colocation deferral (Gemini #3).** v2 still defers
+   with explicit justification. PLAN-NEEDS-MINOR vs PLAN-KILL?
+5. **`pop_matching_snapshot` returning owned
+   `CoSQueuePopSnapshot`** vs `Option<&CoSQueuePopSnapshot>`. v2
+   picks owned because the matched-snapshot arm consumes its
+   fields by value.
+6. **Should `mirror_lease_active_flow_increment` hoist into
+   `active_buckets.rs`?** Same pattern exists for push_back /
+   accounting paths. v2 keeps it local to minimize cross-file
+   churn.

--- a/docs/pr/1355-cos-push-split/plan.md
+++ b/docs/pr/1355-cos-push-split/plan.md
@@ -1,0 +1,248 @@
+# #1355 — Split 218-LOC `cos_queue_push_front` along `flow_fair()` branch
+
+**Status:** DRAFT v1 — pending adversarial plan review.
+
+## Issue framing
+
+`userspace-dp/src/afxdp/cos/queue_ops/push.rs` is 271 production LOC,
+but the single function `cos_queue_push_front` (push.rs:54) is a
+218-LOC body sitting on the hot per-packet CoS enqueue path. Issue
+#1355 asks for a pure code-motion split along the `flow_fair()`
+config-time branch, so the two paths are reviewed independently:
+
+- Non-`flow_fair` fast path (~10 LOC).
+- `flow_fair` path with v8 v_min epoch accounting, snapshot-rollback,
+  disjoint-borrow lease handoff, head-finish rebase (~150+ LOC).
+
+`docs/engineering-style.md` flags >100 LOC as a refactor cue; the
+function is 2.18× the threshold and is a Tier-1 hard hit (>200 LOC).
+All callers go through `pub(in crate::afxdp)` re-exports from
+`queue_ops/mod.rs`, so the public boundary stays at the parent module.
+
+## Honest scope/value framing
+
+Pure code motion. **No** algorithmic change. Hot-path codegen is
+preserved by keeping `#[inline]` on the outer fn AND the two helpers.
+LLVM should lower the post-split call graph to the same instructions
+as the pre-split body — verified by smoke (line rate, 0 retrans) on
+the loss userspace cluster, not by IR diffing.
+
+The win is **reviewability + tests**:
+
+- Non-flow-fair branch and flow-fair branch can be exercised by
+  separate cargo tests rather than through the union-fn.
+- The 150-LOC flow-fair body (snapshot rollback, vtime restore, lease
+  handoff) sits in its own helper, not entangled with the trivial
+  non-flow-fair branch.
+
+*If reviewers conclude the refactor delivers no reviewability or
+test-strength win that justifies the churn, PLAN-KILL is an
+acceptable verdict.*
+
+## What's already shipped / partially batched
+
+- `cos_queue_push_back` already lives alongside in `push.rs` (51 LOC).
+  Both are `#[inline]` and cross-module-inline through the
+  `pub(in crate::afxdp)` re-export at `queue_ops/mod.rs:43`.
+- Sibling extractions (`accounting.rs`, `drain.rs`, `pop.rs`,
+  `v_min.rs`, `active_buckets.rs`) already split out from the
+  pre-#1034 monolith. This PR follows the same module/foo convention.
+- Pop+push-front contract pairing is already documented at
+  `push.rs:78-124` (#913 peek-then-pop snapshot consumption); the
+  helper extraction MUST preserve this contract byte-for-byte.
+
+## Concrete design
+
+**Layout option chosen:** sibling files inside `queue_ops/` (no
+`push/` sub-dir). Rationale: `queue_ops/` is already a directory of
+sibling files (`pop.rs`, `drain.rs`, `accounting.rs`, etc.), and the
+non-`flow_fair` branch is too small (~10 LOC) to deserve its own
+file. Both helpers live in the same `push.rs` so the matched
+push_back/push_front pair stays colocated.
+
+After the split, `push.rs` contains:
+
+```rust
+#[inline]
+pub(in crate::afxdp) fn cos_queue_push_front(
+    queue: &mut CoSQueueRuntime,
+    item: CoSPendingTxItem,
+) {
+    let item_len = cos_item_len(&item);
+    let flow_key = cos_item_flow_key(&item);
+    if matches!(item, CoSPendingTxItem::Local(_)) {
+        queue.hot.local_item_count =
+            queue.hot.local_item_count.saturating_add(1);
+    }
+    if !queue.flow_fair() {
+        push_front_non_flow_fair(queue, flow_key, item_len, item);
+        return;
+    }
+    push_front_flow_fair_v8(queue, flow_key, item_len, item);
+}
+
+#[inline]
+fn push_front_non_flow_fair(
+    queue: &mut CoSQueueRuntime,
+    flow_key: SessionKey,
+    item_len: u64,
+    item: CoSPendingTxItem,
+) {
+    account_cos_queue_flow_enqueue(queue, flow_key, item_len);
+    queue.hot.items.push_front(item);
+}
+
+#[inline]
+fn push_front_flow_fair_v8(
+    queue: &mut CoSQueueRuntime,
+    flow_key: SessionKey,
+    item_len: u64,
+    item: CoSPendingTxItem,
+) {
+    // <existing 150+ LOC verbatim from push.rs:65-271>
+}
+```
+
+**Critical:** the helper bodies are moved verbatim. The outer fn
+shape is preserved 1:1 with the original prelude:
+
+1. `cos_item_len(&item)` (line 55).
+2. `cos_item_flow_key(&item)` (line 56).
+3. `local_item_count` saturating add for `Local(_)` (lines 57-59).
+4. Branch on `!queue.flow_fair()`.
+5. Non-flow-fair branch: `account_cos_queue_flow_enqueue` +
+   `push_front` (lines 61-62).
+6. Flow-fair branch: capture `worker_id`, take `&mut ff`, run the
+   snapshot/rollback/lease state machine (lines 65-270).
+
+The flow-fair helper takes ownership of `item` and re-runs the
+existing `cos_item_len` / `cos_item_flow_key` for its own use? **No.**
+We pass `item_len` and `flow_key` as parameters from the outer fn so
+the helper does no redundant work. `item` is moved in by value.
+
+`worker_id` capture stays *inside* the flow-fair helper because the
+NLL borrow comment (`push.rs:65-69`) explicitly requires the capture
+to happen before the `flow_fair_state.as_mut()` mutable borrow. The
+helper boundary does not interfere — the helper has its own scope.
+
+## Public API preservation
+
+- `pub(in crate::afxdp) fn cos_queue_push_front(...)` — signature
+  unchanged.
+- `pub(in crate::afxdp) fn cos_queue_push_back(...)` — untouched.
+- The two new helpers are **module-private** (`fn`, no `pub`). They
+  are only callable from within `push.rs`. No re-export from
+  `queue_ops/mod.rs`.
+
+## Hidden invariants the change must preserve
+
+1. **`cos_item_len` and `cos_item_flow_key` evaluation order** — read
+   BEFORE the `matches!(Local(_))` arm. The current code reads them
+   first, then mutates `local_item_count`. Preserved.
+2. **`local_item_count` bump fires on BOTH branches** (flow-fair and
+   non-flow-fair). The mutation lives in the outer fn before the
+   `!flow_fair()` branch, so both helpers inherit it. Preserved by
+   leaving the mutation in the outer fn.
+3. **`account_cos_queue_flow_enqueue` is called ONLY on the
+   non-flow-fair path** (line 61). The flow-fair branch does its own
+   bucket-level accounting via the snapshot machinery. Preserved by
+   moving the call into `push_front_non_flow_fair`.
+4. **`worker_id` capture before `flow_fair_state.as_mut()`** — NLL
+   discipline (push.rs:65-69) mandates this order. Preserved
+   because the capture moves with the flow-fair body intact.
+5. **Snapshot stack contract** — top-entry bucket mismatch panics in
+   both dev and release via `assert!(false) + unreachable!()`.
+   Preserved verbatim.
+6. **`flow_fair_state` expect message** — current message says
+   `"cos_queue_push_front: flow_fair queue without flow_fair_state"`.
+   Helper retains the same message string so panics still grep with
+   the same operator-facing text.
+7. **v_min slot republish after vtime restore** — block at lines
+   144-148 must run on every flow-fair invocation. Moves verbatim
+   into the helper.
+8. **v8 lease per-worker counter mirror on both rollback paths**
+   (lines 171-175 and 209-215). Moves verbatim.
+9. **`#[inline]`** on outer fn AND both helpers, so cross-module
+   inlining at the `pub(in crate::afxdp)` boundary still folds the
+   call graph flat at -O3.
+10. **No new allocation** on either branch. Helpers receive `item` by
+    value, `flow_key` (`SessionKey` — `Copy`), `item_len` (`u64`).
+
+## Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Pure code motion. Outer-fn prelude (cos_item_len, cos_item_flow_key, local_item_count, branch) preserved 1:1. Helper bodies moved verbatim. |
+| Lifetime / borrow-checker | LOW | `worker_id` capture stays inside the flow-fair helper before the `&mut ff` borrow; the helper has its own scope so NLL discipline is identical. `item` moves by value through the helper boundary. |
+| Performance regression | LOW | `#[inline]` on outer + both helpers; LLVM should produce identical machine code. Smoke gate (line rate, 0 retrans on the multi-stream `-P 12 -R` reverse reproducer) is the live verification. |
+| Architectural mismatch (#946 Phase 2 / #961) | LOW | Not a pipeline change. Not a data-structure change. No cross-packet state introduced. The split is along a config-time boolean — the same dimension issue #1355 itself proposes. |
+
+## Test plan
+
+- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build` clean.
+- `cargo test --release` — full cargo suite passes (target current
+  count after rebases).
+- 5/5 flake check on the most affected named test in
+  `cos/queue_ops/tests.rs` (push-related — likely
+  `test_push_front_rollback_*` family).
+- `go test ./...` — all 30 Go packages pass.
+- Deploy on loss userspace cluster.
+- **Pass A — CoS disabled:** v4 + v6 × push + reverse, plus
+  multi-stream `-P 12 -R` reverse reproducers. Line rate, 0 retrans
+  on the multi-stream cells.
+- **Pass B — CoS enabled:** per-class smoke 5201-5206 × v4/v6 ×
+  push/reverse = 24 cells. Shaped classes hit shape rate cleanly.
+
+## Out of scope (explicitly)
+
+- Splitting the flow-fair body further (e.g.,
+  `account_then_push_front_flow_fair` sub-extraction the issue body
+  suggests). The flow-fair helper will still be over 100 LOC after
+  this split; a second extraction can land as a follow-up PR once
+  the snapshot-vs-no-snapshot decomposition is reviewed in isolation.
+- Migrating push-specific tests from `cos/queue_ops/tests.rs` /
+  `cos/queue_ops/pop_tests.rs` into a new `push_tests.rs` file. Test
+  colocation is a separate refactor (test files >2000 LOC tracked
+  elsewhere).
+- Any change to the snapshot stack contract, the v8 epoch handoff,
+  or the head-finish rebase arithmetic. All settled in #1229 / #913.
+
+## Open questions for adversarial review
+
+1. **Is splitting along `flow_fair()` the right axis?** The
+   alternative is splitting by "snapshot present / absent" inside the
+   flow-fair body — that's where the actual cyclomatic complexity
+   lives. Is the config-time-branch split the right *first* split, or
+   should we go straight for the snapshot-axis split? PLAN-KILL if the
+   config-axis split adds no test-strength and the real refactor is
+   the snapshot-axis one.
+2. **`#[inline]` discipline + cross-module inlining.** The current
+   `cos_queue_push_front` is `#[inline]` and `pub(in crate::afxdp)`.
+   After the split the *helpers* are private to `push.rs`, so
+   cross-module inlining doesn't apply to them — but they're called
+   only from within the same crate root. Is `#[inline]` even needed
+   on intra-module-private fns? Or does LLVM inline them by default
+   at `-O3`?
+3. **Parameter passing vs re-reading `cos_item_len`/`flow_key` in
+   helpers.** Plan passes them as `u64` + `SessionKey`. If the helper
+   bodies are inlined, this is free. If for some reason LLVM declines
+   to inline, we pay 16 bytes of stack per helper call. Acceptable?
+4. **Helper signature shape.** Should the helpers take
+   `&mut CoSQueueRuntime` and pull `item_len` / `flow_key` from
+   already-captured locals at the top of the helper, or should the
+   outer fn pass them by value? Plan picks the latter to avoid a
+   second `cos_item_len(&item)` call after `item` is moved. Right
+   choice?
+5. **Test colocation deferral.** The issue body explicitly says
+   `push_tests.rs` does not exist and tests live in
+   `pop_tests.rs` (1996 LOC). Should the test split land in this PR
+   or a follow-up? Plan defers. PLAN-KILL or PLAN-NEEDS-MAJOR if
+   reviewers think test colocation must land *with* the code split.
+6. **Architectural mismatch / wrong-target risk.** #1355 is a
+   "Refactor: <Pattern>" issue. Recent history (#946 Phase 2, #961,
+   #1144) shows these can be architecturally misdirected. Is this
+   refactor's *target* (push.rs single-function) right, or is the
+   real review-pain elsewhere in `cos/queue_ops/` (e.g.,
+   `pop_tests.rs` 1996 LOC, or the snapshot machinery split across
+   `push.rs` + `drain.rs` + `accounting.rs`)?
+

--- a/docs/pr/1355-cos-push-split/reviewer-ids.md
+++ b/docs/pr/1355-cos-push-split/reviewer-ids.md
@@ -1,0 +1,6 @@
+# Reviewer task IDs — #1355 cos_queue_push_front split
+
+## Plan review round 1
+
+- Codex: pending
+- Gemini: pending

--- a/docs/pr/1355-cos-push-split/reviewer-ids.md
+++ b/docs/pr/1355-cos-push-split/reviewer-ids.md
@@ -9,5 +9,5 @@
 
 ## Plan review round 2 — snapshot-axis re-target
 
-- Codex: pending (v2)
-- Gemini: pending (v2)
+- Codex: task-mpn35b09-ztxsth (dispatched 2026-05-26 20:35 UTC, v2 @ 509f1e0d)
+- Gemini: task-mpn35twr-zfl64q (dispatched 2026-05-26 20:35 UTC, v2 @ 509f1e0d)

--- a/docs/pr/1355-cos-push-split/reviewer-ids.md
+++ b/docs/pr/1355-cos-push-split/reviewer-ids.md
@@ -9,5 +9,14 @@
 
 ## Plan review round 2 — snapshot-axis re-target
 
-- Codex: task-mpn35b09-ztxsth (dispatched 2026-05-26 20:35 UTC, v2 @ 509f1e0d)
-- Gemini: task-mpn35twr-zfl64q (dispatched 2026-05-26 20:35 UTC, v2 @ 509f1e0d)
+- Codex: task-mpn35b09-ztxsth (PLAN-NEEDS-MINOR — codegen-gate widening + test-path)
+- Gemini: task-mpn35twr-zfl64q (PLAN-NEEDS-MINOR — unicode arrow + was_idle ack)
+
+## Code review round 1 — PR #1590 @ 2600109b — 4-of-4 MERGE-READY
+
+- Codex: task-mpn5jy3w-gq92x5 — MERGE-READY (no blocking findings)
+- Gemini: task-mpn5kiig-rqk14a — MERGE-READY (byte-for-byte parity confirmed)
+- Copilot: COMMENTED at 2026-05-26T21:35:22Z (PRR_kwDORLJrbM8AAAABBFVlLw) — 0 inline findings on 4/4 files
+- Claude (SMR): MERGE-READY — full build/test/flake/Go/codegen/Pass-A/Pass-B smoke matrix passed; pre-existing snat_contract_doc_guard failure confirmed unrelated
+
+AWAITING-BATCH-MERGE per user mandate.

--- a/docs/pr/1355-cos-push-split/reviewer-ids.md
+++ b/docs/pr/1355-cos-push-split/reviewer-ids.md
@@ -1,6 +1,13 @@
 # Reviewer task IDs — #1355 cos_queue_push_front split
 
-## Plan review round 1
+## Plan review round 1 — both PLAN-KILL on flow_fair() axis
 
-- Codex: pending
-- Gemini: pending
+- Codex: task-mpn2tomp-5t6oam (PLAN-KILL — split axis weak; helper
+  signatures invalid: SessionKey is Clone not Copy)
+- Gemini: task-mpn2u791-tq1zkx (PLAN-KILL — re-target along
+  snapshot-present/absent axis)
+
+## Plan review round 2 — snapshot-axis re-target
+
+- Codex: pending (v2)
+- Gemini: pending (v2)

--- a/userspace-dp/src/afxdp/cos/queue_ops/push.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/push.rs
@@ -4,6 +4,17 @@ use super::*;
 // the standard enqueue path; push_front is used by the worker drain loop
 // when a popped item must be returned to the head of the queue (partial
 // commit rollback before draining-side bookkeeping settled).
+//
+// #1355: cos_queue_push_front was decomposed along the snapshot-axis
+// into seven #[inline] private helpers (pop_matching_snapshot,
+// restore_queue_vtime, republish_worker_vtime_slot,
+// push_front_drained_bucket_with_snapshot,
+// push_front_drained_bucket_no_snapshot,
+// mirror_lease_active_flow_increment,
+// push_front_active_bucket_head_rebase). Both round-1 reviewers
+// PLAN-KILL'd the earlier flow_fair() axis; the snapshot-axis
+// decomposition is the round-2 PLAN-READY split. Plan doc:
+// docs/pr/1355-cos-push-split/plan.md.
 
 #[inline]
 pub(in crate::afxdp) fn cos_queue_push_back(queue: &mut CoSQueueRuntime, item: CoSPendingTxItem) {
@@ -50,6 +61,14 @@ pub(in crate::afxdp) fn cos_queue_push_back(queue: &mut CoSQueueRuntime, item: C
     }
 }
 
+/// #1355: thin outer fn — common prelude + non-flow-fair fast path
+/// + bucket pre-computation, then dispatch to the flow-fair helper.
+///
+/// The split along the snapshot-axis lives inside
+/// `push_front_flow_fair_v8`. Codex/Gemini round-1 PLAN-KILL
+/// rejected the earlier flow_fair() split; round-2 accepted the
+/// snapshot-axis decomposition documented in
+/// docs/pr/1355-cos-push-split/plan.md.
 #[inline]
 pub(in crate::afxdp) fn cos_queue_push_front(queue: &mut CoSQueueRuntime, item: CoSPendingTxItem) {
     let item_len = cos_item_len(&item);
@@ -68,46 +87,133 @@ pub(in crate::afxdp) fn cos_queue_push_front(queue: &mut CoSQueueRuntime, item: 
     // (disjoint field) is then accessed without an Arc clone. See
     // accounting.rs for the same pattern; plan §v8.1.
     let worker_id = queue.v_min.worker_id as usize;
+    // #1355: pre-compute the bucket index via a short `&ff` borrow
+    // BEFORE `item` is moved into the flow-fair helper. `flow_key`
+    // borrows into `item` (cos_item_flow_key returns
+    // `Option<&SessionKey>`; SessionKey is Clone, not Copy), so the
+    // bucket-index computation must complete and the borrow drop
+    // BEFORE we move `item`. Only `bucket: usize` (Copy) crosses
+    // the helper boundary.
+    //
     // Invariant: see cos_queue_push_back for the same flow_fair/state
     // pairing. Silent drop here would also corrupt the snapshot stack.
+    let bucket = {
+        let ff = queue
+            .flow_fair_state
+            .as_ref()
+            .expect("cos_queue_push_front: flow_fair queue without flow_fair_state");
+        cos_flow_bucket_index(ff.flow_hash_seed, flow_key)
+    };
+    push_front_flow_fair_v8(queue, bucket, item_len, item, worker_id);
+}
+
+/// #1355: orchestrates the snapshot-axis state machine for the
+/// flow-fair push-front path. Re-borrows `&mut flow_fair_state` in
+/// two discrete blocks separated by the disjoint-field access in
+/// `republish_worker_vtime_slot` (which reads `queue.v_min`). This
+/// matches the NLL pattern the monolith used implicitly — v2 just
+/// makes the borrow-block boundaries explicit at the helper edges.
+#[inline]
+fn push_front_flow_fair_v8(
+    queue: &mut CoSQueueRuntime,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+    worker_id: usize,
+) {
+    let snapshot = {
+        let ff = queue
+            .flow_fair_state
+            .as_mut()
+            .expect("cos_queue_push_front: flow_fair queue without flow_fair_state");
+        let snap = pop_matching_snapshot(ff, bucket);
+        restore_queue_vtime(ff, snap.as_ref(), item_len);
+        snap
+    };
+    // First `&mut ff` borrow ends. `republish_worker_vtime_slot`
+    // re-borrows `&queue.flow_fair_state` and reads `queue.v_min`
+    // (disjoint field) — same NLL pattern as the original monolith.
+    republish_worker_vtime_slot(queue);
     let ff = queue
         .flow_fair_state
         .as_mut()
         .expect("cos_queue_push_front: flow_fair queue without flow_fair_state");
-    let bucket = cos_flow_bucket_index(ff.flow_hash_seed, flow_key);
-    // #913: peek-then-pop snapshot consumption.
-    //
-    // Three states:
-    //   1. Empty stack: legitimate (drain_all cleared it; or
-    //      fresh-flow / non-Phase-3 caller). Aggregate-bytes
-    //      rewind path — `vtime -= item_len` pairs with the
-    //      no-snapshot pop's `vtime += bytes` for round-trip
-    //      neutrality (see plan §3.7 walkthrough for
-    //      drain_all→restore_front).
-    //   2. Top entry's bucket matches: hot-path matched
-    //      rollback. Pop and restore vtime + head/tail
-    //      from snapshot (closes #913 max-based advance).
-    //   3. Top entry's bucket DOES NOT match: hard contract
-    //      violation. With §3.4's scratch-builder orphan
-    //      cleanup in place, this is believed unreachable in
-    //      current code. `assert!(false)` panics in BOTH dev
-    //      and release.
-    //
-    //      No supervisor in this PR (#913 R4 revert): the
-    //      panic propagates to the default Rust panic
-    //      handler, which emits the panic message to stderr
-    //      → journald and kills the worker thread. The
-    //      helper process keeps running with one fewer
-    //      worker; bindings served by that worker stall
-    //      until the daemon is restarted via config change
-    //      or operator intervention. SAME blast radius as
-    //      every existing `unwrap`/`expect`/`panic!` site
-    //      in `worker_loop` — #913 introduces zero
-    //      incremental panic risk. Cross-cutting panic
-    //      supervision (catch_unwind on helper side +
-    //      parent-side restart in xpfd) tracked in #925.
+    let was_empty = ff.flow_bucket_items[bucket].is_empty();
+    if was_empty {
+        if let Some(snap) = snapshot {
+            push_front_drained_bucket_with_snapshot(ff, bucket, item_len, item, snap);
+            // `ff` borrow ends here (NLL: last use above).
+            // #1229 Phase 6 v8: mirror to lease per-worker counter
+            // on this rollback re-increment. Codex v7 review of
+            // #1229 caught that omitting this leaks the asymmetry
+            // until u32 wrap. Snapshot-restore path: lease mirror
+            // fires unconditionally (the bucket was drained AND we
+            // restored an item, so active_flow_buckets bumped from
+            // 0 → 1).
+            mirror_lease_active_flow_increment(queue, worker_id);
+        } else {
+            // No snapshot — drain_all/restore_front path or
+            // fresh-flow caller. Helper returns `was_idle` (the
+            // pre-mutation `flow_bucket_bytes == 0` check) so the
+            // call site can gate the lease mirror.
+            let was_idle = push_front_drained_bucket_no_snapshot(ff, bucket, item_len, item);
+            // `ff` borrow ends here.
+            // #1229 Phase 6 v8: idle-bucket-rebuild rollback path.
+            // Mirror only when `was_idle` (consistent with the
+            // pre-#1355 monolith's gate). Plan v2 round-2 Gemini
+            // ack: branch on the pre-computed `was_idle` BEFORE
+            // the lease load — harmless reorder relative to the
+            // monolith's `if let Some(lease) { if was_idle ... }`
+            // shape, and skips the lease load entirely for
+            // non-v8 queues when `!was_idle`.
+            if was_idle {
+                mirror_lease_active_flow_increment(queue, worker_id);
+            }
+        }
+        return;
+    }
+    // Active-bucket path: bucket is already tracked, so NO
+    // active_flow_buckets bump, NO flow_rr_buckets push, NO tail
+    // update, NO lease mirror (Gemini round-1 finding #2). The
+    // helper preserves these by absence.
+    push_front_active_bucket_head_rebase(ff, bucket, item_len, item);
+}
+
+/// #913: peek-then-pop snapshot consumption.
+///
+/// Three states:
+///   1. Empty stack: legitimate (drain_all cleared it; or
+///      fresh-flow / non-Phase-3 caller). Aggregate-bytes
+///      rewind path — `vtime -= item_len` pairs with the
+///      no-snapshot pop's `vtime += bytes` for round-trip
+///      neutrality (see plan §3.7 walkthrough for
+///      drain_all→restore_front).
+///   2. Top entry's bucket matches: hot-path matched
+///      rollback. Pop and restore vtime + head/tail
+///      from snapshot (closes #913 max-based advance).
+///   3. Top entry's bucket DOES NOT match: hard contract
+///      violation. With §3.4's scratch-builder orphan
+///      cleanup in place, this is believed unreachable in
+///      current code. `assert!(false)` panics in BOTH dev
+///      and release.
+///
+///      No supervisor in this PR (#913 R4 revert): the
+///      panic propagates to the default Rust panic
+///      handler, which emits the panic message to stderr
+///      → journald and kills the worker thread. The
+///      helper process keeps running with one fewer
+///      worker; bindings served by that worker stall
+///      until the daemon is restarted via config change
+///      or operator intervention. SAME blast radius as
+///      every existing `unwrap`/`expect`/`panic!` site
+///      in `worker_loop` — #913 introduces zero
+///      incremental panic risk. Cross-cutting panic
+///      supervision (catch_unwind on helper side +
+///      parent-side restart in xpfd) tracked in #925.
+#[inline]
+fn pop_matching_snapshot(ff: &mut FlowFairState, bucket: usize) -> Option<CoSQueuePopSnapshot> {
     let stack_top_bucket = ff.pop_snapshot_stack.last().map(|s| usize::from(s.bucket));
-    let snapshot = match stack_top_bucket {
+    match stack_top_bucket {
         None => None,
         Some(top) if top == bucket => ff.pop_snapshot_stack.pop(),
         Some(top) => {
@@ -121,14 +227,21 @@ pub(in crate::afxdp) fn cos_queue_push_front(queue: &mut CoSQueueRuntime, item: 
             );
             unreachable!()
         }
-    };
+    }
+}
 
-    // #913: vtime restore — symmetric inverse of the §3.1 advance.
-    // Matched-snapshot path: restore from snapshot for both the
-    // was_empty (drained-bucket) and active-bucket branches.
-    // Empty-stack path: legacy aggregate-bytes rewind paired with
-    // the no-snapshot pop's `vtime += bytes`.
-    match snapshot.as_ref() {
+/// #913: vtime restore — symmetric inverse of the §3.1 advance.
+/// Matched-snapshot path: restore from snapshot for both the
+/// was_empty (drained-bucket) and active-bucket branches.
+/// Empty-stack path: legacy aggregate-bytes rewind paired with
+/// the no-snapshot pop's `vtime += bytes`.
+#[inline]
+fn restore_queue_vtime(
+    ff: &mut FlowFairState,
+    snapshot: Option<&CoSQueuePopSnapshot>,
+    item_len: u64,
+) {
+    match snapshot {
         Some(snap) => {
             ff.queue_vtime = snap.pre_pop_queue_vtime;
         }
@@ -136,130 +249,165 @@ pub(in crate::afxdp) fn cos_queue_push_front(queue: &mut CoSQueueRuntime, item: 
             ff.queue_vtime = ff.queue_vtime.saturating_sub(item_len);
         }
     }
-    // #917 Phase 3: republish the rolled-back queue_vtime so peers
-    // see the restored value, not the speculative pop's advanced
-    // value. Without this, a peer reading mid-rollback would see
-    // an inflated V_min slot for this worker — over-throttling
-    // peers until the next pop fixes it.
+}
+
+/// #917 Phase 3: republish the rolled-back queue_vtime so peers
+/// see the restored value, not the speculative pop's advanced
+/// value. Without this, a peer reading mid-rollback would see
+/// an inflated V_min slot for this worker — over-throttling
+/// peers until the next pop fixes it.
+///
+/// Read-only on the `queue` so the `&mut flow_fair_state` borrow
+/// in the caller can be split into two discrete blocks around
+/// this call.
+#[inline]
+fn republish_worker_vtime_slot(queue: &CoSQueueRuntime) {
+    let ff = match queue.flow_fair_state.as_ref() {
+        Some(f) => f,
+        None => return,
+    };
     if let Some(floor) = queue.v_min.vtime_floor.as_ref() {
         if let Some(slot) = floor.slots.get(queue.v_min.worker_id as usize) {
             slot.publish(ff.queue_vtime);
         }
     }
+}
 
-    let was_empty = ff.flow_bucket_items[bucket].is_empty();
-    if was_empty {
-        // Bucket was drained by the matching pop. Snapshot (if
-        // present) holds the exact pre-pop head/tail so we can
-        // restore them.
-        if let Some(snap) = snapshot {
-            ff.flow_bucket_bytes[bucket] = ff.flow_bucket_bytes[bucket].saturating_add(item_len);
-            ff.flow_bucket_head_finish_bytes[bucket] = snap.pre_pop_head_finish;
-            ff.flow_bucket_tail_finish_bytes[bucket] = snap.pre_pop_tail_finish;
-            ff.active_flow_buckets = ff.active_flow_buckets.saturating_add(1);
-            if ff.active_flow_buckets > ff.active_flow_buckets_peak {
-                ff.active_flow_buckets_peak = ff.active_flow_buckets;
-            }
-            // Finish the `ff` mutations first so NLL ends the borrow
-            // before the lease update below (no Arc clone needed).
-            ff.flow_bucket_items[bucket].push_front(item);
-            ff.flow_rr_buckets.push_front(bucket as u16);
-            // `ff` borrow ends here (NLL: last use above).
-            // #1229 Phase 6 v8: mirror to lease per-worker counter
-            // on this rollback re-increment. Codex v7 review caught
-            // that omitting this leaks the asymmetry until u32 wrap.
-            if let Some(lease) = queue.queue_lease_v8.as_ref() {
-                if let Some(slot) = lease.worker_active_flow_buckets_for(worker_id) {
-                    slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
-            }
-            return;
-        }
-        // No snapshot — drain_all/restore_front path or fresh-flow
-        // caller. Standard idle-bucket re-anchor.
-        // The aggregate-bytes vtime rewind above leaves vtime
-        // correctly positioned for `max(tail, vtime) + bytes`
-        // (see plan §3.7 walkthrough for the drain_all case).
-        // #1229 Phase 6 v8: `was_idle` serves as both the push-front
-        // anchor flag AND the v8 lease bump gate. Captured once here
-        // (before any byte mutations) to avoid a redundant re-check
-        // after the active_flow_buckets increment below.
-        let was_idle = ff.flow_bucket_bytes[bucket] == 0;
-        if was_idle {
-            ff.active_flow_buckets = ff.active_flow_buckets.saturating_add(1);
-            if ff.active_flow_buckets > ff.active_flow_buckets_peak {
-                ff.active_flow_buckets_peak = ff.active_flow_buckets;
-            }
-        }
-        ff.flow_bucket_bytes[bucket] = ff.flow_bucket_bytes[bucket].saturating_add(item_len);
-        let new_tail = ff.flow_bucket_tail_finish_bytes[bucket]
-            .max(ff.queue_vtime)
-            .saturating_add(item_len);
-        ff.flow_bucket_tail_finish_bytes[bucket] = new_tail;
-        if was_idle {
-            ff.flow_bucket_head_finish_bytes[bucket] = new_tail;
-        }
-        ff.flow_bucket_items[bucket].push_front(item);
-        ff.flow_rr_buckets.push_front(bucket as u16);
-        // `ff` borrow ends here (NLL: last use above).
-        // #1229 Phase 6 v8: idle-bucket-rebuild rollback path.
-        // Mirror the re-increment to the lease counter. Hoist lease
-        // check outside `was_idle` so non-v8 queues (lease None)
-        // short-circuit immediately without evaluating `was_idle`.
-        if let Some(lease) = queue.queue_lease_v8.as_ref() {
-            if was_idle {
-                if let Some(slot) = lease.worker_active_flow_buckets_for(worker_id) {
-                    slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
-            }
-        }
-        return;
+/// #913: drained-bucket restore from snapshot. Bucket was drained
+/// by the matching pop; snapshot holds the exact pre-pop head/tail
+/// so we restore them. Caller fires the lease mirror after this
+/// returns (unconditional on the snapshot path).
+#[inline]
+fn push_front_drained_bucket_with_snapshot(
+    ff: &mut FlowFairState,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+    snap: CoSQueuePopSnapshot,
+) {
+    ff.flow_bucket_bytes[bucket] = ff.flow_bucket_bytes[bucket].saturating_add(item_len);
+    ff.flow_bucket_head_finish_bytes[bucket] = snap.pre_pop_head_finish;
+    ff.flow_bucket_tail_finish_bytes[bucket] = snap.pre_pop_tail_finish;
+    ff.active_flow_buckets = ff.active_flow_buckets.saturating_add(1);
+    if ff.active_flow_buckets > ff.active_flow_buckets_peak {
+        ff.active_flow_buckets_peak = ff.active_flow_buckets;
     }
-    // #785 Phase 3 — MQFQ push_front onto an ACTIVE bucket.
-    //
-    // Codex adversarial review (round-2) flagged this path as HIGH:
-    // the prior revision funnelled through
-    // `account_cos_queue_flow_enqueue`, which only advances `tail`
-    // on an active bucket — head stayed stale at a value keyed off
-    // whatever was the HEAD packet before this push_front.
-    // Selection would then pick the bucket based on the STALE head
-    // finish (stale because the item-queue front changed), and the
-    // subsequent non-drain pop would `head += bytes(next_head)`
-    // off the stale base, producing arbitrary finish values.
-    //
-    // Fix: push_front is only called from TX-ring-full restoration
-    // paths where an item was JUST popped from this same bucket.
-    // We reverse that pop's head-advance: at pop time we computed
-    // `head += bytes(what_is_now_front)`. At push_front time we
-    // subtract the SAME quantity to get back to the pop-time head
-    // (which was the popped item's finish). The restored item
-    // takes over as the new head and inherits that finish — which
-    // is exactly what it had before the pop. Net effect: the
-    // pop-and-restore round-trip is finish-time neutral, which is
-    // what correctness on the error-retry path demands.
-    //
-    // #913: vtime is already restored above (snapshot path or
-    // aggregate-bytes path). The active-bucket head reversal
-    // here is unchanged from pre-#913 — `head -= bytes(current_head)`
-    // is correct under MQFQ "drops consume virtual service"
-    // semantics. Reasoning:
-    //
-    // - Single-pop case: push_front is the exact inverse of the
-    //   most recent pop. head was advanced by bytes(current_head);
-    //   subtracting reverses it.
-    // - Multi-pop case with mid-Drop (e.g., pop A1, pop A2, drop A2,
-    //   restore A1 while A3 is in bucket): head=4500 after pop A2.
-    //   Arithmetic gives head=4500-bytes(A3=1500)=3000. Subsequent
-    //   pop A1 then advances head to 3000+bytes(A3)=4500. A3 ends
-    //   up at finish=4500, preserving A2's "consumed virtual
-    //   service" — competing buckets between 3000 and 4500
-    //   correctly drain before A3.
-    //
-    // (Codex code-review R8 initially flagged this as wrong with
-    // recommendation to use snap.pre_pop_head_finish; R9 then
-    // reversed when its own walkthrough showed the arithmetic
-    // result is needed for the post-restore-pop case. Documented
-    // in §3.3 of the plan.)
+    ff.flow_bucket_items[bucket].push_front(item);
+    ff.flow_rr_buckets.push_front(bucket as u16);
+}
+
+/// No snapshot — drain_all/restore_front path or fresh-flow caller.
+/// Standard idle-bucket re-anchor. The aggregate-bytes vtime rewind
+/// (in `restore_queue_vtime`) leaves vtime correctly positioned for
+/// `max(tail, vtime) + bytes` (see plan §3.7 walkthrough for the
+/// drain_all case).
+///
+/// Returns `was_idle` — the pre-mutation `flow_bucket_bytes == 0`
+/// check. Caller gates the lease mirror on this return value (the
+/// lease bump only fires when `was_idle`).
+///
+/// #1229 Phase 6 v8: `was_idle` serves as both the push-front
+/// anchor flag AND the v8 lease bump gate. Captured once here
+/// (before any byte mutations) to avoid a redundant re-check after
+/// the active_flow_buckets increment below.
+#[inline]
+fn push_front_drained_bucket_no_snapshot(
+    ff: &mut FlowFairState,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+) -> bool {
+    let was_idle = ff.flow_bucket_bytes[bucket] == 0;
+    if was_idle {
+        ff.active_flow_buckets = ff.active_flow_buckets.saturating_add(1);
+        if ff.active_flow_buckets > ff.active_flow_buckets_peak {
+            ff.active_flow_buckets_peak = ff.active_flow_buckets;
+        }
+    }
+    ff.flow_bucket_bytes[bucket] = ff.flow_bucket_bytes[bucket].saturating_add(item_len);
+    let new_tail = ff.flow_bucket_tail_finish_bytes[bucket]
+        .max(ff.queue_vtime)
+        .saturating_add(item_len);
+    ff.flow_bucket_tail_finish_bytes[bucket] = new_tail;
+    if was_idle {
+        ff.flow_bucket_head_finish_bytes[bucket] = new_tail;
+    }
+    ff.flow_bucket_items[bucket].push_front(item);
+    ff.flow_rr_buckets.push_front(bucket as u16);
+    was_idle
+}
+
+/// #1229 Phase 6 v8: mirror an `active_flow_buckets` increment to
+/// the lease per-worker counter. Caller has already bumped the
+/// local `active_flow_buckets` count; this hooks the v8 lease
+/// per-worker slot to keep cross-worker view consistent.
+#[inline]
+fn mirror_lease_active_flow_increment(queue: &CoSQueueRuntime, worker_id: usize) {
+    if let Some(lease) = queue.queue_lease_v8.as_ref() {
+        if let Some(slot) = lease.worker_active_flow_buckets_for(worker_id) {
+            slot.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
+
+/// #785 Phase 3 — MQFQ push_front onto an ACTIVE bucket.
+///
+/// Codex adversarial review (round-2 of the #785 series) flagged
+/// this path as HIGH: the prior revision funnelled through
+/// `account_cos_queue_flow_enqueue`, which only advances `tail`
+/// on an active bucket — head stayed stale at a value keyed off
+/// whatever was the HEAD packet before this push_front.
+/// Selection would then pick the bucket based on the STALE head
+/// finish (stale because the item-queue front changed), and the
+/// subsequent non-drain pop would `head += bytes(next_head)`
+/// off the stale base, producing arbitrary finish values.
+///
+/// Fix: push_front is only called from TX-ring-full restoration
+/// paths where an item was JUST popped from this same bucket.
+/// We reverse that pop's head-advance: at pop time we computed
+/// `head += bytes(what_is_now_front)`. At push_front time we
+/// subtract the SAME quantity to get back to the pop-time head
+/// (which was the popped item's finish). The restored item
+/// takes over as the new head and inherits that finish — which
+/// is exactly what it had before the pop. Net effect: the
+/// pop-and-restore round-trip is finish-time neutral, which is
+/// what correctness on the error-retry path demands.
+///
+/// #913: vtime is already restored above (snapshot path or
+/// aggregate-bytes path). The active-bucket head reversal here
+/// is unchanged from pre-#913 — `head -= bytes(current_head)`
+/// is correct under MQFQ "drops consume virtual service"
+/// semantics. Reasoning:
+///
+/// - Single-pop case: push_front is the exact inverse of the
+///   most recent pop. head was advanced by bytes(current_head);
+///   subtracting reverses it.
+/// - Multi-pop case with mid-Drop (e.g., pop A1, pop A2, drop A2,
+///   restore A1 while A3 is in bucket): head=4500 after pop A2.
+///   Arithmetic gives head=4500-bytes(A3=1500)=3000. Subsequent
+///   pop A1 then advances head to 3000+bytes(A3)=4500. A3 ends
+///   up at finish=4500, preserving A2's "consumed virtual
+///   service" — competing buckets between 3000 and 4500
+///   correctly drain before A3.
+///
+/// (Codex code-review R8 of #785 initially flagged this as wrong
+/// with recommendation to use snap.pre_pop_head_finish; R9 then
+/// reversed when its own walkthrough showed the arithmetic
+/// result is needed for the post-restore-pop case. Documented in
+/// §3.3 of the original #785 plan.)
+///
+/// Invariant (Gemini round-1 finding #2 on #1355): this path does
+/// NOT bump active_flow_buckets, does NOT push to flow_rr_buckets,
+/// does NOT update tail finish, and does NOT mirror to the v8
+/// lease. All preserved by absence — the helper simply does not
+/// contain those operations.
+#[inline]
+fn push_front_active_bucket_head_rebase(
+    ff: &mut FlowFairState,
+    bucket: usize,
+    item_len: u64,
+    item: CoSPendingTxItem,
+) {
     let current_head_bytes = ff.flow_bucket_items[bucket]
         .front()
         .map(cos_item_len)


### PR DESCRIPTION
## Summary

Decompose the 218-LOC `cos_queue_push_front` in
`userspace-dp/src/afxdp/cos/queue_ops/push.rs` into a thin outer
`#[inline] pub(in crate::afxdp)` orchestrator plus seven private
`#[inline]` helpers, partitioned along the snapshot-state machine
that lives inside the flow-fair body. Pure code motion; all seven
helpers fully inlined per the release-mode codegen gate.

Closes #1355.

## Plan + adversarial review

Plan doc: `docs/pr/1355-cos-push-split/plan.md`

- Codex round-1: PLAN-KILL (task-mpn2tomp-5t6oam) — split axis weak
  + `SessionKey` defect.
- Gemini round-1: PLAN-KILL (task-mpn2u791-tq1zkx) — re-target along
  snapshot-axis; missing active-bucket invariant.
- Codex round-2: PLAN-NEEDS-MINOR (task-mpn35b09-ztxsth) — codegen
  gate widening, test-file path fix, panic-message Unicode parity.
- Gemini round-2: PLAN-NEEDS-MINOR (task-mpn35twr-zfl64q) — Unicode
  arrow, `was_idle` short-circuit reorder ack.

All round-2 minors folded into the implementation.

## Test plan

- [x] cargo build clean (122 pre-existing warnings, 0 new)
- [x] cargo test --release: 1433+ tests pass. Pre-existing
      `snat_contract_doc_guard` failure on origin/master base
      63dfe02a (unrelated; `docs/userspace-dataplane-gaps.md`
      missing \"fail-closed\" — #1476 follow-up).
- [x] 5/5 flake check on `mqfq_push_front_*` (push-front pins in
      `pop_tests.rs`): 2/2 pass per iteration
- [x] `go test ./...`: all packages pass
- [x] **Codegen gate**: `objdump -Cd xpf-userspace-dp` shows zero
      call edges to `push_front_flow_fair_v8`,
      `pop_matching_snapshot`, `restore_queue_vtime`,
      `republish_worker_vtime_slot`,
      `push_front_drained_bucket_{with,no}_snapshot`,
      `mirror_lease_active_flow_increment`, or
      `push_front_active_bucket_head_rebase`. All seven helpers
      fully inlined.
- [x] Deploy on loss userspace cluster
- [x] **Pass A — CoS disabled** (best-effort fast path)
  - [x] v4 push: 8.61 Gb/s, 0 retrans (172.16.80.200)
  - [x] v4 reverse: 8.85 Gb/s, 0 retrans
  - [x] v6 push: 8.49 Gb/s, 0 retrans (2001:559:8585:80::200)
  - [x] v6 reverse: 8.63 Gb/s, 0 retrans
  - [x] v4 multi-stream `iperf3 -P 12 -t 10 -R`: 23.0 Gb/s line
        rate, 0 retrans
  - [x] v6 multi-stream `iperf3 -P 12 -t 10 -R`: 22.8 Gb/s line
        rate, 0 retrans
- [x] **Pass B — CoS enabled** (per-class shaper + classifier,
      24 cells = 6 ports × v4/v6 × push/reverse)
  - [x] All 24 cells achieve connectivity
  - [x] Shaped classes hit configured rates cleanly (iperf-a
        83 Mb/s push, iperf-b 845 Mb/s push, iperf-c 2.52 Gb/s
        push, iperf-d 4.86 Gb/s push, iperf-e 5.84 Gb/s push,
        iperf-f 6.38 Gb/s push)
  - [x] Push paths uniformly 0 retrans; three reverse cells show
        small retrans (487/85/57) consistent with normal CoS
        shaper ECN behavior

<!-- AWAITING-BATCH-MERGE -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)