### PR TITLE
#1578: realign loss userspace cluster smoke target to 172.16.80.200

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,3 +284,29 @@ Test containers:
   untrust-host  10.0.2.102  (2001:559:8585:bf02::102)  — xpf-untrust bridge
   dmz-host      10.0.30.101 (2001:559:8585:bf03::101)  — xpf-dmz bridge
 ```
+
+**HA cluster on `loss:xpf-userspace-fw0/fw1`** — different topology from
+the standalone VM above. Do NOT extrapolate the standalone PCI map to
+the loss userspace cluster; the WAN interface there is `ge-0-0-2`, not
+`ge-0-0-3`, and `ge-0-0-0` is the fabric IPVLAN parent (not WAN). The
+per-cluster wiring is canonical in `docs/ha-cluster-userspace.conf` +
+`test/incus/loss-userspace-cluster.env`. Summary:
+
+```
+loss:xpf-userspace-fw{0,1} — node-id 0 / 1, /etc/xpf/node-id present:
+  Virtio (PCI bus 05-07, lower bus → lower vSRX name):
+    enp5s0  → fxp0       DHCP                          — mgmt zone (SSH + ping)
+    enp6s0  → em0        10.99.{0..12}.{1,2}           — cluster control plane / heartbeat
+    enp7s0  → ge-0-0-0   fab0 IPVLAN parent            — fabric (xdpgeneric — fabric path only)
+  mlx5 SR-IOV VF (PCI bus 08-09 — native XDP):
+    enp8s0  → ge-0-0-1   reth1.0 (LAN, 10.0.61.1/24)   — LAN-side, mlx5_core xdp native
+    enp9s0  → ge-0-0-2   reth0 (WAN; VLAN 50 + 80)     — WAN-side, mlx5_core xdp native
+                         reth0.50  172.16.50.8/24      —   transit
+                         reth0.80  172.16.80.8/24      —   data path target VLAN
+
+Smoke iperf3 target: 172.16.80.200 / 2001:559:8585:80::200 (on reth0.80
+WAN path, AF_XDP zero-copy fast path). Per-class iperf3 servers live on
+ports 5201-5211 matching `test/incus/cos-iperf-config.set`. Do NOT use
+172.16.100.x — that reaches a different `loss:` uplink path capped at
+~9-10 Gb/s and was the misdiagnosed "cluster ceiling" in #1578.
+```

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,31 @@
 # Action Log
 
+## 2026-05-26 23:10 UTC — #1578 cluster perf root-cause (smoke target IP misalignment)
+
+- **Timestamp**: 2026-05-26 23:10 UTC
+  - **Action**: Investigated the "loss userspace cluster ~9 Gb/s
+    reverse P=12 ceiling" reported in #1578 / #1580 / #1593. Direct
+    empirical probing on `loss:xpf-userspace-fw0` against the
+    canonical AF_XDP fast path showed 23.4 Gb/s push P=12 and 23.1
+    Gb/s reverse P=12 with CoS off, and 19-23 Gb/s reverse P=12 on
+    every port 5201-5211 with CoS active. Confirmed all 11 per-class
+    iperf3 listeners are live on `172.16.80.200`. The prior 9.35
+    Gb/s numbers reproduce only when iperf3 targets `172.16.100.200`
+    — which `loss-userspace-cluster.env IPERF_TARGET4` inherited
+    from the legacy bpfrx-fw0/1 cluster — reaching a different
+    `loss:` uplink path capped at ~10 Gb/s. The port 5211 / CoS /
+    virtio_net-xdpgeneric-WAN theories are all empirically false:
+    port 5211 is iperf-uncapped, CoS doesn't cap reverse direction,
+    and WAN on the loss userspace cluster is `ge-0-0-2` on mlx5_core
+    native XDP, not `ge-0-0-0` (which is the fabric IPVLAN parent).
+    Repointed `IPERF_TARGET4/6` to `172.16.80.200` /
+    `2001:559:8585:80::200` so failover scripts share the same
+    canonical target as the triple-review SKILL.md smoke harness,
+    and added a loss-cluster topology block to CLAUDE.md to prevent
+    future "ge-0-0-0 is WAN" misdiagnoses.
+  - **File(s)**: test/incus/loss-userspace-cluster.env, CLAUDE.md,
+    _Log.md (this entry).
+
 ## 2026-05-26 22:46 UTC — #1439 snapshot.go split (rebase carry-forward)
 
 - **Timestamp**: 2026-05-26 22:46 UTC

--- a/test/incus/loss-userspace-cluster.env
+++ b/test/incus/loss-userspace-cluster.env
@@ -30,5 +30,13 @@ LAN_VIP4="10.0.61.1"
 LAN_VIP6="2001:559:8585:ef00::1"
 WAN_GW4="172.16.50.1"
 WAN_VIP4="172.16.50.6"
-IPERF_TARGET4="172.16.100.200"
-IPERF_TARGET6="2001:559:8585:100::200"
+# iperf3 server lives on the WAN-side host attached to reth0.80 (VLAN 80,
+# `172.16.80.0/24` / `2001:559:8585:80::/64`). Earlier versions of this env
+# inherited `172.16.100.x` from the legacy `bpfrx-fw0/1` cluster and pointed
+# smoke / failover scripts at an iperf3 listener reachable only via a
+# different `loss:` uplink path that itself caps at ~9-10 Gb/s, which
+# masqueraded as an xpf-side perf ceiling in #1578 / #1580 / #1593. The
+# canonical AF_XDP fast path through `ge-0-0-2.80` delivers 22-23 Gb/s
+# reverse P=12; the smoke target must point at the matching VLAN-80 host.
+IPERF_TARGET4="172.16.80.200"
+IPERF_TARGET6="2001:559:8585:80::200"


### PR DESCRIPTION
## Summary

Root-cause for #1578 / #1580 / #1593 "loss userspace cluster ~9 Gb/s
ceiling": the `IPERF_TARGET4`/`IPERF_TARGET6` defaults in
`test/incus/loss-userspace-cluster.env` were inherited from the legacy
`bpfrx-fw0/1` cluster and pointed at `172.16.100.200`. That target is
reachable on the loss userspace cluster only via a different `loss:`
uplink path that itself caps at ~9-10 Gb/s reverse P=12 — direct A/B
measurement below — with no relation to the AF_XDP fast path through
`reth0.80`.

This PR repoints the env file's iperf3 target to `172.16.80.200` /
`2001:559:8585:80::200` (the canonical WAN-side host matching the
`reth0.80` VLAN-80 address in `docs/ha-cluster-userspace.conf` and the
`triple-review` SKILL.md smoke harness), and adds an HA-cluster
topology block to CLAUDE.md so future smoke diagnostics don't
mis-identify `ge-0-0-0` (fabric IPVLAN parent, virtio_net xdpgeneric)
as WAN.

Closes #1578.

## Root-cause evidence

Direct A/B on `loss:xpf-userspace-fw0` at master `1c1965a9d`, CoS
removed, 2026-05-26 ~23:10 UTC, identical command except target IP:

| Target | Source | v4 rev P=12 | v6 rev P=12 |
|---|---|---|---|
| `172.16.80.200` | `docs/ha-cluster-userspace.conf` reth0.80 + skill doc | **23.2 Gb/s** | **22.5 Gb/s** |
| `172.16.100.200` | env file default (legacy bpfrx-fw0/1 inheritance) | 9.44 Gb/s | 9.31 Gb/s |

CoS-on per-port reverse P=12 sweep against `172.16.80.200` (ports
5201-5211 all listening, none caps reverse): 19.5 / 22.7 / 23.2 / 23.3
/ 21.8 / 21.3 / 23.0 / 23.3 / 23.2 / 23.1 / 23.2 Gb/s.

The original #1578 hypotheses tested and falsified:

- **"CoS on port 5211 limiting performance"** — port 5211 maps to
  forwarding-class `iperf-uncapped` in `cos-iperf-config.set`; reverse
  P=12 against `172.16.80.200:5211` with CoS active = 23.2 Gb/s. CoS
  `bandwidth-output` is an egress filter on `reth0.80` so reverse
  direction (WAN-side server → firewall ingress → LAN-side client) is
  not shaped by it on any port.
- **"WAN ge-0-0-0 is virtio_net in xdpgeneric"** — on the loss
  userspace cluster, `ge-0-0-0` is the fab0 IPVLAN parent (cluster
  fabric, not WAN). WAN is `ge-0-0-2` on `mlx5_core` in native `xdp`
  mode. Verified via `ip -d link show` + `ethtool -i` on each
  interface on `loss:xpf-userspace-fw0`.
- **"per-class iperf3 fleet 5202-5206 not provisioned"** — true for
  `172.16.100.200` (where `nc -z` was probing), false for
  `172.16.80.200`: all 11 per-class iperf3 listeners (5201-5211) are
  live. Pass B 24-cell matrix is fully exercisable on the canonical
  target.

## Test plan

- [x] env file syntax OK (`bash -n` + sourced; `IPERF_TARGET4` /
      `IPERF_TARGET6` resolve to `172.16.80.200` /
      `2001:559:8585:80::200`)
- [x] Pass A CoS-off canonical target: v4 push P=12 23.4 Gb/s, v4 rev
      P=12 23.1 Gb/s, v6 rev P=12 22.8 Gb/s — all 0 retr (single-stream
      P=1: 7.74 / 8.29 Gb/s push/rev, 0 retr)
- [x] Pass B CoS-on per-port reverse P=12 sweep: ports 5201-5211 all
      reach 19-23 Gb/s on `172.16.80.200`
- [x] Pure config + doc change; no Rust / Go build impact

## Files changed

- `test/incus/loss-userspace-cluster.env` — repoint
  `IPERF_TARGET4/6` to VLAN-80 canonical target + explanatory comment
  on the 172.16.100.x inheritance hazard
- `CLAUDE.md` — add HA cluster topology block (loss userspace) next
  to the existing standalone-VM block; document `ge-0-0-2 = WAN`,
  `ge-0-0-0 = fabric IPVLAN parent`, canonical smoke target
- `_Log.md` — investigation entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)