### PR TITLE
daemon: harden legacyDP canary against struct-field + selector + ident reintroduction (#1559)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4089,3 +4089,9 @@ top.
 - **Timestamp**: 2026-05-27 03:42 UTC
   - **Action**: Address Gemini code-review-round-1 MAJOR finding (synthetic tests defended a parallel copy of production canary logic instead of the SUT). Extract scanFileForLegacyDP() helper; both TestLegacyDPAccessorRemoved and the synthetic negative tests now route through it. All 8 tests pass, 5/5 flake clean, full Go suite (32 packages) green.
   - **File(s)**: pkg/daemon/legacy_dataplane_canary_test.go, pkg/daemon/legacy_dataplane_canary_synthetic_test.go
+
+## 2026-05-27 03:48 — #1559 Copilot review: align pass numbering + spelling
+
+- **Timestamp**: 2026-05-27 03:48 UTC
+  - **Action**: Address Copilot inline comments (5 numbering inconsistencies, 2 'descendent'->'descendant' spellings). Pass numbering now consistent everywhere: 1=FuncDecl, 2=StructType.Fields, 3=CallExpr, 4=SelectorExpr, 5=bare Ident. All 8 canary tests still pass, 5/5 flake clean.
+  - **File(s)**: pkg/daemon/legacy_dataplane_canary_test.go, pkg/daemon/legacy_dataplane_canary_synthetic_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -4077,3 +4077,9 @@ top.
 - **Timestamp**: 2026-05-27 03:22 UTC
   - **Action**: #1559 plan v1 drafted + pushed; Codex task-mpnhxj2g-p4047b and Gemini task-mpnhy4io-gzc7jp dispatched for adversarial plan review.
   - **File(s)**: docs/pr/1559-canary-harden/plan.md (commit c2b77ea5)
+
+## 2026-05-27 03:35 — #1559 canary harden implementation + tests passing
+
+- **Timestamp**: 2026-05-27 03:35 UTC
+  - **Action**: Implemented v3 plan: rewrote pkg/daemon/legacy_dataplane_canary_test.go with 5-pass AST scan + record-once dedup; added pkg/daemon/legacy_dataplane_canary_synthetic_test.go with 7 negative-pattern tests. All 8 canary tests pass; 5/5 flake check clean; full Go suite (32 packages) green.
+  - **File(s)**: pkg/daemon/legacy_dataplane_canary_test.go (rewritten), pkg/daemon/legacy_dataplane_canary_synthetic_test.go (new), docs/pr/1559-canary-harden/plan.md (v3)

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,55 @@
 # Action Log
 
+## 2026-05-26 — #1598 secondary fix (TX-dispatch funnel)
+- **Action**: Post-merge smoke on PR #1600 caught a SECONDARY funnel:
+  primary fix at `worker/cos/mod.rs:126-131` correctly set
+  `WorkerCoSQueueFastPath.shared_exact = true` for the non-exact
+  uncapped queue, but the TX dispatch path at
+  `userspace-dp/src/afxdp/tx/dispatch/cos.rs:54` was gating "keep
+  local vs route to owner" on `shared_queue_lease.is_some()`, an
+  exact-only marker. For the iperf-uncapped class the lease is None
+  (filtered out at `coordinator/mod.rs:1058`), so the dispatch still
+  funneled the request to a single `owner_worker_id`. Smoke showed
+  port 5211 push P=12 stable at 9.08 Gbps with 2k-3.6k retr.
+  Added `request_runs_under_shared_exact_policy` helper that gates
+  on `queue_fast.shared_exact` directly (the routing-level shared
+  flag). Switched both call sites: `enqueue_local_request_to_target_or_owner`
+  (cos.rs:54) and the in-place-rewrite gate `owner_matches_target`
+  in `dispatch/mod.rs:426`. Retained the legacy
+  `request_uses_shared_exact_queue_lease` helper — it still correctly
+  identifies queues with a per-queue rate lease, which is a
+  different question. Added test fixture
+  `test_cos_fast_interfaces_decoupled` that decouples
+  `(shared_exact, has_lease)` so all four combinations can be tested.
+  Added 3 regression tests covering (shared_exact=true, lease=None)
+  + (shared_exact=false, lease=Some) + unknown-queue safety.
+- **Tests**: 1441 cargo tests pass (+3 new); Go suite clean across
+  all packages; pre-existing `snat_contract_doc_guard` failure
+  unchanged on master.
+- **File(s)**: `userspace-dp/src/afxdp/tx/dispatch/cos.rs`,
+  `userspace-dp/src/afxdp/tx/dispatch/mod.rs`,
+  `userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs`,
+  `docs/pr/1598-cos-uncapped-fix/plan.md`, `_Log.md`.
+Entries land at the top when added. Within a topic batch (same
+issue / PR), entries run reverse-chronological (newest first).
+Across topic batches the ordering is by add-time, not strict wall
+clock, so older topic batches push down when newer work lands on
+top.
+## 2026-05-27 01:30 UTC — #1598 Copilot review addressed
+- **Timestamp**: 2026-05-27 01:30 UTC
+- **Action**: For #1598, addressed four Copilot inline comments. (1) Rewrote the function-level doc above `queue_uses_shared_exact_service` so it no longer claims non-exact queues are never shared; new doc explains that the gate is now threshold-only, and that the exact/non-exact distinction lives at the lease + V_min allocation gates (coordinator/mod.rs:1058 and :1145). (2) Replaced `feedback_cross_binding_impossible in memory` reference in the inline comment with a stable in-repo reference (PR #680/#690 + the plan doc). (3) Updated both new test fixtures to set `guarantee_enabled=false` AND `exact=false`, so the fixtures actually mirror the production uncapped-class shape (no transmit-rate at all, not just non-exact-with-rate). (4) Restored reverse-chronological log ordering and added a header note explaining the convention.
+- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `_Log.md`
+## 2026-05-26 13:25 UTC — #1598 implementation + tests pass
+- **Timestamp**: 2026-05-26 13:25 UTC
+- **Action**: Implemented plan v2. Removed the `if !queue.exact { return false; }` early return in `queue_uses_shared_exact_service` at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` so the rate-threshold check `transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES` admits non-exact queues that hit the threshold. Updated the test that previously pinned the rejection: renamed `queue_uses_shared_exact_service_rejects_non_exact_queue` → `queue_uses_shared_exact_service_admits_high_rate_non_exact_queue` + added a complementary regression test `queue_uses_shared_exact_service_keeps_low_rate_non_exact_single_owner` to lock the threshold-gated behavior. Updated doc comment at `coordinator/mod.rs:1145` to note the V_min floor filter is intentionally stricter than the routing gate. Build clean, 1438+10 cargo tests pass, Go suite clean, 5x flake check pass on `queue_uses_shared_exact_service` tests.
+- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `userspace-dp/src/afxdp/coordinator/mod.rs`
+## 2026-05-26 12:50 UTC — #1598 plan v2 (after round-1 reviewer split)
+- **Timestamp**: 2026-05-26 12:50 UTC
+- **Action**: Updated plan to v2 incorporating round-1 reviewer outcomes. Codex PLAN-KILL was infra-blocked (sandbox runner missing); AGY round-1 verdict PLAN-READY after walking the actual files. Added explicit trace of `build_worker_cos_owner_live_by_tx_ifindex` showing `tx_owner_live` is per-worker local (loop_body/mod.rs:91-95), so Step2 never funnels foreign-worker. Documented residual concern about non-binding workers (not applicable to the loss userspace cluster which has every worker bound to reth0.80 mlx5 VF). Re-dispatching Codex.
+- **File(s)**: `docs/pr/1598-cos-uncapped-fix/plan.md`
+## 2026-05-26 12:30 UTC — #1598 plan v1 (CoS iperf-uncapped caps at ~10 Gbps)
+- **Timestamp**: 2026-05-26 12:30 UTC
+- **Action**: Drafted plan v1 for #1598. Root-cause identified at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` — `queue_uses_shared_exact_service` early-returns false on `!queue.exact`, excluding the uncapped non-exact queue from sharded multi-worker drain. This forces 100% of class-11 traffic through a single `owner_worker_id` (built at `coordinator/mod.rs:900-904`), hitting the per-worker AF_XDP UMEM ceiling. The 24g/exact queue escapes this because it trips the same gate with `exact=true && rate >= 312 MB/s`.
 ## 2026-05-26 23:10 UTC — #1578 cluster perf root-cause (smoke target IP misalignment)
 - **Timestamp**: 2026-05-26 23:10 UTC
   - **Action**: Investigated the "loss userspace cluster ~9 Gb/s
@@ -3831,56 +3881,6 @@
   - AGY r2: MERGE-READY
   - Copilot r1: COMMENTED w/ 3 inline findings, all addressed in d013302748 + 0e2a88c8b
   - Codex: 3 consecutive sandbox failures (`unified-exec` blocked)
-## 2026-05-26 — #1598 secondary fix (TX-dispatch funnel)
-- **Action**: Post-merge smoke on PR #1600 caught a SECONDARY funnel:
-  primary fix at `worker/cos/mod.rs:126-131` correctly set
-  `WorkerCoSQueueFastPath.shared_exact = true` for the non-exact
-  uncapped queue, but the TX dispatch path at
-  `userspace-dp/src/afxdp/tx/dispatch/cos.rs:54` was gating "keep
-  local vs route to owner" on `shared_queue_lease.is_some()`, an
-  exact-only marker. For the iperf-uncapped class the lease is None
-  (filtered out at `coordinator/mod.rs:1058`), so the dispatch still
-  funneled the request to a single `owner_worker_id`. Smoke showed
-  port 5211 push P=12 stable at 9.08 Gbps with 2k-3.6k retr.
-  Added `request_runs_under_shared_exact_policy` helper that gates
-  on `queue_fast.shared_exact` directly (the routing-level shared
-  flag). Switched both call sites: `enqueue_local_request_to_target_or_owner`
-  (cos.rs:54) and the in-place-rewrite gate `owner_matches_target`
-  in `dispatch/mod.rs:426`. Retained the legacy
-  `request_uses_shared_exact_queue_lease` helper — it still correctly
-  identifies queues with a per-queue rate lease, which is a
-  different question. Added test fixture
-  `test_cos_fast_interfaces_decoupled` that decouples
-  `(shared_exact, has_lease)` so all four combinations can be tested.
-  Added 3 regression tests covering (shared_exact=true, lease=None)
-  + (shared_exact=false, lease=Some) + unknown-queue safety.
-- **Tests**: 1441 cargo tests pass (+3 new); Go suite clean across
-  all packages; pre-existing `snat_contract_doc_guard` failure
-  unchanged on master.
-- **File(s)**: `userspace-dp/src/afxdp/tx/dispatch/cos.rs`,
-  `userspace-dp/src/afxdp/tx/dispatch/mod.rs`,
-  `userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs`,
-  `docs/pr/1598-cos-uncapped-fix/plan.md`, `_Log.md`.
-Entries land at the top when added. Within a topic batch (same
-issue / PR), entries run reverse-chronological (newest first).
-Across topic batches the ordering is by add-time, not strict wall
-clock, so older topic batches push down when newer work lands on
-top.
-## 2026-05-27 01:30 UTC — #1598 Copilot review addressed
-- **Timestamp**: 2026-05-27 01:30 UTC
-- **Action**: For #1598, addressed four Copilot inline comments. (1) Rewrote the function-level doc above `queue_uses_shared_exact_service` so it no longer claims non-exact queues are never shared; new doc explains that the gate is now threshold-only, and that the exact/non-exact distinction lives at the lease + V_min allocation gates (coordinator/mod.rs:1058 and :1145). (2) Replaced `feedback_cross_binding_impossible in memory` reference in the inline comment with a stable in-repo reference (PR #680/#690 + the plan doc). (3) Updated both new test fixtures to set `guarantee_enabled=false` AND `exact=false`, so the fixtures actually mirror the production uncapped-class shape (no transmit-rate at all, not just non-exact-with-rate). (4) Restored reverse-chronological log ordering and added a header note explaining the convention.
-- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `_Log.md`
-## 2026-05-26 13:25 UTC — #1598 implementation + tests pass
-- **Timestamp**: 2026-05-26 13:25 UTC
-- **Action**: Implemented plan v2. Removed the `if !queue.exact { return false; }` early return in `queue_uses_shared_exact_service` at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` so the rate-threshold check `transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES` admits non-exact queues that hit the threshold. Updated the test that previously pinned the rejection: renamed `queue_uses_shared_exact_service_rejects_non_exact_queue` → `queue_uses_shared_exact_service_admits_high_rate_non_exact_queue` + added a complementary regression test `queue_uses_shared_exact_service_keeps_low_rate_non_exact_single_owner` to lock the threshold-gated behavior. Updated doc comment at `coordinator/mod.rs:1145` to note the V_min floor filter is intentionally stricter than the routing gate. Build clean, 1438+10 cargo tests pass, Go suite clean, 5x flake check pass on `queue_uses_shared_exact_service` tests.
-- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `userspace-dp/src/afxdp/coordinator/mod.rs`
-## 2026-05-26 12:50 UTC — #1598 plan v2 (after round-1 reviewer split)
-- **Timestamp**: 2026-05-26 12:50 UTC
-- **Action**: Updated plan to v2 incorporating round-1 reviewer outcomes. Codex PLAN-KILL was infra-blocked (sandbox runner missing); AGY round-1 verdict PLAN-READY after walking the actual files. Added explicit trace of `build_worker_cos_owner_live_by_tx_ifindex` showing `tx_owner_live` is per-worker local (loop_body/mod.rs:91-95), so Step2 never funnels foreign-worker. Documented residual concern about non-binding workers (not applicable to the loss userspace cluster which has every worker bound to reth0.80 mlx5 VF). Re-dispatching Codex.
-- **File(s)**: `docs/pr/1598-cos-uncapped-fix/plan.md`
-## 2026-05-26 12:30 UTC — #1598 plan v1 (CoS iperf-uncapped caps at ~10 Gbps)
-- **Timestamp**: 2026-05-26 12:30 UTC
-- **Action**: Drafted plan v1 for #1598. Root-cause identified at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` — `queue_uses_shared_exact_service` early-returns false on `!queue.exact`, excluding the uncapped non-exact queue from sharded multi-worker drain. This forces 100% of class-11 traffic through a single `owner_worker_id` (built at `coordinator/mod.rs:900-904`), hitting the per-worker AF_XDP UMEM ceiling. The 24g/exact queue escapes this because it trips the same gate with `exact=true && rate >= 312 MB/s`.
 ## 2026-05-27
 - **Timestamp**: 03:34 UTC
 - **Action**: #1563 fix — `cli -c` non-TTY segfault. Plan v1→v3
@@ -4056,32 +4056,24 @@ top.
 ## 03:17 UTC — #1565 plan v1 drafted
 - **Action**: Draft plan for pkg/api Junos→Linux ifname translation fix
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
-
 ## 03:25 UTC — #1565 plan v2 after round-1 NEEDS-MAJOR
 - **Action**: Revise plan addressing Codex+AGY findings (TunnelNameMap, DHCP key shape, helper centralization, drop CLI smoke claim)
-- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
-
 ## 03:35 UTC — #1565 plan v3 after round-2 Codex NEEDS-MAJOR
 - **Action**: Address VLAN-vs-unit conflation, IRB, tunnel collision, DHCP test mock design, smoke specificity
-- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
-
 ## 03:46 UTC — #1565 plan v4 after round-3 Codex NEEDS-MAJOR
 - **Action**: Drop ResolveFab from helper (fab0 is kernel device), add st* short-circuit, fix smoke gates to actual cfg, AGY minors (fmt import, test_seams.go, drift NOTE comments)
-- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
-
 ## 03:53 UTC — #1565 plan v5 after round-4 (Codex MAJOR, AGY MINOR)
 - **Action**: Fix fab0.0 collapse expectation, drop ge-0/0/0 from gates (not in allInterfaceNames), redesign lo test as reth0->lo synthetic, add drift-guard test, nil-guard Interfaces.Interfaces
-- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
-
 ## 03:58 UTC — #1565 plan v6 PLAN-READY
 - **Action**: Close 4 round-5 minors (stale fab text, drift-guard nil-unit + branch coverage, redundant-parent grammar, Atoi error fallback)
-- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
 - **Verdict**: Codex r5 PLAN-NEEDS-MINOR (4 minors all closed in v6); AGY r5 PLAN-READY (one drift-guard test setup note also closed in v6). Plan moves to implementation.
-
 ## 04:01 UTC — #1565 implementation complete
 - **Action**: Add (*Config).ResolveKernelIfName + DHCPLeaseKey; rewrite 4 pkg/api sites; add SeedLeaseForTesting; 12 unit + 2 handler + 1 drift-guard tests all pass 5/5; go vet clean on modified pkgs; full Go suite passes
 - **File(s)**: pkg/config/types.go, pkg/config/types_test.go, pkg/api/interfaces.go, pkg/api/stats.go, pkg/api/metrics_counters.go, pkg/api/iface_name_test.go, pkg/dhcp/test_seams.go, pkg/dataplane/userspace/interfaces.go, pkg/dataplane/userspace/interfaces_test.go, pkg/daemon/daemon_dhcp.go
-
 ## 04:13 UTC — #1565 fix Codex MERGE-NEEDS-MINOR findings
 - **Action**: gofmt clean on my files; route writeInterfacesTerse normal-iface lookup through ResolveKernelIfName (catches gr-0/0/0.0); strengthen DHCP test with decoy lease assertion
 - **File(s)**: pkg/config/types.go, pkg/config/types_test.go, pkg/dataplane/userspace/interfaces_test.go (gofmt), pkg/api/interfaces.go (terse fix), pkg/api/iface_name_test.go (decoy assertion)
+## 2026-05-27 03:22 — #1559 canary harden plan v1 dispatched
+- **Timestamp**: 2026-05-27 03:22 UTC
+  - **Action**: #1559 plan v1 drafted + pushed; Codex task-mpnhxj2g-p4047b and Gemini task-mpnhy4io-gzc7jp dispatched for adversarial plan review.
+  - **File(s)**: docs/pr/1559-canary-harden/plan.md (commit c2b77ea5)

--- a/_Log.md
+++ b/_Log.md
@@ -4083,3 +4083,9 @@ top.
 - **Timestamp**: 2026-05-27 03:35 UTC
   - **Action**: Implemented v3 plan: rewrote pkg/daemon/legacy_dataplane_canary_test.go with 5-pass AST scan + record-once dedup; added pkg/daemon/legacy_dataplane_canary_synthetic_test.go with 7 negative-pattern tests. All 8 canary tests pass; 5/5 flake check clean; full Go suite (32 packages) green.
   - **File(s)**: pkg/daemon/legacy_dataplane_canary_test.go (rewritten), pkg/daemon/legacy_dataplane_canary_synthetic_test.go (new), docs/pr/1559-canary-harden/plan.md (v3)
+
+## 2026-05-27 03:42 — #1559 round-1 code review fix: extract shared scan helper
+
+- **Timestamp**: 2026-05-27 03:42 UTC
+  - **Action**: Address Gemini code-review-round-1 MAJOR finding (synthetic tests defended a parallel copy of production canary logic instead of the SUT). Extract scanFileForLegacyDP() helper; both TestLegacyDPAccessorRemoved and the synthetic negative tests now route through it. All 8 tests pass, 5/5 flake clean, full Go suite (32 packages) green.
+  - **File(s)**: pkg/daemon/legacy_dataplane_canary_test.go, pkg/daemon/legacy_dataplane_canary_synthetic_test.go

--- a/docs/pr/1559-canary-harden/plan.md
+++ b/docs/pr/1559-canary-harden/plan.md
@@ -1,0 +1,272 @@
+# #1559 plan — harden legacy_dataplane_canary against struct-field + selector reintroduction
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+PR #1557 (capstone delete `ee4b34bf`) added
+`pkg/daemon/legacy_dataplane_canary_test.go` as a regression guard.
+The canary scans every non-test `*.go` file under `pkg/daemon` and
+fails on two AST shapes:
+
+1. `FuncDecl` named `legacyDP` whose receiver type is `*Daemon` or
+   `Daemon` (canary lines 75-90).
+2. `CallExpr` whose `Fun` is a `SelectorExpr` with `Sel.Name ==
+   "legacyDP"` (canary lines 92-110).
+
+AGY adversarial review on PR #1557 (`adversarial-review-mpm8y8a3-8cbeh2`,
+2026-05-26T06:23:17Z) identified two structural blind spots that
+shipped with #1557:
+
+- **P2 — struct-field reintroduction.** A developer can re-add
+  `legacyDP dataplane.DataPlane` as a `Daemon` struct field and then
+  consume it via `dp := d.legacyDP; dp.ReadGlobalCounter(1)`. The
+  field declaration parses as `*ast.StructType.Fields`, not
+  `*ast.FuncDecl`. The consumer reads `d.legacyDP` as a bare
+  `*ast.SelectorExpr` inside `*ast.AssignStmt` — not a `*ast.CallExpr`.
+  Both shapes bypass the current canary.
+- **P3 — false-positive surface.** The CallExpr check matches *any*
+  selector named `legacyDP` regardless of receiver type. A future
+  internal helper `type mockHelper struct{}` with a legitimate
+  `legacyDP()` method would trip the canary. Not in-tree today; worth
+  documenting OR narrowing.
+
+## Honest scope/value framing
+
+This is a test-only file (`pkg/daemon/legacy_dataplane_canary_test.go`).
+The "win" is closing two CI bypass paths against re-introduction of
+the deleted `(*Daemon).legacyDP()` accessor. No runtime impact, no
+performance impact, no API surface change. The two new AST passes
+are O(file size) and run once per `go test ./pkg/daemon` invocation.
+
+If reviewers conclude the hardening is unnecessary (e.g. the
+retirement boundary canary at `pkg/daemon/retirement_boundary_canary_test.go`
+already catches this), PLAN-KILL is an acceptable verdict.
+
+## What's already shipped / partially batched
+
+- PR #1557 (merged as `ee4b34bf`): deleted `(*Daemon).legacyDP()` and
+  added the v1 canary at `pkg/daemon/legacy_dataplane_canary_test.go`.
+- The retirement-boundary canary at
+  `pkg/daemon/retirement_boundary_canary_test.go` enforces a wider
+  package-level allowlist but is **not** focused on the `legacyDP`
+  identifier specifically.
+- The canary itself is brand new (3 days old) and has zero prior
+  authors to coordinate with.
+
+## Concrete design
+
+Extend the canary's per-file scan with two additional passes inside
+the existing `for _, entry := range entries` loop. Both passes reuse
+the same `*token.FileSet` and append to the same `offenders` slice
+for a unified failure message.
+
+### Pass 3 — struct-field reintroduction
+
+Walk every `*ast.StructType` in the file and check each field's
+identifier list. If any field has `Names[i].Name == "legacyDP"`,
+record an offender.
+
+```go
+ast.Inspect(file, func(n ast.Node) bool {
+    st, ok := n.(*ast.StructType)
+    if !ok {
+        return true
+    }
+    if st.Fields == nil {
+        return true
+    }
+    for _, field := range st.Fields.List {
+        for _, fname := range field.Names {
+            if fname == nil || fname.Name != "legacyDP" {
+                continue
+            }
+            pos := fset.Position(fname.Pos())
+            offenders = append(offenders,
+                name+":"+itoa(pos.Line)+": forbidden struct field "+
+                    "named legacyDP — removed in #1519; do not "+
+                    "re-introduce as a Daemon field. Use a typed "+
+                    "probe in runtime_probes.go instead")
+        }
+    }
+    return true
+})
+```
+
+Scope note: this fires on ANY struct field named `legacyDP` in any
+`pkg/daemon` non-test `*.go` file, not just on `Daemon` itself. That
+is intentional — the historical accessor's whole point was to leak
+a `dataplane.DataPlane`-shaped value, and the field-name canary is
+the narrowest forbidden-identifier check. If a developer wants to
+add a `legacyDP` field to a different struct in `pkg/daemon`, the
+canary will fail and they'll need to either (a) rename the field or
+(b) update the canary and document the new architectural review.
+
+### Pass 4 — SelectorExpr matching (catches bare selector reads)
+
+Walk every `*ast.SelectorExpr` (including those NOT wrapped in
+`*ast.CallExpr`) and fail on `.Sel.Name == "legacyDP"`. This catches:
+
+- Bare field read: `dp := d.legacyDP`
+- Method-value expression: `f := d.legacyDP` (when `legacyDP` is a
+  method, not a field)
+- Method-expression: `(*Daemon).legacyDP` — `*ast.SelectorExpr` with
+  ParenExpr receiver
+- Any selector chain ending in `.legacyDP` regardless of context
+
+```go
+ast.Inspect(file, func(n ast.Node) bool {
+    sel, ok := n.(*ast.SelectorExpr)
+    if !ok {
+        return true
+    }
+    if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+        return true
+    }
+    pos := fset.Position(sel.Pos())
+    offenders = append(offenders,
+        name+":"+itoa(pos.Line)+": forbidden selector .legacyDP — "+
+            "removed in #1519; do not re-introduce as a field, "+
+            "method, or accessor. Use a typed probe in "+
+            "runtime_probes.go instead")
+    return true
+})
+```
+
+Note: this pass subsumes the existing CallExpr check. The current
+CallExpr loop fires on `d.legacyDP()`; the new SelectorExpr loop
+fires on the inner `d.legacyDP` of the same expression — same line,
+same line number. To avoid double-reporting, we keep the CallExpr
+loop intact (it has a more specific, call-site-shaped message) and
+let the SelectorExpr loop ALSO fire — both emissions reference the
+same line; the unified offenders message is acceptable noise for
+the rare case where the canary actually trips.
+
+Alternative considered: replace the CallExpr loop entirely with
+just the SelectorExpr loop. Rejected because the existing call-shape
+message ("forbidden call to .legacyDP()") is more actionable for the
+common reintroduction path (a callsite that calls the accessor), and
+removing it would be a behavior change unrelated to this hardening.
+
+### Pass 3 vs Pass 4 overlap
+
+`legacyDP` field declarations don't appear as `*ast.SelectorExpr` —
+they live in `*ast.StructType.Fields`. So Pass 3 catches the
+*declaration*; Pass 4 catches the *use*. A struct-field reintroduction
+will trip both (declaration on one line, every consumer on its own
+line) — the test author will see a clear unified failure with multiple
+offender entries, all pointing at the same root cause. That's the
+right behavior: each line that needs to change is named.
+
+### P3 — receiver narrowing (deferred, documented)
+
+The plan does NOT narrow Pass 4 to a specific receiver type because
+doing so requires type information (the canary is AST-only and does
+not run `go/types`). A future internal helper struct with a
+legitimately-named `legacyDP()` method would trip the canary; the
+fix is to either rename the new method (the canary documents that
+the name is reserved within `pkg/daemon` production code), or to
+update the canary AND get architectural-review sign-off as part of
+the new feature work.
+
+Update the canary's package doc comment to explicitly state: "the
+identifier `legacyDP` is reserved within pkg/daemon production code;
+do not re-use it for any field, method, or selector regardless of
+the surrounding type."
+
+## Public API preservation
+
+None. This is a test-only file. The exported names are:
+
+- `TestLegacyDPAccessorRemoved` — preserved, same signature.
+- `receiverIsDaemon` — package-private helper, unchanged.
+- `itoa` — package-private helper, unchanged.
+
+Two new sub-passes are added inline; no new exported names.
+
+## Hidden invariants the change must preserve
+
+- **Out-of-scope comments still allowed.** The canary parses `.go`
+  files but only inspects AST nodes — `parser.ParseFile` ignores
+  comments by default (no `parser.ParseComments` flag). Plan-impl.md
+  and commit messages remain free to mention the historical
+  `legacyDP` symbol. **Verify:** `parser.AllErrors` is the only flag
+  used; comments are not loaded.
+- **_test.go files excluded.** The existing loop skips `_test.go`
+  files. Both new passes run inside the same loop and inherit this
+  filter — tests can still reference `legacyDP` in their own files
+  (and indeed this test file references it in string literals for
+  failure messages, which is fine because string literals are
+  `*ast.BasicLit` not `*ast.SelectorExpr` / `*ast.StructType.Fields`).
+- **No `go/types` dependency.** Pure AST scan; the canary remains
+  fast and self-contained.
+- **Unified failure message.** All offenders aggregate into the same
+  `offenders` slice and are emitted by a single `t.Fatalf` at the
+  end. Both new passes feed the same slice.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression risk | **LOW** | Test-only file; no production code touched. |
+| Lifetime / borrow-checker risk | **N/A** | Go, not Rust. |
+| Performance regression risk | **LOW** | Two added `ast.Inspect` walks per file; pkg/daemon has ~20-30 files; runs once per `go test`. |
+| Architectural mismatch risk | **LOW** | This is the AGY-recommended fix, applied directly. The only architectural question is whether the broader retirement-boundary canary already covers this — see "Open questions" below. |
+| False-positive risk on developer onboarding | **MED** | If a developer adds an unrelated `legacyDP` identifier in `pkg/daemon`, they get a clear failure pointing at this canary. The canary's doc comment names the constraint explicitly. |
+
+## Test plan
+
+The canary itself is the test. To validate the hardening:
+
+1. **Build and run the canary clean:** confirm `go test ./pkg/daemon -run TestLegacyDPAccessorRemoved` passes on the current master baseline.
+2. **Negative tests via temp file:** add a small `legacy_dataplane_canary_synthetic_test.go` (or extend the existing file) that loads synthetic Go source via `parser.ParseFile` against a fake fset, walks it with the new passes wrapped in callable helpers, and asserts:
+   - Struct with `legacyDP` field → offender count > 0
+   - Function body with `d.legacyDP` (bare selector, no call) → offender count > 0
+   - Function body with `d.legacyDP()` (call) → offender count > 0 (existing behavior preserved)
+   - File with `legacyDP` in a comment or string literal → offender count == 0
+3. **Run the canary against the current tree:** must pass cleanly (the deleted accessor is gone; no production code references it).
+4. **Sanity:** `go test ./pkg/daemon ./...` to confirm no incidental breakage.
+
+Smoke testing on `loss:xpf-userspace-fw0/fw1` is NOT required for
+this PR — it's a test-only change in `pkg/daemon` that does not
+affect deployed dataplane behavior. AGY/Codex/Gemini sign-off plus
+Go test suite is the full gate.
+
+## Out of scope (explicitly)
+
+- **Receiver-narrowed Pass 4** (P3 fix). Requires `go/types`, deferred
+  with a docstring instead. Captured as a future tightening if a
+  legitimate helper hits the reserved-identifier wall.
+- **Wider package coverage.** This canary only inspects `pkg/daemon`.
+  Other packages don't need their own `legacyDP` canary because the
+  identifier never existed outside `pkg/daemon`.
+- **String-literal / comment scanning.** Intentionally allowed — see
+  "Hidden invariants" above.
+- **Adding `legacyDP` to a reserved-identifiers DB / lint rule.**
+  Overkill for one identifier; the AST canary is the right shape.
+
+## Open questions for adversarial review
+
+1. **Does `retirement_boundary_canary_test.go` already catch this?**
+   If yes, this PR is redundant and PLAN-KILL is correct. (Initial
+   reading of #1557 suggests no — the boundary canary is package-
+   allowlist-shaped, not identifier-name-shaped — but reviewers
+   should confirm.)
+2. **Is the false-positive risk on Pass 3/4 acceptable?** A pkg/daemon
+   developer who wants to name a *different* field/method `legacyDP`
+   will be blocked. Is reserving the identifier across the whole
+   package the right scope?
+3. **Should Pass 4 also fire on `legacyDP` as a non-selector identifier**
+   (e.g. a local var named `legacyDP`, a const named `legacyDP`)?
+   The current proposal does not — only selector and struct-field
+   shapes. Reviewers: is that the right scope, or should the canary
+   reserve the bare identifier entirely?
+4. **Should the synthetic negative tests live in this same file** or
+   in a new `legacy_dataplane_canary_synthetic_test.go`? Coloc keeps
+   the canary self-documenting; separate file keeps the production
+   canary file shorter. Either is fine.
+5. **Is keeping the existing CallExpr loop alongside the new
+   SelectorExpr loop the right call**, or should Pass 4 replace it
+   entirely? Keeping both gives two messages on a single offending
+   call site; removing the CallExpr loop loses the "this is a call"
+   actionable hint. Reviewers: pick one.

--- a/docs/pr/1559-canary-harden/plan.md
+++ b/docs/pr/1559-canary-harden/plan.md
@@ -1,6 +1,6 @@
 # #1559 plan — harden legacy_dataplane_canary against struct-field + selector reintroduction
 
-**Status:** DRAFT v2 — addresses Codex + Gemini PLAN-NEEDS-MINOR (round 1)
+**Status:** DRAFT v3 — addresses Codex round-2 PLAN-NEEDS-MINOR (position tokens + Pass-4 noise wording)
 
 ## Issue framing
 
@@ -89,7 +89,10 @@ for _, decl := range file.Decls {
     }
     // Receiver shape no longer narrows — Daemon method,
     // package-level function, or any other shape is forbidden.
-    pos := fset.Position(fd.Pos())
+    // Record at fd.Name.Pos() (not fd.Pos()) so multiline function
+    // declarations land the offender on the identifier's line, not
+    // the opening `func` keyword. Pairs with Pass 5's ident.Pos().
+    pos := fset.Position(fd.Name.Pos())
     msg := "forbidden function/method declaration named legacyDP — " +
         "removed in #1519, see plan-impl.md. The identifier is " +
         "reserved within pkg/daemon production code."
@@ -107,46 +110,16 @@ is `*ast.Ident` (no selector) needs to be caught by walking
 `legacyDP`, local var assignments `legacyDP := ...`, and any other
 bare identifier use.
 
-```go
-ast.Inspect(file, func(n ast.Node) bool {
-    ident, ok := n.(*ast.Ident)
-    if !ok {
-        return true
-    }
-    if ident.Name != "legacyDP" {
-        return true
-    }
-    // Skip occurrences inside SelectorExpr.Sel — those are caught
-    // by Pass 4 with a more specific selector-shaped message.
-    // We don't have parent-pointer info inside ast.Inspect's
-    // callback, so we instead suppress this pass when the parent
-    // is a SelectorExpr by checking inside the SelectorExpr walk
-    // and adding a sentinel — but that's overkill. Simpler:
-    // accept the duplicate offender entries (one from Pass 4 for
-    // the selector, one from Pass 5 for the bare ident embedded
-    // in the selector). The canary is already in fail-state when
-    // either fires; duplicate offenders just make the diagnostic
-    // louder.
-    pos := fset.Position(ident.Pos())
-    offenders = append(offenders,
-        name+":"+itoa(pos.Line)+": forbidden identifier legacyDP — "+
-            "removed in #1519; the name is reserved within pkg/daemon "+
-            "production code (no field, method, function, selector, "+
-            "or bare identifier may use it)")
-    return true
-})
-```
-
-Wait — `ast.Inspect` walks every node, including the `Sel` of every
-`SelectorExpr` and the `Name` of every `FuncDecl`. That means Pass 5
-will fire on the SAME identifier node that Pass 1's `fd.Name` and
-Pass 4's `sel.Sel` are checking. Duplicate offender entries on
-every match. That's not the fail mode we want — a single struct-field
+Because `ast.Inspect` walks every node — including the `Sel` of
+every `SelectorExpr`, the `Name` of every `FuncDecl`, and the `Names`
+of every `*ast.Field` — Pass 5 will fire on the SAME identifier node
+that Pass 1's `fd.Name`, Pass 3's field `Names[i]`, and Pass 4's
+`sel.Sel` are also checking. Without dedup, a single struct-field
 reintroduction would emit ~3-5 offenders for the same line.
 
-Better approach: keep a `set` of `(file, line)` already-recorded and
-only append an offender when not present. Implement as a
-`map[string]bool` keyed on `name + ":" + itoa(line)`:
+Solution: a record-once dedup keyed on `(file, line)`. First pass
+to record wins; later passes on the same line are suppressed. Pass
+order is chosen so the most specific diagnostic survives.
 
 ```go
 recorded := make(map[string]bool)
@@ -160,10 +133,33 @@ record := func(pos token.Position, msg string) {
 }
 ```
 
-Each pass calls `record(...)` instead of appending directly. First
-hit wins; later passes on the same line are suppressed. The order of
-passes determines which message survives — keep the most specific
-message first (FuncDecl > StructType.Field > SelectorExpr/CallExpr >
+Each pass calls `record(...)` instead of appending directly. With
+dedup in place, Pass 5 becomes:
+
+```go
+ast.Inspect(file, func(n ast.Node) bool {
+    ident, ok := n.(*ast.Ident)
+    if !ok {
+        return true
+    }
+    if ident.Name != "legacyDP" {
+        return true
+    }
+    // Pass 5 is the catch-all. Earlier passes (1, 3, 2, 4) record
+    // their more specific diagnostics first; this pass only writes
+    // when the (file, line) hasn't been recorded yet, e.g. a bare
+    // callsite `legacyDP(d)` whose Fun is *ast.Ident (no SelectorExpr).
+    pos := fset.Position(ident.Pos())
+    record(pos, "forbidden identifier legacyDP — removed in #1519; "+
+        "the name is reserved within pkg/daemon production code "+
+        "(no field, method, function, selector, or bare identifier "+
+        "may use it)")
+    return true
+})
+```
+
+Pass ordering invariants: most specific first
+(FuncDecl > StructType.Field > CallExpr > SelectorExpr >
 bare Ident).
 
 ### Pass 3 — struct-field reintroduction
@@ -219,6 +215,13 @@ reintroduction takes the call-shape (most common path). With the
 record-once deduplication in place, this fires first for any callsite
 and suppresses the SelectorExpr/Ident duplicates on the same line.
 
+Update Pass 2 to record at `sel.Sel.Pos()` (not `call.Pos()`) so the
+recorded line matches Pass 4 and Pass 5 for the multiline
+`d.\n  legacyDP()` case. Pairs with the record-once dedup so the same
+line that Pass 2 catches via the CallExpr is also the line Pass 4
+would have used for the selector and Pass 5 would have used for the
+bare ident.
+
 ### Pass 4 — SelectorExpr matching (catches bare selector reads)
 
 Walk every `*ast.SelectorExpr` (including those NOT wrapped in
@@ -240,7 +243,11 @@ ast.Inspect(file, func(n ast.Node) bool {
     if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
         return true
     }
-    pos := fset.Position(sel.Pos())
+    // Record at sel.Sel.Pos() (not sel.Pos()) so multiline
+    // `d.\n  legacyDP` lands on the identifier's line, which
+    // matches the line Pass 5 would record. Pairs with the
+    // record-once dedup.
+    pos := fset.Position(sel.Sel.Pos())
     record(pos, "forbidden selector .legacyDP — removed in #1519; "+
         "do not re-introduce as a field, method, or accessor. "+
         "Use a typed probe in runtime_probes.go instead")
@@ -248,14 +255,15 @@ ast.Inspect(file, func(n ast.Node) bool {
 })
 ```
 
-Note: this pass subsumes the existing CallExpr check. The current
-CallExpr loop fires on `d.legacyDP()`; the new SelectorExpr loop
-fires on the inner `d.legacyDP` of the same expression — same line,
-same line number. To avoid double-reporting, we keep the CallExpr
-loop intact (it has a more specific, call-site-shaped message) and
-let the SelectorExpr loop ALSO fire — both emissions reference the
-same line; the unified offenders message is acceptable noise for
-the rare case where the canary actually trips.
+Note: this pass overlaps with the existing CallExpr check. The
+existing CallExpr loop fires on `d.legacyDP()`; the new SelectorExpr
+loop fires on the inner `d.legacyDP` of the same expression. Both
+record at `sel.Sel.Pos()` (same identifier token, same line). With
+the record-once dedup in place, Pass 2 (CallExpr) runs BEFORE Pass 4
+(SelectorExpr), so Pass 2's call-shaped diagnostic wins the
+`(file, line)` slot and Pass 4 is suppressed for that line. Pass 4
+still fires on its own when the offender is a bare selector read
+(no CallExpr wrap), which is the new shape it exists to catch.
 
 Alternative considered: replace the CallExpr loop entirely with
 just the SelectorExpr loop. Rejected because the existing call-shape
@@ -268,10 +276,12 @@ removing it would be a behavior change unrelated to this hardening.
 `legacyDP` field declarations don't appear as `*ast.SelectorExpr` —
 they live in `*ast.StructType.Fields`. So Pass 3 catches the
 *declaration*; Pass 4 catches the *use*. A struct-field reintroduction
-will trip both (declaration on one line, every consumer on its own
-line) — the test author will see a clear unified failure with multiple
-offender entries, all pointing at the same root cause. That's the
-right behavior: each line that needs to change is named.
+trips Pass 3 on the declaration line and Pass 4 on each consumer
+line. With record-once dedup the diagnostic on the declaration line
+is the StructType message (Pass 3 wins; Pass 5 is suppressed for that
+same line because `ast.Inspect` reaches the field's `*ast.Ident` and
+calls `record` for it AFTER Pass 3 has already inserted the key).
+Consumer lines get the SelectorExpr message from Pass 4.
 
 ### Pass execution order (record-once)
 

--- a/docs/pr/1559-canary-harden/plan.md
+++ b/docs/pr/1559-canary-harden/plan.md
@@ -40,7 +40,7 @@ performance impact, no API surface change. The two new AST passes
 are O(file size) and run once per `go test ./pkg/daemon` invocation.
 
 If reviewers conclude the hardening is unnecessary (e.g. the
-retirement boundary canary at `pkg/daemon/retirement_boundary_canary_test.go`
+retirement boundary canary at `pkg/dataplane/retirement_boundary_canary_test.go`
 already catches this), PLAN-KILL is an acceptable verdict.
 
 ## What's already shipped / partially batched

--- a/docs/pr/1559-canary-harden/plan.md
+++ b/docs/pr/1559-canary-harden/plan.md
@@ -1,6 +1,6 @@
 # #1559 plan — harden legacy_dataplane_canary against struct-field + selector reintroduction
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — addresses Codex + Gemini PLAN-NEEDS-MINOR (round 1)
 
 ## Issue framing
 
@@ -48,9 +48,12 @@ already catches this), PLAN-KILL is an acceptable verdict.
 - PR #1557 (merged as `ee4b34bf`): deleted `(*Daemon).legacyDP()` and
   added the v1 canary at `pkg/daemon/legacy_dataplane_canary_test.go`.
 - The retirement-boundary canary at
-  `pkg/daemon/retirement_boundary_canary_test.go` enforces a wider
-  package-level allowlist but is **not** focused on the `legacyDP`
-  identifier specifically.
+  `pkg/dataplane/retirement_boundary_canary_test.go` enforces a wider
+  package-level import allowlist (and asserts only that `Daemon.dp`
+  remains `dataplane.RuntimeDataPlane`) but is **not** focused on the
+  `legacyDP` identifier specifically. Confirmed by Codex round-1:
+  it would not catch adding a sibling `legacyDP dataplane.DataPlane`
+  field, nor a bare `d.legacyDP` selector read.
 - The canary itself is brand new (3 days old) and has zero prior
   authors to coordinate with.
 
@@ -60,6 +63,108 @@ Extend the canary's per-file scan with two additional passes inside
 the existing `for _, entry := range entries` loop. Both passes reuse
 the same `*token.FileSet` and append to the same `offenders` slice
 for a unified failure message.
+
+### Pass 1 (tightened) — FuncDecl name match, receiver-agnostic
+
+Round-1 Gemini caught a critical bypass: the existing Pass 1 checks
+`receiverIsDaemon(fd.Recv)` and returns false when `fd.Recv` is nil
+(canary.go line 83 — `if recv == nil || len(recv.List) != 1`). A
+package-level `func legacyDP(d *Daemon) dataplane.DataPlane { ... }`
+is a `*ast.FuncDecl` with nil receiver and bypasses Pass 1 entirely.
+The consumer `legacyDP(d)` parses as `*ast.CallExpr` whose `Fun` is
+`*ast.Ident` (not `*ast.SelectorExpr`) — bypasses both the existing
+Pass 2 and the new Pass 4.
+
+Tighten Pass 1 to forbid ANY `FuncDecl` named `legacyDP`, regardless
+of receiver shape:
+
+```go
+for _, decl := range file.Decls {
+    fd, ok := decl.(*ast.FuncDecl)
+    if !ok {
+        continue
+    }
+    if fd.Name == nil || fd.Name.Name != "legacyDP" {
+        continue
+    }
+    // Receiver shape no longer narrows — Daemon method,
+    // package-level function, or any other shape is forbidden.
+    pos := fset.Position(fd.Pos())
+    msg := "forbidden function/method declaration named legacyDP — " +
+        "removed in #1519, see plan-impl.md. The identifier is " +
+        "reserved within pkg/daemon production code."
+    offenders = append(offenders, name+":"+itoa(pos.Line)+": "+msg)
+}
+```
+
+The `receiverIsDaemon` helper becomes dead code. Delete it.
+
+### Pass 5 — bare *ast.Ident name match
+
+Close the consumer-side bypass: a callsite `legacyDP(d)` whose `Fun`
+is `*ast.Ident` (no selector) needs to be caught by walking
+`*ast.Ident` directly. Also catches: package-level var/const named
+`legacyDP`, local var assignments `legacyDP := ...`, and any other
+bare identifier use.
+
+```go
+ast.Inspect(file, func(n ast.Node) bool {
+    ident, ok := n.(*ast.Ident)
+    if !ok {
+        return true
+    }
+    if ident.Name != "legacyDP" {
+        return true
+    }
+    // Skip occurrences inside SelectorExpr.Sel — those are caught
+    // by Pass 4 with a more specific selector-shaped message.
+    // We don't have parent-pointer info inside ast.Inspect's
+    // callback, so we instead suppress this pass when the parent
+    // is a SelectorExpr by checking inside the SelectorExpr walk
+    // and adding a sentinel — but that's overkill. Simpler:
+    // accept the duplicate offender entries (one from Pass 4 for
+    // the selector, one from Pass 5 for the bare ident embedded
+    // in the selector). The canary is already in fail-state when
+    // either fires; duplicate offenders just make the diagnostic
+    // louder.
+    pos := fset.Position(ident.Pos())
+    offenders = append(offenders,
+        name+":"+itoa(pos.Line)+": forbidden identifier legacyDP — "+
+            "removed in #1519; the name is reserved within pkg/daemon "+
+            "production code (no field, method, function, selector, "+
+            "or bare identifier may use it)")
+    return true
+})
+```
+
+Wait — `ast.Inspect` walks every node, including the `Sel` of every
+`SelectorExpr` and the `Name` of every `FuncDecl`. That means Pass 5
+will fire on the SAME identifier node that Pass 1's `fd.Name` and
+Pass 4's `sel.Sel` are checking. Duplicate offender entries on
+every match. That's not the fail mode we want — a single struct-field
+reintroduction would emit ~3-5 offenders for the same line.
+
+Better approach: keep a `set` of `(file, line)` already-recorded and
+only append an offender when not present. Implement as a
+`map[string]bool` keyed on `name + ":" + itoa(line)`:
+
+```go
+recorded := make(map[string]bool)
+record := func(pos token.Position, msg string) {
+    key := name + ":" + itoa(pos.Line)
+    if recorded[key] {
+        return
+    }
+    recorded[key] = true
+    offenders = append(offenders, key+": "+msg)
+}
+```
+
+Each pass calls `record(...)` instead of appending directly. First
+hit wins; later passes on the same line are suppressed. The order of
+passes determines which message survives — keep the most specific
+message first (FuncDecl > StructType.Field > SelectorExpr/CallExpr >
+bare Ident).
 
 ### Pass 3 — struct-field reintroduction
 
@@ -82,11 +187,15 @@ ast.Inspect(file, func(n ast.Node) bool {
                 continue
             }
             pos := fset.Position(fname.Pos())
-            offenders = append(offenders,
-                name+":"+itoa(pos.Line)+": forbidden struct field "+
-                    "named legacyDP — removed in #1519; do not "+
-                    "re-introduce as a Daemon field. Use a typed "+
-                    "probe in runtime_probes.go instead")
+            // Message intentionally does NOT say "as a Daemon
+            // field" — Pass 3 walks every StructType, not just
+            // the Daemon struct, so a developer naming an
+            // unrelated struct's field legacyDP would otherwise
+            // get a misleading diagnostic (Codex round-1 finding).
+            record(pos, "forbidden struct field named legacyDP — "+
+                "removed in #1519; the identifier is reserved "+
+                "within pkg/daemon production code. Use a typed "+
+                "probe in runtime_probes.go instead")
         }
     }
     return true
@@ -101,6 +210,14 @@ the narrowest forbidden-identifier check. If a developer wants to
 add a `legacyDP` field to a different struct in `pkg/daemon`, the
 canary will fail and they'll need to either (a) rename the field or
 (b) update the canary and document the new architectural review.
+
+### Pass 2 (preserved) — CallExpr match
+
+The existing CallExpr loop (canary lines 92-110) is kept. It produces
+a more actionable "forbidden call to .legacyDP()" diagnostic when the
+reintroduction takes the call-shape (most common path). With the
+record-once deduplication in place, this fires first for any callsite
+and suppresses the SelectorExpr/Ident duplicates on the same line.
 
 ### Pass 4 — SelectorExpr matching (catches bare selector reads)
 
@@ -124,11 +241,9 @@ ast.Inspect(file, func(n ast.Node) bool {
         return true
     }
     pos := fset.Position(sel.Pos())
-    offenders = append(offenders,
-        name+":"+itoa(pos.Line)+": forbidden selector .legacyDP — "+
-            "removed in #1519; do not re-introduce as a field, "+
-            "method, or accessor. Use a typed probe in "+
-            "runtime_probes.go instead")
+    record(pos, "forbidden selector .legacyDP — removed in #1519; "+
+        "do not re-introduce as a field, method, or accessor. "+
+        "Use a typed probe in runtime_probes.go instead")
     return true
 })
 ```
@@ -158,6 +273,20 @@ line) — the test author will see a clear unified failure with multiple
 offender entries, all pointing at the same root cause. That's the
 right behavior: each line that needs to change is named.
 
+### Pass execution order (record-once)
+
+1. Pass 1 — FuncDecl name match (any receiver shape, incl. nil)
+2. Pass 3 — StructType.Fields name match
+3. Pass 2 — CallExpr selector name match
+4. Pass 4 — SelectorExpr name match (bare selector reads)
+5. Pass 5 — bare *ast.Ident name match (catches `legacyDP(d)` call
+   target, var decls, type names — anything not already recorded)
+
+First match per (file, line) wins; later passes suppressed. Any
+single reintroduction will fire at least one offender; complex
+multi-line reintroductions (decl + multiple consumers) will fire
+one offender per affected line.
+
 ### P3 — receiver narrowing (deferred, documented)
 
 The plan does NOT narrow Pass 4 to a specific receiver type because
@@ -170,16 +299,18 @@ update the canary AND get architectural-review sign-off as part of
 the new feature work.
 
 Update the canary's package doc comment to explicitly state: "the
-identifier `legacyDP` is reserved within pkg/daemon production code;
-do not re-use it for any field, method, or selector regardless of
-the surrounding type."
+identifier `legacyDP` is reserved within pkg/daemon production code
+(non-test `*.go` files only). The canary will fail on any field,
+method, function, selector, or bare identifier using this name,
+regardless of surrounding type or receiver." This wording matches
+the actual five-pass coverage (Codex round-1 finding 5).
 
 ## Public API preservation
 
 None. This is a test-only file. The exported names are:
 
 - `TestLegacyDPAccessorRemoved` — preserved, same signature.
-- `receiverIsDaemon` — package-private helper, unchanged.
+- `receiverIsDaemon` — DELETED (Pass 1 no longer narrows on receiver).
 - `itoa` — package-private helper, unchanged.
 
 Two new sub-passes are added inline; no new exported names.
@@ -220,10 +351,14 @@ The canary itself is the test. To validate the hardening:
 
 1. **Build and run the canary clean:** confirm `go test ./pkg/daemon -run TestLegacyDPAccessorRemoved` passes on the current master baseline.
 2. **Negative tests via temp file:** add a small `legacy_dataplane_canary_synthetic_test.go` (or extend the existing file) that loads synthetic Go source via `parser.ParseFile` against a fake fset, walks it with the new passes wrapped in callable helpers, and asserts:
-   - Struct with `legacyDP` field → offender count > 0
-   - Function body with `d.legacyDP` (bare selector, no call) → offender count > 0
-   - Function body with `d.legacyDP()` (call) → offender count > 0 (existing behavior preserved)
-   - File with `legacyDP` in a comment or string literal → offender count == 0
+   - Struct with `legacyDP` field → offenders contains at least one entry naming the field's line
+   - Function body with `d.legacyDP` (bare selector, no call) → at least one entry on the selector's line
+   - Function body with `d.legacyDP()` (call) → at least one entry on the call's line (existing behavior preserved)
+   - **Package-level `func legacyDP(d *Daemon) X` declaration** → at least one entry on the FuncDecl's line (closes v1 bypass)
+   - **Bare `legacyDP(d)` callsite** → at least one entry on the callsite's line (closes v1 bypass)
+   - File with `legacyDP` in a comment or string literal → offenders empty
+
+   Tests assert "at least one entry naming the expected line", NOT exact offender counts. Pass overlap + record-once mean the surviving entry per line depends on pass order; the contract the canary documents is "any reintroduction line is named at least once", not "exactly N times". (Codex round-1 finding 4.)
 3. **Run the canary against the current tree:** must pass cleanly (the deleted accessor is gone; no production code references it).
 4. **Sanity:** `go test ./pkg/daemon ./...` to confirm no incidental breakage.
 
@@ -235,8 +370,10 @@ Go test suite is the full gate.
 ## Out of scope (explicitly)
 
 - **Receiver-narrowed Pass 4** (P3 fix). Requires `go/types`, deferred
-  with a docstring instead. Captured as a future tightening if a
-  legitimate helper hits the reserved-identifier wall.
+  with a docstring instead. The identifier is now reserved across
+  ALL of pkg/daemon production code (Pass 5 closes the bypass that
+  v1 left open); a legitimate future helper hitting the wall must
+  either rename or update the canary + architectural review.
 - **Wider package coverage.** This canary only inspects `pkg/daemon`.
   Other packages don't need their own `legacyDP` canary because the
   identifier never existed outside `pkg/daemon`.
@@ -256,11 +393,11 @@ Go test suite is the full gate.
    developer who wants to name a *different* field/method `legacyDP`
    will be blocked. Is reserving the identifier across the whole
    package the right scope?
-3. **Should Pass 4 also fire on `legacyDP` as a non-selector identifier**
-   (e.g. a local var named `legacyDP`, a const named `legacyDP`)?
-   The current proposal does not — only selector and struct-field
-   shapes. Reviewers: is that the right scope, or should the canary
-   reserve the bare identifier entirely?
+3. **[RESOLVED v2]** Pass 5 added in v2 to walk bare `*ast.Ident`
+   tokens. Closes the Gemini round-1 critical bypass: package-level
+   `func legacyDP(d *Daemon)` + callsite `legacyDP(d)` would
+   otherwise sneak past every previous pass. The identifier is now
+   reserved across all pkg/daemon production-code AST surfaces.
 4. **Should the synthetic negative tests live in this same file** or
    in a new `legacy_dataplane_canary_synthetic_test.go`? Coloc keeps
    the canary self-documenting; separate file keeps the production

--- a/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
@@ -1,117 +1,34 @@
 package daemon
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"strings"
 	"testing"
 )
 
-// scanSynthetic mirrors TestLegacyDPAccessorRemoved's 5-pass scan
-// against an in-memory Go source string and returns the offender
-// list. Keeps the canary's contract testable without writing
-// disposable files to pkg/daemon — synthetic Go that intentionally
-// reintroduces `legacyDP` must NOT be picked up by the real
-// canary's directory scan, which is why the synthetic tests parse
-// from a fixed name ("synthetic.go") that doesn't exist on disk.
+// scanSyntheticSource parses an in-memory Go source string and
+// runs the SAME 5-pass scan as TestLegacyDPAccessorRemoved by
+// calling the shared scanFileForLegacyDP helper. Gemini's #1559
+// code-review-round-1 MAJOR finding flagged the earlier draft of
+// this file for duplicating the production canary's logic into a
+// parallel copy — fixed by routing both call sites through
+// scanFileForLegacyDP. Any change to the production canary's
+// scan is exercised by these synthetic negative-pattern tests.
 //
-// The function intentionally does not share code with the
-// production canary — duplication is the point. If the canary's
-// scan ever diverges from this scanner, the synthetic tests will
-// silently miss the divergence. The synthetic tests therefore
-// assert behavior the canary doc comment promises (which line gets
-// recorded, no false positives on comments/strings), not the
-// implementation shape.
-func scanSynthetic(t *testing.T, src string) []string {
+// The fake filename "synthetic.go" never matches anything on disk,
+// so the production canary's directory walk does not see this
+// source. It also doesn't end in _test.go, but that's fine — the
+// _test.go suffix filter applies to real files in pkg/daemon, not
+// to ad-hoc strings passed to the shared helper.
+func scanSyntheticSource(t *testing.T, src string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "synthetic.go", src, parser.AllErrors)
 	if err != nil {
 		t.Fatalf("parse synthetic: %v", err)
 	}
-	var offenders []string
-	recorded := make(map[string]bool)
-	record := func(pos token.Position, msg string) {
-		key := "synthetic.go:" + itoa(pos.Line)
-		if recorded[key] {
-			return
-		}
-		recorded[key] = true
-		offenders = append(offenders, key+": "+msg)
-	}
-
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if fd.Name == nil || fd.Name.Name != "legacyDP" {
-			continue
-		}
-		record(fset.Position(fd.Name.Pos()), "FuncDecl")
-	}
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		st, ok := n.(*ast.StructType)
-		if !ok {
-			return true
-		}
-		if st.Fields == nil {
-			return true
-		}
-		for _, field := range st.Fields.List {
-			for _, fname := range field.Names {
-				if fname == nil || fname.Name != "legacyDP" {
-					continue
-				}
-				record(fset.Position(fname.Pos()), "StructField")
-			}
-		}
-		return true
-	})
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
-			return true
-		}
-		record(fset.Position(sel.Sel.Pos()), "CallExpr")
-		return true
-	})
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		sel, ok := n.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
-			return true
-		}
-		record(fset.Position(sel.Sel.Pos()), "SelectorExpr")
-		return true
-	})
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		ident, ok := n.(*ast.Ident)
-		if !ok {
-			return true
-		}
-		if ident.Name != "legacyDP" {
-			return true
-		}
-		record(fset.Position(ident.Pos()), "Ident")
-		return true
-	})
-
-	return offenders
+	return scanFileForLegacyDP(fset, file, "synthetic.go")
 }
 
 // hasOffenderOnLine returns true if the offender list contains an
@@ -136,7 +53,7 @@ type Daemon struct {
 	legacyDP fakeDataPlane
 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Line 4 is the field declaration `legacyDP fakeDataPlane`.
 	if !hasOffenderOnLine(offenders, 4) {
 		t.Fatalf("expected struct-field reintroduction on line 4 to "+
@@ -155,7 +72,7 @@ func ExampleRead(d *Daemon) {
 	_ = dp
 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Line 4 is the bare selector read `dp := d.legacyDP`.
 	if !hasOffenderOnLine(offenders, 4) {
 		t.Fatalf("expected bare selector read on line 4 to trip "+
@@ -164,7 +81,7 @@ func ExampleRead(d *Daemon) {
 }
 
 // TestCanarySyntheticCallSitePreserved — existing v1 behavior.
-// `d.legacyDP()` must still trip Pass 2 / Pass 4.
+// `d.legacyDP()` must still trip Pass 2.
 func TestCanarySyntheticCallSitePreserved(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
@@ -176,7 +93,7 @@ func ExampleCall(d *Daemon) {
 	d.legacyDP().Probe()
 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Line 5 is the FuncDecl `func (d *Daemon) legacyDP() *fakeDP`.
 	// Line 7 is the callsite `d.legacyDP().Probe()`.
 	if !hasOffenderOnLine(offenders, 5) {
@@ -189,16 +106,16 @@ func ExampleCall(d *Daemon) {
 	}
 }
 
-// TestCanarySyntheticPackageLevelFuncDecl — Gemini #1559 round-1
-// critical finding. A package-level `func legacyDP(d *Daemon)`
-// must trip the receiver-agnostic Pass 1.
+// TestCanarySyntheticPackageLevelFuncDecl — Gemini #1559
+// plan-round-1 critical finding. A package-level `func legacyDP(d
+// *Daemon)` must trip the receiver-agnostic Pass 1.
 func TestCanarySyntheticPackageLevelFuncDecl(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
 type Daemon struct{}
 func legacyDP(d *Daemon) int { return 0 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Line 3 is the package-level `func legacyDP(d *Daemon)`.
 	if !hasOffenderOnLine(offenders, 3) {
 		t.Fatalf("expected package-level FuncDecl on line 3 to trip "+
@@ -206,9 +123,9 @@ func legacyDP(d *Daemon) int { return 0 }
 	}
 }
 
-// TestCanarySyntheticBareIdentCallsite — Gemini #1559 round-1
-// critical finding. `legacyDP(d)` whose Fun is *ast.Ident (no
-// SelectorExpr) must trip Pass 5.
+// TestCanarySyntheticBareIdentCallsite — Gemini #1559
+// plan-round-1 critical finding. `legacyDP(d)` whose Fun is
+// *ast.Ident (no SelectorExpr) must trip Pass 5.
 func TestCanarySyntheticBareIdentCallsite(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
@@ -218,7 +135,7 @@ func Caller(d *Daemon) {
 	_ = legacyDP(d)
 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Line 3 trips Pass 1 (FuncDecl).
 	// Line 5 is the bare callsite `_ = legacyDP(d)`.
 	if !hasOffenderOnLine(offenders, 3) {
@@ -243,7 +160,7 @@ func TestCanarySyntheticCommentsAndStringsSafe(t *testing.T) {
 /* d.legacyDP block-comment mention */
 var docString = "legacyDP referenced in a string literal"
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	if len(offenders) != 0 {
 		t.Fatalf("expected zero offenders for comments + string "+
 			"literals; got %v", offenders)
@@ -252,8 +169,9 @@ var docString = "legacyDP referenced in a string literal"
 
 // TestCanarySyntheticDedupOneOffenderPerLine — record-once
 // invariant. A struct field declared on one line and read on a
-// different line emits ONE offender per line (not 3+), because
-// the (file, line) dedup map suppresses the multi-pass overlap.
+// different line emits exactly ONE offender per line (not 3+),
+// because the (file, line) dedup map suppresses the multi-pass
+// overlap.
 func TestCanarySyntheticDedupOneOffenderPerLine(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
@@ -264,7 +182,7 @@ func Reader(d *Daemon) int {
 	return d.legacyDP
 }
 `
-	offenders := scanSynthetic(t, src)
+	offenders := scanSyntheticSource(t, src)
 	// Expect 2 offenders total: line 3 (struct field) and line 6
 	// (selector read). Multi-pass overlap on each line is collapsed
 	// to one by the record-once dedup.

--- a/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
@@ -44,7 +44,8 @@ func hasOffenderOnLine(offenders []string, line int) bool {
 }
 
 // TestCanarySyntheticStructFieldReintroduction — AGY P2 / #1559.
-// A sibling field on Daemon named legacyDP must trip Pass 3.
+// A sibling field on Daemon named legacyDP must trip Pass 2
+// (StructType.Fields).
 func TestCanarySyntheticStructFieldReintroduction(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
@@ -81,7 +82,7 @@ func ExampleRead(d *Daemon) {
 }
 
 // TestCanarySyntheticCallSitePreserved — existing v1 behavior.
-// `d.legacyDP()` must still trip Pass 2.
+// `d.legacyDP()` must still trip Pass 3 (CallExpr).
 func TestCanarySyntheticCallSitePreserved(t *testing.T) {
 	t.Parallel()
 	src := `package daemon
@@ -152,7 +153,7 @@ func Caller(d *Daemon) {
 // `legacyDP` in comments and string literals must NOT trip the
 // canary, because parser.ParseFile without parser.ParseComments
 // drops *ast.Comment nodes and string literals are *ast.BasicLit
-// (whose Value field is a Go string, not descendent ast.Ident).
+// (whose Value field is a Go string, not descendant ast.Ident).
 func TestCanarySyntheticCommentsAndStringsSafe(t *testing.T) {
 	t.Parallel()
 	src := `package daemon

--- a/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_synthetic_test.go
@@ -1,0 +1,283 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// scanSynthetic mirrors TestLegacyDPAccessorRemoved's 5-pass scan
+// against an in-memory Go source string and returns the offender
+// list. Keeps the canary's contract testable without writing
+// disposable files to pkg/daemon — synthetic Go that intentionally
+// reintroduces `legacyDP` must NOT be picked up by the real
+// canary's directory scan, which is why the synthetic tests parse
+// from a fixed name ("synthetic.go") that doesn't exist on disk.
+//
+// The function intentionally does not share code with the
+// production canary — duplication is the point. If the canary's
+// scan ever diverges from this scanner, the synthetic tests will
+// silently miss the divergence. The synthetic tests therefore
+// assert behavior the canary doc comment promises (which line gets
+// recorded, no false positives on comments/strings), not the
+// implementation shape.
+func scanSynthetic(t *testing.T, src string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic.go", src, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse synthetic: %v", err)
+	}
+	var offenders []string
+	recorded := make(map[string]bool)
+	record := func(pos token.Position, msg string) {
+		key := "synthetic.go:" + itoa(pos.Line)
+		if recorded[key] {
+			return
+		}
+		recorded[key] = true
+		offenders = append(offenders, key+": "+msg)
+	}
+
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name == nil || fd.Name.Name != "legacyDP" {
+			continue
+		}
+		record(fset.Position(fd.Name.Pos()), "FuncDecl")
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		st, ok := n.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		if st.Fields == nil {
+			return true
+		}
+		for _, field := range st.Fields.List {
+			for _, fname := range field.Names {
+				if fname == nil || fname.Name != "legacyDP" {
+					continue
+				}
+				record(fset.Position(fname.Pos()), "StructField")
+			}
+		}
+		return true
+	})
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+			return true
+		}
+		record(fset.Position(sel.Sel.Pos()), "CallExpr")
+		return true
+	})
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+			return true
+		}
+		record(fset.Position(sel.Sel.Pos()), "SelectorExpr")
+		return true
+	})
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name != "legacyDP" {
+			return true
+		}
+		record(fset.Position(ident.Pos()), "Ident")
+		return true
+	})
+
+	return offenders
+}
+
+// hasOffenderOnLine returns true if the offender list contains an
+// entry that starts with "synthetic.go:<line>:".
+func hasOffenderOnLine(offenders []string, line int) bool {
+	prefix := "synthetic.go:" + itoa(line) + ":"
+	for _, o := range offenders {
+		if strings.HasPrefix(o, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCanarySyntheticStructFieldReintroduction — AGY P2 / #1559.
+// A sibling field on Daemon named legacyDP must trip Pass 3.
+func TestCanarySyntheticStructFieldReintroduction(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type fakeDataPlane interface{}
+type Daemon struct {
+	legacyDP fakeDataPlane
+}
+`
+	offenders := scanSynthetic(t, src)
+	// Line 4 is the field declaration `legacyDP fakeDataPlane`.
+	if !hasOffenderOnLine(offenders, 4) {
+		t.Fatalf("expected struct-field reintroduction on line 4 to "+
+			"trip canary; got offenders=%v", offenders)
+	}
+}
+
+// TestCanarySyntheticBareSelectorRead — AGY P2 / #1559.
+// `dp := d.legacyDP` (no call) must trip Pass 4.
+func TestCanarySyntheticBareSelectorRead(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type Daemon struct{ legacyDP int }
+func ExampleRead(d *Daemon) {
+	dp := d.legacyDP
+	_ = dp
+}
+`
+	offenders := scanSynthetic(t, src)
+	// Line 4 is the bare selector read `dp := d.legacyDP`.
+	if !hasOffenderOnLine(offenders, 4) {
+		t.Fatalf("expected bare selector read on line 4 to trip "+
+			"canary; got offenders=%v", offenders)
+	}
+}
+
+// TestCanarySyntheticCallSitePreserved — existing v1 behavior.
+// `d.legacyDP()` must still trip Pass 2 / Pass 4.
+func TestCanarySyntheticCallSitePreserved(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type fakeDP struct{}
+func (f *fakeDP) Probe() {}
+type Daemon struct{}
+func (d *Daemon) legacyDP() *fakeDP { return nil }
+func ExampleCall(d *Daemon) {
+	d.legacyDP().Probe()
+}
+`
+	offenders := scanSynthetic(t, src)
+	// Line 5 is the FuncDecl `func (d *Daemon) legacyDP() *fakeDP`.
+	// Line 7 is the callsite `d.legacyDP().Probe()`.
+	if !hasOffenderOnLine(offenders, 5) {
+		t.Fatalf("expected FuncDecl on line 5 to trip canary; got "+
+			"offenders=%v", offenders)
+	}
+	if !hasOffenderOnLine(offenders, 7) {
+		t.Fatalf("expected callsite on line 7 to trip canary; got "+
+			"offenders=%v", offenders)
+	}
+}
+
+// TestCanarySyntheticPackageLevelFuncDecl — Gemini #1559 round-1
+// critical finding. A package-level `func legacyDP(d *Daemon)`
+// must trip the receiver-agnostic Pass 1.
+func TestCanarySyntheticPackageLevelFuncDecl(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type Daemon struct{}
+func legacyDP(d *Daemon) int { return 0 }
+`
+	offenders := scanSynthetic(t, src)
+	// Line 3 is the package-level `func legacyDP(d *Daemon)`.
+	if !hasOffenderOnLine(offenders, 3) {
+		t.Fatalf("expected package-level FuncDecl on line 3 to trip "+
+			"canary; got offenders=%v", offenders)
+	}
+}
+
+// TestCanarySyntheticBareIdentCallsite — Gemini #1559 round-1
+// critical finding. `legacyDP(d)` whose Fun is *ast.Ident (no
+// SelectorExpr) must trip Pass 5.
+func TestCanarySyntheticBareIdentCallsite(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type Daemon struct{}
+func legacyDP(d *Daemon) int { return 0 }
+func Caller(d *Daemon) {
+	_ = legacyDP(d)
+}
+`
+	offenders := scanSynthetic(t, src)
+	// Line 3 trips Pass 1 (FuncDecl).
+	// Line 5 is the bare callsite `_ = legacyDP(d)`.
+	if !hasOffenderOnLine(offenders, 3) {
+		t.Fatalf("expected FuncDecl on line 3 to trip canary; got "+
+			"offenders=%v", offenders)
+	}
+	if !hasOffenderOnLine(offenders, 5) {
+		t.Fatalf("expected bare ident callsite on line 5 to trip "+
+			"canary; got offenders=%v", offenders)
+	}
+}
+
+// TestCanarySyntheticCommentsAndStringsSafe — invariant from #1557.
+// `legacyDP` in comments and string literals must NOT trip the
+// canary, because parser.ParseFile without parser.ParseComments
+// drops *ast.Comment nodes and string literals are *ast.BasicLit
+// (whose Value field is a Go string, not descendent ast.Ident).
+func TestCanarySyntheticCommentsAndStringsSafe(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+// legacyDP() was deleted in #1519 (this is a comment).
+/* d.legacyDP block-comment mention */
+var docString = "legacyDP referenced in a string literal"
+`
+	offenders := scanSynthetic(t, src)
+	if len(offenders) != 0 {
+		t.Fatalf("expected zero offenders for comments + string "+
+			"literals; got %v", offenders)
+	}
+}
+
+// TestCanarySyntheticDedupOneOffenderPerLine — record-once
+// invariant. A struct field declared on one line and read on a
+// different line emits ONE offender per line (not 3+), because
+// the (file, line) dedup map suppresses the multi-pass overlap.
+func TestCanarySyntheticDedupOneOffenderPerLine(t *testing.T) {
+	t.Parallel()
+	src := `package daemon
+type Daemon struct {
+	legacyDP int
+}
+func Reader(d *Daemon) int {
+	return d.legacyDP
+}
+`
+	offenders := scanSynthetic(t, src)
+	// Expect 2 offenders total: line 3 (struct field) and line 6
+	// (selector read). Multi-pass overlap on each line is collapsed
+	// to one by the record-once dedup.
+	if len(offenders) != 2 {
+		t.Fatalf("expected exactly 2 offenders (one per affected "+
+			"line); got %d: %v", len(offenders), offenders)
+	}
+	if !hasOffenderOnLine(offenders, 3) {
+		t.Fatalf("expected field-decl offender on line 3; got %v",
+			offenders)
+	}
+	if !hasOffenderOnLine(offenders, 6) {
+		t.Fatalf("expected selector-read offender on line 6; got %v",
+			offenders)
+	}
+}

--- a/pkg/daemon/legacy_dataplane_canary_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_test.go
@@ -66,11 +66,11 @@ func scanFileForLegacyDP(fset *token.FileSet, file *ast.File, displayName string
 			"production code.")
 	}
 
-	// Pass 3 — StructType.Fields name match. Catches a sibling
+	// Pass 2 — StructType.Fields name match. Catches a sibling
 	// `legacyDP T` field reintroduction on any struct in the file
 	// (not just Daemon — naming an unrelated struct's field
 	// legacyDP is also blocked; the diagnostic does NOT claim
-	// "Daemon field" because Pass 3 is struct-agnostic).
+	// "Daemon field" because Pass 2 is struct-agnostic).
 	ast.Inspect(file, func(n ast.Node) bool {
 		st, ok := n.(*ast.StructType)
 		if !ok {
@@ -95,7 +95,7 @@ func scanFileForLegacyDP(fset *token.FileSet, file *ast.File, displayName string
 		return true
 	})
 
-	// Pass 2 — CallExpr selector match. Existing v1 shape,
+	// Pass 3 — CallExpr selector match. Existing v1 shape,
 	// preserved for its more actionable "forbidden call to
 	// .legacyDP()" diagnostic. Record at sel.Sel.Pos() so the
 	// line aligns with Pass 4 and Pass 5 for multiline
@@ -142,7 +142,7 @@ func scanFileForLegacyDP(fset *token.FileSet, file *ast.File, displayName string
 	// Pass 5 — bare *ast.Ident name match. Catch-all for any
 	// `legacyDP` token not already named by Pass 1-4. Closes
 	// the package-level callsite bypass: `legacyDP(d)` has
-	// Fun=*ast.Ident, not *ast.SelectorExpr, so Pass 2 and
+	// Fun=*ast.Ident, not *ast.SelectorExpr, so Pass 3 and
 	// Pass 4 do not see it. ast.Inspect walks FuncDecl.Name,
 	// Field.Names, and SelectorExpr.Sel as ast.Ident, so Pass 5
 	// would otherwise duplicate the other passes — record-once
@@ -193,7 +193,7 @@ func scanFileForLegacyDP(fset *token.FileSet, file *ast.File, displayName string
 // parser.ParseComments, so the AST does not include *ast.Comment
 // nodes; mentions of legacyDP in // ... or /* ... */ blocks are
 // invisible to this canary. String literals are *ast.BasicLit
-// whose Value is a string, not descendent *ast.Ident — so string
+// whose Value is a string, not descendant *ast.Ident — so string
 // literals mentioning legacyDP are also safe.
 //
 // Out of scope:

--- a/pkg/daemon/legacy_dataplane_canary_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_test.go
@@ -10,31 +10,166 @@ import (
 	"testing"
 )
 
+// scanFileForLegacyDP performs the 5-pass AST scan that the
+// legacyDP canary contract documents. It is shared between the
+// production directory-walker test (TestLegacyDPAccessorRemoved)
+// and the synthetic negative-pattern tests in
+// legacy_dataplane_canary_synthetic_test.go, so any change to the
+// scan logic is exercised by both call sites — the synthetic tests
+// genuinely defend the production canary instead of a parallel
+// copy of it (Gemini #1559 code-review-round-1 finding).
+//
+// Passes (most-specific first; record-once dedup keyed on
+// (displayName, line) selects the surviving diagnostic):
+//
+//  1. *ast.FuncDecl named legacyDP (any receiver shape).
+//  2. *ast.StructType.Fields with Names[i] == "legacyDP".
+//  3. *ast.CallExpr whose Fun is *ast.SelectorExpr with Sel.Name
+//     == "legacyDP".
+//  4. *ast.SelectorExpr with Sel.Name == "legacyDP" (bare reads).
+//  5. *ast.Ident with Name == "legacyDP" (catch-all for
+//     `legacyDP(d)` callsites whose Fun is *ast.Ident).
+//
+// displayName is the prefix used in offender strings (typically the
+// scanned filename). The scan never recurses outside the supplied
+// *ast.File.
+func scanFileForLegacyDP(fset *token.FileSet, file *ast.File, displayName string) []string {
+	var offenders []string
+	recorded := make(map[string]bool)
+	record := func(pos token.Position, msg string) {
+		key := displayName + ":" + itoa(pos.Line)
+		if recorded[key] {
+			return
+		}
+		recorded[key] = true
+		offenders = append(offenders, key+": "+msg)
+	}
+
+	// Pass 1 — FuncDecl name match (receiver-agnostic).
+	// Closes the package-level `func legacyDP(d *Daemon)` bypass
+	// (Gemini #1559 plan-round-1). Record at fd.Name.Pos() so
+	// multiline func declarations land on the identifier line, not
+	// the `func` keyword (Codex #1559 plan-round-2).
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name == nil || fd.Name.Name != "legacyDP" {
+			continue
+		}
+		pos := fset.Position(fd.Name.Pos())
+		record(pos, "forbidden function/method declaration named "+
+			"legacyDP — removed in #1519, see "+
+			"docs/pr/1519-daemon-legacydp-shrink/plan-impl.md. "+
+			"The identifier is reserved within pkg/daemon "+
+			"production code.")
+	}
+
+	// Pass 3 — StructType.Fields name match. Catches a sibling
+	// `legacyDP T` field reintroduction on any struct in the file
+	// (not just Daemon — naming an unrelated struct's field
+	// legacyDP is also blocked; the diagnostic does NOT claim
+	// "Daemon field" because Pass 3 is struct-agnostic).
+	ast.Inspect(file, func(n ast.Node) bool {
+		st, ok := n.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		if st.Fields == nil {
+			return true
+		}
+		for _, field := range st.Fields.List {
+			for _, fname := range field.Names {
+				if fname == nil || fname.Name != "legacyDP" {
+					continue
+				}
+				pos := fset.Position(fname.Pos())
+				record(pos, "forbidden struct field named "+
+					"legacyDP — removed in #1519; the "+
+					"identifier is reserved within pkg/daemon "+
+					"production code. Use a typed probe in "+
+					"runtime_probes.go instead.")
+			}
+		}
+		return true
+	})
+
+	// Pass 2 — CallExpr selector match. Existing v1 shape,
+	// preserved for its more actionable "forbidden call to
+	// .legacyDP()" diagnostic. Record at sel.Sel.Pos() so the
+	// line aligns with Pass 4 and Pass 5 for multiline
+	// d.\n  legacyDP() forms.
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+			return true
+		}
+		pos := fset.Position(sel.Sel.Pos())
+		record(pos, "forbidden call to .legacyDP() — removed "+
+			"in #1519; use a daemon-local typed probe from "+
+			"runtime_probes.go instead.")
+		return true
+	})
+
+	// Pass 4 — SelectorExpr name match. Catches bare reads
+	// `dp := d.legacyDP`, method-values `f := d.legacyDP`, and
+	// any other SelectorExpr ending in .legacyDP that is not
+	// wrapped in a CallExpr.
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+			return true
+		}
+		pos := fset.Position(sel.Sel.Pos())
+		record(pos, "forbidden selector .legacyDP — removed "+
+			"in #1519; do not re-introduce as a field, "+
+			"method, or accessor. Use a typed probe in "+
+			"runtime_probes.go instead.")
+		return true
+	})
+
+	// Pass 5 — bare *ast.Ident name match. Catch-all for any
+	// `legacyDP` token not already named by Pass 1-4. Closes
+	// the package-level callsite bypass: `legacyDP(d)` has
+	// Fun=*ast.Ident, not *ast.SelectorExpr, so Pass 2 and
+	// Pass 4 do not see it. ast.Inspect walks FuncDecl.Name,
+	// Field.Names, and SelectorExpr.Sel as ast.Ident, so Pass 5
+	// would otherwise duplicate the other passes — record-once
+	// dedup suppresses those duplicates.
+	ast.Inspect(file, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name != "legacyDP" {
+			return true
+		}
+		pos := fset.Position(ident.Pos())
+		record(pos, "forbidden identifier legacyDP — removed "+
+			"in #1519; the name is reserved within pkg/daemon "+
+			"production code (no field, method, function, "+
+			"selector, or bare identifier may use it).")
+		return true
+	})
+
+	return offenders
+}
+
 // TestLegacyDPAccessorRemoved is the #1519 (sub-#1451 S4)
 // regression-guard canary: it scans every non-test .go file in
 // pkg/daemon and fails if the identifier `legacyDP` reappears in
-// ANY of these AST surfaces:
-//
-//  1. *ast.FuncDecl named legacyDP (any receiver shape — Daemon
-//     method, package-level function, or any other).
-//  2. *ast.StructType.Fields.Names[i] == "legacyDP" (struct field
-//     reintroduction, e.g. a sibling field on Daemon).
-//  3. *ast.CallExpr whose Fun is *ast.SelectorExpr with Sel.Name ==
-//     "legacyDP" (call-shaped reintroduction, e.g. d.legacyDP()).
-//  4. *ast.SelectorExpr with Sel.Name == "legacyDP" not wrapped in
-//     a CallExpr (bare selector read, e.g. `dp := d.legacyDP`).
-//  5. *ast.Ident with Name == "legacyDP" (catch-all for package-
-//     level function callsites `legacyDP(d)`, local var decls,
-//     and any other bare-identifier usage).
-//
-// Passes share a record-once dedup keyed on (file, line); the
-// first pass to record a given line wins, so each reintroduction
-// line emits exactly one offender with the most specific diagnostic
-// available. The pass execution order is chosen so the most
-// specific message survives:
-//
-//	Pass 1 (FuncDecl) > Pass 3 (StructType.Field) > Pass 2 (CallExpr)
-//	> Pass 4 (SelectorExpr) > Pass 5 (bare Ident).
+// any of the AST surfaces documented on scanFileForLegacyDP.
 //
 // The pre-#1519 daemon used (*Daemon).legacyDP() as an escape
 // hatch that re-exposed the full BPF-shaped dataplane.DataPlane to
@@ -97,135 +232,7 @@ func TestLegacyDPAccessorRemoved(t *testing.T) {
 			t.Fatalf("parse %s: %v", name, err)
 		}
 
-		// record-once dedup: first pass to write a given (file, line)
-		// wins; later passes on the same line are suppressed.
-		recorded := make(map[string]bool)
-		record := func(pos token.Position, msg string) {
-			key := name + ":" + itoa(pos.Line)
-			if recorded[key] {
-				return
-			}
-			recorded[key] = true
-			offenders = append(offenders, key+": "+msg)
-		}
-
-		// Pass 1 — FuncDecl name match (receiver-agnostic).
-		// Closes the package-level `func legacyDP(d *Daemon)` bypass
-		// (Gemini #1559 round-1). Record at fd.Name.Pos() so multiline
-		// func declarations land on the identifier line, not the `func`
-		// keyword (Codex #1559 round-2).
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok {
-				continue
-			}
-			if fd.Name == nil || fd.Name.Name != "legacyDP" {
-				continue
-			}
-			pos := fset.Position(fd.Name.Pos())
-			record(pos, "forbidden function/method declaration named "+
-				"legacyDP — removed in #1519, see "+
-				"docs/pr/1519-daemon-legacydp-shrink/plan-impl.md. "+
-				"The identifier is reserved within pkg/daemon "+
-				"production code.")
-		}
-
-		// Pass 3 — StructType.Fields name match. Catches a sibling
-		// `legacyDP T` field reintroduction on any struct in the file
-		// (not just Daemon — naming an unrelated struct's field
-		// legacyDP is also blocked, by design; the diagnostic does
-		// NOT claim "Daemon field" because Pass 3 is struct-agnostic).
-		ast.Inspect(file, func(n ast.Node) bool {
-			st, ok := n.(*ast.StructType)
-			if !ok {
-				return true
-			}
-			if st.Fields == nil {
-				return true
-			}
-			for _, field := range st.Fields.List {
-				for _, fname := range field.Names {
-					if fname == nil || fname.Name != "legacyDP" {
-						continue
-					}
-					pos := fset.Position(fname.Pos())
-					record(pos, "forbidden struct field named "+
-						"legacyDP — removed in #1519; the "+
-						"identifier is reserved within pkg/daemon "+
-						"production code. Use a typed probe in "+
-						"runtime_probes.go instead.")
-				}
-			}
-			return true
-		})
-
-		// Pass 2 — CallExpr selector match. Existing v1 shape,
-		// preserved for its more actionable "forbidden call to
-		// .legacyDP()" diagnostic. Record at sel.Sel.Pos() so the
-		// line aligns with Pass 4 and Pass 5 for multiline
-		// d.\n  legacyDP() forms.
-		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
-				return true
-			}
-			pos := fset.Position(sel.Sel.Pos())
-			record(pos, "forbidden call to .legacyDP() — removed "+
-				"in #1519; use a daemon-local typed probe from "+
-				"runtime_probes.go instead.")
-			return true
-		})
-
-		// Pass 4 — SelectorExpr name match. Catches bare reads
-		// `dp := d.legacyDP`, method-values `f := d.legacyDP`, and
-		// any other SelectorExpr ending in .legacyDP that is not
-		// wrapped in a CallExpr.
-		ast.Inspect(file, func(n ast.Node) bool {
-			sel, ok := n.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
-				return true
-			}
-			pos := fset.Position(sel.Sel.Pos())
-			record(pos, "forbidden selector .legacyDP — removed "+
-				"in #1519; do not re-introduce as a field, "+
-				"method, or accessor. Use a typed probe in "+
-				"runtime_probes.go instead.")
-			return true
-		})
-
-		// Pass 5 — bare *ast.Ident name match. Catch-all for any
-		// `legacyDP` token not already named by Pass 1-4. Closes
-		// the package-level callsite bypass: `legacyDP(d)` has
-		// Fun=*ast.Ident, not *ast.SelectorExpr, so Pass 2 and
-		// Pass 4 do not see it. ast.Inspect walks FuncDecl.Name,
-		// Field.Names, and SelectorExpr.Sel as ast.Ident, so Pass 5
-		// would otherwise duplicate the other passes — record-once
-		// dedup suppresses those duplicates.
-		ast.Inspect(file, func(n ast.Node) bool {
-			ident, ok := n.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			if ident.Name != "legacyDP" {
-				return true
-			}
-			pos := fset.Position(ident.Pos())
-			record(pos, "forbidden identifier legacyDP — removed "+
-				"in #1519; the name is reserved within pkg/daemon "+
-				"production code (no field, method, function, "+
-				"selector, or bare identifier may use it).")
-			return true
-		})
+		offenders = append(offenders, scanFileForLegacyDP(fset, file, name)...)
 	}
 
 	if len(offenders) > 0 {

--- a/pkg/daemon/legacy_dataplane_canary_test.go
+++ b/pkg/daemon/legacy_dataplane_canary_test.go
@@ -12,37 +12,62 @@ import (
 
 // TestLegacyDPAccessorRemoved is the #1519 (sub-#1451 S4)
 // regression-guard canary: it scans every non-test .go file in
-// pkg/daemon and fails if a method declaration with name
-// legacyDP and receiver *Daemon reappears, OR if any call
-// expression of the form receiver.legacyDP() reappears.
+// pkg/daemon and fails if the identifier `legacyDP` reappears in
+// ANY of these AST surfaces:
+//
+//  1. *ast.FuncDecl named legacyDP (any receiver shape — Daemon
+//     method, package-level function, or any other).
+//  2. *ast.StructType.Fields.Names[i] == "legacyDP" (struct field
+//     reintroduction, e.g. a sibling field on Daemon).
+//  3. *ast.CallExpr whose Fun is *ast.SelectorExpr with Sel.Name ==
+//     "legacyDP" (call-shaped reintroduction, e.g. d.legacyDP()).
+//  4. *ast.SelectorExpr with Sel.Name == "legacyDP" not wrapped in
+//     a CallExpr (bare selector read, e.g. `dp := d.legacyDP`).
+//  5. *ast.Ident with Name == "legacyDP" (catch-all for package-
+//     level function callsites `legacyDP(d)`, local var decls,
+//     and any other bare-identifier usage).
+//
+// Passes share a record-once dedup keyed on (file, line); the
+// first pass to record a given line wins, so each reintroduction
+// line emits exactly one offender with the most specific diagnostic
+// available. The pass execution order is chosen so the most
+// specific message survives:
+//
+//	Pass 1 (FuncDecl) > Pass 3 (StructType.Field) > Pass 2 (CallExpr)
+//	> Pass 4 (SelectorExpr) > Pass 5 (bare Ident).
 //
 // The pre-#1519 daemon used (*Daemon).legacyDP() as an escape
-// hatch that re-exposed the full BPF-shaped dataplane.DataPlane
-// to internal callers; the capstone PR migrated every consumer
-// to a narrow typed probe (runtime_probes.go) and deleted the
-// accessor. This canary keeps a quiet "I'll just add it back"
-// refactor from undoing the boundary work.
+// hatch that re-exposed the full BPF-shaped dataplane.DataPlane to
+// internal callers; the capstone PR migrated every consumer to a
+// narrow typed probe (runtime_probes.go) and deleted the accessor.
+// AGY adversarial review on PR #1557 (adversarial-review-mpm8y8a3-
+// 8cbeh2, 2026-05-26) identified two structural bypasses in the v1
+// canary — struct-field reintroduction and bare-selector reads.
+// Codex+Gemini round-1 of #1559 additionally surfaced the package-
+// level FuncDecl + bare-Ident-callsite bypass. The 5-pass canary
+// closes all four.
 //
-// Comments are NOT scanned. The pre-#1519 audit and migration
-// notes in plan-impl.md / commit messages explicitly mention
-// the historical legacyDP() symbol; only AST occurrences in
-// real Go code are forbidden.
+// The identifier `legacyDP` is reserved within pkg/daemon
+// production code (non-test *.go files only). The canary will fail
+// on any field, method, function, selector, or bare identifier
+// using this name, regardless of surrounding type or receiver. A
+// future architectural review wanting to re-use the name must
+// update this canary as part of that review.
 //
-// Scope:
-//   - FuncDecl named "legacyDP" with receiver type *Daemon (any
-//     other method name is fine; the canary doesn't gate against
-//     adding a different escape hatch — that's a separate
-//     architectural review).
-//   - CallExpr where the SelectorExpr.Sel.Name == "legacyDP"
-//     (catches d.legacyDP(), x.daemon.legacyDP(), and any other
-//     receiver chain that ends in a call to .legacyDP).
+// Comments are NOT scanned. parser.ParseFile is called without
+// parser.ParseComments, so the AST does not include *ast.Comment
+// nodes; mentions of legacyDP in // ... or /* ... */ blocks are
+// invisible to this canary. String literals are *ast.BasicLit
+// whose Value is a string, not descendent *ast.Ident — so string
+// literals mentioning legacyDP are also safe.
 //
 // Out of scope:
-//   - Comments / docstrings / string literals (no false positives
-//     for plan-impl.md or audit references in *.go file
-//     comments).
 //   - _test.go files (tests may legitimately want to reference
 //     the symbol for documentation or to assert non-existence).
+//   - Cross-package: this canary only inspects pkg/daemon/*.go.
+//     The retirement-boundary canary at
+//     pkg/dataplane/retirement_boundary_canary_test.go handles the
+//     wider package-allowlist boundary.
 //
 // If a future #1451 phase or follow-up legitimately needs to
 // reintroduce a legacy escape hatch, update this canary together
@@ -72,6 +97,23 @@ func TestLegacyDPAccessorRemoved(t *testing.T) {
 			t.Fatalf("parse %s: %v", name, err)
 		}
 
+		// record-once dedup: first pass to write a given (file, line)
+		// wins; later passes on the same line are suppressed.
+		recorded := make(map[string]bool)
+		record := func(pos token.Position, msg string) {
+			key := name + ":" + itoa(pos.Line)
+			if recorded[key] {
+				return
+			}
+			recorded[key] = true
+			offenders = append(offenders, key+": "+msg)
+		}
+
+		// Pass 1 — FuncDecl name match (receiver-agnostic).
+		// Closes the package-level `func legacyDP(d *Daemon)` bypass
+		// (Gemini #1559 round-1). Record at fd.Name.Pos() so multiline
+		// func declarations land on the identifier line, not the `func`
+		// keyword (Codex #1559 round-2).
 		for _, decl := range file.Decls {
 			fd, ok := decl.(*ast.FuncDecl)
 			if !ok {
@@ -80,15 +122,48 @@ func TestLegacyDPAccessorRemoved(t *testing.T) {
 			if fd.Name == nil || fd.Name.Name != "legacyDP" {
 				continue
 			}
-			if !receiverIsDaemon(fd.Recv) {
-				continue
-			}
-			pos := fset.Position(fd.Pos())
-			offenders = append(offenders,
-				name+":"+itoa(pos.Line)+": forbidden method declaration "+
-					"(*Daemon).legacyDP — removed in #1519, see plan-impl.md")
+			pos := fset.Position(fd.Name.Pos())
+			record(pos, "forbidden function/method declaration named "+
+				"legacyDP — removed in #1519, see "+
+				"docs/pr/1519-daemon-legacydp-shrink/plan-impl.md. "+
+				"The identifier is reserved within pkg/daemon "+
+				"production code.")
 		}
 
+		// Pass 3 — StructType.Fields name match. Catches a sibling
+		// `legacyDP T` field reintroduction on any struct in the file
+		// (not just Daemon — naming an unrelated struct's field
+		// legacyDP is also blocked, by design; the diagnostic does
+		// NOT claim "Daemon field" because Pass 3 is struct-agnostic).
+		ast.Inspect(file, func(n ast.Node) bool {
+			st, ok := n.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			if st.Fields == nil {
+				return true
+			}
+			for _, field := range st.Fields.List {
+				for _, fname := range field.Names {
+					if fname == nil || fname.Name != "legacyDP" {
+						continue
+					}
+					pos := fset.Position(fname.Pos())
+					record(pos, "forbidden struct field named "+
+						"legacyDP — removed in #1519; the "+
+						"identifier is reserved within pkg/daemon "+
+						"production code. Use a typed probe in "+
+						"runtime_probes.go instead.")
+				}
+			}
+			return true
+		})
+
+		// Pass 2 — CallExpr selector match. Existing v1 shape,
+		// preserved for its more actionable "forbidden call to
+		// .legacyDP()" diagnostic. Record at sel.Sel.Pos() so the
+		// line aligns with Pass 4 and Pass 5 for multiline
+		// d.\n  legacyDP() forms.
 		ast.Inspect(file, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
@@ -101,37 +176,65 @@ func TestLegacyDPAccessorRemoved(t *testing.T) {
 			if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
 				return true
 			}
-			pos := fset.Position(call.Pos())
-			offenders = append(offenders,
-				name+":"+itoa(pos.Line)+": forbidden call to .legacyDP() — "+
-					"removed in #1519; use a daemon-local typed probe from "+
-					"runtime_probes.go instead")
+			pos := fset.Position(sel.Sel.Pos())
+			record(pos, "forbidden call to .legacyDP() — removed "+
+				"in #1519; use a daemon-local typed probe from "+
+				"runtime_probes.go instead.")
+			return true
+		})
+
+		// Pass 4 — SelectorExpr name match. Catches bare reads
+		// `dp := d.legacyDP`, method-values `f := d.legacyDP`, and
+		// any other SelectorExpr ending in .legacyDP that is not
+		// wrapped in a CallExpr.
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if sel.Sel == nil || sel.Sel.Name != "legacyDP" {
+				return true
+			}
+			pos := fset.Position(sel.Sel.Pos())
+			record(pos, "forbidden selector .legacyDP — removed "+
+				"in #1519; do not re-introduce as a field, "+
+				"method, or accessor. Use a typed probe in "+
+				"runtime_probes.go instead.")
+			return true
+		})
+
+		// Pass 5 — bare *ast.Ident name match. Catch-all for any
+		// `legacyDP` token not already named by Pass 1-4. Closes
+		// the package-level callsite bypass: `legacyDP(d)` has
+		// Fun=*ast.Ident, not *ast.SelectorExpr, so Pass 2 and
+		// Pass 4 do not see it. ast.Inspect walks FuncDecl.Name,
+		// Field.Names, and SelectorExpr.Sel as ast.Ident, so Pass 5
+		// would otherwise duplicate the other passes — record-once
+		// dedup suppresses those duplicates.
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name != "legacyDP" {
+				return true
+			}
+			pos := fset.Position(ident.Pos())
+			record(pos, "forbidden identifier legacyDP — removed "+
+				"in #1519; the name is reserved within pkg/daemon "+
+				"production code (no field, method, function, "+
+				"selector, or bare identifier may use it).")
 			return true
 		})
 	}
 
 	if len(offenders) > 0 {
-		t.Fatalf("legacyDP() reintroduced in pkg/daemon production code:\n  %s\n"+
+		t.Fatalf("legacyDP reintroduced in pkg/daemon production code:\n  %s\n"+
 			"this symbol was removed in #1519 (sub-#1451 S4); see "+
 			"docs/pr/1519-daemon-legacydp-shrink/plan-impl.md for the "+
 			"migration matrix and rationale",
 			strings.Join(offenders, "\n  "))
 	}
-}
-
-func receiverIsDaemon(recv *ast.FieldList) bool {
-	if recv == nil || len(recv.List) != 1 {
-		return false
-	}
-	expr := recv.List[0].Type
-	star, ok := expr.(*ast.StarExpr)
-	if !ok {
-		// Value receiver (Daemon) — also forbidden.
-		ident, ok := expr.(*ast.Ident)
-		return ok && ident.Name == "Daemon"
-	}
-	ident, ok := star.X.(*ast.Ident)
-	return ok && ident.Name == "Daemon"
 }
 
 // itoa avoids strconv import bloat for a single int->string in the


### PR DESCRIPTION
## Summary

Extend `pkg/daemon/legacy_dataplane_canary_test.go` from 2 AST
passes to 5 with record-once dedup, closing the structural bypasses
that AGY adversarial review on PR #1557 (P2) and Codex+Gemini
round-1 of #1559 (package-level FuncDecl + bare-Ident callsite)
identified.

The identifier `legacyDP` is now reserved across all pkg/daemon
production-code AST surfaces: FuncDecl, StructType.Field, CallExpr,
SelectorExpr, and bare `*ast.Ident`. Comments and string literals
remain safe (parser called without `parser.ParseComments`; string
literals are `*ast.BasicLit`).

Closes #1559

## Plan + adversarial review

Plan doc: [`docs/pr/1559-canary-harden/plan.md`](docs/pr/1559-canary-harden/plan.md)

- Codex round-1 (`task-mpnhxj2g-p4047b`): PLAN-NEEDS-MINOR — wrong canary path mention, exact-count assertions, StructType message wording.
- Gemini round-1 (`task-mpnhy4io-gzc7jp`): PLAN-NEEDS-MINOR — critical bypass: package-level `func legacyDP(d *Daemon)` + bare callsite `legacyDP(d)`.
- v2 addressed all round-1 findings (Pass 1 receiver-agnostic, Pass 5 bare-Ident catch-all, record-once dedup).
- Codex round-2 (`task-mpni67pj-2lztaa`): PLAN-NEEDS-MINOR — record at identifier token (fd.Name.Pos / sel.Sel.Pos) for multiline-form stability.
- Gemini round-2 (`task-mpni6wln-usco7m`): PLAN-READY.
- v3 addressed Codex round-2 cleanups.

## Test plan

- [x] cargo build: N/A (no Rust changes)
- [x] go test `./pkg/daemon -run "TestLegacyDPAccessorRemoved|TestCanarySynthetic"`: 8/8 pass
- [x] 5/5 flake check on the combined run
- [x] go test `./...`: 32 packages green, zero failures
- [x] Synthetic negative tests cover every AST bypass shape (struct field, bare selector read, call site, package-level FuncDecl, bare ident callsite, comments+strings safety, dedup invariant)

Cluster smoke deferred: test-only change in `pkg/daemon`. No runtime/dataplane behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)