### PR TITLE
#1563: cli: hard-error `-c` paths that depend on readline

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4682,3 +4682,31 @@
   - AGY r2: MERGE-READY
   - Copilot r1: COMMENTED w/ 3 inline findings, all addressed in d013302748 + 0e2a88c8b
   - Codex: 3 consecutive sandbox failures (`unified-exec` blocked)
+
+## 2026-05-27
+
+- **Timestamp**: 03:34 UTC
+- **Action**: #1563 fix — `cli -c` non-TTY segfault. Plan v1→v3
+  through Codex + AGY adversarial review (3 rounds). v1
+  nil-guarded the cosmetic SetPrompt sites; v2 added bufio
+  fallback for `load terminal` and quoted configLockInterceptor
+  to argue daemon self-cleanup; v3 converged on hard-erroring
+  `configure` in `-c` mode after both reviewers caught that
+  (a) configLockInterceptor is a Unary Interceptor and doesn't
+  fire on connection close (lock leak), (b) `load` is not in
+  operational dispatch so the bufio work was solving an
+  unreachable code path. Implementation: hard-error `configure`
+  when `c.rl == nil`, factored `confirmYes()` helper in
+  request.go for the three destructive prompt sites
+  (reboot/halt/zeroize/ISSU), defensive nil-guards in
+  dispatchConfig SetPrompt sites. Tests: 4 new tests in
+  `cmd/cli/nontty_test.go` using interface-embedding fake gRPC
+  client; full cmd/cli suite green (5/5 flake); full Go suite
+  green.
+- **File(s)**:
+  - `cmd/cli/shared.go` (configure hard-error + dispatchConfig defensive guards)
+  - `cmd/cli/request.go` (confirmYes helper + 3 site refactors)
+  - `cmd/cli/nontty_test.go` (new)
+  - `docs/pr/1563-cli-c-nontty-fix/plan.md` (new)
+- **Status**: PR opened — AWAITING-BATCH-MERGE; smoke-runner
+  picks up via `<!-- AWAITING-SMOKE -->` marker.

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -1,0 +1,164 @@
+// Tests for the non-TTY (`-c`) safety guards added in #1563.
+//
+// The remote `cli` binary segfaulted when invoked as `cli -c "configure"`
+// from a non-TTY context (e.g. `incus exec`, scripted CI) because the
+// dispatch path touched the readline instance before it was initialized
+// — readline.NewEx() runs AFTER `-c` dispatch in cmd/cli/main.go. The
+// `c.rl == nil` guards in these tests pin the safe behavior in place:
+//
+//   - `configure` returns a hard error rather than issuing the
+//     EnterConfigure RPC, which would leak the daemon-side config
+//     lock (the gRPC configLockInterceptor is unary-only and never
+//     fires on connection close).
+//   - The destructive `request system <action>` paths (reboot, halt,
+//     power-off, zeroize, in-service-upgrade) return a hard error
+//     rather than silently proceeding without operator confirmation.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// fakeBpfrxClient embeds the generated client interface so we can
+// override only the RPC methods we care about. Any method the test
+// does not override will nil-panic when called — which is exactly
+// what we want, since calling an un-stubbed RPC from the test path
+// is itself a bug.
+type fakeBpfrxClient struct {
+	pb.BpfrxServiceClient
+
+	enterConfigureCalls int
+	systemActionCalls   int
+}
+
+func (f *fakeBpfrxClient) EnterConfigure(
+	_ context.Context, _ *pb.EnterConfigureRequest, _ ...grpc.CallOption,
+) (*pb.EnterConfigureResponse, error) {
+	f.enterConfigureCalls++
+	return &pb.EnterConfigureResponse{}, nil
+}
+
+func (f *fakeBpfrxClient) SystemAction(
+	_ context.Context, _ *pb.SystemActionRequest, _ ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+	f.systemActionCalls++
+	return &pb.SystemActionResponse{Message: "ok"}, nil
+}
+
+// TestDispatchOperational_ConfigureNonTTYHardErrors verifies that
+// `cli -c "configure"` returns a hard error and crucially does NOT
+// issue the EnterConfigure RPC. Issuing the RPC and then exiting
+// would leak the daemon-side config lock (see comments in
+// dispatchOperational + pkg/grpcapi/server.go configLockInterceptor).
+func TestDispatchOperational_ConfigureNonTTYHardErrors(t *testing.T) {
+	fake := &fakeBpfrxClient{}
+	c := &ctl{
+		client: fake,
+		rl:     nil, // non-TTY mode
+	}
+
+	err := c.dispatchOperational("configure")
+	if err == nil {
+		t.Fatal("dispatchOperational(\"configure\") returned nil; expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), "interactive terminal") {
+		t.Errorf("expected error mentioning interactive terminal, got %v", err)
+	}
+
+	if fake.enterConfigureCalls != 0 {
+		t.Errorf("EnterConfigure RPC was issued %d times; expected 0 (no lock leak)",
+			fake.enterConfigureCalls)
+	}
+	if c.configMode {
+		t.Error("c.configMode = true after hard-errored configure; expected false")
+	}
+}
+
+// TestDispatchOperational_ConfigureExclusiveNonTTYHardErrors covers
+// the `cli -c "configure exclusive"` variant — the guard must fire
+// before the exclusive-form branches.
+func TestDispatchOperational_ConfigureExclusiveNonTTYHardErrors(t *testing.T) {
+	fake := &fakeBpfrxClient{}
+	c := &ctl{
+		client: fake,
+		rl:     nil,
+	}
+
+	err := c.dispatchOperational("configure exclusive")
+	if err == nil {
+		t.Fatal("dispatchOperational(\"configure exclusive\") returned nil")
+	}
+	if fake.enterConfigureCalls != 0 {
+		t.Errorf("EnterConfigure issued %d times for `configure exclusive`; expected 0",
+			fake.enterConfigureCalls)
+	}
+}
+
+// TestConfirmYes_NoTTYError pins the helper's non-TTY contract:
+// hard-error rather than silently consuming stdin.
+func TestConfirmYes_NoTTYError(t *testing.T) {
+	c := &ctl{
+		client: &fakeBpfrxClient{},
+		rl:     nil,
+	}
+
+	ok, err := c.confirmYes("Reboot the system? [yes,no] (no) ")
+	if err == nil {
+		t.Fatal("confirmYes returned nil error in non-TTY mode")
+	}
+	if !strings.Contains(err.Error(), "interactive confirmation") {
+		t.Errorf("expected error mentioning interactive confirmation, got %v", err)
+	}
+	if ok {
+		t.Error("confirmYes returned ok=true in non-TTY mode; expected false")
+	}
+}
+
+// TestHandleRequestSystem_NonTTYBlocksDestructive verifies that every
+// destructive `request system <action>` command refuses to issue the
+// SystemAction RPC when there is no interactive terminal. Table-driven
+// across every prompt-guarded command per AGY round-3 finding.
+func TestHandleRequestSystem_NonTTYBlocksDestructive(t *testing.T) {
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{"reboot", []string{"system", "reboot"}},
+		{"halt", []string{"system", "halt"}},
+		{"power-off", []string{"system", "power-off"}},
+		{"zeroize", []string{"system", "zeroize"}},
+		{"in-service-upgrade",
+			[]string{"system", "software", "in-service-upgrade"}},
+	}
+
+	for _, tc := range commands {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeBpfrxClient{}
+			c := &ctl{
+				client: fake,
+				rl:     nil,
+			}
+
+			err := c.handleRequest(tc.args)
+			if err == nil {
+				t.Fatalf("handleRequest(%v) returned nil error; expected hard error",
+					tc.args)
+			}
+			if !strings.Contains(err.Error(), "interactive confirmation") {
+				t.Errorf("expected error mentioning interactive confirmation, got %v",
+					err)
+			}
+			if fake.systemActionCalls != 0 {
+				t.Errorf("SystemAction RPC was issued %d times for %q; "+
+					"expected 0 — destructive action must not proceed in non-TTY",
+					fake.systemActionCalls, tc.name)
+			}
+		})
+	}
+}

--- a/cmd/cli/request.go
+++ b/cmd/cli/request.go
@@ -8,6 +8,43 @@ import (
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
+// confirmYes prompts the operator with `prompt`, reads a line via
+// the readline instance, and returns true when the trimmed +
+// lowercased response is exactly "yes". Any other response (or a
+// read error) returns false with a nil error so callers can print
+// their "cancelled" message and return cleanly.
+//
+// When invoked without a readline instance (non-TTY `-c` mode) the
+// caller has no way to gather confirmation. Rather than silently
+// reading stdin and possibly executing a destructive action against
+// unintended input, hard-error so the script visibly fails. This
+// applies to reboot / halt / power-off / zeroize / in-service-upgrade
+// — operator-authored automation should drive these through the
+// gRPC SystemAction RPC directly, not via the interactive CLI
+// binary. See #1563.
+func (c *ctl) confirmYes(prompt string) (bool, error) {
+	if c.rl == nil {
+		return false, fmt.Errorf(
+			"this command requires interactive confirmation (TTY); " +
+				"not available in -c mode")
+	}
+	fmt.Print(prompt)
+	c.rl.SetPrompt("")
+	line, err := c.rl.Readline()
+	// Restore the correct prompt for the current mode so this
+	// helper composes with both `request system ...` (operational)
+	// and `run request system ...` (from configuration mode).
+	if c.configMode {
+		c.rl.SetPrompt(c.configPrompt())
+	} else {
+		c.rl.SetPrompt(c.operationalPrompt())
+	}
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(strings.ToLower(line)) == "yes", nil
+}
+
 func (c *ctl) handleRequest(args []string) error {
 	if len(args) == 0 {
 		printRemoteTreeHelp("request:", "request")
@@ -33,11 +70,12 @@ func (c *ctl) handleRequest(args []string) error {
 
 	switch args[1] {
 	case "reboot", "halt", "power-off":
-		fmt.Printf("%s the system? [yes,no] (no) ", strings.Title(args[1]))
-		c.rl.SetPrompt("")
-		line, err := c.rl.Readline()
-		c.rl.SetPrompt(c.operationalPrompt())
-		if err != nil || strings.TrimSpace(strings.ToLower(line)) != "yes" {
+		ok, err := c.confirmYes(fmt.Sprintf(
+			"%s the system? [yes,no] (no) ", strings.Title(args[1])))
+		if err != nil {
+			return err
+		}
+		if !ok {
 			fmt.Printf("%s cancelled\n", strings.Title(args[1]))
 			return nil
 		}
@@ -51,11 +89,11 @@ func (c *ctl) handleRequest(args []string) error {
 		return nil
 	case "zeroize":
 		fmt.Println("WARNING: This will erase all configuration and return to factory defaults.")
-		fmt.Print("Zeroize the system? [yes,no] (no) ")
-		c.rl.SetPrompt("")
-		line, err := c.rl.Readline()
-		c.rl.SetPrompt(c.operationalPrompt())
-		if err != nil || strings.TrimSpace(strings.ToLower(line)) != "yes" {
+		ok, err := c.confirmYes("Zeroize the system? [yes,no] (no) ")
+		if err != nil {
+			return err
+		}
+		if !ok {
 			fmt.Println("Zeroize cancelled")
 			return nil
 		}
@@ -73,11 +111,11 @@ func (c *ctl) handleRequest(args []string) error {
 			return nil
 		}
 		fmt.Println("WARNING: This will force this node to secondary for all redundancy groups.")
-		fmt.Print("Proceed with in-service upgrade? [yes,no] (no) ")
-		c.rl.SetPrompt("")
-		line, err := c.rl.Readline()
-		c.rl.SetPrompt(c.operationalPrompt())
-		if err != nil || strings.TrimSpace(strings.ToLower(line)) != "yes" {
+		ok, err := c.confirmYes("Proceed with in-service upgrade? [yes,no] (no) ")
+		if err != nil {
+			return err
+		}
+		if !ok {
 			fmt.Println("ISSU cancelled")
 			return nil
 		}

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -222,7 +222,11 @@ func (c *ctl) dispatchOperational(line string) error {
 		// configLockInterceptor (pkg/grpcapi/server.go) is a UNARY
 		// interceptor — it only fires while an RPC is in flight, never
 		// on connection close. Issuing EnterConfigure here and exiting
-		// would leak the exclusive config lock until daemon restart.
+		// would leak the daemon-side config lock until daemon restart.
+		// Exclusive locks are especially bad: EnterConfigureExclusive
+		// sets `exclusiveHolder`, but ExitConfigureSession only
+		// releases when the session matches `configHolder`, so even
+		// an explicit teardown call wouldn't recover them.
 		// See #1563.
 		if c.rl == nil {
 			return fmt.Errorf(

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -214,6 +214,21 @@ func (c *ctl) dispatchOperational(line string) error {
 
 	switch parts[0] {
 	case "configure":
+		// Hard-error when the readline instance is nil (i.e. `cli -c
+		// "configure"` from a non-TTY context). Entering configuration
+		// mode without a follow-up interactive command is useless: -c
+		// runs a single command and exits, so the configMode flag is
+		// immediately discarded. Worse, the daemon-side gRPC
+		// configLockInterceptor (pkg/grpcapi/server.go) is a UNARY
+		// interceptor — it only fires while an RPC is in flight, never
+		// on connection close. Issuing EnterConfigure here and exiting
+		// would leak the exclusive config lock until daemon restart.
+		// See #1563.
+		if c.rl == nil {
+			return fmt.Errorf(
+				"configuration mode requires an interactive terminal " +
+					"(TTY); not available in -c mode")
+		}
 		exclusive := len(parts) >= 2 && parts[1] == "exclusive"
 		_, err := c.client.EnterConfigure(c.ctx(), &pb.EnterConfigureRequest{
 			Exclusive: exclusive,
@@ -280,13 +295,17 @@ func (c *ctl) dispatchConfig(line string) error {
 			return nil
 		}
 		c.editPath = append(c.editPath, parts[1:]...)
-		c.rl.SetPrompt(c.configPrompt())
+		if c.rl != nil {
+			c.rl.SetPrompt(c.configPrompt())
+		}
 		fmt.Printf("[edit %s]\n", strings.Join(c.editPath, " "))
 		return nil
 
 	case "top":
 		c.editPath = nil
-		c.rl.SetPrompt(c.configPrompt())
+		if c.rl != nil {
+			c.rl.SetPrompt(c.configPrompt())
+		}
 		fmt.Println("[edit]")
 		return nil
 
@@ -294,7 +313,9 @@ func (c *ctl) dispatchConfig(line string) error {
 		if len(c.editPath) > 0 {
 			c.editPath = c.editPath[:len(c.editPath)-1]
 		}
-		c.rl.SetPrompt(c.configPrompt())
+		if c.rl != nil {
+			c.rl.SetPrompt(c.configPrompt())
+		}
 		if len(c.editPath) > 0 {
 			fmt.Printf("[edit %s]\n", strings.Join(c.editPath, " "))
 		} else {
@@ -411,7 +432,9 @@ func (c *ctl) dispatchConfig(line string) error {
 		_, _ = c.client.ExitConfigure(c.ctx(), &pb.ExitConfigureRequest{})
 		c.configMode = false
 		c.editPath = nil
-		c.rl.SetPrompt(c.operationalPrompt())
+		if c.rl != nil {
+			c.rl.SetPrompt(c.operationalPrompt())
+		}
 		fmt.Println("Exiting configuration mode")
 		return nil
 

--- a/docs/pr/1563-cli-c-nontty-fix/plan.md
+++ b/docs/pr/1563-cli-c-nontty-fix/plan.md
@@ -1,160 +1,103 @@
 # #1563 cli -c segfault on readline.SetPrompt in non-TTY mode
 
-**Status:** DRAFT v2 — addresses Codex PLAN-NEEDS-MAJOR + AGY PLAN-NEEDS-MINOR (round 1)
+**Status:** DRAFT v3 — addresses Codex R2 PLAN-NEEDS-MAJOR + AGY R2 PLAN-NEEDS-MINOR
 
-## Round-1 review summary
+## Review history
 
-- **AGY (PLAN-NEEDS-MINOR):** call-site enumeration confirmed
-  complete; asked for bufio.NewScanner fallback on `load terminal`
-  instead of hard-error; asked for explicit fake gRPC client
-  pattern in test plan.
-- **Codex (PLAN-NEEDS-MAJOR):** flagged that `configure` mutates
-  daemon state (`EnterConfigure` RPC) before the cosmetic SetPrompt
-  fires, so nil-guarding the prompt risks leaving the daemon with
-  an exclusive config holder if the client disconnects without
-  ExitConfigure. Required: prove daemon cleanup on disconnect,
-  hard-error `configure` in -c, OR add guaranteed cleanup. Also
-  asked for actual recorded grep inventory + tests that exercise
-  real dispatch surface with a fake client.
+- **AGY R1 (PLAN-NEEDS-MINOR):** add bufio fallback to `load terminal`;
+  specify fake gRPC client pattern. Both adopted in v2.
+- **Codex R1 (PLAN-NEEDS-MAJOR):** flagged `configure` state-mutation
+  before crash → lock-leak concern. v2 attempted to refute via
+  configLockInterceptor.
+- **AGY R2 (PLAN-NEEDS-MINOR) + Codex R2 (PLAN-NEEDS-MAJOR) — CONVERGED:**
+  v2's configLockInterceptor argument is **wrong**. The interceptor
+  is a Unary Interceptor; it only fires *during* RPC execution.
+  After EnterConfigure returns and the connection later closes, no
+  cleanup hook ever runs. The lock leaks permanently. Both reviewers
+  independently caught this.
+- **Codex R2 additional finding:** `EnterConfigureExclusive` sets
+  `exclusiveHolder` not `configHolder`. `ExitConfigureSession`
+  refuses to release if session doesn't match `configHolder`. So
+  even an explicit `client.ExitConfigure(...)` call from a `-c`
+  cleanup path **would not release an exclusive lock**.
+- **Codex R2 additional finding:** `load merge terminal` is **not
+  reachable** from `cli -c`. `-c` starts with `c.configMode = false`
+  → dispatches operational → operational has no `load` case →
+  "unknown command: load". The v2 bufio/io.ReadAll plan was solving
+  an unreachable code path.
 
-This v2 addresses both reviewers in full.
+## Converged-on architecture (v3)
 
-## Issue framing
+The reviewers' converged answer is: **hard-error `configure` when
+`c.rl == nil`** at the dispatchOperational layer. This:
 
-`cli -c "<command>"` segfaults when invoked from non-TTY contexts
-(`incus exec`, scripted CI, cron). Crash site is
-`cmd/cli/shared.go:225` — `c.rl.SetPrompt(c.configPrompt())` panics
-because `c.rl == nil`.
+1. Stops the segfault dead in its tracks (the crash site at
+   shared.go:225 is never reached because `EnterConfigure` is never
+   issued).
+2. Stops the lock leak dead in its tracks (no RPC issued → no
+   server-side `EnterConfigure` to leak).
+3. Stops the exclusive-lock leak dead in its tracks (same).
+4. Is a 4-line change instead of a multi-site refactor.
+5. Makes the cosmetic-SetPrompt sites in shared.go (283, 289, 297,
+   414) and the `load terminal` path **unreachable in `-c` mode**
+   by construction, because `c.configMode` can never become true.
 
-Root cause confirmed by reading `cmd/cli/main.go:67-76`: the `-c`
-fast path dispatches the command **before** `readline.NewEx()` runs
-(`c.rl = rl` is at main.go:132). Any code path inside dispatch that
-touches `c.rl` will nil-deref.
+For belt-and-suspenders defense in depth we still nil-guard those
+cosmetic SetPrompts, but the guards are dead code in `-c` mode
+once `configure` errors out. They remain useful if any future
+caller constructs a `ctl` with `rl == nil` for some other reason.
 
-## Codex's `configure` state-mutation concern — resolved
+The `request system <action>` confirmation paths in request.go
+remain reachable from `-c` mode (`request` is an operational
+command). They must hard-error in non-TTY mode.
 
-Codex flagged that `cli -c configure` calls `EnterConfigure` RPC
-before the SetPrompt panics, so a nil-guard would convert
-"crash-after-side-effect" to "success-after-side-effect" and
-could leave the daemon's config locked.
+## Final concrete design
 
-**Verified resolution: the daemon already auto-releases on client
-disconnect.** Quote from `pkg/grpcapi/server.go:214-228`:
+### 1. dispatchOperational (shared.go:215) — hard-error configure when rl==nil
 
 ```go
-// configLockInterceptor auto-releases stale config locks when a gRPC client
-// disconnects (context cancelled) without calling ExitConfigure.
-func (s *Server) configLockInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-    resp, err := handler(ctx, req)
-    // If the client's context was cancelled (disconnect, Ctrl-C), release any
-    // config lock held by this connection.
-    if ctx.Err() != nil {
-        sessionID := peerSessionID(ctx)
-        if sessionID != "" {
-            if s.store.ExitConfigureSession(sessionID) {
-                slog.Info("auto-released config lock on client disconnect", "session", sessionID)
-            }
-        }
+case "configure":
+    if c.rl == nil {
+        return fmt.Errorf("configuration mode requires an interactive terminal (TTY); not available in -c mode")
     }
-    return resp, err
-}
+    exclusive := len(parts) >= 2 && parts[1] == "exclusive"
+    _, err := c.client.EnterConfigure(c.ctx(), &pb.EnterConfigureRequest{
+        Exclusive: exclusive,
+    })
+    if err != nil {
+        return fmt.Errorf("%v", err)
+    }
+    c.configMode = true
+    c.rl.SetPrompt(c.configPrompt())  // safe — guarded by the nil-check above
+    if exclusive {
+        ...
 ```
 
-When `cli -c configure` exits, `defer conn.Close()` in
-`cmd/cli/main.go:37` closes the gRPC connection, the context
-cancels, and `configLockInterceptor` calls `ExitConfigureSession`.
-The lock is released cleanly.
+Rationale: the gRPC `EnterConfigure` RPC is never issued, so the
+daemon never enters config mode for this client. No lock, no leak,
+no segfault. Operator sees a clear error.
 
-**Conclusion:** nil-guarding the SetPrompt in `configure` is safe.
-The "state leak" Codex worried about does not exist on master.
+### 2. shared.go dispatchConfig — defensive nil-guards (dead code in -c but cheap)
 
-This also addresses the boundary-classification concern: the
-SetPrompt IS purely cosmetic because the daemon owns the canonical
-config-mode state and self-cleans.
+Wrap SetPrompt at lines 283, 289, 297, 414 with `if c.rl != nil`.
+These paths are now formally unreachable from `-c` (since
+`c.configMode` can never become true). Keep the guards anyway as
+defense-in-depth.
 
-## Recorded `c.rl` call-site inventory
+### 3. request.go — confirmYes helper
 
-`grep -n 'c\.rl' cmd/cli/*.go` against worktree HEAD (dd05de380):
+`request` is operational and reachable from `-c`. Destructive
+confirmations must hard-error in non-TTY mode rather than wait
+for input on a stream that will never deliver "yes".
 
-```
-cmd/cli/main.go:105:    fmt.Fprintln(c.rl.Stdout(), "  (no help available)")
-cmd/cli/main.go:122:    cmdtree.WriteHelp(c.rl.Stdout(), candidates)
-cmd/cli/main.go:132:    c.rl = rl
-cmd/cli/main.go:379:    line, err := c.rl.Readline()
-cmd/cli/shared.go:225:  c.rl.SetPrompt(c.configPrompt())
-cmd/cli/shared.go:283:  c.rl.SetPrompt(c.configPrompt())
-cmd/cli/shared.go:289:  c.rl.SetPrompt(c.configPrompt())
-cmd/cli/shared.go:297:  c.rl.SetPrompt(c.configPrompt())
-cmd/cli/shared.go:414:  c.rl.SetPrompt(c.operationalPrompt())
-cmd/cli/shared.go:437:  if c.rl != nil {
-cmd/cli/shared.go:439:      c.rl.SetPrompt(c.configPrompt())
-cmd/cli/shared.go:441:      c.rl.SetPrompt(c.operationalPrompt())
-cmd/cli/shared.go:530:  cmdtree.WriteHelp(rc.ctl.rl.Stdout(), candidates)
-cmd/cli/request.go:37:  c.rl.SetPrompt("")
-cmd/cli/request.go:38:  line, err := c.rl.Readline()
-cmd/cli/request.go:39:  c.rl.SetPrompt(c.operationalPrompt())
-cmd/cli/request.go:55:  c.rl.SetPrompt("")
-cmd/cli/request.go:56:  line, err := c.rl.Readline()
-cmd/cli/request.go:57:  c.rl.SetPrompt(c.operationalPrompt())
-cmd/cli/request.go:77:  c.rl.SetPrompt("")
-cmd/cli/request.go:78:  line, err := c.rl.Readline()
-cmd/cli/request.go:79:  c.rl.SetPrompt(c.operationalPrompt())
-```
-
-Categorisation:
-
-| Site | Category | Action |
-|------|----------|--------|
-| main.go:105, 122 | inside readline Listener callback (`?` key) | unreachable in -c (Listener registered by readline.NewEx) — no change |
-| main.go:132 | init | no change |
-| main.go:379 | `load <mode> terminal` interactive read | switch to bufio.NewScanner(os.Stdin) when rl==nil |
-| shared.go:225, 283, 289, 297, 414 | cosmetic SetPrompt | nil-guard each call |
-| shared.go:437-442 | refreshPrompt (already guarded) | no change |
-| shared.go:530 | autocomplete WriteHelp via `rc.ctl.rl.Stdout()` | unreachable in -c (`Do()` driven by readline) — no change |
-| request.go:37-39, 55-57, 77-79 | yes/no confirmation prompts | factor `confirmYes()` helper that hard-errors when rl==nil |
-
-**Total touched sites:** 5 in shared.go + 3 in request.go + 1 in
-main.go = 9. All other references are init, the dual-guard pattern
-already in place, or fire only inside the readline read loop.
-
-## Two fix candidates
-
-### Option A — guard c.rl != nil at the existing call sites
-
-Adopted. Details below.
-
-### Option B — denylist interactive commands at -c entry
-
-Rejected for the same reasons as v1, now reinforced:
-
-- Codex agreed Option A is directionally right.
-- Option B would block future multi-command `-c`
-  (`cli -c "configure; set X; commit"`).
-- The boundary problem Codex raised (`configure` mutates state
-  before cosmetic call) is moot because the daemon self-cleans on
-  disconnect.
-
-## Concrete design (v2)
-
-### shared.go — 5 cosmetic SetPrompt sites
-
-Wrap each in the same nil-guard already used by `refreshPrompt`:
+Factor a helper (placed in `cmd/cli/request.go`):
 
 ```go
-if c.rl != nil {
-    c.rl.SetPrompt(c.configPrompt())  // or operationalPrompt()
-}
-```
-
-Sites: lines 225, 283, 289, 297, 414. All pure UI updates.
-`c.configMode` / `c.editPath` state is updated independently and
-is harmless when discarded at -c exit.
-
-### request.go — 3 confirmation sites
-
-Factor a `confirmYes` helper that hard-errors in non-TTY mode:
-
-```go
+// confirmYes prompts the operator for a yes/no answer. In non-TTY
+// (`-c`) mode there is no readline instance, so we hard-error
+// rather than silently waiting on stdin for input that will
+// never come — and certainly never proceed with a destructive
+// action.
 func (c *ctl) confirmYes(prompt string) (bool, error) {
     if c.rl == nil {
         return false, fmt.Errorf(
@@ -172,201 +115,183 @@ func (c *ctl) confirmYes(prompt string) (bool, error) {
 }
 ```
 
-Each request.go confirmation becomes:
+Three sites in request.go become:
 
 ```go
-ok, err := c.confirmYes(fmt.Sprintf("%s the system? [yes,no] (no) ", strings.Title(args[1])))
-if err != nil {
-    return err
-}
-if !ok {
-    fmt.Printf("%s cancelled\n", strings.Title(args[1]))
-    return nil
-}
-```
-
-Hard-error is correct here: `request system reboot` from a script
-without confirmation MUST NOT proceed silently. The clear error
-tells the operator to invoke `pb.BpfrxServiceClient.SystemAction`
-directly via gRPC if non-interactive operation is required.
-
-### main.go handleLoad — bufio.NewScanner fallback (per AGY)
-
-In `handleLoad`, when `source == "terminal"` and `c.rl == nil`,
-read stdin via bufio.NewScanner so the canonical pipe pattern
-works:
-
-```go
-if source == "terminal" {
-    var lines []string
-    if c.rl != nil {
-        fmt.Println("[Type or paste configuration, then press Ctrl-D on an empty line]")
-        for {
-            line, err := c.rl.Readline()
-            if err != nil {
-                break
-            }
-            lines = append(lines, line)
-        }
-    } else {
-        // Non-TTY: read piped config directly from stdin.
-        scanner := bufio.NewScanner(os.Stdin)
-        // Default scanner buffer is 64 KiB which is too small for
-        // a Junos-style override. Bump to 1 MiB.
-        scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-        for scanner.Scan() {
-            lines = append(lines, scanner.Text())
-        }
-        if err := scanner.Err(); err != nil {
-            return fmt.Errorf("load %s: stdin read: %v", mode, err)
-        }
+case "reboot", "halt", "power-off":
+    ok, err := c.confirmYes(fmt.Sprintf("%s the system? [yes,no] (no) ", strings.Title(args[1])))
+    if err != nil {
+        return err
     }
-    content = strings.Join(lines, "\n")
-}
+    if !ok {
+        fmt.Printf("%s cancelled\n", strings.Title(args[1]))
+        return nil
+    }
+    ...
 ```
 
-This unlocks `echo "set system hostname foo" | cli -c "load merge terminal"`.
+Similar for `zeroize` and `software in-service-upgrade`.
+
+### 4. main.go handleLoad — REMOVED from plan
+
+`load` is not in operational dispatch. `cli -c "load merge terminal"`
+returns "unknown command: load" today and after the fix. There is
+no segfault to repair here. Drop the bufio/io.ReadAll work.
+
+If a future feature wants `cli -c "load merge <file>"` to work,
+that becomes a separate issue (add `load` to operational dispatch
++ define how it interacts with non-TTY mode).
 
 ## Public API preservation
 
 - `ctl` struct: unchanged.
-- `confirmYes`: new unexported helper.
-- `-c` flag semantics: unchanged externally — it just no longer
-  crashes.
-- All other dispatch paths in TTY mode behave identically.
+- `confirmYes`: new unexported helper, placed in `cmd/cli/request.go`.
+- `-c` flag semantics: unchanged externally — `cli -c "show version"`
+  and similar operational commands work; `cli -c "configure"` now
+  exits with a clear error code 1; destructive confirmations exit
+  with a clear error code 1.
 
 ## Hidden invariants the change must preserve
 
-- Interactive `cli` (TTY) behaviour MUST be identical. Every
-  SetPrompt that fires today still fires when `c.rl != nil`.
-  Verified by guard pattern: `if c.rl != nil { existing-call }`.
+- Interactive `cli` (TTY) behaviour MUST be identical. Every path
+  that fires today still fires when `c.rl != nil`. The
+  `dispatchOperational` `configure` case adds a guard that is
+  bypassed in TTY mode.
 - Confirmation prompts in TTY mode still demand "yes" — the
-  `confirmYes` helper preserves the exact existing logic
-  (read, compare lowercased+trimmed, exact match "yes").
-- Error-on-no-rl in interactive-input sites surfaces a non-zero
-  exit so scripts can detect the failure: main.go:71-74 already
-  does `os.Exit(1)` on dispatch error.
-- Daemon-side EnterConfigure cleanup is preserved by existing
-  configLockInterceptor (pkg/grpcapi/server.go:214-228).
-- No new goroutines, no new locks, no new allocations on the hot
-  path.
+  `confirmYes` helper preserves the exact existing logic.
+- No new RPC issued in non-TTY mode for configure → no daemon
+  state to clean up → no lock leak.
+- No new goroutines, no new locks, no new allocations.
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |------------|-------|-------|
-| Behavioural regression (TTY) | LOW | Each guard is `if rl != nil { existing-call }`; in TTY mode rl is non-nil so behaviour is unchanged. |
-| Lifetime / borrow-checker | N/A | Go, not Rust. |
-| Performance regression | NEGLIGIBLE | CLI is cold path; one nil-check per cosmetic SetPrompt. |
-| Architectural mismatch | LOW | Pattern already in use at shared.go:437; we're propagating it consistently. |
-| State leak via `cli -c configure` | LOW (verified) | Daemon auto-releases on conn close via configLockInterceptor. |
-| stdin-stream encoding for piped `load terminal` | LOW | bufio.NewScanner with 1 MiB buffer covers realistic configs; CRLF handled by Scanner.Text() stripping the trailing newline character. |
+| Behavioural regression (TTY) | LOW | `c.rl` is non-nil in TTY mode so all hard-errors are bypassed. |
+| Lifetime / borrow-checker | N/A | Go. |
+| Performance regression | NEGLIGIBLE | CLI cold path; one nil-check per invocation of `configure` / `confirmYes`. |
+| Architectural mismatch | LOW | Pattern matches existing `if c.rl != nil` at shared.go:437. |
+| Daemon lock leak | ZERO (was HIGH in v2) | No `EnterConfigure` RPC issued in `-c` mode. |
+| Lost feature: `cli -c configure` | NONE | This was never a usable feature — `-c` runs a single command, then exits, so entering config mode without a follow-up command was pointless. |
 
-## Test plan (v2)
+## Test plan
 
 ### Unit tests
 
-Add `cmd/cli/cdash_nontty_test.go` (or extend `main_test.go`)
-using the interface-embedding fake gRPC client pattern that AGY
-suggested:
+Add to `cmd/cli/main_test.go` (or a new `cmd/cli/cdash_nontty_test.go`)
+using the interface-embedding fakeBpfrxClient pattern AGY suggested:
 
 ```go
 type fakeBpfrxClient struct {
-    pb.BpfrxServiceClient // embed interface; nil for unused methods
+    pb.BpfrxServiceClient // embed; nil for unused methods
+
+    // Recorders
+    enterConfigureCalls int
+    systemActionCalls   int
 }
 
 func (f *fakeBpfrxClient) EnterConfigure(
     ctx context.Context, in *pb.EnterConfigureRequest, opts ...grpc.CallOption,
 ) (*pb.EnterConfigureResponse, error) {
+    f.enterConfigureCalls++
     return &pb.EnterConfigureResponse{}, nil
 }
-func (f *fakeBpfrxClient) ExitConfigure(
-    ctx context.Context, in *pb.ExitConfigureRequest, opts ...grpc.CallOption,
-) (*pb.ExitConfigureResponse, error) {
-    return &pb.ExitConfigureResponse{}, nil
+
+func (f *fakeBpfrxClient) SystemAction(
+    ctx context.Context, in *pb.SystemActionRequest, opts ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+    f.systemActionCalls++
+    return &pb.SystemActionResponse{Message: "ok"}, nil
 }
-// ... other RPCs as needed, all returning the empty response.
 ```
 
-Test cases (every site that nil-derefs today):
+Test cases (every site touched by the fix):
 
-1. `TestDispatchOperational_ConfigureNoTTY` — ctl{rl: nil} +
-   fakeBpfrxClient; call `dispatchOperational("configure")`; must
-   not panic, must return nil, must set `c.configMode = true`.
-2. `TestDispatchConfig_EditTopUpExitNoTTY` — ctl{rl: nil,
-   configMode: true}; call each of `edit foo`, `top`, `up`,
-   `exit`; must not panic, must return nil; verifies all four
-   shared.go SetPrompt sites (283, 289, 297, 414).
-3. `TestConfirmYes_NoTTYError` — ctl{rl: nil}; call
-   `confirmYes("?")`; must return (false, non-nil error).
-4. `TestHandleRequestSystem_NoTTY` — ctl{rl: nil}; call
-   `handleRequestSystem([]string{"system", "reboot"})`; must
-   return the no-TTY error, must NOT call SystemAction RPC
-   (verify with a fake that increments a counter and asserts
-   it's still zero).
-5. `TestHandleLoad_TerminalNoTTYReadsStdin` — ctl{rl: nil};
-   redirect os.Stdin to a pipe containing
-   `"set system hostname foo\n"`; call `handleLoad(
-   ["override", "terminal"])`; verify the fake's Load was called
-   with the piped content. Use `os.Pipe()` + `os.Stdin =
-   readEnd` (save/restore for cleanup).
+1. **`TestDispatchOperational_ConfigureNonTTYHardErrors`** — ctl{rl: nil}
+   + fakeBpfrxClient; call `dispatchOperational("configure")`; must
+   return a non-nil error matching "requires an interactive
+   terminal", must NOT increment `enterConfigureCalls` (verifies no
+   RPC issued → no daemon-side lock leak).
+2. **`TestDispatchOperational_ConfigureInteractive`** — ctl with a
+   non-nil rl stub (use `&readline.Instance{}` via a tiny shim, OR
+   skip this test on platforms where readline can't be constructed
+   in tests; alternatively add a small interface for "SetPrompt"
+   that we can stub). Validates that the TTY path is unchanged.
+   *If the readline.Instance is too awkward to fake, settle for the
+   non-nil case being covered by the existing CLI integration via
+   `make test-ssh` manual repro — note this in the test file.*
+3. **`TestConfirmYes_NoTTYError`** — ctl{rl: nil}; call
+   `confirmYes("?")`; must return (false, non-nil error matching
+   "requires interactive confirmation").
+4. **`TestHandleRequestSystem_NoTTYBlocksDestructive`** — ctl{rl: nil}
+   + fakeBpfrxClient; call `handleRequest([]string{"system",
+   "reboot"})`; must return the no-TTY error AND must NOT have
+   incremented `systemActionCalls`. Repeat for `zeroize` and
+   `software in-service-upgrade`.
 
-### Integration / smoke tests
+### Build / suite gates
 
-- `make build && make build-ctl`: clean.
-- `go vet ./cmd/cli/...`: clean.
-- `go test ./cmd/cli/...`: all green, including 5 new tests.
-- `go test ./...`: full Go suite green (30 packages).
-- Manual repro:
-  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "show version"` — must print version, exit 0.
-  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "configure"` — must succeed, exit 0, daemon auto-releases config lock.
-  - `incus exec loss:xpf-userspace-fw0 -- bash -c 'echo "set system hostname testxxx" | /usr/local/sbin/cli -c "load merge terminal"'` — must succeed, exit 0; check `cli -c "show configuration system"` confirms the hostname change.
-  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "request system reboot"` — must return error, exit non-zero, MUST NOT reboot.
+- `go vet ./cmd/cli/...` — clean.
+- `go build ./cmd/cli` — clean.
+- `go test ./cmd/cli/...` — all green, including the new tests.
+- `go test ./...` — full Go suite green (30 packages).
+
+### Manual repro on cluster (after deploy)
+
+- `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "show version"`
+  — must print version, exit 0. (segfault fix proved.)
+- `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "configure"`
+  — must exit non-zero with the "requires an interactive terminal"
+  error. Verify `show system configuration-database` on the daemon
+  shows no lingering config holder (lock leak prevention proved).
+- `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "request system reboot"`
+  — must exit non-zero with the "requires interactive confirmation"
+  error and MUST NOT reboot.
 - TTY regression: `make test-ssh` and run interactive `cli`,
-  verify `configure` / `edit foo` / `top` / `up` / `exit` still
-  update the prompt visually.
+  verify `configure` / `edit foo` / `top` / `up` / `exit` work
+  unchanged and the prompt updates as before.
 
 ### Smoke matrix
 
-This is a CLI binary fix, not a dataplane change. The full Pass A +
-Pass B per-class CoS matrix from triple-review is not required.
-But we still run the standard userspace cluster smoke (v4 + v6,
-push + reverse, multi-stream) to confirm we haven't broken
-anything by linking against the modified `cli` binary.
+CLI binary fix, not a dataplane change. Full per-class CoS matrix
+not required. Standard userspace cluster smoke (v4 + v6, push +
+reverse, multi-stream) to confirm we haven't broken the deployment
+itself.
 
 ## Out of scope
 
-- Multi-command `-c` support (e.g. `cli -c "configure; set X; commit"`).
+- `cli -c "configure; set X; commit"` multi-command support. Would
+  require explicit teardown sequencing in `-c` mode plus fixes to
+  `ExitConfigureSession` to handle `exclusiveHolder` (Codex R2
+  finding #2). Separate issue.
+- `cli -c "load merge <file>"` support (or `load merge terminal`
+  via stdin). Would require adding `load` to operational dispatch.
   Separate issue.
-- Refactoring `request system <action>` confirmations to read
-  stdin directly. The hard-error in non-TTY mode is correct for
-  destructive operations; allowing piped "yes" input would
-  reduce the protection.
-- Adding a `--yes` / `--non-interactive` flag for destructive
-  actions. Separate issue.
+- `--yes` / `--non-interactive` flag for destructive operations.
+  Separate audited-automation feature.
+- Fixing `ExitConfigureSession` exclusive-vs-non-exclusive asymmetry
+  in `pkg/configstore/store.go`. Pre-existing daemon-side bug;
+  worth a separate issue.
 
-## Open questions for adversarial review (round 2)
+## Open questions for adversarial review (round 3)
 
-1. **`load terminal` stdin EOF handling.** bufio.NewScanner stops
-   on EOF. Is there any case where stdin is a pipe that never
-   closes (e.g. interactive heredoc)? My read: `cli -c "load merge
-   terminal"` users will pipe a finite payload; if they want
-   open-ended interactive, they don't pass `-c`. Acceptable?
-2. **Should the 1 MiB scanner buffer be tunable?** I picked 1 MiB
-   because Junos override configs are usually <100 KiB. Edge
-   case: someone pipes a multi-MB config. Should we bump to 16
-   MiB by default, or fail loudly when the buffer is exceeded?
-   Default scanner behaviour with buffer-exceeded is to fail with
-   `bufio.ErrTooLong`, which we'll surface as "load: stdin read".
-3. **Test pattern: interface embedding vs gomock vs full fake.**
-   AGY suggested embedding. Codex asked for "real dispatch
-   surface plus fake client". Embedding satisfies both —
-   confirmed acceptable?
-4. **Should `cli -c "configure"` emit an info note** that the
-   command has no effect at exit, since the daemon auto-releases?
-   My read: silence is correct because there's no follow-up
-   command anyway. Counter-argue?
-5. **`request system in-service-upgrade` shape.** Same confirmYes
-   treatment, but ISSU specifically is the kind of thing
-   automation might want to drive. The current "must use gRPC
-   SystemAction RPC" error message is accurate. Counter-argue?
+1. **Is hard-erroring `configure` an acceptable UX?** Today
+   `cli -c configure` segfaults. After fix it returns a clean
+   error. Operators who currently rely on the crash to detect
+   "I'm in non-TTY mode" (cargo-cult) will need to read the new
+   error message. Acceptable?
+2. **Should we also gate `dispatchConfig` itself with a nil-check
+   at the top, returning the same error?** It would never trigger
+   given the new `configure` guard, but it'd be a stronger
+   structural invariant. My read: the per-case nil-guards on
+   SetPrompt are sufficient as defense in depth; adding a
+   top-level guard would be redundant.
+3. **Test #2 readline.Instance stubbing.** The chzyer/readline
+   instance is hard to construct in unit tests without a real
+   TTY. Acceptable to rely on manual `make test-ssh` for the TTY
+   regression rather than a unit test?
+4. **Confirmation tests** — should they also assert the printed
+   stdout matches "X cancelled" pattern, or is "no RPC issued"
+   sufficient? My read: assert no RPC AND assert no cancellation
+   message (because cancellation message implies we got past the
+   confirm point, which we shouldn't).

--- a/docs/pr/1563-cli-c-nontty-fix/plan.md
+++ b/docs/pr/1563-cli-c-nontty-fix/plan.md
@@ -1,0 +1,258 @@
+# #1563 cli -c segfault on readline.SetPrompt in non-TTY mode
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY)
+
+## Issue framing
+
+`cli -c "<command>"` segfaults when invoked from non-TTY contexts
+(`incus exec`, scripted CI, cron). Crash site is
+`cmd/cli/shared.go:225` — `c.rl.SetPrompt(c.configPrompt())` panics
+because `c.rl == nil`.
+
+Root cause confirmed by reading `cmd/cli/main.go:67-76`: the `-c`
+fast path dispatches the command **before** `readline.NewEx()` runs
+(`c.rl = rl` is at line 132). Any code path inside dispatch that
+touches `c.rl` will nil-deref.
+
+## All currently-broken `c.rl` call sites under `-c`
+
+Verified by `grep -n 'c\.rl' cmd/cli/*.go`:
+
+| File:line | Code | Category |
+|-----------|------|----------|
+| shared.go:225 | `c.rl.SetPrompt(c.configPrompt())` (in `configure`) | cosmetic prompt update |
+| shared.go:283 | `c.rl.SetPrompt(c.configPrompt())` (in `edit`) | cosmetic prompt update |
+| shared.go:289 | `c.rl.SetPrompt(c.configPrompt())` (in `top`) | cosmetic prompt update |
+| shared.go:297 | `c.rl.SetPrompt(c.configPrompt())` (in `up`) | cosmetic prompt update |
+| shared.go:414 | `c.rl.SetPrompt(c.operationalPrompt())` (in config `exit`/`quit`) | cosmetic prompt update |
+| shared.go:437-442 | `if c.rl != nil { ... }` (refreshPrompt) | already guarded |
+| shared.go:530 | `cmdtree.WriteHelp(rc.ctl.rl.Stdout(), ...)` (Do completer) | unreachable in `-c` (no readline = no completer driven) |
+| main.go:105, 122 | `c.rl.Stdout()` inside readline Listener (`?` key) | unreachable in `-c` (Listener only fires inside Readline()) |
+| main.go:132 | `c.rl = rl` | init |
+| main.go:179 | `rl.SetPrompt(...)` (local `rl`, not `c.rl`) | unreachable in `-c` (in the read loop) |
+| request.go:37, 39 | `c.rl.SetPrompt("")` + `c.rl.Readline()` (reboot confirm) | **interactive input** |
+| request.go:55, 57 | same (zeroize confirm) | **interactive input** |
+| request.go:77, 79 | same (in-service upgrade confirm) | **interactive input** |
+| main.go (handleLoad):379 | `c.rl.Readline()` for `load <mode> terminal` | **interactive input** |
+
+Pipe-output pathway (`dispatchWithPipe` shared.go:133) doesn't touch
+`c.rl`, so `cli -c "show version | match foo"` would work if the
+underlying dispatch did.
+
+## Two fix candidates
+
+### Option A — guard `c.rl != nil` everywhere it's touched
+
+- Adds `if c.rl != nil { c.rl.SetPrompt(...) }` around the 5
+  cosmetic SetPrompt sites in shared.go.
+- For interactive-input sites (3 confirmation prompts in
+  request.go + 1 `load terminal` in main.go), return a clear error
+  in non-TTY mode: e.g.
+  `return fmt.Errorf("request system %s requires an interactive TTY; not available in -c mode", args[1])`.
+- Behaviour:
+  - `cli -c "show version"` works.
+  - `cli -c "configure"` flips `c.configMode = true` and prints
+    "Entering configuration mode" but the prompt is never shown so
+    the cosmetic SetPrompt being a no-op is invisible. Then `-c`
+    exits — the configMode state is discarded. Side-effect-free.
+  - `cli -c "request system reboot"` returns a clean error instead
+    of waiting on stdin for a yes/no that will never come (or
+    worse, crashing).
+
+### Option B — structural: `-c` rejects interactive commands up front
+
+Add a denylist in `main.go` before dispatch:
+
+```go
+if isInteractiveOnly(*cmdFlag) {
+    fmt.Fprintln(os.Stderr, "error: this command requires an interactive TTY")
+    os.Exit(1)
+}
+```
+
+This sidesteps the question of what `configure`/`edit`/etc.
+"mean" in `-c` mode by forbidding them entirely.
+
+### Choice: **Option A**
+
+Rationale:
+
+1. **Smaller blast radius.** Option A touches only the call sites
+   that today nil-deref. Option B requires a denylist that we'd
+   have to maintain alongside the dispatch tables.
+2. **Pipe-friendly.** Operators may legitimately want to do
+   `cli -c "configure; set X; commit"` once we add multi-command
+   `-c` support (separate issue, not in scope here). Option A
+   doesn't preclude that.
+3. **Consistent with existing pattern.** `refreshPrompt`
+   (shared.go:437) already uses `if c.rl != nil { ... }`. The five
+   shared.go cosmetic SetPrompt sites are simply missing the same
+   guard.
+4. **Confirmation prompts get a real error**, not a hang. Option B
+   would also error, but at the dispatch-table layer, away from
+   the specific reason (no stdin for confirmation), making the
+   error message less precise.
+
+## Concrete design
+
+### shared.go — five cosmetic SetPrompt sites
+
+Wrap each in the same nil-guard already used by `refreshPrompt`:
+
+```go
+if c.rl != nil {
+    c.rl.SetPrompt(c.configPrompt())  // or operationalPrompt()
+}
+```
+
+Sites: lines 225, 283, 289, 297, 414. All are pure UI updates; the
+in-memory `c.configMode` / `c.editPath` state is updated
+independently of the prompt.
+
+### request.go — three confirmation sites
+
+The three `request system <action>` confirmations (`reboot`, `halt`,
+`power-off`, `zeroize`, `software in-service-upgrade`) need an
+interactive yes/no. In `-c` mode that input is impossible.
+
+Factor a small helper:
+
+```go
+func (c *ctl) confirmYes(prompt string) (bool, error) {
+    if c.rl == nil {
+        return false, fmt.Errorf("this command requires an interactive TTY (not available in -c mode); use the gRPC SystemAction RPC if scripting")
+    }
+    fmt.Print(prompt)
+    c.rl.SetPrompt("")
+    line, err := c.rl.Readline()
+    c.rl.SetPrompt(c.operationalPrompt())
+    if err != nil {
+        return false, nil  // treat read error as "no"
+    }
+    return strings.TrimSpace(strings.ToLower(line)) == "yes", nil
+}
+```
+
+Each of the three sites becomes:
+
+```go
+ok, err := c.confirmYes("Reboot the system? [yes,no] (no) ")
+if err != nil {
+    return err
+}
+if !ok {
+    fmt.Println("Reboot cancelled")
+    return nil
+}
+```
+
+### main.go handleLoad — terminal source
+
+For `load <mode> terminal` with no `c.rl`, return:
+
+```go
+return fmt.Errorf("load %s terminal requires an interactive TTY; use 'load %s <file>' or pipe via gRPC", mode, mode)
+```
+
+### `cli -c "configure"` — what happens
+
+After the fix:
+1. `configure` RPC succeeds (or fails — independent of TTY).
+2. `c.configMode = true`.
+3. SetPrompt is a no-op (rl is nil).
+4. Print messages go to stdout.
+5. `-c` path exits because there are no further commands.
+
+The in-memory configMode is discarded. The daemon-side
+EnterConfigure was issued; ExitConfigure is NOT issued in the `-c`
+path. **This is a pre-existing leak** unrelated to the segfault — a
+script that does `cli -c "configure"` would leave the daemon in
+exclusive-config mode held by the disconnected client. Out of
+scope for this fix (note in PR body); the segfault must come out
+either way.
+
+## Public API preservation
+
+No public signatures change. `ctl` struct unchanged. `confirmYes`
+is an unexported helper. The `-c` flag semantics are unchanged
+externally — it just no longer crashes.
+
+## Hidden invariants the change must preserve
+
+- Interactive `cli` (TTY) behaviour MUST be identical. Every
+  SetPrompt that fires today must still fire when `c.rl != nil`.
+  Verified by guard pattern: `if c.rl != nil { existing-call }`.
+- Confirmation prompts in TTY mode must still demand "yes" — the
+  `confirmYes` helper preserves that exactly.
+- Error-on-no-rl in interactive-input sites must surface a
+  non-zero exit so scripts can detect the failure: main.go's `-c`
+  path already does `os.Exit(1)` on dispatch error (line 73).
+- No new goroutines, no new locks, no new allocations on the hot
+  path. (CLI is cold path anyway.)
+
+## Risk assessment
+
+| Risk class | Level | Notes |
+|------------|-------|-------|
+| Behavioural regression (TTY) | LOW | Each guard is `if rl != nil { existing-call }`; in TTY mode rl is non-nil so behaviour is unchanged. |
+| Lifetime / borrow-checker | N/A | Go, not Rust. No lifetime hazards. |
+| Performance regression | NEGLIGIBLE | CLI is cold path; one nil-check per cosmetic SetPrompt. |
+| Architectural mismatch | LOW | Pattern already in use at shared.go:437; we're propagating it consistently. |
+
+## Test plan
+
+1. **`go vet ./cmd/cli/...`** clean.
+2. **`go build ./cmd/cli`** clean.
+3. **`go test ./cmd/cli/...`** — existing tests pass. Add a new
+   table-driven test for the `-c` path: construct a `ctl` with
+   `rl == nil`, call `dispatchOperational("configure")`,
+   `dispatchConfig("edit X")`, `dispatchConfig("top")`,
+   `dispatchConfig("up")`, `dispatchConfig("exit")` — must not
+   panic, must return nil error (gRPC client can be a stub or
+   nil-checked path; use a fake client).
+4. **`go test ./...`** — full suite green.
+5. **Manual repro on cluster**: deploy and run
+   `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "show version"`
+   — must print version and exit 0, no segfault.
+6. **TTY regression check**: `make test-ssh` and run interactive
+   `cli`, verify `configure` / `edit foo` / `top` / `up` / `exit`
+   still update the prompt visually.
+7. **Confirmation-error path**: `cli -c "request system reboot"`
+   on the test VM — must return the clear-TTY error and exit
+   non-zero, NOT reboot.
+
+## Out of scope
+
+- Multi-command `-c` support (e.g. `cli -c "configure; set X; commit"`).
+- The daemon-side EnterConfigure leak when `cli -c "configure"` is
+  issued without follow-up. Pre-existing; addressed in a separate
+  issue.
+- Refactoring `request system <action>` confirmations to read
+  stdin directly (instead of via readline). Pre-existing coupling;
+  out of scope.
+
+## Open questions for adversarial review
+
+1. **Is Option A really safer than Option B?** Could there be a
+   call site that touches `c.rl` and is NOT in our enumerated
+   list? `grep -n 'c\.rl' cmd/cli/*.go` ran on the worktree at
+   commit e07f733a6 — please re-grep against the head you review
+   to confirm coverage.
+2. **`cli -c "configure"` state leak** — is fixing the segfault
+   without fixing the leak acceptable for this PR, or should both
+   ship together? My read: segfault is a crash bug, leak is a
+   resource bug. Crash-fix should not be gated on leak-fix.
+3. **Confirmation-prompt error wording.** The proposed error
+   suggests "use the gRPC SystemAction RPC if scripting" — is that
+   the right pointer, or should it say "use REST POST
+   /api/v1/system" or "drop this command from the script"?
+4. **Should `load <mode> terminal` in `-c` mode be a hard error,
+   or silently fall back to reading from `os.Stdin`?** The pipe
+   shape `echo "config..." | cli -c "load merge terminal"` could
+   conceivably work if we used `bufio.NewReader(os.Stdin)` instead
+   of `c.rl.Readline()`. I propose hard error for now (smaller
+   blast radius) but note the alternative.
+5. **Test coverage** — should the new test exercise every shared.go
+   SetPrompt path or just one canary site? My read: hit every
+   path that today nil-derefs (5 sites in shared.go + 3 in
+   request.go + 1 in handleLoad). Cost is one table entry each.

--- a/docs/pr/1563-cli-c-nontty-fix/plan.md
+++ b/docs/pr/1563-cli-c-nontty-fix/plan.md
@@ -1,6 +1,23 @@
 # #1563 cli -c segfault on readline.SetPrompt in non-TTY mode
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY)
+**Status:** DRAFT v2 — addresses Codex PLAN-NEEDS-MAJOR + AGY PLAN-NEEDS-MINOR (round 1)
+
+## Round-1 review summary
+
+- **AGY (PLAN-NEEDS-MINOR):** call-site enumeration confirmed
+  complete; asked for bufio.NewScanner fallback on `load terminal`
+  instead of hard-error; asked for explicit fake gRPC client
+  pattern in test plan.
+- **Codex (PLAN-NEEDS-MAJOR):** flagged that `configure` mutates
+  daemon state (`EnterConfigure` RPC) before the cosmetic SetPrompt
+  fires, so nil-guarding the prompt risks leaving the daemon with
+  an exclusive config holder if the client disconnects without
+  ExitConfigure. Required: prove daemon cleanup on disconnect,
+  hard-error `configure` in -c, OR add guaranteed cleanup. Also
+  asked for actual recorded grep inventory + tests that exercise
+  real dispatch surface with a fake client.
+
+This v2 addresses both reviewers in full.
 
 ## Issue framing
 
@@ -11,91 +28,115 @@ because `c.rl == nil`.
 
 Root cause confirmed by reading `cmd/cli/main.go:67-76`: the `-c`
 fast path dispatches the command **before** `readline.NewEx()` runs
-(`c.rl = rl` is at line 132). Any code path inside dispatch that
+(`c.rl = rl` is at main.go:132). Any code path inside dispatch that
 touches `c.rl` will nil-deref.
 
-## All currently-broken `c.rl` call sites under `-c`
+## Codex's `configure` state-mutation concern — resolved
 
-Verified by `grep -n 'c\.rl' cmd/cli/*.go`:
+Codex flagged that `cli -c configure` calls `EnterConfigure` RPC
+before the SetPrompt panics, so a nil-guard would convert
+"crash-after-side-effect" to "success-after-side-effect" and
+could leave the daemon's config locked.
 
-| File:line | Code | Category |
-|-----------|------|----------|
-| shared.go:225 | `c.rl.SetPrompt(c.configPrompt())` (in `configure`) | cosmetic prompt update |
-| shared.go:283 | `c.rl.SetPrompt(c.configPrompt())` (in `edit`) | cosmetic prompt update |
-| shared.go:289 | `c.rl.SetPrompt(c.configPrompt())` (in `top`) | cosmetic prompt update |
-| shared.go:297 | `c.rl.SetPrompt(c.configPrompt())` (in `up`) | cosmetic prompt update |
-| shared.go:414 | `c.rl.SetPrompt(c.operationalPrompt())` (in config `exit`/`quit`) | cosmetic prompt update |
-| shared.go:437-442 | `if c.rl != nil { ... }` (refreshPrompt) | already guarded |
-| shared.go:530 | `cmdtree.WriteHelp(rc.ctl.rl.Stdout(), ...)` (Do completer) | unreachable in `-c` (no readline = no completer driven) |
-| main.go:105, 122 | `c.rl.Stdout()` inside readline Listener (`?` key) | unreachable in `-c` (Listener only fires inside Readline()) |
-| main.go:132 | `c.rl = rl` | init |
-| main.go:179 | `rl.SetPrompt(...)` (local `rl`, not `c.rl`) | unreachable in `-c` (in the read loop) |
-| request.go:37, 39 | `c.rl.SetPrompt("")` + `c.rl.Readline()` (reboot confirm) | **interactive input** |
-| request.go:55, 57 | same (zeroize confirm) | **interactive input** |
-| request.go:77, 79 | same (in-service upgrade confirm) | **interactive input** |
-| main.go (handleLoad):379 | `c.rl.Readline()` for `load <mode> terminal` | **interactive input** |
-
-Pipe-output pathway (`dispatchWithPipe` shared.go:133) doesn't touch
-`c.rl`, so `cli -c "show version | match foo"` would work if the
-underlying dispatch did.
-
-## Two fix candidates
-
-### Option A — guard `c.rl != nil` everywhere it's touched
-
-- Adds `if c.rl != nil { c.rl.SetPrompt(...) }` around the 5
-  cosmetic SetPrompt sites in shared.go.
-- For interactive-input sites (3 confirmation prompts in
-  request.go + 1 `load terminal` in main.go), return a clear error
-  in non-TTY mode: e.g.
-  `return fmt.Errorf("request system %s requires an interactive TTY; not available in -c mode", args[1])`.
-- Behaviour:
-  - `cli -c "show version"` works.
-  - `cli -c "configure"` flips `c.configMode = true` and prints
-    "Entering configuration mode" but the prompt is never shown so
-    the cosmetic SetPrompt being a no-op is invisible. Then `-c`
-    exits — the configMode state is discarded. Side-effect-free.
-  - `cli -c "request system reboot"` returns a clean error instead
-    of waiting on stdin for a yes/no that will never come (or
-    worse, crashing).
-
-### Option B — structural: `-c` rejects interactive commands up front
-
-Add a denylist in `main.go` before dispatch:
+**Verified resolution: the daemon already auto-releases on client
+disconnect.** Quote from `pkg/grpcapi/server.go:214-228`:
 
 ```go
-if isInteractiveOnly(*cmdFlag) {
-    fmt.Fprintln(os.Stderr, "error: this command requires an interactive TTY")
-    os.Exit(1)
+// configLockInterceptor auto-releases stale config locks when a gRPC client
+// disconnects (context cancelled) without calling ExitConfigure.
+func (s *Server) configLockInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+    resp, err := handler(ctx, req)
+    // If the client's context was cancelled (disconnect, Ctrl-C), release any
+    // config lock held by this connection.
+    if ctx.Err() != nil {
+        sessionID := peerSessionID(ctx)
+        if sessionID != "" {
+            if s.store.ExitConfigureSession(sessionID) {
+                slog.Info("auto-released config lock on client disconnect", "session", sessionID)
+            }
+        }
+    }
+    return resp, err
 }
 ```
 
-This sidesteps the question of what `configure`/`edit`/etc.
-"mean" in `-c` mode by forbidding them entirely.
+When `cli -c configure` exits, `defer conn.Close()` in
+`cmd/cli/main.go:37` closes the gRPC connection, the context
+cancels, and `configLockInterceptor` calls `ExitConfigureSession`.
+The lock is released cleanly.
 
-### Choice: **Option A**
+**Conclusion:** nil-guarding the SetPrompt in `configure` is safe.
+The "state leak" Codex worried about does not exist on master.
 
-Rationale:
+This also addresses the boundary-classification concern: the
+SetPrompt IS purely cosmetic because the daemon owns the canonical
+config-mode state and self-cleans.
 
-1. **Smaller blast radius.** Option A touches only the call sites
-   that today nil-deref. Option B requires a denylist that we'd
-   have to maintain alongside the dispatch tables.
-2. **Pipe-friendly.** Operators may legitimately want to do
-   `cli -c "configure; set X; commit"` once we add multi-command
-   `-c` support (separate issue, not in scope here). Option A
-   doesn't preclude that.
-3. **Consistent with existing pattern.** `refreshPrompt`
-   (shared.go:437) already uses `if c.rl != nil { ... }`. The five
-   shared.go cosmetic SetPrompt sites are simply missing the same
-   guard.
-4. **Confirmation prompts get a real error**, not a hang. Option B
-   would also error, but at the dispatch-table layer, away from
-   the specific reason (no stdin for confirmation), making the
-   error message less precise.
+## Recorded `c.rl` call-site inventory
 
-## Concrete design
+`grep -n 'c\.rl' cmd/cli/*.go` against worktree HEAD (dd05de380):
 
-### shared.go — five cosmetic SetPrompt sites
+```
+cmd/cli/main.go:105:    fmt.Fprintln(c.rl.Stdout(), "  (no help available)")
+cmd/cli/main.go:122:    cmdtree.WriteHelp(c.rl.Stdout(), candidates)
+cmd/cli/main.go:132:    c.rl = rl
+cmd/cli/main.go:379:    line, err := c.rl.Readline()
+cmd/cli/shared.go:225:  c.rl.SetPrompt(c.configPrompt())
+cmd/cli/shared.go:283:  c.rl.SetPrompt(c.configPrompt())
+cmd/cli/shared.go:289:  c.rl.SetPrompt(c.configPrompt())
+cmd/cli/shared.go:297:  c.rl.SetPrompt(c.configPrompt())
+cmd/cli/shared.go:414:  c.rl.SetPrompt(c.operationalPrompt())
+cmd/cli/shared.go:437:  if c.rl != nil {
+cmd/cli/shared.go:439:      c.rl.SetPrompt(c.configPrompt())
+cmd/cli/shared.go:441:      c.rl.SetPrompt(c.operationalPrompt())
+cmd/cli/shared.go:530:  cmdtree.WriteHelp(rc.ctl.rl.Stdout(), candidates)
+cmd/cli/request.go:37:  c.rl.SetPrompt("")
+cmd/cli/request.go:38:  line, err := c.rl.Readline()
+cmd/cli/request.go:39:  c.rl.SetPrompt(c.operationalPrompt())
+cmd/cli/request.go:55:  c.rl.SetPrompt("")
+cmd/cli/request.go:56:  line, err := c.rl.Readline()
+cmd/cli/request.go:57:  c.rl.SetPrompt(c.operationalPrompt())
+cmd/cli/request.go:77:  c.rl.SetPrompt("")
+cmd/cli/request.go:78:  line, err := c.rl.Readline()
+cmd/cli/request.go:79:  c.rl.SetPrompt(c.operationalPrompt())
+```
+
+Categorisation:
+
+| Site | Category | Action |
+|------|----------|--------|
+| main.go:105, 122 | inside readline Listener callback (`?` key) | unreachable in -c (Listener registered by readline.NewEx) — no change |
+| main.go:132 | init | no change |
+| main.go:379 | `load <mode> terminal` interactive read | switch to bufio.NewScanner(os.Stdin) when rl==nil |
+| shared.go:225, 283, 289, 297, 414 | cosmetic SetPrompt | nil-guard each call |
+| shared.go:437-442 | refreshPrompt (already guarded) | no change |
+| shared.go:530 | autocomplete WriteHelp via `rc.ctl.rl.Stdout()` | unreachable in -c (`Do()` driven by readline) — no change |
+| request.go:37-39, 55-57, 77-79 | yes/no confirmation prompts | factor `confirmYes()` helper that hard-errors when rl==nil |
+
+**Total touched sites:** 5 in shared.go + 3 in request.go + 1 in
+main.go = 9. All other references are init, the dual-guard pattern
+already in place, or fire only inside the readline read loop.
+
+## Two fix candidates
+
+### Option A — guard c.rl != nil at the existing call sites
+
+Adopted. Details below.
+
+### Option B — denylist interactive commands at -c entry
+
+Rejected for the same reasons as v1, now reinforced:
+
+- Codex agreed Option A is directionally right.
+- Option B would block future multi-command `-c`
+  (`cli -c "configure; set X; commit"`).
+- The boundary problem Codex raised (`configure` mutates state
+  before cosmetic call) is moot because the daemon self-cleans on
+  disconnect.
+
+## Concrete design (v2)
+
+### shared.go — 5 cosmetic SetPrompt sites
 
 Wrap each in the same nil-guard already used by `refreshPrompt`:
 
@@ -105,154 +146,227 @@ if c.rl != nil {
 }
 ```
 
-Sites: lines 225, 283, 289, 297, 414. All are pure UI updates; the
-in-memory `c.configMode` / `c.editPath` state is updated
-independently of the prompt.
+Sites: lines 225, 283, 289, 297, 414. All pure UI updates.
+`c.configMode` / `c.editPath` state is updated independently and
+is harmless when discarded at -c exit.
 
-### request.go — three confirmation sites
+### request.go — 3 confirmation sites
 
-The three `request system <action>` confirmations (`reboot`, `halt`,
-`power-off`, `zeroize`, `software in-service-upgrade`) need an
-interactive yes/no. In `-c` mode that input is impossible.
-
-Factor a small helper:
+Factor a `confirmYes` helper that hard-errors in non-TTY mode:
 
 ```go
 func (c *ctl) confirmYes(prompt string) (bool, error) {
     if c.rl == nil {
-        return false, fmt.Errorf("this command requires an interactive TTY (not available in -c mode); use the gRPC SystemAction RPC if scripting")
+        return false, fmt.Errorf(
+            "this command requires interactive confirmation (TTY); " +
+            "not available in -c mode")
     }
     fmt.Print(prompt)
     c.rl.SetPrompt("")
     line, err := c.rl.Readline()
     c.rl.SetPrompt(c.operationalPrompt())
     if err != nil {
-        return false, nil  // treat read error as "no"
+        return false, nil
     }
     return strings.TrimSpace(strings.ToLower(line)) == "yes", nil
 }
 ```
 
-Each of the three sites becomes:
+Each request.go confirmation becomes:
 
 ```go
-ok, err := c.confirmYes("Reboot the system? [yes,no] (no) ")
+ok, err := c.confirmYes(fmt.Sprintf("%s the system? [yes,no] (no) ", strings.Title(args[1])))
 if err != nil {
     return err
 }
 if !ok {
-    fmt.Println("Reboot cancelled")
+    fmt.Printf("%s cancelled\n", strings.Title(args[1]))
     return nil
 }
 ```
 
-### main.go handleLoad — terminal source
+Hard-error is correct here: `request system reboot` from a script
+without confirmation MUST NOT proceed silently. The clear error
+tells the operator to invoke `pb.BpfrxServiceClient.SystemAction`
+directly via gRPC if non-interactive operation is required.
 
-For `load <mode> terminal` with no `c.rl`, return:
+### main.go handleLoad — bufio.NewScanner fallback (per AGY)
+
+In `handleLoad`, when `source == "terminal"` and `c.rl == nil`,
+read stdin via bufio.NewScanner so the canonical pipe pattern
+works:
 
 ```go
-return fmt.Errorf("load %s terminal requires an interactive TTY; use 'load %s <file>' or pipe via gRPC", mode, mode)
+if source == "terminal" {
+    var lines []string
+    if c.rl != nil {
+        fmt.Println("[Type or paste configuration, then press Ctrl-D on an empty line]")
+        for {
+            line, err := c.rl.Readline()
+            if err != nil {
+                break
+            }
+            lines = append(lines, line)
+        }
+    } else {
+        // Non-TTY: read piped config directly from stdin.
+        scanner := bufio.NewScanner(os.Stdin)
+        // Default scanner buffer is 64 KiB which is too small for
+        // a Junos-style override. Bump to 1 MiB.
+        scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+        for scanner.Scan() {
+            lines = append(lines, scanner.Text())
+        }
+        if err := scanner.Err(); err != nil {
+            return fmt.Errorf("load %s: stdin read: %v", mode, err)
+        }
+    }
+    content = strings.Join(lines, "\n")
+}
 ```
 
-### `cli -c "configure"` — what happens
-
-After the fix:
-1. `configure` RPC succeeds (or fails — independent of TTY).
-2. `c.configMode = true`.
-3. SetPrompt is a no-op (rl is nil).
-4. Print messages go to stdout.
-5. `-c` path exits because there are no further commands.
-
-The in-memory configMode is discarded. The daemon-side
-EnterConfigure was issued; ExitConfigure is NOT issued in the `-c`
-path. **This is a pre-existing leak** unrelated to the segfault — a
-script that does `cli -c "configure"` would leave the daemon in
-exclusive-config mode held by the disconnected client. Out of
-scope for this fix (note in PR body); the segfault must come out
-either way.
+This unlocks `echo "set system hostname foo" | cli -c "load merge terminal"`.
 
 ## Public API preservation
 
-No public signatures change. `ctl` struct unchanged. `confirmYes`
-is an unexported helper. The `-c` flag semantics are unchanged
-externally — it just no longer crashes.
+- `ctl` struct: unchanged.
+- `confirmYes`: new unexported helper.
+- `-c` flag semantics: unchanged externally — it just no longer
+  crashes.
+- All other dispatch paths in TTY mode behave identically.
 
 ## Hidden invariants the change must preserve
 
 - Interactive `cli` (TTY) behaviour MUST be identical. Every
-  SetPrompt that fires today must still fire when `c.rl != nil`.
+  SetPrompt that fires today still fires when `c.rl != nil`.
   Verified by guard pattern: `if c.rl != nil { existing-call }`.
-- Confirmation prompts in TTY mode must still demand "yes" — the
-  `confirmYes` helper preserves that exactly.
-- Error-on-no-rl in interactive-input sites must surface a
-  non-zero exit so scripts can detect the failure: main.go's `-c`
-  path already does `os.Exit(1)` on dispatch error (line 73).
+- Confirmation prompts in TTY mode still demand "yes" — the
+  `confirmYes` helper preserves the exact existing logic
+  (read, compare lowercased+trimmed, exact match "yes").
+- Error-on-no-rl in interactive-input sites surfaces a non-zero
+  exit so scripts can detect the failure: main.go:71-74 already
+  does `os.Exit(1)` on dispatch error.
+- Daemon-side EnterConfigure cleanup is preserved by existing
+  configLockInterceptor (pkg/grpcapi/server.go:214-228).
 - No new goroutines, no new locks, no new allocations on the hot
-  path. (CLI is cold path anyway.)
+  path.
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |------------|-------|-------|
 | Behavioural regression (TTY) | LOW | Each guard is `if rl != nil { existing-call }`; in TTY mode rl is non-nil so behaviour is unchanged. |
-| Lifetime / borrow-checker | N/A | Go, not Rust. No lifetime hazards. |
+| Lifetime / borrow-checker | N/A | Go, not Rust. |
 | Performance regression | NEGLIGIBLE | CLI is cold path; one nil-check per cosmetic SetPrompt. |
 | Architectural mismatch | LOW | Pattern already in use at shared.go:437; we're propagating it consistently. |
+| State leak via `cli -c configure` | LOW (verified) | Daemon auto-releases on conn close via configLockInterceptor. |
+| stdin-stream encoding for piped `load terminal` | LOW | bufio.NewScanner with 1 MiB buffer covers realistic configs; CRLF handled by Scanner.Text() stripping the trailing newline character. |
 
-## Test plan
+## Test plan (v2)
 
-1. **`go vet ./cmd/cli/...`** clean.
-2. **`go build ./cmd/cli`** clean.
-3. **`go test ./cmd/cli/...`** — existing tests pass. Add a new
-   table-driven test for the `-c` path: construct a `ctl` with
-   `rl == nil`, call `dispatchOperational("configure")`,
-   `dispatchConfig("edit X")`, `dispatchConfig("top")`,
-   `dispatchConfig("up")`, `dispatchConfig("exit")` — must not
-   panic, must return nil error (gRPC client can be a stub or
-   nil-checked path; use a fake client).
-4. **`go test ./...`** — full suite green.
-5. **Manual repro on cluster**: deploy and run
-   `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "show version"`
-   — must print version and exit 0, no segfault.
-6. **TTY regression check**: `make test-ssh` and run interactive
-   `cli`, verify `configure` / `edit foo` / `top` / `up` / `exit`
-   still update the prompt visually.
-7. **Confirmation-error path**: `cli -c "request system reboot"`
-   on the test VM — must return the clear-TTY error and exit
-   non-zero, NOT reboot.
+### Unit tests
+
+Add `cmd/cli/cdash_nontty_test.go` (or extend `main_test.go`)
+using the interface-embedding fake gRPC client pattern that AGY
+suggested:
+
+```go
+type fakeBpfrxClient struct {
+    pb.BpfrxServiceClient // embed interface; nil for unused methods
+}
+
+func (f *fakeBpfrxClient) EnterConfigure(
+    ctx context.Context, in *pb.EnterConfigureRequest, opts ...grpc.CallOption,
+) (*pb.EnterConfigureResponse, error) {
+    return &pb.EnterConfigureResponse{}, nil
+}
+func (f *fakeBpfrxClient) ExitConfigure(
+    ctx context.Context, in *pb.ExitConfigureRequest, opts ...grpc.CallOption,
+) (*pb.ExitConfigureResponse, error) {
+    return &pb.ExitConfigureResponse{}, nil
+}
+// ... other RPCs as needed, all returning the empty response.
+```
+
+Test cases (every site that nil-derefs today):
+
+1. `TestDispatchOperational_ConfigureNoTTY` — ctl{rl: nil} +
+   fakeBpfrxClient; call `dispatchOperational("configure")`; must
+   not panic, must return nil, must set `c.configMode = true`.
+2. `TestDispatchConfig_EditTopUpExitNoTTY` — ctl{rl: nil,
+   configMode: true}; call each of `edit foo`, `top`, `up`,
+   `exit`; must not panic, must return nil; verifies all four
+   shared.go SetPrompt sites (283, 289, 297, 414).
+3. `TestConfirmYes_NoTTYError` — ctl{rl: nil}; call
+   `confirmYes("?")`; must return (false, non-nil error).
+4. `TestHandleRequestSystem_NoTTY` — ctl{rl: nil}; call
+   `handleRequestSystem([]string{"system", "reboot"})`; must
+   return the no-TTY error, must NOT call SystemAction RPC
+   (verify with a fake that increments a counter and asserts
+   it's still zero).
+5. `TestHandleLoad_TerminalNoTTYReadsStdin` — ctl{rl: nil};
+   redirect os.Stdin to a pipe containing
+   `"set system hostname foo\n"`; call `handleLoad(
+   ["override", "terminal"])`; verify the fake's Load was called
+   with the piped content. Use `os.Pipe()` + `os.Stdin =
+   readEnd` (save/restore for cleanup).
+
+### Integration / smoke tests
+
+- `make build && make build-ctl`: clean.
+- `go vet ./cmd/cli/...`: clean.
+- `go test ./cmd/cli/...`: all green, including 5 new tests.
+- `go test ./...`: full Go suite green (30 packages).
+- Manual repro:
+  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "show version"` — must print version, exit 0.
+  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "configure"` — must succeed, exit 0, daemon auto-releases config lock.
+  - `incus exec loss:xpf-userspace-fw0 -- bash -c 'echo "set system hostname testxxx" | /usr/local/sbin/cli -c "load merge terminal"'` — must succeed, exit 0; check `cli -c "show configuration system"` confirms the hostname change.
+  - `incus exec loss:xpf-userspace-fw0 -- /usr/local/sbin/cli -c "request system reboot"` — must return error, exit non-zero, MUST NOT reboot.
+- TTY regression: `make test-ssh` and run interactive `cli`,
+  verify `configure` / `edit foo` / `top` / `up` / `exit` still
+  update the prompt visually.
+
+### Smoke matrix
+
+This is a CLI binary fix, not a dataplane change. The full Pass A +
+Pass B per-class CoS matrix from triple-review is not required.
+But we still run the standard userspace cluster smoke (v4 + v6,
+push + reverse, multi-stream) to confirm we haven't broken
+anything by linking against the modified `cli` binary.
 
 ## Out of scope
 
 - Multi-command `-c` support (e.g. `cli -c "configure; set X; commit"`).
-- The daemon-side EnterConfigure leak when `cli -c "configure"` is
-  issued without follow-up. Pre-existing; addressed in a separate
-  issue.
+  Separate issue.
 - Refactoring `request system <action>` confirmations to read
-  stdin directly (instead of via readline). Pre-existing coupling;
-  out of scope.
+  stdin directly. The hard-error in non-TTY mode is correct for
+  destructive operations; allowing piped "yes" input would
+  reduce the protection.
+- Adding a `--yes` / `--non-interactive` flag for destructive
+  actions. Separate issue.
 
-## Open questions for adversarial review
+## Open questions for adversarial review (round 2)
 
-1. **Is Option A really safer than Option B?** Could there be a
-   call site that touches `c.rl` and is NOT in our enumerated
-   list? `grep -n 'c\.rl' cmd/cli/*.go` ran on the worktree at
-   commit e07f733a6 — please re-grep against the head you review
-   to confirm coverage.
-2. **`cli -c "configure"` state leak** — is fixing the segfault
-   without fixing the leak acceptable for this PR, or should both
-   ship together? My read: segfault is a crash bug, leak is a
-   resource bug. Crash-fix should not be gated on leak-fix.
-3. **Confirmation-prompt error wording.** The proposed error
-   suggests "use the gRPC SystemAction RPC if scripting" — is that
-   the right pointer, or should it say "use REST POST
-   /api/v1/system" or "drop this command from the script"?
-4. **Should `load <mode> terminal` in `-c` mode be a hard error,
-   or silently fall back to reading from `os.Stdin`?** The pipe
-   shape `echo "config..." | cli -c "load merge terminal"` could
-   conceivably work if we used `bufio.NewReader(os.Stdin)` instead
-   of `c.rl.Readline()`. I propose hard error for now (smaller
-   blast radius) but note the alternative.
-5. **Test coverage** — should the new test exercise every shared.go
-   SetPrompt path or just one canary site? My read: hit every
-   path that today nil-derefs (5 sites in shared.go + 3 in
-   request.go + 1 in handleLoad). Cost is one table entry each.
+1. **`load terminal` stdin EOF handling.** bufio.NewScanner stops
+   on EOF. Is there any case where stdin is a pipe that never
+   closes (e.g. interactive heredoc)? My read: `cli -c "load merge
+   terminal"` users will pipe a finite payload; if they want
+   open-ended interactive, they don't pass `-c`. Acceptable?
+2. **Should the 1 MiB scanner buffer be tunable?** I picked 1 MiB
+   because Junos override configs are usually <100 KiB. Edge
+   case: someone pipes a multi-MB config. Should we bump to 16
+   MiB by default, or fail loudly when the buffer is exceeded?
+   Default scanner behaviour with buffer-exceeded is to fail with
+   `bufio.ErrTooLong`, which we'll surface as "load: stdin read".
+3. **Test pattern: interface embedding vs gomock vs full fake.**
+   AGY suggested embedding. Codex asked for "real dispatch
+   surface plus fake client". Embedding satisfies both —
+   confirmed acceptable?
+4. **Should `cli -c "configure"` emit an info note** that the
+   command has no effect at exit, since the daemon auto-releases?
+   My read: silence is correct because there's no follow-up
+   command anyway. Counter-argue?
+5. **`request system in-service-upgrade` shape.** Same confirmYes
+   treatment, but ISSU specifically is the kind of thing
+   automation might want to drive. The current "must use gRPC
+   SystemAction RPC" error message is accurate. Counter-argue?

--- a/docs/pr/1563-cli-c-nontty-fix/reviewer-ids.md
+++ b/docs/pr/1563-cli-c-nontty-fix/reviewer-ids.md
@@ -1,0 +1,39 @@
+# Reviewer task IDs for #1563
+
+Recorded so any future continuation can fetch results by ID rather
+than re-dispatching.
+
+## Plan review
+
+| Round | Reviewer | Task ID | Verdict |
+|-------|----------|---------|---------|
+| 1 | Codex | task-mpnhw9dl-x9ci3c | PLAN-NEEDS-MAJOR |
+| 1 | AGY | review-mpnhwj5s-pec4dp | PLAN-NEEDS-MINOR |
+| 2 | Codex | task-mpni2ff9-799vbw | PLAN-NEEDS-MAJOR |
+| 2 | AGY | review-mpni2nbc-yosv1u | PLAN-NEEDS-MINOR |
+| 3 | Codex | task-mpni9hhz-88hm9u | PLAN-NEEDS-MINOR |
+| 3 | AGY | review-mpni9pux-rhf7u6 | PLAN-NEEDS-MINOR |
+
+## Code review (round 1 — post-PR-open)
+
+Pending PR creation.
+
+## Notes
+
+- Round-2 critical finding (both reviewers): configLockInterceptor
+  is a Unary Interceptor and doesn't fire on connection close, so
+  `cli -c configure` would leak the daemon-side config lock unless
+  we hard-error before issuing EnterConfigure.
+- Round-2 Codex bonus finding: EnterConfigureExclusive sets
+  `exclusiveHolder` not `configHolder`; ExitConfigureSession
+  refuses to release exclusive locks. Pre-existing daemon bug,
+  out-of-scope for #1563.
+- Round-2 Codex bonus finding: `load` is not in operational
+  dispatch, so `cli -c "load merge terminal"` is unreachable
+  today. Bufio fallback dropped from plan.
+- Round-3 AGY finding: confirmYes prompt-restoration must be
+  configMode-aware (else `run request system reboot` from config
+  mode would restore the wrong prompt).
+- Plan v3 converged design: hard-error `configure` when c.rl==nil,
+  factor confirmYes helper for destructive prompts, defensive
+  nil-guards in dispatchConfig SetPrompt sites.


### PR DESCRIPTION
## Summary

Closes #1563

`cli -c "<cmd>"` segfaulted from non-TTY contexts because the dispatch
path touched the readline instance (`c.rl`) before `readline.NewEx()`
was ever called. Hard-error in non-TTY mode for the two reachable
classes of failure: `configure` (which would otherwise leak the
daemon-side config lock — see plan v3 + reviewer-ids for the
configLockInterceptor argument) and destructive `request system
<action>` confirmation prompts. Defensive nil-guards in
`dispatchConfig` SetPrompt sites are dead code in `-c` mode after
the `configure` guard but cheap and document the invariant.

## Plan + adversarial review

Plan doc: `docs/pr/1563-cli-c-nontty-fix/plan.md`. Reviewer task IDs:
`docs/pr/1563-cli-c-nontty-fix/reviewer-ids.md`.

Three rounds of plan-review with Codex + Antigravity (AGY).

- **Round 1 (v1 — nil-guard SetPrompt sites):** Codex
  PLAN-NEEDS-MAJOR, AGY PLAN-NEEDS-MINOR. Both reviewers flagged
  scope concerns: AGY wanted a `bufio` fallback for `load
  terminal`; Codex worried about `configure`'s state mutation
  before the cosmetic SetPrompt panic.
- **Round 2 (v2 — bufio fallback + daemon-cleanup quote):** Codex
  PLAN-NEEDS-MAJOR and AGY PLAN-NEEDS-MINOR converged on a
  **critical correctness finding** — the
  `configLockInterceptor` cited as proof of daemon cleanup is a
  **Unary Interceptor**. It only fires while an RPC is in
  flight, never on connection close. After `EnterConfigure`
  returns and the client exits, the daemon-side config lock
  leaks permanently. Codex additionally noted that
  `EnterConfigureExclusive` writes `exclusiveHolder` but
  `ExitConfigureSession` only releases `configHolder`, so even
  an explicit teardown call wouldn't recover an exclusive lock
  (pre-existing daemon-side bug, out of scope here). Codex also
  caught that `load` is not in operational dispatch — `cli -c
  "load merge terminal"` returns "unknown command: load" today,
  so the `bufio`/`io.ReadAll` work was solving an unreachable
  code path.
- **Round 3 (v3 — hard-error `configure` in `-c` mode):** both
  reviewers PLAN-NEEDS-MINOR with no architectural blockers.
  Design accepted. AGY's minor finding (prompt restoration in
  the new `confirmYes` helper must be configMode-aware so `run
  request system reboot` from config mode restores the right
  prompt) is fixed in this implementation.

## What ships

- `cmd/cli/shared.go`:
  - `dispatchOperational("configure")`: hard-error when `c.rl == nil`
    before issuing `EnterConfigure` RPC. Prevents both the segfault
    and the daemon-side config-lock leak.
  - `dispatchConfig` SetPrompt sites at lines 283, 289, 297, 414:
    defensive nil-guards. Dead code in `-c` after the configure
    guard, but cheap and document the invariant.
- `cmd/cli/request.go`:
  - New `confirmYes(prompt)` helper. Hard-errors when
    `c.rl == nil`. configMode-aware prompt restoration so it
    composes with `run request system ...` from config mode.
  - All three destructive confirmation sites (reboot/halt/power-off,
    zeroize, ISSU) refactored to use `confirmYes`.
- `cmd/cli/nontty_test.go` (new): table-driven tests using an
  interface-embedded fake gRPC client. Covers every hard-error
  site and asserts the dangerous RPCs are NOT issued under
  non-TTY mode.

## Test plan

- [x] `go vet ./cmd/cli/...` clean (pre-existing monitor.go warning unrelated)
- [x] `go build ./cmd/cli/...` clean
- [x] `go test ./cmd/cli/...` green; 4 new tests + every existing
      `cmd/cli` test still passes
- [x] 5/5 flake check on the 4 new tests
- [x] `go test ./...` full Go suite green
- [ ] Manual repro on `loss:xpf-userspace-fw0`:
  - `cli -c "show version"` — must print + exit 0 (segfault gone)
  - `cli -c "configure"` — must exit 1 with "requires an interactive terminal"
  - `cli -c "request system reboot"` — must exit 1 with "requires interactive confirmation", must NOT reboot
  - Interactive `cli` — `configure` / `edit` / `top` / `up` / `exit` work unchanged

<!-- AWAITING-SMOKE -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)